### PR TITLE
feat(duplicated_node_checker): show the node name on the terminal

### DIFF
--- a/system/duplicated_node_checker/src/duplicated_node_checker_core.cpp
+++ b/system/duplicated_node_checker/src/duplicated_node_checker_core.cpp
@@ -67,6 +67,8 @@ void DuplicatedNodeChecker::produceDiagnostics(diagnostic_updater::DiagnosticSta
     }
     for (auto name : identical_names) {
       stat.add("Duplicated Node Name", name);
+      RCLCPP_WARN_THROTTLE(
+        get_logger(), *get_clock(), 5000, "%s node is duplicated.", name.c_str());
     }
   } else {
     msg = "OK";


### PR DESCRIPTION
## Description

Currently, when there are duplicated nodes, we cannot see the node name unless we run `rqt_runtime_monitor` or something, which makes the debuggability quite low.
The duplicated_node_checker node will show the following message with the duplicated node name on the terminal.

```
[duplicated_node_checker_node-3] [WARN 1733839043.581189550] [system.duplicated_node_checker]: /perception/object_recognition/prediction/map_based_prediction node is duplicated. (produceDiagnostics():70)
```
## Related links

## How was this PR tested?

It worked on the planning simulator.
## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
