### PR TITLE
chore(autoware_multi_object_tracker): fix autoware univserse documentation page

### DIFF
--- a/perception/autoware_multi_object_tracker/README.md
+++ b/perception/autoware_multi_object_tracker/README.md
@@ -69,7 +69,12 @@ Multiple inputs are pre-defined in the input channel parameters (described below
 
 ### Core Parameters
 
+- Node
+
 {{ json_to_markdown("perception/autoware_multi_object_tracker/schema/multi_object_tracker_node.schema.json") }}
+
+- Association
+
 {{ json_to_markdown("perception/autoware_multi_object_tracker/schema/data_association_matrix.schema.json") }}
 
 #### Simulation parameters

--- a/perception/autoware_multi_object_tracker/schema/multi_object_tracker_node.schema.json
+++ b/perception/autoware_multi_object_tracker/schema/multi_object_tracker_node.schema.json
@@ -86,38 +86,45 @@
           "properties": {
             "UNKNOWN": {
               "type": "number",
-              "default": 3
+              "default": 3,
+              "description": "Number of measurements to consider tracker as confident for unknown object classes."
             },
             "CAR": {
               "type": "number",
-              "default": 3
+              "default": 3,
+              "description": "Number of measurements to consider tracker as confident for car object classes."
             },
             "TRUCK": {
               "type": "number",
-              "default": 3
+              "default": 3,
+              "description": "Number of measurements to consider tracker as confident for truck object classes."
             },
             "BUS": {
               "type": "number",
-              "default": 3
+              "default": 3,
+              "description": "Number of measurements to consider tracker as confident for bus object classes."
             },
             "TRAILER": {
               "type": "number",
-              "default": 3
+              "default": 3,
+              "description": "Number of measurements to consider tracker as confident for trailer object classes."
             },
             "MOTORBIKE": {
               "type": "number",
-              "default": 3
+              "default": 3,
+              "description": "Number of measurements to consider tracker as confident for motorbike object classes."
             },
             "BICYCLE": {
               "type": "number",
-              "default": 3
+              "default": 3,
+              "description": "Number of measurements to consider tracker as confident for bicycle object classes."
             },
             "PEDESTRIAN": {
               "type": "number",
-              "default": 3
+              "default": 3,
+              "description": "Number of measurements to consider tracker as confident for pedestrian object classes."
             }
-          },
-          "description": "Number of measurements to consider tracker as confident for different object classes."
+          }
         },
         "publish_processing_time": {
           "type": "boolean",

--- a/perception/autoware_multi_object_tracker/schema/multi_object_tracker_node.schema.json
+++ b/perception/autoware_multi_object_tracker/schema/multi_object_tracker_node.schema.json
@@ -86,43 +86,43 @@
           "properties": {
             "UNKNOWN": {
               "type": "number",
-              "default": 3,
-              "description": "Number of measurements to consider tracker as confident for unknown object classes."
+              "description": "Number of measurements to consider tracker as confident for unknown object classes.",
+              "default": 3
             },
             "CAR": {
               "type": "number",
-              "default": 3,
-              "description": "Number of measurements to consider tracker as confident for car object classes."
+              "description": "Number of measurements to consider tracker as confident for car object classes.",
+              "default": 3
             },
             "TRUCK": {
               "type": "number",
-              "default": 3,
-              "description": "Number of measurements to consider tracker as confident for truck object classes."
+              "description": "Number of measurements to consider tracker as confident for truck object classes.",
+              "default": 3
             },
             "BUS": {
               "type": "number",
-              "default": 3,
-              "description": "Number of measurements to consider tracker as confident for bus object classes."
+              "description": "Number of measurements to consider tracker as confident for bus object classes.",
+              "default": 3
             },
             "TRAILER": {
               "type": "number",
-              "default": 3,
-              "description": "Number of measurements to consider tracker as confident for trailer object classes."
+              "description": "Number of measurements to consider tracker as confident for trailer object classes.",
+              "default": 3
             },
             "MOTORBIKE": {
               "type": "number",
-              "default": 3,
-              "description": "Number of measurements to consider tracker as confident for motorbike object classes."
+              "description": "Number of measurements to consider tracker as confident for motorbike object classes.",
+              "default": 3
             },
             "BICYCLE": {
               "type": "number",
-              "default": 3,
-              "description": "Number of measurements to consider tracker as confident for bicycle object classes."
+              "description": "Number of measurements to consider tracker as confident for bicycle object classes.",
+              "default": 3
             },
             "PEDESTRIAN": {
               "type": "number",
-              "default": 3,
-              "description": "Number of measurements to consider tracker as confident for pedestrian object classes."
+              "description": "Number of measurements to consider tracker as confident for pedestrian object classes.",
+              "default": 3
             }
           }
         },


### PR DESCRIPTION
## Description

Fix error of https://autowarefoundation.github.io/autoware.universe/main/perception/autoware_multi_object_tracker/ 




## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

Documentation generation is confirmed by the following local generation method.

https://autowarefoundation.github.io/autoware-documentation/main/contributing/documentation-guidelines/#2-running-an-mkdocs-server-in-your-local-environment


## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
