### PR TITLE
fix(autoware_obstacle_cruise_planner): fix clang-diagnostic-delete-abstract-non-virtual-dtor

### DIFF
--- a/planning/autoware_obstacle_cruise_planner/include/autoware/obstacle_cruise_planner/planner_interface.hpp
+++ b/planning/autoware_obstacle_cruise_planner/include/autoware/obstacle_cruise_planner/planner_interface.hpp
@@ -42,6 +42,7 @@ using MetricArray = tier4_metric_msgs::msg::MetricArray;
 class PlannerInterface
 {
 public:
+  virtual ~PlannerInterface() = default;
   PlannerInterface(
     rclcpp::Node & node, const LongitudinalInfo & longitudinal_info,
     const autoware::vehicle_info_utils::VehicleInfo & vehicle_info,


### PR DESCRIPTION
## Description
This is a fix based on clang-tidy `clang-diagnostic-delete-abstract-non-virtual-dtor` and `clang-diagnostic-delete-non-abstract-non-virtual-dtor` error.

```
/usr/include/c++/11/bits/unique_ptr.h:85:2: error: delete called on 'PlannerInterface' that is abstract but has non-virtual destructor [clang-diagnostic-delete-abstract-non-virtual-dtor]
        delete __ptr;
        ^
/usr/include/c++/11/bits/unique_ptr.h:361:4: note: in instantiation of member function 'std::default_delete<PlannerInterface>::operator()' requested here
          get_deleter()(std::move(__ptr));
          ^
/home/emb4/autoware/autoware/src/universe/autoware.universe/planning/autoware_obstacle_cruise_planner/src/node.cpp:490:28: note: in instantiation of member function 'std::unique_ptr<PlannerInterface>::~unique_ptr' requested here
ObstacleCruisePlannerNode::ObstacleCruisePlannerNode(const rclcpp::NodeOptions & node_options)
                           ^
/usr/include/c++/11/bits/unique_ptr.h:85:2: error: delete called on non-final 'OptimizationBasedPlanner' that has virtual functions but non-virtual destructor [clang-diagnostic-delete-non-abstract-non-virtual-dtor]
        delete __ptr;
        ^
/usr/include/c++/11/bits/unique_ptr.h:361:4: note: in instantiation of member function 'std::default_delete<OptimizationBasedPlanner>::operator()' requested here
          get_deleter()(std::move(__ptr));
          ^
/home/emb4/autoware/autoware/src/universe/autoware.universe/planning/autoware_obstacle_cruise_planner/src/node.cpp:548:22: note: in instantiation of member function 'std::unique_ptr<OptimizationBasedPlanner>::~unique_ptr' requested here
      planner_ptr_ = std::make_unique<OptimizationBasedPlanner>(
                     ^
/usr/include/c++/11/bits/unique_ptr.h:85:2: error: delete called on non-final 'PIDBasedPlanner' that has virtual functions but non-virtual destructor [clang-diagnostic-delete-non-abstract-non-virtual-dtor]
        delete __ptr;
        ^
/usr/include/c++/11/bits/unique_ptr.h:361:4: note: in instantiation of member function 'std::default_delete<PIDBasedPlanner>::operator()' requested here
          get_deleter()(std::move(__ptr));
          ^
```
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
