### PR TITLE
feat(tier4_control_launch): use preset.yaml to control which modules to launch for control modules

### DIFF
--- a/launch/tier4_control_launch/launch/control.launch.xml
+++ b/launch/tier4_control_launch/launch/control.launch.xml
@@ -53,129 +53,138 @@
     <group>
       <!-- set container to run all required components in the same process -->
       <node_container pkg="rclcpp_components" exec="$(var container_executable)" name="control_container" namespace=""/>
-
-      <load_composable_node target="/control/control_container" if="$(eval &quot;'$(var trajectory_follower_mode)' == 'trajectory_follower_node'&quot;)">
-        <composable_node pkg="autoware_trajectory_follower_node" plugin="autoware::motion::control::trajectory_follower_node::Controller" name="controller_node_exe" namespace="trajectory_follower">
-          <remap from="~/input/reference_trajectory" to="/planning/scenario_planning/trajectory"/>
-          <remap from="~/input/current_odometry" to="/localization/kinematic_state"/>
-          <remap from="~/input/current_steering" to="/vehicle/status/steering_status"/>
-          <remap from="~/input/current_accel" to="/localization/acceleration"/>
-          <remap from="~/input/current_operation_mode" to="/system/operation_mode/state"/>
-          <remap from="~/output/predicted_trajectory" to="lateral/predicted_trajectory"/>
-          <remap from="~/output/lateral_diagnostic" to="lateral/diagnostic"/>
-          <remap from="~/output/slope_angle" to="longitudinal/slope_angle"/>
-          <remap from="~/output/longitudinal_diagnostic" to="longitudinal/diagnostic"/>
-          <remap from="~/output/stop_reason" to="longitudinal/stop_reason"/>
-          <remap from="~/output/control_cmd" to="control_cmd"/>
-          <param name="lateral_controller_mode" value="$(var lateral_controller_mode)"/>
-          <param name="longitudinal_controller_mode" value="$(var longitudinal_controller_mode)"/>
-          <param from="$(var nearest_search_param_path)"/>
-          <param from="$(var trajectory_follower_node_param_path)"/>
-          <param from="$(var lon_controller_param_path)"/>
-          <param from="$(var lat_controller_param_path)"/>
-          <param from="$(var vehicle_param_file)"/>
-          <extra_arg name="use_intra_process_comms" value="$(var use_intra_process)"/>
-        </composable_node>
-      </load_composable_node>
+      <group if="$(eval &quot;'$(var trajectory_follower_mode)' == 'trajectory_follower_node'&quot;)">
+        <load_composable_node target="/control/control_container">
+          <composable_node pkg="autoware_trajectory_follower_node" plugin="autoware::motion::control::trajectory_follower_node::Controller" name="controller_node_exe" namespace="trajectory_follower">
+            <remap from="~/input/reference_trajectory" to="/planning/scenario_planning/trajectory"/>
+            <remap from="~/input/current_odometry" to="/localization/kinematic_state"/>
+            <remap from="~/input/current_steering" to="/vehicle/status/steering_status"/>
+            <remap from="~/input/current_accel" to="/localization/acceleration"/>
+            <remap from="~/input/current_operation_mode" to="/system/operation_mode/state"/>
+            <remap from="~/output/predicted_trajectory" to="lateral/predicted_trajectory"/>
+            <remap from="~/output/lateral_diagnostic" to="lateral/diagnostic"/>
+            <remap from="~/output/slope_angle" to="longitudinal/slope_angle"/>
+            <remap from="~/output/longitudinal_diagnostic" to="longitudinal/diagnostic"/>
+            <remap from="~/output/stop_reason" to="longitudinal/stop_reason"/>
+            <remap from="~/output/control_cmd" to="control_cmd"/>
+            <param name="lateral_controller_mode" value="$(var lateral_controller_mode)"/>
+            <param name="longitudinal_controller_mode" value="$(var longitudinal_controller_mode)"/>
+            <param from="$(var nearest_search_param_path)"/>
+            <param from="$(var trajectory_follower_node_param_path)"/>
+            <param from="$(var lon_controller_param_path)"/>
+            <param from="$(var lat_controller_param_path)"/>
+            <param from="$(var vehicle_param_file)"/>
+            <extra_arg name="use_intra_process_comms" value="$(var use_intra_process)"/>
+          </composable_node>
+        </load_composable_node>
+      </group>
 
       <!-- lane departure checker -->
-      <load_composable_node target="/control/control_container" if="$(var launch_lane_departure_checker)">
-        <composable_node pkg="autoware_lane_departure_checker" plugin="autoware::lane_departure_checker::LaneDepartureCheckerNode" name="lane_departure_checker_node" namespace="trajectory_follower">
-          <remap from="~/input/odometry" to="/localization/kinematic_state"/>
-          <remap from="~/input/lanelet_map_bin" to="/map/vector_map"/>
-          <remap from="~/input/route" to="/planning/mission_planning/route"/>
-          <remap from="~/input/reference_trajectory" to="/planning/scenario_planning/trajectory"/>
-          <remap from="~/input/predicted_trajectory" to="/control/trajectory_follower/lateral/predicted_trajectory"/>
-          <param from="$(var nearest_search_param_path)"/>
-          <param from="$(var lane_departure_checker_param_path)"/>
-          <param from="$(var vehicle_param_file)"/>
-          <extra_arg name="use_intra_process_comms" value="$(var use_intra_process)"/>
-        </composable_node>
-      </load_composable_node>
+      <group if="$(var launch_lane_departure_checker)">
+        <load_composable_node target="/control/control_container">
+          <composable_node pkg="autoware_lane_departure_checker" plugin="autoware::lane_departure_checker::LaneDepartureCheckerNode" name="lane_departure_checker_node" namespace="trajectory_follower">
+            <remap from="~/input/odometry" to="/localization/kinematic_state"/>
+            <remap from="~/input/lanelet_map_bin" to="/map/vector_map"/>
+            <remap from="~/input/route" to="/planning/mission_planning/route"/>
+            <remap from="~/input/reference_trajectory" to="/planning/scenario_planning/trajectory"/>
+            <remap from="~/input/predicted_trajectory" to="/control/trajectory_follower/lateral/predicted_trajectory"/>
+            <param from="$(var nearest_search_param_path)"/>
+            <param from="$(var lane_departure_checker_param_path)"/>
+            <param from="$(var vehicle_param_file)"/>
+            <extra_arg name="use_intra_process_comms" value="$(var use_intra_process)"/>
+          </composable_node>
+        </load_composable_node>
+      </group>
 
       <!-- shift decider -->
-      <load_composable_node target="/control/control_container" if="$(var launch_shift_decider)">
-        <composable_node pkg="autoware_shift_decider" plugin="autoware::shift_decider::ShiftDecider" name="autoware_shift_decider">
-          <remap from="input/control_cmd" to="/control/trajectory_follower/control_cmd"/>
-          <remap from="input/state" to="/autoware/state"/>
-          <remap from="input/current_gear" to="/vehicle/status/gear_status"/>
-          <remap from="output/gear_cmd" to="/control/shift_decider/gear_cmd"/>
-          <param from="$(var shift_decider_param_path)"/>
-          <extra_arg name="use_intra_process_comms" value="$(var use_intra_process)"/>
-        </composable_node>
-      </load_composable_node>
+      <group if="$(var launch_shift_decider)">
+        <load_composable_node target="/control/control_container">
+          <composable_node pkg="autoware_shift_decider" plugin="autoware::shift_decider::ShiftDecider" name="autoware_shift_decider">
+            <remap from="input/control_cmd" to="/control/trajectory_follower/control_cmd"/>
+            <remap from="input/state" to="/autoware/state"/>
+            <remap from="input/current_gear" to="/vehicle/status/gear_status"/>
+            <remap from="output/gear_cmd" to="/control/shift_decider/gear_cmd"/>
+            <param from="$(var shift_decider_param_path)"/>
+            <extra_arg name="use_intra_process_comms" value="$(var use_intra_process)"/>
+          </composable_node>
+        </load_composable_node>
+      </group>
 
       <!-- vehicle cmd gate -->
-      <load_composable_node target="/control/control_container" if="$(var launch_vehicle_cmd_gate)">
-        <composable_node pkg="autoware_vehicle_cmd_gate" plugin="autoware::vehicle_cmd_gate::VehicleCmdGate" name="vehicle_cmd_gate">
-          <remap from="input/steering" to="/vehicle/status/steering_status"/>
-          <remap from="input/operation_mode" to="/system/operation_mode/state"/>
-          <remap from="input/auto/control_cmd" to="/control/trajectory_follower/control_cmd"/>
-          <remap from="input/auto/turn_indicators_cmd" to="/planning/turn_indicators_cmd"/>
-          <remap from="input/auto/hazard_lights_cmd" to="/planning/hazard_lights_cmd"/>
-          <remap from="input/auto/gear_cmd" to="/control/shift_decider/gear_cmd"/>
-          <remap from="input/external/control_cmd" to="/external/selected/control_cmd"/>
-          <remap from="input/external/turn_indicators_cmd" to="/external/selected/turn_indicators_cmd"/>
-          <remap from="input/external/hazard_lights_cmd" to="/external/selected/hazard_lights_cmd"/>
-          <remap from="input/external/gear_cmd" to="/external/selected/gear_cmd"/>
-          <remap from="input/external_emergency_stop_heartbeat" to="/external/selected/heartbeat"/>
-          <remap from="input/gate_mode" to="/control/gate_mode_cmd"/>
-          <remap from="input/emergency/control_cmd" to="/system/emergency/control_cmd"/>
-          <remap from="input/emergency/hazard_lights_cmd" to="/system/emergency/hazard_lights_cmd"/>
-          <remap from="input/emergency/gear_cmd" to="/system/emergency/gear_cmd"/>
-          <remap from="input/mrm_state" to="/system/fail_safe/mrm_state"/>
-          <remap from="input/kinematics" to="/localization/kinematic_state"/>
-          <remap from="input/acceleration" to="/localization/acceleration"/>
-          <remap from="output/vehicle_cmd_emergency" to="/control/command/emergency_cmd"/>
-          <remap from="output/control_cmd" to="/control/command/control_cmd"/>
-          <remap from="output/gear_cmd" to="/control/command/gear_cmd"/>
-          <remap from="output/turn_indicators_cmd" to="/control/command/turn_indicators_cmd"/>
-          <remap from="output/hazard_lights_cmd" to="/control/command/hazard_lights_cmd"/>
-          <remap from="output/gate_mode" to="/control/current_gate_mode"/>
-          <remap from="output/engage" to="/api/autoware/get/engage"/>
-          <remap from="output/external_emergency" to="/api/autoware/get/emergency"/>
-          <remap from="output/operation_mode" to="/control/vehicle_cmd_gate/operation_mode"/>
-          <remap from="~/service/engage" to="/api/autoware/set/engage"/>
-          <remap from="~/service/external_emergency" to="/api/autoware/set/emergency"/>
-          <!-- TODO(Takagi, Isamu): deprecated -->
-          <remap from="input/engage" to="/autoware/engage"/>
-          <remap from="~/service/external_emergency_stop" to="~/external_emergency_stop"/>
-          <remap from="~/service/clear_external_emergency_stop" to="~/clear_external_emergency_stop"/>
-          <param from="$(var vehicle_cmd_gate_param_path)"/>
-          <param from="$(var vehicle_param_file)"/>
-          <param name="check_external_emergency_heartbeat" value="$(var check_external_emergency_heartbeat)"/>
-          <extra_arg name="use_intra_process_comms" value="$(var use_intra_process)"/>
-        </composable_node>
-      </load_composable_node>
+      <group if="$(var launch_vehicle_cmd_gate)">
+        <load_composable_node target="/control/control_container">
+          <composable_node pkg="autoware_vehicle_cmd_gate" plugin="autoware::vehicle_cmd_gate::VehicleCmdGate" name="vehicle_cmd_gate">
+            <remap from="input/steering" to="/vehicle/status/steering_status"/>
+            <remap from="input/operation_mode" to="/system/operation_mode/state"/>
+            <remap from="input/auto/control_cmd" to="/control/trajectory_follower/control_cmd"/>
+            <remap from="input/auto/turn_indicators_cmd" to="/planning/turn_indicators_cmd"/>
+            <remap from="input/auto/hazard_lights_cmd" to="/planning/hazard_lights_cmd"/>
+            <remap from="input/auto/gear_cmd" to="/control/shift_decider/gear_cmd"/>
+            <remap from="input/external/control_cmd" to="/external/selected/control_cmd"/>
+            <remap from="input/external/turn_indicators_cmd" to="/external/selected/turn_indicators_cmd"/>
+            <remap from="input/external/hazard_lights_cmd" to="/external/selected/hazard_lights_cmd"/>
+            <remap from="input/external/gear_cmd" to="/external/selected/gear_cmd"/>
+            <remap from="input/external_emergency_stop_heartbeat" to="/external/selected/heartbeat"/>
+            <remap from="input/gate_mode" to="/control/gate_mode_cmd"/>
+            <remap from="input/emergency/control_cmd" to="/system/emergency/control_cmd"/>
+            <remap from="input/emergency/hazard_lights_cmd" to="/system/emergency/hazard_lights_cmd"/>
+            <remap from="input/emergency/gear_cmd" to="/system/emergency/gear_cmd"/>
+            <remap from="input/mrm_state" to="/system/fail_safe/mrm_state"/>
+            <remap from="input/kinematics" to="/localization/kinematic_state"/>
+            <remap from="input/acceleration" to="/localization/acceleration"/>
+            <remap from="output/vehicle_cmd_emergency" to="/control/command/emergency_cmd"/>
+            <remap from="output/control_cmd" to="/control/command/control_cmd"/>
+            <remap from="output/gear_cmd" to="/control/command/gear_cmd"/>
+            <remap from="output/turn_indicators_cmd" to="/control/command/turn_indicators_cmd"/>
+            <remap from="output/hazard_lights_cmd" to="/control/command/hazard_lights_cmd"/>
+            <remap from="output/gate_mode" to="/control/current_gate_mode"/>
+            <remap from="output/engage" to="/api/autoware/get/engage"/>
+            <remap from="output/external_emergency" to="/api/autoware/get/emergency"/>
+            <remap from="output/operation_mode" to="/control/vehicle_cmd_gate/operation_mode"/>
+            <remap from="~/service/engage" to="/api/autoware/set/engage"/>
+            <remap from="~/service/external_emergency" to="/api/autoware/set/emergency"/>
+            <!-- TODO(Takagi, Isamu): deprecated -->
+            <remap from="input/engage" to="/autoware/engage"/>
+            <remap from="~/service/external_emergency_stop" to="~/external_emergency_stop"/>
+            <remap from="~/service/clear_external_emergency_stop" to="~/clear_external_emergency_stop"/>
+            <param from="$(var vehicle_cmd_gate_param_path)"/>
+            <param from="$(var vehicle_param_file)"/>
+            <param name="check_external_emergency_heartbeat" value="$(var check_external_emergency_heartbeat)"/>
+            <extra_arg name="use_intra_process_comms" value="$(var use_intra_process)"/>
+          </composable_node>
+        </load_composable_node>
+      </group>
 
       <!-- operation mode transition manager -->
