### PR TITLE
fix(autoware_image_transport_decompressor): fix bugprone-branch-clone

### DIFF
--- a/sensing/autoware_image_transport_decompressor/src/image_transport_decompressor.cpp
+++ b/sensing/autoware_image_transport_decompressor/src/image_transport_decompressor.cpp
@@ -107,13 +107,12 @@ void ImageTransportDecompressor::onCompressedImage(
       }
     } else {
       std::string image_encoding;
-      if (encoding_ == std::string("default")) {
-        image_encoding = input_compressed_image_msg->format.substr(0, split_pos);
-      } else if (encoding_ == std::string("rgb8")) {
+      if (encoding_ == std::string("rgb8")) {
         image_encoding = "rgb8";
       } else if (encoding_ == std::string("bgr8")) {
         image_encoding = "bgr8";
       } else {
+        // default encoding
         image_encoding = input_compressed_image_msg->format.substr(0, split_pos);
       }
 


### PR DESCRIPTION
## Description
This is a fix based on clang-tidy `bugprone-branch-clone` error.

```
/home/emb4/autoware/autoware/src/universe/autoware.universe/sensing/autoware_image_transport_decompressor/src/image_transport_decompressor.cpp:110:48: error: repeated branch in conditional chain [bugprone-branch-clone,-warnings-as-errors]
      if (encoding_ == std::string("default")) {
                                               ^
/home/emb4/autoware/autoware/src/universe/autoware.universe/sensing/autoware_image_transport_decompressor/src/image_transport_decompressor.cpp:112:8: note: end of the original
      } else if (encoding_ == std::string("rgb8")) {
       ^
/home/emb4/autoware/autoware/src/universe/autoware.universe/sensing/autoware_image_transport_decompressor/src/image_transport_decompressor.cpp:116:14: note: clone 1 starts here
      } else {
             ^
```
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
