### PR TITLE
fix(autoware_obstacle_stop_planner): fix cppcheck warnings

### DIFF
--- a/planning/autoware_obstacle_stop_planner/src/adaptive_cruise_control.cpp
+++ b/planning/autoware_obstacle_stop_planner/src/adaptive_cruise_control.cpp
@@ -111,16 +111,6 @@ double getDistanceFromTwoPoint(
   }
 }
 
-constexpr double sign(const double value)
-{
-  if (value > 0) {
-    return 1.0;
-  } else if (value < 0) {
-    return -1.0;
-  } else {
-    return 0.0;
-  }
-}
 }  // namespace
 
 namespace autoware::motion_planning
@@ -573,7 +563,7 @@ double AdaptiveCruiseController::calcUpperVelocity(
 }
 
 double AdaptiveCruiseController::calcThreshDistToForwardObstacle(
-  const double current_vel, const double obj_vel)
+  const double current_vel, const double obj_vel) const
 {
   const double current_vel_min = std::max(1.0, std::fabs(current_vel));
   const double obj_vel_min = std::max(0.0, obj_vel);
@@ -590,7 +580,7 @@ double AdaptiveCruiseController::calcThreshDistToForwardObstacle(
 }
 
 double AdaptiveCruiseController::calcBaseDistToForwardObstacle(
-  const double current_vel, const double obj_vel)
+  const double current_vel, const double obj_vel) const
 {
   const double obj_vel_min = std::max(0.0, obj_vel);
   const double minimum_distance = param_.min_dist_standard;

--- a/planning/autoware_obstacle_stop_planner/src/adaptive_cruise_control.hpp
+++ b/planning/autoware_obstacle_stop_planner/src/adaptive_cruise_control.hpp
@@ -203,8 +203,8 @@ private:
   double estimateRoughPointVelocity(double current_vel);
   bool isObstacleVelocityHigh(const double obj_vel);
   double calcUpperVelocity(const double dist_to_col, const double obj_vel, const double self_vel);
-  double calcThreshDistToForwardObstacle(const double current_vel, const double obj_vel);
-  double calcBaseDistToForwardObstacle(const double current_vel, const double obj_vel);
+  double calcThreshDistToForwardObstacle(const double current_vel, const double obj_vel) const;
+  double calcBaseDistToForwardObstacle(const double current_vel, const double obj_vel) const;
   double calcTargetVelocity_P(const double target_dist, const double current_dist) const;
   static double calcTargetVelocity_I(const double target_dist, const double current_dist);
   double calcTargetVelocity_D(const double target_dist, const double current_dist);

--- a/planning/autoware_obstacle_stop_planner/src/debug_marker.hpp
+++ b/planning/autoware_obstacle_stop_planner/src/debug_marker.hpp
@@ -77,7 +77,7 @@ public:
    * @brief get all the debug values as an std::array
    * @return array of all debug values
    */
-  std::array<double, static_cast<int>(TYPE::SIZE)> getValues() const { return values_; }
+  const std::array<double, static_cast<int>(TYPE::SIZE)> & getValues() const { return values_; }
   /**
    * @brief set the given type to the given value
    * @param [in] type TYPE of the value


### PR DESCRIPTION
## Description

Fixed the following cppcheck warnings
```
planning/autoware_obstacle_stop_planner/src/adaptive_cruise_control.hpp:206:10: style: inconclusive: Technically the member function 'autoware::motion_planning::AdaptiveCruiseController::calcThreshDistToForwardObstacle' can be const. [functionConst]
  double calcThreshDistToForwardObstacle(const double current_vel, const double obj_vel);
         ^
planning/autoware_obstacle_stop_planner/src/adaptive_cruise_control.cpp:575:34: note: Technically the member function 'autoware::motion_planning::AdaptiveCruiseController::calcThreshDistToForwardObstacle' can be const.
double AdaptiveCruiseController::calcThreshDistToForwardObstacle(
                                 ^
planning/autoware_obstacle_stop_planner/src/adaptive_cruise_control.hpp:206:10: note: Technically the member function 'autoware::motion_planning::AdaptiveCruiseController::calcThreshDistToForwardObstacle' can be const.
  double calcThreshDistToForwardObstacle(const double current_vel, const double obj_vel);
         ^
planning/autoware_obstacle_stop_planner/src/adaptive_cruise_control.hpp:207:10: style: inconclusive: Technically the member function 'autoware::motion_planning::AdaptiveCruiseController::calcBaseDistToForwardObstacle' can be const. [functionConst]
  double calcBaseDistToForwardObstacle(const double current_vel, const double obj_vel);
         ^
planning/autoware_obstacle_stop_planner/src/adaptive_cruise_control.cpp:592:34: note: Technically the member function 'autoware::motion_planning::AdaptiveCruiseController::calcBaseDistToForwardObstacle' can be const.
double AdaptiveCruiseController::calcBaseDistToForwardObstacle(
                                 ^
planning/autoware_obstacle_stop_planner/src/adaptive_cruise_control.hpp:207:10: note: Technically the member function 'autoware::motion_planning::AdaptiveCruiseController::calcBaseDistToForwardObstacle' can be const.
  double calcBaseDistToForwardObstacle(const double current_vel, const double obj_vel);
         ^
planning/autoware_obstacle_stop_planner/src/debug_marker.hpp:80:52: performance: Function 'getValues()' should return member 'values_' by const reference. [returnByReference]
  std::array<double, static_cast<int>(TYPE::SIZE)> getValues() const { return values_; }
                                                   ^
planning/autoware_obstacle_stop_planner/src/adaptive_cruise_control.cpp:114:0: style: The function 'sign' is never used. [unusedFunction]
constexpr double sign(const double value)
^
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
