### PR TITLE
fix(autoware_multi_object_tracker): fix bugprone-errors

### DIFF
--- a/perception/autoware_multi_object_tracker/lib/tracker/model/bicycle_tracker.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/model/bicycle_tracker.cpp
@@ -208,11 +208,8 @@ bool BicycleTracker::measureWithShape(const autoware_perception_msgs::msg::Detec
   constexpr double size_min = 0.1;   // [m]
   if (
     object.shape.dimensions.x > size_max || object.shape.dimensions.y > size_max ||
-    object.shape.dimensions.z > size_max) {
-    return false;
-  } else if (
-    object.shape.dimensions.x < size_min || object.shape.dimensions.y < size_min ||
-    object.shape.dimensions.z < size_min) {
+    object.shape.dimensions.z > size_max || object.shape.dimensions.x < size_min ||
+    object.shape.dimensions.y < size_min || object.shape.dimensions.z < size_min) {
     return false;
   }
 

--- a/perception/autoware_multi_object_tracker/lib/tracker/motion_model/bicycle_motion_model.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/motion_model/bicycle_motion_model.cpp
@@ -315,7 +315,7 @@ bool BicycleMotionModel::predictStateStep(const double dt, KalmanFilter & ekf) c
   double w = vel * sin_slip / lr_;
   const double sin_2yaw = std::sin(2.0f * X_t(IDX::YAW));
   const double w_dtdt = w * dt * dt;
-  const double vv_dtdt__lr = vel * vel * dt * dt / lr_;
+  const double vv_dtdt_lr = vel * vel * dt * dt / lr_;
 
   // Predict state vector X t+1
   Eigen::MatrixXd X_next_t(DIM, 1);  // predicted state
@@ -332,11 +332,11 @@ bool BicycleMotionModel::predictStateStep(const double dt, KalmanFilter & ekf) c
   A(IDX::X, IDX::YAW) = -vel * sin_yaw * dt - 0.5 * vel * cos_yaw * w_dtdt;
   A(IDX::X, IDX::VEL) = cos_yaw * dt - sin_yaw * w_dtdt;
   A(IDX::X, IDX::SLIP) =
-    -vel * sin_yaw * dt - 0.5 * (cos_slip * sin_yaw + sin_slip * cos_yaw) * vv_dtdt__lr;
+    -vel * sin_yaw * dt - 0.5 * (cos_slip * sin_yaw + sin_slip * cos_yaw) * vv_dtdt_lr;
   A(IDX::Y, IDX::YAW) = vel * cos_yaw * dt - 0.5 * vel * sin_yaw * w_dtdt;
   A(IDX::Y, IDX::VEL) = sin_yaw * dt + cos_yaw * w_dtdt;
   A(IDX::Y, IDX::SLIP) =
-    vel * cos_yaw * dt + 0.5 * (cos_slip * cos_yaw - sin_slip * sin_yaw) * vv_dtdt__lr;
+    vel * cos_yaw * dt + 0.5 * (cos_slip * cos_yaw - sin_slip * sin_yaw) * vv_dtdt_lr;
   A(IDX::YAW, IDX::VEL) = 1.0 / lr_ * sin_slip * dt;
   A(IDX::YAW, IDX::SLIP) = vel / lr_ * cos_slip * dt;
 

--- a/perception/autoware_multi_object_tracker/src/processor/input_manager.cpp
+++ b/perception/autoware_multi_object_tracker/src/processor/input_manager.cpp
@@ -263,11 +263,11 @@ void InputManager::getObjectTimeInterval(
   // The default object_earliest_time is to have a 1-second time interval
   const rclcpp::Time object_earliest_time_default =
     object_latest_time - rclcpp::Duration::from_seconds(1.0);
-  if (latest_exported_object_time_ < object_earliest_time_default) {
-    // if the latest exported object time is too old, set to the default
-    object_earliest_time = object_earliest_time_default;
-  } else if (latest_exported_object_time_ > object_latest_time) {
-    // if the latest exported object time is newer than the object_latest_time, set to the default
+  if (
+    latest_exported_object_time_ < object_earliest_time_default ||
+    latest_exported_object_time_ > object_latest_time) {
+    // if the latest exported object time is too old or newer than the object_latest_time,
+    // set to the default
     object_earliest_time = object_earliest_time_default;
   } else {
     // The object_earliest_time is the latest exported object time


### PR DESCRIPTION
## Description
This is a fix based on clang-tidy `bugprone-branch-clone` and `bugprone-reserved-identifier` error.

```
/home/emb4/autoware/autoware/src/universe/autoware.universe/perception/autoware_multi_object_tracker/lib/tracker/model/bicycle_tracker.cpp:211:43: error: repeated branch in conditional chain [bugprone-branch-clone,-warnings-as-errors]
    object.shape.dimensions.z > size_max) {
                                          ^
/home/emb4/autoware/autoware/src/universe/autoware.universe/perception/autoware_multi_object_tracker/lib/tracker/model/bicycle_tracker.cpp:213:4: note: end of the original
  } else if (
   ^
/home/emb4/autoware/autoware/src/universe/autoware.universe/perception/autoware_multi_object_tracker/lib/tracker/model/bicycle_tracker.cpp:215:43: note: clone 1 starts here
    object.shape.dimensions.z < size_min) {
                                          ^

/home/emb4/autoware/autoware/src/universe/autoware.universe/perception/autoware_multi_object_tracker/src/processor/input_manager.cpp:267:56: error: repeated branch in conditional chain [bugprone-branch-clone,-warnings-as-errors]
    latest_exported_object_time_ > object_latest_time) {
                                                       ^
/home/emb4/autoware/autoware/src/universe/autoware.universe/perception/autoware_multi_object_tracker/src/processor/input_manager.cpp:270:4: note: end of the original
  } else if (latest_exported_object_time_ > object_latest_time) {
   ^
/home/emb4/autoware/autoware/src/universe/autoware.universe/perception/autoware_multi_object_tracker/src/processor/input_manager.cpp:270:65: note: clone 1 starts here
  } else if (latest_exported_object_time_ > object_latest_time) {
                                                                ^

/home/emb4/autoware/autoware/src/universe/autoware.universe/perception/autoware_multi_object_tracker/lib/tracker/motion_model/bicycle_motion_model.cpp:318:16: error: declaration uses identifier 'vv_dtdt__lr', which is a reserved identifier [bugprone-reserved-identifier,-warnings-as-errors]
  const double vv_dtdt__lr = vel * vel * dt * dt / lr_;
               ^~~~~~~~~~~
               vv_dtdt_lr

```
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
