### PR TITLE
fix(raw_veihicle_converter): fix too long line

### DIFF
--- a/vehicle/autoware_raw_vehicle_cmd_converter/CMakeLists.txt
+++ b/vehicle/autoware_raw_vehicle_cmd_converter/CMakeLists.txt
@@ -21,7 +21,10 @@ ament_auto_add_library(autoware_raw_vehicle_cmd_converter_node_component SHARED
   src/node.cpp
 )
 
-target_link_libraries(autoware_raw_vehicle_cmd_converter_node_component actuation_map_converter vehicle_adaptor)
+target_link_libraries(autoware_raw_vehicle_cmd_converter_node_component
+  actuation_map_converter
+  vehicle_adaptor
+)
 
 rclcpp_components_register_node(autoware_raw_vehicle_cmd_converter_node_component
   PLUGIN "autoware::raw_vehicle_cmd_converter::RawVehicleCommandConverterNode"
@@ -34,7 +37,11 @@ if(BUILD_TESTING)
   )
   set(TEST_RAW_VEHICLE_CMD_CONVERTER_EXE test_autoware_raw_vehicle_cmd_converter)
   ament_add_ros_isolated_gtest(${TEST_RAW_VEHICLE_CMD_CONVERTER_EXE} ${TEST_SOURCES})
-  target_link_libraries(${TEST_RAW_VEHICLE_CMD_CONVERTER_EXE} actuation_map_converter vehicle_adaptor autoware_raw_vehicle_cmd_converter_node_component)
+  target_link_libraries(${TEST_RAW_VEHICLE_CMD_CONVERTER_EXE}
+    actuation_map_converter
+    vehicle_adaptor
+    autoware_raw_vehicle_cmd_converter_node_component
+  )
 endif()
 
 ament_auto_package(INSTALL_TO_SHARE


### PR DESCRIPTION
## Description

fix build-and-test-daily error which mentioned in 
https://github.com/autowarefoundation/autoware.universe/pull/8782#discussion_r1895007089

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
