### PR TITLE
refactor(autoware_test_utils): enhance makeMapBinMsg to accept package name and map filename parameters

### DIFF
--- a/common/autoware_test_utils/include/autoware_test_utils/autoware_test_utils.hpp
+++ b/common/autoware_test_utils/include/autoware_test_utils/autoware_test_utils.hpp
@@ -226,7 +226,8 @@ LaneletMapBin make_map_bin_msg(
  * @return A LaneletMapBin message containing the map data.
  */
 LaneletMapBin makeMapBinMsg(
-  const std::string & package_name = "", const std::string & map_filename = "lanelet2_map.osm");
+  const std::string & package_name = "autoware_test_utils",
+  const std::string & map_filename = "lanelet2_map.osm");
 
 /**
  * @brief Creates an Odometry message with a specified shift.

--- a/common/autoware_test_utils/include/autoware_test_utils/autoware_test_utils.hpp
+++ b/common/autoware_test_utils/include/autoware_test_utils/autoware_test_utils.hpp
@@ -213,15 +213,20 @@ LaneletMapBin make_map_bin_msg(
   const std::string & absolute_path, const double center_line_resolution = 5.0);
 
 /**
- * @brief Creates a LaneletMapBin message using a predefined Lanelet2 map file.
+ * @brief Creates a LaneletMapBin message using a Lanelet2 map file.
  *
- * This function loads a lanelet2_map.osm from the test_map folder in the
- * autoware_test_utils package, overwrites the centerline with a resolution of 5.0,
+ * This function loads a specified map file from the test_map folder in the
+ * specified package (or autoware_test_utils if no package is specified),
+ * overwrites the centerline with a resolution of 5.0,
  * and converts the map to a LaneletMapBin message.
  *
+ * @param package_name The name of the package containing the map file. If empty, defaults to
+ * "autoware_test_utils".
+ * @param map_filename The name of the map file (e.g. "lanelet2_map.osm")
  * @return A LaneletMapBin message containing the map data.
  */
