### PR TITLE
feat(image_projection_based_fusion): add cache for camera projection

### DIFF
--- a/perception/autoware_image_projection_based_fusion/CMakeLists.txt
+++ b/perception/autoware_image_projection_based_fusion/CMakeLists.txt
@@ -16,6 +16,7 @@ endif()
 
 # Build non-CUDA dependent nodes
 ament_auto_add_library(${PROJECT_NAME} SHARED
+  src/camera_projection.cpp
   src/fusion_node.cpp
   src/debugger.cpp
   src/utils/geometry.cpp

--- a/perception/autoware_image_projection_based_fusion/README.md
+++ b/perception/autoware_image_projection_based_fusion/README.md
@@ -66,6 +66,12 @@ ros2 launch autoware_image_projection_based_fusion pointpainting_fusion.launch.x
 
 The rclcpp::TimerBase timer could not break a for loop, therefore even if time is out when fusing a roi msg at the middle, the program will run until all msgs are fused.
 
+### Approximate camera projection
+
+For algorithms like `pointpainting_fusion`, the computation required to project points onto an unrectified (raw) image can be substantial. To address this, an option is provided to reduce the computational load. Set the [`approximate_camera_projection parameter`](config/fusion_common.param.yaml) to `true` for each camera (ROIs). If the corresponding `point_project_to_unrectified_image` parameter is also set to true, the projections will be pre-cached.
+
+The cached projections are calculated using a grid, with the grid size specified by the `approximation_grid_width_size` and `approximation_grid_height_size` parameters in the [configuration file](config/fusion_common.param.yaml). The centers of the grid are used as the projected points.
+
 ### Detail description of each fusion's algorithm is in the following links
 
 | Fusion Name                | Description                                                                                     | Detail                                       |

--- a/perception/autoware_image_projection_based_fusion/config/fusion_common.param.yaml
+++ b/perception/autoware_image_projection_based_fusion/config/fusion_common.param.yaml
@@ -17,8 +17,8 @@
     # camera cache setting for each ROI
     approximate_camera_projection: [true, true, true, true, true, true]
     # grid size in pixels
-    approximation_grid_width_size: 1.0
-    approximation_grid_height_size: 1.0
+    approximation_grid_cell_width: 1.0
+    approximation_grid_cell_height: 1.0
 
     # debug parameters
     publish_processing_time_detail: false

--- a/perception/autoware_image_projection_based_fusion/config/fusion_common.param.yaml
+++ b/perception/autoware_image_projection_based_fusion/config/fusion_common.param.yaml
@@ -4,7 +4,8 @@
     timeout_ms: 70.0
     match_threshold_ms: 50.0
     image_buffer_size: 15
-    point_project_to_unrectified_image: false
+    # projection setting for each ROI whether unrectify image
+    point_project_to_unrectified_image: [false, false, false, false, false, false]
     debug_mode: false
     filter_scope_min_x: -100.0
     filter_scope_min_y: -100.0
@@ -12,6 +13,12 @@
     filter_scope_max_x: 100.0
     filter_scope_max_y: 100.0
     filter_scope_max_z: 100.0
+
+    # camera cache setting for each ROI
+    approximate_camera_projection: [true, true, true, true, true, true]
+    # grid size in pixels
+    approximation_grid_width_size: 1.0
+    approximation_grid_height_size: 1.0
 
     # debug parameters
     publish_processing_time_detail: false

--- a/perception/autoware_image_projection_based_fusion/include/autoware/image_projection_based_fusion/camera_projection.hpp
+++ b/perception/autoware_image_projection_based_fusion/include/autoware/image_projection_based_fusion/camera_projection.hpp
@@ -40,7 +40,7 @@ public:
   explicit CameraProjection(
     const sensor_msgs::msg::CameraInfo & camera_info, const float grid_width,
     const float grid_height, const bool unrectify, const bool use_approximation);
-  CameraProjection() : grid_w_size_(1.0), grid_h_size_(1.0), unrectify_(false) {};
+  CameraProjection() : grid_w_size_(1.0), grid_h_size_(1.0), unrectify_(false) {}
   void initialize();
   std::function<bool(const cv::Point3d &, Eigen::Vector2d &)> calcImageProjectedPoint;
   sensor_msgs::msg::CameraInfo getCameraInfo();

--- a/perception/autoware_image_projection_based_fusion/include/autoware/image_projection_based_fusion/camera_projection.hpp
+++ b/perception/autoware_image_projection_based_fusion/include/autoware/image_projection_based_fusion/camera_projection.hpp
@@ -18,14 +18,12 @@
 #define EIGEN_MPL2_ONLY
 
 #include <Eigen/Core>
-#include <autoware/universe_utils/system/lru_cache.hpp>
 #include <opencv2/core/core.hpp>
 
 #include <sensor_msgs/msg/camera_info.hpp>
 
 #include <image_geometry/pinhole_camera_model.h>
 
-#include <map>
 #include <memory>
 
 namespace autoware::image_projection_based_fusion

--- a/perception/autoware_image_projection_based_fusion/include/autoware/image_projection_based_fusion/camera_projection.hpp
+++ b/perception/autoware_image_projection_based_fusion/include/autoware/image_projection_based_fusion/camera_projection.hpp
@@ -18,12 +18,10 @@
 #define EIGEN_MPL2_ONLY
 
 #include <Eigen/Core>
-
 #include <autoware/universe_utils/system/lru_cache.hpp>
+#include <opencv2/core/core.hpp>
 
 #include <sensor_msgs/msg/camera_info.hpp>
-
-#include <opencv2/core/core.hpp>
 
 #include <image_geometry/pinhole_camera_model.h>
 
@@ -42,12 +40,9 @@ class CameraProjection
 {
 public:
   explicit CameraProjection(
-    const sensor_msgs::msg::CameraInfo & camera_info,
-    const float grid_width, const float grid_height,
-    const bool unrectify,
-    const bool use_approximation
-  );
-  CameraProjection(): grid_w_size_(1.0), grid_h_size_(1.0), unrectify_(false) {};
+    const sensor_msgs::msg::CameraInfo & camera_info, const float grid_width,
+    const float grid_height, const bool unrectify, const bool use_approximation);
+  CameraProjection() : grid_w_size_(1.0), grid_h_size_(1.0), unrectify_(false) {};
   void initialize();
   std::function<bool(const cv::Point3d &, Eigen::Vector2d &)> calcImageProjectedPoint;
   sensor_msgs::msg::CameraInfo getCameraInfo();
@@ -55,9 +50,11 @@ public:
   bool isOutsideVerticalView(const float py, const float pz);
 
 protected:
-  bool calcRectifiedImageProjectedPoint(const cv::Point3d & point3d, Eigen::Vector2d & projected_point);
+  bool calcRectifiedImageProjectedPoint(
+    const cv::Point3d & point3d, Eigen::Vector2d & projected_point);
   bool calcRawImageProjectedPoint(const cv::Point3d & point3d, Eigen::Vector2d & projected_point);
-  bool calcRawImageProjectedPointWithApproximation(const cv::Point3d & point3d, Eigen::Vector2d & projected_point);
+  bool calcRawImageProjectedPointWithApproximation(
+    const cv::Point3d & point3d, Eigen::Vector2d & projected_point);
   void initializeCache();
 
   sensor_msgs::msg::CameraInfo camera_info_;

--- a/perception/autoware_image_projection_based_fusion/include/autoware/image_projection_based_fusion/camera_projection.hpp
+++ b/perception/autoware_image_projection_based_fusion/include/autoware/image_projection_based_fusion/camera_projection.hpp
@@ -68,8 +68,8 @@ protected:
   float half_grid_h_size_;
   float inv_grid_w_size_;
   float inv_grid_h_size_;
-  uint32_t grid_x_num_;
-  uint32_t grid_y_num_;
+  int grid_x_num_;
+  int grid_y_num_;
   float index_grid_out_h_;
   float index_grid_out_w_;
 

--- a/perception/autoware_image_projection_based_fusion/include/autoware/image_projection_based_fusion/camera_projection.hpp
+++ b/perception/autoware_image_projection_based_fusion/include/autoware/image_projection_based_fusion/camera_projection.hpp
@@ -1,0 +1,88 @@
+// Copyright 2024 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__IMAGE_PROJECTION_BASED_FUSION__CAMERA_PROJECTION_HPP_
+#define AUTOWARE__IMAGE_PROJECTION_BASED_FUSION__CAMERA_PROJECTION_HPP_
+
+#define EIGEN_MPL2_ONLY
+
+#include <Eigen/Core>
+
+#include <autoware/universe_utils/system/lru_cache.hpp>
+
+#include <sensor_msgs/msg/camera_info.hpp>
+
+#include <opencv2/core/core.hpp>
+
+#include <image_geometry/pinhole_camera_model.h>
+
+#include <map>
+#include <memory>
+
+namespace autoware::image_projection_based_fusion
+{
+struct PixelPos
+{
+  float x;
+  float y;
+};
+
+class CameraProjection
+{
+public:
+  explicit CameraProjection(
+    const sensor_msgs::msg::CameraInfo & camera_info,
+    const float grid_width, const float grid_height,
+    const bool unrectify,
+    const bool use_approximation
+  );
+  CameraProjection(): grid_w_size_(1.0), grid_h_size_(1.0), unrectify_(false) {};
+  void initialize();
+  std::function<bool(const cv::Point3d &, Eigen::Vector2d &)> calcImageProjectedPoint;
+  sensor_msgs::msg::CameraInfo getCameraInfo();
+  bool isOutsideHorizontalView(const float px, const float pz);
+  bool isOutsideVerticalView(const float py, const float pz);
+
+protected:
+  bool calcRectifiedImageProjectedPoint(const cv::Point3d & point3d, Eigen::Vector2d & projected_point);
+  bool calcRawImageProjectedPoint(const cv::Point3d & point3d, Eigen::Vector2d & projected_point);
+  bool calcRawImageProjectedPointWithApproximation(const cv::Point3d & point3d, Eigen::Vector2d & projected_point);
+  void initializeCache();
+
+  sensor_msgs::msg::CameraInfo camera_info_;
+  uint32_t image_h_, image_w_;
+  double tan_h_x_, tan_h_y_;
+
+  uint32_t cache_size_;
+  float grid_w_size_;
+  float grid_h_size_;
+  float half_grid_w_size_;
+  float half_grid_h_size_;
+  float inv_grid_w_size_;
+  float inv_grid_h_size_;
+  uint32_t grid_x_num_;
+  uint32_t grid_y_num_;
+  float index_grid_out_h_;
+  float index_grid_out_w_;
+
+  bool unrectify_;
+  bool use_approximation_;
+
+  std::unique_ptr<PixelPos[]> projection_cache_;
+  image_geometry::PinholeCameraModel camera_model_;
+};
+
+}  // namespace autoware::image_projection_based_fusion
+
+#endif  // AUTOWARE__IMAGE_PROJECTION_BASED_FUSION__CAMERA_PROJECTION_HPP_

--- a/perception/autoware_image_projection_based_fusion/include/autoware/image_projection_based_fusion/camera_projection.hpp
+++ b/perception/autoware_image_projection_based_fusion/include/autoware/image_projection_based_fusion/camera_projection.hpp
@@ -38,9 +38,9 @@ class CameraProjection
 {
 public:
   explicit CameraProjection(
-    const sensor_msgs::msg::CameraInfo & camera_info, const float grid_width,
-    const float grid_height, const bool unrectify, const bool use_approximation);
-  CameraProjection() : grid_w_size_(1.0), grid_h_size_(1.0), unrectify_(false) {}
+    const sensor_msgs::msg::CameraInfo & camera_info, const float grid_cell_width,
+    const float grid_cell_height, const bool unrectify, const bool use_approximation);
+  CameraProjection() : cell_width_(1.0), cell_height_(1.0), unrectify_(false) {}
   void initialize();
   std::function<bool(const cv::Point3d &, Eigen::Vector2d &)> calcImageProjectedPoint;
   sensor_msgs::msg::CameraInfo getCameraInfo();
@@ -62,16 +62,12 @@ protected:
   double fov_left_, fov_right_, fov_top_, fov_bottom_;
 
   uint32_t cache_size_;
-  float grid_w_size_;
-  float grid_h_size_;
-  float half_grid_w_size_;
-  float half_grid_h_size_;
-  float inv_grid_w_size_;
-  float inv_grid_h_size_;
-  int grid_x_num_;
-  int grid_y_num_;
-  float index_grid_out_h_;
-  float index_grid_out_w_;
+  float cell_width_;
+  float cell_height_;
+  float inv_cell_width_;
+  float inv_cell_height_;
+  int grid_width_;
+  int grid_height_;
 
   bool unrectify_;
   bool use_approximation_;

--- a/perception/autoware_image_projection_based_fusion/include/autoware/image_projection_based_fusion/camera_projection.hpp
+++ b/perception/autoware_image_projection_based_fusion/include/autoware/image_projection_based_fusion/camera_projection.hpp
@@ -57,7 +57,7 @@ protected:
   void initializeCache();
 
   sensor_msgs::msg::CameraInfo camera_info_;
-  uint32_t image_h_, image_w_;
+  uint32_t image_height_, image_width_;
   double tan_h_x_, tan_h_y_;
   double fov_left_, fov_right_, fov_top_, fov_bottom_;
 

--- a/perception/autoware_image_projection_based_fusion/include/autoware/image_projection_based_fusion/camera_projection.hpp
+++ b/perception/autoware_image_projection_based_fusion/include/autoware/image_projection_based_fusion/camera_projection.hpp
@@ -48,6 +48,7 @@ public:
   sensor_msgs::msg::CameraInfo getCameraInfo();
   bool isOutsideHorizontalView(const float px, const float pz);
   bool isOutsideVerticalView(const float py, const float pz);
+  bool isOutsideFOV(const float px, const float py, const float pz);
 
 protected:
   bool calcRectifiedImageProjectedPoint(
@@ -60,6 +61,7 @@ protected:
   sensor_msgs::msg::CameraInfo camera_info_;
   uint32_t image_h_, image_w_;
   double tan_h_x_, tan_h_y_;
+  double fov_left_, fov_right_, fov_top_, fov_bottom_;
 
   uint32_t cache_size_;
   float grid_w_size_;

--- a/perception/autoware_image_projection_based_fusion/include/autoware/image_projection_based_fusion/fusion_node.hpp
+++ b/perception/autoware_image_projection_based_fusion/include/autoware/image_projection_based_fusion/fusion_node.hpp
@@ -110,8 +110,8 @@ protected:
   // camera projection
   std::vector<CameraProjection> camera_projectors_;
   std::vector<bool> approx_camera_projection_;
-  float approx_grid_w_size_;
-  float approx_grid_h_size_;
+  float approx_grid_cell_w_size_;
+  float approx_grid_cell_h_size_;
 
   rclcpp::TimerBase::SharedPtr timer_;
   double timeout_ms_{};

--- a/perception/autoware_image_projection_based_fusion/include/autoware/image_projection_based_fusion/fusion_node.hpp
+++ b/perception/autoware_image_projection_based_fusion/include/autoware/image_projection_based_fusion/fusion_node.hpp
@@ -102,7 +102,7 @@ protected:
   tf2_ros::Buffer tf_buffer_;
   tf2_ros::TransformListener tf_listener_;
 
-  std::vector<bool> point_project_to_unrectified_image_{false};
+  std::vector<bool> point_project_to_unrectified_image_;
 
   // camera_info
   std::map<std::size_t, sensor_msgs::msg::CameraInfo> camera_info_map_;

--- a/perception/autoware_image_projection_based_fusion/include/autoware/image_projection_based_fusion/fusion_node.hpp
+++ b/perception/autoware_image_projection_based_fusion/include/autoware/image_projection_based_fusion/fusion_node.hpp
@@ -56,8 +56,8 @@ using sensor_msgs::msg::PointCloud2;
 using tier4_perception_msgs::msg::DetectedObjectsWithFeature;
 using tier4_perception_msgs::msg::DetectedObjectWithFeature;
 using PointCloud = pcl::PointCloud<pcl::PointXYZ>;
-using autoware_perception_msgs::msg::ObjectClassification;
 using autoware::image_projection_based_fusion::CameraProjection;
+using autoware_perception_msgs::msg::ObjectClassification;
 
 template <class TargetMsg3D, class ObjType, class Msg2D>
 class FusionNode : public rclcpp::Node

--- a/perception/autoware_image_projection_based_fusion/include/autoware/image_projection_based_fusion/fusion_node.hpp
+++ b/perception/autoware_image_projection_based_fusion/include/autoware/image_projection_based_fusion/fusion_node.hpp
@@ -15,6 +15,7 @@
 #ifndef AUTOWARE__IMAGE_PROJECTION_BASED_FUSION__FUSION_NODE_HPP_
 #define AUTOWARE__IMAGE_PROJECTION_BASED_FUSION__FUSION_NODE_HPP_
 
+#include <autoware/image_projection_based_fusion/camera_projection.hpp>
 #include <autoware/image_projection_based_fusion/debugger.hpp>
 #include <autoware/universe_utils/ros/debug_publisher.hpp>
 #include <autoware/universe_utils/system/stop_watch.hpp>
@@ -56,6 +57,7 @@ using tier4_perception_msgs::msg::DetectedObjectsWithFeature;
 using tier4_perception_msgs::msg::DetectedObjectWithFeature;
 using PointCloud = pcl::PointCloud<pcl::PointXYZ>;
 using autoware_perception_msgs::msg::ObjectClassification;
+using autoware::image_projection_based_fusion::CameraProjection;
 
 template <class TargetMsg3D, class ObjType, class Msg2D>
 class FusionNode : public rclcpp::Node
@@ -86,7 +88,7 @@ protected:
 
   virtual void fuseOnSingleImage(
     const TargetMsg3D & input_msg, const std::size_t image_id, const Msg2D & input_roi_msg,
-    const sensor_msgs::msg::CameraInfo & camera_info, TargetMsg3D & output_msg) = 0;
+    TargetMsg3D & output_msg) = 0;
 
   // set args if you need
   virtual void postprocess(TargetMsg3D & output_msg);
@@ -100,11 +102,16 @@ protected:
   tf2_ros::Buffer tf_buffer_;
   tf2_ros::TransformListener tf_listener_;
 
-  bool point_project_to_unrectified_image_{false};
+  std::vector<bool> point_project_to_unrectified_image_{false};
 
   // camera_info
   std::map<std::size_t, sensor_msgs::msg::CameraInfo> camera_info_map_;
   std::vector<rclcpp::Subscription<sensor_msgs::msg::CameraInfo>::SharedPtr> camera_info_subs_;
+  // camera projection
+  std::vector<CameraProjection> camera_projectors_;
+  std::vector<bool> approx_camera_projection_;
+  float approx_grid_w_size_;
+  float approx_grid_h_size_;
 
   rclcpp::TimerBase::SharedPtr timer_;
   double timeout_ms_{};

--- a/perception/autoware_image_projection_based_fusion/include/autoware/image_projection_based_fusion/pointpainting_fusion/node.hpp
+++ b/perception/autoware_image_projection_based_fusion/include/autoware/image_projection_based_fusion/pointpainting_fusion/node.hpp
@@ -53,14 +53,11 @@ protected:
   void fuseOnSingleImage(
     const sensor_msgs::msg::PointCloud2 & input_pointcloud_msg, const std::size_t image_id,
     const DetectedObjectsWithFeature & input_roi_msg,
-    const sensor_msgs::msg::CameraInfo & camera_info,
     sensor_msgs::msg::PointCloud2 & painted_pointcloud_msg) override;
 
   void postprocess(sensor_msgs::msg::PointCloud2 & painted_pointcloud_msg) override;
 
   rclcpp::Publisher<DetectedObjects>::SharedPtr obj_pub_ptr_;
-
-  std::vector<double> tan_h_;  // horizontal field of view
 
   int omp_num_threads_{1};
   float score_threshold_{0.0};

--- a/perception/autoware_image_projection_based_fusion/include/autoware/image_projection_based_fusion/roi_cluster_fusion/node.hpp
+++ b/perception/autoware_image_projection_based_fusion/include/autoware/image_projection_based_fusion/roi_cluster_fusion/node.hpp
@@ -38,7 +38,6 @@ protected:
   void fuseOnSingleImage(
     const DetectedObjectsWithFeature & input_cluster_msg, const std::size_t image_id,
     const DetectedObjectsWithFeature & input_roi_msg,
-    const sensor_msgs::msg::CameraInfo & camera_info,
     DetectedObjectsWithFeature & output_cluster_msg) override;
 
   std::string trust_object_iou_mode_{"iou"};

--- a/perception/autoware_image_projection_based_fusion/include/autoware/image_projection_based_fusion/roi_detected_object_fusion/node.hpp
+++ b/perception/autoware_image_projection_based_fusion/include/autoware/image_projection_based_fusion/roi_detected_object_fusion/node.hpp
@@ -43,12 +43,11 @@ protected:
   void fuseOnSingleImage(
     const DetectedObjects & input_object_msg, const std::size_t image_id,
     const DetectedObjectsWithFeature & input_roi_msg,
-    const sensor_msgs::msg::CameraInfo & camera_info, DetectedObjects & output_object_msg) override;
+    DetectedObjects & output_object_msg) override;
 
   std::map<std::size_t, DetectedObjectWithFeature> generateDetectedObjectRoIs(
-    const DetectedObjects & input_object_msg, const double image_width, const double image_height,
-    const Eigen::Affine3d & object2camera_affine,
-    const image_geometry::PinholeCameraModel & pinhole_camera_model);
+    const DetectedObjects & input_object_msg, const std::size_t & image_id,
+    const Eigen::Affine3d & object2camera_affine);
 
   void fuseObjectsOnImage(
     const DetectedObjects & input_object_msg,

--- a/perception/autoware_image_projection_based_fusion/include/autoware/image_projection_based_fusion/roi_detected_object_fusion/node.hpp
+++ b/perception/autoware_image_projection_based_fusion/include/autoware/image_projection_based_fusion/roi_detected_object_fusion/node.hpp
@@ -42,8 +42,7 @@ protected:
 
   void fuseOnSingleImage(
     const DetectedObjects & input_object_msg, const std::size_t image_id,
-    const DetectedObjectsWithFeature & input_roi_msg,
-    DetectedObjects & output_object_msg) override;
+    const DetectedObjectsWithFeature & input_roi_msg, DetectedObjects & output_object_msg) override;
 
   std::map<std::size_t, DetectedObjectWithFeature> generateDetectedObjectRoIs(
     const DetectedObjects & input_object_msg, const std::size_t & image_id,

--- a/perception/autoware_image_projection_based_fusion/include/autoware/image_projection_based_fusion/roi_pointcloud_fusion/node.hpp
+++ b/perception/autoware_image_projection_based_fusion/include/autoware/image_projection_based_fusion/roi_pointcloud_fusion/node.hpp
@@ -50,7 +50,7 @@ protected:
   void fuseOnSingleImage(
     const PointCloud2 & input_pointcloud_msg, const std::size_t image_id,
     const DetectedObjectsWithFeature & input_roi_msg,
-    const sensor_msgs::msg::CameraInfo & camera_info, PointCloud2 & output_pointcloud_msg) override;
+    PointCloud2 & output_pointcloud_msg) override;
   bool out_of_scope(const DetectedObjectWithFeature & obj) override;
 };
 

