### PR TITLE
fix(autoware_image_projection_based_fusion): fix clang-diagnostic-inconsistent-missing-override

### DIFF
--- a/perception/autoware_image_projection_based_fusion/include/autoware/image_projection_based_fusion/segmentation_pointcloud_fusion/node.hpp
+++ b/perception/autoware_image_projection_based_fusion/include/autoware/image_projection_based_fusion/segmentation_pointcloud_fusion/node.hpp
@@ -62,7 +62,7 @@ protected:
     const PointCloud2 & input_pointcloud_msg, const std::size_t image_id, const Image & input_mask,
     const CameraInfo & camera_info, PointCloud2 & output_pointcloud_msg) override;
 
-  bool out_of_scope(const PointCloud2 & filtered_cloud);
+  bool out_of_scope(const PointCloud2 & filtered_cloud) override;
   inline void copyPointCloud(
     const PointCloud2 & input, const int point_step, const size_t global_offset,
     PointCloud2 & output, size_t & output_pointcloud_size)


### PR DESCRIPTION
## Description
This is a fix based on clang-tidy `clang-diagnostic-inconsistent-missing-override` error.

```
/home/emb4/autoware/autoware/src/universe/autoware.universe/perception/autoware_image_projection_based_fusion/include/autoware/image_projection_based_fusion/segmentation_pointcloud_fusion/node.hpp:65:8: error: 'out_of_scope' overrides a member function but is not marked 'override' [clang-diagnostic-inconsistent-missing-override]
  bool out_of_scope(const PointCloud2 & filtered_cloud);
       ^
/home/emb4/autoware/autoware/src/universe/autoware.universe/perception/autoware_image_projection_based_fusion/include/autoware/image_projection_based_fusion/fusion_node.hpp:134:16: note: overridden virtual function is here
  virtual bool out_of_scope(const ObjType & obj) = 0;
               ^
```
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
