### PR TITLE
fix(lane_change): fix prepare length too short at low speed (RT1-8909)

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/calculation.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/calculation.cpp
@@ -417,7 +417,7 @@ double calc_actual_prepare_duration(
     if (max_acc < eps) {
       return params.max_prepare_duration;
     }
-    return (min_lc_velocity - current_velocity) / max_acc;
+    return std::max((min_lc_velocity - current_velocity) / max_acc, params.min_prepare_duration);
   });
 
   return std::max(params.max_prepare_duration - active_signal_duration, min_prepare_duration);


### PR DESCRIPTION
## Description

When the prepare metrics are computed, if the ego velocity is lower than the lane-changing velocity, the returned prepare duration becomes abnormally short, even when the ego vehicle is far from the terminal stop.

In the following video, the prepare distance is less than 1m.

https://github.com/user-attachments/assets/0abc6453-bf89-4598-8080-d903ef7e48c7

In above video, current_velocity is somewhere less than min_lc_velocity, and the following is computed

```
(min_lc_velocity - current_velocity) / max_acc;
```

the small discrepancy resulted in very short duration.

#### After PR

The solution is to compare the computation with parameterized `min_prepare_duration`

https://github.com/user-attachments/assets/fae6266e-a198-44d6-8c45-16ca1a0d66c4

## Related links

[TIER IV Internal link](https://tier4.atlassian.net/browse/RT1-8909)

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

Longer prepare duration when ego's velocity is low and the distance from ego to terminal stop is far.
