### PR TITLE
fix(autoware_mpc_lateral_controller): fix variableScope

### DIFF
--- a/control/autoware_mpc_lateral_controller/src/mpc.cpp
+++ b/control/autoware_mpc_lateral_controller/src/mpc.cpp
@@ -511,7 +511,6 @@ MPCMatrix MPC::generateMPCMatrix(
 
     // update mpc matrix
     int idx_x_i = i * DIM_X;
-    int idx_x_i_prev = (i - 1) * DIM_X;
     int idx_u_i = i * DIM_U;
     int idx_y_i = i * DIM_Y;
     if (i == 0) {
@@ -519,6 +518,7 @@ MPCMatrix MPC::generateMPCMatrix(
       m.Bex.block(0, 0, DIM_X, DIM_U) = Bd;
       m.Wex.block(0, 0, DIM_X, 1) = Wd;
     } else {
+      int idx_x_i_prev = (i - 1) * DIM_X;
       m.Aex.block(idx_x_i, 0, DIM_X, DIM_X) = Ad * m.Aex.block(idx_x_i_prev, 0, DIM_X, DIM_X);
       for (int j = 0; j < i; ++j) {
         int idx_u_j = j * DIM_U;


### PR DESCRIPTION
## Description

Fixed the following cppcheck `variableScope` warning
```
control/autoware_mpc_lateral_controller/src/mpc.cpp:514:9: style: The scope of the variable 'idx_x_i_prev' can be reduced. [variableScope]
    int idx_x_i_prev = (i - 1) * DIM_X;
        ^
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
