### PR TITLE
refactor(autoware_behavior_velocity_planner_common,autoware_behavior_velocity_planner): separate param files

### DIFF
--- a/launch/tier4_planning_launch/launch/scenario_planning/lane_driving/behavior_planning/behavior_planning.launch.xml
+++ b/launch/tier4_planning_launch/launch/scenario_planning/lane_driving/behavior_planning/behavior_planning.launch.xml
@@ -233,6 +233,7 @@
       <param from="$(var velocity_smoother_param_path)"/>
       <param from="$(var behavior_velocity_smoother_type_param_path)"/>
       <param from="$(var behavior_velocity_planner_common_param_path)"/>
+      <param from="$(var behavior_velocity_planner_param_path)"/>
       <param name="launch_modules" value="$(var behavior_velocity_planner_launch_modules)"/>
       <param name="enable_all_modules_auto_mode" value="$(var enable_all_modules_auto_mode)"/>
       <param name="is_simulation" value="$(var is_simulation)"/>

--- a/planning/autoware_static_centerline_generator/test/test_static_centerline_generator.test.py
+++ b/planning/autoware_static_centerline_generator/test/test_static_centerline_generator.test.py
@@ -59,8 +59,8 @@ def generate_test_description():
                 "config/behavior_path_planner.param.yaml",
             ),
             os.path.join(
-                get_package_share_directory("autoware_behavior_velocity_planner"),
-                "config/behavior_velocity_planner.param.yaml",
+                get_package_share_directory("autoware_behavior_velocity_planner_common"),
+                "config/behavior_velocity_planner_common.param.yaml",
             ),
             os.path.join(
                 get_package_share_directory("autoware_path_smoother"),

--- a/planning/autoware_static_centerline_generator/test/test_static_centerline_generator.test.py
+++ b/planning/autoware_static_centerline_generator/test/test_static_centerline_generator.test.py
@@ -59,8 +59,8 @@ def generate_test_description():
                 "config/behavior_path_planner.param.yaml",
             ),
             os.path.join(
-                get_package_share_directory("autoware_behavior_velocity_planner_common"),
-                "config/behavior_velocity_planner_common.param.yaml",
+                get_package_share_directory("autoware_behavior_velocity_planner"),
+                "config/behavior_velocity_planner.param.yaml",
             ),
             os.path.join(
                 get_package_share_directory("autoware_path_smoother"),

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/config/behavior_velocity_planner.param.yaml
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/config/behavior_velocity_planner.param.yaml
@@ -4,8 +4,3 @@
     backward_path_length: 5.0
     behavior_output_path_interval: 1.0
     stop_line_extend_length: 5.0
-    max_accel: -2.8
-    max_jerk: -5.0
-    system_delay: 0.5
-    delay_response_time: 0.5
-    is_publish_debug_path: false # publish all debug path with lane id in each module

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/launch/behavior_velocity_planner.launch.xml
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/launch/behavior_velocity_planner.launch.xml
@@ -11,6 +11,7 @@
   <!-- module config path -->
   <arg name="behavior_velocity_config_path"/>
   <arg name="behavior_velocity_smoother_type_param_path"/>
+  <arg name="behavior_velocity_planner_param_path"/>
   <arg name="behavior_velocity_planner_common_param_path"/>
   <arg name="behavior_velocity_planner_blind_spot_module_param_path"/>
   <arg name="behavior_velocity_planner_crosswalk_module_param_path"/>
@@ -26,7 +27,6 @@
   <arg name="behavior_velocity_planner_speed_bump_module_param_path"/>
   <arg name="behavior_velocity_planner_no_drivable_lane_module_param_path"/>
   <!-- <arg name="behavior_velocity_planner_template_module_param_path"/> -->
-  <arg name="behavior_velocity_planner_param_file" default="$(find-pkg-share behavior_velocity_planner)/config/behavior_velocity_planner.param.yaml"/>
 
   <node pkg="autoware_behavior_velocity_planner" exec="behavior_velocity_planner_node" name="behavior_velocity_planner" output="screen">
     <!-- topic remap -->
@@ -53,6 +53,7 @@
     <param from="$(var vehicle_param_file)"/>
     <param from="$(var nearest_search_param_path)"/>
     <param from="$(var behavior_velocity_smoother_type_param_path)"/>
+    <param from="$(var behavior_velocity_planner_param_path)"/>
     <param from="$(var behavior_velocity_planner_common_param_path)"/>
     <param from="$(var behavior_velocity_planner_blind_spot_module_param_path)"/>
     <param from="$(var behavior_velocity_planner_crosswalk_module_param_path)"/>
@@ -68,7 +69,5 @@
     <param from="$(var behavior_velocity_planner_speed_bump_module_param_path)"/>
     <param from="$(var behavior_velocity_planner_no_drivable_lane_module_param_path)"/>
     <!-- <param from="$(var behavior_velocity_planner_template_param_path)"/> -->
-
-    <param from="$(var behavior_velocity_planner_param_file)"/>
   </node>
 </launch>

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/schema/behavior_velocity_planner.schema.json
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/schema/behavior_velocity_planner.schema.json
@@ -21,47 +21,17 @@
           "default": "1.0",
           "description": "the output path will be interpolated by this interval"
         },
