### PR TITLE
fix(static_obstacle_avoidance): override setInitState

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/include/autoware/behavior_path_static_obstacle_avoidance_module/scene.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/include/autoware/behavior_path_static_obstacle_avoidance_module/scene.hpp
@@ -66,6 +66,8 @@ public:
   std::shared_ptr<AvoidanceDebugMsgArray> get_debug_msg_array() const;
 
 private:
+  ModuleStatus setInitState() const override { return ModuleStatus::WAITING_APPROVAL; };
+
   /**
    * @brief return the result whether the module can stop path generation process.
    * @param avoidance data.


### PR DESCRIPTION
## Description
Currently the static obstacle avoidance module with transit from `IDLE` to `RUNNING` for it's initial state transition. Ideally the module should check safety before it executes the avoidance maneuver. Thus the initial state transition is modified to `IDLE` to `WAITING_FOR_APPROVAL` in this PR.

## Related links
None

## How was this PR tested?
- [x] [TIER IV internal evaluator](https://evaluation.tier4.jp/evaluation/reports/736dbfa5-d46d-5111-ac62-8a2c01006c96?project_id=prd_jt)

## Notes for reviewers
None.

## Interface changes
None.

## Effects on system behavior
None.
