### PR TITLE
fix(behavior_path_planner_common): prevent duplicated point insertion in cutOverlappedLanes

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/drivable_area_expansion/static_drivable_area.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/drivable_area_expansion/static_drivable_area.cpp
@@ -729,10 +729,13 @@ std::vector<DrivableLanes> cutOverlappedLanes(
   }
 
   // Step2. pick up only path points within drivable lanes
+  std::set<size_t> path_point_indices;
   for (const auto & drivable_lanes : shorten_lanes) {
     for (size_t i = start_point_idx; i < original_points.size(); ++i) {
-      if (is_point_in_drivable_lanes(drivable_lanes, original_points.at(i))) {
-        path.points.push_back(original_points.at(i));
+      const auto & p = original_points.at(i);
+      if (is_point_in_drivable_lanes(drivable_lanes, p) && path_point_indices.count(i) == 0) {
+        path.points.push_back(p);
+        path_point_indices.insert(i);
         continue;
       }
       start_point_idx = i;


### PR DESCRIPTION
## Description



In this PR, we check if the same point has already been inserted.
This fixed path distortion caused by duplicated points.

before

![image](https://github.com/user-attachments/assets/d306de38-eb17-42f3-8276-324180297d28)



after

![image](https://github.com/user-attachments/assets/78dfcffe-1bbb-4f54-992e-ceea01184eaa)


## Related links
t4 internal ticket : https://tier4.atlassian.net/browse/RT1-4810

## How was this PR tested?


psim

2024/11/18 https://evaluation.tier4.jp/evaluation/reports/b3906a49-741b-5fc5-a388-13fcd3419152/?project_id=prd_jt


## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
