### PR TITLE
fix(autoware_image_projection_based_fusion): detected object roi box projection fix

### DIFF
--- a/perception/autoware_image_projection_based_fusion/src/roi_detected_object_fusion/node.cpp
+++ b/perception/autoware_image_projection_based_fusion/src/roi_detected_object_fusion/node.cpp
@@ -141,8 +141,7 @@ RoiDetectedObjectFusionNode::generateDetectedObjectRoIs(
       transformPoints(vertices, object2camera_affine, vertices_camera_coord);
     }
 
-    double min_x(std::numeric_limits<double>::max()), min_y(std::numeric_limits<double>::max()),
-      max_x(std::numeric_limits<double>::min()), max_y(std::numeric_limits<double>::min());
+    double min_x(image_width), min_y(image_height), max_x(0.0), max_y(0.0);
     std::size_t point_on_image_cnt = 0;
     for (const auto & point : vertices_camera_coord) {
       if (point.z() <= 0.0) {
@@ -159,8 +158,8 @@ RoiDetectedObjectFusionNode::generateDetectedObjectRoIs(
       max_y = std::max(proj_point.y(), max_y);
 
       if (
-        proj_point.x() >= 0 && proj_point.x() <= image_width - 1 && proj_point.y() >= 0 &&
-        proj_point.y() <= image_height - 1) {
+        proj_point.x() >= 0 && proj_point.x() <= image_width && proj_point.y() >= 0 &&
+        proj_point.y() <= image_height) {
         point_on_image_cnt++;
 
         if (debugger_) {
@@ -174,8 +173,8 @@ RoiDetectedObjectFusionNode::generateDetectedObjectRoIs(
 
     min_x = std::max(min_x, 0.0);
     min_y = std::max(min_y, 0.0);
-    max_x = std::min(max_x, image_width - 1);
-    max_y = std::min(max_y, image_height - 1);
+    max_x = std::min(max_x, image_width);
+    max_y = std::min(max_y, image_height);
 
     DetectedObjectWithFeature object_roi;
     object_roi.feature.roi.x_offset = static_cast<std::uint32_t>(min_x);

--- a/perception/autoware_image_projection_based_fusion/src/roi_detected_object_fusion/node.cpp
+++ b/perception/autoware_image_projection_based_fusion/src/roi_detected_object_fusion/node.cpp
@@ -158,8 +158,8 @@ RoiDetectedObjectFusionNode::generateDetectedObjectRoIs(
       max_y = std::max(proj_point.y(), max_y);
 
       if (
-        proj_point.x() >= 0 && proj_point.x() <= image_width && proj_point.y() >= 0 &&
-        proj_point.y() <= image_height) {
+        proj_point.x() >= 0 && proj_point.x() < image_width && proj_point.y() >= 0 &&
+        proj_point.y() < image_height) {
         point_on_image_cnt++;
 
         if (debugger_) {
@@ -171,18 +171,16 @@ RoiDetectedObjectFusionNode::generateDetectedObjectRoIs(
       continue;
     }
 
-    min_x = std::max(min_x, 0.0);
-    min_y = std::max(min_y, 0.0);
-    max_x = std::min(max_x, image_width);
-    max_y = std::min(max_y, image_height);
+    const uint32_t idx_min_x = std::floor(std::max(min_x, 0.0));
+    const uint32_t idx_min_y = std::floor(std::max(min_y, 0.0));
+    const uint32_t idx_max_x = std::ceil(std::min(max_x, image_width));
+    const uint32_t idx_max_y = std::ceil(std::min(max_y, image_height));
 
     DetectedObjectWithFeature object_roi;
-    object_roi.feature.roi.x_offset = static_cast<std::uint32_t>(min_x);
-    object_roi.feature.roi.y_offset = static_cast<std::uint32_t>(min_y);
-    object_roi.feature.roi.width =
-      static_cast<std::uint32_t>(max_x) - static_cast<std::uint32_t>(min_x);
-    object_roi.feature.roi.height =
-      static_cast<std::uint32_t>(max_y) - static_cast<std::uint32_t>(min_y);
+    object_roi.feature.roi.x_offset = idx_min_x;
+    object_roi.feature.roi.y_offset = idx_min_y;
+    object_roi.feature.roi.width = idx_max_x - idx_min_x;
+    object_roi.feature.roi.height = idx_max_y - idx_min_y;
     object_roi.object = object;
     object_roi_map.insert(std::make_pair(obj_i, object_roi));
 


### PR DESCRIPTION
## Description

1. eliminate misuse of `std::numeric_limits<double>::min()`
2. fix roi range up to the image edges


## Related links

**Parent Issue:**

- Link [TIER IV INTERNAL](https://star4.slack.com/archives/CTEJP8L4T/p1732608837719329)

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

![Screenshot from 2024-12-02 15-09-33](https://github.com/user-attachments/assets/f8b13e34-b14b-4508-8f07-6cdc052dde2b)

![Screenshot from 2024-12-02 15-17-24](https://github.com/user-attachments/assets/b22344a1-ad1e-442d-a18e-de367dae3f53)

Objects at the edges are fused without issue.

## Notes for reviewers
It will be merged after https://github.com/autowarefoundation/autoware.universe/pull/9505 is merged and the build issue is resolved.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
