### PR TITLE
feat(costmap_generator, scenario_selector): improve freespace planning stability

### DIFF
--- a/planning/autoware_costmap_generator/include/autoware/costmap_generator/costmap_generator.hpp
+++ b/planning/autoware_costmap_generator/include/autoware/costmap_generator/costmap_generator.hpp
@@ -139,6 +139,13 @@ private:
 
   void set_current_pose();
 
+  /// \brief set position of grid center
+  /// \details computes relative position of ego from current grid center,
+  /// if offset is larger than grid resolution, grid center will be updated
+  /// by a multiple of the grid resolution
+  /// \param[in] tf costmap frame to vehicle frame transform
+  void set_grid_center(const geometry_msgs::msg::TransformStamped & tf);
+
   void onTimer();
 
   bool isActive();
@@ -148,7 +155,9 @@ private:
 
   /// \brief publish ros msg: grid_map::GridMap, and nav_msgs::OccupancyGrid
   /// \param[in] gridmap with calculated cost
-  void publishCostmap(const grid_map::GridMap & costmap);
+  /// \param[in] tf costmap frame to vehicle frame transform
+  void publishCostmap(
+    const grid_map::GridMap & costmap, const geometry_msgs::msg::TransformStamped & tf);
 
   /// \brief fill a vector with road area polygons
   /// \param [in] lanelet_map input lanelet map

--- a/planning/autoware_costmap_generator/src/costmap_generator.cpp
+++ b/planning/autoware_costmap_generator/src/costmap_generator.cpp
@@ -316,9 +316,9 @@ void CostmapGenerator::set_grid_center(const geometry_msgs::msg::TransformStampe
   const auto cur_pos = costmap_.getPosition();
   const grid_map::Position ref_pos(tf.transform.translation.x, tf.transform.translation.y);
   const auto disp = ref_pos - cur_pos;
-  const auto resol = costmap_.getResolution();
+  const auto resolution = costmap_.getResolution();
   const grid_map::Position offset(
-    std::round(disp.x() / resol) * resol, std::round(disp.y() / resol) * resol);
+    std::round(disp.x() / resolution) * resolution, std::round(disp.y() / resolution) * resolution);
   costmap_.setPosition(cur_pos + offset);
 }
 

--- a/planning/autoware_costmap_generator/src/costmap_generator.cpp
+++ b/planning/autoware_costmap_generator/src/costmap_generator.cpp
@@ -286,11 +286,7 @@ void CostmapGenerator::onTimer()
   }
   time_keeper_->end_track("lookupTransform");
 
-  // Set grid center
-  grid_map::Position p;
-  p.x() = tf.transform.translation.x;
-  p.y() = tf.transform.translation.y;
-  costmap_.setPosition(p);
+  set_grid_center(tf);
 
   if ((param_->use_wayarea || param_->use_parkinglot) && lanelet_map_) {
     autoware::universe_utils::ScopedTimeTrack st("generatePrimitivesCostmap()", *time_keeper_);
@@ -312,7 +308,18 @@ void CostmapGenerator::onTimer()
     costmap_[LayerName::combined] = generateCombinedCostmap();
   }
 
-  publishCostmap(costmap_);
+  publishCostmap(costmap_, tf);
+}
+
+void CostmapGenerator::set_grid_center(const geometry_msgs::msg::TransformStamped & tf)
+{
+  const auto cur_pos = costmap_.getPosition();
+  const grid_map::Position ref_pos(tf.transform.translation.x, tf.transform.translation.y);
+  const auto disp = ref_pos - cur_pos;
+  const auto resol = costmap_.getResolution();
+  const grid_map::Position offset(
+    std::round(disp.x() / resol) * resol, std::round(disp.y() / resol) * resol);
+  costmap_.setPosition(cur_pos + offset);
 }
 
 bool CostmapGenerator::isActive()
@@ -452,7 +459,8 @@ grid_map::Matrix CostmapGenerator::generateCombinedCostmap()
   return combined_costmap[LayerName::combined];
 }
 
-void CostmapGenerator::publishCostmap(const grid_map::GridMap & costmap)
+void CostmapGenerator::publishCostmap(
+  const grid_map::GridMap & costmap, const geometry_msgs::msg::TransformStamped & tf)
 {
   // Set header
   std_msgs::msg::Header header;
@@ -465,11 +473,13 @@ void CostmapGenerator::publishCostmap(const grid_map::GridMap & costmap)
     costmap, LayerName::combined, param_->grid_min_value, param_->grid_max_value,
     out_occupancy_grid);
   out_occupancy_grid.header = header;
+  out_occupancy_grid.info.origin.position.z = tf.transform.translation.z;
   pub_occupancy_grid_->publish(out_occupancy_grid);
 
   // Publish GridMap
   auto out_gridmap_msg = grid_map::GridMapRosConverter::toMessage(costmap);
   out_gridmap_msg->header = header;
+  out_gridmap_msg->info.pose.position.z = tf.transform.translation.z;
   pub_costmap_->publish(*out_gridmap_msg);
 
   // Publish ProcessingTime


### PR DESCRIPTION
## Description

In parking scenario, ego can sometimes get stuck when navigating close to freespace area boundary. This happens due to the inconsistency of costmap evaluation at the boundaries.
As shown below, Initially freespace generates a valid trajectory, but as ego moves the costmap evaluation fluctuates, and the endpoint of the forward trajectory becomes invalid, and freespace fails to generate a new trajectory.

https://github.com/user-attachments/assets/713a458d-c164-497b-87d5-f1dd5c5452bd

Another issue is, when ego is stuck for sometime in parking scenario, it will attempt to switch to lane driving (feature added in this [previous PR](https://github.com/autowarefoundation/autoware.universe/pull/8348)), However the logic for switching to lane driving doesn't guarantee ego pose is proper enough to follow lanelet route. Which can cause control error due to large deviation as shown below.

https://github.com/user-attachments/assets/0c3ac6bd-b9c1-48aa-a9f2-26365a7496a9

To fix the first issue (unstable costmap evaluation at boundary):
- instead of continuously setting grid center at ego position
- compute the relative position of ego wrt current grid center
- compute the offset as a multiple of grid resolution
- use offset to set the new position of grid center

To fix second issue (incorrect switching to lane driving):
- get closest lane to ego using distance and yaw constraints
- ensure ego is close enough to lane center line

The resulting behavior is shown below.

https://github.com/user-attachments/assets/5debd550-c398-4b98-be48-3c435c2021f2

## Related links

**Private Links:**

- [TIER IV internal link](https://star4.slack.com/archives/C03QW0GU6P7/p1732863756724719)

## How was this PR tested?
- PSIM.
- Scenario simulator

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

Described above.
