### PR TITLE
chore(cspell): add new word `libtensorrt` to `cspell.json`

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -4,5 +4,5 @@
     "planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/scripts/**"
   ],
   "ignoreRegExpList": [],
-  "words": ["dltype", "tvmgen", "fromarray", "soblin", "brkay54"]
+  "words": ["dltype", "tvmgen", "fromarray", "soblin", "brkay54", "libtensorrt"]
 }


### PR DESCRIPTION
## Description

This PR adds `libtensorrt` word to `cspell.json, file.

This word used in https://github.com/autowarefoundation/autoware.universe/pull/8165.

We decided to add this word to the local directory instead of Autoware dictionary because it has limited usage and is not a common term.

## Notes for reviewers

None

## Interface changes

None

## Effects on system behavior

None