-      <load_composable_node target="/control/control_container" if="$(var launch_operation_mode_transition_manager)">
-        <composable_node
-          pkg="autoware_operation_mode_transition_manager"
-          plugin="autoware::operation_mode_transition_manager::OperationModeTransitionManager"
-          name="autoware_operation_mode_transition_manager"
-        >
-          <!-- input -->
-          <remap from="kinematics" to="/localization/kinematic_state"/>
-          <remap from="steering" to="/vehicle/status/steering_status"/>
-          <remap from="trajectory" to="/planning/scenario_planning/trajectory"/>
-          <remap from="control_cmd" to="/control/command/control_cmd"/>
-          <remap from="trajectory_follower_control_cmd" to="/control/trajectory_follower/control_cmd"/>
-          <remap from="control_mode_report" to="/vehicle/status/control_mode"/>
-          <remap from="gate_operation_mode" to="/control/vehicle_cmd_gate/operation_mode"/>
-          <!-- output -->
-          <remap from="is_autonomous_available" to="/control/is_autonomous_available"/>
-          <remap from="control_mode_request" to="/control/control_mode_request"/>
-          <param from="$(var nearest_search_param_path)"/>
-          <param from="$(var operation_mode_transition_manager_param_path)"/>
-          <param from="$(var vehicle_param_file)"/>
-          <extra_arg name="use_intra_process_comms" value="$(var use_intra_process)"/>
-        </composable_node>
-      </load_composable_node>
+      <group if="$(var launch_operation_mode_transition_manager)">
+        <load_composable_node target="/control/control_container">
+          <composable_node
+            pkg="autoware_operation_mode_transition_manager"
+            plugin="autoware::operation_mode_transition_manager::OperationModeTransitionManager"
+            name="autoware_operation_mode_transition_manager"
+          >
+            <!-- input -->
+            <remap from="kinematics" to="/localization/kinematic_state"/>
+            <remap from="steering" to="/vehicle/status/steering_status"/>
+            <remap from="trajectory" to="/planning/scenario_planning/trajectory"/>
+            <remap from="control_cmd" to="/control/command/control_cmd"/>
+            <remap from="trajectory_follower_control_cmd" to="/control/trajectory_follower/control_cmd"/>
+            <remap from="control_mode_report" to="/vehicle/status/control_mode"/>
+            <remap from="gate_operation_mode" to="/control/vehicle_cmd_gate/operation_mode"/>
+            <!-- output -->
+            <remap from="is_autonomous_available" to="/control/is_autonomous_available"/>
+            <remap from="control_mode_request" to="/control/control_mode_request"/>
+            <param from="$(var nearest_search_param_path)"/>
+            <param from="$(var operation_mode_transition_manager_param_path)"/>
+            <param from="$(var vehicle_param_file)"/>
+            <extra_arg name="use_intra_process_comms" value="$(var use_intra_process)"/>
+          </composable_node>
+        </load_composable_node>
 
-      <load_composable_node target="/control/control_container">
-        <composable_node pkg="glog_component" plugin="GlogComponent" name="glog_component"/>
-      </load_composable_node>
+        <load_composable_node target="/control/control_container">
+          <composable_node pkg="glog_component" plugin="GlogComponent" name="glog_component"/>
+        </load_composable_node>
+      </group>
     </group>
 
     <!-- external cmd selector -->

--- a/launch/tier4_control_launch/launch/control.launch.xml
+++ b/launch/tier4_control_launch/launch/control.launch.xml
@@ -12,7 +12,10 @@
   <arg name="check_external_emergency_heartbeat"/>
 
   <!-- option available for test/debug only -->
-  <arg name="launch_trajectory_follower_components" default="true"/>
+  <arg name="launch_lane_departure_checker" default="true"/>
+  <arg name="launch_shift_decider" default="true"/>
+  <arg name="launch_vehicle_cmd_gate" default="true"/>
+  <arg name="launch_operation_mode_transition_manager" default="true"/>
   <arg name="launch_external_cmd_selector" default="true"/>
   <arg name="launch_external_cmd_converter" default="true"/>
   <arg name="launch_control_evaluator" default="true"/>
@@ -75,8 +78,8 @@
         </composable_node>
       </load_composable_node>
 
-      <load_composable_node target="/control/control_container" if="$(var launch_trajectory_follower_components)">
-        <!-- lane departure checker -->
+      <!-- lane departure checker -->
+      <load_composable_node target="/control/control_container" if="$(var launch_lane_departure_checker)">
         <composable_node pkg="autoware_lane_departure_checker" plugin="autoware::lane_departure_checker::LaneDepartureCheckerNode" name="lane_departure_checker_node" namespace="trajectory_follower">
           <remap from="~/input/odometry" to="/localization/kinematic_state"/>
           <remap from="~/input/lanelet_map_bin" to="/map/vector_map"/>
@@ -88,8 +91,10 @@
           <param from="$(var vehicle_param_file)"/>
           <extra_arg name="use_intra_process_comms" value="$(var use_intra_process)"/>
         </composable_node>
+      </load_composable_node>
 
-        <!-- shift decider -->
+      <!-- shift decider -->
+      <load_composable_node target="/control/control_container" if="$(var launch_shift_decider)">
         <composable_node pkg="autoware_shift_decider" plugin="autoware::shift_decider::ShiftDecider" name="autoware_shift_decider">
           <remap from="input/control_cmd" to="/control/trajectory_follower/control_cmd"/>
           <remap from="input/state" to="/autoware/state"/>
@@ -98,8 +103,10 @@
           <param from="$(var shift_decider_param_path)"/>
           <extra_arg name="use_intra_process_comms" value="$(var use_intra_process)"/>
         </composable_node>
+      </load_composable_node>
 
-        <!-- vehicle cmd gate -->
+      <!-- vehicle cmd gate -->
+      <load_composable_node target="/control/control_container" if="$(var launch_vehicle_cmd_gate)">
         <composable_node pkg="autoware_vehicle_cmd_gate" plugin="autoware::vehicle_cmd_gate::VehicleCmdGate" name="vehicle_cmd_gate">
           <remap from="input/steering" to="/vehicle/status/steering_status"/>
           <remap from="input/operation_mode" to="/system/operation_mode/state"/>
@@ -139,8 +146,10 @@
           <param name="check_external_emergency_heartbeat" value="$(var check_external_emergency_heartbeat)"/>
           <extra_arg name="use_intra_process_comms" value="$(var use_intra_process)"/>
         </composable_node>
+      </load_composable_node>
 
-        <!-- operation mode transition manager -->
+      <!-- operation mode transition manager -->
+      <load_composable_node target="/control/control_container" if="$(var launch_operation_mode_transition_manager)">
         <composable_node
           pkg="autoware_operation_mode_transition_manager"
           plugin="autoware::operation_mode_transition_manager::OperationModeTransitionManager"
@@ -162,9 +171,9 @@
           <param from="$(var vehicle_param_file)"/>
           <extra_arg name="use_intra_process_comms" value="$(var use_intra_process)"/>
         </composable_node>
+      </load_composable_node>
 
         <composable_node pkg="glog_component" plugin="GlogComponent" name="glog_component"/>
-      </load_composable_node>
     </group>
 
     <!-- external cmd selector -->

--- a/launch/tier4_control_launch/launch/control.launch.xml
+++ b/launch/tier4_control_launch/launch/control.launch.xml
@@ -53,6 +53,7 @@
     <group>
       <!-- set container to run all required components in the same process -->
       <node_container pkg="rclcpp_components" exec="$(var container_executable)" name="control_container" namespace=""/>
+
       <group if="$(eval &quot;'$(var trajectory_follower_mode)' == 'trajectory_follower_node'&quot;)">
         <load_composable_node target="/control/control_container">
           <composable_node pkg="autoware_trajectory_follower_node" plugin="autoware::motion::control::trajectory_follower_node::Controller" name="controller_node_exe" namespace="trajectory_follower">

--- a/launch/tier4_control_launch/launch/control.launch.xml
+++ b/launch/tier4_control_launch/launch/control.launch.xml
@@ -54,35 +54,34 @@
       <!-- set container to run all required components in the same process -->
       <node_container pkg="rclcpp_components" exec="$(var container_executable)" name="control_container" namespace=""/>
 
-      <group if="$(eval &quot;'$(var trajectory_follower_mode)' == 'trajectory_follower_node'&quot;)">
-        <load_composable_node target="/control/control_container">
-          <composable_node pkg="autoware_trajectory_follower_node" plugin="autoware::motion::control::trajectory_follower_node::Controller" name="controller_node_exe" namespace="trajectory_follower">
-            <remap from="~/input/reference_trajectory" to="/planning/scenario_planning/trajectory"/>
-            <remap from="~/input/current_odometry" to="/localization/kinematic_state"/>
-            <remap from="~/input/current_steering" to="/vehicle/status/steering_status"/>
-            <remap from="~/input/current_accel" to="/localization/acceleration"/>
-            <remap from="~/input/current_operation_mode" to="/system/operation_mode/state"/>
-            <remap from="~/output/predicted_trajectory" to="lateral/predicted_trajectory"/>
-            <remap from="~/output/lateral_diagnostic" to="lateral/diagnostic"/>
-            <remap from="~/output/slope_angle" to="longitudinal/slope_angle"/>
-            <remap from="~/output/longitudinal_diagnostic" to="longitudinal/diagnostic"/>
-            <remap from="~/output/stop_reason" to="longitudinal/stop_reason"/>
-            <remap from="~/output/control_cmd" to="control_cmd"/>
-            <param name="lateral_controller_mode" value="$(var lateral_controller_mode)"/>
-            <param name="longitudinal_controller_mode" value="$(var longitudinal_controller_mode)"/>
-            <param from="$(var nearest_search_param_path)"/>
-            <param from="$(var trajectory_follower_node_param_path)"/>
-            <param from="$(var lon_controller_param_path)"/>
-            <param from="$(var lat_controller_param_path)"/>
-            <param from="$(var vehicle_param_file)"/>
-            <extra_arg name="use_intra_process_comms" value="$(var use_intra_process)"/>
-          </composable_node>
-        </load_composable_node>
-      </group>
+      <!-- trajectory_follower_node -->
+      <load_composable_node target="/control/control_container" if="$(eval &quot;'$(var trajectory_follower_mode)' == 'trajectory_follower_node'&quot;)">
+        <composable_node pkg="autoware_trajectory_follower_node" plugin="autoware::motion::control::trajectory_follower_node::Controller" name="controller_node_exe" namespace="trajectory_follower">
+          <remap from="~/input/reference_trajectory" to="/planning/scenario_planning/trajectory"/>
+          <remap from="~/input/current_odometry" to="/localization/kinematic_state"/>
+          <remap from="~/input/current_steering" to="/vehicle/status/steering_status"/>
+          <remap from="~/input/current_accel" to="/localization/acceleration"/>
+          <remap from="~/input/current_operation_mode" to="/system/operation_mode/state"/>
+          <remap from="~/output/predicted_trajectory" to="lateral/predicted_trajectory"/>
+          <remap from="~/output/lateral_diagnostic" to="lateral/diagnostic"/>
+          <remap from="~/output/slope_angle" to="longitudinal/slope_angle"/>
+          <remap from="~/output/longitudinal_diagnostic" to="longitudinal/diagnostic"/>
+          <remap from="~/output/stop_reason" to="longitudinal/stop_reason"/>
+          <remap from="~/output/control_cmd" to="control_cmd"/>
+          <param name="lateral_controller_mode" value="$(var lateral_controller_mode)"/>
+          <param name="longitudinal_controller_mode" value="$(var longitudinal_controller_mode)"/>
+          <param from="$(var nearest_search_param_path)"/>
+          <param from="$(var trajectory_follower_node_param_path)"/>
+          <param from="$(var lon_controller_param_path)"/>
+          <param from="$(var lat_controller_param_path)"/>
+          <param from="$(var vehicle_param_file)"/>
+          <extra_arg name="use_intra_process_comms" value="$(var use_intra_process)"/>
+        </composable_node>
+      </load_composable_node>
 
-      <!-- lane departure checker -->
-      <group if="$(var launch_lane_departure_checker)">
-        <load_composable_node target="/control/control_container">
+      <load_composable_node target="/control/control_container">
+        <!-- lane departure checker -->
+        <group if="$(var launch_lane_departure_checker)">
           <composable_node pkg="autoware_lane_departure_checker" plugin="autoware::lane_departure_checker::LaneDepartureCheckerNode" name="lane_departure_checker_node" namespace="trajectory_follower">
             <remap from="~/input/odometry" to="/localization/kinematic_state"/>
             <remap from="~/input/lanelet_map_bin" to="/map/vector_map"/>
@@ -94,12 +93,10 @@
             <param from="$(var vehicle_param_file)"/>
             <extra_arg name="use_intra_process_comms" value="$(var use_intra_process)"/>
           </composable_node>
-        </load_composable_node>
-      </group>
+        </group>
 
-      <!-- shift decider -->
-      <group if="$(var launch_shift_decider)">
-        <load_composable_node target="/control/control_container">
+        <!-- shift decider -->
+        <group if="$(var launch_shift_decider)">
           <composable_node pkg="autoware_shift_decider" plugin="autoware::shift_decider::ShiftDecider" name="autoware_shift_decider">
             <remap from="input/control_cmd" to="/control/trajectory_follower/control_cmd"/>
             <remap from="input/state" to="/autoware/state"/>
@@ -108,12 +105,10 @@
             <param from="$(var shift_decider_param_path)"/>
             <extra_arg name="use_intra_process_comms" value="$(var use_intra_process)"/>
           </composable_node>
-        </load_composable_node>
-      </group>
+        </group>
 
-      <!-- vehicle cmd gate -->
-      <group if="$(var launch_vehicle_cmd_gate)">
-        <load_composable_node target="/control/control_container">
+        <!-- vehicle cmd gate -->
+        <group if="$(var launch_vehicle_cmd_gate)">
           <composable_node pkg="autoware_vehicle_cmd_gate" plugin="autoware::vehicle_cmd_gate::VehicleCmdGate" name="vehicle_cmd_gate">
             <remap from="input/steering" to="/vehicle/status/steering_status"/>
             <remap from="input/operation_mode" to="/system/operation_mode/state"/>
@@ -153,12 +148,10 @@
             <param name="check_external_emergency_heartbeat" value="$(var check_external_emergency_heartbeat)"/>
             <extra_arg name="use_intra_process_comms" value="$(var use_intra_process)"/>
           </composable_node>
-        </load_composable_node>
-      </group>
+        </group>
 
-      <!-- operation mode transition manager -->
-      <group if="$(var launch_operation_mode_transition_manager)">
-        <load_composable_node target="/control/control_container">
+        <!-- operation mode transition manager -->
+        <group if="$(var launch_operation_mode_transition_manager)">
           <composable_node
             pkg="autoware_operation_mode_transition_manager"
             plugin="autoware::operation_mode_transition_manager::OperationModeTransitionManager"
@@ -180,12 +173,9 @@
             <param from="$(var vehicle_param_file)"/>
             <extra_arg name="use_intra_process_comms" value="$(var use_intra_process)"/>
           </composable_node>
-        </load_composable_node>
-
-        <load_composable_node target="/control/control_container">
           <composable_node pkg="glog_component" plugin="GlogComponent" name="glog_component"/>
-        </load_composable_node>
-      </group>
+        </group>
+      </load_composable_node>
     </group>
 
     <!-- external cmd selector -->

--- a/launch/tier4_control_launch/launch/control.launch.xml
+++ b/launch/tier4_control_launch/launch/control.launch.xml
@@ -1,6 +1,6 @@
 <launch>
   <!-- option -->
