### PR TITLE
fix: fix missing namespaces in C++ code

### DIFF
--- a/common/autoware_component_interface_tools/CMakeLists.txt
+++ b/common/autoware_component_interface_tools/CMakeLists.txt
@@ -9,7 +9,7 @@ ament_auto_add_library(${PROJECT_NAME} SHARED
 )
 
 rclcpp_components_register_node(${PROJECT_NAME}
-  PLUGIN "ServiceLogChecker"
+  PLUGIN "autoware::component_interface_tools::ServiceLogChecker"
   EXECUTABLE service_log_checker_node
 )
 

--- a/common/autoware_component_interface_tools/src/service_log_checker.cpp
+++ b/common/autoware_component_interface_tools/src/service_log_checker.cpp
@@ -22,6 +22,8 @@
 #define FMT_HEADER_ONLY
 #include <fmt/format.h>
 
+namespace autoware::component_interface_tools
+{
 ServiceLogChecker::ServiceLogChecker(const rclcpp::NodeOptions & options)
 : Node("service_log_checker", options), diagnostics_(this)
 {
@@ -98,6 +100,6 @@ void ServiceLogChecker::update_diagnostics(diagnostic_updater::DiagnosticStatusW
     stat.summary(DiagnosticStatus::ERROR, "ERROR");
   }
 }
-
+}  // namespace autoware::component_interface_tools
 #include <rclcpp_components/register_node_macro.hpp>
-RCLCPP_COMPONENTS_REGISTER_NODE(ServiceLogChecker)
+RCLCPP_COMPONENTS_REGISTER_NODE(autoware::component_interface_tools::ServiceLogChecker)

--- a/common/autoware_component_interface_tools/src/service_log_checker.hpp
+++ b/common/autoware_component_interface_tools/src/service_log_checker.hpp
@@ -23,6 +23,8 @@
 #include <string>
 #include <unordered_map>
 
+namespace autoware::component_interface_tools
+{
 class ServiceLogChecker : public rclcpp::Node
 {
 public:
@@ -38,5 +40,5 @@ private:
   void update_diagnostics(diagnostic_updater::DiagnosticStatusWrapper & stat);
   std::unordered_map<std::string, std::string> errors_;
 };
-
+}  // namespace autoware::component_interface_tools
 #endif  // SERVICE_LOG_CHECKER_HPP_

--- a/common/autoware_traffic_light_recognition_marker_publisher/CMakeLists.txt
+++ b/common/autoware_traffic_light_recognition_marker_publisher/CMakeLists.txt
@@ -9,7 +9,7 @@ ament_auto_add_library(${PROJECT_NAME} SHARED
 )
 
 rclcpp_components_register_node(${PROJECT_NAME}
-  PLUGIN "TrafficLightRecognitionMarkerPublisher"
+  PLUGIN "autoware::traffic_light_recognition_marker_publisher::TrafficLightRecognitionMarkerPublisher"
   EXECUTABLE ${PROJECT_NAME}_node
 )
 

--- a/common/autoware_traffic_light_recognition_marker_publisher/src/traffic_light_recognition_marker_publisher.cpp
+++ b/common/autoware_traffic_light_recognition_marker_publisher/src/traffic_light_recognition_marker_publisher.cpp
@@ -20,6 +20,8 @@
 #include <utility>
 #include <vector>
 
+namespace autoware::traffic_light_recognition_marker_publisher
+{
 TrafficLightRecognitionMarkerPublisher::TrafficLightRecognitionMarkerPublisher(
   const rclcpp::NodeOptions & options)
 : Node("traffic_light_recognition_marker_publisher", options)
@@ -159,6 +161,8 @@ std_msgs::msg::ColorRGBA TrafficLightRecognitionMarkerPublisher::getTrafficLight
 
   return c;  // white
 }
+}  // namespace autoware::traffic_light_recognition_marker_publisher
 
 #include <rclcpp_components/register_node_macro.hpp>
-RCLCPP_COMPONENTS_REGISTER_NODE(TrafficLightRecognitionMarkerPublisher)
+RCLCPP_COMPONENTS_REGISTER_NODE(
+  autoware::traffic_light_recognition_marker_publisher::TrafficLightRecognitionMarkerPublisher)

--- a/common/autoware_traffic_light_recognition_marker_publisher/src/traffic_light_recognition_marker_publisher.hpp
+++ b/common/autoware_traffic_light_recognition_marker_publisher/src/traffic_light_recognition_marker_publisher.hpp
@@ -29,6 +29,8 @@
 #include <map>
 #include <string>
 
+namespace autoware::traffic_light_recognition_marker_publisher
+{
 class TrafficLightRecognitionMarkerPublisher : public rclcpp::Node
 {
 public:
@@ -58,5 +60,6 @@ private:
   bool is_map_ready_ = false;
   int32_t marker_id = 0;
 };
+}  // namespace autoware::traffic_light_recognition_marker_publisher
 
 #endif  // TRAFFIC_LIGHT_RECOGNITION_MARKER_PUBLISHER_HPP_


### PR DESCRIPTION
## Description

I noticed that the plugins were missing namespaces, this PR adds namespaces in the code and in the plugin definitions in CMake.

## Related links

**Parent Issue:**

- https://github.com/autowarefoundation/autoware/issues/5077
- https://github.com/autowarefoundation/autoware/issues/4569


<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
