### PR TITLE
refactor(autoware_multi_object_tracker): add configurable tracker parameters

### DIFF
--- a/perception/autoware_multi_object_tracker/config/multi_object_tracker_node.param.yaml
+++ b/perception/autoware_multi_object_tracker/config/multi_object_tracker_node.param.yaml
@@ -15,6 +15,21 @@
     enable_delay_compensation: false
     consider_odometry_uncertainty: false
 
+    # tracker parameters
+    tracker_lifetime: 1.0  # [s]
+    min_known_object_removal_iou: 0.1  # [ratio]
+    min_unknown_object_removal_iou: 0.001  # [ratio]
+    distance_threshold: 5.0  # [m]
+    confident_count_threshold:
+      UNKNOWN: 3
+      CAR: 3
+      TRUCK: 3
+      BUS: 3
+      TRAILER: 3
+      MOTORBIKE: 3
+      BICYCLE: 3
+      PEDESTRIAN: 3
+
     # debug parameters
     publish_processing_time: false
     publish_tentative_objects: false

--- a/perception/autoware_multi_object_tracker/schema/multi_object_tracker_node.schema.json
+++ b/perception/autoware_multi_object_tracker/schema/multi_object_tracker_node.schema.json
@@ -56,6 +56,69 @@
           "description": "If True, tracker use timers to schedule publishers and use prediction step to extrapolate object state at desired timestamp.",
           "default": false
         },
