### PR TITLE
fix(lane_change): check obj predicted path when filtering

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/utils.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/utils.hpp
@@ -382,5 +382,8 @@ bool filter_target_lane_objects(
   const double dist_ego_to_current_lanes_center, const bool ahead_of_ego,
   const bool before_terminal, TargetLaneLeadingObjects & leading_objects,
   ExtendedPredictedObjects & trailing_objects);
+
+bool has_path_overlapped_target_lanes(
+  const ExtendedPredictedObject & object, const lanelet::BasicPolygon2d & lanes_polygon);
 }  // namespace autoware::behavior_path_planner::utils::lane_change
 #endif  // AUTOWARE__BEHAVIOR_PATH_LANE_CHANGE_MODULE__UTILS__UTILS_HPP_

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/utils.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/utils.hpp
@@ -397,7 +397,7 @@ bool filter_target_lane_objects(
  * @return true if any of the object's predicted paths overlap with the lanes polygon, false
  * otherwise.
  */
-bool is_object_path_overlapped_lanes(
+bool object_path_overlaps_lanes(
   const ExtendedPredictedObject & object, const lanelet::BasicPolygon2d & lanes_polygon);
 }  // namespace autoware::behavior_path_planner::utils::lane_change
 #endif  // AUTOWARE__BEHAVIOR_PATH_LANE_CHANGE_MODULE__UTILS__UTILS_HPP_

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/utils.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/utils.hpp
@@ -383,7 +383,21 @@ bool filter_target_lane_objects(
   const bool before_terminal, TargetLaneLeadingObjects & leading_objects,
   ExtendedPredictedObjects & trailing_objects);
 
-bool has_path_overlapped_target_lanes(
+/**
+ * @brief Determines if the object's predicted path overlaps with the given lane polygon.
+ *
+ * This function checks whether any of the line string paths derived from the object's predicted
+ * trajectories intersect or overlap with the specified polygon representing lanes.
+ *
+ * @param object The extended predicted object containing predicted trajectories and initial
+ * polygon.
+ * @param lanes_polygon A polygon representing the lanes to check for overlaps with the object's
+ * paths.
+ *
+ * @return true if any of the object's predicted paths overlap with the lanes polygon, false
+ * otherwise.
+ */
+bool is_object_path_overlapped_lanes(
   const ExtendedPredictedObject & object, const lanelet::BasicPolygon2d & lanes_polygon);
 }  // namespace autoware::behavior_path_planner::utils::lane_change
 #endif  // AUTOWARE__BEHAVIOR_PATH_LANE_CHANGE_MODULE__UTILS__UTILS_HPP_

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/scene.cpp
@@ -988,6 +988,7 @@ lane_change::TargetObjects NormalLaneChange::get_target_objects(
 
 FilteredLanesObjects NormalLaneChange::filter_objects() const
 {
+  universe_utils::ScopedTimeTrack st(__func__, *time_keeper_);
   auto objects = *planner_data_->dynamic_object;
   utils::path_safety_checker::filterObjectsByClass(
     objects, lane_change_parameters_->safety.target_object_types);

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/utils.cpp
@@ -1171,7 +1171,7 @@ bool has_overtaking_turn_lane_object(
       return true;
     }
 
-    return is_object_path_overlapped_lanes(object, common_data_ptr->lanes_polygon_ptr->target);
+    return object_path_overlaps_lanes(object, common_data_ptr->lanes_polygon_ptr->target);
   };
 
   return std::any_of(
@@ -1207,7 +1207,7 @@ bool filter_target_lane_objects(
       }
 
       return !is_stopped && is_vehicle(object.classification) &&
-             is_object_path_overlapped_lanes(object, lanes_polygon.target);
+             object_path_overlaps_lanes(object, lanes_polygon.target);
     });
 
     if (overlapped_target_lanes) {
@@ -1250,7 +1250,7 @@ bool filter_target_lane_objects(
   return false;
 }
 
-bool is_object_path_overlapped_lanes(
+bool object_path_overlaps_lanes(
   const ExtendedPredictedObject & object, const lanelet::BasicPolygon2d & lanes_polygon)
 {
   return ranges::any_of(get_line_string_paths(object), [&](const auto & path) {

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/utils.cpp
@@ -1201,14 +1201,7 @@ bool filter_target_lane_objects(
   const auto is_stopped = velocity_filter(
     object.initial_twist, -std::numeric_limits<double>::epsilon(), stopped_obj_vel_th);
   if (is_lateral_far && before_terminal) {
-    const auto overlapped_target_lanes = std::invoke([&]() {
-      if (!boost::geometry::disjoint(object.initial_polygon, lanes_polygon.target)) {
-        return true;
-      }
-
-      return !is_stopped && is_vehicle(object.classification) &&
-             object_path_overlaps_lanes(object, lanes_polygon.target);
-    });
+    const auto overlapped_target_lanes = !boost::geometry::disjoint(object.initial_polygon, lanes_polygon.target) || (!is_stopped && is_vehicle(object.classification) && object_path_overlaps_lanes(object, lanes_polygon.target));
 
     if (overlapped_target_lanes) {
       if (!ahead_of_ego && !is_stopped) {

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/utils.cpp
@@ -1171,7 +1171,7 @@ bool has_overtaking_turn_lane_object(
       return true;
     }
 
-    return has_path_overlapped_target_lanes(object, common_data_ptr->lanes_polygon_ptr->target);
+    return is_object_path_overlapped_lanes(object, common_data_ptr->lanes_polygon_ptr->target);
   };
 
   return std::any_of(
@@ -1207,7 +1207,7 @@ bool filter_target_lane_objects(
       }
 
       return !is_stopped && is_vehicle(object.classification) &&
-             has_path_overlapped_target_lanes(object, lanes_polygon.target);
+             is_object_path_overlapped_lanes(object, lanes_polygon.target);
     });
 
     if (overlapped_target_lanes) {
@@ -1250,7 +1250,7 @@ bool filter_target_lane_objects(
   return false;
 }
 
-bool has_path_overlapped_target_lanes(
+bool is_object_path_overlapped_lanes(
   const ExtendedPredictedObject & object, const lanelet::BasicPolygon2d & lanes_polygon)
 {
   return ranges::any_of(get_line_string_paths(object), [&](const auto & path) {

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/utils.cpp
@@ -1201,9 +1201,12 @@ bool filter_target_lane_objects(
   const auto is_stopped = velocity_filter(
     object.initial_twist, -std::numeric_limits<double>::epsilon(), stopped_obj_vel_th);
   if (is_lateral_far && before_terminal) {
-    const auto overlapped_target_lanes = !boost::geometry::disjoint(object.initial_polygon, lanes_polygon.target) || (!is_stopped && is_vehicle(object.classification) && object_path_overlaps_lanes(object, lanes_polygon.target));
+    const auto overlapping_with_target_lanes =
+      !boost::geometry::disjoint(object.initial_polygon, lanes_polygon.target) ||
+      (!is_stopped && is_vehicle(object.classification) &&
+       object_path_overlaps_lanes(object, lanes_polygon.target));
 
-    if (overlapped_target_lanes) {
+    if (overlapping_with_target_lanes) {
       if (!ahead_of_ego && !is_stopped) {
         trailing_objects.push_back(object);
         return true;

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/utils.cpp
@@ -1184,6 +1184,7 @@ bool filter_target_lane_objects(
   const bool before_terminal, TargetLaneLeadingObjects & leading_objects,
   ExtendedPredictedObjects & trailing_objects)
 {
+  using behavior_path_planner::utils::path_safety_checker::filter::is_vehicle;
   using behavior_path_planner::utils::path_safety_checker::filter::velocity_filter;
   const auto & current_lanes = common_data_ptr->lanes_ptr->current;
   const auto & vehicle_width = common_data_ptr->bpp_param_ptr->vehicle_info.vehicle_width_m;
@@ -1205,7 +1206,8 @@ bool filter_target_lane_objects(
         return true;
       }
 
-      return !is_stopped && has_path_overlapped_target_lanes(object, lanes_polygon.target);
+      return !is_stopped && is_vehicle(object.classification) &&
+             has_path_overlapped_target_lanes(object, lanes_polygon.target);
     });
 
     if (overlapped_target_lanes) {

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/utils.cpp
@@ -35,6 +35,8 @@
 #include <autoware_lanelet2_extension/utility/utilities.hpp>
 #include <autoware_vehicle_info_utils/vehicle_info.hpp>
 #include <range/v3/algorithm/any_of.hpp>
+#include <range/v3/range/conversion.hpp>
+#include <range/v3/view/transform.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include <geometry_msgs/msg/detail/pose__struct.hpp>
@@ -1149,11 +1151,8 @@ std::vector<LineString2d> get_line_string_paths(const ExtendedPredictedObject & 
     return line_string;
   };
 
-  const auto paths = object.predicted_paths;
-  std::vector<LineString2d> line_strings;
-  std::transform(paths.begin(), paths.end(), std::back_inserter(line_strings), to_linestring_2d);
-
-  return line_strings;
+  return object.predicted_paths | ranges::views::transform(to_linestring_2d) |
+         ranges::to<std::vector>();
 }
 
 bool has_overtaking_turn_lane_object(
@@ -1252,8 +1251,7 @@ bool filter_target_lane_objects(
 bool has_path_overlapped_target_lanes(
   const ExtendedPredictedObject & object, const lanelet::BasicPolygon2d & lanes_polygon)
 {
-  const auto paths = get_line_string_paths(object);
-  return ranges::any_of(paths, [&](const LineString2d & path) {
+  return ranges::any_of(get_line_string_paths(object), [&](const auto & path) {
     return !boost::geometry::disjoint(path, lanes_polygon);
   });
 }

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/utils/path_safety_checker/objects_filtering.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/utils/path_safety_checker/objects_filtering.hpp
@@ -71,6 +71,16 @@ bool is_within_circle(
   const geometry_msgs::msg::Point & object_pos, const geometry_msgs::msg::Point & reference_point,
   const double search_radius);
 
+/**
+ * @brief Checks if the object classification represents a vehicle (CAR, TRUCK, BUS, TRAILER,
+ * MOTORCYCLE).
+ *
+ * @param classification The object classification to check.
+ * @return true If the classification is a vehicle type.
+ * @return false Otherwise.
+ */
+bool is_vehicle(const ObjectClassification & classification);
+
 }  // namespace autoware::behavior_path_planner::utils::path_safety_checker::filter
 
 namespace autoware::behavior_path_planner::utils::path_safety_checker

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/path_safety_checker/objects_filtering.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/path_safety_checker/objects_filtering.cpp
@@ -57,6 +57,20 @@ bool is_within_circle(
     std::hypot(reference_point.x - object_pos.x, reference_point.y - object_pos.y);
   return dist < search_radius;
 }
+
+bool is_vehicle(const ObjectClassification & classification)
+{
+  switch (classification.label) {
+    case ObjectClassification::CAR:
+    case ObjectClassification::TRUCK:
+    case ObjectClassification::BUS:
+    case ObjectClassification::TRAILER:
+    case ObjectClassification::MOTORCYCLE:
+      return true;
+    default:
+      return false;
+  }
+}
 }  // namespace autoware::behavior_path_planner::utils::path_safety_checker::filter
 
 namespace autoware::behavior_path_planner::utils::path_safety_checker


### PR DESCRIPTION
## Description

If there’s object that crosses predicted target lanes but it is not in target lane or target preceding lane, then the object will be treated as other lane object and will be ignored.

This PR aims to fix this.

### Before PR

The following video shows the use case.
If the object is not in cyan lane (current) or blue (target preceding), then it will be considered as others object (purple cube).

https://github.com/user-attachments/assets/40cbb71d-a3eb-48a0-9530-113d8e255a3e

### With PR

Object is now considered as target lane leading object (cyan cube)

https://github.com/user-attachments/assets/f781f984-6249-4c6f-8baa-56300dba6993

## Related links


**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

1. PSIM
2. Internal evaluator: [TIER IV Internal link](https://evaluation.tier4.jp/evaluation/reports/2e106800-248c-5576-8f53-37c0f5a710b0?project_id=prd_jt)

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
