### PR TITLE
fix(dummy_infrastructure): fix bugprone-reserved-identifier

### DIFF
--- a/system/dummy_infrastructure/src/dummy_infrastructure_node/dummy_infrastructure_node.cpp
+++ b/system/dummy_infrastructure/src/dummy_infrastructure_node/dummy_infrastructure_node.cpp
@@ -24,7 +24,6 @@ using namespace std::literals;
 using std::chrono::duration;
 using std::chrono::duration_cast;
 using std::chrono::nanoseconds;
-using std::placeholders::_1;
 
 namespace dummy_infrastructure
 {
@@ -84,6 +83,7 @@ boost::optional<InfrastructureCommandArray> findCommand(
 DummyInfrastructureNode::DummyInfrastructureNode(const rclcpp::NodeOptions & node_options)
 : Node("dummy_infrastructure", node_options)
 {
+  using std::placeholders::_1;
   // Parameter Server
   set_param_res_ =
     this->add_on_set_parameters_callback(std::bind(&DummyInfrastructureNode::onSetParam, this, _1));


### PR DESCRIPTION
## Description
This is a fix based on clang-tidy `bugprone-reserved-identifier` error.

```
/home/emb4/autoware/autoware/src/universe/autoware.universe/system/dummy_infrastructure/src/dummy_infrastructure_node/dummy_infrastructure_node.cpp:27:26: error: declaration uses identifier '_1', which is reserved in the global namespace; cannot be fixed automatically [bugprone-reserved-identifier,-warnings-as-errors]
using std::placeholders::_1;
                         ^
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
