### PR TITLE
fix(autoware_behavior_velocity_stop_line_module): remove unused function

### DIFF
--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_stop_line_module/src/scene.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_stop_line_module/src/scene.cpp
@@ -26,15 +26,6 @@
 namespace autoware::behavior_velocity_planner
 {
 
-geometry_msgs::msg::Point getCenterOfStopLine(const lanelet::ConstLineString3d & stop_line)
-{
-  geometry_msgs::msg::Point center_point;
-  center_point.x = (stop_line[0].x() + stop_line[1].x()) / 2.0;
-  center_point.y = (stop_line[0].y() + stop_line[1].y()) / 2.0;
-  center_point.z = (stop_line[0].z() + stop_line[1].z()) / 2.0;
-  return center_point;
-}
-
 StopLineModule::StopLineModule(
   const int64_t module_id, lanelet::ConstLineString3d stop_line, const PlannerParam & planner_param,
   const rclcpp::Logger & logger, const rclcpp::Clock::SharedPtr clock)


### PR DESCRIPTION
## Description

Removed cppcheck warning `unusedFunction` for `getCenterOfStopLine`
```
planning/behavior_velocity_planner/autoware_behavior_velocity_stop_line_module/src/scene.cpp:29:0: style: The function 'getCenterOfStopLine' is never used. [unusedFunction]
geometry_msgs::msg::Point getCenterOfStopLine(const lanelet::ConstLineString3d & stop_line)
^
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
