### PR TITLE
fix(autoware_trajectory): fix unusedFunction

### DIFF
--- a/common/autoware_trajectory/include/autoware/trajectory/detail/utils.hpp
+++ b/common/autoware_trajectory/include/autoware/trajectory/detail/utils.hpp
@@ -34,7 +34,6 @@ namespace autoware::trajectory::detail
  * @param p The input point to be converted.
  * @return geometry_msgs::msg::Point The converted point.
  */
-geometry_msgs::msg::Point to_point(const geometry_msgs::msg::Point & p);
 geometry_msgs::msg::Point to_point(const geometry_msgs::msg::Pose & p);
 geometry_msgs::msg::Point to_point(const Eigen::Vector2d & p);
 geometry_msgs::msg::Point to_point(const autoware_planning_msgs::msg::PathPoint & p);

--- a/common/autoware_trajectory/src/detail/util.cpp
+++ b/common/autoware_trajectory/src/detail/util.cpp
@@ -20,11 +20,6 @@
 namespace autoware::trajectory::detail
 {
 
-geometry_msgs::msg::Point to_point(const geometry_msgs::msg::Point & p)
-{
-  return p;
-}
-
 geometry_msgs::msg::Point to_point(const geometry_msgs::msg::Pose & p)
 {
   return p.position;


### PR DESCRIPTION
## Description

Fixed cppcheck `unusedFunction` warning
```
common/autoware_trajectory/src/detail/util.cpp:23:0: style: The function 'to_point' is never used. [unusedFunction]
geometry_msgs::msg::Point to_point(const geometry_msgs::msg::Point & p)
^
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