-LaneletMapBin makeMapBinMsg();
+LaneletMapBin makeMapBinMsg(
+  const std::string & package_name = "", const std::string & map_filename = "lanelet2_map.osm");
 
 /**
  * @brief Creates an Odometry message with a specified shift.

--- a/common/autoware_test_utils/src/autoware_test_utils.cpp
+++ b/common/autoware_test_utils/src/autoware_test_utils.cpp
@@ -182,11 +182,7 @@ LaneletMapBin make_map_bin_msg(
 
 LaneletMapBin makeMapBinMsg(const std::string & package_name, const std::string & map_filename)
 {
-  if (package_name.empty()) {
-    return make_map_bin_msg(get_absolute_path_to_lanelet_map("autoware_test_utils", map_filename));
-  } else {
-    return make_map_bin_msg(get_absolute_path_to_lanelet_map(package_name, map_filename));
-  }
+  return make_map_bin_msg(get_absolute_path_to_lanelet_map(package_name, map_filename));
 }
 
 Odometry makeOdometry(const double shift)

--- a/common/autoware_test_utils/src/autoware_test_utils.cpp
+++ b/common/autoware_test_utils/src/autoware_test_utils.cpp
@@ -180,10 +180,13 @@ LaneletMapBin make_map_bin_msg(
   return map_bin_msg;
 }
 
-LaneletMapBin makeMapBinMsg()
+LaneletMapBin makeMapBinMsg(const std::string & package_name, const std::string & map_filename)
 {
-  return make_map_bin_msg(
-    get_absolute_path_to_lanelet_map("autoware_test_utils", "lanelet2_map.osm"));
+  if (package_name.empty()) {
+    return make_map_bin_msg(get_absolute_path_to_lanelet_map("autoware_test_utils", map_filename));
+  } else {
+    return make_map_bin_msg(get_absolute_path_to_lanelet_map(package_name, map_filename));
+  }
 }
 
 Odometry makeOdometry(const double shift)

--- a/planning/autoware_planning_test_manager/include/autoware_planning_test_manager/autoware_planning_test_manager_utils.hpp
+++ b/planning/autoware_planning_test_manager/include/autoware_planning_test_manager/autoware_planning_test_manager_utils.hpp
@@ -24,6 +24,7 @@
 
 #include <iostream>
 #include <memory>
+#include <string>
 #include <vector>
 
 namespace autoware_planning_test_manager::utils
@@ -34,9 +35,11 @@ using geometry_msgs::msg::Pose;
 using nav_msgs::msg::Odometry;
 using RouteSections = std::vector<autoware_planning_msgs::msg::LaneletSegment>;
 
-Pose createPoseFromLaneID(const lanelet::Id & lane_id)
+Pose createPoseFromLaneID(
+  const lanelet::Id & lane_id, const std::string & package_name = "",
+  const std::string & map_filename = "lanelet2_map.osm")
 {
-  auto map_bin_msg = autoware::test_utils::makeMapBinMsg();
+  auto map_bin_msg = autoware::test_utils::makeMapBinMsg(package_name, map_filename);
   // create route_handler
   auto route_handler = std::make_shared<RouteHandler>();
   route_handler->setMap(map_bin_msg);
@@ -67,16 +70,18 @@ Pose createPoseFromLaneID(const lanelet::Id & lane_id)
 
 // Function to create a route from given start and goal lanelet ids
 // start pose and goal pose are set to the middle of the lanelet
-LaneletRoute makeBehaviorRouteFromLaneId(const int & start_lane_id, const int & goal_lane_id)
+LaneletRoute makeBehaviorRouteFromLaneId(
+  const int & start_lane_id, const int & goal_lane_id, const std::string & package_name = "",
+  const std::string & map_filename = "lanelet2_map.osm")
 {
   LaneletRoute route;
   route.header.frame_id = "map";
-  auto start_pose = createPoseFromLaneID(start_lane_id);
-  auto goal_pose = createPoseFromLaneID(goal_lane_id);
+  auto start_pose = createPoseFromLaneID(start_lane_id, package_name, map_filename);
+  auto goal_pose = createPoseFromLaneID(goal_lane_id, package_name, map_filename);
   route.start_pose = start_pose;
   route.goal_pose = goal_pose;
 
-  auto map_bin_msg = autoware::test_utils::makeMapBinMsg();
+  auto map_bin_msg = autoware::test_utils::makeMapBinMsg(package_name, map_filename);
   // create route_handler
   auto route_handler = std::make_shared<RouteHandler>();
   route_handler->setMap(map_bin_msg);

--- a/planning/autoware_planning_test_manager/include/autoware_planning_test_manager/autoware_planning_test_manager_utils.hpp
+++ b/planning/autoware_planning_test_manager/include/autoware_planning_test_manager/autoware_planning_test_manager_utils.hpp
@@ -36,7 +36,7 @@ using nav_msgs::msg::Odometry;
 using RouteSections = std::vector<autoware_planning_msgs::msg::LaneletSegment>;
 
 Pose createPoseFromLaneID(
-  const lanelet::Id & lane_id, const std::string & package_name = "",
+  const lanelet::Id & lane_id, const std::string & package_name = "autoware_test_utils",
   const std::string & map_filename = "lanelet2_map.osm")
 {
   auto map_bin_msg = autoware::test_utils::makeMapBinMsg(package_name, map_filename);
@@ -71,7 +71,8 @@ Pose createPoseFromLaneID(
 // Function to create a route from given start and goal lanelet ids
 // start pose and goal pose are set to the middle of the lanelet
 LaneletRoute makeBehaviorRouteFromLaneId(
-  const int & start_lane_id, const int & goal_lane_id, const std::string & package_name = "",
+  const int & start_lane_id, const int & goal_lane_id,
+  const std::string & package_name = "autoware_test_utils",
   const std::string & map_filename = "lanelet2_map.osm")
 {
   LaneletRoute route;


### PR DESCRIPTION
## Description

- Add optional parameters to `makeMapBinMsg` function to allow specifying custom package name and map filename
- Update documentation for `makeMapBinMsg` to reflect new parameters
- Add optional parameters to `createPoseFromLaneID` and `makeBehaviorRouteFromLaneId` to support custom map loading
- Set default values to maintain backward compatibility (`package_name=""`, `map_filename="lanelet2_map.osm"`)

This change is necessary to use a different map than the default one when calling the function `makeBehaviorRouteFromLaneId` to generate a route.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
