### PR TITLE
feat(planning_evaluator): add a trigger to choice whether to output metrics to log folder

### DIFF
--- a/evaluator/autoware_planning_evaluator/README.md
+++ b/evaluator/autoware_planning_evaluator/README.md
@@ -62,8 +62,8 @@ Each metric is published on a topic named after the metric name.
 | ----------- | ------------------------------------- | ----------------------------------------------------------------- |
 | `~/metrics` | `tier4_metric_msgs::msg::MetricArray` | MetricArray with many metrics of `tier4_metric_msgs::msg::Metric` |
 
-When shut down, the evaluation node writes the values of the metrics measured during its lifetime
-to a file as specified by the `output_file` parameter.
+If `output_metrics = true`, the evaluation node writes the statics of the metrics measured during its lifetime
+to `<ros2_logging_directory>/autoware_metrics/<node_name>-<time_stamp>.json` when shut down.
 
 ## Parameters
 

--- a/evaluator/autoware_planning_evaluator/config/planning_evaluator.param.yaml
+++ b/evaluator/autoware_planning_evaluator/config/planning_evaluator.param.yaml
@@ -1,6 +1,5 @@
 /**:
   ros__parameters:
-    output_metrics: false # if true, metrics are written to `<ros2_logging_directory>/autoware_metrics/<node_name>-<time_stamp>.json`.
     ego_frame: base_link # reference frame of ego
 
     selected_metrics:

--- a/evaluator/autoware_planning_evaluator/config/planning_evaluator.param.yaml
+++ b/evaluator/autoware_planning_evaluator/config/planning_evaluator.param.yaml
@@ -1,6 +1,6 @@
 /**:
   ros__parameters:
-    output_file: "" # if empty, metrics are not written to file
+    output_metrics: false # if true, metrics are written to `<ros2_logging_directory>/autoware_metrics/<node_name>-<time_stamp>.json`.
     ego_frame: base_link # reference frame of ego
 
     selected_metrics:

--- a/evaluator/autoware_planning_evaluator/include/autoware/planning_evaluator/motion_evaluator_node.hpp
+++ b/evaluator/autoware_planning_evaluator/include/autoware/planning_evaluator/motion_evaluator_node.hpp
@@ -61,7 +61,7 @@ private:
   std::unique_ptr<tf2_ros::TransformListener> tf_listener_ptr_;
 
   // Parameters
-  std::string output_file_str_;
+  bool output_metrics_;
 
   // Calculator
   MetricsCalculator metrics_calculator_;

--- a/evaluator/autoware_planning_evaluator/include/autoware/planning_evaluator/planning_evaluator_node.hpp
+++ b/evaluator/autoware_planning_evaluator/include/autoware/planning_evaluator/planning_evaluator_node.hpp
@@ -61,7 +61,7 @@ class PlanningEvaluatorNode : public rclcpp::Node
 {
 public:
   explicit PlanningEvaluatorNode(const rclcpp::NodeOptions & node_options);
-  ~PlanningEvaluatorNode();
+  ~PlanningEvaluatorNode() override;
 
   /**
    * @brief callback on receiving an odometry
@@ -97,17 +97,17 @@ public:
     const Odometry::ConstSharedPtr ego_state_ptr);
 
   /**
-   * @brief publish the given metric statistic
+   * @brief add the given metric statistic
    */
   void AddMetricMsg(const Metric & metric, const Accumulator<double> & metric_stat);
 
   /**
-   * @brief publish current ego lane info
+   * @brief add current ego lane info
    */
   void AddLaneletMetricMsg(const Odometry::ConstSharedPtr ego_state_ptr);
 
   /**
-   * @brief publish current ego kinematic state
+   * @brief add current ego kinematic state
    */
   void AddKinematicStateMetricMsg(
     const AccelWithCovarianceStamped & accel_stamped, const Odometry::ConstSharedPtr ego_state_ptr);

