### PR TITLE
feat(tier4_state_rviz_plugin): check for abrupt deceleration

### DIFF
--- a/common/tier4_state_rviz_plugin/package.xml
+++ b/common/tier4_state_rviz_plugin/package.xml
@@ -14,6 +14,7 @@
 
   <depend>ament_index_cpp</depend>
   <depend>autoware_adapi_v1_msgs</depend>
+  <depend>autoware_motion_utils</depend>
   <depend>autoware_vehicle_msgs</depend>
   <depend>libqt5-core</depend>
   <depend>libqt5-gui</depend>

--- a/common/tier4_state_rviz_plugin/src/include/velocity_steering_factors_panel.hpp
+++ b/common/tier4_state_rviz_plugin/src/include/velocity_steering_factors_panel.hpp
@@ -53,6 +53,8 @@ protected:
   static constexpr double JERK_DEFAULT = 1.0;
   static constexpr double DECEL_LIMIT_DEFAULT = 1.0;
 
+  static constexpr QColor COLOR_FREAK_PINK = {255, 0, 108};
+
   // Layout
   QGroupBox * makeVelocityFactorsGroup();
   QGroupBox * makeSteeringFactorsGroup();

--- a/common/tier4_state_rviz_plugin/src/include/velocity_steering_factors_panel.hpp
+++ b/common/tier4_state_rviz_plugin/src/include/velocity_steering_factors_panel.hpp
@@ -50,13 +50,8 @@ public:
   void onInitialize() override;
 
 protected:
-  static constexpr double JERK_MIN = 0.0;
   static constexpr double JERK_DEFAULT = 1.0;
-  static constexpr double JERK_MAX = 2.0;
-
-  static constexpr double DECEL_LIMIT_MIN = 0.0;
   static constexpr double DECEL_LIMIT_DEFAULT = 1.0;
-  static constexpr double DECEL_LIMIT_MAX = 2.0;
 
   // Layout
   QGroupBox * makeVelocityFactorsGroup();

--- a/common/tier4_state_rviz_plugin/src/include/velocity_steering_factors_panel.hpp
+++ b/common/tier4_state_rviz_plugin/src/include/velocity_steering_factors_panel.hpp
@@ -29,6 +29,8 @@
 #include <autoware_adapi_v1_msgs/msg/planning_behavior.hpp>
 #include <autoware_adapi_v1_msgs/msg/steering_factor_array.hpp>
 #include <autoware_adapi_v1_msgs/msg/velocity_factor_array.hpp>
+#include <geometry_msgs/msg/accel_with_covariance_stamped.hpp>
+#include <nav_msgs/msg/odometry.hpp>
 
 #include <memory>
 
@@ -49,6 +51,14 @@ public:
   void onInitialize() override;
 
 protected:
+  static constexpr double MAX_JERK_MIN = 0.0;
+  static constexpr double MAX_JERK_DEFAULT = 1.0;
+  static constexpr double MAX_JERK_MAX = 2.0;
+
+  static constexpr double MAX_DECELERATION_MIN = 0.0;
+  static constexpr double MAX_DECELERATION_DEFAULT = 1.0;
+  static constexpr double MAX_DECELERATION_MAX = 2.0;
+
   // Layout
   QGroupBox * makeVelocityFactorsGroup();
   QGroupBox * makeSteeringFactorsGroup();
@@ -58,12 +68,24 @@ protected:
   // Planning
   QTableWidget * velocity_factors_table_{nullptr};
   QTableWidget * steering_factors_table_{nullptr};
+  QSlider * max_jerk_slider_{nullptr};
+  QLabel * max_jerk_label_{nullptr};
+  QSlider * max_deceleration_slider_{nullptr};
+  QLabel * max_deceleration_label_{nullptr};
 
+  nav_msgs::msg::Odometry::ConstSharedPtr kinematic_state_;
+  geometry_msgs::msg::AccelWithCovarianceStamped::ConstSharedPtr acceleration_;
+
+  rclcpp::Subscription<nav_msgs::msg::Odometry>::SharedPtr sub_kinematic_state_;
+  rclcpp::Subscription<geometry_msgs::msg::AccelWithCovarianceStamped>::SharedPtr sub_acceleration_;
   rclcpp::Subscription<VelocityFactorArray>::SharedPtr sub_velocity_factors_;
   rclcpp::Subscription<SteeringFactorArray>::SharedPtr sub_steering_factors_;
 
   void onVelocityFactors(const VelocityFactorArray::ConstSharedPtr msg);
   void onSteeringFactors(const SteeringFactorArray::ConstSharedPtr msg);
