### PR TITLE
feat(motion_planning): use StringStamped in autoware_internal_debug_msgs

### DIFF
--- a/planning/autoware_path_optimizer/include/autoware/path_optimizer/type_alias.hpp
+++ b/planning/autoware_path_optimizer/include/autoware/path_optimizer/type_alias.hpp
@@ -15,6 +15,7 @@
 #ifndef AUTOWARE__PATH_OPTIMIZER__TYPE_ALIAS_HPP_
 #define AUTOWARE__PATH_OPTIMIZER__TYPE_ALIAS_HPP_
 
+#include "autoware_internal_debug_msgs/msg/string_stamped.hpp"
 #include "autoware_planning_msgs/msg/path.hpp"
 #include "autoware_planning_msgs/msg/path_point.hpp"
 #include "autoware_planning_msgs/msg/trajectory.hpp"
@@ -25,7 +26,6 @@
 #include "nav_msgs/msg/odometry.hpp"
 #include "std_msgs/msg/header.hpp"
 #include "tier4_debug_msgs/msg/float64_stamped.hpp"
-#include "tier4_debug_msgs/msg/string_stamped.hpp"
 #include "visualization_msgs/msg/marker_array.hpp"
 
 namespace autoware::path_optimizer
@@ -43,8 +43,8 @@ using nav_msgs::msg::Odometry;
 using visualization_msgs::msg::Marker;
 using visualization_msgs::msg::MarkerArray;
 // debug
+using autoware_internal_debug_msgs::msg::StringStamped;
 using tier4_debug_msgs::msg::Float64Stamped;
-using tier4_debug_msgs::msg::StringStamped;
 }  // namespace autoware::path_optimizer
 
 #endif  // AUTOWARE__PATH_OPTIMIZER__TYPE_ALIAS_HPP_

--- a/planning/autoware_path_optimizer/package.xml
+++ b/planning/autoware_path_optimizer/package.xml
@@ -14,6 +14,7 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
+  <depend>autoware_internal_debug_msgs</depend>
   <depend>autoware_interpolation</depend>
   <depend>autoware_motion_utils</depend>
   <depend>autoware_osqp_interface</depend>

--- a/planning/autoware_path_smoother/include/autoware/path_smoother/type_alias.hpp
+++ b/planning/autoware_path_smoother/include/autoware/path_smoother/type_alias.hpp
@@ -15,6 +15,7 @@
 #ifndef AUTOWARE__PATH_SMOOTHER__TYPE_ALIAS_HPP_
 #define AUTOWARE__PATH_SMOOTHER__TYPE_ALIAS_HPP_
 
+#include "autoware_internal_debug_msgs/msg/string_stamped.hpp"
 #include "autoware_planning_msgs/msg/path.hpp"
 #include "autoware_planning_msgs/msg/path_point.hpp"
 #include "autoware_planning_msgs/msg/trajectory.hpp"
@@ -23,7 +24,6 @@
 #include "nav_msgs/msg/odometry.hpp"
 #include "std_msgs/msg/header.hpp"
 #include "tier4_debug_msgs/msg/float64_stamped.hpp"
-#include "tier4_debug_msgs/msg/string_stamped.hpp"
 
 namespace autoware::path_smoother
 {
@@ -37,8 +37,8 @@ using autoware_planning_msgs::msg::TrajectoryPoint;
 // navigation
 using nav_msgs::msg::Odometry;
 // debug
+using autoware_internal_debug_msgs::msg::StringStamped;
 using tier4_debug_msgs::msg::Float64Stamped;
-using tier4_debug_msgs::msg::StringStamped;
 }  // namespace autoware::path_smoother
 
 #endif  // AUTOWARE__PATH_SMOOTHER__TYPE_ALIAS_HPP_

--- a/planning/autoware_path_smoother/package.xml
+++ b/planning/autoware_path_smoother/package.xml
@@ -14,6 +14,7 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
+  <depend>autoware_internal_debug_msgs</depend>
   <depend>autoware_interpolation</depend>
   <depend>autoware_motion_utils</depend>
   <depend>autoware_osqp_interface</depend>

--- a/planning/sampling_based_planner/autoware_path_sampler/include/autoware_path_sampler/type_alias.hpp
+++ b/planning/sampling_based_planner/autoware_path_sampler/include/autoware_path_sampler/type_alias.hpp
@@ -15,6 +15,7 @@
 #ifndef AUTOWARE_PATH_SAMPLER__TYPE_ALIAS_HPP_
 #define AUTOWARE_PATH_SAMPLER__TYPE_ALIAS_HPP_
 
+#include "autoware_internal_debug_msgs/msg/string_stamped.hpp"
 #include "autoware_perception_msgs/msg/predicted_objects.hpp"
 #include "autoware_planning_msgs/msg/path.hpp"
 #include "autoware_planning_msgs/msg/path_point.hpp"
@@ -25,7 +26,6 @@
 #include "geometry_msgs/msg/twist.hpp"
 #include "nav_msgs/msg/odometry.hpp"
 #include "std_msgs/msg/header.hpp"
-#include "tier4_debug_msgs/msg/string_stamped.hpp"
 #include "visualization_msgs/msg/marker_array.hpp"
 
 namespace autoware::path_sampler
@@ -45,7 +45,7 @@ using nav_msgs::msg::Odometry;
 using visualization_msgs::msg::Marker;
 using visualization_msgs::msg::MarkerArray;
 // debug
-using tier4_debug_msgs::msg::StringStamped;
+using autoware_internal_debug_msgs::msg::StringStamped;
 }  // namespace autoware::path_sampler
 
 #endif  // AUTOWARE_PATH_SAMPLER__TYPE_ALIAS_HPP_

--- a/planning/sampling_based_planner/autoware_path_sampler/package.xml
+++ b/planning/sampling_based_planner/autoware_path_sampler/package.xml
@@ -15,6 +15,7 @@
 
   <depend>autoware_bezier_sampler</depend>
   <depend>autoware_frenet_planner</depend>
+  <depend>autoware_internal_debug_msgs</depend>
   <depend>autoware_interpolation</depend>
   <depend>autoware_motion_utils</depend>
   <depend>autoware_perception_msgs</depend>


### PR DESCRIPTION
## Description

Run the following command, and manually add `autoware_internal_debug_msgs` in the package.xml
```
find ./ -type f -exec sed -i -e 's/tier4_debug_msgs::msg::StringStamped/autoware_internal_debug_msgs::msg::StringStamped/g' {} \;
find ./ -type f -exec sed -i -e 's/tier4_debug_msgs\/msg\/string_stamped/autoware_internal_debug_msgs\/msg\/string_stamped/g' {} \;
```


## Related links

https://github.com/autowarefoundation/autoware/issues/5580
## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
