### PR TITLE
feat(goal_planner): remove unnecessary member from ThreadSafeData

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/thread_data.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/thread_data.hpp
@@ -111,10 +111,6 @@ public:
     prev_data_ = PathDecisionState{};
   }
 
-  // main --> lane/freespace
-  DEFINE_SETTER_GETTER_WITH_MUTEX(PredictedObjects, static_target_objects)
-  DEFINE_SETTER_GETTER_WITH_MUTEX(PredictedObjects, dynamic_target_objects)
-
   // main --> lane
   DEFINE_SETTER_GETTER_WITH_MUTEX(PathDecisionState, prev_data)
 
@@ -125,8 +121,6 @@ public:
   // main <--> lane/freespace
   DEFINE_GETTER_WITH_MUTEX(std::shared_ptr<PullOverPath>, pull_over_path)
   DEFINE_GETTER_WITH_MUTEX(std::optional<rclcpp::Time>, last_path_update_time)
-  DEFINE_SETTER_GETTER_WITH_MUTEX(
-    utils::path_safety_checker::CollisionCheckDebugMap, collision_check)
 
 private:
   void set_pull_over_path_no_lock(const PullOverPath & path)
@@ -145,18 +139,11 @@ private:
   void set_no_lock(const std::vector<PullOverPath> & arg) { pull_over_path_candidates_ = arg; }
   void set_no_lock(const std::shared_ptr<PullOverPath> & arg) { set_pull_over_path_no_lock(arg); }
   void set_no_lock(const PullOverPath & arg) { set_pull_over_path_no_lock(arg); }
-  void set_no_lock(const utils::path_safety_checker::CollisionCheckDebugMap & arg)
-  {
-    collision_check_ = arg;
-  }
 
   std::shared_ptr<PullOverPath> pull_over_path_{nullptr};
   std::vector<PullOverPath> pull_over_path_candidates_;
   std::optional<rclcpp::Time> last_path_update_time_;
   std::optional<Pose> closest_start_pose_{};
-  utils::path_safety_checker::CollisionCheckDebugMap collision_check_{};
-  PredictedObjects static_target_objects_{};
-  PredictedObjects dynamic_target_objects_{};
   PathDecisionState prev_data_{};
 
   std::recursive_mutex & mutex_;

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/goal_planner_module.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/goal_planner_module.cpp
@@ -395,8 +395,8 @@ void GoalPlannerModule::onFreespaceParkingTimer()
   }
   // end of critical section
   if (
-    !local_planner_data || !current_status_opt || !parameters_opt || !vehicle_footprint_opt ||
-    !goal_candidates_opt) {
+    !local_planner_data || !current_status_opt || !occupancy_grid_map || !parameters_opt ||
+    !vehicle_footprint_opt || !goal_candidates_opt) {
     RCLCPP_ERROR(
       getLogger(),
       "failed to get valid planner_data/current_status/parameters in "
@@ -434,20 +434,43 @@ void GoalPlannerModule::onFreespaceParkingTimer()
     return;
   }
 
+  const double vehicle_width = planner_data_->parameters.vehicle_width;
+  const bool left_side_parking = parameters.parking_policy == ParkingPolicy::LEFT_SIDE;
+  const auto pull_over_lanes = goal_planner_utils::getPullOverLanes(
+    *(local_planner_data->route_handler), left_side_parking, parameters.backward_goal_search_length,
+    parameters.forward_goal_search_length);
+  const auto objects_extraction_polygon = goal_planner_utils::generateObjectExtractionPolygon(
+    pull_over_lanes, left_side_parking, parameters.detection_bound_offset,
+    parameters.margin_from_boundary + parameters.max_lateral_offset + vehicle_width);
+
+  PredictedObjects dynamic_target_objects{};
+  for (const auto & object : local_planner_data->dynamic_object->objects) {
+    const auto object_polygon = universe_utils::toPolygon2d(object);
+    if (
+      objects_extraction_polygon.has_value() &&
+      boost::geometry::intersects(object_polygon, objects_extraction_polygon.value())) {
+      dynamic_target_objects.objects.push_back(object);
+    }
+  }
+  const auto static_target_objects = utils::path_safety_checker::filterObjectsByVelocity(
+    dynamic_target_objects, parameters.th_moving_object_velocity);
+
   const bool is_new_costmap =
     (clock_->now() - local_planner_data->costmap->header.stamp).seconds() < 1.0;
   constexpr double path_update_duration = 1.0;
   if (
     isStuck(
-      thread_safe_data_.get_static_target_objects(), thread_safe_data_.get_dynamic_target_objects(),
-      local_planner_data, occupancy_grid_map, parameters) &&
+      static_target_objects, dynamic_target_objects, local_planner_data, occupancy_grid_map,
+      parameters) &&
     is_new_costmap &&
     needPathUpdate(
       local_planner_data->self_odometry->pose.pose, path_update_duration, modified_goal_opt,
       parameters)) {
     auto goal_searcher = std::make_shared<GoalSearcher>(parameters, vehicle_footprint);
 
-    planFreespacePath(local_planner_data, goal_searcher, goal_candidates, occupancy_grid_map);
+    planFreespacePath(
+      local_planner_data, goal_searcher, goal_candidates, occupancy_grid_map,
+      static_target_objects);
   }
 }
 
@@ -503,10 +526,6 @@ void GoalPlannerModule::updateData()
   }
   const auto static_target_objects = utils::path_safety_checker::filterObjectsByVelocity(
     dynamic_target_objects, p->th_moving_object_velocity);
