### PR TITLE
fix(autoware_behavior_velocity_intersection_module): fix clang-diagnostic-unused-parameter

### DIFF
--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_intersection.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_intersection.cpp
@@ -490,8 +490,10 @@ VisitorSwitch(Ts...) -> VisitorSwitch<Ts...>;
 
 template <typename T>
 void prepareRTCByDecisionResult(
-  const T & result, const tier4_planning_msgs::msg::PathWithLaneId & path, bool * default_safety,
-  double * default_distance, bool * occlusion_safety, double * occlusion_distance)
+  [[maybe_unused]] const T & result,
+  [[maybe_unused]] const tier4_planning_msgs::msg::PathWithLaneId & path,
+  [[maybe_unused]] bool * default_safety, [[maybe_unused]] double * default_distance,
+  [[maybe_unused]] bool * occlusion_safety, [[maybe_unused]] double * occlusion_distance)
 {
   static_assert("Unsupported type passed to prepareRTCByDecisionResult");
   return;
@@ -704,10 +706,14 @@ void IntersectionModule::prepareRTCStatus(
 
 template <typename T>
 void reactRTCApprovalByDecisionResult(
-  const bool rtc_default_approved, const bool rtc_occlusion_approved, const T & decision_result,
-  const IntersectionModule::PlannerParam & planner_param, const double baselink2front,
-  tier4_planning_msgs::msg::PathWithLaneId * path, StopReason * stop_reason,
-  VelocityFactorInterface * velocity_factor, IntersectionModule::DebugData * debug_data)
+  [[maybe_unused]] const bool rtc_default_approved,
+  [[maybe_unused]] const bool rtc_occlusion_approved, [[maybe_unused]] const T & decision_result,
+  [[maybe_unused]] const IntersectionModule::PlannerParam & planner_param,
+  [[maybe_unused]] const double baselink2front,
+  [[maybe_unused]] tier4_planning_msgs::msg::PathWithLaneId * path,
+  [[maybe_unused]] StopReason * stop_reason,
+  [[maybe_unused]] VelocityFactorInterface * velocity_factor,
+  [[maybe_unused]] IntersectionModule::DebugData * debug_data)
 {
   static_assert("Unsupported type passed to reactRTCByDecisionResult");
   return;


### PR DESCRIPTION
## Description
This is a fix based on clang-tidy `clang-diagnostic-unused-parameter` error.

```
/home/emb4/autoware/autoware/src/universe/autoware.universe/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_intersection.cpp:493:13: error: unused parameter 'result' [clang-diagnostic-unused-parameter]
  const T & result, const tier4_planning_msgs::msg::PathWithLaneId & path, bool * default_safety,
            ^
/home/emb4/autoware/autoware/src/universe/autoware.universe/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_intersection.cpp:493:70: error: unused parameter 'path' [clang-diagnostic-unused-parameter]
  const T & result, const tier4_planning_msgs::msg::PathWithLaneId & path, bool * default_safety,
                                                                     ^
/home/emb4/autoware/autoware/src/universe/autoware.universe/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_intersection.cpp:493:83: error: unused parameter 'default_safety' [clang-diagnostic-unused-parameter]
  const T & result, const tier4_planning_msgs::msg::PathWithLaneId & path, bool * default_safety,
                                                                                  ^
/home/emb4/autoware/autoware/src/universe/autoware.universe/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_intersection.cpp:494:12: error: unused parameter 'default_distance' [clang-diagnostic-unused-parameter]
  double * default_distance, bool * occlusion_safety, double * occlusion_distance)
           ^
/home/emb4/autoware/autoware/src/universe/autoware.universe/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_intersection.cpp:494:37: error: unused parameter 'occlusion_safety' [clang-diagnostic-unused-parameter]
  double * default_distance, bool * occlusion_safety, double * occlusion_distance)
                                    ^
/home/emb4/autoware/autoware/src/universe/autoware.universe/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_intersection.cpp:494:64: error: unused parameter 'occlusion_distance' [clang-diagnostic-unused-parameter]
  double * default_distance, bool * occlusion_safety, double * occlusion_distance)
                                                               ^
/home/emb4/autoware/autoware/src/universe/autoware.universe/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_intersection.cpp:707:14: error: unused parameter 'rtc_default_approved' [clang-diagnostic-unused-parameter]
  const bool rtc_default_approved, const bool rtc_occlusion_approved, const T & decision_result,
             ^
/home/emb4/autoware/autoware/src/universe/autoware.universe/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_intersection.cpp:707:47: error: unused parameter 'rtc_occlusion_approved' [clang-diagnostic-unused-parameter]
  const bool rtc_default_approved, const bool rtc_occlusion_approved, const T & decision_result,
                                              ^
/home/emb4/autoware/autoware/src/universe/autoware.universe/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_intersection.cpp:707:81: error: unused parameter 'decision_result' [clang-diagnostic-unused-parameter]
  const bool rtc_default_approved, const bool rtc_occlusion_approved, const T & decision_result,
                                                                                ^
/home/emb4/autoware/autoware/src/universe/autoware.universe/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_intersection.cpp:708:44: error: unused parameter 'planner_param' [clang-diagnostic-unused-parameter]
  const IntersectionModule::PlannerParam & planner_param, const double baselink2front,
                                           ^
/home/emb4/autoware/autoware/src/universe/autoware.universe/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_intersection.cpp:708:72: error: unused parameter 'baselink2front' [clang-diagnostic-unused-parameter]
  const IntersectionModule::PlannerParam & planner_param, const double baselink2front,
                                                                       ^
/home/emb4/autoware/autoware/src/universe/autoware.universe/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_intersection.cpp:709:46: error: unused parameter 'path' [clang-diagnostic-unused-parameter]
  tier4_planning_msgs::msg::PathWithLaneId * path, StopReason * stop_reason,
                                             ^
/home/emb4/autoware/autoware/src/universe/autoware.universe/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_intersection.cpp:709:65: error: unused parameter 'stop_reason' [clang-diagnostic-unused-parameter]
  tier4_planning_msgs::msg::PathWithLaneId * path, StopReason * stop_reason,
                                                                ^
/home/emb4/autoware/autoware/src/universe/autoware.universe/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_intersection.cpp:710:29: error: unused parameter 'velocity_factor' [clang-diagnostic-unused-parameter]
  VelocityFactorInterface * velocity_factor, IntersectionModule::DebugData * debug_data)
                            ^
/home/emb4/autoware/autoware/src/universe/autoware.universe/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_intersection.cpp:710:78: error: unused parameter 'debug_data' [clang-diagnostic-unused-parameter]
  VelocityFactorInterface * velocity_factor, IntersectionModule::DebugData * debug_data)
                                                                             ^
```
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
