### PR TITLE
fix(autoware_planning_evaluator): fix bugprone-exception-escape

### DIFF
--- a/evaluator/autoware_planning_evaluator/src/planning_evaluator_node.cpp
+++ b/evaluator/autoware_planning_evaluator/src/planning_evaluator_node.cpp
@@ -25,6 +25,7 @@
 #include <chrono>
 #include <filesystem>
 #include <fstream>
+#include <iostream>
 #include <limits>
 #include <memory>
 #include <string>
@@ -74,45 +75,51 @@ PlanningEvaluatorNode::~PlanningEvaluatorNode()
     return;
   }
 
-  // generate json data
-  using json = nlohmann::json;
-  json j;
-  for (Metric metric : metrics_) {
-    const std::string base_name = metric_to_str.at(metric) + "/";
-    j[base_name + "min"] = metric_accumulators_[static_cast<size_t>(metric)][0].min();
-    j[base_name + "max"] = metric_accumulators_[static_cast<size_t>(metric)][1].max();
-    j[base_name + "mean"] = metric_accumulators_[static_cast<size_t>(metric)][2].mean();
-    j[base_name + "count"] = metric_accumulators_[static_cast<size_t>(metric)][2].count();
-    j[base_name + "description"] = metric_descriptions.at(metric);
-  }
-
-  // get output folder
-  const std::string output_folder_str =
-    rclcpp::get_logging_directory().string() + "/autoware_metrics";
-  if (!std::filesystem::exists(output_folder_str)) {
-    if (!std::filesystem::create_directories(output_folder_str)) {
-      RCLCPP_ERROR(
-        this->get_logger(), "Failed to create directories: %s", output_folder_str.c_str());
-      return;
+  try {
+    // generate json data
+    using json = nlohmann::json;
+    json j;
+    for (Metric metric : metrics_) {
+      const std::string base_name = metric_to_str.at(metric) + "/";
+      j[base_name + "min"] = metric_accumulators_[static_cast<size_t>(metric)][0].min();
+      j[base_name + "max"] = metric_accumulators_[static_cast<size_t>(metric)][1].max();
+      j[base_name + "mean"] = metric_accumulators_[static_cast<size_t>(metric)][2].mean();
+      j[base_name + "count"] = metric_accumulators_[static_cast<size_t>(metric)][2].count();
+      j[base_name + "description"] = metric_descriptions.at(metric);
     }
-  }
 
-  // get time stamp
-  std::time_t now_time_t = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
-  std::tm * local_time = std::localtime(&now_time_t);
-  std::ostringstream oss;
-  oss << std::put_time(local_time, "%Y-%m-%d-%H-%M-%S");
-  std::string cur_time_str = oss.str();
+    // get output folder
+    const std::string output_folder_str =
+      rclcpp::get_logging_directory().string() + "/autoware_metrics";
+    if (!std::filesystem::exists(output_folder_str)) {
+      if (!std::filesystem::create_directories(output_folder_str)) {
+        RCLCPP_ERROR(
+          this->get_logger(), "Failed to create directories: %s", output_folder_str.c_str());
+        return;
+      }
+    }
 
-  // Write metrics .json to file
-  const std::string output_file_str =
-    output_folder_str + "/autoware_planning_evaluator-" + cur_time_str + ".json";
-  std::ofstream f(output_file_str);
-  if (f.is_open()) {
-    f << j.dump(4);
-    f.close();
-  } else {
-    RCLCPP_ERROR(this->get_logger(), "Failed to open file: %s", output_file_str.c_str());
+    // get time stamp
+    std::time_t now_time_t = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
+    std::tm * local_time = std::localtime(&now_time_t);
+    std::ostringstream oss;
+    oss << std::put_time(local_time, "%Y-%m-%d-%H-%M-%S");
+    std::string cur_time_str = oss.str();
+
+    // Write metrics .json to file
+    const std::string output_file_str =
+      output_folder_str + "/autoware_planning_evaluator-" + cur_time_str + ".json";
+    std::ofstream f(output_file_str);
+    if (f.is_open()) {
+      f << j.dump(4);
+      f.close();
+    } else {
+      RCLCPP_ERROR(this->get_logger(), "Failed to open file: %s", output_file_str.c_str());
+    }
+  } catch (const std::exception & e) {
+    std::cerr << "Exception in MotionEvaluatorNode destructor: " << e.what() << std::endl;
+  } catch (...) {
+    std::cerr << "Unknown exception in MotionEvaluatorNode destructor" << std::endl;
   }
 }
 


### PR DESCRIPTION
## Description
This is a fix based on clang-tidy `bugprone-exception-escape` error.

```
/home/emb4/autoware/autoware/src/universe/autoware.universe/evaluator/autoware_planning_evaluator/src/motion_evaluator_node.cpp:48:22: error: an exception may be thrown in function '~MotionEvaluatorNode' which should not throw exceptions [bugprone-exception-escape,-warnings-as-errors]
MotionEvaluatorNode::~MotionEvaluatorNode()
                     ^
/home/emb4/autoware/autoware/src/universe/autoware.universe/evaluator/autoware_planning_evaluator/src/planning_evaluator_node.cpp:71:24: error: an exception may be thrown in function '~PlanningEvaluatorNode' which should not throw exceptions [bugprone-exception-escape,-warnings-as-errors]
PlanningEvaluatorNode::~PlanningEvaluatorNode()
                       ^
```
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
