### PR TITLE
feat(bytetrack): remove unreachable code block from lapjv.h

### DIFF
--- a/perception/autoware_bytetrack/lib/include/lapjv.h
+++ b/perception/autoware_bytetrack/lib/include/lapjv.h
@@ -64,40 +64,10 @@
     b = _temp_index;       \
   }
 
-#if 0
-#include <assert.h>
-#define ASSERT(cond) assert(cond)
-#define PRINTF(fmt, ...) printf(fmt, ##__VA_ARGS__)
-#define PRINT_COST_ARRAY(a, n)         \
-  while (1) {                          \
-    printf(#a " = [");                 \
-    if ((n) > 0) {                     \
-      printf("%f", (a)[0]);            \
-      for (uint_t j = 1; j < n; j++) { \
-        printf(", %f", (a)[j]);        \
-      }                                \
-    }                                  \
-    printf("]\n");                     \
-    break;                             \
-  }
-#define PRINT_INDEX_ARRAY(a, n)        \
-  while (1) {                          \
-    printf(#a " = [");                 \
-    if ((n) > 0) {                     \
-      printf("%d", (a)[0]);            \
-      for (uint_t j = 1; j < n; j++) { \
-        printf(", %d", (a)[j]);        \
-      }                                \
-    }                                  \
-    printf("]\n");                     \
-    break;                             \
-  }
-#else
 #define ASSERT(cond)
 #define PRINTF(fmt, ...)
 #define PRINT_COST_ARRAY(a, n)
 #define PRINT_INDEX_ARRAY(a, n)
-#endif
 
 typedef signed int int_t;
 typedef unsigned int uint_t;


### PR DESCRIPTION
## Description

This code block is unreachable unless the header is modified by hand and recompiled.

This PR removes that.

### Why?

As part of:
- https://github.com/autowarefoundation/autoware.universe/issues/9556

This weird macro heavy code snippet was confusing the static analysis tool.

It uses `printf` function yet doesn't include `<cstdio>`. Even if I include it, because of the conditional structure, the cpplint wasn't able to recognize it.

So I decided to remove it since it is not used anyways.

## How was this PR tested?

Basic CI.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
