### PR TITLE
fix(run_out): output velocity factor

### DIFF
--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_run_out_module/src/scene.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_run_out_module/src/scene.cpp
@@ -50,7 +50,7 @@ RunOutModule::RunOutModule(
   debug_ptr_(debug_ptr),
   state_machine_(std::make_unique<run_out_utils::StateMachine>(planner_param.approaching.state))
 {
-  velocity_factor_.init(PlanningBehavior::UNKNOWN);
+  velocity_factor_.init(PlanningBehavior::ROUTE_OBSTACLE);
 
   if (planner_param.run_out.use_partition_lanelet) {
     const lanelet::LaneletMapConstPtr & ll = planner_data->route_handler_->getLaneletMapPtr();
@@ -768,6 +768,11 @@ bool RunOutModule::insertStopPoint(
   stop_point_with_lane_id = path.points.at(nearest_seg_idx);
   stop_point_with_lane_id.point.pose = *stop_point;
   planning_utils::insertVelocity(path, stop_point_with_lane_id, 0.0, insert_idx);
+
+  velocity_factor_.set(
+    path.points, planner_data_->current_odometry->pose, stop_point.value(), VelocityFactor::UNKNOWN,
+    "run_out");
+
   return true;
 }
 
@@ -869,6 +874,9 @@ void RunOutModule::insertApproachingVelocity(
     RCLCPP_WARN_STREAM(logger_, "failed to calculate stop point.");
     return;
   }
+
+  velocity_factor_.set(
+    output_path.points, current_pose, stop_point.value(), VelocityFactor::UNKNOWN, "run_out");
 
   // debug
   debug_ptr_->pushStopPose(autoware::universe_utils::calcOffsetPose(

--- a/system/autoware_default_adapi/src/planning.cpp
+++ b/system/autoware_default_adapi/src/planning.cpp
@@ -81,6 +81,7 @@ PlanningNode::PlanningNode(const rclcpp::NodeOptions & options) : Node("planning
     "/planning/velocity_factors/obstacle_stop",
     "/planning/velocity_factors/obstacle_cruise",
     "/planning/velocity_factors/occlusion_spot",
+    "/planning/velocity_factors/run_out",
     "/planning/velocity_factors/stop_line",
     "/planning/velocity_factors/surround_obstacle",
     "/planning/velocity_factors/traffic_light",


### PR DESCRIPTION
## Description

Set velocity factor when run out module inserts stop point.

![Screenshot from 2024-11-14 11-29-49](https://github.com/user-attachments/assets/a304f9d7-c89f-4274-aa5b-703d3e646c1f)

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

Psim

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
