### PR TITLE
fix: enable to copy all information in pickup based pointcloud downsampler

### DIFF
--- a/sensing/autoware_pointcloud_preprocessor/src/downsample_filter/pickup_based_voxel_grid_downsample_filter_node.cpp
+++ b/sensing/autoware_pointcloud_preprocessor/src/downsample_filter/pickup_based_voxel_grid_downsample_filter_node.cpp
@@ -124,15 +124,7 @@ void PickupBasedVoxelGridDownsampleFilterComponent::filter(
   size_t output_global_offset = 0;
   output.data.resize(voxel_map.size() * input->point_step);
   for (const auto & kv : voxel_map) {
-    std::memcpy(
-      &output.data[output_global_offset + x_offset], &input->data[kv.second + x_offset],
-      sizeof(float));
-    std::memcpy(
-      &output.data[output_global_offset + y_offset], &input->data[kv.second + y_offset],
-      sizeof(float));
-    std::memcpy(
-      &output.data[output_global_offset + z_offset], &input->data[kv.second + z_offset],
-      sizeof(float));
+    std::memcpy(&output.data[output_global_offset], &input->data[kv.second], input->point_step);
     output_global_offset += input->point_step;
   }
 


### PR DESCRIPTION
## Description

Previously pickup-based downsampler, which is used in the default downsampler for the perception input, only copies x,y,z attribute and do not copy other one like intensity. This leads to cause some perception issue.

This PR fix this problem by copying all attributes.

## Related links

## How was this PR tested?

Just build and tested with sample bag file(WIP).

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
