### PR TITLE
fix(learning_based_vehicle_model): fix clang-diagnostic-delete-abstract-non-virtual-dtor

### DIFF
--- a/simulator/learning_based_vehicle_model/src/interconnected_model.cpp
+++ b/simulator/learning_based_vehicle_model/src/interconnected_model.cpp
@@ -79,8 +79,7 @@ void InterconnectedModel::addSubmodel(
   std::tuple<std::string, std::string, std::string> submodel_desc)
 {
   const auto [lib_path, param_path, class_name] = submodel_desc;
-  auto new_model = new SimplePyModel(lib_path, param_path, class_name);
-  submodels.push_back(std::unique_ptr<SimplePyModel>(new_model));
+  submodels.emplace_back(std::make_unique<SimplePyModel>(lib_path, param_path, class_name));
 }
 
 void InterconnectedModel::initState(std::vector<double> new_state)


### PR DESCRIPTION
## Description

This is a fix based on clang-tidy clang-diagnostic-delete-abstract-non-virtual-dtor error.

```
Command: clang-tidy-14 -p build/learning_based_vehicle_model --header-filter=/home/hisaki/workspace/clang-tidy-ci/autoware/src/universe/autoware.universe/simulator/learning_based_vehicle_model/.* --config-file=.clang-tidy-ci /home/hisaki/workspace/clang-tidy-ci/autoware/src/universe/autoware.universe/simulator/learning_based_vehicle_model/src/interconnected_model.cpp
2 errors generated.
Error while processing /home/hisaki/workspace/clang-tidy-ci/autoware/src/universe/autoware.universe/simulator/learning_based_vehicle_model/src/interconnected_model.cpp.
Found compiler error(s).

/usr/lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/bits/unique_ptr.h:95:2: error: delete called on 'SubModelInterface' that is abstract but has non-virtual destructor [clang-diagnostic-delete-abstract-non-virtual-dtor]
        delete __ptr;
        ^
/usr/lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/bits/unique_ptr.h:396:4: note: in instantiation of member function 'std::default_delete<SubModelInterface>::operator()' requested here
          get_deleter()(std::move(__ptr));
          ^
/home/hisaki/workspace/clang-tidy-ci/autoware/src/universe/autoware.universe/simulator/learning_based_vehicle_model/src/interconnected_model.cpp:79:23: note: in instantiation of member function 'std::unique_ptr<SubModelInterface>::~unique_ptr' requested here
  submodels.push_back(std::unique_ptr<SimplePyModel>(new_model));
                      ^
/usr/lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/bits/unique_ptr.h:95:2: error: delete called on non-final 'SimplePyModel' that has virtual functions but non-virtual destructor [clang-diagnostic-delete-non-abstract-non-virtual-dtor]
        delete __ptr;
        ^
/usr/lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/bits/unique_ptr.h:396:4: note: in instantiation of member function 'std::default_delete<SimplePyModel>::operator()' requested here
          get_deleter()(std::move(__ptr));
          ^
/home/hisaki/workspace/clang-tidy-ci/autoware/src/universe/autoware.universe/simulator/learning_based_vehicle_model/src/interconnected_model.cpp:79:23: note: in instantiation of member function 'std::unique_ptr<SimplePyModel>::~unique_ptr' requested here
  submodels.push_back(std::unique_ptr<SimplePyModel>(new_model));
                      ^
```


## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
