### PR TITLE
fix(cpplint): include what you use - planning

### DIFF
--- a/planning/autoware_costmap_generator/src/utils/objects_to_costmap.cpp
+++ b/planning/autoware_costmap_generator/src/utils/objects_to_costmap.cpp
@@ -50,6 +50,7 @@
 #include <Eigen/src/Core/util/Constants.h>
 #include <tf2/utils.h>
 
+#include <algorithm>
 #include <cmath>
 #include <string>
 

--- a/planning/autoware_costmap_generator/test/test_costmap_generator.cpp
+++ b/planning/autoware_costmap_generator/test/test_costmap_generator.cpp
@@ -20,6 +20,10 @@
 
 #include <gtest/gtest.h>
 
+#include <memory>
+#include <string>
+#include <vector>
+
 using autoware::costmap_generator::CostmapGenerator;
 using tier4_planning_msgs::msg::Scenario;
 

--- a/planning/autoware_costmap_generator/test/test_object_map_utils.cpp
+++ b/planning/autoware_costmap_generator/test/test_object_map_utils.cpp
@@ -17,6 +17,8 @@
 
 #include <gtest/gtest.h>
 
+#include <vector>
+
 namespace
 {
 grid_map::GridMap construct_gridmap(

--- a/planning/autoware_costmap_generator/test/test_objects_to_costmap.cpp
+++ b/planning/autoware_costmap_generator/test/test_objects_to_costmap.cpp
@@ -19,6 +19,8 @@
 #include <gtest/gtest.h>
 #include <tf2/utils.h>
 
+#include <memory>
+
 namespace
 {
 geometry_msgs::msg::Point32 toPoint32(const geometry_msgs::msg::Pose & pose)

--- a/planning/autoware_costmap_generator/test/test_points_to_costmap.cpp
+++ b/planning/autoware_costmap_generator/test/test_points_to_costmap.cpp
@@ -16,6 +16,8 @@
 
 #include <gtest/gtest.h>
 
+#include <string>
+
 namespace autoware::costmap_generator
 {
 using pointcloud = pcl::PointCloud<pcl::PointXYZ>;

--- a/planning/autoware_freespace_planner/src/autoware_freespace_planner/utils.cpp
+++ b/planning/autoware_freespace_planner/src/autoware_freespace_planner/utils.cpp
@@ -16,6 +16,9 @@
 
 #include <autoware/motion_utils/trajectory/trajectory.hpp>
 
+#include <deque>
+#include <vector>
+
 namespace autoware::freespace_planner::utils
 {
 

--- a/planning/autoware_freespace_planner/test/test_freespace_planner.cpp
+++ b/planning/autoware_freespace_planner/test/test_freespace_planner.cpp
@@ -25,6 +25,11 @@
 #include <geometry_msgs/msg/pose.h>
 #include <gtest/gtest.h>
 
+#include <limits>
+#include <memory>
+#include <utility>
+#include <vector>
+
 using autoware::freespace_planner::FreespacePlannerNode;
 using autoware_planning_msgs::msg::Trajectory;
 using autoware_planning_msgs::msg::TrajectoryPoint;

--- a/planning/autoware_freespace_planner/test/test_freespace_planner_node_interface.cpp
+++ b/planning/autoware_freespace_planner/test/test_freespace_planner_node_interface.cpp
@@ -20,6 +20,7 @@
 
 #include <gtest/gtest.h>
 
+#include <memory>
 #include <vector>
 
 using autoware::freespace_planner::FreespacePlannerNode;

--- a/planning/autoware_freespace_planner/test/test_freespace_planner_utils.cpp
+++ b/planning/autoware_freespace_planner/test/test_freespace_planner_utils.cpp
@@ -19,6 +19,7 @@
 #include <gtest/gtest.h>
 
 #include <deque>
+#include <memory>
 #include <vector>
 
 using autoware::freespace_planner::utils::Odometry;

--- a/planning/autoware_freespace_planning_algorithms/scripts/bind/astar_search_pybind.cpp
+++ b/planning/autoware_freespace_planning_algorithms/scripts/bind/astar_search_pybind.cpp
@@ -24,6 +24,9 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
+#include <string>
+#include <vector>
+
 namespace autoware::freespace_planning_algorithms
 {
 struct PlannerWaypointsVector

--- a/planning/autoware_freespace_planning_algorithms/src/abstract_algorithm.cpp
+++ b/planning/autoware_freespace_planning_algorithms/src/abstract_algorithm.cpp
@@ -19,6 +19,8 @@
 #include <autoware/universe_utils/geometry/geometry.hpp>
 #include <autoware/universe_utils/math/normalization.hpp>
 
+#include <algorithm>
+#include <iostream>
 #include <limits>
 #include <vector>
 

--- a/planning/autoware_freespace_planning_algorithms/src/astar_search.cpp
+++ b/planning/autoware_freespace_planning_algorithms/src/astar_search.cpp
@@ -24,6 +24,9 @@
 #include <tf2/utils.h>
 
 #include <limits>
+#include <memory>
+#include <queue>
+#include <utility>
 
 #ifdef ROS_DISTRO_GALACTIC
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>

--- a/planning/autoware_freespace_planning_algorithms/src/rrtstar.cpp
+++ b/planning/autoware_freespace_planning_algorithms/src/rrtstar.cpp
@@ -16,6 +16,8 @@
 
 #include "autoware/freespace_planning_algorithms/kinematic_bicycle_model.hpp"
 
+#include <vector>
+
 namespace autoware::freespace_planning_algorithms
 {
 rrtstar_core::Pose poseMsgToPose(const geometry_msgs::msg::Pose & pose_msg)

--- a/planning/autoware_freespace_planning_algorithms/src/rrtstar_core.cpp
+++ b/planning/autoware_freespace_planning_algorithms/src/rrtstar_core.cpp
@@ -16,13 +16,16 @@
 
 #include <nlohmann/json.hpp>
 
+#include <algorithm>
 #include <fstream>
 #include <functional>
 #include <memory>
 #include <queue>
 #include <stack>
+#include <string>
 #include <unordered_map>
 #include <unordered_set>
+#include <vector>
 
 // cspell: ignore rsspace
 // In this case, RSSpace means "Reeds Shepp state Space"

--- a/planning/autoware_freespace_planning_algorithms/test/src/test_freespace_planning_algorithms.cpp
+++ b/planning/autoware_freespace_planning_algorithms/test/src/test_freespace_planning_algorithms.cpp
@@ -29,6 +29,8 @@
 #include <algorithm>
 #include <array>
 #include <fstream>
+#include <iostream>
+#include <memory>
 #include <string>
 #include <unordered_map>
 #include <vector>

--- a/planning/autoware_freespace_planning_algorithms/test/src/test_rrtstar_core_informed.cpp
+++ b/planning/autoware_freespace_planning_algorithms/test/src/test_rrtstar_core_informed.cpp
@@ -18,6 +18,7 @@
 
 #include <iostream>
 #include <stack>
+#include <vector>
 
 namespace autoware::freespace_planning_algorithms::rrtstar_core
 {

--- a/planning/autoware_mission_planner/src/lanelet2_plugins/utility_functions.cpp
+++ b/planning/autoware_mission_planner/src/lanelet2_plugins/utility_functions.cpp
@@ -23,6 +23,7 @@
 #include <lanelet2_core/geometry/Lanelet.h>
 
 #include <limits>
+#include <vector>
 
 namespace autoware::mission_planner::lanelet2
 {

--- a/planning/autoware_mission_planner/src/mission_planner/mission_planner.cpp
+++ b/planning/autoware_mission_planner/src/mission_planner/mission_planner.cpp
@@ -27,7 +27,10 @@
 #include <lanelet2_core/geometry/LineString.h>
 
 #include <algorithm>
+#include <memory>
+#include <string>
 #include <utility>
+#include <vector>
 
 namespace autoware::mission_planner
 {

--- a/planning/autoware_mission_planner/test/test_lanelet2_plugins_default_planner.cpp
+++ b/planning/autoware_mission_planner/test/test_lanelet2_plugins_default_planner.cpp
@@ -29,6 +29,10 @@
 #include <lanelet2_core/primitives/Point.h>
 #include <tf2/utils.h>
 
+#include <memory>
+#include <string>
+#include <vector>
+
 using autoware::universe_utils::calcOffsetPose;
 using autoware::universe_utils::createQuaternionFromRPY;
 using autoware_planning_msgs::msg::LaneletRoute;

--- a/planning/autoware_mission_planner/test/test_utility_functions.cpp
+++ b/planning/autoware_mission_planner/test/test_utility_functions.cpp
@@ -23,6 +23,8 @@
 #include <lanelet2_core/primitives/LineString.h>
 #include <lanelet2_core/primitives/Point.h>
 
+#include <vector>
+
 using autoware::mission_planner::lanelet2::convert_linear_ring_to_polygon;
 using autoware::mission_planner::lanelet2::convertBasicPoint3dToPose;
 using autoware::mission_planner::lanelet2::convertCenterlineToPoints;

--- a/planning/autoware_objects_of_interest_marker_interface/src/marker_utils.cpp
+++ b/planning/autoware_objects_of_interest_marker_interface/src/marker_utils.cpp
@@ -14,6 +14,8 @@
 
 #include "autoware/objects_of_interest_marker_interface/marker_utils.hpp"
 
+#include <string>
+
 namespace autoware::objects_of_interest_marker_interface::marker_utils
 {
 using geometry_msgs::msg::Point;

--- a/planning/autoware_objects_of_interest_marker_interface/src/objects_of_interest_marker_interface.cpp
+++ b/planning/autoware_objects_of_interest_marker_interface/src/objects_of_interest_marker_interface.cpp
@@ -18,6 +18,8 @@
 #include <autoware/universe_utils/math/constants.hpp>
 #include <autoware/universe_utils/math/trigonometry.hpp>
 
+#include <string>
+
 namespace autoware::objects_of_interest_marker_interface
 {
 using autoware_perception_msgs::msg::Shape;

--- a/planning/autoware_obstacle_cruise_planner/src/node.cpp
+++ b/planning/autoware_obstacle_cruise_planner/src/node.cpp
@@ -32,6 +32,13 @@
 
 #include <algorithm>
 #include <chrono>
+#include <limits>
+#include <memory>
+#include <string>
+#include <tuple>
+#include <unordered_map>
+#include <utility>
+#include <vector>
 
 namespace
 {

--- a/planning/autoware_obstacle_cruise_planner/src/optimization_based_planner/optimization_based_planner.cpp
+++ b/planning/autoware_obstacle_cruise_planner/src/optimization_based_planner/optimization_based_planner.cpp
@@ -25,6 +25,12 @@
 #include "autoware/universe_utils/geometry/geometry.hpp"
 #include "autoware/universe_utils/ros/marker_helper.hpp"
 
+#include <algorithm>
+#include <limits>
+#include <memory>
+#include <tuple>
+#include <vector>
+
 #ifdef ROS_DISTRO_GALACTIC
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 #else

--- a/planning/autoware_obstacle_cruise_planner/src/optimization_based_planner/velocity_optimizer.cpp
+++ b/planning/autoware_obstacle_cruise_planner/src/optimization_based_planner/velocity_optimizer.cpp
@@ -16,7 +16,9 @@
 
 #include <Eigen/Core>
 
+#include <algorithm>
 #include <iostream>
+#include <vector>
 
 VelocityOptimizer::VelocityOptimizer(
   const double max_s_weight, const double max_v_weight, const double over_s_safety_weight,

--- a/planning/autoware_obstacle_cruise_planner/src/pid_based_planner/pid_based_planner.cpp
+++ b/planning/autoware_obstacle_cruise_planner/src/pid_based_planner/pid_based_planner.cpp
@@ -23,6 +23,11 @@
 
 #include "tier4_planning_msgs/msg/velocity_limit.hpp"
 
+#include <algorithm>
+#include <memory>
+#include <string>
+#include <vector>
+
 using autoware::signal_processing::LowpassFilter1d;
 
 namespace

--- a/planning/autoware_obstacle_cruise_planner/src/planner_interface.cpp
+++ b/planning/autoware_obstacle_cruise_planner/src/planner_interface.cpp
@@ -25,8 +25,12 @@
 #include <boost/geometry/algorithms/distance.hpp>
 #include <boost/geometry/strategies/strategies.hpp>
 
+#include <algorithm>
+#include <iostream>
 #include <optional>
 #include <string>
+#include <utility>
+#include <vector>
 
 namespace
 {

--- a/planning/autoware_obstacle_cruise_planner/src/polygon_utils.cpp
+++ b/planning/autoware_obstacle_cruise_planner/src/polygon_utils.cpp
@@ -18,6 +18,11 @@
 #include "autoware/universe_utils/geometry/boost_polygon_utils.hpp"
 #include "autoware/universe_utils/geometry/geometry.hpp"
 
+#include <algorithm>
+#include <limits>
+#include <utility>
+#include <vector>
+
 namespace
 {
 PointWithStamp calcNearestCollisionPoint(

--- a/planning/autoware_obstacle_cruise_planner/src/utils.cpp
+++ b/planning/autoware_obstacle_cruise_planner/src/utils.cpp
@@ -17,6 +17,10 @@
 #include "autoware/object_recognition_utils/predicted_path_utils.hpp"
 #include "autoware/universe_utils/ros/marker_helper.hpp"
 
+#include <limits>
+#include <string>
+#include <vector>
+
 namespace obstacle_cruise_utils
 {
 namespace

--- a/planning/autoware_obstacle_cruise_planner/test/test_obstacle_cruise_planner_node_interface.cpp
+++ b/planning/autoware_obstacle_cruise_planner/test/test_obstacle_cruise_planner_node_interface.cpp
@@ -20,6 +20,7 @@
 
 #include <gtest/gtest.h>
 
+#include <memory>
 #include <vector>
 
 using autoware::motion_planning::ObstacleCruisePlannerNode;

--- a/planning/autoware_obstacle_cruise_planner/test/test_obstacle_cruise_planner_utils.cpp
+++ b/planning/autoware_obstacle_cruise_planner/test/test_obstacle_cruise_planner_utils.cpp
@@ -21,6 +21,9 @@
 
 #include <gtest/gtest.h>
 
+#include <string>
+#include <vector>
+
 StopObstacle generate_stop_obstacle(uint8_t label, double dist)
 {
   const std::string uuid{};

--- a/planning/autoware_obstacle_stop_planner/src/debug_marker.cpp
+++ b/planning/autoware_obstacle_stop_planner/src/debug_marker.cpp
@@ -18,6 +18,8 @@
 #include <autoware/universe_utils/geometry/geometry.hpp>
 #include <autoware/universe_utils/ros/marker_helper.hpp>
 
+#include <string>
+
 #ifdef ROS_DISTRO_GALACTIC
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 #else

--- a/planning/autoware_obstacle_stop_planner/src/planner_utils.cpp
+++ b/planning/autoware_obstacle_stop_planner/src/planner_utils.cpp
@@ -31,6 +31,9 @@
 
 #include <algorithm>
 #include <limits>
+#include <map>
+#include <string>
+#include <utility>
 
 namespace autoware::motion_planning
 {

--- a/planning/autoware_obstacle_stop_planner/test/test_autoware_obstacle_stop_planner_node_interface.cpp
+++ b/planning/autoware_obstacle_stop_planner/test/test_autoware_obstacle_stop_planner_node_interface.cpp
@@ -20,6 +20,7 @@
 
 #include <gtest/gtest.h>
 
+#include <memory>
 #include <vector>
 
 using autoware::motion_planning::ObstacleStopPlannerNode;

--- a/planning/autoware_path_optimizer/src/debug_marker.cpp
+++ b/planning/autoware_path_optimizer/src/debug_marker.cpp
@@ -18,6 +18,9 @@
 
 #include "visualization_msgs/msg/marker_array.hpp"
 
+#include <string>
+#include <vector>
+
 namespace autoware::path_optimizer
 {
 using autoware::universe_utils::appendMarkerArray;

--- a/planning/autoware_path_optimizer/src/mpt_optimizer.cpp
+++ b/planning/autoware_path_optimizer/src/mpt_optimizer.cpp
@@ -26,8 +26,12 @@
 #include <algorithm>
 #include <chrono>
 #include <limits>
+#include <memory>
 #include <optional>
+#include <string>
 #include <tuple>
+#include <utility>
+#include <vector>
 
 namespace autoware::path_optimizer
 {

--- a/planning/autoware_path_optimizer/src/node.cpp
+++ b/planning/autoware_path_optimizer/src/node.cpp
@@ -25,6 +25,9 @@
 #include <chrono>
 #include <iostream>
 #include <limits>
+#include <memory>
+#include <string>
+#include <vector>
 
 namespace autoware::path_optimizer
 {

--- a/planning/autoware_path_optimizer/src/replan_checker.cpp
+++ b/planning/autoware_path_optimizer/src/replan_checker.cpp
@@ -19,6 +19,7 @@
 #include "autoware/universe_utils/geometry/geometry.hpp"
 #include "autoware/universe_utils/ros/update_param.hpp"
 
+#include <memory>
 #include <vector>
 
 namespace autoware::path_optimizer

--- a/planning/autoware_path_optimizer/src/state_equation_generator.cpp
+++ b/planning/autoware_path_optimizer/src/state_equation_generator.cpp
@@ -16,6 +16,8 @@
 
 #include "autoware/path_optimizer/mpt_optimizer.hpp"
 
+#include <vector>
+
 namespace autoware::path_optimizer
 {
 // state equation: x = B u + W (u includes x_0)

--- a/planning/autoware_path_optimizer/test/test_path_optimizer_node_interface.cpp
+++ b/planning/autoware_path_optimizer/test/test_path_optimizer_node_interface.cpp
@@ -20,6 +20,7 @@
 
 #include <gtest/gtest.h>
 
+#include <memory>
 #include <vector>
 
 TEST(PlanningModuleInterfaceTest, NodeTestWithExceptionTrajectory)

--- a/planning/autoware_path_smoother/src/elastic_band.cpp
+++ b/planning/autoware_path_smoother/src/elastic_band.cpp
@@ -27,6 +27,9 @@
 #include <algorithm>
 #include <chrono>
 #include <limits>
+#include <memory>
+#include <tuple>
+#include <vector>
 
 namespace
 {

--- a/planning/autoware_path_smoother/src/elastic_band_smoother.cpp
+++ b/planning/autoware_path_smoother/src/elastic_band_smoother.cpp
@@ -22,6 +22,9 @@
 
 #include <chrono>
 #include <limits>
+#include <memory>
+#include <string>
+#include <vector>
 
 namespace autoware::path_smoother
 {

--- a/planning/autoware_path_smoother/src/replan_checker.cpp
+++ b/planning/autoware_path_smoother/src/replan_checker.cpp
@@ -19,6 +19,7 @@
 #include "autoware/universe_utils/geometry/geometry.hpp"
 #include "autoware/universe_utils/ros/update_param.hpp"
 
+#include <memory>
 #include <vector>
 
 namespace autoware::path_smoother

--- a/planning/autoware_path_smoother/test/test_autoware_path_smoother_node_interface.cpp
+++ b/planning/autoware_path_smoother/test/test_autoware_path_smoother_node_interface.cpp
@@ -20,6 +20,7 @@
 
 #include <gtest/gtest.h>
 
+#include <memory>
 #include <vector>
 
 TEST(PlanningModuleInterfaceTest, NodeTestWithExceptionTrajectory)

--- a/planning/autoware_planning_test_manager/include/autoware_planning_test_manager/autoware_planning_test_manager_utils.hpp
+++ b/planning/autoware_planning_test_manager/include/autoware_planning_test_manager/autoware_planning_test_manager_utils.hpp
@@ -22,6 +22,7 @@
 #include <geometry_msgs/msg/pose.hpp>
 #include <nav_msgs/msg/odometry.hpp>
 
+#include <iostream>
 #include <memory>
 #include <vector>
 

--- a/planning/autoware_planning_test_manager/src/autoware_planning_test_manager.cpp
+++ b/planning/autoware_planning_test_manager/src/autoware_planning_test_manager.cpp
@@ -19,6 +19,11 @@
 #include <autoware_planning_test_manager/autoware_planning_test_manager_utils.hpp>
 #include <autoware_test_utils/autoware_test_utils.hpp>
 
+#include <iostream>
+#include <memory>
+#include <string>
+#include <vector>
+
 namespace autoware::planning_test_manager
 {
 

--- a/planning/autoware_planning_topic_converter/src/path_to_trajectory.cpp
+++ b/planning/autoware_planning_topic_converter/src/path_to_trajectory.cpp
@@ -17,6 +17,8 @@
 #include <autoware/motion_utils/trajectory/conversion.hpp>
 #include <autoware/universe_utils/geometry/geometry.hpp>
 
+#include <vector>
+
 namespace autoware::planning_topic_converter
 {
 namespace

--- a/planning/autoware_planning_validator/src/utils.cpp
+++ b/planning/autoware_planning_validator/src/utils.cpp
@@ -17,6 +17,7 @@
 #include <autoware/motion_utils/trajectory/trajectory.hpp>
 #include <autoware/universe_utils/geometry/geometry.hpp>
 
+#include <algorithm>
 #include <memory>
 #include <string>
 #include <utility>

--- a/planning/autoware_planning_validator/test/src/test_planning_validator_functions.cpp
+++ b/planning/autoware_planning_validator/test/src/test_planning_validator_functions.cpp
@@ -19,6 +19,7 @@
 
 #include <gtest/gtest.h>
 
+#include <memory>
 #include <string>
 
 using autoware::planning_validator::PlanningValidator;

--- a/planning/autoware_planning_validator/test/src/test_planning_validator_node_interface.cpp
+++ b/planning/autoware_planning_validator/test/src/test_planning_validator_node_interface.cpp
@@ -20,6 +20,7 @@
 
 #include <gtest/gtest.h>
 
+#include <memory>
 #include <vector>
 
 using autoware::planning_test_manager::PlanningInterfaceTestManager;

--- a/planning/autoware_planning_validator/test/src/test_planning_validator_pubsub.cpp
+++ b/planning/autoware_planning_validator/test/src/test_planning_validator_pubsub.cpp
@@ -22,7 +22,10 @@
 
 #include <gtest/gtest.h>
 
+#include <iostream>
 #include <memory>
+#include <string>
+#include <utility>
 #include <vector>
 
 /*

--- a/planning/autoware_route_handler/src/route_handler.cpp
+++ b/planning/autoware_route_handler/src/route_handler.cpp
@@ -35,9 +35,11 @@
 #include <tf2/utils.h>
 
 #include <algorithm>
+#include <functional>
 #include <limits>
 #include <memory>
 #include <optional>
+#include <set>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>

--- a/planning/autoware_route_handler/test/test_route_handler.hpp
+++ b/planning/autoware_route_handler/test/test_route_handler.hpp
@@ -31,6 +31,7 @@
 
 #include <lanelet2_io/Io.h>
 
+#include <iostream>
 #include <memory>
 #include <string>
 namespace autoware::route_handler::test

--- a/planning/autoware_rtc_interface/src/rtc_interface.cpp
+++ b/planning/autoware_rtc_interface/src/rtc_interface.cpp
@@ -14,6 +14,9 @@
 
 #include "autoware/rtc_interface/rtc_interface.hpp"
 
+#include <string>
+#include <vector>
+
 namespace
 {
 using tier4_rtc_msgs::msg::Module;

--- a/planning/autoware_rtc_interface/test/test_rtc_interface.cpp
+++ b/planning/autoware_rtc_interface/test/test_rtc_interface.cpp
@@ -22,6 +22,9 @@
 
 #include <gtest/gtest.h>
 
+#include <memory>
+#include <vector>
+
 using tier4_rtc_msgs::msg::State;
 
 namespace autoware::rtc_interface

--- a/planning/autoware_scenario_selector/test/test_autoware_scenario_selector_node_interface.cpp
+++ b/planning/autoware_scenario_selector/test/test_autoware_scenario_selector_node_interface.cpp
@@ -21,6 +21,7 @@
 #include <gtest/gtest.h>
 
 #include <cmath>
+#include <memory>
 #include <vector>
 namespace autoware::scenario_selector
 {

--- a/planning/autoware_static_centerline_generator/src/centerline_source/bag_ego_trajectory_based_centerline.cpp
+++ b/planning/autoware_static_centerline_generator/src/centerline_source/bag_ego_trajectory_based_centerline.cpp
@@ -22,6 +22,7 @@
 
 #include <memory>
 #include <string>
+#include <vector>
 
 namespace autoware::static_centerline_generator
 {

--- a/planning/autoware_static_centerline_generator/src/centerline_source/optimization_trajectory_based_centerline.cpp
+++ b/planning/autoware_static_centerline_generator/src/centerline_source/optimization_trajectory_based_centerline.cpp
@@ -23,6 +23,7 @@
 #include "utils.hpp"
 
 #include <algorithm>
+#include <vector>
 
 namespace autoware::static_centerline_generator
 {

--- a/planning/autoware_static_centerline_generator/src/main.cpp
+++ b/planning/autoware_static_centerline_generator/src/main.cpp
@@ -14,6 +14,9 @@
 
 #include "static_centerline_generator_node.hpp"
 
+#include <memory>
+#include <string>
+
 int main(int argc, char * argv[])
 {
   rclcpp::init(argc, argv);

--- a/planning/autoware_static_centerline_generator/src/static_centerline_generator_node.cpp
+++ b/planning/autoware_static_centerline_generator/src/static_centerline_generator_node.cpp
@@ -51,6 +51,7 @@
 #include <chrono>
 #include <filesystem>
 #include <fstream>
+#include <iostream>
 #include <limits>
 #include <memory>
 #include <string>

--- a/planning/autoware_static_centerline_generator/src/utils.cpp
+++ b/planning/autoware_static_centerline_generator/src/utils.cpp
@@ -23,7 +23,10 @@
 #include <lanelet2_core/geometry/Lanelet.h>
 
 #include <limits>
+#include <memory>
+#include <string>
 #include <utility>
+#include <vector>
 
 namespace autoware::static_centerline_generator
 {

--- a/planning/autoware_surround_obstacle_checker/src/debug_marker.cpp
+++ b/planning/autoware_surround_obstacle_checker/src/debug_marker.cpp
@@ -17,6 +17,8 @@
 #include <autoware/motion_utils/marker/marker_helper.hpp>
 #include <autoware/universe_utils/geometry/geometry.hpp>
 #include <autoware/universe_utils/ros/marker_helper.hpp>
+
+#include <string>
 #ifdef ROS_DISTRO_GALACTIC
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 #else

--- a/planning/autoware_surround_obstacle_checker/src/node.cpp
+++ b/planning/autoware_surround_obstacle_checker/src/node.cpp
@@ -32,6 +32,7 @@
 #include <pcl_conversions/pcl_conversions.h>
 
 #include <optional>
+#include <utility>
 #ifdef ROS_DISTRO_GALACTIC
 #include <tf2_eigen/tf2_eigen.h>
 #else

--- a/planning/autoware_surround_obstacle_checker/test/test_surround_obstacle_checker.cpp
+++ b/planning/autoware_surround_obstacle_checker/test/test_surround_obstacle_checker.cpp
@@ -20,6 +20,9 @@
 
 #include <gtest/gtest.h>
 
+#include <memory>
+#include <utility>
+
 namespace autoware::surround_obstacle_checker
 {
 auto generateTestTargetNode() -> std::shared_ptr<SurroundObstacleCheckerNode>

--- a/planning/autoware_velocity_smoother/src/node.cpp
+++ b/planning/autoware_velocity_smoother/src/node.cpp
@@ -29,6 +29,7 @@
 #include <memory>
 #include <string>
 #include <tuple>
+#include <utility>
 #include <vector>
 
 // clang-format on

--- a/planning/autoware_velocity_smoother/src/smoother/analytical_jerk_constrained_smoother/analytical_jerk_constrained_smoother.cpp
+++ b/planning/autoware_velocity_smoother/src/smoother/analytical_jerk_constrained_smoother/analytical_jerk_constrained_smoother.cpp
@@ -19,6 +19,7 @@
 #include "autoware/velocity_smoother/trajectory_utils.hpp"
 
 #include <algorithm>
+#include <memory>
 #include <string>
 #include <tuple>
 #include <utility>

--- a/planning/autoware_velocity_smoother/src/smoother/jerk_filtered_smoother.cpp
+++ b/planning/autoware_velocity_smoother/src/smoother/jerk_filtered_smoother.cpp
@@ -22,7 +22,9 @@
 #include <algorithm>
 #include <chrono>
 #include <cmath>
+#include <iostream>
 #include <limits>
+#include <memory>
 #include <numeric>
 #include <vector>
 

--- a/planning/autoware_velocity_smoother/src/smoother/l2_pseudo_jerk_smoother.cpp
+++ b/planning/autoware_velocity_smoother/src/smoother/l2_pseudo_jerk_smoother.cpp
@@ -21,6 +21,7 @@
 #include <algorithm>
 #include <chrono>
 #include <limits>
+#include <memory>
 #include <vector>
 
 namespace autoware::velocity_smoother

--- a/planning/autoware_velocity_smoother/src/smoother/linf_pseudo_jerk_smoother.cpp
+++ b/planning/autoware_velocity_smoother/src/smoother/linf_pseudo_jerk_smoother.cpp
@@ -21,6 +21,7 @@
 #include <algorithm>
 #include <chrono>
 #include <limits>
+#include <memory>
 #include <vector>
 
 namespace autoware::velocity_smoother

--- a/planning/autoware_velocity_smoother/src/smoother/smoother_base.cpp
+++ b/planning/autoware_velocity_smoother/src/smoother/smoother_base.cpp
@@ -24,6 +24,8 @@
 
 #include <algorithm>
 #include <cmath>
+#include <limits>
+#include <memory>
 #include <vector>
 
 namespace autoware::velocity_smoother

--- a/planning/autoware_velocity_smoother/test/test_velocity_smoother_node_interface.cpp
+++ b/planning/autoware_velocity_smoother/test/test_velocity_smoother_node_interface.cpp
@@ -20,6 +20,7 @@
 
 #include <gtest/gtest.h>
 
+#include <memory>
 #include <vector>
 
 using autoware::planning_test_manager::PlanningInterfaceTestManager;

--- a/planning/behavior_path_planner/autoware_behavior_path_avoidance_by_lane_change_module/src/interface.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_avoidance_by_lane_change_module/src/interface.cpp
@@ -19,6 +19,7 @@
 
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace autoware::behavior_path_planner
 {

--- a/planning/behavior_path_planner/autoware_behavior_path_avoidance_by_lane_change_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_avoidance_by_lane_change_module/src/scene.cpp
@@ -31,6 +31,7 @@
 
 #include <algorithm>
 #include <limits>
+#include <memory>
 #include <optional>
 #include <utility>
 

--- a/planning/behavior_path_planner/autoware_behavior_path_avoidance_by_lane_change_module/test/test_behavior_path_planner_node_interface.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_avoidance_by_lane_change_module/test/test_behavior_path_planner_node_interface.cpp
@@ -21,6 +21,8 @@
 #include <gtest/gtest.h>
 
 #include <cmath>
+#include <memory>
+#include <string>
 #include <vector>
 
 using autoware::behavior_path_planner::BehaviorPathPlannerNode;

--- a/planning/behavior_path_planner/autoware_behavior_path_dynamic_obstacle_avoidance_module/include/autoware/behavior_path_dynamic_obstacle_avoidance_module/scene.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_dynamic_obstacle_avoidance_module/include/autoware/behavior_path_dynamic_obstacle_avoidance_module/scene.hpp
@@ -28,6 +28,7 @@
 #include <tier4_planning_msgs/msg/path_with_lane_id.hpp>
 
 #include <algorithm>
+#include <iostream>
 #include <memory>
 #include <optional>
 #include <string>

--- a/planning/behavior_path_planner/autoware_behavior_path_dynamic_obstacle_avoidance_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_dynamic_obstacle_avoidance_module/src/scene.cpp
@@ -36,6 +36,8 @@
 #include <limits>
 #include <memory>
 #include <string>
+#include <unordered_map>
+#include <utility>
 #include <vector>
 
 namespace autoware::behavior_path_planner

--- a/planning/behavior_path_planner/autoware_behavior_path_dynamic_obstacle_avoidance_module/test/test_behavior_path_planner_node_interface.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_dynamic_obstacle_avoidance_module/test/test_behavior_path_planner_node_interface.cpp
@@ -18,6 +18,8 @@
 #include <autoware_planning_test_manager/autoware_planning_test_manager.hpp>
 #include <autoware_test_utils/autoware_test_utils.hpp>
 
+#include <memory>
+#include <string>
 #include <vector>
 
 using autoware::behavior_path_planner::BehaviorPathPlannerNode;

--- a/planning/behavior_path_planner/autoware_behavior_path_external_request_lane_change_module/src/manager.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_external_request_lane_change_module/src/manager.cpp
@@ -17,6 +17,8 @@
 #include "autoware/behavior_path_lane_change_module/interface.hpp"
 #include "scene.hpp"
 
+#include <memory>
+
 namespace autoware::behavior_path_planner
 {
 using autoware::behavior_path_planner::LaneChangeInterface;

--- a/planning/behavior_path_planner/autoware_behavior_path_external_request_lane_change_module/test/test_behavior_path_planner_node_interface.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_external_request_lane_change_module/test/test_behavior_path_planner_node_interface.cpp
@@ -20,6 +20,8 @@
 #include <gtest/gtest.h>
 
 #include <cmath>
+#include <memory>
+#include <string>
 #include <vector>
 
 using autoware::behavior_path_planner::BehaviorPathPlannerNode;

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/examples/plot_map.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/examples/plot_map.cpp
@@ -41,9 +41,17 @@
 #include <lanelet2_io/Io.h>
 #include <matplotlibcpp17/pyplot.h>
 
+#include <algorithm>
 #include <chrono>
 #include <cmath>
+#include <functional>
 #include <iostream>
+#include <map>
+#include <memory>
+#include <string>
+#include <tuple>
+#include <unordered_map>
+#include <vector>
 
 using namespace std::chrono_literals;  // NOLINT
 

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/decision_state.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/decision_state.cpp
@@ -17,6 +17,9 @@
 #include <autoware/behavior_path_goal_planner_module/decision_state.hpp>
 #include <autoware/motion_utils/trajectory/trajectory.hpp>
 
+#include <memory>
+#include <vector>
+
 namespace autoware::behavior_path_planner
 {
 

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/goal_planner_module.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/goal_planner_module.cpp
@@ -37,10 +37,15 @@
 
 #include <algorithm>
 #include <cstddef>
+#include <deque>
+#include <functional>
 #include <limits>
+#include <map>
 #include <memory>
 #include <optional>
 #include <string>
+#include <tuple>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/goal_searcher.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/goal_searcher.cpp
@@ -29,7 +29,9 @@
 
 #include <lanelet2_core/geometry/Polygon.h>
 
+#include <algorithm>
 #include <memory>
+#include <utility>
 #include <vector>
 
 namespace autoware::behavior_path_planner

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/pull_over_planner/pull_over_planner_base.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/pull_over_planner/pull_over_planner_base.cpp
@@ -14,6 +14,9 @@
 
 #include <autoware/behavior_path_goal_planner_module/pull_over_planner/pull_over_planner_base.hpp>
 
+#include <utility>
+#include <vector>
+
 namespace autoware::behavior_path_planner
 {
 

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/pull_over_planner/shift_pull_over.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/pull_over_planner/shift_pull_over.cpp
@@ -22,7 +22,10 @@
 #include <autoware_lanelet2_extension/utility/query.hpp>
 #include <autoware_lanelet2_extension/utility/utilities.hpp>
 
+#include <algorithm>
+#include <limits>
 #include <memory>
+#include <utility>
 #include <vector>
 
 namespace autoware::behavior_path_planner

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/util.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/util.cpp
@@ -33,7 +33,11 @@
 #include <tf2_ros/transform_listener.h>
 
 #include <algorithm>
+#include <map>
+#include <memory>
 #include <string>
+#include <unordered_set>
+#include <utility>
 #include <vector>
 
 namespace autoware::behavior_path_planner::goal_planner_utils

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/test/test_util.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/test/test_util.cpp
@@ -20,6 +20,10 @@
 
 #include <gtest/gtest.h>
 
+#include <memory>
+#include <string>
+#include <vector>
+
 class TestUtilWithMap : public ::testing::Test
 {
 protected:

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/interface.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/interface.cpp
@@ -24,8 +24,10 @@
 #include <autoware/universe_utils/system/time_keeper.hpp>
 
 #include <algorithm>
+#include <limits>
 #include <memory>
 #include <string>
+#include <unordered_map>
 #include <utility>
 
 namespace autoware::behavior_path_planner

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/manager.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/manager.cpp
@@ -20,6 +20,7 @@
 
 #include <rclcpp/rclcpp.hpp>
 
+#include <algorithm>
 #include <memory>
 #include <string>
 #include <vector>

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/scene.cpp
@@ -42,6 +42,7 @@
 #include <cmath>
 #include <limits>
 #include <memory>
+#include <string>
 #include <utility>
 #include <vector>
 

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/markers.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/markers.cpp
@@ -26,6 +26,7 @@
 #include <visualization_msgs/msg/detail/marker__struct.hpp>
 #include <visualization_msgs/msg/detail/marker_array__struct.hpp>
 
+#include <algorithm>
 #include <cstdint>
 #include <cstdlib>
 #include <sstream>

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/test/test_behavior_path_planner_node_interface.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/test/test_behavior_path_planner_node_interface.cpp
@@ -20,6 +20,8 @@
 #include <gtest/gtest.h>
 
 #include <cmath>
+#include <memory>
+#include <string>
 #include <vector>
 
 using autoware::behavior_path_planner::BehaviorPathPlannerNode;

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/test/test_lane_change_scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/test/test_lane_change_scene.cpp
@@ -25,7 +25,9 @@
 
 #include <gtest/gtest.h>
 
+#include <limits>
 #include <memory>
+#include <string>
 
 using autoware::behavior_path_planner::FilteredLanesObjects;
 using autoware::behavior_path_planner::LaneChangeModuleManager;

--- a/planning/behavior_path_planner/autoware_behavior_path_planner/src/planner_manager.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner/src/planner_manager.cpp
@@ -25,8 +25,13 @@
 
 #include <boost/scope_exit.hpp>
 
+#include <algorithm>
+#include <iostream>
 #include <memory>
 #include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
 
 namespace autoware::behavior_path_planner
 {

--- a/planning/behavior_path_planner/autoware_behavior_path_planner/test/input.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner/test/input.cpp
@@ -13,6 +13,8 @@
 // limitations under the License.
 #include "input.hpp"
 
+#include <vector>
+
 namespace autoware::behavior_path_planner
 {
 using autoware_planning_msgs::msg::PathPoint;

--- a/planning/behavior_path_planner/autoware_behavior_path_planner/test/test_autoware_behavior_path_planner_node_interface.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner/test/test_autoware_behavior_path_planner_node_interface.cpp
@@ -21,6 +21,8 @@
 #include <gtest/gtest.h>
 
 #include <cmath>
+#include <memory>
+#include <string>
 #include <vector>
 
 using autoware::behavior_path_planner::BehaviorPathPlannerNode;

--- a/planning/behavior_path_planner/autoware_behavior_path_planner/test/test_utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner/test/test_utils.cpp
@@ -23,6 +23,8 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <vector>
+
 using autoware::behavior_path_planner::PathWithLaneId;
 using autoware::behavior_path_planner::Pose;
 using autoware::behavior_path_planner::utils::FrenetPoint;

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/interface/scene_module_interface.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/interface/scene_module_interface.cpp
@@ -14,6 +14,8 @@
 
 #include "autoware/behavior_path_planner_common/interface/scene_module_interface.hpp"
 
+#include <vector>
+
 namespace autoware::behavior_path_planner
 {
 void SceneModuleInterface::setDrivableLanes(const std::vector<DrivableLanes> & drivable_lanes)

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/interface/scene_module_manager_interface.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/interface/scene_module_manager_interface.cpp
@@ -14,6 +14,10 @@
 
 #include "autoware/behavior_path_planner_common/interface/scene_module_manager_interface.hpp"
 
+#include <memory>
+#include <string>
+#include <vector>
+
 namespace autoware::behavior_path_planner
 {
 void SceneModuleManagerInterface::initInterface(

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/interface/scene_module_visitor.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/interface/scene_module_visitor.cpp
@@ -16,6 +16,8 @@
 
 #include "autoware/behavior_path_planner_common/interface/scene_module_interface.hpp"
 
+#include <memory>
+
 namespace autoware::behavior_path_planner
 {
 std::shared_ptr<AvoidanceDebugMsgArray> SceneModuleVisitor::getAvoidanceModuleDebugMsg() const

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/marker_utils/utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/marker_utils/utils.cpp
@@ -27,6 +27,8 @@
 #include <lanelet2_core/primitives/LineString.h>
 
 #include <cstdint>
+#include <string>
+#include <vector>
 
 namespace marker_utils
 {

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/turn_signal_decider.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/turn_signal_decider.cpp
@@ -26,10 +26,14 @@
 #include <autoware_lanelet2_extension/utility/message_conversion.hpp>
 #include <autoware_lanelet2_extension/utility/utilities.hpp>
 
+#include <algorithm>
 #include <limits>
+#include <memory>
 #include <queue>
+#include <set>
 #include <string>
 #include <utility>
+#include <vector>
 
 namespace autoware::behavior_path_planner
 {

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/drivable_area_expansion/drivable_area_expansion.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/drivable_area_expansion/drivable_area_expansion.cpp
@@ -30,7 +30,11 @@
 
 #include <boost/geometry/strategies/strategies.hpp>
 
+#include <algorithm>
+#include <iostream>
 #include <limits>
+#include <memory>
+#include <vector>
 
 namespace autoware::behavior_path_planner::drivable_area_expansion
 {

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/drivable_area_expansion/map_utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/drivable_area_expansion/map_utils.cpp
@@ -20,6 +20,8 @@
 #include <lanelet2_core/primitives/LineString.h>
 
 #include <algorithm>
+#include <string>
+#include <vector>
 
 namespace autoware::behavior_path_planner::drivable_area_expansion
 {

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/drivable_area_expansion/static_drivable_area.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/drivable_area_expansion/static_drivable_area.cpp
@@ -29,6 +29,14 @@
 #include <lanelet2_core/geometry/Polygon.h>
 #include <lanelet2_routing/RoutingGraphContainer.h>
 
+#include <algorithm>
+#include <limits>
+#include <memory>
+#include <set>
+#include <string>
+#include <utility>
+#include <vector>
+
 namespace
 {
 template <class T>

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/parking_departure/geometric_parallel_parking.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/parking_departure/geometric_parallel_parking.cpp
@@ -27,6 +27,9 @@
 
 #include <lanelet2_core/geometry/Polygon.h>
 
+#include <algorithm>
+#include <limits>
+#include <memory>
 #include <optional>
 #include <utility>
 #include <vector>

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/parking_departure/utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/parking_departure/utils.cpp
@@ -19,6 +19,11 @@
 #include <autoware/motion_utils/distance/distance.hpp>
 #include <autoware_lanelet2_extension/utility/utilities.hpp>
 
+#include <algorithm>
+#include <memory>
+#include <utility>
+#include <vector>
+
 namespace autoware::behavior_path_planner::utils::parking_departure
 {
 

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/path_safety_checker/objects_filtering.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/path_safety_checker/objects_filtering.cpp
@@ -23,6 +23,10 @@
 #include <boost/geometry/algorithms/distance.hpp>
 
 #include <algorithm>
+#include <limits>
+#include <memory>
+#include <utility>
+#include <vector>
 
 namespace autoware::behavior_path_planner::utils::path_safety_checker::filter
 {

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/path_safety_checker/safety_check.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/path_safety_checker/safety_check.cpp
@@ -28,8 +28,12 @@
 
 #include <tf2/utils.h>
 
+#include <algorithm>
 #include <cmath>
 #include <limits>
+#include <string>
+#include <utility>
+#include <vector>
 
 namespace autoware::behavior_path_planner::utils::path_safety_checker
 {

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/path_shifter/path_shifter.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/path_shifter/path_shifter.cpp
@@ -20,6 +20,7 @@
 #include <autoware/motion_utils/trajectory/path_with_lane_id.hpp>
 #include <autoware_lanelet2_extension/utility/utilities.hpp>
 
+#include <algorithm>
 #include <string>
 #include <utility>
 #include <vector>

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/path_utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/path_utils.cpp
@@ -27,7 +27,9 @@
 #include <tf2/utils.h>
 
 #include <algorithm>
+#include <memory>
 #include <optional>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/traffic_light_utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/traffic_light_utils.cpp
@@ -16,6 +16,9 @@
 #include <autoware/motion_utils/trajectory/trajectory.hpp>
 #include <autoware/traffic_light_utils/traffic_light_utils.hpp>
 
+#include <limits>
+#include <memory>
+
 namespace autoware::behavior_path_planner::utils::traffic_light
 {
 using autoware::motion_utils::calcSignedArcLength;

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/utils.cpp
@@ -33,7 +33,9 @@
 #include <algorithm>
 #include <limits>
 #include <memory>
+#include <set>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/test/test_drivable_area_expansion.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/test/test_drivable_area_expansion.cpp
@@ -21,6 +21,8 @@
 #include <gtest/gtest.h>
 #include <lanelet2_core/LaneletMap.h>
 
+#include <memory>
+
 using autoware::behavior_path_planner::drivable_area_expansion::LineString2d;
 using autoware::behavior_path_planner::drivable_area_expansion::Point2d;
 using autoware::behavior_path_planner::drivable_area_expansion::Segment2d;

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/test/test_objects_filtering.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/test/test_objects_filtering.cpp
@@ -26,6 +26,7 @@
 #include <gtest/gtest.h>
 #include <lanelet2_core/Forward.h>
 
+#include <algorithm>
 #include <cmath>
 #include <memory>
 #include <vector>

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/test/test_parking_departure_utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/test/test_parking_departure_utils.cpp
@@ -23,6 +23,9 @@
 #include <lanelet2_core/Forward.h>
 
 #include <cstddef>
+#include <memory>
+#include <utility>
+#include <vector>
 
 constexpr double epsilon = 1e-6;
 

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/test/test_path_shifter.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/test/test_path_shifter.cpp
@@ -21,6 +21,9 @@
 
 #include <gtest/gtest.h>
 
+#include <utility>
+#include <vector>
+
 namespace autoware::behavior_path_planner
 {
 

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/test/test_path_utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/test/test_path_utils.cpp
@@ -22,6 +22,7 @@
 #include <gtest/gtest.h>
 
 #include <cstddef>
+#include <vector>
 
 using tier4_planning_msgs::msg::PathWithLaneId;
 

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/test/test_static_drivable_area.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/test/test_static_drivable_area.cpp
@@ -32,6 +32,7 @@
 #include <lanelet2_core/primitives/Point.h>
 
 #include <memory>
+#include <vector>
 
 const auto intersection_map =
   autoware::test_utils::make_map_bin_msg(autoware::test_utils::get_absolute_path_to_lanelet_map(

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/test/test_utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/test/test_utils.cpp
@@ -22,7 +22,9 @@
 
 #include <cmath>
 #include <cstddef>
+#include <limits>
 #include <memory>
+#include <string>
 
 using autoware::universe_utils::Point2d;
 using autoware_perception_msgs::msg::PredictedObject;

--- a/planning/behavior_path_planner/autoware_behavior_path_sampling_planner_module/src/sampling_planner_module.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_sampling_planner_module/src/sampling_planner_module.cpp
@@ -14,6 +14,15 @@
 
 #include "autoware/behavior_path_sampling_planner_module/sampling_planner_module.hpp"
 
+#include <algorithm>
+#include <iostream>
+#include <limits>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
 namespace autoware::behavior_path_planner
 {
 using autoware::motion_utils::calcSignedArcLength;

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/scene.cpp
@@ -26,6 +26,7 @@
 #include <algorithm>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace autoware::behavior_path_planner
 {

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/test/test_behavior_path_planner_node_interface.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/test/test_behavior_path_planner_node_interface.cpp
@@ -21,6 +21,8 @@
 #include <gtest/gtest.h>
 
 #include <cmath>
+#include <memory>
+#include <string>
 #include <vector>
 
 using autoware::behavior_path_planner::BehaviorPathPlannerNode;

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/test/test_side_shift_utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/test/test_side_shift_utils.cpp
@@ -19,6 +19,8 @@
 #include <tf2/LinearMath/Quaternion.h>
 #include <tf2/utils.h>
 
+#include <vector>
+
 namespace autoware::behavior_path_planner
 {
 

--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/freespace_pull_out.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/freespace_pull_out.cpp
@@ -21,6 +21,8 @@
 
 #include <autoware_lanelet2_extension/utility/utilities.hpp>
 
+#include <algorithm>
+#include <limits>
 #include <memory>
 #include <vector>
 

--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/geometric_pull_out.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/geometric_pull_out.cpp
@@ -22,6 +22,10 @@
 
 #include <autoware_lanelet2_extension/utility/utilities.hpp>
 
+#include <limits>
+#include <memory>
+#include <utility>
+
 using autoware::motion_utils::findNearestIndex;
 using autoware::universe_utils::calcDistance2d;
 using autoware::universe_utils::calcOffsetPose;

--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/shift_pull_out.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/shift_pull_out.cpp
@@ -25,7 +25,10 @@
 #include <autoware/motion_utils/trajectory/path_shift.hpp>
 #include <autoware_lanelet2_extension/utility/utilities.hpp>
 
+#include <algorithm>
+#include <limits>
 #include <memory>
+#include <utility>
 #include <vector>
 
 using autoware::motion_utils::findNearestIndex;

--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/start_planner_module.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/start_planner_module.cpp
@@ -34,9 +34,13 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstdio>
+#include <limits>
+#include <map>
 #include <memory>
 #include <optional>
 #include <string>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 

--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/debug.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/debug.cpp
@@ -20,6 +20,8 @@
 #include <autoware_lanelet2_extension/visualization/visualization.hpp>
 #include <magic_enum.hpp>
 
+#include <algorithm>
+#include <memory>
 #include <string>
 #include <vector>
 

--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/scene.cpp
@@ -35,6 +35,7 @@
 #include <optional>
 #include <set>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 namespace autoware::behavior_path_planner

--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/shift_line_generator.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/shift_line_generator.cpp
@@ -17,6 +17,11 @@
 #include "autoware/behavior_path_planner_common/utils/utils.hpp"
 #include "autoware/behavior_path_static_obstacle_avoidance_module/utils.hpp"
 
+#include <algorithm>
+#include <string>
+#include <utility>
+#include <vector>
+
 namespace autoware::behavior_path_planner::utils::static_obstacle_avoidance
 {
 

--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/utils.cpp
@@ -37,6 +37,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace autoware::behavior_path_planner::utils::static_obstacle_avoidance

--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/test/test_behavior_path_planner_node_interface.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/test/test_behavior_path_planner_node_interface.cpp
@@ -18,6 +18,8 @@
 #include <autoware_planning_test_manager/autoware_planning_test_manager.hpp>
 #include <autoware_test_utils/autoware_test_utils.hpp>
 
+#include <memory>
+#include <string>
 #include <vector>
 
 using autoware::behavior_path_planner::BehaviorPathPlannerNode;

--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/test/test_utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/test/test_utils.cpp
@@ -26,6 +26,9 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <limits>
+#include <memory>
+
 namespace autoware::behavior_path_planner::utils::static_obstacle_avoidance
 {
 

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/src/debug.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/src/debug.cpp
@@ -24,6 +24,7 @@
 #include <tf2/utils.h>
 
 #include <string>
+#include <vector>
 
 namespace autoware::behavior_velocity_planner
 {

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/scene_crosswalk.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/scene_crosswalk.cpp
@@ -35,7 +35,9 @@
 #include <functional>
 #include <limits>
 #include <set>
+#include <string>
 #include <tuple>
+#include <utility>
 #include <vector>
 
 namespace autoware::behavior_velocity_planner

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/scene_crosswalk.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/scene_crosswalk.hpp
@@ -39,6 +39,7 @@
 #include <pcl_conversions/pcl_conversions.h>
 
 #include <algorithm>
+#include <iostream>
 #include <memory>
 #include <optional>
 #include <string>

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/util.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/util.cpp
@@ -34,6 +34,7 @@
 #include <algorithm>
 #include <cmath>
 #include <memory>
+#include <set>
 #include <string>
 #include <vector>
 

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/test/test_crosswalk.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/test/test_crosswalk.cpp
@@ -16,6 +16,8 @@
 
 #include <gtest/gtest.h>
 
+#include <vector>
+
 TEST(CrosswalkTest, CheckInterpolateEgoPassMargin)
 {
   namespace bvp = autoware::behavior_velocity_planner;

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_detection_area_module/src/utils.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_detection_area_module/src/utils.cpp
@@ -22,7 +22,9 @@
 #include <lanelet2_core/Forward.h>
 #include <lanelet2_core/geometry/Point.h>
 
+#include <memory>
 #include <utility>
+#include <vector>
 
 namespace
 {

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/debug.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/debug.cpp
@@ -22,6 +22,8 @@
 
 #include <tf2/utils.h>
 
+#include <tuple>
+
 #ifdef ROS_DISTRO_GALACTIC
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 #else

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/decision_result.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/decision_result.cpp
@@ -14,6 +14,8 @@
 
 #include "decision_result.hpp"
 
+#include <string>
+
 namespace autoware::behavior_velocity_planner
 {
 std::string formatDecisionResult(

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/object_manager.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/object_manager.cpp
@@ -25,6 +25,8 @@
 #include <lanelet2_core/geometry/Lanelet.h>
 #include <lanelet2_core/geometry/LineString.h>
 
+#include <memory>
+#include <string>
 #include <vector>
 
 namespace

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_intersection.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_intersection.cpp
@@ -36,6 +36,9 @@
 #include <algorithm>
 #include <limits>
 #include <memory>
+#include <set>
+#include <string>
+#include <utility>
 #include <vector>
 
 namespace autoware::behavior_velocity_planner

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_intersection_collision.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_intersection_collision.cpp
@@ -30,6 +30,14 @@
 #include <fmt/format.h>
 #include <lanelet2_core/geometry/Polygon.h>
 
+#include <algorithm>
+#include <limits>
+#include <list>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
 namespace autoware::behavior_velocity_planner
 {
 namespace bg = boost::geometry;

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_intersection_occlusion.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_intersection_occlusion.cpp
@@ -23,7 +23,11 @@
 
 #include <lanelet2_core/geometry/Polygon.h>
 
+#include <algorithm>
+#include <limits>
 #include <tuple>
+#include <utility>
+#include <vector>
 
 namespace autoware::behavior_velocity_planner
 {

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_intersection_prepare_data.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_intersection_prepare_data.cpp
@@ -31,6 +31,13 @@
 #include <lanelet2_core/geometry/Polygon.h>
 #include <lanelet2_core/primitives/Point.h>
 
+#include <algorithm>
+#include <list>
+#include <set>
+#include <string>
+#include <utility>
+#include <vector>
+
 namespace autoware::universe_utils
 {
 

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_intersection_stuck.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_intersection_stuck.cpp
@@ -26,6 +26,10 @@
 #include <lanelet2_core/geometry/LineString.h>
 #include <lanelet2_core/geometry/Point.h>
 
+#include <algorithm>
+#include <string>
+#include <vector>
+
 namespace
 {
 lanelet::LineString3d getLineStringFromArcLength(

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_merge_from_private_road.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_merge_from_private_road.cpp
@@ -29,6 +29,7 @@
 #include <algorithm>
 #include <limits>
 #include <memory>
+#include <set>
 #include <string>
 #include <vector>
 

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/util.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/util.cpp
@@ -39,6 +39,7 @@
 #include <set>
 #include <string>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 namespace autoware::behavior_velocity_planner::util

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/test/test_util.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/test/test_util.cpp
@@ -20,6 +20,8 @@
 
 #include <gtest/gtest.h>
 
+#include <vector>
+
 TEST(TestUtil, retrievePathsBackward)
 {
   /*

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_no_drivable_lane_module/src/manager.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_no_drivable_lane_module/src/manager.cpp
@@ -17,6 +17,7 @@
 #include <autoware/behavior_velocity_planner_common/utilization/util.hpp>
 #include <autoware/universe_utils/ros/parameter.hpp>
 
+#include <memory>
 #include <string>
 
 namespace autoware::behavior_velocity_planner

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_no_drivable_lane_module/src/util.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_no_drivable_lane_module/src/util.cpp
@@ -23,6 +23,7 @@
 #include <lanelet2_core/geometry/Polygon.h>
 
 #include <algorithm>
+#include <vector>
 
 namespace autoware::behavior_velocity_planner
 {

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_no_stopping_area_module/src/utils.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_no_stopping_area_module/src/utils.cpp
@@ -26,6 +26,7 @@
 #include <lanelet2_core/geometry/Polygon.h>
 
 #include <limits>
+#include <vector>
 
 namespace autoware::behavior_velocity_planner::no_stopping_area
 {

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_occlusion_spot_module/src/grid_utils.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_occlusion_spot_module/src/grid_utils.cpp
@@ -15,6 +15,7 @@
 #include "grid_utils.hpp"
 
 #include <algorithm>
+#include <iostream>
 #include <limits>
 #include <stdexcept>
 #include <utility>

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_occlusion_spot_module/src/occlusion_spot_utils.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_occlusion_spot_module/src/occlusion_spot_utils.cpp
@@ -24,6 +24,7 @@
 #include <autoware/universe_utils/math/normalization.hpp>
 #include <rclcpp/rclcpp.hpp>
 
+#include <algorithm>
 #include <deque>
 #include <functional>
 #include <limits>

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_occlusion_spot_module/src/scene_occlusion_spot.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_occlusion_spot_module/src/scene_occlusion_spot.cpp
@@ -30,6 +30,7 @@
 
 #include <algorithm>
 #include <memory>
+#include <string>
 #include <vector>
 
 // turn on only when debugging.

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_occlusion_spot_module/test/src/test_grid_utils.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_occlusion_spot_module/test/src/test_grid_utils.cpp
@@ -21,7 +21,9 @@
 #include <gtest/gtest.h>
 
 #include <cmath>
+#include <iostream>
 #include <unordered_set>
+#include <vector>
 
 struct indexHash
 {

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_occlusion_spot_module/test/src/test_occlusion_spot_utils.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_occlusion_spot_module/test/src/test_occlusion_spot_utils.cpp
@@ -22,6 +22,9 @@
 #include "geometry_msgs/msg/point.hpp"
 #include "geometry_msgs/msg/vector3.hpp"
 
+#include <iostream>
+#include <vector>
+
 using Point = geometry_msgs::msg::Point;
 using Vector3 = geometry_msgs::msg::Vector3;
 using DynamicObjects = autoware_perception_msgs::msg::PredictedObjects;

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/src/node.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/src/node.cpp
@@ -28,6 +28,8 @@
 #include <lanelet2_routing/Route.h>
 #include <pcl/common/transforms.h>
 #include <pcl_conversions/pcl_conversions.h>
+
+#include <string>
 #ifdef ROS_DISTRO_GALACTIC
 #include <tf2_eigen/tf2_eigen.h>
 #else

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/test/src/test_node_interface.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/test/src/test_node_interface.cpp
@@ -21,6 +21,8 @@
 #include <gtest/gtest.h>
 
 #include <cmath>
+#include <memory>
+#include <string>
 #include <vector>
 
 using autoware::behavior_velocity_planner::BehaviorVelocityPlannerNode;

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/src/scene_module_interface.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/src/scene_module_interface.cpp
@@ -22,6 +22,8 @@
 #include <algorithm>
 #include <limits>
 #include <memory>
+#include <string>
+#include <vector>
 
 namespace autoware::behavior_velocity_planner
 {

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/src/utilization/debug.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/src/utilization/debug.cpp
@@ -15,6 +15,9 @@
 #include <autoware/behavior_velocity_planner_common/utilization/debug.hpp>
 #include <autoware/behavior_velocity_planner_common/utilization/util.hpp>
 #include <autoware/universe_utils/ros/marker_helper.hpp>
+
+#include <string>
+#include <vector>
 namespace autoware::behavior_velocity_planner
 {
 namespace debug

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/src/utilization/trajectory_utils.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/src/utilization/trajectory_utils.cpp
@@ -25,6 +25,10 @@
 
 #include <tf2/utils.h>
 
+#include <iostream>
+#include <utility>
+#include <vector>
+
 #ifdef ROS_DISTRO_GALACTIC
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 #else

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/src/utilization/util.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/src/utilization/util.cpp
@@ -25,6 +25,9 @@
 #include <lanelet2_routing/RoutingGraph.h>
 #include <tf2/utils.h>
 
+#include <iostream>
+#include <set>
+
 #ifdef ROS_DISTRO_GALACTIC
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 #else

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/test/src/test_utilization.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/test/src/test_utilization.cpp
@@ -22,6 +22,7 @@
 #include <gtest/gtest.h>
 
 #include <iostream>
+#include <vector>
 
 #define DEBUG_PRINT_PATH(path)                                                        \
   {                                                                                   \

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_run_out_module/src/debug.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_run_out_module/src/debug.cpp
@@ -20,6 +20,9 @@
 #include <autoware/universe_utils/geometry/geometry.hpp>
 #include <autoware/universe_utils/ros/marker_helper.hpp>
 
+#include <string>
+#include <vector>
+
 using autoware::universe_utils::appendMarkerArray;
 using autoware::universe_utils::calcOffsetPose;
 using autoware::universe_utils::createDefaultMarker;

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_run_out_module/src/dynamic_obstacle.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_run_out_module/src/dynamic_obstacle.cpp
@@ -28,7 +28,9 @@
 
 #include <algorithm>
 #include <limits>
+#include <memory>
 #include <string>
+#include <vector>
 
 namespace autoware::behavior_velocity_planner
 {

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_run_out_module/src/manager.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_run_out_module/src/manager.cpp
@@ -16,6 +16,7 @@
 
 #include <autoware/universe_utils/ros/parameter.hpp>
 
+#include <memory>
 #include <string>
 #include <utility>
 #include <vector>

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_run_out_module/src/path_utils.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_run_out_module/src/path_utils.cpp
@@ -15,6 +15,9 @@
 #include "path_utils.hpp"
 
 #include <autoware/motion_utils/trajectory/trajectory.hpp>
+
+#include <limits>
+#include <vector>
 namespace autoware::behavior_velocity_planner::run_out_utils
 {
 /**

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_run_out_module/src/scene.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_run_out_module/src/scene.cpp
@@ -32,7 +32,9 @@
 
 #include <algorithm>
 #include <limits>
+#include <memory>
 #include <utility>
+#include <vector>
 
 namespace autoware::behavior_velocity_planner
 {

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_run_out_module/src/state_machine.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_run_out_module/src/state_machine.cpp
@@ -14,6 +14,8 @@
 
 #include "state_machine.hpp"
 
+#include <string>
+
 namespace autoware::behavior_velocity_planner
 {
 namespace run_out_utils

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_run_out_module/src/utils.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_run_out_module/src/utils.cpp
@@ -25,6 +25,8 @@
 
 #include <algorithm>
 #include <limits>
+#include <string>
+#include <vector>
 
 #ifdef ROS_DISTRO_GALACTIC
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_speed_bump_module/src/scene.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_speed_bump_module/src/scene.cpp
@@ -20,6 +20,9 @@
 
 #include <rclcpp/rclcpp.hpp>
 
+#include <iostream>
+#include <utility>
+
 namespace autoware::behavior_velocity_planner
 {
 using autoware::motion_utils::calcSignedArcLength;

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_stop_line_module/src/scene.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_stop_line_module/src/scene.cpp
@@ -21,6 +21,7 @@
 #include <tier4_planning_msgs/msg/path_with_lane_id.hpp>
 
 #include <optional>
+#include <utility>
 
 namespace autoware::behavior_velocity_planner
 {

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/src/scene.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/src/scene.cpp
@@ -25,6 +25,8 @@
 
 #include <tf2/utils.h>
 
+#include <memory>
+
 #ifdef ROS_DISTRO_GALACTIC
 #include <tf2_eigen/tf2_eigen.h>
 #else

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/src/utils.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/src/utils.cpp
@@ -19,6 +19,8 @@
 #include <boost/geometry/algorithms/distance.hpp>
 #include <boost/geometry/algorithms/intersection.hpp>
 
+#include <vector>
+
 namespace autoware::behavior_velocity_planner
 {
 namespace bg = boost::geometry;

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_virtual_traffic_light_module/src/debug.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_virtual_traffic_light_module/src/debug.cpp
@@ -18,6 +18,8 @@
 #include <autoware/motion_utils/marker/virtual_wall_marker_creator.hpp>
 #include <autoware/universe_utils/math/constants.hpp>
 #include <autoware/universe_utils/ros/marker_helper.hpp>
+
+#include <vector>
 using autoware::motion_utils::createStopVirtualWallMarker;
 using autoware::universe_utils::appendMarkerArray;
 using autoware::universe_utils::createDefaultMarker;

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_virtual_traffic_light_module/src/utils.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_virtual_traffic_light_module/src/utils.cpp
@@ -20,6 +20,8 @@
 #include <autoware/universe_utils/geometry/geometry.hpp>
 
 #include <limits>
+#include <string>
+#include <vector>
 
 namespace autoware::behavior_velocity_planner::virtual_traffic_light
 {

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_virtual_traffic_light_module/test/test_utils.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_virtual_traffic_light_module/test/test_utils.cpp
@@ -19,7 +19,9 @@
 
 #include <gtest/gtest.h>
 
+#include <iostream>
 #include <memory>
+#include <vector>
 
 using autoware::behavior_velocity_planner::virtual_traffic_light::calcCenter;
 using autoware::behavior_velocity_planner::virtual_traffic_light::calcHeadPose;

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_walkway_module/src/scene_walkway.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_walkway_module/src/scene_walkway.cpp
@@ -18,6 +18,7 @@
 #include <autoware/motion_utils/trajectory/trajectory.hpp>
 
 #include <cmath>
+#include <utility>
 
 namespace autoware::behavior_velocity_planner
 {

--- a/planning/motion_velocity_planner/autoware_motion_velocity_dynamic_obstacle_stop_module/src/object_stop_decision.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_dynamic_obstacle_stop_module/src/object_stop_decision.cpp
@@ -17,6 +17,7 @@
 #include <autoware/motion_utils/trajectory/trajectory.hpp>
 
 #include <limits>
+#include <vector>
 
 namespace autoware::motion_velocity_planner::dynamic_obstacle_stop
 {

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_velocity_limiter_module/benchmarks/collision_checker_benchmark.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_velocity_limiter_module/benchmarks/collision_checker_benchmark.cpp
@@ -17,6 +17,7 @@
 
 #include <chrono>
 #include <random>
+#include <vector>
 
 using autoware::motion_velocity_planner::obstacle_velocity_limiter::CollisionChecker;
 using autoware::motion_velocity_planner::obstacle_velocity_limiter::linestring_t;

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_velocity_limiter_module/src/debug.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_velocity_limiter_module/src/debug.cpp
@@ -20,6 +20,7 @@
 #include <visualization_msgs/msg/marker_array.hpp>
 
 #include <algorithm>
+#include <vector>
 
 namespace autoware::motion_velocity_planner::obstacle_velocity_limiter
 {

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_velocity_limiter_module/src/map_utils.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_velocity_limiter_module/src/map_utils.cpp
@@ -23,6 +23,8 @@
 #include <lanelet2_core/geometry/LaneletMap.h>
 
 #include <algorithm>
+#include <string>
+#include <vector>
 
 namespace autoware::motion_velocity_planner::obstacle_velocity_limiter
 {

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_velocity_limiter_module/src/obstacle_velocity_limiter.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_velocity_limiter_module/src/obstacle_velocity_limiter.cpp
@@ -23,6 +23,7 @@
 #include <boost/geometry/algorithms/correct.hpp>
 
 #include <algorithm>
+#include <vector>
 
 namespace autoware::motion_velocity_planner::obstacle_velocity_limiter
 {

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_velocity_limiter_module/src/obstacle_velocity_limiter_module.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_velocity_limiter_module/src/obstacle_velocity_limiter_module.cpp
@@ -33,6 +33,9 @@
 
 #include <chrono>
 #include <map>
+#include <memory>
+#include <string>
+#include <vector>
 
 namespace autoware::motion_velocity_planner
 {

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_velocity_limiter_module/test/test_forward_projection.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_velocity_limiter_module/test/test_forward_projection.cpp
@@ -24,6 +24,7 @@
 #include <gtest/gtest.h>
 
 #include <algorithm>
+#include <iostream>
 
 constexpr auto EPS = 1e-15;
 constexpr auto EPS_APPROX = 1e-3;

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/src/collision_checker.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/src/collision_checker.cpp
@@ -14,6 +14,10 @@
 
 #include "autoware/motion_velocity_planner_common/collision_checker.hpp"
 
+#include <memory>
+#include <utility>
+#include <vector>
+
 namespace autoware::motion_velocity_planner
 {
 CollisionChecker::CollisionChecker(autoware::universe_utils::MultiPolygon2d trajectory_footprints)

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/test/test_collision_checker.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/test/test_collision_checker.cpp
@@ -19,6 +19,8 @@
 #include <gtest/gtest.h>
 
 #include <chrono>
+#include <cstdio>
+#include <iostream>
 #include <random>
 
 using autoware::motion_velocity_planner::CollisionChecker;

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_node/src/node.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_node/src/node.cpp
@@ -36,6 +36,7 @@
 #include <functional>
 #include <map>
 #include <memory>
+#include <string>
 #include <vector>
 
 namespace

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_node/src/planner_manager.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_node/src/planner_manager.cpp
@@ -18,6 +18,7 @@
 
 #include <memory>
 #include <string>
+#include <vector>
 
 namespace autoware::motion_velocity_planner
 {

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_node/test/src/test_node_interface.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_node/test/src/test_node_interface.cpp
@@ -20,6 +20,8 @@
 
 #include <gtest/gtest.h>
 
+#include <memory>
+#include <string>
 #include <vector>
 
 using autoware::motion_velocity_planner::MotionVelocityPlannerNode;

--- a/planning/sampling_based_planner/autoware_bezier_sampler/src/bezier.cpp
+++ b/planning/sampling_based_planner/autoware_bezier_sampler/src/bezier.cpp
@@ -15,6 +15,9 @@
 #include <autoware_bezier_sampler/bezier.hpp>
 
 #include <iostream>
+#include <limits>
+#include <utility>
+#include <vector>
 
 namespace autoware::bezier_sampler
 {

--- a/planning/sampling_based_planner/autoware_bezier_sampler/src/bezier_sampling.cpp
+++ b/planning/sampling_based_planner/autoware_bezier_sampler/src/bezier_sampling.cpp
@@ -14,6 +14,8 @@
 
 #include <autoware_bezier_sampler/bezier_sampling.hpp>
 
+#include <vector>
+
 namespace autoware::bezier_sampler
 {
 std::vector<Bezier> sample(

--- a/planning/sampling_based_planner/autoware_frenet_planner/src/frenet_planner/frenet_planner.cpp
+++ b/planning/sampling_based_planner/autoware_frenet_planner/src/frenet_planner/frenet_planner.cpp
@@ -30,6 +30,7 @@
 #include <algorithm>
 #include <cmath>
 #include <iostream>
+#include <vector>
 
 namespace autoware::frenet_planner
 {

--- a/planning/sampling_based_planner/autoware_path_sampler/src/node.cpp
+++ b/planning/sampling_based_planner/autoware_path_sampler/src/node.cpp
@@ -27,8 +27,11 @@
 
 #include <boost/geometry/algorithms/distance.hpp>
 
+#include <algorithm>
 #include <chrono>
 #include <limits>
+#include <string>
+#include <vector>
 
 namespace autoware::path_sampler
 {

--- a/planning/sampling_based_planner/autoware_path_sampler/src/prepare_inputs.cpp
+++ b/planning/sampling_based_planner/autoware_path_sampler/src/prepare_inputs.cpp
@@ -25,6 +25,7 @@
 #include <boost/geometry/geometry.hpp>
 
 #include <algorithm>
+#include <limits>
 #include <list>
 #include <memory>
 #include <vector>

--- a/planning/sampling_based_planner/autoware_sampler_common/src/sampler_common/transform/spline_transform.cpp
+++ b/planning/sampling_based_planner/autoware_sampler_common/src/sampler_common/transform/spline_transform.cpp
@@ -18,6 +18,7 @@
 #include <cmath>
 #include <iostream>
 #include <limits>
+#include <vector>
 
 namespace autoware::sampler_common::transform
 {

--- a/planning/sampling_based_planner/autoware_sampler_common/test/test_transform.cpp
+++ b/planning/sampling_based_planner/autoware_sampler_common/test/test_transform.cpp
@@ -17,8 +17,10 @@
 #include <gtest/gtest.h>
 
 #include <chrono>
+#include <iostream>
 #include <random>
 #include <ratio>
+#include <vector>
 
 constexpr auto TOL = 1E-6;  // 1µm tolerance
 


### PR DESCRIPTION
## Description

**Parent Issue:**
- https://github.com/autowarefoundation/autoware.universe/issues/9556

Extracted from:
- https://github.com/autowarefoundation/autoware.universe/pull/9558

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
