### PR TITLE
fix(autoware_behavior_velocity_planner): fix clang-diagnostic-format-security

### DIFF
--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/src/node.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/src/node.cpp
@@ -233,7 +233,7 @@ bool BehaviorVelocityPlannerNode::processData(rclcpp::Clock clock)
   bool is_ready = true;
   const auto & logData = [&clock, this](const std::string & data_type) {
     std::string msg = "Waiting for " + data_type + " data";
-    RCLCPP_INFO_THROTTLE(get_logger(), clock, logger_throttle_interval, msg.c_str());
+    RCLCPP_INFO_THROTTLE(get_logger(), clock, logger_throttle_interval, "%s", msg.c_str());
   };
 
   const auto & getData = [&logData](auto & dest, auto & sub, const std::string & data_type = "") {


### PR DESCRIPTION
## Description
This is a fix based on clang-tidy `clang-diagnostic-format-security` error.
```
/home/emb4/autoware/autoware/src/universe/autoware.universe/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/src/node.cpp:236:73: error: format string is not a string literal (potentially insecure) [clang-diagnostic-format-security]
    RCLCPP_INFO_THROTTLE(get_logger(), clock, logger_throttle_interval, msg.c_str());
                                                                        ^
/opt/ros/humble/include/rclcpp/rclcpp/logging.hpp:671:7: note: expanded from macro 'RCLCPP_INFO_THROTTLE'
      __VA_ARGS__); \
      ^~~~~~~~~~~
/opt/ros/humble/include/rcutils/rcutils/logging_macros.h:680:5: note: expanded from macro 'RCUTILS_LOG_INFO_THROTTLE_NAMED'
    __VA_ARGS__)
    ^~~~~~~~~~~
/opt/ros/humble/include/rcutils/rcutils/logging_macros.h:79:64: note: expanded from macro 'RCUTILS_LOG_COND_NAMED'
      rcutils_log(&__rcutils_logging_location, severity, name, __VA_ARGS__); \
                                                               ^~~~~~~~~~~
/home/emb4/autoware/autoware/src/universe/autoware.universe/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/src/node.cpp:236:73: note: treat the string as an argument to avoid this
    RCLCPP_INFO_THROTTLE(get_logger(), clock, logger_throttle_interval, msg.c_str());
                                                                        ^
                                                                        "%s", 
/opt/ros/humble/include/rclcpp/rclcpp/logging.hpp:671:7: note: expanded from macro 'RCLCPP_INFO_THROTTLE'
      __VA_ARGS__); \
      ^
/opt/ros/humble/include/rcutils/rcutils/logging_macros.h:680:5: note: expanded from macro 'RCUTILS_LOG_INFO_THROTTLE_NAMED'
    __VA_ARGS__)
    ^
/opt/ros/humble/include/rcutils/rcutils/logging_macros.h:79:64: note: expanded from macro 'RCUTILS_LOG_COND_NAMED'
      rcutils_log(&__rcutils_logging_location, severity, name, __VA_ARGS__); \
                                                               ^
```
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
