### PR TITLE
refactor: correct spelling

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -4,5 +4,5 @@
     "planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/scripts/**"
   ],
   "ignoreRegExpList": [],
-  "words": ["dltype", "tvmgen", "fromarray", "soblin"]
+  "words": ["dltype", "tvmgen", "fromarray", "soblin", "brkay54"]
 }

--- a/common/autoware_trajectory/include/autoware/trajectory/point.hpp
+++ b/common/autoware_trajectory/include/autoware/trajectory/point.hpp
@@ -122,7 +122,7 @@ public:
     using trajectory::detail::to_point;
     Eigen::Vector2d point(to_point(p).x, to_point(p).y);
     std::vector<double> distances_from_segments;
-    std::vector<double> lengthes_from_start_points;
+    std::vector<double> lengths_from_start_points;
 
     auto axis = detail::crop_bases(bases_, start_, end_);
 
@@ -149,7 +149,7 @@ public:
       }
       if (constraints(length_from_start_point)) {
         distances_from_segments.push_back(distance_from_segment);
-        lengthes_from_start_points.push_back(length_from_start_point);
+        lengths_from_start_points.push_back(length_from_start_point);
       }
     }
     if (distances_from_segments.empty()) {
@@ -158,7 +158,7 @@ public:
 
     auto min_it = std::min_element(distances_from_segments.begin(), distances_from_segments.end());
 
-    return lengthes_from_start_points[std::distance(distances_from_segments.begin(), min_it)] -
+    return lengths_from_start_points[std::distance(distances_from_segments.begin(), min_it)] -
            start_;
   }
 

--- a/common/autoware_trajectory/test/test_trajectory_container.cpp
+++ b/common/autoware_trajectory/test/test_trajectory_container.cpp
@@ -106,9 +106,9 @@ TEST_F(TrajectoryTest, direction)
 
 TEST_F(TrajectoryTest, curvature)
 {
-  double curv = trajectory->curvature(0.0);
-  EXPECT_LT(-1.0, curv);
-  EXPECT_LT(curv, 1.0);
+  double curvature_val = trajectory->curvature(0.0);
+  EXPECT_LT(-1.0, curvature_val);
+  EXPECT_LT(curvature_val, 1.0);
 }
 
 TEST_F(TrajectoryTest, restore)

--- a/control/autoware_trajectory_follower_node/config/plot_juggler_trajectory_follower.xml
+++ b/control/autoware_trajectory_follower_node/config/plot_juggler_trajectory_follower.xml
@@ -258,7 +258,7 @@
    <parameters delimiter="0" time_axis=""/>
   </plugin>
   <plugin ID="DataLoad MCAP"/>
-  <plugin ID="DataLoad ROS2 bags">
+  <plugin ID="DataLoad ROS 2 bags">
    <use_header_stamp value="false"/>
    <discard_large_arrays value="true"/>
    <max_array_size value="100"/>
@@ -268,7 +268,7 @@
   </plugin>
   <plugin ID="DataLoad ULog"/>
   <plugin ID="MQTT Subscriber (Mosquitto)"/>
-  <plugin ID="ROS2 Topic Subscriber">
+  <plugin ID="ROS 2 Topic Subscriber">
    <use_header_stamp value="false"/>
    <discard_large_arrays value="false"/>
    <max_array_size value="100"/>
@@ -286,7 +286,7 @@
    <scripts/>
   </plugin>
   <plugin ID="CSV Exporter"/>
-  <plugin ID="ROS2 Topic Re-Publisher"/>
+  <plugin ID="ROS 2 Topic Re-Publisher"/>
  </Plugins>
  <!-- - - - - - - - - - - - - - - -->
  <previouslyLoaded_Datafiles/>

--- a/perception/autoware_shape_estimation/lib/tensorrt_shape_estimator.cpp
+++ b/perception/autoware_shape_estimation/lib/tensorrt_shape_estimator.cpp
@@ -140,7 +140,7 @@ void TrtShapeEstimator::preprocess(const DetectedObjectsWithFeature & input)
       }
 
       int iter_count = static_cast<int>(input_pc_size) / point_size_of_cloud;
-      int remainer_count = static_cast<int>(input_pc_size) % point_size_of_cloud;
+      int remaining_points_count = static_cast<int>(input_pc_size) % point_size_of_cloud;
 
       for (int j = 1; j < iter_count; j++) {
         for (int k = 0; k < point_size_of_cloud; k++) {
@@ -155,7 +155,7 @@ void TrtShapeEstimator::preprocess(const DetectedObjectsWithFeature & input)
         }
       }
 
