### PR TITLE
docs(control_performance_analysis): utilize mathjax syntax in readme

### DIFF
--- a/control/control_performance_analysis/README.md
+++ b/control/control_performance_analysis/README.md
@@ -56,7 +56,7 @@ Error acceleration calculations are made based on the velocity calculations abov
 #### control_performance_analysis::msg::ErrorStamped
 
 | Name                                       | Type  | Description                                                                                                                               |
-| ------------------------------------------ | ----- |-------------------------------------------------------------------------------------------------------------------------------------------|
+| ------------------------------------------ | ----- | ----------------------------------------------------------------------------------------------------------------------------------------- |
 | `lateral_error`                            | float | $[ \mathrm{m} ]$                                                                                                                          |
 | `lateral_error_velocity`                   | float | $[ \mathrm{m/s} ]$                                                                                                                        |
 | `lateral_error_acceleration`               | float | $[ \mathrm{m/s^2} ]$                                                                                                                      |
@@ -65,7 +65,7 @@ Error acceleration calculations are made based on the velocity calculations abov
 | `longitudinal_error_acceleration`          | float | $[ \mathrm{m/s^2} ]$                                                                                                                      |
 | `heading_error`                            | float | $[ \mathrm{rad} ]$                                                                                                                        |
 | `heading_error_velocity`                   | float | $[ \mathrm{rad/s} ]$                                                                                                                      |
-| `control_effort_energy`                    | float | $[ \mathbf{u}^\top \mathbf{R} \mathbf{u} ]$ simplfied to $[ R \cdot u^2 ]$                                                                                 |
+| `control_effort_energy`                    | float | $[ \mathbf{u}^\top \mathbf{R} \mathbf{u} ]$ simplfied to $[ R \cdot u^2 ]$                                                                |
 | `error_energy`                             | float | $e_{\text{lat}}^2 + e_\theta^2$ (squared lateral error + squared heading error)                                                           |
 | `value_approximation`                      | float | $V = \mathbf{x}^\top \mathbf{P} \mathbf{x}$; Value function from DARE Lyapunov matrix $\mathbf{P}$                                        |
 | `curvature_estimate`                       | float | $[ \mathrm{1/m} ]$                                                                                                                        |

--- a/control/control_performance_analysis/README.md
+++ b/control/control_performance_analysis/README.md
@@ -66,7 +66,7 @@ Error acceleration calculations are made based on the velocity calculations abov
 | `heading_error`                            | float | $[ \mathrm{rad} ]$                                                                                                                              |
 | `heading_error_velocity`                   | float | $[ \mathrm{rad/s} ]$                                                                                                                            |
 | `control_effort_energy`                    | float | $[ \mathbf{u}^\top \mathbf{R} \mathbf{u} ]$                                                                                                     |
-| `error_energy`                             | float | $\mathrm{lateral\_error}^2 + \mathrm{heading\_error}^2$                                                                                               |
+| `error_energy`                             | float | $\mathrm{lateral_error}^2 + \mathrm{heading_error}^2$                                                                                               |
 | `value_approximation`                      | float | $V = \mathbf{x}^\top \mathbf{P} \mathbf{x}$; Value function from DARE Lyapunov matrix $\mathbf{P}$                                              |
 | `curvature_estimate`                       | float | $[ \mathrm{1/m} ]$                                                                                                                              |
 | `curvature_estimate_pp`                    | float | $[ \mathrm{1/m} ]$                                                                                                                              |

--- a/control/control_performance_analysis/README.md
+++ b/control/control_performance_analysis/README.md
@@ -56,7 +56,7 @@ Error acceleration calculations are made based on the velocity calculations abov
 #### control_performance_analysis::msg::ErrorStamped
 
 | Name                                       | Type  | Description                                                                                                                               |
-| ------------------------------------------ | ----- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| ------------------------------------------ | ----- |-------------------------------------------------------------------------------------------------------------------------------------------|
 | `lateral_error`                            | float | $[ \mathrm{m} ]$                                                                                                                          |
 | `lateral_error_velocity`                   | float | $[ \mathrm{m/s} ]$                                                                                                                        |
 | `lateral_error_acceleration`               | float | $[ \mathrm{m/s^2} ]$                                                                                                                      |