-        "max_accel": {
-          "type": "number",
-          "default": "-2.8",
-          "description": "(to be a global parameter) max acceleration of the vehicle"
-        },
-        "system_delay": {
-          "type": "number",
-          "default": "0.5",
-          "description": "(to be a global parameter) delay time until output control command"
-        },
-        "delay_response_time": {
-          "type": "number",
-          "default": "0.5",
-          "description": "(to be a global parameter) delay time of the vehicle's response to control commands"
-        },
         "stop_line_extend_length": {
           "type": "number",
           "default": "5.0",
           "description": "extend length of stop line"
-        },
-        "max_jerk": {
-          "type": "number",
-          "default": "-5.0",
-          "description": "max jerk of the vehicle"
-        },
-        "is_publish_debug_path": {
-          "type": "boolean",
-          "default": "false",
-          "description": "is publish debug path?"
         }
       },
       "required": [
         "forward_path_length",
         "behavior_output_path_interval",
         "backward_path_length",
-        "max_accel",
-        "system_delay",
-        "delay_response_time",
-        "stop_line_extend_length",
-        "max_jerk",
-        "is_publish_debug_path"
+        "stop_line_extend_length"
       ],
       "additionalProperties": false
     }

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/test/src/test_node_interface.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/test/src/test_node_interface.cpp
@@ -49,6 +49,8 @@ std::shared_ptr<BehaviorVelocityPlannerNode> generateNode()
 
   const auto autoware_test_utils_dir =
     ament_index_cpp::get_package_share_directory("autoware_test_utils");
+  const auto behavior_velocity_planner_common_dir =
+    ament_index_cpp::get_package_share_directory("autoware_behavior_velocity_planner_common");
   const auto behavior_velocity_planner_dir =
     ament_index_cpp::get_package_share_directory("autoware_behavior_velocity_planner");
   const auto velocity_smoother_dir =
@@ -82,25 +84,27 @@ std::shared_ptr<BehaviorVelocityPlannerNode> generateNode()
   node_options.parameter_overrides(params);
 
   autoware::test_utils::updateNodeOptions(
-    node_options, {autoware_test_utils_dir + "/config/test_common.param.yaml",
-                   autoware_test_utils_dir + "/config/test_nearest_search.param.yaml",
-                   autoware_test_utils_dir + "/config/test_vehicle_info.param.yaml",
-                   velocity_smoother_dir + "/config/default_velocity_smoother.param.yaml",
-                   velocity_smoother_dir + "/config/Analytical.param.yaml",
-                   behavior_velocity_planner_dir + "/config/behavior_velocity_planner.param.yaml",
-                   get_behavior_velocity_module_config("blind_spot"),
-                   get_behavior_velocity_module_config("crosswalk"),
-                   get_behavior_velocity_module_config("walkway"),
-                   get_behavior_velocity_module_config("detection_area"),
-                   get_behavior_velocity_module_config("intersection"),
-                   get_behavior_velocity_module_config("no_stopping_area"),
-                   get_behavior_velocity_module_config("occlusion_spot"),
-                   get_behavior_velocity_module_config("run_out"),
-                   get_behavior_velocity_module_config("speed_bump"),
-                   get_behavior_velocity_module_config("stop_line"),
-                   get_behavior_velocity_module_config("traffic_light"),
-                   get_behavior_velocity_module_config("virtual_traffic_light"),
-                   get_behavior_velocity_module_config("no_drivable_lane")});
+    node_options,
+    {autoware_test_utils_dir + "/config/test_common.param.yaml",
+     autoware_test_utils_dir + "/config/test_nearest_search.param.yaml",
+     autoware_test_utils_dir + "/config/test_vehicle_info.param.yaml",
+     velocity_smoother_dir + "/config/default_velocity_smoother.param.yaml",
+     velocity_smoother_dir + "/config/Analytical.param.yaml",
+     behavior_velocity_planner_common_dir + "/config/behavior_velocity_planner_common.param.yaml",
+     behavior_velocity_planner_dir + "/config/behavior_velocity_planner.param.yaml",
+     get_behavior_velocity_module_config("blind_spot"),
+     get_behavior_velocity_module_config("crosswalk"),
+     get_behavior_velocity_module_config("walkway"),
+     get_behavior_velocity_module_config("detection_area"),
+     get_behavior_velocity_module_config("intersection"),
+     get_behavior_velocity_module_config("no_stopping_area"),
+     get_behavior_velocity_module_config("occlusion_spot"),
+     get_behavior_velocity_module_config("run_out"),
+     get_behavior_velocity_module_config("speed_bump"),
+     get_behavior_velocity_module_config("stop_line"),
+     get_behavior_velocity_module_config("traffic_light"),
+     get_behavior_velocity_module_config("virtual_traffic_light"),
+     get_behavior_velocity_module_config("no_drivable_lane")});
 
   // TODO(Takagi, Isamu): set launch_modules
   // TODO(Kyoichi Sugahara) set to true launch_virtual_traffic_light

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/CMakeLists.txt
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/CMakeLists.txt
@@ -26,4 +26,6 @@ if(BUILD_TESTING)
   )
 endif()
 
