### PR TITLE
perf(static_obstacle_avoidance): use lanelet::utils instead of route handle for closest lanelet

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/scene.cpp
@@ -212,7 +212,8 @@ void StaticObstacleAvoidanceModule::fillFundamentalData(
     data.current_lanelets, getEgoPose(), planner_data_);
 
   lanelet::ConstLanelet closest_lanelet{};
-  if (planner_data_->route_handler->getClosestLaneletWithinRoute(getEgoPose(), &closest_lanelet))
+  if (lanelet::utils::query::getClosestLanelet(
+        data.current_lanelets, getEgoPose(), &closest_lanelet))
     data.closest_lanelet = closest_lanelet;
 
   // expand drivable lanes


### PR DESCRIPTION
## Description
Currently `route_handler->getClosestLaneletWithinRoute` was used to calculate the closest lanelet. To decrease the processing time, the functions to obtain the closest lanelet is changed to `lanelet::utils::query::getClosestLanelet`.

## Related links
https://github.com/autowarefoundation/autoware.universe/pull/9355

## How was this PR tested?
- [x] [TIER IV internal evalutor](https://evaluation.tier4.jp/evaluation/reports/63d5350d-ec58-50b8-a300-b73c8c55f9b1?project_id=prd_jt)

## Notes for reviewers
None.

## Interface changes
None.

## Effects on system behavior
None.