@@ -65,7 +65,7 @@ Error acceleration calculations are made based on the velocity calculations abov
 | `longitudinal_error_acceleration`          | float | $[ \mathrm{m/s^2} ]$                                                                                                                      |
 | `heading_error`                            | float | $[ \mathrm{rad} ]$                                                                                                                        |
 | `heading_error_velocity`                   | float | $[ \mathrm{rad/s} ]$                                                                                                                      |
-| `control_effort_energy`                    | float | $[ \mathbf{u}^\top \mathbf{R} \mathbf{u} ]$ simplfied to $[ R \cdot u^2 ]$                                                                |
+| `control_effort_energy`                    | float | $[ \mathbf{u}^\top \mathbf{R} \mathbf{u} ]$ simplified to $[ R \cdot u^2 ]$                                                               |
 | `error_energy`                             | float | $e_{\text{lat}}^2 + e_\theta^2$ (squared lateral error + squared heading error)                                                           |
 | `value_approximation`                      | float | $V = \mathbf{x}^\top \mathbf{P} \mathbf{x}$; Value function from DARE Lyapunov matrix $\mathbf{P}$                                        |
 | `curvature_estimate`                       | float | $[ \mathrm{1/m} ]$                                                                                                                        |

--- a/control/control_performance_analysis/README.md
+++ b/control/control_performance_analysis/README.md
@@ -66,12 +66,12 @@ Error acceleration calculations are made based on the velocity calculations abov
 | `heading_error`                            | float | $[ \mathrm{rad} ]$                                                                                                                              |
 | `heading_error_velocity`                   | float | $[ \mathrm{rad/s} ]$                                                                                                                            |
 | `control_effort_energy`                    | float | $[ \mathbf{u}^\top \mathbf{R} \mathbf{u} ]$                                                                                                     |
-| `error_energy`                             | float | $\text{lateral_error}^2 + \text{heading_error}^2$                                                                                               |
+| `error_energy`                             | float | $\text{lateral\_error}^2 + \text{heading\_error}^2$                                                                                               |
 | `value_approximation`                      | float | $V = \mathbf{x}^\top \mathbf{P} \mathbf{x}$; Value function from DARE Lyapunov matrix $\mathbf{P}$                                              |
 | `curvature_estimate`                       | float | $[ \mathrm{1/m} ]$                                                                                                                              |
 | `curvature_estimate_pp`                    | float | $[ \mathrm{1/m} ]$                                                                                                                              |
 | `vehicle_velocity_error`                   | float | $[ \mathrm{m/s} ]$                                                                                                                              |
-| `tracking_curvature_discontinuity_ability` | float | Measures the ability to track curvature changes $\frac{\lvert \Delta(\text{curvature}) \rvert}{1 + \lvert \Delta(\text{lateral_error}) \rvert}$ |
+| `tracking_curvature_discontinuity_ability` | float | Measures the ability to track curvature changes $\frac{\lvert \Delta(\text{curvature}) \rvert}{1 + \lvert \Delta(\text{lateral\_error}) \rvert}$ |
 
 ## Parameters
 

--- a/control/control_performance_analysis/README.md
+++ b/control/control_performance_analysis/README.md
@@ -55,22 +55,22 @@ Error acceleration calculations are made based on the velocity calculations abov
 
 #### control_performance_analysis::msg::ErrorStamped
 
