### PR TITLE
fix(control_evaluator): correct goal_lateal_deviation

### DIFF
--- a/evaluator/autoware_control_evaluator/src/control_evaluator_node.cpp
+++ b/evaluator/autoware_control_evaluator/src/control_evaluator_node.cpp
@@ -232,7 +232,7 @@ void ControlEvaluatorNode::AddGoalLongitudinalDeviationMetricMsg(const Pose & eg
 
 void ControlEvaluatorNode::AddGoalLateralDeviationMetricMsg(const Pose & ego_pose)
 {
-  const Metric metric = Metric::lateral_deviation;
+  const Metric metric = Metric::goal_lateral_deviation;
   const double metric_value =
     metrics::calcLateralDeviation(route_handler_.getGoalPose(), ego_pose.position);
 


### PR DESCRIPTION
## Description

Fixed a bug that `goal_lateal_deviation` became `lateral_deviation` when echoing `/control/control_evaluator/metrics`.

## Related links

https://github.com/autowarefoundation/autoware.universe/pull/9478/files#diff-843ce11499d139e51e783a5e2e016da0976dbd01ffc8a809c50b22db177f3dedR235

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

Before
![image](https://github.com/user-attachments/assets/176445d9-6740-49f2-9c82-e74a2234f9d4)

After
![image (2)](https://github.com/user-attachments/assets/ebf40dad-ba3e-4c5e-8329-4c5a1853e683)

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