--- a/perception/autoware_image_projection_based_fusion/include/autoware/image_projection_based_fusion/roi_pointcloud_fusion/node.hpp
+++ b/perception/autoware_image_projection_based_fusion/include/autoware/image_projection_based_fusion/roi_pointcloud_fusion/node.hpp
@@ -49,8 +49,7 @@ protected:
 
   void fuseOnSingleImage(
     const PointCloud2 & input_pointcloud_msg, const std::size_t image_id,
-    const DetectedObjectsWithFeature & input_roi_msg,
-    PointCloud2 & output_pointcloud_msg) override;
+    const DetectedObjectsWithFeature & input_roi_msg, PointCloud2 & output_pointcloud_msg) override;
   bool out_of_scope(const DetectedObjectWithFeature & obj) override;
 };
 

--- a/perception/autoware_image_projection_based_fusion/include/autoware/image_projection_based_fusion/segmentation_pointcloud_fusion/node.hpp
+++ b/perception/autoware_image_projection_based_fusion/include/autoware/image_projection_based_fusion/segmentation_pointcloud_fusion/node.hpp
@@ -61,7 +61,7 @@ protected:
 
   void fuseOnSingleImage(
     const PointCloud2 & input_pointcloud_msg, const std::size_t image_id, const Image & input_mask,
-    const CameraInfo & camera_info, PointCloud2 & output_pointcloud_msg) override;
+    PointCloud2 & output_pointcloud_msg) override;
 
   bool out_of_scope(const PointCloud2 & filtered_cloud) override;
   inline void copyPointCloud(

--- a/perception/autoware_image_projection_based_fusion/include/autoware/image_projection_based_fusion/utils/utils.hpp
+++ b/perception/autoware_image_projection_based_fusion/include/autoware/image_projection_based_fusion/utils/utils.hpp
@@ -65,10 +65,6 @@ struct PointData
 
 bool checkCameraInfo(const sensor_msgs::msg::CameraInfo & camera_info);
 
-Eigen::Vector2d calcRawImageProjectedPoint(
-  const image_geometry::PinholeCameraModel & pinhole_camera_model, const cv::Point3d & point3d,
-  const bool & unrectify = false);
-
 std::optional<geometry_msgs::msg::TransformStamped> getTransformStamped(
   const tf2_ros::Buffer & tf_buffer, const std::string & target_frame_id,
   const std::string & source_frame_id, const rclcpp::Time & time);

--- a/perception/autoware_image_projection_based_fusion/schema/fusion_common.schema.json
+++ b/perception/autoware_image_projection_based_fusion/schema/fusion_common.schema.json
@@ -71,14 +71,14 @@
           "description": "An array of options indicating whether to use approximated projection for each camera.",
           "default": [true, true, true, true, true, true]
         },