-| Name                                       | Type  | Description                                                                                                                                       |
-| ------------------------------------------ | ----- |---------------------------------------------------------------------------------------------------------------------------------------------------|
-| `lateral_error`                            | float | $[ \mathrm{m} ]$                                                                                                                                  |
-| `lateral_error_velocity`                   | float | $[ \mathrm{m/s} ]$                                                                                                                                |
-| `lateral_error_acceleration`               | float | $[ \mathrm{m/s^2} ]$                                                                                                                              |
-| `longitudinal_error`                       | float | $[ \mathrm{m} ]$                                                                                                                                  |
-| `longitudinal_error_velocity`              | float | $[ \mathrm{m/s} ]$                                                                                                                                |
-| `longitudinal_error_acceleration`          | float | $[ \mathrm{m/s^2} ]$                                                                                                                              |
-| `heading_error`                            | float | $[ \mathrm{rad} ]$                                                                                                                                |
-| `heading_error_velocity`                   | float | $[ \mathrm{rad/s} ]$                                                                                                                              |
-| `control_effort_energy`                    | float | $[ \mathbf{u}^\top \mathbf{R} \mathbf{u} ]$                                                                                                       |
-| `error_energy`                             | float | $e_{\text{lat}}^2 + e_\theta^2$ (squared lateral error + squared heading error)                                                                   |
-| `value_approximation`                      | float | $V = \mathbf{x}^\top \mathbf{P} \mathbf{x}$; Value function from DARE Lyapunov matrix $\mathbf{P}$                                                |
-| `curvature_estimate`                       | float | $[ \mathrm{1/m} ]$                                                                                                                                |
-| `curvature_estimate_pp`                    | float | $[ \mathrm{1/m} ]$                                                                                                                                |
-| `vehicle_velocity_error`                   | float | $[ \mathrm{m/s} ]$                                                                                                                                |
+| Name                                       | Type  | Description                                                                                                                               |
+| ------------------------------------------ | ----- |-------------------------------------------------------------------------------------------------------------------------------------------|
+| `lateral_error`                            | float | $[ \mathrm{m} ]$                                                                                                                          |
+| `lateral_error_velocity`                   | float | $[ \mathrm{m/s} ]$                                                                                                                        |
+| `lateral_error_acceleration`               | float | $[ \mathrm{m/s^2} ]$                                                                                                                      |
+| `longitudinal_error`                       | float | $[ \mathrm{m} ]$                                                                                                                          |
+| `longitudinal_error_velocity`              | float | $[ \mathrm{m/s} ]$                                                                                                                        |
+| `longitudinal_error_acceleration`          | float | $[ \mathrm{m/s^2} ]$                                                                                                                      |
+| `heading_error`                            | float | $[ \mathrm{rad} ]$                                                                                                                        |
+| `heading_error_velocity`                   | float | $[ \mathrm{rad/s} ]$                                                                                                                      |
+| `control_effort_energy`                    | float | $[ \mathbf{u}^\top \mathbf{R} \mathbf{u} ]$ simplfied to $[ R \cdot u^2 ]$                                                                                 |
+| `error_energy`                             | float | $e_{\text{lat}}^2 + e_\theta^2$ (squared lateral error + squared heading error)                                                           |
+| `value_approximation`                      | float | $V = \mathbf{x}^\top \mathbf{P} \mathbf{x}$; Value function from DARE Lyapunov matrix $\mathbf{P}$                                        |
+| `curvature_estimate`                       | float | $[ \mathrm{1/m} ]$                                                                                                                        |
+| `curvature_estimate_pp`                    | float | $[ \mathrm{1/m} ]$                                                                                                                        |
+| `vehicle_velocity_error`                   | float | $[ \mathrm{m/s} ]$                                                                                                                        |
 | `tracking_curvature_discontinuity_ability` | float | Measures the ability to track curvature changes $\frac{\lvert \Delta(\text{curvature}) \rvert}{1 + \lvert \Delta(e_{\text{lat}}) \rvert}$ |
 
 ## Parameters

--- a/control/control_performance_analysis/README.md
+++ b/control/control_performance_analysis/README.md
@@ -44,19 +44,19 @@ Error acceleration calculations are made based on the velocity calculations abov
 
 #### control_performance_analysis::msg::DrivingMonitorStamped
 
-| Name                         | Type  | Description                                              |
-| ---------------------------- | ----- | -------------------------------------------------------- |
-| `longitudinal_acceleration`  | float | $[ \mathrm{m/s^2} ]$                          |
-| `longitudinal_jerk`          | float | $[ \mathrm{m/s^3} ]$                          |
-| `lateral_acceleration`       | float | $[ \mathrm{m/s^2} ]$                          |
-| `lateral_jerk`               | float | $[ \mathrm{m/s^3} ]$                          |
-| `desired_steering_angle`     | float | $[ \mathrm{rad} ]$                            |
+| Name                         | Type  | Description                                                           |
+| ---------------------------- | ----- | --------------------------------------------------------------------- |
+| `longitudinal_acceleration`  | float | $[ \mathrm{m/s^2} ]$                                                  |
+| `longitudinal_jerk`          | float | $[ \mathrm{m/s^3} ]$                                                  |
+| `lateral_acceleration`       | float | $[ \mathrm{m/s^2} ]$                                                  |
+| `lateral_jerk`               | float | $[ \mathrm{m/s^3} ]$                                                  |
+| `desired_steering_angle`     | float | $[ \mathrm{rad} ]$                                                    |
 | `controller_processing_time` | float | Timestamp between last two control command messages $[ \mathrm{ms} ]$ |
 
 #### control_performance_analysis::msg::ErrorStamped
 
 | Name                                       | Type  | Description                                                                                                                                     |
