### PR TITLE
fix(lane_change): remove overlapping preceding lanes

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/utils.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/utils.hpp
@@ -384,6 +384,22 @@ bool filter_target_lane_objects(
   ExtendedPredictedObjects & trailing_objects);
 
 /**
+ * @brief Retrieves the preceding lanes for the target lanes while removing overlapping and
+ * disconnected lanes.
+ *
+ * This function identifies all lanes that precede the target lanes based on the ego vehicle's
+ * current position and a specified backward search length. The resulting preceding lanes are
+ * filtered to remove lanes that overlap with the current lanes or are not connected to the route.
+ *
+ * @param common_data_ptr Shared pointer to commonly used data in lane change module, which contains
+ * route handler information, lane details, ego vehicle pose, and behavior parameters.
+ *
+ * @return A vector of preceding lanelet groups, with each group containing only the connected and
+ * non-overlapping preceding lanes.
+ */
+std::vector<lanelet::ConstLanelets> get_preceding_lanes(const CommonDataPtr & common_data_ptr);
+
+/**
  * @brief Determines if the object's predicted path overlaps with the given lane polygon.
  *
  * This function checks whether any of the line string paths derived from the object's predicted

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/scene.cpp
@@ -112,9 +112,8 @@ void NormalLaneChange::update_lanes(const bool is_approved)
   common_data_ptr_->lanes_ptr->target_lane_in_goal_section =
     route_handler_ptr->isInGoalRouteSection(target_lanes.back());
 
-  common_data_ptr_->lanes_ptr->preceding_target = utils::getPrecedingLanelets(
-    *route_handler_ptr, get_target_lanes(), common_data_ptr_->get_ego_pose(),
-    common_data_ptr_->lc_param_ptr->backward_lane_length);
+  common_data_ptr_->lanes_ptr->preceding_target =
+    utils::lane_change::get_preceding_lanes(common_data_ptr_);
 
   lane_change_debug_.current_lanes = common_data_ptr_->lanes_ptr->current;
   lane_change_debug_.target_lanes = common_data_ptr_->lanes_ptr->target;

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/utils.cpp
@@ -1287,7 +1287,6 @@ std::vector<lanelet::ConstLanelets> get_preceding_lanes(const CommonDataPtr & co
   return non_overlapping_lanes_vec;
 }
 
-
 bool object_path_overlaps_lanes(
   const ExtendedPredictedObject & object, const lanelet::BasicPolygon2d & lanes_polygon)
 {

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/utils.cpp
@@ -1278,7 +1278,9 @@ std::vector<lanelet::ConstLanelets> get_preceding_lanes(const CommonDataPtr & co
       continue;
     }
 
-    lanelet::ConstLanelets non_overlapping_lanes(lanes_reversed.begin(), overlapped_itr);
+    // Lanes are not reversed by default. Avoid returning reversed lanes to prevent undefined
+    // behavior.
+    lanelet::ConstLanelets non_overlapping_lanes(overlapped_itr.base(), lanes.end());
     non_overlapping_lanes_vec.push_back(non_overlapping_lanes);
   }
 

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/utils.cpp
@@ -1262,15 +1262,11 @@ std::vector<lanelet::ConstLanelets> get_preceding_lanes(const CommonDataPtr & co
   const auto & current_lanes = common_data_ptr->lanes_ptr->current;
   std::unordered_set<lanelet::Id> current_lanes_id;
   for (const auto & lane : current_lanes) {
-    if (current_lanes_id.find(lane.id()) == current_lanes_id.end()) {
-      current_lanes_id.insert(lane.id());
-    }
+    current_lanes_id.insert(lane.id());
 
     const auto prev_lanes = route_handler_ptr->getPreviousLanelets(lane);
     for (const auto & prev_lane : prev_lanes) {
-      if (current_lanes_id.find(prev_lane.id()) == current_lanes_id.end()) {
-        current_lanes_id.insert(prev_lane.id());
-      }
+      current_lanes_id.insert(prev_lane.id());
     }
   }
 
@@ -1283,15 +1279,12 @@ std::vector<lanelet::ConstLanelets> get_preceding_lanes(const CommonDataPtr & co
 
     // Step 2: Identify disconnected lanes
     std::unordered_set<lanelet::Id> not_connected_ids;
-    for (const auto & pair : ranges::views::zip(
+    for (const auto [current_lane, next_lane] : ranges::views::zip(
            non_overlapping_lanes, non_overlapping_lanes | ranges::views::drop(1))) {
-      const auto & current_lane = pair.first;
-      const auto & next_lane = pair.second;
-
       const auto next_lanes = route_handler_ptr->getNextLanelets(current_lane);
 
-      const auto is_connected =
-        ranges::any_of(next_lanes, [&](const auto & lane) { return lane.id() == next_lane.id(); });
+      const auto is_connected = ranges::any_of(
+        next_lanes, [next_id = next_lane.id()](const auto & lane) { return lane.id() == next_id; });
 
       if (!is_connected) {
         not_connected_ids.insert(current_lane.id());


### PR DESCRIPTION
## Description

When the lanes are short, the preceding lane might overlap with the current lanes, as shown in the video below.

This could potentially affect the safety check results. To avoid this, we should remove the overlapping lane.

#### Before

Preceding lanes (Dark blue lanes) overlap current lanes. 

https://github.com/user-attachments/assets/d9dd7c51-4609-4be3-8d6c-c561d1582aae

#### After

Preceding lanes no longer overlaps current lanes.

https://github.com/user-attachments/assets/24a0bb3d-e4b8-4408-914d-feec7ffbb0c9

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
