### PR TITLE
feat: suppress warning/error of the empty predicted trajectory by MPC

### DIFF
--- a/control/autoware_control_validator/src/control_validator.cpp
+++ b/control/autoware_control_validator/src/control_validator.cpp
@@ -191,9 +191,7 @@ void ControlValidator::validate(
   const Odometry & kinematics)
 {
   if (predicted_trajectory.points.size() < 2) {
-    RCLCPP_ERROR_THROTTLE(
-      get_logger(), *get_clock(), 1000,
-      "predicted_trajectory size is less than 2. Cannot validate.");
+    RCLCPP_DEBUG(get_logger(), "predicted_trajectory size is less than 2. Cannot validate.");
     return;
   }
   if (reference_trajectory.points.size() < 2) {

--- a/control/autoware_lane_departure_checker/src/lane_departure_checker_node/lane_departure_checker_node.cpp
+++ b/control/autoware_lane_departure_checker/src/lane_departure_checker_node/lane_departure_checker_node.cpp
@@ -252,8 +252,7 @@ bool LaneDepartureCheckerNode::isDataValid()
   }
 
   if (predicted_trajectory_->points.empty()) {
-    RCLCPP_ERROR_THROTTLE(
-      get_logger(), *get_clock(), 5000, "predicted_trajectory is empty. Not expected!");
+    RCLCPP_DEBUG(get_logger(), "predicted_trajectory is empty. Not expected!");
     return false;
   }
 

--- a/control/autoware_mpc_lateral_controller/README.md
+++ b/control/autoware_mpc_lateral_controller/README.md
@@ -75,6 +75,12 @@ Return LateralOutput which contains the following to the controller node
 - LateralSyncData
   - steer angle convergence
 
+Publish the following messages.
+
+| Name                            | Type                               | Description                                                                                                                                                                |
+| ------------------------------- | ---------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `~/output/predicted_trajectory` | autoware_planning_msgs::Trajectory | Predicted trajectory calculated by MPC. The trajectory size will be empty when the controller is in an emergency such as too large deviation from the planning trajectory. |
+
 ### MPC class
 
 The `MPC` class (defined in `mpc.hpp`) provides the interface with the MPC algorithm.


### PR DESCRIPTION
## Description

The empty predicted trajectory is intended when the MPC is in an emergency such as too large deviation from the planning trajectory.
Based on this specification, I changed the logger level of the error/warn messages for the predicted trajectory since they fill the terminal.

## Related links


## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