+
+  double getMaxJerk() const;
+  double getMaxDeceleration() const;
 };
 }  // namespace rviz_plugins
 

--- a/common/tier4_state_rviz_plugin/src/include/velocity_steering_factors_panel.hpp
+++ b/common/tier4_state_rviz_plugin/src/include/velocity_steering_factors_panel.hpp
@@ -17,11 +17,10 @@
 #ifndef VELOCITY_STEERING_FACTORS_PANEL_HPP_
 #define VELOCITY_STEERING_FACTORS_PANEL_HPP_
 
+#include <QDoubleSpinBox>
 #include <QGroupBox>
 #include <QLabel>
 #include <QLayout>
-#include <QPushButton>
-#include <QSpinBox>
 #include <QTableWidget>
 #include <rclcpp/rclcpp.hpp>
 #include <rviz_common/panel.hpp>
@@ -51,13 +50,13 @@ public:
   void onInitialize() override;
 
 protected:
-  static constexpr double MAX_JERK_MIN = 0.0;
-  static constexpr double MAX_JERK_DEFAULT = 1.0;
-  static constexpr double MAX_JERK_MAX = 2.0;
+  static constexpr double JERK_MIN = 0.0;
+  static constexpr double JERK_DEFAULT = 1.0;
+  static constexpr double JERK_MAX = 2.0;
 
-  static constexpr double MAX_DECELERATION_MIN = 0.0;
-  static constexpr double MAX_DECELERATION_DEFAULT = 1.0;
-  static constexpr double MAX_DECELERATION_MAX = 2.0;
+  static constexpr double DECEL_LIMIT_MIN = 0.0;
+  static constexpr double DECEL_LIMIT_DEFAULT = 1.0;
+  static constexpr double DECEL_LIMIT_MAX = 2.0;
 
   // Layout
   QGroupBox * makeVelocityFactorsGroup();
@@ -68,10 +67,8 @@ protected:
   // Planning
   QTableWidget * velocity_factors_table_{nullptr};
   QTableWidget * steering_factors_table_{nullptr};
-  QSlider * max_jerk_slider_{nullptr};
-  QLabel * max_jerk_label_{nullptr};
-  QSlider * max_deceleration_slider_{nullptr};
-  QLabel * max_deceleration_label_{nullptr};
+  QDoubleSpinBox * jerk_input_{nullptr};
+  QDoubleSpinBox * decel_limit_input_{nullptr};
 
   nav_msgs::msg::Odometry::ConstSharedPtr kinematic_state_;
   geometry_msgs::msg::AccelWithCovarianceStamped::ConstSharedPtr acceleration_;
@@ -83,9 +80,6 @@ protected:
 
   void onVelocityFactors(const VelocityFactorArray::ConstSharedPtr msg);
   void onSteeringFactors(const SteeringFactorArray::ConstSharedPtr msg);
-
-  double getMaxJerk() const;
-  double getMaxDeceleration() const;
 };
 }  // namespace rviz_plugins
 

--- a/common/tier4_state_rviz_plugin/src/velocity_steering_factors_panel.cpp
+++ b/common/tier4_state_rviz_plugin/src/velocity_steering_factors_panel.cpp
@@ -200,7 +200,7 @@ void VelocitySteeringFactorsPanel::onVelocityFactors(const VelocityFactorArray::
       const auto decel_dist = autoware::motion_utils::calcDecelDistWithJerkAndAccConstraints(
         current_vel, 0., current_acc, acc_min, jerk_acc, -jerk_acc);
       if (decel_dist > e.distance && e.distance >= 0 && e.status == VelocityFactor::APPROACHING) {
-        return QColor{255, 0, 0, 127};
+        return COLOR_FREAK_PINK;
       }
       return {};
     }();

--- a/common/tier4_state_rviz_plugin/src/velocity_steering_factors_panel.cpp
+++ b/common/tier4_state_rviz_plugin/src/velocity_steering_factors_panel.cpp
@@ -62,8 +62,7 @@ QGroupBox * VelocitySteeringFactorsPanel::makeVelocityFactorsGroup()
   grid->addWidget(jerk_label, 0, 1);
 
   jerk_input_ = new QDoubleSpinBox;
