### PR TITLE
feat(behavior_velocity_planner)!: remove stop_reason

### DIFF
--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/include/autoware/behavior_velocity_blind_spot_module/scene.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/include/autoware/behavior_velocity_blind_spot_module/scene.hpp
@@ -114,7 +114,7 @@ public:
    * @brief plan go-stop velocity at traffic crossing with collision check between reference path
    * and object predicted path
    */
-  bool modifyPathVelocity(PathWithLaneId * path, StopReason * stop_reason) override;
+  bool modifyPathVelocity(PathWithLaneId * path) override;
 
   visualization_msgs::msg::MarkerArray createDebugMarkerArray() override;
   std::vector<autoware::motion_utils::VirtualWall> createVirtualWalls() override;
@@ -133,7 +133,7 @@ private:
   // Parameter
 
   void initializeRTCStatus();
-  BlindSpotDecision modifyPathVelocityDetail(PathWithLaneId * path, StopReason * stop_reason);
+  BlindSpotDecision modifyPathVelocityDetail(PathWithLaneId * path);
   // setSafe(), setDistance()
   void setRTCStatus(
     const BlindSpotDecision & decision, const tier4_planning_msgs::msg::PathWithLaneId & path);
@@ -141,12 +141,10 @@ private:
   void setRTCStatusByDecision(
     const Decision & decision, const tier4_planning_msgs::msg::PathWithLaneId & path);
   // stop/GO
-  void reactRTCApproval(
-    const BlindSpotDecision & decision, PathWithLaneId * path, StopReason * stop_reason);
+  void reactRTCApproval(const BlindSpotDecision & decision, PathWithLaneId * path);
   template <typename Decision>
   void reactRTCApprovalByDecision(
-    const Decision & decision, tier4_planning_msgs::msg::PathWithLaneId * path,
-    StopReason * stop_reason);
+    const Decision & decision, tier4_planning_msgs::msg::PathWithLaneId * path);
 
   std::optional<InterpolatedPathInfo> generateInterpolatedPathInfo(
     const tier4_planning_msgs::msg::PathWithLaneId & input_path) const;

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/src/decisions.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/src/decisions.cpp
@@ -33,8 +33,7 @@ void BlindSpotModule::setRTCStatusByDecision(
 template <typename T>
 void BlindSpotModule::reactRTCApprovalByDecision(
   [[maybe_unused]] const T & decision,
-  [[maybe_unused]] tier4_planning_msgs::msg::PathWithLaneId * path,
-  [[maybe_unused]] StopReason * stop_reason)
+  [[maybe_unused]] tier4_planning_msgs::msg::PathWithLaneId * path)
 {
   static_assert("Unsupported type passed to reactRTCApprovalByDecision");
 }
@@ -53,8 +52,7 @@ void BlindSpotModule::setRTCStatusByDecision(
 template <>
 void BlindSpotModule::reactRTCApprovalByDecision(
   [[maybe_unused]] const InternalError & decision,
-  [[maybe_unused]] tier4_planning_msgs::msg::PathWithLaneId * path,
-  [[maybe_unused]] StopReason * stop_reason)
+  [[maybe_unused]] tier4_planning_msgs::msg::PathWithLaneId * path)
 {
   return;
 }
@@ -73,8 +71,7 @@ void BlindSpotModule::setRTCStatusByDecision(
 template <>
 void BlindSpotModule::reactRTCApprovalByDecision(
   [[maybe_unused]] const OverPassJudge & decision,
-  [[maybe_unused]] tier4_planning_msgs::msg::PathWithLaneId * path,
-  [[maybe_unused]] StopReason * stop_reason)
+  [[maybe_unused]] tier4_planning_msgs::msg::PathWithLaneId * path)
 {
   return;
 }
