### PR TITLE
fix(autoware_bytetrack): fix clang-diagnostic-implicit-const-int-float-conversion

### DIFF
--- a/perception/autoware_bytetrack/lib/include/byte_tracker.h
+++ b/perception/autoware_bytetrack/lib/include/byte_tracker.h
@@ -41,6 +41,7 @@
 #include "strack.h"
 
 #include <vector>
+#include <limits>
 
 struct ByteTrackObject
 {
@@ -83,7 +84,7 @@ private:
 
   double lapjv(
     const std::vector<std::vector<float>> & cost, std::vector<int> & rowsol,
-    std::vector<int> & colsol, bool extend_cost = false, float cost_limit = LONG_MAX,
+    std::vector<int> & colsol, bool extend_cost = false, float cost_limit = std::numeric_limits<float>::max(),
     bool return_cost = true);
 
 private:

--- a/perception/autoware_bytetrack/lib/include/byte_tracker.h
+++ b/perception/autoware_bytetrack/lib/include/byte_tracker.h
@@ -40,8 +40,8 @@
 
 #include "strack.h"
 
-#include <vector>
 #include <limits>
+#include <vector>
 
 struct ByteTrackObject
 {
@@ -84,8 +84,8 @@ private:
 
   double lapjv(
     const std::vector<std::vector<float>> & cost, std::vector<int> & rowsol,
-    std::vector<int> & colsol, bool extend_cost = false, float cost_limit = std::numeric_limits<float>::max(),
-    bool return_cost = true);
+    std::vector<int> & colsol, bool extend_cost = false,
+    float cost_limit = std::numeric_limits<float>::max(), bool return_cost = true);
 
 private:
   float track_thresh;


### PR DESCRIPTION
## Description
This is a fix based on clang-tidy `clang-diagnostic-implicit-const-int-float-conversion` error.

```
/home/emb4/autoware/autoware/src/universe/autoware.universe/perception/autoware_bytetrack/lib/include/byte_tracker.h:86:77: error: implicit conversion from 'long' to 'float' changes value from 9223372036854775807 to 9223372036854775808 [clang-diagnostic-implicit-const-int-float-conversion]
    std::vector<int> & colsol, bool extend_cost = false, float cost_limit = LONG_MAX,
                                                                          ~ ^
```
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
