### PR TITLE
test(autoware_universe_utils): make opencv_fast_atan2 test reproducible

### DIFF
--- a/common/autoware_universe_utils/test/src/math/test_trigonometry.cpp
+++ b/common/autoware_universe_utils/test/src/math/test_trigonometry.cpp
@@ -61,8 +61,8 @@ float normalize_angle(double angle)
 
 TEST(trigonometry, opencv_fast_atan2)
 {
-  std::random_device rd;
-  std::mt19937 gen(rd());
+  // Default initialization ensures a constant seed needed for reproducible tests
+  std::mt19937 gen{};
 
   // Generate random x and y between -10.0 and 10.0 as float
   std::uniform_real_distribution<float> dis(-10.0f, 10.0f);


### PR DESCRIPTION
## Description

PR #9710 made the random numbers used in the `trigonometry_opencv_fast_atan2` test _random_, but introduced made the test non-reproducible. 
The common wisdom is to initialize all random number generators used in unit tests with a fixed seed, so the same numbers are generated across test runs.

This PR does that for the abovementioned test.

## Related links

- #9710 

## How was this PR tested?

Printing x/y similar to #9710. Note how before this PR, the values change across runs, whereas with this PR they stay constant (reproducible).

Before:
```
# Run 1
x=-7.54321    y=1.59532
x=-1.60106    y=-9.32045
x=2.97877     y=-3.35861
# Run 2
x=-1.19224    y=8.64908
x=-0.808514   y=-0.856808
x=5.27276     y=5.93498
```

After: 
```
# Run 1
x=6.29447     y=-7.29046
x=8.11584     y=6.70017
x=-7.46026    y=9.37736
# Run 2
x=6.29447     y=-7.29046
x=8.11584     y=6.70017
x=-7.46026    y=9.37736
```

## Effects on system behavior

None.
