### PR TITLE
fix(autoware_objects_of_interest_marker_interface): fix bugprone-branch-clone

### DIFF
--- a/planning/autoware_objects_of_interest_marker_interface/src/objects_of_interest_marker_interface.cpp
+++ b/planning/autoware_objects_of_interest_marker_interface/src/objects_of_interest_marker_interface.cpp
@@ -83,7 +83,6 @@ ColorRGBA ObjectsOfInterestMarkerInterface::getColor(
     case ColorName::RED:
       return coloring::getRed(alpha);
     case ColorName::GRAY:
-      return coloring::getGray(alpha);
     default:
       return coloring::getGray(alpha);
   }

--- a/planning/autoware_objects_of_interest_marker_interface/src/objects_of_interest_marker_interface.cpp
+++ b/planning/autoware_objects_of_interest_marker_interface/src/objects_of_interest_marker_interface.cpp
@@ -82,7 +82,8 @@ ColorRGBA ObjectsOfInterestMarkerInterface::getColor(
       return coloring::getAmber(alpha);
     case ColorName::RED:
       return coloring::getRed(alpha);
-    case ColorName::GRAY:
+    case ColorName::GRAY:  // NOLINT
+      return coloring::getGray(alpha);
     default:
       return coloring::getGray(alpha);
   }

--- a/planning/autoware_objects_of_interest_marker_interface/src/objects_of_interest_marker_interface.cpp
+++ b/planning/autoware_objects_of_interest_marker_interface/src/objects_of_interest_marker_interface.cpp
@@ -76,14 +76,14 @@ ColorRGBA ObjectsOfInterestMarkerInterface::getColor(
   const ColorName & color_name, const float alpha)
 {
   switch (color_name) {
+    case ColorName::GRAY:
+      return coloring::getGray(alpha);
     case ColorName::GREEN:
       return coloring::getGreen(alpha);
     case ColorName::AMBER:
       return coloring::getAmber(alpha);
     case ColorName::RED:
       return coloring::getRed(alpha);
-    case ColorName::GRAY:  // NOLINT
-      return coloring::getGray(alpha);
     default:
       return coloring::getGray(alpha);
   }


### PR DESCRIPTION
## Description
This is a fix based on clang-tidy `bugprone-branch-clone` error.

```
/home/emb4/autoware/autoware/src/universe/autoware.universe/planning/autoware_objects_of_interest_marker_interface/src/objects_of_interest_marker_interface.cpp:85:5: error: switch has 2 consecutive identical branches [bugprone-branch-clone,-warnings-as-errors]
    case ColorName::GRAY:
    ^
/home/emb4/autoware/autoware/src/universe/autoware.universe/planning/autoware_objects_of_interest_marker_interface/src/objects_of_interest_marker_interface.cpp:88:38: note: last of these clones ends here
      return coloring::getGray(alpha);
                                     ^
```
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
