### PR TITLE
fix(path_optimizer): solve issue with time keeper

### DIFF
--- a/planning/autoware_path_optimizer/src/node.cpp
+++ b/planning/autoware_path_optimizer/src/node.cpp
@@ -222,7 +222,7 @@ void PathOptimizer::resetPreviousData()
 
 void PathOptimizer::onPath(const Path::ConstSharedPtr path_ptr)
 {
-  time_keeper_->start_track(__func__);
+  universe_utils::ScopedTimeTrack st(__func__, *time_keeper_);
   stop_watch_.tic();
 
   // check if input path is valid
@@ -277,8 +277,6 @@ void PathOptimizer::onPath(const Path::ConstSharedPtr path_ptr)
     autoware::motion_utils::convertToTrajectory(full_traj_points, path_ptr->header);
   traj_pub_->publish(output_traj_msg);
   published_time_publisher_->publish_if_subscribed(traj_pub_, output_traj_msg.header.stamp);
-
-  time_keeper_->end_track(__func__);
 }
 
 bool PathOptimizer::checkInputPath(const Path & path, rclcpp::Clock clock) const


### PR DESCRIPTION
## Description
under certain conditions, the onPath method of the path optimizer will spam an error related to the time keeper. This PR solves the issue: 

Before: 


https://github.com/user-attachments/assets/08f4f8d7-028f-4bae-a375-1eca32a00116


After:


https://github.com/user-attachments/assets/13131c5d-1fad-4952-adc8-c3401a7f808c



## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
Psim
## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
