### PR TITLE
fix(traffic_light_roi_visualizer): show unknown results correctly

### DIFF
--- a/perception/autoware_traffic_light_visualization/src/traffic_light_roi_visualizer/node.cpp
+++ b/perception/autoware_traffic_light_visualization/src/traffic_light_roi_visualizer/node.cpp
@@ -201,15 +201,17 @@ void TrafficLightRoiVisualizerNode::imageRoughRoiCallback(
     // bbox drawing
     cv_ptr = cv_bridge::toCvCopy(input_image_msg, sensor_msgs::image_encodings::RGB8);
     for (auto tl_rough_roi : input_tl_rough_roi_msg->rois) {
-      // visualize rough roi
-      createRect(cv_ptr->image, tl_rough_roi, cv::Scalar(0, 255, 0));
-
+      // note: a signal will still be output even if it is undetected
+      // Its position and size will be set as 0 and the color will be set as unknown
+      // So a rough roi will always have correspond roi a correspond traffic signal
       ClassificationResult result;
       bool has_correspond_traffic_signal =
         getClassificationResult(tl_rough_roi.traffic_light_id, *input_traffic_signals_msg, result);
       tier4_perception_msgs::msg::TrafficLightRoi tl_roi;
       bool has_correspond_roi =
         getRoiFromId(tl_rough_roi.traffic_light_id, input_tl_roi_msg, tl_roi);
+
+      createRect(cv_ptr->image, tl_rough_roi, extractShapeInfo(result.label).color);
 
       if (has_correspond_roi && has_correspond_traffic_signal) {
         // has fine detection and classification results

--- a/perception/autoware_traffic_light_visualization/src/traffic_light_roi_visualizer/shape_draw.cpp
+++ b/perception/autoware_traffic_light_visualization/src/traffic_light_roi_visualizer/shape_draw.cpp
@@ -29,6 +29,10 @@ void drawShape(
   cv::Mat & image, const std::vector<ShapeImgParam> & params, int size, const cv::Point & position,
   const cv::Scalar & color, float probability)
 {
+  // skip if the roi position is set as (0,0), which means it is undetected
+  if (position.x == 0 && position.y == 0) {
+    return;
+  }
   // load concatenated shape image
   const auto shape_img = loadShapeImage(params, size);
 
@@ -42,14 +46,13 @@ void drawShape(
   const int fill_rect_h = std::max(shape_img.rows, text_size.height) + 10;
 
   const cv::Point rect_position(position.x, position.y - fill_rect_h);
-
   if (
     rect_position.x < 0 || rect_position.y < 0 || rect_position.x + fill_rect_w > image.cols ||
     position.y > image.rows) {
     // TODO(KhalilSelyan): This error message may flood the terminal logs, so commented out
     // temporarily. Need to consider a better way.
 
-    // std::cerr << "Adjusted position is out of image bounds." << std::endl;
+    std::cerr << "Adjusted position is out of image bounds." << std::endl;
     return;
   }
   cv::Rect rectangle(rect_position.x, rect_position.y, fill_rect_w, fill_rect_h);


### PR DESCRIPTION
## Description

This PR fixes the following issue: https://github.com/autowarefoundation/autoware.universe/issues/7924

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

![image](https://github.com/user-attachments/assets/4683eb12-7a66-40a4-a418-87f07b47bf48)
The rough roi of unknown traffic light is shown in white.
The error message resulted by the undetected traffic lights is fixed, so that it will not flood the terminal.

## Notes for reviewers

https://github.com/autowarefoundation/autoware.universe/pull/5934
Previously, it was required to output the signal message as long as the rough roi exists. 
I'm afraid there exists some misunderstanding here, as a result `has_correspond_traffic_signal` and `has_correspond_roi` at [ this part ](https://github.com/autowarefoundation/autoware.universe/blob/main/perception/autoware_traffic_light_visualization/src/traffic_light_roi_visualizer/node.cpp#L208-L225) will always be True.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
