### PR TITLE
test(static_centerline_generator): add test for launch.xml

### DIFF
--- a/planning/autoware_static_centerline_generator/CMakeLists.txt
+++ b/planning/autoware_static_centerline_generator/CMakeLists.txt
@@ -52,6 +52,10 @@ if(BUILD_TESTING)
     test/test_static_centerline_generator.test.py
     TIMEOUT "30"
   )
+  add_launch_test(
+    test/test_static_centerline_generator_launch.test.py
+    TIMEOUT "30"
+  )
   install(DIRECTORY
     test/data/
     DESTINATION share/${PROJECT_NAME}/test/data/

--- a/planning/autoware_static_centerline_generator/launch/static_centerline_generator.launch.xml
+++ b/planning/autoware_static_centerline_generator/launch/static_centerline_generator.launch.xml
@@ -1,6 +1,6 @@
 <launch>
   <!-- mandatory arguments for planning-->
-  <arg name="vehicle_model"/>
+  <arg name="vehicle_model" default="bus"/>
 
   <!-- flag -->
   <arg name="mode" default="AUTO" description="select from AUTO, GUI, and VMB"/>

--- a/planning/autoware_static_centerline_generator/test/test_static_centerline_generator.test.py
+++ b/planning/autoware_static_centerline_generator/test/test_static_centerline_generator.test.py
@@ -27,21 +27,20 @@ import pytest
 
 @pytest.mark.launch_test
 def generate_test_description():
-    lanelet2_map_path = os.path.join(
-        get_package_share_directory("autoware_static_centerline_generator"),
-        "test/data/lanelet2_map.osm",
-    )
-
     static_centerline_generator_node = Node(
         package="autoware_static_centerline_generator",
         executable="main",
         output="screen",
         parameters=[
-            {"lanelet2_map_path": lanelet2_map_path},
             {"mode": "AUTO"},
             {"rviz": False},
             {"centerline_source": "optimization_trajectory_base"},
-            {"lanelet2_input_file_path": lanelet2_map_path},
+            {
+                "lanelet2_input_file_path": os.path.join(
+                    get_package_share_directory("autoware_static_centerline_generator"),
+                    "test/data/lanelet2_map.osm",
+                )
+            },
             {"lanelet2_output_file_path": "/tmp/lanelet2_map.osm"},
             {"start_lanelet_id": 215},
             {"end_lanelet_id": 216},

--- a/planning/autoware_static_centerline_generator/test/test_static_centerline_generator_launch.test.py
+++ b/planning/autoware_static_centerline_generator/test/test_static_centerline_generator_launch.test.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+
+# Copyright 2024 TIER IV, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import unittest
+
+from ament_index_python import get_package_share_directory
+import launch
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.actions import IncludeLaunchDescription
+from launch.launch_description_sources import AnyLaunchDescriptionSource
+import launch_testing
+import pytest
+
+
+@pytest.mark.launch_test
+def generate_test_description():
+    test_static_centerline_generator_launch_file = os.path.join(
+        get_package_share_directory("autoware_static_centerline_generator"),
+        "launch",
+        "static_centerline_generator.launch.xml",
+    )
+
+    static_centerline_generator = IncludeLaunchDescription(
+        AnyLaunchDescriptionSource(test_static_centerline_generator_launch_file),
+    )
+
+    return LaunchDescription(
+        [
+            DeclareLaunchArgument(
+                "lanelet2_input_file_path",
+                default_value=os.path.join(
+                    get_package_share_directory("autoware_static_centerline_generator"),
+                    "test/data/lanelet2_map.osm",
+                ),
+            ),
+            DeclareLaunchArgument(
+                "lanelet2_output_file_path", default_value="/tmp/lanelet2_map.osm"
+            ),
+            DeclareLaunchArgument("rviz", default_value="false"),
+            DeclareLaunchArgument("start_lanelet_id", default_value="215"),
+            DeclareLaunchArgument("end_lanelet_id", default_value="216"),
+            DeclareLaunchArgument(
+                "centerline_source", default_value="optimization_trajectory_base"
+            ),
+            static_centerline_generator,
+            # Start test after 1s - gives time for the autoware_static_centerline_generator to finish initialization
+            launch.actions.TimerAction(period=1.0, actions=[launch_testing.actions.ReadyToTest()]),
+        ]
+    )
+
+
+@launch_testing.post_shutdown_test()
+class TestProcessOutput(unittest.TestCase):
+    def test_exit_code(self, proc_info):
+        # Check that process exits with code 0: no error
+        launch_testing.asserts.assertExitCodes(proc_info)


### PR DESCRIPTION
## Description

depends on https://github.com/autowarefoundation/autoware.universe/pull/9426
Added a test for static_centerline_generator.launch.xml
## Related links

## How was this PR tested?

unit test passed.
## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
