### PR TITLE
fix(obstacle_stop_planner): remove stop reason

### DIFF
--- a/planning/autoware_obstacle_stop_planner/README.md
+++ b/planning/autoware_obstacle_stop_planner/README.md
@@ -24,10 +24,9 @@
 
 ### Output topics
 
-| Name                   | Type                                 | Description                            |
-| ---------------------- | ------------------------------------ | -------------------------------------- |
-| `~output/trajectory`   | autoware_planning_msgs::Trajectory   | trajectory to be followed              |
-| `~output/stop_reasons` | tier4_planning_msgs::StopReasonArray | reasons that cause the vehicle to stop |
+| Name                 | Type                               | Description               |
+| -------------------- | ---------------------------------- | ------------------------- |
+| `~output/trajectory` | autoware_planning_msgs::Trajectory | trajectory to be followed |
 
 ### Common Parameter
 

--- a/planning/autoware_obstacle_stop_planner/launch/obstacle_stop_planner.launch.xml
+++ b/planning/autoware_obstacle_stop_planner/launch/obstacle_stop_planner.launch.xml
@@ -22,7 +22,6 @@
     <param from="$(var vehicle_info_param_file)"/>
     <!-- remap topic name -->
     <remap from="~/output/stop_reason" to="/planning/scenario_planning/status/stop_reason"/>
-    <remap from="~/output/stop_reasons" to="/planning/scenario_planning/status/stop_reasons"/>
     <remap from="~/output/trajectory" to="$(var output_trajectory)"/>
     <remap from="~/output/max_velocity" to="$(var output_velocity_limit)"/>
     <remap from="~/output/velocity_limit_clear_command" to="$(var output_velocity_limit_clear_command)"/>

--- a/planning/autoware_obstacle_stop_planner/src/debug_marker.cpp
+++ b/planning/autoware_obstacle_stop_planner/src/debug_marker.cpp
@@ -47,7 +47,6 @@ ObstacleStopPlannerDebugNode::ObstacleStopPlannerDebugNode(
 {
   virtual_wall_pub_ = node_->create_publisher<MarkerArray>("~/virtual_wall", 1);
   debug_viz_pub_ = node_->create_publisher<MarkerArray>("~/debug/marker", 1);
-  stop_reason_pub_ = node_->create_publisher<StopReasonArray>("~/output/stop_reasons", 1);
   velocity_factor_pub_ =
     node_->create_publisher<VelocityFactorArray>("/planning/velocity_factors/obstacle_stop", 1);
   pub_debug_values_ =
@@ -188,8 +187,6 @@ void ObstacleStopPlannerDebugNode::publish()
   debug_viz_pub_->publish(visualization_msg);
 
   /* publish stop reason for autoware api */
-  const auto stop_reason_msg = makeStopReasonArray();
-  stop_reason_pub_->publish(stop_reason_msg);
   const auto velocity_factor_msg = makeVelocityFactorArray();
   velocity_factor_pub_->publish(velocity_factor_msg);
 
@@ -491,33 +488,6 @@ MarkerArray ObstacleStopPlannerDebugNode::makeVisualizationMarker()
   }
 
   return msg;
-}
-
-StopReasonArray ObstacleStopPlannerDebugNode::makeStopReasonArray()
-{
-  // create header
-  Header header;
-  header.frame_id = "map";
-  header.stamp = node_->now();
-
-  // create stop reason stamped
-  StopReason stop_reason_msg;
-  stop_reason_msg.reason = StopReason::OBSTACLE_STOP;
-  StopFactor stop_factor;
-
-  if (stop_pose_ptr_ != nullptr) {
-    stop_factor.stop_pose = *stop_pose_ptr_;
-    if (stop_obstacle_point_ptr_ != nullptr) {
-      stop_factor.stop_factor_points.emplace_back(*stop_obstacle_point_ptr_);
-    }
-    stop_reason_msg.stop_factors.emplace_back(stop_factor);
-  }
-
-  // create stop reason array
-  StopReasonArray stop_reason_array;
-  stop_reason_array.header = header;
-  stop_reason_array.stop_reasons.emplace_back(stop_reason_msg);
-  return stop_reason_array;
 }
 
 VelocityFactorArray ObstacleStopPlannerDebugNode::makeVelocityFactorArray()

--- a/planning/autoware_obstacle_stop_planner/src/debug_marker.hpp
+++ b/planning/autoware_obstacle_stop_planner/src/debug_marker.hpp
@@ -21,7 +21,6 @@
 #include <geometry_msgs/msg/point.hpp>
 #include <geometry_msgs/msg/pose.hpp>
 #include <tier4_debug_msgs/msg/float32_multi_array_stamped.hpp>
-#include <tier4_planning_msgs/msg/stop_reason_array.hpp>
 #include <visualization_msgs/msg/marker.hpp>
 #include <visualization_msgs/msg/marker_array.hpp>
 
@@ -47,9 +46,6 @@ using autoware_adapi_v1_msgs::msg::PlanningBehavior;
 using autoware_adapi_v1_msgs::msg::VelocityFactor;
 using autoware_adapi_v1_msgs::msg::VelocityFactorArray;
 using tier4_debug_msgs::msg::Float32MultiArrayStamped;
-using tier4_planning_msgs::msg::StopFactor;
-using tier4_planning_msgs::msg::StopReason;
-using tier4_planning_msgs::msg::StopReasonArray;
 
 enum class PolygonType : int8_t { Vehicle = 0, Collision, SlowDownRange, SlowDown, Obstacle };
 
@@ -113,7 +109,6 @@ public:
   bool pushObstaclePoint(const pcl::PointXYZ & obstacle_point, const PointType & type);
   MarkerArray makeVirtualWallMarker();
   MarkerArray makeVisualizationMarker();
-  StopReasonArray makeStopReasonArray();
   VelocityFactorArray makeVelocityFactorArray();
 
   void setDebugValues(const DebugValues::TYPE type, const double val)
@@ -125,7 +120,6 @@ public:
 private:
   rclcpp::Publisher<MarkerArray>::SharedPtr virtual_wall_pub_;
   rclcpp::Publisher<MarkerArray>::SharedPtr debug_viz_pub_;
-  rclcpp::Publisher<StopReasonArray>::SharedPtr stop_reason_pub_;
   rclcpp::Publisher<VelocityFactorArray>::SharedPtr velocity_factor_pub_;
   rclcpp::Publisher<Float32MultiArrayStamped>::SharedPtr pub_debug_values_;
   rclcpp::Node * node_;


### PR DESCRIPTION
## Description

Don't use stop reason. This module uses velocity factor instead of it.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

Please confirm that this module doesn't output stop reason.

```
/planning/scenario_planning/status/stop_reasons
```

- [x] [TIER IV INTERNAL SCENARIOS](https://evaluation.tier4.jp/evaluation/reports/7fd68c7e-5f22-5b47-85c9-e829bdbc1e43?project_id=prd_jt)

## Notes for reviewers

After this PR, this module only outputs velocity factors.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
