### PR TITLE
chore(autoware_traffic_light_visualization): include opencv as system

### DIFF
--- a/perception/autoware_traffic_light_visualization/CMakeLists.txt
+++ b/perception/autoware_traffic_light_visualization/CMakeLists.txt
@@ -11,6 +11,10 @@ ament_auto_add_library(traffic_light_roi_visualizer SHARED
   src/traffic_light_roi_visualizer/shape_draw.cpp
 )
 
+target_include_directories(traffic_light_roi_visualizer SYSTEM PUBLIC
+  ${OpenCV_INCLUDE_DIRS}
+)
+
 target_link_libraries(traffic_light_roi_visualizer
   ${OpenCV_LIBRARIES}
 )


### PR DESCRIPTION
## Description

To suppress the following error from clang-tidy, we include opencv as a system header.

```
Error while processing /home/hisaki/workspace/clang-tidy-ci/autoware/src/universe/autoware.universe/perception/autoware_traffic_light_visualization/src/traffic_light_roi_visualizer/shape_draw.cpp.
/usr/include/opencv4/opencv2/core/cuda.inl.hpp:105:9: error: '_Atomic' is a C11 extension [clang-diagnostic-c11-extensions]
        CV_XADD(refcount, 1);
        ^
/usr/include/opencv4/opencv2/core/cvdef.h:670:60: note: expanded from macro 'CV_XADD'
#      define CV_XADD(addr, delta) __c11_atomic_fetch_add((_Atomic(int)*)(addr), delta, __ATOMIC_ACQ_REL)
                                                           ^
/usr/include/opencv4/opencv2/core/cuda.inl.hpp:487:9: error: '_Atomic' is a C11 extension [clang-diagnostic-c11-extensions]
        CV_XADD(refcount, 1);
        ^
/usr/include/opencv4/opencv2/core/cvdef.h:670:60: note: expanded from macro 'CV_XADD'
#      define CV_XADD(addr, delta) __c11_atomic_fetch_add((_Atomic(int)*)(addr), delta, __ATOMIC_ACQ_REL)
                                                           ^
/usr/include/opencv4/opencv2/core/mat.inl.hpp:2116:9: error: '_Atomic' is a C11 extension [clang-diagnostic-c11-extensions]
        CV_XADD(&this->hdr->refcount, 1);
        ^
/usr/include/opencv4/opencv2/core/cvdef.h:670:60: note: expanded from macro 'CV_XADD'
#      define CV_XADD(addr, delta) __c11_atomic_fetch_add((_Atomic(int)*)(addr), delta, __ATOMIC_ACQ_REL)
                                                           ^
/usr/include/opencv4/opencv2/core/mat.inl.hpp:2131:21: error: '_Atomic' is a C11 extension [clang-diagnostic-c11-extensions]
        if( m.hdr ) CV_XADD(&m.hdr->refcount, 1);
                    ^
/usr/include/opencv4/opencv2/core/cvdef.h:670:60: note: expanded from macro 'CV_XADD'
#      define CV_XADD(addr, delta) __c11_atomic_fetch_add((_Atomic(int)*)(addr), delta, __ATOMIC_ACQ_REL)
                                                           ^
/usr/include/opencv4/opencv2/flann/index_testing.h:249:11: error: variable 'p1' set but not used [clang-diagnostic-unused-but-set-variable]
    float p1;
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
