### PR TITLE
fix(autoware_default_adapi): fix bugprone-branch-clone

### DIFF
--- a/system/autoware_default_adapi/src/utils/route_conversion.cpp
+++ b/system/autoware_default_adapi/src/utils/route_conversion.cpp
@@ -115,13 +115,13 @@ ExternalState convert_state(const InternalState & internal)
   const auto convert = [](InternalState::_state_type state) {
     switch(state) {
       // TODO(Takagi, Isamu): Add adapi state.
-      case InternalState::INITIALIZING: return ExternalState::UNSET;
+      case InternalState::INITIALIZING: return ExternalState::UNSET; // NOLINT
       case InternalState::UNSET:        return ExternalState::UNSET;
       case InternalState::ROUTING:      return ExternalState::UNSET;
       case InternalState::SET:          return ExternalState::SET;
       case InternalState::REROUTING:    return ExternalState::CHANGING;
       case InternalState::ARRIVED:      return ExternalState::ARRIVED;
-      case InternalState::ABORTED:      return ExternalState::SET;
+      case InternalState::ABORTED:      return ExternalState::SET;  // NOLINT
       case InternalState::INTERRUPTED:  return ExternalState::SET;
       default:                          return ExternalState::UNKNOWN;
     }


### PR DESCRIPTION
## Description
This is a fix based on clang-tidy `bugprone-branch-clone` error.
In the case of `switch-case`, it is difficult to understand if the conditions are summarized, so a comment is used to suppress errors.

```
/home/emb4/autoware/autoware/src/universe/autoware.universe/system/autoware_default_adapi/src/utils/route_conversion.cpp:118:7: error: switch has 3 consecutive identical branches [bugprone-branch-clone,-warnings-as-errors]
      case InternalState::INITIALIZING: return ExternalState::UNSET;
      ^
/home/emb4/autoware/autoware/src/universe/autoware.universe/system/autoware_default_adapi/src/utils/route_conversion.cpp:120:68: note: last of these clones ends here
      case InternalState::ROUTING:      return ExternalState::UNSET;
                                                                   ^
/home/emb4/autoware/autoware/src/universe/autoware.universe/system/autoware_default_adapi/src/utils/route_conversion.cpp:124:7: error: switch has 2 consecutive identical branches [bugprone-branch-clone,-warnings-as-errors]
      case InternalState::ABORTED:      return ExternalState::SET;
      ^
/home/emb4/autoware/autoware/src/universe/autoware.universe/system/autoware_default_adapi/src/utils/route_conversion.cpp:125:66: note: last of these clones ends here
      case InternalState::INTERRUPTED:  return ExternalState::SET;
                                                                 ^

```
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
