### PR TITLE
fix(autoware_surround_obstacle_checker): fix clang-diagnostic-unused-private-field

### DIFF
--- a/planning/autoware_surround_obstacle_checker/src/debug_marker.cpp
+++ b/planning/autoware_surround_obstacle_checker/src/debug_marker.cpp
@@ -60,13 +60,12 @@ using autoware::universe_utils::createMarkerScale;
 using autoware::universe_utils::createPoint;
 
 SurroundObstacleCheckerDebugNode::SurroundObstacleCheckerDebugNode(
-  const autoware::vehicle_info_utils::VehicleInfo & vehicle_info, const double base_link2front,
-  const std::string & object_label, const double & surround_check_front_distance,
-  const double & surround_check_side_distance, const double & surround_check_back_distance,
-  const double & surround_check_hysteresis_distance, const geometry_msgs::msg::Pose & self_pose,
-  const rclcpp::Clock::SharedPtr clock, rclcpp::Node & node)
+  const autoware::vehicle_info_utils::VehicleInfo & vehicle_info, const std::string & object_label,
+  const double & surround_check_front_distance, const double & surround_check_side_distance,
+  const double & surround_check_back_distance, const double & surround_check_hysteresis_distance,
+  const geometry_msgs::msg::Pose & self_pose, const rclcpp::Clock::SharedPtr clock,
+  rclcpp::Node & node)
 : vehicle_info_(vehicle_info),
-  base_link2front_(base_link2front),
   object_label_(object_label),
   surround_check_front_distance_(surround_check_front_distance),
   surround_check_side_distance_(surround_check_side_distance),

--- a/planning/autoware_surround_obstacle_checker/src/debug_marker.cpp
+++ b/planning/autoware_surround_obstacle_checker/src/debug_marker.cpp
@@ -60,11 +60,11 @@ using autoware::universe_utils::createMarkerScale;
 using autoware::universe_utils::createPoint;
 
 SurroundObstacleCheckerDebugNode::SurroundObstacleCheckerDebugNode(
-  const autoware::vehicle_info_utils::VehicleInfo & vehicle_info,
-  const std::string & object_label, const double & surround_check_front_distance,
-  const double & surround_check_side_distance, const double & surround_check_back_distance,
-  const double & surround_check_hysteresis_distance, const geometry_msgs::msg::Pose & self_pose,
-  const rclcpp::Clock::SharedPtr clock, rclcpp::Node & node)
+  const autoware::vehicle_info_utils::VehicleInfo & vehicle_info, const std::string & object_label,
+  const double & surround_check_front_distance, const double & surround_check_side_distance,
+  const double & surround_check_back_distance, const double & surround_check_hysteresis_distance,
+  const geometry_msgs::msg::Pose & self_pose, const rclcpp::Clock::SharedPtr clock,
+  rclcpp::Node & node)
 : vehicle_info_(vehicle_info),
   object_label_(object_label),
   surround_check_front_distance_(surround_check_front_distance),

--- a/planning/autoware_surround_obstacle_checker/src/debug_marker.cpp
+++ b/planning/autoware_surround_obstacle_checker/src/debug_marker.cpp
@@ -60,11 +60,11 @@ using autoware::universe_utils::createMarkerScale;
 using autoware::universe_utils::createPoint;
 
 SurroundObstacleCheckerDebugNode::SurroundObstacleCheckerDebugNode(
-  const autoware::vehicle_info_utils::VehicleInfo & vehicle_info, const std::string & object_label,
-  const double & surround_check_front_distance, const double & surround_check_side_distance,
-  const double & surround_check_back_distance, const double & surround_check_hysteresis_distance,
-  const geometry_msgs::msg::Pose & self_pose, const rclcpp::Clock::SharedPtr clock,
-  rclcpp::Node & node)
+  const autoware::vehicle_info_utils::VehicleInfo & vehicle_info,
+  const std::string & object_label, const double & surround_check_front_distance,
+  const double & surround_check_side_distance, const double & surround_check_back_distance,
+  const double & surround_check_hysteresis_distance, const geometry_msgs::msg::Pose & self_pose,
+  const rclcpp::Clock::SharedPtr clock, rclcpp::Node & node)
 : vehicle_info_(vehicle_info),
   object_label_(object_label),
   surround_check_front_distance_(surround_check_front_distance),