-        "approximation_grid_width_size": {
+        "approximation_grid_cell_width": {
           "type": "number",
-          "description": "The size of the gird's width of approximate_camera_projection in pixel.",
+          "description": "The width of grid cell used in approximated projection [pixel].",
           "default": 1.0
         },
-        "approximation_grid_height_size": {
+        "approximation_grid_cell_height": {
           "type": "number",
-          "description": "The size of the gird's height of approximate_camera_projection in pixel.",
+          "description": "The height of grid cell used in approximated projection [pixel].",
           "default": 1.0
         }
       }

--- a/perception/autoware_image_projection_based_fusion/schema/fusion_common.schema.json
+++ b/perception/autoware_image_projection_based_fusion/schema/fusion_common.schema.json
@@ -65,6 +65,21 @@
           "type": "number",
           "description": "Maximum z position [m].",
           "default": 100.0
+        },
+        "approximate_camera_projection": {
+          "type": "array",
+          "description": "An array of options indicating whether to use approximated projection for each camera.",
+          "default": [true, true, true, true, true, true]
+        },
+        "approximation_grid_width_size": {
+          "type": "number",
+          "description": "The size of the gird's width of approximate_camera_projection in pixel.",
+          "default": 1.0
+        },
+        "approximation_grid_height_size": {
+          "type": "number",
+          "description": "The size of the gird's height of approximate_camera_projection in pixel.",
+          "default": 1.0
         }
       }
     }

--- a/perception/autoware_image_projection_based_fusion/schema/fusion_common.schema.json
+++ b/perception/autoware_image_projection_based_fusion/schema/fusion_common.schema.json
@@ -31,6 +31,11 @@
           "default": 15,
           "minimum": 1
         },
