### PR TITLE
fix(autoware_tracking_object_merger): fix clang-diagnostic-sign-conversion

### DIFF
--- a/perception/autoware_tracking_object_merger/src/decorative_tracker_merger_node.cpp
+++ b/perception/autoware_tracking_object_merger/src/decorative_tracker_merger_node.cpp
@@ -57,7 +57,8 @@ Eigen::MatrixXd calcScoreMatrixForAssociation(
   const rclcpp::Time current_time = rclcpp::Time(objects0.header.stamp);
 
   // calc score matrix
-  Eigen::MatrixXd score_matrix = Eigen::MatrixXd::Zero(trackers.size(), objects0.objects.size());
+  Eigen::MatrixXd score_matrix = Eigen::MatrixXd::Zero(
+    static_cast<Eigen::Index>(trackers.size()), static_cast<Eigen::Index>(objects0.objects.size()));
   for (size_t trackers_idx = 0; trackers_idx < trackers.size(); ++trackers_idx) {
     const auto & tracker_obj = trackers.at(trackers_idx);
     const auto & object1 = tracker_obj.getObject();
@@ -77,7 +78,8 @@ Eigen::MatrixXd calcScoreMatrixForAssociation(
       } else {
         score = data_association_map.at("lidar-radar")->calcScoreBetweenObjects(object0, object1);
       }
-      score_matrix(trackers_idx, objects0_idx) = score;
+      score_matrix(
+        static_cast<Eigen::Index>(trackers_idx), static_cast<Eigen::Index>(objects0_idx)) = score;
     }
   }
   return score_matrix;
@@ -316,9 +318,11 @@ bool DecorativeTrackerMergerNode::decorativeMerger(
   // look for tracker
   for (int tracker_idx = 0; tracker_idx < static_cast<int>(inner_tracker_objects_.size());
        ++tracker_idx) {
-    auto & object0_state = inner_tracker_objects_.at(tracker_idx);
+    auto & object0_state =
+      inner_tracker_objects_.at(static_cast<std::vector<int>::size_type>(tracker_idx));
     if (direct_assignment.find(tracker_idx) != direct_assignment.end()) {  // found and merge
-      const auto & object1 = objects1.at(direct_assignment.at(tracker_idx));
+      const auto & object1 =
+        objects1.at(static_cast<std::vector<int>::size_type>(direct_assignment.at(tracker_idx)));
       // merge object1 into object0_state
       object0_state.updateState(input_sensor, current_time, object1);
     } else {  // not found
@@ -328,7 +332,7 @@ bool DecorativeTrackerMergerNode::decorativeMerger(
   }
   // look for new object
   for (int object1_idx = 0; object1_idx < static_cast<int>(objects1.size()); ++object1_idx) {
-    const auto & object1 = objects1.at(object1_idx);
+    const auto & object1 = objects1.at(static_cast<std::vector<int>::size_type>(object1_idx));
     if (reverse_assignment.find(object1_idx) != reverse_assignment.end()) {  // found
     } else {                                                                 // not found
       inner_tracker_objects_.push_back(createNewTracker(input_sensor, current_time, object1));


### PR DESCRIPTION
## Description
This is a fix based on clang-tidy `clang-diagnostic-sign-conversion` error.

```
/home/emb4/autoware/autoware/src/universe/autoware.universe/perception/autoware_tracking_object_merger/src/decorative_tracker_merger_node.cpp:60:65: error: implicit conversion changes signedness: 'std::vector::size_type' (aka 'unsigned long') to 'Eigen::Index' (aka 'long') [clang-diagnostic-sign-conversion]
  Eigen::MatrixXd score_matrix = Eigen::MatrixXd::Zero(trackers.size(), objects0.objects.size());
                                 ~~~~~                 ~~~~~~~~~^~~~~~
/home/emb4/autoware/autoware/src/universe/autoware.universe/perception/autoware_tracking_object_merger/src/decorative_tracker_merger_node.cpp:60:90: error: implicit conversion changes signedness: 'std::vector::size_type' (aka 'unsigned long') to 'Eigen::Index' (aka 'long') [clang-diagnostic-sign-conversion]
  Eigen::MatrixXd score_matrix = Eigen::MatrixXd::Zero(trackers.size(), objects0.objects.size());
                                 ~~~~~                                  ~~~~~~~~~~~~~~~~~^~~~~~
/home/emb4/autoware/autoware/src/universe/autoware.universe/perception/autoware_tracking_object_merger/src/decorative_tracker_merger_node.cpp:80:20: error: implicit conversion changes signedness: 'size_t' (aka 'unsigned long') to 'Eigen::Index' (aka 'long') [clang-diagnostic-sign-conversion]
      score_matrix(trackers_idx, objects0_idx) = score;
      ~~~~~~~~~~~~ ^~~~~~~~~~~~
/home/emb4/autoware/autoware/src/universe/autoware.universe/perception/autoware_tracking_object_merger/src/decorative_tracker_merger_node.cpp:80:34: error: implicit conversion changes signedness: 'size_t' (aka 'unsigned long') to 'Eigen::Index' (aka 'long') [clang-diagnostic-sign-conversion]
      score_matrix(trackers_idx, objects0_idx) = score;
      ~~~~~~~~~~~~               ^~~~~~~~~~~~
/home/emb4/autoware/autoware/src/universe/autoware.universe/perception/autoware_tracking_object_merger/src/decorative_tracker_merger_node.cpp:319:54: error: implicit conversion changes signedness: 'int' to 'std::vector::size_type' (aka 'unsigned long') [clang-diagnostic-sign-conversion]
    auto & object0_state = inner_tracker_objects_.at(tracker_idx);
                                                  ~~ ^~~~~~~~~~~
/home/emb4/autoware/autoware/src/universe/autoware.universe/perception/autoware_tracking_object_merger/src/decorative_tracker_merger_node.cpp:321:60: error: implicit conversion changes signedness: 'std::unordered_map<int, int>::mapped_type' (aka 'int') to 'std::vector::size_type' (aka 'unsigned long') [clang-diagnostic-sign-conversion]
      const auto & object1 = objects1.at(direct_assignment.at(tracker_idx));
                                      ~~ ~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~
/home/emb4/autoware/autoware/src/universe/autoware.universe/perception/autoware_tracking_object_merger/src/decorative_tracker_merger_node.cpp:331:40: error: implicit conversion changes signedness: 'int' to 'std::vector::size_type' (aka 'unsigned long') [clang-diagnostic-sign-conversion]
    const auto & object1 = objects1.at(object1_idx);
                                    ~~ ^~~~~~~~~~~
```
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