-| ------------------------------------------ | ----- |-------------------------------------------------------------------------------------------------------------------------------------------------|
+| ------------------------------------------ | ----- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
 | `lateral_error`                            | float | $[ \mathrm{m} ]$                                                                                                                                |
 | `lateral_error_velocity`                   | float | $[ \mathrm{m/s} ]$                                                                                                                              |
 | `lateral_error_acceleration`               | float | $[ \mathrm{m/s^2} ]$                                                                                                                            |

--- a/control/control_performance_analysis/README.md
+++ b/control/control_performance_analysis/README.md
@@ -46,32 +46,32 @@ Error acceleration calculations are made based on the velocity calculations abov
 
 | Name                         | Type  | Description                                              |
 | ---------------------------- | ----- | -------------------------------------------------------- |
-| `longitudinal_acceleration`  | float | [m / s^2]                                                |
-| `longitudinal_jerk`          | float | [m / s^3]                                                |
-| `lateral_acceleration`       | float | [m / s^2]                                                |
-| `lateral_jerk`               | float | [m / s^3]                                                |
-| `desired_steering_angle`     | float | [rad]                                                    |
-| `controller_processing_time` | float | Timestamp between last two control command messages [ms] |
+| `longitudinal_acceleration`  | float | $[ \mathrm{m/s^2} ]$                          |
+| `longitudinal_jerk`          | float | $[ \mathrm{m/s^3} ]$                          |
+| `lateral_acceleration`       | float | $[ \mathrm{m/s^2} ]$                          |
+| `lateral_jerk`               | float | $[ \mathrm{m/s^3} ]$                          |
+| `desired_steering_angle`     | float | $[ \mathrm{rad} ]$                            |
+| `controller_processing_time` | float | Timestamp between last two control command messages $[ \mathrm{ms} ]$ |
 
 #### control_performance_analysis::msg::ErrorStamped
 
-| Name                                       | Type  | Description                                                                                                       |
-| ------------------------------------------ | ----- | ----------------------------------------------------------------------------------------------------------------- |
-| `lateral_error`                            | float | [m]                                                                                                               |
-| `lateral_error_velocity`                   | float | [m / s]                                                                                                           |
-| `lateral_error_acceleration`               | float | [m / s^2]                                                                                                         |
-| `longitudinal_error`                       | float | [m]                                                                                                               |
-| `longitudinal_error_velocity`              | float | [m / s]                                                                                                           |
-| `longitudinal_error_acceleration`          | float | [m / s^2]                                                                                                         |
-| `heading_error`                            | float | [rad]                                                                                                             |
-| `heading_error_velocity`                   | float | [rad / s]                                                                                                         |
-| `control_effort_energy`                    | float | [u * R * u^T]                                                                                                     |
-| `error_energy`                             | float | lateral_error^2 + heading_error^2                                                                                 |
-| `value_approximation`                      | float | V = xPx' ; Value function from DARE Lyap matrix P                                                                 |
-| `curvature_estimate`                       | float | [1 / m]                                                                                                           |
-| `curvature_estimate_pp`                    | float | [1 / m]                                                                                                           |
-| `vehicle_velocity_error`                   | float | [m / s]                                                                                                           |
-| `tracking_curvature_discontinuity_ability` | float | Measures the ability to tracking the curvature changes [`abs(delta(curvature)) / (1 + abs(delta(lateral_error))`] |
+| Name                                       | Type  | Description                                                                                                                                     |
+| ------------------------------------------ | ----- |-------------------------------------------------------------------------------------------------------------------------------------------------|
+| `lateral_error`                            | float | $[ \mathrm{m} ]$                                                                                                                                |
+| `lateral_error_velocity`                   | float | $[ \mathrm{m/s} ]$                                                                                                                              |
+| `lateral_error_acceleration`               | float | $[ \mathrm{m/s^2} ]$                                                                                                                            |
+| `longitudinal_error`                       | float | $[ \mathrm{m} ]$                                                                                                                                |
+| `longitudinal_error_velocity`              | float | $[ \mathrm{m/s} ]$                                                                                                                              |
+| `longitudinal_error_acceleration`          | float | $[ \mathrm{m/s^2} ]$                                                                                                                            |
+| `heading_error`                            | float | $[ \mathrm{rad} ]$                                                                                                                              |
+| `heading_error_velocity`                   | float | $[ \mathrm{rad/s} ]$                                                                                                                            |
+| `control_effort_energy`                    | float | $[ \mathbf{u}^\top \mathbf{R} \mathbf{u} ]$                                                                                                     |
+| `error_energy`                             | float | $\text{lateral_error}^2 + \text{heading_error}^2$                                                                                               |
+| `value_approximation`                      | float | $V = \mathbf{x}^\top \mathbf{P} \mathbf{x}$; Value function from DARE Lyapunov matrix $\mathbf{P}$                                              |
+| `curvature_estimate`                       | float | $[ \mathrm{1/m} ]$                                                                                                                              |
+| `curvature_estimate_pp`                    | float | $[ \mathrm{1/m} ]$                                                                                                                              |
+| `vehicle_velocity_error`                   | float | $[ \mathrm{m/s} ]$                                                                                                                              |
+| `tracking_curvature_discontinuity_ability` | float | Measures the ability to track curvature changes $\frac{\lvert \Delta(\text{curvature}) \rvert}{1 + \lvert \Delta(\text{lateral_error}) \rvert}$ |
 
 ## Parameters
 

