### PR TITLE
fix(autoware_pointcloud_preprocessor): fix image display in distortion corrector

### DIFF
--- a/sensing/autoware_pointcloud_preprocessor/docs/distortion-corrector.md
+++ b/sensing/autoware_pointcloud_preprocessor/docs/distortion-corrector.md
@@ -55,16 +55,9 @@ ros2 launch autoware_pointcloud_preprocessor distortion_corrector.launch.xml
   - `hesai`: (x: 90 degrees, y: 0 degrees)
   - `others`: (x: 0 degrees, y: 90 degrees) and (x: 270 degrees, y: 0 degrees)
 
-<table>
-  <tr>
-    <td><img src="./image/velodyne.drawio.png" alt="velodyne azimuth coordinate"></td>
-    <td><img src="./image/hesai.drawio.png" alt="hesai azimuth coordinate"></td>
-   </tr>
-   <tr>
-    <td><p style="text-align: center;">Velodyne azimuth coordinate</p></td>
-    <td><p style="text-align: center;">Hesai azimuth coordinate</p></td>
-  </tr>
-</table>
+| ![Velodyne Azimuth Coordinate](./image/velodyne.drawio.png) | ![Hesai Azimuth Coordinate](./image/hesai.drawio.png) |
+| :---------------------------------------------------------: | :---------------------------------------------------: |
+|               **Velodyne azimuth coordinate**               |             **Hesai azimuth coordinate**              |
 
 ## References/External links
 


### PR DESCRIPTION
## Description
Images were displayed in the HTML table instead of the markdown table.
Which causes the images to fail to display on the Autoware documentation page.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
