### PR TITLE
feat(motion_velocity_planner): remove unnecessary tier4_planning_msgs dependency

### DIFF
--- a/planning/motion_velocity_planner/autoware_motion_velocity_dynamic_obstacle_stop_module/package.xml
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_dynamic_obstacle_stop_module/package.xml
@@ -24,7 +24,6 @@
   <depend>pluginlib</depend>
   <depend>rclcpp</depend>
   <depend>tf2</depend>
-  <depend>tier4_planning_msgs</depend>
   <depend>visualization_msgs</depend>
 
   <test_depend>ament_cmake_ros</test_depend>

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_velocity_limiter_module/package.xml
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_velocity_limiter_module/package.xml
@@ -33,7 +33,6 @@
   <depend>sensor_msgs</depend>
   <depend>tf2_eigen</depend>
   <depend>tf2_geometry_msgs</depend>
-  <depend>tier4_planning_msgs</depend>
   <depend>visualization_msgs</depend>
 
   <test_depend>ament_cmake_ros</test_depend>

--- a/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/package.xml
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/package.xml
@@ -29,7 +29,6 @@
   <depend>pluginlib</depend>
   <depend>rclcpp</depend>
   <depend>tf2</depend>
-  <depend>tier4_planning_msgs</depend>
   <depend>visualization_msgs</depend>
 
   <test_depend>ament_cmake_ros</test_depend>

--- a/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/out_of_lane_module.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/src/out_of_lane_module.hpp
@@ -24,8 +24,6 @@
 
 #include <autoware_perception_msgs/msg/predicted_objects.hpp>
 #include <geometry_msgs/msg/pose.hpp>
-#include <tier4_planning_msgs/msg/path_point_with_lane_id.hpp>
-#include <tier4_planning_msgs/msg/path_with_lane_id.hpp>
 
 #include <lanelet2_core/LaneletMap.h>
 

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/include/autoware/motion_velocity_planner_common/planner_data.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/include/autoware/motion_velocity_planner_common/planner_data.hpp
@@ -31,7 +31,6 @@
 #include <nav_msgs/msg/odometry.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
 #include <std_msgs/msg/header.hpp>
-#include <tier4_planning_msgs/msg/velocity_limit.hpp>
 
 #include <lanelet2_core/Forward.h>
 #include <pcl/point_cloud.h>
@@ -72,7 +71,6 @@ struct PlannerData
   // last observed infomation for UNKNOWN
   std::map<lanelet::Id, TrafficSignalStamped> traffic_light_id_map_raw_;
   std::map<lanelet::Id, TrafficSignalStamped> traffic_light_id_map_last_observed_;
-  std::optional<tier4_planning_msgs::msg::VelocityLimit> external_velocity_limit;
 
   // velocity smoother
   std::shared_ptr<autoware::velocity_smoother::SmootherBase> velocity_smoother_;

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/package.xml
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/package.xml
@@ -28,7 +28,6 @@
   <depend>geometry_msgs</depend>
   <depend>libboost-dev</depend>
   <depend>rclcpp</depend>
-  <depend>tier4_planning_msgs</depend>
   <depend>visualization_msgs</depend>
 
   <test_depend>ament_cmake_ros</test_depend>

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_node/package.xml
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_node/package.xml
@@ -39,7 +39,6 @@
   <depend>tf2_geometry_msgs</depend>
   <depend>tf2_ros</depend>
   <depend>tier4_metric_msgs</depend>
-  <depend>tier4_planning_msgs</depend>
   <depend>visualization_msgs</depend>
 
   <exec_depend>rosidl_default_runtime</exec_depend>

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_node/src/node.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_node/src/node.cpp
@@ -357,7 +357,6 @@ autoware::motion_velocity_planner::TrajectoryPoints MotionVelocityPlannerNode::s
   const geometry_msgs::msg::Pose current_pose = planner_data.current_odometry.pose.pose;
   const double v0 = planner_data.current_odometry.twist.twist.linear.x;
   const double a0 = planner_data.current_acceleration.accel.accel.linear.x;
-  const auto & external_v_limit = planner_data.external_velocity_limit;
   const auto & smoother = planner_data.velocity_smoother_;
 
   const auto traj_lateral_acc_filtered =

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_node/src/node.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_node/src/node.cpp
@@ -381,10 +381,6 @@ autoware::motion_velocity_planner::TrajectoryPoints MotionVelocityPlannerNode::s
   if (!smoother->apply(v0, a0, clipped, traj_smoothed, debug_trajectories, false)) {
     RCLCPP_ERROR(get_logger(), "failed to smooth");
   }
-  if (external_v_limit) {
-    autoware::velocity_smoother::trajectory_utils::applyMaximumVelocityLimit(
-      0LU, traj_smoothed.size(), external_v_limit->max_velocity, traj_smoothed);
-  }
   return traj_smoothed;
 }
 


### PR DESCRIPTION
## Description

remove unnecessary tier4_planning_msgs dependency in motion_velocity_planner

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
