### PR TITLE
feat(pid_longitudinal_controller): suppress rclcpp_warning/error

### DIFF
--- a/control/autoware_pid_longitudinal_controller/CMakeLists.txt
+++ b/control/autoware_pid_longitudinal_controller/CMakeLists.txt
@@ -4,6 +4,8 @@ project(autoware_pid_longitudinal_controller)
 find_package(autoware_cmake REQUIRED)
 autoware_package()
 
+find_package(fmt REQUIRED)
+
 set(PID_LON_CON_LIB ${PROJECT_NAME}_lib)
 ament_auto_add_library(${PID_LON_CON_LIB} SHARED
   DIRECTORY src

--- a/control/autoware_pid_longitudinal_controller/include/autoware/pid_longitudinal_controller/pid_longitudinal_controller.hpp
+++ b/control/autoware_pid_longitudinal_controller/include/autoware/pid_longitudinal_controller/pid_longitudinal_controller.hpp
@@ -254,6 +254,12 @@ private:
   void setupDiagnosticUpdater();
   void checkControlState(diagnostic_updater::DiagnosticStatusWrapper & stat);
 
+  struct ResultWithReason
+  {
+    bool result{false};
+    std::string reason{""};
+  };
+
   /**
    * @brief set current and previous velocity with received message
    * @param [in] msg current state message
@@ -297,6 +303,13 @@ private:
    * @param [in] dt time between previous and current one
    */
   Motion calcEmergencyCtrlCmd(const double dt);
+
+  /**
+   * @brief change control state
+   * @param [in] new state
+   * @param [in] reason to change control state
+   */
+  void changeControlState(const ControlState & control_state, const std::string & reason = "");
 
   /**
    * @brief update control state according to the current situation

--- a/control/autoware_pid_longitudinal_controller/package.xml
+++ b/control/autoware_pid_longitudinal_controller/package.xml
@@ -8,6 +8,7 @@
   <maintainer email="takamasa.horibe@tier4.jp">Takamasa Horibe</maintainer>
   <maintainer email="takayuki.murooka@tier4.jp">Takayuki Murooka</maintainer>
   <maintainer email="mamoru.sobue@tier4.jp">Mamoru Sobue</maintainer>
+  <maintainer email="yuki.takagi@tier4.jp">Yuki Takagi</maintainer>
 
   <license>Apache 2.0</license>
 


### PR DESCRIPTION
## Description

Suppress the too-frequent MPC's warning which fills the terminal.
Instead, set a diag with a detailed reason, and show it on the terminal once as follows.
![image](https://github.com/user-attachments/assets/f607d7ab-b9e4-4cf9-a0c7-15ac23a9b1fb)


## Related links



## How was this PR tested?
unit test passed perfectly, and psim worked as expected.
## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
