### PR TITLE
fix(goal_planner): use departure_check_lane for path

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/pull_over_planner/geometric_pull_over.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/pull_over_planner/geometric_pull_over.cpp
@@ -55,7 +55,6 @@ std::optional<PullOverPath> GeometricPullOver::plan(
   if (road_lanes.empty() || pull_over_lanes.empty()) {
     return {};
   }
-  const auto lanes = utils::combineLanelets(road_lanes, pull_over_lanes);
 
   const auto & p = parallel_parking_parameters_;
   const double max_steer_angle =
@@ -69,10 +68,12 @@ std::optional<PullOverPath> GeometricPullOver::plan(
     return {};
   }
 
+  const auto departure_check_lane = goal_planner_utils::createDepartureCheckLanelet(
+    pull_over_lanes, *planner_data->route_handler, left_side_parking_);
   const auto arc_path = planner_.getArcPath();
 
   // check lane departure with road and shoulder lanes
-  if (lane_departure_checker_.checkPathWillLeaveLane(lanes, arc_path)) return {};
+  if (lane_departure_checker_.checkPathWillLeaveLane({departure_check_lane}, arc_path)) return {};
 
   auto pull_over_path_opt = PullOverPath::create(
     getPlannerType(), id, planner_.getPaths(), planner_.getStartPose(), modified_goal_pose,


### PR DESCRIPTION
## Description

use departure_check_lane ( introduced in https://github.com/autowarefoundation/autoware.universe/pull/8716 ) for shift/geoetric planner too.
currently pull over path with large vehicle is sometimes judged as invalid with lanedeparture check.

lane departure_check_lane is as follow. 

---
yellow lanes are for lane departure check

- before: pull over lane and current lane

![image](https://github.com/user-attachments/assets/e52b2c0e-7d8a-43c7-9a3d-f7ec2968f8c9)

![image](https://github.com/user-attachments/assets/e1cf3983-f816-4476-bd81-d788780c7474)


- after: pull over lane and the same segment


![image](https://github.com/user-attachments/assets/b1234e2a-2e3d-4394-ae4a-c6b958e1d13a)


![image](https://github.com/user-attachments/assets/ddc5f5ed-dbce-4010-96b6-697869d495d6)


## Related links
- https://github.com/autowarefoundation/autoware.universe/pull/8716

## How was this PR tested?
2024/11/21 https://evaluation.tier4.jp/evaluation/reports/03a71a48-7d44-536e-8020-34c7e9ed2dbf/?project_id=prd_jt

2024/11/21 https://evaluation.tier4.jp/evaluation/reports/2619a5e5-c10d-554e-9aed-3b8cb1536fb8/?project_id=prd_jt

2024/11/21 https://evaluation.tier4.jp/evaluation/reports/52631ab7-e143-5606-9c28-04f30c07d14a/?project_id=prd_jt

scenario sim
```
webauto ci scenario run --project-id x2_dev --scenario-id 4c1f3c3a-62f3-402d-8eb0-8dfb15a3cab4 --scenario-version-id 2 --scenario-parameters '__tier4_modifier_ego_speed=2.7778,__tier4_modifier_goalposition=0.5,__tier4_modifier_npc_speed=5.5556' --simulation-name planning_sim_v2
```

- before

path without departure is not found and ego vehicle is stuck

https://github.com/user-attachments/assets/14c3edab-66b2-48b2-8c9c-9631466955cb

![image](https://github.com/user-attachments/assets/883fbf85-ebbb-4ba0-8b36-3c717cc27a18)


- after

https://github.com/user-attachments/assets/9e568735-3996-42c7-8df0-0c01cc56f65b







## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
