### PR TITLE
feat(behavior_velocity_planner): remove virtual traffic light dependency from behavior_velocity_planner and behavior_velocity_planner_common

### DIFF
--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/include/autoware/behavior_velocity_planner/node.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/include/autoware/behavior_velocity_planner/node.hpp
@@ -81,10 +81,6 @@ private:
     autoware_perception_msgs::msg::TrafficLightGroupArray>
     sub_traffic_signals_{this, "~/input/traffic_signals"};
 
-  autoware::universe_utils::InterProcessPollingSubscriber<
-    tier4_v2x_msgs::msg::VirtualTrafficLightStateArray>
-    sub_virtual_traffic_light_states_{this, "~/input/virtual_traffic_light_states"};
-
   autoware::universe_utils::InterProcessPollingSubscriber<nav_msgs::msg::OccupancyGrid>
     sub_occupancy_grid_{this, "~/input/occupancy_grid"};
 

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/package.xml
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/package.xml
@@ -56,7 +56,6 @@
   <depend>tf2_geometry_msgs</depend>
   <depend>tf2_ros</depend>
   <depend>tier4_planning_msgs</depend>
-  <depend>tier4_v2x_msgs</depend>
   <depend>visualization_msgs</depend>
 
   <test_depend>ament_cmake_ros</test_depend>

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/src/node.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/src/node.cpp
@@ -271,9 +271,6 @@ bool BehaviorVelocityPlannerNode::processData(rclcpp::Clock clock)
     planner_data_.route_handler_ = std::make_shared<route_handler::RouteHandler>(*map_data);
   }
 
-  // optional data
-  getData(planner_data_.virtual_traffic_light_states, sub_virtual_traffic_light_states_);
-
   // planner_data_.external_velocity_limit is std::optional type variable.
   const auto external_velocity_limit = sub_external_velocity_limit_.takeData();
   if (external_velocity_limit) {

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/src/test_utils.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/src/test_utils.cpp
@@ -113,8 +113,6 @@ void publishMandatoryTopics(
     test_target_node, "behavior_velocity_planner_node/input/traffic_signals");
   test_manager->publishMaxVelocity(
     test_target_node, "behavior_velocity_planner_node/input/external_velocity_limit_mps");
-  test_manager->publishVirtualTrafficLightState(
-    test_target_node, "behavior_velocity_planner_node/input/virtual_traffic_light_states");
   test_manager->publishOccupancyGrid(
     test_target_node, "behavior_velocity_planner_node/input/occupancy_grid");
 }

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/include/autoware/behavior_velocity_planner_common/planner_data.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/include/autoware/behavior_velocity_planner_common/planner_data.hpp
@@ -30,7 +30,6 @@
 #include <sensor_msgs/msg/point_cloud2.hpp>
 #include <std_msgs/msg/header.hpp>
 #include <tier4_planning_msgs/msg/velocity_limit.hpp>
-#include <tier4_v2x_msgs/msg/virtual_traffic_light_state_array.hpp>
 
 #include <pcl/point_cloud.h>
 #include <pcl/point_types.h>
@@ -64,7 +63,6 @@ struct PlannerData
   std::map<lanelet::Id, TrafficSignalStamped> traffic_light_id_map_raw_;
   std::map<lanelet::Id, TrafficSignalStamped> traffic_light_id_map_last_observed_;
   std::optional<tier4_planning_msgs::msg::VelocityLimit> external_velocity_limit;
-  tier4_v2x_msgs::msg::VirtualTrafficLightStateArray::ConstSharedPtr virtual_traffic_light_states;
 
   bool is_simulation = false;
 

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/package.xml
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/package.xml
@@ -45,7 +45,6 @@
   <depend>tf2_geometry_msgs</depend>
   <depend>tf2_ros</depend>
   <depend>tier4_planning_msgs</depend>
