### PR TITLE
ci(build-and-test): set concurrency to sequential and remove workflow_dispatch

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -4,11 +4,11 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
-  cancel-in-progress: true
+  # Ensures sequential execution of this workflow
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
 
 env:
   CC: /usr/lib/ccache/gcc


### PR DESCRIPTION
## Description

Since this workflow circularly uses and updates the build cache used by all the other sub-jobs, it should run sequentially to avoid breaking the buffer integrity.

And since it only runs for already merged commits, it doesn't block any other task.

And removing the workflow_dispatch execution, since that also makes the buffer unusable due to [**Restrictions for accessing a cache**](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache). It is advised to use build-and-test-daily for such testing, since it does pretty much the same thing, but without updating the cache.

## How was this PR tested?

Since it is relatively simple, https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/control-the-concurrency-of-workflows-and-jobs#example-concurrency-groups can be used to understand how it would act.

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.