-  <arg name="launch_obstacle_collision_checker" value="false"/>
+  <arg name="launch_obstacle_collision_checker" default="false"/>
   <arg name="launch_autonomous_emergency_braking" default="true"/>
   <arg name="launch_predicted_path_checker" default="false"/>
   <arg name="launch_collision_detector" default="false"/>
@@ -173,7 +173,9 @@
         </composable_node>
       </load_composable_node>
 
+      <load_composable_node target="/control/control_container">
         <composable_node pkg="glog_component" plugin="GlogComponent" name="glog_component"/>
+      </load_composable_node>
     </group>
 
     <!-- external cmd selector -->

--- a/launch/tier4_control_launch/launch/control.launch.xml
+++ b/launch/tier4_control_launch/launch/control.launch.xml
@@ -1,25 +1,27 @@
 <launch>
-  <!-- option -->
-  <arg name="enable_obstacle_collision_checker" default="false"/>
-  <arg name="launch_autonomous_emergency_braking" default="true"/>
-  <arg name="launch_predicted_path_checker" default="false"/>
-  <arg name="launch_collision_detector" default="false"/>
+
   <arg name="trajectory_follower_mode" default="trajectory_follower_node"/>
   <arg name="lateral_controller_mode"/>
   <arg name="longitudinal_controller_mode"/>
-  <arg name="use_aeb_autoware_state_check"/>
   <arg name="check_external_emergency_heartbeat"/>
+  <arg name="use_aeb_autoware_state_check"/>
 
-  <!-- option available for test/debug only -->
-  <arg name="launch_lane_departure_checker" default="true"/>
+  <!-- control-related modules, turn off only when debugging/testing. -->
   <arg name="launch_shift_decider" default="true"/>
   <arg name="launch_vehicle_cmd_gate" default="true"/>
   <arg name="launch_operation_mode_transition_manager" default="true"/>
   <arg name="launch_external_cmd_selector" default="true"/>
   <arg name="launch_external_cmd_converter" default="true"/>
-  <arg name="launch_control_evaluator" default="true"/>
+
+  <!-- control-check modules, optional -->
+  <arg name="launch_lane_departure_checker" default="true"/>
   <arg name="launch_control_validator" default="true"/>
-  
+  <arg name="launch_autonomous_emergency_braking" default="true"/>
+  <arg name="launch_collision_detector" default="true"/>
+  <arg name="launch_obstacle_collision_checker" default="false"/>
+  <arg name="launch_predicted_path_checker" default="false"/>
+  <arg name="launch_control_evaluator" default="true"/>
+
   <!-- common param path -->
   <arg name="vehicle_param_file"/>
   <arg name="nearest_search_param_path"/>
@@ -50,10 +52,10 @@
     <push-ros-namespace namespace="control"/>
 
     <group>
-      <!-- set container to run all required components in the same process -->
+      <!-- set a control container to run all required components in the same process -->
       <node_container pkg="rclcpp_components" exec="$(var container_executable)" name="control_container" namespace="">
-        <composable_node pkg="glog_component" plugin="GlogComponent" name="glog_component"/>
-      <node_container/>
+        <composable_node pkg="glog_component" plugin="GlogComponent" name="glog_control_container_component"/>
+      </node_container>
 
       <!-- trajectory_follower_node -->
       <group if="$(eval &quot;'$(var trajectory_follower_mode)' == 'trajectory_follower_node'&quot;)">
@@ -82,21 +84,9 @@
         </load_composable_node>
       </group>
 
-      <!-- lane departure checker -->
-      <group if="$(var launch_lane_departure_checker)">
-        <load_composable_node target="/control/control_container">
-          <composable_node pkg="autoware_lane_departure_checker" plugin="autoware::lane_departure_checker::LaneDepartureCheckerNode" name="lane_departure_checker_node" namespace="trajectory_follower">
-            <remap from="~/input/odometry" to="/localization/kinematic_state"/>
-            <remap from="~/input/lanelet_map_bin" to="/map/vector_map"/>
-            <remap from="~/input/route" to="/planning/mission_planning/route"/>
-            <remap from="~/input/reference_trajectory" to="/planning/scenario_planning/trajectory"/>
-            <remap from="~/input/predicted_trajectory" to="/control/trajectory_follower/lateral/predicted_trajectory"/>
-            <param from="$(var nearest_search_param_path)"/>
-            <param from="$(var lane_departure_checker_param_path)"/>
-            <param from="$(var vehicle_param_file)"/>
-            <extra_arg name="use_intra_process_comms" value="$(var use_intra_process)"/>
-          </composable_node>
-        </load_composable_node>
+      <!-- smart_mpc, under development -->
+      <group if="$(eval &quot;'$(var trajectory_follower_mode)' == 'smart_mpc_trajectory_follower'&quot;)">
+        <node pkg="autoware_smart_mpc_trajectory_follower" exec="pympc_trajectory_follower.py" name="controller_node_exe"/>
       </group>
 
       <!-- shift decider -->
@@ -184,119 +174,135 @@
           </composable_node>
         </load_composable_node>
       </group>
+
+      <!-- external cmd selector -->
+      <group if="$(var launch_external_cmd_selector)">
+        <include file="$(find-pkg-share autoware_external_cmd_selector)/launch/external_cmd_selector.launch.py">
+          <arg name="use_intra_process" value="$(var use_intra_process)"/>
+          <arg name="target_container" value="/control/control_container"/>
+          <arg name="external_cmd_selector_param_path" value="$(var external_cmd_selector_param_path)"/>
+        </include>
+      </group>
+
+      <!-- external cmd converter -->
+      <group if="$(var launch_external_cmd_converter)">
+        <include file="$(find-pkg-share autoware_external_cmd_converter)/launch/external_cmd_converter.launch.py">
+          <arg name="use_intra_process" value="$(var use_intra_process)"/>
+          <arg name="target_container" value="/control/control_container"/>
+        </include>
+      </group>
     </group>
 
-    <!-- external cmd selector -->
-    <group if="$(var launch_external_cmd_selector)">
-      <include file="$(find-pkg-share autoware_external_cmd_selector)/launch/external_cmd_selector.launch.py">
-        <arg name="use_intra_process" value="$(var use_intra_process)"/>
-        <arg name="target_container" value="/control/control_container"/>
-        <arg name="external_cmd_selector_param_path" value="$(var external_cmd_selector_param_path)"/>
-      </include>
+    <group>
+      <!-- set a control check container to run all control checker components in the same process -->
+      <node_container pkg="rclcpp_components" exec="$(var container_executable)" name="control_check_container" namespace="">
+        <composable_node pkg="glog_component" plugin="GlogComponent" name="glog_control_check_container_component"/>
+      </node_container>
+
+      <!-- lane departure checker -->
+      <group if="$(var launch_lane_departure_checker)">
+        <load_composable_node target="/control/control_check_container">
+          <composable_node pkg="autoware_lane_departure_checker" plugin="autoware::lane_departure_checker::LaneDepartureCheckerNode" name="lane_departure_checker_node" namespace="trajectory_follower">
+            <remap from="~/input/odometry" to="/localization/kinematic_state"/>
+            <remap from="~/input/lanelet_map_bin" to="/map/vector_map"/>
+            <remap from="~/input/route" to="/planning/mission_planning/route"/>
+            <remap from="~/input/reference_trajectory" to="/planning/scenario_planning/trajectory"/>
+            <remap from="~/input/predicted_trajectory" to="/control/trajectory_follower/lateral/predicted_trajectory"/>
+            <param from="$(var nearest_search_param_path)"/>
+            <param from="$(var lane_departure_checker_param_path)"/>
+            <param from="$(var vehicle_param_file)"/>
+            <extra_arg name="use_intra_process_comms" value="$(var use_intra_process)"/>
+          </composable_node>
+        </load_composable_node>
+      </group>
+
+      <!-- control validator checker -->
+      <group if="$(var launch_control_validator)">
+        <load_composable_node target="/control/control_check_container">
+          <composable_node pkg="autoware_control_validator" plugin="autoware::control_validator::ControlValidator" name="control_validator">
+            <remap from="~/input/kinematics" to="/localization/kinematic_state"/>
+            <remap from="~/input/reference_trajectory" to="/planning/scenario_planning/trajectory"/>
+            <remap from="~/input/predicted_trajectory" to="/control/trajectory_follower/lateral/predicted_trajectory"/>
+            <remap from="~/output/validation_status" to="~/validation_status"/>
+            <param from="$(var control_validator_param_path)"/>
+          </composable_node>
+        </load_composable_node>
+      </group>
+
+      <!-- autonomous emergency braking -->
+      <group if="$(var launch_autonomous_emergency_braking)">
+        <load_composable_node target="/control/control_check_container" >
+          <composable_node pkg="autoware_autonomous_emergency_braking" plugin="autoware::motion::control::autonomous_emergency_braking::AEB" name="autonomous_emergency_braking">
+            <remap from="~/input/pointcloud" to="/perception/obstacle_segmentation/pointcloud"/>
+            <remap from="~/input/velocity" to="/vehicle/status/velocity_status"/>
+            <remap from="~/input/imu" to="/sensing/imu/imu_data"/>
+            <remap from="~/input/objects" to="/perception/object_recognition/objects"/>
+            <remap from="~/input/predicted_trajectory" to="/control/trajectory_follower/lateral/predicted_trajectory"/>
+            <param from="$(var aeb_param_path)"/>
+            <param name="check_autoware_state" value="$(var use_aeb_autoware_state_check)"/>
+            <extra_arg name="use_intra_process_comms" value="$(var use_intra_process)"/>
+          </composable_node>
+        </load_composable_node>
+      </group>
+
+      <!-- collision detector-->
+      <group if="$(var launch_collision_detector)">
+        <load_composable_node target="/control/control_check_container">
+          <composable_node pkg="autoware_collision_detector" plugin="autoware::collision_detector::CollisionDetectorNode" name="collision_detector">
+            <remap from="~/input/odometry" to="/localization/kinematic_state"/>
+            <remap from="~/input/pointcloud" to="/perception/obstacle_segmentation/pointcloud"/>
+            <remap from="~/input/objects" to="/perception/object_recognition/objects"/>
+            <param from="$(var collision_detector_param_path)"/>
+          </composable_node>
+        </load_composable_node>
+      </group>
+
+      <!-- obstacle collision checker -->
+      <group if="$(var launch_obstacle_collision_checker)">
+        <load_composable_node target="/control/control_check_container">
+          <composable_node pkg="autoware_obstacle_collision_checker" plugin="autoware::obstacle_collision_checker::ObstacleCollisionCheckerNode" name="obstacle_collision_checker">
+            <remap from="input/lanelet_map_bin" to="/map/vector_map"/>
+            <remap from="input/obstacle_pointcloud" to="/perception/obstacle_segmentation/pointcloud"/>
+            <remap from="input/reference_trajectory" to="/planning/scenario_planning/trajectory"/>
+            <remap from="input/predicted_trajectory" to="/control/trajectory_follower/lateral/predicted_trajectory"/>
+            <remap from="input/odometry" to="/localization/kinematic_state"/>
+            <param from="$(var obstacle_collision_checker_param_path)"/>
+            <param from="$(var vehicle_param_file)"/>
+            <extra_arg name="use_intra_process_comms" value="$(var use_intra_process)"/>
+          </composable_node>
+        </load_composable_node>
+      </group>
+
+      <!-- predicted path checker -->
+      <group if="$(var launch_predicted_path_checker)">
+        <load_composable_node target="/control/control_check_container">
+          <composable_node pkg="predicted_path_checker" plugin="autoware::motion::control::predicted_path_checker::PredictedPathCheckerNode" name="predicted_path_checker">
+            <remap from="~/input/objects" to="/perception/object_recognition/objects"/>
+            <remap from="~/input/reference_trajectory" to="/planning/scenario_planning/trajectory"/>
+            <remap from="~/input/current_accel" to="/localization/acceleration"/>
+            <remap from="~/input/odometry" to="/localization/kinematic_state"/>
+            <remap from="~/input/predicted_trajectory" to="/control/trajectory_follower/lateral/predicted_trajectory"/>
+            <param from="$(var vehicle_param_file)"/>
+            <param from="$(var predicted_path_checker_param_path)"/>
+            <extra_arg name="use_intra_process_comms" value="$(var use_intra_process)"/>
+          </composable_node>
+        </load_composable_node>
+      </group>
+
+      <!-- control evaluator -->
+      <group if="$(var launch_control_evaluator)">
+        <load_composable_node target="/control/control_check_container">
+          <composable_node pkg="autoware_control_evaluator" plugin="control_diagnostics::ControlEvaluatorNode" name="control_evaluator">
+            <remap from="~/input/diagnostics" to="/diagnostics"/>
+            <remap from="~/input/odometry" to="/localization/kinematic_state"/>
+            <remap from="~/input/acceleration" to="/localization/acceleration"/>
+            <remap from="~/input/trajectory" to="/planning/scenario_planning/trajectory"/>
+            <remap from="~/metrics" to="/control/control_evaluator/metrics"/>
+            <remap from="~/input/vector_map" to="/map/vector_map"/>
+            <remap from="~/input/route" to="/planning/mission_planning/route"/>
+          </composable_node>
+        </load_composable_node>
+      </group>
     </group>