--- a/control/control_performance_analysis/README.md
+++ b/control/control_performance_analysis/README.md
@@ -66,7 +66,7 @@ Error acceleration calculations are made based on the velocity calculations abov
 | `heading_error`                            | float | $[ \mathrm{rad} ]$                                                                                                                              |
 | `heading_error_velocity`                   | float | $[ \mathrm{rad/s} ]$                                                                                                                            |
 | `control_effort_energy`                    | float | $[ \mathbf{u}^\top \mathbf{R} \mathbf{u} ]$                                                                                                     |
-| `error_energy`                             | float | $\text{lateral\_error}^2 + \text{heading\_error}^2$                                                                                               |
+| `error_energy`                             | float | $\mathrm{lateral\_error}^2 + \mathrm{heading\_error}^2$                                                                                               |
 | `value_approximation`                      | float | $V = \mathbf{x}^\top \mathbf{P} \mathbf{x}$; Value function from DARE Lyapunov matrix $\mathbf{P}$                                              |
 | `curvature_estimate`                       | float | $[ \mathrm{1/m} ]$                                                                                                                              |
 | `curvature_estimate_pp`                    | float | $[ \mathrm{1/m} ]$                                                                                                                              |

--- a/control/control_performance_analysis/README.md
+++ b/control/control_performance_analysis/README.md
@@ -55,23 +55,23 @@ Error acceleration calculations are made based on the velocity calculations abov
 
 #### control_performance_analysis::msg::ErrorStamped
 