-  <depend>tier4_v2x_msgs</depend>
   <depend>visualization_msgs</depend>
 
   <test_depend>ament_cmake_ros</test_depend>

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_virtual_traffic_light_module/src/manager.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_virtual_traffic_light_module/src/manager.cpp
@@ -53,6 +53,10 @@ VirtualTrafficLightModuleManager::VirtualTrafficLightModuleManager(rclcpp::Node 
     p.check_timeout_after_stop_line =
       getOrDeclareParameter<bool>(node, ns + ".check_timeout_after_stop_line");
   }
+
+  sub_virtual_traffic_light_states_ = autoware::universe_utils::InterProcessPollingSubscriber<
+    tier4_v2x_msgs::msg::VirtualTrafficLightStateArray>::
+    create_subscription(&node, "~/input/virtual_traffic_light_states");
 }
 
 void VirtualTrafficLightModuleManager::launchNewModules(
@@ -84,7 +88,8 @@ void VirtualTrafficLightModuleManager::launchNewModules(
         ego_path_linestring, lanelet::utils::to2D(stop_line_opt.value()).basicLineString())) {
       registerModule(std::make_shared<VirtualTrafficLightModule>(
         module_id, lane_id, *m.first, m.second, planner_param_,
-        logger_.get_child("virtual_traffic_light_module"), clock_));
+        logger_.get_child("virtual_traffic_light_module"), clock_,
+        sub_virtual_traffic_light_states_));
     }
   }
 }

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_virtual_traffic_light_module/src/manager.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_virtual_traffic_light_module/src/manager.hpp
@@ -24,6 +24,7 @@
 #include <rclcpp/rclcpp.hpp>
 
 #include <tier4_planning_msgs/msg/path_with_lane_id.hpp>
+#include <tier4_v2x_msgs/msg/infrastructure_command_array.hpp>
 #include <tier4_v2x_msgs/msg/virtual_traffic_light_state_array.hpp>
 
 #include <functional>
@@ -40,6 +41,9 @@ public:
 
 private:
   VirtualTrafficLightModule::PlannerParam planner_param_;
+
+  void modifyPathVelocity(tier4_planning_msgs::msg::PathWithLaneId * path) override;
+
   void launchNewModules(const tier4_planning_msgs::msg::PathWithLaneId & path) override;
 
   std::function<bool(const std::shared_ptr<SceneModuleInterface> &)> getModuleExpiredFunction(
@@ -48,6 +52,9 @@ private:
   autoware::universe_utils::InterProcessPollingSubscriber<
     tier4_v2x_msgs::msg::VirtualTrafficLightStateArray>::SharedPtr
     sub_virtual_traffic_light_states_;
+
+  rclcpp::Publisher<tier4_v2x_msgs::msg::InfrastructureCommandArray>::SharedPtr
+    pub_infrastructure_commands_;
 };
 
 class VirtualTrafficLightModulePlugin : public PluginWrapper<VirtualTrafficLightModuleManager>

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_virtual_traffic_light_module/src/manager.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_virtual_traffic_light_module/src/manager.hpp
@@ -20,9 +20,11 @@
 #include <autoware/behavior_velocity_planner_common/plugin_interface.hpp>
 #include <autoware/behavior_velocity_planner_common/plugin_wrapper.hpp>
 #include <autoware/behavior_velocity_planner_common/scene_module_interface.hpp>
+#include <autoware/universe_utils/ros/polling_subscriber.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include <tier4_planning_msgs/msg/path_with_lane_id.hpp>
+#include <tier4_v2x_msgs/msg/virtual_traffic_light_state_array.hpp>
 
 #include <functional>
 #include <memory>
@@ -42,6 +44,10 @@ private:
 
   std::function<bool(const std::shared_ptr<SceneModuleInterface> &)> getModuleExpiredFunction(
     const tier4_planning_msgs::msg::PathWithLaneId & path) override;
