### PR TITLE
fix(autoware_traffic_light_visualization): fix bugprone-branch-clone

### DIFF
--- a/perception/autoware_traffic_light_visualization/src/traffic_light_map_visualizer/node.cpp
+++ b/perception/autoware_traffic_light_visualization/src/traffic_light_map_visualizer/node.cpp
@@ -169,7 +169,7 @@ void TrafficLightMapVisualizerNode::trafficSignalsCallback(
               visualization_msgs::msg::Marker marker;
               if (
                 isAttributeValue(pt, "color", "red") &&
-                elem.color == autoware_perception_msgs::msg::TrafficLightElement::RED) {
+                elem.color == autoware_perception_msgs::msg::TrafficLightElement::RED) {  // NOLINT
                 lightAsMarker(
                   get_node_logging_interface(), pt, &marker, "traffic_light", current_time);
               } else if (  // NOLINT
@@ -177,7 +177,6 @@ void TrafficLightMapVisualizerNode::trafficSignalsCallback(
                 elem.color == autoware_perception_msgs::msg::TrafficLightElement::GREEN) {
                 lightAsMarker(
                   get_node_logging_interface(), pt, &marker, "traffic_light", current_time);
-
               } else if (  // NOLINT
                 isAttributeValue(pt, "color", "yellow") &&
                 elem.color == autoware_perception_msgs::msg::TrafficLightElement::AMBER) {


### PR DESCRIPTION
## Description
This is a fix based on clang-tidy `bugprone-branch-clone` error.
Since it was originally suppressed by NOLINT, this error is also suppressed by NOLINT.
```
/home/emb4/autoware/autoware/src/universe/autoware.universe/perception/autoware_traffic_light_visualization/src/traffic_light_map_visualizer/node.cpp:172:88: error: repeated branch in conditional chain [bugprone-branch-clone,-warnings-as-errors]
                elem.color == autoware_perception_msgs::msg::TrafficLightElement::RED) {
                                                                                       ^
```
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
