### PR TITLE
fix(autoware_behavior_path_planner_common): fix bugprone-errors

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/drivable_area_expansion/static_drivable_area.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/drivable_area_expansion/static_drivable_area.cpp
@@ -1127,9 +1127,7 @@ std::vector<lanelet::ConstPoint3d> getBoundWithHatchedRoadMarkings(
           get_corresponding_polygon_index(*current_polygon, bound_point.id()));
       }
     } else {
-      if (!polygon) {
-        will_close_polygon = true;
-      } else if (polygon.value().id() != current_polygon.value().id()) {
+      if (!polygon || polygon.value().id() != current_polygon.value().id()) {
         will_close_polygon = true;
       } else {
         current_polygon_border_indices.push_back(
@@ -1496,9 +1494,9 @@ std::vector<geometry_msgs::msg::Point> postProcess(
     [](const lanelet::ConstLineString3d & points, std::vector<geometry_msgs::msg::Point> & bound) {
       for (const auto & bound_p : points) {
         const auto cp = lanelet::utils::conversion::toGeomMsgPt(bound_p);
-        if (bound.empty()) {
-          bound.push_back(cp);
-        } else if (autoware::universe_utils::calcDistance2d(cp, bound.back()) > overlap_threshold) {
+        if (
+          bound.empty() ||
+          autoware::universe_utils::calcDistance2d(cp, bound.back()) > overlap_threshold) {
           bound.push_back(cp);
         }
       }

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/occupancy_grid_based_collision_detector/occupancy_grid_based_collision_detector.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/occupancy_grid_based_collision_detector/occupancy_grid_based_collision_detector.cpp
@@ -80,7 +80,7 @@ void OccupancyGridBasedCollisionDetector::setMap(const nav_msgs::msg::OccupancyG
   for (uint32_t i = 0; i < height; i++) {
     is_obstacle_table.at(i).resize(width);
     for (uint32_t j = 0; j < width; j++) {
-      const int cost = costmap_.data[i * width + j];
+      const int cost = costmap_.data[i * width + j];  // NOLINT
 
       if (cost < 0 || param_.obstacle_threshold <= cost) {
         is_obstacle_table[i][j] = true;


### PR DESCRIPTION
## Description
This is a fix based on clang-tidy `bugprone-branch-clone` and `bugprone-signed-char-misuse` error.

```
/home/emb4/autoware/autoware/src/universe/autoware.universe/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/drivable_area_expansion/static_drivable_area.cpp:1130:21: error: repeated branch in conditional chain [bugprone-branch-clone,-warnings-as-errors]
      if (!polygon) {
                    ^
/home/emb4/autoware/autoware/src/universe/autoware.universe/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/drivable_area_expansion/static_drivable_area.cpp:1132:8: note: end of the original
      } else if (polygon.value().id() != current_polygon.value().id()) {
       ^
/home/emb4/autoware/autoware/src/universe/autoware.universe/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/drivable_area_expansion/static_drivable_area.cpp:1132:72: note: clone 1 starts here
      } else if (polygon.value().id() != current_polygon.value().id()) {
                                                                       ^
/home/emb4/autoware/autoware/src/universe/autoware.universe/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/drivable_area_expansion/static_drivable_area.cpp:1499:28: error: repeated branch in conditional chain [bugprone-branch-clone,-warnings-as-errors]
        if (bound.empty()) {
                           ^
/home/emb4/autoware/autoware/src/universe/autoware.universe/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/drivable_area_expansion/static_drivable_area.cpp:1501:10: note: end of the original
        } else if (autoware::universe_utils::calcDistance2d(cp, bound.back()) > overlap_threshold) {
         ^
/home/emb4/autoware/autoware/src/universe/autoware.universe/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/drivable_area_expansion/static_drivable_area.cpp:1501:100: note: clone 1 starts here
        } else if (autoware::universe_utils::calcDistance2d(cp, bound.back()) > overlap_threshold) {
                                                                                                   ^
/home/emb4/autoware/autoware/src/universe/autoware.universe/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/occupancy_grid_based_collision_detector/occupancy_grid_based_collision_detector.cpp:83:24: error: 'signed char' to 'const int' conversion; consider casting to 'unsigned char' first. [bugprone-signed-char-misuse,-warnings-as-errors]
      const int cost = costmap_.data[i * width + j];
                       ^
```
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
