### PR TITLE
fix(collision_detector): skip process when odometry is not published

### DIFF
--- a/control/autoware_collision_detector/include/autoware/collision_detector/node.hpp
+++ b/control/autoware_collision_detector/include/autoware/collision_detector/node.hpp
@@ -108,6 +108,8 @@ private:
   rclcpp::TimerBase::SharedPtr timer_;
 
   // publisher and subscriber
+  autoware::universe_utils::InterProcessPollingSubscriber<nav_msgs::msg::Odometry> sub_odometry_{
+    this, "~/input/odometry"};
   autoware::universe_utils::InterProcessPollingSubscriber<sensor_msgs::msg::PointCloud2>
     sub_pointcloud_{this, "~/input/pointcloud", autoware::universe_utils::SingleDepthSensorQoS()};
   autoware::universe_utils::InterProcessPollingSubscriber<PredictedObjects> sub_dynamic_objects_{
@@ -121,6 +123,7 @@ private:
   autoware::vehicle_info_utils::VehicleInfo vehicle_info_;
 
   // data
+  nav_msgs::msg::Odometry::ConstSharedPtr odometry_ptr_;
   sensor_msgs::msg::PointCloud2::ConstSharedPtr pointcloud_ptr_;
   PredictedObjects::ConstSharedPtr object_ptr_;
   OperationModeState::ConstSharedPtr operation_mode_ptr_;

--- a/control/autoware_collision_detector/src/node.cpp
+++ b/control/autoware_collision_detector/src/node.cpp
@@ -312,6 +312,14 @@ bool CollisionDetectorNode::shouldBeExcluded(
 
 void CollisionDetectorNode::checkCollision(diagnostic_updater::DiagnosticStatusWrapper & stat)
 {
+  odometry_ptr_ = sub_odometry_.takeData();
+
+  if (!odometry_ptr_) {
+    RCLCPP_INFO_THROTTLE(
+      this->get_logger(), *this->get_clock(), 5000 /* ms */, "waiting for current odometry...");
+    return;
+  }
+
   pointcloud_ptr_ = sub_pointcloud_.takeData();
   object_ptr_ = sub_dynamic_objects_.takeData();
   operation_mode_ptr_ = sub_operation_mode_.takeData();
@@ -487,6 +495,7 @@ boost::optional<geometry_msgs::msg::TransformStamped> CollisionDetectorNode::get
     transform_stamped =
       tf_buffer_.lookupTransform(source, target, stamp, tf2::durationFromSec(duration_sec));
   } catch (const tf2::TransformException & ex) {
+    RCLCPP_INFO(this->get_logger(),"%s",ex.what());
     return {};
   }
 

--- a/control/autoware_collision_detector/src/node.cpp
+++ b/control/autoware_collision_detector/src/node.cpp
@@ -495,7 +495,7 @@ boost::optional<geometry_msgs::msg::TransformStamped> CollisionDetectorNode::get
     transform_stamped =
       tf_buffer_.lookupTransform(source, target, stamp, tf2::durationFromSec(duration_sec));
   } catch (const tf2::TransformException & ex) {
-    RCLCPP_INFO(this->get_logger(),"%s",ex.what());
+    RCLCPP_INFO(this->get_logger(), "%s", ex.what());
     return {};
   }
 

--- a/control/autoware_collision_detector/src/node.cpp
+++ b/control/autoware_collision_detector/src/node.cpp
@@ -495,7 +495,6 @@ boost::optional<geometry_msgs::msg::TransformStamped> CollisionDetectorNode::get
     transform_stamped =
       tf_buffer_.lookupTransform(source, target, stamp, tf2::durationFromSec(duration_sec));
   } catch (const tf2::TransformException & ex) {
-    RCLCPP_INFO(this->get_logger(), "%s", ex.what());
     return {};
   }
 

--- a/launch/tier4_control_launch/launch/control.launch.xml
+++ b/launch/tier4_control_launch/launch/control.launch.xml
@@ -233,6 +233,7 @@
     <!-- collision detector-->
     <load_composable_node target="/control/control_container" if="$(var enable_collision_detector)">
       <composable_node pkg="autoware_collision_detector" plugin="autoware::collision_detector::CollisionDetectorNode" name="collision_detector">
+        <remap from="~/input/odometry" to="/localization/kinematic_state"/>
         <remap from="~/input/pointcloud" to="/perception/obstacle_segmentation/pointcloud"/>
         <remap from="~/input/objects" to="/perception/object_recognition/objects"/>
         <param from="$(var collision_detector_param_path)"/>


### PR DESCRIPTION
## Description
The collision detection published some error information when the vehicle position was not set in PSim.
```
[component_container_mt-39] [ERROR 1731399700.354588656] [control.collision_detector] filterObjects(): Failed to get transform from object frame to base_link:(L185)
```
This was caused due to not finding a connection between 'base_link' and 'map'.
This PR adds a subscriber for ego vehicle odometry information, and skips the process when the odometry information is not published.
As the `collision_detector` package is to be merged into the `surround_obstacle_checker` packages, subscribing the odometry information would not be a big issue, since the `surround_obstacle_checker`  is already subscribing this information.

## Related links
None

## How was this PR tested?
- [x] [TIER IV internal evaluator](https://evaluation.tier4.jp/evaluation/reports/f33be73c-95dc-5339-a46a-f6e3a3581e8f?project_id=prd_jt)
- [x] Confirmed that the error message does not appear before putting the vehicle in any position

## Notes for reviewers
None

## Interface changes
### Topic changes
#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added| Sub | `~/input/odometry` | `nav_msgs::msg::Odometry`   | Ego vehicle odometry |

## Effects on system behavior
None.