-
-    <!-- external cmd converter -->
-    <group if="$(var launch_external_cmd_converter)">
-      <include file="$(find-pkg-share autoware_external_cmd_converter)/launch/external_cmd_converter.launch.py">
-        <arg name="use_intra_process" value="$(var use_intra_process)"/>
-        <arg name="target_container" value="/control/control_container"/>
-      </include>
-    </group>
-
-    <!-- obstacle collision checker -->
-    <group if="$(var enable_obstacle_collision_checker)">
-      <load_composable_node target="/control/control_container">
-        <composable_node pkg="autoware_obstacle_collision_checker" plugin="autoware::obstacle_collision_checker::ObstacleCollisionCheckerNode" name="obstacle_collision_checker">
-          <remap from="input/lanelet_map_bin" to="/map/vector_map"/>
-          <remap from="input/obstacle_pointcloud" to="/perception/obstacle_segmentation/pointcloud"/>
-          <remap from="input/reference_trajectory" to="/planning/scenario_planning/trajectory"/>
-          <remap from="input/predicted_trajectory" to="/control/trajectory_follower/lateral/predicted_trajectory"/>
-          <remap from="input/odometry" to="/localization/kinematic_state"/>
-          <param from="$(var obstacle_collision_checker_param_path)"/>
-          <param from="$(var vehicle_param_file)"/>
-          <extra_arg name="use_intra_process_comms" value="$(var use_intra_process)"/>
-        </composable_node>
-      </load_composable_node>
-    </group>
-
-    <!-- autonomous emergency braking -->
-    <group if="$(var launch_autonomous_emergency_braking)">
-      <load_composable_node target="/control/control_container" >
-        <composable_node pkg="autoware_autonomous_emergency_braking" plugin="autoware::motion::control::autonomous_emergency_braking::AEB" name="autonomous_emergency_braking">
-          <remap from="~/input/pointcloud" to="/perception/obstacle_segmentation/pointcloud"/>
-          <remap from="~/input/velocity" to="/vehicle/status/velocity_status"/>
-          <remap from="~/input/imu" to="/sensing/imu/imu_data"/>
-          <remap from="~/input/objects" to="/perception/object_recognition/objects"/>
-          <remap from="~/input/predicted_trajectory" to="/control/trajectory_follower/lateral/predicted_trajectory"/>
-          <param from="$(var aeb_param_path)"/>
-          <param name="check_autoware_state" value="$(var use_aeb_autoware_state_check)"/>
-          <extra_arg name="use_intra_process_comms" value="$(var use_intra_process)"/>
-        </composable_node>
-      </load_composable_node>
-    </group>
-
-    <!-- predicted path checker -->
-    <group if="$(var launch_predicted_path_checker)">
-      <load_composable_node target="/control/control_container">
-        <composable_node pkg="predicted_path_checker" plugin="autoware::motion::control::predicted_path_checker::PredictedPathCheckerNode" name="predicted_path_checker">
-          <remap from="~/input/objects" to="/perception/object_recognition/objects"/>
-          <remap from="~/input/reference_trajectory" to="/planning/scenario_planning/trajectory"/>
-          <remap from="~/input/current_accel" to="/localization/acceleration"/>
-          <remap from="~/input/odometry" to="/localization/kinematic_state"/>
-          <remap from="~/input/predicted_trajectory" to="/control/trajectory_follower/lateral/predicted_trajectory"/>
-          <param from="$(var vehicle_param_file)"/>
-          <param from="$(var predicted_path_checker_param_path)"/>
-          <extra_arg name="use_intra_process_comms" value="$(var use_intra_process)"/>
-        </composable_node>
-      </load_composable_node>
-    </group>
-
-    <!-- control evaluator -->
-    <group if="$(var launch_control_evaluator)">
-      <load_composable_node target="/control/control_container">
-        <composable_node pkg="autoware_control_evaluator" plugin="control_diagnostics::ControlEvaluatorNode" name="control_evaluator">
-          <remap from="~/input/diagnostics" to="/diagnostics"/>
-          <remap from="~/input/odometry" to="/localization/kinematic_state"/>
-          <remap from="~/input/acceleration" to="/localization/acceleration"/>
-          <remap from="~/input/trajectory" to="/planning/scenario_planning/trajectory"/>
-          <remap from="~/metrics" to="/control/control_evaluator/metrics"/>
-          <remap from="~/input/vector_map" to="/map/vector_map"/>
-          <remap from="~/input/route" to="/planning/mission_planning/route"/>
-        </composable_node>
-      </load_composable_node>
-    </group>
-
-    <!-- collision detector-->
-    <group if="$(var launch_collision_detector)">
-      <load_composable_node target="/control/control_container">
-        <composable_node pkg="autoware_collision_detector" plugin="autoware::collision_detector::CollisionDetectorNode" name="collision_detector">
-          <remap from="~/input/odometry" to="/localization/kinematic_state"/>
-          <remap from="~/input/pointcloud" to="/perception/obstacle_segmentation/pointcloud"/>
-          <remap from="~/input/objects" to="/perception/object_recognition/objects"/>
-          <param from="$(var collision_detector_param_path)"/>
-        </composable_node>
-      </load_composable_node>
-    </group>
-  </group>
-
-  <group if="$(var launch_control_validator)">
-    <push-ros-namespace namespace="control"/>
-
-    <!-- control validator checker -->
-    <node_container pkg="rclcpp_components" exec="$(var container_executable)" name="control_validator_container" namespace="">
-      <composable_node pkg="autoware_control_validator" plugin="autoware::control_validator::ControlValidator" name="control_validator">
-        <remap from="~/input/kinematics" to="/localization/kinematic_state"/>
-        <remap from="~/input/reference_trajectory" to="/planning/scenario_planning/trajectory"/>
-        <remap from="~/input/predicted_trajectory" to="/control/trajectory_follower/lateral/predicted_trajectory"/>
-        <remap from="~/output/validation_status" to="~/validation_status"/>
-        <param from="$(var control_validator_param_path)"/>
-      </composable_node>
-
-      <composable_node pkg="glog_component" plugin="GlogComponent" name="glog_validator_component"/>
-    </node_container>
-  </group>
-
-  <group if="$(eval &quot;'$(var trajectory_follower_mode)' == 'smart_mpc_trajectory_follower'&quot;)">
-    <node pkg="autoware_smart_mpc_trajectory_follower" exec="pympc_trajectory_follower.py" name="controller_node_exe"/>
   </group>
 </launch>

--- a/launch/tier4_control_launch/launch/control.launch.xml
+++ b/launch/tier4_control_launch/launch/control.launch.xml
@@ -1,5 +1,5 @@
 <launch>
-  <!-- controler -->
+  <!-- controller -->
   <arg name="trajectory_follower_mode" default="trajectory_follower_node"/>
   <arg name="lateral_controller_mode"/>
   <arg name="longitudinal_controller_mode"/>
@@ -127,7 +127,7 @@
 
       <!-- trajectory_follower_node -->
       <group if="$(eval &quot;'$(var trajectory_follower_mode)' == 'trajectory_follower_node'&quot;)">
-        <load_composable_node target="/control/control_container" >
+        <load_composable_node target="/control/control_container">
           <composable_node pkg="autoware_trajectory_follower_node" plugin="autoware::motion::control::trajectory_follower_node::Controller" name="controller_node_exe" namespace="trajectory_follower">
             <remap from="~/input/reference_trajectory" to="/planning/scenario_planning/trajectory"/>
             <remap from="~/input/current_odometry" to="/localization/kinematic_state"/>
@@ -212,7 +212,7 @@
 
       <!-- autonomous emergency braking -->
       <group if="$(var launch_autonomous_emergency_braking)">
-        <load_composable_node target="/control/control_check_container" >
+        <load_composable_node target="/control/control_check_container">
           <composable_node pkg="autoware_autonomous_emergency_braking" plugin="autoware::motion::control::autonomous_emergency_braking::AEB" name="autonomous_emergency_braking">
             <remap from="~/input/pointcloud" to="/perception/obstacle_segmentation/pointcloud"/>
             <remap from="~/input/velocity" to="/vehicle/status/velocity_status"/>

--- a/launch/tier4_control_launch/launch/control.launch.xml
+++ b/launch/tier4_control_launch/launch/control.launch.xml
@@ -1,9 +1,9 @@
 <launch>
   <!-- option -->
   <arg name="enable_obstacle_collision_checker" default="false"/>
-  <arg name="enable_autonomous_emergency_braking" default="true"/>
-  <arg name="enable_predicted_path_checker" default="false"/>
-  <arg name="enable_collision_detector" default="false"/>
+  <arg name="launch_autonomous_emergency_braking" default="true"/>
+  <arg name="launch_predicted_path_checker" default="false"/>
+  <arg name="launch_collision_detector" default="false"/>
   <arg name="trajectory_follower_mode" default="trajectory_follower_node"/>
   <arg name="lateral_controller_mode"/>
   <arg name="longitudinal_controller_mode"/>
@@ -15,7 +15,6 @@
   <arg name="launch_shift_decider" default="true"/>
   <arg name="launch_vehicle_cmd_gate" default="true"/>
   <arg name="launch_operation_mode_transition_manager" default="true"/>
-  <arg name="launch_basic_control_modules" default="true"/>
   <arg name="launch_external_cmd_selector" default="true"/>
   <arg name="launch_external_cmd_converter" default="true"/>
   <arg name="launch_control_evaluator" default="true"/>
@@ -52,7 +51,9 @@
 
     <group>
       <!-- set container to run all required components in the same process -->
-      <node_container pkg="rclcpp_components" exec="$(var container_executable)" name="control_container" namespace=""/>
+      <node_container pkg="rclcpp_components" exec="$(var container_executable)" name="control_container" namespace="">
+        <composable_node pkg="glog_component" plugin="GlogComponent" name="glog_component"/>
+      <node_container/>
 
       <!-- trajectory_follower_node -->
       <group if="$(eval &quot;'$(var trajectory_follower_mode)' == 'trajectory_follower_node'&quot;)">
@@ -81,9 +82,9 @@
         </load_composable_node>
       </group>
 
-      <group if="$(var launch_basic_control_modules)">
+      <!-- lane departure checker -->
+      <group if="$(var launch_lane_departure_checker)">
         <load_composable_node target="/control/control_container">
-          <!-- lane departure checker -->
           <composable_node pkg="autoware_lane_departure_checker" plugin="autoware::lane_departure_checker::LaneDepartureCheckerNode" name="lane_departure_checker_node" namespace="trajectory_follower">
             <remap from="~/input/odometry" to="/localization/kinematic_state"/>
             <remap from="~/input/lanelet_map_bin" to="/map/vector_map"/>
@@ -95,8 +96,12 @@
             <param from="$(var vehicle_param_file)"/>
             <extra_arg name="use_intra_process_comms" value="$(var use_intra_process)"/>
           </composable_node>
+        </load_composable_node>
+      </group>
 
-          <!-- shift decider -->
+      <!-- shift decider -->
+      <group if="$(var launch_shift_decider)">
+        <load_composable_node target="/control/control_container">
           <composable_node pkg="autoware_shift_decider" plugin="autoware::shift_decider::ShiftDecider" name="autoware_shift_decider">
             <remap from="input/control_cmd" to="/control/trajectory_follower/control_cmd"/>
             <remap from="input/state" to="/autoware/state"/>
@@ -105,8 +110,12 @@
             <param from="$(var shift_decider_param_path)"/>
             <extra_arg name="use_intra_process_comms" value="$(var use_intra_process)"/>
           </composable_node>
+        </load_composable_node>
+      </group>
 
-          <!-- vehicle cmd gate -->
+      <!-- vehicle cmd gate -->
+      <group if="$(var launch_vehicle_cmd_gate)">
+        <load_composable_node target="/control/control_container">
           <composable_node pkg="autoware_vehicle_cmd_gate" plugin="autoware::vehicle_cmd_gate::VehicleCmdGate" name="vehicle_cmd_gate">
             <remap from="input/steering" to="/vehicle/status/steering_status"/>
             <remap from="input/operation_mode" to="/system/operation_mode/state"/>
@@ -146,8 +155,12 @@
             <param name="check_external_emergency_heartbeat" value="$(var check_external_emergency_heartbeat)"/>
             <extra_arg name="use_intra_process_comms" value="$(var use_intra_process)"/>
           </composable_node>
+        </load_composable_node>
+      </group>
 
-          <!-- operation mode transition manager -->
+      <!-- operation mode transition manager -->
+      <group if="$(var launch_operation_mode_transition_manager)">
+        <load_composable_node target="/control/control_container">
           <composable_node
             pkg="autoware_operation_mode_transition_manager"
             plugin="autoware::operation_mode_transition_manager::OperationModeTransitionManager"
@@ -169,8 +182,6 @@
             <param from="$(var vehicle_param_file)"/>
             <extra_arg name="use_intra_process_comms" value="$(var use_intra_process)"/>
           </composable_node>
-
-          <composable_node pkg="glog_component" plugin="GlogComponent" name="glog_component"/>
         </load_composable_node>
       </group>
     </group>
@@ -209,7 +220,7 @@
     </group>
 
     <!-- autonomous emergency braking -->
-    <group if="$(var enable_autonomous_emergency_braking)">
+    <group if="$(var launch_autonomous_emergency_braking)">
       <load_composable_node target="/control/control_container" >
         <composable_node pkg="autoware_autonomous_emergency_braking" plugin="autoware::motion::control::autonomous_emergency_braking::AEB" name="autonomous_emergency_braking">
           <remap from="~/input/pointcloud" to="/perception/obstacle_segmentation/pointcloud"/>
@@ -225,7 +236,7 @@
     </group>
 
     <!-- predicted path checker -->
-    <group if="$(var enable_predicted_path_checker)">
+    <group if="$(var launch_predicted_path_checker)">
       <load_composable_node target="/control/control_container">
         <composable_node pkg="predicted_path_checker" plugin="autoware::motion::control::predicted_path_checker::PredictedPathCheckerNode" name="predicted_path_checker">
           <remap from="~/input/objects" to="/perception/object_recognition/objects"/>
@@ -256,7 +267,7 @@
     </group>
 
     <!-- collision detector-->
-    <group if="$(var enable_collision_detector)">
+    <group if="$(var launch_collision_detector)">
       <load_composable_node target="/control/control_container">
         <composable_node pkg="autoware_collision_detector" plugin="autoware::collision_detector::CollisionDetectorNode" name="collision_detector">
           <remap from="~/input/odometry" to="/localization/kinematic_state"/>

--- a/launch/tier4_control_launch/launch/control.launch.xml
+++ b/launch/tier4_control_launch/launch/control.launch.xml
@@ -1,9 +1,9 @@
 <launch>
   <!-- option -->
-  <arg name="launch_obstacle_collision_checker" default="false"/>
-  <arg name="launch_autonomous_emergency_braking" default="true"/>
-  <arg name="launch_predicted_path_checker" default="false"/>
-  <arg name="launch_collision_detector" default="false"/>
+  <arg name="enable_obstacle_collision_checker" default="false"/>
+  <arg name="enable_autonomous_emergency_braking" default="true"/>
+  <arg name="enable_predicted_path_checker" default="false"/>
+  <arg name="enable_collision_detector" default="false"/>
   <arg name="trajectory_follower_mode" default="trajectory_follower_node"/>
   <arg name="lateral_controller_mode"/>
   <arg name="longitudinal_controller_mode"/>
@@ -196,7 +196,7 @@
     </group>
 
     <!-- obstacle collision checker -->
-    <load_composable_node target="/control/control_container" if="$(var launch_obstacle_collision_checker)">
+    <load_composable_node target="/control/control_container" if="$(var enable_obstacle_collision_checker)">
       <composable_node pkg="autoware_obstacle_collision_checker" plugin="autoware::obstacle_collision_checker::ObstacleCollisionCheckerNode" name="obstacle_collision_checker">
         <remap from="input/lanelet_map_bin" to="/map/vector_map"/>
         <remap from="input/obstacle_pointcloud" to="/perception/obstacle_segmentation/pointcloud"/>
@@ -210,7 +210,7 @@
     </load_composable_node>
 
     <!-- autonomous emergency braking -->
-    <load_composable_node target="/control/control_container" if="$(var launch_autonomous_emergency_braking)">
+    <load_composable_node target="/control/control_container" if="$(var enable_autonomous_emergency_braking)">
       <composable_node pkg="autoware_autonomous_emergency_braking" plugin="autoware::motion::control::autonomous_emergency_braking::AEB" name="autonomous_emergency_braking">
         <remap from="~/input/pointcloud" to="/perception/obstacle_segmentation/pointcloud"/>
         <remap from="~/input/velocity" to="/vehicle/status/velocity_status"/>
@@ -224,7 +224,7 @@
     </load_composable_node>
 
     <!-- predicted path checker -->
-    <load_composable_node target="/control/control_container" if="$(var launch_predicted_path_checker)">
+    <load_composable_node target="/control/control_container" if="$(var enable_predicted_path_checker)">
       <composable_node pkg="predicted_path_checker" plugin="autoware::motion::control::predicted_path_checker::PredictedPathCheckerNode" name="predicted_path_checker">
         <remap from="~/input/objects" to="/perception/object_recognition/objects"/>
         <remap from="~/input/reference_trajectory" to="/planning/scenario_planning/trajectory"/>
@@ -251,7 +251,7 @@
     </load_composable_node>
 
     <!-- collision detector-->
-    <load_composable_node target="/control/control_container" if="$(var launch_collision_detector)">
+    <load_composable_node target="/control/control_container" if="$(var enable_collision_detector)">
       <composable_node pkg="autoware_collision_detector" plugin="autoware::collision_detector::CollisionDetectorNode" name="collision_detector">
         <remap from="~/input/odometry" to="/localization/kinematic_state"/>
         <remap from="~/input/pointcloud" to="/perception/obstacle_segmentation/pointcloud"/>

