### PR TITLE
chore(autoware_behavior_velocity_intersection_module): include opencv as system

### DIFF
--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/CMakeLists.txt
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/CMakeLists.txt
@@ -22,6 +22,10 @@ ament_auto_add_library(${PROJECT_NAME} SHARED
   src/debug.cpp
 )
 
+target_include_directories(${PROJECT_NAME} SYSTEM PUBLIC
+  ${OpenCV_INCLUDE_DIRS}
+)
+
 target_link_libraries(${PROJECT_NAME}
   ${OpenCV_LIBRARIES}
 )


### PR DESCRIPTION
## Description

To suppress the following error from clang-tidy, we include opencv as a system header.

```
/home/hisaki/workspace/clang-tidy-ci/autoware/src/universe/autoware.universe/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_intersection_occlusion.cpp:307:43: warning: use of a signed integer operand with a binary bitwise operator [hicpp-signed-bitwise]
  occlusion_mask = cv::Mat(width, height, CV_8UC1, cv::Scalar(0));
                                          ^
/usr/include/opencv4/opencv2/core/hal/interface.h:88:17: note: expanded from macro 'CV_8UC1'
#define CV_8UC1 CV_MAKETYPE(CV_8U,1)
                ^~~~~~~~~~~~~~~~~~~~
/usr/include/opencv4/opencv2/core/hal/interface.h:85:32: note: expanded from macro 'CV_MAKETYPE'
#define CV_MAKETYPE(depth,cn) (CV_MAT_DEPTH(depth) + (((cn)-1) << CV_CN_SHIFT))
                               ^~~~~~~~~~~~~~~~~~~
/usr/include/opencv4/opencv2/core/hal/interface.h:83:34: note: expanded from macro 'CV_MAT_DEPTH'
#define CV_MAT_DEPTH(flags)     ((flags) & CV_MAT_DEPTH_MASK)
                                 ^~~~~~~
/usr/include/opencv4/opencv2/core/mat.inl.hpp:2116:9: error: '_Atomic' is a C11 extension [clang-diagnostic-c11-extensions]
        CV_XADD(&this->hdr->refcount, 1);
        ^
/usr/include/opencv4/opencv2/core/cvdef.h:670:60: note: expanded from macro 'CV_XADD'
#      define CV_XADD(addr, delta) __c11_atomic_fetch_add((_Atomic(int)*)(addr), delta, __ATOMIC_ACQ_REL)
                                                           ^
/usr/include/opencv4/opencv2/core/mat.inl.hpp:2131:21: error: '_Atomic' is a C11 extension [clang-diagnostic-c11-extensions]
        if( m.hdr ) CV_XADD(&m.hdr->refcount, 1);
                    ^
/usr/include/opencv4/opencv2/core/cvdef.h:670:60: note: expanded from macro 'CV_XADD'
#      define CV_XADD(addr, delta) __c11_atomic_fetch_add((_Atomic(int)*)(addr), delta, __ATOMIC_ACQ_REL)
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
