### PR TITLE
feat(diagnostic_graph_utils): use StringStamped in autoware_internal_debug_msgs

### DIFF
--- a/system/diagnostic_graph_utils/package.xml
+++ b/system/diagnostic_graph_utils/package.xml
@@ -10,6 +10,8 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
+  <depend>autoware_internal_debug_msgs</depend>
+  <depend>autowware_internal_debug_msgs</depend>
   <depend>diagnostic_msgs</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>

--- a/system/diagnostic_graph_utils/package.xml
+++ b/system/diagnostic_graph_utils/package.xml
@@ -11,7 +11,6 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_internal_debug_msgs</depend>
-  <depend>autowware_internal_debug_msgs</depend>
   <depend>diagnostic_msgs</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>

--- a/system/diagnostic_graph_utils/src/node/logging.cpp
+++ b/system/diagnostic_graph_utils/src/node/logging.cpp
@@ -34,7 +34,7 @@ LoggingNode::LoggingNode(const rclcpp::NodeOptions & options) : Node("logging", 
   sub_graph_.register_create_callback(std::bind(&LoggingNode::on_create, this, _1));
   sub_graph_.subscribe(*this, 1);
 
-  pub_error_graph_text_ = create_publisher<tier4_debug_msgs::msg::StringStamped>(
+  pub_error_graph_text_ = create_publisher<autoware_internal_debug_msgs::msg::StringStamped>(
     "~/debug/error_graph_text", rclcpp::QoS(1));
 
   const auto period = rclcpp::Rate(declare_parameter<double>("show_rate")).period();
@@ -68,12 +68,12 @@ void LoggingNode::on_timer()
       RCLCPP_WARN_STREAM(get_logger(), prefix_message << std::endl << dump_text_.str());
     }
 
-    tier4_debug_msgs::msg::StringStamped message;
+    autoware_internal_debug_msgs::msg::StringStamped message;
     message.stamp = now();
     message.data = dump_text_.str();
     pub_error_graph_text_->publish(message);
   } else {
-    tier4_debug_msgs::msg::StringStamped message;
+    autoware_internal_debug_msgs::msg::StringStamped message;
     message.stamp = now();
     pub_error_graph_text_->publish(message);
   }

--- a/system/diagnostic_graph_utils/src/node/logging.hpp
+++ b/system/diagnostic_graph_utils/src/node/logging.hpp
@@ -19,7 +19,7 @@
 
 #include <rclcpp/rclcpp.hpp>
 
-#include "tier4_debug_msgs/msg/string_stamped.hpp"
+#include "autoware_internal_debug_msgs/msg/string_stamped.hpp"
 
 #include <sstream>
 #include <string>
@@ -37,7 +37,8 @@ private:
   void on_timer();
   void dump_unit(DiagUnit * unit, int depth, const std::string & indent);
   DiagGraphSubscription sub_graph_;
-  rclcpp::Publisher<tier4_debug_msgs::msg::StringStamped>::SharedPtr pub_error_graph_text_;
+  rclcpp::Publisher<autoware_internal_debug_msgs::msg::StringStamped>::SharedPtr
+    pub_error_graph_text_;
   rclcpp::TimerBase::SharedPtr timer_;
 
   DiagUnit * root_unit_;


### PR DESCRIPTION
## Description

Run the following command, and manually add `autoware_internal_debug_msgs` in the package.xml
```
find ./ -type f -exec sed -i -e 's/tier4_debug_msgs::msg::StringStamped/autoware_internal_debug_msgs::msg::StringStamped/g' {} \;
find ./ -type f -exec sed -i -e 's/tier4_debug_msgs\/msg\/string_stamped/autoware_internal_debug_msgs\/msg\/string_stamped/g' {} \;
```


## Related links

https://github.com/autowarefoundation/autoware/issues/5580

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
