### PR TITLE
fix(mpc_lateral_controller): prevent unstable steering command while stopped

### DIFF
--- a/control/autoware_mpc_lateral_controller/include/autoware/mpc_lateral_controller/mpc.hpp
+++ b/control/autoware_mpc_lateral_controller/include/autoware/mpc_lateral_controller/mpc.hpp
@@ -537,6 +537,8 @@ public:
    * @param clock The shared pointer to the RCLCPP clock.
    */
   inline void setClock(rclcpp::Clock::SharedPtr clock) { m_clock = clock; }
+
+  inline double get_wheelbase_length() { return m_vehicle_model_ptr->getWheelbase(); }
 };  // class MPC
 }  // namespace autoware::motion::control::mpc_lateral_controller
 

--- a/control/autoware_mpc_lateral_controller/include/autoware/mpc_lateral_controller/mpc.hpp
+++ b/control/autoware_mpc_lateral_controller/include/autoware/mpc_lateral_controller/mpc.hpp
@@ -537,8 +537,6 @@ public:
    * @param clock The shared pointer to the RCLCPP clock.
    */
   inline void setClock(rclcpp::Clock::SharedPtr clock) { m_clock = clock; }
-
-  inline double get_wheelbase_length() { return m_vehicle_model_ptr->getWheelbase(); }
 };  // class MPC
 }  // namespace autoware::motion::control::mpc_lateral_controller
 

--- a/control/autoware_mpc_lateral_controller/src/mpc_lateral_controller.cpp
+++ b/control/autoware_mpc_lateral_controller/src/mpc_lateral_controller.cpp
@@ -454,7 +454,7 @@ bool MpcLateralController::isStoppedState() const
     m_current_trajectory.points, m_current_kinematic_state.pose.pose, m_ego_nearest_dist_threshold,
     m_ego_nearest_yaw_threshold);
 
-  const auto wheelbase_length = m_mpc->get_wheelbase_length();
+  static constexpr double distance_margin = 1.0;
   const double target_vel = std::invoke([&]() -> double {
     auto min_vel = m_current_trajectory.points.at(nearest).longitudinal_velocity_mps;
     auto covered_distance = 0.0;
@@ -462,7 +462,7 @@ bool MpcLateralController::isStoppedState() const
       min_vel = std::min(min_vel, m_current_trajectory.points.at(i).longitudinal_velocity_mps);
       covered_distance += autoware::universe_utils::calcDistance2d(
         m_current_trajectory.points.at(i - 1).pose, m_current_trajectory.points.at(i).pose);
-      if (covered_distance > wheelbase_length) break;
+      if (covered_distance > distance_margin) break;
     }
     return min_vel;
   });

--- a/control/autoware_mpc_lateral_controller/src/mpc_lateral_controller.cpp
+++ b/control/autoware_mpc_lateral_controller/src/mpc_lateral_controller.cpp
@@ -454,6 +454,9 @@ bool MpcLateralController::isStoppedState() const
     m_current_trajectory.points, m_current_kinematic_state.pose.pose, m_ego_nearest_dist_threshold,
     m_ego_nearest_yaw_threshold);
 
+  // It is possible that stop is executed earlier than stop point, and velocity controller
+  // will not start when the distance from ego to stop point is less than 0.5 meter.
+  // So we use a distance margin to ensure we can detect stopped state.
   static constexpr double distance_margin = 1.0;
   const double target_vel = std::invoke([&]() -> double {
     auto min_vel = m_current_trajectory.points.at(nearest).longitudinal_velocity_mps;


### PR DESCRIPTION
## Description

In certain situations steering command can become unstable when Ego is stopped.

`mpc_lateral_controller` has logic to detect when Ego is in stopped state and stabilize steering command.
The logic for stopped state check considers:
- Ego velocity is below threshold
- Target velocity is below threshold
- Steering is converged

However the target velocity check only considers the velocity at the trajectory point closest to the Ego base. In some cases stop can be executed before stop point, and velocity controller will not start if distance from Ego to stop point is less than 0.5. So the velocity at the nearest trajectory point to base can be greater than zero even when Ego is stopped.

To fix that, this PR modifies the target velocity check to consider the velocities of trajectory points within a 1 m margin from base.

Plot below shows steering command before:
![Screenshot from 2024-12-19 11-32-28](https://github.com/user-attachments/assets/1001fef2-60e0-4509-a2c8-490c53e7ebe5)

Plot below shows steering command after:
![Screenshot from 2024-12-19 11-09-33](https://github.com/user-attachments/assets/eca4beee-1b39-492d-92b5-633d8e3a480e)


## Related links

**Parent Issue:**

**Private Links:**

- [TIER IV Jira link](https://tier4.atlassian.net/browse/RT0-34623?focusedCommentId=200855&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-200855)
- [TIER IV slack link](https://star4.slack.com/archives/CRUE57C30/p1733911916093339)

## How was this PR tested?
- PSIM
- [TIER IV Internal Evaluator](https://evaluation.tier4.jp/evaluation/reports/9e4580f4-e31a-52dc-a2d9-825880fc7e49?project_id=prd_jt)

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

Prevent unstable steering command when Ego is stopped.