### PR TITLE
test(bpp_common): add unit test for safety check

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/utils/path_safety_checker/safety_check.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/utils/path_safety_checker/safety_check.hpp
@@ -131,6 +131,21 @@ ExtendedPredictedObjects filterObjectPredictedPathByTimeHorizon(
 std::vector<PoseWithVelocityStamped> filterPredictedPathAfterTargetPose(
   const std::vector<PoseWithVelocityStamped> & path, const Pose & target_pose);
 
+/**
+ * @brief Iterate the points in the ego and target's predicted path and
+ *        perform safety check for each of the iterated points using RSS parameters
+ * @param planned_path The planned path of the ego vehicle.
+ * @param ego_predicted_path Ego vehicle's predicted path
+ * @param objects Detected objects.
+ * @param debug_map Map for collision check debug.
+ * @param target_object_path The predicted path of the target object.
+ * @param parameters The common parameters used in behavior path planner.
+ * @param rss_params The parameters used in RSS
+ * @param check_all_predicted_path If true, uses all predicted path
+ * @param hysteresis_factor Hysteresis factor
+ * @param yaw_difference_th Threshold for yaw difference
+ * @return True if distance is safe.
+ */
 bool checkSafetyWithRSS(
   const PathWithLaneId & planned_path,
   const std::vector<PoseWithVelocityStamped> & ego_predicted_path,
@@ -166,16 +181,17 @@ bool checkCollision(
 /**
  * @brief Iterate the points in the ego and target's predicted path and
  *        perform safety check for each of the iterated points.
- * @param planned_path The predicted path of the ego vehicle.
+ * @param planned_path The planned path of the ego vehicle.
  * @param predicted_ego_path Ego vehicle's predicted path
- * @param ego_current_velocity Current velocity of the ego vehicle.
  * @param target_object The predicted object to check collision with.
  * @param target_object_path The predicted path of the target object.
- * @param common_parameters The common parameters used in behavior path planner.
- * @param front_object_deceleration The deceleration of the object in the front.(used in RSS)
- * @param rear_object_deceleration The deceleration of the object in the rear.(used in RSS)
+ * @param vehicle_info Ego vehicle information.
+ * @param rss_parameters The parameters used in RSS.
+ * @param hysteresis_factor Hysteresis factor.
+ * @param max_velocity_limit Maximum velocity of ego vehicle.
+ * @param yaw_difference_th Threshold of yaw difference.
  * @param debug The debug information for collision checking.
- * @return a list of polygon when collision is expected.
+ * @return List of polygon which collision is expected.
  */
 std::vector<Polygon2d> get_collided_polygons(
   const PathWithLaneId & planned_path,

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/utils/path_safety_checker/safety_check.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/utils/path_safety_checker/safety_check.hpp
@@ -159,16 +159,14 @@ bool checkSafetyWithRSS(
  *        perform safety check for each of the iterated points.
  * @param planned_path The predicted path of the ego vehicle.
  * @param predicted_ego_path Ego vehicle's predicted path
- * @param ego_current_velocity Current velocity of the ego vehicle.
  * @param target_object The predicted object to check collision with.
  * @param target_object_path The predicted path of the target object.
- * @param common_parameters The common parameters used in behavior path planner.
- * @param front_object_deceleration The deceleration of the object in the front.(used in RSS)
- * @param rear_object_deceleration The deceleration of the object in the rear.(used in RSS)
- * @param yaw_difference_th maximum yaw difference between any given ego path pose and object
- * predicted path pose.
+ * @param common_parameters Common parameters used for behavior path planning.
+ * @param rss_parameters The parameters used in RSS.
+ * @param hysteresis_factor Hysteresis factor.
+ * @param yaw_difference_th Threshold of yaw difference.
  * @param debug The debug information for collision checking.
- * @return true if distance is safe.
+ * @return True if there is no collision.
  */
 bool checkCollision(
   const PathWithLaneId & planned_path,
@@ -203,6 +201,7 @@ std::vector<Polygon2d> get_collided_polygons(
 
 bool checkPolygonsIntersects(
   const std::vector<Polygon2d> & polys_1, const std::vector<Polygon2d> & polys_2);
+
 bool checkSafetyWithIntegralPredictedPolygon(
   const std::vector<PoseWithVelocityStamped> & ego_predicted_path, const VehicleInfo & vehicle_info,
   const ExtendedPredictedObjects & objects, const bool check_all_predicted_path,

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/utils/path_safety_checker/safety_check.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/utils/path_safety_checker/safety_check.hpp
@@ -76,9 +76,22 @@ Polygon2d createExtendedPolygon(
   const PoseWithVelocityAndPolygonStamped & obj_pose_with_poly, const double lon_length,
   const double lat_margin, const bool is_stopped_obj, CollisionCheckDebug & debug);
 
+/**
+ * @brief Converts path (path with velocity stamped) to predicted path.
+ * @param path Path.
+ * @param time_resolution Time resolution.
+ * @return Predicted path.
+ */
 PredictedPath convertToPredictedPath(
   const std::vector<PoseWithVelocityStamped> & path, const double time_resolution);
 
+/**
+ * @brief Calculates RSS related distance.
+ * @param front_object_velocity Velocity of front object.
+ * @param rear_object_velocity Velocity of rear object.
+ * @param rss_params RSS parameters.
+ * @return Longitudinal distance.
+ */
 double calcRssDistance(
   const double front_object_velocity, const double rear_object_velocity,
   const RSSparams & rss_params);
@@ -128,6 +141,12 @@ ExtendedPredictedObjects filterObjectPredictedPathByTimeHorizon(
   const ExtendedPredictedObjects & objects, const double time_horizon,
   const bool check_all_predicted_path);
 
+/**
+ * @brief Filters the path by obtaining points after target pose.
+ * @param path Path to filter.
+ * @param target_pose Target pose.
+ * @return Filtered path.
+ */
 std::vector<PoseWithVelocityStamped> filterPredictedPathAfterTargetPose(
   const std::vector<PoseWithVelocityStamped> & path, const Pose & target_pose);
 
@@ -138,13 +157,12 @@ std::vector<PoseWithVelocityStamped> filterPredictedPathAfterTargetPose(
  * @param ego_predicted_path Ego vehicle's predicted path
  * @param objects Detected objects.
  * @param debug_map Map for collision check debug.
- * @param target_object_path The predicted path of the target object.
  * @param parameters The common parameters used in behavior path planner.
- * @param rss_params The parameters used in RSS
+ * @param rss_params The parameters used in RSSs
  * @param check_all_predicted_path If true, uses all predicted path
  * @param hysteresis_factor Hysteresis factor
  * @param yaw_difference_th Threshold for yaw difference
- * @return True if distance is safe.
+ * @return True if planned path is safe.
  */
 bool checkSafetyWithRSS(
   const PathWithLaneId & planned_path,
@@ -202,6 +220,16 @@ std::vector<Polygon2d> get_collided_polygons(
 bool checkPolygonsIntersects(
   const std::vector<Polygon2d> & polys_1, const std::vector<Polygon2d> & polys_2);
 
+/**
+ * @brief Checks for safety using integral predicted polygons.
+ * @param ego_predicted_path The predicted path of ego vehicle.
+ * @param vehicle_info Information (parameters) about ego vehicle.
+ * @param objects Surrounding objects.
+ * @param check_all_predicted_path Whether to check all predicted paths of objects.
+ * @param params Parameters for integral predicted polygon.
+ * @param debug_map Map to store debug information.
+ * @return True if the ego vehicle's path is safe, and false otherwise.
+ */
 bool checkSafetyWithIntegralPredictedPolygon(
   const std::vector<PoseWithVelocityStamped> & ego_predicted_path, const VehicleInfo & vehicle_info,
   const ExtendedPredictedObjects & objects, const bool check_all_predicted_path,

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/path_safety_checker/safety_check.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/path_safety_checker/safety_check.cpp
@@ -29,6 +29,7 @@
 #include <tf2/utils.h>
 
 #include <cmath>
+#include <iostream>
 #include <limits>
 
 namespace autoware::behavior_path_planner::utils::path_safety_checker
@@ -637,6 +638,7 @@ std::vector<Polygon2d> get_collided_polygons(
     // compute which one is at the front of the other
     const bool is_object_front =
       isTargetObjectFront(ego_pose, obj_polygon, ego_vehicle_info.max_longitudinal_offset_m);
+
     const auto & [front_object_velocity, rear_object_velocity] =
       is_object_front ? std::make_pair(object_velocity, ego_velocity)
                       : std::make_pair(ego_velocity, object_velocity);

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/path_safety_checker/safety_check.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/path_safety_checker/safety_check.cpp
@@ -29,7 +29,6 @@
 #include <tf2/utils.h>
 
 #include <cmath>
-#include <iostream>
 #include <limits>
 
 namespace autoware::behavior_path_planner::utils::path_safety_checker
@@ -638,7 +637,6 @@ std::vector<Polygon2d> get_collided_polygons(
     // compute which one is at the front of the other
     const bool is_object_front =
       isTargetObjectFront(ego_pose, obj_polygon, ego_vehicle_info.max_longitudinal_offset_m);
-
     const auto & [front_object_velocity, rear_object_velocity] =
       is_object_front ? std::make_pair(object_velocity, ego_velocity)
                       : std::make_pair(ego_velocity, object_velocity);

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/test/test_safety_check.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/test/test_safety_check.cpp
@@ -392,6 +392,16 @@ TEST(BehaviorPathPlanningSafetyUtilsTest, get_interpolated_pose_with_velocity_an
   EXPECT_TRUE(interpolation_result.has_value());
 }
 
+TEST(BehaviorPathPlanningSafetyUtilsTest, checkSafetyWithRSS)
+{
+  using autoware::behavior_path_planner::utils::path_safety_checker::checkSafetyWithRSS;
+}
+
+TEST(BehaviorPathPlanningSafetyUtilsTest, get_collided_polygons)
+{
+  using autoware::behavior_path_planner::utils::path_safety_checker::get_collided_polygons;
+}
+
 TEST(BehaviorPathPlanningSafetyUtilsTest, checkPolygonsIntersects)
 {
   using autoware::behavior_path_planner::utils::path_safety_checker::checkPolygonsIntersects;


### PR DESCRIPTION
## Description
Add unit test for `autoware_behavior_path_planner_common/utils/safety_check.cpp`
![image](https://github.com/user-attachments/assets/35293cef-76e7-4696-b729-98769ceaaf48)


## Related links
None

## How was this PR tested?
Colcon test
```
4: [==========] Running 28 tests from 3 test suites.
4: [----------] Global test environment set-up.
4: [----------] 16 tests from BehaviorPathPlanningSafetyUtilsTest
4: [ RUN      ] BehaviorPathPlanningSafetyUtilsTest.isTargetObjectOncoming
4: [       OK ] BehaviorPathPlanningSafetyUtilsTest.isTargetObjectOncoming (0 ms)
4: [ RUN      ] BehaviorPathPlanningSafetyUtilsTest.isTargetObjectFront
4: [       OK ] BehaviorPathPlanningSafetyUtilsTest.isTargetObjectFront (0 ms)
4: [ RUN      ] BehaviorPathPlanningSafetyUtilsTest.createExtendedEgoPolygon
4: [       OK ] BehaviorPathPlanningSafetyUtilsTest.createExtendedEgoPolygon (0 ms)
4: [ RUN      ] BehaviorPathPlanningSafetyUtilsTest.createExtendedObjPolygon
4: [       OK ] BehaviorPathPlanningSafetyUtilsTest.createExtendedObjPolygon (0 ms)
4: [ RUN      ] BehaviorPathPlanningSafetyUtilsTest.convertToPredictedPath
4: [       OK ] BehaviorPathPlanningSafetyUtilsTest.convertToPredictedPath (0 ms)
4: [ RUN      ] BehaviorPathPlanningSafetyUtilsTest.calcRssDistance
4: [       OK ] BehaviorPathPlanningSafetyUtilsTest.calcRssDistance (0 ms)
4: [ RUN      ] BehaviorPathPlanningSafetyUtilsTest.calc_minimum_longitudinal_length
4: [       OK ] BehaviorPathPlanningSafetyUtilsTest.calc_minimum_longitudinal_length (0 ms)
4: [ RUN      ] BehaviorPathPlanningSafetyUtilsTest.get_interpolated_pose_with_velocity_and_polygon_stamped
4: [       OK ] BehaviorPathPlanningSafetyUtilsTest.get_interpolated_pose_with_velocity_and_polygon_stamped (0 ms)
4: [ RUN      ] BehaviorPathPlanningSafetyUtilsTest.filterPredictedPathAfterTargetPose
4: [       OK ] BehaviorPathPlanningSafetyUtilsTest.filterPredictedPathAfterTargetPose (0 ms)
4: [ RUN      ] BehaviorPathPlanningSafetyUtilsTest.checkSafetyWithRSS
4: [       OK ] BehaviorPathPlanningSafetyUtilsTest.checkSafetyWithRSS (4 ms)
4: [ RUN      ] BehaviorPathPlanningSafetyUtilsTest.checkSafetyWithIntegralPredictedPolygon
4: [       OK ] BehaviorPathPlanningSafetyUtilsTest.checkSafetyWithIntegralPredictedPolygon (8 ms)
4: [ RUN      ] BehaviorPathPlanningSafetyUtilsTest.checkCollision
4: [       OK ] BehaviorPathPlanningSafetyUtilsTest.checkCollision (8 ms)
4: [ RUN      ] BehaviorPathPlanningSafetyUtilsTest.checkPolygonsIntersects
4: [       OK ] BehaviorPathPlanningSafetyUtilsTest.checkPolygonsIntersects (1 ms)
4: [ RUN      ] BehaviorPathPlanningSafetyUtilsTest.calc_obstacle_length
4: [       OK ] BehaviorPathPlanningSafetyUtilsTest.calc_obstacle_length (0 ms)
4: [ RUN      ] BehaviorPathPlanningSafetyUtilsTest.checkObjectsCollisionRough
4: [       OK ] BehaviorPathPlanningSafetyUtilsTest.checkObjectsCollisionRough (0 ms)
4: [ RUN      ] BehaviorPathPlanningSafetyUtilsTest.calculateRoughDistanceToObjects
4: [       OK ] BehaviorPathPlanningSafetyUtilsTest.calculateRoughDistanceToObjects (0 ms)
4: [----------] 16 tests from BehaviorPathPlanningSafetyUtilsTest (21 ms total)

```

## Notes for reviewers
None.

## Interface changes
None.

## Effects on system behavior
None.
