### PR TITLE
refactor(lane_change): separate path-related function to utils/path

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/CMakeLists.txt
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/CMakeLists.txt
@@ -12,6 +12,7 @@ ament_auto_add_library(${PROJECT_NAME} SHARED
   src/utils/calculation.cpp
   src/utils/markers.cpp
   src/utils/utils.cpp
+  src/utils/path.cpp
 )
 
 if(BUILD_TESTING)

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/base_class.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/base_class.hpp
@@ -235,9 +235,6 @@ public:
 protected:
   virtual int getNumToPreferredLane(const lanelet::ConstLanelet & lane) const = 0;
 
-  virtual bool get_prepare_segment(
-    PathWithLaneId & prepare_segment, const double prepare_length) const = 0;
-
   virtual bool isValidPath(const PathWithLaneId & path) const = 0;
 
   virtual bool isAbleToStopSafely() const = 0;

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/base_class.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/base_class.hpp
@@ -102,8 +102,6 @@ public:
 
   virtual LaneChangePath getLaneChangePath() const = 0;
 
-  virtual BehaviorModuleOutput getTerminalLaneChangePath() const = 0;
-
   virtual bool isEgoOnPreparePhase() const = 0;
 
   virtual bool isRequiredStop(const bool is_trailing_object) = 0;

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/scene.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/scene.hpp
@@ -64,8 +64,6 @@ public:
 
   LaneChangePath getLaneChangePath() const override;
 
-  BehaviorModuleOutput getTerminalLaneChangePath() const override;
-
   BehaviorModuleOutput generateOutput() override;
 
   void extendOutputDrivableArea(BehaviorModuleOutput & output) const override;

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/scene.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/scene.hpp
@@ -128,14 +128,6 @@ protected:
 
   void filterOncomingObjects(PredictedObjects & objects) const;
 
-  bool get_prepare_segment(
-    PathWithLaneId & prepare_segment, const double prepare_length) const override;
-
-  PathWithLaneId getTargetSegment(
-    const lanelet::ConstLanelets & target_lanes, const Pose & lane_changing_start_pose,
-    const double target_lane_length, const double lane_changing_length,
-    const double lane_changing_velocity, const double buffer_for_next_lane_change) const;
-
   std::vector<LaneChangePhaseMetrics> get_prepare_metrics() const;
   std::vector<LaneChangePhaseMetrics> get_lane_changing_metrics(
     const PathWithLaneId & prep_segment, const LaneChangePhaseMetrics & prep_metrics,
@@ -143,30 +135,17 @@ protected:
 
   bool get_lane_change_paths(LaneChangePaths & candidate_paths) const;
 
-  LaneChangePath get_candidate_path(
-    const LaneChangePhaseMetrics & prep_metrics, const LaneChangePhaseMetrics & lc_metrics,
-    const PathWithLaneId & prep_segment, const std::vector<std::vector<int64_t>> & sorted_lane_ids,
-    const Pose & lc_start_pose, const double shift_length) const;
-
   bool check_candidate_path_safety(
     const LaneChangePath & candidate_path, const lane_change::TargetObjects & target_objects) const;
-
-  std::optional<LaneChangePath> calcTerminalLaneChangePath(
-    const lanelet::ConstLanelets & current_lanes,
-    const lanelet::ConstLanelets & target_lanes) const;
 
   bool isValidPath(const PathWithLaneId & path) const override;
 
   PathSafetyStatus isLaneChangePathSafe(
     const LaneChangePath & lane_change_path,
+    const std::vector<std::vector<PoseWithVelocityStamped>> & ego_predicted_paths,
     const lane_change::TargetObjects & collision_check_objects,
     const utils::path_safety_checker::RSSparams & rss_params,
-    const size_t deceleration_sampling_num, CollisionCheckDebugMap & debug_data) const;
-
-  bool has_collision_with_decel_patterns(
-    const LaneChangePath & lane_change_path, const ExtendedPredictedObjects & objects,
-    const size_t deceleration_sampling_num, const RSSparams & rss_param,
-    const bool check_prepare_phase, CollisionCheckDebugMap & debug_data) const;
+    CollisionCheckDebugMap & debug_data) const;
 
   bool is_collided(
     const LaneChangePath & lane_change_path, const ExtendedPredictedObject & obj,
@@ -177,24 +156,6 @@ protected:
   double get_max_velocity_for_safety_check() const;
 
   bool is_ego_stuck() const;
-
-  /**
-   * @brief Checks if the given pose is a valid starting point for a lane change.
-   *
-   * This function determines whether the given pose (position) of the vehicle is within
-   * the area of either the target neighbor lane or the target lane itself. It uses geometric
-   * checks to see if the start point of the lane change is covered by the polygons representing
-   * these lanes.
-   *
-   * @param common_data_ptr Shared pointer to a CommonData structure, which should include:
-   *  - Non-null `lanes_polygon_ptr` that contains the polygon data for lanes.
-   * @param pose The current pose of the vehicle
-   *
-   * @return `true` if the pose is within either the target neighbor lane or the target lane;
-   * `false` otherwise.
-   */
-  bool is_valid_start_point(
-    const lane_change::CommonDataPtr & common_data_ptr, const Pose & pose) const;
 
   bool check_prepare_phase() const;
 
@@ -213,7 +174,6 @@ protected:
 
   std::vector<PathPointWithLaneId> path_after_intersection_;
   double stop_time_{0.0};
-  static constexpr double floating_err_th{1e-3};
 };
 }  // namespace autoware::behavior_path_planner
 #endif  // AUTOWARE__BEHAVIOR_PATH_LANE_CHANGE_MODULE__SCENE_HPP_

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/scene.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/scene.hpp
@@ -145,7 +145,7 @@ protected:
     const utils::path_safety_checker::RSSparams & rss_params,
     CollisionCheckDebugMap & debug_data) const;
 