--- a/planning/autoware_surround_obstacle_checker/src/debug_marker.hpp
+++ b/planning/autoware_surround_obstacle_checker/src/debug_marker.hpp
@@ -77,7 +77,6 @@ private:
   rclcpp::Publisher<PolygonStamped>::SharedPtr vehicle_footprint_recover_offset_pub_;
 
   autoware::vehicle_info_utils::VehicleInfo vehicle_info_;
-  double base_link2front_;
   std::string object_label_;
   double surround_check_front_distance_;
   double surround_check_side_distance_;

--- a/planning/autoware_surround_obstacle_checker/src/debug_marker.hpp
+++ b/planning/autoware_surround_obstacle_checker/src/debug_marker.hpp
@@ -56,7 +56,7 @@ class SurroundObstacleCheckerDebugNode
 {
 public:
   explicit SurroundObstacleCheckerDebugNode(
-    const autoware::vehicle_info_utils::VehicleInfo & vehicle_info, const double base_link2front,
+    const autoware::vehicle_info_utils::VehicleInfo & vehicle_info,
     const std::string & object_label, const double & surround_check_front_distance,
     const double & surround_check_side_distance, const double & surround_check_back_distance,
     const double & surround_check_hysteresis_distance, const geometry_msgs::msg::Pose & self_pose,

--- a/planning/autoware_surround_obstacle_checker/src/node.cpp
+++ b/planning/autoware_surround_obstacle_checker/src/node.cpp
@@ -126,9 +126,9 @@ SurroundObstacleCheckerNode::SurroundObstacleCheckerNode(const rclcpp::NodeOptio
     const auto param = param_listener_->get_params();
     const auto check_distances = getCheckDistances(param.debug_footprint_label);
     debug_ptr_ = std::make_shared<SurroundObstacleCheckerDebugNode>(
-      vehicle_info_, param.debug_footprint_label, check_distances.at(0), check_distances.at(1),
-      check_distances.at(2), param.surround_check_hysteresis_distance, odometry_ptr_->pose.pose,
-      this->get_clock(), *this);
+      vehicle_info_, param.debug_footprint_label,
+      check_distances.at(0), check_distances.at(1), check_distances.at(2),
+      param.surround_check_hysteresis_distance, odometry_ptr_->pose.pose, this->get_clock(), *this);
   }
 }
 
