### PR TITLE
fix(autoware_pointcloud_preprocessor): clang-tidy error in distortion corrector

### DIFF
--- a/sensing/autoware_pointcloud_preprocessor/include/autoware/pointcloud_preprocessor/distortion_corrector/distortion_corrector.hpp
+++ b/sensing/autoware_pointcloud_preprocessor/include/autoware/pointcloud_preprocessor/distortion_corrector/distortion_corrector.hpp
@@ -90,6 +90,9 @@ public:
     managed_tf_buffer_ =
       std::make_unique<autoware::universe_utils::ManagedTransformBuffer>(&node, has_static_tf_only);
   }
+
+  virtual ~DistortionCorrectorBase() = default;
+
   [[nodiscard]] bool pointcloud_transform_exists() const;
   [[nodiscard]] bool pointcloud_transform_needed() const;
   std::deque<geometry_msgs::msg::TwistStamped> get_twist_queue();


### PR DESCRIPTION
## Description
Fix clang-tidy error
```
/usr/lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/bits/unique_ptr.h:95:2: error: delete called on 'autoware::pointcloud_preprocessor::DistortionCorrectorBase' that is abstract but has non-virtual destructor [clang-diagnostic-delete-abstract-non-virtual-dtor]
        delete __ptr;
        ^
/usr/lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/bits/unique_ptr.h:396:4: note: in instantiation of member function 'std::default_delete<autoware::pointcloud_preprocessor::DistortionCorrectorBase>::operator()' requested here
          get_deleter()(std::move(__ptr));
          ^
/home/veqcc/work/autoware/src/universe/autoware.universe/sensing/autoware_pointcloud_preprocessor/src/distortion_corrector/distortion_corrector_node.cpp:22:31: note: in instantiation of member function 'std::unique_ptr<autoware::pointcloud_preprocessor::DistortionCorrectorBase>::~unique_ptr' requested here
DistortionCorrectorComponent::DistortionCorrectorComponent(const rclcpp::NodeOptions & options)
                              ^
/usr/lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/bits/unique_ptr.h:95:2: error: delete called on non-final 'autoware::pointcloud_preprocessor::DistortionCorrector2D' that has virtual functions but non-virtual destructor [clang-diagnostic-delete-non-abstract-non-virtual-dtor]
        delete __ptr;
        ^
/usr/lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/bits/unique_ptr.h:396:4: note: in instantiation of member function 'std::default_delete<autoware::pointcloud_preprocessor::DistortionCorrector2D>::operator()' requested here
          get_deleter()(std::move(__ptr));
          ^
/home/veqcc/work/autoware/src/universe/autoware.universe/sensing/autoware_pointcloud_preprocessor/src/distortion_corrector/distortion_corrector_node.cpp:67:29: note: in instantiation of member function 'std::unique_ptr<autoware::pointcloud_preprocessor::DistortionCorrector2D>::~unique_ptr' requested here
    distortion_corrector_ = std::make_unique<DistortionCorrector2D>(*this, has_static_tf_only);
                            ^
/usr/lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/bits/unique_ptr.h:95:2: error: delete called on non-final 'autoware::pointcloud_preprocessor::DistortionCorrector3D' that has virtual functions but non-virtual destructor [clang-diagnostic-delete-non-abstract-non-virtual-dtor]
        delete __ptr;
        ^
/usr/lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/bits/unique_ptr.h:396:4: note: in instantiation of member function 'std::default_delete<autoware::pointcloud_preprocessor::DistortionCorrector3D>::operator()' requested here
          get_deleter()(std::move(__ptr));
          ^
/home/veqcc/work/autoware/src/universe/autoware.universe/sensing/autoware_pointcloud_preprocessor/src/distortion_corrector/distortion_corrector_node.cpp:65:29: note: in instantiation of member function 'std::unique_ptr<autoware::pointcloud_preprocessor::DistortionCorrector3D>::~unique_ptr' requested here
    distortion_corrector_ = std::make_unique<DistortionCorrector3D>(*this, has_static_tf_only);
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
