### PR TITLE
ci(build-and-test): use self hosted X64 and add ccache to -daily

### DIFF
--- a/.github/workflows/build-and-test-daily.yaml
+++ b/.github/workflows/build-and-test-daily.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build-and-test-daily:
-    runs-on: [self-hosted, linux, X64, gpu]
+    runs-on: [self-hosted, Linux, X64]
     container: ${{ matrix.container }}${{ matrix.container-suffix }}
     strategy:
       fail-fast: false
@@ -37,6 +37,33 @@ jobs:
         id: get-self-packages
         uses: autowarefoundation/autoware-github-actions/get-self-packages@v1
 
+      - name: Create ccache directory
+        run: |
+          mkdir -p ${CCACHE_DIR}
+          du -sh ${CCACHE_DIR} && ccache -s
+        shell: bash
+
+      - name: Attempt to restore ccache
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            /root/.ccache
+          key: ccache-main-${{ runner.arch }}-${{ matrix.rosdistro }}-${{ github.sha }}
+          restore-keys: |
+            ccache-main-${{ runner.arch }}-${{ matrix.rosdistro }}-
+
+      - name: Limit ccache size
+        run: |
+          rm -f "${CCACHE_DIR}/ccache.conf"
+          echo -e "# Set maximum cache size\nmax_size = 600MB" >> "${CCACHE_DIR}/ccache.conf"
+        shell: bash
+
+      - name: Show ccache stats before build and reset stats
+        run: |
+          du -sh ${CCACHE_DIR} && ccache -s
+          ccache --zero-stats
+        shell: bash
+
       - name: Export CUDA state as a variable for adding to cache key
         run: |
           build_type_cuda_state=nocuda
@@ -55,6 +82,10 @@ jobs:
           target-packages: ${{ steps.get-self-packages.outputs.self-packages }}
           build-depends-repos: ${{ matrix.build-depends-repos }}
           cache-key-element: ${{ env.BUILD_TYPE_CUDA_STATE }}
+
+      - name: Show ccache stats after build
+        run: du -sh ${CCACHE_DIR} && ccache -s
+        shell: bash
 
       - name: Test
         if: ${{ steps.get-self-packages.outputs.self-packages != '' }}

--- a/.github/workflows/build-and-test-daily.yaml
+++ b/.github/workflows/build-and-test-daily.yaml
@@ -5,6 +5,10 @@ on:
     - cron: 0 0 * * *
   workflow_dispatch:
 
+env:
+  CC: /usr/lib/ccache/gcc
+  CXX: /usr/lib/ccache/g++
+
 jobs:
   build-and-test-daily:
     runs-on: [self-hosted, Linux, X64]

--- a/.github/workflows/build-and-test-daily.yaml
+++ b/.github/workflows/build-and-test-daily.yaml
@@ -34,6 +34,9 @@ jobs:
       - name: Show disk space before the tasks
         run: df -h
 
+      - name: Show machine specs
+        run: lscpu && free -h
+
       - name: Remove exec_depend
         uses: autowarefoundation/autoware-github-actions/remove-exec-depend@v1
 

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -16,7 +16,7 @@ env:
 
 jobs:
   build-and-test:
-    runs-on: codebuild-autoware-us-east-1-${{ github.run_id }}-${{ github.run_attempt }}-ubuntu-7.0-large
+    runs-on: [self-hosted, Linux, X64]
     container: ${{ matrix.container }}${{ matrix.container-suffix }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Description

It seems I forgot to add ccache to the daily, It uses the cache now. (Doesn't update it, since it runs daily, no need).

This PR makes:
- `build-and-test.yaml`
- `build-and-test-daily.yaml`
workflows use the self hosted machines.

For now, they will use the `ovh-runner-01`
Specs:
```yaml
 OS: Ubuntu 22.04 jammy
 Kernel: x86_64 Linux 5.15.0-126-generic
 Disk: 5.0G / 429G (2%)
 CPU: Intel Xeon D-2141I @ 16x 3GHz [28.0°C]
 RAM: 3978MiB / 31754MiB
```

They can also use `leo-copper` since it covers the same labels too.

## Related links

**Parent Issue:**

- https://github.com/autowarefoundation/autoware.universe/issues/9088

## How was this PR tested?

- [build-and-test-daily (humble)](https://github.com/autowarefoundation/autoware.universe/actions/runs/12255199589/job/34187745128) - leo-copper
- [build-and-test-daily (humble, -cuda)](https://github.com/autowarefoundation/autoware.universe/actions/runs/12255199589/job/34187745427) - ovh-runner-01

(Updated ✅)

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.
