### PR TITLE
fix(tier4_state_rviz_plugin): fix bugprone-integer-division

### DIFF
--- a/visualization/tier4_state_rviz_plugin/src/custom_container.cpp
+++ b/visualization/tier4_state_rviz_plugin/src/custom_container.cpp
@@ -51,7 +51,7 @@ void CustomContainer::paintEvent(QPaintEvent *)
 
   // Draw background
   QPainterPath path;
-  path.addRoundedRect(rect(), height() / 2, height() / 2);  // Use height for rounded corners
+  path.addRoundedRect(rect(), height() / 2.0, height() / 2.0);  // Use height for rounded corners
   painter.setPen(Qt::NoPen);
   painter.setBrush(QColor(
     autoware::state_rviz_plugin::colors::default_colors.surface.c_str()));  // Background color

--- a/visualization/tier4_state_rviz_plugin/src/custom_icon_label.cpp
+++ b/visualization/tier4_state_rviz_plugin/src/custom_icon_label.cpp
@@ -65,7 +65,7 @@ void CustomIconLabel::paintEvent(QPaintEvent *)
 
   // Draw background circle
   QPainterPath path;
-  path.addEllipse(width() / 2 - radius, height() / 2 - radius, diameter, diameter);
+  path.addEllipse(width() / 2.0 - radius, height() / 2.0 - radius, diameter, diameter);
   painter.setPen(Qt::NoPen);
   painter.setBrush(backgroundColor);
   painter.drawPath(path);

--- a/visualization/tier4_state_rviz_plugin/src/custom_segmented_button.cpp
+++ b/visualization/tier4_state_rviz_plugin/src/custom_segmented_button.cpp
@@ -66,7 +66,7 @@ void CustomSegmentedButton::paintEvent(QPaintEvent *)
 
   // Draw background
   QPainterPath path;
-  path.addRoundedRect(rect(), height() / 2, height() / 2);
+  path.addRoundedRect(rect(), height() / 2.0, height() / 2.0);
 
   painter.setPen(Qt::NoPen);
   painter.setBrush(

--- a/visualization/tier4_state_rviz_plugin/src/custom_segmented_button_item.cpp
+++ b/visualization/tier4_state_rviz_plugin/src/custom_segmented_button_item.cpp
@@ -125,7 +125,7 @@ void CustomSegmentedButtonItem::paintEvent(QPaintEvent *)
   }
 
   QPainterPath path;
-  double radius = (height() - 2) / 2;
+  double radius = (height() - 2.0) / 2.0;
 
   path.setFillRule(Qt::WindingFill);
   if (isFirstButton) {


### PR DESCRIPTION
## Description
This is a fix based on clang-tidy `bugprone-integer-division` error.

```
/home/emb4/autoware/autoware/src/universe/autoware.universe/visualization/tier4_state_rviz_plugin/src/custom_container.cpp:54:31: error: result of integer division used in a floating point context; possible loss of precision [bugprone-integer-division,-warnings-as-errors]
  path.addRoundedRect(rect(), height() / 2, height() / 2);  // Use height for rounded corners
                              ^
/home/emb4/autoware/autoware/src/universe/autoware.universe/visualization/tier4_state_rviz_plugin/src/custom_container.cpp:54:45: error: result of integer division used in a floating point context; possible loss of precision [bugprone-integer-division,-warnings-as-errors]
  path.addRoundedRect(rect(), height() / 2, height() / 2);  // Use height for rounded corners
                                            ^
/home/emb4/autoware/autoware/src/universe/autoware.universe/visualization/tier4_state_rviz_plugin/src/custom_icon_label.cpp:68:19: error: result of integer division used in a floating point context; possible loss of precision [bugprone-integer-division,-warnings-as-errors]
  path.addEllipse(width() / 2 - radius, height() / 2 - radius, diameter, diameter);
                  ^
/home/emb4/autoware/autoware/src/universe/autoware.universe/visualization/tier4_state_rviz_plugin/src/custom_icon_label.cpp:68:41: error: result of integer division used in a floating point context; possible loss of precision [bugprone-integer-division,-warnings-as-errors]
  path.addEllipse(width() / 2 - radius, height() / 2 - radius, diameter, diameter);
                                        ^
/home/emb4/autoware/autoware/src/universe/autoware.universe/visualization/tier4_state_rviz_plugin/src/custom_segmented_button.cpp:69:31: error: result of integer division used in a floating point context; possible loss of precision [bugprone-integer-division,-warnings-as-errors]
  path.addRoundedRect(rect(), height() / 2, height() / 2);
                              ^
/home/emb4/autoware/autoware/src/universe/autoware.universe/visualization/tier4_state_rviz_plugin/src/custom_segmented_button.cpp:69:45: error: result of integer division used in a floating point context; possible loss of precision [bugprone-integer-division,-warnings-as-errors]
  path.addRoundedRect(rect(), height() / 2, height() / 2);
                                            ^
/home/emb4/autoware/autoware/src/universe/autoware.universe/visualization/tier4_state_rviz_plugin/src/custom_segmented_button_item.cpp:128:19: error: result of integer division used in a floating point context; possible loss of precision [bugprone-integer-division,-warnings-as-errors]
  double radius = (height() - 2) / 2;
                  ^
```
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
