### PR TITLE
feat(mrm_comfortable_stop_operator): add updateParam for mrm comfortable stop

### DIFF
--- a/system/mrm_comfortable_stop_operator/include/mrm_comfortable_stop_operator/mrm_comfortable_stop_operator_core.hpp
+++ b/system/mrm_comfortable_stop_operator/include/mrm_comfortable_stop_operator/mrm_comfortable_stop_operator_core.hpp
@@ -17,6 +17,7 @@
 
 // Core
 #include <memory>
+#include <vector>
 
 // Autoware
 #include <tier4_planning_msgs/msg/velocity_limit.hpp>
@@ -55,6 +56,9 @@ private:
     const tier4_system_msgs::srv::OperateMrm::Request::SharedPtr request,
     const tier4_system_msgs::srv::OperateMrm::Response::SharedPtr response);
 
+  rcl_interfaces::msg::SetParametersResult onParameter(
+    const std::vector<rclcpp::Parameter> & parameters);
+
   // Publisher
   rclcpp::Publisher<tier4_system_msgs::msg::MrmBehaviorStatus>::SharedPtr pub_status_;
   rclcpp::Publisher<tier4_planning_msgs::msg::VelocityLimit>::SharedPtr pub_velocity_limit_;
@@ -72,6 +76,9 @@ private:
 
   // States
   tier4_system_msgs::msg::MrmBehaviorStatus status_;
+
+  // Parameter callback
+  OnSetParametersCallbackHandle::SharedPtr set_param_res_;
 };
 
 }  // namespace mrm_comfortable_stop_operator

--- a/system/mrm_comfortable_stop_operator/package.xml
+++ b/system/mrm_comfortable_stop_operator/package.xml
@@ -12,6 +12,7 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_adapi_v1_msgs</depend>
+  <depend>autoware_universe_utils</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>std_msgs</depend>

--- a/system/mrm_comfortable_stop_operator/src/mrm_comfortable_stop_operator/mrm_comfortable_stop_operator_core.cpp
+++ b/system/mrm_comfortable_stop_operator/src/mrm_comfortable_stop_operator/mrm_comfortable_stop_operator_core.cpp
@@ -14,6 +14,8 @@
 
 #include "mrm_comfortable_stop_operator/mrm_comfortable_stop_operator_core.hpp"
 
+#include <autoware/universe_utils/ros/update_param.hpp>
+
 namespace mrm_comfortable_stop_operator
 {
 
@@ -48,6 +50,10 @@ MrmComfortableStopOperator::MrmComfortableStopOperator(const rclcpp::NodeOptions
 
   // Initialize
   status_.state = tier4_system_msgs::msg::MrmBehaviorStatus::AVAILABLE;
+
+  // Parameter Callback
+  set_param_res_ = add_on_set_parameters_callback(
+    std::bind(&MrmComfortableStopOperator::onParameter, this, std::placeholders::_1));
 }
 
 void MrmComfortableStopOperator::operateComfortableStop(
@@ -63,6 +69,21 @@ void MrmComfortableStopOperator::operateComfortableStop(
     status_.state = tier4_system_msgs::msg::MrmBehaviorStatus::AVAILABLE;
     response->response.success = true;
   }
+}
+
+rcl_interfaces::msg::SetParametersResult MrmComfortableStopOperator::onParameter(
+  const std::vector<rclcpp::Parameter> & parameters)
+{
+  using autoware::universe_utils::updateParam;
+  updateParam<double>(parameters, "min_acceleration", params_.min_acceleration);
+  params_.min_acceleration = std::abs(params_.min_acceleration);
+  updateParam<double>(parameters, "max_jerk", params_.max_jerk);
+  updateParam<double>(parameters, "min_jerk", params_.min_jerk);
+
+  rcl_interfaces::msg::SetParametersResult result;
+  result.successful = true;
+  result.reason = "success";
+  return result;
 }
 
 void MrmComfortableStopOperator::publishStatus() const

--- a/system/mrm_comfortable_stop_operator/src/mrm_comfortable_stop_operator/mrm_comfortable_stop_operator_core.cpp
+++ b/system/mrm_comfortable_stop_operator/src/mrm_comfortable_stop_operator/mrm_comfortable_stop_operator_core.cpp
@@ -76,7 +76,6 @@ rcl_interfaces::msg::SetParametersResult MrmComfortableStopOperator::onParameter
 {
   using autoware::universe_utils::updateParam;
   updateParam<double>(parameters, "min_acceleration", params_.min_acceleration);
-  params_.min_acceleration = std::abs(params_.min_acceleration);
   updateParam<double>(parameters, "max_jerk", params_.max_jerk);
   updateParam<double>(parameters, "min_jerk", params_.min_jerk);
 


### PR DESCRIPTION
## Description
Add updateParam to facilitate comfortable stop param tuning and avoid relaunching autoware to test new params 

Note: I did not add the option to change the Hz of the module since I believe that might cause some troubles and it is best to not change it while Autoware is running



## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
PSim


https://github.com/user-attachments/assets/5f8f4841-b9c2-462e-8ef6-7190ab0fea22


## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
