### PR TITLE
refactor(obstacle_cruise_planner)!: refactor rviz and terminal info

### DIFF
--- a/planning/autoware_obstacle_cruise_planner/include/autoware/obstacle_cruise_planner/common_structs.hpp
+++ b/planning/autoware_obstacle_cruise_planner/include/autoware/obstacle_cruise_planner/common_structs.hpp
@@ -169,12 +169,15 @@ struct CruiseObstacle : public TargetObstacleInterface
   CruiseObstacle(
     const std::string & arg_uuid, const rclcpp::Time & arg_stamp,
     const geometry_msgs::msg::Pose & arg_pose, const double arg_lon_velocity,
-    const double arg_lat_velocity, const std::vector<PointWithStamp> & arg_collision_points)
+    const double arg_lat_velocity, const std::vector<PointWithStamp> & arg_collision_points,
+    bool arg_is_yield_obstacle = false)
   : TargetObstacleInterface(arg_uuid, arg_stamp, arg_pose, arg_lon_velocity, arg_lat_velocity),
-    collision_points(arg_collision_points)
+    collision_points(arg_collision_points),
+    is_yield_obstacle(arg_is_yield_obstacle)
   {
   }
   std::vector<PointWithStamp> collision_points;  // time-series collision points
+  bool is_yield_obstacle;
 };
 
 struct SlowDownObstacle : public TargetObstacleInterface

--- a/planning/autoware_obstacle_cruise_planner/include/autoware/obstacle_cruise_planner/node.hpp
+++ b/planning/autoware_obstacle_cruise_planner/include/autoware/obstacle_cruise_planner/node.hpp
@@ -24,6 +24,7 @@
 #include "autoware/universe_utils/ros/polling_subscriber.hpp"
 #include "autoware/universe_utils/system/stop_watch.hpp"
 
+#include <autoware/objects_of_interest_marker_interface/objects_of_interest_marker_interface.hpp>
 #include <autoware/universe_utils/ros/published_time_publisher.hpp>
 #include <rclcpp/rclcpp.hpp>
 
@@ -180,6 +181,8 @@ private:
     this, "~/input/pointcloud"};
   autoware::universe_utils::InterProcessPollingSubscriber<AccelWithCovarianceStamped> acc_sub_{
     this, "~/input/acceleration"};
+  autoware::objects_of_interest_marker_interface::ObjectsOfInterestMarkerInterface
+    objects_of_interest_marker_interface_{this, "obstacle_cruise_planner"};
 
   std::unique_ptr<tf2_ros::Buffer> tf_buffer_;
   std::shared_ptr<tf2_ros::TransformListener> tf_listener_{nullptr};

--- a/planning/autoware_obstacle_cruise_planner/package.xml
+++ b/planning/autoware_obstacle_cruise_planner/package.xml
@@ -23,6 +23,7 @@
   <depend>autoware_lanelet2_extension</depend>
   <depend>autoware_motion_utils</depend>
   <depend>autoware_object_recognition_utils</depend>
+  <depend>autoware_objects_of_interest_marker_interface</depend>
   <depend>autoware_osqp_interface</depend>
   <depend>autoware_perception_msgs</depend>
   <depend>autoware_planning_msgs</depend>

--- a/planning/autoware_obstacle_cruise_planner/src/pid_based_planner/pid_based_planner.cpp
+++ b/planning/autoware_obstacle_cruise_planner/src/pid_based_planner/pid_based_planner.cpp
@@ -320,8 +320,11 @@ std::vector<TrajectoryPoint> PIDBasedPlanner::planCruise(
       const size_t wall_idx = obstacle_cruise_utils::getIndexWithLongitudinalOffset(
         stop_traj_points, dist_to_rss_wall, ego_idx);
 
+      const std::string wall_reason_string = cruise_obstacle_info->obstacle.is_yield_obstacle
+                                               ? "obstacle cruise (yield)"
+                                               : "obstacle cruise";
       auto markers = autoware::motion_utils::createSlowDownVirtualWallMarker(
-        stop_traj_points.at(wall_idx).pose, "obstacle cruise", planner_data.current_time, 0);
+        stop_traj_points.at(wall_idx).pose, wall_reason_string, planner_data.current_time, 0);
       // NOTE: use a different color from slow down one to visualize cruise and slow down
       // separately.
       markers.markers.front().color =

--- a/planning/autoware_obstacle_cruise_planner/src/utils.cpp
+++ b/planning/autoware_obstacle_cruise_planner/src/utils.cpp
@@ -92,7 +92,7 @@ PoseWithStamp getCurrentObjectPose(
     getCurrentObjectPoseFromPredictedPaths(predicted_paths, obj_base_time, current_time);
 
   if (!interpolated_pose) {
-    RCLCPP_WARN(
+    RCLCPP_DEBUG(
       rclcpp::get_logger("ObstacleCruisePlanner"), "Failed to find the interpolated obstacle pose");
     return PoseWithStamp{obj_base_time, pose};
   }


### PR DESCRIPTION
## Description
This PR consists of the following changes.
1. To distinguish the cruise and the yield by rviz, extra stings are added to the cruise virtual walls
2. To recognize the yield behavior by rviz, objects of interest marker is added to the corresponding stopped object
3. Virtual wall topic names are aligned
4. WARN messages for the case of failing time interpolation of the objects are suppressed by published as DEBUG

![Screenshot from 2024-12-09 12-16-14](https://github.com/user-attachments/assets/3beb4929-f6f7-4a3e-a4db-42239e7e5cd0)


## Related links
launch PR: https://github.com/autowarefoundation/autoware_launch/pull/1264

**Parent Issue:**

- Link


## How was this PR tested?
psim

## Notes for reviewers

None.

## Interface changes

None.



## Effects on system behavior

None.