+        "consider_odometry_uncertainty": {
+          "type": "boolean",
+          "description": "If True, consider odometry uncertainty in tracking.",
+          "default": false
+        },
+        "tracker_lifetime": {
+          "type": "number",
+          "description": "Lifetime of the tracker in seconds.",
+          "default": 1.0
+        },
+        "min_known_object_removal_iou": {
+          "type": "number",
+          "description": "Minimum IOU between associated objects with known label to remove younger tracker",
+          "default": 0.1
+        },
+        "min_unknown_object_removal_iou": {
+          "type": "number",
+          "description": "Minimum IOU between associated objects with unknown label to remove unknown tracker",
+          "default": 0.001
+        },
+        "distance_threshold": {
+          "type": "number",
+          "description": "Distance threshold in meters.",
+          "default": 5.0
+        },
+        "confident_count_threshold": {
+          "type": "object",
+          "properties": {
+            "UNKNOWN": {
+              "type": "number",
+              "default": 3
+            },
+            "CAR": {
+              "type": "number",
+              "default": 3
+            },
+            "TRUCK": {
+              "type": "number",
+              "default": 3
+            },
+            "BUS": {
+              "type": "number",
+              "default": 3
+            },
+            "TRAILER": {
+              "type": "number",
+              "default": 3
+            },
+            "MOTORBIKE": {
+              "type": "number",
+              "default": 3
+            },
+            "BICYCLE": {
+              "type": "number",
+              "default": 3
+            },
+            "PEDESTRIAN": {
+              "type": "number",
+              "default": 3
+            }
+          },
+          "description": "Number of measurements to consider tracker as confident for different object classes."
+        },
         "publish_processing_time": {
           "type": "boolean",
           "description": "Enable to publish debug message of process time information.",
@@ -93,6 +156,12 @@
         "publish_rate",
         "world_frame_id",
         "enable_delay_compensation",
+        "consider_odometry_uncertainty",
+        "tracker_lifetime",
+        "min_known_object_removal_iou",
+        "min_unknown_object_removal_iou",
+        "distance_threshold",
+        "confident_count_threshold",
         "publish_processing_time",
         "publish_tentative_objects",
         "publish_debug_markers",

--- a/perception/autoware_multi_object_tracker/src/multi_object_tracker_node.cpp
+++ b/perception/autoware_multi_object_tracker/src/multi_object_tracker_node.cpp
@@ -185,7 +185,8 @@ MultiObjectTracker::MultiObjectTracker(const rclcpp::NodeOptions & node_options)
 
     // Declare parameters
     config.tracker_lifetime = declare_parameter<double>("tracker_lifetime", 1.0);
-    config.min_known_object_removal_iou = declare_parameter<double>("min_known_object_removal_iou", 0.1);
+    config.min_known_object_removal_iou =
+      declare_parameter<double>("min_known_object_removal_iou", 0.1);
     config.min_unknown_object_removal_iou =
       declare_parameter<double>("min_unknown_object_removal_iou", 0.05);
     config.distance_threshold = declare_parameter<double>("distance_threshold", 5.0);

--- a/perception/autoware_multi_object_tracker/src/multi_object_tracker_node.cpp
+++ b/perception/autoware_multi_object_tracker/src/multi_object_tracker_node.cpp
@@ -184,12 +184,11 @@ MultiObjectTracker::MultiObjectTracker(const rclcpp::NodeOptions & node_options)
     config.channel_size = input_channel_size_;
 
     // Declare parameters
-    config.tracker_lifetime = declare_parameter<double>("tracker_lifetime", 1.0);
-    config.min_known_object_removal_iou =
-      declare_parameter<double>("min_known_object_removal_iou", 0.1);
+    config.tracker_lifetime = declare_parameter<double>("tracker_lifetime");
+    config.min_known_object_removal_iou = declare_parameter<double>("min_known_object_removal_iou");
     config.min_unknown_object_removal_iou =
-      declare_parameter<double>("min_unknown_object_removal_iou", 0.05);
-    config.distance_threshold = declare_parameter<double>("distance_threshold", 5.0);
+      declare_parameter<double>("min_unknown_object_removal_iou");
+    config.distance_threshold = declare_parameter<double>("distance_threshold");
 
     // Map from class name to label
     std::map<std::string, LabelType> class_name_to_label = {
@@ -200,7 +199,7 @@ MultiObjectTracker::MultiObjectTracker(const rclcpp::NodeOptions & node_options)
 
     // Declare parameters and initialize confident_count_threshold_map
     for (const auto & [class_name, class_label] : class_name_to_label) {
-      int64_t value = declare_parameter<int64_t>("confident_count_threshold." + class_name, 3);
+      int64_t value = declare_parameter<int64_t>("confident_count_threshold." + class_name);
       config.confident_count_threshold[class_label] = static_cast<int>(value);
     }
 

--- a/perception/autoware_multi_object_tracker/src/processor/processor.cpp
+++ b/perception/autoware_multi_object_tracker/src/processor/processor.cpp
@@ -93,7 +93,7 @@ std::shared_ptr<Tracker> TrackerProcessor::createNewTracker(
         time, object, self_transform, config_.channel_size, channel_index);
     if (tracker == "big_vehicle_tracker")
       return std::make_shared<VehicleTracker>(
-        object_model::big_vehicle, time, object, self_transform, config_.channel_size_,
+        object_model::big_vehicle, time, object, self_transform, config_.channel_size,
         channel_index);
     if (tracker == "multi_vehicle_tracker")
       return std::make_shared<MultipleVehicleTracker>(

--- a/perception/autoware_multi_object_tracker/src/processor/processor.cpp
+++ b/perception/autoware_multi_object_tracker/src/processor/processor.cpp
@@ -93,13 +93,15 @@ std::shared_ptr<Tracker> TrackerProcessor::createNewTracker(
         time, object, self_transform, config_.channel_size, channel_index);
     if (tracker == "big_vehicle_tracker")
       return std::make_shared<VehicleTracker>(
-        object_model::big_vehicle, time, object, self_transform, config_.channel_size_, channel_index);
+        object_model::big_vehicle, time, object, self_transform, config_.channel_size_,
+        channel_index);
     if (tracker == "multi_vehicle_tracker")
       return std::make_shared<MultipleVehicleTracker>(
         time, object, self_transform, config_.channel_size, channel_index);
     if (tracker == "normal_vehicle_tracker")
       return std::make_shared<VehicleTracker>(
-        object_model::normal_vehicle, time, object, self_transform, config_.channel_size_, channel_index);
+        object_model::normal_vehicle, time, object, self_transform, config_.channel_size_,
+        channel_index);
     if (tracker == "pass_through_tracker")
       return std::make_shared<PassThroughTracker>(
         time, object, self_transform, config_.channel_size, channel_index);

--- a/perception/autoware_multi_object_tracker/src/processor/processor.cpp
+++ b/perception/autoware_multi_object_tracker/src/processor/processor.cpp
@@ -30,21 +30,10 @@ namespace autoware::multi_object_tracker
 {
 
 using Label = autoware_perception_msgs::msg::ObjectClassification;
+using LabelType = autoware_perception_msgs::msg::ObjectClassification::_label_type;
 
-TrackerProcessor::TrackerProcessor(
-  const std::map<std::uint8_t, std::string> & tracker_map, const size_t & channel_size)
-: tracker_map_(tracker_map), channel_size_(channel_size)
+TrackerProcessor::TrackerProcessor(const TrackerProcessorConfig & config) : config_(config)
 {
-  // Set tracker lifetime parameters
-  max_elapsed_time_ = 1.0;  // [s]
-
-  // Set tracker overlap remover parameters
-  min_iou_ = 0.1;                       // [ratio]
-  min_iou_for_unknown_object_ = 0.001;  // [ratio]
-  distance_threshold_ = 5.0;            // [m]
-
-  // Set tracker confidence threshold
-  confident_count_threshold_ = 3;  // [count]
 }
 
 void TrackerProcessor::predict(const rclcpp::Time & time)
@@ -95,34 +84,33 @@ std::shared_ptr<Tracker> TrackerProcessor::createNewTracker(
   const autoware_perception_msgs::msg::DetectedObject & object, const rclcpp::Time & time,
   const geometry_msgs::msg::Transform & self_transform, const uint & channel_index) const
 {
-  const std::uint8_t label =
-    autoware::object_recognition_utils::getHighestProbLabel(object.classification);
-  if (tracker_map_.count(label) != 0) {
-    const auto tracker = tracker_map_.at(label);
+  const LabelType label = autoware::object_recognition_utils::getHighestProbLabel(object.classification);
+  if (config_.tracker_map.count(label) != 0) {
+    const auto tracker = config_.tracker_map.at(label);
     if (tracker == "bicycle_tracker")
       return std::make_shared<BicycleTracker>(
-        time, object, self_transform, channel_size_, channel_index);
+        time, object, self_transform, config_.channel_size, channel_index);
     if (tracker == "big_vehicle_tracker")
       return std::make_shared<VehicleTracker>(
-        object_model::big_vehicle, time, object, self_transform, channel_size_, channel_index);
+        object_model::big_vehicle, time, object, self_transform, config_.channel_size_, channel_index);
     if (tracker == "multi_vehicle_tracker")
       return std::make_shared<MultipleVehicleTracker>(
-        time, object, self_transform, channel_size_, channel_index);
+        time, object, self_transform, config_.channel_size, channel_index);
     if (tracker == "normal_vehicle_tracker")
       return std::make_shared<VehicleTracker>(
-        object_model::normal_vehicle, time, object, self_transform, channel_size_, channel_index);
+        object_model::normal_vehicle, time, object, self_transform, config_.channel_size_, channel_index);
     if (tracker == "pass_through_tracker")
       return std::make_shared<PassThroughTracker>(
-        time, object, self_transform, channel_size_, channel_index);
+        time, object, self_transform, config_.channel_size, channel_index);
     if (tracker == "pedestrian_and_bicycle_tracker")
       return std::make_shared<PedestrianAndBicycleTracker>(
-        time, object, self_transform, channel_size_, channel_index);
+        time, object, self_transform, config_.channel_size, channel_index);
     if (tracker == "pedestrian_tracker")
       return std::make_shared<PedestrianTracker>(
-        time, object, self_transform, channel_size_, channel_index);
+        time, object, self_transform, config_.channel_size, channel_index);
   }
   return std::make_shared<UnknownTracker>(
-    time, object, self_transform, channel_size_, channel_index);
+    time, object, self_transform, config_.channel_size, channel_index);
 }
 
 void TrackerProcessor::prune(const rclcpp::Time & time)
