### PR TITLE
fix(autoware_ndt_scan_matcher): remove unsed functions

### DIFF
--- a/localization/autoware_ndt_scan_matcher/include/autoware/ndt_scan_matcher/ndt_omp/multi_voxel_grid_covariance_omp.h
+++ b/localization/autoware_ndt_scan_matcher/include/autoware/ndt_scan_matcher/ndt_omp/multi_voxel_grid_covariance_omp.h
@@ -340,6 +340,16 @@ protected:
     }
   }
 
+  // A wrapper of the real apply_filter
+  // cppcheck-suppress unusedFunction
+  inline bool apply_filter_thread(int tid, GridNodeType & node)
+  {
+    apply_filter(processing_inputs_[tid], node);
+    processing_inputs_[tid].reset();
+
+    return true;
+  }
+
   /** \brief Filter cloud and initializes voxel structure.
    * \param[out] output cloud containing centroids of voxels containing a sufficient number of
    * points

--- a/localization/autoware_ndt_scan_matcher/include/autoware/ndt_scan_matcher/ndt_omp/multi_voxel_grid_covariance_omp.h
+++ b/localization/autoware_ndt_scan_matcher/include/autoware/ndt_scan_matcher/ndt_omp/multi_voxel_grid_covariance_omp.h
@@ -171,12 +171,6 @@ public:
       return *this;
     }
 
-    /** \brief Get the voxel covariance.
-     * \return covariance matrix
-     */
-    const Eigen::Matrix3d & getCov() const { return (cov_); }
-    Eigen::Matrix3d & getCov() { return (cov_); }
-
     /** \brief Get the inverse of the voxel covariance.
      * \return inverse covariance matrix
      */
@@ -190,11 +184,6 @@ public:
     const Eigen::Vector3d & getMean() const { return (mean_); }
 
     Eigen::Vector3d & getMean() { return (mean_); }
-
-    /** \brief Get the number of points contained by this voxel.
-     * \return number of points
-     */
-    int getPointCount() const { return (nr_points_); }
 
     /** \brief Number of points contained by voxel */
     int nr_points_;
@@ -349,15 +338,6 @@ protected:
         tf.wait();
       }
     }
-  }
-
-  // A wrapper of the real apply_filter
-  inline bool apply_filter_thread(int tid, GridNodeType & node)
-  {
-    apply_filter(processing_inputs_[tid], node);
-    processing_inputs_[tid].reset();
-
-    return true;
   }
 
   /** \brief Filter cloud and initializes voxel structure.

--- a/localization/autoware_ndt_scan_matcher/include/autoware/ndt_scan_matcher/ndt_omp/multigrid_ndt_omp.h
+++ b/localization/autoware_ndt_scan_matcher/include/autoware/ndt_scan_matcher/ndt_omp/multigrid_ndt_omp.h
@@ -132,15 +132,6 @@ public:
   /** \brief Empty destructor */
   virtual ~MultiGridNormalDistributionsTransform() {}
 
-  void setNumThreads(int n)
-  {
-    params_.num_threads = n;
-
-    target_cells_.setThreadNum(params_.num_threads);
-  }
-
-  inline int getNumThreads() const { return params_.num_threads; }
-
   inline void setInputSource(const PointCloudSourceConstPtr & input)
   {
     // This is to avoid segmentation fault when setting null input
@@ -177,43 +168,6 @@ public:
     target_cells_.createKdtree();
     target_cloud_updated_ = false;
   }
