### PR TITLE
fix(autoware_freespace_planning_algorithms): fix clang-diagnostic-unused-private-field

### DIFF
--- a/planning/autoware_freespace_planning_algorithms/include/autoware/freespace_planning_algorithms/rrtstar.hpp
+++ b/planning/autoware_freespace_planning_algorithms/include/autoware/freespace_planning_algorithms/rrtstar.hpp
@@ -68,8 +68,6 @@ private:
 
   // algorithm specific param
   const RRTStarParam rrtstar_param_;
-
-  const VehicleShape original_vehicle_shape_;
 };
 
 }  // namespace autoware::freespace_planning_algorithms

--- a/planning/autoware_freespace_planning_algorithms/src/rrtstar.cpp
+++ b/planning/autoware_freespace_planning_algorithms/src/rrtstar.cpp
@@ -34,7 +34,6 @@ RRTStar::RRTStar(
                             original_vehicle_shape.base_length, original_vehicle_shape.max_steering,
                             original_vehicle_shape.base2back + rrtstar_param.margin)),
   rrtstar_param_(rrtstar_param),
-  original_vehicle_shape_(original_vehicle_shape)
 {
   if (rrtstar_param_.margin <= 0) {
     throw std::invalid_argument("rrt's collision margin must be greater than 0");

--- a/planning/autoware_freespace_planning_algorithms/src/rrtstar.cpp
+++ b/planning/autoware_freespace_planning_algorithms/src/rrtstar.cpp
@@ -33,7 +33,7 @@ RRTStar::RRTStar(
                             original_vehicle_shape.width + 2 * rrtstar_param.margin,
                             original_vehicle_shape.base_length, original_vehicle_shape.max_steering,
                             original_vehicle_shape.base2back + rrtstar_param.margin)),
-  rrtstar_param_(rrtstar_param),
+  rrtstar_param_(rrtstar_param)
 {
   if (rrtstar_param_.margin <= 0) {
     throw std::invalid_argument("rrt's collision margin must be greater than 0");


### PR DESCRIPTION
## Description
This is a fix based on clang-tidy `clang-diagnostic-unused-private-field` error.

```
/home/emb4/autoware/autoware/src/universe/autoware.universe/planning/autoware_freespace_planning_algorithms/include/autoware/freespace_planning_algorithms/rrtstar.hpp:72:22: error: private field 'original_vehicle_shape_' is not used [clang-diagnostic-unused-private-field]
  const VehicleShape original_vehicle_shape_;
                     ^
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
