### PR TITLE
feat(motion_utils): add planning factor interface

### DIFF
--- a/common/autoware_motion_utils/include/autoware/motion_utils/factor/planning_factor_interface.hpp
+++ b/common/autoware_motion_utils/include/autoware/motion_utils/factor/planning_factor_interface.hpp
@@ -1,0 +1,138 @@
+// Copyright 2024 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__MOTION_UTILS__FACTOR__PLANNING_FACTOR_INTERFACE_HPP_
+#define AUTOWARE__MOTION_UTILS__FACTOR__PLANNING_FACTOR_INTERFACE_HPP_
+
+#include <rclcpp/rclcpp.hpp>
+
+#include <geometry_msgs/msg/pose.hpp>
+#include <tier4_planning_msgs/msg/control_point.hpp>
+#include <tier4_planning_msgs/msg/planning_factor.hpp>
+#include <tier4_planning_msgs/msg/planning_factor_array.hpp>
+#include <tier4_planning_msgs/msg/safety_factor_array.hpp>
+
+#include <string>
+#include <vector>
+
+namespace autoware::motion_utils
+{
+
+using geometry_msgs::msg::Pose;
+using tier4_planning_msgs::msg::ControlPoint;
+using tier4_planning_msgs::msg::PlanningFactor;
+using tier4_planning_msgs::msg::PlanningFactorArray;
+using tier4_planning_msgs::msg::SafetyFactorArray;
+
+class PlanningFactorInterface
+{
+public:
+  PlanningFactorInterface(rclcpp::Node * node, const std::string & name);
+
+  /**
+   * @brief factor setter for single control point.
+   *
+   * @param path points.
+   * @param ego current pose.
+   * @param control point pose. (e.g. stop or slow down point pose)
+   * @param behavior of this planning factor.
+   * @param safety factor.
+   * @param driving direction.
+   * @param target velocity of the control point.
+   * @param shift length of the control point.
+   * @param detail information.
+   */
+  template <class PointType>
+  void add(
+    const std::vector<PointType> & points, const Pose & ego_pose, const Pose & control_point_pose,
+    const uint16_t behavior, const SafetyFactorArray & safety_factors,
+    const bool is_driving_forward = true, const double velocity = 0.0,
+    const double shift_length = 0.0, const std::string & detail = "");
+
+  /**
+   * @brief factor setter for two control points (section).
+   *
+   * @param path points.
+   * @param ego current pose.
+   * @param control section start pose. (e.g. lane change start point pose)
+   * @param control section end pose. (e.g. lane change end point pose)
+   * @param behavior of this planning factor.
+   * @param safety factor.
+   * @param driving direction.
+   * @param target velocity of the control point.
+   * @param shift length of the control point.
+   * @param detail information.
+   */
+  template <class PointType>
+  void add(
+    const std::vector<PointType> & points, const Pose & ego_pose, const Pose & start_pose,
+    const Pose & end_pose, const uint16_t behavior, const SafetyFactorArray & safety_factors,
+    const bool is_driving_forward = true, const double velocity = 0.0,
+    const double shift_length = 0.0, const std::string & detail = "");
+
+  /**
+   * @brief factor setter for single control point.
+   *
+   * @param distance to control point.
+   * @param control point pose. (e.g. stop point pose)
+   * @param behavior of this planning factor.
+   * @param safety factor.
+   * @param driving direction.
+   * @param target velocity of the control point.
+   * @param shift length of the control point.
+   * @param detail information.
+   */
+  void add(
+    const double distance, const Pose & control_point_pose, const uint16_t behavior,
+    const SafetyFactorArray & safety_factors, const bool is_driving_forward = true,
+    const double velocity = 0.0, const double shift_length = 0.0, const std::string & detail = "");
+
+  /**
+   * @brief factor setter for two control points (section).
+   *
+   * @param distance to control section start point.
+   * @param distance to control section end point.
+   * @param control section start pose. (e.g. lane change start point pose)
+   * @param control section end pose. (e.g. lane change end point pose)
+   * @param behavior of this planning factor.
+   * @param safety factor.
+   * @param driving direction.
+   * @param target velocity of the control point.
+   * @param shift length of the control point.
+   * @param detail information.
+   */
+  void add(
+    const double start_distance, const double end_distance, const Pose & start_pose,
+    const Pose & end_pose, const uint16_t behavior, const SafetyFactorArray & safety_factors,
+    const bool is_driving_forward = true, const double velocity = 0.0,
+    const double shift_length = 0.0, const std::string & detail = "");
+
+  /**
+   * @brief publish planning factors.
+   */
+  void publish();
+
+private:
+  std::string name_;
+
+  rclcpp::Publisher<PlanningFactorArray>::SharedPtr pub_factors_;
+
+  rclcpp::Clock::SharedPtr clock_;
+
+  std::vector<PlanningFactor> factors_;
+};
+
+}  // namespace autoware::motion_utils
+
+#endif  // AUTOWARE__MOTION_UTILS__FACTOR__PLANNING_FACTOR_INTERFACE_HPP_

