### PR TITLE
feat(behavior_path_planner): use autoware internal stamped messages

### DIFF
--- a/common/autoware_universe_utils/include/autoware/universe_utils/ros/debug_traits.hpp
+++ b/common/autoware_universe_utils/include/autoware/universe_utils/ros/debug_traits.hpp
@@ -15,6 +15,16 @@
 #ifndef AUTOWARE__UNIVERSE_UTILS__ROS__DEBUG_TRAITS_HPP_
 #define AUTOWARE__UNIVERSE_UTILS__ROS__DEBUG_TRAITS_HPP_
 
+#include <autoware_internal_debug_msgs/msg/bool_stamped.hpp>
+#include <autoware_internal_debug_msgs/msg/float32_multi_array_stamped.hpp>
+#include <autoware_internal_debug_msgs/msg/float32_stamped.hpp>
+#include <autoware_internal_debug_msgs/msg/float64_multi_array_stamped.hpp>
+#include <autoware_internal_debug_msgs/msg/float64_stamped.hpp>
+#include <autoware_internal_debug_msgs/msg/int32_multi_array_stamped.hpp>
+#include <autoware_internal_debug_msgs/msg/int32_stamped.hpp>
+#include <autoware_internal_debug_msgs/msg/int64_multi_array_stamped.hpp>
+#include <autoware_internal_debug_msgs/msg/int64_stamped.hpp>
+#include <autoware_internal_debug_msgs/msg/string_stamped.hpp>
 #include <tier4_debug_msgs/msg/bool_stamped.hpp>
 #include <tier4_debug_msgs/msg/float32_multi_array_stamped.hpp>
 #include <tier4_debug_msgs/msg/float32_stamped.hpp>
@@ -82,6 +92,58 @@ struct is_debug_message<tier4_debug_msgs::msg::Int64Stamped> : std::true_type
 
 template <>
 struct is_debug_message<tier4_debug_msgs::msg::StringStamped> : std::true_type
+{
+};
+
+template <>
+struct is_debug_message<autoware_internal_debug_msgs::msg::BoolStamped> : std::true_type
+{
+};
+
+template <>
+struct is_debug_message<autoware_internal_debug_msgs::msg::Float32MultiArrayStamped>
+: std::true_type
+{
+};
+
+template <>
+struct is_debug_message<autoware_internal_debug_msgs::msg::Float32Stamped> : std::true_type
+{
+};
+
+template <>
+struct is_debug_message<autoware_internal_debug_msgs::msg::Float64MultiArrayStamped>
+: std::true_type
+{
+};
+
+template <>
+struct is_debug_message<autoware_internal_debug_msgs::msg::Float64Stamped> : std::true_type
+{
+};
+
+template <>
+struct is_debug_message<autoware_internal_debug_msgs::msg::Int32MultiArrayStamped> : std::true_type
+{
+};
+
+template <>
+struct is_debug_message<autoware_internal_debug_msgs::msg::Int32Stamped> : std::true_type
+{
+};
+
+template <>
+struct is_debug_message<autoware_internal_debug_msgs::msg::Int64MultiArrayStamped> : std::true_type
+{
+};
+
+template <>
+struct is_debug_message<autoware_internal_debug_msgs::msg::Int64Stamped> : std::true_type
+{
+};
+
+template <>
+struct is_debug_message<autoware_internal_debug_msgs::msg::StringStamped> : std::true_type
 {
 };
 }  // namespace autoware::universe_utils::debug_traits

--- a/common/autoware_universe_utils/package.xml
+++ b/common/autoware_universe_utils/package.xml
@@ -12,6 +12,7 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
+  <depend>autoware_internal_debug_msgs</depend>
   <depend>autoware_internal_msgs</depend>
   <depend>autoware_perception_msgs</depend>
   <depend>autoware_planning_msgs</depend>

--- a/planning/behavior_path_planner/autoware_behavior_path_planner/include/autoware/behavior_path_planner/planner_manager.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner/include/autoware/behavior_path_planner/planner_manager.hpp
@@ -25,6 +25,8 @@
 #include <pluginlib/class_loader.hpp>
 #include <rclcpp/rclcpp.hpp>
 
+#include <autoware_internal_debug_msgs/msg/float64_stamped.hpp>
+#include <autoware_internal_debug_msgs/msg/string_stamped.hpp>
 #include <tier4_planning_msgs/msg/path_with_lane_id.hpp>
 
 #include <lanelet2_core/primitives/Lanelet.h>
@@ -44,8 +46,8 @@ using tier4_planning_msgs::msg::PathWithLaneId;
 using SceneModulePtr = std::shared_ptr<SceneModuleInterface>;
 using SceneModuleManagerPtr = std::shared_ptr<SceneModuleManagerInterface>;
 using DebugPublisher = autoware::universe_utils::DebugPublisher;
-using DebugDoubleMsg = tier4_debug_msgs::msg::Float64Stamped;
-using DebugStringMsg = tier4_debug_msgs::msg::StringStamped;
+using DebugDoubleMsg = autoware_internal_debug_msgs::msg::Float64Stamped;
+using DebugStringMsg = autoware_internal_debug_msgs::msg::StringStamped;
 
 struct SceneModuleUpdateInfo
 {

--- a/planning/behavior_path_planner/autoware_behavior_path_planner/package.xml
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner/package.xml
@@ -40,6 +40,7 @@
   <depend>autoware_behavior_path_planner_common</depend>
   <depend>autoware_freespace_planning_algorithms</depend>
   <depend>autoware_frenet_planner</depend>
+  <depend>autoware_internal_debug_msgs</depend>
   <depend>autoware_interpolation</depend>
   <depend>autoware_lane_departure_checker</depend>
   <depend>autoware_lanelet2_extension</depend>


### PR DESCRIPTION
## Description

Use stamped message in autoware_internal_debug_msgs in behavior_path_planner
## Related links

https://github.com/autowarefoundation/autoware/issues/5580

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
