### PR TITLE
fix(freespace_planner): fix is near target check

### DIFF
--- a/planning/autoware_freespace_planner/src/autoware_freespace_planner/utils.cpp
+++ b/planning/autoware_freespace_planner/src/autoware_freespace_planner/utils.cpp
@@ -171,8 +171,8 @@ bool is_stopped(
 
 bool is_near_target(const Pose & target_pose, const Pose & current_pose, const double th_distance_m)
 {
-  const double long_disp_to_target =
-    autoware::universe_utils::calcLongitudinalDeviation(target_pose, current_pose.position);
-  return std::abs(long_disp_to_target) < th_distance_m;
+  const auto pose_dev = autoware::universe_utils::calcPoseDeviation(target_pose, current_pose);
+  return abs(pose_dev.yaw) < M_PI_2 && abs(pose_dev.longitudinal) < th_distance_m &&
+         abs(pose_dev.lateral) < th_distance_m;
 }
 }  // namespace autoware::freespace_planner::utils

--- a/planning/autoware_freespace_planner/test/test_freespace_planner_utils.cpp
+++ b/planning/autoware_freespace_planner/test/test_freespace_planner_utils.cpp
@@ -153,9 +153,11 @@ TEST(FreespacePlannerUtilsTest, testIsNearTarget)
   const auto trajectory = get_trajectory(0ul);
   const auto target_pose = trajectory.points.back().pose;
 
+  static constexpr double eps = 0.01;
   auto current_pose = target_pose;
   current_pose.position.x -= 1.0;
   current_pose.position.y += 1.0;
+  current_pose.orientation = autoware::universe_utils::createQuaternionFromYaw(M_PI_2 + eps);
 
   const double th_distance_m = 0.5;
 
@@ -163,6 +165,14 @@ TEST(FreespacePlannerUtilsTest, testIsNearTarget)
     autoware::freespace_planner::utils::is_near_target(target_pose, current_pose, th_distance_m));
 
   current_pose.position.x += 0.6;
+  EXPECT_FALSE(
+    autoware::freespace_planner::utils::is_near_target(target_pose, current_pose, th_distance_m));
+
+  current_pose.position.y -= 0.6;
+  EXPECT_FALSE(
+    autoware::freespace_planner::utils::is_near_target(target_pose, current_pose, th_distance_m));
+
+  current_pose.orientation = autoware::universe_utils::createQuaternionFromYaw(M_PI_4);
   EXPECT_TRUE(
     autoware::freespace_planner::utils::is_near_target(target_pose, current_pose, th_distance_m));
 }


### PR DESCRIPTION
## Description

`is_near_target` function only considers longitudinal deviation which can cause wrong behavior in some cases like below.

![Screenshot from 2024-11-15 09-23-31](https://github.com/user-attachments/assets/f76586e7-63f4-4503-ae56-924b29ac2a2e)

Instead it should consider the entire pose deviation including lateral and orientation as well to give the correct behavior as shown below.

![Screenshot from 2024-11-15 09-18-52](https://github.com/user-attachments/assets/9e40f078-ba1d-40ef-9c4e-f68bf14d5245)


## Related links

None.

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
- PSIM

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