--- a/common/autoware_motion_utils/include/autoware/motion_utils/factor/planning_factor_interface.hpp
+++ b/common/autoware_motion_utils/include/autoware/motion_utils/factor/planning_factor_interface.hpp
@@ -15,6 +15,7 @@
 #ifndef AUTOWARE__MOTION_UTILS__FACTOR__PLANNING_FACTOR_INTERFACE_HPP_
 #define AUTOWARE__MOTION_UTILS__FACTOR__PLANNING_FACTOR_INTERFACE_HPP_
 
+#include <autoware/motion_utils/trajectory/trajectory.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include <autoware_planning_msgs/msg/path_point.hpp>
@@ -41,7 +42,13 @@ using tier4_planning_msgs::msg::SafetyFactorArray;
 class PlanningFactorInterface
 {
 public:
-  PlanningFactorInterface(rclcpp::Node * node, const std::string & name);
+  PlanningFactorInterface(rclcpp::Node * node, const std::string & name)
+  : name_{name},
+    pub_factors_{
+      node->create_publisher<PlanningFactorArray>("/planning/planning_factors/" + name, 1)},
+    clock_{node->get_clock()}
+  {
+  }
 
   /**
    * @brief factor setter for single control point.
@@ -61,7 +68,14 @@ public:
     const std::vector<PointType> & points, const Pose & ego_pose, const Pose & control_point_pose,
     const uint16_t behavior, const SafetyFactorArray & safety_factors,
     const bool is_driving_forward = true, const double velocity = 0.0,
-    const double shift_length = 0.0, const std::string & detail = "");
+    const double shift_length = 0.0, const std::string & detail = "")
+  {
+    const auto distance = static_cast<float>(autoware::motion_utils::calcSignedArcLength(
+      points, ego_pose.position, control_point_pose.position));
+    add(
+      distance, control_point_pose, behavior, safety_factors, is_driving_forward, velocity,
+      shift_length, detail);
+  }
 
   /**
    * @brief factor setter for two control points (section).
@@ -82,7 +96,16 @@ public:
     const std::vector<PointType> & points, const Pose & ego_pose, const Pose & start_pose,
     const Pose & end_pose, const uint16_t behavior, const SafetyFactorArray & safety_factors,
     const bool is_driving_forward = true, const double velocity = 0.0,
-    const double shift_length = 0.0, const std::string & detail = "");
+    const double shift_length = 0.0, const std::string & detail = "")
+  {
+    const auto start_distance = static_cast<float>(
+      autoware::motion_utils::calcSignedArcLength(points, ego_pose.position, start_pose.position));
+    const auto end_distance = static_cast<float>(
+      autoware::motion_utils::calcSignedArcLength(points, ego_pose.position, end_pose.position));
+    add(
+      start_distance, end_distance, start_pose, end_pose, behavior, safety_factors,
+      is_driving_forward, velocity, shift_length, detail);
+  }
 
   /**
    * @brief factor setter for single control point.
@@ -99,7 +122,24 @@ public:
   void add(
     const double distance, const Pose & control_point_pose, const uint16_t behavior,
     const SafetyFactorArray & safety_factors, const bool is_driving_forward = true,
-    const double velocity = 0.0, const double shift_length = 0.0, const std::string & detail = "");
+    const double velocity = 0.0, const double shift_length = 0.0, const std::string & detail = "")
+  {
+    const auto control_point = tier4_planning_msgs::build<ControlPoint>()
+                                 .pose(control_point_pose)
+                                 .velocity(velocity)
+                                 .shift_length(shift_length)
+                                 .distance(distance);
+
+    const auto factor = tier4_planning_msgs::build<PlanningFactor>()
+                          .module(name_)
+                          .is_driving_forward(is_driving_forward)
+                          .control_points({control_point})
+                          .behavior(behavior)
+                          .detail(detail)
+                          .safety_factors(safety_factors);
+
+    factors_.push_back(factor);
+  }
 
   /**
    * @brief factor setter for two control points (section).
@@ -119,12 +159,45 @@ public:
     const double start_distance, const double end_distance, const Pose & start_pose,
     const Pose & end_pose, const uint16_t behavior, const SafetyFactorArray & safety_factors,
     const bool is_driving_forward = true, const double velocity = 0.0,
-    const double shift_length = 0.0, const std::string & detail = "");
+    const double shift_length = 0.0, const std::string & detail = "")
+  {
+    const auto control_start_point = tier4_planning_msgs::build<ControlPoint>()
+                                       .pose(start_pose)
+                                       .velocity(velocity)
+                                       .shift_length(shift_length)
+                                       .distance(start_distance);
+
+    const auto control_end_point = tier4_planning_msgs::build<ControlPoint>()
+                                     .pose(end_pose)
+                                     .velocity(velocity)
+                                     .shift_length(shift_length)
+                                     .distance(end_distance);
+
+    const auto factor = tier4_planning_msgs::build<PlanningFactor>()
+                          .module(name_)
+                          .is_driving_forward(is_driving_forward)
+                          .control_points({control_start_point, control_end_point})
+                          .behavior(behavior)
+                          .detail(detail)
+                          .safety_factors(safety_factors);
+
+    factors_.push_back(factor);
+  }
 
   /**
    * @brief publish planning factors.
    */
-  void publish();
+  void publish()
+  {
+    PlanningFactorArray msg;
+    msg.header.frame_id = "map";
+    msg.header.stamp = clock_->now();
+    msg.factors = factors_;
+
+    pub_factors_->publish(msg);
+
+    factors_.clear();
+  }
 
 private:
   std::string name_;

--- a/common/autoware_motion_utils/include/autoware/motion_utils/factor/planning_factor_interface.hpp
+++ b/common/autoware_motion_utils/include/autoware/motion_utils/factor/planning_factor_interface.hpp
@@ -17,8 +17,11 @@
 
 #include <rclcpp/rclcpp.hpp>
 
+#include <autoware_planning_msgs/msg/path_point.hpp>
+#include <autoware_planning_msgs/msg/trajectory_point.hpp>
 #include <geometry_msgs/msg/pose.hpp>
 #include <tier4_planning_msgs/msg/control_point.hpp>
+#include <tier4_planning_msgs/msg/path_point_with_lane_id.hpp>
 #include <tier4_planning_msgs/msg/planning_factor.hpp>
 #include <tier4_planning_msgs/msg/planning_factor_array.hpp>
 #include <tier4_planning_msgs/msg/safety_factor_array.hpp>
@@ -132,6 +135,32 @@ private:
 
   std::vector<PlanningFactor> factors_;
 };
