### PR TITLE
fix(autoware_costmap_generator): fix clang-diagnostic-unused-private-field

### DIFF
--- a/planning/autoware_costmap_generator/include/autoware/costmap_generator/utils/points_to_costmap.hpp
+++ b/planning/autoware_costmap_generator/include/autoware/costmap_generator/utils/points_to_costmap.hpp
@@ -79,8 +79,6 @@ private:
   double grid_resolution_;
   double grid_position_x_;
   double grid_position_y_;
-  double y_cell_size_;
-  double x_cell_size_;
 
   /// \brief initialize gridmap parameters
   /// \param[in] gridmap: gridmap object to be initialized


### PR DESCRIPTION
## Description
This is a fix based on clang-tidy `clang-diagnostic-unused-private-field` error.

```
/home/emb4/autoware/autoware/src/universe/autoware.universe/planning/autoware_costmap_generator/include/autoware/costmap_generator/utils/points_to_costmap.hpp:82:10: error: private field 'y_cell_size_' is not used [clang-diagnostic-unused-private-field]
  double y_cell_size_;
         ^
/home/emb4/autoware/autoware/src/universe/autoware.universe/planning/autoware_costmap_generator/include/autoware/costmap_generator/utils/points_to_costmap.hpp:83:10: error: private field 'x_cell_size_' is not used [clang-diagnostic-unused-private-field]
  double x_cell_size_;
         ^
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