-  jerk_input_->setMinimum(JERK_MIN);
-  jerk_input_->setMaximum(JERK_MAX);
+  jerk_input_->setMinimum(0.0);
   jerk_input_->setValue(JERK_DEFAULT);
   jerk_input_->setSingleStep(0.1);
   jerk_input_->setSuffix(" [m/s\u00B3]");
@@ -73,8 +72,7 @@ QGroupBox * VelocitySteeringFactorsPanel::makeVelocityFactorsGroup()
   grid->addWidget(decel_limit_label, 2, 1);
 
   decel_limit_input_ = new QDoubleSpinBox;
-  decel_limit_input_->setMinimum(DECEL_LIMIT_MIN);
-  decel_limit_input_->setMaximum(DECEL_LIMIT_MAX);
+  decel_limit_input_->setMinimum(0.0);
   decel_limit_input_->setValue(DECEL_LIMIT_DEFAULT);
   decel_limit_input_->setSingleStep(0.1);
   decel_limit_input_->setSuffix(" [m/s\u00B2]");

--- a/common/tier4_state_rviz_plugin/src/velocity_steering_factors_panel.cpp
+++ b/common/tier4_state_rviz_plugin/src/velocity_steering_factors_panel.cpp
@@ -21,6 +21,7 @@
 #include <QHeaderView>
 #include <QString>
 #include <QVBoxLayout>
+#include <autoware/motion_utils/distance/distance.hpp>
 #include <rviz_common/display_context.hpp>
 
 #include <memory>
@@ -46,7 +47,8 @@ QGroupBox * VelocitySteeringFactorsPanel::makeVelocityFactorsGroup()
   auto vertical_header = new QHeaderView(Qt::Vertical);
   vertical_header->hide();
   auto horizontal_header = new QHeaderView(Qt::Horizontal);
-  horizontal_header->setSectionResizeMode(QHeaderView::Stretch);
+  horizontal_header->setSectionResizeMode(QHeaderView::ResizeToContents);
+  horizontal_header->setStretchLastSection(true);
 
   auto header_labels = QStringList({"Type", "Status", "Distance [m]", "Detail"});
   velocity_factors_table_ = new QTableWidget();
@@ -54,7 +56,47 @@ QGroupBox * VelocitySteeringFactorsPanel::makeVelocityFactorsGroup()
   velocity_factors_table_->setHorizontalHeaderLabels(header_labels);
   velocity_factors_table_->setVerticalHeader(vertical_header);
   velocity_factors_table_->setHorizontalHeader(horizontal_header);
-  grid->addWidget(velocity_factors_table_, 0, 0);
+  grid->addWidget(velocity_factors_table_, 0, 0, 1, 3);
+
+  auto * max_jerk_slider_label = new QLabel("Max jerk");
+  grid->addWidget(max_jerk_slider_label, 1, 0);
+
+  max_jerk_slider_ = new QSlider(Qt::Horizontal);
+  max_jerk_slider_->setMinimum(0);
+  max_jerk_slider_->setMaximum(100);
+  grid->addWidget(max_jerk_slider_, 1, 1);
+
+  max_jerk_label_ = new QLabel;
+  grid->addWidget(max_jerk_label_, 1, 2);
+
+  auto * max_deceleration_slider_label = new QLabel("Max deceleration");
+  grid->addWidget(max_deceleration_slider_label, 2, 0);
+
+  max_deceleration_slider_ = new QSlider(Qt::Horizontal);
+  max_deceleration_slider_->setMinimum(0);
+  max_deceleration_slider_->setMaximum(100);
+  grid->addWidget(max_deceleration_slider_, 2, 1);
+
+  max_deceleration_label_ = new QLabel;
+  grid->addWidget(max_deceleration_label_, 2, 2);
+
+  connect(max_jerk_slider_, &QSlider::valueChanged, this, [this](int) {
+    max_jerk_label_->setText(QString("%1 [m/s<sup>3</sup>]").arg(getMaxJerk(), 4, 'f', 2));
+  });
+  connect(max_deceleration_slider_, &QSlider::valueChanged, this, [this](int) {
+    max_deceleration_label_->setText(
+      QString("%1 [m/s<sup>2</sup>]").arg(getMaxDeceleration(), 4, 'f', 2));
+  });
+
+  max_jerk_slider_->setValue(
+    max_jerk_slider_->minimum() + (max_jerk_slider_->maximum() - max_jerk_slider_->minimum()) *
+                                    (MAX_JERK_DEFAULT - MAX_JERK_MIN) /
+                                    (MAX_JERK_MAX - MAX_JERK_MIN));
+  max_deceleration_slider_->setValue(
+    max_deceleration_slider_->minimum() +
+    (max_deceleration_slider_->maximum() - max_deceleration_slider_->minimum()) *
+      (MAX_DECELERATION_DEFAULT - MAX_DECELERATION_MIN) /
+      (MAX_DECELERATION_MAX - MAX_DECELERATION_MIN));
 
   group->setLayout(grid);
   return group;