--- a/evaluator/autoware_planning_evaluator/include/autoware/planning_evaluator/planning_evaluator_node.hpp
+++ b/evaluator/autoware_planning_evaluator/include/autoware/planning_evaluator/planning_evaluator_node.hpp
@@ -155,15 +155,14 @@ private:
   MetricArrayMsg metrics_msg_;
 
   // Parameters
-  std::string output_file_str_;
+  bool output_metrics_;
   std::string ego_frame_str_;
 
   // Calculator
   MetricsCalculator metrics_calculator_;
   // Metrics
   std::vector<Metric> metrics_;
-  std::deque<rclcpp::Time> stamps_;
-  std::array<std::deque<Accumulator<double>>, static_cast<size_t>(Metric::SIZE)> metric_stats_;
+  std::array<std::array<Accumulator<double>, 3>, static_cast<size_t>(Metric::SIZE)> metric_accumulators_; // 3(min, max, mean) * metric_size
 
   rclcpp::TimerBase::SharedPtr timer_;
   std::optional<AccelWithCovarianceStamped> prev_acc_stamped_{std::nullopt};

--- a/evaluator/autoware_planning_evaluator/include/autoware/planning_evaluator/planning_evaluator_node.hpp
+++ b/evaluator/autoware_planning_evaluator/include/autoware/planning_evaluator/planning_evaluator_node.hpp
@@ -162,7 +162,8 @@ private:
   MetricsCalculator metrics_calculator_;
   // Metrics
   std::vector<Metric> metrics_;
-  std::array<std::array<Accumulator<double>, 3>, static_cast<size_t>(Metric::SIZE)> metric_accumulators_; // 3(min, max, mean) * metric_size
+  std::array<std::array<Accumulator<double>, 3>, static_cast<size_t>(Metric::SIZE)>
+    metric_accumulators_;  // 3(min, max, mean) * metric_size
 
   rclcpp::TimerBase::SharedPtr timer_;
   std::optional<AccelWithCovarianceStamped> prev_acc_stamped_{std::nullopt};

--- a/evaluator/autoware_planning_evaluator/launch/motion_evaluator.launch.xml
+++ b/evaluator/autoware_planning_evaluator/launch/motion_evaluator.launch.xml
@@ -1,7 +1,10 @@
 <launch>
+  <!-- if output_metrics=true, metrics are written to `<ros2_logging_directory>/autoware_metrics/<node_name>-<time_stamp>.json`. -->
+  <arg name="output_metrics" default="false"/>
   <arg name="input/twist" default="/localization/twist"/>
 
   <node name="motion_evaluator" exec="motion_evaluator" pkg="autoware_planning_evaluator" output="screen">
+    <param name="output_metrics" value="$(var output_metrics)"/>
     <remap from="~/input/twist" to="$(var input/twist)"/>
   </node>
 </launch>

--- a/evaluator/autoware_planning_evaluator/launch/planning_evaluator.launch.xml
+++ b/evaluator/autoware_planning_evaluator/launch/planning_evaluator.launch.xml
@@ -1,4 +1,5 @@
 <launch>
+  <!-- if output_metrics=true, metrics are written to `<ros2_logging_directory>/autoware_metrics/<node_name>-<time_stamp>.json`. -->
   <arg name="output_metrics" default="false"/>
   <arg name="input/odometry" default="/localization/kinematic_state"/>
   <arg name="input/acceleration" default="/localization/acceleration"/>

--- a/evaluator/autoware_planning_evaluator/launch/planning_evaluator.launch.xml
+++ b/evaluator/autoware_planning_evaluator/launch/planning_evaluator.launch.xml
@@ -1,4 +1,5 @@
 <launch>
+  <arg name="output_metrics" default="false"/>
   <arg name="input/odometry" default="/localization/kinematic_state"/>
   <arg name="input/acceleration" default="/localization/acceleration"/>
   <arg name="input/trajectory" default="/planning/scenario_planning/trajectory"/>
@@ -12,6 +13,7 @@
   <group>
     <node name="planning_evaluator" exec="planning_evaluator" pkg="autoware_planning_evaluator">
       <param from="$(find-pkg-share autoware_planning_evaluator)/config/planning_evaluator.param.yaml"/>