--- a/launch/tier4_control_launch/launch/control.launch.xml
+++ b/launch/tier4_control_launch/launch/control.launch.xml
@@ -7,7 +7,6 @@
   <arg name="trajectory_follower_mode" default="trajectory_follower_node"/>
   <arg name="lateral_controller_mode"/>
   <arg name="longitudinal_controller_mode"/>
-  <arg name="enable_autonomous_emergency_braking"/>
   <arg name="use_aeb_autoware_state_check"/>
   <arg name="check_external_emergency_heartbeat"/>
 
@@ -16,6 +15,7 @@
   <arg name="launch_shift_decider" default="true"/>
   <arg name="launch_vehicle_cmd_gate" default="true"/>
   <arg name="launch_operation_mode_transition_manager" default="true"/>
+  <arg name="launch_basic_control_modules" default="true"/>
   <arg name="launch_external_cmd_selector" default="true"/>
   <arg name="launch_external_cmd_converter" default="true"/>
   <arg name="launch_control_evaluator" default="true"/>
@@ -78,103 +78,95 @@
           <extra_arg name="use_intra_process_comms" value="$(var use_intra_process)"/>
         </composable_node>
       </load_composable_node>
-
+        <!-- if="$(var launch_basic_control_modules)" -->
       <load_composable_node target="/control/control_container">
         <!-- lane departure checker -->
-        <group if="$(var launch_lane_departure_checker)">
-          <composable_node pkg="autoware_lane_departure_checker" plugin="autoware::lane_departure_checker::LaneDepartureCheckerNode" name="lane_departure_checker_node" namespace="trajectory_follower">
-            <remap from="~/input/odometry" to="/localization/kinematic_state"/>
-            <remap from="~/input/lanelet_map_bin" to="/map/vector_map"/>
-            <remap from="~/input/route" to="/planning/mission_planning/route"/>
-            <remap from="~/input/reference_trajectory" to="/planning/scenario_planning/trajectory"/>
-            <remap from="~/input/predicted_trajectory" to="/control/trajectory_follower/lateral/predicted_trajectory"/>
-            <param from="$(var nearest_search_param_path)"/>
-            <param from="$(var lane_departure_checker_param_path)"/>
-            <param from="$(var vehicle_param_file)"/>
-            <extra_arg name="use_intra_process_comms" value="$(var use_intra_process)"/>
-          </composable_node>
-        </group>
+        <composable_node pkg="autoware_lane_departure_checker" plugin="autoware::lane_departure_checker::LaneDepartureCheckerNode" name="lane_departure_checker_node" namespace="trajectory_follower">
+          <remap from="~/input/odometry" to="/localization/kinematic_state"/>
+          <remap from="~/input/lanelet_map_bin" to="/map/vector_map"/>
+          <remap from="~/input/route" to="/planning/mission_planning/route"/>
+          <remap from="~/input/reference_trajectory" to="/planning/scenario_planning/trajectory"/>
+          <remap from="~/input/predicted_trajectory" to="/control/trajectory_follower/lateral/predicted_trajectory"/>
+          <param from="$(var nearest_search_param_path)"/>
+          <param from="$(var lane_departure_checker_param_path)"/>
+          <param from="$(var vehicle_param_file)"/>
+          <extra_arg name="use_intra_process_comms" value="$(var use_intra_process)"/>
+        </composable_node>
 
         <!-- shift decider -->
-        <group if="$(var launch_shift_decider)">
-          <composable_node pkg="autoware_shift_decider" plugin="autoware::shift_decider::ShiftDecider" name="autoware_shift_decider">
-            <remap from="input/control_cmd" to="/control/trajectory_follower/control_cmd"/>
-            <remap from="input/state" to="/autoware/state"/>
-            <remap from="input/current_gear" to="/vehicle/status/gear_status"/>
-            <remap from="output/gear_cmd" to="/control/shift_decider/gear_cmd"/>
-            <param from="$(var shift_decider_param_path)"/>
-            <extra_arg name="use_intra_process_comms" value="$(var use_intra_process)"/>
-          </composable_node>
-        </group>
+        <composable_node pkg="autoware_shift_decider" plugin="autoware::shift_decider::ShiftDecider" name="autoware_shift_decider">
+          <remap from="input/control_cmd" to="/control/trajectory_follower/control_cmd"/>
+          <remap from="input/state" to="/autoware/state"/>
+          <remap from="input/current_gear" to="/vehicle/status/gear_status"/>
+          <remap from="output/gear_cmd" to="/control/shift_decider/gear_cmd"/>
+          <param from="$(var shift_decider_param_path)"/>
+          <extra_arg name="use_intra_process_comms" value="$(var use_intra_process)"/>
+        </composable_node>
 
         <!-- vehicle cmd gate -->
-        <group if="$(var launch_vehicle_cmd_gate)">
-          <composable_node pkg="autoware_vehicle_cmd_gate" plugin="autoware::vehicle_cmd_gate::VehicleCmdGate" name="vehicle_cmd_gate">
-            <remap from="input/steering" to="/vehicle/status/steering_status"/>
-            <remap from="input/operation_mode" to="/system/operation_mode/state"/>
-            <remap from="input/auto/control_cmd" to="/control/trajectory_follower/control_cmd"/>
-            <remap from="input/auto/turn_indicators_cmd" to="/planning/turn_indicators_cmd"/>
-            <remap from="input/auto/hazard_lights_cmd" to="/planning/hazard_lights_cmd"/>
-            <remap from="input/auto/gear_cmd" to="/control/shift_decider/gear_cmd"/>
-            <remap from="input/external/control_cmd" to="/external/selected/control_cmd"/>
-            <remap from="input/external/turn_indicators_cmd" to="/external/selected/turn_indicators_cmd"/>
-            <remap from="input/external/hazard_lights_cmd" to="/external/selected/hazard_lights_cmd"/>
-            <remap from="input/external/gear_cmd" to="/external/selected/gear_cmd"/>
-            <remap from="input/external_emergency_stop_heartbeat" to="/external/selected/heartbeat"/>
-            <remap from="input/gate_mode" to="/control/gate_mode_cmd"/>
-            <remap from="input/emergency/control_cmd" to="/system/emergency/control_cmd"/>
-            <remap from="input/emergency/hazard_lights_cmd" to="/system/emergency/hazard_lights_cmd"/>
-            <remap from="input/emergency/gear_cmd" to="/system/emergency/gear_cmd"/>
-            <remap from="input/mrm_state" to="/system/fail_safe/mrm_state"/>
-            <remap from="input/kinematics" to="/localization/kinematic_state"/>
-            <remap from="input/acceleration" to="/localization/acceleration"/>
-            <remap from="output/vehicle_cmd_emergency" to="/control/command/emergency_cmd"/>
-            <remap from="output/control_cmd" to="/control/command/control_cmd"/>
-            <remap from="output/gear_cmd" to="/control/command/gear_cmd"/>
-            <remap from="output/turn_indicators_cmd" to="/control/command/turn_indicators_cmd"/>
-            <remap from="output/hazard_lights_cmd" to="/control/command/hazard_lights_cmd"/>
-            <remap from="output/gate_mode" to="/control/current_gate_mode"/>
-            <remap from="output/engage" to="/api/autoware/get/engage"/>
-            <remap from="output/external_emergency" to="/api/autoware/get/emergency"/>
-            <remap from="output/operation_mode" to="/control/vehicle_cmd_gate/operation_mode"/>
-            <remap from="~/service/engage" to="/api/autoware/set/engage"/>
-            <remap from="~/service/external_emergency" to="/api/autoware/set/emergency"/>
-            <!-- TODO(Takagi, Isamu): deprecated -->
-            <remap from="input/engage" to="/autoware/engage"/>
-            <remap from="~/service/external_emergency_stop" to="~/external_emergency_stop"/>
-            <remap from="~/service/clear_external_emergency_stop" to="~/clear_external_emergency_stop"/>
-            <param from="$(var vehicle_cmd_gate_param_path)"/>
-            <param from="$(var vehicle_param_file)"/>
-            <param name="check_external_emergency_heartbeat" value="$(var check_external_emergency_heartbeat)"/>
-            <extra_arg name="use_intra_process_comms" value="$(var use_intra_process)"/>
-          </composable_node>
-        </group>
+        <composable_node pkg="autoware_vehicle_cmd_gate" plugin="autoware::vehicle_cmd_gate::VehicleCmdGate" name="vehicle_cmd_gate">
+          <remap from="input/steering" to="/vehicle/status/steering_status"/>
+          <remap from="input/operation_mode" to="/system/operation_mode/state"/>
+          <remap from="input/auto/control_cmd" to="/control/trajectory_follower/control_cmd"/>
+          <remap from="input/auto/turn_indicators_cmd" to="/planning/turn_indicators_cmd"/>
+          <remap from="input/auto/hazard_lights_cmd" to="/planning/hazard_lights_cmd"/>
+          <remap from="input/auto/gear_cmd" to="/control/shift_decider/gear_cmd"/>
+          <remap from="input/external/control_cmd" to="/external/selected/control_cmd"/>
+          <remap from="input/external/turn_indicators_cmd" to="/external/selected/turn_indicators_cmd"/>
+          <remap from="input/external/hazard_lights_cmd" to="/external/selected/hazard_lights_cmd"/>
+          <remap from="input/external/gear_cmd" to="/external/selected/gear_cmd"/>
+          <remap from="input/external_emergency_stop_heartbeat" to="/external/selected/heartbeat"/>
+          <remap from="input/gate_mode" to="/control/gate_mode_cmd"/>
+          <remap from="input/emergency/control_cmd" to="/system/emergency/control_cmd"/>
+          <remap from="input/emergency/hazard_lights_cmd" to="/system/emergency/hazard_lights_cmd"/>
+          <remap from="input/emergency/gear_cmd" to="/system/emergency/gear_cmd"/>
+          <remap from="input/mrm_state" to="/system/fail_safe/mrm_state"/>
+          <remap from="input/kinematics" to="/localization/kinematic_state"/>
+          <remap from="input/acceleration" to="/localization/acceleration"/>
+          <remap from="output/vehicle_cmd_emergency" to="/control/command/emergency_cmd"/>
+          <remap from="output/control_cmd" to="/control/command/control_cmd"/>
+          <remap from="output/gear_cmd" to="/control/command/gear_cmd"/>
+          <remap from="output/turn_indicators_cmd" to="/control/command/turn_indicators_cmd"/>
+          <remap from="output/hazard_lights_cmd" to="/control/command/hazard_lights_cmd"/>
+          <remap from="output/gate_mode" to="/control/current_gate_mode"/>
+          <remap from="output/engage" to="/api/autoware/get/engage"/>
+          <remap from="output/external_emergency" to="/api/autoware/get/emergency"/>
+          <remap from="output/operation_mode" to="/control/vehicle_cmd_gate/operation_mode"/>
+          <remap from="~/service/engage" to="/api/autoware/set/engage"/>
+          <remap from="~/service/external_emergency" to="/api/autoware/set/emergency"/>
+          <!-- TODO(Takagi, Isamu): deprecated -->
+          <remap from="input/engage" to="/autoware/engage"/>
+          <remap from="~/service/external_emergency_stop" to="~/external_emergency_stop"/>
+          <remap from="~/service/clear_external_emergency_stop" to="~/clear_external_emergency_stop"/>
+          <param from="$(var vehicle_cmd_gate_param_path)"/>
+          <param from="$(var vehicle_param_file)"/>
+          <param name="check_external_emergency_heartbeat" value="$(var check_external_emergency_heartbeat)"/>
+          <extra_arg name="use_intra_process_comms" value="$(var use_intra_process)"/>
+        </composable_node>
 
         <!-- operation mode transition manager -->
-        <group if="$(var launch_operation_mode_transition_manager)">
-          <composable_node
-            pkg="autoware_operation_mode_transition_manager"
-            plugin="autoware::operation_mode_transition_manager::OperationModeTransitionManager"
-            name="autoware_operation_mode_transition_manager"
-          >
-            <!-- input -->
-            <remap from="kinematics" to="/localization/kinematic_state"/>
-            <remap from="steering" to="/vehicle/status/steering_status"/>
-            <remap from="trajectory" to="/planning/scenario_planning/trajectory"/>
-            <remap from="control_cmd" to="/control/command/control_cmd"/>
-            <remap from="trajectory_follower_control_cmd" to="/control/trajectory_follower/control_cmd"/>
-            <remap from="control_mode_report" to="/vehicle/status/control_mode"/>
-            <remap from="gate_operation_mode" to="/control/vehicle_cmd_gate/operation_mode"/>
-            <!-- output -->
-            <remap from="is_autonomous_available" to="/control/is_autonomous_available"/>
-            <remap from="control_mode_request" to="/control/control_mode_request"/>
-            <param from="$(var nearest_search_param_path)"/>
-            <param from="$(var operation_mode_transition_manager_param_path)"/>
-            <param from="$(var vehicle_param_file)"/>
-            <extra_arg name="use_intra_process_comms" value="$(var use_intra_process)"/>
-          </composable_node>
-          <composable_node pkg="glog_component" plugin="GlogComponent" name="glog_component"/>
-        </group>
+        <composable_node
+          pkg="autoware_operation_mode_transition_manager"
+          plugin="autoware::operation_mode_transition_manager::OperationModeTransitionManager"
+          name="autoware_operation_mode_transition_manager"
+        >
+          <!-- input -->
+          <remap from="kinematics" to="/localization/kinematic_state"/>
+          <remap from="steering" to="/vehicle/status/steering_status"/>
+          <remap from="trajectory" to="/planning/scenario_planning/trajectory"/>
+          <remap from="control_cmd" to="/control/command/control_cmd"/>
+          <remap from="trajectory_follower_control_cmd" to="/control/trajectory_follower/control_cmd"/>
+          <remap from="control_mode_report" to="/vehicle/status/control_mode"/>
+          <remap from="gate_operation_mode" to="/control/vehicle_cmd_gate/operation_mode"/>
+          <!-- output -->
+          <remap from="is_autonomous_available" to="/control/is_autonomous_available"/>
+          <remap from="control_mode_request" to="/control/control_mode_request"/>
+          <param from="$(var nearest_search_param_path)"/>
+          <param from="$(var operation_mode_transition_manager_param_path)"/>
+          <param from="$(var vehicle_param_file)"/>
+          <extra_arg name="use_intra_process_comms" value="$(var use_intra_process)"/>
+        </composable_node>
+        <composable_node pkg="glog_component" plugin="GlogComponent" name="glog_component"/>
       </load_composable_node>
     </group>
 

--- a/launch/tier4_control_launch/launch/control.launch.xml
+++ b/launch/tier4_control_launch/launch/control.launch.xml
@@ -55,119 +55,124 @@
       <node_container pkg="rclcpp_components" exec="$(var container_executable)" name="control_container" namespace=""/>
 
       <!-- trajectory_follower_node -->