+        "point_project_to_unrectified_image": {
+          "type": "array",
+          "description": "An array of options indicating whether to project point to unrectified image or not.",
+          "default": [false, false, false, false, false, false]
+        },
         "debug_mode": {
           "type": "boolean",
           "description": "Whether to debug or not.",

--- a/perception/autoware_image_projection_based_fusion/src/camera_projection.cpp
+++ b/perception/autoware_image_projection_based_fusion/src/camera_projection.cpp
@@ -51,14 +51,17 @@ CameraProjection::CameraProjection(
   const double ocy = static_cast<double>(camera_info.k.at(5));
   // for checking pincushion shape case
   const cv::Point3d ray_top_left = camera_model_.projectPixelTo3dRay(cv::Point(0, 0));
-  const cv::Point3d ray_top_right = camera_model_.projectPixelTo3dRay(cv::Point(image_width_ - 1, 0));
-  const cv::Point3d ray_bottom_left = camera_model_.projectPixelTo3dRay(cv::Point(0, image_height_ - 1));
+  const cv::Point3d ray_top_right =
+    camera_model_.projectPixelTo3dRay(cv::Point(image_width_ - 1, 0));
+  const cv::Point3d ray_bottom_left =
+    camera_model_.projectPixelTo3dRay(cv::Point(0, image_height_ - 1));
   const cv::Point3d ray_bottom_right =
     camera_model_.projectPixelTo3dRay(cv::Point(image_width_ - 1, image_height_ - 1));
   // for checking barrel shape case
   const cv::Point3d ray_mid_top = camera_model_.projectPixelTo3dRay(cv::Point(ocx, 0));
   const cv::Point3d ray_mid_left = camera_model_.projectPixelTo3dRay(cv::Point(0, ocy));
-  const cv::Point3d ray_mid_right = camera_model_.projectPixelTo3dRay(cv::Point(image_width_ - 1, ocy));
+  const cv::Point3d ray_mid_right =
+    camera_model_.projectPixelTo3dRay(cv::Point(image_width_ - 1, ocy));
   const cv::Point3d ray_mid_bottom =
     camera_model_.projectPixelTo3dRay(cv::Point(ocx, image_height_ - 1));
 
@@ -137,11 +140,11 @@ void CameraProjection::initializeCache()
   for (int idx_y = 0; idx_y < grid_height_; idx_y++) {
     for (int idx_x = 0; idx_x < grid_width_; idx_x++) {
       const uint32_t grid_index = idx_y * grid_width_ + idx_x;
-      const float qx = (idx_x + 0.5f) * cell_width_;
-      const float qy = (idx_y + 0.5f) * cell_height_;
-      
+      const float px = (idx_x + 0.5f) * cell_width_;
+      const float py = (idx_y + 0.5f) * cell_height_;
+
       // precompute projected point
-      cv::Point2d raw_image_point = camera_model_.unrectifyPoint(cv::Point2d(qx, qy));
+      cv::Point2d raw_image_point = camera_model_.unrectifyPoint(cv::Point2d(px, py));
       projection_cache_[grid_index] =
         PixelPos{static_cast<float>(raw_image_point.x), static_cast<float>(raw_image_point.y)};
     }
@@ -158,8 +161,8 @@ bool CameraProjection::calcRectifiedImageProjectedPoint(
   const cv::Point2d rectified_image_point = camera_model_.project3dToPixel(point3d);
 
   if (
-    rectified_image_point.x < 0.0 || rectified_image_point.x >= image_w_ ||
-    rectified_image_point.y < 0.0 || rectified_image_point.y >= image_h_) {
+    rectified_image_point.x < 0.0 || rectified_image_point.x >= image_width_ ||
+    rectified_image_point.y < 0.0 || rectified_image_point.y >= image_height_) {
     return false;
   } else {
     projected_point << rectified_image_point.x, rectified_image_point.y;
@@ -178,8 +181,8 @@ bool CameraProjection::calcRawImageProjectedPoint(
   const cv::Point2d raw_image_point = camera_model_.unrectifyPoint(rectified_image_point);
 
   if (
-    rectified_image_point.x < 0.0 || rectified_image_point.x >= image_w_ ||
-    rectified_image_point.y < 0.0 || rectified_image_point.y >= image_h_) {
+    rectified_image_point.x < 0.0 || rectified_image_point.x >= image_width_ ||
+    rectified_image_point.y < 0.0 || rectified_image_point.y >= image_height_) {
     return false;
   } else {
     projected_point << raw_image_point.x, raw_image_point.y;

--- a/perception/autoware_image_projection_based_fusion/src/camera_projection.cpp
+++ b/perception/autoware_image_projection_based_fusion/src/camera_projection.cpp
@@ -138,7 +138,7 @@ void CameraProjection::initializeCache()
       // grid_x * grid_w_size_ + half_grid_w_size_
       const float qx = (grid_x + 0.5f) * cell_width_;
       const float qy = (grid_y + 0.5f) * cell_height_;
-      const uint32_t index = grid_y*grid_width_ + grid_x;
+      const uint32_t index = grid_y * grid_width_ + grid_x;
 
       // precompute projected point
       cv::Point2d raw_image_point = camera_model_.unrectifyPoint(cv::Point2d(qx, qy));
@@ -200,8 +200,8 @@ bool CameraProjection::calcRawImageProjectedPointWithApproximation(
   const int grid_x = static_cast<int>(std::floor(rectified_image_point.x * inv_cell_width_));
   const int grid_y = static_cast<int>(std::floor(rectified_image_point.y * inv_cell_height_));
 
-  if (grid_x < 0.0 || grid_x>= grid_width_) return false;
-  if (grid_y < 0.0 || grid_y>= grid_height_) return false;
+  if (grid_x < 0.0 || grid_x >= grid_width_) return false;
+  if (grid_y < 0.0 || grid_y >= grid_height_) return false;
 
   const uint32_t index = grid_y * grid_width_ + grid_x;
   projected_point << projection_cache_[index].x, projection_cache_[index].y;

--- a/perception/autoware_image_projection_based_fusion/src/camera_projection.cpp
+++ b/perception/autoware_image_projection_based_fusion/src/camera_projection.cpp
@@ -63,15 +63,16 @@ CameraProjection::CameraProjection(
   const double ocy = static_cast<double>(camera_info.k.at(5));
   // for checking pincushion shape case
   const cv::Point3d ray_top_left = camera_model_.projectPixelTo3dRay(cv::Point(0, 0));
-  const cv::Point3d ray_top_right = camera_model_.projectPixelTo3dRay(cv::Point(image_w_-1, 0));
-  const cv::Point3d ray_bottom_left = camera_model_.projectPixelTo3dRay(cv::Point(0, image_h_-1));
+  const cv::Point3d ray_top_right = camera_model_.projectPixelTo3dRay(cv::Point(image_w_ - 1, 0));
+  const cv::Point3d ray_bottom_left = camera_model_.projectPixelTo3dRay(cv::Point(0, image_h_ - 1));
   const cv::Point3d ray_bottom_right =
-    camera_model_.projectPixelTo3dRay(cv::Point(image_w_-1, image_h_-1));
+    camera_model_.projectPixelTo3dRay(cv::Point(image_w_ - 1, image_h_ - 1));
   // for checking barrel shape case
   const cv::Point3d ray_mid_top = camera_model_.projectPixelTo3dRay(cv::Point(ocx, 0));
   const cv::Point3d ray_mid_left = camera_model_.projectPixelTo3dRay(cv::Point(0, ocy));
-  const cv::Point3d ray_mid_right = camera_model_.projectPixelTo3dRay(cv::Point(image_w_-1, ocy));
-  const cv::Point3d ray_mid_bottom = camera_model_.projectPixelTo3dRay(cv::Point(ocx, image_h_-1));
+  const cv::Point3d ray_mid_right = camera_model_.projectPixelTo3dRay(cv::Point(image_w_ - 1, ocy));
+  const cv::Point3d ray_mid_bottom =
+    camera_model_.projectPixelTo3dRay(cv::Point(ocx, image_h_ - 1));
 
   cv::Point3d x_left = ray_top_left;
   cv::Point3d x_right = ray_top_right;
@@ -92,10 +93,10 @@ CameraProjection::CameraProjection(
   if (ray_mid_bottom.y < y_bottom.y) y_bottom = ray_mid_bottom;
 
   // set FOV at z = 1.0
-  fov_left_ = x_left.x/x_left.z;
-  fov_right_ = x_right.x/x_right.z;
-  fov_top_ = y_top.y/y_top.z;
-  fov_bottom_ = y_bottom.y/y_bottom.z;
+  fov_left_ = x_left.x / x_left.z;
+  fov_right_ = x_right.x / x_right.z;
+  fov_top_ = y_top.y / y_top.z;
+  fov_bottom_ = y_bottom.y / y_bottom.z;
 }
 
 void CameraProjection::initialize()
@@ -162,7 +163,6 @@ void CameraProjection::initializeCache()
     }
   }
 }
-
 
 /**
  * @brief Calculate a projection of 3D point to rectified image plane 2D point.

--- a/perception/autoware_image_projection_based_fusion/src/camera_projection.cpp
+++ b/perception/autoware_image_projection_based_fusion/src/camera_projection.cpp
@@ -29,8 +29,13 @@ namespace autoware::image_projection_based_fusion
 {
 CameraProjection::CameraProjection(
   const sensor_msgs::msg::CameraInfo & camera_info, const float grid_width, const float grid_height,
-  const bool unrectify, const bool use_approximation=false
-): camera_info_(camera_info), grid_w_size_(grid_width), grid_h_size_(grid_height), unrectify_(unrectify), use_approximation_(use_approximation){
+  const bool unrectify, const bool use_approximation = false)
+: camera_info_(camera_info),
+  grid_w_size_(grid_width),
+  grid_h_size_(grid_height),
+  unrectify_(unrectify),
+  use_approximation_(use_approximation)
+{
   if (grid_w_size_ <= 0.0 || grid_h_size_ <= 0.0) {
     throw std::runtime_error("Both grid_width and grid_height must be > 0.0");
   }
@@ -45,20 +50,21 @@ CameraProjection::CameraProjection(
   // for shifting to the grid center
   half_grid_w_size_ = grid_w_size_ / 2.0;
   half_grid_h_size_ = grid_h_size_ / 2.0;
-  inv_grid_w_size_ = 1/grid_w_size_;
-  inv_grid_h_size_ = 1/grid_h_size_;
+  inv_grid_w_size_ = 1 / grid_w_size_;
+  inv_grid_h_size_ = 1 / grid_h_size_;
   grid_x_num_ = static_cast<uint32_t>(std::ceil(image_w_ / grid_w_size_));
   grid_y_num_ = static_cast<uint32_t>(std::ceil(image_h_ / grid_h_size_));
-  cache_size_ = grid_x_num_*grid_y_num_;
+  cache_size_ = grid_x_num_ * grid_y_num_;
 
   // for checking the views
   // cx/fx
-  tan_h_x_ = camera_info.k.at(2)/camera_info.k.at(0);
+  tan_h_x_ = camera_info.k.at(2) / camera_info.k.at(0);
   // cy/fy
-  tan_h_y_ = camera_info.k.at(5)/camera_info.k.at(4);
+  tan_h_y_ = camera_info.k.at(5) / camera_info.k.at(4);
 }
 
-void CameraProjection::initialize(){
+void CameraProjection::initialize()
+{
   if (unrectify_) {
     if (use_approximation_) {
       // create the cache with size of grid center
@@ -66,22 +72,26 @@ void CameraProjection::initialize(){
       projection_cache_ = std::make_unique<PixelPos[]>(cache_size_);
       initializeCache();
 
-      calcImageProjectedPoint = [this](const cv::Point3d & point3d, Eigen::Vector2d & projected_point) {
+      calcImageProjectedPoint = [this](
+                                  const cv::Point3d & point3d, Eigen::Vector2d & projected_point) {
         return this->calcRawImageProjectedPointWithApproximation(point3d, projected_point);
       };
     } else {
-      calcImageProjectedPoint = [this](const cv::Point3d & point3d, Eigen::Vector2d & projected_point) {
+      calcImageProjectedPoint = [this](
+                                  const cv::Point3d & point3d, Eigen::Vector2d & projected_point) {
         return this->calcRawImageProjectedPoint(point3d, projected_point);
       };
     }
   } else {
-    calcImageProjectedPoint = [this](const cv::Point3d & point3d, Eigen::Vector2d & projected_point) {
+    calcImageProjectedPoint = [this](
+                                const cv::Point3d & point3d, Eigen::Vector2d & projected_point) {
       return this->calcRectifiedImageProjectedPoint(point3d, projected_point);
     };
   }
 }
 
-void CameraProjection::initializeCache(){
+void CameraProjection::initializeCache()
+{
   // sample grid centers till the camera height, width to precompute the projection
   //
   //      grid_size
@@ -101,31 +111,35 @@ void CameraProjection::initializeCache(){
 
   for (float y = half_grid_h_size_; y < image_h_; y += grid_h_size_) {
     for (float x = half_grid_w_size_; x < image_w_; x += grid_w_size_) {
-      const float qx = std::round((x-half_grid_w_size_)*inv_grid_w_size_)*grid_w_size_+half_grid_w_size_;
-      const float qy = std::round((y-half_grid_h_size_)*inv_grid_h_size_)*grid_h_size_+half_grid_h_size_;
+      const float qx =
+        std::round((x - half_grid_w_size_) * inv_grid_w_size_) * grid_w_size_ + half_grid_w_size_;
+      const float qy =
+        std::round((y - half_grid_h_size_) * inv_grid_h_size_) * grid_h_size_ + half_grid_h_size_;
 
       const int grid_x = static_cast<int>(std::floor(qx / grid_w_size_));
       const int grid_y = static_cast<int>(std::floor(qy / grid_h_size_));
-      const int index = (grid_y) * grid_x_num_ + grid_x;
+      const int index = (grid_y)*grid_x_num_ + grid_x;
 
       // precompute projected point
       cv::Point2d raw_image_point = camera_model_.unrectifyPoint(cv::Point2d(qx, qy));
-      projection_cache_[index] = PixelPos{static_cast<float>(raw_image_point.x), static_cast<float>(raw_image_point.y)};
+      projection_cache_[index] =
+        PixelPos{static_cast<float>(raw_image_point.x), static_cast<float>(raw_image_point.y)};
     }
   }
 }
-
 
 /**
  * @brief Calculate a projection of 3D point to rectified image plane 2D point.
  * @return Return a boolean indicating whether the projected point is on the image plane.
  */
 bool CameraProjection::calcRectifiedImageProjectedPoint(
-  const cv::Point3d & point3d, Eigen::Vector2d & projected_point
-){
+  const cv::Point3d & point3d, Eigen::Vector2d & projected_point)
+{
   const cv::Point2d rectified_image_point = camera_model_.project3dToPixel(point3d);
 
-  if (rectified_image_point.x < 0.0 || rectified_image_point.x >= image_w_ || rectified_image_point.y < 0.0 || rectified_image_point.y >= image_h_){
+  if (
+    rectified_image_point.x < 0.0 || rectified_image_point.x >= image_w_ ||
+    rectified_image_point.y < 0.0 || rectified_image_point.y >= image_h_) {
     return false;
   } else {
     projected_point << rectified_image_point.x, rectified_image_point.y;
@@ -138,12 +152,14 @@ bool CameraProjection::calcRectifiedImageProjectedPoint(
  * @return Return a boolean indicating whether the projected point is on the image plane.
  */
 bool CameraProjection::calcRawImageProjectedPoint(
-  const cv::Point3d & point3d, Eigen::Vector2d & projected_point
-){
+  const cv::Point3d & point3d, Eigen::Vector2d & projected_point)
+{
   const cv::Point2d rectified_image_point = camera_model_.project3dToPixel(point3d);
   const cv::Point2d raw_image_point = camera_model_.unrectifyPoint(rectified_image_point);
 
-  if (rectified_image_point.x < 0.0 || rectified_image_point.x >= image_w_ || rectified_image_point.y < 0.0 || rectified_image_point.y >= image_h_){
+  if (
+    rectified_image_point.x < 0.0 || rectified_image_point.x >= image_w_ ||
+    rectified_image_point.y < 0.0 || rectified_image_point.y >= image_h_) {
     return false;
   } else {
     projected_point << raw_image_point.x, raw_image_point.y;
@@ -156,16 +172,20 @@ bool CameraProjection::calcRawImageProjectedPoint(
  * @return Return a boolean indicating whether the projected point is on the image plane.
  */
 bool CameraProjection::calcRawImageProjectedPointWithApproximation(
-  const cv::Point3d & point3d, Eigen::Vector2d & projected_point
-){
+  const cv::Point3d & point3d, Eigen::Vector2d & projected_point)
+{
   const cv::Point2d rectified_image_point = camera_model_.project3dToPixel(point3d);
 
   // round to a near grid center
-  const float qx = std::round((rectified_image_point.x-half_grid_w_size_)*inv_grid_w_size_)*grid_w_size_+half_grid_w_size_;
+  const float qx =
+    std::round((rectified_image_point.x - half_grid_w_size_) * inv_grid_w_size_) * grid_w_size_ +
+    half_grid_w_size_;
   if (qx < 0.0 || qx >= image_w_) {
     return false;
   }
-  const float qy = std::round((rectified_image_point.y-half_grid_h_size_)*inv_grid_h_size_)*grid_h_size_+half_grid_h_size_;
+  const float qy =
+    std::round((rectified_image_point.y - half_grid_h_size_) * inv_grid_h_size_) * grid_h_size_ +
+    half_grid_h_size_;
   if (qy < 0.0 || qy >= image_h_) {
     return false;
   }
@@ -179,16 +199,19 @@ bool CameraProjection::calcRawImageProjectedPointWithApproximation(
   return true;
 }
 
-sensor_msgs::msg::CameraInfo CameraProjection::getCameraInfo(){
+sensor_msgs::msg::CameraInfo CameraProjection::getCameraInfo()
+{
   return camera_info_;
 }
 
-bool CameraProjection::isOutsideHorizontalView(const float px, const float pz){
+bool CameraProjection::isOutsideHorizontalView(const float px, const float pz)
+{
   // assuming the points' origin is centered on the camera
   return pz <= 0.0 || px > tan_h_x_ * pz || px < -tan_h_x_ * pz;
 }
 
-bool CameraProjection::isOutsideVerticalView(const float py, const float pz){
+bool CameraProjection::isOutsideVerticalView(const float py, const float pz)
+{
   // assuming the points' origin is centered on the camera
   return pz <= 0.0 || py > tan_h_y_ * pz || py < -tan_h_y_ * pz;
 }

--- a/perception/autoware_image_projection_based_fusion/src/camera_projection.cpp
+++ b/perception/autoware_image_projection_based_fusion/src/camera_projection.cpp
@@ -14,17 +14,6 @@
 
 #include "autoware/image_projection_based_fusion/camera_projection.hpp"
 
-#include <sensor_msgs/msg/point_cloud2.hpp>
-#include <sensor_msgs/point_cloud2_iterator.hpp>
-
-#ifdef ROS_DISTRO_GALACTIC
-#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
-#include <tf2_sensor_msgs/tf2_sensor_msgs.h>
-#else
-#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
-#include <tf2_sensor_msgs/tf2_sensor_msgs.hpp>
-#endif
-
 namespace autoware::image_projection_based_fusion
 {
 CameraProjection::CameraProjection(

--- a/perception/autoware_image_projection_based_fusion/src/camera_projection.cpp
+++ b/perception/autoware_image_projection_based_fusion/src/camera_projection.cpp
@@ -198,14 +198,14 @@ bool CameraProjection::calcRawImageProjectedPointWithApproximation(
   const cv::Point2d rectified_image_point = camera_model_.project3dToPixel(point3d);
 
   // round to a near grid cell
-  const int grid_x = static_cast<int>(std::floor(rectified_image_point.x * inv_cell_width_));
-  const int grid_y = static_cast<int>(std::floor(rectified_image_point.y * inv_cell_height_));
+  const int grid_idx_x = static_cast<int>(std::floor(rectified_image_point.x * inv_cell_width_));
+  const int grid_idx_y = static_cast<int>(std::floor(rectified_image_point.y * inv_cell_height_));
 
-  if (grid_x < 0.0 || grid_x >= grid_width_) return false;
-  if (grid_y < 0.0 || grid_y >= grid_height_) return false;
+  if (grid_idx_x < 0.0 || grid_idx_x >= grid_width_) return false;
+  if (grid_idx_y < 0.0 || grid_idx_y >= grid_height_) return false;
 
-  const uint32_t index = grid_y * grid_width_ + grid_x;
-  projected_point << projection_cache_[index].x, projection_cache_[index].y;
+  const uint32_t grid_index = grid_idx_y * grid_width_ + grid_idx_x;
+  projected_point << projection_cache_[grid_index].x, projection_cache_[grid_index].y;
 
   return true;
 }

--- a/perception/autoware_image_projection_based_fusion/src/camera_projection.cpp
+++ b/perception/autoware_image_projection_based_fusion/src/camera_projection.cpp
@@ -134,16 +134,15 @@ void CameraProjection::initializeCache()
   // edge pixels in right and bottom side in the image will be assign to these centers
   // that is the outside of the image
 
-  for (int grid_y = 0; grid_y < grid_height_; grid_y++) {
-    for (int grid_x = 0; grid_x < grid_width_; grid_x++) {
-      // grid_x * grid_w_size_ + half_grid_w_size_
-      const float qx = (grid_x + 0.5f) * cell_width_;
-      const float qy = (grid_y + 0.5f) * cell_height_;
-      const uint32_t index = grid_y * grid_width_ + grid_x;
-
+  for (int idx_y = 0; idx_y < grid_height_; idx_y++) {
+    for (int idx_x = 0; idx_x < grid_width_; idx_x++) {
+      const uint32_t grid_index = idx_y * grid_width_ + idx_x;
+      const float qx = (idx_x + 0.5f) * cell_width_;
+      const float qy = (idx_y + 0.5f) * cell_height_;
+      
       // precompute projected point
       cv::Point2d raw_image_point = camera_model_.unrectifyPoint(cv::Point2d(qx, qy));
-      projection_cache_[index] =
+      projection_cache_[grid_index] =
         PixelPos{static_cast<float>(raw_image_point.x), static_cast<float>(raw_image_point.y)};
     }
   }

--- a/perception/autoware_image_projection_based_fusion/src/camera_projection.cpp
+++ b/perception/autoware_image_projection_based_fusion/src/camera_projection.cpp
@@ -1,0 +1,196 @@
+// Copyright 2024 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/image_projection_based_fusion/camera_projection.hpp"
+
+#include <sensor_msgs/msg/point_cloud2.hpp>
+#include <sensor_msgs/point_cloud2_iterator.hpp>
+
+#ifdef ROS_DISTRO_GALACTIC
+#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#include <tf2_sensor_msgs/tf2_sensor_msgs.h>
+#else
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+#include <tf2_sensor_msgs/tf2_sensor_msgs.hpp>
+#endif
+
+namespace autoware::image_projection_based_fusion
+{
+CameraProjection::CameraProjection(
+  const sensor_msgs::msg::CameraInfo & camera_info, const float grid_width, const float grid_height,
+  const bool unrectify, const bool use_approximation=false
+): camera_info_(camera_info), grid_w_size_(grid_width), grid_h_size_(grid_height), unrectify_(unrectify), use_approximation_(use_approximation){
+  if (grid_w_size_ <= 0.0 || grid_h_size_ <= 0.0) {
+    throw std::runtime_error("Both grid_width and grid_height must be > 0.0");
+  }
+
+  image_w_ = camera_info.width;
+  image_h_ = camera_info.height;
+
+  // prepare camera model
+  camera_model_.fromCameraInfo(camera_info);
+
+  // cache settings
+  // for shifting to the grid center
+  half_grid_w_size_ = grid_w_size_ / 2.0;
+  half_grid_h_size_ = grid_h_size_ / 2.0;
+  inv_grid_w_size_ = 1/grid_w_size_;
+  inv_grid_h_size_ = 1/grid_h_size_;
+  grid_x_num_ = static_cast<uint32_t>(std::ceil(image_w_ / grid_w_size_));
+  grid_y_num_ = static_cast<uint32_t>(std::ceil(image_h_ / grid_h_size_));
+  cache_size_ = grid_x_num_*grid_y_num_;
+
+  // for checking the views
+  // cx/fx
+  tan_h_x_ = camera_info.k.at(2)/camera_info.k.at(0);
+  // cy/fy
+  tan_h_y_ = camera_info.k.at(5)/camera_info.k.at(4);
+}
+
+void CameraProjection::initialize(){
+  if (unrectify_) {
+    if (use_approximation_) {
+      // create the cache with size of grid center
+      // store only xy position in float to reduce memory consumption
+      projection_cache_ = std::make_unique<PixelPos[]>(cache_size_);
+      initializeCache();
+
+      calcImageProjectedPoint = [this](const cv::Point3d & point3d, Eigen::Vector2d & projected_point) {
+        return this->calcRawImageProjectedPointWithApproximation(point3d, projected_point);
+      };
+    } else {
+      calcImageProjectedPoint = [this](const cv::Point3d & point3d, Eigen::Vector2d & projected_point) {
+        return this->calcRawImageProjectedPoint(point3d, projected_point);
+      };
+    }
+  } else {
+    calcImageProjectedPoint = [this](const cv::Point3d & point3d, Eigen::Vector2d & projected_point) {
+      return this->calcRectifiedImageProjectedPoint(point3d, projected_point);
+    };
+  }
+}
+
+void CameraProjection::initializeCache(){
+  // sample grid centers till the camera height, width to precompute the projection
+  //
+  //      grid_size
+  //      /
+  //     v
+  //   |---|          w
+  //  0----------------->
+  // 0 | . | . | . |
+  //   |___|___|___|
+  //   | . | . | . |
+  //   | ^
+  // h | |
+  //   v grid center
+  //
+  // each pixel will be rounded in this grid center
+  // edge pixels in the image will be assign to centers that is the outside of the image
+
+  for (float y = half_grid_h_size_; y < image_h_; y += grid_h_size_) {
+    for (float x = half_grid_w_size_; x < image_w_; x += grid_w_size_) {
+      const float qx = std::round((x-half_grid_w_size_)*inv_grid_w_size_)*grid_w_size_+half_grid_w_size_;
+      const float qy = std::round((y-half_grid_h_size_)*inv_grid_h_size_)*grid_h_size_+half_grid_h_size_;
+
+      const int grid_x = static_cast<int>(std::floor(qx / grid_w_size_));
+      const int grid_y = static_cast<int>(std::floor(qy / grid_h_size_));
+      const int index = (grid_y) * grid_x_num_ + grid_x;
+
+      // precompute projected point
+      cv::Point2d raw_image_point = camera_model_.unrectifyPoint(cv::Point2d(qx, qy));
+      projection_cache_[index] = PixelPos{static_cast<float>(raw_image_point.x), static_cast<float>(raw_image_point.y)};
+    }
+  }
+}
+
+
+/**
+ * @brief Calculate a projection of 3D point to rectified image plane 2D point.
+ * @return Return a boolean indicating whether the projected point is on the image plane.
+ */
+bool CameraProjection::calcRectifiedImageProjectedPoint(
+  const cv::Point3d & point3d, Eigen::Vector2d & projected_point
+){
+  const cv::Point2d rectified_image_point = camera_model_.project3dToPixel(point3d);
+
+  if (rectified_image_point.x < 0.0 || rectified_image_point.x >= image_w_ || rectified_image_point.y < 0.0 || rectified_image_point.y >= image_h_){
+    return false;
+  } else {
+    projected_point << rectified_image_point.x, rectified_image_point.y;
+    return true;
+  }
+}
+
+/**
+ * @brief Calculate a projection of 3D point to raw image plane 2D point.
+ * @return Return a boolean indicating whether the projected point is on the image plane.
+ */
+bool CameraProjection::calcRawImageProjectedPoint(
+  const cv::Point3d & point3d, Eigen::Vector2d & projected_point
+){
+  const cv::Point2d rectified_image_point = camera_model_.project3dToPixel(point3d);
+  const cv::Point2d raw_image_point = camera_model_.unrectifyPoint(rectified_image_point);
+
+  if (rectified_image_point.x < 0.0 || rectified_image_point.x >= image_w_ || rectified_image_point.y < 0.0 || rectified_image_point.y >= image_h_){
+    return false;
+  } else {
+    projected_point << raw_image_point.x, raw_image_point.y;
+    return true;
+  }
+}
+
+/**
+ * @brief Calculate a projection of 3D point to raw image plane 2D point with approximation.
+ * @return Return a boolean indicating whether the projected point is on the image plane.
+ */
+bool CameraProjection::calcRawImageProjectedPointWithApproximation(
+  const cv::Point3d & point3d, Eigen::Vector2d & projected_point
+){
+  const cv::Point2d rectified_image_point = camera_model_.project3dToPixel(point3d);
+
+  // round to a near grid center
+  const float qx = std::round((rectified_image_point.x-half_grid_w_size_)*inv_grid_w_size_)*grid_w_size_+half_grid_w_size_;
+  if (qx < 0.0 || qx >= image_w_) {
+    return false;
+  }
+  const float qy = std::round((rectified_image_point.y-half_grid_h_size_)*inv_grid_h_size_)*grid_h_size_+half_grid_h_size_;
+  if (qy < 0.0 || qy >= image_h_) {
+    return false;
+  }
+
+  const int grid_x = static_cast<int>(std::floor(qx / grid_w_size_));
+  const int grid_y = static_cast<int>(std::floor(qy / grid_h_size_));
+  const int index = grid_y * grid_x_num_ + grid_x;
+
+  projected_point << projection_cache_[index].x, projection_cache_[index].y;
+
+  return true;
+}
+
+sensor_msgs::msg::CameraInfo CameraProjection::getCameraInfo(){
+  return camera_info_;
+}
+
+bool CameraProjection::isOutsideHorizontalView(const float px, const float pz){
+  // assuming the points' origin is centered on the camera
+  return pz <= 0.0 || px > tan_h_x_ * pz || px < -tan_h_x_ * pz;
+}
+
+bool CameraProjection::isOutsideVerticalView(const float py, const float pz){
+  // assuming the points' origin is centered on the camera
+  return pz <= 0.0 || py > tan_h_y_ * pz || py < -tan_h_y_ * pz;
+}
+
+}  // namespace autoware::image_projection_based_fusion

--- a/perception/autoware_image_projection_based_fusion/src/camera_projection.cpp
+++ b/perception/autoware_image_projection_based_fusion/src/camera_projection.cpp
@@ -51,16 +51,16 @@ CameraProjection::CameraProjection(
   const double ocy = static_cast<double>(camera_info.k.at(5));
   // for checking pincushion shape case
   const cv::Point3d ray_top_left = camera_model_.projectPixelTo3dRay(cv::Point(0, 0));
-  const cv::Point3d ray_top_right = camera_model_.projectPixelTo3dRay(cv::Point(image_w_ - 1, 0));
-  const cv::Point3d ray_bottom_left = camera_model_.projectPixelTo3dRay(cv::Point(0, image_h_ - 1));
+  const cv::Point3d ray_top_right = camera_model_.projectPixelTo3dRay(cv::Point(image_width_ - 1, 0));
+  const cv::Point3d ray_bottom_left = camera_model_.projectPixelTo3dRay(cv::Point(0, image_height_ - 1));
   const cv::Point3d ray_bottom_right =
-    camera_model_.projectPixelTo3dRay(cv::Point(image_w_ - 1, image_h_ - 1));
+    camera_model_.projectPixelTo3dRay(cv::Point(image_width_ - 1, image_height_ - 1));
   // for checking barrel shape case
   const cv::Point3d ray_mid_top = camera_model_.projectPixelTo3dRay(cv::Point(ocx, 0));
   const cv::Point3d ray_mid_left = camera_model_.projectPixelTo3dRay(cv::Point(0, ocy));
-  const cv::Point3d ray_mid_right = camera_model_.projectPixelTo3dRay(cv::Point(image_w_ - 1, ocy));
+  const cv::Point3d ray_mid_right = camera_model_.projectPixelTo3dRay(cv::Point(image_width_ - 1, ocy));
   const cv::Point3d ray_mid_bottom =
-    camera_model_.projectPixelTo3dRay(cv::Point(ocx, image_h_ - 1));
+    camera_model_.projectPixelTo3dRay(cv::Point(ocx, image_height_ - 1));
 
   cv::Point3d x_left = ray_top_left;
   cv::Point3d x_right = ray_top_right;

--- a/perception/autoware_image_projection_based_fusion/src/camera_projection.cpp
+++ b/perception/autoware_image_projection_based_fusion/src/camera_projection.cpp
@@ -31,8 +31,8 @@ CameraProjection::CameraProjection(
     throw std::runtime_error("Both grid_cell_width and grid_cell_height must be > 0.0");
   }
 
-  image_w_ = camera_info.width;
-  image_h_ = camera_info.height;
+  image_width_ = camera_info.width;
+  image_height_ = camera_info.height;
 
   // prepare camera model
   camera_model_.fromCameraInfo(camera_info);
@@ -40,8 +40,8 @@ CameraProjection::CameraProjection(
   // cache settings
   inv_cell_width_ = 1 / cell_width_;
   inv_cell_height_ = 1 / cell_height_;
-  grid_width_ = static_cast<int>(std::ceil(image_w_ / cell_width_));
-  grid_height_ = static_cast<int>(std::ceil(image_h_ / cell_height_));
+  grid_width_ = static_cast<int>(std::ceil(image_width_ / cell_width_));
+  grid_height_ = static_cast<int>(std::ceil(image_height_ / cell_height_));
   cache_size_ = grid_width_ * grid_height_;
 
   // compute 3D rays for the image corners and pixels related to optical center

--- a/perception/autoware_image_projection_based_fusion/src/camera_projection.cpp
+++ b/perception/autoware_image_projection_based_fusion/src/camera_projection.cpp
@@ -116,9 +116,9 @@ void CameraProjection::initialize()
 
 void CameraProjection::initializeCache()
 {
-  // sample grid centers till the camera height, width to precompute the projection
+  // sample grid cell centers till the camera height, width to precompute the projections
   //
-  //      grid_size
+  //      grid cell size
   //      /
   //     v
   //   |---|          w
@@ -128,10 +128,11 @@ void CameraProjection::initializeCache()
   //   | . | . | . |
   //   | ^
   // h | |
-  //   v grid center
+  //   v grid cell center
   //
-  // each pixel will be rounded in this grid center
-  // edge pixels in the image will be assign to centers that is the outside of the image
+  // each pixel will be rounded in these grid cell centers
+  // edge pixels in right and bottom side in the image will be assign to these centers
+  // that is the outside of the image
 
   for (int grid_y = 0; grid_y < grid_height_; grid_y++) {
     for (int grid_x = 0; grid_x < grid_width_; grid_x++) {

--- a/perception/autoware_image_projection_based_fusion/src/camera_projection.cpp
+++ b/perception/autoware_image_projection_based_fusion/src/camera_projection.cpp
@@ -14,6 +14,8 @@
 
 #include "autoware/image_projection_based_fusion/camera_projection.hpp"
 
+#include <memory>
+
 namespace autoware::image_projection_based_fusion
 {
 CameraProjection::CameraProjection(

--- a/perception/autoware_image_projection_based_fusion/src/fusion_node.cpp
+++ b/perception/autoware_image_projection_based_fusion/src/fusion_node.cpp
@@ -305,8 +305,7 @@ void FusionNode<TargetMsg3D, Obj, Msg2D>::subCallback(
         }
 
         fuseOnSingleImage(
-          *input_msg, roi_i, *((cached_roi_msgs_.at(roi_i))[matched_stamp]),
-          *output_msg);
+          *input_msg, roi_i, *((cached_roi_msgs_.at(roi_i))[matched_stamp]), *output_msg);
         (cached_roi_msgs_.at(roi_i)).erase(matched_stamp);
         is_fused_.at(roi_i) = true;
 

--- a/perception/autoware_image_projection_based_fusion/src/fusion_node.cpp
+++ b/perception/autoware_image_projection_based_fusion/src/fusion_node.cpp
@@ -129,6 +129,11 @@ FusionNode<TargetMsg3D, ObjType, Msg2D>::FusionNode(
   camera_projectors_.resize(rois_number_);
   point_project_to_unrectified_image_ =
     declare_parameter<std::vector<bool>>("point_project_to_unrectified_image");
+
+  if (rois_number_ > point_project_to_unrectified_image_.size()) {
+    throw std::runtime_error(
+      "The number of point_project_to_unrectified_image does not match the number of rois topics.");
+  }
   approx_camera_projection_ = declare_parameter<std::vector<bool>>("approximate_camera_projection");
   if (rois_number_ != approx_camera_projection_.size()) {
     const std::size_t current_size = approx_camera_projection_.size();

--- a/perception/autoware_image_projection_based_fusion/src/fusion_node.cpp
+++ b/perception/autoware_image_projection_based_fusion/src/fusion_node.cpp
@@ -145,8 +145,8 @@ FusionNode<TargetMsg3D, ObjType, Msg2D>::FusionNode(
       }
     }
   }
-  approx_grid_w_size_ = declare_parameter<float>("approximation_grid_width_size");
-  approx_grid_h_size_ = declare_parameter<float>("approximation_grid_height_size");
+  approx_grid_cell_w_size_ = declare_parameter<float>("approximation_grid_cell_width");
+  approx_grid_cell_h_size_ = declare_parameter<float>("approximation_grid_cell_height");
 
   // debugger
   if (declare_parameter("debug_mode", false)) {
@@ -195,7 +195,7 @@ void FusionNode<TargetMsg3D, Obj, Msg2D>::cameraInfoCallback(
     camera_info_map_.find(camera_id) == camera_info_map_.end() &&
     checkCameraInfo(*input_camera_info_msg)) {
     camera_projectors_.at(camera_id) = CameraProjection(
-      *input_camera_info_msg, approx_grid_w_size_, approx_grid_h_size_,
+      *input_camera_info_msg, approx_grid_cell_w_size_, approx_grid_cell_h_size_,
       point_project_to_unrectified_image_.at(camera_id), approx_camera_projection_.at(camera_id));
     camera_projectors_.at(camera_id).initialize();
 

--- a/perception/autoware_image_projection_based_fusion/src/pointpainting_fusion/node.cpp
+++ b/perception/autoware_image_projection_based_fusion/src/pointpainting_fusion/node.cpp
@@ -346,8 +346,7 @@ dc   | dc dc dc  dc ||zc|
         // paint current point if it is inside bbox
         int label2d = feature_object.object.classification.front().label;
         if (
-          !isUnknown(label2d) &&
-          isInsideBbox(projected_point.x(), projected_point.y(), roi, 1.0)) {
+          !isUnknown(label2d) && isInsideBbox(projected_point.x(), projected_point.y(), roi, 1.0)) {
           // cppcheck-suppress invalidPointerCast
           auto p_class = reinterpret_cast<float *>(&output[stride + class_offset]);
           for (const auto & cls : isClassTable_) {

--- a/perception/autoware_image_projection_based_fusion/src/pointpainting_fusion/node.cpp
+++ b/perception/autoware_image_projection_based_fusion/src/pointpainting_fusion/node.cpp
@@ -161,13 +161,6 @@ PointPaintingFusionNode::PointPaintingFusionNode(const rclcpp::NodeOptions & opt
   sub_ = this->create_subscription<sensor_msgs::msg::PointCloud2>(
     "~/input/pointcloud", rclcpp::SensorDataQoS().keep_last(3), sub_callback);
 
-  tan_h_.resize(rois_number_);
-  for (std::size_t roi_i = 0; roi_i < rois_number_; ++roi_i) {
-    auto fx = camera_info_map_[roi_i].k.at(0);
-    auto x0 = camera_info_map_[roi_i].k.at(2);
-    tan_h_[roi_i] = x0 / fx;
-  }
-
   detection_class_remapper_.setParameters(
     allow_remapping_by_area_matrix, min_area_matrix, max_area_matrix);
 
@@ -260,9 +253,7 @@ void PointPaintingFusionNode::preprocess(sensor_msgs::msg::PointCloud2 & painted
 
 void PointPaintingFusionNode::fuseOnSingleImage(
   __attribute__((unused)) const sensor_msgs::msg::PointCloud2 & input_pointcloud_msg,
-  __attribute__((unused)) const std::size_t image_id,
-  const DetectedObjectsWithFeature & input_roi_msg,
-  const sensor_msgs::msg::CameraInfo & camera_info,
+  const std::size_t image_id, const DetectedObjectsWithFeature & input_roi_msg,
   sensor_msgs::msg::PointCloud2 & painted_pointcloud_msg)
 {
   if (painted_pointcloud_msg.data.empty() || painted_pointcloud_msg.fields.empty()) {
@@ -275,8 +266,6 @@ void PointPaintingFusionNode::fuseOnSingleImage(
   if (num_bbox == 0) {
     return;
   }
-
-  if (!checkCameraInfo(camera_info)) return;
 
   std::unique_ptr<ScopedTimeTrack> st_ptr;
   if (time_keeper_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_);
@@ -312,9 +301,6 @@ void PointPaintingFusionNode::fuseOnSingleImage(
                           .offset;
   const auto class_offset = painted_pointcloud_msg.fields.at(4).offset;
   const auto p_step = painted_pointcloud_msg.point_step;
-  // projection matrix
-  image_geometry::PinholeCameraModel pinhole_camera_model;
-  pinhole_camera_model.fromCameraInfo(camera_info);
 
   Eigen::Vector3f point_lidar, point_camera;
   /** dc : don't care
@@ -346,24 +332,28 @@ dc   | dc dc dc  dc ||zc|
     p_y = point_camera.y();
     p_z = point_camera.z();
 
-    if (p_z <= 0.0 || p_x > (tan_h_.at(image_id) * p_z) || p_x < (-tan_h_.at(image_id) * p_z)) {
+    if (camera_projectors_[image_id].isOutsideHorizontalView(p_x, p_z)) {
       continue;
     }
-    // project
-    Eigen::Vector2d projected_point = calcRawImageProjectedPoint(
-      pinhole_camera_model, cv::Point3d(p_x, p_y, p_z), point_project_to_unrectified_image_);
 
-    // iterate 2d bbox
-    for (const auto & feature_object : objects) {
-      sensor_msgs::msg::RegionOfInterest roi = feature_object.feature.roi;
-      // paint current point if it is inside bbox
-      int label2d = feature_object.object.classification.front().label;
-      if (!isUnknown(label2d) && isInsideBbox(projected_point.x(), projected_point.y(), roi, 1.0)) {
-        // cppcheck-suppress invalidPointerCast
-        auto p_class = reinterpret_cast<float *>(&output[stride + class_offset]);
-        for (const auto & cls : isClassTable_) {
-          // add up the class values if the point belongs to multiple classes
-          *p_class = cls.second(label2d) ? (class_index_[cls.first] + *p_class) : *p_class;
+    // project
+    Eigen::Vector2d projected_point;
+    if (camera_projectors_[image_id].calcImageProjectedPoint(
+          cv::Point3d(p_x, p_y, p_z), projected_point)) {
+      // iterate 2d bbox
+      for (const auto & feature_object : objects) {
+        sensor_msgs::msg::RegionOfInterest roi = feature_object.feature.roi;
+        // paint current point if it is inside bbox
+        int label2d = feature_object.object.classification.front().label;
+        if (
+          !isUnknown(label2d) &&
+          isInsideBbox(projected_point.x(), projected_point.y(), roi, 1.0)) {
+          // cppcheck-suppress invalidPointerCast
+          auto p_class = reinterpret_cast<float *>(&output[stride + class_offset]);
+          for (const auto & cls : isClassTable_) {
+            // add up the class values if the point belongs to multiple classes
+            *p_class = cls.second(label2d) ? (class_index_[cls.first] + *p_class) : *p_class;
+          }
         }
       }
 #if 0
@@ -375,14 +365,14 @@ dc   | dc dc dc  dc ||zc|
     }
   }
 
-  for (const auto & feature_object : input_roi_msg.feature_objects) {
-    debug_image_rois.push_back(feature_object.feature.roi);
-  }
-
   if (debugger_) {
     std::unique_ptr<ScopedTimeTrack> inner_st_ptr;
     if (time_keeper_)
       inner_st_ptr = std::make_unique<ScopedTimeTrack>("publish debug message", *time_keeper_);
+
+    for (const auto & feature_object : input_roi_msg.feature_objects) {
+      debug_image_rois.push_back(feature_object.feature.roi);
+    }
 
     debugger_->image_rois_ = debug_image_rois;
     debugger_->obstacle_points_ = debug_image_points;

--- a/perception/autoware_image_projection_based_fusion/src/roi_detected_object_fusion/node.cpp
+++ b/perception/autoware_image_projection_based_fusion/src/roi_detected_object_fusion/node.cpp
@@ -100,8 +100,8 @@ void RoiDetectedObjectFusionNode::fuseOnSingleImage(
     object2camera_affine = transformToEigen(transform_stamped_optional.value().transform);
   }
 
-  const auto object_roi_map = generateDetectedObjectRoIs(
-    input_object_msg, image_id, object2camera_affine);
+  const auto object_roi_map =
+    generateDetectedObjectRoIs(input_object_msg, image_id, object2camera_affine);
   fuseObjectsOnImage(input_object_msg, input_roi_msg.feature_objects, object_roi_map);
 
   if (debugger_) {
@@ -163,8 +163,7 @@ RoiDetectedObjectFusionNode::generateDetectedObjectRoIs(
 
       Eigen::Vector2d proj_point;
       if (camera_projectors_[image_id].calcImageProjectedPoint(
-        cv::Point3d(point.x(), point.y(), point.z()), proj_point
-      )){
+            cv::Point3d(point.x(), point.y(), point.z()), proj_point)) {
         const double px = proj_point.x();
         const double py = proj_point.y();
 

--- a/perception/autoware_image_projection_based_fusion/src/roi_detected_object_fusion/node.cpp
+++ b/perception/autoware_image_projection_based_fusion/src/roi_detected_object_fusion/node.cpp
@@ -84,13 +84,10 @@ void RoiDetectedObjectFusionNode::preprocess(DetectedObjects & output_msg)
 void RoiDetectedObjectFusionNode::fuseOnSingleImage(
   const DetectedObjects & input_object_msg, const std::size_t image_id,
   const DetectedObjectsWithFeature & input_roi_msg,
-  const sensor_msgs::msg::CameraInfo & camera_info,
   DetectedObjects & output_object_msg __attribute__((unused)))
 {
   std::unique_ptr<ScopedTimeTrack> st_ptr;
   if (time_keeper_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_);
-
-  if (!checkCameraInfo(camera_info)) return;
 
   Eigen::Affine3d object2camera_affine;
   {
@@ -103,12 +100,8 @@ void RoiDetectedObjectFusionNode::fuseOnSingleImage(
     object2camera_affine = transformToEigen(transform_stamped_optional.value().transform);
   }
 
-  image_geometry::PinholeCameraModel pinhole_camera_model;
-  pinhole_camera_model.fromCameraInfo(camera_info);
-
   const auto object_roi_map = generateDetectedObjectRoIs(
-    input_object_msg, static_cast<double>(camera_info.width),
-    static_cast<double>(camera_info.height), object2camera_affine, pinhole_camera_model);
+    input_object_msg, image_id, object2camera_affine);
   fuseObjectsOnImage(input_object_msg, input_roi_msg.feature_objects, object_roi_map);
 
   if (debugger_) {
@@ -122,9 +115,8 @@ void RoiDetectedObjectFusionNode::fuseOnSingleImage(
 
 std::map<std::size_t, DetectedObjectWithFeature>
 RoiDetectedObjectFusionNode::generateDetectedObjectRoIs(
-  const DetectedObjects & input_object_msg, const double image_width, const double image_height,
-  const Eigen::Affine3d & object2camera_affine,
-  const image_geometry::PinholeCameraModel & pinhole_camera_model)
+  const DetectedObjects & input_object_msg, const std::size_t & image_id,
+  const Eigen::Affine3d & object2camera_affine)
 {
   std::unique_ptr<ScopedTimeTrack> st_ptr;
   if (time_keeper_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_);
@@ -139,6 +131,10 @@ RoiDetectedObjectFusionNode::generateDetectedObjectRoIs(
     return object_roi_map;
   }
   const auto & passthrough_object_flags = passthrough_object_flags_map_.at(timestamp_nsec);
+  const sensor_msgs::msg::CameraInfo & camera_info = camera_projectors_[image_id].getCameraInfo();
+  const double image_width = static_cast<double>(camera_info.width);
+  const double image_height = static_cast<double>(camera_info.height);
+
   for (std::size_t obj_i = 0; obj_i < input_object_msg.objects.size(); ++obj_i) {
     std::vector<Eigen::Vector3d> vertices_camera_coord;
     const auto & object = input_object_msg.objects.at(obj_i);
@@ -165,18 +161,18 @@ RoiDetectedObjectFusionNode::generateDetectedObjectRoIs(
         continue;
       }
 
-      Eigen::Vector2d proj_point = calcRawImageProjectedPoint(
-        pinhole_camera_model, cv::Point3d(point.x(), point.y(), point.z()),
-        point_project_to_unrectified_image_);
+      Eigen::Vector2d proj_point;
+      if (camera_projectors_[image_id].calcImageProjectedPoint(
+        cv::Point3d(point.x(), point.y(), point.z()), proj_point
+      )){
+        const double px = proj_point.x();
+        const double py = proj_point.y();
 
-      min_x = std::min(proj_point.x(), min_x);
-      min_y = std::min(proj_point.y(), min_y);
-      max_x = std::max(proj_point.x(), max_x);
-      max_y = std::max(proj_point.y(), max_y);
+        min_x = std::min(px, min_x);
+        min_y = std::min(py, min_y);
+        max_x = std::max(px, max_x);
+        max_y = std::max(py, max_y);
 
-      if (
-        proj_point.x() >= 0 && proj_point.x() < image_width && proj_point.y() >= 0 &&
-        proj_point.y() < image_height) {
         point_on_image_cnt++;
 
         if (debugger_) {

--- a/perception/autoware_image_projection_based_fusion/src/roi_pointcloud_fusion/node.cpp
+++ b/perception/autoware_image_projection_based_fusion/src/roi_pointcloud_fusion/node.cpp
@@ -87,9 +87,8 @@ void RoiPointCloudFusionNode::postprocess(
 }
 void RoiPointCloudFusionNode::fuseOnSingleImage(
   const sensor_msgs::msg::PointCloud2 & input_pointcloud_msg,
-  __attribute__((unused)) const std::size_t image_id,
+  const std::size_t image_id,
   const DetectedObjectsWithFeature & input_roi_msg,
-  const sensor_msgs::msg::CameraInfo & camera_info,
   __attribute__((unused)) sensor_msgs::msg::PointCloud2 & output_pointcloud_msg)
 {
   std::unique_ptr<ScopedTimeTrack> st_ptr;
@@ -98,7 +97,6 @@ void RoiPointCloudFusionNode::fuseOnSingleImage(
   if (input_pointcloud_msg.data.empty()) {
     return;
   }
-  if (!checkCameraInfo(camera_info)) return;
 
   std::vector<DetectedObjectWithFeature> output_objs;
   std::vector<sensor_msgs::msg::RegionOfInterest> debug_image_rois;
@@ -122,10 +120,6 @@ void RoiPointCloudFusionNode::fuseOnSingleImage(
     return;
   }
 
-  // transform pointcloud to camera optical frame id
-  image_geometry::PinholeCameraModel pinhole_camera_model;
-  pinhole_camera_model.fromCameraInfo(camera_info);
-
   geometry_msgs::msg::TransformStamped transform_stamped;
   {
     const auto transform_stamped_optional = getTransformStamped(
@@ -136,10 +130,10 @@ void RoiPointCloudFusionNode::fuseOnSingleImage(
     }
     transform_stamped = transform_stamped_optional.value();
   }
-  int point_step = input_pointcloud_msg.point_step;
-  int x_offset = input_pointcloud_msg.fields[pcl::getFieldIndex(input_pointcloud_msg, "x")].offset;
-  int y_offset = input_pointcloud_msg.fields[pcl::getFieldIndex(input_pointcloud_msg, "y")].offset;
-  int z_offset = input_pointcloud_msg.fields[pcl::getFieldIndex(input_pointcloud_msg, "z")].offset;
+  const int point_step = input_pointcloud_msg.point_step;
+  const int x_offset = input_pointcloud_msg.fields[pcl::getFieldIndex(input_pointcloud_msg, "x")].offset;
+  const int y_offset = input_pointcloud_msg.fields[pcl::getFieldIndex(input_pointcloud_msg, "y")].offset;
+  const int z_offset = input_pointcloud_msg.fields[pcl::getFieldIndex(input_pointcloud_msg, "z")].offset;
 
   sensor_msgs::msg::PointCloud2 transformed_cloud;
   tf2::doTransform(input_pointcloud_msg, transformed_cloud, transform_stamped);
@@ -164,33 +158,37 @@ void RoiPointCloudFusionNode::fuseOnSingleImage(
     if (transformed_z <= 0.0) {
       continue;
     }
-    Eigen::Vector2d projected_point = calcRawImageProjectedPoint(
-      pinhole_camera_model, cv::Point3d(transformed_x, transformed_y, transformed_z),
-      point_project_to_unrectified_image_);
-    for (std::size_t i = 0; i < output_objs.size(); ++i) {
-      auto & feature_obj = output_objs.at(i);
-      const auto & check_roi = feature_obj.feature.roi;
-      auto & cluster = clusters.at(i);
 
-      if (
-        clusters_data_size.at(i) >=
-        static_cast<size_t>(max_cluster_size_) * static_cast<size_t>(point_step)) {
-        continue;
+    Eigen::Vector2d projected_point;
+    if (camera_projectors_[image_id].calcImageProjectedPoint(
+      cv::Point3d(transformed_x, transformed_y, transformed_z), projected_point)
+    ) {
+      for (std::size_t i = 0; i < output_objs.size(); ++i) {
+        auto & feature_obj = output_objs.at(i);
+        const auto & check_roi = feature_obj.feature.roi;
+        auto & cluster = clusters.at(i);
+
+        const double px = projected_point.x();
+        const double py = projected_point.y();
+
+        if (
+          clusters_data_size.at(i) >=
+          static_cast<size_t>(max_cluster_size_) * static_cast<size_t>(point_step)) {
+          continue;
+        }
+        if (
+          check_roi.x_offset <= px && check_roi.y_offset <= py &&
+          check_roi.x_offset + check_roi.width >= px &&
+          check_roi.y_offset + check_roi.height >= py) {
+          std::memcpy(
+            &cluster.data[clusters_data_size.at(i)], &input_pointcloud_msg.data[offset],
+            point_step);
+          clusters_data_size.at(i) += point_step;
+        }
       }
-      if (
-        check_roi.x_offset <= projected_point.x() && check_roi.y_offset <= projected_point.y() &&
-        check_roi.x_offset + check_roi.width >= projected_point.x() &&
-        check_roi.y_offset + check_roi.height >= projected_point.y()) {
-        std::memcpy(
-          &cluster.data[clusters_data_size.at(i)], &input_pointcloud_msg.data[offset], point_step);
-        clusters_data_size.at(i) += point_step;
-      }
-    }
-    if (debugger_) {
-      // add all points inside image to debug
-      if (
-        projected_point.x() > 0 && projected_point.x() < camera_info.width &&
-        projected_point.y() > 0 && projected_point.y() < camera_info.height) {
+
+      if (debugger_) {
+        // add all points inside image to debug
         debug_image_points.push_back(projected_point);
       }
     }

--- a/perception/autoware_image_projection_based_fusion/src/roi_pointcloud_fusion/node.cpp
+++ b/perception/autoware_image_projection_based_fusion/src/roi_pointcloud_fusion/node.cpp
@@ -86,8 +86,7 @@ void RoiPointCloudFusionNode::postprocess(
   }
 }
 void RoiPointCloudFusionNode::fuseOnSingleImage(
-  const sensor_msgs::msg::PointCloud2 & input_pointcloud_msg,
-  const std::size_t image_id,
+  const sensor_msgs::msg::PointCloud2 & input_pointcloud_msg, const std::size_t image_id,
   const DetectedObjectsWithFeature & input_roi_msg,
   __attribute__((unused)) sensor_msgs::msg::PointCloud2 & output_pointcloud_msg)
 {
@@ -131,9 +130,12 @@ void RoiPointCloudFusionNode::fuseOnSingleImage(
     transform_stamped = transform_stamped_optional.value();
   }
   const int point_step = input_pointcloud_msg.point_step;
-  const int x_offset = input_pointcloud_msg.fields[pcl::getFieldIndex(input_pointcloud_msg, "x")].offset;
-  const int y_offset = input_pointcloud_msg.fields[pcl::getFieldIndex(input_pointcloud_msg, "y")].offset;
-  const int z_offset = input_pointcloud_msg.fields[pcl::getFieldIndex(input_pointcloud_msg, "z")].offset;
+  const int x_offset =
+    input_pointcloud_msg.fields[pcl::getFieldIndex(input_pointcloud_msg, "x")].offset;
+  const int y_offset =
+    input_pointcloud_msg.fields[pcl::getFieldIndex(input_pointcloud_msg, "y")].offset;
+  const int z_offset =
+    input_pointcloud_msg.fields[pcl::getFieldIndex(input_pointcloud_msg, "z")].offset;
 
   sensor_msgs::msg::PointCloud2 transformed_cloud;
   tf2::doTransform(input_pointcloud_msg, transformed_cloud, transform_stamped);
@@ -161,8 +163,7 @@ void RoiPointCloudFusionNode::fuseOnSingleImage(
 
     Eigen::Vector2d projected_point;
     if (camera_projectors_[image_id].calcImageProjectedPoint(
-      cv::Point3d(transformed_x, transformed_y, transformed_z), projected_point)
-    ) {
+          cv::Point3d(transformed_x, transformed_y, transformed_z), projected_point)) {
       for (std::size_t i = 0; i < output_objs.size(); ++i) {
         auto & feature_obj = output_objs.at(i);
         const auto & check_roi = feature_obj.feature.roi;

--- a/perception/autoware_image_projection_based_fusion/src/segmentation_pointcloud_fusion/node.cpp
+++ b/perception/autoware_image_projection_based_fusion/src/segmentation_pointcloud_fusion/node.cpp
@@ -151,8 +151,7 @@ void SegmentPointCloudFusionNode::fuseOnSingleImage(
 
     Eigen::Vector2d projected_point;
     if (!camera_projectors_[image_id].calcImageProjectedPoint(
-      cv::Point3d(transformed_x, transformed_y, transformed_z), projected_point
-    )){
+          cv::Point3d(transformed_x, transformed_y, transformed_z), projected_point)) {
       continue;
     }
 

--- a/perception/autoware_image_projection_based_fusion/src/utils/utils.cpp
+++ b/perception/autoware_image_projection_based_fusion/src/utils/utils.cpp
@@ -44,20 +44,6 @@ bool checkCameraInfo(const sensor_msgs::msg::CameraInfo & camera_info)
   return true;
 }
 
-Eigen::Vector2d calcRawImageProjectedPoint(
-  const image_geometry::PinholeCameraModel & pinhole_camera_model, const cv::Point3d & point3d,
-  const bool & unrectify)
-{
-  const cv::Point2d rectified_image_point = pinhole_camera_model.project3dToPixel(point3d);
-
-  if (!unrectify) {
-    return Eigen::Vector2d(rectified_image_point.x, rectified_image_point.y);
-  }
-  const cv::Point2d raw_image_point = pinhole_camera_model.unrectifyPoint(rectified_image_point);
-
-  return Eigen::Vector2d(raw_image_point.x, raw_image_point.y);
-}
-
 std::optional<geometry_msgs::msg::TransformStamped> getTransformStamped(
   const tf2_ros::Buffer & tf_buffer, const std::string & target_frame_id,
   const std::string & source_frame_id, const rclcpp::Time & time)


### PR DESCRIPTION
## Description
This PR introduces a caching feature for calculating raw image projections (unrectifyPoint).
This PR must merged with https://github.com/autowarefoundation/autoware_launch/pull/1275

It introduces the CameraProjection class to handle the related processes. The cache is computed based on specific grid centers, and the projected points are represented using these grid centers. These grid centers are determined by `approximation_grid_cell_width` and `approximation_grid_cell_height`.
Pre-cached result will be simply stored in an array and all grid cells on the image will be pre-computed.

For example, when approximation_grid_cell_\* is set to 1.0 pixel, the grid centers will be created as shown in the following image:
![image_projection_based_fusion_PR_image](https://github.com/user-attachments/assets/23ff12f0-beb1-4d38-beae-c50921628626)

***Note that edge pixels ((w, \*), (\*, h)) will be rounded to fall outside the image bounds***.

#### memory consumption
When using caching, memory consumption is calculated as:

ceil(image_width / grid_cell_width) \* ceil(image_height / grid_cell_height) \* (4 \* 2) \* roi_numbers [bytes]

Here, (4 \* 2) represents the bytes for two float values.
For example, for an image with dimensions 1440 × 1080, a grid size of 1 pixel, and caching enabled for 6 cameras, the memory consumption is:

(1440 / 1.0) \* (1080 / 1.0) \* 4 \* 2 \* 6 / (1024 \* 1024) ≈ 71.2 MiB (theoretical).

Also when using the cache feature, it requires an initialization step (pre-caching). This will make some delay to a node before starting the processing. 

### Other changes
- This PR fixes a bug where the camera parameters were used before being properly initialized in `pointpainting_fusion`.
- take a list input instead of single bool for `point_project_to_unrectified_image` param

## Performance: current impl. vs. this PR
- The following result is done with the same rosbag file, but the starting is determined by the (almost) first topic from the `map_based_prediction` node, so there is no guarantee it is aligned. 
- The processing time is timed with TimeKeeper (subCallback is timed).
- CPU usage and memory usage is collected with [autoware_tools](https://github.com/autowarefoundation/autoware_tools/tree/main/common/autoware_debug_tools)
- The grid cell size is set to a square (width == height), and the camera (roi) number is set to 6.
- `baseline` indicates the current implementation, `unrectified` is the `point_project_to_unrectified_image` and `cache` means `approximate_camera_projection` option in the config.
### Processing Time
#### roi_cluster_fusion
- all processing times
![all_roi_cluster_fusion_processing_time](https://github.com/user-attachments/assets/ae30b95f-808e-47e7-9f72-21c88b0dc914)
 
- current `point_project_to_unrectified_image=false` vs. this PR `point_project_to_unrectified_image=true, cache=true`
![roi_cluster_fusion_baseline_vs_cache](https://github.com/user-attachments/assets/71c45aca-a55c-4134-bdc9-bf33530afde2)
This shows the processing time is close to the case of `point_project_to_unrectified_image=false` case when we use the cache feature.

#### pointpainting_fusion
- all processing times
![all_pointpainting_processing_time](https://github.com/user-attachments/assets/76b8a7f0-eaad-47de-9dca-4c41102067a0)
- current `point_project_to_unrectified_image=false` vs. this PR `point_project_to_unrectified_image=true, cache=true`
![pointpainting_baseline_vs_cache](https://github.com/user-attachments/assets/35a55f7b-6733-4b18-a06d-135e523cf97b)

- current `point_project_to_unrectified_image=true` vs. this PR `point_project_to_unrectified_image=true, no cache`
![pointpainting_rectified_true_no_cache_compare](https://github.com/user-attachments/assets/c3a1532e-873a-45ab-a1e6-906fbae17a85)
This performance difference should be coming from the fix of the bug in FOV filtering (`camera_info` was not properly initialized).

### CPU Usage
#### roi_cluster_fusion
![roi_cluster_fusion_compare_cpu_usage](https://github.com/user-attachments/assets/8055ca41-11db-49ac-b2c5-bf071bead8ae)
Plot length differ because of the difference of play rate (0.1x is 3 times longer than 0.3x).
It does not contains the CPU usage of initialization step (which might use 100% of CPU).

### Memory Usage
#### roi_cluster_fusion
![roi_cluster_fusion_compare_memory_usage](https://github.com/user-attachments/assets/1f4c4137-44f3-412a-a55b-ec1b2b7d8a99)
Plot length differ because of the difference of play rate (0.1x is 3 times longer than 0.3x).


## Visualization
Following images ware not captured at the same frame.
![example_compare_of_grid_cell_size](https://github.com/user-attachments/assets/c2714945-2295-4a8d-b978-01733e5188e4)
All images are in the case of `point_project_to_unrectified_image=true`.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [TIERIV internal link](https://tier4.atlassian.net/browse/RT1-8469?focusedCommentId=199686&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-199686)
⬆️🟢 -->

## How was this PR tested?
Checked the rviz output and each fusion node's visualization.
![output_is_normal](https://github.com/user-attachments/assets/64f4d735-1cc4-4996-8994-2e86944d84b6)

For checking by yourself, you need some processing like
```
# decompress image
ros2 launch autoware_image_transport_decompressor image_transport_decompressor.launch.xml input_topic_name:=/sensing/camera/camera0/image_rect_color/compressed output_topic_name:=/sensing/camera/camera0/image_rect_color

# relay camera info
ros2 run topic_tools relay /sensing/camera/camera0/camera_info /perception/object_recognition/detection/pointpainting/pointpainting/debug/camera_info
```
and set the `debug_mode: true` in param. For `pointpainting_fusion`, you need to set the `#if 0` to `#if 1` to contain the points in an image.

## Notes for reviewers


None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
