### PR TITLE
refactor(behavior_velocity_planner): independent of plugin packages

### DIFF
--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/CMakeLists.txt
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/CMakeLists.txt
@@ -16,6 +16,7 @@ autoware_package()
 ament_auto_add_library(${PROJECT_NAME}_lib SHARED
   src/node.cpp
   src/planner_manager.cpp
+  src/test_utils.cpp
 )
 
 rclcpp_components_register_node(${PROJECT_NAME}_lib
@@ -34,7 +35,7 @@ endif()
 
 if(BUILD_TESTING)
   ament_add_ros_isolated_gtest(test_${PROJECT_NAME}
-    test/src/test_node_interface.cpp
+    test/test_node_interface.cpp
   )
   target_link_libraries(test_${PROJECT_NAME}
     gtest_main

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/include/autoware/behavior_velocity_planner/node.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/include/autoware/behavior_velocity_planner/node.hpp
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef NODE_HPP_
-#define NODE_HPP_
+#ifndef AUTOWARE__BEHAVIOR_VELOCITY_PLANNER__NODE_HPP_
+#define AUTOWARE__BEHAVIOR_VELOCITY_PLANNER__NODE_HPP_
 
+#include "autoware/behavior_velocity_planner/planner_manager.hpp"
 #include "autoware/universe_utils/ros/logger_level_configure.hpp"
 #include "autoware/universe_utils/ros/polling_subscriber.hpp"
-#include "planner_manager.hpp"
 
 #include <autoware/behavior_velocity_planner_common/planner_data.hpp>
 #include <autoware/universe_utils/ros/published_time_publisher.hpp>
@@ -150,4 +150,4 @@ private:
 };
 }  // namespace autoware::behavior_velocity_planner
 
-#endif  // NODE_HPP_
+#endif  // AUTOWARE__BEHAVIOR_VELOCITY_PLANNER__NODE_HPP_

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/include/autoware/behavior_velocity_planner/planner_manager.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/include/autoware/behavior_velocity_planner/planner_manager.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef PLANNER_MANAGER_HPP_
-#define PLANNER_MANAGER_HPP_
+#ifndef AUTOWARE__BEHAVIOR_VELOCITY_PLANNER__PLANNER_MANAGER_HPP_
+#define AUTOWARE__BEHAVIOR_VELOCITY_PLANNER__PLANNER_MANAGER_HPP_
 
 #include <autoware/behavior_velocity_planner_common/plugin_interface.hpp>
 #include <autoware/behavior_velocity_planner_common/plugin_wrapper.hpp>
@@ -57,4 +57,4 @@ private:
 };
 }  // namespace autoware::behavior_velocity_planner
 
-#endif  // PLANNER_MANAGER_HPP_
+#endif  // AUTOWARE__BEHAVIOR_VELOCITY_PLANNER__PLANNER_MANAGER_HPP_

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/include/autoware/behavior_velocity_planner/test_utils.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/include/autoware/behavior_velocity_planner/test_utils.hpp
@@ -1,0 +1,47 @@
+// Copyright 2024 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__BEHAVIOR_VELOCITY_PLANNER__TEST_UTILS_HPP_
+#define AUTOWARE__BEHAVIOR_VELOCITY_PLANNER__TEST_UTILS_HPP_
+
+#include "autoware/behavior_velocity_planner/node.hpp"
+
+#include <autoware_planning_test_manager/autoware_planning_test_manager.hpp>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace autoware::behavior_velocity_planner
+{
+using autoware::behavior_velocity_planner::BehaviorVelocityPlannerNode;
+using autoware::planning_test_manager::PlanningInterfaceTestManager;
+
+struct PluginInfo
+{
+  std::string module_name;  // e.g. crosswalk
+  std::string plugin_name;  // e.g. autoware::behavior_velocity_planner::CrosswalkModulePlugin
+};
+
+std::shared_ptr<PlanningInterfaceTestManager> generateTestManager();
+
+std::shared_ptr<BehaviorVelocityPlannerNode> generateNode(
+  const std::vector<PluginInfo> & plugin_info_vec);
+
+void publishMandatoryTopics(
+  std::shared_ptr<PlanningInterfaceTestManager> test_manager,
+  std::shared_ptr<BehaviorVelocityPlannerNode> test_target_node);
+}  // namespace autoware::behavior_velocity_planner
+
+#endif  // AUTOWARE__BEHAVIOR_VELOCITY_PLANNER__TEST_UTILS_HPP_

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/package.xml
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/package.xml
@@ -64,19 +64,6 @@
 
   <test_depend>ament_cmake_ros</test_depend>
   <test_depend>ament_lint_auto</test_depend>
