### PR TITLE
fix(autoware_perception_rviz_plugin): fix orientation indication rendering fix

### DIFF
--- a/common/autoware_perception_rviz_plugin/src/object_detection/object_polygon_detail.cpp
+++ b/common/autoware_perception_rviz_plugin/src/object_detection/object_polygon_detail.cpp
@@ -728,10 +728,10 @@ void calc_2d_bounding_box_bottom_orientation_line_list(
 
   // front corner cuts for orientation
   const double point_list[4][3] = {
-    {length_half, width_half - tick_width, height_half},
-    {length_half - tick_length, width_half, height_half},
-    {length_half, -width_half + tick_width, height_half},
-    {length_half - tick_length, -width_half, height_half},
+    {length_half, width_half - tick_width, -height_half},
+    {length_half - tick_length, width_half, -height_half},
+    {length_half, -width_half + tick_width, -height_half},
+    {length_half - tick_length, -width_half, -height_half},
   };
   const int point_pairs[2][2] = {
     {0, 1},


### PR DESCRIPTION
## Description
Fix bounding box rendering under the following condition.

- orientation_availability: SIGN_UNKNOWN
- Polygon Type: 2d

Before

![Screenshot from 2024-11-25 11-06-23](https://github.com/user-attachments/assets/b813adb5-5c1e-42d9-8e26-6435f6f308bc)

After

![Screenshot from 2024-11-25 11-08-52](https://github.com/user-attachments/assets/4a1a6cba-72ab-45d6-83ee-c70f34fe3738)


## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
