### PR TITLE
feat(velocity_smoother, external_velocity_limit_selector): enable stronger acceleration when requested

### DIFF
--- a/planning/autoware_external_velocity_limit_selector/include/autoware/external_velocity_limit_selector/external_velocity_limit_selector_node.hpp
+++ b/planning/autoware_external_velocity_limit_selector/include/autoware/external_velocity_limit_selector/external_velocity_limit_selector_node.hpp
@@ -22,7 +22,6 @@
 #include <tier4_planning_msgs/msg/velocity_limit.hpp>
 #include <tier4_planning_msgs/msg/velocity_limit_clear_command.hpp>
 
-#include <deque>
 #include <memory>
 #include <string>
 #include <unordered_map>

--- a/planning/autoware_external_velocity_limit_selector/src/external_velocity_limit_selector_node.cpp
+++ b/planning/autoware_external_velocity_limit_selector/src/external_velocity_limit_selector_node.cpp
@@ -46,7 +46,6 @@ VelocityLimit getHardestLimit(
   size_t constraint_num = 0;
   size_t acceleration_constraint_num = 0;
 
-
   for (const auto & limit : velocity_limits) {
     // guard nan, inf
     const auto max_velocity =
@@ -65,9 +64,9 @@ VelocityLimit getHardestLimit(
         ? limit.second.constraints
         : normal_constraints;
 
-    if(limit.second.use_constraints) {
+    if (limit.second.use_constraints) {
       constraint_num++;
-      if(limit.second.constraints.max_acceleration > normal_constraints.max_acceleration) {
+      if (limit.second.constraints.max_acceleration > normal_constraints.max_acceleration) {
         acceleration_constraint_num++;
         hardest_max_acceleration_key = limit.first;
       }
@@ -86,9 +85,8 @@ VelocityLimit getHardestLimit(
     }
   }
 
-  if(constraint_num > 0 && constraint_num == acceleration_constraint_num) {
-    if(velocity_limits.find(hardest_max_acceleration_key) != velocity_limits.end()) // Just in case guard
-    {
+  if (constraint_num > 0 && constraint_num == acceleration_constraint_num) {
+    if (velocity_limits.find(hardest_max_acceleration_key) != velocity_limits.end()) {
       const auto constraints = velocity_limits.at(hardest_max_acceleration_key).constraints;
       hardest_limit.constraints = constraints;
       hardest_limit.use_constraints = true;

--- a/planning/autoware_velocity_smoother/include/autoware/velocity_smoother/node.hpp
+++ b/planning/autoware_velocity_smoother/include/autoware/velocity_smoother/node.hpp
@@ -164,10 +164,17 @@ private:
     bool plan_from_ego_speed_on_manual_mode = true;
   } node_param_{};
 
+  struct AccelerationRequest
+  {
+    bool request{false};
+    double max_acceleration{0.0};
+    double max_jerk{0.0};
+  };
   struct ExternalVelocityLimit
   {
     double velocity{0.0};  // current external_velocity_limit
     double dist{0.0};      // distance to set external velocity limit
+    AccelerationRequest acceleration_request;
     std::string sender{""};
   };
   ExternalVelocityLimit

--- a/planning/autoware_velocity_smoother/include/autoware/velocity_smoother/smoother/smoother_base.hpp
+++ b/planning/autoware_velocity_smoother/include/autoware/velocity_smoother/smoother/smoother_base.hpp
@@ -83,6 +83,8 @@ public:
   double getMinJerk() const;
 
   void setWheelBase(const double wheel_base);
+  void setMaxAccel(const double max_acceleration);
+  void setMaxJerk(const double max_jerk);
 
   void setParam(const BaseParam & param);
   BaseParam getBaseParam() const;

--- a/planning/autoware_velocity_smoother/src/node.cpp
+++ b/planning/autoware_velocity_smoother/src/node.cpp
@@ -319,6 +319,7 @@ void VelocitySmootherNode::calcExternalVelocityLimit()
   autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_);
 
   if (!external_velocity_limit_ptr_) {
+    external_velocity_limit_.acceleration_request.request = false;
     return;
   }
 
@@ -340,6 +341,20 @@ void VelocitySmootherNode::calcExternalVelocityLimit()
     std::fabs(current_odometry_ptr_->twist.twist.linear.x) < eps &&
     external_velocity_limit_.velocity < eps) {
     external_velocity_limit_.dist = 0.0;
+  }
+
+  const auto base_max_acceleration = get_parameter("normal.max_acc").as_double();
+  const auto acceleration_request =
+    external_velocity_limit_ptr_->use_constraints &&
+    base_max_acceleration < external_velocity_limit_ptr_->constraints.max_acceleration;
+  if (
+    acceleration_request &&
+    current_odometry_ptr_->twist.twist.linear.x < external_velocity_limit_ptr_->max_velocity) {
+    external_velocity_limit_.acceleration_request.request = true;
+    external_velocity_limit_.acceleration_request.max_acceleration =
+      external_velocity_limit_ptr_->constraints.max_acceleration;
+    external_velocity_limit_.acceleration_request.max_jerk =
+      external_velocity_limit_ptr_->constraints.max_jerk;
   }
 
   // calculate distance and maximum velocity
@@ -627,6 +642,18 @@ bool VelocitySmootherNode::smoothVelocity(
   clipped.insert(
     clipped.end(), traj_resampled.begin() + traj_resampled_closest, traj_resampled.end());
 
+  // Set maximum acceleration before applying smoother. Depends on acceleration request from
+  // external velocity limit
+  const double smoother_max_acceleration =
+    external_velocity_limit_.acceleration_request.request
+      ? external_velocity_limit_.acceleration_request.max_acceleration
+      : get_parameter("normal.max_acc").as_double();
+  const double smoother_max_jerk = external_velocity_limit_.acceleration_request.request
+                                     ? external_velocity_limit_.acceleration_request.max_jerk
+                                     : get_parameter("normal.max_jerk").as_double();
+  smoother_->setMaxAccel(smoother_max_acceleration);
+  smoother_->setMaxJerk(smoother_max_jerk);
+
   std::vector<TrajectoryPoints> debug_trajectories;
   if (!smoother_->apply(
         initial_motion.vel, initial_motion.acc, clipped, traj_smoothed, debug_trajectories,
@@ -791,12 +818,15 @@ std::pair<Motion, VelocitySmootherNode::InitializeType> VelocitySmootherNode::ca
           "calcInitialMotion : vehicle speed is low (%.3f), and desired speed is high (%.3f). Use "
           "engage speed (%.3f) until vehicle speed reaches engage_vel_thr (%.3f). stop_dist = %.3f",
           vehicle_speed, target_vel, node_param_.engage_velocity, engage_vel_thr, stop_dist);
-        Motion initial_motion = {node_param_.engage_velocity, node_param_.engage_acceleration};
+        const double engage_acceleration =
+          external_velocity_limit_.acceleration_request.request
+            ? external_velocity_limit_.acceleration_request.max_acceleration
+            : node_param_.engage_acceleration;
+        Motion initial_motion = {node_param_.engage_velocity, engage_acceleration};
         return {initial_motion, InitializeType::ENGAGING};
-      } else {
-        RCLCPP_DEBUG(
-          get_logger(), "calcInitialMotion : stop point is close (%.3f[m]). no engage.", stop_dist);
       }
+      RCLCPP_DEBUG(
+        get_logger(), "calcInitialMotion : stop point is close (%.3f[m]). no engage.", stop_dist);
     } else if (target_vel > 0.0) {
       RCLCPP_WARN_THROTTLE(
         get_logger(), *clock_, 3000,

--- a/planning/autoware_velocity_smoother/src/smoother/smoother_base.cpp
+++ b/planning/autoware_velocity_smoother/src/smoother/smoother_base.cpp
@@ -97,6 +97,16 @@ void SmootherBase::setWheelBase(const double wheel_base)
   base_param_.wheel_base = wheel_base;
 }
 
+void SmootherBase::setMaxAccel(const double max_acceleration)
+{
+  base_param_.max_accel = max_acceleration;
+}
+
+void SmootherBase::setMaxJerk(const double max_jerk)
+{
+  base_param_.max_jerk = max_jerk;
+}
+
 void SmootherBase::setParam(const BaseParam & param)
 {
   base_param_ = param;


### PR DESCRIPTION
## Description
Currently the smoother's constraint (max_acceleration, min_acceleration, max_jerk, min_jerk) was set constantly in velocity_smoother. 
Furthermore, the external velocity limit just considered the min_acceleration, and not the max_acceleration.
This made it impossible to achieve quick acceleration when needed.
For example, when turning right or left at an intersection, if an oncoming vehicle is close to the ego vehicle, it is necessary to quickly leave the intersection.
This PR, changes the smoother's max_acceleration and max_jerk constraint whenever it is requested from the external velocity limiter.
The acceleration request is only applied when there is only accelerations requests only. This is considered inside the external_velocity_limit_selector.

## Related links
- https://github.com/tier4/tier4_autoware_msgs/pull/154
- https://github.com/orgs/autowarefoundation/discussions/5209

## How was this PR tested?
- [x] Degrade check with [TIER IV internal evaluator](https://evaluation.tier4.jp/evaluation/reports/bcf0f980-3c27-5059-9f2d-50c390002ed6?project_id=prd_jt) 
- [x] PSim + command line `ros2 topic pub`. The given command line is

```
ros2 topic pub /planning/scenario_planning/max_velocity tier4_planning_msgs/msg/VelocityLimit "
stamp:
  sec: $(date +%s)
  nanosec: $(date +%N)
max_velocity: 11.1111111111111
use_constraints: true
constraints:
  max_acceleration: 2.0
  min_acceleration: -1.0
  max_jerk: 5.0
  min_jerk: -1.0
sender: api
" --rate 10
```
![Screenshot from 2024-11-27 19-57-24](https://github.com/user-attachments/assets/8c1fba93-f19f-42b6-811a-f0f25d588875)
Blue line: Before this PR, Red line: After this PR
- [x]  TIER IV internal application (FOA) + PSim
[Screencast from 2024年11月28日 12時02分36秒.webm](https://github.com/user-attachments/assets/1468d6dc-759c-49d3-b325-c8ecf1c0bc70)
The RCLCPP_INFO is shows that the `max_acceleration` and `max_jerk` is changed as it is intended, and it will not be included in this PR.


## Notes for reviewers
None.

## Interface changes
None.

## Effects on system behavior
None.
