### PR TITLE
fix(autoware_motion_utils): remove clang compiler error

### DIFF
--- a/common/autoware_motion_utils/test/src/trajectory/benchmark_calcLateralOffset.cpp
+++ b/common/autoware_motion_utils/test/src/trajectory/benchmark_calcLateralOffset.cpp
@@ -26,8 +26,6 @@ using autoware::universe_utils::createPoint;
 using autoware::universe_utils::createQuaternionFromRPY;
 using autoware_planning_msgs::msg::Trajectory;
 
-constexpr double epsilon = 1e-6;
-
 geometry_msgs::msg::Pose createPose(
   double x, double y, double z, double roll, double pitch, double yaw)
 {


### PR DESCRIPTION
## Description

Fixed clang compiler error
```
--- stderr: autoware_motion_utils                                
/home/veqcc/work/autoware/src/universe/autoware.universe/common/autoware_motion_utils/test/src/trajectory/benchmark_calcLateralOffset.cpp:29:18: error: unused variable 'epsilon' [-Werror,-Wunused-const-variable]
constexpr double epsilon = 1e-6;
                 ^
1 error generated.
gmake[2]: *** [CMakeFiles/test_autoware_motion_utils.dir/build.make:132: CMakeFiles/test_autoware_motion_utils.dir/test/src/trajectory/benchmark_calcLateralOffset.cpp.o] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:185: CMakeFiles/test_autoware_motion_utils.dir/all] Error 2
gmake: *** [Makefile:146: all] Error 2
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

build and test

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
