### PR TITLE
fix(autoware_bytetrack): fix bugprone-reserved-identifier

### DIFF
--- a/perception/autoware_bytetrack/lib/src/lapjv.cpp
+++ b/perception/autoware_bytetrack/lib/src/lapjv.cpp
@@ -44,7 +44,7 @@
 
 /** Column-reduction and reduction transfer for a dense cost matrix.
  */
-int_t _ccrrt_dense(
+int_t ccrrt_dense(
   const uint_t n, cost_t * cost[], int_t * free_rows, int_t * x, int_t * y, cost_t * v)
 {
   int_t n_free_rows;
@@ -108,7 +108,7 @@ int_t _ccrrt_dense(
 
 /** Augmenting row reduction for a dense cost matrix.
  */
-int_t _carr_dense(
+int_t carr_dense(
   const uint_t n, cost_t * cost[], const uint_t n_free_rows, int_t * free_rows, int_t * x,
   int_t * y, cost_t * v)
 {
@@ -181,7 +181,7 @@ int_t _carr_dense(
 
 /** Find columns with minimum d[j] and put them on the SCAN list.
  */
-uint_t _find_dense(
+uint_t find_dense(
   const uint_t n, uint_t lo, const cost_t * d, int_t * cols, [[maybe_unused]] int_t * y)
 {
   uint_t hi = lo + 1;
@@ -202,7 +202,7 @@ uint_t _find_dense(
 
 // Scan all columns in TODO starting from arbitrary column in SCAN
 // and try to decrease d of the TODO columns using the SCAN column.
-int_t _scan_dense(
+int_t scan_dense(
   const uint_t n, cost_t * cost[], uint_t * plo, uint_t * phi, cost_t * d, int_t * cols,
   int_t * pred, const int_t * y, const cost_t * v)
 {
@@ -267,7 +267,7 @@ int_t find_path_dense(
     if (lo == hi) {
       PRINTF("%d..%d -> find\n", lo, hi);
       n_ready = lo;
-      hi = _find_dense(n, lo, d, cols, y);
+      hi = find_dense(n, lo, d, cols, y);
       PRINTF("check %d..%d\n", lo, hi);
       PRINT_INDEX_ARRAY(cols, n);
       for (uint_t k = lo; k < hi; k++) {
@@ -279,7 +279,7 @@ int_t find_path_dense(
     }
     if (final_j == -1) {
       PRINTF("%d..%d -> scan\n", lo, hi);
-      final_j = _scan_dense(n, cost, &lo, &hi, d, cols, pred, y, v);
+      final_j = scan_dense(n, cost, &lo, &hi, d, cols, pred, y, v);
       PRINT_COST_ARRAY(d, n);
       PRINT_INDEX_ARRAY(cols, n);
       PRINT_INDEX_ARRAY(pred, n);
@@ -304,7 +304,7 @@ int_t find_path_dense(
 
 /** Augment for a dense cost matrix.
  */
-int_t _ca_dense(
+int_t ca_dense(
   const uint_t n, cost_t * cost[], const uint_t n_free_rows, int_t * free_rows, int_t * x,
   int_t * y, cost_t * v)
 {
@@ -348,14 +348,14 @@ int lapjv_internal(const uint_t n, cost_t * cost[], int_t * x, int_t * y)
 
   NEW(free_rows, int_t, n);
   NEW(v, cost_t, n);
-  ret = _ccrrt_dense(n, cost, free_rows, x, y, v);
+  ret = ccrrt_dense(n, cost, free_rows, x, y, v);
   int i = 0;
   while (ret > 0 && i < 2) {
-    ret = _carr_dense(n, cost, ret, free_rows, x, y, v);
+    ret = carr_dense(n, cost, ret, free_rows, x, y, v);
     i++;
   }
   if (ret > 0) {
-    ret = _ca_dense(n, cost, ret, free_rows, x, y, v);
+    ret = ca_dense(n, cost, ret, free_rows, x, y, v);
   }
   FREE(v);
   FREE(free_rows);


### PR DESCRIPTION
## Description
This is a fix based on clang-tidy `bugprone-reserved-identifier` error.

```
/home/emb4/autoware/autoware/src/universe/autoware.universe/perception/autoware_bytetrack/lib/src/lapjv.cpp:47:7: error: declaration uses identifier '_ccrrt_dense', which is reserved in the global namespace [bugprone-reserved-identifier,-warnings-as-errors]
int_t _ccrrt_dense(
      ^~~~~~~~~~~~
      ccrrt_dense
/home/emb4/autoware/autoware/src/universe/autoware.universe/perception/autoware_bytetrack/lib/src/lapjv.cpp:111:7: error: declaration uses identifier '_carr_dense', which is reserved in the global namespace [bugprone-reserved-identifier,-warnings-as-errors]
int_t _carr_dense(
      ^~~~~~~~~~~
      carr_dense
/home/emb4/autoware/autoware/src/universe/autoware.universe/perception/autoware_bytetrack/lib/src/lapjv.cpp:184:8: error: declaration uses identifier '_find_dense', which is reserved in the global namespace [bugprone-reserved-identifier,-warnings-as-errors]
uint_t _find_dense(
       ^~~~~~~~~~~
       find_dense
/home/emb4/autoware/autoware/src/universe/autoware.universe/perception/autoware_bytetrack/lib/src/lapjv.cpp:205:7: error: declaration uses identifier '_scan_dense', which is reserved in the global namespace [bugprone-reserved-identifier,-warnings-as-errors]
int_t _scan_dense(
      ^~~~~~~~~~~
      scan_dense
/home/emb4/autoware/autoware/src/universe/autoware.universe/perception/autoware_bytetrack/lib/src/lapjv.cpp:307:7: error: declaration uses identifier '_ca_dense', which is reserved in the global namespace [bugprone-reserved-identifier,-warnings-as-errors]
int_t _ca_dense(
      ^~~~~~~~~
      ca_dense
```
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
