### PR TITLE
chore(autoware_costmap_generator): suppress Could not find a connection between 'map' and 'base_link'

### DIFF
--- a/planning/autoware_costmap_generator/src/costmap_generator.cpp
+++ b/planning/autoware_costmap_generator/src/costmap_generator.cpp
@@ -51,6 +51,7 @@
 #include <autoware_lanelet2_extension/utility/utilities.hpp>
 #include <autoware_lanelet2_extension/visualization/visualization.hpp>
 #include <pcl_ros/transforms.hpp>
+#include <rclcpp/clock.hpp>
 #include <rclcpp/logging.hpp>
 #include <tf2_eigen/tf2_eigen.hpp>
 
@@ -68,14 +69,15 @@ namespace
 
 // Copied from scenario selector
 geometry_msgs::msg::PoseStamped::ConstSharedPtr getCurrentPose(
-  const tf2_ros::Buffer & tf_buffer, const rclcpp::Logger & logger)
+  const tf2_ros::Buffer & tf_buffer, const rclcpp::Logger & logger,
+  const rclcpp::Clock::SharedPtr clock)
 {
   geometry_msgs::msg::TransformStamped tf_current_pose;
 
   try {
     tf_current_pose = tf_buffer.lookupTransform("map", "base_link", tf2::TimePointZero);
   } catch (tf2::TransformException & ex) {
-    RCLCPP_ERROR(logger, "%s", ex.what());
+    RCLCPP_ERROR_THROTTLE(logger, *clock, 5000, "%s", ex.what());
     return nullptr;
   }
 
@@ -253,7 +255,7 @@ void CostmapGenerator::update_data()
 
 void CostmapGenerator::set_current_pose()
 {
-  current_pose_ = getCurrentPose(tf_buffer_, this->get_logger());
+  current_pose_ = getCurrentPose(tf_buffer_, this->get_logger(), this->get_clock());
 }
 
 void CostmapGenerator::onTimer()


### PR DESCRIPTION
## Description

Suppress this error.

```
[component_container_mt-35] [ERROR] [1734317356.286407477] [planning.scenario_planning.parking.costmap_generator]: Could not find a connection between 'map' and 'base_link' because they are not part of the same tree.Tf has two or more unconnected trees.
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
