### PR TITLE
fix(autoware_behavior_path_static_obstacle_avoidance_module): fix bugprone-branch-clone

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/scene.cpp
@@ -233,11 +233,7 @@ void StaticObstacleAvoidanceModule::fillFundamentalData(
 
   std::for_each(
     data.current_lanelets.begin(), data.current_lanelets.end(), [&](const auto & lanelet) {
-      if (!not_use_adjacent_lane) {
-        data.drivable_lanes.push_back(
-          utils::static_obstacle_avoidance::generateExpandedDrivableLanes(
-            lanelet, planner_data_, parameters_));
-      } else if (red_signal_lane_itr->id() != lanelet.id()) {
+      if (!not_use_adjacent_lane || red_signal_lane_itr->id() != lanelet.id()) {
         data.drivable_lanes.push_back(
           utils::static_obstacle_avoidance::generateExpandedDrivableLanes(
             lanelet, planner_data_, parameters_));

--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/shift_line_generator.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/shift_line_generator.cpp
@@ -264,9 +264,7 @@ AvoidOutlines ShiftLineGenerator::generateAvoidOutline(
   AvoidOutlines outlines;
   for (auto & o : data.target_objects) {
     if (!o.avoid_margin.has_value()) {
-      if (!data.red_signal_lane.has_value()) {
-        o.info = ObjectInfo::INSUFFICIENT_DRIVABLE_SPACE;
-      } else if (data.red_signal_lane.value().id() == o.overhang_lanelet.id()) {
+      if (data.red_signal_lane.value().id() == o.overhang_lanelet.id()) {
         o.info = ObjectInfo::LIMIT_DRIVABLE_SPACE_TEMPORARY;
       } else {
         o.info = ObjectInfo::INSUFFICIENT_DRIVABLE_SPACE;


### PR DESCRIPTION
## Description
This is a fix based on clang-tidy `bugprone-branch-clone` error.

```
/home/emb4/autoware/autoware/src/universe/autoware.universe/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/scene.cpp:236:35: error: repeated branch in conditional chain [bugprone-branch-clone,-warnings-as-errors]
      if (!not_use_adjacent_lane) {
                                  ^
/home/emb4/autoware/autoware/src/universe/autoware.universe/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/scene.cpp:240:8: note: end of the original
      } else if (red_signal_lane_itr->id() != lanelet.id()) {
       ^
/home/emb4/autoware/autoware/src/universe/autoware.universe/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/scene.cpp:240:61: note: clone 1 starts here
      } else if (red_signal_lane_itr->id() != lanelet.id()) {
                                                            ^

/home/emb4/autoware/autoware/src/universe/autoware.universe/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/shift_line_generator.cpp:267:46: error: repeated branch in conditional chain [bugprone-branch-clone,-warnings-as-errors]
      if (!data.red_signal_lane.has_value()) {
                                             ^
/home/emb4/autoware/autoware/src/universe/autoware.universe/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/shift_line_generator.cpp:269:8: note: end of the original
      } else if (data.red_signal_lane.value().id() == o.overhang_lanelet.id()) {
       ^
/home/emb4/autoware/autoware/src/universe/autoware.universe/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/shift_line_generator.cpp:271:14: note: clone 1 starts here
      } else {
             ^
```
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
