### PR TITLE
fix(yabloc_pose_initializer): include opencv as system

### DIFF
--- a/localization/autoware_pose_estimator_arbiter/src/shared_data.hpp
+++ b/localization/autoware_pose_estimator_arbiter/src/shared_data.hpp
@@ -24,6 +24,7 @@
 #include <memory>
 #include <optional>
 #include <vector>
+#include <functional>
 
 namespace autoware::pose_estimator_arbiter
 {

--- a/localization/autoware_pose_estimator_arbiter/src/shared_data.hpp
+++ b/localization/autoware_pose_estimator_arbiter/src/shared_data.hpp
@@ -24,7 +24,6 @@
 #include <memory>
 #include <optional>
 #include <vector>
-#include <functional>
 
 namespace autoware::pose_estimator_arbiter
 {

--- a/localization/yabloc/yabloc_pose_initializer/CMakeLists.txt
+++ b/localization/yabloc/yabloc_pose_initializer/CMakeLists.txt
@@ -27,7 +27,7 @@ ament_auto_add_library(${PROJECT_NAME}
   src/camera/semantic_segmentation.cpp
   src/camera/camera_pose_initializer_core.cpp)
 target_include_directories(${PROJECT_NAME} PUBLIC include)
-target_include_directories(${PROJECT_NAME} SYSTEM PRIVATE ${EIGEN3_INCLUDE_DIRS} ${PCL_INCLUDE_DIRS})
+target_include_directories(${PROJECT_NAME} SYSTEM PRIVATE ${EIGEN3_INCLUDE_DIRS} ${PCL_INCLUDE_DIRS} ${OpenCV_INCLUDE_DIRS})
 target_link_libraries(${PROJECT_NAME} ${PCL_LIBRARIES} Sophus::Sophus)
 ament_target_dependencies(${PROJECT_NAME} OpenCV)
 


### PR DESCRIPTION
## Description

Include opencv as a system header.
This solves the following clang-tidy diagnostic error.

```
clang-tidy-14 --use-color -p=build/ /home/veqcc/work/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_pose_initializer/src/camera/semantic_segmentation.cpp
/usr/include/opencv4/opencv2/flann/index_testing.h:249:11: error: variable 'p1' set but not used [clang-diagnostic-unused-but-set-variable]
    float p1;
          ^
1 error generated.
Error while processing /home/veqcc/work/autoware/src/universe/autoware.universe/localization/yabloc/yabloc_pose_initializer/src/camera/semantic_segmentation.cpp.
Found compiler error(s).
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
