### PR TITLE
feat(route_selector): add processing time publisher

### DIFF
--- a/planning/autoware_mission_planner/src/mission_planner/route_selector.cpp
+++ b/planning/autoware_mission_planner/src/mission_planner/route_selector.cpp
@@ -204,6 +204,7 @@ void RouteSelector::on_set_waypoint_route_main(
 
   // Forward the request if not in MRM.
   res->status = service_utils::sync_call(cli_set_waypoint_route_, req);
+  publish_processing_time(stop_watch);
 }
 
 void RouteSelector::on_set_lanelet_route_main(
@@ -225,6 +226,7 @@ void RouteSelector::on_set_lanelet_route_main(
 
   // Forward the request if not in MRM.
   res->status = service_utils::sync_call(cli_set_lanelet_route_, req);
+  publish_processing_time(stop_watch);
 }
 
 void RouteSelector::on_clear_route_mrm(

--- a/planning/autoware_mission_planner/src/mission_planner/route_selector.hpp
+++ b/planning/autoware_mission_planner/src/mission_planner/route_selector.hpp
@@ -15,9 +15,11 @@
 #ifndef MISSION_PLANNER__ROUTE_SELECTOR_HPP_
 #define MISSION_PLANNER__ROUTE_SELECTOR_HPP_
 
+#include <autoware/universe_utils/system/stop_watch.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include <autoware_planning_msgs/msg/lanelet_route.hpp>
+#include <tier4_debug_msgs/msg/float64_stamped.hpp>
 #include <tier4_planning_msgs/msg/route_state.hpp>
 #include <tier4_planning_msgs/srv/clear_route.hpp>
 #include <tier4_planning_msgs/srv/set_lanelet_route.hpp>
@@ -78,10 +80,14 @@ private:
   rclcpp::Client<SetLaneletRoute>::SharedPtr cli_set_lanelet_route_;
   rclcpp::Subscription<RouteState>::SharedPtr sub_state_;
   rclcpp::Subscription<LaneletRoute>::SharedPtr sub_route_;
+  rclcpp::Publisher<tier4_debug_msgs::msg::Float64Stamped>::SharedPtr pub_processing_time_;
 
   bool initialized_;
   bool mrm_operating_;
   std::variant<std::monostate, WaypointRequest, LaneletRequest> main_request_;
+
+  void publish_processing_time(
+    autoware::universe_utils::StopWatch<std::chrono::milliseconds> stop_watch);
 
   void on_state(const RouteState::ConstSharedPtr msg);
   void on_route(const LaneletRoute::ConstSharedPtr msg);


### PR DESCRIPTION
## Description
The processing time of `route_selector` was measured and made to Pub.
Since A is not a module that is processed cyclically, Pub was added to the following four functions that may become heavy processing.
- `on_set_waypoint_route_main`
- `on_set_lanelet_route_main`
- `on_set_waypoint_route_mrm`
- `on_set_lanelet_route_mrm`

(TIER IV internal usecase)
This output is then read by the Basic scenario and tested daily for cycle failures.

## Related links
<!-- ⬇️🟢
**Private Links:**
[TIER IV slack link](https://star4.slack.com/archives/C03QW0GU6P7/p1730975647418399?thread_ts=1730447688.664039&cid=C03QW0GU6P7)
⬆️🟢 -->

## How was this PR tested?

1. Place Ego and goal_pose in psim and generate route
2. `ros2 topic echo /planning/mission_planning/route autoware_planning_msgs/msg/LaneletRoute > routefile`
3. Delete `start_pose` and `---` on the last line of the routefile
4. `ros2 service call /planning/mission_planning/route_selector/mrm/set_lanelet_route tier4_planning_msgs/srv/SetLaneletRoute "$(cat routefile)"`

![Screenshot from 2024-11-18 08-49-13](https://github.com/user-attachments/assets/0b94814c-cd99-452b-abe6-1c367312cc29)

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