-      <load_composable_node target="/control/control_container" if="$(eval &quot;'$(var trajectory_follower_mode)' == 'trajectory_follower_node'&quot;)">
-        <composable_node pkg="autoware_trajectory_follower_node" plugin="autoware::motion::control::trajectory_follower_node::Controller" name="controller_node_exe" namespace="trajectory_follower">
-          <remap from="~/input/reference_trajectory" to="/planning/scenario_planning/trajectory"/>
-          <remap from="~/input/current_odometry" to="/localization/kinematic_state"/>
-          <remap from="~/input/current_steering" to="/vehicle/status/steering_status"/>
-          <remap from="~/input/current_accel" to="/localization/acceleration"/>
-          <remap from="~/input/current_operation_mode" to="/system/operation_mode/state"/>
-          <remap from="~/output/predicted_trajectory" to="lateral/predicted_trajectory"/>
-          <remap from="~/output/lateral_diagnostic" to="lateral/diagnostic"/>
-          <remap from="~/output/slope_angle" to="longitudinal/slope_angle"/>
-          <remap from="~/output/longitudinal_diagnostic" to="longitudinal/diagnostic"/>
-          <remap from="~/output/stop_reason" to="longitudinal/stop_reason"/>
-          <remap from="~/output/control_cmd" to="control_cmd"/>
-          <param name="lateral_controller_mode" value="$(var lateral_controller_mode)"/>
-          <param name="longitudinal_controller_mode" value="$(var longitudinal_controller_mode)"/>
-          <param from="$(var nearest_search_param_path)"/>
-          <param from="$(var trajectory_follower_node_param_path)"/>
-          <param from="$(var lon_controller_param_path)"/>
-          <param from="$(var lat_controller_param_path)"/>
-          <param from="$(var vehicle_param_file)"/>
-          <extra_arg name="use_intra_process_comms" value="$(var use_intra_process)"/>
-        </composable_node>
-      </load_composable_node>
-        <!-- if="$(var launch_basic_control_modules)" -->
-      <load_composable_node target="/control/control_container">
-        <!-- lane departure checker -->
-        <composable_node pkg="autoware_lane_departure_checker" plugin="autoware::lane_departure_checker::LaneDepartureCheckerNode" name="lane_departure_checker_node" namespace="trajectory_follower">
-          <remap from="~/input/odometry" to="/localization/kinematic_state"/>
-          <remap from="~/input/lanelet_map_bin" to="/map/vector_map"/>
-          <remap from="~/input/route" to="/planning/mission_planning/route"/>
-          <remap from="~/input/reference_trajectory" to="/planning/scenario_planning/trajectory"/>
-          <remap from="~/input/predicted_trajectory" to="/control/trajectory_follower/lateral/predicted_trajectory"/>
-          <param from="$(var nearest_search_param_path)"/>
-          <param from="$(var lane_departure_checker_param_path)"/>
-          <param from="$(var vehicle_param_file)"/>
-          <extra_arg name="use_intra_process_comms" value="$(var use_intra_process)"/>
-        </composable_node>
+      <group if="$(eval &quot;'$(var trajectory_follower_mode)' == 'trajectory_follower_node'&quot;)">
+        <load_composable_node target="/control/control_container" >
+          <composable_node pkg="autoware_trajectory_follower_node" plugin="autoware::motion::control::trajectory_follower_node::Controller" name="controller_node_exe" namespace="trajectory_follower">
+            <remap from="~/input/reference_trajectory" to="/planning/scenario_planning/trajectory"/>
+            <remap from="~/input/current_odometry" to="/localization/kinematic_state"/>
+            <remap from="~/input/current_steering" to="/vehicle/status/steering_status"/>
+            <remap from="~/input/current_accel" to="/localization/acceleration"/>
+            <remap from="~/input/current_operation_mode" to="/system/operation_mode/state"/>
+            <remap from="~/output/predicted_trajectory" to="lateral/predicted_trajectory"/>
+            <remap from="~/output/lateral_diagnostic" to="lateral/diagnostic"/>
+            <remap from="~/output/slope_angle" to="longitudinal/slope_angle"/>
+            <remap from="~/output/longitudinal_diagnostic" to="longitudinal/diagnostic"/>
+            <remap from="~/output/stop_reason" to="longitudinal/stop_reason"/>
+            <remap from="~/output/control_cmd" to="control_cmd"/>
+            <param name="lateral_controller_mode" value="$(var lateral_controller_mode)"/>
+            <param name="longitudinal_controller_mode" value="$(var longitudinal_controller_mode)"/>
+            <param from="$(var nearest_search_param_path)"/>
+            <param from="$(var trajectory_follower_node_param_path)"/>
+            <param from="$(var lon_controller_param_path)"/>
+            <param from="$(var lat_controller_param_path)"/>
+            <param from="$(var vehicle_param_file)"/>
+            <extra_arg name="use_intra_process_comms" value="$(var use_intra_process)"/>
+          </composable_node>
+        </load_composable_node>
+      </group>
 
-        <!-- shift decider -->
-        <composable_node pkg="autoware_shift_decider" plugin="autoware::shift_decider::ShiftDecider" name="autoware_shift_decider">
-          <remap from="input/control_cmd" to="/control/trajectory_follower/control_cmd"/>
-          <remap from="input/state" to="/autoware/state"/>
-          <remap from="input/current_gear" to="/vehicle/status/gear_status"/>
-          <remap from="output/gear_cmd" to="/control/shift_decider/gear_cmd"/>
-          <param from="$(var shift_decider_param_path)"/>
-          <extra_arg name="use_intra_process_comms" value="$(var use_intra_process)"/>
-        </composable_node>
+      <group if="$(var launch_basic_control_modules)">
+        <load_composable_node target="/control/control_container">
+          <!-- lane departure checker -->
+          <composable_node pkg="autoware_lane_departure_checker" plugin="autoware::lane_departure_checker::LaneDepartureCheckerNode" name="lane_departure_checker_node" namespace="trajectory_follower">
+            <remap from="~/input/odometry" to="/localization/kinematic_state"/>
+            <remap from="~/input/lanelet_map_bin" to="/map/vector_map"/>
+            <remap from="~/input/route" to="/planning/mission_planning/route"/>
+            <remap from="~/input/reference_trajectory" to="/planning/scenario_planning/trajectory"/>
+            <remap from="~/input/predicted_trajectory" to="/control/trajectory_follower/lateral/predicted_trajectory"/>
+            <param from="$(var nearest_search_param_path)"/>
+            <param from="$(var lane_departure_checker_param_path)"/>
+            <param from="$(var vehicle_param_file)"/>
+            <extra_arg name="use_intra_process_comms" value="$(var use_intra_process)"/>
+          </composable_node>
 
-        <!-- vehicle cmd gate -->
-        <composable_node pkg="autoware_vehicle_cmd_gate" plugin="autoware::vehicle_cmd_gate::VehicleCmdGate" name="vehicle_cmd_gate">
-          <remap from="input/steering" to="/vehicle/status/steering_status"/>
-          <remap from="input/operation_mode" to="/system/operation_mode/state"/>
-          <remap from="input/auto/control_cmd" to="/control/trajectory_follower/control_cmd"/>
-          <remap from="input/auto/turn_indicators_cmd" to="/planning/turn_indicators_cmd"/>
-          <remap from="input/auto/hazard_lights_cmd" to="/planning/hazard_lights_cmd"/>
-          <remap from="input/auto/gear_cmd" to="/control/shift_decider/gear_cmd"/>
-          <remap from="input/external/control_cmd" to="/external/selected/control_cmd"/>
-          <remap from="input/external/turn_indicators_cmd" to="/external/selected/turn_indicators_cmd"/>
-          <remap from="input/external/hazard_lights_cmd" to="/external/selected/hazard_lights_cmd"/>
-          <remap from="input/external/gear_cmd" to="/external/selected/gear_cmd"/>
-          <remap from="input/external_emergency_stop_heartbeat" to="/external/selected/heartbeat"/>
-          <remap from="input/gate_mode" to="/control/gate_mode_cmd"/>
-          <remap from="input/emergency/control_cmd" to="/system/emergency/control_cmd"/>
-          <remap from="input/emergency/hazard_lights_cmd" to="/system/emergency/hazard_lights_cmd"/>
-          <remap from="input/emergency/gear_cmd" to="/system/emergency/gear_cmd"/>
-          <remap from="input/mrm_state" to="/system/fail_safe/mrm_state"/>
-          <remap from="input/kinematics" to="/localization/kinematic_state"/>
-          <remap from="input/acceleration" to="/localization/acceleration"/>
-          <remap from="output/vehicle_cmd_emergency" to="/control/command/emergency_cmd"/>
-          <remap from="output/control_cmd" to="/control/command/control_cmd"/>
-          <remap from="output/gear_cmd" to="/control/command/gear_cmd"/>
-          <remap from="output/turn_indicators_cmd" to="/control/command/turn_indicators_cmd"/>
-          <remap from="output/hazard_lights_cmd" to="/control/command/hazard_lights_cmd"/>
-          <remap from="output/gate_mode" to="/control/current_gate_mode"/>
-          <remap from="output/engage" to="/api/autoware/get/engage"/>
-          <remap from="output/external_emergency" to="/api/autoware/get/emergency"/>
-          <remap from="output/operation_mode" to="/control/vehicle_cmd_gate/operation_mode"/>
-          <remap from="~/service/engage" to="/api/autoware/set/engage"/>
-          <remap from="~/service/external_emergency" to="/api/autoware/set/emergency"/>
-          <!-- TODO(Takagi, Isamu): deprecated -->
-          <remap from="input/engage" to="/autoware/engage"/>
-          <remap from="~/service/external_emergency_stop" to="~/external_emergency_stop"/>
-          <remap from="~/service/clear_external_emergency_stop" to="~/clear_external_emergency_stop"/>
-          <param from="$(var vehicle_cmd_gate_param_path)"/>
-          <param from="$(var vehicle_param_file)"/>
-          <param name="check_external_emergency_heartbeat" value="$(var check_external_emergency_heartbeat)"/>
-          <extra_arg name="use_intra_process_comms" value="$(var use_intra_process)"/>
-        </composable_node>
+          <!-- shift decider -->
+          <composable_node pkg="autoware_shift_decider" plugin="autoware::shift_decider::ShiftDecider" name="autoware_shift_decider">
+            <remap from="input/control_cmd" to="/control/trajectory_follower/control_cmd"/>
+            <remap from="input/state" to="/autoware/state"/>
+            <remap from="input/current_gear" to="/vehicle/status/gear_status"/>
+            <remap from="output/gear_cmd" to="/control/shift_decider/gear_cmd"/>
+            <param from="$(var shift_decider_param_path)"/>
+            <extra_arg name="use_intra_process_comms" value="$(var use_intra_process)"/>
+          </composable_node>
 
-        <!-- operation mode transition manager -->
-        <composable_node
-          pkg="autoware_operation_mode_transition_manager"
-          plugin="autoware::operation_mode_transition_manager::OperationModeTransitionManager"
-          name="autoware_operation_mode_transition_manager"
-        >
-          <!-- input -->
-          <remap from="kinematics" to="/localization/kinematic_state"/>
-          <remap from="steering" to="/vehicle/status/steering_status"/>
-          <remap from="trajectory" to="/planning/scenario_planning/trajectory"/>
-          <remap from="control_cmd" to="/control/command/control_cmd"/>
-          <remap from="trajectory_follower_control_cmd" to="/control/trajectory_follower/control_cmd"/>
-          <remap from="control_mode_report" to="/vehicle/status/control_mode"/>
-          <remap from="gate_operation_mode" to="/control/vehicle_cmd_gate/operation_mode"/>
-          <!-- output -->
-          <remap from="is_autonomous_available" to="/control/is_autonomous_available"/>
-          <remap from="control_mode_request" to="/control/control_mode_request"/>
-          <param from="$(var nearest_search_param_path)"/>
-          <param from="$(var operation_mode_transition_manager_param_path)"/>
-          <param from="$(var vehicle_param_file)"/>
-          <extra_arg name="use_intra_process_comms" value="$(var use_intra_process)"/>
-        </composable_node>
-        <composable_node pkg="glog_component" plugin="GlogComponent" name="glog_component"/>
-      </load_composable_node>
+          <!-- vehicle cmd gate -->
+          <composable_node pkg="autoware_vehicle_cmd_gate" plugin="autoware::vehicle_cmd_gate::VehicleCmdGate" name="vehicle_cmd_gate">
+            <remap from="input/steering" to="/vehicle/status/steering_status"/>
+            <remap from="input/operation_mode" to="/system/operation_mode/state"/>
+            <remap from="input/auto/control_cmd" to="/control/trajectory_follower/control_cmd"/>
+            <remap from="input/auto/turn_indicators_cmd" to="/planning/turn_indicators_cmd"/>
+            <remap from="input/auto/hazard_lights_cmd" to="/planning/hazard_lights_cmd"/>
+            <remap from="input/auto/gear_cmd" to="/control/shift_decider/gear_cmd"/>
+            <remap from="input/external/control_cmd" to="/external/selected/control_cmd"/>
+            <remap from="input/external/turn_indicators_cmd" to="/external/selected/turn_indicators_cmd"/>
+            <remap from="input/external/hazard_lights_cmd" to="/external/selected/hazard_lights_cmd"/>
+            <remap from="input/external/gear_cmd" to="/external/selected/gear_cmd"/>
+            <remap from="input/external_emergency_stop_heartbeat" to="/external/selected/heartbeat"/>
+            <remap from="input/gate_mode" to="/control/gate_mode_cmd"/>
+            <remap from="input/emergency/control_cmd" to="/system/emergency/control_cmd"/>
+            <remap from="input/emergency/hazard_lights_cmd" to="/system/emergency/hazard_lights_cmd"/>
+            <remap from="input/emergency/gear_cmd" to="/system/emergency/gear_cmd"/>
+            <remap from="input/mrm_state" to="/system/fail_safe/mrm_state"/>
+            <remap from="input/kinematics" to="/localization/kinematic_state"/>
+            <remap from="input/acceleration" to="/localization/acceleration"/>
+            <remap from="output/vehicle_cmd_emergency" to="/control/command/emergency_cmd"/>
+            <remap from="output/control_cmd" to="/control/command/control_cmd"/>
+            <remap from="output/gear_cmd" to="/control/command/gear_cmd"/>
+            <remap from="output/turn_indicators_cmd" to="/control/command/turn_indicators_cmd"/>
+            <remap from="output/hazard_lights_cmd" to="/control/command/hazard_lights_cmd"/>
+            <remap from="output/gate_mode" to="/control/current_gate_mode"/>
+            <remap from="output/engage" to="/api/autoware/get/engage"/>
+            <remap from="output/external_emergency" to="/api/autoware/get/emergency"/>
+            <remap from="output/operation_mode" to="/control/vehicle_cmd_gate/operation_mode"/>
+            <remap from="~/service/engage" to="/api/autoware/set/engage"/>
+            <remap from="~/service/external_emergency" to="/api/autoware/set/emergency"/>
+            <!-- TODO(Takagi, Isamu): deprecated -->
+            <remap from="input/engage" to="/autoware/engage"/>
+            <remap from="~/service/external_emergency_stop" to="~/external_emergency_stop"/>
+            <remap from="~/service/clear_external_emergency_stop" to="~/clear_external_emergency_stop"/>
+            <param from="$(var vehicle_cmd_gate_param_path)"/>
+            <param from="$(var vehicle_param_file)"/>
+            <param name="check_external_emergency_heartbeat" value="$(var check_external_emergency_heartbeat)"/>
+            <extra_arg name="use_intra_process_comms" value="$(var use_intra_process)"/>
+          </composable_node>
+
+          <!-- operation mode transition manager -->
+          <composable_node
+            pkg="autoware_operation_mode_transition_manager"
+            plugin="autoware::operation_mode_transition_manager::OperationModeTransitionManager"
+            name="autoware_operation_mode_transition_manager"
+          >
+            <!-- input -->
+            <remap from="kinematics" to="/localization/kinematic_state"/>
+            <remap from="steering" to="/vehicle/status/steering_status"/>
+            <remap from="trajectory" to="/planning/scenario_planning/trajectory"/>
+            <remap from="control_cmd" to="/control/command/control_cmd"/>
+            <remap from="trajectory_follower_control_cmd" to="/control/trajectory_follower/control_cmd"/>
+            <remap from="control_mode_report" to="/vehicle/status/control_mode"/>
+            <remap from="gate_operation_mode" to="/control/vehicle_cmd_gate/operation_mode"/>
+            <!-- output -->
+            <remap from="is_autonomous_available" to="/control/is_autonomous_available"/>
+            <remap from="control_mode_request" to="/control/control_mode_request"/>
+            <param from="$(var nearest_search_param_path)"/>
+            <param from="$(var operation_mode_transition_manager_param_path)"/>
+            <param from="$(var vehicle_param_file)"/>
+            <extra_arg name="use_intra_process_comms" value="$(var use_intra_process)"/>
+          </composable_node>
+
+          <composable_node pkg="glog_component" plugin="GlogComponent" name="glog_component"/>
+        </load_composable_node>
+      </group>
     </group>
 
     <!-- external cmd selector -->