-| Name                                       | Type  | Description                                                                                                                                     |
-| ------------------------------------------ | ----- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
-| `lateral_error`                            | float | $[ \mathrm{m} ]$                                                                                                                                |
-| `lateral_error_velocity`                   | float | $[ \mathrm{m/s} ]$                                                                                                                              |
-| `lateral_error_acceleration`               | float | $[ \mathrm{m/s^2} ]$                                                                                                                            |
-| `longitudinal_error`                       | float | $[ \mathrm{m} ]$                                                                                                                                |
-| `longitudinal_error_velocity`              | float | $[ \mathrm{m/s} ]$                                                                                                                              |
-| `longitudinal_error_acceleration`          | float | $[ \mathrm{m/s^2} ]$                                                                                                                            |
-| `heading_error`                            | float | $[ \mathrm{rad} ]$                                                                                                                              |
-| `heading_error_velocity`                   | float | $[ \mathrm{rad/s} ]$                                                                                                                            |
-| `control_effort_energy`                    | float | $[ \mathbf{u}^\top \mathbf{R} \mathbf{u} ]$                                                                                                     |
-| `error_energy`                             | float | $\mathrm{lateral_error}^2 + \mathrm{heading_error}^2$                                                                                               |
-| `value_approximation`                      | float | $V = \mathbf{x}^\top \mathbf{P} \mathbf{x}$; Value function from DARE Lyapunov matrix $\mathbf{P}$                                              |
-| `curvature_estimate`                       | float | $[ \mathrm{1/m} ]$                                                                                                                              |
-| `curvature_estimate_pp`                    | float | $[ \mathrm{1/m} ]$                                                                                                                              |
-| `vehicle_velocity_error`                   | float | $[ \mathrm{m/s} ]$                                                                                                                              |
-| `tracking_curvature_discontinuity_ability` | float | Measures the ability to track curvature changes $\frac{\lvert \Delta(\text{curvature}) \rvert}{1 + \lvert \Delta(\text{lateral\_error}) \rvert}$ |
+| Name                                       | Type  | Description                                                                                                                                       |
+| ------------------------------------------ | ----- |---------------------------------------------------------------------------------------------------------------------------------------------------|
+| `lateral_error`                            | float | $[ \mathrm{m} ]$                                                                                                                                  |
+| `lateral_error_velocity`                   | float | $[ \mathrm{m/s} ]$                                                                                                                                |
+| `lateral_error_acceleration`               | float | $[ \mathrm{m/s^2} ]$                                                                                                                              |
+| `longitudinal_error`                       | float | $[ \mathrm{m} ]$                                                                                                                                  |
+| `longitudinal_error_velocity`              | float | $[ \mathrm{m/s} ]$                                                                                                                                |
+| `longitudinal_error_acceleration`          | float | $[ \mathrm{m/s^2} ]$                                                                                                                              |
+| `heading_error`                            | float | $[ \mathrm{rad} ]$                                                                                                                                |
+| `heading_error_velocity`                   | float | $[ \mathrm{rad/s} ]$                                                                                                                              |
+| `control_effort_energy`                    | float | $[ \mathbf{u}^\top \mathbf{R} \mathbf{u} ]$                                                                                                       |
+| `error_energy`                             | float | $e_{\text{lat}}^2 + e_\theta^2$ (squared lateral error + squared heading error)                                                                   |
+| `value_approximation`                      | float | $V = \mathbf{x}^\top \mathbf{P} \mathbf{x}$; Value function from DARE Lyapunov matrix $\mathbf{P}$                                                |
+| `curvature_estimate`                       | float | $[ \mathrm{1/m} ]$                                                                                                                                |
+| `curvature_estimate_pp`                    | float | $[ \mathrm{1/m} ]$                                                                                                                                |
+| `vehicle_velocity_error`                   | float | $[ \mathrm{m/s} ]$                                                                                                                                |
+| `tracking_curvature_discontinuity_ability` | float | Measures the ability to track curvature changes $\frac{\lvert \Delta(\text{curvature}) \rvert}{1 + \lvert \Delta(e_{\text{lat}}) \rvert}$ |
 
 ## Parameters
 

--- a/control/control_performance_analysis/README.md
+++ b/control/control_performance_analysis/README.md
@@ -56,7 +56,7 @@ Error acceleration calculations are made based on the velocity calculations abov
 #### control_performance_analysis::msg::ErrorStamped
 
 | Name                                       | Type  | Description                                                                                                                               |
-| ------------------------------------------ | ----- |-------------------------------------------------------------------------------------------------------------------------------------------|
+| ------------------------------------------ | ----- | ----------------------------------------------------------------------------------------------------------------------------------------- |
 | `lateral_error`                            | float | $[ \mathrm{m} ]$                                                                                                                          |
 | `lateral_error_velocity`                   | float | $[ \mathrm{m/s} ]$                                                                                                                        |
 | `lateral_error_acceleration`               | float | $[ \mathrm{m/s^2} ]$                                                                                                                      |


### PR DESCRIPTION
## Description

https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/writing-mathematical-expressions#about-writing-mathematical-expressions

![image](https://github.com/user-attachments/assets/23b0219a-ae74-4992-b751-20811ba34c39)

This will sacrifice from the maintainability a bit but make it better and more professional for rendered output.

Rendered beautifully in the documentation page too:
https://autowarefoundation.github.io/autoware.universe/pr-9552/control/control_performance_analysis/#outputs

![image](https://github.com/user-attachments/assets/a8d25f45-2b1f-4b43-80a3-3e4e65f45a75)


## Related links

**Related PR:**

- https://github.com/autowarefoundation/autoware.universe/pull/8949

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.
