### PR TITLE
feat(obstacle_cruise_planner): outputs velocity factor when the ego follows front vehicle.

### DIFF
--- a/planning/autoware_obstacle_cruise_planner/include/autoware/obstacle_cruise_planner/utils.hpp
+++ b/planning/autoware_obstacle_cruise_planner/include/autoware/obstacle_cruise_planner/utils.hpp
@@ -93,6 +93,10 @@ size_t getIndexWithLongitudinalOffset(
   }
   return 0;
 }
+
+VelocityFactorArray makeVelocityFactorArray(
+  const rclcpp::Time & time, const std::string behavior = PlanningBehavior::ROUTE_OBSTACLE,
+  const std::optional<geometry_msgs::msg::Pose> pose = std::nullopt);
 }  // namespace obstacle_cruise_utils
 
 #endif  // AUTOWARE__OBSTACLE_CRUISE_PLANNER__UTILS_HPP_

--- a/planning/autoware_obstacle_cruise_planner/include/autoware/obstacle_cruise_planner/utils.hpp
+++ b/planning/autoware_obstacle_cruise_planner/include/autoware/obstacle_cruise_planner/utils.hpp
@@ -95,7 +95,7 @@ size_t getIndexWithLongitudinalOffset(
 }
 
 VelocityFactorArray makeVelocityFactorArray(
-  const rclcpp::Time & time, const std::string behavior = PlanningBehavior::ROUTE_OBSTACLE,
+  const rclcpp::Time & time, const std::string & behavior = PlanningBehavior::ROUTE_OBSTACLE,
   const std::optional<geometry_msgs::msg::Pose> pose = std::nullopt);
 }  // namespace obstacle_cruise_utils
 

--- a/planning/autoware_obstacle_cruise_planner/src/pid_based_planner/pid_based_planner.cpp
+++ b/planning/autoware_obstacle_cruise_planner/src/pid_based_planner/pid_based_planner.cpp
@@ -326,6 +326,10 @@ std::vector<TrajectoryPoint> PIDBasedPlanner::planCruise(
       // cruise obstacle
       debug_data_ptr_->obstacles_to_cruise.push_back(cruise_obstacle_info->obstacle);
       debug_data_ptr_->cruise_metrics = makeMetrics("PIDBasedPlanner", "cruise", planner_data);
+
+      velocity_factors_pub_->publish(obstacle_cruise_utils::makeVelocityFactorArray(
+        planner_data.current_time, PlanningBehavior::ADAPTIVE_CRUISE,
+        stop_traj_points.at(wall_idx).pose));
     }
 
     // do cruise planning

--- a/planning/autoware_obstacle_cruise_planner/src/utils.cpp
+++ b/planning/autoware_obstacle_cruise_planner/src/utils.cpp
@@ -115,7 +115,7 @@ std::vector<StopObstacle> getClosestStopObstacles(const std::vector<StopObstacle
 }
 
 VelocityFactorArray makeVelocityFactorArray(
-  const rclcpp::Time & time, const std::string behavior,
+  const rclcpp::Time & time, const std::string & behavior,
   const std::optional<geometry_msgs::msg::Pose> pose)
 {
   VelocityFactorArray velocity_factor_array;

--- a/planning/autoware_obstacle_cruise_planner/src/utils.cpp
+++ b/planning/autoware_obstacle_cruise_planner/src/utils.cpp
@@ -113,4 +113,26 @@ std::vector<StopObstacle> getClosestStopObstacles(const std::vector<StopObstacle
   }
   return candidates;
 }
+
+VelocityFactorArray makeVelocityFactorArray(
+  const rclcpp::Time & time, const std::string behavior,
+  const std::optional<geometry_msgs::msg::Pose> pose)
+{
+  VelocityFactorArray velocity_factor_array;
+  velocity_factor_array.header.frame_id = "map";
+  velocity_factor_array.header.stamp = time;
+
+  if (pose) {
+    using distance_type = VelocityFactor::_distance_type;
+    VelocityFactor velocity_factor;
+    velocity_factor.behavior = behavior;
+    velocity_factor.pose = pose.value();
+    velocity_factor.distance = std::numeric_limits<distance_type>::quiet_NaN();
+    velocity_factor.status = VelocityFactor::UNKNOWN;
+    velocity_factor.detail = std::string();
+    velocity_factor_array.factors.push_back(velocity_factor);
+  }
+  return velocity_factor_array;
+}
+
 }  // namespace obstacle_cruise_utils


### PR DESCRIPTION
## Description

I fixed logic so that this planner outputs velocity factor during adaptive cruising.

:warning: Please merge following PR at first. (NOTE: I added new planning behavior in order to distinguish adaptive cruise behavior from obstacle stop.)
- https://github.com/autowarefoundation/autoware_adapi_msgs/pull/67

https://github.com/user-attachments/assets/0b81193e-73b5-4c3e-ad13-25b2341cd416

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