-  bool is_collided(
+  bool is_colliding(
     const LaneChangePath & lane_change_path, const ExtendedPredictedObject & obj,
     const std::vector<PoseWithVelocityStamped> & ego_predicted_path,
     const RSSparams & selected_rss_param, const bool check_prepare_phase,

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/structs/data.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/structs/data.hpp
@@ -160,6 +160,8 @@ struct TargetObjects
   : leading(std::move(leading)), trailing(std::move(trailing))
   {
   }
+
+  [[nodiscard]] bool empty() const { return leading.empty() && trailing.empty(); }
 };
 
 enum class ModuleType {

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/path.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/path.hpp
@@ -27,16 +27,74 @@ namespace autoware::behavior_path_planner::utils::lane_change
 using behavior_path_planner::LaneChangePath;
 using behavior_path_planner::lane_change::CommonDataPtr;
 
+/**
+ * @brief Generates a prepare segment for a lane change maneuver.
+ *
+ * This function generates the "prepare segment" of the path by trimming it to the specified length,
+ * adjusting longitudinal velocity for acceleration or deceleration, and ensuring the starting point
+ * meets necessary constraints for a lane change. the ego vehicle for a lane change. It adjusts the
+ *
+ * @param common_data_ptr Shared pointer to CommonData containing current and target lane
+ *                        information, vehicle parameters, and ego state.
+ * @param prev_module_path The input path from the previous module, which will be used
+ *                         as the base for the prepare segment.
+ * @param prep_metric Preparation metrics containing desired length and velocity for the segment.
+ * @param prepare_segment Output parameter where the resulting prepare segment path will be stored.
+ *
+ * @throws std::logic_error If the lane change start point is behind the target lanelet or
+ *                          if lane information is invalid.
+ *
+ * @return true if the prepare segment is successfully generated, false otherwise.
+ */
 bool get_prepare_segment(
   const CommonDataPtr & common_data_ptr, const PathWithLaneId & prev_module_path,
   const LaneChangePhaseMetrics prep_metric, PathWithLaneId & prepare_segment);
 
+/**
+ * @brief Generates the candidate path for a lane change maneuver.
+ *
+ * This function calculates the candidate lane change path based on the provided preparation
+ * and lane change metrics. It resamples the target lane reference path, determines the start
+ * and end poses for the lane change, and constructs the shift line required for the maneuver.
+ * The function ensures that the resulting path satisfies length and distance constraints.
+ *
+ * @param common_data_ptr Shared pointer to CommonData containing route, lane, and transient data.
+ * @param prep_metric Metrics for the preparation phase, including path length and velocity.
+ * @param lc_metric Metrics for the lane change phase, including path length and velocity.
+ * @param prep_segment The path segment prepared before initiating the lane change.
+ * @param sorted_lane_ids A vector of sorted lane IDs used for updating lane information in the
+ * path.
+ * @param lc_start_pose The pose where the lane change begins.
+ * @param shift_length The lateral distance to shift during the lane change maneuver.
+ *
+ * @throws std::logic_error If the target lane reference path is empty, candidate path generation
+ * fails, or the resulting path length exceeds terminal constraints.
+ *
+ * @return LaneChangePath The constructed candidate lane change path.
+ */
 LaneChangePath get_candidate_path(
   const CommonDataPtr & common_data_ptr, const LaneChangePhaseMetrics & prep_metric,
   const LaneChangePhaseMetrics & lc_metric, const PathWithLaneId & prep_segment,
   const std::vector<std::vector<int64_t>> & sorted_lane_ids, const Pose & lc_start_pose,
   const double shift_length);
 
+/**
+ * @brief Constructs a candidate path for a lane change maneuver.
+ *
+ * This function generates a candidate lane change path by shifting the target lane's reference path
+ * and combining it with the prepare segment. It verifies the path's validity by checking the yaw
+ * difference, adjusting longitudinal velocity, and updating lane IDs based on the provided lane
+ * sorting information.
+ *
+ * @param lane_change_info Information about the lane change, including shift line and target
+ * velocity.
+ * @param prepare_segment The path segment leading up to the lane change.
+ * @param target_lane_reference_path The reference path of the target lane.
+ * @param sorted_lane_ids A vector of sorted lane IDs used to update the candidate path's lane IDs.
+ *
+ * @return std::optional<LaneChangePath> The constructed candidate path if valid, or std::nullopt
+ *                                       if the path fails any constraints.
+ */
 std::optional<LaneChangePath> construct_candidate_path(
   const LaneChangeInfo & lane_change_info, const PathWithLaneId & prepare_segment,
   const PathWithLaneId & target_lane_reference_path,

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/path.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/path.hpp
@@ -95,7 +95,7 @@ LaneChangePath get_candidate_path(
  * @return std::optional<LaneChangePath> The constructed candidate path if valid, or std::nullopt
  *                                       if the path fails any constraints.
  */
-std::optional<LaneChangePath> construct_candidate_path(
+LaneChangePath construct_candidate_path(
   const LaneChangeInfo & lane_change_info, const PathWithLaneId & prepare_segment,
   const PathWithLaneId & target_lane_reference_path,
   const std::vector<std::vector<int64_t>> & sorted_lane_ids);

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/path.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/path.hpp
@@ -32,7 +32,7 @@ using behavior_path_planner::lane_change::CommonDataPtr;
  *
  * This function generates the "prepare segment" of the path by trimming it to the specified length,
  * adjusting longitudinal velocity for acceleration or deceleration, and ensuring the starting point
- * meets necessary constraints for a lane change. the ego vehicle for a lane change. It adjusts the
+ * meets necessary constraints for a lane change.
  *
  * @param common_data_ptr Shared pointer to CommonData containing current and target lane
  *                        information, vehicle parameters, and ego state.
@@ -75,8 +75,7 @@ bool get_prepare_segment(
 LaneChangePath get_candidate_path(
   const CommonDataPtr & common_data_ptr, const LaneChangePhaseMetrics & prep_metric,
   const LaneChangePhaseMetrics & lc_metric, const PathWithLaneId & prep_segment,
-  const std::vector<std::vector<int64_t>> & sorted_lane_ids, const Pose & lc_start_pose,
-  const double shift_length);
+  const std::vector<std::vector<int64_t>> & sorted_lane_ids, const double shift_length);
 
 /**
  * @brief Constructs a candidate path for a lane change maneuver.

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/path.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/path.hpp
@@ -41,8 +41,5 @@ std::optional<LaneChangePath> construct_candidate_path(
   const LaneChangeInfo & lane_change_info, const PathWithLaneId & prepare_segment,
   const PathWithLaneId & target_lane_reference_path,
   const std::vector<std::vector<int64_t>> & sorted_lane_ids);
-
-std::optional<LaneChangePath> calcTerminalLaneChangePath(
-  const CommonDataPtr & common_data_ptr, const PathWithLaneId & prev_module_path);
 }  // namespace autoware::behavior_path_planner::utils::lane_change
 #endif  // AUTOWARE__BEHAVIOR_PATH_LANE_CHANGE_MODULE__UTILS__PATH_HPP_

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/path.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/path.hpp
@@ -1,0 +1,48 @@
+// Copyright 2024 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__BEHAVIOR_PATH_LANE_CHANGE_MODULE__UTILS__PATH_HPP_
+#define AUTOWARE__BEHAVIOR_PATH_LANE_CHANGE_MODULE__UTILS__PATH_HPP_
+
+#include "autoware/behavior_path_lane_change_module/structs/data.hpp"
+#include "autoware/behavior_path_lane_change_module/structs/path.hpp"
+
+#include <autoware/behavior_path_planner_common/utils/utils.hpp>
+
+#include <vector>
+
+namespace autoware::behavior_path_planner::utils::lane_change
+{
+using behavior_path_planner::LaneChangePath;
+using behavior_path_planner::lane_change::CommonDataPtr;
+
+bool get_prepare_segment(
+  const CommonDataPtr & common_data_ptr, const PathWithLaneId & prev_module_path,
+  const LaneChangePhaseMetrics prep_metric, PathWithLaneId & prepare_segment);
+
+LaneChangePath get_candidate_path(
+  const CommonDataPtr & common_data_ptr, const LaneChangePhaseMetrics & prep_metric,
+  const LaneChangePhaseMetrics & lc_metric, const PathWithLaneId & prep_segment,
+  const std::vector<std::vector<int64_t>> & sorted_lane_ids, const Pose & lc_start_pose,
+  const double shift_length);
+
+std::optional<LaneChangePath> construct_candidate_path(
+  const LaneChangeInfo & lane_change_info, const PathWithLaneId & prepare_segment,
+  const PathWithLaneId & target_lane_reference_path,
+  const std::vector<std::vector<int64_t>> & sorted_lane_ids);
+
+std::optional<LaneChangePath> calcTerminalLaneChangePath(
+  const CommonDataPtr & common_data_ptr, const PathWithLaneId & prev_module_path);
+}  // namespace autoware::behavior_path_planner::utils::lane_change
+#endif  // AUTOWARE__BEHAVIOR_PATH_LANE_CHANGE_MODULE__UTILS__PATH_HPP_

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/utils.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/utils.hpp
@@ -61,7 +61,7 @@ using geometry_msgs::msg::Pose;
 using geometry_msgs::msg::Twist;
 using path_safety_checker::CollisionCheckDebugMap;
 using tier4_planning_msgs::msg::PathWithLaneId;
-rclcpp::Logger get_logger();
+
 bool is_mandatory_lane_change(const ModuleType lc_type);
 
 std::vector<int64_t> replaceWithSortedIds(

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/utils.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/utils.hpp
@@ -62,6 +62,8 @@ using geometry_msgs::msg::Twist;
 using path_safety_checker::CollisionCheckDebugMap;
 using tier4_planning_msgs::msg::PathWithLaneId;
 
+rclcpp::Logger get_logger();
+
 bool is_mandatory_lane_change(const ModuleType lc_type);
 
 std::vector<int64_t> replaceWithSortedIds(

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/utils.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/utils.hpp
@@ -66,6 +66,9 @@ rclcpp::Logger get_logger();
 
 bool is_mandatory_lane_change(const ModuleType lc_type);
 
+void set_prepare_velocity(
+  PathWithLaneId & prepare_segment, const double current_velocity, const double prepare_velocity);
+
 std::vector<int64_t> replaceWithSortedIds(
   const std::vector<int64_t> & original_lane_ids,
   const std::vector<std::vector<int64_t>> & sorted_lane_ids);

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/utils.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/utils.hpp
@@ -397,10 +397,37 @@ std::vector<lanelet::ConstLanelets> get_preceding_lanes(const CommonDataPtr & co
 bool object_path_overlaps_lanes(
   const ExtendedPredictedObject & object, const lanelet::BasicPolygon2d & lanes_polygon);
 
+/**
+ * @brief Converts a lane change path into multiple predicted paths with varying acceleration
+ * profiles.
+ *
+ * This function generates a set of predicted paths for the ego vehicle during a lane change,
+ * using different acceleration values within the specified range. It accounts for deceleration
+ * sampling if the global minimum acceleration differs from the lane-changing acceleration.
+ *
+ * @param common_data_ptr Shared pointer to CommonData containing parameters and state information.
+ * @param lane_change_path The lane change path used to generate predicted paths.
+ * @param deceleration_sampling_num Number of samples for deceleration profiles to generate paths.
+ *
+ * @return std::vector<std::vector<PoseWithVelocityStamped>> A collection of predicted paths, where
+ *         each path is represented as a series of poses with associated velocity.
+ */
 std::vector<std::vector<PoseWithVelocityStamped>> convert_to_predicted_paths(
   const CommonDataPtr & common_data_ptr, const LaneChangePath & lane_change_path,
   const size_t deceleration_sampling_num);
 
+/**
+ * @brief Validates whether a given pose is a valid starting point for a lane change.
+ *
+ * This function checks if the specified pose lies within the polygons representing
+ * the target lane or its neighboring areas. This ensures that the starting point is
+ * appropriately positioned for initiating a lane change, even if previous paths were adjusted.
+ *
+ * @param common_data_ptr Shared pointer to CommonData containing lane polygon information.
+ * @param pose The pose to validate as a potential lane change starting point.
+ *
+ * @return true if the pose is within the target or target neighbor polygons, false otherwise.
+ */
 bool is_valid_start_point(const lane_change::CommonDataPtr & common_data_ptr, const Pose & pose);
 }  // namespace autoware::behavior_path_planner::utils::lane_change
 #endif  // AUTOWARE__BEHAVIOR_PATH_LANE_CHANGE_MODULE__UTILS__UTILS_HPP_

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/scene.cpp
@@ -1160,8 +1160,7 @@ bool NormalLaneChange::get_lane_change_paths(LaneChangePaths & candidate_paths) 
       LaneChangePath candidate_path;
       try {
         candidate_path = utils::lane_change::get_candidate_path(
-          common_data_ptr_, prep_metric, lc_metric, prepare_segment, sorted_lane_ids,
-          lane_changing_start_pose, shift_length);
+          common_data_ptr_, prep_metric, lc_metric, prepare_segment, sorted_lane_ids, shift_length);
       } catch (const std::exception & e) {
         debug_print_lat(std::string("Reject: ") + e.what());
         continue;

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/scene.cpp
@@ -1145,6 +1145,11 @@ bool NormalLaneChange::get_lane_change_paths(LaneChangePaths & candidate_paths) 
     const auto lane_changing_metrics = get_lane_changing_metrics(
       prepare_segment, prep_metric, shift_length, dist_to_next_regulatory_element);
 
+    // set_prepare_velocity must only be called after computing lane change metrics, as lane change
+    // metrics rely on the prepare segment's original velocity as max_path_velocity.
+    utils::lane_change::set_prepare_velocity(
+      prepare_segment, common_data_ptr_->get_ego_speed(), prep_metric.velocity);
+
     for (const auto & lc_metric : lane_changing_metrics) {
       const auto debug_print_lat = [&](const std::string & s) {
         RCLCPP_DEBUG(

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/scene.cpp
@@ -1522,7 +1522,7 @@ PathSafetyStatus NormalLaneChange::isLaneChangePathSafe(
         const auto selected_rss_param = (object.initial_twist.linear.x <= stopped_obj_vel_th)
                                           ? lane_change_parameters_->safety.rss_params_for_parked
                                           : rss_params;
-        return is_collided(
+        return is_colliding(
           lane_change_path, object, ego_predicted_path, selected_rss_param, is_check_prepare_phase,
           debug_data);
       };
@@ -1541,20 +1541,20 @@ PathSafetyStatus NormalLaneChange::isLaneChangePathSafe(
   return {is_safe, !is_object_behind_ego};
 }
 
-bool NormalLaneChange::is_collided(
+bool NormalLaneChange::is_colliding(
   const LaneChangePath & lane_change_path, const ExtendedPredictedObject & obj,
   const std::vector<PoseWithVelocityStamped> & ego_predicted_path,
   const RSSparams & selected_rss_param, const bool check_prepare_phase,
   CollisionCheckDebugMap & debug_data) const
 {
-  constexpr auto is_collided{true};
+  constexpr auto is_colliding{true};
 
   if (lane_change_path.path.points.empty()) {
-    return !is_collided;
+    return !is_colliding;
   }
 
   if (ego_predicted_path.empty()) {
-    return !is_collided;
+    return !is_colliding;
   }
 
   const auto & lanes_polygon_ptr = common_data_ptr_->lanes_polygon_ptr;
@@ -1562,7 +1562,7 @@ bool NormalLaneChange::is_collided(
   const auto & expanded_target_polygon = lanes_polygon_ptr->target;
 
   if (current_polygon.empty() || expanded_target_polygon.empty()) {
-    return !is_collided;
+    return !is_colliding;
   }
 
   constexpr auto is_safe{true};
@@ -1613,10 +1613,10 @@ bool NormalLaneChange::is_collided(
 
     utils::path_safety_checker::updateCollisionCheckDebugMap(
       debug_data, current_debug_data, !is_safe);
-    return is_collided;
+    return is_colliding;
   }
   utils::path_safety_checker::updateCollisionCheckDebugMap(debug_data, current_debug_data, is_safe);
-  return !is_collided;
+  return !is_colliding;
 }
 
 double NormalLaneChange::get_max_velocity_for_safety_check() const

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/path.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/path.cpp
@@ -1,0 +1,477 @@
+// Copyright 2024 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/behavior_path_lane_change_module/utils/path.hpp"
+
+#include "autoware/behavior_path_lane_change_module/structs/data.hpp"
+#include "autoware/behavior_path_lane_change_module/utils/utils.hpp"
+#include "autoware/behavior_path_planner_common/utils/path_utils.hpp"
+#include "autoware/behavior_path_planner_common/utils/utils.hpp"
+
+#include <autoware/motion_utils/trajectory/path_shift.hpp>
+#include <autoware/universe_utils/system/stop_watch.hpp>
+#include <autoware_frenet_planner/frenet_planner.hpp>
+#include <range/v3/action/insert.hpp>
+#include <range/v3/algorithm.hpp>
+#include <range/v3/numeric/accumulate.hpp>
+#include <range/v3/view.hpp>
+
+#include <algorithm>
+#include <limits>
+#include <vector>
+
+namespace
+{
+using autoware::behavior_path_planner::LaneChangeInfo;
+using autoware::behavior_path_planner::PathPointWithLaneId;
+using autoware::behavior_path_planner::PathShifter;
+using autoware::behavior_path_planner::PathWithLaneId;
+using autoware::behavior_path_planner::ShiftedPath;
+using autoware::behavior_path_planner::lane_change::CommonDataPtr;
+using autoware::behavior_path_planner::lane_change::LCParamPtr;
+
+using autoware::behavior_path_planner::LaneChangePhaseMetrics;
+using autoware::behavior_path_planner::ShiftLine;
+using geometry_msgs::msg::Pose;
+
+double calcLaneChangeResampleInterval(
+  const double lane_changing_length, const double lane_changing_velocity)
+{
+  constexpr auto min_resampling_points{30.0};
+  constexpr auto resampling_dt{0.2};
+  return std::max(
+    lane_changing_length / min_resampling_points, lane_changing_velocity * resampling_dt);
+}
+
+PathWithLaneId get_reference_path_from_target_Lane(
+  const CommonDataPtr & common_data_ptr, const Pose & lane_changing_start_pose,
+  const double lane_changing_length, const double resample_interval)
+{
+  const auto & route_handler = *common_data_ptr->route_handler_ptr;
+  const auto & target_lanes = common_data_ptr->lanes_ptr->target;
+  const auto target_lane_length = common_data_ptr->transient_data.target_lane_length;
+  const auto is_goal_in_route = common_data_ptr->lanes_ptr->target_lane_in_goal_section;
+  const auto next_lc_buffer = common_data_ptr->transient_data.next_dist_buffer.min;
+  const auto forward_path_length = common_data_ptr->bpp_param_ptr->forward_path_length;
+
+  const auto lane_change_start_arc_position =
+    lanelet::utils::getArcCoordinates(target_lanes, lane_changing_start_pose);
+
+  const double s_start = lane_change_start_arc_position.length;
+  const double s_end = std::invoke([&]() {
+    const auto dist_from_lc_start = s_start + lane_changing_length + forward_path_length;
+    if (is_goal_in_route) {
+      const double s_goal =
+        lanelet::utils::getArcCoordinates(target_lanes, route_handler.getGoalPose()).length -
+        next_lc_buffer;
+      return std::min(dist_from_lc_start, s_goal);
+    }
+    return std::min(dist_from_lc_start, target_lane_length - next_lc_buffer);
+  });
+
+  constexpr double epsilon = 1e-4;
+  if (s_end - s_start + epsilon < lane_changing_length) {
+    return PathWithLaneId();
+  }
+
+  const auto lane_changing_reference_path =
+    route_handler.getCenterLinePath(target_lanes, s_start, s_end);
+
+  return autoware::behavior_path_planner::utils::resamplePathWithSpline(
+    lane_changing_reference_path, resample_interval, true, {0.0, lane_changing_length});
+}
+
+ShiftLine get_lane_changing_shift_line(
+  const Pose & lane_changing_start_pose, const Pose & lane_changing_end_pose,
+  const PathWithLaneId & reference_path, const double shift_length)
+{
+  ShiftLine shift_line;
+  shift_line.end_shift_length = shift_length;
+  shift_line.start = lane_changing_start_pose;
+  shift_line.end = lane_changing_end_pose;
+  shift_line.start_idx = autoware::motion_utils::findNearestIndex(
+    reference_path.points, lane_changing_start_pose.position);
+  shift_line.end_idx = autoware::motion_utils::findNearestIndex(
+    reference_path.points, lane_changing_end_pose.position);
+
+  return shift_line;
+}
+
+ShiftedPath get_shifted_path(
+  const PathWithLaneId & target_lane_reference_path, const LaneChangeInfo & lane_change_info)
+{
+  const auto & shift_line = lane_change_info.shift_line;
+  const auto longitudinal_acceleration = lane_change_info.longitudinal_acceleration;
+  const auto lane_change_velocity = lane_change_info.velocity;
+  ShiftedPath shifted_path;
+  PathShifter path_shifter;
+  path_shifter.setPath(target_lane_reference_path);
+  path_shifter.addShiftLine(shift_line);
+  path_shifter.setLongitudinalAcceleration(longitudinal_acceleration.lane_changing);
+
+  // offset front side
+  bool offset_back = false;
+
+  const auto initial_lane_changing_velocity = lane_change_velocity.lane_changing;
+  path_shifter.setVelocity(initial_lane_changing_velocity);
+  path_shifter.setLateralAccelerationLimit(std::abs(lane_change_info.lateral_acceleration));
+
+  if (!path_shifter.generate(&shifted_path, offset_back)) {
+    RCLCPP_DEBUG(
+      autoware::behavior_path_planner::utils::lane_change::get_logger(),
+      "Failed to generate shifted path.");
+  }
+  // TODO(Zulfaqar Azmi): have to think of a more feasible solution for points being remove by
+  // path shifter.
+  return shifted_path;
+}
+
+std::optional<double> exceed_yaw_threshold(
+  const PathWithLaneId & prepare_segment, const PathWithLaneId & lane_changing_segment)
+{
+  const auto & prepare = prepare_segment.points;
+  const auto & lane_changing = lane_changing_segment.points;
+
+  if (prepare.size() <= 1 || lane_changing.size() <= 1) {
+    return std::nullopt;
+  }
+
+  const auto & p1 = std::prev(prepare.end() - 1)->point.pose;
+  const auto & p2 = std::next(lane_changing.begin())->point.pose;
+  const auto yaw_diff = std::abs(autoware::universe_utils::normalizeRadian(
+    tf2::getYaw(p1.orientation) - tf2::getYaw(p2.orientation)));
+  if (yaw_diff > autoware::universe_utils::deg2rad(5.0)) {
+    return yaw_diff;
+  }
+  return std::nullopt;
+}
+
+PathWithLaneId getTargetSegment(
+  const CommonDataPtr & common_data_ptr, const lanelet::ConstLanelets & target_lanes,
+  const Pose & lane_changing_start_pose, const double target_lane_length,
+  const double lane_changing_length, const double lane_changing_velocity,
+  const double buffer_for_next_lane_change)
+{
+  const auto & route_handler = *common_data_ptr->route_handler_ptr;
+  const auto forward_path_length = common_data_ptr->bpp_param_ptr->forward_path_length;
+
+  const double s_start = std::invoke([&lane_changing_start_pose, &target_lanes,
+                                      &lane_changing_length, &target_lane_length,
+                                      &buffer_for_next_lane_change]() {
+    const auto arc_to_start_pose =
+      lanelet::utils::getArcCoordinates(target_lanes, lane_changing_start_pose);
+    const double dist_from_front_target_lanelet = arc_to_start_pose.length + lane_changing_length;
+    const double end_of_lane_dist_without_buffer = target_lane_length - buffer_for_next_lane_change;
+    return std::min(dist_from_front_target_lanelet, end_of_lane_dist_without_buffer);
+  });
+
+  const double s_end = std::invoke(
+    [&s_start, &forward_path_length, &target_lane_length, &buffer_for_next_lane_change]() {
+      const double dist_from_start = s_start + forward_path_length;
+      const double dist_from_end = target_lane_length - buffer_for_next_lane_change;
+      return std::max(
+        std::min(dist_from_start, dist_from_end), s_start + std::numeric_limits<double>::epsilon());
+    });
+
+  PathWithLaneId target_segment = route_handler.getCenterLinePath(target_lanes, s_start, s_end);
+  for (auto & point : target_segment.points) {
+    point.point.longitudinal_velocity_mps =
+      std::min(point.point.longitudinal_velocity_mps, static_cast<float>(lane_changing_velocity));
+  }
+
+  return target_segment;
+}
+};  // namespace
+
+namespace autoware::behavior_path_planner::utils::lane_change
+{
+using behavior_path_planner::lane_change::CommonDataPtr;
+
+bool get_prepare_segment(
+  const CommonDataPtr & common_data_ptr, const PathWithLaneId & prev_module_path,
+  const LaneChangePhaseMetrics prep_metric, PathWithLaneId & prepare_segment)
+{
+  const auto & current_lanes = common_data_ptr->lanes_ptr->current;
+  const auto & target_lanes = common_data_ptr->lanes_ptr->target;
+  const auto backward_path_length = common_data_ptr->bpp_param_ptr->backward_path_length;
+
+  if (current_lanes.empty() || target_lanes.empty()) {
+    throw std::logic_error("lane change start is behind target lanelet!");
+  }
+
+  prepare_segment = prev_module_path;
+  const size_t current_seg_idx =
+    autoware::motion_utils::findFirstNearestSegmentIndexWithSoftConstraints(
+      prepare_segment.points, common_data_ptr->get_ego_pose(), 3.0, 1.0);
+  utils::clipPathLength(prepare_segment, current_seg_idx, prep_metric.length, backward_path_length);
+
+  if (prepare_segment.points.empty()) return false;
+
+  const auto & lc_start_pose = prepare_segment.points.back().point.pose;
+
+  // TODO(Quda, Azu): Is it possible to remove these checks if we ensure prepare segment length is
+  // larger than distance to target lane start
+  if (!is_valid_start_point(common_data_ptr, lc_start_pose)) return false;
+
+  // lane changing start is at the end of prepare segment
+  const auto target_length_from_lane_change_start_pose =
+    utils::getArcLengthToTargetLanelet(current_lanes, target_lanes.front(), lc_start_pose);
+
+  // Check if the lane changing start point is not on the lanes next to target lanes,
+  if (target_length_from_lane_change_start_pose > std::numeric_limits<double>::epsilon()) {
+    throw std::logic_error("lane change start is behind target lanelet!");
+  }
+
+  if (common_data_ptr->get_ego_speed() >= prep_metric.velocity) {
+    // deceleration
+    prepare_segment.points.back().point.longitudinal_velocity_mps = std::min(
+      prepare_segment.points.back().point.longitudinal_velocity_mps,
+      static_cast<float>(prep_metric.velocity));
+  } else {
+    // acceleration
+    for (auto & point : prepare_segment.points) {
+      point.point.longitudinal_velocity_mps =
+        std::min(point.point.longitudinal_velocity_mps, static_cast<float>(prep_metric.velocity));
+    }
+  }
+
+  return true;
+}
+
+LaneChangePath get_candidate_path(
+  const CommonDataPtr & common_data_ptr, const LaneChangePhaseMetrics & prep_metric,
+  const LaneChangePhaseMetrics & lc_metric, const PathWithLaneId & prep_segment,
+  const std::vector<std::vector<int64_t>> & sorted_lane_ids, const Pose & lc_start_pose,
+  const double shift_length)
+{
+  const auto & route_handler = *common_data_ptr->route_handler_ptr;
+  const auto & target_lanes = common_data_ptr->lanes_ptr->target;
+
+  const auto resample_interval =
+    calcLaneChangeResampleInterval(lc_metric.length, prep_metric.velocity);
+  const auto target_lane_reference_path = get_reference_path_from_target_Lane(
+    common_data_ptr, lc_start_pose, lc_metric.length, resample_interval);
+
+  if (target_lane_reference_path.points.empty()) {
+    throw std::logic_error("target_lane_reference_path is empty!");
+  }
+
+  const auto lc_end_pose = std::invoke([&]() {
+    const auto dist_to_lc_start =
+      lanelet::utils::getArcCoordinates(target_lanes, lc_start_pose).length;
+    const auto dist_to_lc_end = dist_to_lc_start + lc_metric.length;
+    return route_handler.get_pose_from_2d_arc_length(target_lanes, dist_to_lc_end);
+  });
+
+  const auto shift_line = get_lane_changing_shift_line(
+    lc_start_pose, lc_end_pose, target_lane_reference_path, shift_length);
+
+  LaneChangeInfo lane_change_info{prep_metric, lc_metric, lc_start_pose, lc_end_pose, shift_line};
+
+  const auto candidate_path = utils::lane_change::construct_candidate_path(
+    lane_change_info, prep_segment, target_lane_reference_path, sorted_lane_ids);
+
+  if (!candidate_path) {
+    throw std::logic_error("failed to generate candidate path!");
+  }
+
+  if (
+    candidate_path.value().info.length.sum() +
+      common_data_ptr->transient_data.next_dist_buffer.min >
+    common_data_ptr->transient_data.dist_to_terminal_end) {
+    throw std::logic_error("invalid candidate path length!");
+  }
+
+  return *candidate_path;
+}
+
+std::optional<LaneChangePath> construct_candidate_path(
+  const LaneChangeInfo & lane_change_info, const PathWithLaneId & prepare_segment,
+  const PathWithLaneId & target_lane_reference_path,
+  const std::vector<std::vector<int64_t>> & sorted_lane_ids)
+{
+  const auto & shift_line = lane_change_info.shift_line;
+  const auto terminal_lane_changing_velocity = lane_change_info.terminal_lane_changing_velocity;
+
+  ShiftedPath shifted_path = get_shifted_path(target_lane_reference_path, lane_change_info);
+  if (shifted_path.path.points.size() < shift_line.end_idx + 1) {
+    RCLCPP_DEBUG(get_logger(), "Path points are removed by PathShifter.");
+    return std::nullopt;
+  }
+
+  LaneChangePath candidate_path;
+  candidate_path.info = lane_change_info;
+
+  const auto lane_change_end_idx = autoware::motion_utils::findNearestIndex(
+    shifted_path.path.points, candidate_path.info.lane_changing_end);
+
+  if (!lane_change_end_idx) {
+    RCLCPP_DEBUG(get_logger(), "Lane change end idx not found on target path.");
+    return std::nullopt;
+  }
+
+  for (size_t i = 0; i < shifted_path.path.points.size(); ++i) {
+    auto & point = shifted_path.path.points.at(i);
+    if (i < *lane_change_end_idx) {
+      point.lane_ids = replaceWithSortedIds(point.lane_ids, sorted_lane_ids);
+      point.point.longitudinal_velocity_mps = std::min(
+        point.point.longitudinal_velocity_mps, static_cast<float>(terminal_lane_changing_velocity));
+      continue;
+    }
+    const auto nearest_idx =
+      autoware::motion_utils::findNearestIndex(target_lane_reference_path.points, point.point.pose);
+    point.lane_ids = target_lane_reference_path.points.at(*nearest_idx).lane_ids;
+  }
+
+  if (const auto yaw_diff_opt = exceed_yaw_threshold(prepare_segment, shifted_path.path)) {
+    RCLCPP_DEBUG(
+      get_logger(), "Excessive yaw difference %.3f which exceeds the 5 degrees threshold.",
+      autoware::universe_utils::rad2deg(yaw_diff_opt.value()));
+    return std::nullopt;
+  }
+
+  candidate_path.path = utils::combinePath(prepare_segment, shifted_path.path);
+  candidate_path.shifted_path = shifted_path;
+
+  return std::optional<LaneChangePath>{candidate_path};
+}
+
+std::optional<LaneChangePath> calcTerminalLaneChangePath(
+  const CommonDataPtr & common_data_ptr, const PathWithLaneId & prev_module_path)
+{
+  const auto is_empty = [&](const auto & data, const auto & s) {
+    if (!data.empty()) return false;
+    RCLCPP_WARN(get_logger(), "%s is empty. Not expected.", s);
+    return true;
+  };
+
+  const auto & current_lanes = common_data_ptr->lanes_ptr->current;
+  const auto & target_lanes = common_data_ptr->lanes_ptr->target;
+  const auto target_lane_neighbors_polygon_2d = common_data_ptr->lanes_polygon_ptr->target_neighbor;
+
+  if (
+    is_empty(current_lanes, "current_lanes") || is_empty(target_lanes, "target_lanes") ||
+    is_empty(target_lane_neighbors_polygon_2d, "target_lane_neighbors_polygon_2d")) {
+    return {};
+  }
+
+  const auto & route_handler = *common_data_ptr->route_handler_ptr;
+  const auto & lc_param_ptr = common_data_ptr->lc_param_ptr;
+
+  const auto minimum_lane_changing_velocity = lc_param_ptr->trajectory.min_lane_changing_velocity;
+
+  const auto is_goal_in_route = route_handler.isInGoalRouteSection(target_lanes.back());
+
+  const auto current_min_dist_buffer = common_data_ptr->transient_data.current_dist_buffer.min;
+  const auto next_min_dist_buffer = common_data_ptr->transient_data.next_dist_buffer.min;
+
+  const auto sorted_lane_ids = utils::lane_change::get_sorted_lane_ids(common_data_ptr);
+
+  // lane changing start getEgoPose() is at the end of prepare segment
+  const auto current_lane_terminal_point =
+    lanelet::utils::conversion::toGeomMsgPt(current_lanes.back().centerline3d().back());
+
+  double distance_to_terminal_from_goal = 0;
+  if (is_goal_in_route) {
+    distance_to_terminal_from_goal =
+      utils::getDistanceToEndOfLane(route_handler.getGoalPose(), current_lanes);
+  }
+
+  const auto lane_changing_start_pose = autoware::motion_utils::calcLongitudinalOffsetPose(
+    prev_module_path.points, current_lane_terminal_point,
+    -(current_min_dist_buffer + next_min_dist_buffer + distance_to_terminal_from_goal));
+
+  if (!lane_changing_start_pose) {
+    RCLCPP_DEBUG(get_logger(), "Reject: lane changing start pose not found!!!");
+    return {};
+  }
+
+  const auto target_length_from_lane_change_start_pose = utils::getArcLengthToTargetLanelet(
+    current_lanes, target_lanes.front(), lane_changing_start_pose.value());
+
+  // Check if the lane changing start point is not on the lanes next to target lanes,
+  if (target_length_from_lane_change_start_pose > 0.0) {
+    RCLCPP_DEBUG(get_logger(), "lane change start getEgoPose() is behind target lanelet!");
+    return {};
+  }
+
+  const auto shift_length = lanelet::utils::getLateralDistanceToClosestLanelet(
+    target_lanes, lane_changing_start_pose.value());
+
+  const auto [min_lateral_acc, max_lateral_acc] =
+    lc_param_ptr->trajectory.lat_acc_map.find(minimum_lane_changing_velocity);
+
+  const auto lane_changing_time = autoware::motion_utils::calc_shift_time_from_jerk(
+    shift_length, lc_param_ptr->trajectory.lateral_jerk, max_lateral_acc);
+
+  const auto target_lane_length = common_data_ptr->transient_data.target_lane_length;
+  const auto target_segment = getTargetSegment(
+    common_data_ptr, target_lanes, lane_changing_start_pose.value(), target_lane_length,
+    current_min_dist_buffer, minimum_lane_changing_velocity, next_min_dist_buffer);
+
+  if (target_segment.points.empty()) {
+    RCLCPP_DEBUG(get_logger(), "Reject: target segment is empty!! something wrong...");
+    return {};
+  }
+
+  LaneChangeInfo lane_change_info;
+  lane_change_info.longitudinal_acceleration = LaneChangePhaseInfo{0.0, 0.0};
+  lane_change_info.duration = LaneChangePhaseInfo{0.0, lane_changing_time};
+  lane_change_info.velocity =
+    LaneChangePhaseInfo{minimum_lane_changing_velocity, minimum_lane_changing_velocity};
+  lane_change_info.length = LaneChangePhaseInfo{0.0, current_min_dist_buffer};
+  lane_change_info.lane_changing_start = lane_changing_start_pose.value();
+  lane_change_info.lane_changing_end = target_segment.points.front().point.pose;
+  lane_change_info.lateral_acceleration = max_lateral_acc;
+  lane_change_info.terminal_lane_changing_velocity = minimum_lane_changing_velocity;
+
+  if (!utils::lane_change::is_valid_start_point(
+        common_data_ptr, lane_changing_start_pose.value())) {
+    RCLCPP_DEBUG(
+      get_logger(),
+      "Reject: lane changing points are not inside of the target preferred lanes or its "
+      "neighbors");
+    return {};
+  }
+
+  const auto resample_interval =
+    calcLaneChangeResampleInterval(current_min_dist_buffer, minimum_lane_changing_velocity);
+  const auto target_lane_reference_path = get_reference_path_from_target_Lane(
+    common_data_ptr, lane_changing_start_pose.value(), current_min_dist_buffer, resample_interval);
+
+  if (target_lane_reference_path.points.empty()) {
+    RCLCPP_DEBUG(get_logger(), "Reject: target_lane_reference_path is empty!!");
+    return {};
+  }
+
+  lane_change_info.shift_line = get_lane_changing_shift_line(
+    lane_changing_start_pose.value(), target_segment.points.front().point.pose,
+    target_lane_reference_path, shift_length);
+
+  auto reference_segment = prev_module_path;
+  const double length_to_lane_changing_start = autoware::motion_utils::calcSignedArcLength(
+    reference_segment.points, reference_segment.points.front().point.pose.position,
+    lane_changing_start_pose->position);
+  utils::clipPathLength(reference_segment, 0, length_to_lane_changing_start, 0.0);
+  // remove terminal points because utils::clipPathLength() calculates extra long path
+  reference_segment.points.pop_back();
+  reference_segment.points.back().point.longitudinal_velocity_mps =
+    static_cast<float>(minimum_lane_changing_velocity);
+
+  const auto terminal_lane_change_path = utils::lane_change::construct_candidate_path(
+    lane_change_info, reference_segment, target_lane_reference_path, sorted_lane_ids);
+
+  return terminal_lane_change_path;
+}
+}  // namespace autoware::behavior_path_planner::utils::lane_change

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/path.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/path.cpp
@@ -21,7 +21,6 @@
 
 #include <autoware/motion_utils/trajectory/path_shift.hpp>
 #include <autoware/universe_utils/system/stop_watch.hpp>
-#include <autoware_frenet_planner/frenet_planner.hpp>
 #include <range/v3/action/insert.hpp>
 #include <range/v3/algorithm.hpp>
 #include <range/v3/numeric/accumulate.hpp>

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/path.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/path.cpp
@@ -187,19 +187,6 @@ bool get_prepare_segment(
     throw std::logic_error("lane change start is behind target lanelet!");
   }
 
-  if (common_data_ptr->get_ego_speed() >= prep_metric.velocity) {
-    // deceleration
-    prepare_segment.points.back().point.longitudinal_velocity_mps = std::min(
-      prepare_segment.points.back().point.longitudinal_velocity_mps,
-      static_cast<float>(prep_metric.velocity));
-  } else {
-    // acceleration
-    for (auto & point : prepare_segment.points) {
-      point.point.longitudinal_velocity_mps =
-        std::min(point.point.longitudinal_velocity_mps, static_cast<float>(prep_metric.velocity));
-    }
-  }
-
   return true;
 }
 

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/path.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/path.cpp
@@ -161,7 +161,7 @@ bool get_prepare_segment(
   const auto backward_path_length = common_data_ptr->bpp_param_ptr->backward_path_length;
 
   if (current_lanes.empty() || target_lanes.empty()) {
-    throw std::logic_error("lane change start is behind target lanelet!");
+    throw std::logic_error("Empty lanes!");
   }
 
   prepare_segment = prev_module_path;

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/path.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/path.cpp
@@ -206,18 +206,23 @@ bool get_prepare_segment(
 LaneChangePath get_candidate_path(
   const CommonDataPtr & common_data_ptr, const LaneChangePhaseMetrics & prep_metric,
   const LaneChangePhaseMetrics & lc_metric, const PathWithLaneId & prep_segment,
-  const std::vector<std::vector<int64_t>> & sorted_lane_ids, const Pose & lc_start_pose,
-  const double shift_length)
+  const std::vector<std::vector<int64_t>> & sorted_lane_ids, const double shift_length)
 {
   const auto & route_handler = *common_data_ptr->route_handler_ptr;
   const auto & target_lanes = common_data_ptr->lanes_ptr->target;
 
   const auto resample_interval = calc_resample_interval(lc_metric.length, prep_metric.velocity);
+
+  if (prep_segment.points.empty()) {
+    throw std::logic_error("Empty prepare segment!");
+  }
+
+  const auto & lc_start_pose = prep_segment.points.back().point.pose;
   const auto target_lane_reference_path = get_reference_path_from_target_Lane(
     common_data_ptr, lc_start_pose, lc_metric.length, resample_interval);
 
   if (target_lane_reference_path.points.empty()) {
-    throw std::logic_error("target_lane_reference_path is empty!");
+    throw std::logic_error("Empty target reference!");
   }
 
   const auto lc_end_pose = std::invoke([&]() {

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/utils.cpp
@@ -19,7 +19,6 @@
 #include "autoware/behavior_path_planner_common/parameters.hpp"
 #include "autoware/behavior_path_planner_common/utils/path_safety_checker/safety_check.hpp"
 #include "autoware/behavior_path_planner_common/utils/path_shifter/path_shifter.hpp"
-#include "autoware/behavior_path_planner_common/utils/path_utils.hpp"
 #include "autoware/behavior_path_planner_common/utils/traffic_light_utils.hpp"
 #include "autoware/behavior_path_planner_common/utils/utils.hpp"
 #include "autoware/object_recognition_utils/predicted_path_utils.hpp"
@@ -29,15 +28,14 @@
 #include <autoware/motion_utils/trajectory/interpolation.hpp>
 #include <autoware/motion_utils/trajectory/path_with_lane_id.hpp>
 #include <autoware/motion_utils/trajectory/trajectory.hpp>
-#include <autoware/universe_utils/geometry/boost_geometry.hpp>
 #include <autoware/universe_utils/geometry/boost_polygon_utils.hpp>
+#include <autoware/universe_utils/geometry/geometry.hpp>
 #include <autoware_lanelet2_extension/utility/query.hpp>
 #include <autoware_lanelet2_extension/utility/utilities.hpp>
 #include <autoware_vehicle_info_utils/vehicle_info.hpp>
-#include <range/v3/action/insert.hpp>
-#include <range/v3/algorithm/any_of.hpp>
-#include <range/v3/algorithm/find_if.hpp>
-#include <range/v3/algorithm/for_each.hpp>
+#include <range/v3/action/remove_if.hpp>
+#include <range/v3/algorithm.hpp>
+#include <range/v3/numeric.hpp>
 #include <range/v3/range/conversion.hpp>
 #include <range/v3/view.hpp>
 #include <rclcpp/rclcpp.hpp>
@@ -72,7 +70,6 @@ using autoware_perception_msgs::msg::PredictedObjects;
 using geometry_msgs::msg::Pose;
 using tier4_planning_msgs::msg::PathWithLaneId;
 
-using lanelet::ArcCoordinates;
 using tier4_planning_msgs::msg::PathPointWithLaneId;
 
 rclcpp::Logger get_logger()
@@ -86,32 +83,6 @@ bool is_mandatory_lane_change(const ModuleType lc_type)
 {
   return lc_type == LaneChangeModuleType::NORMAL ||
          lc_type == LaneChangeModuleType::AVOIDANCE_BY_LANE_CHANGE;
-}
-
-double calcLaneChangeResampleInterval(
-  const double lane_changing_length, const double lane_changing_velocity)
-{
-  constexpr auto min_resampling_points{30.0};
-  constexpr auto resampling_dt{0.2};
-  return std::max(
-    lane_changing_length / min_resampling_points, lane_changing_velocity * resampling_dt);
-}
-
-void setPrepareVelocity(
-  PathWithLaneId & prepare_segment, const double current_velocity, const double prepare_velocity)
-{
-  if (current_velocity < prepare_velocity) {
-    // acceleration
-    for (auto & point : prepare_segment.points) {
-      point.point.longitudinal_velocity_mps =
-        std::min(point.point.longitudinal_velocity_mps, static_cast<float>(prepare_velocity));
-    }
-  } else {
-    // deceleration
-    prepare_segment.points.back().point.longitudinal_velocity_mps = std::min(
-      prepare_segment.points.back().point.longitudinal_velocity_mps,
-      static_cast<float>(prepare_velocity));
-  }
 }
 
 lanelet::ConstLanelets get_target_neighbor_lanes(
@@ -132,32 +103,7 @@ lanelet::ConstLanelets get_target_neighbor_lanes(
       }
     }
   }
-
   return neighbor_lanes;
-}
-
-bool isPathInLanelets(
-  const PathWithLaneId & path, const lanelet::ConstLanelets & current_lanes,
-  const lanelet::ConstLanelets & target_lanes)
-{
-  const auto current_lane_poly =
-    lanelet::utils::getPolygonFromArcLength(current_lanes, 0, std::numeric_limits<double>::max());
-  const auto target_lane_poly =
-    lanelet::utils::getPolygonFromArcLength(target_lanes, 0, std::numeric_limits<double>::max());
-  const auto current_lane_poly_2d = lanelet::utils::to2D(current_lane_poly).basicPolygon();
-  const auto target_lane_poly_2d = lanelet::utils::to2D(target_lane_poly).basicPolygon();
-  for (const auto & pt : path.points) {
-    const lanelet::BasicPoint2d ll_pt(pt.point.pose.position.x, pt.point.pose.position.y);
-    const auto is_in_current = boost::geometry::covered_by(ll_pt, current_lane_poly_2d);
-    if (is_in_current) {
-      continue;
-    }
-    const auto is_in_target = boost::geometry::covered_by(ll_pt, target_lane_poly_2d);
-    if (!is_in_target) {
-      return false;
-    }
-  }
-  return true;
 }
 
 bool path_footprint_exceeds_target_lane_bound(
@@ -188,152 +134,6 @@ bool path_footprint_exceeds_target_lane_bound(
   }
 
   return false;
-}
-
-std::optional<LaneChangePath> construct_candidate_path(
-  const CommonDataPtr & common_data_ptr, const LaneChangeInfo & lane_change_info,
-  const PathWithLaneId & prepare_segment, const PathWithLaneId & target_lane_reference_path,
-  const std::vector<std::vector<int64_t>> & sorted_lane_ids)
-{
-  const auto & shift_line = lane_change_info.shift_line;
-  const auto terminal_lane_changing_velocity = lane_change_info.terminal_lane_changing_velocity;
-  const auto longitudinal_acceleration = lane_change_info.longitudinal_acceleration;
-  const auto lane_change_velocity = lane_change_info.velocity;
-
-  PathShifter path_shifter;
-  path_shifter.setPath(target_lane_reference_path);
-  path_shifter.addShiftLine(shift_line);
-  path_shifter.setLongitudinalAcceleration(longitudinal_acceleration.lane_changing);
-  ShiftedPath shifted_path;
-
-  // offset front side
-  bool offset_back = false;
-
-  const auto initial_lane_changing_velocity = lane_change_velocity.lane_changing;
-  path_shifter.setVelocity(initial_lane_changing_velocity);
-  path_shifter.setLateralAccelerationLimit(std::abs(lane_change_info.lateral_acceleration));
-
-  if (!path_shifter.generate(&shifted_path, offset_back)) {
-    RCLCPP_DEBUG(get_logger(), "Failed to generate shifted path.");
-  }
-
-  // TODO(Zulfaqar Azmi): have to think of a more feasible solution for points being remove by path
-  // shifter.
-  if (shifted_path.path.points.size() < shift_line.end_idx + 1) {
-    RCLCPP_DEBUG(get_logger(), "Path points are removed by PathShifter.");
-    return std::nullopt;
-  }
-
-  LaneChangePath candidate_path;
-  candidate_path.info = lane_change_info;
-
-  const auto lane_change_end_idx = autoware::motion_utils::findNearestIndex(
-    shifted_path.path.points, candidate_path.info.lane_changing_end);
-
-  if (!lane_change_end_idx) {
-    RCLCPP_DEBUG(get_logger(), "Lane change end idx not found on target path.");
-    return std::nullopt;
-  }
-
-  for (size_t i = 0; i < shifted_path.path.points.size(); ++i) {
-    auto & point = shifted_path.path.points.at(i);
-    if (i < *lane_change_end_idx) {
-      point.lane_ids = replaceWithSortedIds(point.lane_ids, sorted_lane_ids);
-      point.point.longitudinal_velocity_mps = std::min(
-        point.point.longitudinal_velocity_mps, static_cast<float>(terminal_lane_changing_velocity));
-      continue;
-    }
-    const auto nearest_idx =
-      autoware::motion_utils::findNearestIndex(target_lane_reference_path.points, point.point.pose);
-    point.lane_ids = target_lane_reference_path.points.at(*nearest_idx).lane_ids;
-  }
-
-  // TODO(Yutaka Shimizu): remove this flag after make the isPathInLanelets faster
-  const bool enable_path_check_in_lanelet = false;
-
-  // check candidate path is in lanelet
-  const auto & current_lanes = common_data_ptr->lanes_ptr->current;
-  const auto & target_lanes = common_data_ptr->lanes_ptr->target;
-  if (
-    enable_path_check_in_lanelet &&
-    !isPathInLanelets(shifted_path.path, current_lanes, target_lanes)) {
-    return std::nullopt;
-  }
-
-  if (prepare_segment.points.size() > 1 && shifted_path.path.points.size() > 1) {
-    const auto & prepare_segment_second_last_point =
-      std::prev(prepare_segment.points.end() - 1)->point.pose;
-    const auto & lane_change_start_from_shifted =
-      std::next(shifted_path.path.points.begin())->point.pose;
-    const auto yaw_diff2 = std::abs(autoware::universe_utils::normalizeRadian(
-      tf2::getYaw(prepare_segment_second_last_point.orientation) -
-      tf2::getYaw(lane_change_start_from_shifted.orientation)));
-    if (yaw_diff2 > autoware::universe_utils::deg2rad(5.0)) {
-      RCLCPP_DEBUG(
-        get_logger(), "Excessive yaw difference %.3f which exceeds the 5 degrees threshold.",
-        autoware::universe_utils::rad2deg(yaw_diff2));
-      return std::nullopt;
-    }
-  }
-
-  candidate_path.path = utils::combinePath(prepare_segment, shifted_path.path);
-  candidate_path.shifted_path = shifted_path;
-
-  return std::optional<LaneChangePath>{candidate_path};
-}
-
-PathWithLaneId get_reference_path_from_target_Lane(
-  const CommonDataPtr & common_data_ptr, const Pose & lane_changing_start_pose,
-  const double lane_changing_length, const double resample_interval)
-{
-  const auto & route_handler = *common_data_ptr->route_handler_ptr;
-  const auto & target_lanes = common_data_ptr->lanes_ptr->target;
-  const auto target_lane_length = common_data_ptr->transient_data.target_lane_length;
-  const auto is_goal_in_route = common_data_ptr->lanes_ptr->target_lane_in_goal_section;
-  const auto next_lc_buffer = common_data_ptr->transient_data.next_dist_buffer.min;
-  const auto forward_path_length = common_data_ptr->bpp_param_ptr->forward_path_length;
-
-  const ArcCoordinates lane_change_start_arc_position =
-    lanelet::utils::getArcCoordinates(target_lanes, lane_changing_start_pose);
-
-  const double s_start = lane_change_start_arc_position.length;
-  const double s_end = std::invoke([&]() {
-    const auto dist_from_lc_start = s_start + lane_changing_length + forward_path_length;
-    if (is_goal_in_route) {
-      const double s_goal =
-        lanelet::utils::getArcCoordinates(target_lanes, route_handler.getGoalPose()).length -
-        next_lc_buffer;
-      return std::min(dist_from_lc_start, s_goal);
-    }
-    return std::min(dist_from_lc_start, target_lane_length - next_lc_buffer);
-  });
-
-  constexpr double epsilon = 1e-4;
-  if (s_end - s_start + epsilon < lane_changing_length) {
-    return PathWithLaneId();
-  }
-
-  const auto lane_changing_reference_path =
-    route_handler.getCenterLinePath(target_lanes, s_start, s_end);
-
-  return utils::resamplePathWithSpline(
-    lane_changing_reference_path, resample_interval, true, {0.0, lane_changing_length});
-}
-
-ShiftLine get_lane_changing_shift_line(
-  const Pose & lane_changing_start_pose, const Pose & lane_changing_end_pose,
-  const PathWithLaneId & reference_path, const double shift_length)
-{
-  ShiftLine shift_line;
-  shift_line.end_shift_length = shift_length;
-  shift_line.start = lane_changing_start_pose;
-  shift_line.end = lane_changing_end_pose;
-  shift_line.start_idx = autoware::motion_utils::findNearestIndex(
-    reference_path.points, lane_changing_start_pose.position);
-  shift_line.end_idx = autoware::motion_utils::findNearestIndex(
-    reference_path.points, lane_changing_end_pose.position);
-
-  return shift_line;
 }
 
 std::vector<DrivableLanes> generateDrivableLanes(
@@ -631,6 +431,7 @@ std::vector<PoseWithVelocityStamped> convert_to_predicted_path(
   const auto & lc_param_ptr = common_data_ptr->lc_param_ptr;
   const auto resolution = lc_param_ptr->safety.collision_check.prediction_time_resolution;
   std::vector<PoseWithVelocityStamped> predicted_path;
+  predicted_path.reserve(static_cast<size_t>(std::ceil(duration / resolution)));
 
   // prepare segment
   for (double t = 0.0; t < prepare_time; t += resolution) {
@@ -647,6 +448,7 @@ std::vector<PoseWithVelocityStamped> convert_to_predicted_path(
     initial_velocity + prepare_acc * prepare_time, 0.0, lane_change_path.info.velocity.prepare);
   const auto offset =
     initial_velocity * prepare_time + 0.5 * prepare_acc * prepare_time * prepare_time;
+
   for (double t = prepare_time; t < duration; t += resolution) {
     const auto delta_t = t - prepare_time;
     const auto velocity = std::clamp(
@@ -1293,5 +1095,39 @@ bool object_path_overlaps_lanes(
   return ranges::any_of(get_line_string_paths(object), [&](const auto & path) {
     return !boost::geometry::disjoint(path, lanes_polygon);
   });
+}
+
+std::vector<std::vector<PoseWithVelocityStamped>> convert_to_predicted_paths(
+  const CommonDataPtr & common_data_ptr, const LaneChangePath & lane_change_path,
+  const size_t deceleration_sampling_num)
+{
+  static constexpr double floating_err_th{1e-3};
+  const auto bpp_param = *common_data_ptr->bpp_param_ptr;
+  const auto global_min_acc = bpp_param.min_acc;
+  const auto lane_changing_acc = lane_change_path.info.longitudinal_acceleration.lane_changing;
+
+  const auto min_acc = std::min(lane_changing_acc, global_min_acc);
+  const auto sampling_num =
+    std::abs(min_acc - lane_changing_acc) > floating_err_th ? deceleration_sampling_num : 1;
+  const auto acc_resolution = (min_acc - lane_changing_acc) / static_cast<double>(sampling_num);
+
+  const auto ego_predicted_path = [&](size_t n) {
+    auto acc = lane_changing_acc + static_cast<double>(n) * acc_resolution;
+    return utils::lane_change::convert_to_predicted_path(common_data_ptr, lane_change_path, acc);
+  };
+
+  return ranges::views::iota(0UL, sampling_num) | ranges::views::transform(ego_predicted_path) |
+         ranges::to<std::vector>();
+}
+
+bool is_valid_start_point(const lane_change::CommonDataPtr & common_data_ptr, const Pose & pose)
+{
+  const lanelet::BasicPoint2d lc_start_point(pose.position.x, pose.position.y);
+
+  const auto & target_neighbor_poly = common_data_ptr->lanes_polygon_ptr->target_neighbor;
+  const auto & target_lane_poly = common_data_ptr->lanes_polygon_ptr->target;
+
+  return boost::geometry::covered_by(lc_start_point, target_neighbor_poly) ||
+         boost::geometry::covered_by(lc_start_point, target_lane_poly);
 }
 }  // namespace autoware::behavior_path_planner::utils::lane_change

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/utils.cpp
@@ -85,6 +85,23 @@ bool is_mandatory_lane_change(const ModuleType lc_type)
          lc_type == LaneChangeModuleType::AVOIDANCE_BY_LANE_CHANGE;
 }
 
+void set_prepare_velocity(
+  PathWithLaneId & prepare_segment, const double current_velocity, const double prepare_velocity)
+{
+  if (current_velocity >= prepare_velocity) {
+    // deceleration
+    prepare_segment.points.back().point.longitudinal_velocity_mps = std::min(
+      prepare_segment.points.back().point.longitudinal_velocity_mps,
+      static_cast<float>(prepare_velocity));
+    return;
+  }
+  // acceleration
+  for (auto & point : prepare_segment.points) {
+    point.point.longitudinal_velocity_mps =
+      std::min(point.point.longitudinal_velocity_mps, static_cast<float>(prepare_velocity));
+  }
+}
+
 lanelet::ConstLanelets get_target_neighbor_lanes(
   const RouteHandler & route_handler, const lanelet::ConstLanelets & current_lanes,
   const LaneChangeModuleType & type)

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/utils.cpp
@@ -1127,6 +1127,7 @@ bool is_valid_start_point(const lane_change::CommonDataPtr & common_data_ptr, co
   const auto & target_neighbor_poly = common_data_ptr->lanes_polygon_ptr->target_neighbor;
   const auto & target_lane_poly = common_data_ptr->lanes_polygon_ptr->target;
 
+  // Check the target lane because the previous approved path might be shifted by avoidance module
   return boost::geometry::covered_by(lc_start_point, target_neighbor_poly) ||
          boost::geometry::covered_by(lc_start_point, target_lane_poly);
 }

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/test/test_lane_change_scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/test/test_lane_change_scene.cpp
@@ -258,6 +258,7 @@ TEST_F(TestNormalLaneChange, testGetPathWhenValid)
   constexpr auto is_approved = true;
   ego_pose_ = autoware::test_utils::createPose(1.0, 1.75, 0.0, 0.0, 0.0, 0.0);
   planner_data_->self_odometry = set_odometry(ego_pose_);
+  normal_lane_change_->setData(planner_data_);
   set_previous_approved_path();
   normal_lane_change_->update_lanes(!is_approved);
   normal_lane_change_->update_filtered_objects();


### PR DESCRIPTION
## Description

Move candidate path generator/constructor-related function to `utils/path.hpp/cpp`.

If we planning  on adding new path generation functions, utils.hpp/cpp file might be overcrowded. So for maintainability purpose, it is better to isolate these functions.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

[TIER IV Internal link](https://evaluation.tier4.jp/evaluation/reports/2745c429-ad26-5514-bc32-8541f7466775?project_id=prd_jt)

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
