### PR TITLE
feat(tier4_system_rviz_plugin): add parameter of max_line_text_num

### DIFF
--- a/common/tier4_system_rviz_plugin/package.xml
+++ b/common/tier4_system_rviz_plugin/package.xml
@@ -3,8 +3,9 @@
 <package format="3">
   <name>tier4_system_rviz_plugin</name>
   <version>0.38.0</version>
-  <description>The tier4_vehicle_rviz_plugin package</description>
+  <description>The tier4_system_rviz_plugin package</description>
   <maintainer email="koji.minoda@tier4.jp">Koji Minoda</maintainer>
+  <maintainer email="takayuki.murooka@tier4.jp">Takayuki Murooka</maintainer>
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>

--- a/common/tier4_system_rviz_plugin/src/mrm_summary_overlay_display.hpp
+++ b/common/tier4_system_rviz_plugin/src/mrm_summary_overlay_display.hpp
@@ -94,6 +94,7 @@ protected:
   rviz_common::properties::FloatProperty * property_value_scale_;
   rviz_common::properties::IntProperty * property_font_size_;
   rviz_common::properties::IntProperty * property_max_letter_num_;
+  rviz_common::properties::IntProperty * property_max_line_text_num_;
   // QImage hud_;
 
 private:


### PR DESCRIPTION
## Description

inserted a new line in the MRM summary rviz plugin so that the text does not cover other visualization

**before**
(See the upper left text)
![image](https://github.com/user-attachments/assets/67830ac8-e77b-4465-884d-32ecea2f2d84)

**after**
![image](https://github.com/user-attachments/assets/d39202a4-e6d0-4d49-af02-265a3350c8cd)

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