-      for (int j = 0; j < remainer_count; j++) {
+      for (int j = 0; j < remaining_points_count; j++) {
         input_pc_h_[i * input_chan * input_pc_size + 0 + iter_count * point_size_of_cloud + j] =
           input_pc_h_[i * input_chan * input_pc_size + j];
 

--- a/planning/autoware_costmap_generator/src/costmap_generator.cpp
+++ b/planning/autoware_costmap_generator/src/costmap_generator.cpp
@@ -324,8 +324,8 @@ bool CostmapGenerator::isActive()
   if (param_->activate_by_scenario) {
     if (!scenario_) return false;
     const auto & s = scenario_->activating_scenarios;
-    return std::any_of(s.begin(), s.end(), [](const auto scen) {
-      return scen == tier4_planning_msgs::msg::Scenario::PARKING;
+    return std::any_of(s.begin(), s.end(), [](const auto scenario) {
+      return scenario == tier4_planning_msgs::msg::Scenario::PARKING;
     });
   }
 

--- a/planning/autoware_freespace_planning_algorithms/test/src/test_freespace_planning_algorithms.cpp
+++ b/planning/autoware_freespace_planning_algorithms/test/src/test_freespace_planning_algorithms.cpp
@@ -231,9 +231,9 @@ std::unique_ptr<fpa::AbstractPlanningAlgorithm> configure_astar(bool use_multi)
     obstacle_distance_weight,
     goal_lat_distance_weight};
 
-  auto clock_shrd_ptr = std::make_shared<rclcpp::Clock>(RCL_ROS_TIME);
+  auto clock_ptr = std::make_shared<rclcpp::Clock>(RCL_ROS_TIME);
   auto algo = std::make_unique<fpa::AstarSearch>(
-    planner_common_param, vehicle_shape, astar_param, clock_shrd_ptr);
+    planner_common_param, vehicle_shape, astar_param, clock_ptr);
   return algo;
 }
 
@@ -247,9 +247,9 @@ std::unique_ptr<fpa::AbstractPlanningAlgorithm> configure_rrtstar(bool informed,
   const double max_planning_time = 200;
   const auto rrtstar_param = fpa::RRTStarParam{update, informed, max_planning_time, mu, margin};
 
-  auto clock_shrd_ptr = std::make_shared<rclcpp::Clock>(RCL_ROS_TIME);
+  auto clock_ptr = std::make_shared<rclcpp::Clock>(RCL_ROS_TIME);
   auto algo = std::make_unique<fpa::RRTStar>(
-    planner_common_param, vehicle_shape, rrtstar_param, clock_shrd_ptr);
+    planner_common_param, vehicle_shape, rrtstar_param, clock_ptr);
   return algo;
 }
 

--- a/planning/autoware_freespace_planning_algorithms/test/src/test_freespace_planning_algorithms.cpp
+++ b/planning/autoware_freespace_planning_algorithms/test/src/test_freespace_planning_algorithms.cpp
@@ -232,8 +232,8 @@ std::unique_ptr<fpa::AbstractPlanningAlgorithm> configure_astar(bool use_multi)
     goal_lat_distance_weight};
 
   auto clock_ptr = std::make_shared<rclcpp::Clock>(RCL_ROS_TIME);
-  auto algo = std::make_unique<fpa::AstarSearch>(
-    planner_common_param, vehicle_shape, astar_param, clock_ptr);
+  auto algo =
+    std::make_unique<fpa::AstarSearch>(planner_common_param, vehicle_shape, astar_param, clock_ptr);
   return algo;
 }
 
@@ -248,8 +248,8 @@ std::unique_ptr<fpa::AbstractPlanningAlgorithm> configure_rrtstar(bool informed,
   const auto rrtstar_param = fpa::RRTStarParam{update, informed, max_planning_time, mu, margin};
 
   auto clock_ptr = std::make_shared<rclcpp::Clock>(RCL_ROS_TIME);
-  auto algo = std::make_unique<fpa::RRTStar>(
-    planner_common_param, vehicle_shape, rrtstar_param, clock_ptr);
+  auto algo =
+    std::make_unique<fpa::RRTStar>(planner_common_param, vehicle_shape, rrtstar_param, clock_ptr);
   return algo;
 }
 

