### PR TITLE
fix(autoware_motion_velocity_obstacle_velocity_limiter_module): fix bugprone-exception-escape

### DIFF
--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_velocity_limiter_module/benchmarks/collision_checker_benchmark.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_velocity_limiter_module/benchmarks/collision_checker_benchmark.cpp
@@ -55,10 +55,9 @@ polygon_t random_polygon()
 
 int main()
 {
-  Obstacles obstacles;
-  std::vector<polygon_t> polygons;
-
   try {
+    Obstacles obstacles;
+    std::vector<polygon_t> polygons;
     polygons.reserve(100);
     for (auto i = 0; i < 100; ++i) {
       polygons.push_back(random_polygon());

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_velocity_limiter_module/benchmarks/collision_checker_benchmark.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_velocity_limiter_module/benchmarks/collision_checker_benchmark.cpp
@@ -57,43 +57,52 @@ int main()
 {
   Obstacles obstacles;
   std::vector<polygon_t> polygons;
-  polygons.reserve(100);
-  for (auto i = 0; i < 100; ++i) {
-    polygons.push_back(random_polygon());
-  }
-  for (auto nb_lines = 1lu; nb_lines < 1000lu; nb_lines += 10) {
-    obstacles.lines.push_back(random_line());
-    obstacles.points.clear();
-    for (auto nb_points = 1lu; nb_points < 1000lu; nb_points += 10) {
-      obstacles.points.push_back(random_point());
-      const auto rtt_constr_start = std::chrono::system_clock::now();
-      CollisionChecker rtree_collision_checker(obstacles, 0, 0);
-      const auto rtt_constr_end = std::chrono::system_clock::now();
-      const auto naive_constr_start = std::chrono::system_clock::now();
-      CollisionChecker naive_collision_checker(obstacles, nb_points + 1, nb_lines * 100);
-      const auto naive_constr_end = std::chrono::system_clock::now();
-      const auto rtt_check_start = std::chrono::system_clock::now();
-      for (const auto & polygon : polygons)
-        // cppcheck-suppress unreadVariable
-        const auto rtree_result = rtree_collision_checker.intersections(polygon);
-      const auto rtt_check_end = std::chrono::system_clock::now();
-      const auto naive_check_start = std::chrono::system_clock::now();
-      for (const auto & polygon : polygons)
-        // cppcheck-suppress unreadVariable
-        const auto naive_result = naive_collision_checker.intersections(polygon);
-      const auto naive_check_end = std::chrono::system_clock::now();
-      const auto rtt_constr_time =
-        std::chrono::duration_cast<std::chrono::nanoseconds>(rtt_constr_end - rtt_constr_start);
-      const auto naive_constr_time =
-        std::chrono::duration_cast<std::chrono::nanoseconds>(naive_constr_end - naive_constr_start);
-      const auto rtt_check_time =
-        std::chrono::duration_cast<std::chrono::nanoseconds>(rtt_check_end - rtt_check_start);
-      const auto naive_check_time =
-        std::chrono::duration_cast<std::chrono::nanoseconds>(naive_check_end - naive_check_start);
-      std::printf(
-        "%lu, %lu, %ld, %ld, %ld, %ld\n", nb_lines, nb_points, rtt_constr_time.count(),
-        rtt_check_time.count(), naive_constr_time.count(), naive_check_time.count());
+
+  try {
+    polygons.reserve(100);
+    for (auto i = 0; i < 100; ++i) {
+      polygons.push_back(random_polygon());
     }
+    for (auto nb_lines = 1lu; nb_lines < 1000lu; nb_lines += 10) {
+      obstacles.lines.push_back(random_line());
+      obstacles.points.clear();
+      for (auto nb_points = 1lu; nb_points < 1000lu; nb_points += 10) {
+        obstacles.points.push_back(random_point());
+        const auto rtt_constr_start = std::chrono::system_clock::now();
+        CollisionChecker rtree_collision_checker(obstacles, 0, 0);
+        const auto rtt_constr_end = std::chrono::system_clock::now();
+        const auto naive_constr_start = std::chrono::system_clock::now();
+        CollisionChecker naive_collision_checker(obstacles, nb_points + 1, nb_lines * 100);
+        const auto naive_constr_end = std::chrono::system_clock::now();
+        const auto rtt_check_start = std::chrono::system_clock::now();
+        for (const auto & polygon : polygons)
+          // cppcheck-suppress unreadVariable
+          const auto rtree_result = rtree_collision_checker.intersections(polygon);
+        const auto rtt_check_end = std::chrono::system_clock::now();
+        const auto naive_check_start = std::chrono::system_clock::now();
+        for (const auto & polygon : polygons)
+          // cppcheck-suppress unreadVariable
+          const auto naive_result = naive_collision_checker.intersections(polygon);
+        const auto naive_check_end = std::chrono::system_clock::now();
+        const auto rtt_constr_time =
+          std::chrono::duration_cast<std::chrono::nanoseconds>(rtt_constr_end - rtt_constr_start);
+        const auto naive_constr_time = std::chrono::duration_cast<std::chrono::nanoseconds>(
+          naive_constr_end - naive_constr_start);
+        const auto rtt_check_time =
+          std::chrono::duration_cast<std::chrono::nanoseconds>(rtt_check_end - rtt_check_start);
+        const auto naive_check_time =
+          std::chrono::duration_cast<std::chrono::nanoseconds>(naive_check_end - naive_check_start);
+        std::printf(
+          "%lu, %lu, %ld, %ld, %ld, %ld\n", nb_lines, nb_points, rtt_constr_time.count(),
+          rtt_check_time.count(), naive_constr_time.count(), naive_check_time.count());
+      }
+    }
+  } catch (const std::exception & e) {
+    std::cerr << "Exception in main(): " << e.what() << std::endl;
+    return {};
+  } catch (...) {
+    std::cerr << "Unknown exception in main()" << std::endl;
+    return {};
   }
   return 0;
 }

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_velocity_limiter_module/benchmarks/collision_checker_benchmark.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_velocity_limiter_module/benchmarks/collision_checker_benchmark.cpp
@@ -16,6 +16,7 @@
 #include "../src/types.hpp"
 
 #include <chrono>
+#include <iostream>
 #include <random>
 #include <vector>
 


### PR DESCRIPTION
## Description
This is a fix based on clang-tidy `bugprone-exception-escape` error.

```
/home/emb4/autoware/autoware/src/universe/autoware.universe/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_velocity_limiter_module/benchmarks/collision_checker_benchmark.cpp:56:5: error: an exception may be thrown in function 'main' which should not throw exceptions [bugprone-exception-escape,-warnings-as-errors]
int main()
    ^
```
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
