### PR TITLE
fix(costmap_generator): use vehicle frame for lidar height thresholds

### DIFF
--- a/planning/autoware_costmap_generator/README.md
+++ b/planning/autoware_costmap_generator/README.md
@@ -50,8 +50,8 @@ None
 | `grid_length_y`              | int    | size of gridmap for y direction                                                                |
 | `grid_position_x`            | int    | offset from coordinate in x direction                                                          |
 | `grid_position_y`            | int    | offset from coordinate in y direction                                                          |
-| `maximum_lidar_height_thres` | double | maximum height threshold for pointcloud data                                                   |
-| `minimum_lidar_height_thres` | double | minimum height threshold for pointcloud data                                                   |
+| `maximum_lidar_height_thres` | double | maximum height threshold for pointcloud data (relative to the vehicle_frame)                   |
+| `minimum_lidar_height_thres` | double | minimum height threshold for pointcloud data (relative to the vehicle_frame)                   |
 | `expand_rectangle_size`      | double | expand object's rectangle with this value                                                      |
 | `size_of_expansion_kernel`   | int    | kernel size for blurring effect on object's costmap                                            |
 

--- a/planning/autoware_costmap_generator/config/costmap_generator.param.yaml
+++ b/planning/autoware_costmap_generator/config/costmap_generator.param.yaml
@@ -12,8 +12,8 @@
     grid_length_y: 70.0
     grid_position_x: 0.0
     grid_position_y: 0.0
-    maximum_lidar_height_thres: 0.3
-    minimum_lidar_height_thres: -2.2
+    maximum_lidar_height_thres: 2.5  # [m] when use_points is true, ignore points with a z value above this (in the vehicle_frame)
+    minimum_lidar_height_thres: 0.0  # [m] when use_points is true, ignore points with a z value bellow this (in the vehicle_frame)
     use_wayarea: true
     use_parkinglot: true
     use_objects: true

--- a/planning/autoware_costmap_generator/include/autoware/costmap_generator/costmap_generator.hpp
+++ b/planning/autoware_costmap_generator/include/autoware/costmap_generator/costmap_generator.hpp
@@ -166,8 +166,9 @@ private:
 
   /// \brief calculate cost from pointcloud data
   /// \param[in] in_points: subscribed pointcloud data
+  /// \param[in] vehicle_to_map_z: z value of the ego vehicle in the costmap frame
   grid_map::Matrix generatePointsCostmap(
-    const sensor_msgs::msg::PointCloud2::ConstSharedPtr & in_points);
+    const sensor_msgs::msg::PointCloud2::ConstSharedPtr & in_points, const double vehicle_to_map_z);
 
   /// \brief calculate cost from DynamicObjectArray
   /// \param[in] in_objects: subscribed DynamicObjectArray

--- a/planning/autoware_costmap_generator/src/costmap_generator.cpp
+++ b/planning/autoware_costmap_generator/src/costmap_generator.cpp
@@ -51,6 +51,7 @@
 #include <autoware_lanelet2_extension/utility/utilities.hpp>
 #include <autoware_lanelet2_extension/visualization/visualization.hpp>
 #include <pcl_ros/transforms.hpp>
+#include <rclcpp/logging.hpp>
 #include <tf2_eigen/tf2_eigen.hpp>
 
 #include <lanelet2_core/Forward.h>
@@ -353,7 +354,8 @@ grid_map::Matrix CostmapGenerator::generatePointsCostmap(
     points2costmap = tf_buffer_.lookupTransform(
       param_->costmap_frame, in_points->header.frame_id, tf2::TimePointZero);
   } catch (const tf2::TransformException & ex) {
-    RCLCPP_ERROR(rclcpp::get_logger("costmap_generator"), "%s", ex.what());
+    RCLCPP_ERROR_THROTTLE(
+      rclcpp::get_logger("costmap_generator"), *get_clock(), 1000, "%s", ex.what());
   }
 
   const auto transformed_points = getTransformedPointCloud(*in_points, points2costmap.transform);


### PR DESCRIPTION
## Description

Fix how the lidar height min/max thresholds are used in the `costmap_generator`.
They were originally designed to be thresholds relative to the lidar frame. However, they are compared to points converted to the costmap frame (`map` by default).
Since the lidar frame is not easily available in the `costmap_generator`, the PR changes the parameters to represent thresholds in the vehicle frame (`base_link` by default) and correctly converts the thresholds to the costmap frame.

Launch PR to update the parameters: https://github.com/autowarefoundation/autoware_launch/pull/1225

## How was this PR tested?

Using the sample map which has a z value of around 19m.
- Run the planning simulation with `perception/enable_object_recognition:=false`.
- Set the ego pose inside the parking area.
- Visualize the costmap.
- Place a bus inside the costmap.
- Without this PR: obstacle points are not reflected in the costmap.
- With this PR: the costmap correctly reflects the obstacle points.

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
