### PR TITLE
feat(lidar_centerpoint, pointpainting)!: move max_voxel_count from _ml_package.param.yaml

### DIFF
--- a/perception/autoware_image_projection_based_fusion/config/pointpainting.param.yaml
+++ b/perception/autoware_image_projection_based_fusion/config/pointpainting.param.yaml
@@ -20,3 +20,4 @@
     omp_params:
       # omp params
       num_threads: 1
+    max_voxel_size: 40000

--- a/perception/autoware_image_projection_based_fusion/config/pointpainting_ml_package.param.yaml
+++ b/perception/autoware_image_projection_based_fusion/config/pointpainting_ml_package.param.yaml
@@ -4,7 +4,6 @@
       class_names: ["CAR", "TRUCK", "BUS", "BICYCLE", "PEDESTRIAN"]
       paint_class_names: ["CAR", "BICYCLE", "PEDESTRIAN"]
       point_feature_size: 7 # x, y, z, time-lag and car, pedestrian, bicycle
-      max_voxel_size: 40000
       point_cloud_range: [-121.6, -76.8, -3.0, 121.6, 76.8, 5.0]
       voxel_size: [0.32, 0.32, 8.0]
       downsample_factor: 1

--- a/perception/autoware_image_projection_based_fusion/src/pointpainting_fusion/node.cpp
+++ b/perception/autoware_image_projection_based_fusion/src/pointpainting_fusion/node.cpp
@@ -142,7 +142,7 @@ PointPaintingFusionNode::PointPaintingFusionNode(const rclcpp::NodeOptions & opt
   const std::size_t point_feature_size = static_cast<std::size_t>(
     this->declare_parameter<std::int64_t>("model_params.point_feature_size"));
   const std::size_t max_voxel_size =
-    static_cast<std::size_t>(this->declare_parameter<std::int64_t>("model_params.max_voxel_size"));
+    static_cast<std::size_t>(this->declare_parameter<std::int64_t>("max_voxel_size"));
   pointcloud_range = this->declare_parameter<std::vector<double>>("model_params.point_cloud_range");
   const auto voxel_size = this->declare_parameter<std::vector<double>>("model_params.voxel_size");
   const std::size_t downsample_factor = static_cast<std::size_t>(

--- a/perception/autoware_lidar_centerpoint/README.md
+++ b/perception/autoware_lidar_centerpoint/README.md
@@ -36,7 +36,6 @@ Note that these parameters are associated with ONNX file, predefined during the 
 | -------------------------------------- | ------------ | ------------------------------------------------ | --------------------------------------------------------------------- |
 | `model_params.class_names`             | list[string] | ["CAR", "TRUCK", "BUS", "BICYCLE", "PEDESTRIAN"] | list of class names for model outputs                                 |
 | `model_params.point_feature_size`      | int          | `4`                                              | number of features per point in the point cloud                       |
-| `model_params.max_voxel_size`          | int          | `40000`                                          | maximum number of voxels                                              |
 | `model_params.point_cloud_range`       | list[double] | [-76.8, -76.8, -4.0, 76.8, 76.8, 6.0]            | detection range [min_x, min_y, min_z, max_x, max_y, max_z] [m]        |
 | `model_params.voxel_size`              | list[double] | [0.32, 0.32, 10.0]                               | size of each voxel [x, y, z] [m]                                      |
 | `model_params.downsample_factor`       | int          | `1`                                              | downsample factor for coordinates                                     |
@@ -62,6 +61,7 @@ Note that these parameters are associated with ONNX file, predefined during the 
 | `post_process_params.has_twist`                  | boolean      | false                     | Indicates whether the model outputs twist value.              |
 | `densification_params.world_frame_id`            | string       | `map`                     | the world frame id to fuse multi-frame pointcloud             |
 | `densification_params.num_past_frames`           | int          | `1`                       | the number of past frames to fuse with the current frame      |
+| `max_voxel_size`          | int          | `40000`                                          | maximum number of voxels                                              |
 
 ### The `build_only` option
 

--- a/perception/autoware_lidar_centerpoint/config/centerpoint.param.yaml
+++ b/perception/autoware_lidar_centerpoint/config/centerpoint.param.yaml
@@ -18,3 +18,4 @@
     densification_params:
       world_frame_id: map
       num_past_frames: 1
+    max_voxel_size: 40000

--- a/perception/autoware_lidar_centerpoint/config/centerpoint_ml_package.param.yaml
+++ b/perception/autoware_lidar_centerpoint/config/centerpoint_ml_package.param.yaml
@@ -3,7 +3,6 @@
     model_params:
       class_names: ["CAR", "TRUCK", "BUS", "BICYCLE", "PEDESTRIAN"]
       point_feature_size: 4
-      max_voxel_size: 40000
       point_cloud_range: [-76.8, -76.8, -4.0, 76.8, 76.8, 6.0]
       voxel_size: [0.32, 0.32, 10.0]
       downsample_factor: 1

--- a/perception/autoware_lidar_centerpoint/config/centerpoint_sigma.param.yaml
+++ b/perception/autoware_lidar_centerpoint/config/centerpoint_sigma.param.yaml
@@ -19,3 +19,4 @@
     densification_params:
       world_frame_id: map
       num_past_frames: 1
+    max_voxel_size: 40000

--- a/perception/autoware_lidar_centerpoint/config/centerpoint_sigma_ml_package.param.yaml
+++ b/perception/autoware_lidar_centerpoint/config/centerpoint_sigma_ml_package.param.yaml
@@ -3,7 +3,6 @@
     model_params:
       class_names: ["CAR", "TRUCK", "BUS", "BICYCLE", "PEDESTRIAN"]
       point_feature_size: 4
-      max_voxel_size: 40000
       point_cloud_range: [-76.8, -76.8, -4.0, 76.8, 76.8, 6.0]
       voxel_size: [0.32, 0.32, 10.0]
       downsample_factor: 1

--- a/perception/autoware_lidar_centerpoint/config/centerpoint_tiny.param.yaml
+++ b/perception/autoware_lidar_centerpoint/config/centerpoint_tiny.param.yaml
@@ -18,3 +18,4 @@
     densification_params:
       world_frame_id: map
       num_past_frames: 1
+    max_voxel_size: 40000

--- a/perception/autoware_lidar_centerpoint/config/centerpoint_tiny_ml_package.param.yaml
+++ b/perception/autoware_lidar_centerpoint/config/centerpoint_tiny_ml_package.param.yaml
@@ -3,7 +3,6 @@
     model_params:
       class_names: ["CAR", "TRUCK", "BUS", "BICYCLE", "PEDESTRIAN"]
       point_feature_size: 4
-      max_voxel_size: 40000
       point_cloud_range: [-76.8, -76.8, -4.0, 76.8, 76.8, 6.0]
       voxel_size: [0.32, 0.32, 10.0]
       downsample_factor: 2

--- a/perception/autoware_lidar_centerpoint/src/node.cpp
+++ b/perception/autoware_lidar_centerpoint/src/node.cpp
@@ -62,7 +62,7 @@ LidarCenterPointNode::LidarCenterPointNode(const rclcpp::NodeOptions & node_opti
     this->declare_parameter<std::int64_t>("model_params.point_feature_size"));
   has_variance_ = this->declare_parameter<bool>("model_params.has_variance");
   const std::size_t max_voxel_size =
-    static_cast<std::size_t>(this->declare_parameter<std::int64_t>("model_params.max_voxel_size"));
+    static_cast<std::size_t>(this->declare_parameter<std::int64_t>("max_voxel_size"));
   const auto point_cloud_range =
     this->declare_parameter<std::vector<double>>("model_params.point_cloud_range");
   const auto voxel_size = this->declare_parameter<std::vector<double>>("model_params.voxel_size");


### PR DESCRIPTION
## Description
Since `max_voxel_count` is likely to be tuned for each vehicle / environment, I would like to move this parameter from `*_ml_package.param.yaml` to `*.param.yaml`.

## Related links
None

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

#### Modifications

| Version | Parameter Name   | 
|:--------|:-----------------|
| Old     | `model_params.max_voxel_count` |
| New     | `new_param_name` |

## Effects on system behavior

None.
