### PR TITLE
fix(autoware_tensorrt_classifier): fix clang errors

### DIFF
--- a/perception/autoware_tensorrt_classifier/include/autoware/tensorrt_classifier/calibrator.hpp
+++ b/perception/autoware_tensorrt_classifier/include/autoware/tensorrt_classifier/calibrator.hpp
@@ -270,19 +270,19 @@ public:
     output.write(reinterpret_cast<const char *>(cache), length);
   }
 
-  double getQuantile() const noexcept
+  double getQuantile() const noexcept override
   {
     printf("Quantile %f\n", m_quantile);
     return m_quantile;
   }
 
-  double getRegressionCutoff(void) const noexcept
+  double getRegressionCutoff(void) const noexcept override
   {
     printf("Cutoff %f\n", m_cutoff);
     return m_cutoff;
   }
 
-  const void * readHistogramCache(std::size_t & length) noexcept
+  const void * readHistogramCache(std::size_t & length) noexcept override
   {
     hist_cache_.clear();
     std::ifstream input(histogram_cache_file_, std::ios::binary);
@@ -301,7 +301,7 @@ public:
     }
     return length ? &hist_cache_[0] : nullptr;
   }
-  void writeHistogramCache(void const * ptr, std::size_t length) noexcept
+  void writeHistogramCache(void const * ptr, std::size_t length) noexcept override
   {
     std::ofstream output(histogram_cache_file_, std::ios::binary);
     output.write(reinterpret_cast<const char *>(ptr), length);

--- a/perception/autoware_tensorrt_classifier/include/autoware/tensorrt_classifier/tensorrt_classifier.hpp
+++ b/perception/autoware_tensorrt_classifier/include/autoware/tensorrt_classifier/tensorrt_classifier.hpp
@@ -107,7 +107,6 @@ private:
   std::vector<float> input_h_;
   CudaUniquePtr<float[]> input_d_;
 
-  bool needs_output_decode_;
   size_t out_elem_num_;
   size_t out_elem_num_per_batch_;
   CudaUniquePtr<float[]> out_prob_d_;


### PR DESCRIPTION
## Description
This is a fix based on clang-tidy errors.

```
/home/emb4/autoware/autoware/src/universe/autoware.universe/perception/autoware_tensorrt_classifier/include/autoware/tensorrt_classifier/calibrator.hpp:273:10: error: 'getQuantile' overrides a member function but is not marked 'override' [clang-diagnostic-inconsistent-missing-override]
  double getQuantile() const noexcept
         ^
/usr/include/x86_64-linux-gnu/NvInfer.h:8412:20: note: overridden virtual function is here
    virtual double getQuantile() const noexcept = 0;
                   ^
/home/emb4/autoware/autoware/src/universe/autoware.universe/perception/autoware_tensorrt_classifier/include/autoware/tensorrt_classifier/calibrator.hpp:279:10: error: 'getRegressionCutoff' overrides a member function but is not marked 'override' [clang-diagnostic-inconsistent-missing-override]
  double getRegressionCutoff(void) const noexcept
         ^
/usr/include/x86_64-linux-gnu/NvInfer.h:8420:20: note: overridden virtual function is here
    virtual double getRegressionCutoff() const noexcept = 0;
                   ^
/home/emb4/autoware/autoware/src/universe/autoware.universe/perception/autoware_tensorrt_classifier/include/autoware/tensorrt_classifier/calibrator.hpp:285:16: error: 'readHistogramCache' overrides a member function but is not marked 'override' [clang-diagnostic-inconsistent-missing-override]
  const void * readHistogramCache(std::size_t & length) noexcept
               ^
/usr/include/x86_64-linux-gnu/NvInfer.h:8434:25: note: overridden virtual function is here
    virtual void const* readHistogramCache(std::size_t& length) noexcept = 0;
                        ^
/home/emb4/autoware/autoware/src/universe/autoware.universe/perception/autoware_tensorrt_classifier/include/autoware/tensorrt_classifier/calibrator.hpp:304:8: error: 'writeHistogramCache' overrides a member function but is not marked 'override' [clang-diagnostic-inconsistent-missing-override]
  void writeHistogramCache(void const * ptr, std::size_t length) noexcept
       ^
/usr/include/x86_64-linux-gnu/NvInfer.h:8444:18: note: overridden virtual function is here
    virtual void writeHistogramCache(void const* ptr, std::size_t length) noexcept = 0;
                 ^
/home/emb4/autoware/autoware/src/universe/autoware.universe/perception/autoware_tensorrt_classifier/include/autoware/tensorrt_classifier/tensorrt_classifier.hpp:110:8: error: private field 'needs_output_decode_' is not used [clang-diagnostic-unused-private-field]
  bool needs_output_decode_;
       ^
```
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
