### PR TITLE
fix(autoware_behavior_velocity_walkway_module): fix clang-diagnostic-unused-lambda-capture

### DIFF
--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_walkway_module/src/manager.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_walkway_module/src/manager.cpp
@@ -45,7 +45,7 @@ void WalkwayModuleManager::launchNewModules(const PathWithLaneId & path)
 {
   const auto rh = planner_data_->route_handler_;
 
-  const auto launch = [this, &path](const auto & lanelet, const auto & use_regulatory_element) {
+  const auto launch = [this](const auto & lanelet, const auto & use_regulatory_element) {
     const auto attribute =
       lanelet.attributeOr(lanelet::AttributeNamesString::Subtype, std::string(""));
     if (attribute != lanelet::AttributeValueString::Walkway) {


### PR DESCRIPTION
## Description
This is a fix based on clang-tidy `clang-diagnostic-unused-lambda-capture` error.

```
/home/emb4/autoware/autoware/src/universe/autoware.universe/planning/behavior_velocity_planner/autoware_behavior_velocity_walkway_module/src/manager.cpp:48:31: error: lambda capture 'path' is not used [clang-diagnostic-unused-lambda-capture]
  const auto launch = [this, &path](const auto & lanelet, const auto & use_regulatory_element) {
                           ~~~^~~~
```
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
