### PR TITLE
refactor(autoware_behavior_path_start_planner_module): move planner_data to method parameter

### DIFF
--- a/control/autoware_lane_departure_checker/CMakeLists.txt
+++ b/control/autoware_lane_departure_checker/CMakeLists.txt
@@ -14,6 +14,7 @@ ament_auto_add_library(autoware_lane_departure_checker SHARED
   src/lane_departure_checker_node/lane_departure_checker.cpp
   src/lane_departure_checker_node/lane_departure_checker_node.cpp
   src/lane_departure_checker_node/utils.cpp
+  src/lane_departure_checker_node/parameters.cpp
 )
 
 rclcpp_components_register_node(${PROJECT_NAME}

--- a/control/autoware_lane_departure_checker/include/autoware/lane_departure_checker/lane_departure_checker.hpp
+++ b/control/autoware_lane_departure_checker/include/autoware/lane_departure_checker/lane_departure_checker.hpp
@@ -15,15 +15,12 @@
 #ifndef AUTOWARE__LANE_DEPARTURE_CHECKER__LANE_DEPARTURE_CHECKER_HPP_
 #define AUTOWARE__LANE_DEPARTURE_CHECKER__LANE_DEPARTURE_CHECKER_HPP_
 
-#include <autoware/universe_utils/geometry/boost_geometry.hpp>
-#include <autoware/universe_utils/geometry/pose_deviation.hpp>
+#include "autoware/lane_departure_checker/parameters.hpp"
+
 #include <autoware/universe_utils/system/time_keeper.hpp>
 #include <autoware_vehicle_info_utils/vehicle_info_utils.hpp>
 #include <rosidl_runtime_cpp/message_initialization.hpp>
 
-#include <autoware_planning_msgs/msg/lanelet_route.hpp>
-#include <autoware_planning_msgs/msg/trajectory.hpp>
-#include <autoware_planning_msgs/msg/trajectory_point.hpp>
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <geometry_msgs/msg/pose_with_covariance_stamped.hpp>
 #include <geometry_msgs/msg/twist_stamped.hpp>
@@ -48,80 +45,32 @@
 
 namespace autoware::lane_departure_checker
 {
-using autoware::universe_utils::LinearRing2d;
-using autoware::universe_utils::PoseDeviation;
 using autoware::universe_utils::Segment2d;
-using autoware_planning_msgs::msg::LaneletRoute;
-using autoware_planning_msgs::msg::Trajectory;
-using autoware_planning_msgs::msg::TrajectoryPoint;
 using tier4_planning_msgs::msg::PathWithLaneId;
-using TrajectoryPoints = std::vector<TrajectoryPoint>;
 typedef boost::geometry::index::rtree<Segment2d, boost::geometry::index::rstar<16>> SegmentRtree;
-
-struct Param
-{
-  double footprint_margin_scale{0.0};
-  double footprint_extra_margin{0.0};
-  double resample_interval{0.0};
-  double max_deceleration{0.0};
-  double delay_time{0.0};
-  double max_lateral_deviation{0.0};
-  double max_longitudinal_deviation{0.0};
-  double max_yaw_deviation_deg{0.0};
-  double min_braking_distance{0.0};
-  // nearest search to ego
-  double ego_nearest_dist_threshold{0.0};
-  double ego_nearest_yaw_threshold{0.0};
-};
-
-struct Input
-{
-  nav_msgs::msg::Odometry::ConstSharedPtr current_odom{};
-  lanelet::LaneletMapPtr lanelet_map{};
-  LaneletRoute::ConstSharedPtr route{};
-  lanelet::ConstLanelets route_lanelets{};
-  lanelet::ConstLanelets shoulder_lanelets{};
-  Trajectory::ConstSharedPtr reference_trajectory{};
-  Trajectory::ConstSharedPtr predicted_trajectory{};
-  std::vector<std::string> boundary_types_to_detect{};
-};
-
-struct Output
-{
-  std::map<std::string, double> processing_time_map{};
-  bool will_leave_lane{};
-  bool is_out_of_lane{};
-  bool will_cross_boundary{};
-  PoseDeviation trajectory_deviation{};
-  lanelet::ConstLanelets candidate_lanelets{};
-  TrajectoryPoints resampled_trajectory{};
-  std::vector<LinearRing2d> vehicle_footprints{};
-  std::vector<LinearRing2d> vehicle_passing_areas{};
-};
 
 class LaneDepartureChecker
 {
 public:
-  LaneDepartureChecker(
+  explicit LaneDepartureChecker(
     std::shared_ptr<universe_utils::TimeKeeper> time_keeper =
       std::make_shared<universe_utils::TimeKeeper>())
   : time_keeper_(time_keeper)
   {
   }
+
+  LaneDepartureChecker(
+    const Param & param, const autoware::vehicle_info_utils::VehicleInfo & vehicle_info,
+    std::shared_ptr<universe_utils::TimeKeeper> time_keeper =
+      std::make_shared<universe_utils::TimeKeeper>())
+  : param_(param),
+    vehicle_info_ptr_(std::make_shared<autoware::vehicle_info_utils::VehicleInfo>(vehicle_info)),
+    time_keeper_(time_keeper)
+  {
+  }
   Output update(const Input & input);
 
-  void setParam(const Param & param, const autoware::vehicle_info_utils::VehicleInfo vehicle_info)
-  {
-    param_ = param;
-    vehicle_info_ptr_ = std::make_shared<autoware::vehicle_info_utils::VehicleInfo>(vehicle_info);
-  }
-
   void setParam(const Param & param) { param_ = param; }
-
-  void setVehicleInfo(const autoware::vehicle_info_utils::VehicleInfo vehicle_info)
-  {
-    vehicle_info_ptr_ = std::make_shared<autoware::vehicle_info_utils::VehicleInfo>(vehicle_info);
-  }
 
   bool checkPathWillLeaveLane(
     const lanelet::ConstLanelets & lanelets, const PathWithLaneId & path) const;

--- a/control/autoware_lane_departure_checker/include/autoware/lane_departure_checker/lane_departure_checker_node.hpp
+++ b/control/autoware_lane_departure_checker/include/autoware/lane_departure_checker/lane_departure_checker_node.hpp
@@ -16,6 +16,7 @@
 #define AUTOWARE__LANE_DEPARTURE_CHECKER__LANE_DEPARTURE_CHECKER_NODE_HPP_
 
 #include "autoware/lane_departure_checker/lane_departure_checker.hpp"
+#include "autoware/lane_departure_checker/parameters.hpp"
 #include "autoware/universe_utils/ros/polling_subscriber.hpp"
 
 #include <autoware/universe_utils/ros/debug_publisher.hpp>
@@ -46,21 +47,6 @@
 namespace autoware::lane_departure_checker
 {
 using autoware_map_msgs::msg::LaneletMapBin;
-
-struct NodeParam
-{
-  bool will_out_of_lane_checker;
-  bool out_of_lane_checker;
-  bool boundary_departure_checker;
-
-  double update_rate;
-  bool visualize_lanelet;
-  bool include_right_lanes;
-  bool include_left_lanes;
-  bool include_opposite_lanes;
-  bool include_conflicting_lanes;
-  std::vector<std::string> boundary_types_to_detect;
-};
 
 class LaneDepartureCheckerNode : public rclcpp::Node
 {

--- a/control/autoware_lane_departure_checker/include/autoware/lane_departure_checker/parameters.hpp
+++ b/control/autoware_lane_departure_checker/include/autoware/lane_departure_checker/parameters.hpp
@@ -1,0 +1,101 @@
+// Copyright 2024 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__LANE_DEPARTURE_CHECKER__PARAMETERS_HPP_
+#define AUTOWARE__LANE_DEPARTURE_CHECKER__PARAMETERS_HPP_
+
+#include <autoware/universe_utils/geometry/boost_geometry.hpp>
+#include <autoware/universe_utils/geometry/pose_deviation.hpp>
+#include <rclcpp/node.hpp>
+
+#include <autoware_planning_msgs/msg/lanelet_route.hpp>
+#include <autoware_planning_msgs/msg/trajectory.hpp>
+#include <autoware_planning_msgs/msg/trajectory_point.hpp>
+#include <nav_msgs/msg/odometry.hpp>
+
+#include <lanelet2_core/LaneletMap.h>
+
+#include <map>
+#include <string>
+#include <vector>
+
+namespace autoware::lane_departure_checker
+{
+using autoware::universe_utils::PoseDeviation;
+using autoware_planning_msgs::msg::LaneletRoute;
+using autoware_planning_msgs::msg::Trajectory;
+using autoware_planning_msgs::msg::TrajectoryPoint;
+using TrajectoryPoints = std::vector<TrajectoryPoint>;
+using autoware::universe_utils::LinearRing2d;
+
+struct Param
+{
+  static Param init(rclcpp::Node & node);
+  double footprint_margin_scale{};
+  double footprint_extra_margin{};
+  double resample_interval{};
+  double max_deceleration{};
+  double delay_time{};
+  double max_lateral_deviation{};
+  double max_longitudinal_deviation{};
+  double max_yaw_deviation_deg{};
+  double min_braking_distance{};
+  // nearest search to ego
+  double ego_nearest_dist_threshold{};
+  double ego_nearest_yaw_threshold{};
+};
+
+struct NodeParam
+{
+  static NodeParam init(rclcpp::Node & node);
+  bool will_out_of_lane_checker{};
+  bool out_of_lane_checker{};
+  bool boundary_departure_checker{};
+
+  double update_rate{};
+  bool visualize_lanelet{};
+  bool include_right_lanes{};
+  bool include_left_lanes{};
+  bool include_opposite_lanes{};
+  bool include_conflicting_lanes{};
+  std::vector<std::string> boundary_types_to_detect{};
+};
+
+struct Input
+{
+  nav_msgs::msg::Odometry::ConstSharedPtr current_odom{};
+  lanelet::LaneletMapPtr lanelet_map{};
+  LaneletRoute::ConstSharedPtr route{};
+  lanelet::ConstLanelets route_lanelets{};
+  lanelet::ConstLanelets shoulder_lanelets{};
+  Trajectory::ConstSharedPtr reference_trajectory{};
+  Trajectory::ConstSharedPtr predicted_trajectory{};
+  std::vector<std::string> boundary_types_to_detect{};
+};
+
+struct Output
+{
+  std::map<std::string, double> processing_time_map{};
+  bool will_leave_lane{};
+  bool is_out_of_lane{};
+  bool will_cross_boundary{};
+  PoseDeviation trajectory_deviation{};
+  lanelet::ConstLanelets candidate_lanelets{};
+  TrajectoryPoints resampled_trajectory{};
+  std::vector<LinearRing2d> vehicle_footprints{};
+  std::vector<LinearRing2d> vehicle_passing_areas{};
+};
+}  // namespace autoware::lane_departure_checker
+
+#endif  // AUTOWARE__LANE_DEPARTURE_CHECKER__PARAMETERS_HPP_

--- a/control/autoware_lane_departure_checker/src/lane_departure_checker_node/lane_departure_checker_node.cpp
+++ b/control/autoware_lane_departure_checker/src/lane_departure_checker_node/lane_departure_checker_node.cpp
@@ -126,48 +126,19 @@ LaneDepartureCheckerNode::LaneDepartureCheckerNode(const rclcpp::NodeOptions & o
 : Node("lane_departure_checker_node", options)
 {
   using std::placeholders::_1;
-
-  // Enable feature
-  node_param_.will_out_of_lane_checker = declare_parameter<bool>("will_out_of_lane_checker");
-  node_param_.out_of_lane_checker = declare_parameter<bool>("out_of_lane_checker");
-  node_param_.boundary_departure_checker = declare_parameter<bool>("boundary_departure_checker");
-
-  // Node Parameter
-  node_param_.update_rate = declare_parameter<double>("update_rate");
-  node_param_.visualize_lanelet = declare_parameter<bool>("visualize_lanelet");
-  node_param_.include_right_lanes = declare_parameter<bool>("include_right_lanes");
-  node_param_.include_left_lanes = declare_parameter<bool>("include_left_lanes");
-  node_param_.include_opposite_lanes = declare_parameter<bool>("include_opposite_lanes");
-  node_param_.include_conflicting_lanes = declare_parameter<bool>("include_conflicting_lanes");
-
-  // Boundary_departure_checker
-  node_param_.boundary_types_to_detect =
-    declare_parameter<std::vector<std::string>>("boundary_types_to_detect");
+  node_param_ = NodeParam::init(*this);
+  param_ = Param::init(*this);
 
   // Vehicle Info
   const auto vehicle_info = autoware::vehicle_info_utils::VehicleInfoUtils(*this).getVehicleInfo();
   vehicle_length_m_ = vehicle_info.vehicle_length_m;
-
-  // Core Parameter
-  param_.footprint_margin_scale = declare_parameter<double>("footprint_margin_scale");
-  param_.footprint_extra_margin = declare_parameter<double>("footprint_extra_margin");
-  param_.resample_interval = declare_parameter<double>("resample_interval");
-  param_.max_deceleration = declare_parameter<double>("max_deceleration");
-  param_.delay_time = declare_parameter<double>("delay_time");
-  param_.max_lateral_deviation = declare_parameter<double>("max_lateral_deviation");
-  param_.max_longitudinal_deviation = declare_parameter<double>("max_longitudinal_deviation");
-  param_.max_yaw_deviation_deg = declare_parameter<double>("max_yaw_deviation_deg");
-  param_.ego_nearest_dist_threshold = declare_parameter<double>("ego_nearest_dist_threshold");
-  param_.ego_nearest_yaw_threshold = declare_parameter<double>("ego_nearest_yaw_threshold");
-  param_.min_braking_distance = declare_parameter<double>("min_braking_distance");
 
   // Parameter Callback
   set_param_res_ =
     add_on_set_parameters_callback(std::bind(&LaneDepartureCheckerNode::onParameter, this, _1));
 
   // Core
-  lane_departure_checker_ = std::make_unique<LaneDepartureChecker>();
-  lane_departure_checker_->setParam(param_, vehicle_info);
+  lane_departure_checker_ = std::make_unique<LaneDepartureChecker>(param_, vehicle_info);
 
   // Publisher
   processing_time_publisher_ =

--- a/control/autoware_lane_departure_checker/src/lane_departure_checker_node/parameters.cpp
+++ b/control/autoware_lane_departure_checker/src/lane_departure_checker_node/parameters.cpp
@@ -1,0 +1,59 @@
+// Copyright 2024 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/lane_departure_checker/parameters.hpp"
+
+#include <autoware/universe_utils/ros/parameter.hpp>
+#include <rclcpp/node.hpp>
+
+#include <string>
+
+namespace autoware::lane_departure_checker
+{
+using autoware::universe_utils::getOrDeclareParameter;
+
+Param Param::init(rclcpp::Node & node)
+{
+  Param p;
+  p.footprint_margin_scale = getOrDeclareParameter<double>(node, "footprint_margin_scale");
+  p.footprint_extra_margin = getOrDeclareParameter<double>(node, "footprint_extra_margin");
+  p.resample_interval = getOrDeclareParameter<double>(node, "resample_interval");
+  p.max_deceleration = getOrDeclareParameter<double>(node, "max_deceleration");
+  p.delay_time = getOrDeclareParameter<double>(node, "delay_time");
+  p.max_lateral_deviation = getOrDeclareParameter<double>(node, "max_lateral_deviation");
+  p.max_longitudinal_deviation = getOrDeclareParameter<double>(node, "max_longitudinal_deviation");
+  p.max_yaw_deviation_deg = getOrDeclareParameter<double>(node, "max_yaw_deviation_deg");
+  p.min_braking_distance = getOrDeclareParameter<double>(node, "min_braking_distance");
+  p.ego_nearest_dist_threshold = getOrDeclareParameter<double>(node, "ego_nearest_dist_threshold");
+  p.ego_nearest_yaw_threshold = getOrDeclareParameter<double>(node, "ego_nearest_yaw_threshold");
+  return p;
+}
+
+NodeParam NodeParam::init(rclcpp::Node & node)
+{
+  NodeParam p;
+  p.will_out_of_lane_checker = getOrDeclareParameter<bool>(node, "will_out_of_lane_checker");
+  p.out_of_lane_checker = getOrDeclareParameter<bool>(node, "out_of_lane_checker");
+  p.boundary_departure_checker = getOrDeclareParameter<bool>(node, "boundary_departure_checker");
+  p.update_rate = getOrDeclareParameter<double>(node, "update_rate");
+  p.visualize_lanelet = getOrDeclareParameter<bool>(node, "visualize_lanelet");
+  p.include_right_lanes = getOrDeclareParameter<bool>(node, "include_right_lanes");
+  p.include_left_lanes = getOrDeclareParameter<bool>(node, "include_left_lanes");
+  p.include_opposite_lanes = getOrDeclareParameter<bool>(node, "include_opposite_lanes");
+  p.include_conflicting_lanes = getOrDeclareParameter<bool>(node, "include_conflicting_lanes");
+  p.boundary_types_to_detect =
+    getOrDeclareParameter<std::vector<std::string>>(node, "boundary_types_to_detect");
+  return p;
+}
+}  // namespace autoware::lane_departure_checker

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/examples/plot_map_case1.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/examples/plot_map_case1.cpp
@@ -564,13 +564,12 @@ int main(int argc, char ** argv)
       node.get(), "goal_planner.");
   goal_planner_parameter.bus_stop_area.use_bus_stop_area = true;
   goal_planner_parameter.lane_departure_check_expansion_margin = 0.2;
-  const auto vehicle_info = autoware::vehicle_info_utils::VehicleInfoUtils(*node).getVehicleInfo();
-  autoware::lane_departure_checker::LaneDepartureChecker lane_departure_checker{};
-  lane_departure_checker.setVehicleInfo(vehicle_info);
   autoware::lane_departure_checker::Param lane_departure_checker_params;
   lane_departure_checker_params.footprint_extra_margin =
     goal_planner_parameter.lane_departure_check_expansion_margin;
-  lane_departure_checker.setParam(lane_departure_checker_params);
+  autoware::lane_departure_checker::LaneDepartureChecker lane_departure_checker(
+    lane_departure_checker_params, vehicle_info);
+
   const auto footprint = vehicle_info.createFootprint();
   autoware::behavior_path_planner::GoalSearcher goal_searcher(goal_planner_parameter, footprint);
   auto goal_candidates = goal_searcher.search(planner_data);

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/examples/plot_map_case2.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/examples/plot_map_case2.cpp
@@ -573,12 +573,11 @@ int main(int argc, char ** argv)
     autoware::behavior_path_planner::GoalPlannerModuleManager::initGoalPlannerParameters(
       node.get(), "goal_planner.");
   const auto vehicle_info = autoware::vehicle_info_utils::VehicleInfoUtils(*node).getVehicleInfo();
-  autoware::lane_departure_checker::LaneDepartureChecker lane_departure_checker{};
-  lane_departure_checker.setVehicleInfo(vehicle_info);
   autoware::lane_departure_checker::Param lane_departure_checker_params;
   lane_departure_checker_params.footprint_extra_margin =
     goal_planner_parameter.lane_departure_check_expansion_margin;
-  lane_departure_checker.setParam(lane_departure_checker_params);
+  autoware::lane_departure_checker::LaneDepartureChecker lane_departure_checker(
+    lane_departure_checker_params, vehicle_info);
   const auto footprint = vehicle_info.createFootprint();
   autoware::behavior_path_planner::GoalSearcher goal_searcher(goal_planner_parameter, footprint);
   auto goal_candidates = goal_searcher.search(planner_data);

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/goal_planner_module.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/goal_planner_module.cpp
@@ -290,12 +290,10 @@ LaneParkingPlanner::LaneParkingPlanner(
   logger_(logger)
 {
   const auto vehicle_info = autoware::vehicle_info_utils::VehicleInfoUtils(node).getVehicleInfo();
-  LaneDepartureChecker lane_departure_checker{};
-  lane_departure_checker.setVehicleInfo(vehicle_info);
   lane_departure_checker::Param lane_departure_checker_params;
   lane_departure_checker_params.footprint_extra_margin =
     parameters.lane_departure_check_expansion_margin;
-  lane_departure_checker.setParam(lane_departure_checker_params);
+  LaneDepartureChecker lane_departure_checker(lane_departure_checker_params, vehicle_info);
 
   for (const std::string & planner_type : parameters.efficient_path_order) {
     if (planner_type == "SHIFT" && parameters.enable_shift_parking) {

--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/include/autoware/behavior_path_start_planner_module/freespace_pull_out.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/include/autoware/behavior_path_start_planner_module/freespace_pull_out.hpp
@@ -35,10 +35,7 @@ using autoware::freespace_planning_algorithms::RRTStar;
 class FreespacePullOut : public PullOutPlannerBase
 {
 public:
-  FreespacePullOut(
-    rclcpp::Node & node, const StartPlannerParameters & parameters,
-    const autoware::vehicle_info_utils::VehicleInfo & vehicle_info,
-    std::shared_ptr<universe_utils::TimeKeeper> time_keeper);
+  FreespacePullOut(rclcpp::Node & node, const StartPlannerParameters & parameters);
 
   PlannerType getPlannerType() const override { return PlannerType::FREESPACE; }
 

--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/include/autoware/behavior_path_start_planner_module/freespace_pull_out.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/include/autoware/behavior_path_start_planner_module/freespace_pull_out.hpp
@@ -43,7 +43,9 @@ public:
   PlannerType getPlannerType() const override { return PlannerType::FREESPACE; }
 
   std::optional<PullOutPath> plan(
-    const Pose & start_pose, const Pose & end_pose, PlannerDebugData & planner_debug_data) override;
+    const Pose & start_pose, const Pose & end_pose,
+    const std::shared_ptr<const PlannerData> & planner_data,
+    PlannerDebugData & planner_debug_data) override;
 
 protected:
   std::unique_ptr<AbstractPlanningAlgorithm> planner_;

--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/include/autoware/behavior_path_start_planner_module/geometric_pull_out.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/include/autoware/behavior_path_start_planner_module/geometric_pull_out.hpp
@@ -40,6 +40,7 @@ public:
   PlannerType getPlannerType() const override { return PlannerType::GEOMETRIC; };
   std::optional<PullOutPath> plan(
     const Pose & start_pose, const Pose & goal_pose,
+    const std::shared_ptr<const PlannerData> & planner_data,
     PlannerDebugData & planner_debug_data) override;
 
   GeometricParallelParking planner_;

--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/include/autoware/behavior_path_start_planner_module/geometric_pull_out.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/include/autoware/behavior_path_start_planner_module/geometric_pull_out.hpp
@@ -35,7 +35,8 @@ public:
     rclcpp::Node & node, const StartPlannerParameters & parameters,
     const std::shared_ptr<autoware::lane_departure_checker::LaneDepartureChecker>
       lane_departure_checker,
-    std::shared_ptr<universe_utils::TimeKeeper> time_keeper);
+    std::shared_ptr<universe_utils::TimeKeeper> time_keeper =
+      std::make_shared<universe_utils::TimeKeeper>());
 
   PlannerType getPlannerType() const override { return PlannerType::GEOMETRIC; };
   std::optional<PullOutPath> plan(

--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/include/autoware/behavior_path_start_planner_module/pull_out_planner_base.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/include/autoware/behavior_path_start_planner_module/pull_out_planner_base.hpp
@@ -41,18 +41,13 @@ public:
   explicit PullOutPlannerBase(
     rclcpp::Node & node, const StartPlannerParameters & parameters,
     std::shared_ptr<universe_utils::TimeKeeper> time_keeper)
-  : time_keeper_(time_keeper)
+  : vehicle_info_{autoware::vehicle_info_utils::VehicleInfoUtils(node).getVehicleInfo()},
+    vehicle_footprint_{vehicle_info_.createFootprint()},
+    parameters_{parameters},
+    time_keeper_(time_keeper)
   {
-    vehicle_info_ = autoware::vehicle_info_utils::VehicleInfoUtils(node).getVehicleInfo();
-    vehicle_footprint_ = vehicle_info_.createFootprint();
-    parameters_ = parameters;
   }
   virtual ~PullOutPlannerBase() = default;
-
-  void setPlannerData(const std::shared_ptr<const PlannerData> & planner_data)
-  {
-    planner_data_ = planner_data;
-  }
 
   void setCollisionCheckMargin(const double collision_check_margin)
   {
@@ -60,14 +55,16 @@ public:
   };
   virtual PlannerType getPlannerType() const = 0;
   virtual std::optional<PullOutPath> plan(
-    const Pose & start_pose, const Pose & goal_pose, PlannerDebugData & planner_debug_data) = 0;
+    const Pose & start_pose, const Pose & goal_pose,
+    const std::shared_ptr<const PlannerData> & planner_data,
+    PlannerDebugData & planner_debug_data) = 0;
 
 protected:
   bool isPullOutPathCollided(
     autoware::behavior_path_planner::PullOutPath & pull_out_path,
+    const std::shared_ptr<const PlannerData> & planner_data,
     double collision_check_distance_from_end) const;
 
-  std::shared_ptr<const PlannerData> planner_data_;
   autoware::vehicle_info_utils::VehicleInfo vehicle_info_;
   LinearRing2d vehicle_footprint_;
   StartPlannerParameters parameters_;

--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/include/autoware/behavior_path_start_planner_module/pull_out_planner_base.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/include/autoware/behavior_path_start_planner_module/pull_out_planner_base.hpp
@@ -40,10 +40,11 @@ class PullOutPlannerBase
 public:
   explicit PullOutPlannerBase(
     rclcpp::Node & node, const StartPlannerParameters & parameters,
-    std::shared_ptr<universe_utils::TimeKeeper> time_keeper)
-  : vehicle_info_{autoware::vehicle_info_utils::VehicleInfoUtils(node).getVehicleInfo()},
+    std::shared_ptr<universe_utils::TimeKeeper> time_keeper =
+      std::make_shared<universe_utils::TimeKeeper>())
+  : parameters_{parameters},
+    vehicle_info_{autoware::vehicle_info_utils::VehicleInfoUtils(node).getVehicleInfo()},
     vehicle_footprint_{vehicle_info_.createFootprint()},
-    parameters_{parameters},
     time_keeper_(time_keeper)
   {
   }
@@ -65,9 +66,9 @@ protected:
     const std::shared_ptr<const PlannerData> & planner_data,
     double collision_check_distance_from_end) const;
 
+  StartPlannerParameters parameters_;
   autoware::vehicle_info_utils::VehicleInfo vehicle_info_;
   LinearRing2d vehicle_footprint_;
-  StartPlannerParameters parameters_;
   double collision_check_margin_;
 
   mutable std::shared_ptr<universe_utils::TimeKeeper> time_keeper_;

--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/include/autoware/behavior_path_start_planner_module/shift_pull_out.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/include/autoware/behavior_path_start_planner_module/shift_pull_out.hpp
@@ -41,11 +41,13 @@ public:
   PlannerType getPlannerType() const override { return PlannerType::SHIFT; };
   std::optional<PullOutPath> plan(
     const Pose & start_pose, const Pose & goal_pose,
+    const std::shared_ptr<const PlannerData> & planner_data,
     PlannerDebugData & planner_debug_data) override;
 
   std::vector<PullOutPath> calcPullOutPaths(
     const RouteHandler & route_handler, const lanelet::ConstLanelets & road_lanes,
-    const Pose & start_pose, const Pose & goal_pose);
+    const Pose & start_pose, const Pose & goal_pose,
+    const BehaviorPathPlannerParameters & behavior_path_parameters);
 
   double calcBeforeShiftedArcLength(
     const PathWithLaneId & path, const double target_after_arc_length, const double dr);

--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/include/autoware/behavior_path_start_planner_module/shift_pull_out.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/include/autoware/behavior_path_start_planner_module/shift_pull_out.hpp
@@ -36,7 +36,8 @@ public:
   explicit ShiftPullOut(
     rclcpp::Node & node, const StartPlannerParameters & parameters,
     std::shared_ptr<LaneDepartureChecker> & lane_departure_checker,
-    std::shared_ptr<universe_utils::TimeKeeper> time_keeper);
+    std::shared_ptr<universe_utils::TimeKeeper> time_keeper =
+      std::make_shared<universe_utils::TimeKeeper>());
 
   PlannerType getPlannerType() const override { return PlannerType::SHIFT; };
   std::optional<PullOutPath> plan(

--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/freespace_pull_out.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/freespace_pull_out.cpp
@@ -51,13 +51,14 @@ FreespacePullOut::FreespacePullOut(
 }
 
 std::optional<PullOutPath> FreespacePullOut::plan(
-  const Pose & start_pose, const Pose & end_pose, PlannerDebugData & planner_debug_data)
+  const Pose & start_pose, const Pose & end_pose,
+  const std::shared_ptr<const PlannerData> & planner_data, PlannerDebugData & planner_debug_data)
 {
-  const auto & route_handler = planner_data_->route_handler;
-  const double backward_path_length = planner_data_->parameters.backward_path_length;
-  const double forward_path_length = planner_data_->parameters.forward_path_length;
+  const auto & route_handler = planner_data->route_handler;
+  const double backward_path_length = planner_data->parameters.backward_path_length;
+  const double forward_path_length = planner_data->parameters.forward_path_length;
 
-  planner_->setMap(*planner_data_->costmap);
+  planner_->setMap(*planner_data->costmap);
 
   try {
     if (!planner_->makePlan(start_pose, end_pose)) {
@@ -69,11 +70,11 @@ std::optional<PullOutPath> FreespacePullOut::plan(
   }
 
   const auto road_lanes = utils::getExtendedCurrentLanes(
-    planner_data_, backward_path_length, std::numeric_limits<double>::max(),
+    planner_data, backward_path_length, std::numeric_limits<double>::max(),
     /*forward_only_in_route*/ true);
   // find candidate paths
   const auto pull_out_lanes =
-    start_planner_utils::getPullOutLanes(planner_data_, backward_path_length);
+    start_planner_utils::getPullOutLanes(planner_data, backward_path_length);
   const auto lanes = utils::combineLanelets(road_lanes, pull_out_lanes);
 
   const PathWithLaneId path =

--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/freespace_pull_out.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/freespace_pull_out.cpp
@@ -28,15 +28,11 @@
 
 namespace autoware::behavior_path_planner
 {
-FreespacePullOut::FreespacePullOut(
-  rclcpp::Node & node, const StartPlannerParameters & parameters,
-  const autoware::vehicle_info_utils::VehicleInfo & vehicle_info,
-  std::shared_ptr<universe_utils::TimeKeeper> time_keeper)
-: PullOutPlannerBase{node, parameters, time_keeper},
-  velocity_{parameters.freespace_planner_velocity}
+FreespacePullOut::FreespacePullOut(rclcpp::Node & node, const StartPlannerParameters & parameters)
+: PullOutPlannerBase{node, parameters}, velocity_{parameters.freespace_planner_velocity}
 {
   autoware::freespace_planning_algorithms::VehicleShape vehicle_shape(
-    vehicle_info, parameters.vehicle_shape_margin);
+    vehicle_info_, parameters.vehicle_shape_margin);
   if (parameters.freespace_planner_algorithm == "astar") {
     use_back_ = parameters.astar_parameters.use_back;
     planner_ = std::make_unique<AstarSearch>(

--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/geometric_pull_out.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/geometric_pull_out.cpp
@@ -47,24 +47,25 @@ GeometricPullOut::GeometricPullOut(
 }
 
 std::optional<PullOutPath> GeometricPullOut::plan(
-  const Pose & start_pose, const Pose & goal_pose, PlannerDebugData & planner_debug_data)
+  const Pose & start_pose, const Pose & goal_pose,
+  const std::shared_ptr<const PlannerData> & planner_data, PlannerDebugData & planner_debug_data)
 {
   PullOutPath output;
 
   // combine road lane and pull out lane
   const double backward_path_length =
-    planner_data_->parameters.backward_path_length + parameters_.max_back_distance;
+    planner_data->parameters.backward_path_length + parameters_.max_back_distance;
   const auto road_lanes = utils::getExtendedCurrentLanes(
-    planner_data_, backward_path_length, std::numeric_limits<double>::max(),
+    planner_data, backward_path_length, std::numeric_limits<double>::max(),
     /*forward_only_in_route*/ true);
-  const auto pull_out_lanes = getPullOutLanes(planner_data_, backward_path_length);
+  const auto pull_out_lanes = getPullOutLanes(planner_data, backward_path_length);
 
   // check if the ego is at left or right side of road lane center
   const bool left_side_start = 0 < getArcCoordinates(road_lanes, start_pose).distance;
 
   planner_.setTurningRadius(
-    planner_data_->parameters, parallel_parking_parameters_.pull_out_max_steer_angle);
-  planner_.setPlannerData(planner_data_);
+    planner_data->parameters, parallel_parking_parameters_.pull_out_max_steer_angle);
+  planner_.setPlannerData(planner_data);
   const bool found_valid_path = planner_.planPullOut(
     start_pose, goal_pose, road_lanes, pull_out_lanes, left_side_start, lane_departure_checker_);
   if (!found_valid_path) {
@@ -122,7 +123,8 @@ std::optional<PullOutPath> GeometricPullOut::plan(
   output.start_pose = planner_.getArcPaths().at(0).points.front().point.pose;
   output.end_pose = planner_.getArcPaths().at(1).points.back().point.pose;
 
-  if (isPullOutPathCollided(output, parameters_.geometric_collision_check_distance_from_end)) {
+  if (isPullOutPathCollided(
+        output, planner_data, parameters_.geometric_collision_check_distance_from_end)) {
     planner_debug_data.conditions_evaluation.emplace_back("collision");
     return {};
   }

--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/pull_out_planner_base.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/pull_out_planner_base.cpp
@@ -14,21 +14,24 @@
 
 #include "autoware/behavior_path_start_planner_module/pull_out_planner_base.hpp"
 
+#include <memory>
+
 namespace autoware::behavior_path_planner
 {
 bool PullOutPlannerBase::isPullOutPathCollided(
   autoware::behavior_path_planner::PullOutPath & pull_out_path,
+  const std::shared_ptr<const PlannerData> & planner_data,
   double collision_check_distance_from_end) const
 {
   universe_utils::ScopedTimeTrack st(__func__, *time_keeper_);
 
   // check for collisions
-  const auto & dynamic_objects = planner_data_->dynamic_object;
+  const auto & dynamic_objects = planner_data->dynamic_object;
   if (!dynamic_objects) {
     return false;
   }
   const auto pull_out_lanes = start_planner_utils::getPullOutLanes(
-    planner_data_, planner_data_->parameters.backward_path_length + parameters_.max_back_distance);
+    planner_data, planner_data->parameters.backward_path_length + parameters_.max_back_distance);
   // extract stop objects in pull out lane for collision check
   const auto stop_objects = utils::path_safety_checker::filterObjectsByVelocity(
     *dynamic_objects, parameters_.th_moving_object_velocity);

--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/shift_pull_out.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/shift_pull_out.cpp
@@ -48,24 +48,26 @@ ShiftPullOut::ShiftPullOut(
 }
 
 std::optional<PullOutPath> ShiftPullOut::plan(
-  const Pose & start_pose, const Pose & goal_pose, PlannerDebugData & planner_debug_data)
+  const Pose & start_pose, const Pose & goal_pose,
+  const std::shared_ptr<const PlannerData> & planner_data, PlannerDebugData & planner_debug_data)
 {
-  const auto & route_handler = planner_data_->route_handler;
-  const auto & common_parameters = planner_data_->parameters;
+  const auto & route_handler = planner_data->route_handler;
+  const auto & common_parameters = planner_data->parameters;
 
   const double backward_path_length =
-    planner_data_->parameters.backward_path_length + parameters_.max_back_distance;
+    planner_data->parameters.backward_path_length + parameters_.max_back_distance;
   const auto road_lanes = utils::getExtendedCurrentLanes(
-    planner_data_, backward_path_length, std::numeric_limits<double>::max(),
+    planner_data, backward_path_length, std::numeric_limits<double>::max(),
     /*forward_only_in_route*/ true);
   // find candidate paths
-  auto pull_out_paths = calcPullOutPaths(*route_handler, road_lanes, start_pose, goal_pose);
+  auto pull_out_paths =
+    calcPullOutPaths(*route_handler, road_lanes, start_pose, goal_pose, common_parameters);
   if (pull_out_paths.empty()) {
     planner_debug_data.conditions_evaluation.emplace_back("no path found");
     return std::nullopt;
   }
 
-  const auto lanelet_map_ptr = planner_data_->route_handler->getLaneletMapPtr();
+  const auto lanelet_map_ptr = planner_data->route_handler->getLaneletMapPtr();
 
   std::vector<lanelet::Id> fused_id_start_to_end{};
   std::optional<autoware::universe_utils::Polygon2d> fused_polygon_start_to_end = std::nullopt;
@@ -159,9 +161,10 @@ std::optional<PullOutPath> ShiftPullOut::plan(
       continue;
     }
     shift_path.points = cropped_path.points;
-    shift_path.header = planner_data_->route_handler->getRouteHeader();
+    shift_path.header = planner_data->route_handler->getRouteHeader();
 
-    if (isPullOutPathCollided(pull_out_path, parameters_.shift_collision_check_distance_from_end)) {
+    if (isPullOutPathCollided(
+          pull_out_path, planner_data, parameters_.shift_collision_check_distance_from_end)) {
       planner_debug_data.conditions_evaluation.emplace_back("collision");
       continue;
     }
@@ -227,7 +230,8 @@ bool ShiftPullOut::refineShiftedPathToStartPose(
 
 std::vector<PullOutPath> ShiftPullOut::calcPullOutPaths(
   const RouteHandler & route_handler, const lanelet::ConstLanelets & road_lanes,
-  const Pose & start_pose, const Pose & goal_pose)
+  const Pose & start_pose, const Pose & goal_pose,
+  const BehaviorPathPlannerParameters & behavior_path_parameters)
 {
   universe_utils::ScopedTimeTrack st(__func__, *time_keeper_);
 
@@ -238,9 +242,8 @@ std::vector<PullOutPath> ShiftPullOut::calcPullOutPaths(
   }
 
   // rename parameter
-  const auto & common_parameters = planner_data_->parameters;
-  const double forward_path_length = common_parameters.forward_path_length;
-  const double backward_path_length = common_parameters.backward_path_length;
+  const double forward_path_length = behavior_path_parameters.forward_path_length;
+  const double backward_path_length = behavior_path_parameters.backward_path_length;
   const double lateral_jerk = parameters_.lateral_jerk;
   const double minimum_lateral_acc = parameters_.minimum_lateral_acc;
   const double maximum_lateral_acc = parameters_.maximum_lateral_acc;

--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/start_planner_module.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/start_planner_module.cpp
@@ -986,17 +986,16 @@ bool StartPlannerModule::findPullOutPath(
   const bool backward_is_unnecessary = backwards_distance < epsilon;
 
   planner->setCollisionCheckMargin(collision_check_margin);
-  planner->setPlannerData(planner_data_);
   PlannerDebugData debug_data{
     planner->getPlannerType(), {}, collision_check_margin, backwards_distance};
 
-  const auto pull_out_path = planner->plan(start_pose_candidate, goal_pose, debug_data);
+  const auto pull_out_path =
+    planner->plan(start_pose_candidate, goal_pose, planner_data_, debug_data);
   debug_data_vector.push_back(debug_data);
   // If no path is found, return false
   if (!pull_out_path) {
     return false;
   }
-
   if (backward_is_unnecessary) {
     updateStatusWithCurrentPath(*pull_out_path, start_pose_candidate, planner->getPlannerType());
     return true;
@@ -1595,9 +1594,9 @@ std::optional<PullOutStatus> StartPlannerModule::planFreespacePath(
 
   for (const auto & p : center_line_path.points) {
     const Pose end_pose = p.point.pose;
-    freespace_planner_->setPlannerData(planner_data);
     PlannerDebugData debug_data{freespace_planner_->getPlannerType(), {}, 0.0, 0.0};
-    auto freespace_path = freespace_planner_->plan(current_pose, end_pose, debug_data);
+    auto freespace_path =
+      freespace_planner_->plan(current_pose, end_pose, planner_data, debug_data);
     DEBUG_PRINT(
       "\nFreespace Pull out path search results\n%s%s", debug_data.header_str().c_str(),
       debug_data.str().c_str());

--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/start_planner_module.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/start_planner_module.cpp
@@ -68,13 +68,11 @@ StartPlannerModule::StartPlannerModule(
   vehicle_info_{autoware::vehicle_info_utils::VehicleInfoUtils(node).getVehicleInfo()},
   is_freespace_planner_cb_running_{false}
 {
-  lane_departure_checker_ = std::make_shared<LaneDepartureChecker>(time_keeper_);
-  lane_departure_checker_->setVehicleInfo(vehicle_info_);
   autoware::lane_departure_checker::Param lane_departure_checker_params{};
   lane_departure_checker_params.footprint_extra_margin =
     parameters->lane_departure_check_expansion_margin;
-
-  lane_departure_checker_->setParam(lane_departure_checker_params);
+  lane_departure_checker_ = std::make_shared<LaneDepartureChecker>(
+    lane_departure_checker_params, vehicle_info_, time_keeper_);
 
   // set enabled planner
   if (parameters_->enable_shift_pull_out) {
@@ -90,8 +88,7 @@ StartPlannerModule::StartPlannerModule(
   }
 
   if (parameters_->enable_freespace_planner) {
-    freespace_planner_ =
-      std::make_unique<FreespacePullOut>(node, *parameters, vehicle_info_, time_keeper_);
+    freespace_planner_ = std::make_unique<FreespacePullOut>(node, *parameters);
     const auto freespace_planner_period_ns = rclcpp::Rate(1.0).period();
     freespace_planner_timer_cb_group_ =
       node.create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);

--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/test/test_geometric_pull_out.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/test/test_geometric_pull_out.cpp
@@ -37,6 +37,7 @@ using autoware::test_utils::get_absolute_path_to_config;
 using autoware_planning_msgs::msg::LaneletRoute;
 using RouteSections = std::vector<autoware_planning_msgs::msg::LaneletSegment>;
 using autoware_planning_test_manager::utils::makeBehaviorRouteFromLaneId;
+using geometry_msgs::msg::Pose;
 
 namespace autoware::behavior_path_planner
 {
@@ -44,37 +45,61 @@ namespace autoware::behavior_path_planner
 class TestGeometricPullOut : public ::testing::Test
 {
 public:
-  std::optional<PullOutPath> plan(
-    const Pose & start_pose, const Pose & goal_pose, PlannerDebugData & planner_debug_data)
+  std::optional<PullOutPath> call_plan(
+    const Pose & start_pose, const Pose & goal_pose,
+    const std::shared_ptr<const PlannerData> & planner_data, PlannerDebugData & planner_debug_data)
   {
-    return geometric_pull_out_->plan(start_pose, goal_pose, planner_debug_data);
+    return geometric_pull_out_->plan(start_pose, goal_pose, planner_data, planner_debug_data);
   }
 
 protected:
   void SetUp() override
   {
     rclcpp::init(0, nullptr);
-    node_ = rclcpp::Node::make_shared("geometric_pull_out", get_node_options());
+    node_ = rclcpp::Node::make_shared("geometric_pull_out", make_node_options());
 
-    load_parameters();
-    initialize_vehicle_info();
     initialize_lane_departure_checker();
-    initialize_routeHandler();
     initialize_geometric_pull_out_planner();
-    initialize_planner_data();
+  }
+  void TearDown() override { rclcpp::shutdown(); }
+
+  std::shared_ptr<const PlannerData> make_planner_data(
+    const Pose & start_pose, const int route_start_lane_id, const int route_goal_lane_id)
+  {
+    auto planner_data = std::make_shared<PlannerData>();
+    planner_data->init_parameters(*node_);
+
+    // Load a sample lanelet map and create a route handler
+    const auto shoulder_map_path = autoware::test_utils::get_absolute_path_to_lanelet_map(
+      "autoware_test_utils", "road_shoulder/lanelet2_map.osm");
+    const auto map_bin_msg = autoware::test_utils::make_map_bin_msg(shoulder_map_path, 0.5);
+    auto route_handler = std::make_shared<autoware::route_handler::RouteHandler>(map_bin_msg);
+
+    // Set up current odometry at start pose
+    auto odometry = std::make_shared<nav_msgs::msg::Odometry>();
+    odometry->pose.pose = start_pose;
+    odometry->header.frame_id = "map";
+    planner_data->self_odometry = odometry;
+
+    // Setup route
+    const auto route = makeBehaviorRouteFromLaneId(
+      route_start_lane_id, route_goal_lane_id, "autoware_test_utils",
+      "road_shoulder/lanelet2_map.osm");
+    route_handler->setRoute(route);
+
+    // Update planner data with the route handler
+    planner_data->route_handler = route_handler;
+
+    return planner_data;
   }
 
-  void TearDown() override { rclcpp::shutdown(); }
   // Member variables
   std::shared_ptr<rclcpp::Node> node_;
-  std::shared_ptr<autoware::route_handler::RouteHandler> route_handler_;
-  autoware::vehicle_info_utils::VehicleInfo vehicle_info_;
   std::shared_ptr<GeometricPullOut> geometric_pull_out_;
   std::shared_ptr<LaneDepartureChecker> lane_departure_checker_;
-  PlannerData planner_data_;
 
 private:
-  rclcpp::NodeOptions get_node_options() const
+  rclcpp::NodeOptions make_node_options() const
   {
     // Load common configuration files
     auto node_options = rclcpp::NodeOptions{};
@@ -102,85 +127,25 @@ private:
     return node_options;
   }
 
-  void load_parameters()
-  {
-    const auto dp_double = [&](const std::string & s) {
-      return node_->declare_parameter<double>(s);
-    };
-    const auto dp_bool = [&](const std::string & s) { return node_->declare_parameter<bool>(s); };
-    // Load parameters required for planning
-    const std::string ns = "start_planner.";
-    lane_departure_check_expansion_margin_ =
-      dp_double(ns + "lane_departure_check_expansion_margin");
-    pull_out_max_steer_angle_ = dp_double(ns + "pull_out_max_steer_angle");
-    pull_out_arc_path_interval_ = dp_double(ns + "arc_path_interval");
-    center_line_path_interval_ = dp_double(ns + "center_line_path_interval");
-    th_moving_object_velocity_ = dp_double(ns + "th_moving_object_velocity");
-    divide_pull_out_path_ = dp_bool(ns + "divide_pull_out_path");
-    backward_path_length_ = dp_double("backward_path_length");
-    forward_path_length_ = dp_double("forward_path_length");
-  }
-
-  void initialize_vehicle_info()
-  {
-    vehicle_info_ = autoware::vehicle_info_utils::VehicleInfoUtils(*node_).getVehicleInfo();
-  }
-
   void initialize_lane_departure_checker()
   {
+    const auto vehicle_info =
+      autoware::vehicle_info_utils::VehicleInfoUtils(*node_).getVehicleInfo();
     lane_departure_checker_ = std::make_shared<LaneDepartureChecker>();
-    lane_departure_checker_->setVehicleInfo(vehicle_info_);
+    lane_departure_checker_->setVehicleInfo(vehicle_info);
 
     autoware::lane_departure_checker::Param lane_departure_checker_params{};
-    lane_departure_checker_params.footprint_extra_margin = lane_departure_check_expansion_margin_;
     lane_departure_checker_->setParam(lane_departure_checker_params);
-  }
-
-  void initialize_routeHandler()
-  {
-    // Load a sample lanelet map and create a route handler
-    const auto shoulder_map_path = autoware::test_utils::get_absolute_path_to_lanelet_map(
-      "autoware_test_utils", "road_shoulder/lanelet2_map.osm");
-    const auto map_bin_msg = autoware::test_utils::make_map_bin_msg(shoulder_map_path, 0.5);
-
-    route_handler_ = std::make_shared<autoware::route_handler::RouteHandler>(map_bin_msg);
   }
 
   void initialize_geometric_pull_out_planner()
   {
-    auto parameters = std::make_shared<StartPlannerParameters>();
-    parameters->parallel_parking_parameters.pull_out_max_steer_angle = pull_out_max_steer_angle_;
-    parameters->parallel_parking_parameters.pull_out_arc_path_interval =
-      pull_out_arc_path_interval_;
-    parameters->parallel_parking_parameters.center_line_path_interval = center_line_path_interval_;
-    parameters->th_moving_object_velocity = th_moving_object_velocity_;
-    parameters->divide_pull_out_path = divide_pull_out_path_;
+    auto parameters = StartPlannerParameters::init(*node_);
 
     auto time_keeper = std::make_shared<autoware::universe_utils::TimeKeeper>();
     geometric_pull_out_ =
-      std::make_shared<GeometricPullOut>(*node_, *parameters, lane_departure_checker_, time_keeper);
+      std::make_shared<GeometricPullOut>(*node_, parameters, lane_departure_checker_, time_keeper);
   }
-
-  void initialize_planner_data()
-  {
-    planner_data_.parameters.backward_path_length = backward_path_length_;
-    planner_data_.parameters.forward_path_length = forward_path_length_;
-    planner_data_.parameters.wheel_base = vehicle_info_.wheel_base_m;
-    planner_data_.parameters.wheel_tread = vehicle_info_.wheel_tread_m;
-    planner_data_.parameters.front_overhang = vehicle_info_.front_overhang_m;
-    planner_data_.parameters.left_over_hang = vehicle_info_.left_overhang_m;
-    planner_data_.parameters.right_over_hang = vehicle_info_.right_overhang_m;
-  }
-
-  // Parameter variables
-  double lane_departure_check_expansion_margin_{0.0};
-  double pull_out_max_steer_angle_{0.0};
-  double pull_out_arc_path_interval_{0.0};
-  double center_line_path_interval_{0.0};
-  double th_moving_object_velocity_{0.0};
-  double backward_path_length_{0.0};
-  double forward_path_length_{0.0};
-  bool divide_pull_out_path_{false};
 };
 
 TEST_F(TestGeometricPullOut, GenerateValidGeometricPullOutPath)
@@ -199,26 +164,13 @@ TEST_F(TestGeometricPullOut, GenerateValidGeometricPullOutPath)
         geometry_msgs::build<geometry_msgs::msg::Quaternion>().x(0.0).y(0.0).z(0.705897).w(
           0.708314));
 
-  // Set up current odometry at start pose
-  auto odometry = std::make_shared<nav_msgs::msg::Odometry>();
-  odometry->pose.pose = start_pose;
-  odometry->header.frame_id = "map";
-  planner_data_.self_odometry = odometry;
-
-  // Setup route
-  const auto route = makeBehaviorRouteFromLaneId(
-    4619, 4635, "autoware_test_utils", "road_shoulder/lanelet2_map.osm");
-  route_handler_->setRoute(route);
-
-  // Update planner data with the route handler
-  planner_data_.route_handler = route_handler_;
-  geometric_pull_out_->setPlannerData(std::make_shared<PlannerData>(planner_data_));
+  const auto planner_data = make_planner_data(start_pose, 4619, 4635);
 
   // Plan the pull out path
   PlannerDebugData debug_data;
-  auto result = plan(start_pose, goal_pose, debug_data);
+  auto result = call_plan(start_pose, goal_pose, planner_data, debug_data);
 
-  // Assert that a valid geometric geometric pull out path is generated
+  // Assert that a valid geometric pull out path is generated
   ASSERT_TRUE(result.has_value()) << "Geometric pull out path generation failed.";
   EXPECT_EQ(result->partial_paths.size(), 2UL)
     << "Generated geometric pull out path does not have the expected number of partial paths.";

--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/test/test_geometric_pull_out.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/test/test_geometric_pull_out.cpp
@@ -24,9 +24,7 @@
 
 #include <gtest/gtest.h>
 
-#include <iostream>
 #include <memory>
-#include <optional>
 #include <string>
 #include <vector>
 
@@ -129,22 +127,19 @@ private:
 
   void initialize_lane_departure_checker()
   {
+    autoware::lane_departure_checker::Param lane_departure_checker_params{};
     const auto vehicle_info =
       autoware::vehicle_info_utils::VehicleInfoUtils(*node_).getVehicleInfo();
-    lane_departure_checker_ = std::make_shared<LaneDepartureChecker>();
-    lane_departure_checker_->setVehicleInfo(vehicle_info);
-
-    autoware::lane_departure_checker::Param lane_departure_checker_params{};
-    lane_departure_checker_->setParam(lane_departure_checker_params);
+    lane_departure_checker_ =
+      std::make_shared<LaneDepartureChecker>(lane_departure_checker_params, vehicle_info);
   }
 
   void initialize_geometric_pull_out_planner()
   {
     auto parameters = StartPlannerParameters::init(*node_);
 
-    auto time_keeper = std::make_shared<autoware::universe_utils::TimeKeeper>();
     geometric_pull_out_ =
-      std::make_shared<GeometricPullOut>(*node_, parameters, lane_departure_checker_, time_keeper);
+      std::make_shared<GeometricPullOut>(*node_, parameters, lane_departure_checker_);
   }
 };
 
@@ -163,7 +158,6 @@ TEST_F(TestGeometricPullOut, GenerateValidGeometricPullOutPath)
       .orientation(
         geometry_msgs::build<geometry_msgs::msg::Quaternion>().x(0.0).y(0.0).z(0.705897).w(
           0.708314));
-
   const auto planner_data = make_planner_data(start_pose, 4619, 4635);
 
   // Plan the pull out path

--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/test/test_shift_pull_out.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/test/test_shift_pull_out.cpp
@@ -127,22 +127,18 @@ private:
 
   void initialize_lane_departure_checker()
   {
+    autoware::lane_departure_checker::Param lane_departure_checker_params{};
     const auto vehicle_info =
       autoware::vehicle_info_utils::VehicleInfoUtils(*node_).getVehicleInfo();
-    lane_departure_checker_ = std::make_shared<LaneDepartureChecker>();
-    lane_departure_checker_->setVehicleInfo(vehicle_info);
-
-    autoware::lane_departure_checker::Param lane_departure_checker_params{};
-    lane_departure_checker_->setParam(lane_departure_checker_params);
+    lane_departure_checker_ =
+      std::make_shared<LaneDepartureChecker>(lane_departure_checker_params, vehicle_info);
   }
 
   void initialize_shift_pull_out_planner()
   {
     auto parameters = StartPlannerParameters::init(*node_);
 
-    auto time_keeper = std::make_shared<autoware::universe_utils::TimeKeeper>();
-    shift_pull_out_ =
-      std::make_shared<ShiftPullOut>(*node_, parameters, lane_departure_checker_, time_keeper);
+    shift_pull_out_ = std::make_shared<ShiftPullOut>(*node_, parameters, lane_departure_checker_);
   }
 };
 


### PR DESCRIPTION
## Description

includes following PRs change
https://github.com/autowarefoundation/autoware.universe/pull/9827
https://github.com/autowarefoundation/autoware.universe/pull/9791


**The PRs from above need to be merged in order.**


This PR refactors the pull-out planner interfaces by removing the planner_data member variable from the PullOutPlannerBase class and passing it as a method parameter instead. 

This change:
- Removes setPlannerData() method from PullOutPlannerBase
- Updates plan() method signature across all pull-out planner implementations to accept planner_data
- Improves testability

The changes maintain the same functionality while making the code more maintainable.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
