### PR TITLE
fix(autoware_behavior_path_lane_change_module): fix clang-diagnostic-error

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/calculation.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/calculation.cpp
@@ -354,8 +354,10 @@ std::vector<double> calc_lon_acceleration_samples(
   const auto goal_pose = common_data_ptr->route_handler_ptr->getGoalPose();
   const auto sampling_num = common_data_ptr->lc_param_ptr->longitudinal_acc_sampling_num;
 
-  const auto [min_accel, max_accel] =
+  const auto min_max_accel =
     calc_min_max_acceleration(common_data_ptr, max_path_velocity, prepare_duration);
+  const auto &min_accel = min_max_accel.first;
+  const auto &max_accel = min_max_accel.second;
 
   const auto is_sampling_required = std::invoke([&]() -> bool {
     if (max_accel < 0.0 || transient_data.is_ego_stuck) return true;

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/calculation.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/calculation.cpp
@@ -356,8 +356,8 @@ std::vector<double> calc_lon_acceleration_samples(
 
   const auto min_max_accel =
     calc_min_max_acceleration(common_data_ptr, max_path_velocity, prepare_duration);
-  const auto &min_accel = min_max_accel.first;
-  const auto &max_accel = min_max_accel.second;
+  const auto & min_accel = min_max_accel.first;
+  const auto & max_accel = min_max_accel.second;
 
   const auto is_sampling_required = std::invoke([&]() -> bool {
     if (max_accel < 0.0 || transient_data.is_ego_stuck) return true;


### PR DESCRIPTION
## Description
This is a fix based on clang-tidy `clang-diagnostic-error` error.

```
/home/emb4/autoware/autoware/src/universe/autoware.universe/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/calculation.cpp:361:9: error: reference to local binding 'max_accel' declared in enclosing function 'autoware::behavior_path_planner::utils::lane_change::calculation::calc_lon_acceleration_samples' [clang-diagnostic-error]
    if (max_accel < 0.0 || transient_data.is_ego_stuck) return true;
        ^
```
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
