### PR TITLE
fix(planning_evaluator): update lateral_trajectory_displacement to absolute value

### DIFF
--- a/evaluator/autoware_planning_evaluator/src/metrics/deviation_metrics.cpp
+++ b/evaluator/autoware_planning_evaluator/src/metrics/deviation_metrics.cpp
@@ -58,7 +58,7 @@ Accumulator<double> calcLocalLateralTrajectoryDisplacement(
     autoware::motion_utils::calcLateralOffset(prev.points, ego_pose.position);
   const auto traj_lateral_deviation =
     autoware::motion_utils::calcLateralOffset(traj.points, ego_pose.position);
-  const auto lateral_trajectory_displacement = traj_lateral_deviation - prev_lateral_deviation;
+  const auto lateral_trajectory_displacement = std::abs(traj_lateral_deviation - prev_lateral_deviation);
   stat.add(lateral_trajectory_displacement);
   return stat;
 }

--- a/evaluator/autoware_planning_evaluator/src/metrics/deviation_metrics.cpp
+++ b/evaluator/autoware_planning_evaluator/src/metrics/deviation_metrics.cpp
@@ -58,7 +58,8 @@ Accumulator<double> calcLocalLateralTrajectoryDisplacement(
     autoware::motion_utils::calcLateralOffset(prev.points, ego_pose.position);
   const auto traj_lateral_deviation =
     autoware::motion_utils::calcLateralOffset(traj.points, ego_pose.position);
-  const auto lateral_trajectory_displacement = std::abs(traj_lateral_deviation - prev_lateral_deviation);
+  const auto lateral_trajectory_displacement =
+    std::abs(traj_lateral_deviation - prev_lateral_deviation);
   stat.add(lateral_trajectory_displacement);
   return stat;
 }


### PR DESCRIPTION
## Description

Changed lateral_trajectory_displacement to absolute value.
This is to make it easier to determine when testing(TIER IV Internal use case).

## Related links

* https://github.com/autowarefoundation/autoware.universe/pull/9674

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

### Before

![Screenshot from 2024-12-20 10-37-45](https://github.com/user-attachments/assets/b1afc9d9-5d58-42c0-9d0a-fdcbab23dc3d)

### After

![Screenshot from 2024-12-20 10-42-25](https://github.com/user-attachments/assets/cd4a0668-ec05-4821-b82f-83466d7ed5da)

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
