### PR TITLE
fix(autoware_shape_estimation): fix bugprone-branch-clone

### DIFF
--- a/perception/autoware_shape_estimation/lib/corrector/utils.cpp
+++ b/perception/autoware_shape_estimation/lib/corrector/utils.cpp
@@ -209,7 +209,7 @@ bool correctWithDefaultValue(
         correction_vector.x();
     }
   }
-    // NOLINTEND(bugprone-branch-clone)
+  // NOLINTEND(bugprone-branch-clone)
   // fit length
   else if (  // NOLINT
     (param.min_length < (v_point.at(first_most_distant_index) * 2.0).norm() &&

--- a/perception/autoware_shape_estimation/lib/corrector/utils.cpp
+++ b/perception/autoware_shape_estimation/lib/corrector/utils.cpp
@@ -156,6 +156,7 @@ bool correctWithDefaultValue(
       return false;
     }
   }
+  // NOLINTBEGIN(bugprone-branch-clone)
   // fit width
   else if (  // NOLINT
     (param.min_width < (v_point.at(first_most_distant_index) * 2.0).norm() &&
@@ -208,6 +209,7 @@ bool correctWithDefaultValue(
         correction_vector.x();
     }
   }
+    // NOLINTEND(bugprone-branch-clone)
   // fit length
   else if (  // NOLINT
     (param.min_length < (v_point.at(first_most_distant_index) * 2.0).norm() &&

--- a/perception/autoware_shape_estimation/lib/corrector/utils.cpp
+++ b/perception/autoware_shape_estimation/lib/corrector/utils.cpp
@@ -158,7 +158,7 @@ bool correctWithDefaultValue(
   }
   // NOLINTBEGIN(bugprone-branch-clone)
   // fit width
-  else if (  // NOLINT
+  else if (
     (param.min_width < (v_point.at(first_most_distant_index) * 2.0).norm() &&
      (v_point.at(first_most_distant_index) * 2.0).norm() < param.max_width) &&
     (param.min_width < (v_point.at(second_most_distant_index) * 2.0).norm() &&
@@ -177,6 +177,7 @@ bool correctWithDefaultValue(
           (correction_vector.x() < 0.0 ? -1.0 : 1.0) -
         correction_vector.x();
     }
+  // NOLINTEND(bugprone-branch-clone)
   } else if (  // NOLINT
     param.min_width < (v_point.at(first_most_distant_index) * 2.0).norm() &&
     (v_point.at(first_most_distant_index) * 2.0).norm() < param.max_width) {
@@ -209,7 +210,6 @@ bool correctWithDefaultValue(
         correction_vector.x();
     }
   }
-  // NOLINTEND(bugprone-branch-clone)
   // fit length
   else if (  // NOLINT
     (param.min_length < (v_point.at(first_most_distant_index) * 2.0).norm() &&

--- a/perception/autoware_shape_estimation/lib/corrector/utils.cpp
+++ b/perception/autoware_shape_estimation/lib/corrector/utils.cpp
@@ -156,15 +156,14 @@ bool correctWithDefaultValue(
       return false;
     }
   }
-  // NOLINTBEGIN(bugprone-branch-clone)
   // fit width
-  else if (
+  else if (  // NOLINT
     (param.min_width < (v_point.at(first_most_distant_index) * 2.0).norm() &&
      (v_point.at(first_most_distant_index) * 2.0).norm() < param.max_width) &&
     (param.min_width < (v_point.at(second_most_distant_index) * 2.0).norm() &&
      (v_point.at(second_most_distant_index) * 2.0).norm() <
        param.max_width))  // both of edge is within width threshold
-  {
+  {                       // NOLINT
     correction_vector = v_point.at(first_most_distant_index);
     if (correction_vector.x() == 0.0) {
       correction_vector.y() =
@@ -177,7 +176,6 @@ bool correctWithDefaultValue(
           (correction_vector.x() < 0.0 ? -1.0 : 1.0) -
         correction_vector.x();
     }
-  // NOLINTEND(bugprone-branch-clone)
   } else if (  // NOLINT
     param.min_width < (v_point.at(first_most_distant_index) * 2.0).norm() &&
     (v_point.at(first_most_distant_index) * 2.0).norm() < param.max_width) {


### PR DESCRIPTION
## Description
This is a fix based on clang-tidy `bugprone-branch-clone` error.
No branches were exactly the same; similar branches existed.
In this case, the process would be difficult to understand if summarized, so it was suppressed with a comment.
```
/home/emb4/autoware/autoware/src/universe/autoware.universe/perception/autoware_shape_estimation/lib/corrector/utils.cpp:166:3: error: repeated branch in conditional chain [bugprone-branch-clone,-warnings-as-errors]
  {
  ^
```
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