@@ -188,69 +193,79 @@
     </group>
 
     <!-- obstacle collision checker -->
-    <load_composable_node target="/control/control_container" if="$(var enable_obstacle_collision_checker)">
-      <composable_node pkg="autoware_obstacle_collision_checker" plugin="autoware::obstacle_collision_checker::ObstacleCollisionCheckerNode" name="obstacle_collision_checker">
-        <remap from="input/lanelet_map_bin" to="/map/vector_map"/>
-        <remap from="input/obstacle_pointcloud" to="/perception/obstacle_segmentation/pointcloud"/>
-        <remap from="input/reference_trajectory" to="/planning/scenario_planning/trajectory"/>
-        <remap from="input/predicted_trajectory" to="/control/trajectory_follower/lateral/predicted_trajectory"/>
-        <remap from="input/odometry" to="/localization/kinematic_state"/>
-        <param from="$(var obstacle_collision_checker_param_path)"/>
-        <param from="$(var vehicle_param_file)"/>
-        <extra_arg name="use_intra_process_comms" value="$(var use_intra_process)"/>
-      </composable_node>
-    </load_composable_node>
+    <group if="$(var enable_obstacle_collision_checker)">
+      <load_composable_node target="/control/control_container">
+        <composable_node pkg="autoware_obstacle_collision_checker" plugin="autoware::obstacle_collision_checker::ObstacleCollisionCheckerNode" name="obstacle_collision_checker">
+          <remap from="input/lanelet_map_bin" to="/map/vector_map"/>
+          <remap from="input/obstacle_pointcloud" to="/perception/obstacle_segmentation/pointcloud"/>
+          <remap from="input/reference_trajectory" to="/planning/scenario_planning/trajectory"/>
+          <remap from="input/predicted_trajectory" to="/control/trajectory_follower/lateral/predicted_trajectory"/>
+          <remap from="input/odometry" to="/localization/kinematic_state"/>
+          <param from="$(var obstacle_collision_checker_param_path)"/>
+          <param from="$(var vehicle_param_file)"/>
+          <extra_arg name="use_intra_process_comms" value="$(var use_intra_process)"/>
+        </composable_node>
+      </load_composable_node>
+    </group>
 
     <!-- autonomous emergency braking -->
-    <load_composable_node target="/control/control_container" if="$(var enable_autonomous_emergency_braking)">
-      <composable_node pkg="autoware_autonomous_emergency_braking" plugin="autoware::motion::control::autonomous_emergency_braking::AEB" name="autonomous_emergency_braking">
-        <remap from="~/input/pointcloud" to="/perception/obstacle_segmentation/pointcloud"/>
-        <remap from="~/input/velocity" to="/vehicle/status/velocity_status"/>
-        <remap from="~/input/imu" to="/sensing/imu/imu_data"/>
-        <remap from="~/input/objects" to="/perception/object_recognition/objects"/>
-        <remap from="~/input/predicted_trajectory" to="/control/trajectory_follower/lateral/predicted_trajectory"/>
-        <param from="$(var aeb_param_path)"/>
-        <param name="check_autoware_state" value="$(var use_aeb_autoware_state_check)"/>
-        <extra_arg name="use_intra_process_comms" value="$(var use_intra_process)"/>
-      </composable_node>
-    </load_composable_node>
+    <group if="$(var enable_autonomous_emergency_braking)">
+      <load_composable_node target="/control/control_container" >
+        <composable_node pkg="autoware_autonomous_emergency_braking" plugin="autoware::motion::control::autonomous_emergency_braking::AEB" name="autonomous_emergency_braking">
+          <remap from="~/input/pointcloud" to="/perception/obstacle_segmentation/pointcloud"/>
+          <remap from="~/input/velocity" to="/vehicle/status/velocity_status"/>
+          <remap from="~/input/imu" to="/sensing/imu/imu_data"/>
+          <remap from="~/input/objects" to="/perception/object_recognition/objects"/>
+          <remap from="~/input/predicted_trajectory" to="/control/trajectory_follower/lateral/predicted_trajectory"/>
+          <param from="$(var aeb_param_path)"/>
+          <param name="check_autoware_state" value="$(var use_aeb_autoware_state_check)"/>
+          <extra_arg name="use_intra_process_comms" value="$(var use_intra_process)"/>
+        </composable_node>
+      </load_composable_node>
+    </group>
 
     <!-- predicted path checker -->
-    <load_composable_node target="/control/control_container" if="$(var enable_predicted_path_checker)">
-      <composable_node pkg="predicted_path_checker" plugin="autoware::motion::control::predicted_path_checker::PredictedPathCheckerNode" name="predicted_path_checker">
-        <remap from="~/input/objects" to="/perception/object_recognition/objects"/>
-        <remap from="~/input/reference_trajectory" to="/planning/scenario_planning/trajectory"/>
-        <remap from="~/input/current_accel" to="/localization/acceleration"/>
-        <remap from="~/input/odometry" to="/localization/kinematic_state"/>
-        <remap from="~/input/predicted_trajectory" to="/control/trajectory_follower/lateral/predicted_trajectory"/>
-        <param from="$(var vehicle_param_file)"/>
-        <param from="$(var predicted_path_checker_param_path)"/>
-        <extra_arg name="use_intra_process_comms" value="$(var use_intra_process)"/>
-      </composable_node>
-    </load_composable_node>
+    <group if="$(var enable_predicted_path_checker)">
+      <load_composable_node target="/control/control_container">
+        <composable_node pkg="predicted_path_checker" plugin="autoware::motion::control::predicted_path_checker::PredictedPathCheckerNode" name="predicted_path_checker">
+          <remap from="~/input/objects" to="/perception/object_recognition/objects"/>
+          <remap from="~/input/reference_trajectory" to="/planning/scenario_planning/trajectory"/>
+          <remap from="~/input/current_accel" to="/localization/acceleration"/>
+          <remap from="~/input/odometry" to="/localization/kinematic_state"/>
+          <remap from="~/input/predicted_trajectory" to="/control/trajectory_follower/lateral/predicted_trajectory"/>
+          <param from="$(var vehicle_param_file)"/>
+          <param from="$(var predicted_path_checker_param_path)"/>
+          <extra_arg name="use_intra_process_comms" value="$(var use_intra_process)"/>
+        </composable_node>
+      </load_composable_node>
+    </group>
 
     <!-- control evaluator -->
-    <load_composable_node target="/control/control_container" if="$(var launch_control_evaluator)">
-      <composable_node pkg="autoware_control_evaluator" plugin="control_diagnostics::ControlEvaluatorNode" name="control_evaluator">
-        <remap from="~/input/diagnostics" to="/diagnostics"/>
-        <remap from="~/input/odometry" to="/localization/kinematic_state"/>
-        <remap from="~/input/acceleration" to="/localization/acceleration"/>
-        <remap from="~/input/trajectory" to="/planning/scenario_planning/trajectory"/>
-        <remap from="~/metrics" to="/control/control_evaluator/metrics"/>
-        <remap from="~/input/vector_map" to="/map/vector_map"/>
-        <remap from="~/input/route" to="/planning/mission_planning/route"/>
-      </composable_node>
-    </load_composable_node>
+    <group if="$(var launch_control_evaluator)">
+      <load_composable_node target="/control/control_container">
+        <composable_node pkg="autoware_control_evaluator" plugin="control_diagnostics::ControlEvaluatorNode" name="control_evaluator">
+          <remap from="~/input/diagnostics" to="/diagnostics"/>
+          <remap from="~/input/odometry" to="/localization/kinematic_state"/>
+          <remap from="~/input/acceleration" to="/localization/acceleration"/>
+          <remap from="~/input/trajectory" to="/planning/scenario_planning/trajectory"/>
+          <remap from="~/metrics" to="/control/control_evaluator/metrics"/>
+          <remap from="~/input/vector_map" to="/map/vector_map"/>
+          <remap from="~/input/route" to="/planning/mission_planning/route"/>
+        </composable_node>
+      </load_composable_node>
+    </group>
 
     <!-- collision detector-->
-    <load_composable_node target="/control/control_container" if="$(var enable_collision_detector)">
-      <composable_node pkg="autoware_collision_detector" plugin="autoware::collision_detector::CollisionDetectorNode" name="collision_detector">
-        <remap from="~/input/odometry" to="/localization/kinematic_state"/>
-        <remap from="~/input/pointcloud" to="/perception/obstacle_segmentation/pointcloud"/>
-        <remap from="~/input/objects" to="/perception/object_recognition/objects"/>
-        <param from="$(var collision_detector_param_path)"/>
-      </composable_node>
-    </load_composable_node>
+    <group if="$(var enable_collision_detector)">
+      <load_composable_node target="/control/control_container">
+        <composable_node pkg="autoware_collision_detector" plugin="autoware::collision_detector::CollisionDetectorNode" name="collision_detector">
+          <remap from="~/input/odometry" to="/localization/kinematic_state"/>
+          <remap from="~/input/pointcloud" to="/perception/obstacle_segmentation/pointcloud"/>
+          <remap from="~/input/objects" to="/perception/object_recognition/objects"/>
+          <param from="$(var collision_detector_param_path)"/>
+        </composable_node>
+      </load_composable_node>
+    </group>
   </group>
 
   <group if="$(var launch_control_validator)">

--- a/launch/tier4_control_launch/launch/control.launch.xml
+++ b/launch/tier4_control_launch/launch/control.launch.xml
@@ -1,14 +1,23 @@
 <launch>
   <!-- option -->
-  <arg name="enable_obstacle_collision_checker"/>
+  <arg name="launch_obstacle_collision_checker" value="false"/>
+  <arg name="launch_autonomous_emergency_braking" default="true"/>
+  <arg name="launch_predicted_path_checker" default="false"/>
+  <arg name="launch_collision_detector" default="false"/>
+  <arg name="trajectory_follower_mode" default="trajectory_follower_node"/>
   <arg name="lateral_controller_mode"/>
   <arg name="longitudinal_controller_mode"/>
   <arg name="enable_autonomous_emergency_braking"/>
   <arg name="use_aeb_autoware_state_check"/>
   <arg name="check_external_emergency_heartbeat"/>
-  <arg name="trajectory_follower_mode" default="trajectory_follower_node"/>
-  <arg name="enable_collision_detector"/>
 
+  <!-- option available for test/debug only -->
+  <arg name="launch_trajectory_follower_components" default="true"/>
+  <arg name="launch_external_cmd_selector" default="true"/>
+  <arg name="launch_external_cmd_converter" default="true"/>
+  <arg name="launch_control_evaluator" default="true"/>
+  <arg name="launch_control_validator" default="true"/>
+  
   <!-- common param path -->
   <arg name="vehicle_param_file"/>
   <arg name="nearest_search_param_path"/>
@@ -66,7 +75,7 @@
         </composable_node>
       </load_composable_node>
 
-      <load_composable_node target="/control/control_container">
+      <load_composable_node target="/control/control_container" if="$(var launch_trajectory_follower_components)">
         <!-- lane departure checker -->
         <composable_node pkg="autoware_lane_departure_checker" plugin="autoware::lane_departure_checker::LaneDepartureCheckerNode" name="lane_departure_checker_node" namespace="trajectory_follower">
           <remap from="~/input/odometry" to="/localization/kinematic_state"/>
@@ -159,7 +168,7 @@
     </group>
 
     <!-- external cmd selector -->
-    <group>
+    <group if="$(var launch_external_cmd_selector)">
       <include file="$(find-pkg-share autoware_external_cmd_selector)/launch/external_cmd_selector.launch.py">
         <arg name="use_intra_process" value="$(var use_intra_process)"/>
         <arg name="target_container" value="/control/control_container"/>
@@ -168,7 +177,7 @@
     </group>
 
     <!-- external cmd converter -->
-    <group>
+    <group if="$(var launch_external_cmd_converter)">
       <include file="$(find-pkg-share autoware_external_cmd_converter)/launch/external_cmd_converter.launch.py">
         <arg name="use_intra_process" value="$(var use_intra_process)"/>
         <arg name="target_container" value="/control/control_container"/>
@@ -176,7 +185,7 @@
     </group>
 
     <!-- obstacle collision checker -->
-    <load_composable_node target="/control/control_container" if="$(var enable_obstacle_collision_checker)">
+    <load_composable_node target="/control/control_container" if="$(var launch_obstacle_collision_checker)">
       <composable_node pkg="autoware_obstacle_collision_checker" plugin="autoware::obstacle_collision_checker::ObstacleCollisionCheckerNode" name="obstacle_collision_checker">
         <remap from="input/lanelet_map_bin" to="/map/vector_map"/>
         <remap from="input/obstacle_pointcloud" to="/perception/obstacle_segmentation/pointcloud"/>
@@ -190,7 +199,7 @@
     </load_composable_node>
 
     <!-- autonomous emergency braking -->
-    <load_composable_node target="/control/control_container" if="$(var enable_autonomous_emergency_braking)">
+    <load_composable_node target="/control/control_container" if="$(var launch_autonomous_emergency_braking)">
       <composable_node pkg="autoware_autonomous_emergency_braking" plugin="autoware::motion::control::autonomous_emergency_braking::AEB" name="autonomous_emergency_braking">
         <remap from="~/input/pointcloud" to="/perception/obstacle_segmentation/pointcloud"/>
         <remap from="~/input/velocity" to="/vehicle/status/velocity_status"/>
@@ -204,7 +213,7 @@
     </load_composable_node>
 
     <!-- predicted path checker -->
-    <load_composable_node target="/control/control_container" if="$(var enable_predicted_path_checker)">
+    <load_composable_node target="/control/control_container" if="$(var launch_predicted_path_checker)">
       <composable_node pkg="predicted_path_checker" plugin="autoware::motion::control::predicted_path_checker::PredictedPathCheckerNode" name="predicted_path_checker">
         <remap from="~/input/objects" to="/perception/object_recognition/objects"/>
         <remap from="~/input/reference_trajectory" to="/planning/scenario_planning/trajectory"/>
@@ -218,7 +227,7 @@
     </load_composable_node>
 
     <!-- control evaluator -->