-ament_auto_package()
+ament_auto_package(INSTALL_TO_SHARE
+  config
+)

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/config/behavior_velocity_planner_common.param.yaml
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/config/behavior_velocity_planner_common.param.yaml
@@ -1,0 +1,7 @@
+/**:
+  ros__parameters:
+    max_accel: -2.8
+    max_jerk: -5.0
+    system_delay: 0.5
+    delay_response_time: 0.5
+    is_publish_debug_path: false # publish all debug path with lane id in each module

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/schema/behavior_velocity_planner_common.schema.json
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/schema/behavior_velocity_planner_common.schema.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Parameters for Behavior Velocity Planner Common",
+  "type": "object",
+  "definitions": {
+    "behavior_velocity_planner_common": {
+      "type": "object",
+      "properties": {
+        "max_accel": {
+          "type": "number",
+          "default": "-2.8",
+          "description": "(to be a global parameter) max acceleration of the vehicle"
+        },
+        "system_delay": {
+          "type": "number",
+          "default": "0.5",
+          "description": "(to be a global parameter) delay time until output control command"
+        },
+        "delay_response_time": {
+          "type": "number",
+          "default": "0.5",
+          "description": "(to be a global parameter) delay time of the vehicle's response to control commands"
+        },
+        "max_jerk": {
+          "type": "number",
+          "default": "-5.0",
+          "description": "max jerk of the vehicle"
+        },
+        "is_publish_debug_path": {
+          "type": "boolean",
+          "default": "false",
+          "description": "is publish debug path?"
+        }
+      },
+      "required": [
+        "max_accel",
+        "system_delay",
+        "delay_response_time",
+        "max_jerk",
+        "is_publish_debug_path"
+      ],
+      "additionalProperties": false
+    }
+  },
+  "properties": {
+    "/**": {
+      "type": "object",
+      "properties": {
+        "ros__parameters": {
+          "$ref": "#/definitions/behavior_velocity_planner_common"
+        }
+      },
+      "required": ["ros__parameters"],
+      "additionalProperties": false
+    }
+  },
+  "required": ["/**"],
+  "additionalProperties": false
+}

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/scripts/dilemma_zone_plotter.py
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/scripts/dilemma_zone_plotter.py
@@ -38,7 +38,7 @@ def get_params_from_yaml():
     # get parameters from behavior velocity planner
     behavior_vel_yaml_file_path = os.path.join(
         autoware_launch_package_path,
-        "config/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/behavior_velocity_planner.param.yaml",
+        "config/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner/behavior_velocity_planner_common.param.yaml",
     )
     with open(behavior_vel_yaml_file_path, "r") as yaml_file:
         params = yaml.safe_load(yaml_file)


### PR DESCRIPTION
## Description

Previously, `behaviour_velocity_planner/config/behaviour_velocity_planner.param.yaml` was used in `autoware_behaviour_velocity_planner` and `autoware_behaviour_velocity_planner_common`.
In this PR, `behaviour_velocity_planner.param.yaml` is split into `behaviour_velocity_planner.param.yaml` and `behaviour_velocity_planner_common.param.yaml`. `behaviour_velocity_planner.param.yaml` is only used in `behaviour_velocity_planner` and `behaviour_velocity_planner_common.param.yaml`  is only used in `behaviour_velocity_planner_common` .

- Before

  <details><summary>behavior_velocity_planner/config/behavior_velocity_planner.param.yaml</summary>

    ```yaml
    /**:
    ros__parameters:
        forward_path_length: 1000.0
        backward_path_length: 5.0
        behavior_output_path_interval: 1.0
        stop_line_extend_length: 5.0
        max_accel: -2.8
        max_jerk: -5.0
        system_delay: 0.5
        delay_response_time: 0.5
        is_publish_debug_path: false # publish all debug path with lane id in each module
    ```

  </details>

- After

  <details><summary>behavior_velocity_planner/config/behavior_velocity_planner.param.yaml</summary>

    ```yaml
    /**:
    ros__parameters:
        forward_path_length: 1000.0
        backward_path_length: 5.0
        behavior_output_path_interval: 1.0
        stop_line_extend_length: 5.0
    ```

  </details>

  <details><summary>behavior_velocity_planner_common/config/behavior_velocity_planner_common.param.yaml</summary>

    ```yaml
    /**:
    ros__parameters:
        max_accel: -2.8
        max_jerk: -5.0
        system_delay: 0.5
        delay_response_time: 0.5
        is_publish_debug_path: false # publish all debug path with lane id in each module
    ```

  </details>

### Why do I need this change?

The file `behavior_velocity_plannner/config/behaviour_velocity_planner.param.yaml` was needed to create unit tests for `behavior_velocity_plannner_common`. However, if `behavior_velocity_plannner_common` depends on `behavior_velocity_plannner`, it causes circular references. Therefore, I came up with the idea of creating this PR.

## Related links

https://github.com/autowarefoundation/autoware_launch/pull/1254

## How was this PR tested?

Tested on psim.

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
