### PR TITLE
fix(behavior_path_planner): change module initial state to WAITING_APPROVAL

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/interface.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/interface.hpp
@@ -104,8 +104,6 @@ protected:
 
   bool canTransitFailureState() override;
 
-  ModuleStatus setInitState() const override { return ModuleStatus::WAITING_APPROVAL; };
-
   void updateRTCStatus(
     const double start_distance, const double finish_distance, const bool safe,
     const uint8_t & state)

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/interface/scene_module_interface.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/interface/scene_module_interface.hpp
@@ -463,7 +463,7 @@ protected:
   /**
    * @brief Explicitly set the initial state
    */
-  virtual ModuleStatus setInitState() const { return ModuleStatus::RUNNING; }
+  virtual ModuleStatus setInitState() const { return ModuleStatus::WAITING_APPROVAL; }
 
   /**
    * @brief Get candidate path. This information is used for external judgement.


### PR DESCRIPTION
## Description
Each initial state of scene module in behavior path planner has been set to `RUNNING` by the `setInitState` function: therefore, the state would transfer from `IDLE` to `RUNNING`.
From the perspective of state transition, each module should transfer from `IDLE` to `WAITING_APPROVAL`.
This PR sets the initial state to `WAITING_APPROVAL` inside the `setInitState`.

## Related links
None

## How was this PR tested?
- [x] [TIER IV internal evaluator](https://evaluation.tier4.jp/evaluation/reports/bdff42fc-f7b7-5392-92e5-42fa0e166d4a?project_id=prd_jt)

## Notes for reviewers
None.

## Interface changes
None.

## Effects on system behavior
None.