+
+extern template void PlanningFactorInterface::add<tier4_planning_msgs::msg::PathPointWithLaneId>(
+  const std::vector<tier4_planning_msgs::msg::PathPointWithLaneId> &, const Pose &, const Pose &,
+  const uint16_t behavior, const SafetyFactorArray &, const bool, const double, const double,
+  const std::string &);
+extern template void PlanningFactorInterface::add<autoware_planning_msgs::msg::PathPoint>(
+  const std::vector<autoware_planning_msgs::msg::PathPoint> &, const Pose &, const Pose &,
+  const uint16_t behavior, const SafetyFactorArray &, const bool, const double, const double,
+  const std::string &);
+extern template void PlanningFactorInterface::add<autoware_planning_msgs::msg::TrajectoryPoint>(
+  const std::vector<autoware_planning_msgs::msg::TrajectoryPoint> &, const Pose &, const Pose &,
+  const uint16_t behavior, const SafetyFactorArray &, const bool, const double, const double,
+  const std::string &);
+
+extern template void PlanningFactorInterface::add<tier4_planning_msgs::msg::PathPointWithLaneId>(
+  const std::vector<tier4_planning_msgs::msg::PathPointWithLaneId> &, const Pose &, const Pose &,
+  const Pose &, const uint16_t behavior, const SafetyFactorArray &, const bool, const double,
+  const double, const std::string &);
+extern template void PlanningFactorInterface::add<autoware_planning_msgs::msg::PathPoint>(
+  const std::vector<autoware_planning_msgs::msg::PathPoint> &, const Pose &, const Pose &,
+  const Pose &, const uint16_t behavior, const SafetyFactorArray &, const bool, const double,
+  const double, const std::string &);
+extern template void PlanningFactorInterface::add<autoware_planning_msgs::msg::TrajectoryPoint>(
+  const std::vector<autoware_planning_msgs::msg::TrajectoryPoint> &, const Pose &, const Pose &,
+  const Pose &, const uint16_t behavior, const SafetyFactorArray &, const bool, const double,
+  const double, const std::string &);
 
 }  // namespace autoware::motion_utils
 

