### PR TITLE
fix(autoware_universe_utils): fix bug in test

### DIFF
--- a/common/autoware_universe_utils/test/src/math/test_trigonometry.cpp
+++ b/common/autoware_universe_utils/test/src/math/test_trigonometry.cpp
@@ -18,6 +18,7 @@
 #include <gtest/gtest.h>
 
 #include <cmath>
+#include <random>
 
 TEST(trigonometry, sin)
 {
@@ -60,11 +61,15 @@ float normalize_angle(double angle)
 
 TEST(trigonometry, opencv_fast_atan2)
 {
+  std::random_device rd;
+  std::mt19937 gen(rd());
+
+  // Generate random x and y between -10.0 and 10.0 as float
+  std::uniform_real_distribution<float> dis(-10.0f, 10.0f);
+
   for (int i = 0; i < 100; ++i) {
-    // Generate random x and y between -10 and 10
-    std::srand(0);
-    float x = static_cast<float>(std::rand()) / RAND_MAX * 20.0 - 10.0;
-    float y = static_cast<float>(std::rand()) / RAND_MAX * 20.0 - 10.0;
+    const float x = dis(gen);
+    const float y = dis(gen);
 
     float fast_atan = autoware::universe_utils::opencv_fast_atan2(y, x);
     float std_atan = normalize_angle(std::atan2(y, x));


### PR DESCRIPTION
## Description

This PR fixes a bug in random float value generations in autoware_unvierse_utils.

When I was fixing clang compiler warning,
```
$ colcon build --packages-select autoware_universe_utils
Starting >>> autoware_universe_utils
--- stderr: autoware_universe_utils                             
/home/veqcc/work/autoware/src/universe/autoware.universe/common/autoware_universe_utils/test/src/math/test_trigonometry.cpp:66:49: error: implicit conversion from 'int' to 'float' changes value from 2147483647 to 2147483648 [-Werror,-Wimplicit-const-int-float-conversion]
    float x = static_cast<float>(std::rand()) / RAND_MAX * 20.0 - 10.0;
                                              ~ ^~~~~~~~
/usr/include/stdlib.h:87:18: note: expanded from macro 'RAND_MAX'
#define RAND_MAX        2147483647
                        ^~~~~~~~~~
```

I found that the way random values are generated was wrong.
I added `std::cout << x << ' ' << y << std::end` to check `std::rand()` is working:
```
TEST(trigonometry, opencv_fast_atan2)
{
  for (int i = 0; i < 100; ++i) {
    // Generate random x and y between -10 and 10
    std::srand(0);
    float x = static_cast<float>(std::rand()) / RAND_MAX * 20.0 - 10.0;
    float y = static_cast<float>(std::rand()) / RAND_MAX * 20.0 - 10.0;
    std::cout << x << ' ' << y << std::end
    ...
  }
}
```

Then I found the values `x` and `y` were constants.
```
[ RUN      ] trigonometry.opencv_fast_atan2
6.80375 -2.11234
6.80375 -2.11234
6.80375 -2.11234
6.80375 -2.11234
6.80375 -2.11234
6.80375 -2.11234
6.80375 -2.11234
6.80375 -2.11234
6.80375 -2.11234
6.80375 -2.11234
6.80375 -2.11234
...
```

I replaced it with more reliable random generator
```
TEST(trigonometry, opencv_fast_atan2)
{
  std::random_device rd;
  std::mt19937 gen(rd());

  // Generate random x and y between -10 and 10
  std::uniform_real_distribution<float> dis(-10.0f, 10.0f);

  for (int i = 0; i < 100; ++i) {
    const float x = dis(gen);
    const float y = dis(gen);
    std::cout << x << ' ' << y << std::endl;
    ...
  }
}
```

I confirmed the values are random.
```
[ RUN      ] trigonometry.opencv_fast_atan2
-0.095993 -0.101926
0.197819 -1.55618
-9.6819 -8.77628
-6.12843 -4.07039
-4.36896 6.82011
4.78307 -8.05005
-7.99907 -5.32101
7.78429 0.780358
-2.63452 0.678116
6.84502 1.99049
-0.410819 3.21309
4.39843 9.20199
4.26471 -5.10922
3.18221 -0.660125
3.48914 -9.87651
6.14163 -1.30869
-9.28647 -7.76091
-6.74409 7.62205
0.0639296 -8.88451
6.97951 -1.29875
-3.45232 -6.32112
-5.72278 7.52109
9.13137 -5.10323
-5.15501 -3.18629
7.2942 -4.47396
...
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?


Run
```
$ colcon test --packages-select autoware_universe_utils
```

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
