### PR TITLE
revert(autoware_lidar_centerpoint): process front voxels first

### DIFF
--- a/perception/autoware_lidar_centerpoint/lib/preprocess/preprocess_kernel.cu
+++ b/perception/autoware_lidar_centerpoint/lib/preprocess/preprocess_kernel.cu
@@ -148,7 +148,7 @@ __global__ void generateVoxels_random_kernel(
 
   int voxel_idx = floorf((point.x - min_x_range) / pillar_x_size);
   int voxel_idy = floorf((point.y - min_y_range) / pillar_y_size);
-  unsigned int voxel_index = (grid_x_size - 1 - voxel_idx) * grid_y_size + voxel_idy;
+  unsigned int voxel_index = voxel_idy * grid_x_size + voxel_idx;
 
   unsigned int point_id = atomicAdd(&(mask[voxel_index]), 1);
 
@@ -185,14 +185,12 @@ __global__ void generateBaseFeatures_kernel(
   unsigned int * mask, float * voxels, int grid_y_size, int grid_x_size, int max_voxel_size,
   unsigned int * pillar_num, float * voxel_features, float * voxel_num, int * voxel_idxs)
 {
-  // exchange x and y to process in a row-major order
-  // flip x axis direction to process front to back
-  unsigned int voxel_idx_inverted = blockIdx.y * blockDim.y + threadIdx.y;
-  unsigned int voxel_idy = blockIdx.x * blockDim.x + threadIdx.x;
-  if (voxel_idx_inverted >= grid_x_size || voxel_idy >= grid_y_size) return;
-  unsigned int voxel_idx = grid_x_size - 1 - voxel_idx_inverted;
+  unsigned int voxel_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  unsigned int voxel_idy = blockIdx.y * blockDim.y + threadIdx.y;
 
-  unsigned int voxel_index = voxel_idx_inverted * grid_y_size + voxel_idy;
+  if (voxel_idx >= grid_x_size || voxel_idy >= grid_y_size) return;
+
+  unsigned int voxel_index = voxel_idy * grid_x_size + voxel_idx;
   unsigned int count = mask[voxel_index];
   if (!(count > 0)) return;
   count = count < MAX_POINT_IN_VOXEL_SIZE ? count : MAX_POINT_IN_VOXEL_SIZE;
@@ -222,10 +220,9 @@ cudaError_t generateBaseFeatures_launch(
   unsigned int * pillar_num, float * voxel_features, float * voxel_num, int * voxel_idxs,
   cudaStream_t stream)
 {
-  // exchange x and y to process in a row-major order
   dim3 threads = {32, 32};
   dim3 blocks = {
-    (grid_y_size + threads.x - 1) / threads.x, (grid_x_size + threads.y - 1) / threads.y};
+    (grid_x_size + threads.x - 1) / threads.x, (grid_y_size + threads.y - 1) / threads.y};
 
   generateBaseFeatures_kernel<<<blocks, threads, 0, stream>>>(
     mask, voxels, grid_y_size, grid_x_size, max_voxel_size, pillar_num, voxel_features, voxel_num,


### PR DESCRIPTION
## Description

revert "feat(autoware_lidar_centerpoint): process front voxels first ……(#9608)"

This reverts commit 91984f819fdbef89e7c7e4c0785857c9b6b2ee70.

Revert since it had illegal memory access as following
```
[component_container_mt-1] [WARN] [1735120020.355710921] [sensing.lidar.concatenate_data]: transformed_raw_points[/sensing/lidar/top/pointcloud_before_sync] is nullptr, skipping pointcloud publish.
[component_container_mt-1] terminate called after throwing an instance of 'thrust::system::system_error'
[component_container_mt-1]   what():  parallel_for: failed to synchronize: cudaErrorIllegalAddress: an illegal memory access was encountered
[component_container_mt-1] *** Aborted at 1735120027 (unix time) try "date -d @1735120027" if you are using GNU date ***
[component_container_mt-1] PC: @                0x0 (unknown)
[component_container_mt-1] *** SIGABRT (@0x3e800028313) received by PID 164627 (TID 0x7fcd397fa640) from PID 164627; stack trace: ***
[component_container_mt-1]     @     0x7fcd64a244d6 google::(anonymous namespace)::FailureSignalHandler()
[component_container_mt-1]     @     0x7fcd642cd520 (unknown)
[component_container_mt-1]     @     0x7fcd643219fc pthread_kill
[component_container_mt-1]     @     0x7fcd642cd476 raise
[component_container_mt-1]     @     0x7fcd642b37f3 abort
[component_container_mt-1]     @     0x7fcd64578b9e (unknown)
[component_container_mt-1]     @     0x7fcd6458420c (unknown)
[component_container_mt-1]     @     0x7fcd64584277 std::terminate()
[component_container_mt-1]     @     0x7fcd645844d8 __cxa_throw
[component_container_mt-1]     @     0x7fcc79f13f4c thrust::detail::vector_base<>::vector_base()
[component_container_mt-1]     @     0x7fcc79f10243 autoware::lidar_centerpoint::PostProcessCUDA::generateDetectedBoxes3D_launch()
[component_container_mt-1]     @     0x7fcc7a0615db autoware::lidar_centerpoint::CenterPointTRT::postProcess()
[component_container_mt-1]     @     0x7fcc7a065db3 autoware::lidar_centerpoint::CenterPointTRT::detect()
[component_container_mt-1]     @     0x7fcc7a1dcdef autoware::lidar_centerpoint::LidarCenterPointNode::pointCloudCallback()
[component_container_mt-1]     @     0x7fcc7a1ef2e8 std::_Function_handler<>::_M_invoke()
[component_container_mt-1]     @     0x7fcd585a1fc7 _ZNSt8__detail9__variant17__gen_vtable_implINS0_12_Multi_arrayIPFNS0_21__deduce_visit_resultIvEEOZN6rclcpp23AnySubscriptionCallbackIN11sensor_msgs3msg12PointCloud2_ISaIvEEESA_E8dispatchESt10shared_ptrISB_ERKNS5_11MessageInfoEEUlOT_E_RSt7variantIJSt8functionIFvRKSB_EESN_IFvSP_SH_EESN_IFvRKNS5_17SerializedMessageEEESN_IFvSW_SH_EESN_IFvSt10unique_ptrISB_St14default_deleteISB_EEEESN_IFvS14_SH_EESN_IFvS11_ISU_S12_ISU_EEEESN_IFvS1A_SH_EESN_IFvSD_ISO_EEESN_IFvS1F_SH_EESN_IFvSD_ISV_EEESN_IFvS1K_SH_EESN_IFvRKS1F_EESN_IFvS1Q_SH_EESN_IFvRKS1K_EESN_IFvS1W_SH_EESN_IFvSE_EESN_IFvSE_SH_EESN_IFvSD_ISU_EEESN_IFvS25_SH_EEEEEJEEESt16integer_sequenceImJLm8EEEE14__visit_invokeESL_S2B_
[component_container_mt-1]     @     0x7fcc7a20a145 rclcpp::Subscription<>::handle_message()
[component_container_mt-1]     @     0x7fcd648a0ba0 rclcpp::Executor::execute_subscription()
[component_container_mt-1]     @     0x7fcd648a210e rclcpp::Executor::execute_any_executable()
[component_container_mt-1]     @     0x7fcd648a8432 rclcpp::executors::MultiThreadedExecutor::run()
[component_container_mt-1]     @     0x7fcd645b2253 (unknown)
[component_container_mt-1]     @     0x7fcd6431fac3 (unknown)
[component_container_mt-1]     @     0x7fcd643b1850 (unknown)
```


## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
