### PR TITLE
fix(autoware_tensorrt_yolox): fix bugprone-exception-escape

### DIFF
--- a/perception/autoware_tensorrt_yolox/src/tensorrt_yolox.cpp
+++ b/perception/autoware_tensorrt_yolox/src/tensorrt_yolox.cpp
@@ -341,16 +341,22 @@ TrtYoloX::TrtYoloX(
 
 TrtYoloX::~TrtYoloX()
 {
-  if (use_gpu_preprocess_) {
-    if (image_buf_h_) {
-      image_buf_h_.reset();
+  try {
+    if (use_gpu_preprocess_) {
+      if (image_buf_h_) {
+        image_buf_h_.reset();
+      }
+      if (image_buf_d_) {
+        image_buf_d_.reset();
+      }
+      if (argmax_buf_d_) {
+        argmax_buf_d_.reset();
+      }
     }
-    if (image_buf_d_) {
-      image_buf_d_.reset();
-    }
-    if (argmax_buf_d_) {
-      argmax_buf_d_.reset();
-    }
+  } catch (const std::exception &e) {
+    std::cerr << "Exception in TrtYoloX destructor: " << e.what() << std::endl;
+  } catch (...) {
+    std::cerr << "Unknown exception in TrtYoloX destructor" << std::endl;
   }
 }
 

--- a/perception/autoware_tensorrt_yolox/src/tensorrt_yolox.cpp
+++ b/perception/autoware_tensorrt_yolox/src/tensorrt_yolox.cpp
@@ -1149,7 +1149,7 @@ void TrtYoloX::generateYoloxProposals(
         objects.push_back(obj);
       }
     }  // class loop
-  }    // point anchor loop
+  }  // point anchor loop
 }
 
 void TrtYoloX::qsortDescentInplace(ObjectArray & face_objects, int left, int right) const

--- a/perception/autoware_tensorrt_yolox/src/tensorrt_yolox.cpp
+++ b/perception/autoware_tensorrt_yolox/src/tensorrt_yolox.cpp
@@ -353,7 +353,7 @@ TrtYoloX::~TrtYoloX()
         argmax_buf_d_.reset();
       }
     }
-  } catch (const std::exception &e) {
+  } catch (const std::exception & e) {
     std::cerr << "Exception in TrtYoloX destructor: " << e.what() << std::endl;
   } catch (...) {
     std::cerr << "Unknown exception in TrtYoloX destructor" << std::endl;
@@ -1149,7 +1149,7 @@ void TrtYoloX::generateYoloxProposals(
         objects.push_back(obj);
       }
     }  // class loop
-  }  // point anchor loop
+  }    // point anchor loop
 }
 
 void TrtYoloX::qsortDescentInplace(ObjectArray & face_objects, int left, int right) const


### PR DESCRIPTION
## Description
This is a fix based on clang-tidy `bugprone-exception-escape` error.

```
/home/emb4/autoware/autoware/src/universe/autoware.universe/perception/autoware_tensorrt_yolox/src/tensorrt_yolox.cpp:342:11: error: an exception may be thrown in function '~TrtYoloX' which should not throw exceptions [bugprone-exception-escape,-warnings-as-errors]
TrtYoloX::~TrtYoloX()
          ^
```
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
