### PR TITLE
fix(autoware_image_projection_based_fusion): fix bug of fov checker in pointpainting

### DIFF
--- a/perception/autoware_image_projection_based_fusion/include/autoware/image_projection_based_fusion/pointpainting_fusion/node.hpp
+++ b/perception/autoware_image_projection_based_fusion/include/autoware/image_projection_based_fusion/pointpainting_fusion/node.hpp
@@ -60,7 +60,9 @@ protected:
 
   rclcpp::Publisher<DetectedObjects>::SharedPtr obj_pub_ptr_;
 
-  std::vector<double> tan_h_;  // horizontal field of view
+  // horizontal field of view
+  std::vector<double> tan_h_left_;
+  std::vector<double> tan_h_right_;
 
   int omp_num_threads_{1};
   float score_threshold_{0.0};

--- a/perception/autoware_image_projection_based_fusion/include/autoware/image_projection_based_fusion/pointpainting_fusion/node.hpp
+++ b/perception/autoware_image_projection_based_fusion/include/autoware/image_projection_based_fusion/pointpainting_fusion/node.hpp
@@ -61,8 +61,8 @@ protected:
   rclcpp::Publisher<DetectedObjects>::SharedPtr obj_pub_ptr_;
 
   // horizontal field of view
-  std::vector<double> tan_h_left_;
-  std::vector<double> tan_h_right_;
+  std::vector<double> fov_left_;
+  std::vector<double> fov_right_;
 
   int omp_num_threads_{1};
   float score_threshold_{0.0};

--- a/perception/autoware_image_projection_based_fusion/src/pointpainting_fusion/node.cpp
+++ b/perception/autoware_image_projection_based_fusion/src/pointpainting_fusion/node.cpp
@@ -161,9 +161,7 @@ PointPaintingFusionNode::PointPaintingFusionNode(const rclcpp::NodeOptions & opt
 
   tan_h_.resize(rois_number_);
   for (std::size_t roi_i = 0; roi_i < rois_number_; ++roi_i) {
-    auto fx = camera_info_map_[roi_i].k.at(0);
-    auto x0 = camera_info_map_[roi_i].k.at(2);
-    tan_h_[roi_i] = x0 / fx;
+    tan_h_[roi_i] = 0;
   }
 
   detection_class_remapper_.setParameters(
@@ -272,6 +270,13 @@ void PointPaintingFusionNode::fuseOnSingleImage(
   }
 
   if (!checkCameraInfo(camera_info)) return;
+
+  // update camera fov
+  for (std::size_t roi_i = 0; roi_i < rois_number_; ++roi_i) {
+    auto fx = camera_info_map_[roi_i].k.at(0);
+    auto x0 = camera_info_map_[roi_i].k.at(2);
+    tan_h_[roi_i] = x0 / fx;
+  }
 
   std::vector<sensor_msgs::msg::RegionOfInterest> debug_image_rois;
   std::vector<Eigen::Vector2d> debug_image_points;

--- a/perception/autoware_image_projection_based_fusion/src/pointpainting_fusion/node.cpp
+++ b/perception/autoware_image_projection_based_fusion/src/pointpainting_fusion/node.cpp
@@ -349,11 +349,12 @@ dc   | dc dc dc  dc ||zc|
 
     /// check if the point is in the camera view
     if (p_z <= 0.0) continue;
+    if (p_x < fov_left_.at(image_id) * p_z) continue;
+    if (p_x > fov_right_.at(image_id) * p_z) continue;
+
     // project
     Eigen::Vector2d projected_point = calcRawImageProjectedPoint(
       pinhole_camera_model, cv::Point3d(p_x, p_y, p_z), point_project_to_unrectified_image_);
-    if (projected_point.x() < fov_left_.at(image_id)) continue;
-    if (projected_point.x() > fov_right_.at(image_id)) continue;
 
     // iterate 2d bbox
     for (const auto & feature_object : objects) {

--- a/perception/autoware_image_projection_based_fusion/src/pointpainting_fusion/node.cpp
+++ b/perception/autoware_image_projection_based_fusion/src/pointpainting_fusion/node.cpp
@@ -349,12 +349,11 @@ dc   | dc dc dc  dc ||zc|
 
     /// check if the point is in the camera view
     if (p_z <= 0.0) continue;
-    if (p_x < fov_left_.at(image_id) * p_z) continue;
-    if (p_x > fov_right_.at(image_id) * p_z) continue;
-
     // project
     Eigen::Vector2d projected_point = calcRawImageProjectedPoint(
       pinhole_camera_model, cv::Point3d(p_x, p_y, p_z), point_project_to_unrectified_image_);
+    if (projected_point.x() < fov_left_.at(image_id)) continue;
+    if (projected_point.x() > fov_right_.at(image_id)) continue;
 
     // iterate 2d bbox
     for (const auto & feature_object : objects) {


### PR DESCRIPTION
## Description

When the point is projected to the image space, the point is checked if the point is in the filed-of-view of corresponding camera.
It may cut unnecessary calculation of later roi matching.

However, @a-maumau found that the current implementation of loading camera parameter is done at the initialization and do not get the camera info.
```c++
    auto fx = camera_info_map_[roi_i].k.at(0); // fx = 0
    auto x0 = camera_info_map_[roi_i].k.at(2); // x0 = 0
    tan_h_[roi_i] = x0 / fx;                   // tan_h_[0] == NaN
```

```c++
    if (p_z <= 0.0 || p_x > (tan_h_.at(image_id) * p_z) || p_x < (-tan_h_.at(image_id) * p_z)) {
      continue;
    }
    // p_x > (tan_h_.at(image_id) * p_z) == false
    // p_x < (-tan_h_.at(image_id) * p_z) == false

```
Therefore the checker of the FoV was not done correctly.

This PR will not induce any logic difference.

Special thanks to @a-maumau 

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

Visually confirmed that the given roi and the pointcloud class is corresponding.

![Screenshot from 2024-12-12 18-19-47](https://github.com/user-attachments/assets/72646100-928d-4856-895a-7723cc060b09)


## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
