### PR TITLE
fix(autoware_elevation_map_loader): fix clang-diagnostic-format-security

### DIFF
--- a/perception/autoware_elevation_map_loader/src/elevation_map_loader_node.cpp
+++ b/perception/autoware_elevation_map_loader/src/elevation_map_loader_node.cpp
@@ -148,7 +148,7 @@ void ElevationMapLoaderNode::publish()
       is_bag_loaded = grid_map::GridMapRosConverter::loadFromBag(
         *data_manager_.elevation_map_path_, "elevation_map", elevation_map_);
     } catch (const std::runtime_error & e) {
-      RCLCPP_ERROR(this->get_logger(), e.what());
+      RCLCPP_ERROR(this->get_logger(), "%s", e.what());
       is_bag_loaded = false;
     }
     if (!is_bag_loaded) {


### PR DESCRIPTION
## Description
This is a fix based on clang-tidy `clang-diagnostic-format-security` error.

```
/home/emb4/autoware/autoware/src/universe/autoware.universe/perception/autoware_elevation_map_loader/src/elevation_map_loader_node.cpp:151:40: error: format string is not a string literal (potentially insecure) [clang-diagnostic-format-security]
      RCLCPP_ERROR(this->get_logger(), e.what());
                                       ^
/opt/ros/humble/include/rclcpp/rclcpp/logging.hpp:1407:7: note: expanded from macro 'RCLCPP_ERROR'
      __VA_ARGS__); \
      ^~~~~~~~~~~
/opt/ros/humble/include/rcutils/rcutils/logging_macros.h:1004:5: note: expanded from macro 'RCUTILS_LOG_ERROR_NAMED'
    __VA_ARGS__)
    ^~~~~~~~~~~
/opt/ros/humble/include/rcutils/rcutils/logging_macros.h:79:64: note: expanded from macro 'RCUTILS_LOG_COND_NAMED'
      rcutils_log(&__rcutils_logging_location, severity, name, __VA_ARGS__); \
                                                               ^~~~~~~~~~~
/home/emb4/autoware/autoware/src/universe/autoware.universe/perception/autoware_elevation_map_loader/src/elevation_map_loader_node.cpp:151:40: note: treat the string as an argument to avoid this
      RCLCPP_ERROR(this->get_logger(), e.what());
                                       ^
                                       "%s", 
/opt/ros/humble/include/rclcpp/rclcpp/logging.hpp:1407:7: note: expanded from macro 'RCLCPP_ERROR'
      __VA_ARGS__); \
      ^
/opt/ros/humble/include/rcutils/rcutils/logging_macros.h:1004:5: note: expanded from macro 'RCUTILS_LOG_ERROR_NAMED'
    __VA_ARGS__)
    ^
/opt/ros/humble/include/rcutils/rcutils/logging_macros.h:79:64: note: expanded from macro 'RCUTILS_LOG_COND_NAMED'
      rcutils_log(&__rcutils_logging_location, severity, name, __VA_ARGS__); \
                                                               ^
```
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
