### PR TITLE
feat(goal_planner): divide Planners to isolated threads

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/CMakeLists.txt
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/CMakeLists.txt
@@ -19,6 +19,7 @@ ament_auto_add_library(${PROJECT_NAME} SHARED
   src/util.cpp
   src/goal_planner_module.cpp
   src/manager.cpp
+  src/thread_data.cpp
   src/decision_state.cpp
 )
 

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/goal_planner_module.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/goal_planner_module.hpp
@@ -18,9 +18,7 @@
 #include "autoware/behavior_path_goal_planner_module/decision_state.hpp"
 #include "autoware/behavior_path_goal_planner_module/fixed_goal_planner_base.hpp"
 #include "autoware/behavior_path_goal_planner_module/goal_planner_parameters.hpp"
-#include "autoware/behavior_path_goal_planner_module/goal_searcher.hpp"
 #include "autoware/behavior_path_goal_planner_module/thread_data.hpp"
-#include "autoware/behavior_path_planner_common/interface/scene_module_interface.hpp"
 #include "autoware/behavior_path_planner_common/utils/parking_departure/common_module_data.hpp"
 #include "autoware/behavior_path_planner_common/utils/path_safety_checker/path_safety_checker_parameters.hpp"
 
@@ -84,32 +82,62 @@ struct LastApprovalData
   Pose pose{};
 };
 
+// store stop_pose_ pointer with reason string
+struct PoseWithString
+{
+  std::optional<Pose> * pose;
+  std::string string;
+
+  explicit PoseWithString(std::optional<Pose> * shared_pose) : pose(shared_pose), string("") {}
+
+  void set(const Pose & new_pose, const std::string & new_string)
+  {
+    *pose = new_pose;
+    string = new_string;
+  }
+
+  void set(const std::string & new_string) { string = new_string; }
+
+  void clear()
+  {
+    pose->reset();
+    string = "";
+  }
+};
+
+struct SelectedPullOverPath
+{
+  PullOverPath path;
+  rclcpp::Time selected_time;
+  std::optional<rclcpp::Time> last_path_idx_increment_time;
+};
+
 struct PullOverContextData
 {
   PullOverContextData() = delete;
   explicit PullOverContextData(
     const bool is_stable_safe_path, const PredictedObjects & static_objects,
-    const PredictedObjects & dynamic_objects, std::optional<PullOverPath> && pull_over_path_opt,
-    const std::vector<PullOverPath> & pull_over_path_candidates,
-    const PathDecisionState & prev_state)
+    const PredictedObjects & dynamic_objects, const PathDecisionState & prev_state,
+    const bool is_stopped, LaneParkingResponse && lane_parking_response,
+    FreespaceParkingResponse && freespace_parking_response)
   : is_stable_safe_path(is_stable_safe_path),
     static_target_objects(static_objects),
     dynamic_target_objects(dynamic_objects),
-    pull_over_path_opt(pull_over_path_opt),
-    pull_over_path_candidates(pull_over_path_candidates),
     prev_state_for_debug(prev_state),
-    last_path_idx_increment_time(std::nullopt)
+    is_stopped(is_stopped),
+    lane_parking_response(lane_parking_response),
+    freespace_parking_response(freespace_parking_response)
   {
   }
   const bool is_stable_safe_path;
   const PredictedObjects static_target_objects;
   const PredictedObjects dynamic_target_objects;
-  // TODO(soblin): due to deceleratePath(), this cannot be const member(velocity is modified by it)
-  std::optional<PullOverPath> pull_over_path_opt;
-  const std::vector<PullOverPath> pull_over_path_candidates;
-  // TODO(soblin): goal_candidate_from_thread, modifed_goal_pose_from_thread, closest_start_pose
   const PathDecisionState prev_state_for_debug;
