### PR TITLE
fix(autoware_processing_time_checker): fix bugprone-exception-escape

### DIFF
--- a/system/autoware_processing_time_checker/src/processing_time_checker.cpp
+++ b/system/autoware_processing_time_checker/src/processing_time_checker.cpp
@@ -103,45 +103,51 @@ ProcessingTimeChecker::~ProcessingTimeChecker()
     return;
   }
 
-  // generate json data
-  nlohmann::json j;
-  for (const auto & accumulator_iterator : processing_time_accumulator_map_) {
-    const auto module_name = accumulator_iterator.first;
-    const auto processing_time_accumulator = accumulator_iterator.second;
-    j[module_name + "/min"] = processing_time_accumulator.min();
-    j[module_name + "/max"] = processing_time_accumulator.max();
-    j[module_name + "/mean"] = processing_time_accumulator.mean();
-    j[module_name + "/count"] = processing_time_accumulator.count();
-    j[module_name + "/description"] = "processing time of " + module_name + "[ms]";
-  }
-
-  // get output folder
-  const std::string output_folder_str =
-    rclcpp::get_logging_directory().string() + "/autoware_metrics";
-  if (!std::filesystem::exists(output_folder_str)) {
-    if (!std::filesystem::create_directories(output_folder_str)) {
-      RCLCPP_ERROR(
-        this->get_logger(), "Failed to create directories: %s", output_folder_str.c_str());
-      return;
+  try {
+    // generate json data
+    nlohmann::json j;
+    for (const auto & accumulator_iterator : processing_time_accumulator_map_) {
+      const auto module_name = accumulator_iterator.first;
+      const auto processing_time_accumulator = accumulator_iterator.second;
+      j[module_name + "/min"] = processing_time_accumulator.min();
+      j[module_name + "/max"] = processing_time_accumulator.max();
+      j[module_name + "/mean"] = processing_time_accumulator.mean();
+      j[module_name + "/count"] = processing_time_accumulator.count();
+      j[module_name + "/description"] = "processing time of " + module_name + "[ms]";
     }
-  }
 
-  // get time stamp
-  std::time_t now_time_t = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
-  std::tm * local_time = std::localtime(&now_time_t);
-  std::ostringstream oss;
-  oss << std::put_time(local_time, "%Y-%m-%d-%H-%M-%S");
-  std::string cur_time_str = oss.str();
+    // get output folder
+    const std::string output_folder_str =
+      rclcpp::get_logging_directory().string() + "/autoware_metrics";
+    if (!std::filesystem::exists(output_folder_str)) {
+      if (!std::filesystem::create_directories(output_folder_str)) {
+        RCLCPP_ERROR(
+          this->get_logger(), "Failed to create directories: %s", output_folder_str.c_str());
+        return;
+      }
+    }
 
-  // Write metrics .json to file
-  const std::string output_file_str =
-    output_folder_str + "/autoware_processing_time_checker-" + cur_time_str + ".json";
-  std::ofstream f(output_file_str);
-  if (f.is_open()) {
-    f << j.dump(4);
-    f.close();
-  } else {
-    RCLCPP_ERROR(this->get_logger(), "Failed to open file: %s", output_file_str.c_str());
+    // get time stamp
+    std::time_t now_time_t = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
+    std::tm * local_time = std::localtime(&now_time_t);
+    std::ostringstream oss;
+    oss << std::put_time(local_time, "%Y-%m-%d-%H-%M-%S");
+    std::string cur_time_str = oss.str();
+
+    // Write metrics .json to file
+    const std::string output_file_str =
+      output_folder_str + "/autoware_processing_time_checker-" + cur_time_str + ".json";
+    std::ofstream f(output_file_str);
+    if (f.is_open()) {
+      f << j.dump(4);
+      f.close();
+    } else {
+      RCLCPP_ERROR(this->get_logger(), "Failed to open file: %s", output_file_str.c_str());
+    }
+  } catch (const std::exception & e) {
+    std::cerr << "Exception in ProcessingTimeChecker: " << e.what() << std::endl;
+  } catch (...) {
+    std::cerr << "Unknown exception in ProcessingTimeChecker" << std::endl;
   }
 }
 

--- a/system/autoware_processing_time_checker/src/processing_time_checker.cpp
+++ b/system/autoware_processing_time_checker/src/processing_time_checker.cpp
@@ -20,6 +20,7 @@
 #include <chrono>
 #include <filesystem>
 #include <fstream>
+#include <iostream>
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
## Description
This is a fix based on clang-tidy `bugprone-exception-escape` error.

```
/home/emb4/autoware/autoware/src/universe/autoware.universe/system/autoware_processing_time_checker/src/processing_time_checker.cpp:100:24: error: an exception may be thrown in function '~ProcessingTimeChecker' which should not throw exceptions [bugprone-exception-escape,-warnings-as-errors]
ProcessingTimeChecker::~ProcessingTimeChecker()
                       ^
```
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
