### PR TITLE
fix(autoware_probabilistic_occupancy_grid_map): fix bugprone-branch-clone

### DIFF
--- a/perception/autoware_probabilistic_occupancy_grid_map/lib/costmap_2d/occupancy_grid_map_fixed.cpp
+++ b/perception/autoware_probabilistic_occupancy_grid_map/lib/costmap_2d/occupancy_grid_map_fixed.cpp
@@ -144,10 +144,11 @@ void OccupancyGridMapFixedBlindSpot::updateWithPointCloud(
     transformPointAndCalculate(pt, pt_map, angle_bin_index, range);
 
     // Ignore obstacle points exceed the range of the raw points
-    if (raw_pointcloud_angle_bins.at(angle_bin_index).empty()) {
-      continue;  // No raw point in this angle bin
-    } else if (range > raw_pointcloud_angle_bins.at(angle_bin_index).back().range) {
-      continue;  // Obstacle point exceeds the range of the raw points
+    // No raw point in this angle bin, or obstacle point exceeds the range of the raw points
+    if (
+      raw_pointcloud_angle_bins.at(angle_bin_index).empty() ||
+      range > raw_pointcloud_angle_bins.at(angle_bin_index).back().range) {
+      continue;
     }
     obstacle_pointcloud_angle_bins.at(angle_bin_index).emplace_back(range, pt_map[0], pt_map[1]);
   }

--- a/perception/autoware_probabilistic_occupancy_grid_map/lib/costmap_2d/occupancy_grid_map_projective.cpp
+++ b/perception/autoware_probabilistic_occupancy_grid_map/lib/costmap_2d/occupancy_grid_map_projective.cpp
@@ -153,10 +153,11 @@ void OccupancyGridMapProjectiveBlindSpot::updateWithPointCloud(
     const double dz = scan_z - obstacle_z;
 
     // Ignore obstacle points exceed the range of the raw points
-    if (raw_pointcloud_angle_bins.at(angle_bin_index).empty()) {
-      continue;  // No raw point in this angle bin
-    } else if (range > raw_pointcloud_angle_bins.at(angle_bin_index).back().range) {
-      continue;  // Obstacle point exceeds the range of the raw points
+    // No raw point in this angle bin, or obstacle point exceeds the range of the raw points
+    if (
+      raw_pointcloud_angle_bins.at(angle_bin_index).empty() ||
+      range > raw_pointcloud_angle_bins.at(angle_bin_index).back().range) {
+      continue;
     }
 
     if (dz > projection_dz_threshold_) {


### PR DESCRIPTION
## Description
This is a fix based on clang-tidy `bugprone-branch-clone` error.

```
/home/emb4/autoware/autoware/src/universe/autoware.universe/perception/autoware_probabilistic_occupancy_grid_map/lib/costmap_2d/occupancy_grid_map_fixed.cpp:147:64: error: repeated branch in conditional chain [bugprone-branch-clone,-warnings-as-errors]
    if (raw_pointcloud_angle_bins.at(angle_bin_index).empty()) {
                                                               ^
/home/emb4/autoware/autoware/src/universe/autoware.universe/perception/autoware_probabilistic_occupancy_grid_map/lib/costmap_2d/occupancy_grid_map_fixed.cpp:149:6: note: end of the original
    } else if (range > raw_pointcloud_angle_bins.at(angle_bin_index).back().range) {
     ^
/home/emb4/autoware/autoware/src/universe/autoware.universe/perception/autoware_probabilistic_occupancy_grid_map/lib/costmap_2d/occupancy_grid_map_fixed.cpp:149:84: note: clone 1 starts here
    } else if (range > raw_pointcloud_angle_bins.at(angle_bin_index).back().range) {
                                                                                   ^
/home/emb4/autoware/autoware/src/universe/autoware.universe/perception/autoware_probabilistic_occupancy_grid_map/lib/costmap_2d/occupancy_grid_map_projective.cpp:156:64: error: repeated branch in conditional chain [bugprone-branch-clone,-warnings-as-errors]
    if (raw_pointcloud_angle_bins.at(angle_bin_index).empty()) {
                                                               ^
/home/emb4/autoware/autoware/src/universe/autoware.universe/perception/autoware_probabilistic_occupancy_grid_map/lib/costmap_2d/occupancy_grid_map_projective.cpp:158:6: note: end of the original
    } else if (range > raw_pointcloud_angle_bins.at(angle_bin_index).back().range) {
     ^
/home/emb4/autoware/autoware/src/universe/autoware.universe/perception/autoware_probabilistic_occupancy_grid_map/lib/costmap_2d/occupancy_grid_map_projective.cpp:158:84: note: clone 1 starts here
    } else if (range > raw_pointcloud_angle_bins.at(angle_bin_index).back().range) {
                                                                                   ^
```
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
