### PR TITLE
fix(control_performance_analysis): clang-diagnostic-pessimizing-move

### DIFF
--- a/control/control_performance_analysis/src/control_performance_analysis_core.cpp
+++ b/control/control_performance_analysis/src/control_performance_analysis_core.cpp
@@ -335,8 +335,7 @@ bool ControlPerformanceAnalysisCore::calculateDrivingVars()
         lpf(curr.desired_steering_angle.data, prev->desired_steering_angle.data);
       }
 
-      prev_driving_vars_ =
-        std::move(std::make_unique<msg::DrivingMonitorStamped>(driving_status_vars));
+      prev_driving_vars_ = std::make_unique<msg::DrivingMonitorStamped>(driving_status_vars);
 
       last_odom_header.stamp = odom_history_ptr_->at(odom_size - 1).header.stamp;
       last_steering_report.stamp = current_vec_steering_msg_ptr_->stamp;


### PR DESCRIPTION
## Description

Removed unnecessary `move`.

This solves the following clang-tidy error
```
autoware/src/universe/autoware.universe/control/control_performance_analysis/src/control_performance_analysis_core.cpp:339:9: error: moving a temporary object prevents copy elision [clang-diagnostic-pessimizing-move]
        std::move(std::make_unique<msg::DrivingMonitorStamped>(driving_status_vars));
        ^
/home/veqcc/work/autoware/src/universe/autoware.universe/control/control_performance_analysis/src/control_performance_analysis_core.cpp:339:9: note: remove std::move call here
        std::move(std::make_unique<msg::DrivingMonitorStamped>(driving_status_vars));
        ^~~~~~~~~~  
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