+      <param name="output_metrics" value="$(var output_metrics)"/>
       <remap from="~/input/odometry" to="$(var input/odometry)"/>
       <remap from="~/input/acceleration" to="$(var input/acceleration)"/>
       <remap from="~/input/trajectory" to="$(var input/trajectory)"/>

--- a/evaluator/autoware_planning_evaluator/package.xml
+++ b/evaluator/autoware_planning_evaluator/package.xml
@@ -22,6 +22,7 @@
   <depend>eigen</depend>
   <depend>geometry_msgs</depend>
   <depend>nav_msgs</depend>
+  <depend>nlohmann-json-dev</depend>
   <depend>pluginlib</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>

--- a/evaluator/autoware_planning_evaluator/schema/autoware_planning_evaluator.schema.json
+++ b/evaluator/autoware_planning_evaluator/schema/autoware_planning_evaluator.schema.json
@@ -7,9 +7,9 @@
       "type": "object",
       "properties": {
         "output_file": {
-          "description": "output metrics file path",
-          "type": "string",
-          "default": ""
+          "description": "If true, the evaluation node writes the metrics' statics to `<ros2_logging_directory>/autoware_metrics/<node_name>-<time_stamp>.json` when the node shut down,",
+          "type": "boolean",
+          "default": "false"
         },
         "ego_frame": {
           "description": "reference frame of ego",

--- a/evaluator/autoware_planning_evaluator/schema/autoware_planning_evaluator.schema.json
+++ b/evaluator/autoware_planning_evaluator/schema/autoware_planning_evaluator.schema.json
@@ -6,7 +6,7 @@
     "autoware_planning_evaluator": {
       "type": "object",
       "properties": {
-        "output_file": {
+        "output_metrics": {
           "description": "If true, the evaluation node writes the metrics' statics to `<ros2_logging_directory>/autoware_metrics/<node_name>-<time_stamp>.json` when the node shut down,",
           "type": "boolean",
           "default": "false"

--- a/evaluator/autoware_planning_evaluator/src/motion_evaluator_node.cpp
+++ b/evaluator/autoware_planning_evaluator/src/motion_evaluator_node.cpp
@@ -35,7 +35,6 @@ MotionEvaluatorNode::MotionEvaluatorNode(const rclcpp::NodeOptions & node_option
     "~/input/twist", rclcpp::QoS{1},
     std::bind(&MotionEvaluatorNode::onOdom, this, std::placeholders::_1));
 
-  
   output_metrics_ = declare_parameter<bool>("output_metrics");
 
   // List of metrics to calculate
@@ -48,7 +47,7 @@ MotionEvaluatorNode::MotionEvaluatorNode(const rclcpp::NodeOptions & node_option
 
 MotionEvaluatorNode::~MotionEvaluatorNode()
 {
-  if (!output_metrics_){
+  if (!output_metrics_) {
     return;
   }
 
@@ -66,23 +65,26 @@ MotionEvaluatorNode::~MotionEvaluatorNode()
   }
 
   // get output folder
-  const std::string output_folder_str = rclcpp::get_logging_directory().string() + "/autoware_metrics";
+  const std::string output_folder_str =
+    rclcpp::get_logging_directory().string() + "/autoware_metrics";
   if (!std::filesystem::exists(output_folder_str)) {
     if (!std::filesystem::create_directories(output_folder_str)) {
-      RCLCPP_ERROR(this->get_logger(), "Failed to create directories: %s", output_folder_str.c_str());
+      RCLCPP_ERROR(
+        this->get_logger(), "Failed to create directories: %s", output_folder_str.c_str());
       return;
     }
   }
 
   // get time stamp
   std::time_t now_time_t = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
-  std::tm* local_time = std::localtime(&now_time_t);
+  std::tm * local_time = std::localtime(&now_time_t);
   std::ostringstream oss;
   oss << std::put_time(local_time, "%Y-%m-%d-%H-%M-%S");
   std::string cur_time_str = oss.str();
 
   // Write metrics .json to file
-  const std::string output_file_str = output_folder_str + "/autoware_motion_evaluator-"+cur_time_str+".json";
+  const std::string output_file_str =
+    output_folder_str + "/autoware_motion_evaluator-" + cur_time_str + ".json";
   std::ofstream f(output_file_str);
   if (f.is_open()) {
     f << j.dump(4);

--- a/evaluator/autoware_planning_evaluator/src/motion_evaluator_node.cpp
+++ b/evaluator/autoware_planning_evaluator/src/motion_evaluator_node.cpp
@@ -14,8 +14,11 @@
 
 #include "autoware/planning_evaluator/motion_evaluator_node.hpp"
 
+#include <nlohmann/json.hpp>
+
+#include <chrono>
+#include <filesystem>
 #include <fstream>
-#include <iostream>
 #include <memory>
 #include <string>
 #include <vector>
@@ -32,7 +35,8 @@ MotionEvaluatorNode::MotionEvaluatorNode(const rclcpp::NodeOptions & node_option
     "~/input/twist", rclcpp::QoS{1},
     std::bind(&MotionEvaluatorNode::onOdom, this, std::placeholders::_1));
 
-  output_file_str_ = declare_parameter<std::string>("output_file");
+  
+  output_metrics_ = declare_parameter<bool>("output_metrics");
 
   // List of metrics to calculate
   for (const std::string & selected_metric :
@@ -44,22 +48,48 @@ MotionEvaluatorNode::MotionEvaluatorNode(const rclcpp::NodeOptions & node_option
 
 MotionEvaluatorNode::~MotionEvaluatorNode()
 {
-  // column width is the maximum size we might print + 1 for the space between columns
-  const auto column_width = 20;  // std::to_string(std::numeric_limits<double>::max()).size() + 1;
-  // Write data using format
-  std::ofstream f(output_file_str_);
-  f << std::fixed << std::left;
-  for (Metric metric : metrics_) {
-    f << std::setw(3 * column_width) << metric_descriptions.at(metric);
+  if (!output_metrics_){
+    return;
   }
-  f << std::endl;
+
+  // generate json data
+  using json = nlohmann::json;
+  json j;
   for (Metric metric : metrics_) {
+    const std::string base_name = metric_to_str.at(metric) + "/";
     const auto & stat = metrics_calculator_.calculate(metric, accumulated_trajectory_);
     if (stat) {
-      f /* << std::setw(3 * column_width) */ << *stat << " ";
+      j[base_name + "min"] = stat->min();
+      j[base_name + "max"] = stat->max();
+      j[base_name + "mean"] = stat->mean();
     }
   }
-  f.close();
+
+  // get output folder
+  const std::string output_folder_str = rclcpp::get_logging_directory().string() + "/autoware_metrics";
+  if (!std::filesystem::exists(output_folder_str)) {
+    if (!std::filesystem::create_directories(output_folder_str)) {
+      RCLCPP_ERROR(this->get_logger(), "Failed to create directories: %s", output_folder_str.c_str());
+      return;
+    }
+  }
+
+  // get time stamp
+  std::time_t now_time_t = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
+  std::tm* local_time = std::localtime(&now_time_t);
+  std::ostringstream oss;
+  oss << std::put_time(local_time, "%Y-%m-%d-%H-%M-%S");
+  std::string cur_time_str = oss.str();
+
+  // Write metrics .json to file
+  const std::string output_file_str = output_folder_str + "/autoware_motion_evaluator-"+cur_time_str+".json";
+  std::ofstream f(output_file_str);
+  if (f.is_open()) {
+    f << j.dump(4);
+    f.close();
+  } else {
+    RCLCPP_ERROR(this->get_logger(), "Failed to open file: %s", output_file_str.c_str());
+  }
 }
 
 void MotionEvaluatorNode::onOdom(const nav_msgs::msg::Odometry::SharedPtr msg)

--- a/evaluator/autoware_planning_evaluator/src/planning_evaluator_node.cpp
+++ b/evaluator/autoware_planning_evaluator/src/planning_evaluator_node.cpp
@@ -81,6 +81,8 @@ PlanningEvaluatorNode::~PlanningEvaluatorNode()
     j[base_name + "min"] = metric_accumulators_[static_cast<size_t>(metric)][0].min();
     j[base_name + "max"] = metric_accumulators_[static_cast<size_t>(metric)][1].max();
     j[base_name + "mean"] = metric_accumulators_[static_cast<size_t>(metric)][2].mean();
+    j[base_name + "count"] = metric_accumulators_[static_cast<size_t>(metric)][2].count();
+    j[base_name + "description"] = metric_descriptions.at(metric);
   }
 
   // get output folder

--- a/evaluator/autoware_planning_evaluator/src/planning_evaluator_node.cpp
+++ b/evaluator/autoware_planning_evaluator/src/planning_evaluator_node.cpp
@@ -22,8 +22,9 @@
 #include "boost/lexical_cast.hpp"
 #include <nlohmann/json.hpp>
 
+#include <chrono>
+#include <filesystem>
 #include <fstream>
-#include <iostream>
 #include <memory>
 #include <string>
 #include <vector>
@@ -51,7 +52,7 @@ PlanningEvaluatorNode::PlanningEvaluatorNode(const rclcpp::NodeOptions & node_op
   metrics_calculator_.parameters.obstacle.dist_thr_m =
     declare_parameter<double>("obstacle.dist_thr_m");
 
-  output_file_str_ = declare_parameter<std::string>("output_file");
+  output_metrics_ = declare_parameter<bool>("output_metrics");
   ego_frame_str_ = declare_parameter<std::string>("ego_frame");
 
   processing_time_pub_ =
@@ -68,34 +69,44 @@ PlanningEvaluatorNode::PlanningEvaluatorNode(const rclcpp::NodeOptions & node_op
 
 PlanningEvaluatorNode::~PlanningEvaluatorNode()
 {
-  if (!output_file_str_.empty()) {
-    // column width is the maximum size we might print + 1 for the space between columns
-    // Write data using format
-    std::ofstream f(output_file_str_);
-    f << std::fixed << std::left;
-    // header
-    f << "#Stamp(ns)";
-    for (Metric metric : metrics_) {
-      f << " " << metric_descriptions.at(metric);
-      f << " . .";  // extra "columns" to align columns headers
+  if (!output_metrics_){
+    return;
+  }
+
+  // generate json data
+  using json = nlohmann::json;
+  json j;
+  for (Metric metric : metrics_) {
+    const std::string base_name = metric_to_str.at(metric) + "/";
+    j[base_name + "min"] = metric_accumulators_[static_cast<size_t>(metric)][0].min();
+    j[base_name + "max"] = metric_accumulators_[static_cast<size_t>(metric)][1].max();
+    j[base_name + "mean"] = metric_accumulators_[static_cast<size_t>(metric)][2].mean();
+  }
+
+  // get output folder
+  const std::string output_folder_str = rclcpp::get_logging_directory().string() + "/autoware_metrics";
+  if (!std::filesystem::exists(output_folder_str)) {
+    if (!std::filesystem::create_directories(output_folder_str)) {
+      RCLCPP_ERROR(this->get_logger(), "Failed to create directories: %s", output_folder_str.c_str());
+      return;
     }
-    f << std::endl;
-    f << "#.";
-    for (Metric metric : metrics_) {
-      (void)metric;
-      f << " min max mean";
-    }
-    f << std::endl;
-    // data
-    for (size_t i = 0; i < stamps_.size(); ++i) {
-      f << stamps_[i].nanoseconds();
-      for (Metric metric : metrics_) {
-        const auto & stat = metric_stats_[static_cast<size_t>(metric)][i];
-        f << " " << stat;
-      }
-      f << std::endl;
-    }
+  }
+
+  // get time stamp
+  std::time_t now_time_t = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
+  std::tm* local_time = std::localtime(&now_time_t);
+  std::ostringstream oss;
+  oss << std::put_time(local_time, "%Y-%m-%d-%H-%M-%S");
+  std::string cur_time_str = oss.str();
+
+  // Write metrics .json to file
+  const std::string output_file_str = output_folder_str + "/autoware_planning_evaluator-"+cur_time_str+".json";
+  std::ofstream f(output_file_str);
+  if (f.is_open()) {
+    f << j.dump(4);
     f.close();
+  } else {
+    RCLCPP_ERROR(this->get_logger(), "Failed to open file: %s", output_file_str.c_str());
   }
 }
 
@@ -270,9 +281,6 @@ void PlanningEvaluatorNode::onTrajectory(
   }
 
   auto start = now();
-  if (!output_file_str_.empty()) {
-    stamps_.push_back(traj_msg->header.stamp);
-  }
 
   for (Metric metric : metrics_) {
     const auto metric_stat = metrics_calculator_.calculate(Metric(metric), *traj_msg);
@@ -280,8 +288,10 @@ void PlanningEvaluatorNode::onTrajectory(
       continue;
     }
 
-    if (!output_file_str_.empty()) {
-      metric_stats_[static_cast<size_t>(metric)].push_back(*metric_stat);
+    if (output_metrics_){
+      metric_accumulators_[static_cast<size_t>(metric)][0].add(metric_stat->min());
+      metric_accumulators_[static_cast<size_t>(metric)][1].add(metric_stat->max());
+      metric_accumulators_[static_cast<size_t>(metric)][2].add(metric_stat->mean());
     }
 
     if (metric_stat->count() > 0) {
@@ -309,7 +319,11 @@ void PlanningEvaluatorNode::onModifiedGoal(
     if (!metric_stat) {
       continue;
     }
-    metric_stats_[static_cast<size_t>(metric)].push_back(*metric_stat);
+    if (output_metrics_){
+      metric_accumulators_[static_cast<size_t>(metric)][0].add(metric_stat->min());
+      metric_accumulators_[static_cast<size_t>(metric)][1].add(metric_stat->max());
+      metric_accumulators_[static_cast<size_t>(metric)][2].add(metric_stat->mean());
+    }
     if (metric_stat->count() > 0) {
       AddMetricMsg(metric, *metric_stat);
     }

--- a/evaluator/autoware_planning_evaluator/src/planning_evaluator_node.cpp
+++ b/evaluator/autoware_planning_evaluator/src/planning_evaluator_node.cpp
@@ -20,6 +20,7 @@
 #include <diagnostic_msgs/msg/detail/diagnostic_status__struct.hpp>
 
 #include "boost/lexical_cast.hpp"
+#include <nlohmann/json.hpp>
 
 #include <fstream>
 #include <iostream>

--- a/evaluator/autoware_planning_evaluator/src/planning_evaluator_node.cpp
+++ b/evaluator/autoware_planning_evaluator/src/planning_evaluator_node.cpp
@@ -16,11 +16,11 @@
 
 #include <autoware_lanelet2_extension/utility/query.hpp>
 #include <autoware_lanelet2_extension/utility/utilities.hpp>
+#include <nlohmann/json.hpp>
 
 #include <diagnostic_msgs/msg/detail/diagnostic_status__struct.hpp>
 
 #include "boost/lexical_cast.hpp"
-#include <nlohmann/json.hpp>
 
 #include <chrono>
 #include <filesystem>
@@ -69,7 +69,7 @@ PlanningEvaluatorNode::PlanningEvaluatorNode(const rclcpp::NodeOptions & node_op
 
 PlanningEvaluatorNode::~PlanningEvaluatorNode()
 {
-  if (!output_metrics_){
+  if (!output_metrics_) {
     return;
   }
 
@@ -86,23 +86,26 @@ PlanningEvaluatorNode::~PlanningEvaluatorNode()
   }
 
   // get output folder
-  const std::string output_folder_str = rclcpp::get_logging_directory().string() + "/autoware_metrics";
+  const std::string output_folder_str =
+    rclcpp::get_logging_directory().string() + "/autoware_metrics";
   if (!std::filesystem::exists(output_folder_str)) {
     if (!std::filesystem::create_directories(output_folder_str)) {
-      RCLCPP_ERROR(this->get_logger(), "Failed to create directories: %s", output_folder_str.c_str());
+      RCLCPP_ERROR(
+        this->get_logger(), "Failed to create directories: %s", output_folder_str.c_str());
       return;
     }
   }
 
   // get time stamp
   std::time_t now_time_t = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
-  std::tm* local_time = std::localtime(&now_time_t);
+  std::tm * local_time = std::localtime(&now_time_t);
   std::ostringstream oss;
   oss << std::put_time(local_time, "%Y-%m-%d-%H-%M-%S");
   std::string cur_time_str = oss.str();
 
   // Write metrics .json to file
-  const std::string output_file_str = output_folder_str + "/autoware_planning_evaluator-"+cur_time_str+".json";
+  const std::string output_file_str =
+    output_folder_str + "/autoware_planning_evaluator-" + cur_time_str + ".json";
   std::ofstream f(output_file_str);
   if (f.is_open()) {
     f << j.dump(4);
@@ -290,7 +293,7 @@ void PlanningEvaluatorNode::onTrajectory(
       continue;
     }
 
-    if (output_metrics_){
+    if (output_metrics_) {
       metric_accumulators_[static_cast<size_t>(metric)][0].add(metric_stat->min());
       metric_accumulators_[static_cast<size_t>(metric)][1].add(metric_stat->max());
       metric_accumulators_[static_cast<size_t>(metric)][2].add(metric_stat->mean());
@@ -321,7 +324,7 @@ void PlanningEvaluatorNode::onModifiedGoal(
     if (!metric_stat) {
       continue;
     }
-    if (output_metrics_){
+    if (output_metrics_) {
       metric_accumulators_[static_cast<size_t>(metric)][0].add(metric_stat->min());
       metric_accumulators_[static_cast<size_t>(metric)][1].add(metric_stat->max());
       metric_accumulators_[static_cast<size_t>(metric)][2].add(metric_stat->mean());

--- a/evaluator/autoware_planning_evaluator/test/test_planning_evaluator_node.cpp
+++ b/evaluator/autoware_planning_evaluator/test/test_planning_evaluator_node.cpp
@@ -53,7 +53,8 @@ protected:
     const auto share_dir =
       ament_index_cpp::get_package_share_directory("autoware_planning_evaluator");
     options.arguments(
-      {"--ros-args", "--params-file", share_dir + "/config/planning_evaluator.param.yaml"});
+      {"--ros-args", "--params-file", share_dir + "/config/planning_evaluator.param.yaml", "-p",
+       "output_metrics:=false"});
 
     dummy_node = std::make_shared<rclcpp::Node>("planning_evaluator_test_node");
     eval_node = std::make_shared<EvalNode>(options);


### PR DESCRIPTION
## Description
Add a bool parameter `output_metrics`, if it's true, the planning_evaluator node writes the statics of the metrics measured during its lifetime to `<ros2_logging_directory>/autoware_metrics/<node_name>-<time_stamp>.json` when shut down.

This feature will be used to collect and analyze test results in real vehicle tests and evaluator tests.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
Psim with `output_metrics=true`:
```bash
$ cat /home/temkeikem/.ros/log/autoware_metrics/autoware_planning_evaluator-2024-11-26-19-00-31.json 
{
    "acceleration/count": 285,
    "acceleration/description": "Trajectory_acceleration[m/s²]",
    "acceleration/max": 1.0012520551681519,
    "acceleration/mean": 0.234304107391435,
    "acceleration/min": -0.9976022839546204,
    # ignore many outputs.
    "yaw_deviation/count": 285,
    "yaw_deviation/description": "Yaw_deviation[rad]",
    "yaw_deviation/max": 0.02092383717239943,
    "yaw_deviation/mean": -9.644752318082534e-06,
    "yaw_deviation/min": -0.02153717392870902
}
```


## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
