### PR TITLE
fix(autoware_trajectory): autoware_trajectory bug

### DIFF
--- a/common/autoware_trajectory/src/path_point.cpp
+++ b/common/autoware_trajectory/src/path_point.cpp
@@ -76,7 +76,7 @@ std::vector<PointType> Trajectory<PointType>::restore(const size_t & min_points)
   points.reserve(bases.size());
   for (const auto & s : bases) {
     PointType p;
-    p.pose = Trajectory<geometry_msgs::msg::Pose>::compute(s);
+    p.pose = Trajectory<geometry_msgs::msg::Pose>::compute(s - start_);
     p.longitudinal_velocity_mps = static_cast<float>(this->longitudinal_velocity_mps.compute(s));
     p.lateral_velocity_mps = static_cast<float>(this->lateral_velocity_mps.compute(s));
     p.heading_rate_rps = static_cast<float>(this->heading_rate_rps.compute(s));

--- a/common/autoware_trajectory/src/path_point_with_lane_id.cpp
+++ b/common/autoware_trajectory/src/path_point_with_lane_id.cpp
@@ -65,7 +65,7 @@ std::vector<PointType> Trajectory<PointType>::restore(const size_t & min_points)
   points.reserve(bases.size());
   for (const auto & s : bases) {
     PointType p;
-    p.point = BaseClass::compute(s);
+    p.point = BaseClass::compute(s - start_);
     p.lane_ids = lane_ids.compute(s);
     points.emplace_back(p);
   }

--- a/common/autoware_trajectory/src/pose.cpp
+++ b/common/autoware_trajectory/src/pose.cpp
@@ -92,7 +92,7 @@ std::vector<PointType> Trajectory<PointType>::restore(const size_t & min_points)
   points.reserve(bases.size());
   for (const auto & s : bases) {
     PointType p;
-    p.position = BaseClass::compute(s);
+    p.position = BaseClass::compute(s - start_);
     p.orientation = orientation_interpolator_->compute(s);
     points.emplace_back(p);
   }


### PR DESCRIPTION
## Description

fix `autoware_trajectory`'s crop bug.

## Related links

- [TIER IV Slack Link](https://star4.slack.com/archives/C0575HP7NJG/p1732610098859539?thread_ts=1732579300.286229&cid=C0575HP7NJG)

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