-    <load_composable_node target="/control/control_container">
+    <load_composable_node target="/control/control_container" if="$(var launch_control_evaluator)">
       <composable_node pkg="autoware_control_evaluator" plugin="control_diagnostics::ControlEvaluatorNode" name="control_evaluator">
         <remap from="~/input/diagnostics" to="/diagnostics"/>
         <remap from="~/input/odometry" to="/localization/kinematic_state"/>
@@ -231,7 +240,7 @@
     </load_composable_node>
 
     <!-- collision detector-->
-    <load_composable_node target="/control/control_container" if="$(var enable_collision_detector)">
+    <load_composable_node target="/control/control_container" if="$(var launch_collision_detector)">
       <composable_node pkg="autoware_collision_detector" plugin="autoware::collision_detector::CollisionDetectorNode" name="collision_detector">
         <remap from="~/input/odometry" to="/localization/kinematic_state"/>
         <remap from="~/input/pointcloud" to="/perception/obstacle_segmentation/pointcloud"/>
@@ -241,7 +250,7 @@
     </load_composable_node>
   </group>
 
-  <group>
+  <group if="$(var launch_control_validator)">
     <push-ros-namespace namespace="control"/>
 
     <!-- control validator checker -->

--- a/launch/tier4_control_launch/launch/control.launch.xml
+++ b/launch/tier4_control_launch/launch/control.launch.xml
@@ -1,15 +1,11 @@
 <launch>
-
+  <!-- controler -->
   <arg name="trajectory_follower_mode" default="trajectory_follower_node"/>
   <arg name="lateral_controller_mode"/>
   <arg name="longitudinal_controller_mode"/>
   <arg name="check_external_emergency_heartbeat"/>
-  <arg name="use_aeb_autoware_state_check"/>
 
-  <!-- control-related modules, turn off only when debugging/testing. -->
-  <arg name="launch_shift_decider" default="true"/>
-  <arg name="launch_vehicle_cmd_gate" default="true"/>
-  <arg name="launch_operation_mode_transition_manager" default="true"/>
+  <!-- external cmd selector and converter -->
   <arg name="launch_external_cmd_selector" default="true"/>
   <arg name="launch_external_cmd_converter" default="true"/>
 
@@ -21,6 +17,7 @@
   <arg name="launch_obstacle_collision_checker" default="false"/>
   <arg name="launch_predicted_path_checker" default="false"/>
   <arg name="launch_control_evaluator" default="true"/>
+  <arg name="use_aeb_autoware_state_check"/>
 
   <!-- common param path -->
   <arg name="vehicle_param_file"/>
@@ -55,6 +52,77 @@
       <!-- set a control container to run all required components in the same process -->
       <node_container pkg="rclcpp_components" exec="$(var container_executable)" name="control_container" namespace="">
         <composable_node pkg="glog_component" plugin="GlogComponent" name="glog_control_container_component"/>
+        <!-- shift decider -->
+        <composable_node pkg="autoware_shift_decider" plugin="autoware::shift_decider::ShiftDecider" name="autoware_shift_decider">
+          <remap from="input/control_cmd" to="/control/trajectory_follower/control_cmd"/>
+          <remap from="input/state" to="/autoware/state"/>
+          <remap from="input/current_gear" to="/vehicle/status/gear_status"/>
+          <remap from="output/gear_cmd" to="/control/shift_decider/gear_cmd"/>
+          <param from="$(var shift_decider_param_path)"/>
+          <extra_arg name="use_intra_process_comms" value="$(var use_intra_process)"/>
+        </composable_node>
+        <!-- vehicle cmd gate -->
+        <composable_node pkg="autoware_vehicle_cmd_gate" plugin="autoware::vehicle_cmd_gate::VehicleCmdGate" name="vehicle_cmd_gate">
+          <remap from="input/steering" to="/vehicle/status/steering_status"/>
+          <remap from="input/operation_mode" to="/system/operation_mode/state"/>
+          <remap from="input/auto/control_cmd" to="/control/trajectory_follower/control_cmd"/>
+          <remap from="input/auto/turn_indicators_cmd" to="/planning/turn_indicators_cmd"/>
+          <remap from="input/auto/hazard_lights_cmd" to="/planning/hazard_lights_cmd"/>
+          <remap from="input/auto/gear_cmd" to="/control/shift_decider/gear_cmd"/>
+          <remap from="input/external/control_cmd" to="/external/selected/control_cmd"/>
+          <remap from="input/external/turn_indicators_cmd" to="/external/selected/turn_indicators_cmd"/>
+          <remap from="input/external/hazard_lights_cmd" to="/external/selected/hazard_lights_cmd"/>
+          <remap from="input/external/gear_cmd" to="/external/selected/gear_cmd"/>
+          <remap from="input/external_emergency_stop_heartbeat" to="/external/selected/heartbeat"/>
+          <remap from="input/gate_mode" to="/control/gate_mode_cmd"/>
+          <remap from="input/emergency/control_cmd" to="/system/emergency/control_cmd"/>
+          <remap from="input/emergency/hazard_lights_cmd" to="/system/emergency/hazard_lights_cmd"/>
+          <remap from="input/emergency/gear_cmd" to="/system/emergency/gear_cmd"/>
+          <remap from="input/mrm_state" to="/system/fail_safe/mrm_state"/>
+          <remap from="input/kinematics" to="/localization/kinematic_state"/>
+          <remap from="input/acceleration" to="/localization/acceleration"/>
+          <remap from="output/vehicle_cmd_emergency" to="/control/command/emergency_cmd"/>
+          <remap from="output/control_cmd" to="/control/command/control_cmd"/>
+          <remap from="output/gear_cmd" to="/control/command/gear_cmd"/>
+          <remap from="output/turn_indicators_cmd" to="/control/command/turn_indicators_cmd"/>
+          <remap from="output/hazard_lights_cmd" to="/control/command/hazard_lights_cmd"/>
+          <remap from="output/gate_mode" to="/control/current_gate_mode"/>
+          <remap from="output/engage" to="/api/autoware/get/engage"/>
+          <remap from="output/external_emergency" to="/api/autoware/get/emergency"/>
+          <remap from="output/operation_mode" to="/control/vehicle_cmd_gate/operation_mode"/>
+          <remap from="~/service/engage" to="/api/autoware/set/engage"/>
+          <remap from="~/service/external_emergency" to="/api/autoware/set/emergency"/>
+          <!-- TODO(Takagi, Isamu): deprecated -->
+          <remap from="input/engage" to="/autoware/engage"/>
+          <remap from="~/service/external_emergency_stop" to="~/external_emergency_stop"/>
+          <remap from="~/service/clear_external_emergency_stop" to="~/clear_external_emergency_stop"/>
+          <param from="$(var vehicle_cmd_gate_param_path)"/>
+          <param from="$(var vehicle_param_file)"/>
+          <param name="check_external_emergency_heartbeat" value="$(var check_external_emergency_heartbeat)"/>
+          <extra_arg name="use_intra_process_comms" value="$(var use_intra_process)"/>
+        </composable_node>
+        <!-- operation mode transition manager -->
+        <composable_node
+          pkg="autoware_operation_mode_transition_manager"
+          plugin="autoware::operation_mode_transition_manager::OperationModeTransitionManager"
+          name="autoware_operation_mode_transition_manager"
+        >
+          <!-- input -->
+          <remap from="kinematics" to="/localization/kinematic_state"/>
+          <remap from="steering" to="/vehicle/status/steering_status"/>
+          <remap from="trajectory" to="/planning/scenario_planning/trajectory"/>
+          <remap from="control_cmd" to="/control/command/control_cmd"/>
+          <remap from="trajectory_follower_control_cmd" to="/control/trajectory_follower/control_cmd"/>
+          <remap from="control_mode_report" to="/vehicle/status/control_mode"/>
+          <remap from="gate_operation_mode" to="/control/vehicle_cmd_gate/operation_mode"/>
+          <!-- output -->
+          <remap from="is_autonomous_available" to="/control/is_autonomous_available"/>
+          <remap from="control_mode_request" to="/control/control_mode_request"/>
+          <param from="$(var nearest_search_param_path)"/>
+          <param from="$(var operation_mode_transition_manager_param_path)"/>
+          <param from="$(var vehicle_param_file)"/>
+          <extra_arg name="use_intra_process_comms" value="$(var use_intra_process)"/>
+        </composable_node>
       </node_container>
 
       <!-- trajectory_follower_node -->
@@ -89,92 +157,6 @@
         <node pkg="autoware_smart_mpc_trajectory_follower" exec="pympc_trajectory_follower.py" name="controller_node_exe"/>
       </group>
 
-      <!-- shift decider -->
-      <group if="$(var launch_shift_decider)">
-        <load_composable_node target="/control/control_container">
-          <composable_node pkg="autoware_shift_decider" plugin="autoware::shift_decider::ShiftDecider" name="autoware_shift_decider">
-            <remap from="input/control_cmd" to="/control/trajectory_follower/control_cmd"/>
-            <remap from="input/state" to="/autoware/state"/>
-            <remap from="input/current_gear" to="/vehicle/status/gear_status"/>
-            <remap from="output/gear_cmd" to="/control/shift_decider/gear_cmd"/>
-            <param from="$(var shift_decider_param_path)"/>
-            <extra_arg name="use_intra_process_comms" value="$(var use_intra_process)"/>
-          </composable_node>
-        </load_composable_node>
-      </group>
-
-      <!-- vehicle cmd gate -->
-      <group if="$(var launch_vehicle_cmd_gate)">
-        <load_composable_node target="/control/control_container">
-          <composable_node pkg="autoware_vehicle_cmd_gate" plugin="autoware::vehicle_cmd_gate::VehicleCmdGate" name="vehicle_cmd_gate">
-            <remap from="input/steering" to="/vehicle/status/steering_status"/>
-            <remap from="input/operation_mode" to="/system/operation_mode/state"/>
-            <remap from="input/auto/control_cmd" to="/control/trajectory_follower/control_cmd"/>
-            <remap from="input/auto/turn_indicators_cmd" to="/planning/turn_indicators_cmd"/>
-            <remap from="input/auto/hazard_lights_cmd" to="/planning/hazard_lights_cmd"/>
-            <remap from="input/auto/gear_cmd" to="/control/shift_decider/gear_cmd"/>
-            <remap from="input/external/control_cmd" to="/external/selected/control_cmd"/>
-            <remap from="input/external/turn_indicators_cmd" to="/external/selected/turn_indicators_cmd"/>
-            <remap from="input/external/hazard_lights_cmd" to="/external/selected/hazard_lights_cmd"/>
-            <remap from="input/external/gear_cmd" to="/external/selected/gear_cmd"/>
-            <remap from="input/external_emergency_stop_heartbeat" to="/external/selected/heartbeat"/>
-            <remap from="input/gate_mode" to="/control/gate_mode_cmd"/>
-            <remap from="input/emergency/control_cmd" to="/system/emergency/control_cmd"/>
-            <remap from="input/emergency/hazard_lights_cmd" to="/system/emergency/hazard_lights_cmd"/>
-            <remap from="input/emergency/gear_cmd" to="/system/emergency/gear_cmd"/>
-            <remap from="input/mrm_state" to="/system/fail_safe/mrm_state"/>
-            <remap from="input/kinematics" to="/localization/kinematic_state"/>
-            <remap from="input/acceleration" to="/localization/acceleration"/>
-            <remap from="output/vehicle_cmd_emergency" to="/control/command/emergency_cmd"/>
-            <remap from="output/control_cmd" to="/control/command/control_cmd"/>
-            <remap from="output/gear_cmd" to="/control/command/gear_cmd"/>
-            <remap from="output/turn_indicators_cmd" to="/control/command/turn_indicators_cmd"/>
-            <remap from="output/hazard_lights_cmd" to="/control/command/hazard_lights_cmd"/>
-            <remap from="output/gate_mode" to="/control/current_gate_mode"/>
-            <remap from="output/engage" to="/api/autoware/get/engage"/>
-            <remap from="output/external_emergency" to="/api/autoware/get/emergency"/>
-            <remap from="output/operation_mode" to="/control/vehicle_cmd_gate/operation_mode"/>
-            <remap from="~/service/engage" to="/api/autoware/set/engage"/>
-            <remap from="~/service/external_emergency" to="/api/autoware/set/emergency"/>
-            <!-- TODO(Takagi, Isamu): deprecated -->
-            <remap from="input/engage" to="/autoware/engage"/>
-            <remap from="~/service/external_emergency_stop" to="~/external_emergency_stop"/>
-            <remap from="~/service/clear_external_emergency_stop" to="~/clear_external_emergency_stop"/>
-            <param from="$(var vehicle_cmd_gate_param_path)"/>
-            <param from="$(var vehicle_param_file)"/>
-            <param name="check_external_emergency_heartbeat" value="$(var check_external_emergency_heartbeat)"/>
-            <extra_arg name="use_intra_process_comms" value="$(var use_intra_process)"/>
-          </composable_node>
-        </load_composable_node>
-      </group>
-
-      <!-- operation mode transition manager -->
-      <group if="$(var launch_operation_mode_transition_manager)">
-        <load_composable_node target="/control/control_container">
-          <composable_node
-            pkg="autoware_operation_mode_transition_manager"
-            plugin="autoware::operation_mode_transition_manager::OperationModeTransitionManager"
-            name="autoware_operation_mode_transition_manager"
-          >
-            <!-- input -->
-            <remap from="kinematics" to="/localization/kinematic_state"/>
-            <remap from="steering" to="/vehicle/status/steering_status"/>
-            <remap from="trajectory" to="/planning/scenario_planning/trajectory"/>
-            <remap from="control_cmd" to="/control/command/control_cmd"/>
-            <remap from="trajectory_follower_control_cmd" to="/control/trajectory_follower/control_cmd"/>
-            <remap from="control_mode_report" to="/vehicle/status/control_mode"/>
-            <remap from="gate_operation_mode" to="/control/vehicle_cmd_gate/operation_mode"/>
-            <!-- output -->
-            <remap from="is_autonomous_available" to="/control/is_autonomous_available"/>
-            <remap from="control_mode_request" to="/control/control_mode_request"/>
-            <param from="$(var nearest_search_param_path)"/>
-            <param from="$(var operation_mode_transition_manager_param_path)"/>
-            <param from="$(var vehicle_param_file)"/>
-            <extra_arg name="use_intra_process_comms" value="$(var use_intra_process)"/>
-          </composable_node>
-        </load_composable_node>
-      </group>
-
       <!-- external cmd selector -->
       <group if="$(var launch_external_cmd_selector)">
         <include file="$(find-pkg-share autoware_external_cmd_selector)/launch/external_cmd_selector.launch.py">
@@ -183,7 +165,6 @@
           <arg name="external_cmd_selector_param_path" value="$(var external_cmd_selector_param_path)"/>
         </include>
       </group>
-
       <!-- external cmd converter -->
       <group if="$(var launch_external_cmd_converter)">
         <include file="$(find-pkg-share autoware_external_cmd_converter)/launch/external_cmd_converter.launch.py">


### PR DESCRIPTION
## Description
Use preset.yaml to control which modules to launch for control modules just as how planning modules are launched.
 
## Related links

autoware_launch PR: https://github.com/autowarefoundation/autoware_launch/pull/1237


## How was this PR tested?
Psim, [Evaluator](https://evaluation.tier4.jp/evaluation/reports/67e201f0-a840-52de-b3d0-e6d64f9d14f8?project_id=prd_jt).

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
