### PR TITLE
feat(obstacle_cruise_planner): independant decision making

### DIFF
--- a/planning/autoware_obstacle_cruise_planner/src/node.cpp
+++ b/planning/autoware_obstacle_cruise_planner/src/node.cpp
@@ -1481,7 +1481,6 @@ ObstacleCruisePlannerNode::createCollisionPointsForInsideCruiseObstacle(
     return std::nullopt;
   }
 
-  /*
   {  // consider hysteresis
     // const bool is_prev_obstacle_stop = getObstacleFromUuid(prev_stop_obstacles_,
     // obstacle.uuid).has_value();
@@ -1502,7 +1501,6 @@ ObstacleCruisePlannerNode::createCollisionPointsForInsideCruiseObstacle(
       // NOTE: else is cruise from stop
     }
   }
-  */
 
   // Get highest confidence predicted path
   const auto resampled_predicted_paths = resampleHighestConfidencePredictedPaths(


### PR DESCRIPTION
## Description

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
