### PR TITLE
fix(lane_change): add metrics to valid paths visualization

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/markers.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/markers.hpp
@@ -35,7 +35,7 @@ using autoware::behavior_path_planner::lane_change::Debug;
 using autoware::behavior_path_planner::utils::path_safety_checker::ExtendedPredictedObjects;
 using visualization_msgs::msg::MarkerArray;
 MarkerArray showAllValidLaneChangePath(
-  const std::vector<LaneChangePath> & lanes, std::string && ns);
+  const std::vector<LaneChangePath> & lane_change_paths, std::string && ns);
 MarkerArray createLaneChangingVirtualWallMarker(
   const geometry_msgs::msg::Pose & lane_changing_pose, const std::string & module_name,
   const rclcpp::Time & now, const std::string & ns);

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/markers.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/markers.cpp
@@ -79,12 +79,11 @@ MarkerArray showAllValidLaneChangePath(
     if (lc_path.path.points.empty()) {
       continue;
     }
-    std::ostringstream ss;
-    ss << ns.c_str() << "[" << idx << "]";
+    std::string ns_with_idx = ns + "[" + std::to_string(idx) + "]";
     const auto & color = colors.at(idx);
     const auto & points = lc_path.path.points;
     auto marker = createDefaultMarker(
-      "map", current_time, ss.str(), ++id, Marker::LINE_STRIP, createMarkerScale(0.1, 0.1, 0.0),
+      "map", current_time, ns_with_idx, ++id, Marker::LINE_STRIP, createMarkerScale(0.1, 0.1, 0.0),
       color);
     marker.points.reserve(points.size());
 
@@ -93,7 +92,7 @@ MarkerArray showAllValidLaneChangePath(
     }
 
     auto text_marker = createDefaultMarker(
-      "map", current_time, ss.str(), ++id, visualization_msgs::msg::Marker::TEXT_VIEW_FACING,
+      "map", current_time, ns_with_idx, ++id, visualization_msgs::msg::Marker::TEXT_VIEW_FACING,
       createMarkerScale(0.1, 0.1, 0.8), colors::yellow());
     const auto prep_idx = points.size() / 4;
     text_marker.pose = points.at(prep_idx).point.pose;


### PR DESCRIPTION
## Description

Adds path metrics along valid paths' visualization.

https://github.com/user-attachments/assets/61d42394-80dd-4cf4-9c1c-3b77364e185f

Visualization can be turn on and off separately.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
