### PR TITLE
fix(autoware_smart_mpc_trajectory_follower): fix clang-diagnostic-ignored-optimization-argument

### DIFF
--- a/control/autoware_smart_mpc_trajectory_follower/CMakeLists.txt
+++ b/control/autoware_smart_mpc_trajectory_follower/CMakeLists.txt
@@ -9,6 +9,8 @@ find_package(pybind11 REQUIRED)
 find_package(Eigen3 REQUIRED)
 autoware_package()
 
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-ignored-optimization-argument")
+
 execute_process(COMMAND bash -c "pip3 install numba==0.58.1 --force-reinstall")
 execute_process(COMMAND bash -c "pip3 install GPy")
 


### PR DESCRIPTION
## Description

Suppressed `clang-diagnostic-ignored-optimization-argument` by ignoring GCC specific compiler optimization.
```
error: optimization flag '-fno-fat-lto-objects' is not supported [clang-diagnostic-ignored-optimization-argument]
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
