### PR TITLE
feat(lane_changing): improve computation of lane changing acceleration

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/README.md
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/README.md
@@ -893,7 +893,7 @@ The following parameters are configurable in [lane_change.param.yaml](https://gi
 | `trajectory.lat_acc_sampling_num`            | [-]    | int    | Number of possible lane-changing trajectories that are being influenced by lateral acceleration                        | 3                  |
 | `trajectory.max_longitudinal_acc`            | [m/s2] | double | maximum longitudinal acceleration for lane change                                                                      | 1.0                |
 | `trajectory.min_longitudinal_acc`            | [m/s2] | double | maximum longitudinal deceleration for lane change                                                                      | -1.0               |
-| `trajectory.lane_changing_decel_factor`      | [m/s2] | double | longitudinal deceleration factor during lane changing phase                                                            | 0.5                |
+| `trajectory.lane_changing_decel_factor`      | [-] | double | longitudinal deceleration factor during lane changing phase                                                            | 0.5                |
 | `min_length_for_turn_signal_activation`      | [m]    | double | Turn signal will be activated if the ego vehicle approaches to this length from minimum lane change length             | 10.0               |
 | `lateral_acceleration.velocity`              | [m/s]  | double | Reference velocity for lateral acceleration calculation (look up table)                                                | [0.0, 4.0, 10.0]   |
 | `lateral_acceleration.min_values`            | [m/s2] | double | Min lateral acceleration values corresponding to velocity (look up table)                                              | [0.4, 0.4, 0.4]    |

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/README.md
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/README.md
@@ -893,6 +893,7 @@ The following parameters are configurable in [lane_change.param.yaml](https://gi
 | `trajectory.lat_acc_sampling_num`            | [-]    | int    | Number of possible lane-changing trajectories that are being influenced by lateral acceleration                        | 3                  |
 | `trajectory.max_longitudinal_acc`            | [m/s2] | double | maximum longitudinal acceleration for lane change                                                                      | 1.0                |
 | `trajectory.min_longitudinal_acc`            | [m/s2] | double | maximum longitudinal deceleration for lane change                                                                      | -1.0               |
+| `trajectory.lane_changing_decel_factor`      | [m/s2] | double | longitudinal deceleration factor during lane changing phase                                                            | 0.5                |
 | `min_length_for_turn_signal_activation`      | [m]    | double | Turn signal will be activated if the ego vehicle approaches to this length from minimum lane change length             | 10.0               |
 | `lateral_acceleration.velocity`              | [m/s]  | double | Reference velocity for lateral acceleration calculation (look up table)                                                | [0.0, 4.0, 10.0]   |
 | `lateral_acceleration.min_values`            | [m/s2] | double | Min lateral acceleration values corresponding to velocity (look up table)                                              | [0.4, 0.4, 0.4]    |

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/README.md
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/README.md
@@ -893,7 +893,7 @@ The following parameters are configurable in [lane_change.param.yaml](https://gi
 | `trajectory.lat_acc_sampling_num`            | [-]    | int    | Number of possible lane-changing trajectories that are being influenced by lateral acceleration                        | 3                  |
 | `trajectory.max_longitudinal_acc`            | [m/s2] | double | maximum longitudinal acceleration for lane change                                                                      | 1.0                |
 | `trajectory.min_longitudinal_acc`            | [m/s2] | double | maximum longitudinal deceleration for lane change                                                                      | -1.0               |
-| `trajectory.lane_changing_decel_factor`      | [-] | double | longitudinal deceleration factor during lane changing phase                                                            | 0.5                |
+| `trajectory.lane_changing_decel_factor`      | [-]    | double | longitudinal deceleration factor during lane changing phase                                                            | 0.5                |
 | `min_length_for_turn_signal_activation`      | [m]    | double | Turn signal will be activated if the ego vehicle approaches to this length from minimum lane change length             | 10.0               |
 | `lateral_acceleration.velocity`              | [m/s]  | double | Reference velocity for lateral acceleration calculation (look up table)                                                | [0.0, 4.0, 10.0]   |
 | `lateral_acceleration.min_values`            | [m/s2] | double | Min lateral acceleration values corresponding to velocity (look up table)                                              | [0.4, 0.4, 0.4]    |

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/config/lane_change.param.yaml
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/config/lane_change.param.yaml
@@ -20,6 +20,7 @@
         min_lane_changing_velocity: 2.78
         lon_acc_sampling_num: 5
         lat_acc_sampling_num: 3
+        lane_changing_decel_factor: 0.5
 
       # delay lane change
       delay_lane_change:

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/calculation.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/calculation.hpp
@@ -106,8 +106,9 @@ double calc_ego_dist_to_lanes_start(
   const lanelet::ConstLanelets & target_lanes);
 
 double calc_lane_changing_acceleration(
-  const double initial_lane_changing_velocity, const double max_path_velocity,
-  const double lane_changing_time, const double prepare_longitudinal_acc);
+  const CommonDataPtr & common_data_ptr, const double initial_lane_changing_velocity,
+  const double max_path_velocity, const double lane_changing_time,
+  const double prepare_longitudinal_acc);
 
 /**
  * @brief Calculates the distance required during a lane change operation.

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/parameters.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/parameters.hpp
@@ -122,6 +122,7 @@ struct TrajectoryParameters
   double th_prepare_length_diff{0.5};
   double th_lane_changing_length_diff{0.5};
   double min_lane_changing_velocity{5.6};
+  double lane_changing_decel_factor{0.5};
   int lon_acc_sampling_num{10};
   int lat_acc_sampling_num{10};
   LateralAccelerationMap lat_acc_map{};

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/manager.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/manager.cpp
@@ -59,6 +59,8 @@ LCParamPtr LaneChangeModuleManager::set_params(rclcpp::Node * node, const std::s
       getOrDeclareParameter<double>(*node, parameter("trajectory.th_lane_changing_length_diff"));
     p.trajectory.min_lane_changing_velocity =
       getOrDeclareParameter<double>(*node, parameter("trajectory.min_lane_changing_velocity"));
+    p.trajectory.lane_changing_decel_factor =
+      getOrDeclareParameter<double>(*node, parameter("trajectory.lane_changing_decel_factor"));
     p.trajectory.lon_acc_sampling_num =
       getOrDeclareParameter<int>(*node, parameter("trajectory.lon_acc_sampling_num"));
     p.trajectory.lat_acc_sampling_num =
@@ -318,6 +320,8 @@ void LaneChangeModuleManager::updateModuleParams(const std::vector<rclcpp::Param
       parameters, ns + "min_longitudinal_acc", p->trajectory.min_longitudinal_acc);
     updateParam<double>(
       parameters, ns + "max_longitudinal_acc", p->trajectory.max_longitudinal_acc);
+    updateParam<double>(
+      parameters, ns + "lane_changing_decel_factor", p->trajectory.lane_changing_decel_factor);
     int longitudinal_acc_sampling_num = 0;
     updateParam<int>(parameters, ns + "lon_acc_sampling_num", longitudinal_acc_sampling_num);
     if (longitudinal_acc_sampling_num > 0) {

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/calculation.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/calculation.cpp
@@ -382,11 +382,16 @@ std::vector<double> calc_lon_acceleration_samples(
 }
 
 double calc_lane_changing_acceleration(
-  const double initial_lane_changing_velocity, const double max_path_velocity,
-  const double lane_changing_time, const double prepare_longitudinal_acc)
+  const CommonDataPtr & common_data_ptr, const double initial_lane_changing_velocity,
+  const double max_path_velocity, const double lane_changing_time,
+  const double prepare_longitudinal_acc)
 {
   if (prepare_longitudinal_acc <= 0.0) {
-    return 0.0;
+    const auto & params = common_data_ptr->lc_param_ptr->trajectory;
+    const auto lane_chaging_acc = common_data_ptr->transient_data.is_ego_near_current_terminal_start
+                                    ? prepare_longitudinal_acc * params.lane_changing_decel_factor
+                                    : 0.0;
+    return lane_chaging_acc;
   }
 
   return std::clamp(
@@ -497,7 +502,7 @@ std::vector<PhaseMetrics> calc_shift_phase_metrics(
       shift_length, common_data_ptr->lc_param_ptr->trajectory.lateral_jerk, lat_acc);
 
     const double lane_changing_accel = calc_lane_changing_acceleration(
-      initial_velocity, max_path_velocity, lane_changing_duration, lon_accel);
+      common_data_ptr, initial_velocity, max_path_velocity, lane_changing_duration, lon_accel);
 
     const auto lane_changing_length = calculation::calc_phase_length(
       initial_velocity, max_vel, lane_changing_accel, lane_changing_duration);

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/calculation.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/calculation.cpp
@@ -388,9 +388,10 @@ double calc_lane_changing_acceleration(
 {
   if (prepare_longitudinal_acc <= 0.0) {
     const auto & params = common_data_ptr->lc_param_ptr->trajectory;
-    const auto lane_changing_acc = common_data_ptr->transient_data.is_ego_near_current_terminal_start
-                                    ? prepare_longitudinal_acc * params.lane_changing_decel_factor
-                                    : 0.0;
+    const auto lane_changing_acc =
+      common_data_ptr->transient_data.is_ego_near_current_terminal_start
+        ? prepare_longitudinal_acc * params.lane_changing_decel_factor
+        : 0.0;
     return lane_changing_acc;
   }
 

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/calculation.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/calculation.cpp
@@ -388,10 +388,10 @@ double calc_lane_changing_acceleration(
 {
   if (prepare_longitudinal_acc <= 0.0) {
     const auto & params = common_data_ptr->lc_param_ptr->trajectory;
-    const auto lane_chaging_acc = common_data_ptr->transient_data.is_ego_near_current_terminal_start
+    const auto lane_changing_acc = common_data_ptr->transient_data.is_ego_near_current_terminal_start
                                     ? prepare_longitudinal_acc * params.lane_changing_decel_factor
                                     : 0.0;
-    return lane_chaging_acc;
+    return lane_changing_acc;
   }
 
   return std::clamp(


### PR DESCRIPTION
## Description

Currently when generating candidate lane change paths, we sample multiple longitudinal acceleration values, however for values below 0.0 (decelerating), it is only applied to the prepare phase, while min acceleration for lane changing phase is limited to 0.0, meaning we assume no deceleration during lane changing phase. And this behavior is not configurable.

Sometimes this assumption can result in not finding a safe candidate path near the terminal, specifically when there is a leading target lane object.

It is better to allow some deceleration during lane changing phase when approaching terminal to increase the chances of finding a safe candidate path.

## Changes

Modified function `calc_lane_changing_acceleration`:
 - IF sampled longitudinal acceleration is negative, AND ego is near terminal, THEN return a ratio of sampled longitudinal acceleration determined by parameter `lane_changing_decel_factor`
 - IF sampled longitudinal acceleration is negative, AND ego is NOT near terminal, THEN return 0.0 (same as before)

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
- PSIM
- [TIER IV Internal Evaluation](https://evaluation.tier4.jp/evaluation/reports/3fe71be5-8d0e-519e-9103-de95af163ad8?project_id=prd_jt)

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

🔴⬆️ -->

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added | `lane_changing_decel_factor` | `double` | `0.5` | longitudinal deceleration factor during lane changing phase |

## Effects on system behavior

Increase chances of finding a safe candidate path near terminal when there is a leading target lane object.