@@ -90,6 +132,17 @@ void VelocitySteeringFactorsPanel::onInitialize()
   raw_node_ = this->getDisplayContext()->getRosNodeAbstraction().lock()->get_raw_node();
 
   // Planning
+  sub_kinematic_state_ = raw_node_->create_subscription<nav_msgs::msg::Odometry>(
+    "/localization/kinematic_state", 10,
+    [this](const nav_msgs::msg::Odometry::ConstSharedPtr msg) { kinematic_state_ = msg; });
+
+  sub_acceleration_ =
+    raw_node_->create_subscription<geometry_msgs::msg::AccelWithCovarianceStamped>(
+      "/localization/acceleration", 10,
+      [this](const geometry_msgs::msg::AccelWithCovarianceStamped::ConstSharedPtr msg) {
+        acceleration_ = msg;
+      });
+
   sub_velocity_factors_ = raw_node_->create_subscription<VelocityFactorArray>(
     "/api/planning/velocity_factors", 10,
     std::bind(&VelocitySteeringFactorsPanel::onVelocityFactors, this, _1));
@@ -154,6 +207,26 @@ void VelocitySteeringFactorsPanel::onVelocityFactors(const VelocityFactorArray::
       auto label = new QLabel(QString::fromStdString(e.detail));
       label->setAlignment(Qt::AlignCenter);
       velocity_factors_table_->setCellWidget(i, 3, label);
+    }
+
+    const auto row_background = [&]() -> QBrush {
+      if (!kinematic_state_ || !acceleration_) {
+        return {};
+      }
+      const auto & current_vel = kinematic_state_->twist.twist.linear.x;
+      const auto & current_acc = acceleration_->accel.accel.linear.x;
+      const auto acc_min = -getMaxDeceleration();
+      const auto jerk_acc = getMaxJerk();
+      const auto decel_dist = autoware::motion_utils::calcDecelDistWithJerkAndAccConstraints(
+        current_vel, 0., current_acc, acc_min, jerk_acc, -jerk_acc);
+      if (decel_dist > e.distance && e.distance >= 0 && e.status == VelocityFactor::APPROACHING) {
+        return QColor{255, 0, 0, 127};
+      }
+      return {};
+    }();
+    for (int j = 0; j < velocity_factors_table_->columnCount(); j++) {
+      velocity_factors_table_->setItem(i, j, new QTableWidgetItem);
+      velocity_factors_table_->item(i, j)->setBackground(row_background);
     }
   }
   velocity_factors_table_->update();
@@ -248,6 +321,21 @@ void VelocitySteeringFactorsPanel::onSteeringFactors(const SteeringFactorArray::
     }
   }
   steering_factors_table_->update();
+}
+
+double VelocitySteeringFactorsPanel::getMaxJerk() const
+{
+  return MAX_JERK_MIN + (MAX_JERK_MAX - MAX_JERK_MIN) *
+                          (max_jerk_slider_->value() - max_jerk_slider_->minimum()) /
+                          (max_jerk_slider_->maximum() - max_jerk_slider_->minimum());
+}
+
+double VelocitySteeringFactorsPanel::getMaxDeceleration() const
+{
+  return MAX_DECELERATION_MIN +
+         (MAX_DECELERATION_MAX - MAX_DECELERATION_MIN) *
+           (max_deceleration_slider_->value() - max_deceleration_slider_->minimum()) /
+           (max_deceleration_slider_->maximum() - max_deceleration_slider_->minimum());
 }
 }  // namespace rviz_plugins
 


### PR DESCRIPTION
## Description

This PR adds an abrupt deceleration checking feature to `VelocitySteeringFactorsPanel`.

If the minimum distance required to stop under the specified jerk and acceleration limit is greater than the distance to the stop point, abrupt deceleration is detected.

## How was this PR tested?

Psim

[Screencast from 2024年11月29日 19時36分39秒.webm](https://github.com/user-attachments/assets/03d68688-e5a7-40c2-b0bb-53bf924e83b1)

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
