### PR TITLE
fix(autoware_behavior_velocity_run_out_module): fix bugprone-branch-clone

### DIFF
--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_run_out_module/src/scene.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_run_out_module/src/scene.cpp
@@ -811,7 +811,7 @@ void RunOutModule::insertVelocityForState(
 
   // insert velocity for each state
   switch (state) {
-    case State::GO: {
+    case State::GO: {  // NOLINT
       insertStoppingVelocity(target_obstacle, current_pose, current_vel, current_acc, output_path);
       break;
     }


### PR DESCRIPTION
## Description
This is a fix based on clang-tidy `bugprone-branch-clone` error.
Suppressed in comments so that the meaning of the branch is clear.
```
/home/emb4/autoware/autoware/src/universe/autoware.universe/planning/behavior_velocity_planner/autoware_behavior_velocity_run_out_module/src/scene.cpp:814:5: error: switch has 2 consecutive identical branches [bugprone-branch-clone,-warnings-as-errors]
    case State::GO: {
    ^
/home/emb4/autoware/autoware/src/universe/autoware.universe/planning/behavior_velocity_planner/autoware_behavior_velocity_run_out_module/src/scene.cpp:822:6: note: last of these clones ends here
    }
     ^
```
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
