### PR TITLE
fix(autoware_processing_time_checker): fix typo

### DIFF
--- a/system/autoware_processing_time_checker/src/processing_time_checker.cpp
+++ b/system/autoware_processing_time_checker/src/processing_time_checker.cpp
@@ -52,7 +52,7 @@ ProcessingTimeChecker::ProcessingTimeChecker(const rclcpp::NodeOptions & node_op
 
     // extract module name from topic name
     auto tmp_topic_name = processing_time_topic_name;
-    for (size_t i = 0; i < 4; ++i) {  // 4 is enouh for the search depth
+    for (size_t i = 0; i < 4; ++i) {  // 4 is enough for the search depth
       tmp_topic_name = remove_last_name(tmp_topic_name);
       const auto module_name_candidate = get_last_name(tmp_topic_name);
       // clang-format off


### PR DESCRIPTION
## Description

There are a lot of following warnings in each PR.

```
 Check warning on line 55 in system/autoware_processing_time_checker/src/processing_time_checker.cpp

GitHub Actions
/ spell-check-differential

Unknown word (enouh)
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
