### PR TITLE
fix(autoware_mission_planner): fix clang-diagnostic-error

### DIFF
--- a/planning/autoware_mission_planner/src/mission_planner/service_utils.hpp
+++ b/planning/autoware_mission_planner/src/mission_planner/service_utils.hpp
@@ -19,6 +19,7 @@
 
 #include <stdexcept>
 #include <string>
+#include <functional>
 
 namespace service_utils
 {


### PR DESCRIPTION
## Description

Fixed clang-tidy error
```
planning/autoware_mission_planner/src/mission_planner/service_utils.hpp:57:6: error: no template named 'function' in namespace 'std' [clang-diagnostic-error]
std::function<void(Req, Res)> handle_exception(void (T::*callback)(Req, Res), T * instance)
~~~~~^
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
