### PR TITLE
fix(autoware_ground_segmentation): remove unused function

### DIFF
--- a/perception/autoware_ground_segmentation/src/scan_ground_filter/grid.hpp
+++ b/perception/autoware_ground_segmentation/src/scan_ground_filter/grid.hpp
@@ -114,7 +114,6 @@ public:
 
   // method to check if the cell is empty
   inline bool isEmpty() const { return point_list_.empty(); }
-  inline int getPointNum() const { return static_cast<int>(point_list_.size()); }
 
   // index of the cell
   int grid_idx_;


### PR DESCRIPTION
## Description

Fixed cppcheck `unusedFunction` warning
```
perception/autoware_ground_segmentation/src/scan_ground_filter/grid.hpp:117:0: style: The function 'getPointNum' is never used. [unusedFunction]
  inline int getPointNum() const { return static_cast<int>(point_list_.size()); }
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