-  <test_depend>autoware_behavior_velocity_blind_spot_module</test_depend>
-  <test_depend>autoware_behavior_velocity_crosswalk_module</test_depend>
-  <test_depend>autoware_behavior_velocity_detection_area_module</test_depend>
-  <test_depend>autoware_behavior_velocity_intersection_module</test_depend>
-  <test_depend>autoware_behavior_velocity_no_drivable_lane_module</test_depend>
-  <test_depend>autoware_behavior_velocity_no_stopping_area_module</test_depend>
-  <test_depend>autoware_behavior_velocity_occlusion_spot_module</test_depend>
-  <test_depend>autoware_behavior_velocity_run_out_module</test_depend>
-  <test_depend>autoware_behavior_velocity_speed_bump_module</test_depend>
-  <test_depend>autoware_behavior_velocity_stop_line_module</test_depend>
-  <test_depend>autoware_behavior_velocity_traffic_light_module</test_depend>
-  <test_depend>autoware_behavior_velocity_virtual_traffic_light_module</test_depend>
-  <test_depend>autoware_behavior_velocity_walkway_module</test_depend>
   <test_depend>autoware_lint_common</test_depend>
   <!--<test_depend>autoware_behavior_velocity_template_module</test_depend>-->
 

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/src/node.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/src/node.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "node.hpp"
+#include "autoware/behavior_velocity_planner/node.hpp"
 
 #include <autoware/behavior_velocity_planner_common/utilization/path_utilization.hpp>
 #include <autoware/motion_utils/trajectory/path_with_lane_id.hpp>

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/src/planner_manager.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/src/planner_manager.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "planner_manager.hpp"
+#include "autoware/behavior_velocity_planner/planner_manager.hpp"
 
 #include <autoware/motion_utils/trajectory/interpolation.hpp>
 #include <autoware/motion_utils/trajectory/trajectory.hpp>

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/test/test_node_interface.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/test/test_node_interface.cpp
@@ -1,0 +1,61 @@
+// Copyright 2023 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/behavior_velocity_planner/test_utils.hpp"
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace autoware::behavior_velocity_planner
+{
+TEST(PlanningModuleInterfaceTest, NodeTestWithExceptionPathWithLaneID)
+{
+  rclcpp::init(0, nullptr);
+  auto test_manager = autoware::behavior_velocity_planner::generateTestManager();
+  auto test_target_node = autoware::behavior_velocity_planner::generateNode({});
+
+  autoware::behavior_velocity_planner::publishMandatoryTopics(test_manager, test_target_node);
+
+  // test with nominal path_with_lane_id
+  ASSERT_NO_THROW_WITH_ERROR_MSG(test_manager->testWithNominalPathWithLaneId(test_target_node));
+  EXPECT_GE(test_manager->getReceivedTopicNum(), 1);
+
+  // test with empty path_with_lane_id
+  ASSERT_NO_THROW_WITH_ERROR_MSG(test_manager->testWithAbnormalPathWithLaneId(test_target_node));
+  rclcpp::shutdown();
+}
+
+TEST(PlanningModuleInterfaceTest, NodeTestWithOffTrackEgoPose)
+{
+  rclcpp::init(0, nullptr);
+
+  auto test_manager = autoware::behavior_velocity_planner::generateTestManager();
+  auto test_target_node = autoware::behavior_velocity_planner::generateNode({});
+  autoware::behavior_velocity_planner::publishMandatoryTopics(test_manager, test_target_node);
+
+  // test for normal trajectory
+  ASSERT_NO_THROW_WITH_ERROR_MSG(test_manager->testWithNominalPathWithLaneId(test_target_node));
+
+  // make sure behavior_path_planner is running
+  EXPECT_GE(test_manager->getReceivedTopicNum(), 1);
+
+  ASSERT_NO_THROW_WITH_ERROR_MSG(test_manager->testOffTrackFromPathWithLaneId(test_target_node));
+
+  rclcpp::shutdown();
+}
+}  // namespace autoware::behavior_velocity_planner


### PR DESCRIPTION
## Description

Currently, due to the node test, the behavior_velocity_planner depends on the plugin packages, which is unexpected because we introduced the ROS2's pluginlib so that the node will node depend on the plugin packages.

Referring to the the structure of the behavior_path_planner's node test, this PR changed the structure of the behavior_velocity_planner's node test.
https://github.com/autowarefoundation/autoware.universe/blob/main/planning/behavior_path_planner/autoware_behavior_path_planner/test/test_autoware_behavior_path_planner_node_interface.cpp

The node test in the plugin packages will be added by the succeeding PRs.


## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