+
+  autoware::universe_utils::InterProcessPollingSubscriber<
+    tier4_v2x_msgs::msg::VirtualTrafficLightStateArray>::SharedPtr
+    sub_virtual_traffic_light_states_;
 };
 
 class VirtualTrafficLightModulePlugin : public PluginWrapper<VirtualTrafficLightModuleManager>

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_virtual_traffic_light_module/src/manager.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_virtual_traffic_light_module/src/manager.hpp
@@ -32,7 +32,8 @@
 
 namespace autoware::behavior_velocity_planner
 {
-class VirtualTrafficLightModuleManager : public SceneModuleManagerInterface<>
+class VirtualTrafficLightModuleManager
+: public SceneModuleManagerInterface<VirtualTrafficLightModule>
 {
 public:
   explicit VirtualTrafficLightModuleManager(rclcpp::Node & node);
@@ -46,7 +47,7 @@ private:
 
   void launchNewModules(const tier4_planning_msgs::msg::PathWithLaneId & path) override;
 
-  std::function<bool(const std::shared_ptr<SceneModuleInterface> &)> getModuleExpiredFunction(
+  std::function<bool(const std::shared_ptr<VirtualTrafficLightModule> &)> getModuleExpiredFunction(
     const tier4_planning_msgs::msg::PathWithLaneId & path) override;
 
   autoware::universe_utils::InterProcessPollingSubscriber<

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_virtual_traffic_light_module/src/scene.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_virtual_traffic_light_module/src/scene.cpp
@@ -461,4 +461,16 @@ void VirtualTrafficLightModule::insertStopVelocityAtEndLine(
   module_data_.stop_head_pose_at_end_line =
     calcHeadPose(stop_pose, planner_data_->vehicle_info_.max_longitudinal_offset_m);
 }
+
+std::optional<tier4_v2x_msgs::msg::InfrastructureCommand>
+VirtualTrafficLightModule::getInfrastructureCommand() const
+{
+  return infrastructure_command_;
+}
+
+void VirtualTrafficLightModule::setInfrastructureCommand(
+  const std::optional<tier4_v2x_msgs::msg::InfrastructureCommand> & command)
+{
+  infrastructure_command_ = command;
+}
 }  // namespace autoware::behavior_velocity_planner

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_virtual_traffic_light_module/src/scene.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_virtual_traffic_light_module/src/scene.cpp
@@ -333,7 +333,7 @@ bool VirtualTrafficLightModule::isNearAnyEndLine(const size_t end_line_idx)
 std::optional<tier4_v2x_msgs::msg::VirtualTrafficLightState>
 VirtualTrafficLightModule::findCorrespondingState()
 {
-  // Note: This variable is set by virtul traffic light's manager.
+  // Note: This variable is set by virtual traffic light's manager.
   if (!virtual_traffic_light_states_) {
     return {};
   }

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_virtual_traffic_light_module/src/scene.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_virtual_traffic_light_module/src/scene.cpp
@@ -38,15 +38,12 @@ VirtualTrafficLightModule::VirtualTrafficLightModule(
   const int64_t module_id, const int64_t lane_id,
   const lanelet::autoware::VirtualTrafficLight & reg_elem, lanelet::ConstLanelet lane,
   const PlannerParam & planner_param, const rclcpp::Logger logger,
-  const rclcpp::Clock::SharedPtr clock,
-  const autoware::universe_utils::InterProcessPollingSubscriber<
-    tier4_v2x_msgs::msg::VirtualTrafficLightStateArray>::SharedPtr sub_virtual_traffic_light_states)
+  const rclcpp::Clock::SharedPtr clock)
 : SceneModuleInterface(module_id, logger, clock),
   lane_id_(lane_id),
   reg_elem_(reg_elem),
   lane_(lane),
-  planner_param_(planner_param),
-  sub_virtual_traffic_light_states_(sub_virtual_traffic_light_states)
+  planner_param_(planner_param)
 {
   velocity_factor_.init(PlanningBehavior::VIRTUAL_TRAFFIC_LIGHT);
 
@@ -336,13 +333,12 @@ bool VirtualTrafficLightModule::isNearAnyEndLine(const size_t end_line_idx)
 std::optional<tier4_v2x_msgs::msg::VirtualTrafficLightState>
 VirtualTrafficLightModule::findCorrespondingState()
 {
-  // No message
-  const auto virtual_traffic_light_states = sub_virtual_traffic_light_states_->takeData();
-  if (!virtual_traffic_light_states) {
+  // Note: This variable is set by virtul traffic light's manager.
+  if (!virtual_traffic_light_states_) {
     return {};
   }
 
-  for (const auto & state : virtual_traffic_light_states->states) {
+  for (const auto & state : virtual_traffic_light_states_->states) {
     if (state.id == map_data_.instrument_id) {
       return state;
     }
@@ -472,5 +468,12 @@ void VirtualTrafficLightModule::setInfrastructureCommand(
   const std::optional<tier4_v2x_msgs::msg::InfrastructureCommand> & command)
 {
   infrastructure_command_ = command;
+}
+
+void VirtualTrafficLightModule::setVirtualTrafficLightStates(
+  const tier4_v2x_msgs::msg::VirtualTrafficLightStateArray::ConstSharedPtr
+    virtual_traffic_light_states)
+{
+  virtual_traffic_light_states_ = virtual_traffic_light_states;
 }
 }  // namespace autoware::behavior_velocity_planner

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_virtual_traffic_light_module/src/scene.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_virtual_traffic_light_module/src/scene.hpp
@@ -81,10 +81,7 @@ public:
     const int64_t module_id, const int64_t lane_id,
     const lanelet::autoware::VirtualTrafficLight & reg_elem, lanelet::ConstLanelet lane,
     const PlannerParam & planner_param, const rclcpp::Logger logger,
-    const rclcpp::Clock::SharedPtr clock,
-    const autoware::universe_utils::InterProcessPollingSubscriber<
-      tier4_v2x_msgs::msg::VirtualTrafficLightStateArray>::SharedPtr
-      sub_virtual_traffic_light_states);
+    const rclcpp::Clock::SharedPtr clock);
 
   bool modifyPathVelocity(PathWithLaneId * path) override;
 
@@ -95,19 +92,21 @@ public:
   void setInfrastructureCommand(
     const std::optional<tier4_v2x_msgs::msg::InfrastructureCommand> & command);
 
+  void setVirtualTrafficLightStates(
+    const tier4_v2x_msgs::msg::VirtualTrafficLightStateArray::ConstSharedPtr
+      virtual_traffic_light_states);
+
 private:
   const int64_t lane_id_;
   const lanelet::autoware::VirtualTrafficLight & reg_elem_;
   const lanelet::ConstLanelet lane_;
   const PlannerParam planner_param_;
+  tier4_v2x_msgs::msg::VirtualTrafficLightStateArray::ConstSharedPtr virtual_traffic_light_states_;
   State state_{State::NONE};
   tier4_v2x_msgs::msg::InfrastructureCommand command_;
   std::optional<tier4_v2x_msgs::msg::InfrastructureCommand> infrastructure_command_;
   MapData map_data_;
   ModuleData module_data_;
-  autoware::universe_utils::InterProcessPollingSubscriber<
-    tier4_v2x_msgs::msg::VirtualTrafficLightStateArray>::SharedPtr
-    sub_virtual_traffic_light_states_;
 
   void updateInfrastructureCommand();
 

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_virtual_traffic_light_module/src/scene.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_virtual_traffic_light_module/src/scene.hpp
@@ -25,6 +25,7 @@
 #include <rclcpp/clock.hpp>
 #include <rclcpp/logger.hpp>
 
+#include <tier4_v2x_msgs/msg/infrastructure_command_array.hpp>
 #include <tier4_v2x_msgs/msg/virtual_traffic_light_state_array.hpp>
 
 #include <lanelet2_core/LaneletMap.h>
@@ -90,6 +91,10 @@ public:
   visualization_msgs::msg::MarkerArray createDebugMarkerArray() override;
   autoware::motion_utils::VirtualWalls createVirtualWalls() override;
 
+  std::optional<tier4_v2x_msgs::msg::InfrastructureCommand> getInfrastructureCommand() const;
+  void setInfrastructureCommand(
+    const std::optional<tier4_v2x_msgs::msg::InfrastructureCommand> & command);
+
 private:
   const int64_t lane_id_;
   const lanelet::autoware::VirtualTrafficLight & reg_elem_;
@@ -97,6 +102,7 @@ private:
   const PlannerParam planner_param_;
   State state_{State::NONE};
   tier4_v2x_msgs::msg::InfrastructureCommand command_;
+  std::optional<tier4_v2x_msgs::msg::InfrastructureCommand> infrastructure_command_;
   MapData map_data_;
   ModuleData module_data_;
   autoware::universe_utils::InterProcessPollingSubscriber<

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_virtual_traffic_light_module/src/scene.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_virtual_traffic_light_module/src/scene.hpp
@@ -17,12 +17,15 @@
 
 #include <autoware/behavior_velocity_planner_common/scene_module_interface.hpp>
 #include <autoware/universe_utils/geometry/boost_geometry.hpp>
+#include <autoware/universe_utils/ros/polling_subscriber.hpp>
 #include <autoware_lanelet2_extension/regulatory_elements/virtual_traffic_light.hpp>
 #include <autoware_lanelet2_extension/utility/query.hpp>
 #include <autoware_vehicle_info_utils/vehicle_info.hpp>
 #include <nlohmann/json.hpp>
 #include <rclcpp/clock.hpp>
 #include <rclcpp/logger.hpp>
+
+#include <tier4_v2x_msgs/msg/virtual_traffic_light_state_array.hpp>
 
 #include <lanelet2_core/LaneletMap.h>
 #include <lanelet2_routing/RoutingGraph.h>
@@ -77,7 +80,10 @@ public:
     const int64_t module_id, const int64_t lane_id,
     const lanelet::autoware::VirtualTrafficLight & reg_elem, lanelet::ConstLanelet lane,
     const PlannerParam & planner_param, const rclcpp::Logger logger,
-    const rclcpp::Clock::SharedPtr clock);
+    const rclcpp::Clock::SharedPtr clock,
+    const autoware::universe_utils::InterProcessPollingSubscriber<
+      tier4_v2x_msgs::msg::VirtualTrafficLightStateArray>::SharedPtr
+      sub_virtual_traffic_light_states);
 
   bool modifyPathVelocity(PathWithLaneId * path) override;
 
@@ -93,6 +99,9 @@ private:
   tier4_v2x_msgs::msg::InfrastructureCommand command_;
   MapData map_data_;
   ModuleData module_data_;
+  autoware::universe_utils::InterProcessPollingSubscriber<
+    tier4_v2x_msgs::msg::VirtualTrafficLightStateArray>::SharedPtr
+    sub_virtual_traffic_light_states_;
 
   void updateInfrastructureCommand();
 

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_virtual_traffic_light_module/test/test_node_interface.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_virtual_traffic_light_module/test/test_node_interface.cpp
@@ -30,6 +30,11 @@ TEST(PlanningModuleInterfaceTest, NodeTestWithExceptionPathWithLaneID)
   auto test_target_node = autoware::behavior_velocity_planner::generateNode({});
 
   autoware::behavior_velocity_planner::publishMandatoryTopics(test_manager, test_target_node);
+<<<<<<< HEAD
+=======
+  test_manager->publishVirtualTrafficLightState(
+    test_target_node, "behavior_velocity_planner_node/input/virtual_traffic_light_states");
+>>>>>>> 383f6d25fd (fix test)
 
   // test with nominal path_with_lane_id
   ASSERT_NO_THROW_WITH_ERROR_MSG(test_manager->testWithNominalPathWithLaneId(test_target_node));
@@ -51,6 +56,11 @@ TEST(PlanningModuleInterfaceTest, NodeTestWithOffTrackEgoPose)
   auto test_manager = autoware::behavior_velocity_planner::generateTestManager();
   auto test_target_node = autoware::behavior_velocity_planner::generateNode(plugin_info_vec);
   autoware::behavior_velocity_planner::publishMandatoryTopics(test_manager, test_target_node);
+<<<<<<< HEAD
+=======
+  test_manager->publishVirtualTrafficLightState(
+    test_target_node, "behavior_velocity_planner_node/input/virtual_traffic_light_states");
+>>>>>>> 383f6d25fd (fix test)
 
   // test for normal trajectory
   ASSERT_NO_THROW_WITH_ERROR_MSG(test_manager->testWithNominalPathWithLaneId(test_target_node));

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_virtual_traffic_light_module/test/test_node_interface.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_virtual_traffic_light_module/test/test_node_interface.cpp
@@ -30,11 +30,8 @@ TEST(PlanningModuleInterfaceTest, NodeTestWithExceptionPathWithLaneID)
   auto test_target_node = autoware::behavior_velocity_planner::generateNode({});
 
   autoware::behavior_velocity_planner::publishMandatoryTopics(test_manager, test_target_node);
-<<<<<<< HEAD
-=======
   test_manager->publishVirtualTrafficLightState(
     test_target_node, "behavior_velocity_planner_node/input/virtual_traffic_light_states");
->>>>>>> 383f6d25fd (fix test)
 
   // test with nominal path_with_lane_id
   ASSERT_NO_THROW_WITH_ERROR_MSG(test_manager->testWithNominalPathWithLaneId(test_target_node));
@@ -56,11 +53,8 @@ TEST(PlanningModuleInterfaceTest, NodeTestWithOffTrackEgoPose)
   auto test_manager = autoware::behavior_velocity_planner::generateTestManager();
   auto test_target_node = autoware::behavior_velocity_planner::generateNode(plugin_info_vec);
   autoware::behavior_velocity_planner::publishMandatoryTopics(test_manager, test_target_node);
-<<<<<<< HEAD
-=======
   test_manager->publishVirtualTrafficLightState(
     test_target_node, "behavior_velocity_planner_node/input/virtual_traffic_light_states");
->>>>>>> 383f6d25fd (fix test)
 
   // test for normal trajectory
   ASSERT_NO_THROW_WITH_ERROR_MSG(test_manager->testWithNominalPathWithLaneId(test_target_node));

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_virtual_traffic_light_module/test/test_node_interface.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_virtual_traffic_light_module/test/test_node_interface.cpp
@@ -26,8 +26,13 @@ namespace autoware::behavior_velocity_planner
 TEST(PlanningModuleInterfaceTest, NodeTestWithExceptionPathWithLaneID)
 {
   rclcpp::init(0, nullptr);
+
+  const auto plugin_info_vec = {autoware::behavior_velocity_planner::PluginInfo{
+    "virtual_traffic_light",
+    "autoware::behavior_velocity_planner::VirtualTrafficLightModulePlugin"}};
+
   auto test_manager = autoware::behavior_velocity_planner::generateTestManager();
-  auto test_target_node = autoware::behavior_velocity_planner::generateNode({});
+  auto test_target_node = autoware::behavior_velocity_planner::generateNode(plugin_info_vec);
 
   autoware::behavior_velocity_planner::publishMandatoryTopics(test_manager, test_target_node);
   test_manager->publishVirtualTrafficLightState(


### PR DESCRIPTION
## Description

Currently, the virtual traffic light's variables in the `behavior_velocity_planner/behavior_velocity_planner_common` are very specific to the `behavior_velocity_virtual_traffic_light_module` and do not need to be shared in other modules.
Therefore, this PR moved the implementation related to the virtual traffic light from the `behavior_velocity_planner/behavior_velocity_planner_common` to the `behavior_velocity_virtual_traffic_light_module`.
## Related links


## How was this PR tested?

The unit test passed.
The psim worked as expected.

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
