### PR TITLE
feat(pid_longitudinal_controller): remove trans/rot deviation validation since the control_validator has the same feature

### DIFF
--- a/control/autoware_pid_longitudinal_controller/config/autoware_pid_longitudinal_controller.param.yaml
+++ b/control/autoware_pid_longitudinal_controller/config/autoware_pid_longitudinal_controller.param.yaml
@@ -16,8 +16,6 @@
     stopped_state_entry_vel: 0.01
     stopped_state_entry_acc: 0.1
     emergency_state_overshoot_stop_dist: 1.5
-    emergency_state_traj_trans_dev: 3.0
-    emergency_state_traj_rot_dev: 0.7854
 
     # drive state
     kp: 1.0

--- a/control/autoware_pid_longitudinal_controller/include/autoware/pid_longitudinal_controller/pid_longitudinal_controller.hpp
+++ b/control/autoware_pid_longitudinal_controller/include/autoware/pid_longitudinal_controller/pid_longitudinal_controller.hpp
@@ -87,7 +87,6 @@ private:
 
   struct ControlData
   {
-    bool is_far_from_trajectory{false};
     autoware_planning_msgs::msg::Trajectory interpolated_traj{};
     size_t nearest_idx{0};  // nearest_idx = 0 when nearest_idx is not found with findNearestIdx
     size_t target_idx{0};
@@ -162,8 +161,6 @@ private:
     double stopped_state_entry_acc;
     // emergency
     double emergency_state_overshoot_stop_dist;
-    double emergency_state_traj_trans_dev;
-    double emergency_state_traj_rot_dev;
   };
   StateTransitionParams m_state_transition_params;
 
@@ -245,12 +242,6 @@ private:
   // Diagnostic
   std::shared_ptr<diagnostic_updater::Updater>
     diag_updater_{};  // Diagnostic updater for publishing diagnostic data.
-  struct DiagnosticData
-  {
-    double trans_deviation{0.0};  // translation deviation between nearest point and current_pose
-    double rot_deviation{0.0};    // rotation deviation between nearest point and current_pose
-  };
-  DiagnosticData m_diagnostic_data;
   void setupDiagnosticUpdater();
   void checkControlState(diagnostic_updater::DiagnosticStatusWrapper & stat);
 

--- a/control/autoware_pid_longitudinal_controller/media/LongitudinalControllerStateTransition.drawio.svg
+++ b/control/autoware_pid_longitudinal_controller/media/LongitudinalControllerStateTransition.drawio.svg
@@ -175,7 +175,7 @@
                   : For 500 [ms], self velocity is smaller than C1, and self acceleration is smaller than C2.
                   <br/>
                   <b>emergency condition</b>
-                  <span>: Speed command is zero velocity, and distance to stop is smaller than D1, or self pose is not within D2, D3 from trajectory.</span>
+                  <span>: Speed command is zero velocity, and distance to stop is smaller than D1.</span>
                 </p>
               </div>
             </div>
@@ -315,10 +315,6 @@
                   C2 : stopped_state_entry_acc
                   <br/>
                   D1 : emergency_state_overshoot_stop_dist
-                  <br/>
-                  D2 : emergency_state_traj_trans_dev
-                  <br/>
-                  D3 : emergency_state_traj_rot_dev
                 </p>
               </div>
             </div>

--- a/control/autoware_pid_longitudinal_controller/schema/autoware_pid_longitudinal_controller.schema.json
+++ b/control/autoware_pid_longitudinal_controller/schema/autoware_pid_longitudinal_controller.schema.json
@@ -71,16 +71,6 @@
           "description": "If `enable_overshoot_emergency` is true and the ego is `emergency_state_overshoot_stop_dist`-meter ahead of the stop point, the state will transit to EMERGENCY. [m]",
           "default": "1.5"
         },
-        "emergency_state_traj_trans_dev": {
-          "type": "number",
-          "description": "If the ego's position is `emergency_state_traj_trans_dev` meter away from the nearest trajectory point, the state will transit to EMERGENCY. [m]",
-          "default": "3.0"
-        },
-        "emergency_state_traj_rot_dev": {
-          "type": "number",
-          "description": "If the ego's orientation is `emergency_state_traj_rot_dev` rad away from the nearest trajectory point orientation, the state will transit to EMERGENCY. [rad]",
-          "default": "0.7854"
-        },
         "kp": {
           "type": "number",
           "description": "p gain for longitudinal control",
@@ -326,8 +316,6 @@
         "stopped_state_entry_vel",
         "stopped_state_entry_acc",
         "emergency_state_overshoot_stop_dist",
-        "emergency_state_traj_trans_dev",
-        "emergency_state_traj_rot_dev",
         "kp",
         "ki",
         "kd",

--- a/control/autoware_trajectory_follower_node/test/test_controller_node.cpp
+++ b/control/autoware_trajectory_follower_node/test/test_controller_node.cpp
@@ -510,34 +510,6 @@ TEST_F(FakeNodeFixture, longitudinal_reverse)
   EXPECT_GT(tester.cmd_msg->longitudinal.acceleration, 0.0f);
 }
 
-TEST_F(FakeNodeFixture, longitudinal_emergency)
-{
-  const auto node_options = makeNodeOptions();
-  ControllerTester tester(this, node_options);
-
-  tester.send_default_transform();
-  tester.publish_default_odom();
-  tester.publish_autonomous_operation_mode();
-  tester.publish_default_steer();
-  tester.publish_default_acc();
-
-  // Publish trajectory starting away from the current ego pose
-  Trajectory traj;
-  traj.header.stamp = tester.node->now();
-  traj.header.frame_id = "map";
-  traj.points.push_back(make_traj_point(10.0, 0.0, 1.0f));
-  traj.points.push_back(make_traj_point(50.0, 0.0, 1.0f));
-  traj.points.push_back(make_traj_point(100.0, 0.0, 1.0f));
-  tester.traj_pub->publish(traj);
-
-  test_utils::waitForMessage(tester.node, this, tester.received_control_command);
-
-  ASSERT_TRUE(tester.received_control_command);
-  // Emergencies (e.g., far from trajectory) produces braking command (0 vel, negative accel)
-  EXPECT_DOUBLE_EQ(tester.cmd_msg->longitudinal.velocity, 0.0f);
-  EXPECT_LT(tester.cmd_msg->longitudinal.acceleration, 0.0f);
-}
-
 TEST_F(FakeNodeFixture, longitudinal_not_check_steer_converged)
 {
   const auto node_options = makeNodeOptions();


### PR DESCRIPTION
## Description

Currently, several nodes have a translational/rotational deviation checker.
Among them, the control_validator should be responsible for it, so I removed it from the pid_longiudinal_controller.
## Related links

## How was this PR tested?

psim worked.
## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
