### PR TITLE
fix: update visualizer param path and not to set default value

### DIFF
--- a/perception/autoware_bytetrack/launch/bytetrack.launch.xml
+++ b/perception/autoware_bytetrack/launch/bytetrack.launch.xml
@@ -5,7 +5,7 @@
   <arg name="detection_rect" default="/perception/object_recognition/detection/rois0"/>
   <arg name="tracked_rect" default="/perception/object_recognition/detection/tracked/rois0"/>
   <arg name="bytetrack_param_path" default="$(find-pkg-share autoware_bytetrack)/config/bytetrack.param.yaml"/>
-  <arg name="bytetrack_visualizer_param_path" default="$(find-pkg-share autoware_bytetrack)/config/bytetrack.param.yaml"/>
+  <arg name="bytetrack_visualizer_param_path" default="$(find-pkg-share autoware_bytetrack)/config/bytetrack_visualizer.param.yaml"/>
   <arg name="enable_visualizer" default="true"/>
 
   <node pkg="autoware_bytetrack" exec="bytetrack_node_exe" output="screen">

--- a/perception/autoware_bytetrack/src/bytetrack_visualizer_node.cpp
+++ b/perception/autoware_bytetrack/src/bytetrack_visualizer_node.cpp
@@ -34,7 +34,7 @@ ByteTrackVisualizerNode::ByteTrackVisualizerNode(const rclcpp::NodeOptions & nod
 {
   using std::chrono_literals::operator""ms;
 
-  use_raw_ = declare_parameter("use_raw", false);
+  use_raw_ = declare_parameter<bool>("use_raw");
 
   // Create timer to find proper settings for subscribed topics
   timer_ = rclcpp::create_timer(


### PR DESCRIPTION
## Description

Rename file path to visualizer param config, and remove default value set in `declare_parameter`.

## Related links

**Parent Issue:**

- https://github.com/autowarefoundation/autoware.universe/issues/9323

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

I confirmed it works with the following command:

```shell
ros2 launch autoware_bytetrack bytetrack.launch.xml
```

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
