### PR TITLE
fix(autoware_tracking_object_merger): fix bugprone-branch-clone

### DIFF
--- a/perception/autoware_tracking_object_merger/src/utils/utils.cpp
+++ b/perception/autoware_tracking_object_merger/src/utils/utils.cpp
@@ -98,10 +98,10 @@ TrackedObject linearInterpolationForTrackedObject(
       output_shape.dimensions.x = shape1.dimensions.x * (1 - weight) + shape2.dimensions.x * weight;
       output_shape.dimensions.y = shape1.dimensions.y * (1 - weight) + shape2.dimensions.y * weight;
       output_shape.dimensions.z = shape1.dimensions.z * (1 - weight) + shape2.dimensions.z * weight;
-    } else if (shape1.type == autoware_perception_msgs::msg::Shape::CYLINDER) {
-      // (TODO) implement
-    } else if (shape1.type == autoware_perception_msgs::msg::Shape::POLYGON) {
-      // (TODO) implement
+    } else if (shape1.type == autoware_perception_msgs::msg::Shape::CYLINDER) { // NOLINT
+      // (TODO) implement and remove NOLINT
+    } else if (shape1.type == autoware_perception_msgs::msg::Shape::POLYGON) { // NOLINT
+      // (TODO) implement and remove NOLINT
     } else {
       // when type is unknown, print warning and do nothing
       std::cerr << "unknown shape type in linearInterpolationForTrackedObject function."

--- a/perception/autoware_tracking_object_merger/src/utils/utils.cpp
+++ b/perception/autoware_tracking_object_merger/src/utils/utils.cpp
@@ -98,9 +98,9 @@ TrackedObject linearInterpolationForTrackedObject(
       output_shape.dimensions.x = shape1.dimensions.x * (1 - weight) + shape2.dimensions.x * weight;
       output_shape.dimensions.y = shape1.dimensions.y * (1 - weight) + shape2.dimensions.y * weight;
       output_shape.dimensions.z = shape1.dimensions.z * (1 - weight) + shape2.dimensions.z * weight;
-    } else if (shape1.type == autoware_perception_msgs::msg::Shape::CYLINDER) { // NOLINT
+    } else if (shape1.type == autoware_perception_msgs::msg::Shape::CYLINDER) {  // NOLINT
       // (TODO) implement and remove NOLINT
-    } else if (shape1.type == autoware_perception_msgs::msg::Shape::POLYGON) { // NOLINT
+    } else if (shape1.type == autoware_perception_msgs::msg::Shape::POLYGON) {  // NOLINT
       // (TODO) implement and remove NOLINT
     } else {
       // when type is unknown, print warning and do nothing


### PR DESCRIPTION
## Description
This is a fix based on clang-tidy `bugprone-branch-clone` error.

```
/home/emb4/autoware/autoware/src/universe/autoware.universe/perception/autoware_tracking_object_merger/src/utils/utils.cpp:101:79: error: repeated branch in conditional chain [bugprone-branch-clone,-warnings-as-errors]
    } else if (shape1.type == autoware_perception_msgs::msg::Shape::CYLINDER) {
                                                                              ^
/home/emb4/autoware/autoware/src/universe/autoware.universe/perception/autoware_tracking_object_merger/src/utils/utils.cpp:103:6: note: end of the original
    } else if (shape1.type == autoware_perception_msgs::msg::Shape::POLYGON) {
     ^
/home/emb4/autoware/autoware/src/universe/autoware.universe/perception/autoware_tracking_object_merger/src/utils/utils.cpp:103:78: note: clone 1 starts here
    } else if (shape1.type == autoware_perception_msgs::msg::Shape::POLYGON) {
                                                                             ^
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
