### PR TITLE
fix(autoware_pose_estimator_arbiter): add missing include

### DIFF
--- a/localization/autoware_pose_estimator_arbiter/src/shared_data.hpp
+++ b/localization/autoware_pose_estimator_arbiter/src/shared_data.hpp
@@ -24,6 +24,7 @@
 #include <memory>
 #include <optional>
 #include <vector>
+#include <functional>
 
 namespace autoware::pose_estimator_arbiter
 {

--- a/localization/autoware_pose_estimator_arbiter/src/shared_data.hpp
+++ b/localization/autoware_pose_estimator_arbiter/src/shared_data.hpp
@@ -21,10 +21,10 @@
 #include <sensor_msgs/msg/image.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
 
+#include <functional>
 #include <memory>
 #include <optional>
 #include <vector>
-#include <functional>
 
 namespace autoware::pose_estimator_arbiter
 {


### PR DESCRIPTION
## Description

Added `functional` include.
This solves the following clang-tidy error
```
/home/veqcc/work/autoware/src/universe/autoware.universe/localization/autoware_pose_estimator_arbiter/src/shared_data.hpp:43:32: error: invalid range expression of type 'const auto'; no viable 'begin' function available [clang-diagnostic-error]
    for (const auto & callback : callbacks_) {
                               ^ ~~~~~~~~~~
/home/veqcc/work/autoware/src/universe/autoware.universe/localization/autoware_pose_estimator_arbiter/src/shared_data.hpp:43:34: error: use of undeclared identifier 'callbacks_'; did you mean 'callback'? [clang-diagnostic-error]
    for (const auto & callback : callbacks_) {
                                 ^
/home/veqcc/work/autoware/src/universe/autoware.universe/localization/autoware_pose_estimator_arbiter/src/shared_data.hpp:43:23: note: 'callback' declared here
    for (const auto & callback : callbacks_) {
                      ^
/home/veqcc/work/autoware/src/universe/autoware.universe/localization/autoware_pose_estimator_arbiter/src/shared_data.hpp:55:31: error: no template named 'function' in namespace 'std' [clang-diagnostic-error]
  void register_callback(std::function<void(T)> callback) const { callbacks_.push_back(callback); }
                         ~~~~~^
/home/veqcc/work/autoware/src/universe/autoware.universe/localization/autoware_pose_estimator_arbiter/src/shared_data.hpp:55:67: error: use of undeclared identifier 'callbacks_'; did you mean 'callback'? [clang-diagnostic-error]
  void register_callback(std::function<void(T)> callback) const { callbacks_.push_back(callback); }
                                                                  ^
/home/veqcc/work/autoware/src/universe/autoware.universe/localization/autoware_pose_estimator_arbiter/src/shared_data.hpp:55:49: note: 'callback' declared here
  void register_callback(std::function<void(T)> callback) const { callbacks_.push_back(callback); }
                                                ^
/home/veqcc/work/autoware/src/universe/autoware.universe/localization/autoware_pose_estimator_arbiter/src/shared_data.hpp:62:17: error: no member named 'bind' in namespace 'std'; did you mean 'find'? [clang-diagnostic-error]
    return std::bind(&CallbackInvokingVariable::set_and_invoke, this, std::placeholders::_1);
           ~~~~~^
/usr/lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/bits/stl_algo.h:3843:5: note: 'find' declared here
    find(_InputIterator __first, _InputIterator __last,
    ^
/home/veqcc/work/autoware/src/universe/autoware.universe/localization/autoware_pose_estimator_arbiter/src/shared_data.hpp:62:76: error: no member named 'placeholders' in namespace 'std' [clang-diagnostic-error]
    return std::bind(&CallbackInvokingVariable::set_and_invoke, this, std::placeholders::_1);
                                                                      ~~~~~^
/home/veqcc/work/autoware/src/universe/autoware.universe/localization/autoware_pose_estimator_arbiter/src/shared_data.hpp:70:28: error: no member named 'function' in namespace 'std' [clang-diagnostic-error]
  mutable std::vector<std::function<void(T)>> callbacks_;
                      ~~~~~^
/home/veqcc/work/autoware/src/universe/autoware.universe/localization/autoware_pose_estimator_arbiter/src/shared_data.hpp:70:42: error: 'T' does not refer to a value [clang-diagnostic-error]
  mutable std::vector<std::function<void(T)>> callbacks_;
                                         ^
/home/veqcc/work/autoware/src/universe/autoware.universe/localization/autoware_pose_estimator_arbiter/src/shared_data.hpp:30:20: note: declared here
template <typename T>
                   ^
/home/veqcc/work/autoware/src/universe/autoware.universe/localization/autoware_pose_estimator_arbiter/src/shared_data.hpp:70:45: error: expected member name or ';' after declaration specifiers [clang-diagnostic-error]
  mutable std::vector<std::function<void(T)>> callbacks_;
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
9 errors generated.
Error while processing /home/veqcc/work/autoware/src/universe/autoware.universe/localization/autoware_pose_estimator_arbiter/src/switch_rule/enable_all_rule.cpp.
Found compiler error(s).
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
