### PR TITLE
fix(factors_panel): sort by distance to stop/decel or point where it starts moving the steering

### DIFF
--- a/common/tier4_state_rviz_plugin/src/velocity_steering_factors_panel.cpp
+++ b/common/tier4_state_rviz_plugin/src/velocity_steering_factors_panel.cpp
@@ -104,8 +104,15 @@ void VelocitySteeringFactorsPanel::onVelocityFactors(const VelocityFactorArray::
   velocity_factors_table_->clearContents();
   velocity_factors_table_->setRowCount(msg->factors.size());
 
-  for (std::size_t i = 0; i < msg->factors.size(); i++) {
-    const auto & e = msg->factors.at(i);
+  auto sorted = *msg;
+
+  // sort by distance to the decel/stop point.
+  std::sort(sorted.factors.begin(), sorted.factors.end(), [](const auto & a, const auto & b) {
+    return a.distance < b.distance;
+  });
+
+  for (std::size_t i = 0; i < sorted.factors.size(); i++) {
+    const auto & e = sorted.factors.at(i);
 
     // behavior
     {
@@ -157,8 +164,15 @@ void VelocitySteeringFactorsPanel::onSteeringFactors(const SteeringFactorArray::
   steering_factors_table_->clearContents();
   steering_factors_table_->setRowCount(msg->factors.size());
 
-  for (std::size_t i = 0; i < msg->factors.size(); i++) {
-    const auto & e = msg->factors.at(i);
+  auto sorted = *msg;
+
+  // sort by distance to the point where it starts moving the steering.
+  std::sort(sorted.factors.begin(), sorted.factors.end(), [](const auto & a, const auto & b) {
+    return a.distance.front() < b.distance.front();
+  });
+
+  for (std::size_t i = 0; i < sorted.factors.size(); i++) {
+    const auto & e = sorted.factors.at(i);
 
     // behavior
     {


### PR DESCRIPTION
## Description

Sort table col by distance.

![Screenshot from 2024-11-18 09-53-04](https://github.com/user-attachments/assets/ebc2ca17-9119-405c-b958-91de30c5431a)

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

Psim

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