-
-  /** \brief Set/change the voxel grid resolution.
-   * \param[in] resolution side length of voxels
-   */
-  inline void setResolution(float resolution)
-  {
-    // Prevents unnecessary voxel initiations
-    if (params_.resolution != resolution) {
-      params_.resolution = resolution;
-      if (input_) init();
-    }
-  }
-
-  /** \brief Get voxel grid resolution.
-   * \return side length of voxels
-   */
-  inline float getResolution() const { return (params_.resolution); }
-
-  /** \brief Get the newton line search maximum step length.
-   * \return maximum step length
-   */
-  inline double getStepSize() const { return (params_.step_size); }
-
-  /** \brief Set/change the newton line search maximum step length.
-   * \param[in] step_size maximum step length
-   */
-  inline void setStepSize(double step_size) { params_.step_size = step_size; }
-
-  /** \brief Get the point cloud outlier ratio.
-   * \return outlier ratio
-   */
-  inline double getOutlierRatio() const { return (outlier_ratio_); }
-
-  /** \brief Set/change the point cloud outlier ratio.
-   * \param[in] outlier_ratio outlier ratio
-   */
-  inline void setOutlierRatio(double outlier_ratio) { outlier_ratio_ = outlier_ratio; }
 
   /** \brief Get the registration alignment probability.
    * \return transformation probability
@@ -271,11 +225,6 @@ public:
   pcl::PointCloud<pcl::PointXYZI> calculateNearestVoxelScoreEachPoint(
     const PointCloudSource & cloud) const;
 
-  inline void setRegularizationScaleFactor(float regularization_scale_factor)
-  {
-    params_.regularization_scale_factor = regularization_scale_factor;
-  }
-
   inline void setRegularizationPose(Eigen::Matrix4f regularization_pose)
   {
     regularization_pose_ = regularization_pose;
@@ -297,29 +246,6 @@ public:
     ndt_result.hessian = getHessian();
     return ndt_result;
   }
-
-  /** \brief Set the transformation epsilon (maximum allowable translation squared
-   * difference between two consecutive transformations) in order for an optimization to
-   * be considered as having converged to the final solution. \param[in] epsilon the
-   * transformation epsilon in order for an optimization to be considered as having
-   * converged to the final solution.
-   */
-  inline void setTransformationEpsilon(double epsilon) { params_.trans_epsilon = epsilon; }
-
-  /** \brief Get the transformation epsilon (maximum allowable translation squared
-   * difference between two consecutive transformations) as set by the user.
-   */
-  inline double getTransformationEpsilon() { return (params_.trans_epsilon); }
-
-  inline void setMaximumIterations(int max_iterations)
-  {
-    params_.max_iterations = max_iterations;
-    max_iterations_ = params_.max_iterations;
-  }
-
-  inline int getMaxIterations() const { return params_.max_iterations; }
-
-  inline int getMaxIterations() { return params_.max_iterations; }
 
   void setParams(const NdtParams & ndt_params)
   {


### PR DESCRIPTION
## Description

Fixed cppcheck `unusedFunction` warnings
```
localization/autoware_ndt_scan_matcher/include/autoware/ndt_scan_matcher/ndt_omp/multi_voxel_grid_covariance_omp.h:177:0: style: The function 'getCov' is never used. [unusedFunction]
    const Eigen::Matrix3d & getCov() const { return (cov_); }
^
localization/autoware_ndt_scan_matcher/include/autoware/ndt_scan_matcher/ndt_omp/multi_voxel_grid_covariance_omp.h:197:0: style: The function 'getPointCount' is never used. [unusedFunction]
    int getPointCount() const { return (nr_points_); }
^
localization/autoware_ndt_scan_matcher/include/autoware/ndt_scan_matcher/ndt_omp/multi_voxel_grid_covariance_omp.h:355:0: style: The function 'apply_filter_thread' is never used. [unusedFunction]
  inline bool apply_filter_thread(int tid, GridNodeType & node)
^
localization/autoware_ndt_scan_matcher/include/autoware/ndt_scan_matcher/ndt_omp/multigrid_ndt_omp.h:135:0: style: The function 'setNumThreads' is never used. [unusedFunction]
  void setNumThreads(int n)
^
localization/autoware_ndt_scan_matcher/include/autoware/ndt_scan_matcher/ndt_omp/multigrid_ndt_omp.h:142:0: style: The function 'getNumThreads' is never used. [unusedFunction]
  inline int getNumThreads() const { return params_.num_threads; }
^
localization/autoware_ndt_scan_matcher/include/autoware/ndt_scan_matcher/ndt_omp/multigrid_ndt_omp.h:184:0: style: The function 'setResolution' is never used. [unusedFunction]
  inline void setResolution(float resolution)
^
localization/autoware_ndt_scan_matcher/include/autoware/ndt_scan_matcher/ndt_omp/multigrid_ndt_omp.h:196:0: style: The function 'getResolution' is never used. [unusedFunction]
  inline float getResolution() const { return (params_.resolution); }
^
localization/autoware_ndt_scan_matcher/include/autoware/ndt_scan_matcher/ndt_omp/multigrid_ndt_omp.h:201:0: style: The function 'getStepSize' is never used. [unusedFunction]
  inline double getStepSize() const { return (params_.step_size); }
^
localization/autoware_ndt_scan_matcher/include/autoware/ndt_scan_matcher/ndt_omp/multigrid_ndt_omp.h:206:0: style: The function 'setStepSize' is never used. [unusedFunction]
  inline void setStepSize(double step_size) { params_.step_size = step_size; }
^
localization/autoware_ndt_scan_matcher/include/autoware/ndt_scan_matcher/ndt_omp/multigrid_ndt_omp.h:211:0: style: The function 'getOutlierRatio' is never used. [unusedFunction]
  inline double getOutlierRatio() const { return (outlier_ratio_); }
^
localization/autoware_ndt_scan_matcher/include/autoware/ndt_scan_matcher/ndt_omp/multigrid_ndt_omp.h:216:0: style: The function 'setOutlierRatio' is never used. [unusedFunction]
  inline void setOutlierRatio(double outlier_ratio) { outlier_ratio_ = outlier_ratio; }
^
localization/autoware_ndt_scan_matcher/include/autoware/ndt_scan_matcher/ndt_omp/multigrid_ndt_omp.h:274:0: style: The function 'setRegularizationScaleFactor' is never used. [unusedFunction]
  inline void setRegularizationScaleFactor(float regularization_scale_factor)
^
localization/autoware_ndt_scan_matcher/include/autoware/ndt_scan_matcher/ndt_omp/multigrid_ndt_omp.h:307:0: style: The function 'setTransformationEpsilon' is never used. [unusedFunction]
  inline void setTransformationEpsilon(double epsilon) { params_.trans_epsilon = epsilon; }
^
localization/autoware_ndt_scan_matcher/include/autoware/ndt_scan_matcher/ndt_omp/multigrid_ndt_omp.h:312:0: style: The function 'getTransformationEpsilon' is never used. [unusedFunction]
  inline double getTransformationEpsilon() { return (params_.trans_epsilon); }
^
localization/autoware_ndt_scan_matcher/include/autoware/ndt_scan_matcher/ndt_omp/multigrid_ndt_omp.h:314:0: style: The function 'setMaximumIterations' is never used. [unusedFunction]
  inline void setMaximumIterations(int max_iterations)
^
localization/autoware_ndt_scan_matcher/include/autoware/ndt_scan_matcher/ndt_omp/multigrid_ndt_omp.h:320:0: style: The function 'getMaxIterations' is never used. [unusedFunction]
  inline int getMaxIterations() const { return params_.max_iterations; }
^
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
