### PR TITLE
fix: fix ticket links to point to https://github.com/autowarefoundation/autoware.universe

### DIFF
--- a/common/autoware_adapi_specs/CHANGELOG.rst
+++ b/common/autoware_adapi_specs/CHANGELOG.rst
@@ -5,8 +5,8 @@ Changelog for package autoware_ad_api_specs
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* fix: adapi vehicle topic qos (`#7847 <https://github.com/youtalk/autoware.universe/issues/7847>`_)
-* feat(default_ad_api): add heratbeat api (`#6969 <https://github.com/youtalk/autoware.universe/issues/6969>`_)
+* fix: adapi vehicle topic qos (`#7847 <https://github.com/autowarefoundation/autoware.universe/issues/7847>`_)
+* feat(default_ad_api): add heratbeat api (`#6969 <https://github.com/autowarefoundation/autoware.universe/issues/6969>`_)
   * feat(default_ad_api): add heratbeat api
   * fix node dying
   ---------
@@ -14,12 +14,12 @@ Changelog for package autoware_ad_api_specs
 
 0.26.0 (2024-04-03)
 -------------------
-* feat(default_ad_api): add door api (`#5737 <https://github.com/youtalk/autoware.universe/issues/5737>`_)
-* chore: update api package maintainers (`#6086 <https://github.com/youtalk/autoware.universe/issues/6086>`_)
+* feat(default_ad_api): add door api (`#5737 <https://github.com/autowarefoundation/autoware.universe/issues/5737>`_)
+* chore: update api package maintainers (`#6086 <https://github.com/autowarefoundation/autoware.universe/issues/6086>`_)
   * update api maintainers
   * fix
   ---------
-* feat(default_ad_api): add object recognition api (`#2887 <https://github.com/youtalk/autoware.universe/issues/2887>`_)
+* feat(default_ad_api): add object recognition api (`#2887 <https://github.com/autowarefoundation/autoware.universe/issues/2887>`_)
   * add object recognition api
   * add unorder map
   * pre-commit
@@ -30,9 +30,9 @@ Changelog for package autoware_ad_api_specs
   * change topic naming
   ---------
   Co-authored-by: Takagi, Isamu <43976882+isamu-takagi@users.noreply.github.com>
-* docs: add readme for interface packages (`#4235 <https://github.com/youtalk/autoware.universe/issues/4235>`_)
+* docs: add readme for interface packages (`#4235 <https://github.com/autowarefoundation/autoware.universe/issues/4235>`_)
   add readme for interface packages
-* feat: add vehicle status api (`#2930 <https://github.com/youtalk/autoware.universe/issues/2930>`_)
+* feat: add vehicle status api (`#2930 <https://github.com/autowarefoundation/autoware.universe/issues/2930>`_)
   * add vehicle status api
   * update msgs
   * change naming
@@ -57,14 +57,14 @@ Changelog for package autoware_ad_api_specs
   * added checking message valid
   * fix msgs
   ---------
-* feat(default_ad_api): add vehicle info api (`#2984 <https://github.com/youtalk/autoware.universe/issues/2984>`_)
+* feat(default_ad_api): add vehicle info api (`#2984 <https://github.com/autowarefoundation/autoware.universe/issues/2984>`_)
   * feat(default_ad_api): add vehicle dimensions api
   * feat: add footprint
   * update api name
   ---------
-* feat(autoware_api_specs): change topic depth of route state api and localization state api (`#3757 <https://github.com/youtalk/autoware.universe/issues/3757>`_)
+* feat(autoware_api_specs): change topic depth of route state api and localization state api (`#3757 <https://github.com/autowarefoundation/autoware.universe/issues/3757>`_)
   fix depth
-* build: mark autoware_cmake as <buildtool_depend> (`#3616 <https://github.com/youtalk/autoware.universe/issues/3616>`_)
+* build: mark autoware_cmake as <buildtool_depend> (`#3616 <https://github.com/autowarefoundation/autoware.universe/issues/3616>`_)
   * build: mark autoware_cmake as <buildtool_depend>
   with <build_depend>, autoware_cmake is automatically exported with ament_target_dependencies() (unecessary)
   * style(pre-commit): autofix
@@ -72,21 +72,21 @@ Changelog for package autoware_ad_api_specs
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Kenji Miyake <kenji.miyake@tier4.jp>
-* chore: update codeowners (`#3513 <https://github.com/youtalk/autoware.universe/issues/3513>`_)
-* feat(default_ad_api): add route change api (`#3197 <https://github.com/youtalk/autoware.universe/issues/3197>`_)
+* chore: update codeowners (`#3513 <https://github.com/autowarefoundation/autoware.universe/issues/3513>`_)
+* feat(default_ad_api): add route change api (`#3197 <https://github.com/autowarefoundation/autoware.universe/issues/3197>`_)
   * feat: add route change api
   * fix: reroute
   ---------
-* feat(default_ad_api): add planning api (`#2481 <https://github.com/youtalk/autoware.universe/issues/2481>`_)
+* feat(default_ad_api): add planning api (`#2481 <https://github.com/autowarefoundation/autoware.universe/issues/2481>`_)
   * feat(default_ad_api): add planning api
   * feat: complement velocity factor
   * feat: add stop check
   * feat: make the same process into a function
   * feat: update visualizer
   * fix: remove flake8 test
-* chore: add api maintainers (`#2361 <https://github.com/youtalk/autoware.universe/issues/2361>`_)
-* feat(default_ad_api): add fail-safe api (`#2295 <https://github.com/youtalk/autoware.universe/issues/2295>`_)
-* feat(default_ad_api): add motion api  (`#1809 <https://github.com/youtalk/autoware.universe/issues/1809>`_)
+* chore: add api maintainers (`#2361 <https://github.com/autowarefoundation/autoware.universe/issues/2361>`_)
+* feat(default_ad_api): add fail-safe api (`#2295 <https://github.com/autowarefoundation/autoware.universe/issues/2295>`_)
+* feat(default_ad_api): add motion api  (`#1809 <https://github.com/autowarefoundation/autoware.universe/issues/1809>`_)
   * feat(autoware_ad_api_specs): define motion interface
   * feat(default_ad_api): add motion api
   * feat: modify motion api
@@ -102,7 +102,7 @@ Changelog for package autoware_ad_api_specs
   * feat: add option
   * feat: modify state name
   Co-authored-by: Kenji Miyake <31987104+kenji-miyake@users.noreply.github.com>
-* feat(autoware_ad_api_specs): define operation mode interface (`#1570 <https://github.com/youtalk/autoware.universe/issues/1570>`_)
+* feat(autoware_ad_api_specs): define operation mode interface (`#1570 <https://github.com/autowarefoundation/autoware.universe/issues/1570>`_)
   * feat(autoware_ad_api_msgs): define operation mode interface
   * fix: add message
   * Update common/autoware_ad_api_msgs/operation_mode/msg/OperationModeState.msg
@@ -112,18 +112,18 @@ Changelog for package autoware_ad_api_specs
   * feat: move adapi message
   * feat: change message type
   Co-authored-by: Kenji Miyake <31987104+kenji-miyake@users.noreply.github.com>
-* feat(autoware_ad_api_specs): define motion interface (`#1808 <https://github.com/youtalk/autoware.universe/issues/1808>`_)
+* feat(autoware_ad_api_specs): define motion interface (`#1808 <https://github.com/autowarefoundation/autoware.universe/issues/1808>`_)
   * feat(autoware_ad_api_specs): define motion interface
   * feat: add error code
   * feat: move adapi messages
   * feat(component_interface_utils): apply message change
   * feat: change message type
-* feat(autoware_ad_api_msgs): replace adapi message (`#1897 <https://github.com/youtalk/autoware.universe/issues/1897>`_)
-* feat(autoware_ad_api_specs): define localization interface (`#1560 <https://github.com/youtalk/autoware.universe/issues/1560>`_)
+* feat(autoware_ad_api_msgs): replace adapi message (`#1897 <https://github.com/autowarefoundation/autoware.universe/issues/1897>`_)
+* feat(autoware_ad_api_specs): define localization interface (`#1560 <https://github.com/autowarefoundation/autoware.universe/issues/1560>`_)
   feat(autoware_ad_api_msgs): define localization interface
-* feat(autoware_ad_api_specs): define routing interface (`#1559 <https://github.com/youtalk/autoware.universe/issues/1559>`_)
+* feat(autoware_ad_api_specs): define routing interface (`#1559 <https://github.com/autowarefoundation/autoware.universe/issues/1559>`_)
   * feat(autoware_ad_api_msgs): define routing interface
   * feat: rename route body message
   * feat: rename route state
-* feat(autoware_ad_api_specs): modify interface version api to use spec package  (`#1677 <https://github.com/youtalk/autoware.universe/issues/1677>`_)
+* feat(autoware_ad_api_specs): modify interface version api to use spec package  (`#1677 <https://github.com/autowarefoundation/autoware.universe/issues/1677>`_)
 * Contributors: Kah Hooi Tan, Takagi, Isamu, Vincent Richard, yabuta

--- a/common/autoware_auto_common/CHANGELOG.rst
+++ b/common/autoware_auto_common/CHANGELOG.rst
@@ -5,27 +5,27 @@ Changelog for package autoware_auto_common
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* fix(autoware_auto_common): fix cppcheck warnings of functionStatic (`#8265 <https://github.com/youtalk/autoware.universe/issues/8265>`_)
+* fix(autoware_auto_common): fix cppcheck warnings of functionStatic (`#8265 <https://github.com/autowarefoundation/autoware.universe/issues/8265>`_)
   fix: deal with functionStatic warnings
-* fix(autoware_auto_common): nullptr_t (`#7212 <https://github.com/youtalk/autoware.universe/issues/7212>`_)
-* fix: do not use c++20 char8_t keyword (`#3629 <https://github.com/youtalk/autoware.universe/issues/3629>`_)
+* fix(autoware_auto_common): nullptr_t (`#7212 <https://github.com/autowarefoundation/autoware.universe/issues/7212>`_)
+* fix: do not use c++20 char8_t keyword (`#3629 <https://github.com/autowarefoundation/autoware.universe/issues/3629>`_)
   fix: do not use c++20 keyword as a type alias
 * Contributors: Shumpei Wakabayashi, Yutaka Kondo, ralwing, taisa1
 
 0.26.0 (2024-04-03)
 -------------------
-* fix(autoware_auto_common): move headers to a separate directory (`#5919 <https://github.com/youtalk/autoware.universe/issues/5919>`_)
+* fix(autoware_auto_common): move headers to a separate directory (`#5919 <https://github.com/autowarefoundation/autoware.universe/issues/5919>`_)
   * fix(autoware_auto_common): move headers to a separate directory
   * style(pre-commit): autofix
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* chore: add maintainer (`#4234 <https://github.com/youtalk/autoware.universe/issues/4234>`_)
+* chore: add maintainer (`#4234 <https://github.com/autowarefoundation/autoware.universe/issues/4234>`_)
   * chore: add maintainer
   * Update evaluator/localization_evaluator/package.xml
   Co-authored-by: kminoda <44218668+kminoda@users.noreply.github.com>
   ---------
   Co-authored-by: kminoda <44218668+kminoda@users.noreply.github.com>
-* build: mark autoware_cmake as <buildtool_depend> (`#3616 <https://github.com/youtalk/autoware.universe/issues/3616>`_)
+* build: mark autoware_cmake as <buildtool_depend> (`#3616 <https://github.com/autowarefoundation/autoware.universe/issues/3616>`_)
   * build: mark autoware_cmake as <buildtool_depend>
   with <build_depend>, autoware_cmake is automatically exported with ament_target_dependencies() (unecessary)
   * style(pre-commit): autofix
@@ -33,7 +33,7 @@ Changelog for package autoware_auto_common
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Kenji Miyake <kenji.miyake@tier4.jp>
-* chore(typo): eliminate typos (`#2216 <https://github.com/youtalk/autoware.universe/issues/2216>`_)
+* chore(typo): eliminate typos (`#2216 <https://github.com/autowarefoundation/autoware.universe/issues/2216>`_)
   * Replace 'asssert' with 'assert'
   * fix(typo): computationall => computational
   * fix(typo): collinearity => collinearity
@@ -205,11 +205,11 @@ Changelog for package autoware_auto_common
   commit c7d3b7d2132323af3437af01e9d774b13005bace
   Author: Hirokazu Ishida <38597814+HiroIshida@users.noreply.github.com>
   Date:   Fri Dec 16 13:51:35 2022 +0900
-  test(freespace_planning_algorithms): done't dump rosbag by default (`#2504 <https://github.com/youtalk/autoware.universe/issues/2504>`_)
+  test(freespace_planning_algorithms): done't dump rosbag by default (`#2504 <https://github.com/autowarefoundation/autoware.universe/issues/2504>`_)
   commit 6731e0ced39e3187c2afffe839eaa697a19e5e84
   Author: kminoda <44218668+kminoda@users.noreply.github.com>
   Date:   Fri Dec 16 09:29:35 2022 +0900
-  feat(pose_initializer): partial map loading (`#2500 <https://github.com/youtalk/autoware.universe/issues/2500>`_)
+  feat(pose_initializer): partial map loading (`#2500 <https://github.com/autowarefoundation/autoware.universe/issues/2500>`_)
   * first commit
   * move function
   * now works
@@ -228,7 +228,7 @@ Changelog for package autoware_auto_common
   commit efb4ff1cea6e07aa9e894a6042e8685e30b420ba
   Author: Kosuke Takeuchi <kosuke.tnp@gmail.com>
   Date:   Thu Dec 15 17:29:44 2022 +0900
-  feat(trajectory_follower): extend mpc trajectory for terminal yaw (`#2447 <https://github.com/youtalk/autoware.universe/issues/2447>`_)
+  feat(trajectory_follower): extend mpc trajectory for terminal yaw (`#2447 <https://github.com/autowarefoundation/autoware.universe/issues/2447>`_)
   * feat(trajectory_follower): extend mpc trajectory for terminal yaw
   * make mpc min vel param
   * add mpc extended point after smoothing
@@ -245,7 +245,7 @@ Changelog for package autoware_auto_common
   commit ad2ae7827bdc3af7da8607fdd53ea74940426421
   Author: Takagi, Isamu <43976882+isamu-takagi@users.noreply.github.com>
   Date:   Thu Dec 15 15:52:34 2022 +0900
-  feat(component_interface_tools): add service log checker  (`#2503 <https://github.com/youtalk/autoware.universe/issues/2503>`_)
+  feat(component_interface_tools): add service log checker  (`#2503 <https://github.com/autowarefoundation/autoware.universe/issues/2503>`_)
   * feat(component_interface_utils): add service log checker
   * feat(component_interface_tools): add service log checker
   * feat(component_interface_tools): add diagnostics
@@ -253,11 +253,11 @@ Changelog for package autoware_auto_common
   commit 4a13cc5a32898f5b17791d9381744bf71ff8ed20
   Author: Yutaka Shimizu <43805014+purewater0901@users.noreply.github.com>
   Date:   Thu Dec 15 12:54:11 2022 +0900
-  fix(behavior_path_planner): fix goal lanelet extension (`#2508 <https://github.com/youtalk/autoware.universe/issues/2508>`_)
+  fix(behavior_path_planner): fix goal lanelet extension (`#2508 <https://github.com/autowarefoundation/autoware.universe/issues/2508>`_)
   commit 77b1c36b5ca89b25250dcbb117c9f03a9c36c1c4
   Author: Kyoichi Sugahara <81.s.kyo.19@gmail.com>
   Date:   Thu Dec 15 10:45:45 2022 +0900
-  feat(behavior_path_planner): change side shift module logic (`#2195 <https://github.com/youtalk/autoware.universe/issues/2195>`_)
+  feat(behavior_path_planner): change side shift module logic (`#2195 <https://github.com/autowarefoundation/autoware.universe/issues/2195>`_)
   * change side shift module design
   * cherry picked side shift controller
   * add debug marker to side shift
@@ -275,45 +275,45 @@ Changelog for package autoware_auto_common
   commit 9183c4f20eb4592ed0b48c2eac67add070711677
   Author: Takamasa Horibe <horibe.takamasa@gmail.com>
   Date:   Wed Dec 14 19:59:00 2022 +0900
-  refactor(simple_planning_simulator): make function for duplicated code (`#2502 <https://github.com/youtalk/autoware.universe/issues/2502>`_)
+  refactor(simple_planning_simulator): make function for duplicated code (`#2502 <https://github.com/autowarefoundation/autoware.universe/issues/2502>`_)
   commit ed992b10ed326f03354dce3b563b8622f9ae9a6c
   Author: Yutaka Shimizu <43805014+purewater0901@users.noreply.github.com>
   Date:   Wed Dec 14 17:48:24 2022 +0900
-  fix(behavior_path_planner): fix planner data copy (`#2501 <https://github.com/youtalk/autoware.universe/issues/2501>`_)
+  fix(behavior_path_planner): fix planner data copy (`#2501 <https://github.com/autowarefoundation/autoware.universe/issues/2501>`_)
   commit 0c6c46b33b3c828cb95eaa31fcbf85655fc6a55f
   Author: Yutaka Shimizu <43805014+purewater0901@users.noreply.github.com>
   Date:   Wed Dec 14 14:42:16 2022 +0900
-  fix(behavior_path_planner): fix find nearest function from lateral distance (`#2499 <https://github.com/youtalk/autoware.universe/issues/2499>`_)
+  fix(behavior_path_planner): fix find nearest function from lateral distance (`#2499 <https://github.com/autowarefoundation/autoware.universe/issues/2499>`_)
   * feat(behavior_path_planner): fix find nearest function from lateral distance
   * empty commit
   commit a26b69d1df55e9369ea3adcdd011ae2d7c86dfb7
   Author: Yutaka Shimizu <43805014+purewater0901@users.noreply.github.com>
   Date:   Wed Dec 14 11:28:07 2022 +0900
-  feat(behavior_path_planner): fix overlap checker (`#2498 <https://github.com/youtalk/autoware.universe/issues/2498>`_)
+  feat(behavior_path_planner): fix overlap checker (`#2498 <https://github.com/autowarefoundation/autoware.universe/issues/2498>`_)
   * feat(behavior_path_planner): fix overlap checker
   * remove reserve
   commit 3a24859ca6851caaeb25fc4fac2334fcbdb887d1
   Author: Ismet Atabay <56237550+ismetatabay@users.noreply.github.com>
   Date:   Tue Dec 13 16:51:59 2022 +0300
-  feat(mission_planner): check goal footprint (`#2088 <https://github.com/youtalk/autoware.universe/issues/2088>`_)
+  feat(mission_planner): check goal footprint (`#2088 <https://github.com/autowarefoundation/autoware.universe/issues/2088>`_)
   commit b6a18855431b5f3a67fcbf383fac8df2b45d462e
   Author: Takamasa Horibe <horibe.takamasa@gmail.com>
   Date:   Tue Dec 13 22:46:24 2022 +0900
-  feat(trajectory_visualizer): update for steer limit, remove tf for pose source (`#2267 <https://github.com/youtalk/autoware.universe/issues/2267>`_)
+  feat(trajectory_visualizer): update for steer limit, remove tf for pose source (`#2267 <https://github.com/autowarefoundation/autoware.universe/issues/2267>`_)
   commit f1a9a9608559a5b89f631df3dc2fadd037e36ab4
   Author: Yutaka Shimizu <43805014+purewater0901@users.noreply.github.com>
   Date:   Tue Dec 13 19:47:16 2022 +0900
-  feat(behavior_path_planner): remove unnecessary code and clean turn signal decider (`#2494 <https://github.com/youtalk/autoware.universe/issues/2494>`_)
+  feat(behavior_path_planner): remove unnecessary code and clean turn signal decider (`#2494 <https://github.com/autowarefoundation/autoware.universe/issues/2494>`_)
   * feat(behavior_path_planner): clean drivable area code
   * make a function for turn signal decider
   commit fafe1d8235b99302bc9ba8f3770ae34878f1e7e7
   Author: Yutaka Shimizu <43805014+purewater0901@users.noreply.github.com>
   Date:   Tue Dec 13 18:19:41 2022 +0900
-  feat(behavior_path_planner): change turn signal output timing (`#2493 <https://github.com/youtalk/autoware.universe/issues/2493>`_)
+  feat(behavior_path_planner): change turn signal output timing (`#2493 <https://github.com/autowarefoundation/autoware.universe/issues/2493>`_)
   commit c48b9cfa7074ecd46d96f6dc43679e17bde3a63d
   Author: kminoda <44218668+kminoda@users.noreply.github.com>
   Date:   Tue Dec 13 09:16:14 2022 +0900
-  feat(map_loader): add differential map loading interface (`#2417 <https://github.com/youtalk/autoware.universe/issues/2417>`_)
+  feat(map_loader): add differential map loading interface (`#2417 <https://github.com/autowarefoundation/autoware.universe/issues/2417>`_)
   * first commit
   * ci(pre-commit): autofix
   * added module load in _node.cpp
@@ -326,13 +326,13 @@ Changelog for package autoware_auto_common
   commit 9a3613bfcd3e36e522d0ea9130f6200ca7689e2b
   Author: Takagi, Isamu <43976882+isamu-takagi@users.noreply.github.com>
   Date:   Tue Dec 13 08:49:23 2022 +0900
-  docs(default_ad_api): add readme (`#2491 <https://github.com/youtalk/autoware.universe/issues/2491>`_)
+  docs(default_ad_api): add readme (`#2491 <https://github.com/autowarefoundation/autoware.universe/issues/2491>`_)
   * docs(default_ad_api): add readme
   * feat: update table
   commit 49aa10b04de61c36706f6151d11bf17257ca54d1
   Author: Takagi, Isamu <43976882+isamu-takagi@users.noreply.github.com>
   Date:   Tue Dec 13 06:46:20 2022 +0900
-  feat(default_ad_api): split parameters into file (`#2488 <https://github.com/youtalk/autoware.universe/issues/2488>`_)
+  feat(default_ad_api): split parameters into file (`#2488 <https://github.com/autowarefoundation/autoware.universe/issues/2488>`_)
   * feat(default_ad_api): split parameters into file
   * feat: remove old parameter
   * fix: test
@@ -340,7 +340,7 @@ Changelog for package autoware_auto_common
   commit 7f0138c356c742b6e15e571e7a4683caa55969ac
   Author: Yutaka Shimizu <43805014+purewater0901@users.noreply.github.com>
   Date:   Mon Dec 12 22:16:54 2022 +0900
-  feat(behavior_path_planner, obstacle_avoidance_planner): add new drivable area (`#2472 <https://github.com/youtalk/autoware.universe/issues/2472>`_)
+  feat(behavior_path_planner, obstacle_avoidance_planner): add new drivable area (`#2472 <https://github.com/autowarefoundation/autoware.universe/issues/2472>`_)
   * update
   * update
   * update
@@ -364,11 +364,11 @@ Changelog for package autoware_auto_common
   commit c855e23cc17d1518ebce5dd15629d03acfe17da3
   Author: Takagi, Isamu <43976882+isamu-takagi@users.noreply.github.com>
   Date:   Mon Dec 12 17:15:10 2022 +0900
-  refactor(vehicle_cmd_gate): remove old emergency topics (`#2403 <https://github.com/youtalk/autoware.universe/issues/2403>`_)
+  refactor(vehicle_cmd_gate): remove old emergency topics (`#2403 <https://github.com/autowarefoundation/autoware.universe/issues/2403>`_)
   commit fa04d540c9afdded016730c9978920a194d2d2b4
   Author: Daisuke Nishimatsu <42202095+wep21@users.noreply.github.com>
   Date:   Mon Dec 12 16:04:00 2022 +0900
-  feat: replace python launch with xml launch for system monitor (`#2430 <https://github.com/youtalk/autoware.universe/issues/2430>`_)
+  feat: replace python launch with xml launch for system monitor (`#2430 <https://github.com/autowarefoundation/autoware.universe/issues/2430>`_)
   * feat: replace python launch with xml launch for system monitor
   * ci(pre-commit): autofix
   * update figure
@@ -376,7 +376,7 @@ Changelog for package autoware_auto_common
   commit 4a6990c49d1f8c3bedfb345e7c94c3c6893b4099
   Author: Kosuke Takeuchi <kosuke.tnp@gmail.com>
   Date:   Mon Dec 12 15:01:39 2022 +0900
-  feat(trajectory_follower): pub steer converged marker (`#2441 <https://github.com/youtalk/autoware.universe/issues/2441>`_)
+  feat(trajectory_follower): pub steer converged marker (`#2441 <https://github.com/autowarefoundation/autoware.universe/issues/2441>`_)
   * feat(trajectory_follower): pub steer converged marker
   * Revert "feat(trajectory_follower): pub steer converged marker"
   This reverts commit a6f6917bc542d5b533150f6abba086121e800974.
@@ -384,15 +384,15 @@ Changelog for package autoware_auto_common
   commit 3c01f15125dfbc45e1050ee96ccc42618d6ee6fd
   Author: Takagi, Isamu <43976882+isamu-takagi@users.noreply.github.com>
   Date:   Mon Dec 12 12:48:41 2022 +0900
-  docs(tier4_state_rviz_plugin): update readme (`#2475 <https://github.com/youtalk/autoware.universe/issues/2475>`_)
+  docs(tier4_state_rviz_plugin): update readme (`#2475 <https://github.com/autowarefoundation/autoware.universe/issues/2475>`_)
   commit d8ece0040354be5381a27403bcc757354735a77b
   Author: Takagi, Isamu <43976882+isamu-takagi@users.noreply.github.com>
   Date:   Mon Dec 12 11:57:03 2022 +0900
-  chore(simulator_compatibility_test): suppress setuptools warnings (`#2483 <https://github.com/youtalk/autoware.universe/issues/2483>`_)
+  chore(simulator_compatibility_test): suppress setuptools warnings (`#2483 <https://github.com/autowarefoundation/autoware.universe/issues/2483>`_)
   commit 727586bfe86dc9cb21ce34d9cbe19c241e162b04
   Author: Zulfaqar Azmi <93502286+zulfaqar-azmi-t4@users.noreply.github.com>
   Date:   Mon Dec 12 10:00:35 2022 +0900
-  fix(behavior_path_planner): lane change candidate resolution (`#2426 <https://github.com/youtalk/autoware.universe/issues/2426>`_)
+  fix(behavior_path_planner): lane change candidate resolution (`#2426 <https://github.com/autowarefoundation/autoware.universe/issues/2426>`_)
   * fix(behavior_path_planner): lane change candidate resolution
   * rework sampling based  on current speed
   * refactor code
@@ -402,21 +402,21 @@ Changelog for package autoware_auto_common
   commit 284548ca7f38b1d83af11f2b9caaac116eb9b09c
   Author: Zulfaqar Azmi <93502286+zulfaqar-azmi-t4@users.noreply.github.com>
   Date:   Mon Dec 12 09:57:19 2022 +0900
-  fix(behavior_path_planner): minimum distance for lane change (`#2413 <https://github.com/youtalk/autoware.universe/issues/2413>`_)
+  fix(behavior_path_planner): minimum distance for lane change (`#2413 <https://github.com/autowarefoundation/autoware.universe/issues/2413>`_)
   commit 469d8927bd7a0c98b9d491d347e111065973e13f
   Author: Ryohsuke Mitsudome <43976834+mitsudome-r@users.noreply.github.com>
   Date:   Fri Dec 9 21:27:18 2022 +0900
-  revert(behavior_path): revert removal of refineGoalFunction (`#2340 <https://github.com/youtalk/autoware.universe/issues/2340>`_)" (`#2485 <https://github.com/youtalk/autoware.universe/issues/2485>`_)
+  revert(behavior_path): revert removal of refineGoalFunction (`#2340 <https://github.com/autowarefoundation/autoware.universe/issues/2340>`_)" (`#2485 <https://github.com/autowarefoundation/autoware.universe/issues/2485>`_)
   This reverts commit 8e13ced6dfb6edfea77a589ef4cb93d82683bf51.
   commit d924f85b079dfe64feab017166685be40e977e62
   Author: NorahXiong <103234047+NorahXiong@users.noreply.github.com>
   Date:   Fri Dec 9 19:53:51 2022 +0800
-  fix(freespace_planning_algorithms): fix rrtstar can't arrive goal error (`#2350 <https://github.com/youtalk/autoware.universe/issues/2350>`_)
+  fix(freespace_planning_algorithms): fix rrtstar can't arrive goal error (`#2350 <https://github.com/autowarefoundation/autoware.universe/issues/2350>`_)
   Co-authored-by: Ryohsuke Mitsudome <43976834+mitsudome-r@users.noreply.github.com>
   commit b2ded82324bce78d9db3ff01b0227b00709b1efe
   Author: badai nguyen <94814556+badai-nguyen@users.noreply.github.com>
   Date:   Fri Dec 9 17:12:13 2022 +0900
-  fix(ground-segmentation): recheck gnd cluster pointcloud (`#2448 <https://github.com/youtalk/autoware.universe/issues/2448>`_)
+  fix(ground-segmentation): recheck gnd cluster pointcloud (`#2448 <https://github.com/autowarefoundation/autoware.universe/issues/2448>`_)
   * fix: reclassify ground cluster pcl
   * fix: add lowest-based recheck
   * chore: refactoring
@@ -425,19 +425,19 @@ Changelog for package autoware_auto_common
   commit 8906a1e78bc5b7d6417683ecedc1efe3f48be31e
   Author: Takamasa Horibe <horibe.takamasa@gmail.com>
   Date:   Fri Dec 9 16:29:45 2022 +0900
-  fix(trajectory_follower): fix mpc trajectory z pos (`#2482 <https://github.com/youtalk/autoware.universe/issues/2482>`_)
+  fix(trajectory_follower): fix mpc trajectory z pos (`#2482 <https://github.com/autowarefoundation/autoware.universe/issues/2482>`_)
   commit d4939058f05f9a1609f0ed22afbd0d4febfb212d
   Author: Yutaka Shimizu <43805014+purewater0901@users.noreply.github.com>
   Date:   Fri Dec 9 12:40:30 2022 +0900
-  feat(behavior_velocity_planner): clean walkway module (`#2480 <https://github.com/youtalk/autoware.universe/issues/2480>`_)
+  feat(behavior_velocity_planner): clean walkway module (`#2480 <https://github.com/autowarefoundation/autoware.universe/issues/2480>`_)
   commit d3b86a37ae7c3a0d59832caf56afa13b148d562c
   Author: Makoto Kurihara <mkuri8m@gmail.com>
   Date:   Thu Dec 8 22:59:32 2022 +0900
-  fix(emergency_handler): fix mrm handling when mrm behavior is none (`#2476 <https://github.com/youtalk/autoware.universe/issues/2476>`_)
+  fix(emergency_handler): fix mrm handling when mrm behavior is none (`#2476 <https://github.com/autowarefoundation/autoware.universe/issues/2476>`_)
   commit 2dde073a101e96757ef0cd189bb9ff06836934e9
   Author: Takagi, Isamu <43976882+isamu-takagi@users.noreply.github.com>
   Date:   Thu Dec 8 17:16:13 2022 +0900
-  feat(behavior_velocity_planner): add velocity factors (`#1985 <https://github.com/youtalk/autoware.universe/issues/1985>`_)
+  feat(behavior_velocity_planner): add velocity factors (`#1985 <https://github.com/autowarefoundation/autoware.universe/issues/1985>`_)
   * (editting) add intersection_coordination to stop reason
   * (editting) add intersection coordination to stop reasons
   * (Editting) add v2x to stop reason
@@ -488,11 +488,11 @@ Changelog for package autoware_auto_common
   commit 9a5057e4948ff5ac9165c14eb7112d79f2de76d5
   Author: Kosuke Takeuchi <kosuke.tnp@gmail.com>
   Date:   Thu Dec 8 13:42:50 2022 +0900
-  fix(freespace_planning_algorithms): comment out failing tests (`#2440 <https://github.com/youtalk/autoware.universe/issues/2440>`_)
+  fix(freespace_planning_algorithms): comment out failing tests (`#2440 <https://github.com/autowarefoundation/autoware.universe/issues/2440>`_)
   commit cddb8c74d0fbf49390b4d462c20c12bc257f4825
   Author: kminoda <44218668+kminoda@users.noreply.github.com>
   Date:   Thu Dec 8 11:57:04 2022 +0900
-  feat(gyro_odometer): publish twist when both data arrives (`#2423 <https://github.com/youtalk/autoware.universe/issues/2423>`_)
+  feat(gyro_odometer): publish twist when both data arrives (`#2423 <https://github.com/autowarefoundation/autoware.universe/issues/2423>`_)
   * feat(gyro_odometer): publish when both data arrive
   * remove unnecessary commentouts
   * ci(pre-commit): autofix
@@ -513,61 +513,61 @@ Changelog for package autoware_auto_common
   commit f0f513cf44532dfe8d51d27c4caef23fb694af16
   Author: kminoda <44218668+kminoda@users.noreply.github.com>
   Date:   Thu Dec 8 11:08:29 2022 +0900
-  fix: remove unnecessary DEBUG_INFO declarations (`#2457 <https://github.com/youtalk/autoware.universe/issues/2457>`_)
+  fix: remove unnecessary DEBUG_INFO declarations (`#2457 <https://github.com/autowarefoundation/autoware.universe/issues/2457>`_)
   commit 01daebf42937a05a2d83f3dee2c0778389492e50
   Author: Takayuki Murooka <takayuki5168@gmail.com>
   Date:   Thu Dec 8 00:28:35 2022 +0900
-  fix(tier4_autoware_api_launch): add rosbridge_server dependency (`#2470 <https://github.com/youtalk/autoware.universe/issues/2470>`_)
+  fix(tier4_autoware_api_launch): add rosbridge_server dependency (`#2470 <https://github.com/autowarefoundation/autoware.universe/issues/2470>`_)
   commit 26ef8174b1c12b84070b36df2a7cd14bfa9c0363
   Author: Shumpei Wakabayashi <42209144+shmpwk@users.noreply.github.com>
   Date:   Wed Dec 7 19:32:09 2022 +0900
-  fix: rename `use_external_emergency_stop` to  `check_external_emergency_heartbeat` (`#2455 <https://github.com/youtalk/autoware.universe/issues/2455>`_)
+  fix: rename `use_external_emergency_stop` to  `check_external_emergency_heartbeat` (`#2455 <https://github.com/autowarefoundation/autoware.universe/issues/2455>`_)
   * fix: rename use_external_emergency_stop to check_external_emergency_heartbeat
   * ci(pre-commit): autofix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   commit 024b993a0db8c0d28db0f05f64990bed7069cbd8
   Author: Yutaka Shimizu <43805014+purewater0901@users.noreply.github.com>
   Date:   Wed Dec 7 18:00:32 2022 +0900
-  fix(motion_utils): rename sampling function (`#2469 <https://github.com/youtalk/autoware.universe/issues/2469>`_)
+  fix(motion_utils): rename sampling function (`#2469 <https://github.com/autowarefoundation/autoware.universe/issues/2469>`_)
   commit c240ce2b6f4e79c435ed651b347a7d665a947862
   Author: Yukihiro Saito <yukky.saito@gmail.com>
   Date:   Wed Dec 7 16:33:44 2022 +0900
-  feat: remove web controller (`#2405 <https://github.com/youtalk/autoware.universe/issues/2405>`_)
+  feat: remove web controller (`#2405 <https://github.com/autowarefoundation/autoware.universe/issues/2405>`_)
   commit 2992b1cadae7e7ac86fd249998ce3c7ddbe476c9
   Author: Yutaka Shimizu <43805014+purewater0901@users.noreply.github.com>
   Date:   Wed Dec 7 15:39:28 2022 +0900
-  feat(motion_utils): add points resample function (`#2465 <https://github.com/youtalk/autoware.universe/issues/2465>`_)
+  feat(motion_utils): add points resample function (`#2465 <https://github.com/autowarefoundation/autoware.universe/issues/2465>`_)
   commit 4a75d7c0ddbd88f54afaf2bb05eb65138a53ea60
   Author: Mingyu1991 <115005477+Mingyu1991@users.noreply.github.com>
   Date:   Wed Dec 7 14:42:33 2022 +0900
-  docs: update training data for traffic light (`#2464 <https://github.com/youtalk/autoware.universe/issues/2464>`_)
+  docs: update training data for traffic light (`#2464 <https://github.com/autowarefoundation/autoware.universe/issues/2464>`_)
   * update traffic light cnn classifier README.md
   * correct to upper case
   Co-authored-by: Daisuke Nishimatsu <42202095+wep21@users.noreply.github.com>
   commit a4287165be87fa7727f79c01dfb0bea6af54c333
   Author: Ryuta Kambe <veqcc.c@gmail.com>
   Date:   Wed Dec 7 12:21:49 2022 +0900
-  perf(behavior_velocity_planner): remove unnecessary debug data (`#2462 <https://github.com/youtalk/autoware.universe/issues/2462>`_)
+  perf(behavior_velocity_planner): remove unnecessary debug data (`#2462 <https://github.com/autowarefoundation/autoware.universe/issues/2462>`_)
   commit 0a5b2857d3b2c1c9370598013b25aeaebf2d654d
   Author: Yutaka Shimizu <43805014+purewater0901@users.noreply.github.com>
   Date:   Wed Dec 7 12:03:46 2022 +0900
-  feat(behavior_path_planner): cut overlapped path (`#2451 <https://github.com/youtalk/autoware.universe/issues/2451>`_)
+  feat(behavior_path_planner): cut overlapped path (`#2451 <https://github.com/autowarefoundation/autoware.universe/issues/2451>`_)
   * feat(behavior_path_planner): cut overlapped path
   * clean code
   commit 65003dc99f2abe937afcc010514530fa666fbbfd
   Author: Takagi, Isamu <43976882+isamu-takagi@users.noreply.github.com>
   Date:   Wed Dec 7 11:06:41 2022 +0900
-  revert(default_ad_api): fix autoware state to add wait time (`#2407 <https://github.com/youtalk/autoware.universe/issues/2407>`_) (`#2460 <https://github.com/youtalk/autoware.universe/issues/2460>`_)
-  Revert "fix(default_ad_api): fix autoware state to add wait time (`#2407 <https://github.com/youtalk/autoware.universe/issues/2407>`_)"
+  revert(default_ad_api): fix autoware state to add wait time (`#2407 <https://github.com/autowarefoundation/autoware.universe/issues/2407>`_) (`#2460 <https://github.com/autowarefoundation/autoware.universe/issues/2460>`_)
+  Revert "fix(default_ad_api): fix autoware state to add wait time (`#2407 <https://github.com/autowarefoundation/autoware.universe/issues/2407>`_)"
   This reverts commit c4224854a7e57a9526dde998f742741fe383471c.
   commit fab18677ca4de378faff84a41db5147577e7448d
   Author: Makoto Kurihara <mkuri8m@gmail.com>
   Date:   Wed Dec 7 10:32:41 2022 +0900
-  fix(raw_vehicle_cmd_converter): fix column index for map validation (`#2450 <https://github.com/youtalk/autoware.universe/issues/2450>`_)
+  fix(raw_vehicle_cmd_converter): fix column index for map validation (`#2450 <https://github.com/autowarefoundation/autoware.universe/issues/2450>`_)
   commit a1d3c80a4f5e3a388887a5afb32d9bf7961301f1
   Author: Ambroise Vincent <ambroise.vincent@arm.com>
   Date:   Tue Dec 6 10:39:02 2022 +0100
-  fix(tvm_utility): copy test result to CPU (`#2414 <https://github.com/youtalk/autoware.universe/issues/2414>`_)
+  fix(tvm_utility): copy test result to CPU (`#2414 <https://github.com/autowarefoundation/autoware.universe/issues/2414>`_)
   Also remove dependency to autoware_auto_common.
   Issue-Id: SCM-5401
   Change-Id: I83b859742df2f2ff7df1d0bd2d287bfe0aa04c3d
@@ -575,12 +575,12 @@ Changelog for package autoware_auto_common
   commit eb9946832c7e42d5380fd71956165409d0b592c3
   Author: Mamoru Sobue <mamoru.sobue@tier4.jp>
   Date:   Tue Dec 6 18:11:41 2022 +0900
-  chore(behaviror_velocity_planner): changed logging level for intersection (`#2459 <https://github.com/youtalk/autoware.universe/issues/2459>`_)
+  chore(behaviror_velocity_planner): changed logging level for intersection (`#2459 <https://github.com/autowarefoundation/autoware.universe/issues/2459>`_)
   changed logging level
   commit c4224854a7e57a9526dde998f742741fe383471c
   Author: Takagi, Isamu <43976882+isamu-takagi@users.noreply.github.com>
   Date:   Tue Dec 6 17:01:37 2022 +0900
-  fix(default_ad_api): fix autoware state to add wait time (`#2407 <https://github.com/youtalk/autoware.universe/issues/2407>`_)
+  fix(default_ad_api): fix autoware state to add wait time (`#2407 <https://github.com/autowarefoundation/autoware.universe/issues/2407>`_)
   * fix(default_ad_api): fix autoware state to add wait time
   * Update system/default_ad_api/src/compatibility/autoware_state.cpp
   Co-authored-by: Kenji Miyake <31987104+kenji-miyake@users.noreply.github.com>
@@ -588,14 +588,14 @@ Changelog for package autoware_auto_common
   commit f984fbb708cb02947ec2824ce041c739c35940f7
   Author: Takamasa Horibe <horibe.takamasa@gmail.com>
   Date:   Tue Dec 6 13:55:17 2022 +0900
-  feat(transition_manager): add param to ignore autonomous transition condition (`#2453 <https://github.com/youtalk/autoware.universe/issues/2453>`_)
+  feat(transition_manager): add param to ignore autonomous transition condition (`#2453 <https://github.com/autowarefoundation/autoware.universe/issues/2453>`_)
   * feat(transition_manager): add param to ignore autonomous transition condition
   * same for modeChangeCompleted
   * remove debug print
   commit d3e640df270a0942c4639e11451faf26e099bbe1
   Author: Tomoya Kimura <tomoya.kimura@tier4.jp>
   Date:   Tue Dec 6 13:01:06 2022 +0900
-  feat(operation_mode_transition_manager): transition to auto quickly when vehicle stops (`#2427 <https://github.com/youtalk/autoware.universe/issues/2427>`_)
+  feat(operation_mode_transition_manager): transition to auto quickly when vehicle stops (`#2427 <https://github.com/autowarefoundation/autoware.universe/issues/2427>`_)
   * chore(cspell): interpolable => interpolatable
   * Revert "Merge branch 'destroy-typos-check-all' into destroy-typos"
   This reverts commit 6116ca02d9df59f815d772a271fed7b0b21ebaf7, reversing
@@ -606,48 +606,48 @@ Changelog for package autoware_auto_common
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Yukihiro Saito <yukky.saito@gmail.com>
-* revert: "feat(pointcloud_preprocessor): use point_cloud_msg_wrapper" (`#2317 <https://github.com/youtalk/autoware.universe/issues/2317>`_)
-  Revert "feat(pointcloud_preprocessor): use point_cloud_msg_wrapper (`#1276 <https://github.com/youtalk/autoware.universe/issues/1276>`_)"
+* revert: "feat(pointcloud_preprocessor): use point_cloud_msg_wrapper" (`#2317 <https://github.com/autowarefoundation/autoware.universe/issues/2317>`_)
+  Revert "feat(pointcloud_preprocessor): use point_cloud_msg_wrapper (`#1276 <https://github.com/autowarefoundation/autoware.universe/issues/1276>`_)"
   This reverts commit ef7dcda087beffaa0acf35e9647be1cb439007ba.
-* feat(pointcloud_preprocessor): use point_cloud_msg_wrapper (`#1276 <https://github.com/youtalk/autoware.universe/issues/1276>`_)
-* docs: update link style and fix typos (`#950 <https://github.com/youtalk/autoware.universe/issues/950>`_)
-  * feat(state_rviz_plugin): add GateMode and PathChangeApproval Button (`#894 <https://github.com/youtalk/autoware.universe/issues/894>`_)
+* feat(pointcloud_preprocessor): use point_cloud_msg_wrapper (`#1276 <https://github.com/autowarefoundation/autoware.universe/issues/1276>`_)
+* docs: update link style and fix typos (`#950 <https://github.com/autowarefoundation/autoware.universe/issues/950>`_)
+  * feat(state_rviz_plugin): add GateMode and PathChangeApproval Button (`#894 <https://github.com/autowarefoundation/autoware.universe/issues/894>`_)
   * feat(state_rviz_plugin): add GateMode and PathChangeApproval Button
   * ci(pre-commit): autofix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   * docs: update link style
   * chore: fix link
-  * feat(map_tf_generator): accelerate the 'viewer' coordinate calculation (`#890 <https://github.com/youtalk/autoware.universe/issues/890>`_)
+  * feat(map_tf_generator): accelerate the 'viewer' coordinate calculation (`#890 <https://github.com/autowarefoundation/autoware.universe/issues/890>`_)
   * add random point sampling function to quickly calculate the 'viewer' coordinate
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Kenji Miyake <31987104+kenji-miyake@users.noreply.github.com>
-  * docs(obstacle_stop_planner): update documentation (`#880 <https://github.com/youtalk/autoware.universe/issues/880>`_)
-  * docs(tier4_traffic_light_rviz_plugin): update documentation (`#905 <https://github.com/youtalk/autoware.universe/issues/905>`_)
-  * fix(accel_brake_map_calibrator): rviz panel type (`#895 <https://github.com/youtalk/autoware.universe/issues/895>`_)
+  * docs(obstacle_stop_planner): update documentation (`#880 <https://github.com/autowarefoundation/autoware.universe/issues/880>`_)
+  * docs(tier4_traffic_light_rviz_plugin): update documentation (`#905 <https://github.com/autowarefoundation/autoware.universe/issues/905>`_)
+  * fix(accel_brake_map_calibrator): rviz panel type (`#895 <https://github.com/autowarefoundation/autoware.universe/issues/895>`_)
   * fixed panel type
   * modified instruction for rosbag replay case
   * modified update_map_dir service name
-  * fix(behavior velocity planner): skipping emplace back stop reason if it is empty (`#898 <https://github.com/youtalk/autoware.universe/issues/898>`_)
+  * fix(behavior velocity planner): skipping emplace back stop reason if it is empty (`#898 <https://github.com/autowarefoundation/autoware.universe/issues/898>`_)
   * skipping emplace back stop reason if it is empty
   * add braces
   * ci(pre-commit): autofix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Takagi, Isamu <43976882+isamu-takagi@users.noreply.github.com>
-  * feat(behavior_path_planner): weakened noise filtering of drivable area (`#838 <https://github.com/youtalk/autoware.universe/issues/838>`_)
+  * feat(behavior_path_planner): weakened noise filtering of drivable area (`#838 <https://github.com/autowarefoundation/autoware.universe/issues/838>`_)
   * feat(behavior_path_planner): Weakened noise filtering of drivable area
   * fix lanelet's longitudinal disconnection
   * add comments of erode/dilate process
-  * refactor(vehicle-cmd-gate): using namespace for msgs (`#913 <https://github.com/youtalk/autoware.universe/issues/913>`_)
+  * refactor(vehicle-cmd-gate): using namespace for msgs (`#913 <https://github.com/autowarefoundation/autoware.universe/issues/913>`_)
   * refactor(vehicle-cmd-gate): using namespace for msgs
   * for clang
-  * feat(pose_initializer): introduce an array copy function (`#900 <https://github.com/youtalk/autoware.universe/issues/900>`_)
+  * feat(pose_initializer): introduce an array copy function (`#900 <https://github.com/autowarefoundation/autoware.universe/issues/900>`_)
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-  * feat: add lidar point filter when debug (`#865 <https://github.com/youtalk/autoware.universe/issues/865>`_)
+  * feat: add lidar point filter when debug (`#865 <https://github.com/autowarefoundation/autoware.universe/issues/865>`_)
   * feat: add lidar point filter when debug
   * ci(pre-commit): autofix
   Co-authored-by: suchang <chang.su@autocore.ai>
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-  * feat(component_interface_utils): add interface classes  (`#899 <https://github.com/youtalk/autoware.universe/issues/899>`_)
+  * feat(component_interface_utils): add interface classes  (`#899 <https://github.com/autowarefoundation/autoware.universe/issues/899>`_)
   * feat(component_interface_utils): add interface classes
   * feat(default_ad_api): apply the changes of interface utils
   * fix(component_interface_utils): remove old comment
@@ -655,18 +655,18 @@ Changelog for package autoware_auto_common
   * fix(component_interface_utils): remove unimplemented message
   * docs(component_interface_utils): add design policy
   * docs(component_interface_utils): add comment
-  * refactor(vehicle_cmd_gate): change namespace in launch file (`#927 <https://github.com/youtalk/autoware.universe/issues/927>`_)
+  * refactor(vehicle_cmd_gate): change namespace in launch file (`#927 <https://github.com/autowarefoundation/autoware.universe/issues/927>`_)
   Co-authored-by: Berkay <berkay@leodrive.ai>
-  * feat: visualize lane boundaries (`#923 <https://github.com/youtalk/autoware.universe/issues/923>`_)
+  * feat: visualize lane boundaries (`#923 <https://github.com/autowarefoundation/autoware.universe/issues/923>`_)
   * feat: visualize lane boundaries
   * fix: start_bound
   * ci(pre-commit): autofix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-  * fix(system_monitor): fix truncation warning in strncpy (`#872 <https://github.com/youtalk/autoware.universe/issues/872>`_)
+  * fix(system_monitor): fix truncation warning in strncpy (`#872 <https://github.com/autowarefoundation/autoware.universe/issues/872>`_)
   * fix(system_monitor): fix truncation warning in strncpy
   * Use std::string constructor to copy char array
   * Fixed typo
-  * fix(behavior_velocity_planner.stopline): extend following and previous search range to avoid no collision (`#917 <https://github.com/youtalk/autoware.universe/issues/917>`_)
+  * fix(behavior_velocity_planner.stopline): extend following and previous search range to avoid no collision (`#917 <https://github.com/autowarefoundation/autoware.universe/issues/917>`_)
   * fix: extend following and previous search range to avoid no collision
   * chore: add debug marker
   * fix: simplify logic
@@ -676,11 +676,11 @@ Changelog for package autoware_auto_common
   * ci(pre-commit): autofix
   * fix: delete debug code
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-  * docs(surround obstacle checker): update documentation (`#878 <https://github.com/youtalk/autoware.universe/issues/878>`_)
+  * docs(surround obstacle checker): update documentation (`#878 <https://github.com/autowarefoundation/autoware.universe/issues/878>`_)
   * docs(surround_obstacle_checker): update pub/sub topics & params
   * docs(surround_obstacle_checker): remove unused files
   * docs(surround_obstacke_checker): update purpose
-  * feat(tier4_autoware_utils): add vehicle state checker (`#896 <https://github.com/youtalk/autoware.universe/issues/896>`_)
+  * feat(tier4_autoware_utils): add vehicle state checker (`#896 <https://github.com/autowarefoundation/autoware.universe/issues/896>`_)
   * feat(tier4_autoware_utils): add vehicle state checker
   * fix(tier4_autoware_utils): use absolute value
   * feat(tier4_autoware_utils): divide into two classies
@@ -690,20 +690,20 @@ Changelog for package autoware_auto_common
   * fix(tier4_autoware_utils): into same loop
   * fix(tier4_autoware_utils): fix variables name
   * fix(tier4_autoware_utils): remove redundant codes
-  * fix(motion_velocity_smoother): fix overwriteStopPoint using backward point (`#816 <https://github.com/youtalk/autoware.universe/issues/816>`_)
+  * fix(motion_velocity_smoother): fix overwriteStopPoint using backward point (`#816 <https://github.com/autowarefoundation/autoware.universe/issues/816>`_)
   * fix(motion_velocity_smoother): fix overwriteStopPoint using backward point
   * Modify overwriteStopPoint input and output
-  * feat(obstacle_avoidance_planner): explicitly insert zero velocity (`#906 <https://github.com/youtalk/autoware.universe/issues/906>`_)
+  * feat(obstacle_avoidance_planner): explicitly insert zero velocity (`#906 <https://github.com/autowarefoundation/autoware.universe/issues/906>`_)
   * feat(obstacle_avoidance_planner) fix bug of stop line unalignment
   * fix bug of unsorted output points
   * move calcVelocity in node.cpp
   * fix build error
-  * feat(behavior_velocity): find occlusion more efficiently (`#829 <https://github.com/youtalk/autoware.universe/issues/829>`_)
-  * fix(system_monitor): add some smart information to diagnostics (`#708 <https://github.com/youtalk/autoware.universe/issues/708>`_)
-  * feat(obstacle_avoidance_planner): dealt with close lane change (`#921 <https://github.com/youtalk/autoware.universe/issues/921>`_)
+  * feat(behavior_velocity): find occlusion more efficiently (`#829 <https://github.com/autowarefoundation/autoware.universe/issues/829>`_)
+  * fix(system_monitor): add some smart information to diagnostics (`#708 <https://github.com/autowarefoundation/autoware.universe/issues/708>`_)
+  * feat(obstacle_avoidance_planner): dealt with close lane change (`#921 <https://github.com/autowarefoundation/autoware.universe/issues/921>`_)
   * feat(obstacle_avoidance_planner): dealt with close lane change
   * fix bug of right lane change
-  * feat(obstacle_avoidance_planner): some fix for narrow driving (`#916 <https://github.com/youtalk/autoware.universe/issues/916>`_)
+  * feat(obstacle_avoidance_planner): some fix for narrow driving (`#916 <https://github.com/autowarefoundation/autoware.universe/issues/916>`_)
   * use car like constraints in mpt
   * use not widest bounds for the first bounds
   * organized params
@@ -713,17 +713,17 @@ Changelog for package autoware_auto_common
   * update config
   * remove unnecessary files
   * update tier4_planning_launch params
-  * chore(obstacle_avoidance_planner): removed obsolete obstacle_avoidance_planner doc in Japanese (`#919 <https://github.com/youtalk/autoware.universe/issues/919>`_)
-  * chore(behavior_velocity_planner.stopline): add debug marker for stopline collision check (`#932 <https://github.com/youtalk/autoware.universe/issues/932>`_)
+  * chore(obstacle_avoidance_planner): removed obsolete obstacle_avoidance_planner doc in Japanese (`#919 <https://github.com/autowarefoundation/autoware.universe/issues/919>`_)
+  * chore(behavior_velocity_planner.stopline): add debug marker for stopline collision check (`#932 <https://github.com/autowarefoundation/autoware.universe/issues/932>`_)
   * chore(behavior_velocity_planner.stopline): add debug marker for stopline collision check
   * feat: use marker helper
-  * feat(map_loader): visualize center line by points (`#931 <https://github.com/youtalk/autoware.universe/issues/931>`_)
+  * feat(map_loader): visualize center line by points (`#931 <https://github.com/autowarefoundation/autoware.universe/issues/931>`_)
   * feat: visualize center line points
   * fix: delete space
   * feat: visualize center line by arrow
   * revert insertMarkerArray
   * fix: delete space
-  * feat: add RTC interface (`#765 <https://github.com/youtalk/autoware.universe/issues/765>`_)
+  * feat: add RTC interface (`#765 <https://github.com/autowarefoundation/autoware.universe/issues/765>`_)
   * feature(rtc_interface): add files
   * feature(rtc_interface): implement functions
   * feature(rtc_interface): reimprement functions to use CooperateCommands and write README.md
@@ -735,23 +735,23 @@ Changelog for package autoware_auto_common
   * feature(rtc_interface): add isRegistered and clearCooperateStatus
   * ci(pre-commit): autofix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-  * chore: sync files (`#911 <https://github.com/youtalk/autoware.universe/issues/911>`_)
+  * chore: sync files (`#911 <https://github.com/autowarefoundation/autoware.universe/issues/911>`_)
   Co-authored-by: kenji-miyake <kenji-miyake@users.noreply.github.com>
-  * fix: replace boost::mutex::scoped_lock to std::scoped_lock (`#907 <https://github.com/youtalk/autoware.universe/issues/907>`_)
+  * fix: replace boost::mutex::scoped_lock to std::scoped_lock (`#907 <https://github.com/autowarefoundation/autoware.universe/issues/907>`_)
   * fix: replace boost::mutex::scoped_lock to std::scoped_lock
   * fix: replace boost::mutex to std::mutex
-  * feat(tensorrt_yolo): add multi gpu support to tensorrt_yolo node (`#885 <https://github.com/youtalk/autoware.universe/issues/885>`_)
+  * feat(tensorrt_yolo): add multi gpu support to tensorrt_yolo node (`#885 <https://github.com/autowarefoundation/autoware.universe/issues/885>`_)
   * feat(tensorrt_yolo): add multi gpu support to tensorrt_yolo node
   * feat(tensorrt_yolo): update arg
   Co-authored-by: Kaan Colak <kcolak@leodrive.ai>
-  * feat(tier4_planning_launch): create parameter yaml for behavior_velocity_planner (`#887 <https://github.com/youtalk/autoware.universe/issues/887>`_)
+  * feat(tier4_planning_launch): create parameter yaml for behavior_velocity_planner (`#887 <https://github.com/autowarefoundation/autoware.universe/issues/887>`_)
   * feat(tier4_planning_launch): create parameter yaml for behavior_velocity_planner
   * Update launch/tier4_planning_launch/config/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/behavior_velocity_planner.param.yaml
   Co-authored-by: taikitanaka3 <65527974+taikitanaka3@users.noreply.github.com>
   * feat: add param.yaml in behavior_velocity_planner package
   * some fix
   Co-authored-by: taikitanaka3 <65527974+taikitanaka3@users.noreply.github.com>
-  * fix(map_loader): use std::filesystem to load pcd files in pointcloud_map_loader (`#942 <https://github.com/youtalk/autoware.universe/issues/942>`_)
+  * fix(map_loader): use std::filesystem to load pcd files in pointcloud_map_loader (`#942 <https://github.com/autowarefoundation/autoware.universe/issues/942>`_)
   * fix(map_loader): use std::filesystem to load pcd files in pointcloud_map_loader
   * fix(map_loader): remove c_str
   * fix(map_loader): replace c_str to string
@@ -790,18 +790,18 @@ Changelog for package autoware_auto_common
   Co-authored-by: Kaan Çolak <kaancolak95@gmail.com>
   Co-authored-by: Kaan Colak <kcolak@leodrive.ai>
   Co-authored-by: Kenji Miyake <kenji.miyake@tier4.jp>
-* feat: isolate gtests in all packages (`#693 <https://github.com/youtalk/autoware.universe/issues/693>`_)
-* chore: upgrade cmake_minimum_required to 3.14 (`#856 <https://github.com/youtalk/autoware.universe/issues/856>`_)
-* refactor: use autoware cmake (`#849 <https://github.com/youtalk/autoware.universe/issues/849>`_)
+* feat: isolate gtests in all packages (`#693 <https://github.com/autowarefoundation/autoware.universe/issues/693>`_)
+* chore: upgrade cmake_minimum_required to 3.14 (`#856 <https://github.com/autowarefoundation/autoware.universe/issues/856>`_)
+* refactor: use autoware cmake (`#849 <https://github.com/autowarefoundation/autoware.universe/issues/849>`_)
   * remove autoware_auto_cmake
   * add build_depend of autoware_cmake
   * use autoware_cmake in CMakeLists.txt
   * fix bugs
   * fix cmake lint errors
-* chore: remove license notations from CMakeLists.txt (`#846 <https://github.com/youtalk/autoware.universe/issues/846>`_)
-* chore: remove bad chars (`#845 <https://github.com/youtalk/autoware.universe/issues/845>`_)
-* style: fix format of package.xml (`#844 <https://github.com/youtalk/autoware.universe/issues/844>`_)
-* fix(autoware_auto_tf2): modify build error in rolling (`#718 <https://github.com/youtalk/autoware.universe/issues/718>`_)
+* chore: remove license notations from CMakeLists.txt (`#846 <https://github.com/autowarefoundation/autoware.universe/issues/846>`_)
+* chore: remove bad chars (`#845 <https://github.com/autowarefoundation/autoware.universe/issues/845>`_)
+* style: fix format of package.xml (`#844 <https://github.com/autowarefoundation/autoware.universe/issues/844>`_)
+* fix(autoware_auto_tf2): modify build error in rolling (`#718 <https://github.com/autowarefoundation/autoware.universe/issues/718>`_)
   * fix(autoware_auto_common): modify build error in rolling
   * fix(autoware_auto_tf2): modify build error in rolling
   * fix(autoware_auto_geometry): modify build error in rolling
@@ -811,8 +811,8 @@ Changelog for package autoware_auto_common
   * fix(simple_planning_simulator): modify build error in rolling
   * ci(pre-commit): autofix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* chore: fix typos (`#751 <https://github.com/youtalk/autoware.universe/issues/751>`_)
-* ci(pre-commit): clear the exclude option (`#426 <https://github.com/youtalk/autoware.universe/issues/426>`_)
+* chore: fix typos (`#751 <https://github.com/autowarefoundation/autoware.universe/issues/751>`_)
+* ci(pre-commit): clear the exclude option (`#426 <https://github.com/autowarefoundation/autoware.universe/issues/426>`_)
   * ci(pre-commit): remove unnecessary excludes
   * ci(pre-commit): autofix
   * ci(pre-commit): autofix
@@ -824,61 +824,61 @@ Changelog for package autoware_auto_common
   * fix build
   * use autoware_lint_common
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* chore: remove filesystem.hpp (`#440 <https://github.com/youtalk/autoware.universe/issues/440>`_)
-* feat: add autoware auto dependencies (`#185 <https://github.com/youtalk/autoware.universe/issues/185>`_)
-  * Back port .auto control packages (`#571 <https://github.com/youtalk/autoware.universe/issues/571>`_)
+* chore: remove filesystem.hpp (`#440 <https://github.com/autowarefoundation/autoware.universe/issues/440>`_)
+* feat: add autoware auto dependencies (`#185 <https://github.com/autowarefoundation/autoware.universe/issues/185>`_)
+  * Back port .auto control packages (`#571 <https://github.com/autowarefoundation/autoware.universe/issues/571>`_)
   * Implement Lateral and Longitudinal Control Muxer
-  * [`#570 <https://github.com/youtalk/autoware.universe/issues/570>`_] Porting wf_simulator
-  * [`#1189 <https://github.com/youtalk/autoware.universe/issues/1189>`_] Deactivate flaky test in 'trajectory_follower_nodes'
-  * [`#1189 <https://github.com/youtalk/autoware.universe/issues/1189>`_] Fix flacky test in 'trajectory_follower_nodes/latlon_muxer'
-  * [`#1057 <https://github.com/youtalk/autoware.universe/issues/1057>`_] Add osqp_interface package
-  * [`#1057 <https://github.com/youtalk/autoware.universe/issues/1057>`_] Add library code for MPC-based lateral control
-  * [`#1271 <https://github.com/youtalk/autoware.universe/issues/1271>`_] Use std::abs instead of abs
-  * [`#1057 <https://github.com/youtalk/autoware.universe/issues/1057>`_] Implement Lateral Controller for Cargo ODD
-  * [`#1246 <https://github.com/youtalk/autoware.universe/issues/1246>`_] Resolve "Test case names currently use snake_case but should be CamelCase"
-  * [`#1325 <https://github.com/youtalk/autoware.universe/issues/1325>`_] Deactivate flaky smoke test in 'trajectory_follower_nodes'
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Add library code of longitudinal controller
+  * [`#570 <https://github.com/autowarefoundation/autoware.universe/issues/570>`_] Porting wf_simulator
+  * [`#1189 <https://github.com/autowarefoundation/autoware.universe/issues/1189>`_] Deactivate flaky test in 'trajectory_follower_nodes'
+  * [`#1189 <https://github.com/autowarefoundation/autoware.universe/issues/1189>`_] Fix flacky test in 'trajectory_follower_nodes/latlon_muxer'
+  * [`#1057 <https://github.com/autowarefoundation/autoware.universe/issues/1057>`_] Add osqp_interface package
+  * [`#1057 <https://github.com/autowarefoundation/autoware.universe/issues/1057>`_] Add library code for MPC-based lateral control
+  * [`#1271 <https://github.com/autowarefoundation/autoware.universe/issues/1271>`_] Use std::abs instead of abs
+  * [`#1057 <https://github.com/autowarefoundation/autoware.universe/issues/1057>`_] Implement Lateral Controller for Cargo ODD
+  * [`#1246 <https://github.com/autowarefoundation/autoware.universe/issues/1246>`_] Resolve "Test case names currently use snake_case but should be CamelCase"
+  * [`#1325 <https://github.com/autowarefoundation/autoware.universe/issues/1325>`_] Deactivate flaky smoke test in 'trajectory_follower_nodes'
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Add library code of longitudinal controller
   * Fix build error for trajectory follower
   * Fix build error for trajectory follower nodes
-  * [`#1272 <https://github.com/youtalk/autoware.universe/issues/1272>`_] Add AckermannControlCommand support to simple_planning_simulator
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Add Longitudinal Controller node
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Rename velocity_controller -> longitudinal_controller
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Update CMakeLists.txt for the longitudinal_controller_node
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Add smoke test python launch file
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Use LowPassFilter1d from trajectory_follower
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Use autoware_auto_msgs
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Changes for .auto (debug msg tmp fix, common func, tf listener)
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Remove unused parameters
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Fix ros test
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Rm default params from declare_parameters + use autoware types
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Use default param file to setup NodeOptions in the ros test
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Fix docstring
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Replace receiving a Twist with a VehicleKinematicState
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Change class variables format to m\_ prefix
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Fix plugin name of LongitudinalController in CMakeLists.txt
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Fix copyright dates
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Reorder includes
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Add some tests (~89% coverage without disabling flaky tests)
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Add more tests (90+% coverage without disabling flaky tests)
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Use Float32MultiArrayDiagnostic message for debug and slope
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Calculate wheel_base value from vehicle parameters
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Cleanup redundant logger setting in tests
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Set ROS_DOMAIN_ID when running tests to prevent CI failures
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Remove TF listener and use published vehicle state instead
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Change smoke tests to use autoware_testing
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Add plotjuggler cfg for both lateral and longitudinal control
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Improve design documents
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Disable flaky test
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Properly transform vehicle state in longitudinal node
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Fix TF buffer of lateral controller
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Tuning of lateral controller for LGSVL
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Fix formating
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Fix /tf_static sub to be transient_local
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Fix yaw recalculation of reverse trajs in the lateral controller
+  * [`#1272 <https://github.com/autowarefoundation/autoware.universe/issues/1272>`_] Add AckermannControlCommand support to simple_planning_simulator
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Add Longitudinal Controller node
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Rename velocity_controller -> longitudinal_controller
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Update CMakeLists.txt for the longitudinal_controller_node
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Add smoke test python launch file
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Use LowPassFilter1d from trajectory_follower
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Use autoware_auto_msgs
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Changes for .auto (debug msg tmp fix, common func, tf listener)
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Remove unused parameters
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Fix ros test
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Rm default params from declare_parameters + use autoware types
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Use default param file to setup NodeOptions in the ros test
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Fix docstring
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Replace receiving a Twist with a VehicleKinematicState
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Change class variables format to m\_ prefix
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Fix plugin name of LongitudinalController in CMakeLists.txt
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Fix copyright dates
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Reorder includes
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Add some tests (~89% coverage without disabling flaky tests)
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Add more tests (90+% coverage without disabling flaky tests)
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Use Float32MultiArrayDiagnostic message for debug and slope
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Calculate wheel_base value from vehicle parameters
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Cleanup redundant logger setting in tests
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Set ROS_DOMAIN_ID when running tests to prevent CI failures
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Remove TF listener and use published vehicle state instead
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Change smoke tests to use autoware_testing
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Add plotjuggler cfg for both lateral and longitudinal control
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Improve design documents
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Disable flaky test
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Properly transform vehicle state in longitudinal node
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Fix TF buffer of lateral controller
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Tuning of lateral controller for LGSVL
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Fix formating
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Fix /tf_static sub to be transient_local
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Fix yaw recalculation of reverse trajs in the lateral controller
   * modify trajectory_follower for galactic build
-  * [`#1379 <https://github.com/youtalk/autoware.universe/issues/1379>`_] Update trajectory_follower
-  * [`#1379 <https://github.com/youtalk/autoware.universe/issues/1379>`_] Update simple_planning_simulator
-  * [`#1379 <https://github.com/youtalk/autoware.universe/issues/1379>`_] Update trajectory_follower_nodes
+  * [`#1379 <https://github.com/autowarefoundation/autoware.universe/issues/1379>`_] Update trajectory_follower
+  * [`#1379 <https://github.com/autowarefoundation/autoware.universe/issues/1379>`_] Update simple_planning_simulator
+  * [`#1379 <https://github.com/autowarefoundation/autoware.universe/issues/1379>`_] Update trajectory_follower_nodes
   * apply trajectory msg modification in control
   * move directory
   * remote control/trajectory_follower level dorectpry
@@ -902,7 +902,7 @@ Changelog for package autoware_auto_common
   Co-authored-by: MIURA Yasuyuki <kokosabu@gmail.com>
   Co-authored-by: wep21 <border_goldenmarket@yahoo.co.jp>
   Co-authored-by: tomoya.kimura <tomoya.kimura@tier4.jp>
-  * Port parking planner packages from .Auto (`#600 <https://github.com/youtalk/autoware.universe/issues/600>`_)
+  * Port parking planner packages from .Auto (`#600 <https://github.com/autowarefoundation/autoware.universe/issues/600>`_)
   * Copy code of 'vehicle_constants_manager'
   * Fix vehicle_constants_manager for ROS galactic
   * Rm .iv costmap_generator freespace_planner freespace_planning_aglorihtms

--- a/common/autoware_component_interface_specs/CHANGELOG.rst
+++ b/common/autoware_component_interface_specs/CHANGELOG.rst
@@ -5,8 +5,8 @@ Changelog for package autoware_component_interface_specs
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* fix: fix internal door interface qos (`#9144 <https://github.com/youtalk/autoware.universe/issues/9144>`_)
-* refactor(component_interface_specs): prefix package and namespace with autoware (`#9094 <https://github.com/youtalk/autoware.universe/issues/9094>`_)
+* fix: fix internal door interface qos (`#9144 <https://github.com/autowarefoundation/autoware.universe/issues/9144>`_)
+* refactor(component_interface_specs): prefix package and namespace with autoware (`#9094 <https://github.com/autowarefoundation/autoware.universe/issues/9094>`_)
 * Contributors: Esteve Fernandez, Takagi, Isamu, Yutaka Kondo
 
 0.26.0 (2024-04-03)

--- a/common/autoware_component_interface_tools/CHANGELOG.rst
+++ b/common/autoware_component_interface_tools/CHANGELOG.rst
@@ -5,7 +5,7 @@ Changelog for package autoware_component_interface_tools
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* refactor(component_interface_tools): prefix package and namespace with autoware (`#9093 <https://github.com/youtalk/autoware.universe/issues/9093>`_)
+* refactor(component_interface_tools): prefix package and namespace with autoware (`#9093 <https://github.com/autowarefoundation/autoware.universe/issues/9093>`_)
 * Contributors: Esteve Fernandez, Yutaka Kondo
 
 0.26.0 (2024-04-03)

--- a/common/autoware_component_interface_utils/CHANGELOG.rst
+++ b/common/autoware_component_interface_utils/CHANGELOG.rst
@@ -5,25 +5,25 @@ Changelog for package component_interface_utils
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* ci(pre-commit): autoupdate (`#7499 <https://github.com/youtalk/autoware.universe/issues/7499>`_)
+* ci(pre-commit): autoupdate (`#7499 <https://github.com/autowarefoundation/autoware.universe/issues/7499>`_)
   Co-authored-by: M. Fatih Cırıt <mfc@leodrive.ai>
 * Contributors: Yutaka Kondo, awf-autoware-bot[bot]
 
 0.26.0 (2024-04-03)
 -------------------
-* chore: update api package maintainers (`#6086 <https://github.com/youtalk/autoware.universe/issues/6086>`_)
+* chore: update api package maintainers (`#6086 <https://github.com/autowarefoundation/autoware.universe/issues/6086>`_)
   * update api maintainers
   * fix
   ---------
-* chore(component_interface_utils): set log level of debug printing to DEBUG (`#5995 <https://github.com/youtalk/autoware.universe/issues/5995>`_)
-* feat: add common interface utils test (`#5173 <https://github.com/youtalk/autoware.universe/issues/5173>`_)
+* chore(component_interface_utils): set log level of debug printing to DEBUG (`#5995 <https://github.com/autowarefoundation/autoware.universe/issues/5995>`_)
+* feat: add common interface utils test (`#5173 <https://github.com/autowarefoundation/autoware.universe/issues/5173>`_)
   * add interface utils test
   * style(pre-commit): autofix
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat(autoware_api_specs): change topic depth of route state api and localization state api (`#3757 <https://github.com/youtalk/autoware.universe/issues/3757>`_)
+* feat(autoware_api_specs): change topic depth of route state api and localization state api (`#3757 <https://github.com/autowarefoundation/autoware.universe/issues/3757>`_)
   fix depth
-* build: mark autoware_cmake as <buildtool_depend> (`#3616 <https://github.com/youtalk/autoware.universe/issues/3616>`_)
+* build: mark autoware_cmake as <buildtool_depend> (`#3616 <https://github.com/autowarefoundation/autoware.universe/issues/3616>`_)
   * build: mark autoware_cmake as <buildtool_depend>
   with <build_depend>, autoware_cmake is automatically exported with ament_target_dependencies() (unecessary)
   * style(pre-commit): autofix
@@ -31,15 +31,15 @@ Changelog for package component_interface_utils
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Kenji Miyake <kenji.miyake@tier4.jp>
-* chore: update codeowners (`#3513 <https://github.com/youtalk/autoware.universe/issues/3513>`_)
-* feat(component_interface_tools): add service log checker  (`#2503 <https://github.com/youtalk/autoware.universe/issues/2503>`_)
+* chore: update codeowners (`#3513 <https://github.com/autowarefoundation/autoware.universe/issues/3513>`_)
+* feat(component_interface_tools): add service log checker  (`#2503 <https://github.com/autowarefoundation/autoware.universe/issues/2503>`_)
   * feat(component_interface_utils): add service log checker
   * feat(component_interface_tools): add service log checker
   * feat(component_interface_tools): add diagnostics
   * feat: update system error monitor config
-* chore: add api maintainers (`#2361 <https://github.com/youtalk/autoware.universe/issues/2361>`_)
-* fix(component_interface_utils): fix error level (`#2322 <https://github.com/youtalk/autoware.universe/issues/2322>`_)
-* feat(operation_mode_transition_manager): support ad api (`#1535 <https://github.com/youtalk/autoware.universe/issues/1535>`_)
+* chore: add api maintainers (`#2361 <https://github.com/autowarefoundation/autoware.universe/issues/2361>`_)
+* fix(component_interface_utils): fix error level (`#2322 <https://github.com/autowarefoundation/autoware.universe/issues/2322>`_)
+* feat(operation_mode_transition_manager): support ad api (`#1535 <https://github.com/autowarefoundation/autoware.universe/issues/1535>`_)
   * feat(operation_mode_transition_manager): support ad api
   * fix: merge operation mode state message
   * feat(autoware_ad_api_msgs): define operation mode interface
@@ -58,7 +58,7 @@ Changelog for package component_interface_utils
   * fix: fix operation mode change when disable autoware control
   * fix: fix operation mode change when autoware control is disabled
   Co-authored-by: Kenji Miyake <31987104+kenji-miyake@users.noreply.github.com>
-* feat(default_ad_api): add motion api  (`#1809 <https://github.com/youtalk/autoware.universe/issues/1809>`_)
+* feat(default_ad_api): add motion api  (`#1809 <https://github.com/autowarefoundation/autoware.universe/issues/1809>`_)
   * feat(autoware_ad_api_specs): define motion interface
   * feat(default_ad_api): add motion api
   * feat: modify motion api
@@ -74,20 +74,20 @@ Changelog for package component_interface_utils
   * feat: add option
   * feat: modify state name
   Co-authored-by: Kenji Miyake <31987104+kenji-miyake@users.noreply.github.com>
-* feat(component_interface_utils): change service log output (`#2022 <https://github.com/youtalk/autoware.universe/issues/2022>`_)
+* feat(component_interface_utils): change service log output (`#2022 <https://github.com/autowarefoundation/autoware.universe/issues/2022>`_)
   * feat(component_interface_utils): change client log
   * feat(component_interface_utils): change server log
   * feat(component_interface_utils): add interface
   * feat: add console log
-* feat(component_interface_utils): apply message change (`#1921 <https://github.com/youtalk/autoware.universe/issues/1921>`_)
+* feat(component_interface_utils): apply message change (`#1921 <https://github.com/autowarefoundation/autoware.universe/issues/1921>`_)
   * feat(component_interface_utils): apply message change
   * feat: add error category
-* feat(autoware_ad_api_msgs): replace adapi message (`#1897 <https://github.com/youtalk/autoware.universe/issues/1897>`_)
-* feat(autoware_ad_api_specs): define routing interface (`#1559 <https://github.com/youtalk/autoware.universe/issues/1559>`_)
+* feat(autoware_ad_api_msgs): replace adapi message (`#1897 <https://github.com/autowarefoundation/autoware.universe/issues/1897>`_)
+* feat(autoware_ad_api_specs): define routing interface (`#1559 <https://github.com/autowarefoundation/autoware.universe/issues/1559>`_)
   * feat(autoware_ad_api_msgs): define routing interface
   * feat: rename route body message
   * feat: rename route state
-* feat(component_interface_utils): update service utility (`#1429 <https://github.com/youtalk/autoware.universe/issues/1429>`_)
+* feat(component_interface_utils): update service utility (`#1429 <https://github.com/autowarefoundation/autoware.universe/issues/1429>`_)
   * feat(component_interface_utils): add exceptions, relay, and synchronous service call
   * feat(autoware_ad_api_msgs): add status code
   * feat(component_interface_utils): fix for hubmle
@@ -99,7 +99,7 @@ Changelog for package component_interface_utils
   * feat(component_interface_utils): use optional for no timeout
   * docs(component_interface_utils): update readme
   * feat(component_interface_utils): add bind function
-* feat(component_interface_utils): add interface classes  (`#899 <https://github.com/youtalk/autoware.universe/issues/899>`_)
+* feat(component_interface_utils): add interface classes  (`#899 <https://github.com/autowarefoundation/autoware.universe/issues/899>`_)
   * feat(component_interface_utils): add interface classes
   * feat(default_ad_api): apply the changes of interface utils
   * fix(component_interface_utils): remove old comment
@@ -107,21 +107,21 @@ Changelog for package component_interface_utils
   * fix(component_interface_utils): remove unimplemented message
   * docs(component_interface_utils): add design policy
   * docs(component_interface_utils): add comment
-* chore: upgrade cmake_minimum_required to 3.14 (`#856 <https://github.com/youtalk/autoware.universe/issues/856>`_)
-* refactor: simplify Rolling support (`#854 <https://github.com/youtalk/autoware.universe/issues/854>`_)
-* refactor: use autoware cmake (`#849 <https://github.com/youtalk/autoware.universe/issues/849>`_)
+* chore: upgrade cmake_minimum_required to 3.14 (`#856 <https://github.com/autowarefoundation/autoware.universe/issues/856>`_)
+* refactor: simplify Rolling support (`#854 <https://github.com/autowarefoundation/autoware.universe/issues/854>`_)
+* refactor: use autoware cmake (`#849 <https://github.com/autowarefoundation/autoware.universe/issues/849>`_)
   * remove autoware_auto_cmake
   * add build_depend of autoware_cmake
   * use autoware_cmake in CMakeLists.txt
   * fix bugs
   * fix cmake lint errors
-* fix: apply fixes for rolling (`#821 <https://github.com/youtalk/autoware.universe/issues/821>`_)
+* fix: apply fixes for rolling (`#821 <https://github.com/autowarefoundation/autoware.universe/issues/821>`_)
   * fix(component_interface_utils): add USE_DEPRECATED_TO_YAML
   * fix(lidar_apollo_instance_segmentation): add USE_TF2_GEOMETRY_MSGS_DEPRECATED_HEADER
   * add rclcpp_components to package.xml
   * ci(pre-commit): autofix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat(default_ad_api): add interface version (`#704 <https://github.com/youtalk/autoware.universe/issues/704>`_)
+* feat(default_ad_api): add interface version (`#704 <https://github.com/autowarefoundation/autoware.universe/issues/704>`_)
   * feat(default_ad_api): add interface version
   * feat(default_ad_api): add http server
   * feat(default_ad_api): add message readme

--- a/common/autoware_geography_utils/CHANGELOG.rst
+++ b/common/autoware_geography_utils/CHANGELOG.rst
@@ -5,7 +5,7 @@ Changelog for package autoware_geography_utils
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* refactor(geography_utils): prefix package and namespace with autoware (`#7790 <https://github.com/youtalk/autoware.universe/issues/7790>`_)
+* refactor(geography_utils): prefix package and namespace with autoware (`#7790 <https://github.com/autowarefoundation/autoware.universe/issues/7790>`_)
   * refactor(geography_utils): prefix package and namespace with autoware
   * move headers to include/autoware/
   ---------

--- a/common/autoware_goal_distance_calculator/CHANGELOG.rst
+++ b/common/autoware_goal_distance_calculator/CHANGELOG.rst
@@ -5,7 +5,7 @@ Changelog for package autoware_goal_distance_calculator
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* refactor(goal_distance_calculator): prefix package and namespace with autoware (`#9172 <https://github.com/youtalk/autoware.universe/issues/9172>`_)
+* refactor(goal_distance_calculator): prefix package and namespace with autoware (`#9172 <https://github.com/autowarefoundation/autoware.universe/issues/9172>`_)
   * refactor(goal_distance_calculator): prefix package and namespace with autoware
   * style(pre-commit): autofix
   ---------

--- a/common/autoware_grid_map_utils/CHANGELOG.rst
+++ b/common/autoware_grid_map_utils/CHANGELOG.rst
@@ -5,11 +5,11 @@ Changelog for package autoware_grid_map_utils
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* refactor(autoware_grid_map_utils): prefix folder structure with autoware/ (`#9170 <https://github.com/youtalk/autoware.universe/issues/9170>`_)
-* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/youtalk/autoware.universe/issues/7594>`_)
-* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/youtalk/autoware.universe/issues/7538>`_)
+* refactor(autoware_grid_map_utils): prefix folder structure with autoware/ (`#9170 <https://github.com/autowarefoundation/autoware.universe/issues/9170>`_)
+* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/autowarefoundation/autoware.universe/issues/7594>`_)
+* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/autowarefoundation/autoware.universe/issues/7538>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* refactor(grid_map_utils): add autoware prefix and namespace (`#7487 <https://github.com/youtalk/autoware.universe/issues/7487>`_)
+* refactor(grid_map_utils): add autoware prefix and namespace (`#7487 <https://github.com/autowarefoundation/autoware.universe/issues/7487>`_)
 * Contributors: Esteve Fernandez, Kosuke Takeuchi, Maxime CLEMENT, Takayuki Murooka, Yutaka Kondo
 
 0.26.0 (2024-04-03)

--- a/common/autoware_interpolation/CHANGELOG.rst
+++ b/common/autoware_interpolation/CHANGELOG.rst
@@ -5,7 +5,7 @@ Changelog for package autoware_interpolation
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* refactor(autoware_interpolation): prefix package and namespace with autoware (`#8088 <https://github.com/youtalk/autoware.universe/issues/8088>`_)
+* refactor(autoware_interpolation): prefix package and namespace with autoware (`#8088 <https://github.com/autowarefoundation/autoware.universe/issues/8088>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
 * Contributors: Esteve Fernandez, Yutaka Kondo
 

--- a/common/autoware_kalman_filter/CHANGELOG.rst
+++ b/common/autoware_kalman_filter/CHANGELOG.rst
@@ -5,7 +5,7 @@ Changelog for package autoware_kalman_filter
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* refactor(kalman_filter): prefix package and namespace with autoware (`#7787 <https://github.com/youtalk/autoware.universe/issues/7787>`_)
+* refactor(kalman_filter): prefix package and namespace with autoware (`#7787 <https://github.com/autowarefoundation/autoware.universe/issues/7787>`_)
   * refactor(kalman_filter): prefix package and namespace with autoware
   * move headers to include/autoware/
   * style(pre-commit): autofix

--- a/common/autoware_motion_utils/CHANGELOG.rst
+++ b/common/autoware_motion_utils/CHANGELOG.rst
@@ -5,8 +5,8 @@ Changelog for package autoware_motion_utils
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* feat(autoware_motion_utils): add spherical linear interpolator (`#9175 <https://github.com/youtalk/autoware.universe/issues/9175>`_)
-* test(motion_utils): add test for path shift (`#9083 <https://github.com/youtalk/autoware.universe/issues/9083>`_)
+* feat(autoware_motion_utils): add spherical linear interpolator (`#9175 <https://github.com/autowarefoundation/autoware.universe/issues/9175>`_)
+* test(motion_utils): add test for path shift (`#9083 <https://github.com/autowarefoundation/autoware.universe/issues/9083>`_)
   * remove unused function
   * mover path shifter utils function to autoware motion utils
   * minor change in license header
@@ -16,31 +16,31 @@ Changelog for package autoware_motion_utils
   * add unit test to all function
   * fix spelling
   ---------
-* refactor(bpp_common, motion_utils): move path shifter util functions to autoware::motion_utils (`#9081 <https://github.com/youtalk/autoware.universe/issues/9081>`_)
+* refactor(bpp_common, motion_utils): move path shifter util functions to autoware::motion_utils (`#9081 <https://github.com/autowarefoundation/autoware.universe/issues/9081>`_)
   * remove unused function
   * mover path shifter utils function to autoware motion utils
   * minor change in license header
   * fix warning message
   * remove header file
   ---------
-* refactor(autoware_motion_utils): refactor interpolator (`#8931 <https://github.com/youtalk/autoware.universe/issues/8931>`_)
+* refactor(autoware_motion_utils): refactor interpolator (`#8931 <https://github.com/autowarefoundation/autoware.universe/issues/8931>`_)
   * refactor interpolator
   * update cmake
   * update
   * rename
   * Update CMakeLists.txt
   ---------
-* refactor(autoware_interpolation): prefix package and namespace with autoware (`#8088 <https://github.com/youtalk/autoware.universe/issues/8088>`_)
+* refactor(autoware_interpolation): prefix package and namespace with autoware (`#8088 <https://github.com/autowarefoundation/autoware.universe/issues/8088>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* feat(autoware_motion_utils): set zero velocity after stop in resample trajectory (`#8768 <https://github.com/youtalk/autoware.universe/issues/8768>`_)
+* feat(autoware_motion_utils): set zero velocity after stop in resample trajectory (`#8768 <https://github.com/autowarefoundation/autoware.universe/issues/8768>`_)
   * feat(autoware_motion_utils): set zero velocity after stop in resample trajectory
   * fix unit test
   * simplify implementation
   * update comment and add test
   ---------
-* fix(autoware_motion_utils): fix unusedFunction (`#8733 <https://github.com/youtalk/autoware.universe/issues/8733>`_)
+* fix(autoware_motion_utils): fix unusedFunction (`#8733 <https://github.com/autowarefoundation/autoware.universe/issues/8733>`_)
   refactor:remove Path/Trajectory length calculation between designated points
-* feat(autoware_motion_utils): add clone function and make the constructor public (`#8688 <https://github.com/youtalk/autoware.universe/issues/8688>`_)
+* feat(autoware_motion_utils): add clone function and make the constructor public (`#8688 <https://github.com/autowarefoundation/autoware.universe/issues/8688>`_)
   * feat(autoware_motion_utils): add interpolator
   * use int32_t instead of int
   * use int32_t instead of int
@@ -55,8 +55,8 @@ Changelog for package autoware_motion_utils
   * fix stairstep
   * make constructor to public
   ---------
-* feat(out_of_lane): redesign to improve accuracy and performance (`#8453 <https://github.com/youtalk/autoware.universe/issues/8453>`_)
-* feat(autoware_motion_utils): add interpolator (`#8517 <https://github.com/youtalk/autoware.universe/issues/8517>`_)
+* feat(out_of_lane): redesign to improve accuracy and performance (`#8453 <https://github.com/autowarefoundation/autoware.universe/issues/8453>`_)
+* feat(autoware_motion_utils): add interpolator (`#8517 <https://github.com/autowarefoundation/autoware.universe/issues/8517>`_)
   * feat(autoware_motion_utils): add interpolator
   * use int32_t instead of int
   * use int32_t instead of int
@@ -68,9 +68,9 @@ Changelog for package autoware_motion_utils
   * remove unused include
   * refactor code
   ---------
-* fix(autoware_motion_utils): fix unusedFunction (`#8519 <https://github.com/youtalk/autoware.universe/issues/8519>`_)
+* fix(autoware_motion_utils): fix unusedFunction (`#8519 <https://github.com/autowarefoundation/autoware.universe/issues/8519>`_)
   fix: unusedFunction
-* fix(start/goal_planner): fix addition of duplicate segments in calcBeforeShiftedArcLength (`#7902 <https://github.com/youtalk/autoware.universe/issues/7902>`_)
+* fix(start/goal_planner): fix addition of duplicate segments in calcBeforeShiftedArcLength (`#7902 <https://github.com/autowarefoundation/autoware.universe/issues/7902>`_)
   * fix(start/goal_planner): fix addition of duplicate segments in calcBeforeShiftedArcLength
   * Update trajectory.hpp
   Co-authored-by: Kyoichi Sugahara <kyoichi.sugahara@tier4.jp>
@@ -78,8 +78,8 @@ Changelog for package autoware_motion_utils
   Co-authored-by: Kyoichi Sugahara <kyoichi.sugahara@tier4.jp>
   ---------
   Co-authored-by: Kyoichi Sugahara <kyoichi.sugahara@tier4.jp>
-* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/youtalk/autoware.universe/issues/7594>`_)
-* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/youtalk/autoware.universe/issues/7539>`_)
+* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/autowarefoundation/autoware.universe/issues/7594>`_)
+* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/autowarefoundation/autoware.universe/issues/7539>`_)
   refactor(motion_utils): add autoware prefix and include dir
 * Contributors: Esteve Fernandez, Go Sakayori, Kosuke Takeuchi, Maxime CLEMENT, Nagi70, Yukinari Hisaki, Yutaka Kondo, kobayu858
 

--- a/common/autoware_object_recognition_utils/CHANGELOG.rst
+++ b/common/autoware_object_recognition_utils/CHANGELOG.rst
@@ -5,7 +5,7 @@ Changelog for package autoware_object_recognition_utils
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* refactor(object_recognition_utils): add autoware prefix to object_recognition_utils (`#8946 <https://github.com/youtalk/autoware.universe/issues/8946>`_)
+* refactor(object_recognition_utils): add autoware prefix to object_recognition_utils (`#8946 <https://github.com/autowarefoundation/autoware.universe/issues/8946>`_)
 * Contributors: Esteve Fernandez, Yutaka Kondo
 
 0.26.0 (2024-04-03)

--- a/common/autoware_osqp_interface/CHANGELOG.rst
+++ b/common/autoware_osqp_interface/CHANGELOG.rst
@@ -5,7 +5,7 @@ Changelog for package autoware_osqp_interface
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* refactor(osqp_interface): added autoware prefix to osqp_interface (`#8958 <https://github.com/youtalk/autoware.universe/issues/8958>`_)
+* refactor(osqp_interface): added autoware prefix to osqp_interface (`#8958 <https://github.com/autowarefoundation/autoware.universe/issues/8958>`_)
 * Contributors: Esteve Fernandez, Yutaka Kondo
 
 0.26.0 (2024-04-03)

--- a/common/autoware_overlay_rviz_plugin/autoware_mission_details_overlay_rviz_plugin/CHANGELOG.rst
+++ b/common/autoware_overlay_rviz_plugin/autoware_mission_details_overlay_rviz_plugin/CHANGELOG.rst
@@ -5,9 +5,9 @@ Changelog for package autoware_mission_details_overlay_rviz_plugin
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* feat: add color customization to gear speed mission speed limit and traffic displays (`#8142 <https://github.com/youtalk/autoware.universe/issues/8142>`_)
+* feat: add color customization to gear speed mission speed limit and traffic displays (`#8142 <https://github.com/autowarefoundation/autoware.universe/issues/8142>`_)
   feat: Add color customization to gear, speed, mission,speedlimit and traffic displays
-* feat: add autoware_remaining_distance_time_calculator and overlay (`#6855 <https://github.com/youtalk/autoware.universe/issues/6855>`_)
+* feat: add autoware_remaining_distance_time_calculator and overlay (`#6855 <https://github.com/autowarefoundation/autoware.universe/issues/6855>`_)
 * Contributors: Ahmed Ebrahim, Khalil Selyan, Yutaka Kondo
 
 0.26.0 (2024-04-03)

--- a/common/autoware_overlay_rviz_plugin/autoware_overlay_rviz_plugin/CHANGELOG.rst
+++ b/common/autoware_overlay_rviz_plugin/autoware_overlay_rviz_plugin/CHANGELOG.rst
@@ -5,16 +5,16 @@ Changelog for package autoware_overlay_rviz_plugin
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* fix(speed_display): always show speed positive and depend on gear for negatives (`#8957 <https://github.com/youtalk/autoware.universe/issues/8957>`_)
-* style: update state panel plugin (`#8846 <https://github.com/youtalk/autoware.universe/issues/8846>`_)
-* feat: add color customization to gear speed mission speed limit and traffic displays (`#8142 <https://github.com/youtalk/autoware.universe/issues/8142>`_)
+* fix(speed_display): always show speed positive and depend on gear for negatives (`#8957 <https://github.com/autowarefoundation/autoware.universe/issues/8957>`_)
+* style: update state panel plugin (`#8846 <https://github.com/autowarefoundation/autoware.universe/issues/8846>`_)
+* feat: add color customization to gear speed mission speed limit and traffic displays (`#8142 <https://github.com/autowarefoundation/autoware.universe/issues/8142>`_)
   feat: Add color customization to gear, speed, mission,speedlimit and traffic displays
-* fix(autoware_overlay_rviz_plugin): topic type of traffic light (`#8098 <https://github.com/youtalk/autoware.universe/issues/8098>`_)
+* fix(autoware_overlay_rviz_plugin): topic type of traffic light (`#8098 <https://github.com/autowarefoundation/autoware.universe/issues/8098>`_)
   * fix(autoware_overlay_rviz_plugin): topic type of traffic light
   * style(pre-commit): autofix
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat: add handle angle scale property to signal display (`#7774 <https://github.com/youtalk/autoware.universe/issues/7774>`_)
+* feat: add handle angle scale property to signal display (`#7774 <https://github.com/autowarefoundation/autoware.universe/issues/7774>`_)
   * feat: add handle angle scale property to signal display
   * fix: set default steering angle to 0.0° when not received
   * fix: set default steering angle to N/A when not received and check for msg_ptr instead of float value
@@ -22,17 +22,17 @@ Changelog for package autoware_overlay_rviz_plugin
   * chore: update steering wheel display to center the steering angle text
   * chore: align steering angle text in both negative and positive cases
   ---------
-* feat!: replace autoware_auto_msgs with autoware_msgs for common modules (`#7239 <https://github.com/youtalk/autoware.universe/issues/7239>`_)
+* feat!: replace autoware_auto_msgs with autoware_msgs for common modules (`#7239 <https://github.com/autowarefoundation/autoware.universe/issues/7239>`_)
   Co-authored-by: Cynthia Liu <cynthia.liu@autocore.ai>
   Co-authored-by: NorahXiong <norah.xiong@autocore.ai>
   Co-authored-by: beginningfan <beginning.fan@autocore.ai>
-* fix(autoware_overlay_rviz_plugin): fix subs and cleanup (`#6978 <https://github.com/youtalk/autoware.universe/issues/6978>`_)
-* feat: update rviz2 overlay (`#6883 <https://github.com/youtalk/autoware.universe/issues/6883>`_)
-* feat(autoware_overlay_rviz_plugin): get the current traffic light (`#6899 <https://github.com/youtalk/autoware.universe/issues/6899>`_)
+* fix(autoware_overlay_rviz_plugin): fix subs and cleanup (`#6978 <https://github.com/autowarefoundation/autoware.universe/issues/6978>`_)
+* feat: update rviz2 overlay (`#6883 <https://github.com/autowarefoundation/autoware.universe/issues/6883>`_)
+* feat(autoware_overlay_rviz_plugin): get the current traffic light (`#6899 <https://github.com/autowarefoundation/autoware.universe/issues/6899>`_)
 * Contributors: Khalil Selyan, M. Fatih Cırıt, Maxime CLEMENT, Ryohsuke Mitsudome, Tomohito ANDO, Yutaka Kondo
 
 0.26.0 (2024-04-03)
 -------------------
-* build(autoware_overlay_rviz_plugin): add missing ament_cmake_auto dependency (`#6519 <https://github.com/youtalk/autoware.universe/issues/6519>`_)
-* feat: update vehicle overlay plugin (`#6323 <https://github.com/youtalk/autoware.universe/issues/6323>`_)
+* build(autoware_overlay_rviz_plugin): add missing ament_cmake_auto dependency (`#6519 <https://github.com/autowarefoundation/autoware.universe/issues/6519>`_)
+* feat: update vehicle overlay plugin (`#6323 <https://github.com/autowarefoundation/autoware.universe/issues/6323>`_)
 * Contributors: Esteve Fernandez, Khalil Selyan

--- a/common/autoware_path_distance_calculator/CHANGELOG.rst
+++ b/common/autoware_path_distance_calculator/CHANGELOG.rst
@@ -5,8 +5,8 @@ Changelog for package autoware_path_distance_calculator
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* fix: add autoware prefix (`#8385 <https://github.com/youtalk/autoware.universe/issues/8385>`_)
-* refactor(autoware_path_distance_calculator): prefix package and namespace with autoware (`#8085 <https://github.com/youtalk/autoware.universe/issues/8085>`_)
+* fix: add autoware prefix (`#8385 <https://github.com/autowarefoundation/autoware.universe/issues/8385>`_)
+* refactor(autoware_path_distance_calculator): prefix package and namespace with autoware (`#8085 <https://github.com/autowarefoundation/autoware.universe/issues/8085>`_)
 * Contributors: Esteve Fernandez, Kotaro Uetake, Yutaka Kondo
 
 0.26.0 (2024-04-03)

--- a/common/autoware_perception_rviz_plugin/CHANGELOG.rst
+++ b/common/autoware_perception_rviz_plugin/CHANGELOG.rst
@@ -5,35 +5,35 @@ Changelog for package autoware_perception_rviz_plugin
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* fix(autoware_perception_rviz_plugin): fix unusedFunction (`#8784 <https://github.com/youtalk/autoware.universe/issues/8784>`_)
+* fix(autoware_perception_rviz_plugin): fix unusedFunction (`#8784 <https://github.com/autowarefoundation/autoware.universe/issues/8784>`_)
   fix: unusedFunction
-* feat(autoware_perception_rviz_plugin): rviz predicted path mark as triangle (`#8536 <https://github.com/youtalk/autoware.universe/issues/8536>`_)
+* feat(autoware_perception_rviz_plugin): rviz predicted path mark as triangle (`#8536 <https://github.com/autowarefoundation/autoware.universe/issues/8536>`_)
   * refactor: predicted path mark replace to triangle
   * chore: clean up
   ---------
-* fix(autoware_perception_rviz_plugin): fix passedByValue (`#8192 <https://github.com/youtalk/autoware.universe/issues/8192>`_)
+* fix(autoware_perception_rviz_plugin): fix passedByValue (`#8192 <https://github.com/autowarefoundation/autoware.universe/issues/8192>`_)
   * fix: passedByValue
   * fix:passedByValue
   ---------
   Co-authored-by: kobayu858 <yutaro.kobayashi@tier4.jp>
-* chore(autoware_perception_rviz_plugin): delete maintainer (`#7900 <https://github.com/youtalk/autoware.universe/issues/7900>`_)
-* fix(autoware_perception_rviz_plugin): fix duplicateBranch warnings (`#7695 <https://github.com/youtalk/autoware.universe/issues/7695>`_)
+* chore(autoware_perception_rviz_plugin): delete maintainer (`#7900 <https://github.com/autowarefoundation/autoware.universe/issues/7900>`_)
+* fix(autoware_perception_rviz_plugin): fix duplicateBranch warnings (`#7695 <https://github.com/autowarefoundation/autoware.universe/issues/7695>`_)
   * fix(autoware_perception_rviz_plugin): fix duplicateBranch warnings
   * style(pre-commit): autofix
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat!: replace autoware_auto_msgs with autoware_msgs for common modules (`#7239 <https://github.com/youtalk/autoware.universe/issues/7239>`_)
+* feat!: replace autoware_auto_msgs with autoware_msgs for common modules (`#7239 <https://github.com/autowarefoundation/autoware.universe/issues/7239>`_)
   Co-authored-by: Cynthia Liu <cynthia.liu@autocore.ai>
   Co-authored-by: NorahXiong <norah.xiong@autocore.ai>
   Co-authored-by: beginningfan <beginning.fan@autocore.ai>
-* feat(autoware_auto_perception_rviz_plugin)!: rename package to autoware_perception_rviz_plugin (`#7221 <https://github.com/youtalk/autoware.universe/issues/7221>`_)
+* feat(autoware_auto_perception_rviz_plugin)!: rename package to autoware_perception_rviz_plugin (`#7221 <https://github.com/autowarefoundation/autoware.universe/issues/7221>`_)
   feat(autoware_auto_perception_rviz_plugin): rename package to autoware_perception_rviz_plugin
   Co-authored-by: Yukihiro Saito <yukky.saito@gmail.com>
 * Contributors: Hayate TOBA, Nagi70, Ryohsuke Mitsudome, Ryuta Kambe, Satoshi Tanaka, Taekjin LEE, Yutaka Kondo
 
 0.26.0 (2024-04-03)
 -------------------
-* feat: add rviz plugin packages (`#3 <https://github.com/youtalk/autoware.universe/issues/3>`_)
+* feat: add rviz plugin packages (`#3 <https://github.com/autowarefoundation/autoware.universe/issues/3>`_)
   * release v0.4.0
   * remove ROS1 packages temporarily
   * add sample ros2 packages
@@ -41,55 +41,55 @@ Changelog for package autoware_perception_rviz_plugin
   * Revert "remove ROS1 packages temporarily"
   This reverts commit 7eacbcea261a65d6c305c7b0d069591ca3a2ee3a.
   * add COLCON_IGNORE to ros1 packages
-  * Port autoware-perception-rviz-plugin (`#100 <https://github.com/youtalk/autoware.universe/issues/100>`_)
+  * Port autoware-perception-rviz-plugin (`#100 <https://github.com/autowarefoundation/autoware.universe/issues/100>`_)
   * Port to ROS2
   * Update namespaces
-  * Port autoware-planning-rviz-plugin (`#103 <https://github.com/youtalk/autoware.universe/issues/103>`_)
+  * Port autoware-planning-rviz-plugin (`#103 <https://github.com/autowarefoundation/autoware.universe/issues/103>`_)
   * Port to ROS2
   * Update deprecated
   * Update namespaces
-  * Adjust copyright notice on 532 out of 699 source files (`#143 <https://github.com/youtalk/autoware.universe/issues/143>`_)
-  * Use quotes for includes where appropriate (`#144 <https://github.com/youtalk/autoware.universe/issues/144>`_)
+  * Adjust copyright notice on 532 out of 699 source files (`#143 <https://github.com/autowarefoundation/autoware.universe/issues/143>`_)
+  * Use quotes for includes where appropriate (`#144 <https://github.com/autowarefoundation/autoware.universe/issues/144>`_)
   * Use quotes for includes where appropriate
   * Fix lint tests
   * Make tests pass hopefully
-  * Run uncrustify on the entire Pilot.Auto codebase (`#151 <https://github.com/youtalk/autoware.universe/issues/151>`_)
+  * Run uncrustify on the entire Pilot.Auto codebase (`#151 <https://github.com/autowarefoundation/autoware.universe/issues/151>`_)
   * Run uncrustify on the entire Pilot.Auto codebase
   * Exclude open PRs
-  * Fix rviz plugins (`#175 <https://github.com/youtalk/autoware.universe/issues/175>`_)
+  * Fix rviz plugins (`#175 <https://github.com/autowarefoundation/autoware.universe/issues/175>`_)
   * [autoware_perception_rviz_plugin] make library to shared and fix library name in plugin_description.xml
   * [autoware_planning_rviz_plugin] make library to shared and fix library name in plugin_description.xml
-  * Port autoware vehicle rviz plugin (`#111 <https://github.com/youtalk/autoware.universe/issues/111>`_)
+  * Port autoware vehicle rviz plugin (`#111 <https://github.com/autowarefoundation/autoware.universe/issues/111>`_)
   * Port to ROS2
   * Amend buildtool
   * Fix license
   * Fix
   * Fixes
-  * adding linters to autoware_planning_rviz_plugin (`#224 <https://github.com/youtalk/autoware.universe/issues/224>`_)
-  * adding linters to autoware_perception_rviz_plugin (`#225 <https://github.com/youtalk/autoware.universe/issues/225>`_)
-  * [autoware_perception_rviz_plugin] make plugin library SHARED (`#236 <https://github.com/youtalk/autoware.universe/issues/236>`_)
-  * Fix bugs in autoware vehicle rviz plugin (`#246 <https://github.com/youtalk/autoware.universe/issues/246>`_)
-  * Ros2 v0.8.0 autoware vehicle rviz plugin (`#333 <https://github.com/youtalk/autoware.universe/issues/333>`_)
+  * adding linters to autoware_planning_rviz_plugin (`#224 <https://github.com/autowarefoundation/autoware.universe/issues/224>`_)
+  * adding linters to autoware_perception_rviz_plugin (`#225 <https://github.com/autowarefoundation/autoware.universe/issues/225>`_)
+  * [autoware_perception_rviz_plugin] make plugin library SHARED (`#236 <https://github.com/autowarefoundation/autoware.universe/issues/236>`_)
+  * Fix bugs in autoware vehicle rviz plugin (`#246 <https://github.com/autowarefoundation/autoware.universe/issues/246>`_)
+  * Ros2 v0.8.0 autoware vehicle rviz plugin (`#333 <https://github.com/autowarefoundation/autoware.universe/issues/333>`_)
   * add test depend
-  * fix console meter size (`#909 <https://github.com/youtalk/autoware.universe/issues/909>`_)
-  * update to change font scale (`#910 <https://github.com/youtalk/autoware.universe/issues/910>`_)
-  * Fix typos in common modules (`#914 <https://github.com/youtalk/autoware.universe/issues/914>`_)
+  * fix console meter size (`#909 <https://github.com/autowarefoundation/autoware.universe/issues/909>`_)
+  * update to change font scale (`#910 <https://github.com/autowarefoundation/autoware.universe/issues/910>`_)
+  * Fix typos in common modules (`#914 <https://github.com/autowarefoundation/autoware.universe/issues/914>`_)
   * fix typos in common modules
   * minor fix (lowercasing)
   * revert changes in PathPoint.msg
-  * Fix memory leaks in turn signal plugin (`#932 <https://github.com/youtalk/autoware.universe/issues/932>`_)
+  * Fix memory leaks in turn signal plugin (`#932 <https://github.com/autowarefoundation/autoware.universe/issues/932>`_)
   * fix memory leak (QPointF)
   * convert raw pointers to smart pointers
-  * update handle image (`#948 <https://github.com/youtalk/autoware.universe/issues/948>`_)
-  * reduce calc cost rviz plugin (`#947 <https://github.com/youtalk/autoware.universe/issues/947>`_)
+  * update handle image (`#948 <https://github.com/autowarefoundation/autoware.universe/issues/948>`_)
+  * reduce calc cost rviz plugin (`#947 <https://github.com/autowarefoundation/autoware.universe/issues/947>`_)
   * reduce calc cost
   * cosmetic change
   * cosmetic change
   * Use CMAKE_CXX_STANDARD to enable C++14 for Qt
   Co-authored-by: Kenji Miyake <kenji.miyake@tier4.jp>
-  * change font size independency desplay (`#946 <https://github.com/youtalk/autoware.universe/issues/946>`_)
-  * bug fix (wrong unit conversion) (`#956 <https://github.com/youtalk/autoware.universe/issues/956>`_)
-  * Refactor autoware_vehicle_rviz_plugin (`#967 <https://github.com/youtalk/autoware.universe/issues/967>`_)
+  * change font size independency desplay (`#946 <https://github.com/autowarefoundation/autoware.universe/issues/946>`_)
+  * bug fix (wrong unit conversion) (`#956 <https://github.com/autowarefoundation/autoware.universe/issues/956>`_)
+  * Refactor autoware_vehicle_rviz_plugin (`#967 <https://github.com/autowarefoundation/autoware.universe/issues/967>`_)
   * Refactor autoware_vehicle_rviz_plugin
   - change smart pointers to raw pointers according to Qt convention
   - remove unused headers
@@ -97,7 +97,7 @@ Changelog for package autoware_perception_rviz_plugin
   - cosmetic changes according to Google C++ Style Guide
   - use the range-based for statement
   - replace push_back with emplace_back
-  See also: `#932 <https://github.com/youtalk/autoware.universe/issues/932>`_, `#964 <https://github.com/youtalk/autoware.universe/issues/964>`_
+  See also: `#932 <https://github.com/autowarefoundation/autoware.universe/issues/932>`_, `#964 <https://github.com/autowarefoundation/autoware.universe/issues/964>`_
   * Apply clang-format
   * Change a variable name to clarify: history -> histories
   * add build testing
@@ -107,28 +107,28 @@ Changelog for package autoware_perception_rviz_plugin
   Co-authored-by: Yukihiro Saito <yukky.saito@gmail.com>
   Co-authored-by: Kazuki Miyahara <kmiya@outlook.com>
   Co-authored-by: Kenji Miyake <kenji.miyake@tier4.jp>
-  * Ros2 v0.8.0 autoware perception rviz plugin (`#334 <https://github.com/youtalk/autoware.universe/issues/334>`_)
-  * Fix typos in common modules (`#914 <https://github.com/youtalk/autoware.universe/issues/914>`_)
+  * Ros2 v0.8.0 autoware perception rviz plugin (`#334 <https://github.com/autowarefoundation/autoware.universe/issues/334>`_)
+  * Fix typos in common modules (`#914 <https://github.com/autowarefoundation/autoware.universe/issues/914>`_)
   * fix typos in common modules
   * minor fix (lowercasing)
   * revert changes in PathPoint.msg
   * ament_cmake_cppcheck  -> ament_lint_common
   * apply lint
   Co-authored-by: Kazuki Miyahara <kmiya@outlook.com>
-  * Ros2 v0.8.0 autoware planning rviz plugin (`#336 <https://github.com/youtalk/autoware.universe/issues/336>`_)
-  * add speed limit visualizer (`#908 <https://github.com/youtalk/autoware.universe/issues/908>`_)
+  * Ros2 v0.8.0 autoware planning rviz plugin (`#336 <https://github.com/autowarefoundation/autoware.universe/issues/336>`_)
+  * add speed limit visualizer (`#908 <https://github.com/autowarefoundation/autoware.universe/issues/908>`_)
   * add speed limit visualizer
   * :put_litter_in_its_place:
   * add max velocity output
   * fix bug
   * update visualizer
   Co-authored-by: tomoya.kimura <tomoya.kimura@tier4.jp>
-  * change font size independency desplay (`#946 <https://github.com/youtalk/autoware.universe/issues/946>`_)
+  * change font size independency desplay (`#946 <https://github.com/autowarefoundation/autoware.universe/issues/946>`_)
   * ament_cmake_cppcheck -> ament_lint_common
   * apply lint
   * change topic type
   Co-authored-by: Yukihiro Saito <yukky.saito@gmail.com>
-  * Ros2 v0.8.0 remove std msgs awapi (`#348 <https://github.com/youtalk/autoware.universe/issues/348>`_)
+  * Ros2 v0.8.0 remove std msgs awapi (`#348 <https://github.com/autowarefoundation/autoware.universe/issues/348>`_)
   * [autoware_vehicle_msgs] add BatteryStatus msg
   * [autoware_planning_msgs] add ExpandStopRange and StopSpeedExceeded messages
   * [autoware_api_msgs] add DoorControlCommand, StopCommand, and VelocityLimit messages
@@ -137,24 +137,24 @@ Changelog for package autoware_perception_rviz_plugin
   * fix build failure
   * fix test failures
   * address review commends
-  * Ros2 v0.9.0 pose history (`#387 <https://github.com/youtalk/autoware.universe/issues/387>`_)
+  * Ros2 v0.9.0 pose history (`#387 <https://github.com/autowarefoundation/autoware.universe/issues/387>`_)
   * Port pose history to ROS2
-  * pose_history (`#1169 <https://github.com/youtalk/autoware.universe/issues/1169>`_)
+  * pose_history (`#1169 <https://github.com/autowarefoundation/autoware.universe/issues/1169>`_)
   * change pkg name
   * add alpha
   Co-authored-by: Yukihiro Saito <yukky.saito@gmail.com>
-  * fix max velocity visualization (`#397 <https://github.com/youtalk/autoware.universe/issues/397>`_)
+  * fix max velocity visualization (`#397 <https://github.com/autowarefoundation/autoware.universe/issues/397>`_)
   * fix max velocity vis
   * apply lint-format
-  * Ros2 rtd plugin (`#444 <https://github.com/youtalk/autoware.universe/issues/444>`_)
+  * Ros2 rtd plugin (`#444 <https://github.com/autowarefoundation/autoware.universe/issues/444>`_)
   * Use RTD instead of MFD
-  * Sync public repo (`#1228 <https://github.com/youtalk/autoware.universe/issues/1228>`_)
-  * [simple_planning_simulator] add readme (`#424 <https://github.com/youtalk/autoware.universe/issues/424>`_)
+  * Sync public repo (`#1228 <https://github.com/autowarefoundation/autoware.universe/issues/1228>`_)
+  * [simple_planning_simulator] add readme (`#424 <https://github.com/autowarefoundation/autoware.universe/issues/424>`_)
   * add readme of simple_planning_simulator
   * Update simulator/simple_planning_simulator/README.md
-  * set transit_margin_time to intersect. planner (`#460 <https://github.com/youtalk/autoware.universe/issues/460>`_)
-  * Fix pose2twist (`#462 <https://github.com/youtalk/autoware.universe/issues/462>`_)
-  * Ros2 vehicle info param server (`#447 <https://github.com/youtalk/autoware.universe/issues/447>`_)
+  * set transit_margin_time to intersect. planner (`#460 <https://github.com/autowarefoundation/autoware.universe/issues/460>`_)
+  * Fix pose2twist (`#462 <https://github.com/autowarefoundation/autoware.universe/issues/462>`_)
+  * Ros2 vehicle info param server (`#447 <https://github.com/autowarefoundation/autoware.universe/issues/447>`_)
   * add vehicle_info_param_server
   * update vehicle info
   * apply format
@@ -162,7 +162,7 @@ Changelog for package autoware_perception_rviz_plugin
   * skip unnecessary search
   * delete vehicle param file
   * fix bug
-  * Ros2 fix topic name part2 (`#425 <https://github.com/youtalk/autoware.universe/issues/425>`_)
+  * Ros2 fix topic name part2 (`#425 <https://github.com/autowarefoundation/autoware.universe/issues/425>`_)
   * Fix topic name of traffic_light_classifier
   * Fix topic name of traffic_light_visualization
   * Fix topic name of traffic_light_ssd_fine_detector
@@ -172,19 +172,19 @@ Changelog for package autoware_perception_rviz_plugin
   * Fix lint traffic_light_classifier
   * Fix lint traffic_light_classifier
   * Fix lint traffic_light_ssd_fine_detector
-  * Fix issues in hdd_reader (`#466 <https://github.com/youtalk/autoware.universe/issues/466>`_)
+  * Fix issues in hdd_reader (`#466 <https://github.com/autowarefoundation/autoware.universe/issues/466>`_)
   * Fix some issues detected by Coverity Scan and Clang-Tidy
   * Update launch command
   * Add more `close(new_sock)`
   * Simplify the definitions of struct
-  * fix: re-construct laneletMapLayer for reindex RTree (`#463 <https://github.com/youtalk/autoware.universe/issues/463>`_)
-  * Rviz overlay render fix (`#461 <https://github.com/youtalk/autoware.universe/issues/461>`_)
+  * fix: re-construct laneletMapLayer for reindex RTree (`#463 <https://github.com/autowarefoundation/autoware.universe/issues/463>`_)
+  * Rviz overlay render fix (`#461 <https://github.com/autowarefoundation/autoware.universe/issues/461>`_)
   * Moved painiting in SteeringAngle plugin to update()
   * super class now back to MFD
   * uncrustified
   * acquire data in mutex
   * back to RTD as superclass
-  * Rviz overlay render in update (`#465 <https://github.com/youtalk/autoware.universe/issues/465>`_)
+  * Rviz overlay render in update (`#465 <https://github.com/autowarefoundation/autoware.universe/issues/465>`_)
   * Moved painiting in SteeringAngle plugin to update()
   * super class now back to MFD
   * uncrustified
@@ -198,29 +198,29 @@ Changelog for package autoware_perception_rviz_plugin
   Co-authored-by: Kazuki Miyahara <kmiya@outlook.com>
   Co-authored-by: Makoto Tokunaga <vios-fish@users.noreply.github.com>
   Co-authored-by: Adam Dąbrowski <adam.dabrowski@robotec.ai>
-  * Unify Apache-2.0 license name (`#1242 <https://github.com/youtalk/autoware.universe/issues/1242>`_)
-  * Porting trajectory rviz plugin (`#1295 <https://github.com/youtalk/autoware.universe/issues/1295>`_)
-  * update trajectory rviz plugin to show velocity (`#1257 <https://github.com/youtalk/autoware.universe/issues/1257>`_)
+  * Unify Apache-2.0 license name (`#1242 <https://github.com/autowarefoundation/autoware.universe/issues/1242>`_)
+  * Porting trajectory rviz plugin (`#1295 <https://github.com/autowarefoundation/autoware.universe/issues/1295>`_)
+  * update trajectory rviz plugin to show velocity (`#1257 <https://github.com/autowarefoundation/autoware.universe/issues/1257>`_)
   * update trajectory rviz plugin to show velocity
   * use size_t instead of int to remove warning during compiling
   * not show velocity on rviz unless check button is enabled
-  * modify visibility of velocity (`#1258 <https://github.com/youtalk/autoware.universe/issues/1258>`_)
+  * modify visibility of velocity (`#1258 <https://github.com/autowarefoundation/autoware.universe/issues/1258>`_)
   * fix plugin
   * add dependency
   Co-authored-by: Takayuki Murooka <takayuki5168@gmail.com>
   Co-authored-by: tomoya.kimura <tomoya.kimura@tier4.jp>
-  * Fix msgs (`#1379 <https://github.com/youtalk/autoware.universe/issues/1379>`_)
+  * Fix msgs (`#1379 <https://github.com/autowarefoundation/autoware.universe/issues/1379>`_)
   * Fix msgs
   * [autoware_planning_rviz_plugin]: Fix lint
   Co-authored-by: wep21 <border_goldenmarket@yahoo.co.jp>
-  * Fix topic name of autoware_perception_rviz_plugin (`#1277 <https://github.com/youtalk/autoware.universe/issues/1277>`_) (`#1479 <https://github.com/youtalk/autoware.universe/issues/1479>`_)
+  * Fix topic name of autoware_perception_rviz_plugin (`#1277 <https://github.com/autowarefoundation/autoware.universe/issues/1277>`_) (`#1479 <https://github.com/autowarefoundation/autoware.universe/issues/1479>`_)
   Co-authored-by: Kenji Miyake <31987104+kenji-miyake@users.noreply.github.com>
-  * Porting polar grid to ros2 (`#1507 <https://github.com/youtalk/autoware.universe/issues/1507>`_)
-  * Add dummy unknown publisher (`#1470 <https://github.com/youtalk/autoware.universe/issues/1470>`_)
+  * Porting polar grid to ros2 (`#1507 <https://github.com/autowarefoundation/autoware.universe/issues/1507>`_)
+  * Add dummy unknown publisher (`#1470 <https://github.com/autowarefoundation/autoware.universe/issues/1470>`_)
   * Add dummy unknown publisher
   * Fix lint
   Co-authored-by: Kenji Miyake <kenji.miyake@tier4.jp>
-  * Add pre-commit (`#1560 <https://github.com/youtalk/autoware.universe/issues/1560>`_)
+  * Add pre-commit (`#1560 <https://github.com/autowarefoundation/autoware.universe/issues/1560>`_)
   * add pre-commit
   * add pre-commit-config
   * add additional settings for private repository
@@ -240,18 +240,18 @@ Changelog for package autoware_perception_rviz_plugin
   Co-authored-by: Kazuki Miyahara <kmiya@outlook.com>
   Co-authored-by: pre-commit <pre-commit@example.com>
   Co-authored-by: Kenji Miyake <31987104+kenji-miyake@users.noreply.github.com>
-  * Fix -Wunused-parameter (`#1836 <https://github.com/youtalk/autoware.universe/issues/1836>`_)
+  * Fix -Wunused-parameter (`#1836 <https://github.com/autowarefoundation/autoware.universe/issues/1836>`_)
   * Fix -Wunused-parameter
   * Fix mistake
   * fix spell
   * Fix lint issues
   * Ignore flake8 warnings
   Co-authored-by: Hiroki OTA <hiroki.ota@tier4.jp>
-  * suppress warnings for common packages (`#1891 <https://github.com/youtalk/autoware.universe/issues/1891>`_)
+  * suppress warnings for common packages (`#1891 <https://github.com/autowarefoundation/autoware.universe/issues/1891>`_)
   * add maybe unused
   * add Werror
   * fix for uncrustify
-  * add sort-package-xml hook in pre-commit (`#1881 <https://github.com/youtalk/autoware.universe/issues/1881>`_)
+  * add sort-package-xml hook in pre-commit (`#1881 <https://github.com/autowarefoundation/autoware.universe/issues/1881>`_)
   * add sort xml hook in pre-commit
   * change retval to exit_status
   * rename
@@ -265,7 +265,7 @@ Changelog for package autoware_perception_rviz_plugin
   * move prettier-xml to pre-commit-hooks-ros
   * update version for bug-fix
   * apply pre-commit
-  * add autoware_state_rviz_plugin (`#2160 <https://github.com/youtalk/autoware.universe/issues/2160>`_)
+  * add autoware_state_rviz_plugin (`#2160 <https://github.com/autowarefoundation/autoware.universe/issues/2160>`_)
   * initial commit
   * fix
   * use raw pointer
@@ -274,11 +274,11 @@ Changelog for package autoware_perception_rviz_plugin
   * fix style
   * fix style
   * fix header arrangement
-  * add gear check and prefix label (`#2173 <https://github.com/youtalk/autoware.universe/issues/2173>`_)
+  * add gear check and prefix label (`#2173 <https://github.com/autowarefoundation/autoware.universe/issues/2173>`_)
   * add gear and prefix label
   * add subscription
   * fix for cpplint
-  * add engage button and status (`#2257 <https://github.com/youtalk/autoware.universe/issues/2257>`_)
+  * add engage button and status (`#2257 <https://github.com/autowarefoundation/autoware.universe/issues/2257>`_)
   * fix style
   * add engage button and engage status
   * use api
@@ -288,14 +288,14 @@ Changelog for package autoware_perception_rviz_plugin
   * fix for cpplint
   * fix for cpplint
   * fix coding style
-  * Add datetime panel (`#2275 <https://github.com/youtalk/autoware.universe/issues/2275>`_)
+  * Add datetime panel (`#2275 <https://github.com/autowarefoundation/autoware.universe/issues/2275>`_)
   * Add datetime panel
-  * Fix/ros time (`#2276 <https://github.com/youtalk/autoware.universe/issues/2276>`_)
+  * Fix/ros time (`#2276 <https://github.com/autowarefoundation/autoware.universe/issues/2276>`_)
   * Fix ros time
   * Add icon
   Co-authored-by: Daisuke Nishimatsu <42202095+wep21@users.noreply.github.com>
-  * add footprint in trajectory msg of rviz plugin (`#1553 <https://github.com/youtalk/autoware.universe/issues/1553>`_) (`#1684 <https://github.com/youtalk/autoware.universe/issues/1684>`_)
-  * add footprint in trajectory msg of rviz plugin (`#1553 <https://github.com/youtalk/autoware.universe/issues/1553>`_)
+  * add footprint in trajectory msg of rviz plugin (`#1553 <https://github.com/autowarefoundation/autoware.universe/issues/1553>`_) (`#1684 <https://github.com/autowarefoundation/autoware.universe/issues/1684>`_)
+  * add footprint in trajectory msg of rviz plugin (`#1553 <https://github.com/autowarefoundation/autoware.universe/issues/1553>`_)
   * add footprint in trajectory msg of rviz plugin
   * update
   * trajectory -> footprint
@@ -306,11 +306,11 @@ Changelog for package autoware_perception_rviz_plugin
   * update
   * Add min value
   Co-authored-by: Takayuki Murooka <takayuki5168@gmail.com>
-  * Feature/trajectory point rviz plugin (`#2123 <https://github.com/youtalk/autoware.universe/issues/2123>`_)
+  * Feature/trajectory point rviz plugin (`#2123 <https://github.com/autowarefoundation/autoware.universe/issues/2123>`_)
   * add trajectory point
   * set trajectory point view false by default
-  * add pull over/out module (`#2147 <https://github.com/youtalk/autoware.universe/issues/2147>`_)
-  * Change formatter to clang-format and black (`#2332 <https://github.com/youtalk/autoware.universe/issues/2332>`_)
+  * add pull over/out module (`#2147 <https://github.com/autowarefoundation/autoware.universe/issues/2147>`_)
+  * Change formatter to clang-format and black (`#2332 <https://github.com/autowarefoundation/autoware.universe/issues/2332>`_)
   * Revert "Temporarily comment out pre-commit hooks"
   This reverts commit 748e9cdb145ce12f8b520bcbd97f5ff899fc28a3.
   * Replace ament_lint_common with autoware_lint_common
@@ -322,27 +322,27 @@ Changelog for package autoware_perception_rviz_plugin
   * Fix include double quotes to angle brackets
   * Apply clang-format
   * Fix build errors
-  * remove unused depends (`#496 <https://github.com/youtalk/autoware.universe/issues/496>`_)
-  * Add COLCON_IGNORE (`#500 <https://github.com/youtalk/autoware.universe/issues/500>`_)
-  * port planning rviz plugins (`#492 <https://github.com/youtalk/autoware.universe/issues/492>`_)
+  * remove unused depends (`#496 <https://github.com/autowarefoundation/autoware.universe/issues/496>`_)
+  * Add COLCON_IGNORE (`#500 <https://github.com/autowarefoundation/autoware.universe/issues/500>`_)
+  * port planning rviz plugins (`#492 <https://github.com/autowarefoundation/autoware.universe/issues/492>`_)
   * port planning rviz plugins
   * remove COLCON_IGNORE
   Co-authored-by: Takayuki Murooka <takayuki.murooka@tier4.jp>
-  * port autoware vehicle rviz plugin (`#542 <https://github.com/youtalk/autoware.universe/issues/542>`_)
-  * [ polar grid ] add readme polar grid remove colcon ignore (`#559 <https://github.com/youtalk/autoware.universe/issues/559>`_)
+  * port autoware vehicle rviz plugin (`#542 <https://github.com/autowarefoundation/autoware.universe/issues/542>`_)
+  * [ polar grid ] add readme polar grid remove colcon ignore (`#559 <https://github.com/autowarefoundation/autoware.universe/issues/559>`_)
   * remove ignore
   * add readme
   * fix invalid link
-  * port autoware_state_rviz_plugin (`#563 <https://github.com/youtalk/autoware.universe/issues/563>`_)
-  * remove COLCON_IGNORE form rviz plugins (`#544 <https://github.com/youtalk/autoware.universe/issues/544>`_)
-  * port autoware_perception_rviz_plugin (`#581 <https://github.com/youtalk/autoware.universe/issues/581>`_)
-  * add readme in rviz plugin (`#591 <https://github.com/youtalk/autoware.universe/issues/591>`_)
-  * [autoware_vehicle_rviz_plugin/route_handler/simple_planning_simulator]fix some packages (`#606 <https://github.com/youtalk/autoware.universe/issues/606>`_)
+  * port autoware_state_rviz_plugin (`#563 <https://github.com/autowarefoundation/autoware.universe/issues/563>`_)
+  * remove COLCON_IGNORE form rviz plugins (`#544 <https://github.com/autowarefoundation/autoware.universe/issues/544>`_)
+  * port autoware_perception_rviz_plugin (`#581 <https://github.com/autowarefoundation/autoware.universe/issues/581>`_)
+  * add readme in rviz plugin (`#591 <https://github.com/autowarefoundation/autoware.universe/issues/591>`_)
+  * [autoware_vehicle_rviz_plugin/route_handler/simple_planning_simulator]fix some packages (`#606 <https://github.com/autowarefoundation/autoware.universe/issues/606>`_)
   * fix console meter
   * fix velocity_history
   * fix route handler
   * change topic name
-  * adding autoware_auto_perception_rviz_plugin (`#574 <https://github.com/youtalk/autoware.universe/issues/574>`_)
+  * adding autoware_auto_perception_rviz_plugin (`#574 <https://github.com/autowarefoundation/autoware.universe/issues/574>`_)
   * [152] Implement BoundingBoxArray rviz display plugin.
   * [285] Clear bounding box markers before adding new markers on new message
   * [274] Trajectory visualization plugin
@@ -354,7 +354,7 @@ Changelog for package autoware_perception_rviz_plugin
   8d15f49d Add weights to acceleration and steer controls; loosen simulation test case:
   git-subtree-dir: src/external/mpc
   git-subtree-split: eaa5908bdd987051a9dcd9c505f99bfd7f028547
-  * [`#404 <https://github.com/youtalk/autoware.universe/issues/404>`_] apply ament_auto macro to autoware_rviz_plugins
+  * [`#404 <https://github.com/autowarefoundation/autoware.universe/issues/404>`_] apply ament_auto macro to autoware_rviz_plugins
   * Adding missing dependency on rviz2.
   * Squashed 'src/external/autoware_auto_msgs/' changes from 56550efd..f40970ea
   f40970ea Adding velocity_mps to VehicleControlCommand.
@@ -363,9 +363,9 @@ Changelog for package autoware_perception_rviz_plugin
   * Update copyright headers to transfer ownership to Autoware Foundation
   * Add CHANGELOG and update package versions for release
   Add CHANGELOG and update package versions for release
-  * [`#286 <https://github.com/youtalk/autoware.universe/issues/286>`_] Parameterize boundingbox colors from rviz
+  * [`#286 <https://github.com/autowarefoundation/autoware.universe/issues/286>`_] Parameterize boundingbox colors from rviz
   - Add visualization colours via Qt
-  * [`#813 <https://github.com/youtalk/autoware.universe/issues/813>`_] use autoware_set_compile_options() for nearly all compiled tests
+  * [`#813 <https://github.com/autowarefoundation/autoware.universe/issues/813>`_] use autoware_set_compile_options() for nearly all compiled tests
   - fix a few causes of warnings and disable warning flags as needed for
   other tests
   - set CXX_STANDARD strictly and only in a single place
@@ -373,13 +373,13 @@ Changelog for package autoware_perception_rviz_plugin
   - update building instructions and MR template
   - fix nasty initialization error of static constexpr member in `GenericState`
   of Kalman filter
-  * [`#910 <https://github.com/youtalk/autoware.universe/issues/910>`_] remove private compilation warning ignore flags
-  * [`#900 <https://github.com/youtalk/autoware.universe/issues/900>`_] Implement rviz plugin to visualize TrackedObjects
-  * [`#1110 <https://github.com/youtalk/autoware.universe/issues/1110>`_] Implement rviz plugin for DetectedObjects msg
+  * [`#910 <https://github.com/autowarefoundation/autoware.universe/issues/910>`_] remove private compilation warning ignore flags
+  * [`#900 <https://github.com/autowarefoundation/autoware.universe/issues/900>`_] Implement rviz plugin to visualize TrackedObjects
+  * [`#1110 <https://github.com/autowarefoundation/autoware.universe/issues/1110>`_] Implement rviz plugin for DetectedObjects msg
   * Resolve "Clarify meaning of pose in *ObjectKinematics messages"
-  * [`#1221 <https://github.com/youtalk/autoware.universe/issues/1221>`_] Add co-developed entry to copyright
-  * [`#1282 <https://github.com/youtalk/autoware.universe/issues/1282>`_] Fix double free in ObjectPolygonDisplayBase rviz plugin
-  * [`#1355 <https://github.com/youtalk/autoware.universe/issues/1355>`_] Make DetectedObject shape corners be in object-local coordinates
+  * [`#1221 <https://github.com/autowarefoundation/autoware.universe/issues/1221>`_] Add co-developed entry to copyright
+  * [`#1282 <https://github.com/autowarefoundation/autoware.universe/issues/1282>`_] Fix double free in ObjectPolygonDisplayBase rviz plugin
+  * [`#1355 <https://github.com/autowarefoundation/autoware.universe/issues/1355>`_] Make DetectedObject shape corners be in object-local coordinates
   * porting AAP perception visualization from https://github.com/tier4/AutowareArchitectureProposal.iv/blob/main/perception/util/visualizer/dynamic_object_visualization/include/dynamic_object_visualization/dynamic_object_visualizer.hpp
   * rename to autoware_auto_perception_rviz_plugin
   * fix copyright
@@ -415,19 +415,19 @@ Changelog for package autoware_perception_rviz_plugin
   Co-authored-by: Nikolai Morin <nikolai.morin@apex.ai>
   Co-authored-by: Igor Bogoslavskyi <igor.bogoslavskyi@gmail.com>
   Co-authored-by: Daisuke Nishimatsu <42202095+wep21@users.noreply.github.com>
-  * add autoware_auto_perception_rviz_plugin README (`#631 <https://github.com/youtalk/autoware.universe/issues/631>`_)
-  * fix readme sentence grammar (`#634 <https://github.com/youtalk/autoware.universe/issues/634>`_)
-  * Auto/fix perception viz (`#639 <https://github.com/youtalk/autoware.universe/issues/639>`_)
+  * add autoware_auto_perception_rviz_plugin README (`#631 <https://github.com/autowarefoundation/autoware.universe/issues/631>`_)
+  * fix readme sentence grammar (`#634 <https://github.com/autowarefoundation/autoware.universe/issues/634>`_)
+  * Auto/fix perception viz (`#639 <https://github.com/autowarefoundation/autoware.universe/issues/639>`_)
   * add ns of uuid
   * remove dynamic_object_visualization
-  * update to support velocity report header (`#655 <https://github.com/youtalk/autoware.universe/issues/655>`_)
+  * update to support velocity report header (`#655 <https://github.com/autowarefoundation/autoware.universe/issues/655>`_)
   * update to support velocity report header
   * Update simulator/simple_planning_simulator/src/simple_planning_simulator/simple_planning_simulator_core.cpp
   Co-authored-by: tkimura4 <tomoya.kimura@tier4.jp>
   * use maybe_unused
   * fix precommit
   Co-authored-by: tkimura4 <tomoya.kimura@tier4.jp>
-  * adapt to actuation cmd/status as control msg (`#646 <https://github.com/youtalk/autoware.universe/issues/646>`_)
+  * adapt to actuation cmd/status as control msg (`#646 <https://github.com/autowarefoundation/autoware.universe/issues/646>`_)
   * adapt to actuation cmd/status as control msg
   * fix readme
   * fix topics
@@ -438,35 +438,35 @@ Changelog for package autoware_perception_rviz_plugin
   * revert gyro_odometer_change
   * revert twist topic change
   * revert unchanged package
-  * FIx vehicle status topic name/type (`#658 <https://github.com/youtalk/autoware.universe/issues/658>`_)
+  * FIx vehicle status topic name/type (`#658 <https://github.com/autowarefoundation/autoware.universe/issues/658>`_)
   * shift -> gear_status
   * twist -> velocity_status
-  * Sync .auto branch with the latest branch in internal repository (`#691 <https://github.com/youtalk/autoware.universe/issues/691>`_)
-  * add trajectory point offset in rviz plugin (`#2270 <https://github.com/youtalk/autoware.universe/issues/2270>`_)
-  * sync rc rc/v0.23.0 (`#2258 <https://github.com/youtalk/autoware.universe/issues/2258>`_)
-  * fix interpolation for insert point (`#2228 <https://github.com/youtalk/autoware.universe/issues/2228>`_)
+  * Sync .auto branch with the latest branch in internal repository (`#691 <https://github.com/autowarefoundation/autoware.universe/issues/691>`_)
+  * add trajectory point offset in rviz plugin (`#2270 <https://github.com/autowarefoundation/autoware.universe/issues/2270>`_)
+  * sync rc rc/v0.23.0 (`#2258 <https://github.com/autowarefoundation/autoware.universe/issues/2258>`_)
+  * fix interpolation for insert point (`#2228 <https://github.com/autowarefoundation/autoware.universe/issues/2228>`_)
   * fix interpolation for insert point
   * to prev interpolation pkg
   * Revert "to prev interpolation pkg"
   This reverts commit 9eb145b5d36e297186015fb17c267ccd5b3c21ef.
   Co-authored-by: taikitanaka3 <65527974+taikitanaka3@users.noreply.github.com>
   Co-authored-by: taikitanaka <ttatcoder@outlook.jp>
-  * fix topic name (`#2266 <https://github.com/youtalk/autoware.universe/issues/2266>`_)
-  * Add namespace to diag for dual_return_filter (`#2269 <https://github.com/youtalk/autoware.universe/issues/2269>`_)
-  * Add a function to make 'geometry_msgs::msg::TransformStamped' (`#2250 <https://github.com/youtalk/autoware.universe/issues/2250>`_)
+  * fix topic name (`#2266 <https://github.com/autowarefoundation/autoware.universe/issues/2266>`_)
+  * Add namespace to diag for dual_return_filter (`#2269 <https://github.com/autowarefoundation/autoware.universe/issues/2269>`_)
+  * Add a function to make 'geometry_msgs::msg::TransformStamped' (`#2250 <https://github.com/autowarefoundation/autoware.universe/issues/2250>`_)
   * Add a function to make 'geometry_msgs::msg::TransformStamped'
   * Add 'child_frame_id' as an argument of 'pose2transform'
-  * Simplify marker scale initialization (`#2286 <https://github.com/youtalk/autoware.universe/issues/2286>`_)
-  * Fix/crosswalk polygon (`#2279 <https://github.com/youtalk/autoware.universe/issues/2279>`_)
+  * Simplify marker scale initialization (`#2286 <https://github.com/autowarefoundation/autoware.universe/issues/2286>`_)
+  * Fix/crosswalk polygon (`#2279 <https://github.com/autowarefoundation/autoware.universe/issues/2279>`_)
   * extend crosswalk polygon
   * improve readability
   * fix polygon shape
-  * Add warning when decel distance calculation fails (`#2289 <https://github.com/youtalk/autoware.universe/issues/2289>`_)
-  * [motion_velocity_smoother] ignore debug print (`#2292 <https://github.com/youtalk/autoware.universe/issues/2292>`_)
+  * Add warning when decel distance calculation fails (`#2289 <https://github.com/autowarefoundation/autoware.universe/issues/2289>`_)
+  * [motion_velocity_smoother] ignore debug print (`#2292 <https://github.com/autowarefoundation/autoware.universe/issues/2292>`_)
   * cosmetic change
   * cahnge severity from WARN to DEBUG for debug info
   * use util for stop_watch
-  * fix map based prediction (`#2200 <https://github.com/youtalk/autoware.universe/issues/2200>`_)
+  * fix map based prediction (`#2200 <https://github.com/autowarefoundation/autoware.universe/issues/2200>`_)
   * fix map based prediction
   * fix format
   * change map based prediction
@@ -497,18 +497,18 @@ Changelog for package autoware_perception_rviz_plugin
   Co-authored-by: Kazuki Miyahara <kmiya@outlook.com>
   Co-authored-by: tkimura4 <tomoya.kimura@tier4.jp>
   Co-authored-by: Kazuki Miyahara <kmiya@outlook.com>
-  * remove failure condition for 0 velocity trajectory (`#2295 <https://github.com/youtalk/autoware.universe/issues/2295>`_)
-  * [mpc_follower] remove stop distance condition from stopState decision (`#1916 <https://github.com/youtalk/autoware.universe/issues/1916>`_)
+  * remove failure condition for 0 velocity trajectory (`#2295 <https://github.com/autowarefoundation/autoware.universe/issues/2295>`_)
+  * [mpc_follower] remove stop distance condition from stopState decision (`#1916 <https://github.com/autowarefoundation/autoware.universe/issues/1916>`_)
   * [mpc_follower] remove stop distance condition from stopState decision
   * add invalid index handling
-  * Move the debug marker initialization part to another file (`#2288 <https://github.com/youtalk/autoware.universe/issues/2288>`_)
+  * Move the debug marker initialization part to another file (`#2288 <https://github.com/autowarefoundation/autoware.universe/issues/2288>`_)
   * Move the debug marker initialization part to 'debug.cpp'
-  * Make 'isLocalOptimalSolutionOscillation' independent from 'NDTScanMatcher' (`#2300 <https://github.com/youtalk/autoware.universe/issues/2300>`_)
-  * Remove an unused function 'getTransform' (`#2301 <https://github.com/youtalk/autoware.universe/issues/2301>`_)
-  * Simplify iteration of initial poses (`#2310 <https://github.com/youtalk/autoware.universe/issues/2310>`_)
-  * Make a transform object const (`#2311 <https://github.com/youtalk/autoware.universe/issues/2311>`_)
-  * Represent poses in 'std::vector' instead of 'geometry_msgs::msg::PoseArray' (`#2312 <https://github.com/youtalk/autoware.universe/issues/2312>`_)
-  * Feature/no stopping area (`#2163 <https://github.com/youtalk/autoware.universe/issues/2163>`_)
+  * Make 'isLocalOptimalSolutionOscillation' independent from 'NDTScanMatcher' (`#2300 <https://github.com/autowarefoundation/autoware.universe/issues/2300>`_)
+  * Remove an unused function 'getTransform' (`#2301 <https://github.com/autowarefoundation/autoware.universe/issues/2301>`_)
+  * Simplify iteration of initial poses (`#2310 <https://github.com/autowarefoundation/autoware.universe/issues/2310>`_)
+  * Make a transform object const (`#2311 <https://github.com/autowarefoundation/autoware.universe/issues/2311>`_)
+  * Represent poses in 'std::vector' instead of 'geometry_msgs::msg::PoseArray' (`#2312 <https://github.com/autowarefoundation/autoware.universe/issues/2312>`_)
+  * Feature/no stopping area (`#2163 <https://github.com/autowarefoundation/autoware.universe/issues/2163>`_)
   * add no stopping area module to behavior velocity planner
   * apply utils
   * add polygon interpolation module order stopline around area is considered
@@ -543,8 +543,8 @@ Changelog for package autoware_perception_rviz_plugin
   * precommit fix
   * cpplint
   Co-authored-by: Yukihiro Saito <yukky.saito@gmail.com>
-  * sync rc rc/v0.23.0 (`#2281 <https://github.com/youtalk/autoware.universe/issues/2281>`_)
-  * Fix side shift planner (`#2171 <https://github.com/youtalk/autoware.universe/issues/2171>`_) (`#2172 <https://github.com/youtalk/autoware.universe/issues/2172>`_)
+  * sync rc rc/v0.23.0 (`#2281 <https://github.com/autowarefoundation/autoware.universe/issues/2281>`_)
+  * Fix side shift planner (`#2171 <https://github.com/autowarefoundation/autoware.universe/issues/2171>`_) (`#2172 <https://github.com/autowarefoundation/autoware.universe/issues/2172>`_)
   * add print debug
   * remove forward shift points when adding new point
   * remove debug print
@@ -552,11 +552,11 @@ Changelog for package autoware_perception_rviz_plugin
   * Fix remove threshold
   Co-authored-by: Fumiya Watanabe <rej55.g@gmail.com>
   Co-authored-by: Takamasa Horibe <horibe.takamasa@gmail.com>
-  * Fix/pull out and pull over (`#2175 <https://github.com/youtalk/autoware.universe/issues/2175>`_)
+  * Fix/pull out and pull over (`#2175 <https://github.com/autowarefoundation/autoware.universe/issues/2175>`_)
   * delete unnecessary check
   * fix condition of starting pull out
-  * Add emergency status API (`#2174 <https://github.com/youtalk/autoware.universe/issues/2174>`_) (`#2182 <https://github.com/youtalk/autoware.universe/issues/2182>`_)
-  * Fix/mpc reset prev result (`#2185 <https://github.com/youtalk/autoware.universe/issues/2185>`_) (`#2195 <https://github.com/youtalk/autoware.universe/issues/2195>`_)
+  * Add emergency status API (`#2174 <https://github.com/autowarefoundation/autoware.universe/issues/2174>`_) (`#2182 <https://github.com/autowarefoundation/autoware.universe/issues/2182>`_)
+  * Fix/mpc reset prev result (`#2185 <https://github.com/autowarefoundation/autoware.universe/issues/2185>`_) (`#2195 <https://github.com/autowarefoundation/autoware.universe/issues/2195>`_)
   * reset prev result
   * clean code
   * reset only raw_steer_cmd
@@ -564,37 +564,37 @@ Changelog for package autoware_perception_rviz_plugin
   Co-authored-by: Takamasa Horibe <horibe.takamasa@gmail.com>
   Co-authored-by: Takamasa Horibe <horibe.takamasa@gmail.com>
   Co-authored-by: Takamasa Horibe <horibe.takamasa@gmail.com>
-  * [hotfix] 1 path point exception after resampling (`#2204 <https://github.com/youtalk/autoware.universe/issues/2204>`_)
+  * [hotfix] 1 path point exception after resampling (`#2204 <https://github.com/autowarefoundation/autoware.universe/issues/2204>`_)
   * fix 1 path point exception after resampling
   * Apply suggestions from code review
   * Apply suggestions from code review
   Co-authored-by: Takamasa Horibe <horibe.takamasa@gmail.com>
   Co-authored-by: tkimura4 <tomoya.kimura@tier4.jp>
-  * [hotfix] Fix lane ids (`#2211 <https://github.com/youtalk/autoware.universe/issues/2211>`_)
+  * [hotfix] Fix lane ids (`#2211 <https://github.com/autowarefoundation/autoware.universe/issues/2211>`_)
   * Fix lane ids
-  * Prevent acceleration on avoidance (`#2214 <https://github.com/youtalk/autoware.universe/issues/2214>`_)
+  * Prevent acceleration on avoidance (`#2214 <https://github.com/autowarefoundation/autoware.universe/issues/2214>`_)
   * prevent acceleration on avoidance
   * fix param name
   * parametrize avoidance acc
   * change param name
   * fix typo
-  * Fix qos in roi cluster fusion (`#2218 <https://github.com/youtalk/autoware.universe/issues/2218>`_)
-  * fix confidence (`#2220 <https://github.com/youtalk/autoware.universe/issues/2220>`_)
-  * too high confidence (`#2229 <https://github.com/youtalk/autoware.universe/issues/2229>`_)
-  * Fix/obstacle stop 0.23.0 (`#2232 <https://github.com/youtalk/autoware.universe/issues/2232>`_)
-  * fix unexpected slow down in sharp curves (`#2181 <https://github.com/youtalk/autoware.universe/issues/2181>`_)
-  * Fix/insert implementation (`#2186 <https://github.com/youtalk/autoware.universe/issues/2186>`_)
+  * Fix qos in roi cluster fusion (`#2218 <https://github.com/autowarefoundation/autoware.universe/issues/2218>`_)
+  * fix confidence (`#2220 <https://github.com/autowarefoundation/autoware.universe/issues/2220>`_)
+  * too high confidence (`#2229 <https://github.com/autowarefoundation/autoware.universe/issues/2229>`_)
+  * Fix/obstacle stop 0.23.0 (`#2232 <https://github.com/autowarefoundation/autoware.universe/issues/2232>`_)
+  * fix unexpected slow down in sharp curves (`#2181 <https://github.com/autowarefoundation/autoware.universe/issues/2181>`_)
+  * Fix/insert implementation (`#2186 <https://github.com/autowarefoundation/autoware.universe/issues/2186>`_)
   Co-authored-by: Satoshi OTA <44889564+satoshi-ota@users.noreply.github.com>
-  * [hotfix] Remove exception in avoidance module (`#2233 <https://github.com/youtalk/autoware.universe/issues/2233>`_)
+  * [hotfix] Remove exception in avoidance module (`#2233 <https://github.com/autowarefoundation/autoware.universe/issues/2233>`_)
   * Remove exception
   * Fix clock
   * Remove blank line
-  * Update traffic light state if ref stop point is ahead of previous one (`#2197 <https://github.com/youtalk/autoware.universe/issues/2197>`_)
-  * fix interpolation for insert point (`#2228 <https://github.com/youtalk/autoware.universe/issues/2228>`_)
+  * Update traffic light state if ref stop point is ahead of previous one (`#2197 <https://github.com/autowarefoundation/autoware.universe/issues/2197>`_)
+  * fix interpolation for insert point (`#2228 <https://github.com/autowarefoundation/autoware.universe/issues/2228>`_)
   * fix interpolation for insert point
   * to prev interpolation pkg
-  * fix index (`#2265 <https://github.com/youtalk/autoware.universe/issues/2265>`_)
-  * turn signal calculation (`#2280 <https://github.com/youtalk/autoware.universe/issues/2280>`_)
+  * fix index (`#2265 <https://github.com/autowarefoundation/autoware.universe/issues/2265>`_)
+  * turn signal calculation (`#2280 <https://github.com/autowarefoundation/autoware.universe/issues/2280>`_)
   * add turn signal funtion in path shifter
   * add ros parameters
   Co-authored-by: Fumiya Watanabe <rej55.g@gmail.com>
@@ -606,7 +606,7 @@ Changelog for package autoware_perception_rviz_plugin
   Co-authored-by: Satoshi OTA <44889564+satoshi-ota@users.noreply.github.com>
   Co-authored-by: taikitanaka3 <65527974+taikitanaka3@users.noreply.github.com>
   Co-authored-by: Sugatyon <32741405+Sugatyon@users.noreply.github.com>
-  * [behavior_path_planner] fix sudden path change around ego (`#2305 <https://github.com/youtalk/autoware.universe/issues/2305>`_) (`#2318 <https://github.com/youtalk/autoware.universe/issues/2318>`_)
+  * [behavior_path_planner] fix sudden path change around ego (`#2305 <https://github.com/autowarefoundation/autoware.universe/issues/2305>`_) (`#2318 <https://github.com/autowarefoundation/autoware.universe/issues/2318>`_)
   * fix return-from-ego shift point generation logic
   * change param for trimSimilarGradShiftPoint
   * add comment for issue
@@ -622,13 +622,13 @@ Changelog for package autoware_perception_rviz_plugin
   Co-authored-by: Kazuki Miyahara <kmiya@outlook.com>
   Co-authored-by: Takamasa Horibe <horibe.takamasa@gmail.com>
   Co-authored-by: Kazuki Miyahara <kmiya@outlook.com>
-  * Add functions to make stamped scalar messages (`#2317 <https://github.com/youtalk/autoware.universe/issues/2317>`_)
-  * Fix/object yaw in intersection module (`#2294 <https://github.com/youtalk/autoware.universe/issues/2294>`_)
+  * Add functions to make stamped scalar messages (`#2317 <https://github.com/autowarefoundation/autoware.universe/issues/2317>`_)
+  * Fix/object yaw in intersection module (`#2294 <https://github.com/autowarefoundation/autoware.universe/issues/2294>`_)
   * fix object orientation
   * fix function name
-  * add guard (`#2321 <https://github.com/youtalk/autoware.universe/issues/2321>`_)
-  * reduce cost (double to float) (`#2298 <https://github.com/youtalk/autoware.universe/issues/2298>`_)
-  * Add detail collision check (`#2274 <https://github.com/youtalk/autoware.universe/issues/2274>`_)
+  * add guard (`#2321 <https://github.com/autowarefoundation/autoware.universe/issues/2321>`_)
+  * reduce cost (double to float) (`#2298 <https://github.com/autowarefoundation/autoware.universe/issues/2298>`_)
+  * Add detail collision check (`#2274 <https://github.com/autowarefoundation/autoware.universe/issues/2274>`_)
   * Add detail collision check
   * Remove unused function
   * Fix arc length
@@ -639,7 +639,7 @@ Changelog for package autoware_perception_rviz_plugin
   * Run pre-commit
   * Fix cpplint
   * Add return for empty polygon
-  * update CenterPoint  (`#2222 <https://github.com/youtalk/autoware.universe/issues/2222>`_)
+  * update CenterPoint  (`#2222 <https://github.com/autowarefoundation/autoware.universe/issues/2222>`_)
   * update to model trained by mmdet3d
   * add vizualizer (debug)
   * for multi-frame inputs
@@ -656,7 +656,7 @@ Changelog for package autoware_perception_rviz_plugin
   * chage lint package
   * fix test error
   * commit suggestion
-  * Feature/lane change detection (`#2331 <https://github.com/youtalk/autoware.universe/issues/2331>`_)
+  * Feature/lane change detection (`#2331 <https://github.com/autowarefoundation/autoware.universe/issues/2331>`_)
   * add old information deleter
   * fix access bug
   * change to deque
@@ -678,7 +678,7 @@ Changelog for package autoware_perception_rviz_plugin
   * change funciton name
   * add lane change description
   Co-authored-by: Kazuki Miyahara <kmiya@outlook.com>
-  * Add Planning Evaluator  (`#2293 <https://github.com/youtalk/autoware.universe/issues/2293>`_)
+  * Add Planning Evaluator  (`#2293 <https://github.com/autowarefoundation/autoware.universe/issues/2293>`_)
   * Add prototype planning evaluator
   Produced data for dist between points, curvature, and relative angle
   * Cleanup the code to make adding metrics easier
@@ -714,12 +714,12 @@ Changelog for package autoware_perception_rviz_plugin
   * Update planning/planning_diagnostics/planning_evaluator/test/test_planning_evaluator_node.cpp
   * change lint format to autoware_lint_common
   Co-authored-by: Takamasa Horibe <horibe.takamasa@gmail.com>
-  * Add keep braking function at driving state (`#2346 <https://github.com/youtalk/autoware.universe/issues/2346>`_)
+  * Add keep braking function at driving state (`#2346 <https://github.com/autowarefoundation/autoware.universe/issues/2346>`_)
   * Add keep braking function at driving state
   * Remove debug messages
   * Fix format
-  * Change diag_updater's pediod from default to 0.1sec (`#2348 <https://github.com/youtalk/autoware.universe/issues/2348>`_)
-  * add cross judgement and common signal function (`#2319 <https://github.com/youtalk/autoware.universe/issues/2319>`_)
+  * Change diag_updater's pediod from default to 0.1sec (`#2348 <https://github.com/autowarefoundation/autoware.universe/issues/2348>`_)
+  * add cross judgement and common signal function (`#2319 <https://github.com/autowarefoundation/autoware.universe/issues/2319>`_)
   * merge branch turn_signal_common
   * add turn signal function in signal decider
   * add cross judge in path_utilities and delete from turn_signal_decider
@@ -739,27 +739,27 @@ Changelog for package autoware_perception_rviz_plugin
   * fix typo
   * decrease nest
   * run pre commit
-  * Add 0 limit at forward jerk velocity filter (`#2340 <https://github.com/youtalk/autoware.universe/issues/2340>`_)
-  * add time offset param to point cloud concatenation (`#2303 <https://github.com/youtalk/autoware.universe/issues/2303>`_)
+  * Add 0 limit at forward jerk velocity filter (`#2340 <https://github.com/autowarefoundation/autoware.universe/issues/2340>`_)
+  * add time offset param to point cloud concatenation (`#2303 <https://github.com/autowarefoundation/autoware.universe/issues/2303>`_)
   * add offset param
   * clang-format
   Co-authored-by: Akihito OHSATO <aohsato@gmail.com>
-  * Feature/add doc for keep braking function at driving state (`#2366 <https://github.com/youtalk/autoware.universe/issues/2366>`_)
+  * Feature/add doc for keep braking function at driving state (`#2366 <https://github.com/autowarefoundation/autoware.universe/issues/2366>`_)
   * Add the description of brake keeping
   * Add the english document
   * Improve description
   * Add english description
-  * Fix include files (`#2339 <https://github.com/youtalk/autoware.universe/issues/2339>`_)
+  * Fix include files (`#2339 <https://github.com/autowarefoundation/autoware.universe/issues/2339>`_)
   * fix behavior intersection module
   * fix behavior no stopping area module
   * fix planning_evaluator
   * fix motion_velocity_smoother
   * rename variable
-  * Revert "[mpc_follower] remove stop distance condition from stopState decision (`#1916 <https://github.com/youtalk/autoware.universe/issues/1916>`_)"
+  * Revert "[mpc_follower] remove stop distance condition from stopState decision (`#1916 <https://github.com/autowarefoundation/autoware.universe/issues/1916>`_)"
   This reverts commit ff4f0b5a844d1f835f1b93bd3b36a76747b0cd02.
-  * Revert "Add keep braking function at driving state (`#2346 <https://github.com/youtalk/autoware.universe/issues/2346>`_)"
+  * Revert "Add keep braking function at driving state (`#2346 <https://github.com/autowarefoundation/autoware.universe/issues/2346>`_)"
   This reverts commit f0478187db4c28bf6092c198723dcc5ec11a9c70.
-  * Revert "Feature/add doc for keep braking function at driving state (`#2366 <https://github.com/youtalk/autoware.universe/issues/2366>`_)"
+  * Revert "Feature/add doc for keep braking function at driving state (`#2366 <https://github.com/autowarefoundation/autoware.universe/issues/2366>`_)"
   This reverts commit 66de2f3924a479049fce2d5c5c6b579cacbd3e49.
   * Fix orientation availability in centerpoint
   * fix test_trajectory.cpp
@@ -789,17 +789,17 @@ Changelog for package autoware_perception_rviz_plugin
   Co-authored-by: Shinnosuke Hirakawa <8327162+0x126@users.noreply.github.com>
   Co-authored-by: Akihito OHSATO <aohsato@gmail.com>
   Co-authored-by: Kenji Miyake <kenji.miyake@tier4.jp>
-  * [autoware_auto_perception_rviz_plugin]fix bug (`#721 <https://github.com/youtalk/autoware.universe/issues/721>`_)
+  * [autoware_auto_perception_rviz_plugin]fix bug (`#721 <https://github.com/autowarefoundation/autoware.universe/issues/721>`_)
   * fix perception_marker
   * fix missing commit
   * apply format
-  * patch for PR721 (`#722 <https://github.com/youtalk/autoware.universe/issues/722>`_)
+  * patch for PR721 (`#722 <https://github.com/autowarefoundation/autoware.universe/issues/722>`_)
   * fix id_map erase operation
   * fix code to use c++11 function
   * update tracked_objects_display
   * fix bug
   Co-authored-by: Taichi Higashide <taichi.higashide@tier4.jp>
-  * fix rviz plugin (`#743 <https://github.com/youtalk/autoware.universe/issues/743>`_)
+  * fix rviz plugin (`#743 <https://github.com/autowarefoundation/autoware.universe/issues/743>`_)
   * move plugin packages
   * add ignore file to apply pre-commit
   Co-authored-by: mitsudome-r <ryohsuke.mitsudome@tier4.jp>

--- a/common/autoware_point_types/CHANGELOG.rst
+++ b/common/autoware_point_types/CHANGELOG.rst
@@ -5,8 +5,8 @@ Changelog for package autoware_point_types
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* refactor(autoware_point_types): prefix namespace with autoware::point_types (`#9169 <https://github.com/youtalk/autoware.universe/issues/9169>`_)
-* feat: migrating pointcloud types (`#6996 <https://github.com/youtalk/autoware.universe/issues/6996>`_)
+* refactor(autoware_point_types): prefix namespace with autoware::point_types (`#9169 <https://github.com/autowarefoundation/autoware.universe/issues/9169>`_)
+* feat: migrating pointcloud types (`#6996 <https://github.com/autowarefoundation/autoware.universe/issues/6996>`_)
   * feat: changed most of sensing to the new type
   * chore: started applying changes to the perception stack
   * feat: confirmed operation until centerpoint
@@ -26,8 +26,8 @@ Changelog for package autoware_point_types
   ---------
   Co-authored-by: kminoda <44218668+kminoda@users.noreply.github.com>
   Co-authored-by: badai nguyen <94814556+badai-nguyen@users.noreply.github.com>
-* chore: updated maintainers for the autoware_point_types package (`#7797 <https://github.com/youtalk/autoware.universe/issues/7797>`_)
-* docs(common): adding .pages file (`#7148 <https://github.com/youtalk/autoware.universe/issues/7148>`_)
+* chore: updated maintainers for the autoware_point_types package (`#7797 <https://github.com/autowarefoundation/autoware.universe/issues/7797>`_)
+* docs(common): adding .pages file (`#7148 <https://github.com/autowarefoundation/autoware.universe/issues/7148>`_)
   * docs(common): adding .pages file
   * fix naming
   * fix naming
@@ -40,7 +40,7 @@ Changelog for package autoware_point_types
 
 0.26.0 (2024-04-03)
 -------------------
-* build: mark autoware_cmake as <buildtool_depend> (`#3616 <https://github.com/youtalk/autoware.universe/issues/3616>`_)
+* build: mark autoware_cmake as <buildtool_depend> (`#3616 <https://github.com/autowarefoundation/autoware.universe/issues/3616>`_)
   * build: mark autoware_cmake as <buildtool_depend>
   with <build_depend>, autoware_cmake is automatically exported with ament_target_dependencies() (unecessary)
   * style(pre-commit): autofix
@@ -48,15 +48,15 @@ Changelog for package autoware_point_types
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Kenji Miyake <kenji.miyake@tier4.jp>
-* feat: isolate gtests in all packages (`#693 <https://github.com/youtalk/autoware.universe/issues/693>`_)
-* chore: upgrade cmake_minimum_required to 3.14 (`#856 <https://github.com/youtalk/autoware.universe/issues/856>`_)
-* refactor: use autoware cmake (`#849 <https://github.com/youtalk/autoware.universe/issues/849>`_)
+* feat: isolate gtests in all packages (`#693 <https://github.com/autowarefoundation/autoware.universe/issues/693>`_)
+* chore: upgrade cmake_minimum_required to 3.14 (`#856 <https://github.com/autowarefoundation/autoware.universe/issues/856>`_)
+* refactor: use autoware cmake (`#849 <https://github.com/autowarefoundation/autoware.universe/issues/849>`_)
   * remove autoware_auto_cmake
   * add build_depend of autoware_cmake
   * use autoware_cmake in CMakeLists.txt
   * fix bugs
   * fix cmake lint errors
-* feat: add blockage diagnostics (`#461 <https://github.com/youtalk/autoware.universe/issues/461>`_)
+* feat: add blockage diagnostics (`#461 <https://github.com/autowarefoundation/autoware.universe/issues/461>`_)
   * feat!: add blockage diagnostic
   * fix: typo
   * docs: add documentation
@@ -83,7 +83,7 @@ Changelog for package autoware_point_types
   * docs: add limits
   * chore: check overflow
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* ci: check include guard (`#438 <https://github.com/youtalk/autoware.universe/issues/438>`_)
+* ci: check include guard (`#438 <https://github.com/autowarefoundation/autoware.universe/issues/438>`_)
   * ci: check include guard
   * apply pre-commit
   * Update .pre-commit-config.yaml
@@ -91,7 +91,7 @@ Changelog for package autoware_point_types
   * fix: pre-commit
   Co-authored-by: Kenji Miyake <kenji.miyake@tier4.jp>
   Co-authored-by: Kenji Miyake <31987104+kenji-miyake@users.noreply.github.com>
-* feat: add point_types for wrapper (`#784 <https://github.com/youtalk/autoware.universe/issues/784>`_) (`#215 <https://github.com/youtalk/autoware.universe/issues/215>`_)
+* feat: add point_types for wrapper (`#784 <https://github.com/autowarefoundation/autoware.universe/issues/784>`_) (`#215 <https://github.com/autowarefoundation/autoware.universe/issues/215>`_)
   * add point_types
   * Revert "add point_types"
   This reverts commit 5810000cd1cbd876bc22372e2bb74ccaca06187b.

--- a/common/autoware_polar_grid/CHANGELOG.rst
+++ b/common/autoware_polar_grid/CHANGELOG.rst
@@ -5,7 +5,7 @@ Changelog for package autoware_polar_grid
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* refactor(polar_grid): add autoware prefix to polar_grid (`#8945 <https://github.com/youtalk/autoware.universe/issues/8945>`_)
+* refactor(polar_grid): add autoware prefix to polar_grid (`#8945 <https://github.com/autowarefoundation/autoware.universe/issues/8945>`_)
 * Contributors: Esteve Fernandez, Yutaka Kondo
 
 0.26.0 (2024-04-03)

--- a/common/autoware_qp_interface/CHANGELOG.rst
+++ b/common/autoware_qp_interface/CHANGELOG.rst
@@ -5,24 +5,24 @@ Changelog for package qp_interface
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* fix(qp_interface): fix unreadVariable (`#8349 <https://github.com/youtalk/autoware.universe/issues/8349>`_)
+* fix(qp_interface): fix unreadVariable (`#8349 <https://github.com/autowarefoundation/autoware.universe/issues/8349>`_)
   * fix:unreadVariable
   * fix:unreadVariable
   * fix:unreadVariable
   ---------
-* perf(velocity_smoother): use ProxQP for faster optimization (`#8028 <https://github.com/youtalk/autoware.universe/issues/8028>`_)
+* perf(velocity_smoother): use ProxQP for faster optimization (`#8028 <https://github.com/autowarefoundation/autoware.universe/issues/8028>`_)
   * perf(velocity_smoother): use ProxQP for faster optimization
   * consider max_iteration
   * disable warm start
   * fix test
   ---------
-* refactor(qp_interface): clean up the code (`#8029 <https://github.com/youtalk/autoware.universe/issues/8029>`_)
+* refactor(qp_interface): clean up the code (`#8029 <https://github.com/autowarefoundation/autoware.universe/issues/8029>`_)
   * refactor qp_interface
   * variable names: m_XXX -> XXX\_
   * update
   * update
   ---------
-* fix(fake_test_node, osqp_interface, qp_interface): remove unnecessary cppcheck inline suppressions (`#7855 <https://github.com/youtalk/autoware.universe/issues/7855>`_)
+* fix(fake_test_node, osqp_interface, qp_interface): remove unnecessary cppcheck inline suppressions (`#7855 <https://github.com/autowarefoundation/autoware.universe/issues/7855>`_)
   * fix(fake_test_node, osqp_interface, qp_interface): remove unnecessary cppcheck inline suppressions
   * style(pre-commit): autofix
   ---------
@@ -31,9 +31,9 @@ Changelog for package qp_interface
 
 0.26.0 (2024-04-03)
 -------------------
-* feat(qp_interface): support proxqp (`#3699 <https://github.com/youtalk/autoware.universe/issues/3699>`_)
+* feat(qp_interface): support proxqp (`#3699 <https://github.com/autowarefoundation/autoware.universe/issues/3699>`_)
   * feat(qp_interface): add proxqp interface
   * update
   ---------
-* feat(qp_interface): add new package which will contain various qp solvers (`#3697 <https://github.com/youtalk/autoware.universe/issues/3697>`_)
+* feat(qp_interface): add new package which will contain various qp solvers (`#3697 <https://github.com/autowarefoundation/autoware.universe/issues/3697>`_)
 * Contributors: Takayuki Murooka

--- a/common/autoware_signal_processing/CHANGELOG.rst
+++ b/common/autoware_signal_processing/CHANGELOG.rst
@@ -5,10 +5,10 @@ Changelog for package autoware_signal_processing
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* fix: fix Boost.Optional build error on Jazzy (`#7602 <https://github.com/youtalk/autoware.universe/issues/7602>`_)
+* fix: fix Boost.Optional build error on Jazzy (`#7602 <https://github.com/autowarefoundation/autoware.universe/issues/7602>`_)
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Kotaro Yoshimoto <pythagora.yoshimoto@gmail.com>
-* refactor(signal_processing): prefix package and namespace with autoware (`#8541 <https://github.com/youtalk/autoware.universe/issues/8541>`_)
+* refactor(signal_processing): prefix package and namespace with autoware (`#8541 <https://github.com/autowarefoundation/autoware.universe/issues/8541>`_)
 * Contributors: Esteve Fernandez, Yutaka Kondo, ぐるぐる
 
 0.26.0 (2024-04-03)

--- a/common/autoware_test_utils/CHANGELOG.rst
+++ b/common/autoware_test_utils/CHANGELOG.rst
@@ -5,53 +5,53 @@ Changelog for package autoware_test_utils
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* feat(autoware_test_utils): add parser for PredictedObjects (`#9176 <https://github.com/youtalk/autoware.universe/issues/9176>`_)
+* feat(autoware_test_utils): add parser for PredictedObjects (`#9176 <https://github.com/autowarefoundation/autoware.universe/issues/9176>`_)
   feat(autoware_test_utils): add parser for predicted objects
-* refactor(autoware_test_utils): sanitizer header (`#9174 <https://github.com/youtalk/autoware.universe/issues/9174>`_)
-* refactor(component_interface_specs): prefix package and namespace with autoware (`#9094 <https://github.com/youtalk/autoware.universe/issues/9094>`_)
-* fix(autoware_test_utils): remove unnecessary cppcheck suppression (`#9165 <https://github.com/youtalk/autoware.universe/issues/9165>`_)
-* feat(autoware_test_utils): add parser for geometry_msgs and others (`#9167 <https://github.com/youtalk/autoware.universe/issues/9167>`_)
-* feat(autoware_test_utils): add path with lane id parser (`#9098 <https://github.com/youtalk/autoware.universe/issues/9098>`_)
+* refactor(autoware_test_utils): sanitizer header (`#9174 <https://github.com/autowarefoundation/autoware.universe/issues/9174>`_)
+* refactor(component_interface_specs): prefix package and namespace with autoware (`#9094 <https://github.com/autowarefoundation/autoware.universe/issues/9094>`_)
+* fix(autoware_test_utils): remove unnecessary cppcheck suppression (`#9165 <https://github.com/autowarefoundation/autoware.universe/issues/9165>`_)
+* feat(autoware_test_utils): add parser for geometry_msgs and others (`#9167 <https://github.com/autowarefoundation/autoware.universe/issues/9167>`_)
+* feat(autoware_test_utils): add path with lane id parser (`#9098 <https://github.com/autowarefoundation/autoware.universe/issues/9098>`_)
   * add path with lane id parser
   * refactor parse to use template
   ---------
-* feat(autoware_test_utils): move test_map, add launcher for test_map (`#9045 <https://github.com/youtalk/autoware.universe/issues/9045>`_)
-* feat(test_utils): add simple path with lane id generator (`#9113 <https://github.com/youtalk/autoware.universe/issues/9113>`_)
+* feat(autoware_test_utils): move test_map, add launcher for test_map (`#9045 <https://github.com/autowarefoundation/autoware.universe/issues/9045>`_)
+* feat(test_utils): add simple path with lane id generator (`#9113 <https://github.com/autowarefoundation/autoware.universe/issues/9113>`_)
   * add simple path with lane id generator
   * chnage to explicit template
   * fix
   * add static cast
   * remove header file
   ---------
-* fix(autoware_test_utils): missing ament_index_cpp dependency (`#8618 <https://github.com/youtalk/autoware.universe/issues/8618>`_)
-* fix(autoware_test_utils): fix unusedFunction (`#8857 <https://github.com/youtalk/autoware.universe/issues/8857>`_)
+* fix(autoware_test_utils): missing ament_index_cpp dependency (`#8618 <https://github.com/autowarefoundation/autoware.universe/issues/8618>`_)
+* fix(autoware_test_utils): fix unusedFunction (`#8857 <https://github.com/autowarefoundation/autoware.universe/issues/8857>`_)
   fix:unusedFunction
-* fix(autoware_test_utils): fix unusedFunction (`#8816 <https://github.com/youtalk/autoware.universe/issues/8816>`_)
+* fix(autoware_test_utils): fix unusedFunction (`#8816 <https://github.com/autowarefoundation/autoware.universe/issues/8816>`_)
   fix: unusedFunction
-* test(autoware_route_handler): add unit test for autoware route handler function (`#8271 <https://github.com/youtalk/autoware.universe/issues/8271>`_)
+* test(autoware_route_handler): add unit test for autoware route handler function (`#8271 <https://github.com/autowarefoundation/autoware.universe/issues/8271>`_)
   * remove unused functions in route handler
   * add docstring for function getShoulderLaneletsAtPose
   * update test map to include shoulder lanelet
   * add unit test for function getShoulderLaneletsAtPose
   * add test case for getCenterLinePath to improve branch coverage
   ---------
-* feat(autoware_test_utils): add qos handler in pub/sub (`#7856 <https://github.com/youtalk/autoware.universe/issues/7856>`_)
+* feat(autoware_test_utils): add qos handler in pub/sub (`#7856 <https://github.com/autowarefoundation/autoware.universe/issues/7856>`_)
   * feat: add qos handler in pub/sub
   * style(pre-commit): autofix
   * feat: update test_pub_msg function to not use setpublisher function
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat: add `autoware\_` prefix to `lanelet2_extension` (`#7640 <https://github.com/youtalk/autoware.universe/issues/7640>`_)
-* feat(auoware_test_utils): add jump_clock interface (`#7638 <https://github.com/youtalk/autoware.universe/issues/7638>`_)
+* feat: add `autoware\_` prefix to `lanelet2_extension` (`#7640 <https://github.com/autowarefoundation/autoware.universe/issues/7640>`_)
+* feat(auoware_test_utils): add jump_clock interface (`#7638 <https://github.com/autowarefoundation/autoware.universe/issues/7638>`_)
   * feat(auoware_test_utils): add jump_clock interface
   * add comment
   ---------
-* feat(route_handler): add unit test for lane change related functions (`#7504 <https://github.com/youtalk/autoware.universe/issues/7504>`_)
+* feat(route_handler): add unit test for lane change related functions (`#7504 <https://github.com/autowarefoundation/autoware.universe/issues/7504>`_)
   * RT1-6230 feat(route_handler): add unit test for lane change related functions
   * fix spell check
   * fix spellcheck
   ---------
-* feat(autoware_test_utils): add autoware test manager (`#7597 <https://github.com/youtalk/autoware.universe/issues/7597>`_)
+* feat(autoware_test_utils): add autoware test manager (`#7597 <https://github.com/autowarefoundation/autoware.universe/issues/7597>`_)
   * feat(detected_object_validation): add test
   * move to autoware_test_utils
   * remove perception
@@ -63,11 +63,11 @@ Changelog for package autoware_test_utils
   * avoid using void and static_pointer_cast
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/youtalk/autoware.universe/issues/7594>`_)
-* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/youtalk/autoware.universe/issues/7538>`_)
+* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/autowarefoundation/autoware.universe/issues/7594>`_)
+* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/autowarefoundation/autoware.universe/issues/7538>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* refactor(autoware_test_utils): function to load paths from folder (`#7474 <https://github.com/youtalk/autoware.universe/issues/7474>`_)
-* fix(route_handler): route handler overlap removal is too conservative (`#7156 <https://github.com/youtalk/autoware.universe/issues/7156>`_)
+* refactor(autoware_test_utils): function to load paths from folder (`#7474 <https://github.com/autowarefoundation/autoware.universe/issues/7474>`_)
+* fix(route_handler): route handler overlap removal is too conservative (`#7156 <https://github.com/autowarefoundation/autoware.universe/issues/7156>`_)
   * add flag to enable/disable loop check in getLaneletSequence functions
   * implement function to get closest route lanelet based on previous closest lanelet
   * refactor DefaultPlanner::plan function
@@ -84,7 +84,7 @@ Changelog for package autoware_test_utils
   * format fix
   * move test map to autoware_test_utils
   ---------
-* refactor(test_utils): move to common folder (`#7158 <https://github.com/youtalk/autoware.universe/issues/7158>`_)
+* refactor(test_utils): move to common folder (`#7158 <https://github.com/autowarefoundation/autoware.universe/issues/7158>`_)
   * Move autoware planning test manager to autoware namespace
   * fix package share directory for behavior path planner
   * renaming files and directory

--- a/common/autoware_testing/CHANGELOG.rst
+++ b/common/autoware_testing/CHANGELOG.rst
@@ -9,13 +9,13 @@ Changelog for package autoware_testing
 
 0.26.0 (2024-04-03)
 -------------------
-* chore: add maintainer (`#4234 <https://github.com/youtalk/autoware.universe/issues/4234>`_)
+* chore: add maintainer (`#4234 <https://github.com/autowarefoundation/autoware.universe/issues/4234>`_)
   * chore: add maintainer
   * Update evaluator/localization_evaluator/package.xml
   Co-authored-by: kminoda <44218668+kminoda@users.noreply.github.com>
   ---------
   Co-authored-by: kminoda <44218668+kminoda@users.noreply.github.com>
-* fix(smoke_test): fix smoke test failing with big nodes (`#3287 <https://github.com/youtalk/autoware.universe/issues/3287>`_)
+* fix(smoke_test): fix smoke test failing with big nodes (`#3287 <https://github.com/autowarefoundation/autoware.universe/issues/3287>`_)
   * fix(smoke_test): fix smoke test failing with big nodes
   * style(pre-commit): autofix
   * minor style changes and comment removal
@@ -28,7 +28,7 @@ Changelog for package autoware_testing
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Takamasa Horibe <horibe.takamasa@gmail.com>
-* build: mark autoware_cmake as <buildtool_depend> (`#3616 <https://github.com/youtalk/autoware.universe/issues/3616>`_)
+* build: mark autoware_cmake as <buildtool_depend> (`#3616 <https://github.com/autowarefoundation/autoware.universe/issues/3616>`_)
   * build: mark autoware_cmake as <buildtool_depend>
   with <build_depend>, autoware_cmake is automatically exported with ament_target_dependencies() (unecessary)
   * style(pre-commit): autofix
@@ -36,47 +36,47 @@ Changelog for package autoware_testing
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Kenji Miyake <kenji.miyake@tier4.jp>
-* build(autoware_testing): add missing dependencies (`#3093 <https://github.com/youtalk/autoware.universe/issues/3093>`_)
-* ci(pre-commit): autoupdate (`#2819 <https://github.com/youtalk/autoware.universe/issues/2819>`_)
+* build(autoware_testing): add missing dependencies (`#3093 <https://github.com/autowarefoundation/autoware.universe/issues/3093>`_)
+* ci(pre-commit): autoupdate (`#2819 <https://github.com/autowarefoundation/autoware.universe/issues/2819>`_)
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* docs: update link style and fix typos (`#950 <https://github.com/youtalk/autoware.universe/issues/950>`_)
-  * feat(state_rviz_plugin): add GateMode and PathChangeApproval Button (`#894 <https://github.com/youtalk/autoware.universe/issues/894>`_)
+* docs: update link style and fix typos (`#950 <https://github.com/autowarefoundation/autoware.universe/issues/950>`_)
+  * feat(state_rviz_plugin): add GateMode and PathChangeApproval Button (`#894 <https://github.com/autowarefoundation/autoware.universe/issues/894>`_)
   * feat(state_rviz_plugin): add GateMode and PathChangeApproval Button
   * ci(pre-commit): autofix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   * docs: update link style
   * chore: fix link
-  * feat(map_tf_generator): accelerate the 'viewer' coordinate calculation (`#890 <https://github.com/youtalk/autoware.universe/issues/890>`_)
+  * feat(map_tf_generator): accelerate the 'viewer' coordinate calculation (`#890 <https://github.com/autowarefoundation/autoware.universe/issues/890>`_)
   * add random point sampling function to quickly calculate the 'viewer' coordinate
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Kenji Miyake <31987104+kenji-miyake@users.noreply.github.com>
-  * docs(obstacle_stop_planner): update documentation (`#880 <https://github.com/youtalk/autoware.universe/issues/880>`_)
-  * docs(tier4_traffic_light_rviz_plugin): update documentation (`#905 <https://github.com/youtalk/autoware.universe/issues/905>`_)
-  * fix(accel_brake_map_calibrator): rviz panel type (`#895 <https://github.com/youtalk/autoware.universe/issues/895>`_)
+  * docs(obstacle_stop_planner): update documentation (`#880 <https://github.com/autowarefoundation/autoware.universe/issues/880>`_)
+  * docs(tier4_traffic_light_rviz_plugin): update documentation (`#905 <https://github.com/autowarefoundation/autoware.universe/issues/905>`_)
+  * fix(accel_brake_map_calibrator): rviz panel type (`#895 <https://github.com/autowarefoundation/autoware.universe/issues/895>`_)
   * fixed panel type
   * modified instruction for rosbag replay case
   * modified update_map_dir service name
-  * fix(behavior velocity planner): skipping emplace back stop reason if it is empty (`#898 <https://github.com/youtalk/autoware.universe/issues/898>`_)
+  * fix(behavior velocity planner): skipping emplace back stop reason if it is empty (`#898 <https://github.com/autowarefoundation/autoware.universe/issues/898>`_)
   * skipping emplace back stop reason if it is empty
   * add braces
   * ci(pre-commit): autofix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Takagi, Isamu <43976882+isamu-takagi@users.noreply.github.com>
-  * feat(behavior_path_planner): weakened noise filtering of drivable area (`#838 <https://github.com/youtalk/autoware.universe/issues/838>`_)
+  * feat(behavior_path_planner): weakened noise filtering of drivable area (`#838 <https://github.com/autowarefoundation/autoware.universe/issues/838>`_)
   * feat(behavior_path_planner): Weakened noise filtering of drivable area
   * fix lanelet's longitudinal disconnection
   * add comments of erode/dilate process
-  * refactor(vehicle-cmd-gate): using namespace for msgs (`#913 <https://github.com/youtalk/autoware.universe/issues/913>`_)
+  * refactor(vehicle-cmd-gate): using namespace for msgs (`#913 <https://github.com/autowarefoundation/autoware.universe/issues/913>`_)
   * refactor(vehicle-cmd-gate): using namespace for msgs
   * for clang
-  * feat(pose_initializer): introduce an array copy function (`#900 <https://github.com/youtalk/autoware.universe/issues/900>`_)
+  * feat(pose_initializer): introduce an array copy function (`#900 <https://github.com/autowarefoundation/autoware.universe/issues/900>`_)
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-  * feat: add lidar point filter when debug (`#865 <https://github.com/youtalk/autoware.universe/issues/865>`_)
+  * feat: add lidar point filter when debug (`#865 <https://github.com/autowarefoundation/autoware.universe/issues/865>`_)
   * feat: add lidar point filter when debug
   * ci(pre-commit): autofix
   Co-authored-by: suchang <chang.su@autocore.ai>
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-  * feat(component_interface_utils): add interface classes  (`#899 <https://github.com/youtalk/autoware.universe/issues/899>`_)
+  * feat(component_interface_utils): add interface classes  (`#899 <https://github.com/autowarefoundation/autoware.universe/issues/899>`_)
   * feat(component_interface_utils): add interface classes
   * feat(default_ad_api): apply the changes of interface utils
   * fix(component_interface_utils): remove old comment
@@ -84,18 +84,18 @@ Changelog for package autoware_testing
   * fix(component_interface_utils): remove unimplemented message
   * docs(component_interface_utils): add design policy
   * docs(component_interface_utils): add comment
-  * refactor(vehicle_cmd_gate): change namespace in launch file (`#927 <https://github.com/youtalk/autoware.universe/issues/927>`_)
+  * refactor(vehicle_cmd_gate): change namespace in launch file (`#927 <https://github.com/autowarefoundation/autoware.universe/issues/927>`_)
   Co-authored-by: Berkay <berkay@leodrive.ai>
-  * feat: visualize lane boundaries (`#923 <https://github.com/youtalk/autoware.universe/issues/923>`_)
+  * feat: visualize lane boundaries (`#923 <https://github.com/autowarefoundation/autoware.universe/issues/923>`_)
   * feat: visualize lane boundaries
   * fix: start_bound
   * ci(pre-commit): autofix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-  * fix(system_monitor): fix truncation warning in strncpy (`#872 <https://github.com/youtalk/autoware.universe/issues/872>`_)
+  * fix(system_monitor): fix truncation warning in strncpy (`#872 <https://github.com/autowarefoundation/autoware.universe/issues/872>`_)
   * fix(system_monitor): fix truncation warning in strncpy
   * Use std::string constructor to copy char array
   * Fixed typo
-  * fix(behavior_velocity_planner.stopline): extend following and previous search range to avoid no collision (`#917 <https://github.com/youtalk/autoware.universe/issues/917>`_)
+  * fix(behavior_velocity_planner.stopline): extend following and previous search range to avoid no collision (`#917 <https://github.com/autowarefoundation/autoware.universe/issues/917>`_)
   * fix: extend following and previous search range to avoid no collision
   * chore: add debug marker
   * fix: simplify logic
@@ -105,11 +105,11 @@ Changelog for package autoware_testing
   * ci(pre-commit): autofix
   * fix: delete debug code
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-  * docs(surround obstacle checker): update documentation (`#878 <https://github.com/youtalk/autoware.universe/issues/878>`_)
+  * docs(surround obstacle checker): update documentation (`#878 <https://github.com/autowarefoundation/autoware.universe/issues/878>`_)
   * docs(surround_obstacle_checker): update pub/sub topics & params
   * docs(surround_obstacle_checker): remove unused files
   * docs(surround_obstacke_checker): update purpose
-  * feat(tier4_autoware_utils): add vehicle state checker (`#896 <https://github.com/youtalk/autoware.universe/issues/896>`_)
+  * feat(tier4_autoware_utils): add vehicle state checker (`#896 <https://github.com/autowarefoundation/autoware.universe/issues/896>`_)
   * feat(tier4_autoware_utils): add vehicle state checker
   * fix(tier4_autoware_utils): use absolute value
   * feat(tier4_autoware_utils): divide into two classies
@@ -119,20 +119,20 @@ Changelog for package autoware_testing
   * fix(tier4_autoware_utils): into same loop
   * fix(tier4_autoware_utils): fix variables name
   * fix(tier4_autoware_utils): remove redundant codes
-  * fix(motion_velocity_smoother): fix overwriteStopPoint using backward point (`#816 <https://github.com/youtalk/autoware.universe/issues/816>`_)
+  * fix(motion_velocity_smoother): fix overwriteStopPoint using backward point (`#816 <https://github.com/autowarefoundation/autoware.universe/issues/816>`_)
   * fix(motion_velocity_smoother): fix overwriteStopPoint using backward point
   * Modify overwriteStopPoint input and output
-  * feat(obstacle_avoidance_planner): explicitly insert zero velocity (`#906 <https://github.com/youtalk/autoware.universe/issues/906>`_)
+  * feat(obstacle_avoidance_planner): explicitly insert zero velocity (`#906 <https://github.com/autowarefoundation/autoware.universe/issues/906>`_)
   * feat(obstacle_avoidance_planner) fix bug of stop line unalignment
   * fix bug of unsorted output points
   * move calcVelocity in node.cpp
   * fix build error
-  * feat(behavior_velocity): find occlusion more efficiently (`#829 <https://github.com/youtalk/autoware.universe/issues/829>`_)
-  * fix(system_monitor): add some smart information to diagnostics (`#708 <https://github.com/youtalk/autoware.universe/issues/708>`_)
-  * feat(obstacle_avoidance_planner): dealt with close lane change (`#921 <https://github.com/youtalk/autoware.universe/issues/921>`_)
+  * feat(behavior_velocity): find occlusion more efficiently (`#829 <https://github.com/autowarefoundation/autoware.universe/issues/829>`_)
+  * fix(system_monitor): add some smart information to diagnostics (`#708 <https://github.com/autowarefoundation/autoware.universe/issues/708>`_)
+  * feat(obstacle_avoidance_planner): dealt with close lane change (`#921 <https://github.com/autowarefoundation/autoware.universe/issues/921>`_)
   * feat(obstacle_avoidance_planner): dealt with close lane change
   * fix bug of right lane change
-  * feat(obstacle_avoidance_planner): some fix for narrow driving (`#916 <https://github.com/youtalk/autoware.universe/issues/916>`_)
+  * feat(obstacle_avoidance_planner): some fix for narrow driving (`#916 <https://github.com/autowarefoundation/autoware.universe/issues/916>`_)
   * use car like constraints in mpt
   * use not widest bounds for the first bounds
   * organized params
@@ -142,17 +142,17 @@ Changelog for package autoware_testing
   * update config
   * remove unnecessary files
   * update tier4_planning_launch params
-  * chore(obstacle_avoidance_planner): removed obsolete obstacle_avoidance_planner doc in Japanese (`#919 <https://github.com/youtalk/autoware.universe/issues/919>`_)
-  * chore(behavior_velocity_planner.stopline): add debug marker for stopline collision check (`#932 <https://github.com/youtalk/autoware.universe/issues/932>`_)
+  * chore(obstacle_avoidance_planner): removed obsolete obstacle_avoidance_planner doc in Japanese (`#919 <https://github.com/autowarefoundation/autoware.universe/issues/919>`_)
+  * chore(behavior_velocity_planner.stopline): add debug marker for stopline collision check (`#932 <https://github.com/autowarefoundation/autoware.universe/issues/932>`_)
   * chore(behavior_velocity_planner.stopline): add debug marker for stopline collision check
   * feat: use marker helper
-  * feat(map_loader): visualize center line by points (`#931 <https://github.com/youtalk/autoware.universe/issues/931>`_)
+  * feat(map_loader): visualize center line by points (`#931 <https://github.com/autowarefoundation/autoware.universe/issues/931>`_)
   * feat: visualize center line points
   * fix: delete space
   * feat: visualize center line by arrow
   * revert insertMarkerArray
   * fix: delete space
-  * feat: add RTC interface (`#765 <https://github.com/youtalk/autoware.universe/issues/765>`_)
+  * feat: add RTC interface (`#765 <https://github.com/autowarefoundation/autoware.universe/issues/765>`_)
   * feature(rtc_interface): add files
   * feature(rtc_interface): implement functions
   * feature(rtc_interface): reimprement functions to use CooperateCommands and write README.md
@@ -164,23 +164,23 @@ Changelog for package autoware_testing
   * feature(rtc_interface): add isRegistered and clearCooperateStatus
   * ci(pre-commit): autofix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-  * chore: sync files (`#911 <https://github.com/youtalk/autoware.universe/issues/911>`_)
+  * chore: sync files (`#911 <https://github.com/autowarefoundation/autoware.universe/issues/911>`_)
   Co-authored-by: kenji-miyake <kenji-miyake@users.noreply.github.com>
-  * fix: replace boost::mutex::scoped_lock to std::scoped_lock (`#907 <https://github.com/youtalk/autoware.universe/issues/907>`_)
+  * fix: replace boost::mutex::scoped_lock to std::scoped_lock (`#907 <https://github.com/autowarefoundation/autoware.universe/issues/907>`_)
   * fix: replace boost::mutex::scoped_lock to std::scoped_lock
   * fix: replace boost::mutex to std::mutex
-  * feat(tensorrt_yolo): add multi gpu support to tensorrt_yolo node (`#885 <https://github.com/youtalk/autoware.universe/issues/885>`_)
+  * feat(tensorrt_yolo): add multi gpu support to tensorrt_yolo node (`#885 <https://github.com/autowarefoundation/autoware.universe/issues/885>`_)
   * feat(tensorrt_yolo): add multi gpu support to tensorrt_yolo node
   * feat(tensorrt_yolo): update arg
   Co-authored-by: Kaan Colak <kcolak@leodrive.ai>
-  * feat(tier4_planning_launch): create parameter yaml for behavior_velocity_planner (`#887 <https://github.com/youtalk/autoware.universe/issues/887>`_)
+  * feat(tier4_planning_launch): create parameter yaml for behavior_velocity_planner (`#887 <https://github.com/autowarefoundation/autoware.universe/issues/887>`_)
   * feat(tier4_planning_launch): create parameter yaml for behavior_velocity_planner
   * Update launch/tier4_planning_launch/config/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/behavior_velocity_planner.param.yaml
   Co-authored-by: taikitanaka3 <65527974+taikitanaka3@users.noreply.github.com>
   * feat: add param.yaml in behavior_velocity_planner package
   * some fix
   Co-authored-by: taikitanaka3 <65527974+taikitanaka3@users.noreply.github.com>
-  * fix(map_loader): use std::filesystem to load pcd files in pointcloud_map_loader (`#942 <https://github.com/youtalk/autoware.universe/issues/942>`_)
+  * fix(map_loader): use std::filesystem to load pcd files in pointcloud_map_loader (`#942 <https://github.com/autowarefoundation/autoware.universe/issues/942>`_)
   * fix(map_loader): use std::filesystem to load pcd files in pointcloud_map_loader
   * fix(map_loader): remove c_str
   * fix(map_loader): replace c_str to string
@@ -219,27 +219,27 @@ Changelog for package autoware_testing
   Co-authored-by: Kaan Çolak <kaancolak95@gmail.com>
   Co-authored-by: Kaan Colak <kcolak@leodrive.ai>
   Co-authored-by: Kenji Miyake <kenji.miyake@tier4.jp>
-* test(autoware_testing): fix smoke_test (`#479 <https://github.com/youtalk/autoware.universe/issues/479>`_)
+* test(autoware_testing): fix smoke_test (`#479 <https://github.com/autowarefoundation/autoware.universe/issues/479>`_)
   * fix(autoware_testing): fix smoke_test
   * restore smoke_test for trajectory_follower_nodes
   * add support multiple parameter files
   * ci(pre-commit): autofix
   * minor fix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* chore: upgrade cmake_minimum_required to 3.14 (`#856 <https://github.com/youtalk/autoware.universe/issues/856>`_)
-* refactor: use autoware cmake (`#849 <https://github.com/youtalk/autoware.universe/issues/849>`_)
+* chore: upgrade cmake_minimum_required to 3.14 (`#856 <https://github.com/autowarefoundation/autoware.universe/issues/856>`_)
+* refactor: use autoware cmake (`#849 <https://github.com/autowarefoundation/autoware.universe/issues/849>`_)
   * remove autoware_auto_cmake
   * add build_depend of autoware_cmake
   * use autoware_cmake in CMakeLists.txt
   * fix bugs
   * fix cmake lint errors
-* chore: remove license notations from CMakeLists.txt (`#846 <https://github.com/youtalk/autoware.universe/issues/846>`_)
-* chore: remove bad chars (`#845 <https://github.com/youtalk/autoware.universe/issues/845>`_)
-* docs(autoware_testing): fix link (`#741 <https://github.com/youtalk/autoware.universe/issues/741>`_)
+* chore: remove license notations from CMakeLists.txt (`#846 <https://github.com/autowarefoundation/autoware.universe/issues/846>`_)
+* chore: remove bad chars (`#845 <https://github.com/autowarefoundation/autoware.universe/issues/845>`_)
+* docs(autoware_testing): fix link (`#741 <https://github.com/autowarefoundation/autoware.universe/issues/741>`_)
   * docs(autoware_testing): fix link
   * fix typo
   Co-authored-by: Kenji Miyake <31987104+kenji-miyake@users.noreply.github.com>
-* ci(pre-commit): clear the exclude option (`#426 <https://github.com/youtalk/autoware.universe/issues/426>`_)
+* ci(pre-commit): clear the exclude option (`#426 <https://github.com/autowarefoundation/autoware.universe/issues/426>`_)
   * ci(pre-commit): remove unnecessary excludes
   * ci(pre-commit): autofix
   * ci(pre-commit): autofix
@@ -251,60 +251,60 @@ Changelog for package autoware_testing
   * fix build
   * use autoware_lint_common
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat: add autoware auto dependencies (`#185 <https://github.com/youtalk/autoware.universe/issues/185>`_)
-  * Back port .auto control packages (`#571 <https://github.com/youtalk/autoware.universe/issues/571>`_)
+* feat: add autoware auto dependencies (`#185 <https://github.com/autowarefoundation/autoware.universe/issues/185>`_)
+  * Back port .auto control packages (`#571 <https://github.com/autowarefoundation/autoware.universe/issues/571>`_)
   * Implement Lateral and Longitudinal Control Muxer
-  * [`#570 <https://github.com/youtalk/autoware.universe/issues/570>`_] Porting wf_simulator
-  * [`#1189 <https://github.com/youtalk/autoware.universe/issues/1189>`_] Deactivate flaky test in 'trajectory_follower_nodes'
-  * [`#1189 <https://github.com/youtalk/autoware.universe/issues/1189>`_] Fix flacky test in 'trajectory_follower_nodes/latlon_muxer'
-  * [`#1057 <https://github.com/youtalk/autoware.universe/issues/1057>`_] Add osqp_interface package
-  * [`#1057 <https://github.com/youtalk/autoware.universe/issues/1057>`_] Add library code for MPC-based lateral control
-  * [`#1271 <https://github.com/youtalk/autoware.universe/issues/1271>`_] Use std::abs instead of abs
-  * [`#1057 <https://github.com/youtalk/autoware.universe/issues/1057>`_] Implement Lateral Controller for Cargo ODD
-  * [`#1246 <https://github.com/youtalk/autoware.universe/issues/1246>`_] Resolve "Test case names currently use snake_case but should be CamelCase"
-  * [`#1325 <https://github.com/youtalk/autoware.universe/issues/1325>`_] Deactivate flaky smoke test in 'trajectory_follower_nodes'
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Add library code of longitudinal controller
+  * [`#570 <https://github.com/autowarefoundation/autoware.universe/issues/570>`_] Porting wf_simulator
+  * [`#1189 <https://github.com/autowarefoundation/autoware.universe/issues/1189>`_] Deactivate flaky test in 'trajectory_follower_nodes'
+  * [`#1189 <https://github.com/autowarefoundation/autoware.universe/issues/1189>`_] Fix flacky test in 'trajectory_follower_nodes/latlon_muxer'
+  * [`#1057 <https://github.com/autowarefoundation/autoware.universe/issues/1057>`_] Add osqp_interface package
+  * [`#1057 <https://github.com/autowarefoundation/autoware.universe/issues/1057>`_] Add library code for MPC-based lateral control
+  * [`#1271 <https://github.com/autowarefoundation/autoware.universe/issues/1271>`_] Use std::abs instead of abs
+  * [`#1057 <https://github.com/autowarefoundation/autoware.universe/issues/1057>`_] Implement Lateral Controller for Cargo ODD
+  * [`#1246 <https://github.com/autowarefoundation/autoware.universe/issues/1246>`_] Resolve "Test case names currently use snake_case but should be CamelCase"
+  * [`#1325 <https://github.com/autowarefoundation/autoware.universe/issues/1325>`_] Deactivate flaky smoke test in 'trajectory_follower_nodes'
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Add library code of longitudinal controller
   * Fix build error for trajectory follower
   * Fix build error for trajectory follower nodes
-  * [`#1272 <https://github.com/youtalk/autoware.universe/issues/1272>`_] Add AckermannControlCommand support to simple_planning_simulator
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Add Longitudinal Controller node
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Rename velocity_controller -> longitudinal_controller
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Update CMakeLists.txt for the longitudinal_controller_node
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Add smoke test python launch file
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Use LowPassFilter1d from trajectory_follower
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Use autoware_auto_msgs
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Changes for .auto (debug msg tmp fix, common func, tf listener)
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Remove unused parameters
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Fix ros test
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Rm default params from declare_parameters + use autoware types
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Use default param file to setup NodeOptions in the ros test
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Fix docstring
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Replace receiving a Twist with a VehicleKinematicState
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Change class variables format to m\_ prefix
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Fix plugin name of LongitudinalController in CMakeLists.txt
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Fix copyright dates
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Reorder includes
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Add some tests (~89% coverage without disabling flaky tests)
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Add more tests (90+% coverage without disabling flaky tests)
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Use Float32MultiArrayDiagnostic message for debug and slope
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Calculate wheel_base value from vehicle parameters
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Cleanup redundant logger setting in tests
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Set ROS_DOMAIN_ID when running tests to prevent CI failures
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Remove TF listener and use published vehicle state instead
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Change smoke tests to use autoware_testing
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Add plotjuggler cfg for both lateral and longitudinal control
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Improve design documents
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Disable flaky test
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Properly transform vehicle state in longitudinal node
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Fix TF buffer of lateral controller
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Tuning of lateral controller for LGSVL
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Fix formating
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Fix /tf_static sub to be transient_local
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Fix yaw recalculation of reverse trajs in the lateral controller
+  * [`#1272 <https://github.com/autowarefoundation/autoware.universe/issues/1272>`_] Add AckermannControlCommand support to simple_planning_simulator
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Add Longitudinal Controller node
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Rename velocity_controller -> longitudinal_controller
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Update CMakeLists.txt for the longitudinal_controller_node
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Add smoke test python launch file
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Use LowPassFilter1d from trajectory_follower
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Use autoware_auto_msgs
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Changes for .auto (debug msg tmp fix, common func, tf listener)
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Remove unused parameters
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Fix ros test
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Rm default params from declare_parameters + use autoware types
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Use default param file to setup NodeOptions in the ros test
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Fix docstring
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Replace receiving a Twist with a VehicleKinematicState
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Change class variables format to m\_ prefix
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Fix plugin name of LongitudinalController in CMakeLists.txt
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Fix copyright dates
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Reorder includes
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Add some tests (~89% coverage without disabling flaky tests)
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Add more tests (90+% coverage without disabling flaky tests)
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Use Float32MultiArrayDiagnostic message for debug and slope
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Calculate wheel_base value from vehicle parameters
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Cleanup redundant logger setting in tests
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Set ROS_DOMAIN_ID when running tests to prevent CI failures
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Remove TF listener and use published vehicle state instead
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Change smoke tests to use autoware_testing
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Add plotjuggler cfg for both lateral and longitudinal control
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Improve design documents
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Disable flaky test
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Properly transform vehicle state in longitudinal node
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Fix TF buffer of lateral controller
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Tuning of lateral controller for LGSVL
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Fix formating
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Fix /tf_static sub to be transient_local
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Fix yaw recalculation of reverse trajs in the lateral controller
   * modify trajectory_follower for galactic build
-  * [`#1379 <https://github.com/youtalk/autoware.universe/issues/1379>`_] Update trajectory_follower
-  * [`#1379 <https://github.com/youtalk/autoware.universe/issues/1379>`_] Update simple_planning_simulator
-  * [`#1379 <https://github.com/youtalk/autoware.universe/issues/1379>`_] Update trajectory_follower_nodes
+  * [`#1379 <https://github.com/autowarefoundation/autoware.universe/issues/1379>`_] Update trajectory_follower
+  * [`#1379 <https://github.com/autowarefoundation/autoware.universe/issues/1379>`_] Update simple_planning_simulator
+  * [`#1379 <https://github.com/autowarefoundation/autoware.universe/issues/1379>`_] Update trajectory_follower_nodes
   * apply trajectory msg modification in control
   * move directory
   * remote control/trajectory_follower level dorectpry
@@ -328,7 +328,7 @@ Changelog for package autoware_testing
   Co-authored-by: MIURA Yasuyuki <kokosabu@gmail.com>
   Co-authored-by: wep21 <border_goldenmarket@yahoo.co.jp>
   Co-authored-by: tomoya.kimura <tomoya.kimura@tier4.jp>
-  * Port parking planner packages from .Auto (`#600 <https://github.com/youtalk/autoware.universe/issues/600>`_)
+  * Port parking planner packages from .Auto (`#600 <https://github.com/autowarefoundation/autoware.universe/issues/600>`_)
   * Copy code of 'vehicle_constants_manager'
   * Fix vehicle_constants_manager for ROS galactic
   * Rm .iv costmap_generator freespace_planner freespace_planning_aglorihtms

--- a/common/autoware_time_utils/CHANGELOG.rst
+++ b/common/autoware_time_utils/CHANGELOG.rst
@@ -5,19 +5,19 @@ Changelog for package time_utils
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* fix(time_utils): fix unusedFunction (`#8606 <https://github.com/youtalk/autoware.universe/issues/8606>`_)
+* fix(time_utils): fix unusedFunction (`#8606 <https://github.com/autowarefoundation/autoware.universe/issues/8606>`_)
   fix:unusedFunction
 * Contributors: Yutaka Kondo, kobayu858
 
 0.26.0 (2024-04-03)
 -------------------
-* chore: add maintainer (`#4234 <https://github.com/youtalk/autoware.universe/issues/4234>`_)
+* chore: add maintainer (`#4234 <https://github.com/autowarefoundation/autoware.universe/issues/4234>`_)
   * chore: add maintainer
   * Update evaluator/localization_evaluator/package.xml
   Co-authored-by: kminoda <44218668+kminoda@users.noreply.github.com>
   ---------
   Co-authored-by: kminoda <44218668+kminoda@users.noreply.github.com>
-* build: mark autoware_cmake as <buildtool_depend> (`#3616 <https://github.com/youtalk/autoware.universe/issues/3616>`_)
+* build: mark autoware_cmake as <buildtool_depend> (`#3616 <https://github.com/autowarefoundation/autoware.universe/issues/3616>`_)
   * build: mark autoware_cmake as <buildtool_depend>
   with <build_depend>, autoware_cmake is automatically exported with ament_target_dependencies() (unecessary)
   * style(pre-commit): autofix
@@ -25,16 +25,16 @@ Changelog for package time_utils
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Kenji Miyake <kenji.miyake@tier4.jp>
-* feat: isolate gtests in all packages (`#693 <https://github.com/youtalk/autoware.universe/issues/693>`_)
-* chore: upgrade cmake_minimum_required to 3.14 (`#856 <https://github.com/youtalk/autoware.universe/issues/856>`_)
-* refactor: use autoware cmake (`#849 <https://github.com/youtalk/autoware.universe/issues/849>`_)
+* feat: isolate gtests in all packages (`#693 <https://github.com/autowarefoundation/autoware.universe/issues/693>`_)
+* chore: upgrade cmake_minimum_required to 3.14 (`#856 <https://github.com/autowarefoundation/autoware.universe/issues/856>`_)
+* refactor: use autoware cmake (`#849 <https://github.com/autowarefoundation/autoware.universe/issues/849>`_)
   * remove autoware_auto_cmake
   * add build_depend of autoware_cmake
   * use autoware_cmake in CMakeLists.txt
   * fix bugs
   * fix cmake lint errors
-* style: fix format of package.xml (`#844 <https://github.com/youtalk/autoware.universe/issues/844>`_)
-* ci(pre-commit): clear the exclude option (`#426 <https://github.com/youtalk/autoware.universe/issues/426>`_)
+* style: fix format of package.xml (`#844 <https://github.com/autowarefoundation/autoware.universe/issues/844>`_)
+* ci(pre-commit): clear the exclude option (`#426 <https://github.com/autowarefoundation/autoware.universe/issues/426>`_)
   * ci(pre-commit): remove unnecessary excludes
   * ci(pre-commit): autofix
   * ci(pre-commit): autofix
@@ -46,60 +46,60 @@ Changelog for package time_utils
   * fix build
   * use autoware_lint_common
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat: add autoware auto dependencies (`#185 <https://github.com/youtalk/autoware.universe/issues/185>`_)
-  * Back port .auto control packages (`#571 <https://github.com/youtalk/autoware.universe/issues/571>`_)
+* feat: add autoware auto dependencies (`#185 <https://github.com/autowarefoundation/autoware.universe/issues/185>`_)
+  * Back port .auto control packages (`#571 <https://github.com/autowarefoundation/autoware.universe/issues/571>`_)
   * Implement Lateral and Longitudinal Control Muxer
-  * [`#570 <https://github.com/youtalk/autoware.universe/issues/570>`_] Porting wf_simulator
-  * [`#1189 <https://github.com/youtalk/autoware.universe/issues/1189>`_] Deactivate flaky test in 'trajectory_follower_nodes'
-  * [`#1189 <https://github.com/youtalk/autoware.universe/issues/1189>`_] Fix flacky test in 'trajectory_follower_nodes/latlon_muxer'
-  * [`#1057 <https://github.com/youtalk/autoware.universe/issues/1057>`_] Add osqp_interface package
-  * [`#1057 <https://github.com/youtalk/autoware.universe/issues/1057>`_] Add library code for MPC-based lateral control
-  * [`#1271 <https://github.com/youtalk/autoware.universe/issues/1271>`_] Use std::abs instead of abs
-  * [`#1057 <https://github.com/youtalk/autoware.universe/issues/1057>`_] Implement Lateral Controller for Cargo ODD
-  * [`#1246 <https://github.com/youtalk/autoware.universe/issues/1246>`_] Resolve "Test case names currently use snake_case but should be CamelCase"
-  * [`#1325 <https://github.com/youtalk/autoware.universe/issues/1325>`_] Deactivate flaky smoke test in 'trajectory_follower_nodes'
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Add library code of longitudinal controller
+  * [`#570 <https://github.com/autowarefoundation/autoware.universe/issues/570>`_] Porting wf_simulator
+  * [`#1189 <https://github.com/autowarefoundation/autoware.universe/issues/1189>`_] Deactivate flaky test in 'trajectory_follower_nodes'
+  * [`#1189 <https://github.com/autowarefoundation/autoware.universe/issues/1189>`_] Fix flacky test in 'trajectory_follower_nodes/latlon_muxer'
+  * [`#1057 <https://github.com/autowarefoundation/autoware.universe/issues/1057>`_] Add osqp_interface package
+  * [`#1057 <https://github.com/autowarefoundation/autoware.universe/issues/1057>`_] Add library code for MPC-based lateral control
+  * [`#1271 <https://github.com/autowarefoundation/autoware.universe/issues/1271>`_] Use std::abs instead of abs
+  * [`#1057 <https://github.com/autowarefoundation/autoware.universe/issues/1057>`_] Implement Lateral Controller for Cargo ODD
+  * [`#1246 <https://github.com/autowarefoundation/autoware.universe/issues/1246>`_] Resolve "Test case names currently use snake_case but should be CamelCase"
+  * [`#1325 <https://github.com/autowarefoundation/autoware.universe/issues/1325>`_] Deactivate flaky smoke test in 'trajectory_follower_nodes'
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Add library code of longitudinal controller
   * Fix build error for trajectory follower
   * Fix build error for trajectory follower nodes
-  * [`#1272 <https://github.com/youtalk/autoware.universe/issues/1272>`_] Add AckermannControlCommand support to simple_planning_simulator
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Add Longitudinal Controller node
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Rename velocity_controller -> longitudinal_controller
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Update CMakeLists.txt for the longitudinal_controller_node
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Add smoke test python launch file
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Use LowPassFilter1d from trajectory_follower
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Use autoware_auto_msgs
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Changes for .auto (debug msg tmp fix, common func, tf listener)
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Remove unused parameters
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Fix ros test
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Rm default params from declare_parameters + use autoware types
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Use default param file to setup NodeOptions in the ros test
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Fix docstring
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Replace receiving a Twist with a VehicleKinematicState
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Change class variables format to m\_ prefix
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Fix plugin name of LongitudinalController in CMakeLists.txt
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Fix copyright dates
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Reorder includes
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Add some tests (~89% coverage without disabling flaky tests)
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Add more tests (90+% coverage without disabling flaky tests)
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Use Float32MultiArrayDiagnostic message for debug and slope
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Calculate wheel_base value from vehicle parameters
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Cleanup redundant logger setting in tests
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Set ROS_DOMAIN_ID when running tests to prevent CI failures
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Remove TF listener and use published vehicle state instead
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Change smoke tests to use autoware_testing
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Add plotjuggler cfg for both lateral and longitudinal control
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Improve design documents
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Disable flaky test
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Properly transform vehicle state in longitudinal node
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Fix TF buffer of lateral controller
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Tuning of lateral controller for LGSVL
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Fix formating
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Fix /tf_static sub to be transient_local
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Fix yaw recalculation of reverse trajs in the lateral controller
+  * [`#1272 <https://github.com/autowarefoundation/autoware.universe/issues/1272>`_] Add AckermannControlCommand support to simple_planning_simulator
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Add Longitudinal Controller node
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Rename velocity_controller -> longitudinal_controller
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Update CMakeLists.txt for the longitudinal_controller_node
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Add smoke test python launch file
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Use LowPassFilter1d from trajectory_follower
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Use autoware_auto_msgs
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Changes for .auto (debug msg tmp fix, common func, tf listener)
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Remove unused parameters
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Fix ros test
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Rm default params from declare_parameters + use autoware types
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Use default param file to setup NodeOptions in the ros test
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Fix docstring
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Replace receiving a Twist with a VehicleKinematicState
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Change class variables format to m\_ prefix
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Fix plugin name of LongitudinalController in CMakeLists.txt
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Fix copyright dates
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Reorder includes
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Add some tests (~89% coverage without disabling flaky tests)
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Add more tests (90+% coverage without disabling flaky tests)
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Use Float32MultiArrayDiagnostic message for debug and slope
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Calculate wheel_base value from vehicle parameters
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Cleanup redundant logger setting in tests
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Set ROS_DOMAIN_ID when running tests to prevent CI failures
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Remove TF listener and use published vehicle state instead
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Change smoke tests to use autoware_testing
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Add plotjuggler cfg for both lateral and longitudinal control
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Improve design documents
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Disable flaky test
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Properly transform vehicle state in longitudinal node
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Fix TF buffer of lateral controller
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Tuning of lateral controller for LGSVL
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Fix formating
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Fix /tf_static sub to be transient_local
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Fix yaw recalculation of reverse trajs in the lateral controller
   * modify trajectory_follower for galactic build
-  * [`#1379 <https://github.com/youtalk/autoware.universe/issues/1379>`_] Update trajectory_follower
-  * [`#1379 <https://github.com/youtalk/autoware.universe/issues/1379>`_] Update simple_planning_simulator
-  * [`#1379 <https://github.com/youtalk/autoware.universe/issues/1379>`_] Update trajectory_follower_nodes
+  * [`#1379 <https://github.com/autowarefoundation/autoware.universe/issues/1379>`_] Update trajectory_follower
+  * [`#1379 <https://github.com/autowarefoundation/autoware.universe/issues/1379>`_] Update simple_planning_simulator
+  * [`#1379 <https://github.com/autowarefoundation/autoware.universe/issues/1379>`_] Update trajectory_follower_nodes
   * apply trajectory msg modification in control
   * move directory
   * remote control/trajectory_follower level dorectpry
@@ -123,7 +123,7 @@ Changelog for package time_utils
   Co-authored-by: MIURA Yasuyuki <kokosabu@gmail.com>
   Co-authored-by: wep21 <border_goldenmarket@yahoo.co.jp>
   Co-authored-by: tomoya.kimura <tomoya.kimura@tier4.jp>
-  * Port parking planner packages from .Auto (`#600 <https://github.com/youtalk/autoware.universe/issues/600>`_)
+  * Port parking planner packages from .Auto (`#600 <https://github.com/autowarefoundation/autoware.universe/issues/600>`_)
   * Copy code of 'vehicle_constants_manager'
   * Fix vehicle_constants_manager for ROS galactic
   * Rm .iv costmap_generator freespace_planner freespace_planning_aglorihtms

--- a/common/autoware_universe_utils/CHANGELOG.rst
+++ b/common/autoware_universe_utils/CHANGELOG.rst
@@ -5,7 +5,7 @@ Changelog for package autoware_universe_utils
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* feat(autoware_pointcloud_preprocessor): distortion corrector node update azimuth and distance (`#8380 <https://github.com/youtalk/autoware.universe/issues/8380>`_)
+* feat(autoware_pointcloud_preprocessor): distortion corrector node update azimuth and distance (`#8380 <https://github.com/autowarefoundation/autoware.universe/issues/8380>`_)
   * feat: add option for updating distance and azimuth value
   * chore: clean code
   * chore: remove space
@@ -101,18 +101,18 @@ Changelog for package autoware_universe_utils
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Max Schmeller <6088931+mojomex@users.noreply.github.com>
   Co-authored-by: Kenzo Lobos Tsunekawa <kenzo.lobos@tier4.jp>
-* fix(universe_utils): avoid test timeout (`#8993 <https://github.com/youtalk/autoware.universe/issues/8993>`_)
+* fix(universe_utils): avoid test timeout (`#8993 <https://github.com/autowarefoundation/autoware.universe/issues/8993>`_)
   reduce number of polygons to be generated
-* fix(autoware_universe_utils): fix unmatchedSuppression (`#8986 <https://github.com/youtalk/autoware.universe/issues/8986>`_)
+* fix(autoware_universe_utils): fix unmatchedSuppression (`#8986 <https://github.com/autowarefoundation/autoware.universe/issues/8986>`_)
   fix:unmatchedSuppression
-* refactor(universe_utils): eliminate dependence on Boost.Geometry (`#8965 <https://github.com/youtalk/autoware.universe/issues/8965>`_)
+* refactor(universe_utils): eliminate dependence on Boost.Geometry (`#8965 <https://github.com/autowarefoundation/autoware.universe/issues/8965>`_)
   * add alt::Polygon2d -> Polygon2d conversion function
   * migrate to alt geometry
   * invert orientation of linked list
   * suppress cppcheck unusedFunction error
   * fix parameter to avoid confusion
   ---------
-* feat(autoware_universe_utils): reduce dependence on Boost.Geometry (`#8592 <https://github.com/youtalk/autoware.universe/issues/8592>`_)
+* feat(autoware_universe_utils): reduce dependence on Boost.Geometry (`#8592 <https://github.com/autowarefoundation/autoware.universe/issues/8592>`_)
   * add find_farthest()
   * add simplify()
   * add envelope()
@@ -126,9 +126,9 @@ Changelog for package autoware_universe_utils
   * Revert "(WIP) add buffer()"
   This reverts commit 123b0ba85ede5e558431a4336038c14023d1bef1.
   ---------
-* refactor(universe_utils): remove raw pointers from the triangulation function (`#8893 <https://github.com/youtalk/autoware.universe/issues/8893>`_)
-* fix(autoware_pointcloud_preprocessor): static TF listener as Filter option (`#8678 <https://github.com/youtalk/autoware.universe/issues/8678>`_)
-* feat(universe_utils): add Triangulation (ear clipping) implementation for 2D concave polygon with/without holes (`#8609 <https://github.com/youtalk/autoware.universe/issues/8609>`_)
+* refactor(universe_utils): remove raw pointers from the triangulation function (`#8893 <https://github.com/autowarefoundation/autoware.universe/issues/8893>`_)
+* fix(autoware_pointcloud_preprocessor): static TF listener as Filter option (`#8678 <https://github.com/autowarefoundation/autoware.universe/issues/8678>`_)
+* feat(universe_utils): add Triangulation (ear clipping) implementation for 2D concave polygon with/without holes (`#8609 <https://github.com/autowarefoundation/autoware.universe/issues/8609>`_)
   * added random_concave_polygon and triangulation
   * disable some test with GJK
   * pre-commit fix
@@ -143,23 +143,23 @@ Changelog for package autoware_universe_utils
   * more spellcheck fixes
   ---------
   Co-authored-by: Maxime CLEMENT <maxime.clement@tier4.jp>
-* refactor(autoware_universe_utils): refactor Boost.Geometry alternatives (`#8594 <https://github.com/youtalk/autoware.universe/issues/8594>`_)
+* refactor(autoware_universe_utils): refactor Boost.Geometry alternatives (`#8594 <https://github.com/autowarefoundation/autoware.universe/issues/8594>`_)
   * move alternatives to separate files
   * style(pre-commit): autofix
   * include missing headers
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* fix(autoware_universe_utils): fix unusedFunction (`#8723 <https://github.com/youtalk/autoware.universe/issues/8723>`_)
+* fix(autoware_universe_utils): fix unusedFunction (`#8723 <https://github.com/autowarefoundation/autoware.universe/issues/8723>`_)
   fix:unusedFunction
-* feat(universe_utils): add SAT implementation for 2D convex polygon collision check (`#8239 <https://github.com/youtalk/autoware.universe/issues/8239>`_)
-* feat(autoware_universe_utils): add thread_id check to time_keeper (`#8628 <https://github.com/youtalk/autoware.universe/issues/8628>`_)
+* feat(universe_utils): add SAT implementation for 2D convex polygon collision check (`#8239 <https://github.com/autowarefoundation/autoware.universe/issues/8239>`_)
+* feat(autoware_universe_utils): add thread_id check to time_keeper (`#8628 <https://github.com/autowarefoundation/autoware.universe/issues/8628>`_)
   add thread_id check
-* fix(autoware_universe_utils): fix unusedFunction (`#8521 <https://github.com/youtalk/autoware.universe/issues/8521>`_)
+* fix(autoware_universe_utils): fix unusedFunction (`#8521 <https://github.com/autowarefoundation/autoware.universe/issues/8521>`_)
   fix: unusedFunction
-* feat(autoware_universe_utils): add LRU Cache (`#8456 <https://github.com/youtalk/autoware.universe/issues/8456>`_)
-* fix(autoware_universe_utils): fix memory leak of time_keeper (`#8425 <https://github.com/youtalk/autoware.universe/issues/8425>`_)
+* feat(autoware_universe_utils): add LRU Cache (`#8456 <https://github.com/autowarefoundation/autoware.universe/issues/8456>`_)
+* fix(autoware_universe_utils): fix memory leak of time_keeper (`#8425 <https://github.com/autowarefoundation/autoware.universe/issues/8425>`_)
   fix bug of time_keeper
-* feat(autoware_universe_utils): reduce dependence on Boost.Geometry (`#7778 <https://github.com/youtalk/autoware.universe/issues/7778>`_)
+* feat(autoware_universe_utils): reduce dependence on Boost.Geometry (`#7778 <https://github.com/autowarefoundation/autoware.universe/issues/7778>`_)
   * add within function
   * return nullopt as is
   * add disjoint function
@@ -222,13 +222,13 @@ Changelog for package autoware_universe_utils
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Satoshi OTA <44889564+satoshi-ota@users.noreply.github.com>
-* fix(autoware_universe_utils): fix constParameterReference (`#8145 <https://github.com/youtalk/autoware.universe/issues/8145>`_)
+* fix(autoware_universe_utils): fix constParameterReference (`#8145 <https://github.com/autowarefoundation/autoware.universe/issues/8145>`_)
   * fix:constParameterReference
   * fix:clang format
   * fix:constParameterReference
   * fix:clang format
   ---------
-* perf(autoware_pointcloud_preprocessor): lazy & managed TF listeners (`#8174 <https://github.com/youtalk/autoware.universe/issues/8174>`_)
+* perf(autoware_pointcloud_preprocessor): lazy & managed TF listeners (`#8174 <https://github.com/autowarefoundation/autoware.universe/issues/8174>`_)
   * perf(autoware_pointcloud_preprocessor): lazy & managed TF listeners
   * fix(autoware_pointcloud_preprocessor): param names & reverse frames transform logic
   * fix(autoware_ground_segmentation): add missing TF listener
@@ -238,7 +238,7 @@ Changelog for package autoware_universe_utils
   * fix(autoware_universe_utils): change checks order
   * doc(autoware_universe_utils): add docstring
   ---------
-* refactor(autoware_universe_utils): changed the API to be more intuitive and added documentation (`#7443 <https://github.com/youtalk/autoware.universe/issues/7443>`_)
+* refactor(autoware_universe_utils): changed the API to be more intuitive and added documentation (`#7443 <https://github.com/autowarefoundation/autoware.universe/issues/7443>`_)
   * refactor(tier4_autoware_utils): Changed the API to be more intuitive and added documentation.
   * use raw shared ptr in PollingPolicy::NEWEST
   * update
@@ -247,8 +247,8 @@ Changelog for package autoware_universe_utils
   Co-authored-by: danielsanchezaran <daniel.sanchez@tier4.jp>
   ---------
   Co-authored-by: danielsanchezaran <daniel.sanchez@tier4.jp>
-* feat(universe_utils): add GJK implementation for 2D convex polygon collision check (`#7853 <https://github.com/youtalk/autoware.universe/issues/7853>`_)
-* feat(autoware_universe_utils): add comment function to time_keeper (`#7991 <https://github.com/youtalk/autoware.universe/issues/7991>`_)
+* feat(universe_utils): add GJK implementation for 2D convex polygon collision check (`#7853 <https://github.com/autowarefoundation/autoware.universe/issues/7853>`_)
+* feat(autoware_universe_utils): add comment function to time_keeper (`#7991 <https://github.com/autowarefoundation/autoware.universe/issues/7991>`_)
   * update readme
   * refactoring
   * remove string reporter
@@ -257,7 +257,7 @@ Changelog for package autoware_universe_utils
   * remove comment from scoped time track
   * modify readme
   ---------
-* chore(autoware_universe_utils): update document (`#7907 <https://github.com/youtalk/autoware.universe/issues/7907>`_)
+* chore(autoware_universe_utils): update document (`#7907 <https://github.com/autowarefoundation/autoware.universe/issues/7907>`_)
   * update readme
   * refactoring
   * remove string reporter
@@ -265,13 +265,13 @@ Changelog for package autoware_universe_utils
   * change node name of example
   * update readme
   ---------
-* fix(autoware_universe_utils): fix constParameterReference (`#7882 <https://github.com/youtalk/autoware.universe/issues/7882>`_)
+* fix(autoware_universe_utils): fix constParameterReference (`#7882 <https://github.com/autowarefoundation/autoware.universe/issues/7882>`_)
   * fix: constParameterReference
   * fix: constParameterReference
   ---------
-* feat(autoware_universe_utils): add TimeKeeper to track function's processing time (`#7754 <https://github.com/youtalk/autoware.universe/issues/7754>`_)
-* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/youtalk/autoware.universe/issues/7594>`_)
-* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/youtalk/autoware.universe/issues/7538>`_)
+* feat(autoware_universe_utils): add TimeKeeper to track function's processing time (`#7754 <https://github.com/autowarefoundation/autoware.universe/issues/7754>`_)
+* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/autowarefoundation/autoware.universe/issues/7594>`_)
+* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/autowarefoundation/autoware.universe/issues/7538>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
 * Contributors: Amadeusz Szymko, Giovanni Muhammad Raditya, Kosuke Takeuchi, Maxime CLEMENT, Mitsuhiro Sakamoto, Nagi70, Takayuki Murooka, Yi-Hsiang Fang (Vivid), Yukinari Hisaki, Yutaka Kondo, kobayu858
 

--- a/common/autoware_vehicle_info_utils/CHANGELOG.rst
+++ b/common/autoware_vehicle_info_utils/CHANGELOG.rst
@@ -5,8 +5,8 @@ Changelog for package autoware_vehicle_info_utils
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* refactor(vehicle_info): add API description, add owner (`#9151 <https://github.com/youtalk/autoware.universe/issues/9151>`_)
-* chore(autoware_vehicle_info_utils): move package to common directory (`#8708 <https://github.com/youtalk/autoware.universe/issues/8708>`_)
+* refactor(vehicle_info): add API description, add owner (`#9151 <https://github.com/autowarefoundation/autoware.universe/issues/9151>`_)
+* chore(autoware_vehicle_info_utils): move package to common directory (`#8708 <https://github.com/autowarefoundation/autoware.universe/issues/8708>`_)
 * Contributors: Mamoru Sobue, Ryohsuke Mitsudome, Yutaka Kondo
 
 0.26.0 (2024-04-03)

--- a/common/bag_time_manager_rviz_plugin/CHANGELOG.rst
+++ b/common/bag_time_manager_rviz_plugin/CHANGELOG.rst
@@ -9,8 +9,8 @@ Changelog for package bag_time_manager_rviz_plugin
 
 0.26.0 (2024-04-03)
 -------------------
-* build(iron): remove rmw_qos_profile_t (`#3809 <https://github.com/youtalk/autoware.universe/issues/3809>`_)
-* build: mark autoware_cmake as <buildtool_depend> (`#3616 <https://github.com/youtalk/autoware.universe/issues/3616>`_)
+* build(iron): remove rmw_qos_profile_t (`#3809 <https://github.com/autowarefoundation/autoware.universe/issues/3809>`_)
+* build: mark autoware_cmake as <buildtool_depend> (`#3616 <https://github.com/autowarefoundation/autoware.universe/issues/3616>`_)
   * build: mark autoware_cmake as <buildtool_depend>
   with <build_depend>, autoware_cmake is automatically exported with ament_target_dependencies() (unecessary)
   * style(pre-commit): autofix
@@ -18,9 +18,9 @@ Changelog for package bag_time_manager_rviz_plugin
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Kenji Miyake <kenji.miyake@tier4.jp>
-* fix(bag_time_manager_rviz_plugin): update create_client API to use rc… (`#2783 <https://github.com/youtalk/autoware.universe/issues/2783>`_)
+* fix(bag_time_manager_rviz_plugin): update create_client API to use rc… (`#2783 <https://github.com/autowarefoundation/autoware.universe/issues/2783>`_)
   * fix(bag_time_manager_rviz_plugin): update create_client API to use rclcpp::QoS
-* feat(bag_time_manager_rviz_plugin): add bag time manager rviz plugin (`#1776 <https://github.com/youtalk/autoware.universe/issues/1776>`_)
+* feat(bag_time_manager_rviz_plugin): add bag time manager rviz plugin (`#1776 <https://github.com/autowarefoundation/autoware.universe/issues/1776>`_)
   * feat(bag_timemanager): add bag time manager rviz plugin
   * fix: fix change
 * Contributors: Daisuke Nishimatsu, Esteve Fernandez, Vincent Richard, taikitanaka3

--- a/common/fake_test_node/CHANGELOG.rst
+++ b/common/fake_test_node/CHANGELOG.rst
@@ -5,12 +5,12 @@ Changelog for package fake_test_node
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* fix(fake_test_node, osqp_interface, qp_interface): remove unnecessary cppcheck inline suppressions (`#7855 <https://github.com/youtalk/autoware.universe/issues/7855>`_)
+* fix(fake_test_node, osqp_interface, qp_interface): remove unnecessary cppcheck inline suppressions (`#7855 <https://github.com/autowarefoundation/autoware.universe/issues/7855>`_)
   * fix(fake_test_node, osqp_interface, qp_interface): remove unnecessary cppcheck inline suppressions
   * style(pre-commit): autofix
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat!: replace autoware_auto_msgs with autoware_msgs for common modules (`#7239 <https://github.com/youtalk/autoware.universe/issues/7239>`_)
+* feat!: replace autoware_auto_msgs with autoware_msgs for common modules (`#7239 <https://github.com/autowarefoundation/autoware.universe/issues/7239>`_)
   Co-authored-by: Cynthia Liu <cynthia.liu@autocore.ai>
   Co-authored-by: NorahXiong <norah.xiong@autocore.ai>
   Co-authored-by: beginningfan <beginning.fan@autocore.ai>
@@ -18,18 +18,18 @@ Changelog for package fake_test_node
 
 0.26.0 (2024-04-03)
 -------------------
-* fix(autoware_auto_common): move headers to a separate directory (`#5919 <https://github.com/youtalk/autoware.universe/issues/5919>`_)
+* fix(autoware_auto_common): move headers to a separate directory (`#5919 <https://github.com/autowarefoundation/autoware.universe/issues/5919>`_)
   * fix(autoware_auto_common): move headers to a separate directory
   * style(pre-commit): autofix
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* chore: add maintainer (`#4234 <https://github.com/youtalk/autoware.universe/issues/4234>`_)
+* chore: add maintainer (`#4234 <https://github.com/autowarefoundation/autoware.universe/issues/4234>`_)
   * chore: add maintainer
   * Update evaluator/localization_evaluator/package.xml
   Co-authored-by: kminoda <44218668+kminoda@users.noreply.github.com>
   ---------
   Co-authored-by: kminoda <44218668+kminoda@users.noreply.github.com>
-* build: mark autoware_cmake as <buildtool_depend> (`#3616 <https://github.com/youtalk/autoware.universe/issues/3616>`_)
+* build: mark autoware_cmake as <buildtool_depend> (`#3616 <https://github.com/autowarefoundation/autoware.universe/issues/3616>`_)
   * build: mark autoware_cmake as <buildtool_depend>
   with <build_depend>, autoware_cmake is automatically exported with ament_target_dependencies() (unecessary)
   * style(pre-commit): autofix
@@ -37,50 +37,50 @@ Changelog for package fake_test_node
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Kenji Miyake <kenji.miyake@tier4.jp>
-* chore: sync files (`#3227 <https://github.com/youtalk/autoware.universe/issues/3227>`_)
+* chore: sync files (`#3227 <https://github.com/autowarefoundation/autoware.universe/issues/3227>`_)
   * chore: sync files
   * style(pre-commit): autofix
   ---------
   Co-authored-by: kenji-miyake <kenji-miyake@users.noreply.github.com>
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* docs: update link style and fix typos (`#950 <https://github.com/youtalk/autoware.universe/issues/950>`_)
-  * feat(state_rviz_plugin): add GateMode and PathChangeApproval Button (`#894 <https://github.com/youtalk/autoware.universe/issues/894>`_)
+* docs: update link style and fix typos (`#950 <https://github.com/autowarefoundation/autoware.universe/issues/950>`_)
+  * feat(state_rviz_plugin): add GateMode and PathChangeApproval Button (`#894 <https://github.com/autowarefoundation/autoware.universe/issues/894>`_)
   * feat(state_rviz_plugin): add GateMode and PathChangeApproval Button
   * ci(pre-commit): autofix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   * docs: update link style
   * chore: fix link
-  * feat(map_tf_generator): accelerate the 'viewer' coordinate calculation (`#890 <https://github.com/youtalk/autoware.universe/issues/890>`_)
+  * feat(map_tf_generator): accelerate the 'viewer' coordinate calculation (`#890 <https://github.com/autowarefoundation/autoware.universe/issues/890>`_)
   * add random point sampling function to quickly calculate the 'viewer' coordinate
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Kenji Miyake <31987104+kenji-miyake@users.noreply.github.com>
-  * docs(obstacle_stop_planner): update documentation (`#880 <https://github.com/youtalk/autoware.universe/issues/880>`_)
-  * docs(tier4_traffic_light_rviz_plugin): update documentation (`#905 <https://github.com/youtalk/autoware.universe/issues/905>`_)
-  * fix(accel_brake_map_calibrator): rviz panel type (`#895 <https://github.com/youtalk/autoware.universe/issues/895>`_)
+  * docs(obstacle_stop_planner): update documentation (`#880 <https://github.com/autowarefoundation/autoware.universe/issues/880>`_)
+  * docs(tier4_traffic_light_rviz_plugin): update documentation (`#905 <https://github.com/autowarefoundation/autoware.universe/issues/905>`_)
+  * fix(accel_brake_map_calibrator): rviz panel type (`#895 <https://github.com/autowarefoundation/autoware.universe/issues/895>`_)
   * fixed panel type
   * modified instruction for rosbag replay case
   * modified update_map_dir service name
-  * fix(behavior velocity planner): skipping emplace back stop reason if it is empty (`#898 <https://github.com/youtalk/autoware.universe/issues/898>`_)
+  * fix(behavior velocity planner): skipping emplace back stop reason if it is empty (`#898 <https://github.com/autowarefoundation/autoware.universe/issues/898>`_)
   * skipping emplace back stop reason if it is empty
   * add braces
   * ci(pre-commit): autofix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Takagi, Isamu <43976882+isamu-takagi@users.noreply.github.com>
-  * feat(behavior_path_planner): weakened noise filtering of drivable area (`#838 <https://github.com/youtalk/autoware.universe/issues/838>`_)
+  * feat(behavior_path_planner): weakened noise filtering of drivable area (`#838 <https://github.com/autowarefoundation/autoware.universe/issues/838>`_)
   * feat(behavior_path_planner): Weakened noise filtering of drivable area
   * fix lanelet's longitudinal disconnection
   * add comments of erode/dilate process
-  * refactor(vehicle-cmd-gate): using namespace for msgs (`#913 <https://github.com/youtalk/autoware.universe/issues/913>`_)
+  * refactor(vehicle-cmd-gate): using namespace for msgs (`#913 <https://github.com/autowarefoundation/autoware.universe/issues/913>`_)
   * refactor(vehicle-cmd-gate): using namespace for msgs
   * for clang
-  * feat(pose_initializer): introduce an array copy function (`#900 <https://github.com/youtalk/autoware.universe/issues/900>`_)
+  * feat(pose_initializer): introduce an array copy function (`#900 <https://github.com/autowarefoundation/autoware.universe/issues/900>`_)
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-  * feat: add lidar point filter when debug (`#865 <https://github.com/youtalk/autoware.universe/issues/865>`_)
+  * feat: add lidar point filter when debug (`#865 <https://github.com/autowarefoundation/autoware.universe/issues/865>`_)
   * feat: add lidar point filter when debug
   * ci(pre-commit): autofix
   Co-authored-by: suchang <chang.su@autocore.ai>
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-  * feat(component_interface_utils): add interface classes  (`#899 <https://github.com/youtalk/autoware.universe/issues/899>`_)
+  * feat(component_interface_utils): add interface classes  (`#899 <https://github.com/autowarefoundation/autoware.universe/issues/899>`_)
   * feat(component_interface_utils): add interface classes
   * feat(default_ad_api): apply the changes of interface utils
   * fix(component_interface_utils): remove old comment
@@ -88,18 +88,18 @@ Changelog for package fake_test_node
   * fix(component_interface_utils): remove unimplemented message
   * docs(component_interface_utils): add design policy
   * docs(component_interface_utils): add comment
-  * refactor(vehicle_cmd_gate): change namespace in launch file (`#927 <https://github.com/youtalk/autoware.universe/issues/927>`_)
+  * refactor(vehicle_cmd_gate): change namespace in launch file (`#927 <https://github.com/autowarefoundation/autoware.universe/issues/927>`_)
   Co-authored-by: Berkay <berkay@leodrive.ai>
-  * feat: visualize lane boundaries (`#923 <https://github.com/youtalk/autoware.universe/issues/923>`_)
+  * feat: visualize lane boundaries (`#923 <https://github.com/autowarefoundation/autoware.universe/issues/923>`_)
   * feat: visualize lane boundaries
   * fix: start_bound
   * ci(pre-commit): autofix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-  * fix(system_monitor): fix truncation warning in strncpy (`#872 <https://github.com/youtalk/autoware.universe/issues/872>`_)
+  * fix(system_monitor): fix truncation warning in strncpy (`#872 <https://github.com/autowarefoundation/autoware.universe/issues/872>`_)
   * fix(system_monitor): fix truncation warning in strncpy
   * Use std::string constructor to copy char array
   * Fixed typo
-  * fix(behavior_velocity_planner.stopline): extend following and previous search range to avoid no collision (`#917 <https://github.com/youtalk/autoware.universe/issues/917>`_)
+  * fix(behavior_velocity_planner.stopline): extend following and previous search range to avoid no collision (`#917 <https://github.com/autowarefoundation/autoware.universe/issues/917>`_)
   * fix: extend following and previous search range to avoid no collision
   * chore: add debug marker
   * fix: simplify logic
@@ -109,11 +109,11 @@ Changelog for package fake_test_node
   * ci(pre-commit): autofix
   * fix: delete debug code
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-  * docs(surround obstacle checker): update documentation (`#878 <https://github.com/youtalk/autoware.universe/issues/878>`_)
+  * docs(surround obstacle checker): update documentation (`#878 <https://github.com/autowarefoundation/autoware.universe/issues/878>`_)
   * docs(surround_obstacle_checker): update pub/sub topics & params
   * docs(surround_obstacle_checker): remove unused files
   * docs(surround_obstacke_checker): update purpose
-  * feat(tier4_autoware_utils): add vehicle state checker (`#896 <https://github.com/youtalk/autoware.universe/issues/896>`_)
+  * feat(tier4_autoware_utils): add vehicle state checker (`#896 <https://github.com/autowarefoundation/autoware.universe/issues/896>`_)
   * feat(tier4_autoware_utils): add vehicle state checker
   * fix(tier4_autoware_utils): use absolute value
   * feat(tier4_autoware_utils): divide into two classies
@@ -123,20 +123,20 @@ Changelog for package fake_test_node
   * fix(tier4_autoware_utils): into same loop
   * fix(tier4_autoware_utils): fix variables name
   * fix(tier4_autoware_utils): remove redundant codes
-  * fix(motion_velocity_smoother): fix overwriteStopPoint using backward point (`#816 <https://github.com/youtalk/autoware.universe/issues/816>`_)
+  * fix(motion_velocity_smoother): fix overwriteStopPoint using backward point (`#816 <https://github.com/autowarefoundation/autoware.universe/issues/816>`_)
   * fix(motion_velocity_smoother): fix overwriteStopPoint using backward point
   * Modify overwriteStopPoint input and output
-  * feat(obstacle_avoidance_planner): explicitly insert zero velocity (`#906 <https://github.com/youtalk/autoware.universe/issues/906>`_)
+  * feat(obstacle_avoidance_planner): explicitly insert zero velocity (`#906 <https://github.com/autowarefoundation/autoware.universe/issues/906>`_)
   * feat(obstacle_avoidance_planner) fix bug of stop line unalignment
   * fix bug of unsorted output points
   * move calcVelocity in node.cpp
   * fix build error
-  * feat(behavior_velocity): find occlusion more efficiently (`#829 <https://github.com/youtalk/autoware.universe/issues/829>`_)
-  * fix(system_monitor): add some smart information to diagnostics (`#708 <https://github.com/youtalk/autoware.universe/issues/708>`_)
-  * feat(obstacle_avoidance_planner): dealt with close lane change (`#921 <https://github.com/youtalk/autoware.universe/issues/921>`_)
+  * feat(behavior_velocity): find occlusion more efficiently (`#829 <https://github.com/autowarefoundation/autoware.universe/issues/829>`_)
+  * fix(system_monitor): add some smart information to diagnostics (`#708 <https://github.com/autowarefoundation/autoware.universe/issues/708>`_)
+  * feat(obstacle_avoidance_planner): dealt with close lane change (`#921 <https://github.com/autowarefoundation/autoware.universe/issues/921>`_)
   * feat(obstacle_avoidance_planner): dealt with close lane change
   * fix bug of right lane change
-  * feat(obstacle_avoidance_planner): some fix for narrow driving (`#916 <https://github.com/youtalk/autoware.universe/issues/916>`_)
+  * feat(obstacle_avoidance_planner): some fix for narrow driving (`#916 <https://github.com/autowarefoundation/autoware.universe/issues/916>`_)
   * use car like constraints in mpt
   * use not widest bounds for the first bounds
   * organized params
@@ -146,17 +146,17 @@ Changelog for package fake_test_node
   * update config
   * remove unnecessary files
   * update tier4_planning_launch params
-  * chore(obstacle_avoidance_planner): removed obsolete obstacle_avoidance_planner doc in Japanese (`#919 <https://github.com/youtalk/autoware.universe/issues/919>`_)
-  * chore(behavior_velocity_planner.stopline): add debug marker for stopline collision check (`#932 <https://github.com/youtalk/autoware.universe/issues/932>`_)
+  * chore(obstacle_avoidance_planner): removed obsolete obstacle_avoidance_planner doc in Japanese (`#919 <https://github.com/autowarefoundation/autoware.universe/issues/919>`_)
+  * chore(behavior_velocity_planner.stopline): add debug marker for stopline collision check (`#932 <https://github.com/autowarefoundation/autoware.universe/issues/932>`_)
   * chore(behavior_velocity_planner.stopline): add debug marker for stopline collision check
   * feat: use marker helper
-  * feat(map_loader): visualize center line by points (`#931 <https://github.com/youtalk/autoware.universe/issues/931>`_)
+  * feat(map_loader): visualize center line by points (`#931 <https://github.com/autowarefoundation/autoware.universe/issues/931>`_)
   * feat: visualize center line points
   * fix: delete space
   * feat: visualize center line by arrow
   * revert insertMarkerArray
   * fix: delete space
-  * feat: add RTC interface (`#765 <https://github.com/youtalk/autoware.universe/issues/765>`_)
+  * feat: add RTC interface (`#765 <https://github.com/autowarefoundation/autoware.universe/issues/765>`_)
   * feature(rtc_interface): add files
   * feature(rtc_interface): implement functions
   * feature(rtc_interface): reimprement functions to use CooperateCommands and write README.md
@@ -168,23 +168,23 @@ Changelog for package fake_test_node
   * feature(rtc_interface): add isRegistered and clearCooperateStatus
   * ci(pre-commit): autofix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-  * chore: sync files (`#911 <https://github.com/youtalk/autoware.universe/issues/911>`_)
+  * chore: sync files (`#911 <https://github.com/autowarefoundation/autoware.universe/issues/911>`_)
   Co-authored-by: kenji-miyake <kenji-miyake@users.noreply.github.com>
-  * fix: replace boost::mutex::scoped_lock to std::scoped_lock (`#907 <https://github.com/youtalk/autoware.universe/issues/907>`_)
+  * fix: replace boost::mutex::scoped_lock to std::scoped_lock (`#907 <https://github.com/autowarefoundation/autoware.universe/issues/907>`_)
   * fix: replace boost::mutex::scoped_lock to std::scoped_lock
   * fix: replace boost::mutex to std::mutex
-  * feat(tensorrt_yolo): add multi gpu support to tensorrt_yolo node (`#885 <https://github.com/youtalk/autoware.universe/issues/885>`_)
+  * feat(tensorrt_yolo): add multi gpu support to tensorrt_yolo node (`#885 <https://github.com/autowarefoundation/autoware.universe/issues/885>`_)
   * feat(tensorrt_yolo): add multi gpu support to tensorrt_yolo node
   * feat(tensorrt_yolo): update arg
   Co-authored-by: Kaan Colak <kcolak@leodrive.ai>
-  * feat(tier4_planning_launch): create parameter yaml for behavior_velocity_planner (`#887 <https://github.com/youtalk/autoware.universe/issues/887>`_)
+  * feat(tier4_planning_launch): create parameter yaml for behavior_velocity_planner (`#887 <https://github.com/autowarefoundation/autoware.universe/issues/887>`_)
   * feat(tier4_planning_launch): create parameter yaml for behavior_velocity_planner
   * Update launch/tier4_planning_launch/config/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/behavior_velocity_planner.param.yaml
   Co-authored-by: taikitanaka3 <65527974+taikitanaka3@users.noreply.github.com>
   * feat: add param.yaml in behavior_velocity_planner package
   * some fix
   Co-authored-by: taikitanaka3 <65527974+taikitanaka3@users.noreply.github.com>
-  * fix(map_loader): use std::filesystem to load pcd files in pointcloud_map_loader (`#942 <https://github.com/youtalk/autoware.universe/issues/942>`_)
+  * fix(map_loader): use std::filesystem to load pcd files in pointcloud_map_loader (`#942 <https://github.com/autowarefoundation/autoware.universe/issues/942>`_)
   * fix(map_loader): use std::filesystem to load pcd files in pointcloud_map_loader
   * fix(map_loader): remove c_str
   * fix(map_loader): replace c_str to string
@@ -223,18 +223,18 @@ Changelog for package fake_test_node
   Co-authored-by: Kaan Çolak <kaancolak95@gmail.com>
   Co-authored-by: Kaan Colak <kcolak@leodrive.ai>
   Co-authored-by: Kenji Miyake <kenji.miyake@tier4.jp>
-* feat: isolate gtests in all packages (`#693 <https://github.com/youtalk/autoware.universe/issues/693>`_)
-* chore: upgrade cmake_minimum_required to 3.14 (`#856 <https://github.com/youtalk/autoware.universe/issues/856>`_)
-* refactor: use autoware cmake (`#849 <https://github.com/youtalk/autoware.universe/issues/849>`_)
+* feat: isolate gtests in all packages (`#693 <https://github.com/autowarefoundation/autoware.universe/issues/693>`_)
+* chore: upgrade cmake_minimum_required to 3.14 (`#856 <https://github.com/autowarefoundation/autoware.universe/issues/856>`_)
+* refactor: use autoware cmake (`#849 <https://github.com/autowarefoundation/autoware.universe/issues/849>`_)
   * remove autoware_auto_cmake
   * add build_depend of autoware_cmake
   * use autoware_cmake in CMakeLists.txt
   * fix bugs
   * fix cmake lint errors
-* chore: remove license notations from CMakeLists.txt (`#846 <https://github.com/youtalk/autoware.universe/issues/846>`_)
-* chore: remove bad chars (`#845 <https://github.com/youtalk/autoware.universe/issues/845>`_)
-* style: fix format of package.xml (`#844 <https://github.com/youtalk/autoware.universe/issues/844>`_)
-* ci(pre-commit): clear the exclude option (`#426 <https://github.com/youtalk/autoware.universe/issues/426>`_)
+* chore: remove license notations from CMakeLists.txt (`#846 <https://github.com/autowarefoundation/autoware.universe/issues/846>`_)
+* chore: remove bad chars (`#845 <https://github.com/autowarefoundation/autoware.universe/issues/845>`_)
+* style: fix format of package.xml (`#844 <https://github.com/autowarefoundation/autoware.universe/issues/844>`_)
+* ci(pre-commit): clear the exclude option (`#426 <https://github.com/autowarefoundation/autoware.universe/issues/426>`_)
   * ci(pre-commit): remove unnecessary excludes
   * ci(pre-commit): autofix
   * ci(pre-commit): autofix
@@ -246,60 +246,60 @@ Changelog for package fake_test_node
   * fix build
   * use autoware_lint_common
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat: add autoware auto dependencies (`#185 <https://github.com/youtalk/autoware.universe/issues/185>`_)
-  * Back port .auto control packages (`#571 <https://github.com/youtalk/autoware.universe/issues/571>`_)
+* feat: add autoware auto dependencies (`#185 <https://github.com/autowarefoundation/autoware.universe/issues/185>`_)
+  * Back port .auto control packages (`#571 <https://github.com/autowarefoundation/autoware.universe/issues/571>`_)
   * Implement Lateral and Longitudinal Control Muxer
-  * [`#570 <https://github.com/youtalk/autoware.universe/issues/570>`_] Porting wf_simulator
-  * [`#1189 <https://github.com/youtalk/autoware.universe/issues/1189>`_] Deactivate flaky test in 'trajectory_follower_nodes'
-  * [`#1189 <https://github.com/youtalk/autoware.universe/issues/1189>`_] Fix flacky test in 'trajectory_follower_nodes/latlon_muxer'
-  * [`#1057 <https://github.com/youtalk/autoware.universe/issues/1057>`_] Add osqp_interface package
-  * [`#1057 <https://github.com/youtalk/autoware.universe/issues/1057>`_] Add library code for MPC-based lateral control
-  * [`#1271 <https://github.com/youtalk/autoware.universe/issues/1271>`_] Use std::abs instead of abs
-  * [`#1057 <https://github.com/youtalk/autoware.universe/issues/1057>`_] Implement Lateral Controller for Cargo ODD
-  * [`#1246 <https://github.com/youtalk/autoware.universe/issues/1246>`_] Resolve "Test case names currently use snake_case but should be CamelCase"
-  * [`#1325 <https://github.com/youtalk/autoware.universe/issues/1325>`_] Deactivate flaky smoke test in 'trajectory_follower_nodes'
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Add library code of longitudinal controller
+  * [`#570 <https://github.com/autowarefoundation/autoware.universe/issues/570>`_] Porting wf_simulator
+  * [`#1189 <https://github.com/autowarefoundation/autoware.universe/issues/1189>`_] Deactivate flaky test in 'trajectory_follower_nodes'
+  * [`#1189 <https://github.com/autowarefoundation/autoware.universe/issues/1189>`_] Fix flacky test in 'trajectory_follower_nodes/latlon_muxer'
+  * [`#1057 <https://github.com/autowarefoundation/autoware.universe/issues/1057>`_] Add osqp_interface package
+  * [`#1057 <https://github.com/autowarefoundation/autoware.universe/issues/1057>`_] Add library code for MPC-based lateral control
+  * [`#1271 <https://github.com/autowarefoundation/autoware.universe/issues/1271>`_] Use std::abs instead of abs
+  * [`#1057 <https://github.com/autowarefoundation/autoware.universe/issues/1057>`_] Implement Lateral Controller for Cargo ODD
+  * [`#1246 <https://github.com/autowarefoundation/autoware.universe/issues/1246>`_] Resolve "Test case names currently use snake_case but should be CamelCase"
+  * [`#1325 <https://github.com/autowarefoundation/autoware.universe/issues/1325>`_] Deactivate flaky smoke test in 'trajectory_follower_nodes'
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Add library code of longitudinal controller
   * Fix build error for trajectory follower
   * Fix build error for trajectory follower nodes
-  * [`#1272 <https://github.com/youtalk/autoware.universe/issues/1272>`_] Add AckermannControlCommand support to simple_planning_simulator
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Add Longitudinal Controller node
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Rename velocity_controller -> longitudinal_controller
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Update CMakeLists.txt for the longitudinal_controller_node
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Add smoke test python launch file
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Use LowPassFilter1d from trajectory_follower
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Use autoware_auto_msgs
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Changes for .auto (debug msg tmp fix, common func, tf listener)
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Remove unused parameters
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Fix ros test
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Rm default params from declare_parameters + use autoware types
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Use default param file to setup NodeOptions in the ros test
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Fix docstring
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Replace receiving a Twist with a VehicleKinematicState
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Change class variables format to m\_ prefix
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Fix plugin name of LongitudinalController in CMakeLists.txt
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Fix copyright dates
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Reorder includes
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Add some tests (~89% coverage without disabling flaky tests)
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Add more tests (90+% coverage without disabling flaky tests)
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Use Float32MultiArrayDiagnostic message for debug and slope
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Calculate wheel_base value from vehicle parameters
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Cleanup redundant logger setting in tests
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Set ROS_DOMAIN_ID when running tests to prevent CI failures
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Remove TF listener and use published vehicle state instead
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Change smoke tests to use autoware_testing
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Add plotjuggler cfg for both lateral and longitudinal control
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Improve design documents
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Disable flaky test
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Properly transform vehicle state in longitudinal node
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Fix TF buffer of lateral controller
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Tuning of lateral controller for LGSVL
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Fix formating
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Fix /tf_static sub to be transient_local
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Fix yaw recalculation of reverse trajs in the lateral controller
+  * [`#1272 <https://github.com/autowarefoundation/autoware.universe/issues/1272>`_] Add AckermannControlCommand support to simple_planning_simulator
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Add Longitudinal Controller node
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Rename velocity_controller -> longitudinal_controller
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Update CMakeLists.txt for the longitudinal_controller_node
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Add smoke test python launch file
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Use LowPassFilter1d from trajectory_follower
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Use autoware_auto_msgs
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Changes for .auto (debug msg tmp fix, common func, tf listener)
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Remove unused parameters
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Fix ros test
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Rm default params from declare_parameters + use autoware types
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Use default param file to setup NodeOptions in the ros test
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Fix docstring
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Replace receiving a Twist with a VehicleKinematicState
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Change class variables format to m\_ prefix
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Fix plugin name of LongitudinalController in CMakeLists.txt
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Fix copyright dates
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Reorder includes
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Add some tests (~89% coverage without disabling flaky tests)
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Add more tests (90+% coverage without disabling flaky tests)
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Use Float32MultiArrayDiagnostic message for debug and slope
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Calculate wheel_base value from vehicle parameters
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Cleanup redundant logger setting in tests
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Set ROS_DOMAIN_ID when running tests to prevent CI failures
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Remove TF listener and use published vehicle state instead
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Change smoke tests to use autoware_testing
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Add plotjuggler cfg for both lateral and longitudinal control
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Improve design documents
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Disable flaky test
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Properly transform vehicle state in longitudinal node
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Fix TF buffer of lateral controller
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Tuning of lateral controller for LGSVL
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Fix formating
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Fix /tf_static sub to be transient_local
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Fix yaw recalculation of reverse trajs in the lateral controller
   * modify trajectory_follower for galactic build
-  * [`#1379 <https://github.com/youtalk/autoware.universe/issues/1379>`_] Update trajectory_follower
-  * [`#1379 <https://github.com/youtalk/autoware.universe/issues/1379>`_] Update simple_planning_simulator
-  * [`#1379 <https://github.com/youtalk/autoware.universe/issues/1379>`_] Update trajectory_follower_nodes
+  * [`#1379 <https://github.com/autowarefoundation/autoware.universe/issues/1379>`_] Update trajectory_follower
+  * [`#1379 <https://github.com/autowarefoundation/autoware.universe/issues/1379>`_] Update simple_planning_simulator
+  * [`#1379 <https://github.com/autowarefoundation/autoware.universe/issues/1379>`_] Update trajectory_follower_nodes
   * apply trajectory msg modification in control
   * move directory
   * remote control/trajectory_follower level dorectpry
@@ -323,7 +323,7 @@ Changelog for package fake_test_node
   Co-authored-by: MIURA Yasuyuki <kokosabu@gmail.com>
   Co-authored-by: wep21 <border_goldenmarket@yahoo.co.jp>
   Co-authored-by: tomoya.kimura <tomoya.kimura@tier4.jp>
-  * Port parking planner packages from .Auto (`#600 <https://github.com/youtalk/autoware.universe/issues/600>`_)
+  * Port parking planner packages from .Auto (`#600 <https://github.com/autowarefoundation/autoware.universe/issues/600>`_)
   * Copy code of 'vehicle_constants_manager'
   * Fix vehicle_constants_manager for ROS galactic
   * Rm .iv costmap_generator freespace_planner freespace_planning_aglorihtms

--- a/common/global_parameter_loader/CHANGELOG.rst
+++ b/common/global_parameter_loader/CHANGELOG.rst
@@ -5,7 +5,7 @@ Changelog for package global_parameter_loader
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* refactor(vehicle_info_utils)!: prefix package and namespace with autoware (`#7353 <https://github.com/youtalk/autoware.universe/issues/7353>`_)
+* refactor(vehicle_info_utils)!: prefix package and namespace with autoware (`#7353 <https://github.com/autowarefoundation/autoware.universe/issues/7353>`_)
   * chore(autoware_vehicle_info_utils): rename header
   * chore(bpp-common): vehicle info
   * chore(path_optimizer): vehicle info
@@ -40,10 +40,10 @@ Changelog for package global_parameter_loader
   * chore(sensing): vehicle info
   * fix(autoware_joy_controller): remove unused deps
   ---------
-* revert: feat(global_parameter_loader): add gtest to global parameter loader (`#6872 <https://github.com/youtalk/autoware.universe/issues/6872>`_)
+* revert: feat(global_parameter_loader): add gtest to global parameter loader (`#6872 <https://github.com/autowarefoundation/autoware.universe/issues/6872>`_)
   Revert "feat(global_parameter_loader): add gtest to global parameter loader (…"
   This reverts commit dfec62ac277f893fd6276e3c6ffd9c7d4f475225.
-* feat(global_parameter_loader): add gtest to global parameter loader (`#5021 <https://github.com/youtalk/autoware.universe/issues/5021>`_)
+* feat(global_parameter_loader): add gtest to global parameter loader (`#5021 <https://github.com/autowarefoundation/autoware.universe/issues/5021>`_)
   * add remote
   * feat(global_parameter_loader): add gtest of global-parameter-loader
   * style(pre-commit): autofix
@@ -54,9 +54,9 @@ Changelog for package global_parameter_loader
 
 0.26.0 (2024-04-03)
 -------------------
-* chore: update maintainer (`#4140 <https://github.com/youtalk/autoware.universe/issues/4140>`_)
+* chore: update maintainer (`#4140 <https://github.com/autowarefoundation/autoware.universe/issues/4140>`_)
   Co-authored-by: Ryohsuke Mitsudome <43976834+mitsudome-r@users.noreply.github.com>
-* build: mark autoware_cmake as <buildtool_depend> (`#3616 <https://github.com/youtalk/autoware.universe/issues/3616>`_)
+* build: mark autoware_cmake as <buildtool_depend> (`#3616 <https://github.com/autowarefoundation/autoware.universe/issues/3616>`_)
   * build: mark autoware_cmake as <buildtool_depend>
   with <build_depend>, autoware_cmake is automatically exported with ament_target_dependencies() (unecessary)
   * style(pre-commit): autofix
@@ -64,15 +64,15 @@ Changelog for package global_parameter_loader
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Kenji Miyake <kenji.miyake@tier4.jp>
-* chore: upgrade cmake_minimum_required to 3.14 (`#856 <https://github.com/youtalk/autoware.universe/issues/856>`_)
-* refactor: use autoware cmake (`#849 <https://github.com/youtalk/autoware.universe/issues/849>`_)
+* chore: upgrade cmake_minimum_required to 3.14 (`#856 <https://github.com/autowarefoundation/autoware.universe/issues/856>`_)
+* refactor: use autoware cmake (`#849 <https://github.com/autowarefoundation/autoware.universe/issues/849>`_)
   * remove autoware_auto_cmake
   * add build_depend of autoware_cmake
   * use autoware_cmake in CMakeLists.txt
   * fix bugs
   * fix cmake lint errors
-* style: fix format of package.xml (`#844 <https://github.com/youtalk/autoware.universe/issues/844>`_)
-* feat: rename existing packages name starting with autoware to different names (`#180 <https://github.com/youtalk/autoware.universe/issues/180>`_)
+* style: fix format of package.xml (`#844 <https://github.com/autowarefoundation/autoware.universe/issues/844>`_)
+* feat: rename existing packages name starting with autoware to different names (`#180 <https://github.com/autowarefoundation/autoware.universe/issues/180>`_)
   * autoware_api_utils -> tier4_api_utils
   * autoware_debug_tools -> tier4_debug_tools
   * autoware_error_monitor -> system_error_monitor

--- a/common/glog_component/CHANGELOG.rst
+++ b/common/glog_component/CHANGELOG.rst
@@ -5,12 +5,12 @@ Changelog for package glog_component
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* chore(glog): add initialization check (`#6792 <https://github.com/youtalk/autoware.universe/issues/6792>`_)
+* chore(glog): add initialization check (`#6792 <https://github.com/autowarefoundation/autoware.universe/issues/6792>`_)
 * Contributors: Takamasa Horibe, Yutaka Kondo
 
 0.26.0 (2024-04-03)
 -------------------
-* feat(glog): add glog in planning and control modules (`#4714 <https://github.com/youtalk/autoware.universe/issues/4714>`_)
+* feat(glog): add glog in planning and control modules (`#4714 <https://github.com/autowarefoundation/autoware.universe/issues/4714>`_)
   * feat(glog): add glog component
   * formatting
   * remove namespace

--- a/common/tier4_adapi_rviz_plugin/CHANGELOG.rst
+++ b/common/tier4_adapi_rviz_plugin/CHANGELOG.rst
@@ -5,29 +5,29 @@ Changelog for package tier4_adapi_rviz_plugin
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* style: update rviz plugin icons to match the theme (`#8868 <https://github.com/youtalk/autoware.universe/issues/8868>`_)
-* fix(tier4_adapi_rviz_plugin): fix unusedFunction (`#8840 <https://github.com/youtalk/autoware.universe/issues/8840>`_)
+* style: update rviz plugin icons to match the theme (`#8868 <https://github.com/autowarefoundation/autoware.universe/issues/8868>`_)
+* fix(tier4_adapi_rviz_plugin): fix unusedFunction (`#8840 <https://github.com/autowarefoundation/autoware.universe/issues/8840>`_)
   fix:unusedFunction
-* feat(tier4_adapi_rviz_plugin, tier4_state_rviz_plugin): set timestamp to velocity_limit msg from rviz panels (`#8548 <https://github.com/youtalk/autoware.universe/issues/8548>`_)
+* feat(tier4_adapi_rviz_plugin, tier4_state_rviz_plugin): set timestamp to velocity_limit msg from rviz panels (`#8548 <https://github.com/autowarefoundation/autoware.universe/issues/8548>`_)
   set timestamp to velocity_limit msg
-* feat(tier4_adapi_rviz_plugin): add legacy state panel (`#7494 <https://github.com/youtalk/autoware.universe/issues/7494>`_)
+* feat(tier4_adapi_rviz_plugin): add legacy state panel (`#7494 <https://github.com/autowarefoundation/autoware.universe/issues/7494>`_)
 * Contributors: Autumn60, Khalil Selyan, Takagi, Isamu, Yutaka Kondo, kobayu858
 
 0.26.0 (2024-04-03)
 -------------------
-* feat(default_ad_api): add door api (`#5737 <https://github.com/youtalk/autoware.universe/issues/5737>`_)
-* feat(tier4_adapi_rviz_plugin): add change button to the route panel (`#6326 <https://github.com/youtalk/autoware.universe/issues/6326>`_)
+* feat(default_ad_api): add door api (`#5737 <https://github.com/autowarefoundation/autoware.universe/issues/5737>`_)
+* feat(tier4_adapi_rviz_plugin): add change button to the route panel (`#6326 <https://github.com/autowarefoundation/autoware.universe/issues/6326>`_)
   feat(tier4_adapi_rviz_plugin): add route change button to the route panel
-* fix(readme): add acknowledgement for material icons in tool plugins (`#6354 <https://github.com/youtalk/autoware.universe/issues/6354>`_)
-* style(update): autoware tools icons (`#6351 <https://github.com/youtalk/autoware.universe/issues/6351>`_)
-* feat(tier4_adapi_rviz_plugin): add route panel (`#3840 <https://github.com/youtalk/autoware.universe/issues/3840>`_)
+* fix(readme): add acknowledgement for material icons in tool plugins (`#6354 <https://github.com/autowarefoundation/autoware.universe/issues/6354>`_)
+* style(update): autoware tools icons (`#6351 <https://github.com/autowarefoundation/autoware.universe/issues/6351>`_)
+* feat(tier4_adapi_rviz_plugin): add route panel (`#3840 <https://github.com/autowarefoundation/autoware.universe/issues/3840>`_)
   * feat: add panel
   * feat: set route
   * feat: set waypoints
   * feat: add readme
   * fix: copyright
   ---------
-* build: mark autoware_cmake as <buildtool_depend> (`#3616 <https://github.com/youtalk/autoware.universe/issues/3616>`_)
+* build: mark autoware_cmake as <buildtool_depend> (`#3616 <https://github.com/autowarefoundation/autoware.universe/issues/3616>`_)
   * build: mark autoware_cmake as <buildtool_depend>
   with <build_depend>, autoware_cmake is automatically exported with ament_target_dependencies() (unecessary)
   * style(pre-commit): autofix
@@ -35,7 +35,7 @@ Changelog for package tier4_adapi_rviz_plugin
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Kenji Miyake <kenji.miyake@tier4.jp>
-* feat(tier4_adapi_rviz_plugin): add adapi rviz plugin (`#3380 <https://github.com/youtalk/autoware.universe/issues/3380>`_)
+* feat(tier4_adapi_rviz_plugin): add adapi rviz plugin (`#3380 <https://github.com/autowarefoundation/autoware.universe/issues/3380>`_)
   * feat(tier4_adapi_rviz_plugin): add adapi rviz plugin
   * feat: fix copyright and name
   ---------

--- a/common/tier4_api_utils/CHANGELOG.rst
+++ b/common/tier4_api_utils/CHANGELOG.rst
@@ -9,16 +9,16 @@ Changelog for package tier4_api_utils
 
 0.26.0 (2024-04-03)
 -------------------
-* chore: update api package maintainers (`#6086 <https://github.com/youtalk/autoware.universe/issues/6086>`_)
+* chore: update api package maintainers (`#6086 <https://github.com/autowarefoundation/autoware.universe/issues/6086>`_)
   * update api maintainers
   * fix
   ---------
-* chore: set log level of debug printing in rviz plugin to DEBUG (`#5996 <https://github.com/youtalk/autoware.universe/issues/5996>`_)
-* docs: add readme for interface packages (`#4235 <https://github.com/youtalk/autoware.universe/issues/4235>`_)
+* chore: set log level of debug printing in rviz plugin to DEBUG (`#5996 <https://github.com/autowarefoundation/autoware.universe/issues/5996>`_)
+* docs: add readme for interface packages (`#4235 <https://github.com/autowarefoundation/autoware.universe/issues/4235>`_)
   add readme for interface packages
-* chore: update maintainer (`#4140 <https://github.com/youtalk/autoware.universe/issues/4140>`_)
+* chore: update maintainer (`#4140 <https://github.com/autowarefoundation/autoware.universe/issues/4140>`_)
   Co-authored-by: Ryohsuke Mitsudome <43976834+mitsudome-r@users.noreply.github.com>
-* build: mark autoware_cmake as <buildtool_depend> (`#3616 <https://github.com/youtalk/autoware.universe/issues/3616>`_)
+* build: mark autoware_cmake as <buildtool_depend> (`#3616 <https://github.com/autowarefoundation/autoware.universe/issues/3616>`_)
   * build: mark autoware_cmake as <buildtool_depend>
   with <build_depend>, autoware_cmake is automatically exported with ament_target_dependencies() (unecessary)
   * style(pre-commit): autofix
@@ -26,22 +26,22 @@ Changelog for package tier4_api_utils
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Kenji Miyake <kenji.miyake@tier4.jp>
-* chore: add api maintainers (`#2361 <https://github.com/youtalk/autoware.universe/issues/2361>`_)
-* refactor(tier4_api_utils): apply clang-tidy (`#1663 <https://github.com/youtalk/autoware.universe/issues/1663>`_)
-* feat: isolate gtests in all packages (`#693 <https://github.com/youtalk/autoware.universe/issues/693>`_)
-* chore: upgrade cmake_minimum_required to 3.14 (`#856 <https://github.com/youtalk/autoware.universe/issues/856>`_)
-* refactor: use autoware cmake (`#849 <https://github.com/youtalk/autoware.universe/issues/849>`_)
+* chore: add api maintainers (`#2361 <https://github.com/autowarefoundation/autoware.universe/issues/2361>`_)
+* refactor(tier4_api_utils): apply clang-tidy (`#1663 <https://github.com/autowarefoundation/autoware.universe/issues/1663>`_)
+* feat: isolate gtests in all packages (`#693 <https://github.com/autowarefoundation/autoware.universe/issues/693>`_)
+* chore: upgrade cmake_minimum_required to 3.14 (`#856 <https://github.com/autowarefoundation/autoware.universe/issues/856>`_)
+* refactor: use autoware cmake (`#849 <https://github.com/autowarefoundation/autoware.universe/issues/849>`_)
   * remove autoware_auto_cmake
   * add build_depend of autoware_cmake
   * use autoware_cmake in CMakeLists.txt
   * fix bugs
   * fix cmake lint errors
-* chore: sync files (`#629 <https://github.com/youtalk/autoware.universe/issues/629>`_)
+* chore: sync files (`#629 <https://github.com/autowarefoundation/autoware.universe/issues/629>`_)
   * chore: sync files
   * ci(pre-commit): autofix
   Co-authored-by: kenji-miyake <kenji-miyake@users.noreply.github.com>
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat: rename existing packages name starting with autoware to different names (`#180 <https://github.com/youtalk/autoware.universe/issues/180>`_)
+* feat: rename existing packages name starting with autoware to different names (`#180 <https://github.com/autowarefoundation/autoware.universe/issues/180>`_)
   * autoware_api_utils -> tier4_api_utils
   * autoware_debug_tools -> tier4_debug_tools
   * autoware_error_monitor -> system_error_monitor

--- a/common/tier4_camera_view_rviz_plugin/CHANGELOG.rst
+++ b/common/tier4_camera_view_rviz_plugin/CHANGELOG.rst
@@ -5,31 +5,31 @@ Changelog for package tier4_camera_view_rviz_plugin
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* fix(tier4_camera_view_rviz_plugin): fix unmatchedSuppression (`#8918 <https://github.com/youtalk/autoware.universe/issues/8918>`_)
+* fix(tier4_camera_view_rviz_plugin): fix unmatchedSuppression (`#8918 <https://github.com/autowarefoundation/autoware.universe/issues/8918>`_)
   fix:unmatchedSuppression
-* style: update rviz plugin icons to match the theme (`#8868 <https://github.com/youtalk/autoware.universe/issues/8868>`_)
-* fix(tier4_camera_view_rviz_plugin): fix unusedFunction (`#8843 <https://github.com/youtalk/autoware.universe/issues/8843>`_)
+* style: update rviz plugin icons to match the theme (`#8868 <https://github.com/autowarefoundation/autoware.universe/issues/8868>`_)
+* fix(tier4_camera_view_rviz_plugin): fix unusedFunction (`#8843 <https://github.com/autowarefoundation/autoware.universe/issues/8843>`_)
   fix:unusedFunction
-* fix(tier4_camera_view_rviz_plugin): fix uninitMemberVar (`#8819 <https://github.com/youtalk/autoware.universe/issues/8819>`_)
+* fix(tier4_camera_view_rviz_plugin): fix uninitMemberVar (`#8819 <https://github.com/autowarefoundation/autoware.universe/issues/8819>`_)
   * fix:uninitMemberVar
   * fix:clang format
   ---------
-* fix(tier4_camera_view_rviz_plugin): fix unusedFunction (`#8639 <https://github.com/youtalk/autoware.universe/issues/8639>`_)
+* fix(tier4_camera_view_rviz_plugin): fix unusedFunction (`#8639 <https://github.com/autowarefoundation/autoware.universe/issues/8639>`_)
   * fix:unusedFunction
   * fix:clang format
   * fix:unusedFunction
   ---------
-* fix: replace Ogre deprecated header (`#7606 <https://github.com/youtalk/autoware.universe/issues/7606>`_)
+* fix: replace Ogre deprecated header (`#7606 <https://github.com/autowarefoundation/autoware.universe/issues/7606>`_)
   Fix Ogre deprecated header
   Co-authored-by: Kotaro Yoshimoto <pythagora.yoshimoto@gmail.com>
-* fix(tier4_camera_view_rviz_plugin): fix funcArgNamesDifferent warnings (`#7621 <https://github.com/youtalk/autoware.universe/issues/7621>`_)
+* fix(tier4_camera_view_rviz_plugin): fix funcArgNamesDifferent warnings (`#7621 <https://github.com/autowarefoundation/autoware.universe/issues/7621>`_)
 * Contributors: Khalil Selyan, Ryuta Kambe, Yutaka Kondo, kobayu858, ぐるぐる
 
 0.26.0 (2024-04-03)
 -------------------
-* fix(readme): add acknowledgement for material icons in tool plugins (`#6354 <https://github.com/youtalk/autoware.universe/issues/6354>`_)
-* style(update): autoware tools icons (`#6351 <https://github.com/youtalk/autoware.universe/issues/6351>`_)
-* feat(camera_view_plugin): add camera view plugin package (`#5472 <https://github.com/youtalk/autoware.universe/issues/5472>`_)
+* fix(readme): add acknowledgement for material icons in tool plugins (`#6354 <https://github.com/autowarefoundation/autoware.universe/issues/6354>`_)
+* style(update): autoware tools icons (`#6351 <https://github.com/autowarefoundation/autoware.universe/issues/6351>`_)
+* feat(camera_view_plugin): add camera view plugin package (`#5472 <https://github.com/autowarefoundation/autoware.universe/issues/5472>`_)
   * add camera view plugin package
   * add readme for short cut
   * style(pre-commit): autofix

--- a/common/tier4_datetime_rviz_plugin/CHANGELOG.rst
+++ b/common/tier4_datetime_rviz_plugin/CHANGELOG.rst
@@ -9,11 +9,11 @@ Changelog for package tier4_datetime_rviz_plugin
 
 0.26.0 (2024-04-03)
 -------------------
-* chore: update api package maintainers (`#6086 <https://github.com/youtalk/autoware.universe/issues/6086>`_)
+* chore: update api package maintainers (`#6086 <https://github.com/autowarefoundation/autoware.universe/issues/6086>`_)
   * update api maintainers
   * fix
   ---------
-* build: mark autoware_cmake as <buildtool_depend> (`#3616 <https://github.com/youtalk/autoware.universe/issues/3616>`_)
+* build: mark autoware_cmake as <buildtool_depend> (`#3616 <https://github.com/autowarefoundation/autoware.universe/issues/3616>`_)
   * build: mark autoware_cmake as <buildtool_depend>
   with <build_depend>, autoware_cmake is automatically exported with ament_target_dependencies() (unecessary)
   * style(pre-commit): autofix
@@ -21,25 +21,25 @@ Changelog for package tier4_datetime_rviz_plugin
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Kenji Miyake <kenji.miyake@tier4.jp>
-* chore: add api maintainers (`#2361 <https://github.com/youtalk/autoware.universe/issues/2361>`_)
-* refactor(tier4_datetime_rviz_plugin): apply clang-tidy (`#1605 <https://github.com/youtalk/autoware.universe/issues/1605>`_)
+* chore: add api maintainers (`#2361 <https://github.com/autowarefoundation/autoware.universe/issues/2361>`_)
+* refactor(tier4_datetime_rviz_plugin): apply clang-tidy (`#1605 <https://github.com/autowarefoundation/autoware.universe/issues/1605>`_)
   * refactor(tier4_datetime_rviz_plugin): apply clang-tidy
   * refactor: apply readability-identifier-naming
-* fix: remove unused check of rviz plugin version (`#1474 <https://github.com/youtalk/autoware.universe/issues/1474>`_)
-* chore: upgrade cmake_minimum_required to 3.14 (`#856 <https://github.com/youtalk/autoware.universe/issues/856>`_)
-* refactor: use autoware cmake (`#849 <https://github.com/youtalk/autoware.universe/issues/849>`_)
+* fix: remove unused check of rviz plugin version (`#1474 <https://github.com/autowarefoundation/autoware.universe/issues/1474>`_)
+* chore: upgrade cmake_minimum_required to 3.14 (`#856 <https://github.com/autowarefoundation/autoware.universe/issues/856>`_)
+* refactor: use autoware cmake (`#849 <https://github.com/autowarefoundation/autoware.universe/issues/849>`_)
   * remove autoware_auto_cmake
   * add build_depend of autoware_cmake
   * use autoware_cmake in CMakeLists.txt
   * fix bugs
   * fix cmake lint errors
-* style: fix format of package.xml (`#844 <https://github.com/youtalk/autoware.universe/issues/844>`_)
-* chore: sync files (`#629 <https://github.com/youtalk/autoware.universe/issues/629>`_)
+* style: fix format of package.xml (`#844 <https://github.com/autowarefoundation/autoware.universe/issues/844>`_)
+* chore: sync files (`#629 <https://github.com/autowarefoundation/autoware.universe/issues/629>`_)
   * chore: sync files
   * ci(pre-commit): autofix
   Co-authored-by: kenji-miyake <kenji-miyake@users.noreply.github.com>
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat: rename existing packages name starting with autoware to different names (`#180 <https://github.com/youtalk/autoware.universe/issues/180>`_)
+* feat: rename existing packages name starting with autoware to different names (`#180 <https://github.com/autowarefoundation/autoware.universe/issues/180>`_)
   * autoware_api_utils -> tier4_api_utils
   * autoware_debug_tools -> tier4_debug_tools
   * autoware_error_monitor -> system_error_monitor

--- a/common/tier4_localization_rviz_plugin/CHANGELOG.rst
+++ b/common/tier4_localization_rviz_plugin/CHANGELOG.rst
@@ -5,22 +5,22 @@ Changelog for package tier4_localization_rviz_plugin
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* fix(tier4_localization_rviz_plugin): fix unmatchedSuppression (`#8919 <https://github.com/youtalk/autoware.universe/issues/8919>`_)
+* fix(tier4_localization_rviz_plugin): fix unmatchedSuppression (`#8919 <https://github.com/autowarefoundation/autoware.universe/issues/8919>`_)
   fix:unmatchedSuppression
-* fix(tier4_localization_rviz_plugin): fix unusedFunction (`#8848 <https://github.com/youtalk/autoware.universe/issues/8848>`_)
+* fix(tier4_localization_rviz_plugin): fix unusedFunction (`#8848 <https://github.com/autowarefoundation/autoware.universe/issues/8848>`_)
   fix:unusedFunction
-* fix(tier4_localization_rviz_plugin): fix constVariableReference (`#8838 <https://github.com/youtalk/autoware.universe/issues/8838>`_)
+* fix(tier4_localization_rviz_plugin): fix constVariableReference (`#8838 <https://github.com/autowarefoundation/autoware.universe/issues/8838>`_)
   fix:constVariableReference
-* fix(tier4_localization_rviz_plugin): fix knownConditionTrueFalse (`#8824 <https://github.com/youtalk/autoware.universe/issues/8824>`_)
+* fix(tier4_localization_rviz_plugin): fix knownConditionTrueFalse (`#8824 <https://github.com/autowarefoundation/autoware.universe/issues/8824>`_)
   * fix:knownConditionTrueFalse
   * fix:merge
   ---------
-* refactor(tier4_localization_rviz_plugin): apply static analysis (`#8683 <https://github.com/youtalk/autoware.universe/issues/8683>`_)
+* refactor(tier4_localization_rviz_plugin): apply static analysis (`#8683 <https://github.com/autowarefoundation/autoware.universe/issues/8683>`_)
   * refactor based on linter
   * add comment on no lint
   * mod comment for clarification
   ---------
-* feat(tier4_localization_rviz_plugin): add visualization of pose with covariance history (`#8191 <https://github.com/youtalk/autoware.universe/issues/8191>`_)
+* feat(tier4_localization_rviz_plugin): add visualization of pose with covariance history (`#8191 <https://github.com/autowarefoundation/autoware.universe/issues/8191>`_)
   * display PoseWithCovariance History
   * Correct spelling errors and year
   * Add arrows clear()
@@ -30,11 +30,11 @@ Changelog for package tier4_localization_rviz_plugin
   ---------
   Co-authored-by: Yamato Ando <yamato.ando@gmail.com>
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* fix(tier4_localization_rviz_plugin): fix unusedFunction (`#8637 <https://github.com/youtalk/autoware.universe/issues/8637>`_)
+* fix(tier4_localization_rviz_plugin): fix unusedFunction (`#8637 <https://github.com/autowarefoundation/autoware.universe/issues/8637>`_)
   fix:unusedFunction
-* chore(tier4_localization_rviz_plugin): add maintainer and author (`#8184 <https://github.com/youtalk/autoware.universe/issues/8184>`_)
+* chore(tier4_localization_rviz_plugin): add maintainer and author (`#8184 <https://github.com/autowarefoundation/autoware.universe/issues/8184>`_)
   add maintainer and author
-* refactor(vehicle_info_utils)!: prefix package and namespace with autoware (`#7353 <https://github.com/youtalk/autoware.universe/issues/7353>`_)
+* refactor(vehicle_info_utils)!: prefix package and namespace with autoware (`#7353 <https://github.com/autowarefoundation/autoware.universe/issues/7353>`_)
   * chore(autoware_vehicle_info_utils): rename header
   * chore(bpp-common): vehicle info
   * chore(path_optimizer): vehicle info
@@ -73,16 +73,16 @@ Changelog for package tier4_localization_rviz_plugin
 
 0.26.0 (2024-04-03)
 -------------------
-* chore: update api package maintainers (`#6086 <https://github.com/youtalk/autoware.universe/issues/6086>`_)
+* chore: update api package maintainers (`#6086 <https://github.com/autowarefoundation/autoware.universe/issues/6086>`_)
   * update api maintainers
   * fix
   ---------
-* build: proper eigen deps and include (`#3615 <https://github.com/youtalk/autoware.universe/issues/3615>`_)
+* build: proper eigen deps and include (`#3615 <https://github.com/autowarefoundation/autoware.universe/issues/3615>`_)
   * build: proper eigen deps and include
   * style(pre-commit): autofix
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* build: mark autoware_cmake as <buildtool_depend> (`#3616 <https://github.com/youtalk/autoware.universe/issues/3616>`_)
+* build: mark autoware_cmake as <buildtool_depend> (`#3616 <https://github.com/autowarefoundation/autoware.universe/issues/3616>`_)
   * build: mark autoware_cmake as <buildtool_depend>
   with <build_depend>, autoware_cmake is automatically exported with ament_target_dependencies() (unecessary)
   * style(pre-commit): autofix
@@ -90,23 +90,23 @@ Changelog for package tier4_localization_rviz_plugin
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Kenji Miyake <kenji.miyake@tier4.jp>
-* chore: sync files (`#3227 <https://github.com/youtalk/autoware.universe/issues/3227>`_)
+* chore: sync files (`#3227 <https://github.com/autowarefoundation/autoware.universe/issues/3227>`_)
   * chore: sync files
   * style(pre-commit): autofix
   ---------
   Co-authored-by: kenji-miyake <kenji-miyake@users.noreply.github.com>
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat(tier4_localization_rviz_plugin): add pose history footprint (`#2387 <https://github.com/youtalk/autoware.universe/issues/2387>`_)
+* feat(tier4_localization_rviz_plugin): add pose history footprint (`#2387 <https://github.com/autowarefoundation/autoware.universe/issues/2387>`_)
   * feat(tier4_localization_rviz_plugin): add pose history footprint
   * remove unused variables
   * add maintainer
-* chore: add api maintainers (`#2361 <https://github.com/youtalk/autoware.universe/issues/2361>`_)
-* revert: readability-identifier-naming for pose history (`#1641 <https://github.com/youtalk/autoware.universe/issues/1641>`_)
+* chore: add api maintainers (`#2361 <https://github.com/autowarefoundation/autoware.universe/issues/2361>`_)
+* revert: readability-identifier-naming for pose history (`#1641 <https://github.com/autowarefoundation/autoware.universe/issues/1641>`_)
   * revert: readability-identifier-naming for pose history
   This reverts commit 9278e714bdbd29ca344976e9a2b26fdb93b41370.
   * Revert "fix: build error"
   This reverts commit 5e855993250a94494d9a8d05e03097162d4e6e0e.
-* refactor(tier4_localization_rviz_plugin): apply clang-tidy (`#1608 <https://github.com/youtalk/autoware.universe/issues/1608>`_)
+* refactor(tier4_localization_rviz_plugin): apply clang-tidy (`#1608 <https://github.com/autowarefoundation/autoware.universe/issues/1608>`_)
   * refactor(tier4_localization_rviz_plugin): apply clang-tidy
   * ci(pre-commit): autofix
   * refactor: add NOLINT
@@ -114,25 +114,25 @@ Changelog for package tier4_localization_rviz_plugin
   * ci(pre-commit): autofix
   * fix: build error
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* refactor(tier4_perception_rviz_plugin): apply clang-tidy (`#1624 <https://github.com/youtalk/autoware.universe/issues/1624>`_)
+* refactor(tier4_perception_rviz_plugin): apply clang-tidy (`#1624 <https://github.com/autowarefoundation/autoware.universe/issues/1624>`_)
   * refactor(tier4_perception_rviz_plugin): apply clang-tidy
   * ci(pre-commit): autofix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* fix: remove unused check of rviz plugin version (`#1474 <https://github.com/youtalk/autoware.universe/issues/1474>`_)
-* chore: upgrade cmake_minimum_required to 3.14 (`#856 <https://github.com/youtalk/autoware.universe/issues/856>`_)
-* refactor: use autoware cmake (`#849 <https://github.com/youtalk/autoware.universe/issues/849>`_)
+* fix: remove unused check of rviz plugin version (`#1474 <https://github.com/autowarefoundation/autoware.universe/issues/1474>`_)
+* chore: upgrade cmake_minimum_required to 3.14 (`#856 <https://github.com/autowarefoundation/autoware.universe/issues/856>`_)
+* refactor: use autoware cmake (`#849 <https://github.com/autowarefoundation/autoware.universe/issues/849>`_)
   * remove autoware_auto_cmake
   * add build_depend of autoware_cmake
   * use autoware_cmake in CMakeLists.txt
   * fix bugs
   * fix cmake lint errors
-* style: fix format of package.xml (`#844 <https://github.com/youtalk/autoware.universe/issues/844>`_)
-* chore: sync files (`#629 <https://github.com/youtalk/autoware.universe/issues/629>`_)
+* style: fix format of package.xml (`#844 <https://github.com/autowarefoundation/autoware.universe/issues/844>`_)
+* chore: sync files (`#629 <https://github.com/autowarefoundation/autoware.universe/issues/629>`_)
   * chore: sync files
   * ci(pre-commit): autofix
   Co-authored-by: kenji-miyake <kenji-miyake@users.noreply.github.com>
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat: rename existing packages name starting with autoware to different names (`#180 <https://github.com/youtalk/autoware.universe/issues/180>`_)
+* feat: rename existing packages name starting with autoware to different names (`#180 <https://github.com/autowarefoundation/autoware.universe/issues/180>`_)
   * autoware_api_utils -> tier4_api_utils
   * autoware_debug_tools -> tier4_debug_tools
   * autoware_error_monitor -> system_error_monitor

--- a/common/tier4_planning_rviz_plugin/CHANGELOG.rst
+++ b/common/tier4_planning_rviz_plugin/CHANGELOG.rst
@@ -5,22 +5,22 @@ Changelog for package tier4_planning_rviz_plugin
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* feat(tier4_planning_rviz_plugin): set path colors from rviz and add fade_out feature (`#8972 <https://github.com/youtalk/autoware.universe/issues/8972>`_)
+* feat(tier4_planning_rviz_plugin): set path colors from rviz and add fade_out feature (`#8972 <https://github.com/autowarefoundation/autoware.universe/issues/8972>`_)
   Co-authored-by: M. Fatih Cırıt <mfc@leodrive.ai>
-* style: update rviz plugin icons to match the theme (`#8868 <https://github.com/youtalk/autoware.universe/issues/8868>`_)
-* fix(tier4_planning_rviz_plugin): fix unusedFunction (`#8616 <https://github.com/youtalk/autoware.universe/issues/8616>`_)
+* style: update rviz plugin icons to match the theme (`#8868 <https://github.com/autowarefoundation/autoware.universe/issues/8868>`_)
+* fix(tier4_planning_rviz_plugin): fix unusedFunction (`#8616 <https://github.com/autowarefoundation/autoware.universe/issues/8616>`_)
   fix:unusedFunction
-* fix(tier4_planning_rviz_plugin): fix cppcheck warning of virtualCallInConstructor (`#8377 <https://github.com/youtalk/autoware.universe/issues/8377>`_)
+* fix(tier4_planning_rviz_plugin): fix cppcheck warning of virtualCallInConstructor (`#8377 <https://github.com/autowarefoundation/autoware.universe/issues/8377>`_)
   fix: deal with virtualCallInConstructor warning
   Co-authored-by: Ryuta Kambe <ryuta.kambe@tier4.jp>
-* fix(tier4_planning_rviz_plugin): fix calculation of drivable area bounds (`#7815 <https://github.com/youtalk/autoware.universe/issues/7815>`_)
+* fix(tier4_planning_rviz_plugin): fix calculation of drivable area bounds (`#7815 <https://github.com/autowarefoundation/autoware.universe/issues/7815>`_)
   change angle condition
-* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/youtalk/autoware.universe/issues/7594>`_)
-* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/youtalk/autoware.universe/issues/7539>`_)
+* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/autowarefoundation/autoware.universe/issues/7594>`_)
+* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/autowarefoundation/autoware.universe/issues/7539>`_)
   refactor(motion_utils): add autoware prefix and include dir
-* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/youtalk/autoware.universe/issues/7538>`_)
+* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/autowarefoundation/autoware.universe/issues/7538>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* refactor(vehicle_info_utils)!: prefix package and namespace with autoware (`#7353 <https://github.com/youtalk/autoware.universe/issues/7353>`_)
+* refactor(vehicle_info_utils)!: prefix package and namespace with autoware (`#7353 <https://github.com/autowarefoundation/autoware.universe/issues/7353>`_)
   * chore(autoware_vehicle_info_utils): rename header
   * chore(bpp-common): vehicle info
   * chore(path_optimizer): vehicle info
@@ -55,45 +55,45 @@ Changelog for package tier4_planning_rviz_plugin
   * chore(sensing): vehicle info
   * fix(autoware_joy_controller): remove unused deps
   ---------
-* feat!: replace autoware_auto_msgs with autoware_msgs for common modules (`#7239 <https://github.com/youtalk/autoware.universe/issues/7239>`_)
+* feat!: replace autoware_auto_msgs with autoware_msgs for common modules (`#7239 <https://github.com/autowarefoundation/autoware.universe/issues/7239>`_)
   Co-authored-by: Cynthia Liu <cynthia.liu@autocore.ai>
   Co-authored-by: NorahXiong <norah.xiong@autocore.ai>
   Co-authored-by: beginningfan <beginning.fan@autocore.ai>
-* fix(tier4_planning_rviz_plugin): memory leak (`#7164 <https://github.com/youtalk/autoware.universe/issues/7164>`_)
+* fix(tier4_planning_rviz_plugin): memory leak (`#7164 <https://github.com/autowarefoundation/autoware.universe/issues/7164>`_)
   fix memory leak
 * Contributors: Khalil Selyan, Kosuke Takeuchi, Ryohsuke Mitsudome, Satoshi OTA, Takayuki Murooka, Yukihiro Saito, Yutaka Kondo, beyzanurkaya, kobayu858, taisa1
 
 0.26.0 (2024-04-03)
 -------------------
-* fix(readme): add acknowledgement for material icons in tool plugins (`#6354 <https://github.com/youtalk/autoware.universe/issues/6354>`_)
-* style(update): autoware tools icons (`#6351 <https://github.com/youtalk/autoware.universe/issues/6351>`_)
-* fix(tier4_planning_rviz_plugin): move headers to tier4_planning_rviz_plugin directory (`#5927 <https://github.com/youtalk/autoware.universe/issues/5927>`_)
+* fix(readme): add acknowledgement for material icons in tool plugins (`#6354 <https://github.com/autowarefoundation/autoware.universe/issues/6354>`_)
+* style(update): autoware tools icons (`#6351 <https://github.com/autowarefoundation/autoware.universe/issues/6351>`_)
+* fix(tier4_planning_rviz_plugin): move headers to tier4_planning_rviz_plugin directory (`#5927 <https://github.com/autowarefoundation/autoware.universe/issues/5927>`_)
   * fix(tier4_planning_rviz_plugin): move headers to tier4_planning_rviz_plugin directory
   * style(pre-commit): autofix
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* chore(planning modules): remove maintainer... (`#5458 <https://github.com/youtalk/autoware.universe/issues/5458>`_)
+* chore(planning modules): remove maintainer... (`#5458 <https://github.com/autowarefoundation/autoware.universe/issues/5458>`_)
   remove shimizu-san from maintainer and add maintainer for stop line and turn signal decider
-* feat(tier4_planning_rviz_plugin): visualize text of slope angle (`#5091 <https://github.com/youtalk/autoware.universe/issues/5091>`_)
-* refactor(common): extern template for motion_utils / remove tier4_autoware_utils.hpp / remove motion_utis.hpp (`#5027 <https://github.com/youtalk/autoware.universe/issues/5027>`_)
-* fix(tier4_planning_rviz_plugin): update vehicle info parameters in panel received from global parameter (`#4907 <https://github.com/youtalk/autoware.universe/issues/4907>`_)
-* fix: max velocity display (`#4203 <https://github.com/youtalk/autoware.universe/issues/4203>`_)
+* feat(tier4_planning_rviz_plugin): visualize text of slope angle (`#5091 <https://github.com/autowarefoundation/autoware.universe/issues/5091>`_)
+* refactor(common): extern template for motion_utils / remove tier4_autoware_utils.hpp / remove motion_utis.hpp (`#5027 <https://github.com/autowarefoundation/autoware.universe/issues/5027>`_)
+* fix(tier4_planning_rviz_plugin): update vehicle info parameters in panel received from global parameter (`#4907 <https://github.com/autowarefoundation/autoware.universe/issues/4907>`_)
+* fix: max velocity display (`#4203 <https://github.com/autowarefoundation/autoware.universe/issues/4203>`_)
   fix max velocity display
   Co-authored-by: Ryohsuke Mitsudome <43976834+mitsudome-r@users.noreply.github.com>
-* fix(tier4_planning_rviz_plugin): fix plugin crash (`#3830 <https://github.com/youtalk/autoware.universe/issues/3830>`_)
+* fix(tier4_planning_rviz_plugin): fix plugin crash (`#3830 <https://github.com/autowarefoundation/autoware.universe/issues/3830>`_)
   * preVisualizePathFootPrint is the cause
   * update ogre_node and text_ptr in each iteration
   ---------
-* fix(tier4_planning_rviz_plugin): fix drivable area width (`#3689 <https://github.com/youtalk/autoware.universe/issues/3689>`_)
+* fix(tier4_planning_rviz_plugin): fix drivable area width (`#3689 <https://github.com/autowarefoundation/autoware.universe/issues/3689>`_)
   * fix(tier4_planning_rviz_plugin): fix drivable area width
   * fix
   ---------
-* build: proper eigen deps and include (`#3615 <https://github.com/youtalk/autoware.universe/issues/3615>`_)
+* build: proper eigen deps and include (`#3615 <https://github.com/autowarefoundation/autoware.universe/issues/3615>`_)
   * build: proper eigen deps and include
   * style(pre-commit): autofix
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* build: mark autoware_cmake as <buildtool_depend> (`#3616 <https://github.com/youtalk/autoware.universe/issues/3616>`_)
+* build: mark autoware_cmake as <buildtool_depend> (`#3616 <https://github.com/autowarefoundation/autoware.universe/issues/3616>`_)
   * build: mark autoware_cmake as <buildtool_depend>
   with <build_depend>, autoware_cmake is automatically exported with ament_target_dependencies() (unecessary)
   * style(pre-commit): autofix
@@ -101,53 +101,53 @@ Changelog for package tier4_planning_rviz_plugin
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Kenji Miyake <kenji.miyake@tier4.jp>
-* fix(tier4_planning_rviz_plugin): suppress warning (`#3578 <https://github.com/youtalk/autoware.universe/issues/3578>`_)
-* feat(tier4_planning_rviz_plugin): remove z offset from the bound (`#3551 <https://github.com/youtalk/autoware.universe/issues/3551>`_)
-* feat(tier4_planning_rviz_plugin): update path width by global parameters (`#3504 <https://github.com/youtalk/autoware.universe/issues/3504>`_)
+* fix(tier4_planning_rviz_plugin): suppress warning (`#3578 <https://github.com/autowarefoundation/autoware.universe/issues/3578>`_)
+* feat(tier4_planning_rviz_plugin): remove z offset from the bound (`#3551 <https://github.com/autowarefoundation/autoware.universe/issues/3551>`_)
+* feat(tier4_planning_rviz_plugin): update path width by global parameters (`#3504 <https://github.com/autowarefoundation/autoware.universe/issues/3504>`_)
   * fix(tier4_planning_rviz_plugin): update vehicle info by global parameters
   * feat(tier4_planning_rviz_plugin): update path width by global parameters
   ---------
-* fix(tier4_planning_rviz_plugin): update vehicle info by global parameters (`#3503 <https://github.com/youtalk/autoware.universe/issues/3503>`_)
+* fix(tier4_planning_rviz_plugin): update vehicle info by global parameters (`#3503 <https://github.com/autowarefoundation/autoware.universe/issues/3503>`_)
   * fix(tier4_planning_rviz_plugin): update vehicle info by global parameters
   * fix
   ---------
-* chore: sync files (`#3227 <https://github.com/youtalk/autoware.universe/issues/3227>`_)
+* chore: sync files (`#3227 <https://github.com/autowarefoundation/autoware.universe/issues/3227>`_)
   * chore: sync files
   * style(pre-commit): autofix
   ---------
   Co-authored-by: kenji-miyake <kenji-miyake@users.noreply.github.com>
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* fix(tier4_planning_rviz_plugin): supress initial warning message (`#2960 <https://github.com/youtalk/autoware.universe/issues/2960>`_)
+* fix(tier4_planning_rviz_plugin): supress initial warning message (`#2960 <https://github.com/autowarefoundation/autoware.universe/issues/2960>`_)
   fix(tier4_planning_rviz_plugin): remove initial warning message
-* fix(tier4_rviz_planning_plugin): clear objects before return (`#2995 <https://github.com/youtalk/autoware.universe/issues/2995>`_)
+* fix(tier4_rviz_planning_plugin): clear objects before return (`#2995 <https://github.com/autowarefoundation/autoware.universe/issues/2995>`_)
   * fix(tier4_rviz_planning_plugin): clear objects before return
   * update
   ---------
-* feat(tier4_planning_rviz_plugin): add maintainer (`#2996 <https://github.com/youtalk/autoware.universe/issues/2996>`_)
-* feat(tier4_planning_rviz_plugin): move footprint plugin to path (`#2971 <https://github.com/youtalk/autoware.universe/issues/2971>`_)
+* feat(tier4_planning_rviz_plugin): add maintainer (`#2996 <https://github.com/autowarefoundation/autoware.universe/issues/2996>`_)
+* feat(tier4_planning_rviz_plugin): move footprint plugin to path (`#2971 <https://github.com/autowarefoundation/autoware.universe/issues/2971>`_)
   * feat(tier4_rviz_plugin): simplify tier4_planning_rviz_plugin
   * update
   ---------
-* feat(tier4_planning_rviz_plugin): add drivable area plugin (`#2868 <https://github.com/youtalk/autoware.universe/issues/2868>`_)
+* feat(tier4_planning_rviz_plugin): add drivable area plugin (`#2868 <https://github.com/autowarefoundation/autoware.universe/issues/2868>`_)
   * feat(tier4_planning_rviz_plugin): add drivable area plugin
   * change default size and color
   * update
   * add drivable area to path
   * update
   ---------
-* feat(tier4_autoware_utils): remove drivable area plugin (`#2876 <https://github.com/youtalk/autoware.universe/issues/2876>`_)
-* refactor(tier4_planning_rviz_plugin): clean up the code of path (`#2871 <https://github.com/youtalk/autoware.universe/issues/2871>`_)
+* feat(tier4_autoware_utils): remove drivable area plugin (`#2876 <https://github.com/autowarefoundation/autoware.universe/issues/2876>`_)
+* refactor(tier4_planning_rviz_plugin): clean up the code of path (`#2871 <https://github.com/autowarefoundation/autoware.universe/issues/2871>`_)
   * refactor(tier4_planning_rviz_plugin): clean up the code of path
   * fix
   ---------
-* refactor(tier4_planning_rviz_plugin): create abstract class for footprint (`#2870 <https://github.com/youtalk/autoware.universe/issues/2870>`_)
+* refactor(tier4_planning_rviz_plugin): create abstract class for footprint (`#2870 <https://github.com/autowarefoundation/autoware.universe/issues/2870>`_)
   * refactor(tier4_planning_rviz_plugin): create abstract class for footprint
   * fix
   * fix
   * fix
   * fix
   ---------
-* feat(tier4_planning_rviz_plugin): visualize pose_with_uuid_stamped (`#2662 <https://github.com/youtalk/autoware.universe/issues/2662>`_)
+* feat(tier4_planning_rviz_plugin): visualize pose_with_uuid_stamped (`#2662 <https://github.com/autowarefoundation/autoware.universe/issues/2662>`_)
   * feat(tier4_planning_rviz_plugin): visualize pose_stamped_with_uuid
   * Update common/tier4_planning_rviz_plugin/include/pose_stamped_with_uuid/display.hpp
   Co-authored-by: Yukihiro Saito <yukky.saito@gmail.com>
@@ -157,7 +157,7 @@ Changelog for package tier4_planning_rviz_plugin
   * add icon
   * change default size
   Co-authored-by: Yukihiro Saito <yukky.saito@gmail.com>
-* feat(behavior_path_planner, obstacle_avoidance_planner): add new drivable area (`#2472 <https://github.com/youtalk/autoware.universe/issues/2472>`_)
+* feat(behavior_path_planner, obstacle_avoidance_planner): add new drivable area (`#2472 <https://github.com/autowarefoundation/autoware.universe/issues/2472>`_)
   * update
   * update
   * update
@@ -178,68 +178,68 @@ Changelog for package tier4_planning_rviz_plugin
   * fix some codes
   * change to makerker array
   * change avoidance utils
-* feat(tier4_planning_rviz_plugin): add offset from baselink param (`#2384 <https://github.com/youtalk/autoware.universe/issues/2384>`_)
-* fix(tier4_planning_rviz_plugin): correct velocity text (`#2179 <https://github.com/youtalk/autoware.universe/issues/2179>`_)
-* fix(tier4_planning/vehicle_rviz_plugin): fixed license (`#2059 <https://github.com/youtalk/autoware.universe/issues/2059>`_)
+* feat(tier4_planning_rviz_plugin): add offset from baselink param (`#2384 <https://github.com/autowarefoundation/autoware.universe/issues/2384>`_)
+* fix(tier4_planning_rviz_plugin): correct velocity text (`#2179 <https://github.com/autowarefoundation/autoware.universe/issues/2179>`_)
+* fix(tier4_planning/vehicle_rviz_plugin): fixed license (`#2059 <https://github.com/autowarefoundation/autoware.universe/issues/2059>`_)
   * fix(tier4_planning/vehicle_rviz_plugin): fixed license
   * fix build error
-* feat(tier4_planning_rviz_plugin): add owner (`#1953 <https://github.com/youtalk/autoware.universe/issues/1953>`_)
-* refactor(tier4_planning_rviz_plugin): apply clang-tidy for path (`#1637 <https://github.com/youtalk/autoware.universe/issues/1637>`_)
-* feat(tier4_planning_rviz_plugin): add velocity_text to path_with_lane_id (`#1735 <https://github.com/youtalk/autoware.universe/issues/1735>`_)
+* feat(tier4_planning_rviz_plugin): add owner (`#1953 <https://github.com/autowarefoundation/autoware.universe/issues/1953>`_)
+* refactor(tier4_planning_rviz_plugin): apply clang-tidy for path (`#1637 <https://github.com/autowarefoundation/autoware.universe/issues/1637>`_)
+* feat(tier4_planning_rviz_plugin): add velocity_text to path_with_lane_id (`#1735 <https://github.com/autowarefoundation/autoware.universe/issues/1735>`_)
   * feat(tier4_planning_rviz_plugin): add velocity_text to path_with_lane_id
   * fix pre-commit
-* refactor(tier4_planning_rviz_plugin): apply clang-tidy for mission_checkpoint (`#1634 <https://github.com/youtalk/autoware.universe/issues/1634>`_)
+* refactor(tier4_planning_rviz_plugin): apply clang-tidy for mission_checkpoint (`#1634 <https://github.com/autowarefoundation/autoware.universe/issues/1634>`_)
   refactor(tier4_planning_rviz_plugin): apply clang-tidy for mission_checkpoint
-* refactor(tier4_planning_rviz_plugin): apply clang-tidy for drivable_area (`#1625 <https://github.com/youtalk/autoware.universe/issues/1625>`_)
-* fix: remove unused check of rviz plugin version (`#1474 <https://github.com/youtalk/autoware.universe/issues/1474>`_)
-* fix(tier4_planning_rviz_plugin): fix initialize planning_rviz_plugin (`#1387 <https://github.com/youtalk/autoware.universe/issues/1387>`_)
+* refactor(tier4_planning_rviz_plugin): apply clang-tidy for drivable_area (`#1625 <https://github.com/autowarefoundation/autoware.universe/issues/1625>`_)
+* fix: remove unused check of rviz plugin version (`#1474 <https://github.com/autowarefoundation/autoware.universe/issues/1474>`_)
+* fix(tier4_planning_rviz_plugin): fix initialize planning_rviz_plugin (`#1387 <https://github.com/autowarefoundation/autoware.universe/issues/1387>`_)
   * fix(tier4_planning_rviz_plugin): fix initialize planning_rviz_plugin
   * ci(pre-commit): autofix
   * remove comment out
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* fix(tier4_planning_rviz_plugin): support backward driving in path/traj plugin (`#1335 <https://github.com/youtalk/autoware.universe/issues/1335>`_)
+* fix(tier4_planning_rviz_plugin): support backward driving in path/traj plugin (`#1335 <https://github.com/autowarefoundation/autoware.universe/issues/1335>`_)
   * fix(tier4_planning_rviz_plugin): support backward driving in path_with_lane_id/path/trajectory plugin
   * add utils.hpp
-* feat: view LaneId on PathWithLaneIdFootprint plugin (`#984 <https://github.com/youtalk/autoware.universe/issues/984>`_)
+* feat: view LaneId on PathWithLaneIdFootprint plugin (`#984 <https://github.com/autowarefoundation/autoware.universe/issues/984>`_)
   * feat: view LaneId on PathWithLaneIdFootprint plugin
   * ci(pre-commit): autofix
   * fix: add utility
   * ci(pre-commit): autofix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* fix: set Eigen include directory as SYSTEM for Humble arm64 (`#978 <https://github.com/youtalk/autoware.universe/issues/978>`_)
-* feat(rviz_plugin): console meter is too large on the Rviz with FHD display, isn't it? (`#587 <https://github.com/youtalk/autoware.universe/issues/587>`_)
+* fix: set Eigen include directory as SYSTEM for Humble arm64 (`#978 <https://github.com/autowarefoundation/autoware.universe/issues/978>`_)
+* feat(rviz_plugin): console meter is too large on the Rviz with FHD display, isn't it? (`#587 <https://github.com/autowarefoundation/autoware.universe/issues/587>`_)
   * feat(tier4_planning/vehicle_plugin): make plugins size scalable
   * remove space
   * scaling
-* chore: upgrade cmake_minimum_required to 3.14 (`#856 <https://github.com/youtalk/autoware.universe/issues/856>`_)
-* refactor: simplify Rolling support (`#854 <https://github.com/youtalk/autoware.universe/issues/854>`_)
-* refactor: use autoware cmake (`#849 <https://github.com/youtalk/autoware.universe/issues/849>`_)
+* chore: upgrade cmake_minimum_required to 3.14 (`#856 <https://github.com/autowarefoundation/autoware.universe/issues/856>`_)
+* refactor: simplify Rolling support (`#854 <https://github.com/autowarefoundation/autoware.universe/issues/854>`_)
+* refactor: use autoware cmake (`#849 <https://github.com/autowarefoundation/autoware.universe/issues/849>`_)
   * remove autoware_auto_cmake
   * add build_depend of autoware_cmake
   * use autoware_cmake in CMakeLists.txt
   * fix bugs
   * fix cmake lint errors
-* fix: suppress compiler warnings (`#852 <https://github.com/youtalk/autoware.universe/issues/852>`_)
-* style: fix format of package.xml (`#844 <https://github.com/youtalk/autoware.universe/issues/844>`_)
-* fix(tier4_planning_rviz_plugins): modify build error in rolling (`#808 <https://github.com/youtalk/autoware.universe/issues/808>`_)
-* feat(tier4_planning_rviz_plugins): add vehicle_info to *FootprintDisplay (`#712 <https://github.com/youtalk/autoware.universe/issues/712>`_)
+* fix: suppress compiler warnings (`#852 <https://github.com/autowarefoundation/autoware.universe/issues/852>`_)
+* style: fix format of package.xml (`#844 <https://github.com/autowarefoundation/autoware.universe/issues/844>`_)
+* fix(tier4_planning_rviz_plugins): modify build error in rolling (`#808 <https://github.com/autowarefoundation/autoware.universe/issues/808>`_)
+* feat(tier4_planning_rviz_plugins): add vehicle_info to *FootprintDisplay (`#712 <https://github.com/autowarefoundation/autoware.universe/issues/712>`_)
   * feat(tier4_planning_rviz_plugins): add vehicle_info to PathFootprintDisplay
   * add vehicle_info to other footprint displays
   * fix the scope of local variables
   Co-authored-by: Takayuki Murooka <takayuki5168@gmail.com>
-* chore: sync files (`#629 <https://github.com/youtalk/autoware.universe/issues/629>`_)
+* chore: sync files (`#629 <https://github.com/autowarefoundation/autoware.universe/issues/629>`_)
   * chore: sync files
   * ci(pre-commit): autofix
   Co-authored-by: kenji-miyake <kenji-miyake@users.noreply.github.com>
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat(tier4_planning_rviz_plugin): add PathWithLaneIdFootprint rviz plugin (`#594 <https://github.com/youtalk/autoware.universe/issues/594>`_)
+* feat(tier4_planning_rviz_plugin): add PathWithLaneIdFootprint rviz plugin (`#594 <https://github.com/autowarefoundation/autoware.universe/issues/594>`_)
   * feat(tier4_planning_rviz_plugin): add PathWithLaneIdFootprint rviz plugin
   * ci(pre-commit): autofix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* chore(tier4_planning_rviz_plugin): add PathWithLaneId icon (`#593 <https://github.com/youtalk/autoware.universe/issues/593>`_)
-* feat(tier4_planning_rviz_plugin): add  PathWithLaneId rviz plugin (`#591 <https://github.com/youtalk/autoware.universe/issues/591>`_)
-  * sync rc rc/v1.7.1 (`#2345 <https://github.com/youtalk/autoware.universe/issues/2345>`_)
-  * add behavior_path_rviz_plugin (`#2343 <https://github.com/youtalk/autoware.universe/issues/2343>`_)
+* chore(tier4_planning_rviz_plugin): add PathWithLaneId icon (`#593 <https://github.com/autowarefoundation/autoware.universe/issues/593>`_)
+* feat(tier4_planning_rviz_plugin): add  PathWithLaneId rviz plugin (`#591 <https://github.com/autowarefoundation/autoware.universe/issues/591>`_)
+  * sync rc rc/v1.7.1 (`#2345 <https://github.com/autowarefoundation/autoware.universe/issues/2345>`_)
+  * add behavior_path_rviz_plugin (`#2343 <https://github.com/autowarefoundation/autoware.universe/issues/2343>`_)
   * add behavior_path_rviz_plugin
   * edit README
   * fix for uncrustify
@@ -258,14 +258,14 @@ Changelog for package tier4_planning_rviz_plugin
   Co-authored-by: autoware-iv-sync-ci[bot] <87871706+autoware-iv-sync-ci[bot]@users.noreply.github.com>
   Co-authored-by: Hiroki OTA <hiroki.ota@tier4.jp>
   Co-authored-by: Kenji Miyake <31987104+kenji-miyake@users.noreply.github.com>
-* feat: add drivable area visualizer (`#779 <https://github.com/youtalk/autoware.universe/issues/779>`_) (`#193 <https://github.com/youtalk/autoware.universe/issues/193>`_)
+* feat: add drivable area visualizer (`#779 <https://github.com/autowarefoundation/autoware.universe/issues/779>`_) (`#193 <https://github.com/autowarefoundation/autoware.universe/issues/193>`_)
   * add drivable area visualizer
   * add license
   * modify pointed out in pre-commit
   * modify pointed out in pre-commit
   Co-authored-by: Yukihiro Saito <yukky.saito@gmail.com>
-* fix: fix typo plannnig -> planning (`#195 <https://github.com/youtalk/autoware.universe/issues/195>`_)
-* feat: rename existing packages name starting with autoware to different names (`#180 <https://github.com/youtalk/autoware.universe/issues/180>`_)
+* fix: fix typo plannnig -> planning (`#195 <https://github.com/autowarefoundation/autoware.universe/issues/195>`_)
+* feat: rename existing packages name starting with autoware to different names (`#180 <https://github.com/autowarefoundation/autoware.universe/issues/180>`_)
   * autoware_api_utils -> tier4_api_utils
   * autoware_debug_tools -> tier4_debug_tools
   * autoware_error_monitor -> system_error_monitor

--- a/common/tier4_state_rviz_plugin/CHANGELOG.rst
+++ b/common/tier4_state_rviz_plugin/CHANGELOG.rst
@@ -5,26 +5,26 @@ Changelog for package tier4_state_rviz_plugin
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* fix(tier4_state_rviz_plugin): fix unmatchedSuppression (`#8921 <https://github.com/youtalk/autoware.universe/issues/8921>`_)
+* fix(tier4_state_rviz_plugin): fix unmatchedSuppression (`#8921 <https://github.com/autowarefoundation/autoware.universe/issues/8921>`_)
   fix:unmatchedSuppression
-* style: update state panel plugin (`#8846 <https://github.com/youtalk/autoware.universe/issues/8846>`_)
-* fix(tier4_state_rviz_plugin): fix unusedFunction (`#8841 <https://github.com/youtalk/autoware.universe/issues/8841>`_)
+* style: update state panel plugin (`#8846 <https://github.com/autowarefoundation/autoware.universe/issues/8846>`_)
+* fix(tier4_state_rviz_plugin): fix unusedFunction (`#8841 <https://github.com/autowarefoundation/autoware.universe/issues/8841>`_)
   fix:unusedFunction
-* fix(tier4_state_rviz_plugin): fix unusedFunction (`#8845 <https://github.com/youtalk/autoware.universe/issues/8845>`_)
+* fix(tier4_state_rviz_plugin): fix unusedFunction (`#8845 <https://github.com/autowarefoundation/autoware.universe/issues/8845>`_)
   * fix:unusedFunction
   * fix:unusedFunction
   * fix:revert
   ---------
-* fix(tier4_state_rviz_plugin): fix constVariablePointer (`#8832 <https://github.com/youtalk/autoware.universe/issues/8832>`_)
+* fix(tier4_state_rviz_plugin): fix constVariablePointer (`#8832 <https://github.com/autowarefoundation/autoware.universe/issues/8832>`_)
   fix:constVariablePointer
-* fix(tier4_state_rviz_plugin): fix shadowVariable (`#8831 <https://github.com/youtalk/autoware.universe/issues/8831>`_)
+* fix(tier4_state_rviz_plugin): fix shadowVariable (`#8831 <https://github.com/autowarefoundation/autoware.universe/issues/8831>`_)
   * fix:shadowVariable
   * fix:clang-format
   ---------
-* refactor(custom_button): improve drop shadow effect (`#8781 <https://github.com/youtalk/autoware.universe/issues/8781>`_)
-* fix(tier4_state_rviz_plugin): fix unmatchedSuppression (`#8658 <https://github.com/youtalk/autoware.universe/issues/8658>`_)
+* refactor(custom_button): improve drop shadow effect (`#8781 <https://github.com/autowarefoundation/autoware.universe/issues/8781>`_)
+* fix(tier4_state_rviz_plugin): fix unmatchedSuppression (`#8658 <https://github.com/autowarefoundation/autoware.universe/issues/8658>`_)
   fix:unmatchedSuppression
-* fix(tier4_state_rviz_plugin): fix unusedFunction (`#8608 <https://github.com/youtalk/autoware.universe/issues/8608>`_)
+* fix(tier4_state_rviz_plugin): fix unusedFunction (`#8608 <https://github.com/autowarefoundation/autoware.universe/issues/8608>`_)
   * fix:unusedFunction
   * fix:clang format
   * fix:revert custom button
@@ -39,35 +39,35 @@ Changelog for package tier4_state_rviz_plugin
   * fix:revert custom botton item
   * fix:remove declaration
   ---------
-* feat(tier4_adapi_rviz_plugin, tier4_state_rviz_plugin): set timestamp to velocity_limit msg from rviz panels (`#8548 <https://github.com/youtalk/autoware.universe/issues/8548>`_)
+* feat(tier4_adapi_rviz_plugin, tier4_state_rviz_plugin): set timestamp to velocity_limit msg from rviz panels (`#8548 <https://github.com/autowarefoundation/autoware.universe/issues/8548>`_)
   set timestamp to velocity_limit msg
-* feat!: replace autoware_auto_msgs with autoware_msgs for common modules (`#7239 <https://github.com/youtalk/autoware.universe/issues/7239>`_)
+* feat!: replace autoware_auto_msgs with autoware_msgs for common modules (`#7239 <https://github.com/autowarefoundation/autoware.universe/issues/7239>`_)
   Co-authored-by: Cynthia Liu <cynthia.liu@autocore.ai>
   Co-authored-by: NorahXiong <norah.xiong@autocore.ai>
   Co-authored-by: beginningfan <beginning.fan@autocore.ai>
-* feat: update autoware state panel (`#7036 <https://github.com/youtalk/autoware.universe/issues/7036>`_)
+* feat: update autoware state panel (`#7036 <https://github.com/autowarefoundation/autoware.universe/issues/7036>`_)
 * Contributors: Autumn60, Khalil Selyan, Ryohsuke Mitsudome, Yutaka Kondo, kobayu858
 
 0.26.0 (2024-04-03)
 -------------------
-* feat: add pull over to autoware_state_panel of rviz (`#6540 <https://github.com/youtalk/autoware.universe/issues/6540>`_)
-* chore: set log level of debug printing in rviz plugin to DEBUG (`#5996 <https://github.com/youtalk/autoware.universe/issues/5996>`_)
-* feat!: remove planning factor type (`#5793 <https://github.com/youtalk/autoware.universe/issues/5793>`_)
+* feat: add pull over to autoware_state_panel of rviz (`#6540 <https://github.com/autowarefoundation/autoware.universe/issues/6540>`_)
+* chore: set log level of debug printing in rviz plugin to DEBUG (`#5996 <https://github.com/autowarefoundation/autoware.universe/issues/5996>`_)
+* feat!: remove planning factor type (`#5793 <https://github.com/autowarefoundation/autoware.universe/issues/5793>`_)
   remove planning factor type
   Co-authored-by: Hiroki OTA <hiroki.ota@tier4.jp>
-* feat: change planning factor behavior constants (`#5590 <https://github.com/youtalk/autoware.universe/issues/5590>`_)
+* feat: change planning factor behavior constants (`#5590 <https://github.com/autowarefoundation/autoware.universe/issues/5590>`_)
   * replace module type
   * support compatibility
   ---------
   Co-authored-by: Hiroki OTA <hiroki.ota@tier4.jp>
-* feat(tier4_state_rviz_plugin): add init by gnss button (`#4392 <https://github.com/youtalk/autoware.universe/issues/4392>`_)
-* fix(tier4_state_rviz_plugin): add NEUTRAL on GEAR (`#3132 <https://github.com/youtalk/autoware.universe/issues/3132>`_)
+* feat(tier4_state_rviz_plugin): add init by gnss button (`#4392 <https://github.com/autowarefoundation/autoware.universe/issues/4392>`_)
+* fix(tier4_state_rviz_plugin): add NEUTRAL on GEAR (`#3132 <https://github.com/autowarefoundation/autoware.universe/issues/3132>`_)
   fix(tier4_state_rviz_plugin): fix bug https://github.com/autowarefoundation/autoware.universe/issues/3121
-* refactor(start_planner): rename pull out to start planner (`#3908 <https://github.com/youtalk/autoware.universe/issues/3908>`_)
-* build(iron): remove rmw_qos_profile_t (`#3809 <https://github.com/youtalk/autoware.universe/issues/3809>`_)
-* fix(rviz_plugin): fx traffic light and velocity factor rviz plugin (`#3598 <https://github.com/youtalk/autoware.universe/issues/3598>`_)
+* refactor(start_planner): rename pull out to start planner (`#3908 <https://github.com/autowarefoundation/autoware.universe/issues/3908>`_)
+* build(iron): remove rmw_qos_profile_t (`#3809 <https://github.com/autowarefoundation/autoware.universe/issues/3809>`_)
+* fix(rviz_plugin): fx traffic light and velocity factor rviz plugin (`#3598 <https://github.com/autowarefoundation/autoware.universe/issues/3598>`_)
   fix(rviz_plugin); fx traffic light and velocity factor rviz plugin
-* build: mark autoware_cmake as <buildtool_depend> (`#3616 <https://github.com/youtalk/autoware.universe/issues/3616>`_)
+* build: mark autoware_cmake as <buildtool_depend> (`#3616 <https://github.com/autowarefoundation/autoware.universe/issues/3616>`_)
   * build: mark autoware_cmake as <buildtool_depend>
   with <build_depend>, autoware_cmake is automatically exported with ament_target_dependencies() (unecessary)
   * style(pre-commit): autofix
@@ -75,17 +75,17 @@ Changelog for package tier4_state_rviz_plugin
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Kenji Miyake <kenji.miyake@tier4.jp>
-* refactor(behavior_path_planner): rename pull_over to goal_planner (`#3501 <https://github.com/youtalk/autoware.universe/issues/3501>`_)
-* chore: sync files (`#3227 <https://github.com/youtalk/autoware.universe/issues/3227>`_)
+* refactor(behavior_path_planner): rename pull_over to goal_planner (`#3501 <https://github.com/autowarefoundation/autoware.universe/issues/3501>`_)
+* chore: sync files (`#3227 <https://github.com/autowarefoundation/autoware.universe/issues/3227>`_)
   * chore: sync files
   * style(pre-commit): autofix
   ---------
   Co-authored-by: kenji-miyake <kenji-miyake@users.noreply.github.com>
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* fix(autoware_state_panel): change variable for fail safe behavior (`#2952 <https://github.com/youtalk/autoware.universe/issues/2952>`_)
+* fix(autoware_state_panel): change variable for fail safe behavior (`#2952 <https://github.com/autowarefoundation/autoware.universe/issues/2952>`_)
   fix fail safe behavior value
-* fix(tier4_state_rviz_plugin): fix typo (`#2988 <https://github.com/youtalk/autoware.universe/issues/2988>`_)
-* fix(tier4_state_rviz_plugin): split into two panels (`#2914 <https://github.com/youtalk/autoware.universe/issues/2914>`_)
+* fix(tier4_state_rviz_plugin): fix typo (`#2988 <https://github.com/autowarefoundation/autoware.universe/issues/2988>`_)
+* fix(tier4_state_rviz_plugin): split into two panels (`#2914 <https://github.com/autowarefoundation/autoware.universe/issues/2914>`_)
   * fix(tier4_state_rviz_plugin): split into two panels
   * feat: add image
   * style(pre-commit): autofix
@@ -100,16 +100,16 @@ Changelog for package tier4_state_rviz_plugin
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Takagi, Isamu <43976882+isamu-takagi@users.noreply.github.com>
-* feat(tier4_state_rviz_plugin): add planning API visualization (`#2632 <https://github.com/youtalk/autoware.universe/issues/2632>`_)
+* feat(tier4_state_rviz_plugin): add planning API visualization (`#2632 <https://github.com/autowarefoundation/autoware.universe/issues/2632>`_)
   feat(tier4_state_rviz_plugin): add Planning Visualization
   Co-authored-by: Takagi, Isamu <43976882+isamu-takagi@users.noreply.github.com>
-* feat(tier4_state_rviz_plugin): add Fail Safe Visualization (`#2626 <https://github.com/youtalk/autoware.universe/issues/2626>`_)
+* feat(tier4_state_rviz_plugin): add Fail Safe Visualization (`#2626 <https://github.com/autowarefoundation/autoware.universe/issues/2626>`_)
   * feat(tier4_state_rviz_plugin): add information for Fail Safe
   * fix color
   * ci(pre-commit): autofix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* docs(tier4_state_rviz_plugin): update readme (`#2475 <https://github.com/youtalk/autoware.universe/issues/2475>`_)
-* feat(tier4_state_rviz_plugin): add API monitoring for Routing, Localization and Motion (`#2436 <https://github.com/youtalk/autoware.universe/issues/2436>`_)
+* docs(tier4_state_rviz_plugin): update readme (`#2475 <https://github.com/autowarefoundation/autoware.universe/issues/2475>`_)
+* feat(tier4_state_rviz_plugin): add API monitoring for Routing, Localization and Motion (`#2436 <https://github.com/autowarefoundation/autoware.universe/issues/2436>`_)
   * feat: add viz for routing API
   * feat: add motion and localiation
   * some refactoring
@@ -122,7 +122,7 @@ Changelog for package tier4_state_rviz_plugin
   * ci(pre-commit): autofix
   Co-authored-by: Takagi, Isamu <isamu.takagi@tier4.jp>
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat(tier4_state_rviz_plugin): use ADAPI v1 instead of old API (`#2433 <https://github.com/youtalk/autoware.universe/issues/2433>`_)
+* feat(tier4_state_rviz_plugin): use ADAPI v1 instead of old API (`#2433 <https://github.com/autowarefoundation/autoware.universe/issues/2433>`_)
   * fix: delete path change approval
   * make operation and control mode layout
   * add nullptr
@@ -132,15 +132,15 @@ Changelog for package tier4_state_rviz_plugin
   * feat: add TRANSITION
   * fix comment
   * delete unused
-* chore(tier4_state_rviz_plugin): add maintainer (`#2435 <https://github.com/youtalk/autoware.universe/issues/2435>`_)
-* revert(tier4_state_rviz_plugin): readability-identifier-naming (`#1595 <https://github.com/youtalk/autoware.universe/issues/1595>`_) (`#1617 <https://github.com/youtalk/autoware.universe/issues/1617>`_)
-  revert(tier4_state_rviz_plugin): readability-identifier-naming (`#1595 <https://github.com/youtalk/autoware.universe/issues/1595>`_)"
+* chore(tier4_state_rviz_plugin): add maintainer (`#2435 <https://github.com/autowarefoundation/autoware.universe/issues/2435>`_)
+* revert(tier4_state_rviz_plugin): readability-identifier-naming (`#1595 <https://github.com/autowarefoundation/autoware.universe/issues/1595>`_) (`#1617 <https://github.com/autowarefoundation/autoware.universe/issues/1617>`_)
+  revert(tier4_state_rviz_plugin): readability-identifier-naming (`#1595 <https://github.com/autowarefoundation/autoware.universe/issues/1595>`_)"
   This reverts commit 57720204fd401a59b5dffd12d5b8958e5ae2a5af.
-* refactor(tier4_state_rviz_plugin): apply clang-tidy for readability-identifier-naming (`#1595 <https://github.com/youtalk/autoware.universe/issues/1595>`_)
+* refactor(tier4_state_rviz_plugin): apply clang-tidy for readability-identifier-naming (`#1595 <https://github.com/autowarefoundation/autoware.universe/issues/1595>`_)
   * refactor(tier4_state_rviz_plugin): apply clang-tidy for readability-identifier-naming
   * ci(pre-commit): autofix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* refactor(tier4_state_rviz_plugin): apply clang-tidy (`#1589 <https://github.com/youtalk/autoware.universe/issues/1589>`_)
+* refactor(tier4_state_rviz_plugin): apply clang-tidy (`#1589 <https://github.com/autowarefoundation/autoware.universe/issues/1589>`_)
   * fix: clang-tidy for tier4_state_rviz_plugin
   * ci(pre-commit): autofix
   * Update common/tier4_state_rviz_plugin/src/autoware_state_panel.cpp
@@ -154,47 +154,47 @@ Changelog for package tier4_state_rviz_plugin
   * ci(pre-commit): autofix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Kenji Miyake <31987104+kenji-miyake@users.noreply.github.com>
-* fix: remove unused check of rviz plugin version (`#1474 <https://github.com/youtalk/autoware.universe/issues/1474>`_)
-* fix(tier4_state_rviz_plugin): qos (`#1085 <https://github.com/youtalk/autoware.universe/issues/1085>`_)
-* feat(tier4_state_rviz_plugin): add emergency button (`#1048 <https://github.com/youtalk/autoware.universe/issues/1048>`_)
+* fix: remove unused check of rviz plugin version (`#1474 <https://github.com/autowarefoundation/autoware.universe/issues/1474>`_)
+* fix(tier4_state_rviz_plugin): qos (`#1085 <https://github.com/autowarefoundation/autoware.universe/issues/1085>`_)
+* feat(tier4_state_rviz_plugin): add emergency button (`#1048 <https://github.com/autowarefoundation/autoware.universe/issues/1048>`_)
   * feat(tier4_state_rviz_plugin):add emergency button
   * ci(pre-commit): autofix
   * chore: add default button name
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* revert: engage button action in autoware_state_panel (`#1079 <https://github.com/youtalk/autoware.universe/issues/1079>`_)
-  * Revert "fix(autoware_state_panel): fix message type for /api/autoware/get/engage (`#666 <https://github.com/youtalk/autoware.universe/issues/666>`_)"
+* revert: engage button action in autoware_state_panel (`#1079 <https://github.com/autowarefoundation/autoware.universe/issues/1079>`_)
+  * Revert "fix(autoware_state_panel): fix message type for /api/autoware/get/engage (`#666 <https://github.com/autowarefoundation/autoware.universe/issues/666>`_)"
   This reverts commit 49cc906418b15994b7facb881f3c133a9d8eb3a1.
-  * Revert "fix(tier4_state_rviz_plugin): change service and topic name for engage (`#633 <https://github.com/youtalk/autoware.universe/issues/633>`_)"
+  * Revert "fix(tier4_state_rviz_plugin): change service and topic name for engage (`#633 <https://github.com/autowarefoundation/autoware.universe/issues/633>`_)"
   This reverts commit 15f43bc7063809d38c369e405a82d9666826c052.
-* feat(state_rviz_plugin): add GateMode and PathChangeApproval Button (`#894 <https://github.com/youtalk/autoware.universe/issues/894>`_)
+* feat(state_rviz_plugin): add GateMode and PathChangeApproval Button (`#894 <https://github.com/autowarefoundation/autoware.universe/issues/894>`_)
   * feat(state_rviz_plugin): add GateMode and PathChangeApproval Button
   * ci(pre-commit): autofix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat(rviz_plugins): add velocity limit to autoware state panel (`#879 <https://github.com/youtalk/autoware.universe/issues/879>`_)
+* feat(rviz_plugins): add velocity limit to autoware state panel (`#879 <https://github.com/autowarefoundation/autoware.universe/issues/879>`_)
   * feat(rviz_plugins): add velocity limit to autoware state panel
   * chore(rviz_plugin): change ms to kmh
-* chore: upgrade cmake_minimum_required to 3.14 (`#856 <https://github.com/youtalk/autoware.universe/issues/856>`_)
-* refactor: use autoware cmake (`#849 <https://github.com/youtalk/autoware.universe/issues/849>`_)
+* chore: upgrade cmake_minimum_required to 3.14 (`#856 <https://github.com/autowarefoundation/autoware.universe/issues/856>`_)
+* refactor: use autoware cmake (`#849 <https://github.com/autowarefoundation/autoware.universe/issues/849>`_)
   * remove autoware_auto_cmake
   * add build_depend of autoware_cmake
   * use autoware_cmake in CMakeLists.txt
   * fix bugs
   * fix cmake lint errors
-* style: fix format of package.xml (`#844 <https://github.com/youtalk/autoware.universe/issues/844>`_)
-* fix(autoware_state_panel): fix message type for /api/autoware/get/engage (`#666 <https://github.com/youtalk/autoware.universe/issues/666>`_)
+* style: fix format of package.xml (`#844 <https://github.com/autowarefoundation/autoware.universe/issues/844>`_)
+* fix(autoware_state_panel): fix message type for /api/autoware/get/engage (`#666 <https://github.com/autowarefoundation/autoware.universe/issues/666>`_)
   * fix(autoware_state_panel): fix message type for /api/autoware/get/engage
   * ci(pre-commit): autofix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* chore: sync files (`#629 <https://github.com/youtalk/autoware.universe/issues/629>`_)
+* chore: sync files (`#629 <https://github.com/autowarefoundation/autoware.universe/issues/629>`_)
   * chore: sync files
   * ci(pre-commit): autofix
   Co-authored-by: kenji-miyake <kenji-miyake@users.noreply.github.com>
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* fix(tier4_state_rviz_plugin): change service and topic name for engage (`#633 <https://github.com/youtalk/autoware.universe/issues/633>`_)
-* feat: add selector mode and disengage function (`#781 <https://github.com/youtalk/autoware.universe/issues/781>`_) (`#194 <https://github.com/youtalk/autoware.universe/issues/194>`_)
+* fix(tier4_state_rviz_plugin): change service and topic name for engage (`#633 <https://github.com/autowarefoundation/autoware.universe/issues/633>`_)
+* feat: add selector mode and disengage function (`#781 <https://github.com/autowarefoundation/autoware.universe/issues/781>`_) (`#194 <https://github.com/autowarefoundation/autoware.universe/issues/194>`_)
   Co-authored-by: Hiroki OTA <hiroki.ota@tier4.jp>
   Co-authored-by: Tomoya Kimura <tomoya.kimura@tier4.jp>
-* feat: rename existing packages name starting with autoware to different names (`#180 <https://github.com/youtalk/autoware.universe/issues/180>`_)
+* feat: rename existing packages name starting with autoware to different names (`#180 <https://github.com/autowarefoundation/autoware.universe/issues/180>`_)
   * autoware_api_utils -> tier4_api_utils
   * autoware_debug_tools -> tier4_debug_tools
   * autoware_error_monitor -> system_error_monitor

--- a/common/tier4_system_rviz_plugin/CHANGELOG.rst
+++ b/common/tier4_system_rviz_plugin/CHANGELOG.rst
@@ -5,16 +5,16 @@ Changelog for package tier4_system_rviz_plugin
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* feat(system_error_monitor): remove system error monitor (`#8929 <https://github.com/youtalk/autoware.universe/issues/8929>`_)
+* feat(system_error_monitor): remove system error monitor (`#8929 <https://github.com/autowarefoundation/autoware.universe/issues/8929>`_)
   * feat: delete-system-error-monitor-from-autoware
   * feat: remove unnecessary params
   ---------
-* fix(tier4_system_rviz_plugin): fix cppcheck warning of virtualCallInConstructor (`#8378 <https://github.com/youtalk/autoware.universe/issues/8378>`_)
+* fix(tier4_system_rviz_plugin): fix cppcheck warning of virtualCallInConstructor (`#8378 <https://github.com/autowarefoundation/autoware.universe/issues/8378>`_)
   fix: deal with virtualCallInConstructor warning
   Co-authored-by: kminoda <44218668+kminoda@users.noreply.github.com>
-* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/youtalk/autoware.universe/issues/7538>`_)
+* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/autowarefoundation/autoware.universe/issues/7538>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* feat!: replace autoware_auto_msgs with autoware_msgs for common modules (`#7239 <https://github.com/youtalk/autoware.universe/issues/7239>`_)
+* feat!: replace autoware_auto_msgs with autoware_msgs for common modules (`#7239 <https://github.com/autowarefoundation/autoware.universe/issues/7239>`_)
   Co-authored-by: Cynthia Liu <cynthia.liu@autocore.ai>
   Co-authored-by: NorahXiong <norah.xiong@autocore.ai>
   Co-authored-by: beginningfan <beginning.fan@autocore.ai>
@@ -22,7 +22,7 @@ Changelog for package tier4_system_rviz_plugin
 
 0.26.0 (2024-04-03)
 -------------------
-* feat(tier4_system_rviz_plugin): improve visualization results and logics (`#5222 <https://github.com/youtalk/autoware.universe/issues/5222>`_)
+* feat(tier4_system_rviz_plugin): improve visualization results and logics (`#5222 <https://github.com/autowarefoundation/autoware.universe/issues/5222>`_)
   * Add Init Localization and Init Planning Check; Add error list check
   * style(pre-commit): autofix
   * int casting problem updated
@@ -39,8 +39,8 @@ Changelog for package tier4_system_rviz_plugin
   ---------
   Co-authored-by: Owen-Liuyuxuan <uken.ryu@tier4.jp>
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* refactor(common): extern template for motion_utils / remove tier4_autoware_utils.hpp / remove motion_utis.hpp (`#5027 <https://github.com/youtalk/autoware.universe/issues/5027>`_)
-* feat(tier4_system_rviz_plugin): add package (`#4945 <https://github.com/youtalk/autoware.universe/issues/4945>`_)
+* refactor(common): extern template for motion_utils / remove tier4_autoware_utils.hpp / remove motion_utis.hpp (`#5027 <https://github.com/autowarefoundation/autoware.universe/issues/5027>`_)
+* feat(tier4_system_rviz_plugin): add package (`#4945 <https://github.com/autowarefoundation/autoware.universe/issues/4945>`_)
   * feat(tier4_system_rviz_plugin): add package
   * update maintainer
   * style(pre-commit): autofix

--- a/common/tier4_traffic_light_rviz_plugin/CHANGELOG.rst
+++ b/common/tier4_traffic_light_rviz_plugin/CHANGELOG.rst
@@ -5,8 +5,8 @@ Changelog for package tier4_traffic_light_rviz_plugin
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* feat: add `autoware\_` prefix to `lanelet2_extension` (`#7640 <https://github.com/youtalk/autoware.universe/issues/7640>`_)
-* feat!: replace autoware_auto_msgs with autoware_msgs for common modules (`#7239 <https://github.com/youtalk/autoware.universe/issues/7239>`_)
+* feat: add `autoware\_` prefix to `lanelet2_extension` (`#7640 <https://github.com/autowarefoundation/autoware.universe/issues/7640>`_)
+* feat!: replace autoware_auto_msgs with autoware_msgs for common modules (`#7239 <https://github.com/autowarefoundation/autoware.universe/issues/7239>`_)
   Co-authored-by: Cynthia Liu <cynthia.liu@autocore.ai>
   Co-authored-by: NorahXiong <norah.xiong@autocore.ai>
   Co-authored-by: beginningfan <beginning.fan@autocore.ai>
@@ -14,7 +14,7 @@ Changelog for package tier4_traffic_light_rviz_plugin
 
 0.26.0 (2024-04-03)
 -------------------
-* feat(behavior_velocity): support new traffic signal interface (`#4133 <https://github.com/youtalk/autoware.universe/issues/4133>`_)
+* feat(behavior_velocity): support new traffic signal interface (`#4133 <https://github.com/autowarefoundation/autoware.universe/issues/4133>`_)
   * feat(behavior_velocity): support new traffic signal interface
   * style(pre-commit): autofix
   * add missing dependency
@@ -31,9 +31,9 @@ Changelog for package tier4_traffic_light_rviz_plugin
   * add debug log when the signal data is outdated
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* fix(rviz_plugin): fx traffic light and velocity factor rviz plugin (`#3598 <https://github.com/youtalk/autoware.universe/issues/3598>`_)
+* fix(rviz_plugin): fx traffic light and velocity factor rviz plugin (`#3598 <https://github.com/autowarefoundation/autoware.universe/issues/3598>`_)
   fix(rviz_plugin); fx traffic light and velocity factor rviz plugin
-* build: mark autoware_cmake as <buildtool_depend> (`#3616 <https://github.com/youtalk/autoware.universe/issues/3616>`_)
+* build: mark autoware_cmake as <buildtool_depend> (`#3616 <https://github.com/autowarefoundation/autoware.universe/issues/3616>`_)
   * build: mark autoware_cmake as <buildtool_depend>
   with <build_depend>, autoware_cmake is automatically exported with ament_target_dependencies() (unecessary)
   * style(pre-commit): autofix
@@ -41,21 +41,21 @@ Changelog for package tier4_traffic_light_rviz_plugin
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Kenji Miyake <kenji.miyake@tier4.jp>
-* refactor(tier4_traffic_light_rviz_plugin): apply clang-tidy (`#1650 <https://github.com/youtalk/autoware.universe/issues/1650>`_)
-* fix: remove unused check of rviz plugin version (`#1474 <https://github.com/youtalk/autoware.universe/issues/1474>`_)
-* feat(traffic-light-rviz-panel): select traffic light ID from Combobox (`#1010 <https://github.com/youtalk/autoware.universe/issues/1010>`_)
+* refactor(tier4_traffic_light_rviz_plugin): apply clang-tidy (`#1650 <https://github.com/autowarefoundation/autoware.universe/issues/1650>`_)
+* fix: remove unused check of rviz plugin version (`#1474 <https://github.com/autowarefoundation/autoware.universe/issues/1474>`_)
+* feat(traffic-light-rviz-panel): select traffic light ID from Combobox (`#1010 <https://github.com/autowarefoundation/autoware.universe/issues/1010>`_)
   * feat(traffic-light-rviz-panel): (1) select traffic light ID instead of inputting its value (2) added a workaround for tinyxml2::tinyxml2 for humble build (3) updated README and fixed mkdocs.yaml to upload .gif file to unvierse documentation (4)sort traffic light IDs, use scrollable box
-* docs(tier4_traffic_light_rviz_plugin): update documentation (`#905 <https://github.com/youtalk/autoware.universe/issues/905>`_)
-* chore: upgrade cmake_minimum_required to 3.14 (`#856 <https://github.com/youtalk/autoware.universe/issues/856>`_)
-* refactor: use autoware cmake (`#849 <https://github.com/youtalk/autoware.universe/issues/849>`_)
+* docs(tier4_traffic_light_rviz_plugin): update documentation (`#905 <https://github.com/autowarefoundation/autoware.universe/issues/905>`_)
+* chore: upgrade cmake_minimum_required to 3.14 (`#856 <https://github.com/autowarefoundation/autoware.universe/issues/856>`_)
+* refactor: use autoware cmake (`#849 <https://github.com/autowarefoundation/autoware.universe/issues/849>`_)
   * remove autoware_auto_cmake
   * add build_depend of autoware_cmake
   * use autoware_cmake in CMakeLists.txt
   * fix bugs
   * fix cmake lint errors
-* style: fix format of package.xml (`#844 <https://github.com/youtalk/autoware.universe/issues/844>`_)
-* feat(tier4_traffic_light_rviz_plugin): selectable light shape, status and confidence (`#663 <https://github.com/youtalk/autoware.universe/issues/663>`_)
-* feat(tier4_traffic_light_rviz_plugin): add traffic light publish panel (`#640 <https://github.com/youtalk/autoware.universe/issues/640>`_)
+* style: fix format of package.xml (`#844 <https://github.com/autowarefoundation/autoware.universe/issues/844>`_)
+* feat(tier4_traffic_light_rviz_plugin): selectable light shape, status and confidence (`#663 <https://github.com/autowarefoundation/autoware.universe/issues/663>`_)
+* feat(tier4_traffic_light_rviz_plugin): add traffic light publish panel (`#640 <https://github.com/autowarefoundation/autoware.universe/issues/640>`_)
   * feat(tier4_traffic_light_rviz_plugin): add traffic light publish panel
   * fix(tier4_traffic_light_rviz_plugin): fix behavior
   * fix: lisense description

--- a/common/tier4_vehicle_rviz_plugin/CHANGELOG.rst
+++ b/common/tier4_vehicle_rviz_plugin/CHANGELOG.rst
@@ -5,16 +5,16 @@ Changelog for package tier4_vehicle_rviz_plugin
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* fix(tier4_vehicle_rviz_plugin): fix cppcheck warning of virtualCallInConstructor (`#8379 <https://github.com/youtalk/autoware.universe/issues/8379>`_)
+* fix(tier4_vehicle_rviz_plugin): fix cppcheck warning of virtualCallInConstructor (`#8379 <https://github.com/autowarefoundation/autoware.universe/issues/8379>`_)
   fix: deal with virtualCallInConstructor warning
   Co-authored-by: Ryuta Kambe <ryuta.kambe@tier4.jp>
-* fix: replace Ogre deprecated header (`#7606 <https://github.com/youtalk/autoware.universe/issues/7606>`_)
+* fix: replace Ogre deprecated header (`#7606 <https://github.com/autowarefoundation/autoware.universe/issues/7606>`_)
   Fix Ogre deprecated header
   Co-authored-by: Kotaro Yoshimoto <pythagora.yoshimoto@gmail.com>
-* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/youtalk/autoware.universe/issues/7594>`_)
-* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/youtalk/autoware.universe/issues/7538>`_)
+* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/autowarefoundation/autoware.universe/issues/7594>`_)
+* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/autowarefoundation/autoware.universe/issues/7538>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* feat!: replace autoware_auto_msgs with autoware_msgs for common modules (`#7239 <https://github.com/youtalk/autoware.universe/issues/7239>`_)
+* feat!: replace autoware_auto_msgs with autoware_msgs for common modules (`#7239 <https://github.com/autowarefoundation/autoware.universe/issues/7239>`_)
   Co-authored-by: Cynthia Liu <cynthia.liu@autocore.ai>
   Co-authored-by: NorahXiong <norah.xiong@autocore.ai>
   Co-authored-by: beginningfan <beginning.fan@autocore.ai>
@@ -22,14 +22,14 @@ Changelog for package tier4_vehicle_rviz_plugin
 
 0.26.0 (2024-04-03)
 -------------------
-* refactor(common): extern template for motion_utils / remove tier4_autoware_utils.hpp / remove motion_utis.hpp (`#5027 <https://github.com/youtalk/autoware.universe/issues/5027>`_)
-* chore(build): remove tier4_autoware_utils.hpp in common/ (`#4828 <https://github.com/youtalk/autoware.universe/issues/4828>`_)
+* refactor(common): extern template for motion_utils / remove tier4_autoware_utils.hpp / remove motion_utis.hpp (`#5027 <https://github.com/autowarefoundation/autoware.universe/issues/5027>`_)
+* chore(build): remove tier4_autoware_utils.hpp in common/ (`#4828 <https://github.com/autowarefoundation/autoware.universe/issues/4828>`_)
   removed tier4_autoware_utils.hpp in common/
-* chore: do not display steer and velocity value when message is not subscribed yet (`#4739 <https://github.com/youtalk/autoware.universe/issues/4739>`_)
+* chore: do not display steer and velocity value when message is not subscribed yet (`#4739 <https://github.com/autowarefoundation/autoware.universe/issues/4739>`_)
   * chore: do not display steer and velocity value when message is not subscribed yet
   * chore: change msgs
   ---------
-* feat(tier4_vehicle_rviz_plugin): add acceleration visualization plugin to RViz (`#4506 <https://github.com/youtalk/autoware.universe/issues/4506>`_)
+* feat(tier4_vehicle_rviz_plugin): add acceleration visualization plugin to RViz (`#4506 <https://github.com/autowarefoundation/autoware.universe/issues/4506>`_)
   * feat: add acceleration visualization plugin to RVIZ
   * feat: add RVIZ plugin for acceleration; remove limit text; debugging: property_label_scale\_ not responding
   * style(pre-commit): autofix
@@ -40,7 +40,7 @@ Changelog for package tier4_vehicle_rviz_plugin
   ---------
   Co-authored-by: Owen-Liuyuxuan <uken.ryu@tier4.jp>
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* build: mark autoware_cmake as <buildtool_depend> (`#3616 <https://github.com/youtalk/autoware.universe/issues/3616>`_)
+* build: mark autoware_cmake as <buildtool_depend> (`#3616 <https://github.com/autowarefoundation/autoware.universe/issues/3616>`_)
   * build: mark autoware_cmake as <buildtool_depend>
   with <build_depend>, autoware_cmake is automatically exported with ament_target_dependencies() (unecessary)
   * style(pre-commit): autofix
@@ -48,34 +48,34 @@ Changelog for package tier4_vehicle_rviz_plugin
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Kenji Miyake <kenji.miyake@tier4.jp>
-* chore: sync files (`#3227 <https://github.com/youtalk/autoware.universe/issues/3227>`_)
+* chore: sync files (`#3227 <https://github.com/autowarefoundation/autoware.universe/issues/3227>`_)
   * chore: sync files
   * style(pre-commit): autofix
   ---------
   Co-authored-by: kenji-miyake <kenji-miyake@users.noreply.github.com>
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* fix(tier4_planning/vehicle_rviz_plugin): fixed license (`#2059 <https://github.com/youtalk/autoware.universe/issues/2059>`_)
+* fix(tier4_planning/vehicle_rviz_plugin): fixed license (`#2059 <https://github.com/autowarefoundation/autoware.universe/issues/2059>`_)
   * fix(tier4_planning/vehicle_rviz_plugin): fixed license
   * fix build error
-* fix: remove unused check of rviz plugin version (`#1474 <https://github.com/youtalk/autoware.universe/issues/1474>`_)
-* fix(tier4_vehicle_rviz_plugin): initialization vehicle rivz plugin (`#1379 <https://github.com/youtalk/autoware.universe/issues/1379>`_)
+* fix: remove unused check of rviz plugin version (`#1474 <https://github.com/autowarefoundation/autoware.universe/issues/1474>`_)
+* fix(tier4_vehicle_rviz_plugin): initialization vehicle rivz plugin (`#1379 <https://github.com/autowarefoundation/autoware.universe/issues/1379>`_)
   * fix(tier4_vehicle_rviz_plugin): initialization vehicle rviz plugin
   * initialize signal_type
-* feat(rviz_plugin): console meter is too large on the Rviz with FHD display, isn't it? (`#587 <https://github.com/youtalk/autoware.universe/issues/587>`_)
+* feat(rviz_plugin): console meter is too large on the Rviz with FHD display, isn't it? (`#587 <https://github.com/autowarefoundation/autoware.universe/issues/587>`_)
   * feat(tier4_planning/vehicle_plugin): make plugins size scalable
   * remove space
   * scaling
-* chore: upgrade cmake_minimum_required to 3.14 (`#856 <https://github.com/youtalk/autoware.universe/issues/856>`_)
-* refactor: simplify Rolling support (`#854 <https://github.com/youtalk/autoware.universe/issues/854>`_)
-* refactor: use autoware cmake (`#849 <https://github.com/youtalk/autoware.universe/issues/849>`_)
+* chore: upgrade cmake_minimum_required to 3.14 (`#856 <https://github.com/autowarefoundation/autoware.universe/issues/856>`_)
+* refactor: simplify Rolling support (`#854 <https://github.com/autowarefoundation/autoware.universe/issues/854>`_)
+* refactor: use autoware cmake (`#849 <https://github.com/autowarefoundation/autoware.universe/issues/849>`_)
   * remove autoware_auto_cmake
   * add build_depend of autoware_cmake
   * use autoware_cmake in CMakeLists.txt
   * fix bugs
   * fix cmake lint errors
-* fix: suppress compiler warnings (`#852 <https://github.com/youtalk/autoware.universe/issues/852>`_)
-* style: fix format of package.xml (`#844 <https://github.com/youtalk/autoware.universe/issues/844>`_)
-* fix(tier4_autoware_utils): modify build error in rolling (`#720 <https://github.com/youtalk/autoware.universe/issues/720>`_)
+* fix: suppress compiler warnings (`#852 <https://github.com/autowarefoundation/autoware.universe/issues/852>`_)
+* style: fix format of package.xml (`#844 <https://github.com/autowarefoundation/autoware.universe/issues/844>`_)
+* fix(tier4_autoware_utils): modify build error in rolling (`#720 <https://github.com/autowarefoundation/autoware.universe/issues/720>`_)
   * fix(tier4_autoware_utils): modify build error in rolling
   * fix(lanelet2_extension): add target compile definition for geometry2
   * fix(ekf_localizer): add target compile definition for geometry2
@@ -113,7 +113,7 @@ Changelog for package tier4_vehicle_rviz_plugin
   * fix(planning_error_monitor): add target compile definition for geometry2
   * fix(planning_evaluator): add target compile definition for geometry2
   * fix(lidar_centerpoint): add target compile definition for geometry2
-* feat: rename existing packages name starting with autoware to different names (`#180 <https://github.com/youtalk/autoware.universe/issues/180>`_)
+* feat: rename existing packages name starting with autoware to different names (`#180 <https://github.com/autowarefoundation/autoware.universe/issues/180>`_)
   * autoware_api_utils -> tier4_api_utils
   * autoware_debug_tools -> tier4_debug_tools
   * autoware_error_monitor -> system_error_monitor

--- a/common/traffic_light_recognition_marker_publisher/CHANGELOG.rst
+++ b/common/traffic_light_recognition_marker_publisher/CHANGELOG.rst
@@ -5,14 +5,14 @@ Changelog for package traffic_light_recognition_marker_publisher
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* feat: add `autoware\_` prefix to `lanelet2_extension` (`#7640 <https://github.com/youtalk/autoware.universe/issues/7640>`_)
-* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/youtalk/autoware.universe/issues/7538>`_)
+* feat: add `autoware\_` prefix to `lanelet2_extension` (`#7640 <https://github.com/autowarefoundation/autoware.universe/issues/7640>`_)
+* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/autowarefoundation/autoware.universe/issues/7538>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* feat!: replace autoware_auto_msgs with autoware_msgs for common modules (`#7239 <https://github.com/youtalk/autoware.universe/issues/7239>`_)
+* feat!: replace autoware_auto_msgs with autoware_msgs for common modules (`#7239 <https://github.com/autowarefoundation/autoware.universe/issues/7239>`_)
   Co-authored-by: Cynthia Liu <cynthia.liu@autocore.ai>
   Co-authored-by: NorahXiong <norah.xiong@autocore.ai>
   Co-authored-by: beginningfan <beginning.fan@autocore.ai>
-* docs(common): adding .pages file (`#7148 <https://github.com/youtalk/autoware.universe/issues/7148>`_)
+* docs(common): adding .pages file (`#7148 <https://github.com/autowarefoundation/autoware.universe/issues/7148>`_)
   * docs(common): adding .pages file
   * fix naming
   * fix naming
@@ -25,7 +25,7 @@ Changelog for package traffic_light_recognition_marker_publisher
 
 0.26.0 (2024-04-03)
 -------------------
-* feat: add visualization node of traffic light recognition result (`#4099 <https://github.com/youtalk/autoware.universe/issues/4099>`_)
+* feat: add visualization node of traffic light recognition result (`#4099 <https://github.com/autowarefoundation/autoware.universe/issues/4099>`_)
   * feat: add visualization node of traffic light recognition result
   * docs: update readme
   * chore: change image

--- a/common/traffic_light_utils/CHANGELOG.rst
+++ b/common/traffic_light_utils/CHANGELOG.rst
@@ -5,12 +5,12 @@ Changelog for package traffic_light_utils
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* fix(traffic_light_utils): fix unusedFunction (`#8605 <https://github.com/youtalk/autoware.universe/issues/8605>`_)
+* fix(traffic_light_utils): fix unusedFunction (`#8605 <https://github.com/autowarefoundation/autoware.universe/issues/8605>`_)
   * fix:unusedFunction
   * fix:unusedFunction
   ---------
-* feat: add `autoware\_` prefix to `lanelet2_extension` (`#7640 <https://github.com/youtalk/autoware.universe/issues/7640>`_)
-* feat!: replace autoware_auto_msgs with autoware_msgs for common modules (`#7239 <https://github.com/youtalk/autoware.universe/issues/7239>`_)
+* feat: add `autoware\_` prefix to `lanelet2_extension` (`#7640 <https://github.com/autowarefoundation/autoware.universe/issues/7640>`_)
+* feat!: replace autoware_auto_msgs with autoware_msgs for common modules (`#7239 <https://github.com/autowarefoundation/autoware.universe/issues/7239>`_)
   Co-authored-by: Cynthia Liu <cynthia.liu@autocore.ai>
   Co-authored-by: NorahXiong <norah.xiong@autocore.ai>
   Co-authored-by: beginningfan <beginning.fan@autocore.ai>
@@ -18,24 +18,24 @@ Changelog for package traffic_light_utils
 
 0.26.0 (2024-04-03)
 -------------------
-* chore(perception modules): remove maintainer... (`#6499 <https://github.com/youtalk/autoware.universe/issues/6499>`_)
+* chore(perception modules): remove maintainer... (`#6499 <https://github.com/autowarefoundation/autoware.universe/issues/6499>`_)
   * change maintainer
   * add uetake san as maintainer
   ---------
-* refactor(tier4_perception_msgs): rename traffic_signal to traffic_light (`#6375 <https://github.com/youtalk/autoware.universe/issues/6375>`_)
+* refactor(tier4_perception_msgs): rename traffic_signal to traffic_light (`#6375 <https://github.com/autowarefoundation/autoware.universe/issues/6375>`_)
   * rename traffic_signal to traffic_light
   * style(pre-commit): autofix
   * fix(crosswalk_traffic_light_estimator): remove unused include, readme
   * rename traffic_signal_array to traffic_light_array
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* fix(avoidance, lane_change): modules handle unknown traffic signal in the same way as red signal (`#6013 <https://github.com/youtalk/autoware.universe/issues/6013>`_)
+* fix(avoidance, lane_change): modules handle unknown traffic signal in the same way as red signal (`#6013 <https://github.com/autowarefoundation/autoware.universe/issues/6013>`_)
   * fix(avoidance, lane_change): modules handle unknown traffic signal in the same way as red signal
   * feat(traffic_light_utils): add util functions
   * refactor(bpp): use traffic light utils
   * refactor(bvp): use traffic light utils
   ---------
-* feat(crosswalk_traffic_light): add detector and classifier for pedestrian traffic light  (`#5871 <https://github.com/youtalk/autoware.universe/issues/5871>`_)
+* feat(crosswalk_traffic_light): add detector and classifier for pedestrian traffic light  (`#5871 <https://github.com/autowarefoundation/autoware.universe/issues/5871>`_)
   * add: crosswalk traffic light recognition
   * fix: set conf=0 when occluded
   * fix: clean code
@@ -99,7 +99,7 @@ Changelog for package traffic_light_utils
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Yusuke Muramatsu <yukke42@users.noreply.github.com>
-* test(traffic_light_utils): add test_traffic_light_utils (`#4643 <https://github.com/youtalk/autoware.universe/issues/4643>`_)
+* test(traffic_light_utils): add test_traffic_light_utils (`#4643 <https://github.com/autowarefoundation/autoware.universe/issues/4643>`_)
   * test(traffic_light_utils): add test_traffic_light_utils
   * style(pre-commit): autofix
   * fix(traffic_light_utils): fix magic number
@@ -108,8 +108,8 @@ Changelog for package traffic_light_utils
   * style(pre-commit): autofix
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* docs: add readme to perception related utils (`#4265 <https://github.com/youtalk/autoware.universe/issues/4265>`_)
-* chore: separate traffic_light_utils from perception_utils (`#4207 <https://github.com/youtalk/autoware.universe/issues/4207>`_)
+* docs: add readme to perception related utils (`#4265 <https://github.com/autowarefoundation/autoware.universe/issues/4265>`_)
+* chore: separate traffic_light_utils from perception_utils (`#4207 <https://github.com/autowarefoundation/autoware.universe/issues/4207>`_)
   * separate traffic_light_utils from perception_utils
   * style(pre-commit): autofix
   * fix namespace bug

--- a/control/autoware_autonomous_emergency_braking/CHANGELOG.rst
+++ b/control/autoware_autonomous_emergency_braking/CHANGELOG.rst
@@ -5,12 +5,12 @@ Changelog for package autoware_autonomous_emergency_braking
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* fix(autonomous_emergency_braking): fix no backward imu path and wrong back distance usage (`#9141 <https://github.com/youtalk/autoware.universe/issues/9141>`_)
+* fix(autonomous_emergency_braking): fix no backward imu path and wrong back distance usage (`#9141 <https://github.com/autowarefoundation/autoware.universe/issues/9141>`_)
   * fix no backward imu path and wrong back distance usage
   * use the motion utils isDrivingForward function
   ---------
-* refactor(autoware_autonomous_emergency_braking): rename info_marker_publisher to virtual_wall_publisher (`#9078 <https://github.com/youtalk/autoware.universe/issues/9078>`_)
-* feat(autonomous_emergency_braking): set max imu path length (`#9004 <https://github.com/youtalk/autoware.universe/issues/9004>`_)
+* refactor(autoware_autonomous_emergency_braking): rename info_marker_publisher to virtual_wall_publisher (`#9078 <https://github.com/autowarefoundation/autoware.universe/issues/9078>`_)
+* feat(autonomous_emergency_braking): set max imu path length (`#9004 <https://github.com/autowarefoundation/autoware.universe/issues/9004>`_)
   * set a limit to the imu path length
   * fix test and add a new one
   * update readme
@@ -19,9 +19,9 @@ Changelog for package autoware_autonomous_emergency_braking
   * refactor to reduce repeated code
   * cleaning code
   ---------
-* feat(autonomous_emergency_braking): add sanity chackes (`#8998 <https://github.com/youtalk/autoware.universe/issues/8998>`_)
+* feat(autonomous_emergency_braking): add sanity chackes (`#8998 <https://github.com/autowarefoundation/autoware.universe/issues/8998>`_)
   add sanity chackes
-* feat(autonomous_emergency_braking): calculate the object's velocity in the search area (`#8591 <https://github.com/youtalk/autoware.universe/issues/8591>`_)
+* feat(autonomous_emergency_braking): calculate the object's velocity in the search area (`#8591 <https://github.com/autowarefoundation/autoware.universe/issues/8591>`_)
   * refactor PR
   * WIP
   * change using polygon to lateral offset
@@ -31,45 +31,45 @@ Changelog for package autoware_autonomous_emergency_braking
   * fix empty path points in short parking scenario
   * fix readme conflicts
   ---------
-* docs(autonomous_emergency_braking): add missing params to README (`#8950 <https://github.com/youtalk/autoware.universe/issues/8950>`_)
+* docs(autonomous_emergency_braking): add missing params to README (`#8950 <https://github.com/autowarefoundation/autoware.universe/issues/8950>`_)
   add missing params
-* feat(autonomous_emergency_braking): make hull markers 3d (`#8930 <https://github.com/youtalk/autoware.universe/issues/8930>`_)
+* feat(autonomous_emergency_braking): make hull markers 3d (`#8930 <https://github.com/autowarefoundation/autoware.universe/issues/8930>`_)
   make hull markers 3d
-* docs(autonomous_emergency_braking): make a clearer image for aeb when localization is faulty (`#8873 <https://github.com/youtalk/autoware.universe/issues/8873>`_)
+* docs(autonomous_emergency_braking): make a clearer image for aeb when localization is faulty (`#8873 <https://github.com/autowarefoundation/autoware.universe/issues/8873>`_)
   make a clearer image for aeb when localization is faulty
-* feat(autonomous_emergency_braking): add markers showing aeb convex hull polygons for debugging purposes (`#8865 <https://github.com/youtalk/autoware.universe/issues/8865>`_)
+* feat(autonomous_emergency_braking): add markers showing aeb convex hull polygons for debugging purposes (`#8865 <https://github.com/autowarefoundation/autoware.universe/issues/8865>`_)
   * add markers showing aeb convex hull polygons for debugging purposes
   * fix briefs
   * fix typo
   ---------
-* fix(control): align the parameters with launcher (`#8789 <https://github.com/youtalk/autoware.universe/issues/8789>`_)
+* fix(control): align the parameters with launcher (`#8789 <https://github.com/autowarefoundation/autoware.universe/issues/8789>`_)
   align the control parameters
-* feat(autonomous_emergency_braking): speed up aeb (`#8778 <https://github.com/youtalk/autoware.universe/issues/8778>`_)
+* feat(autonomous_emergency_braking): speed up aeb (`#8778 <https://github.com/autowarefoundation/autoware.universe/issues/8778>`_)
   * add missing rclcpp::Time(0)
   * refactor to reduce cropping to once per iteration
   * add LookUpTransform to utils
   * separate object creation and clustering
   * error handling of empty pointcloud
   ---------
-* feat(autonomous_emergency_braking): increase aeb speed by getting last transform (`#8734 <https://github.com/youtalk/autoware.universe/issues/8734>`_)
+* feat(autonomous_emergency_braking): increase aeb speed by getting last transform (`#8734 <https://github.com/autowarefoundation/autoware.universe/issues/8734>`_)
   set stamp to 0 to get the latest stamp instead of waiting for the stamp
-* feat(autonomous_emergency_braking): add timekeeper to AEB (`#8706 <https://github.com/youtalk/autoware.universe/issues/8706>`_)
+* feat(autonomous_emergency_braking): add timekeeper to AEB (`#8706 <https://github.com/autowarefoundation/autoware.universe/issues/8706>`_)
   * add timekeeper to AEB
   * add more info to output
   ---------
-* docs(autoware_autonomous_emergency_braking): improve AEB module's README (`#8612 <https://github.com/youtalk/autoware.universe/issues/8612>`_)
+* docs(autoware_autonomous_emergency_braking): improve AEB module's README (`#8612 <https://github.com/autowarefoundation/autoware.universe/issues/8612>`_)
   * docs: improve AEB module's README
   * update rss distance length
   ---------
-* fix(autonomous_emergency_braking): fix debug marker visual bug (`#8611 <https://github.com/youtalk/autoware.universe/issues/8611>`_)
+* fix(autonomous_emergency_braking): fix debug marker visual bug (`#8611 <https://github.com/autowarefoundation/autoware.universe/issues/8611>`_)
   fix bug by using the collision data keeper
-* feat(autonomous_emergency_braking): enable aeb with only one req path (`#8569 <https://github.com/youtalk/autoware.universe/issues/8569>`_)
+* feat(autonomous_emergency_braking): enable aeb with only one req path (`#8569 <https://github.com/autowarefoundation/autoware.universe/issues/8569>`_)
   * make it so AEB works with only one req path type (imu or MPC)
   * fix missing mpc path return
   * add check
   * modify no path msg
   ---------
-* feat(autonomous_emergency_braking): add some tests to aeb (`#8126 <https://github.com/youtalk/autoware.universe/issues/8126>`_)
+* feat(autonomous_emergency_braking): add some tests to aeb (`#8126 <https://github.com/autowarefoundation/autoware.universe/issues/8126>`_)
   * add initial tests
   * add more tests
   * more tests
@@ -84,11 +84,11 @@ Changelog for package autoware_autonomous_emergency_braking
   * add briefs
   * delete repeated test
   ---------
-* docs(autonomous_emergency_braking): update readme for new param (`#8330 <https://github.com/youtalk/autoware.universe/issues/8330>`_)
+* docs(autonomous_emergency_braking): update readme for new param (`#8330 <https://github.com/autowarefoundation/autoware.universe/issues/8330>`_)
   update readme for new param
-* feat(autonomous_emergency_braking): add info marker and override for state (`#8312 <https://github.com/youtalk/autoware.universe/issues/8312>`_)
+* feat(autonomous_emergency_braking): add info marker and override for state (`#8312 <https://github.com/autowarefoundation/autoware.universe/issues/8312>`_)
   add info marker and override for state
-* refactor(pointcloud_preprocessor): prefix package and namespace with autoware (`#7983 <https://github.com/youtalk/autoware.universe/issues/7983>`_)
+* refactor(pointcloud_preprocessor): prefix package and namespace with autoware (`#7983 <https://github.com/autowarefoundation/autoware.universe/issues/7983>`_)
   * refactor(pointcloud_preprocessor)!: prefix package and namespace with autoware
   * style(pre-commit): autofix
   * style(pointcloud_preprocessor): suppress line length check for macros
@@ -102,23 +102,23 @@ Changelog for package autoware_autonomous_emergency_braking
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Kenzo Lobos Tsunekawa <kenzo.lobos@tier4.jp>
-* feat(autonomous_emergency_braking): add virtual stop wall to aeb (`#7894 <https://github.com/youtalk/autoware.universe/issues/7894>`_)
+* feat(autonomous_emergency_braking): add virtual stop wall to aeb (`#7894 <https://github.com/autowarefoundation/autoware.universe/issues/7894>`_)
   * add virtual stop wall to aeb
   * add maintainer
   * add uppercase
   * use motion utils function instead of shiftPose
   ---------
-* chore(autonomous_emergency_braking): apply clangd suggestions to aeb (`#7703 <https://github.com/youtalk/autoware.universe/issues/7703>`_)
+* chore(autonomous_emergency_braking): apply clangd suggestions to aeb (`#7703 <https://github.com/autowarefoundation/autoware.universe/issues/7703>`_)
   * apply clangd suggestions
   * add maintainer
   ---------
-* feat(autonomous_emergency_braking): aeb add support negative speeds (`#7707 <https://github.com/youtalk/autoware.universe/issues/7707>`_)
+* feat(autonomous_emergency_braking): aeb add support negative speeds (`#7707 <https://github.com/autowarefoundation/autoware.universe/issues/7707>`_)
   * add support for negative speeds
   * remove negative speed check for predicted obj
   ---------
-* fix(autonomous_emergency_braking): aeb strange mpc polygon (`#7740 <https://github.com/youtalk/autoware.universe/issues/7740>`_)
+* fix(autonomous_emergency_braking): aeb strange mpc polygon (`#7740 <https://github.com/autowarefoundation/autoware.universe/issues/7740>`_)
   change resize to reserve
-* feat(autonomous_emergency_braking): add cluster min height for aeb (`#7605 <https://github.com/youtalk/autoware.universe/issues/7605>`_)
+* feat(autonomous_emergency_braking): add cluster min height for aeb (`#7605 <https://github.com/autowarefoundation/autoware.universe/issues/7605>`_)
   * add minimum cluster height threshold
   * add update param option
   * use param
@@ -126,8 +126,8 @@ Changelog for package autoware_autonomous_emergency_braking
   * update README
   * add cluster height description
   ---------
-* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/youtalk/autoware.universe/issues/7594>`_)
-* feat(autonomous_emergency_braking): add predicted object support for aeb (`#7548 <https://github.com/youtalk/autoware.universe/issues/7548>`_)
+* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/autowarefoundation/autoware.universe/issues/7594>`_)
+* feat(autonomous_emergency_braking): add predicted object support for aeb (`#7548 <https://github.com/autowarefoundation/autoware.universe/issues/7548>`_)
   * add polling sub to predicted objects
   * WIP requires changing path frame to map
   * add parameters and reuse predicted obj speed
@@ -142,34 +142,34 @@ Changelog for package autoware_autonomous_emergency_braking
   * add utils.cpp
   * remove _ for non member variable
   ---------
-* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/youtalk/autoware.universe/issues/7539>`_)
+* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/autowarefoundation/autoware.universe/issues/7539>`_)
   refactor(motion_utils): add autoware prefix and include dir
-* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/youtalk/autoware.universe/issues/7538>`_)
+* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/autowarefoundation/autoware.universe/issues/7538>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* refactor(control)!: refactor directory structures of the control checkers (`#7524 <https://github.com/youtalk/autoware.universe/issues/7524>`_)
+* refactor(control)!: refactor directory structures of the control checkers (`#7524 <https://github.com/autowarefoundation/autoware.universe/issues/7524>`_)
   * aeb
   * control_validator
   * lane_departure_checker
   * shift_decider
   * fix
   ---------
-* feat(autonomous_emergency_braking): aeb disable obj velocity calc w param (`#7493 <https://github.com/youtalk/autoware.universe/issues/7493>`_)
-  * feat(autonomous_emergenct_braking): update README and imgs of aeb (`#7482 <https://github.com/youtalk/autoware.universe/issues/7482>`_)
+* feat(autonomous_emergency_braking): aeb disable obj velocity calc w param (`#7493 <https://github.com/autowarefoundation/autoware.universe/issues/7493>`_)
+  * feat(autonomous_emergenct_braking): update README and imgs of aeb (`#7482 <https://github.com/autowarefoundation/autoware.universe/issues/7482>`_)
   update README
   * add param to toggle on or off object speed calc for aeb
   * pre-commit readme
   ---------
-* fix(planning): set single depth sensor data qos for pointlcoud polling subscribers (`#7490 <https://github.com/youtalk/autoware.universe/issues/7490>`_)
+* fix(planning): set single depth sensor data qos for pointlcoud polling subscribers (`#7490 <https://github.com/autowarefoundation/autoware.universe/issues/7490>`_)
   set single depth sensor data qos for pointlcoud polling subscribers
-* feat(autonomous_emergenct_braking): update README and imgs of aeb (`#7482 <https://github.com/youtalk/autoware.universe/issues/7482>`_)
+* feat(autonomous_emergenct_braking): update README and imgs of aeb (`#7482 <https://github.com/autowarefoundation/autoware.universe/issues/7482>`_)
   update README
-* feat(autonomous_emergency_braking): aeb for backwards driving (`#7279 <https://github.com/youtalk/autoware.universe/issues/7279>`_)
+* feat(autonomous_emergency_braking): aeb for backwards driving (`#7279 <https://github.com/autowarefoundation/autoware.universe/issues/7279>`_)
   * add support for backward path AEB
   * fix sign)
   * add abs and protect against nan
   * solve sign problem with relative speed
   ---------
-* refactor(vehicle_info_utils)!: prefix package and namespace with autoware (`#7353 <https://github.com/youtalk/autoware.universe/issues/7353>`_)
+* refactor(vehicle_info_utils)!: prefix package and namespace with autoware (`#7353 <https://github.com/autowarefoundation/autoware.universe/issues/7353>`_)
   * chore(autoware_vehicle_info_utils): rename header
   * chore(bpp-common): vehicle info
   * chore(path_optimizer): vehicle info
@@ -204,7 +204,7 @@ Changelog for package autoware_autonomous_emergency_braking
   * chore(sensing): vehicle info
   * fix(autoware_joy_controller): remove unused deps
   ---------
-* feat(autonomous_emergency_braking): prefix package and namespace with autoware\_ (`#7294 <https://github.com/youtalk/autoware.universe/issues/7294>`_)
+* feat(autonomous_emergency_braking): prefix package and namespace with autoware\_ (`#7294 <https://github.com/autowarefoundation/autoware.universe/issues/7294>`_)
   * change package name
   * add the prefix
   * change option

--- a/control/autoware_collision_detector/CHANGELOG.rst
+++ b/control/autoware_collision_detector/CHANGELOG.rst
@@ -5,9 +5,9 @@ Changelog for package autoware_collision_detector
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* chore(collision_detector): add maintainer  (`#9184 <https://github.com/youtalk/autoware.universe/issues/9184>`_)
+* chore(collision_detector): add maintainer  (`#9184 <https://github.com/autowarefoundation/autoware.universe/issues/9184>`_)
   add maintainer
-* feat(collision_detector): add autoware_collision_detector (`#9157 <https://github.com/youtalk/autoware.universe/issues/9157>`_)
+* feat(collision_detector): add autoware_collision_detector (`#9157 <https://github.com/autowarefoundation/autoware.universe/issues/9157>`_)
   * add new package autoware_collision_detector
   * update to latest
   * fix

--- a/control/autoware_control_validator/CHANGELOG.rst
+++ b/control/autoware_control_validator/CHANGELOG.rst
@@ -5,17 +5,17 @@ Changelog for package autoware_control_validator
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* feat(control_validator): add hold and lpf (`#9120 <https://github.com/youtalk/autoware.universe/issues/9120>`_)
-* feat(costmap_generator, control_validator, scenario_selector, surround_obstacle_checker, vehicle_cmd_gate): add processing time pub. (`#9065 <https://github.com/youtalk/autoware.universe/issues/9065>`_)
+* feat(control_validator): add hold and lpf (`#9120 <https://github.com/autowarefoundation/autoware.universe/issues/9120>`_)
+* feat(costmap_generator, control_validator, scenario_selector, surround_obstacle_checker, vehicle_cmd_gate): add processing time pub. (`#9065 <https://github.com/autowarefoundation/autoware.universe/issues/9065>`_)
   * feat(costmap_generator, control_validator, scenario_selector, surround_obstacle_checker, vehicle_cmd_gate): Add: processing_time_pub
   * fix: pre-commit
   * feat(costmap_generator): fix: No output when not Active.
   * fix: clang-format
   * Re: fix: clang-format
   ---------
-* fix(control): align the parameters with launcher (`#8789 <https://github.com/youtalk/autoware.universe/issues/8789>`_)
+* fix(control): align the parameters with launcher (`#8789 <https://github.com/autowarefoundation/autoware.universe/issues/8789>`_)
   align the control parameters
-* feat(autoware_control_validator): refactoring & testing (`#8096 <https://github.com/youtalk/autoware.universe/issues/8096>`_)
+* feat(autoware_control_validator): refactoring & testing (`#8096 <https://github.com/autowarefoundation/autoware.universe/issues/8096>`_)
   * refactoring
   * updating...
   * update
@@ -24,29 +24,29 @@ Changelog for package autoware_control_validator
   * Update CMakeLists.txt
   * use yaml to load vehicle info
   ---------
-* fix(control_validator): fix param names and doc (`#8104 <https://github.com/youtalk/autoware.universe/issues/8104>`_)
+* fix(control_validator): fix param names and doc (`#8104 <https://github.com/autowarefoundation/autoware.universe/issues/8104>`_)
   * fix
-* feat(control_validator)!: add velocity check (`#7806 <https://github.com/youtalk/autoware.universe/issues/7806>`_)
+* feat(control_validator)!: add velocity check (`#7806 <https://github.com/autowarefoundation/autoware.universe/issues/7806>`_)
   * add velocity check
   ---------
-* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/youtalk/autoware.universe/issues/7594>`_)
-* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/youtalk/autoware.universe/issues/7539>`_)
+* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/autowarefoundation/autoware.universe/issues/7594>`_)
+* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/autowarefoundation/autoware.universe/issues/7539>`_)
   refactor(motion_utils): add autoware prefix and include dir
-* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/youtalk/autoware.universe/issues/7538>`_)
+* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/autowarefoundation/autoware.universe/issues/7538>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* refactor(control)!: refactor directory structures of the control checkers (`#7524 <https://github.com/youtalk/autoware.universe/issues/7524>`_)
+* refactor(control)!: refactor directory structures of the control checkers (`#7524 <https://github.com/autowarefoundation/autoware.universe/issues/7524>`_)
   * aeb
   * control_validator
   * lane_departure_checker
   * shift_decider
   * fix
   ---------
-* feat(autoware_control_validator): add polling subcribers (`#7426 <https://github.com/youtalk/autoware.universe/issues/7426>`_)
+* feat(autoware_control_validator): add polling subcribers (`#7426 <https://github.com/autowarefoundation/autoware.universe/issues/7426>`_)
   * add polling subs
   * delete extra line
   ---------
-* fix(autoware_control_validator): fix vehicle info utils (`#7417 <https://github.com/youtalk/autoware.universe/issues/7417>`_)
-* refactor(control_validator)!: prefix package and namespace with autoware (`#7304 <https://github.com/youtalk/autoware.universe/issues/7304>`_)
+* fix(autoware_control_validator): fix vehicle info utils (`#7417 <https://github.com/autowarefoundation/autoware.universe/issues/7417>`_)
+* refactor(control_validator)!: prefix package and namespace with autoware (`#7304 <https://github.com/autowarefoundation/autoware.universe/issues/7304>`_)
   * rename folders
   * rename add prefix
   * change param path

--- a/control/autoware_external_cmd_selector/CHANGELOG.rst
+++ b/control/autoware_external_cmd_selector/CHANGELOG.rst
@@ -5,16 +5,16 @@ Changelog for package autoware_external_cmd_selector
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* refactor(external_cmd_selector): rework parameters (`#8198 <https://github.com/youtalk/autoware.universe/issues/8198>`_)
+* refactor(external_cmd_selector): rework parameters (`#8198 <https://github.com/autowarefoundation/autoware.universe/issues/8198>`_)
   * refactor(external_cmd_selector): rework parameters
   * style(pre-commit): autofix
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* refactor(control)!: refactor directory structures of the control interface nodes (`#7528 <https://github.com/youtalk/autoware.universe/issues/7528>`_)
+* refactor(control)!: refactor directory structures of the control interface nodes (`#7528 <https://github.com/autowarefoundation/autoware.universe/issues/7528>`_)
   * external_cmd_selector
   * joy_controller
   ---------
-* refactor(external_cmd_selector): prefix package and namespace with au… (`#7384 <https://github.com/youtalk/autoware.universe/issues/7384>`_)
+* refactor(external_cmd_selector): prefix package and namespace with au… (`#7384 <https://github.com/autowarefoundation/autoware.universe/issues/7384>`_)
   refactor(external_cmd_selector): prefix package and namespace with autoware\_
 * Contributors: Batuhan Beytekin, Yuki TAKAGI, Yukinari Hisaki, Yutaka Kondo
 

--- a/control/autoware_joy_controller/CHANGELOG.rst
+++ b/control/autoware_joy_controller/CHANGELOG.rst
@@ -5,16 +5,16 @@ Changelog for package autoware_joy_controller
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* fix(autoware_joy_controller): add virtual destructor to autoware_joy_controller (`#7760 <https://github.com/youtalk/autoware.universe/issues/7760>`_)
-* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/youtalk/autoware.universe/issues/7594>`_)
-* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/youtalk/autoware.universe/issues/7538>`_)
+* fix(autoware_joy_controller): add virtual destructor to autoware_joy_controller (`#7760 <https://github.com/autowarefoundation/autoware.universe/issues/7760>`_)
+* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/autowarefoundation/autoware.universe/issues/7594>`_)
+* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/autowarefoundation/autoware.universe/issues/7538>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* fix(joy_controller): check for nullptr messages (`#7540 <https://github.com/youtalk/autoware.universe/issues/7540>`_)
-* refactor(control)!: refactor directory structures of the control interface nodes (`#7528 <https://github.com/youtalk/autoware.universe/issues/7528>`_)
+* fix(joy_controller): check for nullptr messages (`#7540 <https://github.com/autowarefoundation/autoware.universe/issues/7540>`_)
+* refactor(control)!: refactor directory structures of the control interface nodes (`#7528 <https://github.com/autowarefoundation/autoware.universe/issues/7528>`_)
   * external_cmd_selector
   * joy_controller
   ---------
-* refactor(joy_controller)!: prefix package and namespace with autoware (`#7382 <https://github.com/youtalk/autoware.universe/issues/7382>`_)
+* refactor(joy_controller)!: prefix package and namespace with autoware (`#7382 <https://github.com/autowarefoundation/autoware.universe/issues/7382>`_)
   * add prefix
   * fix codeowner
   * fix
@@ -24,7 +24,7 @@ Changelog for package autoware_joy_controller
 
 0.26.0 (2024-04-03)
 -------------------
-* feat: change pachage name: autoware_msgs -> tier4_msgs (`#150 <https://github.com/youtalk/autoware.universe/issues/150>`_)
+* feat: change pachage name: autoware_msgs -> tier4_msgs (`#150 <https://github.com/autowarefoundation/autoware.universe/issues/150>`_)
   * change pkg name: autoware\_*_msgs -> tier\_*_msgs
   * ci(pre-commit): autofix
   * autoware_external_api_msgs -> tier4_external_api_msgs
@@ -32,9 +32,9 @@ Changelog for package autoware_joy_controller
   * fix description
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Takeshi Miura <57553950+1222-takeshi@users.noreply.github.com>
-* feat: add autoware joy controller (`#72 <https://github.com/youtalk/autoware.universe/issues/72>`_)
+* feat: add autoware joy controller (`#72 <https://github.com/autowarefoundation/autoware.universe/issues/72>`_)
   * release v0.4.0
-  * Support G29 controller in autoware_joy_controller (`#699 <https://github.com/youtalk/autoware.universe/issues/699>`_)
+  * Support G29 controller in autoware_joy_controller (`#699 <https://github.com/autowarefoundation/autoware.universe/issues/699>`_)
   * Add map for G29 controller
   * Add new line at end of file
   * Change structure of JoyConverterBase class
@@ -46,38 +46,38 @@ Changelog for package autoware_joy_controller
   * Remap AccelPedal -> accel, BrakePedal -> brake
   * Remove [autoware_joy_controller] from ROS_INFO
   Co-authored-by: Fumiya Watanabe <fumiya.watanabe@tier4.jp>
-  * Change key map for G29 controller and set deadzone parameter (`#740 <https://github.com/youtalk/autoware.universe/issues/740>`_)
-  * Add missing dependencies of autoware_joy_controller (`#755 <https://github.com/youtalk/autoware.universe/issues/755>`_)
+  * Change key map for G29 controller and set deadzone parameter (`#740 <https://github.com/autowarefoundation/autoware.universe/issues/740>`_)
+  * Add missing dependencies of autoware_joy_controller (`#755 <https://github.com/autowarefoundation/autoware.universe/issues/755>`_)
   * remove ROS1 packages temporarily
   * add sample ros2 packages
   * remove ROS1 packages
   * Revert "remove ROS1 packages temporarily"
   This reverts commit c98294b0b159fb98cd3091d34a626d06f29fdece.
   * add COLCON_IGNORE to ros1 packages
-  * Rename launch files to launch.xml (`#28 <https://github.com/youtalk/autoware.universe/issues/28>`_)
-  * Rename h files to hpp (`#142 <https://github.com/youtalk/autoware.universe/issues/142>`_)
+  * Rename launch files to launch.xml (`#28 <https://github.com/autowarefoundation/autoware.universe/issues/28>`_)
+  * Rename h files to hpp (`#142 <https://github.com/autowarefoundation/autoware.universe/issues/142>`_)
   * Change includes
   * Rename files
   * Adjustments to make things compile
   * Other packages
-  * Adjust copyright notice on 532 out of 699 source files (`#143 <https://github.com/youtalk/autoware.universe/issues/143>`_)
-  * Use quotes for includes where appropriate (`#144 <https://github.com/youtalk/autoware.universe/issues/144>`_)
+  * Adjust copyright notice on 532 out of 699 source files (`#143 <https://github.com/autowarefoundation/autoware.universe/issues/143>`_)
+  * Use quotes for includes where appropriate (`#144 <https://github.com/autowarefoundation/autoware.universe/issues/144>`_)
   * Use quotes for includes where appropriate
   * Fix lint tests
   * Make tests pass hopefully
-  * Port autoware joy controller (`#124 <https://github.com/youtalk/autoware.universe/issues/124>`_)
+  * Port autoware joy controller (`#124 <https://github.com/autowarefoundation/autoware.universe/issues/124>`_)
   * Port
   * Fixed package.xml
   * now() to use node clock
   * Fix include
   * Clear compilation warnings
-  * Run uncrustify on the entire Pilot.Auto codebase (`#151 <https://github.com/youtalk/autoware.universe/issues/151>`_)
+  * Run uncrustify on the entire Pilot.Auto codebase (`#151 <https://github.com/autowarefoundation/autoware.universe/issues/151>`_)
   * Run uncrustify on the entire Pilot.Auto codebase
   * Exclude open PRs
-  * [update to v0.8.0] autoware joy controller (`#251 <https://github.com/youtalk/autoware.universe/issues/251>`_)
+  * [update to v0.8.0] autoware joy controller (`#251 <https://github.com/autowarefoundation/autoware.universe/issues/251>`_)
   * restore filename to original for version update
-  * Enable to change sensitivity (`#868 <https://github.com/youtalk/autoware.universe/issues/868>`_)
-  * Improve remote emergency stop (`#900 <https://github.com/youtalk/autoware.universe/issues/900>`_)
+  * Enable to change sensitivity (`#868 <https://github.com/autowarefoundation/autoware.universe/issues/868>`_)
+  * Improve remote emergency stop (`#900 <https://github.com/autowarefoundation/autoware.universe/issues/900>`_)
   * Apply format
   * Rename emergency to system_emergency in vehicle_cmd_gate
   * Add emergency stop feature to vehicle_cmd_gate
@@ -112,14 +112,14 @@ Changelog for package autoware_joy_controller
   Co-authored-by: Fumiya Watanabe <rej55.g@gmail.com>
   Co-authored-by: Kenji Miyake <31987104+kenji-miyake@users.noreply.github.com>
   Co-authored-by: jpntaxi4943-autoware <proj-jpntaxi@tier4.jp>
-  * Rename ROS-related .yaml to .param.yaml (`#352 <https://github.com/youtalk/autoware.universe/issues/352>`_)
+  * Rename ROS-related .yaml to .param.yaml (`#352 <https://github.com/autowarefoundation/autoware.universe/issues/352>`_)
   * Rename ROS-related .yaml to .param.yaml
   * Remove prefix 'default\_' of yaml files
   * Rename vehicle_info.yaml to vehicle_info.param.yaml
   * Rename diagnostic_aggregator's param files
   * Fix overlooked parameters
-  * remove using in global namespace (`#379 <https://github.com/youtalk/autoware.universe/issues/379>`_)
-  * remove using in global namespace (`#1166 <https://github.com/youtalk/autoware.universe/issues/1166>`_)
+  * remove using in global namespace (`#379 <https://github.com/autowarefoundation/autoware.universe/issues/379>`_)
+  * remove using in global namespace (`#1166 <https://github.com/autowarefoundation/autoware.universe/issues/1166>`_)
   * remove using in global namespace
   * Revert "remove using in global namespace"
   This reverts commit 7f120509c9e3a036a38e84883868f6036bca23ad.
@@ -127,23 +127,23 @@ Changelog for package autoware_joy_controller
   Co-authored-by: Kenji Miyake <kenji.miyake@tier4.jp>
   * [autoware_joy_controller] add lint tests
   Co-authored-by: Kenji Miyake <kenji.miyake@tier4.jp>
-  * fix namespace (`#414 <https://github.com/youtalk/autoware.universe/issues/414>`_)
-  * add use_sim-time option (`#454 <https://github.com/youtalk/autoware.universe/issues/454>`_)
-  * Fix for rolling (`#1226 <https://github.com/youtalk/autoware.universe/issues/1226>`_)
+  * fix namespace (`#414 <https://github.com/autowarefoundation/autoware.universe/issues/414>`_)
+  * add use_sim-time option (`#454 <https://github.com/autowarefoundation/autoware.universe/issues/454>`_)
+  * Fix for rolling (`#1226 <https://github.com/autowarefoundation/autoware.universe/issues/1226>`_)
   * Replace doc by description
   * Replace ns by push-ros-namespace
-  * Make control modules components (`#1262 <https://github.com/youtalk/autoware.universe/issues/1262>`_)
-  * Remove use_sim_time for set_parameter (`#1260 <https://github.com/youtalk/autoware.universe/issues/1260>`_)
-  * Remove autoware_debug_msgs from autoware_joy_controller (`#1303 <https://github.com/youtalk/autoware.universe/issues/1303>`_)
-  * Porting remote cmd selector (`#1286 <https://github.com/youtalk/autoware.universe/issues/1286>`_)
-  * Feature/add remote cmd selector (`#1179 <https://github.com/youtalk/autoware.universe/issues/1179>`_)
+  * Make control modules components (`#1262 <https://github.com/autowarefoundation/autoware.universe/issues/1262>`_)
+  * Remove use_sim_time for set_parameter (`#1260 <https://github.com/autowarefoundation/autoware.universe/issues/1260>`_)
+  * Remove autoware_debug_msgs from autoware_joy_controller (`#1303 <https://github.com/autowarefoundation/autoware.universe/issues/1303>`_)
+  * Porting remote cmd selector (`#1286 <https://github.com/autowarefoundation/autoware.universe/issues/1286>`_)
+  * Feature/add remote cmd selector (`#1179 <https://github.com/autowarefoundation/autoware.universe/issues/1179>`_)
   * Add in/out args of remote_cmd_converter.launch
   * Change remote input topic of vehicle_cmd_gate
   * Add msgs for remote_cmd_selector
   * Add remote_cmd_selector
   * Rename remote_cmd_selector to external_cmd_selector
   * Remove VehicleCommand support in autoware_joy_controller
-  * Support external_cmd_source in autoware_joy_controller.launch (`#1194 <https://github.com/youtalk/autoware.universe/issues/1194>`_)
+  * Support external_cmd_source in autoware_joy_controller.launch (`#1194 <https://github.com/autowarefoundation/autoware.universe/issues/1194>`_)
   * Fix porting miss
   * fix missing function
   * modify xml format
@@ -158,7 +158,7 @@ Changelog for package autoware_joy_controller
   * Change default mode of autoware_joy_controller
   Co-authored-by: Kenji Miyake <31987104+kenji-miyake@users.noreply.github.com>
   Co-authored-by: Kenji Miyake <kenji.miyake@tier4.jp>
-  * Ros2/create/external commands (`#1299 <https://github.com/youtalk/autoware.universe/issues/1299>`_)
+  * Ros2/create/external commands (`#1299 <https://github.com/autowarefoundation/autoware.universe/issues/1299>`_)
   * add remote message
   * add remote commands
   * fix topic
@@ -167,18 +167,18 @@ Changelog for package autoware_joy_controller
   * add external cmd instead
   * ToExternalComd
   * fix topic in joy con
-  * Fix -Wunused-parameter (`#1836 <https://github.com/youtalk/autoware.universe/issues/1836>`_)
+  * Fix -Wunused-parameter (`#1836 <https://github.com/autowarefoundation/autoware.universe/issues/1836>`_)
   * Fix -Wunused-parameter
   * Fix mistake
   * fix spell
   * Fix lint issues
   * Ignore flake8 warnings
   Co-authored-by: Hiroki OTA <hiroki.ota@tier4.jp>
-  * Add autoware api (`#1979 <https://github.com/youtalk/autoware.universe/issues/1979>`_)
-  * Use EmergencyState instead of deprecated EmergencyMode (`#2030 <https://github.com/youtalk/autoware.universe/issues/2030>`_)
+  * Add autoware api (`#1979 <https://github.com/autowarefoundation/autoware.universe/issues/1979>`_)
+  * Use EmergencyState instead of deprecated EmergencyMode (`#2030 <https://github.com/autowarefoundation/autoware.universe/issues/2030>`_)
   * Use EmergencyState instead of deprecated EmergencyMode
   * Use stamped type
-  * add sort-package-xml hook in pre-commit (`#1881 <https://github.com/youtalk/autoware.universe/issues/1881>`_)
+  * add sort-package-xml hook in pre-commit (`#1881 <https://github.com/autowarefoundation/autoware.universe/issues/1881>`_)
   * add sort xml hook in pre-commit
   * change retval to exit_status
   * rename
@@ -192,8 +192,8 @@ Changelog for package autoware_joy_controller
   * move prettier-xml to pre-commit-hooks-ros
   * update version for bug-fix
   * apply pre-commit
-  * Add selected external command API (`#2053 <https://github.com/youtalk/autoware.universe/issues/2053>`_)
-  * submit engage with api service from joy controller (`#2320 <https://github.com/youtalk/autoware.universe/issues/2320>`_)
+  * Add selected external command API (`#2053 <https://github.com/autowarefoundation/autoware.universe/issues/2053>`_)
+  * submit engage with api service from joy controller (`#2320 <https://github.com/autowarefoundation/autoware.universe/issues/2320>`_)
   * fix engagew with api
   * delete unused
   * fix for uncrustify
@@ -201,7 +201,7 @@ Changelog for package autoware_joy_controller
   * some fix
   * revive autoware name
   * fix service name
-  * Change formatter to clang-format and black (`#2332 <https://github.com/youtalk/autoware.universe/issues/2332>`_)
+  * Change formatter to clang-format and black (`#2332 <https://github.com/autowarefoundation/autoware.universe/issues/2332>`_)
   * Revert "Temporarily comment out pre-commit hooks"
   This reverts commit 748e9cdb145ce12f8b520bcbd97f5ff899fc28a3.
   * Replace ament_lint_common with autoware_lint_common
@@ -213,14 +213,14 @@ Changelog for package autoware_joy_controller
   * Fix include double quotes to angle brackets
   * Apply clang-format
   * Fix build errors
-  * Add COLCON_IGNORE (`#500 <https://github.com/youtalk/autoware.universe/issues/500>`_)
-  * port autoware joy controller (`#588 <https://github.com/youtalk/autoware.universe/issues/588>`_)
+  * Add COLCON_IGNORE (`#500 <https://github.com/autowarefoundation/autoware.universe/issues/500>`_)
+  * port autoware joy controller (`#588 <https://github.com/autowarefoundation/autoware.universe/issues/588>`_)
   * port autoware joy controller
   * fix compile error
   * use odometry instead of twist
   * update launch
   Co-authored-by: Takayuki Murooka <takayuki.murooka@tier4.jp>
-  * update README.md in autoware_joy_controller (`#593 <https://github.com/youtalk/autoware.universe/issues/593>`_)
+  * update README.md in autoware_joy_controller (`#593 <https://github.com/autowarefoundation/autoware.universe/issues/593>`_)
   * update README.md
   * update README.md
   * fix typo

--- a/control/autoware_lane_departure_checker/CHANGELOG.rst
+++ b/control/autoware_lane_departure_checker/CHANGELOG.rst
@@ -5,21 +5,21 @@ Changelog for package autoware_lane_departure_checker
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* test(lane_departure_checker): add tests for createVehicleFootprints (`#8928 <https://github.com/youtalk/autoware.universe/issues/8928>`_)
+* test(lane_departure_checker): add tests for createVehicleFootprints (`#8928 <https://github.com/autowarefoundation/autoware.universe/issues/8928>`_)
   * move createVehicleFootprints() to seperate files
   * add tests for createVehicleFootprints()
   ---------
-* test(lane_departure_checker): add tests for resampleTrajectory (`#8895 <https://github.com/youtalk/autoware.universe/issues/8895>`_)
+* test(lane_departure_checker): add tests for resampleTrajectory (`#8895 <https://github.com/autowarefoundation/autoware.universe/issues/8895>`_)
   * move resampleTrajectory() to separate file
   * add tests for resampleTrajectory()
   ---------
-* test(lane_departure_checker): add tests for cutTrajectory (`#8887 <https://github.com/youtalk/autoware.universe/issues/8887>`_)
+* test(lane_departure_checker): add tests for cutTrajectory (`#8887 <https://github.com/autowarefoundation/autoware.universe/issues/8887>`_)
   * move cutTrajectory() to separate file
   * add test for cutTrajectory()
   ---------
-* fix(control): align the parameters with launcher (`#8789 <https://github.com/youtalk/autoware.universe/issues/8789>`_)
+* fix(control): align the parameters with launcher (`#8789 <https://github.com/autowarefoundation/autoware.universe/issues/8789>`_)
   align the control parameters
-* refactor(start_planner, lane_departure_checker): remove redundant calculation in fuseLaneletPolygon (`#8682 <https://github.com/youtalk/autoware.universe/issues/8682>`_)
+* refactor(start_planner, lane_departure_checker): remove redundant calculation in fuseLaneletPolygon (`#8682 <https://github.com/autowarefoundation/autoware.universe/issues/8682>`_)
   * remove redundant fused lanelet calculation
   * remove unnecessary change
   * add new function
@@ -29,22 +29,22 @@ Changelog for package autoware_lane_departure_checker
   * add comment for better understanding
   * fix cppcheck
   ---------
-* fix(autoware_lane_departure_checker): not to show error message "trajectory deviation is too large" during manual driving (`#8404 <https://github.com/youtalk/autoware.universe/issues/8404>`_)
+* fix(autoware_lane_departure_checker): not to show error message "trajectory deviation is too large" during manual driving (`#8404 <https://github.com/autowarefoundation/autoware.universe/issues/8404>`_)
   * update: update not to show error message "trajectory deviation is too large" during manual driving
   * style(pre-commit): autofix
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* fix(lane_departure_checker): fix uninitialized variables (`#8451 <https://github.com/youtalk/autoware.universe/issues/8451>`_)
+* fix(lane_departure_checker): fix uninitialized variables (`#8451 <https://github.com/autowarefoundation/autoware.universe/issues/8451>`_)
   fix(lane_departure_checker): fix uninitialized_variables
-* feat(start_planner): add time_keeper (`#8254 <https://github.com/youtalk/autoware.universe/issues/8254>`_)
+* feat(start_planner): add time_keeper (`#8254 <https://github.com/autowarefoundation/autoware.universe/issues/8254>`_)
   * feat(start_planner): add time_keeper
   * fix
   * fix
   * fix shadow variables
   ---------
-* fix(autoware_lane_departure_checker): fix shadowVariable (`#7931 <https://github.com/youtalk/autoware.universe/issues/7931>`_)
+* fix(autoware_lane_departure_checker): fix shadowVariable (`#7931 <https://github.com/autowarefoundation/autoware.universe/issues/7931>`_)
   fix:shadowVariable
-* refactor(autoware_universe_utils): changed the API to be more intuitive and added documentation (`#7443 <https://github.com/youtalk/autoware.universe/issues/7443>`_)
+* refactor(autoware_universe_utils): changed the API to be more intuitive and added documentation (`#7443 <https://github.com/autowarefoundation/autoware.universe/issues/7443>`_)
   * refactor(tier4_autoware_utils): Changed the API to be more intuitive and added documentation.
   * use raw shared ptr in PollingPolicy::NEWEST
   * update
@@ -53,21 +53,21 @@ Changelog for package autoware_lane_departure_checker
   Co-authored-by: danielsanchezaran <daniel.sanchez@tier4.jp>
   ---------
   Co-authored-by: danielsanchezaran <daniel.sanchez@tier4.jp>
-* feat: add `autoware\_` prefix to `lanelet2_extension` (`#7640 <https://github.com/youtalk/autoware.universe/issues/7640>`_)
-* feat(motion_velocity_planner, lane_departure_checker): add processing time Float64 publishers (`#7683 <https://github.com/youtalk/autoware.universe/issues/7683>`_)
-* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/youtalk/autoware.universe/issues/7594>`_)
-* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/youtalk/autoware.universe/issues/7539>`_)
+* feat: add `autoware\_` prefix to `lanelet2_extension` (`#7640 <https://github.com/autowarefoundation/autoware.universe/issues/7640>`_)
+* feat(motion_velocity_planner, lane_departure_checker): add processing time Float64 publishers (`#7683 <https://github.com/autowarefoundation/autoware.universe/issues/7683>`_)
+* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/autowarefoundation/autoware.universe/issues/7594>`_)
+* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/autowarefoundation/autoware.universe/issues/7539>`_)
   refactor(motion_utils): add autoware prefix and include dir
-* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/youtalk/autoware.universe/issues/7538>`_)
+* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/autowarefoundation/autoware.universe/issues/7538>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* refactor(control)!: refactor directory structures of the control checkers (`#7524 <https://github.com/youtalk/autoware.universe/issues/7524>`_)
+* refactor(control)!: refactor directory structures of the control checkers (`#7524 <https://github.com/autowarefoundation/autoware.universe/issues/7524>`_)
   * aeb
   * control_validator
   * lane_departure_checker
   * shift_decider
   * fix
   ---------
-* refactor(autoware_lane_departure_checker)!: rename directory name  (`#7410 <https://github.com/youtalk/autoware.universe/issues/7410>`_)
+* refactor(autoware_lane_departure_checker)!: rename directory name  (`#7410 <https://github.com/autowarefoundation/autoware.universe/issues/7410>`_)
 * Contributors: Go Sakayori, Kosuke Takeuchi, Kyoichi Sugahara, Maxime CLEMENT, Mitsuhiro Sakamoto, T-Kimura-MM, Takayuki Murooka, Yuki TAKAGI, Yukinari Hisaki, Yutaka Kondo, Zhe Shen, kobayu858
 
 0.26.0 (2024-04-03)

--- a/control/autoware_mpc_lateral_controller/CHANGELOG.rst
+++ b/control/autoware_mpc_lateral_controller/CHANGELOG.rst
@@ -5,51 +5,51 @@ Changelog for package autoware_mpc_lateral_controller
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* refactor(osqp_interface): added autoware prefix to osqp_interface (`#8958 <https://github.com/youtalk/autoware.universe/issues/8958>`_)
-* fix(autoware_mpc_lateral_controller): fix calculation method of predicted trajectory (`#9048 <https://github.com/youtalk/autoware.universe/issues/9048>`_)
+* refactor(osqp_interface): added autoware prefix to osqp_interface (`#8958 <https://github.com/autowarefoundation/autoware.universe/issues/8958>`_)
+* fix(autoware_mpc_lateral_controller): fix calculation method of predicted trajectory (`#9048 <https://github.com/autowarefoundation/autoware.universe/issues/9048>`_)
   * fix(vehicle_model): fix calculation method of predicted trajectory
   ---------
-* refactor(autoware_interpolation): prefix package and namespace with autoware (`#8088 <https://github.com/youtalk/autoware.universe/issues/8088>`_)
+* refactor(autoware_interpolation): prefix package and namespace with autoware (`#8088 <https://github.com/autowarefoundation/autoware.universe/issues/8088>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* chore(mpc_lateral_controller): consistent parameters with autoware_launch (`#8914 <https://github.com/youtalk/autoware.universe/issues/8914>`_)
-* chore: remove duplicate line in mpc_lateral_controller.cpp (`#8916 <https://github.com/youtalk/autoware.universe/issues/8916>`_)
+* chore(mpc_lateral_controller): consistent parameters with autoware_launch (`#8914 <https://github.com/autowarefoundation/autoware.universe/issues/8914>`_)
+* chore: remove duplicate line in mpc_lateral_controller.cpp (`#8916 <https://github.com/autowarefoundation/autoware.universe/issues/8916>`_)
   remove duplicate line in mpc_lateral_controller.cpp
-* feat(autoware_mpc_lateral_controller): add predicted trajectory acconts for input delay (`#8436 <https://github.com/youtalk/autoware.universe/issues/8436>`_)
+* feat(autoware_mpc_lateral_controller): add predicted trajectory acconts for input delay (`#8436 <https://github.com/autowarefoundation/autoware.universe/issues/8436>`_)
   * feat: enable delayed initial state for predicted trajectory
   * feat: enable debug publishing of predicted and resampled reference trajectories
   ---------
-* fix(autoware_mpc_lateral_controller): fix cppcheck warnings (`#8149 <https://github.com/youtalk/autoware.universe/issues/8149>`_)
+* fix(autoware_mpc_lateral_controller): fix cppcheck warnings (`#8149 <https://github.com/autowarefoundation/autoware.universe/issues/8149>`_)
   * fix(autoware_mpc_lateral_controller): fix cppcheck warnings
   * Update control/autoware_mpc_lateral_controller/src/lowpass_filter.cpp
   Co-authored-by: Takayuki Murooka <takayuki5168@gmail.com>
   ---------
   Co-authored-by: Takayuki Murooka <takayuki5168@gmail.com>
-* fix(autoware_mpc_lateral_controller): add timestamp and frame ID to published trajectory (`#8164 <https://github.com/youtalk/autoware.universe/issues/8164>`_)
+* fix(autoware_mpc_lateral_controller): add timestamp and frame ID to published trajectory (`#8164 <https://github.com/autowarefoundation/autoware.universe/issues/8164>`_)
   add timestamp and frame ID to published trajectory
-* fix(controller): revival of dry steering (`#7903 <https://github.com/youtalk/autoware.universe/issues/7903>`_)
-  * Revert "fix(autoware_mpc_lateral_controller): delete the zero speed constraint (`#7673 <https://github.com/youtalk/autoware.universe/issues/7673>`_)"
+* fix(controller): revival of dry steering (`#7903 <https://github.com/autowarefoundation/autoware.universe/issues/7903>`_)
+  * Revert "fix(autoware_mpc_lateral_controller): delete the zero speed constraint (`#7673 <https://github.com/autowarefoundation/autoware.universe/issues/7673>`_)"
   This reverts commit 69258bd92cb8a0ff8320df9b2302db72975e027f.
   * dry steering
   * add comments
   * add minor fix and modify unit test for dry steering
   ---------
-* fix(autoware_mpc_lateral_controller): delete the zero speed constraint (`#7673 <https://github.com/youtalk/autoware.universe/issues/7673>`_)
+* fix(autoware_mpc_lateral_controller): delete the zero speed constraint (`#7673 <https://github.com/autowarefoundation/autoware.universe/issues/7673>`_)
   * delete steer rate limit when vel = 0
   * delete unnecessary variable
   * pre-commit
   ---------
-* fix(autoware_mpc_lateral_controller): relax the steering rate constraint at zero speed (`#7581 <https://github.com/youtalk/autoware.universe/issues/7581>`_)
+* fix(autoware_mpc_lateral_controller): relax the steering rate constraint at zero speed (`#7581 <https://github.com/autowarefoundation/autoware.universe/issues/7581>`_)
   * constraint for zero velocity updated
   * correct the comment
   ---------
-* fix(autoware_mpc_lateral_controller): fix duplicateExpression warning (`#7542 <https://github.com/youtalk/autoware.universe/issues/7542>`_)
+* fix(autoware_mpc_lateral_controller): fix duplicateExpression warning (`#7542 <https://github.com/autowarefoundation/autoware.universe/issues/7542>`_)
   * fix(autoware_mpc_lateral_controller): fix duplicateExpression warning
   * style(pre-commit): autofix
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* fix(autoware_mpc_lateral_controller): fix duplicateAssignExpression warning (`#7572 <https://github.com/youtalk/autoware.universe/issues/7572>`_)
-* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/youtalk/autoware.universe/issues/7594>`_)
-* fix(mpc_lateral_controller): align the MPC steering angle when the car is controlled manually. (`#7109 <https://github.com/youtalk/autoware.universe/issues/7109>`_)
+* fix(autoware_mpc_lateral_controller): fix duplicateAssignExpression warning (`#7572 <https://github.com/autowarefoundation/autoware.universe/issues/7572>`_)
+* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/autowarefoundation/autoware.universe/issues/7594>`_)
+* fix(mpc_lateral_controller): align the MPC steering angle when the car is controlled manually. (`#7109 <https://github.com/autowarefoundation/autoware.universe/issues/7109>`_)
   * align the MPC steering angle when the car is controlled manually.
   * update the condition for is_driving_manually
   * STOP mode included
@@ -62,7 +62,7 @@ Changelog for package autoware_mpc_lateral_controller
   * unchange the unrelevant line
   * pre-commit
   ---------
-* feat(mpc_lateral_controller): signal a MRM when MPC fails. (`#7016 <https://github.com/youtalk/autoware.universe/issues/7016>`_)
+* feat(mpc_lateral_controller): signal a MRM when MPC fails. (`#7016 <https://github.com/autowarefoundation/autoware.universe/issues/7016>`_)
   * mpc fail checker diagnostic added
   * fix some scope issues
   * member attribute added.
@@ -79,27 +79,27 @@ Changelog for package autoware_mpc_lateral_controller
   * pre-commit
   ---------
   Co-authored-by: Takamasa Horibe <horibe.takamasa@gmail.com>
-* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/youtalk/autoware.universe/issues/7539>`_)
+* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/autowarefoundation/autoware.universe/issues/7539>`_)
   refactor(motion_utils): add autoware prefix and include dir
-* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/youtalk/autoware.universe/issues/7538>`_)
+* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/autowarefoundation/autoware.universe/issues/7538>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* refactor(control)!: refactor directory structures of the trajectory followers (`#7521 <https://github.com/youtalk/autoware.universe/issues/7521>`_)
+* refactor(control)!: refactor directory structures of the trajectory followers (`#7521 <https://github.com/autowarefoundation/autoware.universe/issues/7521>`_)
   * control_traj
   * add follower_node
   * fix
   ---------
-* refactor(trajectory_follower_node): trajectory follower node add autoware prefix (`#7344 <https://github.com/youtalk/autoware.universe/issues/7344>`_)
+* refactor(trajectory_follower_node): trajectory follower node add autoware prefix (`#7344 <https://github.com/autowarefoundation/autoware.universe/issues/7344>`_)
   * rename trajectory follower node package
   * update dependencies, launch files, and README files
   * fix formats
   * remove autoware\_ prefix from launch arg option
   ---------
-* refactor(trajectory_follower_base): trajectory follower base add autoware prefix (`#7343 <https://github.com/youtalk/autoware.universe/issues/7343>`_)
+* refactor(trajectory_follower_base): trajectory follower base add autoware prefix (`#7343 <https://github.com/autowarefoundation/autoware.universe/issues/7343>`_)
   * rename trajectory follower base package
   * update dependencies and includes
   * fix formats
   ---------
-* refactor(vehicle_info_utils)!: prefix package and namespace with autoware (`#7353 <https://github.com/youtalk/autoware.universe/issues/7353>`_)
+* refactor(vehicle_info_utils)!: prefix package and namespace with autoware (`#7353 <https://github.com/autowarefoundation/autoware.universe/issues/7353>`_)
   * chore(autoware_vehicle_info_utils): rename header
   * chore(bpp-common): vehicle info
   * chore(path_optimizer): vehicle info
@@ -134,7 +134,7 @@ Changelog for package autoware_mpc_lateral_controller
   * chore(sensing): vehicle info
   * fix(autoware_joy_controller): remove unused deps
   ---------
-* refactor(mpc_lateral_controller, trajectory_follower_node)!: prefix package and namespace with autoware (`#7306 <https://github.com/youtalk/autoware.universe/issues/7306>`_)
+* refactor(mpc_lateral_controller, trajectory_follower_node)!: prefix package and namespace with autoware (`#7306 <https://github.com/autowarefoundation/autoware.universe/issues/7306>`_)
   * add the prefix to the folder
   * named to autoware_mpc_lateral_controller
   * rename the folder in the include

--- a/control/autoware_obstacle_collision_checker/CHANGELOG.rst
+++ b/control/autoware_obstacle_collision_checker/CHANGELOG.rst
@@ -5,7 +5,7 @@ Changelog for package autoware_obstacle_collision_checker
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* refactor(obstacle_collision_checker): move to autoware namespace (`#9047 <https://github.com/youtalk/autoware.universe/issues/9047>`_)
+* refactor(obstacle_collision_checker): move to autoware namespace (`#9047 <https://github.com/autowarefoundation/autoware.universe/issues/9047>`_)
 * Contributors: Maxime CLEMENT, Yutaka Kondo
 
 0.26.0 (2024-04-03)

--- a/control/autoware_operation_mode_transition_manager/CHANGELOG.rst
+++ b/control/autoware_operation_mode_transition_manager/CHANGELOG.rst
@@ -5,16 +5,16 @@ Changelog for package autoware_operation_mode_transition_manager
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* refactor(component_interface_specs): prefix package and namespace with autoware (`#9094 <https://github.com/youtalk/autoware.universe/issues/9094>`_)
-* fix(autoware_operation_mode_transition_manager): fix funcArgNamesDifferent (`#7997 <https://github.com/youtalk/autoware.universe/issues/7997>`_)
+* refactor(component_interface_specs): prefix package and namespace with autoware (`#9094 <https://github.com/autowarefoundation/autoware.universe/issues/9094>`_)
+* fix(autoware_operation_mode_transition_manager): fix funcArgNamesDifferent (`#7997 <https://github.com/autowarefoundation/autoware.universe/issues/7997>`_)
   fix: funcArgNamesDifferent_con-1
-* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/youtalk/autoware.universe/issues/7594>`_)
-* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/youtalk/autoware.universe/issues/7539>`_)
+* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/autowarefoundation/autoware.universe/issues/7594>`_)
+* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/autowarefoundation/autoware.universe/issues/7539>`_)
   refactor(motion_utils): add autoware prefix and include dir
-* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/youtalk/autoware.universe/issues/7538>`_)
+* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/autowarefoundation/autoware.universe/issues/7538>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* fix(operation mode manager): add nullptr check in onTimer (`#7446 <https://github.com/youtalk/autoware.universe/issues/7446>`_)
-* refactor(operation_mode_transition_manager): prefix package and namespace with autoware\_ (`#7291 <https://github.com/youtalk/autoware.universe/issues/7291>`_)
+* fix(operation mode manager): add nullptr check in onTimer (`#7446 <https://github.com/autowarefoundation/autoware.universe/issues/7446>`_)
+* refactor(operation_mode_transition_manager): prefix package and namespace with autoware\_ (`#7291 <https://github.com/autowarefoundation/autoware.universe/issues/7291>`_)
   * RT1-6682 add prefix package and namespace with autoware\_
   * RT1-6682 fix package's description
   ---------

--- a/control/autoware_pid_longitudinal_controller/CHANGELOG.rst
+++ b/control/autoware_pid_longitudinal_controller/CHANGELOG.rst
@@ -5,58 +5,58 @@ Changelog for package autoware_pid_longitudinal_controller
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* refactor(autoware_interpolation): prefix package and namespace with autoware (`#8088 <https://github.com/youtalk/autoware.universe/issues/8088>`_)
+* refactor(autoware_interpolation): prefix package and namespace with autoware (`#8088 <https://github.com/autowarefoundation/autoware.universe/issues/8088>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* fix(pid_longitudinal_controller): fix the same point error (`#8758 <https://github.com/youtalk/autoware.universe/issues/8758>`_)
+* fix(pid_longitudinal_controller): fix the same point error (`#8758 <https://github.com/autowarefoundation/autoware.universe/issues/8758>`_)
   * fix same point
-* feat(pid_longitudinal_controller)!: add acceleration feedback block (`#8325 <https://github.com/youtalk/autoware.universe/issues/8325>`_)
-* refactor(control/pid_longitudinal_controller): rework parameters (`#6707 <https://github.com/youtalk/autoware.universe/issues/6707>`_)
+* feat(pid_longitudinal_controller)!: add acceleration feedback block (`#8325 <https://github.com/autowarefoundation/autoware.universe/issues/8325>`_)
+* refactor(control/pid_longitudinal_controller): rework parameters (`#6707 <https://github.com/autowarefoundation/autoware.universe/issues/6707>`_)
   * reset and re-apply refactoring
   * style(pre-commit): autofix
   * .
   * .
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat(pid_longitudinal_controller): re-organize diff limit structure and fix state change condition (`#7718 <https://github.com/youtalk/autoware.universe/issues/7718>`_)
+* feat(pid_longitudinal_controller): re-organize diff limit structure and fix state change condition (`#7718 <https://github.com/autowarefoundation/autoware.universe/issues/7718>`_)
   change diff limit structure
   change stopped condition
   define a new param
-* fix(controller): revival of dry steering (`#7903 <https://github.com/youtalk/autoware.universe/issues/7903>`_)
-  * Revert "fix(autoware_mpc_lateral_controller): delete the zero speed constraint (`#7673 <https://github.com/youtalk/autoware.universe/issues/7673>`_)"
+* fix(controller): revival of dry steering (`#7903 <https://github.com/autowarefoundation/autoware.universe/issues/7903>`_)
+  * Revert "fix(autoware_mpc_lateral_controller): delete the zero speed constraint (`#7673 <https://github.com/autowarefoundation/autoware.universe/issues/7673>`_)"
   This reverts commit 69258bd92cb8a0ff8320df9b2302db72975e027f.
   * dry steering
   * add comments
   * add minor fix and modify unit test for dry steering
   ---------
-* fix(autoware_pid_longitudinal_controller, autoware_trajectory_follower_node): unite diagnostic_updater\_ in PID and MPC. (`#7674 <https://github.com/youtalk/autoware.universe/issues/7674>`_)
+* fix(autoware_pid_longitudinal_controller, autoware_trajectory_follower_node): unite diagnostic_updater\_ in PID and MPC. (`#7674 <https://github.com/autowarefoundation/autoware.universe/issues/7674>`_)
   * diag_updater\_ added in PID
   * correct the pointer form
   * pre-commit
   ---------
-* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/youtalk/autoware.universe/issues/7594>`_)
-* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/youtalk/autoware.universe/issues/7539>`_)
+* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/autowarefoundation/autoware.universe/issues/7594>`_)
+* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/autowarefoundation/autoware.universe/issues/7539>`_)
   refactor(motion_utils): add autoware prefix and include dir
-* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/youtalk/autoware.universe/issues/7538>`_)
+* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/autowarefoundation/autoware.universe/issues/7538>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* refactor(control)!: refactor directory structures of the trajectory followers (`#7521 <https://github.com/youtalk/autoware.universe/issues/7521>`_)
+* refactor(control)!: refactor directory structures of the trajectory followers (`#7521 <https://github.com/autowarefoundation/autoware.universe/issues/7521>`_)
   * control_traj
   * add follower_node
   * fix
   ---------
-* ci(pre-commit): autoupdate (`#7499 <https://github.com/youtalk/autoware.universe/issues/7499>`_)
+* ci(pre-commit): autoupdate (`#7499 <https://github.com/autowarefoundation/autoware.universe/issues/7499>`_)
   Co-authored-by: M. Fatih Cırıt <mfc@leodrive.ai>
-* refactor(trajectory_follower_node): trajectory follower node add autoware prefix (`#7344 <https://github.com/youtalk/autoware.universe/issues/7344>`_)
+* refactor(trajectory_follower_node): trajectory follower node add autoware prefix (`#7344 <https://github.com/autowarefoundation/autoware.universe/issues/7344>`_)
   * rename trajectory follower node package
   * update dependencies, launch files, and README files
   * fix formats
   * remove autoware\_ prefix from launch arg option
   ---------
-* refactor(trajectory_follower_base): trajectory follower base add autoware prefix (`#7343 <https://github.com/youtalk/autoware.universe/issues/7343>`_)
+* refactor(trajectory_follower_base): trajectory follower base add autoware prefix (`#7343 <https://github.com/autowarefoundation/autoware.universe/issues/7343>`_)
   * rename trajectory follower base package
   * update dependencies and includes
   * fix formats
   ---------
-* refactor(vehicle_info_utils)!: prefix package and namespace with autoware (`#7353 <https://github.com/youtalk/autoware.universe/issues/7353>`_)
+* refactor(vehicle_info_utils)!: prefix package and namespace with autoware (`#7353 <https://github.com/autowarefoundation/autoware.universe/issues/7353>`_)
   * chore(autoware_vehicle_info_utils): rename header
   * chore(bpp-common): vehicle info
   * chore(path_optimizer): vehicle info
@@ -91,7 +91,7 @@ Changelog for package autoware_pid_longitudinal_controller
   * chore(sensing): vehicle info
   * fix(autoware_joy_controller): remove unused deps
   ---------
-* refactor(pid_longitudinal_controller)!: prefix package and namespace with autoware (`#7383 <https://github.com/youtalk/autoware.universe/issues/7383>`_)
+* refactor(pid_longitudinal_controller)!: prefix package and namespace with autoware (`#7383 <https://github.com/autowarefoundation/autoware.universe/issues/7383>`_)
   * add prefix
   * fix
   * fix trajectory follower node param

--- a/control/autoware_pure_pursuit/CHANGELOG.rst
+++ b/control/autoware_pure_pursuit/CHANGELOG.rst
@@ -5,31 +5,31 @@ Changelog for package autoware_pure_pursuit
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* fix(pure_pursuit): add autoware\_ prefix in launch file (`#8687 <https://github.com/youtalk/autoware.universe/issues/8687>`_)
-* fix(autoware_pure_pursuit): fix unusedFunction (`#8552 <https://github.com/youtalk/autoware.universe/issues/8552>`_)
+* fix(pure_pursuit): add autoware\_ prefix in launch file (`#8687 <https://github.com/autowarefoundation/autoware.universe/issues/8687>`_)
+* fix(autoware_pure_pursuit): fix unusedFunction (`#8552 <https://github.com/autowarefoundation/autoware.universe/issues/8552>`_)
   fix:unusedFunction
-* fix(autoware_pure_pursuit): fix redundantInitialization redundantInitialization (`#8225 <https://github.com/youtalk/autoware.universe/issues/8225>`_)
+* fix(autoware_pure_pursuit): fix redundantInitialization redundantInitialization (`#8225 <https://github.com/autowarefoundation/autoware.universe/issues/8225>`_)
   * fix(autoware_pure_pursuit): fix redundantInitialization redundantInitialization
   * style(pre-commit): autofix
   * Update control/autoware_pure_pursuit/src/autoware_pure_pursuit_core/interpolate.cpp
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Takayuki Murooka <takayuki5168@gmail.com>
-* fix(autoware_pure_pursuit): fix shadowVariable (`#7932 <https://github.com/youtalk/autoware.universe/issues/7932>`_)
+* fix(autoware_pure_pursuit): fix shadowVariable (`#7932 <https://github.com/autowarefoundation/autoware.universe/issues/7932>`_)
   * fix:shadowVariable
   * refactor: using range-based for loop
   ---------
-* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/youtalk/autoware.universe/issues/7594>`_)
-* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/youtalk/autoware.universe/issues/7539>`_)
+* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/autowarefoundation/autoware.universe/issues/7594>`_)
+* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/autowarefoundation/autoware.universe/issues/7539>`_)
   refactor(motion_utils): add autoware prefix and include dir
-* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/youtalk/autoware.universe/issues/7538>`_)
+* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/autowarefoundation/autoware.universe/issues/7538>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* refactor(control)!: refactor directory structures of the trajectory followers (`#7521 <https://github.com/youtalk/autoware.universe/issues/7521>`_)
+* refactor(control)!: refactor directory structures of the trajectory followers (`#7521 <https://github.com/autowarefoundation/autoware.universe/issues/7521>`_)
   * control_traj
   * add follower_node
   * fix
   ---------
-* refactor(pure_pursuit): prefix package and namespace with autoware\_ (`#7301 <https://github.com/youtalk/autoware.universe/issues/7301>`_)
+* refactor(pure_pursuit): prefix package and namespace with autoware\_ (`#7301 <https://github.com/autowarefoundation/autoware.universe/issues/7301>`_)
   * RT1-6683 add autoware prefix to package and namepace
   * fix precommit
   ---------

--- a/control/autoware_shift_decider/CHANGELOG.rst
+++ b/control/autoware_shift_decider/CHANGELOG.rst
@@ -5,19 +5,19 @@ Changelog for package autoware_shift_decider
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/youtalk/autoware.universe/issues/7594>`_)
-* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/youtalk/autoware.universe/issues/7538>`_)
+* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/autowarefoundation/autoware.universe/issues/7594>`_)
+* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/autowarefoundation/autoware.universe/issues/7538>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* refactor(control)!: refactor directory structures of the control checkers (`#7524 <https://github.com/youtalk/autoware.universe/issues/7524>`_)
+* refactor(control)!: refactor directory structures of the control checkers (`#7524 <https://github.com/autowarefoundation/autoware.universe/issues/7524>`_)
   * aeb
   * control_validator
   * lane_departure_checker
   * shift_decider
   * fix
   ---------
-* feat(shift_decider): use polling subscriber (`#7345 <https://github.com/youtalk/autoware.universe/issues/7345>`_)
+* feat(shift_decider): use polling subscriber (`#7345 <https://github.com/autowarefoundation/autoware.universe/issues/7345>`_)
   RT1-6697 use polling subscriber
-* refactor(shift_decider): prefix package and namespace with autoware\_ (`#7310 <https://github.com/youtalk/autoware.universe/issues/7310>`_)
+* refactor(shift_decider): prefix package and namespace with autoware\_ (`#7310 <https://github.com/autowarefoundation/autoware.universe/issues/7310>`_)
   * RT1-6684 add autoware prefix and namespace
   * RT1-6684 Revert svg
   This reverts commit 4e0569e4796ab432c734905fb7f2106779575e29.

--- a/control/autoware_smart_mpc_trajectory_follower/CHANGELOG.rst
+++ b/control/autoware_smart_mpc_trajectory_follower/CHANGELOG.rst
@@ -5,12 +5,12 @@ Changelog for package autoware_smart_mpc_trajectory_follower
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* fix(autoware_smart_mpc_trajectory_follower): fix unusedFunction (`#8553 <https://github.com/youtalk/autoware.universe/issues/8553>`_)
+* fix(autoware_smart_mpc_trajectory_follower): fix unusedFunction (`#8553 <https://github.com/autowarefoundation/autoware.universe/issues/8553>`_)
   fix:unusedFunction
-* fix(autoware_smart_mpc_trajectory_follower): fix uninitMemberVar (`#8346 <https://github.com/youtalk/autoware.universe/issues/8346>`_)
+* fix(autoware_smart_mpc_trajectory_follower): fix uninitMemberVar (`#8346 <https://github.com/autowarefoundation/autoware.universe/issues/8346>`_)
   fix: uninitMemberVar
   Co-authored-by: kobayu858 <129580202+kobayu858@users.noreply.github.com>
-* refactor(smart_mpc_trajectory_folower): modify pacakge structure and install without setup.py (`#8268 <https://github.com/youtalk/autoware.universe/issues/8268>`_)
+* refactor(smart_mpc_trajectory_folower): modify pacakge structure and install without setup.py (`#8268 <https://github.com/autowarefoundation/autoware.universe/issues/8268>`_)
   * refactor(smart_mpc_trajectory_follower): modify pacakge structure and install without setup.py
   * import proxima calc
   * use ament_get_python_install_dir
@@ -19,7 +19,7 @@ Changelog for package autoware_smart_mpc_trajectory_follower
   * remove str conversion from open
   * sort in cmake
   ---------
-* feat(smart_mpc_trajectory_follower): enhance performance with LSTM and compensation, add compensator outside of MPC (`#7696 <https://github.com/youtalk/autoware.universe/issues/7696>`_)
+* feat(smart_mpc_trajectory_follower): enhance performance with LSTM and compensation, add compensator outside of MPC (`#7696 <https://github.com/autowarefoundation/autoware.universe/issues/7696>`_)
   * update smart mpc package
   * Update control/autoware_smart_mpc_trajectory_follower/autoware_smart_mpc_trajectory_follower/python_simulator/data_collection_utils.py
   Co-authored-by: Kosuke Takeuchi <kosuke.tnp@gmail.com>
@@ -59,14 +59,14 @@ Changelog for package autoware_smart_mpc_trajectory_follower
   Co-authored-by: Kosuke Takeuchi <kosuke.tnp@gmail.com>
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: asei-proxima <asei.inoue@proxima-ai-tech.com>
-* fix(smart_mpc_trajectory_folower): fix running by adding control_state and changing msg/package_name (`#7666 <https://github.com/youtalk/autoware.universe/issues/7666>`_)
-* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/youtalk/autoware.universe/issues/7539>`_)
+* fix(smart_mpc_trajectory_folower): fix running by adding control_state and changing msg/package_name (`#7666 <https://github.com/autowarefoundation/autoware.universe/issues/7666>`_)
+* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/autowarefoundation/autoware.universe/issues/7539>`_)
   refactor(motion_utils): add autoware prefix and include dir
-* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/youtalk/autoware.universe/issues/7538>`_)
+* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/autowarefoundation/autoware.universe/issues/7538>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* ci(pre-commit): autoupdate (`#7499 <https://github.com/youtalk/autoware.universe/issues/7499>`_)
+* ci(pre-commit): autoupdate (`#7499 <https://github.com/autowarefoundation/autoware.universe/issues/7499>`_)
   Co-authored-by: M. Fatih Cırıt <mfc@leodrive.ai>
-* chore(smart_mpc_trajectory_follower): add prefix autoware\_ to smart_mpc_trajectory_follower (`#7367 <https://github.com/youtalk/autoware.universe/issues/7367>`_)
+* chore(smart_mpc_trajectory_follower): add prefix autoware\_ to smart_mpc_trajectory_follower (`#7367 <https://github.com/autowarefoundation/autoware.universe/issues/7367>`_)
   * add prefix
   * fix pre-commit
   ---------

--- a/control/autoware_trajectory_follower_base/CHANGELOG.rst
+++ b/control/autoware_trajectory_follower_base/CHANGELOG.rst
@@ -5,25 +5,25 @@ Changelog for package autoware_trajectory_follower_base
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* refactor(osqp_interface): added autoware prefix to osqp_interface (`#8958 <https://github.com/youtalk/autoware.universe/issues/8958>`_)
-* refactor(autoware_interpolation): prefix package and namespace with autoware (`#8088 <https://github.com/youtalk/autoware.universe/issues/8088>`_)
+* refactor(osqp_interface): added autoware prefix to osqp_interface (`#8958 <https://github.com/autowarefoundation/autoware.universe/issues/8958>`_)
+* refactor(autoware_interpolation): prefix package and namespace with autoware (`#8088 <https://github.com/autowarefoundation/autoware.universe/issues/8088>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/youtalk/autoware.universe/issues/7539>`_)
+* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/autowarefoundation/autoware.universe/issues/7539>`_)
   refactor(motion_utils): add autoware prefix and include dir
-* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/youtalk/autoware.universe/issues/7538>`_)
+* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/autowarefoundation/autoware.universe/issues/7538>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* refactor(control)!: refactor directory structures of the trajectory followers (`#7521 <https://github.com/youtalk/autoware.universe/issues/7521>`_)
+* refactor(control)!: refactor directory structures of the trajectory followers (`#7521 <https://github.com/autowarefoundation/autoware.universe/issues/7521>`_)
   * control_traj
   * add follower_node
   * fix
   ---------
-* refactor(trajectory_follower_node): trajectory follower node add autoware prefix (`#7344 <https://github.com/youtalk/autoware.universe/issues/7344>`_)
+* refactor(trajectory_follower_node): trajectory follower node add autoware prefix (`#7344 <https://github.com/autowarefoundation/autoware.universe/issues/7344>`_)
   * rename trajectory follower node package
   * update dependencies, launch files, and README files
   * fix formats
   * remove autoware\_ prefix from launch arg option
   ---------
-* refactor(trajectory_follower_base): trajectory follower base add autoware prefix (`#7343 <https://github.com/youtalk/autoware.universe/issues/7343>`_)
+* refactor(trajectory_follower_base): trajectory follower base add autoware prefix (`#7343 <https://github.com/autowarefoundation/autoware.universe/issues/7343>`_)
   * rename trajectory follower base package
   * update dependencies and includes
   * fix formats

--- a/control/autoware_trajectory_follower_node/CHANGELOG.rst
+++ b/control/autoware_trajectory_follower_node/CHANGELOG.rst
@@ -5,39 +5,39 @@ Changelog for package autoware_trajectory_follower_node
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* fix(control): align the parameters with launcher (`#8789 <https://github.com/youtalk/autoware.universe/issues/8789>`_)
+* fix(control): align the parameters with launcher (`#8789 <https://github.com/autowarefoundation/autoware.universe/issues/8789>`_)
   align the control parameters
-* feat(autoware_mpc_lateral_controller): add predicted trajectory acconts for input delay (`#8436 <https://github.com/youtalk/autoware.universe/issues/8436>`_)
+* feat(autoware_mpc_lateral_controller): add predicted trajectory acconts for input delay (`#8436 <https://github.com/autowarefoundation/autoware.universe/issues/8436>`_)
   * feat: enable delayed initial state for predicted trajectory
   * feat: enable debug publishing of predicted and resampled reference trajectories
   ---------
-* feat(pid_longitudinal_controller)!: add acceleration feedback block (`#8325 <https://github.com/youtalk/autoware.universe/issues/8325>`_)
-* refactor(control/pid_longitudinal_controller): rework parameters (`#6707 <https://github.com/youtalk/autoware.universe/issues/6707>`_)
+* feat(pid_longitudinal_controller)!: add acceleration feedback block (`#8325 <https://github.com/autowarefoundation/autoware.universe/issues/8325>`_)
+* refactor(control/pid_longitudinal_controller): rework parameters (`#6707 <https://github.com/autowarefoundation/autoware.universe/issues/6707>`_)
   * reset and re-apply refactoring
   * style(pre-commit): autofix
   * .
   * .
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat(pid_longitudinal_controller): re-organize diff limit structure and fix state change condition (`#7718 <https://github.com/youtalk/autoware.universe/issues/7718>`_)
+* feat(pid_longitudinal_controller): re-organize diff limit structure and fix state change condition (`#7718 <https://github.com/autowarefoundation/autoware.universe/issues/7718>`_)
   change diff limit structure
   change stopped condition
   define a new param
-* fix(controller): revival of dry steering (`#7903 <https://github.com/youtalk/autoware.universe/issues/7903>`_)
-  * Revert "fix(autoware_mpc_lateral_controller): delete the zero speed constraint (`#7673 <https://github.com/youtalk/autoware.universe/issues/7673>`_)"
+* fix(controller): revival of dry steering (`#7903 <https://github.com/autowarefoundation/autoware.universe/issues/7903>`_)
+  * Revert "fix(autoware_mpc_lateral_controller): delete the zero speed constraint (`#7673 <https://github.com/autowarefoundation/autoware.universe/issues/7673>`_)"
   This reverts commit 69258bd92cb8a0ff8320df9b2302db72975e027f.
   * dry steering
   * add comments
   * add minor fix and modify unit test for dry steering
   ---------
-* ci: disable failing tests undetected due to broken regex filter (`#7731 <https://github.com/youtalk/autoware.universe/issues/7731>`_)
-* fix(autoware_pid_longitudinal_controller, autoware_trajectory_follower_node): unite diagnostic_updater\_ in PID and MPC. (`#7674 <https://github.com/youtalk/autoware.universe/issues/7674>`_)
+* ci: disable failing tests undetected due to broken regex filter (`#7731 <https://github.com/autowarefoundation/autoware.universe/issues/7731>`_)
+* fix(autoware_pid_longitudinal_controller, autoware_trajectory_follower_node): unite diagnostic_updater\_ in PID and MPC. (`#7674 <https://github.com/autowarefoundation/autoware.universe/issues/7674>`_)
   * diag_updater\_ added in PID
   * correct the pointer form
   * pre-commit
   ---------
-* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/youtalk/autoware.universe/issues/7594>`_)
-* feat(mpc_lateral_controller): signal a MRM when MPC fails. (`#7016 <https://github.com/youtalk/autoware.universe/issues/7016>`_)
+* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/autowarefoundation/autoware.universe/issues/7594>`_)
+* feat(mpc_lateral_controller): signal a MRM when MPC fails. (`#7016 <https://github.com/autowarefoundation/autoware.universe/issues/7016>`_)
   * mpc fail checker diagnostic added
   * fix some scope issues
   * member attribute added.
@@ -54,20 +54,20 @@ Changelog for package autoware_trajectory_follower_node
   * pre-commit
   ---------
   Co-authored-by: Takamasa Horibe <horibe.takamasa@gmail.com>
-* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/youtalk/autoware.universe/issues/7539>`_)
+* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/autowarefoundation/autoware.universe/issues/7539>`_)
   refactor(motion_utils): add autoware prefix and include dir
-* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/youtalk/autoware.universe/issues/7538>`_)
+* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/autowarefoundation/autoware.universe/issues/7538>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* refactor(control)!: refactor directory structures of the trajectory followers (`#7521 <https://github.com/youtalk/autoware.universe/issues/7521>`_)
+* refactor(control)!: refactor directory structures of the trajectory followers (`#7521 <https://github.com/autowarefoundation/autoware.universe/issues/7521>`_)
   * control_traj
   * add follower_node
   * fix
   ---------
-* refactor(pure_pursuit): prefix package and namespace with autoware\_ (`#7301 <https://github.com/youtalk/autoware.universe/issues/7301>`_)
+* refactor(pure_pursuit): prefix package and namespace with autoware\_ (`#7301 <https://github.com/autowarefoundation/autoware.universe/issues/7301>`_)
   * RT1-6683 add autoware prefix to package and namepace
   * fix precommit
   ---------
-* refactor(trajectory_follower_node): trajectory follower node add autoware prefix (`#7344 <https://github.com/youtalk/autoware.universe/issues/7344>`_)
+* refactor(trajectory_follower_node): trajectory follower node add autoware prefix (`#7344 <https://github.com/autowarefoundation/autoware.universe/issues/7344>`_)
   * rename trajectory follower node package
   * update dependencies, launch files, and README files
   * fix formats

--- a/control/autoware_vehicle_cmd_gate/CHANGELOG.rst
+++ b/control/autoware_vehicle_cmd_gate/CHANGELOG.rst
@@ -5,23 +5,23 @@ Changelog for package autoware_vehicle_cmd_gate
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* refactor(component_interface_specs): prefix package and namespace with autoware (`#9094 <https://github.com/youtalk/autoware.universe/issues/9094>`_)
-* feat(costmap_generator, control_validator, scenario_selector, surround_obstacle_checker, vehicle_cmd_gate): add processing time pub. (`#9065 <https://github.com/youtalk/autoware.universe/issues/9065>`_)
+* refactor(component_interface_specs): prefix package and namespace with autoware (`#9094 <https://github.com/autowarefoundation/autoware.universe/issues/9094>`_)
+* feat(costmap_generator, control_validator, scenario_selector, surround_obstacle_checker, vehicle_cmd_gate): add processing time pub. (`#9065 <https://github.com/autowarefoundation/autoware.universe/issues/9065>`_)
   * feat(costmap_generator, control_validator, scenario_selector, surround_obstacle_checker, vehicle_cmd_gate): Add: processing_time_pub
   * fix: pre-commit
   * feat(costmap_generator): fix: No output when not Active.
   * fix: clang-format
   * Re: fix: clang-format
   ---------
-* fix(control): align the parameters with launcher (`#8789 <https://github.com/youtalk/autoware.universe/issues/8789>`_)
+* fix(control): align the parameters with launcher (`#8789 <https://github.com/autowarefoundation/autoware.universe/issues/8789>`_)
   align the control parameters
-* chore(vehicle_cmd_gate): delete deprecated parameters (`#8537 <https://github.com/youtalk/autoware.universe/issues/8537>`_)
+* chore(vehicle_cmd_gate): delete deprecated parameters (`#8537 <https://github.com/autowarefoundation/autoware.universe/issues/8537>`_)
   delete deprecated params in vehicle_cmd_gate.param.yaml
-* fix(autoware_vehicle_cmd_gate): fix unusedFunction (`#8556 <https://github.com/youtalk/autoware.universe/issues/8556>`_)
+* fix(autoware_vehicle_cmd_gate): fix unusedFunction (`#8556 <https://github.com/autowarefoundation/autoware.universe/issues/8556>`_)
   fix:unusedFunction
-* refactor(vehicle_cmd_gate): use smaller class for filter command (`#8518 <https://github.com/youtalk/autoware.universe/issues/8518>`_)
-* fix(autoware_vehicle_cmd_gate): fix unreadVariable (`#8351 <https://github.com/youtalk/autoware.universe/issues/8351>`_)
-* feat(autoware_vehicle_cmd_gate):  accept same topic unless mode change occurs (`#8479 <https://github.com/youtalk/autoware.universe/issues/8479>`_)
+* refactor(vehicle_cmd_gate): use smaller class for filter command (`#8518 <https://github.com/autowarefoundation/autoware.universe/issues/8518>`_)
+* fix(autoware_vehicle_cmd_gate): fix unreadVariable (`#8351 <https://github.com/autowarefoundation/autoware.universe/issues/8351>`_)
+* feat(autoware_vehicle_cmd_gate):  accept same topic unless mode change occurs (`#8479 <https://github.com/autowarefoundation/autoware.universe/issues/8479>`_)
   * add prev_commands\_ and check cmd's time stamp
   * add timestamp when is_engaged is false
   * style(pre-commit): autofix
@@ -45,7 +45,7 @@ Changelog for package autoware_vehicle_cmd_gate
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Takamasa Horibe <horibe.takamasa@gmail.com>
   Co-authored-by: Shumpei Wakabayashi <42209144+shmpwk@users.noreply.github.com>
-* feat(autoware_vehicle_cmd_gate): check the timestamp of input topics to avoid using old topics (`#8084 <https://github.com/youtalk/autoware.universe/issues/8084>`_)
+* feat(autoware_vehicle_cmd_gate): check the timestamp of input topics to avoid using old topics (`#8084 <https://github.com/autowarefoundation/autoware.universe/issues/8084>`_)
   * add prev_commands\_ and check cmd's time stamp
   * add timestamp when is_engaged is false
   * style(pre-commit): autofix
@@ -67,38 +67,38 @@ Changelog for package autoware_vehicle_cmd_gate
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Takamasa Horibe <horibe.takamasa@gmail.com>
   Co-authored-by: Shumpei Wakabayashi <42209144+shmpwk@users.noreply.github.com>
-* fix(autoware_vehicle_cmd_gate): fix functionConst (`#8253 <https://github.com/youtalk/autoware.universe/issues/8253>`_)
+* fix(autoware_vehicle_cmd_gate): fix functionConst (`#8253 <https://github.com/autowarefoundation/autoware.universe/issues/8253>`_)
   fix: functionConst
-* fix(autoware_vehicle_cmd_gate): fix cppcheck warning of functionStatic (`#8260 <https://github.com/youtalk/autoware.universe/issues/8260>`_)
+* fix(autoware_vehicle_cmd_gate): fix cppcheck warning of functionStatic (`#8260 <https://github.com/autowarefoundation/autoware.universe/issues/8260>`_)
   * fix: deal with functionStatic warnings
   * style(pre-commit): autofix
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* fix(autoware_vehicle_cmd_gate): fix uninitMemberVar (`#8339 <https://github.com/youtalk/autoware.universe/issues/8339>`_)
+* fix(autoware_vehicle_cmd_gate): fix uninitMemberVar (`#8339 <https://github.com/autowarefoundation/autoware.universe/issues/8339>`_)
   fix:uninitMemberVar
-* fix(autoware_vehicle_cmd_gate): fix passedByValue (`#8243 <https://github.com/youtalk/autoware.universe/issues/8243>`_)
+* fix(autoware_vehicle_cmd_gate): fix passedByValue (`#8243 <https://github.com/autowarefoundation/autoware.universe/issues/8243>`_)
   fix: passedByValue
-* fix(autoware_vehicle_cmd_gate): fix funcArgNamesDifferent (`#8006 <https://github.com/youtalk/autoware.universe/issues/8006>`_)
+* fix(autoware_vehicle_cmd_gate): fix funcArgNamesDifferent (`#8006 <https://github.com/autowarefoundation/autoware.universe/issues/8006>`_)
   fix:funcArgNamesDifferent
-* refactor(vehicle_cmd_gate)!: delete rate limit skipping function for vehicle departure (`#7720 <https://github.com/youtalk/autoware.universe/issues/7720>`_)
+* refactor(vehicle_cmd_gate)!: delete rate limit skipping function for vehicle departure (`#7720 <https://github.com/autowarefoundation/autoware.universe/issues/7720>`_)
   * delete a fucntion block. More appropriate function can be achieved by the parameter settings.
   * add notation to readme
   ---------
-* fix(vehicle_cmd_gate): colcon test failure due to heavy process (`#7678 <https://github.com/youtalk/autoware.universe/issues/7678>`_)
-* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/youtalk/autoware.universe/issues/7594>`_)
-* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/youtalk/autoware.universe/issues/7539>`_)
+* fix(vehicle_cmd_gate): colcon test failure due to heavy process (`#7678 <https://github.com/autowarefoundation/autoware.universe/issues/7678>`_)
+* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/autowarefoundation/autoware.universe/issues/7594>`_)
+* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/autowarefoundation/autoware.universe/issues/7539>`_)
   refactor(motion_utils): add autoware prefix and include dir
-* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/youtalk/autoware.universe/issues/7538>`_)
+* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/autowarefoundation/autoware.universe/issues/7538>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* fix(vehicle_cmd_gate): put back subscriber rather than using polling subsriber (`#7500 <https://github.com/youtalk/autoware.universe/issues/7500>`_)
+* fix(vehicle_cmd_gate): put back subscriber rather than using polling subsriber (`#7500 <https://github.com/autowarefoundation/autoware.universe/issues/7500>`_)
   put back polling subscribers to subscribers in neccesary cases
-* fix(vehicle_cmd_gate): fix unnecessary modification (`#7488 <https://github.com/youtalk/autoware.universe/issues/7488>`_)
+* fix(vehicle_cmd_gate): fix unnecessary modification (`#7488 <https://github.com/autowarefoundation/autoware.universe/issues/7488>`_)
   fix onGateMode function
-* feat(vehicle_cmd_gate): use polling subscriber (`#7418 <https://github.com/youtalk/autoware.universe/issues/7418>`_)
+* feat(vehicle_cmd_gate): use polling subscriber (`#7418 <https://github.com/autowarefoundation/autoware.universe/issues/7418>`_)
   * change to polling subscriber
   * fix
   ---------
-* refactor(vehicle_info_utils)!: prefix package and namespace with autoware (`#7353 <https://github.com/youtalk/autoware.universe/issues/7353>`_)
+* refactor(vehicle_info_utils)!: prefix package and namespace with autoware (`#7353 <https://github.com/autowarefoundation/autoware.universe/issues/7353>`_)
   * chore(autoware_vehicle_info_utils): rename header
   * chore(bpp-common): vehicle info
   * chore(path_optimizer): vehicle info
@@ -133,7 +133,7 @@ Changelog for package autoware_vehicle_cmd_gate
   * chore(sensing): vehicle info
   * fix(autoware_joy_controller): remove unused deps
   ---------
-* chore(vehicle_cmd_gate): add prefix autoware\_ to vehicle_cmd_gate (`#7327 <https://github.com/youtalk/autoware.universe/issues/7327>`_)
+* chore(vehicle_cmd_gate): add prefix autoware\_ to vehicle_cmd_gate (`#7327 <https://github.com/autowarefoundation/autoware.universe/issues/7327>`_)
   * add prefix autoware\_ to vehicle_cmd_gate package
   * fix
   * fix include guard

--- a/control/control_performance_analysis/CHANGELOG.rst
+++ b/control/control_performance_analysis/CHANGELOG.rst
@@ -5,15 +5,15 @@ Changelog for package control_performance_analysis
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* refactor(signal_processing): prefix package and namespace with autoware (`#8541 <https://github.com/youtalk/autoware.universe/issues/8541>`_)
-* fix(control_performance_analysis): fix unusedFunction (`#8557 <https://github.com/youtalk/autoware.universe/issues/8557>`_)
+* refactor(signal_processing): prefix package and namespace with autoware (`#8541 <https://github.com/autowarefoundation/autoware.universe/issues/8541>`_)
+* fix(control_performance_analysis): fix unusedFunction (`#8557 <https://github.com/autowarefoundation/autoware.universe/issues/8557>`_)
   fix:unusedFunction
-* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/youtalk/autoware.universe/issues/7594>`_)
-* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/youtalk/autoware.universe/issues/7539>`_)
+* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/autowarefoundation/autoware.universe/issues/7594>`_)
+* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/autowarefoundation/autoware.universe/issues/7539>`_)
   refactor(motion_utils): add autoware prefix and include dir
-* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/youtalk/autoware.universe/issues/7538>`_)
+* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/autowarefoundation/autoware.universe/issues/7538>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* refactor(vehicle_info_utils)!: prefix package and namespace with autoware (`#7353 <https://github.com/youtalk/autoware.universe/issues/7353>`_)
+* refactor(vehicle_info_utils)!: prefix package and namespace with autoware (`#7353 <https://github.com/autowarefoundation/autoware.universe/issues/7353>`_)
   * chore(autoware_vehicle_info_utils): rename header
   * chore(bpp-common): vehicle info
   * chore(path_optimizer): vehicle info
@@ -48,23 +48,23 @@ Changelog for package control_performance_analysis
   * chore(sensing): vehicle info
   * fix(autoware_joy_controller): remove unused deps
   ---------
-* feat!: replace autoware_auto_msgs with autoware_msgs for control modules (`#7240 <https://github.com/youtalk/autoware.universe/issues/7240>`_)
+* feat!: replace autoware_auto_msgs with autoware_msgs for control modules (`#7240 <https://github.com/autowarefoundation/autoware.universe/issues/7240>`_)
   Co-authored-by: Cynthia Liu <cynthia.liu@autocore.ai>
   Co-authored-by: NorahXiong <norah.xiong@autocore.ai>
   Co-authored-by: beginningfan <beginning.fan@autocore.ai>
-* fix(control_performance_analysis): fix bug of ignoredReturnValue (`#6921 <https://github.com/youtalk/autoware.universe/issues/6921>`_)
+* fix(control_performance_analysis): fix bug of ignoredReturnValue (`#6921 <https://github.com/autowarefoundation/autoware.universe/issues/6921>`_)
 * Contributors: Esteve Fernandez, Kosuke Takeuchi, Ryohsuke Mitsudome, Ryuta Kambe, Satoshi OTA, Takayuki Murooka, Yutaka Kondo, kobayu858
 
 0.26.0 (2024-04-03)
 -------------------
-* refactor(common, control, planning): replace boost::optional with std::optional (`#5717 <https://github.com/youtalk/autoware.universe/issues/5717>`_)
+* refactor(common, control, planning): replace boost::optional with std::optional (`#5717 <https://github.com/autowarefoundation/autoware.universe/issues/5717>`_)
   * refactor(behavior_path_planner): replace boost optional with std
   * do it on motion utils as well.
   * up  until now
   * finally
   * fix all issue
   ---------
-* refactor(control_performance_analysis): rework parameters (`#4730 <https://github.com/youtalk/autoware.universe/issues/4730>`_)
+* refactor(control_performance_analysis): rework parameters (`#4730 <https://github.com/autowarefoundation/autoware.universe/issues/4730>`_)
   * refactor the configuration files of the node control_performance_analysis according to the new ROS node config guideline.
   Rename controller_performance_analysis.launch.xml->control_performance_analysis.launch.xml
   update the parameter information in the README.md
@@ -73,8 +73,8 @@ Changelog for package control_performance_analysis
   * revert copyright info
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* style: fix typos in PlotJuggler config files (`#3618 <https://github.com/youtalk/autoware.universe/issues/3618>`_)
-* refactor(control_performance_analysis): refactor structure (`#3786 <https://github.com/youtalk/autoware.universe/issues/3786>`_)
+* style: fix typos in PlotJuggler config files (`#3618 <https://github.com/autowarefoundation/autoware.universe/issues/3618>`_)
+* refactor(control_performance_analysis): refactor structure (`#3786 <https://github.com/autowarefoundation/autoware.universe/issues/3786>`_)
   * fix(control_performance_analysis): data is not updated on failure
   * update
   * update all (tmp
@@ -82,18 +82,18 @@ Changelog for package control_performance_analysis
   * update
   * fix pre-commit
   ---------
-* fix(control_performance_analysis): fix interpolate method (`#3704 <https://github.com/youtalk/autoware.universe/issues/3704>`_)
+* fix(control_performance_analysis): fix interpolate method (`#3704 <https://github.com/autowarefoundation/autoware.universe/issues/3704>`_)
   * fix(control_performance_analysis): fix interpolate method
   * pre-commit
   * fix process die due to failure on the closest index search
   * minor refactor to use autoware_util
   ---------
-* build: proper eigen deps and include (`#3615 <https://github.com/youtalk/autoware.universe/issues/3615>`_)
+* build: proper eigen deps and include (`#3615 <https://github.com/autowarefoundation/autoware.universe/issues/3615>`_)
   * build: proper eigen deps and include
   * style(pre-commit): autofix
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* build: mark autoware_cmake as <buildtool_depend> (`#3616 <https://github.com/youtalk/autoware.universe/issues/3616>`_)
+* build: mark autoware_cmake as <buildtool_depend> (`#3616 <https://github.com/autowarefoundation/autoware.universe/issues/3616>`_)
   * build: mark autoware_cmake as <buildtool_depend>
   with <build_depend>, autoware_cmake is automatically exported with ament_target_dependencies() (unecessary)
   * style(pre-commit): autofix
@@ -101,7 +101,7 @@ Changelog for package control_performance_analysis
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Kenji Miyake <kenji.miyake@tier4.jp>
-* chore(typo): eliminate typos (`#2216 <https://github.com/youtalk/autoware.universe/issues/2216>`_)
+* chore(typo): eliminate typos (`#2216 <https://github.com/autowarefoundation/autoware.universe/issues/2216>`_)
   * Replace 'asssert' with 'assert'
   * fix(typo): computationall => computational
   * fix(typo): collinearity => collinearity
@@ -273,11 +273,11 @@ Changelog for package control_performance_analysis
   commit c7d3b7d2132323af3437af01e9d774b13005bace
   Author: Hirokazu Ishida <38597814+HiroIshida@users.noreply.github.com>
   Date:   Fri Dec 16 13:51:35 2022 +0900
-  test(freespace_planning_algorithms): done't dump rosbag by default (`#2504 <https://github.com/youtalk/autoware.universe/issues/2504>`_)
+  test(freespace_planning_algorithms): done't dump rosbag by default (`#2504 <https://github.com/autowarefoundation/autoware.universe/issues/2504>`_)
   commit 6731e0ced39e3187c2afffe839eaa697a19e5e84
   Author: kminoda <44218668+kminoda@users.noreply.github.com>
   Date:   Fri Dec 16 09:29:35 2022 +0900
-  feat(pose_initializer): partial map loading (`#2500 <https://github.com/youtalk/autoware.universe/issues/2500>`_)
+  feat(pose_initializer): partial map loading (`#2500 <https://github.com/autowarefoundation/autoware.universe/issues/2500>`_)
   * first commit
   * move function
   * now works
@@ -296,7 +296,7 @@ Changelog for package control_performance_analysis
   commit efb4ff1cea6e07aa9e894a6042e8685e30b420ba
   Author: Kosuke Takeuchi <kosuke.tnp@gmail.com>
   Date:   Thu Dec 15 17:29:44 2022 +0900
-  feat(trajectory_follower): extend mpc trajectory for terminal yaw (`#2447 <https://github.com/youtalk/autoware.universe/issues/2447>`_)
+  feat(trajectory_follower): extend mpc trajectory for terminal yaw (`#2447 <https://github.com/autowarefoundation/autoware.universe/issues/2447>`_)
   * feat(trajectory_follower): extend mpc trajectory for terminal yaw
   * make mpc min vel param
   * add mpc extended point after smoothing
@@ -313,7 +313,7 @@ Changelog for package control_performance_analysis
   commit ad2ae7827bdc3af7da8607fdd53ea74940426421
   Author: Takagi, Isamu <43976882+isamu-takagi@users.noreply.github.com>
   Date:   Thu Dec 15 15:52:34 2022 +0900
-  feat(component_interface_tools): add service log checker  (`#2503 <https://github.com/youtalk/autoware.universe/issues/2503>`_)
+  feat(component_interface_tools): add service log checker  (`#2503 <https://github.com/autowarefoundation/autoware.universe/issues/2503>`_)
   * feat(component_interface_utils): add service log checker
   * feat(component_interface_tools): add service log checker
   * feat(component_interface_tools): add diagnostics
@@ -321,11 +321,11 @@ Changelog for package control_performance_analysis
   commit 4a13cc5a32898f5b17791d9381744bf71ff8ed20
   Author: Yutaka Shimizu <43805014+purewater0901@users.noreply.github.com>
   Date:   Thu Dec 15 12:54:11 2022 +0900
-  fix(behavior_path_planner): fix goal lanelet extension (`#2508 <https://github.com/youtalk/autoware.universe/issues/2508>`_)
+  fix(behavior_path_planner): fix goal lanelet extension (`#2508 <https://github.com/autowarefoundation/autoware.universe/issues/2508>`_)
   commit 77b1c36b5ca89b25250dcbb117c9f03a9c36c1c4
   Author: Kyoichi Sugahara <81.s.kyo.19@gmail.com>
   Date:   Thu Dec 15 10:45:45 2022 +0900
-  feat(behavior_path_planner): change side shift module logic (`#2195 <https://github.com/youtalk/autoware.universe/issues/2195>`_)
+  feat(behavior_path_planner): change side shift module logic (`#2195 <https://github.com/autowarefoundation/autoware.universe/issues/2195>`_)
   * change side shift module design
   * cherry picked side shift controller
   * add debug marker to side shift
@@ -343,45 +343,45 @@ Changelog for package control_performance_analysis
   commit 9183c4f20eb4592ed0b48c2eac67add070711677
   Author: Takamasa Horibe <horibe.takamasa@gmail.com>
   Date:   Wed Dec 14 19:59:00 2022 +0900
-  refactor(simple_planning_simulator): make function for duplicated code (`#2502 <https://github.com/youtalk/autoware.universe/issues/2502>`_)
+  refactor(simple_planning_simulator): make function for duplicated code (`#2502 <https://github.com/autowarefoundation/autoware.universe/issues/2502>`_)
   commit ed992b10ed326f03354dce3b563b8622f9ae9a6c
   Author: Yutaka Shimizu <43805014+purewater0901@users.noreply.github.com>
   Date:   Wed Dec 14 17:48:24 2022 +0900
-  fix(behavior_path_planner): fix planner data copy (`#2501 <https://github.com/youtalk/autoware.universe/issues/2501>`_)
+  fix(behavior_path_planner): fix planner data copy (`#2501 <https://github.com/autowarefoundation/autoware.universe/issues/2501>`_)
   commit 0c6c46b33b3c828cb95eaa31fcbf85655fc6a55f
   Author: Yutaka Shimizu <43805014+purewater0901@users.noreply.github.com>
   Date:   Wed Dec 14 14:42:16 2022 +0900
-  fix(behavior_path_planner): fix find nearest function from lateral distance (`#2499 <https://github.com/youtalk/autoware.universe/issues/2499>`_)
+  fix(behavior_path_planner): fix find nearest function from lateral distance (`#2499 <https://github.com/autowarefoundation/autoware.universe/issues/2499>`_)
   * feat(behavior_path_planner): fix find nearest function from lateral distance
   * empty commit
   commit a26b69d1df55e9369ea3adcdd011ae2d7c86dfb7
   Author: Yutaka Shimizu <43805014+purewater0901@users.noreply.github.com>
   Date:   Wed Dec 14 11:28:07 2022 +0900
-  feat(behavior_path_planner): fix overlap checker (`#2498 <https://github.com/youtalk/autoware.universe/issues/2498>`_)
+  feat(behavior_path_planner): fix overlap checker (`#2498 <https://github.com/autowarefoundation/autoware.universe/issues/2498>`_)
   * feat(behavior_path_planner): fix overlap checker
   * remove reserve
   commit 3a24859ca6851caaeb25fc4fac2334fcbdb887d1
   Author: Ismet Atabay <56237550+ismetatabay@users.noreply.github.com>
   Date:   Tue Dec 13 16:51:59 2022 +0300
-  feat(mission_planner): check goal footprint (`#2088 <https://github.com/youtalk/autoware.universe/issues/2088>`_)
+  feat(mission_planner): check goal footprint (`#2088 <https://github.com/autowarefoundation/autoware.universe/issues/2088>`_)
   commit b6a18855431b5f3a67fcbf383fac8df2b45d462e
   Author: Takamasa Horibe <horibe.takamasa@gmail.com>
   Date:   Tue Dec 13 22:46:24 2022 +0900
-  feat(trajectory_visualizer): update for steer limit, remove tf for pose source (`#2267 <https://github.com/youtalk/autoware.universe/issues/2267>`_)
+  feat(trajectory_visualizer): update for steer limit, remove tf for pose source (`#2267 <https://github.com/autowarefoundation/autoware.universe/issues/2267>`_)
   commit f1a9a9608559a5b89f631df3dc2fadd037e36ab4
   Author: Yutaka Shimizu <43805014+purewater0901@users.noreply.github.com>
   Date:   Tue Dec 13 19:47:16 2022 +0900
-  feat(behavior_path_planner): remove unnecessary code and clean turn signal decider (`#2494 <https://github.com/youtalk/autoware.universe/issues/2494>`_)
+  feat(behavior_path_planner): remove unnecessary code and clean turn signal decider (`#2494 <https://github.com/autowarefoundation/autoware.universe/issues/2494>`_)
   * feat(behavior_path_planner): clean drivable area code
   * make a function for turn signal decider
   commit fafe1d8235b99302bc9ba8f3770ae34878f1e7e7
   Author: Yutaka Shimizu <43805014+purewater0901@users.noreply.github.com>
   Date:   Tue Dec 13 18:19:41 2022 +0900
-  feat(behavior_path_planner): change turn signal output timing (`#2493 <https://github.com/youtalk/autoware.universe/issues/2493>`_)
+  feat(behavior_path_planner): change turn signal output timing (`#2493 <https://github.com/autowarefoundation/autoware.universe/issues/2493>`_)
   commit c48b9cfa7074ecd46d96f6dc43679e17bde3a63d
   Author: kminoda <44218668+kminoda@users.noreply.github.com>
   Date:   Tue Dec 13 09:16:14 2022 +0900
-  feat(map_loader): add differential map loading interface (`#2417 <https://github.com/youtalk/autoware.universe/issues/2417>`_)
+  feat(map_loader): add differential map loading interface (`#2417 <https://github.com/autowarefoundation/autoware.universe/issues/2417>`_)
   * first commit
   * ci(pre-commit): autofix
   * added module load in _node.cpp
@@ -394,13 +394,13 @@ Changelog for package control_performance_analysis
   commit 9a3613bfcd3e36e522d0ea9130f6200ca7689e2b
   Author: Takagi, Isamu <43976882+isamu-takagi@users.noreply.github.com>
   Date:   Tue Dec 13 08:49:23 2022 +0900
-  docs(default_ad_api): add readme (`#2491 <https://github.com/youtalk/autoware.universe/issues/2491>`_)
+  docs(default_ad_api): add readme (`#2491 <https://github.com/autowarefoundation/autoware.universe/issues/2491>`_)
   * docs(default_ad_api): add readme
   * feat: update table
   commit 49aa10b04de61c36706f6151d11bf17257ca54d1
   Author: Takagi, Isamu <43976882+isamu-takagi@users.noreply.github.com>
   Date:   Tue Dec 13 06:46:20 2022 +0900
-  feat(default_ad_api): split parameters into file (`#2488 <https://github.com/youtalk/autoware.universe/issues/2488>`_)
+  feat(default_ad_api): split parameters into file (`#2488 <https://github.com/autowarefoundation/autoware.universe/issues/2488>`_)
   * feat(default_ad_api): split parameters into file
   * feat: remove old parameter
   * fix: test
@@ -408,7 +408,7 @@ Changelog for package control_performance_analysis
   commit 7f0138c356c742b6e15e571e7a4683caa55969ac
   Author: Yutaka Shimizu <43805014+purewater0901@users.noreply.github.com>
   Date:   Mon Dec 12 22:16:54 2022 +0900
-  feat(behavior_path_planner, obstacle_avoidance_planner): add new drivable area (`#2472 <https://github.com/youtalk/autoware.universe/issues/2472>`_)
+  feat(behavior_path_planner, obstacle_avoidance_planner): add new drivable area (`#2472 <https://github.com/autowarefoundation/autoware.universe/issues/2472>`_)
   * update
   * update
   * update
@@ -432,11 +432,11 @@ Changelog for package control_performance_analysis
   commit c855e23cc17d1518ebce5dd15629d03acfe17da3
   Author: Takagi, Isamu <43976882+isamu-takagi@users.noreply.github.com>
   Date:   Mon Dec 12 17:15:10 2022 +0900
-  refactor(vehicle_cmd_gate): remove old emergency topics (`#2403 <https://github.com/youtalk/autoware.universe/issues/2403>`_)
+  refactor(vehicle_cmd_gate): remove old emergency topics (`#2403 <https://github.com/autowarefoundation/autoware.universe/issues/2403>`_)
   commit fa04d540c9afdded016730c9978920a194d2d2b4
   Author: Daisuke Nishimatsu <42202095+wep21@users.noreply.github.com>
   Date:   Mon Dec 12 16:04:00 2022 +0900
-  feat: replace python launch with xml launch for system monitor (`#2430 <https://github.com/youtalk/autoware.universe/issues/2430>`_)
+  feat: replace python launch with xml launch for system monitor (`#2430 <https://github.com/autowarefoundation/autoware.universe/issues/2430>`_)
   * feat: replace python launch with xml launch for system monitor
   * ci(pre-commit): autofix
   * update figure
@@ -444,7 +444,7 @@ Changelog for package control_performance_analysis
   commit 4a6990c49d1f8c3bedfb345e7c94c3c6893b4099
   Author: Kosuke Takeuchi <kosuke.tnp@gmail.com>
   Date:   Mon Dec 12 15:01:39 2022 +0900
-  feat(trajectory_follower): pub steer converged marker (`#2441 <https://github.com/youtalk/autoware.universe/issues/2441>`_)
+  feat(trajectory_follower): pub steer converged marker (`#2441 <https://github.com/autowarefoundation/autoware.universe/issues/2441>`_)
   * feat(trajectory_follower): pub steer converged marker
   * Revert "feat(trajectory_follower): pub steer converged marker"
   This reverts commit a6f6917bc542d5b533150f6abba086121e800974.
@@ -452,15 +452,15 @@ Changelog for package control_performance_analysis
   commit 3c01f15125dfbc45e1050ee96ccc42618d6ee6fd
   Author: Takagi, Isamu <43976882+isamu-takagi@users.noreply.github.com>
   Date:   Mon Dec 12 12:48:41 2022 +0900
-  docs(tier4_state_rviz_plugin): update readme (`#2475 <https://github.com/youtalk/autoware.universe/issues/2475>`_)
+  docs(tier4_state_rviz_plugin): update readme (`#2475 <https://github.com/autowarefoundation/autoware.universe/issues/2475>`_)
   commit d8ece0040354be5381a27403bcc757354735a77b
   Author: Takagi, Isamu <43976882+isamu-takagi@users.noreply.github.com>
   Date:   Mon Dec 12 11:57:03 2022 +0900
-  chore(simulator_compatibility_test): suppress setuptools warnings (`#2483 <https://github.com/youtalk/autoware.universe/issues/2483>`_)
+  chore(simulator_compatibility_test): suppress setuptools warnings (`#2483 <https://github.com/autowarefoundation/autoware.universe/issues/2483>`_)
   commit 727586bfe86dc9cb21ce34d9cbe19c241e162b04
   Author: Zulfaqar Azmi <93502286+zulfaqar-azmi-t4@users.noreply.github.com>
   Date:   Mon Dec 12 10:00:35 2022 +0900
-  fix(behavior_path_planner): lane change candidate resolution (`#2426 <https://github.com/youtalk/autoware.universe/issues/2426>`_)
+  fix(behavior_path_planner): lane change candidate resolution (`#2426 <https://github.com/autowarefoundation/autoware.universe/issues/2426>`_)
   * fix(behavior_path_planner): lane change candidate resolution
   * rework sampling based  on current speed
   * refactor code
@@ -470,21 +470,21 @@ Changelog for package control_performance_analysis
   commit 284548ca7f38b1d83af11f2b9caaac116eb9b09c
   Author: Zulfaqar Azmi <93502286+zulfaqar-azmi-t4@users.noreply.github.com>
   Date:   Mon Dec 12 09:57:19 2022 +0900
-  fix(behavior_path_planner): minimum distance for lane change (`#2413 <https://github.com/youtalk/autoware.universe/issues/2413>`_)
+  fix(behavior_path_planner): minimum distance for lane change (`#2413 <https://github.com/autowarefoundation/autoware.universe/issues/2413>`_)
   commit 469d8927bd7a0c98b9d491d347e111065973e13f
   Author: Ryohsuke Mitsudome <43976834+mitsudome-r@users.noreply.github.com>
   Date:   Fri Dec 9 21:27:18 2022 +0900
-  revert(behavior_path): revert removal of refineGoalFunction (`#2340 <https://github.com/youtalk/autoware.universe/issues/2340>`_)" (`#2485 <https://github.com/youtalk/autoware.universe/issues/2485>`_)
+  revert(behavior_path): revert removal of refineGoalFunction (`#2340 <https://github.com/autowarefoundation/autoware.universe/issues/2340>`_)" (`#2485 <https://github.com/autowarefoundation/autoware.universe/issues/2485>`_)
   This reverts commit 8e13ced6dfb6edfea77a589ef4cb93d82683bf51.
   commit d924f85b079dfe64feab017166685be40e977e62
   Author: NorahXiong <103234047+NorahXiong@users.noreply.github.com>
   Date:   Fri Dec 9 19:53:51 2022 +0800
-  fix(freespace_planning_algorithms): fix rrtstar can't arrive goal error (`#2350 <https://github.com/youtalk/autoware.universe/issues/2350>`_)
+  fix(freespace_planning_algorithms): fix rrtstar can't arrive goal error (`#2350 <https://github.com/autowarefoundation/autoware.universe/issues/2350>`_)
   Co-authored-by: Ryohsuke Mitsudome <43976834+mitsudome-r@users.noreply.github.com>
   commit b2ded82324bce78d9db3ff01b0227b00709b1efe
   Author: badai nguyen <94814556+badai-nguyen@users.noreply.github.com>
   Date:   Fri Dec 9 17:12:13 2022 +0900
-  fix(ground-segmentation): recheck gnd cluster pointcloud (`#2448 <https://github.com/youtalk/autoware.universe/issues/2448>`_)
+  fix(ground-segmentation): recheck gnd cluster pointcloud (`#2448 <https://github.com/autowarefoundation/autoware.universe/issues/2448>`_)
   * fix: reclassify ground cluster pcl
   * fix: add lowest-based recheck
   * chore: refactoring
@@ -493,19 +493,19 @@ Changelog for package control_performance_analysis
   commit 8906a1e78bc5b7d6417683ecedc1efe3f48be31e
   Author: Takamasa Horibe <horibe.takamasa@gmail.com>
   Date:   Fri Dec 9 16:29:45 2022 +0900
-  fix(trajectory_follower): fix mpc trajectory z pos (`#2482 <https://github.com/youtalk/autoware.universe/issues/2482>`_)
+  fix(trajectory_follower): fix mpc trajectory z pos (`#2482 <https://github.com/autowarefoundation/autoware.universe/issues/2482>`_)
   commit d4939058f05f9a1609f0ed22afbd0d4febfb212d
   Author: Yutaka Shimizu <43805014+purewater0901@users.noreply.github.com>
   Date:   Fri Dec 9 12:40:30 2022 +0900
-  feat(behavior_velocity_planner): clean walkway module (`#2480 <https://github.com/youtalk/autoware.universe/issues/2480>`_)
+  feat(behavior_velocity_planner): clean walkway module (`#2480 <https://github.com/autowarefoundation/autoware.universe/issues/2480>`_)
   commit d3b86a37ae7c3a0d59832caf56afa13b148d562c
   Author: Makoto Kurihara <mkuri8m@gmail.com>
   Date:   Thu Dec 8 22:59:32 2022 +0900
-  fix(emergency_handler): fix mrm handling when mrm behavior is none (`#2476 <https://github.com/youtalk/autoware.universe/issues/2476>`_)
+  fix(emergency_handler): fix mrm handling when mrm behavior is none (`#2476 <https://github.com/autowarefoundation/autoware.universe/issues/2476>`_)
   commit 2dde073a101e96757ef0cd189bb9ff06836934e9
   Author: Takagi, Isamu <43976882+isamu-takagi@users.noreply.github.com>
   Date:   Thu Dec 8 17:16:13 2022 +0900
-  feat(behavior_velocity_planner): add velocity factors (`#1985 <https://github.com/youtalk/autoware.universe/issues/1985>`_)
+  feat(behavior_velocity_planner): add velocity factors (`#1985 <https://github.com/autowarefoundation/autoware.universe/issues/1985>`_)
   * (editting) add intersection_coordination to stop reason
   * (editting) add intersection coordination to stop reasons
   * (Editting) add v2x to stop reason
@@ -556,11 +556,11 @@ Changelog for package control_performance_analysis
   commit 9a5057e4948ff5ac9165c14eb7112d79f2de76d5
   Author: Kosuke Takeuchi <kosuke.tnp@gmail.com>
   Date:   Thu Dec 8 13:42:50 2022 +0900
-  fix(freespace_planning_algorithms): comment out failing tests (`#2440 <https://github.com/youtalk/autoware.universe/issues/2440>`_)
+  fix(freespace_planning_algorithms): comment out failing tests (`#2440 <https://github.com/autowarefoundation/autoware.universe/issues/2440>`_)
   commit cddb8c74d0fbf49390b4d462c20c12bc257f4825
   Author: kminoda <44218668+kminoda@users.noreply.github.com>
   Date:   Thu Dec 8 11:57:04 2022 +0900
-  feat(gyro_odometer): publish twist when both data arrives (`#2423 <https://github.com/youtalk/autoware.universe/issues/2423>`_)
+  feat(gyro_odometer): publish twist when both data arrives (`#2423 <https://github.com/autowarefoundation/autoware.universe/issues/2423>`_)
   * feat(gyro_odometer): publish when both data arrive
   * remove unnecessary commentouts
   * ci(pre-commit): autofix
@@ -581,61 +581,61 @@ Changelog for package control_performance_analysis
   commit f0f513cf44532dfe8d51d27c4caef23fb694af16
   Author: kminoda <44218668+kminoda@users.noreply.github.com>
   Date:   Thu Dec 8 11:08:29 2022 +0900
-  fix: remove unnecessary DEBUG_INFO declarations (`#2457 <https://github.com/youtalk/autoware.universe/issues/2457>`_)
+  fix: remove unnecessary DEBUG_INFO declarations (`#2457 <https://github.com/autowarefoundation/autoware.universe/issues/2457>`_)
   commit 01daebf42937a05a2d83f3dee2c0778389492e50
   Author: Takayuki Murooka <takayuki5168@gmail.com>
   Date:   Thu Dec 8 00:28:35 2022 +0900
-  fix(tier4_autoware_api_launch): add rosbridge_server dependency (`#2470 <https://github.com/youtalk/autoware.universe/issues/2470>`_)
+  fix(tier4_autoware_api_launch): add rosbridge_server dependency (`#2470 <https://github.com/autowarefoundation/autoware.universe/issues/2470>`_)
   commit 26ef8174b1c12b84070b36df2a7cd14bfa9c0363
   Author: Shumpei Wakabayashi <42209144+shmpwk@users.noreply.github.com>
   Date:   Wed Dec 7 19:32:09 2022 +0900
-  fix: rename `use_external_emergency_stop` to  `check_external_emergency_heartbeat` (`#2455 <https://github.com/youtalk/autoware.universe/issues/2455>`_)
+  fix: rename `use_external_emergency_stop` to  `check_external_emergency_heartbeat` (`#2455 <https://github.com/autowarefoundation/autoware.universe/issues/2455>`_)
   * fix: rename use_external_emergency_stop to check_external_emergency_heartbeat
   * ci(pre-commit): autofix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   commit 024b993a0db8c0d28db0f05f64990bed7069cbd8
   Author: Yutaka Shimizu <43805014+purewater0901@users.noreply.github.com>
   Date:   Wed Dec 7 18:00:32 2022 +0900
-  fix(motion_utils): rename sampling function (`#2469 <https://github.com/youtalk/autoware.universe/issues/2469>`_)
+  fix(motion_utils): rename sampling function (`#2469 <https://github.com/autowarefoundation/autoware.universe/issues/2469>`_)
   commit c240ce2b6f4e79c435ed651b347a7d665a947862
   Author: Yukihiro Saito <yukky.saito@gmail.com>
   Date:   Wed Dec 7 16:33:44 2022 +0900
-  feat: remove web controller (`#2405 <https://github.com/youtalk/autoware.universe/issues/2405>`_)
+  feat: remove web controller (`#2405 <https://github.com/autowarefoundation/autoware.universe/issues/2405>`_)
   commit 2992b1cadae7e7ac86fd249998ce3c7ddbe476c9
   Author: Yutaka Shimizu <43805014+purewater0901@users.noreply.github.com>
   Date:   Wed Dec 7 15:39:28 2022 +0900
-  feat(motion_utils): add points resample function (`#2465 <https://github.com/youtalk/autoware.universe/issues/2465>`_)
+  feat(motion_utils): add points resample function (`#2465 <https://github.com/autowarefoundation/autoware.universe/issues/2465>`_)
   commit 4a75d7c0ddbd88f54afaf2bb05eb65138a53ea60
   Author: Mingyu1991 <115005477+Mingyu1991@users.noreply.github.com>
   Date:   Wed Dec 7 14:42:33 2022 +0900
-  docs: update training data for traffic light (`#2464 <https://github.com/youtalk/autoware.universe/issues/2464>`_)
+  docs: update training data for traffic light (`#2464 <https://github.com/autowarefoundation/autoware.universe/issues/2464>`_)
   * update traffic light cnn classifier README.md
   * correct to upper case
   Co-authored-by: Daisuke Nishimatsu <42202095+wep21@users.noreply.github.com>
   commit a4287165be87fa7727f79c01dfb0bea6af54c333
   Author: Ryuta Kambe <veqcc.c@gmail.com>
   Date:   Wed Dec 7 12:21:49 2022 +0900
-  perf(behavior_velocity_planner): remove unnecessary debug data (`#2462 <https://github.com/youtalk/autoware.universe/issues/2462>`_)
+  perf(behavior_velocity_planner): remove unnecessary debug data (`#2462 <https://github.com/autowarefoundation/autoware.universe/issues/2462>`_)
   commit 0a5b2857d3b2c1c9370598013b25aeaebf2d654d
   Author: Yutaka Shimizu <43805014+purewater0901@users.noreply.github.com>
   Date:   Wed Dec 7 12:03:46 2022 +0900
-  feat(behavior_path_planner): cut overlapped path (`#2451 <https://github.com/youtalk/autoware.universe/issues/2451>`_)
+  feat(behavior_path_planner): cut overlapped path (`#2451 <https://github.com/autowarefoundation/autoware.universe/issues/2451>`_)
   * feat(behavior_path_planner): cut overlapped path
   * clean code
   commit 65003dc99f2abe937afcc010514530fa666fbbfd
   Author: Takagi, Isamu <43976882+isamu-takagi@users.noreply.github.com>
   Date:   Wed Dec 7 11:06:41 2022 +0900
-  revert(default_ad_api): fix autoware state to add wait time (`#2407 <https://github.com/youtalk/autoware.universe/issues/2407>`_) (`#2460 <https://github.com/youtalk/autoware.universe/issues/2460>`_)
-  Revert "fix(default_ad_api): fix autoware state to add wait time (`#2407 <https://github.com/youtalk/autoware.universe/issues/2407>`_)"
+  revert(default_ad_api): fix autoware state to add wait time (`#2407 <https://github.com/autowarefoundation/autoware.universe/issues/2407>`_) (`#2460 <https://github.com/autowarefoundation/autoware.universe/issues/2460>`_)
+  Revert "fix(default_ad_api): fix autoware state to add wait time (`#2407 <https://github.com/autowarefoundation/autoware.universe/issues/2407>`_)"
   This reverts commit c4224854a7e57a9526dde998f742741fe383471c.
   commit fab18677ca4de378faff84a41db5147577e7448d
   Author: Makoto Kurihara <mkuri8m@gmail.com>
   Date:   Wed Dec 7 10:32:41 2022 +0900
-  fix(raw_vehicle_cmd_converter): fix column index for map validation (`#2450 <https://github.com/youtalk/autoware.universe/issues/2450>`_)
+  fix(raw_vehicle_cmd_converter): fix column index for map validation (`#2450 <https://github.com/autowarefoundation/autoware.universe/issues/2450>`_)
   commit a1d3c80a4f5e3a388887a5afb32d9bf7961301f1
   Author: Ambroise Vincent <ambroise.vincent@arm.com>
   Date:   Tue Dec 6 10:39:02 2022 +0100
-  fix(tvm_utility): copy test result to CPU (`#2414 <https://github.com/youtalk/autoware.universe/issues/2414>`_)
+  fix(tvm_utility): copy test result to CPU (`#2414 <https://github.com/autowarefoundation/autoware.universe/issues/2414>`_)
   Also remove dependency to autoware_auto_common.
   Issue-Id: SCM-5401
   Change-Id: I83b859742df2f2ff7df1d0bd2d287bfe0aa04c3d
@@ -643,12 +643,12 @@ Changelog for package control_performance_analysis
   commit eb9946832c7e42d5380fd71956165409d0b592c3
   Author: Mamoru Sobue <mamoru.sobue@tier4.jp>
   Date:   Tue Dec 6 18:11:41 2022 +0900
-  chore(behaviror_velocity_planner): changed logging level for intersection (`#2459 <https://github.com/youtalk/autoware.universe/issues/2459>`_)
+  chore(behaviror_velocity_planner): changed logging level for intersection (`#2459 <https://github.com/autowarefoundation/autoware.universe/issues/2459>`_)
   changed logging level
   commit c4224854a7e57a9526dde998f742741fe383471c
   Author: Takagi, Isamu <43976882+isamu-takagi@users.noreply.github.com>
   Date:   Tue Dec 6 17:01:37 2022 +0900
-  fix(default_ad_api): fix autoware state to add wait time (`#2407 <https://github.com/youtalk/autoware.universe/issues/2407>`_)
+  fix(default_ad_api): fix autoware state to add wait time (`#2407 <https://github.com/autowarefoundation/autoware.universe/issues/2407>`_)
   * fix(default_ad_api): fix autoware state to add wait time
   * Update system/default_ad_api/src/compatibility/autoware_state.cpp
   Co-authored-by: Kenji Miyake <31987104+kenji-miyake@users.noreply.github.com>
@@ -656,14 +656,14 @@ Changelog for package control_performance_analysis
   commit f984fbb708cb02947ec2824ce041c739c35940f7
   Author: Takamasa Horibe <horibe.takamasa@gmail.com>
   Date:   Tue Dec 6 13:55:17 2022 +0900
-  feat(transition_manager): add param to ignore autonomous transition condition (`#2453 <https://github.com/youtalk/autoware.universe/issues/2453>`_)
+  feat(transition_manager): add param to ignore autonomous transition condition (`#2453 <https://github.com/autowarefoundation/autoware.universe/issues/2453>`_)
   * feat(transition_manager): add param to ignore autonomous transition condition
   * same for modeChangeCompleted
   * remove debug print
   commit d3e640df270a0942c4639e11451faf26e099bbe1
   Author: Tomoya Kimura <tomoya.kimura@tier4.jp>
   Date:   Tue Dec 6 13:01:06 2022 +0900
-  feat(operation_mode_transition_manager): transition to auto quickly when vehicle stops (`#2427 <https://github.com/youtalk/autoware.universe/issues/2427>`_)
+  feat(operation_mode_transition_manager): transition to auto quickly when vehicle stops (`#2427 <https://github.com/autowarefoundation/autoware.universe/issues/2427>`_)
   * chore(cspell): interpolable => interpolatable
   * Revert "Merge branch 'destroy-typos-check-all' into destroy-typos"
   This reverts commit 6116ca02d9df59f815d772a271fed7b0b21ebaf7, reversing
@@ -674,10 +674,10 @@ Changelog for package control_performance_analysis
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Yukihiro Saito <yukky.saito@gmail.com>
-* refactor(control_performance_analysis): delete default values (`#2944 <https://github.com/youtalk/autoware.universe/issues/2944>`_)
+* refactor(control_performance_analysis): delete default values (`#2944 <https://github.com/autowarefoundation/autoware.universe/issues/2944>`_)
   delete param
   Co-authored-by: yamazakiTasuku <tasuku.yamazaki@tier4.jp>
-* chore(control, planning): add maintainers (`#2951 <https://github.com/youtalk/autoware.universe/issues/2951>`_)
+* chore(control, planning): add maintainers (`#2951 <https://github.com/autowarefoundation/autoware.universe/issues/2951>`_)
   * chore(control_performance_analysis): add maintainers
   * chore(external_cmd_selector): add maintainers
   * chore(joy_controller): add maintainers
@@ -687,13 +687,13 @@ Changelog for package control_performance_analysis
   Co-authored-by: Kenji Miyake <31987104+kenji-miyake@users.noreply.github.com>
   ---------
   Co-authored-by: Kenji Miyake <31987104+kenji-miyake@users.noreply.github.com>
-* chore: remove motion_common dependency (`#2231 <https://github.com/youtalk/autoware.universe/issues/2231>`_)
+* chore: remove motion_common dependency (`#2231 <https://github.com/autowarefoundation/autoware.universe/issues/2231>`_)
   * remove motion_common from smoother
   * remove motion_common from control_performance_analysis and simple_planning_simualtor
   * fix include
   * add include
-* chore: missing topic info duration 1000 -> 5000 (`#2056 <https://github.com/youtalk/autoware.universe/issues/2056>`_)
-* chore(planning/control packages): organized authors and maintainers (`#1610 <https://github.com/youtalk/autoware.universe/issues/1610>`_)
+* chore: missing topic info duration 1000 -> 5000 (`#2056 <https://github.com/autowarefoundation/autoware.universe/issues/2056>`_)
+* chore(planning/control packages): organized authors and maintainers (`#1610 <https://github.com/autowarefoundation/autoware.universe/issues/1610>`_)
   * organized planning authors and maintainers
   * organized control authors and maintainers
   * fix typo
@@ -726,7 +726,7 @@ Changelog for package control_performance_analysis
   * fix
   Co-authored-by: Kenji Miyake <31987104+kenji-miyake@users.noreply.github.com>
   Co-authored-by: Kenji Miyake <kenji.miyake@tier4.jp>
-* fix(control_performance_analysis): fix choosing wrong closest trajectory point (`#1522 <https://github.com/youtalk/autoware.universe/issues/1522>`_)
+* fix(control_performance_analysis): fix choosing wrong closest trajectory point (`#1522 <https://github.com/autowarefoundation/autoware.universe/issues/1522>`_)
   * fix(control_performance_analysis): fix choosing wrong closest trajectory point
   * removed comments
   * ci(pre-commit): autofix
@@ -741,7 +741,7 @@ Changelog for package control_performance_analysis
   * ci(pre-commit): autofix
   Co-authored-by: Berkay <berkay@leodrive.ai>
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat(control_performance_analysis): monitor desired and current steering tire angle in driving monitor (`#1133 <https://github.com/youtalk/autoware.universe/issues/1133>`_)
+* feat(control_performance_analysis): monitor desired and current steering tire angle in driving monitor (`#1133 <https://github.com/autowarefoundation/autoware.universe/issues/1133>`_)
   * feat(control_performance_analysis): monitor desired and current steering tire angle in driving monitor
   * ci(pre-commit): autofix
   * update readme
@@ -750,25 +750,25 @@ Changelog for package control_performance_analysis
   * ci(pre-commit): autofix
   Co-authored-by: Berkay <berkay@leodrive.ai>
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat(control_performance_analysis): add low pass filter to control_performance_analysis tool (`#1099 <https://github.com/youtalk/autoware.universe/issues/1099>`_)
+* feat(control_performance_analysis): add low pass filter to control_performance_analysis tool (`#1099 <https://github.com/autowarefoundation/autoware.universe/issues/1099>`_)
   * feat(control_performance_analysis): add low pass filter to control_performance_analysis tool
   * ci(pre-commit): autofix
   * Member variables are suffixed by an underscore
   Co-authored-by: Berkay <berkay@leodrive.ai>
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat(control_performance_analysis): add new functionalities to evaluate the control modules (`#659 <https://github.com/youtalk/autoware.universe/issues/659>`_)
+* feat(control_performance_analysis): add new functionalities to evaluate the control modules (`#659 <https://github.com/autowarefoundation/autoware.universe/issues/659>`_)
   Co-authored-by: M. Fatih Cırıt <mfc@leodrive.ai>
-* fix: set Eigen include directory as SYSTEM for Humble arm64 (`#978 <https://github.com/youtalk/autoware.universe/issues/978>`_)
-* chore: upgrade cmake_minimum_required to 3.14 (`#856 <https://github.com/youtalk/autoware.universe/issues/856>`_)
-* refactor: simplify Rolling support (`#854 <https://github.com/youtalk/autoware.universe/issues/854>`_)
-* refactor: use autoware cmake (`#849 <https://github.com/youtalk/autoware.universe/issues/849>`_)
+* fix: set Eigen include directory as SYSTEM for Humble arm64 (`#978 <https://github.com/autowarefoundation/autoware.universe/issues/978>`_)
+* chore: upgrade cmake_minimum_required to 3.14 (`#856 <https://github.com/autowarefoundation/autoware.universe/issues/856>`_)
+* refactor: simplify Rolling support (`#854 <https://github.com/autowarefoundation/autoware.universe/issues/854>`_)
+* refactor: use autoware cmake (`#849 <https://github.com/autowarefoundation/autoware.universe/issues/849>`_)
   * remove autoware_auto_cmake
   * add build_depend of autoware_cmake
   * use autoware_cmake in CMakeLists.txt
   * fix bugs
   * fix cmake lint errors
-* fix(control_performance_analysis): modify build error in rolling (`#757 <https://github.com/youtalk/autoware.universe/issues/757>`_)
-* fix(tier4_autoware_utils): modify build error in rolling (`#720 <https://github.com/youtalk/autoware.universe/issues/720>`_)
+* fix(control_performance_analysis): modify build error in rolling (`#757 <https://github.com/autowarefoundation/autoware.universe/issues/757>`_)
+* fix(tier4_autoware_utils): modify build error in rolling (`#720 <https://github.com/autowarefoundation/autoware.universe/issues/720>`_)
   * fix(tier4_autoware_utils): modify build error in rolling
   * fix(lanelet2_extension): add target compile definition for geometry2
   * fix(ekf_localizer): add target compile definition for geometry2
@@ -806,11 +806,11 @@ Changelog for package control_performance_analysis
   * fix(planning_error_monitor): add target compile definition for geometry2
   * fix(planning_evaluator): add target compile definition for geometry2
   * fix(lidar_centerpoint): add target compile definition for geometry2
-* ci(pre-commit): update pre-commit-hooks-ros (`#625 <https://github.com/youtalk/autoware.universe/issues/625>`_)
+* ci(pre-commit): update pre-commit-hooks-ros (`#625 <https://github.com/autowarefoundation/autoware.universe/issues/625>`_)
   * ci(pre-commit): update pre-commit-hooks-ros
   * ci(pre-commit): autofix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* chore: replace legacy timer (`#329 <https://github.com/youtalk/autoware.universe/issues/329>`_)
+* chore: replace legacy timer (`#329 <https://github.com/autowarefoundation/autoware.universe/issues/329>`_)
   * chore(goal_distance_calculator): replace legacy timer
   * chore(path_distance_calculator): replace legacy timer
   * chore(control_performance_analysis): replace legacy timer
@@ -845,11 +845,11 @@ Changelog for package control_performance_analysis
   * chore(external_cmd_converter): replace legacy timer
   * chore(pacmod_interface): replace legacy timer
   * chore(lint): apply pre-commit
-* fix(control performance analysis): suppress warnings (`#293 <https://github.com/youtalk/autoware.universe/issues/293>`_)
+* fix(control performance analysis): suppress warnings (`#293 <https://github.com/autowarefoundation/autoware.universe/issues/293>`_)
   * fix: delete unused variable
   * feat: add Werror
   * fix: fix clang-diagnostic-unused-private-field
-* feat: rename existing packages name starting with autoware to different names (`#180 <https://github.com/youtalk/autoware.universe/issues/180>`_)
+* feat: rename existing packages name starting with autoware to different names (`#180 <https://github.com/autowarefoundation/autoware.universe/issues/180>`_)
   * autoware_api_utils -> tier4_api_utils
   * autoware_debug_tools -> tier4_debug_tools
   * autoware_error_monitor -> system_error_monitor
@@ -866,7 +866,7 @@ Changelog for package control_performance_analysis
   * fix ad_service_state_monitor
   * ci(pre-commit): autofix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat: load vehicle info default param (`#148 <https://github.com/youtalk/autoware.universe/issues/148>`_)
+* feat: load vehicle info default param (`#148 <https://github.com/autowarefoundation/autoware.universe/issues/148>`_)
   * update global_parameter loader readme
   * remove unused dependency
   * add default vehicle_info_param to launch files
@@ -880,7 +880,7 @@ Changelog for package control_performance_analysis
   * ci(pre-commit): autofix
   Co-authored-by: Takeshi Miura <57553950+1222-takeshi@users.noreply.github.com>
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat: change pachage name: autoware_msgs -> tier4_msgs (`#150 <https://github.com/youtalk/autoware.universe/issues/150>`_)
+* feat: change pachage name: autoware_msgs -> tier4_msgs (`#150 <https://github.com/autowarefoundation/autoware.universe/issues/150>`_)
   * change pkg name: autoware\_*_msgs -> tier\_*_msgs
   * ci(pre-commit): autofix
   * autoware_external_api_msgs -> tier4_external_api_msgs
@@ -888,9 +888,9 @@ Changelog for package control_performance_analysis
   * fix description
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Takeshi Miura <57553950+1222-takeshi@users.noreply.github.com>
-* feat: add control_performance_analysis (`#95 <https://github.com/youtalk/autoware.universe/issues/95>`_)
-  * Feature/porting control performance analysis (`#1671 <https://github.com/youtalk/autoware.universe/issues/1671>`_)
-  * Feature/control performance analysis (`#1212 <https://github.com/youtalk/autoware.universe/issues/1212>`_)
+* feat: add control_performance_analysis (`#95 <https://github.com/autowarefoundation/autoware.universe/issues/95>`_)
+  * Feature/porting control performance analysis (`#1671 <https://github.com/autowarefoundation/autoware.universe/issues/1671>`_)
+  * Feature/control performance analysis (`#1212 <https://github.com/autowarefoundation/autoware.universe/issues/1212>`_)
   * First commit of kinematic_controller
   * First commit.
   * second commit
@@ -950,13 +950,13 @@ Changelog for package control_performance_analysis
   * Add comment for eigen macro
   * pre-commit fixes
   Co-authored-by: Ali BOYALI <boyali@users.noreply.github.com>
-  * Fix package.xml (`#2056 <https://github.com/youtalk/autoware.universe/issues/2056>`_)
-  * Fix typo for control_performance_analysis (`#2328 <https://github.com/youtalk/autoware.universe/issues/2328>`_)
+  * Fix package.xml (`#2056 <https://github.com/autowarefoundation/autoware.universe/issues/2056>`_)
+  * Fix typo for control_performance_analysis (`#2328 <https://github.com/autowarefoundation/autoware.universe/issues/2328>`_)
   * fix typo
   * fix Contro -> Control
   * fix for spellcheck
   * fix
-  * Change formatter to clang-format and black (`#2332 <https://github.com/youtalk/autoware.universe/issues/2332>`_)
+  * Change formatter to clang-format and black (`#2332 <https://github.com/autowarefoundation/autoware.universe/issues/2332>`_)
   * Revert "Temporarily comment out pre-commit hooks"
   This reverts commit 748e9cdb145ce12f8b520bcbd97f5ff899fc28a3.
   * Replace ament_lint_common with autoware_lint_common
@@ -968,8 +968,8 @@ Changelog for package control_performance_analysis
   * Fix include double quotes to angle brackets
   * Apply clang-format
   * Fix build errors
-  * Add COLCON_IGNORE (`#500 <https://github.com/youtalk/autoware.universe/issues/500>`_)
-  * adapt to actuation cmd/status as control msg (`#646 <https://github.com/youtalk/autoware.universe/issues/646>`_)
+  * Add COLCON_IGNORE (`#500 <https://github.com/autowarefoundation/autoware.universe/issues/500>`_)
+  * adapt to actuation cmd/status as control msg (`#646 <https://github.com/autowarefoundation/autoware.universe/issues/646>`_)
   * adapt to actuation cmd/status as control msg
   * fix readme
   * fix topics
@@ -980,18 +980,18 @@ Changelog for package control_performance_analysis
   * revert gyro_odometer_change
   * revert twist topic change
   * revert unchanged package
-  * port control_performance_analysis (`#698 <https://github.com/youtalk/autoware.universe/issues/698>`_)
+  * port control_performance_analysis (`#698 <https://github.com/autowarefoundation/autoware.universe/issues/698>`_)
   * port control_performance_analysis
   * rename
   * fix topic name
   * remove unnecessary depedency
   * change name of odom topic
-  * add readme in control_performance_analysis (`#716 <https://github.com/youtalk/autoware.universe/issues/716>`_)
+  * add readme in control_performance_analysis (`#716 <https://github.com/autowarefoundation/autoware.universe/issues/716>`_)
   * add readme
   * update readme
   * update readme
   * Update control/control_performance_analysis/README.md
-  * Update twist topic name (`#736 <https://github.com/youtalk/autoware.universe/issues/736>`_)
+  * Update twist topic name (`#736 <https://github.com/autowarefoundation/autoware.universe/issues/736>`_)
   * Apply suggestions from code review
   Co-authored-by: Daisuke Nishimatsu <42202095+wep21@users.noreply.github.com>
   Co-authored-by: Ali BOYALI <boyali@users.noreply.github.com>

--- a/control/predicted_path_checker/CHANGELOG.rst
+++ b/control/predicted_path_checker/CHANGELOG.rst
@@ -5,17 +5,17 @@ Changelog for package predicted_path_checker
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* refactor(component_interface_specs): prefix package and namespace with autoware (`#9094 <https://github.com/youtalk/autoware.universe/issues/9094>`_)
-* refactor(autoware_interpolation): prefix package and namespace with autoware (`#8088 <https://github.com/youtalk/autoware.universe/issues/8088>`_)
+* refactor(component_interface_specs): prefix package and namespace with autoware (`#9094 <https://github.com/autowarefoundation/autoware.universe/issues/9094>`_)
+* refactor(autoware_interpolation): prefix package and namespace with autoware (`#8088 <https://github.com/autowarefoundation/autoware.universe/issues/8088>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* fix(predicted_path_checker): fix constParameterReference  (`#8038 <https://github.com/youtalk/autoware.universe/issues/8038>`_)
+* fix(predicted_path_checker): fix constParameterReference  (`#8038 <https://github.com/autowarefoundation/autoware.universe/issues/8038>`_)
   fix:constParameterReference
-* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/youtalk/autoware.universe/issues/7594>`_)
-* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/youtalk/autoware.universe/issues/7539>`_)
+* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/autowarefoundation/autoware.universe/issues/7594>`_)
+* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/autowarefoundation/autoware.universe/issues/7539>`_)
   refactor(motion_utils): add autoware prefix and include dir
-* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/youtalk/autoware.universe/issues/7538>`_)
+* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/autowarefoundation/autoware.universe/issues/7538>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* refactor(vehicle_info_utils)!: prefix package and namespace with autoware (`#7353 <https://github.com/youtalk/autoware.universe/issues/7353>`_)
+* refactor(vehicle_info_utils)!: prefix package and namespace with autoware (`#7353 <https://github.com/autowarefoundation/autoware.universe/issues/7353>`_)
   * chore(autoware_vehicle_info_utils): rename header
   * chore(bpp-common): vehicle info
   * chore(path_optimizer): vehicle info
@@ -50,7 +50,7 @@ Changelog for package predicted_path_checker
   * chore(sensing): vehicle info
   * fix(autoware_joy_controller): remove unused deps
   ---------
-* feat!: replace autoware_auto_msgs with autoware_msgs for control modules (`#7240 <https://github.com/youtalk/autoware.universe/issues/7240>`_)
+* feat!: replace autoware_auto_msgs with autoware_msgs for control modules (`#7240 <https://github.com/autowarefoundation/autoware.universe/issues/7240>`_)
   Co-authored-by: Cynthia Liu <cynthia.liu@autocore.ai>
   Co-authored-by: NorahXiong <norah.xiong@autocore.ai>
   Co-authored-by: beginningfan <beginning.fan@autocore.ai>
@@ -58,10 +58,10 @@ Changelog for package predicted_path_checker
 
 0.26.0 (2024-04-03)
 -------------------
-* fix(predicted_path_checker): check if trajectory size (`#6730 <https://github.com/youtalk/autoware.universe/issues/6730>`_)
+* fix(predicted_path_checker): check if trajectory size (`#6730 <https://github.com/autowarefoundation/autoware.universe/issues/6730>`_)
   check trajectory size
   Co-authored-by: beyza <bnk@leodrive.ai>
-* refactor(motion_utils): change directory name of tmp_conversion (`#5908 <https://github.com/youtalk/autoware.universe/issues/5908>`_)
+* refactor(motion_utils): change directory name of tmp_conversion (`#5908 <https://github.com/autowarefoundation/autoware.universe/issues/5908>`_)
   * change .hpp name
   * change .cpp name
   * correct the #inlcude and #ifndef
@@ -72,8 +72,8 @@ Changelog for package predicted_path_checker
   * style(pre-commit): autofix
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat(predicted_path_checker): check predicted trajectory to avoid collisions planning can not handle (`#2528 <https://github.com/youtalk/autoware.universe/issues/2528>`_)
-  * feat(predicted_path_checker): check predicted trajectory to avoid collisions planning can not handle (`#2528 <https://github.com/youtalk/autoware.universe/issues/2528>`_)
+* feat(predicted_path_checker): check predicted trajectory to avoid collisions planning can not handle (`#2528 <https://github.com/autowarefoundation/autoware.universe/issues/2528>`_)
+  * feat(predicted_path_checker): check predicted trajectory to avoid collisions planning can not handle (`#2528 <https://github.com/autowarefoundation/autoware.universe/issues/2528>`_)
   * Added pkg to control.launch.py
   ---------
 * Contributors: Berkay Karaman, Zhe Shen, beyzanurkaya

--- a/evaluator/autoware_control_evaluator/CHANGELOG.rst
+++ b/evaluator/autoware_control_evaluator/CHANGELOG.rst
@@ -5,7 +5,7 @@ Changelog for package autoware_control_evaluator
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* feat(control_evaluator): add goal accuracy longitudinal, lateral, yaw (`#9155 <https://github.com/youtalk/autoware.universe/issues/9155>`_)
+* feat(control_evaluator): add goal accuracy longitudinal, lateral, yaw (`#9155 <https://github.com/autowarefoundation/autoware.universe/issues/9155>`_)
   * feat(control_evaluator): add goal accuracy longitudinal, lateral, yaw
   * style(pre-commit): autofix
   * fix: content of kosuke55-san comments
@@ -13,7 +13,7 @@ Changelog for package autoware_control_evaluator
   * fix: variable name
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* test(autoware_control_evaluator): add test for autoware_control_evaluator. (`#9114 <https://github.com/youtalk/autoware.universe/issues/9114>`_)
+* test(autoware_control_evaluator): add test for autoware_control_evaluator. (`#9114 <https://github.com/autowarefoundation/autoware.universe/issues/9114>`_)
   * init
   * tmp save.
   * save, there is a bug
@@ -21,7 +21,7 @@ Changelog for package autoware_control_evaluator
   * coverage rate 64.5
   * remove comments.
   ---------
-* docs(control_evaluator): update readme (`#8829 <https://github.com/youtalk/autoware.universe/issues/8829>`_)
+* docs(control_evaluator): update readme (`#8829 <https://github.com/autowarefoundation/autoware.universe/issues/8829>`_)
   * update readme
   * add maintainer
   * Update evaluator/autoware_control_evaluator/package.xml
@@ -29,11 +29,11 @@ Changelog for package autoware_control_evaluator
   Co-authored-by: Tiankui Xian <1041084556@qq.com>
   ---------
   Co-authored-by: Tiankui Xian <1041084556@qq.com>
-* feat(evalautor): rename evaluator diag topics (`#8152 <https://github.com/youtalk/autoware.universe/issues/8152>`_)
+* feat(evalautor): rename evaluator diag topics (`#8152 <https://github.com/autowarefoundation/autoware.universe/issues/8152>`_)
   * feat(evalautor): rename evaluator diag topics
   * perception
   ---------
-* refactor(autoware_universe_utils): changed the API to be more intuitive and added documentation (`#7443 <https://github.com/youtalk/autoware.universe/issues/7443>`_)
+* refactor(autoware_universe_utils): changed the API to be more intuitive and added documentation (`#7443 <https://github.com/autowarefoundation/autoware.universe/issues/7443>`_)
   * refactor(tier4_autoware_utils): Changed the API to be more intuitive and added documentation.
   * use raw shared ptr in PollingPolicy::NEWEST
   * update
@@ -42,15 +42,15 @@ Changelog for package autoware_control_evaluator
   Co-authored-by: danielsanchezaran <daniel.sanchez@tier4.jp>
   ---------
   Co-authored-by: danielsanchezaran <daniel.sanchez@tier4.jp>
-* feat(planning_evaluator,control_evaluator, evaluator utils): add diagnostics subscriber to planning eval (`#7849 <https://github.com/youtalk/autoware.universe/issues/7849>`_)
+* feat(planning_evaluator,control_evaluator, evaluator utils): add diagnostics subscriber to planning eval (`#7849 <https://github.com/autowarefoundation/autoware.universe/issues/7849>`_)
   * add utils and diagnostics subscription to planning_evaluator
   * add diagnostics eval
   * fix input diag in launch
   ---------
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* refactor(control_evaluator): use class naming standard and use remapped param name (`#7782 <https://github.com/youtalk/autoware.universe/issues/7782>`_)
+* refactor(control_evaluator): use class naming standard and use remapped param name (`#7782 <https://github.com/autowarefoundation/autoware.universe/issues/7782>`_)
   use class naming standard and use remapped param name
-* feat(control_evaluator): add lanelet info to the metrics (`#7765 <https://github.com/youtalk/autoware.universe/issues/7765>`_)
+* feat(control_evaluator): add lanelet info to the metrics (`#7765 <https://github.com/autowarefoundation/autoware.universe/issues/7765>`_)
   * add route handler
   * add lanelet info to diagnostic
   * add const
@@ -61,12 +61,12 @@ Changelog for package autoware_control_evaluator
   * add shoulder lanelets
   * fix includes
   ---------
-* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/youtalk/autoware.universe/issues/7594>`_)
-* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/youtalk/autoware.universe/issues/7539>`_)
+* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/autowarefoundation/autoware.universe/issues/7594>`_)
+* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/autowarefoundation/autoware.universe/issues/7539>`_)
   refactor(motion_utils): add autoware prefix and include dir
-* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/youtalk/autoware.universe/issues/7538>`_)
+* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/autowarefoundation/autoware.universe/issues/7538>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* feat(control_evaluator): rename to include/autoware/{package_name} (`#7520 <https://github.com/youtalk/autoware.universe/issues/7520>`_)
+* feat(control_evaluator): rename to include/autoware/{package_name} (`#7520 <https://github.com/autowarefoundation/autoware.universe/issues/7520>`_)
   * feat(control_evaluator): rename to include/autoware/{package_name}
   * fix
   ---------

--- a/evaluator/autoware_planning_evaluator/CHANGELOG.rst
+++ b/evaluator/autoware_planning_evaluator/CHANGELOG.rst
@@ -5,8 +5,8 @@ Changelog for package autoware_planning_evaluator
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* refactor(autoware_planning_evaluator): devops node dojo (`#8746 <https://github.com/youtalk/autoware.universe/issues/8746>`_)
-* feat(motion_velocity_planner,planning_evaluator): add  stop, slow_down diags (`#8503 <https://github.com/youtalk/autoware.universe/issues/8503>`_)
+* refactor(autoware_planning_evaluator): devops node dojo (`#8746 <https://github.com/autowarefoundation/autoware.universe/issues/8746>`_)
+* feat(motion_velocity_planner,planning_evaluator): add  stop, slow_down diags (`#8503 <https://github.com/autowarefoundation/autoware.universe/issues/8503>`_)
   * tmp save.
   * publish diagnostics.
   * move clearDiagnostics func to head
@@ -23,15 +23,15 @@ Changelog for package autoware_planning_evaluator
   Co-authored-by: Kosuke Takeuchi <kosuke.tnp@gmail.com>
   ---------
   Co-authored-by: Kosuke Takeuchi <kosuke.tnp@gmail.com>
-* fix(autoware_planning_evaluator): fix unreadVariable (`#8352 <https://github.com/youtalk/autoware.universe/issues/8352>`_)
+* fix(autoware_planning_evaluator): fix unreadVariable (`#8352 <https://github.com/autowarefoundation/autoware.universe/issues/8352>`_)
   * fix:unreadVariable
   * fix:unreadVariable
   ---------
-* feat(evalautor): rename evaluator diag topics (`#8152 <https://github.com/youtalk/autoware.universe/issues/8152>`_)
+* feat(evalautor): rename evaluator diag topics (`#8152 <https://github.com/autowarefoundation/autoware.universe/issues/8152>`_)
   * feat(evalautor): rename evaluator diag topics
   * perception
   ---------
-* refactor(autoware_universe_utils): changed the API to be more intuitive and added documentation (`#7443 <https://github.com/youtalk/autoware.universe/issues/7443>`_)
+* refactor(autoware_universe_utils): changed the API to be more intuitive and added documentation (`#7443 <https://github.com/autowarefoundation/autoware.universe/issues/7443>`_)
   * refactor(tier4_autoware_utils): Changed the API to be more intuitive and added documentation.
   * use raw shared ptr in PollingPolicy::NEWEST
   * update
@@ -40,32 +40,32 @@ Changelog for package autoware_planning_evaluator
   Co-authored-by: danielsanchezaran <daniel.sanchez@tier4.jp>
   ---------
   Co-authored-by: danielsanchezaran <daniel.sanchez@tier4.jp>
-* feat(cruise_planner,planning_evaluator): add cruise and slow down diags (`#7960 <https://github.com/youtalk/autoware.universe/issues/7960>`_)
+* feat(cruise_planner,planning_evaluator): add cruise and slow down diags (`#7960 <https://github.com/autowarefoundation/autoware.universe/issues/7960>`_)
   * add cruise and slow down diags to cruise planner
   * add cruise types
   * adjust planning eval
   ---------
-* feat(planning_evaluator,control_evaluator, evaluator utils): add diagnostics subscriber to planning eval (`#7849 <https://github.com/youtalk/autoware.universe/issues/7849>`_)
+* feat(planning_evaluator,control_evaluator, evaluator utils): add diagnostics subscriber to planning eval (`#7849 <https://github.com/autowarefoundation/autoware.universe/issues/7849>`_)
   * add utils and diagnostics subscription to planning_evaluator
   * add diagnostics eval
   * fix input diag in launch
   ---------
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* feat(planning_evaluator): add planning evaluator polling sub (`#7827 <https://github.com/youtalk/autoware.universe/issues/7827>`_)
+* feat(planning_evaluator): add planning evaluator polling sub (`#7827 <https://github.com/autowarefoundation/autoware.universe/issues/7827>`_)
   * WIP add polling subs
   * WIP
   * update functions
   * remove semicolon
   * use last data for modified goal
   ---------
-* feat(planning_evaluator): add lanelet info to the planning evaluator (`#7781 <https://github.com/youtalk/autoware.universe/issues/7781>`_)
+* feat(planning_evaluator): add lanelet info to the planning evaluator (`#7781 <https://github.com/autowarefoundation/autoware.universe/issues/7781>`_)
   add lanelet info to the planning evaluator
-* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/youtalk/autoware.universe/issues/7594>`_)
-* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/youtalk/autoware.universe/issues/7539>`_)
+* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/autowarefoundation/autoware.universe/issues/7594>`_)
+* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/autowarefoundation/autoware.universe/issues/7539>`_)
   refactor(motion_utils): add autoware prefix and include dir
-* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/youtalk/autoware.universe/issues/7538>`_)
+* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/autowarefoundation/autoware.universe/issues/7538>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* feat(planning_evaluator): rename to include/autoware/{package_name} (`#7518 <https://github.com/youtalk/autoware.universe/issues/7518>`_)
+* feat(planning_evaluator): rename to include/autoware/{package_name} (`#7518 <https://github.com/autowarefoundation/autoware.universe/issues/7518>`_)
   * fix
   * fix
   ---------

--- a/evaluator/kinematic_evaluator/CHANGELOG.rst
+++ b/evaluator/kinematic_evaluator/CHANGELOG.rst
@@ -5,12 +5,12 @@ Changelog for package kinematic_evaluator
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* refactor(kinematic_evaluator): rework parameters (`#8199 <https://github.com/youtalk/autoware.universe/issues/8199>`_)
-* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/youtalk/autoware.universe/issues/7538>`_)
+* refactor(kinematic_evaluator): rework parameters (`#8199 <https://github.com/autowarefoundation/autoware.universe/issues/8199>`_)
+* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/autowarefoundation/autoware.universe/issues/7538>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* ci(pre-commit): autoupdate (`#7499 <https://github.com/youtalk/autoware.universe/issues/7499>`_)
+* ci(pre-commit): autoupdate (`#7499 <https://github.com/autowarefoundation/autoware.universe/issues/7499>`_)
   Co-authored-by: M. Fatih Cırıt <mfc@leodrive.ai>
-* feat!: replace autoware_auto_msgs with autoware_msgs for evaluator modules (`#7241 <https://github.com/youtalk/autoware.universe/issues/7241>`_)
+* feat!: replace autoware_auto_msgs with autoware_msgs for evaluator modules (`#7241 <https://github.com/autowarefoundation/autoware.universe/issues/7241>`_)
   Co-authored-by: Cynthia Liu <cynthia.liu@autocore.ai>
   Co-authored-by: NorahXiong <norah.xiong@autocore.ai>
   Co-authored-by: beginningfan <beginning.fan@autocore.ai>
@@ -18,20 +18,20 @@ Changelog for package kinematic_evaluator
 
 0.26.0 (2024-04-03)
 -------------------
-* chore(build): remove tier4_autoware_utils.hpp evaluator/ simulator/ (`#4839 <https://github.com/youtalk/autoware.universe/issues/4839>`_)
-* chore: add maintainer (`#4234 <https://github.com/youtalk/autoware.universe/issues/4234>`_)
+* chore(build): remove tier4_autoware_utils.hpp evaluator/ simulator/ (`#4839 <https://github.com/autowarefoundation/autoware.universe/issues/4839>`_)
+* chore: add maintainer (`#4234 <https://github.com/autowarefoundation/autoware.universe/issues/4234>`_)
   * chore: add maintainer
   * Update evaluator/localization_evaluator/package.xml
   Co-authored-by: kminoda <44218668+kminoda@users.noreply.github.com>
   ---------
   Co-authored-by: kminoda <44218668+kminoda@users.noreply.github.com>
-* style: fix typos (`#3617 <https://github.com/youtalk/autoware.universe/issues/3617>`_)
+* style: fix typos (`#3617 <https://github.com/autowarefoundation/autoware.universe/issues/3617>`_)
   * style: fix typos in documents
   * style: fix typos in package.xml
   * style: fix typos in launch files
   * style: fix typos in comments
   ---------
-* build: mark autoware_cmake as <buildtool_depend> (`#3616 <https://github.com/youtalk/autoware.universe/issues/3616>`_)
+* build: mark autoware_cmake as <buildtool_depend> (`#3616 <https://github.com/autowarefoundation/autoware.universe/issues/3616>`_)
   * build: mark autoware_cmake as <buildtool_depend>
   with <build_depend>, autoware_cmake is automatically exported with ament_target_dependencies() (unecessary)
   * style(pre-commit): autofix
@@ -39,7 +39,7 @@ Changelog for package kinematic_evaluator
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Kenji Miyake <kenji.miyake@tier4.jp>
-* feat(metrics_calculation): add kinematic and localization evaluators with metrics (`#928 <https://github.com/youtalk/autoware.universe/issues/928>`_)
+* feat(metrics_calculation): add kinematic and localization evaluators with metrics (`#928 <https://github.com/autowarefoundation/autoware.universe/issues/928>`_)
   * initial skeleton of localization evaluator
   * Add simple localization evaliuation framework
   * Clean and add tests

--- a/evaluator/localization_evaluator/CHANGELOG.rst
+++ b/evaluator/localization_evaluator/CHANGELOG.rst
@@ -5,7 +5,7 @@ Changelog for package localization_evaluator
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* refactor(evaluator/localization_evaluator): rework parameters  (`#6744 <https://github.com/youtalk/autoware.universe/issues/6744>`_)
+* refactor(evaluator/localization_evaluator): rework parameters  (`#6744 <https://github.com/autowarefoundation/autoware.universe/issues/6744>`_)
   * add param file and schema
   * style(pre-commit): autofix
   * .
@@ -13,11 +13,11 @@ Changelog for package localization_evaluator
   * .
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/youtalk/autoware.universe/issues/7538>`_)
+* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/autowarefoundation/autoware.universe/issues/7538>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* ci(pre-commit): autoupdate (`#7499 <https://github.com/youtalk/autoware.universe/issues/7499>`_)
+* ci(pre-commit): autoupdate (`#7499 <https://github.com/autowarefoundation/autoware.universe/issues/7499>`_)
   Co-authored-by: M. Fatih Cırıt <mfc@leodrive.ai>
-* feat!: replace autoware_auto_msgs with autoware_msgs for evaluator modules (`#7241 <https://github.com/youtalk/autoware.universe/issues/7241>`_)
+* feat!: replace autoware_auto_msgs with autoware_msgs for evaluator modules (`#7241 <https://github.com/autowarefoundation/autoware.universe/issues/7241>`_)
   Co-authored-by: Cynthia Liu <cynthia.liu@autocore.ai>
   Co-authored-by: NorahXiong <norah.xiong@autocore.ai>
   Co-authored-by: beginningfan <beginning.fan@autocore.ai>
@@ -25,20 +25,20 @@ Changelog for package localization_evaluator
 
 0.26.0 (2024-04-03)
 -------------------
-* chore(build): remove tier4_autoware_utils.hpp evaluator/ simulator/ (`#4839 <https://github.com/youtalk/autoware.universe/issues/4839>`_)
-* chore: add maintainer (`#4234 <https://github.com/youtalk/autoware.universe/issues/4234>`_)
+* chore(build): remove tier4_autoware_utils.hpp evaluator/ simulator/ (`#4839 <https://github.com/autowarefoundation/autoware.universe/issues/4839>`_)
+* chore: add maintainer (`#4234 <https://github.com/autowarefoundation/autoware.universe/issues/4234>`_)
   * chore: add maintainer
   * Update evaluator/localization_evaluator/package.xml
   Co-authored-by: kminoda <44218668+kminoda@users.noreply.github.com>
   ---------
   Co-authored-by: kminoda <44218668+kminoda@users.noreply.github.com>
-* style: fix typos (`#3617 <https://github.com/youtalk/autoware.universe/issues/3617>`_)
+* style: fix typos (`#3617 <https://github.com/autowarefoundation/autoware.universe/issues/3617>`_)
   * style: fix typos in documents
   * style: fix typos in package.xml
   * style: fix typos in launch files
   * style: fix typos in comments
   ---------
-* build: mark autoware_cmake as <buildtool_depend> (`#3616 <https://github.com/youtalk/autoware.universe/issues/3616>`_)
+* build: mark autoware_cmake as <buildtool_depend> (`#3616 <https://github.com/autowarefoundation/autoware.universe/issues/3616>`_)
   * build: mark autoware_cmake as <buildtool_depend>
   with <build_depend>, autoware_cmake is automatically exported with ament_target_dependencies() (unecessary)
   * style(pre-commit): autofix
@@ -46,7 +46,7 @@ Changelog for package localization_evaluator
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Kenji Miyake <kenji.miyake@tier4.jp>
-* feat(metrics_calculation): add kinematic and localization evaluators with metrics (`#928 <https://github.com/youtalk/autoware.universe/issues/928>`_)
+* feat(metrics_calculation): add kinematic and localization evaluators with metrics (`#928 <https://github.com/autowarefoundation/autoware.universe/issues/928>`_)
   * initial skeleton of localization evaluator
   * Add simple localization evaliuation framework
   * Clean and add tests

--- a/evaluator/perception_online_evaluator/CHANGELOG.rst
+++ b/evaluator/perception_online_evaluator/CHANGELOG.rst
@@ -5,27 +5,27 @@ Changelog for package perception_online_evaluator
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* refactor(object_recognition_utils): add autoware prefix to object_recognition_utils (`#8946 <https://github.com/youtalk/autoware.universe/issues/8946>`_)
-* fix(perception_online_evaluator): fix unusedFunction (`#8559 <https://github.com/youtalk/autoware.universe/issues/8559>`_)
+* refactor(object_recognition_utils): add autoware prefix to object_recognition_utils (`#8946 <https://github.com/autowarefoundation/autoware.universe/issues/8946>`_)
+* fix(perception_online_evaluator): fix unusedFunction (`#8559 <https://github.com/autowarefoundation/autoware.universe/issues/8559>`_)
   fix:unusedFunction
-* feat(evalautor): rename evaluator diag topics (`#8152 <https://github.com/youtalk/autoware.universe/issues/8152>`_)
+* feat(evalautor): rename evaluator diag topics (`#8152 <https://github.com/autowarefoundation/autoware.universe/issues/8152>`_)
   * feat(evalautor): rename evaluator diag topics
   * perception
   ---------
-* fix(perception_online_evaluator): passedByValue (`#8201 <https://github.com/youtalk/autoware.universe/issues/8201>`_)
+* fix(perception_online_evaluator): passedByValue (`#8201 <https://github.com/autowarefoundation/autoware.universe/issues/8201>`_)
   fix: passedByValue
-* fix(perception_online_evaluator): fix shadowVariable (`#7933 <https://github.com/youtalk/autoware.universe/issues/7933>`_)
+* fix(perception_online_evaluator): fix shadowVariable (`#7933 <https://github.com/autowarefoundation/autoware.universe/issues/7933>`_)
   * fix:shadowVariable
   * fix:clang-format
   * fix:shadowVariable
   ---------
-* feat: add `autoware\_` prefix to `lanelet2_extension` (`#7640 <https://github.com/youtalk/autoware.universe/issues/7640>`_)
-* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/youtalk/autoware.universe/issues/7594>`_)
-* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/youtalk/autoware.universe/issues/7539>`_)
+* feat: add `autoware\_` prefix to `lanelet2_extension` (`#7640 <https://github.com/autowarefoundation/autoware.universe/issues/7640>`_)
+* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/autowarefoundation/autoware.universe/issues/7594>`_)
+* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/autowarefoundation/autoware.universe/issues/7539>`_)
   refactor(motion_utils): add autoware prefix and include dir
-* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/youtalk/autoware.universe/issues/7538>`_)
+* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/autowarefoundation/autoware.universe/issues/7538>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* refactor(vehicle_info_utils)!: prefix package and namespace with autoware (`#7353 <https://github.com/youtalk/autoware.universe/issues/7353>`_)
+* refactor(vehicle_info_utils)!: prefix package and namespace with autoware (`#7353 <https://github.com/autowarefoundation/autoware.universe/issues/7353>`_)
   * chore(autoware_vehicle_info_utils): rename header
   * chore(bpp-common): vehicle info
   * chore(path_optimizer): vehicle info
@@ -60,7 +60,7 @@ Changelog for package perception_online_evaluator
   * chore(sensing): vehicle info
   * fix(autoware_joy_controller): remove unused deps
   ---------
-* fix(perception_online_evaluator):  add metric_value not only stat (`#7100 <https://github.com/youtalk/autoware.universe/issues/7100>`_)(`#7118 <https://github.com/youtalk/autoware.universe/issues/7118>`_) (revert of revert) (`#7167 <https://github.com/youtalk/autoware.universe/issues/7167>`_)
+* fix(perception_online_evaluator):  add metric_value not only stat (`#7100 <https://github.com/autowarefoundation/autoware.universe/issues/7100>`_)(`#7118 <https://github.com/autowarefoundation/autoware.universe/issues/7118>`_) (revert of revert) (`#7167 <https://github.com/autowarefoundation/autoware.universe/issues/7167>`_)
   * Revert "fix(perception_online_evaluator): revert "add metric_value not only s…"
   This reverts commit d827b1bd1f4bbacf0333eb14a62ef42e56caef25.
   * Update evaluator/perception_online_evaluator/include/perception_online_evaluator/perception_online_evaluator_node.hpp
@@ -68,20 +68,20 @@ Changelog for package perception_online_evaluator
   * use emplace back
   ---------
   Co-authored-by: Kotaro Uetake <60615504+ktro2828@users.noreply.github.com>
-* feat!: replace autoware_auto_msgs with autoware_msgs for evaluator modules (`#7241 <https://github.com/youtalk/autoware.universe/issues/7241>`_)
+* feat!: replace autoware_auto_msgs with autoware_msgs for evaluator modules (`#7241 <https://github.com/autowarefoundation/autoware.universe/issues/7241>`_)
   Co-authored-by: Cynthia Liu <cynthia.liu@autocore.ai>
   Co-authored-by: NorahXiong <norah.xiong@autocore.ai>
   Co-authored-by: beginningfan <beginning.fan@autocore.ai>
-* fix(perception_online_evaluator): revert "add metric_value not only stat (`#7100 <https://github.com/youtalk/autoware.universe/issues/7100>`_)" (`#7118 <https://github.com/youtalk/autoware.universe/issues/7118>`_)
-* feat(perception_online_evaluator): add metric_value not only stat (`#7100 <https://github.com/youtalk/autoware.universe/issues/7100>`_)
-* fix(perception_online_evaluator): fix range resolution (`#7115 <https://github.com/youtalk/autoware.universe/issues/7115>`_)
-* chore(glog): add initialization check (`#6792 <https://github.com/youtalk/autoware.universe/issues/6792>`_)
-* fix(perception_online_evaluator): fix bug of constStatement (`#6922 <https://github.com/youtalk/autoware.universe/issues/6922>`_)
-* feat(perception_online_evaluator): imporve yaw rate metrics considering flip (`#6881 <https://github.com/youtalk/autoware.universe/issues/6881>`_)
+* fix(perception_online_evaluator): revert "add metric_value not only stat (`#7100 <https://github.com/autowarefoundation/autoware.universe/issues/7100>`_)" (`#7118 <https://github.com/autowarefoundation/autoware.universe/issues/7118>`_)
+* feat(perception_online_evaluator): add metric_value not only stat (`#7100 <https://github.com/autowarefoundation/autoware.universe/issues/7100>`_)
+* fix(perception_online_evaluator): fix range resolution (`#7115 <https://github.com/autowarefoundation/autoware.universe/issues/7115>`_)
+* chore(glog): add initialization check (`#6792 <https://github.com/autowarefoundation/autoware.universe/issues/6792>`_)
+* fix(perception_online_evaluator): fix bug of constStatement (`#6922 <https://github.com/autowarefoundation/autoware.universe/issues/6922>`_)
+* feat(perception_online_evaluator): imporve yaw rate metrics considering flip (`#6881 <https://github.com/autowarefoundation/autoware.universe/issues/6881>`_)
   * feat(perception_online_evaluator): imporve yaw rate metrics considering flip
   * fix test
   ---------
-* feat(perception_evaluator): counts objects within detection range  (`#6848 <https://github.com/youtalk/autoware.universe/issues/6848>`_)
+* feat(perception_evaluator): counts objects within detection range  (`#6848 <https://github.com/autowarefoundation/autoware.universe/issues/6848>`_)
   * feat(perception_evaluator): counts objects within detection range
   detection counter
   add enable option and refactoring
@@ -94,36 +94,36 @@ Changelog for package perception_online_evaluator
   fix
   * fix include
   ---------
-* docs(perception_online_evaluator): update metrics explanation (`#6819 <https://github.com/youtalk/autoware.universe/issues/6819>`_)
-* feat(perception_online_evaluator): better waitForDummyNode (`#6827 <https://github.com/youtalk/autoware.universe/issues/6827>`_)
-* feat(perception_online_evaluator): add predicted path variance (`#6793 <https://github.com/youtalk/autoware.universe/issues/6793>`_)
+* docs(perception_online_evaluator): update metrics explanation (`#6819 <https://github.com/autowarefoundation/autoware.universe/issues/6819>`_)
+* feat(perception_online_evaluator): better waitForDummyNode (`#6827 <https://github.com/autowarefoundation/autoware.universe/issues/6827>`_)
+* feat(perception_online_evaluator): add predicted path variance (`#6793 <https://github.com/autowarefoundation/autoware.universe/issues/6793>`_)
   * feat(perception_online_evaluator): add predicted path variance
   * add unit test
   * update readme
   * pre commit
   ---------
-* feat(perception_online_evaluator): ignore reversal of orientation from yaw_rate calculation (`#6748 <https://github.com/youtalk/autoware.universe/issues/6748>`_)
-* docs(perception_online_evaluator): add description about yaw rate evaluation (`#6737 <https://github.com/youtalk/autoware.universe/issues/6737>`_)
+* feat(perception_online_evaluator): ignore reversal of orientation from yaw_rate calculation (`#6748 <https://github.com/autowarefoundation/autoware.universe/issues/6748>`_)
+* docs(perception_online_evaluator): add description about yaw rate evaluation (`#6737 <https://github.com/autowarefoundation/autoware.universe/issues/6737>`_)
 * Contributors: Esteve Fernandez, Fumiya Watanabe, Kosuke Takeuchi, Kyoichi Sugahara, Nagi70, Ryohsuke Mitsudome, Ryuta Kambe, Satoshi OTA, Takamasa Horibe, Takayuki Murooka, Yutaka Kondo, kobayu858
 
 0.26.0 (2024-04-03)
 -------------------
-* feat(perception_online_evaluator): extract moving object for deviation check (`#6682 <https://github.com/youtalk/autoware.universe/issues/6682>`_)
+* feat(perception_online_evaluator): extract moving object for deviation check (`#6682 <https://github.com/autowarefoundation/autoware.universe/issues/6682>`_)
   fix test
-* feat(perception_online_evaluator): unify debug markers instead of separating for each object (`#6681 <https://github.com/youtalk/autoware.universe/issues/6681>`_)
+* feat(perception_online_evaluator): unify debug markers instead of separating for each object (`#6681 <https://github.com/autowarefoundation/autoware.universe/issues/6681>`_)
   * feat(perception_online_evaluator): unify debug markers instead of separating for each object
   * fix for
   ---------
-* feat(perception_online_evaluator): add yaw rate metrics for stopped object (`#6667 <https://github.com/youtalk/autoware.universe/issues/6667>`_)
+* feat(perception_online_evaluator): add yaw rate metrics for stopped object (`#6667 <https://github.com/autowarefoundation/autoware.universe/issues/6667>`_)
   * feat(perception_online_evaluator): add yaw rate metrics for stopped object
   add
   add test
   * feat: add stopped vel parameter
   ---------
-* fix(perception_online_evaluator): fix build error (`#6595 <https://github.com/youtalk/autoware.universe/issues/6595>`_)
-* build(perception_online_evaluator): add lanelet_extension dependency (`#6592 <https://github.com/youtalk/autoware.universe/issues/6592>`_)
-* feat(perception_online_evaluator): publish metrics of each object class (`#6556 <https://github.com/youtalk/autoware.universe/issues/6556>`_)
-* feat(perception_online_evaluator): add perception_online_evaluator (`#6493 <https://github.com/youtalk/autoware.universe/issues/6493>`_)
+* fix(perception_online_evaluator): fix build error (`#6595 <https://github.com/autowarefoundation/autoware.universe/issues/6595>`_)
+* build(perception_online_evaluator): add lanelet_extension dependency (`#6592 <https://github.com/autowarefoundation/autoware.universe/issues/6592>`_)
+* feat(perception_online_evaluator): publish metrics of each object class (`#6556 <https://github.com/autowarefoundation/autoware.universe/issues/6556>`_)
+* feat(perception_online_evaluator): add perception_online_evaluator (`#6493 <https://github.com/autowarefoundation/autoware.universe/issues/6493>`_)
   * feat(perception_evaluator): add perception_evaluator
   tmp
   update

--- a/evaluator/scenario_simulator_v2_adapter/CHANGELOG.rst
+++ b/evaluator/scenario_simulator_v2_adapter/CHANGELOG.rst
@@ -9,12 +9,12 @@ Changelog for package diagnostic_converter
 
 0.26.0 (2024-04-03)
 -------------------
-* fix(diagnostic_converter): move headers to a separate directory (`#5943 <https://github.com/youtalk/autoware.universe/issues/5943>`_)
+* fix(diagnostic_converter): move headers to a separate directory (`#5943 <https://github.com/autowarefoundation/autoware.universe/issues/5943>`_)
   * fix(diagnostic_converter): move headers to a separate directory
   * style(pre-commit): autofix
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* build: mark autoware_cmake as <buildtool_depend> (`#3616 <https://github.com/youtalk/autoware.universe/issues/3616>`_)
+* build: mark autoware_cmake as <buildtool_depend> (`#3616 <https://github.com/autowarefoundation/autoware.universe/issues/3616>`_)
   * build: mark autoware_cmake as <buildtool_depend>
   with <build_depend>, autoware_cmake is automatically exported with ament_target_dependencies() (unecessary)
   * style(pre-commit): autofix
@@ -22,12 +22,12 @@ Changelog for package diagnostic_converter
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Kenji Miyake <kenji.miyake@tier4.jp>
-* feat(diagnostic_converter): remove unit and blank in the value (`#3151 <https://github.com/youtalk/autoware.universe/issues/3151>`_)
+* feat(diagnostic_converter): remove unit and blank in the value (`#3151 <https://github.com/autowarefoundation/autoware.universe/issues/3151>`_)
   * feat(diagnostic_converter): remove unit and blank in the value
   * fix
   ---------
-* feat(diagnostic_converter): apply regex for topic name (`#3149 <https://github.com/youtalk/autoware.universe/issues/3149>`_)
-* feat(diagnostic_converter): add converter to use planning_evaluator's output for scenario's condition (`#2514 <https://github.com/youtalk/autoware.universe/issues/2514>`_)
+* feat(diagnostic_converter): apply regex for topic name (`#3149 <https://github.com/autowarefoundation/autoware.universe/issues/3149>`_)
+* feat(diagnostic_converter): add converter to use planning_evaluator's output for scenario's condition (`#2514 <https://github.com/autowarefoundation/autoware.universe/issues/2514>`_)
   * add original diagnostic_convertor
   * add test
   * fix typo

--- a/launch/tier4_autoware_api_launch/CHANGELOG.rst
+++ b/launch/tier4_autoware_api_launch/CHANGELOG.rst
@@ -5,25 +5,25 @@ Changelog for package tier4_autoware_api_launch
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* chore(autoware_default_adapi)!: prefix autoware to package name (`#8533 <https://github.com/youtalk/autoware.universe/issues/8533>`_)
-* refactor(autoware_path_distance_calculator): prefix package and namespace with autoware (`#8085 <https://github.com/youtalk/autoware.universe/issues/8085>`_)
+* chore(autoware_default_adapi)!: prefix autoware to package name (`#8533 <https://github.com/autowarefoundation/autoware.universe/issues/8533>`_)
+* refactor(autoware_path_distance_calculator): prefix package and namespace with autoware (`#8085 <https://github.com/autowarefoundation/autoware.universe/issues/8085>`_)
 * Contributors: Esteve Fernandez, Takagi, Isamu, Yutaka Kondo
 
 0.26.0 (2024-04-03)
 -------------------
-* chore: update api package maintainers (`#6086 <https://github.com/youtalk/autoware.universe/issues/6086>`_)
+* chore: update api package maintainers (`#6086 <https://github.com/autowarefoundation/autoware.universe/issues/6086>`_)
   * update api maintainers
   * fix
   ---------
-* chore: update maintainer (`#4140 <https://github.com/youtalk/autoware.universe/issues/4140>`_)
+* chore: update maintainer (`#4140 <https://github.com/autowarefoundation/autoware.universe/issues/4140>`_)
   Co-authored-by: Ryohsuke Mitsudome <43976834+mitsudome-r@users.noreply.github.com>
-* style: fix typos (`#3617 <https://github.com/youtalk/autoware.universe/issues/3617>`_)
+* style: fix typos (`#3617 <https://github.com/autowarefoundation/autoware.universe/issues/3617>`_)
   * style: fix typos in documents
   * style: fix typos in package.xml
   * style: fix typos in launch files
   * style: fix typos in comments
   ---------
-* build: mark autoware_cmake as <buildtool_depend> (`#3616 <https://github.com/youtalk/autoware.universe/issues/3616>`_)
+* build: mark autoware_cmake as <buildtool_depend> (`#3616 <https://github.com/autowarefoundation/autoware.universe/issues/3616>`_)
   * build: mark autoware_cmake as <buildtool_depend>
   with <build_depend>, autoware_cmake is automatically exported with ament_target_dependencies() (unecessary)
   * style(pre-commit): autofix
@@ -31,13 +31,13 @@ Changelog for package tier4_autoware_api_launch
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Kenji Miyake <kenji.miyake@tier4.jp>
-* feat(tier4_autoware_api_launch): suppress rtc_controller's info (`#3020 <https://github.com/youtalk/autoware.universe/issues/3020>`_)
+* feat(tier4_autoware_api_launch): suppress rtc_controller's info (`#3020 <https://github.com/autowarefoundation/autoware.universe/issues/3020>`_)
   * feat(tier4_autoware_api_launch): suppress rtc_controller's info
   * Update launch/tier4_autoware_api_launch/launch/autoware_api.launch.xml
   Co-authored-by: Takagi, Isamu <43976882+isamu-takagi@users.noreply.github.com>
   ---------
   Co-authored-by: Takagi, Isamu <43976882+isamu-takagi@users.noreply.github.com>
-* feat: replace tier4_ad_api_adaptor with default_ad_api (`#2438 <https://github.com/youtalk/autoware.universe/issues/2438>`_)
+* feat: replace tier4_ad_api_adaptor with default_ad_api (`#2438 <https://github.com/autowarefoundation/autoware.universe/issues/2438>`_)
   * feat: add options
   * fix: rosbridge max message size
   * feat: remove old apis
@@ -45,16 +45,16 @@ Changelog for package tier4_autoware_api_launch
   * feat: remove external engage
   * feat: add deprecated api option
   * fix: path
-* fix(tier4_autoware_api_launch): add rosbridge_server dependency (`#2470 <https://github.com/youtalk/autoware.universe/issues/2470>`_)
-* chore: add api maintainers (`#2361 <https://github.com/youtalk/autoware.universe/issues/2361>`_)
-* feat: remove launch for old routing api (`#2136 <https://github.com/youtalk/autoware.universe/issues/2136>`_)
-* feat(autoware_api_launch): delete image base64 converter launch (`#2131 <https://github.com/youtalk/autoware.universe/issues/2131>`_)
+* fix(tier4_autoware_api_launch): add rosbridge_server dependency (`#2470 <https://github.com/autowarefoundation/autoware.universe/issues/2470>`_)
+* chore: add api maintainers (`#2361 <https://github.com/autowarefoundation/autoware.universe/issues/2361>`_)
+* feat: remove launch for old routing api (`#2136 <https://github.com/autowarefoundation/autoware.universe/issues/2136>`_)
+* feat(autoware_api_launch): delete image base64 converter launch (`#2131 <https://github.com/autowarefoundation/autoware.universe/issues/2131>`_)
   delete image base64 converter launch
-* feat(tier4_autoware_api_launch): add rtc_controller to api launch (`#1919 <https://github.com/youtalk/autoware.universe/issues/1919>`_)
-* fix: add adapi dependency (`#1892 <https://github.com/youtalk/autoware.universe/issues/1892>`_)
-* feat: move adapi rviz adaptor  (`#1900 <https://github.com/youtalk/autoware.universe/issues/1900>`_)
+* feat(tier4_autoware_api_launch): add rtc_controller to api launch (`#1919 <https://github.com/autowarefoundation/autoware.universe/issues/1919>`_)
+* fix: add adapi dependency (`#1892 <https://github.com/autowarefoundation/autoware.universe/issues/1892>`_)
+* feat: move adapi rviz adaptor  (`#1900 <https://github.com/autowarefoundation/autoware.universe/issues/1900>`_)
   feat: move adapi rviz adaptor
-* feat(default_ad_api): add localization api  (`#1431 <https://github.com/youtalk/autoware.universe/issues/1431>`_)
+* feat(default_ad_api): add localization api  (`#1431 <https://github.com/autowarefoundation/autoware.universe/issues/1431>`_)
   * feat(default_ad_api): add localization api
   * docs: add readme
   * feat: add auto initial pose
@@ -74,7 +74,7 @@ Changelog for package tier4_autoware_api_launch
   * fix: remove needless keyword
   * feat: change api helper node namespace
   * fix: fix launch file path
-* chore(planning/control packages): organized authors and maintainers (`#1610 <https://github.com/youtalk/autoware.universe/issues/1610>`_)
+* chore(planning/control packages): organized authors and maintainers (`#1610 <https://github.com/autowarefoundation/autoware.universe/issues/1610>`_)
   * organized planning authors and maintainers
   * organized control authors and maintainers
   * fix typo
@@ -107,7 +107,7 @@ Changelog for package tier4_autoware_api_launch
   * fix
   Co-authored-by: Kenji Miyake <31987104+kenji-miyake@users.noreply.github.com>
   Co-authored-by: Kenji Miyake <kenji.miyake@tier4.jp>
-* feat(default_ad_api): add routing api (`#1494 <https://github.com/youtalk/autoware.universe/issues/1494>`_)
+* feat(default_ad_api): add routing api (`#1494 <https://github.com/autowarefoundation/autoware.universe/issues/1494>`_)
   * feat(default_ad_api): add routing api
   * fix: build error
   * docs: add readme
@@ -127,17 +127,17 @@ Changelog for package tier4_autoware_api_launch
   * feat: adaptor package
   * fix: helper node
   * fix: error handling
-* feat(tier4_autoware_api_launch): add some arguments (`#1324 <https://github.com/youtalk/autoware.universe/issues/1324>`_)
+* feat(tier4_autoware_api_launch): add some arguments (`#1324 <https://github.com/autowarefoundation/autoware.universe/issues/1324>`_)
   * feat(tier4_autoware_api_launch): add some arguments
   * fix launch py
   * deal with review
   * deal with review
   * deal with review
-* fix(tier4_autoware_api_launch): add group tag (`#1235 <https://github.com/youtalk/autoware.universe/issues/1235>`_)
-* fix(tier4_autoware_api_launch): typo (`#1047 <https://github.com/youtalk/autoware.universe/issues/1047>`_)
+* fix(tier4_autoware_api_launch): add group tag (`#1235 <https://github.com/autowarefoundation/autoware.universe/issues/1235>`_)
+* fix(tier4_autoware_api_launch): typo (`#1047 <https://github.com/autowarefoundation/autoware.universe/issues/1047>`_)
   I will write release note, thank you.
-* feat(tier4_autoware_api_launch): add rosbridge (`#779 <https://github.com/youtalk/autoware.universe/issues/779>`_)
-  * fix(image_projection_based_fusion): modify build error in rolling (`#775 <https://github.com/youtalk/autoware.universe/issues/775>`_)
+* feat(tier4_autoware_api_launch): add rosbridge (`#779 <https://github.com/autowarefoundation/autoware.universe/issues/779>`_)
+  * fix(image_projection_based_fusion): modify build error in rolling (`#775 <https://github.com/autowarefoundation/autoware.universe/issues/775>`_)
   * feat(tier4_autoware_api_launch): add rosbridge
   docs(web_controller): rosbridge is automatically launched in tier4_autoware_api_launch
   * docs(web_controller): rosbridge is automatically launched in tier4_autoware_api_launch
@@ -145,18 +145,18 @@ Changelog for package tier4_autoware_api_launch
   Co-authored-by: Kenji Miyake <31987104+kenji-miyake@users.noreply.github.com>
   Co-authored-by: Daisuke Nishimatsu <42202095+wep21@users.noreply.github.com>
   Co-authored-by: Kenji Miyake <31987104+kenji-miyake@users.noreply.github.com>
-* chore: replace topic tools (`#986 <https://github.com/youtalk/autoware.universe/issues/986>`_)
+* chore: replace topic tools (`#986 <https://github.com/autowarefoundation/autoware.universe/issues/986>`_)
   * chore: replace topic tools
   * ci(pre-commit): autofix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* chore: upgrade cmake_minimum_required to 3.14 (`#856 <https://github.com/youtalk/autoware.universe/issues/856>`_)
-* refactor: use autoware cmake (`#849 <https://github.com/youtalk/autoware.universe/issues/849>`_)
+* chore: upgrade cmake_minimum_required to 3.14 (`#856 <https://github.com/autowarefoundation/autoware.universe/issues/856>`_)
+* refactor: use autoware cmake (`#849 <https://github.com/autowarefoundation/autoware.universe/issues/849>`_)
   * remove autoware_auto_cmake
   * add build_depend of autoware_cmake
   * use autoware_cmake in CMakeLists.txt
   * fix bugs
   * fix cmake lint errors
-* feat(tier4_autoware_api_launch): add tier4_autoware_api_launch package (`#658 <https://github.com/youtalk/autoware.universe/issues/658>`_)
+* feat(tier4_autoware_api_launch): add tier4_autoware_api_launch package (`#658 <https://github.com/autowarefoundation/autoware.universe/issues/658>`_)
   * feat(tier4_autoware_api_launch): add tier4_autoware_api_launch package
   * ci(pre-commit): autofix
   * fix(tier4_autoware_api_launch): fix the command in the README instructions

--- a/launch/tier4_control_launch/CHANGELOG.rst
+++ b/launch/tier4_control_launch/CHANGELOG.rst
@@ -5,10 +5,10 @@ Changelog for package tier4_control_launch
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* refactor(obstacle_collision_checker): move to autoware namespace (`#9047 <https://github.com/youtalk/autoware.universe/issues/9047>`_)
-* fix(tier4_control_launch): fix aeb input predicted object topic name (`#8874 <https://github.com/youtalk/autoware.universe/issues/8874>`_)
+* refactor(obstacle_collision_checker): move to autoware namespace (`#9047 <https://github.com/autowarefoundation/autoware.universe/issues/9047>`_)
+* fix(tier4_control_launch): fix aeb input predicted object topic name (`#8874 <https://github.com/autowarefoundation/autoware.universe/issues/8874>`_)
   fix aeb input predicted object topic
-* feat(autonomous_emergency_braking): add some tests to aeb (`#8126 <https://github.com/youtalk/autoware.universe/issues/8126>`_)
+* feat(autonomous_emergency_braking): add some tests to aeb (`#8126 <https://github.com/autowarefoundation/autoware.universe/issues/8126>`_)
   * add initial tests
   * add more tests
   * more tests
@@ -23,13 +23,13 @@ Changelog for package tier4_control_launch
   * add briefs
   * delete repeated test
   ---------
-* feat(evalautor): rename evaluator diag topics (`#8152 <https://github.com/youtalk/autoware.universe/issues/8152>`_)
+* feat(evalautor): rename evaluator diag topics (`#8152 <https://github.com/autowarefoundation/autoware.universe/issues/8152>`_)
   * feat(evalautor): rename evaluator diag topics
   * perception
   ---------
-* fix(control_launch): fix control launch control_evaluator plugin name (`#7846 <https://github.com/youtalk/autoware.universe/issues/7846>`_)
+* fix(control_launch): fix control launch control_evaluator plugin name (`#7846 <https://github.com/autowarefoundation/autoware.universe/issues/7846>`_)
   fix control evaluator plugin name
-* refactor(tier4_control_launch): replace python launch with xml (`#7682 <https://github.com/youtalk/autoware.universe/issues/7682>`_)
+* refactor(tier4_control_launch): replace python launch with xml (`#7682 <https://github.com/autowarefoundation/autoware.universe/issues/7682>`_)
   * refactor: add xml version of control launch
   * refactor: remove python version of control launch
   * set default value of trajectory_follower_mode
@@ -43,9 +43,9 @@ Changelog for package tier4_control_launch
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Kosuke Takeuchi <kosuke.tnp@gmail.com>
   Co-authored-by: Kotaro Yoshimoto <pythagora.yoshimoto@gmail.com>
-* refactor(control_evaluator): use class naming standard and use remapped param name (`#7782 <https://github.com/youtalk/autoware.universe/issues/7782>`_)
+* refactor(control_evaluator): use class naming standard and use remapped param name (`#7782 <https://github.com/autowarefoundation/autoware.universe/issues/7782>`_)
   use class naming standard and use remapped param name
-* feat(control_evaluator): add lanelet info to the metrics (`#7765 <https://github.com/youtalk/autoware.universe/issues/7765>`_)
+* feat(control_evaluator): add lanelet info to the metrics (`#7765 <https://github.com/autowarefoundation/autoware.universe/issues/7765>`_)
   * add route handler
   * add lanelet info to diagnostic
   * add const
@@ -56,8 +56,8 @@ Changelog for package tier4_control_launch
   * add shoulder lanelets
   * fix includes
   ---------
-* fix(smart_mpc_trajectory_folower): fix running by adding control_state and changing msg/package_name (`#7666 <https://github.com/youtalk/autoware.universe/issues/7666>`_)
-* feat(autonomous_emergency_braking): add predicted object support for aeb (`#7548 <https://github.com/youtalk/autoware.universe/issues/7548>`_)
+* fix(smart_mpc_trajectory_folower): fix running by adding control_state and changing msg/package_name (`#7666 <https://github.com/autowarefoundation/autoware.universe/issues/7666>`_)
+* feat(autonomous_emergency_braking): add predicted object support for aeb (`#7548 <https://github.com/autowarefoundation/autoware.universe/issues/7548>`_)
   * add polling sub to predicted objects
   * WIP requires changing path frame to map
   * add parameters and reuse predicted obj speed
@@ -72,31 +72,31 @@ Changelog for package tier4_control_launch
   * add utils.cpp
   * remove _ for non member variable
   ---------
-* feat(control_evaluator): rename to include/autoware/{package_name} (`#7520 <https://github.com/youtalk/autoware.universe/issues/7520>`_)
+* feat(control_evaluator): rename to include/autoware/{package_name} (`#7520 <https://github.com/autowarefoundation/autoware.universe/issues/7520>`_)
   * feat(control_evaluator): rename to include/autoware/{package_name}
   * fix
   ---------
-* feat(diagnostic_converter): fix output metrics topic name and add to converter (`#7495 <https://github.com/youtalk/autoware.universe/issues/7495>`_)
-* feat(control_evaluator): add deviation metrics and queue for diagnostics (`#7484 <https://github.com/youtalk/autoware.universe/issues/7484>`_)
-* refactor(operation_mode_transition_manager): prefix package and namespace with autoware\_ (`#7291 <https://github.com/youtalk/autoware.universe/issues/7291>`_)
+* feat(diagnostic_converter): fix output metrics topic name and add to converter (`#7495 <https://github.com/autowarefoundation/autoware.universe/issues/7495>`_)
+* feat(control_evaluator): add deviation metrics and queue for diagnostics (`#7484 <https://github.com/autowarefoundation/autoware.universe/issues/7484>`_)
+* refactor(operation_mode_transition_manager): prefix package and namespace with autoware\_ (`#7291 <https://github.com/autowarefoundation/autoware.universe/issues/7291>`_)
   * RT1-6682 add prefix package and namespace with autoware\_
   * RT1-6682 fix package's description
   ---------
-* refactor(trajectory_follower_node): trajectory follower node add autoware prefix (`#7344 <https://github.com/youtalk/autoware.universe/issues/7344>`_)
+* refactor(trajectory_follower_node): trajectory follower node add autoware prefix (`#7344 <https://github.com/autowarefoundation/autoware.universe/issues/7344>`_)
   * rename trajectory follower node package
   * update dependencies, launch files, and README files
   * fix formats
   * remove autoware\_ prefix from launch arg option
   ---------
-* refactor(shift_decider): prefix package and namespace with autoware\_ (`#7310 <https://github.com/youtalk/autoware.universe/issues/7310>`_)
+* refactor(shift_decider): prefix package and namespace with autoware\_ (`#7310 <https://github.com/autowarefoundation/autoware.universe/issues/7310>`_)
   * RT1-6684 add autoware prefix and namespace
   * RT1-6684 Revert svg
   This reverts commit 4e0569e4796ab432c734905fb7f2106779575e29.
   ---------
   Co-authored-by: Takayuki Murooka <takayuki5168@gmail.com>
-* fix(tier4_control_launch, crosswalk_traffic_light_estimator): fix a mistake when adding prefixes (`#7423 <https://github.com/youtalk/autoware.universe/issues/7423>`_)
+* fix(tier4_control_launch, crosswalk_traffic_light_estimator): fix a mistake when adding prefixes (`#7423 <https://github.com/autowarefoundation/autoware.universe/issues/7423>`_)
   Fixed a mistake when adding prefixes
-* refactor(external cmd converter)!: add autoware\_ prefix (`#7361 <https://github.com/youtalk/autoware.universe/issues/7361>`_)
+* refactor(external cmd converter)!: add autoware\_ prefix (`#7361 <https://github.com/autowarefoundation/autoware.universe/issues/7361>`_)
   * add prefix to the code
   * rename
   * fix
@@ -105,7 +105,7 @@ Changelog for package tier4_control_launch
   * Update .github/CODEOWNERS
   ---------
   Co-authored-by: Takayuki Murooka <takayuki5168@gmail.com>
-* refactor(control_validator)!: prefix package and namespace with autoware (`#7304 <https://github.com/youtalk/autoware.universe/issues/7304>`_)
+* refactor(control_validator)!: prefix package and namespace with autoware (`#7304 <https://github.com/autowarefoundation/autoware.universe/issues/7304>`_)
   * rename folders
   * rename add prefix
   * change param path
@@ -115,15 +115,15 @@ Changelog for package tier4_control_launch
   * add namespace to address conflict
   * delete stubborn file
   ---------
-* refactor(external_cmd_selector): prefix package and namespace with au… (`#7384 <https://github.com/youtalk/autoware.universe/issues/7384>`_)
+* refactor(external_cmd_selector): prefix package and namespace with au… (`#7384 <https://github.com/autowarefoundation/autoware.universe/issues/7384>`_)
   refactor(external_cmd_selector): prefix package and namespace with autoware\_
-* chore(vehicle_cmd_gate): add prefix autoware\_ to vehicle_cmd_gate (`#7327 <https://github.com/youtalk/autoware.universe/issues/7327>`_)
+* chore(vehicle_cmd_gate): add prefix autoware\_ to vehicle_cmd_gate (`#7327 <https://github.com/autowarefoundation/autoware.universe/issues/7327>`_)
   * add prefix autoware\_ to vehicle_cmd_gate package
   * fix
   * fix include guard
   * fix pre-commit
   ---------
-* feat(autonomous_emergency_braking): prefix package and namespace with autoware\_ (`#7294 <https://github.com/youtalk/autoware.universe/issues/7294>`_)
+* feat(autonomous_emergency_braking): prefix package and namespace with autoware\_ (`#7294 <https://github.com/autowarefoundation/autoware.universe/issues/7294>`_)
   * change package name
   * add the prefix
   * change option
@@ -131,14 +131,14 @@ Changelog for package tier4_control_launch
   * eliminate some prefixes that are not required
   * fix node name
   ---------
-* chore(smart_mpc_trajectory_follower): add prefix autoware\_ to smart_mpc_trajectory_follower (`#7367 <https://github.com/youtalk/autoware.universe/issues/7367>`_)
+* chore(smart_mpc_trajectory_follower): add prefix autoware\_ to smart_mpc_trajectory_follower (`#7367 <https://github.com/autowarefoundation/autoware.universe/issues/7367>`_)
   * add prefix
   * fix pre-commit
   ---------
-* refactor(lane_departure_checker)!: prefix package and namespace with autoware (`#7325 <https://github.com/youtalk/autoware.universe/issues/7325>`_)
+* refactor(lane_departure_checker)!: prefix package and namespace with autoware (`#7325 <https://github.com/autowarefoundation/autoware.universe/issues/7325>`_)
   * add prefix autoware\_ to lane_departure_checker package
   ---------
-* feat(smart_mpc_trajectory_follower): add smart_mpc_trajectory_follower (`#6805 <https://github.com/youtalk/autoware.universe/issues/6805>`_)
+* feat(smart_mpc_trajectory_follower): add smart_mpc_trajectory_follower (`#6805 <https://github.com/autowarefoundation/autoware.universe/issues/6805>`_)
   * feat(smart_mpc_trajectory_follower): add smart_mpc_trajectory_follower
   * style(pre-commit): autofix
   * modified control.launch.py
@@ -160,7 +160,7 @@ Changelog for package tier4_control_launch
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Takamasa Horibe <horibe.takamasa@gmail.com>
   Co-authored-by: Kosuke Takeuchi <kosuke.tnp@gmail.com>
-* feat(control_evaluator): implement a control evaluator (`#6959 <https://github.com/youtalk/autoware.universe/issues/6959>`_)
+* feat(control_evaluator): implement a control evaluator (`#6959 <https://github.com/autowarefoundation/autoware.universe/issues/6959>`_)
   * add control evaluator module
   * make the evaluator depend on messages from AEB
   * update output msg
@@ -169,9 +169,9 @@ Changelog for package tier4_control_launch
   * add a package mantainer
   * Add a timer to maintain a constant rate of msg publishing
   ---------
-* revert: "feat(logger_level_configure): make it possible to change level of container logger (`#6823 <https://github.com/youtalk/autoware.universe/issues/6823>`_)" (`#6842 <https://github.com/youtalk/autoware.universe/issues/6842>`_)
+* revert: "feat(logger_level_configure): make it possible to change level of container logger (`#6823 <https://github.com/autowarefoundation/autoware.universe/issues/6823>`_)" (`#6842 <https://github.com/autowarefoundation/autoware.universe/issues/6842>`_)
   This reverts commit 51b5f830780eb69bd1a7dfe60e295773f394fd8e.
-* feat(logger_level_configure): make it possible to change level of container logger (`#6823 <https://github.com/youtalk/autoware.universe/issues/6823>`_)
+* feat(logger_level_configure): make it possible to change level of container logger (`#6823 <https://github.com/autowarefoundation/autoware.universe/issues/6823>`_)
   * feat(launch): add logging_demo::LoggerConfig into container
   * fix(logger_level_reconfigure_plugin): fix yaml
   * feat(logging_level_configure): add composable node
@@ -180,20 +180,20 @@ Changelog for package tier4_control_launch
 
 0.26.0 (2024-04-03)
 -------------------
-* feat: enable multithreading for the control container (`#6666 <https://github.com/youtalk/autoware.universe/issues/6666>`_)
-* feat(pid_longitudinal_controller): add maker for stop reason (`#6579 <https://github.com/youtalk/autoware.universe/issues/6579>`_)
+* feat: enable multithreading for the control container (`#6666 <https://github.com/autowarefoundation/autoware.universe/issues/6666>`_)
+* feat(pid_longitudinal_controller): add maker for stop reason (`#6579 <https://github.com/autowarefoundation/autoware.universe/issues/6579>`_)
   * feat(pid_longitudinal_controller): add maker for stop reason
   * minor fix
   ---------
-* chore(tier4_control_launch): fix control validator name duplication (`#6446 <https://github.com/youtalk/autoware.universe/issues/6446>`_)
-* feat(tier4_control_launch): run control_validator out of main control container (`#6435 <https://github.com/youtalk/autoware.universe/issues/6435>`_)
-* feat(tier4_control_launch): add launch argument for predicted path checker (`#5186 <https://github.com/youtalk/autoware.universe/issues/5186>`_)
-* feat(predicted_path_checker): check predicted trajectory to avoid collisions planning can not handle (`#2528 <https://github.com/youtalk/autoware.universe/issues/2528>`_)
-  * feat(predicted_path_checker): check predicted trajectory to avoid collisions planning can not handle (`#2528 <https://github.com/youtalk/autoware.universe/issues/2528>`_)
+* chore(tier4_control_launch): fix control validator name duplication (`#6446 <https://github.com/autowarefoundation/autoware.universe/issues/6446>`_)
+* feat(tier4_control_launch): run control_validator out of main control container (`#6435 <https://github.com/autowarefoundation/autoware.universe/issues/6435>`_)
+* feat(tier4_control_launch): add launch argument for predicted path checker (`#5186 <https://github.com/autowarefoundation/autoware.universe/issues/5186>`_)
+* feat(predicted_path_checker): check predicted trajectory to avoid collisions planning can not handle (`#2528 <https://github.com/autowarefoundation/autoware.universe/issues/2528>`_)
+  * feat(predicted_path_checker): check predicted trajectory to avoid collisions planning can not handle (`#2528 <https://github.com/autowarefoundation/autoware.universe/issues/2528>`_)
   * Added pkg to control.launch.py
   ---------
-* fix(operation_mode_transition_manager): check trajectory_follower_cmd for engage condition (`#5038 <https://github.com/youtalk/autoware.universe/issues/5038>`_)
-* feat(glog): add glog in planning and control modules (`#4714 <https://github.com/youtalk/autoware.universe/issues/4714>`_)
+* fix(operation_mode_transition_manager): check trajectory_follower_cmd for engage condition (`#5038 <https://github.com/autowarefoundation/autoware.universe/issues/5038>`_)
+* feat(glog): add glog in planning and control modules (`#4714 <https://github.com/autowarefoundation/autoware.universe/issues/4714>`_)
   * feat(glog): add glog component
   * formatting
   * remove namespace
@@ -209,7 +209,7 @@ Changelog for package tier4_control_launch
   * add copyright
   ---------
   Co-authored-by: Daisuke Nishimatsu <42202095+wep21@users.noreply.github.com>
-* feat(control_validator): measure predicted path deviation from trajectory (`#4549 <https://github.com/youtalk/autoware.universe/issues/4549>`_)
+* feat(control_validator): measure predicted path deviation from trajectory (`#4549 <https://github.com/autowarefoundation/autoware.universe/issues/4549>`_)
   * add feature for getting predicted path deviation from trajectory
   * fix for build success
   * fix topic name
@@ -230,7 +230,7 @@ Changelog for package tier4_control_launch
   * change maintainer
   * refactor
   * style(pre-commit): autofix
-  * feat(dynamic_avoidance): object polygon based drivable area generation (`#4598 <https://github.com/youtalk/autoware.universe/issues/4598>`_)
+  * feat(dynamic_avoidance): object polygon based drivable area generation (`#4598 <https://github.com/autowarefoundation/autoware.universe/issues/4598>`_)
   * update
   * update README
   * fix typo
@@ -243,16 +243,16 @@ Changelog for package tier4_control_launch
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Takayuki Murooka <takayuki5168@gmail.com>
   Co-authored-by: Takamasa Horibe <horibe.takamasa@gmail.com>
-* feat(shift_decider): send current gear if the autoware state is not driving (`#3684 <https://github.com/youtalk/autoware.universe/issues/3684>`_)
-* feat(vehicle_cmd_gate):  do not send current gear if autoware is not engaged (`#3683 <https://github.com/youtalk/autoware.universe/issues/3683>`_)
+* feat(shift_decider): send current gear if the autoware state is not driving (`#3684 <https://github.com/autowarefoundation/autoware.universe/issues/3684>`_)
+* feat(vehicle_cmd_gate):  do not send current gear if autoware is not engaged (`#3683 <https://github.com/autowarefoundation/autoware.universe/issues/3683>`_)
   This reverts commit be3138545d6814a684a314a7dbf1ffb450f90970.
-* style: fix typos (`#3617 <https://github.com/youtalk/autoware.universe/issues/3617>`_)
+* style: fix typos (`#3617 <https://github.com/autowarefoundation/autoware.universe/issues/3617>`_)
   * style: fix typos in documents
   * style: fix typos in package.xml
   * style: fix typos in launch files
   * style: fix typos in comments
   ---------
-* build: mark autoware_cmake as <buildtool_depend> (`#3616 <https://github.com/youtalk/autoware.universe/issues/3616>`_)
+* build: mark autoware_cmake as <buildtool_depend> (`#3616 <https://github.com/autowarefoundation/autoware.universe/issues/3616>`_)
   * build: mark autoware_cmake as <buildtool_depend>
   with <build_depend>, autoware_cmake is automatically exported with ament_target_dependencies() (unecessary)
   * style(pre-commit): autofix
@@ -260,31 +260,31 @@ Changelog for package tier4_control_launch
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Kenji Miyake <kenji.miyake@tier4.jp>
-* fix(control_launch): add necessary parameter (`#3235 <https://github.com/youtalk/autoware.universe/issues/3235>`_)
-* feat(tier4_control_launch): add check_external_emergency_heartbeat option (`#3079 <https://github.com/youtalk/autoware.universe/issues/3079>`_)
-* feat(control): add autonomous emergency braking module (`#2793 <https://github.com/youtalk/autoware.universe/issues/2793>`_)
-* feat(vehicle_cmd_gate): enable filter with actual steer in manual mode (`#2717 <https://github.com/youtalk/autoware.universe/issues/2717>`_)
+* fix(control_launch): add necessary parameter (`#3235 <https://github.com/autowarefoundation/autoware.universe/issues/3235>`_)
+* feat(tier4_control_launch): add check_external_emergency_heartbeat option (`#3079 <https://github.com/autowarefoundation/autoware.universe/issues/3079>`_)
+* feat(control): add autonomous emergency braking module (`#2793 <https://github.com/autowarefoundation/autoware.universe/issues/2793>`_)
+* feat(vehicle_cmd_gate): enable filter with actual steer in manual mode (`#2717 <https://github.com/autowarefoundation/autoware.universe/issues/2717>`_)
   * feature(vehicle_cmd_gate): enable filter with actual steer in manual mode
   * update parameters based on experiment
   * update launch
   * update param
   ---------
-* feat(longitudinal_controller): skip integral in manual mode (`#2619 <https://github.com/youtalk/autoware.universe/issues/2619>`_)
+* feat(longitudinal_controller): skip integral in manual mode (`#2619 <https://github.com/autowarefoundation/autoware.universe/issues/2619>`_)
   * feat(longitudinal_controller): skip integral in manual mode
   * change control_mode to operation_mode
   * fix test
-* chore(control_launch): add maintainer (`#2758 <https://github.com/youtalk/autoware.universe/issues/2758>`_)
-* feat(vehicle_cmd_gate): send current gear if autoware is not engaged (`#2555 <https://github.com/youtalk/autoware.universe/issues/2555>`_)
+* chore(control_launch): add maintainer (`#2758 <https://github.com/autowarefoundation/autoware.universe/issues/2758>`_)
+* feat(vehicle_cmd_gate): send current gear if autoware is not engaged (`#2555 <https://github.com/autowarefoundation/autoware.universe/issues/2555>`_)
   * feat(vehicle_cmd_gate): send current gear if autoware is not engaged
   * ci(pre-commit): autofix
   * add topic map to launch file
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* refactor(tier4_control_launch): remove parameter definition in control.launch.py (`#2585 <https://github.com/youtalk/autoware.universe/issues/2585>`_)
+* refactor(tier4_control_launch): remove parameter definition in control.launch.py (`#2585 <https://github.com/autowarefoundation/autoware.universe/issues/2585>`_)
   * refactor trajectory_follower_node's param
   * organize parameter definition in control_launch
   * fix typo
   * fix failed test
-* feat(trajectory_follower): seperate lat lon controller packages (`#2580 <https://github.com/youtalk/autoware.universe/issues/2580>`_)
+* feat(trajectory_follower): seperate lat lon controller packages (`#2580 <https://github.com/autowarefoundation/autoware.universe/issues/2580>`_)
   * feat(trajectory_follower): seperate controller implementation packages
   * update doc
   * fix doc
@@ -293,14 +293,14 @@ Changelog for package tier4_control_launch
   * rename to trajectory_follower_base, trajectory_follower_node
   * fix doc
   * remove unnecessary change
-* feat(tier4_control_launch): remove configs and move to autoware_launch  (`#2544 <https://github.com/youtalk/autoware.universe/issues/2544>`_)
+* feat(tier4_control_launch): remove configs and move to autoware_launch  (`#2544 <https://github.com/autowarefoundation/autoware.universe/issues/2544>`_)
   * feat(tier4_control_launch): remove configs and move to autoware_launch
   * remove config
   * Update launch/tier4_control_launch/README.md
   Co-authored-by: kminoda <44218668+kminoda@users.noreply.github.com>
   Co-authored-by: kminoda <koji.minoda@tier4.jp>
-* fix(tier4_control_launch): add parameter about nearest search (`#2542 <https://github.com/youtalk/autoware.universe/issues/2542>`_)
-* feat(trajectory_follower): extend mpc trajectory for terminal yaw (`#2447 <https://github.com/youtalk/autoware.universe/issues/2447>`_)
+* fix(tier4_control_launch): add parameter about nearest search (`#2542 <https://github.com/autowarefoundation/autoware.universe/issues/2542>`_)
+* feat(trajectory_follower): extend mpc trajectory for terminal yaw (`#2447 <https://github.com/autowarefoundation/autoware.universe/issues/2447>`_)
   * feat(trajectory_follower): extend mpc trajectory for terminal yaw
   * make mpc min vel param
   * add mpc extended point after smoothing
@@ -314,18 +314,18 @@ Changelog for package tier4_control_launch
   * fix from TakaHoribe review
   * fix typo
   * refactor
-* refactor(vehicle_cmd_gate): remove old emergency topics (`#2403 <https://github.com/youtalk/autoware.universe/issues/2403>`_)
-* fix: rename `use_external_emergency_stop` to  `check_external_emergency_heartbeat` (`#2455 <https://github.com/youtalk/autoware.universe/issues/2455>`_)
+* refactor(vehicle_cmd_gate): remove old emergency topics (`#2403 <https://github.com/autowarefoundation/autoware.universe/issues/2403>`_)
+* fix: rename `use_external_emergency_stop` to  `check_external_emergency_heartbeat` (`#2455 <https://github.com/autowarefoundation/autoware.universe/issues/2455>`_)
   * fix: rename use_external_emergency_stop to check_external_emergency_heartbeat
   * ci(pre-commit): autofix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat(transition_manager): add param to ignore autonomous transition condition (`#2453 <https://github.com/youtalk/autoware.universe/issues/2453>`_)
+* feat(transition_manager): add param to ignore autonomous transition condition (`#2453 <https://github.com/autowarefoundation/autoware.universe/issues/2453>`_)
   * feat(transition_manager): add param to ignore autonomous transition condition
   * same for modeChangeCompleted
   * remove debug print
-* feat(operation_mode_transition_manager): modify transition timeout (`#2318 <https://github.com/youtalk/autoware.universe/issues/2318>`_)
+* feat(operation_mode_transition_manager): modify transition timeout (`#2318 <https://github.com/autowarefoundation/autoware.universe/issues/2318>`_)
   feat(operation_mode_transition_manager): modify mode change in transition
-* feat(emergency_handler): add a selector for multiple MRM behaviors (`#2070 <https://github.com/youtalk/autoware.universe/issues/2070>`_)
+* feat(emergency_handler): add a selector for multiple MRM behaviors (`#2070 <https://github.com/autowarefoundation/autoware.universe/issues/2070>`_)
   * feat(emergency_handler): add mrm command and status publishers
   * feat(autoware_ad_api_msgs): define mrm operation srv and mrm status msg
   * feat(emergency_handler): add mrm clients and subscribers
@@ -387,7 +387,7 @@ Changelog for package tier4_control_launch
   * fix(emergency_handler): fix acronyms case
   * chore(tier4_system_launch): add a mrm comfortable stop parameter
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat(operation_mode_transition_manager): support ad api (`#1535 <https://github.com/youtalk/autoware.universe/issues/1535>`_)
+* feat(operation_mode_transition_manager): support ad api (`#1535 <https://github.com/autowarefoundation/autoware.universe/issues/1535>`_)
   * feat(operation_mode_transition_manager): support ad api
   * fix: merge operation mode state message
   * feat(autoware_ad_api_msgs): define operation mode interface
@@ -406,18 +406,18 @@ Changelog for package tier4_control_launch
   * fix: fix operation mode change when disable autoware control
   * fix: fix operation mode change when autoware control is disabled
   Co-authored-by: Kenji Miyake <31987104+kenji-miyake@users.noreply.github.com>
-* feat(tier4_control_launch): add obstacle_collision_checker in control.launch.py (`#2193 <https://github.com/youtalk/autoware.universe/issues/2193>`_)
+* feat(tier4_control_launch): add obstacle_collision_checker in control.launch.py (`#2193 <https://github.com/autowarefoundation/autoware.universe/issues/2193>`_)
   Co-authored-by: Berkay Karaman <berkay@leodrive.ai>
-* feat(tier4_planning/control_launch): add missing dependency (`#2201 <https://github.com/youtalk/autoware.universe/issues/2201>`_)
-* ci(pre-commit): format SVG files (`#2172 <https://github.com/youtalk/autoware.universe/issues/2172>`_)
+* feat(tier4_planning/control_launch): add missing dependency (`#2201 <https://github.com/autowarefoundation/autoware.universe/issues/2201>`_)
+* ci(pre-commit): format SVG files (`#2172 <https://github.com/autowarefoundation/autoware.universe/issues/2172>`_)
   * ci(pre-commit): format SVG files
   * ci(pre-commit): autofix
   * apply pre-commit
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat(control_launch): add longitudinal controller mode (`#2062 <https://github.com/youtalk/autoware.universe/issues/2062>`_)
+* feat(control_launch): add longitudinal controller mode (`#2062 <https://github.com/autowarefoundation/autoware.universe/issues/2062>`_)
   feature(control_launch): add longitudinal controller mode
-* fix: modified to reflect the argument "initial_selector_mode" in control_launch (`#1961 <https://github.com/youtalk/autoware.universe/issues/1961>`_)
-* refactor: replace acc calculation in planning control modules (`#1213 <https://github.com/youtalk/autoware.universe/issues/1213>`_)
+* fix: modified to reflect the argument "initial_selector_mode" in control_launch (`#1961 <https://github.com/autowarefoundation/autoware.universe/issues/1961>`_)
+* refactor: replace acc calculation in planning control modules (`#1213 <https://github.com/autowarefoundation/autoware.universe/issues/1213>`_)
   * [obstacle_cruise_planner] replace acceleration calculation
   * [obstacle_stop_planner] replace acceleration calculation
   * [trajectory_follower] replace acceleration calculation
@@ -425,12 +425,12 @@ Changelog for package tier4_control_launch
   * fix nullptr check
   * fix controller test
   * fix
-* feat(shift_decider): add config file (`#1857 <https://github.com/youtalk/autoware.universe/issues/1857>`_)
+* feat(shift_decider): add config file (`#1857 <https://github.com/autowarefoundation/autoware.universe/issues/1857>`_)
   * feat(shift_decider): add config file
   * feat(tier4_control_launch): add shift_decider.param.yaml
   * ci(pre-commit): autofix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat(shift_decider): put the gear in park when vehicle reaches the goal (`#1818 <https://github.com/youtalk/autoware.universe/issues/1818>`_)
+* feat(shift_decider): put the gear in park when vehicle reaches the goal (`#1818 <https://github.com/autowarefoundation/autoware.universe/issues/1818>`_)
   * feat(shift_decider): put the gear in park when vehicle reaches the goal
   * ci(pre-commit): autofix
   * feat(shift_decider): check /autoware/state subscriber in timer function
@@ -440,8 +440,8 @@ Changelog for package tier4_control_launch
   * feat(shift_decider): add park_on_goal flag
   * feat(tier4_control_launch): add park_on_goal param for shift_decider
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat(motion_velocity_smoother): add steering rate limit while planning velocity (`#1071 <https://github.com/youtalk/autoware.universe/issues/1071>`_)
-  * feat(motion_velocity_smoother): add steering rate limit while planning velocity (`#1071 <https://github.com/youtalk/autoware.universe/issues/1071>`_)
+* feat(motion_velocity_smoother): add steering rate limit while planning velocity (`#1071 <https://github.com/autowarefoundation/autoware.universe/issues/1071>`_)
+  * feat(motion_velocity_smoother): add steering rate limit while planning velocity (`#1071 <https://github.com/autowarefoundation/autoware.universe/issues/1071>`_)
   function added,
   not turning
   fix the always positive curvature problem
@@ -485,7 +485,7 @@ Changelog for package tier4_control_launch
   * ci(pre-commit): autofix
   Co-authored-by: Berkay <berkay@leodrive.ai>
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* chore(planning/control packages): organized authors and maintainers (`#1610 <https://github.com/youtalk/autoware.universe/issues/1610>`_)
+* chore(planning/control packages): organized authors and maintainers (`#1610 <https://github.com/autowarefoundation/autoware.universe/issues/1610>`_)
   * organized planning authors and maintainers
   * organized control authors and maintainers
   * fix typo
@@ -518,9 +518,9 @@ Changelog for package tier4_control_launch
   * fix
   Co-authored-by: Kenji Miyake <31987104+kenji-miyake@users.noreply.github.com>
   Co-authored-by: Kenji Miyake <kenji.miyake@tier4.jp>
-* chore(trajectory_follower_nodes): remove the remaining latlon_muxer (`#1592 <https://github.com/youtalk/autoware.universe/issues/1592>`_)
-* feat(trajectory_follower): keep stop until the steering control is done (`#1672 <https://github.com/youtalk/autoware.universe/issues/1672>`_)
-* fix(velocity_controller, mpc_follower): use common ego nearest search (`#1590 <https://github.com/youtalk/autoware.universe/issues/1590>`_)
+* chore(trajectory_follower_nodes): remove the remaining latlon_muxer (`#1592 <https://github.com/autowarefoundation/autoware.universe/issues/1592>`_)
+* feat(trajectory_follower): keep stop until the steering control is done (`#1672 <https://github.com/autowarefoundation/autoware.universe/issues/1672>`_)
+* fix(velocity_controller, mpc_follower): use common ego nearest search (`#1590 <https://github.com/autowarefoundation/autoware.universe/issues/1590>`_)
   * fix(trajectory_follower): use common ego nearest search
   * removed calcNearestIndex
   * add nearest search param
@@ -528,14 +528,14 @@ Changelog for package tier4_control_launch
   * fix
   * Update launch/tier4_control_launch/launch/control.launch.py
   * update test fil
-* fix(tier4_control_launch): pass vehicle_info_param to trajectory_follower (`#1450 <https://github.com/youtalk/autoware.universe/issues/1450>`_)
-* refactor(trajectory_follower_nodes): use max_steer_angle in common (`#1422 <https://github.com/youtalk/autoware.universe/issues/1422>`_)
+* fix(tier4_control_launch): pass vehicle_info_param to trajectory_follower (`#1450 <https://github.com/autowarefoundation/autoware.universe/issues/1450>`_)
+* refactor(trajectory_follower_nodes): use max_steer_angle in common (`#1422 <https://github.com/autowarefoundation/autoware.universe/issues/1422>`_)
   * refactor(trajectory_follower_nodes): use max_steer_angle in common
   * remove parameters from tier4_control_launch
   * fix
-* feat(tier4_control_launch): declare param path argument (`#1432 <https://github.com/youtalk/autoware.universe/issues/1432>`_)
-* fix(operation_mode_transition_manager): add required param (`#1342 <https://github.com/youtalk/autoware.universe/issues/1342>`_)
-* feat(operation_mode_transition_manager): add package to manage vehicle autonomous mode change (`#1246 <https://github.com/youtalk/autoware.universe/issues/1246>`_)
+* feat(tier4_control_launch): declare param path argument (`#1432 <https://github.com/autowarefoundation/autoware.universe/issues/1432>`_)
+* fix(operation_mode_transition_manager): add required param (`#1342 <https://github.com/autowarefoundation/autoware.universe/issues/1342>`_)
+* feat(operation_mode_transition_manager): add package to manage vehicle autonomous mode change (`#1246 <https://github.com/autowarefoundation/autoware.universe/issues/1246>`_)
   * add engage_transition_manager
   * rename to operation mode transition manager
   * fix precommit
@@ -546,55 +546,55 @@ Changelog for package tier4_control_launch
   * add allow_autonomous_in_stopped
   * fix typo
   * fix precommit
-* feat(trajectory_follower): add min_prediction_length to mpc (`#1171 <https://github.com/youtalk/autoware.universe/issues/1171>`_)
+* feat(trajectory_follower): add min_prediction_length to mpc (`#1171 <https://github.com/autowarefoundation/autoware.universe/issues/1171>`_)
   * feat(trajectory_follower): Add min_prediction_length to mpc
   * refactor
-* feat(vehicle cmd gate): add transition filter (`#1244 <https://github.com/youtalk/autoware.universe/issues/1244>`_)
+* feat(vehicle cmd gate): add transition filter (`#1244 <https://github.com/autowarefoundation/autoware.universe/issues/1244>`_)
   * feat(vehicle_cmd_gate): add transition filter
   * fix precommit
   * remove debug code
   * update param yaml
   * update readme
   * fix default topic name
-* feat(trajectory_follower): integrate latlon controller (`#901 <https://github.com/youtalk/autoware.universe/issues/901>`_)
+* feat(trajectory_follower): integrate latlon controller (`#901 <https://github.com/autowarefoundation/autoware.universe/issues/901>`_)
   * feat(trajectory_follower): integrate latlon controller
   * Remove unnecessary throw error
   * update from review comment
   * Set steer converged params false
   * Update params of design.md
   Co-authored-by: Takamasa Horibe <horibe.takamasa@gmail.com>
-* feat(longitudinal_controller): add disable emergency option (`#1201 <https://github.com/youtalk/autoware.universe/issues/1201>`_)
+* feat(longitudinal_controller): add disable emergency option (`#1201 <https://github.com/autowarefoundation/autoware.universe/issues/1201>`_)
   * feat(longitudinal_controller): add disable emergency option
   * update readme
   * add param
-* refactor(vehicle_cmd_gate): change namespace in launch file (`#927 <https://github.com/youtalk/autoware.universe/issues/927>`_)
+* refactor(vehicle_cmd_gate): change namespace in launch file (`#927 <https://github.com/autowarefoundation/autoware.universe/issues/927>`_)
   Co-authored-by: Berkay <berkay@leodrive.ai>
-* chore: upgrade cmake_minimum_required to 3.14 (`#856 <https://github.com/youtalk/autoware.universe/issues/856>`_)
-* refactor: use autoware cmake (`#849 <https://github.com/youtalk/autoware.universe/issues/849>`_)
+* chore: upgrade cmake_minimum_required to 3.14 (`#856 <https://github.com/autowarefoundation/autoware.universe/issues/856>`_)
+* refactor: use autoware cmake (`#849 <https://github.com/autowarefoundation/autoware.universe/issues/849>`_)
   * remove autoware_auto_cmake
   * add build_depend of autoware_cmake
   * use autoware_cmake in CMakeLists.txt
   * fix bugs
   * fix cmake lint errors
-* style: fix format of package.xml (`#844 <https://github.com/youtalk/autoware.universe/issues/844>`_)
-* perf(trajectory_follower_nodes): change longitudinal control to use period parameter (`#763 <https://github.com/youtalk/autoware.universe/issues/763>`_)
+* style: fix format of package.xml (`#844 <https://github.com/autowarefoundation/autoware.universe/issues/844>`_)
+* perf(trajectory_follower_nodes): change longitudinal control to use period parameter (`#763 <https://github.com/autowarefoundation/autoware.universe/issues/763>`_)
   * perf(trajectory_follower_nodes): change longitudinal control to use period parameter
   * perf(trajectory_follower_nodes): remove duplicate ros parameters in 'control.launch.py'
   * doc(trajectory_follower_nodes): update design doc according to code update
   * ci(pre-commit): autofix
   Co-authored-by: Shark Liu <shark.liu@autocore.ai>
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* fix: add pure_pursuit as lateral controller into launch files (`#750 <https://github.com/youtalk/autoware.universe/issues/750>`_)
-* fix(longitudinal_controller_node, vehicle_cmd_gate): update stopped condition and behavior (`#700 <https://github.com/youtalk/autoware.universe/issues/700>`_)
+* fix: add pure_pursuit as lateral controller into launch files (`#750 <https://github.com/autowarefoundation/autoware.universe/issues/750>`_)
+* fix(longitudinal_controller_node, vehicle_cmd_gate): update stopped condition and behavior (`#700 <https://github.com/autowarefoundation/autoware.universe/issues/700>`_)
   * fix(longitudinal_controller_node): parameterize stopped state entry condition
   * fix(longitudinal_controller_node): simply set stopped velocity in STOPPED STATE
   * fix(vehicle_cmd_gate): check time duration since the vehicle stopped
-* fix(control_launch): change default mpc param to improve performance (`#667 <https://github.com/youtalk/autoware.universe/issues/667>`_)
-* fix(trajectory_follower): change stop check speed threshold to almost 0 (`#473 <https://github.com/youtalk/autoware.universe/issues/473>`_)
+* fix(control_launch): change default mpc param to improve performance (`#667 <https://github.com/autowarefoundation/autoware.universe/issues/667>`_)
+* fix(trajectory_follower): change stop check speed threshold to almost 0 (`#473 <https://github.com/autowarefoundation/autoware.universe/issues/473>`_)
   * fix(trajectory_follower): change stop check speed threshold to 0
   * change default parameter
-* fix(trajectory_follower): change default param for curvature smoothing (`#498 <https://github.com/youtalk/autoware.universe/issues/498>`_)
-* feat: change launch package name (`#186 <https://github.com/youtalk/autoware.universe/issues/186>`_)
+* fix(trajectory_follower): change default param for curvature smoothing (`#498 <https://github.com/autowarefoundation/autoware.universe/issues/498>`_)
+* feat: change launch package name (`#186 <https://github.com/autowarefoundation/autoware.universe/issues/186>`_)
   * rename launch folder
   * autoware_launch -> tier4_autoware_launch
   * integration_launch -> tier4_integration_launch

--- a/launch/tier4_localization_launch/CHANGELOG.rst
+++ b/launch/tier4_localization_launch/CHANGELOG.rst
@@ -5,20 +5,20 @@ Changelog for package tier4_localization_launch
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* refactor(ndt_scan_matcher)!: prefix package and namespace with autoware (`#8904 <https://github.com/youtalk/autoware.universe/issues/8904>`_)
+* refactor(ndt_scan_matcher)!: prefix package and namespace with autoware (`#8904 <https://github.com/autowarefoundation/autoware.universe/issues/8904>`_)
   add autoware\_ prefix
-* refactor(ekf_localizer)!: prefix package and namespace with autoware (`#8888 <https://github.com/youtalk/autoware.universe/issues/8888>`_)
+* refactor(ekf_localizer)!: prefix package and namespace with autoware (`#8888 <https://github.com/autowarefoundation/autoware.universe/issues/8888>`_)
   * import lanelet2_map_preprocessor
   * move headers to include/autoware/efk_localier
   ---------
-* refactor(pose_initializer)!: prefix package and namespace with autoware (`#8701 <https://github.com/youtalk/autoware.universe/issues/8701>`_)
+* refactor(pose_initializer)!: prefix package and namespace with autoware (`#8701 <https://github.com/autowarefoundation/autoware.universe/issues/8701>`_)
   * add autoware\_ prefix
   * fix link
   ---------
   Co-authored-by: SakodaShintaro <shintaro.sakoda@tier4.jp>
-* chore(stop_filter): extract stop_filter.param.yaml to autoware_launch (`#8681 <https://github.com/youtalk/autoware.universe/issues/8681>`_)
+* chore(stop_filter): extract stop_filter.param.yaml to autoware_launch (`#8681 <https://github.com/autowarefoundation/autoware.universe/issues/8681>`_)
   Extract stop_filter.param.yaml to autoware_launch
-* feat(localization): add `lidar_marker_localizer` (`#5573 <https://github.com/youtalk/autoware.universe/issues/5573>`_)
+* feat(localization): add `lidar_marker_localizer` (`#5573 <https://github.com/autowarefoundation/autoware.universe/issues/5573>`_)
   * Added lidar_marker_localizer
   * style(pre-commit): autofix
   * fix launch file
@@ -140,39 +140,39 @@ Changelog for package tier4_localization_launch
   Co-authored-by: yamato-ando <Yamato ANDO>
   Co-authored-by: Yamato Ando <yamato.ando@gmail.com>
   Co-authored-by: yamato-ando <yamato.ando@tier4.jp>
-* refactor(pose_instability_detector)!: prefix package and namespace with autoware (`#8568 <https://github.com/youtalk/autoware.universe/issues/8568>`_)
+* refactor(pose_instability_detector)!: prefix package and namespace with autoware (`#8568 <https://github.com/autowarefoundation/autoware.universe/issues/8568>`_)
   * add autoware\_ prefix
   * add autoware\_ prefix
   ---------
   Co-authored-by: SakodaShintaro <shintaro.sakoda@tier4.jp>
-* refactor(pose_estimator_arbiter)!: prefix package and namespace with autoware (`#8386 <https://github.com/youtalk/autoware.universe/issues/8386>`_)
+* refactor(pose_estimator_arbiter)!: prefix package and namespace with autoware (`#8386 <https://github.com/autowarefoundation/autoware.universe/issues/8386>`_)
   * add autoware\_ prefix
   * add autoware\_ prefix
   * fix link for landmark_based_localizer
   * remove Shadowing
   ---------
   Co-authored-by: SakodaShintaro <shintaro.sakoda@tier4.jp>
-* refactor(gyro_odometer)!: prefix package and namespace with autoware (`#8340 <https://github.com/youtalk/autoware.universe/issues/8340>`_)
+* refactor(gyro_odometer)!: prefix package and namespace with autoware (`#8340 <https://github.com/autowarefoundation/autoware.universe/issues/8340>`_)
   * add autoware\_ prefix
   * add missing header
   * use target_include_directories instead
   * add autoware\_ prefix
   ---------
-* refactor(localization_error_monitor)!: prefix package and namespace with autoware (`#8423 <https://github.com/youtalk/autoware.universe/issues/8423>`_)
+* refactor(localization_error_monitor)!: prefix package and namespace with autoware (`#8423 <https://github.com/autowarefoundation/autoware.universe/issues/8423>`_)
   add autoware\_ prefix
-* refactor(geo_pose_projector)!: prefix package and namespace with autoware (`#8334 <https://github.com/youtalk/autoware.universe/issues/8334>`_)
+* refactor(geo_pose_projector)!: prefix package and namespace with autoware (`#8334 <https://github.com/autowarefoundation/autoware.universe/issues/8334>`_)
   * add autoware\_ prefix
   * style(pre-commit): autofix
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: SakodaShintaro <shintaro.sakoda@tier4.jp>
-* refactor(twist2accel)!: prefix package and namespace with autoware (`#8299 <https://github.com/youtalk/autoware.universe/issues/8299>`_)
+* refactor(twist2accel)!: prefix package and namespace with autoware (`#8299 <https://github.com/autowarefoundation/autoware.universe/issues/8299>`_)
   * add autoware\_ prefix
   * add autoware\_ prefix
   * add autoware\_ prefix
   ---------
   Co-authored-by: SakodaShintaro <shintaro.sakoda@tier4.jp>
-* refactor(pointcloud_preprocessor): prefix package and namespace with autoware (`#7983 <https://github.com/youtalk/autoware.universe/issues/7983>`_)
+* refactor(pointcloud_preprocessor): prefix package and namespace with autoware (`#7983 <https://github.com/autowarefoundation/autoware.universe/issues/7983>`_)
   * refactor(pointcloud_preprocessor)!: prefix package and namespace with autoware
   * style(pre-commit): autofix
   * style(pointcloud_preprocessor): suppress line length check for macros
@@ -186,25 +186,25 @@ Changelog for package tier4_localization_launch
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Kenzo Lobos Tsunekawa <kenzo.lobos@tier4.jp>
-* chore(localization, map): remove maintainer (`#7940 <https://github.com/youtalk/autoware.universe/issues/7940>`_)
-* refactor(stop_filter): prefix package and namespace with autoware (`#7789 <https://github.com/youtalk/autoware.universe/issues/7789>`_)
+* chore(localization, map): remove maintainer (`#7940 <https://github.com/autowarefoundation/autoware.universe/issues/7940>`_)
+* refactor(stop_filter): prefix package and namespace with autoware (`#7789 <https://github.com/autowarefoundation/autoware.universe/issues/7789>`_)
   * refactor(stop_filter): prefix package and namespace with autoware
   * fix launch files and update CODEOWNERS
   ---------
-* refactor(ar_tag_based_localizer): add prefix "autoware\_" to ar_tag_based_localizer (`#7483 <https://github.com/youtalk/autoware.universe/issues/7483>`_)
+* refactor(ar_tag_based_localizer): add prefix "autoware\_" to ar_tag_based_localizer (`#7483 <https://github.com/autowarefoundation/autoware.universe/issues/7483>`_)
   * Added prefix "autoware\_" to ar_tag_based_localizer
   * style(pre-commit): autofix
   * Fixed localization_launch
   * style(pre-commit): autofix
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat(autoware_pose_covariance_modifier): add new node to early fuse gnss and ndt poses (`#6570 <https://github.com/youtalk/autoware.universe/issues/6570>`_)
+* feat(autoware_pose_covariance_modifier): add new node to early fuse gnss and ndt poses (`#6570 <https://github.com/autowarefoundation/autoware.universe/issues/6570>`_)
   Co-authored-by: M. Fatih Cırıt <mfc@leodrive.ai>
 * Contributors: Amadeusz Szymko, Esteve Fernandez, Masaki Baba, SakodaShintaro, TaikiYamada4, Yutaka Kondo, kminoda, melike tanrikulu
 
 0.26.0 (2024-04-03)
 -------------------
-* feat(pose_initilizer): set intial pose directly (`#6692 <https://github.com/youtalk/autoware.universe/issues/6692>`_)
+* feat(pose_initilizer): set intial pose directly (`#6692 <https://github.com/autowarefoundation/autoware.universe/issues/6692>`_)
   * feat(pose_initilizer): set intial pose directly
   * style(pre-commit): autofix
   * fix arg order
@@ -223,25 +223,25 @@ Changelog for package tier4_localization_launch
   * style(pre-commit): autofix
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat(tier4_localization_launch):  change the default input pointcloud of localization into the concatenated pointcloud (`#6528 <https://github.com/youtalk/autoware.universe/issues/6528>`_)
+* feat(tier4_localization_launch):  change the default input pointcloud of localization into the concatenated pointcloud (`#6528 <https://github.com/autowarefoundation/autoware.universe/issues/6528>`_)
   refactor lacun argument lidar_container_name to localization_pointcloud_container_name
-* fix(ar_tag_based_localizer): add ar tag based localizer param (`#6390 <https://github.com/youtalk/autoware.universe/issues/6390>`_)
+* fix(ar_tag_based_localizer): add ar tag based localizer param (`#6390 <https://github.com/autowarefoundation/autoware.universe/issues/6390>`_)
   Added ar_tag_based_localizer_param_path
-* chore(tier4_localization_launch): add maintainer (`#6350 <https://github.com/youtalk/autoware.universe/issues/6350>`_)
+* chore(tier4_localization_launch): add maintainer (`#6350 <https://github.com/autowarefoundation/autoware.universe/issues/6350>`_)
   add maintainer
-* chore(ndt scan matcher): rename config path (`#6333 <https://github.com/youtalk/autoware.universe/issues/6333>`_)
+* chore(ndt scan matcher): rename config path (`#6333 <https://github.com/autowarefoundation/autoware.universe/issues/6333>`_)
   * refactor(tier4_localization_launch): use util.launch.xml instead of util.launch.py
   * style(pre-commit): autofix
   * chore(ndt_scan_matcher): rename config path
   * rename path
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* refactor(tier4_localization_launch): use util.launch.xml instead of util.launch.py (`#6287 <https://github.com/youtalk/autoware.universe/issues/6287>`_)
+* refactor(tier4_localization_launch): use util.launch.xml instead of util.launch.py (`#6287 <https://github.com/autowarefoundation/autoware.universe/issues/6287>`_)
   * refactor(tier4_localization_launch): use util.launch.xml instead of util.launch.py
   * style(pre-commit): autofix
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat(pose_estimator_arbiter): add pose_estimator_arbiter with simple switching rule (`#6144 <https://github.com/youtalk/autoware.universe/issues/6144>`_)
+* feat(pose_estimator_arbiter): add pose_estimator_arbiter with simple switching rule (`#6144 <https://github.com/autowarefoundation/autoware.universe/issues/6144>`_)
   * implement pose_estimator_manager pkg
   * tmp
   * swap ndt & yabloc
@@ -364,7 +364,7 @@ Changelog for package tier4_localization_launch
   * remove obsolete args
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* chore(twist2accel): rework parameters (`#6266 <https://github.com/youtalk/autoware.universe/issues/6266>`_)
+* chore(twist2accel): rework parameters (`#6266 <https://github.com/autowarefoundation/autoware.universe/issues/6266>`_)
   * Added twist2accel.param.yaml
   * Added twist2accel.schema.json
   * Fixed README.md and description
@@ -372,7 +372,7 @@ Changelog for package tier4_localization_launch
   * Removed default parameters
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat: always separate lidar preprocessing from pointcloud_container (`#6091 <https://github.com/youtalk/autoware.universe/issues/6091>`_)
+* feat: always separate lidar preprocessing from pointcloud_container (`#6091 <https://github.com/autowarefoundation/autoware.universe/issues/6091>`_)
   * feat!: replace use_pointcloud_container
   * feat: remove from planning
   * fix: fix to remove all use_pointcloud_container
@@ -390,21 +390,21 @@ Changelog for package tier4_localization_launch
   * fix: fix pre-commit
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* chore: add localization & mapping maintainers (`#6085 <https://github.com/youtalk/autoware.universe/issues/6085>`_)
+* chore: add localization & mapping maintainers (`#6085 <https://github.com/autowarefoundation/autoware.universe/issues/6085>`_)
   * Added lm maintainers
   * Add more
   * Fixed maintainer
   ---------
-* refactor(ndt_scan_matcher): fixed ndt_scan_matcher.launch.xml (`#6041 <https://github.com/youtalk/autoware.universe/issues/6041>`_)
+* refactor(ndt_scan_matcher): fixed ndt_scan_matcher.launch.xml (`#6041 <https://github.com/autowarefoundation/autoware.universe/issues/6041>`_)
   Fixed ndt_scan_matcher.launch.xml
-* refactor(ar_tag_based_localizer): refactor pub/sub and so on (`#5854 <https://github.com/youtalk/autoware.universe/issues/5854>`_)
+* refactor(ar_tag_based_localizer): refactor pub/sub and so on (`#5854 <https://github.com/autowarefoundation/autoware.universe/issues/5854>`_)
   * Fixed ar_tag_based_localizer pub/sub
   * Remove dependency on image_transport
   ---------
-* refactor(localization_launch, ground_segmentation_launch): rename lidar topic (`#5781 <https://github.com/youtalk/autoware.universe/issues/5781>`_)
+* refactor(localization_launch, ground_segmentation_launch): rename lidar topic (`#5781 <https://github.com/autowarefoundation/autoware.universe/issues/5781>`_)
   rename lidar topic
   Co-authored-by: yamato-ando <Yamato ANDO>
-* feat(localization): add `pose_instability_detector` (`#5439 <https://github.com/youtalk/autoware.universe/issues/5439>`_)
+* feat(localization): add `pose_instability_detector` (`#5439 <https://github.com/autowarefoundation/autoware.universe/issues/5439>`_)
   * Added pose_instability_detector
   * Renamed files
   * Fixed parameter name
@@ -447,7 +447,7 @@ Changelog for package tier4_localization_launch
   * Updated rqt_runtime_monitor.png
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat(geo_pose_projector): use geo_pose_projector in eagleye (`#5513 <https://github.com/youtalk/autoware.universe/issues/5513>`_)
+* feat(geo_pose_projector): use geo_pose_projector in eagleye (`#5513 <https://github.com/autowarefoundation/autoware.universe/issues/5513>`_)
   * feat(tier4_geo_pose_projector): use tier4_geo_pose_projector in eagleye
   * style(pre-commit): autofix
   * fix(eagleye): split fix2pose
@@ -469,7 +469,7 @@ Changelog for package tier4_localization_launch
   * style(pre-commit): autofix
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat(eagleye): split fix2pose (`#5506 <https://github.com/youtalk/autoware.universe/issues/5506>`_)
+* feat(eagleye): split fix2pose (`#5506 <https://github.com/autowarefoundation/autoware.universe/issues/5506>`_)
   * fix(eagleye): split fix2pose
   * style(pre-commit): autofix
   * fix name: fuser -> fusion
@@ -478,7 +478,7 @@ Changelog for package tier4_localization_launch
   * fix typo
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* refactor(landmark_based_localizer): refactored landmark_tf_caster (`#5414 <https://github.com/youtalk/autoware.universe/issues/5414>`_)
+* refactor(landmark_based_localizer): refactored landmark_tf_caster (`#5414 <https://github.com/autowarefoundation/autoware.universe/issues/5414>`_)
   * Removed landmark_tf_caster node
   * Added maintainer
   * style(pre-commit): autofix
@@ -492,18 +492,18 @@ Changelog for package tier4_localization_launch
   * Fixed Marker to MarkerArray
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat(yabloc_image_processing): support both of  raw and compressed image input (`#5209 <https://github.com/youtalk/autoware.universe/issues/5209>`_)
+* feat(yabloc_image_processing): support both of  raw and compressed image input (`#5209 <https://github.com/autowarefoundation/autoware.universe/issues/5209>`_)
   * add raw image subscriber
   * update README
   * improve format and variable names
   ---------
-* feat(pose_twist_estimator): automatically initialize pose only with gnss (`#5115 <https://github.com/youtalk/autoware.universe/issues/5115>`_)
-* fix(tier4_localization_launch):  fixed exec_depend (`#5075 <https://github.com/youtalk/autoware.universe/issues/5075>`_)
+* feat(pose_twist_estimator): automatically initialize pose only with gnss (`#5115 <https://github.com/autowarefoundation/autoware.universe/issues/5115>`_)
+* fix(tier4_localization_launch):  fixed exec_depend (`#5075 <https://github.com/autowarefoundation/autoware.universe/issues/5075>`_)
   * Fixed exec_depend
   * style(pre-commit): autofix
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat(ar_tag_based_localizer): split the package `ar_tag_based_localizer` (`#5043 <https://github.com/youtalk/autoware.universe/issues/5043>`_)
+* feat(ar_tag_based_localizer): split the package `ar_tag_based_localizer` (`#5043 <https://github.com/autowarefoundation/autoware.universe/issues/5043>`_)
   * Fix package name
   * Removed utils
   * Renamed tag_tf_caster to landmark_tf_caster
@@ -519,7 +519,7 @@ Changelog for package tier4_localization_launch
   * Fixed ArTagDetector to ArTagBasedLocalizer
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat(ar_tag_based_localizer): add ekf_pose subscriber (`#4946 <https://github.com/youtalk/autoware.universe/issues/4946>`_)
+* feat(ar_tag_based_localizer): add ekf_pose subscriber (`#4946 <https://github.com/autowarefoundation/autoware.universe/issues/4946>`_)
   * Fixed qos
   * Fixed camera_frame\_
   * Fixed for awsim
@@ -540,7 +540,7 @@ Changelog for package tier4_localization_launch
   * Added comments to param.yaml
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* fix(ar_tag_based_localizer): added small changes (`#4885 <https://github.com/youtalk/autoware.universe/issues/4885>`_)
+* fix(ar_tag_based_localizer): added small changes (`#4885 <https://github.com/autowarefoundation/autoware.universe/issues/4885>`_)
   * Fixed qos
   * Fixed camera_frame\_
   * Fixed for awsim
@@ -551,7 +551,7 @@ Changelog for package tier4_localization_launch
   * Updated README.md
   * Fixed distance_threshold to 13m
   ---------
-* feat(localization): add a new localization package `ar_tag_based_localizer` (`#4347 <https://github.com/youtalk/autoware.universe/issues/4347>`_)
+* feat(localization): add a new localization package `ar_tag_based_localizer` (`#4347 <https://github.com/autowarefoundation/autoware.universe/issues/4347>`_)
   * Added ar_tag_based_localizer
   * style(pre-commit): autofix
   * Added include
@@ -604,7 +604,7 @@ Changelog for package tier4_localization_launch
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: kminoda <44218668+kminoda@users.noreply.github.com>
-* feat(yabloc_monitor): add yabloc_monitor (`#4395 <https://github.com/youtalk/autoware.universe/issues/4395>`_)
+* feat(yabloc_monitor): add yabloc_monitor (`#4395 <https://github.com/autowarefoundation/autoware.universe/issues/4395>`_)
   * feat(yabloc_monitor): add yabloc_monitor
   * style(pre-commit): autofix
   * add readme
@@ -638,14 +638,14 @@ Changelog for package tier4_localization_launch
   * style(pre-commit): autofix
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* refactor(tier4_localization_launch): change input/pointcloud param (`#4411 <https://github.com/youtalk/autoware.universe/issues/4411>`_)
+* refactor(tier4_localization_launch): change input/pointcloud param (`#4411 <https://github.com/autowarefoundation/autoware.universe/issues/4411>`_)
   * refactor(tier4_localization_launch): change input/pointcloud param
   * parameter renaming moved util.launch.py
-* feat(yabloc): change namespace (`#4389 <https://github.com/youtalk/autoware.universe/issues/4389>`_)
+* feat(yabloc): change namespace (`#4389 <https://github.com/autowarefoundation/autoware.universe/issues/4389>`_)
   * fix(yabloc): update namespace
   * fix
   ---------
-* feat: use `pose_source` and `twist_source` for selecting localization methods (`#4257 <https://github.com/youtalk/autoware.universe/issues/4257>`_)
+* feat: use `pose_source` and `twist_source` for selecting localization methods (`#4257 <https://github.com/autowarefoundation/autoware.universe/issues/4257>`_)
   * feat(tier4_localization_launch): add pose_twist_estimator.launch.py
   * update format
   * update launcher
@@ -670,7 +670,7 @@ Changelog for package tier4_localization_launch
   * Update yabloc document
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat(yabloc): add camera and vector map localization (`#3946 <https://github.com/youtalk/autoware.universe/issues/3946>`_)
+* feat(yabloc): add camera and vector map localization (`#3946 <https://github.com/autowarefoundation/autoware.universe/issues/3946>`_)
   * adopt scane_case to undistort, segment_filter
   * adopt scane_case to ground_server, ll2_decomposer
   * adopt scane_case to twist_converter, twist_estimator
@@ -816,26 +816,26 @@ Changelog for package tier4_localization_launch
   * update README and some sample images
   * update README.md
   * fix override_camera_frame_id bahaviors
-  * fix some bugs (`#4 <https://github.com/youtalk/autoware.universe/issues/4>`_)
-  * fix: use initialpose from Rviz (`#6 <https://github.com/youtalk/autoware.universe/issues/6>`_)
+  * fix some bugs (`#4 <https://github.com/autowarefoundation/autoware.universe/issues/4>`_)
+  * fix: use initialpose from Rviz (`#6 <https://github.com/autowarefoundation/autoware.universe/issues/6>`_)
   * use initialpose from Rviz to init
   * add description about how-to-set-initialpose
   ---------
-  * misc: add license (`#7 <https://github.com/youtalk/autoware.universe/issues/7>`_)
+  * misc: add license (`#7 <https://github.com/autowarefoundation/autoware.universe/issues/7>`_)
   * WIP: add license description
   * add license description
   * add description about license in README
   ---------
-  * add quick start demo (`#8 <https://github.com/youtalk/autoware.universe/issues/8>`_)
-  * refactor(launch) remove & update obsolete launch files (`#9 <https://github.com/youtalk/autoware.universe/issues/9>`_)
+  * add quick start demo (`#8 <https://github.com/autowarefoundation/autoware.universe/issues/8>`_)
+  * refactor(launch) remove & update obsolete launch files (`#9 <https://github.com/autowarefoundation/autoware.universe/issues/9>`_)
   * delete obsolete launch files
   * update documents
   ---------
-  * docs(readme): update architecture image (`#10 <https://github.com/youtalk/autoware.universe/issues/10>`_)
+  * docs(readme): update architecture image (`#10 <https://github.com/autowarefoundation/autoware.universe/issues/10>`_)
   * replace architecture image in README
   * update some images
   ---------
-  * refactor(pcdless_launc/scripts): remove unnecessary scripts (`#11 <https://github.com/youtalk/autoware.universe/issues/11>`_)
+  * refactor(pcdless_launc/scripts): remove unnecessary scripts (`#11 <https://github.com/autowarefoundation/autoware.universe/issues/11>`_)
   * remove not useful scripts
   * rename scripts &  add descriptions
   * little change
@@ -846,18 +846,18 @@ Changelog for package tier4_localization_launch
   * fix(twist_estimator): use velocity_report by default
   * fix bug
   * debugged, now works
-  * update sample rosbag link (`#14 <https://github.com/youtalk/autoware.universe/issues/14>`_)
-  * feature(graph_segment, gnss_particle_corrector): make some features switchable (`#17 <https://github.com/youtalk/autoware.universe/issues/17>`_)
+  * update sample rosbag link (`#14 <https://github.com/autowarefoundation/autoware.universe/issues/14>`_)
+  * feature(graph_segment, gnss_particle_corrector): make some features switchable (`#17 <https://github.com/autowarefoundation/autoware.universe/issues/17>`_)
   * make additional-graph-segment-pickup disablable
   * enlarge gnss_mahalanobis_distance_threshold in expressway.launch
   ---------
-  * fix: minor fix for multi camera support (`#18 <https://github.com/youtalk/autoware.universe/issues/18>`_)
+  * fix: minor fix for multi camera support (`#18 <https://github.com/autowarefoundation/autoware.universe/issues/18>`_)
   * fix: minor fix for multi camera support
   * update
   * update
   * fix typo
   ---------
-  * refactor(retroactive_resampler): more readable (`#19 <https://github.com/youtalk/autoware.universe/issues/19>`_)
+  * refactor(retroactive_resampler): more readable (`#19 <https://github.com/autowarefoundation/autoware.universe/issues/19>`_)
   * make Hisotry class
   * use boost:adaptors::indexed()
   * add many comment in resampling()
@@ -865,42 +865,42 @@ Changelog for package tier4_localization_launch
   * rename interface of resampler
   * circular_buffer is unnecessary
   ---------
-  * refactor(mpf::predictor) resampling interval control in out of resampler (`#20 <https://github.com/youtalk/autoware.universe/issues/20>`_)
+  * refactor(mpf::predictor) resampling interval control in out of resampler (`#20 <https://github.com/autowarefoundation/autoware.universe/issues/20>`_)
   * resampling interval management should be done out of resample()
   * resampler class throw exeption rather than optional
   * split files for resampling_history
   * split files for experimental/suspention_adaptor
   ---------
-  * refactor(mpf::predictor): just refactoring (`#21 <https://github.com/youtalk/autoware.universe/issues/21>`_)
+  * refactor(mpf::predictor): just refactoring (`#21 <https://github.com/autowarefoundation/autoware.universe/issues/21>`_)
   * remove obsolete functions
   * remove test of predictor
   * remove remapping in pf.launch.xml for suspension_adapator
   * add some comments
   ---------
-  * fix(twist_estimator): remove stop filter for velocity (`#23 <https://github.com/youtalk/autoware.universe/issues/23>`_)
-  * feat(pcdless_launch): add multi camera launcher (`#22 <https://github.com/youtalk/autoware.universe/issues/22>`_)
+  * fix(twist_estimator): remove stop filter for velocity (`#23 <https://github.com/autowarefoundation/autoware.universe/issues/23>`_)
+  * feat(pcdless_launch): add multi camera launcher (`#22 <https://github.com/autowarefoundation/autoware.universe/issues/22>`_)
   * feat(pcdless_launch): add multi camera launcher
   * minor fix
   ---------
-  * refactor(CMakeListx.txt): just refactoring (`#24 <https://github.com/youtalk/autoware.universe/issues/24>`_)
+  * refactor(CMakeListx.txt): just refactoring (`#24 <https://github.com/autowarefoundation/autoware.universe/issues/24>`_)
   * refactor imgproc/*/CMakeListx.txt
   * refactor initializer/*/CMakeListx.txt & add gnss_pose_initializer pkg
   * rename some files in twist/ & refactor pf/*/cmakelist
   * refactor validation/*/CMakeListx.txt
   * fix some obsolete executor name
   ---------
-  * fix: rename lsd variables and files (`#26 <https://github.com/youtalk/autoware.universe/issues/26>`_)
-  * misc: reame pcdless to yabloc (`#25 <https://github.com/youtalk/autoware.universe/issues/25>`_)
+  * fix: rename lsd variables and files (`#26 <https://github.com/autowarefoundation/autoware.universe/issues/26>`_)
+  * misc: reame pcdless to yabloc (`#25 <https://github.com/autowarefoundation/autoware.universe/issues/25>`_)
   * rename pcdless to yabloc
   * fix conflict miss
   ---------
-  * visualize path (`#28 <https://github.com/youtalk/autoware.universe/issues/28>`_)
-  * docs: update readme about particle filter (`#30 <https://github.com/youtalk/autoware.universe/issues/30>`_)
+  * visualize path (`#28 <https://github.com/autowarefoundation/autoware.universe/issues/28>`_)
+  * docs: update readme about particle filter (`#30 <https://github.com/autowarefoundation/autoware.universe/issues/30>`_)
   * update mpf/README.md
   * update gnss_corrector/README.md
   * update camera_corrector/README.md
   ---------
-  * feat(segment_filter): publish images with lines and refactor (`#29 <https://github.com/youtalk/autoware.universe/issues/29>`_)
+  * feat(segment_filter): publish images with lines and refactor (`#29 <https://github.com/autowarefoundation/autoware.universe/issues/29>`_)
   * feat(segment_filter): publish images with lines
   * update validation
   * update imgproc (reverted)
@@ -914,47 +914,47 @@ Changelog for package tier4_localization_launch
   * no throw runtime_error (unintentionaly applying format)
   ---------
   Co-authored-by: Kento Yabuuchi <kento.yabuuchi.2@tier4.jp>
-  * catch runtime_error when particle id is invalid (`#31 <https://github.com/youtalk/autoware.universe/issues/31>`_)
-  * return if info is nullopt (`#32 <https://github.com/youtalk/autoware.universe/issues/32>`_)
-  * pose_buffer is sometimes empty (`#33 <https://github.com/youtalk/autoware.universe/issues/33>`_)
-  * use_yaw_of_initialpose (`#34 <https://github.com/youtalk/autoware.universe/issues/34>`_)
-  * feat(interface):  remove incompatible interface (`#35 <https://github.com/youtalk/autoware.universe/issues/35>`_)
+  * catch runtime_error when particle id is invalid (`#31 <https://github.com/autowarefoundation/autoware.universe/issues/31>`_)
+  * return if info is nullopt (`#32 <https://github.com/autowarefoundation/autoware.universe/issues/32>`_)
+  * pose_buffer is sometimes empty (`#33 <https://github.com/autowarefoundation/autoware.universe/issues/33>`_)
+  * use_yaw_of_initialpose (`#34 <https://github.com/autowarefoundation/autoware.universe/issues/34>`_)
+  * feat(interface):  remove incompatible interface (`#35 <https://github.com/autowarefoundation/autoware.universe/issues/35>`_)
   * not use ublox_msg when run as autoware
   * remove twist/kalman/twist & use twist_estimator/twist_with_covariance
   * update particle_array stamp even if the time stamp seems wrong
   ---------
-  * fix: suppress info/warn_stream (`#37 <https://github.com/youtalk/autoware.universe/issues/37>`_)
+  * fix: suppress info/warn_stream (`#37 <https://github.com/autowarefoundation/autoware.universe/issues/37>`_)
   * does not stream undistortion time
   * improve warn stream when skip particle weighting
   * surpress frequency of  warnings during synchronized particle searching
   * fix camera_pose_initializer
   ---------
-  * /switch must not be nice name (`#39 <https://github.com/youtalk/autoware.universe/issues/39>`_)
-  * misc(readme): update readme (`#41 <https://github.com/youtalk/autoware.universe/issues/41>`_)
+  * /switch must not be nice name (`#39 <https://github.com/autowarefoundation/autoware.universe/issues/39>`_)
+  * misc(readme): update readme (`#41 <https://github.com/autowarefoundation/autoware.universe/issues/41>`_)
   * add youtube link and change thumbnail
   * improve input/output topics
   * quick start demo screen image
   * add abstruct architecture and detail architecture
   ---------
-  * docs(rosdep): fix package.xml to ensure build success (`#44 <https://github.com/youtalk/autoware.universe/issues/44>`_)
+  * docs(rosdep): fix package.xml to ensure build success (`#44 <https://github.com/autowarefoundation/autoware.universe/issues/44>`_)
   * fix package.xml to success build
   * add 'rosdep install' in how-to-build
   ---------
-  * add geographiclib in package.xml (`#46 <https://github.com/youtalk/autoware.universe/issues/46>`_)
-  * fix path search error in build stage (`#45 <https://github.com/youtalk/autoware.universe/issues/45>`_)
+  * add geographiclib in package.xml (`#46 <https://github.com/autowarefoundation/autoware.universe/issues/46>`_)
+  * fix path search error in build stage (`#45 <https://github.com/autowarefoundation/autoware.universe/issues/45>`_)
   * fix path search error in build stage
   * fix https://github.com/tier4/YabLoc/pull/45#issuecomment-1546808419
-  * Feature/remove submodule (`#47 <https://github.com/youtalk/autoware.universe/issues/47>`_)
+  * Feature/remove submodule (`#47 <https://github.com/autowarefoundation/autoware.universe/issues/47>`_)
   * remove submodules
   * remove doppler converter
   ---------
-  * feature: change node namespace to /localization/yabloc/** from /localization/** (`#48 <https://github.com/youtalk/autoware.universe/issues/48>`_)
+  * feature: change node namespace to /localization/yabloc/** from /localization/** (`#48 <https://github.com/autowarefoundation/autoware.universe/issues/48>`_)
   * change node namespace
   * update namespace for autoware-mode
   * update namespace in multi_camera.launch
   ---------
-  * removed unstable packages (`#49 <https://github.com/youtalk/autoware.universe/issues/49>`_)
-  * feature: add *.param.yaml to manage parameters (`#50 <https://github.com/youtalk/autoware.universe/issues/50>`_)
+  * removed unstable packages (`#49 <https://github.com/autowarefoundation/autoware.universe/issues/49>`_)
+  * feature: add *.param.yaml to manage parameters (`#50 <https://github.com/autowarefoundation/autoware.universe/issues/50>`_)
   * make *.param.yaml in imgproc packages
   * make *.param.yaml in initializer packages
   * make *.param.yaml in map packages
@@ -965,8 +965,8 @@ Changelog for package tier4_localization_launch
   * remove default parameters
   * fix some remaining invalida parameters
   ---------
-  * does not estimate twist (`#51 <https://github.com/youtalk/autoware.universe/issues/51>`_)
-  * feat(particle_initializer): merge particle_initializer into mpf (`#52 <https://github.com/youtalk/autoware.universe/issues/52>`_)
+  * does not estimate twist (`#51 <https://github.com/autowarefoundation/autoware.universe/issues/51>`_)
+  * feat(particle_initializer): merge particle_initializer into mpf (`#52 <https://github.com/autowarefoundation/autoware.universe/issues/52>`_)
   * feat(particle_initializer): merge particle_initializer to modulalized_particle_filter
   * remove particle_initializer
   * remove debug message
@@ -975,8 +975,8 @@ Changelog for package tier4_localization_launch
   * rename publishing topic
   ---------
   Co-authored-by: Kento Yabuuchi <kento.yabuuchi.2@tier4.jp>
-  * fix: remove ll2_transition_area (`#54 <https://github.com/youtalk/autoware.universe/issues/54>`_)
-  * feature(initializer): combine some initializer packages (`#56 <https://github.com/youtalk/autoware.universe/issues/56>`_)
+  * fix: remove ll2_transition_area (`#54 <https://github.com/autowarefoundation/autoware.universe/issues/54>`_)
+  * feature(initializer): combine some initializer packages (`#56 <https://github.com/autowarefoundation/autoware.universe/issues/56>`_)
   * combine some package about initializer
   * yabloc_pose_initializer works well
   * remove old initializer packages
@@ -984,15 +984,15 @@ Changelog for package tier4_localization_launch
   * fix bug
   * revert initializer mode
   ---------
-  * feature(imgproc): reudce imgproc packages (`#57 <https://github.com/youtalk/autoware.universe/issues/57>`_)
+  * feature(imgproc): reudce imgproc packages (`#57 <https://github.com/autowarefoundation/autoware.universe/issues/57>`_)
   * combine some imgproc packages
   * combine overlay monitors into imgproc
   ---------
-  * feature(validation): remove validation packages (`#58 <https://github.com/youtalk/autoware.universe/issues/58>`_)
+  * feature(validation): remove validation packages (`#58 <https://github.com/autowarefoundation/autoware.universe/issues/58>`_)
   * remove validation packages
   * remove path visualization
   ---------
-  * feature(pf): combine some packages related to particle filter (`#59 <https://github.com/youtalk/autoware.universe/issues/59>`_)
+  * feature(pf): combine some packages related to particle filter (`#59 <https://github.com/autowarefoundation/autoware.universe/issues/59>`_)
   * create yabloc_particle_filter
   * combine gnss_particle_corrector
   * combine ll2_cost_map
@@ -1001,7 +1001,7 @@ Changelog for package tier4_localization_launch
   * split README & remove obsolete scripts
   * fix config path of multi_camera mode
   ---------
-  * feature: combine map and twist packages (`#60 <https://github.com/youtalk/autoware.universe/issues/60>`_)
+  * feature: combine map and twist packages (`#60 <https://github.com/autowarefoundation/autoware.universe/issues/60>`_)
   * removed some twist nodes & rename remains to yabloc_twist
   * fix launch files for yabloc_twist
   * move map packages to yabloc_common
@@ -1085,13 +1085,13 @@ Changelog for package tier4_localization_launch
   Co-authored-by: Akihiro Komori <akihiro.komori@unity3d.com>
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Takagi, Isamu <43976882+isamu-takagi@users.noreply.github.com>
-* style: fix typos (`#3617 <https://github.com/youtalk/autoware.universe/issues/3617>`_)
+* style: fix typos (`#3617 <https://github.com/autowarefoundation/autoware.universe/issues/3617>`_)
   * style: fix typos in documents
   * style: fix typos in package.xml
   * style: fix typos in launch files
   * style: fix typos in comments
   ---------
-* build: mark autoware_cmake as <buildtool_depend> (`#3616 <https://github.com/youtalk/autoware.universe/issues/3616>`_)
+* build: mark autoware_cmake as <buildtool_depend> (`#3616 <https://github.com/autowarefoundation/autoware.universe/issues/3616>`_)
   * build: mark autoware_cmake as <buildtool_depend>
   with <build_depend>, autoware_cmake is automatically exported with ament_target_dependencies() (unecessary)
   * style(pre-commit): autofix
@@ -1099,7 +1099,7 @@ Changelog for package tier4_localization_launch
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Kenji Miyake <kenji.miyake@tier4.jp>
-* feat: add gnss/imu localizer  (`#3063 <https://github.com/youtalk/autoware.universe/issues/3063>`_)
+* feat: add gnss/imu localizer  (`#3063 <https://github.com/autowarefoundation/autoware.universe/issues/3063>`_)
   * Add gnss_imu_localizar
   * Fix twist switching bug
   * Fix spell and reformat
@@ -1134,19 +1134,19 @@ Changelog for package tier4_localization_launch
   * List the packages that depend on map4_localization_launch correctly
   * Ran precommit locally
   ---------
-* chore(tier4_localization_launch): add maintainer (`#3133 <https://github.com/youtalk/autoware.universe/issues/3133>`_)
-* chore(ekf_localizer): move parameters to its dedicated yaml file (`#3039 <https://github.com/youtalk/autoware.universe/issues/3039>`_)
+* chore(tier4_localization_launch): add maintainer (`#3133 <https://github.com/autowarefoundation/autoware.universe/issues/3133>`_)
+* chore(ekf_localizer): move parameters to its dedicated yaml file (`#3039 <https://github.com/autowarefoundation/autoware.universe/issues/3039>`_)
   * chores(ekf_localizer): move parameters to its dedicated yaml file
   * style(pre-commit): autofix
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat(pose_initializer): enable pose initialization while running (only for sim) (`#3038 <https://github.com/youtalk/autoware.universe/issues/3038>`_)
+* feat(pose_initializer): enable pose initialization while running (only for sim) (`#3038 <https://github.com/autowarefoundation/autoware.universe/issues/3038>`_)
   * feat(pose_initializer): enable pose initialization while running (only for sim)
   * both logsim and psim params
   * only one pose_initializer_param_path arg
   * use two param files for pose_initializer
   ---------
-* feat(pose_initilizer): support gnss/imu pose estimator (`#2904 <https://github.com/youtalk/autoware.universe/issues/2904>`_)
+* feat(pose_initilizer): support gnss/imu pose estimator (`#2904 <https://github.com/autowarefoundation/autoware.universe/issues/2904>`_)
   * Support GNSS/IMU pose estimator
   * style(pre-commit): autofix
   * Revert gnss/imu support
@@ -1174,7 +1174,7 @@ Changelog for package tier4_localization_launch
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Ryohei Sasaki <ryohei.sasaki@map4.jp>
   Co-authored-by: Takagi, Isamu <43976882+isamu-takagi@users.noreply.github.com>
-* feat(tier4_localization_launch): remove configs and move to autoware_launch (`#2537 <https://github.com/youtalk/autoware.universe/issues/2537>`_)
+* feat(tier4_localization_launch): remove configs and move to autoware_launch (`#2537 <https://github.com/autowarefoundation/autoware.universe/issues/2537>`_)
   * feat(tier4_localization_launch): remove configs and move to autoware_launch
   * update readme
   * Update launch/tier4_localization_launch/README.md
@@ -1184,18 +1184,18 @@ Changelog for package tier4_localization_launch
   * update readme
   * pre-commit
   Co-authored-by: Yamato Ando <yamato.ando@gmail.com>
-* feat(tier4_localization_launch): pass pc container to localization (`#2114 <https://github.com/youtalk/autoware.universe/issues/2114>`_)
+* feat(tier4_localization_launch): pass pc container to localization (`#2114 <https://github.com/autowarefoundation/autoware.universe/issues/2114>`_)
   * feature(tier4_localization_launch): pass pc container to localization
   * ci(pre-commit): autofix
   * feature(tier4_localization_launch): update util.launch.xml
   * feature(tier4_localization_launch): update use container param value
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* ci(pre-commit): format SVG files (`#2172 <https://github.com/youtalk/autoware.universe/issues/2172>`_)
+* ci(pre-commit): format SVG files (`#2172 <https://github.com/autowarefoundation/autoware.universe/issues/2172>`_)
   * ci(pre-commit): format SVG files
   * ci(pre-commit): autofix
   * apply pre-commit
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat(ndt): remove ndt package (`#2053 <https://github.com/youtalk/autoware.universe/issues/2053>`_)
+* feat(ndt): remove ndt package (`#2053 <https://github.com/autowarefoundation/autoware.universe/issues/2053>`_)
   * first commit
   * CMakeLists.txt does not work........
   * build works
@@ -1210,8 +1210,8 @@ Changelog for package tier4_localization_launch
   * removed default parameter from search_method
   * small fix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* fix: add adapi dependency (`#1892 <https://github.com/youtalk/autoware.universe/issues/1892>`_)
-* feat(pose_initializer)!: support ad api (`#1500 <https://github.com/youtalk/autoware.universe/issues/1500>`_)
+* fix: add adapi dependency (`#1892 <https://github.com/autowarefoundation/autoware.universe/issues/1892>`_)
+* feat(pose_initializer)!: support ad api (`#1500 <https://github.com/autowarefoundation/autoware.universe/issues/1500>`_)
   * feat(pose_initializer): support ad api
   * docs: update readme
   * fix: build error
@@ -1227,18 +1227,18 @@ Changelog for package tier4_localization_launch
   * fix: fix build error
   * ci(pre-commit): autofix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat(tier4_localization_launch): manual sync with tier4/localization_launch (`#1442 <https://github.com/youtalk/autoware.universe/issues/1442>`_)
+* feat(tier4_localization_launch): manual sync with tier4/localization_launch (`#1442 <https://github.com/autowarefoundation/autoware.universe/issues/1442>`_)
   * feat(tier4_localization_launch): manual sync with tier4/localization_launch
   * ci(pre-commit): autofix
   * fix
   * revert modification
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* fix(ekf_localizer): rename biased pose topics (`#1787 <https://github.com/youtalk/autoware.universe/issues/1787>`_)
+* fix(ekf_localizer): rename biased pose topics (`#1787 <https://github.com/autowarefoundation/autoware.universe/issues/1787>`_)
   * fix(ekf_localizer): rename biased pose topics
   * Update topic descriptions in README
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: kminoda <44218668+kminoda@users.noreply.github.com>
-* feat(default_ad_api): add localization api  (`#1431 <https://github.com/youtalk/autoware.universe/issues/1431>`_)
+* feat(default_ad_api): add localization api  (`#1431 <https://github.com/autowarefoundation/autoware.universe/issues/1431>`_)
   * feat(default_ad_api): add localization api
   * docs: add readme
   * feat: add auto initial pose
@@ -1258,7 +1258,7 @@ Changelog for package tier4_localization_launch
   * fix: remove needless keyword
   * feat: change api helper node namespace
   * fix: fix launch file path
-* chore(localization packages, etc): modify maintainer and e-mail address (`#1661 <https://github.com/youtalk/autoware.universe/issues/1661>`_)
+* chore(localization packages, etc): modify maintainer and e-mail address (`#1661 <https://github.com/autowarefoundation/autoware.universe/issues/1661>`_)
   * chore(localization packages, etc): modify maintainer and e-mail address
   * remove indent
   * add authors
@@ -1271,7 +1271,7 @@ Changelog for package tier4_localization_launch
   * add author
   Co-authored-by: Yukihiro Saito <yukky.saito@gmail.com>
   Co-authored-by: kminoda <44218668+kminoda@users.noreply.github.com>
-* fix(ekf_localizer): enable enable_yaw_bias (`#1601 <https://github.com/youtalk/autoware.universe/issues/1601>`_)
+* fix(ekf_localizer): enable enable_yaw_bias (`#1601 <https://github.com/autowarefoundation/autoware.universe/issues/1601>`_)
   * fix(ekf_localizer): enable enable_yaw_bias
   * remove proc_stddev_yaw_bias from ekf
   * ci(pre-commit): autofix
@@ -1280,33 +1280,33 @@ Changelog for package tier4_localization_launch
   * fixed minor bugs
   * change default parameter
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* fix(ndt_scan_matcher): fix default parameter to 0.0225 (`#1583 <https://github.com/youtalk/autoware.universe/issues/1583>`_)
+* fix(ndt_scan_matcher): fix default parameter to 0.0225 (`#1583 <https://github.com/autowarefoundation/autoware.universe/issues/1583>`_)
   * fix(ndt_scan_matcher): fix default parameter to 0.0225
   * added a sidenote
   * added a sidenote
-* feat(localization_error_monitor): change subscribing topic type (`#1532 <https://github.com/youtalk/autoware.universe/issues/1532>`_)
+* feat(localization_error_monitor): change subscribing topic type (`#1532 <https://github.com/autowarefoundation/autoware.universe/issues/1532>`_)
   * feat(localization_error_monitor): change subscribing topic type
   * ci(pre-commit): autofix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat(tier4_localization_launch): declare param path argument (`#1404 <https://github.com/youtalk/autoware.universe/issues/1404>`_)
+* feat(tier4_localization_launch): declare param path argument (`#1404 <https://github.com/autowarefoundation/autoware.universe/issues/1404>`_)
   * first commit
   * added arguments in each launch files
   * finished implementation
   * ci(pre-commit): autofix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat(tier4_localization_launch): change rectified pointcloud to outlier_filtered pointcloud (`#1365 <https://github.com/youtalk/autoware.universe/issues/1365>`_)
-* fix(tier4_localization_launch): add group tag (`#1237 <https://github.com/youtalk/autoware.universe/issues/1237>`_)
+* feat(tier4_localization_launch): change rectified pointcloud to outlier_filtered pointcloud (`#1365 <https://github.com/autowarefoundation/autoware.universe/issues/1365>`_)
+* fix(tier4_localization_launch): add group tag (`#1237 <https://github.com/autowarefoundation/autoware.universe/issues/1237>`_)
   * fix(tier4_localization_launch): add group tag
   * add more args into group
-* feat(localization_error_monitor): add a config file (`#1282 <https://github.com/youtalk/autoware.universe/issues/1282>`_)
+* feat(localization_error_monitor): add a config file (`#1282 <https://github.com/autowarefoundation/autoware.universe/issues/1282>`_)
   * feat(localization_error_monitor): add a config file
   * ci(pre-commit): autofix
   * feat(localization_error_monitor): add a config file in tier4_localization_launch too
   * ci(pre-commit): autofix
   * debugged
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* fix(tier4_localization_launch): remove unnecessary param from pose_twist_fusion_filter.launch (`#1224 <https://github.com/youtalk/autoware.universe/issues/1224>`_)
-* feat(ekf_localizer): allow multi sensor inputs in ekf_localizer (`#1027 <https://github.com/youtalk/autoware.universe/issues/1027>`_)
+* fix(tier4_localization_launch): remove unnecessary param from pose_twist_fusion_filter.launch (`#1224 <https://github.com/autowarefoundation/autoware.universe/issues/1224>`_)
+* feat(ekf_localizer): allow multi sensor inputs in ekf_localizer (`#1027 <https://github.com/autowarefoundation/autoware.universe/issues/1027>`_)
   * first commit
   * ci(pre-commit): autofix
   * updated
@@ -1346,7 +1346,7 @@ Changelog for package tier4_localization_launch
   * change the default gnss covariance to the previous one
   * pre-commit
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat(distortion_corrector): use gyroscope for correcting LiDAR distortion (`#1120 <https://github.com/youtalk/autoware.universe/issues/1120>`_)
+* feat(distortion_corrector): use gyroscope for correcting LiDAR distortion (`#1120 <https://github.com/autowarefoundation/autoware.universe/issues/1120>`_)
   * first commit
   * ci(pre-commit): autofix
   * check if angular_velocity_queue\_ is empty or not
@@ -1356,7 +1356,7 @@ Changelog for package tier4_localization_launch
   * ci(pre-commit): autofix
   * reflected reviews
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat: regularized NDT matching (`#1006 <https://github.com/youtalk/autoware.universe/issues/1006>`_)
+* feat: regularized NDT matching (`#1006 <https://github.com/autowarefoundation/autoware.universe/issues/1006>`_)
   * add interface of gnss regularization in ndt class
   * gnss pose is applied to regularize NDT
   * add descriptions in ndt_scan_matcher/README
@@ -1368,7 +1368,7 @@ Changelog for package tier4_localization_launch
   * modify README to visualize well
   * fixed descriptions about principle of regularization
   Co-authored-by: Kento Yabuuchi <kento.yabuuchi.2@tier4.jp>
-* feat(twist2accel)!: add new package for estimating acceleration in localization module (`#1089 <https://github.com/youtalk/autoware.universe/issues/1089>`_)
+* feat(twist2accel)!: add new package for estimating acceleration in localization module (`#1089 <https://github.com/autowarefoundation/autoware.universe/issues/1089>`_)
   * first commit
   * update launch arg names
   * use lowpassfilter in signalprocessing
@@ -1386,26 +1386,26 @@ Changelog for package tier4_localization_launch
   * added future work
   * ci(pre-commit): autofix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* chore: upgrade cmake_minimum_required to 3.14 (`#856 <https://github.com/youtalk/autoware.universe/issues/856>`_)
-* refactor: use autoware cmake (`#849 <https://github.com/youtalk/autoware.universe/issues/849>`_)
+* chore: upgrade cmake_minimum_required to 3.14 (`#856 <https://github.com/autowarefoundation/autoware.universe/issues/856>`_)
+* refactor: use autoware cmake (`#849 <https://github.com/autowarefoundation/autoware.universe/issues/849>`_)
   * remove autoware_auto_cmake
   * add build_depend of autoware_cmake
   * use autoware_cmake in CMakeLists.txt
   * fix bugs
   * fix cmake lint errors
-* style: fix format of package.xml (`#844 <https://github.com/youtalk/autoware.universe/issues/844>`_)
-* feat: added raw twist in gyro_odometer (`#676 <https://github.com/youtalk/autoware.universe/issues/676>`_)
+* style: fix format of package.xml (`#844 <https://github.com/autowarefoundation/autoware.universe/issues/844>`_)
+* feat: added raw twist in gyro_odometer (`#676 <https://github.com/autowarefoundation/autoware.universe/issues/676>`_)
   * feat: added raw twist output from gyro_odometer
   * fix: prettier
-* fix: localization and perception launch for tutorial (`#645 <https://github.com/youtalk/autoware.universe/issues/645>`_)
+* fix: localization and perception launch for tutorial (`#645 <https://github.com/autowarefoundation/autoware.universe/issues/645>`_)
   * fix: localization and perception launch for tutorial
   * ci(pre-commit): autofix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* ci(pre-commit): update pre-commit-hooks-ros (`#625 <https://github.com/youtalk/autoware.universe/issues/625>`_)
+* ci(pre-commit): update pre-commit-hooks-ros (`#625 <https://github.com/autowarefoundation/autoware.universe/issues/625>`_)
   * ci(pre-commit): update pre-commit-hooks-ros
   * ci(pre-commit): autofix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat(ndt_scan_matcher): add nearest voxel transfromation probability (`#364 <https://github.com/youtalk/autoware.universe/issues/364>`_)
+* feat(ndt_scan_matcher): add nearest voxel transfromation probability (`#364 <https://github.com/autowarefoundation/autoware.universe/issues/364>`_)
   * feat(ndt_scan_matcher): add nearest voxel transfromation probability
   * add calculateTransformationProbability funcs
   * add calculateTransformationProbability funcs
@@ -1422,7 +1422,7 @@ Changelog for package tier4_localization_launch
   * ci(pre-commit): autofix
   * avoid a warning unused parameter
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat(ndt_scan_matcher): add tolerance of initial pose (`#408 <https://github.com/youtalk/autoware.universe/issues/408>`_)
+* feat(ndt_scan_matcher): add tolerance of initial pose (`#408 <https://github.com/autowarefoundation/autoware.universe/issues/408>`_)
   * feat(ndt_scan_matcher): add tolerance of initial pose
   * move codes
   * modify the default value
@@ -1432,15 +1432,15 @@ Changelog for package tier4_localization_launch
   * add depend fmt
   * ci(pre-commit): autofix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat(ndt_scan_matcher): add particles param (`#330 <https://github.com/youtalk/autoware.universe/issues/330>`_)
+* feat(ndt_scan_matcher): add particles param (`#330 <https://github.com/autowarefoundation/autoware.universe/issues/330>`_)
   * feat(ndt_scan_matcher): add particles param
   * fix data type
   * ci(pre-commit): autofix
   * fix data type
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* fix: remove unused param (`#291 <https://github.com/youtalk/autoware.universe/issues/291>`_)
-* fix: typo in localization util.launch.py (`#277 <https://github.com/youtalk/autoware.universe/issues/277>`_)
-* feat: add covariance param (`#281 <https://github.com/youtalk/autoware.universe/issues/281>`_)
+* fix: remove unused param (`#291 <https://github.com/autowarefoundation/autoware.universe/issues/291>`_)
+* fix: typo in localization util.launch.py (`#277 <https://github.com/autowarefoundation/autoware.universe/issues/277>`_)
+* feat: add covariance param (`#281 <https://github.com/autowarefoundation/autoware.universe/issues/281>`_)
   * add covariance param
   * add description
   * add description
@@ -1448,7 +1448,7 @@ Changelog for package tier4_localization_launch
   * refactor
   * ci(pre-commit): autofix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat: change launch package name (`#186 <https://github.com/youtalk/autoware.universe/issues/186>`_)
+* feat: change launch package name (`#186 <https://github.com/autowarefoundation/autoware.universe/issues/186>`_)
   * rename launch folder
   * autoware_launch -> tier4_autoware_launch
   * integration_launch -> tier4_integration_launch

--- a/launch/tier4_map_launch/CHANGELOG.rst
+++ b/launch/tier4_map_launch/CHANGELOG.rst
@@ -5,36 +5,36 @@ Changelog for package tier4_map_launch
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* fix(tier4_map_launch): remove parameter use_intra_process (`#9138 <https://github.com/youtalk/autoware.universe/issues/9138>`_)
-* refactor(map_projection_loader)!: prefix package and namespace with autoware (`#8420 <https://github.com/youtalk/autoware.universe/issues/8420>`_)
+* fix(tier4_map_launch): remove parameter use_intra_process (`#9138 <https://github.com/autowarefoundation/autoware.universe/issues/9138>`_)
+* refactor(map_projection_loader)!: prefix package and namespace with autoware (`#8420 <https://github.com/autowarefoundation/autoware.universe/issues/8420>`_)
   * add autoware\_ prefix
   * add autoware\_ prefix
   ---------
   Co-authored-by: SakodaShintaro <shintaro.sakoda@tier4.jp>
-* fix(map_tf_genrator): fix map launch prefix (`#8598 <https://github.com/youtalk/autoware.universe/issues/8598>`_)
+* fix(map_tf_genrator): fix map launch prefix (`#8598 <https://github.com/autowarefoundation/autoware.universe/issues/8598>`_)
   fix(map_tf_geenrator): fix map launch prefix
-* refactor(map_tf_generator)!: prefix package and namespace with autoware (`#8422 <https://github.com/youtalk/autoware.universe/issues/8422>`_)
+* refactor(map_tf_generator)!: prefix package and namespace with autoware (`#8422 <https://github.com/autowarefoundation/autoware.universe/issues/8422>`_)
   * add autoware\_ prefix
   * add autoware\_ prefix
   ---------
   Co-authored-by: SakodaShintaro <shintaro.sakoda@tier4.jp>
-* chore(localization, map): remove maintainer (`#7940 <https://github.com/youtalk/autoware.universe/issues/7940>`_)
-* chore(map): udpate maintainer (`#7405 <https://github.com/youtalk/autoware.universe/issues/7405>`_)
+* chore(localization, map): remove maintainer (`#7940 <https://github.com/autowarefoundation/autoware.universe/issues/7940>`_)
+* chore(map): udpate maintainer (`#7405 <https://github.com/autowarefoundation/autoware.universe/issues/7405>`_)
   udpate maintainer
-* fix(tier4_map_launch): change log output (`#7289 <https://github.com/youtalk/autoware.universe/issues/7289>`_)
+* fix(tier4_map_launch): change log output (`#7289 <https://github.com/autowarefoundation/autoware.universe/issues/7289>`_)
   change log output from screen to both
   Co-authored-by: SakodaShintaro <shintaro.sakoda@tier4.jp>
 * Contributors: Kosuke Takeuchi, Masaki Baba, Yamato Ando, Yutaka Kondo, cyn-liu, kminoda
 
 0.26.0 (2024-04-03)
 -------------------
-* refactor(map_tf_generator): rework parameters (`#6233 <https://github.com/youtalk/autoware.universe/issues/6233>`_)
+* refactor(map_tf_generator): rework parameters (`#6233 <https://github.com/autowarefoundation/autoware.universe/issues/6233>`_)
   * refactor(map_tf_generator): rework parameters
   * add config
   * style(pre-commit): autofix
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* refactor(map_projection_loader): rework parameters (`#6253 <https://github.com/youtalk/autoware.universe/issues/6253>`_)
+* refactor(map_projection_loader): rework parameters (`#6253 <https://github.com/autowarefoundation/autoware.universe/issues/6253>`_)
   * Extract all params in map_projection_loader to map_projection_loader.param.yaml
   Added launch argument map_projection_loader_param_path to map.launch.xml
   * Added map_projection_loader.schema.json.
@@ -44,17 +44,17 @@ Changelog for package tier4_map_launch
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Kotaro Yoshimoto <pythagora.yoshimoto@gmail.com>
-* chore(tier4_map_launch): add maintainer (`#6284 <https://github.com/youtalk/autoware.universe/issues/6284>`_)
-* refactor(map_launch): use map.launch.xml instead of map.launch.py (`#6185 <https://github.com/youtalk/autoware.universe/issues/6185>`_)
+* chore(tier4_map_launch): add maintainer (`#6284 <https://github.com/autowarefoundation/autoware.universe/issues/6284>`_)
+* refactor(map_launch): use map.launch.xml instead of map.launch.py (`#6185 <https://github.com/autowarefoundation/autoware.universe/issues/6185>`_)
   * refactor(map_launch): use map.launch.xml instead of map.launch.py
   * style(pre-commit): autofix
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* chore: add maintainer in map packages (`#5865 <https://github.com/youtalk/autoware.universe/issues/5865>`_)
+* chore: add maintainer in map packages (`#5865 <https://github.com/autowarefoundation/autoware.universe/issues/5865>`_)
   * add maintainer
   * modify map_tf_generator's maintainer
   ---------
-* fix(map_loader, map_projection_loader): use component interface specs (`#4585 <https://github.com/youtalk/autoware.universe/issues/4585>`_)
+* fix(map_loader, map_projection_loader): use component interface specs (`#4585 <https://github.com/autowarefoundation/autoware.universe/issues/4585>`_)
   * feat(map): use component_interface_specs in map_projection_loader
   * update map_loader
   * style(pre-commit): autofix
@@ -64,7 +64,7 @@ Changelog for package tier4_map_launch
   * fix test
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat(map_projection_loader): add map_projection_loader (`#3986 <https://github.com/youtalk/autoware.universe/issues/3986>`_)
+* feat(map_projection_loader): add map_projection_loader (`#3986 <https://github.com/autowarefoundation/autoware.universe/issues/3986>`_)
   * feat(map_projection_loader): add map_projection_loader
   * style(pre-commit): autofix
   * Update default algorithm
@@ -118,13 +118,13 @@ Changelog for package tier4_map_launch
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Ryohsuke Mitsudome <43976834+mitsudome-r@users.noreply.github.com>
-* style: fix typos (`#3617 <https://github.com/youtalk/autoware.universe/issues/3617>`_)
+* style: fix typos (`#3617 <https://github.com/autowarefoundation/autoware.universe/issues/3617>`_)
   * style: fix typos in documents
   * style: fix typos in package.xml
   * style: fix typos in launch files
   * style: fix typos in comments
   ---------
-* build: mark autoware_cmake as <buildtool_depend> (`#3616 <https://github.com/youtalk/autoware.universe/issues/3616>`_)
+* build: mark autoware_cmake as <buildtool_depend> (`#3616 <https://github.com/autowarefoundation/autoware.universe/issues/3616>`_)
   * build: mark autoware_cmake as <buildtool_depend>
   with <build_depend>, autoware_cmake is automatically exported with ament_target_dependencies() (unecessary)
   * style(pre-commit): autofix
@@ -132,7 +132,7 @@ Changelog for package tier4_map_launch
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Kenji Miyake <kenji.miyake@tier4.jp>
-* feat(map_loader): add selected map loader (`#3286 <https://github.com/youtalk/autoware.universe/issues/3286>`_)
+* feat(map_loader): add selected map loader (`#3286 <https://github.com/autowarefoundation/autoware.universe/issues/3286>`_)
   * add id based map loader
   * add metadata publisher
   * feat(map_loader): add support for sequential_map_loading
@@ -145,7 +145,7 @@ Changelog for package tier4_map_launch
   ---------
   Co-authored-by: Shin-kyoto <58775300+Shin-kyoto@users.noreply.github.com>
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat(map_loader): add grid coordinates for partial/differential map load (`#3205 <https://github.com/youtalk/autoware.universe/issues/3205>`_)
+* feat(map_loader): add grid coordinates for partial/differential map load (`#3205 <https://github.com/autowarefoundation/autoware.universe/issues/3205>`_)
   * feat(map_loader): add grid coordinates for partial/differential map load
   * style(pre-commit): autofix
   * update readme
@@ -155,7 +155,7 @@ Changelog for package tier4_map_launch
   * update readme
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* chore(tier4_map_launch): add lanelet2 config files to tier4_map_launch (`#2670 <https://github.com/youtalk/autoware.universe/issues/2670>`_)
+* chore(tier4_map_launch): add lanelet2 config files to tier4_map_launch (`#2670 <https://github.com/autowarefoundation/autoware.universe/issues/2670>`_)
   * chore(tier4_map_launch): add lanelet2 config files to tier4_map_launch
   Update launch/tier4_map_launch/launch/map.launch.xml
   Co-authored-by: kminoda <44218668+kminoda@users.noreply.github.com>
@@ -163,20 +163,20 @@ Changelog for package tier4_map_launch
   remove config path
   * chore(tier4_map_launch): fix lanelet launch name
   ---------
-* refactor(tier4_map_launch): remove unused config (`#2722 <https://github.com/youtalk/autoware.universe/issues/2722>`_)
+* refactor(tier4_map_launch): remove unused config (`#2722 <https://github.com/autowarefoundation/autoware.universe/issues/2722>`_)
   * refactor(tier4_map_launch): remove unused config
   * load lanelet2 parameter from upper level
   * revert the addition of lanelet2 param
-* revert(tier4_map_launch): move config back to autoware.universe (`#2561 <https://github.com/youtalk/autoware.universe/issues/2561>`_)
+* revert(tier4_map_launch): move config back to autoware.universe (`#2561 <https://github.com/autowarefoundation/autoware.universe/issues/2561>`_)
   * revert(tier4_map_launch): move config back to autoware.universe
   * fix map.launch.xml
-* feat(tier4_map_launch): remove configs and move to autoware_launch (`#2538 <https://github.com/youtalk/autoware.universe/issues/2538>`_)
+* feat(tier4_map_launch): remove configs and move to autoware_launch (`#2538 <https://github.com/autowarefoundation/autoware.universe/issues/2538>`_)
   * feat(tier4_map_launch): remove configs and move to autoware_launch
   * update readme
   * fix readme
   * remove config
   * update readme
-* feat(map_loader): add differential map loading interface (`#2417 <https://github.com/youtalk/autoware.universe/issues/2417>`_)
+* feat(map_loader): add differential map loading interface (`#2417 <https://github.com/autowarefoundation/autoware.universe/issues/2417>`_)
   * first commit
   * ci(pre-commit): autofix
   * added module load in _node.cpp
@@ -186,7 +186,7 @@ Changelog for package tier4_map_launch
   * fix readme
   * ci(pre-commit): autofix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat(map_loader): add downsampled pointcloud publisher (`#2418 <https://github.com/youtalk/autoware.universe/issues/2418>`_)
+* feat(map_loader): add downsampled pointcloud publisher (`#2418 <https://github.com/autowarefoundation/autoware.universe/issues/2418>`_)
   * first commit
   * debugged
   * update readme
@@ -198,7 +198,7 @@ Changelog for package tier4_map_launch
   * set default param to false
   * ci(pre-commit): autofix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat(map_loader): add partial map loading interface in pointcloud_map_loader (`#1938 <https://github.com/youtalk/autoware.universe/issues/1938>`_)
+* feat(map_loader): add partial map loading interface in pointcloud_map_loader (`#1938 <https://github.com/autowarefoundation/autoware.universe/issues/1938>`_)
   * first commit
   * reverted unnecessary modification
   * ci(pre-commit): autofix
@@ -248,13 +248,13 @@ Changelog for package tier4_map_launch
   * remove fmt from target_link_libraries in test
   * minor fix in cmakelists.txt
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* chore(tier4_map_launch): add maintainers (`#2416 <https://github.com/youtalk/autoware.universe/issues/2416>`_)
-* ci(pre-commit): format SVG files (`#2172 <https://github.com/youtalk/autoware.universe/issues/2172>`_)
+* chore(tier4_map_launch): add maintainers (`#2416 <https://github.com/autowarefoundation/autoware.universe/issues/2416>`_)
+* ci(pre-commit): format SVG files (`#2172 <https://github.com/autowarefoundation/autoware.universe/issues/2172>`_)
   * ci(pre-commit): format SVG files
   * ci(pre-commit): autofix
   * apply pre-commit
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* chore(planning/control packages): organized authors and maintainers (`#1610 <https://github.com/youtalk/autoware.universe/issues/1610>`_)
+* chore(planning/control packages): organized authors and maintainers (`#1610 <https://github.com/autowarefoundation/autoware.universe/issues/1610>`_)
   * organized planning authors and maintainers
   * organized control authors and maintainers
   * fix typo
@@ -287,7 +287,7 @@ Changelog for package tier4_map_launch
   * fix
   Co-authored-by: Kenji Miyake <31987104+kenji-miyake@users.noreply.github.com>
   Co-authored-by: Kenji Miyake <kenji.miyake@tier4.jp>
-* feat(map_tf_generator)!: launching planning_simulator without pointcloud map (`#1216 <https://github.com/youtalk/autoware.universe/issues/1216>`_)
+* feat(map_tf_generator)!: launching planning_simulator without pointcloud map (`#1216 <https://github.com/autowarefoundation/autoware.universe/issues/1216>`_)
   * feat(map_tf_generator): add vector map tf generator
   * fix(ad_service_state_monitor): rm unused cofig param
   * chore: change launching vector_map_tf_generator
@@ -303,22 +303,22 @@ Changelog for package tier4_map_launch
   * Update map/map_tf_generator/Readme.md
   Co-authored-by: Kenji Miyake <31987104+kenji-miyake@users.noreply.github.com>
   Co-authored-by: Kenji Miyake <31987104+kenji-miyake@users.noreply.github.com>
-* feat: add parameter argument for lanelet2_map_loader (`#954 <https://github.com/youtalk/autoware.universe/issues/954>`_)
+* feat: add parameter argument for lanelet2_map_loader (`#954 <https://github.com/autowarefoundation/autoware.universe/issues/954>`_)
   * feat: add parameter argument for lanelet2_map_loader
   * feat: add comment
-* refactor: tier4_map_launch (`#953 <https://github.com/youtalk/autoware.universe/issues/953>`_)
+* refactor: tier4_map_launch (`#953 <https://github.com/autowarefoundation/autoware.universe/issues/953>`_)
   * refactor: tier4_map_launch
   * ci(pre-commit): autofix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* chore: upgrade cmake_minimum_required to 3.14 (`#856 <https://github.com/youtalk/autoware.universe/issues/856>`_)
-* refactor: use autoware cmake (`#849 <https://github.com/youtalk/autoware.universe/issues/849>`_)
+* chore: upgrade cmake_minimum_required to 3.14 (`#856 <https://github.com/autowarefoundation/autoware.universe/issues/856>`_)
+* refactor: use autoware cmake (`#849 <https://github.com/autowarefoundation/autoware.universe/issues/849>`_)
   * remove autoware_auto_cmake
   * add build_depend of autoware_cmake
   * use autoware_cmake in CMakeLists.txt
   * fix bugs
   * fix cmake lint errors
-* style: fix format of package.xml (`#844 <https://github.com/youtalk/autoware.universe/issues/844>`_)
-* fix(map_loader): map_loader package not working in UTM coordinates (`#627 <https://github.com/youtalk/autoware.universe/issues/627>`_)
+* style: fix format of package.xml (`#844 <https://github.com/autowarefoundation/autoware.universe/issues/844>`_)
+* fix(map_loader): map_loader package not working in UTM coordinates (`#627 <https://github.com/autowarefoundation/autoware.universe/issues/627>`_)
   * ci(pre-commit): autofix
   * ci(pre-commit): autofix
   * fix(map_loader): add UTM projector to map_loader package
@@ -341,11 +341,11 @@ Changelog for package tier4_map_launch
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: M. Fatih Cırıt <xmfcx@users.noreply.github.com>
   Co-authored-by: Berkay <brkay54@gmail.com>
-* ci(pre-commit): update pre-commit-hooks-ros (`#625 <https://github.com/youtalk/autoware.universe/issues/625>`_)
+* ci(pre-commit): update pre-commit-hooks-ros (`#625 <https://github.com/autowarefoundation/autoware.universe/issues/625>`_)
   * ci(pre-commit): update pre-commit-hooks-ros
   * ci(pre-commit): autofix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat: change launch package name (`#186 <https://github.com/youtalk/autoware.universe/issues/186>`_)
+* feat: change launch package name (`#186 <https://github.com/autowarefoundation/autoware.universe/issues/186>`_)
   * rename launch folder
   * autoware_launch -> tier4_autoware_launch
   * integration_launch -> tier4_integration_launch

--- a/launch/tier4_perception_launch/CHANGELOG.rst
+++ b/launch/tier4_perception_launch/CHANGELOG.rst
@@ -5,7 +5,7 @@ Changelog for package tier4_perception_launch
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* chore(tier4_perception_launch): enable to receive argument `centerpoint_model_name` from autoware_launch (`#9003 <https://github.com/youtalk/autoware.universe/issues/9003>`_)
+* chore(tier4_perception_launch): enable to receive argument `centerpoint_model_name` from autoware_launch (`#9003 <https://github.com/autowarefoundation/autoware.universe/issues/9003>`_)
   * enable to receive arguments
   * adopt transfusion
   * add lidar_detection_model_type
@@ -19,30 +19,30 @@ Changelog for package tier4_perception_launch
   * fix condition when default model name
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* refactor(tier4_perception_launch): remove duplicated parameter declaration (`#9031 <https://github.com/youtalk/autoware.universe/issues/9031>`_)
-* feat(tier4_perception_launch): enable to use multi camera on traffic light recognition (`#8676 <https://github.com/youtalk/autoware.universe/issues/8676>`_)
+* refactor(tier4_perception_launch): remove duplicated parameter declaration (`#9031 <https://github.com/autowarefoundation/autoware.universe/issues/9031>`_)
+* feat(tier4_perception_launch): enable to use multi camera on traffic light recognition (`#8676 <https://github.com/autowarefoundation/autoware.universe/issues/8676>`_)
   * main process
   * style(pre-commit): autofix
   * add exception if input is invalid
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* refactor(autoware_lidar_transfusion): split config (`#8205 <https://github.com/youtalk/autoware.universe/issues/8205>`_)
+* refactor(autoware_lidar_transfusion): split config (`#8205 <https://github.com/autowarefoundation/autoware.universe/issues/8205>`_)
   * refactor(autoware_lidar_transfusion): split config
   * style(pre-commit): autofix
   * chore(autoware_lidar_transfusion): bypass schema CI workflow
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Kenzo Lobos Tsunekawa <kenzo.lobos@tier4.jp>
-* fix(tier4_perception_launch): launch namespace of `detection_by_tracker` (`#8702 <https://github.com/youtalk/autoware.universe/issues/8702>`_)
+* fix(tier4_perception_launch): launch namespace of `detection_by_tracker` (`#8702 <https://github.com/autowarefoundation/autoware.universe/issues/8702>`_)
   fix: namespace of detection_by_tracker do not need to have the prefix `autoware\_`
-* refactor(perception/occupancy_grid_map_outlier_filter): rework parameters (`#6745 <https://github.com/youtalk/autoware.universe/issues/6745>`_)
+* refactor(perception/occupancy_grid_map_outlier_filter): rework parameters (`#6745 <https://github.com/autowarefoundation/autoware.universe/issues/6745>`_)
   * add param and schema file, edit readme
   * .
   * correct linter errors
   ---------
-* fix(tier4_perception_launch): set `use_image_transport` in launch (`#8315 <https://github.com/youtalk/autoware.universe/issues/8315>`_)
+* fix(tier4_perception_launch): set `use_image_transport` in launch (`#8315 <https://github.com/autowarefoundation/autoware.universe/issues/8315>`_)
   set use_image_transport in launch
-* refactor: image transport decompressor/autoware prefix (`#8197 <https://github.com/youtalk/autoware.universe/issues/8197>`_)
+* refactor: image transport decompressor/autoware prefix (`#8197 <https://github.com/autowarefoundation/autoware.universe/issues/8197>`_)
   * refactor: add `autoware` namespace prefix to image_transport_decompressor
   * refactor(image_transport_decompressor): add `autoware` prefix to the package code
   * refactor: update package name in CODEOWNER
@@ -53,13 +53,13 @@ Changelog for package tier4_perception_launch
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Taekjin LEE <taekjin.lee@tier4.jp>
-* refactor: traffic light arbiter/autoware prefix (`#8181 <https://github.com/youtalk/autoware.universe/issues/8181>`_)
+* refactor: traffic light arbiter/autoware prefix (`#8181 <https://github.com/autowarefoundation/autoware.universe/issues/8181>`_)
   * refactor(traffic_light_arbiter): apply `autoware` namespace to traffic_light_arbiter
   * refactor(traffic_light_arbiter): update the package name in CODEWONER
   * style(pre-commit): autofix
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* refactor(probabilistic_occupancy_grid_map, occupancy_grid_map_outlier_filter): add autoware\_ prefix to package name (`#8183 <https://github.com/youtalk/autoware.universe/issues/8183>`_)
+* refactor(probabilistic_occupancy_grid_map, occupancy_grid_map_outlier_filter): add autoware\_ prefix to package name (`#8183 <https://github.com/autowarefoundation/autoware.universe/issues/8183>`_)
   * chore: fix package name probabilistic occupancy grid map
   * fix: solve launch error
   * chore: update occupancy_grid_map_outlier_filter
@@ -69,20 +69,20 @@ Changelog for package tier4_perception_launch
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Taekjin LEE <taekjin.lee@tier4.jp>
-* refactor(elevation_map_loader): add package name prefix `autoware\_`, fix namespace and directory structure (`#7988 <https://github.com/youtalk/autoware.universe/issues/7988>`_)
+* refactor(elevation_map_loader): add package name prefix `autoware\_`, fix namespace and directory structure (`#7988 <https://github.com/autowarefoundation/autoware.universe/issues/7988>`_)
   * refactor: add namespace, remove unused dependencies, file structure
   chore: remove unused dependencies
   style(pre-commit): autofix
   * refactor: rename elevation_map_loader to autoware_elevation_map_loader
   Rename the `elevation_map_loader` package to `autoware_elevation_map_loader` to align with the Autoware naming convention.
   style(pre-commit): autofix
-* refactor(tensorrt_yolox)!: fix namespace and directory structure (`#7992 <https://github.com/youtalk/autoware.universe/issues/7992>`_)
+* refactor(tensorrt_yolox)!: fix namespace and directory structure (`#7992 <https://github.com/autowarefoundation/autoware.universe/issues/7992>`_)
   * refactor: add autoware namespace prefix to `tensorrt_yolox`
   * refactor: apply `autoware` namespace to tensorrt_yolox
   * chore: update CODEOWNERS
   * fix: resolve `yolox_tiny` to work
   ---------
-* refactor(traffic_light\_*)!: add package name prefix of autoware\_ (`#8159 <https://github.com/youtalk/autoware.universe/issues/8159>`_)
+* refactor(traffic_light\_*)!: add package name prefix of autoware\_ (`#8159 <https://github.com/autowarefoundation/autoware.universe/issues/8159>`_)
   * chore: rename traffic_light_fine_detector to autoware_traffic_light_fine_detector
   * chore: rename traffic_light_multi_camera_fusion to autoware_traffic_light_multi_camera_fusion
   * chore: rename traffic_light_occlusion_predictor to autoware_traffic_light_occlusion_predictor
@@ -90,29 +90,29 @@ Changelog for package tier4_perception_launch
   * chore: rename traffic_light_map_based_detector to autoware_traffic_light_map_based_detector
   * chore: rename traffic_light_visualization to autoware_traffic_light_visualization
   ---------
-* refactor(lidar_apollo_instance_segmentation)!: fix namespace and directory structure (`#7995 <https://github.com/youtalk/autoware.universe/issues/7995>`_)
+* refactor(lidar_apollo_instance_segmentation)!: fix namespace and directory structure (`#7995 <https://github.com/autowarefoundation/autoware.universe/issues/7995>`_)
   * refactor: add autoware namespace prefix
   * chore: update CODEOWNERS
   * refactor: add `autoware` prefix
   ---------
-* refactor(image_projection_based_fusion)!: add package name prefix of autoware\_ (`#8162 <https://github.com/youtalk/autoware.universe/issues/8162>`_)
+* refactor(image_projection_based_fusion)!: add package name prefix of autoware\_ (`#8162 <https://github.com/autowarefoundation/autoware.universe/issues/8162>`_)
   refactor: rename image_projection_based_fusion to autoware_image_projection_based_fusion
-* refactor(compare_map_segmentation): add package name prefix of autoware\_ (`#8005 <https://github.com/youtalk/autoware.universe/issues/8005>`_)
+* refactor(compare_map_segmentation): add package name prefix of autoware\_ (`#8005 <https://github.com/autowarefoundation/autoware.universe/issues/8005>`_)
   * refactor(compare_map_segmentation): add package name prefix of autoware\_
   * docs: update Readme
   ---------
-* refactor(shape_estimation): add package name prefix of autoware\_ (`#7999 <https://github.com/youtalk/autoware.universe/issues/7999>`_)
+* refactor(shape_estimation): add package name prefix of autoware\_ (`#7999 <https://github.com/autowarefoundation/autoware.universe/issues/7999>`_)
   * refactor(shape_estimation): add package name prefix of autoware\_
   * style(pre-commit): autofix
   * fix: mising prefix
   * fix: cmake
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* refactor(ground_segmentation)!: add package name prefix of autoware\_ (`#8135 <https://github.com/youtalk/autoware.universe/issues/8135>`_)
+* refactor(ground_segmentation)!: add package name prefix of autoware\_ (`#8135 <https://github.com/autowarefoundation/autoware.universe/issues/8135>`_)
   * refactor(ground_segmentation): add package name prefix of autoware\_
   * fix: update prefix cmake
   ---------
-* refactor(lidar_centerpoint)!: fix namespace and directory structure (`#8049 <https://github.com/youtalk/autoware.universe/issues/8049>`_)
+* refactor(lidar_centerpoint)!: fix namespace and directory structure (`#8049 <https://github.com/autowarefoundation/autoware.universe/issues/8049>`_)
   * add prefix in lidar_centerpoint
   * add .gitignore
   * change include package name in image_projection_based fusion
@@ -132,11 +132,11 @@ Changelog for package tier4_perception_launch
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Kenzo Lobos Tsunekawa <kenzo.lobos@tier4.jp>
-* refactor(detected_object_validation)!: add package name prefix of autoware\_ (`#8122 <https://github.com/youtalk/autoware.universe/issues/8122>`_)
+* refactor(detected_object_validation)!: add package name prefix of autoware\_ (`#8122 <https://github.com/autowarefoundation/autoware.universe/issues/8122>`_)
   refactor: rename detected_object_validation to autoware_detected_object_validation
-* refactor(detected_object_feature_remover)!: add package name prefix of autoware\_ (`#8127 <https://github.com/youtalk/autoware.universe/issues/8127>`_)
+* refactor(detected_object_feature_remover)!: add package name prefix of autoware\_ (`#8127 <https://github.com/autowarefoundation/autoware.universe/issues/8127>`_)
   refactor(detected_object_feature_remover): add package name prefix of autoware\_
-* refactor(pointcloud_preprocessor): prefix package and namespace with autoware (`#7983 <https://github.com/youtalk/autoware.universe/issues/7983>`_)
+* refactor(pointcloud_preprocessor): prefix package and namespace with autoware (`#7983 <https://github.com/autowarefoundation/autoware.universe/issues/7983>`_)
   * refactor(pointcloud_preprocessor)!: prefix package and namespace with autoware
   * style(pre-commit): autofix
   * style(pointcloud_preprocessor): suppress line length check for macros
@@ -150,15 +150,15 @@ Changelog for package tier4_perception_launch
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Kenzo Lobos Tsunekawa <kenzo.lobos@tier4.jp>
-* refactor(traffic_light_visualization): fix namespace and directory structure (`#7968 <https://github.com/youtalk/autoware.universe/issues/7968>`_)
+* refactor(traffic_light_visualization): fix namespace and directory structure (`#7968 <https://github.com/autowarefoundation/autoware.universe/issues/7968>`_)
   * feat: namespace fix and directory structure
   * chore: Remove main.cpp and implement node by template
   ---------
-* refactor(traffic_light_fine_detector): fix namespace and directory structure (`#7973 <https://github.com/youtalk/autoware.universe/issues/7973>`_)
+* refactor(traffic_light_fine_detector): fix namespace and directory structure (`#7973 <https://github.com/autowarefoundation/autoware.universe/issues/7973>`_)
   * refactor: add autoware on the namespace
   * refactor: rename nodelet to node
   ---------
-* refactor(lidar_transfusion)!: fix namespace and directory structure (`#8022 <https://github.com/youtalk/autoware.universe/issues/8022>`_)
+* refactor(lidar_transfusion)!: fix namespace and directory structure (`#8022 <https://github.com/autowarefoundation/autoware.universe/issues/8022>`_)
   * add prefix
   * add prefix in code owner
   * style(pre-commit): autofix
@@ -167,31 +167,31 @@ Changelog for package tier4_perception_launch
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Amadeusz Szymko <amadeusz.szymko.2@tier4.jp>
   Co-authored-by: Kenzo Lobos Tsunekawa <kenzo.lobos@tier4.jp>
-* refactor(euclidean_cluster): add package name prefix of autoware\_ (`#8003 <https://github.com/youtalk/autoware.universe/issues/8003>`_)
+* refactor(euclidean_cluster): add package name prefix of autoware\_ (`#8003 <https://github.com/autowarefoundation/autoware.universe/issues/8003>`_)
   * refactor(euclidean_cluster): add package name prefix of autoware\_
   * style(pre-commit): autofix
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* refactor(traffic_light_classifier): fix namespace and directory structure (`#7970 <https://github.com/youtalk/autoware.universe/issues/7970>`_)
+* refactor(traffic_light_classifier): fix namespace and directory structure (`#7970 <https://github.com/autowarefoundation/autoware.universe/issues/7970>`_)
   * refactor: update namespace for traffic light classifier code
   * refactor: directory structure
   ---------
-* fix(tier4_perception_launch): delete unnecessary dependency (`#8101 <https://github.com/youtalk/autoware.universe/issues/8101>`_)
+* fix(tier4_perception_launch): delete unnecessary dependency (`#8101 <https://github.com/autowarefoundation/autoware.universe/issues/8101>`_)
   delete cluster merger
-* refactor(multi_object_tracker)!: add package name prefix of autoware\_ (`#8083 <https://github.com/youtalk/autoware.universe/issues/8083>`_)
+* refactor(multi_object_tracker)!: add package name prefix of autoware\_ (`#8083 <https://github.com/autowarefoundation/autoware.universe/issues/8083>`_)
   * refactor: rename multi_object_tracker package to autoware_multi_object_tracker
   * style(pre-commit): autofix
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* refactor(autoware_tracking_object_merger): move headers to include/autoware and rename package (`#7809 <https://github.com/youtalk/autoware.universe/issues/7809>`_)
-* refactor(autoware_object_merger): move headers to src and rename package (`#7804 <https://github.com/youtalk/autoware.universe/issues/7804>`_)
-* refactor(detection_by_tracker): add package name prefix of autoware\_ (`#7998 <https://github.com/youtalk/autoware.universe/issues/7998>`_)
-* refactor(raindrop_cluster_filter): add package name prefix of autoware\_ (`#8000 <https://github.com/youtalk/autoware.universe/issues/8000>`_)
+* refactor(autoware_tracking_object_merger): move headers to include/autoware and rename package (`#7809 <https://github.com/autowarefoundation/autoware.universe/issues/7809>`_)
+* refactor(autoware_object_merger): move headers to src and rename package (`#7804 <https://github.com/autowarefoundation/autoware.universe/issues/7804>`_)
+* refactor(detection_by_tracker): add package name prefix of autoware\_ (`#7998 <https://github.com/autowarefoundation/autoware.universe/issues/7998>`_)
+* refactor(raindrop_cluster_filter): add package name prefix of autoware\_ (`#8000 <https://github.com/autowarefoundation/autoware.universe/issues/8000>`_)
   * refactor(raindrop_cluster_filter): add package name prefix of autoware\_
   * fix: typo
   ---------
-* refactor(cluster_merger): add package name prefix of autoware\_ (`#8001 <https://github.com/youtalk/autoware.universe/issues/8001>`_)
-* refactor(radar)!: add package name prefix of autoware\_ (`#7892 <https://github.com/youtalk/autoware.universe/issues/7892>`_)
+* refactor(cluster_merger): add package name prefix of autoware\_ (`#8001 <https://github.com/autowarefoundation/autoware.universe/issues/8001>`_)
+* refactor(radar)!: add package name prefix of autoware\_ (`#7892 <https://github.com/autowarefoundation/autoware.universe/issues/7892>`_)
   * refactor: rename radar_object_tracker
   * refactor: rename package from radar_object_tracker to autoware_radar_object_tracker
   * refactor: rename package from radar_object_clustering to autoware_radar_object_clustering
@@ -201,16 +201,16 @@ Changelog for package tier4_perception_launch
   * refactor: rename object_range_splitter to autoware_object_range_splitter
   * refactor: update readme
   ---------
-* refactor(compare_map_segmentation)!: fix namespace and directory structure (`#7910 <https://github.com/youtalk/autoware.universe/issues/7910>`_)
+* refactor(compare_map_segmentation)!: fix namespace and directory structure (`#7910 <https://github.com/autowarefoundation/autoware.universe/issues/7910>`_)
   * feat: update namespace and directory structure for compare_map_segmentation code
   * refactor: update  directory structure
   * fix: add missing include
   * style(pre-commit): autofix
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* chore: add missing dependency (`#7919 <https://github.com/youtalk/autoware.universe/issues/7919>`_)
+* chore: add missing dependency (`#7919 <https://github.com/autowarefoundation/autoware.universe/issues/7919>`_)
   add raindrop_cluster_filter dependency
-* feat: migrating pointcloud types (`#6996 <https://github.com/youtalk/autoware.universe/issues/6996>`_)
+* feat: migrating pointcloud types (`#6996 <https://github.com/autowarefoundation/autoware.universe/issues/6996>`_)
   * feat: changed most of sensing to the new type
   * chore: started applying changes to the perception stack
   * feat: confirmed operation until centerpoint
@@ -230,9 +230,9 @@ Changelog for package tier4_perception_launch
   ---------
   Co-authored-by: kminoda <44218668+kminoda@users.noreply.github.com>
   Co-authored-by: badai nguyen <94814556+badai-nguyen@users.noreply.github.com>
-* refactor(tier4_perception_launch): add maintainer to tier4_perception_launch (`#7893 <https://github.com/youtalk/autoware.universe/issues/7893>`_)
+* refactor(tier4_perception_launch): add maintainer to tier4_perception_launch (`#7893 <https://github.com/autowarefoundation/autoware.universe/issues/7893>`_)
   refactor: add maintainer to tier4_perception_launch
-* feat(tier4_perception_launch): add image segmentation based pointcloud filter (`#7225 <https://github.com/youtalk/autoware.universe/issues/7225>`_)
+* feat(tier4_perception_launch): add image segmentation based pointcloud filter (`#7225 <https://github.com/autowarefoundation/autoware.universe/issues/7225>`_)
   * feat(tier4_perception_launch): add image segmentation based pointcloud filter
   * chore: typo
   * fix: detection launch
@@ -240,9 +240,9 @@ Changelog for package tier4_perception_launch
   * Revert "chore: add maintainer"
   This reverts commit 5adfef6e9ca8196d3ba88ad574b2ba35489a5e49.
   ---------
-* refactor(occupancy_grid_map_outlier_filter)!: fix namespace and directory structure (`#7748 <https://github.com/youtalk/autoware.universe/issues/7748>`_)
+* refactor(occupancy_grid_map_outlier_filter)!: fix namespace and directory structure (`#7748 <https://github.com/autowarefoundation/autoware.universe/issues/7748>`_)
   chore: update namespace and file structure
-* refactor(ground_segmentation)!: fix namespace and directory structure (`#7744 <https://github.com/youtalk/autoware.universe/issues/7744>`_)
+* refactor(ground_segmentation)!: fix namespace and directory structure (`#7744 <https://github.com/autowarefoundation/autoware.universe/issues/7744>`_)
   * refactor: update namespace in ground_segmentation files
   * refactor: update namespace in ground_segmentation files
   * refactor: update ground_segmentation namespace and file structure
@@ -251,13 +251,13 @@ Changelog for package tier4_perception_launch
   * refactor: update ransac tester
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* fix(ground_segmentation): fix bug  (`#7771 <https://github.com/youtalk/autoware.universe/issues/7771>`_)
-* feat(tier4_perception_launch): add missing arg use_multi_channel_tracker_merger (`#7705 <https://github.com/youtalk/autoware.universe/issues/7705>`_)
+* fix(ground_segmentation): fix bug  (`#7771 <https://github.com/autowarefoundation/autoware.universe/issues/7771>`_)
+* feat(tier4_perception_launch): add missing arg use_multi_channel_tracker_merger (`#7705 <https://github.com/autowarefoundation/autoware.universe/issues/7705>`_)
   * feat(tier4_perception_launch): add missing arg use_multi_channel_tracker_merger
   * feat: add use_multi_channel_tracker_merger argument to simulator launch
   This commit adds the `use_multi_channel_tracker_merger` argument to the simulator launch file. The argument is set to `false` by default. This change enables the use of the multi-channel tracker merger in the simulator.
   ---------
-* feat(tier4_perception_launch): enable multi channel tracker merger (`#7459 <https://github.com/youtalk/autoware.universe/issues/7459>`_)
+* feat(tier4_perception_launch): enable multi channel tracker merger (`#7459 <https://github.com/autowarefoundation/autoware.universe/issues/7459>`_)
   * feat: introduce multi channel tracker merger
   feat: separate filters
   feat: filtering camera lidar fusion
@@ -282,7 +282,7 @@ Changelog for package tier4_perception_launch
   * fix: group to avoid argument mixture
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* chore(tier4_perception_launch): perception launcher refactoring second round (`#7440 <https://github.com/youtalk/autoware.universe/issues/7440>`_)
+* chore(tier4_perception_launch): perception launcher refactoring second round (`#7440 <https://github.com/autowarefoundation/autoware.universe/issues/7440>`_)
   * feat: separate filters
   * fix: object validator to modular
   * chore: remove default values from subsequent launch files
@@ -305,9 +305,9 @@ Changelog for package tier4_perception_launch
   * fix: radar object filter parameter
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* ci(pre-commit): autoupdate (`#7499 <https://github.com/youtalk/autoware.universe/issues/7499>`_)
+* ci(pre-commit): autoupdate (`#7499 <https://github.com/autowarefoundation/autoware.universe/issues/7499>`_)
   Co-authored-by: M. Fatih Cırıt <mfc@leodrive.ai>
-* chore(tier4_perception_launch): perception launcher refactoring (`#7194 <https://github.com/youtalk/autoware.universe/issues/7194>`_)
+* chore(tier4_perception_launch): perception launcher refactoring (`#7194 <https://github.com/autowarefoundation/autoware.universe/issues/7194>`_)
   * fix: reorder object merger launchers
   * fix: separate detection by tracker launch
   * fix: refactor tracking launch
@@ -322,12 +322,12 @@ Changelog for package tier4_perception_launch
   * fix: rename radar detector to filter
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* fix(tier4_perception_launch): enable low_intensity_filter as default (`#7390 <https://github.com/youtalk/autoware.universe/issues/7390>`_)
-* refactor(crosswalk_traffic_light_estimator)!: add autoware\_ prefix (`#7365 <https://github.com/youtalk/autoware.universe/issues/7365>`_)
+* fix(tier4_perception_launch): enable low_intensity_filter as default (`#7390 <https://github.com/autowarefoundation/autoware.universe/issues/7390>`_)
+* refactor(crosswalk_traffic_light_estimator)!: add autoware\_ prefix (`#7365 <https://github.com/autowarefoundation/autoware.universe/issues/7365>`_)
   * add prefix
-* chore(tier4_perception_launch): rename autoware_map_based_prediction_depend (`#7395 <https://github.com/youtalk/autoware.universe/issues/7395>`_)
-* refactor(map_based_prediction): prefix map based prediction (`#7391 <https://github.com/youtalk/autoware.universe/issues/7391>`_)
-* feat(lidar_transfusion): add lidar_transfusion 3D detection package (`#6890 <https://github.com/youtalk/autoware.universe/issues/6890>`_)
+* chore(tier4_perception_launch): rename autoware_map_based_prediction_depend (`#7395 <https://github.com/autowarefoundation/autoware.universe/issues/7395>`_)
+* refactor(map_based_prediction): prefix map based prediction (`#7391 <https://github.com/autowarefoundation/autoware.universe/issues/7391>`_)
+* feat(lidar_transfusion): add lidar_transfusion 3D detection package (`#6890 <https://github.com/autowarefoundation/autoware.universe/issues/6890>`_)
   * feat(lidar_transfusion): add lidar_transfusion 3D detection package
   * style(pre-commit): autofix
   * style(lidar_transfusion): cpplint
@@ -371,7 +371,7 @@ Changelog for package tier4_perception_launch
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Kenzo Lobos Tsunekawa <kenzo.lobos@tier4.jp>
-* feat!: replace autoware_auto_msgs with autoware_msgs for launch files (`#7242 <https://github.com/youtalk/autoware.universe/issues/7242>`_)
+* feat!: replace autoware_auto_msgs with autoware_msgs for launch files (`#7242 <https://github.com/autowarefoundation/autoware.universe/issues/7242>`_)
   * feat!: replace autoware_auto_msgs with autoware_msgs for launch files
   Co-authored-by: Cynthia Liu <cynthia.liu@autocore.ai>
   Co-authored-by: NorahXiong <norah.xiong@autocore.ai>
@@ -382,7 +382,7 @@ Changelog for package tier4_perception_launch
   Co-authored-by: NorahXiong <norah.xiong@autocore.ai>
   Co-authored-by: beginningfan <beginning.fan@autocore.ai>
   Co-authored-by: Yukihiro Saito <yukky.saito@gmail.com>
-* feat(multi_object_tracker): multi object input (`#6820 <https://github.com/youtalk/autoware.universe/issues/6820>`_)
+* feat(multi_object_tracker): multi object input (`#6820 <https://github.com/autowarefoundation/autoware.universe/issues/6820>`_)
   * refactor: frequently used types, namespace
   * test: multiple inputs
   * feat: check latest measurement time
@@ -455,7 +455,7 @@ Changelog for package tier4_perception_launch
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Shunsuke Miura <37187849+miursh@users.noreply.github.com>
-* feat(tier4_perception_launch): fix typo error (`#6999 <https://github.com/youtalk/autoware.universe/issues/6999>`_)
+* feat(tier4_perception_launch): fix typo error (`#6999 <https://github.com/autowarefoundation/autoware.universe/issues/6999>`_)
   * feat: downsample perception input pointcloud
   * fix: add group if to switch downsample node
   * fix: add test and exec depend
@@ -465,7 +465,7 @@ Changelog for package tier4_perception_launch
   * fix: fix name
   ---------
   Co-authored-by: Yukihiro Saito <yukky.saito@gmail.com>
-* feat(tier4_perception_launch): downsample perception input pointcloud (`#6886 <https://github.com/youtalk/autoware.universe/issues/6886>`_)
+* feat(tier4_perception_launch): downsample perception input pointcloud (`#6886 <https://github.com/autowarefoundation/autoware.universe/issues/6886>`_)
   * feat: downsample perception input pointcloud
   * fix: add group if to switch downsample node
   * fix: add test and exec depend
@@ -474,15 +474,15 @@ Changelog for package tier4_perception_launch
   * chore: refactor perception.launch.xml
   ---------
   Co-authored-by: Yukihiro Saito <yukky.saito@gmail.com>
-* feat: add low_intensity_cluster_filter (`#6850 <https://github.com/youtalk/autoware.universe/issues/6850>`_)
+* feat: add low_intensity_cluster_filter (`#6850 <https://github.com/autowarefoundation/autoware.universe/issues/6850>`_)
   * feat: add low_intensity_cluster_filter
   * chore: typo
   * fix: build test error
   ---------
-* fix(voxel_grid_downsample_filter): add intensity field (`#6849 <https://github.com/youtalk/autoware.universe/issues/6849>`_)
+* fix(voxel_grid_downsample_filter): add intensity field (`#6849 <https://github.com/autowarefoundation/autoware.universe/issues/6849>`_)
   fix(downsample_filter): add intensity field
-* fix(lidar_centerpoint): add param file for centerpoint_tiny (`#6901 <https://github.com/youtalk/autoware.universe/issues/6901>`_)
-* refactor(centerpoint, pointpainting): rearrange parameters for ML models and packages (`#6591 <https://github.com/youtalk/autoware.universe/issues/6591>`_)
+* fix(lidar_centerpoint): add param file for centerpoint_tiny (`#6901 <https://github.com/autowarefoundation/autoware.universe/issues/6901>`_)
+* refactor(centerpoint, pointpainting): rearrange parameters for ML models and packages (`#6591 <https://github.com/autowarefoundation/autoware.universe/issues/6591>`_)
   * refactor: lidar_centerpoint
   * refactor: pointpainting
   * chore: fix launch
@@ -506,11 +506,11 @@ Changelog for package tier4_perception_launch
   ---------
   Co-authored-by: Kenzo Lobos Tsunekawa <kenzo.lobos@tier4.jp>
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* fix(tier4_perception_launch): change traffic light recognition pipeline (`#6879 <https://github.com/youtalk/autoware.universe/issues/6879>`_)
+* fix(tier4_perception_launch): change traffic light recognition pipeline (`#6879 <https://github.com/autowarefoundation/autoware.universe/issues/6879>`_)
   style(pre-commit): autofix
   refactor: topic name
-* feat(perception_online_evaluator): add use_perception_online_evaluator option and disable it by default (`#6861 <https://github.com/youtalk/autoware.universe/issues/6861>`_)
-* feat(lidar_centerpoint): output the covariance of pose and twist (`#6573 <https://github.com/youtalk/autoware.universe/issues/6573>`_)
+* feat(perception_online_evaluator): add use_perception_online_evaluator option and disable it by default (`#6861 <https://github.com/autowarefoundation/autoware.universe/issues/6861>`_)
+* feat(lidar_centerpoint): output the covariance of pose and twist (`#6573 <https://github.com/autowarefoundation/autoware.universe/issues/6573>`_)
   * feat: postprocess variance
   * feat: output variance
   * feat: add has_variance to config
@@ -531,13 +531,13 @@ Changelog for package tier4_perception_launch
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Yoshi Ri <yoshiyoshidetteiu@gmail.com>
   Co-authored-by: Taekjin LEE <technolojin@gmail.com>
-* fix(ground_segmentation launch): fix topic name conflict in additional_lidars option (`#6801 <https://github.com/youtalk/autoware.universe/issues/6801>`_)
+* fix(ground_segmentation launch): fix topic name conflict in additional_lidars option (`#6801 <https://github.com/autowarefoundation/autoware.universe/issues/6801>`_)
   fix(ground_segmentation launch): fix topic name conflict when using additional lidars
 * Contributors: Amadeusz Szymko, Esteve Fernandez, Kenzo Lobos Tsunekawa, Kosuke Takeuchi, Kotaro Uetake, Mamoru Sobue, Manato Hirabayashi, Masato Saeki, Mehmet Emin BAŞOĞLU, Ryohsuke Mitsudome, Shunsuke Miura, Taekjin LEE, Tao Zhong, Yoshi Ri, Yuki TAKAGI, Yutaka Kondo, awf-autoware-bot[bot], badai nguyen, oguzkaganozt
 
 0.26.0 (2024-04-03)
 -------------------
-* feat(probabilistic_occupancy_grid_map): add synchronized ogm fusion node (`#5485 <https://github.com/youtalk/autoware.universe/issues/5485>`_)
+* feat(probabilistic_occupancy_grid_map): add synchronized ogm fusion node (`#5485 <https://github.com/autowarefoundation/autoware.universe/issues/5485>`_)
   * add synchronized ogm fusion node
   * add launch test for grid map fusion node
   * fix test cases input msg error
@@ -552,15 +552,15 @@ Changelog for package tier4_perception_launch
   * chore: fix ogm pointcloud subscription
   * feat: enable to publish pipeline latency
   ---------
-* chore(ground_segmentation_launch): change max_z of cropbox filter to vehicle_height (`#6549 <https://github.com/youtalk/autoware.universe/issues/6549>`_)
+* chore(ground_segmentation_launch): change max_z of cropbox filter to vehicle_height (`#6549 <https://github.com/autowarefoundation/autoware.universe/issues/6549>`_)
   * chore(ground_segmentation_launch): change max_z of cropbox filter to vehicle_height
   * fix: typo
   ---------
-* chore(ground_segmentation): rename topic and node (`#6536 <https://github.com/youtalk/autoware.universe/issues/6536>`_)
+* chore(ground_segmentation): rename topic and node (`#6536 <https://github.com/autowarefoundation/autoware.universe/issues/6536>`_)
   * chore(ground_segmentation): rename topic and node
   * docs: update synchronized_grid_map_fusion
   ---------
-* feat(perception_online_evaluator): add perception_online_evaluator (`#6493 <https://github.com/youtalk/autoware.universe/issues/6493>`_)
+* feat(perception_online_evaluator): add perception_online_evaluator (`#6493 <https://github.com/autowarefoundation/autoware.universe/issues/6493>`_)
   * feat(perception_evaluator): add perception_evaluator
   tmp
   update
@@ -578,14 +578,14 @@ Changelog for package tier4_perception_launch
   * feat: add test
   * fix: ci check
   ---------
-* chore(image_projection_based_fusion): rename debug topics (`#6418 <https://github.com/youtalk/autoware.universe/issues/6418>`_)
+* chore(image_projection_based_fusion): rename debug topics (`#6418 <https://github.com/autowarefoundation/autoware.universe/issues/6418>`_)
   * chore(image_projection_based_fusion): rename debug topics
   * style(pre-commit): autofix
   * fix: roi_pointcloud_fusion namespace
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* fix: remove `tensorrt_yolo` from package dependencies in launcher (`#6377 <https://github.com/youtalk/autoware.universe/issues/6377>`_)
-* chore(traffic_light_map_based_detector): rework parameters (`#6200 <https://github.com/youtalk/autoware.universe/issues/6200>`_)
+* fix: remove `tensorrt_yolo` from package dependencies in launcher (`#6377 <https://github.com/autowarefoundation/autoware.universe/issues/6377>`_)
+* chore(traffic_light_map_based_detector): rework parameters (`#6200 <https://github.com/autowarefoundation/autoware.universe/issues/6200>`_)
   * chore: use config
   * chore: use config
   * fix: revert min_timestamp_offset
@@ -600,31 +600,31 @@ Changelog for package tier4_perception_launch
   Co-authored-by: kminoda <44218668+kminoda@users.noreply.github.com>
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: kminoda <koji.minoda@tier4.jp>
-* feat(tensorrt_yolo): remove package (`#6361 <https://github.com/youtalk/autoware.universe/issues/6361>`_)
+* feat(tensorrt_yolo): remove package (`#6361 <https://github.com/autowarefoundation/autoware.universe/issues/6361>`_)
   * feat(tensorrt_yolo): remove package
   * remove tensorrt_yolo inclusion
   * feat: add multiple yolox launcher
   ---------
   Co-authored-by: Shunsuke Miura <shunsuke.miura@tier4.jp>
-* chore(traffic_light_fine_detector_and_classifier): rework parameters (`#6216 <https://github.com/youtalk/autoware.universe/issues/6216>`_)
+* chore(traffic_light_fine_detector_and_classifier): rework parameters (`#6216 <https://github.com/autowarefoundation/autoware.universe/issues/6216>`_)
   * chore: use config
   * style(pre-commit): autofix
   * chore: move build only back
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* chore(object_merger): rework parameters (`#6160 <https://github.com/youtalk/autoware.universe/issues/6160>`_)
+* chore(object_merger): rework parameters (`#6160 <https://github.com/autowarefoundation/autoware.universe/issues/6160>`_)
   * chore(object_merger): parametrize some parameters
   * style(pre-commit): autofix
   * revert priority_mode
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* chore(radar_object_tracker): move tracker config directory to parameter yaml (`#6250 <https://github.com/youtalk/autoware.universe/issues/6250>`_)
+* chore(radar_object_tracker): move tracker config directory to parameter yaml (`#6250 <https://github.com/autowarefoundation/autoware.universe/issues/6250>`_)
   * chore: move tracker config directory to parameter yaml
   * fix: add allow_substs to fix error
   * fix: use radar tracking parameter from autoware_launch
   ---------
   Co-authored-by: kminoda <44218668+kminoda@users.noreply.github.com>
-* feat: remove use_pointcloud_container (`#6115 <https://github.com/youtalk/autoware.universe/issues/6115>`_)
+* feat: remove use_pointcloud_container (`#6115 <https://github.com/autowarefoundation/autoware.universe/issues/6115>`_)
   * feat!: remove use_pointcloud_container
   * fix pre-commit
   * fix: completely remove use_pointcloud_container after merge main
@@ -632,7 +632,7 @@ Changelog for package tier4_perception_launch
   * revert: revert change in probabilistic_occupancy_grid_map
   * revert change in launcher of ogm
   ---------
-* chore(lidar_centerpoint): rework parameters (`#6167 <https://github.com/youtalk/autoware.universe/issues/6167>`_)
+* chore(lidar_centerpoint): rework parameters (`#6167 <https://github.com/autowarefoundation/autoware.universe/issues/6167>`_)
   * chore(lidar_centerpoint): use config
   * revert unnecessary fix
   * fix: revert build_only option
@@ -642,7 +642,7 @@ Changelog for package tier4_perception_launch
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Kenzo Lobos Tsunekawa <kenzo.lobos@tier4.jp>
-* feat(detection): add container option (`#6228 <https://github.com/youtalk/autoware.universe/issues/6228>`_)
+* feat(detection): add container option (`#6228 <https://github.com/autowarefoundation/autoware.universe/issues/6228>`_)
   * feat(lidar_centerpoint,image_projection_based_fusion): add pointcloud_container option
   * revert lidar_perception_model
   * style(pre-commit): autofix
@@ -661,26 +661,26 @@ Changelog for package tier4_perception_launch
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Shunsuke Miura <37187849+miursh@users.noreply.github.com>
   Co-authored-by: Kenzo Lobos Tsunekawa <kenzo.lobos@tier4.jp>
-* chore(tier4_perception_launch): fix arg name radar lanelet filter (`#6215 <https://github.com/youtalk/autoware.universe/issues/6215>`_)
-* chore(radar_crossing_objects_noise_filter): add config file (`#6210 <https://github.com/youtalk/autoware.universe/issues/6210>`_)
+* chore(tier4_perception_launch): fix arg name radar lanelet filter (`#6215 <https://github.com/autowarefoundation/autoware.universe/issues/6215>`_)
+* chore(radar_crossing_objects_noise_filter): add config file (`#6210 <https://github.com/autowarefoundation/autoware.universe/issues/6210>`_)
   * chore(radar_crossing_objects_noise_filter): add config file
   * bug fix
   * merge main branch
   ---------
-* chore(radar_object_clustering): fix config arg name (`#6214 <https://github.com/youtalk/autoware.universe/issues/6214>`_)
-* chore(object_velocity_splitter): rework parameters (`#6158 <https://github.com/youtalk/autoware.universe/issues/6158>`_)
+* chore(radar_object_clustering): fix config arg name (`#6214 <https://github.com/autowarefoundation/autoware.universe/issues/6214>`_)
+* chore(object_velocity_splitter): rework parameters (`#6158 <https://github.com/autowarefoundation/autoware.universe/issues/6158>`_)
   * chore(object_velocity_splitter): add param file
   * fix
   * fix arg name
   * fix: update launch param handling
   ---------
-* fix(tier4_perception_launch): fix a bug in `#6159 <https://github.com/youtalk/autoware.universe/issues/6159>`_ (`#6203 <https://github.com/youtalk/autoware.universe/issues/6203>`_)
-* chore(object_range_splitter): rework parameters (`#6159 <https://github.com/youtalk/autoware.universe/issues/6159>`_)
+* fix(tier4_perception_launch): fix a bug in `#6159 <https://github.com/autowarefoundation/autoware.universe/issues/6159>`_ (`#6203 <https://github.com/autowarefoundation/autoware.universe/issues/6203>`_)
+* chore(object_range_splitter): rework parameters (`#6159 <https://github.com/autowarefoundation/autoware.universe/issues/6159>`_)
   * chore(object_range_splitter): add param file
   * fix arg name
   * feat: use param file from autoware.launch
   ---------
-* refactor(tier4_perception_launch): refactor object_recognition/detection launcher  (`#6152 <https://github.com/youtalk/autoware.universe/issues/6152>`_)
+* refactor(tier4_perception_launch): refactor object_recognition/detection launcher  (`#6152 <https://github.com/autowarefoundation/autoware.universe/issues/6152>`_)
   * refactor: align mode parameters
   * refactor: cluster detector and merger
   * refactor: separate object merger launches
@@ -688,8 +688,8 @@ Changelog for package tier4_perception_launch
   * refactor: lidar detector modules
   * chore: fix mis spell, align typo, clean-up
   ---------
-* chore(pointcloud_container): move glog_component to autoware_launch (`#6114 <https://github.com/youtalk/autoware.universe/issues/6114>`_)
-* feat: always separate lidar preprocessing from pointcloud_container (`#6091 <https://github.com/youtalk/autoware.universe/issues/6091>`_)
+* chore(pointcloud_container): move glog_component to autoware_launch (`#6114 <https://github.com/autowarefoundation/autoware.universe/issues/6114>`_)
+* feat: always separate lidar preprocessing from pointcloud_container (`#6091 <https://github.com/autowarefoundation/autoware.universe/issues/6091>`_)
   * feat!: replace use_pointcloud_container
   * feat: remove from planning
   * fix: fix to remove all use_pointcloud_container
@@ -707,14 +707,14 @@ Changelog for package tier4_perception_launch
   * fix: fix pre-commit
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* fix(pointpainting): fix param path declaration (`#6106 <https://github.com/youtalk/autoware.universe/issues/6106>`_)
+* fix(pointpainting): fix param path declaration (`#6106 <https://github.com/autowarefoundation/autoware.universe/issues/6106>`_)
   * fix(pointpainting): fix param path declaration
   * remove pointpainting_model_name
   * revert: revert unnecessary change
   ---------
-* fix(image_projection_based_fusion): re-organize the parameters for image projection fusion (`#6075 <https://github.com/youtalk/autoware.universe/issues/6075>`_)
+* fix(image_projection_based_fusion): re-organize the parameters for image projection fusion (`#6075 <https://github.com/autowarefoundation/autoware.universe/issues/6075>`_)
   re-organize the parameters for image projection fusion
-* feat(probabilistic_occupancy_grid_map): add grid map fusion node (`#5993 <https://github.com/youtalk/autoware.universe/issues/5993>`_)
+* feat(probabilistic_occupancy_grid_map): add grid map fusion node (`#5993 <https://github.com/autowarefoundation/autoware.universe/issues/5993>`_)
   * add synchronized ogm fusion node
   * add launch test for grid map fusion node
   * fix test cases input msg error
@@ -725,7 +725,7 @@ Changelog for package tier4_perception_launch
   * fix: change ogm fusion node pub policy to reliable
   * chore: remove files outof scope with divied PR
   ---------
-* feat(crosswalk_traffic_light): add detector and classifier for pedestrian traffic light  (`#5871 <https://github.com/youtalk/autoware.universe/issues/5871>`_)
+* feat(crosswalk_traffic_light): add detector and classifier for pedestrian traffic light  (`#5871 <https://github.com/autowarefoundation/autoware.universe/issues/5871>`_)
   * add: crosswalk traffic light recognition
   * fix: set conf=0 when occluded
   * fix: clean code
@@ -789,40 +789,40 @@ Changelog for package tier4_perception_launch
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Yusuke Muramatsu <yukke42@users.noreply.github.com>
-* feat: add support of overwriting signals if harsh backlight is detected (`#5852 <https://github.com/youtalk/autoware.universe/issues/5852>`_)
+* feat: add support of overwriting signals if harsh backlight is detected (`#5852 <https://github.com/autowarefoundation/autoware.universe/issues/5852>`_)
   * feat: add support of overwriting signals if backlit is detected
   * feat: remove default parameter in nodelet and update lauch for composable node
   * docs: update README
   * docs: update README
   * feat: update confidence to 0.0 corresponding signals overwritten by unkonwn
   ---------
-* chore: add glog_component for pointcloud_container (`#5716 <https://github.com/youtalk/autoware.universe/issues/5716>`_)
-* refactor(localization_launch, ground_segmentation_launch): rename lidar topic (`#5781 <https://github.com/youtalk/autoware.universe/issues/5781>`_)
+* chore: add glog_component for pointcloud_container (`#5716 <https://github.com/autowarefoundation/autoware.universe/issues/5716>`_)
+* refactor(localization_launch, ground_segmentation_launch): rename lidar topic (`#5781 <https://github.com/autowarefoundation/autoware.universe/issues/5781>`_)
   rename lidar topic
   Co-authored-by: yamato-ando <Yamato ANDO>
-* fix: add missing param on perception launch: (`#5812 <https://github.com/youtalk/autoware.universe/issues/5812>`_)
+* fix: add missing param on perception launch: (`#5812 <https://github.com/autowarefoundation/autoware.universe/issues/5812>`_)
   detection_by_tracker_param_path was missing
-* refactor(multi_object_tracker): put node parameters to yaml file (`#5769 <https://github.com/youtalk/autoware.universe/issues/5769>`_)
+* refactor(multi_object_tracker): put node parameters to yaml file (`#5769 <https://github.com/autowarefoundation/autoware.universe/issues/5769>`_)
   * rework multi object tracker parameters
   * update README
   * rework radar tracker parameter too
   ---------
-* refactor(tier4_perception_launch): refactor perception launcher (`#5630 <https://github.com/youtalk/autoware.universe/issues/5630>`_)
-* chore(tier4_perception_launcher): remove launch parameter default of detection_by_tracker (`#5664 <https://github.com/youtalk/autoware.universe/issues/5664>`_)
+* refactor(tier4_perception_launch): refactor perception launcher (`#5630 <https://github.com/autowarefoundation/autoware.universe/issues/5630>`_)
+* chore(tier4_perception_launcher): remove launch parameter default of detection_by_tracker (`#5664 <https://github.com/autowarefoundation/autoware.universe/issues/5664>`_)
   * chore(tier4_perception_launcher): remove launch parameter default
   * chore: typo
   ---------
-* feat(radar_object_tracker): Change to use `use_radar_tracking_fusion` as true (`#5605 <https://github.com/youtalk/autoware.universe/issues/5605>`_)
-* refactor(radar_object_clustering): move radar object clustering parameter to param file (`#5451 <https://github.com/youtalk/autoware.universe/issues/5451>`_)
+* feat(radar_object_tracker): Change to use `use_radar_tracking_fusion` as true (`#5605 <https://github.com/autowarefoundation/autoware.universe/issues/5605>`_)
+* refactor(radar_object_clustering): move radar object clustering parameter to param file (`#5451 <https://github.com/autowarefoundation/autoware.universe/issues/5451>`_)
   * move radar object clustering parameter to param file
   * remove default parameter settings and fix cmakelists
   ---------
-* build(tier4_perception_launch): add tracking_object_merger (`#5602 <https://github.com/youtalk/autoware.universe/issues/5602>`_)
-* fix(detection_by_tracker): add ignore option for each label (`#5473 <https://github.com/youtalk/autoware.universe/issues/5473>`_)
+* build(tier4_perception_launch): add tracking_object_merger (`#5602 <https://github.com/autowarefoundation/autoware.universe/issues/5602>`_)
+* fix(detection_by_tracker): add ignore option for each label (`#5473 <https://github.com/autowarefoundation/autoware.universe/issues/5473>`_)
   * fix(detection_by_tracker): add ignore for each class
   * fix: launch
   ---------
-* feat(tier4_perception_launch): add parameter to control detection_by_tracker on/off (`#5313 <https://github.com/youtalk/autoware.universe/issues/5313>`_)
+* feat(tier4_perception_launch): add parameter to control detection_by_tracker on/off (`#5313 <https://github.com/autowarefoundation/autoware.universe/issues/5313>`_)
   * add parameter to control detection_by_tracker on/off
   * style(pre-commit): autofix
   * Update launch/tier4_perception_launch/launch/perception.launch.xml
@@ -830,11 +830,11 @@ Changelog for package tier4_perception_launch
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Shunsuke Miura <37187849+miursh@users.noreply.github.com>
-* fix(tracking_object_merger): fix unintended error in radar tracking merger (`#5328 <https://github.com/youtalk/autoware.universe/issues/5328>`_)
+* fix(tracking_object_merger): fix unintended error in radar tracking merger (`#5328 <https://github.com/autowarefoundation/autoware.universe/issues/5328>`_)
   * fix: fix tracking merger node
   * fix: unintended condition setting
   ---------
-* feat(tier4_perception_launch): add radar far object integration in tracking stage (`#5269 <https://github.com/youtalk/autoware.universe/issues/5269>`_)
+* feat(tier4_perception_launch): add radar far object integration in tracking stage (`#5269 <https://github.com/autowarefoundation/autoware.universe/issues/5269>`_)
   * update tracking/perception launch
   * switch tracker launcher mode with argument
   * update prediction to switch by radar_long_range_integration paramter
@@ -847,7 +847,7 @@ Changelog for package tier4_perception_launch
   * refactor: rename and remove paramters in prediction.launch
   * refactor: rename merger control variable from string to bool
   ---------
-* fix(image_projection_based_fusion): add iou_x use in long range for roi_cluster_fusion (`#5148 <https://github.com/youtalk/autoware.universe/issues/5148>`_)
+* fix(image_projection_based_fusion): add iou_x use in long range for roi_cluster_fusion (`#5148 <https://github.com/autowarefoundation/autoware.universe/issues/5148>`_)
   * fix: add iou_x for long range obj
   * fix: add launch file param
   * chore: fix unexpect calc iou in long range
@@ -856,29 +856,29 @@ Changelog for package tier4_perception_launch
   * docs: update readme
   * chore: refactor
   ---------
-* fix(tier4_perception_launch): fix faraway detection to reduce calculation cost (`#5233 <https://github.com/youtalk/autoware.universe/issues/5233>`_)
+* fix(tier4_perception_launch): fix faraway detection to reduce calculation cost (`#5233 <https://github.com/autowarefoundation/autoware.universe/issues/5233>`_)
   * fix(tier4_perception_launch): fix node order in radar_based_detection.launch
   * fix comment out unused node
   ---------
-* fix(detected_object_validation): change the points_num of the validator to be set class by class (`#5177 <https://github.com/youtalk/autoware.universe/issues/5177>`_)
+* fix(detected_object_validation): change the points_num of the validator to be set class by class (`#5177 <https://github.com/autowarefoundation/autoware.universe/issues/5177>`_)
   * fix: add param for each object class
   * fix: add missing classes param
   * fix: launch file
   * fix: typo
   * chore: refactor
   ---------
-* feat(perception_launch): add data_path arg to perception launch (`#5069 <https://github.com/youtalk/autoware.universe/issues/5069>`_)
+* feat(perception_launch): add data_path arg to perception launch (`#5069 <https://github.com/autowarefoundation/autoware.universe/issues/5069>`_)
   * feat(perception_launch): add var data_path to perception.launch
   * feat(perception_launch): update default center_point_model_path
   ---------
-* fix(tier4_perception_launch): add parameters for light weight radar fusion and fix launch order (`#5166 <https://github.com/youtalk/autoware.universe/issues/5166>`_)
+* fix(tier4_perception_launch): add parameters for light weight radar fusion and fix launch order (`#5166 <https://github.com/autowarefoundation/autoware.universe/issues/5166>`_)
   * fix(tier4_perception_launch): add parameters for light weight radar fusion and fix launch order
   * style(pre-commit): autofix
   * add far_object_merger_sync_queue_size param for package arg
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* fix(pointcloud_preprocessor): organize input twist topic (`#5125 <https://github.com/youtalk/autoware.universe/issues/5125>`_)
-  * fix(pointcloud_preprocessor): organize input twist topic (`#25 <https://github.com/youtalk/autoware.universe/issues/25>`_)
+* fix(pointcloud_preprocessor): organize input twist topic (`#5125 <https://github.com/autowarefoundation/autoware.universe/issues/5125>`_)
+  * fix(pointcloud_preprocessor): organize input twist topic (`#25 <https://github.com/autowarefoundation/autoware.universe/issues/25>`_)
   * fix(pointcloud_preprocessor): organize input twist topic
   * style(pre-commit): autofix
   * fix build bug
@@ -893,11 +893,11 @@ Changelog for package tier4_perception_launch
   * style(pre-commit): autofix
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* fix(tier4_perception_launch): add object_merger of far_objects to fusion for Camera-LiDAR-Radar fusion (`#5026 <https://github.com/youtalk/autoware.universe/issues/5026>`_)
+* fix(tier4_perception_launch): add object_merger of far_objects to fusion for Camera-LiDAR-Radar fusion (`#5026 <https://github.com/autowarefoundation/autoware.universe/issues/5026>`_)
   * fix(tier4_perception_launch): add object_merger of far_objects to fusion for Camera-LiDAR-Radar fusion
   * fix conflict
   ---------
-* refactor(perception): rearrange clustering pipeline (`#4999 <https://github.com/youtalk/autoware.universe/issues/4999>`_)
+* refactor(perception): rearrange clustering pipeline (`#4999 <https://github.com/autowarefoundation/autoware.universe/issues/4999>`_)
   * fix: change downsample filter
   * fix: remove downsamle after compare map
   * fix: add low range cropbox
@@ -907,9 +907,9 @@ Changelog for package tier4_perception_launch
   * chore: change node name
   * fix: launch argument pasrer
   ---------
-* fix(tier4_perception_launch): camera lidar fusion launch (`#4983 <https://github.com/youtalk/autoware.universe/issues/4983>`_)
+* fix(tier4_perception_launch): camera lidar fusion launch (`#4983 <https://github.com/autowarefoundation/autoware.universe/issues/4983>`_)
   fix: camera lidar fusion launch
-* feat(image_projection_based_fusion): add roi based clustering for small unknown object detection (`#4681 <https://github.com/youtalk/autoware.universe/issues/4681>`_)
+* feat(image_projection_based_fusion): add roi based clustering for small unknown object detection (`#4681 <https://github.com/autowarefoundation/autoware.universe/issues/4681>`_)
   * feat: add roi_pointcloud_fusion node
   fix: postprocess
   fix: launch file
@@ -941,7 +941,7 @@ Changelog for package tier4_perception_launch
   * fix: update camera_lidar_radar mode launch
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* refactor(crosswalk_traffic_light_estimator): rework parameters (`#4699 <https://github.com/youtalk/autoware.universe/issues/4699>`_)
+* refactor(crosswalk_traffic_light_estimator): rework parameters (`#4699 <https://github.com/autowarefoundation/autoware.universe/issues/4699>`_)
   * refactor the configuration files of the node crosswalk_traffic_light_estimator according to the new ROS node config guideline.
   update the parameter information in the README.md
   * style(pre-commit): autofix
@@ -954,7 +954,7 @@ Changelog for package tier4_perception_launch
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Shunsuke Miura <37187849+miursh@users.noreply.github.com>
   Co-authored-by: Shunsuke Miura <shunsuke.miura@tier4.jp>
-* fix(crosswalk_traffic_light_estimator): move crosswalk after fusion (`#4734 <https://github.com/youtalk/autoware.universe/issues/4734>`_)
+* fix(crosswalk_traffic_light_estimator): move crosswalk after fusion (`#4734 <https://github.com/autowarefoundation/autoware.universe/issues/4734>`_)
   * fix: move crosswalk after fusion
   * Update launch/tier4_perception_launch/launch/traffic_light_recognition/traffic_light.launch.xml
   Co-authored-by: Shunsuke Miura <37187849+miursh@users.noreply.github.com>
@@ -963,8 +963,8 @@ Changelog for package tier4_perception_launch
   ---------
   Co-authored-by: Shunsuke Miura <37187849+miursh@users.noreply.github.com>
   Co-authored-by: Shunsuke Miura <shunsuke.miura@tier4.jp>
-* chore: add TLR model args to launch files (`#4805 <https://github.com/youtalk/autoware.universe/issues/4805>`_)
-* fix(tier4_percetion_launch): fix order of Camera-Lidar-Radar fusion pipeline (`#4779 <https://github.com/youtalk/autoware.universe/issues/4779>`_)
+* chore: add TLR model args to launch files (`#4805 <https://github.com/autowarefoundation/autoware.universe/issues/4805>`_)
+* fix(tier4_percetion_launch): fix order of Camera-Lidar-Radar fusion pipeline (`#4779 <https://github.com/autowarefoundation/autoware.universe/issues/4779>`_)
   * fix(tier4_percetion_launch): fix order of Camera-Lidar-Radar fusion pipeline
   * fix clustering update
   * fix from Camera-LidAR fusion
@@ -977,15 +977,15 @@ Changelog for package tier4_perception_launch
   ---------
   Co-authored-by: Shunsuke Miura <37187849+miursh@users.noreply.github.com>
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* fix(launch): add missing launch args and defaults to lidar_based_detection.launch.xml (`#4596 <https://github.com/youtalk/autoware.universe/issues/4596>`_)
+* fix(launch): add missing launch args and defaults to lidar_based_detection.launch.xml (`#4596 <https://github.com/autowarefoundation/autoware.universe/issues/4596>`_)
   * Update lidar_based_detection.launch.xml
   Some launch arguments were missing. These arguments and their defaults were added.
   * changed default of objects_filter_method
   changed default of the "objects_filter_method" to "lanelet_filter" as requested.
   ---------
-* feat(tier4_perception_launch): lower the detection by tracker priority to suppress yaw oscillation (`#4690 <https://github.com/youtalk/autoware.universe/issues/4690>`_)
+* feat(tier4_perception_launch): lower the detection by tracker priority to suppress yaw oscillation (`#4690 <https://github.com/autowarefoundation/autoware.universe/issues/4690>`_)
   lower the detection by tracker priority to suppress yaw oscillation
-* feat(image_projection_based_fusion): add objects filter by rois (`#4546 <https://github.com/youtalk/autoware.universe/issues/4546>`_)
+* feat(image_projection_based_fusion): add objects filter by rois (`#4546 <https://github.com/autowarefoundation/autoware.universe/issues/4546>`_)
   * tmp
   style(pre-commit): autofix
   update
@@ -1010,32 +1010,32 @@ Changelog for package tier4_perception_launch
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Shunsuke Miura <37187849+miursh@users.noreply.github.com>
-* refactor(detected_object_validation): add an option for filtering and validation (`#4402 <https://github.com/youtalk/autoware.universe/issues/4402>`_)
+* refactor(detected_object_validation): add an option for filtering and validation (`#4402 <https://github.com/autowarefoundation/autoware.universe/issues/4402>`_)
   * init commit
   * update occupancy_grid_map path
   * update argument names
   * correct radar launch objects_filter_method name
   * remove radar option
   ---------
-* refactor(traffic_light_arbiter): read parameters from config file (`#4454 <https://github.com/youtalk/autoware.universe/issues/4454>`_)
-* fix(compare_map_segmentation): change to using kinematic_state topic (`#4448 <https://github.com/youtalk/autoware.universe/issues/4448>`_)
-* chore(tier4_perception_launch): fix typo (`#4406 <https://github.com/youtalk/autoware.universe/issues/4406>`_)
+* refactor(traffic_light_arbiter): read parameters from config file (`#4454 <https://github.com/autowarefoundation/autoware.universe/issues/4454>`_)
+* fix(compare_map_segmentation): change to using kinematic_state topic (`#4448 <https://github.com/autowarefoundation/autoware.universe/issues/4448>`_)
+* chore(tier4_perception_launch): fix typo (`#4406 <https://github.com/autowarefoundation/autoware.universe/issues/4406>`_)
   * fix(tier4_perception_launch): fix typo
   * fix typo
   ---------
-* fix(traffic_light): fix traffic_light_arbiter pipeline (`#4393 <https://github.com/youtalk/autoware.universe/issues/4393>`_)
+* fix(traffic_light): fix traffic_light_arbiter pipeline (`#4393 <https://github.com/autowarefoundation/autoware.universe/issues/4393>`_)
   * fix(traffic_light): fix traffic_light_arbiter pipeline
   * style(pre-commit): autofix
   * fix: output topic name
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* fix(euclidean_cluster): add disuse downsample in clustering pipeline (`#4385 <https://github.com/youtalk/autoware.universe/issues/4385>`_)
+* fix(euclidean_cluster): add disuse downsample in clustering pipeline (`#4385 <https://github.com/autowarefoundation/autoware.universe/issues/4385>`_)
   * fix: add unuse downsample launch option
   * fix: add default param for downsample option
   * fix typo
   ---------
   Co-authored-by: Shunsuke Miura <shunsuke.miura@tier4.jp>
-* fix(compare_map_segmentation): add option to reduce distance_threshold in z axis (`#4243 <https://github.com/youtalk/autoware.universe/issues/4243>`_)
+* fix(compare_map_segmentation): add option to reduce distance_threshold in z axis (`#4243 <https://github.com/autowarefoundation/autoware.universe/issues/4243>`_)
   * fix(compare_map_segmentation): keep low level pointcloud
   * fix: add option to compare lower neighbor points
   * docs: readme update
@@ -1046,21 +1046,21 @@ Changelog for package tier4_perception_launch
   * fix: reduce voxel leaf size in z axis
   * fix: change param type
   ---------
-* refactor(image_projection_based_fusion): update rois topic names definitions (`#4356 <https://github.com/youtalk/autoware.universe/issues/4356>`_)
-* refactor(image_projection_based_fusion): read lidar models parameters from autoware_launch (`#4278 <https://github.com/youtalk/autoware.universe/issues/4278>`_)
+* refactor(image_projection_based_fusion): update rois topic names definitions (`#4356 <https://github.com/autowarefoundation/autoware.universe/issues/4356>`_)
+* refactor(image_projection_based_fusion): read lidar models parameters from autoware_launch (`#4278 <https://github.com/autowarefoundation/autoware.universe/issues/4278>`_)
   * init commit
   * add centerpoints param
   * add detection_class_remapper.param.yaml
   * remove unused centerpoint param path
   ---------
   Co-authored-by: Yusuke Muramatsu <yukke42@users.noreply.github.com>
-* feat(tier4_perception_launch): add radar tracking node to launcher (`#4361 <https://github.com/youtalk/autoware.universe/issues/4361>`_)
+* feat(tier4_perception_launch): add radar tracking node to launcher (`#4361 <https://github.com/autowarefoundation/autoware.universe/issues/4361>`_)
   * update tracking/perception launch
   * switch tracker launcher mode with argument
   * add radar tracker dependency
   ---------
   Co-authored-by: Shunsuke Miura <37187849+miursh@users.noreply.github.com>
-* feat(tier4_perception_launch): add radar faraway detection  (`#4330 <https://github.com/youtalk/autoware.universe/issues/4330>`_)
+* feat(tier4_perception_launch): add radar faraway detection  (`#4330 <https://github.com/autowarefoundation/autoware.universe/issues/4330>`_)
   * feat(tier4_perception_launch): add radar faraway detection
   * apply pre-commit
   * fix unused param
@@ -1068,11 +1068,11 @@ Changelog for package tier4_perception_launch
   * add exec depends
   ---------
   Co-authored-by: Shunsuke Miura <shunsuke.miura@tier4.jp>
-* refactor(object_merger): read parameters from autoware_launch (`#4339 <https://github.com/youtalk/autoware.universe/issues/4339>`_)
+* refactor(object_merger): read parameters from autoware_launch (`#4339 <https://github.com/autowarefoundation/autoware.universe/issues/4339>`_)
   init commit
-* refactor(map_based_prediction): read parameters from autoware_launch (`#4337 <https://github.com/youtalk/autoware.universe/issues/4337>`_)
+* refactor(map_based_prediction): read parameters from autoware_launch (`#4337 <https://github.com/autowarefoundation/autoware.universe/issues/4337>`_)
   init commit
-* refactor(euclidean clustering): read parameters from autoware_launch (`#4262 <https://github.com/youtalk/autoware.universe/issues/4262>`_)
+* refactor(euclidean clustering): read parameters from autoware_launch (`#4262 <https://github.com/autowarefoundation/autoware.universe/issues/4262>`_)
   * update clustering param path
   * update param paths
   * style(pre-commit): autofix
@@ -1080,7 +1080,7 @@ Changelog for package tier4_perception_launch
   * style(pre-commit): autofix
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* chore: separate traffic_light_utils from perception_utils (`#4207 <https://github.com/youtalk/autoware.universe/issues/4207>`_)
+* chore: separate traffic_light_utils from perception_utils (`#4207 <https://github.com/autowarefoundation/autoware.universe/issues/4207>`_)
   * separate traffic_light_utils from perception_utils
   * style(pre-commit): autofix
   * fix namespace bug
@@ -1095,7 +1095,7 @@ Changelog for package tier4_perception_launch
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Daisuke Nishimatsu <42202095+wep21@users.noreply.github.com>
-* feat(tier4_perception_launch): update traffic light launch (`#4176 <https://github.com/youtalk/autoware.universe/issues/4176>`_)
+* feat(tier4_perception_launch): update traffic light launch (`#4176 <https://github.com/autowarefoundation/autoware.universe/issues/4176>`_)
   * first commit
   * add image number arg
   * style(pre-commit): autofix
@@ -1109,23 +1109,23 @@ Changelog for package tier4_perception_launch
   Co-authored-by: Shunsuke Miura <shunsuke.miura@tier4.jp>
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Shunsuke Miura <37187849+miursh@users.noreply.github.com>
-* feat(traffic_light): improved traffic_light_map_based_detector and new traffic_light_fine_detector package (`#4084 <https://github.com/youtalk/autoware.universe/issues/4084>`_)
+* feat(traffic_light): improved traffic_light_map_based_detector and new traffic_light_fine_detector package (`#4084 <https://github.com/autowarefoundation/autoware.universe/issues/4084>`_)
   * update traffic_light_map_based_detector traffic_light_classifier traffic_light_fine_detector traffic_light_multi_camera_fusion
   * replace autoware_auto_perception_msgs with tier4_perception_msgs
   ---------
-* refactor(occpuancy grid map): move param to yaml (`#4038 <https://github.com/youtalk/autoware.universe/issues/4038>`_)
-* fix(tier4_perception_launch): fix camera_lidar_radar_fusion_based_detection (`#3950 <https://github.com/youtalk/autoware.universe/issues/3950>`_)
+* refactor(occpuancy grid map): move param to yaml (`#4038 <https://github.com/autowarefoundation/autoware.universe/issues/4038>`_)
+* fix(tier4_perception_launch): fix camera_lidar_radar_fusion_based_detection (`#3950 <https://github.com/autowarefoundation/autoware.universe/issues/3950>`_)
   * fix: launch arguments
   * chore: revert arg
   ---------
-* fix(tier4_perception_launch): sync param path (`#3713 <https://github.com/youtalk/autoware.universe/issues/3713>`_)
+* fix(tier4_perception_launch): sync param path (`#3713 <https://github.com/autowarefoundation/autoware.universe/issues/3713>`_)
   * fix(tier4_perception_launch):modify sync_param_path reading method
   * fix(tier4_perception_launch): fix image_number used for testing
   * style(pre-commit): autofix
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* fix(tier4_perception_launch): fix image_number description (`#3686 <https://github.com/youtalk/autoware.universe/issues/3686>`_)
-* feat(traffic_light_ssd_fine_detector): add support of ssd trained by mmdetection (`#3485 <https://github.com/youtalk/autoware.universe/issues/3485>`_)
+* fix(tier4_perception_launch): fix image_number description (`#3686 <https://github.com/autowarefoundation/autoware.universe/issues/3686>`_)
+* feat(traffic_light_ssd_fine_detector): add support of ssd trained by mmdetection (`#3485 <https://github.com/autowarefoundation/autoware.universe/issues/3485>`_)
   * feat: update to allow out-of-order for scores and boxes
   * feat: add GatherTopk plugin
   * feat: add GridPriors plugin
@@ -1141,11 +1141,11 @@ Changelog for package tier4_perception_launch
   Co-authored-by: Daisuke Nishimatsu <42202095+wep21@users.noreply.github.com>
   ---------
   Co-authored-by: Daisuke Nishimatsu <42202095+wep21@users.noreply.github.com>
-* fix(tier4_perception_launch): fix duplicated topic name (`#3645 <https://github.com/youtalk/autoware.universe/issues/3645>`_)
+* fix(tier4_perception_launch): fix duplicated topic name (`#3645 <https://github.com/autowarefoundation/autoware.universe/issues/3645>`_)
   * fix(tier4_perception_launch): fix dublicated topic name
   * chore: rename topic
   ---------
-* build: mark autoware_cmake as <buildtool_depend> (`#3616 <https://github.com/youtalk/autoware.universe/issues/3616>`_)
+* build: mark autoware_cmake as <buildtool_depend> (`#3616 <https://github.com/autowarefoundation/autoware.universe/issues/3616>`_)
   * build: mark autoware_cmake as <buildtool_depend>
   with <build_depend>, autoware_cmake is automatically exported with ament_target_dependencies() (unecessary)
   * style(pre-commit): autofix
@@ -1153,7 +1153,7 @@ Changelog for package tier4_perception_launch
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Kenji Miyake <kenji.miyake@tier4.jp>
-* fix(compare_map_segmentation): update voxel_based for dynamic map loader with map grid coordinate (`#3277 <https://github.com/youtalk/autoware.universe/issues/3277>`_)
+* fix(compare_map_segmentation): update voxel_based for dynamic map loader with map grid coordinate (`#3277 <https://github.com/autowarefoundation/autoware.universe/issues/3277>`_)
   * fix: change map grid searching
   * refactoring
   * fix: reload map after initilization
@@ -1171,14 +1171,14 @@ Changelog for package tier4_perception_launch
   * chore: typo
   * docs: correct parameter description
   ---------
-* refactor(occupancy_grid_map): add occupancy_grid_map method/param var to launcher (`#3393 <https://github.com/youtalk/autoware.universe/issues/3393>`_)
+* refactor(occupancy_grid_map): add occupancy_grid_map method/param var to launcher (`#3393 <https://github.com/autowarefoundation/autoware.universe/issues/3393>`_)
   * add occcupancy_grid_map method/param var to launcher
   * added CODEOWNER
   * Revert "added CODEOWNER"
   This reverts commit 2213c2956af19580d0a7788680aab321675aab3b.
   * add maintainer
   ---------
-* feat(elevation_map_loader): add support for seleceted_map_loader (`#3344 <https://github.com/youtalk/autoware.universe/issues/3344>`_)
+* feat(elevation_map_loader): add support for seleceted_map_loader (`#3344 <https://github.com/autowarefoundation/autoware.universe/issues/3344>`_)
   * feat(elevation_map_loader): add support for sequential_map_loading
   * fix(elevation_map_loader): fix bug
   * feat(elevation_map_loader): make it possible to adjust the number of PCD maps loaded at once when using sequential map loading
@@ -1187,7 +1187,7 @@ Changelog for package tier4_perception_launch
   * refactor(elevation_map_loader): Add a range of param. And refactor receiveMap.
   * feat(elevation_map_loader): Change info level log into debug level log with throttle. And remove abbreviation
   ---------
-* feat(tier4_perception_launch): refactored occupancy_grid_map launcher (`#3058 <https://github.com/youtalk/autoware.universe/issues/3058>`_)
+* feat(tier4_perception_launch): refactored occupancy_grid_map launcher (`#3058 <https://github.com/autowarefoundation/autoware.universe/issues/3058>`_)
   * rebase on to master
   add scan_frame and raytrace center
   * rebase to main
@@ -1202,9 +1202,9 @@ Changelog for package tier4_perception_launch
   * document: update README
   * enable to change origins by lanch args
   ---------
-* chore(tier4_perception_launch): add custom parameters for roi_cluster_fusion (`#3281 <https://github.com/youtalk/autoware.universe/issues/3281>`_)
-* fix(tier4_perception_launch): add missing parameter for voxel based compare map filter (`#3251 <https://github.com/youtalk/autoware.universe/issues/3251>`_)
-* feat(compare_map_segmentation): add dynamic map loading for voxel_based_compare_map_filter (`#3087 <https://github.com/youtalk/autoware.universe/issues/3087>`_)
+* chore(tier4_perception_launch): add custom parameters for roi_cluster_fusion (`#3281 <https://github.com/autowarefoundation/autoware.universe/issues/3281>`_)
+* fix(tier4_perception_launch): add missing parameter for voxel based compare map filter (`#3251 <https://github.com/autowarefoundation/autoware.universe/issues/3251>`_)
+* feat(compare_map_segmentation): add dynamic map loading for voxel_based_compare_map_filter (`#3087 <https://github.com/autowarefoundation/autoware.universe/issues/3087>`_)
   * feat: add interface to dynamic loader
   * refactor: refactoring
   * refactor: refactoring
@@ -1217,7 +1217,7 @@ Changelog for package tier4_perception_launch
   * fix: add neighbor map_cell checking
   * fix: neighbor map grid check
   ---------
-* feat(elevation_map_loader): use polygon iterator to speed up (`#2885 <https://github.com/youtalk/autoware.universe/issues/2885>`_)
+* feat(elevation_map_loader): use polygon iterator to speed up (`#2885 <https://github.com/autowarefoundation/autoware.universe/issues/2885>`_)
   * use grid_map::PolygonIterator instead of grid_map::GridMapIterator
   * formatting
   * use use_lane_filter option
@@ -1229,16 +1229,16 @@ Changelog for package tier4_perception_launch
   * Change use_lane_filter param default to false
   * update README
   ---------
-* bugfix(tier4_simulator_launch): fix occupancy grid map not appearing problem in psim  (`#3081 <https://github.com/youtalk/autoware.universe/issues/3081>`_)
+* bugfix(tier4_simulator_launch): fix occupancy grid map not appearing problem in psim  (`#3081 <https://github.com/autowarefoundation/autoware.universe/issues/3081>`_)
   * fixed psim occupancy grid map problem
   * fix parameter designation
   ---------
   Co-authored-by: Takayuki Murooka <takayuki5168@gmail.com>
-* fix(tier4_perception_launch): fix config path (`#3078 <https://github.com/youtalk/autoware.universe/issues/3078>`_)
+* fix(tier4_perception_launch): fix config path (`#3078 <https://github.com/autowarefoundation/autoware.universe/issues/3078>`_)
   * fix(tier4_perception_launch): fix config path
   * use pointcloud_based_occupancy_grid_map.launch.py in tier4_simulator_launch
   ---------
-* feat(probablisitic_occupancy_grid_map): add scan_frame option for gridmap generation (`#3032 <https://github.com/youtalk/autoware.universe/issues/3032>`_)
+* feat(probablisitic_occupancy_grid_map): add scan_frame option for gridmap generation (`#3032 <https://github.com/autowarefoundation/autoware.universe/issues/3032>`_)
   * add scan_frame and raytrace center
   * add scan frame to laserscan based method
   * update readme
@@ -1247,31 +1247,31 @@ Changelog for package tier4_perception_launch
   * fix config and launch file
   * fixed laserscan based launcher
   ---------
-* fix(tier4_perception_launch): remove unnecessary node (`#2941 <https://github.com/youtalk/autoware.universe/issues/2941>`_)
-* fix(tier4_perception_launch): fix typo (`#2926 <https://github.com/youtalk/autoware.universe/issues/2926>`_)
-* feat(tier4_perception_launch): update cam/lidar detection architecture (`#2845 <https://github.com/youtalk/autoware.universe/issues/2845>`_)
+* fix(tier4_perception_launch): remove unnecessary node (`#2941 <https://github.com/autowarefoundation/autoware.universe/issues/2941>`_)
+* fix(tier4_perception_launch): fix typo (`#2926 <https://github.com/autowarefoundation/autoware.universe/issues/2926>`_)
+* feat(tier4_perception_launch): update cam/lidar detection architecture (`#2845 <https://github.com/autowarefoundation/autoware.universe/issues/2845>`_)
   * feat(tier4_perception_launch): update cam/lidar detection architecture
   * style(pre-commit): autofix
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* ci(pre-commit): autoupdate (`#2819 <https://github.com/youtalk/autoware.universe/issues/2819>`_)
+* ci(pre-commit): autoupdate (`#2819 <https://github.com/autowarefoundation/autoware.universe/issues/2819>`_)
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* fix(ground_segmentation): fix unuse_time_series_filter bug (`#2824 <https://github.com/youtalk/autoware.universe/issues/2824>`_)
-* feat(tier4_perception_launch): add option for euclidean lidar detection model (`#842 <https://github.com/youtalk/autoware.universe/issues/842>`_)
+* fix(ground_segmentation): fix unuse_time_series_filter bug (`#2824 <https://github.com/autowarefoundation/autoware.universe/issues/2824>`_)
+* feat(tier4_perception_launch): add option for euclidean lidar detection model (`#842 <https://github.com/autowarefoundation/autoware.universe/issues/842>`_)
   feat(tier4_perception_launch): add euclidean lidar detection model
-* fix(tier4_perception_launch): sync with tier4/autoware_launch (`#2568 <https://github.com/youtalk/autoware.universe/issues/2568>`_)
+* fix(tier4_perception_launch): sync with tier4/autoware_launch (`#2568 <https://github.com/autowarefoundation/autoware.universe/issues/2568>`_)
   * fix(tier4_perception_launch): sync with tier4/autoware_launch
   * move centerpoint configs to perception.launch.xml
-* feat(tier4_perception_launch): change the merge priority of roi_cluster_fusion to the lowest (`#2522 <https://github.com/youtalk/autoware.universe/issues/2522>`_)
-* feat(tier4_perception_launch): remove configs and move to autoware_launch (`#2539 <https://github.com/youtalk/autoware.universe/issues/2539>`_)
+* feat(tier4_perception_launch): change the merge priority of roi_cluster_fusion to the lowest (`#2522 <https://github.com/autowarefoundation/autoware.universe/issues/2522>`_)
+* feat(tier4_perception_launch): remove configs and move to autoware_launch (`#2539 <https://github.com/autowarefoundation/autoware.universe/issues/2539>`_)
   * feat(tier4_perception_launch): remove configs and move to autoware_launch
   * update readme
   * remove config
   * update readme
-* fix(ground segmentation): change crop box range and add processing time (`#2260 <https://github.com/youtalk/autoware.universe/issues/2260>`_)
+* fix(ground segmentation): change crop box range and add processing time (`#2260 <https://github.com/autowarefoundation/autoware.universe/issues/2260>`_)
   * fix(ground segmentation): change crop box range
   * chore(ground_segmentation): add processing time
-* feat(tier4_perception_launch): sync perception launch to autoware_launch (`#2168 <https://github.com/youtalk/autoware.universe/issues/2168>`_)
+* feat(tier4_perception_launch): sync perception launch to autoware_launch (`#2168 <https://github.com/autowarefoundation/autoware.universe/issues/2168>`_)
   * sync launch file from tier4 autoware launch
   * sync tlr launcher
   * ci(pre-commit): autofix
@@ -1281,26 +1281,26 @@ Changelog for package tier4_perception_launch
   * fix exec_depend in package.xml
   * Sync traffic light node
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat(multiframe-pointpainting): add multi-sweep pointpainting (`#2124 <https://github.com/youtalk/autoware.universe/issues/2124>`_)
+* feat(multiframe-pointpainting): add multi-sweep pointpainting (`#2124 <https://github.com/autowarefoundation/autoware.universe/issues/2124>`_)
   * feat: multiframe-pointpainting
   * ci(pre-commit): autofix
   * fix: retrieve changes of classremap
-  * fix(image_projection_based_fusion): fix input to quaternion (`#1933 <https://github.com/youtalk/autoware.universe/issues/1933>`_)
+  * fix(image_projection_based_fusion): fix input to quaternion (`#1933 <https://github.com/autowarefoundation/autoware.universe/issues/1933>`_)
   * add: launch files
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Yusuke Muramatsu <yukke42@users.noreply.github.com>
-* ci(pre-commit): format SVG files (`#2172 <https://github.com/youtalk/autoware.universe/issues/2172>`_)
+* ci(pre-commit): format SVG files (`#2172 <https://github.com/autowarefoundation/autoware.universe/issues/2172>`_)
   * ci(pre-commit): format SVG files
   * ci(pre-commit): autofix
   * apply pre-commit
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* fix(tier4_perception_launch): fix missing container argument (`#2087 <https://github.com/youtalk/autoware.universe/issues/2087>`_)
+* fix(tier4_perception_launch): fix missing container argument (`#2087 <https://github.com/autowarefoundation/autoware.universe/issues/2087>`_)
   * fix(tier4_perception_launch): fix missing container argument
   * fix(tier4_perception_launch): rm unused param
-* chore: fix typos (`#2140 <https://github.com/youtalk/autoware.universe/issues/2140>`_)
+* chore: fix typos (`#2140 <https://github.com/autowarefoundation/autoware.universe/issues/2140>`_)
   * chore: fix typos
   * chore: remove names in NOTE
-* feat: use tracker shape size in detection by tracker (`#1683 <https://github.com/youtalk/autoware.universe/issues/1683>`_)
+* feat: use tracker shape size in detection by tracker (`#1683 <https://github.com/autowarefoundation/autoware.universe/issues/1683>`_)
   * support ref size in detection by tracker
   * add priority mode in object_merger
   * update launch
@@ -1315,8 +1315,8 @@ Changelog for package tier4_perception_launch
   * :put_litter_in_its_place:
   Co-authored-by: Yusuke Muramatsu <yukke42@users.noreply.github.com>
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat(multi_object_tracking): enable delay compensation (`#1349 <https://github.com/youtalk/autoware.universe/issues/1349>`_)
-* fix(ground segmentation): add elevation grid ground filter (`#1899 <https://github.com/youtalk/autoware.universe/issues/1899>`_)
+* feat(multi_object_tracking): enable delay compensation (`#1349 <https://github.com/autowarefoundation/autoware.universe/issues/1349>`_)
+* fix(ground segmentation): add elevation grid ground filter (`#1899 <https://github.com/autowarefoundation/autoware.universe/issues/1899>`_)
   * fix: add grid elevation scan ground filter
   * chore: typo
   * fix: merge with scan ground filter
@@ -1342,20 +1342,20 @@ Changelog for package tier4_perception_launch
   * chore: typo
   * docs: update
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat(tier4_perception_launch): add enable_fine_detection_option (`#1991 <https://github.com/youtalk/autoware.universe/issues/1991>`_)
+* feat(tier4_perception_launch): add enable_fine_detection_option (`#1991 <https://github.com/autowarefoundation/autoware.universe/issues/1991>`_)
   * feat(tier4_perception_launch): add enable_fine_detection_option
   * chore: rename
   * ci(pre-commit): autofix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat(tier4_perception_launch): add arg to swtich lidar_centerpoint model (`#1865 <https://github.com/youtalk/autoware.universe/issues/1865>`_)
-* feat(multi_object_tracker): update bus size (`#1887 <https://github.com/youtalk/autoware.universe/issues/1887>`_)
-* refactor(lidar_centerpoint): change default threshold params (`#1874 <https://github.com/youtalk/autoware.universe/issues/1874>`_)
-* feat(multi_object_tracker): increase max-area for truck and trailer (`#1710 <https://github.com/youtalk/autoware.universe/issues/1710>`_)
+* feat(tier4_perception_launch): add arg to swtich lidar_centerpoint model (`#1865 <https://github.com/autowarefoundation/autoware.universe/issues/1865>`_)
+* feat(multi_object_tracker): update bus size (`#1887 <https://github.com/autowarefoundation/autoware.universe/issues/1887>`_)
+* refactor(lidar_centerpoint): change default threshold params (`#1874 <https://github.com/autowarefoundation/autoware.universe/issues/1874>`_)
+* feat(multi_object_tracker): increase max-area for truck and trailer (`#1710 <https://github.com/autowarefoundation/autoware.universe/issues/1710>`_)
   * feat(multi_object_tracker): increase max-area for truck
   * feat: change truck and trailer max-area gate params
   * feat: change trailer params
-* fix(tier4_perception_launch): add input/pointcloud to ground-segmentation (`#1833 <https://github.com/youtalk/autoware.universe/issues/1833>`_)
-* feat(radar_object_fusion_to_detected_object): enable confidence compensation in radar fusion (`#1755 <https://github.com/youtalk/autoware.universe/issues/1755>`_)
+* fix(tier4_perception_launch): add input/pointcloud to ground-segmentation (`#1833 <https://github.com/autowarefoundation/autoware.universe/issues/1833>`_)
+* feat(radar_object_fusion_to_detected_object): enable confidence compensation in radar fusion (`#1755 <https://github.com/autowarefoundation/autoware.universe/issues/1755>`_)
   * update parameter
   * feature(radar_fusion_to_detected_object): add debug topic
   * feat(tier4_perception_launch): enable confidence compensation in radar fusion
@@ -1366,13 +1366,13 @@ Changelog for package tier4_perception_launch
   * fix parameter
   * ci(pre-commit): autofix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat(tier4_perception_launch): make lanelet object filter optional (`#1698 <https://github.com/youtalk/autoware.universe/issues/1698>`_)
+* feat(tier4_perception_launch): make lanelet object filter optional (`#1698 <https://github.com/autowarefoundation/autoware.universe/issues/1698>`_)
   * feat(tier4_perception_launch): make lanelet object filter optional
   * feat(tier4_perception_launch): fix arg
   * feat(tier4_perception_launch): fix argument var
   * feat(tier4_perception_launch): add new parameter
   Co-authored-by: Kaan Colak <kcolak@leodrive.ai>
-* fix(ground_filter): remove base_frame and fix ray_ground_filter  (`#1614 <https://github.com/youtalk/autoware.universe/issues/1614>`_)
+* fix(ground_filter): remove base_frame and fix ray_ground_filter  (`#1614 <https://github.com/autowarefoundation/autoware.universe/issues/1614>`_)
   * fix(ray_ground_filter): cannot remove ground pcl
   * fix: remove base_frame
   * docs: update docs
@@ -1380,30 +1380,30 @@ Changelog for package tier4_perception_launch
   * chores: remove unnecessary calculation
   * docs: update parameters
   * docs: update parameters
-* fix(tier4_perception_launch): remove duplicated namespace of clustering in camera-lidar-fusion mode (`#1655 <https://github.com/youtalk/autoware.universe/issues/1655>`_)
-* feat(tier4_perception_launch): change unknown max area (`#1484 <https://github.com/youtalk/autoware.universe/issues/1484>`_)
-* fix(tier4_perception_launch): fix error of tier4_perception_launch_param_path (`#1445 <https://github.com/youtalk/autoware.universe/issues/1445>`_)
-* feat(tier4_perception_launch): declare param path argument (`#1394 <https://github.com/youtalk/autoware.universe/issues/1394>`_)
+* fix(tier4_perception_launch): remove duplicated namespace of clustering in camera-lidar-fusion mode (`#1655 <https://github.com/autowarefoundation/autoware.universe/issues/1655>`_)
+* feat(tier4_perception_launch): change unknown max area (`#1484 <https://github.com/autowarefoundation/autoware.universe/issues/1484>`_)
+* fix(tier4_perception_launch): fix error of tier4_perception_launch_param_path (`#1445 <https://github.com/autowarefoundation/autoware.universe/issues/1445>`_)
+* feat(tier4_perception_launch): declare param path argument (`#1394 <https://github.com/autowarefoundation/autoware.universe/issues/1394>`_)
   * feat(tier4_perception_launch): declare param path argument
   * Update launch/tier4_perception_launch/launch/perception.launch.xml
   * fix ci error
   * fix ci error
-* feature: update and fix detection launch (`#1340 <https://github.com/youtalk/autoware.universe/issues/1340>`_)
+* feature: update and fix detection launch (`#1340 <https://github.com/autowarefoundation/autoware.universe/issues/1340>`_)
   * cosmetic change
   * fix bug
   * ci(pre-commit): autofix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* fix(tier4_perception_launch): add group tag (`#1238 <https://github.com/youtalk/autoware.universe/issues/1238>`_)
+* fix(tier4_perception_launch): add group tag (`#1238 <https://github.com/autowarefoundation/autoware.universe/issues/1238>`_)
   * fix(tier4_perception_launch): add group tag
   * fix missing tag
-* fix(tier4_perception_launch): pass pointcloud_container params to pointcloud_map_filter in detection module (`#1312 <https://github.com/youtalk/autoware.universe/issues/1312>`_)
+* fix(tier4_perception_launch): pass pointcloud_container params to pointcloud_map_filter in detection module (`#1312 <https://github.com/autowarefoundation/autoware.universe/issues/1312>`_)
   * fix(tier4_perception_launch): pass pointcloud_container to detection module
   * fix(tier4_perception_launch): container name in detection
-* feat(tier4_perception_launch): add object filter params to tier4_perception_launch (`#1322 <https://github.com/youtalk/autoware.universe/issues/1322>`_)
+* feat(tier4_perception_launch): add object filter params to tier4_perception_launch (`#1322 <https://github.com/autowarefoundation/autoware.universe/issues/1322>`_)
   * Add params to tier4_perception_launch
   * ci(pre-commit): autofix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* fix: avoid same name nodes in detection module (`#1301 <https://github.com/youtalk/autoware.universe/issues/1301>`_)
+* fix: avoid same name nodes in detection module (`#1301 <https://github.com/autowarefoundation/autoware.universe/issues/1301>`_)
   * fix: avoid same name nodes in detection module
   * add node_name of object_association_merger
   * Update launch/tier4_perception_launch/launch/object_recognition/detection/camera_lidar_fusion_based_detection.launch.xml
@@ -1414,24 +1414,24 @@ Changelog for package tier4_perception_launch
   Co-authored-by: Shumpei Wakabayashi <42209144+shmpwk@users.noreply.github.com>
   * apply pre-commit
   Co-authored-by: Shumpei Wakabayashi <42209144+shmpwk@users.noreply.github.com>
-* Feature/radar fusion launch (`#1294 <https://github.com/youtalk/autoware.universe/issues/1294>`_)
-  * feat(tier4_perception_launch): add radar launcher (`#1263 <https://github.com/youtalk/autoware.universe/issues/1263>`_)
+* Feature/radar fusion launch (`#1294 <https://github.com/autowarefoundation/autoware.universe/issues/1294>`_)
+  * feat(tier4_perception_launch): add radar launcher (`#1263 <https://github.com/autowarefoundation/autoware.universe/issues/1263>`_)
   * feat(tier4_perception_launch): add radar launcher
   * ci(pre-commit): autofix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-  * fix reviewed by `#1263 <https://github.com/youtalk/autoware.universe/issues/1263>`_
+  * fix reviewed by `#1263 <https://github.com/autowarefoundation/autoware.universe/issues/1263>`_
   * fix format
   * fix default arg
   * Revert "fix default arg"
   This reverts commit 72b2690dc8cbd91fa5b14da091f4027c2c5fa661.
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat(tier4_perception_launch): revert `#1263 <https://github.com/youtalk/autoware.universe/issues/1263>`_ (`#1285 <https://github.com/youtalk/autoware.universe/issues/1285>`_)
-* feat(tier4_perception_launch): add radar launcher (`#1263 <https://github.com/youtalk/autoware.universe/issues/1263>`_)
+* feat(tier4_perception_launch): revert `#1263 <https://github.com/autowarefoundation/autoware.universe/issues/1263>`_ (`#1285 <https://github.com/autowarefoundation/autoware.universe/issues/1285>`_)
+* feat(tier4_perception_launch): add radar launcher (`#1263 <https://github.com/autowarefoundation/autoware.universe/issues/1263>`_)
   * feat(tier4_perception_launch): add radar launcher
   * ci(pre-commit): autofix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat: change iou param of multi object  tracking (`#1267 <https://github.com/youtalk/autoware.universe/issues/1267>`_)
-* feat(object_filter): add detected object filter (`#1221 <https://github.com/youtalk/autoware.universe/issues/1221>`_)
+* feat: change iou param of multi object  tracking (`#1267 <https://github.com/autowarefoundation/autoware.universe/issues/1267>`_)
+* feat(object_filter): add detected object filter (`#1221 <https://github.com/autowarefoundation/autoware.universe/issues/1221>`_)
   * Add detected object filter
   * Refactor class name
   * Add readme
@@ -1456,13 +1456,13 @@ Changelog for package tier4_perception_launch
   * Fix typo, remove debug code.
   * Use shared_ptr
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat: add option to use validator node in detection module (`#1233 <https://github.com/youtalk/autoware.universe/issues/1233>`_)
+* feat: add option to use validator node in detection module (`#1233 <https://github.com/autowarefoundation/autoware.universe/issues/1233>`_)
   * feat: add option to use validator node in detection module
   * fix
   * remove use_validator option in detection/perception.launch
   * fix
-* feat: change tracking param (`#1161 <https://github.com/youtalk/autoware.universe/issues/1161>`_)
-* feat: unknown objects from perception (`#870 <https://github.com/youtalk/autoware.universe/issues/870>`_)
+* feat: change tracking param (`#1161 <https://github.com/autowarefoundation/autoware.universe/issues/1161>`_)
+* feat: unknown objects from perception (`#870 <https://github.com/autowarefoundation/autoware.universe/issues/870>`_)
   * initial commit
   * change param
   * modify launch
@@ -1481,14 +1481,14 @@ Changelog for package tier4_perception_launch
   * modify for pre-commit
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Daisuke Nishimatsu <42202095+wep21@users.noreply.github.com>
-* feat: change data association param (`#1158 <https://github.com/youtalk/autoware.universe/issues/1158>`_)
-* fix(tier4_perception_launch): add missing dependencies in package.xml (`#1024 <https://github.com/youtalk/autoware.universe/issues/1024>`_)
-* feat: use multithread for traffic light container as default (`#995 <https://github.com/youtalk/autoware.universe/issues/995>`_)
-* fix: delete unused arg (`#988 <https://github.com/youtalk/autoware.universe/issues/988>`_)
+* feat: change data association param (`#1158 <https://github.com/autowarefoundation/autoware.universe/issues/1158>`_)
+* fix(tier4_perception_launch): add missing dependencies in package.xml (`#1024 <https://github.com/autowarefoundation/autoware.universe/issues/1024>`_)
+* feat: use multithread for traffic light container as default (`#995 <https://github.com/autowarefoundation/autoware.universe/issues/995>`_)
+* fix: delete unused arg (`#988 <https://github.com/autowarefoundation/autoware.universe/issues/988>`_)
   * fix: delete unused arg
   * rename: detection_preprocessor -> pointcloud_map_filter
-* fix(tier4_perception_launch): rename pkg name (`#981 <https://github.com/youtalk/autoware.universe/issues/981>`_)
-* feat: add down sample filter before detection module (`#961 <https://github.com/youtalk/autoware.universe/issues/961>`_)
+* fix(tier4_perception_launch): rename pkg name (`#981 <https://github.com/autowarefoundation/autoware.universe/issues/981>`_)
+* feat: add down sample filter before detection module (`#961 <https://github.com/autowarefoundation/autoware.universe/issues/961>`_)
   * feat: add down sample filter before detection module
   * fix format
   * change comment
@@ -1501,21 +1501,21 @@ Changelog for package tier4_perception_launch
   * fix pre-commit
   Co-authored-by: Yukihiro Saito <yukky.saito@gmail.com>
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat: remove deprecated package in prediction launch (`#875 <https://github.com/youtalk/autoware.universe/issues/875>`_)
-* chore: upgrade cmake_minimum_required to 3.14 (`#856 <https://github.com/youtalk/autoware.universe/issues/856>`_)
-* refactor: use autoware cmake (`#849 <https://github.com/youtalk/autoware.universe/issues/849>`_)
+* feat: remove deprecated package in prediction launch (`#875 <https://github.com/autowarefoundation/autoware.universe/issues/875>`_)
+* chore: upgrade cmake_minimum_required to 3.14 (`#856 <https://github.com/autowarefoundation/autoware.universe/issues/856>`_)
+* refactor: use autoware cmake (`#849 <https://github.com/autowarefoundation/autoware.universe/issues/849>`_)
   * remove autoware_auto_cmake
   * add build_depend of autoware_cmake
   * use autoware_cmake in CMakeLists.txt
   * fix bugs
   * fix cmake lint errors
-* style: fix format of package.xml (`#844 <https://github.com/youtalk/autoware.universe/issues/844>`_)
-* feat: change ogm default launch (`#735 <https://github.com/youtalk/autoware.universe/issues/735>`_)
-* feat(scan_ground_filter): change launch option and threshold (`#670 <https://github.com/youtalk/autoware.universe/issues/670>`_)
+* style: fix format of package.xml (`#844 <https://github.com/autowarefoundation/autoware.universe/issues/844>`_)
+* feat: change ogm default launch (`#735 <https://github.com/autowarefoundation/autoware.universe/issues/735>`_)
+* feat(scan_ground_filter): change launch option and threshold (`#670 <https://github.com/autowarefoundation/autoware.universe/issues/670>`_)
   * Add care for near but high points
   * ci(pre-commit): autofix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat(image_projection_based_fusion, roi_cluster_fusion): roi and obstacle fusion method (`#548 <https://github.com/youtalk/autoware.universe/issues/548>`_)
+* feat(image_projection_based_fusion, roi_cluster_fusion): roi and obstacle fusion method (`#548 <https://github.com/autowarefoundation/autoware.universe/issues/548>`_)
   * feat: init image_projection_based_fusion package
   * feat: debugger
   * feat: port roi_cluster_fusion to image_projection_based_fusion
@@ -1540,7 +1540,7 @@ Changelog for package tier4_perception_launch
   * chore: add maintainer
   * feat: change the output in perception_launch
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat: pointcloud based probabilistic occupancy grid map (`#624 <https://github.com/youtalk/autoware.universe/issues/624>`_)
+* feat: pointcloud based probabilistic occupancy grid map (`#624 <https://github.com/autowarefoundation/autoware.universe/issues/624>`_)
   * initial commit
   * ci(pre-commit): autofix
   * change param
@@ -1556,15 +1556,15 @@ Changelog for package tier4_perception_launch
   * add single frame mode
   * ci(pre-commit): autofix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* fix: localization and perception launch for tutorial (`#645 <https://github.com/youtalk/autoware.universe/issues/645>`_)
+* fix: localization and perception launch for tutorial (`#645 <https://github.com/autowarefoundation/autoware.universe/issues/645>`_)
   * fix: localization and perception launch for tutorial
   * ci(pre-commit): autofix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* ci(pre-commit): update pre-commit-hooks-ros (`#625 <https://github.com/youtalk/autoware.universe/issues/625>`_)
+* ci(pre-commit): update pre-commit-hooks-ros (`#625 <https://github.com/autowarefoundation/autoware.universe/issues/625>`_)
   * ci(pre-commit): update pre-commit-hooks-ros
   * ci(pre-commit): autofix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat: launch detected object validator (`#585 <https://github.com/youtalk/autoware.universe/issues/585>`_)
+* feat: launch detected object validator (`#585 <https://github.com/autowarefoundation/autoware.universe/issues/585>`_)
   * fix bug
   * add validator in launch
   * bug fix
@@ -1574,13 +1574,13 @@ Changelog for package tier4_perception_launch
   * Update launch/tier4_perception_launch/launch/object_recognition/detection/camera_lidar_fusion_based_detection.launch.xml
   Co-authored-by: Shunsuke Miura <37187849+miursh@users.noreply.github.com>
   Co-authored-by: Shunsuke Miura <37187849+miursh@users.noreply.github.com>
-* fix(multi_object_tracker): data association parameter (`#541 <https://github.com/youtalk/autoware.universe/issues/541>`_)
+* fix(multi_object_tracker): data association parameter (`#541 <https://github.com/autowarefoundation/autoware.universe/issues/541>`_)
   * sort matrix
   * ANIMAL->TRAILER
   * apply change to another file
   * ci(pre-commit): autofix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat(multi_object_tracker): add iou gate (`#483 <https://github.com/youtalk/autoware.universe/issues/483>`_)
+* feat(multi_object_tracker): add iou gate (`#483 <https://github.com/autowarefoundation/autoware.universe/issues/483>`_)
   * add iou gate
   * ci(pre-commit): autofix
   * cosmetic change
@@ -1589,23 +1589,23 @@ Changelog for package tier4_perception_launch
   * fix bug
   * fix tier4_launch
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* fix: detection launch in perception_launch (`#506 <https://github.com/youtalk/autoware.universe/issues/506>`_)
-* fix: integration miss related to camera lidar fusion (`#481 <https://github.com/youtalk/autoware.universe/issues/481>`_)
+* fix: detection launch in perception_launch (`#506 <https://github.com/autowarefoundation/autoware.universe/issues/506>`_)
+* fix: integration miss related to camera lidar fusion (`#481 <https://github.com/autowarefoundation/autoware.universe/issues/481>`_)
   * fix integration miss
   * bug fix
   * add detection by tracker
   * Update launch/tier4_perception_launch/launch/object_recognition/detection/camera_lidar_fusion_based_detection.launch.xml
-* fix(dummy_perception): fix to use launch at perception launch (`#454 <https://github.com/youtalk/autoware.universe/issues/454>`_)
+* fix(dummy_perception): fix to use launch at perception launch (`#454 <https://github.com/autowarefoundation/autoware.universe/issues/454>`_)
   * fix(dummy_perception): fix to use launch file in perception launch
   * fix(tier4_perception_launch): fix angle increment for occupancy grid
-* fix: change the default mode of perception.launch (`#409 <https://github.com/youtalk/autoware.universe/issues/409>`_)
+* fix: change the default mode of perception.launch (`#409 <https://github.com/autowarefoundation/autoware.universe/issues/409>`_)
   * fix: change the default mode of perception.launch
   * chore: remove unnecessary comments
   * chore: remove default values
-* ci: update .yamllint.yaml (`#229 <https://github.com/youtalk/autoware.universe/issues/229>`_)
+* ci: update .yamllint.yaml (`#229 <https://github.com/autowarefoundation/autoware.universe/issues/229>`_)
   * ci: update .yamllint.yaml
   * chore: fix for yamllint
-* feat: change launch package name (`#186 <https://github.com/youtalk/autoware.universe/issues/186>`_)
+* feat: change launch package name (`#186 <https://github.com/autowarefoundation/autoware.universe/issues/186>`_)
   * rename launch folder
   * autoware_launch -> tier4_autoware_launch
   * integration_launch -> tier4_integration_launch

--- a/launch/tier4_planning_launch/CHANGELOG.rst
+++ b/launch/tier4_planning_launch/CHANGELOG.rst
@@ -5,9 +5,9 @@ Changelog for package tier4_planning_launch
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* fix(autoware_obstacle_stop_planner): register obstacle stop planner node with autoware scoping (`#8512 <https://github.com/youtalk/autoware.universe/issues/8512>`_)
+* fix(autoware_obstacle_stop_planner): register obstacle stop planner node with autoware scoping (`#8512 <https://github.com/autowarefoundation/autoware.universe/issues/8512>`_)
   Register node plugin with autoware scoping
-* feat(scenario_selector, freespace_planner): improve freespace planner edge case behavior (`#8348 <https://github.com/youtalk/autoware.universe/issues/8348>`_)
+* feat(scenario_selector, freespace_planner): improve freespace planner edge case behavior (`#8348 <https://github.com/autowarefoundation/autoware.universe/issues/8348>`_)
   * refactor free space planner subscribers
   * implement scenario switching for edge cases
   * fix scenario selector test
@@ -18,11 +18,11 @@ Changelog for package tier4_planning_launch
   * improve near target logic
   * use timer based implementation for obstacle check
   ---------
-* refactor(compare_map_segmentation): add package name prefix of autoware\_ (`#8005 <https://github.com/youtalk/autoware.universe/issues/8005>`_)
+* refactor(compare_map_segmentation): add package name prefix of autoware\_ (`#8005 <https://github.com/autowarefoundation/autoware.universe/issues/8005>`_)
   * refactor(compare_map_segmentation): add package name prefix of autoware\_
   * docs: update Readme
   ---------
-* refactor(pointcloud_preprocessor): prefix package and namespace with autoware (`#7983 <https://github.com/youtalk/autoware.universe/issues/7983>`_)
+* refactor(pointcloud_preprocessor): prefix package and namespace with autoware (`#7983 <https://github.com/autowarefoundation/autoware.universe/issues/7983>`_)
   * refactor(pointcloud_preprocessor)!: prefix package and namespace with autoware
   * style(pre-commit): autofix
   * style(pointcloud_preprocessor): suppress line length check for macros
@@ -36,15 +36,15 @@ Changelog for package tier4_planning_launch
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Kenzo Lobos Tsunekawa <kenzo.lobos@tier4.jp>
-* refactor(compare_map_segmentation)!: fix namespace and directory structure (`#7910 <https://github.com/youtalk/autoware.universe/issues/7910>`_)
+* refactor(compare_map_segmentation)!: fix namespace and directory structure (`#7910 <https://github.com/autowarefoundation/autoware.universe/issues/7910>`_)
   * feat: update namespace and directory structure for compare_map_segmentation code
   * refactor: update  directory structure
   * fix: add missing include
   * style(pre-commit): autofix
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* fix(frenet_planner): fix mistake in the curvature calculation (`#7920 <https://github.com/youtalk/autoware.universe/issues/7920>`_)
-* feat(obstacle_cruise_planner): support pointcloud-based obstacles (`#6907 <https://github.com/youtalk/autoware.universe/issues/6907>`_)
+* fix(frenet_planner): fix mistake in the curvature calculation (`#7920 <https://github.com/autowarefoundation/autoware.universe/issues/7920>`_)
+* feat(obstacle_cruise_planner): support pointcloud-based obstacles (`#6907 <https://github.com/autowarefoundation/autoware.universe/issues/6907>`_)
   * add pointcloud to obstacle properties
   * add tf listener & pointcloud subscriber
   * add parameters for pointcloud obstacle
@@ -116,18 +116,18 @@ Changelog for package tier4_planning_launch
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Takagi, Isamu <isamu.takagi@tier4.jp>
   Co-authored-by: Satoshi OTA <44889564+satoshi-ota@users.noreply.github.com>
-* refactor(autoware_obstacle_stop_planner): prefix package and namespace with autoware (`#7565 <https://github.com/youtalk/autoware.universe/issues/7565>`_)
+* refactor(autoware_obstacle_stop_planner): prefix package and namespace with autoware (`#7565 <https://github.com/autowarefoundation/autoware.universe/issues/7565>`_)
   * refactor(autoware_obstacle_stop_planner): prefix package and namespace with autoware
   * style(pre-commit): autofix
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat(planning_evaluator): rename to include/autoware/{package_name} (`#7518 <https://github.com/youtalk/autoware.universe/issues/7518>`_)
+* feat(planning_evaluator): rename to include/autoware/{package_name} (`#7518 <https://github.com/autowarefoundation/autoware.universe/issues/7518>`_)
   * fix
   * fix
   ---------
-* refactor(dynamic_obstacle_stop): move to motion_velocity_planner (`#7460 <https://github.com/youtalk/autoware.universe/issues/7460>`_)
-* feat(obstacle_velocity_limiter): move to motion_velocity_planner (`#7439 <https://github.com/youtalk/autoware.universe/issues/7439>`_)
-* refactor(bpp): add namespace `autoware::` (`#7437 <https://github.com/youtalk/autoware.universe/issues/7437>`_)
+* refactor(dynamic_obstacle_stop): move to motion_velocity_planner (`#7460 <https://github.com/autowarefoundation/autoware.universe/issues/7460>`_)
+* feat(obstacle_velocity_limiter): move to motion_velocity_planner (`#7439 <https://github.com/autowarefoundation/autoware.universe/issues/7439>`_)
+* refactor(bpp): add namespace `autoware::` (`#7437 <https://github.com/autowarefoundation/autoware.universe/issues/7437>`_)
   * refactor: add namespace autoware::
   * refactor(bpp-common): add namespace autoware::
   * refactor(ablc): add namespace autoware::
@@ -141,24 +141,24 @@ Changelog for package tier4_planning_launch
   * refactor(tier4_planning_launch): add namespace autoware::
   * refactor(sbp): add namespace autoware::
   ---------
-* refactor(behavior_path_planner): prefix autoware\_ to behavior_path_planner package (`#7433 <https://github.com/youtalk/autoware.universe/issues/7433>`_)
+* refactor(behavior_path_planner): prefix autoware\_ to behavior_path_planner package (`#7433 <https://github.com/autowarefoundation/autoware.universe/issues/7433>`_)
   * move dir
   * fix pluginlib
   ---------
-* refactor(obstacle_cruise_planner)!: add autoware\_ prefix (`#7419 <https://github.com/youtalk/autoware.universe/issues/7419>`_)
-* refactor(behavior_path_sampling_planner_module): add autoware prefix (`#7392 <https://github.com/youtalk/autoware.universe/issues/7392>`_)
-* refactor(mission_planner)!: add autoware prefix and namespace (`#7414 <https://github.com/youtalk/autoware.universe/issues/7414>`_)
+* refactor(obstacle_cruise_planner)!: add autoware\_ prefix (`#7419 <https://github.com/autowarefoundation/autoware.universe/issues/7419>`_)
+* refactor(behavior_path_sampling_planner_module): add autoware prefix (`#7392 <https://github.com/autowarefoundation/autoware.universe/issues/7392>`_)
+* refactor(mission_planner)!: add autoware prefix and namespace (`#7414 <https://github.com/autowarefoundation/autoware.universe/issues/7414>`_)
   * refactor(mission_planner)!: add autoware prefix and namespace
   * fix svg
   ---------
-* refactor(freespace_planner)!: add autoware prefix (`#7376 <https://github.com/youtalk/autoware.universe/issues/7376>`_)
+* refactor(freespace_planner)!: add autoware prefix (`#7376 <https://github.com/autowarefoundation/autoware.universe/issues/7376>`_)
   refactor(freespace_planner)!: add autoawre prefix
-* refactor(external_cmd_selector): prefix package and namespace with au… (`#7384 <https://github.com/youtalk/autoware.universe/issues/7384>`_)
+* refactor(external_cmd_selector): prefix package and namespace with au… (`#7384 <https://github.com/autowarefoundation/autoware.universe/issues/7384>`_)
   refactor(external_cmd_selector): prefix package and namespace with autoware\_
-* refactor(scenario_selector): prefix package and namespace with autoware\_ (`#7379 <https://github.com/youtalk/autoware.universe/issues/7379>`_)
-* fix(motion_planning.launch): fix input traj of obstacle_velocity_limiter (`#7386 <https://github.com/youtalk/autoware.universe/issues/7386>`_)
-* refactor(out_of_lane): remove from behavior_velocity (`#7359 <https://github.com/youtalk/autoware.universe/issues/7359>`_)
-* refactor(path_smoother)!: prefix package and namespace with autoware (`#7381 <https://github.com/youtalk/autoware.universe/issues/7381>`_)
+* refactor(scenario_selector): prefix package and namespace with autoware\_ (`#7379 <https://github.com/autowarefoundation/autoware.universe/issues/7379>`_)
+* fix(motion_planning.launch): fix input traj of obstacle_velocity_limiter (`#7386 <https://github.com/autowarefoundation/autoware.universe/issues/7386>`_)
+* refactor(out_of_lane): remove from behavior_velocity (`#7359 <https://github.com/autowarefoundation/autoware.universe/issues/7359>`_)
+* refactor(path_smoother)!: prefix package and namespace with autoware (`#7381 <https://github.com/autowarefoundation/autoware.universe/issues/7381>`_)
   * git mv
   * fix
   * fix launch
@@ -168,47 +168,47 @@ Changelog for package tier4_planning_launch
   * fix static_centerline_optimizer
   * fix
   ---------
-* fix(tier4_planning_launch): unexpected modules were registered (`#7377 <https://github.com/youtalk/autoware.universe/issues/7377>`_)
-* refactor(costmap_generator)!: add autoware prefix (`#7329 <https://github.com/youtalk/autoware.universe/issues/7329>`_)
+* fix(tier4_planning_launch): unexpected modules were registered (`#7377 <https://github.com/autowarefoundation/autoware.universe/issues/7377>`_)
+* refactor(costmap_generator)!: add autoware prefix (`#7329 <https://github.com/autowarefoundation/autoware.universe/issues/7329>`_)
   refactor(costmap_generator): add autoware prefix
-* refactor(path_optimizer, velocity_smoother)!: prefix package and namespace with autoware (`#7354 <https://github.com/youtalk/autoware.universe/issues/7354>`_)
+* refactor(path_optimizer, velocity_smoother)!: prefix package and namespace with autoware (`#7354 <https://github.com/autowarefoundation/autoware.universe/issues/7354>`_)
   * chore(autoware_velocity_smoother): update namespace
   * chore(autoware_path_optimizer): update namespace
   ---------
-* refactor(planning_validator)!: prefix package and namespace with autoware (`#7320 <https://github.com/youtalk/autoware.universe/issues/7320>`_)
+* refactor(planning_validator)!: prefix package and namespace with autoware (`#7320 <https://github.com/autowarefoundation/autoware.universe/issues/7320>`_)
   * add autoware\_ prefix to planning_validator
   * add prefix to package name in .pages
   * fix link of the image
   ---------
-* refactor(behavior_velocity_planner_common)!: prefix package and namespace with autoware (`#7314 <https://github.com/youtalk/autoware.universe/issues/7314>`_)
+* refactor(behavior_velocity_planner_common)!: prefix package and namespace with autoware (`#7314 <https://github.com/autowarefoundation/autoware.universe/issues/7314>`_)
   * refactor(behavior_velocity_planner_common): add autoware prefix
   * refactor(behavior_velocity_planner_common): fix run_out module
   * refactor(behavior_velocity_planner_common): fix for autoware_behavior_velocity_walkway_module
   * refactor(behavior_velocity_planner_common): remove unnecessary using
   ---------
-* refactor(sampling_based_planner): add autoware prefix (`#7348 <https://github.com/youtalk/autoware.universe/issues/7348>`_)
-* refactor(surround_obstacle_checker)!: prefix package and namespace with autoware (`#7298 <https://github.com/youtalk/autoware.universe/issues/7298>`_)
+* refactor(sampling_based_planner): add autoware prefix (`#7348 <https://github.com/autowarefoundation/autoware.universe/issues/7348>`_)
+* refactor(surround_obstacle_checker)!: prefix package and namespace with autoware (`#7298 <https://github.com/autowarefoundation/autoware.universe/issues/7298>`_)
   * fix(autoware_surround_obstacle_checker): rename
   * fix(autoware_surround_obstacle_checker): rename header
   * fix(launch): update package name
   ---------
-* refactor(autoware_velocity_walkway_module): prefix package with autoware\_ and move code to the autoware namespace (`#7153 <https://github.com/youtalk/autoware.universe/issues/7153>`_)
+* refactor(autoware_velocity_walkway_module): prefix package with autoware\_ and move code to the autoware namespace (`#7153 <https://github.com/autowarefoundation/autoware.universe/issues/7153>`_)
   * refactor(autoware_velocity_walkway_module): prefix package with autoware\_ and move code to the autoware namespace
   * style(pre-commit): autofix
   * fix: fix issue loading packages that have been prefixed
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* chore(autoware_planning_topic_converter): add prefix `autoware\_` (`#7296 <https://github.com/youtalk/autoware.universe/issues/7296>`_)
+* chore(autoware_planning_topic_converter): add prefix `autoware\_` (`#7296 <https://github.com/autowarefoundation/autoware.universe/issues/7296>`_)
   chore(autoware_planning_topic_converter): rename
-* chore(autoware_external_velocity_limit_selector): add prefix `autoware\_` (`#7295 <https://github.com/youtalk/autoware.universe/issues/7295>`_)
+* chore(autoware_external_velocity_limit_selector): add prefix `autoware\_` (`#7295 <https://github.com/autowarefoundation/autoware.universe/issues/7295>`_)
   chore(autoware_external_velocity_limit_selector): rename
-* refactor(autoware_velocity_run_out_module): prefix package with autoware\_ and move code to the autoware namespace (`#7154 <https://github.com/youtalk/autoware.universe/issues/7154>`_)
+* refactor(autoware_velocity_run_out_module): prefix package with autoware\_ and move code to the autoware namespace (`#7154 <https://github.com/autowarefoundation/autoware.universe/issues/7154>`_)
   * refactor(autoware_velocity_run_out_module): prefix package with autoware\_ and move code to the autoware namespace
   * style(pre-commit): autofix
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* refactor(autoware_velocity_virtual_traffic_light_module): prefix package with autoware\_ and move code to the autoware namespace (`#7155 <https://github.com/youtalk/autoware.universe/issues/7155>`_)
-* feat!: replace autoware_auto_msgs with autoware_msgs for launch files (`#7242 <https://github.com/youtalk/autoware.universe/issues/7242>`_)
+* refactor(autoware_velocity_virtual_traffic_light_module): prefix package with autoware\_ and move code to the autoware namespace (`#7155 <https://github.com/autowarefoundation/autoware.universe/issues/7155>`_)
+* feat!: replace autoware_auto_msgs with autoware_msgs for launch files (`#7242 <https://github.com/autowarefoundation/autoware.universe/issues/7242>`_)
   * feat!: replace autoware_auto_msgs with autoware_msgs for launch files
   Co-authored-by: Cynthia Liu <cynthia.liu@autocore.ai>
   Co-authored-by: NorahXiong <norah.xiong@autocore.ai>
@@ -219,7 +219,7 @@ Changelog for package tier4_planning_launch
   Co-authored-by: NorahXiong <norah.xiong@autocore.ai>
   Co-authored-by: beginningfan <beginning.fan@autocore.ai>
   Co-authored-by: Yukihiro Saito <yukky.saito@gmail.com>
-* chore(autoware_velocity_smoother, autoware_path_optimizer): rename packages (`#7202 <https://github.com/youtalk/autoware.universe/issues/7202>`_)
+* chore(autoware_velocity_smoother, autoware_path_optimizer): rename packages (`#7202 <https://github.com/autowarefoundation/autoware.universe/issues/7202>`_)
   * chore(autoware_path_optimizer): rename package and namespace
   * chore(autoware_static_centerline_generator): rename package and namespace
   * chore: update module name
@@ -230,7 +230,7 @@ Changelog for package tier4_planning_launch
   * fix: test
   * fix: test
   ---------
-* chore(static_obstacle_avoidance, dynamic_obstacle_avoidance): rename avoidance package (`#7168 <https://github.com/youtalk/autoware.universe/issues/7168>`_)
+* chore(static_obstacle_avoidance, dynamic_obstacle_avoidance): rename avoidance package (`#7168 <https://github.com/autowarefoundation/autoware.universe/issues/7168>`_)
   * chore(autoware_behavior_path_static_obstacle_avoidance_module): rename package and namespace
   * chore(autoware_behavior_path_dynamic_obstacle_avoidance_module): rename package and namespace
   * chore(tier4_planning_launch): update module name
@@ -240,13 +240,13 @@ Changelog for package tier4_planning_launch
   * fix(AbLC): fix file name
   * docs: update module name
   ---------
-* feat(motion_velocity_planner): add new motion velocity planning (`#7064 <https://github.com/youtalk/autoware.universe/issues/7064>`_)
-* refactor(behavior_velocity_planner)!: prefix package and namespace with autoware\_ (`#6693 <https://github.com/youtalk/autoware.universe/issues/6693>`_)
-* build(behavior_path_external_request_lane_change_module): prefix package and namespace with autoware\_ (`#6636 <https://github.com/youtalk/autoware.universe/issues/6636>`_)
-* feat: add autoware_remaining_distance_time_calculator and overlay (`#6855 <https://github.com/youtalk/autoware.universe/issues/6855>`_)
-* revert: "feat(logger_level_configure): make it possible to change level of container logger (`#6823 <https://github.com/youtalk/autoware.universe/issues/6823>`_)" (`#6842 <https://github.com/youtalk/autoware.universe/issues/6842>`_)
+* feat(motion_velocity_planner): add new motion velocity planning (`#7064 <https://github.com/autowarefoundation/autoware.universe/issues/7064>`_)
+* refactor(behavior_velocity_planner)!: prefix package and namespace with autoware\_ (`#6693 <https://github.com/autowarefoundation/autoware.universe/issues/6693>`_)
+* build(behavior_path_external_request_lane_change_module): prefix package and namespace with autoware\_ (`#6636 <https://github.com/autowarefoundation/autoware.universe/issues/6636>`_)
+* feat: add autoware_remaining_distance_time_calculator and overlay (`#6855 <https://github.com/autowarefoundation/autoware.universe/issues/6855>`_)
+* revert: "feat(logger_level_configure): make it possible to change level of container logger (`#6823 <https://github.com/autowarefoundation/autoware.universe/issues/6823>`_)" (`#6842 <https://github.com/autowarefoundation/autoware.universe/issues/6842>`_)
   This reverts commit 51b5f830780eb69bd1a7dfe60e295773f394fd8e.
-* feat(logger_level_configure): make it possible to change level of container logger (`#6823 <https://github.com/youtalk/autoware.universe/issues/6823>`_)
+* feat(logger_level_configure): make it possible to change level of container logger (`#6823 <https://github.com/autowarefoundation/autoware.universe/issues/6823>`_)
   * feat(launch): add logging_demo::LoggerConfig into container
   * fix(logger_level_reconfigure_plugin): fix yaml
   * feat(logging_level_configure): add composable node
@@ -255,13 +255,13 @@ Changelog for package tier4_planning_launch
 
 0.26.0 (2024-04-03)
 -------------------
-* chore(tier4_planning_launch): set log output both (`#6685 <https://github.com/youtalk/autoware.universe/issues/6685>`_)
-* feat(traffic_light): depend on is_simulation for scenario simulator (`#6498 <https://github.com/youtalk/autoware.universe/issues/6498>`_)
+* chore(tier4_planning_launch): set log output both (`#6685 <https://github.com/autowarefoundation/autoware.universe/issues/6685>`_)
+* feat(traffic_light): depend on is_simulation for scenario simulator (`#6498 <https://github.com/autowarefoundation/autoware.universe/issues/6498>`_)
   * feat(traffic_light): depend on is_simulation for scenario simulator
   * fix comments
   * fix
   ---------
-* feat(mission_planner)!: introduce route_selector node (`#6363 <https://github.com/youtalk/autoware.universe/issues/6363>`_)
+* feat(mission_planner)!: introduce route_selector node (`#6363 <https://github.com/autowarefoundation/autoware.universe/issues/6363>`_)
   * feat(mission_planner): introduce route_selector node
   * remove unused file
   * fix use goal pose only when resuming
@@ -274,7 +274,7 @@ Changelog for package tier4_planning_launch
   * remove debug code
   * use full license text instead of spdx
   ---------
-* feat: remove use_pointcloud_container (`#6115 <https://github.com/youtalk/autoware.universe/issues/6115>`_)
+* feat: remove use_pointcloud_container (`#6115 <https://github.com/autowarefoundation/autoware.universe/issues/6115>`_)
   * feat!: remove use_pointcloud_container
   * fix pre-commit
   * fix: completely remove use_pointcloud_container after merge main
@@ -282,7 +282,7 @@ Changelog for package tier4_planning_launch
   * revert: revert change in probabilistic_occupancy_grid_map
   * revert change in launcher of ogm
   ---------
-* feat(behavior_path_sampling_module): add sampling based planner  (`#6131 <https://github.com/youtalk/autoware.universe/issues/6131>`_)
+* feat(behavior_path_sampling_module): add sampling based planner  (`#6131 <https://github.com/autowarefoundation/autoware.universe/issues/6131>`_)
   * first commit: add only necessary bpp code for template
   * change name of file
   * delete more unrelated code
@@ -400,27 +400,27 @@ Changelog for package tier4_planning_launch
   * remove unused commented code
   ---------
   Co-authored-by: Maxime CLEMENT <maxime.clement@tier4.jp>
-* feat(behavior_velocity_planner): add enable_all_modules_auto_mode argument to launch files for behavior velocity planner modules (`#6094 <https://github.com/youtalk/autoware.universe/issues/6094>`_)
+* feat(behavior_velocity_planner): add enable_all_modules_auto_mode argument to launch files for behavior velocity planner modules (`#6094 <https://github.com/autowarefoundation/autoware.universe/issues/6094>`_)
   * set default value for enable_all_modules_auto_mode
   * fix enable_rtc configuration in scene_module_manager_interface.hpp
   * Refactor scene module managers to use getEnableRTC function
   ---------
-* feat(behavior_path_planner): add enable_all_modules_auto_mode argument to launch files for behavior path planner modules (`#6093 <https://github.com/youtalk/autoware.universe/issues/6093>`_)
+* feat(behavior_path_planner): add enable_all_modules_auto_mode argument to launch files for behavior path planner modules (`#6093 <https://github.com/autowarefoundation/autoware.universe/issues/6093>`_)
   * Add enable_all_modules_auto_mode argument to launch files
   * set default value for enable_all_modules_auto_mode
   * fix enable_rtc configuration in scene_module_manager_interface.hpp
   ---------
-* refactor(tier4_planning_launch): remove duplicate arguments in launchfile (`#6040 <https://github.com/youtalk/autoware.universe/issues/6040>`_)
-* feat(behavior_velocity_planner): add new 'dynamic_obstacle_stop' module (`#5835 <https://github.com/youtalk/autoware.universe/issues/5835>`_)
-* refactor(behavior_path_planner): remove use_experimental_lane_change_function (`#5889 <https://github.com/youtalk/autoware.universe/issues/5889>`_)
-* fix(behavior, launch): fix launch error (`#5847 <https://github.com/youtalk/autoware.universe/issues/5847>`_)
+* refactor(tier4_planning_launch): remove duplicate arguments in launchfile (`#6040 <https://github.com/autowarefoundation/autoware.universe/issues/6040>`_)
+* feat(behavior_velocity_planner): add new 'dynamic_obstacle_stop' module (`#5835 <https://github.com/autowarefoundation/autoware.universe/issues/5835>`_)
+* refactor(behavior_path_planner): remove use_experimental_lane_change_function (`#5889 <https://github.com/autowarefoundation/autoware.universe/issues/5889>`_)
+* fix(behavior, launch): fix launch error (`#5847 <https://github.com/autowarefoundation/autoware.universe/issues/5847>`_)
   * fix(launch): set null to avoid launch error
   * fix(behavior): check null
   * chore(behavior): add comment
   * fix(launch): set  at the end of list
   * fix(launch): fill empty string at the end of module list
   ---------
-* refactor(bpp): use pluginlib to load scene module (`#5771 <https://github.com/youtalk/autoware.universe/issues/5771>`_)
+* refactor(bpp): use pluginlib to load scene module (`#5771 <https://github.com/autowarefoundation/autoware.universe/issues/5771>`_)
   * refactor(bpp): use pluginlib
   * refactor(tier4_planning_launch): update launcher
   * refactor(avoidance): support pluginlib
@@ -432,30 +432,30 @@ Changelog for package tier4_planning_launch
   * refactor(bpp): move interface
   * fix(bpp): add const
   ---------
-* fix(tier4_planning_launch): obstacle_cruise_planner pipeline is not connected (`#5542 <https://github.com/youtalk/autoware.universe/issues/5542>`_)
-* refactor(tier4_planning_launch): align argument name (`#5505 <https://github.com/youtalk/autoware.universe/issues/5505>`_)
+* fix(tier4_planning_launch): obstacle_cruise_planner pipeline is not connected (`#5542 <https://github.com/autowarefoundation/autoware.universe/issues/5542>`_)
+* refactor(tier4_planning_launch): align argument name (`#5505 <https://github.com/autowarefoundation/autoware.universe/issues/5505>`_)
   * chore(tier4_planning_launch): align arument name
   * refactor(tier4_planning_launch): pass params directly
   ---------
-* refactor(tier4_planning_launch): use xml style launch (`#5502 <https://github.com/youtalk/autoware.universe/issues/5502>`_)
+* refactor(tier4_planning_launch): use xml style launch (`#5502 <https://github.com/autowarefoundation/autoware.universe/issues/5502>`_)
   * refactor(tier4_planning_launch): use xml style launch
   * refactor(tier4_planning_launch): remove python style launch
   * fix(tier4_planning_launch): enable console output
   ---------
-* chore(planning modules): remove maintainer... (`#5458 <https://github.com/youtalk/autoware.universe/issues/5458>`_)
+* chore(planning modules): remove maintainer... (`#5458 <https://github.com/autowarefoundation/autoware.universe/issues/5458>`_)
   remove shimizu-san from maintainer and add maintainer for stop line and turn signal decider
-* refactor(tier4_planning_launch): use xml style launch (`#5470 <https://github.com/youtalk/autoware.universe/issues/5470>`_)
+* refactor(tier4_planning_launch): use xml style launch (`#5470 <https://github.com/autowarefoundation/autoware.universe/issues/5470>`_)
   * refactor(tier4_planning_launch): use xml style launch
   * refactor(tier4_planning_launch): remove python style launch
   * fix(tier4_plannning_launch): fix namespace
   ---------
-* refactor(tier4_planning_launch): use xml style launch (`#5448 <https://github.com/youtalk/autoware.universe/issues/5448>`_)
+* refactor(tier4_planning_launch): use xml style launch (`#5448 <https://github.com/autowarefoundation/autoware.universe/issues/5448>`_)
   * refactor(tier4_planning_launch): use xml style launch
   * refactor(tier4_planning_launch): remove python style launch
   ---------
-* feat(behavior_path_planner): subscribe traffic light recognition result (`#5436 <https://github.com/youtalk/autoware.universe/issues/5436>`_)
+* feat(behavior_path_planner): subscribe traffic light recognition result (`#5436 <https://github.com/autowarefoundation/autoware.universe/issues/5436>`_)
   feat(avoidance): use traffic light signal info
-* feat(rtc_auto_mode_manager): eliminate rtc auto mode manager (`#5235 <https://github.com/youtalk/autoware.universe/issues/5235>`_)
+* feat(rtc_auto_mode_manager): eliminate rtc auto mode manager (`#5235 <https://github.com/autowarefoundation/autoware.universe/issues/5235>`_)
   * change namespace of auto_mode
   * delete RTC auto mode manager package
   * delete rtc_replayer.param
@@ -464,7 +464,7 @@ Changelog for package tier4_planning_launch
   * fix typo
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat(behavior_velocity): support new traffic signal interface (`#4133 <https://github.com/youtalk/autoware.universe/issues/4133>`_)
+* feat(behavior_velocity): support new traffic signal interface (`#4133 <https://github.com/autowarefoundation/autoware.universe/issues/4133>`_)
   * feat(behavior_velocity): support new traffic signal interface
   * style(pre-commit): autofix
   * add missing dependency
@@ -481,12 +481,12 @@ Changelog for package tier4_planning_launch
   * add debug log when the signal data is outdated
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat(mission_planning.launch): add glog in mission planner (`#4745 <https://github.com/youtalk/autoware.universe/issues/4745>`_)
-* feat(motion_velocity_smoother.launch): add glog component (`#4746 <https://github.com/youtalk/autoware.universe/issues/4746>`_)
+* feat(mission_planning.launch): add glog in mission planner (`#4745 <https://github.com/autowarefoundation/autoware.universe/issues/4745>`_)
+* feat(motion_velocity_smoother.launch): add glog component (`#4746 <https://github.com/autowarefoundation/autoware.universe/issues/4746>`_)
   * use node instead of include
   * use container & add glog component
   ---------
-* feat(glog): add glog in planning and control modules (`#4714 <https://github.com/youtalk/autoware.universe/issues/4714>`_)
+* feat(glog): add glog in planning and control modules (`#4714 <https://github.com/autowarefoundation/autoware.universe/issues/4714>`_)
   * feat(glog): add glog component
   * formatting
   * remove namespace
@@ -502,9 +502,9 @@ Changelog for package tier4_planning_launch
   * add copyright
   ---------
   Co-authored-by: Daisuke Nishimatsu <42202095+wep21@users.noreply.github.com>
-* chore(tier4_planning_launch): enable to abort lane change from a parameter file (`#4469 <https://github.com/youtalk/autoware.universe/issues/4469>`_)
-* refactor(behavior_path_planner): remove unused config files (`#4241 <https://github.com/youtalk/autoware.universe/issues/4241>`_)
-* refactor(obstacle_avoidance_planner): move the elastic band smoothing to a new package (`#4114 <https://github.com/youtalk/autoware.universe/issues/4114>`_)
+* chore(tier4_planning_launch): enable to abort lane change from a parameter file (`#4469 <https://github.com/autowarefoundation/autoware.universe/issues/4469>`_)
+* refactor(behavior_path_planner): remove unused config files (`#4241 <https://github.com/autowarefoundation/autoware.universe/issues/4241>`_)
+* refactor(obstacle_avoidance_planner): move the elastic band smoothing to a new package (`#4114 <https://github.com/autowarefoundation/autoware.universe/issues/4114>`_)
   * Add path_smoothing package
   * Add elastic band smoother node
   * Add Debug section to elastic band documentation
@@ -515,13 +515,13 @@ Changelog for package tier4_planning_launch
   * Publish path with backward paths
   * Rename path_smoothing -> path_smoother
   ---------
-* fix(obstacle_velocity_limiter): remove hardcoded parameter (`#4098 <https://github.com/youtalk/autoware.universe/issues/4098>`_)
-* refactor(lane_change): add namespace for lane-change-cancel (`#4090 <https://github.com/youtalk/autoware.universe/issues/4090>`_)
+* fix(obstacle_velocity_limiter): remove hardcoded parameter (`#4098 <https://github.com/autowarefoundation/autoware.universe/issues/4098>`_)
+* refactor(lane_change): add namespace for lane-change-cancel (`#4090 <https://github.com/autowarefoundation/autoware.universe/issues/4090>`_)
   * refactor(lane_change): add namespace for lane-change-cancel
   * fix indent
   * lane_change_cancel -> cancel
   ---------
-* refactor(behavior_velocity_planner): update launch and parameter files for plugin (`#3811 <https://github.com/youtalk/autoware.universe/issues/3811>`_)
+* refactor(behavior_velocity_planner): update launch and parameter files for plugin (`#3811 <https://github.com/autowarefoundation/autoware.universe/issues/3811>`_)
   * feat: move param files
   * WIP
   * feat: use behavior velocity module param file list
@@ -535,22 +535,22 @@ Changelog for package tier4_planning_launch
   * move param
   * add test depend
   ---------
-* refactor(start_planner): rename pull out to start planner (`#3908 <https://github.com/youtalk/autoware.universe/issues/3908>`_)
-* feat: handle invalid areas / lanelets (`#3000 <https://github.com/youtalk/autoware.universe/issues/3000>`_)
-* feat(behavior_path_planner): output stop reasons (`#3807 <https://github.com/youtalk/autoware.universe/issues/3807>`_)
+* refactor(start_planner): rename pull out to start planner (`#3908 <https://github.com/autowarefoundation/autoware.universe/issues/3908>`_)
+* feat: handle invalid areas / lanelets (`#3000 <https://github.com/autowarefoundation/autoware.universe/issues/3000>`_)
+* feat(behavior_path_planner): output stop reasons (`#3807 <https://github.com/autowarefoundation/autoware.universe/issues/3807>`_)
   * feat(launch): remap stop reasons
   * feat(behavior_path_planner): add interface to output stop reasons
   * feat(behavior_path_planner): add interface to output stop reasons
   * feat(avoidance): output stop reason
   ---------
-* feat(path_sampler): add a sampling based path planner (`#3532 <https://github.com/youtalk/autoware.universe/issues/3532>`_)
-* style: fix typos (`#3617 <https://github.com/youtalk/autoware.universe/issues/3617>`_)
+* feat(path_sampler): add a sampling based path planner (`#3532 <https://github.com/autowarefoundation/autoware.universe/issues/3532>`_)
+* style: fix typos (`#3617 <https://github.com/autowarefoundation/autoware.universe/issues/3617>`_)
   * style: fix typos in documents
   * style: fix typos in package.xml
   * style: fix typos in launch files
   * style: fix typos in comments
   ---------
-* build: mark autoware_cmake as <buildtool_depend> (`#3616 <https://github.com/youtalk/autoware.universe/issues/3616>`_)
+* build: mark autoware_cmake as <buildtool_depend> (`#3616 <https://github.com/autowarefoundation/autoware.universe/issues/3616>`_)
   * build: mark autoware_cmake as <buildtool_depend>
   with <build_depend>, autoware_cmake is automatically exported with ament_target_dependencies() (unecessary)
   * style(pre-commit): autofix
@@ -558,7 +558,7 @@ Changelog for package tier4_planning_launch
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Kenji Miyake <kenji.miyake@tier4.jp>
-* feat(behavior_path_planner): add dynamic obstacle avoidance module (`#3415 <https://github.com/youtalk/autoware.universe/issues/3415>`_)
+* feat(behavior_path_planner): add dynamic obstacle avoidance module (`#3415 <https://github.com/autowarefoundation/autoware.universe/issues/3415>`_)
   * implement dynamic avoidance module
   * update
   * update
@@ -576,18 +576,18 @@ Changelog for package tier4_planning_launch
   * fix
   ---------
   Co-authored-by: Satoshi OTA <44889564+satoshi-ota@users.noreply.github.com>
-* refactor(behavior_path_planner): rename pull_over to goal_planner (`#3501 <https://github.com/youtalk/autoware.universe/issues/3501>`_)
-* refactor(behavior_path_planeer): use common.params for lane change (`#3520 <https://github.com/youtalk/autoware.universe/issues/3520>`_)
+* refactor(behavior_path_planner): rename pull_over to goal_planner (`#3501 <https://github.com/autowarefoundation/autoware.universe/issues/3501>`_)
+* refactor(behavior_path_planeer): use common.params for lane change (`#3520 <https://github.com/autowarefoundation/autoware.universe/issues/3520>`_)
   * refactor(behavior_path_planeer): use common.params for lane change
   * update
   ---------
-* feat(behavior_path_planner): move lane_following_params to behavior path params (`#3445 <https://github.com/youtalk/autoware.universe/issues/3445>`_)
+* feat(behavior_path_planner): move lane_following_params to behavior path params (`#3445 <https://github.com/autowarefoundation/autoware.universe/issues/3445>`_)
   * feat(behavior_path_planner): move lane_following_params to behavior path params
   * fix missing pakage include
   * fix test
   ---------
-* chore(planning_evaluator): add dependency (`#3388 <https://github.com/youtalk/autoware.universe/issues/3388>`_)
-* feat(behavior_velocity_planner): add out of lane module (`#3191 <https://github.com/youtalk/autoware.universe/issues/3191>`_)
+* chore(planning_evaluator): add dependency (`#3388 <https://github.com/autowarefoundation/autoware.universe/issues/3388>`_)
+* feat(behavior_velocity_planner): add out of lane module (`#3191 <https://github.com/autowarefoundation/autoware.universe/issues/3191>`_)
   * Add OutOfLane module to the behavior_velocity_planner
   * Add functions for calculating path footprint and overlaps (WIP)
   * Update behavior_planning launch file to add out_of_lane param file
@@ -650,7 +650,7 @@ Changelog for package tier4_planning_launch
   * Remove default value for declare_parameter of 'launch_run_out'
   ---------
   Co-authored-by: Satoshi OTA <44889564+satoshi-ota@users.noreply.github.com>
-* feat(avoidance_by_lc): add new module to avoid obstacle by lane change (`#3125 <https://github.com/youtalk/autoware.universe/issues/3125>`_)
+* feat(avoidance_by_lc): add new module to avoid obstacle by lane change (`#3125 <https://github.com/autowarefoundation/autoware.universe/issues/3125>`_)
   * feat(rtc_interface): add new module avoidance by lc
   * feat(launch): add new param files
   * feat(avoidance_by_lc): add avoidance by lane change module
@@ -660,12 +660,12 @@ Changelog for package tier4_planning_launch
   * fix request condition
   * fix build error
   ---------
-* feat(behavior_path_planner): update behavior param file (`#3220 <https://github.com/youtalk/autoware.universe/issues/3220>`_)
+* feat(behavior_path_planner): update behavior param file (`#3220 <https://github.com/autowarefoundation/autoware.universe/issues/3220>`_)
   * feat(behavior_path_planner): add new config file for manger
   * feat(launch): add config path
   * fix(behavior_path_planner): add missing param file
   ---------
-* feat(diagnostic_converter): add converter to use planning_evaluator's output for scenario's condition (`#2514 <https://github.com/youtalk/autoware.universe/issues/2514>`_)
+* feat(diagnostic_converter): add converter to use planning_evaluator's output for scenario's condition (`#2514 <https://github.com/autowarefoundation/autoware.universe/issues/2514>`_)
   * add original diagnostic_convertor
   * add test
   * fix typo
@@ -715,8 +715,8 @@ Changelog for package tier4_planning_launch
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Maxime CLEMENT <78338830+maxime-clem@users.noreply.github.com>
-* feat(mission_planner): refine goal pose with parameter and add config file (`#2603 <https://github.com/youtalk/autoware.universe/issues/2603>`_)
-* feat(behavior_path_planner): pull over freespace parking (`#2879 <https://github.com/youtalk/autoware.universe/issues/2879>`_)
+* feat(mission_planner): refine goal pose with parameter and add config file (`#2603 <https://github.com/autowarefoundation/autoware.universe/issues/2603>`_)
+* feat(behavior_path_planner): pull over freespace parking (`#2879 <https://github.com/autowarefoundation/autoware.universe/issues/2879>`_)
   * feat(behavior_path_planner): pull over freespace parking
   * Update planning/behavior_path_planner/include/behavior_path_planner/scene_module/pull_over/pull_over_module.hpp
   Co-authored-by: Takamasa Horibe <horibe.takamasa@gmail.com>
@@ -729,19 +729,19 @@ Changelog for package tier4_planning_launch
   * pre-commit
   ---------
   Co-authored-by: Takamasa Horibe <horibe.takamasa@gmail.com>
-* refactor(obstacle_avoidance_planner): clean up the code (`#2796 <https://github.com/youtalk/autoware.universe/issues/2796>`_)
+* refactor(obstacle_avoidance_planner): clean up the code (`#2796 <https://github.com/autowarefoundation/autoware.universe/issues/2796>`_)
   * update obstacle avoidance planner, static centerline optimizer, tier4_planning_launch
   * update velocity on joint and correct trajectory z
   * update
   * minor change
   * pre-commit
   ---------
-* refactor(planning_error_monitor): remove pkg (`#2604 <https://github.com/youtalk/autoware.universe/issues/2604>`_)
+* refactor(planning_error_monitor): remove pkg (`#2604 <https://github.com/autowarefoundation/autoware.universe/issues/2604>`_)
   * remove planning_error_monitor
   * remove launch
   ---------
-* fix(tier4_planning_launch): remove unnecessary config (`#2910 <https://github.com/youtalk/autoware.universe/issues/2910>`_)
-* feat(behavior_velocity): add mandatory detection area for run out module (`#2864 <https://github.com/youtalk/autoware.universe/issues/2864>`_)
+* fix(tier4_planning_launch): remove unnecessary config (`#2910 <https://github.com/autowarefoundation/autoware.universe/issues/2910>`_)
+* feat(behavior_velocity): add mandatory detection area for run out module (`#2864 <https://github.com/autowarefoundation/autoware.universe/issues/2864>`_)
   * feat: add mandatory detection area
   * change the topic order to subscribe compare map filtered points
   * define function for transform pointcloud
@@ -763,12 +763,12 @@ Changelog for package tier4_planning_launch
   * style(pre-commit): autofix
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat(behavior_path_planner): expand the drivable area based on the vehicle footprint (`#2609 <https://github.com/youtalk/autoware.universe/issues/2609>`_)
-* ci(pre-commit): autoupdate (`#2819 <https://github.com/youtalk/autoware.universe/issues/2819>`_)
+* feat(behavior_path_planner): expand the drivable area based on the vehicle footprint (`#2609 <https://github.com/autowarefoundation/autoware.universe/issues/2609>`_)
+* ci(pre-commit): autoupdate (`#2819 <https://github.com/autowarefoundation/autoware.universe/issues/2819>`_)
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* chore(tier4_planning_launch): add missing params and sort params of costmap generator (`#2764 <https://github.com/youtalk/autoware.universe/issues/2764>`_)
-* refactor(behavior_path_planner): set occupancy grid map topic name from launch (`#2725 <https://github.com/youtalk/autoware.universe/issues/2725>`_)
-* feat(behavior_path_planner): external request lane change (`#2442 <https://github.com/youtalk/autoware.universe/issues/2442>`_)
+* chore(tier4_planning_launch): add missing params and sort params of costmap generator (`#2764 <https://github.com/autowarefoundation/autoware.universe/issues/2764>`_)
+* refactor(behavior_path_planner): set occupancy grid map topic name from launch (`#2725 <https://github.com/autowarefoundation/autoware.universe/issues/2725>`_)
+* feat(behavior_path_planner): external request lane change (`#2442 <https://github.com/autowarefoundation/autoware.universe/issues/2442>`_)
   * feature(behavior_path_planner): add external request lane change module
   feature(behavior_path_planner): fix for RTC
   feature(behavior_path_planner): fix decision logic
@@ -790,7 +790,7 @@ Changelog for package tier4_planning_launch
   * Update rtc_auto_mode_manager.param.yaml
   * fix(route_handler): remove redundant code
   * fix(behavior_path_planner): fix for turn signal
-* feat(planning_validator): add planning validator package (`#1947 <https://github.com/youtalk/autoware.universe/issues/1947>`_)
+* feat(planning_validator): add planning validator package (`#1947 <https://github.com/autowarefoundation/autoware.universe/issues/1947>`_)
   * feat(planning_validator): add planning validator package
   * remove planning_error_monitor
   * pre-commit
@@ -827,21 +827,21 @@ Changelog for package tier4_planning_launch
   * update doc!
   * fix readme
   * update
-* feat(behavior_path_planner): modified goal with uuid (`#2602 <https://github.com/youtalk/autoware.universe/issues/2602>`_)
+* feat(behavior_path_planner): modified goal with uuid (`#2602 <https://github.com/autowarefoundation/autoware.universe/issues/2602>`_)
   * feat(behavior_path_planner): modified goal with uuid
   * fix typo
   * fix for top header
   * change to PoseWithUuidStamped
-* fix(tier4_planning_launch): make use_experimental_lane_change_function available (`#2676 <https://github.com/youtalk/autoware.universe/issues/2676>`_)
-* refactor(tier4_planning_launch): organize arguments (`#2666 <https://github.com/youtalk/autoware.universe/issues/2666>`_)
+* fix(tier4_planning_launch): make use_experimental_lane_change_function available (`#2676 <https://github.com/autowarefoundation/autoware.universe/issues/2676>`_)
+* refactor(tier4_planning_launch): organize arguments (`#2666 <https://github.com/autowarefoundation/autoware.universe/issues/2666>`_)
   * refactor(tier4_planning_launch): organize arguments
   * update
-* feat(behavior_path_planner): param to skip some linestring types when expanding the drivable area (`#2288 <https://github.com/youtalk/autoware.universe/issues/2288>`_)
-* feat(behavior_velocity_planner): add speed bump module (`#647 <https://github.com/youtalk/autoware.universe/issues/647>`_)
+* feat(behavior_path_planner): param to skip some linestring types when expanding the drivable area (`#2288 <https://github.com/autowarefoundation/autoware.universe/issues/2288>`_)
+* feat(behavior_velocity_planner): add speed bump module (`#647 <https://github.com/autowarefoundation/autoware.universe/issues/647>`_)
   Co-authored-by: Kosuke Takeuchi <kosuke.tnp@gmail.com>
   Co-authored-by: Takayuki Murooka <takayuki5168@gmail.com>
-* fix(tier4_planning_launch): remove unintended config file (`#2554 <https://github.com/youtalk/autoware.universe/issues/2554>`_)
-* feat(tier4_planning_launch): remove configs and move to autoware_launch (`#2543 <https://github.com/youtalk/autoware.universe/issues/2543>`_)
+* fix(tier4_planning_launch): remove unintended config file (`#2554 <https://github.com/autowarefoundation/autoware.universe/issues/2554>`_)
+* feat(tier4_planning_launch): remove configs and move to autoware_launch (`#2543 <https://github.com/autowarefoundation/autoware.universe/issues/2543>`_)
   * feat(tier4_planning_launch): remove configs and move to autoware_launch
   * fix
   * remove config
@@ -849,15 +849,15 @@ Changelog for package tier4_planning_launch
   * Update launch/tier4_planning_launch/README.md
   Co-authored-by: kminoda <44218668+kminoda@users.noreply.github.com>
   Co-authored-by: kminoda <44218668+kminoda@users.noreply.github.com>
-* fix(intersection): fixed stuck vehicle detection area (`#2463 <https://github.com/youtalk/autoware.universe/issues/2463>`_)
-* feat(behavior_path_planner): remove unnecessary parameters (`#2516 <https://github.com/youtalk/autoware.universe/issues/2516>`_)
+* fix(intersection): fixed stuck vehicle detection area (`#2463 <https://github.com/autowarefoundation/autoware.universe/issues/2463>`_)
+* feat(behavior_path_planner): remove unnecessary parameters (`#2516 <https://github.com/autowarefoundation/autoware.universe/issues/2516>`_)
   * feat(behavior_path_planner): remove unnecessary parameters
   * remove from static_centerline_optimizer
-* feat(obstacle_cruies_planner): improve pid_based cruise planner (`#2507 <https://github.com/youtalk/autoware.universe/issues/2507>`_)
+* feat(obstacle_cruies_planner): improve pid_based cruise planner (`#2507 <https://github.com/autowarefoundation/autoware.universe/issues/2507>`_)
   * feat(obstacle_cruies_planner): improve pid_based cruise planner
   * fix
   * update param in tier4_planning_launch
-* feat(behavior_path_planner, obstacle_avoidance_planner): add new drivable area (`#2472 <https://github.com/youtalk/autoware.universe/issues/2472>`_)
+* feat(behavior_path_planner, obstacle_avoidance_planner): add new drivable area (`#2472 <https://github.com/autowarefoundation/autoware.universe/issues/2472>`_)
   * update
   * update
   * update
@@ -878,14 +878,14 @@ Changelog for package tier4_planning_launch
   * fix some codes
   * change to makerker array
   * change avoidance utils
-* refactor(behavior_path_planner): move turn_signal_on_swerving param to bpp.param.yaml (`#2406 <https://github.com/youtalk/autoware.universe/issues/2406>`_)
+* refactor(behavior_path_planner): move turn_signal_on_swerving param to bpp.param.yaml (`#2406 <https://github.com/autowarefoundation/autoware.universe/issues/2406>`_)
   * move turn_signal_on_swerving param to bpp.param.yaml
   * change default value to true
   * add description
   * ci(pre-commit): autofix
   Co-authored-by: beyza <bnk@leodrive.ai>
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat(avoidance): improve avoidance target filter (`#2329 <https://github.com/youtalk/autoware.universe/issues/2329>`_)
+* feat(avoidance): improve avoidance target filter (`#2329 <https://github.com/autowarefoundation/autoware.universe/issues/2329>`_)
   * feat(route_handler): add getMostLeftLanelet()
   * feat(avoidance): calc shiftable ratio in avoidance target filtering process
   * feat(avoidance): output object's debug info for rviz
@@ -893,7 +893,7 @@ Changelog for package tier4_planning_launch
   * feat(tier4_planning_launch): add new params for avoidance
   * fix(avoidance): reorder params for readability
   * fix(tier4_planning_launch): reorder params for readability
-* feat(behavior_path_planner): update path when object is gone (`#2314 <https://github.com/youtalk/autoware.universe/issues/2314>`_)
+* feat(behavior_path_planner): update path when object is gone (`#2314 <https://github.com/autowarefoundation/autoware.universe/issues/2314>`_)
   * feat(behavior_path_planner): update state with obstacles.
   feat(behavior_path_planner): update path when obstacle is gone
   * ci(pre-commit): autofix
@@ -911,7 +911,7 @@ Changelog for package tier4_planning_launch
   * ci(pre-commit): autofix
   * fix typos
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat(behavior_path_planner): add option to turn signal while obstacle swerving (`#2333 <https://github.com/youtalk/autoware.universe/issues/2333>`_)
+* feat(behavior_path_planner): add option to turn signal while obstacle swerving (`#2333 <https://github.com/autowarefoundation/autoware.universe/issues/2333>`_)
   * add turn_signal_on_swerving param
   * add option for signals
   * get turn_signal_on_swerving param from config file
@@ -919,27 +919,27 @@ Changelog for package tier4_planning_launch
   * ci(pre-commit): autofix
   Co-authored-by: beyza <bnk@leodrive.ai>
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* fix(obstacle_avoidance_planner): apply dynamic path length to fixed trajectory in eb (`#2357 <https://github.com/youtalk/autoware.universe/issues/2357>`_)
+* fix(obstacle_avoidance_planner): apply dynamic path length to fixed trajectory in eb (`#2357 <https://github.com/autowarefoundation/autoware.universe/issues/2357>`_)
   * fix(obstacle_avoidance_planner): apply dynamic path length to fixed trajectory in eb
   * add flag to enable clipping fixed trajectory
   * add maintainer
-* fix(slow_down_planner): improper parameter used in slow down (`#2276 <https://github.com/youtalk/autoware.universe/issues/2276>`_)
+* fix(slow_down_planner): improper parameter used in slow down (`#2276 <https://github.com/autowarefoundation/autoware.universe/issues/2276>`_)
   * fix(slow_down_planner): improper parameter used in slow down
   * fix(tier4_planning_launch): remove hardcoded param enable_slow_down from launch.py
-* feat(obstacle_avoidance_planner): parameterize non_fixed_trajectory_length (`#2349 <https://github.com/youtalk/autoware.universe/issues/2349>`_)
-* fix(behavior_path_planner): replace object_hold_max_count with object_last_seen_threshold (`#2345 <https://github.com/youtalk/autoware.universe/issues/2345>`_)
+* feat(obstacle_avoidance_planner): parameterize non_fixed_trajectory_length (`#2349 <https://github.com/autowarefoundation/autoware.universe/issues/2349>`_)
+* fix(behavior_path_planner): replace object_hold_max_count with object_last_seen_threshold (`#2345 <https://github.com/autowarefoundation/autoware.universe/issues/2345>`_)
   fix: replace object_hold_max_count with object_last_seen_threshold
-* feat(behavior_velocity_planner): parameterize ego_yield_query_stop_duration for crosswalk module (`#2346 <https://github.com/youtalk/autoware.universe/issues/2346>`_)
+* feat(behavior_velocity_planner): parameterize ego_yield_query_stop_duration for crosswalk module (`#2346 <https://github.com/autowarefoundation/autoware.universe/issues/2346>`_)
   feat: parameterize ego_yield_query_stop_duration for crosswalk module
-* feat(avoidance): improve avoidance target filter (`#2282 <https://github.com/youtalk/autoware.universe/issues/2282>`_)
+* feat(avoidance): improve avoidance target filter (`#2282 <https://github.com/autowarefoundation/autoware.universe/issues/2282>`_)
   * feat(avoidance): use envelope polygon for measure against perception noise
   * feat(avoidance): use moving time for measure against perception noise
   * feat(tier4_planning_launch): add new params for avoidance
   * fix(avoidance): reserve marker array size
-* feat(motion_velocity_smoother): tunable deceleration limit for curve … (`#2278 <https://github.com/youtalk/autoware.universe/issues/2278>`_)
+* feat(motion_velocity_smoother): tunable deceleration limit for curve … (`#2278 <https://github.com/autowarefoundation/autoware.universe/issues/2278>`_)
   feat(motion_velocity_smoother): tunable deceleration limit for curve deceleration
-* feat(tier4_planning/control_launch): add missing dependency (`#2201 <https://github.com/youtalk/autoware.universe/issues/2201>`_)
-* feat: add 'obstacle_velocity_limiter' package (`#1579 <https://github.com/youtalk/autoware.universe/issues/1579>`_)
+* feat(tier4_planning/control_launch): add missing dependency (`#2201 <https://github.com/autowarefoundation/autoware.universe/issues/2201>`_)
+* feat: add 'obstacle_velocity_limiter' package (`#1579 <https://github.com/autowarefoundation/autoware.universe/issues/1579>`_)
   * Initial commit with barebone SafeVelocityAdjustorNode
   * Add debug topics, launch file, and config file
   * Fix debug markers
@@ -1041,33 +1041,33 @@ Changelog for package tier4_planning_launch
   * Update copyright notice: Tier IV -> TIER IV
   * Remove use_sim_time param from node launch file
   * Update launch files to run in the motion_planner + add launch config
-* feat(motion_velocity_smoother): change osqp parameter (`#2157 <https://github.com/youtalk/autoware.universe/issues/2157>`_)
-* ci(pre-commit): format SVG files (`#2172 <https://github.com/youtalk/autoware.universe/issues/2172>`_)
+* feat(motion_velocity_smoother): change osqp parameter (`#2157 <https://github.com/autowarefoundation/autoware.universe/issues/2157>`_)
+* ci(pre-commit): format SVG files (`#2172 <https://github.com/autowarefoundation/autoware.universe/issues/2172>`_)
   * ci(pre-commit): format SVG files
   * ci(pre-commit): autofix
   * apply pre-commit
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat(motion_velocity_smoother): change max_lateral_accel from 0.8 to 1.0 (`#2057 <https://github.com/youtalk/autoware.universe/issues/2057>`_)
-* feat(behavior_path_planner): params to expand drivable area in each module (`#1973 <https://github.com/youtalk/autoware.universe/issues/1973>`_)
-* feat(behavior_path_planner): add turn signal parameters (`#2086 <https://github.com/youtalk/autoware.universe/issues/2086>`_)
+* feat(motion_velocity_smoother): change max_lateral_accel from 0.8 to 1.0 (`#2057 <https://github.com/autowarefoundation/autoware.universe/issues/2057>`_)
+* feat(behavior_path_planner): params to expand drivable area in each module (`#1973 <https://github.com/autowarefoundation/autoware.universe/issues/1973>`_)
+* feat(behavior_path_planner): add turn signal parameters (`#2086 <https://github.com/autowarefoundation/autoware.universe/issues/2086>`_)
   * feat(behavior_path_planner): add and change parameters
   * update
   * update
-* feat(behavior_path_planner): pull_over lateral goal search (`#2036 <https://github.com/youtalk/autoware.universe/issues/2036>`_)
+* feat(behavior_path_planner): pull_over lateral goal search (`#2036 <https://github.com/autowarefoundation/autoware.universe/issues/2036>`_)
   * feat(behavior_path_planner): pull_over lateral goal search
   * fix werror of humble
-* feat(obstacle_cruise_planner): add an explanation (`#2034 <https://github.com/youtalk/autoware.universe/issues/2034>`_)
+* feat(obstacle_cruise_planner): add an explanation (`#2034 <https://github.com/autowarefoundation/autoware.universe/issues/2034>`_)
   * feat(obstacle_cruise_planner): add an explanation
   * update readme
-* feat(run_out): avoid chattering of state transition (`#1975 <https://github.com/youtalk/autoware.universe/issues/1975>`_)
+* feat(run_out): avoid chattering of state transition (`#1975 <https://github.com/autowarefoundation/autoware.universe/issues/1975>`_)
   * feat: keep approach state to avoid chattering of detection
   * add parameter
   * update parameter
   * update documents
   * revert changed parameter
-* feat(obstacle_cruise_planner): add goal safe distance (`#2031 <https://github.com/youtalk/autoware.universe/issues/2031>`_)
-* chore(behavior_velocity): add maintainer for run out module (`#1967 <https://github.com/youtalk/autoware.universe/issues/1967>`_)
-* refactor(run_out): add state machine class for state transition  (`#1884 <https://github.com/youtalk/autoware.universe/issues/1884>`_)
+* feat(obstacle_cruise_planner): add goal safe distance (`#2031 <https://github.com/autowarefoundation/autoware.universe/issues/2031>`_)
+* chore(behavior_velocity): add maintainer for run out module (`#1967 <https://github.com/autowarefoundation/autoware.universe/issues/1967>`_)
+* refactor(run_out): add state machine class for state transition  (`#1884 <https://github.com/autowarefoundation/autoware.universe/issues/1884>`_)
   * refactor(run_out): add state machine class for state transition
   * remove debug print
   * move parameters
@@ -1076,7 +1076,7 @@ Changelog for package tier4_planning_launch
   * fix conflict
   * remove unused argument
   * fix parameter value
-* feat(behavior_path_planner): add pull_over base class (`#1911 <https://github.com/youtalk/autoware.universe/issues/1911>`_)
+* feat(behavior_path_planner): add pull_over base class (`#1911 <https://github.com/autowarefoundation/autoware.universe/issues/1911>`_)
   * feat(behavior_path_planner): add pull_over base class
   * modify calculation of velocity abs
   * modify from review
@@ -1089,9 +1089,9 @@ Changelog for package tier4_planning_launch
   * fix werror
   * fix build for main
   Co-authored-by: Zulfaqar Azmi <93502286+zulfaqar-azmi-t4@users.noreply.github.com>
-* chore(tier4_planning_launch): add maintainers (`#1955 <https://github.com/youtalk/autoware.universe/issues/1955>`_)
-* feat(intersection): use intersection_area if available (`#1733 <https://github.com/youtalk/autoware.universe/issues/1733>`_)
-* refactor: replace acc calculation in planning control modules (`#1213 <https://github.com/youtalk/autoware.universe/issues/1213>`_)
+* chore(tier4_planning_launch): add maintainers (`#1955 <https://github.com/autowarefoundation/autoware.universe/issues/1955>`_)
+* feat(intersection): use intersection_area if available (`#1733 <https://github.com/autowarefoundation/autoware.universe/issues/1733>`_)
+* refactor: replace acc calculation in planning control modules (`#1213 <https://github.com/autowarefoundation/autoware.universe/issues/1213>`_)
   * [obstacle_cruise_planner] replace acceleration calculation
   * [obstacle_stop_planner] replace acceleration calculation
   * [trajectory_follower] replace acceleration calculation
@@ -1099,17 +1099,17 @@ Changelog for package tier4_planning_launch
   * fix nullptr check
   * fix controller test
   * fix
-* fix: fix missing dependency (`#1891 <https://github.com/youtalk/autoware.universe/issues/1891>`_)
+* fix: fix missing dependency (`#1891 <https://github.com/autowarefoundation/autoware.universe/issues/1891>`_)
   * fix: fix missing dependency
   * fix
-* feat(obstacle_avoidance_planner): fix can be applied to the first trajectory point (`#1775 <https://github.com/youtalk/autoware.universe/issues/1775>`_)
+* feat(obstacle_avoidance_planner): fix can be applied to the first trajectory point (`#1775 <https://github.com/autowarefoundation/autoware.universe/issues/1775>`_)
   * add bicycle model collision avoidance and single fixed point
   * refactor manual warm start
   * add calculation cost plotter
   * fix
   * fix
   * update params
-* feat(rtc_auto_mode_manager): add rtc_auto_mode_manager and fix auto mode behavior (`#1541 <https://github.com/youtalk/autoware.universe/issues/1541>`_)
+* feat(rtc_auto_mode_manager): add rtc_auto_mode_manager and fix auto mode behavior (`#1541 <https://github.com/autowarefoundation/autoware.universe/issues/1541>`_)
   * feat(rtc_auto_mode_manager): add rtc_auto_mode_manager and fix auto mode behavior
   * ci(pre-commit): autofix
   * fix(rtc_auto_mode_manager): fix typo
@@ -1124,19 +1124,19 @@ Changelog for package tier4_planning_launch
   * feat(rtc_auto_mode_manager): fix initialization
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: taikitanaka3 <65527974+taikitanaka3@users.noreply.github.com>
-* feat(behavior_planning): use acceleration from localization module (`#1859 <https://github.com/youtalk/autoware.universe/issues/1859>`_)
+* feat(behavior_planning): use acceleration from localization module (`#1859 <https://github.com/autowarefoundation/autoware.universe/issues/1859>`_)
   * feat(behavior_path_planner): subscribe acceleration from localization module
   * feat(behavior_velocity_planner): subscribe acceleration from localization module
-* refactor(run_out): remove unused parameter (`#1836 <https://github.com/youtalk/autoware.universe/issues/1836>`_)
-* feat(obstacle_cruise_planner): add terminal collision checker (`#1807 <https://github.com/youtalk/autoware.universe/issues/1807>`_)
+* refactor(run_out): remove unused parameter (`#1836 <https://github.com/autowarefoundation/autoware.universe/issues/1836>`_)
+* feat(obstacle_cruise_planner): add terminal collision checker (`#1807 <https://github.com/autowarefoundation/autoware.universe/issues/1807>`_)
   * feat(motion_utils): add new search zero velocity
   * change arguments
   * feat(obstacle_cruise_planner): add terminal collision checker
   * add parameters
   * change parameters
-* feat(behavior_path_planner): change pull over params (`#1815 <https://github.com/youtalk/autoware.universe/issues/1815>`_)
-* feat(motion_velocity_smoother): add steering rate limit while planning velocity (`#1071 <https://github.com/youtalk/autoware.universe/issues/1071>`_)
-  * feat(motion_velocity_smoother): add steering rate limit while planning velocity (`#1071 <https://github.com/youtalk/autoware.universe/issues/1071>`_)
+* feat(behavior_path_planner): change pull over params (`#1815 <https://github.com/autowarefoundation/autoware.universe/issues/1815>`_)
+* feat(motion_velocity_smoother): add steering rate limit while planning velocity (`#1071 <https://github.com/autowarefoundation/autoware.universe/issues/1071>`_)
+  * feat(motion_velocity_smoother): add steering rate limit while planning velocity (`#1071 <https://github.com/autowarefoundation/autoware.universe/issues/1071>`_)
   function added,
   not turning
   fix the always positive curvature problem
@@ -1180,14 +1180,14 @@ Changelog for package tier4_planning_launch
   * ci(pre-commit): autofix
   Co-authored-by: Berkay <berkay@leodrive.ai>
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat(behavior_path_planner): check goal to objects logitudinal distance for pull_over (`#1796 <https://github.com/youtalk/autoware.universe/issues/1796>`_)
+* feat(behavior_path_planner): check goal to objects logitudinal distance for pull_over (`#1796 <https://github.com/autowarefoundation/autoware.universe/issues/1796>`_)
   * feat(behavior_path_planner): check goal to objects logitudinal distance for pull_over
   * Update planning/behavior_path_planner/src/utilities.cpp
   Co-authored-by: Shumpei Wakabayashi <42209144+shmpwk@users.noreply.github.com>
   * rename to goal_to_obstacle_margin
   * fix rear check
   Co-authored-by: Shumpei Wakabayashi <42209144+shmpwk@users.noreply.github.com>
-* refactor(obstacle_stop_planner): update params name for readability (`#1720 <https://github.com/youtalk/autoware.universe/issues/1720>`_)
+* refactor(obstacle_stop_planner): update params name for readability (`#1720 <https://github.com/autowarefoundation/autoware.universe/issues/1720>`_)
   * refactor(obstacle_stop_planner): update parameter name for readability
   * docs(obstacle_stop_planner): update module documentation
   * docs(obstacle_stop_planner): update figure
@@ -1195,8 +1195,8 @@ Changelog for package tier4_planning_launch
   * fix(tier4_planning_launch): separate params by namespace
   * refactor(obstacle_stop_planner): remove default value from declare_parameter
   * refactor(obstacle_stop_planner): add params to config
-* fix(behavior_path_planner): fix pull_over request_length and maximum_deceleration (`#1789 <https://github.com/youtalk/autoware.universe/issues/1789>`_)
-* feat(behavior_path_planner): use object recognition for pull_over (`#1777 <https://github.com/youtalk/autoware.universe/issues/1777>`_)
+* fix(behavior_path_planner): fix pull_over request_length and maximum_deceleration (`#1789 <https://github.com/autowarefoundation/autoware.universe/issues/1789>`_)
+* feat(behavior_path_planner): use object recognition for pull_over (`#1777 <https://github.com/autowarefoundation/autoware.universe/issues/1777>`_)
   * feat(behavior_path_planner): use object recognition for pull_over
   * Update planning/behavior_path_planner/src/scene_module/pull_over/pull_over_module.cpp
   Co-authored-by: Shumpei Wakabayashi <42209144+shmpwk@users.noreply.github.com>
@@ -1205,7 +1205,7 @@ Changelog for package tier4_planning_launch
   * remove unnecessary lines
   * update warn message
   Co-authored-by: Shumpei Wakabayashi <42209144+shmpwk@users.noreply.github.com>
-* feat(behavior_path_planner): update pull out (`#1438 <https://github.com/youtalk/autoware.universe/issues/1438>`_)
+* feat(behavior_path_planner): update pull out (`#1438 <https://github.com/autowarefoundation/autoware.universe/issues/1438>`_)
   * feat(behavior_path_planner): update pull out
   * refactor(behavior_path_planner): rename pull_out params
   * update from review
@@ -1215,10 +1215,10 @@ Changelog for package tier4_planning_launch
   * fix debug marker
   * add seach priority
   * change before_pull_out_straight_distance to 0.0
-* refactor(behavior_path_planner): rename pull_over params (`#1747 <https://github.com/youtalk/autoware.universe/issues/1747>`_)
-* feat(intersection): continue detection after pass judge (`#1719 <https://github.com/youtalk/autoware.universe/issues/1719>`_)
-* feat(behavior_path_palnner): update geometric parallel parking for pull_out module (`#1534 <https://github.com/youtalk/autoware.universe/issues/1534>`_)
-* chore(planning/control packages): organized authors and maintainers (`#1610 <https://github.com/youtalk/autoware.universe/issues/1610>`_)
+* refactor(behavior_path_planner): rename pull_over params (`#1747 <https://github.com/autowarefoundation/autoware.universe/issues/1747>`_)
+* feat(intersection): continue detection after pass judge (`#1719 <https://github.com/autowarefoundation/autoware.universe/issues/1719>`_)
+* feat(behavior_path_palnner): update geometric parallel parking for pull_out module (`#1534 <https://github.com/autowarefoundation/autoware.universe/issues/1534>`_)
+* chore(planning/control packages): organized authors and maintainers (`#1610 <https://github.com/autowarefoundation/autoware.universe/issues/1610>`_)
   * organized planning authors and maintainers
   * organized control authors and maintainers
   * fix typo
@@ -1251,9 +1251,9 @@ Changelog for package tier4_planning_launch
   * fix
   Co-authored-by: Kenji Miyake <31987104+kenji-miyake@users.noreply.github.com>
   Co-authored-by: Kenji Miyake <kenji.miyake@tier4.jp>
-* feat(behavior_path_planner): enable pull_over backward_parking by default (`#1653 <https://github.com/youtalk/autoware.universe/issues/1653>`_)
-* feat(obstacle_avoidance_planne): enable plan_from_ego by default (`#1673 <https://github.com/youtalk/autoware.universe/issues/1673>`_)
-* feat: add vector map inside area filter (`#1530 <https://github.com/youtalk/autoware.universe/issues/1530>`_)
+* feat(behavior_path_planner): enable pull_over backward_parking by default (`#1653 <https://github.com/autowarefoundation/autoware.universe/issues/1653>`_)
+* feat(obstacle_avoidance_planne): enable plan_from_ego by default (`#1673 <https://github.com/autowarefoundation/autoware.universe/issues/1673>`_)
+* feat: add vector map inside area filter (`#1530 <https://github.com/autowarefoundation/autoware.universe/issues/1530>`_)
   * feat: add no detection area filter
   * ci(pre-commit): autofix
   * chore: add documents
@@ -1277,10 +1277,10 @@ Changelog for package tier4_planning_launch
   * chore: using namespace of PolygonCgal for readability
   * feat: add functions for multiple polygons
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* refactor(mission_planner): prepare to support ad api (`#1561 <https://github.com/youtalk/autoware.universe/issues/1561>`_)
+* refactor(mission_planner): prepare to support ad api (`#1561 <https://github.com/autowarefoundation/autoware.universe/issues/1561>`_)
   * refactor(mission_planner): prepare to support ad api
   * fix node name
-* feat(surround_obstacle_checker): add vehicle footprint with offset (`#1577 <https://github.com/youtalk/autoware.universe/issues/1577>`_)
+* feat(surround_obstacle_checker): add vehicle footprint with offset (`#1577 <https://github.com/autowarefoundation/autoware.universe/issues/1577>`_)
   * fix: right and left overhang fix in SelfPolygon func
   * feat: init base polygon
   * ci(pre-commit): autofix
@@ -1291,32 +1291,32 @@ Changelog for package tier4_planning_launch
   * feat: add footprint publish boolean param to config
   * docs: update readme
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat(behavior_path_planner): resample output path (`#1604 <https://github.com/youtalk/autoware.universe/issues/1604>`_)
+* feat(behavior_path_planner): resample output path (`#1604 <https://github.com/autowarefoundation/autoware.universe/issues/1604>`_)
   * feat(behavior_path_planner): resample output path
   * update param
-* fix(behavior_velocity_planner): disable debug path publisher by default (`#1680 <https://github.com/youtalk/autoware.universe/issues/1680>`_)
-* fix(behavior_path_planner): pull_over shift parking (`#1652 <https://github.com/youtalk/autoware.universe/issues/1652>`_)
+* fix(behavior_velocity_planner): disable debug path publisher by default (`#1680 <https://github.com/autowarefoundation/autoware.universe/issues/1680>`_)
+* fix(behavior_path_planner): pull_over shift parking (`#1652 <https://github.com/autowarefoundation/autoware.universe/issues/1652>`_)
   * fix(behavior_path_planner): pull_over shift parking
   * check lane_depature for each shift path
   * change pull_over_velocity to 3.0
-* feat(obstacle_cruise_planner): add velocity_threshold to outside obstacle (`#1646 <https://github.com/youtalk/autoware.universe/issues/1646>`_)
+* feat(obstacle_cruise_planner): add velocity_threshold to outside obstacle (`#1646 <https://github.com/autowarefoundation/autoware.universe/issues/1646>`_)
   * feat(obstacle_cruise_planner): add velocity_threshold to outside obstacle
   * add parameter to config
   * update readme
-* feat(behavior_velocity): publish internal debug path (`#1635 <https://github.com/youtalk/autoware.universe/issues/1635>`_)
+* feat(behavior_velocity): publish internal debug path (`#1635 <https://github.com/autowarefoundation/autoware.universe/issues/1635>`_)
   * feat(behavior_velocity): publish internal path as debug path
   * feat(behavior_velocity): add debug internal scene module path
   * feat(behavior_velcoity, planning_debug_tools): add params for debug path
-* feat(run_out): add lateral nearest points filter  (`#1527 <https://github.com/youtalk/autoware.universe/issues/1527>`_)
+* feat(run_out): add lateral nearest points filter  (`#1527 <https://github.com/autowarefoundation/autoware.universe/issues/1527>`_)
   * feat(run_out): add lateral nearest points filter
   * chore: update documents
   * chore: pre-commit fix
   * chore: fix typo
-* fix(tier4_planning_launch): change parameter to enable abort lane change (`#1602 <https://github.com/youtalk/autoware.universe/issues/1602>`_)
-* feat(tier4_planning_launch): add nearest search param (`#1582 <https://github.com/youtalk/autoware.universe/issues/1582>`_)
+* fix(tier4_planning_launch): change parameter to enable abort lane change (`#1602 <https://github.com/autowarefoundation/autoware.universe/issues/1602>`_)
+* feat(tier4_planning_launch): add nearest search param (`#1582 <https://github.com/autowarefoundation/autoware.universe/issues/1582>`_)
   * feat(tier4_planning_launch): add nearest search param
   * fix
-* feat(obstacle_cruise_planner): delete shape from target obstacle (`#1558 <https://github.com/youtalk/autoware.universe/issues/1558>`_)
+* feat(obstacle_cruise_planner): delete shape from target obstacle (`#1558 <https://github.com/autowarefoundation/autoware.universe/issues/1558>`_)
   * delete is on ego traj
   * update
   * feat(obstacle_cruise_planner): delete shape
@@ -1328,24 +1328,24 @@ Changelog for package tier4_planning_launch
   * fix terminal point
   * update
   * update parameters
-* fix(behavior_velocity_planner, tier4_planning_launch): modify delay_resopnse_time (`#1557 <https://github.com/youtalk/autoware.universe/issues/1557>`_)
+* fix(behavior_velocity_planner, tier4_planning_launch): modify delay_resopnse_time (`#1557 <https://github.com/autowarefoundation/autoware.universe/issues/1557>`_)
   * fix(behavior_velocity_planner): modify delay_resopnse_time
   * fix(tier4_planning_launch): modify delay_resopnse_time
-* fix(costmap_generator): restrict costmap within parking lot (`#996 <https://github.com/youtalk/autoware.universe/issues/996>`_)
+* fix(costmap_generator): restrict costmap within parking lot (`#996 <https://github.com/autowarefoundation/autoware.universe/issues/996>`_)
   * fix(costmap_generator): restrict costmap within parking lot
   * add parameters for free space planning area selection
   * ci(pre-commit): autofix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* fix(obstacle_cruise_planner): add missing param (`#1515 <https://github.com/youtalk/autoware.universe/issues/1515>`_)
-* fix(behavior_path_planner): fix turn singal output in a avoidance sequence (`#1511 <https://github.com/youtalk/autoware.universe/issues/1511>`_)
+* fix(obstacle_cruise_planner): add missing param (`#1515 <https://github.com/autowarefoundation/autoware.universe/issues/1515>`_)
+* fix(behavior_path_planner): fix turn singal output in a avoidance sequence (`#1511 <https://github.com/autowarefoundation/autoware.universe/issues/1511>`_)
   * remove search distance for turn signal
   * set distance to max when a lane_attriute is straight
-* refactor(obstacle_avoidance_planner): use max_steer_angle in common (`#1423 <https://github.com/youtalk/autoware.universe/issues/1423>`_)
+* refactor(obstacle_avoidance_planner): use max_steer_angle in common (`#1423 <https://github.com/autowarefoundation/autoware.universe/issues/1423>`_)
   * refactor(obstacle_avoidance_planner): use max_steer_angle in common
   * fix runtime error
   * fix
   * fix yaml file
-* feat(behavior_velocitiy_planner): predict front vehicle deceleration in intersection and temporarily stop (`#1194 <https://github.com/youtalk/autoware.universe/issues/1194>`_)
+* feat(behavior_velocitiy_planner): predict front vehicle deceleration in intersection and temporarily stop (`#1194 <https://github.com/autowarefoundation/autoware.universe/issues/1194>`_)
   * calculating stopping distance for frontcar from estimated velocity
   * calc stopping_point_projected and stopping_point along centerline
   * create stuck_vehicle_detect_area in modifyVelocity(TODO: use pose of frontcar at stopping_position
@@ -1360,21 +1360,21 @@ Changelog for package tier4_planning_launch
   * fixed the order of isAheadOf, working in scenario test as well
   * added description in stuck vehicle detection section
   * reflected comments: (1) use vector of ids (2) changed intersection.param.yaml
-* feat(tier4_planning_launch): declare param path argument (`#1337 <https://github.com/youtalk/autoware.universe/issues/1337>`_)
+* feat(tier4_planning_launch): declare param path argument (`#1337 <https://github.com/autowarefoundation/autoware.universe/issues/1337>`_)
   * feat(tier4_planning_launch): declare param path argument
   * Update launch/tier4_planning_launch/launch/planning.launch.xml
   Co-authored-by: Kenji Miyake <31987104+kenji-miyake@users.noreply.github.com>
   * Update launch/tier4_planning_launch/launch/planning.launch.xml
   Co-authored-by: Kenji Miyake <31987104+kenji-miyake@users.noreply.github.com>
   Co-authored-by: Kenji Miyake <31987104+kenji-miyake@users.noreply.github.com>
-* fix(behavior_path_planner): remove unnecessary publisher and subscriber  (`#1371 <https://github.com/youtalk/autoware.universe/issues/1371>`_)
+* fix(behavior_path_planner): remove unnecessary publisher and subscriber  (`#1371 <https://github.com/autowarefoundation/autoware.universe/issues/1371>`_)
   * fix(behavior_path_planner): remove unnecessary publisher and subscriber
   * fix(tier4_planning_launch): fix launch file
   * fix(tier4_planning_launch): fix xml file
-* fix: fix parameter names of motion_velocity_smoother (`#1376 <https://github.com/youtalk/autoware.universe/issues/1376>`_)
+* fix: fix parameter names of motion_velocity_smoother (`#1376 <https://github.com/autowarefoundation/autoware.universe/issues/1376>`_)
   * fix: fix parameter names of motion_velocity_smoother
   * fix indent
-* feat(intersection_module): add option to change the stopline position (`#1364 <https://github.com/youtalk/autoware.universe/issues/1364>`_)
+* feat(intersection_module): add option to change the stopline position (`#1364 <https://github.com/autowarefoundation/autoware.universe/issues/1364>`_)
   * use constexpr
   * add stopline before intersection
   * feat(intersection_module): add update stopline index before intersection
@@ -1385,19 +1385,19 @@ Changelog for package tier4_planning_launch
   * reduce nest
   * ci(pre-commit): autofix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* fix(tier4_planning_launch): add group tag (`#1239 <https://github.com/youtalk/autoware.universe/issues/1239>`_)
+* fix(tier4_planning_launch): add group tag (`#1239 <https://github.com/autowarefoundation/autoware.universe/issues/1239>`_)
   * fix(tier4_planning_launch): add group tag
   * move arg
   * move arg inside group
-* fix(behavior_velocity_planner): fix rtc behavior in crosswalk module (`#1296 <https://github.com/youtalk/autoware.universe/issues/1296>`_)
-* feat(behavior_path_planner): update pull_over module (`#873 <https://github.com/youtalk/autoware.universe/issues/873>`_)
+* fix(behavior_velocity_planner): fix rtc behavior in crosswalk module (`#1296 <https://github.com/autowarefoundation/autoware.universe/issues/1296>`_)
+* feat(behavior_path_planner): update pull_over module (`#873 <https://github.com/autowarefoundation/autoware.universe/issues/873>`_)
   * feat(behavior_path_planner): update pull_over module
   * use tf2_geometry_msgs/tf2_geometry_msgs.hpp for humble
   * fix werror of humble
   * fix test
   * fix goal change bug when starting drive
-* feat(tier4_planning_launch): update crosswalk param (`#1265 <https://github.com/youtalk/autoware.universe/issues/1265>`_)
-* feat(behavior_velocity): filter points with detection area (`#1073 <https://github.com/youtalk/autoware.universe/issues/1073>`_)
+* feat(tier4_planning_launch): update crosswalk param (`#1265 <https://github.com/autowarefoundation/autoware.universe/issues/1265>`_)
+* feat(behavior_velocity): filter points with detection area (`#1073 <https://github.com/autowarefoundation/autoware.universe/issues/1073>`_)
   * feat(behavior_velocity): filter points with detection area
   * remove unnecessary functions
   * update documents
@@ -1407,10 +1407,10 @@ Changelog for package tier4_planning_launch
   * update configs
   * return empty points when the detection area polygon is empty
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* chore(obstacle_avoidance_planner): add description of max_plan_from_ego_length (`#1223 <https://github.com/youtalk/autoware.universe/issues/1223>`_)
+* chore(obstacle_avoidance_planner): add description of max_plan_from_ego_length (`#1223 <https://github.com/autowarefoundation/autoware.universe/issues/1223>`_)
   * chore(obstacle_avoidance_planner): add description of max_plan_from_ego_length
   * fix typo
-* feat(obstacle_cruise_planner): implemented common obstacle stop (`#1185 <https://github.com/youtalk/autoware.universe/issues/1185>`_)
+* feat(obstacle_cruise_planner): implemented common obstacle stop (`#1185 <https://github.com/autowarefoundation/autoware.universe/issues/1185>`_)
   * feat(obstacle_cruise_planner): implemented common obstacle stop
   * fix some implementation
   * minor changes
@@ -1418,11 +1418,11 @@ Changelog for package tier4_planning_launch
   * remove unnecessary code
   * fix CI error
   * fix typo
-* refactor(freespace_planner): parameterize margin. (`#1190 <https://github.com/youtalk/autoware.universe/issues/1190>`_)
-* fix(intersection_module): remove decel parameter (`#1188 <https://github.com/youtalk/autoware.universe/issues/1188>`_)
+* refactor(freespace_planner): parameterize margin. (`#1190 <https://github.com/autowarefoundation/autoware.universe/issues/1190>`_)
+* fix(intersection_module): remove decel parameter (`#1188 <https://github.com/autowarefoundation/autoware.universe/issues/1188>`_)
   * fix(intersection_module): remove decel parameter
   * remove unuse parameter
-* feat(obstacle_cruise_planner): some minor updates (`#1136 <https://github.com/youtalk/autoware.universe/issues/1136>`_)
+* feat(obstacle_cruise_planner): some minor updates (`#1136 <https://github.com/autowarefoundation/autoware.universe/issues/1136>`_)
   * checkout latest obstacle cruise changes
   * fix cruise/stop chattering
   * add lpf for cruise wall
@@ -1433,7 +1433,7 @@ Changelog for package tier4_planning_launch
   * update tier4_planning_launch param
   * fix typo
   * fix CI error
-* feat(obstacle_cruise_planner): clean parameters for optimization based cruise planner (`#1059 <https://github.com/youtalk/autoware.universe/issues/1059>`_)
+* feat(obstacle_cruise_planner): clean parameters for optimization based cruise planner (`#1059 <https://github.com/autowarefoundation/autoware.universe/issues/1059>`_)
   * remove unnecessary parameter
   * add new parameter and delete unnecessary constructor
   * remove unnecessary parameter
@@ -1443,7 +1443,7 @@ Changelog for package tier4_planning_launch
   * delete yaw threshold parameter and update license
   * update
   * remove unnecessary checker
-* feat(intersection): add conflicting area with margin debug (`#1021 <https://github.com/youtalk/autoware.universe/issues/1021>`_)
+* feat(intersection): add conflicting area with margin debug (`#1021 <https://github.com/autowarefoundation/autoware.universe/issues/1021>`_)
   * add detection area margin debug
   * extention lanelet in intersection function
   * feat: add conflicting area with margin
@@ -1459,11 +1459,11 @@ Changelog for package tier4_planning_launch
   * refactor: lanelet::utils::resamplePoints -> resamplePoints
   * feat: add right and left margin parameter
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat(tier4_planning_launch): launch rtc_auto_approver (`#1046 <https://github.com/youtalk/autoware.universe/issues/1046>`_)
+* feat(tier4_planning_launch): launch rtc_auto_approver (`#1046 <https://github.com/autowarefoundation/autoware.universe/issues/1046>`_)
   * feature(tier4_planning_launch): launch rtc_auto_approver
   * ci(pre-commit): autofix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat(obstacle_cruise_planner): add new package (`#570 <https://github.com/youtalk/autoware.universe/issues/570>`_)
+* feat(obstacle_cruise_planner): add new package (`#570 <https://github.com/autowarefoundation/autoware.universe/issues/570>`_)
   * feat(obstacle_velocity_planner): add obstacle_velocity_planner
   * udpate yaml
   * update dependency
@@ -1483,23 +1483,23 @@ Changelog for package tier4_planning_launch
   * rename to obstacle_cruise_planner
   * fix tier4_planning_launch
   * fix humble CI
-* feat(behavior_velocity): add run out module (`#752 <https://github.com/youtalk/autoware.universe/issues/752>`_)
-  * fix(behavior_velocity): calculate detection area from the nearest point from ego (`#730 <https://github.com/youtalk/autoware.universe/issues/730>`_)
+* feat(behavior_velocity): add run out module (`#752 <https://github.com/autowarefoundation/autoware.universe/issues/752>`_)
+  * fix(behavior_velocity): calculate detection area from the nearest point from ego (`#730 <https://github.com/autowarefoundation/autoware.universe/issues/730>`_)
   * fix(behavior_velocity): calculate lateral distance from the beginning of the path
   * add argument of min_velocity
   * use veloicty from the nearest point from ego
   * pass struct by reference
   * fix to interpolate point in util
-  * fix(longitudinal_controller_node, vehicle_cmd_gate): update stopped condition and behavior (`#700 <https://github.com/youtalk/autoware.universe/issues/700>`_)
+  * fix(longitudinal_controller_node, vehicle_cmd_gate): update stopped condition and behavior (`#700 <https://github.com/autowarefoundation/autoware.universe/issues/700>`_)
   * fix(longitudinal_controller_node): parameterize stopped state entry condition
   * fix(longitudinal_controller_node): simply set stopped velocity in STOPPED STATE
   * fix(vehicle_cmd_gate): check time duration since the vehicle stopped
-  * docs(autoware_testing): fix link (`#741 <https://github.com/youtalk/autoware.universe/issues/741>`_)
+  * docs(autoware_testing): fix link (`#741 <https://github.com/autowarefoundation/autoware.universe/issues/741>`_)
   * docs(autoware_testing): fix link
   * fix typo
   Co-authored-by: Kenji Miyake <31987104+kenji-miyake@users.noreply.github.com>
-  * fix: trajectory visualizer (`#745 <https://github.com/youtalk/autoware.universe/issues/745>`_)
-  * fix(tier4_autoware_utils): modify build error in rolling (`#720 <https://github.com/youtalk/autoware.universe/issues/720>`_)
+  * fix: trajectory visualizer (`#745 <https://github.com/autowarefoundation/autoware.universe/issues/745>`_)
+  * fix(tier4_autoware_utils): modify build error in rolling (`#720 <https://github.com/autowarefoundation/autoware.universe/issues/720>`_)
   * fix(tier4_autoware_utils): modify build error in rolling
   * fix(lanelet2_extension): add target compile definition for geometry2
   * fix(ekf_localizer): add target compile definition for geometry2
@@ -1537,7 +1537,7 @@ Changelog for package tier4_planning_launch
   * fix(planning_error_monitor): add target compile definition for geometry2
   * fix(planning_evaluator): add target compile definition for geometry2
   * fix(lidar_centerpoint): add target compile definition for geometry2
-  * fix(behavior_velocity): handle the case when finding index failed (`#746 <https://github.com/youtalk/autoware.universe/issues/746>`_)
+  * fix(behavior_velocity): handle the case when finding index failed (`#746 <https://github.com/autowarefoundation/autoware.universe/issues/746>`_)
   * feat: add scene module of dynamic obstacle stop
   * fix warnings
   * add temporary debug value
@@ -1644,14 +1644,14 @@ Changelog for package tier4_planning_launch
   Co-authored-by: Yukihiro Saito <yukky.saito@gmail.com>
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Makoto Kurihara <mkuri8m@gmail.com>
-* feat(tier4_planning_launch): create parameter yaml for behavior_velocity_planner (`#887 <https://github.com/youtalk/autoware.universe/issues/887>`_)
+* feat(tier4_planning_launch): create parameter yaml for behavior_velocity_planner (`#887 <https://github.com/autowarefoundation/autoware.universe/issues/887>`_)
   * feat(tier4_planning_launch): create parameter yaml for behavior_velocity_planner
   * Update launch/tier4_planning_launch/config/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/behavior_velocity_planner.param.yaml
   Co-authored-by: taikitanaka3 <65527974+taikitanaka3@users.noreply.github.com>
   * feat: add param.yaml in behavior_velocity_planner package
   * some fix
   Co-authored-by: taikitanaka3 <65527974+taikitanaka3@users.noreply.github.com>
-* feat(obstacle_avoidance_planner): some fix for narrow driving (`#916 <https://github.com/youtalk/autoware.universe/issues/916>`_)
+* feat(obstacle_avoidance_planner): some fix for narrow driving (`#916 <https://github.com/autowarefoundation/autoware.universe/issues/916>`_)
   * use car like constraints in mpt
   * use not widest bounds for the first bounds
   * organized params
@@ -1661,8 +1661,8 @@ Changelog for package tier4_planning_launch
   * update config
   * remove unnecessary files
   * update tier4_planning_launch params
-* feat(behavior_velocity): find occlusion more efficiently (`#829 <https://github.com/youtalk/autoware.universe/issues/829>`_)
-* feat(surround_obstacle_checker): separate surround_obstacle_checker from hierarchical planning flow (`#830 <https://github.com/youtalk/autoware.universe/issues/830>`_)
+* feat(behavior_velocity): find occlusion more efficiently (`#829 <https://github.com/autowarefoundation/autoware.universe/issues/829>`_)
+* feat(surround_obstacle_checker): separate surround_obstacle_checker from hierarchical planning flow (`#830 <https://github.com/autowarefoundation/autoware.universe/issues/830>`_)
   * fix(surroud_obstacle_checker): use alias
   * feat(surround_obstacle_checker): use velocity limit
   * chore(surround_obstacle_checker): rename publisher, subscriber and callback functions
@@ -1672,26 +1672,26 @@ Changelog for package tier4_planning_launch
   * refactor(surround_obstacle_checker): cleanup polygon handling
   * refactor(surround_obstacle_checker): use marker helper
   * feat(planning_launch): separate surround_obstacle_checker from hierarchical motion planning flow
-* chore: upgrade cmake_minimum_required to 3.14 (`#856 <https://github.com/youtalk/autoware.universe/issues/856>`_)
-* refactor: use autoware cmake (`#849 <https://github.com/youtalk/autoware.universe/issues/849>`_)
+* chore: upgrade cmake_minimum_required to 3.14 (`#856 <https://github.com/autowarefoundation/autoware.universe/issues/856>`_)
+* refactor: use autoware cmake (`#849 <https://github.com/autowarefoundation/autoware.universe/issues/849>`_)
   * remove autoware_auto_cmake
   * add build_depend of autoware_cmake
   * use autoware_cmake in CMakeLists.txt
   * fix bugs
   * fix cmake lint errors
-* style: fix format of package.xml (`#844 <https://github.com/youtalk/autoware.universe/issues/844>`_)
-* feat(obstacle_avoidance_planner): parameterize bounds search widths (`#807 <https://github.com/youtalk/autoware.universe/issues/807>`_)
+* style: fix format of package.xml (`#844 <https://github.com/autowarefoundation/autoware.universe/issues/844>`_)
+* feat(obstacle_avoidance_planner): parameterize bounds search widths (`#807 <https://github.com/autowarefoundation/autoware.universe/issues/807>`_)
   * feat(obstacle_avoidance_planner): parameterize bounds search widths
   * update bounds search widths
   * update tier4_planning_launch
   * Added parameter description of README.md
-* chore(behavior_velocity): add system delay parameter and minor update (`#764 <https://github.com/youtalk/autoware.universe/issues/764>`_)
+* chore(behavior_velocity): add system delay parameter and minor update (`#764 <https://github.com/autowarefoundation/autoware.universe/issues/764>`_)
   * chore(behavior_velocity): add system delay parameter and minor update
   * doc(behavior_velocity): add system delay discription
-* fix(motion_velocity_smoother): add stop decel parameter (`#739 <https://github.com/youtalk/autoware.universe/issues/739>`_)
+* fix(motion_velocity_smoother): add stop decel parameter (`#739 <https://github.com/autowarefoundation/autoware.universe/issues/739>`_)
   * add stop decel parameter
   * add stop decel parameter
-* feat(behavior_velocity): occlusion spot generate not detection area occupancy grid (`#620 <https://github.com/youtalk/autoware.universe/issues/620>`_)
+* feat(behavior_velocity): occlusion spot generate not detection area occupancy grid (`#620 <https://github.com/autowarefoundation/autoware.universe/issues/620>`_)
   * feat(behavior_velocity): filter dynamic object by default
   * feat(behavior_velocity): raycast object shadow
   * chore(behavior_velocity): replace target vehicle to filtered vehicle in detection area
@@ -1701,22 +1701,22 @@ Changelog for package tier4_planning_launch
   * fix(behavior_velocity): fix launch and stuck vehicle
   * chore(behavior_velocity): use experiment value
   * chore(behavior_velocity): add comment
-* fix(tier4_planning_launch): fix tier4_planning_launch package (`#660 <https://github.com/youtalk/autoware.universe/issues/660>`_)
-* feat(behavior_path_planner): stop lane_driving planners in non-lane-driving scenario (`#668 <https://github.com/youtalk/autoware.universe/issues/668>`_)
+* fix(tier4_planning_launch): fix tier4_planning_launch package (`#660 <https://github.com/autowarefoundation/autoware.universe/issues/660>`_)
+* feat(behavior_path_planner): stop lane_driving planners in non-lane-driving scenario (`#668 <https://github.com/autowarefoundation/autoware.universe/issues/668>`_)
   * stop lanedriving in parking scenario
   * use skip_first
   * add scenario remap in launch
   * replace warn to info
-* ci(pre-commit): update pre-commit-hooks-ros (`#625 <https://github.com/youtalk/autoware.universe/issues/625>`_)
+* ci(pre-commit): update pre-commit-hooks-ros (`#625 <https://github.com/autowarefoundation/autoware.universe/issues/625>`_)
   * ci(pre-commit): update pre-commit-hooks-ros
   * ci(pre-commit): autofix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat(behavior_path_planner): parametrize avoidance target type (`#574 <https://github.com/youtalk/autoware.universe/issues/574>`_)
+* feat(behavior_path_planner): parametrize avoidance target type (`#574 <https://github.com/autowarefoundation/autoware.universe/issues/574>`_)
   * parametrize avoidance target type
   * add target type parameter in yaml
   * mototbike -> motorcycle
   * apply clang
-* feat(obstacle avoidance planner): fix out curve, make calculation cost low, make optimization stable, refactor, etc. (`#233 <https://github.com/youtalk/autoware.universe/issues/233>`_)
+* feat(obstacle avoidance planner): fix out curve, make calculation cost low, make optimization stable, refactor, etc. (`#233 <https://github.com/autowarefoundation/autoware.universe/issues/233>`_)
   * feat (obstacle avoidance planner) fix out curve, make optimization stable, make computation cost low, etc
   * fix typos
   * remove unnecessary codes
@@ -1729,12 +1729,12 @@ Changelog for package tier4_planning_launch
   * truncate path to detect path change, and tune path change detection
   * disable yaw slerp
   * fix ci error
-* fix(behavior_path_planner): parametrize avoidance lateral distance threshold (`#404 <https://github.com/youtalk/autoware.universe/issues/404>`_)
+* fix(behavior_path_planner): parametrize avoidance lateral distance threshold (`#404 <https://github.com/autowarefoundation/autoware.universe/issues/404>`_)
   * parametrize lateral threshold
   * format readme
   * apply clang format
-* refactor(scenario_planning.launch.xml): add parameter description (`#464 <https://github.com/youtalk/autoware.universe/issues/464>`_)
-* feat(behavior_path_planner): make drivable area coordinate fixed to the map coordinate and make its size dynamic (`#360 <https://github.com/youtalk/autoware.universe/issues/360>`_)
+* refactor(scenario_planning.launch.xml): add parameter description (`#464 <https://github.com/autowarefoundation/autoware.universe/issues/464>`_)
+* feat(behavior_path_planner): make drivable area coordinate fixed to the map coordinate and make its size dynamic (`#360 <https://github.com/autowarefoundation/autoware.universe/issues/360>`_)
   * make drivable area not to oscillate and its size dynamic
   * update README for new parameters
   * remove getLaneletScope from route_handler
@@ -1743,7 +1743,7 @@ Changelog for package tier4_planning_launch
   * rename function and put it in proper namespace
   * update param for tier4_planning_launch
   Co-authored-by: Takamasa Horibe <horibe.takamasa@gmail.com>
-* feat(behavior_path_planner): better avoidance drivable areas extension in behavior path planning (`#287 <https://github.com/youtalk/autoware.universe/issues/287>`_)
+* feat(behavior_path_planner): better avoidance drivable areas extension in behavior path planning (`#287 <https://github.com/autowarefoundation/autoware.universe/issues/287>`_)
   * feat: Increases the flexibility of the function in dealing with several scenarios
   The implementation updates generateExtendedDrivableArea
   this is a part of .iv PR (`tier4/autoware.iv#2383 <https://github.com/tier4/autoware.iv/issues/2383>`_) port
@@ -1770,8 +1770,8 @@ Changelog for package tier4_planning_launch
   The decision to increase is based on discussion with the planning control team
   and also from input by FI team.
   Co-authored-by: taikitanaka3 <65527974+taikitanaka3@users.noreply.github.com>
-* fix: use autoware_auto_msgs (`#197 <https://github.com/youtalk/autoware.universe/issues/197>`_)
-* feat: change launch package name (`#186 <https://github.com/youtalk/autoware.universe/issues/186>`_)
+* fix: use autoware_auto_msgs (`#197 <https://github.com/autowarefoundation/autoware.universe/issues/197>`_)
+* feat: change launch package name (`#186 <https://github.com/autowarefoundation/autoware.universe/issues/186>`_)
   * rename launch folder
   * autoware_launch -> tier4_autoware_launch
   * integration_launch -> tier4_integration_launch

--- a/launch/tier4_sensing_launch/CHANGELOG.rst
+++ b/launch/tier4_sensing_launch/CHANGELOG.rst
@@ -5,7 +5,7 @@ Changelog for package tier4_sensing_launch
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* refactor(vehicle_info_utils)!: prefix package and namespace with autoware (`#7353 <https://github.com/youtalk/autoware.universe/issues/7353>`_)
+* refactor(vehicle_info_utils)!: prefix package and namespace with autoware (`#7353 <https://github.com/autowarefoundation/autoware.universe/issues/7353>`_)
   * chore(autoware_vehicle_info_utils): rename header
   * chore(bpp-common): vehicle info
   * chore(path_optimizer): vehicle info
@@ -44,7 +44,7 @@ Changelog for package tier4_sensing_launch
 
 0.26.0 (2024-04-03)
 -------------------
-* feat: remove use_pointcloud_container (`#6115 <https://github.com/youtalk/autoware.universe/issues/6115>`_)
+* feat: remove use_pointcloud_container (`#6115 <https://github.com/autowarefoundation/autoware.universe/issues/6115>`_)
   * feat!: remove use_pointcloud_container
   * fix pre-commit
   * fix: completely remove use_pointcloud_container after merge main
@@ -52,7 +52,7 @@ Changelog for package tier4_sensing_launch
   * revert: revert change in probabilistic_occupancy_grid_map
   * revert change in launcher of ogm
   ---------
-* build: mark autoware_cmake as <buildtool_depend> (`#3616 <https://github.com/youtalk/autoware.universe/issues/3616>`_)
+* build: mark autoware_cmake as <buildtool_depend> (`#3616 <https://github.com/autowarefoundation/autoware.universe/issues/3616>`_)
   * build: mark autoware_cmake as <buildtool_depend>
   with <build_depend>, autoware_cmake is automatically exported with ament_target_dependencies() (unecessary)
   * style(pre-commit): autofix
@@ -60,7 +60,7 @@ Changelog for package tier4_sensing_launch
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Kenji Miyake <kenji.miyake@tier4.jp>
-* feat(tier4_perception_launch): sync perception launch to autoware_launch (`#2168 <https://github.com/youtalk/autoware.universe/issues/2168>`_)
+* feat(tier4_perception_launch): sync perception launch to autoware_launch (`#2168 <https://github.com/autowarefoundation/autoware.universe/issues/2168>`_)
   * sync launch file from tier4 autoware launch
   * sync tlr launcher
   * ci(pre-commit): autofix
@@ -70,29 +70,29 @@ Changelog for package tier4_sensing_launch
   * fix exec_depend in package.xml
   * Sync traffic light node
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* ci(pre-commit): format SVG files (`#2172 <https://github.com/youtalk/autoware.universe/issues/2172>`_)
+* ci(pre-commit): format SVG files (`#2172 <https://github.com/autowarefoundation/autoware.universe/issues/2172>`_)
   * ci(pre-commit): format SVG files
   * ci(pre-commit): autofix
   * apply pre-commit
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* chore: upgrade cmake_minimum_required to 3.14 (`#856 <https://github.com/youtalk/autoware.universe/issues/856>`_)
-* refactor: use autoware cmake (`#849 <https://github.com/youtalk/autoware.universe/issues/849>`_)
+* chore: upgrade cmake_minimum_required to 3.14 (`#856 <https://github.com/autowarefoundation/autoware.universe/issues/856>`_)
+* refactor: use autoware cmake (`#849 <https://github.com/autowarefoundation/autoware.universe/issues/849>`_)
   * remove autoware_auto_cmake
   * add build_depend of autoware_cmake
   * use autoware_cmake in CMakeLists.txt
   * fix bugs
   * fix cmake lint errors
-* chore: remove bad chars (`#845 <https://github.com/youtalk/autoware.universe/issues/845>`_)
-* style: fix format of package.xml (`#844 <https://github.com/youtalk/autoware.universe/issues/844>`_)
-* ci(pre-commit): update pre-commit-hooks-ros (`#625 <https://github.com/youtalk/autoware.universe/issues/625>`_)
+* chore: remove bad chars (`#845 <https://github.com/autowarefoundation/autoware.universe/issues/845>`_)
+* style: fix format of package.xml (`#844 <https://github.com/autowarefoundation/autoware.universe/issues/844>`_)
+* ci(pre-commit): update pre-commit-hooks-ros (`#625 <https://github.com/autowarefoundation/autoware.universe/issues/625>`_)
   * ci(pre-commit): update pre-commit-hooks-ros
   * ci(pre-commit): autofix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* fix: delete common_sensor_launch from exec_depend (`#626 <https://github.com/youtalk/autoware.universe/issues/626>`_)
-* feat(tier4_autoware_launch)!: move package to autoware_launch (`#420 <https://github.com/youtalk/autoware.universe/issues/420>`_)
+* fix: delete common_sensor_launch from exec_depend (`#626 <https://github.com/autowarefoundation/autoware.universe/issues/626>`_)
+* feat(tier4_autoware_launch)!: move package to autoware_launch (`#420 <https://github.com/autowarefoundation/autoware.universe/issues/420>`_)
   * feat(tier4_autoware_launch)!: move package to autoware_launch
   * remove unnecessary depends
-* feat: change launch package name (`#186 <https://github.com/youtalk/autoware.universe/issues/186>`_)
+* feat: change launch package name (`#186 <https://github.com/autowarefoundation/autoware.universe/issues/186>`_)
   * rename launch folder
   * autoware_launch -> tier4_autoware_launch
   * integration_launch -> tier4_integration_launch

--- a/launch/tier4_simulator_launch/CHANGELOG.rst
+++ b/launch/tier4_simulator_launch/CHANGELOG.rst
@@ -5,29 +5,29 @@ Changelog for package tier4_simulator_launch
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* chore(simple_planning_simulator): add stop_filter_param_path (`#9127 <https://github.com/youtalk/autoware.universe/issues/9127>`_)
-* refactor(pose_initializer)!: prefix package and namespace with autoware (`#8701 <https://github.com/youtalk/autoware.universe/issues/8701>`_)
+* chore(simple_planning_simulator): add stop_filter_param_path (`#9127 <https://github.com/autowarefoundation/autoware.universe/issues/9127>`_)
+* refactor(pose_initializer)!: prefix package and namespace with autoware (`#8701 <https://github.com/autowarefoundation/autoware.universe/issues/8701>`_)
   * add autoware\_ prefix
   * fix link
   ---------
   Co-authored-by: SakodaShintaro <shintaro.sakoda@tier4.jp>
-* feat(psim)!: preapre settings to launch localization modules on psim (`#8212 <https://github.com/youtalk/autoware.universe/issues/8212>`_)
-* feat(psim)!: change a setting parameter type from bool to string (`#8331 <https://github.com/youtalk/autoware.universe/issues/8331>`_)
+* feat(psim)!: preapre settings to launch localization modules on psim (`#8212 <https://github.com/autowarefoundation/autoware.universe/issues/8212>`_)
+* feat(psim)!: change a setting parameter type from bool to string (`#8331 <https://github.com/autowarefoundation/autoware.universe/issues/8331>`_)
   * change a param type, bool to string
   * add param description, add null tag group for the null option
   ---------
-* feat(evalautor): rename evaluator diag topics (`#8152 <https://github.com/youtalk/autoware.universe/issues/8152>`_)
+* feat(evalautor): rename evaluator diag topics (`#8152 <https://github.com/autowarefoundation/autoware.universe/issues/8152>`_)
   * feat(evalautor): rename evaluator diag topics
   * perception
   ---------
-* refactor(elevation_map_loader): add package name prefix `autoware\_`, fix namespace and directory structure (`#7988 <https://github.com/youtalk/autoware.universe/issues/7988>`_)
+* refactor(elevation_map_loader): add package name prefix `autoware\_`, fix namespace and directory structure (`#7988 <https://github.com/autowarefoundation/autoware.universe/issues/7988>`_)
   * refactor: add namespace, remove unused dependencies, file structure
   chore: remove unused dependencies
   style(pre-commit): autofix
   * refactor: rename elevation_map_loader to autoware_elevation_map_loader
   Rename the `elevation_map_loader` package to `autoware_elevation_map_loader` to align with the Autoware naming convention.
   style(pre-commit): autofix
-* feat(simple_planning_simulator): add actuation command simulator (`#8065 <https://github.com/youtalk/autoware.universe/issues/8065>`_)
+* feat(simple_planning_simulator): add actuation command simulator (`#8065 <https://github.com/autowarefoundation/autoware.universe/issues/8065>`_)
   * feat(simple_planning_simulator): add actuation command simulator
   tmp
   add
@@ -43,7 +43,7 @@ Changelog for package tier4_simulator_launch
   * fix typo
   ---------
   Co-authored-by: Takamasa Horibe <horibe.takamasa@gmail.com>
-* feat(processing_time_checker): add a new package (`#7957 <https://github.com/youtalk/autoware.universe/issues/7957>`_)
+* feat(processing_time_checker): add a new package (`#7957 <https://github.com/autowarefoundation/autoware.universe/issues/7957>`_)
   * feat(processing_time_checker): add a new package
   * fix
   * fix
@@ -52,22 +52,22 @@ Changelog for package tier4_simulator_launch
   * fix
   * fix
   ---------
-* feat(tier4_perception_launch): add missing arg use_multi_channel_tracker_merger (`#7705 <https://github.com/youtalk/autoware.universe/issues/7705>`_)
+* feat(tier4_perception_launch): add missing arg use_multi_channel_tracker_merger (`#7705 <https://github.com/autowarefoundation/autoware.universe/issues/7705>`_)
   * feat(tier4_perception_launch): add missing arg use_multi_channel_tracker_merger
   * feat: add use_multi_channel_tracker_merger argument to simulator launch
   This commit adds the `use_multi_channel_tracker_merger` argument to the simulator launch file. The argument is set to `false` by default. This change enables the use of the multi-channel tracker merger in the simulator.
   ---------
-* feat(diagnostic_converter): fix output metrics topic name and add to converter (`#7495 <https://github.com/youtalk/autoware.universe/issues/7495>`_)
-* feat(perception_online_evaluator): add use_perception_online_evaluator option and disable it by default (`#6861 <https://github.com/youtalk/autoware.universe/issues/6861>`_)
+* feat(diagnostic_converter): fix output metrics topic name and add to converter (`#7495 <https://github.com/autowarefoundation/autoware.universe/issues/7495>`_)
+* feat(perception_online_evaluator): add use_perception_online_evaluator option and disable it by default (`#6861 <https://github.com/autowarefoundation/autoware.universe/issues/6861>`_)
 * Contributors: Kosuke Takeuchi, Masaki Baba, Taekjin LEE, Takayuki Murooka, Yuki TAKAGI, Yutaka Kondo
 
 0.26.0 (2024-04-03)
 -------------------
-* fix(pose_initializer): added "user_defined_initial_pose" to dummy localization (`#6723 <https://github.com/youtalk/autoware.universe/issues/6723>`_)
+* fix(pose_initializer): added "user_defined_initial_pose" to dummy localization (`#6723 <https://github.com/autowarefoundation/autoware.universe/issues/6723>`_)
   Added "used_defined_initial_pose" to dummy localization
-* feat(default_ad_api): add door api (`#5737 <https://github.com/youtalk/autoware.universe/issues/5737>`_)
-* feat(tier4_simulator_launch): add option to disable all perception related modules (`#6382 <https://github.com/youtalk/autoware.universe/issues/6382>`_)
-* feat(perception_online_evaluator): add perception_online_evaluator (`#6493 <https://github.com/youtalk/autoware.universe/issues/6493>`_)
+* feat(default_ad_api): add door api (`#5737 <https://github.com/autowarefoundation/autoware.universe/issues/5737>`_)
+* feat(tier4_simulator_launch): add option to disable all perception related modules (`#6382 <https://github.com/autowarefoundation/autoware.universe/issues/6382>`_)
+* feat(perception_online_evaluator): add perception_online_evaluator (`#6493 <https://github.com/autowarefoundation/autoware.universe/issues/6493>`_)
   * feat(perception_evaluator): add perception_evaluator
   tmp
   update
@@ -85,9 +85,9 @@ Changelog for package tier4_simulator_launch
   * feat: add test
   * fix: ci check
   ---------
-* fix(tier4_simulator_launch): add lacked param path (`#5326 <https://github.com/youtalk/autoware.universe/issues/5326>`_)
-* chore(tier4_simulator_launch): launch camera and V2X fusion module in simple planning simulator (`#4522 <https://github.com/youtalk/autoware.universe/issues/4522>`_)
-* feat: use `pose_source` and `twist_source` for selecting localization methods (`#4257 <https://github.com/youtalk/autoware.universe/issues/4257>`_)
+* fix(tier4_simulator_launch): add lacked param path (`#5326 <https://github.com/autowarefoundation/autoware.universe/issues/5326>`_)
+* chore(tier4_simulator_launch): launch camera and V2X fusion module in simple planning simulator (`#4522 <https://github.com/autowarefoundation/autoware.universe/issues/4522>`_)
+* feat: use `pose_source` and `twist_source` for selecting localization methods (`#4257 <https://github.com/autowarefoundation/autoware.universe/issues/4257>`_)
   * feat(tier4_localization_launch): add pose_twist_estimator.launch.py
   * update format
   * update launcher
@@ -112,8 +112,8 @@ Changelog for package tier4_simulator_launch
   * Update yabloc document
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* refactor(occpuancy grid map): move param to yaml (`#4038 <https://github.com/youtalk/autoware.universe/issues/4038>`_)
-* build: mark autoware_cmake as <buildtool_depend> (`#3616 <https://github.com/youtalk/autoware.universe/issues/3616>`_)
+* refactor(occpuancy grid map): move param to yaml (`#4038 <https://github.com/autowarefoundation/autoware.universe/issues/4038>`_)
+* build: mark autoware_cmake as <buildtool_depend> (`#3616 <https://github.com/autowarefoundation/autoware.universe/issues/3616>`_)
   * build: mark autoware_cmake as <buildtool_depend>
   with <build_depend>, autoware_cmake is automatically exported with ament_target_dependencies() (unecessary)
   * style(pre-commit): autofix
@@ -121,34 +121,34 @@ Changelog for package tier4_simulator_launch
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Kenji Miyake <kenji.miyake@tier4.jp>
-* fix(dummy_perception_publisher): add parameter to configure z pose of dummy object (`#3457 <https://github.com/youtalk/autoware.universe/issues/3457>`_)
-* refactor(occupancy_grid_map): add occupancy_grid_map method/param var to launcher (`#3393 <https://github.com/youtalk/autoware.universe/issues/3393>`_)
+* fix(dummy_perception_publisher): add parameter to configure z pose of dummy object (`#3457 <https://github.com/autowarefoundation/autoware.universe/issues/3457>`_)
+* refactor(occupancy_grid_map): add occupancy_grid_map method/param var to launcher (`#3393 <https://github.com/autowarefoundation/autoware.universe/issues/3393>`_)
   * add occcupancy_grid_map method/param var to launcher
   * added CODEOWNER
   * Revert "added CODEOWNER"
   This reverts commit 2213c2956af19580d0a7788680aab321675aab3b.
   * add maintainer
   ---------
-* fix(tier4_simulator_launch): fix launch package name (`#3340 <https://github.com/youtalk/autoware.universe/issues/3340>`_)
-* feat(tier4_simulator_launch): convert /diagnostics_err (`#3152 <https://github.com/youtalk/autoware.universe/issues/3152>`_)
-* bugfix(tier4_simulator_launch): fix occupancy grid map not appearing problem in psim  (`#3081 <https://github.com/youtalk/autoware.universe/issues/3081>`_)
+* fix(tier4_simulator_launch): fix launch package name (`#3340 <https://github.com/autowarefoundation/autoware.universe/issues/3340>`_)
+* feat(tier4_simulator_launch): convert /diagnostics_err (`#3152 <https://github.com/autowarefoundation/autoware.universe/issues/3152>`_)
+* bugfix(tier4_simulator_launch): fix occupancy grid map not appearing problem in psim  (`#3081 <https://github.com/autowarefoundation/autoware.universe/issues/3081>`_)
   * fixed psim occupancy grid map problem
   * fix parameter designation
   ---------
   Co-authored-by: Takayuki Murooka <takayuki5168@gmail.com>
-* chore(tier4_simulator_launch): add code owner (`#3080 <https://github.com/youtalk/autoware.universe/issues/3080>`_)
+* chore(tier4_simulator_launch): add code owner (`#3080 <https://github.com/autowarefoundation/autoware.universe/issues/3080>`_)
   chore(tier4_simulator_launch): add code owners
-* fix(tier4_perception_launch): fix config path (`#3078 <https://github.com/youtalk/autoware.universe/issues/3078>`_)
+* fix(tier4_perception_launch): fix config path (`#3078 <https://github.com/autowarefoundation/autoware.universe/issues/3078>`_)
   * fix(tier4_perception_launch): fix config path
   * use pointcloud_based_occupancy_grid_map.launch.py in tier4_simulator_launch
   ---------
-* feat(pose_initializer): enable pose initialization while running (only for sim) (`#3038 <https://github.com/youtalk/autoware.universe/issues/3038>`_)
+* feat(pose_initializer): enable pose initialization while running (only for sim) (`#3038 <https://github.com/autowarefoundation/autoware.universe/issues/3038>`_)
   * feat(pose_initializer): enable pose initialization while running (only for sim)
   * both logsim and psim params
   * only one pose_initializer_param_path arg
   * use two param files for pose_initializer
   ---------
-* feat(diagnostic_converter): add converter to use planning_evaluator's output for scenario's condition (`#2514 <https://github.com/youtalk/autoware.universe/issues/2514>`_)
+* feat(diagnostic_converter): add converter to use planning_evaluator's output for scenario's condition (`#2514 <https://github.com/autowarefoundation/autoware.universe/issues/2514>`_)
   * add original diagnostic_convertor
   * add test
   * fix typo
@@ -198,7 +198,7 @@ Changelog for package tier4_simulator_launch
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Maxime CLEMENT <78338830+maxime-clem@users.noreply.github.com>
-* feat(pose_initilizer): support gnss/imu pose estimator (`#2904 <https://github.com/youtalk/autoware.universe/issues/2904>`_)
+* feat(pose_initilizer): support gnss/imu pose estimator (`#2904 <https://github.com/autowarefoundation/autoware.universe/issues/2904>`_)
   * Support GNSS/IMU pose estimator
   * style(pre-commit): autofix
   * Revert gnss/imu support
@@ -226,18 +226,18 @@ Changelog for package tier4_simulator_launch
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Ryohei Sasaki <ryohei.sasaki@map4.jp>
   Co-authored-by: Takagi, Isamu <43976882+isamu-takagi@users.noreply.github.com>
-* feat(tier4_simulator_launch): remove configs and move to autoware_launch (`#2541 <https://github.com/youtalk/autoware.universe/issues/2541>`_)
+* feat(tier4_simulator_launch): remove configs and move to autoware_launch (`#2541 <https://github.com/autowarefoundation/autoware.universe/issues/2541>`_)
   * feat(tier4_perception_launch): remove configs and move to autoware_launch
   * update readme
   * first commit
   * remove config
-* fix(tier4_simulator_launch): fix path (`#2281 <https://github.com/youtalk/autoware.universe/issues/2281>`_)
-* ci(pre-commit): format SVG files (`#2172 <https://github.com/youtalk/autoware.universe/issues/2172>`_)
+* fix(tier4_simulator_launch): fix path (`#2281 <https://github.com/autowarefoundation/autoware.universe/issues/2281>`_)
+* ci(pre-commit): format SVG files (`#2172 <https://github.com/autowarefoundation/autoware.universe/issues/2172>`_)
   * ci(pre-commit): format SVG files
   * ci(pre-commit): autofix
   * apply pre-commit
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat(pose_initializer)!: support ad api (`#1500 <https://github.com/youtalk/autoware.universe/issues/1500>`_)
+* feat(pose_initializer)!: support ad api (`#1500 <https://github.com/autowarefoundation/autoware.universe/issues/1500>`_)
   * feat(pose_initializer): support ad api
   * docs: update readme
   * fix: build error
@@ -253,23 +253,23 @@ Changelog for package tier4_simulator_launch
   * fix: fix build error
   * ci(pre-commit): autofix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat(tier4_simulator_launch): manual sync with tier4/autoware_launch.*/simulator_launch (`#1820 <https://github.com/youtalk/autoware.universe/issues/1820>`_)
+* feat(tier4_simulator_launch): manual sync with tier4/autoware_launch.*/simulator_launch (`#1820 <https://github.com/autowarefoundation/autoware.universe/issues/1820>`_)
   * feat(tier4_simulator_launch): manual sync with tier4/autoware_launch.*/simulator_launch
   * ci(pre-commit): autofix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Kenji Miyake <31987104+kenji-miyake@users.noreply.github.com>
-* feat(tier4_simulator_launch): declare param path argument (`#1443 <https://github.com/youtalk/autoware.universe/issues/1443>`_)
+* feat(tier4_simulator_launch): declare param path argument (`#1443 <https://github.com/autowarefoundation/autoware.universe/issues/1443>`_)
   feat(tier4_simulator_launch): declare param path
-* feat!: replace ogm at scenario simulation (`#1062 <https://github.com/youtalk/autoware.universe/issues/1062>`_)
-* chore: upgrade cmake_minimum_required to 3.14 (`#856 <https://github.com/youtalk/autoware.universe/issues/856>`_)
-* refactor: use autoware cmake (`#849 <https://github.com/youtalk/autoware.universe/issues/849>`_)
+* feat!: replace ogm at scenario simulation (`#1062 <https://github.com/autowarefoundation/autoware.universe/issues/1062>`_)
+* chore: upgrade cmake_minimum_required to 3.14 (`#856 <https://github.com/autowarefoundation/autoware.universe/issues/856>`_)
+* refactor: use autoware cmake (`#849 <https://github.com/autowarefoundation/autoware.universe/issues/849>`_)
   * remove autoware_auto_cmake
   * add build_depend of autoware_cmake
   * use autoware_cmake in CMakeLists.txt
   * fix bugs
   * fix cmake lint errors
-* style: fix format of package.xml (`#844 <https://github.com/youtalk/autoware.universe/issues/844>`_)
-* feat: pointcloud based probabilistic occupancy grid map (`#624 <https://github.com/youtalk/autoware.universe/issues/624>`_)
+* style: fix format of package.xml (`#844 <https://github.com/autowarefoundation/autoware.universe/issues/844>`_)
+* feat: pointcloud based probabilistic occupancy grid map (`#624 <https://github.com/autowarefoundation/autoware.universe/issues/624>`_)
   * initial commit
   * ci(pre-commit): autofix
   * change param
@@ -285,19 +285,19 @@ Changelog for package tier4_simulator_launch
   * add single frame mode
   * ci(pre-commit): autofix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* ci(pre-commit): update pre-commit-hooks-ros (`#625 <https://github.com/youtalk/autoware.universe/issues/625>`_)
+* ci(pre-commit): update pre-commit-hooks-ros (`#625 <https://github.com/autowarefoundation/autoware.universe/issues/625>`_)
   * ci(pre-commit): update pre-commit-hooks-ros
   * ci(pre-commit): autofix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat: move empty_objects_publisher (`#613 <https://github.com/youtalk/autoware.universe/issues/613>`_)
+* feat: move empty_objects_publisher (`#613 <https://github.com/autowarefoundation/autoware.universe/issues/613>`_)
   * feat: move empty_objects_publisher
   * fix group of empty_object_publisher
-* feat(tier4_simulator_launch, dummy_perception_publisher): launch perception modules from simulator.launch.xml (`#465 <https://github.com/youtalk/autoware.universe/issues/465>`_)
+* feat(tier4_simulator_launch, dummy_perception_publisher): launch perception modules from simulator.launch.xml (`#465 <https://github.com/autowarefoundation/autoware.universe/issues/465>`_)
   * feat(tier4_simulator_launch, dummy_perception_publisher): launch perception modules from simualtor.launch.xml
   * remove perception launching dummy_perception_publisher.launch.xml
   * remove unnecessary comment
-* fix(tier4_simulator_launch, tier4_vehicle_launch)!: fix launch args (`#443 <https://github.com/youtalk/autoware.universe/issues/443>`_)
-* feat: change launch package name (`#186 <https://github.com/youtalk/autoware.universe/issues/186>`_)
+* fix(tier4_simulator_launch, tier4_vehicle_launch)!: fix launch args (`#443 <https://github.com/autowarefoundation/autoware.universe/issues/443>`_)
+* feat: change launch package name (`#186 <https://github.com/autowarefoundation/autoware.universe/issues/186>`_)
   * rename launch folder
   * autoware_launch -> tier4_autoware_launch
   * integration_launch -> tier4_integration_launch

--- a/launch/tier4_system_launch/CHANGELOG.rst
+++ b/launch/tier4_system_launch/CHANGELOG.rst
@@ -5,15 +5,15 @@ Changelog for package tier4_system_launch
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* fix(system): fixed to use autoware_component_interface_tools (`#9133 <https://github.com/youtalk/autoware.universe/issues/9133>`_)
+* fix(system): fixed to use autoware_component_interface_tools (`#9133 <https://github.com/autowarefoundation/autoware.universe/issues/9133>`_)
   Fixed component_interface_tools
-* feat(system_error_monitor): remove system error monitor (`#8929 <https://github.com/youtalk/autoware.universe/issues/8929>`_)
+* feat(system_error_monitor): remove system error monitor (`#8929 <https://github.com/autowarefoundation/autoware.universe/issues/8929>`_)
   * feat: delete-system-error-monitor-from-autoware
   * feat: remove unnecessary params
   ---------
-* feat(emergency_handler): delete package (`#8917 <https://github.com/youtalk/autoware.universe/issues/8917>`_)
+* feat(emergency_handler): delete package (`#8917 <https://github.com/autowarefoundation/autoware.universe/issues/8917>`_)
   * feat(emergency_handler): delete package
-* feat(processing_time_checker): add a new package (`#7957 <https://github.com/youtalk/autoware.universe/issues/7957>`_)
+* feat(processing_time_checker): add a new package (`#7957 <https://github.com/autowarefoundation/autoware.universe/issues/7957>`_)
   * feat(processing_time_checker): add a new package
   * fix
   * fix
@@ -22,19 +22,19 @@ Changelog for package tier4_system_launch
   * fix
   * fix
   ---------
-* feat(tier4_system_launch): use mrm handler by default (`#7728 <https://github.com/youtalk/autoware.universe/issues/7728>`_)
-* feat(tier4_system_launch): modify diagnostic_graph_aggregator_graph argument (`#7133 <https://github.com/youtalk/autoware.universe/issues/7133>`_)
-* feat(default_ad_api): use diagnostic graph (`#7043 <https://github.com/youtalk/autoware.universe/issues/7043>`_)
+* feat(tier4_system_launch): use mrm handler by default (`#7728 <https://github.com/autowarefoundation/autoware.universe/issues/7728>`_)
+* feat(tier4_system_launch): modify diagnostic_graph_aggregator_graph argument (`#7133 <https://github.com/autowarefoundation/autoware.universe/issues/7133>`_)
+* feat(default_ad_api): use diagnostic graph (`#7043 <https://github.com/autowarefoundation/autoware.universe/issues/7043>`_)
 * Contributors: Ryuta Kambe, SakodaShintaro, Takagi, Isamu, Takayuki Murooka, TetsuKawa, Yutaka Kondo
 
 0.26.0 (2024-04-03)
 -------------------
-* chore(tier4_system_launch): add option to select graph path depending on running mode (`#6700 <https://github.com/youtalk/autoware.universe/issues/6700>`_)
+* chore(tier4_system_launch): add option to select graph path depending on running mode (`#6700 <https://github.com/autowarefoundation/autoware.universe/issues/6700>`_)
   chore(tier4_system_launch): add option of using graph path for simulation
-* feat(tier4_system_launch): add option to launch mrm handler (`#6660 <https://github.com/youtalk/autoware.universe/issues/6660>`_)
-* chore: update maintainer (`#5730 <https://github.com/youtalk/autoware.universe/issues/5730>`_)
+* feat(tier4_system_launch): add option to launch mrm handler (`#6660 <https://github.com/autowarefoundation/autoware.universe/issues/6660>`_)
+* chore: update maintainer (`#5730 <https://github.com/autowarefoundation/autoware.universe/issues/5730>`_)
   update maintainer
-* feat(duplicated_node_checker): add packages to check duplication of node names in ros2 (`#5286 <https://github.com/youtalk/autoware.universe/issues/5286>`_)
+* feat(duplicated_node_checker): add packages to check duplication of node names in ros2 (`#5286 <https://github.com/autowarefoundation/autoware.universe/issues/5286>`_)
   * add implementation for duplicated node checking
   * update the default parameters of system_error_monitor to include results from duplication check
   * style(pre-commit): autofix
@@ -51,9 +51,9 @@ Changelog for package tier4_system_launch
   Co-authored-by: Owen-Liuyuxuan <uken.ryu@tier4.jp>
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Shumpei Wakabayashi <42209144+shmpwk@users.noreply.github.com>
-* chore: update maintainer (`#4140 <https://github.com/youtalk/autoware.universe/issues/4140>`_)
+* chore: update maintainer (`#4140 <https://github.com/autowarefoundation/autoware.universe/issues/4140>`_)
   Co-authored-by: Ryohsuke Mitsudome <43976834+mitsudome-r@users.noreply.github.com>
-* build: mark autoware_cmake as <buildtool_depend> (`#3616 <https://github.com/youtalk/autoware.universe/issues/3616>`_)
+* build: mark autoware_cmake as <buildtool_depend> (`#3616 <https://github.com/autowarefoundation/autoware.universe/issues/3616>`_)
   * build: mark autoware_cmake as <buildtool_depend>
   with <build_depend>, autoware_cmake is automatically exported with ament_target_dependencies() (unecessary)
   * style(pre-commit): autofix
@@ -61,13 +61,13 @@ Changelog for package tier4_system_launch
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Kenji Miyake <kenji.miyake@tier4.jp>
-* feat(pose_initializer): enable pose initialization while running (only for sim) (`#3038 <https://github.com/youtalk/autoware.universe/issues/3038>`_)
+* feat(pose_initializer): enable pose initialization while running (only for sim) (`#3038 <https://github.com/autowarefoundation/autoware.universe/issues/3038>`_)
   * feat(pose_initializer): enable pose initialization while running (only for sim)
   * both logsim and psim params
   * only one pose_initializer_param_path arg
   * use two param files for pose_initializer
   ---------
-* feat(dummy diag publisher): change diag name specification method to YAML (`#2840 <https://github.com/youtalk/autoware.universe/issues/2840>`_)
+* feat(dummy diag publisher): change diag name specification method to YAML (`#2840 <https://github.com/autowarefoundation/autoware.universe/issues/2840>`_)
   * Signed-off-by: asana17 <akihiro.sakurai@tier4.jp>
   modified dummy_diag_publisher to use YAML for param
   * Signed-off-by: asana17 <akihiro.sakurai@tier4.jp>
@@ -78,7 +78,7 @@ Changelog for package tier4_system_launch
   * add pkg maintainer
   * launch dummy_diag_publisher by launch_dummy_diag_publisher param
   ---------
-* feat(tier4_system_launch): remove configs and move to autoware_launch (`#2540 <https://github.com/youtalk/autoware.universe/issues/2540>`_)
+* feat(tier4_system_launch): remove configs and move to autoware_launch (`#2540 <https://github.com/autowarefoundation/autoware.universe/issues/2540>`_)
   * feat(tier4_system_launch): remove configs and move to autoware_launch
   * update readme
   * fix readme
@@ -87,18 +87,18 @@ Changelog for package tier4_system_launch
   * fix readme
   * fix mistake
   * fix typo
-* feat(component_interface_tools): add service log checker  (`#2503 <https://github.com/youtalk/autoware.universe/issues/2503>`_)
+* feat(component_interface_tools): add service log checker  (`#2503 <https://github.com/autowarefoundation/autoware.universe/issues/2503>`_)
   * feat(component_interface_utils): add service log checker
   * feat(component_interface_tools): add service log checker
   * feat(component_interface_tools): add diagnostics
   * feat: update system error monitor config
-* feat: replace python launch with xml launch for system monitor (`#2430 <https://github.com/youtalk/autoware.universe/issues/2430>`_)
+* feat: replace python launch with xml launch for system monitor (`#2430 <https://github.com/autowarefoundation/autoware.universe/issues/2430>`_)
   * feat: replace python launch with xml launch for system monitor
   * ci(pre-commit): autofix
   * update figure
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* chore(system_monitor): add maintainer (`#2420 <https://github.com/youtalk/autoware.universe/issues/2420>`_)
-* feat!: replace HADMap with Lanelet (`#2356 <https://github.com/youtalk/autoware.universe/issues/2356>`_)
+* chore(system_monitor): add maintainer (`#2420 <https://github.com/autowarefoundation/autoware.universe/issues/2420>`_)
+* feat!: replace HADMap with Lanelet (`#2356 <https://github.com/autowarefoundation/autoware.universe/issues/2356>`_)
   * feat!: replace HADMap with Lanelet
   * update topic.yaml
   * Update perception/traffic_light_map_based_detector/README.md
@@ -111,13 +111,13 @@ Changelog for package tier4_system_launch
   Co-authored-by: Daisuke Nishimatsu <42202095+wep21@users.noreply.github.com>
   * format readme
   Co-authored-by: Daisuke Nishimatsu <42202095+wep21@users.noreply.github.com>
-* fix(mrm_emergency_stop_operator): fix parameter loading in mrm operators (`#2378 <https://github.com/youtalk/autoware.universe/issues/2378>`_)
+* fix(mrm_emergency_stop_operator): fix parameter loading in mrm operators (`#2378 <https://github.com/autowarefoundation/autoware.universe/issues/2378>`_)
   * fix(mrm_emergency_stop_operator): fix parameter loading in mrm operators
   * ci(pre-commit): autofix
   * fix(mrm_emergency_stop_operator): remove os import
   * fix(mrm_emergency_stop_operator): remove unused packages
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat(ad_service_state_monitor)!: remove ad_service_state_monitor (`#2311 <https://github.com/youtalk/autoware.universe/issues/2311>`_)
+* feat(ad_service_state_monitor)!: remove ad_service_state_monitor (`#2311 <https://github.com/autowarefoundation/autoware.universe/issues/2311>`_)
   * feat(autoware_ad_api_msgs): define operation mode interface
   * feat(default_ad_api): add operation mode api
   * fix: add message
@@ -158,8 +158,8 @@ Changelog for package tier4_system_launch
   * feat: remove sensing alive monitoring
   Co-authored-by: Kenji Miyake <31987104+kenji-miyake@users.noreply.github.com>
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* fix(system_monitor): add parameter to launch system_monitor and fix hdd_monitor (`#2285 <https://github.com/youtalk/autoware.universe/issues/2285>`_)
-* feat(emergency_handler): add a selector for multiple MRM behaviors (`#2070 <https://github.com/youtalk/autoware.universe/issues/2070>`_)
+* fix(system_monitor): add parameter to launch system_monitor and fix hdd_monitor (`#2285 <https://github.com/autowarefoundation/autoware.universe/issues/2285>`_)
+* feat(emergency_handler): add a selector for multiple MRM behaviors (`#2070 <https://github.com/autowarefoundation/autoware.universe/issues/2070>`_)
   * feat(emergency_handler): add mrm command and status publishers
   * feat(autoware_ad_api_msgs): define mrm operation srv and mrm status msg
   * feat(emergency_handler): add mrm clients and subscribers
@@ -221,18 +221,18 @@ Changelog for package tier4_system_launch
   * fix(emergency_handler): fix acronyms case
   * chore(tier4_system_launch): add a mrm comfortable stop parameter
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* chore(tier4_system_launch): remove unused system file (`#2263 <https://github.com/youtalk/autoware.universe/issues/2263>`_)
+* chore(tier4_system_launch): remove unused system file (`#2263 <https://github.com/autowarefoundation/autoware.universe/issues/2263>`_)
   * chore(tier4_system_launch): remove unused system file
   * remove unnecessary code
-* ci(pre-commit): format SVG files (`#2172 <https://github.com/youtalk/autoware.universe/issues/2172>`_)
+* ci(pre-commit): format SVG files (`#2172 <https://github.com/autowarefoundation/autoware.universe/issues/2172>`_)
   * ci(pre-commit): format SVG files
   * ci(pre-commit): autofix
   * apply pre-commit
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat(component_state_monitor): add component state monitor (`#2120 <https://github.com/youtalk/autoware.universe/issues/2120>`_)
+* feat(component_state_monitor): add component state monitor (`#2120 <https://github.com/autowarefoundation/autoware.universe/issues/2120>`_)
   * feat(component_state_monitor): add component state monitor
   * feat: change module
-* feat: (system_monitor) adding a node for CMOS battery monitoring (`#1989 <https://github.com/youtalk/autoware.universe/issues/1989>`_)
+* feat: (system_monitor) adding a node for CMOS battery monitoring (`#1989 <https://github.com/autowarefoundation/autoware.universe/issues/1989>`_)
   * adding document for voltage monitor
   * ci(pre-commit): autofix
   * fixed for the issue of multithread
@@ -252,36 +252,36 @@ Changelog for package tier4_system_launch
   * ci(pre-commit): autofix
   * added topics_voltage_monitor.md)
   * ci(pre-commit): autofix
-  * chore: sync files (`#629 <https://github.com/youtalk/autoware.universe/issues/629>`_)
+  * chore: sync files (`#629 <https://github.com/autowarefoundation/autoware.universe/issues/629>`_)
   * chore: sync files
   * ci(pre-commit): autofix
   Co-authored-by: kenji-miyake <kenji-miyake@users.noreply.github.com>
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-  * fix(dummy_diag_publisher): use anon to make unique node name instead of diag name (`#639 <https://github.com/youtalk/autoware.universe/issues/639>`_)
-  * chore: sync files (`#648 <https://github.com/youtalk/autoware.universe/issues/648>`_)
+  * fix(dummy_diag_publisher): use anon to make unique node name instead of diag name (`#639 <https://github.com/autowarefoundation/autoware.universe/issues/639>`_)
+  * chore: sync files (`#648 <https://github.com/autowarefoundation/autoware.universe/issues/648>`_)
   * chore: sync files
   * Revert "chore: sync files"
   This reverts commit b24f530b48306e16aa285f80a629ce5c5a9ccda7.
   * sync codecov.yaml
   Co-authored-by: kenji-miyake <kenji-miyake@users.noreply.github.com>
   Co-authored-by: Kenji Miyake <kenji.miyake@tier4.jp>
-  * fix(autoware_state_panel): fix message type for /api/autoware/get/engage (`#666 <https://github.com/youtalk/autoware.universe/issues/666>`_)
+  * fix(autoware_state_panel): fix message type for /api/autoware/get/engage (`#666 <https://github.com/autowarefoundation/autoware.universe/issues/666>`_)
   * fix(autoware_state_panel): fix message type for /api/autoware/get/engage
   * ci(pre-commit): autofix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-  * fix(behavior_velocity): avoid insert same point on trajectory utils (`#834 <https://github.com/youtalk/autoware.universe/issues/834>`_)
-  * refactor(behavior_velocity_planner): simplify CMakeLists.txt (`#855 <https://github.com/youtalk/autoware.universe/issues/855>`_)
-  * docs: fix 404 error caused by typo in url (`#871 <https://github.com/youtalk/autoware.universe/issues/871>`_)
+  * fix(behavior_velocity): avoid insert same point on trajectory utils (`#834 <https://github.com/autowarefoundation/autoware.universe/issues/834>`_)
+  * refactor(behavior_velocity_planner): simplify CMakeLists.txt (`#855 <https://github.com/autowarefoundation/autoware.universe/issues/855>`_)
+  * docs: fix 404 error caused by typo in url (`#871 <https://github.com/autowarefoundation/autoware.universe/issues/871>`_)
   * docs: fix 404 error caused by typo in url
   * docs: fix typo in url for yolov4
-  * fix(image_projection_based_fusion): set imagebuffersize (`#820 <https://github.com/youtalk/autoware.universe/issues/820>`_)
+  * fix(image_projection_based_fusion): set imagebuffersize (`#820 <https://github.com/autowarefoundation/autoware.universe/issues/820>`_)
   * fix: set imagebuffersize configured
   * ci(pre-commit): autofix
   Co-authored-by: suchang <chang.su@autocore.ai>
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-  * chore(avoidance_module): fix spell check (`#732 <https://github.com/youtalk/autoware.universe/issues/732>`_)
-  * feat: isolate gtests in all packages (`#693 <https://github.com/youtalk/autoware.universe/issues/693>`_)
-  * docs(virtual traffic light): add documentation (`#245 <https://github.com/youtalk/autoware.universe/issues/245>`_)
+  * chore(avoidance_module): fix spell check (`#732 <https://github.com/autowarefoundation/autoware.universe/issues/732>`_)
+  * feat: isolate gtests in all packages (`#693 <https://github.com/autowarefoundation/autoware.universe/issues/693>`_)
+  * docs(virtual traffic light): add documentation (`#245 <https://github.com/autowarefoundation/autoware.universe/issues/245>`_)
   * doc(behavior_velocity): add graph and fix link
   * doc(behavior_velocity): update virtual traffic light doc
   * doc(behavior_velocity): minor fix
@@ -292,7 +292,7 @@ Changelog for package tier4_system_launch
   * apply suggestion
   * doc: to intersection-coordination
   Co-authored-by: Kenji Miyake <31987104+kenji-miyake@users.noreply.github.com>
-  * feat(surround_obstacle_checker): separate surround_obstacle_checker from hierarchical planning flow (`#830 <https://github.com/youtalk/autoware.universe/issues/830>`_)
+  * feat(surround_obstacle_checker): separate surround_obstacle_checker from hierarchical planning flow (`#830 <https://github.com/autowarefoundation/autoware.universe/issues/830>`_)
   * fix(surroud_obstacle_checker): use alias
   * feat(surround_obstacle_checker): use velocity limit
   * chore(surround_obstacle_checker): rename publisher, subscriber and callback functions
@@ -302,50 +302,50 @@ Changelog for package tier4_system_launch
   * refactor(surround_obstacle_checker): cleanup polygon handling
   * refactor(surround_obstacle_checker): use marker helper
   * feat(planning_launch): separate surround_obstacle_checker from hierarchical motion planning flow
-  * fix(surround_obstacle_checker): fix ego footprint polygon (`#877 <https://github.com/youtalk/autoware.universe/issues/877>`_)
-  * fix: update nvinfer api (`#863 <https://github.com/youtalk/autoware.universe/issues/863>`_)
+  * fix(surround_obstacle_checker): fix ego footprint polygon (`#877 <https://github.com/autowarefoundation/autoware.universe/issues/877>`_)
+  * fix: update nvinfer api (`#863 <https://github.com/autowarefoundation/autoware.universe/issues/863>`_)
   * fix(lidar_centerpoint): update nvinfer api
   * fix(tensorrt_yolo): update nvinfer api
   * fix(lidar_apollo_instance_segmentation): update nvinfer api
   * fix(traffic_light_classifier): update nvinfer api
   * fix(traffic_light_ssd_fine_detector): update nvinfer api
   * pre-commit run
-  * fix(avoidance_module): ignore object instead of creating zero shift (`#731 <https://github.com/youtalk/autoware.universe/issues/731>`_)
+  * fix(avoidance_module): ignore object instead of creating zero shift (`#731 <https://github.com/autowarefoundation/autoware.universe/issues/731>`_)
   * fix: ignore object instead of creating zero shift
   instead of creating zero shift point, the object will be ignored.
   no behavior changes should be observed.
   * refactor: sync continue with upstream
   * fix: fix debug message for insufficient lateral margin
-  * fix(motion_velocity_smoother): curve deceleration not working with a specific parameter set (`#738 <https://github.com/youtalk/autoware.universe/issues/738>`_)
-  * test(autoware_testing): fix smoke_test (`#479 <https://github.com/youtalk/autoware.universe/issues/479>`_)
+  * fix(motion_velocity_smoother): curve deceleration not working with a specific parameter set (`#738 <https://github.com/autowarefoundation/autoware.universe/issues/738>`_)
+  * test(autoware_testing): fix smoke_test (`#479 <https://github.com/autowarefoundation/autoware.universe/issues/479>`_)
   * fix(autoware_testing): fix smoke_test
   * restore smoke_test for trajectory_follower_nodes
   * add support multiple parameter files
   * ci(pre-commit): autofix
   * minor fix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-  * feat(rviz_plugins): add velocity limit to autoware state panel (`#879 <https://github.com/youtalk/autoware.universe/issues/879>`_)
+  * feat(rviz_plugins): add velocity limit to autoware state panel (`#879 <https://github.com/autowarefoundation/autoware.universe/issues/879>`_)
   * feat(rviz_plugins): add velocity limit to autoware state panel
   * chore(rviz_plugin): change ms to kmh
-  * feat(vehicle_info_util): add max_steer_angle (`#740 <https://github.com/youtalk/autoware.universe/issues/740>`_)
+  * feat(vehicle_info_util): add max_steer_angle (`#740 <https://github.com/autowarefoundation/autoware.universe/issues/740>`_)
   * feat(vehicle_info_util): add max_steer_angle
   * applied pre-commit
   * Added max_steer_angle in test config
   Co-authored-by: Tomoya Kimura <tomoya.kimura@tier4.jp>
-  * fix(lidar_centerpoint): fix google drive url to avoid 404 (`#889 <https://github.com/youtalk/autoware.universe/issues/889>`_)
+  * fix(lidar_centerpoint): fix google drive url to avoid 404 (`#889 <https://github.com/autowarefoundation/autoware.universe/issues/889>`_)
   * fix(lidar_centerpoint): fix google drive url to avoid 404
   * Update CMakeLists.txt
   Co-authored-by: Kenji Miyake <31987104+kenji-miyake@users.noreply.github.com>
-  * chore: fix typos (`#886 <https://github.com/youtalk/autoware.universe/issues/886>`_)
-  * feat(state_rviz_plugin): add GateMode and PathChangeApproval Button (`#894 <https://github.com/youtalk/autoware.universe/issues/894>`_)
+  * chore: fix typos (`#886 <https://github.com/autowarefoundation/autoware.universe/issues/886>`_)
+  * feat(state_rviz_plugin): add GateMode and PathChangeApproval Button (`#894 <https://github.com/autowarefoundation/autoware.universe/issues/894>`_)
   * feat(state_rviz_plugin): add GateMode and PathChangeApproval Button
   * ci(pre-commit): autofix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-  * feat(map_tf_generator): accelerate the 'viewer' coordinate calculation (`#890 <https://github.com/youtalk/autoware.universe/issues/890>`_)
+  * feat(map_tf_generator): accelerate the 'viewer' coordinate calculation (`#890 <https://github.com/autowarefoundation/autoware.universe/issues/890>`_)
   * add random point sampling function to quickly calculate the 'viewer' coordinate
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Kenji Miyake <31987104+kenji-miyake@users.noreply.github.com>
-  * docs(obstacle_stop_planner): update documentation (`#880 <https://github.com/youtalk/autoware.universe/issues/880>`_)
+  * docs(obstacle_stop_planner): update documentation (`#880 <https://github.com/autowarefoundation/autoware.universe/issues/880>`_)
   * ci(pre-commit): autofix
   * fixed conflicts
   * ci(pre-commit): autofix
@@ -366,36 +366,36 @@ Changelog for package tier4_system_launch
   * ci(pre-commit): autofix
   * ci(pre-commit): autofix
   * ci(pre-commit): autofix
-  * chore: sync files (`#629 <https://github.com/youtalk/autoware.universe/issues/629>`_)
+  * chore: sync files (`#629 <https://github.com/autowarefoundation/autoware.universe/issues/629>`_)
   * chore: sync files
   * ci(pre-commit): autofix
   Co-authored-by: kenji-miyake <kenji-miyake@users.noreply.github.com>
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-  * fix(dummy_diag_publisher): use anon to make unique node name instead of diag name (`#639 <https://github.com/youtalk/autoware.universe/issues/639>`_)
-  * chore: sync files (`#648 <https://github.com/youtalk/autoware.universe/issues/648>`_)
+  * fix(dummy_diag_publisher): use anon to make unique node name instead of diag name (`#639 <https://github.com/autowarefoundation/autoware.universe/issues/639>`_)
+  * chore: sync files (`#648 <https://github.com/autowarefoundation/autoware.universe/issues/648>`_)
   * chore: sync files
   * Revert "chore: sync files"
   This reverts commit b24f530b48306e16aa285f80a629ce5c5a9ccda7.
   * sync codecov.yaml
   Co-authored-by: kenji-miyake <kenji-miyake@users.noreply.github.com>
   Co-authored-by: Kenji Miyake <kenji.miyake@tier4.jp>
-  * fix(autoware_state_panel): fix message type for /api/autoware/get/engage (`#666 <https://github.com/youtalk/autoware.universe/issues/666>`_)
+  * fix(autoware_state_panel): fix message type for /api/autoware/get/engage (`#666 <https://github.com/autowarefoundation/autoware.universe/issues/666>`_)
   * fix(autoware_state_panel): fix message type for /api/autoware/get/engage
   * ci(pre-commit): autofix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-  * fix(behavior_velocity): avoid insert same point on trajectory utils (`#834 <https://github.com/youtalk/autoware.universe/issues/834>`_)
-  * refactor(behavior_velocity_planner): simplify CMakeLists.txt (`#855 <https://github.com/youtalk/autoware.universe/issues/855>`_)
-  * docs: fix 404 error caused by typo in url (`#871 <https://github.com/youtalk/autoware.universe/issues/871>`_)
+  * fix(behavior_velocity): avoid insert same point on trajectory utils (`#834 <https://github.com/autowarefoundation/autoware.universe/issues/834>`_)
+  * refactor(behavior_velocity_planner): simplify CMakeLists.txt (`#855 <https://github.com/autowarefoundation/autoware.universe/issues/855>`_)
+  * docs: fix 404 error caused by typo in url (`#871 <https://github.com/autowarefoundation/autoware.universe/issues/871>`_)
   * docs: fix 404 error caused by typo in url
   * docs: fix typo in url for yolov4
-  * fix(image_projection_based_fusion): set imagebuffersize (`#820 <https://github.com/youtalk/autoware.universe/issues/820>`_)
+  * fix(image_projection_based_fusion): set imagebuffersize (`#820 <https://github.com/autowarefoundation/autoware.universe/issues/820>`_)
   * fix: set imagebuffersize configured
   * ci(pre-commit): autofix
   Co-authored-by: suchang <chang.su@autocore.ai>
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-  * chore(avoidance_module): fix spell check (`#732 <https://github.com/youtalk/autoware.universe/issues/732>`_)
-  * feat: isolate gtests in all packages (`#693 <https://github.com/youtalk/autoware.universe/issues/693>`_)
-  * docs(virtual traffic light): add documentation (`#245 <https://github.com/youtalk/autoware.universe/issues/245>`_)
+  * chore(avoidance_module): fix spell check (`#732 <https://github.com/autowarefoundation/autoware.universe/issues/732>`_)
+  * feat: isolate gtests in all packages (`#693 <https://github.com/autowarefoundation/autoware.universe/issues/693>`_)
+  * docs(virtual traffic light): add documentation (`#245 <https://github.com/autowarefoundation/autoware.universe/issues/245>`_)
   * doc(behavior_velocity): add graph and fix link
   * doc(behavior_velocity): update virtual traffic light doc
   * doc(behavior_velocity): minor fix
@@ -406,7 +406,7 @@ Changelog for package tier4_system_launch
   * apply suggestion
   * doc: to intersection-coordination
   Co-authored-by: Kenji Miyake <31987104+kenji-miyake@users.noreply.github.com>
-  * feat(surround_obstacle_checker): separate surround_obstacle_checker from hierarchical planning flow (`#830 <https://github.com/youtalk/autoware.universe/issues/830>`_)
+  * feat(surround_obstacle_checker): separate surround_obstacle_checker from hierarchical planning flow (`#830 <https://github.com/autowarefoundation/autoware.universe/issues/830>`_)
   * fix(surroud_obstacle_checker): use alias
   * feat(surround_obstacle_checker): use velocity limit
   * chore(surround_obstacle_checker): rename publisher, subscriber and callback functions
@@ -416,50 +416,50 @@ Changelog for package tier4_system_launch
   * refactor(surround_obstacle_checker): cleanup polygon handling
   * refactor(surround_obstacle_checker): use marker helper
   * feat(planning_launch): separate surround_obstacle_checker from hierarchical motion planning flow
-  * fix(surround_obstacle_checker): fix ego footprint polygon (`#877 <https://github.com/youtalk/autoware.universe/issues/877>`_)
-  * fix: update nvinfer api (`#863 <https://github.com/youtalk/autoware.universe/issues/863>`_)
+  * fix(surround_obstacle_checker): fix ego footprint polygon (`#877 <https://github.com/autowarefoundation/autoware.universe/issues/877>`_)
+  * fix: update nvinfer api (`#863 <https://github.com/autowarefoundation/autoware.universe/issues/863>`_)
   * fix(lidar_centerpoint): update nvinfer api
   * fix(tensorrt_yolo): update nvinfer api
   * fix(lidar_apollo_instance_segmentation): update nvinfer api
   * fix(traffic_light_classifier): update nvinfer api
   * fix(traffic_light_ssd_fine_detector): update nvinfer api
   * pre-commit run
-  * fix(avoidance_module): ignore object instead of creating zero shift (`#731 <https://github.com/youtalk/autoware.universe/issues/731>`_)
+  * fix(avoidance_module): ignore object instead of creating zero shift (`#731 <https://github.com/autowarefoundation/autoware.universe/issues/731>`_)
   * fix: ignore object instead of creating zero shift
   instead of creating zero shift point, the object will be ignored.
   no behavior changes should be observed.
   * refactor: sync continue with upstream
   * fix: fix debug message for insufficient lateral margin
-  * fix(motion_velocity_smoother): curve deceleration not working with a specific parameter set (`#738 <https://github.com/youtalk/autoware.universe/issues/738>`_)
-  * test(autoware_testing): fix smoke_test (`#479 <https://github.com/youtalk/autoware.universe/issues/479>`_)
+  * fix(motion_velocity_smoother): curve deceleration not working with a specific parameter set (`#738 <https://github.com/autowarefoundation/autoware.universe/issues/738>`_)
+  * test(autoware_testing): fix smoke_test (`#479 <https://github.com/autowarefoundation/autoware.universe/issues/479>`_)
   * fix(autoware_testing): fix smoke_test
   * restore smoke_test for trajectory_follower_nodes
   * add support multiple parameter files
   * ci(pre-commit): autofix
   * minor fix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-  * feat(rviz_plugins): add velocity limit to autoware state panel (`#879 <https://github.com/youtalk/autoware.universe/issues/879>`_)
+  * feat(rviz_plugins): add velocity limit to autoware state panel (`#879 <https://github.com/autowarefoundation/autoware.universe/issues/879>`_)
   * feat(rviz_plugins): add velocity limit to autoware state panel
   * chore(rviz_plugin): change ms to kmh
-  * feat(vehicle_info_util): add max_steer_angle (`#740 <https://github.com/youtalk/autoware.universe/issues/740>`_)
+  * feat(vehicle_info_util): add max_steer_angle (`#740 <https://github.com/autowarefoundation/autoware.universe/issues/740>`_)
   * feat(vehicle_info_util): add max_steer_angle
   * applied pre-commit
   * Added max_steer_angle in test config
   Co-authored-by: Tomoya Kimura <tomoya.kimura@tier4.jp>
-  * fix(lidar_centerpoint): fix google drive url to avoid 404 (`#889 <https://github.com/youtalk/autoware.universe/issues/889>`_)
+  * fix(lidar_centerpoint): fix google drive url to avoid 404 (`#889 <https://github.com/autowarefoundation/autoware.universe/issues/889>`_)
   * fix(lidar_centerpoint): fix google drive url to avoid 404
   * Update CMakeLists.txt
   Co-authored-by: Kenji Miyake <31987104+kenji-miyake@users.noreply.github.com>
-  * chore: fix typos (`#886 <https://github.com/youtalk/autoware.universe/issues/886>`_)
-  * feat(state_rviz_plugin): add GateMode and PathChangeApproval Button (`#894 <https://github.com/youtalk/autoware.universe/issues/894>`_)
+  * chore: fix typos (`#886 <https://github.com/autowarefoundation/autoware.universe/issues/886>`_)
+  * feat(state_rviz_plugin): add GateMode and PathChangeApproval Button (`#894 <https://github.com/autowarefoundation/autoware.universe/issues/894>`_)
   * feat(state_rviz_plugin): add GateMode and PathChangeApproval Button
   * ci(pre-commit): autofix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-  * feat(map_tf_generator): accelerate the 'viewer' coordinate calculation (`#890 <https://github.com/youtalk/autoware.universe/issues/890>`_)
+  * feat(map_tf_generator): accelerate the 'viewer' coordinate calculation (`#890 <https://github.com/autowarefoundation/autoware.universe/issues/890>`_)
   * add random point sampling function to quickly calculate the 'viewer' coordinate
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Kenji Miyake <31987104+kenji-miyake@users.noreply.github.com>
-  * docs(obstacle_stop_planner): update documentation (`#880 <https://github.com/youtalk/autoware.universe/issues/880>`_)
+  * docs(obstacle_stop_planner): update documentation (`#880 <https://github.com/autowarefoundation/autoware.universe/issues/880>`_)
   * ci(pre-commit): autofix
   * fixed conflicts
   * ci(pre-commit): autofix
@@ -469,11 +469,11 @@ Changelog for package tier4_system_launch
   * merge  main ->feature_battery_monitoring
   * Added voltages are provisional values.
   * ci(pre-commit): autofix
-  * feat(behavior_path_planner): add turn signal parameters (`#2086 <https://github.com/youtalk/autoware.universe/issues/2086>`_)
+  * feat(behavior_path_planner): add turn signal parameters (`#2086 <https://github.com/autowarefoundation/autoware.universe/issues/2086>`_)
   * feat(behavior_path_planner): add and change parameters
   * update
   * update
-  * refactor(perception_utils): refactor matching function in perception_utils (`#2045 <https://github.com/youtalk/autoware.universe/issues/2045>`_)
+  * refactor(perception_utils): refactor matching function in perception_utils (`#2045 <https://github.com/autowarefoundation/autoware.universe/issues/2045>`_)
   * refactor(perception_util): refactor matching function in perception_util
   * fix namespace
   * refactor
@@ -481,7 +481,7 @@ Changelog for package tier4_system_launch
   * fix bug
   * add const
   * refactor function name
-  * refactor(perception_utils): refactor object_classification (`#2042 <https://github.com/youtalk/autoware.universe/issues/2042>`_)
+  * refactor(perception_utils): refactor object_classification (`#2042 <https://github.com/autowarefoundation/autoware.universe/issues/2042>`_)
   * refactor(perception_utils): refactor object_classification
   * fix bug
   * fix unittest
@@ -489,14 +489,14 @@ Changelog for package tier4_system_launch
   * fix unit test
   * remove redundant else
   * refactor variable name
-  * feat(autoware_auto_perception_rviz_plugin): add accel text visualization (`#2046 <https://github.com/youtalk/autoware.universe/issues/2046>`_)
-  * refactor(motion_utils, obstacle_cruise_planner): add offset to virtual wall utils func (`#2078 <https://github.com/youtalk/autoware.universe/issues/2078>`_)
-  * refactor(osqp_interface, motion_velocity_smoother): unsolved status log (`#2076 <https://github.com/youtalk/autoware.universe/issues/2076>`_)
+  * feat(autoware_auto_perception_rviz_plugin): add accel text visualization (`#2046 <https://github.com/autowarefoundation/autoware.universe/issues/2046>`_)
+  * refactor(motion_utils, obstacle_cruise_planner): add offset to virtual wall utils func (`#2078 <https://github.com/autowarefoundation/autoware.universe/issues/2078>`_)
+  * refactor(osqp_interface, motion_velocity_smoother): unsolved status log (`#2076 <https://github.com/autowarefoundation/autoware.universe/issues/2076>`_)
   * refactor(osqp_interface, motion_velocity_smoother): unsolved status log
   * Update common/osqp_interface/src/osqp_interface.cpp
   Co-authored-by: Maxime CLEMENT <78338830+maxime-clem@users.noreply.github.com>
   Co-authored-by: Maxime CLEMENT <78338830+maxime-clem@users.noreply.github.com>
-  * feat(lidar_centerpoint): eliminated the tf dependency for single frame detection (`#1925 <https://github.com/youtalk/autoware.universe/issues/1925>`_)
+  * feat(lidar_centerpoint): eliminated the tf dependency for single frame detection (`#1925 <https://github.com/autowarefoundation/autoware.universe/issues/1925>`_)
   Co-authored-by: Yusuke Muramatsu <yukke42@users.noreply.github.com>
   * change name hardware_monitor -> voltage_monitor
   * copy right 2020 -> 2022
@@ -521,36 +521,36 @@ Changelog for package tier4_system_launch
   * ci(pre-commit): autofix
   * added topics_voltage_monitor.md)
   * ci(pre-commit): autofix
-  * chore: sync files (`#629 <https://github.com/youtalk/autoware.universe/issues/629>`_)
+  * chore: sync files (`#629 <https://github.com/autowarefoundation/autoware.universe/issues/629>`_)
   * chore: sync files
   * ci(pre-commit): autofix
   Co-authored-by: kenji-miyake <kenji-miyake@users.noreply.github.com>
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-  * fix(dummy_diag_publisher): use anon to make unique node name instead of diag name (`#639 <https://github.com/youtalk/autoware.universe/issues/639>`_)
-  * chore: sync files (`#648 <https://github.com/youtalk/autoware.universe/issues/648>`_)
+  * fix(dummy_diag_publisher): use anon to make unique node name instead of diag name (`#639 <https://github.com/autowarefoundation/autoware.universe/issues/639>`_)
+  * chore: sync files (`#648 <https://github.com/autowarefoundation/autoware.universe/issues/648>`_)
   * chore: sync files
   * Revert "chore: sync files"
   This reverts commit b24f530b48306e16aa285f80a629ce5c5a9ccda7.
   * sync codecov.yaml
   Co-authored-by: kenji-miyake <kenji-miyake@users.noreply.github.com>
   Co-authored-by: Kenji Miyake <kenji.miyake@tier4.jp>
-  * fix(autoware_state_panel): fix message type for /api/autoware/get/engage (`#666 <https://github.com/youtalk/autoware.universe/issues/666>`_)
+  * fix(autoware_state_panel): fix message type for /api/autoware/get/engage (`#666 <https://github.com/autowarefoundation/autoware.universe/issues/666>`_)
   * fix(autoware_state_panel): fix message type for /api/autoware/get/engage
   * ci(pre-commit): autofix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-  * fix(behavior_velocity): avoid insert same point on trajectory utils (`#834 <https://github.com/youtalk/autoware.universe/issues/834>`_)
-  * refactor(behavior_velocity_planner): simplify CMakeLists.txt (`#855 <https://github.com/youtalk/autoware.universe/issues/855>`_)
-  * docs: fix 404 error caused by typo in url (`#871 <https://github.com/youtalk/autoware.universe/issues/871>`_)
+  * fix(behavior_velocity): avoid insert same point on trajectory utils (`#834 <https://github.com/autowarefoundation/autoware.universe/issues/834>`_)
+  * refactor(behavior_velocity_planner): simplify CMakeLists.txt (`#855 <https://github.com/autowarefoundation/autoware.universe/issues/855>`_)
+  * docs: fix 404 error caused by typo in url (`#871 <https://github.com/autowarefoundation/autoware.universe/issues/871>`_)
   * docs: fix 404 error caused by typo in url
   * docs: fix typo in url for yolov4
-  * fix(image_projection_based_fusion): set imagebuffersize (`#820 <https://github.com/youtalk/autoware.universe/issues/820>`_)
+  * fix(image_projection_based_fusion): set imagebuffersize (`#820 <https://github.com/autowarefoundation/autoware.universe/issues/820>`_)
   * fix: set imagebuffersize configured
   * ci(pre-commit): autofix
   Co-authored-by: suchang <chang.su@autocore.ai>
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-  * chore(avoidance_module): fix spell check (`#732 <https://github.com/youtalk/autoware.universe/issues/732>`_)
-  * feat: isolate gtests in all packages (`#693 <https://github.com/youtalk/autoware.universe/issues/693>`_)
-  * docs(virtual traffic light): add documentation (`#245 <https://github.com/youtalk/autoware.universe/issues/245>`_)
+  * chore(avoidance_module): fix spell check (`#732 <https://github.com/autowarefoundation/autoware.universe/issues/732>`_)
+  * feat: isolate gtests in all packages (`#693 <https://github.com/autowarefoundation/autoware.universe/issues/693>`_)
+  * docs(virtual traffic light): add documentation (`#245 <https://github.com/autowarefoundation/autoware.universe/issues/245>`_)
   * doc(behavior_velocity): add graph and fix link
   * doc(behavior_velocity): update virtual traffic light doc
   * doc(behavior_velocity): minor fix
@@ -561,7 +561,7 @@ Changelog for package tier4_system_launch
   * apply suggestion
   * doc: to intersection-coordination
   Co-authored-by: Kenji Miyake <31987104+kenji-miyake@users.noreply.github.com>
-  * feat(surround_obstacle_checker): separate surround_obstacle_checker from hierarchical planning flow (`#830 <https://github.com/youtalk/autoware.universe/issues/830>`_)
+  * feat(surround_obstacle_checker): separate surround_obstacle_checker from hierarchical planning flow (`#830 <https://github.com/autowarefoundation/autoware.universe/issues/830>`_)
   * fix(surroud_obstacle_checker): use alias
   * feat(surround_obstacle_checker): use velocity limit
   * chore(surround_obstacle_checker): rename publisher, subscriber and callback functions
@@ -571,50 +571,50 @@ Changelog for package tier4_system_launch
   * refactor(surround_obstacle_checker): cleanup polygon handling
   * refactor(surround_obstacle_checker): use marker helper
   * feat(planning_launch): separate surround_obstacle_checker from hierarchical motion planning flow
-  * fix(surround_obstacle_checker): fix ego footprint polygon (`#877 <https://github.com/youtalk/autoware.universe/issues/877>`_)
-  * fix: update nvinfer api (`#863 <https://github.com/youtalk/autoware.universe/issues/863>`_)
+  * fix(surround_obstacle_checker): fix ego footprint polygon (`#877 <https://github.com/autowarefoundation/autoware.universe/issues/877>`_)
+  * fix: update nvinfer api (`#863 <https://github.com/autowarefoundation/autoware.universe/issues/863>`_)
   * fix(lidar_centerpoint): update nvinfer api
   * fix(tensorrt_yolo): update nvinfer api
   * fix(lidar_apollo_instance_segmentation): update nvinfer api
   * fix(traffic_light_classifier): update nvinfer api
   * fix(traffic_light_ssd_fine_detector): update nvinfer api
   * pre-commit run
-  * fix(avoidance_module): ignore object instead of creating zero shift (`#731 <https://github.com/youtalk/autoware.universe/issues/731>`_)
+  * fix(avoidance_module): ignore object instead of creating zero shift (`#731 <https://github.com/autowarefoundation/autoware.universe/issues/731>`_)
   * fix: ignore object instead of creating zero shift
   instead of creating zero shift point, the object will be ignored.
   no behavior changes should be observed.
   * refactor: sync continue with upstream
   * fix: fix debug message for insufficient lateral margin
-  * fix(motion_velocity_smoother): curve deceleration not working with a specific parameter set (`#738 <https://github.com/youtalk/autoware.universe/issues/738>`_)
-  * test(autoware_testing): fix smoke_test (`#479 <https://github.com/youtalk/autoware.universe/issues/479>`_)
+  * fix(motion_velocity_smoother): curve deceleration not working with a specific parameter set (`#738 <https://github.com/autowarefoundation/autoware.universe/issues/738>`_)
+  * test(autoware_testing): fix smoke_test (`#479 <https://github.com/autowarefoundation/autoware.universe/issues/479>`_)
   * fix(autoware_testing): fix smoke_test
   * restore smoke_test for trajectory_follower_nodes
   * add support multiple parameter files
   * ci(pre-commit): autofix
   * minor fix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-  * feat(rviz_plugins): add velocity limit to autoware state panel (`#879 <https://github.com/youtalk/autoware.universe/issues/879>`_)
+  * feat(rviz_plugins): add velocity limit to autoware state panel (`#879 <https://github.com/autowarefoundation/autoware.universe/issues/879>`_)
   * feat(rviz_plugins): add velocity limit to autoware state panel
   * chore(rviz_plugin): change ms to kmh
-  * feat(vehicle_info_util): add max_steer_angle (`#740 <https://github.com/youtalk/autoware.universe/issues/740>`_)
+  * feat(vehicle_info_util): add max_steer_angle (`#740 <https://github.com/autowarefoundation/autoware.universe/issues/740>`_)
   * feat(vehicle_info_util): add max_steer_angle
   * applied pre-commit
   * Added max_steer_angle in test config
   Co-authored-by: Tomoya Kimura <tomoya.kimura@tier4.jp>
-  * fix(lidar_centerpoint): fix google drive url to avoid 404 (`#889 <https://github.com/youtalk/autoware.universe/issues/889>`_)
+  * fix(lidar_centerpoint): fix google drive url to avoid 404 (`#889 <https://github.com/autowarefoundation/autoware.universe/issues/889>`_)
   * fix(lidar_centerpoint): fix google drive url to avoid 404
   * Update CMakeLists.txt
   Co-authored-by: Kenji Miyake <31987104+kenji-miyake@users.noreply.github.com>
-  * chore: fix typos (`#886 <https://github.com/youtalk/autoware.universe/issues/886>`_)
-  * feat(state_rviz_plugin): add GateMode and PathChangeApproval Button (`#894 <https://github.com/youtalk/autoware.universe/issues/894>`_)
+  * chore: fix typos (`#886 <https://github.com/autowarefoundation/autoware.universe/issues/886>`_)
+  * feat(state_rviz_plugin): add GateMode and PathChangeApproval Button (`#894 <https://github.com/autowarefoundation/autoware.universe/issues/894>`_)
   * feat(state_rviz_plugin): add GateMode and PathChangeApproval Button
   * ci(pre-commit): autofix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-  * feat(map_tf_generator): accelerate the 'viewer' coordinate calculation (`#890 <https://github.com/youtalk/autoware.universe/issues/890>`_)
+  * feat(map_tf_generator): accelerate the 'viewer' coordinate calculation (`#890 <https://github.com/autowarefoundation/autoware.universe/issues/890>`_)
   * add random point sampling function to quickly calculate the 'viewer' coordinate
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Kenji Miyake <31987104+kenji-miyake@users.noreply.github.com>
-  * docs(obstacle_stop_planner): update documentation (`#880 <https://github.com/youtalk/autoware.universe/issues/880>`_)
+  * docs(obstacle_stop_planner): update documentation (`#880 <https://github.com/autowarefoundation/autoware.universe/issues/880>`_)
   * ci(pre-commit): autofix
   * fixed conflicts
   * ci(pre-commit): autofix
@@ -632,36 +632,36 @@ Changelog for package tier4_system_launch
   * ci(pre-commit): autofix
   * ci(pre-commit): autofix
   * ci(pre-commit): autofix
-  * chore: sync files (`#629 <https://github.com/youtalk/autoware.universe/issues/629>`_)
+  * chore: sync files (`#629 <https://github.com/autowarefoundation/autoware.universe/issues/629>`_)
   * chore: sync files
   * ci(pre-commit): autofix
   Co-authored-by: kenji-miyake <kenji-miyake@users.noreply.github.com>
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-  * fix(dummy_diag_publisher): use anon to make unique node name instead of diag name (`#639 <https://github.com/youtalk/autoware.universe/issues/639>`_)
-  * chore: sync files (`#648 <https://github.com/youtalk/autoware.universe/issues/648>`_)
+  * fix(dummy_diag_publisher): use anon to make unique node name instead of diag name (`#639 <https://github.com/autowarefoundation/autoware.universe/issues/639>`_)
+  * chore: sync files (`#648 <https://github.com/autowarefoundation/autoware.universe/issues/648>`_)
   * chore: sync files
   * Revert "chore: sync files"
   This reverts commit b24f530b48306e16aa285f80a629ce5c5a9ccda7.
   * sync codecov.yaml
   Co-authored-by: kenji-miyake <kenji-miyake@users.noreply.github.com>
   Co-authored-by: Kenji Miyake <kenji.miyake@tier4.jp>
-  * fix(autoware_state_panel): fix message type for /api/autoware/get/engage (`#666 <https://github.com/youtalk/autoware.universe/issues/666>`_)
+  * fix(autoware_state_panel): fix message type for /api/autoware/get/engage (`#666 <https://github.com/autowarefoundation/autoware.universe/issues/666>`_)
   * fix(autoware_state_panel): fix message type for /api/autoware/get/engage
   * ci(pre-commit): autofix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-  * fix(behavior_velocity): avoid insert same point on trajectory utils (`#834 <https://github.com/youtalk/autoware.universe/issues/834>`_)
-  * refactor(behavior_velocity_planner): simplify CMakeLists.txt (`#855 <https://github.com/youtalk/autoware.universe/issues/855>`_)
-  * docs: fix 404 error caused by typo in url (`#871 <https://github.com/youtalk/autoware.universe/issues/871>`_)
+  * fix(behavior_velocity): avoid insert same point on trajectory utils (`#834 <https://github.com/autowarefoundation/autoware.universe/issues/834>`_)
+  * refactor(behavior_velocity_planner): simplify CMakeLists.txt (`#855 <https://github.com/autowarefoundation/autoware.universe/issues/855>`_)
+  * docs: fix 404 error caused by typo in url (`#871 <https://github.com/autowarefoundation/autoware.universe/issues/871>`_)
   * docs: fix 404 error caused by typo in url
   * docs: fix typo in url for yolov4
-  * fix(image_projection_based_fusion): set imagebuffersize (`#820 <https://github.com/youtalk/autoware.universe/issues/820>`_)
+  * fix(image_projection_based_fusion): set imagebuffersize (`#820 <https://github.com/autowarefoundation/autoware.universe/issues/820>`_)
   * fix: set imagebuffersize configured
   * ci(pre-commit): autofix
   Co-authored-by: suchang <chang.su@autocore.ai>
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-  * chore(avoidance_module): fix spell check (`#732 <https://github.com/youtalk/autoware.universe/issues/732>`_)
-  * feat: isolate gtests in all packages (`#693 <https://github.com/youtalk/autoware.universe/issues/693>`_)
-  * docs(virtual traffic light): add documentation (`#245 <https://github.com/youtalk/autoware.universe/issues/245>`_)
+  * chore(avoidance_module): fix spell check (`#732 <https://github.com/autowarefoundation/autoware.universe/issues/732>`_)
+  * feat: isolate gtests in all packages (`#693 <https://github.com/autowarefoundation/autoware.universe/issues/693>`_)
+  * docs(virtual traffic light): add documentation (`#245 <https://github.com/autowarefoundation/autoware.universe/issues/245>`_)
   * doc(behavior_velocity): add graph and fix link
   * doc(behavior_velocity): update virtual traffic light doc
   * doc(behavior_velocity): minor fix
@@ -672,7 +672,7 @@ Changelog for package tier4_system_launch
   * apply suggestion
   * doc: to intersection-coordination
   Co-authored-by: Kenji Miyake <31987104+kenji-miyake@users.noreply.github.com>
-  * feat(surround_obstacle_checker): separate surround_obstacle_checker from hierarchical planning flow (`#830 <https://github.com/youtalk/autoware.universe/issues/830>`_)
+  * feat(surround_obstacle_checker): separate surround_obstacle_checker from hierarchical planning flow (`#830 <https://github.com/autowarefoundation/autoware.universe/issues/830>`_)
   * fix(surroud_obstacle_checker): use alias
   * feat(surround_obstacle_checker): use velocity limit
   * chore(surround_obstacle_checker): rename publisher, subscriber and callback functions
@@ -682,50 +682,50 @@ Changelog for package tier4_system_launch
   * refactor(surround_obstacle_checker): cleanup polygon handling
   * refactor(surround_obstacle_checker): use marker helper
   * feat(planning_launch): separate surround_obstacle_checker from hierarchical motion planning flow
-  * fix(surround_obstacle_checker): fix ego footprint polygon (`#877 <https://github.com/youtalk/autoware.universe/issues/877>`_)
-  * fix: update nvinfer api (`#863 <https://github.com/youtalk/autoware.universe/issues/863>`_)
+  * fix(surround_obstacle_checker): fix ego footprint polygon (`#877 <https://github.com/autowarefoundation/autoware.universe/issues/877>`_)
+  * fix: update nvinfer api (`#863 <https://github.com/autowarefoundation/autoware.universe/issues/863>`_)
   * fix(lidar_centerpoint): update nvinfer api
   * fix(tensorrt_yolo): update nvinfer api
   * fix(lidar_apollo_instance_segmentation): update nvinfer api
   * fix(traffic_light_classifier): update nvinfer api
   * fix(traffic_light_ssd_fine_detector): update nvinfer api
   * pre-commit run
-  * fix(avoidance_module): ignore object instead of creating zero shift (`#731 <https://github.com/youtalk/autoware.universe/issues/731>`_)
+  * fix(avoidance_module): ignore object instead of creating zero shift (`#731 <https://github.com/autowarefoundation/autoware.universe/issues/731>`_)
   * fix: ignore object instead of creating zero shift
   instead of creating zero shift point, the object will be ignored.
   no behavior changes should be observed.
   * refactor: sync continue with upstream
   * fix: fix debug message for insufficient lateral margin
-  * fix(motion_velocity_smoother): curve deceleration not working with a specific parameter set (`#738 <https://github.com/youtalk/autoware.universe/issues/738>`_)
-  * test(autoware_testing): fix smoke_test (`#479 <https://github.com/youtalk/autoware.universe/issues/479>`_)
+  * fix(motion_velocity_smoother): curve deceleration not working with a specific parameter set (`#738 <https://github.com/autowarefoundation/autoware.universe/issues/738>`_)
+  * test(autoware_testing): fix smoke_test (`#479 <https://github.com/autowarefoundation/autoware.universe/issues/479>`_)
   * fix(autoware_testing): fix smoke_test
   * restore smoke_test for trajectory_follower_nodes
   * add support multiple parameter files
   * ci(pre-commit): autofix
   * minor fix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-  * feat(rviz_plugins): add velocity limit to autoware state panel (`#879 <https://github.com/youtalk/autoware.universe/issues/879>`_)
+  * feat(rviz_plugins): add velocity limit to autoware state panel (`#879 <https://github.com/autowarefoundation/autoware.universe/issues/879>`_)
   * feat(rviz_plugins): add velocity limit to autoware state panel
   * chore(rviz_plugin): change ms to kmh
-  * feat(vehicle_info_util): add max_steer_angle (`#740 <https://github.com/youtalk/autoware.universe/issues/740>`_)
+  * feat(vehicle_info_util): add max_steer_angle (`#740 <https://github.com/autowarefoundation/autoware.universe/issues/740>`_)
   * feat(vehicle_info_util): add max_steer_angle
   * applied pre-commit
   * Added max_steer_angle in test config
   Co-authored-by: Tomoya Kimura <tomoya.kimura@tier4.jp>
-  * fix(lidar_centerpoint): fix google drive url to avoid 404 (`#889 <https://github.com/youtalk/autoware.universe/issues/889>`_)
+  * fix(lidar_centerpoint): fix google drive url to avoid 404 (`#889 <https://github.com/autowarefoundation/autoware.universe/issues/889>`_)
   * fix(lidar_centerpoint): fix google drive url to avoid 404
   * Update CMakeLists.txt
   Co-authored-by: Kenji Miyake <31987104+kenji-miyake@users.noreply.github.com>
-  * chore: fix typos (`#886 <https://github.com/youtalk/autoware.universe/issues/886>`_)
-  * feat(state_rviz_plugin): add GateMode and PathChangeApproval Button (`#894 <https://github.com/youtalk/autoware.universe/issues/894>`_)
+  * chore: fix typos (`#886 <https://github.com/autowarefoundation/autoware.universe/issues/886>`_)
+  * feat(state_rviz_plugin): add GateMode and PathChangeApproval Button (`#894 <https://github.com/autowarefoundation/autoware.universe/issues/894>`_)
   * feat(state_rviz_plugin): add GateMode and PathChangeApproval Button
   * ci(pre-commit): autofix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-  * feat(map_tf_generator): accelerate the 'viewer' coordinate calculation (`#890 <https://github.com/youtalk/autoware.universe/issues/890>`_)
+  * feat(map_tf_generator): accelerate the 'viewer' coordinate calculation (`#890 <https://github.com/autowarefoundation/autoware.universe/issues/890>`_)
   * add random point sampling function to quickly calculate the 'viewer' coordinate
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Kenji Miyake <31987104+kenji-miyake@users.noreply.github.com>
-  * docs(obstacle_stop_planner): update documentation (`#880 <https://github.com/youtalk/autoware.universe/issues/880>`_)
+  * docs(obstacle_stop_planner): update documentation (`#880 <https://github.com/autowarefoundation/autoware.universe/issues/880>`_)
   * ci(pre-commit): autofix
   * fixed conflicts
   * ci(pre-commit): autofix
@@ -768,7 +768,7 @@ Changelog for package tier4_system_launch
   Co-authored-by: Satoshi Tanaka <16330533+scepter914@users.noreply.github.com>
   Co-authored-by: Kenzo Lobos Tsunekawa <kenzo.lobos@tier4.jp>
   Co-authored-by: Yusuke Muramatsu <yukke42@users.noreply.github.com>
-* feat: add HDD monitoring items to hdd_monitor (`#721 <https://github.com/youtalk/autoware.universe/issues/721>`_)
+* feat: add HDD monitoring items to hdd_monitor (`#721 <https://github.com/autowarefoundation/autoware.universe/issues/721>`_)
   * feat: add HDD monitoring items to hdd_monitor
   * fix pre-commit C long type error
   * fixed the monitoring method of RecoveredError
@@ -779,8 +779,8 @@ Changelog for package tier4_system_launch
   * fix(system_monitor): level change when not connected in HDD connection monitoring
   * fix(system_monitor): unmount function added in hdd_reader
   * fix(system_monitor): separate S.M.A.R.T. request and lazy unmount request for hdd_reader
-* chore(system_error_monitor): add maintainer (`#1922 <https://github.com/youtalk/autoware.universe/issues/1922>`_)
-* feat(system_monitor): add IP packet reassembles failed monitoring to net_monitor (`#1427 <https://github.com/youtalk/autoware.universe/issues/1427>`_)
+* chore(system_error_monitor): add maintainer (`#1922 <https://github.com/autowarefoundation/autoware.universe/issues/1922>`_)
+* feat(system_monitor): add IP packet reassembles failed monitoring to net_monitor (`#1427 <https://github.com/autowarefoundation/autoware.universe/issues/1427>`_)
   * feat(system_monitor): add IP packet reassembles failed monitoring to net_monitor
   * fix build errors caused by merge mistakes
   * fix(system_monitor): chang word Reasm and fix deep nesting
@@ -790,7 +790,7 @@ Changelog for package tier4_system_launch
   * fix(system_monitor): remove unnecessary static_cast
   * fix(system_monitor): typo fix
   Co-authored-by: ito-san <57388357+ito-san@users.noreply.github.com>
-* feat(pose_initializer)!: support ad api (`#1500 <https://github.com/youtalk/autoware.universe/issues/1500>`_)
+* feat(pose_initializer)!: support ad api (`#1500 <https://github.com/autowarefoundation/autoware.universe/issues/1500>`_)
   * feat(pose_initializer): support ad api
   * docs: update readme
   * fix: build error
@@ -806,33 +806,33 @@ Changelog for package tier4_system_launch
   * fix: fix build error
   * ci(pre-commit): autofix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* fix(system_monitor): fix parameter threshold of CPU Usage monitoring (`#1805 <https://github.com/youtalk/autoware.universe/issues/1805>`_)
+* fix(system_monitor): fix parameter threshold of CPU Usage monitoring (`#1805 <https://github.com/autowarefoundation/autoware.universe/issues/1805>`_)
   Co-authored-by: ito-san <57388357+ito-san@users.noreply.github.com>
-* feat: add CRC error monitoring to net_monitor (`#638 <https://github.com/youtalk/autoware.universe/issues/638>`_)
+* feat: add CRC error monitoring to net_monitor (`#638 <https://github.com/autowarefoundation/autoware.universe/issues/638>`_)
   * feat: add CRC error monitoring to net_monitor
   * add CRC error monitoring information to README.md
   * ci(pre-commit): autofix
   Co-authored-by: noriyuki.h <n-hamaike@esol.co.jp>
   Co-authored-by: ito-san <57388357+ito-san@users.noreply.github.com>
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat(tier4_system_launch): declare tier4_system_launch_param_path (`#1411 <https://github.com/youtalk/autoware.universe/issues/1411>`_)
-* fix(tier4_system_launch): add group tag (`#1240 <https://github.com/youtalk/autoware.universe/issues/1240>`_)
+* feat(tier4_system_launch): declare tier4_system_launch_param_path (`#1411 <https://github.com/autowarefoundation/autoware.universe/issues/1411>`_)
+* fix(tier4_system_launch): add group tag (`#1240 <https://github.com/autowarefoundation/autoware.universe/issues/1240>`_)
   * fix(tier4_system_launch): add group tag
   * move arg into group
-* fix(system_monitor): add some smart information to diagnostics (`#708 <https://github.com/youtalk/autoware.universe/issues/708>`_)
-* chore: upgrade cmake_minimum_required to 3.14 (`#856 <https://github.com/youtalk/autoware.universe/issues/856>`_)
-* refactor: use autoware cmake (`#849 <https://github.com/youtalk/autoware.universe/issues/849>`_)
+* fix(system_monitor): add some smart information to diagnostics (`#708 <https://github.com/autowarefoundation/autoware.universe/issues/708>`_)
+* chore: upgrade cmake_minimum_required to 3.14 (`#856 <https://github.com/autowarefoundation/autoware.universe/issues/856>`_)
+* refactor: use autoware cmake (`#849 <https://github.com/autowarefoundation/autoware.universe/issues/849>`_)
   * remove autoware_auto_cmake
   * add build_depend of autoware_cmake
   * use autoware_cmake in CMakeLists.txt
   * fix bugs
   * fix cmake lint errors
-* style: fix format of package.xml (`#844 <https://github.com/youtalk/autoware.universe/issues/844>`_)
-* ci(pre-commit): update pre-commit-hooks-ros (`#625 <https://github.com/youtalk/autoware.universe/issues/625>`_)
+* style: fix format of package.xml (`#844 <https://github.com/autowarefoundation/autoware.universe/issues/844>`_)
+* ci(pre-commit): update pre-commit-hooks-ros (`#625 <https://github.com/autowarefoundation/autoware.universe/issues/625>`_)
   * ci(pre-commit): update pre-commit-hooks-ros
   * ci(pre-commit): autofix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat: change launch package name (`#186 <https://github.com/youtalk/autoware.universe/issues/186>`_)
+* feat: change launch package name (`#186 <https://github.com/autowarefoundation/autoware.universe/issues/186>`_)
   * rename launch folder
   * autoware_launch -> tier4_autoware_launch
   * integration_launch -> tier4_integration_launch

--- a/launch/tier4_vehicle_launch/CHANGELOG.rst
+++ b/launch/tier4_vehicle_launch/CHANGELOG.rst
@@ -5,7 +5,7 @@ Changelog for package tier4_vehicle_launch
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* refactor(raw_vehicle_cmd_converter)!: prefix package and namespace with autoware (`#7385 <https://github.com/youtalk/autoware.universe/issues/7385>`_)
+* refactor(raw_vehicle_cmd_converter)!: prefix package and namespace with autoware (`#7385 <https://github.com/autowarefoundation/autoware.universe/issues/7385>`_)
   * add prefix
   * fix other packages
   * fix cppcheck
@@ -16,8 +16,8 @@ Changelog for package tier4_vehicle_launch
 
 0.26.0 (2024-04-03)
 -------------------
-* fix(raw_vehicle_cmd_converter): fix parameter files to parse path to csv files (`#6136 <https://github.com/youtalk/autoware.universe/issues/6136>`_)
-* build: mark autoware_cmake as <buildtool_depend> (`#3616 <https://github.com/youtalk/autoware.universe/issues/3616>`_)
+* fix(raw_vehicle_cmd_converter): fix parameter files to parse path to csv files (`#6136 <https://github.com/autowarefoundation/autoware.universe/issues/6136>`_)
+* build: mark autoware_cmake as <buildtool_depend> (`#3616 <https://github.com/autowarefoundation/autoware.universe/issues/3616>`_)
   * build: mark autoware_cmake as <buildtool_depend>
   with <build_depend>, autoware_cmake is automatically exported with ament_target_dependencies() (unecessary)
   * style(pre-commit): autofix
@@ -25,40 +25,40 @@ Changelog for package tier4_vehicle_launch
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Kenji Miyake <kenji.miyake@tier4.jp>
-* ci(pre-commit): format SVG files (`#2172 <https://github.com/youtalk/autoware.universe/issues/2172>`_)
+* ci(pre-commit): format SVG files (`#2172 <https://github.com/autowarefoundation/autoware.universe/issues/2172>`_)
   * ci(pre-commit): format SVG files
   * ci(pre-commit): autofix
   * apply pre-commit
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* fix: fix xacro command in vehicle.launch (`#2171 <https://github.com/youtalk/autoware.universe/issues/2171>`_)
-* feat(tier4_vehicle launch): switch config_dir value for default/individual_param (`#1416 <https://github.com/youtalk/autoware.universe/issues/1416>`_)
+* fix: fix xacro command in vehicle.launch (`#2171 <https://github.com/autowarefoundation/autoware.universe/issues/2171>`_)
+* feat(tier4_vehicle launch): switch config_dir value for default/individual_param (`#1416 <https://github.com/autowarefoundation/autoware.universe/issues/1416>`_)
   * feat(tier4_vehicle_launch): migrate from autoware_launch::vehicle_launch to tier4_vehicle_launch
   * By default config_dir is <sensor_model>_description/config/ (like in planning_simulation) in tier4_vehicle_launch, and in product release config_dir will be set to <individual_param>/config/<product-ID>/<sensor_model>, and its value is set from either planning_simulator.launch orautoware_launch
-* chore: upgrade cmake_minimum_required to 3.14 (`#856 <https://github.com/youtalk/autoware.universe/issues/856>`_)
-* refactor: use autoware cmake (`#849 <https://github.com/youtalk/autoware.universe/issues/849>`_)
+* chore: upgrade cmake_minimum_required to 3.14 (`#856 <https://github.com/autowarefoundation/autoware.universe/issues/856>`_)
+* refactor: use autoware cmake (`#849 <https://github.com/autowarefoundation/autoware.universe/issues/849>`_)
   * remove autoware_auto_cmake
   * add build_depend of autoware_cmake
   * use autoware_cmake in CMakeLists.txt
   * fix bugs
   * fix cmake lint errors
-* style: fix format of package.xml (`#844 <https://github.com/youtalk/autoware.universe/issues/844>`_)
-* chore: sync files (`#629 <https://github.com/youtalk/autoware.universe/issues/629>`_)
+* style: fix format of package.xml (`#844 <https://github.com/autowarefoundation/autoware.universe/issues/844>`_)
+* chore: sync files (`#629 <https://github.com/autowarefoundation/autoware.universe/issues/629>`_)
   * chore: sync files
   * ci(pre-commit): autofix
   Co-authored-by: kenji-miyake <kenji-miyake@users.noreply.github.com>
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* fix(tier4_simulator_launch, tier4_vehicle_launch)!: fix launch args (`#443 <https://github.com/youtalk/autoware.universe/issues/443>`_)
-* fix(tier4_vehicle_launch): refer to launch packages to find vehicle_interface.launch.xml (`#439 <https://github.com/youtalk/autoware.universe/issues/439>`_)
-* fix(tier4_vehicle_launch): remove unnecessary config_dir (`#436 <https://github.com/youtalk/autoware.universe/issues/436>`_)
+* fix(tier4_simulator_launch, tier4_vehicle_launch)!: fix launch args (`#443 <https://github.com/autowarefoundation/autoware.universe/issues/443>`_)
+* fix(tier4_vehicle_launch): refer to launch packages to find vehicle_interface.launch.xml (`#439 <https://github.com/autowarefoundation/autoware.universe/issues/439>`_)
+* fix(tier4_vehicle_launch): remove unnecessary config_dir (`#436 <https://github.com/autowarefoundation/autoware.universe/issues/436>`_)
   * fix(tier4_vehicle_launch): remove unnecessary config_dir
   * refactor: rename arg
   * remove vehicle_description.launch.xml to simplify the structure
   * chore: simplify vehicle.xacro
-* feat(tier4_autoware_launch)!: move package to autoware_launch (`#420 <https://github.com/youtalk/autoware.universe/issues/420>`_)
+* feat(tier4_autoware_launch)!: move package to autoware_launch (`#420 <https://github.com/autowarefoundation/autoware.universe/issues/420>`_)
   * feat(tier4_autoware_launch)!: move package to autoware_launch
   * remove unnecessary depends
-* docs: fix invalid links (`#309 <https://github.com/youtalk/autoware.universe/issues/309>`_)
-* feat: change launch package name (`#186 <https://github.com/youtalk/autoware.universe/issues/186>`_)
+* docs: fix invalid links (`#309 <https://github.com/autowarefoundation/autoware.universe/issues/309>`_)
+* feat: change launch package name (`#186 <https://github.com/autowarefoundation/autoware.universe/issues/186>`_)
   * rename launch folder
   * autoware_launch -> tier4_autoware_launch
   * integration_launch -> tier4_integration_launch

--- a/localization/autoware_ekf_localizer/CHANGELOG.rst
+++ b/localization/autoware_ekf_localizer/CHANGELOG.rst
@@ -5,9 +5,9 @@ Changelog for package autoware_ekf_localizer
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* refactor(localization_util)!: prefix package and namespace with autoware (`#8922 <https://github.com/youtalk/autoware.universe/issues/8922>`_)
+* refactor(localization_util)!: prefix package and namespace with autoware (`#8922 <https://github.com/autowarefoundation/autoware.universe/issues/8922>`_)
   add autoware prefix to localization_util
-* refactor(ekf_localizer)!: prefix package and namespace with autoware (`#8888 <https://github.com/youtalk/autoware.universe/issues/8888>`_)
+* refactor(ekf_localizer)!: prefix package and namespace with autoware (`#8888 <https://github.com/autowarefoundation/autoware.universe/issues/8888>`_)
   * import lanelet2_map_preprocessor
   * move headers to include/autoware/efk_localier
   ---------

--- a/localization/autoware_geo_pose_projector/CHANGELOG.rst
+++ b/localization/autoware_geo_pose_projector/CHANGELOG.rst
@@ -5,12 +5,12 @@ Changelog for package autoware_geo_pose_projector
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* refactor(component_interface_specs): prefix package and namespace with autoware (`#9094 <https://github.com/youtalk/autoware.universe/issues/9094>`_)
-* refactor(geography_utils): prefix package and namespace with autoware (`#7790 <https://github.com/youtalk/autoware.universe/issues/7790>`_)
+* refactor(component_interface_specs): prefix package and namespace with autoware (`#9094 <https://github.com/autowarefoundation/autoware.universe/issues/9094>`_)
+* refactor(geography_utils): prefix package and namespace with autoware (`#7790 <https://github.com/autowarefoundation/autoware.universe/issues/7790>`_)
   * refactor(geography_utils): prefix package and namespace with autoware
   * move headers to include/autoware/
   ---------
-* refactor(geo_pose_projector)!: prefix package and namespace with autoware (`#8334 <https://github.com/youtalk/autoware.universe/issues/8334>`_)
+* refactor(geo_pose_projector)!: prefix package and namespace with autoware (`#8334 <https://github.com/autowarefoundation/autoware.universe/issues/8334>`_)
   * add autoware\_ prefix
   * style(pre-commit): autofix
   ---------

--- a/localization/autoware_gyro_odometer/CHANGELOG.rst
+++ b/localization/autoware_gyro_odometer/CHANGELOG.rst
@@ -5,9 +5,9 @@ Changelog for package autoware_gyro_odometer
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* refactor(localization_util)!: prefix package and namespace with autoware (`#8922 <https://github.com/youtalk/autoware.universe/issues/8922>`_)
+* refactor(localization_util)!: prefix package and namespace with autoware (`#8922 <https://github.com/autowarefoundation/autoware.universe/issues/8922>`_)
   add autoware prefix to localization_util
-* refactor(gyro_odometer)!: prefix package and namespace with autoware (`#8340 <https://github.com/youtalk/autoware.universe/issues/8340>`_)
+* refactor(gyro_odometer)!: prefix package and namespace with autoware (`#8340 <https://github.com/autowarefoundation/autoware.universe/issues/8340>`_)
   * add autoware\_ prefix
   * add missing header
   * use target_include_directories instead

--- a/localization/autoware_landmark_based_localizer/autoware_ar_tag_based_localizer/CHANGELOG.rst
+++ b/localization/autoware_landmark_based_localizer/autoware_ar_tag_based_localizer/CHANGELOG.rst
@@ -5,27 +5,27 @@ Changelog for package autoware_ar_tag_based_localizer
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* refactor(localization_util)!: prefix package and namespace with autoware (`#8922 <https://github.com/youtalk/autoware.universe/issues/8922>`_)
+* refactor(localization_util)!: prefix package and namespace with autoware (`#8922 <https://github.com/autowarefoundation/autoware.universe/issues/8922>`_)
   add autoware prefix to localization_util
-* fix(doc): landmark localizer (`#8301 <https://github.com/youtalk/autoware.universe/issues/8301>`_)
+* fix(doc): landmark localizer (`#8301 <https://github.com/autowarefoundation/autoware.universe/issues/8301>`_)
   fix landmark localizer
-* refactor(localization): remove unnecessary dependency in localization packages (`#8202 <https://github.com/youtalk/autoware.universe/issues/8202>`_)
+* refactor(localization): remove unnecessary dependency in localization packages (`#8202 <https://github.com/autowarefoundation/autoware.universe/issues/8202>`_)
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Yamato Ando <yamato.ando@gmail.com>
-* perf(autoware_ar_tag_based_localizer): remove unnecessary pub/sub depth for transient_local (`#8259 <https://github.com/youtalk/autoware.universe/issues/8259>`_)
-* feat: add `autoware\_` prefix to `lanelet2_extension` (`#7640 <https://github.com/youtalk/autoware.universe/issues/7640>`_)
-* chore: update sample rosbags for localization modules (`#7716 <https://github.com/youtalk/autoware.universe/issues/7716>`_)
+* perf(autoware_ar_tag_based_localizer): remove unnecessary pub/sub depth for transient_local (`#8259 <https://github.com/autowarefoundation/autoware.universe/issues/8259>`_)
+* feat: add `autoware\_` prefix to `lanelet2_extension` (`#7640 <https://github.com/autowarefoundation/autoware.universe/issues/7640>`_)
+* chore: update sample rosbags for localization modules (`#7716 <https://github.com/autowarefoundation/autoware.universe/issues/7716>`_)
   Update sample rosbags for new message types
-* fix: replace deprecated header in Jazzy (`#7603 <https://github.com/youtalk/autoware.universe/issues/7603>`_)
+* fix: replace deprecated header in Jazzy (`#7603 <https://github.com/autowarefoundation/autoware.universe/issues/7603>`_)
   * Use cv_bridge.hpp if available
   * Fix image_geometry deprecated header
   * Add comment for __has_include
   ---------
   Co-authored-by: Kotaro Yoshimoto <pythagora.yoshimoto@gmail.com>
-* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/youtalk/autoware.universe/issues/7594>`_)
-* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/youtalk/autoware.universe/issues/7538>`_)
+* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/autowarefoundation/autoware.universe/issues/7594>`_)
+* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/autowarefoundation/autoware.universe/issues/7538>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* refactor(ar_tag_based_localizer): add prefix "autoware\_" to ar_tag_based_localizer (`#7483 <https://github.com/youtalk/autoware.universe/issues/7483>`_)
+* refactor(ar_tag_based_localizer): add prefix "autoware\_" to ar_tag_based_localizer (`#7483 <https://github.com/autowarefoundation/autoware.universe/issues/7483>`_)
   * Added prefix "autoware\_" to ar_tag_based_localizer
   * style(pre-commit): autofix
   * Fixed localization_launch

--- a/localization/autoware_landmark_based_localizer/autoware_landmark_manager/CHANGELOG.rst
+++ b/localization/autoware_landmark_based_localizer/autoware_landmark_manager/CHANGELOG.rst
@@ -5,16 +5,16 @@ Changelog for package autoware_landmark_manager
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* refactor(localization_util)!: prefix package and namespace with autoware (`#8922 <https://github.com/youtalk/autoware.universe/issues/8922>`_)
+* refactor(localization_util)!: prefix package and namespace with autoware (`#8922 <https://github.com/autowarefoundation/autoware.universe/issues/8922>`_)
   add autoware prefix to localization_util
-* refactor(localization): remove unnecessary dependency in localization packages (`#8202 <https://github.com/youtalk/autoware.universe/issues/8202>`_)
+* refactor(localization): remove unnecessary dependency in localization packages (`#8202 <https://github.com/autowarefoundation/autoware.universe/issues/8202>`_)
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Yamato Ando <yamato.ando@gmail.com>
-* feat: add `autoware\_` prefix to `lanelet2_extension` (`#7640 <https://github.com/youtalk/autoware.universe/issues/7640>`_)
-* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/youtalk/autoware.universe/issues/7594>`_)
-* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/youtalk/autoware.universe/issues/7538>`_)
+* feat: add `autoware\_` prefix to `lanelet2_extension` (`#7640 <https://github.com/autowarefoundation/autoware.universe/issues/7640>`_)
+* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/autowarefoundation/autoware.universe/issues/7594>`_)
+* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/autowarefoundation/autoware.universe/issues/7538>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* refactor(ar_tag_based_localizer): add prefix "autoware\_" to ar_tag_based_localizer (`#7483 <https://github.com/youtalk/autoware.universe/issues/7483>`_)
+* refactor(ar_tag_based_localizer): add prefix "autoware\_" to ar_tag_based_localizer (`#7483 <https://github.com/autowarefoundation/autoware.universe/issues/7483>`_)
   * Added prefix "autoware\_" to ar_tag_based_localizer
   * style(pre-commit): autofix
   * Fixed localization_launch

--- a/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/CHANGELOG.rst
+++ b/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/CHANGELOG.rst
@@ -5,10 +5,10 @@ Changelog for package autoware_lidar_marker_localizer
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* refactor(autoware_point_types): prefix namespace with autoware::point_types (`#9169 <https://github.com/youtalk/autoware.universe/issues/9169>`_)
-* refactor(localization_util)!: prefix package and namespace with autoware (`#8922 <https://github.com/youtalk/autoware.universe/issues/8922>`_)
+* refactor(autoware_point_types): prefix namespace with autoware::point_types (`#9169 <https://github.com/autowarefoundation/autoware.universe/issues/9169>`_)
+* refactor(localization_util)!: prefix package and namespace with autoware (`#8922 <https://github.com/autowarefoundation/autoware.universe/issues/8922>`_)
   add autoware prefix to localization_util
-* feat(localization): add `lidar_marker_localizer` (`#5573 <https://github.com/youtalk/autoware.universe/issues/5573>`_)
+* feat(localization): add `lidar_marker_localizer` (`#5573 <https://github.com/autowarefoundation/autoware.universe/issues/5573>`_)
   * Added lidar_marker_localizer
   * style(pre-commit): autofix
   * fix launch file

--- a/localization/autoware_localization_error_monitor/CHANGELOG.rst
+++ b/localization/autoware_localization_error_monitor/CHANGELOG.rst
@@ -5,15 +5,15 @@ Changelog for package autoware_localization_error_monitor
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* refactor(localization_util)!: prefix package and namespace with autoware (`#8922 <https://github.com/youtalk/autoware.universe/issues/8922>`_)
+* refactor(localization_util)!: prefix package and namespace with autoware (`#8922 <https://github.com/autowarefoundation/autoware.universe/issues/8922>`_)
   add autoware prefix to localization_util
-* fix(localization_error_monitor, system diag): fix to use diagnostics_module in localization_util (`#8543 <https://github.com/youtalk/autoware.universe/issues/8543>`_)
+* fix(localization_error_monitor, system diag): fix to use diagnostics_module in localization_util (`#8543 <https://github.com/autowarefoundation/autoware.universe/issues/8543>`_)
   * fix(localization_error_monitor): fix to use diagnostics_module in localization_util
   * fix: update media
   * fix: update component name
   * fix: rename include file
   ---------
-* refactor(localization_error_monitor)!: prefix package and namespace with autoware (`#8423 <https://github.com/youtalk/autoware.universe/issues/8423>`_)
+* refactor(localization_error_monitor)!: prefix package and namespace with autoware (`#8423 <https://github.com/autowarefoundation/autoware.universe/issues/8423>`_)
   add autoware\_ prefix
 * Contributors: Masaki Baba, RyuYamamoto, Yutaka Kondo
 

--- a/localization/autoware_localization_util/CHANGELOG.rst
+++ b/localization/autoware_localization_util/CHANGELOG.rst
@@ -5,7 +5,7 @@ Changelog for package autoware_localization_util
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* refactor(localization_util)!: prefix package and namespace with autoware (`#8922 <https://github.com/youtalk/autoware.universe/issues/8922>`_)
+* refactor(localization_util)!: prefix package and namespace with autoware (`#8922 <https://github.com/autowarefoundation/autoware.universe/issues/8922>`_)
   add autoware prefix to localization_util
 * Contributors: Masaki Baba, Yutaka Kondo
 

--- a/localization/autoware_ndt_scan_matcher/CHANGELOG.rst
+++ b/localization/autoware_ndt_scan_matcher/CHANGELOG.rst
@@ -5,9 +5,9 @@ Changelog for package autoware_ndt_scan_matcher
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* refactor(localization_util)!: prefix package and namespace with autoware (`#8922 <https://github.com/youtalk/autoware.universe/issues/8922>`_)
+* refactor(localization_util)!: prefix package and namespace with autoware (`#8922 <https://github.com/autowarefoundation/autoware.universe/issues/8922>`_)
   add autoware prefix to localization_util
-* refactor(ndt_scan_matcher)!: prefix package and namespace with autoware (`#8904 <https://github.com/youtalk/autoware.universe/issues/8904>`_)
+* refactor(ndt_scan_matcher)!: prefix package and namespace with autoware (`#8904 <https://github.com/autowarefoundation/autoware.universe/issues/8904>`_)
   add autoware\_ prefix
 * Contributors: Masaki Baba, Yutaka Kondo
 

--- a/localization/autoware_pose2twist/CHANGELOG.rst
+++ b/localization/autoware_pose2twist/CHANGELOG.rst
@@ -5,7 +5,7 @@ Changelog for package autoware_pose2twist
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* refactor(pose2twist)!: prefix package and namespace with autoware (`#8347 <https://github.com/youtalk/autoware.universe/issues/8347>`_)
+* refactor(pose2twist)!: prefix package and namespace with autoware (`#8347 <https://github.com/autowarefoundation/autoware.universe/issues/8347>`_)
   * add autoware\_ prefix
   * use target_include_directories instead
   ---------

--- a/localization/autoware_pose_covariance_modifier/CHANGELOG.rst
+++ b/localization/autoware_pose_covariance_modifier/CHANGELOG.rst
@@ -5,22 +5,22 @@ Changelog for package autoware_pose_covariance_modifier
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* docs(autoware_pose_covariance_modifier): fix gt symbol (`#9082 <https://github.com/youtalk/autoware.universe/issues/9082>`_)
-* docs(autoware_pose_cov_modifier): fix line breaks and dead links (`#8991 <https://github.com/youtalk/autoware.universe/issues/8991>`_)
+* docs(autoware_pose_covariance_modifier): fix gt symbol (`#9082 <https://github.com/autowarefoundation/autoware.universe/issues/9082>`_)
+* docs(autoware_pose_cov_modifier): fix line breaks and dead links (`#8991 <https://github.com/autowarefoundation/autoware.universe/issues/8991>`_)
   * fix(autoware_pose_cov_modifier): fix line breaks
   * fix dead links
   ---------
-* refactor(autoware_interpolation): prefix package and namespace with autoware (`#8088 <https://github.com/youtalk/autoware.universe/issues/8088>`_)
+* refactor(autoware_interpolation): prefix package and namespace with autoware (`#8088 <https://github.com/autowarefoundation/autoware.universe/issues/8088>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* fix(autoware_pose_covariance_modifier): fix funcArgNamesDifferent (`#8007 <https://github.com/youtalk/autoware.universe/issues/8007>`_)
+* fix(autoware_pose_covariance_modifier): fix funcArgNamesDifferent (`#8007 <https://github.com/autowarefoundation/autoware.universe/issues/8007>`_)
   fix:funcArgNamesDifferent
-* fix(pose_covariance_modifier): fix json schema (`#7323 <https://github.com/youtalk/autoware.universe/issues/7323>`_)
+* fix(pose_covariance_modifier): fix json schema (`#7323 <https://github.com/autowarefoundation/autoware.universe/issues/7323>`_)
   fix json schema
   Co-authored-by: Kotaro Yoshimoto <pythagora.yoshimoto@gmail.com>
-* fix(autoware_pose_covariance_modifier): change log output from screen to both (`#7198 <https://github.com/youtalk/autoware.universe/issues/7198>`_)
+* fix(autoware_pose_covariance_modifier): change log output from screen to both (`#7198 <https://github.com/autowarefoundation/autoware.universe/issues/7198>`_)
   change log output from screen to both
   Co-authored-by: SakodaShintaro <shintaro.sakoda@tier4.jp>
-* feat(autoware_pose_covariance_modifier): add new node to early fuse gnss and ndt poses (`#6570 <https://github.com/youtalk/autoware.universe/issues/6570>`_)
+* feat(autoware_pose_covariance_modifier): add new node to early fuse gnss and ndt poses (`#6570 <https://github.com/autowarefoundation/autoware.universe/issues/6570>`_)
   Co-authored-by: M. Fatih Cırıt <mfc@leodrive.ai>
 * Contributors: Esteve Fernandez, Masaki Baba, Yamato Ando, Yutaka Kondo, kobayu858, melike tanrikulu
 

--- a/localization/autoware_pose_estimator_arbiter/CHANGELOG.rst
+++ b/localization/autoware_pose_estimator_arbiter/CHANGELOG.rst
@@ -5,9 +5,9 @@ Changelog for package autoware_pose_estimator_arbiter
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* refactor(ndt_scan_matcher)!: prefix package and namespace with autoware (`#8904 <https://github.com/youtalk/autoware.universe/issues/8904>`_)
+* refactor(ndt_scan_matcher)!: prefix package and namespace with autoware (`#8904 <https://github.com/autowarefoundation/autoware.universe/issues/8904>`_)
   add autoware\_ prefix
-* refactor(pose_estimator_arbiter)!: prefix package and namespace with autoware (`#8386 <https://github.com/youtalk/autoware.universe/issues/8386>`_)
+* refactor(pose_estimator_arbiter)!: prefix package and namespace with autoware (`#8386 <https://github.com/autowarefoundation/autoware.universe/issues/8386>`_)
   * add autoware\_ prefix
   * add autoware\_ prefix
   * fix link for landmark_based_localizer

--- a/localization/autoware_pose_initializer/CHANGELOG.rst
+++ b/localization/autoware_pose_initializer/CHANGELOG.rst
@@ -5,8 +5,8 @@ Changelog for package autoware_pose_initializer
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* refactor(component_interface_specs): prefix package and namespace with autoware (`#9094 <https://github.com/youtalk/autoware.universe/issues/9094>`_)
-* feat(pose_initializer): check error initial pose and gnss pose, output diagnostics (`#8947 <https://github.com/youtalk/autoware.universe/issues/8947>`_)
+* refactor(component_interface_specs): prefix package and namespace with autoware (`#9094 <https://github.com/autowarefoundation/autoware.universe/issues/9094>`_)
+* feat(pose_initializer): check error initial pose and gnss pose, output diagnostics (`#8947 <https://github.com/autowarefoundation/autoware.universe/issues/8947>`_)
   * check initial pose error use GNSS pose
   * add pose_error_check_enabled parameter
   * fixed key value name
@@ -16,9 +16,9 @@ Changelog for package autoware_pose_initializer
   * fixed type and default in schema json
   * rename key value
   ---------
-* refactor(localization_util)!: prefix package and namespace with autoware (`#8922 <https://github.com/youtalk/autoware.universe/issues/8922>`_)
+* refactor(localization_util)!: prefix package and namespace with autoware (`#8922 <https://github.com/autowarefoundation/autoware.universe/issues/8922>`_)
   add autoware prefix to localization_util
-* refactor(pose_initializer)!: prefix package and namespace with autoware (`#8701 <https://github.com/youtalk/autoware.universe/issues/8701>`_)
+* refactor(pose_initializer)!: prefix package and namespace with autoware (`#8701 <https://github.com/autowarefoundation/autoware.universe/issues/8701>`_)
   * add autoware\_ prefix
   * fix link
   ---------

--- a/localization/autoware_pose_instability_detector/CHANGELOG.rst
+++ b/localization/autoware_pose_instability_detector/CHANGELOG.rst
@@ -5,7 +5,7 @@ Changelog for package autoware_pose_instability_detector
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* refactor(pose_instability_detector)!: prefix package and namespace with autoware (`#8568 <https://github.com/youtalk/autoware.universe/issues/8568>`_)
+* refactor(pose_instability_detector)!: prefix package and namespace with autoware (`#8568 <https://github.com/autowarefoundation/autoware.universe/issues/8568>`_)
   * add autoware\_ prefix
   * add autoware\_ prefix
   ---------

--- a/localization/autoware_stop_filter/CHANGELOG.rst
+++ b/localization/autoware_stop_filter/CHANGELOG.rst
@@ -5,14 +5,14 @@ Changelog for package autoware_stop_filter
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* fix(docs): autoware stop filter docs (`#8302 <https://github.com/youtalk/autoware.universe/issues/8302>`_)
+* fix(docs): autoware stop filter docs (`#8302 <https://github.com/autowarefoundation/autoware.universe/issues/8302>`_)
   fix autoware stop filter docs
-* fix(autoware_stop_filter): fix funcArgNamesDifferent (`#8008 <https://github.com/youtalk/autoware.universe/issues/8008>`_)
+* fix(autoware_stop_filter): fix funcArgNamesDifferent (`#8008 <https://github.com/autowarefoundation/autoware.universe/issues/8008>`_)
   fix:funcArgNamesDifferent
-* chore(localization, map): remove maintainer (`#7940 <https://github.com/youtalk/autoware.universe/issues/7940>`_)
-* fix(stop_filter): fix plugin name (`#7820 <https://github.com/youtalk/autoware.universe/issues/7820>`_)
+* chore(localization, map): remove maintainer (`#7940 <https://github.com/autowarefoundation/autoware.universe/issues/7940>`_)
+* fix(stop_filter): fix plugin name (`#7820 <https://github.com/autowarefoundation/autoware.universe/issues/7820>`_)
   Fixed plugin name
-* refactor(stop_filter): prefix package and namespace with autoware (`#7789 <https://github.com/youtalk/autoware.universe/issues/7789>`_)
+* refactor(stop_filter): prefix package and namespace with autoware (`#7789 <https://github.com/autowarefoundation/autoware.universe/issues/7789>`_)
   * refactor(stop_filter): prefix package and namespace with autoware
   * fix launch files and update CODEOWNERS
   ---------

--- a/localization/autoware_twist2accel/CHANGELOG.rst
+++ b/localization/autoware_twist2accel/CHANGELOG.rst
@@ -5,10 +5,10 @@ Changelog for package autoware_twist2accel
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* refactor(signal_processing): prefix package and namespace with autoware (`#8541 <https://github.com/youtalk/autoware.universe/issues/8541>`_)
-* fix(autoware_twist2accel): fix funcArgNamesDifferent (`#8391 <https://github.com/youtalk/autoware.universe/issues/8391>`_)
+* refactor(signal_processing): prefix package and namespace with autoware (`#8541 <https://github.com/autowarefoundation/autoware.universe/issues/8541>`_)
+* fix(autoware_twist2accel): fix funcArgNamesDifferent (`#8391 <https://github.com/autowarefoundation/autoware.universe/issues/8391>`_)
   fix:funcArgNamesDifferent
-* refactor(twist2accel)!: prefix package and namespace with autoware (`#8299 <https://github.com/youtalk/autoware.universe/issues/8299>`_)
+* refactor(twist2accel)!: prefix package and namespace with autoware (`#8299 <https://github.com/autowarefoundation/autoware.universe/issues/8299>`_)
   * add autoware\_ prefix
   * add autoware\_ prefix
   * add autoware\_ prefix

--- a/localization/yabloc/yabloc_common/CHANGELOG.rst
+++ b/localization/yabloc/yabloc_common/CHANGELOG.rst
@@ -5,21 +5,21 @@ Changelog for package yabloc_common
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* refactor(signal_processing): prefix package and namespace with autoware (`#8541 <https://github.com/youtalk/autoware.universe/issues/8541>`_)
-* fix(yabloc_common): fix unusedFunction (`#8560 <https://github.com/youtalk/autoware.universe/issues/8560>`_)
+* refactor(signal_processing): prefix package and namespace with autoware (`#8541 <https://github.com/autowarefoundation/autoware.universe/issues/8541>`_)
+* fix(yabloc_common): fix unusedFunction (`#8560 <https://github.com/autowarefoundation/autoware.universe/issues/8560>`_)
   fix:unusedFunction
-* perf(yabloc_common): remove unnecessary pub/sub depth for transient_local (`#8248 <https://github.com/youtalk/autoware.universe/issues/8248>`_)
-* feat: add `autoware\_` prefix to `lanelet2_extension` (`#7640 <https://github.com/youtalk/autoware.universe/issues/7640>`_)
-* fix: replace deprecated header in Jazzy (`#7603 <https://github.com/youtalk/autoware.universe/issues/7603>`_)
+* perf(yabloc_common): remove unnecessary pub/sub depth for transient_local (`#8248 <https://github.com/autowarefoundation/autoware.universe/issues/8248>`_)
+* feat: add `autoware\_` prefix to `lanelet2_extension` (`#7640 <https://github.com/autowarefoundation/autoware.universe/issues/7640>`_)
+* fix: replace deprecated header in Jazzy (`#7603 <https://github.com/autowarefoundation/autoware.universe/issues/7603>`_)
   * Use cv_bridge.hpp if available
   * Fix image_geometry deprecated header
   * Add comment for __has_include
   ---------
   Co-authored-by: Kotaro Yoshimoto <pythagora.yoshimoto@gmail.com>
-* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/youtalk/autoware.universe/issues/7594>`_)
-* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/youtalk/autoware.universe/issues/7538>`_)
+* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/autowarefoundation/autoware.universe/issues/7594>`_)
+* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/autowarefoundation/autoware.universe/issues/7538>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* refactor(yabloc_common): apply static analysis (`#7481 <https://github.com/youtalk/autoware.universe/issues/7481>`_)
+* refactor(yabloc_common): apply static analysis (`#7481 <https://github.com/autowarefoundation/autoware.universe/issues/7481>`_)
   * refactor based on linter
   * restore unwanted change
   * remove unnecessary comment
@@ -28,7 +28,7 @@ Changelog for package yabloc_common
   * add static cast
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* fix(yabloc): suppress no viable conversion error (`#7299 <https://github.com/youtalk/autoware.universe/issues/7299>`_)
+* fix(yabloc): suppress no viable conversion error (`#7299 <https://github.com/autowarefoundation/autoware.universe/issues/7299>`_)
   * use tier4_autoware_utils instead of yabloc::Color
   * use static_cast to convert Color to RGBA
   * use tier4_autoware_utils instead of yabloc::Color
@@ -36,17 +36,17 @@ Changelog for package yabloc_common
   * style(pre-commit): autofix
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat!: replace autoware_auto_msgs with autoware_msgs for localization modules (`#7243 <https://github.com/youtalk/autoware.universe/issues/7243>`_)
+* feat!: replace autoware_auto_msgs with autoware_msgs for localization modules (`#7243 <https://github.com/autowarefoundation/autoware.universe/issues/7243>`_)
   Co-authored-by: Cynthia Liu <cynthia.liu@autocore.ai>
   Co-authored-by: NorahXiong <norah.xiong@autocore.ai>
   Co-authored-by: beginningfan <beginning.fan@autocore.ai>
-* refactor(yabloc): use constexpr properly (`#7207 <https://github.com/youtalk/autoware.universe/issues/7207>`_)
-* fix(yabloc): fix bug in capturing in lambda function (`#7208 <https://github.com/youtalk/autoware.universe/issues/7208>`_)
+* refactor(yabloc): use constexpr properly (`#7207 <https://github.com/autowarefoundation/autoware.universe/issues/7207>`_)
+* fix(yabloc): fix bug in capturing in lambda function (`#7208 <https://github.com/autowarefoundation/autoware.universe/issues/7208>`_)
   * fix(yabloc): fix bug in capturing in lambda function
   * style(pre-commit): autofix
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat(yabloc_common): componentize yabloc_common nodes (`#7143 <https://github.com/youtalk/autoware.universe/issues/7143>`_)
+* feat(yabloc_common): componentize yabloc_common nodes (`#7143 <https://github.com/autowarefoundation/autoware.universe/issues/7143>`_)
   * make executables component
   * log output changes to both
   * style(pre-commit): autofix
@@ -55,17 +55,17 @@ Changelog for package yabloc_common
   * style(pre-commit): autofix
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* chore(glog): add initialization check (`#6792 <https://github.com/youtalk/autoware.universe/issues/6792>`_)
+* chore(glog): add initialization check (`#6792 <https://github.com/autowarefoundation/autoware.universe/issues/6792>`_)
 * Contributors: Esteve Fernandez, Kento Yabuuchi, Kosuke Takeuchi, Masaki Baba, Ryohsuke Mitsudome, Ryuta Kambe, Takamasa Horibe, Takayuki Murooka, Yutaka Kondo, kobayu858, ぐるぐる
 
 0.26.0 (2024-04-03)
 -------------------
-* chore(yabloc): replace parameters by json_to_markdown in readme (`#6183 <https://github.com/youtalk/autoware.universe/issues/6183>`_)
+* chore(yabloc): replace parameters by json_to_markdown in readme (`#6183 <https://github.com/autowarefoundation/autoware.universe/issues/6183>`_)
   * replace parameters by json_to_markdown
   * fix some schma path
   * fix again
   ---------
-* chore(yabloc): rework parameters (`#6170 <https://github.com/youtalk/autoware.universe/issues/6170>`_)
+* chore(yabloc): rework parameters (`#6170 <https://github.com/autowarefoundation/autoware.universe/issues/6170>`_)
   * introduce json schema for ground_server
   * introduce json schema for ll2_decomposer
   * style(pre-commit): autofix
@@ -88,20 +88,20 @@ Changelog for package yabloc_common
   * style(pre-commit): autofix
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* chore: add localization & mapping maintainers (`#6085 <https://github.com/youtalk/autoware.universe/issues/6085>`_)
+* chore: add localization & mapping maintainers (`#6085 <https://github.com/autowarefoundation/autoware.universe/issues/6085>`_)
   * Added lm maintainers
   * Add more
   * Fixed maintainer
   ---------
-* build(yabloc_common): add missing libgoogle-glog-dev dependency (`#5225 <https://github.com/youtalk/autoware.universe/issues/5225>`_)
+* build(yabloc_common): add missing libgoogle-glog-dev dependency (`#5225 <https://github.com/autowarefoundation/autoware.universe/issues/5225>`_)
   * build(yabloc_common): add missing libgoogle-glog-dev dependency
   * style(pre-commit): autofix
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* refactor(localization_packages): remove unused <depend> in packages.xml files (`#5171 <https://github.com/youtalk/autoware.universe/issues/5171>`_)
+* refactor(localization_packages): remove unused <depend> in packages.xml files (`#5171 <https://github.com/autowarefoundation/autoware.universe/issues/5171>`_)
   Co-authored-by: yamato-ando <Yamato ANDO>
-* chore: add maintainer in localization and map packages (`#4501 <https://github.com/youtalk/autoware.universe/issues/4501>`_)
-* fix(yabloc): fix typo (`#4281 <https://github.com/youtalk/autoware.universe/issues/4281>`_)
+* chore: add maintainer in localization and map packages (`#4501 <https://github.com/autowarefoundation/autoware.universe/issues/4501>`_)
+* fix(yabloc): fix typo (`#4281 <https://github.com/autowarefoundation/autoware.universe/issues/4281>`_)
   * fix(yabloc): fix typo
   * fix Kinv and mean_pose
   * style(pre-commit): autofix
@@ -112,7 +112,7 @@ Changelog for package yabloc_common
   * fix typo
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat(yabloc): add camera and vector map localization (`#3946 <https://github.com/youtalk/autoware.universe/issues/3946>`_)
+* feat(yabloc): add camera and vector map localization (`#3946 <https://github.com/autowarefoundation/autoware.universe/issues/3946>`_)
   * adopt scane_case to undistort, segment_filter
   * adopt scane_case to ground_server, ll2_decomposer
   * adopt scane_case to twist_converter, twist_estimator
@@ -258,26 +258,26 @@ Changelog for package yabloc_common
   * update README and some sample images
   * update README.md
   * fix override_camera_frame_id bahaviors
-  * fix some bugs (`#4 <https://github.com/youtalk/autoware.universe/issues/4>`_)
-  * fix: use initialpose from Rviz (`#6 <https://github.com/youtalk/autoware.universe/issues/6>`_)
+  * fix some bugs (`#4 <https://github.com/autowarefoundation/autoware.universe/issues/4>`_)
+  * fix: use initialpose from Rviz (`#6 <https://github.com/autowarefoundation/autoware.universe/issues/6>`_)
   * use initialpose from Rviz to init
   * add description about how-to-set-initialpose
   ---------
-  * misc: add license (`#7 <https://github.com/youtalk/autoware.universe/issues/7>`_)
+  * misc: add license (`#7 <https://github.com/autowarefoundation/autoware.universe/issues/7>`_)
   * WIP: add license description
   * add license description
   * add description about license in README
   ---------
-  * add quick start demo (`#8 <https://github.com/youtalk/autoware.universe/issues/8>`_)
-  * refactor(launch) remove & update obsolete launch files (`#9 <https://github.com/youtalk/autoware.universe/issues/9>`_)
+  * add quick start demo (`#8 <https://github.com/autowarefoundation/autoware.universe/issues/8>`_)
+  * refactor(launch) remove & update obsolete launch files (`#9 <https://github.com/autowarefoundation/autoware.universe/issues/9>`_)
   * delete obsolete launch files
   * update documents
   ---------
-  * docs(readme): update architecture image (`#10 <https://github.com/youtalk/autoware.universe/issues/10>`_)
+  * docs(readme): update architecture image (`#10 <https://github.com/autowarefoundation/autoware.universe/issues/10>`_)
   * replace architecture image in README
   * update some images
   ---------
-  * refactor(pcdless_launc/scripts): remove unnecessary scripts (`#11 <https://github.com/youtalk/autoware.universe/issues/11>`_)
+  * refactor(pcdless_launc/scripts): remove unnecessary scripts (`#11 <https://github.com/autowarefoundation/autoware.universe/issues/11>`_)
   * remove not useful scripts
   * rename scripts &  add descriptions
   * little change
@@ -288,18 +288,18 @@ Changelog for package yabloc_common
   * fix(twist_estimator): use velocity_report by default
   * fix bug
   * debugged, now works
-  * update sample rosbag link (`#14 <https://github.com/youtalk/autoware.universe/issues/14>`_)
-  * feature(graph_segment, gnss_particle_corrector): make some features switchable (`#17 <https://github.com/youtalk/autoware.universe/issues/17>`_)
+  * update sample rosbag link (`#14 <https://github.com/autowarefoundation/autoware.universe/issues/14>`_)
+  * feature(graph_segment, gnss_particle_corrector): make some features switchable (`#17 <https://github.com/autowarefoundation/autoware.universe/issues/17>`_)
   * make additional-graph-segment-pickup disablable
   * enlarge gnss_mahalanobis_distance_threshold in expressway.launch
   ---------
-  * fix: minor fix for multi camera support (`#18 <https://github.com/youtalk/autoware.universe/issues/18>`_)
+  * fix: minor fix for multi camera support (`#18 <https://github.com/autowarefoundation/autoware.universe/issues/18>`_)
   * fix: minor fix for multi camera support
   * update
   * update
   * fix typo
   ---------
-  * refactor(retroactive_resampler): more readable (`#19 <https://github.com/youtalk/autoware.universe/issues/19>`_)
+  * refactor(retroactive_resampler): more readable (`#19 <https://github.com/autowarefoundation/autoware.universe/issues/19>`_)
   * make Hisotry class
   * use boost:adaptors::indexed()
   * add many comment in resampling()
@@ -307,42 +307,42 @@ Changelog for package yabloc_common
   * rename interface of resampler
   * circular_buffer is unnecessary
   ---------
-  * refactor(mpf::predictor) resampling interval control in out of resampler (`#20 <https://github.com/youtalk/autoware.universe/issues/20>`_)
+  * refactor(mpf::predictor) resampling interval control in out of resampler (`#20 <https://github.com/autowarefoundation/autoware.universe/issues/20>`_)
   * resampling interval management should be done out of resample()
   * resampler class throw exeption rather than optional
   * split files for resampling_history
   * split files for experimental/suspention_adaptor
   ---------
-  * refactor(mpf::predictor): just refactoring (`#21 <https://github.com/youtalk/autoware.universe/issues/21>`_)
+  * refactor(mpf::predictor): just refactoring (`#21 <https://github.com/autowarefoundation/autoware.universe/issues/21>`_)
   * remove obsolete functions
   * remove test of predictor
   * remove remapping in pf.launch.xml for suspension_adapator
   * add some comments
   ---------
-  * fix(twist_estimator): remove stop filter for velocity (`#23 <https://github.com/youtalk/autoware.universe/issues/23>`_)
-  * feat(pcdless_launch): add multi camera launcher (`#22 <https://github.com/youtalk/autoware.universe/issues/22>`_)
+  * fix(twist_estimator): remove stop filter for velocity (`#23 <https://github.com/autowarefoundation/autoware.universe/issues/23>`_)
+  * feat(pcdless_launch): add multi camera launcher (`#22 <https://github.com/autowarefoundation/autoware.universe/issues/22>`_)
   * feat(pcdless_launch): add multi camera launcher
   * minor fix
   ---------
-  * refactor(CMakeListx.txt): just refactoring (`#24 <https://github.com/youtalk/autoware.universe/issues/24>`_)
+  * refactor(CMakeListx.txt): just refactoring (`#24 <https://github.com/autowarefoundation/autoware.universe/issues/24>`_)
   * refactor imgproc/*/CMakeListx.txt
   * refactor initializer/*/CMakeListx.txt & add gnss_pose_initializer pkg
   * rename some files in twist/ & refactor pf/*/cmakelist
   * refactor validation/*/CMakeListx.txt
   * fix some obsolete executor name
   ---------
-  * fix: rename lsd variables and files (`#26 <https://github.com/youtalk/autoware.universe/issues/26>`_)
-  * misc: reame pcdless to yabloc (`#25 <https://github.com/youtalk/autoware.universe/issues/25>`_)
+  * fix: rename lsd variables and files (`#26 <https://github.com/autowarefoundation/autoware.universe/issues/26>`_)
+  * misc: reame pcdless to yabloc (`#25 <https://github.com/autowarefoundation/autoware.universe/issues/25>`_)
   * rename pcdless to yabloc
   * fix conflict miss
   ---------
-  * visualize path (`#28 <https://github.com/youtalk/autoware.universe/issues/28>`_)
-  * docs: update readme about particle filter (`#30 <https://github.com/youtalk/autoware.universe/issues/30>`_)
+  * visualize path (`#28 <https://github.com/autowarefoundation/autoware.universe/issues/28>`_)
+  * docs: update readme about particle filter (`#30 <https://github.com/autowarefoundation/autoware.universe/issues/30>`_)
   * update mpf/README.md
   * update gnss_corrector/README.md
   * update camera_corrector/README.md
   ---------
-  * feat(segment_filter): publish images with lines and refactor (`#29 <https://github.com/youtalk/autoware.universe/issues/29>`_)
+  * feat(segment_filter): publish images with lines and refactor (`#29 <https://github.com/autowarefoundation/autoware.universe/issues/29>`_)
   * feat(segment_filter): publish images with lines
   * update validation
   * update imgproc (reverted)
@@ -356,47 +356,47 @@ Changelog for package yabloc_common
   * no throw runtime_error (unintentionaly applying format)
   ---------
   Co-authored-by: Kento Yabuuchi <kento.yabuuchi.2@tier4.jp>
-  * catch runtime_error when particle id is invalid (`#31 <https://github.com/youtalk/autoware.universe/issues/31>`_)
-  * return if info is nullopt (`#32 <https://github.com/youtalk/autoware.universe/issues/32>`_)
-  * pose_buffer is sometimes empty (`#33 <https://github.com/youtalk/autoware.universe/issues/33>`_)
-  * use_yaw_of_initialpose (`#34 <https://github.com/youtalk/autoware.universe/issues/34>`_)
-  * feat(interface):  remove incompatible interface (`#35 <https://github.com/youtalk/autoware.universe/issues/35>`_)
+  * catch runtime_error when particle id is invalid (`#31 <https://github.com/autowarefoundation/autoware.universe/issues/31>`_)
+  * return if info is nullopt (`#32 <https://github.com/autowarefoundation/autoware.universe/issues/32>`_)
+  * pose_buffer is sometimes empty (`#33 <https://github.com/autowarefoundation/autoware.universe/issues/33>`_)
+  * use_yaw_of_initialpose (`#34 <https://github.com/autowarefoundation/autoware.universe/issues/34>`_)
+  * feat(interface):  remove incompatible interface (`#35 <https://github.com/autowarefoundation/autoware.universe/issues/35>`_)
   * not use ublox_msg when run as autoware
   * remove twist/kalman/twist & use twist_estimator/twist_with_covariance
   * update particle_array stamp even if the time stamp seems wrong
   ---------
-  * fix: suppress info/warn_stream (`#37 <https://github.com/youtalk/autoware.universe/issues/37>`_)
+  * fix: suppress info/warn_stream (`#37 <https://github.com/autowarefoundation/autoware.universe/issues/37>`_)
   * does not stream undistortion time
   * improve warn stream when skip particle weighting
   * surpress frequency of  warnings during synchronized particle searching
   * fix camera_pose_initializer
   ---------
-  * /switch must not be nice name (`#39 <https://github.com/youtalk/autoware.universe/issues/39>`_)
-  * misc(readme): update readme (`#41 <https://github.com/youtalk/autoware.universe/issues/41>`_)
+  * /switch must not be nice name (`#39 <https://github.com/autowarefoundation/autoware.universe/issues/39>`_)
+  * misc(readme): update readme (`#41 <https://github.com/autowarefoundation/autoware.universe/issues/41>`_)
   * add youtube link and change thumbnail
   * improve input/output topics
   * quick start demo screen image
   * add abstruct architecture and detail architecture
   ---------
-  * docs(rosdep): fix package.xml to ensure build success (`#44 <https://github.com/youtalk/autoware.universe/issues/44>`_)
+  * docs(rosdep): fix package.xml to ensure build success (`#44 <https://github.com/autowarefoundation/autoware.universe/issues/44>`_)
   * fix package.xml to success build
   * add 'rosdep install' in how-to-build
   ---------
-  * add geographiclib in package.xml (`#46 <https://github.com/youtalk/autoware.universe/issues/46>`_)
-  * fix path search error in build stage (`#45 <https://github.com/youtalk/autoware.universe/issues/45>`_)
+  * add geographiclib in package.xml (`#46 <https://github.com/autowarefoundation/autoware.universe/issues/46>`_)
+  * fix path search error in build stage (`#45 <https://github.com/autowarefoundation/autoware.universe/issues/45>`_)
   * fix path search error in build stage
   * fix https://github.com/tier4/YabLoc/pull/45#issuecomment-1546808419
-  * Feature/remove submodule (`#47 <https://github.com/youtalk/autoware.universe/issues/47>`_)
+  * Feature/remove submodule (`#47 <https://github.com/autowarefoundation/autoware.universe/issues/47>`_)
   * remove submodules
   * remove doppler converter
   ---------
-  * feature: change node namespace to /localization/yabloc/** from /localization/** (`#48 <https://github.com/youtalk/autoware.universe/issues/48>`_)
+  * feature: change node namespace to /localization/yabloc/** from /localization/** (`#48 <https://github.com/autowarefoundation/autoware.universe/issues/48>`_)
   * change node namespace
   * update namespace for autoware-mode
   * update namespace in multi_camera.launch
   ---------
-  * removed unstable packages (`#49 <https://github.com/youtalk/autoware.universe/issues/49>`_)
-  * feature: add *.param.yaml to manage parameters (`#50 <https://github.com/youtalk/autoware.universe/issues/50>`_)
+  * removed unstable packages (`#49 <https://github.com/autowarefoundation/autoware.universe/issues/49>`_)
+  * feature: add *.param.yaml to manage parameters (`#50 <https://github.com/autowarefoundation/autoware.universe/issues/50>`_)
   * make *.param.yaml in imgproc packages
   * make *.param.yaml in initializer packages
   * make *.param.yaml in map packages
@@ -407,8 +407,8 @@ Changelog for package yabloc_common
   * remove default parameters
   * fix some remaining invalida parameters
   ---------
-  * does not estimate twist (`#51 <https://github.com/youtalk/autoware.universe/issues/51>`_)
-  * feat(particle_initializer): merge particle_initializer into mpf (`#52 <https://github.com/youtalk/autoware.universe/issues/52>`_)
+  * does not estimate twist (`#51 <https://github.com/autowarefoundation/autoware.universe/issues/51>`_)
+  * feat(particle_initializer): merge particle_initializer into mpf (`#52 <https://github.com/autowarefoundation/autoware.universe/issues/52>`_)
   * feat(particle_initializer): merge particle_initializer to modulalized_particle_filter
   * remove particle_initializer
   * remove debug message
@@ -417,8 +417,8 @@ Changelog for package yabloc_common
   * rename publishing topic
   ---------
   Co-authored-by: Kento Yabuuchi <kento.yabuuchi.2@tier4.jp>
-  * fix: remove ll2_transition_area (`#54 <https://github.com/youtalk/autoware.universe/issues/54>`_)
-  * feature(initializer): combine some initializer packages (`#56 <https://github.com/youtalk/autoware.universe/issues/56>`_)
+  * fix: remove ll2_transition_area (`#54 <https://github.com/autowarefoundation/autoware.universe/issues/54>`_)
+  * feature(initializer): combine some initializer packages (`#56 <https://github.com/autowarefoundation/autoware.universe/issues/56>`_)
   * combine some package about initializer
   * yabloc_pose_initializer works well
   * remove old initializer packages
@@ -426,15 +426,15 @@ Changelog for package yabloc_common
   * fix bug
   * revert initializer mode
   ---------
-  * feature(imgproc): reudce imgproc packages (`#57 <https://github.com/youtalk/autoware.universe/issues/57>`_)
+  * feature(imgproc): reudce imgproc packages (`#57 <https://github.com/autowarefoundation/autoware.universe/issues/57>`_)
   * combine some imgproc packages
   * combine overlay monitors into imgproc
   ---------
-  * feature(validation): remove validation packages (`#58 <https://github.com/youtalk/autoware.universe/issues/58>`_)
+  * feature(validation): remove validation packages (`#58 <https://github.com/autowarefoundation/autoware.universe/issues/58>`_)
   * remove validation packages
   * remove path visualization
   ---------
-  * feature(pf): combine some packages related to particle filter (`#59 <https://github.com/youtalk/autoware.universe/issues/59>`_)
+  * feature(pf): combine some packages related to particle filter (`#59 <https://github.com/autowarefoundation/autoware.universe/issues/59>`_)
   * create yabloc_particle_filter
   * combine gnss_particle_corrector
   * combine ll2_cost_map
@@ -443,7 +443,7 @@ Changelog for package yabloc_common
   * split README & remove obsolete scripts
   * fix config path of multi_camera mode
   ---------
-  * feature: combine map and twist packages (`#60 <https://github.com/youtalk/autoware.universe/issues/60>`_)
+  * feature: combine map and twist packages (`#60 <https://github.com/autowarefoundation/autoware.universe/issues/60>`_)
   * removed some twist nodes & rename remains to yabloc_twist
   * fix launch files for yabloc_twist
   * move map packages to yabloc_common

--- a/localization/yabloc/yabloc_image_processing/CHANGELOG.rst
+++ b/localization/yabloc/yabloc_image_processing/CHANGELOG.rst
@@ -5,27 +5,27 @@ Changelog for package yabloc_image_processing
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* fix(yabloc_image_processing): fix shadowFunction (`#7865 <https://github.com/youtalk/autoware.universe/issues/7865>`_)
+* fix(yabloc_image_processing): fix shadowFunction (`#7865 <https://github.com/autowarefoundation/autoware.universe/issues/7865>`_)
   * fix(yabloc_image_processing): fix shadowFunction
   * fix
   * style(pre-commit): autofix
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* fix: replace deprecated header in Jazzy (`#7603 <https://github.com/youtalk/autoware.universe/issues/7603>`_)
+* fix: replace deprecated header in Jazzy (`#7603 <https://github.com/autowarefoundation/autoware.universe/issues/7603>`_)
   * Use cv_bridge.hpp if available
   * Fix image_geometry deprecated header
   * Add comment for __has_include
   ---------
   Co-authored-by: Kotaro Yoshimoto <pythagora.yoshimoto@gmail.com>
-* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/youtalk/autoware.universe/issues/7594>`_)
-* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/youtalk/autoware.universe/issues/7538>`_)
+* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/autowarefoundation/autoware.universe/issues/7594>`_)
+* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/autowarefoundation/autoware.universe/issues/7538>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* refactor(yabloc_image_processing): apply static analysis (`#7489 <https://github.com/youtalk/autoware.universe/issues/7489>`_)
+* refactor(yabloc_image_processing): apply static analysis (`#7489 <https://github.com/autowarefoundation/autoware.universe/issues/7489>`_)
   * refactor based on linter
   * style(pre-commit): autofix
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat(yabloc_image_processing): componentize yabloc_image_processing nodes (`#7196 <https://github.com/youtalk/autoware.universe/issues/7196>`_)
+* feat(yabloc_image_processing): componentize yabloc_image_processing nodes (`#7196 <https://github.com/autowarefoundation/autoware.universe/issues/7196>`_)
   * replace executable with component
   * modify launch
   * fix line_segments_overlay namespace & node_name
@@ -37,12 +37,12 @@ Changelog for package yabloc_image_processing
 
 0.26.0 (2024-04-03)
 -------------------
-* chore(yabloc): replace parameters by json_to_markdown in readme (`#6183 <https://github.com/youtalk/autoware.universe/issues/6183>`_)
+* chore(yabloc): replace parameters by json_to_markdown in readme (`#6183 <https://github.com/autowarefoundation/autoware.universe/issues/6183>`_)
   * replace parameters by json_to_markdown
   * fix some schma path
   * fix again
   ---------
-* chore(yabloc): rework parameters (`#6170 <https://github.com/youtalk/autoware.universe/issues/6170>`_)
+* chore(yabloc): rework parameters (`#6170 <https://github.com/autowarefoundation/autoware.universe/issues/6170>`_)
   * introduce json schema for ground_server
   * introduce json schema for ll2_decomposer
   * style(pre-commit): autofix
@@ -65,30 +65,30 @@ Changelog for package yabloc_image_processing
   * style(pre-commit): autofix
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* chore: add localization & mapping maintainers (`#6085 <https://github.com/youtalk/autoware.universe/issues/6085>`_)
+* chore: add localization & mapping maintainers (`#6085 <https://github.com/autowarefoundation/autoware.universe/issues/6085>`_)
   * Added lm maintainers
   * Add more
   * Fixed maintainer
   ---------
-* feat(yabloc): add yabloc trigger service to suspend and restart the estimation (`#6076 <https://github.com/youtalk/autoware.universe/issues/6076>`_)
+* feat(yabloc): add yabloc trigger service to suspend and restart the estimation (`#6076 <https://github.com/autowarefoundation/autoware.universe/issues/6076>`_)
   * change arg default value
   * add yabloc_trigger_service
   * fix misc
   ---------
-* feat(yabloc_image_processing): support both of  raw and compressed image input (`#5209 <https://github.com/youtalk/autoware.universe/issues/5209>`_)
+* feat(yabloc_image_processing): support both of  raw and compressed image input (`#5209 <https://github.com/autowarefoundation/autoware.universe/issues/5209>`_)
   * add raw image subscriber
   * update README
   * improve format and variable names
   ---------
-* refactor(localization_packages): remove unused <depend> in packages.xml files (`#5171 <https://github.com/youtalk/autoware.universe/issues/5171>`_)
+* refactor(localization_packages): remove unused <depend> in packages.xml files (`#5171 <https://github.com/autowarefoundation/autoware.universe/issues/5171>`_)
   Co-authored-by: yamato-ando <Yamato ANDO>
-* fix(yabloc_image_processing): handle exception when no lines detected (`#4717 <https://github.com/youtalk/autoware.universe/issues/4717>`_)
-* chore: add maintainer in localization and map packages (`#4501 <https://github.com/youtalk/autoware.universe/issues/4501>`_)
-* feat(yabloc): change namespace (`#4389 <https://github.com/youtalk/autoware.universe/issues/4389>`_)
+* fix(yabloc_image_processing): handle exception when no lines detected (`#4717 <https://github.com/autowarefoundation/autoware.universe/issues/4717>`_)
+* chore: add maintainer in localization and map packages (`#4501 <https://github.com/autowarefoundation/autoware.universe/issues/4501>`_)
+* feat(yabloc): change namespace (`#4389 <https://github.com/autowarefoundation/autoware.universe/issues/4389>`_)
   * fix(yabloc): update namespace
   * fix
   ---------
-* fix(yabloc): fix typo (`#4281 <https://github.com/youtalk/autoware.universe/issues/4281>`_)
+* fix(yabloc): fix typo (`#4281 <https://github.com/autowarefoundation/autoware.universe/issues/4281>`_)
   * fix(yabloc): fix typo
   * fix Kinv and mean_pose
   * style(pre-commit): autofix
@@ -99,7 +99,7 @@ Changelog for package yabloc_image_processing
   * fix typo
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat: use `pose_source` and `twist_source` for selecting localization methods (`#4257 <https://github.com/youtalk/autoware.universe/issues/4257>`_)
+* feat: use `pose_source` and `twist_source` for selecting localization methods (`#4257 <https://github.com/autowarefoundation/autoware.universe/issues/4257>`_)
   * feat(tier4_localization_launch): add pose_twist_estimator.launch.py
   * update format
   * update launcher
@@ -124,14 +124,14 @@ Changelog for package yabloc_image_processing
   * Update yabloc document
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* fix(yabloc): fix spell-check CI (`#4268 <https://github.com/youtalk/autoware.universe/issues/4268>`_)
+* fix(yabloc): fix spell-check CI (`#4268 <https://github.com/autowarefoundation/autoware.universe/issues/4268>`_)
   * fix(yabloc): fix typo
   * style(pre-commit): autofix
   * fix more typo
   * style(pre-commit): autofix
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat(yabloc): add camera and vector map localization (`#3946 <https://github.com/youtalk/autoware.universe/issues/3946>`_)
+* feat(yabloc): add camera and vector map localization (`#3946 <https://github.com/autowarefoundation/autoware.universe/issues/3946>`_)
   * adopt scane_case to undistort, segment_filter
   * adopt scane_case to ground_server, ll2_decomposer
   * adopt scane_case to twist_converter, twist_estimator
@@ -277,26 +277,26 @@ Changelog for package yabloc_image_processing
   * update README and some sample images
   * update README.md
   * fix override_camera_frame_id bahaviors
-  * fix some bugs (`#4 <https://github.com/youtalk/autoware.universe/issues/4>`_)
-  * fix: use initialpose from Rviz (`#6 <https://github.com/youtalk/autoware.universe/issues/6>`_)
+  * fix some bugs (`#4 <https://github.com/autowarefoundation/autoware.universe/issues/4>`_)
+  * fix: use initialpose from Rviz (`#6 <https://github.com/autowarefoundation/autoware.universe/issues/6>`_)
   * use initialpose from Rviz to init
   * add description about how-to-set-initialpose
   ---------
-  * misc: add license (`#7 <https://github.com/youtalk/autoware.universe/issues/7>`_)
+  * misc: add license (`#7 <https://github.com/autowarefoundation/autoware.universe/issues/7>`_)
   * WIP: add license description
   * add license description
   * add description about license in README
   ---------
-  * add quick start demo (`#8 <https://github.com/youtalk/autoware.universe/issues/8>`_)
-  * refactor(launch) remove & update obsolete launch files (`#9 <https://github.com/youtalk/autoware.universe/issues/9>`_)
+  * add quick start demo (`#8 <https://github.com/autowarefoundation/autoware.universe/issues/8>`_)
+  * refactor(launch) remove & update obsolete launch files (`#9 <https://github.com/autowarefoundation/autoware.universe/issues/9>`_)
   * delete obsolete launch files
   * update documents
   ---------
-  * docs(readme): update architecture image (`#10 <https://github.com/youtalk/autoware.universe/issues/10>`_)
+  * docs(readme): update architecture image (`#10 <https://github.com/autowarefoundation/autoware.universe/issues/10>`_)
   * replace architecture image in README
   * update some images
   ---------
-  * refactor(pcdless_launc/scripts): remove unnecessary scripts (`#11 <https://github.com/youtalk/autoware.universe/issues/11>`_)
+  * refactor(pcdless_launc/scripts): remove unnecessary scripts (`#11 <https://github.com/autowarefoundation/autoware.universe/issues/11>`_)
   * remove not useful scripts
   * rename scripts &  add descriptions
   * little change
@@ -307,18 +307,18 @@ Changelog for package yabloc_image_processing
   * fix(twist_estimator): use velocity_report by default
   * fix bug
   * debugged, now works
-  * update sample rosbag link (`#14 <https://github.com/youtalk/autoware.universe/issues/14>`_)
-  * feature(graph_segment, gnss_particle_corrector): make some features switchable (`#17 <https://github.com/youtalk/autoware.universe/issues/17>`_)
+  * update sample rosbag link (`#14 <https://github.com/autowarefoundation/autoware.universe/issues/14>`_)
+  * feature(graph_segment, gnss_particle_corrector): make some features switchable (`#17 <https://github.com/autowarefoundation/autoware.universe/issues/17>`_)
   * make additional-graph-segment-pickup disablable
   * enlarge gnss_mahalanobis_distance_threshold in expressway.launch
   ---------
-  * fix: minor fix for multi camera support (`#18 <https://github.com/youtalk/autoware.universe/issues/18>`_)
+  * fix: minor fix for multi camera support (`#18 <https://github.com/autowarefoundation/autoware.universe/issues/18>`_)
   * fix: minor fix for multi camera support
   * update
   * update
   * fix typo
   ---------
-  * refactor(retroactive_resampler): more readable (`#19 <https://github.com/youtalk/autoware.universe/issues/19>`_)
+  * refactor(retroactive_resampler): more readable (`#19 <https://github.com/autowarefoundation/autoware.universe/issues/19>`_)
   * make Hisotry class
   * use boost:adaptors::indexed()
   * add many comment in resampling()
@@ -326,42 +326,42 @@ Changelog for package yabloc_image_processing
   * rename interface of resampler
   * circular_buffer is unnecessary
   ---------
-  * refactor(mpf::predictor) resampling interval control in out of resampler (`#20 <https://github.com/youtalk/autoware.universe/issues/20>`_)
+  * refactor(mpf::predictor) resampling interval control in out of resampler (`#20 <https://github.com/autowarefoundation/autoware.universe/issues/20>`_)
   * resampling interval management should be done out of resample()
   * resampler class throw exeption rather than optional
   * split files for resampling_history
   * split files for experimental/suspention_adaptor
   ---------
-  * refactor(mpf::predictor): just refactoring (`#21 <https://github.com/youtalk/autoware.universe/issues/21>`_)
+  * refactor(mpf::predictor): just refactoring (`#21 <https://github.com/autowarefoundation/autoware.universe/issues/21>`_)
   * remove obsolete functions
   * remove test of predictor
   * remove remapping in pf.launch.xml for suspension_adapator
   * add some comments
   ---------
-  * fix(twist_estimator): remove stop filter for velocity (`#23 <https://github.com/youtalk/autoware.universe/issues/23>`_)
-  * feat(pcdless_launch): add multi camera launcher (`#22 <https://github.com/youtalk/autoware.universe/issues/22>`_)
+  * fix(twist_estimator): remove stop filter for velocity (`#23 <https://github.com/autowarefoundation/autoware.universe/issues/23>`_)
+  * feat(pcdless_launch): add multi camera launcher (`#22 <https://github.com/autowarefoundation/autoware.universe/issues/22>`_)
   * feat(pcdless_launch): add multi camera launcher
   * minor fix
   ---------
-  * refactor(CMakeListx.txt): just refactoring (`#24 <https://github.com/youtalk/autoware.universe/issues/24>`_)
+  * refactor(CMakeListx.txt): just refactoring (`#24 <https://github.com/autowarefoundation/autoware.universe/issues/24>`_)
   * refactor imgproc/*/CMakeListx.txt
   * refactor initializer/*/CMakeListx.txt & add gnss_pose_initializer pkg
   * rename some files in twist/ & refactor pf/*/cmakelist
   * refactor validation/*/CMakeListx.txt
   * fix some obsolete executor name
   ---------
-  * fix: rename lsd variables and files (`#26 <https://github.com/youtalk/autoware.universe/issues/26>`_)
-  * misc: reame pcdless to yabloc (`#25 <https://github.com/youtalk/autoware.universe/issues/25>`_)
+  * fix: rename lsd variables and files (`#26 <https://github.com/autowarefoundation/autoware.universe/issues/26>`_)
+  * misc: reame pcdless to yabloc (`#25 <https://github.com/autowarefoundation/autoware.universe/issues/25>`_)
   * rename pcdless to yabloc
   * fix conflict miss
   ---------
-  * visualize path (`#28 <https://github.com/youtalk/autoware.universe/issues/28>`_)
-  * docs: update readme about particle filter (`#30 <https://github.com/youtalk/autoware.universe/issues/30>`_)
+  * visualize path (`#28 <https://github.com/autowarefoundation/autoware.universe/issues/28>`_)
+  * docs: update readme about particle filter (`#30 <https://github.com/autowarefoundation/autoware.universe/issues/30>`_)
   * update mpf/README.md
   * update gnss_corrector/README.md
   * update camera_corrector/README.md
   ---------
-  * feat(segment_filter): publish images with lines and refactor (`#29 <https://github.com/youtalk/autoware.universe/issues/29>`_)
+  * feat(segment_filter): publish images with lines and refactor (`#29 <https://github.com/autowarefoundation/autoware.universe/issues/29>`_)
   * feat(segment_filter): publish images with lines
   * update validation
   * update imgproc (reverted)
@@ -375,47 +375,47 @@ Changelog for package yabloc_image_processing
   * no throw runtime_error (unintentionaly applying format)
   ---------
   Co-authored-by: Kento Yabuuchi <kento.yabuuchi.2@tier4.jp>
-  * catch runtime_error when particle id is invalid (`#31 <https://github.com/youtalk/autoware.universe/issues/31>`_)
-  * return if info is nullopt (`#32 <https://github.com/youtalk/autoware.universe/issues/32>`_)
-  * pose_buffer is sometimes empty (`#33 <https://github.com/youtalk/autoware.universe/issues/33>`_)
-  * use_yaw_of_initialpose (`#34 <https://github.com/youtalk/autoware.universe/issues/34>`_)
-  * feat(interface):  remove incompatible interface (`#35 <https://github.com/youtalk/autoware.universe/issues/35>`_)
+  * catch runtime_error when particle id is invalid (`#31 <https://github.com/autowarefoundation/autoware.universe/issues/31>`_)
+  * return if info is nullopt (`#32 <https://github.com/autowarefoundation/autoware.universe/issues/32>`_)
+  * pose_buffer is sometimes empty (`#33 <https://github.com/autowarefoundation/autoware.universe/issues/33>`_)
+  * use_yaw_of_initialpose (`#34 <https://github.com/autowarefoundation/autoware.universe/issues/34>`_)
+  * feat(interface):  remove incompatible interface (`#35 <https://github.com/autowarefoundation/autoware.universe/issues/35>`_)
   * not use ublox_msg when run as autoware
   * remove twist/kalman/twist & use twist_estimator/twist_with_covariance
   * update particle_array stamp even if the time stamp seems wrong
   ---------
-  * fix: suppress info/warn_stream (`#37 <https://github.com/youtalk/autoware.universe/issues/37>`_)
+  * fix: suppress info/warn_stream (`#37 <https://github.com/autowarefoundation/autoware.universe/issues/37>`_)
   * does not stream undistortion time
   * improve warn stream when skip particle weighting
   * surpress frequency of  warnings during synchronized particle searching
   * fix camera_pose_initializer
   ---------
-  * /switch must not be nice name (`#39 <https://github.com/youtalk/autoware.universe/issues/39>`_)
-  * misc(readme): update readme (`#41 <https://github.com/youtalk/autoware.universe/issues/41>`_)
+  * /switch must not be nice name (`#39 <https://github.com/autowarefoundation/autoware.universe/issues/39>`_)
+  * misc(readme): update readme (`#41 <https://github.com/autowarefoundation/autoware.universe/issues/41>`_)
   * add youtube link and change thumbnail
   * improve input/output topics
   * quick start demo screen image
   * add abstruct architecture and detail architecture
   ---------
-  * docs(rosdep): fix package.xml to ensure build success (`#44 <https://github.com/youtalk/autoware.universe/issues/44>`_)
+  * docs(rosdep): fix package.xml to ensure build success (`#44 <https://github.com/autowarefoundation/autoware.universe/issues/44>`_)
   * fix package.xml to success build
   * add 'rosdep install' in how-to-build
   ---------
-  * add geographiclib in package.xml (`#46 <https://github.com/youtalk/autoware.universe/issues/46>`_)
-  * fix path search error in build stage (`#45 <https://github.com/youtalk/autoware.universe/issues/45>`_)
+  * add geographiclib in package.xml (`#46 <https://github.com/autowarefoundation/autoware.universe/issues/46>`_)
+  * fix path search error in build stage (`#45 <https://github.com/autowarefoundation/autoware.universe/issues/45>`_)
   * fix path search error in build stage
   * fix https://github.com/tier4/YabLoc/pull/45#issuecomment-1546808419
-  * Feature/remove submodule (`#47 <https://github.com/youtalk/autoware.universe/issues/47>`_)
+  * Feature/remove submodule (`#47 <https://github.com/autowarefoundation/autoware.universe/issues/47>`_)
   * remove submodules
   * remove doppler converter
   ---------
-  * feature: change node namespace to /localization/yabloc/** from /localization/** (`#48 <https://github.com/youtalk/autoware.universe/issues/48>`_)
+  * feature: change node namespace to /localization/yabloc/** from /localization/** (`#48 <https://github.com/autowarefoundation/autoware.universe/issues/48>`_)
   * change node namespace
   * update namespace for autoware-mode
   * update namespace in multi_camera.launch
   ---------
-  * removed unstable packages (`#49 <https://github.com/youtalk/autoware.universe/issues/49>`_)
-  * feature: add *.param.yaml to manage parameters (`#50 <https://github.com/youtalk/autoware.universe/issues/50>`_)
+  * removed unstable packages (`#49 <https://github.com/autowarefoundation/autoware.universe/issues/49>`_)
+  * feature: add *.param.yaml to manage parameters (`#50 <https://github.com/autowarefoundation/autoware.universe/issues/50>`_)
   * make *.param.yaml in imgproc packages
   * make *.param.yaml in initializer packages
   * make *.param.yaml in map packages
@@ -426,8 +426,8 @@ Changelog for package yabloc_image_processing
   * remove default parameters
   * fix some remaining invalida parameters
   ---------
-  * does not estimate twist (`#51 <https://github.com/youtalk/autoware.universe/issues/51>`_)
-  * feat(particle_initializer): merge particle_initializer into mpf (`#52 <https://github.com/youtalk/autoware.universe/issues/52>`_)
+  * does not estimate twist (`#51 <https://github.com/autowarefoundation/autoware.universe/issues/51>`_)
+  * feat(particle_initializer): merge particle_initializer into mpf (`#52 <https://github.com/autowarefoundation/autoware.universe/issues/52>`_)
   * feat(particle_initializer): merge particle_initializer to modulalized_particle_filter
   * remove particle_initializer
   * remove debug message
@@ -436,8 +436,8 @@ Changelog for package yabloc_image_processing
   * rename publishing topic
   ---------
   Co-authored-by: Kento Yabuuchi <kento.yabuuchi.2@tier4.jp>
-  * fix: remove ll2_transition_area (`#54 <https://github.com/youtalk/autoware.universe/issues/54>`_)
-  * feature(initializer): combine some initializer packages (`#56 <https://github.com/youtalk/autoware.universe/issues/56>`_)
+  * fix: remove ll2_transition_area (`#54 <https://github.com/autowarefoundation/autoware.universe/issues/54>`_)
+  * feature(initializer): combine some initializer packages (`#56 <https://github.com/autowarefoundation/autoware.universe/issues/56>`_)
   * combine some package about initializer
   * yabloc_pose_initializer works well
   * remove old initializer packages
@@ -445,15 +445,15 @@ Changelog for package yabloc_image_processing
   * fix bug
   * revert initializer mode
   ---------
-  * feature(imgproc): reudce imgproc packages (`#57 <https://github.com/youtalk/autoware.universe/issues/57>`_)
+  * feature(imgproc): reudce imgproc packages (`#57 <https://github.com/autowarefoundation/autoware.universe/issues/57>`_)
   * combine some imgproc packages
   * combine overlay monitors into imgproc
   ---------
-  * feature(validation): remove validation packages (`#58 <https://github.com/youtalk/autoware.universe/issues/58>`_)
+  * feature(validation): remove validation packages (`#58 <https://github.com/autowarefoundation/autoware.universe/issues/58>`_)
   * remove validation packages
   * remove path visualization
   ---------
-  * feature(pf): combine some packages related to particle filter (`#59 <https://github.com/youtalk/autoware.universe/issues/59>`_)
+  * feature(pf): combine some packages related to particle filter (`#59 <https://github.com/autowarefoundation/autoware.universe/issues/59>`_)
   * create yabloc_particle_filter
   * combine gnss_particle_corrector
   * combine ll2_cost_map
@@ -462,7 +462,7 @@ Changelog for package yabloc_image_processing
   * split README & remove obsolete scripts
   * fix config path of multi_camera mode
   ---------
-  * feature: combine map and twist packages (`#60 <https://github.com/youtalk/autoware.universe/issues/60>`_)
+  * feature: combine map and twist packages (`#60 <https://github.com/autowarefoundation/autoware.universe/issues/60>`_)
   * removed some twist nodes & rename remains to yabloc_twist
   * fix launch files for yabloc_twist
   * move map packages to yabloc_common

--- a/localization/yabloc/yabloc_monitor/CHANGELOG.rst
+++ b/localization/yabloc/yabloc_monitor/CHANGELOG.rst
@@ -5,8 +5,8 @@ Changelog for package yabloc_monitor
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* chore(localization, map): remove maintainer (`#7940 <https://github.com/youtalk/autoware.universe/issues/7940>`_)
-* feat(yabloc_monitor): componentize yabloc_monitor node (`#7509 <https://github.com/youtalk/autoware.universe/issues/7509>`_)
+* chore(localization, map): remove maintainer (`#7940 <https://github.com/autowarefoundation/autoware.universe/issues/7940>`_)
+* feat(yabloc_monitor): componentize yabloc_monitor node (`#7509 <https://github.com/autowarefoundation/autoware.universe/issues/7509>`_)
   * change node to component
   * fix launch file & cmake
   ---------
@@ -14,7 +14,7 @@ Changelog for package yabloc_monitor
 
 0.26.0 (2024-04-03)
 -------------------
-* chore(yabloc): rework parameters (`#6170 <https://github.com/youtalk/autoware.universe/issues/6170>`_)
+* chore(yabloc): rework parameters (`#6170 <https://github.com/autowarefoundation/autoware.universe/issues/6170>`_)
   * introduce json schema for ground_server
   * introduce json schema for ll2_decomposer
   * style(pre-commit): autofix
@@ -37,13 +37,13 @@ Changelog for package yabloc_monitor
   * style(pre-commit): autofix
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* chore: add localization & mapping maintainers (`#6085 <https://github.com/youtalk/autoware.universe/issues/6085>`_)
+* chore: add localization & mapping maintainers (`#6085 <https://github.com/autowarefoundation/autoware.universe/issues/6085>`_)
   * Added lm maintainers
   * Add more
   * Fixed maintainer
   ---------
-* chore: add maintainer in localization and map packages (`#4501 <https://github.com/youtalk/autoware.universe/issues/4501>`_)
-* feat(yabloc_monitor): add yabloc_monitor (`#4395 <https://github.com/youtalk/autoware.universe/issues/4395>`_)
+* chore: add maintainer in localization and map packages (`#4501 <https://github.com/autowarefoundation/autoware.universe/issues/4501>`_)
+* feat(yabloc_monitor): add yabloc_monitor (`#4395 <https://github.com/autowarefoundation/autoware.universe/issues/4395>`_)
   * feat(yabloc_monitor): add yabloc_monitor
   * style(pre-commit): autofix
   * add readme

--- a/localization/yabloc/yabloc_particle_filter/CHANGELOG.rst
+++ b/localization/yabloc/yabloc_particle_filter/CHANGELOG.rst
@@ -5,8 +5,8 @@ Changelog for package yabloc_particle_filter
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/youtalk/autoware.universe/issues/7594>`_)
-* refactor(yabloc_particle_filter): apply static analysis (`#7519 <https://github.com/youtalk/autoware.universe/issues/7519>`_)
+* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/autowarefoundation/autoware.universe/issues/7594>`_)
+* refactor(yabloc_particle_filter): apply static analysis (`#7519 <https://github.com/autowarefoundation/autoware.universe/issues/7519>`_)
   * removed unused
   * style(pre-commit): autofix
   * removed unused
@@ -17,9 +17,9 @@ Changelog for package yabloc_particle_filter
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Kento Yabuuchi <moc.liamg.8y8@gmail.com>
-* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/youtalk/autoware.universe/issues/7538>`_)
+* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/autowarefoundation/autoware.universe/issues/7538>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* refactor(yabloc_common): apply static analysis (`#7481 <https://github.com/youtalk/autoware.universe/issues/7481>`_)
+* refactor(yabloc_common): apply static analysis (`#7481 <https://github.com/autowarefoundation/autoware.universe/issues/7481>`_)
   * refactor based on linter
   * restore unwanted change
   * remove unnecessary comment
@@ -28,7 +28,7 @@ Changelog for package yabloc_particle_filter
   * add static cast
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat(yabloc_particle_filter): componentize yabloc_particle_filter nodes (`#7305 <https://github.com/youtalk/autoware.universe/issues/7305>`_)
+* feat(yabloc_particle_filter): componentize yabloc_particle_filter nodes (`#7305 <https://github.com/autowarefoundation/autoware.universe/issues/7305>`_)
   * componentize particle predictor
   * componentize particle visualizer
   * componentize particle correctors
@@ -39,7 +39,7 @@ Changelog for package yabloc_particle_filter
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Kotaro Yoshimoto <pythagora.yoshimoto@gmail.com>
-* fix(yabloc): suppress no viable conversion error (`#7299 <https://github.com/youtalk/autoware.universe/issues/7299>`_)
+* fix(yabloc): suppress no viable conversion error (`#7299 <https://github.com/autowarefoundation/autoware.universe/issues/7299>`_)
   * use tier4_autoware_utils instead of yabloc::Color
   * use static_cast to convert Color to RGBA
   * use tier4_autoware_utils instead of yabloc::Color
@@ -47,7 +47,7 @@ Changelog for package yabloc_particle_filter
   * style(pre-commit): autofix
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat(yabloc_common): componentize yabloc_common nodes (`#7143 <https://github.com/youtalk/autoware.universe/issues/7143>`_)
+* feat(yabloc_common): componentize yabloc_common nodes (`#7143 <https://github.com/autowarefoundation/autoware.universe/issues/7143>`_)
   * make executables component
   * log output changes to both
   * style(pre-commit): autofix
@@ -56,12 +56,12 @@ Changelog for package yabloc_particle_filter
   * style(pre-commit): autofix
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* chore(glog): add initialization check (`#6792 <https://github.com/youtalk/autoware.universe/issues/6792>`_)
+* chore(glog): add initialization check (`#6792 <https://github.com/autowarefoundation/autoware.universe/issues/6792>`_)
 * Contributors: Kento Yabuuchi, Kosuke Takeuchi, Masaki Baba, Takamasa Horibe, Takayuki Murooka, Yutaka Kondo
 
 0.26.0 (2024-04-03)
 -------------------
-* chore(yabloc): rework parameters (`#6170 <https://github.com/youtalk/autoware.universe/issues/6170>`_)
+* chore(yabloc): rework parameters (`#6170 <https://github.com/autowarefoundation/autoware.universe/issues/6170>`_)
   * introduce json schema for ground_server
   * introduce json schema for ll2_decomposer
   * style(pre-commit): autofix
@@ -84,29 +84,29 @@ Changelog for package yabloc_particle_filter
   * style(pre-commit): autofix
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* chore: add localization & mapping maintainers (`#6085 <https://github.com/youtalk/autoware.universe/issues/6085>`_)
+* chore: add localization & mapping maintainers (`#6085 <https://github.com/autowarefoundation/autoware.universe/issues/6085>`_)
   * Added lm maintainers
   * Add more
   * Fixed maintainer
   ---------
-* feat(yabloc): add yabloc trigger service to suspend and restart the estimation (`#6076 <https://github.com/youtalk/autoware.universe/issues/6076>`_)
+* feat(yabloc): add yabloc trigger service to suspend and restart the estimation (`#6076 <https://github.com/autowarefoundation/autoware.universe/issues/6076>`_)
   * change arg default value
   * add yabloc_trigger_service
   * fix misc
   ---------
-* refactor(localization_packages): remove unused <depend> in packages.xml files (`#5171 <https://github.com/youtalk/autoware.universe/issues/5171>`_)
+* refactor(localization_packages): remove unused <depend> in packages.xml files (`#5171 <https://github.com/autowarefoundation/autoware.universe/issues/5171>`_)
   Co-authored-by: yamato-ando <Yamato ANDO>
-* chore: add maintainer in localization and map packages (`#4501 <https://github.com/youtalk/autoware.universe/issues/4501>`_)
-* refactor(yabloc): replace deprecated rosidl API (`#4423 <https://github.com/youtalk/autoware.universe/issues/4423>`_)
+* chore: add maintainer in localization and map packages (`#4501 <https://github.com/autowarefoundation/autoware.universe/issues/4501>`_)
+* refactor(yabloc): replace deprecated rosidl API (`#4423 <https://github.com/autowarefoundation/autoware.universe/issues/4423>`_)
   * refactor(yabloc_particle_filter): remove deprecated cmake ros2idl API
   * refactor(yabloc_pose_initializer): remove deprecated cmake ros2idl API
   ---------
-* feat(yabloc): change namespace (`#4389 <https://github.com/youtalk/autoware.universe/issues/4389>`_)
+* feat(yabloc): change namespace (`#4389 <https://github.com/autowarefoundation/autoware.universe/issues/4389>`_)
   * fix(yabloc): update namespace
   * fix
   ---------
-* fix(yabloc_particle_filter): fix typo (`#4332 <https://github.com/youtalk/autoware.universe/issues/4332>`_)
-* fix(yabloc): fix typo (`#4281 <https://github.com/youtalk/autoware.universe/issues/4281>`_)
+* fix(yabloc_particle_filter): fix typo (`#4332 <https://github.com/autowarefoundation/autoware.universe/issues/4332>`_)
+* fix(yabloc): fix typo (`#4281 <https://github.com/autowarefoundation/autoware.universe/issues/4281>`_)
   * fix(yabloc): fix typo
   * fix Kinv and mean_pose
   * style(pre-commit): autofix
@@ -117,7 +117,7 @@ Changelog for package yabloc_particle_filter
   * fix typo
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat: use `pose_source` and `twist_source` for selecting localization methods (`#4257 <https://github.com/youtalk/autoware.universe/issues/4257>`_)
+* feat: use `pose_source` and `twist_source` for selecting localization methods (`#4257 <https://github.com/autowarefoundation/autoware.universe/issues/4257>`_)
   * feat(tier4_localization_launch): add pose_twist_estimator.launch.py
   * update format
   * update launcher
@@ -142,14 +142,14 @@ Changelog for package yabloc_particle_filter
   * Update yabloc document
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* fix(yabloc): fix spell-check CI (`#4268 <https://github.com/youtalk/autoware.universe/issues/4268>`_)
+* fix(yabloc): fix spell-check CI (`#4268 <https://github.com/autowarefoundation/autoware.universe/issues/4268>`_)
   * fix(yabloc): fix typo
   * style(pre-commit): autofix
   * fix more typo
   * style(pre-commit): autofix
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat(yabloc): add camera and vector map localization (`#3946 <https://github.com/youtalk/autoware.universe/issues/3946>`_)
+* feat(yabloc): add camera and vector map localization (`#3946 <https://github.com/autowarefoundation/autoware.universe/issues/3946>`_)
   * adopt scane_case to undistort, segment_filter
   * adopt scane_case to ground_server, ll2_decomposer
   * adopt scane_case to twist_converter, twist_estimator
@@ -295,26 +295,26 @@ Changelog for package yabloc_particle_filter
   * update README and some sample images
   * update README.md
   * fix override_camera_frame_id bahaviors
-  * fix some bugs (`#4 <https://github.com/youtalk/autoware.universe/issues/4>`_)
-  * fix: use initialpose from Rviz (`#6 <https://github.com/youtalk/autoware.universe/issues/6>`_)
+  * fix some bugs (`#4 <https://github.com/autowarefoundation/autoware.universe/issues/4>`_)
+  * fix: use initialpose from Rviz (`#6 <https://github.com/autowarefoundation/autoware.universe/issues/6>`_)
   * use initialpose from Rviz to init
   * add description about how-to-set-initialpose
   ---------
-  * misc: add license (`#7 <https://github.com/youtalk/autoware.universe/issues/7>`_)
+  * misc: add license (`#7 <https://github.com/autowarefoundation/autoware.universe/issues/7>`_)
   * WIP: add license description
   * add license description
   * add description about license in README
   ---------
-  * add quick start demo (`#8 <https://github.com/youtalk/autoware.universe/issues/8>`_)
-  * refactor(launch) remove & update obsolete launch files (`#9 <https://github.com/youtalk/autoware.universe/issues/9>`_)
+  * add quick start demo (`#8 <https://github.com/autowarefoundation/autoware.universe/issues/8>`_)
+  * refactor(launch) remove & update obsolete launch files (`#9 <https://github.com/autowarefoundation/autoware.universe/issues/9>`_)
   * delete obsolete launch files
   * update documents
   ---------
-  * docs(readme): update architecture image (`#10 <https://github.com/youtalk/autoware.universe/issues/10>`_)
+  * docs(readme): update architecture image (`#10 <https://github.com/autowarefoundation/autoware.universe/issues/10>`_)
   * replace architecture image in README
   * update some images
   ---------
-  * refactor(pcdless_launc/scripts): remove unnecessary scripts (`#11 <https://github.com/youtalk/autoware.universe/issues/11>`_)
+  * refactor(pcdless_launc/scripts): remove unnecessary scripts (`#11 <https://github.com/autowarefoundation/autoware.universe/issues/11>`_)
   * remove not useful scripts
   * rename scripts &  add descriptions
   * little change
@@ -325,18 +325,18 @@ Changelog for package yabloc_particle_filter
   * fix(twist_estimator): use velocity_report by default
   * fix bug
   * debugged, now works
-  * update sample rosbag link (`#14 <https://github.com/youtalk/autoware.universe/issues/14>`_)
-  * feature(graph_segment, gnss_particle_corrector): make some features switchable (`#17 <https://github.com/youtalk/autoware.universe/issues/17>`_)
+  * update sample rosbag link (`#14 <https://github.com/autowarefoundation/autoware.universe/issues/14>`_)
+  * feature(graph_segment, gnss_particle_corrector): make some features switchable (`#17 <https://github.com/autowarefoundation/autoware.universe/issues/17>`_)
   * make additional-graph-segment-pickup disablable
   * enlarge gnss_mahalanobis_distance_threshold in expressway.launch
   ---------
-  * fix: minor fix for multi camera support (`#18 <https://github.com/youtalk/autoware.universe/issues/18>`_)
+  * fix: minor fix for multi camera support (`#18 <https://github.com/autowarefoundation/autoware.universe/issues/18>`_)
   * fix: minor fix for multi camera support
   * update
   * update
   * fix typo
   ---------
-  * refactor(retroactive_resampler): more readable (`#19 <https://github.com/youtalk/autoware.universe/issues/19>`_)
+  * refactor(retroactive_resampler): more readable (`#19 <https://github.com/autowarefoundation/autoware.universe/issues/19>`_)
   * make Hisotry class
   * use boost:adaptors::indexed()
   * add many comment in resampling()
@@ -344,42 +344,42 @@ Changelog for package yabloc_particle_filter
   * rename interface of resampler
   * circular_buffer is unnecessary
   ---------
-  * refactor(mpf::predictor) resampling interval control in out of resampler (`#20 <https://github.com/youtalk/autoware.universe/issues/20>`_)
+  * refactor(mpf::predictor) resampling interval control in out of resampler (`#20 <https://github.com/autowarefoundation/autoware.universe/issues/20>`_)
   * resampling interval management should be done out of resample()
   * resampler class throw exeption rather than optional
   * split files for resampling_history
   * split files for experimental/suspention_adaptor
   ---------
-  * refactor(mpf::predictor): just refactoring (`#21 <https://github.com/youtalk/autoware.universe/issues/21>`_)
+  * refactor(mpf::predictor): just refactoring (`#21 <https://github.com/autowarefoundation/autoware.universe/issues/21>`_)
   * remove obsolete functions
   * remove test of predictor
   * remove remapping in pf.launch.xml for suspension_adapator
   * add some comments
   ---------
-  * fix(twist_estimator): remove stop filter for velocity (`#23 <https://github.com/youtalk/autoware.universe/issues/23>`_)
-  * feat(pcdless_launch): add multi camera launcher (`#22 <https://github.com/youtalk/autoware.universe/issues/22>`_)
+  * fix(twist_estimator): remove stop filter for velocity (`#23 <https://github.com/autowarefoundation/autoware.universe/issues/23>`_)
+  * feat(pcdless_launch): add multi camera launcher (`#22 <https://github.com/autowarefoundation/autoware.universe/issues/22>`_)
   * feat(pcdless_launch): add multi camera launcher
   * minor fix
   ---------
-  * refactor(CMakeListx.txt): just refactoring (`#24 <https://github.com/youtalk/autoware.universe/issues/24>`_)
+  * refactor(CMakeListx.txt): just refactoring (`#24 <https://github.com/autowarefoundation/autoware.universe/issues/24>`_)
   * refactor imgproc/*/CMakeListx.txt
   * refactor initializer/*/CMakeListx.txt & add gnss_pose_initializer pkg
   * rename some files in twist/ & refactor pf/*/cmakelist
   * refactor validation/*/CMakeListx.txt
   * fix some obsolete executor name
   ---------
-  * fix: rename lsd variables and files (`#26 <https://github.com/youtalk/autoware.universe/issues/26>`_)
-  * misc: reame pcdless to yabloc (`#25 <https://github.com/youtalk/autoware.universe/issues/25>`_)
+  * fix: rename lsd variables and files (`#26 <https://github.com/autowarefoundation/autoware.universe/issues/26>`_)
+  * misc: reame pcdless to yabloc (`#25 <https://github.com/autowarefoundation/autoware.universe/issues/25>`_)
   * rename pcdless to yabloc
   * fix conflict miss
   ---------
-  * visualize path (`#28 <https://github.com/youtalk/autoware.universe/issues/28>`_)
-  * docs: update readme about particle filter (`#30 <https://github.com/youtalk/autoware.universe/issues/30>`_)
+  * visualize path (`#28 <https://github.com/autowarefoundation/autoware.universe/issues/28>`_)
+  * docs: update readme about particle filter (`#30 <https://github.com/autowarefoundation/autoware.universe/issues/30>`_)
   * update mpf/README.md
   * update gnss_corrector/README.md
   * update camera_corrector/README.md
   ---------
-  * feat(segment_filter): publish images with lines and refactor (`#29 <https://github.com/youtalk/autoware.universe/issues/29>`_)
+  * feat(segment_filter): publish images with lines and refactor (`#29 <https://github.com/autowarefoundation/autoware.universe/issues/29>`_)
   * feat(segment_filter): publish images with lines
   * update validation
   * update imgproc (reverted)
@@ -393,47 +393,47 @@ Changelog for package yabloc_particle_filter
   * no throw runtime_error (unintentionaly applying format)
   ---------
   Co-authored-by: Kento Yabuuchi <kento.yabuuchi.2@tier4.jp>
-  * catch runtime_error when particle id is invalid (`#31 <https://github.com/youtalk/autoware.universe/issues/31>`_)
-  * return if info is nullopt (`#32 <https://github.com/youtalk/autoware.universe/issues/32>`_)
-  * pose_buffer is sometimes empty (`#33 <https://github.com/youtalk/autoware.universe/issues/33>`_)
-  * use_yaw_of_initialpose (`#34 <https://github.com/youtalk/autoware.universe/issues/34>`_)
-  * feat(interface):  remove incompatible interface (`#35 <https://github.com/youtalk/autoware.universe/issues/35>`_)
+  * catch runtime_error when particle id is invalid (`#31 <https://github.com/autowarefoundation/autoware.universe/issues/31>`_)
+  * return if info is nullopt (`#32 <https://github.com/autowarefoundation/autoware.universe/issues/32>`_)
+  * pose_buffer is sometimes empty (`#33 <https://github.com/autowarefoundation/autoware.universe/issues/33>`_)
+  * use_yaw_of_initialpose (`#34 <https://github.com/autowarefoundation/autoware.universe/issues/34>`_)
+  * feat(interface):  remove incompatible interface (`#35 <https://github.com/autowarefoundation/autoware.universe/issues/35>`_)
   * not use ublox_msg when run as autoware
   * remove twist/kalman/twist & use twist_estimator/twist_with_covariance
   * update particle_array stamp even if the time stamp seems wrong
   ---------
-  * fix: suppress info/warn_stream (`#37 <https://github.com/youtalk/autoware.universe/issues/37>`_)
+  * fix: suppress info/warn_stream (`#37 <https://github.com/autowarefoundation/autoware.universe/issues/37>`_)
   * does not stream undistortion time
   * improve warn stream when skip particle weighting
   * surpress frequency of  warnings during synchronized particle searching
   * fix camera_pose_initializer
   ---------
-  * /switch must not be nice name (`#39 <https://github.com/youtalk/autoware.universe/issues/39>`_)
-  * misc(readme): update readme (`#41 <https://github.com/youtalk/autoware.universe/issues/41>`_)
+  * /switch must not be nice name (`#39 <https://github.com/autowarefoundation/autoware.universe/issues/39>`_)
+  * misc(readme): update readme (`#41 <https://github.com/autowarefoundation/autoware.universe/issues/41>`_)
   * add youtube link and change thumbnail
   * improve input/output topics
   * quick start demo screen image
   * add abstruct architecture and detail architecture
   ---------
-  * docs(rosdep): fix package.xml to ensure build success (`#44 <https://github.com/youtalk/autoware.universe/issues/44>`_)
+  * docs(rosdep): fix package.xml to ensure build success (`#44 <https://github.com/autowarefoundation/autoware.universe/issues/44>`_)
   * fix package.xml to success build
   * add 'rosdep install' in how-to-build
   ---------
-  * add geographiclib in package.xml (`#46 <https://github.com/youtalk/autoware.universe/issues/46>`_)
-  * fix path search error in build stage (`#45 <https://github.com/youtalk/autoware.universe/issues/45>`_)
+  * add geographiclib in package.xml (`#46 <https://github.com/autowarefoundation/autoware.universe/issues/46>`_)
+  * fix path search error in build stage (`#45 <https://github.com/autowarefoundation/autoware.universe/issues/45>`_)
   * fix path search error in build stage
   * fix https://github.com/tier4/YabLoc/pull/45#issuecomment-1546808419
-  * Feature/remove submodule (`#47 <https://github.com/youtalk/autoware.universe/issues/47>`_)
+  * Feature/remove submodule (`#47 <https://github.com/autowarefoundation/autoware.universe/issues/47>`_)
   * remove submodules
   * remove doppler converter
   ---------
-  * feature: change node namespace to /localization/yabloc/** from /localization/** (`#48 <https://github.com/youtalk/autoware.universe/issues/48>`_)
+  * feature: change node namespace to /localization/yabloc/** from /localization/** (`#48 <https://github.com/autowarefoundation/autoware.universe/issues/48>`_)
   * change node namespace
   * update namespace for autoware-mode
   * update namespace in multi_camera.launch
   ---------
-  * removed unstable packages (`#49 <https://github.com/youtalk/autoware.universe/issues/49>`_)
-  * feature: add *.param.yaml to manage parameters (`#50 <https://github.com/youtalk/autoware.universe/issues/50>`_)
+  * removed unstable packages (`#49 <https://github.com/autowarefoundation/autoware.universe/issues/49>`_)
+  * feature: add *.param.yaml to manage parameters (`#50 <https://github.com/autowarefoundation/autoware.universe/issues/50>`_)
   * make *.param.yaml in imgproc packages
   * make *.param.yaml in initializer packages
   * make *.param.yaml in map packages
@@ -444,8 +444,8 @@ Changelog for package yabloc_particle_filter
   * remove default parameters
   * fix some remaining invalida parameters
   ---------
-  * does not estimate twist (`#51 <https://github.com/youtalk/autoware.universe/issues/51>`_)
-  * feat(particle_initializer): merge particle_initializer into mpf (`#52 <https://github.com/youtalk/autoware.universe/issues/52>`_)
+  * does not estimate twist (`#51 <https://github.com/autowarefoundation/autoware.universe/issues/51>`_)
+  * feat(particle_initializer): merge particle_initializer into mpf (`#52 <https://github.com/autowarefoundation/autoware.universe/issues/52>`_)
   * feat(particle_initializer): merge particle_initializer to modulalized_particle_filter
   * remove particle_initializer
   * remove debug message
@@ -454,8 +454,8 @@ Changelog for package yabloc_particle_filter
   * rename publishing topic
   ---------
   Co-authored-by: Kento Yabuuchi <kento.yabuuchi.2@tier4.jp>
-  * fix: remove ll2_transition_area (`#54 <https://github.com/youtalk/autoware.universe/issues/54>`_)
-  * feature(initializer): combine some initializer packages (`#56 <https://github.com/youtalk/autoware.universe/issues/56>`_)
+  * fix: remove ll2_transition_area (`#54 <https://github.com/autowarefoundation/autoware.universe/issues/54>`_)
+  * feature(initializer): combine some initializer packages (`#56 <https://github.com/autowarefoundation/autoware.universe/issues/56>`_)
   * combine some package about initializer
   * yabloc_pose_initializer works well
   * remove old initializer packages
@@ -463,15 +463,15 @@ Changelog for package yabloc_particle_filter
   * fix bug
   * revert initializer mode
   ---------
-  * feature(imgproc): reudce imgproc packages (`#57 <https://github.com/youtalk/autoware.universe/issues/57>`_)
+  * feature(imgproc): reudce imgproc packages (`#57 <https://github.com/autowarefoundation/autoware.universe/issues/57>`_)
   * combine some imgproc packages
   * combine overlay monitors into imgproc
   ---------
-  * feature(validation): remove validation packages (`#58 <https://github.com/youtalk/autoware.universe/issues/58>`_)
+  * feature(validation): remove validation packages (`#58 <https://github.com/autowarefoundation/autoware.universe/issues/58>`_)
   * remove validation packages
   * remove path visualization
   ---------
-  * feature(pf): combine some packages related to particle filter (`#59 <https://github.com/youtalk/autoware.universe/issues/59>`_)
+  * feature(pf): combine some packages related to particle filter (`#59 <https://github.com/autowarefoundation/autoware.universe/issues/59>`_)
   * create yabloc_particle_filter
   * combine gnss_particle_corrector
   * combine ll2_cost_map
@@ -480,7 +480,7 @@ Changelog for package yabloc_particle_filter
   * split README & remove obsolete scripts
   * fix config path of multi_camera mode
   ---------
-  * feature: combine map and twist packages (`#60 <https://github.com/youtalk/autoware.universe/issues/60>`_)
+  * feature: combine map and twist packages (`#60 <https://github.com/autowarefoundation/autoware.universe/issues/60>`_)
   * removed some twist nodes & rename remains to yabloc_twist
   * fix launch files for yabloc_twist
   * move map packages to yabloc_common

--- a/localization/yabloc/yabloc_pose_initializer/CHANGELOG.rst
+++ b/localization/yabloc/yabloc_pose_initializer/CHANGELOG.rst
@@ -5,31 +5,31 @@ Changelog for package yabloc_pose_initializer
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* feat(pose_initializer, ndt_scan_matcher): check initial pose result and publish diag (`#8275 <https://github.com/youtalk/autoware.universe/issues/8275>`_)
+* feat(pose_initializer, ndt_scan_matcher): check initial pose result and publish diag (`#8275 <https://github.com/autowarefoundation/autoware.universe/issues/8275>`_)
   * feat(localization): check initial pose result and publish diag
   * fix: refactor
   * feat: update README
   * fix: rename reliability to reliable
   * feat: always return true in yabloc module
   ---------
-* refactor(yabloc_pose_initializer): apply static analysis (`#7719 <https://github.com/youtalk/autoware.universe/issues/7719>`_)
+* refactor(yabloc_pose_initializer): apply static analysis (`#7719 <https://github.com/autowarefoundation/autoware.universe/issues/7719>`_)
   * refactor based on linter
   * style(pre-commit): autofix
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat: add `autoware\_` prefix to `lanelet2_extension` (`#7640 <https://github.com/youtalk/autoware.universe/issues/7640>`_)
-* fix: replace deprecated header in Jazzy (`#7603 <https://github.com/youtalk/autoware.universe/issues/7603>`_)
+* feat: add `autoware\_` prefix to `lanelet2_extension` (`#7640 <https://github.com/autowarefoundation/autoware.universe/issues/7640>`_)
+* fix: replace deprecated header in Jazzy (`#7603 <https://github.com/autowarefoundation/autoware.universe/issues/7603>`_)
   * Use cv_bridge.hpp if available
   * Fix image_geometry deprecated header
   * Add comment for __has_include
   ---------
   Co-authored-by: Kotaro Yoshimoto <pythagora.yoshimoto@gmail.com>
-* feat(yabloc_pose_initializer): componentize yabloc_pose_initializer node (`#7506 <https://github.com/youtalk/autoware.universe/issues/7506>`_)
+* feat(yabloc_pose_initializer): componentize yabloc_pose_initializer node (`#7506 <https://github.com/autowarefoundation/autoware.universe/issues/7506>`_)
   * change the node to component
   * remove useless node.cpp
   * add rclcpp_components as dependency
   ---------
-* fix(yabloc): suppress no viable conversion error (`#7299 <https://github.com/youtalk/autoware.universe/issues/7299>`_)
+* fix(yabloc): suppress no viable conversion error (`#7299 <https://github.com/autowarefoundation/autoware.universe/issues/7299>`_)
   * use tier4_autoware_utils instead of yabloc::Color
   * use static_cast to convert Color to RGBA
   * use tier4_autoware_utils instead of yabloc::Color
@@ -37,17 +37,17 @@ Changelog for package yabloc_pose_initializer
   * style(pre-commit): autofix
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat!: replace autoware_auto_msgs with autoware_msgs for localization modules (`#7243 <https://github.com/youtalk/autoware.universe/issues/7243>`_)
+* feat!: replace autoware_auto_msgs with autoware_msgs for localization modules (`#7243 <https://github.com/autowarefoundation/autoware.universe/issues/7243>`_)
   Co-authored-by: Cynthia Liu <cynthia.liu@autocore.ai>
   Co-authored-by: NorahXiong <norah.xiong@autocore.ai>
   Co-authored-by: beginningfan <beginning.fan@autocore.ai>
-* perf(yabloc): fix performance warning of iterateByValue (`#6929 <https://github.com/youtalk/autoware.universe/issues/6929>`_)
+* perf(yabloc): fix performance warning of iterateByValue (`#6929 <https://github.com/autowarefoundation/autoware.universe/issues/6929>`_)
 * Contributors: Kento Yabuuchi, Masaki Baba, Ryohsuke Mitsudome, RyuYamamoto, Ryuta Kambe, Yutaka Kondo, ぐるぐる
 
 0.26.0 (2024-04-03)
 -------------------
-* build(yabloc_pose_initializer): fix dependencies (`#6190 <https://github.com/youtalk/autoware.universe/issues/6190>`_)
-* chore(yabloc): rework parameters (`#6170 <https://github.com/youtalk/autoware.universe/issues/6170>`_)
+* build(yabloc_pose_initializer): fix dependencies (`#6190 <https://github.com/autowarefoundation/autoware.universe/issues/6190>`_)
+* chore(yabloc): rework parameters (`#6170 <https://github.com/autowarefoundation/autoware.universe/issues/6170>`_)
   * introduce json schema for ground_server
   * introduce json schema for ll2_decomposer
   * style(pre-commit): autofix
@@ -70,19 +70,19 @@ Changelog for package yabloc_pose_initializer
   * style(pre-commit): autofix
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* chore: add localization & mapping maintainers (`#6085 <https://github.com/youtalk/autoware.universe/issues/6085>`_)
+* chore: add localization & mapping maintainers (`#6085 <https://github.com/autowarefoundation/autoware.universe/issues/6085>`_)
   * Added lm maintainers
   * Add more
   * Fixed maintainer
   ---------
-* refactor(localization_packages): remove unused <depend> in packages.xml files (`#5171 <https://github.com/youtalk/autoware.universe/issues/5171>`_)
+* refactor(localization_packages): remove unused <depend> in packages.xml files (`#5171 <https://github.com/autowarefoundation/autoware.universe/issues/5171>`_)
   Co-authored-by: yamato-ando <Yamato ANDO>
-* build(yabloc_pose_initializer): remove downloading logic from CMake (`#4905 <https://github.com/youtalk/autoware.universe/issues/4905>`_)
+* build(yabloc_pose_initializer): remove downloading logic from CMake (`#4905 <https://github.com/autowarefoundation/autoware.universe/issues/4905>`_)
   * remove downloading logic from Cmake
   * build(yabloc_pose_initializer): remove downloading logic from CMake
   * build(yabloc_pose_initializer): update default model path in launch file
   ---------
-* refactor(yabloc_pose_initializer): use cpp DNN module instead of python (`#5025 <https://github.com/youtalk/autoware.universe/issues/5025>`_)
+* refactor(yabloc_pose_initializer): use cpp DNN module instead of python (`#5025 <https://github.com/autowarefoundation/autoware.universe/issues/5025>`_)
   * cannot include yabloc_pose_initializer.srv
   * launch semantic_segmentation_cpp
   * implement DNN inference as C++
@@ -98,16 +98,16 @@ Changelog for package yabloc_pose_initializer
   * style(pre-commit): autofix
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* chore: add maintainer in localization and map packages (`#4501 <https://github.com/youtalk/autoware.universe/issues/4501>`_)
-* refactor(yabloc): replace deprecated rosidl API (`#4423 <https://github.com/youtalk/autoware.universe/issues/4423>`_)
+* chore: add maintainer in localization and map packages (`#4501 <https://github.com/autowarefoundation/autoware.universe/issues/4501>`_)
+* refactor(yabloc): replace deprecated rosidl API (`#4423 <https://github.com/autowarefoundation/autoware.universe/issues/4423>`_)
   * refactor(yabloc_particle_filter): remove deprecated cmake ros2idl API
   * refactor(yabloc_pose_initializer): remove deprecated cmake ros2idl API
   ---------
-* feat(yabloc): change namespace (`#4389 <https://github.com/youtalk/autoware.universe/issues/4389>`_)
+* feat(yabloc): change namespace (`#4389 <https://github.com/autowarefoundation/autoware.universe/issues/4389>`_)
   * fix(yabloc): update namespace
   * fix
   ---------
-* feat(yabloc_pose_initializer): make yabloc independent of dnn model by default (`#4296 <https://github.com/youtalk/autoware.universe/issues/4296>`_)
+* feat(yabloc_pose_initializer): make yabloc independent of dnn model by default (`#4296 <https://github.com/autowarefoundation/autoware.universe/issues/4296>`_)
   * care no dnn model exists
   * modify segmentation_srv to inform inference failure
   * add documentation
@@ -116,7 +116,7 @@ Changelog for package yabloc_pose_initializer
   * make const variable be capital
   * use std::optional rather than reference arg
   ---------
-* fix(yabloc): fix typo (`#4281 <https://github.com/youtalk/autoware.universe/issues/4281>`_)
+* fix(yabloc): fix typo (`#4281 <https://github.com/autowarefoundation/autoware.universe/issues/4281>`_)
   * fix(yabloc): fix typo
   * fix Kinv and mean_pose
   * style(pre-commit): autofix
@@ -127,7 +127,7 @@ Changelog for package yabloc_pose_initializer
   * fix typo
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat: use `pose_source` and `twist_source` for selecting localization methods (`#4257 <https://github.com/youtalk/autoware.universe/issues/4257>`_)
+* feat: use `pose_source` and `twist_source` for selecting localization methods (`#4257 <https://github.com/autowarefoundation/autoware.universe/issues/4257>`_)
   * feat(tier4_localization_launch): add pose_twist_estimator.launch.py
   * update format
   * update launcher
@@ -152,9 +152,9 @@ Changelog for package yabloc_pose_initializer
   * Update yabloc document
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* fix(yabloc_pose_initializer): disable downloading artifacts by default (`#4110 <https://github.com/youtalk/autoware.universe/issues/4110>`_)
+* fix(yabloc_pose_initializer): disable downloading artifacts by default (`#4110 <https://github.com/autowarefoundation/autoware.universe/issues/4110>`_)
   Co-authored-by: Esteve Fernandez <esteve.fernadnez@tier4.jp>
-* feat(yabloc): add camera and vector map localization (`#3946 <https://github.com/youtalk/autoware.universe/issues/3946>`_)
+* feat(yabloc): add camera and vector map localization (`#3946 <https://github.com/autowarefoundation/autoware.universe/issues/3946>`_)
   * adopt scane_case to undistort, segment_filter
   * adopt scane_case to ground_server, ll2_decomposer
   * adopt scane_case to twist_converter, twist_estimator
@@ -300,26 +300,26 @@ Changelog for package yabloc_pose_initializer
   * update README and some sample images
   * update README.md
   * fix override_camera_frame_id bahaviors
-  * fix some bugs (`#4 <https://github.com/youtalk/autoware.universe/issues/4>`_)
-  * fix: use initialpose from Rviz (`#6 <https://github.com/youtalk/autoware.universe/issues/6>`_)
+  * fix some bugs (`#4 <https://github.com/autowarefoundation/autoware.universe/issues/4>`_)
+  * fix: use initialpose from Rviz (`#6 <https://github.com/autowarefoundation/autoware.universe/issues/6>`_)
   * use initialpose from Rviz to init
   * add description about how-to-set-initialpose
   ---------
-  * misc: add license (`#7 <https://github.com/youtalk/autoware.universe/issues/7>`_)
+  * misc: add license (`#7 <https://github.com/autowarefoundation/autoware.universe/issues/7>`_)
   * WIP: add license description
   * add license description
   * add description about license in README
   ---------
-  * add quick start demo (`#8 <https://github.com/youtalk/autoware.universe/issues/8>`_)
-  * refactor(launch) remove & update obsolete launch files (`#9 <https://github.com/youtalk/autoware.universe/issues/9>`_)
+  * add quick start demo (`#8 <https://github.com/autowarefoundation/autoware.universe/issues/8>`_)
+  * refactor(launch) remove & update obsolete launch files (`#9 <https://github.com/autowarefoundation/autoware.universe/issues/9>`_)
   * delete obsolete launch files
   * update documents
   ---------
-  * docs(readme): update architecture image (`#10 <https://github.com/youtalk/autoware.universe/issues/10>`_)
+  * docs(readme): update architecture image (`#10 <https://github.com/autowarefoundation/autoware.universe/issues/10>`_)
   * replace architecture image in README
   * update some images
   ---------
-  * refactor(pcdless_launc/scripts): remove unnecessary scripts (`#11 <https://github.com/youtalk/autoware.universe/issues/11>`_)
+  * refactor(pcdless_launc/scripts): remove unnecessary scripts (`#11 <https://github.com/autowarefoundation/autoware.universe/issues/11>`_)
   * remove not useful scripts
   * rename scripts &  add descriptions
   * little change
@@ -330,18 +330,18 @@ Changelog for package yabloc_pose_initializer
   * fix(twist_estimator): use velocity_report by default
   * fix bug
   * debugged, now works
-  * update sample rosbag link (`#14 <https://github.com/youtalk/autoware.universe/issues/14>`_)
-  * feature(graph_segment, gnss_particle_corrector): make some features switchable (`#17 <https://github.com/youtalk/autoware.universe/issues/17>`_)
+  * update sample rosbag link (`#14 <https://github.com/autowarefoundation/autoware.universe/issues/14>`_)
+  * feature(graph_segment, gnss_particle_corrector): make some features switchable (`#17 <https://github.com/autowarefoundation/autoware.universe/issues/17>`_)
   * make additional-graph-segment-pickup disablable
   * enlarge gnss_mahalanobis_distance_threshold in expressway.launch
   ---------
-  * fix: minor fix for multi camera support (`#18 <https://github.com/youtalk/autoware.universe/issues/18>`_)
+  * fix: minor fix for multi camera support (`#18 <https://github.com/autowarefoundation/autoware.universe/issues/18>`_)
   * fix: minor fix for multi camera support
   * update
   * update
   * fix typo
   ---------
-  * refactor(retroactive_resampler): more readable (`#19 <https://github.com/youtalk/autoware.universe/issues/19>`_)
+  * refactor(retroactive_resampler): more readable (`#19 <https://github.com/autowarefoundation/autoware.universe/issues/19>`_)
   * make Hisotry class
   * use boost:adaptors::indexed()
   * add many comment in resampling()
@@ -349,42 +349,42 @@ Changelog for package yabloc_pose_initializer
   * rename interface of resampler
   * circular_buffer is unnecessary
   ---------
-  * refactor(mpf::predictor) resampling interval control in out of resampler (`#20 <https://github.com/youtalk/autoware.universe/issues/20>`_)
+  * refactor(mpf::predictor) resampling interval control in out of resampler (`#20 <https://github.com/autowarefoundation/autoware.universe/issues/20>`_)
   * resampling interval management should be done out of resample()
   * resampler class throw exeption rather than optional
   * split files for resampling_history
   * split files for experimental/suspention_adaptor
   ---------
-  * refactor(mpf::predictor): just refactoring (`#21 <https://github.com/youtalk/autoware.universe/issues/21>`_)
+  * refactor(mpf::predictor): just refactoring (`#21 <https://github.com/autowarefoundation/autoware.universe/issues/21>`_)
   * remove obsolete functions
   * remove test of predictor
   * remove remapping in pf.launch.xml for suspension_adapator
   * add some comments
   ---------
-  * fix(twist_estimator): remove stop filter for velocity (`#23 <https://github.com/youtalk/autoware.universe/issues/23>`_)
-  * feat(pcdless_launch): add multi camera launcher (`#22 <https://github.com/youtalk/autoware.universe/issues/22>`_)
+  * fix(twist_estimator): remove stop filter for velocity (`#23 <https://github.com/autowarefoundation/autoware.universe/issues/23>`_)
+  * feat(pcdless_launch): add multi camera launcher (`#22 <https://github.com/autowarefoundation/autoware.universe/issues/22>`_)
   * feat(pcdless_launch): add multi camera launcher
   * minor fix
   ---------
-  * refactor(CMakeListx.txt): just refactoring (`#24 <https://github.com/youtalk/autoware.universe/issues/24>`_)
+  * refactor(CMakeListx.txt): just refactoring (`#24 <https://github.com/autowarefoundation/autoware.universe/issues/24>`_)
   * refactor imgproc/*/CMakeListx.txt
   * refactor initializer/*/CMakeListx.txt & add gnss_pose_initializer pkg
   * rename some files in twist/ & refactor pf/*/cmakelist
   * refactor validation/*/CMakeListx.txt
   * fix some obsolete executor name
   ---------
-  * fix: rename lsd variables and files (`#26 <https://github.com/youtalk/autoware.universe/issues/26>`_)
-  * misc: reame pcdless to yabloc (`#25 <https://github.com/youtalk/autoware.universe/issues/25>`_)
+  * fix: rename lsd variables and files (`#26 <https://github.com/autowarefoundation/autoware.universe/issues/26>`_)
+  * misc: reame pcdless to yabloc (`#25 <https://github.com/autowarefoundation/autoware.universe/issues/25>`_)
   * rename pcdless to yabloc
   * fix conflict miss
   ---------
-  * visualize path (`#28 <https://github.com/youtalk/autoware.universe/issues/28>`_)
-  * docs: update readme about particle filter (`#30 <https://github.com/youtalk/autoware.universe/issues/30>`_)
+  * visualize path (`#28 <https://github.com/autowarefoundation/autoware.universe/issues/28>`_)
+  * docs: update readme about particle filter (`#30 <https://github.com/autowarefoundation/autoware.universe/issues/30>`_)
   * update mpf/README.md
   * update gnss_corrector/README.md
   * update camera_corrector/README.md
   ---------
-  * feat(segment_filter): publish images with lines and refactor (`#29 <https://github.com/youtalk/autoware.universe/issues/29>`_)
+  * feat(segment_filter): publish images with lines and refactor (`#29 <https://github.com/autowarefoundation/autoware.universe/issues/29>`_)
   * feat(segment_filter): publish images with lines
   * update validation
   * update imgproc (reverted)
@@ -398,47 +398,47 @@ Changelog for package yabloc_pose_initializer
   * no throw runtime_error (unintentionaly applying format)
   ---------
   Co-authored-by: Kento Yabuuchi <kento.yabuuchi.2@tier4.jp>
-  * catch runtime_error when particle id is invalid (`#31 <https://github.com/youtalk/autoware.universe/issues/31>`_)
-  * return if info is nullopt (`#32 <https://github.com/youtalk/autoware.universe/issues/32>`_)
-  * pose_buffer is sometimes empty (`#33 <https://github.com/youtalk/autoware.universe/issues/33>`_)
-  * use_yaw_of_initialpose (`#34 <https://github.com/youtalk/autoware.universe/issues/34>`_)
-  * feat(interface):  remove incompatible interface (`#35 <https://github.com/youtalk/autoware.universe/issues/35>`_)
+  * catch runtime_error when particle id is invalid (`#31 <https://github.com/autowarefoundation/autoware.universe/issues/31>`_)
+  * return if info is nullopt (`#32 <https://github.com/autowarefoundation/autoware.universe/issues/32>`_)
+  * pose_buffer is sometimes empty (`#33 <https://github.com/autowarefoundation/autoware.universe/issues/33>`_)
+  * use_yaw_of_initialpose (`#34 <https://github.com/autowarefoundation/autoware.universe/issues/34>`_)
+  * feat(interface):  remove incompatible interface (`#35 <https://github.com/autowarefoundation/autoware.universe/issues/35>`_)
   * not use ublox_msg when run as autoware
   * remove twist/kalman/twist & use twist_estimator/twist_with_covariance
   * update particle_array stamp even if the time stamp seems wrong
   ---------
-  * fix: suppress info/warn_stream (`#37 <https://github.com/youtalk/autoware.universe/issues/37>`_)
+  * fix: suppress info/warn_stream (`#37 <https://github.com/autowarefoundation/autoware.universe/issues/37>`_)
   * does not stream undistortion time
   * improve warn stream when skip particle weighting
   * surpress frequency of  warnings during synchronized particle searching
   * fix camera_pose_initializer
   ---------
-  * /switch must not be nice name (`#39 <https://github.com/youtalk/autoware.universe/issues/39>`_)
-  * misc(readme): update readme (`#41 <https://github.com/youtalk/autoware.universe/issues/41>`_)
+  * /switch must not be nice name (`#39 <https://github.com/autowarefoundation/autoware.universe/issues/39>`_)
+  * misc(readme): update readme (`#41 <https://github.com/autowarefoundation/autoware.universe/issues/41>`_)
   * add youtube link and change thumbnail
   * improve input/output topics
   * quick start demo screen image
   * add abstruct architecture and detail architecture
   ---------
-  * docs(rosdep): fix package.xml to ensure build success (`#44 <https://github.com/youtalk/autoware.universe/issues/44>`_)
+  * docs(rosdep): fix package.xml to ensure build success (`#44 <https://github.com/autowarefoundation/autoware.universe/issues/44>`_)
   * fix package.xml to success build
   * add 'rosdep install' in how-to-build
   ---------
-  * add geographiclib in package.xml (`#46 <https://github.com/youtalk/autoware.universe/issues/46>`_)
-  * fix path search error in build stage (`#45 <https://github.com/youtalk/autoware.universe/issues/45>`_)
+  * add geographiclib in package.xml (`#46 <https://github.com/autowarefoundation/autoware.universe/issues/46>`_)
+  * fix path search error in build stage (`#45 <https://github.com/autowarefoundation/autoware.universe/issues/45>`_)
   * fix path search error in build stage
   * fix https://github.com/tier4/YabLoc/pull/45#issuecomment-1546808419
-  * Feature/remove submodule (`#47 <https://github.com/youtalk/autoware.universe/issues/47>`_)
+  * Feature/remove submodule (`#47 <https://github.com/autowarefoundation/autoware.universe/issues/47>`_)
   * remove submodules
   * remove doppler converter
   ---------
-  * feature: change node namespace to /localization/yabloc/** from /localization/** (`#48 <https://github.com/youtalk/autoware.universe/issues/48>`_)
+  * feature: change node namespace to /localization/yabloc/** from /localization/** (`#48 <https://github.com/autowarefoundation/autoware.universe/issues/48>`_)
   * change node namespace
   * update namespace for autoware-mode
   * update namespace in multi_camera.launch
   ---------
-  * removed unstable packages (`#49 <https://github.com/youtalk/autoware.universe/issues/49>`_)
-  * feature: add *.param.yaml to manage parameters (`#50 <https://github.com/youtalk/autoware.universe/issues/50>`_)
+  * removed unstable packages (`#49 <https://github.com/autowarefoundation/autoware.universe/issues/49>`_)
+  * feature: add *.param.yaml to manage parameters (`#50 <https://github.com/autowarefoundation/autoware.universe/issues/50>`_)
   * make *.param.yaml in imgproc packages
   * make *.param.yaml in initializer packages
   * make *.param.yaml in map packages
@@ -449,8 +449,8 @@ Changelog for package yabloc_pose_initializer
   * remove default parameters
   * fix some remaining invalida parameters
   ---------
-  * does not estimate twist (`#51 <https://github.com/youtalk/autoware.universe/issues/51>`_)
-  * feat(particle_initializer): merge particle_initializer into mpf (`#52 <https://github.com/youtalk/autoware.universe/issues/52>`_)
+  * does not estimate twist (`#51 <https://github.com/autowarefoundation/autoware.universe/issues/51>`_)
+  * feat(particle_initializer): merge particle_initializer into mpf (`#52 <https://github.com/autowarefoundation/autoware.universe/issues/52>`_)
   * feat(particle_initializer): merge particle_initializer to modulalized_particle_filter
   * remove particle_initializer
   * remove debug message
@@ -459,8 +459,8 @@ Changelog for package yabloc_pose_initializer
   * rename publishing topic
   ---------
   Co-authored-by: Kento Yabuuchi <kento.yabuuchi.2@tier4.jp>
-  * fix: remove ll2_transition_area (`#54 <https://github.com/youtalk/autoware.universe/issues/54>`_)
-  * feature(initializer): combine some initializer packages (`#56 <https://github.com/youtalk/autoware.universe/issues/56>`_)
+  * fix: remove ll2_transition_area (`#54 <https://github.com/autowarefoundation/autoware.universe/issues/54>`_)
+  * feature(initializer): combine some initializer packages (`#56 <https://github.com/autowarefoundation/autoware.universe/issues/56>`_)
   * combine some package about initializer
   * yabloc_pose_initializer works well
   * remove old initializer packages
@@ -468,15 +468,15 @@ Changelog for package yabloc_pose_initializer
   * fix bug
   * revert initializer mode
   ---------
-  * feature(imgproc): reudce imgproc packages (`#57 <https://github.com/youtalk/autoware.universe/issues/57>`_)
+  * feature(imgproc): reudce imgproc packages (`#57 <https://github.com/autowarefoundation/autoware.universe/issues/57>`_)
   * combine some imgproc packages
   * combine overlay monitors into imgproc
   ---------
-  * feature(validation): remove validation packages (`#58 <https://github.com/youtalk/autoware.universe/issues/58>`_)
+  * feature(validation): remove validation packages (`#58 <https://github.com/autowarefoundation/autoware.universe/issues/58>`_)
   * remove validation packages
   * remove path visualization
   ---------
-  * feature(pf): combine some packages related to particle filter (`#59 <https://github.com/youtalk/autoware.universe/issues/59>`_)
+  * feature(pf): combine some packages related to particle filter (`#59 <https://github.com/autowarefoundation/autoware.universe/issues/59>`_)
   * create yabloc_particle_filter
   * combine gnss_particle_corrector
   * combine ll2_cost_map
@@ -485,7 +485,7 @@ Changelog for package yabloc_pose_initializer
   * split README & remove obsolete scripts
   * fix config path of multi_camera mode
   ---------
-  * feature: combine map and twist packages (`#60 <https://github.com/youtalk/autoware.universe/issues/60>`_)
+  * feature: combine map and twist packages (`#60 <https://github.com/autowarefoundation/autoware.universe/issues/60>`_)
   * removed some twist nodes & rename remains to yabloc_twist
   * fix launch files for yabloc_twist
   * move map packages to yabloc_common

--- a/map/autoware_map_height_fitter/CHANGELOG.rst
+++ b/map/autoware_map_height_fitter/CHANGELOG.rst
@@ -5,7 +5,7 @@ Changelog for package autoware_map_height_fitter
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* refactor(map_height_fitter)!: prefix package and namespace with autoware  (`#8421 <https://github.com/youtalk/autoware.universe/issues/8421>`_)
+* refactor(map_height_fitter)!: prefix package and namespace with autoware  (`#8421 <https://github.com/autowarefoundation/autoware.universe/issues/8421>`_)
   * add autoware\_ prefix
   * style(pre-commit): autofix
   * remove duplicated dependency

--- a/map/autoware_map_projection_loader/CHANGELOG.rst
+++ b/map/autoware_map_projection_loader/CHANGELOG.rst
@@ -5,8 +5,8 @@ Changelog for package autoware_map_projection_loader
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* refactor(component_interface_specs): prefix package and namespace with autoware (`#9094 <https://github.com/youtalk/autoware.universe/issues/9094>`_)
-* refactor(map_projection_loader)!: prefix package and namespace with autoware (`#8420 <https://github.com/youtalk/autoware.universe/issues/8420>`_)
+* refactor(component_interface_specs): prefix package and namespace with autoware (`#9094 <https://github.com/autowarefoundation/autoware.universe/issues/9094>`_)
+* refactor(map_projection_loader)!: prefix package and namespace with autoware (`#8420 <https://github.com/autowarefoundation/autoware.universe/issues/8420>`_)
   * add autoware\_ prefix
   * add autoware\_ prefix
   ---------

--- a/map/autoware_map_tf_generator/CHANGELOG.rst
+++ b/map/autoware_map_tf_generator/CHANGELOG.rst
@@ -5,7 +5,7 @@ Changelog for package autoware_map_tf_generator
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* refactor(map_tf_generator)!: prefix package and namespace with autoware (`#8422 <https://github.com/youtalk/autoware.universe/issues/8422>`_)
+* refactor(map_tf_generator)!: prefix package and namespace with autoware (`#8422 <https://github.com/autowarefoundation/autoware.universe/issues/8422>`_)
   * add autoware\_ prefix
   * add autoware\_ prefix
   ---------

--- a/map/map_loader/CHANGELOG.rst
+++ b/map/map_loader/CHANGELOG.rst
@@ -5,37 +5,37 @@ Changelog for package map_loader
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* refactor(component_interface_specs): prefix package and namespace with autoware (`#9094 <https://github.com/youtalk/autoware.universe/issues/9094>`_)
-* refactor(ndt_scan_matcher)!: prefix package and namespace with autoware (`#8904 <https://github.com/youtalk/autoware.universe/issues/8904>`_)
+* refactor(component_interface_specs): prefix package and namespace with autoware (`#9094 <https://github.com/autowarefoundation/autoware.universe/issues/9094>`_)
+* refactor(ndt_scan_matcher)!: prefix package and namespace with autoware (`#8904 <https://github.com/autowarefoundation/autoware.universe/issues/8904>`_)
   add autoware\_ prefix
-* docs(map_loader): update the link of pointcloud_divider (`#8823 <https://github.com/youtalk/autoware.universe/issues/8823>`_)
+* docs(map_loader): update the link of pointcloud_divider (`#8823 <https://github.com/autowarefoundation/autoware.universe/issues/8823>`_)
   update link
-* docs(map_loader): update the link of map_projection_loader (`#8825 <https://github.com/youtalk/autoware.universe/issues/8825>`_)
+* docs(map_loader): update the link of map_projection_loader (`#8825 <https://github.com/autowarefoundation/autoware.universe/issues/8825>`_)
   update the link of map_projection_loader
-* chore(map_loader): update maintainer (`#8821 <https://github.com/youtalk/autoware.universe/issues/8821>`_)
+* chore(map_loader): update maintainer (`#8821 <https://github.com/autowarefoundation/autoware.universe/issues/8821>`_)
   update maintainer
-* feat(map loader): visualize bus stop area and bicycle_lane (`#8777 <https://github.com/youtalk/autoware.universe/issues/8777>`_)
-* refactor(geography_utils): prefix package and namespace with autoware (`#7790 <https://github.com/youtalk/autoware.universe/issues/7790>`_)
+* feat(map loader): visualize bus stop area and bicycle_lane (`#8777 <https://github.com/autowarefoundation/autoware.universe/issues/8777>`_)
+* refactor(geography_utils): prefix package and namespace with autoware (`#7790 <https://github.com/autowarefoundation/autoware.universe/issues/7790>`_)
   * refactor(geography_utils): prefix package and namespace with autoware
   * move headers to include/autoware/
   ---------
-* revert: revert "refactor(autoware_map_msgs): modify pcd metadata msg (`#7852 <https://github.com/youtalk/autoware.universe/issues/7852>`_)" (`#8180 <https://github.com/youtalk/autoware.universe/issues/8180>`_)
-* refactor(autoware_map_msgs): modify pcd metadata msg (`#7852 <https://github.com/youtalk/autoware.universe/issues/7852>`_)
-* refactor(compare_map_segmentation): add package name prefix of autoware\_ (`#8005 <https://github.com/youtalk/autoware.universe/issues/8005>`_)
+* revert: revert "refactor(autoware_map_msgs): modify pcd metadata msg (`#7852 <https://github.com/autowarefoundation/autoware.universe/issues/7852>`_)" (`#8180 <https://github.com/autowarefoundation/autoware.universe/issues/8180>`_)
+* refactor(autoware_map_msgs): modify pcd metadata msg (`#7852 <https://github.com/autowarefoundation/autoware.universe/issues/7852>`_)
+* refactor(compare_map_segmentation): add package name prefix of autoware\_ (`#8005 <https://github.com/autowarefoundation/autoware.universe/issues/8005>`_)
   * refactor(compare_map_segmentation): add package name prefix of autoware\_
   * docs: update Readme
   ---------
-* chore(localization, map): remove maintainer (`#7940 <https://github.com/youtalk/autoware.universe/issues/7940>`_)
-* feat(map_loader, route_handler)!: add format_version validation (`#7074 <https://github.com/youtalk/autoware.universe/issues/7074>`_)
+* chore(localization, map): remove maintainer (`#7940 <https://github.com/autowarefoundation/autoware.universe/issues/7940>`_)
+* feat(map_loader, route_handler)!: add format_version validation (`#7074 <https://github.com/autowarefoundation/autoware.universe/issues/7074>`_)
   Co-authored-by: Yamato Ando <yamato.ando@gmail.com>
-* refactor(map_loader): apply static analysis (`#7845 <https://github.com/youtalk/autoware.universe/issues/7845>`_)
+* refactor(map_loader): apply static analysis (`#7845 <https://github.com/autowarefoundation/autoware.universe/issues/7845>`_)
   * refactor based on linter
   * style(pre-commit): autofix
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat: add `autoware\_` prefix to `lanelet2_extension` (`#7640 <https://github.com/youtalk/autoware.universe/issues/7640>`_)
-* style: updating the colors for the parking spaces and lot (`#7726 <https://github.com/youtalk/autoware.universe/issues/7726>`_)
-* feat(map_loader): add waypoints flag (`#7480 <https://github.com/youtalk/autoware.universe/issues/7480>`_)
+* feat: add `autoware\_` prefix to `lanelet2_extension` (`#7640 <https://github.com/autowarefoundation/autoware.universe/issues/7640>`_)
+* style: updating the colors for the parking spaces and lot (`#7726 <https://github.com/autowarefoundation/autoware.universe/issues/7726>`_)
+* feat(map_loader): add waypoints flag (`#7480 <https://github.com/autowarefoundation/autoware.universe/issues/7480>`_)
   * feat(map_loader): handle centelrine and waypoints
   * update README
   * fix doc
@@ -43,7 +43,7 @@ Changelog for package map_loader
   * fix
   * fix
   ---------
-* feat(map_loader): warn if some pcds from the metadata file are missing (`#7406 <https://github.com/youtalk/autoware.universe/issues/7406>`_)
+* feat(map_loader): warn if some pcds from the metadata file are missing (`#7406 <https://github.com/autowarefoundation/autoware.universe/issues/7406>`_)
   * Examine if there are PCD segments found in the metadata file but are missing from the input pcd paths
   * style(pre-commit): autofix
   * Fixing CI
@@ -53,12 +53,12 @@ Changelog for package map_loader
   * Removed try{} block from getPCDMetadata and redundant std::endl at the end of error messages
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* chore(map): udpate maintainer (`#7405 <https://github.com/youtalk/autoware.universe/issues/7405>`_)
+* chore(map): udpate maintainer (`#7405 <https://github.com/autowarefoundation/autoware.universe/issues/7405>`_)
   udpate maintainer
-* fix(map_loader): add log output (`#7203 <https://github.com/youtalk/autoware.universe/issues/7203>`_)
+* fix(map_loader): add log output (`#7203 <https://github.com/autowarefoundation/autoware.universe/issues/7203>`_)
   add log output
   Co-authored-by: SakodaShintaro <shintaro.sakoda@tier4.jp>
-* feat!: replace autoware_auto_msgs with autoware_msgs for map modules (`#7244 <https://github.com/youtalk/autoware.universe/issues/7244>`_)
+* feat!: replace autoware_auto_msgs with autoware_msgs for map modules (`#7244 <https://github.com/autowarefoundation/autoware.universe/issues/7244>`_)
   Co-authored-by: Cynthia Liu <cynthia.liu@autocore.ai>
   Co-authored-by: NorahXiong <norah.xiong@autocore.ai>
   Co-authored-by: beginningfan <beginning.fan@autocore.ai>
@@ -66,9 +66,9 @@ Changelog for package map_loader
 
 0.26.0 (2024-04-03)
 -------------------
-* fix(map_loader): fix warnings with single point cloud map metadata (`#6384 <https://github.com/youtalk/autoware.universe/issues/6384>`_)
-* fix(log-messages): reduce excessive log messages (`#5971 <https://github.com/youtalk/autoware.universe/issues/5971>`_)
-* chore(map_loader): rework parameters of map_loader (`#6199 <https://github.com/youtalk/autoware.universe/issues/6199>`_)
+* fix(map_loader): fix warnings with single point cloud map metadata (`#6384 <https://github.com/autowarefoundation/autoware.universe/issues/6384>`_)
+* fix(log-messages): reduce excessive log messages (`#5971 <https://github.com/autowarefoundation/autoware.universe/issues/5971>`_)
+* chore(map_loader): rework parameters of map_loader (`#6199 <https://github.com/autowarefoundation/autoware.universe/issues/6199>`_)
   * Rework parameters of map_loader
   * style(pre-commit): autofix
   * Fixed typo in name of map_based_pediction.schema.json, which cause json-schema-check failed
@@ -78,24 +78,24 @@ Changelog for package map_loader
   * Remove default values of declare_parameter from map_loader
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* revert(map_loader): revert the change error handling when pcd_metadata file (`#6294 <https://github.com/youtalk/autoware.universe/issues/6294>`_)
-  Revert "fix(map_loader): change error handling when pcd_metadata file not found (`#6227 <https://github.com/youtalk/autoware.universe/issues/6227>`_)"
+* revert(map_loader): revert the change error handling when pcd_metadata file (`#6294 <https://github.com/autowarefoundation/autoware.universe/issues/6294>`_)
+  Revert "fix(map_loader): change error handling when pcd_metadata file not found (`#6227 <https://github.com/autowarefoundation/autoware.universe/issues/6227>`_)"
   This reverts commit 25bc636fe0f796c63daac60123aa6138146e515d.
-* chore(lanelet2_map_loader): enrich error message (`#6245 <https://github.com/youtalk/autoware.universe/issues/6245>`_)
-* chore(map_loader): add maintainer (`#6232 <https://github.com/youtalk/autoware.universe/issues/6232>`_)
-* fix(map_loader): change error handling when pcd_metadata file not found (`#6227 <https://github.com/youtalk/autoware.universe/issues/6227>`_)
+* chore(lanelet2_map_loader): enrich error message (`#6245 <https://github.com/autowarefoundation/autoware.universe/issues/6245>`_)
+* chore(map_loader): add maintainer (`#6232 <https://github.com/autowarefoundation/autoware.universe/issues/6232>`_)
+* fix(map_loader): change error handling when pcd_metadata file not found (`#6227 <https://github.com/autowarefoundation/autoware.universe/issues/6227>`_)
   Changed error handling when pcd_metadata file not found
-* chore: add localization & mapping maintainers (`#6085 <https://github.com/youtalk/autoware.universe/issues/6085>`_)
+* chore: add localization & mapping maintainers (`#6085 <https://github.com/autowarefoundation/autoware.universe/issues/6085>`_)
   * Added lm maintainers
   * Add more
   * Fixed maintainer
   ---------
-* fix(map_loader): show traffic light regulatory element id per lanelet (`#6028 <https://github.com/youtalk/autoware.universe/issues/6028>`_)
+* fix(map_loader): show traffic light regulatory element id per lanelet (`#6028 <https://github.com/autowarefoundation/autoware.universe/issues/6028>`_)
   * fix(map_loader): show traffic light regulatory element id per lanelet
   * feat(map_loader): show traffic light id
   ---------
   Co-authored-by: Ryohsuke Mitsudome <43976834+mitsudome-r@users.noreply.github.com>
-* refactor(ndt_scan_matcher, map_loader): remove map_module (`#5873 <https://github.com/youtalk/autoware.universe/issues/5873>`_)
+* refactor(ndt_scan_matcher, map_loader): remove map_module (`#5873 <https://github.com/autowarefoundation/autoware.universe/issues/5873>`_)
   * Removed use_dynamic_map_loading
   * Removed enable_differential_load option
   * style(pre-commit): autofix
@@ -104,39 +104,39 @@ Changelog for package map_loader
   * Removed pointcloud_map and  input_ekf_odom
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat(map_loader): use dummy projector when using local coordinates (`#5866 <https://github.com/youtalk/autoware.universe/issues/5866>`_)
+* feat(map_loader): use dummy projector when using local coordinates (`#5866 <https://github.com/autowarefoundation/autoware.universe/issues/5866>`_)
   * feat(map_loader): use dummy projector when using local coordinates
   * fix build warning
   * fix runtime error
   * fix reverse function
   ---------
-* chore(map_loader): visualize crosswalk id (`#5880 <https://github.com/youtalk/autoware.universe/issues/5880>`_)
-* chore: add maintainer in map packages (`#5865 <https://github.com/youtalk/autoware.universe/issues/5865>`_)
+* chore(map_loader): visualize crosswalk id (`#5880 <https://github.com/autowarefoundation/autoware.universe/issues/5880>`_)
+* chore: add maintainer in map packages (`#5865 <https://github.com/autowarefoundation/autoware.universe/issues/5865>`_)
   * add maintainer
   * modify map_tf_generator's maintainer
   ---------
-* fix: add_ros_test to add_launch_test (`#5486 <https://github.com/youtalk/autoware.universe/issues/5486>`_)
+* fix: add_ros_test to add_launch_test (`#5486 <https://github.com/autowarefoundation/autoware.universe/issues/5486>`_)
   * fix: add_ros_test to add_launch_test
   * fix ndt_scan_matcher
   ---------
-* chore(map_loader): update readme (`#5468 <https://github.com/youtalk/autoware.universe/issues/5468>`_)
+* chore(map_loader): update readme (`#5468 <https://github.com/autowarefoundation/autoware.universe/issues/5468>`_)
   * chore(map_loader): update readme
   * make the annotation bold
   * fix
   ---------
-* feat(map_loader): show intersection areas (`#5401 <https://github.com/youtalk/autoware.universe/issues/5401>`_)
-* feat(map_loader): display curbstone as marker array (`#4958 <https://github.com/youtalk/autoware.universe/issues/4958>`_)
+* feat(map_loader): show intersection areas (`#5401 <https://github.com/autowarefoundation/autoware.universe/issues/5401>`_)
+* feat(map_loader): display curbstone as marker array (`#4958 <https://github.com/autowarefoundation/autoware.universe/issues/4958>`_)
   display curbstone as marker array
   Co-authored-by: kminoda <44218668+kminoda@users.noreply.github.com>
-* refactor(map_packages): remove unused depend in pakcages.xml files (`#5172 <https://github.com/youtalk/autoware.universe/issues/5172>`_)
+* refactor(map_packages): remove unused depend in pakcages.xml files (`#5172 <https://github.com/autowarefoundation/autoware.universe/issues/5172>`_)
   Co-authored-by: yamato-ando <Yamato ANDO>
-* feat: support transverse mercator projection (`#4883 <https://github.com/youtalk/autoware.universe/issues/4883>`_)
+* feat: support transverse mercator projection (`#4883 <https://github.com/autowarefoundation/autoware.universe/issues/4883>`_)
   * feat: support transverse mercator projection
   * fix some
   * style(pre-commit): autofix
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat(geography_utils): add lanelet2_projector (`#4852 <https://github.com/youtalk/autoware.universe/issues/4852>`_)
+* feat(geography_utils): add lanelet2_projector (`#4852 <https://github.com/autowarefoundation/autoware.universe/issues/4852>`_)
   * feat(geography_utils): add lanelet2_projector
   * style(pre-commit): autofix
   * update package.xml
@@ -145,14 +145,14 @@ Changelog for package map_loader
   * style(pre-commit): autofix
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat: use constant string for map_projector_info (`#4789 <https://github.com/youtalk/autoware.universe/issues/4789>`_)
+* feat: use constant string for map_projector_info (`#4789 <https://github.com/autowarefoundation/autoware.universe/issues/4789>`_)
   * feat: use constant string for map_projector_info
   * style(pre-commit): autofix
   * update
   * style(pre-commit): autofix
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat!: add vertical datum in map_projector_info (`#4708 <https://github.com/youtalk/autoware.universe/issues/4708>`_)
+* feat!: add vertical datum in map_projector_info (`#4708 <https://github.com/autowarefoundation/autoware.universe/issues/4708>`_)
   * resolve conflict
   * update
   * UTM -> LocalCartesianUTM
@@ -165,15 +165,15 @@ Changelog for package map_loader
   * add vertical datum for lanelet2
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat!: rename utm to local_cartesian_utm (`#4704 <https://github.com/youtalk/autoware.universe/issues/4704>`_)
+* feat!: rename utm to local_cartesian_utm (`#4704 <https://github.com/autowarefoundation/autoware.universe/issues/4704>`_)
   * feat(map_projection_loader, map_loader): rename utm to local_cartesian_utm
   * fix readme
   * fix default ad api
   ---------
-* feat!: rename map_projector_type to map_projector_info (`#4664 <https://github.com/youtalk/autoware.universe/issues/4664>`_)
-* fix(lanelet2_map_loader): fixed parameter declaration timing (`#4639 <https://github.com/youtalk/autoware.universe/issues/4639>`_)
+* feat!: rename map_projector_type to map_projector_info (`#4664 <https://github.com/autowarefoundation/autoware.universe/issues/4664>`_)
+* fix(lanelet2_map_loader): fixed parameter declaration timing (`#4639 <https://github.com/autowarefoundation/autoware.universe/issues/4639>`_)
   Change parameter declaration timing
-* fix(map_loader, map_projection_loader): use component interface specs (`#4585 <https://github.com/youtalk/autoware.universe/issues/4585>`_)
+* fix(map_loader, map_projection_loader): use component interface specs (`#4585 <https://github.com/autowarefoundation/autoware.universe/issues/4585>`_)
   * feat(map): use component_interface_specs in map_projection_loader
   * update map_loader
   * style(pre-commit): autofix
@@ -183,7 +183,7 @@ Changelog for package map_loader
   * fix test
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat(map_projection_loader): add map_projection_loader (`#3986 <https://github.com/youtalk/autoware.universe/issues/3986>`_)
+* feat(map_projection_loader): add map_projection_loader (`#3986 <https://github.com/autowarefoundation/autoware.universe/issues/3986>`_)
   * feat(map_projection_loader): add map_projection_loader
   * style(pre-commit): autofix
   * Update default algorithm
@@ -237,17 +237,17 @@ Changelog for package map_loader
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Ryohsuke Mitsudome <43976834+mitsudome-r@users.noreply.github.com>
-* chore: add maintainer in localization and map packages (`#4501 <https://github.com/youtalk/autoware.universe/issues/4501>`_)
-* feat(goal_planner): add no_parking_area for goal search (`#3467 <https://github.com/youtalk/autoware.universe/issues/3467>`_)
+* chore: add maintainer in localization and map packages (`#4501 <https://github.com/autowarefoundation/autoware.universe/issues/4501>`_)
+* feat(goal_planner): add no_parking_area for goal search (`#3467 <https://github.com/autowarefoundation/autoware.universe/issues/3467>`_)
   * feat(behavior_path_planner): use no_parking_area for pull_over
   * support no_stopping_area
   ---------
-* fix(map_loader): fix spell-check (`#4280 <https://github.com/youtalk/autoware.universe/issues/4280>`_)
-* feat(crosswalk): support crosswalk regulatory element (`#3939 <https://github.com/youtalk/autoware.universe/issues/3939>`_)
+* fix(map_loader): fix spell-check (`#4280 <https://github.com/autowarefoundation/autoware.universe/issues/4280>`_)
+* feat(crosswalk): support crosswalk regulatory element (`#3939 <https://github.com/autowarefoundation/autoware.universe/issues/3939>`_)
   * feat(crosswalk): use regulatory element
   * feat(map_loader): show crosswalk areas
   ---------
-* fix(map_loader): update readme for metadata (`#3919 <https://github.com/youtalk/autoware.universe/issues/3919>`_)
+* fix(map_loader): update readme for metadata (`#3919 <https://github.com/autowarefoundation/autoware.universe/issues/3919>`_)
   * fix(map_loader): update readme for metadata
   * style(pre-commit): autofix
   * update
@@ -258,14 +258,14 @@ Changelog for package map_loader
   * update
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* fix(map_loader): handle enable_selected_load correctly (`#3920 <https://github.com/youtalk/autoware.universe/issues/3920>`_)
+* fix(map_loader): handle enable_selected_load correctly (`#3920 <https://github.com/autowarefoundation/autoware.universe/issues/3920>`_)
   * fix(map_loader): update readme for metadata
   * fix(map_loader): handle enable_selected_load flag correctly
   * style(pre-commit): autofix
   * revert readme
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat(map_loader): use cylindrical area for map loader (`#3863 <https://github.com/youtalk/autoware.universe/issues/3863>`_)
+* feat(map_loader): use cylindrical area for map loader (`#3863 <https://github.com/autowarefoundation/autoware.universe/issues/3863>`_)
   * feat(map_loader): use cylindrical area for query instead of spherical area
   * update
   * style(pre-commit): autofix
@@ -273,7 +273,7 @@ Changelog for package map_loader
   * style(pre-commit): autofix
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat(map_loader): add publish map projector info (`#3200 <https://github.com/youtalk/autoware.universe/issues/3200>`_)
+* feat(map_loader): add publish map projector info (`#3200 <https://github.com/autowarefoundation/autoware.universe/issues/3200>`_)
   * add publish mgrs grid
   * fix publish wrong grid code when there is no mgrs code in lanelet
   * Revert "fix publish wrong grid code when there is no mgrs code in lanelet"
@@ -287,19 +287,19 @@ Changelog for package map_loader
   * add local publish
   ---------
   Co-authored-by: Takagi, Isamu <43976882+isamu-takagi@users.noreply.github.com>
-* fix(map_loader): re-align lanelet borders after overwriting coordinates (`#3825 <https://github.com/youtalk/autoware.universe/issues/3825>`_)
-* fix(map_loader): fix readme (`#3667 <https://github.com/youtalk/autoware.universe/issues/3667>`_)
-* feat(map_loader): visualize hatched road markings (`#3639 <https://github.com/youtalk/autoware.universe/issues/3639>`_)
+* fix(map_loader): re-align lanelet borders after overwriting coordinates (`#3825 <https://github.com/autowarefoundation/autoware.universe/issues/3825>`_)
+* fix(map_loader): fix readme (`#3667 <https://github.com/autowarefoundation/autoware.universe/issues/3667>`_)
+* feat(map_loader): visualize hatched road markings (`#3639 <https://github.com/autowarefoundation/autoware.universe/issues/3639>`_)
   * feat(map_loader): visualize hatched road markings
   * update
   ---------
-* style: fix typos (`#3617 <https://github.com/youtalk/autoware.universe/issues/3617>`_)
+* style: fix typos (`#3617 <https://github.com/autowarefoundation/autoware.universe/issues/3617>`_)
   * style: fix typos in documents
   * style: fix typos in package.xml
   * style: fix typos in launch files
   * style: fix typos in comments
   ---------
-* build: mark autoware_cmake as <buildtool_depend> (`#3616 <https://github.com/youtalk/autoware.universe/issues/3616>`_)
+* build: mark autoware_cmake as <buildtool_depend> (`#3616 <https://github.com/autowarefoundation/autoware.universe/issues/3616>`_)
   * build: mark autoware_cmake as <buildtool_depend>
   with <build_depend>, autoware_cmake is automatically exported with ament_target_dependencies() (unecessary)
   * style(pre-commit): autofix
@@ -307,13 +307,13 @@ Changelog for package map_loader
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Kenji Miyake <kenji.miyake@tier4.jp>
-* feat(map_loader): add local map projector (`#3492 <https://github.com/youtalk/autoware.universe/issues/3492>`_)
+* feat(map_loader): add local map projector (`#3492 <https://github.com/autowarefoundation/autoware.universe/issues/3492>`_)
   * feat(map_loader): add local map projector
   * update README
   * update readme
   * use the same naming standard
   ---------
-* feat(map_loader): add selected map loader (`#3286 <https://github.com/youtalk/autoware.universe/issues/3286>`_)
+* feat(map_loader): add selected map loader (`#3286 <https://github.com/autowarefoundation/autoware.universe/issues/3286>`_)
   * add id based map loader
   * add metadata publisher
   * feat(map_loader): add support for sequential_map_loading
@@ -326,11 +326,11 @@ Changelog for package map_loader
   ---------
   Co-authored-by: Shin-kyoto <58775300+Shin-kyoto@users.noreply.github.com>
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* fix(map_loader): fix a bug that occurs when loading multiple pcds (`#3274 <https://github.com/youtalk/autoware.universe/issues/3274>`_)
+* fix(map_loader): fix a bug that occurs when loading multiple pcds (`#3274 <https://github.com/autowarefoundation/autoware.universe/issues/3274>`_)
   * fix(map_loader): fix a bug that occurs when loading multiple pcds
   * fix
   ---------
-* feat(map_loader): add grid coordinates for partial/differential map load (`#3205 <https://github.com/youtalk/autoware.universe/issues/3205>`_)
+* feat(map_loader): add grid coordinates for partial/differential map load (`#3205 <https://github.com/autowarefoundation/autoware.universe/issues/3205>`_)
   * feat(map_loader): add grid coordinates for partial/differential map load
   * style(pre-commit): autofix
   * update readme
@@ -340,9 +340,9 @@ Changelog for package map_loader
   * update readme
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* fix(map_loader): address deprecated warning for some environment (`#3188 <https://github.com/youtalk/autoware.universe/issues/3188>`_)
+* fix(map_loader): address deprecated warning for some environment (`#3188 <https://github.com/autowarefoundation/autoware.universe/issues/3188>`_)
   fix(map_loader): address deprecated warning for some version
-* test(map_loader): add a ROS 2 test (`#3170 <https://github.com/youtalk/autoware.universe/issues/3170>`_)
+* test(map_loader): add a ROS 2 test (`#3170 <https://github.com/autowarefoundation/autoware.universe/issues/3170>`_)
   * chore(map_loader): add a ROS 2 test
   * style(pre-commit): autofix
   * debug
@@ -352,7 +352,7 @@ Changelog for package map_loader
   * fix pre-commit
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* chore(tier4_map_launch): add lanelet2 config files to tier4_map_launch (`#2670 <https://github.com/youtalk/autoware.universe/issues/2670>`_)
+* chore(tier4_map_launch): add lanelet2 config files to tier4_map_launch (`#2670 <https://github.com/autowarefoundation/autoware.universe/issues/2670>`_)
   * chore(tier4_map_launch): add lanelet2 config files to tier4_map_launch
   Update launch/tier4_map_launch/launch/map.launch.xml
   Co-authored-by: kminoda <44218668+kminoda@users.noreply.github.com>
@@ -360,9 +360,9 @@ Changelog for package map_loader
   remove config path
   * chore(tier4_map_launch): fix lanelet launch name
   ---------
-* ci(pre-commit): autoupdate (`#2819 <https://github.com/youtalk/autoware.universe/issues/2819>`_)
+* ci(pre-commit): autoupdate (`#2819 <https://github.com/autowarefoundation/autoware.universe/issues/2819>`_)
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat(ndt_scan_matcher): dynamic map loading (`#2339 <https://github.com/youtalk/autoware.universe/issues/2339>`_)
+* feat(ndt_scan_matcher): dynamic map loading (`#2339 <https://github.com/autowarefoundation/autoware.universe/issues/2339>`_)
   * first commit
   * ci(pre-commit): autofix
   * import map update module in core
@@ -415,17 +415,17 @@ Changelog for package map_loader
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Daisuke Nishimatsu <42202095+wep21@users.noreply.github.com>
-* fix(lanelet2_map_loader): delete unused parameters (`#2761 <https://github.com/youtalk/autoware.universe/issues/2761>`_)
+* fix(lanelet2_map_loader): delete unused parameters (`#2761 <https://github.com/autowarefoundation/autoware.universe/issues/2761>`_)
   * fix(lanelet2_map_loader): delete unused parameters
   * Update lanelet2_map_loader.launch.xml
-* fix(map_loader): apply clang-tidy (`#2668 <https://github.com/youtalk/autoware.universe/issues/2668>`_)
+* fix(map_loader): apply clang-tidy (`#2668 <https://github.com/autowarefoundation/autoware.universe/issues/2668>`_)
   * fix(map_loader): apply clang-tidy
   * ci(pre-commit): autofix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat(behavior_velocity_planner): add speed bump module (`#647 <https://github.com/youtalk/autoware.universe/issues/647>`_)
+* feat(behavior_velocity_planner): add speed bump module (`#647 <https://github.com/autowarefoundation/autoware.universe/issues/647>`_)
   Co-authored-by: Kosuke Takeuchi <kosuke.tnp@gmail.com>
   Co-authored-by: Takayuki Murooka <takayuki5168@gmail.com>
-* feat(map_loader): add differential map loading interface (`#2417 <https://github.com/youtalk/autoware.universe/issues/2417>`_)
+* feat(map_loader): add differential map loading interface (`#2417 <https://github.com/autowarefoundation/autoware.universe/issues/2417>`_)
   * first commit
   * ci(pre-commit): autofix
   * added module load in _node.cpp
@@ -435,7 +435,7 @@ Changelog for package map_loader
   * fix readme
   * ci(pre-commit): autofix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat(map_loader): add downsampled pointcloud publisher (`#2418 <https://github.com/youtalk/autoware.universe/issues/2418>`_)
+* feat(map_loader): add downsampled pointcloud publisher (`#2418 <https://github.com/autowarefoundation/autoware.universe/issues/2418>`_)
   * first commit
   * debugged
   * update readme
@@ -447,7 +447,7 @@ Changelog for package map_loader
   * set default param to false
   * ci(pre-commit): autofix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat(map_loader): add partial map loading interface in pointcloud_map_loader (`#1938 <https://github.com/youtalk/autoware.universe/issues/1938>`_)
+* feat(map_loader): add partial map loading interface in pointcloud_map_loader (`#1938 <https://github.com/autowarefoundation/autoware.universe/issues/1938>`_)
   * first commit
   * reverted unnecessary modification
   * ci(pre-commit): autofix
@@ -497,7 +497,7 @@ Changelog for package map_loader
   * remove fmt from target_link_libraries in test
   * minor fix in cmakelists.txt
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* refactor(map_loader): modularization (`#2243 <https://github.com/youtalk/autoware.universe/issues/2243>`_)
+* refactor(map_loader): modularization (`#2243 <https://github.com/autowarefoundation/autoware.universe/issues/2243>`_)
   * refactor(map_loader): modularization
   * ci(pre-commit): autofix
   * simplified
@@ -508,14 +508,14 @@ Changelog for package map_loader
   * ci(pre-commit): autofix
   * edit copyright
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* chore(map_loader): add maintainer (`#2245 <https://github.com/youtalk/autoware.universe/issues/2245>`_)
+* chore(map_loader): add maintainer (`#2245 <https://github.com/autowarefoundation/autoware.universe/issues/2245>`_)
   * chore(map_loader): add maintainer
   * remove miyake-san
-* feat(map_loader): make some functions static (`#2014 <https://github.com/youtalk/autoware.universe/issues/2014>`_)
+* feat(map_loader): make some functions static (`#2014 <https://github.com/autowarefoundation/autoware.universe/issues/2014>`_)
   * feat(map_loader): make some functions static
   * make publisher alive after constructor
-* refactor(map_loader): split to member functions (`#1941 <https://github.com/youtalk/autoware.universe/issues/1941>`_)
-* chore(planning/control packages): organized authors and maintainers (`#1610 <https://github.com/youtalk/autoware.universe/issues/1610>`_)
+* refactor(map_loader): split to member functions (`#1941 <https://github.com/autowarefoundation/autoware.universe/issues/1941>`_)
+* chore(planning/control packages): organized authors and maintainers (`#1610 <https://github.com/autowarefoundation/autoware.universe/issues/1610>`_)
   * organized planning authors and maintainers
   * organized control authors and maintainers
   * fix typo
@@ -548,7 +548,7 @@ Changelog for package map_loader
   * fix
   Co-authored-by: Kenji Miyake <31987104+kenji-miyake@users.noreply.github.com>
   Co-authored-by: Kenji Miyake <kenji.miyake@tier4.jp>
-* feat: add vector map inside area filter (`#1530 <https://github.com/youtalk/autoware.universe/issues/1530>`_)
+* feat: add vector map inside area filter (`#1530 <https://github.com/autowarefoundation/autoware.universe/issues/1530>`_)
   * feat: add no detection area filter
   * ci(pre-commit): autofix
   * chore: add documents
@@ -572,25 +572,25 @@ Changelog for package map_loader
   * chore: using namespace of PolygonCgal for readability
   * feat: add functions for multiple polygons
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* test(map_loader): add launch test for the 'lanelet2_map_loader' node (`#1056 <https://github.com/youtalk/autoware.universe/issues/1056>`_)
+* test(map_loader): add launch test for the 'lanelet2_map_loader' node (`#1056 <https://github.com/autowarefoundation/autoware.universe/issues/1056>`_)
   Co-authored-by: Kenji Miyake <31987104+kenji-miyake@users.noreply.github.com>
-* feat: add parameter argument for lanelet2_map_loader (`#954 <https://github.com/youtalk/autoware.universe/issues/954>`_)
+* feat: add parameter argument for lanelet2_map_loader (`#954 <https://github.com/autowarefoundation/autoware.universe/issues/954>`_)
   * feat: add parameter argument for lanelet2_map_loader
   * feat: add comment
-* fix(map_loader): use std::filesystem to load pcd files in pointcloud_map_loader (`#942 <https://github.com/youtalk/autoware.universe/issues/942>`_)
+* fix(map_loader): use std::filesystem to load pcd files in pointcloud_map_loader (`#942 <https://github.com/autowarefoundation/autoware.universe/issues/942>`_)
   * fix(map_loader): use std::filesystem to load pcd files in pointcloud_map_loader
   * fix(map_loader): remove c_str
   * fix(map_loader): replace c_str to string
-* chore: upgrade cmake_minimum_required to 3.14 (`#856 <https://github.com/youtalk/autoware.universe/issues/856>`_)
-* refactor: use autoware cmake (`#849 <https://github.com/youtalk/autoware.universe/issues/849>`_)
+* chore: upgrade cmake_minimum_required to 3.14 (`#856 <https://github.com/autowarefoundation/autoware.universe/issues/856>`_)
+* refactor: use autoware cmake (`#849 <https://github.com/autowarefoundation/autoware.universe/issues/849>`_)
   * remove autoware_auto_cmake
   * add build_depend of autoware_cmake
   * use autoware_cmake in CMakeLists.txt
   * fix bugs
   * fix cmake lint errors
-* style: fix format of package.xml (`#844 <https://github.com/youtalk/autoware.universe/issues/844>`_)
-* fix(map_loader): modify build error in rolling (`#777 <https://github.com/youtalk/autoware.universe/issues/777>`_)
-* fix(map_loader): map_loader package not working in UTM coordinates (`#627 <https://github.com/youtalk/autoware.universe/issues/627>`_)
+* style: fix format of package.xml (`#844 <https://github.com/autowarefoundation/autoware.universe/issues/844>`_)
+* fix(map_loader): modify build error in rolling (`#777 <https://github.com/autowarefoundation/autoware.universe/issues/777>`_)
+* fix(map_loader): map_loader package not working in UTM coordinates (`#627 <https://github.com/autowarefoundation/autoware.universe/issues/627>`_)
   * ci(pre-commit): autofix
   * ci(pre-commit): autofix
   * fix(map_loader): add UTM projector to map_loader package
@@ -613,14 +613,14 @@ Changelog for package map_loader
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: M. Fatih Cırıt <xmfcx@users.noreply.github.com>
   Co-authored-by: Berkay <brkay54@gmail.com>
-* ci(pre-commit): update pre-commit-hooks-ros (`#625 <https://github.com/youtalk/autoware.universe/issues/625>`_)
+* ci(pre-commit): update pre-commit-hooks-ros (`#625 <https://github.com/autowarefoundation/autoware.universe/issues/625>`_)
   * ci(pre-commit): update pre-commit-hooks-ros
   * ci(pre-commit): autofix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat(lanelet2_extension,map_loader): add guard_rail wall fence as lanelet tag (`#478 <https://github.com/youtalk/autoware.universe/issues/478>`_)
+* feat(lanelet2_extension,map_loader): add guard_rail wall fence as lanelet tag (`#478 <https://github.com/autowarefoundation/autoware.universe/issues/478>`_)
   * feat(lanelet2_extension): add guard_rails fence wall as lanelet tag
   * feat(map_loader): add visualization for partion lanelet
-* feat: rename existing packages name starting with autoware to different names (`#180 <https://github.com/youtalk/autoware.universe/issues/180>`_)
+* feat: rename existing packages name starting with autoware to different names (`#180 <https://github.com/autowarefoundation/autoware.universe/issues/180>`_)
   * autoware_api_utils -> tier4_api_utils
   * autoware_debug_tools -> tier4_debug_tools
   * autoware_error_monitor -> system_error_monitor
@@ -637,7 +637,7 @@ Changelog for package map_loader
   * fix ad_service_state_monitor
   * ci(pre-commit): autofix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat: change pachage name: autoware_msgs -> tier4_msgs (`#150 <https://github.com/youtalk/autoware.universe/issues/150>`_)
+* feat: change pachage name: autoware_msgs -> tier4_msgs (`#150 <https://github.com/autowarefoundation/autoware.universe/issues/150>`_)
   * change pkg name: autoware\_*_msgs -> tier\_*_msgs
   * ci(pre-commit): autofix
   * autoware_external_api_msgs -> tier4_external_api_msgs
@@ -645,7 +645,7 @@ Changelog for package map_loader
   * fix description
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Takeshi Miura <57553950+1222-takeshi@users.noreply.github.com>
-* refactor: remove unnecessary messages (`#133 <https://github.com/youtalk/autoware.universe/issues/133>`_)
+* refactor: remove unnecessary messages (`#133 <https://github.com/autowarefoundation/autoware.universe/issues/133>`_)
   * remove ControlCommand.msg and ControlCommandStamped.msg
   * remove BatteryStatus.msg RawControlCommand.msg RawVehicleCommand.msg VehicleCommand.msg
   * remove traffic_light_recognition msgs
@@ -664,8 +664,8 @@ Changelog for package map_loader
   * ci(pre-commit): autofix
   * fix: each messages
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat: move elevation map loader (`#740 <https://github.com/youtalk/autoware.universe/issues/740>`_) (`#136 <https://github.com/youtalk/autoware.universe/issues/136>`_)
-  * feat: Move elevation map loader (`#740 <https://github.com/youtalk/autoware.universe/issues/740>`_)
+* feat: move elevation map loader (`#740 <https://github.com/autowarefoundation/autoware.universe/issues/740>`_) (`#136 <https://github.com/autowarefoundation/autoware.universe/issues/136>`_)
+  * feat: Move elevation map loader (`#740 <https://github.com/autowarefoundation/autoware.universe/issues/740>`_)
   * Update perception/elevation_map_loader/README.md
   Co-authored-by: Tomoya Kimura <tomoya.kimura@tier4.jp>
   * Update perception/elevation_map_loader/README.md
@@ -674,34 +674,34 @@ Changelog for package map_loader
   Co-authored-by: Tomoya Kimura <tomoya.kimura@tier4.jp>
   Co-authored-by: Taichi Higashide <taichi.higashide@tier4.jp>
   Co-authored-by: Tomoya Kimura <tomoya.kimura@tier4.jp>
-* feat: add pcd map hash generator (`#745 <https://github.com/youtalk/autoware.universe/issues/745>`_) (`#130 <https://github.com/youtalk/autoware.universe/issues/130>`_)
+* feat: add pcd map hash generator (`#745 <https://github.com/autowarefoundation/autoware.universe/issues/745>`_) (`#130 <https://github.com/autowarefoundation/autoware.universe/issues/130>`_)
   Co-authored-by: Taichi Higashide <taichi.higashide@tier4.jp>
   Co-authored-by: Tomoya Kimura <tomoya.kimura@tier4.jp>
-* feat: add map packages (`#8 <https://github.com/youtalk/autoware.universe/issues/8>`_)
+* feat: add map packages (`#8 <https://github.com/autowarefoundation/autoware.universe/issues/8>`_)
   * release v0.4.0
-  * add resolution param in lanelet2_extension (`#760 <https://github.com/youtalk/autoware.universe/issues/760>`_)
-  * Fix/extend drivable area beyond goal (`#781 <https://github.com/youtalk/autoware.universe/issues/781>`_)
+  * add resolution param in lanelet2_extension (`#760 <https://github.com/autowarefoundation/autoware.universe/issues/760>`_)
+  * Fix/extend drivable area beyond goal (`#781 <https://github.com/autowarefoundation/autoware.universe/issues/781>`_)
   * update llt2 extention query func
   * extend drivable area over goal point
   * apply clang
   * update get preeceeding func
   * update preceeding func in lanechange
   * update comment
-  * Fix intersection preceeding lane query (`#807 <https://github.com/youtalk/autoware.universe/issues/807>`_)
+  * Fix intersection preceeding lane query (`#807 <https://github.com/autowarefoundation/autoware.universe/issues/807>`_)
   * modified interseciton module to add lanelets in intersection to objective lanelets due to change in getPreceedingLaneletSequences()
   * update comment
-  * Install executables in lanelet2_map_preprocessor (`#834 <https://github.com/youtalk/autoware.universe/issues/834>`_)
+  * Install executables in lanelet2_map_preprocessor (`#834 <https://github.com/autowarefoundation/autoware.universe/issues/834>`_)
   * remove ROS1 packages temporarily
   * Revert "remove ROS1 packages temporarily"
   This reverts commit 3290a8b9e92c9eae05d9159c8b9fd56ca8935c01.
   * add COLCON_IGNORE to ros1 packages
-  * Rename launch files to launch.xml (`#28 <https://github.com/youtalk/autoware.universe/issues/28>`_)
-  * port map_tf_generator (`#32 <https://github.com/youtalk/autoware.universe/issues/32>`_)
+  * Rename launch files to launch.xml (`#28 <https://github.com/autowarefoundation/autoware.universe/issues/28>`_)
+  * port map_tf_generator (`#32 <https://github.com/autowarefoundation/autoware.universe/issues/32>`_)
   * port map_tf_generator
   * add missing dependency
   * fix pointor, tf_broadcaster, add compile option
   * use ament_auto
-  * Port lanelet2 extension (`#36 <https://github.com/youtalk/autoware.universe/issues/36>`_)
+  * Port lanelet2 extension (`#36 <https://github.com/autowarefoundation/autoware.universe/issues/36>`_)
   * remove COLCON_IGNORE
   * port to ROS2
   * minor fix
@@ -711,18 +711,18 @@ Changelog for package map_loader
   * fix usage for ROS2
   * fix usage message and parameter declaration
   * fix getting map_file parameter
-  * Port map loader (`#44 <https://github.com/youtalk/autoware.universe/issues/44>`_)
+  * Port map loader (`#44 <https://github.com/autowarefoundation/autoware.universe/issues/44>`_)
   * port map_loader to ROS2
   * fix unintended change
   * Update map/map_loader/CMakeLists.txt
   Co-authored-by: Takamasa Horibe <horibe.takamasa@gmail.com>
   Co-authored-by: Takamasa Horibe <horibe.takamasa@gmail.com>
-  * Add geometry2 to repos (`#76 <https://github.com/youtalk/autoware.universe/issues/76>`_)
+  * Add geometry2 to repos (`#76 <https://github.com/autowarefoundation/autoware.universe/issues/76>`_)
   * add geometry2 package temporarily until new release
   * trigger-ci
   * add tf2 dependency to the packages that use tf2_geometry_msgs
-  * Revert "Add geometry2 to repos (`#76 <https://github.com/youtalk/autoware.universe/issues/76>`_)" (`#96 <https://github.com/youtalk/autoware.universe/issues/96>`_)
-  * Revert "Add geometry2 to repos (`#76 <https://github.com/youtalk/autoware.universe/issues/76>`_)"
+  * Revert "Add geometry2 to repos (`#76 <https://github.com/autowarefoundation/autoware.universe/issues/76>`_)" (`#96 <https://github.com/autowarefoundation/autoware.universe/issues/96>`_)
+  * Revert "Add geometry2 to repos (`#76 <https://github.com/autowarefoundation/autoware.universe/issues/76>`_)"
   This reverts commit 7dbe25ed5ff7d5f413fda567dcc77a70c79a7826.
   * Re-add tf2 dependencies
   * Revert "Re-add tf2 dependencies"
@@ -733,31 +733,31 @@ Changelog for package map_loader
   * Explicitly install known versions of the geometry packages
   * No need to skip tf2 packages anymore
   Co-authored-by: Esteve Fernandez <esteve@apache.org>
-  * Rename h files to hpp (`#142 <https://github.com/youtalk/autoware.universe/issues/142>`_)
+  * Rename h files to hpp (`#142 <https://github.com/autowarefoundation/autoware.universe/issues/142>`_)
   * Change includes
   * Rename files
   * Adjustments to make things compile
   * Other packages
-  * Adjust copyright notice on 532 out of 699 source files (`#143 <https://github.com/youtalk/autoware.universe/issues/143>`_)
-  * Use quotes for includes where appropriate (`#144 <https://github.com/youtalk/autoware.universe/issues/144>`_)
+  * Adjust copyright notice on 532 out of 699 source files (`#143 <https://github.com/autowarefoundation/autoware.universe/issues/143>`_)
+  * Use quotes for includes where appropriate (`#144 <https://github.com/autowarefoundation/autoware.universe/issues/144>`_)
   * Use quotes for includes where appropriate
   * Fix lint tests
   * Make tests pass hopefully
-  * Run uncrustify on the entire Pilot.Auto codebase (`#151 <https://github.com/youtalk/autoware.universe/issues/151>`_)
+  * Run uncrustify on the entire Pilot.Auto codebase (`#151 <https://github.com/autowarefoundation/autoware.universe/issues/151>`_)
   * Run uncrustify on the entire Pilot.Auto codebase
   * Exclude open PRs
-  * fixing trasient_local in ROS2 packages (`#160 <https://github.com/youtalk/autoware.universe/issues/160>`_)
-  * added linters to lanelet1_extension (`#170 <https://github.com/youtalk/autoware.universe/issues/170>`_)
-  * adding linters to map_loader (`#171 <https://github.com/youtalk/autoware.universe/issues/171>`_)
-  * adding linters to map_tf_generator (`#172 <https://github.com/youtalk/autoware.universe/issues/172>`_)
-  * apply env_var to  use_sim_time (`#222 <https://github.com/youtalk/autoware.universe/issues/222>`_)
-  * Ros2 v0.8.0 map loader and lanelet2 extension (`#279 <https://github.com/youtalk/autoware.universe/issues/279>`_)
-  * Ros2 v0.8 fix typo of "preceding" (`#323 <https://github.com/youtalk/autoware.universe/issues/323>`_)
+  * fixing trasient_local in ROS2 packages (`#160 <https://github.com/autowarefoundation/autoware.universe/issues/160>`_)
+  * added linters to lanelet1_extension (`#170 <https://github.com/autowarefoundation/autoware.universe/issues/170>`_)
+  * adding linters to map_loader (`#171 <https://github.com/autowarefoundation/autoware.universe/issues/171>`_)
+  * adding linters to map_tf_generator (`#172 <https://github.com/autowarefoundation/autoware.universe/issues/172>`_)
+  * apply env_var to  use_sim_time (`#222 <https://github.com/autowarefoundation/autoware.universe/issues/222>`_)
+  * Ros2 v0.8.0 map loader and lanelet2 extension (`#279 <https://github.com/autowarefoundation/autoware.universe/issues/279>`_)
+  * Ros2 v0.8 fix typo of "preceding" (`#323 <https://github.com/autowarefoundation/autoware.universe/issues/323>`_)
   * Fix typo of getPrecedingLaneletSequences
   * Fix comment
-  * Fix rviz2 low FPS (`#390 <https://github.com/youtalk/autoware.universe/issues/390>`_)
-  * add nullptr check when publish concatenate data (`#369 <https://github.com/youtalk/autoware.universe/issues/369>`_)
-  * Add warning msg when concat pointcloud is not published (`#388 <https://github.com/youtalk/autoware.universe/issues/388>`_)
+  * Fix rviz2 low FPS (`#390 <https://github.com/autowarefoundation/autoware.universe/issues/390>`_)
+  * add nullptr check when publish concatenate data (`#369 <https://github.com/autowarefoundation/autoware.universe/issues/369>`_)
+  * Add warning msg when concat pointcloud is not published (`#388 <https://github.com/autowarefoundation/autoware.universe/issues/388>`_)
   * Change lineString2Marker
   * Change trafficLight2TriangleMarker
   * Change laneletDirectionAsMarker
@@ -765,21 +765,21 @@ Changelog for package map_loader
   * Fix linter problems
   Co-authored-by: Taichi Higashide <taichi.higashide@tier4.jp>
   Co-authored-by: Kenji Miyake <31987104+kenji-miyake@users.noreply.github.com>
-  * [map_loader] modify colors for lane markers for better visualization (`#398 <https://github.com/youtalk/autoware.universe/issues/398>`_)
-  * fix empty marker (`#423 <https://github.com/youtalk/autoware.universe/issues/423>`_)
-  * Fix typo in map module (`#437 <https://github.com/youtalk/autoware.universe/issues/437>`_)
-  * add license (`#443 <https://github.com/youtalk/autoware.universe/issues/443>`_)
-  * avoid pushing empty marker (`#441 <https://github.com/youtalk/autoware.universe/issues/441>`_)
+  * [map_loader] modify colors for lane markers for better visualization (`#398 <https://github.com/autowarefoundation/autoware.universe/issues/398>`_)
+  * fix empty marker (`#423 <https://github.com/autowarefoundation/autoware.universe/issues/423>`_)
+  * Fix typo in map module (`#437 <https://github.com/autowarefoundation/autoware.universe/issues/437>`_)
+  * add license (`#443 <https://github.com/autowarefoundation/autoware.universe/issues/443>`_)
+  * avoid pushing empty marker (`#441 <https://github.com/autowarefoundation/autoware.universe/issues/441>`_)
   * avoid pushing empty marker
   * size0 -> empty
-  * add use_sim-time option (`#454 <https://github.com/youtalk/autoware.universe/issues/454>`_)
-  * Sync public repo (`#1228 <https://github.com/youtalk/autoware.universe/issues/1228>`_)
-  * [simple_planning_simulator] add readme (`#424 <https://github.com/youtalk/autoware.universe/issues/424>`_)
+  * add use_sim-time option (`#454 <https://github.com/autowarefoundation/autoware.universe/issues/454>`_)
+  * Sync public repo (`#1228 <https://github.com/autowarefoundation/autoware.universe/issues/1228>`_)
+  * [simple_planning_simulator] add readme (`#424 <https://github.com/autowarefoundation/autoware.universe/issues/424>`_)
   * add readme of simple_planning_simulator
   * Update simulator/simple_planning_simulator/README.md
-  * set transit_margin_time to intersect. planner (`#460 <https://github.com/youtalk/autoware.universe/issues/460>`_)
-  * Fix pose2twist (`#462 <https://github.com/youtalk/autoware.universe/issues/462>`_)
-  * Ros2 vehicle info param server (`#447 <https://github.com/youtalk/autoware.universe/issues/447>`_)
+  * set transit_margin_time to intersect. planner (`#460 <https://github.com/autowarefoundation/autoware.universe/issues/460>`_)
+  * Fix pose2twist (`#462 <https://github.com/autowarefoundation/autoware.universe/issues/462>`_)
+  * Ros2 vehicle info param server (`#447 <https://github.com/autowarefoundation/autoware.universe/issues/447>`_)
   * add vehicle_info_param_server
   * update vehicle info
   * apply format
@@ -787,7 +787,7 @@ Changelog for package map_loader
   * skip unnecessary search
   * delete vehicle param file
   * fix bug
-  * Ros2 fix topic name part2 (`#425 <https://github.com/youtalk/autoware.universe/issues/425>`_)
+  * Ros2 fix topic name part2 (`#425 <https://github.com/autowarefoundation/autoware.universe/issues/425>`_)
   * Fix topic name of traffic_light_classifier
   * Fix topic name of traffic_light_visualization
   * Fix topic name of traffic_light_ssd_fine_detector
@@ -797,19 +797,19 @@ Changelog for package map_loader
   * Fix lint traffic_light_classifier
   * Fix lint traffic_light_classifier
   * Fix lint traffic_light_ssd_fine_detector
-  * Fix issues in hdd_reader (`#466 <https://github.com/youtalk/autoware.universe/issues/466>`_)
+  * Fix issues in hdd_reader (`#466 <https://github.com/autowarefoundation/autoware.universe/issues/466>`_)
   * Fix some issues detected by Coverity Scan and Clang-Tidy
   * Update launch command
   * Add more `close(new_sock)`
   * Simplify the definitions of struct
-  * fix: re-construct laneletMapLayer for reindex RTree (`#463 <https://github.com/youtalk/autoware.universe/issues/463>`_)
-  * Rviz overlay render fix (`#461 <https://github.com/youtalk/autoware.universe/issues/461>`_)
+  * fix: re-construct laneletMapLayer for reindex RTree (`#463 <https://github.com/autowarefoundation/autoware.universe/issues/463>`_)
+  * Rviz overlay render fix (`#461 <https://github.com/autowarefoundation/autoware.universe/issues/461>`_)
   * Moved painiting in SteeringAngle plugin to update()
   * super class now back to MFD
   * uncrustified
   * acquire data in mutex
   * back to RTD as superclass
-  * Rviz overlay render in update (`#465 <https://github.com/youtalk/autoware.universe/issues/465>`_)
+  * Rviz overlay render in update (`#465 <https://github.com/autowarefoundation/autoware.universe/issues/465>`_)
   * Moved painiting in SteeringAngle plugin to update()
   * super class now back to MFD
   * uncrustified
@@ -823,16 +823,16 @@ Changelog for package map_loader
   Co-authored-by: Kazuki Miyahara <kmiya@outlook.com>
   Co-authored-by: Makoto Tokunaga <vios-fish@users.noreply.github.com>
   Co-authored-by: Adam Dąbrowski <adam.dabrowski@robotec.ai>
-  * Revert "fix: re-construct laneletMapLayer for reindex RTree (`#463 <https://github.com/youtalk/autoware.universe/issues/463>`_)" (`#1229 <https://github.com/youtalk/autoware.universe/issues/1229>`_)
+  * Revert "fix: re-construct laneletMapLayer for reindex RTree (`#463 <https://github.com/autowarefoundation/autoware.universe/issues/463>`_)" (`#1229 <https://github.com/autowarefoundation/autoware.universe/issues/1229>`_)
   This reverts commit d2ecdfe4c58cb4544c9a3ee84947b36b7ee54421.
-  * add pcd file check (`#1232 <https://github.com/youtalk/autoware.universe/issues/1232>`_)
+  * add pcd file check (`#1232 <https://github.com/autowarefoundation/autoware.universe/issues/1232>`_)
   * add pcd file check
   * add space
   * add &
   * use namespace
-  * Unify Apache-2.0 license name (`#1242 <https://github.com/youtalk/autoware.universe/issues/1242>`_)
-  * Remove use_sim_time for set_parameter (`#1260 <https://github.com/youtalk/autoware.universe/issues/1260>`_)
-  * Map components (`#1311 <https://github.com/youtalk/autoware.universe/issues/1311>`_)
+  * Unify Apache-2.0 license name (`#1242 <https://github.com/autowarefoundation/autoware.universe/issues/1242>`_)
+  * Remove use_sim_time for set_parameter (`#1260 <https://github.com/autowarefoundation/autoware.universe/issues/1260>`_)
+  * Map components (`#1311 <https://github.com/autowarefoundation/autoware.universe/issues/1311>`_)
   * Make pointcloud map loader component
   * Make lanelet2 map loader component
   * Make map tf generator component
@@ -841,13 +841,13 @@ Changelog for package map_loader
   * Fix license
   * Add comment for filesystem
   * Fix variable name for glob
-  * Fix dependency for query (`#1519 <https://github.com/youtalk/autoware.universe/issues/1519>`_)
-  * Fix a small bug (`#1644 <https://github.com/youtalk/autoware.universe/issues/1644>`_)
-  * Fix minor flaws detected by Clang-Tidy (`#1647 <https://github.com/youtalk/autoware.universe/issues/1647>`_)
+  * Fix dependency for query (`#1519 <https://github.com/autowarefoundation/autoware.universe/issues/1519>`_)
+  * Fix a small bug (`#1644 <https://github.com/autowarefoundation/autoware.universe/issues/1644>`_)
+  * Fix minor flaws detected by Clang-Tidy (`#1647 <https://github.com/autowarefoundation/autoware.universe/issues/1647>`_)
   - misc-throw-by-value-catch-by-reference
   - cppcoreguidelines-init-variables
   - readability-isolate-declaration
-  * Add pre-commit (`#1560 <https://github.com/youtalk/autoware.universe/issues/1560>`_)
+  * Add pre-commit (`#1560 <https://github.com/autowarefoundation/autoware.universe/issues/1560>`_)
   * add pre-commit
   * add pre-commit-config
   * add additional settings for private repository
@@ -867,8 +867,8 @@ Changelog for package map_loader
   Co-authored-by: Kazuki Miyahara <kmiya@outlook.com>
   Co-authored-by: pre-commit <pre-commit@example.com>
   Co-authored-by: Kenji Miyake <31987104+kenji-miyake@users.noreply.github.com>
-  * Porting traffic light viz (`#1284 <https://github.com/youtalk/autoware.universe/issues/1284>`_)
-  * Feature/traffic light viz (`#1001 <https://github.com/youtalk/autoware.universe/issues/1001>`_)
+  * Porting traffic light viz (`#1284 <https://github.com/autowarefoundation/autoware.universe/issues/1284>`_)
+  * Feature/traffic light viz (`#1001 <https://github.com/autowarefoundation/autoware.universe/issues/1001>`_)
   * add tl map viz
   * bug fix
   * update map visualizer
@@ -882,12 +882,12 @@ Changelog for package map_loader
   * Replace deprecated duration api
   Co-authored-by: Yukihiro Saito <yukky.saito@gmail.com>
   Co-authored-by: wep21 <border_goldenmarket@yahoo.co.jp>
-  * Add markdownlint and prettier (`#1661 <https://github.com/youtalk/autoware.universe/issues/1661>`_)
+  * Add markdownlint and prettier (`#1661 <https://github.com/autowarefoundation/autoware.universe/issues/1661>`_)
   * Add markdownlint and prettier
   * Ignore .param.yaml
   * Apply format
-  * Feature/compare elevation map (`#1488 <https://github.com/youtalk/autoware.universe/issues/1488>`_)
-  * suppress warnings for declare parameters (`#1724 <https://github.com/youtalk/autoware.universe/issues/1724>`_)
+  * Feature/compare elevation map (`#1488 <https://github.com/autowarefoundation/autoware.universe/issues/1488>`_)
+  * suppress warnings for declare parameters (`#1724 <https://github.com/autowarefoundation/autoware.universe/issues/1724>`_)
   * fix for lanelet2_extension
   * fix for traffic light ssd fine detector
   * fix for topic_state_monitor
@@ -906,7 +906,7 @@ Changelog for package map_loader
   * add Werror
   * add Werror
   * fix style
-  * suppress warnings for map (`#1773 <https://github.com/youtalk/autoware.universe/issues/1773>`_)
+  * suppress warnings for map (`#1773 <https://github.com/autowarefoundation/autoware.universe/issues/1773>`_)
   * add compile option
   * fix error
   * add compile option
@@ -919,30 +919,30 @@ Changelog for package map_loader
   * use U
   * use U
   Co-authored-by: Kenji Miyake <31987104+kenji-miyake@users.noreply.github.com>
-  * Fix clang warnings (`#1859 <https://github.com/youtalk/autoware.universe/issues/1859>`_)
+  * Fix clang warnings (`#1859 <https://github.com/autowarefoundation/autoware.universe/issues/1859>`_)
   * Fix -Wreturn-std-move
   * Fix -Wunused-private-field
   * Ignore -Wnonportable-include-path for mussp
   * Fix -Wunused-const-variable
   * Fix "can not be used when making a shared object"
-  * Sync v1.3.0 (`#1909 <https://github.com/youtalk/autoware.universe/issues/1909>`_)
-  * Add elevation_map to autoware_state_monitor (`#1907 <https://github.com/youtalk/autoware.universe/issues/1907>`_)
-  * Disable saving elevation map temporarily (`#1906 <https://github.com/youtalk/autoware.universe/issues/1906>`_)
-  * Fix typos in README of map_loader (`#1923 <https://github.com/youtalk/autoware.universe/issues/1923>`_)
+  * Sync v1.3.0 (`#1909 <https://github.com/autowarefoundation/autoware.universe/issues/1909>`_)
+  * Add elevation_map to autoware_state_monitor (`#1907 <https://github.com/autowarefoundation/autoware.universe/issues/1907>`_)
+  * Disable saving elevation map temporarily (`#1906 <https://github.com/autowarefoundation/autoware.universe/issues/1906>`_)
+  * Fix typos in README of map_loader (`#1923 <https://github.com/autowarefoundation/autoware.universe/issues/1923>`_)
   * Fix typos in README of map_loader
   * Apply Prettier
-  * fix some typos (`#1941 <https://github.com/youtalk/autoware.universe/issues/1941>`_)
+  * fix some typos (`#1941 <https://github.com/autowarefoundation/autoware.universe/issues/1941>`_)
   * fix some typos
   * fix typo
   * Fix typo
   Co-authored-by: Kenji Miyake <kenji.miyake@tier4.jp>
-  * Add autoware api (`#1979 <https://github.com/youtalk/autoware.universe/issues/1979>`_)
-  * Invoke code formatter at pre-commit (`#1935 <https://github.com/youtalk/autoware.universe/issues/1935>`_)
+  * Add autoware api (`#1979 <https://github.com/autowarefoundation/autoware.universe/issues/1979>`_)
+  * Invoke code formatter at pre-commit (`#1935 <https://github.com/autowarefoundation/autoware.universe/issues/1935>`_)
   * Run ament_uncrustify at pre-commit
   * Reformat existing files
   * Fix copyright and cpplint errors
   Co-authored-by: Kenji Miyake <kenji.miyake@tier4.jp>
-  * Save elevation_map with pcd md5sum (`#1988 <https://github.com/youtalk/autoware.universe/issues/1988>`_)
+  * Save elevation_map with pcd md5sum (`#1988 <https://github.com/autowarefoundation/autoware.universe/issues/1988>`_)
   * Save elevation_map with pcd md5sum
   * Update sample launch
   * Fix cpplint
@@ -969,10 +969,10 @@ Changelog for package map_loader
   * Add isPcdFile
   * Fix pre-commit
   * Use icPcdFile when giving file of pcd
-  * Feature/add virtual traffic light planner (`#1588 <https://github.com/youtalk/autoware.universe/issues/1588>`_)
-  * Fix deprecated constant of transient local (`#1994 <https://github.com/youtalk/autoware.universe/issues/1994>`_)
-  * Fix lint errors in lanelet2_extension (`#2028 <https://github.com/youtalk/autoware.universe/issues/2028>`_)
-  * add sort-package-xml hook in pre-commit (`#1881 <https://github.com/youtalk/autoware.universe/issues/1881>`_)
+  * Feature/add virtual traffic light planner (`#1588 <https://github.com/autowarefoundation/autoware.universe/issues/1588>`_)
+  * Fix deprecated constant of transient local (`#1994 <https://github.com/autowarefoundation/autoware.universe/issues/1994>`_)
+  * Fix lint errors in lanelet2_extension (`#2028 <https://github.com/autowarefoundation/autoware.universe/issues/2028>`_)
+  * add sort-package-xml hook in pre-commit (`#1881 <https://github.com/autowarefoundation/autoware.universe/issues/1881>`_)
   * add sort xml hook in pre-commit
   * change retval to exit_status
   * rename
@@ -986,27 +986,27 @@ Changelog for package map_loader
   * move prettier-xml to pre-commit-hooks-ros
   * update version for bug-fix
   * apply pre-commit
-  * Revert "[map_loader] modify colors for lane markers for better visualization (`#398 <https://github.com/youtalk/autoware.universe/issues/398>`_)" (`#2063 <https://github.com/youtalk/autoware.universe/issues/2063>`_)
+  * Revert "[map_loader] modify colors for lane markers for better visualization (`#398 <https://github.com/autowarefoundation/autoware.universe/issues/398>`_)" (`#2063 <https://github.com/autowarefoundation/autoware.universe/issues/2063>`_)
   This reverts commit 046dc9a770bf03fb8813ddf6aa1b2f05e9357b67.
-  * Fix elevation_map_loader downsample (`#2055 <https://github.com/youtalk/autoware.universe/issues/2055>`_)
-  * Add elevation_map data dir (`#2093 <https://github.com/youtalk/autoware.universe/issues/2093>`_)
-  * Minor fixes of map_loader's README (`#2116 <https://github.com/youtalk/autoware.universe/issues/2116>`_)
+  * Fix elevation_map_loader downsample (`#2055 <https://github.com/autowarefoundation/autoware.universe/issues/2055>`_)
+  * Add elevation_map data dir (`#2093 <https://github.com/autowarefoundation/autoware.universe/issues/2093>`_)
+  * Minor fixes of map_loader's README (`#2116 <https://github.com/autowarefoundation/autoware.universe/issues/2116>`_)
   * Minor fixes of map_loader's README
   * Fix map_loader run command
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-  * Fix elevation_map hash due to mutiple slashes of pcd path (`#2192 <https://github.com/youtalk/autoware.universe/issues/2192>`_)
+  * Fix elevation_map hash due to mutiple slashes of pcd path (`#2192 <https://github.com/autowarefoundation/autoware.universe/issues/2192>`_)
   * Fix elevation_map hash due to mutiple slashes of pcd path
   * Use filesystem lexically_normal
-  * Fix broken links of images on lanelet2_extension docs (`#2206 <https://github.com/youtalk/autoware.universe/issues/2206>`_)
-  * Add lanelet XML API (`#2262 <https://github.com/youtalk/autoware.universe/issues/2262>`_)
-  * show traffic light id marker (`#1554 <https://github.com/youtalk/autoware.universe/issues/1554>`_) (`#1678 <https://github.com/youtalk/autoware.universe/issues/1678>`_)
+  * Fix broken links of images on lanelet2_extension docs (`#2206 <https://github.com/autowarefoundation/autoware.universe/issues/2206>`_)
+  * Add lanelet XML API (`#2262 <https://github.com/autowarefoundation/autoware.universe/issues/2262>`_)
+  * show traffic light id marker (`#1554 <https://github.com/autowarefoundation/autoware.universe/issues/1554>`_) (`#1678 <https://github.com/autowarefoundation/autoware.universe/issues/1678>`_)
   * show traffic light id
   * fix typo
   Co-authored-by: satoshi-ota <satoshi.ota@gmail.com>
   Co-authored-by: Satoshi OTA <44889564+satoshi-ota@users.noreply.github.com>
   Co-authored-by: satoshi-ota <satoshi.ota@gmail.com>
-  * Feature/porting behavior path planner (`#1645 <https://github.com/youtalk/autoware.universe/issues/1645>`_)
-  * Add behavior path planner pkg with Lane Change (`#1525 <https://github.com/youtalk/autoware.universe/issues/1525>`_)
+  * Feature/porting behavior path planner (`#1645 <https://github.com/autowarefoundation/autoware.universe/issues/1645>`_)
+  * Add behavior path planner pkg with Lane Change (`#1525 <https://github.com/autowarefoundation/autoware.universe/issues/1525>`_)
   * add lanelet extension funcs
   * add planning msgs for FOA
   * add behavior_path_planner pkg
@@ -1022,7 +1022,7 @@ Changelog for package map_loader
   * add build depend for behavior tree cpp
   * temporally disable lint test in lanelet2_extension
   Co-authored-by: rej55 <rej55.g@gmail.com>
-  * Add avoidance module in behavior_path_planner (`#1528 <https://github.com/youtalk/autoware.universe/issues/1528>`_)
+  * Add avoidance module in behavior_path_planner (`#1528 <https://github.com/autowarefoundation/autoware.universe/issues/1528>`_)
   * Revert "remove shide-shift & avoidance related files"
   This reverts commit d819ea0291fca251012e4b9ffd16de3896830aa2.
   * refactor findNewShiftPoint func
@@ -1046,41 +1046,41 @@ Changelog for package map_loader
   - fix typo
   * fix typo
   Co-authored-by: Yukihiro Saito <yukky.saito@gmail.com>
-  * Replace behavior_path utilities with autoware_utils (`#1532 <https://github.com/youtalk/autoware.universe/issues/1532>`_)
+  * Replace behavior_path utilities with autoware_utils (`#1532 <https://github.com/autowarefoundation/autoware.universe/issues/1532>`_)
   * replace calcDistance
   * replace arange
   * replave convertToEigenPt with autoware_utils::fromMsg
   * replace normalizeRadian
   * cosmetic change
-  * import `#1526 <https://github.com/youtalk/autoware.universe/issues/1526>`_ into behavior path planner (`#1531 <https://github.com/youtalk/autoware.universe/issues/1531>`_)
-  * Fix/behavior path empty path output guard (`#1536 <https://github.com/youtalk/autoware.universe/issues/1536>`_)
+  * import `#1526 <https://github.com/autowarefoundation/autoware.universe/issues/1526>`_ into behavior path planner (`#1531 <https://github.com/autowarefoundation/autoware.universe/issues/1531>`_)
+  * Fix/behavior path empty path output guard (`#1536 <https://github.com/autowarefoundation/autoware.universe/issues/1536>`_)
   * add guard
   * Update planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/src/behavior_path_planner.cpp
-  * fix lateral jerk calculation (`#1549 <https://github.com/youtalk/autoware.universe/issues/1549>`_)
-  * fix: error handling on exception in behavior_path_planner (`#1551 <https://github.com/youtalk/autoware.universe/issues/1551>`_)
-  * Fix ignore too steep avoidance path (`#1550 <https://github.com/youtalk/autoware.universe/issues/1550>`_)
+  * fix lateral jerk calculation (`#1549 <https://github.com/autowarefoundation/autoware.universe/issues/1549>`_)
+  * fix: error handling on exception in behavior_path_planner (`#1551 <https://github.com/autowarefoundation/autoware.universe/issues/1551>`_)
+  * Fix ignore too steep avoidance path (`#1550 <https://github.com/autowarefoundation/autoware.universe/issues/1550>`_)
   * ignore too steep path
   * Update planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
   * parametrize lateral jerk limit
   * Update planning/scenario_planning/lane_driving/behavior_planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module.hpp
   Co-authored-by: tkimura4 <tomoya.kimura@tier4.jp>
   Co-authored-by: tkimura4 <tomoya.kimura@tier4.jp>
-  * use offsetNoThrow and add error log (`#1615 <https://github.com/youtalk/autoware.universe/issues/1615>`_)
-  * Ignore object ahead goal for avoidance (`#1618 <https://github.com/youtalk/autoware.universe/issues/1618>`_)
+  * use offsetNoThrow and add error log (`#1615 <https://github.com/autowarefoundation/autoware.universe/issues/1615>`_)
+  * Ignore object ahead goal for avoidance (`#1618 <https://github.com/autowarefoundation/autoware.universe/issues/1618>`_)
   * Ignore object ahead goal for avoidance
   * Add flag
   * Fix position of definition of goal_pose
   * Fix arclength calculation
   * Fix position of definition of goal_pose
-  * fix intersection stop line (`#1636 <https://github.com/youtalk/autoware.universe/issues/1636>`_)
+  * fix intersection stop line (`#1636 <https://github.com/autowarefoundation/autoware.universe/issues/1636>`_)
   * fix intersection stop line
   * fix typo
-  * add document (`#1635 <https://github.com/youtalk/autoware.universe/issues/1635>`_)
+  * add document (`#1635 <https://github.com/autowarefoundation/autoware.universe/issues/1635>`_)
   * Port behavior path planner to ros2
   * Apply lint
   * Fix typo
   * Fix map qos
-  * debug slope calculation in behavior (`#1566 <https://github.com/youtalk/autoware.universe/issues/1566>`_)
+  * debug slope calculation in behavior (`#1566 <https://github.com/autowarefoundation/autoware.universe/issues/1566>`_)
   * update
   * update
   * revert change of autoware_utils
@@ -1113,17 +1113,17 @@ Changelog for package map_loader
   Co-authored-by: Yukihiro Saito <yukky.saito@gmail.com>
   Co-authored-by: tkimura4 <tomoya.kimura@tier4.jp>
   Co-authored-by: Takayuki Murooka <takayuki5168@gmail.com>
-  * change type of traffic light marker (SPHERE_LIST->SPHERE) (`#1789 <https://github.com/youtalk/autoware.universe/issues/1789>`_)
-  * fix alpha (`#1797 <https://github.com/youtalk/autoware.universe/issues/1797>`_)
-  * Feature/improve intersection detection area (`#1958 <https://github.com/youtalk/autoware.universe/issues/1958>`_)
+  * change type of traffic light marker (SPHERE_LIST->SPHERE) (`#1789 <https://github.com/autowarefoundation/autoware.universe/issues/1789>`_)
+  * fix alpha (`#1797 <https://github.com/autowarefoundation/autoware.universe/issues/1797>`_)
+  * Feature/improve intersection detection area (`#1958 <https://github.com/autowarefoundation/autoware.universe/issues/1958>`_)
   * exclude ego_lanes from detection_area
   * add empty handling
   * remove unused function
   * Fix for uncrustify
   Co-authored-by: Kenji Miyake <31987104+kenji-miyake@users.noreply.github.com>
-  * Apply format (`#1999 <https://github.com/youtalk/autoware.universe/issues/1999>`_)
+  * Apply format (`#1999 <https://github.com/autowarefoundation/autoware.universe/issues/1999>`_)
   Fix cpplint
-  * Feature/expand drivable area (`#1812 <https://github.com/youtalk/autoware.universe/issues/1812>`_)
+  * Feature/expand drivable area (`#1812 <https://github.com/autowarefoundation/autoware.universe/issues/1812>`_)
   * check if ego lane has adjacent lane or not
   * expand drivable area by using lanelet
   * remove unnecessary operator
@@ -1136,7 +1136,7 @@ Changelog for package map_loader
   * update area name
   * disable expand by default
   Co-authored-by: satoshi-ota <satoshi.ota@gmail.com>
-  * add shoulder road lanelets (`#2121 <https://github.com/youtalk/autoware.universe/issues/2121>`_)
+  * add shoulder road lanelets (`#2121 <https://github.com/autowarefoundation/autoware.universe/issues/2121>`_)
   * add shoulder lanelets
   * Update map/lanelet2_extension/lib/query.cpp
   Co-authored-by: Daisuke Nishimatsu <42202095+wep21@users.noreply.github.com>
@@ -1149,7 +1149,7 @@ Changelog for package map_loader
   * Update map/lanelet2_extension/lib/visualization.cpp
   Co-authored-by: Daisuke Nishimatsu <42202095+wep21@users.noreply.github.com>
   Co-authored-by: Daisuke Nishimatsu <42202095+wep21@users.noreply.github.com>
-  * Feature/no stopping area reg element (`#2144 <https://github.com/youtalk/autoware.universe/issues/2144>`_)
+  * Feature/no stopping area reg element (`#2144 <https://github.com/autowarefoundation/autoware.universe/issues/2144>`_)
   * add no stopping area to ll2
   * add no stopping area visualization
   * add no stopping area marker to RVIZ
@@ -1157,7 +1157,7 @@ Changelog for package map_loader
   * Update map/map_loader/src/lanelet2_map_loader/lanelet2_map_visualization_node.cpp
   Co-authored-by: taikitanaka3 <65527974+taikitanaka3@users.noreply.github.com>
   Co-authored-by: tkimura4 <tomoya.kimura@tier4.jp>
-  * Add document for new map format (`#1778 <https://github.com/youtalk/autoware.universe/issues/1778>`_)
+  * Add document for new map format (`#1778 <https://github.com/autowarefoundation/autoware.universe/issues/1778>`_)
   * add roadside lane doc
   * fix typo
   * fix typo
@@ -1167,7 +1167,7 @@ Changelog for package map_loader
   * add reason for new subtype definition
   * fix typo
   Co-authored-by: kyoichi <kyoichi.sugahara@tier4.jp>
-  * Change formatter to clang-format and black (`#2332 <https://github.com/youtalk/autoware.universe/issues/2332>`_)
+  * Change formatter to clang-format and black (`#2332 <https://github.com/autowarefoundation/autoware.universe/issues/2332>`_)
   * Revert "Temporarily comment out pre-commit hooks"
   This reverts commit 748e9cdb145ce12f8b520bcbd97f5ff899fc28a3.
   * Replace ament_lint_common with autoware_lint_common
@@ -1179,14 +1179,14 @@ Changelog for package map_loader
   * Fix include double quotes to angle brackets
   * Apply clang-format
   * Fix build errors
-  * Add COLCON_IGNORE (`#500 <https://github.com/youtalk/autoware.universe/issues/500>`_)
-  * port lanelet2_extension (`#483 <https://github.com/youtalk/autoware.universe/issues/483>`_)
+  * Add COLCON_IGNORE (`#500 <https://github.com/autowarefoundation/autoware.universe/issues/500>`_)
+  * port lanelet2_extension (`#483 <https://github.com/autowarefoundation/autoware.universe/issues/483>`_)
   * port with auto_msgs
   * remove COLCON_IGNORE
   Co-authored-by: Takayuki Murooka <takayuki.murooka@tier4.jp>
-  * port map loader (`#508 <https://github.com/youtalk/autoware.universe/issues/508>`_)
-  * remove COLCON_IGNORE in system_packages and map_tf_generator (`#532 <https://github.com/youtalk/autoware.universe/issues/532>`_)
-  * add readme (`#561 <https://github.com/youtalk/autoware.universe/issues/561>`_)
+  * port map loader (`#508 <https://github.com/autowarefoundation/autoware.universe/issues/508>`_)
+  * remove COLCON_IGNORE in system_packages and map_tf_generator (`#532 <https://github.com/autowarefoundation/autoware.universe/issues/532>`_)
+  * add readme (`#561 <https://github.com/autowarefoundation/autoware.universe/issues/561>`_)
   * fix old description
   Co-authored-by: mitsudome-r <ryohsuke.mitsudome@tier4.jp>
   Co-authored-by: Taichi Higashide <taichi.higashide@tier4.jp>

--- a/perception/autoware_bytetrack/CHANGELOG.rst
+++ b/perception/autoware_bytetrack/CHANGELOG.rst
@@ -5,7 +5,7 @@ Changelog for package autoware_bytetrack
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* refactor(tensorrt_common)!: fix namespace, directory structure & move to perception namespace (`#9099 <https://github.com/youtalk/autoware.universe/issues/9099>`_)
+* refactor(tensorrt_common)!: fix namespace, directory structure & move to perception namespace (`#9099 <https://github.com/autowarefoundation/autoware.universe/issues/9099>`_)
   * refactor(tensorrt_common)!: fix namespace, directory structure & move to perception namespace
   * refactor(tensorrt_common): directory structure
   * style(pre-commit): autofix
@@ -13,13 +13,13 @@ Changelog for package autoware_bytetrack
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Kenzo Lobos Tsunekawa <kenzo.lobos@tier4.jp>
-* refactor(kalman_filter): prefix package and namespace with autoware (`#7787 <https://github.com/youtalk/autoware.universe/issues/7787>`_)
+* refactor(kalman_filter): prefix package and namespace with autoware (`#7787 <https://github.com/autowarefoundation/autoware.universe/issues/7787>`_)
   * refactor(kalman_filter): prefix package and namespace with autoware
   * move headers to include/autoware/
   * style(pre-commit): autofix
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* refactor(bytetrack):  fix namespace and directory structure (`#8125 <https://github.com/youtalk/autoware.universe/issues/8125>`_)
+* refactor(bytetrack):  fix namespace and directory structure (`#8125 <https://github.com/autowarefoundation/autoware.universe/issues/8125>`_)
   * chore: fix namespace
   * chore: change include name
   * refactor: rename perception/bytetrack to perception/autoware_bytetrack

--- a/perception/autoware_cluster_merger/CHANGELOG.rst
+++ b/perception/autoware_cluster_merger/CHANGELOG.rst
@@ -5,13 +5,13 @@ Changelog for package autoware_cluster_merger
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* refactor(object_recognition_utils): add autoware prefix to object_recognition_utils (`#8946 <https://github.com/youtalk/autoware.universe/issues/8946>`_)
-* chore(cluster_merger): add node test (`#8810 <https://github.com/youtalk/autoware.universe/issues/8810>`_)
+* refactor(object_recognition_utils): add autoware prefix to object_recognition_utils (`#8946 <https://github.com/autowarefoundation/autoware.universe/issues/8946>`_)
+* chore(cluster_merger): add node test (`#8810 <https://github.com/autowarefoundation/autoware.universe/issues/8810>`_)
   * chore(cluster_merger): add node test
   * fix: rename output topic
   ---------
-* refactor(cluster_merger): remove unused variable and rename topic (`#8809 <https://github.com/youtalk/autoware.universe/issues/8809>`_)
-* refactor(cluster_merger): add package name prefix of autoware\_ (`#8001 <https://github.com/youtalk/autoware.universe/issues/8001>`_)
+* refactor(cluster_merger): remove unused variable and rename topic (`#8809 <https://github.com/autowarefoundation/autoware.universe/issues/8809>`_)
+* refactor(cluster_merger): add package name prefix of autoware\_ (`#8001 <https://github.com/autowarefoundation/autoware.universe/issues/8001>`_)
 * Contributors: Esteve Fernandez, Yutaka Kondo, badai nguyen
 
 0.26.0 (2024-04-03)

--- a/perception/autoware_compare_map_segmentation/CHANGELOG.rst
+++ b/perception/autoware_compare_map_segmentation/CHANGELOG.rst
@@ -5,15 +5,15 @@ Changelog for package autoware_compare_map_segmentation
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* refactor(autoware_point_types): prefix namespace with autoware::point_types (`#9169 <https://github.com/youtalk/autoware.universe/issues/9169>`_)
-* refactor(autoware_compare_map_segmentation): resolve clang-tidy error in autoware_compare_map_segmentation (`#9162 <https://github.com/youtalk/autoware.universe/issues/9162>`_)
+* refactor(autoware_point_types): prefix namespace with autoware::point_types (`#9169 <https://github.com/autowarefoundation/autoware.universe/issues/9169>`_)
+* refactor(autoware_compare_map_segmentation): resolve clang-tidy error in autoware_compare_map_segmentation (`#9162 <https://github.com/autowarefoundation/autoware.universe/issues/9162>`_)
   * refactor(autoware_compare_map_segmentation): resolve clang-tidy error in autoware_compare_map_segmentation
   * style(pre-commit): autofix
   * include message_filters as SYSTEM
   * style(pre-commit): autofix
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* fix(compare_map_segmentation): add missing mutex lock (`#9097 <https://github.com/youtalk/autoware.universe/issues/9097>`_)
+* fix(compare_map_segmentation): add missing mutex lock (`#9097 <https://github.com/autowarefoundation/autoware.universe/issues/9097>`_)
   * fix(compare_map_segmentation): missing mutux
   * chore: rename mutex\_
   * fix: remove unnecessary mutex
@@ -24,7 +24,7 @@ Changelog for package autoware_compare_map_segmentation
   * fix: memory ordering
   * fix: replace all static_map_loader_mutex\_
   ---------
-* fix(compare_map_segmentation): throw runtime error when using non-split map pointcloud for DynamicMapLoader (`#9024 <https://github.com/youtalk/autoware.universe/issues/9024>`_)
+* fix(compare_map_segmentation): throw runtime error when using non-split map pointcloud for DynamicMapLoader (`#9024 <https://github.com/autowarefoundation/autoware.universe/issues/9024>`_)
   * fix(compare_map_segmentation): throw runtime error when using non-split map pointcloud for DynamicMapLoader
   * chore: typo
   * fix: launch
@@ -33,34 +33,34 @@ Changelog for package autoware_compare_map_segmentation
   * fix: change to RCLCPP_ERROR
   ---------
   Co-authored-by: Yoshi Ri <yoshiyoshidetteiu@gmail.com>
-* chore(compare_map_segmentation): add node tests (`#8907 <https://github.com/youtalk/autoware.universe/issues/8907>`_)
+* chore(compare_map_segmentation): add node tests (`#8907 <https://github.com/autowarefoundation/autoware.universe/issues/8907>`_)
   * chore(compare_map_segmentation): add test for voxel_based_compare_map_filter
   * feat: add test for other compare map filter
   * style(pre-commit): autofix
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* fix(autoware_compare_map_segmentation): typo bug fix (`#8939 <https://github.com/youtalk/autoware.universe/issues/8939>`_)
+* fix(autoware_compare_map_segmentation): typo bug fix (`#8939 <https://github.com/autowarefoundation/autoware.universe/issues/8939>`_)
   fix(compare_map_filter): typo bug fix
-* fix(autoware_compare_map_segmentation): fix unusedFunction (`#8725 <https://github.com/youtalk/autoware.universe/issues/8725>`_)
+* fix(autoware_compare_map_segmentation): fix unusedFunction (`#8725 <https://github.com/autowarefoundation/autoware.universe/issues/8725>`_)
   fix:unusedFunction
-* fix(compare_map_segmentation): use squared distance to compare threshold (`#8744 <https://github.com/youtalk/autoware.universe/issues/8744>`_)
+* fix(compare_map_segmentation): use squared distance to compare threshold (`#8744 <https://github.com/autowarefoundation/autoware.universe/issues/8744>`_)
   fix: use square distance to compare threshold
-* fix(autoware_compare_map_segmentation): fix unusedFunction (`#8565 <https://github.com/youtalk/autoware.universe/issues/8565>`_)
+* fix(autoware_compare_map_segmentation): fix unusedFunction (`#8565 <https://github.com/autowarefoundation/autoware.universe/issues/8565>`_)
   fix:unusedFunction
-* fix(autoware_compare_map_segmentation): fix cppcheck warnings of functionStatic (`#8263 <https://github.com/youtalk/autoware.universe/issues/8263>`_)
+* fix(autoware_compare_map_segmentation): fix cppcheck warnings of functionStatic (`#8263 <https://github.com/autowarefoundation/autoware.universe/issues/8263>`_)
   * fix: deal with functionStatic warnings
   * fix: deal with functionStatic warnings
   * fix: remove unnecessary const
   * fix: build error
   ---------
-* fix(autoware_compare_map_segmentation): fix uninitMemberVar (`#8338 <https://github.com/youtalk/autoware.universe/issues/8338>`_)
+* fix(autoware_compare_map_segmentation): fix uninitMemberVar (`#8338 <https://github.com/autowarefoundation/autoware.universe/issues/8338>`_)
   fix:uninitMemberVar
-* fix(autoware_compare_map_segmentation): fix passedByValue (`#8233 <https://github.com/youtalk/autoware.universe/issues/8233>`_)
+* fix(autoware_compare_map_segmentation): fix passedByValue (`#8233 <https://github.com/autowarefoundation/autoware.universe/issues/8233>`_)
   fix:passedByValue
-* fix(autoware_compare_map_segmentation): fix redundantInitialization warning (`#8226 <https://github.com/youtalk/autoware.universe/issues/8226>`_)
-* revert: revert "refactor(autoware_map_msgs): modify pcd metadata msg (`#7852 <https://github.com/youtalk/autoware.universe/issues/7852>`_)" (`#8180 <https://github.com/youtalk/autoware.universe/issues/8180>`_)
-* refactor(autoware_map_msgs): modify pcd metadata msg (`#7852 <https://github.com/youtalk/autoware.universe/issues/7852>`_)
-* refactor(compare_map_segmentation): add package name prefix of autoware\_ (`#8005 <https://github.com/youtalk/autoware.universe/issues/8005>`_)
+* fix(autoware_compare_map_segmentation): fix redundantInitialization warning (`#8226 <https://github.com/autowarefoundation/autoware.universe/issues/8226>`_)
+* revert: revert "refactor(autoware_map_msgs): modify pcd metadata msg (`#7852 <https://github.com/autowarefoundation/autoware.universe/issues/7852>`_)" (`#8180 <https://github.com/autowarefoundation/autoware.universe/issues/8180>`_)
+* refactor(autoware_map_msgs): modify pcd metadata msg (`#7852 <https://github.com/autowarefoundation/autoware.universe/issues/7852>`_)
+* refactor(compare_map_segmentation): add package name prefix of autoware\_ (`#8005 <https://github.com/autowarefoundation/autoware.universe/issues/8005>`_)
   * refactor(compare_map_segmentation): add package name prefix of autoware\_
   * docs: update Readme
   ---------

--- a/perception/autoware_crosswalk_traffic_light_estimator/CHANGELOG.rst
+++ b/perception/autoware_crosswalk_traffic_light_estimator/CHANGELOG.rst
@@ -5,15 +5,15 @@ Changelog for package autoware_crosswalk_traffic_light_estimator
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* fix(autoware_crosswalk_traffic_light_estimator): fix constVariableReference (`#8055 <https://github.com/youtalk/autoware.universe/issues/8055>`_)
+* fix(autoware_crosswalk_traffic_light_estimator): fix constVariableReference (`#8055 <https://github.com/autowarefoundation/autoware.universe/issues/8055>`_)
   fix:constVariableReference
-* feat: add `autoware\_` prefix to `lanelet2_extension` (`#7640 <https://github.com/youtalk/autoware.universe/issues/7640>`_)
-* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/youtalk/autoware.universe/issues/7594>`_)
-* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/youtalk/autoware.universe/issues/7538>`_)
+* feat: add `autoware\_` prefix to `lanelet2_extension` (`#7640 <https://github.com/autowarefoundation/autoware.universe/issues/7640>`_)
+* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/autowarefoundation/autoware.universe/issues/7594>`_)
+* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/autowarefoundation/autoware.universe/issues/7538>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* fix(tier4_control_launch, crosswalk_traffic_light_estimator): fix a mistake when adding prefixes (`#7423 <https://github.com/youtalk/autoware.universe/issues/7423>`_)
+* fix(tier4_control_launch, crosswalk_traffic_light_estimator): fix a mistake when adding prefixes (`#7423 <https://github.com/autowarefoundation/autoware.universe/issues/7423>`_)
   Fixed a mistake when adding prefixes
-* refactor(accel_brake_map_calibrator)!: add autoware\_ prefix (`#7351 <https://github.com/youtalk/autoware.universe/issues/7351>`_)
+* refactor(accel_brake_map_calibrator)!: add autoware\_ prefix (`#7351 <https://github.com/autowarefoundation/autoware.universe/issues/7351>`_)
   * add prefix to the codes
   change dir name
   update
@@ -24,7 +24,7 @@ Changelog for package autoware_crosswalk_traffic_light_estimator
   * restore
   * poi
   ---------
-* refactor(crosswalk_traffic_light_estimator)!: add autoware\_ prefix (`#7365 <https://github.com/youtalk/autoware.universe/issues/7365>`_)
+* refactor(crosswalk_traffic_light_estimator)!: add autoware\_ prefix (`#7365 <https://github.com/autowarefoundation/autoware.universe/issues/7365>`_)
   * add prefix
 * Contributors: Kosuke Takeuchi, SakodaShintaro, Takayuki Murooka, Yuki TAKAGI, Yutaka Kondo, kobayu858
 

--- a/perception/autoware_detected_object_feature_remover/CHANGELOG.rst
+++ b/perception/autoware_detected_object_feature_remover/CHANGELOG.rst
@@ -5,13 +5,13 @@ Changelog for package autoware_detected_object_feature_remover
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* test(autoware_detected_object_feature_remover): add unit testing for the node (`#8735 <https://github.com/youtalk/autoware.universe/issues/8735>`_)
+* test(autoware_detected_object_feature_remover): add unit testing for the node (`#8735 <https://github.com/autowarefoundation/autoware.universe/issues/8735>`_)
   * test: add unit testing for the node
   * test: update to run node testings with `ROS_DOMAIN_ID` isolation
   ---------
-* chore(autoware_deteted_object_feature_remover): add code owners (`#8962 <https://github.com/youtalk/autoware.universe/issues/8962>`_)
+* chore(autoware_deteted_object_feature_remover): add code owners (`#8962 <https://github.com/autowarefoundation/autoware.universe/issues/8962>`_)
   Add yoshiri and kotaro as code owners of feature remover
-* refactor(detected_object_feature_remover)!: add package name prefix of autoware\_ (`#8127 <https://github.com/youtalk/autoware.universe/issues/8127>`_)
+* refactor(detected_object_feature_remover)!: add package name prefix of autoware\_ (`#8127 <https://github.com/autowarefoundation/autoware.universe/issues/8127>`_)
   refactor(detected_object_feature_remover): add package name prefix of autoware\_
 * Contributors: Kotaro Uetake, Yoshi Ri, Yutaka Kondo, badai nguyen
 

--- a/perception/autoware_detected_object_validation/CHANGELOG.rst
+++ b/perception/autoware_detected_object_validation/CHANGELOG.rst
@@ -5,8 +5,8 @@ Changelog for package autoware_detected_object_validation
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* refactor(object_recognition_utils): add autoware prefix to object_recognition_utils (`#8946 <https://github.com/youtalk/autoware.universe/issues/8946>`_)
-* refactor(detected_object_validation): rework parameters (`#7750 <https://github.com/youtalk/autoware.universe/issues/7750>`_)
+* refactor(object_recognition_utils): add autoware prefix to object_recognition_utils (`#8946 <https://github.com/autowarefoundation/autoware.universe/issues/8946>`_)
+* refactor(detected_object_validation): rework parameters (`#7750 <https://github.com/autowarefoundation/autoware.universe/issues/7750>`_)
   * refactor(detected_object_validation): rework parameters
   * style(pre-commit): autofix
   * Update perception/detected_object_validation/schema/object_lanelet_filter.schema.json
@@ -22,13 +22,13 @@ Changelog for package autoware_detected_object_validation
   * style(pre-commit): autofix
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* fix(autoware_detected_object_validation): fix functionStatic (`#8482 <https://github.com/youtalk/autoware.universe/issues/8482>`_)
+* fix(autoware_detected_object_validation): fix functionStatic (`#8482 <https://github.com/autowarefoundation/autoware.universe/issues/8482>`_)
   fix:functionStatic
-* fix(autoware_detected_object_validation): fix cppcheck warnings of functionStatic (`#8256 <https://github.com/youtalk/autoware.universe/issues/8256>`_)
+* fix(autoware_detected_object_validation): fix cppcheck warnings of functionStatic (`#8256 <https://github.com/autowarefoundation/autoware.universe/issues/8256>`_)
   fix: deal with functionStatic warnings
-* fix(autoware_detected_object_validation): fix functionConst (`#8285 <https://github.com/youtalk/autoware.universe/issues/8285>`_)
+* fix(autoware_detected_object_validation): fix functionConst (`#8285 <https://github.com/autowarefoundation/autoware.universe/issues/8285>`_)
   fix: functionConst
-* perf(autoware_detected_object_validation): reduce lanelet_filter processing time  (`#8240 <https://github.com/youtalk/autoware.universe/issues/8240>`_)
+* perf(autoware_detected_object_validation): reduce lanelet_filter processing time  (`#8240 <https://github.com/autowarefoundation/autoware.universe/issues/8240>`_)
   * add local r-tree for fast searching
   change to _func\_\_
   add more debug
@@ -46,7 +46,7 @@ Changelog for package autoware_detected_object_validation
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Taekjin LEE <taekjin.lee@tier4.jp>
-* refactor(probabilistic_occupancy_grid_map, occupancy_grid_map_outlier_filter): add autoware\_ prefix to package name (`#8183 <https://github.com/youtalk/autoware.universe/issues/8183>`_)
+* refactor(probabilistic_occupancy_grid_map, occupancy_grid_map_outlier_filter): add autoware\_ prefix to package name (`#8183 <https://github.com/autowarefoundation/autoware.universe/issues/8183>`_)
   * chore: fix package name probabilistic occupancy grid map
   * fix: solve launch error
   * chore: update occupancy_grid_map_outlier_filter
@@ -56,7 +56,7 @@ Changelog for package autoware_detected_object_validation
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Taekjin LEE <taekjin.lee@tier4.jp>
-* refactor(detected_object_validation)!: add package name prefix of autoware\_ (`#8122 <https://github.com/youtalk/autoware.universe/issues/8122>`_)
+* refactor(detected_object_validation)!: add package name prefix of autoware\_ (`#8122 <https://github.com/autowarefoundation/autoware.universe/issues/8122>`_)
   refactor: rename detected_object_validation to autoware_detected_object_validation
 * Contributors: Batuhan Beytekin, Esteve Fernandez, Hayate TOBA, Masaki Baba, Taekjin LEE, Yoshi Ri, Yutaka Kondo, kobayu858, taisa1
 

--- a/perception/autoware_detection_by_tracker/CHANGELOG.rst
+++ b/perception/autoware_detection_by_tracker/CHANGELOG.rst
@@ -5,33 +5,33 @@ Changelog for package autoware_detection_by_tracker
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* feat(autoware_shape_estimation): add reference object based corrector (`#9148 <https://github.com/youtalk/autoware.universe/issues/9148>`_)
+* feat(autoware_shape_estimation): add reference object based corrector (`#9148 <https://github.com/autowarefoundation/autoware.universe/issues/9148>`_)
   * add object based corrector
   * apply cppcheck suggestion
   * fix typo
   ---------
   Co-authored-by: Taekjin LEE <taekjin.lee@tier4.jp>
-* refactor(object_recognition_utils): add autoware prefix to object_recognition_utils (`#8946 <https://github.com/youtalk/autoware.universe/issues/8946>`_)
-* fix(autoware_detection_by_tracker): fix cppcheck warning of functionStatic (`#8257 <https://github.com/youtalk/autoware.universe/issues/8257>`_)
+* refactor(object_recognition_utils): add autoware prefix to object_recognition_utils (`#8946 <https://github.com/autowarefoundation/autoware.universe/issues/8946>`_)
+* fix(autoware_detection_by_tracker): fix cppcheck warning of functionStatic (`#8257 <https://github.com/autowarefoundation/autoware.universe/issues/8257>`_)
   fix: deal with functionStatic warnings
   Co-authored-by: Yi-Hsiang Fang (Vivid) <146902905+vividf@users.noreply.github.com>
-* refactor(shape_estimation): add package name prefix of autoware\_ (`#7999 <https://github.com/youtalk/autoware.universe/issues/7999>`_)
+* refactor(shape_estimation): add package name prefix of autoware\_ (`#7999 <https://github.com/autowarefoundation/autoware.universe/issues/7999>`_)
   * refactor(shape_estimation): add package name prefix of autoware\_
   * style(pre-commit): autofix
   * fix: mising prefix
   * fix: cmake
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* fix(autoware_detection_by_tracker): fix funcArgNamesDifferent (`#8076 <https://github.com/youtalk/autoware.universe/issues/8076>`_)
+* fix(autoware_detection_by_tracker): fix funcArgNamesDifferent (`#8076 <https://github.com/autowarefoundation/autoware.universe/issues/8076>`_)
   * fix:funcArgNamesDifferent
   * fix:funcArgNamesDifferent
   ---------
-* refactor(euclidean_cluster): add package name prefix of autoware\_ (`#8003 <https://github.com/youtalk/autoware.universe/issues/8003>`_)
+* refactor(euclidean_cluster): add package name prefix of autoware\_ (`#8003 <https://github.com/autowarefoundation/autoware.universe/issues/8003>`_)
   * refactor(euclidean_cluster): add package name prefix of autoware\_
   * style(pre-commit): autofix
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* refactor(detection_by_tracker): add package name prefix of autoware\_ (`#7998 <https://github.com/youtalk/autoware.universe/issues/7998>`_)
+* refactor(detection_by_tracker): add package name prefix of autoware\_ (`#7998 <https://github.com/autowarefoundation/autoware.universe/issues/7998>`_)
 * Contributors: Esteve Fernandez, Masaki Baba, Yutaka Kondo, badai nguyen, kobayu858, taisa1
 
 0.26.0 (2024-04-03)

--- a/perception/autoware_elevation_map_loader/CHANGELOG.rst
+++ b/perception/autoware_elevation_map_loader/CHANGELOG.rst
@@ -5,10 +5,10 @@ Changelog for package autoware_elevation_map_loader
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* refactor(autoware_grid_map_utils): prefix folder structure with autoware/ (`#9170 <https://github.com/youtalk/autoware.universe/issues/9170>`_)
-* fix(autoware_elevation_map_loader): fix functionConst (`#8293 <https://github.com/youtalk/autoware.universe/issues/8293>`_)
+* refactor(autoware_grid_map_utils): prefix folder structure with autoware/ (`#9170 <https://github.com/autowarefoundation/autoware.universe/issues/9170>`_)
+* fix(autoware_elevation_map_loader): fix functionConst (`#8293 <https://github.com/autowarefoundation/autoware.universe/issues/8293>`_)
   fix: functionConst
-* refactor(elevation_map_loader): add package name prefix `autoware\_`, fix namespace and directory structure (`#7988 <https://github.com/youtalk/autoware.universe/issues/7988>`_)
+* refactor(elevation_map_loader): add package name prefix `autoware\_`, fix namespace and directory structure (`#7988 <https://github.com/autowarefoundation/autoware.universe/issues/7988>`_)
   * refactor: add namespace, remove unused dependencies, file structure
   chore: remove unused dependencies
   style(pre-commit): autofix

--- a/perception/autoware_euclidean_cluster/CHANGELOG.rst
+++ b/perception/autoware_euclidean_cluster/CHANGELOG.rst
@@ -5,8 +5,8 @@ Changelog for package autoware_euclidean_cluster
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* refactor(autoware_point_types): prefix namespace with autoware::point_types (`#9169 <https://github.com/youtalk/autoware.universe/issues/9169>`_)
-* refactor(autoware_pointcloud_preprocessor): rework crop box parameters (`#8466 <https://github.com/youtalk/autoware.universe/issues/8466>`_)
+* refactor(autoware_point_types): prefix namespace with autoware::point_types (`#9169 <https://github.com/autowarefoundation/autoware.universe/issues/9169>`_)
+* refactor(autoware_pointcloud_preprocessor): rework crop box parameters (`#8466 <https://github.com/autowarefoundation/autoware.universe/issues/8466>`_)
   * feat: add parameter schema for crop box
   * chore: fix readme
   * chore: remove filter.param.yaml file
@@ -14,7 +14,7 @@ Changelog for package autoware_euclidean_cluster
   * chore: fix schema description
   * chore: fix description of negative param
   ---------
-* refactor(pointcloud_preprocessor): prefix package and namespace with autoware (`#7983 <https://github.com/youtalk/autoware.universe/issues/7983>`_)
+* refactor(pointcloud_preprocessor): prefix package and namespace with autoware (`#7983 <https://github.com/autowarefoundation/autoware.universe/issues/7983>`_)
   * refactor(pointcloud_preprocessor)!: prefix package and namespace with autoware
   * style(pre-commit): autofix
   * style(pointcloud_preprocessor): suppress line length check for macros
@@ -28,7 +28,7 @@ Changelog for package autoware_euclidean_cluster
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Kenzo Lobos Tsunekawa <kenzo.lobos@tier4.jp>
-* refactor(euclidean_cluster): add package name prefix of autoware\_ (`#8003 <https://github.com/youtalk/autoware.universe/issues/8003>`_)
+* refactor(euclidean_cluster): add package name prefix of autoware\_ (`#8003 <https://github.com/autowarefoundation/autoware.universe/issues/8003>`_)
   * refactor(euclidean_cluster): add package name prefix of autoware\_
   * style(pre-commit): autofix
   ---------

--- a/perception/autoware_ground_segmentation/CHANGELOG.rst
+++ b/perception/autoware_ground_segmentation/CHANGELOG.rst
@@ -5,7 +5,7 @@ Changelog for package autoware_ground_segmentation
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* feat(autoware_ground_segmentation): implementing linear least square fitting for local gradient calculation (`#9116 <https://github.com/youtalk/autoware.universe/issues/9116>`_)
+* feat(autoware_ground_segmentation): implementing linear least square fitting for local gradient calculation (`#9116 <https://github.com/autowarefoundation/autoware.universe/issues/9116>`_)
   * refactor: calculate local ground gradient in classifyPointCloudGridScan
   Calculate the local ground gradient by fitting a line to the ground grids in the classifyPointCloudGridScan function. This improves the accuracy of the gradient calculation and ensures more precise extrapolation of the ground height.
   * refactor: calculate local ground gradient in classifyPointCloudGridScan
@@ -16,7 +16,7 @@ Changelog for package autoware_ground_segmentation
   * refactor: fix ground gradient calculation in checkContinuousGndGrid function
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* fix(autoware_ground_segmentation): fix scan ground filter logic  (`#9084 <https://github.com/youtalk/autoware.universe/issues/9084>`_)
+* fix(autoware_ground_segmentation): fix scan ground filter logic  (`#9084 <https://github.com/autowarefoundation/autoware.universe/issues/9084>`_)
   * refactor: initialize gnd_grids in ScanGroundFilterComponent::initializeFirstGndGrids
   Initialize gnd_grids vector in the ScanGroundFilterComponent::initializeFirstGndGrids function to ensure it is empty and has the correct capacity. This improves the efficiency of the function and ensures accurate grid initialization.
   * refactor: initialize gnd_grids vector in initializeFirstGndGrids function
@@ -35,7 +35,7 @@ Changelog for package autoware_ground_segmentation
   * refactor: fix logic description comment
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* chore(autoware_ground_segmentation): scan ground filter refactoring (`#9061 <https://github.com/youtalk/autoware.universe/issues/9061>`_)
+* chore(autoware_ground_segmentation): scan ground filter refactoring (`#9061 <https://github.com/autowarefoundation/autoware.universe/issues/9061>`_)
   * chore: Add comment classification logic for point cloud grid scan
   * chore: renamed horizontal angle to azimuth angle
   * chore: rename offset to data_index
@@ -54,7 +54,7 @@ Changelog for package autoware_ground_segmentation
   * chore: reduce scope
   * refactor: align structure between convertPointcloud and convertPointcloudGridScan
   ---------
-* feat(ground_segmentation): add time_keeper (`#8585 <https://github.com/youtalk/autoware.universe/issues/8585>`_)
+* feat(ground_segmentation): add time_keeper (`#8585 <https://github.com/autowarefoundation/autoware.universe/issues/8585>`_)
   * add time_keeper
   * add timekeeper option
   * add autoware_universe_utils
@@ -63,17 +63,17 @@ Changelog for package autoware_ground_segmentation
   * remove debug code
   * remove some timekeeper and mod block comment
   ---------
-* fix(autoware_pointcloud_preprocessor): static TF listener as Filter option (`#8678 <https://github.com/youtalk/autoware.universe/issues/8678>`_)
-* fix(ground-segmentation): missing ament_index_cpp dependency (`#8587 <https://github.com/youtalk/autoware.universe/issues/8587>`_)
-* fix(autoware_ground_segmentation): fix unusedFunction (`#8566 <https://github.com/youtalk/autoware.universe/issues/8566>`_)
+* fix(autoware_pointcloud_preprocessor): static TF listener as Filter option (`#8678 <https://github.com/autowarefoundation/autoware.universe/issues/8678>`_)
+* fix(ground-segmentation): missing ament_index_cpp dependency (`#8587 <https://github.com/autowarefoundation/autoware.universe/issues/8587>`_)
+* fix(autoware_ground_segmentation): fix unusedFunction (`#8566 <https://github.com/autowarefoundation/autoware.universe/issues/8566>`_)
   fix:unusedFunction
-* fix(ground_segmentation): missing default parameters ERROR (`#8538 <https://github.com/youtalk/autoware.universe/issues/8538>`_)
+* fix(ground_segmentation): missing default parameters ERROR (`#8538 <https://github.com/autowarefoundation/autoware.universe/issues/8538>`_)
   fix(ground_segmentation): remove unused params
-* fix(autoware_ground_segmentation): fix unreadVariable (`#8353 <https://github.com/youtalk/autoware.universe/issues/8353>`_)
+* fix(autoware_ground_segmentation): fix unreadVariable (`#8353 <https://github.com/autowarefoundation/autoware.universe/issues/8353>`_)
   * fix:unreadVariable
   * fix:unreadVariable
   ---------
-* perf(autoware_pointcloud_preprocessor): lazy & managed TF listeners (`#8174 <https://github.com/youtalk/autoware.universe/issues/8174>`_)
+* perf(autoware_pointcloud_preprocessor): lazy & managed TF listeners (`#8174 <https://github.com/autowarefoundation/autoware.universe/issues/8174>`_)
   * perf(autoware_pointcloud_preprocessor): lazy & managed TF listeners
   * fix(autoware_pointcloud_preprocessor): param names & reverse frames transform logic
   * fix(autoware_ground_segmentation): add missing TF listener
@@ -83,11 +83,11 @@ Changelog for package autoware_ground_segmentation
   * fix(autoware_universe_utils): change checks order
   * doc(autoware_universe_utils): add docstring
   ---------
-* fix(autoware_ground_segmentation): fix uninitMemberVar (`#8336 <https://github.com/youtalk/autoware.universe/issues/8336>`_)
+* fix(autoware_ground_segmentation): fix uninitMemberVar (`#8336 <https://github.com/autowarefoundation/autoware.universe/issues/8336>`_)
   fix:uninitMemberVar
-* fix(autoware_ground_segmentation): fix functionConst (`#8291 <https://github.com/youtalk/autoware.universe/issues/8291>`_)
+* fix(autoware_ground_segmentation): fix functionConst (`#8291 <https://github.com/autowarefoundation/autoware.universe/issues/8291>`_)
   fix:functionConst
-* refactor(ground_segmentation)!: add package name prefix of autoware\_ (`#8135 <https://github.com/youtalk/autoware.universe/issues/8135>`_)
+* refactor(ground_segmentation)!: add package name prefix of autoware\_ (`#8135 <https://github.com/autowarefoundation/autoware.universe/issues/8135>`_)
   * refactor(ground_segmentation): add package name prefix of autoware\_
   * fix: update prefix cmake
   ---------

--- a/perception/autoware_image_projection_based_fusion/CHANGELOG.rst
+++ b/perception/autoware_image_projection_based_fusion/CHANGELOG.rst
@@ -5,18 +5,18 @@ Changelog for package autoware_image_projection_based_fusion
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* refactor(autoware_point_types): prefix namespace with autoware::point_types (`#9169 <https://github.com/youtalk/autoware.universe/issues/9169>`_)
-* fix(autoware_image_projection_based_fusion): pointpainting bug fix for point projection (`#9150 <https://github.com/youtalk/autoware.universe/issues/9150>`_)
+* refactor(autoware_point_types): prefix namespace with autoware::point_types (`#9169 <https://github.com/autowarefoundation/autoware.universe/issues/9169>`_)
+* fix(autoware_image_projection_based_fusion): pointpainting bug fix for point projection (`#9150 <https://github.com/autowarefoundation/autoware.universe/issues/9150>`_)
   fix: projected 2d point has 1.0 of depth
-* refactor(object_recognition_utils): add autoware prefix to object_recognition_utils (`#8946 <https://github.com/youtalk/autoware.universe/issues/8946>`_)
-* fix(autoware_image_projection_based_fusion): roi cluster fusion has no existence probability update (`#8864 <https://github.com/youtalk/autoware.universe/issues/8864>`_)
+* refactor(object_recognition_utils): add autoware prefix to object_recognition_utils (`#8946 <https://github.com/autowarefoundation/autoware.universe/issues/8946>`_)
+* fix(autoware_image_projection_based_fusion): roi cluster fusion has no existence probability update (`#8864 <https://github.com/autowarefoundation/autoware.universe/issues/8864>`_)
   fix: add existence probability update, refactoring
-* fix(autoware_image_projection_based_fusion): resolve issue with segmentation pointcloud fusion node failing with multiple mask inputs (`#8769 <https://github.com/youtalk/autoware.universe/issues/8769>`_)
-* fix(image_projection_based_fusion): remove unused variable (`#8634 <https://github.com/youtalk/autoware.universe/issues/8634>`_)
+* fix(autoware_image_projection_based_fusion): resolve issue with segmentation pointcloud fusion node failing with multiple mask inputs (`#8769 <https://github.com/autowarefoundation/autoware.universe/issues/8769>`_)
+* fix(image_projection_based_fusion): remove unused variable (`#8634 <https://github.com/autowarefoundation/autoware.universe/issues/8634>`_)
   fix: remove unused variable
-* fix(autoware_image_projection_based_fusion): fix unusedFunction (`#8567 <https://github.com/youtalk/autoware.universe/issues/8567>`_)
+* fix(autoware_image_projection_based_fusion): fix unusedFunction (`#8567 <https://github.com/autowarefoundation/autoware.universe/issues/8567>`_)
   fix:unusedFunction
-* fix(image_projection_based_fusion): add run length decoding for segmentation_pointcloud_fusion (`#7909 <https://github.com/youtalk/autoware.universe/issues/7909>`_)
+* fix(image_projection_based_fusion): add run length decoding for segmentation_pointcloud_fusion (`#7909 <https://github.com/autowarefoundation/autoware.universe/issues/7909>`_)
   * fix: add rle decompress
   * style(pre-commit): autofix
   * fix: use rld in tensorrt utils
@@ -31,16 +31,16 @@ Changelog for package autoware_image_projection_based_fusion
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: kminoda <44218668+kminoda@users.noreply.github.com>
-* fix(image_projection_based_fusion): handle projection errors in image fusion nodes (`#7747 <https://github.com/youtalk/autoware.universe/issues/7747>`_)
+* fix(image_projection_based_fusion): handle projection errors in image fusion nodes (`#7747 <https://github.com/autowarefoundation/autoware.universe/issues/7747>`_)
   * fix: add check for camera distortion model
   * feat(utils): add const qualifier to local variables in checkCameraInfo function
   * style(pre-commit): autofix
   * chore(utils): update checkCameraInfo function to use RCLCPP_ERROR_STREAM for unsupported distortion model and coefficients size
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* fix(autoware_image_projection_based_fusion): fix passedByValue (`#8234 <https://github.com/youtalk/autoware.universe/issues/8234>`_)
+* fix(autoware_image_projection_based_fusion): fix passedByValue (`#8234 <https://github.com/autowarefoundation/autoware.universe/issues/8234>`_)
   fix:passedByValue
-* refactor(image_projection_based_fusion)!: add package name prefix of autoware\_ (`#8162 <https://github.com/youtalk/autoware.universe/issues/8162>`_)
+* refactor(image_projection_based_fusion)!: add package name prefix of autoware\_ (`#8162 <https://github.com/autowarefoundation/autoware.universe/issues/8162>`_)
   refactor: rename image_projection_based_fusion to autoware_image_projection_based_fusion
 * Contributors: Esteve Fernandez, Taekjin LEE, Yi-Hsiang Fang (Vivid), Yoshi Ri, Yutaka Kondo, badai nguyen, kobayu858
 

--- a/perception/autoware_lidar_apollo_instance_segmentation/CHANGELOG.rst
+++ b/perception/autoware_lidar_apollo_instance_segmentation/CHANGELOG.rst
@@ -5,7 +5,7 @@ Changelog for package autoware_lidar_apollo_instance_segmentation
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* refactor(tensorrt_common)!: fix namespace, directory structure & move to perception namespace (`#9099 <https://github.com/youtalk/autoware.universe/issues/9099>`_)
+* refactor(tensorrt_common)!: fix namespace, directory structure & move to perception namespace (`#9099 <https://github.com/autowarefoundation/autoware.universe/issues/9099>`_)
   * refactor(tensorrt_common)!: fix namespace, directory structure & move to perception namespace
   * refactor(tensorrt_common): directory structure
   * style(pre-commit): autofix
@@ -13,14 +13,14 @@ Changelog for package autoware_lidar_apollo_instance_segmentation
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Kenzo Lobos Tsunekawa <kenzo.lobos@tier4.jp>
-* fix(autoware_lidar_apollo_instance_segmentation): added existence probability (`#8862 <https://github.com/youtalk/autoware.universe/issues/8862>`_)
+* fix(autoware_lidar_apollo_instance_segmentation): added existence probability (`#8862 <https://github.com/autowarefoundation/autoware.universe/issues/8862>`_)
   * added existence probability
   * style(pre-commit): autofix
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* fix(lidar_apollo_instance_segmentation): fix critical bug (`#8444 <https://github.com/youtalk/autoware.universe/issues/8444>`_)
+* fix(lidar_apollo_instance_segmentation): fix critical bug (`#8444 <https://github.com/autowarefoundation/autoware.universe/issues/8444>`_)
   Co-authored-by: Shintaro Tomie <58775300+Shin-kyoto@users.noreply.github.com>
-* refactor(lidar_apollo_instance_segmentation)!: fix namespace and directory structure (`#7995 <https://github.com/youtalk/autoware.universe/issues/7995>`_)
+* refactor(lidar_apollo_instance_segmentation)!: fix namespace and directory structure (`#7995 <https://github.com/autowarefoundation/autoware.universe/issues/7995>`_)
   * refactor: add autoware namespace prefix
   * chore: update CODEOWNERS
   * refactor: add `autoware` prefix

--- a/perception/autoware_lidar_centerpoint/CHANGELOG.rst
+++ b/perception/autoware_lidar_centerpoint/CHANGELOG.rst
@@ -5,7 +5,7 @@ Changelog for package autoware_lidar_centerpoint
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* refactor(tensorrt_common)!: fix namespace, directory structure & move to perception namespace (`#9099 <https://github.com/youtalk/autoware.universe/issues/9099>`_)
+* refactor(tensorrt_common)!: fix namespace, directory structure & move to perception namespace (`#9099 <https://github.com/autowarefoundation/autoware.universe/issues/9099>`_)
   * refactor(tensorrt_common)!: fix namespace, directory structure & move to perception namespace
   * refactor(tensorrt_common): directory structure
   * style(pre-commit): autofix
@@ -13,19 +13,19 @@ Changelog for package autoware_lidar_centerpoint
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Kenzo Lobos Tsunekawa <kenzo.lobos@tier4.jp>
-* refactor(object_recognition_utils): add autoware prefix to object_recognition_utils (`#8946 <https://github.com/youtalk/autoware.universe/issues/8946>`_)
-* fix(autoware_lidar_centerpoint): fix twist covariance orientation (`#8996 <https://github.com/youtalk/autoware.universe/issues/8996>`_)
+* refactor(object_recognition_utils): add autoware prefix to object_recognition_utils (`#8946 <https://github.com/autowarefoundation/autoware.universe/issues/8946>`_)
+* fix(autoware_lidar_centerpoint): fix twist covariance orientation (`#8996 <https://github.com/autowarefoundation/autoware.universe/issues/8996>`_)
   * fix(autoware_lidar_centerpoint): fix covariance converter considering the twist covariance matrix is based on the object coordinate
   fix style
   * fix: update test of box3DToDetectedObject function
   ---------
-* fix(autoware_lidar_centerpoint): convert object's velocity to follow its definition (`#8980 <https://github.com/youtalk/autoware.universe/issues/8980>`_)
+* fix(autoware_lidar_centerpoint): convert object's velocity to follow its definition (`#8980 <https://github.com/autowarefoundation/autoware.universe/issues/8980>`_)
   * fix: convert object's velocity to follow its definition in box3DToDetectedObject function
   * Update perception/autoware_lidar_centerpoint/lib/ros_utils.cpp
   Co-authored-by: Kenzo Lobos Tsunekawa <kenzo.lobos@tier4.jp>
   ---------
   Co-authored-by: Kenzo Lobos Tsunekawa <kenzo.lobos@tier4.jp>
-* feat(autoware_lidar_centerpoint): shuffled points before feeding them to the model (`#8814 <https://github.com/youtalk/autoware.universe/issues/8814>`_)
+* feat(autoware_lidar_centerpoint): shuffled points before feeding them to the model (`#8814 <https://github.com/autowarefoundation/autoware.universe/issues/8814>`_)
   * feat: shuffling points before feeding them into the model to achieve uniform sampling into the voxels
   * Update perception/autoware_lidar_centerpoint/src/node.cpp
   Co-authored-by: kminoda <44218668+kminoda@users.noreply.github.com>
@@ -37,20 +37,20 @@ Changelog for package autoware_lidar_centerpoint
   Co-authored-by: kminoda <44218668+kminoda@users.noreply.github.com>
   ---------
   Co-authored-by: kminoda <44218668+kminoda@users.noreply.github.com>
-* refactor(autoware_lidar_centerpoint): use std::size_t instead of size_t (`#8820 <https://github.com/youtalk/autoware.universe/issues/8820>`_)
+* refactor(autoware_lidar_centerpoint): use std::size_t instead of size_t (`#8820 <https://github.com/autowarefoundation/autoware.universe/issues/8820>`_)
   * refactor(autoware_lidar_centerpoint): use std::size_t instead of size_t
   * style(pre-commit): autofix
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* chore(autoware_lidar_centerpoint): add centerpoint sigma parameter (`#8731 <https://github.com/youtalk/autoware.universe/issues/8731>`_)
+* chore(autoware_lidar_centerpoint): add centerpoint sigma parameter (`#8731 <https://github.com/autowarefoundation/autoware.universe/issues/8731>`_)
   add centerpoint sigma parameter
-* fix(autoware_lidar_centerpoint): fix unusedFunction (`#8572 <https://github.com/youtalk/autoware.universe/issues/8572>`_)
+* fix(autoware_lidar_centerpoint): fix unusedFunction (`#8572 <https://github.com/autowarefoundation/autoware.universe/issues/8572>`_)
   fix:unusedFunction
-* fix(autoware_lidar_centerpoint): place device vector in CUDA device system (`#8272 <https://github.com/youtalk/autoware.universe/issues/8272>`_)
-* docs(centerpoint): add description for ml package params (`#8187 <https://github.com/youtalk/autoware.universe/issues/8187>`_)
-* chore(autoware_lidar_centerpoint): updated tests (`#8158 <https://github.com/youtalk/autoware.universe/issues/8158>`_)
+* fix(autoware_lidar_centerpoint): place device vector in CUDA device system (`#8272 <https://github.com/autowarefoundation/autoware.universe/issues/8272>`_)
+* docs(centerpoint): add description for ml package params (`#8187 <https://github.com/autowarefoundation/autoware.universe/issues/8187>`_)
+* chore(autoware_lidar_centerpoint): updated tests (`#8158 <https://github.com/autowarefoundation/autoware.universe/issues/8158>`_)
   chore: updated centerpoin tests. they are currently commented out but they were not compiling (forgot to update them when I added the new cloud capacity parameter)
-* refactor(lidar_centerpoint)!: fix namespace and directory structure (`#8049 <https://github.com/youtalk/autoware.universe/issues/8049>`_)
+* refactor(lidar_centerpoint)!: fix namespace and directory structure (`#8049 <https://github.com/autowarefoundation/autoware.universe/issues/8049>`_)
   * add prefix in lidar_centerpoint
   * add .gitignore
   * change include package name in image_projection_based fusion

--- a/perception/autoware_lidar_transfusion/CHANGELOG.rst
+++ b/perception/autoware_lidar_transfusion/CHANGELOG.rst
@@ -5,8 +5,8 @@ Changelog for package autoware_lidar_transfusion
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* refactor(autoware_point_types): prefix namespace with autoware::point_types (`#9169 <https://github.com/youtalk/autoware.universe/issues/9169>`_)
-* refactor(tensorrt_common)!: fix namespace, directory structure & move to perception namespace (`#9099 <https://github.com/youtalk/autoware.universe/issues/9099>`_)
+* refactor(autoware_point_types): prefix namespace with autoware::point_types (`#9169 <https://github.com/autowarefoundation/autoware.universe/issues/9169>`_)
+* refactor(tensorrt_common)!: fix namespace, directory structure & move to perception namespace (`#9099 <https://github.com/autowarefoundation/autoware.universe/issues/9099>`_)
   * refactor(tensorrt_common)!: fix namespace, directory structure & move to perception namespace
   * refactor(tensorrt_common): directory structure
   * style(pre-commit): autofix
@@ -14,8 +14,8 @@ Changelog for package autoware_lidar_transfusion
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Kenzo Lobos Tsunekawa <kenzo.lobos@tier4.jp>
-* refactor(object_recognition_utils): add autoware prefix to object_recognition_utils (`#8946 <https://github.com/youtalk/autoware.universe/issues/8946>`_)
-* fix(autoware_lidar_transfusion): set tensor names by matching with predefined values. (`#9057 <https://github.com/youtalk/autoware.universe/issues/9057>`_)
+* refactor(object_recognition_utils): add autoware prefix to object_recognition_utils (`#8946 <https://github.com/autowarefoundation/autoware.universe/issues/8946>`_)
+* fix(autoware_lidar_transfusion): set tensor names by matching with predefined values. (`#9057 <https://github.com/autowarefoundation/autoware.universe/issues/9057>`_)
   * set tensor order using api
   * style(pre-commit): autofix
   * fix tensor order
@@ -24,26 +24,26 @@ Changelog for package autoware_lidar_transfusion
   * style(pre-commit): autofix
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat(autoware_lidar _ransfusion): fix 3d bounding box orientation (`#9052 <https://github.com/youtalk/autoware.universe/issues/9052>`_)
+* feat(autoware_lidar _ransfusion): fix 3d bounding box orientation (`#9052 <https://github.com/autowarefoundation/autoware.universe/issues/9052>`_)
   * fix bbox orientation
   * revert newline changes
   * change kernel
   ---------
   Co-authored-by: Amadeusz Szymko <amadeusz.szymko.2@tier4.jp>
-* feat(autoware_lidar_transfusion): shuffled points before feeding them to the model (`#8815 <https://github.com/youtalk/autoware.universe/issues/8815>`_)
+* feat(autoware_lidar_transfusion): shuffled points before feeding them to the model (`#8815 <https://github.com/autowarefoundation/autoware.universe/issues/8815>`_)
   feat: shuffling points before feeding them into the model to achieve random sampling into the voxels
   Co-authored-by: Amadeusz Szymko <amadeusz.szymko.2@tier4.jp>
-* refactor(autoware_lidar_transfusion): split config (`#8205 <https://github.com/youtalk/autoware.universe/issues/8205>`_)
+* refactor(autoware_lidar_transfusion): split config (`#8205 <https://github.com/autowarefoundation/autoware.universe/issues/8205>`_)
   * refactor(autoware_lidar_transfusion): split config
   * style(pre-commit): autofix
   * chore(autoware_lidar_transfusion): bypass schema CI workflow
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Kenzo Lobos Tsunekawa <kenzo.lobos@tier4.jp>
-* fix(autoware_lidar_transfusion): place device vector in CUDA device system (`#8273 <https://github.com/youtalk/autoware.universe/issues/8273>`_)
-* fix(lidar_transfusion): commented tests were out of date (`#8116 <https://github.com/youtalk/autoware.universe/issues/8116>`_)
+* fix(autoware_lidar_transfusion): place device vector in CUDA device system (`#8273 <https://github.com/autowarefoundation/autoware.universe/issues/8273>`_)
+* fix(lidar_transfusion): commented tests were out of date (`#8116 <https://github.com/autowarefoundation/autoware.universe/issues/8116>`_)
   chore: commented tests were out of date
-* refactor(lidar_transfusion)!: fix namespace and directory structure (`#8022 <https://github.com/youtalk/autoware.universe/issues/8022>`_)
+* refactor(lidar_transfusion)!: fix namespace and directory structure (`#8022 <https://github.com/autowarefoundation/autoware.universe/issues/8022>`_)
   * add prefix
   * add prefix in code owner
   * style(pre-commit): autofix

--- a/perception/autoware_map_based_prediction/CHANGELOG.rst
+++ b/perception/autoware_map_based_prediction/CHANGELOG.rst
@@ -5,7 +5,7 @@ Changelog for package autoware_map_based_prediction
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* refactor(autoware_map_based_prediction): refactoring lanelet path prediction and pose path conversion (`#9104 <https://github.com/youtalk/autoware.universe/issues/9104>`_)
+* refactor(autoware_map_based_prediction): refactoring lanelet path prediction and pose path conversion (`#9104 <https://github.com/autowarefoundation/autoware.universe/issues/9104>`_)
   * refactor: update predictObjectManeuver function parameters
   * refactor: update hash function for LaneletPath in map_based_prediction_node.hpp
   * refactor: path list rename
@@ -17,14 +17,14 @@ Changelog for package autoware_map_based_prediction
   * Update perception/autoware_map_based_prediction/src/map_based_prediction_node.cpp
   ---------
   Co-authored-by: Mamoru Sobue <hilo.soblin@gmail.com>
-* chore(autoware_map_based_prediction): add maintainers to package.xml (`#9125 <https://github.com/youtalk/autoware.universe/issues/9125>`_)
+* chore(autoware_map_based_prediction): add maintainers to package.xml (`#9125 <https://github.com/autowarefoundation/autoware.universe/issues/9125>`_)
   chore: add maintainers to package.xml
   The package.xml file was updated to include additional maintainers' email addresses.
-* fix(autoware_map_based_prediction): adjust lateral duration when object is behind reference path (`#8973 <https://github.com/youtalk/autoware.universe/issues/8973>`_)
+* fix(autoware_map_based_prediction): adjust lateral duration when object is behind reference path (`#8973 <https://github.com/autowarefoundation/autoware.universe/issues/8973>`_)
   fix: adjust lateral duration when object is behind reference path
-* refactor(autoware_interpolation): prefix package and namespace with autoware (`#8088 <https://github.com/youtalk/autoware.universe/issues/8088>`_)
+* refactor(autoware_interpolation): prefix package and namespace with autoware (`#8088 <https://github.com/autowarefoundation/autoware.universe/issues/8088>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* feat(autoware_map_based_prediction): improve frenet path generation (`#8811 <https://github.com/youtalk/autoware.universe/issues/8811>`_)
+* feat(autoware_map_based_prediction): improve frenet path generation (`#8811 <https://github.com/autowarefoundation/autoware.universe/issues/8811>`_)
   * feat: calculate terminal d position based on playable width in path_generator.cpp
   * feat: Add width parameter path generations
   refactor(path_generator): improve backlash width calculation
@@ -71,10 +71,10 @@ Changelog for package autoware_map_based_prediction
   * fix: object orientation calculation is added to the predicted path generation
   * chore: fix spell-check
   ---------
-* revert(autoware_map_based_prediction): revert improve frenet path gen (`#8808 <https://github.com/youtalk/autoware.universe/issues/8808>`_)
-  Revert "feat(autoware_map_based_prediction): improve frenet path generation (`#8602 <https://github.com/youtalk/autoware.universe/issues/8602>`_)"
+* revert(autoware_map_based_prediction): revert improve frenet path gen (`#8808 <https://github.com/autowarefoundation/autoware.universe/issues/8808>`_)
+  Revert "feat(autoware_map_based_prediction): improve frenet path generation (`#8602 <https://github.com/autowarefoundation/autoware.universe/issues/8602>`_)"
   This reverts commit 67265bbd60c85282c1c3cf65e603098e0c30c477.
-* feat(autoware_map_based_prediction): improve frenet path generation (`#8602 <https://github.com/youtalk/autoware.universe/issues/8602>`_)
+* feat(autoware_map_based_prediction): improve frenet path generation (`#8602 <https://github.com/autowarefoundation/autoware.universe/issues/8602>`_)
   * feat: calculate terminal d position based on playable width in path_generator.cpp
   * feat: Add width parameter path generations
   refactor(path_generator): improve backlash width calculation
@@ -119,14 +119,14 @@ Changelog for package autoware_map_based_prediction
   * refactor: separate a logic to searchProperStartingRefPathIndex function
   * refactor: search starting ref path using optional for return type
   ---------
-* perf(autoware_map_based_prediction): replace pow (`#8751 <https://github.com/youtalk/autoware.universe/issues/8751>`_)
-* fix(autoware_map_based_prediction): output from screen to both (`#8408 <https://github.com/youtalk/autoware.universe/issues/8408>`_)
-* perf(autoware_map_based_prediction): removed duplicate findNearest calculations (`#8490 <https://github.com/youtalk/autoware.universe/issues/8490>`_)
-* perf(autoware_map_based_prediction): enhance speed by removing unnecessary calculation (`#8471 <https://github.com/youtalk/autoware.universe/issues/8471>`_)
+* perf(autoware_map_based_prediction): replace pow (`#8751 <https://github.com/autowarefoundation/autoware.universe/issues/8751>`_)
+* fix(autoware_map_based_prediction): output from screen to both (`#8408 <https://github.com/autowarefoundation/autoware.universe/issues/8408>`_)
+* perf(autoware_map_based_prediction): removed duplicate findNearest calculations (`#8490 <https://github.com/autowarefoundation/autoware.universe/issues/8490>`_)
+* perf(autoware_map_based_prediction): enhance speed by removing unnecessary calculation (`#8471 <https://github.com/autowarefoundation/autoware.universe/issues/8471>`_)
   * fix(autoware_map_based_prediction): use surrounding_crosswalks instead of external_surrounding_crosswalks
   * perf(autoware_map_based_prediction): enhance speed by removing unnecessary calculation
   ---------
-* refactor(autoware_map_based_prediction): map based pred time keeper ptr (`#8462 <https://github.com/youtalk/autoware.universe/issues/8462>`_)
+* refactor(autoware_map_based_prediction): map based pred time keeper ptr (`#8462 <https://github.com/autowarefoundation/autoware.universe/issues/8462>`_)
   * refactor(map_based_prediction): implement time keeper by pointer
   * feat(map_based_prediction): set time keeper in path generator
   * feat: use scoped time track only when the timekeeper ptr is not null
@@ -135,16 +135,16 @@ Changelog for package autoware_map_based_prediction
   * chore: remove unnecessary ScopedTimeTrack instances
   * feat: replace member to pointer
   ---------
-* fix(autoware_map_based_prediction): use surrounding_crosswalks instead of external_surrounding_crosswalks (`#8467 <https://github.com/youtalk/autoware.universe/issues/8467>`_)
-* perf(autoware_map_based_prediction): speed up map based prediction by using lru cache in convertPathType (`#8461 <https://github.com/youtalk/autoware.universe/issues/8461>`_)
+* fix(autoware_map_based_prediction): use surrounding_crosswalks instead of external_surrounding_crosswalks (`#8467 <https://github.com/autowarefoundation/autoware.universe/issues/8467>`_)
+* perf(autoware_map_based_prediction): speed up map based prediction by using lru cache in convertPathType (`#8461 <https://github.com/autowarefoundation/autoware.universe/issues/8461>`_)
   feat(autoware_map_based_prediction): speed up map based prediction by using lru cache in convertPathType
-* perf(map_based_prediction): improve world to map transform calculation (`#8413 <https://github.com/youtalk/autoware.universe/issues/8413>`_)
+* perf(map_based_prediction): improve world to map transform calculation (`#8413 <https://github.com/autowarefoundation/autoware.universe/issues/8413>`_)
   * perf(map_based_prediction): improve world to map transform calculation
   1. remove unused transforms
   2. make transform loading late as possible
   * perf(map_based_prediction): get transform only when it is necessary
   ---------
-* perf(autoware_map_based_prediction): improve orientation calculation and resample converted path (`#8427 <https://github.com/youtalk/autoware.universe/issues/8427>`_)
+* perf(autoware_map_based_prediction): improve orientation calculation and resample converted path (`#8427 <https://github.com/autowarefoundation/autoware.universe/issues/8427>`_)
   * refactor: improve orientation calculation and resample converted path with linear interpolation
   Simplify the calculation of the orientation for each pose in the convertPathType function by directly calculating the sine and cosine of half the yaw angle. This improves efficiency and readability. Also, improve the resampling of the converted path by using linear interpolation for better performance.
   * Update perception/autoware_map_based_prediction/src/map_based_prediction_node.cpp
@@ -154,12 +154,12 @@ Changelog for package autoware_map_based_prediction
   ---------
   Co-authored-by: Shumpei Wakabayashi <42209144+shmpwk@users.noreply.github.com>
   Co-authored-by: Kotaro Uetake <60615504+ktro2828@users.noreply.github.com>
-* perf(map_based_prediction): apply lerp instead of spline (`#8416 <https://github.com/youtalk/autoware.universe/issues/8416>`_)
+* perf(map_based_prediction): apply lerp instead of spline (`#8416 <https://github.com/autowarefoundation/autoware.universe/issues/8416>`_)
   perf: apply lerp interpolation instead of spline
-* revert (map_based_prediction): use linear interpolation for path conversion (`#8400 <https://github.com/youtalk/autoware.universe/issues/8400>`_)" (`#8417 <https://github.com/youtalk/autoware.universe/issues/8417>`_)
-  Revert "perf(map_based_prediction): use linear interpolation for path conversion (`#8400 <https://github.com/youtalk/autoware.universe/issues/8400>`_)"
+* revert (map_based_prediction): use linear interpolation for path conversion (`#8400 <https://github.com/autowarefoundation/autoware.universe/issues/8400>`_)" (`#8417 <https://github.com/autowarefoundation/autoware.universe/issues/8417>`_)
+  Revert "perf(map_based_prediction): use linear interpolation for path conversion (`#8400 <https://github.com/autowarefoundation/autoware.universe/issues/8400>`_)"
   This reverts commit 147403f1765346be9c5a3273552d86133298a899.
-* perf(map_based_prediction): use linear interpolation for path conversion (`#8400 <https://github.com/youtalk/autoware.universe/issues/8400>`_)
+* perf(map_based_prediction): use linear interpolation for path conversion (`#8400 <https://github.com/autowarefoundation/autoware.universe/issues/8400>`_)
   * refactor: improve orientation calculation in MapBasedPredictionNode
   Simplify the calculation of the orientation for each pose in the convertPathType function. Instead of using the atan2 function, calculate the sine and cosine of half the yaw angle directly. This improves the efficiency and readability of the code.
   * refactor: resample converted path with linear interpolation
@@ -167,20 +167,20 @@ Changelog for package autoware_map_based_prediction
   the mark indicates true, but the function resamplePoseVector implementation is opposite.
   chore: write comment about use_akima_slpine_for_xy
   ---------
-* perf(map_based_prediction): create a fence LineString layer and use rtree query (`#8406 <https://github.com/youtalk/autoware.universe/issues/8406>`_)
+* perf(map_based_prediction): create a fence LineString layer and use rtree query (`#8406 <https://github.com/autowarefoundation/autoware.universe/issues/8406>`_)
   use fence layer
-* perf(map_based_prediction): remove unncessary withinRoadLanelet() (`#8403 <https://github.com/youtalk/autoware.universe/issues/8403>`_)
-* feat(map_based_prediction): filter surrounding crosswalks for pedestrians beforehand (`#8388 <https://github.com/youtalk/autoware.universe/issues/8388>`_)
+* perf(map_based_prediction): remove unncessary withinRoadLanelet() (`#8403 <https://github.com/autowarefoundation/autoware.universe/issues/8403>`_)
+* feat(map_based_prediction): filter surrounding crosswalks for pedestrians beforehand (`#8388 <https://github.com/autowarefoundation/autoware.universe/issues/8388>`_)
   fix withinAnyCroswalk
-* fix(autoware_map_based_prediction): fix argument order (`#8031 <https://github.com/youtalk/autoware.universe/issues/8031>`_)
+* fix(autoware_map_based_prediction): fix argument order (`#8031 <https://github.com/autowarefoundation/autoware.universe/issues/8031>`_)
   fix(autoware_map_based_prediction): fix argument order in call `getFrenetPoint()`
   Co-authored-by: Shintaro Tomie <58775300+Shin-kyoto@users.noreply.github.com>
   Co-authored-by: Kotaro Uetake <60615504+ktro2828@users.noreply.github.com>
-* feat(map_based_prediction): add time_keeper (`#8176 <https://github.com/youtalk/autoware.universe/issues/8176>`_)
-* fix(autoware_map_based_prediction): fix shadowVariable (`#7934 <https://github.com/youtalk/autoware.universe/issues/7934>`_)
+* feat(map_based_prediction): add time_keeper (`#8176 <https://github.com/autowarefoundation/autoware.universe/issues/8176>`_)
+* fix(autoware_map_based_prediction): fix shadowVariable (`#7934 <https://github.com/autowarefoundation/autoware.universe/issues/7934>`_)
   fix:shadowVariable
-* perf(map_based_prediction): remove query on all fences linestrings (`#7237 <https://github.com/youtalk/autoware.universe/issues/7237>`_)
-* fix(autoware_map_based_prediction): fix syntaxError (`#7813 <https://github.com/youtalk/autoware.universe/issues/7813>`_)
+* perf(map_based_prediction): remove query on all fences linestrings (`#7237 <https://github.com/autowarefoundation/autoware.universe/issues/7237>`_)
+* fix(autoware_map_based_prediction): fix syntaxError (`#7813 <https://github.com/autowarefoundation/autoware.universe/issues/7813>`_)
   * fix(autoware_map_based_prediction): fix syntaxError
   * style(pre-commit): autofix
   * fix spellcheck
@@ -188,15 +188,15 @@ Changelog for package autoware_map_based_prediction
   * style(pre-commit): autofix
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat: add `autoware\_` prefix to `lanelet2_extension` (`#7640 <https://github.com/youtalk/autoware.universe/issues/7640>`_)
-* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/youtalk/autoware.universe/issues/7594>`_)
-* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/youtalk/autoware.universe/issues/7539>`_)
+* feat: add `autoware\_` prefix to `lanelet2_extension` (`#7640 <https://github.com/autowarefoundation/autoware.universe/issues/7640>`_)
+* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/autowarefoundation/autoware.universe/issues/7594>`_)
+* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/autowarefoundation/autoware.universe/issues/7539>`_)
   refactor(motion_utils): add autoware prefix and include dir
-* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/youtalk/autoware.universe/issues/7538>`_)
+* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/autowarefoundation/autoware.universe/issues/7538>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* feat(map based prediction): use polling subscriber (`#7397 <https://github.com/youtalk/autoware.universe/issues/7397>`_)
+* feat(map based prediction): use polling subscriber (`#7397 <https://github.com/autowarefoundation/autoware.universe/issues/7397>`_)
   feat(map_based_prediction): use polling subscriber
-* refactor(map_based_prediction): prefix map based prediction (`#7391 <https://github.com/youtalk/autoware.universe/issues/7391>`_)
+* refactor(map_based_prediction): prefix map based prediction (`#7391 <https://github.com/autowarefoundation/autoware.universe/issues/7391>`_)
 * Contributors: Esteve Fernandez, Kosuke Takeuchi, Kotaro Uetake, Mamoru Sobue, Maxime CLEMENT, Onur Can Yücedağ, Ryuta Kambe, Taekjin LEE, Takamasa Horibe, Takayuki Murooka, Yukinari Hisaki, Yutaka Kondo, kminoda, kobayu858
 
 0.26.0 (2024-04-03)

--- a/perception/autoware_multi_object_tracker/CHANGELOG.rst
+++ b/perception/autoware_multi_object_tracker/CHANGELOG.rst
@@ -5,8 +5,8 @@ Changelog for package autoware_multi_object_tracker
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* refactor(object_recognition_utils): add autoware prefix to object_recognition_utils (`#8946 <https://github.com/youtalk/autoware.universe/issues/8946>`_)
-* feat(autoware_multi_object_tracker): Set maximum reverse velocity to bicycle and crtv motion models (`#9019 <https://github.com/youtalk/autoware.universe/issues/9019>`_)
+* refactor(object_recognition_utils): add autoware prefix to object_recognition_utils (`#8946 <https://github.com/autowarefoundation/autoware.universe/issues/8946>`_)
+* feat(autoware_multi_object_tracker): Set maximum reverse velocity to bicycle and crtv motion models (`#9019 <https://github.com/autowarefoundation/autoware.universe/issues/9019>`_)
   * feat: Add maximum reverse velocity to bicycle and CTRV motion models
   revert the tracker orientation when the velocity exceed the maximum reverse velocity
   refactor: Update motion model parameters for bicycle and CTRV motion models
@@ -14,7 +14,7 @@ Changelog for package autoware_multi_object_tracker
   max_reverse_vel is expected to be  negative
   * refactor: remove config checker in the initializer
   ---------
-* refactor(autoware_multi_object_tracker): separate detected object covariance modeling (`#9001 <https://github.com/youtalk/autoware.universe/issues/9001>`_)
+* refactor(autoware_multi_object_tracker): separate detected object covariance modeling (`#9001 <https://github.com/autowarefoundation/autoware.universe/issues/9001>`_)
   * refactor: update object model includes in tracker models
   * feat: add uncertainty processor for object tracking
   feat: refactor uncertainty processing for object tracking
@@ -45,69 +45,69 @@ Changelog for package autoware_multi_object_tracker
   * refactor: update runProcess function parameters in multi_object_tracker_node.hpp
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* fix(autoware_multi_object_tracker): update yaw with range-limited innovation (`#8976 <https://github.com/youtalk/autoware.universe/issues/8976>`_)
+* fix(autoware_multi_object_tracker): update yaw with range-limited innovation (`#8976 <https://github.com/autowarefoundation/autoware.universe/issues/8976>`_)
   fix: update yaw with range-limited innovation
-* feat(autoware_multi_object_tracker): reduce trigger latency (`#8657 <https://github.com/youtalk/autoware.universe/issues/8657>`_)
+* feat(autoware_multi_object_tracker): reduce trigger latency (`#8657 <https://github.com/autowarefoundation/autoware.universe/issues/8657>`_)
   * feat: timer-based trigger with phase compensation
   * chore: update comments, name of variable
   * chore: declare min and max publish interval ratios
   * style(pre-commit): autofix
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* fix(autoware_multi_object_tracker): output from screen to both (`#8407 <https://github.com/youtalk/autoware.universe/issues/8407>`_)
-* fix(autoware_multi_object_tracker): fix unusedFunction (`#8573 <https://github.com/youtalk/autoware.universe/issues/8573>`_)
+* fix(autoware_multi_object_tracker): output from screen to both (`#8407 <https://github.com/autowarefoundation/autoware.universe/issues/8407>`_)
+* fix(autoware_multi_object_tracker): fix unusedFunction (`#8573 <https://github.com/autowarefoundation/autoware.universe/issues/8573>`_)
   fix:unusedFunction
-* chore(autoware_multi_object_tracker): fix typo in input_channels.schema.json (`#8515 <https://github.com/youtalk/autoware.universe/issues/8515>`_)
+* chore(autoware_multi_object_tracker): fix typo in input_channels.schema.json (`#8515 <https://github.com/autowarefoundation/autoware.universe/issues/8515>`_)
   * fix(schema): fix typo in input_channels.schema.json
   Fixed a typo in the "lidar_pointpainting" key in the input_channels.schema.json file.
   * fix: fix typo in lidar_pointpainting key
   * chore: fix typo of lidar_pointpainitng channel
   ---------
   Co-authored-by: Shintaro Tomie <58775300+Shin-kyoto@users.noreply.github.com>
-* refactor(kalman_filter): prefix package and namespace with autoware (`#7787 <https://github.com/youtalk/autoware.universe/issues/7787>`_)
+* refactor(kalman_filter): prefix package and namespace with autoware (`#7787 <https://github.com/autowarefoundation/autoware.universe/issues/7787>`_)
   * refactor(kalman_filter): prefix package and namespace with autoware
   * move headers to include/autoware/
   * style(pre-commit): autofix
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* docs(autoware_multi_object_tracker): update input_channels schema with default values (`#8473 <https://github.com/youtalk/autoware.universe/issues/8473>`_)
+* docs(autoware_multi_object_tracker): update input_channels schema with default values (`#8473 <https://github.com/autowarefoundation/autoware.universe/issues/8473>`_)
   chore(perception): update input_channels schema with default values
-* fix(autoware_multi_object_tracker): enable trigger publish when delay_compensation is false (`#8484 <https://github.com/youtalk/autoware.universe/issues/8484>`_)
+* fix(autoware_multi_object_tracker): enable trigger publish when delay_compensation is false (`#8484 <https://github.com/autowarefoundation/autoware.universe/issues/8484>`_)
   fix: enable trigger publish when delay_compensation is false
-* fix(autoware_multi_object_tracker): fix functionConst (`#8424 <https://github.com/youtalk/autoware.universe/issues/8424>`_)
+* fix(autoware_multi_object_tracker): fix functionConst (`#8424 <https://github.com/autowarefoundation/autoware.universe/issues/8424>`_)
   fix:functionConst
-* docs(autoware_multi_object_tracker): add default values on the schema json (`#8179 <https://github.com/youtalk/autoware.universe/issues/8179>`_)
+* docs(autoware_multi_object_tracker): add default values on the schema json (`#8179 <https://github.com/autowarefoundation/autoware.universe/issues/8179>`_)
   * Refractored the parameters, build the schema file, updated the readme file.
   * style(pre-commit): autofix
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* fix(autoware_multi_object_tracker): fix functionConst (`#8290 <https://github.com/youtalk/autoware.universe/issues/8290>`_)
+* fix(autoware_multi_object_tracker): fix functionConst (`#8290 <https://github.com/autowarefoundation/autoware.universe/issues/8290>`_)
   * fix:functionConst
   * fix:functionConst
   * fix:clang format
   ---------
-* fix(autoware_multi_object_tracker): revert latency reduction logic and bring back to timer trigger (`#8277 <https://github.com/youtalk/autoware.universe/issues/8277>`_)
+* fix(autoware_multi_object_tracker): revert latency reduction logic and bring back to timer trigger (`#8277 <https://github.com/autowarefoundation/autoware.universe/issues/8277>`_)
   * fix: revert latency reduction logic and bring back to timer trigger
   * style(pre-commit): autofix
   * chore: remove unused variables
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* fix(autoware_multi_object_tracker): fix uninitMemberVar (`#8335 <https://github.com/youtalk/autoware.universe/issues/8335>`_)
+* fix(autoware_multi_object_tracker): fix uninitMemberVar (`#8335 <https://github.com/autowarefoundation/autoware.universe/issues/8335>`_)
   fix:uninitMemberVar
-* fix(autoware_multi_object_tracker): fix passedByValue (`#8231 <https://github.com/youtalk/autoware.universe/issues/8231>`_)
+* fix(autoware_multi_object_tracker): fix passedByValue (`#8231 <https://github.com/autowarefoundation/autoware.universe/issues/8231>`_)
   fix:passedByValue
-* fix(multi_object_tracker, object_merger, radar_object_tracker, tracking_object_merger): fix knownConditionTrueFalse warnings (`#8137 <https://github.com/youtalk/autoware.universe/issues/8137>`_)
+* fix(multi_object_tracker, object_merger, radar_object_tracker, tracking_object_merger): fix knownConditionTrueFalse warnings (`#8137 <https://github.com/autowarefoundation/autoware.universe/issues/8137>`_)
   * fix: cppcheck knownConditionTrueFalse
   * fix
   * fix
   ---------
-* fix(autoware_multi_object_tracker): missing parameter schema path fix (`#8120 <https://github.com/youtalk/autoware.universe/issues/8120>`_)
+* fix(autoware_multi_object_tracker): missing parameter schema path fix (`#8120 <https://github.com/autowarefoundation/autoware.universe/issues/8120>`_)
   fix: missing parameter schema path fix
-* fix(multi_object_tracker): fix funcArgNamesDifferent (`#8079 <https://github.com/youtalk/autoware.universe/issues/8079>`_)
+* fix(multi_object_tracker): fix funcArgNamesDifferent (`#8079 <https://github.com/autowarefoundation/autoware.universe/issues/8079>`_)
   fix:funcArgNamesDifferent
-* refactor(multi_object_tracker): bring parameter schema to new package folder (`#8105 <https://github.com/youtalk/autoware.universe/issues/8105>`_)
+* refactor(multi_object_tracker): bring parameter schema to new package folder (`#8105 <https://github.com/autowarefoundation/autoware.universe/issues/8105>`_)
   refactor: bring parameter schema to new package folder
-* refactor(multi_object_tracker)!: add package name prefix of autoware\_ (`#8083 <https://github.com/youtalk/autoware.universe/issues/8083>`_)
+* refactor(multi_object_tracker)!: add package name prefix of autoware\_ (`#8083 <https://github.com/autowarefoundation/autoware.universe/issues/8083>`_)
   * refactor: rename multi_object_tracker package to autoware_multi_object_tracker
   * style(pre-commit): autofix
   ---------

--- a/perception/autoware_object_merger/CHANGELOG.rst
+++ b/perception/autoware_object_merger/CHANGELOG.rst
@@ -5,21 +5,21 @@ Changelog for package autoware_object_merger
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* refactor(object_recognition_utils): add autoware prefix to object_recognition_utils (`#8946 <https://github.com/youtalk/autoware.universe/issues/8946>`_)
-* fix(autoware_object_merger): default merger priority within enum range (`#8858 <https://github.com/youtalk/autoware.universe/issues/8858>`_)
+* refactor(object_recognition_utils): add autoware prefix to object_recognition_utils (`#8946 <https://github.com/autowarefoundation/autoware.universe/issues/8946>`_)
+* fix(autoware_object_merger): default merger priority within enum range (`#8858 <https://github.com/autowarefoundation/autoware.universe/issues/8858>`_)
   fix: default merger priority within enum range
-* fix(object_association_merger_node): fix the frame id of output object msg  (`#8674 <https://github.com/youtalk/autoware.universe/issues/8674>`_)
+* fix(object_association_merger_node): fix the frame id of output object msg  (`#8674 <https://github.com/autowarefoundation/autoware.universe/issues/8674>`_)
   fix: fix the object msg header
-* fix(doc, object_merger): fix object merger document path (`#8292 <https://github.com/youtalk/autoware.universe/issues/8292>`_)
+* fix(doc, object_merger): fix object merger document path (`#8292 <https://github.com/autowarefoundation/autoware.universe/issues/8292>`_)
   fix object merger document path
-* fix(autoware_object_merger): fix passedByValue (`#8232 <https://github.com/youtalk/autoware.universe/issues/8232>`_)
+* fix(autoware_object_merger): fix passedByValue (`#8232 <https://github.com/autowarefoundation/autoware.universe/issues/8232>`_)
   fix:passedByValue
-* fix(multi_object_tracker, object_merger, radar_object_tracker, tracking_object_merger): fix knownConditionTrueFalse warnings (`#8137 <https://github.com/youtalk/autoware.universe/issues/8137>`_)
+* fix(multi_object_tracker, object_merger, radar_object_tracker, tracking_object_merger): fix knownConditionTrueFalse warnings (`#8137 <https://github.com/autowarefoundation/autoware.universe/issues/8137>`_)
   * fix: cppcheck knownConditionTrueFalse
   * fix
   * fix
   ---------
-* refactor(autoware_object_merger): move headers to src and rename package (`#7804 <https://github.com/youtalk/autoware.universe/issues/7804>`_)
+* refactor(autoware_object_merger): move headers to src and rename package (`#7804 <https://github.com/autowarefoundation/autoware.universe/issues/7804>`_)
 * Contributors: Esteve Fernandez, Ryuta Kambe, Taekjin LEE, Yi-Hsiang Fang (Vivid), Yutaka Kondo, Yuxuan Liu, kobayu858
 
 0.26.0 (2024-04-03)

--- a/perception/autoware_object_range_splitter/CHANGELOG.rst
+++ b/perception/autoware_object_range_splitter/CHANGELOG.rst
@@ -5,11 +5,11 @@ Changelog for package autoware_object_range_splitter
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* fix(docs): fox docs for autoware object range splitter (`#8306 <https://github.com/youtalk/autoware.universe/issues/8306>`_)
+* fix(docs): fox docs for autoware object range splitter (`#8306 <https://github.com/autowarefoundation/autoware.universe/issues/8306>`_)
   * fix docs for autoware object range splitter
   * fix spelling
   ---------
-* refactor(radar)!: add package name prefix of autoware\_ (`#7892 <https://github.com/youtalk/autoware.universe/issues/7892>`_)
+* refactor(radar)!: add package name prefix of autoware\_ (`#7892 <https://github.com/autowarefoundation/autoware.universe/issues/7892>`_)
   * refactor: rename radar_object_tracker
   * refactor: rename package from radar_object_tracker to autoware_radar_object_tracker
   * refactor: rename package from radar_object_clustering to autoware_radar_object_clustering

--- a/perception/autoware_object_velocity_splitter/CHANGELOG.rst
+++ b/perception/autoware_object_velocity_splitter/CHANGELOG.rst
@@ -5,11 +5,11 @@ Changelog for package autoware_object_velocity_splitter
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* fix(autoware_object_velocity_splitter): fix funcArgNamesDifferent (`#8013 <https://github.com/youtalk/autoware.universe/issues/8013>`_)
+* fix(autoware_object_velocity_splitter): fix funcArgNamesDifferent (`#8013 <https://github.com/autowarefoundation/autoware.universe/issues/8013>`_)
   * fix:funcArgNamesDifferent
   * fix:funcArgNamesDifferent
   ---------
-* refactor(radar)!: add package name prefix of autoware\_ (`#7892 <https://github.com/youtalk/autoware.universe/issues/7892>`_)
+* refactor(radar)!: add package name prefix of autoware\_ (`#7892 <https://github.com/autowarefoundation/autoware.universe/issues/7892>`_)
   * refactor: rename radar_object_tracker
   * refactor: rename package from radar_object_tracker to autoware_radar_object_tracker
   * refactor: rename package from radar_object_clustering to autoware_radar_object_clustering

--- a/perception/autoware_occupancy_grid_map_outlier_filter/CHANGELOG.rst
+++ b/perception/autoware_occupancy_grid_map_outlier_filter/CHANGELOG.rst
@@ -5,7 +5,7 @@ Changelog for package autoware_occupancy_grid_map_outlier_filter
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* feat(occupancy_grid_map_outlier_filter): add time_keeper (`#8597 <https://github.com/youtalk/autoware.universe/issues/8597>`_)
+* feat(occupancy_grid_map_outlier_filter): add time_keeper (`#8597 <https://github.com/autowarefoundation/autoware.universe/issues/8597>`_)
   * add time_keeper
   * add option for time keeper
   * add scope and timekeeper
@@ -14,12 +14,12 @@ Changelog for package autoware_occupancy_grid_map_outlier_filter
   * add timekeeper option
   * fix comment
   ---------
-* refactor(perception/occupancy_grid_map_outlier_filter): rework parameters (`#6745 <https://github.com/youtalk/autoware.universe/issues/6745>`_)
+* refactor(perception/occupancy_grid_map_outlier_filter): rework parameters (`#6745 <https://github.com/autowarefoundation/autoware.universe/issues/6745>`_)
   * add param and schema file, edit readme
   * .
   * correct linter errors
   ---------
-* refactor(probabilistic_occupancy_grid_map, occupancy_grid_map_outlier_filter): add autoware\_ prefix to package name (`#8183 <https://github.com/youtalk/autoware.universe/issues/8183>`_)
+* refactor(probabilistic_occupancy_grid_map, occupancy_grid_map_outlier_filter): add autoware\_ prefix to package name (`#8183 <https://github.com/autowarefoundation/autoware.universe/issues/8183>`_)
   * chore: fix package name probabilistic occupancy grid map
   * fix: solve launch error
   * chore: update occupancy_grid_map_outlier_filter

--- a/perception/autoware_probabilistic_occupancy_grid_map/CHANGELOG.rst
+++ b/perception/autoware_probabilistic_occupancy_grid_map/CHANGELOG.rst
@@ -5,7 +5,7 @@ Changelog for package autoware_probabilistic_occupancy_grid_map
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* feat(probabilistic_occupancy_grid_map): add time_keeper (`#8601 <https://github.com/youtalk/autoware.universe/issues/8601>`_)
+* feat(probabilistic_occupancy_grid_map): add time_keeper (`#8601 <https://github.com/autowarefoundation/autoware.universe/issues/8601>`_)
   * add time_keeper
   * add option for time keeper
   * correct namespace
@@ -18,15 +18,15 @@ Changelog for package autoware_probabilistic_occupancy_grid_map
   * fix variable shadowing
   ---------
   Co-authored-by: Taekjin LEE <technolojin@gmail.com>
-* fix(autoware_probabilistic_occupancy_grid_map): fix unusedFunction (`#8574 <https://github.com/youtalk/autoware.universe/issues/8574>`_)
+* fix(autoware_probabilistic_occupancy_grid_map): fix unusedFunction (`#8574 <https://github.com/autowarefoundation/autoware.universe/issues/8574>`_)
   fix:unusedFunction
-* fix(autoware_probabilistic_occupancy_grid_map): fix functionConst (`#8426 <https://github.com/youtalk/autoware.universe/issues/8426>`_)
+* fix(autoware_probabilistic_occupancy_grid_map): fix functionConst (`#8426 <https://github.com/autowarefoundation/autoware.universe/issues/8426>`_)
   fix:functionConst
-* fix(autoware_probabilistic_occupancy_grid_map): fix uninitMemberVar (`#8333 <https://github.com/youtalk/autoware.universe/issues/8333>`_)
+* fix(autoware_probabilistic_occupancy_grid_map): fix uninitMemberVar (`#8333 <https://github.com/autowarefoundation/autoware.universe/issues/8333>`_)
   fix:uninitMemberVar
-* fix(autoware_probabilistic_occupancy_grid_map): fix functionConst (`#8289 <https://github.com/youtalk/autoware.universe/issues/8289>`_)
+* fix(autoware_probabilistic_occupancy_grid_map): fix functionConst (`#8289 <https://github.com/autowarefoundation/autoware.universe/issues/8289>`_)
   fix:functionConst
-* refactor(probabilistic_occupancy_grid_map, occupancy_grid_map_outlier_filter): add autoware\_ prefix to package name (`#8183 <https://github.com/youtalk/autoware.universe/issues/8183>`_)
+* refactor(probabilistic_occupancy_grid_map, occupancy_grid_map_outlier_filter): add autoware\_ prefix to package name (`#8183 <https://github.com/autowarefoundation/autoware.universe/issues/8183>`_)
   * chore: fix package name probabilistic occupancy grid map
   * fix: solve launch error
   * chore: update occupancy_grid_map_outlier_filter

--- a/perception/autoware_radar_crossing_objects_noise_filter/CHANGELOG.rst
+++ b/perception/autoware_radar_crossing_objects_noise_filter/CHANGELOG.rst
@@ -5,12 +5,12 @@ Changelog for package autoware_radar_crossing_objects_noise_filter
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* refactor(radar_tracks_msgs_converter, simple_object_merger, radar_tracks_noise_filter)!: add package name prefix of autoware\_ (`#8173 <https://github.com/youtalk/autoware.universe/issues/8173>`_)
+* refactor(radar_tracks_msgs_converter, simple_object_merger, radar_tracks_noise_filter)!: add package name prefix of autoware\_ (`#8173 <https://github.com/autowarefoundation/autoware.universe/issues/8173>`_)
   * refactor: rename radar_tracks_msgs_converter package to autoware_radar_tracks_msgs_converter
   * refactor: rename simple_object_merger package to autoware_simple_object_merger
   * refactor: rename sensing/radar_tracks_noise_filter to sensing/autoware_radar_tracks_noise_filter
   ---------
-* refactor(radar)!: add package name prefix of autoware\_ (`#7892 <https://github.com/youtalk/autoware.universe/issues/7892>`_)
+* refactor(radar)!: add package name prefix of autoware\_ (`#7892 <https://github.com/autowarefoundation/autoware.universe/issues/7892>`_)
   * refactor: rename radar_object_tracker
   * refactor: rename package from radar_object_tracker to autoware_radar_object_tracker
   * refactor: rename package from radar_object_clustering to autoware_radar_object_clustering

--- a/perception/autoware_radar_fusion_to_detected_object/CHANGELOG.rst
+++ b/perception/autoware_radar_fusion_to_detected_object/CHANGELOG.rst
@@ -5,16 +5,16 @@ Changelog for package autoware_radar_fusion_to_detected_object
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* fix(autoware_radar_fusion_to_detected_object): fix variableScope (`#8429 <https://github.com/youtalk/autoware.universe/issues/8429>`_)
+* fix(autoware_radar_fusion_to_detected_object): fix variableScope (`#8429 <https://github.com/autowarefoundation/autoware.universe/issues/8429>`_)
   fix:variableScope
   Co-authored-by: kobayu858 <129580202+kobayu858@users.noreply.github.com>
-* fix(autoware_radar_fusion_to_detected_object): fix functionConst (`#8287 <https://github.com/youtalk/autoware.universe/issues/8287>`_)
+* fix(autoware_radar_fusion_to_detected_object): fix functionConst (`#8287 <https://github.com/autowarefoundation/autoware.universe/issues/8287>`_)
   fix:functionConst
-* fix(autoware_radar_fusion_to_detected_object): fix warnings of functionStatic (`#8052 <https://github.com/youtalk/autoware.universe/issues/8052>`_)
+* fix(autoware_radar_fusion_to_detected_object): fix warnings of functionStatic (`#8052 <https://github.com/autowarefoundation/autoware.universe/issues/8052>`_)
   fix: deal with functionStatic warning
-* fix(autoware_radar_fusion_to_detected_object): fix constParameterReference (`#8040 <https://github.com/youtalk/autoware.universe/issues/8040>`_)
+* fix(autoware_radar_fusion_to_detected_object): fix constParameterReference (`#8040 <https://github.com/autowarefoundation/autoware.universe/issues/8040>`_)
   fix:constParameterReference
-* refactor(radar)!: add package name prefix of autoware\_ (`#7892 <https://github.com/youtalk/autoware.universe/issues/7892>`_)
+* refactor(radar)!: add package name prefix of autoware\_ (`#7892 <https://github.com/autowarefoundation/autoware.universe/issues/7892>`_)
   * refactor: rename radar_object_tracker
   * refactor: rename package from radar_object_tracker to autoware_radar_object_tracker
   * refactor: rename package from radar_object_clustering to autoware_radar_object_clustering

--- a/perception/autoware_radar_object_clustering/CHANGELOG.rst
+++ b/perception/autoware_radar_object_clustering/CHANGELOG.rst
@@ -5,22 +5,22 @@ Changelog for package autoware_radar_object_clustering
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* refactor(object_recognition_utils): add autoware prefix to object_recognition_utils (`#8946 <https://github.com/youtalk/autoware.universe/issues/8946>`_)
-* refactor(radar_tracks_msgs_converter, simple_object_merger, radar_tracks_noise_filter)!: add package name prefix of autoware\_ (`#8173 <https://github.com/youtalk/autoware.universe/issues/8173>`_)
+* refactor(object_recognition_utils): add autoware prefix to object_recognition_utils (`#8946 <https://github.com/autowarefoundation/autoware.universe/issues/8946>`_)
+* refactor(radar_tracks_msgs_converter, simple_object_merger, radar_tracks_noise_filter)!: add package name prefix of autoware\_ (`#8173 <https://github.com/autowarefoundation/autoware.universe/issues/8173>`_)
   * refactor: rename radar_tracks_msgs_converter package to autoware_radar_tracks_msgs_converter
   * refactor: rename simple_object_merger package to autoware_simple_object_merger
   * refactor: rename sensing/radar_tracks_noise_filter to sensing/autoware_radar_tracks_noise_filter
   ---------
-* fix(autoware_radar_object_clustering): fix funcArgNamesDifferent (`#8014 <https://github.com/youtalk/autoware.universe/issues/8014>`_)
+* fix(autoware_radar_object_clustering): fix funcArgNamesDifferent (`#8014 <https://github.com/autowarefoundation/autoware.universe/issues/8014>`_)
   * fix:funcArgNamesDifferent
   * fix:funcArgNamesDifferent
   ---------
-* refactor(multi_object_tracker)!: add package name prefix of autoware\_ (`#8083 <https://github.com/youtalk/autoware.universe/issues/8083>`_)
+* refactor(multi_object_tracker)!: add package name prefix of autoware\_ (`#8083 <https://github.com/autowarefoundation/autoware.universe/issues/8083>`_)
   * refactor: rename multi_object_tracker package to autoware_multi_object_tracker
   * style(pre-commit): autofix
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* refactor(radar)!: add package name prefix of autoware\_ (`#7892 <https://github.com/youtalk/autoware.universe/issues/7892>`_)
+* refactor(radar)!: add package name prefix of autoware\_ (`#7892 <https://github.com/autowarefoundation/autoware.universe/issues/7892>`_)
   * refactor: rename radar_object_tracker
   * refactor: rename package from radar_object_tracker to autoware_radar_object_tracker
   * refactor: rename package from radar_object_clustering to autoware_radar_object_clustering

--- a/perception/autoware_radar_object_tracker/CHANGELOG.rst
+++ b/perception/autoware_radar_object_tracker/CHANGELOG.rst
@@ -5,29 +5,29 @@ Changelog for package autoware_radar_object_tracker
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* refactor(object_recognition_utils): add autoware prefix to object_recognition_utils (`#8946 <https://github.com/youtalk/autoware.universe/issues/8946>`_)
-* refactor(kalman_filter): prefix package and namespace with autoware (`#7787 <https://github.com/youtalk/autoware.universe/issues/7787>`_)
+* refactor(object_recognition_utils): add autoware prefix to object_recognition_utils (`#8946 <https://github.com/autowarefoundation/autoware.universe/issues/8946>`_)
+* refactor(kalman_filter): prefix package and namespace with autoware (`#7787 <https://github.com/autowarefoundation/autoware.universe/issues/7787>`_)
   * refactor(kalman_filter): prefix package and namespace with autoware
   * move headers to include/autoware/
   * style(pre-commit): autofix
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* fix(autoware_radar_object_tracker): fix redundantInitialization (`#8227 <https://github.com/youtalk/autoware.universe/issues/8227>`_)
+* fix(autoware_radar_object_tracker): fix redundantInitialization (`#8227 <https://github.com/autowarefoundation/autoware.universe/issues/8227>`_)
   * fix(autoware_radar_object_tracker): fix redundantInitialization
   * Update perception/autoware_radar_object_tracker/src/tracker/model/constant_turn_rate_motion_tracker.cpp
   Co-authored-by: Yukihiro Saito <yukky.saito@gmail.com>
   ---------
   Co-authored-by: Yukihiro Saito <yukky.saito@gmail.com>
-* fix(multi_object_tracker, object_merger, radar_object_tracker, tracking_object_merger): fix knownConditionTrueFalse warnings (`#8137 <https://github.com/youtalk/autoware.universe/issues/8137>`_)
+* fix(multi_object_tracker, object_merger, radar_object_tracker, tracking_object_merger): fix knownConditionTrueFalse warnings (`#8137 <https://github.com/autowarefoundation/autoware.universe/issues/8137>`_)
   * fix: cppcheck knownConditionTrueFalse
   * fix
   * fix
   ---------
-* fix(autoware_radar_object_tracker): fix funcArgNamesDifferent (`#8015 <https://github.com/youtalk/autoware.universe/issues/8015>`_)
+* fix(autoware_radar_object_tracker): fix funcArgNamesDifferent (`#8015 <https://github.com/autowarefoundation/autoware.universe/issues/8015>`_)
   fix:funcArgNamesDifferent
-* fix(autoware_radar_object_tracker): fix shadowVariable (`#7945 <https://github.com/youtalk/autoware.universe/issues/7945>`_)
+* fix(autoware_radar_object_tracker): fix shadowVariable (`#7945 <https://github.com/autowarefoundation/autoware.universe/issues/7945>`_)
   fix:shadowVariable
-* refactor(radar)!: add package name prefix of autoware\_ (`#7892 <https://github.com/youtalk/autoware.universe/issues/7892>`_)
+* refactor(radar)!: add package name prefix of autoware\_ (`#7892 <https://github.com/autowarefoundation/autoware.universe/issues/7892>`_)
   * refactor: rename radar_object_tracker
   * refactor: rename package from radar_object_tracker to autoware_radar_object_tracker
   * refactor: rename package from radar_object_clustering to autoware_radar_object_clustering

--- a/perception/autoware_radar_tracks_msgs_converter/CHANGELOG.rst
+++ b/perception/autoware_radar_tracks_msgs_converter/CHANGELOG.rst
@@ -5,11 +5,11 @@ Changelog for package autoware_radar_tracks_msgs_converter
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* fix(docs): fix docs for radar tracks msgs converter (`#8305 <https://github.com/youtalk/autoware.universe/issues/8305>`_)
+* fix(docs): fix docs for radar tracks msgs converter (`#8305 <https://github.com/autowarefoundation/autoware.universe/issues/8305>`_)
   * fix docs for radar tracks msgs converter
   * fix a not correctly formatted link in readme found by CI
   ---------
-* refactor(radar_tracks_msgs_converter, simple_object_merger, radar_tracks_noise_filter)!: add package name prefix of autoware\_ (`#8173 <https://github.com/youtalk/autoware.universe/issues/8173>`_)
+* refactor(radar_tracks_msgs_converter, simple_object_merger, radar_tracks_noise_filter)!: add package name prefix of autoware\_ (`#8173 <https://github.com/autowarefoundation/autoware.universe/issues/8173>`_)
   * refactor: rename radar_tracks_msgs_converter package to autoware_radar_tracks_msgs_converter
   * refactor: rename simple_object_merger package to autoware_simple_object_merger
   * refactor: rename sensing/radar_tracks_noise_filter to sensing/autoware_radar_tracks_noise_filter

--- a/perception/autoware_raindrop_cluster_filter/CHANGELOG.rst
+++ b/perception/autoware_raindrop_cluster_filter/CHANGELOG.rst
@@ -5,11 +5,11 @@ Changelog for package autoware_raindrop_cluster_filter
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* refactor(autoware_point_types): prefix namespace with autoware::point_types (`#9169 <https://github.com/youtalk/autoware.universe/issues/9169>`_)
-* chore(raindrop_cluster_filter): add node test (`#8859 <https://github.com/youtalk/autoware.universe/issues/8859>`_)
-* refactor(detected_object_validation)!: add package name prefix of autoware\_ (`#8122 <https://github.com/youtalk/autoware.universe/issues/8122>`_)
+* refactor(autoware_point_types): prefix namespace with autoware::point_types (`#9169 <https://github.com/autowarefoundation/autoware.universe/issues/9169>`_)
+* chore(raindrop_cluster_filter): add node test (`#8859 <https://github.com/autowarefoundation/autoware.universe/issues/8859>`_)
+* refactor(detected_object_validation)!: add package name prefix of autoware\_ (`#8122 <https://github.com/autowarefoundation/autoware.universe/issues/8122>`_)
   refactor: rename detected_object_validation to autoware_detected_object_validation
-* refactor(raindrop_cluster_filter): add package name prefix of autoware\_ (`#8000 <https://github.com/youtalk/autoware.universe/issues/8000>`_)
+* refactor(raindrop_cluster_filter): add package name prefix of autoware\_ (`#8000 <https://github.com/autowarefoundation/autoware.universe/issues/8000>`_)
   * refactor(raindrop_cluster_filter): add package name prefix of autoware\_
   * fix: typo
   ---------

--- a/perception/autoware_shape_estimation/CHANGELOG.rst
+++ b/perception/autoware_shape_estimation/CHANGELOG.rst
@@ -5,13 +5,13 @@ Changelog for package autoware_shape_estimation
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* feat(autoware_shape_estimation): add reference object based corrector (`#9148 <https://github.com/youtalk/autoware.universe/issues/9148>`_)
+* feat(autoware_shape_estimation): add reference object based corrector (`#9148 <https://github.com/autowarefoundation/autoware.universe/issues/9148>`_)
   * add object based corrector
   * apply cppcheck suggestion
   * fix typo
   ---------
   Co-authored-by: Taekjin LEE <taekjin.lee@tier4.jp>
-* refactor(tensorrt_common)!: fix namespace, directory structure & move to perception namespace (`#9099 <https://github.com/youtalk/autoware.universe/issues/9099>`_)
+* refactor(tensorrt_common)!: fix namespace, directory structure & move to perception namespace (`#9099 <https://github.com/autowarefoundation/autoware.universe/issues/9099>`_)
   * refactor(tensorrt_common)!: fix namespace, directory structure & move to perception namespace
   * refactor(tensorrt_common): directory structure
   * style(pre-commit): autofix
@@ -19,17 +19,17 @@ Changelog for package autoware_shape_estimation
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Kenzo Lobos Tsunekawa <kenzo.lobos@tier4.jp>
-* test(autoware_shape_estimation): add unit testing for `ShapeEstimationNode` (`#8740 <https://github.com/youtalk/autoware.universe/issues/8740>`_)
+* test(autoware_shape_estimation): add unit testing for `ShapeEstimationNode` (`#8740 <https://github.com/autowarefoundation/autoware.universe/issues/8740>`_)
   test: add unit testing for `ShapeEstimationNode`
-* fix(autoware_shape_estimation): fix unusedFunction (`#8575 <https://github.com/youtalk/autoware.universe/issues/8575>`_)
+* fix(autoware_shape_estimation): fix unusedFunction (`#8575 <https://github.com/autowarefoundation/autoware.universe/issues/8575>`_)
   * fix:unusedFunction
   * fix:unusedFunction
   * fix:end of file issues
   * fix:copyright
   ---------
-* fix(autoware_shape_estimation): resolve undefined reference to `~TrtShapeEstimator()` (`#8738 <https://github.com/youtalk/autoware.universe/issues/8738>`_)
+* fix(autoware_shape_estimation): resolve undefined reference to `~TrtShapeEstimator()` (`#8738 <https://github.com/autowarefoundation/autoware.universe/issues/8738>`_)
   fix: resolve undefined reference to `~TrtShapeEstimator()`
-* feat(shape_estimation): add ml shape estimation (`#7860 <https://github.com/youtalk/autoware.universe/issues/7860>`_)
+* feat(shape_estimation): add ml shape estimation (`#7860 <https://github.com/autowarefoundation/autoware.universe/issues/7860>`_)
   * feat(shape_estimation): add ml shape estimation
   * style(pre-commit): autofix
   * feat(shape_estimation): fix exceed objects
@@ -37,7 +37,7 @@ Changelog for package autoware_shape_estimation
   * feat(shape_estimation): fix indent
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* refactor(shape_estimation): add package name prefix of autoware\_ (`#7999 <https://github.com/youtalk/autoware.universe/issues/7999>`_)
+* refactor(shape_estimation): add package name prefix of autoware\_ (`#7999 <https://github.com/autowarefoundation/autoware.universe/issues/7999>`_)
   * refactor(shape_estimation): add package name prefix of autoware\_
   * style(pre-commit): autofix
   * fix: mising prefix

--- a/perception/autoware_simple_object_merger/CHANGELOG.rst
+++ b/perception/autoware_simple_object_merger/CHANGELOG.rst
@@ -5,7 +5,7 @@ Changelog for package autoware_simple_object_merger
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* refactor(radar_tracks_msgs_converter, simple_object_merger, radar_tracks_noise_filter)!: add package name prefix of autoware\_ (`#8173 <https://github.com/youtalk/autoware.universe/issues/8173>`_)
+* refactor(radar_tracks_msgs_converter, simple_object_merger, radar_tracks_noise_filter)!: add package name prefix of autoware\_ (`#8173 <https://github.com/autowarefoundation/autoware.universe/issues/8173>`_)
   * refactor: rename radar_tracks_msgs_converter package to autoware_radar_tracks_msgs_converter
   * refactor: rename simple_object_merger package to autoware_simple_object_merger
   * refactor: rename sensing/radar_tracks_noise_filter to sensing/autoware_radar_tracks_noise_filter

--- a/perception/autoware_tensorrt_classifier/CHANGELOG.rst
+++ b/perception/autoware_tensorrt_classifier/CHANGELOG.rst
@@ -5,7 +5,7 @@ Changelog for package autoware_tensorrt_classifier
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* refactor(tensorrt_common)!: fix namespace, directory structure & move to perception namespace (`#9099 <https://github.com/youtalk/autoware.universe/issues/9099>`_)
+* refactor(tensorrt_common)!: fix namespace, directory structure & move to perception namespace (`#9099 <https://github.com/autowarefoundation/autoware.universe/issues/9099>`_)
   * refactor(tensorrt_common)!: fix namespace, directory structure & move to perception namespace
   * refactor(tensorrt_common): directory structure
   * style(pre-commit): autofix
@@ -13,13 +13,13 @@ Changelog for package autoware_tensorrt_classifier
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Kenzo Lobos Tsunekawa <kenzo.lobos@tier4.jp>
-* fix(tensorrt classifier wrapper): fix unreadVariable (`#8355 <https://github.com/youtalk/autoware.universe/issues/8355>`_)
+* fix(tensorrt classifier wrapper): fix unreadVariable (`#8355 <https://github.com/autowarefoundation/autoware.universe/issues/8355>`_)
   * fix:unreadVariable
   * fix:unreadVariable
   ---------
-* fix(autoware_tensorrt_classifier): fix passedByValue (`#8236 <https://github.com/youtalk/autoware.universe/issues/8236>`_)
+* fix(autoware_tensorrt_classifier): fix passedByValue (`#8236 <https://github.com/autowarefoundation/autoware.universe/issues/8236>`_)
   fix:passedByValue
-* refactor(tensorrt_classifier)!: fix namespace and directory structure (`#8009 <https://github.com/youtalk/autoware.universe/issues/8009>`_)
+* refactor(tensorrt_classifier)!: fix namespace and directory structure (`#8009 <https://github.com/autowarefoundation/autoware.universe/issues/8009>`_)
   * add prefix  into
   * add prefix in CODEOWNERS
   * remove invalid author

--- a/perception/autoware_tensorrt_common/CHANGELOG.rst
+++ b/perception/autoware_tensorrt_common/CHANGELOG.rst
@@ -5,7 +5,7 @@ Changelog for package autoware_tensorrt_common
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* refactor(tensorrt_common)!: fix namespace, directory structure & move to perception namespace (`#9099 <https://github.com/youtalk/autoware.universe/issues/9099>`_)
+* refactor(tensorrt_common)!: fix namespace, directory structure & move to perception namespace (`#9099 <https://github.com/autowarefoundation/autoware.universe/issues/9099>`_)
   * refactor(tensorrt_common)!: fix namespace, directory structure & move to perception namespace
   * refactor(tensorrt_common): directory structure
   * style(pre-commit): autofix

--- a/perception/autoware_tensorrt_yolox/CHANGELOG.rst
+++ b/perception/autoware_tensorrt_yolox/CHANGELOG.rst
@@ -5,7 +5,7 @@ Changelog for package autoware_tensorrt_yolox
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* refactor(tensorrt_common)!: fix namespace, directory structure & move to perception namespace (`#9099 <https://github.com/youtalk/autoware.universe/issues/9099>`_)
+* refactor(tensorrt_common)!: fix namespace, directory structure & move to perception namespace (`#9099 <https://github.com/autowarefoundation/autoware.universe/issues/9099>`_)
   * refactor(tensorrt_common)!: fix namespace, directory structure & move to perception namespace
   * refactor(tensorrt_common): directory structure
   * style(pre-commit): autofix
@@ -13,27 +13,27 @@ Changelog for package autoware_tensorrt_yolox
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Kenzo Lobos Tsunekawa <kenzo.lobos@tier4.jp>
-* refactor(object_recognition_utils): add autoware prefix to object_recognition_utils (`#8946 <https://github.com/youtalk/autoware.universe/issues/8946>`_)
-* feat(autoware_tensorrt_yolox): add GPU - CUDA device option (`#8245 <https://github.com/youtalk/autoware.universe/issues/8245>`_)
+* refactor(object_recognition_utils): add autoware prefix to object_recognition_utils (`#8946 <https://github.com/autowarefoundation/autoware.universe/issues/8946>`_)
+* feat(autoware_tensorrt_yolox): add GPU - CUDA device option (`#8245 <https://github.com/autowarefoundation/autoware.universe/issues/8245>`_)
   * init CUDA device option
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* chore(autoware_tensorrt_yolox): add Kotaro Uetake as maintainer (`#8595 <https://github.com/youtalk/autoware.universe/issues/8595>`_)
+* chore(autoware_tensorrt_yolox): add Kotaro Uetake as maintainer (`#8595 <https://github.com/autowarefoundation/autoware.universe/issues/8595>`_)
   chore: add Kotaro Uetake as maintainer
-* fix: cpp17 namespaces (`#8526 <https://github.com/youtalk/autoware.universe/issues/8526>`_)
+* fix: cpp17 namespaces (`#8526 <https://github.com/autowarefoundation/autoware.universe/issues/8526>`_)
   Use traditional-style nameplace nesting for nvcc
   Co-authored-by: Yuri Guimaraes <yuri.kgpps@gmail.com>
-* fix(docs): fix docs for tensorrt yolox (`#8304 <https://github.com/youtalk/autoware.universe/issues/8304>`_)
+* fix(docs): fix docs for tensorrt yolox (`#8304 <https://github.com/autowarefoundation/autoware.universe/issues/8304>`_)
   fix docs for tensorrt yolox
-* refactor(tensorrt_yolox): move utils into perception_utils (`#8435 <https://github.com/youtalk/autoware.universe/issues/8435>`_)
+* refactor(tensorrt_yolox): move utils into perception_utils (`#8435 <https://github.com/autowarefoundation/autoware.universe/issues/8435>`_)
   * chore(tensorrt_yolo): refactor utils
   * style(pre-commit): autofix
   * fix: tensorrt_yolox
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* fix(autoware_tensorrt_yolox): fix variableScope (`#8430 <https://github.com/youtalk/autoware.universe/issues/8430>`_)
+* fix(autoware_tensorrt_yolox): fix variableScope (`#8430 <https://github.com/autowarefoundation/autoware.universe/issues/8430>`_)
   fix: variableScope
   Co-authored-by: kobayu858 <129580202+kobayu858@users.noreply.github.com>
-* fix(tensorrt_yolox): add run length encoding for sematic segmentation mask (`#7905 <https://github.com/youtalk/autoware.universe/issues/7905>`_)
+* fix(tensorrt_yolox): add run length encoding for sematic segmentation mask (`#7905 <https://github.com/autowarefoundation/autoware.universe/issues/7905>`_)
   * fix: add rle compress
   * fix: rle compress
   * fix: move rle into utils
@@ -55,11 +55,11 @@ Changelog for package autoware_tensorrt_yolox
   Co-authored-by: Yukihiro Saito <yukky.saito@gmail.com>
   Co-authored-by: Manato Hirabayashi <3022416+manato@users.noreply.github.com>
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* fix(autoware_tensorrt_yolox): fix unreadVariable (`#8356 <https://github.com/youtalk/autoware.universe/issues/8356>`_)
+* fix(autoware_tensorrt_yolox): fix unreadVariable (`#8356 <https://github.com/autowarefoundation/autoware.universe/issues/8356>`_)
   * fix:unreadVariable
   * fix:unreadVariable
   ---------
-* refactor: image transport decompressor/autoware prefix (`#8197 <https://github.com/youtalk/autoware.universe/issues/8197>`_)
+* refactor: image transport decompressor/autoware prefix (`#8197 <https://github.com/autowarefoundation/autoware.universe/issues/8197>`_)
   * refactor: add `autoware` namespace prefix to image_transport_decompressor
   * refactor(image_transport_decompressor): add `autoware` prefix to the package code
   * refactor: update package name in CODEOWNER
@@ -70,7 +70,7 @@ Changelog for package autoware_tensorrt_yolox
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Taekjin LEE <taekjin.lee@tier4.jp>
-* refactor(tensorrt_yolox)!: fix namespace and directory structure (`#7992 <https://github.com/youtalk/autoware.universe/issues/7992>`_)
+* refactor(tensorrt_yolox)!: fix namespace and directory structure (`#7992 <https://github.com/autowarefoundation/autoware.universe/issues/7992>`_)
   * refactor: add autoware namespace prefix to `tensorrt_yolox`
   * refactor: apply `autoware` namespace to tensorrt_yolox
   * chore: update CODEOWNERS

--- a/perception/autoware_tracking_object_merger/CHANGELOG.rst
+++ b/perception/autoware_tracking_object_merger/CHANGELOG.rst
@@ -5,20 +5,20 @@ Changelog for package autoware_tracking_object_merger
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* refactor(object_recognition_utils): add autoware prefix to object_recognition_utils (`#8946 <https://github.com/youtalk/autoware.universe/issues/8946>`_)
-* fix(autoware_tracking_object_merger): fix unusedFunction (`#8578 <https://github.com/youtalk/autoware.universe/issues/8578>`_)
+* refactor(object_recognition_utils): add autoware prefix to object_recognition_utils (`#8946 <https://github.com/autowarefoundation/autoware.universe/issues/8946>`_)
+* fix(autoware_tracking_object_merger): fix unusedFunction (`#8578 <https://github.com/autowarefoundation/autoware.universe/issues/8578>`_)
   fix:unusedFunction
-* fix(autoware_tracking_object_merger): add merge frame (`#8418 <https://github.com/youtalk/autoware.universe/issues/8418>`_)
+* fix(autoware_tracking_object_merger): add merge frame (`#8418 <https://github.com/autowarefoundation/autoware.universe/issues/8418>`_)
   * fix(autoware_tracking_object_merger): add merge frame
   * style(pre-commit): autofix
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* fix(multi_object_tracker, object_merger, radar_object_tracker, tracking_object_merger): fix knownConditionTrueFalse warnings (`#8137 <https://github.com/youtalk/autoware.universe/issues/8137>`_)
+* fix(multi_object_tracker, object_merger, radar_object_tracker, tracking_object_merger): fix knownConditionTrueFalse warnings (`#8137 <https://github.com/autowarefoundation/autoware.universe/issues/8137>`_)
   * fix: cppcheck knownConditionTrueFalse
   * fix
   * fix
   ---------
-* refactor(autoware_tracking_object_merger): move headers to include/autoware and rename package (`#7809 <https://github.com/youtalk/autoware.universe/issues/7809>`_)
+* refactor(autoware_tracking_object_merger): move headers to include/autoware and rename package (`#7809 <https://github.com/autowarefoundation/autoware.universe/issues/7809>`_)
 * Contributors: Esteve Fernandez, Kaan Çolak, Ryuta Kambe, Yutaka Kondo, kobayu858
 
 0.26.0 (2024-04-03)

--- a/perception/autoware_traffic_light_arbiter/CHANGELOG.rst
+++ b/perception/autoware_traffic_light_arbiter/CHANGELOG.rst
@@ -5,9 +5,9 @@ Changelog for package autoware_traffic_light_arbiter
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* fix(autoware_traffic_light_arbiter): fix build error (`#9186 <https://github.com/youtalk/autoware.universe/issues/9186>`_)
+* fix(autoware_traffic_light_arbiter): fix build error (`#9186 <https://github.com/autowarefoundation/autoware.universe/issues/9186>`_)
   fix build error
-* test(autoware_traffic_light_arbiter): add node test (`#8747 <https://github.com/youtalk/autoware.universe/issues/8747>`_)
+* test(autoware_traffic_light_arbiter): add node test (`#8747 <https://github.com/autowarefoundation/autoware.universe/issues/8747>`_)
   * add test dir
   * update test node
   * style(pre-commit): autofix
@@ -17,9 +17,9 @@ Changelog for package autoware_traffic_light_arbiter
   * fix typo
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* chore(traffic_light_arbiter): missing name changes (`#8278 <https://github.com/youtalk/autoware.universe/issues/8278>`_)
+* chore(traffic_light_arbiter): missing name changes (`#8278 <https://github.com/autowarefoundation/autoware.universe/issues/8278>`_)
   chore: missing name changes
-* refactor: traffic light arbiter/autoware prefix (`#8181 <https://github.com/youtalk/autoware.universe/issues/8181>`_)
+* refactor: traffic light arbiter/autoware prefix (`#8181 <https://github.com/autowarefoundation/autoware.universe/issues/8181>`_)
   * refactor(traffic_light_arbiter): apply `autoware` namespace to traffic_light_arbiter
   * refactor(traffic_light_arbiter): update the package name in CODEWONER
   * style(pre-commit): autofix

--- a/perception/autoware_traffic_light_classifier/CHANGELOG.rst
+++ b/perception/autoware_traffic_light_classifier/CHANGELOG.rst
@@ -5,7 +5,7 @@ Changelog for package autoware_traffic_light_classifier
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* refactor(tensorrt_common)!: fix namespace, directory structure & move to perception namespace (`#9099 <https://github.com/youtalk/autoware.universe/issues/9099>`_)
+* refactor(tensorrt_common)!: fix namespace, directory structure & move to perception namespace (`#9099 <https://github.com/autowarefoundation/autoware.universe/issues/9099>`_)
   * refactor(tensorrt_common)!: fix namespace, directory structure & move to perception namespace
   * refactor(tensorrt_common): directory structure
   * style(pre-commit): autofix
@@ -13,11 +13,11 @@ Changelog for package autoware_traffic_light_classifier
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Kenzo Lobos Tsunekawa <kenzo.lobos@tier4.jp>
-* fix(traffic_light_classifier): fix traffic light monitor warning (`#8412 <https://github.com/youtalk/autoware.universe/issues/8412>`_)
+* fix(traffic_light_classifier): fix traffic light monitor warning (`#8412 <https://github.com/autowarefoundation/autoware.universe/issues/8412>`_)
   fix traffic light monitor warning
-* fix(autoware_traffic_light_classifier): fix passedByValue (`#8392 <https://github.com/youtalk/autoware.universe/issues/8392>`_)
+* fix(autoware_traffic_light_classifier): fix passedByValue (`#8392 <https://github.com/autowarefoundation/autoware.universe/issues/8392>`_)
   fix:passedByValue
-* fix(traffic_light_classifier): fix zero size roi bug (`#7608 <https://github.com/youtalk/autoware.universe/issues/7608>`_)
+* fix(traffic_light_classifier): fix zero size roi bug (`#7608 <https://github.com/autowarefoundation/autoware.universe/issues/7608>`_)
   * fix: continue to process when input roi size is zero
   * fix: consider when roi size is zero, rois is empty
   fix
@@ -27,11 +27,11 @@ Changelog for package autoware_traffic_light_classifier
   * chore: refactor code to handle empty input ROIs in traffic_light_classifier_node.cpp
   * refactor: using index instead of vector length
   ---------
-* fix(traffic_light_classifier): fix funcArgNamesDifferent (`#8153 <https://github.com/youtalk/autoware.universe/issues/8153>`_)
+* fix(traffic_light_classifier): fix funcArgNamesDifferent (`#8153 <https://github.com/autowarefoundation/autoware.universe/issues/8153>`_)
   * fix:funcArgNamesDifferent
   * fix:clang format
   ---------
-* refactor(traffic_light\_*)!: add package name prefix of autoware\_ (`#8159 <https://github.com/youtalk/autoware.universe/issues/8159>`_)
+* refactor(traffic_light\_*)!: add package name prefix of autoware\_ (`#8159 <https://github.com/autowarefoundation/autoware.universe/issues/8159>`_)
   * chore: rename traffic_light_fine_detector to autoware_traffic_light_fine_detector
   * chore: rename traffic_light_multi_camera_fusion to autoware_traffic_light_multi_camera_fusion
   * chore: rename traffic_light_occlusion_predictor to autoware_traffic_light_occlusion_predictor

--- a/perception/autoware_traffic_light_fine_detector/CHANGELOG.rst
+++ b/perception/autoware_traffic_light_fine_detector/CHANGELOG.rst
@@ -5,7 +5,7 @@ Changelog for package autoware_traffic_light_fine_detector
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* refactor(tensorrt_common)!: fix namespace, directory structure & move to perception namespace (`#9099 <https://github.com/youtalk/autoware.universe/issues/9099>`_)
+* refactor(tensorrt_common)!: fix namespace, directory structure & move to perception namespace (`#9099 <https://github.com/autowarefoundation/autoware.universe/issues/9099>`_)
   * refactor(tensorrt_common)!: fix namespace, directory structure & move to perception namespace
   * refactor(tensorrt_common): directory structure
   * style(pre-commit): autofix
@@ -13,27 +13,27 @@ Changelog for package autoware_traffic_light_fine_detector
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Kenzo Lobos Tsunekawa <kenzo.lobos@tier4.jp>
-* feat(autoware_tensorrt_yolox): add GPU - CUDA device option (`#8245 <https://github.com/youtalk/autoware.universe/issues/8245>`_)
+* feat(autoware_tensorrt_yolox): add GPU - CUDA device option (`#8245 <https://github.com/autowarefoundation/autoware.universe/issues/8245>`_)
   * init CUDA device option
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* fix(autoware_traffic_light_fine_detector): fix unusedFunction (`#8583 <https://github.com/youtalk/autoware.universe/issues/8583>`_)
+* fix(autoware_traffic_light_fine_detector): fix unusedFunction (`#8583 <https://github.com/autowarefoundation/autoware.universe/issues/8583>`_)
   fix:unusedFunction
-* fix(autoware_traffic_light_fine_detector): fix passedByValue (`#8237 <https://github.com/youtalk/autoware.universe/issues/8237>`_)
+* fix(autoware_traffic_light_fine_detector): fix passedByValue (`#8237 <https://github.com/autowarefoundation/autoware.universe/issues/8237>`_)
   fix:passedByValue
-* fix(traffic_light_fine_detector): fix funcArgNamesDifferent (`#8154 <https://github.com/youtalk/autoware.universe/issues/8154>`_)
+* fix(traffic_light_fine_detector): fix funcArgNamesDifferent (`#8154 <https://github.com/autowarefoundation/autoware.universe/issues/8154>`_)
   fix:funcArgNamesDifferent
-* fix(autoware_traffic_light_fine_detector): fix constParameterReference (`#8146 <https://github.com/youtalk/autoware.universe/issues/8146>`_)
+* fix(autoware_traffic_light_fine_detector): fix constParameterReference (`#8146 <https://github.com/autowarefoundation/autoware.universe/issues/8146>`_)
   * fix:constParameterReference
   * fix:constParameterReference
   * fix:constParameterReference
   ---------
-* refactor(tensorrt_yolox)!: fix namespace and directory structure (`#7992 <https://github.com/youtalk/autoware.universe/issues/7992>`_)
+* refactor(tensorrt_yolox)!: fix namespace and directory structure (`#7992 <https://github.com/autowarefoundation/autoware.universe/issues/7992>`_)
   * refactor: add autoware namespace prefix to `tensorrt_yolox`
   * refactor: apply `autoware` namespace to tensorrt_yolox
   * chore: update CODEOWNERS
   * fix: resolve `yolox_tiny` to work
   ---------
-* refactor(traffic_light\_*)!: add package name prefix of autoware\_ (`#8159 <https://github.com/youtalk/autoware.universe/issues/8159>`_)
+* refactor(traffic_light\_*)!: add package name prefix of autoware\_ (`#8159 <https://github.com/autowarefoundation/autoware.universe/issues/8159>`_)
   * chore: rename traffic_light_fine_detector to autoware_traffic_light_fine_detector
   * chore: rename traffic_light_multi_camera_fusion to autoware_traffic_light_multi_camera_fusion
   * chore: rename traffic_light_occlusion_predictor to autoware_traffic_light_occlusion_predictor

--- a/perception/autoware_traffic_light_map_based_detector/CHANGELOG.rst
+++ b/perception/autoware_traffic_light_map_based_detector/CHANGELOG.rst
@@ -5,10 +5,10 @@ Changelog for package autoware_traffic_light_map_based_detector
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* fix(autoware_traffic_light_map_based_detector): output from screen to both (`#8411 <https://github.com/youtalk/autoware.universe/issues/8411>`_)
-* fix(traffic_light_map_based_detector): fix funcArgNamesDifferent (`#8155 <https://github.com/youtalk/autoware.universe/issues/8155>`_)
+* fix(autoware_traffic_light_map_based_detector): output from screen to both (`#8411 <https://github.com/autowarefoundation/autoware.universe/issues/8411>`_)
+* fix(traffic_light_map_based_detector): fix funcArgNamesDifferent (`#8155 <https://github.com/autowarefoundation/autoware.universe/issues/8155>`_)
   fix:funcArgNamesDifferent
-* refactor(traffic_light\_*)!: add package name prefix of autoware\_ (`#8159 <https://github.com/youtalk/autoware.universe/issues/8159>`_)
+* refactor(traffic_light\_*)!: add package name prefix of autoware\_ (`#8159 <https://github.com/autowarefoundation/autoware.universe/issues/8159>`_)
   * chore: rename traffic_light_fine_detector to autoware_traffic_light_fine_detector
   * chore: rename traffic_light_multi_camera_fusion to autoware_traffic_light_multi_camera_fusion
   * chore: rename traffic_light_occlusion_predictor to autoware_traffic_light_occlusion_predictor

--- a/perception/autoware_traffic_light_multi_camera_fusion/CHANGELOG.rst
+++ b/perception/autoware_traffic_light_multi_camera_fusion/CHANGELOG.rst
@@ -5,7 +5,7 @@ Changelog for package autoware_traffic_light_multi_camera_fusion
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* refactor(traffic_light\_*)!: add package name prefix of autoware\_ (`#8159 <https://github.com/youtalk/autoware.universe/issues/8159>`_)
+* refactor(traffic_light\_*)!: add package name prefix of autoware\_ (`#8159 <https://github.com/autowarefoundation/autoware.universe/issues/8159>`_)
   * chore: rename traffic_light_fine_detector to autoware_traffic_light_fine_detector
   * chore: rename traffic_light_multi_camera_fusion to autoware_traffic_light_multi_camera_fusion
   * chore: rename traffic_light_occlusion_predictor to autoware_traffic_light_occlusion_predictor

--- a/perception/autoware_traffic_light_occlusion_predictor/CHANGELOG.rst
+++ b/perception/autoware_traffic_light_occlusion_predictor/CHANGELOG.rst
@@ -5,11 +5,11 @@ Changelog for package autoware_traffic_light_occlusion_predictor
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* fix(traffic_light_occlusion_predictor): fix cppcheck warnings of functionStatic (`#8258 <https://github.com/youtalk/autoware.universe/issues/8258>`_)
+* fix(traffic_light_occlusion_predictor): fix cppcheck warnings of functionStatic (`#8258 <https://github.com/autowarefoundation/autoware.universe/issues/8258>`_)
   fix: deal with functionStatic warnings
-* fix(autoware_traffic_light_occlusion_predictor): fix functionConst (`#8286 <https://github.com/youtalk/autoware.universe/issues/8286>`_)
+* fix(autoware_traffic_light_occlusion_predictor): fix functionConst (`#8286 <https://github.com/autowarefoundation/autoware.universe/issues/8286>`_)
   fix:functionConst
-* refactor(traffic_light\_*)!: add package name prefix of autoware\_ (`#8159 <https://github.com/youtalk/autoware.universe/issues/8159>`_)
+* refactor(traffic_light\_*)!: add package name prefix of autoware\_ (`#8159 <https://github.com/autowarefoundation/autoware.universe/issues/8159>`_)
   * chore: rename traffic_light_fine_detector to autoware_traffic_light_fine_detector
   * chore: rename traffic_light_multi_camera_fusion to autoware_traffic_light_multi_camera_fusion
   * chore: rename traffic_light_occlusion_predictor to autoware_traffic_light_occlusion_predictor

--- a/perception/autoware_traffic_light_visualization/CHANGELOG.rst
+++ b/perception/autoware_traffic_light_visualization/CHANGELOG.rst
@@ -5,26 +5,26 @@ Changelog for package autoware_traffic_light_visualization
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* fix(docs): fix documentation for traffic light visualization (`#8303 <https://github.com/youtalk/autoware.universe/issues/8303>`_)
+* fix(docs): fix documentation for traffic light visualization (`#8303 <https://github.com/autowarefoundation/autoware.universe/issues/8303>`_)
   fix docs traffic light visualization
-* fix(autoware_traffic_light_visualization): fix to visualize correct color and shapes (`#8428 <https://github.com/youtalk/autoware.universe/issues/8428>`_)
+* fix(autoware_traffic_light_visualization): fix to visualize correct color and shapes (`#8428 <https://github.com/autowarefoundation/autoware.universe/issues/8428>`_)
   fix(autoware_traffic_light_visualization): fix vialization to draw correct shapes
   Co-authored-by: Yi-Hsiang Fang (Vivid) <146902905+vividf@users.noreply.github.com>
-* fix(traffic_light_visualization): fix funcArgNamesDifferent (`#8156 <https://github.com/youtalk/autoware.universe/issues/8156>`_)
+* fix(traffic_light_visualization): fix funcArgNamesDifferent (`#8156 <https://github.com/autowarefoundation/autoware.universe/issues/8156>`_)
   fix:funcArgNamesDifferent
-* fix(traffic_light_visualizer): remove cerr temporarily to avoid flooding logs (`#8294 <https://github.com/youtalk/autoware.universe/issues/8294>`_)
+* fix(traffic_light_visualizer): remove cerr temporarily to avoid flooding logs (`#8294 <https://github.com/autowarefoundation/autoware.universe/issues/8294>`_)
   * fix(traffic_light_visualizer): remove cerr temporarily to avoid flooding logs
   * fix precommit
   * fix
   ---------
-* fix(autoware_traffic_light_visualization): fix passedByValue (`#8241 <https://github.com/youtalk/autoware.universe/issues/8241>`_)
+* fix(autoware_traffic_light_visualization): fix passedByValue (`#8241 <https://github.com/autowarefoundation/autoware.universe/issues/8241>`_)
   fix:passedByValue
-* feat(traffic_light_roi_visualizer): add an option to use normal publisher instead of image tranport in traffic light roi visualizer (`#8157 <https://github.com/youtalk/autoware.universe/issues/8157>`_)
+* feat(traffic_light_roi_visualizer): add an option to use normal publisher instead of image tranport in traffic light roi visualizer (`#8157 <https://github.com/autowarefoundation/autoware.universe/issues/8157>`_)
   * apply new parameter schemes, set default parameters
   add an option to use normal publisher instead of image tranport in traffic light roi visualizer
   * small fix on default value
   ---------
-* refactor(traffic_light\_*)!: add package name prefix of autoware\_ (`#8159 <https://github.com/youtalk/autoware.universe/issues/8159>`_)
+* refactor(traffic_light\_*)!: add package name prefix of autoware\_ (`#8159 <https://github.com/autowarefoundation/autoware.universe/issues/8159>`_)
   * chore: rename traffic_light_fine_detector to autoware_traffic_light_fine_detector
   * chore: rename traffic_light_multi_camera_fusion to autoware_traffic_light_multi_camera_fusion
   * chore: rename traffic_light_occlusion_predictor to autoware_traffic_light_occlusion_predictor

--- a/perception/perception_utils/CHANGELOG.rst
+++ b/perception/perception_utils/CHANGELOG.rst
@@ -5,8 +5,8 @@ Changelog for package perception_utils
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* chore(perception_utils): add unit test (`#8414 <https://github.com/youtalk/autoware.universe/issues/8414>`_)
-* feat(perception_utils)!: move perception_utils from common to perception folder (`#8748 <https://github.com/youtalk/autoware.universe/issues/8748>`_)
+* chore(perception_utils): add unit test (`#8414 <https://github.com/autowarefoundation/autoware.universe/issues/8414>`_)
+* feat(perception_utils)!: move perception_utils from common to perception folder (`#8748 <https://github.com/autowarefoundation/autoware.universe/issues/8748>`_)
   feat: move perception utils which is only used in perception
   Co-authored-by: yoshiri <yoshiyoshidetteiu@gmail.com>
 * Contributors: Shintaro Tomie, Yutaka Kondo, badai nguyen

--- a/planning/autoware_costmap_generator/CHANGELOG.rst
+++ b/planning/autoware_costmap_generator/CHANGELOG.rst
@@ -5,32 +5,32 @@ Changelog for package autoware_costmap_generator
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* fix(costmap_generator): fix include for grid_map_utils (`#9179 <https://github.com/youtalk/autoware.universe/issues/9179>`_)
-* perf(costmap_generator): manual blurring and fill polygons without OpenCV (`#9160 <https://github.com/youtalk/autoware.universe/issues/9160>`_)
-* feat(costmap_generator, control_validator, scenario_selector, surround_obstacle_checker, vehicle_cmd_gate): add processing time pub. (`#9065 <https://github.com/youtalk/autoware.universe/issues/9065>`_)
+* fix(costmap_generator): fix include for grid_map_utils (`#9179 <https://github.com/autowarefoundation/autoware.universe/issues/9179>`_)
+* perf(costmap_generator): manual blurring and fill polygons without OpenCV (`#9160 <https://github.com/autowarefoundation/autoware.universe/issues/9160>`_)
+* feat(costmap_generator, control_validator, scenario_selector, surround_obstacle_checker, vehicle_cmd_gate): add processing time pub. (`#9065 <https://github.com/autowarefoundation/autoware.universe/issues/9065>`_)
   * feat(costmap_generator, control_validator, scenario_selector, surround_obstacle_checker, vehicle_cmd_gate): Add: processing_time_pub
   * fix: pre-commit
   * feat(costmap_generator): fix: No output when not Active.
   * fix: clang-format
   * Re: fix: clang-format
   ---------
-* perf(costmap_generator): prevent long transform lookup and add timekeeper (`#8886 <https://github.com/youtalk/autoware.universe/issues/8886>`_)
-* feat(costmap_generator): integrate generate_parameter_library (`#8827 <https://github.com/youtalk/autoware.universe/issues/8827>`_)
+* perf(costmap_generator): prevent long transform lookup and add timekeeper (`#8886 <https://github.com/autowarefoundation/autoware.universe/issues/8886>`_)
+* feat(costmap_generator): integrate generate_parameter_library (`#8827 <https://github.com/autowarefoundation/autoware.universe/issues/8827>`_)
   * add parameter description
   * use parameter listener
   * append global identifier
   * suppress deprecated error
   * fix parameter type
   ---------
-* fix(other_planning_packages): align the parameters with launcher (`#8793 <https://github.com/youtalk/autoware.universe/issues/8793>`_)
+* fix(other_planning_packages): align the parameters with launcher (`#8793 <https://github.com/autowarefoundation/autoware.universe/issues/8793>`_)
   * parameters in planning/others aligned
   * update json
   ---------
-* fix(autoware_costmap_generator): fix unusedFunction (`#8641 <https://github.com/youtalk/autoware.universe/issues/8641>`_)
+* fix(autoware_costmap_generator): fix unusedFunction (`#8641 <https://github.com/autowarefoundation/autoware.universe/issues/8641>`_)
   fix:unusedFunction
-* perf(costmap_generator, scenario_selector): faster getLinkedParkingLot (`#7930 <https://github.com/youtalk/autoware.universe/issues/7930>`_)
-* feat: add `autoware\_` prefix to `lanelet2_extension` (`#7640 <https://github.com/youtalk/autoware.universe/issues/7640>`_)
-* refactor(costmap_generator)!: add autoware prefix (`#7329 <https://github.com/youtalk/autoware.universe/issues/7329>`_)
+* perf(costmap_generator, scenario_selector): faster getLinkedParkingLot (`#7930 <https://github.com/autowarefoundation/autoware.universe/issues/7930>`_)
+* feat: add `autoware\_` prefix to `lanelet2_extension` (`#7640 <https://github.com/autowarefoundation/autoware.universe/issues/7640>`_)
+* refactor(costmap_generator)!: add autoware prefix (`#7329 <https://github.com/autowarefoundation/autoware.universe/issues/7329>`_)
   refactor(costmap_generator): add autoware prefix
 * Contributors: Kazunori-Nakajima, Kosuke Takeuchi, Maxime CLEMENT, Mitsuhiro Sakamoto, Yutaka Kondo, Zhe Shen, kobayu858
 

--- a/planning/autoware_external_velocity_limit_selector/CHANGELOG.rst
+++ b/planning/autoware_external_velocity_limit_selector/CHANGELOG.rst
@@ -5,12 +5,12 @@ Changelog for package autoware_external_velocity_limit_selector
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* feat(external_velocity_limit_selector): integrate generate_parameter_library (`#8770 <https://github.com/youtalk/autoware.universe/issues/8770>`_)
+* feat(external_velocity_limit_selector): integrate generate_parameter_library (`#8770 <https://github.com/autowarefoundation/autoware.universe/issues/8770>`_)
   * add parameter description
   * use parameter listener
   ---------
-* feat(external_velocity_limit_selector): rename to include/autoware/{package_name} (`#7516 <https://github.com/youtalk/autoware.universe/issues/7516>`_)
-* chore(autoware_external_velocity_limit_selector): add prefix `autoware\_` (`#7295 <https://github.com/youtalk/autoware.universe/issues/7295>`_)
+* feat(external_velocity_limit_selector): rename to include/autoware/{package_name} (`#7516 <https://github.com/autowarefoundation/autoware.universe/issues/7516>`_)
+* chore(autoware_external_velocity_limit_selector): add prefix `autoware\_` (`#7295 <https://github.com/autowarefoundation/autoware.universe/issues/7295>`_)
   chore(autoware_external_velocity_limit_selector): rename
 * Contributors: Mitsuhiro Sakamoto, Satoshi OTA, Takayuki Murooka, Yutaka Kondo
 

--- a/planning/autoware_freespace_planner/CHANGELOG.rst
+++ b/planning/autoware_freespace_planner/CHANGELOG.rst
@@ -5,7 +5,7 @@ Changelog for package autoware_freespace_planner
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* test(freespace_planner): make unit tests for member functions (`#9060 <https://github.com/youtalk/autoware.universe/issues/9060>`_)
+* test(freespace_planner): make unit tests for member functions (`#9060 <https://github.com/autowarefoundation/autoware.universe/issues/9060>`_)
   * refactor freespace planner
   * implement unit tests for freespace planner util functions
   * add freespace planner utils namespace
@@ -14,7 +14,7 @@ Changelog for package autoware_freespace_planner
   * implement unit tests for FreespacePlanner member functions
   * add docstring for functions
   ---------
-* test(freespace_planner): add unit tests for util functions (`#9059 <https://github.com/youtalk/autoware.universe/issues/9059>`_)
+* test(freespace_planner): add unit tests for util functions (`#9059 <https://github.com/autowarefoundation/autoware.universe/issues/9059>`_)
   * refactor freespace planner
   * add function is_near_target to freespace planner utils
   * add freespace planner utils namespace
@@ -22,19 +22,19 @@ Changelog for package autoware_freespace_planner
   * implement unit tests for freespace planner util functions
   * add freespace planner utils namespace
   ---------
-* refactor(freespace_planner): move functions to utils (`#9058 <https://github.com/youtalk/autoware.universe/issues/9058>`_)
+* refactor(freespace_planner): move functions to utils (`#9058 <https://github.com/autowarefoundation/autoware.universe/issues/9058>`_)
   * refactor freespace planner
   * add function is_near_target to freespace planner utils
   * add freespace planner utils namespace
   * fix function call
   ---------
-* fix(other_planning_packages): align the parameters with launcher (`#8793 <https://github.com/youtalk/autoware.universe/issues/8793>`_)
+* fix(other_planning_packages): align the parameters with launcher (`#8793 <https://github.com/autowarefoundation/autoware.universe/issues/8793>`_)
   * parameters in planning/others aligned
   * update json
   ---------
-* fix(freespace_planner): fix free space planner spamming message (`#8614 <https://github.com/youtalk/autoware.universe/issues/8614>`_)
+* fix(freespace_planner): fix free space planner spamming message (`#8614 <https://github.com/autowarefoundation/autoware.universe/issues/8614>`_)
   check data availability only when scenario is active
-* feat(freespace_planning_algorithms): implement support for multiple goal candidates in A star planner (`#8092 <https://github.com/youtalk/autoware.universe/issues/8092>`_)
+* feat(freespace_planning_algorithms): implement support for multiple goal candidates in A star planner (`#8092 <https://github.com/autowarefoundation/autoware.universe/issues/8092>`_)
   * refactor freespace planning algorithms
   * fix error
   * use vector instead of map for a-star node graph
@@ -112,7 +112,7 @@ Changelog for package autoware_freespace_planner
   * minor refactor
   ---------
   Co-authored-by: Maxime CLEMENT <78338830+maxime-clem@users.noreply.github.com>
-* feat(freespace_planning_algorithms): implement option for backward search from goal to start (`#8091 <https://github.com/youtalk/autoware.universe/issues/8091>`_)
+* feat(freespace_planning_algorithms): implement option for backward search from goal to start (`#8091 <https://github.com/autowarefoundation/autoware.universe/issues/8091>`_)
   * refactor freespace planning algorithms
   * fix error
   * use vector instead of map for a-star node graph
@@ -178,7 +178,7 @@ Changelog for package autoware_freespace_planner
   * minor refactor
   ---------
   Co-authored-by: Maxime CLEMENT <78338830+maxime-clem@users.noreply.github.com>
-* feat(scenario_selector, freespace_planner): improve freespace planner edge case behavior (`#8348 <https://github.com/youtalk/autoware.universe/issues/8348>`_)
+* feat(scenario_selector, freespace_planner): improve freespace planner edge case behavior (`#8348 <https://github.com/autowarefoundation/autoware.universe/issues/8348>`_)
   * refactor free space planner subscribers
   * implement scenario switching for edge cases
   * fix scenario selector test
@@ -189,8 +189,8 @@ Changelog for package autoware_freespace_planner
   * improve near target logic
   * use timer based implementation for obstacle check
   ---------
-* refactor(autoware_freespace_planner): rework parameters (`#8296 <https://github.com/youtalk/autoware.universe/issues/8296>`_)
-* feat(freespace_planning_algorithms): use distance to nearest obstacle to improve path planning (`#8089 <https://github.com/youtalk/autoware.universe/issues/8089>`_)
+* refactor(autoware_freespace_planner): rework parameters (`#8296 <https://github.com/autowarefoundation/autoware.universe/issues/8296>`_)
+* feat(freespace_planning_algorithms): use distance to nearest obstacle to improve path planning (`#8089 <https://github.com/autowarefoundation/autoware.universe/issues/8089>`_)
   * refactor freespace planning algorithms
   * fix error
   * use vector instead of map for a-star node graph
@@ -244,8 +244,8 @@ Changelog for package autoware_freespace_planner
   * suppress spell check
   ---------
   Co-authored-by: Maxime CLEMENT <78338830+maxime-clem@users.noreply.github.com>
-* fix(freespace_planner): disable randomly failing tests (`#8337 <https://github.com/youtalk/autoware.universe/issues/8337>`_)
-* refactor(freespace_planning_algorithm): refactor and improve astar search (`#8068 <https://github.com/youtalk/autoware.universe/issues/8068>`_)
+* fix(freespace_planner): disable randomly failing tests (`#8337 <https://github.com/autowarefoundation/autoware.universe/issues/8337>`_)
+* refactor(freespace_planning_algorithm): refactor and improve astar search (`#8068 <https://github.com/autowarefoundation/autoware.universe/issues/8068>`_)
   * refactor freespace planning algorithms
   * fix error
   * use vector instead of map for a-star node graph
@@ -278,14 +278,14 @@ Changelog for package autoware_freespace_planner
   * check goal pose validity before setting collision free distance map
   * declare variables as const where necessary
   ---------
-* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/youtalk/autoware.universe/issues/7594>`_)
-* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/youtalk/autoware.universe/issues/7539>`_)
+* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/autowarefoundation/autoware.universe/issues/7594>`_)
+* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/autowarefoundation/autoware.universe/issues/7539>`_)
   refactor(motion_utils): add autoware prefix and include dir
-* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/youtalk/autoware.universe/issues/7538>`_)
+* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/autowarefoundation/autoware.universe/issues/7538>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* refactor(route_handler)!: rename to include/autoware/{package_name}  (`#7530 <https://github.com/youtalk/autoware.universe/issues/7530>`_)
+* refactor(route_handler)!: rename to include/autoware/{package_name}  (`#7530 <https://github.com/autowarefoundation/autoware.universe/issues/7530>`_)
   refactor(route_handler)!: rename to include/autoware/{package_name}
-* refactor(freespace_planner)!: rename to include/autoware/{package_name}  (`#7525 <https://github.com/youtalk/autoware.universe/issues/7525>`_)
+* refactor(freespace_planner)!: rename to include/autoware/{package_name}  (`#7525 <https://github.com/autowarefoundation/autoware.universe/issues/7525>`_)
   refactor(freespace_planner)!: rename to include/autoware/{package_name}
   refactor(start_planner): make autoware include dir
   refactor(goal_planner): make autoware include dir
@@ -302,7 +302,7 @@ Changelog for package autoware_freespace_planner
   fix build
   autoware_freespace_planner
   freespace_planning_algorithms
-* refactor(test_utils): move to common folder (`#7158 <https://github.com/youtalk/autoware.universe/issues/7158>`_)
+* refactor(test_utils): move to common folder (`#7158 <https://github.com/autowarefoundation/autoware.universe/issues/7158>`_)
   * Move autoware planning test manager to autoware namespace
   * fix package share directory for behavior path planner
   * renaming files and directory
@@ -314,7 +314,7 @@ Changelog for package autoware_freespace_planner
   * removed obstacle velocity limiter test artifact
   * remove namespace from planning validator, it has using keyword
   ---------
-* refactor(route_handler): route handler add autoware prefix (`#7341 <https://github.com/youtalk/autoware.universe/issues/7341>`_)
+* refactor(route_handler): route handler add autoware prefix (`#7341 <https://github.com/autowarefoundation/autoware.universe/issues/7341>`_)
   * rename route handler package
   * update packages dependencies
   * update include guards
@@ -323,7 +323,7 @@ Changelog for package autoware_freespace_planner
   * fix formats
   * keep header and source file name as before
   ---------
-* refactor(freespace_planner)!: add autoware prefix (`#7376 <https://github.com/youtalk/autoware.universe/issues/7376>`_)
+* refactor(freespace_planner)!: add autoware prefix (`#7376 <https://github.com/autowarefoundation/autoware.universe/issues/7376>`_)
   refactor(freespace_planner)!: add autoawre prefix
 * Contributors: Batuhan Beytekin, Kosuke Takeuchi, Maxime CLEMENT, Takayuki Murooka, Yutaka Kondo, Zhe Shen, Zulfaqar Azmi, mkquda
 

--- a/planning/autoware_freespace_planning_algorithms/CHANGELOG.rst
+++ b/planning/autoware_freespace_planning_algorithms/CHANGELOG.rst
@@ -5,7 +5,7 @@ Changelog for package autoware_freespace_planning_algorithms
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* feat(freespace_planning_algorithms): implement support for multiple goal candidates in A star planner (`#8092 <https://github.com/youtalk/autoware.universe/issues/8092>`_)
+* feat(freespace_planning_algorithms): implement support for multiple goal candidates in A star planner (`#8092 <https://github.com/autowarefoundation/autoware.universe/issues/8092>`_)
   * refactor freespace planning algorithms
   * fix error
   * use vector instead of map for a-star node graph
@@ -83,7 +83,7 @@ Changelog for package autoware_freespace_planning_algorithms
   * minor refactor
   ---------
   Co-authored-by: Maxime CLEMENT <78338830+maxime-clem@users.noreply.github.com>
-* feat(freespace_planning_algorithms): implement option for backward search from goal to start (`#8091 <https://github.com/youtalk/autoware.universe/issues/8091>`_)
+* feat(freespace_planning_algorithms): implement option for backward search from goal to start (`#8091 <https://github.com/autowarefoundation/autoware.universe/issues/8091>`_)
   * refactor freespace planning algorithms
   * fix error
   * use vector instead of map for a-star node graph
@@ -149,11 +149,11 @@ Changelog for package autoware_freespace_planning_algorithms
   * minor refactor
   ---------
   Co-authored-by: Maxime CLEMENT <78338830+maxime-clem@users.noreply.github.com>
-* fix(autoware_freespace_planning_algorithms): fix variableScope (`#8431 <https://github.com/youtalk/autoware.universe/issues/8431>`_)
+* fix(autoware_freespace_planning_algorithms): fix variableScope (`#8431 <https://github.com/autowarefoundation/autoware.universe/issues/8431>`_)
   fix: variableScope
   Co-authored-by: kobayu858 <129580202+kobayu858@users.noreply.github.com>
-* chore(autoware_freespace_planning_algorithms): add missing dependency (`#8494 <https://github.com/youtalk/autoware.universe/issues/8494>`_)
-* feat(freespace_planning_algorithms): use distance to nearest obstacle to improve path planning (`#8089 <https://github.com/youtalk/autoware.universe/issues/8089>`_)
+* chore(autoware_freespace_planning_algorithms): add missing dependency (`#8494 <https://github.com/autowarefoundation/autoware.universe/issues/8494>`_)
+* feat(freespace_planning_algorithms): use distance to nearest obstacle to improve path planning (`#8089 <https://github.com/autowarefoundation/autoware.universe/issues/8089>`_)
   * refactor freespace planning algorithms
   * fix error
   * use vector instead of map for a-star node graph
@@ -207,13 +207,13 @@ Changelog for package autoware_freespace_planning_algorithms
   * suppress spell check
   ---------
   Co-authored-by: Maxime CLEMENT <78338830+maxime-clem@users.noreply.github.com>
-* fix(autoware_freespace_planning_algorithms): fix unreadVariable (`#8360 <https://github.com/youtalk/autoware.universe/issues/8360>`_)
+* fix(autoware_freespace_planning_algorithms): fix unreadVariable (`#8360 <https://github.com/autowarefoundation/autoware.universe/issues/8360>`_)
   * fix:unreadVariable
   * fix:clang format
   ---------
-* fix(autoware_freespace_planning_algorithms): fix functionConst (`#8281 <https://github.com/youtalk/autoware.universe/issues/8281>`_)
+* fix(autoware_freespace_planning_algorithms): fix functionConst (`#8281 <https://github.com/autowarefoundation/autoware.universe/issues/8281>`_)
   fix:functionConst
-* refactor(freespace_planning_algorithm): refactor and improve astar search (`#8068 <https://github.com/youtalk/autoware.universe/issues/8068>`_)
+* refactor(freespace_planning_algorithm): refactor and improve astar search (`#8068 <https://github.com/autowarefoundation/autoware.universe/issues/8068>`_)
   * refactor freespace planning algorithms
   * fix error
   * use vector instead of map for a-star node graph
@@ -246,28 +246,28 @@ Changelog for package autoware_freespace_planning_algorithms
   * check goal pose validity before setting collision free distance map
   * declare variables as const where necessary
   ---------
-* fix(autoware_freespace_planning_algorithms): fix shadowVariable (`#7949 <https://github.com/youtalk/autoware.universe/issues/7949>`_)
+* fix(autoware_freespace_planning_algorithms): fix shadowVariable (`#7949 <https://github.com/autowarefoundation/autoware.universe/issues/7949>`_)
   * fix:shadowVariable
   * fix:shadowVariable
   * fix:shadowVariable
   ---------
-* chore(freespace_planning_algorithm): modify A* script for standalone running (`#7070 <https://github.com/youtalk/autoware.universe/issues/7070>`_)
+* chore(freespace_planning_algorithm): modify A* script for standalone running (`#7070 <https://github.com/autowarefoundation/autoware.universe/issues/7070>`_)
   * modify astar for standalone running
   move clearNoe() from setMap to makePlan().
   * small modification
   * run pre-commit
   ---------
   Co-authored-by: Takumi Ito <takumi.ito@tier4.jp>
-* feat(freespace_planning_algorithms): add is_back flag into the return of A* python wrapper (`#7831 <https://github.com/youtalk/autoware.universe/issues/7831>`_)
+* feat(freespace_planning_algorithms): add is_back flag into the return of A* python wrapper (`#7831 <https://github.com/autowarefoundation/autoware.universe/issues/7831>`_)
   add is_back flag to the return of getWaypoints
   Co-authored-by: Takumi Ito <takumi.ito@tier4.jp>
-* fix(autoware_freespace_planning_algorithms): fix syntaxError (`#7812 <https://github.com/youtalk/autoware.universe/issues/7812>`_)
-* fix(autoware_freespace_planning_algorithms): fix constStatement warning (`#7580 <https://github.com/youtalk/autoware.universe/issues/7580>`_)
-* fix(autoware_freespace_planning_algorithms): fix unusedScopedObject bug (`#7562 <https://github.com/youtalk/autoware.universe/issues/7562>`_)
-* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/youtalk/autoware.universe/issues/7594>`_)
-* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/youtalk/autoware.universe/issues/7538>`_)
+* fix(autoware_freespace_planning_algorithms): fix syntaxError (`#7812 <https://github.com/autowarefoundation/autoware.universe/issues/7812>`_)
+* fix(autoware_freespace_planning_algorithms): fix constStatement warning (`#7580 <https://github.com/autowarefoundation/autoware.universe/issues/7580>`_)
+* fix(autoware_freespace_planning_algorithms): fix unusedScopedObject bug (`#7562 <https://github.com/autowarefoundation/autoware.universe/issues/7562>`_)
+* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/autowarefoundation/autoware.universe/issues/7594>`_)
+* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/autowarefoundation/autoware.universe/issues/7538>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* refactor(freespace_planner)!: rename to include/autoware/{package_name}  (`#7525 <https://github.com/youtalk/autoware.universe/issues/7525>`_)
+* refactor(freespace_planner)!: rename to include/autoware/{package_name}  (`#7525 <https://github.com/autowarefoundation/autoware.universe/issues/7525>`_)
   refactor(freespace_planner)!: rename to include/autoware/{package_name}
   refactor(start_planner): make autoware include dir
   refactor(goal_planner): make autoware include dir
@@ -284,7 +284,7 @@ Changelog for package autoware_freespace_planning_algorithms
   fix build
   autoware_freespace_planner
   freespace_planning_algorithms
-* refactor(vehicle_info_utils)!: prefix package and namespace with autoware (`#7353 <https://github.com/youtalk/autoware.universe/issues/7353>`_)
+* refactor(vehicle_info_utils)!: prefix package and namespace with autoware (`#7353 <https://github.com/autowarefoundation/autoware.universe/issues/7353>`_)
   * chore(autoware_vehicle_info_utils): rename header
   * chore(bpp-common): vehicle info
   * chore(path_optimizer): vehicle info
@@ -319,7 +319,7 @@ Changelog for package autoware_freespace_planning_algorithms
   * chore(sensing): vehicle info
   * fix(autoware_joy_controller): remove unused deps
   ---------
-* refactor(freespace_planning_algorithms)!: add autoware prefix (`#7375 <https://github.com/youtalk/autoware.universe/issues/7375>`_)
+* refactor(freespace_planning_algorithms)!: add autoware prefix (`#7375 <https://github.com/autowarefoundation/autoware.universe/issues/7375>`_)
 * Contributors: Kosuke Takeuchi, M. Fatih Cırıt, Nagi70, Ryuta Kambe, Satoshi OTA, Takayuki Murooka, TakumIto, Yutaka Kondo, kobayu858, mkquda
 
 0.26.0 (2024-04-03)

--- a/planning/autoware_mission_planner/CHANGELOG.rst
+++ b/planning/autoware_mission_planner/CHANGELOG.rst
@@ -5,47 +5,47 @@ Changelog for package autoware_mission_planner
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* feat(mission_planner): reroute with current route start pose when triggered by modifed goal (`#9136 <https://github.com/youtalk/autoware.universe/issues/9136>`_)
+* feat(mission_planner): reroute with current route start pose when triggered by modifed goal (`#9136 <https://github.com/autowarefoundation/autoware.universe/issues/9136>`_)
   * feat(mission_planner): reroute with current route start pose when triggered by modifed goal
   * check new ego goal is in original preffered lane as much as possible
   * check goal is in goal_lane
   ---------
-* fix(mission_planner): return without change_route if new route is empty  (`#9101 <https://github.com/youtalk/autoware.universe/issues/9101>`_)
+* fix(mission_planner): return without change_route if new route is empty  (`#9101 <https://github.com/autowarefoundation/autoware.universe/issues/9101>`_)
   fix(mission_planner): return if new route is empty without change_route
-* chore(mission_planner): fix typo (`#9053 <https://github.com/youtalk/autoware.universe/issues/9053>`_)
-* test(mission_planner): add test of default_planner (`#9050 <https://github.com/youtalk/autoware.universe/issues/9050>`_)
-* test(mission_planner): add unit tests of utility functions (`#9011 <https://github.com/youtalk/autoware.universe/issues/9011>`_)
-* refactor(mission_planner): move anonymous functions to utils and add namespace (`#9012 <https://github.com/youtalk/autoware.universe/issues/9012>`_)
+* chore(mission_planner): fix typo (`#9053 <https://github.com/autowarefoundation/autoware.universe/issues/9053>`_)
+* test(mission_planner): add test of default_planner (`#9050 <https://github.com/autowarefoundation/autoware.universe/issues/9050>`_)
+* test(mission_planner): add unit tests of utility functions (`#9011 <https://github.com/autowarefoundation/autoware.universe/issues/9011>`_)
+* refactor(mission_planner): move anonymous functions to utils and add namespace (`#9012 <https://github.com/autowarefoundation/autoware.universe/issues/9012>`_)
   feat(mission_planner): move functions to utils and add namespace
-* feat(mission_planner): add option to prevent rerouting in autonomous driving mode (`#8757 <https://github.com/youtalk/autoware.universe/issues/8757>`_)
-* feat(mission_planner): make the "goal inside lanes" function more robuts and add tests (`#8760 <https://github.com/youtalk/autoware.universe/issues/8760>`_)
-* fix(mission_planner): improve condition to check if the goal is within the lane (`#8710 <https://github.com/youtalk/autoware.universe/issues/8710>`_)
-* fix(autoware_mission_planner): fix unusedFunction (`#8642 <https://github.com/youtalk/autoware.universe/issues/8642>`_)
+* feat(mission_planner): add option to prevent rerouting in autonomous driving mode (`#8757 <https://github.com/autowarefoundation/autoware.universe/issues/8757>`_)
+* feat(mission_planner): make the "goal inside lanes" function more robuts and add tests (`#8760 <https://github.com/autowarefoundation/autoware.universe/issues/8760>`_)
+* fix(mission_planner): improve condition to check if the goal is within the lane (`#8710 <https://github.com/autowarefoundation/autoware.universe/issues/8710>`_)
+* fix(autoware_mission_planner): fix unusedFunction (`#8642 <https://github.com/autowarefoundation/autoware.universe/issues/8642>`_)
   fix:unusedFunction
-* fix(autoware_mission_planner): fix noConstructor (`#8505 <https://github.com/youtalk/autoware.universe/issues/8505>`_)
+* fix(autoware_mission_planner): fix noConstructor (`#8505 <https://github.com/autowarefoundation/autoware.universe/issues/8505>`_)
   fix:noConstructor
-* fix(autoware_mission_planner): fix funcArgNamesDifferent (`#8017 <https://github.com/youtalk/autoware.universe/issues/8017>`_)
+* fix(autoware_mission_planner): fix funcArgNamesDifferent (`#8017 <https://github.com/autowarefoundation/autoware.universe/issues/8017>`_)
   fix:funcArgNamesDifferent
-* feat(mission_planner): reroute in manual driving (`#7842 <https://github.com/youtalk/autoware.universe/issues/7842>`_)
+* feat(mission_planner): reroute in manual driving (`#7842 <https://github.com/autowarefoundation/autoware.universe/issues/7842>`_)
   * feat(mission_planner): reroute in manual driving
   * docs(mission_planner): update document
   * feat(mission_planner): fix operation mode state receiving check
   ---------
-* feat: add `autoware\_` prefix to `lanelet2_extension` (`#7640 <https://github.com/youtalk/autoware.universe/issues/7640>`_)
-* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/youtalk/autoware.universe/issues/7594>`_)
-* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/youtalk/autoware.universe/issues/7539>`_)
+* feat: add `autoware\_` prefix to `lanelet2_extension` (`#7640 <https://github.com/autowarefoundation/autoware.universe/issues/7640>`_)
+* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/autowarefoundation/autoware.universe/issues/7594>`_)
+* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/autowarefoundation/autoware.universe/issues/7539>`_)
   refactor(motion_utils): add autoware prefix and include dir
-* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/youtalk/autoware.universe/issues/7538>`_)
+* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/autowarefoundation/autoware.universe/issues/7538>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* refactor(route_handler)!: rename to include/autoware/{package_name}  (`#7530 <https://github.com/youtalk/autoware.universe/issues/7530>`_)
+* refactor(route_handler)!: rename to include/autoware/{package_name}  (`#7530 <https://github.com/autowarefoundation/autoware.universe/issues/7530>`_)
   refactor(route_handler)!: rename to include/autoware/{package_name}
-* feat(mission_planner): rename to include/autoware/{package_name} (`#7513 <https://github.com/youtalk/autoware.universe/issues/7513>`_)
+* feat(mission_planner): rename to include/autoware/{package_name} (`#7513 <https://github.com/autowarefoundation/autoware.universe/issues/7513>`_)
   * feat(mission_planner): rename to include/autoware/{package_name}
   * feat(mission_planner): rename to include/autoware/{package_name}
   * feat(mission_planner): rename to include/autoware/{package_name}
   ---------
-* feat(mission_planner): use polling subscriber (`#7447 <https://github.com/youtalk/autoware.universe/issues/7447>`_)
-* fix(route_handler): route handler overlap removal is too conservative (`#7156 <https://github.com/youtalk/autoware.universe/issues/7156>`_)
+* feat(mission_planner): use polling subscriber (`#7447 <https://github.com/autowarefoundation/autoware.universe/issues/7447>`_)
+* fix(route_handler): route handler overlap removal is too conservative (`#7156 <https://github.com/autowarefoundation/autoware.universe/issues/7156>`_)
   * add flag to enable/disable loop check in getLaneletSequence functions
   * implement function to get closest route lanelet based on previous closest lanelet
   * refactor DefaultPlanner::plan function
@@ -62,7 +62,7 @@ Changelog for package autoware_mission_planner
   * format fix
   * move test map to autoware_test_utils
   ---------
-* refactor(route_handler): route handler add autoware prefix (`#7341 <https://github.com/youtalk/autoware.universe/issues/7341>`_)
+* refactor(route_handler): route handler add autoware prefix (`#7341 <https://github.com/autowarefoundation/autoware.universe/issues/7341>`_)
   * rename route handler package
   * update packages dependencies
   * update include guards
@@ -71,7 +71,7 @@ Changelog for package autoware_mission_planner
   * fix formats
   * keep header and source file name as before
   ---------
-* refactor(mission_planner)!: add autoware prefix and namespace (`#7414 <https://github.com/youtalk/autoware.universe/issues/7414>`_)
+* refactor(mission_planner)!: add autoware prefix and namespace (`#7414 <https://github.com/autowarefoundation/autoware.universe/issues/7414>`_)
   * refactor(mission_planner)!: add autoware prefix and namespace
   * fix svg
   ---------

--- a/planning/autoware_objects_of_interest_marker_interface/CHANGELOG.rst
+++ b/planning/autoware_objects_of_interest_marker_interface/CHANGELOG.rst
@@ -5,11 +5,11 @@ Changelog for package autoware_objects_of_interest_marker_interface
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/youtalk/autoware.universe/issues/7594>`_)
-* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/youtalk/autoware.universe/issues/7538>`_)
+* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/autowarefoundation/autoware.universe/issues/7594>`_)
+* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/autowarefoundation/autoware.universe/issues/7538>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* refactor(objects_of_interest_marker_interface): rename to include/autoware/{package_name} (`#7535 <https://github.com/youtalk/autoware.universe/issues/7535>`_)
-* refactor(objects_of_interest_marker_interface)!: prefix package and namespace with autoware (`#7413 <https://github.com/youtalk/autoware.universe/issues/7413>`_)
+* refactor(objects_of_interest_marker_interface): rename to include/autoware/{package_name} (`#7535 <https://github.com/autowarefoundation/autoware.universe/issues/7535>`_)
+* refactor(objects_of_interest_marker_interface)!: prefix package and namespace with autoware (`#7413 <https://github.com/autowarefoundation/autoware.universe/issues/7413>`_)
 * Contributors: Fumiya Watanabe, Kosuke Takeuchi, Takayuki Murooka, Yutaka Kondo
 
 0.26.0 (2024-04-03)

--- a/planning/autoware_obstacle_cruise_planner/CHANGELOG.rst
+++ b/planning/autoware_obstacle_cruise_planner/CHANGELOG.rst
@@ -5,10 +5,10 @@ Changelog for package autoware_obstacle_cruise_planner
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* refactor(object_recognition_utils): add autoware prefix to object_recognition_utils (`#8946 <https://github.com/youtalk/autoware.universe/issues/8946>`_)
-* refactor(osqp_interface): added autoware prefix to osqp_interface (`#8958 <https://github.com/youtalk/autoware.universe/issues/8958>`_)
-* chore(obstacle_cruise_planner): add maintainer (`#9077 <https://github.com/youtalk/autoware.universe/issues/9077>`_)
-* feat(obstacle_cruise_planner): improve stop and cruise behavior for cut-in & out (`#8072 <https://github.com/youtalk/autoware.universe/issues/8072>`_)
+* refactor(object_recognition_utils): add autoware prefix to object_recognition_utils (`#8946 <https://github.com/autowarefoundation/autoware.universe/issues/8946>`_)
+* refactor(osqp_interface): added autoware prefix to osqp_interface (`#8958 <https://github.com/autowarefoundation/autoware.universe/issues/8958>`_)
+* chore(obstacle_cruise_planner): add maintainer (`#9077 <https://github.com/autowarefoundation/autoware.universe/issues/9077>`_)
+* feat(obstacle_cruise_planner): improve stop and cruise behavior for cut-in & out (`#8072 <https://github.com/autowarefoundation/autoware.universe/issues/8072>`_)
   * feat(obstacle_cruise_planner): improve stop and cruise behavior for cut-in & out
   * cleanup, add stop safety margin for transient objects
   style(pre-commit): autofix
@@ -20,28 +20,28 @@ Changelog for package autoware_obstacle_cruise_planner
   * feat: add predefined deceleration rate for VRUs
   * feat: update
   ---------
-* refactor(autoware_interpolation): prefix package and namespace with autoware (`#8088 <https://github.com/youtalk/autoware.universe/issues/8088>`_)
+* refactor(autoware_interpolation): prefix package and namespace with autoware (`#8088 <https://github.com/autowarefoundation/autoware.universe/issues/8088>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* refactor(signal_processing): prefix package and namespace with autoware (`#8541 <https://github.com/youtalk/autoware.universe/issues/8541>`_)
-* fix(motion_planning): align the parameters with launcher (`#8792 <https://github.com/youtalk/autoware.universe/issues/8792>`_)
+* refactor(signal_processing): prefix package and namespace with autoware (`#8541 <https://github.com/autowarefoundation/autoware.universe/issues/8541>`_)
+* fix(motion_planning): align the parameters with launcher (`#8792 <https://github.com/autowarefoundation/autoware.universe/issues/8792>`_)
   parameters in motion_planning aligned
-* fix(velocity_smoother, obstacle_cruise_planner ): float type of processing time was wrong (`#8161 <https://github.com/youtalk/autoware.universe/issues/8161>`_)
+* fix(velocity_smoother, obstacle_cruise_planner ): float type of processing time was wrong (`#8161 <https://github.com/autowarefoundation/autoware.universe/issues/8161>`_)
   fix(velocity_smoother): float type of processing time was wrong
-* feat(cruise_planner,planning_evaluator): add cruise and slow down diags (`#7960 <https://github.com/youtalk/autoware.universe/issues/7960>`_)
+* feat(cruise_planner,planning_evaluator): add cruise and slow down diags (`#7960 <https://github.com/autowarefoundation/autoware.universe/issues/7960>`_)
   * add cruise and slow down diags to cruise planner
   * add cruise types
   * adjust planning eval
   ---------
-* feat(obstacle_cruise_planner): prevent chattering when using point cloud (`#7861 <https://github.com/youtalk/autoware.universe/issues/7861>`_)
+* feat(obstacle_cruise_planner): prevent chattering when using point cloud (`#7861 <https://github.com/autowarefoundation/autoware.universe/issues/7861>`_)
   * prevent chattering of stop planning
   * Update planning/autoware_obstacle_cruise_planner/src/node.cpp
   Co-authored-by: Satoshi OTA <44889564+satoshi-ota@users.noreply.github.com>
   * fix stop position oscillation
   ---------
   Co-authored-by: Satoshi OTA <44889564+satoshi-ota@users.noreply.github.com>
-* feat(obstacle_cruise_planner): add diagnostics publishing to cruise planner (`#7836 <https://github.com/youtalk/autoware.universe/issues/7836>`_)
+* feat(obstacle_cruise_planner): add diagnostics publishing to cruise planner (`#7836 <https://github.com/autowarefoundation/autoware.universe/issues/7836>`_)
   add diagnostics publishing to cruise planner
-* feat(obstacle_cruise_planner): support pointcloud-based obstacles (`#6907 <https://github.com/youtalk/autoware.universe/issues/6907>`_)
+* feat(obstacle_cruise_planner): support pointcloud-based obstacles (`#6907 <https://github.com/autowarefoundation/autoware.universe/issues/6907>`_)
   * add pointcloud to obstacle properties
   * add tf listener & pointcloud subscriber
   * add parameters for pointcloud obstacle
@@ -113,35 +113,35 @@ Changelog for package autoware_obstacle_cruise_planner
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Takagi, Isamu <isamu.takagi@tier4.jp>
   Co-authored-by: Satoshi OTA <44889564+satoshi-ota@users.noreply.github.com>
-* feat: add `autoware\_` prefix to `lanelet2_extension` (`#7640 <https://github.com/youtalk/autoware.universe/issues/7640>`_)
-* fix(autoware_obstacle_cruise_planner): fix shadowVariable warning in generateSlowDownTrajectory (`#7659 <https://github.com/youtalk/autoware.universe/issues/7659>`_)
-* fix(autoware_obstacle_cruise_planner): fix shadowVariable warning (`#7656 <https://github.com/youtalk/autoware.universe/issues/7656>`_)
+* feat: add `autoware\_` prefix to `lanelet2_extension` (`#7640 <https://github.com/autowarefoundation/autoware.universe/issues/7640>`_)
+* fix(autoware_obstacle_cruise_planner): fix shadowVariable warning in generateSlowDownTrajectory (`#7659 <https://github.com/autowarefoundation/autoware.universe/issues/7659>`_)
+* fix(autoware_obstacle_cruise_planner): fix shadowVariable warning (`#7656 <https://github.com/autowarefoundation/autoware.universe/issues/7656>`_)
   * fix(autoware_obstacle_cruise_planner): fix shadowVariable warning
   * fix
   * style(pre-commit): autofix
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* fix(autoware_obstacle_cruise_planner): fix knownConditionTrueFalse warnings (`#7620 <https://github.com/youtalk/autoware.universe/issues/7620>`_)
+* fix(autoware_obstacle_cruise_planner): fix knownConditionTrueFalse warnings (`#7620 <https://github.com/autowarefoundation/autoware.universe/issues/7620>`_)
   * fix(autoware_obstacle_cruise_planner): fix knownConditionTrueFalse warnings
   * fix
   ---------
-* fix(autoware_obstacle_cruise_planner): fix unreadVariable warning (`#7627 <https://github.com/youtalk/autoware.universe/issues/7627>`_)
-* refactor(obstacle_cruise_planner): apply clang-tidy check (`#7553 <https://github.com/youtalk/autoware.universe/issues/7553>`_)
+* fix(autoware_obstacle_cruise_planner): fix unreadVariable warning (`#7627 <https://github.com/autowarefoundation/autoware.universe/issues/7627>`_)
+* refactor(obstacle_cruise_planner): apply clang-tidy check (`#7553 <https://github.com/autowarefoundation/autoware.universe/issues/7553>`_)
   obstacle_cruise
-* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/youtalk/autoware.universe/issues/7594>`_)
-* fix(autoware_obstacle_cruise_planner): fix assignBoolToFloat warning (`#7541 <https://github.com/youtalk/autoware.universe/issues/7541>`_)
+* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/autowarefoundation/autoware.universe/issues/7594>`_)
+* fix(autoware_obstacle_cruise_planner): fix assignBoolToFloat warning (`#7541 <https://github.com/autowarefoundation/autoware.universe/issues/7541>`_)
   * fix(autoware_obstacle_cruise_planner): fix assignBoolToFloat warning
   * delete unnecessary file
   * style(pre-commit): autofix
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* fix(autoware_obstacle_cruise_planner): fix unusedScopedObject bug (`#7569 <https://github.com/youtalk/autoware.universe/issues/7569>`_)
-* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/youtalk/autoware.universe/issues/7539>`_)
+* fix(autoware_obstacle_cruise_planner): fix unusedScopedObject bug (`#7569 <https://github.com/autowarefoundation/autoware.universe/issues/7569>`_)
+* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/autowarefoundation/autoware.universe/issues/7539>`_)
   refactor(motion_utils): add autoware prefix and include dir
-* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/youtalk/autoware.universe/issues/7538>`_)
+* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/autowarefoundation/autoware.universe/issues/7538>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* feat(obstacle_cruise_planner): rename to include/autoware/{package_name} (`#7510 <https://github.com/youtalk/autoware.universe/issues/7510>`_)
-* refactor(test_utils): move to common folder (`#7158 <https://github.com/youtalk/autoware.universe/issues/7158>`_)
+* feat(obstacle_cruise_planner): rename to include/autoware/{package_name} (`#7510 <https://github.com/autowarefoundation/autoware.universe/issues/7510>`_)
+* refactor(test_utils): move to common folder (`#7158 <https://github.com/autowarefoundation/autoware.universe/issues/7158>`_)
   * Move autoware planning test manager to autoware namespace
   * fix package share directory for behavior path planner
   * renaming files and directory
@@ -153,7 +153,7 @@ Changelog for package autoware_obstacle_cruise_planner
   * removed obstacle velocity limiter test artifact
   * remove namespace from planning validator, it has using keyword
   ---------
-* refactor(obstacle_cruise_planner)!: add autoware\_ prefix (`#7419 <https://github.com/youtalk/autoware.universe/issues/7419>`_)
+* refactor(obstacle_cruise_planner)!: add autoware\_ prefix (`#7419 <https://github.com/autowarefoundation/autoware.universe/issues/7419>`_)
 * Contributors: Berkay Karaman, Esteve Fernandez, Koichi98, Kosuke Takeuchi, Mamoru Sobue, Mitsuhiro Sakamoto, Ryuta Kambe, Takayuki Murooka, Yuki TAKAGI, Yutaka Kondo, Zhe Shen, Zulfaqar Azmi, danielsanchezaran
 
 0.26.0 (2024-04-03)

--- a/planning/autoware_obstacle_stop_planner/CHANGELOG.rst
+++ b/planning/autoware_obstacle_stop_planner/CHANGELOG.rst
@@ -5,35 +5,35 @@ Changelog for package autoware_obstacle_stop_planner
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* refactor(signal_processing): prefix package and namespace with autoware (`#8541 <https://github.com/youtalk/autoware.universe/issues/8541>`_)
-* chore(planning): consistent parameters with autoware_launch (`#8915 <https://github.com/youtalk/autoware.universe/issues/8915>`_)
+* refactor(signal_processing): prefix package and namespace with autoware (`#8541 <https://github.com/autowarefoundation/autoware.universe/issues/8541>`_)
+* chore(planning): consistent parameters with autoware_launch (`#8915 <https://github.com/autowarefoundation/autoware.universe/issues/8915>`_)
   * chore(planning): consistent parameters with autoware_launch
   * update
   * fix json schema
   ---------
-* fix(other_planning_packages): align the parameters with launcher (`#8793 <https://github.com/youtalk/autoware.universe/issues/8793>`_)
+* fix(other_planning_packages): align the parameters with launcher (`#8793 <https://github.com/autowarefoundation/autoware.universe/issues/8793>`_)
   * parameters in planning/others aligned
   * update json
   ---------
-* fix(autoware_obstacle_stop_planner): register obstacle stop planner node with autoware scoping (`#8512 <https://github.com/youtalk/autoware.universe/issues/8512>`_)
+* fix(autoware_obstacle_stop_planner): register obstacle stop planner node with autoware scoping (`#8512 <https://github.com/autowarefoundation/autoware.universe/issues/8512>`_)
   Register node plugin with autoware scoping
-* fix(autoware_obstacle_stop_planner): fix unusedFunction (`#8643 <https://github.com/youtalk/autoware.universe/issues/8643>`_)
+* fix(autoware_obstacle_stop_planner): fix unusedFunction (`#8643 <https://github.com/autowarefoundation/autoware.universe/issues/8643>`_)
   fix:unusedFunction
-* refactor(autoware_obstacle_stop_planner): rework parameters (`#7795 <https://github.com/youtalk/autoware.universe/issues/7795>`_)
-* fix(autoware_obstacle_stop_planner): fix cppcheck warning of functionStatic (`#8264 <https://github.com/youtalk/autoware.universe/issues/8264>`_)
+* refactor(autoware_obstacle_stop_planner): rework parameters (`#7795 <https://github.com/autowarefoundation/autoware.universe/issues/7795>`_)
+* fix(autoware_obstacle_stop_planner): fix cppcheck warning of functionStatic (`#8264 <https://github.com/autowarefoundation/autoware.universe/issues/8264>`_)
   * fix: deal with functionStatic warnings
   * style(pre-commit): autofix
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* fix(autoware_obstacle_stop_planner): fix functionConst (`#8282 <https://github.com/youtalk/autoware.universe/issues/8282>`_)
+* fix(autoware_obstacle_stop_planner): fix functionConst (`#8282 <https://github.com/autowarefoundation/autoware.universe/issues/8282>`_)
   fix:functionConst
-* fix(autoware_obstacle_stop_planner): fix passedByValue (`#8189 <https://github.com/youtalk/autoware.universe/issues/8189>`_)
+* fix(autoware_obstacle_stop_planner): fix passedByValue (`#8189 <https://github.com/autowarefoundation/autoware.universe/issues/8189>`_)
   fix:passedByValue
-* fix(autoware_obstacle_stop_planner): fix funcArgNamesDifferent (`#8018 <https://github.com/youtalk/autoware.universe/issues/8018>`_)
+* fix(autoware_obstacle_stop_planner): fix funcArgNamesDifferent (`#8018 <https://github.com/autowarefoundation/autoware.universe/issues/8018>`_)
   * fix:funcArgNamesDifferent
   * fix:funcArgNamesDifferent
   ---------
-* refactor(autoware_obstacle_stop_planner): prefix package and namespace with autoware (`#7565 <https://github.com/youtalk/autoware.universe/issues/7565>`_)
+* refactor(autoware_obstacle_stop_planner): prefix package and namespace with autoware (`#7565 <https://github.com/autowarefoundation/autoware.universe/issues/7565>`_)
   * refactor(autoware_obstacle_stop_planner): prefix package and namespace with autoware
   * style(pre-commit): autofix
   ---------

--- a/planning/autoware_path_optimizer/CHANGELOG.rst
+++ b/planning/autoware_path_optimizer/CHANGELOG.rst
@@ -5,30 +5,30 @@ Changelog for package autoware_path_optimizer
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* refactor(osqp_interface): added autoware prefix to osqp_interface (`#8958 <https://github.com/youtalk/autoware.universe/issues/8958>`_)
-* chore(path_optimizer): add warn msg for exceptional behavior (`#9033 <https://github.com/youtalk/autoware.universe/issues/9033>`_)
-* refactor(autoware_interpolation): prefix package and namespace with autoware (`#8088 <https://github.com/youtalk/autoware.universe/issues/8088>`_)
+* refactor(osqp_interface): added autoware prefix to osqp_interface (`#8958 <https://github.com/autowarefoundation/autoware.universe/issues/8958>`_)
+* chore(path_optimizer): add warn msg for exceptional behavior (`#9033 <https://github.com/autowarefoundation/autoware.universe/issues/9033>`_)
+* refactor(autoware_interpolation): prefix package and namespace with autoware (`#8088 <https://github.com/autowarefoundation/autoware.universe/issues/8088>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* fix(motion_planning): align the parameters with launcher (`#8792 <https://github.com/youtalk/autoware.universe/issues/8792>`_)
+* fix(motion_planning): align the parameters with launcher (`#8792 <https://github.com/autowarefoundation/autoware.universe/issues/8792>`_)
   parameters in motion_planning aligned
-* fix(autoware_path_optimizer): fix unusedFunction (`#8644 <https://github.com/youtalk/autoware.universe/issues/8644>`_)
+* fix(autoware_path_optimizer): fix unusedFunction (`#8644 <https://github.com/autowarefoundation/autoware.universe/issues/8644>`_)
   fix:unusedFunction
-* fix(autoware_path_optimizer): fix unreadVariable (`#8361 <https://github.com/youtalk/autoware.universe/issues/8361>`_)
+* fix(autoware_path_optimizer): fix unreadVariable (`#8361 <https://github.com/autowarefoundation/autoware.universe/issues/8361>`_)
   * fix:unreadVariable
   * fix:unreadVariable
   ---------
-* fix(autoware_path_optimizer): fix passedByValue (`#8190 <https://github.com/youtalk/autoware.universe/issues/8190>`_)
+* fix(autoware_path_optimizer): fix passedByValue (`#8190 <https://github.com/autowarefoundation/autoware.universe/issues/8190>`_)
   fix:passedByValue
-* fix(path_optimizer): revert the feature of publishing processing time (`#8160 <https://github.com/youtalk/autoware.universe/issues/8160>`_)
-* feat(autoware_universe_utils): add TimeKeeper to track function's processing time (`#7754 <https://github.com/youtalk/autoware.universe/issues/7754>`_)
-* fix(autoware_path_optimizer): fix redundantContinue warnings (`#7577 <https://github.com/youtalk/autoware.universe/issues/7577>`_)
-* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/youtalk/autoware.universe/issues/7594>`_)
-* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/youtalk/autoware.universe/issues/7539>`_)
+* fix(path_optimizer): revert the feature of publishing processing time (`#8160 <https://github.com/autowarefoundation/autoware.universe/issues/8160>`_)
+* feat(autoware_universe_utils): add TimeKeeper to track function's processing time (`#7754 <https://github.com/autowarefoundation/autoware.universe/issues/7754>`_)
+* fix(autoware_path_optimizer): fix redundantContinue warnings (`#7577 <https://github.com/autowarefoundation/autoware.universe/issues/7577>`_)
+* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/autowarefoundation/autoware.universe/issues/7594>`_)
+* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/autowarefoundation/autoware.universe/issues/7539>`_)
   refactor(motion_utils): add autoware prefix and include dir
-* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/youtalk/autoware.universe/issues/7538>`_)
+* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/autowarefoundation/autoware.universe/issues/7538>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* feat(path_optimizer): rename to include/autoware/{package_name} (`#7529 <https://github.com/youtalk/autoware.universe/issues/7529>`_)
-* refactor(test_utils): move to common folder (`#7158 <https://github.com/youtalk/autoware.universe/issues/7158>`_)
+* feat(path_optimizer): rename to include/autoware/{package_name} (`#7529 <https://github.com/autowarefoundation/autoware.universe/issues/7529>`_)
+* refactor(test_utils): move to common folder (`#7158 <https://github.com/autowarefoundation/autoware.universe/issues/7158>`_)
   * Move autoware planning test manager to autoware namespace
   * fix package share directory for behavior path planner
   * renaming files and directory
@@ -40,7 +40,7 @@ Changelog for package autoware_path_optimizer
   * removed obstacle velocity limiter test artifact
   * remove namespace from planning validator, it has using keyword
   ---------
-* refactor(vehicle_info_utils)!: prefix package and namespace with autoware (`#7353 <https://github.com/youtalk/autoware.universe/issues/7353>`_)
+* refactor(vehicle_info_utils)!: prefix package and namespace with autoware (`#7353 <https://github.com/autowarefoundation/autoware.universe/issues/7353>`_)
   * chore(autoware_vehicle_info_utils): rename header
   * chore(bpp-common): vehicle info
   * chore(path_optimizer): vehicle info
@@ -75,15 +75,15 @@ Changelog for package autoware_path_optimizer
   * chore(sensing): vehicle info
   * fix(autoware_joy_controller): remove unused deps
   ---------
-* refactor(path_optimizer, velocity_smoother)!: prefix package and namespace with autoware (`#7354 <https://github.com/youtalk/autoware.universe/issues/7354>`_)
+* refactor(path_optimizer, velocity_smoother)!: prefix package and namespace with autoware (`#7354 <https://github.com/autowarefoundation/autoware.universe/issues/7354>`_)
   * chore(autoware_velocity_smoother): update namespace
   * chore(autoware_path_optimizer): update namespace
   ---------
-* feat!: replace autoware_auto_msgs with autoware_msgs for planning modules (`#7246 <https://github.com/youtalk/autoware.universe/issues/7246>`_)
+* feat!: replace autoware_auto_msgs with autoware_msgs for planning modules (`#7246 <https://github.com/autowarefoundation/autoware.universe/issues/7246>`_)
   Co-authored-by: Cynthia Liu <cynthia.liu@autocore.ai>
   Co-authored-by: NorahXiong <norah.xiong@autocore.ai>
   Co-authored-by: beginningfan <beginning.fan@autocore.ai>
-* chore(autoware_velocity_smoother, autoware_path_optimizer): rename packages (`#7202 <https://github.com/youtalk/autoware.universe/issues/7202>`_)
+* chore(autoware_velocity_smoother, autoware_path_optimizer): rename packages (`#7202 <https://github.com/autowarefoundation/autoware.universe/issues/7202>`_)
   * chore(autoware_path_optimizer): rename package and namespace
   * chore(autoware_static_centerline_generator): rename package and namespace
   * chore: update module name

--- a/planning/autoware_path_smoother/CHANGELOG.rst
+++ b/planning/autoware_path_smoother/CHANGELOG.rst
@@ -5,23 +5,23 @@ Changelog for package autoware_path_smoother
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* refactor(osqp_interface): added autoware prefix to osqp_interface (`#8958 <https://github.com/youtalk/autoware.universe/issues/8958>`_)
-* refactor(autoware_interpolation): prefix package and namespace with autoware (`#8088 <https://github.com/youtalk/autoware.universe/issues/8088>`_)
+* refactor(osqp_interface): added autoware prefix to osqp_interface (`#8958 <https://github.com/autowarefoundation/autoware.universe/issues/8958>`_)
+* refactor(autoware_interpolation): prefix package and namespace with autoware (`#8088 <https://github.com/autowarefoundation/autoware.universe/issues/8088>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* fix(motion_planning): align the parameters with launcher (`#8792 <https://github.com/youtalk/autoware.universe/issues/8792>`_)
+* fix(motion_planning): align the parameters with launcher (`#8792 <https://github.com/autowarefoundation/autoware.universe/issues/8792>`_)
   parameters in motion_planning aligned
-* fix(autoware_path_smoother): fix passedByValue (`#8203 <https://github.com/youtalk/autoware.universe/issues/8203>`_)
+* fix(autoware_path_smoother): fix passedByValue (`#8203 <https://github.com/autowarefoundation/autoware.universe/issues/8203>`_)
   fix:passedByValue
-* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/youtalk/autoware.universe/issues/7594>`_)
-* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/youtalk/autoware.universe/issues/7539>`_)
+* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/autowarefoundation/autoware.universe/issues/7594>`_)
+* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/autowarefoundation/autoware.universe/issues/7539>`_)
   refactor(motion_utils): add autoware prefix and include dir
-* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/youtalk/autoware.universe/issues/7538>`_)
+* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/autowarefoundation/autoware.universe/issues/7538>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* feat(path_smoother): rename to include/autoware/{package_name} (`#7527 <https://github.com/youtalk/autoware.universe/issues/7527>`_)
+* feat(path_smoother): rename to include/autoware/{package_name} (`#7527 <https://github.com/autowarefoundation/autoware.universe/issues/7527>`_)
   * feat(path_smoother): rename to include/autoware/{package_name}
   * fix
   ---------
-* refactor(test_utils): move to common folder (`#7158 <https://github.com/youtalk/autoware.universe/issues/7158>`_)
+* refactor(test_utils): move to common folder (`#7158 <https://github.com/autowarefoundation/autoware.universe/issues/7158>`_)
   * Move autoware planning test manager to autoware namespace
   * fix package share directory for behavior path planner
   * renaming files and directory
@@ -33,7 +33,7 @@ Changelog for package autoware_path_smoother
   * removed obstacle velocity limiter test artifact
   * remove namespace from planning validator, it has using keyword
   ---------
-* refactor(path_smoother)!: prefix package and namespace with autoware (`#7381 <https://github.com/youtalk/autoware.universe/issues/7381>`_)
+* refactor(path_smoother)!: prefix package and namespace with autoware (`#7381 <https://github.com/autowarefoundation/autoware.universe/issues/7381>`_)
   * git mv
   * fix
   * fix launch

--- a/planning/autoware_planning_test_manager/CHANGELOG.rst
+++ b/planning/autoware_planning_test_manager/CHANGELOG.rst
@@ -5,17 +5,17 @@ Changelog for package autoware_planning_test_manager
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* refactor(autoware_test_utils): sanitizer header (`#9174 <https://github.com/youtalk/autoware.universe/issues/9174>`_)
-* refactor(component_interface_specs): prefix package and namespace with autoware (`#9094 <https://github.com/youtalk/autoware.universe/issues/9094>`_)
-* feat: add `autoware\_` prefix to `lanelet2_extension` (`#7640 <https://github.com/youtalk/autoware.universe/issues/7640>`_)
-* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/youtalk/autoware.universe/issues/7594>`_)
-* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/youtalk/autoware.universe/issues/7539>`_)
+* refactor(autoware_test_utils): sanitizer header (`#9174 <https://github.com/autowarefoundation/autoware.universe/issues/9174>`_)
+* refactor(component_interface_specs): prefix package and namespace with autoware (`#9094 <https://github.com/autowarefoundation/autoware.universe/issues/9094>`_)
+* feat: add `autoware\_` prefix to `lanelet2_extension` (`#7640 <https://github.com/autowarefoundation/autoware.universe/issues/7640>`_)
+* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/autowarefoundation/autoware.universe/issues/7594>`_)
+* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/autowarefoundation/autoware.universe/issues/7539>`_)
   refactor(motion_utils): add autoware prefix and include dir
-* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/youtalk/autoware.universe/issues/7538>`_)
+* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/autowarefoundation/autoware.universe/issues/7538>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* refactor(route_handler)!: rename to include/autoware/{package_name}  (`#7530 <https://github.com/youtalk/autoware.universe/issues/7530>`_)
+* refactor(route_handler)!: rename to include/autoware/{package_name}  (`#7530 <https://github.com/autowarefoundation/autoware.universe/issues/7530>`_)
   refactor(route_handler)!: rename to include/autoware/{package_name}
-* refactor(test_utils): move to common folder (`#7158 <https://github.com/youtalk/autoware.universe/issues/7158>`_)
+* refactor(test_utils): move to common folder (`#7158 <https://github.com/autowarefoundation/autoware.universe/issues/7158>`_)
   * Move autoware planning test manager to autoware namespace
   * fix package share directory for behavior path planner
   * renaming files and directory
@@ -27,7 +27,7 @@ Changelog for package autoware_planning_test_manager
   * removed obstacle velocity limiter test artifact
   * remove namespace from planning validator, it has using keyword
   ---------
-* refactor(route_handler): route handler add autoware prefix (`#7341 <https://github.com/youtalk/autoware.universe/issues/7341>`_)
+* refactor(route_handler): route handler add autoware prefix (`#7341 <https://github.com/autowarefoundation/autoware.universe/issues/7341>`_)
   * rename route handler package
   * update packages dependencies
   * update include guards
@@ -36,16 +36,16 @@ Changelog for package autoware_planning_test_manager
   * fix formats
   * keep header and source file name as before
   ---------
-* refactor(planning_validator)!: prefix package and namespace with autoware (`#7320 <https://github.com/youtalk/autoware.universe/issues/7320>`_)
+* refactor(planning_validator)!: prefix package and namespace with autoware (`#7320 <https://github.com/autowarefoundation/autoware.universe/issues/7320>`_)
   * add autoware\_ prefix to planning_validator
   * add prefix to package name in .pages
   * fix link of the image
   ---------
-* feat!: replace autoware_auto_msgs with autoware_msgs for planning modules (`#7246 <https://github.com/youtalk/autoware.universe/issues/7246>`_)
+* feat!: replace autoware_auto_msgs with autoware_msgs for planning modules (`#7246 <https://github.com/autowarefoundation/autoware.universe/issues/7246>`_)
   Co-authored-by: Cynthia Liu <cynthia.liu@autocore.ai>
   Co-authored-by: NorahXiong <norah.xiong@autocore.ai>
   Co-authored-by: beginningfan <beginning.fan@autocore.ai>
-* chore(autoware_velocity_smoother, autoware_path_optimizer): rename packages (`#7202 <https://github.com/youtalk/autoware.universe/issues/7202>`_)
+* chore(autoware_velocity_smoother, autoware_path_optimizer): rename packages (`#7202 <https://github.com/autowarefoundation/autoware.universe/issues/7202>`_)
   * chore(autoware_path_optimizer): rename package and namespace
   * chore(autoware_static_centerline_generator): rename package and namespace
   * chore: update module name
@@ -56,19 +56,19 @@ Changelog for package autoware_planning_test_manager
   * fix: test
   * fix: test
   ---------
-* docs(planning_test_utils): update purpose of the package and add lanelet map images (`#7077 <https://github.com/youtalk/autoware.universe/issues/7077>`_)
+* docs(planning_test_utils): update purpose of the package and add lanelet map images (`#7077 <https://github.com/autowarefoundation/autoware.universe/issues/7077>`_)
   * docs(planning_test_utils): Add explanation
   * remove autoware prefix from autoware planning test manager
   * fix document
   * remove implemented test part
   ---------
-* refactor(planning_test_utils): remove route_handler dependencies (`#7005 <https://github.com/youtalk/autoware.universe/issues/7005>`_)
+* refactor(planning_test_utils): remove route_handler dependencies (`#7005 <https://github.com/autowarefoundation/autoware.universe/issues/7005>`_)
   * refactor(planning_test_utils): remove route_handler dependencies
   * style(pre-commit): autofix
   * Fix precommit
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* refactor(autoware_planning_test_manager): rename package (`#6995 <https://github.com/youtalk/autoware.universe/issues/6995>`_)
+* refactor(autoware_planning_test_manager): rename package (`#6995 <https://github.com/autowarefoundation/autoware.universe/issues/6995>`_)
   * refactor(autoware_planning_test_manager): rename package
   * rename file
   * Add maintainer for planning test utils

--- a/planning/autoware_planning_topic_converter/CHANGELOG.rst
+++ b/planning/autoware_planning_topic_converter/CHANGELOG.rst
@@ -5,16 +5,16 @@ Changelog for package autoware_planning_topic_converter
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/youtalk/autoware.universe/issues/7594>`_)
-* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/youtalk/autoware.universe/issues/7539>`_)
+* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/autowarefoundation/autoware.universe/issues/7594>`_)
+* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/autowarefoundation/autoware.universe/issues/7539>`_)
   refactor(motion_utils): add autoware prefix and include dir
-* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/youtalk/autoware.universe/issues/7538>`_)
+* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/autowarefoundation/autoware.universe/issues/7538>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* feat(planning_topic_converter): rename to include/autoware/{package_name} (`#7515 <https://github.com/youtalk/autoware.universe/issues/7515>`_)
+* feat(planning_topic_converter): rename to include/autoware/{package_name} (`#7515 <https://github.com/autowarefoundation/autoware.universe/issues/7515>`_)
   * feat(planning_topic_converter): rename to include/autoware/{package_name}
   * fix
   ---------
-* chore(autoware_planning_topic_converter): add prefix `autoware\_` (`#7296 <https://github.com/youtalk/autoware.universe/issues/7296>`_)
+* chore(autoware_planning_topic_converter): add prefix `autoware\_` (`#7296 <https://github.com/autowarefoundation/autoware.universe/issues/7296>`_)
   chore(autoware_planning_topic_converter): rename
 * Contributors: Kosuke Takeuchi, Satoshi OTA, Takayuki Murooka, Yutaka Kondo
 

--- a/planning/autoware_planning_validator/CHANGELOG.rst
+++ b/planning/autoware_planning_validator/CHANGELOG.rst
@@ -5,19 +5,19 @@ Changelog for package autoware_planning_validator
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* fix(autoware_planning_validator): fix unusedFunction (`#8646 <https://github.com/youtalk/autoware.universe/issues/8646>`_)
+* fix(autoware_planning_validator): fix unusedFunction (`#8646 <https://github.com/autowarefoundation/autoware.universe/issues/8646>`_)
   fix:unusedFunction
-* fix(autoware_planning_validator): fix knownConditionTrueFalse (`#7817 <https://github.com/youtalk/autoware.universe/issues/7817>`_)
-* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/youtalk/autoware.universe/issues/7594>`_)
-* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/youtalk/autoware.universe/issues/7539>`_)
+* fix(autoware_planning_validator): fix knownConditionTrueFalse (`#7817 <https://github.com/autowarefoundation/autoware.universe/issues/7817>`_)
+* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/autowarefoundation/autoware.universe/issues/7594>`_)
+* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/autowarefoundation/autoware.universe/issues/7539>`_)
   refactor(motion_utils): add autoware prefix and include dir
-* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/youtalk/autoware.universe/issues/7538>`_)
+* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/autowarefoundation/autoware.universe/issues/7538>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* feat(planning_validator): rename to include/autoware/{package_name} (`#7514 <https://github.com/youtalk/autoware.universe/issues/7514>`_)
+* feat(planning_validator): rename to include/autoware/{package_name} (`#7514 <https://github.com/autowarefoundation/autoware.universe/issues/7514>`_)
   * feat(planning_validator): rename to include/autoware/{package_name}
   * fix
   ---------
-* refactor(test_utils): move to common folder (`#7158 <https://github.com/youtalk/autoware.universe/issues/7158>`_)
+* refactor(test_utils): move to common folder (`#7158 <https://github.com/autowarefoundation/autoware.universe/issues/7158>`_)
   * Move autoware planning test manager to autoware namespace
   * fix package share directory for behavior path planner
   * renaming files and directory
@@ -29,7 +29,7 @@ Changelog for package autoware_planning_validator
   * removed obstacle velocity limiter test artifact
   * remove namespace from planning validator, it has using keyword
   ---------
-* refactor(planning_validator)!: rename directory name  (`#7411 <https://github.com/youtalk/autoware.universe/issues/7411>`_)
+* refactor(planning_validator)!: rename directory name  (`#7411 <https://github.com/autowarefoundation/autoware.universe/issues/7411>`_)
   change directory name
 * Contributors: Kosuke Takeuchi, Kyoichi Sugahara, Ryuta Kambe, Takayuki Murooka, Yutaka Kondo, Zulfaqar Azmi, kobayu858
 

--- a/planning/autoware_remaining_distance_time_calculator/CHANGELOG.rst
+++ b/planning/autoware_remaining_distance_time_calculator/CHANGELOG.rst
@@ -5,16 +5,16 @@ Changelog for package autoware_remaining_distance_time_calculator
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* fix: change remaning distance when the size of route is 1 (`#8852 <https://github.com/youtalk/autoware.universe/issues/8852>`_)
-* feat: add `autoware\_` prefix to `lanelet2_extension` (`#7640 <https://github.com/youtalk/autoware.universe/issues/7640>`_)
-* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/youtalk/autoware.universe/issues/7594>`_)
-* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/youtalk/autoware.universe/issues/7539>`_)
+* fix: change remaning distance when the size of route is 1 (`#8852 <https://github.com/autowarefoundation/autoware.universe/issues/8852>`_)
+* feat: add `autoware\_` prefix to `lanelet2_extension` (`#7640 <https://github.com/autowarefoundation/autoware.universe/issues/7640>`_)
+* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/autowarefoundation/autoware.universe/issues/7594>`_)
+* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/autowarefoundation/autoware.universe/issues/7539>`_)
   refactor(motion_utils): add autoware prefix and include dir
-* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/youtalk/autoware.universe/issues/7538>`_)
+* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/autowarefoundation/autoware.universe/issues/7538>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* refactor(route_handler)!: rename to include/autoware/{package_name}  (`#7530 <https://github.com/youtalk/autoware.universe/issues/7530>`_)
+* refactor(route_handler)!: rename to include/autoware/{package_name}  (`#7530 <https://github.com/autowarefoundation/autoware.universe/issues/7530>`_)
   refactor(route_handler)!: rename to include/autoware/{package_name}
-* refactor(test_utils): move to common folder (`#7158 <https://github.com/youtalk/autoware.universe/issues/7158>`_)
+* refactor(test_utils): move to common folder (`#7158 <https://github.com/autowarefoundation/autoware.universe/issues/7158>`_)
   * Move autoware planning test manager to autoware namespace
   * fix package share directory for behavior path planner
   * renaming files and directory
@@ -26,7 +26,7 @@ Changelog for package autoware_remaining_distance_time_calculator
   * removed obstacle velocity limiter test artifact
   * remove namespace from planning validator, it has using keyword
   ---------
-* refactor(route_handler): route handler add autoware prefix (`#7341 <https://github.com/youtalk/autoware.universe/issues/7341>`_)
+* refactor(route_handler): route handler add autoware prefix (`#7341 <https://github.com/autowarefoundation/autoware.universe/issues/7341>`_)
   * rename route handler package
   * update packages dependencies
   * update include guards
@@ -35,11 +35,11 @@ Changelog for package autoware_remaining_distance_time_calculator
   * fix formats
   * keep header and source file name as before
   ---------
-* feat!: replace autoware_auto_msgs with autoware_msgs for planning modules (`#7246 <https://github.com/youtalk/autoware.universe/issues/7246>`_)
+* feat!: replace autoware_auto_msgs with autoware_msgs for planning modules (`#7246 <https://github.com/autowarefoundation/autoware.universe/issues/7246>`_)
   Co-authored-by: Cynthia Liu <cynthia.liu@autocore.ai>
   Co-authored-by: NorahXiong <norah.xiong@autocore.ai>
   Co-authored-by: beginningfan <beginning.fan@autocore.ai>
-* feat: add autoware_remaining_distance_time_calculator and overlay (`#6855 <https://github.com/youtalk/autoware.universe/issues/6855>`_)
+* feat: add autoware_remaining_distance_time_calculator and overlay (`#6855 <https://github.com/autowarefoundation/autoware.universe/issues/6855>`_)
 * Contributors: Ahmed Ebrahim, Kosuke Takeuchi, Ryohsuke Mitsudome, Takayuki Murooka, Yutaka Kondo, Zulfaqar Azmi, mkquda, shulanbushangshu
 
 0.26.0 (2024-04-03)

--- a/planning/autoware_route_handler/CHANGELOG.rst
+++ b/planning/autoware_route_handler/CHANGELOG.rst
@@ -5,17 +5,17 @@ Changelog for package autoware_route_handler
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* fix(autoware_route_handler): fix cppcheck unusedVariable (`#9191 <https://github.com/youtalk/autoware.universe/issues/9191>`_)
-* feat(mission_planner): reroute with current route start pose when triggered by modifed goal (`#9136 <https://github.com/youtalk/autoware.universe/issues/9136>`_)
+* fix(autoware_route_handler): fix cppcheck unusedVariable (`#9191 <https://github.com/autowarefoundation/autoware.universe/issues/9191>`_)
+* feat(mission_planner): reroute with current route start pose when triggered by modifed goal (`#9136 <https://github.com/autowarefoundation/autoware.universe/issues/9136>`_)
   * feat(mission_planner): reroute with current route start pose when triggered by modifed goal
   * check new ego goal is in original preffered lane as much as possible
   * check goal is in goal_lane
   ---------
-* feat(autoware_test_utils): add path with lane id parser (`#9098 <https://github.com/youtalk/autoware.universe/issues/9098>`_)
+* feat(autoware_test_utils): add path with lane id parser (`#9098 <https://github.com/autowarefoundation/autoware.universe/issues/9098>`_)
   * add path with lane id parser
   * refactor parse to use template
   ---------
-* refactor(lane_change): refactor getLaneChangePaths function (`#8909 <https://github.com/youtalk/autoware.universe/issues/8909>`_)
+* refactor(lane_change): refactor getLaneChangePaths function (`#8909 <https://github.com/autowarefoundation/autoware.universe/issues/8909>`_)
   * refactor lane change utility funcions
   * LC utility function to get distance to next regulatory element
   * don't activate LC module when close to regulatory element
@@ -45,29 +45,29 @@ Changelog for package autoware_route_handler
   * add colors to flow chart in README
   ---------
   Co-authored-by: Zulfaqar Azmi <93502286+zulfaqar-azmi-t4@users.noreply.github.com>
-* test(autoware_route_handler): add unit test for autoware route handler function (`#8271 <https://github.com/youtalk/autoware.universe/issues/8271>`_)
+* test(autoware_route_handler): add unit test for autoware route handler function (`#8271 <https://github.com/autowarefoundation/autoware.universe/issues/8271>`_)
   * remove unused functions in route handler
   * add docstring for function getShoulderLaneletsAtPose
   * update test map to include shoulder lanelet
   * add unit test for function getShoulderLaneletsAtPose
   * add test case for getCenterLinePath to improve branch coverage
   ---------
-* fix(route_handler): make new route continuous with previous route (`#8238 <https://github.com/youtalk/autoware.universe/issues/8238>`_)
-* feat(map_loader, route_handler)!: add format_version validation (`#7074 <https://github.com/youtalk/autoware.universe/issues/7074>`_)
+* fix(route_handler): make new route continuous with previous route (`#8238 <https://github.com/autowarefoundation/autoware.universe/issues/8238>`_)
+* feat(map_loader, route_handler)!: add format_version validation (`#7074 <https://github.com/autowarefoundation/autoware.universe/issues/7074>`_)
   Co-authored-by: Yamato Ando <yamato.ando@gmail.com>
-* feat: add `autoware\_` prefix to `lanelet2_extension` (`#7640 <https://github.com/youtalk/autoware.universe/issues/7640>`_)
-* feat(route_handler): add unit test for lane change related functions (`#7504 <https://github.com/youtalk/autoware.universe/issues/7504>`_)
+* feat: add `autoware\_` prefix to `lanelet2_extension` (`#7640 <https://github.com/autowarefoundation/autoware.universe/issues/7640>`_)
+* feat(route_handler): add unit test for lane change related functions (`#7504 <https://github.com/autowarefoundation/autoware.universe/issues/7504>`_)
   * RT1-6230 feat(route_handler): add unit test for lane change related functions
   * fix spell check
   * fix spellcheck
   ---------
-* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/youtalk/autoware.universe/issues/7594>`_)
-* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/youtalk/autoware.universe/issues/7538>`_)
+* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/autowarefoundation/autoware.universe/issues/7594>`_)
+* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/autowarefoundation/autoware.universe/issues/7538>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* refactor(route_handler)!: rename to include/autoware/{package_name}  (`#7530 <https://github.com/youtalk/autoware.universe/issues/7530>`_)
+* refactor(route_handler)!: rename to include/autoware/{package_name}  (`#7530 <https://github.com/autowarefoundation/autoware.universe/issues/7530>`_)
   refactor(route_handler)!: rename to include/autoware/{package_name}
-* chore(route_handler, lane_change): add codeowner (`#7475 <https://github.com/youtalk/autoware.universe/issues/7475>`_)
-* fix(route_handler): route handler overlap removal is too conservative (`#7156 <https://github.com/youtalk/autoware.universe/issues/7156>`_)
+* chore(route_handler, lane_change): add codeowner (`#7475 <https://github.com/autowarefoundation/autoware.universe/issues/7475>`_)
+* fix(route_handler): route handler overlap removal is too conservative (`#7156 <https://github.com/autowarefoundation/autoware.universe/issues/7156>`_)
   * add flag to enable/disable loop check in getLaneletSequence functions
   * implement function to get closest route lanelet based on previous closest lanelet
   * refactor DefaultPlanner::plan function
@@ -84,7 +84,7 @@ Changelog for package autoware_route_handler
   * format fix
   * move test map to autoware_test_utils
   ---------
-* refactor(test_utils): move to common folder (`#7158 <https://github.com/youtalk/autoware.universe/issues/7158>`_)
+* refactor(test_utils): move to common folder (`#7158 <https://github.com/autowarefoundation/autoware.universe/issues/7158>`_)
   * Move autoware planning test manager to autoware namespace
   * fix package share directory for behavior path planner
   * renaming files and directory
@@ -96,7 +96,7 @@ Changelog for package autoware_route_handler
   * removed obstacle velocity limiter test artifact
   * remove namespace from planning validator, it has using keyword
   ---------
-* refactor(route_handler): route handler add autoware prefix (`#7341 <https://github.com/youtalk/autoware.universe/issues/7341>`_)
+* refactor(route_handler): route handler add autoware prefix (`#7341 <https://github.com/autowarefoundation/autoware.universe/issues/7341>`_)
   * rename route handler package
   * update packages dependencies
   * update include guards

--- a/planning/autoware_rtc_interface/CHANGELOG.rst
+++ b/planning/autoware_rtc_interface/CHANGELOG.rst
@@ -5,32 +5,32 @@ Changelog for package autoware_rtc_interface
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* fix(rtc_interface): update cooperateStatus state transition (`#8883 <https://github.com/youtalk/autoware.universe/issues/8883>`_)
+* fix(rtc_interface): update cooperateStatus state transition (`#8883 <https://github.com/autowarefoundation/autoware.universe/issues/8883>`_)
   fix state transition for failure/success
-* feat(rtc_interface, lane_change): check state transition for cooperate status (`#8855 <https://github.com/youtalk/autoware.universe/issues/8855>`_)
+* feat(rtc_interface, lane_change): check state transition for cooperate status (`#8855 <https://github.com/autowarefoundation/autoware.universe/issues/8855>`_)
   * update rtc state transition
   * remove transition from failuer and succeeded
   * fix
   * check initial state for cooperate status
   * change rtc cooperate status according to module status
   ---------
-* feat(rtc_inteface): add function to check force deactivate (`#8221 <https://github.com/youtalk/autoware.universe/issues/8221>`_)
+* feat(rtc_inteface): add function to check force deactivate (`#8221 <https://github.com/autowarefoundation/autoware.universe/issues/8221>`_)
   add function to check for deactivation
-* fix(autoware_rtc_interface): fix constParameterReference (`#8042 <https://github.com/youtalk/autoware.universe/issues/8042>`_)
+* fix(autoware_rtc_interface): fix constParameterReference (`#8042 <https://github.com/autowarefoundation/autoware.universe/issues/8042>`_)
   * fix:constParameterReference
   * fix: clang format
   * fix:constParameterReference
   ---------
-* fix(rtc_interface): fix build error (`#8111 <https://github.com/youtalk/autoware.universe/issues/8111>`_)
+* fix(rtc_interface): fix build error (`#8111 <https://github.com/autowarefoundation/autoware.universe/issues/8111>`_)
   * fix
   * fix format
   ---------
-* fix(bpp, rtc_interface): fix state transition (`#7743 <https://github.com/youtalk/autoware.universe/issues/7743>`_)
+* fix(bpp, rtc_interface): fix state transition (`#7743 <https://github.com/autowarefoundation/autoware.universe/issues/7743>`_)
   * fix(rtc_interface): check rtc state
   * fix(bpp_interface): check rtc state
   * feat(rtc_interface): print
   ---------
-* feat(static_obstacle_avoidance): enable force execution under unsafe conditions (`#8094 <https://github.com/youtalk/autoware.universe/issues/8094>`_)
+* feat(static_obstacle_avoidance): enable force execution under unsafe conditions (`#8094 <https://github.com/autowarefoundation/autoware.universe/issues/8094>`_)
   * add force execution for static obstacle avoidance
   * fix
   * erase unused function in RTC interface
@@ -39,20 +39,20 @@ Changelog for package autoware_rtc_interface
   * add warn throtthle and move code block
   * fix
   ---------
-* docs(planning): fix wrong link (`#7751 <https://github.com/youtalk/autoware.universe/issues/7751>`_)
+* docs(planning): fix wrong link (`#7751 <https://github.com/autowarefoundation/autoware.universe/issues/7751>`_)
   * fix page link
   * fix out of lane link
   * fix
   * fix cost map generator link
   ---------
-* docs(rtc_replayer): fix wrong link (`#7714 <https://github.com/youtalk/autoware.universe/issues/7714>`_)
+* docs(rtc_replayer): fix wrong link (`#7714 <https://github.com/autowarefoundation/autoware.universe/issues/7714>`_)
   * fix link for rtc_replayer
   * delete RTC replayer header
   * fix
   ---------
-* refactor(rtc_interface)!: rename to include/autoware/{package_name} (`#7531 <https://github.com/youtalk/autoware.universe/issues/7531>`_)
+* refactor(rtc_interface)!: rename to include/autoware/{package_name} (`#7531 <https://github.com/autowarefoundation/autoware.universe/issues/7531>`_)
   Co-authored-by: Fumiya Watanabe <rej55.g@gmail.com>
-* refactor(rtc_interface)!: prefix package and namespace with autoware (`#7321 <https://github.com/youtalk/autoware.universe/issues/7321>`_)
+* refactor(rtc_interface)!: prefix package and namespace with autoware (`#7321 <https://github.com/autowarefoundation/autoware.universe/issues/7321>`_)
   refactor(rtc_interface): add autoware prefix
 * Contributors: Fumiya Watanabe, Go Sakayori, Kosuke Takeuchi, Satoshi OTA, Yutaka Kondo, kobayu858
 

--- a/planning/autoware_scenario_selector/CHANGELOG.rst
+++ b/planning/autoware_scenario_selector/CHANGELOG.rst
@@ -5,14 +5,14 @@ Changelog for package autoware_scenario_selector
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* feat(costmap_generator, control_validator, scenario_selector, surround_obstacle_checker, vehicle_cmd_gate): add processing time pub. (`#9065 <https://github.com/youtalk/autoware.universe/issues/9065>`_)
+* feat(costmap_generator, control_validator, scenario_selector, surround_obstacle_checker, vehicle_cmd_gate): add processing time pub. (`#9065 <https://github.com/autowarefoundation/autoware.universe/issues/9065>`_)
   * feat(costmap_generator, control_validator, scenario_selector, surround_obstacle_checker, vehicle_cmd_gate): Add: processing_time_pub
   * fix: pre-commit
   * feat(costmap_generator): fix: No output when not Active.
   * fix: clang-format
   * Re: fix: clang-format
   ---------
-* feat(scenario_selector, freespace_planner): improve freespace planner edge case behavior (`#8348 <https://github.com/youtalk/autoware.universe/issues/8348>`_)
+* feat(scenario_selector, freespace_planner): improve freespace planner edge case behavior (`#8348 <https://github.com/autowarefoundation/autoware.universe/issues/8348>`_)
   * refactor free space planner subscribers
   * implement scenario switching for edge cases
   * fix scenario selector test
@@ -23,8 +23,8 @@ Changelog for package autoware_scenario_selector
   * improve near target logic
   * use timer based implementation for obstacle check
   ---------
-* perf(costmap_generator, scenario_selector): faster getLinkedParkingLot (`#7930 <https://github.com/youtalk/autoware.universe/issues/7930>`_)
-* refactor(autoware_universe_utils): changed the API to be more intuitive and added documentation (`#7443 <https://github.com/youtalk/autoware.universe/issues/7443>`_)
+* perf(costmap_generator, scenario_selector): faster getLinkedParkingLot (`#7930 <https://github.com/autowarefoundation/autoware.universe/issues/7930>`_)
+* refactor(autoware_universe_utils): changed the API to be more intuitive and added documentation (`#7443 <https://github.com/autowarefoundation/autoware.universe/issues/7443>`_)
   * refactor(tier4_autoware_utils): Changed the API to be more intuitive and added documentation.
   * use raw shared ptr in PollingPolicy::NEWEST
   * update
@@ -33,14 +33,14 @@ Changelog for package autoware_scenario_selector
   Co-authored-by: danielsanchezaran <daniel.sanchez@tier4.jp>
   ---------
   Co-authored-by: danielsanchezaran <daniel.sanchez@tier4.jp>
-* feat: add `autoware\_` prefix to `lanelet2_extension` (`#7640 <https://github.com/youtalk/autoware.universe/issues/7640>`_)
-* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/youtalk/autoware.universe/issues/7594>`_)
-* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/youtalk/autoware.universe/issues/7538>`_)
+* feat: add `autoware\_` prefix to `lanelet2_extension` (`#7640 <https://github.com/autowarefoundation/autoware.universe/issues/7640>`_)
+* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/autowarefoundation/autoware.universe/issues/7594>`_)
+* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/autowarefoundation/autoware.universe/issues/7538>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* refactor(route_handler)!: rename to include/autoware/{package_name}  (`#7530 <https://github.com/youtalk/autoware.universe/issues/7530>`_)
+* refactor(route_handler)!: rename to include/autoware/{package_name}  (`#7530 <https://github.com/autowarefoundation/autoware.universe/issues/7530>`_)
   refactor(route_handler)!: rename to include/autoware/{package_name}
-* feat(scenario_selector): rename to include/autoware/{package_name} (`#7512 <https://github.com/youtalk/autoware.universe/issues/7512>`_)
-* refactor(test_utils): move to common folder (`#7158 <https://github.com/youtalk/autoware.universe/issues/7158>`_)
+* feat(scenario_selector): rename to include/autoware/{package_name} (`#7512 <https://github.com/autowarefoundation/autoware.universe/issues/7512>`_)
+* refactor(test_utils): move to common folder (`#7158 <https://github.com/autowarefoundation/autoware.universe/issues/7158>`_)
   * Move autoware planning test manager to autoware namespace
   * fix package share directory for behavior path planner
   * renaming files and directory
@@ -52,8 +52,8 @@ Changelog for package autoware_scenario_selector
   * removed obstacle velocity limiter test artifact
   * remove namespace from planning validator, it has using keyword
   ---------
-* feat(scenario_selector): use polling subscribers (`#7412 <https://github.com/youtalk/autoware.universe/issues/7412>`_)
-* refactor(route_handler): route handler add autoware prefix (`#7341 <https://github.com/youtalk/autoware.universe/issues/7341>`_)
+* feat(scenario_selector): use polling subscribers (`#7412 <https://github.com/autowarefoundation/autoware.universe/issues/7412>`_)
+* refactor(route_handler): route handler add autoware prefix (`#7341 <https://github.com/autowarefoundation/autoware.universe/issues/7341>`_)
   * rename route handler package
   * update packages dependencies
   * update include guards
@@ -62,7 +62,7 @@ Changelog for package autoware_scenario_selector
   * fix formats
   * keep header and source file name as before
   ---------
-* refactor(scenario_selector): prefix package and namespace with autoware\_ (`#7379 <https://github.com/youtalk/autoware.universe/issues/7379>`_)
+* refactor(scenario_selector): prefix package and namespace with autoware\_ (`#7379 <https://github.com/autowarefoundation/autoware.universe/issues/7379>`_)
 * Contributors: Kazunori-Nakajima, Kosuke Takeuchi, Maxime CLEMENT, Takayuki Murooka, Yukinari Hisaki, Yutaka Kondo, Zulfaqar Azmi, mkquda
 
 0.26.0 (2024-04-03)

--- a/planning/autoware_static_centerline_generator/CHANGELOG.rst
+++ b/planning/autoware_static_centerline_generator/CHANGELOG.rst
@@ -5,41 +5,41 @@ Changelog for package autoware_static_centerline_generator
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* refactor(osqp_interface): added autoware prefix to osqp_interface (`#8958 <https://github.com/youtalk/autoware.universe/issues/8958>`_)
-* refactor(autoware_interpolation): prefix package and namespace with autoware (`#8088 <https://github.com/youtalk/autoware.universe/issues/8088>`_)
+* refactor(osqp_interface): added autoware prefix to osqp_interface (`#8958 <https://github.com/autowarefoundation/autoware.universe/issues/8958>`_)
+* refactor(autoware_interpolation): prefix package and namespace with autoware (`#8088 <https://github.com/autowarefoundation/autoware.universe/issues/8088>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* fix(other_planning_packages): align the parameters with launcher (`#8793 <https://github.com/youtalk/autoware.universe/issues/8793>`_)
+* fix(other_planning_packages): align the parameters with launcher (`#8793 <https://github.com/autowarefoundation/autoware.universe/issues/8793>`_)
   * parameters in planning/others aligned
   * update json
   ---------
-* refactor(map_projection_loader)!: prefix package and namespace with autoware (`#8420 <https://github.com/youtalk/autoware.universe/issues/8420>`_)
+* refactor(map_projection_loader)!: prefix package and namespace with autoware (`#8420 <https://github.com/autowarefoundation/autoware.universe/issues/8420>`_)
   * add autoware\_ prefix
   * add autoware\_ prefix
   ---------
   Co-authored-by: SakodaShintaro <shintaro.sakoda@tier4.jp>
-* fix(autoware_static_centerline_generator): fix unusedFunction (`#8647 <https://github.com/youtalk/autoware.universe/issues/8647>`_)
+* fix(autoware_static_centerline_generator): fix unusedFunction (`#8647 <https://github.com/autowarefoundation/autoware.universe/issues/8647>`_)
   * fix:unusedFunction
   * fix:unusedFunction
   * fix:compile error
   ---------
-* refactor(geography_utils): prefix package and namespace with autoware (`#7790 <https://github.com/youtalk/autoware.universe/issues/7790>`_)
+* refactor(geography_utils): prefix package and namespace with autoware (`#7790 <https://github.com/autowarefoundation/autoware.universe/issues/7790>`_)
   * refactor(geography_utils): prefix package and namespace with autoware
   * move headers to include/autoware/
   ---------
-* fix(autoware_static_centerline_generator): fix funcArgNamesDifferent (`#8019 <https://github.com/youtalk/autoware.universe/issues/8019>`_)
+* fix(autoware_static_centerline_generator): fix funcArgNamesDifferent (`#8019 <https://github.com/autowarefoundation/autoware.universe/issues/8019>`_)
   fix:funcArgNamesDifferent
-* fix(static_centerline_generator): save_map only once (`#7770 <https://github.com/youtalk/autoware.universe/issues/7770>`_)
-* refactor(static_centerline_optimizer): clean up the code (`#7756 <https://github.com/youtalk/autoware.universe/issues/7756>`_)
-* feat: add `autoware\_` prefix to `lanelet2_extension` (`#7640 <https://github.com/youtalk/autoware.universe/issues/7640>`_)
-* feat(static_centerline_generator): organize AUTO/GUI/VMB modes (`#7432 <https://github.com/youtalk/autoware.universe/issues/7432>`_)
-* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/youtalk/autoware.universe/issues/7594>`_)
-* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/youtalk/autoware.universe/issues/7539>`_)
+* fix(static_centerline_generator): save_map only once (`#7770 <https://github.com/autowarefoundation/autoware.universe/issues/7770>`_)
+* refactor(static_centerline_optimizer): clean up the code (`#7756 <https://github.com/autowarefoundation/autoware.universe/issues/7756>`_)
+* feat: add `autoware\_` prefix to `lanelet2_extension` (`#7640 <https://github.com/autowarefoundation/autoware.universe/issues/7640>`_)
+* feat(static_centerline_generator): organize AUTO/GUI/VMB modes (`#7432 <https://github.com/autowarefoundation/autoware.universe/issues/7432>`_)
+* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/autowarefoundation/autoware.universe/issues/7594>`_)
+* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/autowarefoundation/autoware.universe/issues/7539>`_)
   refactor(motion_utils): add autoware prefix and include dir
-* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/youtalk/autoware.universe/issues/7538>`_)
+* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/autowarefoundation/autoware.universe/issues/7538>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* refactor(route_handler)!: rename to include/autoware/{package_name}  (`#7530 <https://github.com/youtalk/autoware.universe/issues/7530>`_)
+* refactor(route_handler)!: rename to include/autoware/{package_name}  (`#7530 <https://github.com/autowarefoundation/autoware.universe/issues/7530>`_)
   refactor(route_handler)!: rename to include/autoware/{package_name}
-* feat(map_loader): add waypoints flag (`#7480 <https://github.com/youtalk/autoware.universe/issues/7480>`_)
+* feat(map_loader): add waypoints flag (`#7480 <https://github.com/autowarefoundation/autoware.universe/issues/7480>`_)
   * feat(map_loader): handle centelrine and waypoints
   * update README
   * fix doc
@@ -47,12 +47,12 @@ Changelog for package autoware_static_centerline_generator
   * fix
   * fix
   ---------
-* feat(path_optimizer): rename to include/autoware/{package_name} (`#7529 <https://github.com/youtalk/autoware.universe/issues/7529>`_)
-* feat(path_smoother): rename to include/autoware/{package_name} (`#7527 <https://github.com/youtalk/autoware.universe/issues/7527>`_)
+* feat(path_optimizer): rename to include/autoware/{package_name} (`#7529 <https://github.com/autowarefoundation/autoware.universe/issues/7529>`_)
+* feat(path_smoother): rename to include/autoware/{package_name} (`#7527 <https://github.com/autowarefoundation/autoware.universe/issues/7527>`_)
   * feat(path_smoother): rename to include/autoware/{package_name}
   * fix
   ---------
-* refactor(behaivor_path_planner)!: rename to include/autoware/{package_name} (`#7522 <https://github.com/youtalk/autoware.universe/issues/7522>`_)
+* refactor(behaivor_path_planner)!: rename to include/autoware/{package_name} (`#7522 <https://github.com/autowarefoundation/autoware.universe/issues/7522>`_)
   * refactor(behavior_path_planner)!: make autoware dir in include
   * refactor(start_planner): make autoware include dir
   * refactor(goal_planner): make autoware include dir
@@ -68,17 +68,17 @@ Changelog for package autoware_static_centerline_generator
   * fix pre-commit
   * fix build
   ---------
-* feat(mission_planner): rename to include/autoware/{package_name} (`#7513 <https://github.com/youtalk/autoware.universe/issues/7513>`_)
+* feat(mission_planner): rename to include/autoware/{package_name} (`#7513 <https://github.com/autowarefoundation/autoware.universe/issues/7513>`_)
   * feat(mission_planner): rename to include/autoware/{package_name}
   * feat(mission_planner): rename to include/autoware/{package_name}
   * feat(mission_planner): rename to include/autoware/{package_name}
   ---------
-* fix(static_centerline_generator): fix dependency (`#7442 <https://github.com/youtalk/autoware.universe/issues/7442>`_)
+* fix(static_centerline_generator): fix dependency (`#7442 <https://github.com/autowarefoundation/autoware.universe/issues/7442>`_)
   * fix: deps
   * fix: package name
   * fix: package name
   ---------
-* refactor(route_handler): route handler add autoware prefix (`#7341 <https://github.com/youtalk/autoware.universe/issues/7341>`_)
+* refactor(route_handler): route handler add autoware prefix (`#7341 <https://github.com/autowarefoundation/autoware.universe/issues/7341>`_)
   * rename route handler package
   * update packages dependencies
   * update include guards
@@ -87,11 +87,11 @@ Changelog for package autoware_static_centerline_generator
   * fix formats
   * keep header and source file name as before
   ---------
-* refactor(mission_planner)!: add autoware prefix and namespace (`#7414 <https://github.com/youtalk/autoware.universe/issues/7414>`_)
+* refactor(mission_planner)!: add autoware prefix and namespace (`#7414 <https://github.com/autowarefoundation/autoware.universe/issues/7414>`_)
   * refactor(mission_planner)!: add autoware prefix and namespace
   * fix svg
   ---------
-* refactor(vehicle_info_utils)!: prefix package and namespace with autoware (`#7353 <https://github.com/youtalk/autoware.universe/issues/7353>`_)
+* refactor(vehicle_info_utils)!: prefix package and namespace with autoware (`#7353 <https://github.com/autowarefoundation/autoware.universe/issues/7353>`_)
   * chore(autoware_vehicle_info_utils): rename header
   * chore(bpp-common): vehicle info
   * chore(path_optimizer): vehicle info
@@ -126,7 +126,7 @@ Changelog for package autoware_static_centerline_generator
   * chore(sensing): vehicle info
   * fix(autoware_joy_controller): remove unused deps
   ---------
-* refactor(path_smoother)!: prefix package and namespace with autoware (`#7381 <https://github.com/youtalk/autoware.universe/issues/7381>`_)
+* refactor(path_smoother)!: prefix package and namespace with autoware (`#7381 <https://github.com/autowarefoundation/autoware.universe/issues/7381>`_)
   * git mv
   * fix
   * fix launch
@@ -136,11 +136,11 @@ Changelog for package autoware_static_centerline_generator
   * fix static_centerline_optimizer
   * fix
   ---------
-* refactor(path_optimizer, velocity_smoother)!: prefix package and namespace with autoware (`#7354 <https://github.com/youtalk/autoware.universe/issues/7354>`_)
+* refactor(path_optimizer, velocity_smoother)!: prefix package and namespace with autoware (`#7354 <https://github.com/autowarefoundation/autoware.universe/issues/7354>`_)
   * chore(autoware_velocity_smoother): update namespace
   * chore(autoware_path_optimizer): update namespace
   ---------
-* chore(bpp): add prefix `autoware\_` (`#7288 <https://github.com/youtalk/autoware.universe/issues/7288>`_)
+* chore(bpp): add prefix `autoware\_` (`#7288 <https://github.com/autowarefoundation/autoware.universe/issues/7288>`_)
   * chore(common): rename package
   * fix(static_obstacle_avoidance): fix header
   * fix(dynamic_obstacle_avoidance): fix header
@@ -155,11 +155,11 @@ Changelog for package autoware_static_centerline_generator
   * fix(static_centerline_generator): fix header
   * fix(.pages): update link
   ---------
-* feat!: replace autoware_auto_msgs with autoware_msgs for planning modules (`#7246 <https://github.com/youtalk/autoware.universe/issues/7246>`_)
+* feat!: replace autoware_auto_msgs with autoware_msgs for planning modules (`#7246 <https://github.com/autowarefoundation/autoware.universe/issues/7246>`_)
   Co-authored-by: Cynthia Liu <cynthia.liu@autocore.ai>
   Co-authored-by: NorahXiong <norah.xiong@autocore.ai>
   Co-authored-by: beginningfan <beginning.fan@autocore.ai>
-* chore(autoware_velocity_smoother, autoware_path_optimizer): rename packages (`#7202 <https://github.com/youtalk/autoware.universe/issues/7202>`_)
+* chore(autoware_velocity_smoother, autoware_path_optimizer): rename packages (`#7202 <https://github.com/autowarefoundation/autoware.universe/issues/7202>`_)
   * chore(autoware_path_optimizer): rename package and namespace
   * chore(autoware_static_centerline_generator): rename package and namespace
   * chore: update module name
@@ -170,13 +170,13 @@ Changelog for package autoware_static_centerline_generator
   * fix: test
   * fix: test
   ---------
-* refactor(behavior_velocity_planner)!: prefix package and namespace with autoware\_ (`#6693 <https://github.com/youtalk/autoware.universe/issues/6693>`_)
-* fix(autoware_static_centerline_generator): update the centerline correctly with map projector (`#6825 <https://github.com/youtalk/autoware.universe/issues/6825>`_)
+* refactor(behavior_velocity_planner)!: prefix package and namespace with autoware\_ (`#6693 <https://github.com/autowarefoundation/autoware.universe/issues/6693>`_)
+* fix(autoware_static_centerline_generator): update the centerline correctly with map projector (`#6825 <https://github.com/autowarefoundation/autoware.universe/issues/6825>`_)
   * fix(static_centerline_generator): fixed the bug of offset lat/lon values
   * fix typo
   ---------
-* fix(autoware_static_centerline_generator): remove prefix from topics and node names (`#7028 <https://github.com/youtalk/autoware.universe/issues/7028>`_)
-* build(static_centerline_generator): prefix package and namespace with autoware\_ (`#6817 <https://github.com/youtalk/autoware.universe/issues/6817>`_)
+* fix(autoware_static_centerline_generator): remove prefix from topics and node names (`#7028 <https://github.com/autowarefoundation/autoware.universe/issues/7028>`_)
+* build(static_centerline_generator): prefix package and namespace with autoware\_ (`#6817 <https://github.com/autowarefoundation/autoware.universe/issues/6817>`_)
   * build(static_centerline_generator): prefix package and namespace with autoware\_
   * style(pre-commit): autofix
   * build: fix CMake target

--- a/planning/autoware_surround_obstacle_checker/CHANGELOG.rst
+++ b/planning/autoware_surround_obstacle_checker/CHANGELOG.rst
@@ -5,26 +5,26 @@ Changelog for package autoware_surround_obstacle_checker
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* feat(costmap_generator, control_validator, scenario_selector, surround_obstacle_checker, vehicle_cmd_gate): add processing time pub. (`#9065 <https://github.com/youtalk/autoware.universe/issues/9065>`_)
+* feat(costmap_generator, control_validator, scenario_selector, surround_obstacle_checker, vehicle_cmd_gate): add processing time pub. (`#9065 <https://github.com/autowarefoundation/autoware.universe/issues/9065>`_)
   * feat(costmap_generator, control_validator, scenario_selector, surround_obstacle_checker, vehicle_cmd_gate): Add: processing_time_pub
   * fix: pre-commit
   * feat(costmap_generator): fix: No output when not Active.
   * fix: clang-format
   * Re: fix: clang-format
   ---------
-* test(surround_obstacle_checker): add unit tests (`#9039 <https://github.com/youtalk/autoware.universe/issues/9039>`_)
+* test(surround_obstacle_checker): add unit tests (`#9039 <https://github.com/autowarefoundation/autoware.universe/issues/9039>`_)
   * refactor: isStopRequired
   * test: write test for isStopRequired
   * refactor: use universe utils
   * fix: shutdown
   ---------
-* fix(other_planning_packages): align the parameters with launcher (`#8793 <https://github.com/youtalk/autoware.universe/issues/8793>`_)
+* fix(other_planning_packages): align the parameters with launcher (`#8793 <https://github.com/autowarefoundation/autoware.universe/issues/8793>`_)
   * parameters in planning/others aligned
   * update json
   ---------
-* fix(autoware_surround_obstacle_checker): fix unusedFunction (`#8774 <https://github.com/youtalk/autoware.universe/issues/8774>`_)
+* fix(autoware_surround_obstacle_checker): fix unusedFunction (`#8774 <https://github.com/autowarefoundation/autoware.universe/issues/8774>`_)
   fix:unusedFunction
-* feat(surround_obstacle_checker): integrate generate_parameter_library (`#8719 <https://github.com/youtalk/autoware.universe/issues/8719>`_)
+* feat(surround_obstacle_checker): integrate generate_parameter_library (`#8719 <https://github.com/autowarefoundation/autoware.universe/issues/8719>`_)
   * add generate_parameter_library to package
   * add parameter file generator script
   * use mapped parameters
@@ -35,25 +35,25 @@ Changelog for package autoware_surround_obstacle_checker
   * fix variable shadowing
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* fix(autoware_surround_obstacle_checker): fix passedByValue (`#8206 <https://github.com/youtalk/autoware.universe/issues/8206>`_)
+* fix(autoware_surround_obstacle_checker): fix passedByValue (`#8206 <https://github.com/autowarefoundation/autoware.universe/issues/8206>`_)
   fix:passedByValue
-* fix(autoware_surround_obstacle_checker): fix constVariableReference (`#8059 <https://github.com/youtalk/autoware.universe/issues/8059>`_)
+* fix(autoware_surround_obstacle_checker): fix constVariableReference (`#8059 <https://github.com/autowarefoundation/autoware.universe/issues/8059>`_)
   fix:constVariableReference
-* fix(autoware_surround_obstacle_checker): fix funcArgNamesDifferent (`#8020 <https://github.com/youtalk/autoware.universe/issues/8020>`_)
+* fix(autoware_surround_obstacle_checker): fix funcArgNamesDifferent (`#8020 <https://github.com/autowarefoundation/autoware.universe/issues/8020>`_)
   fix:funcArgNamesDifferent
-* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/youtalk/autoware.universe/issues/7594>`_)
-* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/youtalk/autoware.universe/issues/7539>`_)
+* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/autowarefoundation/autoware.universe/issues/7594>`_)
+* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/autowarefoundation/autoware.universe/issues/7539>`_)
   refactor(motion_utils): add autoware prefix and include dir
-* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/youtalk/autoware.universe/issues/7538>`_)
+* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/autowarefoundation/autoware.universe/issues/7538>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* feat(surround_obstacle_checker): remove include directory (`#7507 <https://github.com/youtalk/autoware.universe/issues/7507>`_)
+* feat(surround_obstacle_checker): remove include directory (`#7507 <https://github.com/autowarefoundation/autoware.universe/issues/7507>`_)
   * feat(surround_obstacle_checker): remove include directory
   * fix
   * fix
   ---------
-* fix(planning): set single depth sensor data qos for pointlcoud polling subscribers (`#7490 <https://github.com/youtalk/autoware.universe/issues/7490>`_)
+* fix(planning): set single depth sensor data qos for pointlcoud polling subscribers (`#7490 <https://github.com/autowarefoundation/autoware.universe/issues/7490>`_)
   set single depth sensor data qos for pointlcoud polling subscribers
-* refactor(vehicle_info_utils)!: prefix package and namespace with autoware (`#7353 <https://github.com/youtalk/autoware.universe/issues/7353>`_)
+* refactor(vehicle_info_utils)!: prefix package and namespace with autoware (`#7353 <https://github.com/autowarefoundation/autoware.universe/issues/7353>`_)
   * chore(autoware_vehicle_info_utils): rename header
   * chore(bpp-common): vehicle info
   * chore(path_optimizer): vehicle info
@@ -88,7 +88,7 @@ Changelog for package autoware_surround_obstacle_checker
   * chore(sensing): vehicle info
   * fix(autoware_joy_controller): remove unused deps
   ---------
-* refactor(surround_obstacle_checker)!: prefix package and namespace with autoware (`#7298 <https://github.com/youtalk/autoware.universe/issues/7298>`_)
+* refactor(surround_obstacle_checker)!: prefix package and namespace with autoware (`#7298 <https://github.com/autowarefoundation/autoware.universe/issues/7298>`_)
   * fix(autoware_surround_obstacle_checker): rename
   * fix(autoware_surround_obstacle_checker): rename header
   * fix(launch): update package name

--- a/planning/autoware_velocity_smoother/CHANGELOG.rst
+++ b/planning/autoware_velocity_smoother/CHANGELOG.rst
@@ -5,40 +5,40 @@ Changelog for package autoware_velocity_smoother
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* refactor(osqp_interface): added autoware prefix to osqp_interface (`#8958 <https://github.com/youtalk/autoware.universe/issues/8958>`_)
-* refactor(autoware_interpolation): prefix package and namespace with autoware (`#8088 <https://github.com/youtalk/autoware.universe/issues/8088>`_)
+* refactor(osqp_interface): added autoware prefix to osqp_interface (`#8958 <https://github.com/autowarefoundation/autoware.universe/issues/8958>`_)
+* refactor(autoware_interpolation): prefix package and namespace with autoware (`#8088 <https://github.com/autowarefoundation/autoware.universe/issues/8088>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* perf(motion_velocity_smoother): remove some heavy debug logging (`#8798 <https://github.com/youtalk/autoware.universe/issues/8798>`_)
+* perf(motion_velocity_smoother): remove some heavy debug logging (`#8798 <https://github.com/autowarefoundation/autoware.universe/issues/8798>`_)
   remove some heavy logging in the velocity smoother
-* fix(autoware_velocity_smoother): fix unusedFunction (`#8649 <https://github.com/youtalk/autoware.universe/issues/8649>`_)
+* fix(autoware_velocity_smoother): fix unusedFunction (`#8649 <https://github.com/autowarefoundation/autoware.universe/issues/8649>`_)
   fix:unusedFunction
-* fix(autoware_velocity_smoother): fix variableScope (`#8442 <https://github.com/youtalk/autoware.universe/issues/8442>`_)
+* fix(autoware_velocity_smoother): fix variableScope (`#8442 <https://github.com/autowarefoundation/autoware.universe/issues/8442>`_)
   fix:variableScope
-* fix(autoware_velocity_smoother): fix unreadVariable (`#8364 <https://github.com/youtalk/autoware.universe/issues/8364>`_)
+* fix(autoware_velocity_smoother): fix unreadVariable (`#8364 <https://github.com/autowarefoundation/autoware.universe/issues/8364>`_)
   fix:unreadVariable
-* fix(autoware_velocity_smoother): fix passedByValue (`#8207 <https://github.com/youtalk/autoware.universe/issues/8207>`_)
+* fix(autoware_velocity_smoother): fix passedByValue (`#8207 <https://github.com/autowarefoundation/autoware.universe/issues/8207>`_)
   * fix:passedByValue
   * fix:clang format
   ---------
-* perf(velocity_smoother): not resample debug_trajectories is not used (`#8030 <https://github.com/youtalk/autoware.universe/issues/8030>`_)
+* perf(velocity_smoother): not resample debug_trajectories is not used (`#8030 <https://github.com/autowarefoundation/autoware.universe/issues/8030>`_)
   * not resample debug_trajectories if not published
   * update dependant packages
   ---------
-* perf(velocity_smoother): use ProxQP for faster optimization (`#8028 <https://github.com/youtalk/autoware.universe/issues/8028>`_)
+* perf(velocity_smoother): use ProxQP for faster optimization (`#8028 <https://github.com/autowarefoundation/autoware.universe/issues/8028>`_)
   * perf(velocity_smoother): use ProxQP for faster optimization
   * consider max_iteration
   * disable warm start
   * fix test
   ---------
-* fix(velocity_smoother, obstacle_cruise_planner ): float type of processing time was wrong (`#8161 <https://github.com/youtalk/autoware.universe/issues/8161>`_)
+* fix(velocity_smoother, obstacle_cruise_planner ): float type of processing time was wrong (`#8161 <https://github.com/autowarefoundation/autoware.universe/issues/8161>`_)
   fix(velocity_smoother): float type of processing time was wrong
-* fix(autoware_velocity_smoother): fix constVariableReference (`#8060 <https://github.com/youtalk/autoware.universe/issues/8060>`_)
+* fix(autoware_velocity_smoother): fix constVariableReference (`#8060 <https://github.com/autowarefoundation/autoware.universe/issues/8060>`_)
   fix:constVariableReference
-* fix(autoware_velocity_smoother): fix constParameterReference (`#8043 <https://github.com/youtalk/autoware.universe/issues/8043>`_)
+* fix(autoware_velocity_smoother): fix constParameterReference (`#8043 <https://github.com/autowarefoundation/autoware.universe/issues/8043>`_)
   fix:constParameterReference
-* chore(velocity_smoother): add maintainer  (`#8121 <https://github.com/youtalk/autoware.universe/issues/8121>`_)
+* chore(velocity_smoother): add maintainer  (`#8121 <https://github.com/autowarefoundation/autoware.universe/issues/8121>`_)
   add maintainer
-* refactor(autoware_universe_utils): changed the API to be more intuitive and added documentation (`#7443 <https://github.com/youtalk/autoware.universe/issues/7443>`_)
+* refactor(autoware_universe_utils): changed the API to be more intuitive and added documentation (`#7443 <https://github.com/autowarefoundation/autoware.universe/issues/7443>`_)
   * refactor(tier4_autoware_utils): Changed the API to be more intuitive and added documentation.
   * use raw shared ptr in PollingPolicy::NEWEST
   * update
@@ -47,21 +47,21 @@ Changelog for package autoware_velocity_smoother
   Co-authored-by: danielsanchezaran <daniel.sanchez@tier4.jp>
   ---------
   Co-authored-by: danielsanchezaran <daniel.sanchez@tier4.jp>
-* fix(autoware_velocity_smoother): fix shadowVariablefix:shadowVariable (`#7950 <https://github.com/youtalk/autoware.universe/issues/7950>`_)
+* fix(autoware_velocity_smoother): fix shadowVariablefix:shadowVariable (`#7950 <https://github.com/autowarefoundation/autoware.universe/issues/7950>`_)
   fix:shadowVariable
-* feat(velocity_smoother): add time_keeper (`#8026 <https://github.com/youtalk/autoware.universe/issues/8026>`_)
-* refactor(velocity_smoother): change method to take data for external velocity (`#7810 <https://github.com/youtalk/autoware.universe/issues/7810>`_)
+* feat(velocity_smoother): add time_keeper (`#8026 <https://github.com/autowarefoundation/autoware.universe/issues/8026>`_)
+* refactor(velocity_smoother): change method to take data for external velocity (`#7810 <https://github.com/autowarefoundation/autoware.universe/issues/7810>`_)
   refactor external velocity
-* fix(autoware_velocity_smoother): fix duplicateBreak warning (`#7699 <https://github.com/youtalk/autoware.universe/issues/7699>`_)
-* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/youtalk/autoware.universe/issues/7594>`_)
-* fix(autoware_velocity_smoother): fix unusedVariable warning (`#7585 <https://github.com/youtalk/autoware.universe/issues/7585>`_)
+* fix(autoware_velocity_smoother): fix duplicateBreak warning (`#7699 <https://github.com/autowarefoundation/autoware.universe/issues/7699>`_)
+* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/autowarefoundation/autoware.universe/issues/7594>`_)
+* fix(autoware_velocity_smoother): fix unusedVariable warning (`#7585 <https://github.com/autowarefoundation/autoware.universe/issues/7585>`_)
   fix unusedVariable warning
-* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/youtalk/autoware.universe/issues/7539>`_)
+* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/autowarefoundation/autoware.universe/issues/7539>`_)
   refactor(motion_utils): add autoware prefix and include dir
-* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/youtalk/autoware.universe/issues/7538>`_)
+* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/autowarefoundation/autoware.universe/issues/7538>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* refactor(velocity_smoother): rename to include/autoware/{package_name} (`#7533 <https://github.com/youtalk/autoware.universe/issues/7533>`_)
-* refactor(test_utils): move to common folder (`#7158 <https://github.com/youtalk/autoware.universe/issues/7158>`_)
+* refactor(velocity_smoother): rename to include/autoware/{package_name} (`#7533 <https://github.com/autowarefoundation/autoware.universe/issues/7533>`_)
+* refactor(test_utils): move to common folder (`#7158 <https://github.com/autowarefoundation/autoware.universe/issues/7158>`_)
   * Move autoware planning test manager to autoware namespace
   * fix package share directory for behavior path planner
   * renaming files and directory
@@ -73,7 +73,7 @@ Changelog for package autoware_velocity_smoother
   * removed obstacle velocity limiter test artifact
   * remove namespace from planning validator, it has using keyword
   ---------
-* refactor(vehicle_info_utils)!: prefix package and namespace with autoware (`#7353 <https://github.com/youtalk/autoware.universe/issues/7353>`_)
+* refactor(vehicle_info_utils)!: prefix package and namespace with autoware (`#7353 <https://github.com/autowarefoundation/autoware.universe/issues/7353>`_)
   * chore(autoware_vehicle_info_utils): rename header
   * chore(bpp-common): vehicle info
   * chore(path_optimizer): vehicle info
@@ -108,17 +108,17 @@ Changelog for package autoware_velocity_smoother
   * chore(sensing): vehicle info
   * fix(autoware_joy_controller): remove unused deps
   ---------
-* feat(autoware_velocity_smoother): use polling subscriber (`#7216 <https://github.com/youtalk/autoware.universe/issues/7216>`_)
+* feat(autoware_velocity_smoother): use polling subscriber (`#7216 <https://github.com/autowarefoundation/autoware.universe/issues/7216>`_)
   feat(motion_velocity_smoother): use polling subscriber
-* refactor(path_optimizer, velocity_smoother)!: prefix package and namespace with autoware (`#7354 <https://github.com/youtalk/autoware.universe/issues/7354>`_)
+* refactor(path_optimizer, velocity_smoother)!: prefix package and namespace with autoware (`#7354 <https://github.com/autowarefoundation/autoware.universe/issues/7354>`_)
   * chore(autoware_velocity_smoother): update namespace
   * chore(autoware_path_optimizer): update namespace
   ---------
-* feat!: replace autoware_auto_msgs with autoware_msgs for planning modules (`#7246 <https://github.com/youtalk/autoware.universe/issues/7246>`_)
+* feat!: replace autoware_auto_msgs with autoware_msgs for planning modules (`#7246 <https://github.com/autowarefoundation/autoware.universe/issues/7246>`_)
   Co-authored-by: Cynthia Liu <cynthia.liu@autocore.ai>
   Co-authored-by: NorahXiong <norah.xiong@autocore.ai>
   Co-authored-by: beginningfan <beginning.fan@autocore.ai>
-* chore(autoware_velocity_smoother, autoware_path_optimizer): rename packages (`#7202 <https://github.com/youtalk/autoware.universe/issues/7202>`_)
+* chore(autoware_velocity_smoother, autoware_path_optimizer): rename packages (`#7202 <https://github.com/autowarefoundation/autoware.universe/issues/7202>`_)
   * chore(autoware_path_optimizer): rename package and namespace
   * chore(autoware_static_centerline_generator): rename package and namespace
   * chore: update module name

--- a/planning/behavior_path_planner/autoware_behavior_path_avoidance_by_lane_change_module/CHANGELOG.rst
+++ b/planning/behavior_path_planner/autoware_behavior_path_avoidance_by_lane_change_module/CHANGELOG.rst
@@ -5,28 +5,28 @@ Changelog for package autoware_behavior_path_avoidance_by_lane_change_module
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* chore(avoidance_by_lane_change, external_request_lane_change): add maintainers (`#9027 <https://github.com/youtalk/autoware.universe/issues/9027>`_)
+* chore(avoidance_by_lane_change, external_request_lane_change): add maintainers (`#9027 <https://github.com/autowarefoundation/autoware.universe/issues/9027>`_)
   * add maintainers to avoidance by lane change
   * add maintainers to external request lane change
   ---------
-* fix(autoware_behavior_path_avoidance_by_lane_change_module): fix unmatchedSuppression (`#8987 <https://github.com/youtalk/autoware.universe/issues/8987>`_)
+* fix(autoware_behavior_path_avoidance_by_lane_change_module): fix unmatchedSuppression (`#8987 <https://github.com/autowarefoundation/autoware.universe/issues/8987>`_)
   fix:unmatchedSuppression
-* refactor(lane_change): add TransientData to store commonly used lane change-related variables. (`#8954 <https://github.com/youtalk/autoware.universe/issues/8954>`_)
+* refactor(lane_change): add TransientData to store commonly used lane change-related variables. (`#8954 <https://github.com/autowarefoundation/autoware.universe/issues/8954>`_)
   * add transient data
   * reverted max lc dist in  calcCurrentMinMax
   * rename
   * minor refactoring
   * update doxygen comments
   ---------
-* feat(lane_change): modify lane change target boundary check to consider velocity (`#8961 <https://github.com/youtalk/autoware.universe/issues/8961>`_)
+* feat(lane_change): modify lane change target boundary check to consider velocity (`#8961 <https://github.com/autowarefoundation/autoware.universe/issues/8961>`_)
   * check if candidate path footprint exceeds target lane boundary when lc velocity is above minimum
   * move functions to relevant module
   * suppress unused function cppcheck
   * minor change
   ---------
-* fix(static_obstacle_avoidance, avoidance_by_lane_change): remove unused variable (`#8926 <https://github.com/youtalk/autoware.universe/issues/8926>`_)
+* fix(static_obstacle_avoidance, avoidance_by_lane_change): remove unused variable (`#8926 <https://github.com/autowarefoundation/autoware.universe/issues/8926>`_)
   remove unused variables
-* feat(lane_change): improve execution condition of lane change module (`#8648 <https://github.com/youtalk/autoware.universe/issues/8648>`_)
+* feat(lane_change): improve execution condition of lane change module (`#8648 <https://github.com/autowarefoundation/autoware.universe/issues/8648>`_)
   * refactor lane change utility funcions
   * LC utility function to get distance to next regulatory element
   * don't activate LC module when close to regulatory element
@@ -39,8 +39,8 @@ Changelog for package autoware_behavior_path_avoidance_by_lane_change_module
   * update readme
   * check distance to reg element for candidate path only if not near terminal start
   ---------
-* fix(bpp): use common steering factor interface for same scene modules (`#8675 <https://github.com/youtalk/autoware.universe/issues/8675>`_)
-* refactor(lane_change): update lanes and its polygons only  when it's updated (`#7989 <https://github.com/youtalk/autoware.universe/issues/7989>`_)
+* fix(bpp): use common steering factor interface for same scene modules (`#8675 <https://github.com/autowarefoundation/autoware.universe/issues/8675>`_)
+* refactor(lane_change): update lanes and its polygons only  when it's updated (`#7989 <https://github.com/autowarefoundation/autoware.universe/issues/7989>`_)
   * refactor(lane_change): compute lanes and polygon only when updated
   * Revert accidental changesd
   This reverts commit cbfd9ae8a88b2d6c3b27b35c9a08bb824ecd5011.
@@ -49,24 +49,24 @@ Changelog for package autoware_behavior_path_avoidance_by_lane_change_module
   * add target lanes getter
   * some minor function refactoring
   ---------
-* fix(static_obstacle_avoidance): don't automatically avoid ambiguous vehicle (`#7851 <https://github.com/youtalk/autoware.universe/issues/7851>`_)
+* fix(static_obstacle_avoidance): don't automatically avoid ambiguous vehicle (`#7851 <https://github.com/autowarefoundation/autoware.universe/issues/7851>`_)
   * fix(static_obstacle_avoidance): don't automatically avoid ambiguous vehicle
   * chore(schema): update schema
   ---------
-* fix(static_obstacle_avoidance): stop position is unstable (`#7880 <https://github.com/youtalk/autoware.universe/issues/7880>`_)
+* fix(static_obstacle_avoidance): stop position is unstable (`#7880 <https://github.com/autowarefoundation/autoware.universe/issues/7880>`_)
   fix(static_obstacle_avoidance): fix stop position
-* feat(safety_check): filter safety check targe objects by yaw deviation between pose and lane (`#7828 <https://github.com/youtalk/autoware.universe/issues/7828>`_)
+* feat(safety_check): filter safety check targe objects by yaw deviation between pose and lane (`#7828 <https://github.com/autowarefoundation/autoware.universe/issues/7828>`_)
   * fix(safety_check): filter by yaw deviation to check object belongs to lane
   * fix(static_obstacle_avoidance): check yaw only when the object is moving
   ---------
-* fix(behavior_path_planner, behavior_velocity_planner): fix redefinition errors (`#7688 <https://github.com/youtalk/autoware.universe/issues/7688>`_)
-* feat: add `autoware\_` prefix to `lanelet2_extension` (`#7640 <https://github.com/youtalk/autoware.universe/issues/7640>`_)
-* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/youtalk/autoware.universe/issues/7594>`_)
-* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/youtalk/autoware.universe/issues/7539>`_)
+* fix(behavior_path_planner, behavior_velocity_planner): fix redefinition errors (`#7688 <https://github.com/autowarefoundation/autoware.universe/issues/7688>`_)
+* feat: add `autoware\_` prefix to `lanelet2_extension` (`#7640 <https://github.com/autowarefoundation/autoware.universe/issues/7640>`_)
+* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/autowarefoundation/autoware.universe/issues/7594>`_)
+* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/autowarefoundation/autoware.universe/issues/7539>`_)
   refactor(motion_utils): add autoware prefix and include dir
-* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/youtalk/autoware.universe/issues/7538>`_)
+* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/autowarefoundation/autoware.universe/issues/7538>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* refactor(behaivor_path_planner)!: rename to include/autoware/{package_name} (`#7522 <https://github.com/youtalk/autoware.universe/issues/7522>`_)
+* refactor(behaivor_path_planner)!: rename to include/autoware/{package_name} (`#7522 <https://github.com/autowarefoundation/autoware.universe/issues/7522>`_)
   * refactor(behavior_path_planner)!: make autoware dir in include
   * refactor(start_planner): make autoware include dir
   * refactor(goal_planner): make autoware include dir

--- a/planning/behavior_path_planner/autoware_behavior_path_dynamic_obstacle_avoidance_module/CHANGELOG.rst
+++ b/planning/behavior_path_planner/autoware_behavior_path_dynamic_obstacle_avoidance_module/CHANGELOG.rst
@@ -5,11 +5,11 @@ Changelog for package autoware_behavior_path_dynamic_obstacle_avoidance_module
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* refactor(object_recognition_utils): add autoware prefix to object_recognition_utils (`#8946 <https://github.com/youtalk/autoware.universe/issues/8946>`_)
-* refactor(signal_processing): prefix package and namespace with autoware (`#8541 <https://github.com/youtalk/autoware.universe/issues/8541>`_)
-* fix(autoware_behavior_path_planner): align the parameters with launcher (`#8790 <https://github.com/youtalk/autoware.universe/issues/8790>`_)
+* refactor(object_recognition_utils): add autoware prefix to object_recognition_utils (`#8946 <https://github.com/autowarefoundation/autoware.universe/issues/8946>`_)
+* refactor(signal_processing): prefix package and namespace with autoware (`#8541 <https://github.com/autowarefoundation/autoware.universe/issues/8541>`_)
+* fix(autoware_behavior_path_planner): align the parameters with launcher (`#8790 <https://github.com/autowarefoundation/autoware.universe/issues/8790>`_)
   parameters in behavior_path_planner aligned
-* feat(autoware_behavior_path_dynamic_obstacle_avoidance): expand drivable area (`#8295 <https://github.com/youtalk/autoware.universe/issues/8295>`_)
+* feat(autoware_behavior_path_dynamic_obstacle_avoidance): expand drivable area (`#8295 <https://github.com/autowarefoundation/autoware.universe/issues/8295>`_)
   * add expansion drivable area feature
   * make expansion optional
   * style(pre-commit): autofix
@@ -17,23 +17,23 @@ Changelog for package autoware_behavior_path_dynamic_obstacle_avoidance_module
   * style(pre-commit): autofix
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* fix(bpp): use common steering factor interface for same scene modules (`#8675 <https://github.com/youtalk/autoware.universe/issues/8675>`_)
-* fix(autoware_behavior_path_dynamic_obstacle_avoidance_module): fix unusedFunction (`#8652 <https://github.com/youtalk/autoware.universe/issues/8652>`_)
+* fix(bpp): use common steering factor interface for same scene modules (`#8675 <https://github.com/autowarefoundation/autoware.universe/issues/8675>`_)
+* fix(autoware_behavior_path_dynamic_obstacle_avoidance_module): fix unusedFunction (`#8652 <https://github.com/autowarefoundation/autoware.universe/issues/8652>`_)
   fix:unusedFunction
-* feat(behavior_path _planner): divide planner manager modules into dependent slots (`#8117 <https://github.com/youtalk/autoware.universe/issues/8117>`_)
-* perf(dynamic_obstacle_avoidance): decrease the computation time with time_keeper (`#7986 <https://github.com/youtalk/autoware.universe/issues/7986>`_)
+* feat(behavior_path _planner): divide planner manager modules into dependent slots (`#8117 <https://github.com/autowarefoundation/autoware.universe/issues/8117>`_)
+* perf(dynamic_obstacle_avoidance): decrease the computation time with time_keeper (`#7986 <https://github.com/autowarefoundation/autoware.universe/issues/7986>`_)
   * decrease computation cost
   * remove TODO
   * fix
   ---------
-* feat: add `autoware\_` prefix to `lanelet2_extension` (`#7640 <https://github.com/youtalk/autoware.universe/issues/7640>`_)
-* fix(autoware_behavior_path_dynamic_obstacle_avoidance_module): fix bitwiseOnBoolean warning (`#7636 <https://github.com/youtalk/autoware.universe/issues/7636>`_)
-* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/youtalk/autoware.universe/issues/7594>`_)
-* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/youtalk/autoware.universe/issues/7539>`_)
+* feat: add `autoware\_` prefix to `lanelet2_extension` (`#7640 <https://github.com/autowarefoundation/autoware.universe/issues/7640>`_)
+* fix(autoware_behavior_path_dynamic_obstacle_avoidance_module): fix bitwiseOnBoolean warning (`#7636 <https://github.com/autowarefoundation/autoware.universe/issues/7636>`_)
+* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/autowarefoundation/autoware.universe/issues/7594>`_)
+* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/autowarefoundation/autoware.universe/issues/7539>`_)
   refactor(motion_utils): add autoware prefix and include dir
-* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/youtalk/autoware.universe/issues/7538>`_)
+* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/autowarefoundation/autoware.universe/issues/7538>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* refactor(behaivor_path_planner)!: rename to include/autoware/{package_name} (`#7522 <https://github.com/youtalk/autoware.universe/issues/7522>`_)
+* refactor(behaivor_path_planner)!: rename to include/autoware/{package_name} (`#7522 <https://github.com/autowarefoundation/autoware.universe/issues/7522>`_)
   * refactor(behavior_path_planner)!: make autoware dir in include
   * refactor(start_planner): make autoware include dir
   * refactor(goal_planner): make autoware include dir

--- a/planning/behavior_path_planner/autoware_behavior_path_external_request_lane_change_module/CHANGELOG.rst
+++ b/planning/behavior_path_planner/autoware_behavior_path_external_request_lane_change_module/CHANGELOG.rst
@@ -5,19 +5,19 @@ Changelog for package autoware_behavior_path_external_request_lane_change_module
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* chore(avoidance_by_lane_change, external_request_lane_change): add maintainers (`#9027 <https://github.com/youtalk/autoware.universe/issues/9027>`_)
+* chore(avoidance_by_lane_change, external_request_lane_change): add maintainers (`#9027 <https://github.com/autowarefoundation/autoware.universe/issues/9027>`_)
   * add maintainers to avoidance by lane change
   * add maintainers to external request lane change
   ---------
-* fix(bpp): use common steering factor interface for same scene modules (`#8675 <https://github.com/youtalk/autoware.universe/issues/8675>`_)
-* feat: add `autoware\_` prefix to `lanelet2_extension` (`#7640 <https://github.com/youtalk/autoware.universe/issues/7640>`_)
-* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/youtalk/autoware.universe/issues/7539>`_)
+* fix(bpp): use common steering factor interface for same scene modules (`#8675 <https://github.com/autowarefoundation/autoware.universe/issues/8675>`_)
+* feat: add `autoware\_` prefix to `lanelet2_extension` (`#7640 <https://github.com/autowarefoundation/autoware.universe/issues/7640>`_)
+* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/autowarefoundation/autoware.universe/issues/7539>`_)
   refactor(motion_utils): add autoware prefix and include dir
-* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/youtalk/autoware.universe/issues/7538>`_)
+* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/autowarefoundation/autoware.universe/issues/7538>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* refactor(route_handler)!: rename to include/autoware/{package_name}  (`#7530 <https://github.com/youtalk/autoware.universe/issues/7530>`_)
+* refactor(route_handler)!: rename to include/autoware/{package_name}  (`#7530 <https://github.com/autowarefoundation/autoware.universe/issues/7530>`_)
   refactor(route_handler)!: rename to include/autoware/{package_name}
-* refactor(behaivor_path_planner)!: rename to include/autoware/{package_name} (`#7522 <https://github.com/youtalk/autoware.universe/issues/7522>`_)
+* refactor(behaivor_path_planner)!: rename to include/autoware/{package_name} (`#7522 <https://github.com/autowarefoundation/autoware.universe/issues/7522>`_)
   * refactor(behavior_path_planner)!: make autoware dir in include
   * refactor(start_planner): make autoware include dir
   * refactor(goal_planner): make autoware include dir

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/CHANGELOG.rst
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/CHANGELOG.rst
@@ -5,57 +5,57 @@ Changelog for package autoware_behavior_path_goal_planner_module
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* feat(goal_planner): align vehicle footprint heading parallel to parking side lane boundary (`#9159 <https://github.com/youtalk/autoware.universe/issues/9159>`_)
-* chore(goal_planner): compare sampled/filtered candidate paths on plot (`#9140 <https://github.com/youtalk/autoware.universe/issues/9140>`_)
+* feat(goal_planner): align vehicle footprint heading parallel to parking side lane boundary (`#9159 <https://github.com/autowarefoundation/autoware.universe/issues/9159>`_)
+* chore(goal_planner): compare sampled/filtered candidate paths on plot (`#9140 <https://github.com/autowarefoundation/autoware.universe/issues/9140>`_)
   Co-authored-by: Kosuke Takeuchi <kosuke.tnp@gmail.com>
-* feat(goal_planner): use vehicle side edge to check isCrossingPossible for pull over execution (`#9102 <https://github.com/youtalk/autoware.universe/issues/9102>`_)
-* feat(autoware_test_utils): move test_map, add launcher for test_map (`#9045 <https://github.com/youtalk/autoware.universe/issues/9045>`_)
-* refactor(goal_planner): move last_previous_module_output_path out of ThreadSafeData (`#9075 <https://github.com/youtalk/autoware.universe/issues/9075>`_)
-* refactor(bpp_common, motion_utils): move path shifter util functions to autoware::motion_utils (`#9081 <https://github.com/youtalk/autoware.universe/issues/9081>`_)
+* feat(goal_planner): use vehicle side edge to check isCrossingPossible for pull over execution (`#9102 <https://github.com/autowarefoundation/autoware.universe/issues/9102>`_)
+* feat(autoware_test_utils): move test_map, add launcher for test_map (`#9045 <https://github.com/autowarefoundation/autoware.universe/issues/9045>`_)
+* refactor(goal_planner): move last_previous_module_output_path out of ThreadSafeData (`#9075 <https://github.com/autowarefoundation/autoware.universe/issues/9075>`_)
+* refactor(bpp_common, motion_utils): move path shifter util functions to autoware::motion_utils (`#9081 <https://github.com/autowarefoundation/autoware.universe/issues/9081>`_)
   * remove unused function
   * mover path shifter utils function to autoware motion utils
   * minor change in license header
   * fix warning message
   * remove header file
   ---------
-* refactor(goal_planner): remove prev_data / last_path_idx_time from ThreadSafeData (`#9064 <https://github.com/youtalk/autoware.universe/issues/9064>`_)
+* refactor(goal_planner): remove prev_data / last_path_idx_time from ThreadSafeData (`#9064 <https://github.com/autowarefoundation/autoware.universe/issues/9064>`_)
   refactor(goal_planner): remove prev_data and last_path_idx_update_time
-* refactor(goal_planner): remove lane parking pull over path (`#9063 <https://github.com/youtalk/autoware.universe/issues/9063>`_)
-* refactor(goal_planner): remove modified_goal in ThreadDafeData (`#9010 <https://github.com/youtalk/autoware.universe/issues/9010>`_)
-* refactor(goal planner): hold modified_goal in PullOverPath ,copy modified goal once from background thread (`#9006 <https://github.com/youtalk/autoware.universe/issues/9006>`_)
+* refactor(goal_planner): remove lane parking pull over path (`#9063 <https://github.com/autowarefoundation/autoware.universe/issues/9063>`_)
+* refactor(goal_planner): remove modified_goal in ThreadDafeData (`#9010 <https://github.com/autowarefoundation/autoware.universe/issues/9010>`_)
+* refactor(goal planner): hold modified_goal in PullOverPath ,copy modified goal once from background thread (`#9006 <https://github.com/autowarefoundation/autoware.universe/issues/9006>`_)
   refactor(goal_planner): save modified_goal_pose in PullOverPlannerBase
-* fix(behavior_path_planner_common): swap boolean for filterObjectsByVelocity (`#9036 <https://github.com/youtalk/autoware.universe/issues/9036>`_)
+* fix(behavior_path_planner_common): swap boolean for filterObjectsByVelocity (`#9036 <https://github.com/autowarefoundation/autoware.universe/issues/9036>`_)
   fix filter object by velocity
-* fix(goal_planner): fix parking_path curvature and DecidingState transition (`#9022 <https://github.com/youtalk/autoware.universe/issues/9022>`_)
-* refactor(goal_planner): use the PullOverPath, PullOverPathCandidates copied from ThreadData to reduce access (`#8994 <https://github.com/youtalk/autoware.universe/issues/8994>`_)
-* refactor(goal_planner): remove unused header and divide ThreadSafeData to another file (`#8990 <https://github.com/youtalk/autoware.universe/issues/8990>`_)
-* refactor(goal_planner): refactor PullOverPlannseBase to instantiate only valid path (`#8983 <https://github.com/youtalk/autoware.universe/issues/8983>`_)
-* fix(goal_planner): fix freespace planning chattering (`#8981 <https://github.com/youtalk/autoware.universe/issues/8981>`_)
-* feat(goal_planner): use neighboring lane of pull over lane to check goal footprint (`#8716 <https://github.com/youtalk/autoware.universe/issues/8716>`_)
+* fix(goal_planner): fix parking_path curvature and DecidingState transition (`#9022 <https://github.com/autowarefoundation/autoware.universe/issues/9022>`_)
+* refactor(goal_planner): use the PullOverPath, PullOverPathCandidates copied from ThreadData to reduce access (`#8994 <https://github.com/autowarefoundation/autoware.universe/issues/8994>`_)
+* refactor(goal_planner): remove unused header and divide ThreadSafeData to another file (`#8990 <https://github.com/autowarefoundation/autoware.universe/issues/8990>`_)
+* refactor(goal_planner): refactor PullOverPlannseBase to instantiate only valid path (`#8983 <https://github.com/autowarefoundation/autoware.universe/issues/8983>`_)
+* fix(goal_planner): fix freespace planning chattering (`#8981 <https://github.com/autowarefoundation/autoware.universe/issues/8981>`_)
+* feat(goal_planner): use neighboring lane of pull over lane to check goal footprint (`#8716 <https://github.com/autowarefoundation/autoware.universe/issues/8716>`_)
   move to utils and add tests
-* refactor(goal_planner): remove unnecessary GoalPlannerData member (`#8920 <https://github.com/youtalk/autoware.universe/issues/8920>`_)
-* feat(goal_planner): move PathDecidingStatus to other controller class (`#8872 <https://github.com/youtalk/autoware.universe/issues/8872>`_)
-* chore(planning): consistent parameters with autoware_launch (`#8915 <https://github.com/youtalk/autoware.universe/issues/8915>`_)
+* refactor(goal_planner): remove unnecessary GoalPlannerData member (`#8920 <https://github.com/autowarefoundation/autoware.universe/issues/8920>`_)
+* feat(goal_planner): move PathDecidingStatus to other controller class (`#8872 <https://github.com/autowarefoundation/autoware.universe/issues/8872>`_)
+* chore(planning): consistent parameters with autoware_launch (`#8915 <https://github.com/autowarefoundation/autoware.universe/issues/8915>`_)
   * chore(planning): consistent parameters with autoware_launch
   * update
   * fix json schema
   ---------
-* fix(goal_planner): fix typo (`#8910 <https://github.com/youtalk/autoware.universe/issues/8910>`_)
-* fix(autoware_behavior_path_goal_planner_module): fix unusedFunction (`#8786 <https://github.com/youtalk/autoware.universe/issues/8786>`_)
+* fix(goal_planner): fix typo (`#8910 <https://github.com/autowarefoundation/autoware.universe/issues/8910>`_)
+* fix(autoware_behavior_path_goal_planner_module): fix unusedFunction (`#8786 <https://github.com/autowarefoundation/autoware.universe/issues/8786>`_)
   fix:unusedFunction
-* refactor(goal_planner): reduce call to isSafePath (`#8812 <https://github.com/youtalk/autoware.universe/issues/8812>`_)
-* feat(goal_planner): execute goal planner if previous module path terminal is pull over neighboring lane (`#8715 <https://github.com/youtalk/autoware.universe/issues/8715>`_)
-* feat(goal_planner):  dense goal candidate sampling in BusStopArea (`#8795 <https://github.com/youtalk/autoware.universe/issues/8795>`_)
-* fix(autoware_behavior_path_planner): align the parameters with launcher (`#8790 <https://github.com/youtalk/autoware.universe/issues/8790>`_)
+* refactor(goal_planner): reduce call to isSafePath (`#8812 <https://github.com/autowarefoundation/autoware.universe/issues/8812>`_)
+* feat(goal_planner): execute goal planner if previous module path terminal is pull over neighboring lane (`#8715 <https://github.com/autowarefoundation/autoware.universe/issues/8715>`_)
+* feat(goal_planner):  dense goal candidate sampling in BusStopArea (`#8795 <https://github.com/autowarefoundation/autoware.universe/issues/8795>`_)
+* fix(autoware_behavior_path_planner): align the parameters with launcher (`#8790 <https://github.com/autowarefoundation/autoware.universe/issues/8790>`_)
   parameters in behavior_path_planner aligned
-* feat(goal_planner): add getBusStopAreaPolygons (`#8794 <https://github.com/youtalk/autoware.universe/issues/8794>`_)
-* fix(autoware_behavior_path_goal_planner_module): fix unusedFunction (`#8775 <https://github.com/youtalk/autoware.universe/issues/8775>`_)
+* feat(goal_planner): add getBusStopAreaPolygons (`#8794 <https://github.com/autowarefoundation/autoware.universe/issues/8794>`_)
+* fix(autoware_behavior_path_goal_planner_module): fix unusedFunction (`#8775 <https://github.com/autowarefoundation/autoware.universe/issues/8775>`_)
   fix:unusedFunction
-* feat(behavior_path_goal planner): add example plot for development (`#8772 <https://github.com/youtalk/autoware.universe/issues/8772>`_)
-* fix(goal_planner): fix time_keeper race (`#8780 <https://github.com/youtalk/autoware.universe/issues/8780>`_)
-* fix(goal_planner): fix object extraction area (`#8764 <https://github.com/youtalk/autoware.universe/issues/8764>`_)
-* fix(goal_planner): fix typo (`#8763 <https://github.com/youtalk/autoware.universe/issues/8763>`_)
-* feat(goal_planner): extend pull over lanes inward to extract objects (`#8714 <https://github.com/youtalk/autoware.universe/issues/8714>`_)
+* feat(behavior_path_goal planner): add example plot for development (`#8772 <https://github.com/autowarefoundation/autoware.universe/issues/8772>`_)
+* fix(goal_planner): fix time_keeper race (`#8780 <https://github.com/autowarefoundation/autoware.universe/issues/8780>`_)
+* fix(goal_planner): fix object extraction area (`#8764 <https://github.com/autowarefoundation/autoware.universe/issues/8764>`_)
+* fix(goal_planner): fix typo (`#8763 <https://github.com/autowarefoundation/autoware.universe/issues/8763>`_)
+* feat(goal_planner): extend pull over lanes inward to extract objects (`#8714 <https://github.com/autowarefoundation/autoware.universe/issues/8714>`_)
   * feat(goal_planner): extend pull over lanes inward to extract objects
   * update from review
   * use optionale
@@ -66,17 +66,17 @@ Changelog for package autoware_behavior_path_goal_planner_module
   * pre-commit
   ---------
   Co-authored-by: Mamoru Sobue <mamoru.sobue@tier4.jp>
-* refactor(goal_planner): initialize parameter with free function (`#8712 <https://github.com/youtalk/autoware.universe/issues/8712>`_)
-* fix(bpp): use common steering factor interface for same scene modules (`#8675 <https://github.com/youtalk/autoware.universe/issues/8675>`_)
-* refactor(goal_planner): remove unnecessary member from PreviousPullOverData (`#8698 <https://github.com/youtalk/autoware.universe/issues/8698>`_)
-* refactor(goal_planner): remove unnecessary member from pull_over_planner (`#8697 <https://github.com/youtalk/autoware.universe/issues/8697>`_)
-* refactor(goal_planner): move pull_over_planner directory (`#8696 <https://github.com/youtalk/autoware.universe/issues/8696>`_)
-* fix(goal_planner): fix zero velocity in middle of path (`#8563 <https://github.com/youtalk/autoware.universe/issues/8563>`_)
+* refactor(goal_planner): initialize parameter with free function (`#8712 <https://github.com/autowarefoundation/autoware.universe/issues/8712>`_)
+* fix(bpp): use common steering factor interface for same scene modules (`#8675 <https://github.com/autowarefoundation/autoware.universe/issues/8675>`_)
+* refactor(goal_planner): remove unnecessary member from PreviousPullOverData (`#8698 <https://github.com/autowarefoundation/autoware.universe/issues/8698>`_)
+* refactor(goal_planner): remove unnecessary member from pull_over_planner (`#8697 <https://github.com/autowarefoundation/autoware.universe/issues/8697>`_)
+* refactor(goal_planner): move pull_over_planner directory (`#8696 <https://github.com/autowarefoundation/autoware.universe/issues/8696>`_)
+* fix(goal_planner): fix zero velocity in middle of path (`#8563 <https://github.com/autowarefoundation/autoware.universe/issues/8563>`_)
   * fix(goal_planner): fix zero velocity in middle of path
   * add comment
   ---------
-* fix(goal_planner): remove time keeper in non main thread (`#8610 <https://github.com/youtalk/autoware.universe/issues/8610>`_)
-* feat(freespace_planning_algorithms): implement option for backward search from goal to start (`#8091 <https://github.com/youtalk/autoware.universe/issues/8091>`_)
+* fix(goal_planner): remove time keeper in non main thread (`#8610 <https://github.com/autowarefoundation/autoware.universe/issues/8610>`_)
+* feat(freespace_planning_algorithms): implement option for backward search from goal to start (`#8091 <https://github.com/autowarefoundation/autoware.universe/issues/8091>`_)
   * refactor freespace planning algorithms
   * fix error
   * use vector instead of map for a-star node graph
@@ -142,37 +142,37 @@ Changelog for package autoware_behavior_path_goal_planner_module
   * minor refactor
   ---------
   Co-authored-by: Maxime CLEMENT <78338830+maxime-clem@users.noreply.github.com>
-* perf(goal_planner): faster path sorting and selection  (`#8457 <https://github.com/youtalk/autoware.universe/issues/8457>`_)
+* perf(goal_planner): faster path sorting and selection  (`#8457 <https://github.com/autowarefoundation/autoware.universe/issues/8457>`_)
   * perf(goal_planner): faster path sorting and selection
   * path_id_to_rough_margin_map
   ---------
-* refactor(behavior_path_planner): apply clang-tidy check (`#7549 <https://github.com/youtalk/autoware.universe/issues/7549>`_)
+* refactor(behavior_path_planner): apply clang-tidy check (`#7549 <https://github.com/autowarefoundation/autoware.universe/issues/7549>`_)
   * goal_planner
   * lane_change
   ---------
   Co-authored-by: Shumpei Wakabayashi <42209144+shmpwk@users.noreply.github.com>
-* perf(goal_planner): reduce unnecessary recursive lock guard (`#8465 <https://github.com/youtalk/autoware.universe/issues/8465>`_)
+* perf(goal_planner): reduce unnecessary recursive lock guard (`#8465 <https://github.com/autowarefoundation/autoware.universe/issues/8465>`_)
   * perf(goal_planner): reduce unnecessary recursive lock guard
   * make set_no_lock private
   ---------
-* fix(turn_signal, lane_change, goal_planner): add optional to tackle lane change turn signal and pull over turn signal (`#8463 <https://github.com/youtalk/autoware.universe/issues/8463>`_)
+* fix(turn_signal, lane_change, goal_planner): add optional to tackle lane change turn signal and pull over turn signal (`#8463 <https://github.com/autowarefoundation/autoware.universe/issues/8463>`_)
   * add optional to tackle LC turn signal and pull over turn signal
   * CPP file should not re-define default value; typo in copying from internal repos
   ---------
-* fix(goal_planner): fix lane departure check not working correctly due to uninitialized variable (`#8449 <https://github.com/youtalk/autoware.universe/issues/8449>`_)
-* fix(autoware_behavior_path_goal_planner_module): fix unreadVariable (`#8365 <https://github.com/youtalk/autoware.universe/issues/8365>`_)
+* fix(goal_planner): fix lane departure check not working correctly due to uninitialized variable (`#8449 <https://github.com/autowarefoundation/autoware.universe/issues/8449>`_)
+* fix(autoware_behavior_path_goal_planner_module): fix unreadVariable (`#8365 <https://github.com/autowarefoundation/autoware.universe/issues/8365>`_)
   fix:unreadVariable
-* feat(behavior_path _planner): divide planner manager modules into dependent slots (`#8117 <https://github.com/youtalk/autoware.universe/issues/8117>`_)
-* perf(goal_planner): reduce processing time  (`#8195 <https://github.com/youtalk/autoware.universe/issues/8195>`_)
+* feat(behavior_path _planner): divide planner manager modules into dependent slots (`#8117 <https://github.com/autowarefoundation/autoware.universe/issues/8117>`_)
+* perf(goal_planner): reduce processing time  (`#8195 <https://github.com/autowarefoundation/autoware.universe/issues/8195>`_)
   * perf(goal_palnner): reduce processing time
   * add const& return
   * use copy getter
   * pre commit
   ---------
-* fix(start/goal_planner): fix freespace planning error handling (`#8246 <https://github.com/youtalk/autoware.universe/issues/8246>`_)
-* feat(goal_planner): add time keeper (`#8194 <https://github.com/youtalk/autoware.universe/issues/8194>`_)
+* fix(start/goal_planner): fix freespace planning error handling (`#8246 <https://github.com/autowarefoundation/autoware.universe/issues/8246>`_)
+* feat(goal_planner): add time keeper (`#8194 <https://github.com/autowarefoundation/autoware.universe/issues/8194>`_)
   time keeper
-* refactor(freespace_planning_algorithm): refactor and improve astar search (`#8068 <https://github.com/youtalk/autoware.universe/issues/8068>`_)
+* refactor(freespace_planning_algorithm): refactor and improve astar search (`#8068 <https://github.com/autowarefoundation/autoware.universe/issues/8068>`_)
   * refactor freespace planning algorithms
   * fix error
   * use vector instead of map for a-star node graph
@@ -205,9 +205,9 @@ Changelog for package autoware_behavior_path_goal_planner_module
   * check goal pose validity before setting collision free distance map
   * declare variables as const where necessary
   ---------
-* fix(autoware_behavior_path_goal_planner_module): fix shadowVariable (`#7962 <https://github.com/youtalk/autoware.universe/issues/7962>`_)
+* fix(autoware_behavior_path_goal_planner_module): fix shadowVariable (`#7962 <https://github.com/autowarefoundation/autoware.universe/issues/7962>`_)
   fix:shadowVariable
-* fix(start/goal_planner): fix addition of duplicate segments in calcBeforeShiftedArcLength (`#7902 <https://github.com/youtalk/autoware.universe/issues/7902>`_)
+* fix(start/goal_planner): fix addition of duplicate segments in calcBeforeShiftedArcLength (`#7902 <https://github.com/autowarefoundation/autoware.universe/issues/7902>`_)
   * fix(start/goal_planner): fix addition of duplicate segments in calcBeforeShiftedArcLength
   * Update trajectory.hpp
   Co-authored-by: Kyoichi Sugahara <kyoichi.sugahara@tier4.jp>
@@ -215,24 +215,24 @@ Changelog for package autoware_behavior_path_goal_planner_module
   Co-authored-by: Kyoichi Sugahara <kyoichi.sugahara@tier4.jp>
   ---------
   Co-authored-by: Kyoichi Sugahara <kyoichi.sugahara@tier4.jp>
-* docs(goal_planner): update parameter description (`#7889 <https://github.com/youtalk/autoware.universe/issues/7889>`_)
+* docs(goal_planner): update parameter description (`#7889 <https://github.com/autowarefoundation/autoware.universe/issues/7889>`_)
   * docs(goal_planner): update parameter description
   * style(pre-commit): autofix
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat(goal_planner): prioritize pull over path by curvature (`#7791 <https://github.com/youtalk/autoware.universe/issues/7791>`_)
+* feat(goal_planner): prioritize pull over path by curvature (`#7791 <https://github.com/autowarefoundation/autoware.universe/issues/7791>`_)
   * feat(goal_planner): prioritize pull over path by curvature
   fix
   * add comment
   * pre commit
   ---------
   Co-authored-by: Mamoru Sobue <mamoru.sobue@tier4.jp>
-* feat(safety_check): filter safety check targe objects by yaw deviation between pose and lane (`#7828 <https://github.com/youtalk/autoware.universe/issues/7828>`_)
+* feat(safety_check): filter safety check targe objects by yaw deviation between pose and lane (`#7828 <https://github.com/autowarefoundation/autoware.universe/issues/7828>`_)
   * fix(safety_check): filter by yaw deviation to check object belongs to lane
   * fix(static_obstacle_avoidance): check yaw only when the object is moving
   ---------
-* feat: add `autoware\_` prefix to `lanelet2_extension` (`#7640 <https://github.com/youtalk/autoware.universe/issues/7640>`_)
-* feat(start_planner): yaw threshold for rss check (`#7657 <https://github.com/youtalk/autoware.universe/issues/7657>`_)
+* feat: add `autoware\_` prefix to `lanelet2_extension` (`#7640 <https://github.com/autowarefoundation/autoware.universe/issues/7640>`_)
+* feat(start_planner): yaw threshold for rss check (`#7657 <https://github.com/autowarefoundation/autoware.universe/issues/7657>`_)
   * add param to customize yaw th
   * add param to other modules
   * docs
@@ -240,13 +240,13 @@ Changelog for package autoware_behavior_path_goal_planner_module
   * fix LC README
   * use normalized yaw diff
   ---------
-* fix(autoware_behavior_path_goal_planner_module): fix lateral_offset related warnings (`#7624 <https://github.com/youtalk/autoware.universe/issues/7624>`_)
-* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/youtalk/autoware.universe/issues/7594>`_)
-* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/youtalk/autoware.universe/issues/7539>`_)
+* fix(autoware_behavior_path_goal_planner_module): fix lateral_offset related warnings (`#7624 <https://github.com/autowarefoundation/autoware.universe/issues/7624>`_)
+* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/autowarefoundation/autoware.universe/issues/7594>`_)
+* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/autowarefoundation/autoware.universe/issues/7539>`_)
   refactor(motion_utils): add autoware prefix and include dir
-* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/youtalk/autoware.universe/issues/7538>`_)
+* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/autowarefoundation/autoware.universe/issues/7538>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* refactor(freespace_planner)!: rename to include/autoware/{package_name}  (`#7525 <https://github.com/youtalk/autoware.universe/issues/7525>`_)
+* refactor(freespace_planner)!: rename to include/autoware/{package_name}  (`#7525 <https://github.com/autowarefoundation/autoware.universe/issues/7525>`_)
   refactor(freespace_planner)!: rename to include/autoware/{package_name}
   refactor(start_planner): make autoware include dir
   refactor(goal_planner): make autoware include dir
@@ -263,14 +263,14 @@ Changelog for package autoware_behavior_path_goal_planner_module
   fix build
   autoware_freespace_planner
   freespace_planning_algorithms
-* refactor(control)!: refactor directory structures of the control checkers (`#7524 <https://github.com/youtalk/autoware.universe/issues/7524>`_)
+* refactor(control)!: refactor directory structures of the control checkers (`#7524 <https://github.com/autowarefoundation/autoware.universe/issues/7524>`_)
   * aeb
   * control_validator
   * lane_departure_checker
   * shift_decider
   * fix
   ---------
-* refactor(behaivor_path_planner)!: rename to include/autoware/{package_name} (`#7522 <https://github.com/youtalk/autoware.universe/issues/7522>`_)
+* refactor(behaivor_path_planner)!: rename to include/autoware/{package_name} (`#7522 <https://github.com/autowarefoundation/autoware.universe/issues/7522>`_)
   * refactor(behavior_path_planner)!: make autoware dir in include
   * refactor(start_planner): make autoware include dir
   * refactor(goal_planner): make autoware include dir

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/CHANGELOG.rst
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/CHANGELOG.rst
@@ -5,14 +5,14 @@ Changelog for package autoware_behavior_path_lane_change_module
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* fix(behavior_path_planner, behavior_velocity_planner): fix to not read invalid ID (`#9103 <https://github.com/youtalk/autoware.universe/issues/9103>`_)
+* fix(behavior_path_planner, behavior_velocity_planner): fix to not read invalid ID (`#9103 <https://github.com/autowarefoundation/autoware.universe/issues/9103>`_)
   * fix(behavior_path_planner, behavior_velocity_planner): fix to not read invalid ID
   * style(pre-commit): autofix
   * fix typo
   * fix(behavior_path_planner, behavior_velocity_planner): fix typo and indentation
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* refactor(lane_change): refactor longitudinal acceleration sampling (`#9091 <https://github.com/youtalk/autoware.universe/issues/9091>`_)
+* refactor(lane_change): refactor longitudinal acceleration sampling (`#9091 <https://github.com/autowarefoundation/autoware.universe/issues/9091>`_)
   * fix calc_all_max_lc_lengths function
   * remove unused functions
   * remove limit on velocity in calc_all_max_lc_lengths function
@@ -21,11 +21,11 @@ Changelog for package autoware_behavior_path_lane_change_module
   * check for zero value prepare duration
   * refactor calc_lon_acceleration_samples function
   ---------
-* feat(autoware_test_utils): add path with lane id parser (`#9098 <https://github.com/youtalk/autoware.universe/issues/9098>`_)
+* feat(autoware_test_utils): add path with lane id parser (`#9098 <https://github.com/autowarefoundation/autoware.universe/issues/9098>`_)
   * add path with lane id parser
   * refactor parse to use template
   ---------
-* feat(lane_change): add unit test for normal lane change class (RT1-7970) (`#9090 <https://github.com/youtalk/autoware.universe/issues/9090>`_)
+* feat(lane_change): add unit test for normal lane change class (RT1-7970) (`#9090 <https://github.com/autowarefoundation/autoware.universe/issues/9090>`_)
   * RT1-7970 testing base class
   * additional test
   * Added update lanes
@@ -33,19 +33,19 @@ Changelog for package autoware_behavior_path_lane_change_module
   * check is lane change required
   * fix PRs comment
   ---------
-* refactor(lane_change): reducing clang-tidy warnings (`#9085 <https://github.com/youtalk/autoware.universe/issues/9085>`_)
+* refactor(lane_change): reducing clang-tidy warnings (`#9085 <https://github.com/autowarefoundation/autoware.universe/issues/9085>`_)
   * refactor(lane_change): reducing clang-tidy warnings
   * change function name to snake case
   ---------
-* refactor(object_recognition_utils): add autoware prefix to object_recognition_utils (`#8946 <https://github.com/youtalk/autoware.universe/issues/8946>`_)
-* refactor(bpp_common, motion_utils): move path shifter util functions to autoware::motion_utils (`#9081 <https://github.com/youtalk/autoware.universe/issues/9081>`_)
+* refactor(object_recognition_utils): add autoware prefix to object_recognition_utils (`#8946 <https://github.com/autowarefoundation/autoware.universe/issues/8946>`_)
+* refactor(bpp_common, motion_utils): move path shifter util functions to autoware::motion_utils (`#9081 <https://github.com/autowarefoundation/autoware.universe/issues/9081>`_)
   * remove unused function
   * mover path shifter utils function to autoware motion utils
   * minor change in license header
   * fix warning message
   * remove header file
   ---------
-* fix(lane_change): insert stop for current lanes object (RT0-33761)  (`#9070 <https://github.com/youtalk/autoware.universe/issues/9070>`_)
+* fix(lane_change): insert stop for current lanes object (RT0-33761)  (`#9070 <https://github.com/autowarefoundation/autoware.universe/issues/9070>`_)
   * RT0-33761 fix lc insert stop for current lanes object
   * fix wrong value used for comparison
   * ignore current lane object that is not on ego's path
@@ -60,11 +60,11 @@ Changelog for package autoware_behavior_path_lane_change_module
   * change color
   ---------
   Co-authored-by: mkquda <168697710+mkquda@users.noreply.github.com>
-* refactor(lane_change): refactor get_lane_change_lanes function (`#9044 <https://github.com/youtalk/autoware.universe/issues/9044>`_)
+* refactor(lane_change): refactor get_lane_change_lanes function (`#9044 <https://github.com/autowarefoundation/autoware.universe/issues/9044>`_)
   * refactor(lane_change): refactor get_lane_change_lanes function
   * Add doxygen comment for to_geom_msg_pose
   ---------
-* refactor(lane_change): replace any code that can use transient data (`#8999 <https://github.com/youtalk/autoware.universe/issues/8999>`_)
+* refactor(lane_change): replace any code that can use transient data (`#8999 <https://github.com/autowarefoundation/autoware.universe/issues/8999>`_)
   * RT1-8004 replace hasEnoughLength
   * RT1-8004 Removed isNearEndOfCurrentLanes
   * RT1-8004 refactor sample longitudinal acc values
@@ -80,7 +80,7 @@ Changelog for package autoware_behavior_path_lane_change_module
   * RT1-8004 Rename isVehicleStuck to is_ego_stuck()
   * RT1-8004 change calcPrepareDuration to snake case
   ---------
-* refactor(lane_change): refactor code using transient data (`#8997 <https://github.com/youtalk/autoware.universe/issues/8997>`_)
+* refactor(lane_change): refactor code using transient data (`#8997 <https://github.com/autowarefoundation/autoware.universe/issues/8997>`_)
   * add target lane length and ego arc length along current and target lanes to transient data
   * refactor code using transient data
   * refactor get_lane_change_paths function
@@ -88,36 +88,36 @@ Changelog for package autoware_behavior_path_lane_change_module
   * refactor util functions
   * refactor getPrepareSegment function
   ---------
-* refactor(bpp): simplify ExtendedPredictedObject and add new member variables (`#8889 <https://github.com/youtalk/autoware.universe/issues/8889>`_)
+* refactor(bpp): simplify ExtendedPredictedObject and add new member variables (`#8889 <https://github.com/autowarefoundation/autoware.universe/issues/8889>`_)
   * simplify ExtendedPredictedObject and add new member variables
   * replace self polygon to initial polygon
   * comment
   * add comments to dist of ego
   ---------
-* fix(lane_change): fix abort distance enough check (`#8979 <https://github.com/youtalk/autoware.universe/issues/8979>`_)
+* fix(lane_change): fix abort distance enough check (`#8979 <https://github.com/autowarefoundation/autoware.universe/issues/8979>`_)
   * RT1-7991 fix abort distance enough check
   * RT-7991 remove unused function
   ---------
-* refactor(lane_change): add TransientData to store commonly used lane change-related variables. (`#8954 <https://github.com/youtalk/autoware.universe/issues/8954>`_)
+* refactor(lane_change): add TransientData to store commonly used lane change-related variables. (`#8954 <https://github.com/autowarefoundation/autoware.universe/issues/8954>`_)
   * add transient data
   * reverted max lc dist in  calcCurrentMinMax
   * rename
   * minor refactoring
   * update doxygen comments
   ---------
-* feat(lane_change): modify lane change target boundary check to consider velocity (`#8961 <https://github.com/youtalk/autoware.universe/issues/8961>`_)
+* feat(lane_change): modify lane change target boundary check to consider velocity (`#8961 <https://github.com/autowarefoundation/autoware.universe/issues/8961>`_)
   * check if candidate path footprint exceeds target lane boundary when lc velocity is above minimum
   * move functions to relevant module
   * suppress unused function cppcheck
   * minor change
   ---------
-* fix(autoware_behavior_path_lane_change_module): fix unusedFunction (`#8960 <https://github.com/youtalk/autoware.universe/issues/8960>`_)
+* fix(autoware_behavior_path_lane_change_module): fix unusedFunction (`#8960 <https://github.com/autowarefoundation/autoware.universe/issues/8960>`_)
   * fix:unusedFunction
   * fix:unusedFunction
   * fix:unusedFunction
   * fix:pre_commit
   ---------
-* refactor(lane_change): refactor getLaneChangePaths function (`#8909 <https://github.com/youtalk/autoware.universe/issues/8909>`_)
+* refactor(lane_change): refactor getLaneChangePaths function (`#8909 <https://github.com/autowarefoundation/autoware.universe/issues/8909>`_)
   * refactor lane change utility funcions
   * LC utility function to get distance to next regulatory element
   * don't activate LC module when close to regulatory element
@@ -147,18 +147,18 @@ Changelog for package autoware_behavior_path_lane_change_module
   * add colors to flow chart in README
   ---------
   Co-authored-by: Zulfaqar Azmi <93502286+zulfaqar-azmi-t4@users.noreply.github.com>
-* refactor(autoware_interpolation): prefix package and namespace with autoware (`#8088 <https://github.com/youtalk/autoware.universe/issues/8088>`_)
+* refactor(autoware_interpolation): prefix package and namespace with autoware (`#8088 <https://github.com/autowarefoundation/autoware.universe/issues/8088>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* feat(lane_change): add checks to ensure the edge of vehicle do not exceed target lane boundary when changing lanes (`#8750 <https://github.com/youtalk/autoware.universe/issues/8750>`_)
+* feat(lane_change): add checks to ensure the edge of vehicle do not exceed target lane boundary when changing lanes (`#8750 <https://github.com/autowarefoundation/autoware.universe/issues/8750>`_)
   * check if LC candidate path footprint exceeds target lane far bound
   * add parameter to enable/disable check
   * check only lane changing section of cadidate path
   * fix spelling
   * small refactoring
   ---------
-* fix(lane_change): set initail rtc state properly (`#8902 <https://github.com/youtalk/autoware.universe/issues/8902>`_)
+* fix(lane_change): set initail rtc state properly (`#8902 <https://github.com/autowarefoundation/autoware.universe/issues/8902>`_)
   set initail rtc state properly
-* feat(lane_change): improve execution condition of lane change module (`#8648 <https://github.com/youtalk/autoware.universe/issues/8648>`_)
+* feat(lane_change): improve execution condition of lane change module (`#8648 <https://github.com/autowarefoundation/autoware.universe/issues/8648>`_)
   * refactor lane change utility funcions
   * LC utility function to get distance to next regulatory element
   * don't activate LC module when close to regulatory element
@@ -171,21 +171,21 @@ Changelog for package autoware_behavior_path_lane_change_module
   * update readme
   * check distance to reg element for candidate path only if not near terminal start
   ---------
-* feat(rtc_interface, lane_change): check state transition for cooperate status (`#8855 <https://github.com/youtalk/autoware.universe/issues/8855>`_)
+* feat(rtc_interface, lane_change): check state transition for cooperate status (`#8855 <https://github.com/autowarefoundation/autoware.universe/issues/8855>`_)
   * update rtc state transition
   * remove transition from failuer and succeeded
   * fix
   * check initial state for cooperate status
   * change rtc cooperate status according to module status
   ---------
-* fix(autoware_behavior_path_planner): align the parameters with launcher (`#8790 <https://github.com/youtalk/autoware.universe/issues/8790>`_)
+* fix(autoware_behavior_path_planner): align the parameters with launcher (`#8790 <https://github.com/autowarefoundation/autoware.universe/issues/8790>`_)
   parameters in behavior_path_planner aligned
-* fix(autoware_behavior_path_lane_change_module): fix unusedFunction (`#8653 <https://github.com/youtalk/autoware.universe/issues/8653>`_)
+* fix(autoware_behavior_path_lane_change_module): fix unusedFunction (`#8653 <https://github.com/autowarefoundation/autoware.universe/issues/8653>`_)
   fix:unusedFunction
-* fix(bpp): use common steering factor interface for same scene modules (`#8675 <https://github.com/youtalk/autoware.universe/issues/8675>`_)
-* fix(lane_change): update rtc status for some failure condition (`#8604 <https://github.com/youtalk/autoware.universe/issues/8604>`_)
+* fix(bpp): use common steering factor interface for same scene modules (`#8675 <https://github.com/autowarefoundation/autoware.universe/issues/8675>`_)
+* fix(lane_change): update rtc status for some failure condition (`#8604 <https://github.com/autowarefoundation/autoware.universe/issues/8604>`_)
   update rtc status for some failure condition
-* fix(lane_change): activate turn signal as soon as we have the intention to change lanes (`#8571 <https://github.com/youtalk/autoware.universe/issues/8571>`_)
+* fix(lane_change): activate turn signal as soon as we have the intention to change lanes (`#8571 <https://github.com/autowarefoundation/autoware.universe/issues/8571>`_)
   * modify lane change requested condition
   * modify lane change requested condition
   * Update planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/calculation.cpp
@@ -200,13 +200,13 @@ Changelog for package autoware_behavior_path_lane_change_module
   Co-authored-by: Muhammad Zulfaqar Azmi <zulfaqar.azmi@tier4.jp>
   Co-authored-by: Zulfaqar Azmi <93502286+zulfaqar-azmi-t4@users.noreply.github.com>
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat(lane_change): fix delay logic that caused timing to be late (`#8549 <https://github.com/youtalk/autoware.universe/issues/8549>`_)
+* feat(lane_change): fix delay logic that caused timing to be late (`#8549 <https://github.com/autowarefoundation/autoware.universe/issues/8549>`_)
   * RT1-5067 fix delay logic that caused timing to be late
   * remove autoware namespace
   Co-authored-by: Maxime CLEMENT <78338830+maxime-clem@users.noreply.github.com>
   ---------
   Co-authored-by: Maxime CLEMENT <78338830+maxime-clem@users.noreply.github.com>
-* fix(lane_change): modify lane change requested condition (`#8510 <https://github.com/youtalk/autoware.universe/issues/8510>`_)
+* fix(lane_change): modify lane change requested condition (`#8510 <https://github.com/autowarefoundation/autoware.universe/issues/8510>`_)
   * modify lane change requested condition
   * Update planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/calculation.cpp
   Co-authored-by: mkquda <168697710+mkquda@users.noreply.github.com>
@@ -215,7 +215,7 @@ Changelog for package autoware_behavior_path_lane_change_module
   ---------
   Co-authored-by: mkquda <168697710+mkquda@users.noreply.github.com>
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat(lane_change): consider deceleration in safety check for cancel (`#7943 <https://github.com/youtalk/autoware.universe/issues/7943>`_)
+* feat(lane_change): consider deceleration in safety check for cancel (`#7943 <https://github.com/autowarefoundation/autoware.universe/issues/7943>`_)
   * feat(lane_change): consider deceleration in safety check for cancel
   * docs(lane_change): fix document
   * fix conflicts and refactor
@@ -224,14 +224,14 @@ Changelog for package autoware_behavior_path_lane_change_module
   ---------
   Co-authored-by: Muhammad Zulfaqar Azmi <zulfaqar.azmi@tier4.jp>
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* refactor(lane_change): rename prepare_segment_ignore_object_velocity_thresh (`#8532 <https://github.com/youtalk/autoware.universe/issues/8532>`_)
+* refactor(lane_change): rename prepare_segment_ignore_object_velocity_thresh (`#8532 <https://github.com/autowarefoundation/autoware.universe/issues/8532>`_)
   change parameter name for more expressive name
-* refactor(behavior_path_planner): apply clang-tidy check (`#7549 <https://github.com/youtalk/autoware.universe/issues/7549>`_)
+* refactor(behavior_path_planner): apply clang-tidy check (`#7549 <https://github.com/autowarefoundation/autoware.universe/issues/7549>`_)
   * goal_planner
   * lane_change
   ---------
   Co-authored-by: Shumpei Wakabayashi <42209144+shmpwk@users.noreply.github.com>
-* feat(lane_change): ensure LC merging lane stop point is safe (`#8369 <https://github.com/youtalk/autoware.universe/issues/8369>`_)
+* feat(lane_change): ensure LC merging lane stop point is safe (`#8369 <https://github.com/autowarefoundation/autoware.universe/issues/8369>`_)
   * function to check for merging lane
   * function to compute distance from last fit width center line point to lane end
   * ensure lane width at LC stop point is larger than ego width
@@ -242,71 +242,71 @@ Changelog for package autoware_behavior_path_lane_change_module
   * minor refactoring
   * overload function isEgoWithinOriginalLane to pass lane polygon directly
   ---------
-* refactor(lane_change): update filtered objects only once (`#8489 <https://github.com/youtalk/autoware.universe/issues/8489>`_)
-* fix(lane_change): moving object is filtered in the extended target lanes (`#8218 <https://github.com/youtalk/autoware.universe/issues/8218>`_)
+* refactor(lane_change): update filtered objects only once (`#8489 <https://github.com/autowarefoundation/autoware.universe/issues/8489>`_)
+* fix(lane_change): moving object is filtered in the extended target lanes (`#8218 <https://github.com/autowarefoundation/autoware.universe/issues/8218>`_)
   * object 3rd
   * named param
   ---------
-* fix(lane_change): do not cancel when approaching terminal start (`#8381 <https://github.com/youtalk/autoware.universe/issues/8381>`_)
+* fix(lane_change): do not cancel when approaching terminal start (`#8381 <https://github.com/autowarefoundation/autoware.universe/issues/8381>`_)
   * do not cancel if ego vehicle approaching terminal start
   * Insert stop point if object is coming from rear
   * minor edit to fix conflict
   * rename function
   ---------
-* fix(lane_change): fix invalid doesn't have stop point (`#8470 <https://github.com/youtalk/autoware.universe/issues/8470>`_)
+* fix(lane_change): fix invalid doesn't have stop point (`#8470 <https://github.com/autowarefoundation/autoware.universe/issues/8470>`_)
   fix invalid doesn't have stop point
-* fix(lane_change): unify stuck detection to avoid unnecessary computation (`#8383 <https://github.com/youtalk/autoware.universe/issues/8383>`_)
+* fix(lane_change): unify stuck detection to avoid unnecessary computation (`#8383 <https://github.com/autowarefoundation/autoware.universe/issues/8383>`_)
   unify stuck detection in getLaneChangePaths
-* fix(turn_signal, lane_change, goal_planner): add optional to tackle lane change turn signal and pull over turn signal (`#8463 <https://github.com/youtalk/autoware.universe/issues/8463>`_)
+* fix(turn_signal, lane_change, goal_planner): add optional to tackle lane change turn signal and pull over turn signal (`#8463 <https://github.com/autowarefoundation/autoware.universe/issues/8463>`_)
   * add optional to tackle LC turn signal and pull over turn signal
   * CPP file should not re-define default value; typo in copying from internal repos
   ---------
-* refactor(lane_change): separate leading and trailing objects (`#8214 <https://github.com/youtalk/autoware.universe/issues/8214>`_)
+* refactor(lane_change): separate leading and trailing objects (`#8214 <https://github.com/autowarefoundation/autoware.universe/issues/8214>`_)
   * refactor(lane_change): separate leading and trailing objects
   * Refactor to use common function
   ---------
-* fix(lane_change): skip generating path if longitudinal distance difference is less than threshold (`#8363 <https://github.com/youtalk/autoware.universe/issues/8363>`_)
+* fix(lane_change): skip generating path if longitudinal distance difference is less than threshold (`#8363 <https://github.com/autowarefoundation/autoware.universe/issues/8363>`_)
   * fix when prepare length is insufficient
   * add reason for comparing prev_prep_diff with eps for lc_length_diff
   ---------
-* fix(lane_change): skip generating path if lane changing path is too long (`#8362 <https://github.com/youtalk/autoware.universe/issues/8362>`_)
+* fix(lane_change): skip generating path if lane changing path is too long (`#8362 <https://github.com/autowarefoundation/autoware.universe/issues/8362>`_)
   rework. skip lane changing for insufficeient distance in target lane
-* fix(lane_change): skip path computation if len exceed dist to terminal start (`#8359 <https://github.com/youtalk/autoware.universe/issues/8359>`_)
+* fix(lane_change): skip path computation if len exceed dist to terminal start (`#8359 <https://github.com/autowarefoundation/autoware.universe/issues/8359>`_)
   Skip computation if prepare length exceed distance to terminal start
-* refactor(lane_change): refactor  debug print when  computing paths (`#8358 <https://github.com/youtalk/autoware.universe/issues/8358>`_)
+* refactor(lane_change): refactor  debug print when  computing paths (`#8358 <https://github.com/autowarefoundation/autoware.universe/issues/8358>`_)
   Refactor debug print
-* chore(lane_change): add codeowner (`#8387 <https://github.com/youtalk/autoware.universe/issues/8387>`_)
-* refactor(lane_change): check start point directly after getting start point (`#8357 <https://github.com/youtalk/autoware.universe/issues/8357>`_)
+* chore(lane_change): add codeowner (`#8387 <https://github.com/autowarefoundation/autoware.universe/issues/8387>`_)
+* refactor(lane_change): check start point directly after getting start point (`#8357 <https://github.com/autowarefoundation/autoware.universe/issues/8357>`_)
   * check start point directly after getting start point
   * Update planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/scene.cpp
   Co-authored-by: Maxime CLEMENT <78338830+maxime-clem@users.noreply.github.com>
   ---------
   Co-authored-by: Maxime CLEMENT <78338830+maxime-clem@users.noreply.github.com>
-* feat(lane_change): use different rss param to deal with parked vehicle (`#8316 <https://github.com/youtalk/autoware.universe/issues/8316>`_)
+* feat(lane_change): use different rss param to deal with parked vehicle (`#8316 <https://github.com/autowarefoundation/autoware.universe/issues/8316>`_)
   * different rss value for parked vehicle
   * Documentation and config file update
   ---------
-* fix(lane_change): relax finish judge (`#8133 <https://github.com/youtalk/autoware.universe/issues/8133>`_)
+* fix(lane_change): relax finish judge (`#8133 <https://github.com/autowarefoundation/autoware.universe/issues/8133>`_)
   * fix(lane_change): relax finish judge
   * documentation update
   * update readme explanations
   * update config
   ---------
-* feat(lane_change): force deactivation in prepare phase (`#8235 <https://github.com/youtalk/autoware.universe/issues/8235>`_)
+* feat(lane_change): force deactivation in prepare phase (`#8235 <https://github.com/autowarefoundation/autoware.universe/issues/8235>`_)
   transfer to cancel state when force deactivated
-* fix(autoware_behavior_path_lane_change_module): fix passedByValue (`#8208 <https://github.com/youtalk/autoware.universe/issues/8208>`_)
+* fix(autoware_behavior_path_lane_change_module): fix passedByValue (`#8208 <https://github.com/autowarefoundation/autoware.universe/issues/8208>`_)
   fix:passedByValue
-* fix(lane_change): filtering object ahead of terminal (`#8093 <https://github.com/youtalk/autoware.universe/issues/8093>`_)
+* fix(lane_change): filtering object ahead of terminal (`#8093 <https://github.com/autowarefoundation/autoware.universe/issues/8093>`_)
   * employ lanelet based filtering before distance based filtering
   * use distance based to terminal check instead
   * remove RCLCPP INFO
   * update flow chart
   ---------
-* fix(lane_change): delay lane change cancel (`#8048 <https://github.com/youtalk/autoware.universe/issues/8048>`_)
+* fix(lane_change): delay lane change cancel (`#8048 <https://github.com/autowarefoundation/autoware.universe/issues/8048>`_)
   RT1-6955: delay lane change cancel
-* feat(lane_change): enable force execution under unsafe conditions (`#8131 <https://github.com/youtalk/autoware.universe/issues/8131>`_)
+* feat(lane_change): enable force execution under unsafe conditions (`#8131 <https://github.com/autowarefoundation/autoware.universe/issues/8131>`_)
   add force execution conditions
-* refactor(lane_change): update lanes and its polygons only  when it's updated (`#7989 <https://github.com/youtalk/autoware.universe/issues/7989>`_)
+* refactor(lane_change): update lanes and its polygons only  when it's updated (`#7989 <https://github.com/autowarefoundation/autoware.universe/issues/7989>`_)
   * refactor(lane_change): compute lanes and polygon only when updated
   * Revert accidental changesd
   This reverts commit cbfd9ae8a88b2d6c3b27b35c9a08bb824ecd5011.
@@ -315,21 +315,21 @@ Changelog for package autoware_behavior_path_lane_change_module
   * add target lanes getter
   * some minor function refactoring
   ---------
-* feat(autoware_behavior_path_planner_common,autoware_behavior_path_lane_change_module): add time_keeper to bpp (`#8004 <https://github.com/youtalk/autoware.universe/issues/8004>`_)
+* feat(autoware_behavior_path_planner_common,autoware_behavior_path_lane_change_module): add time_keeper to bpp (`#8004 <https://github.com/autowarefoundation/autoware.universe/issues/8004>`_)
   * feat(autoware_behavior_path_planner_common,autoware_behavior_path_lane_change_module): add time_keeper to bpp
   * update
   ---------
-* fix(autoware_behavior_path_lane_change_module): fix shadowVariable (`#7964 <https://github.com/youtalk/autoware.universe/issues/7964>`_)
+* fix(autoware_behavior_path_lane_change_module): fix shadowVariable (`#7964 <https://github.com/autowarefoundation/autoware.universe/issues/7964>`_)
   fix:shadowVariable
-* refactor(lane_change): move struct to lane change namespace (`#7841 <https://github.com/youtalk/autoware.universe/issues/7841>`_)
+* refactor(lane_change): move struct to lane change namespace (`#7841 <https://github.com/autowarefoundation/autoware.universe/issues/7841>`_)
   * move struct to lane change namespace
   * Revert "move struct to lane change namespace"
   This reverts commit 306984a76103c427732f170a6f7eb5f94e895b0b.
   ---------
-* feat: add `autoware\_` prefix to `lanelet2_extension` (`#7640 <https://github.com/youtalk/autoware.universe/issues/7640>`_)
-* fix(lane_change): prevent empty path when rerouting (`#7717 <https://github.com/youtalk/autoware.universe/issues/7717>`_)
+* feat: add `autoware\_` prefix to `lanelet2_extension` (`#7640 <https://github.com/autowarefoundation/autoware.universe/issues/7640>`_)
+* fix(lane_change): prevent empty path when rerouting (`#7717 <https://github.com/autowarefoundation/autoware.universe/issues/7717>`_)
   fix(lane_change): prevent empty path when routing
-* feat(start_planner): yaw threshold for rss check (`#7657 <https://github.com/youtalk/autoware.universe/issues/7657>`_)
+* feat(start_planner): yaw threshold for rss check (`#7657 <https://github.com/autowarefoundation/autoware.universe/issues/7657>`_)
   * add param to customize yaw th
   * add param to other modules
   * docs
@@ -337,18 +337,18 @@ Changelog for package autoware_behavior_path_lane_change_module
   * fix LC README
   * use normalized yaw diff
   ---------
-* refactor(lane_change): use lane change namespace for structs (`#7508 <https://github.com/youtalk/autoware.universe/issues/7508>`_)
+* refactor(lane_change): use lane change namespace for structs (`#7508 <https://github.com/autowarefoundation/autoware.universe/issues/7508>`_)
   * refactor(lane_change): use lane change namespace for structs
   * Move lane change namespace to bottom level
   ---------
-* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/youtalk/autoware.universe/issues/7594>`_)
-* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/youtalk/autoware.universe/issues/7539>`_)
+* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/autowarefoundation/autoware.universe/issues/7594>`_)
+* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/autowarefoundation/autoware.universe/issues/7539>`_)
   refactor(motion_utils): add autoware prefix and include dir
-* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/youtalk/autoware.universe/issues/7538>`_)
+* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/autowarefoundation/autoware.universe/issues/7538>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* refactor(route_handler)!: rename to include/autoware/{package_name}  (`#7530 <https://github.com/youtalk/autoware.universe/issues/7530>`_)
+* refactor(route_handler)!: rename to include/autoware/{package_name}  (`#7530 <https://github.com/autowarefoundation/autoware.universe/issues/7530>`_)
   refactor(route_handler)!: rename to include/autoware/{package_name}
-* refactor(behaivor_path_planner)!: rename to include/autoware/{package_name} (`#7522 <https://github.com/youtalk/autoware.universe/issues/7522>`_)
+* refactor(behaivor_path_planner)!: rename to include/autoware/{package_name} (`#7522 <https://github.com/autowarefoundation/autoware.universe/issues/7522>`_)
   * refactor(behavior_path_planner)!: make autoware dir in include
   * refactor(start_planner): make autoware include dir
   * refactor(goal_planner): make autoware include dir

--- a/planning/behavior_path_planner/autoware_behavior_path_planner/CHANGELOG.rst
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner/CHANGELOG.rst
@@ -5,41 +5,41 @@ Changelog for package autoware_behavior_path_planner
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* fix(autoware_behavior_path_planner): fix cppcheck unusedVariable (`#9193 <https://github.com/youtalk/autoware.universe/issues/9193>`_)
-* fix(behavior_path_planner): suppress reseting root lanelet (`#9129 <https://github.com/youtalk/autoware.universe/issues/9129>`_)
+* fix(autoware_behavior_path_planner): fix cppcheck unusedVariable (`#9193 <https://github.com/autowarefoundation/autoware.universe/issues/9193>`_)
+* fix(behavior_path_planner): suppress reseting root lanelet (`#9129 <https://github.com/autowarefoundation/autoware.universe/issues/9129>`_)
   fix(behavior_path_planner): suppress resseting root lanelet
-* refactor(object_recognition_utils): add autoware prefix to object_recognition_utils (`#8946 <https://github.com/youtalk/autoware.universe/issues/8946>`_)
-* test(bpp_common): add test for object related functions (`#9062 <https://github.com/youtalk/autoware.universe/issues/9062>`_)
+* refactor(object_recognition_utils): add autoware prefix to object_recognition_utils (`#8946 <https://github.com/autowarefoundation/autoware.universe/issues/8946>`_)
+* test(bpp_common): add test for object related functions (`#9062 <https://github.com/autowarefoundation/autoware.universe/issues/9062>`_)
   * add test for object related functions
   * use EXPECT_DOUBLE_EQ instead of EXPECT_NEAR
   * fix build error
   ---------
-* refactor(autoware_interpolation): prefix package and namespace with autoware (`#8088 <https://github.com/youtalk/autoware.universe/issues/8088>`_)
+* refactor(autoware_interpolation): prefix package and namespace with autoware (`#8088 <https://github.com/autowarefoundation/autoware.universe/issues/8088>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* refactor(signal_processing): prefix package and namespace with autoware (`#8541 <https://github.com/youtalk/autoware.universe/issues/8541>`_)
-* chore(planning): consistent parameters with autoware_launch (`#8915 <https://github.com/youtalk/autoware.universe/issues/8915>`_)
+* refactor(signal_processing): prefix package and namespace with autoware (`#8541 <https://github.com/autowarefoundation/autoware.universe/issues/8541>`_)
+* chore(planning): consistent parameters with autoware_launch (`#8915 <https://github.com/autowarefoundation/autoware.universe/issues/8915>`_)
   * chore(planning): consistent parameters with autoware_launch
   * update
   * fix json schema
   ---------
-* fix(autoware_behavior_path_planner): fix syntaxError (`#8834 <https://github.com/youtalk/autoware.universe/issues/8834>`_)
+* fix(autoware_behavior_path_planner): fix syntaxError (`#8834 <https://github.com/autowarefoundation/autoware.universe/issues/8834>`_)
   fix:syntaxError
-* fix(autoware_behavior_path_planner): align the parameters with launcher (`#8790 <https://github.com/youtalk/autoware.universe/issues/8790>`_)
+* fix(autoware_behavior_path_planner): align the parameters with launcher (`#8790 <https://github.com/autowarefoundation/autoware.universe/issues/8790>`_)
   parameters in behavior_path_planner aligned
-* refactor(behavior_path_planner): planner data parameter initializer function (`#8767 <https://github.com/youtalk/autoware.universe/issues/8767>`_)
-* chore(autoware_default_adapi)!: prefix autoware to package name (`#8533 <https://github.com/youtalk/autoware.universe/issues/8533>`_)
-* fix(docs): fix dead links in behavior path planner manager (`#8309 <https://github.com/youtalk/autoware.universe/issues/8309>`_)
+* refactor(behavior_path_planner): planner data parameter initializer function (`#8767 <https://github.com/autowarefoundation/autoware.universe/issues/8767>`_)
+* chore(autoware_default_adapi)!: prefix autoware to package name (`#8533 <https://github.com/autowarefoundation/autoware.universe/issues/8533>`_)
+* fix(docs): fix dead links in behavior path planner manager (`#8309 <https://github.com/autowarefoundation/autoware.universe/issues/8309>`_)
   * fix dead links
   * style(pre-commit): autofix
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* fix(behavior_path_planner, spellchecks): spell checks in behavior path planner (`#8307 <https://github.com/youtalk/autoware.universe/issues/8307>`_)
+* fix(behavior_path_planner, spellchecks): spell checks in behavior path planner (`#8307 <https://github.com/autowarefoundation/autoware.universe/issues/8307>`_)
   * fix spell checks in behavior path planner
   * try re-routable
   ---------
-* feat(behavior_path _planner): divide planner manager modules into dependent slots (`#8117 <https://github.com/youtalk/autoware.universe/issues/8117>`_)
-* fix(behavior_path_planner_common): fix dynamic drivable area expansion with few input bound points (`#8136 <https://github.com/youtalk/autoware.universe/issues/8136>`_)
-* refactor(autoware_universe_utils): changed the API to be more intuitive and added documentation (`#7443 <https://github.com/youtalk/autoware.universe/issues/7443>`_)
+* feat(behavior_path _planner): divide planner manager modules into dependent slots (`#8117 <https://github.com/autowarefoundation/autoware.universe/issues/8117>`_)
+* fix(behavior_path_planner_common): fix dynamic drivable area expansion with few input bound points (`#8136 <https://github.com/autowarefoundation/autoware.universe/issues/8136>`_)
+* refactor(autoware_universe_utils): changed the API to be more intuitive and added documentation (`#7443 <https://github.com/autowarefoundation/autoware.universe/issues/7443>`_)
   * refactor(tier4_autoware_utils): Changed the API to be more intuitive and added documentation.
   * use raw shared ptr in PollingPolicy::NEWEST
   * update
@@ -48,26 +48,26 @@ Changelog for package autoware_behavior_path_planner
   Co-authored-by: danielsanchezaran <daniel.sanchez@tier4.jp>
   ---------
   Co-authored-by: danielsanchezaran <daniel.sanchez@tier4.jp>
-* feat(autoware_behavior_path_planner): prevent infinite loop in approving scene module process (`#7881 <https://github.com/youtalk/autoware.universe/issues/7881>`_)
+* feat(autoware_behavior_path_planner): prevent infinite loop in approving scene module process (`#7881 <https://github.com/autowarefoundation/autoware.universe/issues/7881>`_)
   * prevent infinite loop
   * calculate max_iteration_num from number of scene modules
   * add doxygen explanation for calculateMaxIterationNum
   ---------
-* feat(autoware_behavior_path_planner_common,autoware_behavior_path_lane_change_module): add time_keeper to bpp (`#8004 <https://github.com/youtalk/autoware.universe/issues/8004>`_)
+* feat(autoware_behavior_path_planner_common,autoware_behavior_path_lane_change_module): add time_keeper to bpp (`#8004 <https://github.com/autowarefoundation/autoware.universe/issues/8004>`_)
   * feat(autoware_behavior_path_planner_common,autoware_behavior_path_lane_change_module): add time_keeper to bpp
   * update
   ---------
-* feat(autoware_behavior_path_planner): remove max_module_size param (`#7764 <https://github.com/youtalk/autoware.universe/issues/7764>`_)
+* feat(autoware_behavior_path_planner): remove max_module_size param (`#7764 <https://github.com/autowarefoundation/autoware.universe/issues/7764>`_)
   * feat(behavior_path_planner): remove max_module_size param
   The max_module_size param has been removed from the behavior_path_planner scene_module_manager.param.yaml file. This param was unnecessary and has been removed to simplify the configuration.
   ---------
-* feat: add `autoware\_` prefix to `lanelet2_extension` (`#7640 <https://github.com/youtalk/autoware.universe/issues/7640>`_)
-* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/youtalk/autoware.universe/issues/7594>`_)
-* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/youtalk/autoware.universe/issues/7539>`_)
+* feat: add `autoware\_` prefix to `lanelet2_extension` (`#7640 <https://github.com/autowarefoundation/autoware.universe/issues/7640>`_)
+* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/autowarefoundation/autoware.universe/issues/7594>`_)
+* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/autowarefoundation/autoware.universe/issues/7539>`_)
   refactor(motion_utils): add autoware prefix and include dir
-* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/youtalk/autoware.universe/issues/7538>`_)
+* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/autowarefoundation/autoware.universe/issues/7538>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* refactor(behaivor_path_planner)!: rename to include/autoware/{package_name} (`#7522 <https://github.com/youtalk/autoware.universe/issues/7522>`_)
+* refactor(behaivor_path_planner)!: rename to include/autoware/{package_name} (`#7522 <https://github.com/autowarefoundation/autoware.universe/issues/7522>`_)
   * refactor(behavior_path_planner)!: make autoware dir in include
   * refactor(start_planner): make autoware include dir
   * refactor(goal_planner): make autoware include dir

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/CHANGELOG.rst
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/CHANGELOG.rst
@@ -5,30 +5,30 @@ Changelog for package autoware_behavior_path_planner_common
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* fix(traffic_light_utils): prevent accessing nullopt (`#9163 <https://github.com/youtalk/autoware.universe/issues/9163>`_)
-* fix(behavior_path_planner, behavior_velocity_planner): fix to not read invalid ID (`#9103 <https://github.com/youtalk/autoware.universe/issues/9103>`_)
+* fix(traffic_light_utils): prevent accessing nullopt (`#9163 <https://github.com/autowarefoundation/autoware.universe/issues/9163>`_)
+* fix(behavior_path_planner, behavior_velocity_planner): fix to not read invalid ID (`#9103 <https://github.com/autowarefoundation/autoware.universe/issues/9103>`_)
   * fix(behavior_path_planner, behavior_velocity_planner): fix to not read invalid ID
   * style(pre-commit): autofix
   * fix typo
   * fix(behavior_path_planner, behavior_velocity_planner): fix typo and indentation
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat(autoware_test_utils): move test_map, add launcher for test_map (`#9045 <https://github.com/youtalk/autoware.universe/issues/9045>`_)
-* test(bpp_common): add test for path utils (`#9122 <https://github.com/youtalk/autoware.universe/issues/9122>`_)
+* feat(autoware_test_utils): move test_map, add launcher for test_map (`#9045 <https://github.com/autowarefoundation/autoware.universe/issues/9045>`_)
+* test(bpp_common): add test for path utils (`#9122 <https://github.com/autowarefoundation/autoware.universe/issues/9122>`_)
   * add test file for path utils
   * fix
   * add tests for map irrelevant function
   * add test for getUnshiftedEgoPose
   * add docstring and remove unneccesary function
   ---------
-* feat(test_utils): add simple path with lane id generator (`#9113 <https://github.com/youtalk/autoware.universe/issues/9113>`_)
+* feat(test_utils): add simple path with lane id generator (`#9113 <https://github.com/autowarefoundation/autoware.universe/issues/9113>`_)
   * add simple path with lane id generator
   * chnage to explicit template
   * fix
   * add static cast
   * remove header file
   ---------
-* feat(lane_change): add unit test for normal lane change class (RT1-7970) (`#9090 <https://github.com/youtalk/autoware.universe/issues/9090>`_)
+* feat(lane_change): add unit test for normal lane change class (RT1-7970) (`#9090 <https://github.com/autowarefoundation/autoware.universe/issues/9090>`_)
   * RT1-7970 testing base class
   * additional test
   * Added update lanes
@@ -36,88 +36,88 @@ Changelog for package autoware_behavior_path_planner_common
   * check is lane change required
   * fix PRs comment
   ---------
-* test(bpp_common): add test for objects filtering except for lanelet using functions (`#9049 <https://github.com/youtalk/autoware.universe/issues/9049>`_)
+* test(bpp_common): add test for objects filtering except for lanelet using functions (`#9049 <https://github.com/autowarefoundation/autoware.universe/issues/9049>`_)
   * add test for objects filtering except for lanelet using functions
   * remove unnecessary include file
   * add doxygen
   ---------
-* refactor(object_recognition_utils): add autoware prefix to object_recognition_utils (`#8946 <https://github.com/youtalk/autoware.universe/issues/8946>`_)
-* refactor(bpp_common, motion_utils): move path shifter util functions to autoware::motion_utils (`#9081 <https://github.com/youtalk/autoware.universe/issues/9081>`_)
+* refactor(object_recognition_utils): add autoware prefix to object_recognition_utils (`#8946 <https://github.com/autowarefoundation/autoware.universe/issues/8946>`_)
+* refactor(bpp_common, motion_utils): move path shifter util functions to autoware::motion_utils (`#9081 <https://github.com/autowarefoundation/autoware.universe/issues/9081>`_)
   * remove unused function
   * mover path shifter utils function to autoware motion utils
   * minor change in license header
   * fix warning message
   * remove header file
   ---------
-* test(bpp_common): add test for occupancy grid based collision detector (`#9066 <https://github.com/youtalk/autoware.universe/issues/9066>`_)
+* test(bpp_common): add test for occupancy grid based collision detector (`#9066 <https://github.com/autowarefoundation/autoware.universe/issues/9066>`_)
   * add test for occupancy grid based collision detector
   * remove unnnecessary header
   * fix
   * change map resolution and corresponding index
   ---------
-* test(bpp_common): add test for parking departure utils (`#9055 <https://github.com/youtalk/autoware.universe/issues/9055>`_)
+* test(bpp_common): add test for parking departure utils (`#9055 <https://github.com/autowarefoundation/autoware.universe/issues/9055>`_)
   * add test for parking departure utils
   * fix
   * fix typo
   * use EXPECT_DOUBLE_EQ instead of EXPECT_NEAR
   ---------
-* test(bpp_common): add test for object related functions (`#9062 <https://github.com/youtalk/autoware.universe/issues/9062>`_)
+* test(bpp_common): add test for object related functions (`#9062 <https://github.com/autowarefoundation/autoware.universe/issues/9062>`_)
   * add test for object related functions
   * use EXPECT_DOUBLE_EQ instead of EXPECT_NEAR
   * fix build error
   ---------
-* test(bpp_common): add test for footprint (`#9056 <https://github.com/youtalk/autoware.universe/issues/9056>`_)
+* test(bpp_common): add test for footprint (`#9056 <https://github.com/autowarefoundation/autoware.universe/issues/9056>`_)
   add test for footprint
-* refactor(lane_change): refactor get_lane_change_lanes function (`#9044 <https://github.com/youtalk/autoware.universe/issues/9044>`_)
+* refactor(lane_change): refactor get_lane_change_lanes function (`#9044 <https://github.com/autowarefoundation/autoware.universe/issues/9044>`_)
   * refactor(lane_change): refactor get_lane_change_lanes function
   * Add doxygen comment for to_geom_msg_pose
   ---------
-* fix(behavior_path_planner_common): swap boolean for filterObjectsByVelocity (`#9036 <https://github.com/youtalk/autoware.universe/issues/9036>`_)
+* fix(behavior_path_planner_common): swap boolean for filterObjectsByVelocity (`#9036 <https://github.com/autowarefoundation/autoware.universe/issues/9036>`_)
   fix filter object by velocity
-* feat(autoware_behavior_path_planner_common): disable feature of turning off blinker at low velocity (`#9005 <https://github.com/youtalk/autoware.universe/issues/9005>`_)
+* feat(autoware_behavior_path_planner_common): disable feature of turning off blinker at low velocity (`#9005 <https://github.com/autowarefoundation/autoware.universe/issues/9005>`_)
   * feat(turn_signal_decider): disable feature of turning off blinker at low velocity
   ---------
-* refactor(bpp): simplify ExtendedPredictedObject and add new member variables (`#8889 <https://github.com/youtalk/autoware.universe/issues/8889>`_)
+* refactor(bpp): simplify ExtendedPredictedObject and add new member variables (`#8889 <https://github.com/autowarefoundation/autoware.universe/issues/8889>`_)
   * simplify ExtendedPredictedObject and add new member variables
   * replace self polygon to initial polygon
   * comment
   * add comments to dist of ego
   ---------
-* refactor(autoware_interpolation): prefix package and namespace with autoware (`#8088 <https://github.com/youtalk/autoware.universe/issues/8088>`_)
+* refactor(autoware_interpolation): prefix package and namespace with autoware (`#8088 <https://github.com/autowarefoundation/autoware.universe/issues/8088>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* fix(behavior_path_planner): fix rtc state update logic (`#8899 <https://github.com/youtalk/autoware.universe/issues/8899>`_)
+* fix(behavior_path_planner): fix rtc state update logic (`#8899 <https://github.com/autowarefoundation/autoware.universe/issues/8899>`_)
   * fix function updateRTCStatus
   * fix pre-commit
   ---------
-* test(autoware_behavior_path_planner_common): add tests for calcInterpolatedPoseWithVelocity (`#8270 <https://github.com/youtalk/autoware.universe/issues/8270>`_)
+* test(autoware_behavior_path_planner_common): add tests for calcInterpolatedPoseWithVelocity (`#8270 <https://github.com/autowarefoundation/autoware.universe/issues/8270>`_)
   * test: add interpolated pose calculation function's test
   * disabled SpecialCases test
   ---------
-* refactor(behavior_path_planner): planner data parameter initializer function (`#8767 <https://github.com/youtalk/autoware.universe/issues/8767>`_)
-* feat(behavior_planning): update test map for BusStopArea and bicycle_lanes (`#8694 <https://github.com/youtalk/autoware.universe/issues/8694>`_)
-* fix(autoware_behavior_path_planner_common): fix unusedFunction (`#8736 <https://github.com/youtalk/autoware.universe/issues/8736>`_)
+* refactor(behavior_path_planner): planner data parameter initializer function (`#8767 <https://github.com/autowarefoundation/autoware.universe/issues/8767>`_)
+* feat(behavior_planning): update test map for BusStopArea and bicycle_lanes (`#8694 <https://github.com/autowarefoundation/autoware.universe/issues/8694>`_)
+* fix(autoware_behavior_path_planner_common): fix unusedFunction (`#8736 <https://github.com/autowarefoundation/autoware.universe/issues/8736>`_)
   fix:unusedFunction
-* fix(autoware_behavior_path_planner_common): fix unusedFunction (`#8707 <https://github.com/youtalk/autoware.universe/issues/8707>`_)
+* fix(autoware_behavior_path_planner_common): fix unusedFunction (`#8707 <https://github.com/autowarefoundation/autoware.universe/issues/8707>`_)
   * fix:createDrivableLanesMarkerArray and setDecelerationVelocity
   * fix:convertToSnakeCase
   * fix:clang format
   ---------
-* fix(bpp): use common steering factor interface for same scene modules (`#8675 <https://github.com/youtalk/autoware.universe/issues/8675>`_)
-* fix(autoware_behavior_path_planner_common): fix unusedFunction (`#8654 <https://github.com/youtalk/autoware.universe/issues/8654>`_)
+* fix(bpp): use common steering factor interface for same scene modules (`#8675 <https://github.com/autowarefoundation/autoware.universe/issues/8675>`_)
+* fix(autoware_behavior_path_planner_common): fix unusedFunction (`#8654 <https://github.com/autowarefoundation/autoware.universe/issues/8654>`_)
   * fix:unusedFunction 0-2
   * fix:unusedFunction 3-5
   * fix:unusedFunction
   ---------
-* chore(behavior_path_planner_common): update road_shoulder test_map (`#8550 <https://github.com/youtalk/autoware.universe/issues/8550>`_)
-* perf(goal_planner): faster path sorting and selection  (`#8457 <https://github.com/youtalk/autoware.universe/issues/8457>`_)
+* chore(behavior_path_planner_common): update road_shoulder test_map (`#8550 <https://github.com/autowarefoundation/autoware.universe/issues/8550>`_)
+* perf(goal_planner): faster path sorting and selection  (`#8457 <https://github.com/autowarefoundation/autoware.universe/issues/8457>`_)
   * perf(goal_planner): faster path sorting and selection
   * path_id_to_rough_margin_map
   ---------
-* feat(behavior_path_planner_common): add calculateRoughDistanceToObjects (`#8464 <https://github.com/youtalk/autoware.universe/issues/8464>`_)
-* fix(autoware_behavior_path_planner_common): fix variableScope (`#8443 <https://github.com/youtalk/autoware.universe/issues/8443>`_)
+* feat(behavior_path_planner_common): add calculateRoughDistanceToObjects (`#8464 <https://github.com/autowarefoundation/autoware.universe/issues/8464>`_)
+* fix(autoware_behavior_path_planner_common): fix variableScope (`#8443 <https://github.com/autowarefoundation/autoware.universe/issues/8443>`_)
   fix:variableScope
-* refactor(safety_checker): remove redundant polygon creation (`#8502 <https://github.com/youtalk/autoware.universe/issues/8502>`_)
-* feat(lane_change): ensure LC merging lane stop point is safe (`#8369 <https://github.com/youtalk/autoware.universe/issues/8369>`_)
+* refactor(safety_checker): remove redundant polygon creation (`#8502 <https://github.com/autowarefoundation/autoware.universe/issues/8502>`_)
+* feat(lane_change): ensure LC merging lane stop point is safe (`#8369 <https://github.com/autowarefoundation/autoware.universe/issues/8369>`_)
   * function to check for merging lane
   * function to compute distance from last fit width center line point to lane end
   * ensure lane width at LC stop point is larger than ego width
@@ -128,54 +128,54 @@ Changelog for package autoware_behavior_path_planner_common
   * minor refactoring
   * overload function isEgoWithinOriginalLane to pass lane polygon directly
   ---------
-* feat(behavior_path_planner_common): add road_shoulder test map (`#8454 <https://github.com/youtalk/autoware.universe/issues/8454>`_)
-* fix(turn_signal, lane_change, goal_planner): add optional to tackle lane change turn signal and pull over turn signal (`#8463 <https://github.com/youtalk/autoware.universe/issues/8463>`_)
+* feat(behavior_path_planner_common): add road_shoulder test map (`#8454 <https://github.com/autowarefoundation/autoware.universe/issues/8454>`_)
+* fix(turn_signal, lane_change, goal_planner): add optional to tackle lane change turn signal and pull over turn signal (`#8463 <https://github.com/autowarefoundation/autoware.universe/issues/8463>`_)
   * add optional to tackle LC turn signal and pull over turn signal
   * CPP file should not re-define default value; typo in copying from internal repos
   ---------
-* perf(static_obstacle_avoidance): improve logic to reduce computational cost (`#8432 <https://github.com/youtalk/autoware.universe/issues/8432>`_)
+* perf(static_obstacle_avoidance): improve logic to reduce computational cost (`#8432 <https://github.com/autowarefoundation/autoware.universe/issues/8432>`_)
   * perf(safety_check): check within first
   * perf(static_obstacle_avoidance): remove duplicated process
   * perf(static_obstacle_avoidance): remove heavy process
   ---------
-* fix(start/goal_planner): align geometric parall parking start pose with center line (`#8326 <https://github.com/youtalk/autoware.universe/issues/8326>`_)
-* feat(behavior_path _planner): divide planner manager modules into dependent slots (`#8117 <https://github.com/youtalk/autoware.universe/issues/8117>`_)
-* feat(path_safety_checker): add rough collision check (`#8193 <https://github.com/youtalk/autoware.universe/issues/8193>`_)
+* fix(start/goal_planner): align geometric parall parking start pose with center line (`#8326 <https://github.com/autowarefoundation/autoware.universe/issues/8326>`_)
+* feat(behavior_path _planner): divide planner manager modules into dependent slots (`#8117 <https://github.com/autowarefoundation/autoware.universe/issues/8117>`_)
+* feat(path_safety_checker): add rough collision check (`#8193 <https://github.com/autowarefoundation/autoware.universe/issues/8193>`_)
   * feat(path_safety_checker): add rough collision check
   * Update planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/path_safety_checker/safety_check.cpp
   ---------
-* fix(autoware_behavior_path_planner_common): fix passedByValue (`#8209 <https://github.com/youtalk/autoware.universe/issues/8209>`_)
+* fix(autoware_behavior_path_planner_common): fix passedByValue (`#8209 <https://github.com/autowarefoundation/autoware.universe/issues/8209>`_)
   * fix:clang format
   * fix:passedByValue
   * fix:passedByValue
   ---------
-* fix(behavior_path_planner_common): fix dynamic drivable area expansion with few input bound points (`#8136 <https://github.com/youtalk/autoware.universe/issues/8136>`_)
-* fix(bpp): fix approved request search  (`#8119 <https://github.com/youtalk/autoware.universe/issues/8119>`_)
+* fix(behavior_path_planner_common): fix dynamic drivable area expansion with few input bound points (`#8136 <https://github.com/autowarefoundation/autoware.universe/issues/8136>`_)
+* fix(bpp): fix approved request search  (`#8119 <https://github.com/autowarefoundation/autoware.universe/issues/8119>`_)
   fix existApprovedRequest condition
-* fix(bpp, rtc_interface): fix state transition (`#7743 <https://github.com/youtalk/autoware.universe/issues/7743>`_)
+* fix(bpp, rtc_interface): fix state transition (`#7743 <https://github.com/autowarefoundation/autoware.universe/issues/7743>`_)
   * fix(rtc_interface): check rtc state
   * fix(bpp_interface): check rtc state
   * feat(rtc_interface): print
   ---------
-* fix(autoware_behavior_path_planner_common): fix constParameterReference (`#8045 <https://github.com/youtalk/autoware.universe/issues/8045>`_)
+* fix(autoware_behavior_path_planner_common): fix constParameterReference (`#8045 <https://github.com/autowarefoundation/autoware.universe/issues/8045>`_)
   fix:constParameterReference
-* feat(autoware_behavior_path_planner_common,autoware_behavior_path_lane_change_module): add time_keeper to bpp (`#8004 <https://github.com/youtalk/autoware.universe/issues/8004>`_)
+* feat(autoware_behavior_path_planner_common,autoware_behavior_path_lane_change_module): add time_keeper to bpp (`#8004 <https://github.com/autowarefoundation/autoware.universe/issues/8004>`_)
   * feat(autoware_behavior_path_planner_common,autoware_behavior_path_lane_change_module): add time_keeper to bpp
   * update
   ---------
-* fix(autoware_behavior_path_planner_common): fix shadowVariable (`#7965 <https://github.com/youtalk/autoware.universe/issues/7965>`_)
+* fix(autoware_behavior_path_planner_common): fix shadowVariable (`#7965 <https://github.com/autowarefoundation/autoware.universe/issues/7965>`_)
   fix:shadowVariable
-* feat(safety_check): filter safety check targe objects by yaw deviation between pose and lane (`#7828 <https://github.com/youtalk/autoware.universe/issues/7828>`_)
+* feat(safety_check): filter safety check targe objects by yaw deviation between pose and lane (`#7828 <https://github.com/autowarefoundation/autoware.universe/issues/7828>`_)
   * fix(safety_check): filter by yaw deviation to check object belongs to lane
   * fix(static_obstacle_avoidance): check yaw only when the object is moving
   ---------
-* fix(autoware_behavior_path_planner_common): fix knownConditionTrueFalse (`#7816 <https://github.com/youtalk/autoware.universe/issues/7816>`_)
-* feat(autoware_behavior_path_planner): remove max_module_size param (`#7764 <https://github.com/youtalk/autoware.universe/issues/7764>`_)
+* fix(autoware_behavior_path_planner_common): fix knownConditionTrueFalse (`#7816 <https://github.com/autowarefoundation/autoware.universe/issues/7816>`_)
+* feat(autoware_behavior_path_planner): remove max_module_size param (`#7764 <https://github.com/autowarefoundation/autoware.universe/issues/7764>`_)
   * feat(behavior_path_planner): remove max_module_size param
   The max_module_size param has been removed from the behavior_path_planner scene_module_manager.param.yaml file. This param was unnecessary and has been removed to simplify the configuration.
   ---------
-* feat: add `autoware\_` prefix to `lanelet2_extension` (`#7640 <https://github.com/youtalk/autoware.universe/issues/7640>`_)
-* feat(start_planner): yaw threshold for rss check (`#7657 <https://github.com/youtalk/autoware.universe/issues/7657>`_)
+* feat: add `autoware\_` prefix to `lanelet2_extension` (`#7640 <https://github.com/autowarefoundation/autoware.universe/issues/7640>`_)
+* feat(start_planner): yaw threshold for rss check (`#7657 <https://github.com/autowarefoundation/autoware.universe/issues/7657>`_)
   * add param to customize yaw th
   * add param to other modules
   * docs
@@ -183,25 +183,25 @@ Changelog for package autoware_behavior_path_planner_common
   * fix LC README
   * use normalized yaw diff
   ---------
-* fix(autoware_behavior_path_planner_common): fix containerOutOfBounds warning (`#7675 <https://github.com/youtalk/autoware.universe/issues/7675>`_)
+* fix(autoware_behavior_path_planner_common): fix containerOutOfBounds warning (`#7675 <https://github.com/autowarefoundation/autoware.universe/issues/7675>`_)
   * fix(autoware_behavior_path_planner_common): fix containerOutOfBounds warning
   * fix type
   ---------
-* fix(autoware_behavior_path_planner_common): fix shadowArgument warning in getDistanceToCrosswalk (`#7665 <https://github.com/youtalk/autoware.universe/issues/7665>`_)
-* fix(autoware_behavior_path_planner_common): fix shadowArgument warning (`#7623 <https://github.com/youtalk/autoware.universe/issues/7623>`_)
-* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/youtalk/autoware.universe/issues/7594>`_)
-* fix(autoware_behavior_path_planner_common): fix redundantContinue warning (`#7578 <https://github.com/youtalk/autoware.universe/issues/7578>`_)
-* fix(behavior_path_planner): fix redundantAssignment warning (`#7560 <https://github.com/youtalk/autoware.universe/issues/7560>`_)
-* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/youtalk/autoware.universe/issues/7539>`_)
+* fix(autoware_behavior_path_planner_common): fix shadowArgument warning in getDistanceToCrosswalk (`#7665 <https://github.com/autowarefoundation/autoware.universe/issues/7665>`_)
+* fix(autoware_behavior_path_planner_common): fix shadowArgument warning (`#7623 <https://github.com/autowarefoundation/autoware.universe/issues/7623>`_)
+* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/autowarefoundation/autoware.universe/issues/7594>`_)
+* fix(autoware_behavior_path_planner_common): fix redundantContinue warning (`#7578 <https://github.com/autowarefoundation/autoware.universe/issues/7578>`_)
+* fix(behavior_path_planner): fix redundantAssignment warning (`#7560 <https://github.com/autowarefoundation/autoware.universe/issues/7560>`_)
+* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/autowarefoundation/autoware.universe/issues/7539>`_)
   refactor(motion_utils): add autoware prefix and include dir
-* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/youtalk/autoware.universe/issues/7538>`_)
+* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/autowarefoundation/autoware.universe/issues/7538>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* fix(behavior_path_planner): fix redundantIfRemove warning (`#7544 <https://github.com/youtalk/autoware.universe/issues/7544>`_)
-* refactor(route_handler)!: rename to include/autoware/{package_name}  (`#7530 <https://github.com/youtalk/autoware.universe/issues/7530>`_)
+* fix(behavior_path_planner): fix redundantIfRemove warning (`#7544 <https://github.com/autowarefoundation/autoware.universe/issues/7544>`_)
+* refactor(route_handler)!: rename to include/autoware/{package_name}  (`#7530 <https://github.com/autowarefoundation/autoware.universe/issues/7530>`_)
   refactor(route_handler)!: rename to include/autoware/{package_name}
-* refactor(rtc_interface)!: rename to include/autoware/{package_name} (`#7531 <https://github.com/youtalk/autoware.universe/issues/7531>`_)
+* refactor(rtc_interface)!: rename to include/autoware/{package_name} (`#7531 <https://github.com/autowarefoundation/autoware.universe/issues/7531>`_)
   Co-authored-by: Fumiya Watanabe <rej55.g@gmail.com>
-* refactor(freespace_planner)!: rename to include/autoware/{package_name}  (`#7525 <https://github.com/youtalk/autoware.universe/issues/7525>`_)
+* refactor(freespace_planner)!: rename to include/autoware/{package_name}  (`#7525 <https://github.com/autowarefoundation/autoware.universe/issues/7525>`_)
   refactor(freespace_planner)!: rename to include/autoware/{package_name}
   refactor(start_planner): make autoware include dir
   refactor(goal_planner): make autoware include dir
@@ -218,15 +218,15 @@ Changelog for package autoware_behavior_path_planner_common
   fix build
   autoware_freespace_planner
   freespace_planning_algorithms
-* refactor(control)!: refactor directory structures of the control checkers (`#7524 <https://github.com/youtalk/autoware.universe/issues/7524>`_)
+* refactor(control)!: refactor directory structures of the control checkers (`#7524 <https://github.com/autowarefoundation/autoware.universe/issues/7524>`_)
   * aeb
   * control_validator
   * lane_departure_checker
   * shift_decider
   * fix
   ---------
-* refactor(objects_of_interest_marker_interface): rename to include/autoware/{package_name} (`#7535 <https://github.com/youtalk/autoware.universe/issues/7535>`_)
-* refactor(behaivor_path_planner)!: rename to include/autoware/{package_name} (`#7522 <https://github.com/youtalk/autoware.universe/issues/7522>`_)
+* refactor(objects_of_interest_marker_interface): rename to include/autoware/{package_name} (`#7535 <https://github.com/autowarefoundation/autoware.universe/issues/7535>`_)
+* refactor(behaivor_path_planner)!: rename to include/autoware/{package_name} (`#7522 <https://github.com/autowarefoundation/autoware.universe/issues/7522>`_)
   * refactor(behavior_path_planner)!: make autoware dir in include
   * refactor(start_planner): make autoware include dir
   * refactor(goal_planner): make autoware include dir

--- a/planning/behavior_path_planner/autoware_behavior_path_sampling_planner_module/CHANGELOG.rst
+++ b/planning/behavior_path_planner/autoware_behavior_path_sampling_planner_module/CHANGELOG.rst
@@ -5,25 +5,25 @@ Changelog for package autoware_behavior_path_sampling_planner_module
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* refactor(autoware_interpolation): prefix package and namespace with autoware (`#8088 <https://github.com/youtalk/autoware.universe/issues/8088>`_)
+* refactor(autoware_interpolation): prefix package and namespace with autoware (`#8088 <https://github.com/autowarefoundation/autoware.universe/issues/8088>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* refactor(signal_processing): prefix package and namespace with autoware (`#8541 <https://github.com/youtalk/autoware.universe/issues/8541>`_)
-* fix(autoware_behavior_path_planner): align the parameters with launcher (`#8790 <https://github.com/youtalk/autoware.universe/issues/8790>`_)
+* refactor(signal_processing): prefix package and namespace with autoware (`#8541 <https://github.com/autowarefoundation/autoware.universe/issues/8541>`_)
+* fix(autoware_behavior_path_planner): align the parameters with launcher (`#8790 <https://github.com/autowarefoundation/autoware.universe/issues/8790>`_)
   parameters in behavior_path_planner aligned
-* fix(bpp): use common steering factor interface for same scene modules (`#8675 <https://github.com/youtalk/autoware.universe/issues/8675>`_)
-* fix(autoware_behavior_path_sampling_planner_module): fix shadowVariable (`#7966 <https://github.com/youtalk/autoware.universe/issues/7966>`_)
+* fix(bpp): use common steering factor interface for same scene modules (`#8675 <https://github.com/autowarefoundation/autoware.universe/issues/8675>`_)
+* fix(autoware_behavior_path_sampling_planner_module): fix shadowVariable (`#7966 <https://github.com/autowarefoundation/autoware.universe/issues/7966>`_)
   * fix:shadowVariable
   * refactor:clang format
   * fix:shadowVariable
   * refactor:CodeSence
   ---------
-* feat: add `autoware\_` prefix to `lanelet2_extension` (`#7640 <https://github.com/youtalk/autoware.universe/issues/7640>`_)
-* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/youtalk/autoware.universe/issues/7594>`_)
-* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/youtalk/autoware.universe/issues/7539>`_)
+* feat: add `autoware\_` prefix to `lanelet2_extension` (`#7640 <https://github.com/autowarefoundation/autoware.universe/issues/7640>`_)
+* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/autowarefoundation/autoware.universe/issues/7594>`_)
+* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/autowarefoundation/autoware.universe/issues/7539>`_)
   refactor(motion_utils): add autoware prefix and include dir
-* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/youtalk/autoware.universe/issues/7538>`_)
+* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/autowarefoundation/autoware.universe/issues/7538>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* refactor(behaivor_path_planner)!: rename to include/autoware/{package_name} (`#7522 <https://github.com/youtalk/autoware.universe/issues/7522>`_)
+* refactor(behaivor_path_planner)!: rename to include/autoware/{package_name} (`#7522 <https://github.com/autowarefoundation/autoware.universe/issues/7522>`_)
   * refactor(behavior_path_planner)!: make autoware dir in include
   * refactor(start_planner): make autoware include dir
   * refactor(goal_planner): make autoware include dir

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/CHANGELOG.rst
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/CHANGELOG.rst
@@ -5,23 +5,23 @@ Changelog for package autoware_behavior_path_side_shift_module
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* refactor(bpp_common, motion_utils): move path shifter util functions to autoware::motion_utils (`#9081 <https://github.com/youtalk/autoware.universe/issues/9081>`_)
+* refactor(bpp_common, motion_utils): move path shifter util functions to autoware::motion_utils (`#9081 <https://github.com/autowarefoundation/autoware.universe/issues/9081>`_)
   * remove unused function
   * mover path shifter utils function to autoware motion utils
   * minor change in license header
   * fix warning message
   * remove header file
   ---------
-* fix(bpp): use common steering factor interface for same scene modules (`#8675 <https://github.com/youtalk/autoware.universe/issues/8675>`_)
-* fix(autoware_behavior_path_side_shift_module): fix unusedFunction (`#8655 <https://github.com/youtalk/autoware.universe/issues/8655>`_)
+* fix(bpp): use common steering factor interface for same scene modules (`#8675 <https://github.com/autowarefoundation/autoware.universe/issues/8675>`_)
+* fix(autoware_behavior_path_side_shift_module): fix unusedFunction (`#8655 <https://github.com/autowarefoundation/autoware.universe/issues/8655>`_)
   fix:unusedFunction
-* feat: add `autoware\_` prefix to `lanelet2_extension` (`#7640 <https://github.com/youtalk/autoware.universe/issues/7640>`_)
-* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/youtalk/autoware.universe/issues/7594>`_)
-* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/youtalk/autoware.universe/issues/7539>`_)
+* feat: add `autoware\_` prefix to `lanelet2_extension` (`#7640 <https://github.com/autowarefoundation/autoware.universe/issues/7640>`_)
+* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/autowarefoundation/autoware.universe/issues/7594>`_)
+* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/autowarefoundation/autoware.universe/issues/7539>`_)
   refactor(motion_utils): add autoware prefix and include dir
-* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/youtalk/autoware.universe/issues/7538>`_)
+* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/autowarefoundation/autoware.universe/issues/7538>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* refactor(behaivor_path_planner)!: rename to include/autoware/{package_name} (`#7522 <https://github.com/youtalk/autoware.universe/issues/7522>`_)
+* refactor(behaivor_path_planner)!: rename to include/autoware/{package_name} (`#7522 <https://github.com/autowarefoundation/autoware.universe/issues/7522>`_)
   * refactor(behavior_path_planner)!: make autoware dir in include
   * refactor(start_planner): make autoware include dir
   * refactor(goal_planner): make autoware include dir

--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/CHANGELOG.rst
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/CHANGELOG.rst
@@ -5,38 +5,38 @@ Changelog for package autoware_behavior_path_start_planner_module
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* feat(start_planner): update param to match launch (`#9158 <https://github.com/youtalk/autoware.universe/issues/9158>`_)
+* feat(start_planner): update param to match launch (`#9158 <https://github.com/autowarefoundation/autoware.universe/issues/9158>`_)
   update param to match launch
-* refactor(bpp_common, motion_utils): move path shifter util functions to autoware::motion_utils (`#9081 <https://github.com/youtalk/autoware.universe/issues/9081>`_)
+* refactor(bpp_common, motion_utils): move path shifter util functions to autoware::motion_utils (`#9081 <https://github.com/autowarefoundation/autoware.universe/issues/9081>`_)
   * remove unused function
   * mover path shifter utils function to autoware motion utils
   * minor change in license header
   * fix warning message
   * remove header file
   ---------
-* fix(behavior_path_planner_common): swap boolean for filterObjectsByVelocity (`#9036 <https://github.com/youtalk/autoware.universe/issues/9036>`_)
+* fix(behavior_path_planner_common): swap boolean for filterObjectsByVelocity (`#9036 <https://github.com/autowarefoundation/autoware.universe/issues/9036>`_)
   fix filter object by velocity
-* refactor(bpp): simplify ExtendedPredictedObject and add new member variables (`#8889 <https://github.com/youtalk/autoware.universe/issues/8889>`_)
+* refactor(bpp): simplify ExtendedPredictedObject and add new member variables (`#8889 <https://github.com/autowarefoundation/autoware.universe/issues/8889>`_)
   * simplify ExtendedPredictedObject and add new member variables
   * replace self polygon to initial polygon
   * comment
   * add comments to dist of ego
   ---------
-* refactor(start_planner,raw_vechile_cmd_converter): align parameter with autoware_launch's parameter (`#8913 <https://github.com/youtalk/autoware.universe/issues/8913>`_)
+* refactor(start_planner,raw_vechile_cmd_converter): align parameter with autoware_launch's parameter (`#8913 <https://github.com/autowarefoundation/autoware.universe/issues/8913>`_)
   * align autoware_raw_vehicle_cmd_converter's parameter
   * align start_planner's parameter
   ---------
-* feat(start_planner): add skip_rear_vehicle_check parameter (`#8863 <https://github.com/youtalk/autoware.universe/issues/8863>`_)
+* feat(start_planner): add skip_rear_vehicle_check parameter (`#8863 <https://github.com/autowarefoundation/autoware.universe/issues/8863>`_)
   Add the skip_rear_vehicle_check parameter to the start planner module configuration. This parameter allows disabling the rear vehicle check during collision detection. By default, the rear vehicle check is enabled.
-* fix(autoware_behavior_path_planner): align the parameters with launcher (`#8790 <https://github.com/youtalk/autoware.universe/issues/8790>`_)
+* fix(autoware_behavior_path_planner): align the parameters with launcher (`#8790 <https://github.com/autowarefoundation/autoware.universe/issues/8790>`_)
   parameters in behavior_path_planner aligned
-* fix(autoware_behavior_path_start_planner_module): fix unusedFunction (`#8709 <https://github.com/youtalk/autoware.universe/issues/8709>`_)
+* fix(autoware_behavior_path_start_planner_module): fix unusedFunction (`#8709 <https://github.com/autowarefoundation/autoware.universe/issues/8709>`_)
   * fix:checkCollisionBetweenPathFootprintsAndObjects
   * fix:add const
   * fix:unusedFunction
   ---------
-* fix(bpp): use common steering factor interface for same scene modules (`#8675 <https://github.com/youtalk/autoware.universe/issues/8675>`_)
-* refactor(start_planner, lane_departure_checker): remove redundant calculation in fuseLaneletPolygon (`#8682 <https://github.com/youtalk/autoware.universe/issues/8682>`_)
+* fix(bpp): use common steering factor interface for same scene modules (`#8675 <https://github.com/autowarefoundation/autoware.universe/issues/8675>`_)
+* refactor(start_planner, lane_departure_checker): remove redundant calculation in fuseLaneletPolygon (`#8682 <https://github.com/autowarefoundation/autoware.universe/issues/8682>`_)
   * remove redundant fused lanelet calculation
   * remove unnecessary change
   * add new function
@@ -46,13 +46,13 @@ Changelog for package autoware_behavior_path_start_planner_module
   * add comment for better understanding
   * fix cppcheck
   ---------
-* fix(autoware_behavior_path_start_planner_module): fix unusedFunction (`#8659 <https://github.com/youtalk/autoware.universe/issues/8659>`_)
+* fix(autoware_behavior_path_start_planner_module): fix unusedFunction (`#8659 <https://github.com/autowarefoundation/autoware.universe/issues/8659>`_)
   fix:unusedFunction
-* refactor(start_planner): remove redundant calculation in shift pull out  (`#8623 <https://github.com/youtalk/autoware.universe/issues/8623>`_)
+* refactor(start_planner): remove redundant calculation in shift pull out  (`#8623 <https://github.com/autowarefoundation/autoware.universe/issues/8623>`_)
   * fix redundant calculation
   * fix unneccesary modification for comment
   ---------
-* feat(freespace_planning_algorithms): implement option for backward search from goal to start (`#8091 <https://github.com/youtalk/autoware.universe/issues/8091>`_)
+* feat(freespace_planning_algorithms): implement option for backward search from goal to start (`#8091 <https://github.com/autowarefoundation/autoware.universe/issues/8091>`_)
   * refactor freespace planning algorithms
   * fix error
   * use vector instead of map for a-star node graph
@@ -118,14 +118,14 @@ Changelog for package autoware_behavior_path_start_planner_module
   * minor refactor
   ---------
   Co-authored-by: Maxime CLEMENT <78338830+maxime-clem@users.noreply.github.com>
-* feat(start_planner): add time_keeper (`#8254 <https://github.com/youtalk/autoware.universe/issues/8254>`_)
+* feat(start_planner): add time_keeper (`#8254 <https://github.com/autowarefoundation/autoware.universe/issues/8254>`_)
   * feat(start_planner): add time_keeper
   * fix
   * fix
   * fix shadow variables
   ---------
-* fix(start/goal_planner): fix freespace planning error handling (`#8246 <https://github.com/youtalk/autoware.universe/issues/8246>`_)
-* refactor(freespace_planning_algorithm): refactor and improve astar search (`#8068 <https://github.com/youtalk/autoware.universe/issues/8068>`_)
+* fix(start/goal_planner): fix freespace planning error handling (`#8246 <https://github.com/autowarefoundation/autoware.universe/issues/8246>`_)
+* refactor(freespace_planning_algorithm): refactor and improve astar search (`#8068 <https://github.com/autowarefoundation/autoware.universe/issues/8068>`_)
   * refactor freespace planning algorithms
   * fix error
   * use vector instead of map for a-star node graph
@@ -158,7 +158,7 @@ Changelog for package autoware_behavior_path_start_planner_module
   * check goal pose validity before setting collision free distance map
   * declare variables as const where necessary
   ---------
-* fix(autoware_behavior_path_start_planner_module): fix shadowVariable (`#7982 <https://github.com/youtalk/autoware.universe/issues/7982>`_)
+* fix(autoware_behavior_path_start_planner_module): fix shadowVariable (`#7982 <https://github.com/autowarefoundation/autoware.universe/issues/7982>`_)
   * fix:shadowVariable
   * fix:shadowVariable
   * refactor:clang format
@@ -172,7 +172,7 @@ Changelog for package autoware_behavior_path_start_planner_module
   * refactor: namespace
   * refactor:clang format
   ---------
-* feat(start_planner): add end_pose_curvature_threshold  (`#7901 <https://github.com/youtalk/autoware.universe/issues/7901>`_)
+* feat(start_planner): add end_pose_curvature_threshold  (`#7901 <https://github.com/autowarefoundation/autoware.universe/issues/7901>`_)
   * feat(start_planner): add end_pose_curvature_threshold
   * Update planning/behavior_path_planner/autoware_behavior_path_start_planner_module/README.md
   Co-authored-by: Kyoichi Sugahara <kyoichi.sugahara@tier4.jp>
@@ -180,8 +180,8 @@ Changelog for package autoware_behavior_path_start_planner_module
   * update readme
   ---------
   Co-authored-by: Kyoichi Sugahara <kyoichi.sugahara@tier4.jp>
-* feat(start_planner): check current_pose and estimated_stop_pose for isPreventingRearVehicleFromPassingThrough (`#8112 <https://github.com/youtalk/autoware.universe/issues/8112>`_)
-* fix(start/goal_planner): fix addition of duplicate segments in calcBeforeShiftedArcLength (`#7902 <https://github.com/youtalk/autoware.universe/issues/7902>`_)
+* feat(start_planner): check current_pose and estimated_stop_pose for isPreventingRearVehicleFromPassingThrough (`#8112 <https://github.com/autowarefoundation/autoware.universe/issues/8112>`_)
+* fix(start/goal_planner): fix addition of duplicate segments in calcBeforeShiftedArcLength (`#7902 <https://github.com/autowarefoundation/autoware.universe/issues/7902>`_)
   * fix(start/goal_planner): fix addition of duplicate segments in calcBeforeShiftedArcLength
   * Update trajectory.hpp
   Co-authored-by: Kyoichi Sugahara <kyoichi.sugahara@tier4.jp>
@@ -189,12 +189,12 @@ Changelog for package autoware_behavior_path_start_planner_module
   Co-authored-by: Kyoichi Sugahara <kyoichi.sugahara@tier4.jp>
   ---------
   Co-authored-by: Kyoichi Sugahara <kyoichi.sugahara@tier4.jp>
-* feat(safety_check): filter safety check targe objects by yaw deviation between pose and lane (`#7828 <https://github.com/youtalk/autoware.universe/issues/7828>`_)
+* feat(safety_check): filter safety check targe objects by yaw deviation between pose and lane (`#7828 <https://github.com/autowarefoundation/autoware.universe/issues/7828>`_)
   * fix(safety_check): filter by yaw deviation to check object belongs to lane
   * fix(static_obstacle_avoidance): check yaw only when the object is moving
   ---------
-* feat: add `autoware\_` prefix to `lanelet2_extension` (`#7640 <https://github.com/youtalk/autoware.universe/issues/7640>`_)
-* feat(start_planner): yaw threshold for rss check (`#7657 <https://github.com/youtalk/autoware.universe/issues/7657>`_)
+* feat: add `autoware\_` prefix to `lanelet2_extension` (`#7640 <https://github.com/autowarefoundation/autoware.universe/issues/7640>`_)
+* feat(start_planner): yaw threshold for rss check (`#7657 <https://github.com/autowarefoundation/autoware.universe/issues/7657>`_)
   * add param to customize yaw th
   * add param to other modules
   * docs
@@ -202,15 +202,15 @@ Changelog for package autoware_behavior_path_start_planner_module
   * fix LC README
   * use normalized yaw diff
   ---------
-* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/youtalk/autoware.universe/issues/7594>`_)
-* fix(autoware_behavior_path_start_planner_module): fix duplicateBreak warning (`#7583 <https://github.com/youtalk/autoware.universe/issues/7583>`_)
-* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/youtalk/autoware.universe/issues/7539>`_)
+* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/autowarefoundation/autoware.universe/issues/7594>`_)
+* fix(autoware_behavior_path_start_planner_module): fix duplicateBreak warning (`#7583 <https://github.com/autowarefoundation/autoware.universe/issues/7583>`_)
+* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/autowarefoundation/autoware.universe/issues/7539>`_)
   refactor(motion_utils): add autoware prefix and include dir
-* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/youtalk/autoware.universe/issues/7538>`_)
+* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/autowarefoundation/autoware.universe/issues/7538>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* refactor(route_handler)!: rename to include/autoware/{package_name}  (`#7530 <https://github.com/youtalk/autoware.universe/issues/7530>`_)
+* refactor(route_handler)!: rename to include/autoware/{package_name}  (`#7530 <https://github.com/autowarefoundation/autoware.universe/issues/7530>`_)
   refactor(route_handler)!: rename to include/autoware/{package_name}
-* refactor(freespace_planner)!: rename to include/autoware/{package_name}  (`#7525 <https://github.com/youtalk/autoware.universe/issues/7525>`_)
+* refactor(freespace_planner)!: rename to include/autoware/{package_name}  (`#7525 <https://github.com/autowarefoundation/autoware.universe/issues/7525>`_)
   refactor(freespace_planner)!: rename to include/autoware/{package_name}
   refactor(start_planner): make autoware include dir
   refactor(goal_planner): make autoware include dir
@@ -227,14 +227,14 @@ Changelog for package autoware_behavior_path_start_planner_module
   fix build
   autoware_freespace_planner
   freespace_planning_algorithms
-* refactor(control)!: refactor directory structures of the control checkers (`#7524 <https://github.com/youtalk/autoware.universe/issues/7524>`_)
+* refactor(control)!: refactor directory structures of the control checkers (`#7524 <https://github.com/autowarefoundation/autoware.universe/issues/7524>`_)
   * aeb
   * control_validator
   * lane_departure_checker
   * shift_decider
   * fix
   ---------
-* refactor(behaivor_path_planner)!: rename to include/autoware/{package_name} (`#7522 <https://github.com/youtalk/autoware.universe/issues/7522>`_)
+* refactor(behaivor_path_planner)!: rename to include/autoware/{package_name} (`#7522 <https://github.com/autowarefoundation/autoware.universe/issues/7522>`_)
   * refactor(behavior_path_planner)!: make autoware dir in include
   * refactor(start_planner): make autoware include dir
   * refactor(goal_planner): make autoware include dir

--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/CHANGELOG.rst
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/CHANGELOG.rst
@@ -5,71 +5,71 @@ Changelog for package autoware_behavior_path_static_obstacle_avoidance_module
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* fix(behavior_path_planner, behavior_velocity_planner): fix to not read invalid ID (`#9103 <https://github.com/youtalk/autoware.universe/issues/9103>`_)
+* fix(behavior_path_planner, behavior_velocity_planner): fix to not read invalid ID (`#9103 <https://github.com/autowarefoundation/autoware.universe/issues/9103>`_)
   * fix(behavior_path_planner, behavior_velocity_planner): fix to not read invalid ID
   * style(pre-commit): autofix
   * fix typo
   * fix(behavior_path_planner, behavior_velocity_planner): fix typo and indentation
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* fix(static_obstacle_avoidance): suppress unnecessary warning (`#9142 <https://github.com/youtalk/autoware.universe/issues/9142>`_)
-* test(static_obstacle_avoidance): add unit test for utils functions (`#9134 <https://github.com/youtalk/autoware.universe/issues/9134>`_)
+* fix(static_obstacle_avoidance): suppress unnecessary warning (`#9142 <https://github.com/autowarefoundation/autoware.universe/issues/9142>`_)
+* test(static_obstacle_avoidance): add unit test for utils functions (`#9134 <https://github.com/autowarefoundation/autoware.universe/issues/9134>`_)
   * docs(static_obstacle_avoidance): add doxygen
   * test: add test
   * fix: assert and expect
   * fix: wrong comment
   * refactor: use autoware test utils
   ---------
-* fix(utils): fix envelope polygon update logic (`#9123 <https://github.com/youtalk/autoware.universe/issues/9123>`_)
-* test(bpp_common): add test for path utils (`#9122 <https://github.com/youtalk/autoware.universe/issues/9122>`_)
+* fix(utils): fix envelope polygon update logic (`#9123 <https://github.com/autowarefoundation/autoware.universe/issues/9123>`_)
+* test(bpp_common): add test for path utils (`#9122 <https://github.com/autowarefoundation/autoware.universe/issues/9122>`_)
   * add test file for path utils
   * fix
   * add tests for map irrelevant function
   * add test for getUnshiftedEgoPose
   * add docstring and remove unneccesary function
   ---------
-* fix(avoidance): don't insert stop line if the ego can't avoid or return (`#9089 <https://github.com/youtalk/autoware.universe/issues/9089>`_)
+* fix(avoidance): don't insert stop line if the ego can't avoid or return (`#9089 <https://github.com/autowarefoundation/autoware.universe/issues/9089>`_)
   * fix(avoidance): don't insert stop line if the ego can't avoid or return
   * fix: build error
   * Update planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/include/autoware/behavior_path_static_obstacle_avoidance_module/helper.hpp
   Co-authored-by: Go Sakayori <go-sakayori@users.noreply.github.com>
   ---------
   Co-authored-by: Go Sakayori <go-sakayori@users.noreply.github.com>
-* refactor(bpp_common, motion_utils): move path shifter util functions to autoware::motion_utils (`#9081 <https://github.com/youtalk/autoware.universe/issues/9081>`_)
+* refactor(bpp_common, motion_utils): move path shifter util functions to autoware::motion_utils (`#9081 <https://github.com/autowarefoundation/autoware.universe/issues/9081>`_)
   * remove unused function
   * mover path shifter utils function to autoware motion utils
   * minor change in license header
   * fix warning message
   * remove header file
   ---------
-* refactor(bpp): simplify ExtendedPredictedObject and add new member variables (`#8889 <https://github.com/youtalk/autoware.universe/issues/8889>`_)
+* refactor(bpp): simplify ExtendedPredictedObject and add new member variables (`#8889 <https://github.com/autowarefoundation/autoware.universe/issues/8889>`_)
   * simplify ExtendedPredictedObject and add new member variables
   * replace self polygon to initial polygon
   * comment
   * add comments to dist of ego
   ---------
-* refactor(static_obstacle_avoidance): move route handler based calculation outside loop (`#8968 <https://github.com/youtalk/autoware.universe/issues/8968>`_)
+* refactor(static_obstacle_avoidance): move route handler based calculation outside loop (`#8968 <https://github.com/autowarefoundation/autoware.universe/issues/8968>`_)
   * refactor filterTargetObjects
   * Update planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/utils.cpp
   Co-authored-by: Satoshi OTA <44889564+satoshi-ota@users.noreply.github.com>
   ---------
   Co-authored-by: Satoshi OTA <44889564+satoshi-ota@users.noreply.github.com>
-* fix(static_obstacle_avoidance): remove redundant calculation (`#8955 <https://github.com/youtalk/autoware.universe/issues/8955>`_)
+* fix(static_obstacle_avoidance): remove redundant calculation (`#8955 <https://github.com/autowarefoundation/autoware.universe/issues/8955>`_)
   remove redundant calculation
-* refactor(signal_processing): prefix package and namespace with autoware (`#8541 <https://github.com/youtalk/autoware.universe/issues/8541>`_)
-* fix(static_obstacle_avoidance, avoidance_by_lane_change): remove unused variable (`#8926 <https://github.com/youtalk/autoware.universe/issues/8926>`_)
+* refactor(signal_processing): prefix package and namespace with autoware (`#8541 <https://github.com/autowarefoundation/autoware.universe/issues/8541>`_)
+* fix(static_obstacle_avoidance, avoidance_by_lane_change): remove unused variable (`#8926 <https://github.com/autowarefoundation/autoware.universe/issues/8926>`_)
   remove unused variables
-* fix(static_obstacle_avoidance): update UUID when candidate shift is empty (`#8901 <https://github.com/youtalk/autoware.universe/issues/8901>`_)
+* fix(static_obstacle_avoidance): update UUID when candidate shift is empty (`#8901 <https://github.com/autowarefoundation/autoware.universe/issues/8901>`_)
   fix candidate shift line's rtc cooperate status
-* docs(static_obstacle_avoidance): update envelope polygon creation (`#8822 <https://github.com/youtalk/autoware.universe/issues/8822>`_)
+* docs(static_obstacle_avoidance): update envelope polygon creation (`#8822 <https://github.com/autowarefoundation/autoware.universe/issues/8822>`_)
   * update envelope polygon creation
   * fix whitespace
   ---------
-* fix(autoware_behavior_path_planner): align the parameters with launcher (`#8790 <https://github.com/youtalk/autoware.universe/issues/8790>`_)
+* fix(autoware_behavior_path_planner): align the parameters with launcher (`#8790 <https://github.com/autowarefoundation/autoware.universe/issues/8790>`_)
   parameters in behavior_path_planner aligned
-* fix(static_obstacle_avoidance): improve turn signal output timing when the ego returns original lane (`#8726 <https://github.com/youtalk/autoware.universe/issues/8726>`_)
+* fix(static_obstacle_avoidance): improve turn signal output timing when the ego returns original lane (`#8726 <https://github.com/autowarefoundation/autoware.universe/issues/8726>`_)
   fix(static_obstacle_avoidance): fix unexpected turn signal output
-* docs(static_obstacle_avoidance): light edits. Typos, grammar fixes (`#8759 <https://github.com/youtalk/autoware.universe/issues/8759>`_)
+* docs(static_obstacle_avoidance): light edits. Typos, grammar fixes (`#8759 <https://github.com/autowarefoundation/autoware.universe/issues/8759>`_)
   * Light edit: Typos, grammar fixes. Additional changes to follow
   * Update planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/README.md
   Paragraph revised to correct typos
@@ -85,21 +85,21 @@ Changelog for package autoware_behavior_path_static_obstacle_avoidance_module
   Co-authored-by: Go Sakayori <go-sakayori@users.noreply.github.com>
   Co-authored-by: Go Sakayori <gsakayori@gmail.com>
   Co-authored-by: Satoshi OTA <44889564+satoshi-ota@users.noreply.github.com>
-* fix(autoware_behavior_path_static_obstacle_avoidance_module): fix unusedFunction (`#8776 <https://github.com/youtalk/autoware.universe/issues/8776>`_)
+* fix(autoware_behavior_path_static_obstacle_avoidance_module): fix unusedFunction (`#8776 <https://github.com/autowarefoundation/autoware.universe/issues/8776>`_)
   fix:unusedFunction
-* fix(static_obstacle_avoidance): ignore objects which has already been decided to avoid (`#8754 <https://github.com/youtalk/autoware.universe/issues/8754>`_)
-* fix(autoware_behavior_path_static_obstacle_avoidance_module): fix unusedFunction (`#8732 <https://github.com/youtalk/autoware.universe/issues/8732>`_)
+* fix(static_obstacle_avoidance): ignore objects which has already been decided to avoid (`#8754 <https://github.com/autowarefoundation/autoware.universe/issues/8754>`_)
+* fix(autoware_behavior_path_static_obstacle_avoidance_module): fix unusedFunction (`#8732 <https://github.com/autowarefoundation/autoware.universe/issues/8732>`_)
   fix:unusedFunction
-* fix(static_obstacle_avoidance): change implementation the logic to remove invalid small shift lines (`#8721 <https://github.com/youtalk/autoware.universe/issues/8721>`_)
-  * Revert "fix(static_obstacle_avoidance): remove invalid small shift lines (`#8344 <https://github.com/youtalk/autoware.universe/issues/8344>`_)"
+* fix(static_obstacle_avoidance): change implementation the logic to remove invalid small shift lines (`#8721 <https://github.com/autowarefoundation/autoware.universe/issues/8721>`_)
+  * Revert "fix(static_obstacle_avoidance): remove invalid small shift lines (`#8344 <https://github.com/autowarefoundation/autoware.universe/issues/8344>`_)"
   This reverts commit 2705a63817f02ecfa705960459438763225ea6cf.
   * fix(static_obstacle_avoidance): remove invalid small shift lines
   ---------
-* fix(static_obstacle_avoidance): use wrong parameter (`#8720 <https://github.com/youtalk/autoware.universe/issues/8720>`_)
-* fix(bpp): use common steering factor interface for same scene modules (`#8675 <https://github.com/youtalk/autoware.universe/issues/8675>`_)
-* fix(autoware_behavior_path_static_obstacle_avoidance_module): fix unusedFunction (`#8664 <https://github.com/youtalk/autoware.universe/issues/8664>`_)
+* fix(static_obstacle_avoidance): use wrong parameter (`#8720 <https://github.com/autowarefoundation/autoware.universe/issues/8720>`_)
+* fix(bpp): use common steering factor interface for same scene modules (`#8675 <https://github.com/autowarefoundation/autoware.universe/issues/8675>`_)
+* fix(autoware_behavior_path_static_obstacle_avoidance_module): fix unusedFunction (`#8664 <https://github.com/autowarefoundation/autoware.universe/issues/8664>`_)
   fix:unusedFunction
-* feat(static_obstacle_avoidance): update envelope polygon creation method (`#8551 <https://github.com/youtalk/autoware.universe/issues/8551>`_)
+* feat(static_obstacle_avoidance): update envelope polygon creation method (`#8551 <https://github.com/autowarefoundation/autoware.universe/issues/8551>`_)
   * update envelope polygon by considering pose covariance
   * change parameter
   * modify schema json
@@ -107,31 +107,31 @@ Changelog for package autoware_behavior_path_static_obstacle_avoidance_module
   Co-authored-by: Satoshi OTA <44889564+satoshi-ota@users.noreply.github.com>
   ---------
   Co-authored-by: Satoshi OTA <44889564+satoshi-ota@users.noreply.github.com>
-* fix(static_obstacle_avoidance): target object sorting (`#8545 <https://github.com/youtalk/autoware.universe/issues/8545>`_)
+* fix(static_obstacle_avoidance): target object sorting (`#8545 <https://github.com/autowarefoundation/autoware.universe/issues/8545>`_)
   * fix compensateLostTargetObjects function
   * remove empty case
   ---------
-* docs(static_obstacle_avoidance): add FAQ section in document (`#8514 <https://github.com/youtalk/autoware.universe/issues/8514>`_)
+* docs(static_obstacle_avoidance): add FAQ section in document (`#8514 <https://github.com/autowarefoundation/autoware.universe/issues/8514>`_)
   * add FAQ section in readme
   * refer to FAQ before detail
   * fix
   ---------
-* fix(static_obstacle_avoidance): change avoidance condition (`#8433 <https://github.com/youtalk/autoware.universe/issues/8433>`_)
-* perf(static_obstacle_avoidance): improve logic to reduce computational cost (`#8432 <https://github.com/youtalk/autoware.universe/issues/8432>`_)
+* fix(static_obstacle_avoidance): change avoidance condition (`#8433 <https://github.com/autowarefoundation/autoware.universe/issues/8433>`_)
+* perf(static_obstacle_avoidance): improve logic to reduce computational cost (`#8432 <https://github.com/autowarefoundation/autoware.universe/issues/8432>`_)
   * perf(safety_check): check within first
   * perf(static_obstacle_avoidance): remove duplicated process
   * perf(static_obstacle_avoidance): remove heavy process
   ---------
-* fix(static_obstacle_avoidance): check opposite lane (`#8345 <https://github.com/youtalk/autoware.universe/issues/8345>`_)
-* fix(static_obstacle_avoidance): remove invalid small shift lines (`#8344 <https://github.com/youtalk/autoware.universe/issues/8344>`_)
-* feat(static_obstacle_avoidance): force deactivation (`#8288 <https://github.com/youtalk/autoware.universe/issues/8288>`_)
+* fix(static_obstacle_avoidance): check opposite lane (`#8345 <https://github.com/autowarefoundation/autoware.universe/issues/8345>`_)
+* fix(static_obstacle_avoidance): remove invalid small shift lines (`#8344 <https://github.com/autowarefoundation/autoware.universe/issues/8344>`_)
+* feat(static_obstacle_avoidance): force deactivation (`#8288 <https://github.com/autowarefoundation/autoware.universe/issues/8288>`_)
   * add force cancel function
   * fix format
   * fix json schema
   * fix spelling
   * fix
   ---------
-* feat(static_obstacle_avoidance): enable force execution under unsafe conditions (`#8094 <https://github.com/youtalk/autoware.universe/issues/8094>`_)
+* feat(static_obstacle_avoidance): enable force execution under unsafe conditions (`#8094 <https://github.com/autowarefoundation/autoware.universe/issues/8094>`_)
   * add force execution for static obstacle avoidance
   * fix
   * erase unused function in RTC interface
@@ -140,48 +140,48 @@ Changelog for package autoware_behavior_path_static_obstacle_avoidance_module
   * add warn throtthle and move code block
   * fix
   ---------
-* fix(autoware_behavior_path_static_obstacle_avoidance_module): fix constParameterReference (`#8046 <https://github.com/youtalk/autoware.universe/issues/8046>`_)
+* fix(autoware_behavior_path_static_obstacle_avoidance_module): fix constParameterReference (`#8046 <https://github.com/autowarefoundation/autoware.universe/issues/8046>`_)
   fix:constParameterReference
-* fix(static_obstacle_avoidance): avoid object behind unavoidance object if unavoidable is not on the path (`#8066 <https://github.com/youtalk/autoware.universe/issues/8066>`_)
-* feat(static_obstacle_avoidance): integrate time keeper to major functions (`#8044 <https://github.com/youtalk/autoware.universe/issues/8044>`_)
-* fix(static_obstacle_avoidance): fix issues in target filtiering logic (`#7954 <https://github.com/youtalk/autoware.universe/issues/7954>`_)
+* fix(static_obstacle_avoidance): avoid object behind unavoidance object if unavoidable is not on the path (`#8066 <https://github.com/autowarefoundation/autoware.universe/issues/8066>`_)
+* feat(static_obstacle_avoidance): integrate time keeper to major functions (`#8044 <https://github.com/autowarefoundation/autoware.universe/issues/8044>`_)
+* fix(static_obstacle_avoidance): fix issues in target filtiering logic (`#7954 <https://github.com/autowarefoundation/autoware.universe/issues/7954>`_)
   * fix: unknown filtering flow
   * fix: relax target filtering logic for object which is in freespace
   * docs: update flowchart
   * fix: check stopped time in freespace
   ---------
-* feat(static_obstacle_avoidance): show markers when system requests operator support (`#7994 <https://github.com/youtalk/autoware.universe/issues/7994>`_)
-* fix(static_obstacle_avoidance): don't automatically avoid ambiguous vehicle (`#7851 <https://github.com/youtalk/autoware.universe/issues/7851>`_)
+* feat(static_obstacle_avoidance): show markers when system requests operator support (`#7994 <https://github.com/autowarefoundation/autoware.universe/issues/7994>`_)
+* fix(static_obstacle_avoidance): don't automatically avoid ambiguous vehicle (`#7851 <https://github.com/autowarefoundation/autoware.universe/issues/7851>`_)
   * fix(static_obstacle_avoidance): don't automatically avoid ambiguous vehicle
   * chore(schema): update schema
   ---------
-* fix(static_obstacle_avoidance): stop position is unstable (`#7880 <https://github.com/youtalk/autoware.universe/issues/7880>`_)
+* fix(static_obstacle_avoidance): stop position is unstable (`#7880 <https://github.com/autowarefoundation/autoware.universe/issues/7880>`_)
   fix(static_obstacle_avoidance): fix stop position
-* fix(static_obstacle_avoidance): ignore pedestrian/cyclist who is not on road edge (`#7850 <https://github.com/youtalk/autoware.universe/issues/7850>`_)
+* fix(static_obstacle_avoidance): ignore pedestrian/cyclist who is not on road edge (`#7850 <https://github.com/autowarefoundation/autoware.universe/issues/7850>`_)
   * fix(static_obstacle_avoidance): ignore pedestrian/cyclist who is not on road edge
   * docs(static_obstacle_avoidance): update flowchart
   * Update planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/README.md
   Co-authored-by: Go Sakayori <go-sakayori@users.noreply.github.com>
   ---------
   Co-authored-by: Go Sakayori <go-sakayori@users.noreply.github.com>
-* refactor(static_avoidance): modify getAdjacentLane function (`#7843 <https://github.com/youtalk/autoware.universe/issues/7843>`_)
+* refactor(static_avoidance): modify getAdjacentLane function (`#7843 <https://github.com/autowarefoundation/autoware.universe/issues/7843>`_)
   add getLeftOppositeLanelers in getAdjacentLane function
-* fix(static_obstacle_avoidance): fix issues in target object filtering logic (`#7830 <https://github.com/youtalk/autoware.universe/issues/7830>`_)
+* fix(static_obstacle_avoidance): fix issues in target object filtering logic (`#7830 <https://github.com/autowarefoundation/autoware.universe/issues/7830>`_)
   * fix(static_obstacle_avoidance): check if object is inside/outside by its position point instead of its polygon
   * refactor(static_obstacle_avoidance): add getter functions
   * fix(static_obstacle_avoidance): check next lane without route if the current lane is not preferred
   * fix(static_obstacle_avoidance): fix parked vehicle check
   ---------
-* feat(safety_check): filter safety check targe objects by yaw deviation between pose and lane (`#7828 <https://github.com/youtalk/autoware.universe/issues/7828>`_)
+* feat(safety_check): filter safety check targe objects by yaw deviation between pose and lane (`#7828 <https://github.com/autowarefoundation/autoware.universe/issues/7828>`_)
   * fix(safety_check): filter by yaw deviation to check object belongs to lane
   * fix(static_obstacle_avoidance): check yaw only when the object is moving
   ---------
-* feat: add `autoware\_` prefix to `lanelet2_extension` (`#7640 <https://github.com/youtalk/autoware.universe/issues/7640>`_)
-* refactor(static_obstacle_avoidance): organize params for drivable lane (`#7715 <https://github.com/youtalk/autoware.universe/issues/7715>`_)
+* feat: add `autoware\_` prefix to `lanelet2_extension` (`#7640 <https://github.com/autowarefoundation/autoware.universe/issues/7640>`_)
+* refactor(static_obstacle_avoidance): organize params for drivable lane (`#7715 <https://github.com/autowarefoundation/autoware.universe/issues/7715>`_)
   * refactor(static_obstacle_avoidance): organize params for drivable lane
   * Update planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/schema/static_obstacle_avoidance.schema.json
   ---------
-* feat(start_planner): yaw threshold for rss check (`#7657 <https://github.com/youtalk/autoware.universe/issues/7657>`_)
+* feat(start_planner): yaw threshold for rss check (`#7657 <https://github.com/autowarefoundation/autoware.universe/issues/7657>`_)
   * add param to customize yaw th
   * add param to other modules
   * docs
@@ -189,24 +189,24 @@ Changelog for package autoware_behavior_path_static_obstacle_avoidance_module
   * fix LC README
   * use normalized yaw diff
   ---------
-* docs(static_obstacle_avoidance): fix wrong flowchart (`#7693 <https://github.com/youtalk/autoware.universe/issues/7693>`_)
-* fix(static_obstacle_avoidance): fix json schema (`#7692 <https://github.com/youtalk/autoware.universe/issues/7692>`_)
-* refactor(static_obstacle_avoidance): change logger name for utils    (`#7617 <https://github.com/youtalk/autoware.universe/issues/7617>`_)
+* docs(static_obstacle_avoidance): fix wrong flowchart (`#7693 <https://github.com/autowarefoundation/autoware.universe/issues/7693>`_)
+* fix(static_obstacle_avoidance): fix json schema (`#7692 <https://github.com/autowarefoundation/autoware.universe/issues/7692>`_)
+* refactor(static_obstacle_avoidance): change logger name for utils    (`#7617 <https://github.com/autowarefoundation/autoware.universe/issues/7617>`_)
   change logger name for static avoidance utils
-* feat(static_obstacle_avoidance): keep object clipping even after the object becomes non-target (`#7591 <https://github.com/youtalk/autoware.universe/issues/7591>`_)
-* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/youtalk/autoware.universe/issues/7594>`_)
-* fix(autoware_behavior_path_static_obstacle_avoidance_module): fix duplicateCondition warnings (`#7582 <https://github.com/youtalk/autoware.universe/issues/7582>`_)
-* docs(bpp_static_obstacle_avoidance): add documentation (`#7554 <https://github.com/youtalk/autoware.universe/issues/7554>`_)
+* feat(static_obstacle_avoidance): keep object clipping even after the object becomes non-target (`#7591 <https://github.com/autowarefoundation/autoware.universe/issues/7591>`_)
+* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/autowarefoundation/autoware.universe/issues/7594>`_)
+* fix(autoware_behavior_path_static_obstacle_avoidance_module): fix duplicateCondition warnings (`#7582 <https://github.com/autowarefoundation/autoware.universe/issues/7582>`_)
+* docs(bpp_static_obstacle_avoidance): add documentation (`#7554 <https://github.com/autowarefoundation/autoware.universe/issues/7554>`_)
   * fix: package path
   * docs: add explanation of lateral margin
   * fix: typo
   * fix: wrong description
   ---------
-* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/youtalk/autoware.universe/issues/7539>`_)
+* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/autowarefoundation/autoware.universe/issues/7539>`_)
   refactor(motion_utils): add autoware prefix and include dir
-* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/youtalk/autoware.universe/issues/7538>`_)
+* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/autowarefoundation/autoware.universe/issues/7538>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* refactor(behaivor_path_planner)!: rename to include/autoware/{package_name} (`#7522 <https://github.com/youtalk/autoware.universe/issues/7522>`_)
+* refactor(behaivor_path_planner)!: rename to include/autoware/{package_name} (`#7522 <https://github.com/autowarefoundation/autoware.universe/issues/7522>`_)
   * refactor(behavior_path_planner)!: make autoware dir in include
   * refactor(start_planner): make autoware include dir
   * refactor(goal_planner): make autoware include dir

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/CHANGELOG.rst
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/CHANGELOG.rst
@@ -5,22 +5,22 @@ Changelog for package autoware_behavior_velocity_blind_spot_module
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* fix(blind_spot): hide debug information (`#8885 <https://github.com/youtalk/autoware.universe/issues/8885>`_)
-* fix(behavior_velocity_planner): fix cppcheck warnings of virtualCallInConstructor (`#8376 <https://github.com/youtalk/autoware.universe/issues/8376>`_)
+* fix(blind_spot): hide debug information (`#8885 <https://github.com/autowarefoundation/autoware.universe/issues/8885>`_)
+* fix(behavior_velocity_planner): fix cppcheck warnings of virtualCallInConstructor (`#8376 <https://github.com/autowarefoundation/autoware.universe/issues/8376>`_)
   Co-authored-by: Ryuta Kambe <ryuta.kambe@tier4.jp>
-* fix(autoware_behavior_velocity_blind_spot_module): fix funcArgNamesDifferent (`#8021 <https://github.com/youtalk/autoware.universe/issues/8021>`_)
+* fix(autoware_behavior_velocity_blind_spot_module): fix funcArgNamesDifferent (`#8021 <https://github.com/autowarefoundation/autoware.universe/issues/8021>`_)
   * fix:funcArgNamesDifferent
   * fix:funcArgNamesDifferent
   * refactor:clang format
   ---------
-* feat(blind_spot): consider road_shoulder if exist (`#7925 <https://github.com/youtalk/autoware.universe/issues/7925>`_)
-* feat: add `autoware\_` prefix to `lanelet2_extension` (`#7640 <https://github.com/youtalk/autoware.universe/issues/7640>`_)
-* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/youtalk/autoware.universe/issues/7594>`_)
-* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/youtalk/autoware.universe/issues/7539>`_)
+* feat(blind_spot): consider road_shoulder if exist (`#7925 <https://github.com/autowarefoundation/autoware.universe/issues/7925>`_)
+* feat: add `autoware\_` prefix to `lanelet2_extension` (`#7640 <https://github.com/autowarefoundation/autoware.universe/issues/7640>`_)
+* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/autowarefoundation/autoware.universe/issues/7594>`_)
+* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/autowarefoundation/autoware.universe/issues/7539>`_)
   refactor(motion_utils): add autoware prefix and include dir
-* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/youtalk/autoware.universe/issues/7538>`_)
+* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/autowarefoundation/autoware.universe/issues/7538>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* chore(behavior_velocity_planner): move packages (`#7526 <https://github.com/youtalk/autoware.universe/issues/7526>`_)
+* chore(behavior_velocity_planner): move packages (`#7526 <https://github.com/autowarefoundation/autoware.universe/issues/7526>`_)
 * Contributors: Fumiya Watanabe, Kosuke Takeuchi, Mamoru Sobue, Satoshi OTA, Takayuki Murooka, Yutaka Kondo, kobayu858, taisa1
 
 0.26.0 (2024-04-03)

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/CHANGELOG.rst
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/CHANGELOG.rst
@@ -5,49 +5,49 @@ Changelog for package autoware_behavior_velocity_crosswalk_module
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* refactor(autoware_grid_map_utils): prefix folder structure with autoware/ (`#9170 <https://github.com/youtalk/autoware.universe/issues/9170>`_)
-* fix(crosswalk): fix occlusion detection range calculation and add debug markers (`#9121 <https://github.com/youtalk/autoware.universe/issues/9121>`_)
-* fix(crosswalk): fix passing direction calclation for the objects (`#9071 <https://github.com/youtalk/autoware.universe/issues/9071>`_)
-* fix(crosswalk): change exceptional handling (`#8956 <https://github.com/youtalk/autoware.universe/issues/8956>`_)
-* refactor(autoware_interpolation): prefix package and namespace with autoware (`#8088 <https://github.com/youtalk/autoware.universe/issues/8088>`_)
+* refactor(autoware_grid_map_utils): prefix folder structure with autoware/ (`#9170 <https://github.com/autowarefoundation/autoware.universe/issues/9170>`_)
+* fix(crosswalk): fix occlusion detection range calculation and add debug markers (`#9121 <https://github.com/autowarefoundation/autoware.universe/issues/9121>`_)
+* fix(crosswalk): fix passing direction calclation for the objects (`#9071 <https://github.com/autowarefoundation/autoware.universe/issues/9071>`_)
+* fix(crosswalk): change exceptional handling (`#8956 <https://github.com/autowarefoundation/autoware.universe/issues/8956>`_)
+* refactor(autoware_interpolation): prefix package and namespace with autoware (`#8088 <https://github.com/autowarefoundation/autoware.universe/issues/8088>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* feat(crosswalk)!: update stop position caluculation (`#8853 <https://github.com/youtalk/autoware.universe/issues/8853>`_)
-* feat(crosswalk): suppress restart when the ego is close to the next stop point (`#8817 <https://github.com/youtalk/autoware.universe/issues/8817>`_)
+* feat(crosswalk)!: update stop position caluculation (`#8853 <https://github.com/autowarefoundation/autoware.universe/issues/8853>`_)
+* feat(crosswalk): suppress restart when the ego is close to the next stop point (`#8817 <https://github.com/autowarefoundation/autoware.universe/issues/8817>`_)
   * feat(crosswalk): suppress restart when the ego is close to the next stop point
   * update
   * add comment
   ---------
-* fix(behavior_velocity_planner): align the parameters with launcher (`#8791 <https://github.com/youtalk/autoware.universe/issues/8791>`_)
+* fix(behavior_velocity_planner): align the parameters with launcher (`#8791 <https://github.com/autowarefoundation/autoware.universe/issues/8791>`_)
   parameters in behavior_velocity_planner aligned
-* fix(autoware_behavior_velocity_crosswalk_module): fix unusedFunction (`#8665 <https://github.com/youtalk/autoware.universe/issues/8665>`_)
+* fix(autoware_behavior_velocity_crosswalk_module): fix unusedFunction (`#8665 <https://github.com/autowarefoundation/autoware.universe/issues/8665>`_)
   fix:unusedFunction
-* fix(crosswalk): fix findEgoPassageDirectionAlongPath finding front and back point logic (`#8459 <https://github.com/youtalk/autoware.universe/issues/8459>`_)
+* fix(crosswalk): fix findEgoPassageDirectionAlongPath finding front and back point logic (`#8459 <https://github.com/autowarefoundation/autoware.universe/issues/8459>`_)
   * fix(crosswalk): fix findEgoPassageDirectionAlongPath finding front and back point logic
   * define ego_crosswalk_passage_direction later
   ---------
-* fix(behavior_velocity_planner): fix cppcheck warnings of virtualCallInConstructor (`#8376 <https://github.com/youtalk/autoware.universe/issues/8376>`_)
+* fix(behavior_velocity_planner): fix cppcheck warnings of virtualCallInConstructor (`#8376 <https://github.com/autowarefoundation/autoware.universe/issues/8376>`_)
   Co-authored-by: Ryuta Kambe <ryuta.kambe@tier4.jp>
-* fix(autoware_behavior_velocity_crosswalk_module): fix passedByValue (`#8210 <https://github.com/youtalk/autoware.universe/issues/8210>`_)
+* fix(autoware_behavior_velocity_crosswalk_module): fix passedByValue (`#8210 <https://github.com/autowarefoundation/autoware.universe/issues/8210>`_)
   * fix:passedByValue
   * fix:passedByValue
   ---------
-* refactor(crosswalk): clean up the structure and create a brief flowchart (`#7868 <https://github.com/youtalk/autoware.universe/issues/7868>`_)
+* refactor(crosswalk): clean up the structure and create a brief flowchart (`#7868 <https://github.com/autowarefoundation/autoware.universe/issues/7868>`_)
   * refactor(crosswalk): clean up the structure and create a brief flowchart
   * update
   * fix
   * static stop pose -> default stop pose
   ---------
-* fix(autoware_behavior_velocity_crosswalk_module): fix shadowVariable (`#7974 <https://github.com/youtalk/autoware.universe/issues/7974>`_)
+* fix(autoware_behavior_velocity_crosswalk_module): fix shadowVariable (`#7974 <https://github.com/autowarefoundation/autoware.universe/issues/7974>`_)
   * fix:shadowVariable
   * fix:shadowVariable
   ---------
-* feat: add `autoware\_` prefix to `lanelet2_extension` (`#7640 <https://github.com/youtalk/autoware.universe/issues/7640>`_)
-* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/youtalk/autoware.universe/issues/7594>`_)
-* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/youtalk/autoware.universe/issues/7539>`_)
+* feat: add `autoware\_` prefix to `lanelet2_extension` (`#7640 <https://github.com/autowarefoundation/autoware.universe/issues/7640>`_)
+* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/autowarefoundation/autoware.universe/issues/7594>`_)
+* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/autowarefoundation/autoware.universe/issues/7539>`_)
   refactor(motion_utils): add autoware prefix and include dir
-* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/youtalk/autoware.universe/issues/7538>`_)
+* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/autowarefoundation/autoware.universe/issues/7538>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* chore(behavior_velocity_planner): move packages (`#7526 <https://github.com/youtalk/autoware.universe/issues/7526>`_)
+* chore(behavior_velocity_planner): move packages (`#7526 <https://github.com/autowarefoundation/autoware.universe/issues/7526>`_)
 * Contributors: Esteve Fernandez, Fumiya Watanabe, Kosuke Takeuchi, Maxime CLEMENT, Mehmet Dogru, Takayuki Murooka, Yuki TAKAGI, Yutaka Kondo, Zhe Shen, kobayu858, taisa1
 
 0.26.0 (2024-04-03)

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_detection_area_module/CHANGELOG.rst
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_detection_area_module/CHANGELOG.rst
@@ -5,22 +5,22 @@ Changelog for package autoware_behavior_velocity_detection_area_module
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* test(detection_area): refactor and add unit tests (`#9087 <https://github.com/youtalk/autoware.universe/issues/9087>`_)
-* fix(behavior_velocity_planner): fix cppcheck warnings of virtualCallInConstructor (`#8376 <https://github.com/youtalk/autoware.universe/issues/8376>`_)
+* test(detection_area): refactor and add unit tests (`#9087 <https://github.com/autowarefoundation/autoware.universe/issues/9087>`_)
+* fix(behavior_velocity_planner): fix cppcheck warnings of virtualCallInConstructor (`#8376 <https://github.com/autowarefoundation/autoware.universe/issues/8376>`_)
   Co-authored-by: Ryuta Kambe <ryuta.kambe@tier4.jp>
-* fix(autoware_behavior_velocity_detection_area_module): fix uninitMemberVar (`#8332 <https://github.com/youtalk/autoware.universe/issues/8332>`_)
+* fix(autoware_behavior_velocity_detection_area_module): fix uninitMemberVar (`#8332 <https://github.com/autowarefoundation/autoware.universe/issues/8332>`_)
   fix:uninitMemberVar
-* feat: add `autoware\_` prefix to `lanelet2_extension` (`#7640 <https://github.com/youtalk/autoware.universe/issues/7640>`_)
-* fix(autoware_behavior_velocity_planner_common): remove lane_id check from arc_lane_util (`#7710 <https://github.com/youtalk/autoware.universe/issues/7710>`_)
+* feat: add `autoware\_` prefix to `lanelet2_extension` (`#7640 <https://github.com/autowarefoundation/autoware.universe/issues/7640>`_)
+* fix(autoware_behavior_velocity_planner_common): remove lane_id check from arc_lane_util (`#7710 <https://github.com/autowarefoundation/autoware.universe/issues/7710>`_)
   * fix(arc_lane_util): remove lane_id check from arc_lane_util
   * modify test_arc_lane_util.cpp
   ---------
-* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/youtalk/autoware.universe/issues/7594>`_)
-* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/youtalk/autoware.universe/issues/7539>`_)
+* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/autowarefoundation/autoware.universe/issues/7594>`_)
+* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/autowarefoundation/autoware.universe/issues/7539>`_)
   refactor(motion_utils): add autoware prefix and include dir
-* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/youtalk/autoware.universe/issues/7538>`_)
+* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/autowarefoundation/autoware.universe/issues/7538>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* chore(behavior_velocity_planner): move packages (`#7526 <https://github.com/youtalk/autoware.universe/issues/7526>`_)
+* chore(behavior_velocity_planner): move packages (`#7526 <https://github.com/autowarefoundation/autoware.universe/issues/7526>`_)
 * Contributors: Fumiya Watanabe, Kosuke Takeuchi, Maxime CLEMENT, Takayuki Murooka, Yukinari Hisaki, Yutaka Kondo, kobayu858, taisa1
 
 0.26.0 (2024-04-03)

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/CHANGELOG.rst
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/CHANGELOG.rst
@@ -5,66 +5,66 @@ Changelog for package autoware_behavior_velocity_intersection_module
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* chore(intersection): print RTC status in diagnostic debug message (`#9007 <https://github.com/youtalk/autoware.universe/issues/9007>`_)
+* chore(intersection): print RTC status in diagnostic debug message (`#9007 <https://github.com/autowarefoundation/autoware.universe/issues/9007>`_)
   debug(intersection): print RTC status in diagnostic message
-* fix(behavior_path_planner, behavior_velocity_planner): fix to not read invalid ID (`#9103 <https://github.com/youtalk/autoware.universe/issues/9103>`_)
+* fix(behavior_path_planner, behavior_velocity_planner): fix to not read invalid ID (`#9103 <https://github.com/autowarefoundation/autoware.universe/issues/9103>`_)
   * fix(behavior_path_planner, behavior_velocity_planner): fix to not read invalid ID
   * style(pre-commit): autofix
   * fix typo
   * fix(behavior_path_planner, behavior_velocity_planner): fix typo and indentation
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* fix(intersection): handle pass judge after red/arrow-signal to ignore NPCs after the signal changed to green again (`#9119 <https://github.com/youtalk/autoware.universe/issues/9119>`_)
-* fix(intersection): set RTC enable (`#9040 <https://github.com/youtalk/autoware.universe/issues/9040>`_)
+* fix(intersection): handle pass judge after red/arrow-signal to ignore NPCs after the signal changed to green again (`#9119 <https://github.com/autowarefoundation/autoware.universe/issues/9119>`_)
+* fix(intersection): set RTC enable (`#9040 <https://github.com/autowarefoundation/autoware.universe/issues/9040>`_)
   set rtc enable
-* fix(interpolation): fix bug of interpolation (`#8969 <https://github.com/youtalk/autoware.universe/issues/8969>`_)
+* fix(interpolation): fix bug of interpolation (`#8969 <https://github.com/autowarefoundation/autoware.universe/issues/8969>`_)
   fix bug of interpolation
-* refactor(autoware_interpolation): prefix package and namespace with autoware (`#8088 <https://github.com/youtalk/autoware.universe/issues/8088>`_)
+* refactor(autoware_interpolation): prefix package and namespace with autoware (`#8088 <https://github.com/autowarefoundation/autoware.universe/issues/8088>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* fix(intersection): fix typo (`#8911 <https://github.com/youtalk/autoware.universe/issues/8911>`_)
+* fix(intersection): fix typo (`#8911 <https://github.com/autowarefoundation/autoware.universe/issues/8911>`_)
   * fix(intersection): fix typo
   * fix(intersection): fix typo
   * style(pre-commit): autofix
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* fix(bvp): fix rtc state update logic (`#8884 <https://github.com/youtalk/autoware.universe/issues/8884>`_)
+* fix(bvp): fix rtc state update logic (`#8884 <https://github.com/autowarefoundation/autoware.universe/issues/8884>`_)
   * fix(bvp): fix rtc state update logic
   * fix(intersection): fix unexpected rtc state initialization
   ---------
-* fix(autoware_behavior_velocity_intersection_module): fix unusedFunction (`#8666 <https://github.com/youtalk/autoware.universe/issues/8666>`_)
+* fix(autoware_behavior_velocity_intersection_module): fix unusedFunction (`#8666 <https://github.com/autowarefoundation/autoware.universe/issues/8666>`_)
   * fix:unusedFunction
   * fix:unusedFunction
   ---------
-* fix(autoware_behavior_velocity_intersection_module): fix unreadVariable (`#8836 <https://github.com/youtalk/autoware.universe/issues/8836>`_)
+* fix(autoware_behavior_velocity_intersection_module): fix unreadVariable (`#8836 <https://github.com/autowarefoundation/autoware.universe/issues/8836>`_)
   fix:unreadVariable
-* fix(autoware_behavior_velocity_intersection_module): fix virtualCallInConstructor (`#8835 <https://github.com/youtalk/autoware.universe/issues/8835>`_)
+* fix(autoware_behavior_velocity_intersection_module): fix virtualCallInConstructor (`#8835 <https://github.com/autowarefoundation/autoware.universe/issues/8835>`_)
   fix:virtualCallInConstructor
-* fix(behavior_velocity_planner): align the parameters with launcher (`#8791 <https://github.com/youtalk/autoware.universe/issues/8791>`_)
+* fix(behavior_velocity_planner): align the parameters with launcher (`#8791 <https://github.com/autowarefoundation/autoware.universe/issues/8791>`_)
   parameters in behavior_velocity_planner aligned
-* fix(intersection): additional fix for 8520 (`#8561 <https://github.com/youtalk/autoware.universe/issues/8561>`_)
-* feat(intersection): fix topological sort for complicated intersection (`#8520 <https://github.com/youtalk/autoware.universe/issues/8520>`_)
+* fix(intersection): additional fix for 8520 (`#8561 <https://github.com/autowarefoundation/autoware.universe/issues/8561>`_)
+* feat(intersection): fix topological sort for complicated intersection (`#8520 <https://github.com/autowarefoundation/autoware.universe/issues/8520>`_)
   * for enclave occlusion detection lanelet
   * some refactorings and modify doxygen
   * fix ci
   ---------
   Co-authored-by: Y.Hisaki <yhisaki31@gmail.com>
-* fix(behavior_velocity_planner): fix cppcheck warnings of virtualCallInConstructor (`#8376 <https://github.com/youtalk/autoware.universe/issues/8376>`_)
+* fix(behavior_velocity_planner): fix cppcheck warnings of virtualCallInConstructor (`#8376 <https://github.com/autowarefoundation/autoware.universe/issues/8376>`_)
   Co-authored-by: Ryuta Kambe <ryuta.kambe@tier4.jp>
-* feat(intersection): add test map for intersection (`#8455 <https://github.com/youtalk/autoware.universe/issues/8455>`_)
-* fix(autoware_smart_mpc_trajectory_follower): fix unusedStructMember (`#8393 <https://github.com/youtalk/autoware.universe/issues/8393>`_)
+* feat(intersection): add test map for intersection (`#8455 <https://github.com/autowarefoundation/autoware.universe/issues/8455>`_)
+* fix(autoware_smart_mpc_trajectory_follower): fix unusedStructMember (`#8393 <https://github.com/autowarefoundation/autoware.universe/issues/8393>`_)
   * fix:unusedStructMember
   * fix:unusedStructMember
   * fix:clang format
   ---------
-* fix(autoware_behavior_velocity_intersection_module): fix functionConst (`#8283 <https://github.com/youtalk/autoware.universe/issues/8283>`_)
+* fix(autoware_behavior_velocity_intersection_module): fix functionConst (`#8283 <https://github.com/autowarefoundation/autoware.universe/issues/8283>`_)
   fix:functionConst
-* fix(autoware_behavior_velocity_intersection_module): fix funcArgNamesDifferent (`#8023 <https://github.com/youtalk/autoware.universe/issues/8023>`_)
+* fix(autoware_behavior_velocity_intersection_module): fix funcArgNamesDifferent (`#8023 <https://github.com/autowarefoundation/autoware.universe/issues/8023>`_)
   * fix:funcArgNamesDifferent
   * fix:funcArgNamesDifferent
   * refactor:clang format
   * fix:funcArgNamesDifferent
   ---------
-* refactor(probabilistic_occupancy_grid_map, occupancy_grid_map_outlier_filter): add autoware\_ prefix to package name (`#8183 <https://github.com/youtalk/autoware.universe/issues/8183>`_)
+* refactor(probabilistic_occupancy_grid_map, occupancy_grid_map_outlier_filter): add autoware\_ prefix to package name (`#8183 <https://github.com/autowarefoundation/autoware.universe/issues/8183>`_)
   * chore: fix package name probabilistic occupancy grid map
   * fix: solve launch error
   * chore: update occupancy_grid_map_outlier_filter
@@ -74,21 +74,21 @@ Changelog for package autoware_behavior_velocity_intersection_module
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Taekjin LEE <taekjin.lee@tier4.jp>
-* fix(autoware_behavior_velocity_intersection_module): fix shadowVariable (`#7976 <https://github.com/youtalk/autoware.universe/issues/7976>`_)
-* fix(autoware_behavior_velocity_intersection_module): fix shadowFunction (`#7835 <https://github.com/youtalk/autoware.universe/issues/7835>`_)
+* fix(autoware_behavior_velocity_intersection_module): fix shadowVariable (`#7976 <https://github.com/autowarefoundation/autoware.universe/issues/7976>`_)
+* fix(autoware_behavior_velocity_intersection_module): fix shadowFunction (`#7835 <https://github.com/autowarefoundation/autoware.universe/issues/7835>`_)
   * fix(autoware_behavior_velocity_intersection_module): fix shadowFunction
   * style(pre-commit): autofix
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat: add `autoware\_` prefix to `lanelet2_extension` (`#7640 <https://github.com/youtalk/autoware.universe/issues/7640>`_)
-* refactor(behavior_velocity_intersection): apply clang-tidy check (`#7552 <https://github.com/youtalk/autoware.universe/issues/7552>`_)
+* feat: add `autoware\_` prefix to `lanelet2_extension` (`#7640 <https://github.com/autowarefoundation/autoware.universe/issues/7640>`_)
+* refactor(behavior_velocity_intersection): apply clang-tidy check (`#7552 <https://github.com/autowarefoundation/autoware.universe/issues/7552>`_)
   intersection
-* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/youtalk/autoware.universe/issues/7594>`_)
-* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/youtalk/autoware.universe/issues/7539>`_)
+* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/autowarefoundation/autoware.universe/issues/7594>`_)
+* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/autowarefoundation/autoware.universe/issues/7539>`_)
   refactor(motion_utils): add autoware prefix and include dir
-* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/youtalk/autoware.universe/issues/7538>`_)
+* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/autowarefoundation/autoware.universe/issues/7538>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* chore(behavior_velocity_planner): move packages (`#7526 <https://github.com/youtalk/autoware.universe/issues/7526>`_)
+* chore(behavior_velocity_planner): move packages (`#7526 <https://github.com/autowarefoundation/autoware.universe/issues/7526>`_)
 * Contributors: Esteve Fernandez, Fumiya Watanabe, Go Sakayori, Kosuke Takeuchi, Mamoru Sobue, Ryuta Kambe, Satoshi OTA, T-Kimura-MM, Takayuki Murooka, Yoshi Ri, Yukinari Hisaki, Yutaka Kondo, Zhe Shen, kobayu858, taisa1
 
 0.26.0 (2024-04-03)

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_no_drivable_lane_module/CHANGELOG.rst
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_no_drivable_lane_module/CHANGELOG.rst
@@ -5,21 +5,21 @@ Changelog for package autoware_behavior_velocity_no_drivable_lane_module
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* fix(behavior_velocity_planner): fix cppcheck warnings of virtualCallInConstructor (`#8376 <https://github.com/youtalk/autoware.universe/issues/8376>`_)
+* fix(behavior_velocity_planner): fix cppcheck warnings of virtualCallInConstructor (`#8376 <https://github.com/autowarefoundation/autoware.universe/issues/8376>`_)
   Co-authored-by: Ryuta Kambe <ryuta.kambe@tier4.jp>
-* fix(autoware_behavior_velocity_no_drivable_lane_module): fix uninitMemberVar (`#8322 <https://github.com/youtalk/autoware.universe/issues/8322>`_)
+* fix(autoware_behavior_velocity_no_drivable_lane_module): fix uninitMemberVar (`#8322 <https://github.com/autowarefoundation/autoware.universe/issues/8322>`_)
   * fix:uninitMemberVar
   * fix:uninitMemberVar
   ---------
-* fix(autoware_behavior_velocity_no_drivable_lane_module): fix bug of uninitialization (`#7928 <https://github.com/youtalk/autoware.universe/issues/7928>`_)
-* feat: add `autoware\_` prefix to `lanelet2_extension` (`#7640 <https://github.com/youtalk/autoware.universe/issues/7640>`_)
-* fix(autoware_behavior_velocity_no_drivable_lane_module): fix containerOutOfBounds wawrning (`#7631 <https://github.com/youtalk/autoware.universe/issues/7631>`_)
+* fix(autoware_behavior_velocity_no_drivable_lane_module): fix bug of uninitialization (`#7928 <https://github.com/autowarefoundation/autoware.universe/issues/7928>`_)
+* feat: add `autoware\_` prefix to `lanelet2_extension` (`#7640 <https://github.com/autowarefoundation/autoware.universe/issues/7640>`_)
+* fix(autoware_behavior_velocity_no_drivable_lane_module): fix containerOutOfBounds wawrning (`#7631 <https://github.com/autowarefoundation/autoware.universe/issues/7631>`_)
   * fix(autoware_behavior_velocity_no_drivable_lane_module): fix containerOutOfBounds wawrning
   * style(pre-commit): autofix
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/youtalk/autoware.universe/issues/7594>`_)
-* refactor(behavior_velocity_no_drivable_lane_module): prefix package and namespace with autoware (`#7469 <https://github.com/youtalk/autoware.universe/issues/7469>`_)
+* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/autowarefoundation/autoware.universe/issues/7594>`_)
+* refactor(behavior_velocity_no_drivable_lane_module): prefix package and namespace with autoware (`#7469 <https://github.com/autowarefoundation/autoware.universe/issues/7469>`_)
 * Contributors: Esteve Fernandez, Kosuke Takeuchi, Ryuta Kambe, Yukinari Hisaki, Yutaka Kondo, kobayu858, taisa1
 
 0.26.0 (2024-04-03)

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_no_stopping_area_module/CHANGELOG.rst
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_no_stopping_area_module/CHANGELOG.rst
@@ -5,25 +5,25 @@ Changelog for package autoware_behavior_velocity_no_stopping_area_module
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* test(no_stopping_area): refactor and add tests (`#9009 <https://github.com/youtalk/autoware.universe/issues/9009>`_)
+* test(no_stopping_area): refactor and add tests (`#9009 <https://github.com/autowarefoundation/autoware.universe/issues/9009>`_)
   Co-authored-by: Kosuke Takeuchi <kosuke.tnp@gmail.com>
-* refactor(autoware_interpolation): prefix package and namespace with autoware (`#8088 <https://github.com/youtalk/autoware.universe/issues/8088>`_)
+* refactor(autoware_interpolation): prefix package and namespace with autoware (`#8088 <https://github.com/autowarefoundation/autoware.universe/issues/8088>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* fix(behavior_velocity_planner): fix cppcheck warnings of virtualCallInConstructor (`#8376 <https://github.com/youtalk/autoware.universe/issues/8376>`_)
+* fix(behavior_velocity_planner): fix cppcheck warnings of virtualCallInConstructor (`#8376 <https://github.com/autowarefoundation/autoware.universe/issues/8376>`_)
   Co-authored-by: Ryuta Kambe <ryuta.kambe@tier4.jp>
-* fix(autoware_behavior_velocity_no_stopping_area_module): fix uninitMemberVar (`#8321 <https://github.com/youtalk/autoware.universe/issues/8321>`_)
+* fix(autoware_behavior_velocity_no_stopping_area_module): fix uninitMemberVar (`#8321 <https://github.com/autowarefoundation/autoware.universe/issues/8321>`_)
   fix:uninitMemberVar
-* feat: add `autoware\_` prefix to `lanelet2_extension` (`#7640 <https://github.com/youtalk/autoware.universe/issues/7640>`_)
-* fix(autoware_behavior_velocity_planner_common): remove lane_id check from arc_lane_util (`#7710 <https://github.com/youtalk/autoware.universe/issues/7710>`_)
+* feat: add `autoware\_` prefix to `lanelet2_extension` (`#7640 <https://github.com/autowarefoundation/autoware.universe/issues/7640>`_)
+* fix(autoware_behavior_velocity_planner_common): remove lane_id check from arc_lane_util (`#7710 <https://github.com/autowarefoundation/autoware.universe/issues/7710>`_)
   * fix(arc_lane_util): remove lane_id check from arc_lane_util
   * modify test_arc_lane_util.cpp
   ---------
-* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/youtalk/autoware.universe/issues/7594>`_)
-* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/youtalk/autoware.universe/issues/7539>`_)
+* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/autowarefoundation/autoware.universe/issues/7594>`_)
+* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/autowarefoundation/autoware.universe/issues/7539>`_)
   refactor(motion_utils): add autoware prefix and include dir
-* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/youtalk/autoware.universe/issues/7538>`_)
+* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/autowarefoundation/autoware.universe/issues/7538>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* chore(behavior_velocity_planner): move packages (`#7526 <https://github.com/youtalk/autoware.universe/issues/7526>`_)
+* chore(behavior_velocity_planner): move packages (`#7526 <https://github.com/autowarefoundation/autoware.universe/issues/7526>`_)
 * Contributors: Esteve Fernandez, Fumiya Watanabe, Kosuke Takeuchi, Maxime CLEMENT, Takayuki Murooka, Yukinari Hisaki, Yutaka Kondo, kobayu858, taisa1
 
 0.26.0 (2024-04-03)

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_occlusion_spot_module/CHANGELOG.rst
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_occlusion_spot_module/CHANGELOG.rst
@@ -5,30 +5,30 @@ Changelog for package autoware_behavior_velocity_occlusion_spot_module
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* refactor(autoware_grid_map_utils): prefix folder structure with autoware/ (`#9170 <https://github.com/youtalk/autoware.universe/issues/9170>`_)
-* refactor(autoware_interpolation): prefix package and namespace with autoware (`#8088 <https://github.com/youtalk/autoware.universe/issues/8088>`_)
+* refactor(autoware_grid_map_utils): prefix folder structure with autoware/ (`#9170 <https://github.com/autowarefoundation/autoware.universe/issues/9170>`_)
+* refactor(autoware_interpolation): prefix package and namespace with autoware (`#8088 <https://github.com/autowarefoundation/autoware.universe/issues/8088>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* fix(behavior_velocity_planner): align the parameters with launcher (`#8791 <https://github.com/youtalk/autoware.universe/issues/8791>`_)
+* fix(behavior_velocity_planner): align the parameters with launcher (`#8791 <https://github.com/autowarefoundation/autoware.universe/issues/8791>`_)
   parameters in behavior_velocity_planner aligned
-* fix(behavior_velocity_planner): fix cppcheck warnings of virtualCallInConstructor (`#8376 <https://github.com/youtalk/autoware.universe/issues/8376>`_)
+* fix(behavior_velocity_planner): fix cppcheck warnings of virtualCallInConstructor (`#8376 <https://github.com/autowarefoundation/autoware.universe/issues/8376>`_)
   Co-authored-by: Ryuta Kambe <ryuta.kambe@tier4.jp>
-* fix(autoware_behavior_velocity_speed_bump_module): fix uninitMemberVar (`#8320 <https://github.com/youtalk/autoware.universe/issues/8320>`_)
+* fix(autoware_behavior_velocity_speed_bump_module): fix uninitMemberVar (`#8320 <https://github.com/autowarefoundation/autoware.universe/issues/8320>`_)
   * fix:uninitMemberVar
   * fix:clang format
   * fix:uninitMemberVar
   * fix:clang format
   * fix:clang format
   ---------
-* fix(autoware_behavior_velocity_occlusion_module): fix passedByValue (`#8211 <https://github.com/youtalk/autoware.universe/issues/8211>`_)
+* fix(autoware_behavior_velocity_occlusion_module): fix passedByValue (`#8211 <https://github.com/autowarefoundation/autoware.universe/issues/8211>`_)
   fix:passedByValue
-* feat: add `autoware\_` prefix to `lanelet2_extension` (`#7640 <https://github.com/youtalk/autoware.universe/issues/7640>`_)
-* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/youtalk/autoware.universe/issues/7594>`_)
-* fix(autoware_behavior_velocity_occlusion_spot_module): fix redundantAssignment bug (`#7559 <https://github.com/youtalk/autoware.universe/issues/7559>`_)
-* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/youtalk/autoware.universe/issues/7539>`_)
+* feat: add `autoware\_` prefix to `lanelet2_extension` (`#7640 <https://github.com/autowarefoundation/autoware.universe/issues/7640>`_)
+* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/autowarefoundation/autoware.universe/issues/7594>`_)
+* fix(autoware_behavior_velocity_occlusion_spot_module): fix redundantAssignment bug (`#7559 <https://github.com/autowarefoundation/autoware.universe/issues/7559>`_)
+* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/autowarefoundation/autoware.universe/issues/7539>`_)
   refactor(motion_utils): add autoware prefix and include dir
-* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/youtalk/autoware.universe/issues/7538>`_)
+* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/autowarefoundation/autoware.universe/issues/7538>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* chore(behavior_velocity_planner): move packages (`#7526 <https://github.com/youtalk/autoware.universe/issues/7526>`_)
+* chore(behavior_velocity_planner): move packages (`#7526 <https://github.com/autowarefoundation/autoware.universe/issues/7526>`_)
 * Contributors: Esteve Fernandez, Fumiya Watanabe, Kosuke Takeuchi, Ryuta Kambe, Takayuki Murooka, Yutaka Kondo, Zhe Shen, kobayu858, taisa1
 
 0.26.0 (2024-04-03)

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/CHANGELOG.rst
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/CHANGELOG.rst
@@ -5,23 +5,23 @@ Changelog for package autoware_behavior_velocity_planner
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* fix(autoware_behavior_velocity_planner): fix passedByValue (`#8213 <https://github.com/youtalk/autoware.universe/issues/8213>`_)
+* fix(autoware_behavior_velocity_planner): fix passedByValue (`#8213 <https://github.com/autowarefoundation/autoware.universe/issues/8213>`_)
   fix:passedByValue
-* chore(autoware_behavior_velocity_planner): remove no_prefix function from tests (`#7589 <https://github.com/youtalk/autoware.universe/issues/7589>`_)
-* feat: add `autoware\_` prefix to `lanelet2_extension` (`#7640 <https://github.com/youtalk/autoware.universe/issues/7640>`_)
-* refactor(autoware_behavior_velocity_speed_bump_module): prefix package and namespace with autoware (`#7467 <https://github.com/youtalk/autoware.universe/issues/7467>`_)
-* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/youtalk/autoware.universe/issues/7594>`_)
-* refactor(behavior_velocity_no_drivable_lane_module): prefix package and namespace with autoware (`#7469 <https://github.com/youtalk/autoware.universe/issues/7469>`_)
-* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/youtalk/autoware.universe/issues/7539>`_)
+* chore(autoware_behavior_velocity_planner): remove no_prefix function from tests (`#7589 <https://github.com/autowarefoundation/autoware.universe/issues/7589>`_)
+* feat: add `autoware\_` prefix to `lanelet2_extension` (`#7640 <https://github.com/autowarefoundation/autoware.universe/issues/7640>`_)
+* refactor(autoware_behavior_velocity_speed_bump_module): prefix package and namespace with autoware (`#7467 <https://github.com/autowarefoundation/autoware.universe/issues/7467>`_)
+* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/autowarefoundation/autoware.universe/issues/7594>`_)
+* refactor(behavior_velocity_no_drivable_lane_module): prefix package and namespace with autoware (`#7469 <https://github.com/autowarefoundation/autoware.universe/issues/7469>`_)
+* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/autowarefoundation/autoware.universe/issues/7539>`_)
   refactor(motion_utils): add autoware prefix and include dir
-* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/youtalk/autoware.universe/issues/7538>`_)
+* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/autowarefoundation/autoware.universe/issues/7538>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* chore(behavior_velocity_planner): fix CODEOWNERS and page links (`#7534 <https://github.com/youtalk/autoware.universe/issues/7534>`_)
+* chore(behavior_velocity_planner): fix CODEOWNERS and page links (`#7534 <https://github.com/autowarefoundation/autoware.universe/issues/7534>`_)
   * chore(behavior_velocity_planner): fix CODEOWNERS and page links
   * fix: fix page link
   ---------
-* refactor(velocity_smoother): rename to include/autoware/{package_name} (`#7533 <https://github.com/youtalk/autoware.universe/issues/7533>`_)
-* chore(behavior_velocity_planner): move packages (`#7526 <https://github.com/youtalk/autoware.universe/issues/7526>`_)
+* refactor(velocity_smoother): rename to include/autoware/{package_name} (`#7533 <https://github.com/autowarefoundation/autoware.universe/issues/7533>`_)
+* chore(behavior_velocity_planner): move packages (`#7526 <https://github.com/autowarefoundation/autoware.universe/issues/7526>`_)
 * Contributors: Esteve Fernandez, Fumiya Watanabe, Kosuke Takeuchi, Takayuki Murooka, Yutaka Kondo, kobayu858
 
 0.26.0 (2024-04-03)

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/CHANGELOG.rst
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/CHANGELOG.rst
@@ -5,52 +5,52 @@ Changelog for package autoware_behavior_velocity_planner_common
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* fix(behavior_velocity_planner_common): fix findOffsetSegment (`#9130 <https://github.com/youtalk/autoware.universe/issues/9130>`_)
-* feat(autoware_test_utils): move test_map, add launcher for test_map (`#9045 <https://github.com/youtalk/autoware.universe/issues/9045>`_)
-* test(no_stopping_area): refactor and add tests (`#9009 <https://github.com/youtalk/autoware.universe/issues/9009>`_)
+* fix(behavior_velocity_planner_common): fix findOffsetSegment (`#9130 <https://github.com/autowarefoundation/autoware.universe/issues/9130>`_)
+* feat(autoware_test_utils): move test_map, add launcher for test_map (`#9045 <https://github.com/autowarefoundation/autoware.universe/issues/9045>`_)
+* test(no_stopping_area): refactor and add tests (`#9009 <https://github.com/autowarefoundation/autoware.universe/issues/9009>`_)
   Co-authored-by: Kosuke Takeuchi <kosuke.tnp@gmail.com>
-* fix(autoware_behavior_velocity_planner_common): add node clock, fix use sim time (`#8876 <https://github.com/youtalk/autoware.universe/issues/8876>`_)
-* refactor(autoware_interpolation): prefix package and namespace with autoware (`#8088 <https://github.com/youtalk/autoware.universe/issues/8088>`_)
+* fix(autoware_behavior_velocity_planner_common): add node clock, fix use sim time (`#8876 <https://github.com/autowarefoundation/autoware.universe/issues/8876>`_)
+* refactor(autoware_interpolation): prefix package and namespace with autoware (`#8088 <https://github.com/autowarefoundation/autoware.universe/issues/8088>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* fix(bvp): fix rtc state update logic (`#8884 <https://github.com/youtalk/autoware.universe/issues/8884>`_)
+* fix(bvp): fix rtc state update logic (`#8884 <https://github.com/autowarefoundation/autoware.universe/issues/8884>`_)
   * fix(bvp): fix rtc state update logic
   * fix(intersection): fix unexpected rtc state initialization
   ---------
-* feat(behavior_planning): update test map for BusStopArea and bicycle_lanes (`#8694 <https://github.com/youtalk/autoware.universe/issues/8694>`_)
-* feat(intersection): fix topological sort for complicated intersection (`#8520 <https://github.com/youtalk/autoware.universe/issues/8520>`_)
+* feat(behavior_planning): update test map for BusStopArea and bicycle_lanes (`#8694 <https://github.com/autowarefoundation/autoware.universe/issues/8694>`_)
+* feat(intersection): fix topological sort for complicated intersection (`#8520 <https://github.com/autowarefoundation/autoware.universe/issues/8520>`_)
   * for enclave occlusion detection lanelet
   * some refactorings and modify doxygen
   * fix ci
   ---------
   Co-authored-by: Y.Hisaki <yhisaki31@gmail.com>
-* fix(autoware_behavior_velocity_planner_common): fix variableScope (`#8446 <https://github.com/youtalk/autoware.universe/issues/8446>`_)
+* fix(autoware_behavior_velocity_planner_common): fix variableScope (`#8446 <https://github.com/autowarefoundation/autoware.universe/issues/8446>`_)
   fix:variableScope
-* feat(intersection): add test map for intersection (`#8455 <https://github.com/youtalk/autoware.universe/issues/8455>`_)
-* perf(velocity_smoother): not resample debug_trajectories is not used (`#8030 <https://github.com/youtalk/autoware.universe/issues/8030>`_)
+* feat(intersection): add test map for intersection (`#8455 <https://github.com/autowarefoundation/autoware.universe/issues/8455>`_)
+* perf(velocity_smoother): not resample debug_trajectories is not used (`#8030 <https://github.com/autowarefoundation/autoware.universe/issues/8030>`_)
   * not resample debug_trajectories if not published
   * update dependant packages
   ---------
-* feat(autoware_behavior_velocity_planner_common,autoware_behavior_velocity_stop_line_module): add time_keeper to bvp (`#8070 <https://github.com/youtalk/autoware.universe/issues/8070>`_)
-* feat: add `autoware\_` prefix to `lanelet2_extension` (`#7640 <https://github.com/youtalk/autoware.universe/issues/7640>`_)
-* fix(autoware_behavior_velocity_planner_common): remove lane_id check from arc_lane_util (`#7710 <https://github.com/youtalk/autoware.universe/issues/7710>`_)
+* feat(autoware_behavior_velocity_planner_common,autoware_behavior_velocity_stop_line_module): add time_keeper to bvp (`#8070 <https://github.com/autowarefoundation/autoware.universe/issues/8070>`_)
+* feat: add `autoware\_` prefix to `lanelet2_extension` (`#7640 <https://github.com/autowarefoundation/autoware.universe/issues/7640>`_)
+* fix(autoware_behavior_velocity_planner_common): remove lane_id check from arc_lane_util (`#7710 <https://github.com/autowarefoundation/autoware.universe/issues/7710>`_)
   * fix(arc_lane_util): remove lane_id check from arc_lane_util
   * modify test_arc_lane_util.cpp
   ---------
-* refactor(behavior_velocity_intersection): apply clang-tidy check (`#7552 <https://github.com/youtalk/autoware.universe/issues/7552>`_)
+* refactor(behavior_velocity_intersection): apply clang-tidy check (`#7552 <https://github.com/autowarefoundation/autoware.universe/issues/7552>`_)
   intersection
-* fix(autoware_behavior_velocity_planner_common): fix unusedScopedObject bug (`#7570 <https://github.com/youtalk/autoware.universe/issues/7570>`_)
-* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/youtalk/autoware.universe/issues/7594>`_)
-* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/youtalk/autoware.universe/issues/7539>`_)
+* fix(autoware_behavior_velocity_planner_common): fix unusedScopedObject bug (`#7570 <https://github.com/autowarefoundation/autoware.universe/issues/7570>`_)
+* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/autowarefoundation/autoware.universe/issues/7594>`_)
+* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/autowarefoundation/autoware.universe/issues/7539>`_)
   refactor(motion_utils): add autoware prefix and include dir
-* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/youtalk/autoware.universe/issues/7538>`_)
+* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/autowarefoundation/autoware.universe/issues/7538>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* refactor(route_handler)!: rename to include/autoware/{package_name}  (`#7530 <https://github.com/youtalk/autoware.universe/issues/7530>`_)
+* refactor(route_handler)!: rename to include/autoware/{package_name}  (`#7530 <https://github.com/autowarefoundation/autoware.universe/issues/7530>`_)
   refactor(route_handler)!: rename to include/autoware/{package_name}
-* refactor(rtc_interface)!: rename to include/autoware/{package_name} (`#7531 <https://github.com/youtalk/autoware.universe/issues/7531>`_)
+* refactor(rtc_interface)!: rename to include/autoware/{package_name} (`#7531 <https://github.com/autowarefoundation/autoware.universe/issues/7531>`_)
   Co-authored-by: Fumiya Watanabe <rej55.g@gmail.com>
-* refactor(objects_of_interest_marker_interface): rename to include/autoware/{package_name} (`#7535 <https://github.com/youtalk/autoware.universe/issues/7535>`_)
-* refactor(velocity_smoother): rename to include/autoware/{package_name} (`#7533 <https://github.com/youtalk/autoware.universe/issues/7533>`_)
-* chore(behavior_velocity_planner): move packages (`#7526 <https://github.com/youtalk/autoware.universe/issues/7526>`_)
+* refactor(objects_of_interest_marker_interface): rename to include/autoware/{package_name} (`#7535 <https://github.com/autowarefoundation/autoware.universe/issues/7535>`_)
+* refactor(velocity_smoother): rename to include/autoware/{package_name} (`#7533 <https://github.com/autowarefoundation/autoware.universe/issues/7533>`_)
+* chore(behavior_velocity_planner): move packages (`#7526 <https://github.com/autowarefoundation/autoware.universe/issues/7526>`_)
 * Contributors: Dawid Moszyński, Esteve Fernandez, Fumiya Watanabe, Kosuke Takeuchi, Mamoru Sobue, Maxime CLEMENT, Ryuta Kambe, Satoshi OTA, Takayuki Murooka, Yukinari Hisaki, Yutaka Kondo, kobayu858
 
 0.26.0 (2024-04-03)

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_run_out_module/CHANGELOG.rst
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_run_out_module/CHANGELOG.rst
@@ -5,37 +5,37 @@ Changelog for package autoware_behavior_velocity_run_out_module
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* refactor(object_recognition_utils): add autoware prefix to object_recognition_utils (`#8946 <https://github.com/youtalk/autoware.universe/issues/8946>`_)
-* fix(behavior_velocity_planner): align the parameters with launcher (`#8791 <https://github.com/youtalk/autoware.universe/issues/8791>`_)
+* refactor(object_recognition_utils): add autoware prefix to object_recognition_utils (`#8946 <https://github.com/autowarefoundation/autoware.universe/issues/8946>`_)
+* fix(behavior_velocity_planner): align the parameters with launcher (`#8791 <https://github.com/autowarefoundation/autoware.universe/issues/8791>`_)
   parameters in behavior_velocity_planner aligned
-* fix(autoware_behavior_velocity_run_out_module): fix unusedFunction (`#8779 <https://github.com/youtalk/autoware.universe/issues/8779>`_)
+* fix(autoware_behavior_velocity_run_out_module): fix unusedFunction (`#8779 <https://github.com/autowarefoundation/autoware.universe/issues/8779>`_)
   fix:unusedFunction
-* fix(autoware_behavior_velocity_run_out_module): fix unusedFunction (`#8669 <https://github.com/youtalk/autoware.universe/issues/8669>`_)
+* fix(autoware_behavior_velocity_run_out_module): fix unusedFunction (`#8669 <https://github.com/autowarefoundation/autoware.universe/issues/8669>`_)
   fix:unusedFunction
-* fix(behavior_velocity_planner): fix cppcheck warnings of virtualCallInConstructor (`#8376 <https://github.com/youtalk/autoware.universe/issues/8376>`_)
+* fix(behavior_velocity_planner): fix cppcheck warnings of virtualCallInConstructor (`#8376 <https://github.com/autowarefoundation/autoware.universe/issues/8376>`_)
   Co-authored-by: Ryuta Kambe <ryuta.kambe@tier4.jp>
-* fix(behavior_velocity_planner): fix cppcheck warnings of functionStatic (`#8262 <https://github.com/youtalk/autoware.universe/issues/8262>`_)
+* fix(behavior_velocity_planner): fix cppcheck warnings of functionStatic (`#8262 <https://github.com/autowarefoundation/autoware.universe/issues/8262>`_)
   fix: deal with functionStatic warnings
-* fix(autoware_behavior_velocity_run_out_module): fix functionConst (`#8284 <https://github.com/youtalk/autoware.universe/issues/8284>`_)
+* fix(autoware_behavior_velocity_run_out_module): fix functionConst (`#8284 <https://github.com/autowarefoundation/autoware.universe/issues/8284>`_)
   fix:functionConst
-* fix(autoware_behavior_velocity_run_out_module): fix passedByValue (`#8215 <https://github.com/youtalk/autoware.universe/issues/8215>`_)
+* fix(autoware_behavior_velocity_run_out_module): fix passedByValue (`#8215 <https://github.com/autowarefoundation/autoware.universe/issues/8215>`_)
   * fix:passedByValue
   * fix:passedByValue
   * fix:passedByValue
   ---------
-* fix(autoware_behavior_velocity_run_out_module): fix constParameterReference (`#8050 <https://github.com/youtalk/autoware.universe/issues/8050>`_)
+* fix(autoware_behavior_velocity_run_out_module): fix constParameterReference (`#8050 <https://github.com/autowarefoundation/autoware.universe/issues/8050>`_)
   fix:constParameterReference
-* fix(behavior_path_planner, behavior_velocity_planner): fix redefinition errors (`#7688 <https://github.com/youtalk/autoware.universe/issues/7688>`_)
-* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/youtalk/autoware.universe/issues/7594>`_)
-* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/youtalk/autoware.universe/issues/7539>`_)
+* fix(behavior_path_planner, behavior_velocity_planner): fix redefinition errors (`#7688 <https://github.com/autowarefoundation/autoware.universe/issues/7688>`_)
+* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/autowarefoundation/autoware.universe/issues/7594>`_)
+* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/autowarefoundation/autoware.universe/issues/7539>`_)
   refactor(motion_utils): add autoware prefix and include dir
-* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/youtalk/autoware.universe/issues/7538>`_)
+* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/autowarefoundation/autoware.universe/issues/7538>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* chore(behavior_velocity_planner): fix CODEOWNERS and page links (`#7534 <https://github.com/youtalk/autoware.universe/issues/7534>`_)
+* chore(behavior_velocity_planner): fix CODEOWNERS and page links (`#7534 <https://github.com/autowarefoundation/autoware.universe/issues/7534>`_)
   * chore(behavior_velocity_planner): fix CODEOWNERS and page links
   * fix: fix page link
   ---------
-* chore(behavior_velocity_planner): move packages (`#7526 <https://github.com/youtalk/autoware.universe/issues/7526>`_)
+* chore(behavior_velocity_planner): move packages (`#7526 <https://github.com/autowarefoundation/autoware.universe/issues/7526>`_)
 * Contributors: Esteve Fernandez, Fumiya Watanabe, Kosuke Takeuchi, Ryuta Kambe, Takayuki Murooka, Yutaka Kondo, Zhe Shen, kobayu858, taisa1
 
 0.26.0 (2024-04-03)

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_speed_bump_module/CHANGELOG.rst
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_speed_bump_module/CHANGELOG.rst
@@ -5,14 +5,14 @@ Changelog for package autoware_behavior_velocity_speed_bump_module
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* fix(behavior_velocity_planner): fix cppcheck warnings of virtualCallInConstructor (`#8376 <https://github.com/youtalk/autoware.universe/issues/8376>`_)
+* fix(behavior_velocity_planner): fix cppcheck warnings of virtualCallInConstructor (`#8376 <https://github.com/autowarefoundation/autoware.universe/issues/8376>`_)
   Co-authored-by: Ryuta Kambe <ryuta.kambe@tier4.jp>
-* fix(autoware_behavior_velocity_speed_bump_module): fix uninitMemberVar (`#8319 <https://github.com/youtalk/autoware.universe/issues/8319>`_)
+* fix(autoware_behavior_velocity_speed_bump_module): fix uninitMemberVar (`#8319 <https://github.com/autowarefoundation/autoware.universe/issues/8319>`_)
   fix:uninitMemberVar
-* feat: add `autoware\_` prefix to `lanelet2_extension` (`#7640 <https://github.com/youtalk/autoware.universe/issues/7640>`_)
-* fix(autoware_behavior_velocity_speed_bump_module): fix containerOutOfBounds warning (`#7671 <https://github.com/youtalk/autoware.universe/issues/7671>`_)
+* feat: add `autoware\_` prefix to `lanelet2_extension` (`#7640 <https://github.com/autowarefoundation/autoware.universe/issues/7640>`_)
+* fix(autoware_behavior_velocity_speed_bump_module): fix containerOutOfBounds warning (`#7671 <https://github.com/autowarefoundation/autoware.universe/issues/7671>`_)
   fix(autoware_behavior_velocity_speed_bump_module): fix containerOutOfBounds
-* refactor(autoware_behavior_velocity_speed_bump_module): prefix package and namespace with autoware (`#7467 <https://github.com/youtalk/autoware.universe/issues/7467>`_)
+* refactor(autoware_behavior_velocity_speed_bump_module): prefix package and namespace with autoware (`#7467 <https://github.com/autowarefoundation/autoware.universe/issues/7467>`_)
 * Contributors: Esteve Fernandez, Ryuta Kambe, Yutaka Kondo, kobayu858, taisa1
 
 0.26.0 (2024-04-03)

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_stop_line_module/CHANGELOG.rst
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_stop_line_module/CHANGELOG.rst
@@ -5,22 +5,22 @@ Changelog for package autoware_behavior_velocity_stop_line_module
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* fix(behavior_velocity_planner): fix cppcheck warnings of virtualCallInConstructor (`#8376 <https://github.com/youtalk/autoware.universe/issues/8376>`_)
+* fix(behavior_velocity_planner): fix cppcheck warnings of virtualCallInConstructor (`#8376 <https://github.com/autowarefoundation/autoware.universe/issues/8376>`_)
   Co-authored-by: Ryuta Kambe <ryuta.kambe@tier4.jp>
-* fix(autoware_behavior_velocity_stop_line_module): fix uninitMemberVar (`#8318 <https://github.com/youtalk/autoware.universe/issues/8318>`_)
+* fix(autoware_behavior_velocity_stop_line_module): fix uninitMemberVar (`#8318 <https://github.com/autowarefoundation/autoware.universe/issues/8318>`_)
   fix:uninitMemberVar
-* feat(autoware_behavior_velocity_planner_common,autoware_behavior_velocity_stop_line_module): add time_keeper to bvp (`#8070 <https://github.com/youtalk/autoware.universe/issues/8070>`_)
-* feat: add `autoware\_` prefix to `lanelet2_extension` (`#7640 <https://github.com/youtalk/autoware.universe/issues/7640>`_)
-* fix(autoware_behavior_velocity_planner_common): remove lane_id check from arc_lane_util (`#7710 <https://github.com/youtalk/autoware.universe/issues/7710>`_)
+* feat(autoware_behavior_velocity_planner_common,autoware_behavior_velocity_stop_line_module): add time_keeper to bvp (`#8070 <https://github.com/autowarefoundation/autoware.universe/issues/8070>`_)
+* feat: add `autoware\_` prefix to `lanelet2_extension` (`#7640 <https://github.com/autowarefoundation/autoware.universe/issues/7640>`_)
+* fix(autoware_behavior_velocity_planner_common): remove lane_id check from arc_lane_util (`#7710 <https://github.com/autowarefoundation/autoware.universe/issues/7710>`_)
   * fix(arc_lane_util): remove lane_id check from arc_lane_util
   * modify test_arc_lane_util.cpp
   ---------
-* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/youtalk/autoware.universe/issues/7594>`_)
-* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/youtalk/autoware.universe/issues/7539>`_)
+* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/autowarefoundation/autoware.universe/issues/7594>`_)
+* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/autowarefoundation/autoware.universe/issues/7539>`_)
   refactor(motion_utils): add autoware prefix and include dir
-* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/youtalk/autoware.universe/issues/7538>`_)
+* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/autowarefoundation/autoware.universe/issues/7538>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* chore(behavior_velocity_planner): move packages (`#7526 <https://github.com/youtalk/autoware.universe/issues/7526>`_)
+* chore(behavior_velocity_planner): move packages (`#7526 <https://github.com/autowarefoundation/autoware.universe/issues/7526>`_)
 * Contributors: Fumiya Watanabe, Kosuke Takeuchi, Takayuki Murooka, Yukinari Hisaki, Yutaka Kondo, kobayu858, taisa1
 
 0.26.0 (2024-04-03)

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_template_module/CHANGELOG.rst
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_template_module/CHANGELOG.rst
@@ -5,16 +5,16 @@ Changelog for package autoware_behavior_velocity_template_module
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* fix(behavior_velocity_planner): fix cppcheck warnings of virtualCallInConstructor (`#8376 <https://github.com/youtalk/autoware.universe/issues/8376>`_)
+* fix(behavior_velocity_planner): fix cppcheck warnings of virtualCallInConstructor (`#8376 <https://github.com/autowarefoundation/autoware.universe/issues/8376>`_)
   Co-authored-by: Ryuta Kambe <ryuta.kambe@tier4.jp>
-* feat: add `autoware\_` prefix to `lanelet2_extension` (`#7640 <https://github.com/youtalk/autoware.universe/issues/7640>`_)
-* refactor(autoware_behavior_velocity_speed_bump_module): prefix package and namespace with autoware (`#7467 <https://github.com/youtalk/autoware.universe/issues/7467>`_)
-* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/youtalk/autoware.universe/issues/7594>`_)
-* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/youtalk/autoware.universe/issues/7539>`_)
+* feat: add `autoware\_` prefix to `lanelet2_extension` (`#7640 <https://github.com/autowarefoundation/autoware.universe/issues/7640>`_)
+* refactor(autoware_behavior_velocity_speed_bump_module): prefix package and namespace with autoware (`#7467 <https://github.com/autowarefoundation/autoware.universe/issues/7467>`_)
+* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/autowarefoundation/autoware.universe/issues/7594>`_)
+* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/autowarefoundation/autoware.universe/issues/7539>`_)
   refactor(motion_utils): add autoware prefix and include dir
-* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/youtalk/autoware.universe/issues/7538>`_)
+* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/autowarefoundation/autoware.universe/issues/7538>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* chore(behavior_velocity_planner): move packages (`#7526 <https://github.com/youtalk/autoware.universe/issues/7526>`_)
+* chore(behavior_velocity_planner): move packages (`#7526 <https://github.com/autowarefoundation/autoware.universe/issues/7526>`_)
 * Contributors: Esteve Fernandez, Fumiya Watanabe, Kosuke Takeuchi, Takayuki Murooka, Yutaka Kondo, taisa1
 
 0.26.0 (2024-04-03)

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/CHANGELOG.rst
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/CHANGELOG.rst
@@ -5,29 +5,29 @@ Changelog for package autoware_behavior_velocity_traffic_light_module
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* test(traffic_light): write test for utils (`#9046 <https://github.com/youtalk/autoware.universe/issues/9046>`_)
+* test(traffic_light): write test for utils (`#9046 <https://github.com/autowarefoundation/autoware.universe/issues/9046>`_)
   * refactor: separate utils file
   * refactor: utils function output
   * test: write test for utils
   * chore: add doxygen
   ---------
-* fix(behavior_velocity_traffic_light): make dilemma_zone_plotter.py executable (`#8684 <https://github.com/youtalk/autoware.universe/issues/8684>`_)
-* feat(traffic_light): add dilemma_zone_plotter.py (`#8638 <https://github.com/youtalk/autoware.universe/issues/8638>`_)
+* fix(behavior_velocity_traffic_light): make dilemma_zone_plotter.py executable (`#8684 <https://github.com/autowarefoundation/autoware.universe/issues/8684>`_)
+* feat(traffic_light): add dilemma_zone_plotter.py (`#8638 <https://github.com/autowarefoundation/autoware.universe/issues/8638>`_)
   * feat(traffic_light): add dilemma_zone_plotter.py
   * fix typo
   * fix typo
   ---------
-* fix(behavior_velocity_planner): fix cppcheck warnings of virtualCallInConstructor (`#8376 <https://github.com/youtalk/autoware.universe/issues/8376>`_)
+* fix(behavior_velocity_planner): fix cppcheck warnings of virtualCallInConstructor (`#8376 <https://github.com/autowarefoundation/autoware.universe/issues/8376>`_)
   Co-authored-by: Ryuta Kambe <ryuta.kambe@tier4.jp>
-* fix(autoware_behavior_velocity_traffic_light_module): fix uninitMemberVar (`#8317 <https://github.com/youtalk/autoware.universe/issues/8317>`_)
+* fix(autoware_behavior_velocity_traffic_light_module): fix uninitMemberVar (`#8317 <https://github.com/autowarefoundation/autoware.universe/issues/8317>`_)
   fix:funinitMemberVar
-* feat: add `autoware\_` prefix to `lanelet2_extension` (`#7640 <https://github.com/youtalk/autoware.universe/issues/7640>`_)
-* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/youtalk/autoware.universe/issues/7594>`_)
-* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/youtalk/autoware.universe/issues/7539>`_)
+* feat: add `autoware\_` prefix to `lanelet2_extension` (`#7640 <https://github.com/autowarefoundation/autoware.universe/issues/7640>`_)
+* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/autowarefoundation/autoware.universe/issues/7594>`_)
+* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/autowarefoundation/autoware.universe/issues/7539>`_)
   refactor(motion_utils): add autoware prefix and include dir
-* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/youtalk/autoware.universe/issues/7538>`_)
+* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/autowarefoundation/autoware.universe/issues/7538>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* chore(behavior_velocity_planner): move packages (`#7526 <https://github.com/youtalk/autoware.universe/issues/7526>`_)
+* chore(behavior_velocity_planner): move packages (`#7526 <https://github.com/autowarefoundation/autoware.universe/issues/7526>`_)
 * Contributors: Fumiya Watanabe, Kosuke Takeuchi, Satoshi OTA, Takayuki Murooka, Yutaka Kondo, kobayu858, taisa1
 
 0.26.0 (2024-04-03)

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_virtual_traffic_light_module/CHANGELOG.rst
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_virtual_traffic_light_module/CHANGELOG.rst
@@ -5,27 +5,27 @@ Changelog for package autoware_behavior_velocity_virtual_traffic_light_module
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* test(virtual_traffic_light): add unit tests for utils (`#9107 <https://github.com/youtalk/autoware.universe/issues/9107>`_)
-* chore(virtual_traffic_light): add soblin to maintainer (`#9147 <https://github.com/youtalk/autoware.universe/issues/9147>`_)
-* refactor(virtual_traffic_light): move to utils for unit test (`#9106 <https://github.com/youtalk/autoware.universe/issues/9106>`_)
-* fix(autoware_behavior_velocity_virtual_traffic_light_module): fix unusedFunction (`#8670 <https://github.com/youtalk/autoware.universe/issues/8670>`_)
+* test(virtual_traffic_light): add unit tests for utils (`#9107 <https://github.com/autowarefoundation/autoware.universe/issues/9107>`_)
+* chore(virtual_traffic_light): add soblin to maintainer (`#9147 <https://github.com/autowarefoundation/autoware.universe/issues/9147>`_)
+* refactor(virtual_traffic_light): move to utils for unit test (`#9106 <https://github.com/autowarefoundation/autoware.universe/issues/9106>`_)
+* fix(autoware_behavior_velocity_virtual_traffic_light_module): fix unusedFunction (`#8670 <https://github.com/autowarefoundation/autoware.universe/issues/8670>`_)
   fix:unusedFunction
-* fix(behavior_velocity_planner): fix cppcheck warnings of virtualCallInConstructor (`#8376 <https://github.com/youtalk/autoware.universe/issues/8376>`_)
+* fix(behavior_velocity_planner): fix cppcheck warnings of virtualCallInConstructor (`#8376 <https://github.com/autowarefoundation/autoware.universe/issues/8376>`_)
   Co-authored-by: Ryuta Kambe <ryuta.kambe@tier4.jp>
-* fix(autoware_behavior_velocity_virtual_traffic_light_module): fix unusedStructMember (`#8394 <https://github.com/youtalk/autoware.universe/issues/8394>`_)
+* fix(autoware_behavior_velocity_virtual_traffic_light_module): fix unusedStructMember (`#8394 <https://github.com/autowarefoundation/autoware.universe/issues/8394>`_)
   fix:unusedStructMember
-* fix(behavior_path_planner, behavior_velocity_planner): fix redefinition errors (`#7688 <https://github.com/youtalk/autoware.universe/issues/7688>`_)
-* feat: add `autoware\_` prefix to `lanelet2_extension` (`#7640 <https://github.com/youtalk/autoware.universe/issues/7640>`_)
-* fix(autoware_behavior_velocity_planner_common): remove lane_id check from arc_lane_util (`#7710 <https://github.com/youtalk/autoware.universe/issues/7710>`_)
+* fix(behavior_path_planner, behavior_velocity_planner): fix redefinition errors (`#7688 <https://github.com/autowarefoundation/autoware.universe/issues/7688>`_)
+* feat: add `autoware\_` prefix to `lanelet2_extension` (`#7640 <https://github.com/autowarefoundation/autoware.universe/issues/7640>`_)
+* fix(autoware_behavior_velocity_planner_common): remove lane_id check from arc_lane_util (`#7710 <https://github.com/autowarefoundation/autoware.universe/issues/7710>`_)
   * fix(arc_lane_util): remove lane_id check from arc_lane_util
   * modify test_arc_lane_util.cpp
   ---------
-* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/youtalk/autoware.universe/issues/7594>`_)
-* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/youtalk/autoware.universe/issues/7539>`_)
+* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/autowarefoundation/autoware.universe/issues/7594>`_)
+* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/autowarefoundation/autoware.universe/issues/7539>`_)
   refactor(motion_utils): add autoware prefix and include dir
-* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/youtalk/autoware.universe/issues/7538>`_)
+* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/autowarefoundation/autoware.universe/issues/7538>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* chore(behavior_velocity_planner): move packages (`#7526 <https://github.com/youtalk/autoware.universe/issues/7526>`_)
+* chore(behavior_velocity_planner): move packages (`#7526 <https://github.com/autowarefoundation/autoware.universe/issues/7526>`_)
 * Contributors: Fumiya Watanabe, Kosuke Takeuchi, Ryuta Kambe, Takayuki Murooka, Yukinari Hisaki, Yutaka Kondo, kobayu858, taisa1
 
 0.26.0 (2024-04-03)

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_walkway_module/CHANGELOG.rst
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_walkway_module/CHANGELOG.rst
@@ -5,21 +5,21 @@ Changelog for package autoware_behavior_velocity_walkway_module
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* fix(behavior_velocity_planner): fix cppcheck warnings of virtualCallInConstructor (`#8376 <https://github.com/youtalk/autoware.universe/issues/8376>`_)
+* fix(behavior_velocity_planner): fix cppcheck warnings of virtualCallInConstructor (`#8376 <https://github.com/autowarefoundation/autoware.universe/issues/8376>`_)
   Co-authored-by: Ryuta Kambe <ryuta.kambe@tier4.jp>
-* refactor(crosswalk): clean up the structure and create a brief flowchart (`#7868 <https://github.com/youtalk/autoware.universe/issues/7868>`_)
+* refactor(crosswalk): clean up the structure and create a brief flowchart (`#7868 <https://github.com/autowarefoundation/autoware.universe/issues/7868>`_)
   * refactor(crosswalk): clean up the structure and create a brief flowchart
   * update
   * fix
   * static stop pose -> default stop pose
   ---------
-* feat: add `autoware\_` prefix to `lanelet2_extension` (`#7640 <https://github.com/youtalk/autoware.universe/issues/7640>`_)
-* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/youtalk/autoware.universe/issues/7594>`_)
-* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/youtalk/autoware.universe/issues/7539>`_)
+* feat: add `autoware\_` prefix to `lanelet2_extension` (`#7640 <https://github.com/autowarefoundation/autoware.universe/issues/7640>`_)
+* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/autowarefoundation/autoware.universe/issues/7594>`_)
+* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/autowarefoundation/autoware.universe/issues/7539>`_)
   refactor(motion_utils): add autoware prefix and include dir
-* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/youtalk/autoware.universe/issues/7538>`_)
+* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/autowarefoundation/autoware.universe/issues/7538>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* chore(behavior_velocity_planner): move packages (`#7526 <https://github.com/youtalk/autoware.universe/issues/7526>`_)
+* chore(behavior_velocity_planner): move packages (`#7526 <https://github.com/autowarefoundation/autoware.universe/issues/7526>`_)
 * Contributors: Fumiya Watanabe, Kosuke Takeuchi, Takayuki Murooka, Yutaka Kondo, taisa1
 
 0.26.0 (2024-04-03)

--- a/planning/motion_velocity_planner/autoware_motion_velocity_dynamic_obstacle_stop_module/CHANGELOG.rst
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_dynamic_obstacle_stop_module/CHANGELOG.rst
@@ -5,20 +5,20 @@ Changelog for package autoware_motion_velocity_dynamic_obstacle_stop_module
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* test(dynamic_obstacle_stop): add tests and do some refactoring (`#8250 <https://github.com/youtalk/autoware.universe/issues/8250>`_)
-* fix(autoware_motion_velocity_dynamic_obstacle_stop_module): fix funcArgNamesDifferent (`#8024 <https://github.com/youtalk/autoware.universe/issues/8024>`_)
+* test(dynamic_obstacle_stop): add tests and do some refactoring (`#8250 <https://github.com/autowarefoundation/autoware.universe/issues/8250>`_)
+* fix(autoware_motion_velocity_dynamic_obstacle_stop_module): fix funcArgNamesDifferent (`#8024 <https://github.com/autowarefoundation/autoware.universe/issues/8024>`_)
   fix:funcArgNamesDifferent
-* perf(dynamic_obstacle_stop): construct rtree nodes in place (`#7753 <https://github.com/youtalk/autoware.universe/issues/7753>`_)
-* perf(dynamic_obstacle_stop): create rtree with packing algorithm (`#7730 <https://github.com/youtalk/autoware.universe/issues/7730>`_)
-* feat(motion_velocity_planner, lane_departure_checker): add processing time Float64 publishers (`#7683 <https://github.com/youtalk/autoware.universe/issues/7683>`_)
-* feat(motion_velocity_planner): publish processing times (`#7633 <https://github.com/youtalk/autoware.universe/issues/7633>`_)
-* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/youtalk/autoware.universe/issues/7594>`_)
-* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/youtalk/autoware.universe/issues/7539>`_)
+* perf(dynamic_obstacle_stop): construct rtree nodes in place (`#7753 <https://github.com/autowarefoundation/autoware.universe/issues/7753>`_)
+* perf(dynamic_obstacle_stop): create rtree with packing algorithm (`#7730 <https://github.com/autowarefoundation/autoware.universe/issues/7730>`_)
+* feat(motion_velocity_planner, lane_departure_checker): add processing time Float64 publishers (`#7683 <https://github.com/autowarefoundation/autoware.universe/issues/7683>`_)
+* feat(motion_velocity_planner): publish processing times (`#7633 <https://github.com/autowarefoundation/autoware.universe/issues/7633>`_)
+* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/autowarefoundation/autoware.universe/issues/7594>`_)
+* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/autowarefoundation/autoware.universe/issues/7539>`_)
   refactor(motion_utils): add autoware prefix and include dir
-* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/youtalk/autoware.universe/issues/7538>`_)
+* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/autowarefoundation/autoware.universe/issues/7538>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* feat(motion_velocity_planner): rename include directories (`#7523 <https://github.com/youtalk/autoware.universe/issues/7523>`_)
-* refactor(dynamic_obstacle_stop): move to motion_velocity_planner (`#7460 <https://github.com/youtalk/autoware.universe/issues/7460>`_)
+* feat(motion_velocity_planner): rename include directories (`#7523 <https://github.com/autowarefoundation/autoware.universe/issues/7523>`_)
+* refactor(dynamic_obstacle_stop): move to motion_velocity_planner (`#7460 <https://github.com/autowarefoundation/autoware.universe/issues/7460>`_)
 * Contributors: Kosuke Takeuchi, Maxime CLEMENT, Takayuki Murooka, Yutaka Kondo, kobayu858
 
 0.26.0 (2024-04-03)

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_velocity_limiter_module/CHANGELOG.rst
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_velocity_limiter_module/CHANGELOG.rst
@@ -5,43 +5,43 @@ Changelog for package autoware_motion_velocity_obstacle_velocity_limiter_module
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* refactor(autoware_grid_map_utils): prefix folder structure with autoware/ (`#9170 <https://github.com/youtalk/autoware.universe/issues/9170>`_)
-* fix(obstacle_velocity_limiter): more stable virtual wall (`#8499 <https://github.com/youtalk/autoware.universe/issues/8499>`_)
-* feat(out_of_lane): redesign to improve accuracy and performance (`#8453 <https://github.com/youtalk/autoware.universe/issues/8453>`_)
-* chore(obstacle_velocity_limiter): add Alqudah Mohammad as codeowner (`#8516 <https://github.com/youtalk/autoware.universe/issues/8516>`_)
-* fix(autoware_motion_velocity_obstacle_velocity_limiter_module): fix functionStatic (`#8483 <https://github.com/youtalk/autoware.universe/issues/8483>`_)
+* refactor(autoware_grid_map_utils): prefix folder structure with autoware/ (`#9170 <https://github.com/autowarefoundation/autoware.universe/issues/9170>`_)
+* fix(obstacle_velocity_limiter): more stable virtual wall (`#8499 <https://github.com/autowarefoundation/autoware.universe/issues/8499>`_)
+* feat(out_of_lane): redesign to improve accuracy and performance (`#8453 <https://github.com/autowarefoundation/autoware.universe/issues/8453>`_)
+* chore(obstacle_velocity_limiter): add Alqudah Mohammad as codeowner (`#8516 <https://github.com/autowarefoundation/autoware.universe/issues/8516>`_)
+* fix(autoware_motion_velocity_obstacle_velocity_limiter_module): fix functionStatic (`#8483 <https://github.com/autowarefoundation/autoware.universe/issues/8483>`_)
   fix:functionStatic
-* fix(autoware_motion_velocity_obstacle_velocity_limiter_module): fix unreadVariable (`#8366 <https://github.com/youtalk/autoware.universe/issues/8366>`_)
+* fix(autoware_motion_velocity_obstacle_velocity_limiter_module): fix unreadVariable (`#8366 <https://github.com/autowarefoundation/autoware.universe/issues/8366>`_)
   * fix:unreadVariable
   * fix:unreadVariable
   ---------
-* fix(autoware_motion_velocity_obstacle_velocity_limiter_module): fix uninitMemberVar (`#8314 <https://github.com/youtalk/autoware.universe/issues/8314>`_)
+* fix(autoware_motion_velocity_obstacle_velocity_limiter_module): fix uninitMemberVar (`#8314 <https://github.com/autowarefoundation/autoware.universe/issues/8314>`_)
   fix:funinitMemberVar
-* fix(autoware_motion_velocity_obstacle_velocity_limiter_module): fix funcArgNamesDifferent (`#8025 <https://github.com/youtalk/autoware.universe/issues/8025>`_)
+* fix(autoware_motion_velocity_obstacle_velocity_limiter_module): fix funcArgNamesDifferent (`#8025 <https://github.com/autowarefoundation/autoware.universe/issues/8025>`_)
   fix:funcArgNamesDifferent
-* fix(autoware_motion_velocity_obstacle_velocity_limiter_module): fix shadowVariable (`#7977 <https://github.com/youtalk/autoware.universe/issues/7977>`_)
+* fix(autoware_motion_velocity_obstacle_velocity_limiter_module): fix shadowVariable (`#7977 <https://github.com/autowarefoundation/autoware.universe/issues/7977>`_)
   * fix:shadowVariable
   * fix:shadowVariable
   ---------
-* perf(motion_velocity_planner): resample trajectory after vel smoothing (`#7732 <https://github.com/youtalk/autoware.universe/issues/7732>`_)
+* perf(motion_velocity_planner): resample trajectory after vel smoothing (`#7732 <https://github.com/autowarefoundation/autoware.universe/issues/7732>`_)
   * perf(dynamic_obstacle_stop): create rtree with packing algorithm
-  * Revert "perf(out_of_lane): downsample the trajectory to improve performance (`#7691 <https://github.com/youtalk/autoware.universe/issues/7691>`_)"
+  * Revert "perf(out_of_lane): downsample the trajectory to improve performance (`#7691 <https://github.com/autowarefoundation/autoware.universe/issues/7691>`_)"
   This reverts commit 8444a9eb29b32f500be3724dd5662013b9b81060.
   * perf(motion_velocity_planner): resample trajectory after vel smoothing
   ---------
-* feat: add `autoware\_` prefix to `lanelet2_extension` (`#7640 <https://github.com/youtalk/autoware.universe/issues/7640>`_)
-* perf(out_of_lane): downsample the trajectory to improve performance (`#7691 <https://github.com/youtalk/autoware.universe/issues/7691>`_)
-* feat(motion_velocity_planner, lane_departure_checker): add processing time Float64 publishers (`#7683 <https://github.com/youtalk/autoware.universe/issues/7683>`_)
-* feat(motion_velocity_planner): publish processing times (`#7633 <https://github.com/youtalk/autoware.universe/issues/7633>`_)
-* fix(autoware_motion_velocity_obstacle_velocity_limiter_module): fix unreadVariable warning (`#7625 <https://github.com/youtalk/autoware.universe/issues/7625>`_)
-* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/youtalk/autoware.universe/issues/7594>`_)
-* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/youtalk/autoware.universe/issues/7539>`_)
+* feat: add `autoware\_` prefix to `lanelet2_extension` (`#7640 <https://github.com/autowarefoundation/autoware.universe/issues/7640>`_)
+* perf(out_of_lane): downsample the trajectory to improve performance (`#7691 <https://github.com/autowarefoundation/autoware.universe/issues/7691>`_)
+* feat(motion_velocity_planner, lane_departure_checker): add processing time Float64 publishers (`#7683 <https://github.com/autowarefoundation/autoware.universe/issues/7683>`_)
+* feat(motion_velocity_planner): publish processing times (`#7633 <https://github.com/autowarefoundation/autoware.universe/issues/7633>`_)
+* fix(autoware_motion_velocity_obstacle_velocity_limiter_module): fix unreadVariable warning (`#7625 <https://github.com/autowarefoundation/autoware.universe/issues/7625>`_)
+* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/autowarefoundation/autoware.universe/issues/7594>`_)
+* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/autowarefoundation/autoware.universe/issues/7539>`_)
   refactor(motion_utils): add autoware prefix and include dir
-* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/youtalk/autoware.universe/issues/7538>`_)
+* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/autowarefoundation/autoware.universe/issues/7538>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* feat(motion_velocity_planner): rename include directories (`#7523 <https://github.com/youtalk/autoware.universe/issues/7523>`_)
-* refactor(grid_map_utils): add autoware prefix and namespace (`#7487 <https://github.com/youtalk/autoware.universe/issues/7487>`_)
-* feat(obstacle_velocity_limiter): move to motion_velocity_planner (`#7439 <https://github.com/youtalk/autoware.universe/issues/7439>`_)
+* feat(motion_velocity_planner): rename include directories (`#7523 <https://github.com/autowarefoundation/autoware.universe/issues/7523>`_)
+* refactor(grid_map_utils): add autoware prefix and namespace (`#7487 <https://github.com/autowarefoundation/autoware.universe/issues/7487>`_)
+* feat(obstacle_velocity_limiter): move to motion_velocity_planner (`#7439 <https://github.com/autowarefoundation/autoware.universe/issues/7439>`_)
 * Contributors: Esteve Fernandez, Kosuke Takeuchi, Maxime CLEMENT, Ryuta Kambe, Takayuki Murooka, Yutaka Kondo, kobayu858
 
 0.26.0 (2024-04-03)

--- a/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/CHANGELOG.rst
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/CHANGELOG.rst
@@ -5,44 +5,44 @@ Changelog for package autoware_motion_velocity_out_of_lane_module
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* perf(out_of_lane): use intersection with other lanes instead of difference with ego lane (`#8870 <https://github.com/youtalk/autoware.universe/issues/8870>`_)
-* chore(motion_velocity_planner): add Alqudah Mohammad as maintainer (`#8877 <https://github.com/youtalk/autoware.universe/issues/8877>`_)
-* chore(planning): consistent parameters with autoware_launch (`#8915 <https://github.com/youtalk/autoware.universe/issues/8915>`_)
+* perf(out_of_lane): use intersection with other lanes instead of difference with ego lane (`#8870 <https://github.com/autowarefoundation/autoware.universe/issues/8870>`_)
+* chore(motion_velocity_planner): add Alqudah Mohammad as maintainer (`#8877 <https://github.com/autowarefoundation/autoware.universe/issues/8877>`_)
+* chore(planning): consistent parameters with autoware_launch (`#8915 <https://github.com/autowarefoundation/autoware.universe/issues/8915>`_)
   * chore(planning): consistent parameters with autoware_launch
   * update
   * fix json schema
   ---------
-* fix(motion_planning): align the parameters with launcher (`#8792 <https://github.com/youtalk/autoware.universe/issues/8792>`_)
+* fix(motion_planning): align the parameters with launcher (`#8792 <https://github.com/autowarefoundation/autoware.universe/issues/8792>`_)
   parameters in motion_planning aligned
-* docs(out_of_lane): update documentation for the new design (`#8692 <https://github.com/youtalk/autoware.universe/issues/8692>`_)
-* fix(out_of_lane): fix a bug with the rtree reference deleted nodes (`#8679 <https://github.com/youtalk/autoware.universe/issues/8679>`_)
-* fix(out_of_lane): fix noConstructor cppcheck warning (`#8636 <https://github.com/youtalk/autoware.universe/issues/8636>`_)
-* feat(out_of_lane): redesign to improve accuracy and performance (`#8453 <https://github.com/youtalk/autoware.universe/issues/8453>`_)
-* perf(out_of_lane): use rtree to get stop lines and trajectory lanelets (`#8439 <https://github.com/youtalk/autoware.universe/issues/8439>`_)
-* chore(out_of_lane): add Mamoru SOBUE as maintainer (`#8440 <https://github.com/youtalk/autoware.universe/issues/8440>`_)
-* feat(out_of_lane): also apply lat buffer between the lane and stop pose (`#7918 <https://github.com/youtalk/autoware.universe/issues/7918>`_)
-* feat(out_of_lane): ignore objects coming from behind ego (`#7891 <https://github.com/youtalk/autoware.universe/issues/7891>`_)
-* fix(autoware_motion_velocity_out_of_lane_module): fix constParameterReference (`#8051 <https://github.com/youtalk/autoware.universe/issues/8051>`_)
+* docs(out_of_lane): update documentation for the new design (`#8692 <https://github.com/autowarefoundation/autoware.universe/issues/8692>`_)
+* fix(out_of_lane): fix a bug with the rtree reference deleted nodes (`#8679 <https://github.com/autowarefoundation/autoware.universe/issues/8679>`_)
+* fix(out_of_lane): fix noConstructor cppcheck warning (`#8636 <https://github.com/autowarefoundation/autoware.universe/issues/8636>`_)
+* feat(out_of_lane): redesign to improve accuracy and performance (`#8453 <https://github.com/autowarefoundation/autoware.universe/issues/8453>`_)
+* perf(out_of_lane): use rtree to get stop lines and trajectory lanelets (`#8439 <https://github.com/autowarefoundation/autoware.universe/issues/8439>`_)
+* chore(out_of_lane): add Mamoru SOBUE as maintainer (`#8440 <https://github.com/autowarefoundation/autoware.universe/issues/8440>`_)
+* feat(out_of_lane): also apply lat buffer between the lane and stop pose (`#7918 <https://github.com/autowarefoundation/autoware.universe/issues/7918>`_)
+* feat(out_of_lane): ignore objects coming from behind ego (`#7891 <https://github.com/autowarefoundation/autoware.universe/issues/7891>`_)
+* fix(autoware_motion_velocity_out_of_lane_module): fix constParameterReference (`#8051 <https://github.com/autowarefoundation/autoware.universe/issues/8051>`_)
   fix:constParameterReference
-* perf(motion_velocity_planner): resample trajectory after vel smoothing (`#7732 <https://github.com/youtalk/autoware.universe/issues/7732>`_)
+* perf(motion_velocity_planner): resample trajectory after vel smoothing (`#7732 <https://github.com/autowarefoundation/autoware.universe/issues/7732>`_)
   * perf(dynamic_obstacle_stop): create rtree with packing algorithm
-  * Revert "perf(out_of_lane): downsample the trajectory to improve performance (`#7691 <https://github.com/youtalk/autoware.universe/issues/7691>`_)"
+  * Revert "perf(out_of_lane): downsample the trajectory to improve performance (`#7691 <https://github.com/autowarefoundation/autoware.universe/issues/7691>`_)"
   This reverts commit 8444a9eb29b32f500be3724dd5662013b9b81060.
   * perf(motion_velocity_planner): resample trajectory after vel smoothing
   ---------
-* feat: add `autoware\_` prefix to `lanelet2_extension` (`#7640 <https://github.com/youtalk/autoware.universe/issues/7640>`_)
-* perf(out_of_lane): downsample the trajectory to improve performance (`#7691 <https://github.com/youtalk/autoware.universe/issues/7691>`_)
-* feat(motion_velocity_planner, lane_departure_checker): add processing time Float64 publishers (`#7683 <https://github.com/youtalk/autoware.universe/issues/7683>`_)
-* feat(motion_velocity_planner): publish processing times (`#7633 <https://github.com/youtalk/autoware.universe/issues/7633>`_)
-* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/youtalk/autoware.universe/issues/7594>`_)
-* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/youtalk/autoware.universe/issues/7539>`_)
+* feat: add `autoware\_` prefix to `lanelet2_extension` (`#7640 <https://github.com/autowarefoundation/autoware.universe/issues/7640>`_)
+* perf(out_of_lane): downsample the trajectory to improve performance (`#7691 <https://github.com/autowarefoundation/autoware.universe/issues/7691>`_)
+* feat(motion_velocity_planner, lane_departure_checker): add processing time Float64 publishers (`#7683 <https://github.com/autowarefoundation/autoware.universe/issues/7683>`_)
+* feat(motion_velocity_planner): publish processing times (`#7633 <https://github.com/autowarefoundation/autoware.universe/issues/7633>`_)
+* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/autowarefoundation/autoware.universe/issues/7594>`_)
+* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/autowarefoundation/autoware.universe/issues/7539>`_)
   refactor(motion_utils): add autoware prefix and include dir
-* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/youtalk/autoware.universe/issues/7538>`_)
+* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/autowarefoundation/autoware.universe/issues/7538>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* refactor(route_handler)!: rename to include/autoware/{package_name}  (`#7530 <https://github.com/youtalk/autoware.universe/issues/7530>`_)
+* refactor(route_handler)!: rename to include/autoware/{package_name}  (`#7530 <https://github.com/autowarefoundation/autoware.universe/issues/7530>`_)
   refactor(route_handler)!: rename to include/autoware/{package_name}
-* feat(motion_velocity_planner): rename include directories (`#7523 <https://github.com/youtalk/autoware.universe/issues/7523>`_)
-* refactor(route_handler): route handler add autoware prefix (`#7341 <https://github.com/youtalk/autoware.universe/issues/7341>`_)
+* feat(motion_velocity_planner): rename include directories (`#7523 <https://github.com/autowarefoundation/autoware.universe/issues/7523>`_)
+* refactor(route_handler): route handler add autoware prefix (`#7341 <https://github.com/autowarefoundation/autoware.universe/issues/7341>`_)
   * rename route handler package
   * update packages dependencies
   * update include guards
@@ -51,7 +51,7 @@ Changelog for package autoware_motion_velocity_out_of_lane_module
   * fix formats
   * keep header and source file name as before
   ---------
-* refactor(vehicle_info_utils)!: prefix package and namespace with autoware (`#7353 <https://github.com/youtalk/autoware.universe/issues/7353>`_)
+* refactor(vehicle_info_utils)!: prefix package and namespace with autoware (`#7353 <https://github.com/autowarefoundation/autoware.universe/issues/7353>`_)
   * chore(autoware_vehicle_info_utils): rename header
   * chore(bpp-common): vehicle info
   * chore(path_optimizer): vehicle info
@@ -86,17 +86,17 @@ Changelog for package autoware_motion_velocity_out_of_lane_module
   * chore(sensing): vehicle info
   * fix(autoware_joy_controller): remove unused deps
   ---------
-* feat(motion_velocity_planner): use polling subscriber to efficiently get messages (`#7223 <https://github.com/youtalk/autoware.universe/issues/7223>`_)
+* feat(motion_velocity_planner): use polling subscriber to efficiently get messages (`#7223 <https://github.com/autowarefoundation/autoware.universe/issues/7223>`_)
   * feat(motion_velocity_planner): use polling subscriber for odometry topic
   * use polling subscribers for more topics
   * remove blocking mutex lock when processing traffic lights
   * fix assign after return
   ---------
-* feat!: replace autoware_auto_msgs with autoware_msgs for planning modules (`#7246 <https://github.com/youtalk/autoware.universe/issues/7246>`_)
+* feat!: replace autoware_auto_msgs with autoware_msgs for planning modules (`#7246 <https://github.com/autowarefoundation/autoware.universe/issues/7246>`_)
   Co-authored-by: Cynthia Liu <cynthia.liu@autocore.ai>
   Co-authored-by: NorahXiong <norah.xiong@autocore.ai>
   Co-authored-by: beginningfan <beginning.fan@autocore.ai>
-* feat(motion_velocity_planner): add new motion velocity planning (`#7064 <https://github.com/youtalk/autoware.universe/issues/7064>`_)
+* feat(motion_velocity_planner): add new motion velocity planning (`#7064 <https://github.com/autowarefoundation/autoware.universe/issues/7064>`_)
 * Contributors: Kosuke Takeuchi, Maxime CLEMENT, Ryohsuke Mitsudome, Satoshi OTA, Takayuki Murooka, Yutaka Kondo, Zhe Shen, kobayu858, mkquda
 
 0.26.0 (2024-04-03)

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/CHANGELOG.rst
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/CHANGELOG.rst
@@ -5,31 +5,31 @@ Changelog for package autoware_motion_velocity_planner_common
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* fix(motion_velocity_planner): disable randomly failing test (`#8923 <https://github.com/youtalk/autoware.universe/issues/8923>`_)
-* chore(motion_velocity_planner): add Alqudah Mohammad as maintainer (`#8877 <https://github.com/youtalk/autoware.universe/issues/8877>`_)
-* fix(motion_velocity_planner): relax test precision to prevent random failures (`#8799 <https://github.com/youtalk/autoware.universe/issues/8799>`_)
-* feat(out_of_lane): redesign to improve accuracy and performance (`#8453 <https://github.com/youtalk/autoware.universe/issues/8453>`_)
-* perf(motion_velocity_planner): resample trajectory after vel smoothing (`#7732 <https://github.com/youtalk/autoware.universe/issues/7732>`_)
+* fix(motion_velocity_planner): disable randomly failing test (`#8923 <https://github.com/autowarefoundation/autoware.universe/issues/8923>`_)
+* chore(motion_velocity_planner): add Alqudah Mohammad as maintainer (`#8877 <https://github.com/autowarefoundation/autoware.universe/issues/8877>`_)
+* fix(motion_velocity_planner): relax test precision to prevent random failures (`#8799 <https://github.com/autowarefoundation/autoware.universe/issues/8799>`_)
+* feat(out_of_lane): redesign to improve accuracy and performance (`#8453 <https://github.com/autowarefoundation/autoware.universe/issues/8453>`_)
+* perf(motion_velocity_planner): resample trajectory after vel smoothing (`#7732 <https://github.com/autowarefoundation/autoware.universe/issues/7732>`_)
   * perf(dynamic_obstacle_stop): create rtree with packing algorithm
-  * Revert "perf(out_of_lane): downsample the trajectory to improve performance (`#7691 <https://github.com/youtalk/autoware.universe/issues/7691>`_)"
+  * Revert "perf(out_of_lane): downsample the trajectory to improve performance (`#7691 <https://github.com/autowarefoundation/autoware.universe/issues/7691>`_)"
   This reverts commit 8444a9eb29b32f500be3724dd5662013b9b81060.
   * perf(motion_velocity_planner): resample trajectory after vel smoothing
   ---------
-* feat: add `autoware\_` prefix to `lanelet2_extension` (`#7640 <https://github.com/youtalk/autoware.universe/issues/7640>`_)
-* perf(out_of_lane): downsample the trajectory to improve performance (`#7691 <https://github.com/youtalk/autoware.universe/issues/7691>`_)
-* feat(motion_velocity_planner, lane_departure_checker): add processing time Float64 publishers (`#7683 <https://github.com/youtalk/autoware.universe/issues/7683>`_)
-* feat(motion_velocity_planner): publish processing times (`#7633 <https://github.com/youtalk/autoware.universe/issues/7633>`_)
-* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/youtalk/autoware.universe/issues/7594>`_)
-* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/youtalk/autoware.universe/issues/7539>`_)
+* feat: add `autoware\_` prefix to `lanelet2_extension` (`#7640 <https://github.com/autowarefoundation/autoware.universe/issues/7640>`_)
+* perf(out_of_lane): downsample the trajectory to improve performance (`#7691 <https://github.com/autowarefoundation/autoware.universe/issues/7691>`_)
+* feat(motion_velocity_planner, lane_departure_checker): add processing time Float64 publishers (`#7683 <https://github.com/autowarefoundation/autoware.universe/issues/7683>`_)
+* feat(motion_velocity_planner): publish processing times (`#7633 <https://github.com/autowarefoundation/autoware.universe/issues/7633>`_)
+* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/autowarefoundation/autoware.universe/issues/7594>`_)
+* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/autowarefoundation/autoware.universe/issues/7539>`_)
   refactor(motion_utils): add autoware prefix and include dir
-* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/youtalk/autoware.universe/issues/7538>`_)
+* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/autowarefoundation/autoware.universe/issues/7538>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* refactor(route_handler)!: rename to include/autoware/{package_name}  (`#7530 <https://github.com/youtalk/autoware.universe/issues/7530>`_)
+* refactor(route_handler)!: rename to include/autoware/{package_name}  (`#7530 <https://github.com/autowarefoundation/autoware.universe/issues/7530>`_)
   refactor(route_handler)!: rename to include/autoware/{package_name}
-* refactor(velocity_smoother): rename to include/autoware/{package_name} (`#7533 <https://github.com/youtalk/autoware.universe/issues/7533>`_)
-* feat(motion_velocity_planner): rename include directories (`#7523 <https://github.com/youtalk/autoware.universe/issues/7523>`_)
-* refactor(dynamic_obstacle_stop): move to motion_velocity_planner (`#7460 <https://github.com/youtalk/autoware.universe/issues/7460>`_)
-* refactor(route_handler): route handler add autoware prefix (`#7341 <https://github.com/youtalk/autoware.universe/issues/7341>`_)
+* refactor(velocity_smoother): rename to include/autoware/{package_name} (`#7533 <https://github.com/autowarefoundation/autoware.universe/issues/7533>`_)
+* feat(motion_velocity_planner): rename include directories (`#7523 <https://github.com/autowarefoundation/autoware.universe/issues/7523>`_)
+* refactor(dynamic_obstacle_stop): move to motion_velocity_planner (`#7460 <https://github.com/autowarefoundation/autoware.universe/issues/7460>`_)
+* refactor(route_handler): route handler add autoware prefix (`#7341 <https://github.com/autowarefoundation/autoware.universe/issues/7341>`_)
   * rename route handler package
   * update packages dependencies
   * update include guards
@@ -38,7 +38,7 @@ Changelog for package autoware_motion_velocity_planner_common
   * fix formats
   * keep header and source file name as before
   ---------
-* refactor(vehicle_info_utils)!: prefix package and namespace with autoware (`#7353 <https://github.com/youtalk/autoware.universe/issues/7353>`_)
+* refactor(vehicle_info_utils)!: prefix package and namespace with autoware (`#7353 <https://github.com/autowarefoundation/autoware.universe/issues/7353>`_)
   * chore(autoware_vehicle_info_utils): rename header
   * chore(bpp-common): vehicle info
   * chore(path_optimizer): vehicle info
@@ -73,27 +73,27 @@ Changelog for package autoware_motion_velocity_planner_common
   * chore(sensing): vehicle info
   * fix(autoware_joy_controller): remove unused deps
   ---------
-* feat(motion_velocity_planner): use polling subscriber to efficiently get messages (`#7223 <https://github.com/youtalk/autoware.universe/issues/7223>`_)
+* feat(motion_velocity_planner): use polling subscriber to efficiently get messages (`#7223 <https://github.com/autowarefoundation/autoware.universe/issues/7223>`_)
   * feat(motion_velocity_planner): use polling subscriber for odometry topic
   * use polling subscribers for more topics
   * remove blocking mutex lock when processing traffic lights
   * fix assign after return
   ---------
-* refactor(path_optimizer, velocity_smoother)!: prefix package and namespace with autoware (`#7354 <https://github.com/youtalk/autoware.universe/issues/7354>`_)
+* refactor(path_optimizer, velocity_smoother)!: prefix package and namespace with autoware (`#7354 <https://github.com/autowarefoundation/autoware.universe/issues/7354>`_)
   * chore(autoware_velocity_smoother): update namespace
   * chore(autoware_path_optimizer): update namespace
   ---------
-* refactor(behavior_velocity_planner_common)!: prefix package and namespace with autoware (`#7314 <https://github.com/youtalk/autoware.universe/issues/7314>`_)
+* refactor(behavior_velocity_planner_common)!: prefix package and namespace with autoware (`#7314 <https://github.com/autowarefoundation/autoware.universe/issues/7314>`_)
   * refactor(behavior_velocity_planner_common): add autoware prefix
   * refactor(behavior_velocity_planner_common): fix run_out module
   * refactor(behavior_velocity_planner_common): fix for autoware_behavior_velocity_walkway_module
   * refactor(behavior_velocity_planner_common): remove unnecessary using
   ---------
-* feat!: replace autoware_auto_msgs with autoware_msgs for planning modules (`#7246 <https://github.com/youtalk/autoware.universe/issues/7246>`_)
+* feat!: replace autoware_auto_msgs with autoware_msgs for planning modules (`#7246 <https://github.com/autowarefoundation/autoware.universe/issues/7246>`_)
   Co-authored-by: Cynthia Liu <cynthia.liu@autocore.ai>
   Co-authored-by: NorahXiong <norah.xiong@autocore.ai>
   Co-authored-by: beginningfan <beginning.fan@autocore.ai>
-* chore(autoware_velocity_smoother, autoware_path_optimizer): rename packages (`#7202 <https://github.com/youtalk/autoware.universe/issues/7202>`_)
+* chore(autoware_velocity_smoother, autoware_path_optimizer): rename packages (`#7202 <https://github.com/autowarefoundation/autoware.universe/issues/7202>`_)
   * chore(autoware_path_optimizer): rename package and namespace
   * chore(autoware_static_centerline_generator): rename package and namespace
   * chore: update module name
@@ -104,7 +104,7 @@ Changelog for package autoware_motion_velocity_planner_common
   * fix: test
   * fix: test
   ---------
-* feat(motion_velocity_planner): add new motion velocity planning (`#7064 <https://github.com/youtalk/autoware.universe/issues/7064>`_)
+* feat(motion_velocity_planner): add new motion velocity planning (`#7064 <https://github.com/autowarefoundation/autoware.universe/issues/7064>`_)
 * Contributors: Fumiya Watanabe, Kosuke Takeuchi, Maxime CLEMENT, Ryohsuke Mitsudome, Satoshi OTA, Takayuki Murooka, Yutaka Kondo, mkquda
 
 0.26.0 (2024-04-03)

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_node/CHANGELOG.rst
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_node/CHANGELOG.rst
@@ -5,11 +5,11 @@ Changelog for package autoware_motion_velocity_planner_node
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* chore(motion_velocity_planner): add Alqudah Mohammad as maintainer (`#8877 <https://github.com/youtalk/autoware.universe/issues/8877>`_)
-* perf(motion_velocity_planner): fix heavy resampling and transform lookup (`#8839 <https://github.com/youtalk/autoware.universe/issues/8839>`_)
-* fix(obstacle_velocity_limiter): more stable virtual wall (`#8499 <https://github.com/youtalk/autoware.universe/issues/8499>`_)
-* feat(out_of_lane): redesign to improve accuracy and performance (`#8453 <https://github.com/youtalk/autoware.universe/issues/8453>`_)
-* feat(motion_velocity_planner,planning_evaluator): add  stop, slow_down diags (`#8503 <https://github.com/youtalk/autoware.universe/issues/8503>`_)
+* chore(motion_velocity_planner): add Alqudah Mohammad as maintainer (`#8877 <https://github.com/autowarefoundation/autoware.universe/issues/8877>`_)
+* perf(motion_velocity_planner): fix heavy resampling and transform lookup (`#8839 <https://github.com/autowarefoundation/autoware.universe/issues/8839>`_)
+* fix(obstacle_velocity_limiter): more stable virtual wall (`#8499 <https://github.com/autowarefoundation/autoware.universe/issues/8499>`_)
+* feat(out_of_lane): redesign to improve accuracy and performance (`#8453 <https://github.com/autowarefoundation/autoware.universe/issues/8453>`_)
+* feat(motion_velocity_planner,planning_evaluator): add  stop, slow_down diags (`#8503 <https://github.com/autowarefoundation/autoware.universe/issues/8503>`_)
   * tmp save.
   * publish diagnostics.
   * move clearDiagnostics func to head
@@ -26,33 +26,33 @@ Changelog for package autoware_motion_velocity_planner_node
   Co-authored-by: Kosuke Takeuchi <kosuke.tnp@gmail.com>
   ---------
   Co-authored-by: Kosuke Takeuchi <kosuke.tnp@gmail.com>
-* perf(velocity_smoother): not resample debug_trajectories is not used (`#8030 <https://github.com/youtalk/autoware.universe/issues/8030>`_)
+* perf(velocity_smoother): not resample debug_trajectories is not used (`#8030 <https://github.com/autowarefoundation/autoware.universe/issues/8030>`_)
   * not resample debug_trajectories if not published
   * update dependant packages
   ---------
-* feat(out_of_lane): ignore objects coming from behind ego (`#7891 <https://github.com/youtalk/autoware.universe/issues/7891>`_)
-* fix(motion_planning): fix processing time topic names (`#7885 <https://github.com/youtalk/autoware.universe/issues/7885>`_)
-* fix(motion_velocity_planner): use the slowdown velocity (instead of 0) (`#7840 <https://github.com/youtalk/autoware.universe/issues/7840>`_)
-* perf(motion_velocity_planner): resample trajectory after vel smoothing (`#7732 <https://github.com/youtalk/autoware.universe/issues/7732>`_)
+* feat(out_of_lane): ignore objects coming from behind ego (`#7891 <https://github.com/autowarefoundation/autoware.universe/issues/7891>`_)
+* fix(motion_planning): fix processing time topic names (`#7885 <https://github.com/autowarefoundation/autoware.universe/issues/7885>`_)
+* fix(motion_velocity_planner): use the slowdown velocity (instead of 0) (`#7840 <https://github.com/autowarefoundation/autoware.universe/issues/7840>`_)
+* perf(motion_velocity_planner): resample trajectory after vel smoothing (`#7732 <https://github.com/autowarefoundation/autoware.universe/issues/7732>`_)
   * perf(dynamic_obstacle_stop): create rtree with packing algorithm
-  * Revert "perf(out_of_lane): downsample the trajectory to improve performance (`#7691 <https://github.com/youtalk/autoware.universe/issues/7691>`_)"
+  * Revert "perf(out_of_lane): downsample the trajectory to improve performance (`#7691 <https://github.com/autowarefoundation/autoware.universe/issues/7691>`_)"
   This reverts commit 8444a9eb29b32f500be3724dd5662013b9b81060.
   * perf(motion_velocity_planner): resample trajectory after vel smoothing
   ---------
-* feat: add `autoware\_` prefix to `lanelet2_extension` (`#7640 <https://github.com/youtalk/autoware.universe/issues/7640>`_)
-* feat(motion_velocity_planner, lane_departure_checker): add processing time Float64 publishers (`#7683 <https://github.com/youtalk/autoware.universe/issues/7683>`_)
-* feat(motion_velocity_planner): publish processing times (`#7633 <https://github.com/youtalk/autoware.universe/issues/7633>`_)
-* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/youtalk/autoware.universe/issues/7594>`_)
-* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/youtalk/autoware.universe/issues/7539>`_)
+* feat: add `autoware\_` prefix to `lanelet2_extension` (`#7640 <https://github.com/autowarefoundation/autoware.universe/issues/7640>`_)
+* feat(motion_velocity_planner, lane_departure_checker): add processing time Float64 publishers (`#7683 <https://github.com/autowarefoundation/autoware.universe/issues/7683>`_)
+* feat(motion_velocity_planner): publish processing times (`#7633 <https://github.com/autowarefoundation/autoware.universe/issues/7633>`_)
+* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/autowarefoundation/autoware.universe/issues/7594>`_)
+* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/autowarefoundation/autoware.universe/issues/7539>`_)
   refactor(motion_utils): add autoware prefix and include dir
-* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/youtalk/autoware.universe/issues/7538>`_)
+* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/autowarefoundation/autoware.universe/issues/7538>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* refactor(velocity_smoother): rename to include/autoware/{package_name} (`#7533 <https://github.com/youtalk/autoware.universe/issues/7533>`_)
-* feat(motion_velocity_planner): rename include directories (`#7523 <https://github.com/youtalk/autoware.universe/issues/7523>`_)
-* fix(planning): set single depth sensor data qos for pointlcoud polling subscribers (`#7490 <https://github.com/youtalk/autoware.universe/issues/7490>`_)
+* refactor(velocity_smoother): rename to include/autoware/{package_name} (`#7533 <https://github.com/autowarefoundation/autoware.universe/issues/7533>`_)
+* feat(motion_velocity_planner): rename include directories (`#7523 <https://github.com/autowarefoundation/autoware.universe/issues/7523>`_)
+* fix(planning): set single depth sensor data qos for pointlcoud polling subscribers (`#7490 <https://github.com/autowarefoundation/autoware.universe/issues/7490>`_)
   set single depth sensor data qos for pointlcoud polling subscribers
-* refactor(dynamic_obstacle_stop): move to motion_velocity_planner (`#7460 <https://github.com/youtalk/autoware.universe/issues/7460>`_)
-* refactor(test_utils): move to common folder (`#7158 <https://github.com/youtalk/autoware.universe/issues/7158>`_)
+* refactor(dynamic_obstacle_stop): move to motion_velocity_planner (`#7460 <https://github.com/autowarefoundation/autoware.universe/issues/7460>`_)
+* refactor(test_utils): move to common folder (`#7158 <https://github.com/autowarefoundation/autoware.universe/issues/7158>`_)
   * Move autoware planning test manager to autoware namespace
   * fix package share directory for behavior path planner
   * renaming files and directory
@@ -64,22 +64,22 @@ Changelog for package autoware_motion_velocity_planner_node
   * removed obstacle velocity limiter test artifact
   * remove namespace from planning validator, it has using keyword
   ---------
-* feat(obstacle_velocity_limiter): move to motion_velocity_planner (`#7439 <https://github.com/youtalk/autoware.universe/issues/7439>`_)
-* feat(motion_velocity_planner): use polling subscriber to efficiently get messages (`#7223 <https://github.com/youtalk/autoware.universe/issues/7223>`_)
+* feat(obstacle_velocity_limiter): move to motion_velocity_planner (`#7439 <https://github.com/autowarefoundation/autoware.universe/issues/7439>`_)
+* feat(motion_velocity_planner): use polling subscriber to efficiently get messages (`#7223 <https://github.com/autowarefoundation/autoware.universe/issues/7223>`_)
   * feat(motion_velocity_planner): use polling subscriber for odometry topic
   * use polling subscribers for more topics
   * remove blocking mutex lock when processing traffic lights
   * fix assign after return
   ---------
-* refactor(path_optimizer, velocity_smoother)!: prefix package and namespace with autoware (`#7354 <https://github.com/youtalk/autoware.universe/issues/7354>`_)
+* refactor(path_optimizer, velocity_smoother)!: prefix package and namespace with autoware (`#7354 <https://github.com/autowarefoundation/autoware.universe/issues/7354>`_)
   * chore(autoware_velocity_smoother): update namespace
   * chore(autoware_path_optimizer): update namespace
   ---------
-* feat!: replace autoware_auto_msgs with autoware_msgs for planning modules (`#7246 <https://github.com/youtalk/autoware.universe/issues/7246>`_)
+* feat!: replace autoware_auto_msgs with autoware_msgs for planning modules (`#7246 <https://github.com/autowarefoundation/autoware.universe/issues/7246>`_)
   Co-authored-by: Cynthia Liu <cynthia.liu@autocore.ai>
   Co-authored-by: NorahXiong <norah.xiong@autocore.ai>
   Co-authored-by: beginningfan <beginning.fan@autocore.ai>
-* chore(autoware_velocity_smoother, autoware_path_optimizer): rename packages (`#7202 <https://github.com/youtalk/autoware.universe/issues/7202>`_)
+* chore(autoware_velocity_smoother, autoware_path_optimizer): rename packages (`#7202 <https://github.com/autowarefoundation/autoware.universe/issues/7202>`_)
   * chore(autoware_path_optimizer): rename package and namespace
   * chore(autoware_static_centerline_generator): rename package and namespace
   * chore: update module name
@@ -90,7 +90,7 @@ Changelog for package autoware_motion_velocity_planner_node
   * fix: test
   * fix: test
   ---------
-* feat(motion_velocity_planner): add new motion velocity planning (`#7064 <https://github.com/youtalk/autoware.universe/issues/7064>`_)
+* feat(motion_velocity_planner): add new motion velocity planning (`#7064 <https://github.com/autowarefoundation/autoware.universe/issues/7064>`_)
 * Contributors: Fumiya Watanabe, Kosuke Takeuchi, Maxime CLEMENT, Ryohsuke Mitsudome, Satoshi OTA, Takayuki Murooka, Tiankui Xian, Yutaka Kondo, Zulfaqar Azmi, mkquda
 
 0.26.0 (2024-04-03)

--- a/planning/sampling_based_planner/autoware_bezier_sampler/CHANGELOG.rst
+++ b/planning/sampling_based_planner/autoware_bezier_sampler/CHANGELOG.rst
@@ -5,7 +5,7 @@ Changelog for package autoware_bezier_sampler
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* refactor(sampling_based_planner): add autoware prefix (`#7348 <https://github.com/youtalk/autoware.universe/issues/7348>`_)
+* refactor(sampling_based_planner): add autoware prefix (`#7348 <https://github.com/autowarefoundation/autoware.universe/issues/7348>`_)
 * Contributors: Maxime CLEMENT, Yutaka Kondo
 
 0.26.0 (2024-04-03)

--- a/planning/sampling_based_planner/autoware_frenet_planner/CHANGELOG.rst
+++ b/planning/sampling_based_planner/autoware_frenet_planner/CHANGELOG.rst
@@ -5,15 +5,15 @@ Changelog for package autoware_frenet_planner
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* fix(autoware_frenet_planner): fix build error (`#8807 <https://github.com/youtalk/autoware.universe/issues/8807>`_)
+* fix(autoware_frenet_planner): fix build error (`#8807 <https://github.com/autowarefoundation/autoware.universe/issues/8807>`_)
   fix:build error
-* fix(autoware_frenet_planner): fix unusedFunction (`#8788 <https://github.com/youtalk/autoware.universe/issues/8788>`_)
+* fix(autoware_frenet_planner): fix unusedFunction (`#8788 <https://github.com/autowarefoundation/autoware.universe/issues/8788>`_)
   fix: unusedFunction
-* fix(frenet_planner): fix mistake in the curvature calculation (`#7920 <https://github.com/youtalk/autoware.universe/issues/7920>`_)
-* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/youtalk/autoware.universe/issues/7594>`_)
-* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/youtalk/autoware.universe/issues/7538>`_)
+* fix(frenet_planner): fix mistake in the curvature calculation (`#7920 <https://github.com/autowarefoundation/autoware.universe/issues/7920>`_)
+* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/autowarefoundation/autoware.universe/issues/7594>`_)
+* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/autowarefoundation/autoware.universe/issues/7538>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* refactor(sampling_based_planner): add autoware prefix (`#7348 <https://github.com/youtalk/autoware.universe/issues/7348>`_)
+* refactor(sampling_based_planner): add autoware prefix (`#7348 <https://github.com/autowarefoundation/autoware.universe/issues/7348>`_)
 * Contributors: Hayate TOBA, Kosuke Takeuchi, Maxime CLEMENT, Takayuki Murooka, Yutaka Kondo, kobayu858
 
 0.26.0 (2024-04-03)

--- a/planning/sampling_based_planner/autoware_path_sampler/CHANGELOG.rst
+++ b/planning/sampling_based_planner/autoware_path_sampler/CHANGELOG.rst
@@ -5,23 +5,23 @@ Changelog for package autoware_path_sampler
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* refactor(autoware_interpolation): prefix package and namespace with autoware (`#8088 <https://github.com/youtalk/autoware.universe/issues/8088>`_)
+* refactor(autoware_interpolation): prefix package and namespace with autoware (`#8088 <https://github.com/autowarefoundation/autoware.universe/issues/8088>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* fix(autoware_path_sampler): fix unusedFunction (`#8730 <https://github.com/youtalk/autoware.universe/issues/8730>`_)
+* fix(autoware_path_sampler): fix unusedFunction (`#8730 <https://github.com/autowarefoundation/autoware.universe/issues/8730>`_)
   fix:unusedFunction
-* fix(autoware_path_sampler): fix passedByValue (`#8216 <https://github.com/youtalk/autoware.universe/issues/8216>`_)
+* fix(autoware_path_sampler): fix passedByValue (`#8216 <https://github.com/autowarefoundation/autoware.universe/issues/8216>`_)
   fix:passedByValue
-* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/youtalk/autoware.universe/issues/7594>`_)
-* fix(autoware_path_sampler): fix unusedVariable warning (`#7584 <https://github.com/youtalk/autoware.universe/issues/7584>`_)
+* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/autowarefoundation/autoware.universe/issues/7594>`_)
+* fix(autoware_path_sampler): fix unusedVariable warning (`#7584 <https://github.com/autowarefoundation/autoware.universe/issues/7584>`_)
   fix unusedVariable warning
-* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/youtalk/autoware.universe/issues/7539>`_)
+* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/autowarefoundation/autoware.universe/issues/7539>`_)
   refactor(motion_utils): add autoware prefix and include dir
-* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/youtalk/autoware.universe/issues/7538>`_)
+* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/autowarefoundation/autoware.universe/issues/7538>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* ci(pre-commit): autoupdate (`#7499 <https://github.com/youtalk/autoware.universe/issues/7499>`_)
+* ci(pre-commit): autoupdate (`#7499 <https://github.com/autowarefoundation/autoware.universe/issues/7499>`_)
   Co-authored-by: M. Fatih Cırıt <mfc@leodrive.ai>
-* feat(sampling_based_planner): use polling subscribers (`#7394 <https://github.com/youtalk/autoware.universe/issues/7394>`_)
-* refactor(vehicle_info_utils)!: prefix package and namespace with autoware (`#7353 <https://github.com/youtalk/autoware.universe/issues/7353>`_)
+* feat(sampling_based_planner): use polling subscribers (`#7394 <https://github.com/autowarefoundation/autoware.universe/issues/7394>`_)
+* refactor(vehicle_info_utils)!: prefix package and namespace with autoware (`#7353 <https://github.com/autowarefoundation/autoware.universe/issues/7353>`_)
   * chore(autoware_vehicle_info_utils): rename header
   * chore(bpp-common): vehicle info
   * chore(path_optimizer): vehicle info
@@ -56,7 +56,7 @@ Changelog for package autoware_path_sampler
   * chore(sensing): vehicle info
   * fix(autoware_joy_controller): remove unused deps
   ---------
-* refactor(sampling_based_planner): add autoware prefix (`#7348 <https://github.com/youtalk/autoware.universe/issues/7348>`_)
+* refactor(sampling_based_planner): add autoware prefix (`#7348 <https://github.com/autowarefoundation/autoware.universe/issues/7348>`_)
 * Contributors: Esteve Fernandez, Kosuke Takeuchi, Maxime CLEMENT, Ryuta Kambe, Satoshi OTA, Takayuki Murooka, Yutaka Kondo, awf-autoware-bot[bot], kobayu858
 
 0.26.0 (2024-04-03)

--- a/planning/sampling_based_planner/autoware_sampler_common/CHANGELOG.rst
+++ b/planning/sampling_based_planner/autoware_sampler_common/CHANGELOG.rst
@@ -5,12 +5,12 @@ Changelog for package autoware_sampler_common
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* refactor(autoware_interpolation): prefix package and namespace with autoware (`#8088 <https://github.com/youtalk/autoware.universe/issues/8088>`_)
+* refactor(autoware_interpolation): prefix package and namespace with autoware (`#8088 <https://github.com/autowarefoundation/autoware.universe/issues/8088>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/youtalk/autoware.universe/issues/7594>`_)
-* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/youtalk/autoware.universe/issues/7538>`_)
+* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/autowarefoundation/autoware.universe/issues/7594>`_)
+* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/autowarefoundation/autoware.universe/issues/7538>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* refactor(sampling_based_planner): add autoware prefix (`#7348 <https://github.com/youtalk/autoware.universe/issues/7348>`_)
+* refactor(sampling_based_planner): add autoware prefix (`#7348 <https://github.com/autowarefoundation/autoware.universe/issues/7348>`_)
 * Contributors: Esteve Fernandez, Kosuke Takeuchi, Maxime CLEMENT, Takayuki Murooka, Yutaka Kondo
 
 0.26.0 (2024-04-03)

--- a/sensing/autoware_cuda_utils/CHANGELOG.rst
+++ b/sensing/autoware_cuda_utils/CHANGELOG.rst
@@ -5,8 +5,8 @@ Changelog for package cuda_utils
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* chore: added maintainers to the cuda_utils package (`#9042 <https://github.com/youtalk/autoware.universe/issues/9042>`_)
-* refactor(cuda_utils): move cuda_utils to sensing (`#8729 <https://github.com/youtalk/autoware.universe/issues/8729>`_)
+* chore: added maintainers to the cuda_utils package (`#9042 <https://github.com/autowarefoundation/autoware.universe/issues/9042>`_)
+* refactor(cuda_utils): move cuda_utils to sensing (`#8729 <https://github.com/autowarefoundation/autoware.universe/issues/8729>`_)
   fix: move cuda_utils to sensing
 * Contributors: Kenzo Lobos Tsunekawa, Yoshi Ri, Yutaka Kondo
 

--- a/sensing/autoware_gnss_poser/CHANGELOG.rst
+++ b/sensing/autoware_gnss_poser/CHANGELOG.rst
@@ -5,13 +5,13 @@ Changelog for package autoware_gnss_poser
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* refactor(component_interface_specs): prefix package and namespace with autoware (`#9094 <https://github.com/youtalk/autoware.universe/issues/9094>`_)
-* chore(autoware_gnss_poser): make source codes follow the coding rules (`#8703 <https://github.com/youtalk/autoware.universe/issues/8703>`_)
+* refactor(component_interface_specs): prefix package and namespace with autoware (`#9094 <https://github.com/autowarefoundation/autoware.universe/issues/9094>`_)
+* chore(autoware_gnss_poser): make source codes follow the coding rules (`#8703 <https://github.com/autowarefoundation/autoware.universe/issues/8703>`_)
   * Follow the coding rules in autoware_gnss_poser
   * Edit _core to _node inside files
   * Fixed AUTOWARE__GNSS_POSER__GNSS_POSER_NODE_HPP\_ part
   ---------
-* chore(gnss_poser): add autoware prefix to gnss_poser (`#8323 <https://github.com/youtalk/autoware.universe/issues/8323>`_)
+* chore(gnss_poser): add autoware prefix to gnss_poser (`#8323 <https://github.com/autowarefoundation/autoware.universe/issues/8323>`_)
   * add "autoware" prefix to gnss_poser
   * Fixed typos and left overs
   * Fixed directory mistake

--- a/sensing/autoware_image_diagnostics/CHANGELOG.rst
+++ b/sensing/autoware_image_diagnostics/CHANGELOG.rst
@@ -5,11 +5,11 @@ Changelog for package autoware_image_diagnostics
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* fix(autoware_image_diagnostics): fix cppcheck warnings (`#8228 <https://github.com/youtalk/autoware.universe/issues/8228>`_)
+* fix(autoware_image_diagnostics): fix cppcheck warnings (`#8228 <https://github.com/autowarefoundation/autoware.universe/issues/8228>`_)
   * fix(autoware_image_diagnostics): fix cppcheck warnings
   * fix
   ---------
-* refactor(image_diagnostics): add package name prefix of autoware\_ (`#8130 <https://github.com/youtalk/autoware.universe/issues/8130>`_)
+* refactor(image_diagnostics): add package name prefix of autoware\_ (`#8130 <https://github.com/autowarefoundation/autoware.universe/issues/8130>`_)
   * refactor: rename image_diagnostics to autoware_image_diagnostics
   * refactor: rename sensing/image_diagnostics to sensing/autoware_image_diagnostics
   ---------

--- a/sensing/autoware_image_transport_decompressor/CHANGELOG.rst
+++ b/sensing/autoware_image_transport_decompressor/CHANGELOG.rst
@@ -5,7 +5,7 @@ Changelog for package autoware_image_transport_decompressor
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* refactor: image transport decompressor/autoware prefix (`#8197 <https://github.com/youtalk/autoware.universe/issues/8197>`_)
+* refactor: image transport decompressor/autoware prefix (`#8197 <https://github.com/autowarefoundation/autoware.universe/issues/8197>`_)
   * refactor: add `autoware` namespace prefix to image_transport_decompressor
   * refactor(image_transport_decompressor): add `autoware` prefix to the package code
   * refactor: update package name in CODEOWNER

--- a/sensing/autoware_imu_corrector/CHANGELOG.rst
+++ b/sensing/autoware_imu_corrector/CHANGELOG.rst
@@ -5,7 +5,7 @@ Changelog for package autoware_imu_corrector
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* chore(autoware_imu_corrector): refactored the imu corrector into the autoware namespace (`#8222 <https://github.com/youtalk/autoware.universe/issues/8222>`_)
+* chore(autoware_imu_corrector): refactored the imu corrector into the autoware namespace (`#8222 <https://github.com/autowarefoundation/autoware.universe/issues/8222>`_)
   * chore: refactored the imu corrector into the autoware namespace
   * chore: reverted to non-exported includes
   ---------

--- a/sensing/autoware_pcl_extensions/CHANGELOG.rst
+++ b/sensing/autoware_pcl_extensions/CHANGELOG.rst
@@ -5,7 +5,7 @@ Changelog for package autoware_pcl_extensions
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* chore(autoware_pcl_extensions): refactored the pcl_extensions (`#8220 <https://github.com/youtalk/autoware.universe/issues/8220>`_)
+* chore(autoware_pcl_extensions): refactored the pcl_extensions (`#8220 <https://github.com/autowarefoundation/autoware.universe/issues/8220>`_)
   chore: refactored the pcl_extensions according to the new rules
 * Contributors: Kenzo Lobos Tsunekawa, Yutaka Kondo
 

--- a/sensing/autoware_pointcloud_preprocessor/CHANGELOG.rst
+++ b/sensing/autoware_pointcloud_preprocessor/CHANGELOG.rst
@@ -5,15 +5,15 @@ Changelog for package autoware_pointcloud_preprocessor
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* refactor(autoware_point_types): prefix namespace with autoware::point_types (`#9169 <https://github.com/youtalk/autoware.universe/issues/9169>`_)
-* refactor(autoware_compare_map_segmentation): resolve clang-tidy error in autoware_compare_map_segmentation (`#9162 <https://github.com/youtalk/autoware.universe/issues/9162>`_)
+* refactor(autoware_point_types): prefix namespace with autoware::point_types (`#9169 <https://github.com/autowarefoundation/autoware.universe/issues/9169>`_)
+* refactor(autoware_compare_map_segmentation): resolve clang-tidy error in autoware_compare_map_segmentation (`#9162 <https://github.com/autowarefoundation/autoware.universe/issues/9162>`_)
   * refactor(autoware_compare_map_segmentation): resolve clang-tidy error in autoware_compare_map_segmentation
   * style(pre-commit): autofix
   * include message_filters as SYSTEM
   * style(pre-commit): autofix
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat(autoware_pointcloud_preprocessor): distortion corrector node update azimuth and distance (`#8380 <https://github.com/youtalk/autoware.universe/issues/8380>`_)
+* feat(autoware_pointcloud_preprocessor): distortion corrector node update azimuth and distance (`#8380 <https://github.com/autowarefoundation/autoware.universe/issues/8380>`_)
   * feat: add option for updating distance and azimuth value
   * chore: clean code
   * chore: remove space
@@ -109,7 +109,7 @@ Changelog for package autoware_pointcloud_preprocessor
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Max Schmeller <6088931+mojomex@users.noreply.github.com>
   Co-authored-by: Kenzo Lobos Tsunekawa <kenzo.lobos@tier4.jp>
-* refactor(autoware_pointcloud_preprocessor): rework crop box parameters (`#8466 <https://github.com/youtalk/autoware.universe/issues/8466>`_)
+* refactor(autoware_pointcloud_preprocessor): rework crop box parameters (`#8466 <https://github.com/autowarefoundation/autoware.universe/issues/8466>`_)
   * feat: add parameter schema for crop box
   * chore: fix readme
   * chore: remove filter.param.yaml file
@@ -117,7 +117,7 @@ Changelog for package autoware_pointcloud_preprocessor
   * chore: fix schema description
   * chore: fix description of negative param
   ---------
-* refactor(autoware_pointcloud_preprocessor): rework approximate downsample filter parameters (`#8480 <https://github.com/youtalk/autoware.universe/issues/8480>`_)
+* refactor(autoware_pointcloud_preprocessor): rework approximate downsample filter parameters (`#8480 <https://github.com/autowarefoundation/autoware.universe/issues/8480>`_)
   * feat: rework approximate downsample parameters
   * chore: add boundary
   * chore: change double to float
@@ -129,7 +129,7 @@ Changelog for package autoware_pointcloud_preprocessor
   * chore: change minimum to float
   * chore: fix CMakeLists
   ---------
-* refactor(autoware_pointcloud_preprocessor): rework dual return outlier filter parameters (`#8475 <https://github.com/youtalk/autoware.universe/issues/8475>`_)
+* refactor(autoware_pointcloud_preprocessor): rework dual return outlier filter parameters (`#8475 <https://github.com/autowarefoundation/autoware.universe/issues/8475>`_)
   * feat: rework dual return outlier filter parameters
   * chore: fix readme
   * chore: change launch file name
@@ -145,7 +145,7 @@ Changelog for package autoware_pointcloud_preprocessor
   * chore: change minimum and maximum to float
   ---------
   Co-authored-by: Kenzo Lobos Tsunekawa <kenzo.lobos@tier4.jp>
-* refactor(autoware_pointcloud_preprocessor): rework ring outlier filter parameters (`#8468 <https://github.com/youtalk/autoware.universe/issues/8468>`_)
+* refactor(autoware_pointcloud_preprocessor): rework ring outlier filter parameters (`#8468 <https://github.com/autowarefoundation/autoware.universe/issues/8468>`_)
   * feat: rework ring outlier parameters
   * chore: add explicit cast
   * chore: add boundary
@@ -154,7 +154,7 @@ Changelog for package autoware_pointcloud_preprocessor
   * chore: add maximum boundary
   * chore: boundary to float type
   ---------
-* refactor(autoware_pointcloud_preprocessor): rework pickup based voxel grid downsample filter parameters (`#8481 <https://github.com/youtalk/autoware.universe/issues/8481>`_)
+* refactor(autoware_pointcloud_preprocessor): rework pickup based voxel grid downsample filter parameters (`#8481 <https://github.com/autowarefoundation/autoware.universe/issues/8481>`_)
   * feat: rework pickup based voxel grid downsample filter parameter
   * chore: update date
   * chore: fix spell error
@@ -162,7 +162,7 @@ Changelog for package autoware_pointcloud_preprocessor
   * chore: fix grammatical error
   ---------
   Co-authored-by: Kenzo Lobos Tsunekawa <kenzo.lobos@tier4.jp>
-* ci(pre-commit): autoupdate (`#7630 <https://github.com/youtalk/autoware.universe/issues/7630>`_)
+* ci(pre-commit): autoupdate (`#7630 <https://github.com/autowarefoundation/autoware.universe/issues/7630>`_)
   * ci(pre-commit): autoupdate
   * style(pre-commit): autofix
   * fix: remove the outer call to dict()
@@ -170,24 +170,24 @@ Changelog for package autoware_pointcloud_preprocessor
   Co-authored-by: github-actions <github-actions@github.com>
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: mitsudome-r <ryohsuke.mitsudome@tier4.jp>
-* refactor(autoware_pointcloud_preprocessor): rework random downsample filter parameters (`#8485 <https://github.com/youtalk/autoware.universe/issues/8485>`_)
+* refactor(autoware_pointcloud_preprocessor): rework random downsample filter parameters (`#8485 <https://github.com/autowarefoundation/autoware.universe/issues/8485>`_)
   * feat: rework random downsample filter parameter
   * chore: change name
   * chore: add explicit cast
   ---------
   Co-authored-by: Kenzo Lobos Tsunekawa <kenzo.lobos@tier4.jp>
-* refactor(autoware_pointcloud_preprocessor): rework pointcloud accumulator parameters  (`#8487 <https://github.com/youtalk/autoware.universe/issues/8487>`_)
+* refactor(autoware_pointcloud_preprocessor): rework pointcloud accumulator parameters  (`#8487 <https://github.com/autowarefoundation/autoware.universe/issues/8487>`_)
   * feat: rework pointcloud accumulator parameters
   * chore: add explicit cast
   * chore: add boundary
   ---------
-* refactor(autoware_pointcloud_preprocessor): rework radius search 2d outlier filter parameters (`#8474 <https://github.com/youtalk/autoware.universe/issues/8474>`_)
+* refactor(autoware_pointcloud_preprocessor): rework radius search 2d outlier filter parameters (`#8474 <https://github.com/autowarefoundation/autoware.universe/issues/8474>`_)
   * feat: rework radius search 2d outlier filter parameters
   * chore: fix schema
   * chore: explicit cast
   * chore: add boundary in schema
   ---------
-* refactor(autoware_pointcloud_preprocessor): rework ring passthrough filter parameters (`#8472 <https://github.com/youtalk/autoware.universe/issues/8472>`_)
+* refactor(autoware_pointcloud_preprocessor): rework ring passthrough filter parameters (`#8472 <https://github.com/autowarefoundation/autoware.universe/issues/8472>`_)
   * feat: rework ring passthrough parameters
   * chore: fix cmake
   * feat: add schema
@@ -197,16 +197,16 @@ Changelog for package autoware_pointcloud_preprocessor
   * chore: fix default parameter
   * chore: fix default parameter in schema
   ---------
-* fix(autoware_pointcloud_preprocessor): static TF listener as Filter option (`#8678 <https://github.com/youtalk/autoware.universe/issues/8678>`_)
-* fix(pointcloud_preprocessor): fix typo (`#8762 <https://github.com/youtalk/autoware.universe/issues/8762>`_)
-* fix(autoware_pointcloud_preprocessor): instantiate templates so that the symbols exist when linking (`#8743 <https://github.com/youtalk/autoware.universe/issues/8743>`_)
-* fix(autoware_pointcloud_preprocessor): fix unusedFunction (`#8673 <https://github.com/youtalk/autoware.universe/issues/8673>`_)
+* fix(autoware_pointcloud_preprocessor): static TF listener as Filter option (`#8678 <https://github.com/autowarefoundation/autoware.universe/issues/8678>`_)
+* fix(pointcloud_preprocessor): fix typo (`#8762 <https://github.com/autowarefoundation/autoware.universe/issues/8762>`_)
+* fix(autoware_pointcloud_preprocessor): instantiate templates so that the symbols exist when linking (`#8743 <https://github.com/autowarefoundation/autoware.universe/issues/8743>`_)
+* fix(autoware_pointcloud_preprocessor): fix unusedFunction (`#8673 <https://github.com/autowarefoundation/autoware.universe/issues/8673>`_)
   fix:unusedFunction
-* fix(autoware_pointcloud_preprocessor): resolve issue with FLT_MAX not declared on Jazzy (`#8586 <https://github.com/youtalk/autoware.universe/issues/8586>`_)
+* fix(autoware_pointcloud_preprocessor): resolve issue with FLT_MAX not declared on Jazzy (`#8586 <https://github.com/autowarefoundation/autoware.universe/issues/8586>`_)
   fix(pointcloud-preprocessor): FLT_MAX not declared
   Fixes compilation error on Jazzy:
   error: ‘FLT_MAX’ was not declared in this scope
-* fix(autoware_pointcloud_preprocessor): blockage diag node add runtime error when the parameter is wrong (`#8564 <https://github.com/youtalk/autoware.universe/issues/8564>`_)
+* fix(autoware_pointcloud_preprocessor): blockage diag node add runtime error when the parameter is wrong (`#8564 <https://github.com/autowarefoundation/autoware.universe/issues/8564>`_)
   * fix: add runtime error
   * Update blockage_diag_node.cpp
   Co-authored-by: badai nguyen  <94814556+badai-nguyen@users.noreply.github.com>
@@ -214,12 +214,12 @@ Changelog for package autoware_pointcloud_preprocessor
   * chore: remove unused variable
   ---------
   Co-authored-by: badai nguyen <94814556+badai-nguyen@users.noreply.github.com>
-* chore(autoware_pointcloud_preprocessor): change unnecessary warning message to debug (`#8525 <https://github.com/youtalk/autoware.universe/issues/8525>`_)
-* refactor(autoware_pointcloud_preprocessor): rework voxel grid outlier filter  parameters (`#8476 <https://github.com/youtalk/autoware.universe/issues/8476>`_)
+* chore(autoware_pointcloud_preprocessor): change unnecessary warning message to debug (`#8525 <https://github.com/autowarefoundation/autoware.universe/issues/8525>`_)
+* refactor(autoware_pointcloud_preprocessor): rework voxel grid outlier filter  parameters (`#8476 <https://github.com/autowarefoundation/autoware.universe/issues/8476>`_)
   * feat: rework voxel grid outlier filter parameters
   * chore: add boundary
   ---------
-* refactor(autoware_pointcloud_preprocessor): rework lanelet2 map filter parameters (`#8491 <https://github.com/youtalk/autoware.universe/issues/8491>`_)
+* refactor(autoware_pointcloud_preprocessor): rework lanelet2 map filter parameters (`#8491 <https://github.com/autowarefoundation/autoware.universe/issues/8491>`_)
   * feat: rework lanelet2 map filter parameters
   * chore: remove unrelated files
   * fix: fix node name in launch
@@ -227,12 +227,12 @@ Changelog for package autoware_pointcloud_preprocessor
   * chore: fix spell error
   * chore: add boundary
   ---------
-* refactor(autoware_pointcloud_preprocessor): rework vector map inside area filter parameters  (`#8493 <https://github.com/youtalk/autoware.universe/issues/8493>`_)
+* refactor(autoware_pointcloud_preprocessor): rework vector map inside area filter parameters  (`#8493 <https://github.com/autowarefoundation/autoware.universe/issues/8493>`_)
   * feat: rework vector map inside area filter parameter
   * chore: fix launcher
   * chore: fix launcher input and output
   ---------
-* refactor(autoware_pointcloud_preprocessor): rework concatenate_pointcloud and time_synchronizer_node parameters (`#8509 <https://github.com/youtalk/autoware.universe/issues/8509>`_)
+* refactor(autoware_pointcloud_preprocessor): rework concatenate_pointcloud and time_synchronizer_node parameters (`#8509 <https://github.com/autowarefoundation/autoware.universe/issues/8509>`_)
   * feat: rewort concatenate pointclouds and time synchronizer parameter
   * chore: fix launch files
   * chore: fix schema
@@ -240,39 +240,39 @@ Changelog for package autoware_pointcloud_preprocessor
   * chore: fix integer and number default value in schema
   * chore: add boundary
   ---------
-* refactor(autoware_pointcloud_preprocessor): rework voxel grid downsample filter parameters (`#8486 <https://github.com/youtalk/autoware.universe/issues/8486>`_)
+* refactor(autoware_pointcloud_preprocessor): rework voxel grid downsample filter parameters (`#8486 <https://github.com/autowarefoundation/autoware.universe/issues/8486>`_)
   * feat:rework voxel grid downsample parameters
   * chore: add boundary
   ---------
   Co-authored-by: Kenzo Lobos Tsunekawa <kenzo.lobos@tier4.jp>
-* refactor(autoware_pointcloud_preprocessor): rework blockage diag parameters  (`#8488 <https://github.com/youtalk/autoware.universe/issues/8488>`_)
+* refactor(autoware_pointcloud_preprocessor): rework blockage diag parameters  (`#8488 <https://github.com/autowarefoundation/autoware.universe/issues/8488>`_)
   * feat: rework blockage diag parameters
   * chore: fix readme
   * chore: fix schema description
   * chore: add boundary for schema
   ---------
-* chore(autoware_pcl_extensions): refactored the pcl_extensions (`#8220 <https://github.com/youtalk/autoware.universe/issues/8220>`_)
+* chore(autoware_pcl_extensions): refactored the pcl_extensions (`#8220 <https://github.com/autowarefoundation/autoware.universe/issues/8220>`_)
   chore: refactored the pcl_extensions according to the new rules
-* feat(pointcloud_preprocessor)!: revert "fix: added temporary retrocompatibility to old perception data (`#7929 <https://github.com/youtalk/autoware.universe/issues/7929>`_)" (`#8397 <https://github.com/youtalk/autoware.universe/issues/8397>`_)
-  * feat!(pointcloud_preprocessor): Revert "fix: added temporary retrocompatibility to old perception data (`#7929 <https://github.com/youtalk/autoware.universe/issues/7929>`_)"
+* feat(pointcloud_preprocessor)!: revert "fix: added temporary retrocompatibility to old perception data (`#7929 <https://github.com/autowarefoundation/autoware.universe/issues/7929>`_)" (`#8397 <https://github.com/autowarefoundation/autoware.universe/issues/8397>`_)
+  * feat!(pointcloud_preprocessor): Revert "fix: added temporary retrocompatibility to old perception data (`#7929 <https://github.com/autowarefoundation/autoware.universe/issues/7929>`_)"
   This reverts commit 6b9f164b123e2f6a6fedf7330e507d4b68e45a09.
   * feat(pointcloud_preprocessor): minor grammar fix
   Co-authored-by: David Wong <33114676+drwnz@users.noreply.github.com>
   ---------
   Co-authored-by: Kenzo Lobos Tsunekawa <kenzo.lobos@tier4.jp>
   Co-authored-by: David Wong <33114676+drwnz@users.noreply.github.com>
-* fix(autoware_pointcloud_preprocessor): fix variableScope (`#8447 <https://github.com/youtalk/autoware.universe/issues/8447>`_)
+* fix(autoware_pointcloud_preprocessor): fix variableScope (`#8447 <https://github.com/autowarefoundation/autoware.universe/issues/8447>`_)
   * fix:variableScope
   * refactor:use const
   ---------
-* fix(autoware_pointcloud_preprocessor): fix unreadVariable (`#8370 <https://github.com/youtalk/autoware.universe/issues/8370>`_)
+* fix(autoware_pointcloud_preprocessor): fix unreadVariable (`#8370 <https://github.com/autowarefoundation/autoware.universe/issues/8370>`_)
   fix:unreadVariable
-* fix(ring_outlier_filter): remove unnecessary resize to prevent zero points (`#8402 <https://github.com/youtalk/autoware.universe/issues/8402>`_)
+* fix(ring_outlier_filter): remove unnecessary resize to prevent zero points (`#8402 <https://github.com/autowarefoundation/autoware.universe/issues/8402>`_)
   fix: remove unnecessary resize
-* fix(autoware_pointcloud_preprocessor): fix cppcheck warnings of functionStatic (`#8163 <https://github.com/youtalk/autoware.universe/issues/8163>`_)
+* fix(autoware_pointcloud_preprocessor): fix cppcheck warnings of functionStatic (`#8163 <https://github.com/autowarefoundation/autoware.universe/issues/8163>`_)
   fix: deal with functionStatic warnings
   Co-authored-by: Yi-Hsiang Fang (Vivid) <146902905+vividf@users.noreply.github.com>
-* perf(autoware_pointcloud_preprocessor): lazy & managed TF listeners (`#8174 <https://github.com/youtalk/autoware.universe/issues/8174>`_)
+* perf(autoware_pointcloud_preprocessor): lazy & managed TF listeners (`#8174 <https://github.com/autowarefoundation/autoware.universe/issues/8174>`_)
   * perf(autoware_pointcloud_preprocessor): lazy & managed TF listeners
   * fix(autoware_pointcloud_preprocessor): param names & reverse frames transform logic
   * fix(autoware_ground_segmentation): add missing TF listener
@@ -282,14 +282,14 @@ Changelog for package autoware_pointcloud_preprocessor
   * fix(autoware_universe_utils): change checks order
   * doc(autoware_universe_utils): add docstring
   ---------
-* fix(autoware_pointcloud_preprocessor): fix functionConst (`#8280 <https://github.com/youtalk/autoware.universe/issues/8280>`_)
+* fix(autoware_pointcloud_preprocessor): fix functionConst (`#8280 <https://github.com/autowarefoundation/autoware.universe/issues/8280>`_)
   fix:functionConst
-* fix(autoware_pointcloud_preprocessor): fix passedByValue (`#8242 <https://github.com/youtalk/autoware.universe/issues/8242>`_)
+* fix(autoware_pointcloud_preprocessor): fix passedByValue (`#8242 <https://github.com/autowarefoundation/autoware.universe/issues/8242>`_)
   fix:passedByValue
-* fix(autoware_pointcloud_preprocessor): fix redundantInitialization (`#8229 <https://github.com/youtalk/autoware.universe/issues/8229>`_)
-* fix(autoware_pointcloud_preprocessor): revert increase_size() in robin_hood (`#8151 <https://github.com/youtalk/autoware.universe/issues/8151>`_)
-* fix(autoware_pointcloud_preprocessor): fix knownConditionTrueFalse warning (`#8139 <https://github.com/youtalk/autoware.universe/issues/8139>`_)
-* refactor(pointcloud_preprocessor): prefix package and namespace with autoware (`#7983 <https://github.com/youtalk/autoware.universe/issues/7983>`_)
+* fix(autoware_pointcloud_preprocessor): fix redundantInitialization (`#8229 <https://github.com/autowarefoundation/autoware.universe/issues/8229>`_)
+* fix(autoware_pointcloud_preprocessor): revert increase_size() in robin_hood (`#8151 <https://github.com/autowarefoundation/autoware.universe/issues/8151>`_)
+* fix(autoware_pointcloud_preprocessor): fix knownConditionTrueFalse warning (`#8139 <https://github.com/autowarefoundation/autoware.universe/issues/8139>`_)
+* refactor(pointcloud_preprocessor): prefix package and namespace with autoware (`#7983 <https://github.com/autowarefoundation/autoware.universe/issues/7983>`_)
   * refactor(pointcloud_preprocessor)!: prefix package and namespace with autoware
   * style(pre-commit): autofix
   * style(pointcloud_preprocessor): suppress line length check for macros

--- a/sensing/autoware_radar_scan_to_pointcloud2/CHANGELOG.rst
+++ b/sensing/autoware_radar_scan_to_pointcloud2/CHANGELOG.rst
@@ -5,7 +5,7 @@ Changelog for package autoware_radar_scan_to_pointcloud2
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* refactor(radar_scan_to_pointcloud2, radar_static_pointcloud_filter, radar_threshold_filter)!: add package name prefix of autoware\_ (`#8132 <https://github.com/youtalk/autoware.universe/issues/8132>`_)
+* refactor(radar_scan_to_pointcloud2, radar_static_pointcloud_filter, radar_threshold_filter)!: add package name prefix of autoware\_ (`#8132 <https://github.com/autowarefoundation/autoware.universe/issues/8132>`_)
   * refactor(radar_scan_to_pointcloud2): rename package and update references
   fix: rename package folder
   * refactor(radar_static_pointcloud_filter): rename package and update references

--- a/sensing/autoware_radar_static_pointcloud_filter/CHANGELOG.rst
+++ b/sensing/autoware_radar_static_pointcloud_filter/CHANGELOG.rst
@@ -5,7 +5,7 @@ Changelog for package autoware_radar_static_pointcloud_filter
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* refactor(radar_scan_to_pointcloud2, radar_static_pointcloud_filter, radar_threshold_filter)!: add package name prefix of autoware\_ (`#8132 <https://github.com/youtalk/autoware.universe/issues/8132>`_)
+* refactor(radar_scan_to_pointcloud2, radar_static_pointcloud_filter, radar_threshold_filter)!: add package name prefix of autoware\_ (`#8132 <https://github.com/autowarefoundation/autoware.universe/issues/8132>`_)
   * refactor(radar_scan_to_pointcloud2): rename package and update references
   fix: rename package folder
   * refactor(radar_static_pointcloud_filter): rename package and update references

--- a/sensing/autoware_radar_threshold_filter/CHANGELOG.rst
+++ b/sensing/autoware_radar_threshold_filter/CHANGELOG.rst
@@ -5,7 +5,7 @@ Changelog for package autoware_radar_threshold_filter
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* refactor(radar_scan_to_pointcloud2, radar_static_pointcloud_filter, radar_threshold_filter)!: add package name prefix of autoware\_ (`#8132 <https://github.com/youtalk/autoware.universe/issues/8132>`_)
+* refactor(radar_scan_to_pointcloud2, radar_static_pointcloud_filter, radar_threshold_filter)!: add package name prefix of autoware\_ (`#8132 <https://github.com/autowarefoundation/autoware.universe/issues/8132>`_)
   * refactor(radar_scan_to_pointcloud2): rename package and update references
   fix: rename package folder
   * refactor(radar_static_pointcloud_filter): rename package and update references

--- a/sensing/autoware_radar_tracks_noise_filter/CHANGELOG.rst
+++ b/sensing/autoware_radar_tracks_noise_filter/CHANGELOG.rst
@@ -5,7 +5,7 @@ Changelog for package autoware_radar_tracks_noise_filter
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* refactor(radar_tracks_msgs_converter, simple_object_merger, radar_tracks_noise_filter)!: add package name prefix of autoware\_ (`#8173 <https://github.com/youtalk/autoware.universe/issues/8173>`_)
+* refactor(radar_tracks_msgs_converter, simple_object_merger, radar_tracks_noise_filter)!: add package name prefix of autoware\_ (`#8173 <https://github.com/autowarefoundation/autoware.universe/issues/8173>`_)
   * refactor: rename radar_tracks_msgs_converter package to autoware_radar_tracks_msgs_converter
   * refactor: rename simple_object_merger package to autoware_simple_object_merger
   * refactor: rename sensing/radar_tracks_noise_filter to sensing/autoware_radar_tracks_noise_filter

--- a/sensing/livox/autoware_livox_tag_filter/CHANGELOG.rst
+++ b/sensing/livox/autoware_livox_tag_filter/CHANGELOG.rst
@@ -5,18 +5,18 @@ Changelog for package autoware_livox_tag_filter
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* fix(autoware_livox_tag_filter): fix unusedStructMember (`#8395 <https://github.com/youtalk/autoware.universe/issues/8395>`_)
+* fix(autoware_livox_tag_filter): fix unusedStructMember (`#8395 <https://github.com/autowarefoundation/autoware.universe/issues/8395>`_)
   * fix:unusedStructMember
   * fix:unusedStructMember
   * fix:clang format
   * fix:unusedStructMember
   ---------
-* feat(pointcloud_preprocessor): runtime configurable output topic qos (`#6658 <https://github.com/youtalk/autoware.universe/issues/6658>`_)
+* feat(pointcloud_preprocessor): runtime configurable output topic qos (`#6658 <https://github.com/autowarefoundation/autoware.universe/issues/6658>`_)
   * feat(pointcloud_preprocessor): runtime configurable output topic qos
   * configurable qos in livox_tag_filter_node
   * configurable qos in radar_scan_to_pointcloud2
   ---------
-* refactor(livox_tag_filter): prefix package and namespace with autoware (`#7788 <https://github.com/youtalk/autoware.universe/issues/7788>`_)
+* refactor(livox_tag_filter): prefix package and namespace with autoware (`#7788 <https://github.com/autowarefoundation/autoware.universe/issues/7788>`_)
 * Contributors: Esteve Fernandez, Yutaka Kondo, kobayu858, ralwing
 
 0.26.0 (2024-04-03)

--- a/sensing/vehicle_velocity_converter/CHANGELOG.rst
+++ b/sensing/vehicle_velocity_converter/CHANGELOG.rst
@@ -5,15 +5,15 @@ Changelog for package vehicle_velocity_converter
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* refactor(vehicle_velocity_converter): apply static analysis (`#7975 <https://github.com/youtalk/autoware.universe/issues/7975>`_)
+* refactor(vehicle_velocity_converter): apply static analysis (`#7975 <https://github.com/autowarefoundation/autoware.universe/issues/7975>`_)
   refactor based on linter
-* feat(vehicle_velocity_converter): componentize VehicleVelocityConverter (`#7116 <https://github.com/youtalk/autoware.universe/issues/7116>`_)
+* feat(vehicle_velocity_converter): componentize VehicleVelocityConverter (`#7116 <https://github.com/autowarefoundation/autoware.universe/issues/7116>`_)
   * remove unusing main func file
   * mod to componentize and use glog
   * change log output from screen to both
   ---------
   Co-authored-by: Yamato Ando <yamato.ando@gmail.com>
-* feat!: replace autoware_auto_msgs with autoware_msgs for sensing modules (`#7247 <https://github.com/youtalk/autoware.universe/issues/7247>`_)
+* feat!: replace autoware_auto_msgs with autoware_msgs for sensing modules (`#7247 <https://github.com/autowarefoundation/autoware.universe/issues/7247>`_)
   Co-authored-by: Cynthia Liu <cynthia.liu@autocore.ai>
   Co-authored-by: NorahXiong <norah.xiong@autocore.ai>
   Co-authored-by: beginningfan <beginning.fan@autocore.ai>
@@ -21,11 +21,11 @@ Changelog for package vehicle_velocity_converter
 
 0.26.0 (2024-04-03)
 -------------------
-* refactor(sensing-vehicle-velocity-converter): rework parameters (`#5609 <https://github.com/youtalk/autoware.universe/issues/5609>`_)
+* refactor(sensing-vehicle-velocity-converter): rework parameters (`#5609 <https://github.com/autowarefoundation/autoware.universe/issues/5609>`_)
   * sensing-vehicle-velocity-converter-module
   * sensing-vehicle-velocity-converter
   ---------
-* build: mark autoware_cmake as <buildtool_depend> (`#3616 <https://github.com/youtalk/autoware.universe/issues/3616>`_)
+* build: mark autoware_cmake as <buildtool_depend> (`#3616 <https://github.com/autowarefoundation/autoware.universe/issues/3616>`_)
   * build: mark autoware_cmake as <buildtool_depend>
   with <build_depend>, autoware_cmake is automatically exported with ament_target_dependencies() (unecessary)
   * style(pre-commit): autofix
@@ -33,16 +33,16 @@ Changelog for package vehicle_velocity_converter
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Kenji Miyake <kenji.miyake@tier4.jp>
-* feat(vehicle_velocity_converter): add `speed_scale_factor` (`#2641 <https://github.com/youtalk/autoware.universe/issues/2641>`_)
+* feat(vehicle_velocity_converter): add `speed_scale_factor` (`#2641 <https://github.com/autowarefoundation/autoware.universe/issues/2641>`_)
   * feat(vehicle_velocity_converter): add speed_scale_factor
   * add parameter description in readme
   * ci(pre-commit): autofix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* fix(vehicle_velocity_converter): simpify parameter inputs (`#1727 <https://github.com/youtalk/autoware.universe/issues/1727>`_)
+* fix(vehicle_velocity_converter): simpify parameter inputs (`#1727 <https://github.com/autowarefoundation/autoware.universe/issues/1727>`_)
   * fix(vehicle_velocity_converter): simpify parameter inputs
   * fix readme and default value
   * fix default value
-* feat(distortion_corrector): use gyroscope for correcting LiDAR distortion (`#1120 <https://github.com/youtalk/autoware.universe/issues/1120>`_)
+* feat(distortion_corrector): use gyroscope for correcting LiDAR distortion (`#1120 <https://github.com/autowarefoundation/autoware.universe/issues/1120>`_)
   * first commit
   * ci(pre-commit): autofix
   * check if angular_velocity_queue\_ is empty or not

--- a/simulator/autoware_carla_interface/CHANGELOG.rst
+++ b/simulator/autoware_carla_interface/CHANGELOG.rst
@@ -5,9 +5,9 @@ Changelog for package autoware_carla_interface
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* fix(autoware_carla_interface): resolve init file error and colcon marker warning (`#9115 <https://github.com/youtalk/autoware.universe/issues/9115>`_)
-* fix: removed access to unused ROS_VERSION environment variable. (`#8896 <https://github.com/youtalk/autoware.universe/issues/8896>`_)
-* ci(pre-commit): autoupdate (`#7630 <https://github.com/youtalk/autoware.universe/issues/7630>`_)
+* fix(autoware_carla_interface): resolve init file error and colcon marker warning (`#9115 <https://github.com/autowarefoundation/autoware.universe/issues/9115>`_)
+* fix: removed access to unused ROS_VERSION environment variable. (`#8896 <https://github.com/autowarefoundation/autoware.universe/issues/8896>`_)
+* ci(pre-commit): autoupdate (`#7630 <https://github.com/autowarefoundation/autoware.universe/issues/7630>`_)
   * ci(pre-commit): autoupdate
   * style(pre-commit): autofix
   * fix: remove the outer call to dict()
@@ -15,7 +15,7 @@ Changelog for package autoware_carla_interface
   Co-authored-by: github-actions <github-actions@github.com>
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: mitsudome-r <ryohsuke.mitsudome@tier4.jp>
-* feat(carla_autoware): add interface to easily use CARLA with Autoware (`#6859 <https://github.com/youtalk/autoware.universe/issues/6859>`_)
+* feat(carla_autoware): add interface to easily use CARLA with Autoware (`#6859 <https://github.com/autowarefoundation/autoware.universe/issues/6859>`_)
   Co-authored-by: Minsu Kim <minsu@korea.ac.kr>
 * Contributors: Esteve Fernandez, Giovanni Muhammad Raditya, Jesus Armando Anaya, Yutaka Kondo, awf-autoware-bot[bot]
 

--- a/simulator/dummy_perception_publisher/CHANGELOG.rst
+++ b/simulator/dummy_perception_publisher/CHANGELOG.rst
@@ -5,26 +5,26 @@ Changelog for package dummy_perception_publisher
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* fix(dummy_perception_publisher, tier4_dummy_object_rviz_plugin): separate dummy object msg (`#8828 <https://github.com/youtalk/autoware.universe/issues/8828>`_)
+* fix(dummy_perception_publisher, tier4_dummy_object_rviz_plugin): separate dummy object msg (`#8828 <https://github.com/autowarefoundation/autoware.universe/issues/8828>`_)
   * fix: dummy object rviz plugin dependency
   * fix: remove message from dummy perception publisher
   * fix: node name
   ---------
-* feat(dummy_perception_publisher): modify orientation availability of dummy objects  (`#8534 <https://github.com/youtalk/autoware.universe/issues/8534>`_)
+* feat(dummy_perception_publisher): modify orientation availability of dummy objects  (`#8534 <https://github.com/autowarefoundation/autoware.universe/issues/8534>`_)
   feat: add orientation availability for tracked objects in perception publisher
-* refactor(shape_estimation): add package name prefix of autoware\_ (`#7999 <https://github.com/youtalk/autoware.universe/issues/7999>`_)
+* refactor(shape_estimation): add package name prefix of autoware\_ (`#7999 <https://github.com/autowarefoundation/autoware.universe/issues/7999>`_)
   * refactor(shape_estimation): add package name prefix of autoware\_
   * style(pre-commit): autofix
   * fix: mising prefix
   * fix: cmake
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* refactor(detected_object_feature_remover)!: add package name prefix of autoware\_ (`#8127 <https://github.com/youtalk/autoware.universe/issues/8127>`_)
+* refactor(detected_object_feature_remover)!: add package name prefix of autoware\_ (`#8127 <https://github.com/autowarefoundation/autoware.universe/issues/8127>`_)
   refactor(detected_object_feature_remover): add package name prefix of autoware\_
-* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/youtalk/autoware.universe/issues/7594>`_)
-* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/youtalk/autoware.universe/issues/7538>`_)
+* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/autowarefoundation/autoware.universe/issues/7594>`_)
+* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/autowarefoundation/autoware.universe/issues/7538>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* feat!: replace autoware_auto_msgs with autoware_msgs for simulator modules (`#7248 <https://github.com/youtalk/autoware.universe/issues/7248>`_)
+* feat!: replace autoware_auto_msgs with autoware_msgs for simulator modules (`#7248 <https://github.com/autowarefoundation/autoware.universe/issues/7248>`_)
   Co-authored-by: Cynthia Liu <cynthia.liu@autocore.ai>
   Co-authored-by: NorahXiong <norah.xiong@autocore.ai>
   Co-authored-by: beginningfan <beginning.fan@autocore.ai>
@@ -32,17 +32,17 @@ Changelog for package dummy_perception_publisher
 
 0.26.0 (2024-04-03)
 -------------------
-* fix(log-messages): reduce excessive log messages (`#5971 <https://github.com/youtalk/autoware.universe/issues/5971>`_)
-* chore(build): remove tier4_autoware_utils.hpp evaluator/ simulator/ (`#4839 <https://github.com/youtalk/autoware.universe/issues/4839>`_)
-* fix: take dummy objects' height into calculation when locating their Z position (`#4195 <https://github.com/youtalk/autoware.universe/issues/4195>`_)
+* fix(log-messages): reduce excessive log messages (`#5971 <https://github.com/autowarefoundation/autoware.universe/issues/5971>`_)
+* chore(build): remove tier4_autoware_utils.hpp evaluator/ simulator/ (`#4839 <https://github.com/autowarefoundation/autoware.universe/issues/4839>`_)
+* fix: take dummy objects' height into calculation when locating their Z position (`#4195 <https://github.com/autowarefoundation/autoware.universe/issues/4195>`_)
   * Update node.cpp
   fix: consider dummy objects' height when locating its Z position
   * style(pre-commit): autofix
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* fix(dummy_perception_publisher): fix runtime error (`#3869 <https://github.com/youtalk/autoware.universe/issues/3869>`_)
+* fix(dummy_perception_publisher): fix runtime error (`#3869 <https://github.com/autowarefoundation/autoware.universe/issues/3869>`_)
   fix(dummy_perception_publisher): fix namespace
-* feat(dummy_perception_publisher): publish ground truth object in option (`#3731 <https://github.com/youtalk/autoware.universe/issues/3731>`_)
+* feat(dummy_perception_publisher): publish ground truth object in option (`#3731 <https://github.com/autowarefoundation/autoware.universe/issues/3731>`_)
   * add ground truth publisher
   * refactor ground truth publisher
   * enable to fix random seed
@@ -50,7 +50,7 @@ Changelog for package dummy_perception_publisher
   * change GT output name to debug info
   * debug info must be under the node ns
   ---------
-* build: mark autoware_cmake as <buildtool_depend> (`#3616 <https://github.com/youtalk/autoware.universe/issues/3616>`_)
+* build: mark autoware_cmake as <buildtool_depend> (`#3616 <https://github.com/autowarefoundation/autoware.universe/issues/3616>`_)
   * build: mark autoware_cmake as <buildtool_depend>
   with <build_depend>, autoware_cmake is automatically exported with ament_target_dependencies() (unecessary)
   * style(pre-commit): autofix
@@ -58,8 +58,8 @@ Changelog for package dummy_perception_publisher
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Kenji Miyake <kenji.miyake@tier4.jp>
-* fix(dummy_perception_publisher): add parameter to configure z pose of dummy object (`#3457 <https://github.com/youtalk/autoware.universe/issues/3457>`_)
-* chore(typo): eliminate typos (`#2216 <https://github.com/youtalk/autoware.universe/issues/2216>`_)
+* fix(dummy_perception_publisher): add parameter to configure z pose of dummy object (`#3457 <https://github.com/autowarefoundation/autoware.universe/issues/3457>`_)
+* chore(typo): eliminate typos (`#2216 <https://github.com/autowarefoundation/autoware.universe/issues/2216>`_)
   * Replace 'asssert' with 'assert'
   * fix(typo): computationall => computational
   * fix(typo): collinearity => collinearity
@@ -231,11 +231,11 @@ Changelog for package dummy_perception_publisher
   commit c7d3b7d2132323af3437af01e9d774b13005bace
   Author: Hirokazu Ishida <38597814+HiroIshida@users.noreply.github.com>
   Date:   Fri Dec 16 13:51:35 2022 +0900
-  test(freespace_planning_algorithms): done't dump rosbag by default (`#2504 <https://github.com/youtalk/autoware.universe/issues/2504>`_)
+  test(freespace_planning_algorithms): done't dump rosbag by default (`#2504 <https://github.com/autowarefoundation/autoware.universe/issues/2504>`_)
   commit 6731e0ced39e3187c2afffe839eaa697a19e5e84
   Author: kminoda <44218668+kminoda@users.noreply.github.com>
   Date:   Fri Dec 16 09:29:35 2022 +0900
-  feat(pose_initializer): partial map loading (`#2500 <https://github.com/youtalk/autoware.universe/issues/2500>`_)
+  feat(pose_initializer): partial map loading (`#2500 <https://github.com/autowarefoundation/autoware.universe/issues/2500>`_)
   * first commit
   * move function
   * now works
@@ -254,7 +254,7 @@ Changelog for package dummy_perception_publisher
   commit efb4ff1cea6e07aa9e894a6042e8685e30b420ba
   Author: Kosuke Takeuchi <kosuke.tnp@gmail.com>
   Date:   Thu Dec 15 17:29:44 2022 +0900
-  feat(trajectory_follower): extend mpc trajectory for terminal yaw (`#2447 <https://github.com/youtalk/autoware.universe/issues/2447>`_)
+  feat(trajectory_follower): extend mpc trajectory for terminal yaw (`#2447 <https://github.com/autowarefoundation/autoware.universe/issues/2447>`_)
   * feat(trajectory_follower): extend mpc trajectory for terminal yaw
   * make mpc min vel param
   * add mpc extended point after smoothing
@@ -271,7 +271,7 @@ Changelog for package dummy_perception_publisher
   commit ad2ae7827bdc3af7da8607fdd53ea74940426421
   Author: Takagi, Isamu <43976882+isamu-takagi@users.noreply.github.com>
   Date:   Thu Dec 15 15:52:34 2022 +0900
-  feat(component_interface_tools): add service log checker  (`#2503 <https://github.com/youtalk/autoware.universe/issues/2503>`_)
+  feat(component_interface_tools): add service log checker  (`#2503 <https://github.com/autowarefoundation/autoware.universe/issues/2503>`_)
   * feat(component_interface_utils): add service log checker
   * feat(component_interface_tools): add service log checker
   * feat(component_interface_tools): add diagnostics
@@ -279,11 +279,11 @@ Changelog for package dummy_perception_publisher
   commit 4a13cc5a32898f5b17791d9381744bf71ff8ed20
   Author: Yutaka Shimizu <43805014+purewater0901@users.noreply.github.com>
   Date:   Thu Dec 15 12:54:11 2022 +0900
-  fix(behavior_path_planner): fix goal lanelet extension (`#2508 <https://github.com/youtalk/autoware.universe/issues/2508>`_)
+  fix(behavior_path_planner): fix goal lanelet extension (`#2508 <https://github.com/autowarefoundation/autoware.universe/issues/2508>`_)
   commit 77b1c36b5ca89b25250dcbb117c9f03a9c36c1c4
   Author: Kyoichi Sugahara <81.s.kyo.19@gmail.com>
   Date:   Thu Dec 15 10:45:45 2022 +0900
-  feat(behavior_path_planner): change side shift module logic (`#2195 <https://github.com/youtalk/autoware.universe/issues/2195>`_)
+  feat(behavior_path_planner): change side shift module logic (`#2195 <https://github.com/autowarefoundation/autoware.universe/issues/2195>`_)
   * change side shift module design
   * cherry picked side shift controller
   * add debug marker to side shift
@@ -301,45 +301,45 @@ Changelog for package dummy_perception_publisher
   commit 9183c4f20eb4592ed0b48c2eac67add070711677
   Author: Takamasa Horibe <horibe.takamasa@gmail.com>
   Date:   Wed Dec 14 19:59:00 2022 +0900
-  refactor(simple_planning_simulator): make function for duplicated code (`#2502 <https://github.com/youtalk/autoware.universe/issues/2502>`_)
+  refactor(simple_planning_simulator): make function for duplicated code (`#2502 <https://github.com/autowarefoundation/autoware.universe/issues/2502>`_)
   commit ed992b10ed326f03354dce3b563b8622f9ae9a6c
   Author: Yutaka Shimizu <43805014+purewater0901@users.noreply.github.com>
   Date:   Wed Dec 14 17:48:24 2022 +0900
-  fix(behavior_path_planner): fix planner data copy (`#2501 <https://github.com/youtalk/autoware.universe/issues/2501>`_)
+  fix(behavior_path_planner): fix planner data copy (`#2501 <https://github.com/autowarefoundation/autoware.universe/issues/2501>`_)
   commit 0c6c46b33b3c828cb95eaa31fcbf85655fc6a55f
   Author: Yutaka Shimizu <43805014+purewater0901@users.noreply.github.com>
   Date:   Wed Dec 14 14:42:16 2022 +0900
-  fix(behavior_path_planner): fix find nearest function from lateral distance (`#2499 <https://github.com/youtalk/autoware.universe/issues/2499>`_)
+  fix(behavior_path_planner): fix find nearest function from lateral distance (`#2499 <https://github.com/autowarefoundation/autoware.universe/issues/2499>`_)
   * feat(behavior_path_planner): fix find nearest function from lateral distance
   * empty commit
   commit a26b69d1df55e9369ea3adcdd011ae2d7c86dfb7
   Author: Yutaka Shimizu <43805014+purewater0901@users.noreply.github.com>
   Date:   Wed Dec 14 11:28:07 2022 +0900
-  feat(behavior_path_planner): fix overlap checker (`#2498 <https://github.com/youtalk/autoware.universe/issues/2498>`_)
+  feat(behavior_path_planner): fix overlap checker (`#2498 <https://github.com/autowarefoundation/autoware.universe/issues/2498>`_)
   * feat(behavior_path_planner): fix overlap checker
   * remove reserve
   commit 3a24859ca6851caaeb25fc4fac2334fcbdb887d1
   Author: Ismet Atabay <56237550+ismetatabay@users.noreply.github.com>
   Date:   Tue Dec 13 16:51:59 2022 +0300
-  feat(mission_planner): check goal footprint (`#2088 <https://github.com/youtalk/autoware.universe/issues/2088>`_)
+  feat(mission_planner): check goal footprint (`#2088 <https://github.com/autowarefoundation/autoware.universe/issues/2088>`_)
   commit b6a18855431b5f3a67fcbf383fac8df2b45d462e
   Author: Takamasa Horibe <horibe.takamasa@gmail.com>
   Date:   Tue Dec 13 22:46:24 2022 +0900
-  feat(trajectory_visualizer): update for steer limit, remove tf for pose source (`#2267 <https://github.com/youtalk/autoware.universe/issues/2267>`_)
+  feat(trajectory_visualizer): update for steer limit, remove tf for pose source (`#2267 <https://github.com/autowarefoundation/autoware.universe/issues/2267>`_)
   commit f1a9a9608559a5b89f631df3dc2fadd037e36ab4
   Author: Yutaka Shimizu <43805014+purewater0901@users.noreply.github.com>
   Date:   Tue Dec 13 19:47:16 2022 +0900
-  feat(behavior_path_planner): remove unnecessary code and clean turn signal decider (`#2494 <https://github.com/youtalk/autoware.universe/issues/2494>`_)
+  feat(behavior_path_planner): remove unnecessary code and clean turn signal decider (`#2494 <https://github.com/autowarefoundation/autoware.universe/issues/2494>`_)
   * feat(behavior_path_planner): clean drivable area code
   * make a function for turn signal decider
   commit fafe1d8235b99302bc9ba8f3770ae34878f1e7e7
   Author: Yutaka Shimizu <43805014+purewater0901@users.noreply.github.com>
   Date:   Tue Dec 13 18:19:41 2022 +0900
-  feat(behavior_path_planner): change turn signal output timing (`#2493 <https://github.com/youtalk/autoware.universe/issues/2493>`_)
+  feat(behavior_path_planner): change turn signal output timing (`#2493 <https://github.com/autowarefoundation/autoware.universe/issues/2493>`_)
   commit c48b9cfa7074ecd46d96f6dc43679e17bde3a63d
   Author: kminoda <44218668+kminoda@users.noreply.github.com>
   Date:   Tue Dec 13 09:16:14 2022 +0900
-  feat(map_loader): add differential map loading interface (`#2417 <https://github.com/youtalk/autoware.universe/issues/2417>`_)
+  feat(map_loader): add differential map loading interface (`#2417 <https://github.com/autowarefoundation/autoware.universe/issues/2417>`_)
   * first commit
   * ci(pre-commit): autofix
   * added module load in _node.cpp
@@ -352,13 +352,13 @@ Changelog for package dummy_perception_publisher
   commit 9a3613bfcd3e36e522d0ea9130f6200ca7689e2b
   Author: Takagi, Isamu <43976882+isamu-takagi@users.noreply.github.com>
   Date:   Tue Dec 13 08:49:23 2022 +0900
-  docs(default_ad_api): add readme (`#2491 <https://github.com/youtalk/autoware.universe/issues/2491>`_)
+  docs(default_ad_api): add readme (`#2491 <https://github.com/autowarefoundation/autoware.universe/issues/2491>`_)
   * docs(default_ad_api): add readme
   * feat: update table
   commit 49aa10b04de61c36706f6151d11bf17257ca54d1
   Author: Takagi, Isamu <43976882+isamu-takagi@users.noreply.github.com>
   Date:   Tue Dec 13 06:46:20 2022 +0900
-  feat(default_ad_api): split parameters into file (`#2488 <https://github.com/youtalk/autoware.universe/issues/2488>`_)
+  feat(default_ad_api): split parameters into file (`#2488 <https://github.com/autowarefoundation/autoware.universe/issues/2488>`_)
   * feat(default_ad_api): split parameters into file
   * feat: remove old parameter
   * fix: test
@@ -366,7 +366,7 @@ Changelog for package dummy_perception_publisher
   commit 7f0138c356c742b6e15e571e7a4683caa55969ac
   Author: Yutaka Shimizu <43805014+purewater0901@users.noreply.github.com>
   Date:   Mon Dec 12 22:16:54 2022 +0900
-  feat(behavior_path_planner, obstacle_avoidance_planner): add new drivable area (`#2472 <https://github.com/youtalk/autoware.universe/issues/2472>`_)
+  feat(behavior_path_planner, obstacle_avoidance_planner): add new drivable area (`#2472 <https://github.com/autowarefoundation/autoware.universe/issues/2472>`_)
   * update
   * update
   * update
@@ -390,11 +390,11 @@ Changelog for package dummy_perception_publisher
   commit c855e23cc17d1518ebce5dd15629d03acfe17da3
   Author: Takagi, Isamu <43976882+isamu-takagi@users.noreply.github.com>
   Date:   Mon Dec 12 17:15:10 2022 +0900
-  refactor(vehicle_cmd_gate): remove old emergency topics (`#2403 <https://github.com/youtalk/autoware.universe/issues/2403>`_)
+  refactor(vehicle_cmd_gate): remove old emergency topics (`#2403 <https://github.com/autowarefoundation/autoware.universe/issues/2403>`_)
   commit fa04d540c9afdded016730c9978920a194d2d2b4
   Author: Daisuke Nishimatsu <42202095+wep21@users.noreply.github.com>
   Date:   Mon Dec 12 16:04:00 2022 +0900
-  feat: replace python launch with xml launch for system monitor (`#2430 <https://github.com/youtalk/autoware.universe/issues/2430>`_)
+  feat: replace python launch with xml launch for system monitor (`#2430 <https://github.com/autowarefoundation/autoware.universe/issues/2430>`_)
   * feat: replace python launch with xml launch for system monitor
   * ci(pre-commit): autofix
   * update figure
@@ -402,7 +402,7 @@ Changelog for package dummy_perception_publisher
   commit 4a6990c49d1f8c3bedfb345e7c94c3c6893b4099
   Author: Kosuke Takeuchi <kosuke.tnp@gmail.com>
   Date:   Mon Dec 12 15:01:39 2022 +0900
-  feat(trajectory_follower): pub steer converged marker (`#2441 <https://github.com/youtalk/autoware.universe/issues/2441>`_)
+  feat(trajectory_follower): pub steer converged marker (`#2441 <https://github.com/autowarefoundation/autoware.universe/issues/2441>`_)
   * feat(trajectory_follower): pub steer converged marker
   * Revert "feat(trajectory_follower): pub steer converged marker"
   This reverts commit a6f6917bc542d5b533150f6abba086121e800974.
@@ -410,15 +410,15 @@ Changelog for package dummy_perception_publisher
   commit 3c01f15125dfbc45e1050ee96ccc42618d6ee6fd
   Author: Takagi, Isamu <43976882+isamu-takagi@users.noreply.github.com>
   Date:   Mon Dec 12 12:48:41 2022 +0900
-  docs(tier4_state_rviz_plugin): update readme (`#2475 <https://github.com/youtalk/autoware.universe/issues/2475>`_)
+  docs(tier4_state_rviz_plugin): update readme (`#2475 <https://github.com/autowarefoundation/autoware.universe/issues/2475>`_)
   commit d8ece0040354be5381a27403bcc757354735a77b
   Author: Takagi, Isamu <43976882+isamu-takagi@users.noreply.github.com>
   Date:   Mon Dec 12 11:57:03 2022 +0900
-  chore(simulator_compatibility_test): suppress setuptools warnings (`#2483 <https://github.com/youtalk/autoware.universe/issues/2483>`_)
+  chore(simulator_compatibility_test): suppress setuptools warnings (`#2483 <https://github.com/autowarefoundation/autoware.universe/issues/2483>`_)
   commit 727586bfe86dc9cb21ce34d9cbe19c241e162b04
   Author: Zulfaqar Azmi <93502286+zulfaqar-azmi-t4@users.noreply.github.com>
   Date:   Mon Dec 12 10:00:35 2022 +0900
-  fix(behavior_path_planner): lane change candidate resolution (`#2426 <https://github.com/youtalk/autoware.universe/issues/2426>`_)
+  fix(behavior_path_planner): lane change candidate resolution (`#2426 <https://github.com/autowarefoundation/autoware.universe/issues/2426>`_)
   * fix(behavior_path_planner): lane change candidate resolution
   * rework sampling based  on current speed
   * refactor code
@@ -428,21 +428,21 @@ Changelog for package dummy_perception_publisher
   commit 284548ca7f38b1d83af11f2b9caaac116eb9b09c
   Author: Zulfaqar Azmi <93502286+zulfaqar-azmi-t4@users.noreply.github.com>
   Date:   Mon Dec 12 09:57:19 2022 +0900
-  fix(behavior_path_planner): minimum distance for lane change (`#2413 <https://github.com/youtalk/autoware.universe/issues/2413>`_)
+  fix(behavior_path_planner): minimum distance for lane change (`#2413 <https://github.com/autowarefoundation/autoware.universe/issues/2413>`_)
   commit 469d8927bd7a0c98b9d491d347e111065973e13f
   Author: Ryohsuke Mitsudome <43976834+mitsudome-r@users.noreply.github.com>
   Date:   Fri Dec 9 21:27:18 2022 +0900
-  revert(behavior_path): revert removal of refineGoalFunction (`#2340 <https://github.com/youtalk/autoware.universe/issues/2340>`_)" (`#2485 <https://github.com/youtalk/autoware.universe/issues/2485>`_)
+  revert(behavior_path): revert removal of refineGoalFunction (`#2340 <https://github.com/autowarefoundation/autoware.universe/issues/2340>`_)" (`#2485 <https://github.com/autowarefoundation/autoware.universe/issues/2485>`_)
   This reverts commit 8e13ced6dfb6edfea77a589ef4cb93d82683bf51.
   commit d924f85b079dfe64feab017166685be40e977e62
   Author: NorahXiong <103234047+NorahXiong@users.noreply.github.com>
   Date:   Fri Dec 9 19:53:51 2022 +0800
-  fix(freespace_planning_algorithms): fix rrtstar can't arrive goal error (`#2350 <https://github.com/youtalk/autoware.universe/issues/2350>`_)
+  fix(freespace_planning_algorithms): fix rrtstar can't arrive goal error (`#2350 <https://github.com/autowarefoundation/autoware.universe/issues/2350>`_)
   Co-authored-by: Ryohsuke Mitsudome <43976834+mitsudome-r@users.noreply.github.com>
   commit b2ded82324bce78d9db3ff01b0227b00709b1efe
   Author: badai nguyen <94814556+badai-nguyen@users.noreply.github.com>
   Date:   Fri Dec 9 17:12:13 2022 +0900
-  fix(ground-segmentation): recheck gnd cluster pointcloud (`#2448 <https://github.com/youtalk/autoware.universe/issues/2448>`_)
+  fix(ground-segmentation): recheck gnd cluster pointcloud (`#2448 <https://github.com/autowarefoundation/autoware.universe/issues/2448>`_)
   * fix: reclassify ground cluster pcl
   * fix: add lowest-based recheck
   * chore: refactoring
@@ -451,19 +451,19 @@ Changelog for package dummy_perception_publisher
   commit 8906a1e78bc5b7d6417683ecedc1efe3f48be31e
   Author: Takamasa Horibe <horibe.takamasa@gmail.com>
   Date:   Fri Dec 9 16:29:45 2022 +0900
-  fix(trajectory_follower): fix mpc trajectory z pos (`#2482 <https://github.com/youtalk/autoware.universe/issues/2482>`_)
+  fix(trajectory_follower): fix mpc trajectory z pos (`#2482 <https://github.com/autowarefoundation/autoware.universe/issues/2482>`_)
   commit d4939058f05f9a1609f0ed22afbd0d4febfb212d
   Author: Yutaka Shimizu <43805014+purewater0901@users.noreply.github.com>
   Date:   Fri Dec 9 12:40:30 2022 +0900
-  feat(behavior_velocity_planner): clean walkway module (`#2480 <https://github.com/youtalk/autoware.universe/issues/2480>`_)
+  feat(behavior_velocity_planner): clean walkway module (`#2480 <https://github.com/autowarefoundation/autoware.universe/issues/2480>`_)
   commit d3b86a37ae7c3a0d59832caf56afa13b148d562c
   Author: Makoto Kurihara <mkuri8m@gmail.com>
   Date:   Thu Dec 8 22:59:32 2022 +0900
-  fix(emergency_handler): fix mrm handling when mrm behavior is none (`#2476 <https://github.com/youtalk/autoware.universe/issues/2476>`_)
+  fix(emergency_handler): fix mrm handling when mrm behavior is none (`#2476 <https://github.com/autowarefoundation/autoware.universe/issues/2476>`_)
   commit 2dde073a101e96757ef0cd189bb9ff06836934e9
   Author: Takagi, Isamu <43976882+isamu-takagi@users.noreply.github.com>
   Date:   Thu Dec 8 17:16:13 2022 +0900
-  feat(behavior_velocity_planner): add velocity factors (`#1985 <https://github.com/youtalk/autoware.universe/issues/1985>`_)
+  feat(behavior_velocity_planner): add velocity factors (`#1985 <https://github.com/autowarefoundation/autoware.universe/issues/1985>`_)
   * (editting) add intersection_coordination to stop reason
   * (editting) add intersection coordination to stop reasons
   * (Editting) add v2x to stop reason
@@ -514,11 +514,11 @@ Changelog for package dummy_perception_publisher
   commit 9a5057e4948ff5ac9165c14eb7112d79f2de76d5
   Author: Kosuke Takeuchi <kosuke.tnp@gmail.com>
   Date:   Thu Dec 8 13:42:50 2022 +0900
-  fix(freespace_planning_algorithms): comment out failing tests (`#2440 <https://github.com/youtalk/autoware.universe/issues/2440>`_)
+  fix(freespace_planning_algorithms): comment out failing tests (`#2440 <https://github.com/autowarefoundation/autoware.universe/issues/2440>`_)
   commit cddb8c74d0fbf49390b4d462c20c12bc257f4825
   Author: kminoda <44218668+kminoda@users.noreply.github.com>
   Date:   Thu Dec 8 11:57:04 2022 +0900
-  feat(gyro_odometer): publish twist when both data arrives (`#2423 <https://github.com/youtalk/autoware.universe/issues/2423>`_)
+  feat(gyro_odometer): publish twist when both data arrives (`#2423 <https://github.com/autowarefoundation/autoware.universe/issues/2423>`_)
   * feat(gyro_odometer): publish when both data arrive
   * remove unnecessary commentouts
   * ci(pre-commit): autofix
@@ -539,61 +539,61 @@ Changelog for package dummy_perception_publisher
   commit f0f513cf44532dfe8d51d27c4caef23fb694af16
   Author: kminoda <44218668+kminoda@users.noreply.github.com>
   Date:   Thu Dec 8 11:08:29 2022 +0900
-  fix: remove unnecessary DEBUG_INFO declarations (`#2457 <https://github.com/youtalk/autoware.universe/issues/2457>`_)
+  fix: remove unnecessary DEBUG_INFO declarations (`#2457 <https://github.com/autowarefoundation/autoware.universe/issues/2457>`_)
   commit 01daebf42937a05a2d83f3dee2c0778389492e50
   Author: Takayuki Murooka <takayuki5168@gmail.com>
   Date:   Thu Dec 8 00:28:35 2022 +0900
-  fix(tier4_autoware_api_launch): add rosbridge_server dependency (`#2470 <https://github.com/youtalk/autoware.universe/issues/2470>`_)
+  fix(tier4_autoware_api_launch): add rosbridge_server dependency (`#2470 <https://github.com/autowarefoundation/autoware.universe/issues/2470>`_)
   commit 26ef8174b1c12b84070b36df2a7cd14bfa9c0363
   Author: Shumpei Wakabayashi <42209144+shmpwk@users.noreply.github.com>
   Date:   Wed Dec 7 19:32:09 2022 +0900
-  fix: rename `use_external_emergency_stop` to  `check_external_emergency_heartbeat` (`#2455 <https://github.com/youtalk/autoware.universe/issues/2455>`_)
+  fix: rename `use_external_emergency_stop` to  `check_external_emergency_heartbeat` (`#2455 <https://github.com/autowarefoundation/autoware.universe/issues/2455>`_)
   * fix: rename use_external_emergency_stop to check_external_emergency_heartbeat
   * ci(pre-commit): autofix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   commit 024b993a0db8c0d28db0f05f64990bed7069cbd8
   Author: Yutaka Shimizu <43805014+purewater0901@users.noreply.github.com>
   Date:   Wed Dec 7 18:00:32 2022 +0900
-  fix(motion_utils): rename sampling function (`#2469 <https://github.com/youtalk/autoware.universe/issues/2469>`_)
+  fix(motion_utils): rename sampling function (`#2469 <https://github.com/autowarefoundation/autoware.universe/issues/2469>`_)
   commit c240ce2b6f4e79c435ed651b347a7d665a947862
   Author: Yukihiro Saito <yukky.saito@gmail.com>
   Date:   Wed Dec 7 16:33:44 2022 +0900
-  feat: remove web controller (`#2405 <https://github.com/youtalk/autoware.universe/issues/2405>`_)
+  feat: remove web controller (`#2405 <https://github.com/autowarefoundation/autoware.universe/issues/2405>`_)
   commit 2992b1cadae7e7ac86fd249998ce3c7ddbe476c9
   Author: Yutaka Shimizu <43805014+purewater0901@users.noreply.github.com>
   Date:   Wed Dec 7 15:39:28 2022 +0900
-  feat(motion_utils): add points resample function (`#2465 <https://github.com/youtalk/autoware.universe/issues/2465>`_)
+  feat(motion_utils): add points resample function (`#2465 <https://github.com/autowarefoundation/autoware.universe/issues/2465>`_)
   commit 4a75d7c0ddbd88f54afaf2bb05eb65138a53ea60
   Author: Mingyu1991 <115005477+Mingyu1991@users.noreply.github.com>
   Date:   Wed Dec 7 14:42:33 2022 +0900
-  docs: update training data for traffic light (`#2464 <https://github.com/youtalk/autoware.universe/issues/2464>`_)
+  docs: update training data for traffic light (`#2464 <https://github.com/autowarefoundation/autoware.universe/issues/2464>`_)
   * update traffic light cnn classifier README.md
   * correct to upper case
   Co-authored-by: Daisuke Nishimatsu <42202095+wep21@users.noreply.github.com>
   commit a4287165be87fa7727f79c01dfb0bea6af54c333
   Author: Ryuta Kambe <veqcc.c@gmail.com>
   Date:   Wed Dec 7 12:21:49 2022 +0900
-  perf(behavior_velocity_planner): remove unnecessary debug data (`#2462 <https://github.com/youtalk/autoware.universe/issues/2462>`_)
+  perf(behavior_velocity_planner): remove unnecessary debug data (`#2462 <https://github.com/autowarefoundation/autoware.universe/issues/2462>`_)
   commit 0a5b2857d3b2c1c9370598013b25aeaebf2d654d
   Author: Yutaka Shimizu <43805014+purewater0901@users.noreply.github.com>
   Date:   Wed Dec 7 12:03:46 2022 +0900
-  feat(behavior_path_planner): cut overlapped path (`#2451 <https://github.com/youtalk/autoware.universe/issues/2451>`_)
+  feat(behavior_path_planner): cut overlapped path (`#2451 <https://github.com/autowarefoundation/autoware.universe/issues/2451>`_)
   * feat(behavior_path_planner): cut overlapped path
   * clean code
   commit 65003dc99f2abe937afcc010514530fa666fbbfd
   Author: Takagi, Isamu <43976882+isamu-takagi@users.noreply.github.com>
   Date:   Wed Dec 7 11:06:41 2022 +0900
-  revert(default_ad_api): fix autoware state to add wait time (`#2407 <https://github.com/youtalk/autoware.universe/issues/2407>`_) (`#2460 <https://github.com/youtalk/autoware.universe/issues/2460>`_)
-  Revert "fix(default_ad_api): fix autoware state to add wait time (`#2407 <https://github.com/youtalk/autoware.universe/issues/2407>`_)"
+  revert(default_ad_api): fix autoware state to add wait time (`#2407 <https://github.com/autowarefoundation/autoware.universe/issues/2407>`_) (`#2460 <https://github.com/autowarefoundation/autoware.universe/issues/2460>`_)
+  Revert "fix(default_ad_api): fix autoware state to add wait time (`#2407 <https://github.com/autowarefoundation/autoware.universe/issues/2407>`_)"
   This reverts commit c4224854a7e57a9526dde998f742741fe383471c.
   commit fab18677ca4de378faff84a41db5147577e7448d
   Author: Makoto Kurihara <mkuri8m@gmail.com>
   Date:   Wed Dec 7 10:32:41 2022 +0900
-  fix(raw_vehicle_cmd_converter): fix column index for map validation (`#2450 <https://github.com/youtalk/autoware.universe/issues/2450>`_)
+  fix(raw_vehicle_cmd_converter): fix column index for map validation (`#2450 <https://github.com/autowarefoundation/autoware.universe/issues/2450>`_)
   commit a1d3c80a4f5e3a388887a5afb32d9bf7961301f1
   Author: Ambroise Vincent <ambroise.vincent@arm.com>
   Date:   Tue Dec 6 10:39:02 2022 +0100
-  fix(tvm_utility): copy test result to CPU (`#2414 <https://github.com/youtalk/autoware.universe/issues/2414>`_)
+  fix(tvm_utility): copy test result to CPU (`#2414 <https://github.com/autowarefoundation/autoware.universe/issues/2414>`_)
   Also remove dependency to autoware_auto_common.
   Issue-Id: SCM-5401
   Change-Id: I83b859742df2f2ff7df1d0bd2d287bfe0aa04c3d
@@ -601,12 +601,12 @@ Changelog for package dummy_perception_publisher
   commit eb9946832c7e42d5380fd71956165409d0b592c3
   Author: Mamoru Sobue <mamoru.sobue@tier4.jp>
   Date:   Tue Dec 6 18:11:41 2022 +0900
-  chore(behaviror_velocity_planner): changed logging level for intersection (`#2459 <https://github.com/youtalk/autoware.universe/issues/2459>`_)
+  chore(behaviror_velocity_planner): changed logging level for intersection (`#2459 <https://github.com/autowarefoundation/autoware.universe/issues/2459>`_)
   changed logging level
   commit c4224854a7e57a9526dde998f742741fe383471c
   Author: Takagi, Isamu <43976882+isamu-takagi@users.noreply.github.com>
   Date:   Tue Dec 6 17:01:37 2022 +0900
-  fix(default_ad_api): fix autoware state to add wait time (`#2407 <https://github.com/youtalk/autoware.universe/issues/2407>`_)
+  fix(default_ad_api): fix autoware state to add wait time (`#2407 <https://github.com/autowarefoundation/autoware.universe/issues/2407>`_)
   * fix(default_ad_api): fix autoware state to add wait time
   * Update system/default_ad_api/src/compatibility/autoware_state.cpp
   Co-authored-by: Kenji Miyake <31987104+kenji-miyake@users.noreply.github.com>
@@ -614,14 +614,14 @@ Changelog for package dummy_perception_publisher
   commit f984fbb708cb02947ec2824ce041c739c35940f7
   Author: Takamasa Horibe <horibe.takamasa@gmail.com>
   Date:   Tue Dec 6 13:55:17 2022 +0900
-  feat(transition_manager): add param to ignore autonomous transition condition (`#2453 <https://github.com/youtalk/autoware.universe/issues/2453>`_)
+  feat(transition_manager): add param to ignore autonomous transition condition (`#2453 <https://github.com/autowarefoundation/autoware.universe/issues/2453>`_)
   * feat(transition_manager): add param to ignore autonomous transition condition
   * same for modeChangeCompleted
   * remove debug print
   commit d3e640df270a0942c4639e11451faf26e099bbe1
   Author: Tomoya Kimura <tomoya.kimura@tier4.jp>
   Date:   Tue Dec 6 13:01:06 2022 +0900
-  feat(operation_mode_transition_manager): transition to auto quickly when vehicle stops (`#2427 <https://github.com/youtalk/autoware.universe/issues/2427>`_)
+  feat(operation_mode_transition_manager): transition to auto quickly when vehicle stops (`#2427 <https://github.com/autowarefoundation/autoware.universe/issues/2427>`_)
   * chore(cspell): interpolable => interpolatable
   * Revert "Merge branch 'destroy-typos-check-all' into destroy-typos"
   This reverts commit 6116ca02d9df59f815d772a271fed7b0b21ebaf7, reversing
@@ -632,35 +632,35 @@ Changelog for package dummy_perception_publisher
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Yukihiro Saito <yukky.saito@gmail.com>
-* feat(dummy_perception_publisher): publish object with acc (`#1853 <https://github.com/youtalk/autoware.universe/issues/1853>`_)
+* feat(dummy_perception_publisher): publish object with acc (`#1853 <https://github.com/autowarefoundation/autoware.universe/issues/1853>`_)
   * feat(dummy_perception_publisher): publish object with acc
   * fix
   * fix
-* fix(dummy_perception_publisher): independent of pointcloud from detection_successful_rate (`#1166 <https://github.com/youtalk/autoware.universe/issues/1166>`_)
+* fix(dummy_perception_publisher): independent of pointcloud from detection_successful_rate (`#1166 <https://github.com/autowarefoundation/autoware.universe/issues/1166>`_)
   * fix(dummy_perception_publisher): independent of pointcloud from detection_success_rate
   * ci(pre-commit): autofix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* perf(dummy_perception_publisher): tune ego-centric pointcloud generation of dummy perception publisher (`#926 <https://github.com/youtalk/autoware.universe/issues/926>`_)
+* perf(dummy_perception_publisher): tune ego-centric pointcloud generation of dummy perception publisher (`#926 <https://github.com/autowarefoundation/autoware.universe/issues/926>`_)
   * Take advantage of visible range
   * Tune
   * Fix: typo
   * Use hypot
-* fix(dummy_perception_publisher): publish multiple layers of pointcloud (`#882 <https://github.com/youtalk/autoware.universe/issues/882>`_)
+* fix(dummy_perception_publisher): publish multiple layers of pointcloud (`#882 <https://github.com/autowarefoundation/autoware.universe/issues/882>`_)
   * fix: single -> multiple layers pointcloud
   * refactor: share common among different pcloud creators
-* feat: isolate gtests in all packages (`#693 <https://github.com/youtalk/autoware.universe/issues/693>`_)
-* chore: upgrade cmake_minimum_required to 3.14 (`#856 <https://github.com/youtalk/autoware.universe/issues/856>`_)
-* refactor: simplify Rolling support (`#854 <https://github.com/youtalk/autoware.universe/issues/854>`_)
-* refactor: use autoware cmake (`#849 <https://github.com/youtalk/autoware.universe/issues/849>`_)
+* feat: isolate gtests in all packages (`#693 <https://github.com/autowarefoundation/autoware.universe/issues/693>`_)
+* chore: upgrade cmake_minimum_required to 3.14 (`#856 <https://github.com/autowarefoundation/autoware.universe/issues/856>`_)
+* refactor: simplify Rolling support (`#854 <https://github.com/autowarefoundation/autoware.universe/issues/854>`_)
+* refactor: use autoware cmake (`#849 <https://github.com/autowarefoundation/autoware.universe/issues/849>`_)
   * remove autoware_auto_cmake
   * add build_depend of autoware_cmake
   * use autoware_cmake in CMakeLists.txt
   * fix bugs
   * fix cmake lint errors
-* chore: remove bad chars (`#845 <https://github.com/youtalk/autoware.universe/issues/845>`_)
-* fix: suppress compiler warnings (`#852 <https://github.com/youtalk/autoware.universe/issues/852>`_)
-* style: fix format of package.xml (`#844 <https://github.com/youtalk/autoware.universe/issues/844>`_)
-* feat(dummy_perception_publisher): publish realistic dummy pointcloud using raymarchig (`#527 <https://github.com/youtalk/autoware.universe/issues/527>`_)
+* chore: remove bad chars (`#845 <https://github.com/autowarefoundation/autoware.universe/issues/845>`_)
+* fix: suppress compiler warnings (`#852 <https://github.com/autowarefoundation/autoware.universe/issues/852>`_)
+* style: fix format of package.xml (`#844 <https://github.com/autowarefoundation/autoware.universe/issues/844>`_)
+* feat(dummy_perception_publisher): publish realistic dummy pointcloud using raymarchig (`#527 <https://github.com/autowarefoundation/autoware.universe/issues/527>`_)
   * Create pointcloud by raycasting from vehicle
   * [after-review] Use vector of ObjectInfo
   * [after-review] Implemented by strategy pattern
@@ -688,28 +688,28 @@ Changelog for package dummy_perception_publisher
   * Fix typo
   * Fix: create merged pointcloud when no idx is selected
   * Use ray-maching by default
-* fix(dummy_perception_publisher): modify build error in rolling (`#761 <https://github.com/youtalk/autoware.universe/issues/761>`_)
-* ci(pre-commit): update pre-commit-hooks-ros (`#625 <https://github.com/youtalk/autoware.universe/issues/625>`_)
+* fix(dummy_perception_publisher): modify build error in rolling (`#761 <https://github.com/autowarefoundation/autoware.universe/issues/761>`_)
+* ci(pre-commit): update pre-commit-hooks-ros (`#625 <https://github.com/autowarefoundation/autoware.universe/issues/625>`_)
   * ci(pre-commit): update pre-commit-hooks-ros
   * ci(pre-commit): autofix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat: move empty_objects_publisher (`#613 <https://github.com/youtalk/autoware.universe/issues/613>`_)
+* feat: move empty_objects_publisher (`#613 <https://github.com/autowarefoundation/autoware.universe/issues/613>`_)
   * feat: move empty_objects_publisher
   * fix group of empty_object_publisher
-* fix(dummy_perception_publisher): modified objects also use baselink z-position (`#588 <https://github.com/youtalk/autoware.universe/issues/588>`_)
-* revert(dummy_perception): change leaf size and disable ray trace (`#468 <https://github.com/youtalk/autoware.universe/issues/468>`_)
-  * Revert "chore(dummy_perception_publisher): change raytrace param (`#414 <https://github.com/youtalk/autoware.universe/issues/414>`_)"
+* fix(dummy_perception_publisher): modified objects also use baselink z-position (`#588 <https://github.com/autowarefoundation/autoware.universe/issues/588>`_)
+* revert(dummy_perception): change leaf size and disable ray trace (`#468 <https://github.com/autowarefoundation/autoware.universe/issues/468>`_)
+  * Revert "chore(dummy_perception_publisher): change raytrace param (`#414 <https://github.com/autowarefoundation/autoware.universe/issues/414>`_)"
   This reverts commit d29e0e1d6630ef53edea1dd66bebf1a657aa6e8b.
   * chore(dummy_perception): revert change leaf size and disable raytrace
-* feat(tier4_simulator_launch, dummy_perception_publisher): launch perception modules from simulator.launch.xml (`#465 <https://github.com/youtalk/autoware.universe/issues/465>`_)
+* feat(tier4_simulator_launch, dummy_perception_publisher): launch perception modules from simulator.launch.xml (`#465 <https://github.com/autowarefoundation/autoware.universe/issues/465>`_)
   * feat(tier4_simulator_launch, dummy_perception_publisher): launch perception modules from simualtor.launch.xml
   * remove perception launching dummy_perception_publisher.launch.xml
   * remove unnecessary comment
-* fix(dummy_perception): fix to use launch at perception launch (`#454 <https://github.com/youtalk/autoware.universe/issues/454>`_)
+* fix(dummy_perception): fix to use launch at perception launch (`#454 <https://github.com/autowarefoundation/autoware.universe/issues/454>`_)
   * fix(dummy_perception): fix to use launch file in perception launch
   * fix(tier4_perception_launch): fix angle increment for occupancy grid
-* chore(dummy_perception_publisher): change raytrace param (`#414 <https://github.com/youtalk/autoware.universe/issues/414>`_)
-* chore: replace legacy timer (`#329 <https://github.com/youtalk/autoware.universe/issues/329>`_)
+* chore(dummy_perception_publisher): change raytrace param (`#414 <https://github.com/autowarefoundation/autoware.universe/issues/414>`_)
+* chore: replace legacy timer (`#329 <https://github.com/autowarefoundation/autoware.universe/issues/329>`_)
   * chore(goal_distance_calculator): replace legacy timer
   * chore(path_distance_calculator): replace legacy timer
   * chore(control_performance_analysis): replace legacy timer
@@ -744,8 +744,8 @@ Changelog for package dummy_perception_publisher
   * chore(external_cmd_converter): replace legacy timer
   * chore(pacmod_interface): replace legacy timer
   * chore(lint): apply pre-commit
-* fix(dummy_perception): fix ns and topic (`#242 <https://github.com/youtalk/autoware.universe/issues/242>`_)
-* feat: change launch package name (`#186 <https://github.com/youtalk/autoware.universe/issues/186>`_)
+* fix(dummy_perception): fix ns and topic (`#242 <https://github.com/autowarefoundation/autoware.universe/issues/242>`_)
+* feat: change launch package name (`#186 <https://github.com/autowarefoundation/autoware.universe/issues/186>`_)
   * rename launch folder
   * autoware_launch -> tier4_autoware_launch
   * integration_launch -> tier4_integration_launch
@@ -763,7 +763,7 @@ Changelog for package dummy_perception_publisher
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: tanaka3 <ttatcoder@outlook.jp>
   Co-authored-by: taikitanaka3 <65527974+taikitanaka3@users.noreply.github.com>
-* feat: change pachage name: autoware_msgs -> tier4_msgs (`#150 <https://github.com/youtalk/autoware.universe/issues/150>`_)
+* feat: change pachage name: autoware_msgs -> tier4_msgs (`#150 <https://github.com/autowarefoundation/autoware.universe/issues/150>`_)
   * change pkg name: autoware\_*_msgs -> tier\_*_msgs
   * ci(pre-commit): autofix
   * autoware_external_api_msgs -> tier4_external_api_msgs
@@ -771,56 +771,56 @@ Changelog for package dummy_perception_publisher
   * fix description
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Takeshi Miura <57553950+1222-takeshi@users.noreply.github.com>
-* feat: add dummy perception publisher (`#90 <https://github.com/youtalk/autoware.universe/issues/90>`_)
+* feat: add dummy perception publisher (`#90 <https://github.com/autowarefoundation/autoware.universe/issues/90>`_)
   * release v0.4.0
-  * add use_object_recognition flag in dummy_perception_publisher (`#696 <https://github.com/youtalk/autoware.universe/issues/696>`_)
+  * add use_object_recognition flag in dummy_perception_publisher (`#696 <https://github.com/autowarefoundation/autoware.universe/issues/696>`_)
   * remove ROS1 packages temporarily
   * add sample ros2 packages
   * remove ROS1 packages
   * Revert "remove ROS1 packages temporarily"
   This reverts commit 2e9822586a3539a32653e6bcd378715674b519ca.
   * add COLCON_IGNORE to ros1 packages
-  * Rename launch files to launch.xml (`#28 <https://github.com/youtalk/autoware.universe/issues/28>`_)
-  * Port dummy_perception_publisher to ROS2 (`#90 <https://github.com/youtalk/autoware.universe/issues/90>`_)
+  * Rename launch files to launch.xml (`#28 <https://github.com/autowarefoundation/autoware.universe/issues/28>`_)
+  * Port dummy_perception_publisher to ROS2 (`#90 <https://github.com/autowarefoundation/autoware.universe/issues/90>`_)
   * Port dummy_perception_publisher to ROS2
   * Uncrustify
   * Lint
   * Copyright
   * Period
   * Further ament_cpplint fixes
-  * Convert calls of Duration to Duration::from_seconds where appropriate (`#131 <https://github.com/youtalk/autoware.universe/issues/131>`_)
-  * Use quotes for includes where appropriate (`#144 <https://github.com/youtalk/autoware.universe/issues/144>`_)
+  * Convert calls of Duration to Duration::from_seconds where appropriate (`#131 <https://github.com/autowarefoundation/autoware.universe/issues/131>`_)
+  * Use quotes for includes where appropriate (`#144 <https://github.com/autowarefoundation/autoware.universe/issues/144>`_)
   * Use quotes for includes where appropriate
   * Fix lint tests
   * Make tests pass hopefully
-  * adding linters to dummy_perception_publisher (`#220 <https://github.com/youtalk/autoware.universe/issues/220>`_)
-  * [dummy_perception_publisher] fix launch file and installation (`#215 <https://github.com/youtalk/autoware.universe/issues/215>`_)
+  * adding linters to dummy_perception_publisher (`#220 <https://github.com/autowarefoundation/autoware.universe/issues/220>`_)
+  * [dummy_perception_publisher] fix launch file and installation (`#215 <https://github.com/autowarefoundation/autoware.universe/issues/215>`_)
   * [dummy_perception_publisher] fix launch file and installation
   * Apply suggestions from code review
   Co-authored-by: Takamasa Horibe <horibe.takamasa@gmail.com>
   Co-authored-by: Takamasa Horibe <horibe.takamasa@gmail.com>
-  * reduce terminal ouput for better error message visibility (`#200 <https://github.com/youtalk/autoware.universe/issues/200>`_)
+  * reduce terminal ouput for better error message visibility (`#200 <https://github.com/autowarefoundation/autoware.universe/issues/200>`_)
   * reduce terminal ouput for better error message visibility
   * [costmap_generator] fix waiting for first transform
   * fix tests
   * fix test
-  * modify launch file for making psim work (`#238 <https://github.com/youtalk/autoware.universe/issues/238>`_)
+  * modify launch file for making psim work (`#238 <https://github.com/autowarefoundation/autoware.universe/issues/238>`_)
   * modify launch file for making psim work
   * remove unnecesary ns
-  * Ros2 v0.8.0 dummy perception publisher (`#286 <https://github.com/youtalk/autoware.universe/issues/286>`_)
-  * Remove "/" in frame_id (`#406 <https://github.com/youtalk/autoware.universe/issues/406>`_)
-  * Fix transform (`#420 <https://github.com/youtalk/autoware.universe/issues/420>`_)
+  * Ros2 v0.8.0 dummy perception publisher (`#286 <https://github.com/autowarefoundation/autoware.universe/issues/286>`_)
+  * Remove "/" in frame_id (`#406 <https://github.com/autowarefoundation/autoware.universe/issues/406>`_)
+  * Fix transform (`#420 <https://github.com/autowarefoundation/autoware.universe/issues/420>`_)
   * Replace rclcpp::Time(0) by tf2::TimePointZero() in lookupTransform
   * Fix canTransform
   * Fix test
-  * add use_sim-time option (`#454 <https://github.com/youtalk/autoware.universe/issues/454>`_)
-  * Remove use_sim_time for set_parameter (`#1260 <https://github.com/youtalk/autoware.universe/issues/1260>`_)
-  * Diable dummy_perception_publisher if argument 'scenario_simulation' i… (`#1275 <https://github.com/youtalk/autoware.universe/issues/1275>`_)
+  * add use_sim-time option (`#454 <https://github.com/autowarefoundation/autoware.universe/issues/454>`_)
+  * Remove use_sim_time for set_parameter (`#1260 <https://github.com/autowarefoundation/autoware.universe/issues/1260>`_)
+  * Diable dummy_perception_publisher if argument 'scenario_simulation' i… (`#1275 <https://github.com/autowarefoundation/autoware.universe/issues/1275>`_)
   * Diable dummy_perception_publisher if argument 'scenario_simulation' is true
   * Rename argument to 'disable_dummy_perception_publisher_node' from 'scenario_simulation'
-  * change theta step for obj point cloud (`#1280 <https://github.com/youtalk/autoware.universe/issues/1280>`_)
-  * Revert changes of PR `#1275 <https://github.com/youtalk/autoware.universe/issues/1275>`_ (`#1377 <https://github.com/youtalk/autoware.universe/issues/1377>`_)
-  * Add pre-commit (`#1560 <https://github.com/youtalk/autoware.universe/issues/1560>`_)
+  * change theta step for obj point cloud (`#1280 <https://github.com/autowarefoundation/autoware.universe/issues/1280>`_)
+  * Revert changes of PR `#1275 <https://github.com/autowarefoundation/autoware.universe/issues/1275>`_ (`#1377 <https://github.com/autowarefoundation/autoware.universe/issues/1377>`_)
+  * Add pre-commit (`#1560 <https://github.com/autowarefoundation/autoware.universe/issues/1560>`_)
   * add pre-commit
   * add pre-commit-config
   * add additional settings for private repository
@@ -840,19 +840,19 @@ Changelog for package dummy_perception_publisher
   Co-authored-by: Kazuki Miyahara <kmiya@outlook.com>
   Co-authored-by: pre-commit <pre-commit@example.com>
   Co-authored-by: Kenji Miyake <31987104+kenji-miyake@users.noreply.github.com>
-  * Fix dependency type of rosidl_default_generators (`#1801 <https://github.com/youtalk/autoware.universe/issues/1801>`_)
+  * Fix dependency type of rosidl_default_generators (`#1801 <https://github.com/autowarefoundation/autoware.universe/issues/1801>`_)
   * Fix dependency type of rosidl_default_generators
   * Remove unnecessary depends
   * Use ament_cmake_auto
-  * Fix -Wunused-parameter (`#1836 <https://github.com/youtalk/autoware.universe/issues/1836>`_)
+  * Fix -Wunused-parameter (`#1836 <https://github.com/autowarefoundation/autoware.universe/issues/1836>`_)
   * Fix -Wunused-parameter
   * Fix mistake
   * fix spell
   * Fix lint issues
   * Ignore flake8 warnings
   Co-authored-by: Hiroki OTA <hiroki.ota@tier4.jp>
-  * fix topic namespace (`#2054 <https://github.com/youtalk/autoware.universe/issues/2054>`_)
-  * add sort-package-xml hook in pre-commit (`#1881 <https://github.com/youtalk/autoware.universe/issues/1881>`_)
+  * fix topic namespace (`#2054 <https://github.com/autowarefoundation/autoware.universe/issues/2054>`_)
+  * add sort-package-xml hook in pre-commit (`#1881 <https://github.com/autowarefoundation/autoware.universe/issues/1881>`_)
   * add sort xml hook in pre-commit
   * change retval to exit_status
   * rename
@@ -866,8 +866,8 @@ Changelog for package dummy_perception_publisher
   * move prettier-xml to pre-commit-hooks-ros
   * update version for bug-fix
   * apply pre-commit
-  * Feature/porting occlusion spot (`#1740 <https://github.com/youtalk/autoware.universe/issues/1740>`_)
-  * Feature/occlusion_spot safety planner public road (`#1594 <https://github.com/youtalk/autoware.universe/issues/1594>`_)
+  * Feature/porting occlusion spot (`#1740 <https://github.com/autowarefoundation/autoware.universe/issues/1740>`_)
+  * Feature/occlusion_spot safety planner public road (`#1594 <https://github.com/autowarefoundation/autoware.universe/issues/1594>`_)
   * add blind spot safety planner public road
   * remove duplicated procesing
   * remove unused private param
@@ -907,7 +907,7 @@ Changelog for package dummy_perception_publisher
   * set more realistic param
   * add lanelet subtype highway
   * cosmetic change of reviews
-  * add occlusion spot module in private area (`#1640 <https://github.com/youtalk/autoware.universe/issues/1640>`_)
+  * add occlusion spot module in private area (`#1640 <https://github.com/autowarefoundation/autoware.universe/issues/1640>`_)
   * add occlusion spot in private
   * For debugging change
   * add spline interpolation to path
@@ -960,7 +960,7 @@ Changelog for package dummy_perception_publisher
   * fix spell check
   * fix default value
   Co-authored-by: tkimura4 <tomoya.kimura@tier4.jp>
-  * Feature/occlusion spot private slice size param (`#1703 <https://github.com/youtalk/autoware.universe/issues/1703>`_)
+  * Feature/occlusion spot private slice size param (`#1703 <https://github.com/autowarefoundation/autoware.universe/issues/1703>`_)
   * add min slice size
   * for a bit narrow lateral distance
   * Update planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/config/occlusion_spot_param.yaml
@@ -979,7 +979,7 @@ Changelog for package dummy_perception_publisher
   Co-authored-by: taikitanaka3 <65527974+taikitanaka3@users.noreply.github.com>
   Co-authored-by: tkimura4 <tomoya.kimura@tier4.jp>
   Co-authored-by: Maxime CLEMENT <78338830+maxime-clem@users.noreply.github.com>
-  * Change formatter to clang-format and black (`#2332 <https://github.com/youtalk/autoware.universe/issues/2332>`_)
+  * Change formatter to clang-format and black (`#2332 <https://github.com/autowarefoundation/autoware.universe/issues/2332>`_)
   * Revert "Temporarily comment out pre-commit hooks"
   This reverts commit 748e9cdb145ce12f8b520bcbd97f5ff899fc28a3.
   * Replace ament_lint_common with autoware_lint_common
@@ -991,13 +991,13 @@ Changelog for package dummy_perception_publisher
   * Fix include double quotes to angle brackets
   * Apply clang-format
   * Fix build errors
-  * Add COLCON_IGNORE (`#500 <https://github.com/youtalk/autoware.universe/issues/500>`_)
-  * port dummy perception publisher to auto (`#562 <https://github.com/youtalk/autoware.universe/issues/562>`_)
+  * Add COLCON_IGNORE (`#500 <https://github.com/autowarefoundation/autoware.universe/issues/500>`_)
+  * port dummy perception publisher to auto (`#562 <https://github.com/autowarefoundation/autoware.universe/issues/562>`_)
   * port dummy perception publisher to auto
   * autoware_perception_msgs/DynamicObjectWithFeatureArray convert to autoware_perception_msgs/DetectedObjectsWithFeature
   * change tracked objects to PREDICTED objects
   * separate pub type with real
-  * Add README.md to dummy perception publisher (`#641 <https://github.com/youtalk/autoware.universe/issues/641>`_)
+  * Add README.md to dummy perception publisher (`#641 <https://github.com/autowarefoundation/autoware.universe/issues/641>`_)
   * Added readme for dummy_perception_pub
   * README update
   * README update
@@ -1010,7 +1010,7 @@ Changelog for package dummy_perception_publisher
   * Modified README.md
   * change parameter name
   * Update README.md
-  * [shape_estimation]change type (`#663 <https://github.com/youtalk/autoware.universe/issues/663>`_)
+  * [shape_estimation]change type (`#663 <https://github.com/autowarefoundation/autoware.universe/issues/663>`_)
   * change output type of shape_estimation
   * remove unused function
   * add dynamic_object_converter
@@ -1026,9 +1026,9 @@ Changelog for package dummy_perception_publisher
   * fix readme
   * fix convert function
   * change topic name of DynamicObjectsWithFeature
-  * Fix no ground pointcloud topic name (`#733 <https://github.com/youtalk/autoware.universe/issues/733>`_)
+  * Fix no ground pointcloud topic name (`#733 <https://github.com/autowarefoundation/autoware.universe/issues/733>`_)
   Co-authored-by: j4tfwm6z <proj-jpntaxi@tier4.jp>
-  * auto/fix occupancy grid name space in dummy perception publisher (`#739 <https://github.com/youtalk/autoware.universe/issues/739>`_)
+  * auto/fix occupancy grid name space in dummy perception publisher (`#739 <https://github.com/autowarefoundation/autoware.universe/issues/739>`_)
   * fix name space
   * change namespace: object_segmentation -> obstacle_segmentation
   * feat: add use_traffic_light status

--- a/simulator/fault_injection/CHANGELOG.rst
+++ b/simulator/fault_injection/CHANGELOG.rst
@@ -5,11 +5,11 @@ Changelog for package fault_injection
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/youtalk/autoware.universe/issues/7538>`_)
+* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/autowarefoundation/autoware.universe/issues/7538>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* feat(system diags): rename diag of ndt scan matcher (`#6889 <https://github.com/youtalk/autoware.universe/issues/6889>`_)
+* feat(system diags): rename diag of ndt scan matcher (`#6889 <https://github.com/autowarefoundation/autoware.universe/issues/6889>`_)
   rename ndt diag
-* feat(fault injection): change for diagnostic graph aggregator (`#6750 <https://github.com/youtalk/autoware.universe/issues/6750>`_)
+* feat(fault injection): change for diagnostic graph aggregator (`#6750 <https://github.com/autowarefoundation/autoware.universe/issues/6750>`_)
   * feat: change to adapt diagnostic graph aggregator
   * Change the configuration to adapt to both system_error_monitor and diagnostic_graph_aggregator
   * style(pre-commit): autofix
@@ -29,10 +29,10 @@ Changelog for package fault_injection
 
 0.26.0 (2024-04-03)
 -------------------
-* refactor(localization_error_monitor): rename localization_accuracy (`#5178 <https://github.com/youtalk/autoware.universe/issues/5178>`_)
+* refactor(localization_error_monitor): rename localization_accuracy (`#5178 <https://github.com/autowarefoundation/autoware.universe/issues/5178>`_)
   refactor: Rename localization_accuracy
   to localization_error_ellipse
-* fix(fault_injection_node): fix history_depth in subscriber qos (`#4042 <https://github.com/youtalk/autoware.universe/issues/4042>`_)
+* fix(fault_injection_node): fix history_depth in subscriber qos (`#4042 <https://github.com/autowarefoundation/autoware.universe/issues/4042>`_)
   * fix(fault_injection_node): fix history_depth in sub qos
   * fix(fault_injection_node): add test cases
   * fix(fault_injection): fix test
@@ -40,7 +40,7 @@ Changelog for package fault_injection
   * ref(test_fault_injection): remove unused import
   ---------
   Co-authored-by: Keisuke Shima <19993104+KeisukeShima@users.noreply.github.com>
-* build: mark autoware_cmake as <buildtool_depend> (`#3616 <https://github.com/youtalk/autoware.universe/issues/3616>`_)
+* build: mark autoware_cmake as <buildtool_depend> (`#3616 <https://github.com/autowarefoundation/autoware.universe/issues/3616>`_)
   * build: mark autoware_cmake as <buildtool_depend>
   with <build_depend>, autoware_cmake is automatically exported with ament_target_dependencies() (unecessary)
   * style(pre-commit): autofix
@@ -48,45 +48,45 @@ Changelog for package fault_injection
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Kenji Miyake <kenji.miyake@tier4.jp>
-* fix(fault injection): add find package to cmake (`#2973 <https://github.com/youtalk/autoware.universe/issues/2973>`_)
+* fix(fault injection): add find package to cmake (`#2973 <https://github.com/autowarefoundation/autoware.universe/issues/2973>`_)
   * fix(fault injection) add find package to cmake
   * feat: add pluginlib to dependency
   ---------
-* ci(pre-commit): format SVG files (`#2172 <https://github.com/youtalk/autoware.universe/issues/2172>`_)
+* ci(pre-commit): format SVG files (`#2172 <https://github.com/autowarefoundation/autoware.universe/issues/2172>`_)
   * ci(pre-commit): format SVG files
   * ci(pre-commit): autofix
   * apply pre-commit
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* fix(fault_injection): fix diag name (`#958 <https://github.com/youtalk/autoware.universe/issues/958>`_)
-* feat: isolate gtests in all packages (`#693 <https://github.com/youtalk/autoware.universe/issues/693>`_)
-* chore: upgrade cmake_minimum_required to 3.14 (`#856 <https://github.com/youtalk/autoware.universe/issues/856>`_)
-* refactor: simplify Rolling support (`#854 <https://github.com/youtalk/autoware.universe/issues/854>`_)
-* refactor: use autoware cmake (`#849 <https://github.com/youtalk/autoware.universe/issues/849>`_)
+* fix(fault_injection): fix diag name (`#958 <https://github.com/autowarefoundation/autoware.universe/issues/958>`_)
+* feat: isolate gtests in all packages (`#693 <https://github.com/autowarefoundation/autoware.universe/issues/693>`_)
+* chore: upgrade cmake_minimum_required to 3.14 (`#856 <https://github.com/autowarefoundation/autoware.universe/issues/856>`_)
+* refactor: simplify Rolling support (`#854 <https://github.com/autowarefoundation/autoware.universe/issues/854>`_)
+* refactor: use autoware cmake (`#849 <https://github.com/autowarefoundation/autoware.universe/issues/849>`_)
   * remove autoware_auto_cmake
   * add build_depend of autoware_cmake
   * use autoware_cmake in CMakeLists.txt
   * fix bugs
   * fix cmake lint errors
-* fix: apply fixes for rolling (`#821 <https://github.com/youtalk/autoware.universe/issues/821>`_)
+* fix: apply fixes for rolling (`#821 <https://github.com/autowarefoundation/autoware.universe/issues/821>`_)
   * fix(component_interface_utils): add USE_DEPRECATED_TO_YAML
   * fix(lidar_apollo_instance_segmentation): add USE_TF2_GEOMETRY_MSGS_DEPRECATED_HEADER
   * add rclcpp_components to package.xml
   * ci(pre-commit): autofix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* fix(fault_injection): fix empty hardware_id (`#814 <https://github.com/youtalk/autoware.universe/issues/814>`_)
-* fix(fault_injection): modify build error in rolling (`#762 <https://github.com/youtalk/autoware.universe/issues/762>`_)
+* fix(fault_injection): fix empty hardware_id (`#814 <https://github.com/autowarefoundation/autoware.universe/issues/814>`_)
+* fix(fault_injection): modify build error in rolling (`#762 <https://github.com/autowarefoundation/autoware.universe/issues/762>`_)
   * fix(fault_injection): modify build error in rolling
   * ci(pre-commit): autofix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* ci(pre-commit): update pre-commit-hooks-ros (`#625 <https://github.com/youtalk/autoware.universe/issues/625>`_)
+* ci(pre-commit): update pre-commit-hooks-ros (`#625 <https://github.com/autowarefoundation/autoware.universe/issues/625>`_)
   * ci(pre-commit): update pre-commit-hooks-ros
   * ci(pre-commit): autofix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* fix(fault_injection): fix launch_testing (`#489 <https://github.com/youtalk/autoware.universe/issues/489>`_)
+* fix(fault_injection): fix launch_testing (`#489 <https://github.com/autowarefoundation/autoware.universe/issues/489>`_)
   * fix(fault_injection): fix launch_testing
   * add label
   * add todo comment
-* ci: check include guard (`#438 <https://github.com/youtalk/autoware.universe/issues/438>`_)
+* ci: check include guard (`#438 <https://github.com/autowarefoundation/autoware.universe/issues/438>`_)
   * ci: check include guard
   * apply pre-commit
   * Update .pre-commit-config.yaml
@@ -94,7 +94,7 @@ Changelog for package fault_injection
   * fix: pre-commit
   Co-authored-by: Kenji Miyake <kenji.miyake@tier4.jp>
   Co-authored-by: Kenji Miyake <31987104+kenji-miyake@users.noreply.github.com>
-* feat: rename existing packages name starting with autoware to different names (`#180 <https://github.com/youtalk/autoware.universe/issues/180>`_)
+* feat: rename existing packages name starting with autoware to different names (`#180 <https://github.com/autowarefoundation/autoware.universe/issues/180>`_)
   * autoware_api_utils -> tier4_api_utils
   * autoware_debug_tools -> tier4_debug_tools
   * autoware_error_monitor -> system_error_monitor
@@ -111,7 +111,7 @@ Changelog for package fault_injection
   * fix ad_service_state_monitor
   * ci(pre-commit): autofix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat: change pachage name: autoware_msgs -> tier4_msgs (`#150 <https://github.com/youtalk/autoware.universe/issues/150>`_)
+* feat: change pachage name: autoware_msgs -> tier4_msgs (`#150 <https://github.com/autowarefoundation/autoware.universe/issues/150>`_)
   * change pkg name: autoware\_*_msgs -> tier\_*_msgs
   * ci(pre-commit): autofix
   * autoware_external_api_msgs -> tier4_external_api_msgs
@@ -119,8 +119,8 @@ Changelog for package fault_injection
   * fix description
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Takeshi Miura <57553950+1222-takeshi@users.noreply.github.com>
-* feat: add fault_injection packages  (`#101 <https://github.com/youtalk/autoware.universe/issues/101>`_)
-  * Add fault injection package (`#1760 <https://github.com/youtalk/autoware.universe/issues/1760>`_)
+* feat: add fault_injection packages  (`#101 <https://github.com/autowarefoundation/autoware.universe/issues/101>`_)
+  * Add fault injection package (`#1760 <https://github.com/autowarefoundation/autoware.universe/issues/1760>`_)
   * add fault injection package
   * fix copyright url
   * fix for lint
@@ -214,17 +214,17 @@ Changelog for package fault_injection
   * remove read_parameter
   * expand timeout
   * comment out launch_test
-  * Fix a broken link of the component diagram on Fault Injection document (`#2202 <https://github.com/youtalk/autoware.universe/issues/2202>`_)
-  * [Fault injection] Update component diagram (`#2203 <https://github.com/youtalk/autoware.universe/issues/2203>`_)
+  * Fix a broken link of the component diagram on Fault Injection document (`#2202 <https://github.com/autowarefoundation/autoware.universe/issues/2202>`_)
+  * [Fault injection] Update component diagram (`#2203 <https://github.com/autowarefoundation/autoware.universe/issues/2203>`_)
   * Update component diagram
   * Rename pSim to scenario_simulator_v2
   * fix upload error
   * Transparent background
-  * Fix line widths of the component diagram on Fault Injection document (`#2205 <https://github.com/youtalk/autoware.universe/issues/2205>`_)
-  * Feature/add fault injection settings (`#2199 <https://github.com/youtalk/autoware.universe/issues/2199>`_)
+  * Fix line widths of the component diagram on Fault Injection document (`#2205 <https://github.com/autowarefoundation/autoware.universe/issues/2205>`_)
+  * Feature/add fault injection settings (`#2199 <https://github.com/autowarefoundation/autoware.universe/issues/2199>`_)
   * add parameter file
   * add message
-  * Change formatter to clang-format and black (`#2332 <https://github.com/youtalk/autoware.universe/issues/2332>`_)
+  * Change formatter to clang-format and black (`#2332 <https://github.com/autowarefoundation/autoware.universe/issues/2332>`_)
   * Revert "Temporarily comment out pre-commit hooks"
   This reverts commit 748e9cdb145ce12f8b520bcbd97f5ff899fc28a3.
   * Replace ament_lint_common with autoware_lint_common
@@ -236,9 +236,9 @@ Changelog for package fault_injection
   * Fix include double quotes to angle brackets
   * Apply clang-format
   * Fix build errors
-  * Add COLCON_IGNORE (`#500 <https://github.com/youtalk/autoware.universe/issues/500>`_)
-  * remove colcon_ignore in fault injection (`#585 <https://github.com/youtalk/autoware.universe/issues/585>`_)
-  * update readme in fault injection (`#644 <https://github.com/youtalk/autoware.universe/issues/644>`_)
+  * Add COLCON_IGNORE (`#500 <https://github.com/autowarefoundation/autoware.universe/issues/500>`_)
+  * remove colcon_ignore in fault injection (`#585 <https://github.com/autowarefoundation/autoware.universe/issues/585>`_)
+  * update readme in fault injection (`#644 <https://github.com/autowarefoundation/autoware.universe/issues/644>`_)
   * Update readme in fault_injection
   * fix precommit
   Co-authored-by: Keisuke Shima <19993104+KeisukeShima@users.noreply.github.com>

--- a/simulator/learning_based_vehicle_model/CHANGELOG.rst
+++ b/simulator/learning_based_vehicle_model/CHANGELOG.rst
@@ -5,17 +5,17 @@ Changelog for package learning_based_vehicle_model
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* fix(learning_based_vehicle_model): fix passedByValue (`#8244 <https://github.com/youtalk/autoware.universe/issues/8244>`_)
+* fix(learning_based_vehicle_model): fix passedByValue (`#8244 <https://github.com/autowarefoundation/autoware.universe/issues/8244>`_)
   * fix:passedByValue
   * fix:clang format
   ---------
-* fix(learning_based_vehicle_model): fix constVariableReference (`#8061 <https://github.com/youtalk/autoware.universe/issues/8061>`_)
+* fix(learning_based_vehicle_model): fix constVariableReference (`#8061 <https://github.com/autowarefoundation/autoware.universe/issues/8061>`_)
   fix:constVariableReference
-* fix(learning_based_vehicle_model): fix constVariablePointer warning (`#7575 <https://github.com/youtalk/autoware.universe/issues/7575>`_)
+* fix(learning_based_vehicle_model): fix constVariablePointer warning (`#7575 <https://github.com/autowarefoundation/autoware.universe/issues/7575>`_)
   * fix constVariablePointer warning
   * add reference
   ---------
-* feat(learned_model): create package (`#6395 <https://github.com/youtalk/autoware.universe/issues/6395>`_)
+* feat(learned_model): create package (`#6395 <https://github.com/autowarefoundation/autoware.universe/issues/6395>`_)
   Co-authored-by: Tomas Nagy <tomas@pmc.sk>
 * Contributors: Ryuta Kambe, Tomas Nagy, Yutaka Kondo, kobayu858
 

--- a/simulator/simple_planning_simulator/CHANGELOG.rst
+++ b/simulator/simple_planning_simulator/CHANGELOG.rst
@@ -5,29 +5,29 @@ Changelog for package simple_planning_simulator
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* fix(simple_planning_simulator): change orger of IDX in SimModelDelayS… (`#9128 <https://github.com/youtalk/autoware.universe/issues/9128>`_)
-* fix(simple_planning_simulator, raw_vehicle_cmd_converter): swap row index and column index for csv loader  (`#8963 <https://github.com/youtalk/autoware.universe/issues/8963>`_)
+* fix(simple_planning_simulator): change orger of IDX in SimModelDelayS… (`#9128 <https://github.com/autowarefoundation/autoware.universe/issues/9128>`_)
+* fix(simple_planning_simulator, raw_vehicle_cmd_converter): swap row index and column index for csv loader  (`#8963 <https://github.com/autowarefoundation/autoware.universe/issues/8963>`_)
   swap row and column
-* chore(simple_planning_simulator): remove unnecessary lines (`#8932 <https://github.com/youtalk/autoware.universe/issues/8932>`_)
+* chore(simple_planning_simulator): remove unnecessary lines (`#8932 <https://github.com/autowarefoundation/autoware.universe/issues/8932>`_)
   remove unnecessary semicolons
-* refactor(autoware_interpolation): prefix package and namespace with autoware (`#8088 <https://github.com/youtalk/autoware.universe/issues/8088>`_)
+* refactor(autoware_interpolation): prefix package and namespace with autoware (`#8088 <https://github.com/autowarefoundation/autoware.universe/issues/8088>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* fix(simple_planning_simulator): delete velocity dead band for brake (`#8685 <https://github.com/youtalk/autoware.universe/issues/8685>`_)
+* fix(simple_planning_simulator): delete velocity dead band for brake (`#8685 <https://github.com/autowarefoundation/autoware.universe/issues/8685>`_)
   * delete dead band
-* fix(simple_planning_simulator): increase test_steer_map values (`#8631 <https://github.com/youtalk/autoware.universe/issues/8631>`_)
-* feat(simple_planning_simulator): print actual and expected value in test (`#8630 <https://github.com/youtalk/autoware.universe/issues/8630>`_)
-* fix(simple_planning_simulator): fix dimension (`#8629 <https://github.com/youtalk/autoware.universe/issues/8629>`_)
-* fix(simple_planning_simulator): fix acc output for the model sim_model_delay_steer_acc_geared_wo_fall_guard (`#8607 <https://github.com/youtalk/autoware.universe/issues/8607>`_)
+* fix(simple_planning_simulator): increase test_steer_map values (`#8631 <https://github.com/autowarefoundation/autoware.universe/issues/8631>`_)
+* feat(simple_planning_simulator): print actual and expected value in test (`#8630 <https://github.com/autowarefoundation/autoware.universe/issues/8630>`_)
+* fix(simple_planning_simulator): fix dimension (`#8629 <https://github.com/autowarefoundation/autoware.universe/issues/8629>`_)
+* fix(simple_planning_simulator): fix acc output for the model sim_model_delay_steer_acc_geared_wo_fall_guard (`#8607 <https://github.com/autowarefoundation/autoware.universe/issues/8607>`_)
   fix acceleration output
-* feat(simple_planning_simulator): add VGR sim model (`#8415 <https://github.com/youtalk/autoware.universe/issues/8415>`_)
+* feat(simple_planning_simulator): add VGR sim model (`#8415 <https://github.com/autowarefoundation/autoware.universe/issues/8415>`_)
   * feat(simple_planning_simulator): add VGR sim model
   * Update simulator/simple_planning_simulator/test/test_simple_planning_simulator.cpp
   * move to interface
   * add const
   ---------
-* feat(psim)!: preapre settings to launch localization modules on psim (`#8212 <https://github.com/youtalk/autoware.universe/issues/8212>`_)
-* fix(simple_planning_simulator): fix publised acc of actuation simulator (`#8169 <https://github.com/youtalk/autoware.universe/issues/8169>`_)
-* feat(simple_planning_simulator): add actuation command simulator (`#8065 <https://github.com/youtalk/autoware.universe/issues/8065>`_)
+* feat(psim)!: preapre settings to launch localization modules on psim (`#8212 <https://github.com/autowarefoundation/autoware.universe/issues/8212>`_)
+* fix(simple_planning_simulator): fix publised acc of actuation simulator (`#8169 <https://github.com/autowarefoundation/autoware.universe/issues/8169>`_)
+* feat(simple_planning_simulator): add actuation command simulator (`#8065 <https://github.com/autowarefoundation/autoware.universe/issues/8065>`_)
   * feat(simple_planning_simulator): add actuation command simulator
   tmp
   add
@@ -43,20 +43,20 @@ Changelog for package simple_planning_simulator
   * fix typo
   ---------
   Co-authored-by: Takamasa Horibe <horibe.takamasa@gmail.com>
-* feat: add `autoware\_` prefix to `lanelet2_extension` (`#7640 <https://github.com/youtalk/autoware.universe/issues/7640>`_)
-* feat(simple_planning_simulator): add new vehicle model with falling down (`#7651 <https://github.com/youtalk/autoware.universe/issues/7651>`_)
+* feat: add `autoware\_` prefix to `lanelet2_extension` (`#7640 <https://github.com/autowarefoundation/autoware.universe/issues/7640>`_)
+* feat(simple_planning_simulator): add new vehicle model with falling down (`#7651 <https://github.com/autowarefoundation/autoware.universe/issues/7651>`_)
   * add new vehicle model
-* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/youtalk/autoware.universe/issues/7594>`_)
-* fix(simple_planning_simulator): fix duplicateBranch warnings (`#7574 <https://github.com/youtalk/autoware.universe/issues/7574>`_)
+* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/autowarefoundation/autoware.universe/issues/7594>`_)
+* fix(simple_planning_simulator): fix duplicateBranch warnings (`#7574 <https://github.com/autowarefoundation/autoware.universe/issues/7574>`_)
   * fix(simple_planning_simulator): fix duplicateBranch warnings
   * style(pre-commit): autofix
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/youtalk/autoware.universe/issues/7539>`_)
+* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/autowarefoundation/autoware.universe/issues/7539>`_)
   refactor(motion_utils): add autoware prefix and include dir
-* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/youtalk/autoware.universe/issues/7538>`_)
+* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/autowarefoundation/autoware.universe/issues/7538>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* refactor(vehicle_info_utils)!: prefix package and namespace with autoware (`#7353 <https://github.com/youtalk/autoware.universe/issues/7353>`_)
+* refactor(vehicle_info_utils)!: prefix package and namespace with autoware (`#7353 <https://github.com/autowarefoundation/autoware.universe/issues/7353>`_)
   * chore(autoware_vehicle_info_utils): rename header
   * chore(bpp-common): vehicle info
   * chore(path_optimizer): vehicle info
@@ -91,28 +91,28 @@ Changelog for package simple_planning_simulator
   * chore(sensing): vehicle info
   * fix(autoware_joy_controller): remove unused deps
   ---------
-* refactor(simple_planning_simulator): remove static odom tf publisher (`#7265 <https://github.com/youtalk/autoware.universe/issues/7265>`_)
-* feat!: replace autoware_auto_msgs with autoware_msgs for simulator modules (`#7248 <https://github.com/youtalk/autoware.universe/issues/7248>`_)
+* refactor(simple_planning_simulator): remove static odom tf publisher (`#7265 <https://github.com/autowarefoundation/autoware.universe/issues/7265>`_)
+* feat!: replace autoware_auto_msgs with autoware_msgs for simulator modules (`#7248 <https://github.com/autowarefoundation/autoware.universe/issues/7248>`_)
   Co-authored-by: Cynthia Liu <cynthia.liu@autocore.ai>
   Co-authored-by: NorahXiong <norah.xiong@autocore.ai>
   Co-authored-by: beginningfan <beginning.fan@autocore.ai>
-* feat!: remove autoware_auto_tf2 package (`#7218 <https://github.com/youtalk/autoware.universe/issues/7218>`_)
+* feat!: remove autoware_auto_tf2 package (`#7218 <https://github.com/autowarefoundation/autoware.universe/issues/7218>`_)
   * feat!: remove autoware_auto_geometry package
   * docs: remove autoware_auto_geometry package from docs
   * feat!: remove autoware_auto_tf2 package
   * fix: remove from autoware_auto_tf2 packages from docs page
   ---------
-* chore(simple_planning_simulator): add maintainer (`#7026 <https://github.com/youtalk/autoware.universe/issues/7026>`_)
-* chore(simple_planning_simulator): publish control mode before the self-position is given (`#7008 <https://github.com/youtalk/autoware.universe/issues/7008>`_)
-* feat(learned_model): create package (`#6395 <https://github.com/youtalk/autoware.universe/issues/6395>`_)
+* chore(simple_planning_simulator): add maintainer (`#7026 <https://github.com/autowarefoundation/autoware.universe/issues/7026>`_)
+* chore(simple_planning_simulator): publish control mode before the self-position is given (`#7008 <https://github.com/autowarefoundation/autoware.universe/issues/7008>`_)
+* feat(learned_model): create package (`#6395 <https://github.com/autowarefoundation/autoware.universe/issues/6395>`_)
   Co-authored-by: Tomas Nagy <tomas@pmc.sk>
 * Contributors: Autumn60, Dawid Moszyński, Esteve Fernandez, Go Sakayori, Kosuke Takeuchi, Maxime CLEMENT, Ryohsuke Mitsudome, Ryuta Kambe, Satoshi OTA, Takayuki Murooka, Tomas Nagy, Tomoya Kimura, Yuki TAKAGI, Yutaka Kondo, Zulfaqar Azmi
 
 0.26.0 (2024-04-03)
 -------------------
-* feat(simple_planning_simulator): add enable_road_slope_simulation param (`#5933 <https://github.com/youtalk/autoware.universe/issues/5933>`_)
-* fix(log-messages): reduce excessive log messages (`#5971 <https://github.com/youtalk/autoware.universe/issues/5971>`_)
-* fix(simple_planning_simulator): fix steering bias model (`#6240 <https://github.com/youtalk/autoware.universe/issues/6240>`_)
+* feat(simple_planning_simulator): add enable_road_slope_simulation param (`#5933 <https://github.com/autowarefoundation/autoware.universe/issues/5933>`_)
+* fix(log-messages): reduce excessive log messages (`#5971 <https://github.com/autowarefoundation/autoware.universe/issues/5971>`_)
+* fix(simple_planning_simulator): fix steering bias model (`#6240 <https://github.com/autowarefoundation/autoware.universe/issues/6240>`_)
   * fix(simple_planning_simulator): fix steering bias model
   * remove old implementation
   * fix initialize order
@@ -126,24 +126,24 @@ Changelog for package simple_planning_simulator
   * Update simulator/simple_planning_simulator/src/simple_planning_simulator/vehicle_model/sim_model_delay_steer_vel.cpp
   ---------
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* feat(simple_planning_simulator): add option to use initialpose for z position (`#4256 <https://github.com/youtalk/autoware.universe/issues/4256>`_)
+* feat(simple_planning_simulator): add option to use initialpose for z position (`#4256 <https://github.com/autowarefoundation/autoware.universe/issues/4256>`_)
   * feat(simple_planning_simulator): add option to use initialpose for z position
   * Revert "feat(simple_planning_simulator): add option to use initialpose for z position"
   This reverts commit a3e2779cd38841ba49e063c42fc3a2366c176ad6.
   * update initial z logic
   ---------
   Co-authored-by: Takagi, Isamu <43976882+isamu-takagi@users.noreply.github.com>
-* fix(autoware_auto_common): move headers to a separate directory (`#5919 <https://github.com/youtalk/autoware.universe/issues/5919>`_)
+* fix(autoware_auto_common): move headers to a separate directory (`#5919 <https://github.com/autowarefoundation/autoware.universe/issues/5919>`_)
   * fix(autoware_auto_common): move headers to a separate directory
   * style(pre-commit): autofix
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat(simple_planning_simulator): add mesurent_steer_bias (`#5868 <https://github.com/youtalk/autoware.universe/issues/5868>`_)
+* feat(simple_planning_simulator): add mesurent_steer_bias (`#5868 <https://github.com/autowarefoundation/autoware.universe/issues/5868>`_)
   * feat(simple_planning_simulator): add mesurent_steer_bias
   * style(pre-commit): autofix
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat(simple_plannign_simulator): add map acc model (`#5688 <https://github.com/youtalk/autoware.universe/issues/5688>`_)
+* feat(simple_plannign_simulator): add map acc model (`#5688 <https://github.com/autowarefoundation/autoware.universe/issues/5688>`_)
   * (simple_planning_simulator):add delay converter model
   * refactoring
   rename and format
@@ -182,19 +182,19 @@ Changelog for package simple_planning_simulator
   Co-authored-by: Takumi Ito <takumi.ito@tier4.jp>
   Co-authored-by: Takamasa Horibe <horibe.takamasa@gmail.com>
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* fix(simple_planning_simulator): fix ego sign pitch problem (`#5616 <https://github.com/youtalk/autoware.universe/issues/5616>`_)
+* fix(simple_planning_simulator): fix ego sign pitch problem (`#5616 <https://github.com/autowarefoundation/autoware.universe/issues/5616>`_)
   * fix ego sign pitch problem
   * change variable name for clarity
   * update documentation to clarify that driving against the lane is not supported
   ---------
-* fix(simple_planning_simulator): change default value of manual gear, DRIVE -> PARK (`#5563 <https://github.com/youtalk/autoware.universe/issues/5563>`_)
-* feat(simple_planning_simulator): add acceleration and steer command scaling factor for debug (`#5534 <https://github.com/youtalk/autoware.universe/issues/5534>`_)
+* fix(simple_planning_simulator): change default value of manual gear, DRIVE -> PARK (`#5563 <https://github.com/autowarefoundation/autoware.universe/issues/5563>`_)
+* feat(simple_planning_simulator): add acceleration and steer command scaling factor for debug (`#5534 <https://github.com/autowarefoundation/autoware.universe/issues/5534>`_)
   * feat(simple_planning_simulator): add acceleration and steer command scaling factor
   * update params as debug
   ---------
-* fix(simple_planning_simulator): set ego pitch to 0 if road slope is not simulated (`#5501 <https://github.com/youtalk/autoware.universe/issues/5501>`_)
+* fix(simple_planning_simulator): set ego pitch to 0 if road slope is not simulated (`#5501 <https://github.com/autowarefoundation/autoware.universe/issues/5501>`_)
   set ego pitch to 0 if road slope is not simulated
-* feat(simple_planning_simulator): add steer dead band (`#5477 <https://github.com/youtalk/autoware.universe/issues/5477>`_)
+* feat(simple_planning_simulator): add steer dead band (`#5477 <https://github.com/autowarefoundation/autoware.universe/issues/5477>`_)
   * feat(simple_planning_simulator): add steer dead band
   * Update simulator/simple_planning_simulator/src/simple_planning_simulator/simple_planning_simulator_core.cpp
   Co-authored-by: Takamasa Horibe <horibe.takamasa@gmail.com>
@@ -203,31 +203,31 @@ Changelog for package simple_planning_simulator
   * update params
   ---------
   Co-authored-by: Takamasa Horibe <horibe.takamasa@gmail.com>
-* fix(simple_planning_simulator): initialize variables (`#5460 <https://github.com/youtalk/autoware.universe/issues/5460>`_)
-* feat(simple_planning_sim): publish lateral acceleration (`#5307 <https://github.com/youtalk/autoware.universe/issues/5307>`_)
-* fix(simulator, controller): fix inverse pitch calculation (`#5199 <https://github.com/youtalk/autoware.universe/issues/5199>`_)
+* fix(simple_planning_simulator): initialize variables (`#5460 <https://github.com/autowarefoundation/autoware.universe/issues/5460>`_)
+* feat(simple_planning_sim): publish lateral acceleration (`#5307 <https://github.com/autowarefoundation/autoware.universe/issues/5307>`_)
+* fix(simulator, controller): fix inverse pitch calculation (`#5199 <https://github.com/autowarefoundation/autoware.universe/issues/5199>`_)
   Co-authored-by: Takamasa Horibe <horibe.takamasa@gmail.com>
-* fix(simple_planning_simulator): fix build error (`#5062 <https://github.com/youtalk/autoware.universe/issues/5062>`_)
-* feat(simple_planning_simulator): consider ego pitch angle for simulation (`#4941 <https://github.com/youtalk/autoware.universe/issues/4941>`_)
+* fix(simple_planning_simulator): fix build error (`#5062 <https://github.com/autowarefoundation/autoware.universe/issues/5062>`_)
+* feat(simple_planning_simulator): consider ego pitch angle for simulation (`#4941 <https://github.com/autowarefoundation/autoware.universe/issues/4941>`_)
   * feat(simple_planning_simulator): consider ego pitch angle for simulation
   * update
   * fix spell
   * update
   ---------
-* chore(build): remove tier4_autoware_utils.hpp evaluator/ simulator/ (`#4839 <https://github.com/youtalk/autoware.universe/issues/4839>`_)
-* docs(simple_planning_simulator): rename docs to readme (`#4221 <https://github.com/youtalk/autoware.universe/issues/4221>`_)
-* fix(simple_planning_simulator): old style arg for static_tf_publisher (`#3736 <https://github.com/youtalk/autoware.universe/issues/3736>`_)
+* chore(build): remove tier4_autoware_utils.hpp evaluator/ simulator/ (`#4839 <https://github.com/autowarefoundation/autoware.universe/issues/4839>`_)
+* docs(simple_planning_simulator): rename docs to readme (`#4221 <https://github.com/autowarefoundation/autoware.universe/issues/4221>`_)
+* fix(simple_planning_simulator): old style arg for static_tf_publisher (`#3736 <https://github.com/autowarefoundation/autoware.universe/issues/3736>`_)
   * fix(simple_planning_simulator): old style arg for static_tf_publisher
   * Update simulator/simple_planning_simulator/launch/simple_planning_simulator.launch.py
   Co-authored-by: Maxime CLEMENT <78338830+maxime-clem@users.noreply.github.com>
   ---------
   Co-authored-by: Maxime CLEMENT <78338830+maxime-clem@users.noreply.github.com>
-* build: proper eigen deps and include (`#3615 <https://github.com/youtalk/autoware.universe/issues/3615>`_)
+* build: proper eigen deps and include (`#3615 <https://github.com/autowarefoundation/autoware.universe/issues/3615>`_)
   * build: proper eigen deps and include
   * style(pre-commit): autofix
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* build: mark autoware_cmake as <buildtool_depend> (`#3616 <https://github.com/youtalk/autoware.universe/issues/3616>`_)
+* build: mark autoware_cmake as <buildtool_depend> (`#3616 <https://github.com/autowarefoundation/autoware.universe/issues/3616>`_)
   * build: mark autoware_cmake as <buildtool_depend>
   with <build_depend>, autoware_cmake is automatically exported with ament_target_dependencies() (unecessary)
   * style(pre-commit): autofix
@@ -235,36 +235,36 @@ Changelog for package simple_planning_simulator
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Kenji Miyake <kenji.miyake@tier4.jp>
-* chore: sync files (`#3227 <https://github.com/youtalk/autoware.universe/issues/3227>`_)
+* chore: sync files (`#3227 <https://github.com/autowarefoundation/autoware.universe/issues/3227>`_)
   * chore: sync files
   * style(pre-commit): autofix
   ---------
   Co-authored-by: kenji-miyake <kenji-miyake@users.noreply.github.com>
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat(simple_planning_sim): publish sensing interface imu data (`#2843 <https://github.com/youtalk/autoware.universe/issues/2843>`_)
+* feat(simple_planning_sim): publish sensing interface imu data (`#2843 <https://github.com/autowarefoundation/autoware.universe/issues/2843>`_)
   * feat(simple_planning_sim): publish sensing interface imu data
   * fix covariance index
   ---------
-* chore(planning-sim): change debug topic name (`#2610 <https://github.com/youtalk/autoware.universe/issues/2610>`_)
-* fix(simple_planning_simulator): fix ideal steer acc calc (`#2595 <https://github.com/youtalk/autoware.universe/issues/2595>`_)
-* refactor(simple_planning_simulator): make function for duplicated code (`#2502 <https://github.com/youtalk/autoware.universe/issues/2502>`_)
-* feat(simple_planning_simulator): add initial twist for debug purpose (`#2268 <https://github.com/youtalk/autoware.universe/issues/2268>`_)
-* chore(simple_planning_simulator): add maintainer  (`#2444 <https://github.com/youtalk/autoware.universe/issues/2444>`_)
+* chore(planning-sim): change debug topic name (`#2610 <https://github.com/autowarefoundation/autoware.universe/issues/2610>`_)
+* fix(simple_planning_simulator): fix ideal steer acc calc (`#2595 <https://github.com/autowarefoundation/autoware.universe/issues/2595>`_)
+* refactor(simple_planning_simulator): make function for duplicated code (`#2502 <https://github.com/autowarefoundation/autoware.universe/issues/2502>`_)
+* feat(simple_planning_simulator): add initial twist for debug purpose (`#2268 <https://github.com/autowarefoundation/autoware.universe/issues/2268>`_)
+* chore(simple_planning_simulator): add maintainer  (`#2444 <https://github.com/autowarefoundation/autoware.universe/issues/2444>`_)
   chore(simple_planning_simulator): add maintainer
   Co-authored-by: Takamasa Horibe <horibe.takamasa@gmail.com>
-* fix(simple_planning_simulator): sim model with gear acc (`#2437 <https://github.com/youtalk/autoware.universe/issues/2437>`_)
-* chore: remove autoware_auto_common dependency from simple_planning_simulator and osqp_interface (`#2233 <https://github.com/youtalk/autoware.universe/issues/2233>`_)
+* fix(simple_planning_simulator): sim model with gear acc (`#2437 <https://github.com/autowarefoundation/autoware.universe/issues/2437>`_)
+* chore: remove autoware_auto_common dependency from simple_planning_simulator and osqp_interface (`#2233 <https://github.com/autowarefoundation/autoware.universe/issues/2233>`_)
   remove autoware_auto_common dependency from simple_planning_simulator, osqp_interface
-* chore: remove motion_common dependency (`#2231 <https://github.com/youtalk/autoware.universe/issues/2231>`_)
+* chore: remove motion_common dependency (`#2231 <https://github.com/autowarefoundation/autoware.universe/issues/2231>`_)
   * remove motion_common from smoother
   * remove motion_common from control_performance_analysis and simple_planning_simualtor
   * fix include
   * add include
-* refactor!: remove tier4 control mode msg (`#1533 <https://github.com/youtalk/autoware.universe/issues/1533>`_)
+* refactor!: remove tier4 control mode msg (`#1533 <https://github.com/autowarefoundation/autoware.universe/issues/1533>`_)
   * [simple_planning_simulator] replace T4 ControlMode msg too auto_msg
   * [operation_mode_transition_manager] replace T4 ControlMode msg too auto_msg
-* refactor(simple_planning_simulator): refactor covariance index (`#1972 <https://github.com/youtalk/autoware.universe/issues/1972>`_)
-* feat(pose_initializer)!: support ad api (`#1500 <https://github.com/youtalk/autoware.universe/issues/1500>`_)
+* refactor(simple_planning_simulator): refactor covariance index (`#1972 <https://github.com/autowarefoundation/autoware.universe/issues/1972>`_)
+* feat(pose_initializer)!: support ad api (`#1500 <https://github.com/autowarefoundation/autoware.universe/issues/1500>`_)
   * feat(pose_initializer): support ad api
   * docs: update readme
   * fix: build error
@@ -280,8 +280,8 @@ Changelog for package simple_planning_simulator
   * fix: fix build error
   * ci(pre-commit): autofix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* fix(simple_planning_simulator): fix param file levels (`#1612 <https://github.com/youtalk/autoware.universe/issues/1612>`_)
-* chore(planning/control packages): organized authors and maintainers (`#1610 <https://github.com/youtalk/autoware.universe/issues/1610>`_)
+* fix(simple_planning_simulator): fix param file levels (`#1612 <https://github.com/autowarefoundation/autoware.universe/issues/1612>`_)
+* chore(planning/control packages): organized authors and maintainers (`#1610 <https://github.com/autowarefoundation/autoware.universe/issues/1610>`_)
   * organized planning authors and maintainers
   * organized control authors and maintainers
   * fix typo
@@ -314,8 +314,8 @@ Changelog for package simple_planning_simulator
   * fix
   Co-authored-by: Kenji Miyake <31987104+kenji-miyake@users.noreply.github.com>
   Co-authored-by: Kenji Miyake <kenji.miyake@tier4.jp>
-* fix(simple_planning_simulator): fix timer type (`#1538 <https://github.com/youtalk/autoware.universe/issues/1538>`_)
-* feat(operation_mode_transition_manager): add package to manage vehicle autonomous mode change (`#1246 <https://github.com/youtalk/autoware.universe/issues/1246>`_)
+* fix(simple_planning_simulator): fix timer type (`#1538 <https://github.com/autowarefoundation/autoware.universe/issues/1538>`_)
+* feat(operation_mode_transition_manager): add package to manage vehicle autonomous mode change (`#1246 <https://github.com/autowarefoundation/autoware.universe/issues/1246>`_)
   * add engage_transition_manager
   * rename to operation mode transition manager
   * fix precommit
@@ -326,59 +326,59 @@ Changelog for package simple_planning_simulator
   * add allow_autonomous_in_stopped
   * fix typo
   * fix precommit
-* feat(simple_planning_simulator): add acceleration publisher (`#1214 <https://github.com/youtalk/autoware.universe/issues/1214>`_)
+* feat(simple_planning_simulator): add acceleration publisher (`#1214 <https://github.com/autowarefoundation/autoware.universe/issues/1214>`_)
   * feat(simple_planning_simulator): add acceleration publisher
   * add cov
-* feat(simple_planning_simulator): add control_mode server (`#1061 <https://github.com/youtalk/autoware.universe/issues/1061>`_)
+* feat(simple_planning_simulator): add control_mode server (`#1061 <https://github.com/autowarefoundation/autoware.universe/issues/1061>`_)
   * add control-mode in simulator
   * precommit
   * update
   * update readme
   * update simulator
   * fix typo
-* fix(simple_planning_simlator): keep alive tf (`#1175 <https://github.com/youtalk/autoware.universe/issues/1175>`_)
+* fix(simple_planning_simlator): keep alive tf (`#1175 <https://github.com/autowarefoundation/autoware.universe/issues/1175>`_)
   * fix(simple_planning_simlator): keep alive tf
   * ci(pre-commit): autofix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* docs(simulator): fixed simple_planning_simulator table (`#1025 <https://github.com/youtalk/autoware.universe/issues/1025>`_)
-* docs: update link style and fix typos (`#950 <https://github.com/youtalk/autoware.universe/issues/950>`_)
-  * feat(state_rviz_plugin): add GateMode and PathChangeApproval Button (`#894 <https://github.com/youtalk/autoware.universe/issues/894>`_)
+* docs(simulator): fixed simple_planning_simulator table (`#1025 <https://github.com/autowarefoundation/autoware.universe/issues/1025>`_)
+* docs: update link style and fix typos (`#950 <https://github.com/autowarefoundation/autoware.universe/issues/950>`_)
+  * feat(state_rviz_plugin): add GateMode and PathChangeApproval Button (`#894 <https://github.com/autowarefoundation/autoware.universe/issues/894>`_)
   * feat(state_rviz_plugin): add GateMode and PathChangeApproval Button
   * ci(pre-commit): autofix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   * docs: update link style
   * chore: fix link
-  * feat(map_tf_generator): accelerate the 'viewer' coordinate calculation (`#890 <https://github.com/youtalk/autoware.universe/issues/890>`_)
+  * feat(map_tf_generator): accelerate the 'viewer' coordinate calculation (`#890 <https://github.com/autowarefoundation/autoware.universe/issues/890>`_)
   * add random point sampling function to quickly calculate the 'viewer' coordinate
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Kenji Miyake <31987104+kenji-miyake@users.noreply.github.com>
-  * docs(obstacle_stop_planner): update documentation (`#880 <https://github.com/youtalk/autoware.universe/issues/880>`_)
-  * docs(tier4_traffic_light_rviz_plugin): update documentation (`#905 <https://github.com/youtalk/autoware.universe/issues/905>`_)
-  * fix(accel_brake_map_calibrator): rviz panel type (`#895 <https://github.com/youtalk/autoware.universe/issues/895>`_)
+  * docs(obstacle_stop_planner): update documentation (`#880 <https://github.com/autowarefoundation/autoware.universe/issues/880>`_)
+  * docs(tier4_traffic_light_rviz_plugin): update documentation (`#905 <https://github.com/autowarefoundation/autoware.universe/issues/905>`_)
+  * fix(accel_brake_map_calibrator): rviz panel type (`#895 <https://github.com/autowarefoundation/autoware.universe/issues/895>`_)
   * fixed panel type
   * modified instruction for rosbag replay case
   * modified update_map_dir service name
-  * fix(behavior velocity planner): skipping emplace back stop reason if it is empty (`#898 <https://github.com/youtalk/autoware.universe/issues/898>`_)
+  * fix(behavior velocity planner): skipping emplace back stop reason if it is empty (`#898 <https://github.com/autowarefoundation/autoware.universe/issues/898>`_)
   * skipping emplace back stop reason if it is empty
   * add braces
   * ci(pre-commit): autofix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Takagi, Isamu <43976882+isamu-takagi@users.noreply.github.com>
-  * feat(behavior_path_planner): weakened noise filtering of drivable area (`#838 <https://github.com/youtalk/autoware.universe/issues/838>`_)
+  * feat(behavior_path_planner): weakened noise filtering of drivable area (`#838 <https://github.com/autowarefoundation/autoware.universe/issues/838>`_)
   * feat(behavior_path_planner): Weakened noise filtering of drivable area
   * fix lanelet's longitudinal disconnection
   * add comments of erode/dilate process
-  * refactor(vehicle-cmd-gate): using namespace for msgs (`#913 <https://github.com/youtalk/autoware.universe/issues/913>`_)
+  * refactor(vehicle-cmd-gate): using namespace for msgs (`#913 <https://github.com/autowarefoundation/autoware.universe/issues/913>`_)
   * refactor(vehicle-cmd-gate): using namespace for msgs
   * for clang
-  * feat(pose_initializer): introduce an array copy function (`#900 <https://github.com/youtalk/autoware.universe/issues/900>`_)
+  * feat(pose_initializer): introduce an array copy function (`#900 <https://github.com/autowarefoundation/autoware.universe/issues/900>`_)
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-  * feat: add lidar point filter when debug (`#865 <https://github.com/youtalk/autoware.universe/issues/865>`_)
+  * feat: add lidar point filter when debug (`#865 <https://github.com/autowarefoundation/autoware.universe/issues/865>`_)
   * feat: add lidar point filter when debug
   * ci(pre-commit): autofix
   Co-authored-by: suchang <chang.su@autocore.ai>
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-  * feat(component_interface_utils): add interface classes  (`#899 <https://github.com/youtalk/autoware.universe/issues/899>`_)
+  * feat(component_interface_utils): add interface classes  (`#899 <https://github.com/autowarefoundation/autoware.universe/issues/899>`_)
   * feat(component_interface_utils): add interface classes
   * feat(default_ad_api): apply the changes of interface utils
   * fix(component_interface_utils): remove old comment
@@ -386,18 +386,18 @@ Changelog for package simple_planning_simulator
   * fix(component_interface_utils): remove unimplemented message
   * docs(component_interface_utils): add design policy
   * docs(component_interface_utils): add comment
-  * refactor(vehicle_cmd_gate): change namespace in launch file (`#927 <https://github.com/youtalk/autoware.universe/issues/927>`_)
+  * refactor(vehicle_cmd_gate): change namespace in launch file (`#927 <https://github.com/autowarefoundation/autoware.universe/issues/927>`_)
   Co-authored-by: Berkay <berkay@leodrive.ai>
-  * feat: visualize lane boundaries (`#923 <https://github.com/youtalk/autoware.universe/issues/923>`_)
+  * feat: visualize lane boundaries (`#923 <https://github.com/autowarefoundation/autoware.universe/issues/923>`_)
   * feat: visualize lane boundaries
   * fix: start_bound
   * ci(pre-commit): autofix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-  * fix(system_monitor): fix truncation warning in strncpy (`#872 <https://github.com/youtalk/autoware.universe/issues/872>`_)
+  * fix(system_monitor): fix truncation warning in strncpy (`#872 <https://github.com/autowarefoundation/autoware.universe/issues/872>`_)
   * fix(system_monitor): fix truncation warning in strncpy
   * Use std::string constructor to copy char array
   * Fixed typo
-  * fix(behavior_velocity_planner.stopline): extend following and previous search range to avoid no collision (`#917 <https://github.com/youtalk/autoware.universe/issues/917>`_)
+  * fix(behavior_velocity_planner.stopline): extend following and previous search range to avoid no collision (`#917 <https://github.com/autowarefoundation/autoware.universe/issues/917>`_)
   * fix: extend following and previous search range to avoid no collision
   * chore: add debug marker
   * fix: simplify logic
@@ -407,11 +407,11 @@ Changelog for package simple_planning_simulator
   * ci(pre-commit): autofix
   * fix: delete debug code
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-  * docs(surround obstacle checker): update documentation (`#878 <https://github.com/youtalk/autoware.universe/issues/878>`_)
+  * docs(surround obstacle checker): update documentation (`#878 <https://github.com/autowarefoundation/autoware.universe/issues/878>`_)
   * docs(surround_obstacle_checker): update pub/sub topics & params
   * docs(surround_obstacle_checker): remove unused files
   * docs(surround_obstacke_checker): update purpose
-  * feat(tier4_autoware_utils): add vehicle state checker (`#896 <https://github.com/youtalk/autoware.universe/issues/896>`_)
+  * feat(tier4_autoware_utils): add vehicle state checker (`#896 <https://github.com/autowarefoundation/autoware.universe/issues/896>`_)
   * feat(tier4_autoware_utils): add vehicle state checker
   * fix(tier4_autoware_utils): use absolute value
   * feat(tier4_autoware_utils): divide into two classies
@@ -421,20 +421,20 @@ Changelog for package simple_planning_simulator
   * fix(tier4_autoware_utils): into same loop
   * fix(tier4_autoware_utils): fix variables name
   * fix(tier4_autoware_utils): remove redundant codes
-  * fix(motion_velocity_smoother): fix overwriteStopPoint using backward point (`#816 <https://github.com/youtalk/autoware.universe/issues/816>`_)
+  * fix(motion_velocity_smoother): fix overwriteStopPoint using backward point (`#816 <https://github.com/autowarefoundation/autoware.universe/issues/816>`_)
   * fix(motion_velocity_smoother): fix overwriteStopPoint using backward point
   * Modify overwriteStopPoint input and output
-  * feat(obstacle_avoidance_planner): explicitly insert zero velocity (`#906 <https://github.com/youtalk/autoware.universe/issues/906>`_)
+  * feat(obstacle_avoidance_planner): explicitly insert zero velocity (`#906 <https://github.com/autowarefoundation/autoware.universe/issues/906>`_)
   * feat(obstacle_avoidance_planner) fix bug of stop line unalignment
   * fix bug of unsorted output points
   * move calcVelocity in node.cpp
   * fix build error
-  * feat(behavior_velocity): find occlusion more efficiently (`#829 <https://github.com/youtalk/autoware.universe/issues/829>`_)
-  * fix(system_monitor): add some smart information to diagnostics (`#708 <https://github.com/youtalk/autoware.universe/issues/708>`_)
-  * feat(obstacle_avoidance_planner): dealt with close lane change (`#921 <https://github.com/youtalk/autoware.universe/issues/921>`_)
+  * feat(behavior_velocity): find occlusion more efficiently (`#829 <https://github.com/autowarefoundation/autoware.universe/issues/829>`_)
+  * fix(system_monitor): add some smart information to diagnostics (`#708 <https://github.com/autowarefoundation/autoware.universe/issues/708>`_)
+  * feat(obstacle_avoidance_planner): dealt with close lane change (`#921 <https://github.com/autowarefoundation/autoware.universe/issues/921>`_)
   * feat(obstacle_avoidance_planner): dealt with close lane change
   * fix bug of right lane change
-  * feat(obstacle_avoidance_planner): some fix for narrow driving (`#916 <https://github.com/youtalk/autoware.universe/issues/916>`_)
+  * feat(obstacle_avoidance_planner): some fix for narrow driving (`#916 <https://github.com/autowarefoundation/autoware.universe/issues/916>`_)
   * use car like constraints in mpt
   * use not widest bounds for the first bounds
   * organized params
@@ -444,17 +444,17 @@ Changelog for package simple_planning_simulator
   * update config
   * remove unnecessary files
   * update tier4_planning_launch params
-  * chore(obstacle_avoidance_planner): removed obsolete obstacle_avoidance_planner doc in Japanese (`#919 <https://github.com/youtalk/autoware.universe/issues/919>`_)
-  * chore(behavior_velocity_planner.stopline): add debug marker for stopline collision check (`#932 <https://github.com/youtalk/autoware.universe/issues/932>`_)
+  * chore(obstacle_avoidance_planner): removed obsolete obstacle_avoidance_planner doc in Japanese (`#919 <https://github.com/autowarefoundation/autoware.universe/issues/919>`_)
+  * chore(behavior_velocity_planner.stopline): add debug marker for stopline collision check (`#932 <https://github.com/autowarefoundation/autoware.universe/issues/932>`_)
   * chore(behavior_velocity_planner.stopline): add debug marker for stopline collision check
   * feat: use marker helper
-  * feat(map_loader): visualize center line by points (`#931 <https://github.com/youtalk/autoware.universe/issues/931>`_)
+  * feat(map_loader): visualize center line by points (`#931 <https://github.com/autowarefoundation/autoware.universe/issues/931>`_)
   * feat: visualize center line points
   * fix: delete space
   * feat: visualize center line by arrow
   * revert insertMarkerArray
   * fix: delete space
-  * feat: add RTC interface (`#765 <https://github.com/youtalk/autoware.universe/issues/765>`_)
+  * feat: add RTC interface (`#765 <https://github.com/autowarefoundation/autoware.universe/issues/765>`_)
   * feature(rtc_interface): add files
   * feature(rtc_interface): implement functions
   * feature(rtc_interface): reimprement functions to use CooperateCommands and write README.md
@@ -466,23 +466,23 @@ Changelog for package simple_planning_simulator
   * feature(rtc_interface): add isRegistered and clearCooperateStatus
   * ci(pre-commit): autofix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-  * chore: sync files (`#911 <https://github.com/youtalk/autoware.universe/issues/911>`_)
+  * chore: sync files (`#911 <https://github.com/autowarefoundation/autoware.universe/issues/911>`_)
   Co-authored-by: kenji-miyake <kenji-miyake@users.noreply.github.com>
-  * fix: replace boost::mutex::scoped_lock to std::scoped_lock (`#907 <https://github.com/youtalk/autoware.universe/issues/907>`_)
+  * fix: replace boost::mutex::scoped_lock to std::scoped_lock (`#907 <https://github.com/autowarefoundation/autoware.universe/issues/907>`_)
   * fix: replace boost::mutex::scoped_lock to std::scoped_lock
   * fix: replace boost::mutex to std::mutex
-  * feat(tensorrt_yolo): add multi gpu support to tensorrt_yolo node (`#885 <https://github.com/youtalk/autoware.universe/issues/885>`_)
+  * feat(tensorrt_yolo): add multi gpu support to tensorrt_yolo node (`#885 <https://github.com/autowarefoundation/autoware.universe/issues/885>`_)
   * feat(tensorrt_yolo): add multi gpu support to tensorrt_yolo node
   * feat(tensorrt_yolo): update arg
   Co-authored-by: Kaan Colak <kcolak@leodrive.ai>
-  * feat(tier4_planning_launch): create parameter yaml for behavior_velocity_planner (`#887 <https://github.com/youtalk/autoware.universe/issues/887>`_)
+  * feat(tier4_planning_launch): create parameter yaml for behavior_velocity_planner (`#887 <https://github.com/autowarefoundation/autoware.universe/issues/887>`_)
   * feat(tier4_planning_launch): create parameter yaml for behavior_velocity_planner
   * Update launch/tier4_planning_launch/config/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/behavior_velocity_planner.param.yaml
   Co-authored-by: taikitanaka3 <65527974+taikitanaka3@users.noreply.github.com>
   * feat: add param.yaml in behavior_velocity_planner package
   * some fix
   Co-authored-by: taikitanaka3 <65527974+taikitanaka3@users.noreply.github.com>
-  * fix(map_loader): use std::filesystem to load pcd files in pointcloud_map_loader (`#942 <https://github.com/youtalk/autoware.universe/issues/942>`_)
+  * fix(map_loader): use std::filesystem to load pcd files in pointcloud_map_loader (`#942 <https://github.com/autowarefoundation/autoware.universe/issues/942>`_)
   * fix(map_loader): use std::filesystem to load pcd files in pointcloud_map_loader
   * fix(map_loader): remove c_str
   * fix(map_loader): replace c_str to string
@@ -521,24 +521,24 @@ Changelog for package simple_planning_simulator
   Co-authored-by: Kaan Çolak <kaancolak95@gmail.com>
   Co-authored-by: Kaan Colak <kcolak@leodrive.ai>
   Co-authored-by: Kenji Miyake <kenji.miyake@tier4.jp>
-* feat(vehicle_info_util): add max_steer_angle (`#740 <https://github.com/youtalk/autoware.universe/issues/740>`_)
+* feat(vehicle_info_util): add max_steer_angle (`#740 <https://github.com/autowarefoundation/autoware.universe/issues/740>`_)
   * feat(vehicle_info_util): add max_steer_angle
   * applied pre-commit
   * Added max_steer_angle in test config
   Co-authored-by: Tomoya Kimura <tomoya.kimura@tier4.jp>
-* feat: isolate gtests in all packages (`#693 <https://github.com/youtalk/autoware.universe/issues/693>`_)
-* chore: upgrade cmake_minimum_required to 3.14 (`#856 <https://github.com/youtalk/autoware.universe/issues/856>`_)
-* refactor: simplify Rolling support (`#854 <https://github.com/youtalk/autoware.universe/issues/854>`_)
-* refactor: use autoware cmake (`#849 <https://github.com/youtalk/autoware.universe/issues/849>`_)
+* feat: isolate gtests in all packages (`#693 <https://github.com/autowarefoundation/autoware.universe/issues/693>`_)
+* chore: upgrade cmake_minimum_required to 3.14 (`#856 <https://github.com/autowarefoundation/autoware.universe/issues/856>`_)
+* refactor: simplify Rolling support (`#854 <https://github.com/autowarefoundation/autoware.universe/issues/854>`_)
+* refactor: use autoware cmake (`#849 <https://github.com/autowarefoundation/autoware.universe/issues/849>`_)
   * remove autoware_auto_cmake
   * add build_depend of autoware_cmake
   * use autoware_cmake in CMakeLists.txt
   * fix bugs
   * fix cmake lint errors
-* chore: remove bad chars (`#845 <https://github.com/youtalk/autoware.universe/issues/845>`_)
-* fix: suppress compiler warnings (`#852 <https://github.com/youtalk/autoware.universe/issues/852>`_)
-* style: fix format of package.xml (`#844 <https://github.com/youtalk/autoware.universe/issues/844>`_)
-* fix(autoware_auto_tf2): modify build error in rolling (`#718 <https://github.com/youtalk/autoware.universe/issues/718>`_)
+* chore: remove bad chars (`#845 <https://github.com/autowarefoundation/autoware.universe/issues/845>`_)
+* fix: suppress compiler warnings (`#852 <https://github.com/autowarefoundation/autoware.universe/issues/852>`_)
+* style: fix format of package.xml (`#844 <https://github.com/autowarefoundation/autoware.universe/issues/844>`_)
+* fix(autoware_auto_tf2): modify build error in rolling (`#718 <https://github.com/autowarefoundation/autoware.universe/issues/718>`_)
   * fix(autoware_auto_common): modify build error in rolling
   * fix(autoware_auto_tf2): modify build error in rolling
   * fix(autoware_auto_geometry): modify build error in rolling
@@ -548,7 +548,7 @@ Changelog for package simple_planning_simulator
   * fix(simple_planning_simulator): modify build error in rolling
   * ci(pre-commit): autofix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* ci(pre-commit): clear the exclude option (`#426 <https://github.com/youtalk/autoware.universe/issues/426>`_)
+* ci(pre-commit): clear the exclude option (`#426 <https://github.com/autowarefoundation/autoware.universe/issues/426>`_)
   * ci(pre-commit): remove unnecessary excludes
   * ci(pre-commit): autofix
   * ci(pre-commit): autofix
@@ -560,35 +560,35 @@ Changelog for package simple_planning_simulator
   * fix build
   * use autoware_lint_common
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* fix(simple_planning_simulator): fix bug in function to apply noise (`#665 <https://github.com/youtalk/autoware.universe/issues/665>`_)
-* test(simple_planning_simulator): add node test (`#422 <https://github.com/youtalk/autoware.universe/issues/422>`_)
+* fix(simple_planning_simulator): fix bug in function to apply noise (`#665 <https://github.com/autowarefoundation/autoware.universe/issues/665>`_)
+* test(simple_planning_simulator): add node test (`#422 <https://github.com/autowarefoundation/autoware.universe/issues/422>`_)
   * test(simple_planning_simulator): add node test
   * use TEST_P
-* fix(simple psim): gear bug to update state in simple psim (`#370 <https://github.com/youtalk/autoware.universe/issues/370>`_)
+* fix(simple psim): gear bug to update state in simple psim (`#370 <https://github.com/autowarefoundation/autoware.universe/issues/370>`_)
   * fix(simple psim): gear bug to update state in simple psim
   * upadte ideal acc geared model as well
-* fix: simple psim with vehicle engage (`#301 <https://github.com/youtalk/autoware.universe/issues/301>`_)
+* fix: simple psim with vehicle engage (`#301 <https://github.com/autowarefoundation/autoware.universe/issues/301>`_)
   * feat: add initial_engage_state for /vehicle/engage sub result
   * feat: simulating only when vehicle engage is true
-* feat(simple_planning_simulator): add delay model of velocity and steering (`#235 <https://github.com/youtalk/autoware.universe/issues/235>`_)
+* feat(simple_planning_simulator): add delay model of velocity and steering (`#235 <https://github.com/autowarefoundation/autoware.universe/issues/235>`_)
   * add delay steer vel in psim
   * change wz to steer
   * fix param description
   * modify readme
   * modify cmake
   * ci: change file URL
-  * fix: order to create callback (`#220 <https://github.com/youtalk/autoware.universe/issues/220>`_)
+  * fix: order to create callback (`#220 <https://github.com/autowarefoundation/autoware.universe/issues/220>`_)
   Co-authored-by: Takeshi Miura <57553950+1222-takeshi@users.noreply.github.com>
-  * chore: remove unnecessary depends (`#227 <https://github.com/youtalk/autoware.universe/issues/227>`_)
+  * chore: remove unnecessary depends (`#227 <https://github.com/autowarefoundation/autoware.universe/issues/227>`_)
   * ci: add check-build-depends.yaml
   * chore: simplify build_depends.repos
   * chore: remove exec_depend
   * chore: use register-autonomoustuff-repository
   * chore: add setup tasks to other workflows
-  * ci: update .yamllint.yaml (`#229 <https://github.com/youtalk/autoware.universe/issues/229>`_)
+  * ci: update .yamllint.yaml (`#229 <https://github.com/autowarefoundation/autoware.universe/issues/229>`_)
   * ci: update .yamllint.yaml
   * chore: fix for yamllint
-  * fix: remove warning for compile error (`#198 <https://github.com/youtalk/autoware.universe/issues/198>`_)
+  * fix: remove warning for compile error (`#198 <https://github.com/autowarefoundation/autoware.universe/issues/198>`_)
   * fix: fix compile error of pointcloud preprocessor
   * fix: fix compiler warning for had map utils
   * fix: fix compiler warning for behavior velocity planner
@@ -596,12 +596,12 @@ Changelog for package simple_planning_simulator
   * fix: fix compiler warning for occupancy grid map outlier filter
   * fix: fix compiler warning for detection by tracker
   * fix: restore comment
-  * fix: set control_mode false before autoware engage (`#232 <https://github.com/youtalk/autoware.universe/issues/232>`_)
+  * fix: set control_mode false before autoware engage (`#232 <https://github.com/autowarefoundation/autoware.universe/issues/232>`_)
   * fix: set control_mode false before autoware engage
   * add input/engage remap in launch
-  * fix: library path (`#225 <https://github.com/youtalk/autoware.universe/issues/225>`_)
+  * fix: library path (`#225 <https://github.com/autowarefoundation/autoware.universe/issues/225>`_)
   Co-authored-by: taikitanaka3 <taiki.tanaka@tier4.jp>
-  * fix: interpolation (`#791 <https://github.com/youtalk/autoware.universe/issues/791>`_) (`#218 <https://github.com/youtalk/autoware.universe/issues/218>`_)
+  * fix: interpolation (`#791 <https://github.com/autowarefoundation/autoware.universe/issues/791>`_) (`#218 <https://github.com/autowarefoundation/autoware.universe/issues/218>`_)
   Co-authored-by: taikitanaka3 <65527974+taikitanaka3@users.noreply.github.com>
   * add missing function definition in .cpp
   * set input and state for DELAY_STEER_VEL model
@@ -614,16 +614,16 @@ Changelog for package simple_planning_simulator
   Co-authored-by: Takayuki Murooka <takayuki5168@gmail.com>
   Co-authored-by: taikitanaka3 <taiki.tanaka@tier4.jp>
   Co-authored-by: Tomoya Kimura <tomoya.kimura@tier4.jp>
-* fix: set control_mode false before autoware engage (`#232 <https://github.com/youtalk/autoware.universe/issues/232>`_)
+* fix: set control_mode false before autoware engage (`#232 <https://github.com/autowarefoundation/autoware.universe/issues/232>`_)
   * fix: set control_mode false before autoware engage
   * add input/engage remap in launch
-* feat: replace VehicleStateCommand with GearCommand (`#217 <https://github.com/youtalk/autoware.universe/issues/217>`_)
+* feat: replace VehicleStateCommand with GearCommand (`#217 <https://github.com/autowarefoundation/autoware.universe/issues/217>`_)
   Co-authored-by: Tomoya Kimura <tomoya.kimura@tier4.jp>
-* fix: fix typo and url (`#201 <https://github.com/youtalk/autoware.universe/issues/201>`_)
+* fix: fix typo and url (`#201 <https://github.com/autowarefoundation/autoware.universe/issues/201>`_)
   * fix typo
   * fix url (jp -> en)
   Co-authored-by: Takeshi Miura <57553950+1222-takeshi@users.noreply.github.com>
-* feat: rename existing packages name starting with autoware to different names (`#180 <https://github.com/youtalk/autoware.universe/issues/180>`_)
+* feat: rename existing packages name starting with autoware to different names (`#180 <https://github.com/autowarefoundation/autoware.universe/issues/180>`_)
   * autoware_api_utils -> tier4_api_utils
   * autoware_debug_tools -> tier4_debug_tools
   * autoware_error_monitor -> system_error_monitor
@@ -640,10 +640,10 @@ Changelog for package simple_planning_simulator
   * fix ad_service_state_monitor
   * ci(pre-commit): autofix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* fix: update simple planning simulator param file (`#179 <https://github.com/youtalk/autoware.universe/issues/179>`_)
+* fix: update simple planning simulator param file (`#179 <https://github.com/autowarefoundation/autoware.universe/issues/179>`_)
   Co-authored-by: taikitanaka3 <65527974+taikitanaka3@users.noreply.github.com>
-* feat: add simulator_launch package (`#166 <https://github.com/youtalk/autoware.universe/issues/166>`_)
-  * Add simulator_launch package (`#459 <https://github.com/youtalk/autoware.universe/issues/459>`_)
+* feat: add simulator_launch package (`#166 <https://github.com/autowarefoundation/autoware.universe/issues/166>`_)
+  * Add simulator_launch package (`#459 <https://github.com/autowarefoundation/autoware.universe/issues/459>`_)
   * Add simulator_launch package
   * add argument
   * fix depend order
@@ -653,7 +653,7 @@ Changelog for package simple_planning_simulator
   * Update simulator_launch/launch/simulator.launch.xml
   Co-authored-by: Kenji Miyake <31987104+kenji-miyake@users.noreply.github.com>
   Co-authored-by: Kenji Miyake <31987104+kenji-miyake@users.noreply.github.com>
-  * Move simple_planning_simulator to simulator_launch (`#462 <https://github.com/youtalk/autoware.universe/issues/462>`_)
+  * Move simple_planning_simulator to simulator_launch (`#462 <https://github.com/autowarefoundation/autoware.universe/issues/462>`_)
   * move simple_planning_simulator
   * add simulation arg to logging_simulator.launch
   * delete unused argument
@@ -662,17 +662,17 @@ Changelog for package simple_planning_simulator
   * update README
   * add default value to simulator arg
   * restore vehicle_simulation arg
-  * Fix/revert initial engage state (`#484 <https://github.com/youtalk/autoware.universe/issues/484>`_)
+  * Fix/revert initial engage state (`#484 <https://github.com/autowarefoundation/autoware.universe/issues/484>`_)
   * Fix args
   * Add initial_engage_state to vehicle.launch.xml
   * Update vehicle.launch.xml
-  * Change formatter to black (`#488 <https://github.com/youtalk/autoware.universe/issues/488>`_)
+  * Change formatter to black (`#488 <https://github.com/autowarefoundation/autoware.universe/issues/488>`_)
   * Update pre-commit settings
   * Apply Black
   * Replace ament_lint_common with autoware_lint_common
   * Update build_depends.repos
   * Fix build_depends
-  * Auto/fix launch (`#110 <https://github.com/youtalk/autoware.universe/issues/110>`_)
+  * Auto/fix launch (`#110 <https://github.com/autowarefoundation/autoware.universe/issues/110>`_)
   * fix namespace
   * remove dynamic_object_visualization
   * fix rviz
@@ -684,7 +684,7 @@ Changelog for package simple_planning_simulator
   Co-authored-by: Kenji Miyake <kenji.miyake@tier4.jp>
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: taikitanaka3 <65527974+taikitanaka3@users.noreply.github.com>
-* feat: load vehicle info default param (`#148 <https://github.com/youtalk/autoware.universe/issues/148>`_)
+* feat: load vehicle info default param (`#148 <https://github.com/autowarefoundation/autoware.universe/issues/148>`_)
   * update global_parameter loader readme
   * remove unused dependency
   * add default vehicle_info_param to launch files
@@ -698,7 +698,7 @@ Changelog for package simple_planning_simulator
   * ci(pre-commit): autofix
   Co-authored-by: Takeshi Miura <57553950+1222-takeshi@users.noreply.github.com>
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat: change pachage name: autoware_msgs -> tier4_msgs (`#150 <https://github.com/youtalk/autoware.universe/issues/150>`_)
+* feat: change pachage name: autoware_msgs -> tier4_msgs (`#150 <https://github.com/autowarefoundation/autoware.universe/issues/150>`_)
   * change pkg name: autoware\_*_msgs -> tier\_*_msgs
   * ci(pre-commit): autofix
   * autoware_external_api_msgs -> tier4_external_api_msgs
@@ -706,33 +706,33 @@ Changelog for package simple_planning_simulator
   * fix description
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Takeshi Miura <57553950+1222-takeshi@users.noreply.github.com>
-* feat: add simple planning simulator package (`#5 <https://github.com/youtalk/autoware.universe/issues/5>`_)
+* feat: add simple planning simulator package (`#5 <https://github.com/autowarefoundation/autoware.universe/issues/5>`_)
   * release v0.4.0
   * remove ROS1 packages temporarily
   * add sample ros2 packages
   * add COLCON_IGNORE to ros1 packages
-  * Fix simple planning simulator (`#26 <https://github.com/youtalk/autoware.universe/issues/26>`_)
+  * Fix simple planning simulator (`#26 <https://github.com/autowarefoundation/autoware.universe/issues/26>`_)
   * simple planning simulator: fix params & launch file
   * remove unused file
   * fix timercallback
-  * [simple_planning_simulator] add rostopic relay in launch file (`#117 <https://github.com/youtalk/autoware.universe/issues/117>`_)
+  * [simple_planning_simulator] add rostopic relay in launch file (`#117 <https://github.com/autowarefoundation/autoware.universe/issues/117>`_)
   * [simple_planning_simulator] add rostopic relay in launch file
   * add topic_tools as exec_depend
-  * Adjust copyright notice on 532 out of 699 source files (`#143 <https://github.com/youtalk/autoware.universe/issues/143>`_)
-  * Use quotes for includes where appropriate (`#144 <https://github.com/youtalk/autoware.universe/issues/144>`_)
+  * Adjust copyright notice on 532 out of 699 source files (`#143 <https://github.com/autowarefoundation/autoware.universe/issues/143>`_)
+  * Use quotes for includes where appropriate (`#144 <https://github.com/autowarefoundation/autoware.universe/issues/144>`_)
   * Use quotes for includes where appropriate
   * Fix lint tests
   * Make tests pass hopefully
-  * Run uncrustify on the entire Pilot.Auto codebase (`#151 <https://github.com/youtalk/autoware.universe/issues/151>`_)
+  * Run uncrustify on the entire Pilot.Auto codebase (`#151 <https://github.com/autowarefoundation/autoware.universe/issues/151>`_)
   * Run uncrustify on the entire Pilot.Auto codebase
   * Exclude open PRs
-  * reduce terminal ouput for better error message visibility (`#200 <https://github.com/youtalk/autoware.universe/issues/200>`_)
+  * reduce terminal ouput for better error message visibility (`#200 <https://github.com/autowarefoundation/autoware.universe/issues/200>`_)
   * reduce terminal ouput for better error message visibility
   * [costmap_generator] fix waiting for first transform
   * fix tests
   * fix test
-  * Use trajectory for z position source (`#243 <https://github.com/youtalk/autoware.universe/issues/243>`_)
-  * Ros2 v0.8.0 engage (`#342 <https://github.com/youtalk/autoware.universe/issues/342>`_)
+  * Use trajectory for z position source (`#243 <https://github.com/autowarefoundation/autoware.universe/issues/243>`_)
+  * Ros2 v0.8.0 engage (`#342 <https://github.com/autowarefoundation/autoware.universe/issues/342>`_)
   * [autoware_vehicle_msgs]: Add engage message
   * [as]: Update message
   * [awapi_awiv_adapter]: Update message
@@ -741,7 +741,7 @@ Changelog for package simple_planning_simulator
   * [autoware_state_monitor]: Update message
   * [autoware_control_msgs]: Remove EngageMode message
   * [simple_planning_simulator]: Update message
-  * Ros2 v0.8.0 fix packages (`#351 <https://github.com/youtalk/autoware.universe/issues/351>`_)
+  * Ros2 v0.8.0 fix packages (`#351 <https://github.com/autowarefoundation/autoware.universe/issues/351>`_)
   * add subscription to QoS
   * add vihicle_param _file to simple_planning_sim
   * update cmake/packages.xml
@@ -755,27 +755,27 @@ Changelog for package simple_planning_simulator
   * apply lint
   * add latch option to autoware_state_monitor
   * delete unused comment
-  * Rename ROS-related .yaml to .param.yaml (`#352 <https://github.com/youtalk/autoware.universe/issues/352>`_)
+  * Rename ROS-related .yaml to .param.yaml (`#352 <https://github.com/autowarefoundation/autoware.universe/issues/352>`_)
   * Rename ROS-related .yaml to .param.yaml
   * Remove prefix 'default\_' of yaml files
   * Rename vehicle_info.yaml to vehicle_info.param.yaml
   * Rename diagnostic_aggregator's param files
   * Fix overlooked parameters
-  * Fix typo in simulator module (`#439 <https://github.com/youtalk/autoware.universe/issues/439>`_)
-  * add use_sim-time option (`#454 <https://github.com/youtalk/autoware.universe/issues/454>`_)
-  * Format launch files (`#1219 <https://github.com/youtalk/autoware.universe/issues/1219>`_)
-  * Fix rolling build errors (`#1225 <https://github.com/youtalk/autoware.universe/issues/1225>`_)
+  * Fix typo in simulator module (`#439 <https://github.com/autowarefoundation/autoware.universe/issues/439>`_)
+  * add use_sim-time option (`#454 <https://github.com/autowarefoundation/autoware.universe/issues/454>`_)
+  * Format launch files (`#1219 <https://github.com/autowarefoundation/autoware.universe/issues/1219>`_)
+  * Fix rolling build errors (`#1225 <https://github.com/autowarefoundation/autoware.universe/issues/1225>`_)
   * Add missing include files
   * Replace rclcpp::Duration
   * Use reference for exceptions
   * Use from_seconds
-  * Sync public repo (`#1228 <https://github.com/youtalk/autoware.universe/issues/1228>`_)
-  * [simple_planning_simulator] add readme (`#424 <https://github.com/youtalk/autoware.universe/issues/424>`_)
+  * Sync public repo (`#1228 <https://github.com/autowarefoundation/autoware.universe/issues/1228>`_)
+  * [simple_planning_simulator] add readme (`#424 <https://github.com/autowarefoundation/autoware.universe/issues/424>`_)
   * add readme of simple_planning_simulator
   * Update simulator/simple_planning_simulator/README.md
-  * set transit_margin_time to intersect. planner (`#460 <https://github.com/youtalk/autoware.universe/issues/460>`_)
-  * Fix pose2twist (`#462 <https://github.com/youtalk/autoware.universe/issues/462>`_)
-  * Ros2 vehicle info param server (`#447 <https://github.com/youtalk/autoware.universe/issues/447>`_)
+  * set transit_margin_time to intersect. planner (`#460 <https://github.com/autowarefoundation/autoware.universe/issues/460>`_)
+  * Fix pose2twist (`#462 <https://github.com/autowarefoundation/autoware.universe/issues/462>`_)
+  * Ros2 vehicle info param server (`#447 <https://github.com/autowarefoundation/autoware.universe/issues/447>`_)
   * add vehicle_info_param_server
   * update vehicle info
   * apply format
@@ -783,7 +783,7 @@ Changelog for package simple_planning_simulator
   * skip unnecessary search
   * delete vehicle param file
   * fix bug
-  * Ros2 fix topic name part2 (`#425 <https://github.com/youtalk/autoware.universe/issues/425>`_)
+  * Ros2 fix topic name part2 (`#425 <https://github.com/autowarefoundation/autoware.universe/issues/425>`_)
   * Fix topic name of traffic_light_classifier
   * Fix topic name of traffic_light_visualization
   * Fix topic name of traffic_light_ssd_fine_detector
@@ -793,19 +793,19 @@ Changelog for package simple_planning_simulator
   * Fix lint traffic_light_classifier
   * Fix lint traffic_light_classifier
   * Fix lint traffic_light_ssd_fine_detector
-  * Fix issues in hdd_reader (`#466 <https://github.com/youtalk/autoware.universe/issues/466>`_)
+  * Fix issues in hdd_reader (`#466 <https://github.com/autowarefoundation/autoware.universe/issues/466>`_)
   * Fix some issues detected by Coverity Scan and Clang-Tidy
   * Update launch command
   * Add more `close(new_sock)`
   * Simplify the definitions of struct
-  * fix: re-construct laneletMapLayer for reindex RTree (`#463 <https://github.com/youtalk/autoware.universe/issues/463>`_)
-  * Rviz overlay render fix (`#461 <https://github.com/youtalk/autoware.universe/issues/461>`_)
+  * fix: re-construct laneletMapLayer for reindex RTree (`#463 <https://github.com/autowarefoundation/autoware.universe/issues/463>`_)
+  * Rviz overlay render fix (`#461 <https://github.com/autowarefoundation/autoware.universe/issues/461>`_)
   * Moved painiting in SteeringAngle plugin to update()
   * super class now back to MFD
   * uncrustified
   * acquire data in mutex
   * back to RTD as superclass
-  * Rviz overlay render in update (`#465 <https://github.com/youtalk/autoware.universe/issues/465>`_)
+  * Rviz overlay render in update (`#465 <https://github.com/autowarefoundation/autoware.universe/issues/465>`_)
   * Moved painiting in SteeringAngle plugin to update()
   * super class now back to MFD
   * uncrustified
@@ -819,8 +819,8 @@ Changelog for package simple_planning_simulator
   Co-authored-by: Kazuki Miyahara <kmiya@outlook.com>
   Co-authored-by: Makoto Tokunaga <vios-fish@users.noreply.github.com>
   Co-authored-by: Adam Dąbrowski <adam.dabrowski@robotec.ai>
-  * Remove use_sim_time for set_parameter (`#1260 <https://github.com/youtalk/autoware.universe/issues/1260>`_)
-  * Refactor vehicle info util (`#1305 <https://github.com/youtalk/autoware.universe/issues/1305>`_)
+  * Remove use_sim_time for set_parameter (`#1260 <https://github.com/autowarefoundation/autoware.universe/issues/1260>`_)
+  * Refactor vehicle info util (`#1305 <https://github.com/autowarefoundation/autoware.universe/issues/1305>`_)
   * Update license
   * Refactor vehicle_info_util
   * Rename and split files
@@ -828,10 +828,10 @@ Changelog for package simple_planning_simulator
   * Fix bug and add error handling
   * Add "// namespace"
   * Add missing include
-  * Fix lint errors (`#1378 <https://github.com/youtalk/autoware.universe/issues/1378>`_)
+  * Fix lint errors (`#1378 <https://github.com/autowarefoundation/autoware.universe/issues/1378>`_)
   * Fix lint errors
   * Fix variable names
-  * Add pre-commit (`#1560 <https://github.com/youtalk/autoware.universe/issues/1560>`_)
+  * Add pre-commit (`#1560 <https://github.com/autowarefoundation/autoware.universe/issues/1560>`_)
   * add pre-commit
   * add pre-commit-config
   * add additional settings for private repository
@@ -851,25 +851,25 @@ Changelog for package simple_planning_simulator
   Co-authored-by: Kazuki Miyahara <kmiya@outlook.com>
   Co-authored-by: pre-commit <pre-commit@example.com>
   Co-authored-by: Kenji Miyake <31987104+kenji-miyake@users.noreply.github.com>
-  * Add markdownlint and prettier (`#1661 <https://github.com/youtalk/autoware.universe/issues/1661>`_)
+  * Add markdownlint and prettier (`#1661 <https://github.com/autowarefoundation/autoware.universe/issues/1661>`_)
   * Add markdownlint and prettier
   * Ignore .param.yaml
   * Apply format
-  * add cov pub in psim (`#1732 <https://github.com/youtalk/autoware.universe/issues/1732>`_)
-  * Fix -Wunused-parameter (`#1836 <https://github.com/youtalk/autoware.universe/issues/1836>`_)
+  * add cov pub in psim (`#1732 <https://github.com/autowarefoundation/autoware.universe/issues/1732>`_)
+  * Fix -Wunused-parameter (`#1836 <https://github.com/autowarefoundation/autoware.universe/issues/1836>`_)
   * Fix -Wunused-parameter
   * Fix mistake
   * fix spell
   * Fix lint issues
   * Ignore flake8 warnings
   Co-authored-by: Hiroki OTA <hiroki.ota@tier4.jp>
-  * fix some typos (`#1941 <https://github.com/youtalk/autoware.universe/issues/1941>`_)
+  * fix some typos (`#1941 <https://github.com/autowarefoundation/autoware.universe/issues/1941>`_)
   * fix some typos
   * fix typo
   * Fix typo
   Co-authored-by: Kenji Miyake <kenji.miyake@tier4.jp>
-  * Add autoware api (`#1979 <https://github.com/youtalk/autoware.universe/issues/1979>`_)
-  * add sort-package-xml hook in pre-commit (`#1881 <https://github.com/youtalk/autoware.universe/issues/1881>`_)
+  * Add autoware api (`#1979 <https://github.com/autowarefoundation/autoware.universe/issues/1979>`_)
+  * add sort-package-xml hook in pre-commit (`#1881 <https://github.com/autowarefoundation/autoware.universe/issues/1881>`_)
   * add sort xml hook in pre-commit
   * change retval to exit_status
   * rename
@@ -883,12 +883,12 @@ Changelog for package simple_planning_simulator
   * move prettier-xml to pre-commit-hooks-ros
   * update version for bug-fix
   * apply pre-commit
-  * Feature/add ideal accel model interface (`#1894 <https://github.com/youtalk/autoware.universe/issues/1894>`_)
+  * Feature/add ideal accel model interface (`#1894 <https://github.com/autowarefoundation/autoware.universe/issues/1894>`_)
   * Add IDEAL_ACCEL model interface for simple planning simulator
   * Add IDEAL_ACCEL model descriptions
   * Fix format
   * Change vehicle model type description at config file
-  * Change formatter to clang-format and black (`#2332 <https://github.com/youtalk/autoware.universe/issues/2332>`_)
+  * Change formatter to clang-format and black (`#2332 <https://github.com/autowarefoundation/autoware.universe/issues/2332>`_)
   * Revert "Temporarily comment out pre-commit hooks"
   This reverts commit 748e9cdb145ce12f8b520bcbd97f5ff899fc28a3.
   * Replace ament_lint_common with autoware_lint_common
@@ -900,60 +900,60 @@ Changelog for package simple_planning_simulator
   * Fix include double quotes to angle brackets
   * Apply clang-format
   * Fix build errors
-  * Add COLCON_IGNORE (`#500 <https://github.com/youtalk/autoware.universe/issues/500>`_)
-  * Back port .auto control packages (`#571 <https://github.com/youtalk/autoware.universe/issues/571>`_)
+  * Add COLCON_IGNORE (`#500 <https://github.com/autowarefoundation/autoware.universe/issues/500>`_)
+  * Back port .auto control packages (`#571 <https://github.com/autowarefoundation/autoware.universe/issues/571>`_)
   * Implement Lateral and Longitudinal Control Muxer
-  * [`#570 <https://github.com/youtalk/autoware.universe/issues/570>`_] Porting wf_simulator
-  * [`#1189 <https://github.com/youtalk/autoware.universe/issues/1189>`_] Deactivate flaky test in 'trajectory_follower_nodes'
-  * [`#1189 <https://github.com/youtalk/autoware.universe/issues/1189>`_] Fix flacky test in 'trajectory_follower_nodes/latlon_muxer'
-  * [`#1057 <https://github.com/youtalk/autoware.universe/issues/1057>`_] Add osqp_interface package
-  * [`#1057 <https://github.com/youtalk/autoware.universe/issues/1057>`_] Add library code for MPC-based lateral control
-  * [`#1271 <https://github.com/youtalk/autoware.universe/issues/1271>`_] Use std::abs instead of abs
-  * [`#1057 <https://github.com/youtalk/autoware.universe/issues/1057>`_] Implement Lateral Controller for Cargo ODD
-  * [`#1246 <https://github.com/youtalk/autoware.universe/issues/1246>`_] Resolve "Test case names currently use snake_case but should be CamelCase"
-  * [`#1325 <https://github.com/youtalk/autoware.universe/issues/1325>`_] Deactivate flaky smoke test in 'trajectory_follower_nodes'
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Add library code of longitudinal controller
+  * [`#570 <https://github.com/autowarefoundation/autoware.universe/issues/570>`_] Porting wf_simulator
+  * [`#1189 <https://github.com/autowarefoundation/autoware.universe/issues/1189>`_] Deactivate flaky test in 'trajectory_follower_nodes'
+  * [`#1189 <https://github.com/autowarefoundation/autoware.universe/issues/1189>`_] Fix flacky test in 'trajectory_follower_nodes/latlon_muxer'
+  * [`#1057 <https://github.com/autowarefoundation/autoware.universe/issues/1057>`_] Add osqp_interface package
+  * [`#1057 <https://github.com/autowarefoundation/autoware.universe/issues/1057>`_] Add library code for MPC-based lateral control
+  * [`#1271 <https://github.com/autowarefoundation/autoware.universe/issues/1271>`_] Use std::abs instead of abs
+  * [`#1057 <https://github.com/autowarefoundation/autoware.universe/issues/1057>`_] Implement Lateral Controller for Cargo ODD
+  * [`#1246 <https://github.com/autowarefoundation/autoware.universe/issues/1246>`_] Resolve "Test case names currently use snake_case but should be CamelCase"
+  * [`#1325 <https://github.com/autowarefoundation/autoware.universe/issues/1325>`_] Deactivate flaky smoke test in 'trajectory_follower_nodes'
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Add library code of longitudinal controller
   * Fix build error for trajectory follower
   * Fix build error for trajectory follower nodes
-  * [`#1272 <https://github.com/youtalk/autoware.universe/issues/1272>`_] Add AckermannControlCommand support to simple_planning_simulator
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Add Longitudinal Controller node
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Rename velocity_controller -> longitudinal_controller
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Update CMakeLists.txt for the longitudinal_controller_node
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Add smoke test python launch file
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Use LowPassFilter1d from trajectory_follower
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Use autoware_auto_msgs
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Changes for .auto (debug msg tmp fix, common func, tf listener)
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Remove unused parameters
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Fix ros test
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Rm default params from declare_parameters + use autoware types
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Use default param file to setup NodeOptions in the ros test
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Fix docstring
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Replace receiving a Twist with a VehicleKinematicState
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Change class variables format to m\_ prefix
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Fix plugin name of LongitudinalController in CMakeLists.txt
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Fix copyright dates
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Reorder includes
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Add some tests (~89% coverage without disabling flaky tests)
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Add more tests (90+% coverage without disabling flaky tests)
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Use Float32MultiArrayDiagnostic message for debug and slope
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Calculate wheel_base value from vehicle parameters
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Cleanup redundant logger setting in tests
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Set ROS_DOMAIN_ID when running tests to prevent CI failures
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Remove TF listener and use published vehicle state instead
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Change smoke tests to use autoware_testing
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Add plotjuggler cfg for both lateral and longitudinal control
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Improve design documents
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Disable flaky test
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Properly transform vehicle state in longitudinal node
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Fix TF buffer of lateral controller
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Tuning of lateral controller for LGSVL
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Fix formating
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Fix /tf_static sub to be transient_local
-  * [`#1058 <https://github.com/youtalk/autoware.universe/issues/1058>`_] Fix yaw recalculation of reverse trajs in the lateral controller
+  * [`#1272 <https://github.com/autowarefoundation/autoware.universe/issues/1272>`_] Add AckermannControlCommand support to simple_planning_simulator
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Add Longitudinal Controller node
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Rename velocity_controller -> longitudinal_controller
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Update CMakeLists.txt for the longitudinal_controller_node
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Add smoke test python launch file
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Use LowPassFilter1d from trajectory_follower
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Use autoware_auto_msgs
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Changes for .auto (debug msg tmp fix, common func, tf listener)
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Remove unused parameters
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Fix ros test
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Rm default params from declare_parameters + use autoware types
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Use default param file to setup NodeOptions in the ros test
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Fix docstring
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Replace receiving a Twist with a VehicleKinematicState
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Change class variables format to m\_ prefix
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Fix plugin name of LongitudinalController in CMakeLists.txt
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Fix copyright dates
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Reorder includes
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Add some tests (~89% coverage without disabling flaky tests)
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Add more tests (90+% coverage without disabling flaky tests)
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Use Float32MultiArrayDiagnostic message for debug and slope
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Calculate wheel_base value from vehicle parameters
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Cleanup redundant logger setting in tests
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Set ROS_DOMAIN_ID when running tests to prevent CI failures
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Remove TF listener and use published vehicle state instead
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Change smoke tests to use autoware_testing
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Add plotjuggler cfg for both lateral and longitudinal control
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Improve design documents
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Disable flaky test
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Properly transform vehicle state in longitudinal node
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Fix TF buffer of lateral controller
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Tuning of lateral controller for LGSVL
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Fix formating
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Fix /tf_static sub to be transient_local
+  * [`#1058 <https://github.com/autowarefoundation/autoware.universe/issues/1058>`_] Fix yaw recalculation of reverse trajs in the lateral controller
   * modify trajectory_follower for galactic build
-  * [`#1379 <https://github.com/youtalk/autoware.universe/issues/1379>`_] Update trajectory_follower
-  * [`#1379 <https://github.com/youtalk/autoware.universe/issues/1379>`_] Update simple_planning_simulator
-  * [`#1379 <https://github.com/youtalk/autoware.universe/issues/1379>`_] Update trajectory_follower_nodes
+  * [`#1379 <https://github.com/autowarefoundation/autoware.universe/issues/1379>`_] Update trajectory_follower
+  * [`#1379 <https://github.com/autowarefoundation/autoware.universe/issues/1379>`_] Update simple_planning_simulator
+  * [`#1379 <https://github.com/autowarefoundation/autoware.universe/issues/1379>`_] Update trajectory_follower_nodes
   * apply trajectory msg modification in control
   * move directory
   * remote control/trajectory_follower level dorectpry
@@ -977,7 +977,7 @@ Changelog for package simple_planning_simulator
   Co-authored-by: MIURA Yasuyuki <kokosabu@gmail.com>
   Co-authored-by: wep21 <border_goldenmarket@yahoo.co.jp>
   Co-authored-by: tomoya.kimura <tomoya.kimura@tier4.jp>
-  * [simple planning simulator]change type of msg (`#590 <https://github.com/youtalk/autoware.universe/issues/590>`_)
+  * [simple planning simulator]change type of msg (`#590 <https://github.com/autowarefoundation/autoware.universe/issues/590>`_)
   * remove kinematic_state
   * remove vehicle_state_command/report
   * get z-position from trajectory
@@ -990,19 +990,19 @@ Changelog for package simple_planning_simulator
   Co-authored-by: taikitanaka3 <65527974+taikitanaka3@users.noreply.github.com>
   * fix typo
   Co-authored-by: taikitanaka3 <65527974+taikitanaka3@users.noreply.github.com>
-  * [autoware_vehicle_rviz_plugin/route_handler/simple_planning_simulator]fix some packages (`#606 <https://github.com/youtalk/autoware.universe/issues/606>`_)
+  * [autoware_vehicle_rviz_plugin/route_handler/simple_planning_simulator]fix some packages (`#606 <https://github.com/autowarefoundation/autoware.universe/issues/606>`_)
   * fix console meter
   * fix velocity_history
   * fix route handler
   * change topic name
-  * update to support velocity report header (`#655 <https://github.com/youtalk/autoware.universe/issues/655>`_)
+  * update to support velocity report header (`#655 <https://github.com/autowarefoundation/autoware.universe/issues/655>`_)
   * update to support velocity report header
   * Update simulator/simple_planning_simulator/src/simple_planning_simulator/simple_planning_simulator_core.cpp
   Co-authored-by: tkimura4 <tomoya.kimura@tier4.jp>
   * use maybe_unused
   * fix precommit
   Co-authored-by: tkimura4 <tomoya.kimura@tier4.jp>
-  * adapt to actuation cmd/status as control msg (`#646 <https://github.com/youtalk/autoware.universe/issues/646>`_)
+  * adapt to actuation cmd/status as control msg (`#646 <https://github.com/autowarefoundation/autoware.universe/issues/646>`_)
   * adapt to actuation cmd/status as control msg
   * fix readme
   * fix topics
@@ -1013,38 +1013,38 @@ Changelog for package simple_planning_simulator
   * revert gyro_odometer_change
   * revert twist topic change
   * revert unchanged package
-  * FIx vehicle status topic name/type (`#658 <https://github.com/youtalk/autoware.universe/issues/658>`_)
+  * FIx vehicle status topic name/type (`#658 <https://github.com/autowarefoundation/autoware.universe/issues/658>`_)
   * shift -> gear_status
   * twist -> velocity_status
-  * fix topic name (`#674 <https://github.com/youtalk/autoware.universe/issues/674>`_)
+  * fix topic name (`#674 <https://github.com/autowarefoundation/autoware.universe/issues/674>`_)
   * fix topic name
   * fix gear message name
-  * Fix psim param path (`#696 <https://github.com/youtalk/autoware.universe/issues/696>`_)
-  * Fix/psim topics emergency handler awapi (`#702 <https://github.com/youtalk/autoware.universe/issues/702>`_)
+  * Fix psim param path (`#696 <https://github.com/autowarefoundation/autoware.universe/issues/696>`_)
+  * Fix/psim topics emergency handler awapi (`#702 <https://github.com/autowarefoundation/autoware.universe/issues/702>`_)
   * fix emergency handler
   * fix awapi
   * remove unused topic
   * remove duplecated vehicle cmd
-  * Auto/add turn indicators and hazards (`#717 <https://github.com/youtalk/autoware.universe/issues/717>`_)
+  * Auto/add turn indicators and hazards (`#717 <https://github.com/autowarefoundation/autoware.universe/issues/717>`_)
   * add turn indicators
   * add hazard light
   * omit name space
   * remap topic name
   * delete unnecessary blank line
-  * [simple_planning_simulator]fix bug (`#727 <https://github.com/youtalk/autoware.universe/issues/727>`_)
+  * [simple_planning_simulator]fix bug (`#727 <https://github.com/autowarefoundation/autoware.universe/issues/727>`_)
   * input z-axis of trajectory to pose(tf/odometry)
   * output 0 velocity when invalid gear is input
-  * fix gear process in sim (`#728 <https://github.com/youtalk/autoware.universe/issues/728>`_)
-  * Fix for integration test (`#732 <https://github.com/youtalk/autoware.universe/issues/732>`_)
+  * fix gear process in sim (`#728 <https://github.com/autowarefoundation/autoware.universe/issues/728>`_)
+  * Fix for integration test (`#732 <https://github.com/autowarefoundation/autoware.universe/issues/732>`_)
   * Add backward compatibility of autoware state
   * Add simulator initial pose service
   * Fix pre-commit
   * Fix pre-commit
-  * Simple planning simulator update for latest develop (`#735 <https://github.com/youtalk/autoware.universe/issues/735>`_)
-  * Refactor vehicle info util (`#1305 <https://github.com/youtalk/autoware.universe/issues/1305>`_)
-  * add cov pub in psim (`#1732 <https://github.com/youtalk/autoware.universe/issues/1732>`_)
+  * Simple planning simulator update for latest develop (`#735 <https://github.com/autowarefoundation/autoware.universe/issues/735>`_)
+  * Refactor vehicle info util (`#1305 <https://github.com/autowarefoundation/autoware.universe/issues/1305>`_)
+  * add cov pub in psim (`#1732 <https://github.com/autowarefoundation/autoware.universe/issues/1732>`_)
   * remove pose_with_covariance publisher and add covariance information in Odometry
-  * Fix acceleration for reverse (`#737 <https://github.com/youtalk/autoware.universe/issues/737>`_)
+  * Fix acceleration for reverse (`#737 <https://github.com/autowarefoundation/autoware.universe/issues/737>`_)
   * Fix acceleration for reverse
   * Fix acceleration in set_input
   * remove unused using

--- a/simulator/tier4_dummy_object_rviz_plugin/CHANGELOG.rst
+++ b/simulator/tier4_dummy_object_rviz_plugin/CHANGELOG.rst
@@ -5,17 +5,17 @@ Changelog for package tier4_dummy_object_rviz_plugin
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* style: update rviz plugin icons to match the theme (`#8868 <https://github.com/youtalk/autoware.universe/issues/8868>`_)
-* fix(dummy_perception_publisher, tier4_dummy_object_rviz_plugin): separate dummy object msg (`#8828 <https://github.com/youtalk/autoware.universe/issues/8828>`_)
+* style: update rviz plugin icons to match the theme (`#8868 <https://github.com/autowarefoundation/autoware.universe/issues/8868>`_)
+* fix(dummy_perception_publisher, tier4_dummy_object_rviz_plugin): separate dummy object msg (`#8828 <https://github.com/autowarefoundation/autoware.universe/issues/8828>`_)
   * fix: dummy object rviz plugin dependency
   * fix: remove message from dummy perception publisher
   * fix: node name
   ---------
-* fix(tier4_dummy_object_rviz_plugin): fix unusedFunction (`#8844 <https://github.com/youtalk/autoware.universe/issues/8844>`_)
+* fix(tier4_dummy_object_rviz_plugin): fix unusedFunction (`#8844 <https://github.com/autowarefoundation/autoware.universe/issues/8844>`_)
   fix:unusedFunction
-* fix(tier4_dummy_object_rviz_plugin): fix functionConst (`#8830 <https://github.com/youtalk/autoware.universe/issues/8830>`_)
+* fix(tier4_dummy_object_rviz_plugin): fix functionConst (`#8830 <https://github.com/autowarefoundation/autoware.universe/issues/8830>`_)
   fix:functionConst
-* fix(tier4_perception_rviz_plugin): relocate tier4_perception_rviz_plugin and rename it to tier4_dummy_object_rviz_plugin (`#8818 <https://github.com/youtalk/autoware.universe/issues/8818>`_)
+* fix(tier4_perception_rviz_plugin): relocate tier4_perception_rviz_plugin and rename it to tier4_dummy_object_rviz_plugin (`#8818 <https://github.com/autowarefoundation/autoware.universe/issues/8818>`_)
   * chore: move tier4_perception_rviz_plugin package to simulation folder
   * chore: reorder codeowners
   * rename package to tier4_dummy_perception_rviz_plugin

--- a/simulator/vehicle_door_simulator/CHANGELOG.rst
+++ b/simulator/vehicle_door_simulator/CHANGELOG.rst
@@ -5,10 +5,10 @@ Changelog for package vehicle_door_simulator
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* fix: fix internal door interface qos (`#9144 <https://github.com/youtalk/autoware.universe/issues/9144>`_)
+* fix: fix internal door interface qos (`#9144 <https://github.com/autowarefoundation/autoware.universe/issues/9144>`_)
 * Contributors: Takagi, Isamu, Yutaka Kondo
 
 0.26.0 (2024-04-03)
 -------------------
-* feat(default_ad_api): add door api (`#5737 <https://github.com/youtalk/autoware.universe/issues/5737>`_)
+* feat(default_ad_api): add door api (`#5737 <https://github.com/autowarefoundation/autoware.universe/issues/5737>`_)
 * Contributors: Takagi, Isamu

--- a/system/autoware_component_monitor/CHANGELOG.rst
+++ b/system/autoware_component_monitor/CHANGELOG.rst
@@ -5,9 +5,9 @@ Changelog for package autoware_component_monitor
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* chore(autoware_component_monitor): add maintainers (`#8867 <https://github.com/youtalk/autoware.universe/issues/8867>`_)
-* fix(autoware_component_monitor): fix unusedFunction (`#8582 <https://github.com/youtalk/autoware.universe/issues/8582>`_)
-* feat(system): create a package to monitor component containers (`#7094 <https://github.com/youtalk/autoware.universe/issues/7094>`_)
+* chore(autoware_component_monitor): add maintainers (`#8867 <https://github.com/autowarefoundation/autoware.universe/issues/8867>`_)
+* fix(autoware_component_monitor): fix unusedFunction (`#8582 <https://github.com/autowarefoundation/autoware.universe/issues/8582>`_)
+* feat(system): create a package to monitor component containers (`#7094 <https://github.com/autowarefoundation/autoware.universe/issues/7094>`_)
 * Contributors: Hayate TOBA, Mehmet Emin BAŞOĞLU, Yutaka Kondo
 
 0.26.0 (2024-04-03)

--- a/system/autoware_default_adapi/CHANGELOG.rst
+++ b/system/autoware_default_adapi/CHANGELOG.rst
@@ -5,15 +5,15 @@ Changelog for package autoware_default_adapi
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* refactor(component_interface_specs): prefix package and namespace with autoware (`#9094 <https://github.com/youtalk/autoware.universe/issues/9094>`_)
-* fix(default_ad_api): fix unusedFunction (`#8581 <https://github.com/youtalk/autoware.universe/issues/8581>`_)
+* refactor(component_interface_specs): prefix package and namespace with autoware (`#9094 <https://github.com/autowarefoundation/autoware.universe/issues/9094>`_)
+* fix(default_ad_api): fix unusedFunction (`#8581 <https://github.com/autowarefoundation/autoware.universe/issues/8581>`_)
   * fix: unusedFunction
   * Revert "fix: unusedFunction"
   This reverts commit c70a36d4d29668f02dae9416f202ccd05abee552.
   * fix: unusedFunction
   ---------
   Co-authored-by: kobayu858 <129580202+kobayu858@users.noreply.github.com>
-* chore(autoware_default_adapi)!: prefix autoware to package name (`#8533 <https://github.com/youtalk/autoware.universe/issues/8533>`_)
+* chore(autoware_default_adapi)!: prefix autoware to package name (`#8533 <https://github.com/autowarefoundation/autoware.universe/issues/8533>`_)
 * Contributors: Esteve Fernandez, Hayate TOBA, Takagi, Isamu, Yutaka Kondo
 
 0.26.0 (2024-04-03)

--- a/system/autoware_processing_time_checker/CHANGELOG.rst
+++ b/system/autoware_processing_time_checker/CHANGELOG.rst
@@ -5,14 +5,14 @@ Changelog for package autoware_processing_time_checker
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* feat(costmap_generator, control_validator, scenario_selector, surround_obstacle_checker, vehicle_cmd_gate): add processing time pub. (`#9065 <https://github.com/youtalk/autoware.universe/issues/9065>`_)
+* feat(costmap_generator, control_validator, scenario_selector, surround_obstacle_checker, vehicle_cmd_gate): add processing time pub. (`#9065 <https://github.com/autowarefoundation/autoware.universe/issues/9065>`_)
   * feat(costmap_generator, control_validator, scenario_selector, surround_obstacle_checker, vehicle_cmd_gate): Add: processing_time_pub
   * fix: pre-commit
   * feat(costmap_generator): fix: No output when not Active.
   * fix: clang-format
   * Re: fix: clang-format
   ---------
-* feat(processing_time_checker): add a new package (`#7957 <https://github.com/youtalk/autoware.universe/issues/7957>`_)
+* feat(processing_time_checker): add a new package (`#7957 <https://github.com/autowarefoundation/autoware.universe/issues/7957>`_)
   * feat(processing_time_checker): add a new package
   * fix
   * fix

--- a/system/bluetooth_monitor/CHANGELOG.rst
+++ b/system/bluetooth_monitor/CHANGELOG.rst
@@ -5,18 +5,18 @@ Changelog for package bluetooth_monitor
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* fix(docs): fix file name for bluetooth monitor schema (`#8308 <https://github.com/youtalk/autoware.universe/issues/8308>`_)
+* fix(docs): fix file name for bluetooth monitor schema (`#8308 <https://github.com/autowarefoundation/autoware.universe/issues/8308>`_)
   * fix file name for schema
   * the variable name should be addresses instead
   ---------
-* fix(bluetooth_monitor): fix unreadVariable (`#8371 <https://github.com/youtalk/autoware.universe/issues/8371>`_)
+* fix(bluetooth_monitor): fix unreadVariable (`#8371 <https://github.com/autowarefoundation/autoware.universe/issues/8371>`_)
   fix:unreadVariable
-* fix(bluetooth_monitor): apply cppcheck-suppress for cstyleCast (`#7869 <https://github.com/youtalk/autoware.universe/issues/7869>`_)
+* fix(bluetooth_monitor): apply cppcheck-suppress for cstyleCast (`#7869 <https://github.com/autowarefoundation/autoware.universe/issues/7869>`_)
 * Contributors: Koichi98, Yutaka Kondo, Yuxuan Liu, kobayu858
 
 0.26.0 (2024-04-03)
 -------------------
-* refactor(bluetooth_monitor): rework parameters (`#5239 <https://github.com/youtalk/autoware.universe/issues/5239>`_)
+* refactor(bluetooth_monitor): rework parameters (`#5239 <https://github.com/autowarefoundation/autoware.universe/issues/5239>`_)
   * refactor(bluetooth_monitor): rework parameters
   * style(pre-commit): autofix
   * doc(bluetooth_monitor): fix default for integer parameters
@@ -25,7 +25,7 @@ Changelog for package bluetooth_monitor
   * doc(bluetooth_monitor): fix parameter description
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* build: mark autoware_cmake as <buildtool_depend> (`#3616 <https://github.com/youtalk/autoware.universe/issues/3616>`_)
+* build: mark autoware_cmake as <buildtool_depend> (`#3616 <https://github.com/autowarefoundation/autoware.universe/issues/3616>`_)
   * build: mark autoware_cmake as <buildtool_depend>
   with <build_depend>, autoware_cmake is automatically exported with ament_target_dependencies() (unecessary)
   * style(pre-commit): autofix
@@ -33,24 +33,24 @@ Changelog for package bluetooth_monitor
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Kenji Miyake <kenji.miyake@tier4.jp>
-* chore: sync files (`#3227 <https://github.com/youtalk/autoware.universe/issues/3227>`_)
+* chore: sync files (`#3227 <https://github.com/autowarefoundation/autoware.universe/issues/3227>`_)
   * chore: sync files
   * style(pre-commit): autofix
   ---------
   Co-authored-by: kenji-miyake <kenji-miyake@users.noreply.github.com>
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* build(bluetooth_monitor): add build dependency (`#2738 <https://github.com/youtalk/autoware.universe/issues/2738>`_)
-* ci(pre-commit): format SVG files (`#2172 <https://github.com/youtalk/autoware.universe/issues/2172>`_)
+* build(bluetooth_monitor): add build dependency (`#2738 <https://github.com/autowarefoundation/autoware.universe/issues/2738>`_)
+* ci(pre-commit): format SVG files (`#2172 <https://github.com/autowarefoundation/autoware.universe/issues/2172>`_)
   * ci(pre-commit): format SVG files
   * ci(pre-commit): autofix
   * apply pre-commit
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat(bluetooth_monitor): run bluetooth monitor with new parameter (`#1111 <https://github.com/youtalk/autoware.universe/issues/1111>`_)
+* feat(bluetooth_monitor): run bluetooth monitor with new parameter (`#1111 <https://github.com/autowarefoundation/autoware.universe/issues/1111>`_)
   * feat(bluetooth_monitor): run bluetooth monitor with new parameter
   * ci(pre-commit): autofix
   * Fixed a build error in humble
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat(bluetooth_monitor): add functionality to monitor Bluetooth connection (`#862 <https://github.com/youtalk/autoware.universe/issues/862>`_)
+* feat(bluetooth_monitor): add functionality to monitor Bluetooth connection (`#862 <https://github.com/autowarefoundation/autoware.universe/issues/862>`_)
   * feat(bluetooth_monitor): add functionality to monitor Bluetooth connection
   * ci(pre-commit): autofix
   * Fixed a typo

--- a/system/component_state_monitor/CHANGELOG.rst
+++ b/system/component_state_monitor/CHANGELOG.rst
@@ -5,29 +5,29 @@ Changelog for package component_state_monitor
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* feat!: replace autoware_auto_msgs with autoware_msgs for system modules (`#7249 <https://github.com/youtalk/autoware.universe/issues/7249>`_)
+* feat!: replace autoware_auto_msgs with autoware_msgs for system modules (`#7249 <https://github.com/autowarefoundation/autoware.universe/issues/7249>`_)
   Co-authored-by: Cynthia Liu <cynthia.liu@autocore.ai>
   Co-authored-by: NorahXiong <norah.xiong@autocore.ai>
   Co-authored-by: beginningfan <beginning.fan@autocore.ai>
-* fix(componet_state_monitor): remove ndt node alive monitoring (`#6957 <https://github.com/youtalk/autoware.universe/issues/6957>`_)
+* fix(componet_state_monitor): remove ndt node alive monitoring (`#6957 <https://github.com/autowarefoundation/autoware.universe/issues/6957>`_)
   remove ndt node alive monitoring
-* chore(component_state_monitor): relax pose_estimator_pose timeout (`#6916 <https://github.com/youtalk/autoware.universe/issues/6916>`_)
+* chore(component_state_monitor): relax pose_estimator_pose timeout (`#6916 <https://github.com/autowarefoundation/autoware.universe/issues/6916>`_)
 * Contributors: Ryohsuke Mitsudome, Shumpei Wakabayashi, Yamato Ando, Yutaka Kondo
 
 0.26.0 (2024-04-03)
 -------------------
-* fix(component_state_monitor): change pose_estimator_pose rate (`#6563 <https://github.com/youtalk/autoware.universe/issues/6563>`_)
-* chore: update api package maintainers (`#6086 <https://github.com/youtalk/autoware.universe/issues/6086>`_)
+* fix(component_state_monitor): change pose_estimator_pose rate (`#6563 <https://github.com/autowarefoundation/autoware.universe/issues/6563>`_)
+* chore: update api package maintainers (`#6086 <https://github.com/autowarefoundation/autoware.universe/issues/6086>`_)
   * update api maintainers
   * fix
   ---------
-* feat(component_state_monitor): monitor traffic light recognition output (`#5778 <https://github.com/youtalk/autoware.universe/issues/5778>`_)
-* feat(component_state_monitor): monitor pose_estimator output (`#5617 <https://github.com/youtalk/autoware.universe/issues/5617>`_)
-* docs: add readme for interface packages (`#4235 <https://github.com/youtalk/autoware.universe/issues/4235>`_)
+* feat(component_state_monitor): monitor traffic light recognition output (`#5778 <https://github.com/autowarefoundation/autoware.universe/issues/5778>`_)
+* feat(component_state_monitor): monitor pose_estimator output (`#5617 <https://github.com/autowarefoundation/autoware.universe/issues/5617>`_)
+* docs: add readme for interface packages (`#4235 <https://github.com/autowarefoundation/autoware.universe/issues/4235>`_)
   add readme for interface packages
-* chore: update maintainer (`#4140 <https://github.com/youtalk/autoware.universe/issues/4140>`_)
+* chore: update maintainer (`#4140 <https://github.com/autowarefoundation/autoware.universe/issues/4140>`_)
   Co-authored-by: Ryohsuke Mitsudome <43976834+mitsudome-r@users.noreply.github.com>
-* build: mark autoware_cmake as <buildtool_depend> (`#3616 <https://github.com/youtalk/autoware.universe/issues/3616>`_)
+* build: mark autoware_cmake as <buildtool_depend> (`#3616 <https://github.com/autowarefoundation/autoware.universe/issues/3616>`_)
   * build: mark autoware_cmake as <buildtool_depend>
   with <build_depend>, autoware_cmake is automatically exported with ament_target_dependencies() (unecessary)
   * style(pre-commit): autofix
@@ -35,15 +35,15 @@ Changelog for package component_state_monitor
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Kenji Miyake <kenji.miyake@tier4.jp>
-* feat(pose_initializer): enable pose initialization while running (only for sim) (`#3038 <https://github.com/youtalk/autoware.universe/issues/3038>`_)
+* feat(pose_initializer): enable pose initialization while running (only for sim) (`#3038 <https://github.com/autowarefoundation/autoware.universe/issues/3038>`_)
   * feat(pose_initializer): enable pose initialization while running (only for sim)
   * both logsim and psim params
   * only one pose_initializer_param_path arg
   * use two param files for pose_initializer
   ---------
-* fix(component_state_monitor): add dependency on topic_state_monitor (`#3030 <https://github.com/youtalk/autoware.universe/issues/3030>`_)
-* fix(component_state_monitor): fix lanelet route package (`#2552 <https://github.com/youtalk/autoware.universe/issues/2552>`_)
-* feat!: replace HADMap with Lanelet (`#2356 <https://github.com/youtalk/autoware.universe/issues/2356>`_)
+* fix(component_state_monitor): add dependency on topic_state_monitor (`#3030 <https://github.com/autowarefoundation/autoware.universe/issues/3030>`_)
+* fix(component_state_monitor): fix lanelet route package (`#2552 <https://github.com/autowarefoundation/autoware.universe/issues/2552>`_)
+* feat!: replace HADMap with Lanelet (`#2356 <https://github.com/autowarefoundation/autoware.universe/issues/2356>`_)
   * feat!: replace HADMap with Lanelet
   * update topic.yaml
   * Update perception/traffic_light_map_based_detector/README.md
@@ -56,8 +56,8 @@ Changelog for package component_state_monitor
   Co-authored-by: Daisuke Nishimatsu <42202095+wep21@users.noreply.github.com>
   * format readme
   Co-authored-by: Daisuke Nishimatsu <42202095+wep21@users.noreply.github.com>
-* chore: add api maintainers (`#2361 <https://github.com/youtalk/autoware.universe/issues/2361>`_)
-* feat(component_state_monitor): add component state monitor (`#2120 <https://github.com/youtalk/autoware.universe/issues/2120>`_)
+* chore: add api maintainers (`#2361 <https://github.com/autowarefoundation/autoware.universe/issues/2361>`_)
+* feat(component_state_monitor): add component state monitor (`#2120 <https://github.com/autowarefoundation/autoware.universe/issues/2120>`_)
   * feat(component_state_monitor): add component state monitor
   * feat: change module
 * Contributors: Kenji Miyake, Kosuke Takeuchi, Takagi, Isamu, Tomohito ANDO, Vincent Richard, Yamato Ando, kminoda

--- a/system/default_ad_api_helpers/ad_api_adaptors/CHANGELOG.rst
+++ b/system/default_ad_api_helpers/ad_api_adaptors/CHANGELOG.rst
@@ -5,7 +5,7 @@ Changelog for package ad_api_adaptors
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* refactor(ad_api_adaptors): rework parameter (`#8796 <https://github.com/youtalk/autoware.universe/issues/8796>`_)
+* refactor(ad_api_adaptors): rework parameter (`#8796 <https://github.com/autowarefoundation/autoware.universe/issues/8796>`_)
   * refactor(ad_api_adaptors): rework parameter
   * <refactor(ad_api_adaptors): rework parameter>
   * ad_api_adaptors.schema.json
@@ -13,19 +13,19 @@ Changelog for package ad_api_adaptors
   * refactor(ad_api_adaptors): rework parameter
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* refactor(map_height_fitter)!: prefix package and namespace with autoware  (`#8421 <https://github.com/youtalk/autoware.universe/issues/8421>`_)
+* refactor(map_height_fitter)!: prefix package and namespace with autoware  (`#8421 <https://github.com/autowarefoundation/autoware.universe/issues/8421>`_)
   * add autoware\_ prefix
   * style(pre-commit): autofix
   * remove duplicated dependency
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: SakodaShintaro <shintaro.sakoda@tier4.jp>
-* feat(ad_api_adaptors): componentize nodes (`#7022 <https://github.com/youtalk/autoware.universe/issues/7022>`_)
+* feat(ad_api_adaptors): componentize nodes (`#7022 <https://github.com/autowarefoundation/autoware.universe/issues/7022>`_)
 * Contributors: Masaki Baba, Prakash Kannaiah, Takagi, Isamu, Yutaka Kondo
 
 0.26.0 (2024-04-03)
 -------------------
-* feat(map_height_fitter): fitting by vector_map (`#6340 <https://github.com/youtalk/autoware.universe/issues/6340>`_)
+* feat(map_height_fitter): fitting by vector_map (`#6340 <https://github.com/autowarefoundation/autoware.universe/issues/6340>`_)
   * Added fit_target
   * Fixed group
   * Fixed to run
@@ -49,22 +49,22 @@ Changelog for package ad_api_adaptors
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Takagi, Isamu <43976882+isamu-takagi@users.noreply.github.com>
-* chore: update api package maintainers (`#6086 <https://github.com/youtalk/autoware.universe/issues/6086>`_)
+* chore: update api package maintainers (`#6086 <https://github.com/autowarefoundation/autoware.universe/issues/6086>`_)
   * update api maintainers
   * fix
   ---------
-* chore(default_ad_api_helpers): update readme topic (`#5258 <https://github.com/youtalk/autoware.universe/issues/5258>`_)
+* chore(default_ad_api_helpers): update readme topic (`#5258 <https://github.com/autowarefoundation/autoware.universe/issues/5258>`_)
   * chore(default_ad_api_helpers): update readme topic
   * style(pre-commit): autofix
   * update readme
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat(map_height_fitter): add service node (`#4128 <https://github.com/youtalk/autoware.universe/issues/4128>`_)
+* feat(map_height_fitter): add service node (`#4128 <https://github.com/autowarefoundation/autoware.universe/issues/4128>`_)
   * add map height fitter node
   * fix response success
   ---------
-* docs(ad_api_adaptors): fix readme to remove unused service (`#4117 <https://github.com/youtalk/autoware.universe/issues/4117>`_)
-* build: mark autoware_cmake as <buildtool_depend> (`#3616 <https://github.com/youtalk/autoware.universe/issues/3616>`_)
+* docs(ad_api_adaptors): fix readme to remove unused service (`#4117 <https://github.com/autowarefoundation/autoware.universe/issues/4117>`_)
+* build: mark autoware_cmake as <buildtool_depend> (`#3616 <https://github.com/autowarefoundation/autoware.universe/issues/3616>`_)
   * build: mark autoware_cmake as <buildtool_depend>
   with <build_depend>, autoware_cmake is automatically exported with ament_target_dependencies() (unecessary)
   * style(pre-commit): autofix
@@ -72,16 +72,16 @@ Changelog for package ad_api_adaptors
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Kenji Miyake <kenji.miyake@tier4.jp>
-* feat(default_ad_api): add route change api (`#3197 <https://github.com/youtalk/autoware.universe/issues/3197>`_)
+* feat(default_ad_api): add route change api (`#3197 <https://github.com/autowarefoundation/autoware.universe/issues/3197>`_)
   * feat: add route change api
   * fix: reroute
   ---------
-* chore(default_ad_api): add yukkysaito and mitsudome-r to maintainer (`#3440 <https://github.com/youtalk/autoware.universe/issues/3440>`_)
+* chore(default_ad_api): add yukkysaito and mitsudome-r to maintainer (`#3440 <https://github.com/autowarefoundation/autoware.universe/issues/3440>`_)
   * chore(default_ad_api): add yukkysaito to maintainer
   * add mitsudome-r instead of kenji-miyake
   ---------
-* feat(default_ad_api_helpers): support goal modification for rviz (`#3370 <https://github.com/youtalk/autoware.universe/issues/3370>`_)
-* feat(map_height_fitter): change map height fitter to library (`#2724 <https://github.com/youtalk/autoware.universe/issues/2724>`_)
+* feat(default_ad_api_helpers): support goal modification for rviz (`#3370 <https://github.com/autowarefoundation/autoware.universe/issues/3370>`_)
+* feat(map_height_fitter): change map height fitter to library (`#2724 <https://github.com/autowarefoundation/autoware.universe/issues/2724>`_)
   * feat: move map height fitter
   * feat: remove map height fitter dependency
   * apply to initial pose adaptor
@@ -94,12 +94,12 @@ Changelog for package ad_api_adaptors
   This reverts commit 71250342305aad6ac3710625ab2ea1dfd3eca11a.
   * feat: add map fit log
   ---------
-* chore: add api maintainers (`#2361 <https://github.com/youtalk/autoware.universe/issues/2361>`_)
-* fix(ad_api_adaptors): fix to merge waypoint (`#2215 <https://github.com/youtalk/autoware.universe/issues/2215>`_)
+* chore: add api maintainers (`#2361 <https://github.com/autowarefoundation/autoware.universe/issues/2361>`_)
+* fix(ad_api_adaptors): fix to merge waypoint (`#2215 <https://github.com/autowarefoundation/autoware.universe/issues/2215>`_)
   * fix(ad_api_adaptors): fix to merge waypoint
   * fix(ad_api_adaptors): update comments and variable name
-* feat(autoware_ad_api_msgs): replace adapi message (`#1897 <https://github.com/youtalk/autoware.universe/issues/1897>`_)
-* feat(default_ad_api): add localization api  (`#1431 <https://github.com/youtalk/autoware.universe/issues/1431>`_)
+* feat(autoware_ad_api_msgs): replace adapi message (`#1897 <https://github.com/autowarefoundation/autoware.universe/issues/1897>`_)
+* feat(default_ad_api): add localization api  (`#1431 <https://github.com/autowarefoundation/autoware.universe/issues/1431>`_)
   * feat(default_ad_api): add localization api
   * docs: add readme
   * feat: add auto initial pose
@@ -119,7 +119,7 @@ Changelog for package ad_api_adaptors
   * fix: remove needless keyword
   * feat: change api helper node namespace
   * fix: fix launch file path
-* feat(default_ad_api): add routing api (`#1494 <https://github.com/youtalk/autoware.universe/issues/1494>`_)
+* feat(default_ad_api): add routing api (`#1494 <https://github.com/autowarefoundation/autoware.universe/issues/1494>`_)
   * feat(default_ad_api): add routing api
   * fix: build error
   * docs: add readme

--- a/system/default_ad_api_helpers/ad_api_visualizers/CHANGELOG.rst
+++ b/system/default_ad_api_helpers/ad_api_visualizers/CHANGELOG.rst
@@ -9,17 +9,17 @@ Changelog for package ad_api_visualizers
 
 0.26.0 (2024-04-03)
 -------------------
-* chore: update api package maintainers (`#6086 <https://github.com/youtalk/autoware.universe/issues/6086>`_)
+* chore: update api package maintainers (`#6086 <https://github.com/autowarefoundation/autoware.universe/issues/6086>`_)
   * update api maintainers
   * fix
   ---------
-* refactor(start_planner): rename pull out to start planner (`#3908 <https://github.com/youtalk/autoware.universe/issues/3908>`_)
-* refactor(behavior_path_planner): rename pull_over to goal_planner (`#3501 <https://github.com/youtalk/autoware.universe/issues/3501>`_)
-* chore(default_ad_api): add yukkysaito and mitsudome-r to maintainer (`#3440 <https://github.com/youtalk/autoware.universe/issues/3440>`_)
+* refactor(start_planner): rename pull out to start planner (`#3908 <https://github.com/autowarefoundation/autoware.universe/issues/3908>`_)
+* refactor(behavior_path_planner): rename pull_over to goal_planner (`#3501 <https://github.com/autowarefoundation/autoware.universe/issues/3501>`_)
+* chore(default_ad_api): add yukkysaito and mitsudome-r to maintainer (`#3440 <https://github.com/autowarefoundation/autoware.universe/issues/3440>`_)
   * chore(default_ad_api): add yukkysaito to maintainer
   * add mitsudome-r instead of kenji-miyake
   ---------
-* feat(default_ad_api): add planning api (`#2481 <https://github.com/youtalk/autoware.universe/issues/2481>`_)
+* feat(default_ad_api): add planning api (`#2481 <https://github.com/autowarefoundation/autoware.universe/issues/2481>`_)
   * feat(default_ad_api): add planning api
   * feat: complement velocity factor
   * feat: add stop check

--- a/system/default_ad_api_helpers/automatic_pose_initializer/CHANGELOG.rst
+++ b/system/default_ad_api_helpers/automatic_pose_initializer/CHANGELOG.rst
@@ -5,18 +5,18 @@ Changelog for package automatic_pose_initializer
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* fix(automatic_pose_initializer): fix plugin name (`#7035 <https://github.com/youtalk/autoware.universe/issues/7035>`_)
+* fix(automatic_pose_initializer): fix plugin name (`#7035 <https://github.com/autowarefoundation/autoware.universe/issues/7035>`_)
   Fixed automatic_pose_initializer plugin name
-* feat(automatic_pose_initializer): componentize node (`#7021 <https://github.com/youtalk/autoware.universe/issues/7021>`_)
+* feat(automatic_pose_initializer): componentize node (`#7021 <https://github.com/autowarefoundation/autoware.universe/issues/7021>`_)
 * Contributors: SakodaShintaro, Takagi, Isamu, Yutaka Kondo
 
 0.26.0 (2024-04-03)
 -------------------
-* chore: update api package maintainers (`#6086 <https://github.com/youtalk/autoware.universe/issues/6086>`_)
+* chore: update api package maintainers (`#6086 <https://github.com/autowarefoundation/autoware.universe/issues/6086>`_)
   * update api maintainers
   * fix
   ---------
-* build: mark autoware_cmake as <buildtool_depend> (`#3616 <https://github.com/youtalk/autoware.universe/issues/3616>`_)
+* build: mark autoware_cmake as <buildtool_depend> (`#3616 <https://github.com/autowarefoundation/autoware.universe/issues/3616>`_)
   * build: mark autoware_cmake as <buildtool_depend>
   with <build_depend>, autoware_cmake is automatically exported with ament_target_dependencies() (unecessary)
   * style(pre-commit): autofix
@@ -24,14 +24,14 @@ Changelog for package automatic_pose_initializer
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Kenji Miyake <kenji.miyake@tier4.jp>
-* chore(default_ad_api): add yukkysaito and mitsudome-r to maintainer (`#3440 <https://github.com/youtalk/autoware.universe/issues/3440>`_)
+* chore(default_ad_api): add yukkysaito and mitsudome-r to maintainer (`#3440 <https://github.com/autowarefoundation/autoware.universe/issues/3440>`_)
   * chore(default_ad_api): add yukkysaito to maintainer
   * add mitsudome-r instead of kenji-miyake
   ---------
-* chore: add api maintainers (`#2361 <https://github.com/youtalk/autoware.universe/issues/2361>`_)
-* feat(autoware_ad_api_msgs): replace adapi message (`#1897 <https://github.com/youtalk/autoware.universe/issues/1897>`_)
-* fix(automatic_pose_initializer): fix starvation (`#1756 <https://github.com/youtalk/autoware.universe/issues/1756>`_)
-* feat(default_ad_api): add localization api  (`#1431 <https://github.com/youtalk/autoware.universe/issues/1431>`_)
+* chore: add api maintainers (`#2361 <https://github.com/autowarefoundation/autoware.universe/issues/2361>`_)
+* feat(autoware_ad_api_msgs): replace adapi message (`#1897 <https://github.com/autowarefoundation/autoware.universe/issues/1897>`_)
+* fix(automatic_pose_initializer): fix starvation (`#1756 <https://github.com/autowarefoundation/autoware.universe/issues/1756>`_)
+* feat(default_ad_api): add localization api  (`#1431 <https://github.com/autowarefoundation/autoware.universe/issues/1431>`_)
   * feat(default_ad_api): add localization api
   * docs: add readme
   * feat: add auto initial pose

--- a/system/diagnostic_graph_aggregator/CHANGELOG.rst
+++ b/system/diagnostic_graph_aggregator/CHANGELOG.rst
@@ -5,57 +5,57 @@ Changelog for package diagnostic_graph_aggregator
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* fix(diagnostic_graph_aggregator): fix unusedFunction (`#8580 <https://github.com/youtalk/autoware.universe/issues/8580>`_)
+* fix(diagnostic_graph_aggregator): fix unusedFunction (`#8580 <https://github.com/autowarefoundation/autoware.universe/issues/8580>`_)
   fix: unusedFunction
   Co-authored-by: kobayu858 <129580202+kobayu858@users.noreply.github.com>
-* fix(diagnostic_graph_aggregator): fix noConstructor (`#8508 <https://github.com/youtalk/autoware.universe/issues/8508>`_)
+* fix(diagnostic_graph_aggregator): fix noConstructor (`#8508 <https://github.com/autowarefoundation/autoware.universe/issues/8508>`_)
   fix:noConstructor
-* fix(diagnostic_graph_aggregator): fix cppcheck warning of functionStatic (`#8266 <https://github.com/youtalk/autoware.universe/issues/8266>`_)
+* fix(diagnostic_graph_aggregator): fix cppcheck warning of functionStatic (`#8266 <https://github.com/autowarefoundation/autoware.universe/issues/8266>`_)
   * fix: deal with functionStatic warning
   * suppress warning by comment
   ---------
-* fix(diagnostic_graph_aggregator): fix uninitMemberVar (`#8313 <https://github.com/youtalk/autoware.universe/issues/8313>`_)
+* fix(diagnostic_graph_aggregator): fix uninitMemberVar (`#8313 <https://github.com/autowarefoundation/autoware.universe/issues/8313>`_)
   * fix:funinitMemberVar
   * fix:funinitMemberVar
   * fix:uninitMemberVar
   * fix:clang format
   ---------
-* fix(diagnostic_graph_aggregator): fix functionConst (`#8279 <https://github.com/youtalk/autoware.universe/issues/8279>`_)
+* fix(diagnostic_graph_aggregator): fix functionConst (`#8279 <https://github.com/autowarefoundation/autoware.universe/issues/8279>`_)
   * fix:functionConst
   * fix:functionConst
   * fix:clang format
   ---------
-* fix(diagnostic_graph_aggregator): fix constParameterReference (`#8054 <https://github.com/youtalk/autoware.universe/issues/8054>`_)
+* fix(diagnostic_graph_aggregator): fix constParameterReference (`#8054 <https://github.com/autowarefoundation/autoware.universe/issues/8054>`_)
   fix:constParameterReference
-* fix(diagnostic_graph_aggregator): fix constVariableReference (`#8062 <https://github.com/youtalk/autoware.universe/issues/8062>`_)
+* fix(diagnostic_graph_aggregator): fix constVariableReference (`#8062 <https://github.com/autowarefoundation/autoware.universe/issues/8062>`_)
   * fix:constVariableReference
   * fix:constVariableReference
   * fix:constVariableReference
   * fix:constVariableReference
   ---------
-* fix(diagnostic_graph_aggregator): fix shadowFunction (`#7838 <https://github.com/youtalk/autoware.universe/issues/7838>`_)
+* fix(diagnostic_graph_aggregator): fix shadowFunction (`#7838 <https://github.com/autowarefoundation/autoware.universe/issues/7838>`_)
   * fix(diagnostic_graph_aggregator): fix shadowFunction
   * feat: modify variable name
   ---------
   Co-authored-by: Takagi, Isamu <isamu.takagi@tier4.jp>
-* fix(diagnostic_graph_aggregator): fix uselessOverride warning (`#7768 <https://github.com/youtalk/autoware.universe/issues/7768>`_)
+* fix(diagnostic_graph_aggregator): fix uselessOverride warning (`#7768 <https://github.com/autowarefoundation/autoware.universe/issues/7768>`_)
   * fix(diagnostic_graph_aggregator): fix uselessOverride warning
   * restore and suppress inline
   * style(pre-commit): autofix
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* fix(diagnostic_graph_aggregator): fix shadowArgument warning in create_unit_config (`#7664 <https://github.com/youtalk/autoware.universe/issues/7664>`_)
-* feat(diagnostic_graph_aggregator): componentize node (`#7025 <https://github.com/youtalk/autoware.universe/issues/7025>`_)
-* fix(diagnostic_graph_aggregator): fix a bug where unit links were incorrectly updated (`#6932 <https://github.com/youtalk/autoware.universe/issues/6932>`_)
+* fix(diagnostic_graph_aggregator): fix shadowArgument warning in create_unit_config (`#7664 <https://github.com/autowarefoundation/autoware.universe/issues/7664>`_)
+* feat(diagnostic_graph_aggregator): componentize node (`#7025 <https://github.com/autowarefoundation/autoware.universe/issues/7025>`_)
+* fix(diagnostic_graph_aggregator): fix a bug where unit links were incorrectly updated (`#6932 <https://github.com/autowarefoundation/autoware.universe/issues/6932>`_)
   fix(diagnostic_graph_aggregator): fix unit link filter
-* feat: remake diagnostic graph packages (`#6715 <https://github.com/youtalk/autoware.universe/issues/6715>`_)
+* feat: remake diagnostic graph packages (`#6715 <https://github.com/autowarefoundation/autoware.universe/issues/6715>`_)
 * Contributors: Hayate TOBA, Koichi98, Ryuta Kambe, Takagi, Isamu, Yutaka Kondo, kobayu858, taisa1
 
 0.26.0 (2024-04-03)
 -------------------
-* feat(diagnostic_graph_aggregator): update tools (`#6614 <https://github.com/youtalk/autoware.universe/issues/6614>`_)
-* docs(diagnostic_graph_aggregator): update documents (`#6613 <https://github.com/youtalk/autoware.universe/issues/6613>`_)
-* feat(diagnostic_graph_aggregator): add dump tool (`#6427 <https://github.com/youtalk/autoware.universe/issues/6427>`_)
-* feat(diagnostic_graph_aggregator): change default publish rate (`#5872 <https://github.com/youtalk/autoware.universe/issues/5872>`_)
-* feat(diagnostic_graph_aggregator): rename system_diagnostic_graph package (`#5827 <https://github.com/youtalk/autoware.universe/issues/5827>`_)
+* feat(diagnostic_graph_aggregator): update tools (`#6614 <https://github.com/autowarefoundation/autoware.universe/issues/6614>`_)
+* docs(diagnostic_graph_aggregator): update documents (`#6613 <https://github.com/autowarefoundation/autoware.universe/issues/6613>`_)
+* feat(diagnostic_graph_aggregator): add dump tool (`#6427 <https://github.com/autowarefoundation/autoware.universe/issues/6427>`_)
+* feat(diagnostic_graph_aggregator): change default publish rate (`#5872 <https://github.com/autowarefoundation/autoware.universe/issues/5872>`_)
+* feat(diagnostic_graph_aggregator): rename system_diagnostic_graph package (`#5827 <https://github.com/autowarefoundation/autoware.universe/issues/5827>`_)
 * Contributors: Takagi, Isamu

--- a/system/diagnostic_graph_utils/CHANGELOG.rst
+++ b/system/diagnostic_graph_utils/CHANGELOG.rst
@@ -5,10 +5,10 @@ Changelog for package diagnostic_graph_utils
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* feat(static_centerline_generator): organize AUTO/GUI/VMB modes (`#7432 <https://github.com/youtalk/autoware.universe/issues/7432>`_)
-* feat(diagnostic_graph_utils): componentize node (`#7189 <https://github.com/youtalk/autoware.universe/issues/7189>`_)
-* feat(default_ad_api): add diagnostics api (`#7052 <https://github.com/youtalk/autoware.universe/issues/7052>`_)
-* feat: remake diagnostic graph packages (`#6715 <https://github.com/youtalk/autoware.universe/issues/6715>`_)
+* feat(static_centerline_generator): organize AUTO/GUI/VMB modes (`#7432 <https://github.com/autowarefoundation/autoware.universe/issues/7432>`_)
+* feat(diagnostic_graph_utils): componentize node (`#7189 <https://github.com/autowarefoundation/autoware.universe/issues/7189>`_)
+* feat(default_ad_api): add diagnostics api (`#7052 <https://github.com/autowarefoundation/autoware.universe/issues/7052>`_)
+* feat: remake diagnostic graph packages (`#6715 <https://github.com/autowarefoundation/autoware.universe/issues/6715>`_)
 * Contributors: Takagi, Isamu, Takayuki Murooka, Yutaka Kondo
 
 0.26.0 (2024-04-03)

--- a/system/dummy_diag_publisher/CHANGELOG.rst
+++ b/system/dummy_diag_publisher/CHANGELOG.rst
@@ -5,25 +5,25 @@ Changelog for package dummy_diag_publisher
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/youtalk/autoware.universe/issues/7594>`_)
-* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/youtalk/autoware.universe/issues/7538>`_)
+* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/autowarefoundation/autoware.universe/issues/7594>`_)
+* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/autowarefoundation/autoware.universe/issues/7538>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* feat(dummy_diag_publisher): componentize node (`#7190 <https://github.com/youtalk/autoware.universe/issues/7190>`_)
+* feat(dummy_diag_publisher): componentize node (`#7190 <https://github.com/autowarefoundation/autoware.universe/issues/7190>`_)
 * Contributors: Kosuke Takeuchi, Takagi, Isamu, Takayuki Murooka, Yutaka Kondo
 
 0.26.0 (2024-04-03)
 -------------------
-* chore: update maintainer (`#5730 <https://github.com/youtalk/autoware.universe/issues/5730>`_)
+* chore: update maintainer (`#5730 <https://github.com/autowarefoundation/autoware.universe/issues/5730>`_)
   update maintainer
-* chore: update maintainer (`#4140 <https://github.com/youtalk/autoware.universe/issues/4140>`_)
+* chore: update maintainer (`#4140 <https://github.com/autowarefoundation/autoware.universe/issues/4140>`_)
   Co-authored-by: Ryohsuke Mitsudome <43976834+mitsudome-r@users.noreply.github.com>
-* style: fix typos (`#3617 <https://github.com/youtalk/autoware.universe/issues/3617>`_)
+* style: fix typos (`#3617 <https://github.com/autowarefoundation/autoware.universe/issues/3617>`_)
   * style: fix typos in documents
   * style: fix typos in package.xml
   * style: fix typos in launch files
   * style: fix typos in comments
   ---------
-* build: mark autoware_cmake as <buildtool_depend> (`#3616 <https://github.com/youtalk/autoware.universe/issues/3616>`_)
+* build: mark autoware_cmake as <buildtool_depend> (`#3616 <https://github.com/autowarefoundation/autoware.universe/issues/3616>`_)
   * build: mark autoware_cmake as <buildtool_depend>
   with <build_depend>, autoware_cmake is automatically exported with ament_target_dependencies() (unecessary)
   * style(pre-commit): autofix
@@ -31,13 +31,13 @@ Changelog for package dummy_diag_publisher
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Kenji Miyake <kenji.miyake@tier4.jp>
-* chore: sync files (`#3227 <https://github.com/youtalk/autoware.universe/issues/3227>`_)
+* chore: sync files (`#3227 <https://github.com/autowarefoundation/autoware.universe/issues/3227>`_)
   * chore: sync files
   * style(pre-commit): autofix
   ---------
   Co-authored-by: kenji-miyake <kenji-miyake@users.noreply.github.com>
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat(dummy diag publisher): change diag name specification method to YAML (`#2840 <https://github.com/youtalk/autoware.universe/issues/2840>`_)
+* feat(dummy diag publisher): change diag name specification method to YAML (`#2840 <https://github.com/autowarefoundation/autoware.universe/issues/2840>`_)
   * Signed-off-by: asana17 <akihiro.sakurai@tier4.jp>
   modified dummy_diag_publisher to use YAML for param
   * Signed-off-by: asana17 <akihiro.sakurai@tier4.jp>
@@ -48,24 +48,24 @@ Changelog for package dummy_diag_publisher
   * add pkg maintainer
   * launch dummy_diag_publisher by launch_dummy_diag_publisher param
   ---------
-* chore: upgrade cmake_minimum_required to 3.14 (`#856 <https://github.com/youtalk/autoware.universe/issues/856>`_)
-* refactor: use autoware cmake (`#849 <https://github.com/youtalk/autoware.universe/issues/849>`_)
+* chore: upgrade cmake_minimum_required to 3.14 (`#856 <https://github.com/autowarefoundation/autoware.universe/issues/856>`_)
+* refactor: use autoware cmake (`#849 <https://github.com/autowarefoundation/autoware.universe/issues/849>`_)
   * remove autoware_auto_cmake
   * add build_depend of autoware_cmake
   * use autoware_cmake in CMakeLists.txt
   * fix bugs
   * fix cmake lint errors
-* fix(dummy_diag_publisher): modify build error in rolling (`#760 <https://github.com/youtalk/autoware.universe/issues/760>`_)
-* feat(dummy_diag_publisher): use as a component (`#652 <https://github.com/youtalk/autoware.universe/issues/652>`_)
+* fix(dummy_diag_publisher): modify build error in rolling (`#760 <https://github.com/autowarefoundation/autoware.universe/issues/760>`_)
+* feat(dummy_diag_publisher): use as a component (`#652 <https://github.com/autowarefoundation/autoware.universe/issues/652>`_)
   * feat(dummy_diag_publisher): use as components
   * fix: add explicit
   * fix: fix node name
-* fix(dummy_diag_publisher): use anon to make unique node name instead of diag name (`#639 <https://github.com/youtalk/autoware.universe/issues/639>`_)
-* ci(pre-commit): update pre-commit-hooks-ros (`#625 <https://github.com/youtalk/autoware.universe/issues/625>`_)
+* fix(dummy_diag_publisher): use anon to make unique node name instead of diag name (`#639 <https://github.com/autowarefoundation/autoware.universe/issues/639>`_)
+* ci(pre-commit): update pre-commit-hooks-ros (`#625 <https://github.com/autowarefoundation/autoware.universe/issues/625>`_)
   * ci(pre-commit): update pre-commit-hooks-ros
   * ci(pre-commit): autofix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* chore(dummy_diag_publisher): update README and launch file (`#536 <https://github.com/youtalk/autoware.universe/issues/536>`_)
+* chore(dummy_diag_publisher): update README and launch file (`#536 <https://github.com/autowarefoundation/autoware.universe/issues/536>`_)
   * chore: update README
   * feat: add param in launch
   * chore: Update system/dummy_diag_publisher/README.md
@@ -74,12 +74,12 @@ Changelog for package dummy_diag_publisher
   * ci(pre-commit): autofix
   Co-authored-by: Kenji Miyake <31987104+kenji-miyake@users.noreply.github.com>
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* chore(dummy_diag_publisher): add exec_depend (`#523 <https://github.com/youtalk/autoware.universe/issues/523>`_)
+* chore(dummy_diag_publisher): add exec_depend (`#523 <https://github.com/autowarefoundation/autoware.universe/issues/523>`_)
   * chore(dummy_diag_publisher): add exec_depend
   * Update system/dummy_diag_publisher/package.xml
   Co-authored-by: Kenji Miyake <31987104+kenji-miyake@users.noreply.github.com>
   Co-authored-by: Kenji Miyake <31987104+kenji-miyake@users.noreply.github.com>
-* chore: replace legacy timer (`#329 <https://github.com/youtalk/autoware.universe/issues/329>`_)
+* chore: replace legacy timer (`#329 <https://github.com/autowarefoundation/autoware.universe/issues/329>`_)
   * chore(goal_distance_calculator): replace legacy timer
   * chore(path_distance_calculator): replace legacy timer
   * chore(control_performance_analysis): replace legacy timer
@@ -114,7 +114,7 @@ Changelog for package dummy_diag_publisher
   * chore(external_cmd_converter): replace legacy timer
   * chore(pacmod_interface): replace legacy timer
   * chore(lint): apply pre-commit
-* feat: rename existing packages name starting with autoware to different names (`#180 <https://github.com/youtalk/autoware.universe/issues/180>`_)
+* feat: rename existing packages name starting with autoware to different names (`#180 <https://github.com/autowarefoundation/autoware.universe/issues/180>`_)
   * autoware_api_utils -> tier4_api_utils
   * autoware_debug_tools -> tier4_debug_tools
   * autoware_error_monitor -> system_error_monitor
@@ -131,14 +131,14 @@ Changelog for package dummy_diag_publisher
   * fix ad_service_state_monitor
   * ci(pre-commit): autofix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat: add dummy_diag_publisher package (`#18 <https://github.com/youtalk/autoware.universe/issues/18>`_)
+* feat: add dummy_diag_publisher package (`#18 <https://github.com/autowarefoundation/autoware.universe/issues/18>`_)
   * release v0.4.0
   * remove ROS1 packages temporarily
   * Revert "remove ROS1 packages temporarily"
   This reverts commit 6ab6bcca1dea5065fcb06aeec107538dad1f62af.
   * add COLCON_IGNORE to ros1 packages
-  * Rename launch files to launch.xml (`#28 <https://github.com/youtalk/autoware.universe/issues/28>`_)
-  * ROS2 Porting: dummy_diag_publisher (`#69 <https://github.com/youtalk/autoware.universe/issues/69>`_)
+  * Rename launch files to launch.xml (`#28 <https://github.com/autowarefoundation/autoware.universe/issues/28>`_)
+  * ROS2 Porting: dummy_diag_publisher (`#69 <https://github.com/autowarefoundation/autoware.universe/issues/69>`_)
   * Fix CMake, package.xml and remove COLCON_IGNORE
   * First pass
   - Remove ROS references: dynamic_configuration
@@ -163,39 +163,39 @@ Changelog for package dummy_diag_publisher
   * Address PR comment:
   - Remove headers specification
   Co-authored-by: Ryohsuke Mitsudome <43976834+mitsudome-r@users.noreply.github.com>
-  * Rename h files to hpp (`#142 <https://github.com/youtalk/autoware.universe/issues/142>`_)
+  * Rename h files to hpp (`#142 <https://github.com/autowarefoundation/autoware.universe/issues/142>`_)
   * Change includes
   * Rename files
   * Adjustments to make things compile
   * Other packages
-  * Adjust copyright notice on 532 out of 699 source files (`#143 <https://github.com/youtalk/autoware.universe/issues/143>`_)
-  * Use quotes for includes where appropriate (`#144 <https://github.com/youtalk/autoware.universe/issues/144>`_)
+  * Adjust copyright notice on 532 out of 699 source files (`#143 <https://github.com/autowarefoundation/autoware.universe/issues/143>`_)
+  * Use quotes for includes where appropriate (`#144 <https://github.com/autowarefoundation/autoware.universe/issues/144>`_)
   * Use quotes for includes where appropriate
   * Fix lint tests
   * Make tests pass hopefully
-  * Run uncrustify on the entire Pilot.Auto codebase (`#151 <https://github.com/youtalk/autoware.universe/issues/151>`_)
+  * Run uncrustify on the entire Pilot.Auto codebase (`#151 <https://github.com/autowarefoundation/autoware.universe/issues/151>`_)
   * Run uncrustify on the entire Pilot.Auto codebase
   * Exclude open PRs
-  * Add linters (`#208 <https://github.com/youtalk/autoware.universe/issues/208>`_)
-  * Rename ROS-related .yaml to .param.yaml (`#352 <https://github.com/youtalk/autoware.universe/issues/352>`_)
+  * Add linters (`#208 <https://github.com/autowarefoundation/autoware.universe/issues/208>`_)
+  * Rename ROS-related .yaml to .param.yaml (`#352 <https://github.com/autowarefoundation/autoware.universe/issues/352>`_)
   * Rename ROS-related .yaml to .param.yaml
   * Remove prefix 'default\_' of yaml files
   * Rename vehicle_info.yaml to vehicle_info.param.yaml
   * Rename diagnostic_aggregator's param files
   * Fix overlooked parameters
-  * add use_sim-time option (`#454 <https://github.com/youtalk/autoware.universe/issues/454>`_)
-  * Fix for rolling (`#1226 <https://github.com/youtalk/autoware.universe/issues/1226>`_)
+  * add use_sim-time option (`#454 <https://github.com/autowarefoundation/autoware.universe/issues/454>`_)
+  * Fix for rolling (`#1226 <https://github.com/autowarefoundation/autoware.universe/issues/1226>`_)
   * Replace doc by description
   * Replace ns by push-ros-namespace
-  * Remove use_sim_time for set_parameter (`#1260 <https://github.com/youtalk/autoware.universe/issues/1260>`_)
-  * Cleanup dummy_diag_publisher (`#1392 <https://github.com/youtalk/autoware.universe/issues/1392>`_)
+  * Remove use_sim_time for set_parameter (`#1260 <https://github.com/autowarefoundation/autoware.universe/issues/1260>`_)
+  * Cleanup dummy_diag_publisher (`#1392 <https://github.com/autowarefoundation/autoware.universe/issues/1392>`_)
   * Cleanup dummy_diag_publisher
   * Fix typo
   * Make double and write comment
   * Set hardware_id from diag_name
   * Add const to daig_name and hardware_id
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-  * suppress warnings for declare parameters (`#1724 <https://github.com/youtalk/autoware.universe/issues/1724>`_)
+  * suppress warnings for declare parameters (`#1724 <https://github.com/autowarefoundation/autoware.universe/issues/1724>`_)
   * fix for lanelet2_extension
   * fix for traffic light ssd fine detector
   * fix for topic_state_monitor
@@ -214,15 +214,15 @@ Changelog for package dummy_diag_publisher
   * add Werror
   * add Werror
   * fix style
-  * Fix -Wunused-parameter (`#1836 <https://github.com/youtalk/autoware.universe/issues/1836>`_)
+  * Fix -Wunused-parameter (`#1836 <https://github.com/autowarefoundation/autoware.universe/issues/1836>`_)
   * Fix -Wunused-parameter
   * Fix mistake
   * fix spell
   * Fix lint issues
   * Ignore flake8 warnings
   Co-authored-by: Hiroki OTA <hiroki.ota@tier4.jp>
-  * Fix typo `obstacle_crush` to `obstacle_crash` (`#2031 <https://github.com/youtalk/autoware.universe/issues/2031>`_)
-  * add sort-package-xml hook in pre-commit (`#1881 <https://github.com/youtalk/autoware.universe/issues/1881>`_)
+  * Fix typo `obstacle_crush` to `obstacle_crash` (`#2031 <https://github.com/autowarefoundation/autoware.universe/issues/2031>`_)
+  * add sort-package-xml hook in pre-commit (`#1881 <https://github.com/autowarefoundation/autoware.universe/issues/1881>`_)
   * add sort xml hook in pre-commit
   * change retval to exit_status
   * rename
@@ -236,10 +236,10 @@ Changelog for package dummy_diag_publisher
   * move prettier-xml to pre-commit-hooks-ros
   * update version for bug-fix
   * apply pre-commit
-  * Refactor dummy_diag_publisher (`#2151 <https://github.com/youtalk/autoware.universe/issues/2151>`_)
+  * Refactor dummy_diag_publisher (`#2151 <https://github.com/autowarefoundation/autoware.universe/issues/2151>`_)
   * Refactor dummy_diag_publisher
   * fix depend order
-  * Change formatter to clang-format and black (`#2332 <https://github.com/youtalk/autoware.universe/issues/2332>`_)
+  * Change formatter to clang-format and black (`#2332 <https://github.com/autowarefoundation/autoware.universe/issues/2332>`_)
   * Revert "Temporarily comment out pre-commit hooks"
   This reverts commit 748e9cdb145ce12f8b520bcbd97f5ff899fc28a3.
   * Replace ament_lint_common with autoware_lint_common
@@ -251,9 +251,9 @@ Changelog for package dummy_diag_publisher
   * Fix include double quotes to angle brackets
   * Apply clang-format
   * Fix build errors
-  * Add COLCON_IGNORE (`#500 <https://github.com/youtalk/autoware.universe/issues/500>`_)
-  * remove COLCON_IGNORE in dummy_diag_publisher (`#528 <https://github.com/youtalk/autoware.universe/issues/528>`_)
-  * add README in dummy diag publisher (`#627 <https://github.com/youtalk/autoware.universe/issues/627>`_)
+  * Add COLCON_IGNORE (`#500 <https://github.com/autowarefoundation/autoware.universe/issues/500>`_)
+  * remove COLCON_IGNORE in dummy_diag_publisher (`#528 <https://github.com/autowarefoundation/autoware.universe/issues/528>`_)
+  * add README in dummy diag publisher (`#627 <https://github.com/autowarefoundation/autoware.universe/issues/627>`_)
   Co-authored-by: mitsudome-r <ryohsuke.mitsudome@tier4.jp>
   Co-authored-by: Nikolai Morin <nnmmgit@gmail.com>
   Co-authored-by: Jilada Eccleston <jilada.eccleston@gmail.com>

--- a/system/dummy_infrastructure/CHANGELOG.rst
+++ b/system/dummy_infrastructure/CHANGELOG.rst
@@ -5,14 +5,14 @@ Changelog for package dummy_infrastructure
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* refactor(dummy_infrastructure): rework parameters (`#5275 <https://github.com/youtalk/autoware.universe/issues/5275>`_)
+* refactor(dummy_infrastructure): rework parameters (`#5275 <https://github.com/autowarefoundation/autoware.universe/issues/5275>`_)
 * Contributors: Yuntianyi Chen, Yutaka Kondo
 
 0.26.0 (2024-04-03)
 -------------------
-* chore: update maintainer (`#4140 <https://github.com/youtalk/autoware.universe/issues/4140>`_)
+* chore: update maintainer (`#4140 <https://github.com/autowarefoundation/autoware.universe/issues/4140>`_)
   Co-authored-by: Ryohsuke Mitsudome <43976834+mitsudome-r@users.noreply.github.com>
-* build: mark autoware_cmake as <buildtool_depend> (`#3616 <https://github.com/youtalk/autoware.universe/issues/3616>`_)
+* build: mark autoware_cmake as <buildtool_depend> (`#3616 <https://github.com/autowarefoundation/autoware.universe/issues/3616>`_)
   * build: mark autoware_cmake as <buildtool_depend>
   with <build_depend>, autoware_cmake is automatically exported with ament_target_dependencies() (unecessary)
   * style(pre-commit): autofix
@@ -20,24 +20,24 @@ Changelog for package dummy_infrastructure
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Kenji Miyake <kenji.miyake@tier4.jp>
-* build(dummy_infrastructure): add build dependency (`#2739 <https://github.com/youtalk/autoware.universe/issues/2739>`_)
-* feat(dummy_infrastructure): change to multiple virtual signal state outputs (`#1717 <https://github.com/youtalk/autoware.universe/issues/1717>`_)
+* build(dummy_infrastructure): add build dependency (`#2739 <https://github.com/autowarefoundation/autoware.universe/issues/2739>`_)
+* feat(dummy_infrastructure): change to multiple virtual signal state outputs (`#1717 <https://github.com/autowarefoundation/autoware.universe/issues/1717>`_)
   * Added parameter to dummy_infrastructure.param.yaml
   * Modified dummy infrastructure
   * Modified dummy infrastructure for multiple commands
   * update dummy_infrastructure
-* chore: upgrade cmake_minimum_required to 3.14 (`#856 <https://github.com/youtalk/autoware.universe/issues/856>`_)
-* refactor: use autoware cmake (`#849 <https://github.com/youtalk/autoware.universe/issues/849>`_)
+* chore: upgrade cmake_minimum_required to 3.14 (`#856 <https://github.com/autowarefoundation/autoware.universe/issues/856>`_)
+* refactor: use autoware cmake (`#849 <https://github.com/autowarefoundation/autoware.universe/issues/849>`_)
   * remove autoware_auto_cmake
   * add build_depend of autoware_cmake
   * use autoware_cmake in CMakeLists.txt
   * fix bugs
   * fix cmake lint errors
-* ci(pre-commit): update pre-commit-hooks-ros (`#625 <https://github.com/youtalk/autoware.universe/issues/625>`_)
+* ci(pre-commit): update pre-commit-hooks-ros (`#625 <https://github.com/autowarefoundation/autoware.universe/issues/625>`_)
   * ci(pre-commit): update pre-commit-hooks-ros
   * ci(pre-commit): autofix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* ci: check include guard (`#438 <https://github.com/youtalk/autoware.universe/issues/438>`_)
+* ci: check include guard (`#438 <https://github.com/autowarefoundation/autoware.universe/issues/438>`_)
   * ci: check include guard
   * apply pre-commit
   * Update .pre-commit-config.yaml
@@ -45,7 +45,7 @@ Changelog for package dummy_infrastructure
   * fix: pre-commit
   Co-authored-by: Kenji Miyake <kenji.miyake@tier4.jp>
   Co-authored-by: Kenji Miyake <31987104+kenji-miyake@users.noreply.github.com>
-* feat: change pachage name: autoware_msgs -> tier4_msgs (`#150 <https://github.com/youtalk/autoware.universe/issues/150>`_)
+* feat: change pachage name: autoware_msgs -> tier4_msgs (`#150 <https://github.com/autowarefoundation/autoware.universe/issues/150>`_)
   * change pkg name: autoware\_*_msgs -> tier\_*_msgs
   * ci(pre-commit): autofix
   * autoware_external_api_msgs -> tier4_external_api_msgs
@@ -53,9 +53,9 @@ Changelog for package dummy_infrastructure
   * fix description
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Takeshi Miura <57553950+1222-takeshi@users.noreply.github.com>
-* feat: add dummy_infrastructure package (`#19 <https://github.com/youtalk/autoware.universe/issues/19>`_)
-  * Feature/add virtual traffic light planner (`#1588 <https://github.com/youtalk/autoware.universe/issues/1588>`_)
-  * Change formatter to clang-format and black (`#2332 <https://github.com/youtalk/autoware.universe/issues/2332>`_)
+* feat: add dummy_infrastructure package (`#19 <https://github.com/autowarefoundation/autoware.universe/issues/19>`_)
+  * Feature/add virtual traffic light planner (`#1588 <https://github.com/autowarefoundation/autoware.universe/issues/1588>`_)
+  * Change formatter to clang-format and black (`#2332 <https://github.com/autowarefoundation/autoware.universe/issues/2332>`_)
   * Revert "Temporarily comment out pre-commit hooks"
   This reverts commit 748e9cdb145ce12f8b520bcbd97f5ff899fc28a3.
   * Replace ament_lint_common with autoware_lint_common
@@ -67,9 +67,9 @@ Changelog for package dummy_infrastructure
   * Fix include double quotes to angle brackets
   * Apply clang-format
   * Fix build errors
-  * Add COLCON_IGNORE (`#500 <https://github.com/youtalk/autoware.universe/issues/500>`_)
-  * delete COLCON_IGNORE (`#540 <https://github.com/youtalk/autoware.universe/issues/540>`_)
-  * add readme [dummy infrastructure] (`#693 <https://github.com/youtalk/autoware.universe/issues/693>`_)
+  * Add COLCON_IGNORE (`#500 <https://github.com/autowarefoundation/autoware.universe/issues/500>`_)
+  * delete COLCON_IGNORE (`#540 <https://github.com/autowarefoundation/autoware.universe/issues/540>`_)
+  * add readme [dummy infrastructure] (`#693 <https://github.com/autowarefoundation/autoware.universe/issues/693>`_)
   * add readme dummy infra
   * fix lint
   * update readme

--- a/system/duplicated_node_checker/CHANGELOG.rst
+++ b/system/duplicated_node_checker/CHANGELOG.rst
@@ -5,10 +5,10 @@ Changelog for package duplicated_node_checker
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* fix(duplicated_node_checker): fix unusedFunction (`#8579 <https://github.com/youtalk/autoware.universe/issues/8579>`_)
+* fix(duplicated_node_checker): fix unusedFunction (`#8579 <https://github.com/autowarefoundation/autoware.universe/issues/8579>`_)
   fix: unusedFunction
   Co-authored-by: kobayu858 <129580202+kobayu858@users.noreply.github.com>
-* feat(duplicated_node_checker): add duplicate nodes to ignore (`#7959 <https://github.com/youtalk/autoware.universe/issues/7959>`_)
+* feat(duplicated_node_checker): add duplicate nodes to ignore (`#7959 <https://github.com/autowarefoundation/autoware.universe/issues/7959>`_)
   * feat: add duplicate nodes to ignore
   * remove talker
   * newline
@@ -21,12 +21,12 @@ Changelog for package duplicated_node_checker
 
 0.26.0 (2024-04-03)
 -------------------
-* chore(duplicate_node_checker): print duplication name (`#6488 <https://github.com/youtalk/autoware.universe/issues/6488>`_)
-* feat(duplicated_node_checker): add duplicated node names to msg (`#5382 <https://github.com/youtalk/autoware.universe/issues/5382>`_)
+* chore(duplicate_node_checker): print duplication name (`#6488 <https://github.com/autowarefoundation/autoware.universe/issues/6488>`_)
+* feat(duplicated_node_checker): add duplicated node names to msg (`#5382 <https://github.com/autowarefoundation/autoware.universe/issues/5382>`_)
   * add duplicated node names to msg
   * align with launcher repository
   ---------
-* feat(duplicated_node_checker): add packages to check duplication of node names in ros2 (`#5286 <https://github.com/youtalk/autoware.universe/issues/5286>`_)
+* feat(duplicated_node_checker): add packages to check duplication of node names in ros2 (`#5286 <https://github.com/autowarefoundation/autoware.universe/issues/5286>`_)
   * add implementation for duplicated node checking
   * update the default parameters of system_error_monitor to include results from duplication check
   * style(pre-commit): autofix

--- a/system/hazard_status_converter/CHANGELOG.rst
+++ b/system/hazard_status_converter/CHANGELOG.rst
@@ -5,12 +5,12 @@ Changelog for package hazard_status_converter
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* feat!: replace autoware_auto_msgs with autoware_msgs for system modules (`#7249 <https://github.com/youtalk/autoware.universe/issues/7249>`_)
+* feat!: replace autoware_auto_msgs with autoware_msgs for system modules (`#7249 <https://github.com/autowarefoundation/autoware.universe/issues/7249>`_)
   Co-authored-by: Cynthia Liu <cynthia.liu@autocore.ai>
   Co-authored-by: NorahXiong <norah.xiong@autocore.ai>
   Co-authored-by: beginningfan <beginning.fan@autocore.ai>
-* feat: remake diagnostic graph packages (`#6715 <https://github.com/youtalk/autoware.universe/issues/6715>`_)
-* fix(hazard_status_converter): check current operation mode (`#6733 <https://github.com/youtalk/autoware.universe/issues/6733>`_)
+* feat: remake diagnostic graph packages (`#6715 <https://github.com/autowarefoundation/autoware.universe/issues/6715>`_)
+* fix(hazard_status_converter): check current operation mode (`#6733 <https://github.com/autowarefoundation/autoware.universe/issues/6733>`_)
   * fix: hazard status converter
   * fix: topic name and modes
   * fix check target mode
@@ -22,6 +22,6 @@ Changelog for package hazard_status_converter
 
 0.26.0 (2024-04-03)
 -------------------
-* feat(tier4_system_launch): add option to launch mrm handler (`#6660 <https://github.com/youtalk/autoware.universe/issues/6660>`_)
-* feat(hazard_status_converter): add package (`#6428 <https://github.com/youtalk/autoware.universe/issues/6428>`_)
+* feat(tier4_system_launch): add option to launch mrm handler (`#6660 <https://github.com/autowarefoundation/autoware.universe/issues/6660>`_)
+* feat(hazard_status_converter): add package (`#6428 <https://github.com/autowarefoundation/autoware.universe/issues/6428>`_)
 * Contributors: Takagi, Isamu

--- a/system/mrm_comfortable_stop_operator/CHANGELOG.rst
+++ b/system/mrm_comfortable_stop_operator/CHANGELOG.rst
@@ -5,20 +5,20 @@ Changelog for package mrm_comfortable_stop_operator
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* chore(mrm_comfortable_stop_operator): remove unused main file (`#7191 <https://github.com/youtalk/autoware.universe/issues/7191>`_)
+* chore(mrm_comfortable_stop_operator): remove unused main file (`#7191 <https://github.com/autowarefoundation/autoware.universe/issues/7191>`_)
 * Contributors: Takagi, Isamu, Yutaka Kondo
 
 0.26.0 (2024-04-03)
 -------------------
-* chore(mrm_emergency_stop_operator): add a maintainer for mrm operator… (`#3489 <https://github.com/youtalk/autoware.universe/issues/3489>`_)
+* chore(mrm_emergency_stop_operator): add a maintainer for mrm operator… (`#3489 <https://github.com/autowarefoundation/autoware.universe/issues/3489>`_)
   chore(mrm_emergency_stop_operator): add a maintainer for mrm operator packages
-* style: fix typos (`#3617 <https://github.com/youtalk/autoware.universe/issues/3617>`_)
+* style: fix typos (`#3617 <https://github.com/autowarefoundation/autoware.universe/issues/3617>`_)
   * style: fix typos in documents
   * style: fix typos in package.xml
   * style: fix typos in launch files
   * style: fix typos in comments
   ---------
-* build: mark autoware_cmake as <buildtool_depend> (`#3616 <https://github.com/youtalk/autoware.universe/issues/3616>`_)
+* build: mark autoware_cmake as <buildtool_depend> (`#3616 <https://github.com/autowarefoundation/autoware.universe/issues/3616>`_)
   * build: mark autoware_cmake as <buildtool_depend>
   with <build_depend>, autoware_cmake is automatically exported with ament_target_dependencies() (unecessary)
   * style(pre-commit): autofix
@@ -26,19 +26,19 @@ Changelog for package mrm_comfortable_stop_operator
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Kenji Miyake <kenji.miyake@tier4.jp>
-* chore: sync files (`#3227 <https://github.com/youtalk/autoware.universe/issues/3227>`_)
+* chore: sync files (`#3227 <https://github.com/autowarefoundation/autoware.universe/issues/3227>`_)
   * chore: sync files
   * style(pre-commit): autofix
   ---------
   Co-authored-by: kenji-miyake <kenji-miyake@users.noreply.github.com>
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* fix(mrm_emergency_stop_operator): fix parameter loading in mrm operators (`#2378 <https://github.com/youtalk/autoware.universe/issues/2378>`_)
+* fix(mrm_emergency_stop_operator): fix parameter loading in mrm operators (`#2378 <https://github.com/autowarefoundation/autoware.universe/issues/2378>`_)
   * fix(mrm_emergency_stop_operator): fix parameter loading in mrm operators
   * ci(pre-commit): autofix
   * fix(mrm_emergency_stop_operator): remove os import
   * fix(mrm_emergency_stop_operator): remove unused packages
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat(emergency_handler): add a selector for multiple MRM behaviors (`#2070 <https://github.com/youtalk/autoware.universe/issues/2070>`_)
+* feat(emergency_handler): add a selector for multiple MRM behaviors (`#2070 <https://github.com/autowarefoundation/autoware.universe/issues/2070>`_)
   * feat(emergency_handler): add mrm command and status publishers
   * feat(autoware_ad_api_msgs): define mrm operation srv and mrm status msg
   * feat(emergency_handler): add mrm clients and subscribers

--- a/system/mrm_emergency_stop_operator/CHANGELOG.rst
+++ b/system/mrm_emergency_stop_operator/CHANGELOG.rst
@@ -5,29 +5,29 @@ Changelog for package mrm_emergency_stop_operator
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/youtalk/autoware.universe/issues/7594>`_)
-* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/youtalk/autoware.universe/issues/7538>`_)
+* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/autowarefoundation/autoware.universe/issues/7594>`_)
+* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/autowarefoundation/autoware.universe/issues/7538>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* feat!: replace autoware_auto_msgs with autoware_msgs for system modules (`#7249 <https://github.com/youtalk/autoware.universe/issues/7249>`_)
+* feat!: replace autoware_auto_msgs with autoware_msgs for system modules (`#7249 <https://github.com/autowarefoundation/autoware.universe/issues/7249>`_)
   Co-authored-by: Cynthia Liu <cynthia.liu@autocore.ai>
   Co-authored-by: NorahXiong <norah.xiong@autocore.ai>
   Co-authored-by: beginningfan <beginning.fan@autocore.ai>
-* feat(mrm_emergency_stop_operator): add support for real time param reconfigure for mrm_emergency_stop (`#6994 <https://github.com/youtalk/autoware.universe/issues/6994>`_)
+* feat(mrm_emergency_stop_operator): add support for real time param reconfigure for mrm_emergency_stop (`#6994 <https://github.com/autowarefoundation/autoware.universe/issues/6994>`_)
   add support for real time param reconfigure for mrm_emergency_stop
 * Contributors: Kosuke Takeuchi, Ryohsuke Mitsudome, Takayuki Murooka, Yutaka Kondo, danielsanchezaran
 
 0.26.0 (2024-04-03)
 -------------------
-* chore(mrm_emergency_stop_operator): add a maintainer for mrm operator… (`#3489 <https://github.com/youtalk/autoware.universe/issues/3489>`_)
+* chore(mrm_emergency_stop_operator): add a maintainer for mrm operator… (`#3489 <https://github.com/autowarefoundation/autoware.universe/issues/3489>`_)
   chore(mrm_emergency_stop_operator): add a maintainer for mrm operator packages
-* docs(mrm_emergency_stop_operator): fix file name (`#4226 <https://github.com/youtalk/autoware.universe/issues/4226>`_)
-* style: fix typos (`#3617 <https://github.com/youtalk/autoware.universe/issues/3617>`_)
+* docs(mrm_emergency_stop_operator): fix file name (`#4226 <https://github.com/autowarefoundation/autoware.universe/issues/4226>`_)
+* style: fix typos (`#3617 <https://github.com/autowarefoundation/autoware.universe/issues/3617>`_)
   * style: fix typos in documents
   * style: fix typos in package.xml
   * style: fix typos in launch files
   * style: fix typos in comments
   ---------
-* build: mark autoware_cmake as <buildtool_depend> (`#3616 <https://github.com/youtalk/autoware.universe/issues/3616>`_)
+* build: mark autoware_cmake as <buildtool_depend> (`#3616 <https://github.com/autowarefoundation/autoware.universe/issues/3616>`_)
   * build: mark autoware_cmake as <buildtool_depend>
   with <build_depend>, autoware_cmake is automatically exported with ament_target_dependencies() (unecessary)
   * style(pre-commit): autofix
@@ -35,13 +35,13 @@ Changelog for package mrm_emergency_stop_operator
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Kenji Miyake <kenji.miyake@tier4.jp>
-* fix(mrm_emergency_stop_operator): fix parameter loading in mrm operators (`#2378 <https://github.com/youtalk/autoware.universe/issues/2378>`_)
+* fix(mrm_emergency_stop_operator): fix parameter loading in mrm operators (`#2378 <https://github.com/autowarefoundation/autoware.universe/issues/2378>`_)
   * fix(mrm_emergency_stop_operator): fix parameter loading in mrm operators
   * ci(pre-commit): autofix
   * fix(mrm_emergency_stop_operator): remove os import
   * fix(mrm_emergency_stop_operator): remove unused packages
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat(emergency_handler): add a selector for multiple MRM behaviors (`#2070 <https://github.com/youtalk/autoware.universe/issues/2070>`_)
+* feat(emergency_handler): add a selector for multiple MRM behaviors (`#2070 <https://github.com/autowarefoundation/autoware.universe/issues/2070>`_)
   * feat(emergency_handler): add mrm command and status publishers
   * feat(autoware_ad_api_msgs): define mrm operation srv and mrm status msg
   * feat(emergency_handler): add mrm clients and subscribers

--- a/system/mrm_handler/CHANGELOG.rst
+++ b/system/mrm_handler/CHANGELOG.rst
@@ -5,33 +5,33 @@ Changelog for package mrm_handler
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* fix(mrm_handler, emergency_handler): remove unnecessary depend (`#8099 <https://github.com/youtalk/autoware.universe/issues/8099>`_)
+* fix(mrm_handler, emergency_handler): remove unnecessary depend (`#8099 <https://github.com/autowarefoundation/autoware.universe/issues/8099>`_)
   * fix(mrm_handler): remove unnecessary depends
   * fix(emergency_handler): remove unnecessary depends
   ---------
-* feat(mrm_handler): input gear command (`#8080 <https://github.com/youtalk/autoware.universe/issues/8080>`_)
+* feat(mrm_handler): input gear command (`#8080 <https://github.com/autowarefoundation/autoware.universe/issues/8080>`_)
   * feat(mrm_handler): input gear command
   * style(pre-commit): autofix
   * fix minor
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* fix(mrm_handler): add check for autonomous mode and do some refactoring (`#8067 <https://github.com/youtalk/autoware.universe/issues/8067>`_)
+* fix(mrm_handler): add check for autonomous mode and do some refactoring (`#8067 <https://github.com/autowarefoundation/autoware.universe/issues/8067>`_)
   * add check for autonomous mode and do some refactoring
   * add comments
   * fix comment
   ---------
-* feat(mrm_handler): operate mrm only when autonomous operation mode (`#7784 <https://github.com/youtalk/autoware.universe/issues/7784>`_)
+* feat(mrm_handler): operate mrm only when autonomous operation mode (`#7784 <https://github.com/autowarefoundation/autoware.universe/issues/7784>`_)
   * feat: add isOperationModeAutonomous() function to MRM handler core
   The code changes add a new function `isOperationModeAutonomous()` to the MRM handler core. This function is used to check if the operation mode is set to autonomous.
   ---------
-* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/youtalk/autoware.universe/issues/7594>`_)
-* fix(mrm_handler): fix multiCondition warning (`#7543 <https://github.com/youtalk/autoware.universe/issues/7543>`_)
-* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/youtalk/autoware.universe/issues/7538>`_)
+* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/autowarefoundation/autoware.universe/issues/7594>`_)
+* fix(mrm_handler): fix multiCondition warning (`#7543 <https://github.com/autowarefoundation/autoware.universe/issues/7543>`_)
+* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/autowarefoundation/autoware.universe/issues/7538>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* fix(mrm_handler): fix stop judgement (`#7362 <https://github.com/youtalk/autoware.universe/issues/7362>`_)
+* fix(mrm_handler): fix stop judgement (`#7362 <https://github.com/autowarefoundation/autoware.universe/issues/7362>`_)
   fix stop judgement
   Co-authored-by: Autumn60 <akiro.harada@tier4.jp>
-* feat(emergency_handler, mrm_handler): change to read topic by polling (`#7297 <https://github.com/youtalk/autoware.universe/issues/7297>`_)
+* feat(emergency_handler, mrm_handler): change to read topic by polling (`#7297 <https://github.com/autowarefoundation/autoware.universe/issues/7297>`_)
   * replace Subscription to InterProcessPollingSubscriber
   * sort depend packages list in package.xml
   * fix end of file
@@ -40,29 +40,29 @@ Changelog for package mrm_handler
   * replace Subscription to InterProcessPollingSubscriber (mrm_handler)
   ---------
   Co-authored-by: Autumn60 <akiro.harada@tier4.jp>
-* refactor(mrm_handler): use switch for state machine (`#7277 <https://github.com/youtalk/autoware.universe/issues/7277>`_)
+* refactor(mrm_handler): use switch for state machine (`#7277 <https://github.com/autowarefoundation/autoware.universe/issues/7277>`_)
   * refactor nested if elses
   * delete other commits
   * return for consistency
   ---------
-* fix(emergency_handler,mrm_handler): check for ego speed when determining the gear command (`#7264 <https://github.com/youtalk/autoware.universe/issues/7264>`_)
+* fix(emergency_handler,mrm_handler): check for ego speed when determining the gear command (`#7264 <https://github.com/autowarefoundation/autoware.universe/issues/7264>`_)
   * check for ego speed when determining the gear command
   * add gear history
   * update msg types
   ---------
   Co-authored-by: veqcc <ryuta.kambe@tier4.jp>
-* feat!: replace autoware_auto_msgs with autoware_msgs for system modules (`#7249 <https://github.com/youtalk/autoware.universe/issues/7249>`_)
+* feat!: replace autoware_auto_msgs with autoware_msgs for system modules (`#7249 <https://github.com/autowarefoundation/autoware.universe/issues/7249>`_)
   Co-authored-by: Cynthia Liu <cynthia.liu@autocore.ai>
   Co-authored-by: NorahXiong <norah.xiong@autocore.ai>
   Co-authored-by: beginningfan <beginning.fan@autocore.ai>
-* feat: componentize-mrm-handler (`#7018 <https://github.com/youtalk/autoware.universe/issues/7018>`_)
+* feat: componentize-mrm-handler (`#7018 <https://github.com/autowarefoundation/autoware.universe/issues/7018>`_)
 * Contributors: Autumn60, Kosuke Takeuchi, Kyoichi Sugahara, Ryohsuke Mitsudome, Ryuta Kambe, Takayuki Murooka, TetsuKawa, Yutaka Kondo, danielsanchezaran
 
 0.26.0 (2024-04-03)
 -------------------
-* fix(mrm_handler): fix bug in operation mode availability timeout (`#6513 <https://github.com/youtalk/autoware.universe/issues/6513>`_)
+* fix(mrm_handler): fix bug in operation mode availability timeout (`#6513 <https://github.com/autowarefoundation/autoware.universe/issues/6513>`_)
   * fix operation mode availability timeout
-* feat: add timeouts of request services (`#6532 <https://github.com/youtalk/autoware.universe/issues/6532>`_)
+* feat: add timeouts of request services (`#6532 <https://github.com/autowarefoundation/autoware.universe/issues/6532>`_)
   * feat: add timeouts of request services
   * style(pre-commit): autofix
   * feat: replace define with enum
@@ -74,11 +74,11 @@ Changelog for package mrm_handler
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Takagi, Isamu <43976882+isamu-takagi@users.noreply.github.com>
   Co-authored-by: Ryuta Kambe <veqcc.c@gmail.com>
-* refactor(mrm_handler): delete control_cmd publish function (`#6514 <https://github.com/youtalk/autoware.universe/issues/6514>`_)
+* refactor(mrm_handler): delete control_cmd publish function (`#6514 <https://github.com/autowarefoundation/autoware.universe/issues/6514>`_)
   * refactor(mrm_handler): delete control_cmd publish function
-* feat(mrm_handler, emergency_handler): remove takeover (`#6522 <https://github.com/youtalk/autoware.universe/issues/6522>`_)
+* feat(mrm_handler, emergency_handler): remove takeover (`#6522 <https://github.com/autowarefoundation/autoware.universe/issues/6522>`_)
   update(mrm_handler, emergency_handler): remove takeover
-* feat(mrm_handler): add mrm_handler (`#6400 <https://github.com/youtalk/autoware.universe/issues/6400>`_)
+* feat(mrm_handler): add mrm_handler (`#6400 <https://github.com/autowarefoundation/autoware.universe/issues/6400>`_)
   * feat: add mrm_handler
   * style(pre-commit): autofix
   * modify: update README

--- a/system/system_diagnostic_monitor/CHANGELOG.rst
+++ b/system/system_diagnostic_monitor/CHANGELOG.rst
@@ -5,24 +5,24 @@ Changelog for package system_diagnostic_monitor
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* fix(localization_error_monitor, system diag): fix to use diagnostics_module in localization_util (`#8543 <https://github.com/youtalk/autoware.universe/issues/8543>`_)
+* fix(localization_error_monitor, system diag): fix to use diagnostics_module in localization_util (`#8543 <https://github.com/autowarefoundation/autoware.universe/issues/8543>`_)
   * fix(localization_error_monitor): fix to use diagnostics_module in localization_util
   * fix: update media
   * fix: update component name
   * fix: rename include file
   ---------
-* feat(autonomous_emergency_braking): enable AEB emergency stop (`#8255 <https://github.com/youtalk/autoware.universe/issues/8255>`_)
+* feat(autonomous_emergency_braking): enable AEB emergency stop (`#8255 <https://github.com/autowarefoundation/autoware.universe/issues/8255>`_)
   enable AEB emergency stop
-* fix(system_diagnostic_monitor): fix local mode config (`#7532 <https://github.com/youtalk/autoware.universe/issues/7532>`_)
-* feat(tier4_system_launch): modify diagnostic_graph_aggregator_graph argument (`#7133 <https://github.com/youtalk/autoware.universe/issues/7133>`_)
-* feat(default_ad_api): use diagnostic graph (`#7043 <https://github.com/youtalk/autoware.universe/issues/7043>`_)
-* feat(system diags): rename diag of ndt scan matcher (`#6889 <https://github.com/youtalk/autoware.universe/issues/6889>`_)
+* fix(system_diagnostic_monitor): fix local mode config (`#7532 <https://github.com/autowarefoundation/autoware.universe/issues/7532>`_)
+* feat(tier4_system_launch): modify diagnostic_graph_aggregator_graph argument (`#7133 <https://github.com/autowarefoundation/autoware.universe/issues/7133>`_)
+* feat(default_ad_api): use diagnostic graph (`#7043 <https://github.com/autowarefoundation/autoware.universe/issues/7043>`_)
+* feat(system diags): rename diag of ndt scan matcher (`#6889 <https://github.com/autowarefoundation/autoware.universe/issues/6889>`_)
   rename ndt diag
-* feat: remake diagnostic graph packages (`#6715 <https://github.com/youtalk/autoware.universe/issues/6715>`_)
+* feat: remake diagnostic graph packages (`#6715 <https://github.com/autowarefoundation/autoware.universe/issues/6715>`_)
 * Contributors: RyuYamamoto, Takagi, Isamu, Yamato Ando, Yutaka Kondo, danielsanchezaran
 
 0.26.0 (2024-04-03)
 -------------------
-* feat(system_diagnostic_graph): change config file format (`#5340 <https://github.com/youtalk/autoware.universe/issues/5340>`_)
-* feat: system diagnostic monitor (`#4722 <https://github.com/youtalk/autoware.universe/issues/4722>`_)
+* feat(system_diagnostic_graph): change config file format (`#5340 <https://github.com/autowarefoundation/autoware.universe/issues/5340>`_)
+* feat: system diagnostic monitor (`#4722 <https://github.com/autowarefoundation/autoware.universe/issues/4722>`_)
 * Contributors: Takagi, Isamu

--- a/system/system_monitor/CHANGELOG.rst
+++ b/system/system_monitor/CHANGELOG.rst
@@ -6,91 +6,91 @@ Changelog for package system_monitor
 -------------------
 * remove system_monitor/CHANGELOG.rst
 * unify package.xml version to 0.37.0
-* fix(system_monitor): fix variableScope (`#8448 <https://github.com/youtalk/autoware.universe/issues/8448>`_)
+* fix(system_monitor): fix variableScope (`#8448 <https://github.com/autowarefoundation/autoware.universe/issues/8448>`_)
   fix:variableScope
-* fix(system_monitor): fix unusedStructMember (`#8401 <https://github.com/youtalk/autoware.universe/issues/8401>`_)
+* fix(system_monitor): fix unusedStructMember (`#8401 <https://github.com/autowarefoundation/autoware.universe/issues/8401>`_)
   * fix:unusedStructMember
   * fix:clang format
   * fix:clang format
   ---------
-* fix(system_monitor): fix unreadVariable (`#8372 <https://github.com/youtalk/autoware.universe/issues/8372>`_)
+* fix(system_monitor): fix unreadVariable (`#8372 <https://github.com/autowarefoundation/autoware.universe/issues/8372>`_)
   fix:unreadVariable
-* fix(system_monitor): fix shadowVariable (`#7981 <https://github.com/youtalk/autoware.universe/issues/7981>`_)
+* fix(system_monitor): fix shadowVariable (`#7981 <https://github.com/autowarefoundation/autoware.universe/issues/7981>`_)
   fix:shadowVariable
-* fix(system_monitor): apply cppcheck-suppress for cstyleCast (`#7867 <https://github.com/youtalk/autoware.universe/issues/7867>`_)
+* fix(system_monitor): apply cppcheck-suppress for cstyleCast (`#7867 <https://github.com/autowarefoundation/autoware.universe/issues/7867>`_)
   * fix(system_monitor): apply cppcheck-suppress for cstyleCast
   * fix(system_monitor): apply cppcheck-suppress for cstyleCast
   * style(pre-commit): autofix
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/youtalk/autoware.universe/issues/7594>`_)
-* fix(net_monitor): fix cppcheck warnings (`#7573 <https://github.com/youtalk/autoware.universe/issues/7573>`_)
+* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/autowarefoundation/autoware.universe/issues/7594>`_)
+* fix(net_monitor): fix cppcheck warnings (`#7573 <https://github.com/autowarefoundation/autoware.universe/issues/7573>`_)
   * fix unusedVariable warning
   * fix unusedVariable warning
   * fix variableScope warning
   * fix unreadVariable warning
   * fix
   ---------
-* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/youtalk/autoware.universe/issues/7538>`_)
+* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/autowarefoundation/autoware.universe/issues/7538>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* fix(system_monitor): fix unsignedLessThanZero warning (`#7545 <https://github.com/youtalk/autoware.universe/issues/7545>`_)
-* ci(pre-commit): autoupdate (`#7499 <https://github.com/youtalk/autoware.universe/issues/7499>`_)
+* fix(system_monitor): fix unsignedLessThanZero warning (`#7545 <https://github.com/autowarefoundation/autoware.universe/issues/7545>`_)
+* ci(pre-commit): autoupdate (`#7499 <https://github.com/autowarefoundation/autoware.universe/issues/7499>`_)
   Co-authored-by: M. Fatih Cırıt <mfc@leodrive.ai>
-* fix(system_monitor): fix warning of containerOutOfBounds (`#6927 <https://github.com/youtalk/autoware.universe/issues/6927>`_)
+* fix(system_monitor): fix warning of containerOutOfBounds (`#6927 <https://github.com/autowarefoundation/autoware.universe/issues/6927>`_)
 * Contributors: Koichi98, Kosuke Takeuchi, Ryuta Kambe, Takayuki Murooka, Yutaka Kondo, awf-autoware-bot[bot], kobayu858
 
 0.26.0 (2024-04-03)
 -------------------
-* fix(system_monitor): move headers to a separate directory (`#5942 <https://github.com/youtalk/autoware.universe/issues/5942>`_)
+* fix(system_monitor): move headers to a separate directory (`#5942 <https://github.com/autowarefoundation/autoware.universe/issues/5942>`_)
   * fix(system_monitor): move headers to a separate directory
   * style(pre-commit): autofix
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* fix(system_monitor): fix uninitialized diag level of process monitor (`#5753 <https://github.com/youtalk/autoware.universe/issues/5753>`_)
-* chore: update maintainer (`#5730 <https://github.com/youtalk/autoware.universe/issues/5730>`_)
+* fix(system_monitor): fix uninitialized diag level of process monitor (`#5753 <https://github.com/autowarefoundation/autoware.universe/issues/5753>`_)
+* chore: update maintainer (`#5730 <https://github.com/autowarefoundation/autoware.universe/issues/5730>`_)
   update maintainer
-* fix(system_monitor): output command line (`#5430 <https://github.com/youtalk/autoware.universe/issues/5430>`_)
+* fix(system_monitor): output command line (`#5430 <https://github.com/autowarefoundation/autoware.universe/issues/5430>`_)
   * fix(system_monitor): output command line
   * style(pre-commit): autofix
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* perf(system_monitor): fix program command line reading (`#5191 <https://github.com/youtalk/autoware.universe/issues/5191>`_)
+* perf(system_monitor): fix program command line reading (`#5191 <https://github.com/autowarefoundation/autoware.universe/issues/5191>`_)
   * Fix program command line reading
   * style(pre-commit): autofix
   * fix spelling commandline->command_line
   ---------
   Co-authored-by: Owen-Liuyuxuan <uken.ryu@tier4.jp>
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* fix(ntp_monitor): move chronyc command execution to a timer (`#4634 <https://github.com/youtalk/autoware.universe/issues/4634>`_)
+* fix(ntp_monitor): move chronyc command execution to a timer (`#4634 <https://github.com/autowarefoundation/autoware.universe/issues/4634>`_)
   * fix(ntp_monitor): move chronyc command execution to a timer
   * add newly added parameter timeout to config
   ---------
   Co-authored-by: Hiroki OTA <hiroki.ota@tier4.jp>
-* fix(system_monitor): high-memory process are not provided in MEM order (`#4654 <https://github.com/youtalk/autoware.universe/issues/4654>`_)
+* fix(system_monitor): high-memory process are not provided in MEM order (`#4654 <https://github.com/autowarefoundation/autoware.universe/issues/4654>`_)
   * fix(process_monitor): high-memory process are not being provided in %MEM order
   * changed option from 'g' to 'n'
   ---------
-* fix(system_monitor): extend command line to display (`#4553 <https://github.com/youtalk/autoware.universe/issues/4553>`_)
-* feat(system_monitor): add detection of ECC memory errors (`#3795 <https://github.com/youtalk/autoware.universe/issues/3795>`_)
+* fix(system_monitor): extend command line to display (`#4553 <https://github.com/autowarefoundation/autoware.universe/issues/4553>`_)
+* feat(system_monitor): add detection of ECC memory errors (`#3795 <https://github.com/autowarefoundation/autoware.universe/issues/3795>`_)
   * feat(system_monitor): add detection of ECC memory errors
   * style(pre-commit): autofix
   * fix process crash when edac-utils is not installed
   * style(pre-commit): autofix
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* fix(perception): remove UB reinterpret_cast (`#3383 <https://github.com/youtalk/autoware.universe/issues/3383>`_)
+* fix(perception): remove UB reinterpret_cast (`#3383 <https://github.com/autowarefoundation/autoware.universe/issues/3383>`_)
   * fix(perception): remove UB reinterpret_cast
   see https://github.com/autowarefoundation/autoware.universe/issues/3215
   * fix(pointcloud_preprocessor): remove UB reinterpret_cast
   * refactor
   ---------
-* style: fix typos (`#3617 <https://github.com/youtalk/autoware.universe/issues/3617>`_)
+* style: fix typos (`#3617 <https://github.com/autowarefoundation/autoware.universe/issues/3617>`_)
   * style: fix typos in documents
   * style: fix typos in package.xml
   * style: fix typos in launch files
   * style: fix typos in comments
   ---------
-* build: mark autoware_cmake as <buildtool_depend> (`#3616 <https://github.com/youtalk/autoware.universe/issues/3616>`_)
+* build: mark autoware_cmake as <buildtool_depend> (`#3616 <https://github.com/autowarefoundation/autoware.universe/issues/3616>`_)
   * build: mark autoware_cmake as <buildtool_depend>
   with <build_depend>, autoware_cmake is automatically exported with ament_target_dependencies() (unecessary)
   * style(pre-commit): autofix
@@ -98,17 +98,17 @@ Changelog for package system_monitor
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Kenji Miyake <kenji.miyake@tier4.jp>
-* chore: sync files (`#3227 <https://github.com/youtalk/autoware.universe/issues/3227>`_)
+* chore: sync files (`#3227 <https://github.com/autowarefoundation/autoware.universe/issues/3227>`_)
   * chore: sync files
   * style(pre-commit): autofix
   ---------
   Co-authored-by: kenji-miyake <kenji-miyake@users.noreply.github.com>
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* build(system_monitor): added missing Boost dependencies (`#2881 <https://github.com/youtalk/autoware.universe/issues/2881>`_)
+* build(system_monitor): added missing Boost dependencies (`#2881 <https://github.com/autowarefoundation/autoware.universe/issues/2881>`_)
   Co-authored-by: ito-san <57388357+ito-san@users.noreply.github.com>
-* build(system_monitor): add build dependency (`#2740 <https://github.com/youtalk/autoware.universe/issues/2740>`_)
-* fix(system_monitor): change default param path (`#2560 <https://github.com/youtalk/autoware.universe/issues/2560>`_)
-* fix(system_monitor): prevent nethogs from monitoring all networks due to high CPU load (`#2474 <https://github.com/youtalk/autoware.universe/issues/2474>`_)
+* build(system_monitor): add build dependency (`#2740 <https://github.com/autowarefoundation/autoware.universe/issues/2740>`_)
+* fix(system_monitor): change default param path (`#2560 <https://github.com/autowarefoundation/autoware.universe/issues/2560>`_)
+* fix(system_monitor): prevent nethogs from monitoring all networks due to high CPU load (`#2474 <https://github.com/autowarefoundation/autoware.universe/issues/2474>`_)
   * fix(system_monitor): prevent nethogs from monitoring all networks due to high CPU load
   * ci(pre-commit): autofix
   * fix(system_monitor): fix include guards
@@ -129,17 +129,17 @@ Changelog for package system_monitor
   * fix(net_monitor): update README
   * fix(net_monitor): add lock guard to protect variable
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat: replace python launch with xml launch for system monitor (`#2430 <https://github.com/youtalk/autoware.universe/issues/2430>`_)
+* feat: replace python launch with xml launch for system monitor (`#2430 <https://github.com/autowarefoundation/autoware.universe/issues/2430>`_)
   * feat: replace python launch with xml launch for system monitor
   * ci(pre-commit): autofix
   * update figure
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* chore(system_monitor): add maintainer (`#2420 <https://github.com/youtalk/autoware.universe/issues/2420>`_)
-* refactor(system_monitor/hdd_monitor): rename structs and functions (`#2144 <https://github.com/youtalk/autoware.universe/issues/2144>`_)
+* chore(system_monitor): add maintainer (`#2420 <https://github.com/autowarefoundation/autoware.universe/issues/2420>`_)
+* refactor(system_monitor/hdd_monitor): rename structs and functions (`#2144 <https://github.com/autowarefoundation/autoware.universe/issues/2144>`_)
   * refactor(system_monitor/hdd_monitor): rename structs and functions
   * fix a mistake
-* chore(system_monitor): fix typos (`#2142 <https://github.com/youtalk/autoware.universe/issues/2142>`_)
-* feat: (system_monitor) adding a node for CMOS battery monitoring (`#1989 <https://github.com/youtalk/autoware.universe/issues/1989>`_)
+* chore(system_monitor): fix typos (`#2142 <https://github.com/autowarefoundation/autoware.universe/issues/2142>`_)
+* feat: (system_monitor) adding a node for CMOS battery monitoring (`#1989 <https://github.com/autowarefoundation/autoware.universe/issues/1989>`_)
   * adding document for voltage monitor
   * ci(pre-commit): autofix
   * fixed for the issue of multithread
@@ -159,36 +159,36 @@ Changelog for package system_monitor
   * ci(pre-commit): autofix
   * added topics_voltage_monitor.md)
   * ci(pre-commit): autofix
-  * chore: sync files (`#629 <https://github.com/youtalk/autoware.universe/issues/629>`_)
+  * chore: sync files (`#629 <https://github.com/autowarefoundation/autoware.universe/issues/629>`_)
   * chore: sync files
   * ci(pre-commit): autofix
   Co-authored-by: kenji-miyake <kenji-miyake@users.noreply.github.com>
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-  * fix(dummy_diag_publisher): use anon to make unique node name instead of diag name (`#639 <https://github.com/youtalk/autoware.universe/issues/639>`_)
-  * chore: sync files (`#648 <https://github.com/youtalk/autoware.universe/issues/648>`_)
+  * fix(dummy_diag_publisher): use anon to make unique node name instead of diag name (`#639 <https://github.com/autowarefoundation/autoware.universe/issues/639>`_)
+  * chore: sync files (`#648 <https://github.com/autowarefoundation/autoware.universe/issues/648>`_)
   * chore: sync files
   * Revert "chore: sync files"
   This reverts commit b24f530b48306e16aa285f80a629ce5c5a9ccda7.
   * sync codecov.yaml
   Co-authored-by: kenji-miyake <kenji-miyake@users.noreply.github.com>
   Co-authored-by: Kenji Miyake <kenji.miyake@tier4.jp>
-  * fix(autoware_state_panel): fix message type for /api/autoware/get/engage (`#666 <https://github.com/youtalk/autoware.universe/issues/666>`_)
+  * fix(autoware_state_panel): fix message type for /api/autoware/get/engage (`#666 <https://github.com/autowarefoundation/autoware.universe/issues/666>`_)
   * fix(autoware_state_panel): fix message type for /api/autoware/get/engage
   * ci(pre-commit): autofix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-  * fix(behavior_velocity): avoid insert same point on trajectory utils (`#834 <https://github.com/youtalk/autoware.universe/issues/834>`_)
-  * refactor(behavior_velocity_planner): simplify CMakeLists.txt (`#855 <https://github.com/youtalk/autoware.universe/issues/855>`_)
-  * docs: fix 404 error caused by typo in url (`#871 <https://github.com/youtalk/autoware.universe/issues/871>`_)
+  * fix(behavior_velocity): avoid insert same point on trajectory utils (`#834 <https://github.com/autowarefoundation/autoware.universe/issues/834>`_)
+  * refactor(behavior_velocity_planner): simplify CMakeLists.txt (`#855 <https://github.com/autowarefoundation/autoware.universe/issues/855>`_)
+  * docs: fix 404 error caused by typo in url (`#871 <https://github.com/autowarefoundation/autoware.universe/issues/871>`_)
   * docs: fix 404 error caused by typo in url
   * docs: fix typo in url for yolov4
-  * fix(image_projection_based_fusion): set imagebuffersize (`#820 <https://github.com/youtalk/autoware.universe/issues/820>`_)
+  * fix(image_projection_based_fusion): set imagebuffersize (`#820 <https://github.com/autowarefoundation/autoware.universe/issues/820>`_)
   * fix: set imagebuffersize configured
   * ci(pre-commit): autofix
   Co-authored-by: suchang <chang.su@autocore.ai>
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-  * chore(avoidance_module): fix spell check (`#732 <https://github.com/youtalk/autoware.universe/issues/732>`_)
-  * feat: isolate gtests in all packages (`#693 <https://github.com/youtalk/autoware.universe/issues/693>`_)
-  * docs(virtual traffic light): add documentation (`#245 <https://github.com/youtalk/autoware.universe/issues/245>`_)
+  * chore(avoidance_module): fix spell check (`#732 <https://github.com/autowarefoundation/autoware.universe/issues/732>`_)
+  * feat: isolate gtests in all packages (`#693 <https://github.com/autowarefoundation/autoware.universe/issues/693>`_)
+  * docs(virtual traffic light): add documentation (`#245 <https://github.com/autowarefoundation/autoware.universe/issues/245>`_)
   * doc(behavior_velocity): add graph and fix link
   * doc(behavior_velocity): update virtual traffic light doc
   * doc(behavior_velocity): minor fix
@@ -199,7 +199,7 @@ Changelog for package system_monitor
   * apply suggestion
   * doc: to intersection-coordination
   Co-authored-by: Kenji Miyake <31987104+kenji-miyake@users.noreply.github.com>
-  * feat(surround_obstacle_checker): separate surround_obstacle_checker from hierarchical planning flow (`#830 <https://github.com/youtalk/autoware.universe/issues/830>`_)
+  * feat(surround_obstacle_checker): separate surround_obstacle_checker from hierarchical planning flow (`#830 <https://github.com/autowarefoundation/autoware.universe/issues/830>`_)
   * fix(surroud_obstacle_checker): use alias
   * feat(surround_obstacle_checker): use velocity limit
   * chore(surround_obstacle_checker): rename publisher, subscriber and callback functions
@@ -209,50 +209,50 @@ Changelog for package system_monitor
   * refactor(surround_obstacle_checker): cleanup polygon handling
   * refactor(surround_obstacle_checker): use marker helper
   * feat(planning_launch): separate surround_obstacle_checker from hierarchical motion planning flow
-  * fix(surround_obstacle_checker): fix ego footprint polygon (`#877 <https://github.com/youtalk/autoware.universe/issues/877>`_)
-  * fix: update nvinfer api (`#863 <https://github.com/youtalk/autoware.universe/issues/863>`_)
+  * fix(surround_obstacle_checker): fix ego footprint polygon (`#877 <https://github.com/autowarefoundation/autoware.universe/issues/877>`_)
+  * fix: update nvinfer api (`#863 <https://github.com/autowarefoundation/autoware.universe/issues/863>`_)
   * fix(lidar_centerpoint): update nvinfer api
   * fix(tensorrt_yolo): update nvinfer api
   * fix(lidar_apollo_instance_segmentation): update nvinfer api
   * fix(traffic_light_classifier): update nvinfer api
   * fix(traffic_light_ssd_fine_detector): update nvinfer api
   * pre-commit run
-  * fix(avoidance_module): ignore object instead of creating zero shift (`#731 <https://github.com/youtalk/autoware.universe/issues/731>`_)
+  * fix(avoidance_module): ignore object instead of creating zero shift (`#731 <https://github.com/autowarefoundation/autoware.universe/issues/731>`_)
   * fix: ignore object instead of creating zero shift
   instead of creating zero shift point, the object will be ignored.
   no behavior changes should be observed.
   * refactor: sync continue with upstream
   * fix: fix debug message for insufficient lateral margin
-  * fix(motion_velocity_smoother): curve deceleration not working with a specific parameter set (`#738 <https://github.com/youtalk/autoware.universe/issues/738>`_)
-  * test(autoware_testing): fix smoke_test (`#479 <https://github.com/youtalk/autoware.universe/issues/479>`_)
+  * fix(motion_velocity_smoother): curve deceleration not working with a specific parameter set (`#738 <https://github.com/autowarefoundation/autoware.universe/issues/738>`_)
+  * test(autoware_testing): fix smoke_test (`#479 <https://github.com/autowarefoundation/autoware.universe/issues/479>`_)
   * fix(autoware_testing): fix smoke_test
   * restore smoke_test for trajectory_follower_nodes
   * add support multiple parameter files
   * ci(pre-commit): autofix
   * minor fix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-  * feat(rviz_plugins): add velocity limit to autoware state panel (`#879 <https://github.com/youtalk/autoware.universe/issues/879>`_)
+  * feat(rviz_plugins): add velocity limit to autoware state panel (`#879 <https://github.com/autowarefoundation/autoware.universe/issues/879>`_)
   * feat(rviz_plugins): add velocity limit to autoware state panel
   * chore(rviz_plugin): change ms to kmh
-  * feat(vehicle_info_util): add max_steer_angle (`#740 <https://github.com/youtalk/autoware.universe/issues/740>`_)
+  * feat(vehicle_info_util): add max_steer_angle (`#740 <https://github.com/autowarefoundation/autoware.universe/issues/740>`_)
   * feat(vehicle_info_util): add max_steer_angle
   * applied pre-commit
   * Added max_steer_angle in test config
   Co-authored-by: Tomoya Kimura <tomoya.kimura@tier4.jp>
-  * fix(lidar_centerpoint): fix google drive url to avoid 404 (`#889 <https://github.com/youtalk/autoware.universe/issues/889>`_)
+  * fix(lidar_centerpoint): fix google drive url to avoid 404 (`#889 <https://github.com/autowarefoundation/autoware.universe/issues/889>`_)
   * fix(lidar_centerpoint): fix google drive url to avoid 404
   * Update CMakeLists.txt
   Co-authored-by: Kenji Miyake <31987104+kenji-miyake@users.noreply.github.com>
-  * chore: fix typos (`#886 <https://github.com/youtalk/autoware.universe/issues/886>`_)
-  * feat(state_rviz_plugin): add GateMode and PathChangeApproval Button (`#894 <https://github.com/youtalk/autoware.universe/issues/894>`_)
+  * chore: fix typos (`#886 <https://github.com/autowarefoundation/autoware.universe/issues/886>`_)
+  * feat(state_rviz_plugin): add GateMode and PathChangeApproval Button (`#894 <https://github.com/autowarefoundation/autoware.universe/issues/894>`_)
   * feat(state_rviz_plugin): add GateMode and PathChangeApproval Button
   * ci(pre-commit): autofix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-  * feat(map_tf_generator): accelerate the 'viewer' coordinate calculation (`#890 <https://github.com/youtalk/autoware.universe/issues/890>`_)
+  * feat(map_tf_generator): accelerate the 'viewer' coordinate calculation (`#890 <https://github.com/autowarefoundation/autoware.universe/issues/890>`_)
   * add random point sampling function to quickly calculate the 'viewer' coordinate
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Kenji Miyake <31987104+kenji-miyake@users.noreply.github.com>
-  * docs(obstacle_stop_planner): update documentation (`#880 <https://github.com/youtalk/autoware.universe/issues/880>`_)
+  * docs(obstacle_stop_planner): update documentation (`#880 <https://github.com/autowarefoundation/autoware.universe/issues/880>`_)
   * ci(pre-commit): autofix
   * fixed conflicts
   * ci(pre-commit): autofix
@@ -273,36 +273,36 @@ Changelog for package system_monitor
   * ci(pre-commit): autofix
   * ci(pre-commit): autofix
   * ci(pre-commit): autofix
-  * chore: sync files (`#629 <https://github.com/youtalk/autoware.universe/issues/629>`_)
+  * chore: sync files (`#629 <https://github.com/autowarefoundation/autoware.universe/issues/629>`_)
   * chore: sync files
   * ci(pre-commit): autofix
   Co-authored-by: kenji-miyake <kenji-miyake@users.noreply.github.com>
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-  * fix(dummy_diag_publisher): use anon to make unique node name instead of diag name (`#639 <https://github.com/youtalk/autoware.universe/issues/639>`_)
-  * chore: sync files (`#648 <https://github.com/youtalk/autoware.universe/issues/648>`_)
+  * fix(dummy_diag_publisher): use anon to make unique node name instead of diag name (`#639 <https://github.com/autowarefoundation/autoware.universe/issues/639>`_)
+  * chore: sync files (`#648 <https://github.com/autowarefoundation/autoware.universe/issues/648>`_)
   * chore: sync files
   * Revert "chore: sync files"
   This reverts commit b24f530b48306e16aa285f80a629ce5c5a9ccda7.
   * sync codecov.yaml
   Co-authored-by: kenji-miyake <kenji-miyake@users.noreply.github.com>
   Co-authored-by: Kenji Miyake <kenji.miyake@tier4.jp>
-  * fix(autoware_state_panel): fix message type for /api/autoware/get/engage (`#666 <https://github.com/youtalk/autoware.universe/issues/666>`_)
+  * fix(autoware_state_panel): fix message type for /api/autoware/get/engage (`#666 <https://github.com/autowarefoundation/autoware.universe/issues/666>`_)
   * fix(autoware_state_panel): fix message type for /api/autoware/get/engage
   * ci(pre-commit): autofix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-  * fix(behavior_velocity): avoid insert same point on trajectory utils (`#834 <https://github.com/youtalk/autoware.universe/issues/834>`_)
-  * refactor(behavior_velocity_planner): simplify CMakeLists.txt (`#855 <https://github.com/youtalk/autoware.universe/issues/855>`_)
-  * docs: fix 404 error caused by typo in url (`#871 <https://github.com/youtalk/autoware.universe/issues/871>`_)
+  * fix(behavior_velocity): avoid insert same point on trajectory utils (`#834 <https://github.com/autowarefoundation/autoware.universe/issues/834>`_)
+  * refactor(behavior_velocity_planner): simplify CMakeLists.txt (`#855 <https://github.com/autowarefoundation/autoware.universe/issues/855>`_)
+  * docs: fix 404 error caused by typo in url (`#871 <https://github.com/autowarefoundation/autoware.universe/issues/871>`_)
   * docs: fix 404 error caused by typo in url
   * docs: fix typo in url for yolov4
-  * fix(image_projection_based_fusion): set imagebuffersize (`#820 <https://github.com/youtalk/autoware.universe/issues/820>`_)
+  * fix(image_projection_based_fusion): set imagebuffersize (`#820 <https://github.com/autowarefoundation/autoware.universe/issues/820>`_)
   * fix: set imagebuffersize configured
   * ci(pre-commit): autofix
   Co-authored-by: suchang <chang.su@autocore.ai>
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-  * chore(avoidance_module): fix spell check (`#732 <https://github.com/youtalk/autoware.universe/issues/732>`_)
-  * feat: isolate gtests in all packages (`#693 <https://github.com/youtalk/autoware.universe/issues/693>`_)
-  * docs(virtual traffic light): add documentation (`#245 <https://github.com/youtalk/autoware.universe/issues/245>`_)
+  * chore(avoidance_module): fix spell check (`#732 <https://github.com/autowarefoundation/autoware.universe/issues/732>`_)
+  * feat: isolate gtests in all packages (`#693 <https://github.com/autowarefoundation/autoware.universe/issues/693>`_)
+  * docs(virtual traffic light): add documentation (`#245 <https://github.com/autowarefoundation/autoware.universe/issues/245>`_)
   * doc(behavior_velocity): add graph and fix link
   * doc(behavior_velocity): update virtual traffic light doc
   * doc(behavior_velocity): minor fix
@@ -313,7 +313,7 @@ Changelog for package system_monitor
   * apply suggestion
   * doc: to intersection-coordination
   Co-authored-by: Kenji Miyake <31987104+kenji-miyake@users.noreply.github.com>
-  * feat(surround_obstacle_checker): separate surround_obstacle_checker from hierarchical planning flow (`#830 <https://github.com/youtalk/autoware.universe/issues/830>`_)
+  * feat(surround_obstacle_checker): separate surround_obstacle_checker from hierarchical planning flow (`#830 <https://github.com/autowarefoundation/autoware.universe/issues/830>`_)
   * fix(surroud_obstacle_checker): use alias
   * feat(surround_obstacle_checker): use velocity limit
   * chore(surround_obstacle_checker): rename publisher, subscriber and callback functions
@@ -323,50 +323,50 @@ Changelog for package system_monitor
   * refactor(surround_obstacle_checker): cleanup polygon handling
   * refactor(surround_obstacle_checker): use marker helper
   * feat(planning_launch): separate surround_obstacle_checker from hierarchical motion planning flow
-  * fix(surround_obstacle_checker): fix ego footprint polygon (`#877 <https://github.com/youtalk/autoware.universe/issues/877>`_)
-  * fix: update nvinfer api (`#863 <https://github.com/youtalk/autoware.universe/issues/863>`_)
+  * fix(surround_obstacle_checker): fix ego footprint polygon (`#877 <https://github.com/autowarefoundation/autoware.universe/issues/877>`_)
+  * fix: update nvinfer api (`#863 <https://github.com/autowarefoundation/autoware.universe/issues/863>`_)
   * fix(lidar_centerpoint): update nvinfer api
   * fix(tensorrt_yolo): update nvinfer api
   * fix(lidar_apollo_instance_segmentation): update nvinfer api
   * fix(traffic_light_classifier): update nvinfer api
   * fix(traffic_light_ssd_fine_detector): update nvinfer api
   * pre-commit run
-  * fix(avoidance_module): ignore object instead of creating zero shift (`#731 <https://github.com/youtalk/autoware.universe/issues/731>`_)
+  * fix(avoidance_module): ignore object instead of creating zero shift (`#731 <https://github.com/autowarefoundation/autoware.universe/issues/731>`_)
   * fix: ignore object instead of creating zero shift
   instead of creating zero shift point, the object will be ignored.
   no behavior changes should be observed.
   * refactor: sync continue with upstream
   * fix: fix debug message for insufficient lateral margin
-  * fix(motion_velocity_smoother): curve deceleration not working with a specific parameter set (`#738 <https://github.com/youtalk/autoware.universe/issues/738>`_)
-  * test(autoware_testing): fix smoke_test (`#479 <https://github.com/youtalk/autoware.universe/issues/479>`_)
+  * fix(motion_velocity_smoother): curve deceleration not working with a specific parameter set (`#738 <https://github.com/autowarefoundation/autoware.universe/issues/738>`_)
+  * test(autoware_testing): fix smoke_test (`#479 <https://github.com/autowarefoundation/autoware.universe/issues/479>`_)
   * fix(autoware_testing): fix smoke_test
   * restore smoke_test for trajectory_follower_nodes
   * add support multiple parameter files
   * ci(pre-commit): autofix
   * minor fix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-  * feat(rviz_plugins): add velocity limit to autoware state panel (`#879 <https://github.com/youtalk/autoware.universe/issues/879>`_)
+  * feat(rviz_plugins): add velocity limit to autoware state panel (`#879 <https://github.com/autowarefoundation/autoware.universe/issues/879>`_)
   * feat(rviz_plugins): add velocity limit to autoware state panel
   * chore(rviz_plugin): change ms to kmh
-  * feat(vehicle_info_util): add max_steer_angle (`#740 <https://github.com/youtalk/autoware.universe/issues/740>`_)
+  * feat(vehicle_info_util): add max_steer_angle (`#740 <https://github.com/autowarefoundation/autoware.universe/issues/740>`_)
   * feat(vehicle_info_util): add max_steer_angle
   * applied pre-commit
   * Added max_steer_angle in test config
   Co-authored-by: Tomoya Kimura <tomoya.kimura@tier4.jp>
-  * fix(lidar_centerpoint): fix google drive url to avoid 404 (`#889 <https://github.com/youtalk/autoware.universe/issues/889>`_)
+  * fix(lidar_centerpoint): fix google drive url to avoid 404 (`#889 <https://github.com/autowarefoundation/autoware.universe/issues/889>`_)
   * fix(lidar_centerpoint): fix google drive url to avoid 404
   * Update CMakeLists.txt
   Co-authored-by: Kenji Miyake <31987104+kenji-miyake@users.noreply.github.com>
-  * chore: fix typos (`#886 <https://github.com/youtalk/autoware.universe/issues/886>`_)
-  * feat(state_rviz_plugin): add GateMode and PathChangeApproval Button (`#894 <https://github.com/youtalk/autoware.universe/issues/894>`_)
+  * chore: fix typos (`#886 <https://github.com/autowarefoundation/autoware.universe/issues/886>`_)
+  * feat(state_rviz_plugin): add GateMode and PathChangeApproval Button (`#894 <https://github.com/autowarefoundation/autoware.universe/issues/894>`_)
   * feat(state_rviz_plugin): add GateMode and PathChangeApproval Button
   * ci(pre-commit): autofix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-  * feat(map_tf_generator): accelerate the 'viewer' coordinate calculation (`#890 <https://github.com/youtalk/autoware.universe/issues/890>`_)
+  * feat(map_tf_generator): accelerate the 'viewer' coordinate calculation (`#890 <https://github.com/autowarefoundation/autoware.universe/issues/890>`_)
   * add random point sampling function to quickly calculate the 'viewer' coordinate
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Kenji Miyake <31987104+kenji-miyake@users.noreply.github.com>
-  * docs(obstacle_stop_planner): update documentation (`#880 <https://github.com/youtalk/autoware.universe/issues/880>`_)
+  * docs(obstacle_stop_planner): update documentation (`#880 <https://github.com/autowarefoundation/autoware.universe/issues/880>`_)
   * ci(pre-commit): autofix
   * fixed conflicts
   * ci(pre-commit): autofix
@@ -376,11 +376,11 @@ Changelog for package system_monitor
   * merge  main ->feature_battery_monitoring
   * Added voltages are provisional values.
   * ci(pre-commit): autofix
-  * feat(behavior_path_planner): add turn signal parameters (`#2086 <https://github.com/youtalk/autoware.universe/issues/2086>`_)
+  * feat(behavior_path_planner): add turn signal parameters (`#2086 <https://github.com/autowarefoundation/autoware.universe/issues/2086>`_)
   * feat(behavior_path_planner): add and change parameters
   * update
   * update
-  * refactor(perception_utils): refactor matching function in perception_utils (`#2045 <https://github.com/youtalk/autoware.universe/issues/2045>`_)
+  * refactor(perception_utils): refactor matching function in perception_utils (`#2045 <https://github.com/autowarefoundation/autoware.universe/issues/2045>`_)
   * refactor(perception_util): refactor matching function in perception_util
   * fix namespace
   * refactor
@@ -388,7 +388,7 @@ Changelog for package system_monitor
   * fix bug
   * add const
   * refactor function name
-  * refactor(perception_utils): refactor object_classification (`#2042 <https://github.com/youtalk/autoware.universe/issues/2042>`_)
+  * refactor(perception_utils): refactor object_classification (`#2042 <https://github.com/autowarefoundation/autoware.universe/issues/2042>`_)
   * refactor(perception_utils): refactor object_classification
   * fix bug
   * fix unittest
@@ -396,14 +396,14 @@ Changelog for package system_monitor
   * fix unit test
   * remove redundant else
   * refactor variable name
-  * feat(autoware_auto_perception_rviz_plugin): add accel text visualization (`#2046 <https://github.com/youtalk/autoware.universe/issues/2046>`_)
-  * refactor(motion_utils, obstacle_cruise_planner): add offset to virtual wall utils func (`#2078 <https://github.com/youtalk/autoware.universe/issues/2078>`_)
-  * refactor(osqp_interface, motion_velocity_smoother): unsolved status log (`#2076 <https://github.com/youtalk/autoware.universe/issues/2076>`_)
+  * feat(autoware_auto_perception_rviz_plugin): add accel text visualization (`#2046 <https://github.com/autowarefoundation/autoware.universe/issues/2046>`_)
+  * refactor(motion_utils, obstacle_cruise_planner): add offset to virtual wall utils func (`#2078 <https://github.com/autowarefoundation/autoware.universe/issues/2078>`_)
+  * refactor(osqp_interface, motion_velocity_smoother): unsolved status log (`#2076 <https://github.com/autowarefoundation/autoware.universe/issues/2076>`_)
   * refactor(osqp_interface, motion_velocity_smoother): unsolved status log
   * Update common/osqp_interface/src/osqp_interface.cpp
   Co-authored-by: Maxime CLEMENT <78338830+maxime-clem@users.noreply.github.com>
   Co-authored-by: Maxime CLEMENT <78338830+maxime-clem@users.noreply.github.com>
-  * feat(lidar_centerpoint): eliminated the tf dependency for single frame detection (`#1925 <https://github.com/youtalk/autoware.universe/issues/1925>`_)
+  * feat(lidar_centerpoint): eliminated the tf dependency for single frame detection (`#1925 <https://github.com/autowarefoundation/autoware.universe/issues/1925>`_)
   Co-authored-by: Yusuke Muramatsu <yukke42@users.noreply.github.com>
   * change name hardware_monitor -> voltage_monitor
   * copy right 2020 -> 2022
@@ -428,36 +428,36 @@ Changelog for package system_monitor
   * ci(pre-commit): autofix
   * added topics_voltage_monitor.md)
   * ci(pre-commit): autofix
-  * chore: sync files (`#629 <https://github.com/youtalk/autoware.universe/issues/629>`_)
+  * chore: sync files (`#629 <https://github.com/autowarefoundation/autoware.universe/issues/629>`_)
   * chore: sync files
   * ci(pre-commit): autofix
   Co-authored-by: kenji-miyake <kenji-miyake@users.noreply.github.com>
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-  * fix(dummy_diag_publisher): use anon to make unique node name instead of diag name (`#639 <https://github.com/youtalk/autoware.universe/issues/639>`_)
-  * chore: sync files (`#648 <https://github.com/youtalk/autoware.universe/issues/648>`_)
+  * fix(dummy_diag_publisher): use anon to make unique node name instead of diag name (`#639 <https://github.com/autowarefoundation/autoware.universe/issues/639>`_)
+  * chore: sync files (`#648 <https://github.com/autowarefoundation/autoware.universe/issues/648>`_)
   * chore: sync files
   * Revert "chore: sync files"
   This reverts commit b24f530b48306e16aa285f80a629ce5c5a9ccda7.
   * sync codecov.yaml
   Co-authored-by: kenji-miyake <kenji-miyake@users.noreply.github.com>
   Co-authored-by: Kenji Miyake <kenji.miyake@tier4.jp>
-  * fix(autoware_state_panel): fix message type for /api/autoware/get/engage (`#666 <https://github.com/youtalk/autoware.universe/issues/666>`_)
+  * fix(autoware_state_panel): fix message type for /api/autoware/get/engage (`#666 <https://github.com/autowarefoundation/autoware.universe/issues/666>`_)
   * fix(autoware_state_panel): fix message type for /api/autoware/get/engage
   * ci(pre-commit): autofix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-  * fix(behavior_velocity): avoid insert same point on trajectory utils (`#834 <https://github.com/youtalk/autoware.universe/issues/834>`_)
-  * refactor(behavior_velocity_planner): simplify CMakeLists.txt (`#855 <https://github.com/youtalk/autoware.universe/issues/855>`_)
-  * docs: fix 404 error caused by typo in url (`#871 <https://github.com/youtalk/autoware.universe/issues/871>`_)
+  * fix(behavior_velocity): avoid insert same point on trajectory utils (`#834 <https://github.com/autowarefoundation/autoware.universe/issues/834>`_)
+  * refactor(behavior_velocity_planner): simplify CMakeLists.txt (`#855 <https://github.com/autowarefoundation/autoware.universe/issues/855>`_)
+  * docs: fix 404 error caused by typo in url (`#871 <https://github.com/autowarefoundation/autoware.universe/issues/871>`_)
   * docs: fix 404 error caused by typo in url
   * docs: fix typo in url for yolov4
-  * fix(image_projection_based_fusion): set imagebuffersize (`#820 <https://github.com/youtalk/autoware.universe/issues/820>`_)
+  * fix(image_projection_based_fusion): set imagebuffersize (`#820 <https://github.com/autowarefoundation/autoware.universe/issues/820>`_)
   * fix: set imagebuffersize configured
   * ci(pre-commit): autofix
   Co-authored-by: suchang <chang.su@autocore.ai>
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-  * chore(avoidance_module): fix spell check (`#732 <https://github.com/youtalk/autoware.universe/issues/732>`_)
-  * feat: isolate gtests in all packages (`#693 <https://github.com/youtalk/autoware.universe/issues/693>`_)
-  * docs(virtual traffic light): add documentation (`#245 <https://github.com/youtalk/autoware.universe/issues/245>`_)
+  * chore(avoidance_module): fix spell check (`#732 <https://github.com/autowarefoundation/autoware.universe/issues/732>`_)
+  * feat: isolate gtests in all packages (`#693 <https://github.com/autowarefoundation/autoware.universe/issues/693>`_)
+  * docs(virtual traffic light): add documentation (`#245 <https://github.com/autowarefoundation/autoware.universe/issues/245>`_)
   * doc(behavior_velocity): add graph and fix link
   * doc(behavior_velocity): update virtual traffic light doc
   * doc(behavior_velocity): minor fix
@@ -468,7 +468,7 @@ Changelog for package system_monitor
   * apply suggestion
   * doc: to intersection-coordination
   Co-authored-by: Kenji Miyake <31987104+kenji-miyake@users.noreply.github.com>
-  * feat(surround_obstacle_checker): separate surround_obstacle_checker from hierarchical planning flow (`#830 <https://github.com/youtalk/autoware.universe/issues/830>`_)
+  * feat(surround_obstacle_checker): separate surround_obstacle_checker from hierarchical planning flow (`#830 <https://github.com/autowarefoundation/autoware.universe/issues/830>`_)
   * fix(surroud_obstacle_checker): use alias
   * feat(surround_obstacle_checker): use velocity limit
   * chore(surround_obstacle_checker): rename publisher, subscriber and callback functions
@@ -478,50 +478,50 @@ Changelog for package system_monitor
   * refactor(surround_obstacle_checker): cleanup polygon handling
   * refactor(surround_obstacle_checker): use marker helper
   * feat(planning_launch): separate surround_obstacle_checker from hierarchical motion planning flow
-  * fix(surround_obstacle_checker): fix ego footprint polygon (`#877 <https://github.com/youtalk/autoware.universe/issues/877>`_)
-  * fix: update nvinfer api (`#863 <https://github.com/youtalk/autoware.universe/issues/863>`_)
+  * fix(surround_obstacle_checker): fix ego footprint polygon (`#877 <https://github.com/autowarefoundation/autoware.universe/issues/877>`_)
+  * fix: update nvinfer api (`#863 <https://github.com/autowarefoundation/autoware.universe/issues/863>`_)
   * fix(lidar_centerpoint): update nvinfer api
   * fix(tensorrt_yolo): update nvinfer api
   * fix(lidar_apollo_instance_segmentation): update nvinfer api
   * fix(traffic_light_classifier): update nvinfer api
   * fix(traffic_light_ssd_fine_detector): update nvinfer api
   * pre-commit run
-  * fix(avoidance_module): ignore object instead of creating zero shift (`#731 <https://github.com/youtalk/autoware.universe/issues/731>`_)
+  * fix(avoidance_module): ignore object instead of creating zero shift (`#731 <https://github.com/autowarefoundation/autoware.universe/issues/731>`_)
   * fix: ignore object instead of creating zero shift
   instead of creating zero shift point, the object will be ignored.
   no behavior changes should be observed.
   * refactor: sync continue with upstream
   * fix: fix debug message for insufficient lateral margin
-  * fix(motion_velocity_smoother): curve deceleration not working with a specific parameter set (`#738 <https://github.com/youtalk/autoware.universe/issues/738>`_)
-  * test(autoware_testing): fix smoke_test (`#479 <https://github.com/youtalk/autoware.universe/issues/479>`_)
+  * fix(motion_velocity_smoother): curve deceleration not working with a specific parameter set (`#738 <https://github.com/autowarefoundation/autoware.universe/issues/738>`_)
+  * test(autoware_testing): fix smoke_test (`#479 <https://github.com/autowarefoundation/autoware.universe/issues/479>`_)
   * fix(autoware_testing): fix smoke_test
   * restore smoke_test for trajectory_follower_nodes
   * add support multiple parameter files
   * ci(pre-commit): autofix
   * minor fix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-  * feat(rviz_plugins): add velocity limit to autoware state panel (`#879 <https://github.com/youtalk/autoware.universe/issues/879>`_)
+  * feat(rviz_plugins): add velocity limit to autoware state panel (`#879 <https://github.com/autowarefoundation/autoware.universe/issues/879>`_)
   * feat(rviz_plugins): add velocity limit to autoware state panel
   * chore(rviz_plugin): change ms to kmh
-  * feat(vehicle_info_util): add max_steer_angle (`#740 <https://github.com/youtalk/autoware.universe/issues/740>`_)
+  * feat(vehicle_info_util): add max_steer_angle (`#740 <https://github.com/autowarefoundation/autoware.universe/issues/740>`_)
   * feat(vehicle_info_util): add max_steer_angle
   * applied pre-commit
   * Added max_steer_angle in test config
   Co-authored-by: Tomoya Kimura <tomoya.kimura@tier4.jp>
-  * fix(lidar_centerpoint): fix google drive url to avoid 404 (`#889 <https://github.com/youtalk/autoware.universe/issues/889>`_)
+  * fix(lidar_centerpoint): fix google drive url to avoid 404 (`#889 <https://github.com/autowarefoundation/autoware.universe/issues/889>`_)
   * fix(lidar_centerpoint): fix google drive url to avoid 404
   * Update CMakeLists.txt
   Co-authored-by: Kenji Miyake <31987104+kenji-miyake@users.noreply.github.com>
-  * chore: fix typos (`#886 <https://github.com/youtalk/autoware.universe/issues/886>`_)
-  * feat(state_rviz_plugin): add GateMode and PathChangeApproval Button (`#894 <https://github.com/youtalk/autoware.universe/issues/894>`_)
+  * chore: fix typos (`#886 <https://github.com/autowarefoundation/autoware.universe/issues/886>`_)
+  * feat(state_rviz_plugin): add GateMode and PathChangeApproval Button (`#894 <https://github.com/autowarefoundation/autoware.universe/issues/894>`_)
   * feat(state_rviz_plugin): add GateMode and PathChangeApproval Button
   * ci(pre-commit): autofix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-  * feat(map_tf_generator): accelerate the 'viewer' coordinate calculation (`#890 <https://github.com/youtalk/autoware.universe/issues/890>`_)
+  * feat(map_tf_generator): accelerate the 'viewer' coordinate calculation (`#890 <https://github.com/autowarefoundation/autoware.universe/issues/890>`_)
   * add random point sampling function to quickly calculate the 'viewer' coordinate
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Kenji Miyake <31987104+kenji-miyake@users.noreply.github.com>
-  * docs(obstacle_stop_planner): update documentation (`#880 <https://github.com/youtalk/autoware.universe/issues/880>`_)
+  * docs(obstacle_stop_planner): update documentation (`#880 <https://github.com/autowarefoundation/autoware.universe/issues/880>`_)
   * ci(pre-commit): autofix
   * fixed conflicts
   * ci(pre-commit): autofix
@@ -539,36 +539,36 @@ Changelog for package system_monitor
   * ci(pre-commit): autofix
   * ci(pre-commit): autofix
   * ci(pre-commit): autofix
-  * chore: sync files (`#629 <https://github.com/youtalk/autoware.universe/issues/629>`_)
+  * chore: sync files (`#629 <https://github.com/autowarefoundation/autoware.universe/issues/629>`_)
   * chore: sync files
   * ci(pre-commit): autofix
   Co-authored-by: kenji-miyake <kenji-miyake@users.noreply.github.com>
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-  * fix(dummy_diag_publisher): use anon to make unique node name instead of diag name (`#639 <https://github.com/youtalk/autoware.universe/issues/639>`_)
-  * chore: sync files (`#648 <https://github.com/youtalk/autoware.universe/issues/648>`_)
+  * fix(dummy_diag_publisher): use anon to make unique node name instead of diag name (`#639 <https://github.com/autowarefoundation/autoware.universe/issues/639>`_)
+  * chore: sync files (`#648 <https://github.com/autowarefoundation/autoware.universe/issues/648>`_)
   * chore: sync files
   * Revert "chore: sync files"
   This reverts commit b24f530b48306e16aa285f80a629ce5c5a9ccda7.
   * sync codecov.yaml
   Co-authored-by: kenji-miyake <kenji-miyake@users.noreply.github.com>
   Co-authored-by: Kenji Miyake <kenji.miyake@tier4.jp>
-  * fix(autoware_state_panel): fix message type for /api/autoware/get/engage (`#666 <https://github.com/youtalk/autoware.universe/issues/666>`_)
+  * fix(autoware_state_panel): fix message type for /api/autoware/get/engage (`#666 <https://github.com/autowarefoundation/autoware.universe/issues/666>`_)
   * fix(autoware_state_panel): fix message type for /api/autoware/get/engage
   * ci(pre-commit): autofix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-  * fix(behavior_velocity): avoid insert same point on trajectory utils (`#834 <https://github.com/youtalk/autoware.universe/issues/834>`_)
-  * refactor(behavior_velocity_planner): simplify CMakeLists.txt (`#855 <https://github.com/youtalk/autoware.universe/issues/855>`_)
-  * docs: fix 404 error caused by typo in url (`#871 <https://github.com/youtalk/autoware.universe/issues/871>`_)
+  * fix(behavior_velocity): avoid insert same point on trajectory utils (`#834 <https://github.com/autowarefoundation/autoware.universe/issues/834>`_)
+  * refactor(behavior_velocity_planner): simplify CMakeLists.txt (`#855 <https://github.com/autowarefoundation/autoware.universe/issues/855>`_)
+  * docs: fix 404 error caused by typo in url (`#871 <https://github.com/autowarefoundation/autoware.universe/issues/871>`_)
   * docs: fix 404 error caused by typo in url
   * docs: fix typo in url for yolov4
-  * fix(image_projection_based_fusion): set imagebuffersize (`#820 <https://github.com/youtalk/autoware.universe/issues/820>`_)
+  * fix(image_projection_based_fusion): set imagebuffersize (`#820 <https://github.com/autowarefoundation/autoware.universe/issues/820>`_)
   * fix: set imagebuffersize configured
   * ci(pre-commit): autofix
   Co-authored-by: suchang <chang.su@autocore.ai>
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-  * chore(avoidance_module): fix spell check (`#732 <https://github.com/youtalk/autoware.universe/issues/732>`_)
-  * feat: isolate gtests in all packages (`#693 <https://github.com/youtalk/autoware.universe/issues/693>`_)
-  * docs(virtual traffic light): add documentation (`#245 <https://github.com/youtalk/autoware.universe/issues/245>`_)
+  * chore(avoidance_module): fix spell check (`#732 <https://github.com/autowarefoundation/autoware.universe/issues/732>`_)
+  * feat: isolate gtests in all packages (`#693 <https://github.com/autowarefoundation/autoware.universe/issues/693>`_)
+  * docs(virtual traffic light): add documentation (`#245 <https://github.com/autowarefoundation/autoware.universe/issues/245>`_)
   * doc(behavior_velocity): add graph and fix link
   * doc(behavior_velocity): update virtual traffic light doc
   * doc(behavior_velocity): minor fix
@@ -579,7 +579,7 @@ Changelog for package system_monitor
   * apply suggestion
   * doc: to intersection-coordination
   Co-authored-by: Kenji Miyake <31987104+kenji-miyake@users.noreply.github.com>
-  * feat(surround_obstacle_checker): separate surround_obstacle_checker from hierarchical planning flow (`#830 <https://github.com/youtalk/autoware.universe/issues/830>`_)
+  * feat(surround_obstacle_checker): separate surround_obstacle_checker from hierarchical planning flow (`#830 <https://github.com/autowarefoundation/autoware.universe/issues/830>`_)
   * fix(surroud_obstacle_checker): use alias
   * feat(surround_obstacle_checker): use velocity limit
   * chore(surround_obstacle_checker): rename publisher, subscriber and callback functions
@@ -589,50 +589,50 @@ Changelog for package system_monitor
   * refactor(surround_obstacle_checker): cleanup polygon handling
   * refactor(surround_obstacle_checker): use marker helper
   * feat(planning_launch): separate surround_obstacle_checker from hierarchical motion planning flow
-  * fix(surround_obstacle_checker): fix ego footprint polygon (`#877 <https://github.com/youtalk/autoware.universe/issues/877>`_)
-  * fix: update nvinfer api (`#863 <https://github.com/youtalk/autoware.universe/issues/863>`_)
+  * fix(surround_obstacle_checker): fix ego footprint polygon (`#877 <https://github.com/autowarefoundation/autoware.universe/issues/877>`_)
+  * fix: update nvinfer api (`#863 <https://github.com/autowarefoundation/autoware.universe/issues/863>`_)
   * fix(lidar_centerpoint): update nvinfer api
   * fix(tensorrt_yolo): update nvinfer api
   * fix(lidar_apollo_instance_segmentation): update nvinfer api
   * fix(traffic_light_classifier): update nvinfer api
   * fix(traffic_light_ssd_fine_detector): update nvinfer api
   * pre-commit run
-  * fix(avoidance_module): ignore object instead of creating zero shift (`#731 <https://github.com/youtalk/autoware.universe/issues/731>`_)
+  * fix(avoidance_module): ignore object instead of creating zero shift (`#731 <https://github.com/autowarefoundation/autoware.universe/issues/731>`_)
   * fix: ignore object instead of creating zero shift
   instead of creating zero shift point, the object will be ignored.
   no behavior changes should be observed.
   * refactor: sync continue with upstream
   * fix: fix debug message for insufficient lateral margin
-  * fix(motion_velocity_smoother): curve deceleration not working with a specific parameter set (`#738 <https://github.com/youtalk/autoware.universe/issues/738>`_)
-  * test(autoware_testing): fix smoke_test (`#479 <https://github.com/youtalk/autoware.universe/issues/479>`_)
+  * fix(motion_velocity_smoother): curve deceleration not working with a specific parameter set (`#738 <https://github.com/autowarefoundation/autoware.universe/issues/738>`_)
+  * test(autoware_testing): fix smoke_test (`#479 <https://github.com/autowarefoundation/autoware.universe/issues/479>`_)
   * fix(autoware_testing): fix smoke_test
   * restore smoke_test for trajectory_follower_nodes
   * add support multiple parameter files
   * ci(pre-commit): autofix
   * minor fix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-  * feat(rviz_plugins): add velocity limit to autoware state panel (`#879 <https://github.com/youtalk/autoware.universe/issues/879>`_)
+  * feat(rviz_plugins): add velocity limit to autoware state panel (`#879 <https://github.com/autowarefoundation/autoware.universe/issues/879>`_)
   * feat(rviz_plugins): add velocity limit to autoware state panel
   * chore(rviz_plugin): change ms to kmh
-  * feat(vehicle_info_util): add max_steer_angle (`#740 <https://github.com/youtalk/autoware.universe/issues/740>`_)
+  * feat(vehicle_info_util): add max_steer_angle (`#740 <https://github.com/autowarefoundation/autoware.universe/issues/740>`_)
   * feat(vehicle_info_util): add max_steer_angle
   * applied pre-commit
   * Added max_steer_angle in test config
   Co-authored-by: Tomoya Kimura <tomoya.kimura@tier4.jp>
-  * fix(lidar_centerpoint): fix google drive url to avoid 404 (`#889 <https://github.com/youtalk/autoware.universe/issues/889>`_)
+  * fix(lidar_centerpoint): fix google drive url to avoid 404 (`#889 <https://github.com/autowarefoundation/autoware.universe/issues/889>`_)
   * fix(lidar_centerpoint): fix google drive url to avoid 404
   * Update CMakeLists.txt
   Co-authored-by: Kenji Miyake <31987104+kenji-miyake@users.noreply.github.com>
-  * chore: fix typos (`#886 <https://github.com/youtalk/autoware.universe/issues/886>`_)
-  * feat(state_rviz_plugin): add GateMode and PathChangeApproval Button (`#894 <https://github.com/youtalk/autoware.universe/issues/894>`_)
+  * chore: fix typos (`#886 <https://github.com/autowarefoundation/autoware.universe/issues/886>`_)
+  * feat(state_rviz_plugin): add GateMode and PathChangeApproval Button (`#894 <https://github.com/autowarefoundation/autoware.universe/issues/894>`_)
   * feat(state_rviz_plugin): add GateMode and PathChangeApproval Button
   * ci(pre-commit): autofix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-  * feat(map_tf_generator): accelerate the 'viewer' coordinate calculation (`#890 <https://github.com/youtalk/autoware.universe/issues/890>`_)
+  * feat(map_tf_generator): accelerate the 'viewer' coordinate calculation (`#890 <https://github.com/autowarefoundation/autoware.universe/issues/890>`_)
   * add random point sampling function to quickly calculate the 'viewer' coordinate
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Kenji Miyake <31987104+kenji-miyake@users.noreply.github.com>
-  * docs(obstacle_stop_planner): update documentation (`#880 <https://github.com/youtalk/autoware.universe/issues/880>`_)
+  * docs(obstacle_stop_planner): update documentation (`#880 <https://github.com/autowarefoundation/autoware.universe/issues/880>`_)
   * ci(pre-commit): autofix
   * fixed conflicts
   * ci(pre-commit): autofix
@@ -675,7 +675,7 @@ Changelog for package system_monitor
   Co-authored-by: Satoshi Tanaka <16330533+scepter914@users.noreply.github.com>
   Co-authored-by: Kenzo Lobos Tsunekawa <kenzo.lobos@tier4.jp>
   Co-authored-by: Yusuke Muramatsu <yukke42@users.noreply.github.com>
-* feat: add HDD monitoring items to hdd_monitor (`#721 <https://github.com/youtalk/autoware.universe/issues/721>`_)
+* feat: add HDD monitoring items to hdd_monitor (`#721 <https://github.com/autowarefoundation/autoware.universe/issues/721>`_)
   * feat: add HDD monitoring items to hdd_monitor
   * fix pre-commit C long type error
   * fixed the monitoring method of RecoveredError
@@ -686,7 +686,7 @@ Changelog for package system_monitor
   * fix(system_monitor): level change when not connected in HDD connection monitoring
   * fix(system_monitor): unmount function added in hdd_reader
   * fix(system_monitor): separate S.M.A.R.T. request and lazy unmount request for hdd_reader
-* feat(system_monitor): add IP packet reassembles failed monitoring to net_monitor (`#1427 <https://github.com/youtalk/autoware.universe/issues/1427>`_)
+* feat(system_monitor): add IP packet reassembles failed monitoring to net_monitor (`#1427 <https://github.com/autowarefoundation/autoware.universe/issues/1427>`_)
   * feat(system_monitor): add IP packet reassembles failed monitoring to net_monitor
   * fix build errors caused by merge mistakes
   * fix(system_monitor): chang word Reasm and fix deep nesting
@@ -696,63 +696,63 @@ Changelog for package system_monitor
   * fix(system_monitor): remove unnecessary static_cast
   * fix(system_monitor): typo fix
   Co-authored-by: ito-san <57388357+ito-san@users.noreply.github.com>
-* feat: add GPU clock monitoring to gpu_monitor (`#687 <https://github.com/youtalk/autoware.universe/issues/687>`_)
-* fix(system_monitor): fix parameter threshold of CPU Usage monitoring (`#1805 <https://github.com/youtalk/autoware.universe/issues/1805>`_)
+* feat: add GPU clock monitoring to gpu_monitor (`#687 <https://github.com/autowarefoundation/autoware.universe/issues/687>`_)
+* fix(system_monitor): fix parameter threshold of CPU Usage monitoring (`#1805 <https://github.com/autowarefoundation/autoware.universe/issues/1805>`_)
   Co-authored-by: ito-san <57388357+ito-san@users.noreply.github.com>
-* fix(system_monitor): incorrect counter increment in CPU Usage monitor (`#1783 <https://github.com/youtalk/autoware.universe/issues/1783>`_)
+* fix(system_monitor): incorrect counter increment in CPU Usage monitor (`#1783 <https://github.com/autowarefoundation/autoware.universe/issues/1783>`_)
   Co-authored-by: ito-san <57388357+ito-san@users.noreply.github.com>
-* feat: add CRC error monitoring to net_monitor (`#638 <https://github.com/youtalk/autoware.universe/issues/638>`_)
+* feat: add CRC error monitoring to net_monitor (`#638 <https://github.com/autowarefoundation/autoware.universe/issues/638>`_)
   * feat: add CRC error monitoring to net_monitor
   * add CRC error monitoring information to README.md
   * ci(pre-commit): autofix
   Co-authored-by: noriyuki.h <n-hamaike@esol.co.jp>
   Co-authored-by: ito-san <57388357+ito-san@users.noreply.github.com>
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* fix(system_monitor): multithreading support for boost::process (`#1714 <https://github.com/youtalk/autoware.universe/issues/1714>`_)
-* fix(system_monitor): move top command execution to a timer (`#948 <https://github.com/youtalk/autoware.universe/issues/948>`_)
+* fix(system_monitor): multithreading support for boost::process (`#1714 <https://github.com/autowarefoundation/autoware.universe/issues/1714>`_)
+* fix(system_monitor): move top command execution to a timer (`#948 <https://github.com/autowarefoundation/autoware.universe/issues/948>`_)
   * fix(system_monitor): move top command execution to  a timer
   * removed unnecessary update method
   * use tier4_autoware_utils::StopWatch
   * Ensure thread-safe
-* fix(system_monitor): add some smart information to diagnostics (`#708 <https://github.com/youtalk/autoware.universe/issues/708>`_)
-* fix(system_monitor): fix truncation warning in strncpy (`#872 <https://github.com/youtalk/autoware.universe/issues/872>`_)
+* fix(system_monitor): add some smart information to diagnostics (`#708 <https://github.com/autowarefoundation/autoware.universe/issues/708>`_)
+* fix(system_monitor): fix truncation warning in strncpy (`#872 <https://github.com/autowarefoundation/autoware.universe/issues/872>`_)
   * fix(system_monitor): fix truncation warning in strncpy
   * Use std::string constructor to copy char array
   * Fixed typo
-* feat: isolate gtests in all packages (`#693 <https://github.com/youtalk/autoware.universe/issues/693>`_)
-* fix(system_monitor): fix build error on tegra platform (`#869 <https://github.com/youtalk/autoware.universe/issues/869>`_)
+* feat: isolate gtests in all packages (`#693 <https://github.com/autowarefoundation/autoware.universe/issues/693>`_)
+* fix(system_monitor): fix build error on tegra platform (`#869 <https://github.com/autowarefoundation/autoware.universe/issues/869>`_)
   * fix(system_monitor): fix build error on tegra platform
   * ci(pre-commit): autofix
   * Update system/system_monitor/src/gpu_monitor/tegra_gpu_monitor.cpp
   Co-authored-by: Shark Liu <shark.liu@autocore.ai>
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Daisuke Nishimatsu <42202095+wep21@users.noreply.github.com>
-* chore: upgrade cmake_minimum_required to 3.14 (`#856 <https://github.com/youtalk/autoware.universe/issues/856>`_)
-* refactor: use autoware cmake (`#849 <https://github.com/youtalk/autoware.universe/issues/849>`_)
+* chore: upgrade cmake_minimum_required to 3.14 (`#856 <https://github.com/autowarefoundation/autoware.universe/issues/856>`_)
+* refactor: use autoware cmake (`#849 <https://github.com/autowarefoundation/autoware.universe/issues/849>`_)
   * remove autoware_auto_cmake
   * add build_depend of autoware_cmake
   * use autoware_cmake in CMakeLists.txt
   * fix bugs
   * fix cmake lint errors
-* chore: remove bad chars (`#845 <https://github.com/youtalk/autoware.universe/issues/845>`_)
-* fix: suppress compiler warnings (`#852 <https://github.com/youtalk/autoware.universe/issues/852>`_)
-* style: fix format of package.xml (`#844 <https://github.com/youtalk/autoware.universe/issues/844>`_)
-* fix(system_monitor): modify build error in rolling (`#788 <https://github.com/youtalk/autoware.universe/issues/788>`_)
-* ci(pre-commit): update pre-commit-hooks-ros (`#625 <https://github.com/youtalk/autoware.universe/issues/625>`_)
+* chore: remove bad chars (`#845 <https://github.com/autowarefoundation/autoware.universe/issues/845>`_)
+* fix: suppress compiler warnings (`#852 <https://github.com/autowarefoundation/autoware.universe/issues/852>`_)
+* style: fix format of package.xml (`#844 <https://github.com/autowarefoundation/autoware.universe/issues/844>`_)
+* fix(system_monitor): modify build error in rolling (`#788 <https://github.com/autowarefoundation/autoware.universe/issues/788>`_)
+* ci(pre-commit): update pre-commit-hooks-ros (`#625 <https://github.com/autowarefoundation/autoware.universe/issues/625>`_)
   * ci(pre-commit): update pre-commit-hooks-ros
   * ci(pre-commit): autofix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat(system_monitor): add some smart information to diagnostics (`#560 <https://github.com/youtalk/autoware.universe/issues/560>`_)
+* feat(system_monitor): add some smart information to diagnostics (`#560 <https://github.com/autowarefoundation/autoware.universe/issues/560>`_)
   * feat(system_monitor): add some smart information to diagnostics
   * ci(pre-commit): autofix
   * modify regex for nvme device name
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat(system_monitor): change method of CPU usage monitoring (`#557 <https://github.com/youtalk/autoware.universe/issues/557>`_)
-  * feat(lidar_detection): changing default input topic name of lidar detection nodes (`#433 <https://github.com/youtalk/autoware.universe/issues/433>`_)
+* feat(system_monitor): change method of CPU usage monitoring (`#557 <https://github.com/autowarefoundation/autoware.universe/issues/557>`_)
+  * feat(lidar_detection): changing default input topic name of lidar detection nodes (`#433 <https://github.com/autowarefoundation/autoware.universe/issues/433>`_)
   * feat(system_monitor): change method of CPU usage monitoring
   Co-authored-by: Taichi Higashide <azumade.30@gmail.com>
-* feat(hdd_monitor): add unit to value side as well as other metrics (`#325 <https://github.com/youtalk/autoware.universe/issues/325>`_)
-* feat: add cpu usage topic (`#353 <https://github.com/youtalk/autoware.universe/issues/353>`_)
+* feat(hdd_monitor): add unit to value side as well as other metrics (`#325 <https://github.com/autowarefoundation/autoware.universe/issues/325>`_)
+* feat: add cpu usage topic (`#353 <https://github.com/autowarefoundation/autoware.universe/issues/353>`_)
   * modified for publishing cpu_usage_api
   * modified for calib error output and cpu usage output
   * modified push_back condition
@@ -768,13 +768,13 @@ Changelog for package system_monitor
   * modify unnecessary change for pull request
   * run pre-commit
   * modify unnecessary change
-  * modified along the comments on PR `#353 <https://github.com/youtalk/autoware.universe/issues/353>`_
-  * modified along the comments on PR `#353 <https://github.com/youtalk/autoware.universe/issues/353>`_
+  * modified along the comments on PR `#353 <https://github.com/autowarefoundation/autoware.universe/issues/353>`_
+  * modified along the comments on PR `#353 <https://github.com/autowarefoundation/autoware.universe/issues/353>`_
   * remove unnecessary process
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat(system_monitor): handle parameter as mount point (`#259 <https://github.com/youtalk/autoware.universe/issues/259>`_)
-* fix(system_monitor): fix build error on aarch64 (`#263 <https://github.com/youtalk/autoware.universe/issues/263>`_)
-* feat: change launch package name (`#186 <https://github.com/youtalk/autoware.universe/issues/186>`_)
+* feat(system_monitor): handle parameter as mount point (`#259 <https://github.com/autowarefoundation/autoware.universe/issues/259>`_)
+* fix(system_monitor): fix build error on aarch64 (`#263 <https://github.com/autowarefoundation/autoware.universe/issues/263>`_)
+* feat: change launch package name (`#186 <https://github.com/autowarefoundation/autoware.universe/issues/186>`_)
   * rename launch folder
   * autoware_launch -> tier4_autoware_launch
   * integration_launch -> tier4_integration_launch
@@ -792,22 +792,22 @@ Changelog for package system_monitor
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: tanaka3 <ttatcoder@outlook.jp>
   Co-authored-by: taikitanaka3 <65527974+taikitanaka3@users.noreply.github.com>
-* chore(sync): merged autoware.iv/pull/2362 (`#761 <https://github.com/youtalk/autoware.universe/issues/761>`_) (`#134 <https://github.com/youtalk/autoware.universe/issues/134>`_)
+* chore(sync): merged autoware.iv/pull/2362 (`#761 <https://github.com/autowarefoundation/autoware.universe/issues/761>`_) (`#134 <https://github.com/autowarefoundation/autoware.universe/issues/134>`_)
   Co-authored-by: h-mitsui-esol <57085544+h-mitsui-esol@users.noreply.github.com>
-* feat: add autoware_system_monitor package (`#14 <https://github.com/youtalk/autoware.universe/issues/14>`_)
+* feat: add autoware_system_monitor package (`#14 <https://github.com/autowarefoundation/autoware.universe/issues/14>`_)
   * release v0.4.0
-  * Fixed uninitialized variable. (`#763 <https://github.com/youtalk/autoware.universe/issues/763>`_)
-  * Fixed various bugs. (`#768 <https://github.com/youtalk/autoware.universe/issues/768>`_)
+  * Fixed uninitialized variable. (`#763 <https://github.com/autowarefoundation/autoware.universe/issues/763>`_)
+  * Fixed various bugs. (`#768 <https://github.com/autowarefoundation/autoware.universe/issues/768>`_)
   * Fixed various bugs.
   * Fixed wrong status report of NIC.
-  * Added the mode of CPU Usage to check statistics calculated as averages among all processors by default. (`#788 <https://github.com/youtalk/autoware.universe/issues/788>`_)
-  * fix uninitialized variables (`#816 <https://github.com/youtalk/autoware.universe/issues/816>`_)
+  * Added the mode of CPU Usage to check statistics calculated as averages among all processors by default. (`#788 <https://github.com/autowarefoundation/autoware.universe/issues/788>`_)
+  * fix uninitialized variables (`#816 <https://github.com/autowarefoundation/autoware.universe/issues/816>`_)
   * remove ROS1 packages temporarily
   * Revert "remove ROS1 packages temporarily"
   This reverts commit a9436882d50dc09fa5b8d6c0a151a10def76b242.
   * add COLCON_IGNORE to ros1 packages
-  * Rename launch files to launch.xml (`#28 <https://github.com/youtalk/autoware.universe/issues/28>`_)
-  * Port system monitor to ros2 (`#71 <https://github.com/youtalk/autoware.universe/issues/71>`_)
+  * Rename launch files to launch.xml (`#28 <https://github.com/autowarefoundation/autoware.universe/issues/28>`_)
+  * Port system monitor to ros2 (`#71 <https://github.com/autowarefoundation/autoware.universe/issues/71>`_)
   * Implement a utility function that spins and updates a monitor node.
   * Port cpu monitor
   * Port hdd monitor.
@@ -820,89 +820,89 @@ Changelog for package system_monitor
   * Clean up the build and launch files:
   * Clean up and comment on CMake and package files.
   * Port the launch file to ROS2
-  * Rename h files to hpp (`#142 <https://github.com/youtalk/autoware.universe/issues/142>`_)
+  * Rename h files to hpp (`#142 <https://github.com/autowarefoundation/autoware.universe/issues/142>`_)
   * Change includes
   * Rename files
   * Adjustments to make things compile
   * Other packages
-  * Adjust copyright notice on 532 out of 699 source files (`#143 <https://github.com/youtalk/autoware.universe/issues/143>`_)
-  * Use quotes for includes where appropriate (`#144 <https://github.com/youtalk/autoware.universe/issues/144>`_)
+  * Adjust copyright notice on 532 out of 699 source files (`#143 <https://github.com/autowarefoundation/autoware.universe/issues/143>`_)
+  * Use quotes for includes where appropriate (`#144 <https://github.com/autowarefoundation/autoware.universe/issues/144>`_)
   * Use quotes for includes where appropriate
   * Fix lint tests
   * Make tests pass hopefully
-  * Run uncrustify on the entire Pilot.Auto codebase (`#151 <https://github.com/youtalk/autoware.universe/issues/151>`_)
+  * Run uncrustify on the entire Pilot.Auto codebase (`#151 <https://github.com/autowarefoundation/autoware.universe/issues/151>`_)
   * Run uncrustify on the entire Pilot.Auto codebase
   * Exclude open PRs
-  * ROS2 Linting: system_monitor (`#207 <https://github.com/youtalk/autoware.universe/issues/207>`_)
+  * ROS2 Linting: system_monitor (`#207 <https://github.com/autowarefoundation/autoware.universe/issues/207>`_)
   * Add linters
   * Fix clang-tidy error in util.hpp
-  * Ros2 v0.8.0 system monitor (`#276 <https://github.com/youtalk/autoware.universe/issues/276>`_)
+  * Ros2 v0.8.0 system monitor (`#276 <https://github.com/autowarefoundation/autoware.universe/issues/276>`_)
   * fix dependency of system_monitor
-  * Rename ROS-related .yaml to .param.yaml (`#352 <https://github.com/youtalk/autoware.universe/issues/352>`_)
+  * Rename ROS-related .yaml to .param.yaml (`#352 <https://github.com/autowarefoundation/autoware.universe/issues/352>`_)
   * Rename ROS-related .yaml to .param.yaml
   * Remove prefix 'default\_' of yaml files
   * Rename vehicle_info.yaml to vehicle_info.param.yaml
   * Rename diagnostic_aggregator's param files
   * Fix overlooked parameters
-  * Exclude SwPowerCap as an error. (`#1146 <https://github.com/youtalk/autoware.universe/issues/1146>`_) (`#364 <https://github.com/youtalk/autoware.universe/issues/364>`_)
+  * Exclude SwPowerCap as an error. (`#1146 <https://github.com/autowarefoundation/autoware.universe/issues/1146>`_) (`#364 <https://github.com/autowarefoundation/autoware.universe/issues/364>`_)
   Co-authored-by: ito-san <57388357+ito-san@users.noreply.github.com>
-  * [Update v0.9.0] system monitor (`#365 <https://github.com/youtalk/autoware.universe/issues/365>`_)
-  * Disable CPU Load Average warning. (`#1147 <https://github.com/youtalk/autoware.universe/issues/1147>`_)
-  * Fix cpu_monitor respawning forever. (`#1150 <https://github.com/youtalk/autoware.universe/issues/1150>`_)
-  * Disable cpu_temperature in planning simulation (`#1151 <https://github.com/youtalk/autoware.universe/issues/1151>`_)
-  * Net Monitor: Handle as an error if specified device not exist. (`#1152 <https://github.com/youtalk/autoware.universe/issues/1152>`_)
+  * [Update v0.9.0] system monitor (`#365 <https://github.com/autowarefoundation/autoware.universe/issues/365>`_)
+  * Disable CPU Load Average warning. (`#1147 <https://github.com/autowarefoundation/autoware.universe/issues/1147>`_)
+  * Fix cpu_monitor respawning forever. (`#1150 <https://github.com/autowarefoundation/autoware.universe/issues/1150>`_)
+  * Disable cpu_temperature in planning simulation (`#1151 <https://github.com/autowarefoundation/autoware.universe/issues/1151>`_)
+  * Net Monitor: Handle as an error if specified device not exist. (`#1152 <https://github.com/autowarefoundation/autoware.universe/issues/1152>`_)
   * Handled as an error if specified device not exist.
   * Disable network diags in simulation
   Co-authored-by: Kenji Miyake <kenji.miyake@tier4.jp>
   * apply ament_uncrustify
-  * Disable resource monitoring in planning_simulator (`#1172 <https://github.com/youtalk/autoware.universe/issues/1172>`_)
-  * Treat logging errors as safe faults (`#1164 <https://github.com/youtalk/autoware.universe/issues/1164>`_)
-  * Fix test code of system_monitor (`#1178 <https://github.com/youtalk/autoware.universe/issues/1178>`_)
+  * Disable resource monitoring in planning_simulator (`#1172 <https://github.com/autowarefoundation/autoware.universe/issues/1172>`_)
+  * Treat logging errors as safe faults (`#1164 <https://github.com/autowarefoundation/autoware.universe/issues/1164>`_)
+  * Fix test code of system_monitor (`#1178 <https://github.com/autowarefoundation/autoware.universe/issues/1178>`_)
   Co-authored-by: ito-san <57388357+ito-san@users.noreply.github.com>
   Co-authored-by: Kenji Miyake <kenji.miyake@tier4.jp>
   Co-authored-by: Kenji Miyake <31987104+kenji-miyake@users.noreply.github.com>
-  * Use thread for ntpdate. (`#1160 <https://github.com/youtalk/autoware.universe/issues/1160>`_) (`#375 <https://github.com/youtalk/autoware.universe/issues/375>`_)
-  * Use thread for ntpdate. (`#1160 <https://github.com/youtalk/autoware.universe/issues/1160>`_)
+  * Use thread for ntpdate. (`#1160 <https://github.com/autowarefoundation/autoware.universe/issues/1160>`_) (`#375 <https://github.com/autowarefoundation/autoware.universe/issues/375>`_)
+  * Use thread for ntpdate. (`#1160 <https://github.com/autowarefoundation/autoware.universe/issues/1160>`_)
   * removed unused variable
-  * Import v0.9.1 (`#431 <https://github.com/youtalk/autoware.universe/issues/431>`_)
-  * add local optimal solution ocillation check to ndt_scan_matcher (`#1182 <https://github.com/youtalk/autoware.universe/issues/1182>`_)
-  * Add obstacle_crush diagnostic (`#1186 <https://github.com/youtalk/autoware.universe/issues/1186>`_)
-  * Fix diagnostics api (`#1185 <https://github.com/youtalk/autoware.universe/issues/1185>`_)
+  * Import v0.9.1 (`#431 <https://github.com/autowarefoundation/autoware.universe/issues/431>`_)
+  * add local optimal solution ocillation check to ndt_scan_matcher (`#1182 <https://github.com/autowarefoundation/autoware.universe/issues/1182>`_)
+  * Add obstacle_crush diagnostic (`#1186 <https://github.com/autowarefoundation/autoware.universe/issues/1186>`_)
+  * Fix diagnostics api (`#1185 <https://github.com/autowarefoundation/autoware.universe/issues/1185>`_)
   * Fix diagnostics api
   * Don't overwrite level
   * Overwrite level of No Fault diagnostics
-  * Add missing diag in autoware_error_monitor.yaml (`#1187 <https://github.com/youtalk/autoware.universe/issues/1187>`_)
-  * Filter hazard_status (`#1191 <https://github.com/youtalk/autoware.universe/issues/1191>`_)
+  * Add missing diag in autoware_error_monitor.yaml (`#1187 <https://github.com/autowarefoundation/autoware.universe/issues/1187>`_)
+  * Filter hazard_status (`#1191 <https://github.com/autowarefoundation/autoware.universe/issues/1191>`_)
   * Filter hazard_status
   * Filter leaf diagnostics
-  * Fix wrong calculation of available memory. (`#1168 <https://github.com/youtalk/autoware.universe/issues/1168>`_)
+  * Fix wrong calculation of available memory. (`#1168 <https://github.com/autowarefoundation/autoware.universe/issues/1168>`_)
   * Fixed wrong calculation of available memory.
   * Added comments about output example of free -tb command.
-  * Change monitoring method to get HDD temperature and usage per specified device. (`#1195 <https://github.com/youtalk/autoware.universe/issues/1195>`_)
+  * Change monitoring method to get HDD temperature and usage per specified device. (`#1195 <https://github.com/autowarefoundation/autoware.universe/issues/1195>`_)
   * Changed monitoring method to get temperature and usage per specified device.
   * Fixed test codes.
   * Removed unnecessary (void) parameter.
-  * return input pointcloud when ground plane not found (`#1190 <https://github.com/youtalk/autoware.universe/issues/1190>`_)
-  * fix yaw-smoothing bug (`#1198 <https://github.com/youtalk/autoware.universe/issues/1198>`_)
+  * return input pointcloud when ground plane not found (`#1190 <https://github.com/autowarefoundation/autoware.universe/issues/1190>`_)
+  * fix yaw-smoothing bug (`#1198 <https://github.com/autowarefoundation/autoware.universe/issues/1198>`_)
   * Fix lint
   Co-authored-by: Taichi Higashide <taichi.higashide@tier4.jp>
   Co-authored-by: ito-san <57388357+ito-san@users.noreply.github.com>
   Co-authored-by: tkimura4 <tomoya.kimura@tier4.jp>
-  * Fix typo in system module (`#434 <https://github.com/youtalk/autoware.universe/issues/434>`_)
+  * Fix typo in system module (`#434 <https://github.com/autowarefoundation/autoware.universe/issues/434>`_)
   * Fix typo in system module
   * Change variable name
   * Move comments
   * Apply uncrustify
-  * Split system_monitor config (`#452 <https://github.com/youtalk/autoware.universe/issues/452>`_)
-  * Remove unnecessary diagnostic update. (`#455 <https://github.com/youtalk/autoware.universe/issues/455>`_)
-  * add use_sim-time option (`#454 <https://github.com/youtalk/autoware.universe/issues/454>`_)
-  * Sync public repo (`#1228 <https://github.com/youtalk/autoware.universe/issues/1228>`_)
-  * [simple_planning_simulator] add readme (`#424 <https://github.com/youtalk/autoware.universe/issues/424>`_)
+  * Split system_monitor config (`#452 <https://github.com/autowarefoundation/autoware.universe/issues/452>`_)
+  * Remove unnecessary diagnostic update. (`#455 <https://github.com/autowarefoundation/autoware.universe/issues/455>`_)
+  * add use_sim-time option (`#454 <https://github.com/autowarefoundation/autoware.universe/issues/454>`_)
+  * Sync public repo (`#1228 <https://github.com/autowarefoundation/autoware.universe/issues/1228>`_)
+  * [simple_planning_simulator] add readme (`#424 <https://github.com/autowarefoundation/autoware.universe/issues/424>`_)
   * add readme of simple_planning_simulator
   * Update simulator/simple_planning_simulator/README.md
-  * set transit_margin_time to intersect. planner (`#460 <https://github.com/youtalk/autoware.universe/issues/460>`_)
-  * Fix pose2twist (`#462 <https://github.com/youtalk/autoware.universe/issues/462>`_)
-  * Ros2 vehicle info param server (`#447 <https://github.com/youtalk/autoware.universe/issues/447>`_)
+  * set transit_margin_time to intersect. planner (`#460 <https://github.com/autowarefoundation/autoware.universe/issues/460>`_)
+  * Fix pose2twist (`#462 <https://github.com/autowarefoundation/autoware.universe/issues/462>`_)
+  * Ros2 vehicle info param server (`#447 <https://github.com/autowarefoundation/autoware.universe/issues/447>`_)
   * add vehicle_info_param_server
   * update vehicle info
   * apply format
@@ -910,7 +910,7 @@ Changelog for package system_monitor
   * skip unnecessary search
   * delete vehicle param file
   * fix bug
-  * Ros2 fix topic name part2 (`#425 <https://github.com/youtalk/autoware.universe/issues/425>`_)
+  * Ros2 fix topic name part2 (`#425 <https://github.com/autowarefoundation/autoware.universe/issues/425>`_)
   * Fix topic name of traffic_light_classifier
   * Fix topic name of traffic_light_visualization
   * Fix topic name of traffic_light_ssd_fine_detector
@@ -920,19 +920,19 @@ Changelog for package system_monitor
   * Fix lint traffic_light_classifier
   * Fix lint traffic_light_classifier
   * Fix lint traffic_light_ssd_fine_detector
-  * Fix issues in hdd_reader (`#466 <https://github.com/youtalk/autoware.universe/issues/466>`_)
+  * Fix issues in hdd_reader (`#466 <https://github.com/autowarefoundation/autoware.universe/issues/466>`_)
   * Fix some issues detected by Coverity Scan and Clang-Tidy
   * Update launch command
   * Add more `close(new_sock)`
   * Simplify the definitions of struct
-  * fix: re-construct laneletMapLayer for reindex RTree (`#463 <https://github.com/youtalk/autoware.universe/issues/463>`_)
-  * Rviz overlay render fix (`#461 <https://github.com/youtalk/autoware.universe/issues/461>`_)
+  * fix: re-construct laneletMapLayer for reindex RTree (`#463 <https://github.com/autowarefoundation/autoware.universe/issues/463>`_)
+  * Rviz overlay render fix (`#461 <https://github.com/autowarefoundation/autoware.universe/issues/461>`_)
   * Moved painiting in SteeringAngle plugin to update()
   * super class now back to MFD
   * uncrustified
   * acquire data in mutex
   * back to RTD as superclass
-  * Rviz overlay render in update (`#465 <https://github.com/youtalk/autoware.universe/issues/465>`_)
+  * Rviz overlay render in update (`#465 <https://github.com/autowarefoundation/autoware.universe/issues/465>`_)
   * Moved painiting in SteeringAngle plugin to update()
   * super class now back to MFD
   * uncrustified
@@ -946,7 +946,7 @@ Changelog for package system_monitor
   Co-authored-by: Kazuki Miyahara <kmiya@outlook.com>
   Co-authored-by: Makoto Tokunaga <vios-fish@users.noreply.github.com>
   Co-authored-by: Adam Dąbrowski <adam.dabrowski@robotec.ai>
-  * Fix issues in gpu_monitor (`#1248 <https://github.com/youtalk/autoware.universe/issues/1248>`_)
+  * Fix issues in gpu_monitor (`#1248 <https://github.com/autowarefoundation/autoware.universe/issues/1248>`_)
   * Fix issues in gpu_monitor
   * Fix uninitialized variables
   * Use range-based for loop
@@ -954,13 +954,13 @@ Changelog for package system_monitor
   * Replace C-style to C++-style
   * Make iterators const
   * Fix fmt::format() usage error
-  * Unify Apache-2.0 license name (`#1242 <https://github.com/youtalk/autoware.universe/issues/1242>`_)
-  * Remove use_sim_time for set_parameter (`#1260 <https://github.com/youtalk/autoware.universe/issues/1260>`_)
-  * [system_monitor] change some nodes into components (`#1234 <https://github.com/youtalk/autoware.universe/issues/1234>`_)
+  * Unify Apache-2.0 license name (`#1242 <https://github.com/autowarefoundation/autoware.universe/issues/1242>`_)
+  * Remove use_sim_time for set_parameter (`#1260 <https://github.com/autowarefoundation/autoware.universe/issues/1260>`_)
+  * [system_monitor] change some nodes into components (`#1234 <https://github.com/autowarefoundation/autoware.universe/issues/1234>`_)
   Co-authored-by: Takeshi Miura <57553950+1222-takeshi@users.noreply.github.com>
   Co-authored-by: Takeshi Miura <takeshi.miura@tier4.jp>
   Co-authored-by: wep21 <border_goldenmarket@yahoo.co.jp>
-  * add system_monitor.launch.py (`#1238 <https://github.com/youtalk/autoware.universe/issues/1238>`_)
+  * add system_monitor.launch.py (`#1238 <https://github.com/autowarefoundation/autoware.universe/issues/1238>`_)
   * add system_monitor.launch.py
   * refactor system_monitor.launch.py
   * fix launch bug
@@ -968,50 +968,50 @@ Changelog for package system_monitor
   * fix launch py
   * fix param loading
   * format code
-  * fix system monitor executor to publish diagnostics asynclonously (`#1283 <https://github.com/youtalk/autoware.universe/issues/1283>`_)
-  * Fix lint errors (`#1378 <https://github.com/youtalk/autoware.universe/issues/1378>`_)
+  * fix system monitor executor to publish diagnostics asynclonously (`#1283 <https://github.com/autowarefoundation/autoware.universe/issues/1283>`_)
+  * Fix lint errors (`#1378 <https://github.com/autowarefoundation/autoware.universe/issues/1378>`_)
   * Fix lint errors
   * Fix variable names
-  * Add kernel CPU usage. (`#1465 <https://github.com/youtalk/autoware.universe/issues/1465>`_)
+  * Add kernel CPU usage. (`#1465 <https://github.com/autowarefoundation/autoware.universe/issues/1465>`_)
   * Add kernel CPU usage.
   * Change CPU x: usage to CPU x: total.
   * Changed variable name.
-  * Add markdownlint and prettier (`#1661 <https://github.com/youtalk/autoware.universe/issues/1661>`_)
+  * Add markdownlint and prettier (`#1661 <https://github.com/autowarefoundation/autoware.universe/issues/1661>`_)
   * Add markdownlint and prettier
   * Ignore .param.yaml
   * Apply format
-  * suppress warnings for system monitor (`#1723 <https://github.com/youtalk/autoware.universe/issues/1723>`_)
+  * suppress warnings for system monitor (`#1723 <https://github.com/autowarefoundation/autoware.universe/issues/1723>`_)
   * fix for hdd_monitor
   * fix no initialization and warning
-  * change command for ntp_monitor (`#1705 <https://github.com/youtalk/autoware.universe/issues/1705>`_)
+  * change command for ntp_monitor (`#1705 <https://github.com/autowarefoundation/autoware.universe/issues/1705>`_)
   * [EVT4-403] change command for ntp_monitor
   * [EVT4-403] fixed CI build error
   * [EVT4-403] fixed cpplint error
   * delete executeChronyc thread, fix error topic and log output code
   * fix cpplint error and code style divergence
   * fix cpplint error(missing correction)
-  * Fix MD029 (`#1813 <https://github.com/youtalk/autoware.universe/issues/1813>`_)
-  * Fix -Wunused-parameter (`#1836 <https://github.com/youtalk/autoware.universe/issues/1836>`_)
+  * Fix MD029 (`#1813 <https://github.com/autowarefoundation/autoware.universe/issues/1813>`_)
+  * Fix -Wunused-parameter (`#1836 <https://github.com/autowarefoundation/autoware.universe/issues/1836>`_)
   * Fix -Wunused-parameter
   * Fix mistake
   * fix spell
   * Fix lint issues
   * Ignore flake8 warnings
   Co-authored-by: Hiroki OTA <hiroki.ota@tier4.jp>
-  * add gpu usage per process (`#1798 <https://github.com/youtalk/autoware.universe/issues/1798>`_)
+  * add gpu usage per process (`#1798 <https://github.com/autowarefoundation/autoware.universe/issues/1798>`_)
   * add gpu usage per process
   * change illegal usage(4294967295%) to 0%, and fix CI running errors
   * Replace gettimeofday with rclcpp::Node::now().
   * Fix uncrustify error.
   * Replace rclcpp::Node::now() with rclcpp::Clock(RCL_SYSTEM_TIME).
   Co-authored-by: ito-san <fumihito.ito@tier4.jp>
-  * fix some typos (`#1941 <https://github.com/youtalk/autoware.universe/issues/1941>`_)
+  * fix some typos (`#1941 <https://github.com/autowarefoundation/autoware.universe/issues/1941>`_)
   * fix some typos
   * fix typo
   * Fix typo
   Co-authored-by: Kenji Miyake <kenji.miyake@tier4.jp>
-  * suppress warnings for system directory `#2046 <https://github.com/youtalk/autoware.universe/issues/2046>`_
-  * add sort-package-xml hook in pre-commit (`#1881 <https://github.com/youtalk/autoware.universe/issues/1881>`_)
+  * suppress warnings for system directory `#2046 <https://github.com/autowarefoundation/autoware.universe/issues/2046>`_
+  * add sort-package-xml hook in pre-commit (`#1881 <https://github.com/autowarefoundation/autoware.universe/issues/1881>`_)
   * add sort xml hook in pre-commit
   * change retval to exit_status
   * rename
@@ -1025,8 +1025,8 @@ Changelog for package system_monitor
   * move prettier-xml to pre-commit-hooks-ros
   * update version for bug-fix
   * apply pre-commit
-  * Add execution time logging. (`#2066 <https://github.com/youtalk/autoware.universe/issues/2066>`_)
-  * Add markdown-link-check pre-commit (`#2215 <https://github.com/youtalk/autoware.universe/issues/2215>`_)
+  * Add execution time logging. (`#2066 <https://github.com/autowarefoundation/autoware.universe/issues/2066>`_)
+  * Add markdown-link-check pre-commit (`#2215 <https://github.com/autowarefoundation/autoware.universe/issues/2215>`_)
   * add markdown-lint-check pre-commit
   * delete files argument
   * add optional hook
@@ -1041,7 +1041,7 @@ Changelog for package system_monitor
   * Ignore tier4 github url
   * Update link
   Co-authored-by: Kenji Miyake <kenji.miyake@tier4.jp>
-  * Change formatter to clang-format and black (`#2332 <https://github.com/youtalk/autoware.universe/issues/2332>`_)
+  * Change formatter to clang-format and black (`#2332 <https://github.com/autowarefoundation/autoware.universe/issues/2332>`_)
   * Revert "Temporarily comment out pre-commit hooks"
   This reverts commit 748e9cdb145ce12f8b520bcbd97f5ff899fc28a3.
   * Replace ament_lint_common with autoware_lint_common
@@ -1053,8 +1053,8 @@ Changelog for package system_monitor
   * Fix include double quotes to angle brackets
   * Apply clang-format
   * Fix build errors
-  * Add COLCON_IGNORE (`#500 <https://github.com/youtalk/autoware.universe/issues/500>`_)
-  * remove COLCON_IGNORE in system_packages and map_tf_generator (`#532 <https://github.com/youtalk/autoware.universe/issues/532>`_)
+  * Add COLCON_IGNORE (`#500 <https://github.com/autowarefoundation/autoware.universe/issues/500>`_)
+  * remove COLCON_IGNORE in system_packages and map_tf_generator (`#532 <https://github.com/autowarefoundation/autoware.universe/issues/532>`_)
   Co-authored-by: mitsudome-r <ryohsuke.mitsudome@tier4.jp>
   Co-authored-by: ito-san <57388357+ito-san@users.noreply.github.com>
   Co-authored-by: Kazuki Miyahara <kmiya@outlook.com>

--- a/system/topic_state_monitor/CHANGELOG.rst
+++ b/system/topic_state_monitor/CHANGELOG.rst
@@ -5,19 +5,19 @@ Changelog for package topic_state_monitor
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* chore(topic_state_monitor): enrich error log message (`#7236 <https://github.com/youtalk/autoware.universe/issues/7236>`_)
+* chore(topic_state_monitor): enrich error log message (`#7236 <https://github.com/autowarefoundation/autoware.universe/issues/7236>`_)
 * Contributors: Takamasa Horibe, Yutaka Kondo
 
 0.26.0 (2024-04-03)
 -------------------
-* refactor(topic_state_monitor): add state log message (`#5378 <https://github.com/youtalk/autoware.universe/issues/5378>`_)
+* refactor(topic_state_monitor): add state log message (`#5378 <https://github.com/autowarefoundation/autoware.universe/issues/5378>`_)
   * refactor(topic_state_monitor): add state log message
   * add debug print
   ---------
-* docs(topic_state_monitor): rename readme to README (`#4225 <https://github.com/youtalk/autoware.universe/issues/4225>`_)
-* chore: update maintainer (`#4140 <https://github.com/youtalk/autoware.universe/issues/4140>`_)
+* docs(topic_state_monitor): rename readme to README (`#4225 <https://github.com/autowarefoundation/autoware.universe/issues/4225>`_)
+* chore: update maintainer (`#4140 <https://github.com/autowarefoundation/autoware.universe/issues/4140>`_)
   Co-authored-by: Ryohsuke Mitsudome <43976834+mitsudome-r@users.noreply.github.com>
-* build: mark autoware_cmake as <buildtool_depend> (`#3616 <https://github.com/youtalk/autoware.universe/issues/3616>`_)
+* build: mark autoware_cmake as <buildtool_depend> (`#3616 <https://github.com/autowarefoundation/autoware.universe/issues/3616>`_)
   * build: mark autoware_cmake as <buildtool_depend>
   with <build_depend>, autoware_cmake is automatically exported with ament_target_dependencies() (unecessary)
   * style(pre-commit): autofix
@@ -25,27 +25,27 @@ Changelog for package topic_state_monitor
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Kenji Miyake <kenji.miyake@tier4.jp>
-* chore: sync files (`#3227 <https://github.com/youtalk/autoware.universe/issues/3227>`_)
+* chore: sync files (`#3227 <https://github.com/autowarefoundation/autoware.universe/issues/3227>`_)
   * chore: sync files
   * style(pre-commit): autofix
   ---------
   Co-authored-by: kenji-miyake <kenji-miyake@users.noreply.github.com>
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat(topic_state_monitor): support transform topic check (`#1586 <https://github.com/youtalk/autoware.universe/issues/1586>`_)
-* refactor(topic_state_monitor): move the parameter group to match implementation (`#1909 <https://github.com/youtalk/autoware.universe/issues/1909>`_)
-* chore: upgrade cmake_minimum_required to 3.14 (`#856 <https://github.com/youtalk/autoware.universe/issues/856>`_)
-* refactor: use autoware cmake (`#849 <https://github.com/youtalk/autoware.universe/issues/849>`_)
+* feat(topic_state_monitor): support transform topic check (`#1586 <https://github.com/autowarefoundation/autoware.universe/issues/1586>`_)
+* refactor(topic_state_monitor): move the parameter group to match implementation (`#1909 <https://github.com/autowarefoundation/autoware.universe/issues/1909>`_)
+* chore: upgrade cmake_minimum_required to 3.14 (`#856 <https://github.com/autowarefoundation/autoware.universe/issues/856>`_)
+* refactor: use autoware cmake (`#849 <https://github.com/autowarefoundation/autoware.universe/issues/849>`_)
   * remove autoware_auto_cmake
   * add build_depend of autoware_cmake
   * use autoware_cmake in CMakeLists.txt
   * fix bugs
   * fix cmake lint errors
-* style: fix format of package.xml (`#844 <https://github.com/youtalk/autoware.universe/issues/844>`_)
-* ci(pre-commit): update pre-commit-hooks-ros (`#625 <https://github.com/youtalk/autoware.universe/issues/625>`_)
+* style: fix format of package.xml (`#844 <https://github.com/autowarefoundation/autoware.universe/issues/844>`_)
+* ci(pre-commit): update pre-commit-hooks-ros (`#625 <https://github.com/autowarefoundation/autoware.universe/issues/625>`_)
   * ci(pre-commit): update pre-commit-hooks-ros
   * ci(pre-commit): autofix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* chore: replace legacy timer (`#329 <https://github.com/youtalk/autoware.universe/issues/329>`_)
+* chore: replace legacy timer (`#329 <https://github.com/autowarefoundation/autoware.universe/issues/329>`_)
   * chore(goal_distance_calculator): replace legacy timer
   * chore(path_distance_calculator): replace legacy timer
   * chore(control_performance_analysis): replace legacy timer
@@ -80,28 +80,28 @@ Changelog for package topic_state_monitor
   * chore(external_cmd_converter): replace legacy timer
   * chore(pacmod_interface): replace legacy timer
   * chore(lint): apply pre-commit
-* feat: add topic_state_monitor package (`#15 <https://github.com/youtalk/autoware.universe/issues/15>`_)
-  * Ros2 v0.8.0 topic state monitor (`#283 <https://github.com/youtalk/autoware.universe/issues/283>`_)
-  * Add node_name_suffix to topic_state_monitor.launch (`#1157 <https://github.com/youtalk/autoware.universe/issues/1157>`_) (`#370 <https://github.com/youtalk/autoware.universe/issues/370>`_)
-  * fix launch file (`#411 <https://github.com/youtalk/autoware.universe/issues/411>`_)
-  * add transient local option to topic state monitor (`#410 <https://github.com/youtalk/autoware.universe/issues/410>`_)
+* feat: add topic_state_monitor package (`#15 <https://github.com/autowarefoundation/autoware.universe/issues/15>`_)
+  * Ros2 v0.8.0 topic state monitor (`#283 <https://github.com/autowarefoundation/autoware.universe/issues/283>`_)
+  * Add node_name_suffix to topic_state_monitor.launch (`#1157 <https://github.com/autowarefoundation/autoware.universe/issues/1157>`_) (`#370 <https://github.com/autowarefoundation/autoware.universe/issues/370>`_)
+  * fix launch file (`#411 <https://github.com/autowarefoundation/autoware.universe/issues/411>`_)
+  * add transient local option to topic state monitor (`#410 <https://github.com/autowarefoundation/autoware.universe/issues/410>`_)
   * add transient local option to topic state monitor
   * sort parameters
   * sort parameter
-  * [topic_state_monitor]: Add best effort option (`#430 <https://github.com/youtalk/autoware.universe/issues/430>`_)
+  * [topic_state_monitor]: Add best effort option (`#430 <https://github.com/autowarefoundation/autoware.universe/issues/430>`_)
   Co-authored-by: autoware <autoware@example.com>
-  * add use_sim-time option (`#454 <https://github.com/youtalk/autoware.universe/issues/454>`_)
-  * Fix for rolling (`#1226 <https://github.com/youtalk/autoware.universe/issues/1226>`_)
+  * add use_sim-time option (`#454 <https://github.com/autowarefoundation/autoware.universe/issues/454>`_)
+  * Fix for rolling (`#1226 <https://github.com/autowarefoundation/autoware.universe/issues/1226>`_)
   * Replace doc by description
   * Replace ns by push-ros-namespace
-  * change to composable node (`#1233 <https://github.com/youtalk/autoware.universe/issues/1233>`_)
-  * Unify Apache-2.0 license name (`#1242 <https://github.com/youtalk/autoware.universe/issues/1242>`_)
-  * Remove use_sim_time for set_parameter (`#1260 <https://github.com/youtalk/autoware.universe/issues/1260>`_)
-  * Fix lint errors (`#1378 <https://github.com/youtalk/autoware.universe/issues/1378>`_)
+  * change to composable node (`#1233 <https://github.com/autowarefoundation/autoware.universe/issues/1233>`_)
+  * Unify Apache-2.0 license name (`#1242 <https://github.com/autowarefoundation/autoware.universe/issues/1242>`_)
+  * Remove use_sim_time for set_parameter (`#1260 <https://github.com/autowarefoundation/autoware.universe/issues/1260>`_)
+  * Fix lint errors (`#1378 <https://github.com/autowarefoundation/autoware.universe/issues/1378>`_)
   * Fix lint errors
   * Fix variable names
-  * Use integrated generic subscription (`#1342 <https://github.com/youtalk/autoware.universe/issues/1342>`_)
-  * suppress warnings for declare parameters (`#1724 <https://github.com/youtalk/autoware.universe/issues/1724>`_)
+  * Use integrated generic subscription (`#1342 <https://github.com/autowarefoundation/autoware.universe/issues/1342>`_)
+  * suppress warnings for declare parameters (`#1724 <https://github.com/autowarefoundation/autoware.universe/issues/1724>`_)
   * fix for lanelet2_extension
   * fix for traffic light ssd fine detector
   * fix for topic_state_monitor
@@ -120,14 +120,14 @@ Changelog for package topic_state_monitor
   * add Werror
   * add Werror
   * fix style
-  * Fix -Wunused-parameter (`#1836 <https://github.com/youtalk/autoware.universe/issues/1836>`_)
+  * Fix -Wunused-parameter (`#1836 <https://github.com/autowarefoundation/autoware.universe/issues/1836>`_)
   * Fix -Wunused-parameter
   * Fix mistake
   * fix spell
   * Fix lint issues
   * Ignore flake8 warnings
   Co-authored-by: Hiroki OTA <hiroki.ota@tier4.jp>
-  * Change formatter to clang-format and black (`#2332 <https://github.com/youtalk/autoware.universe/issues/2332>`_)
+  * Change formatter to clang-format and black (`#2332 <https://github.com/autowarefoundation/autoware.universe/issues/2332>`_)
   * Revert "Temporarily comment out pre-commit hooks"
   This reverts commit 748e9cdb145ce12f8b520bcbd97f5ff899fc28a3.
   * Replace ament_lint_common with autoware_lint_common
@@ -139,9 +139,9 @@ Changelog for package topic_state_monitor
   * Fix include double quotes to angle brackets
   * Apply clang-format
   * Fix build errors
-  * Add COLCON_IGNORE (`#500 <https://github.com/youtalk/autoware.universe/issues/500>`_)
-  * remove COLCON_IGNORE in system_packages and map_tf_generator (`#532 <https://github.com/youtalk/autoware.universe/issues/532>`_)
-  * [topic_state_monitor]add readme (`#565 <https://github.com/youtalk/autoware.universe/issues/565>`_)
+  * Add COLCON_IGNORE (`#500 <https://github.com/autowarefoundation/autoware.universe/issues/500>`_)
+  * remove COLCON_IGNORE in system_packages and map_tf_generator (`#532 <https://github.com/autowarefoundation/autoware.universe/issues/532>`_)
+  * [topic_state_monitor]add readme (`#565 <https://github.com/autowarefoundation/autoware.universe/issues/565>`_)
   * add readme
   * Update system/topic_state_monitor/Readme.md
   Co-authored-by: Kazuki Miyahara <kmiya@outlook.com>

--- a/system/velodyne_monitor/CHANGELOG.rst
+++ b/system/velodyne_monitor/CHANGELOG.rst
@@ -5,15 +5,15 @@ Changelog for package velodyne_monitor
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* feat(velodyne_monitor): componentize node (`#7201 <https://github.com/youtalk/autoware.universe/issues/7201>`_)
+* feat(velodyne_monitor): componentize node (`#7201 <https://github.com/autowarefoundation/autoware.universe/issues/7201>`_)
 * Contributors: Takagi, Isamu, Yutaka Kondo
 
 0.26.0 (2024-04-03)
 -------------------
-* refactor(system-velodyne-monitor): rework parameters (`#5667 <https://github.com/youtalk/autoware.universe/issues/5667>`_)
+* refactor(system-velodyne-monitor): rework parameters (`#5667 <https://github.com/autowarefoundation/autoware.universe/issues/5667>`_)
   system-velodyne-monitor
-* docs(velodyne_monitor): rename readme to README (`#4224 <https://github.com/youtalk/autoware.universe/issues/4224>`_)
-* build: mark autoware_cmake as <buildtool_depend> (`#3616 <https://github.com/youtalk/autoware.universe/issues/3616>`_)
+* docs(velodyne_monitor): rename readme to README (`#4224 <https://github.com/autowarefoundation/autoware.universe/issues/4224>`_)
+* build: mark autoware_cmake as <buildtool_depend> (`#3616 <https://github.com/autowarefoundation/autoware.universe/issues/3616>`_)
   * build: mark autoware_cmake as <buildtool_depend>
   with <build_depend>, autoware_cmake is automatically exported with ament_target_dependencies() (unecessary)
   * style(pre-commit): autofix
@@ -21,14 +21,14 @@ Changelog for package velodyne_monitor
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Kenji Miyake <kenji.miyake@tier4.jp>
-* fix(velodyne_monitor): add fmt package to dependencies (`#3069 <https://github.com/youtalk/autoware.universe/issues/3069>`_)
+* fix(velodyne_monitor): add fmt package to dependencies (`#3069 <https://github.com/autowarefoundation/autoware.universe/issues/3069>`_)
   Co-authored-by: ito-san <57388357+ito-san@users.noreply.github.com>
-* docs(velodyne_monitor): add known limits (`#1802 <https://github.com/youtalk/autoware.universe/issues/1802>`_)
+* docs(velodyne_monitor): add known limits (`#1802 <https://github.com/autowarefoundation/autoware.universe/issues/1802>`_)
   * docs(velodyne_monitor): add known limits
   * Update Readme.md
-* fix(velodyne_monitor): add temp_hot\_*** to 20 (`#1744 <https://github.com/youtalk/autoware.universe/issues/1744>`_)
+* fix(velodyne_monitor): add temp_hot\_*** to 20 (`#1744 <https://github.com/autowarefoundation/autoware.universe/issues/1744>`_)
   fix(velodyne_monitor): add 20 to temp_hot\_***
-* fix(velodyne monitor): fix warning and error threshold of hot temperature (`#1623 <https://github.com/youtalk/autoware.universe/issues/1623>`_)
+* fix(velodyne monitor): fix warning and error threshold of hot temperature (`#1623 <https://github.com/autowarefoundation/autoware.universe/issues/1623>`_)
   * fix(velodyne_monitor): fix warning and error threshold of hot temperature
   * doc: update README
   * doc: fix typo
@@ -37,41 +37,41 @@ Changelog for package velodyne_monitor
   * Update Readme.md
   * Update Readme.md
   * fix: typo
-* chore: upgrade cmake_minimum_required to 3.14 (`#856 <https://github.com/youtalk/autoware.universe/issues/856>`_)
-* refactor: use autoware cmake (`#849 <https://github.com/youtalk/autoware.universe/issues/849>`_)
+* chore: upgrade cmake_minimum_required to 3.14 (`#856 <https://github.com/autowarefoundation/autoware.universe/issues/856>`_)
+* refactor: use autoware cmake (`#849 <https://github.com/autowarefoundation/autoware.universe/issues/849>`_)
   * remove autoware_auto_cmake
   * add build_depend of autoware_cmake
   * use autoware_cmake in CMakeLists.txt
   * fix bugs
   * fix cmake lint errors
-* style: fix format of package.xml (`#844 <https://github.com/youtalk/autoware.universe/issues/844>`_)
-* ci(pre-commit): update pre-commit-hooks-ros (`#625 <https://github.com/youtalk/autoware.universe/issues/625>`_)
+* style: fix format of package.xml (`#844 <https://github.com/autowarefoundation/autoware.universe/issues/844>`_)
+* ci(pre-commit): update pre-commit-hooks-ros (`#625 <https://github.com/autowarefoundation/autoware.universe/issues/625>`_)
   * ci(pre-commit): update pre-commit-hooks-ros
   * ci(pre-commit): autofix
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* feat: add velodyne_monitor package (`#17 <https://github.com/youtalk/autoware.universe/issues/17>`_)
-  * Ros2 v0.8.0 velodyne monitor (`#285 <https://github.com/youtalk/autoware.universe/issues/285>`_)
-  * Rename ROS-related .yaml to .param.yaml (`#352 <https://github.com/youtalk/autoware.universe/issues/352>`_)
+* feat: add velodyne_monitor package (`#17 <https://github.com/autowarefoundation/autoware.universe/issues/17>`_)
+  * Ros2 v0.8.0 velodyne monitor (`#285 <https://github.com/autowarefoundation/autoware.universe/issues/285>`_)
+  * Rename ROS-related .yaml to .param.yaml (`#352 <https://github.com/autowarefoundation/autoware.universe/issues/352>`_)
   * Rename ROS-related .yaml to .param.yaml
   * Remove prefix 'default\_' of yaml files
   * Rename vehicle_info.yaml to vehicle_info.param.yaml
   * Rename diagnostic_aggregator's param files
   * Fix overlooked parameters
-  * add use_sim-time option (`#454 <https://github.com/youtalk/autoware.universe/issues/454>`_)
-  * Unify Apache-2.0 license name (`#1242 <https://github.com/youtalk/autoware.universe/issues/1242>`_)
-  * Remove use_sim_time for set_parameter (`#1260 <https://github.com/youtalk/autoware.universe/issues/1260>`_)
-  * Add exception handling for extract_json() (`#1779 <https://github.com/youtalk/autoware.universe/issues/1779>`_)
+  * add use_sim-time option (`#454 <https://github.com/autowarefoundation/autoware.universe/issues/454>`_)
+  * Unify Apache-2.0 license name (`#1242 <https://github.com/autowarefoundation/autoware.universe/issues/1242>`_)
+  * Remove use_sim_time for set_parameter (`#1260 <https://github.com/autowarefoundation/autoware.universe/issues/1260>`_)
+  * Add exception handling for extract_json() (`#1779 <https://github.com/autowarefoundation/autoware.universe/issues/1779>`_)
   * Add exception handling for extract_json()
   * Add diagnostics error when catching exception
   Co-authored-by: Takayuki AKAMINE <takayuki.akamine@tier4.jp>
-  * Fix -Wunused-parameter (`#1836 <https://github.com/youtalk/autoware.universe/issues/1836>`_)
+  * Fix -Wunused-parameter (`#1836 <https://github.com/autowarefoundation/autoware.universe/issues/1836>`_)
   * Fix -Wunused-parameter
   * Fix mistake
   * fix spell
   * Fix lint issues
   * Ignore flake8 warnings
   Co-authored-by: Hiroki OTA <hiroki.ota@tier4.jp>
-  * Fix compiler warnings (`#1837 <https://github.com/youtalk/autoware.universe/issues/1837>`_)
+  * Fix compiler warnings (`#1837 <https://github.com/autowarefoundation/autoware.universe/issues/1837>`_)
   * Fix -Wunused-private-field
   * Fix -Wunused-variable
   * Fix -Wformat-security
@@ -86,13 +86,13 @@ Changelog for package velodyne_monitor
   * Ignore -Wno-deprecated-declarations in CUDA-related packages
   * Fix mistake
   * Fix -Wunused-parameter
-  * Remove duplicated update (`#2072 <https://github.com/youtalk/autoware.universe/issues/2072>`_) (`#2084 <https://github.com/youtalk/autoware.universe/issues/2084>`_)
+  * Remove duplicated update (`#2072 <https://github.com/autowarefoundation/autoware.universe/issues/2072>`_) (`#2084 <https://github.com/autowarefoundation/autoware.universe/issues/2084>`_)
   Co-authored-by: Daisuke Nishimatsu <42202095+wep21@users.noreply.github.com>
-  * Fix velodyne monitor config file variable name (`#2090 <https://github.com/youtalk/autoware.universe/issues/2090>`_) (`#2092 <https://github.com/youtalk/autoware.universe/issues/2092>`_)
+  * Fix velodyne monitor config file variable name (`#2090 <https://github.com/autowarefoundation/autoware.universe/issues/2090>`_) (`#2092 <https://github.com/autowarefoundation/autoware.universe/issues/2092>`_)
   Co-authored-by: j4tfwm6z <proj-jpntaxi@tier4.jp>
   Co-authored-by: Daisuke Nishimatsu <42202095+wep21@users.noreply.github.com>
   Co-authored-by: j4tfwm6z <proj-jpntaxi@tier4.jp>
-  * Change formatter to clang-format and black (`#2332 <https://github.com/youtalk/autoware.universe/issues/2332>`_)
+  * Change formatter to clang-format and black (`#2332 <https://github.com/autowarefoundation/autoware.universe/issues/2332>`_)
   * Revert "Temporarily comment out pre-commit hooks"
   This reverts commit 748e9cdb145ce12f8b520bcbd97f5ff899fc28a3.
   * Replace ament_lint_common with autoware_lint_common
@@ -104,9 +104,9 @@ Changelog for package velodyne_monitor
   * Fix include double quotes to angle brackets
   * Apply clang-format
   * Fix build errors
-  * Add COLCON_IGNORE (`#500 <https://github.com/youtalk/autoware.universe/issues/500>`_)
-  * remove COLCON_IGNORE in system_packages and map_tf_generator (`#532 <https://github.com/youtalk/autoware.universe/issues/532>`_)
-  * [Velodyne monitor]add readme (`#570 <https://github.com/youtalk/autoware.universe/issues/570>`_)
+  * Add COLCON_IGNORE (`#500 <https://github.com/autowarefoundation/autoware.universe/issues/500>`_)
+  * remove COLCON_IGNORE in system_packages and map_tf_generator (`#532 <https://github.com/autowarefoundation/autoware.universe/issues/532>`_)
+  * [Velodyne monitor]add readme (`#570 <https://github.com/autowarefoundation/autoware.universe/issues/570>`_)
   * add readme
   * change the description
   * Update system/velodyne_monitor/Readme.md

--- a/tools/reaction_analyzer/CHANGELOG.rst
+++ b/tools/reaction_analyzer/CHANGELOG.rst
@@ -5,30 +5,30 @@ Changelog for package reaction_analyzer
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* docs(reaction_analyzer): update bag files and the README (`#8633 <https://github.com/youtalk/autoware.universe/issues/8633>`_)
+* docs(reaction_analyzer): update bag files and the README (`#8633 <https://github.com/autowarefoundation/autoware.universe/issues/8633>`_)
   * docs(reaction_analyzer): update bag files and the README
-* fix(reaction_analyzer): fix include hierarchy of tf2_eigen (`#8663 <https://github.com/youtalk/autoware.universe/issues/8663>`_)
+* fix(reaction_analyzer): fix include hierarchy of tf2_eigen (`#8663 <https://github.com/autowarefoundation/autoware.universe/issues/8663>`_)
   Fixed include hierarchy of tf2_eigen
-* fix(reaction_analyzer): fix variableScope (`#8450 <https://github.com/youtalk/autoware.universe/issues/8450>`_)
+* fix(reaction_analyzer): fix variableScope (`#8450 <https://github.com/autowarefoundation/autoware.universe/issues/8450>`_)
   * fix:variableScope
   * fix:clang format
   ---------
-* fix(reaction_analyzer): fix constVariableReference (`#8063 <https://github.com/youtalk/autoware.universe/issues/8063>`_)
+* fix(reaction_analyzer): fix constVariableReference (`#8063 <https://github.com/autowarefoundation/autoware.universe/issues/8063>`_)
   * fix:constVariableReference
   * fix:constVariableReference
   * fix:constVariableReference
   * fix:suppression constVariableReference
   ---------
-* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/youtalk/autoware.universe/issues/7594>`_)
-* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/youtalk/autoware.universe/issues/7539>`_)
+* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/autowarefoundation/autoware.universe/issues/7594>`_)
+* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/autowarefoundation/autoware.universe/issues/7539>`_)
   refactor(motion_utils): add autoware prefix and include dir
-* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/youtalk/autoware.universe/issues/7538>`_)
+* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/autowarefoundation/autoware.universe/issues/7538>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* feat!: replace autoware_auto_msgs with autoware_msgs for tools (`#7250 <https://github.com/youtalk/autoware.universe/issues/7250>`_)
+* feat!: replace autoware_auto_msgs with autoware_msgs for tools (`#7250 <https://github.com/autowarefoundation/autoware.universe/issues/7250>`_)
   Co-authored-by: Cynthia Liu <cynthia.liu@autocore.ai>
   Co-authored-by: NorahXiong <norah.xiong@autocore.ai>
   Co-authored-by: beginningfan <beginning.fan@autocore.ai>
-* feat(reaction_analyzer): add reaction anaylzer tool to measure end-to-end delay in sudden obstacle braking response (`#5954 <https://github.com/youtalk/autoware.universe/issues/5954>`_)
+* feat(reaction_analyzer): add reaction anaylzer tool to measure end-to-end delay in sudden obstacle braking response (`#5954 <https://github.com/autowarefoundation/autoware.universe/issues/5954>`_)
   * feat(reaction_analyzer): add reaction anaylzer tool to measure end-to-end delay in sudden obstacle braking response
   * feat: implement message_filters package, clean up
   * feat: update style and readme

--- a/vehicle/autoware_accel_brake_map_calibrator/CHANGELOG.rst
+++ b/vehicle/autoware_accel_brake_map_calibrator/CHANGELOG.rst
@@ -5,7 +5,7 @@ Changelog for package autoware_accel_brake_map_calibrator
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* feat(autoware_accel_brake_map_calibrator): conditional actuation data processing based on source (`#8593 <https://github.com/youtalk/autoware.universe/issues/8593>`_)
+* feat(autoware_accel_brake_map_calibrator): conditional actuation data processing based on source (`#8593 <https://github.com/autowarefoundation/autoware.universe/issues/8593>`_)
   * fix: Conditional Actuation Data Processing Based on Source
   * style(pre-commit): autofix
   * delete extra comentout, indent
@@ -13,20 +13,20 @@ Changelog for package autoware_accel_brake_map_calibrator
   * style(pre-commit): autofix
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* refactor(autowre_accel_brake_map_calibrator): fix for flake-ros v0.9.0 (`#8529 <https://github.com/youtalk/autoware.universe/issues/8529>`_)
-* fix(autoware_accel_brake_map_calibrator): fix redundantInitialization (`#8230 <https://github.com/youtalk/autoware.universe/issues/8230>`_)
-* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/youtalk/autoware.universe/issues/7594>`_)
-* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/youtalk/autoware.universe/issues/7539>`_)
+* refactor(autowre_accel_brake_map_calibrator): fix for flake-ros v0.9.0 (`#8529 <https://github.com/autowarefoundation/autoware.universe/issues/8529>`_)
+* fix(autoware_accel_brake_map_calibrator): fix redundantInitialization (`#8230 <https://github.com/autowarefoundation/autoware.universe/issues/8230>`_)
+* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/autowarefoundation/autoware.universe/issues/7594>`_)
+* refactor(motion_utils)!: add autoware prefix and include dir (`#7539 <https://github.com/autowarefoundation/autoware.universe/issues/7539>`_)
   refactor(motion_utils): add autoware prefix and include dir
-* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/youtalk/autoware.universe/issues/7538>`_)
+* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/autowarefoundation/autoware.universe/issues/7538>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* feat(accel_brake_map_calibrator): replace polling takeData function with the callback function (`#7429 <https://github.com/youtalk/autoware.universe/issues/7429>`_)
+* feat(accel_brake_map_calibrator): replace polling takeData function with the callback function (`#7429 <https://github.com/autowarefoundation/autoware.universe/issues/7429>`_)
   * fix : repush to solve conflict
   * style(pre-commit): autofix
   * delete duplicated int cast
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
-* refactor(accel_brake_map_calibrator)!: add autoware\_ prefix (`#7351 <https://github.com/youtalk/autoware.universe/issues/7351>`_)
+* refactor(accel_brake_map_calibrator)!: add autoware\_ prefix (`#7351 <https://github.com/autowarefoundation/autoware.universe/issues/7351>`_)
   * add prefix to the codes
   change dir name
   update

--- a/vehicle/autoware_external_cmd_converter/CHANGELOG.rst
+++ b/vehicle/autoware_external_cmd_converter/CHANGELOG.rst
@@ -5,18 +5,18 @@ Changelog for package autoware_external_cmd_converter
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* feat(autoware_external_cmd_converter): add ext cmd converter tests (`#9118 <https://github.com/youtalk/autoware.universe/issues/9118>`_)
+* feat(autoware_external_cmd_converter): add ext cmd converter tests (`#9118 <https://github.com/autowarefoundation/autoware.universe/issues/9118>`_)
   * add ext cmd converter tests
   * add briefs to describe the tests
   * update tests and add nan and inf check
   ---------
-* refactor(autoware_external_cmd_converter): add explanation about external control commands (`#8224 <https://github.com/youtalk/autoware.universe/issues/8224>`_)
+* refactor(autoware_external_cmd_converter): add explanation about external control commands (`#8224 <https://github.com/autowarefoundation/autoware.universe/issues/8224>`_)
   * refactor(autoware_external_cmd_converter): add explanation about external control commands
   * style(pre-commit): autofix
   ---------
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Tomoya Kimura <tomoya.kimura@tier4.jp>
-* fix(autoware_external_cmd_converter): fix check_topic_state (`#7921 <https://github.com/youtalk/autoware.universe/issues/7921>`_)
+* fix(autoware_external_cmd_converter): fix check_topic_state (`#7921 <https://github.com/autowarefoundation/autoware.universe/issues/7921>`_)
   * fix(autoware_external_cmd_converter): fix check_topic_state
   * style(pre-commit): autofix
   * Update vehicle/autoware_external_cmd_converter/src/node.cpp
@@ -26,10 +26,10 @@ Changelog for package autoware_external_cmd_converter
   Co-authored-by: shtokuda <shumpei.tokuda@tier4.jp>
   Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
   Co-authored-by: Shumpei Wakabayashi <42209144+shmpwk@users.noreply.github.com>
-* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/youtalk/autoware.universe/issues/7594>`_)
-* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/youtalk/autoware.universe/issues/7538>`_)
+* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/autowarefoundation/autoware.universe/issues/7594>`_)
+* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/autowarefoundation/autoware.universe/issues/7538>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* refactor(external cmd converter)!: add autoware\_ prefix (`#7361 <https://github.com/youtalk/autoware.universe/issues/7361>`_)
+* refactor(external cmd converter)!: add autoware\_ prefix (`#7361 <https://github.com/autowarefoundation/autoware.universe/issues/7361>`_)
   * add prefix to the code
   * rename
   * fix

--- a/vehicle/autoware_raw_vehicle_cmd_converter/CHANGELOG.rst
+++ b/vehicle/autoware_raw_vehicle_cmd_converter/CHANGELOG.rst
@@ -5,9 +5,9 @@ Changelog for package autoware_raw_vehicle_cmd_converter
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* fix(simple_planning_simulator, raw_vehicle_cmd_converter): swap row index and column index for csv loader  (`#8963 <https://github.com/youtalk/autoware.universe/issues/8963>`_)
+* fix(simple_planning_simulator, raw_vehicle_cmd_converter): swap row index and column index for csv loader  (`#8963 <https://github.com/autowarefoundation/autoware.universe/issues/8963>`_)
   swap row and column
-* test(raw_vehicle_cmd_converter): add tests (`#8951 <https://github.com/youtalk/autoware.universe/issues/8951>`_)
+* test(raw_vehicle_cmd_converter): add tests (`#8951 <https://github.com/autowarefoundation/autoware.universe/issues/8951>`_)
   * remove header file according to clangd warning
   * add test
   * fix
@@ -15,18 +15,18 @@ Changelog for package autoware_raw_vehicle_cmd_converter
   * apply clang tidy
   * fix test content
   ---------
-* refactor(autoware_interpolation): prefix package and namespace with autoware (`#8088 <https://github.com/youtalk/autoware.universe/issues/8088>`_)
+* refactor(autoware_interpolation): prefix package and namespace with autoware (`#8088 <https://github.com/autowarefoundation/autoware.universe/issues/8088>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* refactor(start_planner,raw_vechile_cmd_converter): align parameter with autoware_launch's parameter (`#8913 <https://github.com/youtalk/autoware.universe/issues/8913>`_)
+* refactor(start_planner,raw_vechile_cmd_converter): align parameter with autoware_launch's parameter (`#8913 <https://github.com/autowarefoundation/autoware.universe/issues/8913>`_)
   * align autoware_raw_vehicle_cmd_converter's parameter
   * align start_planner's parameter
   ---------
-* fix(raw_vehicle_cmd_converter): fix convert_steer_cmd_method condition (`#8813 <https://github.com/youtalk/autoware.universe/issues/8813>`_)
-* fix(raw_vehicle_cmd_converter): fix null check (`#8677 <https://github.com/youtalk/autoware.universe/issues/8677>`_)
-* chore(raw_vehicle_cmd_converter): add maintainer (`#8671 <https://github.com/youtalk/autoware.universe/issues/8671>`_)
-* feat(raw_vehicle_cmd_converter): set convert_actuation_to_steering_status false by default (`#8668 <https://github.com/youtalk/autoware.universe/issues/8668>`_)
-* feat(raw_vehicle_cmd_converter): disable actuation to steering (`#8588 <https://github.com/youtalk/autoware.universe/issues/8588>`_)
-* feat(raw_vehicle_cmd_converter): add steer command conversion with VGR (`#8504 <https://github.com/youtalk/autoware.universe/issues/8504>`_)
+* fix(raw_vehicle_cmd_converter): fix convert_steer_cmd_method condition (`#8813 <https://github.com/autowarefoundation/autoware.universe/issues/8813>`_)
+* fix(raw_vehicle_cmd_converter): fix null check (`#8677 <https://github.com/autowarefoundation/autoware.universe/issues/8677>`_)
+* chore(raw_vehicle_cmd_converter): add maintainer (`#8671 <https://github.com/autowarefoundation/autoware.universe/issues/8671>`_)
+* feat(raw_vehicle_cmd_converter): set convert_actuation_to_steering_status false by default (`#8668 <https://github.com/autowarefoundation/autoware.universe/issues/8668>`_)
+* feat(raw_vehicle_cmd_converter): disable actuation to steering (`#8588 <https://github.com/autowarefoundation/autoware.universe/issues/8588>`_)
+* feat(raw_vehicle_cmd_converter): add steer command conversion with VGR (`#8504 <https://github.com/autowarefoundation/autoware.universe/issues/8504>`_)
   * feat(raw_vehicle_cmd_converter): add steer command conversion with VGR
   * make class and add test
   * remove member vgr_coef from node
@@ -39,17 +39,17 @@ Changelog for package autoware_raw_vehicle_cmd_converter
   * add comment for using normal sub for steering status
   ---------
   Co-authored-by: Takamasa Horibe <horibe.takamasa@gmail.com>
-* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/youtalk/autoware.universe/issues/7594>`_)
-* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/youtalk/autoware.universe/issues/7538>`_)
+* refactor(universe_utils/motion_utils)!: add autoware namespace (`#7594 <https://github.com/autowarefoundation/autoware.universe/issues/7594>`_)
+* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/autowarefoundation/autoware.universe/issues/7538>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* feat(raw_vehicle_cmd_converter): use polling subscriber (`#7319 <https://github.com/youtalk/autoware.universe/issues/7319>`_)
+* feat(raw_vehicle_cmd_converter): use polling subscriber (`#7319 <https://github.com/autowarefoundation/autoware.universe/issues/7319>`_)
   * replace subscription
   * fix document
   * sum up functions
   * add maintainer
   ---------
   Co-authored-by: Shumpei Wakabayashi <42209144+shmpwk@users.noreply.github.com>
-* refactor(accel_brake_map_calibrator)!: add autoware\_ prefix (`#7351 <https://github.com/youtalk/autoware.universe/issues/7351>`_)
+* refactor(accel_brake_map_calibrator)!: add autoware\_ prefix (`#7351 <https://github.com/autowarefoundation/autoware.universe/issues/7351>`_)
   * add prefix to the codes
   change dir name
   update
@@ -60,7 +60,7 @@ Changelog for package autoware_raw_vehicle_cmd_converter
   * restore
   * poi
   ---------
-* refactor(raw_vehicle_cmd_converter)!: prefix package and namespace with autoware (`#7385 <https://github.com/youtalk/autoware.universe/issues/7385>`_)
+* refactor(raw_vehicle_cmd_converter)!: prefix package and namespace with autoware (`#7385 <https://github.com/autowarefoundation/autoware.universe/issues/7385>`_)
   * add prefix
   * fix other packages
   * fix cppcheck

--- a/vehicle/autoware_steer_offset_estimator/CHANGELOG.rst
+++ b/vehicle/autoware_steer_offset_estimator/CHANGELOG.rst
@@ -5,15 +5,15 @@ Changelog for package autoware_steer_offset_estimator
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* refactor(pose2twist)!: prefix package and namespace with autoware (`#8347 <https://github.com/youtalk/autoware.universe/issues/8347>`_)
+* refactor(pose2twist)!: prefix package and namespace with autoware (`#8347 <https://github.com/autowarefoundation/autoware.universe/issues/8347>`_)
   * add autoware\_ prefix
   * use target_include_directories instead
   ---------
   Co-authored-by: SakodaShintaro <shintaro.sakoda@tier4.jp>
-* fix(steer_offset_estimator): fix link to json schema in README (`#7655 <https://github.com/youtalk/autoware.universe/issues/7655>`_)
-* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/youtalk/autoware.universe/issues/7538>`_)
+* fix(steer_offset_estimator): fix link to json schema in README (`#7655 <https://github.com/autowarefoundation/autoware.universe/issues/7655>`_)
+* feat(autoware_universe_utils)!: rename from tier4_autoware_utils (`#7538 <https://github.com/autowarefoundation/autoware.universe/issues/7538>`_)
   Co-authored-by: kosuke55 <kosuke.tnp@gmail.com>
-* refactor(vehicle_info_utils)!: prefix package and namespace with autoware (`#7353 <https://github.com/youtalk/autoware.universe/issues/7353>`_)
+* refactor(vehicle_info_utils)!: prefix package and namespace with autoware (`#7353 <https://github.com/autowarefoundation/autoware.universe/issues/7353>`_)
   * chore(autoware_vehicle_info_utils): rename header
   * chore(bpp-common): vehicle info
   * chore(path_optimizer): vehicle info
@@ -48,7 +48,7 @@ Changelog for package autoware_steer_offset_estimator
   * chore(sensing): vehicle info
   * fix(autoware_joy_controller): remove unused deps
   ---------
-* chore(steer_offset_estimator): add prefix autoware\_ to steer_offset_estimator (`#7342 <https://github.com/youtalk/autoware.universe/issues/7342>`_)
+* chore(steer_offset_estimator): add prefix autoware\_ to steer_offset_estimator (`#7342 <https://github.com/autowarefoundation/autoware.universe/issues/7342>`_)
   * add perfix
   * fix directory structrue
   * fix include guard


### PR DESCRIPTION
## Description

The links in the `CHANGELOG.rst` files were pointing to an incorrect URL.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