-
-  // these objects are used for path collision check not for safety check
-  thread_safe_data_.set_static_target_objects(static_target_objects);
-  thread_safe_data_.set_dynamic_target_objects(dynamic_target_objects);
 
   // update goal searcher and generate goal candidates
   if (goal_candidates_.empty()) {
@@ -583,9 +602,10 @@ void GoalPlannerModule::updateData()
 
   // save "old" state
   const auto prev_decision_state = path_decision_controller_.get_current_state();
-  const bool is_current_safe = isSafePath(
+  const auto [is_current_safe, collision_check_map] = isSafePath(
     planner_data_, found_pull_over_path, pull_over_path_recv, prev_decision_state, *parameters_,
     ego_predicted_path_params_, objects_filtering_params_, safety_check_params_);
+  debug_data_.collision_check = collision_check_map;
   // update to latest state
   path_decision_controller_.transit_state(
     found_pull_over_path, clock_->now(), static_target_objects, dynamic_target_objects,
@@ -768,12 +788,11 @@ double GoalPlannerModule::calcModuleRequestLength() const
 bool GoalPlannerModule::planFreespacePath(
   std::shared_ptr<const PlannerData> planner_data,
   const std::shared_ptr<GoalSearcherBase> goal_searcher, const GoalCandidates & goal_candidates_arg,
-  const std::shared_ptr<OccupancyGridBasedCollisionDetector> occupancy_grid_map)
+  const std::shared_ptr<OccupancyGridBasedCollisionDetector> occupancy_grid_map,
+  const PredictedObjects & static_target_objects)
 {
   auto goal_candidates = goal_candidates_arg;
-  goal_searcher->update(
-    goal_candidates, occupancy_grid_map, planner_data,
-    thread_safe_data_.get_static_target_objects());
+  goal_searcher->update(goal_candidates, occupancy_grid_map, planner_data, static_target_objects);
   debug_data_.freespace_planner.num_goal_candidates = goal_candidates.size();
   debug_data_.freespace_planner.is_planning = true;
 
@@ -2201,7 +2220,7 @@ static std::vector<utils::path_safety_checker::ExtendedPredictedObject> filterOb
   return refined_filtered_objects;
 }
 
-bool GoalPlannerModule::isSafePath(
+std::pair<bool, utils::path_safety_checker::CollisionCheckDebugMap> GoalPlannerModule::isSafePath(
   const std::shared_ptr<const PlannerData> planner_data, const bool found_pull_over_path,
   const std::optional<PullOverPath> & pull_over_path_opt, const PathDecisionState & prev_data,
   const GoalPlannerParameters & parameters,
@@ -2212,9 +2231,10 @@ bool GoalPlannerModule::isSafePath(
   using autoware::behavior_path_planner::utils::path_safety_checker::createPredictedPath;
   using autoware::behavior_path_planner::utils::path_safety_checker::
     filterPredictedPathAfterTargetPose;
+  CollisionCheckDebugMap collision_check{};
 
   if (!found_pull_over_path || !pull_over_path_opt) {
-    return false;
+    return {false, collision_check};
   }
   const auto & pull_over_path = pull_over_path_opt.value();
   const auto & current_pull_over_path = pull_over_path.getCurrentPath();
@@ -2299,7 +2319,6 @@ bool GoalPlannerModule::isSafePath(
   const double hysteresis_factor =
     prev_data.is_stable_safe ? 1.0 : parameters.hysteresis_factor_expand_rate;
 
-  CollisionCheckDebugMap collision_check{};
   const bool current_is_safe = std::invoke([&]() {
     if (parameters.safety_check_params.method == "RSS") {
       return autoware::behavior_path_planner::utils::path_safety_checker::checkSafetyWithRSS(
@@ -2319,7 +2338,6 @@ bool GoalPlannerModule::isSafePath(
       parameters.safety_check_params.method.c_str());
     throw std::domain_error("[pull_over] invalid safety check method");
   });
-  thread_safe_data_.set_collision_check(collision_check);
 
   /*
    *                      ==== is_safe
@@ -2334,7 +2352,7 @@ bool GoalPlannerModule::isSafePath(
    *     |  |    |   |       |           |   |  |
    *   0 =========================-------==========-- t
    */
-  return current_is_safe;
+  return {current_is_safe, collision_check};
 }
 
 void GoalPlannerModule::setDebugData(const PullOverContextData & context_data)
@@ -2451,7 +2469,6 @@ void GoalPlannerModule::setDebugData(const PullOverContextData & context_data)
     }
   }
 
-  auto collision_check = thread_safe_data_.get_collision_check();
   // safety check
   if (parameters_->safety_check_params.enable_safety_check) {
     if (goal_planner_data_.ego_predicted_path.size() > 0) {
@@ -2465,6 +2482,7 @@ void GoalPlannerModule::setDebugData(const PullOverContextData & context_data)
         goal_planner_data_.filtered_objects, "filtered_objects", 0, 0.0, 0.5, 0.9));
     }
 
+    auto collision_check = debug_data_.collision_check;
     if (parameters_->safety_check_params.method == "RSS") {
       add(showSafetyCheckInfo(collision_check, "object_debug_info"));
     }


### PR DESCRIPTION
## Description

remove static_target_objects and dynamic_target_objects from ThreadSafeData because there is no need to share

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

- https://evaluation.tier4.jp/evaluation/reports/4afa22b2-fbc1-50f0-801c-b2064c3b77b0?project_id=prd_jt

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
