### PR TITLE
feat(diagnostic_graph_utils): publish error graph instead of the terminal log

### DIFF
--- a/system/diagnostic_graph_utils/launch/logging.launch.xml
+++ b/system/diagnostic_graph_utils/launch/logging.launch.xml
@@ -6,5 +6,6 @@
     <param name="root_path" value="$(var root_path)"/>
     <param name="max_depth" value="$(var max_depth)"/>
     <param name="show_rate" value="$(var show_rate)"/>
+    <param name="enable_terminal_log" value="$(var enable_terminal_log)"/>
   </node>
 </launch>

--- a/system/diagnostic_graph_utils/package.xml
+++ b/system/diagnostic_graph_utils/package.xml
@@ -13,6 +13,7 @@
   <depend>diagnostic_msgs</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
+  <depend>tier4_debug_msgs</depend>
   <depend>tier4_system_msgs</depend>
 
   <test_depend>ament_lint_auto</test_depend>

--- a/system/diagnostic_graph_utils/src/node/logging.cpp
+++ b/system/diagnostic_graph_utils/src/node/logging.cpp
@@ -61,7 +61,7 @@ void LoggingNode::on_timer()
   if (root_unit_ && root_unit_->level() != DiagUnit::DiagnosticStatus::OK) {
     dump_text_.str("");
     dump_text_.clear(std::stringstream::goodbit);
-    dump_unit(root_unit_, 0, "    ");
+    dump_unit(root_unit_, 0, "");
 
     if (enable_terminal_log_) {
       RCLCPP_WARN_STREAM(get_logger(), prefix_message << std::endl << dump_text_.str());

--- a/system/diagnostic_graph_utils/src/node/logging.cpp
+++ b/system/diagnostic_graph_utils/src/node/logging.cpp
@@ -57,14 +57,14 @@ void LoggingNode::on_create(DiagGraph::ConstSharedPtr graph)
 
 void LoggingNode::on_timer()
 {
-  static const auto message = "The target mode is not available for the following reasons:";
+  static const auto prefix_message = "The target mode is not available for the following reasons:";
   if (root_unit_ && root_unit_->level() != DiagUnit::DiagnosticStatus::OK) {
     dump_text_.str("");
     dump_text_.clear(std::stringstream::goodbit);
     dump_unit(root_unit_, 0, "    ");
 
     if (enable_terminal_log_) {
-      RCLCPP_WARN_STREAM(get_logger(), message << std::endl << dump_text_.str());
+      RCLCPP_WARN_STREAM(get_logger(), prefix_message << std::endl << dump_text_.str());
     }
 
     tier4_debug_msgs::msg::StringStamped message;

--- a/system/diagnostic_graph_utils/src/node/logging.cpp
+++ b/system/diagnostic_graph_utils/src/node/logging.cpp
@@ -33,8 +33,8 @@ LoggingNode::LoggingNode(const rclcpp::NodeOptions & options) : Node("logging", 
   sub_graph_.register_create_callback(std::bind(&LoggingNode::on_create, this, _1));
   sub_graph_.subscribe(*this, 1);
 
-  pub_error_graph_ =
-    create_publisher<tier4_debug_msgs::msg::StringStamped>("~/debug/error_graph", rclcpp::QoS(1));
+  pub_error_graph_text_ = create_publisher<tier4_debug_msgs::msg::StringStamped>(
+    "~/debug/error_graph_text", rclcpp::QoS(1));
 
   const auto period = rclcpp::Rate(declare_parameter<double>("show_rate")).period();
   timer_ = rclcpp::create_timer(this, get_clock(), period, [this]() { on_timer(); });
@@ -70,11 +70,11 @@ void LoggingNode::on_timer()
     tier4_debug_msgs::msg::StringStamped message;
     message.stamp = now();
     message.data = dump_text_.str();
-    pub_error_graph_->publish(message);
+    pub_error_graph_text_->publish(message);
   } else {
     tier4_debug_msgs::msg::StringStamped message;
     message.stamp = now();
-    pub_error_graph_->publish(message);
+    pub_error_graph_text_->publish(message);
   }
 }
 

--- a/system/diagnostic_graph_utils/src/node/logging.hpp
+++ b/system/diagnostic_graph_utils/src/node/logging.hpp
@@ -19,6 +19,8 @@
 
 #include <rclcpp/rclcpp.hpp>
 
+#include "tier4_debug_msgs/msg/string_stamped.hpp"
+
 #include <sstream>
 #include <string>
 
@@ -35,6 +37,7 @@ private:
   void on_timer();
   void dump_unit(DiagUnit * unit, int depth, const std::string & indent);
   DiagGraphSubscription sub_graph_;
+  rclcpp::Publisher<tier4_debug_msgs::msg::StringStamped>::SharedPtr pub_error_graph_;
   rclcpp::TimerBase::SharedPtr timer_;
 
   DiagUnit * root_unit_;

--- a/system/diagnostic_graph_utils/src/node/logging.hpp
+++ b/system/diagnostic_graph_utils/src/node/logging.hpp
@@ -44,6 +44,7 @@ private:
   int max_depth_;
   std::string root_path_;
   std::ostringstream dump_text_;
+  bool enable_terminal_log_;
 };
 
 }  // namespace diagnostic_graph_utils

--- a/system/diagnostic_graph_utils/src/node/logging.hpp
+++ b/system/diagnostic_graph_utils/src/node/logging.hpp
@@ -37,7 +37,7 @@ private:
   void on_timer();
   void dump_unit(DiagUnit * unit, int depth, const std::string & indent);
   DiagGraphSubscription sub_graph_;
-  rclcpp::Publisher<tier4_debug_msgs::msg::StringStamped>::SharedPtr pub_error_graph_;
+  rclcpp::Publisher<tier4_debug_msgs::msg::StringStamped>::SharedPtr pub_error_graph_text_;
   rclcpp::TimerBase::SharedPtr timer_;
 
   DiagUnit * root_unit_;


### PR DESCRIPTION
## Description

The diag_graph_utils's output to the terminal is a bit too frequent to fill the whole terminal screen.
Instead of the output to the terminal, this PR makes the diag_graph_utils publish the string message of the error diag graph so that the Rviz can visualize it as follows.
![image](https://github.com/user-attachments/assets/fe759d19-8bfc-4ada-8032-b774af8490ee)

## Related links


## How was this PR tested?

psim worked well

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
