### PR TITLE
fix(autoware_freespace_planning_algorithms): fix bugprone-errors

### DIFF
--- a/planning/autoware_freespace_planning_algorithms/src/abstract_algorithm.cpp
+++ b/planning/autoware_freespace_planning_algorithms/src/abstract_algorithm.cpp
@@ -115,7 +115,7 @@ void AbstractPlanningAlgorithm::setMap(const nav_msgs::msg::OccupancyGrid & cost
   std::vector<bool> is_obstacle_table;
   is_obstacle_table.resize(nb_of_cells);
   for (uint32_t i = 0; i < nb_of_cells; ++i) {
-    const int cost = static_cast<unsigned char>(costmap_.data[i]);
+    const int cost = costmap_.data[i];  // NOLINT
     if (cost < 0 || planner_common_param_.obstacle_threshold <= cost) {
       is_obstacle_table[i] = true;
     }

--- a/planning/autoware_freespace_planning_algorithms/src/abstract_algorithm.cpp
+++ b/planning/autoware_freespace_planning_algorithms/src/abstract_algorithm.cpp
@@ -115,7 +115,7 @@ void AbstractPlanningAlgorithm::setMap(const nav_msgs::msg::OccupancyGrid & cost
   std::vector<bool> is_obstacle_table;
   is_obstacle_table.resize(nb_of_cells);
   for (uint32_t i = 0; i < nb_of_cells; ++i) {
-    const int cost = costmap_.data[i];
+    const int cost = static_cast<unsigned char>(costmap_.data[i]);
     if (cost < 0 || planner_common_param_.obstacle_threshold <= cost) {
       is_obstacle_table[i] = true;
     }

--- a/planning/autoware_freespace_planning_algorithms/src/astar_search.cpp
+++ b/planning/autoware_freespace_planning_algorithms/src/astar_search.cpp
@@ -388,7 +388,7 @@ double AstarSearch::getExpansionDistance(const AstarNode & current_node) const
 double AstarSearch::getSteeringCost(const int steering_index) const
 {
   return planner_common_param_.curve_weight *
-         (abs(steering_index) / planner_common_param_.turning_steps);
+         (static_cast<double>(abs(steering_index)) / planner_common_param_.turning_steps);
 }
 
 double AstarSearch::getSteeringChangeCost(


### PR DESCRIPTION
## Description
This is a fix based on clang-tidy `bugprone-signed-char-misuse` and `bugprone-integer-division` error.

```
/home/emb4/autoware/autoware/src/universe/autoware.universe/planning/autoware_freespace_planning_algorithms/src/abstract_algorithm.cpp:118:22: error: 'signed char' to 'const int' conversion; consider casting to 'unsigned char' first. [bugprone-signed-char-misuse,-warnings-as-errors]
    const int cost = costmap_.data[i];
                     ^

/home/emb4/autoware/autoware/src/universe/autoware.universe/planning/autoware_freespace_planning_algorithms/src/astar_search.cpp:391:11: error: result of integer division used in a floating point context; possible loss of precision [bugprone-integer-division,-warnings-as-errors]
         (abs(steering_index) / planner_common_param_.turning_steps);
          ^
```
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
