### PR TITLE
fix(autoware_carla_interface): include "modules" submodule in release package and update setup.py

### DIFF
--- a/simulator/autoware_carla_interface/setup.py
+++ b/simulator/autoware_carla_interface/setup.py
@@ -1,20 +1,19 @@
 from glob import glob
 import os
-
-from setuptools import setup
+from setuptools import setup, find_packages
 
 package_name = "autoware_carla_interface"
 
 setup(
     name=package_name,
     version="0.38.0",
-    packages=[package_name],
+    packages=find_packages(where="src"),
     data_files=[
-        ("share/" + package_name, glob("config/*")),
-        ("share/" + package_name, glob("calibration_maps/*.csv")),
-        ("share/" + package_name, ["package.xml"]),
-        (os.path.join("share", package_name), glob("launch/autoware_carla_interface.launch.xml")),
-        ("share/ament_index/resource_index/packages", ["resource/autoware_carla_interface"]),
+        ("share/ament_index/resource_index/packages", [f"resource/{package_name}"]),
+        (os.path.join('share', package_name), ['package.xml']),
+        (os.path.join('share', package_name), glob("config/*")),
+        (os.path.join('share', package_name), glob("calibration_maps/*.csv")),
+        (os.path.join('share', package_name), glob("launch/*.launch.xml")),
     ],
     install_requires=["setuptools"],
     zip_safe=True,

--- a/simulator/autoware_carla_interface/setup.py
+++ b/simulator/autoware_carla_interface/setup.py
@@ -1,6 +1,8 @@
 from glob import glob
 import os
-from setuptools import setup, find_packages
+
+from setuptools import find_packages
+from setuptools import setup
 
 package_name = "autoware_carla_interface"
 
@@ -10,10 +12,10 @@ setup(
     packages=find_packages(where="src"),
     data_files=[
         ("share/ament_index/resource_index/packages", [f"resource/{package_name}"]),
-        (os.path.join('share', package_name), ['package.xml']),
-        (os.path.join('share', package_name), glob("config/*")),
-        (os.path.join('share', package_name), glob("calibration_maps/*.csv")),
-        (os.path.join('share', package_name), glob("launch/*.launch.xml")),
+        (os.path.join("share", package_name), ["package.xml"]),
+        (os.path.join("share", package_name), glob("config/*")),
+        (os.path.join("share", package_name), glob("calibration_maps/*.csv")),
+        (os.path.join("share", package_name), glob("launch/*.launch.xml")),
     ],
     install_requires=["setuptools"],
     zip_safe=True,


### PR DESCRIPTION
## Description

This PR fixes an issue where the `autoware_carla_interface` package failed to include the "modules" submodule in the release package. This omission caused the following runtime error in the official `universe-cuda` Docker image:

`ModuleNotFoundError: No module named 'autoware_carla_interface.modules'`

The fix involves updating `setup.py` to:

- Use `find_packages(where="src")` to automatically detect and include the "modules" subpackage.
- Correct paths in `data_files` to comply with ROS 2 packaging conventions.

This ensures that the `autoware_carla_interface` module is properly packaged and resolves the runtime error.

## Related links

**Parent Issue:**

None

## How was this PR tested?

- Built a Docker image based on this commit.
- Verified the `autoware_carla_interface` module connects to CARLA Simulator without the `ModuleNotFoundError`.
- Ensured compatibility with the ROS 2 colcon build system by running `colcon build` and confirming successful packaging.

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.
