### PR TITLE
fix(autoware_raindrop_cluster_filter): fix clang-diagnostic-unused-private-field

### DIFF
--- a/perception/autoware_raindrop_cluster_filter/src/low_intensity_cluster_filter_node.hpp
+++ b/perception/autoware_raindrop_cluster_filter/src/low_intensity_cluster_filter_node.hpp
@@ -56,13 +56,8 @@ private:
   double max_y_;
   double min_y_;
 
-  double max_x_transformed_;
-  double min_x_transformed_;
-  double max_y_transformed_;
-  double min_y_transformed_;
   // Eigen::Vector4f min_boundary_transformed_;
   // Eigen::Vector4f max_boundary_transformed_;
-  bool is_validation_range_transformed_ = false;
   const std::string base_link_frame_id_ = "base_link";
   autoware::detected_object_validation::utils::FilterTargetLabel filter_target_;
 


### PR DESCRIPTION
## Description
This is a fix based on clang-tidy `clang-diagnostic-unused-private-field` error.

```
/home/emb4/autoware/autoware/src/universe/autoware.universe/perception/autoware_raindrop_cluster_filter/src/low_intensity_cluster_filter_node.hpp:59:10: error: private field 'max_x_transformed_' is not used [clang-diagnostic-unused-private-field]
  double max_x_transformed_;
         ^
/home/emb4/autoware/autoware/src/universe/autoware.universe/perception/autoware_raindrop_cluster_filter/src/low_intensity_cluster_filter_node.hpp:60:10: error: private field 'min_x_transformed_' is not used [clang-diagnostic-unused-private-field]
  double min_x_transformed_;
         ^
/home/emb4/autoware/autoware/src/universe/autoware.universe/perception/autoware_raindrop_cluster_filter/src/low_intensity_cluster_filter_node.hpp:61:10: error: private field 'max_y_transformed_' is not used [clang-diagnostic-unused-private-field]
  double max_y_transformed_;
         ^
/home/emb4/autoware/autoware/src/universe/autoware.universe/perception/autoware_raindrop_cluster_filter/src/low_intensity_cluster_filter_node.hpp:62:10: error: private field 'min_y_transformed_' is not used [clang-diagnostic-unused-private-field]
  double min_y_transformed_;
         ^
/home/emb4/autoware/autoware/src/universe/autoware.universe/perception/autoware_raindrop_cluster_filter/src/low_intensity_cluster_filter_node.hpp:65:8: error: private field 'is_validation_range_transformed_' is not used [clang-diagnostic-unused-private-field]
  bool is_validation_range_transformed_ = false;
       ^
```
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
