### PR TITLE
fix(autoware_behavior_velocity_intersection_module): fix clang-diagnostic-unused-lambda-capture

### DIFF
--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/manager.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/manager.cpp
@@ -360,7 +360,7 @@ IntersectionModuleManager::getModuleExpiredFunction(
   const auto lane_set = planning_utils::getLaneletsOnPath(
     path, planner_data_->route_handler_->getLaneletMapPtr(), planner_data_->current_odometry->pose);
 
-  return [this, lane_set](const std::shared_ptr<SceneModuleInterface> & scene_module) {
+  return [lane_set](const std::shared_ptr<SceneModuleInterface> & scene_module) {
     const auto intersection_module = std::dynamic_pointer_cast<IntersectionModule>(scene_module);
     const auto & associative_ids = intersection_module->getAssociativeIds();
     for (const auto & lane : lane_set) {
@@ -555,7 +555,7 @@ MergeFromPrivateModuleManager::getModuleExpiredFunction(
   const auto lane_set = planning_utils::getLaneletsOnPath(
     path, planner_data_->route_handler_->getLaneletMapPtr(), planner_data_->current_odometry->pose);
 
-  return [this, lane_set](const std::shared_ptr<SceneModuleInterface> & scene_module) {
+  return [lane_set](const std::shared_ptr<SceneModuleInterface> & scene_module) {
     const auto merge_from_private_module =
       std::dynamic_pointer_cast<MergeFromPrivateRoadModule>(scene_module);
     const auto & associative_ids = merge_from_private_module->getAssociativeIds();


### PR DESCRIPTION
## Description
This is a fix based on clang-tidy `clang-diagnostic-unused-lambda-capture` error.

```
/home/emb4/autoware/autoware/src/universe/autoware.universe/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/manager.cpp:363:11: error: lambda capture 'this' is not used [clang-diagnostic-unused-lambda-capture]
  return [this, lane_set](const std::shared_ptr<SceneModuleInterface> & scene_module) {
          ^~~~~
/home/emb4/autoware/autoware/src/universe/autoware.universe/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/manager.cpp:558:11: error: lambda capture 'this' is not used [clang-diagnostic-unused-lambda-capture]
  return [this, lane_set](const std::shared_ptr<SceneModuleInterface> & scene_module) {
          ^~~~~
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
