### PR TITLE
fix(autoware_image_projection_based_fusion): fix clang-diagnostic-unused-private-field

### DIFF
--- a/perception/autoware_image_projection_based_fusion/CMakeLists.txt
+++ b/perception/autoware_image_projection_based_fusion/CMakeLists.txt
@@ -2,7 +2,6 @@ cmake_minimum_required(VERSION 3.14)
 project(autoware_image_projection_based_fusion)
 # add_compile_options(-Wno-unknown-pragmas)
 add_compile_options(-Wno-unknown-pragmas -fopenmp)
-add_compile_options(-Wno-error=attributes)
 
 find_package(autoware_cmake REQUIRED)
 find_package(OpenCV REQUIRED)

--- a/perception/autoware_image_projection_based_fusion/include/autoware/image_projection_based_fusion/debugger.hpp
+++ b/perception/autoware_image_projection_based_fusion/include/autoware/image_projection_based_fusion/debugger.hpp
@@ -56,7 +56,6 @@ private:
   void imageCallback(
     const sensor_msgs::msg::Image::ConstSharedPtr input_image_msg, const std::size_t image_id);
 
-  [[maybe_unused]] rclcpp::Node * node_ptr_;
   std::shared_ptr<image_transport::ImageTransport> image_transport_;
   std::vector<std::string> input_camera_topics_;
   std::vector<image_transport::Subscriber> image_subs_;

--- a/perception/autoware_image_projection_based_fusion/src/debugger.cpp
+++ b/perception/autoware_image_projection_based_fusion/src/debugger.cpp
@@ -41,7 +41,7 @@ namespace autoware::image_projection_based_fusion
 Debugger::Debugger(
   rclcpp::Node * node_ptr, const std::size_t image_num, const std::size_t image_buffer_size,
   std::vector<std::string> input_camera_topics)
-: node_ptr_(node_ptr), input_camera_topics_{input_camera_topics}
+: input_camera_topics_{input_camera_topics}
 {
   image_buffers_.resize(image_num);
   image_buffer_size_ = image_buffer_size;


### PR DESCRIPTION
## Description
This is a fix based on clang-tidy `clang-diagnostic-unused-private-field` error.
The following PR was mistakenly assumed to be in use but was deleted as it was not actually being utilized.

```
/home/emb4/autoware/autoware/src/universe/autoware.universe/perception/autoware_image_projection_based_fusion/include/autoware/image_projection_based_fusion/debugger.hpp:59:18: error: private field 'node_ptr_' is not used [clang-diagnostic-unused-private-field]
  rclcpp::Node * node_ptr_;
                 ^
```
## Related links

**Parent Issue:**

- #9473 

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