@@ -95,8 +92,7 @@ void BlindSpotModule::setRTCStatusByDecision(
 
 template <>
 void BlindSpotModule::reactRTCApprovalByDecision(
-  const Unsafe & decision, tier4_planning_msgs::msg::PathWithLaneId * path,
-  StopReason * stop_reason)
+  const Unsafe & decision, tier4_planning_msgs::msg::PathWithLaneId * path)
 {
   if (!isActivated()) {
     constexpr double stop_vel = 0.0;
@@ -104,11 +100,7 @@ void BlindSpotModule::reactRTCApprovalByDecision(
     debug_data_.virtual_wall_pose = planning_utils::getAheadPose(
       decision.stop_line_idx, planner_data_->vehicle_info_.max_longitudinal_offset_m, *path);
 
-    tier4_planning_msgs::msg::StopFactor stop_factor;
     const auto stop_pose = path->points.at(decision.stop_line_idx).point.pose;
-    stop_factor.stop_pose = stop_pose;
-    stop_factor.stop_factor_points = planning_utils::toRosPoints(debug_data_.conflicting_targets);
-    planning_utils::appendStopReason(stop_factor, stop_reason);
     velocity_factor_.set(
       path->points, planner_data_->current_odometry->pose, stop_pose, VelocityFactor::UNKNOWN);
   }
@@ -131,7 +123,7 @@ void BlindSpotModule::setRTCStatusByDecision(
 
 template <>
 void BlindSpotModule::reactRTCApprovalByDecision(
-  const Safe & decision, tier4_planning_msgs::msg::PathWithLaneId * path, StopReason * stop_reason)
+  const Safe & decision, tier4_planning_msgs::msg::PathWithLaneId * path)
 {
   if (!isActivated()) {
     constexpr double stop_vel = 0.0;
@@ -139,11 +131,7 @@ void BlindSpotModule::reactRTCApprovalByDecision(
     debug_data_.virtual_wall_pose = planning_utils::getAheadPose(
       decision.stop_line_idx, planner_data_->vehicle_info_.max_longitudinal_offset_m, *path);
 
-    tier4_planning_msgs::msg::StopFactor stop_factor;
     const auto stop_pose = path->points.at(decision.stop_line_idx).point.pose;
-    stop_factor.stop_pose = stop_pose;
-    stop_factor.stop_factor_points = planning_utils::toRosPoints(debug_data_.conflicting_targets);
-    planning_utils::appendStopReason(stop_factor, stop_reason);
     velocity_factor_.set(
       path->points, planner_data_->current_odometry->pose, stop_pose, VelocityFactor::UNKNOWN);
   }

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/src/scene.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/src/scene.cpp
@@ -64,8 +64,7 @@ void BlindSpotModule::initializeRTCStatus()
   setDistance(std::numeric_limits<double>::lowest());
 }
 
-BlindSpotDecision BlindSpotModule::modifyPathVelocityDetail(
-  PathWithLaneId * path, [[maybe_unused]] StopReason * stop_reason)
+BlindSpotDecision BlindSpotModule::modifyPathVelocityDetail(PathWithLaneId * path)
 {
   if (planner_param_.use_pass_judge_line && is_over_pass_judge_line_) {
     return OverPassJudge{"already over the pass judge line. no plan needed."};
@@ -160,26 +159,23 @@ void BlindSpotModule::setRTCStatus(
     decision);
 }
 
-void BlindSpotModule::reactRTCApproval(
-  const BlindSpotDecision & decision, PathWithLaneId * path, StopReason * stop_reason)
+void BlindSpotModule::reactRTCApproval(const BlindSpotDecision & decision, PathWithLaneId * path)
 {
   std::visit(
-    VisitorSwitch{[&](const auto & sub_decision) {
-      reactRTCApprovalByDecision(sub_decision, path, stop_reason);
-    }},
+    VisitorSwitch{
+      [&](const auto & sub_decision) { reactRTCApprovalByDecision(sub_decision, path); }},
     decision);
 }
 
-bool BlindSpotModule::modifyPathVelocity(PathWithLaneId * path, StopReason * stop_reason)
+bool BlindSpotModule::modifyPathVelocity(PathWithLaneId * path)
 {
   debug_data_ = DebugData();
-  *stop_reason = planning_utils::initializeStopReason(StopReason::BLIND_SPOT);
 
   initializeRTCStatus();
-  const auto decision = modifyPathVelocityDetail(path, stop_reason);
+  const auto decision = modifyPathVelocityDetail(path);
   const auto & input_path = *path;
   setRTCStatus(decision, input_path);
-  reactRTCApproval(decision, path, stop_reason);
+  reactRTCApproval(decision, path);
 
   return true;
 }

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/scene_crosswalk.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/scene_crosswalk.cpp
@@ -201,7 +201,7 @@ CrosswalkModule::CrosswalkModule(
     node.create_publisher<tier4_debug_msgs::msg::StringStamped>("~/debug/collision_info", 1);
 }
 
-bool CrosswalkModule::modifyPathVelocity(PathWithLaneId * path, StopReason * stop_reason)
+bool CrosswalkModule::modifyPathVelocity(PathWithLaneId * path)
 {
   if (path->points.size() < 2) {
     RCLCPP_DEBUG(logger_, "Do not interpolate because path size is less than 2.");
@@ -213,7 +213,6 @@ bool CrosswalkModule::modifyPathVelocity(PathWithLaneId * path, StopReason * sto
     logger_, planner_param_.show_processing_time,
     "=========== module_id: %ld ===========", module_id_);
 
-  *stop_reason = planning_utils::initializeStopReason(StopReason::CROSSWALK);
   const auto & ego_pos = planner_data_->current_odometry->pose.position;
   const auto objects_ptr = planner_data_->predicted_objects;
 
@@ -274,7 +273,7 @@ bool CrosswalkModule::modifyPathVelocity(PathWithLaneId * path, StopReason * sto
   if (isActivated()) {
     planGo(*path, nearest_stop_factor);
   } else {
-    planStop(*path, nearest_stop_factor, default_stop_pose, stop_reason);
+    planStop(*path, nearest_stop_factor, default_stop_pose);
   }
   recordTime(4);
 
@@ -1353,7 +1352,7 @@ void CrosswalkModule::planGo(
 
 void CrosswalkModule::planStop(
   PathWithLaneId & ego_path, const std::optional<StopFactor> & nearest_stop_factor,
-  const std::optional<geometry_msgs::msg::Pose> & default_stop_pose, StopReason * stop_reason)
+  const std::optional<geometry_msgs::msg::Pose> & default_stop_pose)
 {
   // Calculate stop factor
   auto stop_factor = [&]() -> std::optional<StopFactor> {
@@ -1376,7 +1375,6 @@ void CrosswalkModule::planStop(
 
   // Plan stop
   insertDecelPointWithDebugInfo(stop_factor->stop_pose.position, 0.0, ego_path);
-  planning_utils::appendStopReason(*stop_factor, stop_reason);
   velocity_factor_.set(
     ego_path.points, planner_data_->current_odometry->pose, stop_factor->stop_pose,
     VelocityFactor::UNKNOWN);

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/scene_crosswalk.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/scene_crosswalk.hpp
@@ -336,7 +336,7 @@ public:
     const PlannerParam & planner_param, const rclcpp::Logger & logger,
     const rclcpp::Clock::SharedPtr clock);
 
-  bool modifyPathVelocity(PathWithLaneId * path, StopReason * stop_reason) override;
+  bool modifyPathVelocity(PathWithLaneId * path) override;
 
   visualization_msgs::msg::MarkerArray createDebugMarkerArray() override;
   autoware::motion_utils::VirtualWalls createVirtualWalls() override;
@@ -399,7 +399,7 @@ private:
 
   void planStop(
     PathWithLaneId & ego_path, const std::optional<StopFactor> & nearest_stop_factor,
-    const std::optional<geometry_msgs::msg::Pose> & default_stop_pose, StopReason * stop_reason);
+    const std::optional<geometry_msgs::msg::Pose> & default_stop_pose);
 
   // minor functions
   std::pair<double, double> getAttentionRange(

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_detection_area_module/src/scene.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_detection_area_module/src/scene.hpp
@@ -70,7 +70,7 @@ public:
     const PlannerParam & planner_param, const rclcpp::Logger & logger,
     const rclcpp::Clock::SharedPtr clock);
 
-  bool modifyPathVelocity(PathWithLaneId * path, StopReason * stop_reason) override;
+  bool modifyPathVelocity(PathWithLaneId * path) override;
 
   visualization_msgs::msg::MarkerArray createDebugMarkerArray() override;
   autoware::motion_utils::VirtualWalls createVirtualWalls() override;

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_intersection.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_intersection.cpp
@@ -91,14 +91,13 @@ IntersectionModule::IntersectionModule(
     "~/debug/intersection/object_ttc", 1);
 }
 
-bool IntersectionModule::modifyPathVelocity(PathWithLaneId * path, StopReason * stop_reason)
+bool IntersectionModule::modifyPathVelocity(PathWithLaneId * path)
 {
   debug_data_ = DebugData();
-  *stop_reason = planning_utils::initializeStopReason(StopReason::INTERSECTION);
 
   initializeRTCStatus();
 
-  const auto decision_result = modifyPathVelocityDetail(path, stop_reason);
+  const auto decision_result = modifyPathVelocityDetail(path);
   prev_decision_result_ = decision_result;
 
   {
@@ -110,7 +109,7 @@ bool IntersectionModule::modifyPathVelocity(PathWithLaneId * path, StopReason * 
 
   prepareRTCStatus(decision_result, *path);
 
-  reactRTCApproval(decision_result, path, stop_reason);
+  reactRTCApproval(decision_result, path);
 
   return true;
 }
@@ -145,8 +144,7 @@ static std::string formatOcclusionType(const IntersectionModule::OcclusionType &
   return "RTCOccluded";
 }
 
-DecisionResult IntersectionModule::modifyPathVelocityDetail(
-  PathWithLaneId * path, [[maybe_unused]] StopReason * stop_reason)
+DecisionResult IntersectionModule::modifyPathVelocityDetail(PathWithLaneId * path)
 {
   const auto prepare_data = prepareIntersectionData(path);
   if (!prepare_data) {
@@ -683,7 +681,6 @@ void prepareRTCByDecisionResult(
   *occlusion_safety = true;
   *occlusion_distance =
     autoware::motion_utils::calcSignedArcLength(path.points, closest_idx, occlusion_stopline_idx);
-  return;
 }
 
 void IntersectionModule::prepareRTCStatus(
@@ -711,7 +708,6 @@ void reactRTCApprovalByDecisionResult(
   [[maybe_unused]] const IntersectionModule::PlannerParam & planner_param,
   [[maybe_unused]] const double baselink2front,
   [[maybe_unused]] tier4_planning_msgs::msg::PathWithLaneId * path,
-  [[maybe_unused]] StopReason * stop_reason,
   [[maybe_unused]] VelocityFactorInterface * velocity_factor,
   [[maybe_unused]] IntersectionModule::DebugData * debug_data)
 {
@@ -727,7 +723,6 @@ void reactRTCApprovalByDecisionResult(
   [[maybe_unused]] const IntersectionModule::PlannerParam & planner_param,
   [[maybe_unused]] const double baselink2front,
   [[maybe_unused]] tier4_planning_msgs::msg::PathWithLaneId * path,
-  [[maybe_unused]] StopReason * stop_reason,
   [[maybe_unused]] VelocityFactorInterface * velocity_factor,
   [[maybe_unused]] IntersectionModule::DebugData * debug_data)
 {
@@ -742,7 +737,6 @@ void reactRTCApprovalByDecisionResult(
   [[maybe_unused]] const IntersectionModule::PlannerParam & planner_param,
   [[maybe_unused]] const double baselink2front,
   [[maybe_unused]] tier4_planning_msgs::msg::PathWithLaneId * path,
-  [[maybe_unused]] StopReason * stop_reason,
   [[maybe_unused]] VelocityFactorInterface * velocity_factor,
   [[maybe_unused]] IntersectionModule::DebugData * debug_data)
 {
@@ -755,8 +749,7 @@ void reactRTCApprovalByDecisionResult(
   const StuckStop & decision_result,
   [[maybe_unused]] const IntersectionModule::PlannerParam & planner_param,
   const double baselink2front, tier4_planning_msgs::msg::PathWithLaneId * path,
-  StopReason * stop_reason, VelocityFactorInterface * velocity_factor,
-  IntersectionModule::DebugData * debug_data)
+  VelocityFactorInterface * velocity_factor, IntersectionModule::DebugData * debug_data)
 {
   RCLCPP_DEBUG(
     rclcpp::get_logger("reactRTCApprovalByDecisionResult"),
@@ -770,10 +763,6 @@ void reactRTCApprovalByDecisionResult(
     debug_data->collision_stop_wall_pose =
       planning_utils::getAheadPose(stopline_idx, baselink2front, *path);
     {
-      tier4_planning_msgs::msg::StopFactor stop_factor;
-      stop_factor.stop_pose = path->points.at(stopline_idx).point.pose;
-      stop_factor.stop_factor_points = planning_utils::toRosPoints(debug_data->unsafe_targets);
-      planning_utils::appendStopReason(stop_factor, stop_reason);
       velocity_factor->set(
         path->points, path->points.at(closest_idx).point.pose,
         path->points.at(stopline_idx).point.pose, VelocityFactor::UNKNOWN);
@@ -785,9 +774,6 @@ void reactRTCApprovalByDecisionResult(
     debug_data->occlusion_stop_wall_pose =
       planning_utils::getAheadPose(occlusion_stopline_idx, baselink2front, *path);
     {
-      tier4_planning_msgs::msg::StopFactor stop_factor;
-      stop_factor.stop_pose = path->points.at(occlusion_stopline_idx).point.pose;
-      planning_utils::appendStopReason(stop_factor, stop_reason);
       velocity_factor->set(
         path->points, path->points.at(closest_idx).point.pose,
         path->points.at(occlusion_stopline_idx).point.pose, VelocityFactor::UNKNOWN);
@@ -802,8 +788,7 @@ void reactRTCApprovalByDecisionResult(
   const YieldStuckStop & decision_result,
   [[maybe_unused]] const IntersectionModule::PlannerParam & planner_param,
   const double baselink2front, tier4_planning_msgs::msg::PathWithLaneId * path,
-  StopReason * stop_reason, VelocityFactorInterface * velocity_factor,
-  IntersectionModule::DebugData * debug_data)
+  VelocityFactorInterface * velocity_factor, IntersectionModule::DebugData * debug_data)
 {
   RCLCPP_DEBUG(
     rclcpp::get_logger("reactRTCApprovalByDecisionResult"),
@@ -817,10 +802,6 @@ void reactRTCApprovalByDecisionResult(
     debug_data->collision_stop_wall_pose =
       planning_utils::getAheadPose(stopline_idx, baselink2front, *path);
     {
-      tier4_planning_msgs::msg::StopFactor stop_factor;
-      stop_factor.stop_pose = path->points.at(stopline_idx).point.pose;
-      stop_factor.stop_factor_points = planning_utils::toRosPoints(debug_data->unsafe_targets);
-      planning_utils::appendStopReason(stop_factor, stop_reason);
       velocity_factor->set(
         path->points, path->points.at(closest_idx).point.pose,
         path->points.at(stopline_idx).point.pose, VelocityFactor::UNKNOWN);
@@ -835,8 +816,7 @@ void reactRTCApprovalByDecisionResult(
   const NonOccludedCollisionStop & decision_result,
   [[maybe_unused]] const IntersectionModule::PlannerParam & planner_param,
   const double baselink2front, tier4_planning_msgs::msg::PathWithLaneId * path,
-  StopReason * stop_reason, VelocityFactorInterface * velocity_factor,
-  IntersectionModule::DebugData * debug_data)
+  VelocityFactorInterface * velocity_factor, IntersectionModule::DebugData * debug_data)
 {
   RCLCPP_DEBUG(
     rclcpp::get_logger("reactRTCApprovalByDecisionResult"),
@@ -848,9 +828,6 @@ void reactRTCApprovalByDecisionResult(
     debug_data->collision_stop_wall_pose =
       planning_utils::getAheadPose(stopline_idx, baselink2front, *path);
     {
-      tier4_planning_msgs::msg::StopFactor stop_factor;
-      stop_factor.stop_pose = path->points.at(stopline_idx).point.pose;
-      planning_utils::appendStopReason(stop_factor, stop_reason);
       velocity_factor->set(
         path->points, path->points.at(decision_result.closest_idx).point.pose,
         path->points.at(stopline_idx).point.pose, VelocityFactor::UNKNOWN);
@@ -862,9 +839,6 @@ void reactRTCApprovalByDecisionResult(
     debug_data->occlusion_stop_wall_pose =
       planning_utils::getAheadPose(stopline_idx, baselink2front, *path);
     {
-      tier4_planning_msgs::msg::StopFactor stop_factor;
-      stop_factor.stop_pose = path->points.at(stopline_idx).point.pose;
-      planning_utils::appendStopReason(stop_factor, stop_reason);
       velocity_factor->set(
         path->points, path->points.at(decision_result.closest_idx).point.pose,
         path->points.at(stopline_idx).point.pose, VelocityFactor::UNKNOWN);
@@ -878,8 +852,8 @@ void reactRTCApprovalByDecisionResult(
   const bool rtc_default_approved, const bool rtc_occlusion_approved,
   const FirstWaitBeforeOcclusion & decision_result,
   const IntersectionModule::PlannerParam & planner_param, const double baselink2front,
-  tier4_planning_msgs::msg::PathWithLaneId * path, StopReason * stop_reason,
-  VelocityFactorInterface * velocity_factor, IntersectionModule::DebugData * debug_data)
+  tier4_planning_msgs::msg::PathWithLaneId * path, VelocityFactorInterface * velocity_factor,
+  IntersectionModule::DebugData * debug_data)
 {
   RCLCPP_DEBUG(
     rclcpp::get_logger("reactRTCApprovalByDecisionResult"),
@@ -891,9 +865,6 @@ void reactRTCApprovalByDecisionResult(
     debug_data->occlusion_first_stop_wall_pose =
       planning_utils::getAheadPose(stopline_idx, baselink2front, *path);
     {
-      tier4_planning_msgs::msg::StopFactor stop_factor;
-      stop_factor.stop_pose = path->points.at(stopline_idx).point.pose;
-      planning_utils::appendStopReason(stop_factor, stop_reason);
       velocity_factor->set(
         path->points, path->points.at(decision_result.closest_idx).point.pose,
         path->points.at(stopline_idx).point.pose, VelocityFactor::UNKNOWN);
@@ -913,9 +884,6 @@ void reactRTCApprovalByDecisionResult(
     debug_data->occlusion_stop_wall_pose =
       planning_utils::getAheadPose(stopline_idx, baselink2front, *path);
     {
-      tier4_planning_msgs::msg::StopFactor stop_factor;
-      stop_factor.stop_pose = path->points.at(stopline_idx).point.pose;
-      planning_utils::appendStopReason(stop_factor, stop_reason);
       velocity_factor->set(
         path->points, path->points.at(decision_result.closest_idx).point.pose,
         path->points.at(stopline_idx).point.pose, VelocityFactor::UNKNOWN);
@@ -929,8 +897,8 @@ void reactRTCApprovalByDecisionResult(
   const bool rtc_default_approved, const bool rtc_occlusion_approved,
   const PeekingTowardOcclusion & decision_result,
   const IntersectionModule::PlannerParam & planner_param, const double baselink2front,
-  tier4_planning_msgs::msg::PathWithLaneId * path, StopReason * stop_reason,
-  VelocityFactorInterface * velocity_factor, IntersectionModule::DebugData * debug_data)
+  tier4_planning_msgs::msg::PathWithLaneId * path, VelocityFactorInterface * velocity_factor,
+  IntersectionModule::DebugData * debug_data)
 {
   RCLCPP_DEBUG(
     rclcpp::get_logger("reactRTCApprovalByDecisionResult"),
@@ -955,9 +923,6 @@ void reactRTCApprovalByDecisionResult(
     debug_data->static_occlusion_with_traffic_light_timeout =
       decision_result.static_occlusion_timeout;
     {
-      tier4_planning_msgs::msg::StopFactor stop_factor;
-      stop_factor.stop_pose = path->points.at(occlusion_peeking_stopline).point.pose;
-      planning_utils::appendStopReason(stop_factor, stop_reason);
       velocity_factor->set(
         path->points, path->points.at(decision_result.closest_idx).point.pose,
         path->points.at(occlusion_peeking_stopline).point.pose, VelocityFactor::UNKNOWN);
@@ -969,9 +934,6 @@ void reactRTCApprovalByDecisionResult(
     debug_data->collision_stop_wall_pose =
       planning_utils::getAheadPose(stopline_idx, baselink2front, *path);
     {
-      tier4_planning_msgs::msg::StopFactor stop_factor;
-      stop_factor.stop_pose = path->points.at(stopline_idx).point.pose;
-      planning_utils::appendStopReason(stop_factor, stop_reason);
       velocity_factor->set(
         path->points, path->points.at(decision_result.closest_idx).point.pose,
         path->points.at(stopline_idx).point.pose, VelocityFactor::UNKNOWN);
@@ -986,8 +948,7 @@ void reactRTCApprovalByDecisionResult(
   const OccludedCollisionStop & decision_result,
   [[maybe_unused]] const IntersectionModule::PlannerParam & planner_param,
   const double baselink2front, tier4_planning_msgs::msg::PathWithLaneId * path,
-  StopReason * stop_reason, VelocityFactorInterface * velocity_factor,
-  IntersectionModule::DebugData * debug_data)
+  VelocityFactorInterface * velocity_factor, IntersectionModule::DebugData * debug_data)
 {
   RCLCPP_DEBUG(
     rclcpp::get_logger("reactRTCApprovalByDecisionResult"),
@@ -999,9 +960,6 @@ void reactRTCApprovalByDecisionResult(
     debug_data->collision_stop_wall_pose =
       planning_utils::getAheadPose(stopline_idx, baselink2front, *path);
     {
-      tier4_planning_msgs::msg::StopFactor stop_factor;
-      stop_factor.stop_pose = path->points.at(stopline_idx).point.pose;
-      planning_utils::appendStopReason(stop_factor, stop_reason);
       velocity_factor->set(
         path->points, path->points.at(decision_result.closest_idx).point.pose,
         path->points.at(stopline_idx).point.pose, VelocityFactor::UNKNOWN);
@@ -1017,9 +975,6 @@ void reactRTCApprovalByDecisionResult(
     debug_data->static_occlusion_with_traffic_light_timeout =
       decision_result.static_occlusion_timeout;
     {
-      tier4_planning_msgs::msg::StopFactor stop_factor;
-      stop_factor.stop_pose = path->points.at(stopline_idx).point.pose;
-      planning_utils::appendStopReason(stop_factor, stop_reason);
       velocity_factor->set(
         path->points, path->points.at(decision_result.closest_idx).point.pose,
         path->points.at(stopline_idx).point.pose, VelocityFactor::UNKNOWN);
@@ -1034,8 +989,7 @@ void reactRTCApprovalByDecisionResult(
   const OccludedAbsenceTrafficLight & decision_result,
   [[maybe_unused]] const IntersectionModule::PlannerParam & planner_param,
   const double baselink2front, tier4_planning_msgs::msg::PathWithLaneId * path,
-  StopReason * stop_reason, VelocityFactorInterface * velocity_factor,
-  IntersectionModule::DebugData * debug_data)
+  VelocityFactorInterface * velocity_factor, IntersectionModule::DebugData * debug_data)
 {
   RCLCPP_DEBUG(
     rclcpp::get_logger("reactRTCApprovalByDecisionResult"),
@@ -1047,9 +1001,6 @@ void reactRTCApprovalByDecisionResult(
     debug_data->collision_stop_wall_pose =
       planning_utils::getAheadPose(stopline_idx, baselink2front, *path);
     {
-      tier4_planning_msgs::msg::StopFactor stop_factor;
-      stop_factor.stop_pose = path->points.at(stopline_idx).point.pose;
-      planning_utils::appendStopReason(stop_factor, stop_reason);
       velocity_factor->set(
         path->points, path->points.at(decision_result.closest_idx).point.pose,
         path->points.at(stopline_idx).point.pose, VelocityFactor::UNKNOWN);
@@ -1061,9 +1012,6 @@ void reactRTCApprovalByDecisionResult(
     debug_data->occlusion_stop_wall_pose =
       planning_utils::getAheadPose(stopline_idx, baselink2front, *path);
     {
-      tier4_planning_msgs::msg::StopFactor stop_factor;
-      stop_factor.stop_pose = path->points.at(stopline_idx).point.pose;
-      planning_utils::appendStopReason(stop_factor, stop_reason);
       velocity_factor->set(
         path->points, path->points.at(decision_result.closest_idx).point.pose,
         path->points.at(stopline_idx).point.pose, VelocityFactor::UNKNOWN);
@@ -1087,8 +1035,7 @@ void reactRTCApprovalByDecisionResult(
   const bool rtc_default_approved, const bool rtc_occlusion_approved, const Safe & decision_result,
   [[maybe_unused]] const IntersectionModule::PlannerParam & planner_param,
   const double baselink2front, tier4_planning_msgs::msg::PathWithLaneId * path,
-  StopReason * stop_reason, VelocityFactorInterface * velocity_factor,
-  IntersectionModule::DebugData * debug_data)
+  VelocityFactorInterface * velocity_factor, IntersectionModule::DebugData * debug_data)
 {
   RCLCPP_DEBUG(
     rclcpp::get_logger("reactRTCApprovalByDecisionResult"),
@@ -1099,9 +1046,6 @@ void reactRTCApprovalByDecisionResult(
     debug_data->collision_stop_wall_pose =
       planning_utils::getAheadPose(stopline_idx, baselink2front, *path);
     {
-      tier4_planning_msgs::msg::StopFactor stop_factor;
-      stop_factor.stop_pose = path->points.at(stopline_idx).point.pose;
-      planning_utils::appendStopReason(stop_factor, stop_reason);
       velocity_factor->set(
         path->points, path->points.at(decision_result.closest_idx).point.pose,
         path->points.at(stopline_idx).point.pose, VelocityFactor::UNKNOWN);
@@ -1113,9 +1057,6 @@ void reactRTCApprovalByDecisionResult(
     debug_data->occlusion_stop_wall_pose =
       planning_utils::getAheadPose(stopline_idx, baselink2front, *path);
     {
-      tier4_planning_msgs::msg::StopFactor stop_factor;
-      stop_factor.stop_pose = path->points.at(stopline_idx).point.pose;
-      planning_utils::appendStopReason(stop_factor, stop_reason);
       velocity_factor->set(
         path->points, path->points.at(decision_result.closest_idx).point.pose,
         path->points.at(stopline_idx).point.pose, VelocityFactor::UNKNOWN);
@@ -1130,8 +1071,7 @@ void reactRTCApprovalByDecisionResult(
   const FullyPrioritized & decision_result,
   [[maybe_unused]] const IntersectionModule::PlannerParam & planner_param,
   const double baselink2front, tier4_planning_msgs::msg::PathWithLaneId * path,
-  StopReason * stop_reason, VelocityFactorInterface * velocity_factor,
-  IntersectionModule::DebugData * debug_data)
+  VelocityFactorInterface * velocity_factor, IntersectionModule::DebugData * debug_data)
 {
   RCLCPP_DEBUG(
     rclcpp::get_logger("reactRTCApprovalByDecisionResult"),
@@ -1143,9 +1083,6 @@ void reactRTCApprovalByDecisionResult(
     debug_data->collision_stop_wall_pose =
       planning_utils::getAheadPose(stopline_idx, baselink2front, *path);
     {
-      tier4_planning_msgs::msg::StopFactor stop_factor;
-      stop_factor.stop_pose = path->points.at(stopline_idx).point.pose;
-      planning_utils::appendStopReason(stop_factor, stop_reason);
       velocity_factor->set(
         path->points, path->points.at(decision_result.closest_idx).point.pose,
         path->points.at(stopline_idx).point.pose, VelocityFactor::UNKNOWN);
@@ -1157,9 +1094,6 @@ void reactRTCApprovalByDecisionResult(
     debug_data->occlusion_stop_wall_pose =
       planning_utils::getAheadPose(stopline_idx, baselink2front, *path);
     {
-      tier4_planning_msgs::msg::StopFactor stop_factor;
-      stop_factor.stop_pose = path->points.at(stopline_idx).point.pose;
-      planning_utils::appendStopReason(stop_factor, stop_reason);
       velocity_factor->set(
         path->points, path->points.at(decision_result.closest_idx).point.pose,
         path->points.at(stopline_idx).point.pose, VelocityFactor::UNKNOWN);
@@ -1169,15 +1103,14 @@ void reactRTCApprovalByDecisionResult(
 }
 
 void IntersectionModule::reactRTCApproval(
-  const DecisionResult & decision_result, tier4_planning_msgs::msg::PathWithLaneId * path,
-  StopReason * stop_reason)
+  const DecisionResult & decision_result, tier4_planning_msgs::msg::PathWithLaneId * path)
 {
   const double baselink2front = planner_data_->vehicle_info_.max_longitudinal_offset_m;
   std::visit(
     VisitorSwitch{[&](const auto & decision) {
       reactRTCApprovalByDecisionResult(
         activated_, occlusion_activated_, decision, planner_param_, baselink2front, path,
-        stop_reason, &velocity_factor_, &debug_data_);
+        &velocity_factor_, &debug_data_);
     }},
     decision_result);
   return;

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_intersection.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_intersection.hpp
@@ -321,7 +321,7 @@ public:
    * INTERSECTION_OCCLUSION.
    * @{
    */
-  bool modifyPathVelocity(PathWithLaneId * path, StopReason * stop_reason) override;
+  bool modifyPathVelocity(PathWithLaneId * path) override;
   /** @}*/
 
   visualization_msgs::msg::MarkerArray createDebugMarkerArray() override;
@@ -504,7 +504,7 @@ private:
   /**
    * @brief analyze traffic_light/occupancy/objects context and return DecisionResult
    */
-  DecisionResult modifyPathVelocityDetail(PathWithLaneId * path, StopReason * stop_reason);
+  DecisionResult modifyPathVelocityDetail(PathWithLaneId * path);
 
   /**
    * @brief set RTC value according to calculated DecisionResult
@@ -516,8 +516,7 @@ private:
    * @brief act based on current RTC approval
    */
   void reactRTCApproval(
-    const DecisionResult & decision_result, tier4_planning_msgs::msg::PathWithLaneId * path,
-    StopReason * stop_reason);
+    const DecisionResult & decision_result, tier4_planning_msgs::msg::PathWithLaneId * path);
   /** @}*/
 
 private:

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_merge_from_private_road.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_merge_from_private_road.cpp
@@ -76,10 +76,9 @@ static std::optional<lanelet::ConstLanelet> getFirstConflictingLanelet(
   return std::nullopt;
 }
 
-bool MergeFromPrivateRoadModule::modifyPathVelocity(PathWithLaneId * path, StopReason * stop_reason)
+bool MergeFromPrivateRoadModule::modifyPathVelocity(PathWithLaneId * path)
 {
   debug_data_ = DebugData();
-  *stop_reason = planning_utils::initializeStopReason(StopReason::MERGE_FROM_PRIVATE_ROAD);
 
   const auto input_path = *path;
 
@@ -152,9 +151,6 @@ bool MergeFromPrivateRoadModule::modifyPathVelocity(PathWithLaneId * path, StopR
     planning_utils::setVelocityFromIndex(stopline_idx, v, path);
 
     /* get stop point and stop factor */
-    tier4_planning_msgs::msg::StopFactor stop_factor;
-    stop_factor.stop_pose = debug_data_.stop_point_pose;
-    planning_utils::appendStopReason(stop_factor, stop_reason);
     const auto & stop_pose = path->points.at(stopline_idx).point.pose;
     velocity_factor_.set(
       path->points, planner_data_->current_odometry->pose, stop_pose, VelocityFactor::UNKNOWN);

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_merge_from_private_road.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_merge_from_private_road.hpp
@@ -67,7 +67,7 @@ public:
    * @brief plan go-stop velocity at traffic crossing with collision check between reference path
    * and object predicted path
    */
-  bool modifyPathVelocity(PathWithLaneId * path, StopReason * stop_reason) override;
+  bool modifyPathVelocity(PathWithLaneId * path) override;
 
   visualization_msgs::msg::MarkerArray createDebugMarkerArray() override;
   autoware::motion_utils::VirtualWalls createVirtualWalls() override;

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_no_drivable_lane_module/src/scene.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_no_drivable_lane_module/src/scene.hpp
@@ -57,7 +57,7 @@ public:
     const int64_t module_id, const int64_t lane_id, const PlannerParam & planner_param,
     const rclcpp::Logger logger, const rclcpp::Clock::SharedPtr clock);
 
-  bool modifyPathVelocity(PathWithLaneId * path, StopReason * stop_reason) override;
+  bool modifyPathVelocity(PathWithLaneId * path) override;
 
   visualization_msgs::msg::MarkerArray createDebugMarkerArray() override;
   autoware::motion_utils::VirtualWalls createVirtualWalls() override;
@@ -79,9 +79,9 @@ private:
   double distance_ego_first_intersection{};
 
   void handle_init_state();
-  void handle_approaching_state(PathWithLaneId * path, StopReason * stop_reason);
-  void handle_inside_no_drivable_lane_state(PathWithLaneId * path, StopReason * stop_reason);
-  void handle_stopped_state(PathWithLaneId * path, StopReason * stop_reason);
+  void handle_approaching_state(PathWithLaneId * path);
+  void handle_inside_no_drivable_lane_state(PathWithLaneId * path);
+  void handle_stopped_state(PathWithLaneId * path);
   void initialize_debug_data(
     const lanelet::Lanelet & no_drivable_lane, const geometry_msgs::msg::Point & ego_pos);
 };

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_no_stopping_area_module/src/scene_no_stopping_area.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_no_stopping_area_module/src/scene_no_stopping_area.cpp
@@ -52,7 +52,7 @@ NoStoppingAreaModule::NoStoppingAreaModule(
   state_machine_.setMarginTime(planner_param_.state_clear_time);
 }
 
-bool NoStoppingAreaModule::modifyPathVelocity(PathWithLaneId * path, StopReason * stop_reason)
+bool NoStoppingAreaModule::modifyPathVelocity(PathWithLaneId * path)
 {
   // Store original path
   const auto original_path = *path;
@@ -64,7 +64,6 @@ bool NoStoppingAreaModule::modifyPathVelocity(PathWithLaneId * path, StopReason 
   // Reset data
   debug_data_ = no_stopping_area::DebugData();
   debug_data_.base_link2front = planner_data_->vehicle_info_.max_longitudinal_offset_m;
-  *stop_reason = planning_utils::initializeStopReason(StopReason::NO_STOPPING_AREA);
 
   const no_stopping_area::EgoData ego_data(*planner_data_);
 
@@ -142,27 +141,11 @@ bool NoStoppingAreaModule::modifyPathVelocity(PathWithLaneId * path, StopReason 
 
     // Create StopReason
     {
-      tier4_planning_msgs::msg::StopFactor stop_factor;
-      stop_factor.stop_pose = stop_point->second;
-      stop_factor.stop_factor_points = debug_data_.stuck_points;
-      planning_utils::appendStopReason(stop_factor, stop_reason);
       velocity_factor_.set(
         path->points, planner_data_->current_odometry->pose, stop_point->second,
         VelocityFactor::UNKNOWN);
     }
 
-    // Create legacy StopReason
-    {
-      const double stop_path_point_distance = autoware::motion_utils::calcSignedArcLength(
-        path->points, 0, stop_pose.position, stop_point->first);
-
-      if (
-        !first_stop_path_point_distance_ ||
-        stop_path_point_distance < first_stop_path_point_distance_.value()) {
-        debug_data_.first_stop_pose = stop_point->second;
-        first_stop_path_point_distance_ = stop_path_point_distance;
-      }
-    }
   } else if (state_machine_.getState() == StateMachine::State::GO) {
     // reset pass judge if current state is go
     pass_judge_.is_stoppable = true;

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_no_stopping_area_module/src/scene_no_stopping_area.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_no_stopping_area_module/src/scene_no_stopping_area.hpp
@@ -59,7 +59,7 @@ public:
     const PlannerParam & planner_param, const rclcpp::Logger & logger,
     const rclcpp::Clock::SharedPtr clock);
 
-  bool modifyPathVelocity(PathWithLaneId * path, StopReason * stop_reason) override;
+  bool modifyPathVelocity(PathWithLaneId * path) override;
 
   visualization_msgs::msg::MarkerArray createDebugMarkerArray() override;
   autoware::motion_utils::VirtualWalls createVirtualWalls() override;

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_occlusion_spot_module/src/scene_occlusion_spot.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_occlusion_spot_module/src/scene_occlusion_spot.cpp
@@ -82,8 +82,7 @@ OcclusionSpotModule::OcclusionSpotModule(
   }
 }
 
-bool OcclusionSpotModule::modifyPathVelocity(
-  PathWithLaneId * path, [[maybe_unused]] StopReason * stop_reason)
+bool OcclusionSpotModule::modifyPathVelocity(PathWithLaneId * path)
 {
   if (param_.is_show_processing_time) stop_watch_.tic("total_processing_time");
   debug_data_.resetData();

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_occlusion_spot_module/src/scene_occlusion_spot.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_occlusion_spot_module/src/scene_occlusion_spot.hpp
@@ -53,7 +53,7 @@ public:
   /**
    * @brief plan occlusion spot velocity at unknown area in occupancy grid
    */
-  bool modifyPathVelocity(PathWithLaneId * path, StopReason * stop_reason) override;
+  bool modifyPathVelocity(PathWithLaneId * path) override;
 
   visualization_msgs::msg::MarkerArray createDebugMarkerArray() override;
   autoware::motion_utils::VirtualWalls createVirtualWalls() override;

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/src/node.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/src/node.cpp
@@ -79,8 +79,6 @@ BehaviorVelocityPlannerNode::BehaviorVelocityPlannerNode(const rclcpp::NodeOptio
 
   // Publishers
   path_pub_ = this->create_publisher<autoware_planning_msgs::msg::Path>("~/output/path", 1);
-  stop_reason_diag_pub_ =
-    this->create_publisher<diagnostic_msgs::msg::DiagnosticStatus>("~/output/stop_reason", 1);
   debug_viz_pub_ = this->create_publisher<visualization_msgs::msg::MarkerArray>("~/debug/path", 1);
 
   // Parameters
@@ -327,7 +325,6 @@ void BehaviorVelocityPlannerNode::onTrigger(
 
   path_pub_->publish(output_path_msg);
   published_time_publisher_->publish_if_subscribed(path_pub_, output_path_msg.header.stamp);
-  stop_reason_diag_pub_->publish(planner_manager_.getStopReasonDiag());
 
   if (debug_viz_pub_->get_subscription_count() > 0) {
     publishDebugMarker(output_path_msg);

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/src/node.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/src/node.hpp
@@ -113,7 +113,6 @@ private:
 
   // publisher
   rclcpp::Publisher<autoware_planning_msgs::msg::Path>::SharedPtr path_pub_;
-  rclcpp::Publisher<diagnostic_msgs::msg::DiagnosticStatus>::SharedPtr stop_reason_diag_pub_;
   rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr debug_viz_pub_;
 
   void publishDebugMarker(const autoware_planning_msgs::msg::Path & path);

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/src/planner_manager.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/src/planner_manager.hpp
@@ -50,10 +50,7 @@ public:
     const std::shared_ptr<const PlannerData> & planner_data,
     const tier4_planning_msgs::msg::PathWithLaneId & input_path_msg);
 
-  diagnostic_msgs::msg::DiagnosticStatus getStopReasonDiag() const;
-
 private:
-  diagnostic_msgs::msg::DiagnosticStatus stop_reason_diag_;
   pluginlib::ClassLoader<PluginInterface> plugin_loader_;
   std::vector<std::shared_ptr<PluginInterface>> scene_manager_plugins_;
 };

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/src/planner_manager.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/src/planner_manager.hpp
@@ -46,6 +46,7 @@ public:
   void launchScenePlugin(rclcpp::Node & node, const std::string & name);
   void removeScenePlugin(rclcpp::Node & node, const std::string & name);
 
+  // cppcheck-suppress functionConst
   tier4_planning_msgs::msg::PathWithLaneId planPathVelocity(
     const std::shared_ptr<const PlannerData> & planner_data,
     const tier4_planning_msgs::msg::PathWithLaneId & input_path_msg);

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/include/autoware/behavior_velocity_planner_common/plugin_interface.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/include/autoware/behavior_velocity_planner_common/plugin_interface.hpp
@@ -34,7 +34,6 @@ public:
   virtual void updateSceneModuleInstances(
     const std::shared_ptr<const PlannerData> & planner_data,
     const tier4_planning_msgs::msg::PathWithLaneId & path) = 0;
-  virtual std::optional<double> getFirstStopPathPointDistance() = 0;
   virtual const char * getModuleName() = 0;
 };
 

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/include/autoware/behavior_velocity_planner_common/plugin_wrapper.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/include/autoware/behavior_velocity_planner_common/plugin_wrapper.hpp
@@ -38,10 +38,6 @@ public:
   {
     scene_manager_->updateSceneModuleInstances(planner_data, path);
   }
-  std::optional<double> getFirstStopPathPointDistance() override
-  {
-    return scene_manager_->getFirstStopPathPointDistance();
-  }
   const char * getModuleName() override { return scene_manager_->getModuleName(); }
 
 private:

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/include/autoware/behavior_velocity_planner_common/scene_module_interface.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/include/autoware/behavior_velocity_planner_common/scene_module_interface.hpp
@@ -30,8 +30,6 @@
 #include <autoware_planning_msgs/msg/path.hpp>
 #include <tier4_debug_msgs/msg/float64_stamped.hpp>
 #include <tier4_planning_msgs/msg/path_with_lane_id.hpp>
-#include <tier4_planning_msgs/msg/stop_reason.hpp>
-#include <tier4_planning_msgs/msg/stop_reason_array.hpp>
 #include <tier4_rtc_msgs/msg/state.hpp>
 #include <tier4_v2x_msgs/msg/infrastructure_command_array.hpp>
 #include <unique_identifier_msgs/msg/uuid.hpp>
@@ -61,8 +59,6 @@ using autoware::universe_utils::getOrDeclareParameter;
 using builtin_interfaces::msg::Time;
 using tier4_debug_msgs::msg::Float64Stamped;
 using tier4_planning_msgs::msg::PathWithLaneId;
-using tier4_planning_msgs::msg::StopFactor;
-using tier4_planning_msgs::msg::StopReason;
 using tier4_rtc_msgs::msg::Module;
 using tier4_rtc_msgs::msg::State;
 using unique_identifier_msgs::msg::UUID;
@@ -87,7 +83,7 @@ public:
     const int64_t module_id, rclcpp::Logger logger, rclcpp::Clock::SharedPtr clock);
   virtual ~SceneModuleInterface() = default;
 
-  virtual bool modifyPathVelocity(PathWithLaneId * path, StopReason * stop_reason) = 0;
+  virtual bool modifyPathVelocity(PathWithLaneId * path) = 0;
 
   virtual visualization_msgs::msg::MarkerArray createDebugMarkerArray() = 0;
   virtual std::vector<autoware::motion_utils::VirtualWall> createVirtualWalls() = 0;
@@ -116,8 +112,6 @@ public:
 
   std::shared_ptr<universe_utils::TimeKeeper> getTimeKeeper() { return time_keeper_; }
 
-  std::optional<double> getFirstStopPathPointDistance() { return first_stop_path_point_distance_; }
-
   void setActivation(const bool activated) { activated_ = activated; }
   void setRTCEnabled(const bool enable_rtc) { rtc_enabled_ = enable_rtc; }
   bool isActivated() const { return activated_; }
@@ -139,7 +133,6 @@ protected:
   rclcpp::Clock::SharedPtr clock_;
   std::shared_ptr<const PlannerData> planner_data_;
   std::optional<tier4_v2x_msgs::msg::InfrastructureCommand> infrastructure_command_;
-  std::optional<double> first_stop_path_point_distance_;
   autoware::motion_utils::VelocityFactorInterface velocity_factor_;
   std::vector<ObjectOfInterest> objects_of_interest_;
   mutable std::shared_ptr<universe_utils::TimeKeeper> time_keeper_;
@@ -174,8 +167,6 @@ public:
 
   virtual const char * getModuleName() = 0;
 
-  std::optional<double> getFirstStopPathPointDistance() { return first_stop_path_point_distance_; }
-
   void updateSceneModuleInstances(
     const std::shared_ptr<const PlannerData> & planner_data,
     const tier4_planning_msgs::msg::PathWithLaneId & path);
@@ -208,7 +199,6 @@ protected:
   std::shared_ptr<const PlannerData> planner_data_;
   autoware::motion_utils::VirtualWallMarkerCreator virtual_wall_marker_creator_;
 
-  std::optional<double> first_stop_path_point_distance_;
   rclcpp::Node & node_;
   rclcpp::Clock::SharedPtr clock_;
   // Debug
@@ -217,7 +207,6 @@ protected:
   rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr pub_virtual_wall_;
   rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr pub_debug_;
   rclcpp::Publisher<tier4_planning_msgs::msg::PathWithLaneId>::SharedPtr pub_debug_path_;
-  rclcpp::Publisher<tier4_planning_msgs::msg::StopReasonArray>::SharedPtr pub_stop_reason_;
   rclcpp::Publisher<autoware_adapi_v1_msgs::msg::VelocityFactorArray>::SharedPtr
     pub_velocity_factor_;
   rclcpp::Publisher<tier4_v2x_msgs::msg::InfrastructureCommandArray>::SharedPtr

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/include/autoware/behavior_velocity_planner_common/utilization/util.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/include/autoware/behavior_velocity_planner_common/utilization/util.hpp
@@ -21,7 +21,6 @@
 #include <autoware_perception_msgs/msg/traffic_light_group.hpp>
 #include <geometry_msgs/msg/point.hpp>
 #include <tier4_planning_msgs/msg/path_with_lane_id.hpp>
-#include <tier4_planning_msgs/msg/stop_reason.hpp>
 
 #include <lanelet2_core/Forward.h>
 #include <lanelet2_core/LaneletMap.h>
@@ -65,8 +64,6 @@ using Polygons2d = std::vector<Polygon2d>;
 using autoware_perception_msgs::msg::PredictedObjects;
 using tier4_planning_msgs::msg::PathPointWithLaneId;
 using tier4_planning_msgs::msg::PathWithLaneId;
-using tier4_planning_msgs::msg::StopFactor;
-using tier4_planning_msgs::msg::StopReason;
 
 namespace planning_utils
 {
@@ -113,10 +110,6 @@ double calcDecelerationVelocityFromDistanceToTarget(
 double findReachTime(
   const double jerk, const double accel, const double velocity, const double distance,
   const double t_min, const double t_max);
-
-StopReason initializeStopReason(const std::string & stop_reason);
-
-void appendStopReason(const StopFactor stop_factor, StopReason * stop_reason);
 
 std::vector<geometry_msgs::msg::Point> toRosPoints(const PredictedObjects & object);
 

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/src/scene_module_interface.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/src/scene_module_interface.cpp
@@ -67,8 +67,6 @@ SceneModuleManagerInterface::SceneModuleManagerInterface(
     std::string("~/virtual_wall/") + module_name, 5);
   pub_velocity_factor_ = node.create_publisher<autoware_adapi_v1_msgs::msg::VelocityFactorArray>(
     std::string("/planning/velocity_factors/") + module_name, 1);
-  pub_stop_reason_ =
-    node.create_publisher<tier4_planning_msgs::msg::StopReasonArray>("~/output/stop_reasons", 1);
   pub_infrastructure_commands_ =
     node.create_publisher<tier4_v2x_msgs::msg::InfrastructureCommandArray>(
       "~/output/infrastructure_commands", 1);
@@ -107,38 +105,26 @@ void SceneModuleManagerInterface::modifyPathVelocity(
   StopWatch<std::chrono::milliseconds> stop_watch;
   stop_watch.tic("Total");
   visualization_msgs::msg::MarkerArray debug_marker_array;
-  tier4_planning_msgs::msg::StopReasonArray stop_reason_array;
   autoware_adapi_v1_msgs::msg::VelocityFactorArray velocity_factor_array;
-  stop_reason_array.header.frame_id = "map";
-  stop_reason_array.header.stamp = clock_->now();
   velocity_factor_array.header.frame_id = "map";
   velocity_factor_array.header.stamp = clock_->now();
 
   tier4_v2x_msgs::msg::InfrastructureCommandArray infrastructure_command_array;
   infrastructure_command_array.stamp = clock_->now();
 
-  first_stop_path_point_distance_ = autoware::motion_utils::calcArcLength(path->points);
   for (const auto & scene_module : scene_modules_) {
-    tier4_planning_msgs::msg::StopReason stop_reason;
     scene_module->resetVelocityFactor();
     scene_module->setPlannerData(planner_data_);
-    scene_module->modifyPathVelocity(path, &stop_reason);
+    scene_module->modifyPathVelocity(path);
 
     // The velocity factor must be called after modifyPathVelocity.
     const auto velocity_factor = scene_module->getVelocityFactor();
     if (velocity_factor.behavior != PlanningBehavior::UNKNOWN) {
       velocity_factor_array.factors.emplace_back(velocity_factor);
     }
-    if (stop_reason.reason != "") {
-      stop_reason_array.stop_reasons.emplace_back(stop_reason);
-    }
 
     if (const auto command = scene_module->getInfrastructureCommand()) {
       infrastructure_command_array.commands.push_back(*command);
-    }
-
-    if (scene_module->getFirstStopPathPointDistance() < first_stop_path_point_distance_) {
-      first_stop_path_point_distance_ = scene_module->getFirstStopPathPointDistance();
     }
 
     for (const auto & marker : scene_module->createDebugMarkerArray().markers) {
@@ -148,9 +134,6 @@ void SceneModuleManagerInterface::modifyPathVelocity(
     virtual_wall_marker_creator_.add_virtual_walls(scene_module->createVirtualWalls());
   }
 
-  if (!stop_reason_array.stop_reasons.empty()) {
-    pub_stop_reason_->publish(stop_reason_array);
-  }
   pub_velocity_factor_->publish(velocity_factor_array);
   pub_infrastructure_commands_->publish(infrastructure_command_array);
   pub_debug_->publish(debug_marker_array);

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/src/utilization/util.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/src/utilization/util.cpp
@@ -490,18 +490,6 @@ double calcDecelerationVelocityFromDistanceToTarget(
   return current_velocity;
 }
 
-StopReason initializeStopReason(const std::string & stop_reason)
-{
-  StopReason stop_reason_msg;
-  stop_reason_msg.reason = stop_reason;
-  return stop_reason_msg;
-}
-
-void appendStopReason(const StopFactor stop_factor, StopReason * stop_reason)
-{
-  stop_reason->stop_factors.emplace_back(stop_factor);
-}
-
 std::vector<geometry_msgs::msg::Point> toRosPoints(const PredictedObjects & object)
 {
   std::vector<geometry_msgs::msg::Point> points;

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_run_out_module/src/scene.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_run_out_module/src/scene.cpp
@@ -63,8 +63,7 @@ void RunOutModule::setPlannerParam(const PlannerParam & planner_param)
   planner_param_ = planner_param;
 }
 
-bool RunOutModule::modifyPathVelocity(
-  PathWithLaneId * path, [[maybe_unused]] StopReason * stop_reason)
+bool RunOutModule::modifyPathVelocity(PathWithLaneId * path)
 {
   // timer starts
   const auto t_start = std::chrono::system_clock::now();

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_run_out_module/src/scene.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_run_out_module/src/scene.hpp
@@ -49,7 +49,7 @@ public:
     std::unique_ptr<DynamicObstacleCreator> dynamic_obstacle_creator,
     const std::shared_ptr<RunOutDebug> & debug_ptr, const rclcpp::Clock::SharedPtr clock);
 
-  bool modifyPathVelocity(PathWithLaneId * path, StopReason * stop_reason) override;
+  bool modifyPathVelocity(PathWithLaneId * path) override;
 
   visualization_msgs::msg::MarkerArray createDebugMarkerArray() override;
   autoware::motion_utils::VirtualWalls createVirtualWalls() override;

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_speed_bump_module/src/scene.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_speed_bump_module/src/scene.cpp
@@ -70,8 +70,7 @@ SpeedBumpModule::SpeedBumpModule(
   }
 }
 
-bool SpeedBumpModule::modifyPathVelocity(
-  PathWithLaneId * path, [[maybe_unused]] StopReason * stop_reason)
+bool SpeedBumpModule::modifyPathVelocity(PathWithLaneId * path)
 {
   if (path->points.empty()) {
     return false;

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_speed_bump_module/src/scene.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_speed_bump_module/src/scene.hpp
@@ -56,7 +56,7 @@ public:
     const lanelet::autoware::SpeedBump & speed_bump_reg_elem, const PlannerParam & planner_param,
     const rclcpp::Logger & logger, const rclcpp::Clock::SharedPtr clock);
 
-  bool modifyPathVelocity(PathWithLaneId * path, StopReason * stop_reason) override;
+  bool modifyPathVelocity(PathWithLaneId * path) override;
 
   visualization_msgs::msg::MarkerArray createDebugMarkerArray() override;
   autoware::motion_utils::VirtualWalls createVirtualWalls() override;

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_stop_line_module/src/scene.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_stop_line_module/src/scene.cpp
@@ -46,7 +46,7 @@ StopLineModule::StopLineModule(
   velocity_factor_.init(PlanningBehavior::STOP_SIGN);
 }
 
-bool StopLineModule::modifyPathVelocity(PathWithLaneId * path, StopReason * stop_reason)
+bool StopLineModule::modifyPathVelocity(PathWithLaneId * path)
 {
   auto trajectory =
     trajectory::Trajectory<tier4_planning_msgs::msg::PathPointWithLaneId>::Builder{}.build(
@@ -73,8 +73,6 @@ bool StopLineModule::modifyPathVelocity(PathWithLaneId * path, StopReason * stop
     &state_, &stopped_time_, clock_->now(), *stop_point - ego_s, planner_data_->isVehicleStopped());
 
   geometry_msgs::msg::Pose stop_pose = trajectory->compute(*stop_point).point.pose;
-
-  updateStopReason(stop_reason, stop_pose);
 
   updateDebugData(&debug_data_, stop_pose, state_);
 
@@ -175,15 +173,6 @@ void StopLineModule::updateVelocityFactor(
     case State::START:
       break;
   }
-}
-
-void StopLineModule::updateStopReason(
-  StopReason * stop_reason, const geometry_msgs::msg::Pose & stop_pose) const
-{
-  tier4_planning_msgs::msg::StopFactor stop_factor;
-  stop_factor.stop_pose = stop_pose;
-  stop_factor.stop_factor_points.push_back(getCenterOfStopLine(stop_line_));
-  planning_utils::appendStopReason(stop_factor, stop_reason);
 }
 
 void StopLineModule::updateDebugData(

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_stop_line_module/src/scene.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_stop_line_module/src/scene.hpp
@@ -70,7 +70,7 @@ public:
     const PlannerParam & planner_param, const rclcpp::Logger & logger,
     const rclcpp::Clock::SharedPtr clock);
 
-  bool modifyPathVelocity(PathWithLaneId * path, StopReason * stop_reason) override;
+  bool modifyPathVelocity(PathWithLaneId * path) override;
 
   /**
    * @brief Calculate ego position and stop point.
@@ -98,8 +98,6 @@ public:
   static void updateVelocityFactor(
     autoware::motion_utils::VelocityFactorInterface * velocity_factor, const State & state,
     const double & distance_to_stop_point);
-
-  void updateStopReason(StopReason * stop_reason, const geometry_msgs::msg::Pose & stop_pose) const;
 
   void updateDebugData(
     DebugData * debug_data, const geometry_msgs::msg::Pose & stop_pose, const State & state) const;

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_template_module/src/scene.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_template_module/src/scene.cpp
@@ -42,8 +42,7 @@ autoware::motion_utils::VirtualWalls TemplateModule::createVirtualWalls()
   return vw;
 }
 
-bool TemplateModule::modifyPathVelocity(
-  [[maybe_unused]] PathWithLaneId * path, [[maybe_unused]] StopReason * stop_reason)
+bool TemplateModule::modifyPathVelocity([[maybe_unused]] PathWithLaneId * path)
 {
   RCLCPP_INFO_ONCE(logger_, "Template Module is executing!");
   return false;

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_template_module/src/scene.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_template_module/src/scene.hpp
@@ -38,10 +38,9 @@ public:
    * specific criteria.
    *
    * @param path A pointer to the path containing points to be modified.
-   * @param stop_reason A pointer to the stop reason data.
    * @return [bool] wether the path velocity was modified or not.
    */
-  bool modifyPathVelocity(PathWithLaneId * path, StopReason * stop_reason) override;
+  bool modifyPathVelocity(PathWithLaneId * path) override;
 
   /**
    * @brief Create a visualization of debug markers.

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/src/scene.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/src/scene.cpp
@@ -54,13 +54,11 @@ TrafficLightModule::TrafficLightModule(
   planner_param_ = planner_param;
 }
 
-bool TrafficLightModule::modifyPathVelocity(PathWithLaneId * path, StopReason * stop_reason)
+bool TrafficLightModule::modifyPathVelocity(PathWithLaneId * path)
 {
   debug_data_ = DebugData();
   debug_data_.base_link2front = planner_data_->vehicle_info_.max_longitudinal_offset_m;
-  first_stop_path_point_distance_ = autoware::motion_utils::calcArcLength(path->points);
   first_ref_stop_path_point_index_ = static_cast<int>(path->points.size()) - 1;
-  *stop_reason = planning_utils::initializeStopReason(StopReason::TRAFFIC_LIGHT);
 
   const auto input_path = *path;
 
@@ -133,8 +131,7 @@ bool TrafficLightModule::modifyPathVelocity(PathWithLaneId * path, StopReason * 
 
     // Decide whether to stop or pass even if a stop signal is received.
     if (!isPassthrough(signed_arc_length_to_stop_point)) {
-      *path =
-        insertStopPose(input_path, stop_line.value().first, stop_line.value().second, stop_reason);
+      *path = insertStopPose(input_path, stop_line.value().first, stop_line.value().second);
       is_prev_state_stop_ = true;
     }
     return true;
@@ -275,7 +272,7 @@ bool TrafficLightModule::isTrafficSignalTimedOut() const
 
 tier4_planning_msgs::msg::PathWithLaneId TrafficLightModule::insertStopPose(
   const tier4_planning_msgs::msg::PathWithLaneId & input, const size_t & insert_target_point_idx,
-  const Eigen::Vector2d & target_point, tier4_planning_msgs::msg::StopReason * stop_reason)
+  const Eigen::Vector2d & target_point)
 {
   tier4_planning_msgs::msg::PathWithLaneId modified_path;
   modified_path = input;
@@ -292,24 +289,9 @@ tier4_planning_msgs::msg::PathWithLaneId TrafficLightModule::insertStopPose(
   size_t insert_index = insert_target_point_idx;
   planning_utils::insertVelocity(modified_path, target_point_with_lane_id, 0.0, insert_index);
 
-  const double target_velocity_point_distance = autoware::motion_utils::calcArcLength(std::vector(
-    modified_path.points.begin(), modified_path.points.begin() + target_velocity_point_idx));
-  if (target_velocity_point_distance < first_stop_path_point_distance_) {
-    first_stop_path_point_distance_ = target_velocity_point_distance;
-    debug_data_.first_stop_pose = target_point_with_lane_id.point.pose;
-  }
-
-  // Get stop point and stop factor
-  tier4_planning_msgs::msg::StopFactor stop_factor;
-  stop_factor.stop_pose = debug_data_.first_stop_pose;
-  if (debug_data_.highest_confidence_traffic_light_point != std::nullopt) {
-    stop_factor.stop_factor_points = std::vector<geometry_msgs::msg::Point>{
-      debug_data_.highest_confidence_traffic_light_point.value()};
-  }
   velocity_factor_.set(
     modified_path.points, planner_data_->current_odometry->pose,
     target_point_with_lane_id.point.pose, VelocityFactor::UNKNOWN);
-  planning_utils::appendStopReason(stop_factor, stop_reason);
 
   return modified_path;
 }

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/src/scene.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/src/scene.hpp
@@ -71,7 +71,7 @@ public:
     lanelet::ConstLanelet lane, const PlannerParam & planner_param, const rclcpp::Logger logger,
     const rclcpp::Clock::SharedPtr clock);
 
-  bool modifyPathVelocity(PathWithLaneId * path, StopReason * stop_reason) override;
+  bool modifyPathVelocity(PathWithLaneId * path) override;
 
   visualization_msgs::msg::MarkerArray createDebugMarkerArray() override;
   autoware::motion_utils::VirtualWalls createVirtualWalls() override;
@@ -90,7 +90,7 @@ private:
 
   tier4_planning_msgs::msg::PathWithLaneId insertStopPose(
     const tier4_planning_msgs::msg::PathWithLaneId & input, const size_t & insert_target_point_idx,
-    const Eigen::Vector2d & target_point, tier4_planning_msgs::msg::StopReason * stop_reason);
+    const Eigen::Vector2d & target_point);
 
   bool isPassthrough(const double & signed_arc_length) const;
 

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_virtual_traffic_light_module/src/scene.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_virtual_traffic_light_module/src/scene.cpp
@@ -97,11 +97,10 @@ VirtualTrafficLightModule::VirtualTrafficLightModule(
   logger_ = logger_.get_child((map_data_.instrument_type + "_" + map_data_.instrument_id).c_str());
 }
 
-bool VirtualTrafficLightModule::modifyPathVelocity(PathWithLaneId * path, StopReason * stop_reason)
+bool VirtualTrafficLightModule::modifyPathVelocity(PathWithLaneId * path)
 {
   // Initialize
   setInfrastructureCommand({});
-  *stop_reason = planning_utils::initializeStopReason(StopReason::VIRTUAL_TRAFFIC_LIGHT);
 
   module_data_ = {};
 
@@ -150,7 +149,7 @@ bool VirtualTrafficLightModule::modifyPathVelocity(PathWithLaneId * path, StopRe
   // Stop at stop_line if no message received
   if (!virtual_traffic_light_state) {
     RCLCPP_DEBUG(logger_, "no message received");
-    insertStopVelocityAtStopLine(path, stop_reason, end_line_idx);
+    insertStopVelocityAtStopLine(path, end_line_idx);
     updateInfrastructureCommand();
     return true;
   }
@@ -158,7 +157,7 @@ bool VirtualTrafficLightModule::modifyPathVelocity(PathWithLaneId * path, StopRe
   // Stop at stop_line if no right is given
   if (!hasRightOfWay(*virtual_traffic_light_state)) {
     RCLCPP_DEBUG(logger_, "no right is given");
-    insertStopVelocityAtStopLine(path, stop_reason, end_line_idx);
+    insertStopVelocityAtStopLine(path, end_line_idx);
     updateInfrastructureCommand();
     return true;
   }
@@ -167,7 +166,7 @@ bool VirtualTrafficLightModule::modifyPathVelocity(PathWithLaneId * path, StopRe
   if (isBeforeStopLine(end_line_idx)) {
     if (isStateTimeout(*virtual_traffic_light_state)) {
       RCLCPP_DEBUG(logger_, "state is timeout before stop line");
-      insertStopVelocityAtStopLine(path, stop_reason, end_line_idx);
+      insertStopVelocityAtStopLine(path, end_line_idx);
     }
 
     updateInfrastructureCommand();
@@ -181,7 +180,7 @@ bool VirtualTrafficLightModule::modifyPathVelocity(PathWithLaneId * path, StopRe
   if (
     planner_param_.check_timeout_after_stop_line && isStateTimeout(*virtual_traffic_light_state)) {
     RCLCPP_DEBUG(logger_, "state is timeout after stop line");
-    insertStopVelocityAtStopLine(path, stop_reason, end_line_idx);
+    insertStopVelocityAtStopLine(path, end_line_idx);
     updateInfrastructureCommand();
     return true;
   }
@@ -189,7 +188,7 @@ bool VirtualTrafficLightModule::modifyPathVelocity(PathWithLaneId * path, StopRe
   // Stop at stop_line if finalization isn't completed
   if (!virtual_traffic_light_state->is_finalized) {
     RCLCPP_DEBUG(logger_, "finalization isn't completed");
-    insertStopVelocityAtEndLine(path, stop_reason, end_line_idx);
+    insertStopVelocityAtEndLine(path, end_line_idx);
 
     if (isNearAnyEndLine(end_line_idx) && planner_data_->isVehicleStopped()) {
       state_ = State::FINALIZING;
@@ -205,15 +204,6 @@ void VirtualTrafficLightModule::updateInfrastructureCommand()
   command_.stamp = clock_->now();
   command_.state = static_cast<uint8_t>(state_);
   setInfrastructureCommand(command_);
-}
-
-void VirtualTrafficLightModule::setStopReason(
-  const geometry_msgs::msg::Pose & stop_pose, tier4_planning_msgs::msg::StopReason * stop_reason)
-{
-  tier4_planning_msgs::msg::StopFactor stop_factor;
-  stop_factor.stop_pose = stop_pose;
-  stop_factor.stop_factor_points.push_back(toMsg(map_data_.instrument_center));
-  planning_utils::appendStopReason(stop_factor, stop_reason);
 }
 
 std::optional<size_t> VirtualTrafficLightModule::getPathIndexOfFirstEndLine()
@@ -376,8 +366,7 @@ bool VirtualTrafficLightModule::hasRightOfWay(
 }
 
 void VirtualTrafficLightModule::insertStopVelocityAtStopLine(
-  tier4_planning_msgs::msg::PathWithLaneId * path,
-  tier4_planning_msgs::msg::StopReason * stop_reason, const size_t end_line_idx)
+  tier4_planning_msgs::msg::PathWithLaneId * path, const size_t end_line_idx)
 {
   const auto collision =
     findLastCollisionBeforeEndLine(path->points, *map_data_.stop_line, end_line_idx);
@@ -428,7 +417,6 @@ void VirtualTrafficLightModule::insertStopVelocityAtStopLine(
   }
 
   // Set StopReason
-  setStopReason(stop_pose, stop_reason);
   velocity_factor_.set(
     path->points, planner_data_->current_odometry->pose, stop_pose, VelocityFactor::UNKNOWN,
     command_.type);
@@ -439,8 +427,7 @@ void VirtualTrafficLightModule::insertStopVelocityAtStopLine(
 }
 
 void VirtualTrafficLightModule::insertStopVelocityAtEndLine(
-  tier4_planning_msgs::msg::PathWithLaneId * path,
-  tier4_planning_msgs::msg::StopReason * stop_reason, const size_t end_line_idx)
+  tier4_planning_msgs::msg::PathWithLaneId * path, const size_t end_line_idx)
 {
   const auto collision =
     findLastCollisionBeforeEndLine(path->points, map_data_.end_lines, end_line_idx);
@@ -463,7 +450,6 @@ void VirtualTrafficLightModule::insertStopVelocityAtEndLine(
   }
 
   // Set StopReason
-  setStopReason(stop_pose, stop_reason);
   velocity_factor_.set(
     path->points, planner_data_->current_odometry->pose, stop_pose, VelocityFactor::UNKNOWN);
 

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_virtual_traffic_light_module/src/scene.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_virtual_traffic_light_module/src/scene.hpp
@@ -79,7 +79,7 @@ public:
     const PlannerParam & planner_param, const rclcpp::Logger logger,
     const rclcpp::Clock::SharedPtr clock);
 
-  bool modifyPathVelocity(PathWithLaneId * path, StopReason * stop_reason) override;
+  bool modifyPathVelocity(PathWithLaneId * path) override;
 
   visualization_msgs::msg::MarkerArray createDebugMarkerArray() override;
   autoware::motion_utils::VirtualWalls createVirtualWalls() override;
@@ -95,8 +95,6 @@ private:
   ModuleData module_data_;
 
   void updateInfrastructureCommand();
-
-  void setStopReason(const Pose & stop_pose, StopReason * stop_reason);
 
   void setVelocityFactor(
     const geometry_msgs::msg::Pose & stop_pose,
@@ -119,12 +117,10 @@ private:
   bool hasRightOfWay(const tier4_v2x_msgs::msg::VirtualTrafficLightState & state);
 
   void insertStopVelocityAtStopLine(
-    tier4_planning_msgs::msg::PathWithLaneId * path,
-    tier4_planning_msgs::msg::StopReason * stop_reason, const size_t end_line_idx);
+    tier4_planning_msgs::msg::PathWithLaneId * path, const size_t end_line_idx);
 
   void insertStopVelocityAtEndLine(
-    tier4_planning_msgs::msg::PathWithLaneId * path,
-    tier4_planning_msgs::msg::StopReason * stop_reason, const size_t end_line_idx);
+    tier4_planning_msgs::msg::PathWithLaneId * path, const size_t end_line_idx);
 };
 }  // namespace autoware::behavior_velocity_planner
 #endif  // SCENE_HPP_

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_walkway_module/src/scene_walkway.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_walkway_module/src/scene_walkway.cpp
@@ -81,12 +81,11 @@ std::pair<double, geometry_msgs::msg::Point> WalkwayModule::getStopLine(
   return std::make_pair(dist_ego_to_stop, p_stop_line);
 }
 
-bool WalkwayModule::modifyPathVelocity(PathWithLaneId * path, StopReason * stop_reason)
+bool WalkwayModule::modifyPathVelocity(PathWithLaneId * path)
 {
   const auto & base_link2front = planner_data_->vehicle_info_.max_longitudinal_offset_m;
 
   debug_data_ = DebugData(planner_data_);
-  *stop_reason = planning_utils::initializeStopReason(StopReason::WALKWAY);
 
   const auto input = *path;
 
@@ -119,10 +118,6 @@ bool WalkwayModule::modifyPathVelocity(PathWithLaneId * path, StopReason * stop_
     }
 
     /* get stop point and stop factor */
-    StopFactor stop_factor;
-    stop_factor.stop_pose = stop_pose.value();
-    stop_factor.stop_factor_points.push_back(path_end_points_on_walkway->first);
-    planning_utils::appendStopReason(stop_factor, stop_reason);
     velocity_factor_.set(
       path->points, planner_data_->current_odometry->pose, stop_pose.value(),
       VelocityFactor::UNKNOWN);

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_walkway_module/src/scene_walkway.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_walkway_module/src/scene_walkway.hpp
@@ -46,7 +46,7 @@ public:
     const PlannerParam & planner_param, const bool use_regulatory_element,
     const rclcpp::Logger & logger, const rclcpp::Clock::SharedPtr clock);
 
-  bool modifyPathVelocity(PathWithLaneId * path, StopReason * stop_reason) override;
+  bool modifyPathVelocity(PathWithLaneId * path) override;
 
   visualization_msgs::msg::MarkerArray createDebugMarkerArray() override;
   autoware::motion_utils::VirtualWalls createVirtualWalls() override;


### PR DESCRIPTION
## Description

StopReason interface will be deprecated, so remove it from behavior_velocity_planner

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

- https://evaluation.tier4.jp/evaluation/reports/338d0cae-17ce-5b20-97b9-c9fdd2e3f54c?project_id=prd_jt&state=failed

## Notes for reviewers

None.

## Interface changes

`~/behavior_velocity/***/stop_reason` disappears

<!-- ⬇️🔴

### Topic changes

~/stop_reason will disappear

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