-  std::optional<rclcpp::Time> last_path_idx_increment_time;
+  const bool is_stopped;
+  const LaneParkingResponse lane_parking_response;
+  const FreespaceParkingResponse freespace_parking_response;
+  // TODO(soblin): due to deceleratePath(), this cannot be const member(velocity is modified by it)
+  std::optional<SelectedPullOverPath> selected_pull_over_path_opt;
 };
 
 bool isOnModifiedGoal(
@@ -133,6 +161,11 @@ bool checkOccupancyGridCollision(
   const PathWithLaneId & path,
   const std::shared_ptr<OccupancyGridBasedCollisionDetector> occupancy_grid_map);
 
+// freespace parking
+std::optional<PullOverPath> planFreespacePath(
+  const FreespaceParkingRequest & req, const PredictedObjects & static_target_objects,
+  std::shared_ptr<PullOverPlannerBase> freespace_planner);
+
 bool isStopped(
   std::deque<nav_msgs::msg::Odometry::ConstSharedPtr> & odometry_buffer,
   const nav_msgs::msg::Odometry::ConstSharedPtr self_odometry, const double duration_lower,
@@ -148,6 +181,61 @@ public:
 
 private:
   std::atomic<bool> & flag_;
+};
+
+class LaneParkingPlanner
+{
+public:
+  LaneParkingPlanner(
+    rclcpp::Node & node, std::mutex & lane_parking_mutex,
+    const std::optional<LaneParkingRequest> & request, LaneParkingResponse & response,
+    std::atomic<bool> & is_lane_parking_cb_running, const rclcpp::Logger & logger,
+    const GoalPlannerParameters & parameters);
+  rclcpp::Logger getLogger() const { return logger_; }
+  void onTimer();
+
+private:
+  std::mutex & mutex_;
+  const std::optional<LaneParkingRequest> & request_;
+  LaneParkingResponse & response_;
+  std::atomic<bool> & is_lane_parking_cb_running_;
+  rclcpp::Logger logger_;
+
+  std::vector<std::shared_ptr<PullOverPlannerBase>> pull_over_planners_;
+};
+
+class FreespaceParkingPlanner
+{
+public:
+  FreespaceParkingPlanner(
+    std::mutex & freespace_parking_mutex, const std::optional<FreespaceParkingRequest> & request,
+    FreespaceParkingResponse & response, std::atomic<bool> & is_freespace_parking_cb_running,
+    const rclcpp::Logger & logger, const rclcpp::Clock::SharedPtr clock,
+    const std::shared_ptr<PullOverPlannerBase> freespace_planner)
+  : mutex_(freespace_parking_mutex),
+    request_(request),
+    response_(response),
+    is_freespace_parking_cb_running_(is_freespace_parking_cb_running),
+    logger_(logger),
+    clock_(clock),
+    freespace_planner_(freespace_planner)
+  {
+  }
+  void onTimer();
+
+private:
+  std::mutex & mutex_;
+  const std::optional<FreespaceParkingRequest> & request_;
+  FreespaceParkingResponse & response_;
+  std::atomic<bool> & is_freespace_parking_cb_running_;
+  rclcpp::Logger logger_;
+  rclcpp::Clock::SharedPtr clock_;
+
+  std::shared_ptr<PullOverPlannerBase> freespace_planner_;
+
+  bool isStuck(
+    const PredictedObjects & static_target_objects, const PredictedObjects & dynamic_target_objects,
+    const FreespaceParkingRequest & req) const;
 };
 
 class GoalPlannerModule : public SceneModuleInterface
@@ -217,48 +305,15 @@ public:
   CandidateOutput planCandidate() const override { return CandidateOutput{}; }
 
 private:
-  /**
-   * @brief shared data for onTimer(onTimer/onFreespaceParkingTimer just read this)
-   */
-  struct GoalPlannerData
-  {
-    GoalPlannerData(
-      const PlannerData & planner_data, const GoalPlannerParameters & parameters,
-      const BehaviorModuleOutput & previous_module_output_)
-    {
-      initializeOccupancyGridMap(planner_data, parameters);
-      previous_module_output = previous_module_output_;
-      last_previous_module_output = previous_module_output_;
-    };
-    GoalPlannerParameters parameters;
-    autoware::universe_utils::LinearRing2d vehicle_footprint;
+  std::pair<LaneParkingResponse, FreespaceParkingResponse> syncWithThreads();
 
-    PlannerData planner_data;
-    ModuleStatus current_status;
-    BehaviorModuleOutput previous_module_output;
-    BehaviorModuleOutput last_previous_module_output;  //<! previous "previous_module_output"
-    GoalCandidates goal_candidates;  //<! only the positional information of goal_candidates
+  std::mutex lane_parking_mutex_;
+  std::optional<LaneParkingRequest> lane_parking_request_;
+  LaneParkingResponse lane_parking_response_;
 
-    // collision detector
-    // need to be shared_ptr to be used in planner and goal searcher
-    std::shared_ptr<OccupancyGridBasedCollisionDetector> occupancy_grid_map;
-
-    const BehaviorModuleOutput & getPreviousModuleOutput() const { return previous_module_output; }
-    const ModuleStatus & getCurrentStatus() const { return current_status; }
-    void updateOccupancyGrid();
-    GoalPlannerData clone() const;
-    void update(
-      const GoalPlannerParameters & parameters, const PlannerData & planner_data,
-      const ModuleStatus & current_status, const BehaviorModuleOutput & previous_module_output,
-      const autoware::universe_utils::LinearRing2d & vehicle_footprint,
-      const GoalCandidates & goal_candidates);
-
-  private:
-    void initializeOccupancyGridMap(
-      const PlannerData & planner_data, const GoalPlannerParameters & parameters);
-  };
-  std::optional<GoalPlannerData> gp_planner_data_{std::nullopt};
-  std::mutex gp_planner_data_mutex_;
+  std::mutex freespace_parking_mutex_;
+  std::optional<FreespaceParkingRequest> freespace_parking_request_;
+  FreespaceParkingResponse freespace_parking_response_;
 
   /*
    * state transitions and plan function used in each state
@@ -291,15 +346,12 @@ private:
 
   std::shared_ptr<GoalPlannerParameters> parameters_;
 
-  mutable std::shared_ptr<EgoPredictedPathParams> ego_predicted_path_params_;
-  mutable std::shared_ptr<ObjectsFilteringParams> objects_filtering_params_;
-  mutable std::shared_ptr<SafetyCheckParams> safety_check_params_;
+  std::shared_ptr<EgoPredictedPathParams> ego_predicted_path_params_;
+  std::shared_ptr<ObjectsFilteringParams> objects_filtering_params_;
+  std::shared_ptr<SafetyCheckParams> safety_check_params_;
 
   autoware::vehicle_info_utils::VehicleInfo vehicle_info_{};
 
-  // planner
-  std::vector<std::shared_ptr<PullOverPlannerBase>> pull_over_planners_;
-  std::unique_ptr<PullOverPlannerBase> freespace_planner_;
   std::unique_ptr<FixedGoalPlannerBase> fixed_goal_planner_;
 
   // goal searcher
@@ -317,11 +369,6 @@ private:
 
   autoware::universe_utils::LinearRing2d vehicle_footprint_;
 
-  std::recursive_mutex mutex_;
-  mutable ThreadSafeData thread_safe_data_;
-
-  // TODO(soblin): organize part of thread_safe_data and previous data to PullOverContextData
-  // context_data_ is initialized in updateData(), used in plan() and refreshed in postProcess()
   std::optional<PullOverContextData> context_data_{std::nullopt};
   // path_decision_controller is updated in updateData(), and used in plan()
   PathDecisionStateController path_decision_controller_{getLogger()};
@@ -367,14 +414,9 @@ private:
   double calcSignedArcLengthFromEgo(const PathWithLaneId & path, const Pose & pose) const;
 
   // status
-  bool hasFinishedCurrentPath(const PullOverContextData & ctx_data);
+  bool hasFinishedCurrentPath(const PullOverContextData & ctx_data) const;
   double calcModuleRequestLength() const;
-  bool isStuck(
-    const PredictedObjects & static_target_objects, const PredictedObjects & dynamic_target_objects,
-    const std::shared_ptr<const PlannerData> planner_data,
-    const std::shared_ptr<OccupancyGridBasedCollisionDetector> occupancy_grid_map,
-    const GoalPlannerParameters & parameters);
-  void decideVelocity();
+  void decideVelocity(PullOverPath & pull_over_path);
   void updateStatus(const BehaviorModuleOutput & output);
 
   // validation
@@ -385,21 +427,14 @@ private:
   bool isCrossingPossible(
     const Pose & start_pose, const Pose & end_pose, const lanelet::ConstLanelets lanes) const;
   bool isCrossingPossible(const PullOverPath & pull_over_path) const;
-  bool hasEnoughTimePassedSincePathUpdate(const double duration) const;
 
-  // freespace parking
-  bool planFreespacePath(
-    std::shared_ptr<const PlannerData> planner_data,
-    const std::shared_ptr<GoalSearcherBase> goal_searcher, const GoalCandidates & goal_candidates,
-    const std::shared_ptr<OccupancyGridBasedCollisionDetector> occupancy_grid_map,
-    const PredictedObjects & static_target_objects);
   bool canReturnToLaneParking(const PullOverContextData & context_data);
 
   // plan pull over path
-  BehaviorModuleOutput planPullOver(const PullOverContextData & context_data);
-  BehaviorModuleOutput planPullOverAsOutput(const PullOverContextData & context_data);
+  BehaviorModuleOutput planPullOver(PullOverContextData & context_data);
+  BehaviorModuleOutput planPullOverAsOutput(PullOverContextData & context_data);
   BehaviorModuleOutput planPullOverAsCandidate(
-    const PullOverContextData & context_data, const std::string & detail);
+    PullOverContextData & context_data, const std::string & detail);
   std::optional<PullOverPath> selectPullOverPath(
     const PullOverContextData & context_data,
     const std::vector<PullOverPath> & pull_over_path_candidates,
@@ -411,7 +446,9 @@ private:
     const PullOverContextData & context_data, BehaviorModuleOutput & output) const;
 
   // output setter
-  void setOutput(const PullOverContextData & context_data, BehaviorModuleOutput & output);
+  void setOutput(
+    const std::optional<PullOverPath> selected_pull_over_path_with_velocity_opt,
+    const PullOverContextData & context_data, BehaviorModuleOutput & output);
 
   void setModifiedGoal(
     const PullOverContextData & context_data, BehaviorModuleOutput & output) const;
@@ -420,10 +457,6 @@ private:
   // new turn signal
   TurnSignalInfo calcTurnSignalInfo(const PullOverContextData & context_data);
   std::optional<lanelet::Id> ignore_signal_{std::nullopt};
-
-  // timer for generating pull over path candidates in a separate thread
-  void onTimer();
-  void onFreespaceParkingTimer();
 
   // steering factor
   void updateSteeringFactor(

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/goal_planner_module.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/goal_planner_module.hpp
@@ -88,8 +88,8 @@ struct PullOverContextData
   explicit PullOverContextData(
     const bool is_stable_safe_path, const PredictedObjects & static_objects,
     const PredictedObjects & dynamic_objects, const PathDecisionState & prev_state,
-    const bool is_stopped, LaneParkingResponse && lane_parking_response,
-    FreespaceParkingResponse && freespace_parking_response)
+    const bool is_stopped, const LaneParkingResponse & lane_parking_response,
+    const FreespaceParkingResponse & freespace_parking_response)
   : is_stable_safe_path(is_stable_safe_path),
     static_target_objects(static_objects),
     dynamic_target_objects(dynamic_objects),
@@ -99,18 +99,32 @@ struct PullOverContextData
     freespace_parking_response(freespace_parking_response)
   {
   }
-  const bool is_stable_safe_path;
-  const PredictedObjects static_target_objects;
-  const PredictedObjects dynamic_target_objects;
-  const PathDecisionState prev_state_for_debug;
-  const bool is_stopped;
-  const LaneParkingResponse lane_parking_response;
-  const FreespaceParkingResponse freespace_parking_response;
-  // TODO(soblin): due to deceleratePath(), this cannot be const member(velocity is modified by it),
-  // and bind following three member, rename as "SelectedPullOverPath"
+  // TODO(soblin): make following variables private
+  bool is_stable_safe_path;
+  PredictedObjects static_target_objects;
+  PredictedObjects dynamic_target_objects;
+  PathDecisionState prev_state_for_debug;
+  bool is_stopped;
+  LaneParkingResponse lane_parking_response;
+  FreespaceParkingResponse freespace_parking_response;
   std::optional<PullOverPath> pull_over_path_opt;
   std::optional<rclcpp::Time> last_path_update_time;
   std::optional<rclcpp::Time> last_path_idx_increment_time;
+
+  void update(
+    const bool is_stable_safe_path_, const PredictedObjects static_target_objects_,
+    const PredictedObjects dynamic_target_objects_, const PathDecisionState prev_state_for_debug_,
+    const bool is_stopped_, const LaneParkingResponse & lane_parking_response_,
+    const FreespaceParkingResponse & freespace_parking_response_)
+  {
+    is_stable_safe_path = is_stable_safe_path_;
+    static_target_objects = static_target_objects_;
+    dynamic_target_objects = dynamic_target_objects_;
+    prev_state_for_debug = prev_state_for_debug_;
+    is_stopped = is_stopped_;
+    lane_parking_response = lane_parking_response_;
+    freespace_parking_response = freespace_parking_response_;
+  }
 };
 
 bool isOnModifiedGoal(

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/thread_data.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/thread_data.hpp
@@ -16,143 +16,129 @@
 #define AUTOWARE__BEHAVIOR_PATH_GOAL_PLANNER_MODULE__THREAD_DATA_HPP_
 
 #include "autoware/behavior_path_goal_planner_module/decision_state.hpp"
-#include "autoware/behavior_path_planner_common/utils/path_safety_checker/path_safety_checker_parameters.hpp"
+#include "autoware/behavior_path_planner_common/interface/scene_module_interface.hpp"
 
 #include <rclcpp/rclcpp.hpp>
 
 #include <memory>
-#include <mutex>
 #include <optional>
+#include <utility>
 #include <vector>
 
 namespace autoware::behavior_path_planner
 {
 
-#define DEFINE_SETTER_WITH_MUTEX(TYPE, NAME)                  \
-public:                                                       \
-  void set_##NAME(const TYPE & value)                         \
-  {                                                           \
-    const std::lock_guard<std::recursive_mutex> lock(mutex_); \
-    NAME##_ = value;                                          \
-  }
-
-#define DEFINE_GETTER_WITH_MUTEX(TYPE, NAME)                  \
-public:                                                       \
-  TYPE get_##NAME() const                                     \
-  {                                                           \
-    const std::lock_guard<std::recursive_mutex> lock(mutex_); \
-    return NAME##_;                                           \
-  }
-
-#define DEFINE_SETTER_GETTER_WITH_MUTEX(TYPE, NAME) \
-  DEFINE_SETTER_WITH_MUTEX(TYPE, NAME)              \
-  DEFINE_GETTER_WITH_MUTEX(TYPE, NAME)
-
-class ThreadSafeData
+class LaneParkingRequest
 {
 public:
-  ThreadSafeData(std::recursive_mutex & mutex, rclcpp::Clock::SharedPtr clock)
-  : mutex_(mutex), clock_(clock)
+  LaneParkingRequest(
+    const GoalPlannerParameters & parameters,
+    const autoware::universe_utils::LinearRing2d & vehicle_footprint,
+    const GoalCandidates & goal_candidates, const BehaviorModuleOutput & previous_module_output)
+  : parameters_(parameters),
+    vehicle_footprint_(vehicle_footprint),
+    goal_candidates_(goal_candidates),
+    previous_module_output_(previous_module_output),
+    last_previous_module_output_(previous_module_output)
   {
   }
 
-  bool incrementPathIndex()
+  void update(
+    const PlannerData & planner_data, const ModuleStatus & current_status,
+    const BehaviorModuleOutput & previous_module_output,
+    const std::optional<std::pair<PullOverPath, rclcpp::Time>> & selected_pull_over_path,
+    const PathDecisionState & prev_data);
+
+  const GoalPlannerParameters parameters_;
+  const autoware::universe_utils::LinearRing2d vehicle_footprint_;
+  const GoalCandidates goal_candidates_;
+
+  const std::shared_ptr<PlannerData> & get_planner_data() const { return planner_data_; }
+  const ModuleStatus & get_current_status() const { return current_status_; }
+  const BehaviorModuleOutput & get_previous_module_output() const
   {
-    const std::lock_guard<std::recursive_mutex> lock(mutex_);
-    if (!pull_over_path_) {
-      return false;
-    }
-
-    return pull_over_path_->incrementPathIndex();
+    return previous_module_output_;
   }
-
-  void set_pull_over_path(const PullOverPath & path)
+  const BehaviorModuleOutput & get_last_previous_module_output() const
   {
-    const std::lock_guard<std::recursive_mutex> lock(mutex_);
-    set_pull_over_path_no_lock(path);
+    return last_previous_module_output_;
   }
-
-  void set_pull_over_path(const std::shared_ptr<PullOverPath> & path)
+  const std::optional<std::pair<PullOverPath, rclcpp::Time>> & get_selected_pull_over_path() const
   {
-    const std::lock_guard<std::recursive_mutex> lock(mutex_);
-    set_pull_over_path_no_lock(path);
+    return selected_pull_over_path_;
   }
-
-  template <typename... Args>
-  void set(Args... args)
-  {
-    std::lock_guard<std::recursive_mutex> lock(mutex_);
-    (..., set_no_lock(args));
-  }
-
-  void clearPullOverPath()
-  {
-    const std::lock_guard<std::recursive_mutex> lock(mutex_);
-    pull_over_path_ = nullptr;
-  }
-
-  bool foundPullOverPath() const
-  {
-    const std::lock_guard<std::recursive_mutex> lock(mutex_);
-    if (!pull_over_path_) {
-      return false;
-    }
-
-    return true;
-  }
-
-  void reset()
-  {
-    const std::lock_guard<std::recursive_mutex> lock(mutex_);
-    pull_over_path_ = nullptr;
-    pull_over_path_candidates_.clear();
-    last_path_update_time_ = std::nullopt;
-    closest_start_pose_ = std::nullopt;
-    prev_data_ = PathDecisionState{};
-  }
-
-  // main --> lane
-  DEFINE_SETTER_GETTER_WITH_MUTEX(PathDecisionState, prev_data)
-
-  // lane --> main
-  DEFINE_SETTER_GETTER_WITH_MUTEX(std::optional<Pose>, closest_start_pose)
-  DEFINE_SETTER_GETTER_WITH_MUTEX(std::vector<PullOverPath>, pull_over_path_candidates)
-
-  // main <--> lane/freespace
-  DEFINE_GETTER_WITH_MUTEX(std::shared_ptr<PullOverPath>, pull_over_path)
-  DEFINE_GETTER_WITH_MUTEX(std::optional<rclcpp::Time>, last_path_update_time)
+  const PathDecisionState & get_prev_data() const { return prev_data_; }
+  LaneParkingRequest clone() const;
 
 private:
-  void set_pull_over_path_no_lock(const PullOverPath & path)
-  {
-    pull_over_path_ = std::make_shared<PullOverPath>(path);
-
-    last_path_update_time_ = clock_->now();
-  }
-
-  void set_pull_over_path_no_lock(const std::shared_ptr<PullOverPath> & path)
-  {
-    pull_over_path_ = path;
-    last_path_update_time_ = clock_->now();
-  }
-
-  void set_no_lock(const std::vector<PullOverPath> & arg) { pull_over_path_candidates_ = arg; }
-  void set_no_lock(const std::shared_ptr<PullOverPath> & arg) { set_pull_over_path_no_lock(arg); }
-  void set_no_lock(const PullOverPath & arg) { set_pull_over_path_no_lock(arg); }
-
-  std::shared_ptr<PullOverPath> pull_over_path_{nullptr};
-  std::vector<PullOverPath> pull_over_path_candidates_;
-  std::optional<rclcpp::Time> last_path_update_time_;
-  std::optional<Pose> closest_start_pose_{};
-  PathDecisionState prev_data_{};
-
-  std::recursive_mutex & mutex_;
-  rclcpp::Clock::SharedPtr clock_;
+  std::shared_ptr<PlannerData> planner_data_;
+  ModuleStatus current_status_;
+  BehaviorModuleOutput previous_module_output_;
+  BehaviorModuleOutput last_previous_module_output_;
+  std::optional<std::pair<PullOverPath, rclcpp::Time>>
+    selected_pull_over_path_;  //<! pull over path selected by main thread
+  PathDecisionState prev_data_;
 };
 
-#undef DEFINE_SETTER_WITH_MUTEX
-#undef DEFINE_GETTER_WITH_MUTEX
-#undef DEFINE_SETTER_GETTER_WITH_MUTEX
+struct LaneParkingResponse
+{
+  std::vector<PullOverPath> pull_over_path_candidates;
+  std::optional<Pose> closest_start_pose;
+};
+
+class FreespaceParkingRequest
+{
+public:
+  FreespaceParkingRequest(
+    const GoalPlannerParameters & parameters,
+    const autoware::universe_utils::LinearRing2d & vehicle_footprint,
+    const GoalCandidates & goal_candidates, const PlannerData & planner_data)
+  : parameters_(parameters),
+    vehicle_footprint_(vehicle_footprint),
+    goal_candidates_(goal_candidates)
+  {
+    initializeOccupancyGridMap(planner_data, parameters_);
+  };
+
+  const ModuleStatus & getCurrentStatus() const { return current_status_; }
+  void update(
+    const PlannerData & planner_data, const ModuleStatus & current_status,
+    const std::optional<std::pair<PullOverPath, rclcpp::Time>> & selected_pull_over_path,
+    const bool is_stopped);
+
+  const GoalPlannerParameters parameters_;
+  const autoware::universe_utils::LinearRing2d vehicle_footprint_;
+  const GoalCandidates goal_candidates_;
+
+  const std::shared_ptr<PlannerData> & get_planner_data() const { return planner_data_; }
+  const ModuleStatus & get_current_status() const { return current_status_; }
+  std::shared_ptr<OccupancyGridBasedCollisionDetector> get_occupancy_grid_map() const
+  {
+    return occupancy_grid_map_;
+  }
+  const std::optional<std::pair<PullOverPath, rclcpp::Time>> & get_selected_pull_over_path() const
+  {
+    return selected_pull_over_path_;
+  }
+  bool is_stopped() const { return is_stopped_; }
+
+  FreespaceParkingRequest clone() const;
+
+private:
+  std::shared_ptr<PlannerData> planner_data_;
+  ModuleStatus current_status_;
+  std::shared_ptr<OccupancyGridBasedCollisionDetector> occupancy_grid_map_;
+  std::optional<std::pair<PullOverPath, rclcpp::Time>> selected_pull_over_path_;
+  bool is_stopped_;
+
+  void initializeOccupancyGridMap(
+    const PlannerData & planner_data, const GoalPlannerParameters & parameters);
+};
+
+struct FreespaceParkingResponse
+{
+  std::optional<PullOverPath> freespace_pull_over_path;
+};
 
 }  // namespace autoware::behavior_path_planner
 

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/thread_data.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/thread_data.hpp
@@ -64,7 +64,6 @@ public:
   }
   const std::optional<PullOverPath> & get_pull_over_path() const { return pull_over_path_; }
   const PathDecisionState & get_prev_data() const { return prev_data_; }
-  LaneParkingRequest clone() const;
 
 private:
   std::shared_ptr<PlannerData> planner_data_;
@@ -117,8 +116,6 @@ public:
     return last_path_update_time_;
   }
   bool is_stopped() const { return is_stopped_; }
-
-  FreespaceParkingRequest clone() const;
 
 private:
   std::shared_ptr<PlannerData> planner_data_;

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/thread_data.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/thread_data.hpp
@@ -46,8 +46,7 @@ public:
   void update(
     const PlannerData & planner_data, const ModuleStatus & current_status,
     const BehaviorModuleOutput & previous_module_output,
-    const std::optional<std::pair<PullOverPath, rclcpp::Time>> & selected_pull_over_path,
-    const PathDecisionState & prev_data);
+    const std::optional<PullOverPath> & pull_over_path, const PathDecisionState & prev_data);
 
   const GoalPlannerParameters parameters_;
   const autoware::universe_utils::LinearRing2d vehicle_footprint_;
@@ -63,10 +62,7 @@ public:
   {
     return last_previous_module_output_;
   }
-  const std::optional<std::pair<PullOverPath, rclcpp::Time>> & get_selected_pull_over_path() const
-  {
-    return selected_pull_over_path_;
-  }
+  const std::optional<PullOverPath> & get_pull_over_path() const { return pull_over_path_; }
   const PathDecisionState & get_prev_data() const { return prev_data_; }
   LaneParkingRequest clone() const;
 
@@ -75,8 +71,7 @@ private:
   ModuleStatus current_status_;
   BehaviorModuleOutput previous_module_output_;
   BehaviorModuleOutput last_previous_module_output_;
-  std::optional<std::pair<PullOverPath, rclcpp::Time>>
-    selected_pull_over_path_;  //<! pull over path selected by main thread
+  std::optional<PullOverPath> pull_over_path_;  //<! pull over path selected by main thread
   PathDecisionState prev_data_;
 };
 
@@ -103,8 +98,8 @@ public:
   const ModuleStatus & getCurrentStatus() const { return current_status_; }
   void update(
     const PlannerData & planner_data, const ModuleStatus & current_status,
-    const std::optional<std::pair<PullOverPath, rclcpp::Time>> & selected_pull_over_path,
-    const bool is_stopped);
+    const std::optional<PullOverPath> & pull_over_path,
+    const std::optional<rclcpp::Time> & last_path_update_time, const bool is_stopped);
 
   const GoalPlannerParameters parameters_;
   const autoware::universe_utils::LinearRing2d vehicle_footprint_;
@@ -116,9 +111,10 @@ public:
   {
     return occupancy_grid_map_;
   }
-  const std::optional<std::pair<PullOverPath, rclcpp::Time>> & get_selected_pull_over_path() const
+  const std::optional<PullOverPath> & get_pull_over_path() const { return pull_over_path_; }
+  const std::optional<rclcpp::Time> & get_last_path_update_time() const
   {
-    return selected_pull_over_path_;
+    return last_path_update_time_;
   }
   bool is_stopped() const { return is_stopped_; }
 
@@ -128,7 +124,8 @@ private:
   std::shared_ptr<PlannerData> planner_data_;
   ModuleStatus current_status_;
   std::shared_ptr<OccupancyGridBasedCollisionDetector> occupancy_grid_map_;
-  std::optional<std::pair<PullOverPath, rclcpp::Time>> selected_pull_over_path_;
+  std::optional<PullOverPath> pull_over_path_;
+  std::optional<rclcpp::Time> last_path_update_time_;
   bool is_stopped_;
 
   void initializeOccupancyGridMap(

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/goal_planner_module.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/goal_planner_module.cpp
@@ -619,6 +619,10 @@ std::pair<LaneParkingResponse, FreespaceParkingResponse> GoalPlannerModule::sync
       isStopped(
         odometry_buffer_stuck_, planner_data_->self_odometry, stuck_time,
         parameters_->th_stopped_velocity));
+    // TODO(soblin): currently, ogm-based-collision-detector is updated to latest in
+    // freespace_parking_request_.value().update, and it is shared with goal_planner_module. Next,
+    // goal_planner_module update it and pass it to freespace_parking_request.
+    occupancy_grid_map_ = freespace_parking_request_.value().get_occupancy_grid_map();
     freespace_parking_response = freespace_parking_response_;
   }
   // end of critical section
@@ -659,7 +663,6 @@ void GoalPlannerModule::updateData()
     goal_candidates_ = generateGoalCandidates();
   }
 
-  occupancy_grid_map_->setMap(*(planner_data_->occupancy_grid));
   auto [lane_parking_response, freespace_parking_response] = syncWithThreads();
 
   if (getCurrentStatus() == ModuleStatus::IDLE && !isExecutionRequested()) {

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/goal_planner_module.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/goal_planner_module.cpp
@@ -498,7 +498,6 @@ void FreespaceParkingPlanner::onTimer()
   const auto & current_status = local_request.get_current_status();
   const auto & pull_over_path_opt = local_request.get_pull_over_path();
   const auto & last_path_update_time = local_request.get_last_path_update_time();
-  const auto & occupancy_grid_map = local_request.get_occupancy_grid_map();
 
   if (current_status == ModuleStatus::IDLE) {
     return;
@@ -1690,11 +1689,10 @@ PathWithLaneId GoalPlannerModule::generateStopPath(
   // 4. feasible stop
   const auto stop_pose_opt = std::invoke([&]() -> std::optional<Pose> {
     if (context_data.pull_over_path_opt)
-      return context_data.pull_over_path_opt.value().start_pose();
+      return std::make_optional<Pose>(context_data.pull_over_path_opt.value().start_pose());
     if (context_data.lane_parking_response.closest_start_pose)
-      return context_data.lane_parking_response.closest_start_pose.value();
-    if (!decel_pose) return std::nullopt;
-    return decel_pose.value();
+      return context_data.lane_parking_response.closest_start_pose;
+    return decel_pose;
   });
   if (!stop_pose_opt.has_value()) {
     const auto feasible_stop_path =

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/goal_planner_module.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/goal_planner_module.cpp
@@ -1480,7 +1480,7 @@ BehaviorModuleOutput GoalPlannerModule::planPullOverAsOutput(PullOverContextData
     // Select a path that is as safe as possible and has a high priority.
     const auto & pull_over_path_candidates =
       context_data.lane_parking_response.pull_over_path_candidates;
-    auto lane_pull_over_path_opt =
+    const auto lane_pull_over_path_opt =
       selectPullOverPath(context_data, pull_over_path_candidates, goal_candidates);
 
     // update thread_safe_data_

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/pull_over_planner/geometric_pull_over.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/pull_over_planner/geometric_pull_over.cpp
@@ -78,9 +78,6 @@ std::optional<PullOverPath> GeometricPullOver::plan(
   auto pull_over_path_opt = PullOverPath::create(
     getPlannerType(), id, planner_.getPaths(), planner_.getStartPose(), modified_goal_pose,
     planner_.getPairsTerminalVelocityAndAccel());
-  if (!pull_over_path_opt) {
-    return {};
-  }
-  return pull_over_path_opt.value();
+  return pull_over_path_opt;
 }
 }  // namespace autoware::behavior_path_planner

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/pull_over_planner/shift_pull_over.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/pull_over_planner/shift_pull_over.cpp
@@ -67,7 +67,7 @@ std::optional<PullOverPath> ShiftPullOver::plan(
       modified_goal_pose, id, planner_data, previous_module_output, road_lanes, pull_over_lanes,
       lateral_jerk);
     if (!pull_over_path) continue;
-    return *pull_over_path;
+    return pull_over_path;
   }
 
   return {};

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/thread_data.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/thread_data.cpp
@@ -20,15 +20,14 @@ namespace autoware::behavior_path_planner
 void LaneParkingRequest::update(
   const PlannerData & planner_data, const ModuleStatus & current_status,
   const BehaviorModuleOutput & previous_module_output,
-  const std::optional<std::pair<PullOverPath, rclcpp::Time>> & selected_pull_over_path,
-  const PathDecisionState & prev_data)
+  const std::optional<PullOverPath> & pull_over_path, const PathDecisionState & prev_data)
 {
   planner_data_ = std::make_shared<PlannerData>(planner_data);
   planner_data_->route_handler = std::make_shared<RouteHandler>(*(planner_data.route_handler));
   current_status_ = current_status;
   last_previous_module_output_ = previous_module_output_;
   previous_module_output_ = previous_module_output;
-  selected_pull_over_path_ = selected_pull_over_path;
+  pull_over_path_ = pull_over_path;
   prev_data_ = prev_data;
 }
 
@@ -37,7 +36,7 @@ LaneParkingRequest LaneParkingRequest::clone() const
   LaneParkingRequest request(
     parameters_, vehicle_footprint_, goal_candidates_, previous_module_output_);
   request.update(
-    *planner_data_, current_status_, previous_module_output_, selected_pull_over_path_, prev_data_);
+    *planner_data_, current_status_, previous_module_output_, pull_over_path_, prev_data_);
   return request;
 }
 
@@ -59,14 +58,15 @@ void FreespaceParkingRequest::initializeOccupancyGridMap(
 
 void FreespaceParkingRequest::update(
   const PlannerData & planner_data, const ModuleStatus & current_status,
-  const std::optional<std::pair<PullOverPath, rclcpp::Time>> & selected_pull_over_path,
-  const bool is_stopped)
+  const std::optional<PullOverPath> & pull_over_path,
+  const std::optional<rclcpp::Time> & last_path_update_time, const bool is_stopped)
 {
   planner_data_ = std::make_shared<PlannerData>(planner_data);
   planner_data_->route_handler = std::make_shared<RouteHandler>(*(planner_data.route_handler));
   current_status_ = current_status;
   occupancy_grid_map_->setMap(*(planner_data_->occupancy_grid));
-  selected_pull_over_path_ = selected_pull_over_path;
+  pull_over_path_ = pull_over_path;
+  last_path_update_time_ = last_path_update_time;
   is_stopped_ = is_stopped;
 }
 
@@ -74,7 +74,8 @@ FreespaceParkingRequest FreespaceParkingRequest::clone() const
 {
   FreespaceParkingRequest request(
     parameters_, vehicle_footprint_, goal_candidates_, *planner_data_);
-  request.update(*planner_data_, current_status_, selected_pull_over_path_, is_stopped_);
+  request.update(
+    *planner_data_, current_status_, pull_over_path_, last_path_update_time_, is_stopped_);
   return request;
 }
 

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/thread_data.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/thread_data.cpp
@@ -1,0 +1,81 @@
+// Copyright 2024 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <autoware/behavior_path_goal_planner_module/thread_data.hpp>
+
+namespace autoware::behavior_path_planner
+{
+
+void LaneParkingRequest::update(
+  const PlannerData & planner_data, const ModuleStatus & current_status,
+  const BehaviorModuleOutput & previous_module_output,
+  const std::optional<std::pair<PullOverPath, rclcpp::Time>> & selected_pull_over_path,
+  const PathDecisionState & prev_data)
+{
+  planner_data_ = std::make_shared<PlannerData>(planner_data);
+  planner_data_->route_handler = std::make_shared<RouteHandler>(*(planner_data.route_handler));
+  current_status_ = current_status;
+  last_previous_module_output_ = previous_module_output_;
+  previous_module_output_ = previous_module_output;
+  selected_pull_over_path_ = selected_pull_over_path;
+  prev_data_ = prev_data;
+}
+
+LaneParkingRequest LaneParkingRequest::clone() const
+{
+  LaneParkingRequest request(
+    parameters_, vehicle_footprint_, goal_candidates_, previous_module_output_);
+  request.update(
+    *planner_data_, current_status_, previous_module_output_, selected_pull_over_path_, prev_data_);
+  return request;
+}
+
+void FreespaceParkingRequest::initializeOccupancyGridMap(
+  const PlannerData & planner_data, const GoalPlannerParameters & parameters)
+{
+  OccupancyGridMapParam occupancy_grid_map_param{};
+  const double margin = parameters.occupancy_grid_collision_check_margin;
+  occupancy_grid_map_param.vehicle_shape.length =
+    planner_data.parameters.vehicle_length + 2 * margin;
+  occupancy_grid_map_param.vehicle_shape.width = planner_data.parameters.vehicle_width + 2 * margin;
+  occupancy_grid_map_param.vehicle_shape.base2back =
+    planner_data.parameters.base_link2rear + margin;
+  occupancy_grid_map_param.theta_size = parameters.theta_size;
+  occupancy_grid_map_param.obstacle_threshold = parameters.obstacle_threshold;
+  occupancy_grid_map_ = std::make_shared<OccupancyGridBasedCollisionDetector>();
+  occupancy_grid_map_->setParam(occupancy_grid_map_param);
+}
+
+void FreespaceParkingRequest::update(
+  const PlannerData & planner_data, const ModuleStatus & current_status,
+  const std::optional<std::pair<PullOverPath, rclcpp::Time>> & selected_pull_over_path,
+  const bool is_stopped)
+{
+  planner_data_ = std::make_shared<PlannerData>(planner_data);
+  planner_data_->route_handler = std::make_shared<RouteHandler>(*(planner_data.route_handler));
+  current_status_ = current_status;
+  occupancy_grid_map_->setMap(*(planner_data_->occupancy_grid));
+  selected_pull_over_path_ = selected_pull_over_path;
+  is_stopped_ = is_stopped;
+}
+
+FreespaceParkingRequest FreespaceParkingRequest::clone() const
+{
+  FreespaceParkingRequest request(
+    parameters_, vehicle_footprint_, goal_candidates_, *planner_data_);
+  request.update(*planner_data_, current_status_, selected_pull_over_path_, is_stopped_);
+  return request;
+}
+
+}  // namespace autoware::behavior_path_planner

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/thread_data.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/thread_data.cpp
@@ -14,6 +14,8 @@
 
 #include <autoware/behavior_path_goal_planner_module/thread_data.hpp>
 
+#include <memory>
+
 namespace autoware::behavior_path_planner
 {
 

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/thread_data.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/thread_data.cpp
@@ -33,15 +33,6 @@ void LaneParkingRequest::update(
   prev_data_ = prev_data;
 }
 
-LaneParkingRequest LaneParkingRequest::clone() const
-{
-  LaneParkingRequest request(
-    parameters_, vehicle_footprint_, goal_candidates_, previous_module_output_);
-  request.update(
-    *planner_data_, current_status_, previous_module_output_, pull_over_path_, prev_data_);
-  return request;
-}
-
 void FreespaceParkingRequest::initializeOccupancyGridMap(
   const PlannerData & planner_data, const GoalPlannerParameters & parameters)
 {
@@ -70,15 +61,6 @@ void FreespaceParkingRequest::update(
   pull_over_path_ = pull_over_path;
   last_path_update_time_ = last_path_update_time;
   is_stopped_ = is_stopped;
-}
-
-FreespaceParkingRequest FreespaceParkingRequest::clone() const
-{
-  FreespaceParkingRequest request(
-    parameters_, vehicle_footprint_, goal_candidates_, *planner_data_);
-  request.update(
-    *planner_data_, current_status_, pull_over_path_, last_path_update_time_, is_stopped_);
-  return request;
 }
 
 }  // namespace autoware::behavior_path_planner


### PR DESCRIPTION
## Description

Currently `thread_safe_data_` member variable is accessed from many member functions. This structure is not healthy because there are other possible not thread-safe member variables, and numerous number of call to lock() is very insufficient.

After this PR, there are 3 agents
- goal_planner_module
- LaneParkingPlannerThread
- FreespaceParkingThread

### goal_planner_module

Lock the `lane_parking_mutex_`, and
- prepare the `LaneParkingRequest` member
- copy the `LaneParkingResponse` to local scope

Lock the `freespace_parking_mutex_`, and
- prepare the `FreespaceParkingRequest` member
- copy the `FreespaceParkingResponse` to local scope

### LaneParkingThread

Lock the `lane_parking_mutex_` which is shared with goal_planner_module via reference, and
- copy `LaneParkingResponse` to local scope

After computation,
Lock the `lane_parking_mutex_`, and
- set `LaneParkingResponse`

This will be used by goal_planner_module

### FreespaceParkingThread

Lock the `freespace_parking_mutex_` which is shared with goal_planner_module via reference, and
- copy `FreespaceParkingResponse` to local scope

After computation,
Lock the `freespace_parking_mutex_`, and
- set `FreespaceParkingResponse`

This will be used by goal_planner_module

Overall, thread  safe data has been divided to above 4 classes, and the `response` value is copied to module side  `PullOverContextData` member, so repetitive access to thread_safe_data with `lock` have been purged.

## Related links

**Parent Issue:**

- https://tier4.atlassian.net/browse/RT1-7966

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

- https://evaluation.tier4.jp/evaluation/reports/f7faf106-25c6-58ee-842c-2b5525b536be?project_id=prd_jt
- https://evaluation.tier4.jp/evaluation/reports/64a5c824-baed-50db-8ff6-6b84809ff07c?project_id=prd_jt

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
