### PR TITLE
feat(autoware_detected_object_validation): set validate distance in the obstacle pointcloud based validator 

### DIFF
--- a/perception/autoware_detected_object_validation/config/obstacle_pointcloud_based_validator.param.yaml
+++ b/perception/autoware_detected_object_validation/config/obstacle_pointcloud_based_validator.param.yaml
@@ -12,5 +12,7 @@
     #UNKNOWN,  CAR,    TRUCK,     BUS,    TRAILER, MOTORBIKE, BICYCLE,      PEDESTRIAN
       [800.0,  800.0,  800.0,    800.0,   800.0,      800.0,    800.0,         800.0]
 
+    validate_max_distance_m: 70.0 # [m]
+
     using_2d_validator: false
     enable_debugger: false

--- a/perception/autoware_detected_object_validation/schema/obstacle_pointcloud_based_validator.schema.json
+++ b/perception/autoware_detected_object_validation/schema/obstacle_pointcloud_based_validator.schema.json
@@ -30,6 +30,11 @@
           "default": [800, 800, 800, 800, 800, 800, 800, 800],
           "description": "Threshold value of the number of point clouds per object when the distance from baselink is 1m, because the number of point clouds varies with the distance from baselink."
         },
+        "validate_max_distance_m": {
+          "type": "number",
+          "default": 70.0,
+          "description": "The maximum distance from the baselink to the object to be validated"
+        },
         "using_2d_validator": {
           "type": "boolean",
           "default": false,

--- a/perception/autoware_detected_object_validation/src/obstacle_pointcloud/obstacle_pointcloud_validator.cpp
+++ b/perception/autoware_detected_object_validation/src/obstacle_pointcloud/obstacle_pointcloud_validator.cpp
@@ -295,7 +295,8 @@ ObstaclePointCloudBasedValidator::ObstaclePointCloudBasedValidator(
     declare_parameter<std::vector<int64_t>>("max_points_num");
   points_num_threshold_param_.min_points_and_distance_ratio =
     declare_parameter<std::vector<double>>("min_points_and_distance_ratio");
-  validate_max_distance_ = declare_parameter<double>("validate_max_distance_m");
+  const double validate_max_distance = declare_parameter<double>("validate_max_distance_m");
+  validate_max_distance_sq_ = validate_max_distance * validate_max_distance;
 
   using_2d_validator_ = declare_parameter<bool>("using_2d_validator");
 
@@ -348,15 +349,17 @@ void ObstaclePointCloudBasedValidator::onObjectsAndObstaclePointCloud(
     const auto & transformed_object = transformed_objects.objects.at(i);
     const auto & object = input_objects->objects.at(i);
     // check object distance
-    const double distance = std::hypot(
-      transformed_object.kinematics.pose_with_covariance.pose.position.x,
-      transformed_object.kinematics.pose_with_covariance.pose.position.y);
-    if (distance > validate_max_distance_) {
+    const double distance_sq =
+      transformed_object.kinematics.pose_with_covariance.pose.position.x *
+        transformed_object.kinematics.pose_with_covariance.pose.position.x +
+      transformed_object.kinematics.pose_with_covariance.pose.position.y *
+        transformed_object.kinematics.pose_with_covariance.pose.position.y;
+    if (distance_sq > validate_max_distance_sq_) {
       // pass to output
       output.objects.push_back(object);
       continue;
     }
-      
+
     const auto validated =
       validation_is_ready ? validator_->validate_object(transformed_object) : false;
     if (debugger_) {

--- a/perception/autoware_detected_object_validation/src/obstacle_pointcloud/obstacle_pointcloud_validator.cpp
+++ b/perception/autoware_detected_object_validation/src/obstacle_pointcloud/obstacle_pointcloud_validator.cpp
@@ -295,6 +295,7 @@ ObstaclePointCloudBasedValidator::ObstaclePointCloudBasedValidator(
     declare_parameter<std::vector<int64_t>>("max_points_num");
   points_num_threshold_param_.min_points_and_distance_ratio =
     declare_parameter<std::vector<double>>("min_points_and_distance_ratio");
+  validate_max_distance_ = declare_parameter<double>("validate_max_distance_m");
 
   using_2d_validator_ = declare_parameter<bool>("using_2d_validator");
 
@@ -346,6 +347,16 @@ void ObstaclePointCloudBasedValidator::onObjectsAndObstaclePointCloud(
   for (size_t i = 0; i < transformed_objects.objects.size(); ++i) {
     const auto & transformed_object = transformed_objects.objects.at(i);
     const auto & object = input_objects->objects.at(i);
+    // check object distance
+    const double distance = std::hypot(
+      transformed_object.kinematics.pose_with_covariance.pose.position.x,
+      transformed_object.kinematics.pose_with_covariance.pose.position.y);
+    if (distance > validate_max_distance_) {
+      // pass to output
+      output.objects.push_back(object);
+      continue;
+    }
+      
     const auto validated =
       validation_is_ready ? validator_->validate_object(transformed_object) : false;
     if (debugger_) {

--- a/perception/autoware_detected_object_validation/src/obstacle_pointcloud/obstacle_pointcloud_validator.hpp
+++ b/perception/autoware_detected_object_validation/src/obstacle_pointcloud/obstacle_pointcloud_validator.hpp
@@ -152,7 +152,7 @@ private:
   typedef message_filters::Synchronizer<SyncPolicy> Sync;
   Sync sync_;
   PointsNumThresholdParam points_num_threshold_param_;
-  double validate_max_distance_; // maximum object distance to validate [m]
+  double validate_max_distance_sq_;  // maximum object distance to validate, squared [m^2]
 
   std::shared_ptr<Debugger> debugger_;
   bool using_2d_validator_;

--- a/perception/autoware_detected_object_validation/src/obstacle_pointcloud/obstacle_pointcloud_validator.hpp
+++ b/perception/autoware_detected_object_validation/src/obstacle_pointcloud/obstacle_pointcloud_validator.hpp
@@ -152,6 +152,7 @@ private:
   typedef message_filters::Synchronizer<SyncPolicy> Sync;
   Sync sync_;
   PointsNumThresholdParam points_num_threshold_param_;
+  double validate_max_distance_; // maximum object distance to validate [m]
 
   std::shared_ptr<Debugger> debugger_;
   bool using_2d_validator_;


### PR DESCRIPTION
## Description

A set of detected objects is validated by the obstacle pointcloud, which is the result of a rule-based detection `ground segmentation`.
In far ranges, however, it is difficult to separate non-ground obstacle since reflection of ground in far range is very week or absent due to the shallow angle.

A parameter `validate_max_distance_m` is added to not validate object far than this parameter.

## Related links

Launcher PR https://github.com/autowarefoundation/autoware_launch/pull/1277

## How was this PR tested?
[TIER IV INTERNAL](https://evaluation.tier4.jp/evaluation/reports/23555364-8459-5d70-a6ae-66a328a44a02?project_id=prd_jt)

### Experiment condition
* ground segmentation setting : change parameters to make obstacle pointcloud less in far distance (for test purpose)
  - global_slope_max_angle_deg: 30.0
  - local_slope_max_angle_deg: 30.0
  - use_recheck_ground_cluster: false  


* obstacle pointcloud based validator set a short validation distance (for test purpose)
  - validate_max_distance_m: 40.0

### Before
Blue bounding box: detected objects
Yellow bounding box: validated objects
White points: obstacle pointcloud

![Screenshot from 2024-12-16 18-43-04](https://github.com/user-attachments/assets/6b54ad1a-12ef-4913-b601-f3cdd832a706)

Since the obstacle pointclouds are fail to segment obstacles in far ranges, far objects are filtered out.

### After
Blue bounding box: detected objects
Yellow bounding box: validated objects

![Screenshot from 2024-12-16 18-59-16](https://github.com/user-attachments/assets/77f654cb-2255-4d26-80e2-672120eab497)

Even the obstacle pointclouds are absent, objects far than 40m could pass the validator.

## Notes for reviewers

The parameter `validate_max_distance_m` need to be set where the ground segmentation is less accurate. If this parameter is set too close, there is a risk that the detected is object is not validated.


## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