@@ -137,7 +125,7 @@ void TrackerProcessor::removeOldTracker(const rclcpp::Time & time)
 {
   // Check elapsed time from last update
   for (auto itr = list_tracker_.begin(); itr != list_tracker_.end(); ++itr) {
-    const bool is_old = max_elapsed_time_ < (*itr)->getElapsedTimeFromLastUpdate(time);
+    const bool is_old = config_.tracker_lifetime < (*itr)->getElapsedTimeFromLastUpdate(time);
     // If the tracker is old, delete it
     if (is_old) {
       auto erase_itr = itr;
@@ -168,14 +156,13 @@ void TrackerProcessor::removeOverlappedTracker(const rclcpp::Time & time)
           object2.kinematics.pose_with_covariance.pose.position.y);
 
       // If the distance is too large, skip
-      if (distance > distance_threshold_) {
+      if (distance > config_.distance_threshold) {
         continue;
       }
 
       // Check the Intersection over Union (IoU) between the two objects
       const double min_union_iou_area = 1e-2;
-      const auto iou =
-        autoware::object_recognition_utils::get2dIoU(object1, object2, min_union_iou_area);
+      const auto iou = autoware::object_recognition_utils::get2dIoU(object1, object2, min_union_iou_area);
       const auto & label1 = (*itr1)->getHighestProbLabel();
       const auto & label2 = (*itr2)->getHighestProbLabel();
       bool should_delete_tracker1 = false;
@@ -184,7 +171,7 @@ void TrackerProcessor::removeOverlappedTracker(const rclcpp::Time & time)
       // If both trackers are UNKNOWN, delete the younger tracker
       // If one side of the tracker is UNKNOWN, delete UNKNOWN objects
       if (label1 == Label::UNKNOWN || label2 == Label::UNKNOWN) {
-        if (iou > min_iou_for_unknown_object_) {
+        if (iou > config_.min_unknown_object_removal_iou) {
           if (label1 == Label::UNKNOWN && label2 == Label::UNKNOWN) {
             if ((*itr1)->getTotalMeasurementCount() < (*itr2)->getTotalMeasurementCount()) {
               should_delete_tracker1 = true;
@@ -198,7 +185,7 @@ void TrackerProcessor::removeOverlappedTracker(const rclcpp::Time & time)
           }
         }
       } else {  // If neither object is UNKNOWN, delete the younger tracker
-        if (iou > min_iou_) {
+        if (iou > config_.min_known_object_removal_iou) {
           if ((*itr1)->getTotalMeasurementCount() < (*itr2)->getTotalMeasurementCount()) {
             should_delete_tracker1 = true;
           } else {
@@ -226,7 +213,8 @@ bool TrackerProcessor::isConfidentTracker(const std::shared_ptr<Tracker> & track
   // Confidence is determined by counting the number of measurements.
   // If the number of measurements is equal to or greater than the threshold, the tracker is
   // considered confident.
-  return tracker->getTotalMeasurementCount() >= confident_count_threshold_;
+  auto label = tracker->getHighestProbLabel();
+  return tracker->getTotalMeasurementCount() >= config_.confident_count_threshold.at(label);
 }
 
 void TrackerProcessor::getTrackedObjects(

--- a/perception/autoware_multi_object_tracker/src/processor/processor.cpp
+++ b/perception/autoware_multi_object_tracker/src/processor/processor.cpp
@@ -84,7 +84,8 @@ std::shared_ptr<Tracker> TrackerProcessor::createNewTracker(
   const autoware_perception_msgs::msg::DetectedObject & object, const rclcpp::Time & time,
   const geometry_msgs::msg::Transform & self_transform, const uint & channel_index) const
 {
-  const LabelType label = autoware::object_recognition_utils::getHighestProbLabel(object.classification);
+  const LabelType label =
+    autoware::object_recognition_utils::getHighestProbLabel(object.classification);
   if (config_.tracker_map.count(label) != 0) {
     const auto tracker = config_.tracker_map.at(label);
     if (tracker == "bicycle_tracker")
@@ -162,7 +163,8 @@ void TrackerProcessor::removeOverlappedTracker(const rclcpp::Time & time)
 
       // Check the Intersection over Union (IoU) between the two objects
       const double min_union_iou_area = 1e-2;
-      const auto iou = autoware::object_recognition_utils::get2dIoU(object1, object2, min_union_iou_area);
+      const auto iou =
+        autoware::object_recognition_utils::get2dIoU(object1, object2, min_union_iou_area);
       const auto & label1 = (*itr1)->getHighestProbLabel();
       const auto & label2 = (*itr2)->getHighestProbLabel();
       bool should_delete_tracker1 = false;

--- a/perception/autoware_multi_object_tracker/src/processor/processor.cpp
+++ b/perception/autoware_multi_object_tracker/src/processor/processor.cpp
@@ -100,7 +100,7 @@ std::shared_ptr<Tracker> TrackerProcessor::createNewTracker(
         time, object, self_transform, config_.channel_size, channel_index);
     if (tracker == "normal_vehicle_tracker")
       return std::make_shared<VehicleTracker>(
-        object_model::normal_vehicle, time, object, self_transform, config_.channel_size_,
+        object_model::normal_vehicle, time, object, self_transform, config_.channel_size,
         channel_index);
     if (tracker == "pass_through_tracker")
       return std::make_shared<PassThroughTracker>(

--- a/perception/autoware_multi_object_tracker/src/processor/processor.hpp
+++ b/perception/autoware_multi_object_tracker/src/processor/processor.hpp
@@ -31,11 +31,23 @@
 
 namespace autoware::multi_object_tracker
 {
+using LabelType = autoware_perception_msgs::msg::ObjectClassification::_label_type;
+
+struct TrackerProcessorConfig
+{
+  std::map<LabelType, std::string> tracker_map;
+  size_t channel_size;
+  float tracker_lifetime;                              // [s]
+  float min_known_object_removal_iou;                  // ratio [0, 1]
+  float min_unknown_object_removal_iou;                // ratio [0, 1]
+  double distance_threshold;                           // [m]
+  std::map<LabelType, int> confident_count_threshold;  // [count]
+};
+
 class TrackerProcessor
 {
 public:
-  explicit TrackerProcessor(
-    const std::map<std::uint8_t, std::string> & tracker_map, const size_t & channel_size);
+  explicit TrackerProcessor(const TrackerProcessorConfig & config);
 
   const std::list<std::shared_ptr<Tracker>> & getListTracker() const { return list_tracker_; }
   // tracker processes
@@ -62,17 +74,8 @@ public:
   void getExistenceProbabilities(std::vector<std::vector<float>> & existence_vectors) const;
 
 private:
-  std::map<std::uint8_t, std::string> tracker_map_;
+  TrackerProcessorConfig config_;
   std::list<std::shared_ptr<Tracker>> list_tracker_;
-  const size_t channel_size_;
-
-  // parameters
-  float max_elapsed_time_;            // [s]
-  float min_iou_;                     // [ratio]
-  float min_iou_for_unknown_object_;  // [ratio]
-  double distance_threshold_;         // [m]
-  int confident_count_threshold_;     // [count]
-
   void removeOldTracker(const rclcpp::Time & time);
   void removeOverlappedTracker(const rclcpp::Time & time);
   std::shared_ptr<Tracker> createNewTracker(


### PR DESCRIPTION
## Description
Extracted `autoware_multi_object_tracker` parameters from source code, refactored parameters declaration and enabled setting `confident_count_threshold` for each classification label separately. 

## Changes
* Extracted tracker-specific parameters: `tracker_lifetime`, `min_known_object_removal_iou`, `min_unknown_object_removal_iou`, `distance_threshold`, and `confident_count_threshold` to the `multi_object_tracker_node.param.yaml` configuration file.
* Introduced `TrackerProcessorConfig` struct to encapsulate tracker-related parameters and refactored the `TrackerProcessor` class to use this struct for initialization.
* Updated the `TrackerProcessor` methods to use the new configuration struct, including `createNewTracker`, `removeOldTracker`, `removeOverlappedTracker`, and `isConfidentTracker`. 

## Related links
https://github.com/autowarefoundation/autoware_launch/pull/1273 `autoware_launch` PR for according parameters.

## How was this PR tested?
Build completed successfully.
Tested parameters changes in Carla environment.

## Notes for reviewers

None.

### ROS Parameter Changes

Extracted parameters from source code and renamed them according to their use:
| Old | New |
|-----------------------------|---------------------|
| `max_elapsed_time_` | `tracker_lifetime` |
| `min_iou_` |  `min_known_object_removal_iou` |
|    `min_iou_for_unknown_object_` | `min_unknown_object_removal_iou` |
|    `distance_threshold_` | `distance_threshold` |
| `confident_count_threshold_` |   `confident_count_threshold` for each label type|

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added | `tracker_lifetime`   | `float` | `1.0`         | How long will tracker last |
| Added | `min_known_object_removal_iou`   | `float` | `0.1`         | Minimal IoU between associated objects with known label to  remove younger tracker|
| Added | `min_unknown_object_removal_iou`   | `float` | `0.001`         | Minimal IoU between associated objects with unknown label to remove unknown tracker|
| Added | `distance_threshold`   | `float` | `5.0`         | Distance threshold for removing overlapped trackers |
| Added | `confident_count_threshold`   | `std::map<std::string, LabelType>` | `Label : 3`         | Number of measurements to consider tracker as confident. Separated for each label. |

## Effects on system behavior

None.
