### PR TITLE
fix(autoware_stop_filter): fix bugprone-reserved-identifier

### DIFF
--- a/localization/autoware_stop_filter/src/stop_filter.cpp
+++ b/localization/autoware_stop_filter/src/stop_filter.cpp
@@ -22,7 +22,6 @@
 #include <string>
 #include <utility>
 
-using std::placeholders::_1;
 
 namespace autoware::stop_filter
 {
@@ -33,7 +32,7 @@ StopFilter::StopFilter(const rclcpp::NodeOptions & node_options)
   wz_threshold_ = declare_parameter<double>("wz_threshold");
 
   sub_odom_ = create_subscription<nav_msgs::msg::Odometry>(
-    "input/odom", 1, std::bind(&StopFilter::callback_odometry, this, _1));
+    "input/odom", 1, std::bind(&StopFilter::callback_odometry, this, std::placeholders::_1));
 
   pub_odom_ = create_publisher<nav_msgs::msg::Odometry>("output/odom", 1);
   pub_stop_flag_ = create_publisher<tier4_debug_msgs::msg::BoolStamped>("debug/stop_flag", 1);

--- a/localization/autoware_stop_filter/src/stop_filter.cpp
+++ b/localization/autoware_stop_filter/src/stop_filter.cpp
@@ -22,7 +22,6 @@
 #include <string>
 #include <utility>
 
-
 namespace autoware::stop_filter
 {
 StopFilter::StopFilter(const rclcpp::NodeOptions & node_options)


### PR DESCRIPTION
## Description
This is a fix based on clang-tidy `bugprone-reserved-identifier` error.

```
/home/emb4/autoware/autoware/src/universe/autoware.universe/localization/autoware_stop_filter/src/stop_filter.cpp:25:26: error: declaration uses identifier '_1', which is reserved in the global namespace; cannot be fixed automatically [bugprone-reserved-identifier,-warnings-as-errors]
using std::placeholders::_1;
                         ^
```
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