@@ -411,8 +411,8 @@ std::optional<geometry_msgs::msg::TransformStamped> SurroundObstacleCheckerNode:
 
 auto SurroundObstacleCheckerNode::isStopRequired(
   const bool is_obstacle_found, const bool is_vehicle_stopped, const State & state,
-  const std::optional<rclcpp::Time> & last_obstacle_found_time, const double time_threshold) const
-  -> std::pair<bool, std::optional<rclcpp::Time>>
+  const std::optional<rclcpp::Time> & last_obstacle_found_time,
+  const double time_threshold) const -> std::pair<bool, std::optional<rclcpp::Time>>
 {
   if (!is_vehicle_stopped) {
     return std::make_pair(false, std::nullopt);

--- a/planning/autoware_surround_obstacle_checker/src/node.cpp
+++ b/planning/autoware_surround_obstacle_checker/src/node.cpp
@@ -411,8 +411,8 @@ std::optional<geometry_msgs::msg::TransformStamped> SurroundObstacleCheckerNode:
 
 auto SurroundObstacleCheckerNode::isStopRequired(
   const bool is_obstacle_found, const bool is_vehicle_stopped, const State & state,
-  const std::optional<rclcpp::Time> & last_obstacle_found_time, const double time_threshold) const
-  -> std::pair<bool, std::optional<rclcpp::Time>>
+  const std::optional<rclcpp::Time> & last_obstacle_found_time,
+  const double time_threshold) const -> std::pair<bool, std::optional<rclcpp::Time>>
 {
   if (!is_vehicle_stopped) {
     return std::make_pair(false, std::nullopt);

--- a/planning/autoware_surround_obstacle_checker/src/node.cpp
+++ b/planning/autoware_surround_obstacle_checker/src/node.cpp
@@ -126,9 +126,9 @@ SurroundObstacleCheckerNode::SurroundObstacleCheckerNode(const rclcpp::NodeOptio
     const auto param = param_listener_->get_params();
     const auto check_distances = getCheckDistances(param.debug_footprint_label);
     debug_ptr_ = std::make_shared<SurroundObstacleCheckerDebugNode>(
-      vehicle_info_, vehicle_info_.max_longitudinal_offset_m, param.debug_footprint_label,
-      check_distances.at(0), check_distances.at(1), check_distances.at(2),
-      param.surround_check_hysteresis_distance, odometry_ptr_->pose.pose, this->get_clock(), *this);
+      vehicle_info_, param.debug_footprint_label, check_distances.at(0), check_distances.at(1),
+      check_distances.at(2), param.surround_check_hysteresis_distance, odometry_ptr_->pose.pose,
+      this->get_clock(), *this);
   }
 }
 
@@ -411,8 +411,8 @@ std::optional<geometry_msgs::msg::TransformStamped> SurroundObstacleCheckerNode:
 
 auto SurroundObstacleCheckerNode::isStopRequired(
   const bool is_obstacle_found, const bool is_vehicle_stopped, const State & state,
-  const std::optional<rclcpp::Time> & last_obstacle_found_time,
-  const double time_threshold) const -> std::pair<bool, std::optional<rclcpp::Time>>
+  const std::optional<rclcpp::Time> & last_obstacle_found_time, const double time_threshold) const
+  -> std::pair<bool, std::optional<rclcpp::Time>>
 {
   if (!is_vehicle_stopped) {
     return std::make_pair(false, std::nullopt);

--- a/planning/autoware_surround_obstacle_checker/src/node.cpp
+++ b/planning/autoware_surround_obstacle_checker/src/node.cpp
@@ -126,9 +126,9 @@ SurroundObstacleCheckerNode::SurroundObstacleCheckerNode(const rclcpp::NodeOptio
     const auto param = param_listener_->get_params();
     const auto check_distances = getCheckDistances(param.debug_footprint_label);
     debug_ptr_ = std::make_shared<SurroundObstacleCheckerDebugNode>(
-      vehicle_info_, param.debug_footprint_label,
-      check_distances.at(0), check_distances.at(1), check_distances.at(2),
-      param.surround_check_hysteresis_distance, odometry_ptr_->pose.pose, this->get_clock(), *this);
+      vehicle_info_, param.debug_footprint_label, check_distances.at(0), check_distances.at(1),
+      check_distances.at(2), param.surround_check_hysteresis_distance, odometry_ptr_->pose.pose,
+      this->get_clock(), *this);
   }
 }
 
@@ -411,8 +411,8 @@ std::optional<geometry_msgs::msg::TransformStamped> SurroundObstacleCheckerNode:
 
 auto SurroundObstacleCheckerNode::isStopRequired(
   const bool is_obstacle_found, const bool is_vehicle_stopped, const State & state,
-  const std::optional<rclcpp::Time> & last_obstacle_found_time,
-  const double time_threshold) const -> std::pair<bool, std::optional<rclcpp::Time>>
+  const std::optional<rclcpp::Time> & last_obstacle_found_time, const double time_threshold) const
+  -> std::pair<bool, std::optional<rclcpp::Time>>
 {
   if (!is_vehicle_stopped) {
     return std::make_pair(false, std::nullopt);


### PR DESCRIPTION
## Description
This is a fix based on clang-tidy `clang-diagnostic-unused-private-field` error.

```
/home/emb4/autoware/autoware/src/universe/autoware.universe/planning/autoware_surround_obstacle_checker/src/debug_marker.hpp:80:10: error: private field 'base_link2front_' is not used [clang-diagnostic-unused-private-field]
  double base_link2front_;
         ^
```



## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