--- a/common/autoware_motion_utils/src/factor/planing_factor_interface.cpp
+++ b/common/autoware_motion_utils/src/factor/planing_factor_interface.cpp
@@ -13,35 +13,12 @@
 // limitations under the License.
 
 #include <autoware/motion_utils/factor/planning_factor_interface.hpp>
-#include <autoware/motion_utils/trajectory/trajectory.hpp>
 
 #include <string>
 #include <vector>
 
 namespace autoware::motion_utils
 {
-
-PlanningFactorInterface::PlanningFactorInterface(rclcpp::Node * node, const std::string & name)
-: name_{name},
-  pub_factors_{
-    node->create_publisher<PlanningFactorArray>("/planning/planning_factors/" + name, 1)},
-  clock_{node->get_clock()}
-{
-}
-
-template <class PointType>
-void PlanningFactorInterface::add(
-  const std::vector<PointType> & points, const Pose & ego_pose, const Pose & control_point_pose,
-  const uint16_t behavior, const SafetyFactorArray & safety_factors, const bool is_driving_forward,
-  const double velocity, const double shift_length, const std::string & detail)
-{
-  const auto distance = static_cast<float>(autoware::motion_utils::calcSignedArcLength(
-    points, ego_pose.position, control_point_pose.position));
-  add(
-    distance, control_point_pose, behavior, safety_factors, is_driving_forward, velocity,
-    shift_length, detail);
-}
-
 template void PlanningFactorInterface::add<tier4_planning_msgs::msg::PathPointWithLaneId>(
   const std::vector<tier4_planning_msgs::msg::PathPointWithLaneId> &, const Pose &, const Pose &,
   const uint16_t behavior, const SafetyFactorArray &, const bool, const double, const double,
@@ -55,22 +32,6 @@ template void PlanningFactorInterface::add<autoware_planning_msgs::msg::Trajecto
   const uint16_t behavior, const SafetyFactorArray &, const bool, const double, const double,
   const std::string &);
 
-template <class PointType>
-void PlanningFactorInterface::add(
-  const std::vector<PointType> & points, const Pose & ego_pose, const Pose & start_pose,
-  const Pose & end_pose, const uint16_t behavior, const SafetyFactorArray & safety_factors,
-  const bool is_driving_forward, const double velocity, const double shift_length,
-  const std::string & detail)
-{
-  const auto start_distance = static_cast<float>(
-    autoware::motion_utils::calcSignedArcLength(points, ego_pose.position, start_pose.position));
-  const auto end_distance = static_cast<float>(
-    autoware::motion_utils::calcSignedArcLength(points, ego_pose.position, end_pose.position));
-  add(
-    start_distance, end_distance, start_pose, end_pose, behavior, safety_factors,
-    is_driving_forward, velocity, shift_length, detail);
-}
-
 template void PlanningFactorInterface::add<tier4_planning_msgs::msg::PathPointWithLaneId>(
   const std::vector<tier4_planning_msgs::msg::PathPointWithLaneId> &, const Pose &, const Pose &,
   const Pose &, const uint16_t behavior, const SafetyFactorArray &, const bool, const double,
@@ -83,68 +44,4 @@ template void PlanningFactorInterface::add<autoware_planning_msgs::msg::Trajecto
   const std::vector<autoware_planning_msgs::msg::TrajectoryPoint> &, const Pose &, const Pose &,
   const Pose &, const uint16_t behavior, const SafetyFactorArray &, const bool, const double,
   const double, const std::string &);
-
-void PlanningFactorInterface::add(
-  const double distance, const Pose & control_point_pose, const uint16_t behavior,
-  const SafetyFactorArray & safety_factors, const bool is_driving_forward, const double velocity,
-  const double shift_length, const std::string & detail)
-{
-  const auto control_point = tier4_planning_msgs::build<ControlPoint>()
-                               .pose(control_point_pose)
-                               .velocity(velocity)
-                               .shift_length(shift_length)
-                               .distance(distance);
-
-  const auto factor = tier4_planning_msgs::build<PlanningFactor>()
-                        .module(name_)
-                        .is_driving_forward(is_driving_forward)
-                        .control_points({control_point})
-                        .behavior(behavior)
-                        .detail(detail)
-                        .safety_factors(safety_factors);
-
-  factors_.push_back(factor);
-}
-
-void PlanningFactorInterface::add(
-  const double start_distance, const double end_distance, const Pose & start_pose,
-  const Pose & end_pose, const uint16_t behavior, const SafetyFactorArray & safety_factors,
-  const bool is_driving_forward, const double velocity, const double shift_length,
-  const std::string & detail)
-{
-  const auto control_start_point = tier4_planning_msgs::build<ControlPoint>()
-                                     .pose(start_pose)
-                                     .velocity(velocity)
-                                     .shift_length(shift_length)
-                                     .distance(start_distance);
-
-  const auto control_end_point = tier4_planning_msgs::build<ControlPoint>()
-                                   .pose(end_pose)
-                                   .velocity(velocity)
-                                   .shift_length(shift_length)
-                                   .distance(end_distance);
-
-  const auto factor = tier4_planning_msgs::build<PlanningFactor>()
-                        .module(name_)
-                        .is_driving_forward(is_driving_forward)
-                        .control_points({control_start_point, control_end_point})
-                        .behavior(behavior)
-                        .detail(detail)
-                        .safety_factors(safety_factors);
-
-  factors_.push_back(factor);
-}
-
-void PlanningFactorInterface::publish()
-{
-  PlanningFactorArray msg;
-  msg.header.frame_id = "map";
-  msg.header.stamp = clock_->now();
-  msg.factors = factors_;
-
-  pub_factors_->publish(msg);
-
-  factors_.clear();
-}
-
 }  // namespace autoware::motion_utils

