### PR TITLE
feat(autoware_object_merger, autoware_tracking_object_merger): enable anonymized node names to be configurable

### DIFF
--- a/launch/tier4_perception_launch/launch/object_recognition/detection/merger/camera_lidar_merger.launch.xml
+++ b/launch/tier4_perception_launch/launch/object_recognition/detection/merger/camera_lidar_merger.launch.xml
@@ -120,6 +120,7 @@
   <!-- 1st merger: camera_lidar_fusion + lidar cluster-->
   <group>
     <include file="$(find-pkg-share autoware_object_merger)/launch/object_association_merger.launch.xml">
+      <arg name="node_name" value="object_association_merger_alpha"/>
       <arg name="input/object0" value="$(var merger1/input/objects0)"/>
       <arg name="input/object1" value="$(var merger1/input/objects1)"/>
       <arg name="output/object" value="$(var merger1/output/objects)"/>
@@ -132,6 +133,7 @@
   <!-- 2nd merger: + detection_by_tracker -->
   <group if="$(var use_detection_by_tracker)">
     <include file="$(find-pkg-share autoware_object_merger)/launch/object_association_merger.launch.xml">
+      <arg name="node_name" value="object_association_merger_beta"/>
       <arg name="input/object0" value="$(var merger2/input/objects0)"/>
       <arg name="input/object1" value="$(var merger2/input/objects1)"/>
       <arg name="output/object" value="$(var merger2/output/objects)"/>

--- a/launch/tier4_perception_launch/launch/object_recognition/detection/merger/camera_lidar_radar_merger.launch.xml
+++ b/launch/tier4_perception_launch/launch/object_recognition/detection/merger/camera_lidar_radar_merger.launch.xml
@@ -143,6 +143,7 @@
   <!-- 1st merger -->
   <group>
     <include file="$(find-pkg-share autoware_object_merger)/launch/object_association_merger.launch.xml">
+      <arg name="node_name" value="object_association_merger_alpha"/>
       <arg name="input/object0" value="$(var merger1/input/objects0)"/>
       <arg name="input/object1" value="$(var merger1/input/objects1)"/>
       <arg name="output/object" value="$(var merger1/output/objects)"/>
@@ -155,6 +156,7 @@
   <!-- 2nd merger: + detection_by_tracker -->
   <group if="$(var use_detection_by_tracker)">
     <include file="$(find-pkg-share autoware_object_merger)/launch/object_association_merger.launch.xml">
+      <arg name="node_name" value="object_association_merger_beta"/>
       <arg name="input/object0" value="$(var merger2/input/objects0)"/>
       <arg name="input/object1" value="$(var merger2/input/objects1)"/>
       <arg name="output/object" value="$(var merger2/output/objects)"/>
@@ -178,6 +180,7 @@
       Control parameter 'use_radar_tracking_fusion' should defined in perception.launch.xml -->
   <group unless="$(var use_radar_tracking_fusion)">
     <include file="$(find-pkg-share autoware_object_merger)/launch/object_association_merger.launch.xml">
+      <arg name="node_name" value="object_association_merger_gamma"/>
       <arg name="input/object0" value="$(var merger3/input/objects0)"/>
       <arg name="input/object1" value="$(var merger3/input/objects1)"/>
       <arg name="output/object" value="$(var merger3/output/objects)"/>

--- a/launch/tier4_perception_launch/launch/object_recognition/detection/merger/lidar_merger.launch.xml
+++ b/launch/tier4_perception_launch/launch/object_recognition/detection/merger/lidar_merger.launch.xml
@@ -58,6 +58,7 @@
   <!-- 1st merger: ML detection + pointcloud cluster -->
   <group>
     <include file="$(find-pkg-share autoware_object_merger)/launch/object_association_merger.launch.xml">
+      <arg name="node_name" value="object_association_merger_alpha"/>
       <arg name="input/object0" value="$(var merger1/input/objects0)"/>
       <arg name="input/object1" value="$(var merger1/input/objects1)"/>
       <arg name="output/object" value="$(var merger1/output/objects)"/>
