### PR TITLE
fix(goal_planner): fix isStopped judgement

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/goal_planner_module.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/goal_planner_module.hpp
@@ -159,7 +159,7 @@ bool checkOccupancyGridCollision(
 bool isStopped(
   std::deque<nav_msgs::msg::Odometry::ConstSharedPtr> & odometry_buffer,
   const nav_msgs::msg::Odometry::ConstSharedPtr self_odometry, const double duration_lower,
-  const double stopped_upper);
+  const double velocity_upper);
 
 // Flag class for managing whether a certain callback is running in multi-threading
 class ScopedFlag

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/goal_planner_module.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/goal_planner_module.hpp
@@ -158,7 +158,8 @@ bool checkOccupancyGridCollision(
 
 bool isStopped(
   std::deque<nav_msgs::msg::Odometry::ConstSharedPtr> & odometry_buffer,
-  const nav_msgs::msg::Odometry::ConstSharedPtr self_odometry, const double duration_lower);
+  const nav_msgs::msg::Odometry::ConstSharedPtr self_odometry, const double duration_lower,
+  const double stopped_upper);
 
 // Flag class for managing whether a certain callback is running in multi-threading
 class ScopedFlag

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/goal_planner_module.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/goal_planner_module.cpp
@@ -245,7 +245,7 @@ bool checkOccupancyGridCollision(
 bool isStopped(
   std::deque<nav_msgs::msg::Odometry::ConstSharedPtr> & odometry_buffer,
   const nav_msgs::msg::Odometry::ConstSharedPtr self_odometry, const double duration_lower,
-  const double velocity_uppper)
+  const double velocity_upper)
 {
   odometry_buffer.push_back(self_odometry);
   // Delete old data in buffer_stuck_
@@ -260,7 +260,7 @@ bool isStopped(
   bool is_stopped = true;
   for (const auto & odometry : odometry_buffer) {
     const double ego_vel = utils::l2Norm(odometry->twist.twist.linear);
-    if (ego_vel > velocity_uppper) {
+    if (ego_vel > velocity_upper) {
       is_stopped = false;
       break;
     }

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/goal_planner_module.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/goal_planner_module.cpp
@@ -244,7 +244,8 @@ bool checkOccupancyGridCollision(
 
 bool isStopped(
   std::deque<nav_msgs::msg::Odometry::ConstSharedPtr> & odometry_buffer,
-  const nav_msgs::msg::Odometry::ConstSharedPtr self_odometry, const double duration_lower)
+  const nav_msgs::msg::Odometry::ConstSharedPtr self_odometry, const double duration_lower,
+  const double velocity_uppper)
 {
   odometry_buffer.push_back(self_odometry);
   // Delete old data in buffer_stuck_
@@ -259,7 +260,7 @@ bool isStopped(
   bool is_stopped = true;
   for (const auto & odometry : odometry_buffer) {
     const double ego_vel = utils::l2Norm(odometry->twist.twist.linear);
-    if (ego_vel > duration_lower) {
+    if (ego_vel > velocity_uppper) {
       is_stopped = false;
       break;
     }
@@ -879,7 +880,8 @@ bool GoalPlannerModule::canReturnToLaneParking(const PullOverContextData & conte
 {
   // return only before starting free space parking
   if (!isStopped(
-        odometry_buffer_stopped_, planner_data_->self_odometry, parameters_->th_stopped_time)) {
+        odometry_buffer_stopped_, planner_data_->self_odometry, parameters_->th_stopped_time,
+        parameters_->th_stopped_velocity)) {
     return false;
   }
 
@@ -1760,7 +1762,9 @@ bool GoalPlannerModule::isStuck(
   }
 
   constexpr double stuck_time = 5.0;
-  if (!isStopped(odometry_buffer_stuck_, planner_data->self_odometry, stuck_time)) {
+  if (!isStopped(
+        odometry_buffer_stuck_, planner_data->self_odometry, stuck_time,
+        parameters_->th_stopped_velocity)) {
     return false;
   }
 
@@ -1801,7 +1805,8 @@ bool GoalPlannerModule::hasFinishedCurrentPath(const PullOverContextData & ctx_d
   }
 
   if (!isStopped(
-        odometry_buffer_stopped_, planner_data_->self_odometry, parameters_->th_stopped_time)) {
+        odometry_buffer_stopped_, planner_data_->self_odometry, parameters_->th_stopped_time,
+        parameters_->th_stopped_velocity)) {
     return false;
   }
 


### PR DESCRIPTION
## Description

in https://github.com/autowarefoundation/autoware.universe/pull/9522, time duration threshould is used for velocity check mistakenly.

![image](https://github.com/user-attachments/assets/679f4b67-0f99-43fb-88b1-b9e59d73ff63)


## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

psim with [scenario](https://evaluation.tier4.jp/evaluation/reports/53ab00d7-2644-5f98-9c0c-809b1b9b9f0e/tests/8bb4cf42-67d4-5d44-9137-e8d09b5793e5/9a60cdd1-dc7b-54c6-b80b-913c688b8916/46048113-55a7-5efe-a71d-92886a1b6761?project_id=prd_jt&state=failed#)

![image](https://github.com/user-attachments/assets/8a301cc0-a0d2-4db4-bbf7-4155ce2fb7ab)

2024/12/06 https://evaluation.tier4.jp/evaluation/reports/ede3fa66-17c1-590b-999d-3f21a2284947/?project_id=prd_jt

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
