### PR TITLE
chore(crosswalk)!: delete wide crosswalk corresponding function

### DIFF
--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/manager.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/manager.cpp
@@ -51,8 +51,6 @@ CrosswalkModuleManager::CrosswalkModuleManager(rclcpp::Node & node)
     getOrDeclareParameter<double>(node, ns + ".stop_position.stop_distance_from_object_preferred");
   cp.stop_distance_from_object_limit =
     getOrDeclareParameter<double>(node, ns + ".stop_position.stop_distance_from_object_limit");
-  cp.far_object_threshold =
-    getOrDeclareParameter<double>(node, ns + ".stop_position.far_object_threshold");
   cp.stop_position_threshold =
     getOrDeclareParameter<double>(node, ns + ".stop_position.stop_position_threshold");
   cp.min_acc_preferred =

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/scene_crosswalk.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/scene_crosswalk.cpp
@@ -420,9 +420,7 @@ std::optional<geometry_msgs::msg::Pose> CrosswalkModule::calcStopPose(
     if (!ped_stop_pref_opt.has_value()) {
       RCLCPP_INFO(logger_, "Failure to calculate pref_stop.");
       return std::nullopt;
-    } else if (
-      default_stop_opt.has_value() && ped_stop_pref_opt->dist > default_stop_opt->dist &&
-      ped_stop_pref_opt->dist < default_stop_opt->dist + planner_param_.far_object_threshold) {
+    } else if (default_stop_opt.has_value() && ped_stop_pref_opt->dist > default_stop_opt->dist) {
       return default_stop_opt;
     } else {
       return ped_stop_pref_opt;

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/scene_crosswalk.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/scene_crosswalk.hpp
@@ -122,7 +122,6 @@ public:
     double stop_distance_from_object_preferred;
     double stop_distance_from_object_limit;
     double stop_distance_from_crosswalk;
-    double far_object_threshold;
     double stop_position_threshold;
     double min_acc_preferred;
     double min_jerk_preferred;


### PR DESCRIPTION
## Description
The current crosswalk module has a feature to handle wide width crosswalk.
However, such use cases are rare against our maintenance cost. 

Therefore, I propose to delete this function.

## Related links
launch PR: https://github.com/autowarefoundation/autoware_launch/pull/1233

## How was this PR tested?
psim and tier4 scenario tests

## Notes for reviewers

## Interface changes

## Effects on system behavior