--- a/common/autoware_motion_utils/src/factor/planing_factor_interface.cpp
+++ b/common/autoware_motion_utils/src/factor/planing_factor_interface.cpp
@@ -15,10 +15,6 @@
 #include <autoware/motion_utils/factor/planning_factor_interface.hpp>
 #include <autoware/motion_utils/trajectory/trajectory.hpp>
 
-#include <autoware_planning_msgs/msg/path_point.hpp>
-#include <autoware_planning_msgs/msg/trajectory_point.hpp>
-#include <tier4_planning_msgs/msg/path_point_with_lane_id.hpp>
-
 #include <string>
 #include <vector>
 

--- a/common/autoware_motion_utils/src/factor/planing_factor_interface.cpp
+++ b/common/autoware_motion_utils/src/factor/planing_factor_interface.cpp
@@ -1,0 +1,154 @@
+// Copyright 2024 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <autoware/motion_utils/factor/planning_factor_interface.hpp>
+#include <autoware/motion_utils/trajectory/trajectory.hpp>
+
+#include <autoware_planning_msgs/msg/path_point.hpp>
+#include <autoware_planning_msgs/msg/trajectory_point.hpp>
+#include <tier4_planning_msgs/msg/path_point_with_lane_id.hpp>
+
+#include <string>
+#include <vector>
+
+namespace autoware::motion_utils
+{
+
+PlanningFactorInterface::PlanningFactorInterface(rclcpp::Node * node, const std::string & name)
+: name_{name},
+  pub_factors_{
+    node->create_publisher<PlanningFactorArray>("/planning/planning_factors/" + name, 1)},
+  clock_{node->get_clock()}
+{
+}
+
+template <class PointType>
+void PlanningFactorInterface::add(
+  const std::vector<PointType> & points, const Pose & ego_pose, const Pose & control_point_pose,
+  const uint16_t behavior, const SafetyFactorArray & safety_factors, const bool is_driving_forward,
+  const double velocity, const double shift_length, const std::string & detail)
+{
+  const auto distance = static_cast<float>(autoware::motion_utils::calcSignedArcLength(
+    points, ego_pose.position, control_point_pose.position));
+  add(
+    distance, control_point_pose, behavior, safety_factors, is_driving_forward, velocity,
+    shift_length, detail);
+}
+
+template void PlanningFactorInterface::add<tier4_planning_msgs::msg::PathPointWithLaneId>(
+  const std::vector<tier4_planning_msgs::msg::PathPointWithLaneId> &, const Pose &, const Pose &,
+  const uint16_t behavior, const SafetyFactorArray &, const bool, const double, const double,
+  const std::string &);
+template void PlanningFactorInterface::add<autoware_planning_msgs::msg::PathPoint>(
+  const std::vector<autoware_planning_msgs::msg::PathPoint> &, const Pose &, const Pose &,
+  const uint16_t behavior, const SafetyFactorArray &, const bool, const double, const double,
+  const std::string &);
+template void PlanningFactorInterface::add<autoware_planning_msgs::msg::TrajectoryPoint>(
+  const std::vector<autoware_planning_msgs::msg::TrajectoryPoint> &, const Pose &, const Pose &,
+  const uint16_t behavior, const SafetyFactorArray &, const bool, const double, const double,
+  const std::string &);
+
+template <class PointType>
+void PlanningFactorInterface::add(
+  const std::vector<PointType> & points, const Pose & ego_pose, const Pose & start_pose,
+  const Pose & end_pose, const uint16_t behavior, const SafetyFactorArray & safety_factors,
+  const bool is_driving_forward, const double velocity, const double shift_length,
+  const std::string & detail)
+{
+  const auto start_distance = static_cast<float>(
+    autoware::motion_utils::calcSignedArcLength(points, ego_pose.position, start_pose.position));
+  const auto end_distance = static_cast<float>(
+    autoware::motion_utils::calcSignedArcLength(points, ego_pose.position, end_pose.position));
+  add(
+    start_distance, end_distance, start_pose, end_pose, behavior, safety_factors,
+    is_driving_forward, velocity, shift_length, detail);
+}
+
+template void PlanningFactorInterface::add<tier4_planning_msgs::msg::PathPointWithLaneId>(
+  const std::vector<tier4_planning_msgs::msg::PathPointWithLaneId> &, const Pose &, const Pose &,
+  const Pose &, const uint16_t behavior, const SafetyFactorArray &, const bool, const double,
+  const double, const std::string &);
+template void PlanningFactorInterface::add<autoware_planning_msgs::msg::PathPoint>(
+  const std::vector<autoware_planning_msgs::msg::PathPoint> &, const Pose &, const Pose &,
+  const Pose &, const uint16_t behavior, const SafetyFactorArray &, const bool, const double,
+  const double, const std::string &);
+template void PlanningFactorInterface::add<autoware_planning_msgs::msg::TrajectoryPoint>(
+  const std::vector<autoware_planning_msgs::msg::TrajectoryPoint> &, const Pose &, const Pose &,
+  const Pose &, const uint16_t behavior, const SafetyFactorArray &, const bool, const double,
+  const double, const std::string &);
+
+void PlanningFactorInterface::add(
+  const double distance, const Pose & control_point_pose, const uint16_t behavior,
+  const SafetyFactorArray & safety_factors, const bool is_driving_forward, const double velocity,
+  const double shift_length, const std::string & detail)
+{
+  const auto control_point = tier4_planning_msgs::build<ControlPoint>()
+                               .pose(control_point_pose)
+                               .velocity(velocity)
+                               .shift_length(shift_length)
+                               .distance(distance);
+
+  const auto factor = tier4_planning_msgs::build<PlanningFactor>()
+                        .module(name_)
+                        .is_driving_forward(is_driving_forward)
+                        .control_points({control_point})
+                        .behavior(behavior)
+                        .detail(detail)
+                        .safety_factors(safety_factors);
+
+  factors_.push_back(factor);
+}
+
+void PlanningFactorInterface::add(
+  const double start_distance, const double end_distance, const Pose & start_pose,
+  const Pose & end_pose, const uint16_t behavior, const SafetyFactorArray & safety_factors,
+  const bool is_driving_forward, const double velocity, const double shift_length,
+  const std::string & detail)
+{
+  const auto control_start_point = tier4_planning_msgs::build<ControlPoint>()
+                                     .pose(start_pose)
+                                     .velocity(velocity)
+                                     .shift_length(shift_length)
+                                     .distance(start_distance);
+
+  const auto control_end_point = tier4_planning_msgs::build<ControlPoint>()
+                                   .pose(end_pose)
+                                   .velocity(velocity)
+                                   .shift_length(shift_length)
+                                   .distance(end_distance);
+
+  const auto factor = tier4_planning_msgs::build<PlanningFactor>()
+                        .module(name_)
+                        .is_driving_forward(is_driving_forward)
+                        .control_points({control_start_point, control_end_point})
+                        .behavior(behavior)
+                        .detail(detail)
+                        .safety_factors(safety_factors);
+
+  factors_.push_back(factor);
+}
+
+void PlanningFactorInterface::publish()
+{
+  PlanningFactorArray msg;
+  msg.header.frame_id = "map";
+  msg.header.stamp = clock_->now();
+  msg.factors = factors_;
+
+  pub_factors_->publish(msg);
+
+  factors_.clear();
+}
+
+}  // namespace autoware::motion_utils


### PR DESCRIPTION
## Description

Add planning factor interface to make it easier for developper to output `PlaninningFactor.msg`.

## Related links

**Parent Issue:**

- https://github.com/tier4/tier4_autoware_msgs/pull/155

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

- [x] [PASS TIER IV INTERNAL SCENARIOS](https://evaluation.tier4.jp/evaluation/reports/7f186012-92a5-508b-bcea-dcf51d9196ed?project_id=prd_jt)

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
