### PR TITLE
feat: remove max rois limit in the image projection based fusion

### DIFF
--- a/perception/autoware_image_projection_based_fusion/src/fusion_node.cpp
+++ b/perception/autoware_image_projection_based_fusion/src/fusion_node.cpp
@@ -57,8 +57,8 @@ FusionNode<TargetMsg3D, ObjType, Msg2D>::FusionNode(
   }
   if (rois_number_ > 8) {
     RCLCPP_WARN(
-      this->get_logger(), "maximum rois_number is 8. current rois_number is %zu", rois_number_);
-    rois_number_ = 8;
+      this->get_logger(),
+      "Current rois_number is %zu. Large rois number may cause performance issue.", rois_number_);
   }
 
   // Set parameters


### PR DESCRIPTION
## Description

Currently, nodes in the image_projection_based_fusion package are restricted to subscribe up to 8 roi messages maximum.
Remove this magic number because it does not have any concrete necessity.

## Related links


<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

Adding launcher to subscribe more than 8 camera topics.

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
