### PR TITLE
feat(autoware_lidar_centerpoint): process front voxels first

### DIFF
--- a/perception/autoware_lidar_centerpoint/lib/preprocess/preprocess_kernel.cu
+++ b/perception/autoware_lidar_centerpoint/lib/preprocess/preprocess_kernel.cu
@@ -185,8 +185,12 @@ __global__ void generateBaseFeatures_kernel(
   unsigned int * mask, float * voxels, int grid_y_size, int grid_x_size, int max_voxel_size,
   unsigned int * pillar_num, float * voxel_features, float * voxel_num, int * voxel_idxs)
 {
-  unsigned int voxel_idx = blockIdx.x * blockDim.x + threadIdx.x;
-  unsigned int voxel_idy = blockIdx.y * blockDim.y + threadIdx.y;
+  // exchange x and y to process in a row-major order
+  // flip x axis direction to process front to back
+  unsigned int voxel_idx_inverted = blockIdx.y * blockDim.y + threadIdx.y;
+  unsigned int voxel_idy = blockIdx.x * blockDim.x + threadIdx.x;
+  if (voxel_idx_inverted >= grid_x_size || voxel_idy >= grid_y_size) return;
+  unsigned int voxel_idx = grid_x_size - 1 - voxel_idx_inverted;
 
   if (voxel_idx >= grid_x_size || voxel_idy >= grid_y_size) return;
 
@@ -220,9 +224,10 @@ cudaError_t generateBaseFeatures_launch(
   unsigned int * pillar_num, float * voxel_features, float * voxel_num, int * voxel_idxs,
   cudaStream_t stream)
 {
+  // exchange x and y to process in a row-major order
   dim3 threads = {32, 32};
   dim3 blocks = {
-    (grid_x_size + threads.x - 1) / threads.x, (grid_y_size + threads.y - 1) / threads.y};
+    (grid_y_size + threads.x - 1) / threads.x, (grid_x_size + threads.y - 1) / threads.y};
 
   generateBaseFeatures_kernel<<<blocks, threads, 0, stream>>>(
     mask, voxels, grid_y_size, grid_x_size, max_voxel_size, pillar_num, voxel_features, voxel_num,

--- a/perception/autoware_lidar_centerpoint/lib/preprocess/preprocess_kernel.cu
+++ b/perception/autoware_lidar_centerpoint/lib/preprocess/preprocess_kernel.cu
@@ -148,7 +148,7 @@ __global__ void generateVoxels_random_kernel(
 
   int voxel_idx = floorf((point.x - min_x_range) / pillar_x_size);
   int voxel_idy = floorf((point.y - min_y_range) / pillar_y_size);
-  unsigned int voxel_index = voxel_idy * grid_x_size + voxel_idx;
+  unsigned int voxel_index = (grid_x_size - 1 - voxel_idx) * grid_y_size + voxel_idy;
 
   unsigned int point_id = atomicAdd(&(mask[voxel_index]), 1);
 
@@ -192,7 +192,7 @@ __global__ void generateBaseFeatures_kernel(
   if (voxel_idx_inverted >= grid_x_size || voxel_idy >= grid_y_size) return;
   unsigned int voxel_idx = grid_x_size - 1 - voxel_idx_inverted;
 
-  unsigned int voxel_index = voxel_idy * grid_x_size + voxel_idx;
+  unsigned int voxel_index = voxel_idx_inverted * grid_y_size + voxel_idy;
   unsigned int count = mask[voxel_index];
   if (!(count > 0)) return;
   count = count < MAX_POINT_IN_VOXEL_SIZE ? count : MAX_POINT_IN_VOXEL_SIZE;

--- a/perception/autoware_lidar_centerpoint/lib/preprocess/preprocess_kernel.cu
+++ b/perception/autoware_lidar_centerpoint/lib/preprocess/preprocess_kernel.cu
@@ -192,8 +192,6 @@ __global__ void generateBaseFeatures_kernel(
   if (voxel_idx_inverted >= grid_x_size || voxel_idy >= grid_y_size) return;
   unsigned int voxel_idx = grid_x_size - 1 - voxel_idx_inverted;
 
-  if (voxel_idx >= grid_x_size || voxel_idy >= grid_y_size) return;
-
   unsigned int voxel_index = voxel_idy * grid_x_size + voxel_idx;
   unsigned int count = mask[voxel_index];
   if (!(count > 0)) return;


### PR DESCRIPTION
## Description

Alternative solution of PR https://github.com/autowarefoundation/autoware.universe/pull/9583

1. exchange x and y to process in a row-major order
2. flip x axis direction to process front to back

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

The following visualization is to show filled voxel distribution. Configurations are as follwing.

- input high-density lidar point cloud
-  score_threshold: 0.01
-  max_voxel_size: 40000
-  point_cloud_range: [-121.6, -76.8, -3.0, 121.6, 76.8, 5.0]

Then lower score object will be shown (due to the lower score_threshold), indirectly visualize where the voxel is filled.


![Screenshot from 2024-12-10 17-55-50](https://github.com/user-attachments/assets/e89066d9-5606-4682-85cb-2809c230dbd0)



## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