--- a/planning/autoware_path_smoother/src/elastic_band.cpp
+++ b/planning/autoware_path_smoother/src/elastic_band.cpp
@@ -34,9 +34,9 @@ Eigen::SparseMatrix<double> makePMatrix(const int num_points)
 {
   std::vector<Eigen::Triplet<double>> triplet_vec;
   const auto assign_value_to_triplet_vec =
-    [&](const double row, const double colum, const double value) {
-      triplet_vec.push_back(Eigen::Triplet<double>(row, colum, value));
-      triplet_vec.push_back(Eigen::Triplet<double>(row + num_points, colum + num_points, value));
+    [&](const double row, const double column, const double value) {
+      triplet_vec.push_back(Eigen::Triplet<double>(row, column, value));
+      triplet_vec.push_back(Eigen::Triplet<double>(row + num_points, column + num_points, value));
     };
 
   for (int r = 0; r < num_points; ++r) {

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_intersection_prepare_data.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_intersection_prepare_data.cpp
@@ -938,7 +938,7 @@ std::vector<lanelet::ConstLineString3d> IntersectionModule::generateDetectionLan
   if (detection_lanelets.empty()) {
     // NOTE(soblin): due to the above filtering detection_lanelets may be empty or do not contain
     // conflicting_detection_lanelets
-    // OK to return empty detction_divsions
+    // OK to return empty detection_divisions
     return detection_divisions;
   }
 

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/test/test_util.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/test/test_util.cpp
@@ -89,7 +89,7 @@ TEST(TestUtil, retrievePathsBackward)
 }
 
 /*
-  TOOD(Mamoru Sobue): instantiating intersection_module and PlannerData is a messy
+  TODO(Mamoru Sobue): instantiating intersection_module and PlannerData is a messy
 class TestWithMap : public ::testing::Test
 {
 protected:

--- a/planning/sampling_based_planner/autoware_sampler_common/test/test_transform.cpp
+++ b/planning/sampling_based_planner/autoware_sampler_common/test/test_transform.cpp
@@ -103,9 +103,9 @@ TEST(splineTransform, benchFrenet)
       EXPECT_NEAR(frenet_naive.d, frenet_lut.d, precision);
     }
     std::cout << "size = " << size << std::endl;
-    std::cout << "\tnaive: " << std::chrono::duration_cast<std::chrono::milliseconds>(naive).count()
+    std::cout << "\t naive: " << std::chrono::duration_cast<std::chrono::milliseconds>(naive).count()
               << "ms\n";
-    std::cout << "\tlut  : " << std::chrono::duration_cast<std::chrono::milliseconds>(lut).count()
+    std::cout << "\t lut  : " << std::chrono::duration_cast<std::chrono::milliseconds>(lut).count()
               << "ms\n";
   }
 }

--- a/planning/sampling_based_planner/autoware_sampler_common/test/test_transform.cpp
+++ b/planning/sampling_based_planner/autoware_sampler_common/test/test_transform.cpp
@@ -103,8 +103,8 @@ TEST(splineTransform, benchFrenet)
       EXPECT_NEAR(frenet_naive.d, frenet_lut.d, precision);
     }
     std::cout << "size = " << size << std::endl;
-    std::cout << "\t naive: " << std::chrono::duration_cast<std::chrono::milliseconds>(naive).count()
-              << "ms\n";
+    std::cout << "\t naive: "
+              << std::chrono::duration_cast<std::chrono::milliseconds>(naive).count() << "ms\n";
     std::cout << "\t lut  : " << std::chrono::duration_cast<std::chrono::milliseconds>(lut).count()
               << "ms\n";
   }

--- a/simulator/autoware_carla_interface/README.md
+++ b/simulator/autoware_carla_interface/README.md
@@ -136,14 +136,14 @@ The maps provided by the Carla Simulator ([Carla Lanelet2 Maps](https://bitbucke
 - Options to Modify the Map
 
   - A. Create a New Map from Scratch
-  - Use the [Tier4 Vector Map Builder](https://tools.tier4.jp/feature/vector_map_builder_ll2/) to create a new map.
+  - Use the [TIER IV Vector Map Builder](https://tools.tier4.jp/feature/vector_map_builder_ll2/) to create a new map.
 
   - B. Modify the Existing Carla Lanelet2 Maps
   - Adjust the longitude and latitude of the [Carla Lanelet2 Maps](https://bitbucket.org/carla-simulator/autoware-contents/src/master/maps/) to align with the PCD (origin).
     - Use this [tool](https://github.com/mraditya01/offset_lanelet2/tree/main) to modify the coordinates.
-    - Snap Lanelet with PCD and add the traffic lights using the [Tier4 Vector Map Builder](https://tools.tier4.jp/feature/vector_map_builder_ll2/).
+    - Snap Lanelet with PCD and add the traffic lights using the [TIER IV Vector Map Builder](https://tools.tier4.jp/feature/vector_map_builder_ll2/).
 
-- When using the Tier4 Vector Map Builder, you must convert the PCD format from `binary_compressed` to `ascii`. You can use `pcl_tools` for this conversion.
+- When using the TIER IV Vector Map Builder, you must convert the PCD format from `binary_compressed` to `ascii`. You can use `pcl_tools` for this conversion.
 - For reference, an example of Town01 with added traffic lights at one intersection can be downloaded [here](https://drive.google.com/drive/folders/1QFU0p3C8NW71sT5wwdnCKXoZFQJzXfTG?usp=sharing).
 
 ## Tips


### PR DESCRIPTION
## Description

Now that we have moved the dictionaries into autowarefoundation and added basic common dictionaries, let's make this check required again.

This PR fixes the spelling errors found in the following daily workflow:
❌ https://github.com/autowarefoundation/autoware.universe/actions/runs/12076804289/job/33678713106#step:3:60

This PR won't change any logic, it's a documentation and renaming-refactor based.

## How was this PR tested?

Basic CI.

And will run it against the spell checker to see if there are any errors left:
✅ [It has passed!](https://github.com/autowarefoundation/autoware.universe/actions/runs/12089382974/job/33714587421)

## Notes for reviewers

The PR is very simple, even if there are lots of packages modified, the changes are very narrow scoped.

## Interface changes

None.

## Effects on system behavior

None.
