### PR TITLE
feat(goal_planner): update lateral_deviation_thresh from 0.3 to 0.1

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/goal_planner_module.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/goal_planner_module.cpp
@@ -155,7 +155,7 @@ bool hasPreviousModulePathShapeChanged(
 {
   // Calculate the lateral distance between each point of the current path and the nearest point of
   // the last path
-  constexpr double LATERAL_DEVIATION_THRESH = 0.3;
+  constexpr double LATERAL_DEVIATION_THRESH = 0.1;
   for (const auto & p : previous_module_output.path.points) {
     const size_t nearest_seg_idx = autoware::motion_utils::findNearestSegmentIndex(
       last_previous_module_output.path.points, p.point.pose.position);
@@ -189,13 +189,13 @@ bool hasDeviatedFromLastPreviousModulePath(
 {
   return std::abs(autoware::motion_utils::calcLateralOffset(
            last_previous_module_output.path.points,
-           planner_data.self_odometry->pose.pose.position)) > 0.3;
+           planner_data.self_odometry->pose.pose.position)) > 0.1;
 }
 
 bool hasDeviatedFromCurrentPreviousModulePath(
   const PlannerData & planner_data, const BehaviorModuleOutput & previous_module_output)
 {
-  constexpr double LATERAL_DEVIATION_THRESH = 0.3;
+  constexpr double LATERAL_DEVIATION_THRESH = 0.1;
   return std::abs(autoware::motion_utils::calcLateralOffset(
            previous_module_output.path.points, planner_data.self_odometry->pose.pose.position)) >
          LATERAL_DEVIATION_THRESH;


### PR DESCRIPTION
## Description

Update lateral_deviation_threash from 0.3 to 0.1 to reduce the lateral displacement of the lane.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [TIER IV internal link](https://star4.slack.com/archives/C03QW0GU6P7/p1735017323758679?thread_ts=1735016349.347359&cid=C03QW0GU6P7)
⬆️🟢 -->

## How was this PR tested?

[TIER IV internal scenario test](https://evaluation.tier4.jp/evaluation/reports/029c10e7-9925-50a1-af7b-d69763c60f61/tests/6e60b703-21fd-5f93-bd7b-c8dfde95ce8a/7a2dc1c4-44b6-5d74-aab7-f7ba939d771a/b5c21f3d-a6ef-55c9-9578-218fd4a8ac17?failure_cause_labels=ConditionFailure%3AUserDefinedValueCondition%3Amax%2CConditionFailure%3AUserDefinedValueCondition%3Amean&project_id=prd_jt&state=failed)

### Before

### After


## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