@@ -70,6 +71,7 @@
   <!-- 2nd merger: + detection_by_tracker -->
   <group if="$(var use_detection_by_tracker)">
     <include file="$(find-pkg-share autoware_object_merger)/launch/object_association_merger.launch.xml">
+      <arg name="node_name" value="object_association_merger_beta"/>
       <arg name="input/object0" value="$(var merger2/input/objects0)"/>
       <arg name="input/object1" value="$(var merger2/input/objects1)"/>
       <arg name="output/object" value="$(var merger2/output/objects)"/>

--- a/launch/tier4_perception_launch/launch/object_recognition/tracking/tracking.launch.xml
+++ b/launch/tier4_perception_launch/launch/object_recognition/tracking/tracking.launch.xml
@@ -57,6 +57,7 @@
 
       <!-- tracking object merger to merge near objects and far objects -->
       <include file="$(find-pkg-share autoware_tracking_object_merger)/launch/decorative_tracker_merger.launch.xml">
+        <arg name="node_name" value="decorative_tracker_merger"/>
         <arg name="input/main_object" value="$(var tracker_merger/input/main_objects)"/>
         <arg name="input/sub_object" value="$(var tracker_merger/input/sub_objects)"/>
         <arg name="output" value="$(var tracker_merger/output/objects)"/>

--- a/perception/autoware_object_merger/launch/object_association_merger.launch.xml
+++ b/perception/autoware_object_merger/launch/object_association_merger.launch.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
 <launch>
+  <arg name="node_name" default="$(anon object_association_merger)"/>
   <arg name="input/object0" default="object0"/>
   <arg name="input/object1" default="object1"/>
   <arg name="output/object" default="merged_object"/>
@@ -8,7 +9,7 @@
   <arg name="distance_threshold_list_path" default="$(find-pkg-share autoware_object_merger)/config/overlapped_judge.param.yaml"/>
   <arg name="object_association_merger_param_path" default="$(find-pkg-share autoware_object_merger)/config/object_association_merger.param.yaml"/>
 
-  <node pkg="autoware_object_merger" exec="object_association_merger_node" name="$(anon object_association_merger)" output="screen">
+  <node pkg="autoware_object_merger" exec="object_association_merger_node" name="$(var node_name)" output="screen">
     <remap from="input/object0" to="$(var input/object0)"/>
     <remap from="input/object1" to="$(var input/object1)"/>
     <remap from="output/object" to="$(var output/object)"/>

--- a/perception/autoware_tracking_object_merger/launch/decorative_tracker_merger.launch.xml
+++ b/perception/autoware_tracking_object_merger/launch/decorative_tracker_merger.launch.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
 <launch>
+  <arg name="node_name" default="$(anon decorative_tracker_merger)"/>
   <arg name="input/main_object" default="main_object"/>
   <arg name="input/sub_object" default="sub_object"/>
   <arg name="output" default="merged_object"/>
@@ -7,7 +8,7 @@
   <arg name="merge_options_path" default="$(find-pkg-share autoware_tracking_object_merger)/config/decorative_tracker_merger_policy.param.yaml"/>
   <arg name="node_param_file_path" default="$(find-pkg-share autoware_tracking_object_merger)/config/decorative_tracker_merger.param.yaml"/>
 
-  <node pkg="autoware_tracking_object_merger" exec="decorative_tracker_merger_node" name="$(anon decorative_tracker_merger)" output="screen">
+  <node pkg="autoware_tracking_object_merger" exec="decorative_tracker_merger_node" name="$(var node_name)" output="screen">
     <remap from="input/main_object" to="$(var input/main_object)"/>
     <remap from="input/sub_object" to="$(var input/sub_object)"/>
     <remap from="output/object" to="$(var output)"/>


### PR DESCRIPTION
## Description
Since the node names are anonymized, the node name changes on every launch.
The random node name introduce complexity on the node diagnostics.

This PR provides the node name variable `node_name` to be configured externally.
If the node name is not set, the name will be anonymized by default.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
