### PR TITLE
fix(autoware_pointcloud_preprocessor): fix clang-diagnostic-unused-but-set-variable

### DIFF
--- a/planning/autoware_obstacle_cruise_planner/src/planner_interface.cpp
+++ b/planning/autoware_obstacle_cruise_planner/src/planner_interface.cpp
@@ -90,7 +90,7 @@ double findReachTime(
   double upper = max;
   double t;
   int iter = 0;
-  for (int i = 0;; i++) {
+  while (true) {
     t = 0.5 * (lower + upper);
     const double fx = f(t, j, a, v, d);
     // std::cout<<"fx: "<<fx<<" up: "<<upper<<" lo: "<<lower<<" t: "<<t<<std::endl;


### PR DESCRIPTION
## Description

This is a fix based on clang-tidy `clang-diagnostic-unused-but-set-variable` error.

```
/home/hisaki/workspace/autowarefoundation/autoware/src/universe/autoware.universe/planning/autoware_obstacle_cruise_planner/src/planner_interface.cpp:93:12: error: variable 'i' set but not used [clang-diagnostic-unused-but-set-variable]
  for (int i = 0;; i++) {
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
