### PR TITLE
feat(goal_planner): check opposite lane for lane departure_check

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/util.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/util.cpp
@@ -723,17 +723,13 @@ lanelet::Lanelet createDepartureCheckLanelet(
   };
 
   const auto getMostInnerLane = [&](const lanelet::ConstLanelet & lane) -> lanelet::ConstLanelet {
-    if (left_side_parking) {
-      const auto most_right_lane = route_handler.getMostRightLanelet(lane, true, true);
-      const auto most_right_opposite_lanes =
-        route_handler.getRightOppositeLanelets(most_right_lane);
-      return most_right_opposite_lanes.empty() ? most_right_lane
-                                               : most_right_opposite_lanes.front();
-    } else {
-      const auto most_left_lane = route_handler.getMostLeftLanelet(lane, true, true);
-      const auto most_left_opposite_lanes = route_handler.getLeftOppositeLanelets(most_left_lane);
-      return most_left_opposite_lanes.empty() ? most_left_lane : most_left_opposite_lanes.front();
-    }
+    const auto getInnerLane =
+      left_side_parking ? &RouteHandler::getMostRightLanelet : &RouteHandler::getMostLeftLanelet;
+    const auto getOppositeLane = left_side_parking ? &RouteHandler::getRightOppositeLanelets
+                                                   : &RouteHandler::getLeftOppositeLanelets;
+    const auto inner_lane = (route_handler.*getInnerLane)(lane, true, true);
+    const auto opposite_lanes = (route_handler.*getOppositeLane)(inner_lane);
+    return opposite_lanes.empty() ? inner_lane : opposite_lanes.front();
   };
 
   lanelet::Points3d outer_bound_points{};

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/util.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/util.cpp
@@ -723,8 +723,17 @@ lanelet::Lanelet createDepartureCheckLanelet(
   };
 
   const auto getMostInnerLane = [&](const lanelet::ConstLanelet & lane) -> lanelet::ConstLanelet {
-    return left_side_parking ? route_handler.getMostRightLanelet(lane, false, true)
-                             : route_handler.getMostLeftLanelet(lane, false, true);
+    if (left_side_parking) {
+      const auto most_right_lane = route_handler.getMostRightLanelet(lane, true, true);
+      const auto most_right_opposite_lanes =
+        route_handler.getRightOppositeLanelets(most_right_lane);
+      return most_right_opposite_lanes.empty() ? most_right_lane
+                                               : most_right_opposite_lanes.front();
+    } else {
+      const auto most_left_lane = route_handler.getMostLeftLanelet(lane, true, true);
+      const auto most_left_opposite_lanes = route_handler.getLeftOppositeLanelets(most_left_lane);
+      return most_left_opposite_lanes.empty() ? most_left_lane : most_left_opposite_lanes.front();
+    }
   };
 
   lanelet::Points3d outer_bound_points{};


### PR DESCRIPTION
## Description

https://github.com/autowarefoundation/autoware.universe/pull/9423  does not check the opposing lane. The avoidance module may cause the ego to enter the opposing lane, but at this time, the current lane departure check  logic of goal planner judges candidate paths invalid.
In this PR, it checks the opposing lane too


before

![image](https://github.com/user-attachments/assets/65baca8c-75f8-4112-bdc1-d977c4402815)

after

![image](https://github.com/user-attachments/assets/62904b62-a29a-49a3-b65e-dabe1b490ca2)


https://github.com/user-attachments/assets/bbc0e706-1b00-4b9c-b232-a2f7fc3fa68e


## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

psim

2024/11/28 https://evaluation.tier4.jp/evaluation/reports/317acd96-acdc-5002-97d1-d1c5fa3067d8/?project_id=prd_jt

https://evaluation.tier4.jp/evaluation/reports/ee27e182-2a8b-5ae5-8159-854a2bad205a?project_id=prd_jt&state=failed

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
