### PR TITLE
build(autoware_freespace_planning_algorithms): increase test timeout to 2 mins

### DIFF
--- a/planning/autoware_freespace_planning_algorithms/CMakeLists.txt
+++ b/planning/autoware_freespace_planning_algorithms/CMakeLists.txt
@@ -34,6 +34,7 @@ if(BUILD_TESTING)
   ament_add_ros_isolated_gtest(${PROJECT_NAME}-test
     test/src/test_freespace_planning_algorithms.cpp
   )
+  set_tests_properties(${PROJECT_NAME}-test PROPERTIES TIMEOUT 120)
   target_link_libraries(${PROJECT_NAME}-test
     ${PROJECT_NAME}
   )


### PR DESCRIPTION
## Description

This test is flaky due to varying times it can take.

It randomly fails due to timeout. The default timeout for a single gtest is 60 seconds.

On my machine, this test took `30.61` seconds:
`1/6 Test #1: autoware_freespace_planning_algorithms-test ...   Passed   30.61 sec`
([Ryzen 5900X](https://www.amd.com/en/products/processors/desktops/ryzen/5000-series/amd-ryzen-9-5900x.html))

But [on the runner, it can take `49.78` seconds.](https://github.com/autowarefoundation/autoware.universe/actions/runs/12294031204/job/34307969122#step:17:17337):
`1/6 Test #1: autoware_freespace_planning_algorithms-test ...   Passed   49.78 sec`
([Xeon D-2141I](https://www.intel.com/content/www/us/en/products/sku/136430/intel-xeon-d2141i-processor-11m-cache-2-20-ghz/specifications.html))

Or it can fail due to timeout:
https://github.com/autowarefoundation/autoware.universe/actions/runs/12294047676/job/34308019262#step:17:17286
`1: Test timeout computed to be: 60`

This PR sets the timeout for this specific test to 120 seconds.

## How was this PR tested?

On my machine, to make sure, I set `set_tests_properties(${PROJECT_NAME}-test PROPERTIES TIMEOUT 5)` to make it fail at 5 seconds. And it failed successfully ✅
`Test timeout computed to be: 5`

Then I made it `120` as in the PR and it succeed ✅

You can test it yourself with `colcon test --event-handlers console_cohesion+ --packages-select autoware_freespace_planning_algorithms`

Don't forget to recompile the package when you change the timeout from the cmakelists file ⚠️

## Notes for reviewers

None.

## Interface changes

None.


## Effects on system behavior

None.
