### PR TITLE
fix(mission_planner): fix initialization after route set

### DIFF
--- a/planning/autoware_mission_planner/src/mission_planner/mission_planner.hpp
+++ b/planning/autoware_mission_planner/src/mission_planner/mission_planner.hpp
@@ -132,6 +132,7 @@ private:
 
   rclcpp::TimerBase::SharedPtr data_check_timer_;
   void check_initialization();
+  bool is_mission_planner_ready_;
 
   double reroute_time_threshold_;
   double minimum_reroute_length_;


### PR DESCRIPTION
## Description

Fix a bug where initialization was completed after setting the route and the state was overwritten. 

## Related links

**Private Links:**

- [TIER IV internal link](https://star4.slack.com/archives/CBX6XHKA4/p1732255264072239?thread_ts=1729579139.622729&cid=CBX6XHKA4)

## How was this PR tested?

[TIER IV internal link](https://star4.slack.com/archives/CBX6XHKA4/p1732767456781819?thread_ts=1729579139.622729&cid=CBX6XHKA4)

If the timer period is too fast, you will not be able to test it manually, so set the check_initialization timer to 10 seconds, for example.

new behavior
1. send route button (failed)
2. initialize pose
3. set goal (failed)
4. wait and initialization done (state=UNSET)
5. set goal (state=SET)

old behavior
1. send route button (state=UNSET)
2. initialize pose
3. set goal (state=SET)
4. wait and initialization done (state=UNSET)

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
