### PR TITLE
refactor(behavior_velocity_planner_common): add behavior_velocity_rtc_interface and move RTC-related implementation

### DIFF
--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/include/autoware/behavior_velocity_blind_spot_module/manager.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/include/autoware/behavior_velocity_blind_spot_module/manager.hpp
@@ -19,7 +19,7 @@
 
 #include <autoware/behavior_velocity_planner_common/plugin_interface.hpp>
 #include <autoware/behavior_velocity_planner_common/plugin_wrapper.hpp>
-#include <autoware/behavior_velocity_planner_common/scene_module_interface.hpp>
+#include <autoware/behavior_velocity_rtc_interface/scene_module_interface_with_rtc.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include <tier4_planning_msgs/msg/path_with_lane_id.hpp>
@@ -42,8 +42,8 @@ private:
 
   void launchNewModules(const tier4_planning_msgs::msg::PathWithLaneId & path) override;
 
-  std::function<bool(const std::shared_ptr<SceneModuleInterface> &)> getModuleExpiredFunction(
-    const tier4_planning_msgs::msg::PathWithLaneId & path) override;
+  std::function<bool(const std::shared_ptr<SceneModuleInterfaceWithRTC> &)>
+  getModuleExpiredFunction(const tier4_planning_msgs::msg::PathWithLaneId & path) override;
 };
 
 class BlindSpotModulePlugin : public PluginWrapper<BlindSpotModuleManager>

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/include/autoware/behavior_velocity_blind_spot_module/scene.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/include/autoware/behavior_velocity_blind_spot_module/scene.hpp
@@ -16,8 +16,8 @@
 #define AUTOWARE__BEHAVIOR_VELOCITY_BLIND_SPOT_MODULE__SCENE_HPP_
 
 #include <autoware/behavior_velocity_blind_spot_module/util.hpp>
-#include <autoware/behavior_velocity_planner_common/scene_module_interface.hpp>
 #include <autoware/behavior_velocity_planner_common/utilization/state_machine.hpp>
+#include <autoware/behavior_velocity_rtc_interface/scene_module_interface_with_rtc.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include <autoware_perception_msgs/msg/predicted_objects.hpp>
@@ -59,7 +59,7 @@ struct Safe
 
 using BlindSpotDecision = std::variant<InternalError, OverPassJudge, Unsafe, Safe>;
 
-class BlindSpotModule : public SceneModuleInterface
+class BlindSpotModule : public SceneModuleInterfaceWithRTC
 {
 public:
   struct DebugData

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/package.xml
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/package.xml
@@ -18,6 +18,7 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_behavior_velocity_planner_common</depend>
+  <depend>autoware_behavior_velocity_rtc_interface</depend>
   <depend>autoware_lanelet2_extension</depend>
   <depend>autoware_motion_utils</depend>
   <depend>autoware_perception_msgs</depend>

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/src/manager.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/src/manager.cpp
@@ -83,7 +83,7 @@ void BlindSpotModuleManager::launchNewModules(const tier4_planning_msgs::msg::Pa
   }
 }
 
-std::function<bool(const std::shared_ptr<SceneModuleInterface> &)>
+std::function<bool(const std::shared_ptr<SceneModuleInterfaceWithRTC> &)>
 BlindSpotModuleManager::getModuleExpiredFunction(
   const tier4_planning_msgs::msg::PathWithLaneId & path)
 {

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/src/scene.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/src/scene.cpp
@@ -41,7 +41,7 @@ BlindSpotModule::BlindSpotModule(
   const int64_t module_id, const int64_t lane_id, const TurnDirection turn_direction,
   const std::shared_ptr<const PlannerData> planner_data, const PlannerParam & planner_param,
   const rclcpp::Logger logger, const rclcpp::Clock::SharedPtr clock)
-: SceneModuleInterface(module_id, logger, clock),
+: SceneModuleInterfaceWithRTC(module_id, logger, clock),
   lane_id_(lane_id),
   planner_param_{planner_param},
   turn_direction_(turn_direction),

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/package.xml
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/package.xml
@@ -22,6 +22,7 @@
   <buildtool_depend>eigen3_cmake_module</buildtool_depend>
 
   <depend>autoware_behavior_velocity_planner_common</depend>
+  <depend>autoware_behavior_velocity_rtc_interface</depend>
   <depend>autoware_grid_map_utils</depend>
   <depend>autoware_internal_debug_msgs</depend>
   <depend>autoware_interpolation</depend>

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/manager.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/manager.cpp
@@ -216,7 +216,7 @@ void CrosswalkModuleManager::launchNewModules(const PathWithLaneId & path)
   }
 }
 
-std::function<bool(const std::shared_ptr<SceneModuleInterface> &)>
+std::function<bool(const std::shared_ptr<SceneModuleInterfaceWithRTC> &)>
 CrosswalkModuleManager::getModuleExpiredFunction(const PathWithLaneId & path)
 {
   const auto rh = planner_data_->route_handler_;
@@ -233,7 +233,7 @@ CrosswalkModuleManager::getModuleExpiredFunction(const PathWithLaneId & path)
     crosswalk_id_set.insert(crosswalk.first->crosswalkLanelet().id());
   }
 
-  return [crosswalk_id_set](const std::shared_ptr<SceneModuleInterface> & scene_module) {
+  return [crosswalk_id_set](const std::shared_ptr<SceneModuleInterfaceWithRTC> & scene_module) {
     return crosswalk_id_set.count(scene_module->getModuleId()) == 0;
   };
 }

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/manager.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/manager.hpp
@@ -19,7 +19,7 @@
 
 #include <autoware/behavior_velocity_planner_common/plugin_interface.hpp>
 #include <autoware/behavior_velocity_planner_common/plugin_wrapper.hpp>
-#include <autoware/behavior_velocity_planner_common/scene_module_interface.hpp>
+#include <autoware/behavior_velocity_rtc_interface/scene_module_interface_with_rtc.hpp>
 #include <autoware_lanelet2_extension/regulatory_elements/crosswalk.hpp>
 #include <rclcpp/rclcpp.hpp>
 
@@ -48,8 +48,8 @@ private:
 
   void launchNewModules(const PathWithLaneId & path) override;
 
-  std::function<bool(const std::shared_ptr<SceneModuleInterface> &)> getModuleExpiredFunction(
-    const PathWithLaneId & path) override;
+  std::function<bool(const std::shared_ptr<SceneModuleInterfaceWithRTC> &)>
+  getModuleExpiredFunction(const PathWithLaneId & path) override;
 };
 
 class CrosswalkModulePlugin : public PluginWrapper<CrosswalkModuleManager>

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/scene_crosswalk.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/scene_crosswalk.cpp
@@ -176,7 +176,7 @@ CrosswalkModule::CrosswalkModule(
   const std::optional<int64_t> & reg_elem_id, const lanelet::LaneletMapPtr & lanelet_map_ptr,
   const PlannerParam & planner_param, const rclcpp::Logger & logger,
   const rclcpp::Clock::SharedPtr clock)
-: SceneModuleInterface(module_id, logger, clock),
+: SceneModuleInterfaceWithRTC(module_id, logger, clock),
   module_id_(module_id),
   planner_param_(planner_param),
   use_regulatory_element_(reg_elem_id)

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/scene_crosswalk.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/scene_crosswalk.hpp
@@ -17,7 +17,7 @@
 
 #include "autoware/behavior_velocity_crosswalk_module/util.hpp"
 
-#include <autoware/behavior_velocity_planner_common/scene_module_interface.hpp>
+#include <autoware/behavior_velocity_rtc_interface/scene_module_interface_with_rtc.hpp>
 #include <autoware/universe_utils/geometry/boost_geometry.hpp>
 #include <autoware/universe_utils/system/stop_watch.hpp>
 #include <autoware_lanelet2_extension/regulatory_elements/crosswalk.hpp>
@@ -112,7 +112,7 @@ double InterpolateMap(
 }
 }  // namespace
 
-class CrosswalkModule : public SceneModuleInterface
+class CrosswalkModule : public SceneModuleInterfaceWithRTC
 {
 public:
   struct PlannerParam

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_detection_area_module/package.xml
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_detection_area_module/package.xml
@@ -18,6 +18,7 @@
   <buildtool_depend>eigen3_cmake_module</buildtool_depend>
 
   <depend>autoware_behavior_velocity_planner_common</depend>
+  <depend>autoware_behavior_velocity_rtc_interface</depend>
   <depend>autoware_lanelet2_extension</depend>
   <depend>autoware_motion_utils</depend>
   <depend>autoware_planning_msgs</depend>

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_detection_area_module/src/manager.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_detection_area_module/src/manager.cpp
@@ -74,16 +74,17 @@ void DetectionAreaModuleManager::launchNewModules(
   }
 }
 
-std::function<bool(const std::shared_ptr<SceneModuleInterface> &)>
+std::function<bool(const std::shared_ptr<SceneModuleInterfaceWithRTC> &)>
 DetectionAreaModuleManager::getModuleExpiredFunction(
   const tier4_planning_msgs::msg::PathWithLaneId & path)
 {
   const auto detection_area_id_set = planning_utils::getRegElemIdSetOnPath<DetectionArea>(
     path, planner_data_->route_handler_->getLaneletMapPtr(), planner_data_->current_odometry->pose);
 
-  return [detection_area_id_set](const std::shared_ptr<SceneModuleInterface> & scene_module) {
-    return detection_area_id_set.count(scene_module->getModuleId()) == 0;
-  };
+  return
+    [detection_area_id_set](const std::shared_ptr<SceneModuleInterfaceWithRTC> & scene_module) {
+      return detection_area_id_set.count(scene_module->getModuleId()) == 0;
+    };
 }
 
 }  // namespace autoware::behavior_velocity_planner

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_detection_area_module/src/manager.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_detection_area_module/src/manager.hpp
@@ -19,7 +19,7 @@
 
 #include <autoware/behavior_velocity_planner_common/plugin_interface.hpp>
 #include <autoware/behavior_velocity_planner_common/plugin_wrapper.hpp>
-#include <autoware/behavior_velocity_planner_common/scene_module_interface.hpp>
+#include <autoware/behavior_velocity_rtc_interface/scene_module_interface_with_rtc.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include <tier4_planning_msgs/msg/path_with_lane_id.hpp>
@@ -41,8 +41,8 @@ private:
 
   void launchNewModules(const tier4_planning_msgs::msg::PathWithLaneId & path) override;
 
-  std::function<bool(const std::shared_ptr<SceneModuleInterface> &)> getModuleExpiredFunction(
-    const tier4_planning_msgs::msg::PathWithLaneId & path) override;
+  std::function<bool(const std::shared_ptr<SceneModuleInterfaceWithRTC> &)>
+  getModuleExpiredFunction(const tier4_planning_msgs::msg::PathWithLaneId & path) override;
 };
 
 class DetectionAreaModulePlugin : public PluginWrapper<DetectionAreaModuleManager>

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_detection_area_module/src/scene.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_detection_area_module/src/scene.cpp
@@ -37,7 +37,7 @@ DetectionAreaModule::DetectionAreaModule(
   const lanelet::autoware::DetectionArea & detection_area_reg_elem,
   const PlannerParam & planner_param, const rclcpp::Logger & logger,
   const rclcpp::Clock::SharedPtr clock)
-: SceneModuleInterface(module_id, logger, clock),
+: SceneModuleInterfaceWithRTC(module_id, logger, clock),
   lane_id_(lane_id),
   detection_area_reg_elem_(detection_area_reg_elem),
   state_(State::GO),

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_detection_area_module/src/scene.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_detection_area_module/src/scene.hpp
@@ -23,8 +23,8 @@
 
 #define EIGEN_MPL2_ONLY
 #include <Eigen/Core>
-#include <autoware/behavior_velocity_planner_common/scene_module_interface.hpp>
 #include <autoware/behavior_velocity_planner_common/utilization/boost_geometry_helper.hpp>
+#include <autoware/behavior_velocity_rtc_interface/scene_module_interface_with_rtc.hpp>
 #include <autoware_lanelet2_extension/regulatory_elements/detection_area.hpp>
 #include <rclcpp/rclcpp.hpp>
 
@@ -38,7 +38,7 @@ using PathIndexWithPoint2d = std::pair<size_t, Point2d>;                // front
 using PathIndexWithOffset = std::pair<size_t, double>;                  // front index, offset
 using tier4_planning_msgs::msg::PathWithLaneId;
 
-class DetectionAreaModule : public SceneModuleInterface
+class DetectionAreaModule : public SceneModuleInterfaceWithRTC
 {
 public:
   enum class State { GO, STOP };

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/manager.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/manager.cpp
@@ -353,14 +353,14 @@ void IntersectionModuleManager::launchNewModules(
   }
 }
 
-std::function<bool(const std::shared_ptr<SceneModuleInterface> &)>
+std::function<bool(const std::shared_ptr<SceneModuleInterfaceWithRTC> &)>
 IntersectionModuleManager::getModuleExpiredFunction(
   const tier4_planning_msgs::msg::PathWithLaneId & path)
 {
   const auto lane_set = planning_utils::getLaneletsOnPath(
     path, planner_data_->route_handler_->getLaneletMapPtr(), planner_data_->current_odometry->pose);
 
-  return [lane_set](const std::shared_ptr<SceneModuleInterface> & scene_module) {
+  return [lane_set](const std::shared_ptr<SceneModuleInterfaceWithRTC> & scene_module) {
     const auto intersection_module = std::dynamic_pointer_cast<IntersectionModule>(scene_module);
     const auto & associative_ids = intersection_module->getAssociativeIds();
     for (const auto & lane : lane_set) {

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/manager.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/manager.hpp
@@ -21,6 +21,7 @@
 #include <autoware/behavior_velocity_planner_common/plugin_interface.hpp>
 #include <autoware/behavior_velocity_planner_common/plugin_wrapper.hpp>
 #include <autoware/behavior_velocity_planner_common/scene_module_interface.hpp>
+#include <autoware/behavior_velocity_rtc_interface/scene_module_interface_with_rtc.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include <std_msgs/msg/string.hpp>
@@ -47,8 +48,8 @@ private:
 
   void launchNewModules(const tier4_planning_msgs::msg::PathWithLaneId & path) override;
 
-  std::function<bool(const std::shared_ptr<SceneModuleInterface> &)> getModuleExpiredFunction(
-    const tier4_planning_msgs::msg::PathWithLaneId & path) override;
+  std::function<bool(const std::shared_ptr<SceneModuleInterfaceWithRTC> &)>
+  getModuleExpiredFunction(const tier4_planning_msgs::msg::PathWithLaneId & path) override;
 
   bool hasSameParentLaneletAndTurnDirectionWithRegistered(const lanelet::ConstLanelet & lane) const;
 
@@ -63,7 +64,7 @@ private:
     tl_observation_pub_;
 };
 
-class MergeFromPrivateModuleManager : public SceneModuleManagerInterface
+class MergeFromPrivateModuleManager : public SceneModuleManagerInterface<>
 {
 public:
   explicit MergeFromPrivateModuleManager(rclcpp::Node & node);

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_intersection.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_intersection.cpp
@@ -53,7 +53,7 @@ IntersectionModule::IntersectionModule(
   const PlannerParam & planner_param, const std::set<lanelet::Id> & associative_ids,
   const std::string & turn_direction, const bool has_traffic_light, rclcpp::Node & node,
   const rclcpp::Logger logger, const rclcpp::Clock::SharedPtr clock)
-: SceneModuleInterface(module_id, logger, clock),
+: SceneModuleInterfaceWithRTC(module_id, logger, clock),
   planner_param_(planner_param),
   lane_id_(lane_id),
   associative_ids_(associative_ids),

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_intersection.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_intersection.hpp
@@ -22,8 +22,8 @@
 #include "object_manager.hpp"
 #include "result.hpp"
 
-#include <autoware/behavior_velocity_planner_common/scene_module_interface.hpp>
 #include <autoware/behavior_velocity_planner_common/utilization/state_machine.hpp>
+#include <autoware/behavior_velocity_rtc_interface/scene_module_interface_with_rtc.hpp>
 #include <autoware/motion_utils/marker/virtual_wall_marker_creator.hpp>
 #include <rclcpp/rclcpp.hpp>
 
@@ -46,7 +46,7 @@
 namespace autoware::behavior_velocity_planner
 {
 
-class IntersectionModule : public SceneModuleInterface
+class IntersectionModule : public SceneModuleInterfaceWithRTC
 {
 public:
   struct PlannerParam

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_no_drivable_lane_module/src/manager.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_no_drivable_lane_module/src/manager.hpp
@@ -29,7 +29,7 @@
 
 namespace autoware::behavior_velocity_planner
 {
-class NoDrivableLaneModuleManager : public SceneModuleManagerInterface
+class NoDrivableLaneModuleManager : public SceneModuleManagerInterface<>
 {
 public:
   explicit NoDrivableLaneModuleManager(rclcpp::Node & node);

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_no_stopping_area_module/package.xml
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_no_stopping_area_module/package.xml
@@ -18,6 +18,7 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_behavior_velocity_planner_common</depend>
+  <depend>autoware_behavior_velocity_rtc_interface</depend>
   <depend>autoware_interpolation</depend>
   <depend>autoware_lanelet2_extension</depend>
   <depend>autoware_motion_utils</depend>

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_no_stopping_area_module/src/manager.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_no_stopping_area_module/src/manager.cpp
@@ -69,16 +69,17 @@ void NoStoppingAreaModuleManager::launchNewModules(
   }
 }
 
-std::function<bool(const std::shared_ptr<SceneModuleInterface> &)>
+std::function<bool(const std::shared_ptr<SceneModuleInterfaceWithRTC> &)>
 NoStoppingAreaModuleManager::getModuleExpiredFunction(
   const tier4_planning_msgs::msg::PathWithLaneId & path)
 {
   const auto no_stopping_area_id_set = planning_utils::getRegElemIdSetOnPath<NoStoppingArea>(
     path, planner_data_->route_handler_->getLaneletMapPtr(), planner_data_->current_odometry->pose);
 
-  return [no_stopping_area_id_set](const std::shared_ptr<SceneModuleInterface> & scene_module) {
-    return no_stopping_area_id_set.count(scene_module->getModuleId()) == 0;
-  };
+  return
+    [no_stopping_area_id_set](const std::shared_ptr<SceneModuleInterfaceWithRTC> & scene_module) {
+      return no_stopping_area_id_set.count(scene_module->getModuleId()) == 0;
+    };
 }
 
 }  // namespace autoware::behavior_velocity_planner

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_no_stopping_area_module/src/manager.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_no_stopping_area_module/src/manager.hpp
@@ -19,7 +19,7 @@
 
 #include <autoware/behavior_velocity_planner_common/plugin_interface.hpp>
 #include <autoware/behavior_velocity_planner_common/plugin_wrapper.hpp>
-#include <autoware/behavior_velocity_planner_common/scene_module_interface.hpp>
+#include <autoware/behavior_velocity_rtc_interface/scene_module_interface_with_rtc.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include <tier4_planning_msgs/msg/path_with_lane_id.hpp>
@@ -41,8 +41,8 @@ private:
 
   void launchNewModules(const tier4_planning_msgs::msg::PathWithLaneId & path) override;
 
-  std::function<bool(const std::shared_ptr<SceneModuleInterface> &)> getModuleExpiredFunction(
-    const tier4_planning_msgs::msg::PathWithLaneId & path) override;
+  std::function<bool(const std::shared_ptr<SceneModuleInterfaceWithRTC> &)>
+  getModuleExpiredFunction(const tier4_planning_msgs::msg::PathWithLaneId & path) override;
 };
 
 class NoStoppingAreaModulePlugin : public PluginWrapper<NoStoppingAreaModuleManager>

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_no_stopping_area_module/src/scene_no_stopping_area.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_no_stopping_area_module/src/scene_no_stopping_area.cpp
@@ -41,7 +41,7 @@ NoStoppingAreaModule::NoStoppingAreaModule(
   const lanelet::autoware::NoStoppingArea & no_stopping_area_reg_elem,
   const PlannerParam & planner_param, const rclcpp::Logger & logger,
   const rclcpp::Clock::SharedPtr clock)
-: SceneModuleInterface(module_id, logger, clock),
+: SceneModuleInterfaceWithRTC(module_id, logger, clock),
   lane_id_(lane_id),
   no_stopping_area_reg_elem_(no_stopping_area_reg_elem),
   planner_param_(planner_param),

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_no_stopping_area_module/src/scene_no_stopping_area.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_no_stopping_area_module/src/scene_no_stopping_area.hpp
@@ -17,9 +17,9 @@
 
 #include "utils.hpp"
 
-#include <autoware/behavior_velocity_planner_common/scene_module_interface.hpp>
 #include <autoware/behavior_velocity_planner_common/utilization/boost_geometry_helper.hpp>
 #include <autoware/behavior_velocity_planner_common/utilization/state_machine.hpp>
+#include <autoware/behavior_velocity_rtc_interface/scene_module_interface_with_rtc.hpp>
 #include <autoware_lanelet2_extension/regulatory_elements/no_stopping_area.hpp>
 #include <rclcpp/rclcpp.hpp>
 
@@ -31,7 +31,7 @@
 
 namespace autoware::behavior_velocity_planner
 {
-class NoStoppingAreaModule : public SceneModuleInterface
+class NoStoppingAreaModule : public SceneModuleInterfaceWithRTC
 {
 public:
   struct PlannerParam

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_occlusion_spot_module/src/manager.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_occlusion_spot_module/src/manager.hpp
@@ -39,7 +39,7 @@
 
 namespace autoware::behavior_velocity_planner
 {
-class OcclusionSpotModuleManager : public SceneModuleManagerInterface
+class OcclusionSpotModuleManager : public SceneModuleManagerInterface<>
 {
 public:
   explicit OcclusionSpotModuleManager(rclcpp::Node & node);

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/README.md
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/README.md
@@ -1,3 +1,3 @@
 # Behavior Velocity Planner Common
 
-This package provides common functions as a library, which are used in the `behavior_velocity_planner` node and modules.
+This package provides a behavior velocity interface without RTC, and common functions as a library, which are used in the `behavior_velocity_planner` node and modules.

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/include/autoware/behavior_velocity_planner_common/scene_module_interface.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/include/autoware/behavior_velocity_planner_common/scene_module_interface.hpp
@@ -308,6 +308,19 @@ protected:
 
   std::shared_ptr<universe_utils::TimeKeeper> time_keeper_;
 };
+extern template SceneModuleManagerInterface<SceneModuleInterface>::SceneModuleManagerInterface(
+  rclcpp::Node & node, [[maybe_unused]] const char * module_name);
+extern template size_t SceneModuleManagerInterface<SceneModuleInterface>::findEgoSegmentIndex(
+  const std::vector<tier4_planning_msgs::msg::PathPointWithLaneId> & points) const;
+extern template void SceneModuleManagerInterface<SceneModuleInterface>::updateSceneModuleInstances(
+  const std::shared_ptr<const PlannerData> & planner_data,
+  const tier4_planning_msgs::msg::PathWithLaneId & path);
+extern template void SceneModuleManagerInterface<SceneModuleInterface>::modifyPathVelocity(
+  tier4_planning_msgs::msg::PathWithLaneId * path);
+extern template void SceneModuleManagerInterface<SceneModuleInterface>::deleteExpiredModules(
+  const tier4_planning_msgs::msg::PathWithLaneId & path);
+extern template void SceneModuleManagerInterface<SceneModuleInterface>::registerModule(
+  const std::shared_ptr<SceneModuleInterface> & scene_module);
 }  // namespace autoware::behavior_velocity_planner
 
 #endif  // AUTOWARE__BEHAVIOR_VELOCITY_PLANNER_COMMON__SCENE_MODULE_INTERFACE_HPP_

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/include/autoware/behavior_velocity_planner_common/scene_module_interface.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/include/autoware/behavior_velocity_planner_common/scene_module_interface.hpp
@@ -16,12 +16,14 @@
 #define AUTOWARE__BEHAVIOR_VELOCITY_PLANNER_COMMON__SCENE_MODULE_INTERFACE_HPP_
 
 #include <autoware/behavior_velocity_planner_common/planner_data.hpp>
+#include <autoware/behavior_velocity_planner_common/utilization/util.hpp>
 #include <autoware/motion_utils/factor/velocity_factor_interface.hpp>
 #include <autoware/motion_utils/marker/virtual_wall_marker_creator.hpp>
+#include <autoware/motion_utils/trajectory/trajectory.hpp>
 #include <autoware/objects_of_interest_marker_interface/objects_of_interest_marker_interface.hpp>
-#include <autoware/rtc_interface/rtc_interface.hpp>
 #include <autoware/universe_utils/ros/debug_publisher.hpp>
 #include <autoware/universe_utils/ros/parameter.hpp>
+#include <autoware/universe_utils/system/stop_watch.hpp>
 #include <autoware/universe_utils/system/time_keeper.hpp>
 #include <builtin_interfaces/msg/time.hpp>
 
@@ -30,7 +32,6 @@
 #include <autoware_internal_debug_msgs/msg/float64_stamped.hpp>
 #include <autoware_planning_msgs/msg/path.hpp>
 #include <tier4_planning_msgs/msg/path_with_lane_id.hpp>
-#include <tier4_rtc_msgs/msg/state.hpp>
 #include <tier4_v2x_msgs/msg/infrastructure_command_array.hpp>
 #include <unique_identifier_msgs/msg/uuid.hpp>
 
@@ -54,14 +55,12 @@ using autoware::motion_utils::PlanningBehavior;
 using autoware::motion_utils::VelocityFactor;
 using autoware::objects_of_interest_marker_interface::ColorName;
 using autoware::objects_of_interest_marker_interface::ObjectsOfInterestMarkerInterface;
-using autoware::rtc_interface::RTCInterface;
 using autoware::universe_utils::DebugPublisher;
 using autoware::universe_utils::getOrDeclareParameter;
+using autoware::universe_utils::StopWatch;
 using autoware_internal_debug_msgs::msg::Float64Stamped;
 using builtin_interfaces::msg::Time;
 using tier4_planning_msgs::msg::PathWithLaneId;
-using tier4_rtc_msgs::msg::Module;
-using tier4_rtc_msgs::msg::State;
 using unique_identifier_msgs::msg::UUID;
 
 struct ObjectOfInterest
@@ -114,12 +113,6 @@ public:
 
   std::shared_ptr<universe_utils::TimeKeeper> getTimeKeeper() { return time_keeper_; }
 
-  void setActivation(const bool activated) { activated_ = activated; }
-  void setRTCEnabled(const bool enable_rtc) { rtc_enabled_ = enable_rtc; }
-  bool isActivated() const { return activated_; }
-  bool isSafe() const { return safe_; }
-  double getDistance() const { return distance_; }
-
   void resetVelocityFactor() { velocity_factor_.reset(); }
   VelocityFactor getVelocityFactor() const { return velocity_factor_.get(); }
   std::vector<ObjectOfInterest> getObjectsOfInterestData() const { return objects_of_interest_; }
@@ -127,10 +120,6 @@ public:
 
 protected:
   const int64_t module_id_;
-  bool activated_;
-  bool safe_;
-  bool rtc_enabled_;
-  double distance_;
   rclcpp::Logger logger_;
   rclcpp::Clock::SharedPtr clock_;
   std::shared_ptr<const PlannerData> planner_data_;
@@ -138,16 +127,6 @@ protected:
   autoware::motion_utils::VelocityFactorInterface velocity_factor_;
   std::vector<ObjectOfInterest> objects_of_interest_;
   mutable std::shared_ptr<universe_utils::TimeKeeper> time_keeper_;
-
-  void setSafe(const bool safe)
-  {
-    safe_ = safe;
-    if (!rtc_enabled_) {
-      syncActivation();
-    }
-  }
-  void setDistance(const double distance) { distance_ = distance; }
-  void syncActivation() { setActivation(isSafe()); }
 
   void setObjectsOfInterestData(
     const geometry_msgs::msg::Pose & pose, const autoware_perception_msgs::msg::Shape & shape,
@@ -160,10 +139,39 @@ protected:
     const std::vector<tier4_planning_msgs::msg::PathPointWithLaneId> & points) const;
 };
 
+template <class T = SceneModuleInterface>
 class SceneModuleManagerInterface
 {
 public:
-  SceneModuleManagerInterface(rclcpp::Node & node, [[maybe_unused]] const char * module_name);
+  SceneModuleManagerInterface(rclcpp::Node & node, [[maybe_unused]] const char * module_name)
+  : node_(node), clock_(node.get_clock()), logger_(node.get_logger())
+  {
+    const auto ns = std::string("~/debug/") + module_name;
+    pub_debug_ = node.create_publisher<visualization_msgs::msg::MarkerArray>(ns, 1);
+    if (!node.has_parameter("is_publish_debug_path")) {
+      is_publish_debug_path_ = node.declare_parameter<bool>("is_publish_debug_path");
+    } else {
+      is_publish_debug_path_ = node.get_parameter("is_publish_debug_path").as_bool();
+    }
+    if (is_publish_debug_path_) {
+      pub_debug_path_ = node.create_publisher<tier4_planning_msgs::msg::PathWithLaneId>(
+        std::string("~/debug/path_with_lane_id/") + module_name, 1);
+    }
+    pub_virtual_wall_ = node.create_publisher<visualization_msgs::msg::MarkerArray>(
+      std::string("~/virtual_wall/") + module_name, 5);
+    pub_velocity_factor_ = node.create_publisher<autoware_adapi_v1_msgs::msg::VelocityFactorArray>(
+      std::string("/planning/velocity_factors/") + module_name, 1);
+    pub_infrastructure_commands_ =
+      node.create_publisher<tier4_v2x_msgs::msg::InfrastructureCommandArray>(
+        "~/output/infrastructure_commands", 1);
+
+    processing_time_publisher_ = std::make_shared<DebugPublisher>(&node, "~/debug");
+
+    pub_processing_time_detail_ = node.create_publisher<universe_utils::ProcessingTimeDetail>(
+      "~/debug/processing_time_detail_ms/" + std::string(module_name), 1);
+
+    time_keeper_ = std::make_shared<universe_utils::TimeKeeper>(pub_processing_time_detail_);
+  }
 
   virtual ~SceneModuleManagerInterface() = default;
 
@@ -171,31 +179,111 @@ public:
 
   void updateSceneModuleInstances(
     const std::shared_ptr<const PlannerData> & planner_data,
-    const tier4_planning_msgs::msg::PathWithLaneId & path);
+    const tier4_planning_msgs::msg::PathWithLaneId & path)
+  {
+    planner_data_ = planner_data;
+
+    launchNewModules(path);
+    deleteExpiredModules(path);
+  }
 
   virtual void plan(tier4_planning_msgs::msg::PathWithLaneId * path) { modifyPathVelocity(path); }
 
 protected:
-  virtual void modifyPathVelocity(tier4_planning_msgs::msg::PathWithLaneId * path);
+  virtual void modifyPathVelocity(tier4_planning_msgs::msg::PathWithLaneId * path)
+  {
+    universe_utils::ScopedTimeTrack st(
+      "SceneModuleManagerInterface::modifyPathVelocity", *time_keeper_);
+    StopWatch<std::chrono::milliseconds> stop_watch;
+    stop_watch.tic("Total");
+    visualization_msgs::msg::MarkerArray debug_marker_array;
+    autoware_adapi_v1_msgs::msg::VelocityFactorArray velocity_factor_array;
+    velocity_factor_array.header.frame_id = "map";
+    velocity_factor_array.header.stamp = clock_->now();
+
+    tier4_v2x_msgs::msg::InfrastructureCommandArray infrastructure_command_array;
+    infrastructure_command_array.stamp = clock_->now();
+
+    for (const auto & scene_module : scene_modules_) {
+      scene_module->resetVelocityFactor();
+      scene_module->setPlannerData(planner_data_);
+      scene_module->modifyPathVelocity(path);
+
+      // The velocity factor must be called after modifyPathVelocity.
+      const auto velocity_factor = scene_module->getVelocityFactor();
+      if (velocity_factor.behavior != PlanningBehavior::UNKNOWN) {
+        velocity_factor_array.factors.emplace_back(velocity_factor);
+      }
+
+      if (const auto command = scene_module->getInfrastructureCommand()) {
+        infrastructure_command_array.commands.push_back(*command);
+      }
+
+      for (const auto & marker : scene_module->createDebugMarkerArray().markers) {
+        debug_marker_array.markers.push_back(marker);
+      }
+
+      virtual_wall_marker_creator_.add_virtual_walls(scene_module->createVirtualWalls());
+    }
+
+    pub_velocity_factor_->publish(velocity_factor_array);
+    pub_infrastructure_commands_->publish(infrastructure_command_array);
+    pub_debug_->publish(debug_marker_array);
+    if (is_publish_debug_path_) {
+      tier4_planning_msgs::msg::PathWithLaneId debug_path;
+      debug_path.header = path->header;
+      debug_path.points = path->points;
+      pub_debug_path_->publish(debug_path);
+    }
+    pub_virtual_wall_->publish(virtual_wall_marker_creator_.create_markers(clock_->now()));
+    processing_time_publisher_->publish<Float64Stamped>(
+      std::string(getModuleName()) + "/processing_time_ms", stop_watch.toc("Total"));
+  }
 
   virtual void launchNewModules(const tier4_planning_msgs::msg::PathWithLaneId & path) = 0;
 
-  virtual std::function<bool(const std::shared_ptr<SceneModuleInterface> &)>
-  getModuleExpiredFunction(const tier4_planning_msgs::msg::PathWithLaneId & path) = 0;
+  virtual std::function<bool(const std::shared_ptr<T> &)> getModuleExpiredFunction(
+    const tier4_planning_msgs::msg::PathWithLaneId & path) = 0;
 
-  virtual void deleteExpiredModules(const tier4_planning_msgs::msg::PathWithLaneId & path);
+  virtual void deleteExpiredModules(const tier4_planning_msgs::msg::PathWithLaneId & path)
+  {
+    const auto isModuleExpired = getModuleExpiredFunction(path);
+
+    auto itr = scene_modules_.begin();
+    while (itr != scene_modules_.end()) {
+      if (isModuleExpired(*itr)) {
+        itr = scene_modules_.erase(itr);
+      } else {
+        itr++;
+      }
+    }
+  }
 
   bool isModuleRegistered(const int64_t module_id)
   {
     return registered_module_id_set_.count(module_id) != 0;
   }
 
-  void registerModule(const std::shared_ptr<SceneModuleInterface> & scene_module);
+  void registerModule(const std::shared_ptr<T> & scene_module)
+  {
+    RCLCPP_DEBUG(
+      logger_, "register task: module = %s, id = %lu", getModuleName(),
+      scene_module->getModuleId());
+    registered_module_id_set_.emplace(scene_module->getModuleId());
+    scene_module->setTimeKeeper(time_keeper_);
+    scene_modules_.insert(scene_module);
+  }
 
   size_t findEgoSegmentIndex(
-    const std::vector<tier4_planning_msgs::msg::PathPointWithLaneId> & points) const;
+    const std::vector<tier4_planning_msgs::msg::PathPointWithLaneId> & points) const
+  {
+    const auto & p = planner_data_;
+    return autoware::motion_utils::findFirstNearestSegmentIndexWithSoftConstraints(
+      points, p->current_odometry->pose, p->ego_nearest_dist_threshold,
+      p->ego_nearest_yaw_threshold);
+  }
 
-  std::set<std::shared_ptr<SceneModuleInterface>> scene_modules_;
+  std::set<std::shared_ptr<T>> scene_modules_;
   std::set<int64_t> registered_module_id_set_;
 
   std::shared_ptr<const PlannerData> planner_data_;
@@ -220,66 +308,6 @@ protected:
 
   std::shared_ptr<universe_utils::TimeKeeper> time_keeper_;
 };
-
-class SceneModuleManagerInterfaceWithRTC : public SceneModuleManagerInterface
-{
-public:
-  SceneModuleManagerInterfaceWithRTC(
-    rclcpp::Node & node, const char * module_name, const bool enable_rtc = true);
-
-  void plan(tier4_planning_msgs::msg::PathWithLaneId * path) override;
-
-protected:
-  RTCInterface rtc_interface_;
-  std::unordered_map<int64_t, UUID> map_uuid_;
-
-  ObjectsOfInterestMarkerInterface objects_of_interest_marker_interface_;
-
-  virtual void sendRTC(const Time & stamp);
-
-  virtual void setActivation();
-
-  void updateRTCStatus(
-    const UUID & uuid, const bool safe, const uint8_t state, const double distance,
-    const Time & stamp)
-  {
-    rtc_interface_.updateCooperateStatus(uuid, safe, state, distance, distance, stamp);
-  }
-
-  void removeRTCStatus(const UUID & uuid) { rtc_interface_.removeCooperateStatus(uuid); }
-
-  void publishRTCStatus(const Time & stamp)
-  {
-    rtc_interface_.removeExpiredCooperateStatus();
-    rtc_interface_.publishCooperateStatus(stamp);
-  }
-
-  UUID getUUID(const int64_t & module_id) const;
-
-  void generateUUID(const int64_t & module_id);
-
-  void removeUUID(const int64_t & module_id);
-
-  void publishObjectsOfInterestMarker();
-
-  void deleteExpiredModules(const tier4_planning_msgs::msg::PathWithLaneId & path) override;
-
-  static bool getEnableRTC(rclcpp::Node & node, const std::string & param_name)
-  {
-    bool enable_rtc = true;
-
-    try {
-      enable_rtc = getOrDeclareParameter<bool>(node, "enable_all_modules_auto_mode")
-                     ? false
-                     : getOrDeclareParameter<bool>(node, param_name);
-    } catch (const std::exception & e) {
-      enable_rtc = getOrDeclareParameter<bool>(node, param_name);
-    }
-
-    return enable_rtc;
-  }
-};
-
 }  // namespace autoware::behavior_velocity_planner
 
 #endif  // AUTOWARE__BEHAVIOR_VELOCITY_PLANNER_COMMON__SCENE_MODULE_INTERFACE_HPP_

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/package.xml
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/package.xml
@@ -29,7 +29,6 @@
   <depend>autoware_perception_msgs</depend>
   <depend>autoware_planning_msgs</depend>
   <depend>autoware_route_handler</depend>
-  <depend>autoware_rtc_interface</depend>
   <depend>autoware_universe_utils</depend>
   <depend>autoware_vehicle_info_utils</depend>
   <depend>autoware_velocity_smoother</depend>

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/src/scene_module_interface.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/src/scene_module_interface.cpp
@@ -13,29 +13,20 @@
 // limitations under the License.
 
 #include <autoware/behavior_velocity_planner_common/scene_module_interface.hpp>
-#include <autoware/behavior_velocity_planner_common/utilization/util.hpp>
 #include <autoware/motion_utils/trajectory/trajectory.hpp>
-#include <autoware/universe_utils/ros/uuid_helper.hpp>
-#include <autoware/universe_utils/system/stop_watch.hpp>
 #include <autoware/universe_utils/system/time_keeper.hpp>
 
 #include <algorithm>
 #include <limits>
 #include <memory>
-#include <string>
 #include <vector>
 
 namespace autoware::behavior_velocity_planner
 {
 
-using autoware::universe_utils::StopWatch;
-
 SceneModuleInterface::SceneModuleInterface(
   const int64_t module_id, rclcpp::Logger logger, rclcpp::Clock::SharedPtr clock)
 : module_id_(module_id),
-  activated_(false),
-  safe_(false),
-  distance_(std::numeric_limits<double>::lowest()),
   logger_(logger),
   clock_(clock),
   time_keeper_(std::shared_ptr<universe_utils::TimeKeeper>())
@@ -50,222 +41,17 @@ size_t SceneModuleInterface::findEgoSegmentIndex(
     points, p->current_odometry->pose, p->ego_nearest_dist_threshold);
 }
 
-SceneModuleManagerInterface::SceneModuleManagerInterface(
-  rclcpp::Node & node, [[maybe_unused]] const char * module_name)
-: node_(node), clock_(node.get_clock()), logger_(node.get_logger())
-{
-  const auto ns = std::string("~/debug/") + module_name;
-  pub_debug_ = node.create_publisher<visualization_msgs::msg::MarkerArray>(ns, 1);
-  if (!node.has_parameter("is_publish_debug_path")) {
-    is_publish_debug_path_ = node.declare_parameter<bool>("is_publish_debug_path");
-  } else {
-    is_publish_debug_path_ = node.get_parameter("is_publish_debug_path").as_bool();
-  }
-  if (is_publish_debug_path_) {
-    pub_debug_path_ = node.create_publisher<tier4_planning_msgs::msg::PathWithLaneId>(
-      std::string("~/debug/path_with_lane_id/") + module_name, 1);
-  }
-  pub_virtual_wall_ = node.create_publisher<visualization_msgs::msg::MarkerArray>(
-    std::string("~/virtual_wall/") + module_name, 5);
-  pub_velocity_factor_ = node.create_publisher<autoware_adapi_v1_msgs::msg::VelocityFactorArray>(
-    std::string("/planning/velocity_factors/") + module_name, 1);
-  pub_infrastructure_commands_ =
-    node.create_publisher<tier4_v2x_msgs::msg::InfrastructureCommandArray>(
-      "~/output/infrastructure_commands", 1);
-
-  processing_time_publisher_ = std::make_shared<DebugPublisher>(&node, "~/debug");
-
-  pub_processing_time_detail_ = node.create_publisher<universe_utils::ProcessingTimeDetail>(
-    "~/debug/processing_time_detail_ms/" + std::string(module_name), 1);
-
-  time_keeper_ = std::make_shared<universe_utils::TimeKeeper>(pub_processing_time_detail_);
-}
-
-size_t SceneModuleManagerInterface::findEgoSegmentIndex(
-  const std::vector<tier4_planning_msgs::msg::PathPointWithLaneId> & points) const
-{
-  const auto & p = planner_data_;
-  return autoware::motion_utils::findFirstNearestSegmentIndexWithSoftConstraints(
-    points, p->current_odometry->pose, p->ego_nearest_dist_threshold, p->ego_nearest_yaw_threshold);
-}
-
-void SceneModuleManagerInterface::updateSceneModuleInstances(
+template SceneModuleManagerInterface<SceneModuleInterface>::SceneModuleManagerInterface(
+  rclcpp::Node & node, [[maybe_unused]] const char * module_name);
+template size_t SceneModuleManagerInterface<SceneModuleInterface>::findEgoSegmentIndex(
+  const std::vector<tier4_planning_msgs::msg::PathPointWithLaneId> & points) const;
+template void SceneModuleManagerInterface<SceneModuleInterface>::updateSceneModuleInstances(
   const std::shared_ptr<const PlannerData> & planner_data,
-  const tier4_planning_msgs::msg::PathWithLaneId & path)
-{
-  planner_data_ = planner_data;
-
-  launchNewModules(path);
-  deleteExpiredModules(path);
-}
-
-void SceneModuleManagerInterface::modifyPathVelocity(
-  tier4_planning_msgs::msg::PathWithLaneId * path)
-{
-  universe_utils::ScopedTimeTrack st(
-    "SceneModuleManagerInterface::modifyPathVelocity", *time_keeper_);
-  StopWatch<std::chrono::milliseconds> stop_watch;
-  stop_watch.tic("Total");
-  visualization_msgs::msg::MarkerArray debug_marker_array;
-  autoware_adapi_v1_msgs::msg::VelocityFactorArray velocity_factor_array;
-  velocity_factor_array.header.frame_id = "map";
-  velocity_factor_array.header.stamp = clock_->now();
-
-  tier4_v2x_msgs::msg::InfrastructureCommandArray infrastructure_command_array;
-  infrastructure_command_array.stamp = clock_->now();
-
-  for (const auto & scene_module : scene_modules_) {
-    scene_module->resetVelocityFactor();
-    scene_module->setPlannerData(planner_data_);
-    scene_module->modifyPathVelocity(path);
-
-    // The velocity factor must be called after modifyPathVelocity.
-    const auto velocity_factor = scene_module->getVelocityFactor();
-    if (velocity_factor.behavior != PlanningBehavior::UNKNOWN) {
-      velocity_factor_array.factors.emplace_back(velocity_factor);
-    }
-
-    if (const auto command = scene_module->getInfrastructureCommand()) {
-      infrastructure_command_array.commands.push_back(*command);
-    }
-
-    for (const auto & marker : scene_module->createDebugMarkerArray().markers) {
-      debug_marker_array.markers.push_back(marker);
-    }
-
-    virtual_wall_marker_creator_.add_virtual_walls(scene_module->createVirtualWalls());
-  }
-
-  pub_velocity_factor_->publish(velocity_factor_array);
-  pub_infrastructure_commands_->publish(infrastructure_command_array);
-  pub_debug_->publish(debug_marker_array);
-  if (is_publish_debug_path_) {
-    tier4_planning_msgs::msg::PathWithLaneId debug_path;
-    debug_path.header = path->header;
-    debug_path.points = path->points;
-    pub_debug_path_->publish(debug_path);
-  }
-  pub_virtual_wall_->publish(virtual_wall_marker_creator_.create_markers(clock_->now()));
-  processing_time_publisher_->publish<Float64Stamped>(
-    std::string(getModuleName()) + "/processing_time_ms", stop_watch.toc("Total"));
-}
-
-void SceneModuleManagerInterface::deleteExpiredModules(
-  const tier4_planning_msgs::msg::PathWithLaneId & path)
-{
-  const auto isModuleExpired = getModuleExpiredFunction(path);
-
-  auto itr = scene_modules_.begin();
-  while (itr != scene_modules_.end()) {
-    if (isModuleExpired(*itr)) {
-      itr = scene_modules_.erase(itr);
-    } else {
-      itr++;
-    }
-  }
-}
-
-void SceneModuleManagerInterface::registerModule(
-  const std::shared_ptr<SceneModuleInterface> & scene_module)
-{
-  RCLCPP_DEBUG(
-    logger_, "register task: module = %s, id = %lu", getModuleName(), scene_module->getModuleId());
-  registered_module_id_set_.emplace(scene_module->getModuleId());
-  scene_module->setTimeKeeper(time_keeper_);
-  scene_modules_.insert(scene_module);
-}
-
-SceneModuleManagerInterfaceWithRTC::SceneModuleManagerInterfaceWithRTC(
-  rclcpp::Node & node, const char * module_name, const bool enable_rtc)
-: SceneModuleManagerInterface(node, module_name),
-  rtc_interface_(&node, module_name, enable_rtc),
-  objects_of_interest_marker_interface_(&node, module_name)
-{
-}
-
-void SceneModuleManagerInterfaceWithRTC::plan(tier4_planning_msgs::msg::PathWithLaneId * path)
-{
-  setActivation();
-  modifyPathVelocity(path);
-  sendRTC(path->header.stamp);
-  publishObjectsOfInterestMarker();
-}
-
-void SceneModuleManagerInterfaceWithRTC::sendRTC(const Time & stamp)
-{
-  for (const auto & scene_module : scene_modules_) {
-    const UUID uuid = getUUID(scene_module->getModuleId());
-    const auto state = !scene_module->isActivated() && scene_module->isSafe()
-                         ? State::WAITING_FOR_EXECUTION
-                         : State::RUNNING;
-    updateRTCStatus(uuid, scene_module->isSafe(), state, scene_module->getDistance(), stamp);
-  }
-  publishRTCStatus(stamp);
-}
-
-void SceneModuleManagerInterfaceWithRTC::setActivation()
-{
-  for (const auto & scene_module : scene_modules_) {
-    const UUID uuid = getUUID(scene_module->getModuleId());
-    scene_module->setActivation(rtc_interface_.isActivated(uuid));
-    scene_module->setRTCEnabled(rtc_interface_.isRTCEnabled(uuid));
-  }
-}
-
-UUID SceneModuleManagerInterfaceWithRTC::getUUID(const int64_t & module_id) const
-{
-  if (map_uuid_.count(module_id) == 0) {
-    const UUID uuid;
-    return uuid;
-  }
-  return map_uuid_.at(module_id);
-}
-
-void SceneModuleManagerInterfaceWithRTC::generateUUID(const int64_t & module_id)
-{
-  map_uuid_.insert({module_id, autoware::universe_utils::generateUUID()});
-}
-
-void SceneModuleManagerInterfaceWithRTC::removeUUID(const int64_t & module_id)
-{
-  const auto result = map_uuid_.erase(module_id);
-  if (result == 0) {
-    RCLCPP_WARN_STREAM(logger_, "[removeUUID] module_id = " << module_id << " is not registered.");
-  }
-}
-
-void SceneModuleManagerInterfaceWithRTC::publishObjectsOfInterestMarker()
-{
-  for (const auto & scene_module : scene_modules_) {
-    const auto objects = scene_module->getObjectsOfInterestData();
-    for (const auto & obj : objects) {
-      objects_of_interest_marker_interface_.insertObjectData(obj.pose, obj.shape, obj.color);
-    }
-    scene_module->clearObjectsOfInterestData();
-  }
-
-  objects_of_interest_marker_interface_.publishMarkerArray();
-}
-
-void SceneModuleManagerInterfaceWithRTC::deleteExpiredModules(
-  const tier4_planning_msgs::msg::PathWithLaneId & path)
-{
-  const auto isModuleExpired = getModuleExpiredFunction(path);
-
-  auto itr = scene_modules_.begin();
-  while (itr != scene_modules_.end()) {
-    if (isModuleExpired(*itr)) {
-      const UUID uuid = getUUID((*itr)->getModuleId());
-      updateRTCStatus(
-        uuid, (*itr)->isSafe(), State::SUCCEEDED, std::numeric_limits<double>::lowest(),
-        clock_->now());
-      removeUUID((*itr)->getModuleId());
-      registered_module_id_set_.erase((*itr)->getModuleId());
-      itr = scene_modules_.erase(itr);
-    } else {
-      itr++;
-    }
-  }
-}
-
+  const tier4_planning_msgs::msg::PathWithLaneId & path);
+template void SceneModuleManagerInterface<SceneModuleInterface>::modifyPathVelocity(
+  tier4_planning_msgs::msg::PathWithLaneId * path);
+template void SceneModuleManagerInterface<SceneModuleInterface>::deleteExpiredModules(
+  const tier4_planning_msgs::msg::PathWithLaneId & path);
+template void SceneModuleManagerInterface<SceneModuleInterface>::registerModule(
+  const std::shared_ptr<SceneModuleInterface> & scene_module);
 }  // namespace autoware::behavior_velocity_planner

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_rtc_interface/CMakeLists.txt
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_rtc_interface/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.14)
+project(autoware_behavior_velocity_rtc_interface)
+
+find_package(autoware_cmake REQUIRED)
+autoware_package()
+
+ament_auto_add_library(${PROJECT_NAME} SHARED
+  src/scene_module_interface_with_rtc.cpp
+)
+
+ament_auto_package(INSTALL_TO_SHARE)

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_rtc_interface/README.md
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_rtc_interface/README.md
@@ -1,0 +1,3 @@
+# Behavior Velocity RTC Interface
+
+This package provides a behavior velocity interface with RTC, which are used in the `behavior_velocity_planner` node and modules.

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_rtc_interface/include/autoware/behavior_velocity_rtc_interface/scene_module_interface_with_rtc.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_rtc_interface/include/autoware/behavior_velocity_rtc_interface/scene_module_interface_with_rtc.hpp
@@ -136,16 +136,19 @@ protected:
 
     return enable_rtc;
   }
-extern template size_t SceneModuleManagerInterface<SceneModuleInterfaceWithRTC>::findEgoSegmentIndex(
+};
+
+extern template size_t
+SceneModuleManagerInterface<SceneModuleInterfaceWithRTC>::findEgoSegmentIndex(
   const std::vector<tier4_planning_msgs::msg::PathPointWithLaneId> & points) const;
-extern template void SceneModuleManagerInterface<SceneModuleInterfaceWithRTC>::updateSceneModuleInstances(
+extern template void
+SceneModuleManagerInterface<SceneModuleInterfaceWithRTC>::updateSceneModuleInstances(
   const std::shared_ptr<const PlannerData> & planner_data,
   const tier4_planning_msgs::msg::PathWithLaneId & path);
 extern template void SceneModuleManagerInterface<SceneModuleInterfaceWithRTC>::modifyPathVelocity(
   tier4_planning_msgs::msg::PathWithLaneId * path);
 extern template void SceneModuleManagerInterface<SceneModuleInterfaceWithRTC>::registerModule(
   const std::shared_ptr<SceneModuleInterfaceWithRTC> & scene_module);
-};
 }  // namespace autoware::behavior_velocity_planner
 
 #endif  // AUTOWARE__BEHAVIOR_VELOCITY_RTC_INTERFACE__SCENE_MODULE_INTERFACE_WITH_RTC_HPP_

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_rtc_interface/include/autoware/behavior_velocity_rtc_interface/scene_module_interface_with_rtc.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_rtc_interface/include/autoware/behavior_velocity_rtc_interface/scene_module_interface_with_rtc.hpp
@@ -136,6 +136,15 @@ protected:
 
     return enable_rtc;
   }
+extern template size_t SceneModuleManagerInterface<SceneModuleInterfaceWithRTC>::findEgoSegmentIndex(
+  const std::vector<tier4_planning_msgs::msg::PathPointWithLaneId> & points) const;
+extern template void SceneModuleManagerInterface<SceneModuleInterfaceWithRTC>::updateSceneModuleInstances(
+  const std::shared_ptr<const PlannerData> & planner_data,
+  const tier4_planning_msgs::msg::PathWithLaneId & path);
+extern template void SceneModuleManagerInterface<SceneModuleInterfaceWithRTC>::modifyPathVelocity(
+  tier4_planning_msgs::msg::PathWithLaneId * path);
+extern template void SceneModuleManagerInterface<SceneModuleInterfaceWithRTC>::registerModule(
+  const std::shared_ptr<SceneModuleInterfaceWithRTC> & scene_module);
 };
 }  // namespace autoware::behavior_velocity_planner
 

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_rtc_interface/include/autoware/behavior_velocity_rtc_interface/scene_module_interface_with_rtc.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_rtc_interface/include/autoware/behavior_velocity_rtc_interface/scene_module_interface_with_rtc.hpp
@@ -1,0 +1,142 @@
+// Copyright 2020 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__BEHAVIOR_VELOCITY_RTC_INTERFACE__SCENE_MODULE_INTERFACE_WITH_RTC_HPP_
+#define AUTOWARE__BEHAVIOR_VELOCITY_RTC_INTERFACE__SCENE_MODULE_INTERFACE_WITH_RTC_HPP_
+
+#include <autoware/behavior_velocity_planner_common/planner_data.hpp>
+#include <autoware/behavior_velocity_planner_common/scene_module_interface.hpp>
+#include <autoware/rtc_interface/rtc_interface.hpp>
+#include <autoware/universe_utils/ros/parameter.hpp>
+#include <builtin_interfaces/msg/time.hpp>
+
+#include <autoware_planning_msgs/msg/path.hpp>
+#include <tier4_planning_msgs/msg/path_with_lane_id.hpp>
+#include <tier4_rtc_msgs/msg/state.hpp>
+#include <unique_identifier_msgs/msg/uuid.hpp>
+
+#include <memory>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+// Debug
+#include <rclcpp/publisher.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+namespace autoware::behavior_velocity_planner
+{
+
+using autoware::rtc_interface::RTCInterface;
+using autoware::universe_utils::getOrDeclareParameter;
+using builtin_interfaces::msg::Time;
+using tier4_planning_msgs::msg::PathWithLaneId;
+using tier4_rtc_msgs::msg::Module;
+using tier4_rtc_msgs::msg::State;
+using unique_identifier_msgs::msg::UUID;
+
+class SceneModuleInterfaceWithRTC : public SceneModuleInterface
+{
+public:
+  explicit SceneModuleInterfaceWithRTC(
+    const int64_t module_id, rclcpp::Logger logger, rclcpp::Clock::SharedPtr clock);
+  virtual ~SceneModuleInterfaceWithRTC() = default;
+
+  void setActivation(const bool activated) { activated_ = activated; }
+  void setRTCEnabled(const bool enable_rtc) { rtc_enabled_ = enable_rtc; }
+  bool isActivated() const { return activated_; }
+  bool isSafe() const { return safe_; }
+  double getDistance() const { return distance_; }
+
+protected:
+  bool activated_;
+  bool safe_;
+  bool rtc_enabled_;
+  double distance_;
+
+  void setSafe(const bool safe)
+  {
+    safe_ = safe;
+    if (!rtc_enabled_) {
+      syncActivation();
+    }
+  }
+  void setDistance(const double distance) { distance_ = distance; }
+  void syncActivation() { setActivation(isSafe()); }
+};
+
+class SceneModuleManagerInterfaceWithRTC
+: public SceneModuleManagerInterface<SceneModuleInterfaceWithRTC>
+{
+public:
+  SceneModuleManagerInterfaceWithRTC(
+    rclcpp::Node & node, const char * module_name, const bool enable_rtc = true);
+
+  void plan(tier4_planning_msgs::msg::PathWithLaneId * path) override;
+
+protected:
+  RTCInterface rtc_interface_;
+  std::unordered_map<int64_t, UUID> map_uuid_;
+
+  ObjectsOfInterestMarkerInterface objects_of_interest_marker_interface_;
+
+  virtual void sendRTC(const Time & stamp);
+
+  virtual void setActivation();
+
+  void updateRTCStatus(
+    const UUID & uuid, const bool safe, const uint8_t state, const double distance,
+    const Time & stamp)
+  {
+    rtc_interface_.updateCooperateStatus(uuid, safe, state, distance, distance, stamp);
+  }
+
+  void removeRTCStatus(const UUID & uuid) { rtc_interface_.removeCooperateStatus(uuid); }
+
+  void publishRTCStatus(const Time & stamp)
+  {
+    rtc_interface_.removeExpiredCooperateStatus();
+    rtc_interface_.publishCooperateStatus(stamp);
+  }
+
+  UUID getUUID(const int64_t & module_id) const;
+
+  void generateUUID(const int64_t & module_id);
+
+  void removeUUID(const int64_t & module_id);
+
+  void publishObjectsOfInterestMarker();
+
+  void deleteExpiredModules(const tier4_planning_msgs::msg::PathWithLaneId & path) override;
+
+  static bool getEnableRTC(rclcpp::Node & node, const std::string & param_name)
+  {
+    bool enable_rtc = true;
+
+    try {
+      enable_rtc = getOrDeclareParameter<bool>(node, "enable_all_modules_auto_mode")
+                     ? false
+                     : getOrDeclareParameter<bool>(node, param_name);
+    } catch (const std::exception & e) {
+      enable_rtc = getOrDeclareParameter<bool>(node, param_name);
+    }
+
+    return enable_rtc;
+  }
+};
+}  // namespace autoware::behavior_velocity_planner
+
+#endif  // AUTOWARE__BEHAVIOR_VELOCITY_RTC_INTERFACE__SCENE_MODULE_INTERFACE_WITH_RTC_HPP_

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_rtc_interface/package.xml
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_rtc_interface/package.xml
@@ -1,47 +1,32 @@
 <?xml version="1.0"?>
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
-  <name>autoware_behavior_velocity_intersection_module</name>
+  <name>autoware_behavior_velocity_rtc_interface</name>
   <version>0.40.0</version>
-  <description>The autoware_behavior_velocity_intersection_module package</description>
+  <description>The autoware_behavior_velocity_rtc_interface package</description>
 
   <maintainer email="mamoru.sobue@tier4.jp">Mamoru Sobue</maintainer>
   <maintainer email="takayuki.murooka@tier4.jp">Takayuki Murooka</maintainer>
   <maintainer email="tomoya.kimura@tier4.jp">Tomoya Kimura</maintainer>
   <maintainer email="shumpei.wakabayashi@tier4.jp">Shumpei Wakabayashi</maintainer>
-  <maintainer email="kyoichi.sugahara@tier4.jp">Kyoichi Sugahara</maintainer>
-  <maintainer email="yukinari.hisaki.2@tier4.jp">Yukinari Hisaki</maintainer>
+  <maintainer email="isamu.takagi@tier4.jp">Takagi, Isamu</maintainer>
+  <maintainer email="fumiya.watanabe@tier4.jp">Fumiya Watanabe</maintainer>
 
   <license>Apache License 2.0</license>
 
-  <author email="mamoru.sobue@tier4.jp">Mamoru Sobue</author>
+  <author email="takayuki.murooka@tier4.jp">Takayuki Murooka</author>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_behavior_velocity_planner_common</depend>
-  <depend>autoware_behavior_velocity_rtc_interface</depend>
-  <depend>autoware_internal_debug_msgs</depend>
-  <depend>autoware_interpolation</depend>
-  <depend>autoware_lanelet2_extension</depend>
   <depend>autoware_motion_utils</depend>
-  <depend>autoware_perception_msgs</depend>
   <depend>autoware_planning_msgs</depend>
-  <depend>autoware_route_handler</depend>
   <depend>autoware_rtc_interface</depend>
-  <depend>autoware_test_utils</depend>
   <depend>autoware_universe_utils</depend>
-  <depend>autoware_vehicle_info_utils</depend>
-  <depend>fmt</depend>
-  <depend>geometry_msgs</depend>
-  <depend>libopencv-dev</depend>
-  <depend>magic_enum</depend>
-  <depend>nav_msgs</depend>
-  <depend>pluginlib</depend>
   <depend>rclcpp</depend>
-  <depend>tf2_geometry_msgs</depend>
+  <depend>rclcpp_components</depend>
   <depend>tier4_planning_msgs</depend>
-  <depend>visualization_msgs</depend>
 
   <test_depend>ament_cmake_ros</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_rtc_interface/src/scene_module_interface_with_rtc.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_rtc_interface/src/scene_module_interface_with_rtc.cpp
@@ -1,0 +1,140 @@
+// Copyright 2023 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <autoware/behavior_velocity_planner_common/scene_module_interface.hpp>
+#include <autoware/behavior_velocity_planner_common/utilization/util.hpp>
+#include <autoware/behavior_velocity_rtc_interface/scene_module_interface_with_rtc.hpp>
+#include <autoware/universe_utils/ros/uuid_helper.hpp>
+
+#include <algorithm>
+#include <limits>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace autoware::behavior_velocity_planner
+{
+
+SceneModuleInterfaceWithRTC::SceneModuleInterfaceWithRTC(
+  const int64_t module_id, rclcpp::Logger logger, rclcpp::Clock::SharedPtr clock)
+: SceneModuleInterface(module_id, logger, clock),
+  activated_(false),
+  safe_(false),
+  distance_(std::numeric_limits<double>::lowest())
+{
+}
+
+SceneModuleManagerInterfaceWithRTC::SceneModuleManagerInterfaceWithRTC(
+  rclcpp::Node & node, const char * module_name, const bool enable_rtc)
+: SceneModuleManagerInterface<SceneModuleInterfaceWithRTC>(node, module_name),
+  rtc_interface_(&node, module_name, enable_rtc),
+  objects_of_interest_marker_interface_(&node, module_name)
+{
+}
+
+void SceneModuleManagerInterfaceWithRTC::plan(tier4_planning_msgs::msg::PathWithLaneId * path)
+{
+  setActivation();
+  modifyPathVelocity(path);
+  sendRTC(path->header.stamp);
+  publishObjectsOfInterestMarker();
+}
+
+void SceneModuleManagerInterfaceWithRTC::sendRTC(const Time & stamp)
+{
+  for (const auto & scene_module : scene_modules_) {
+    const UUID uuid = getUUID(scene_module->getModuleId());
+    const auto state = !scene_module->isActivated() && scene_module->isSafe()
+                         ? State::WAITING_FOR_EXECUTION
+                         : State::RUNNING;
+    updateRTCStatus(uuid, scene_module->isSafe(), state, scene_module->getDistance(), stamp);
+  }
+  publishRTCStatus(stamp);
+}
+
+void SceneModuleManagerInterfaceWithRTC::setActivation()
+{
+  for (const auto & scene_module : scene_modules_) {
+    const UUID uuid = getUUID(scene_module->getModuleId());
+    scene_module->setActivation(rtc_interface_.isActivated(uuid));
+    scene_module->setRTCEnabled(rtc_interface_.isRTCEnabled(uuid));
+  }
+}
+
+UUID SceneModuleManagerInterfaceWithRTC::getUUID(const int64_t & module_id) const
+{
+  if (map_uuid_.count(module_id) == 0) {
+    const UUID uuid;
+    return uuid;
+  }
+  return map_uuid_.at(module_id);
+}
+
+void SceneModuleManagerInterfaceWithRTC::generateUUID(const int64_t & module_id)
+{
+  map_uuid_.insert({module_id, autoware::universe_utils::generateUUID()});
+}
+
+void SceneModuleManagerInterfaceWithRTC::removeUUID(const int64_t & module_id)
+{
+  const auto result = map_uuid_.erase(module_id);
+  if (result == 0) {
+    RCLCPP_WARN_STREAM(logger_, "[removeUUID] module_id = " << module_id << " is not registered.");
+  }
+}
+
+void SceneModuleManagerInterfaceWithRTC::publishObjectsOfInterestMarker()
+{
+  for (const auto & scene_module : scene_modules_) {
+    const auto objects = scene_module->getObjectsOfInterestData();
+    for (const auto & obj : objects) {
+      objects_of_interest_marker_interface_.insertObjectData(obj.pose, obj.shape, obj.color);
+    }
+    scene_module->clearObjectsOfInterestData();
+  }
+
+  objects_of_interest_marker_interface_.publishMarkerArray();
+}
+
+void SceneModuleManagerInterfaceWithRTC::deleteExpiredModules(
+  const tier4_planning_msgs::msg::PathWithLaneId & path)
+{
+  const auto isModuleExpired = getModuleExpiredFunction(path);
+
+  auto itr = scene_modules_.begin();
+  while (itr != scene_modules_.end()) {
+    if (isModuleExpired(*itr)) {
+      const UUID uuid = getUUID((*itr)->getModuleId());
+      updateRTCStatus(
+        uuid, (*itr)->isSafe(), State::SUCCEEDED, std::numeric_limits<double>::lowest(),
+        clock_->now());
+      removeUUID((*itr)->getModuleId());
+      registered_module_id_set_.erase((*itr)->getModuleId());
+      itr = scene_modules_.erase(itr);
+    } else {
+      itr++;
+    }
+  }
+}
+
+template size_t SceneModuleManagerInterface<SceneModuleInterfaceWithRTC>::findEgoSegmentIndex(
+  const std::vector<tier4_planning_msgs::msg::PathPointWithLaneId> & points) const;
+template void SceneModuleManagerInterface<SceneModuleInterfaceWithRTC>::updateSceneModuleInstances(
+  const std::shared_ptr<const PlannerData> & planner_data,
+  const tier4_planning_msgs::msg::PathWithLaneId & path);
+template void SceneModuleManagerInterface<SceneModuleInterfaceWithRTC>::modifyPathVelocity(
+  tier4_planning_msgs::msg::PathWithLaneId * path);
+template void SceneModuleManagerInterface<SceneModuleInterfaceWithRTC>::registerModule(
+  const std::shared_ptr<SceneModuleInterfaceWithRTC> & scene_module);
+}  // namespace autoware::behavior_velocity_planner

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_run_out_module/src/manager.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_run_out_module/src/manager.hpp
@@ -25,7 +25,7 @@
 
 namespace autoware::behavior_velocity_planner
 {
-class RunOutModuleManager : public SceneModuleManagerInterface
+class RunOutModuleManager : public SceneModuleManagerInterface<>
 {
 public:
   explicit RunOutModuleManager(rclcpp::Node & node);

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_speed_bump_module/src/manager.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_speed_bump_module/src/manager.hpp
@@ -29,7 +29,7 @@
 
 namespace autoware::behavior_velocity_planner
 {
-class SpeedBumpModuleManager : public SceneModuleManagerInterface
+class SpeedBumpModuleManager : public SceneModuleManagerInterface<>
 {
 public:
   explicit SpeedBumpModuleManager(rclcpp::Node & node);

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_stop_line_module/src/manager.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_stop_line_module/src/manager.hpp
@@ -33,7 +33,7 @@ namespace autoware::behavior_velocity_planner
 {
 using StopLineWithLaneId = std::pair<lanelet::ConstLineString3d, int64_t>;
 
-class StopLineModuleManager : public SceneModuleManagerInterface
+class StopLineModuleManager : public SceneModuleManagerInterface<>
 {
 public:
   explicit StopLineModuleManager(rclcpp::Node & node);

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_template_module/src/manager.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_template_module/src/manager.hpp
@@ -38,7 +38,7 @@ namespace autoware::behavior_velocity_planner
  * @param node A reference to the ROS node.
  */
 class TemplateModuleManager
-: public autoware::behavior_velocity_planner::SceneModuleManagerInterface
+: public autoware::behavior_velocity_planner::SceneModuleManagerInterface<>
 {
 public:
   explicit TemplateModuleManager(rclcpp::Node & node);

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/package.xml
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/package.xml
@@ -20,6 +20,7 @@
 
   <depend>autoware_adapi_v1_msgs</depend>
   <depend>autoware_behavior_velocity_planner_common</depend>
+  <depend>autoware_behavior_velocity_rtc_interface</depend>
   <depend>autoware_lanelet2_extension</depend>
   <depend>autoware_motion_utils</depend>
   <depend>autoware_perception_msgs</depend>

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/src/manager.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/src/manager.cpp
@@ -123,7 +123,7 @@ void TrafficLightModuleManager::launchNewModules(
   }
 }
 
-std::function<bool(const std::shared_ptr<SceneModuleInterface> &)>
+std::function<bool(const std::shared_ptr<SceneModuleInterfaceWithRTC> &)>
 TrafficLightModuleManager::getModuleExpiredFunction(
   const tier4_planning_msgs::msg::PathWithLaneId & path)
 {
@@ -131,7 +131,7 @@ TrafficLightModuleManager::getModuleExpiredFunction(
     path, planner_data_->route_handler_->getLaneletMapPtr(), planner_data_->current_odometry->pose);
 
   return [this, lanelet_id_set](
-           [[maybe_unused]] const std::shared_ptr<SceneModuleInterface> & scene_module) {
+           [[maybe_unused]] const std::shared_ptr<SceneModuleInterfaceWithRTC> & scene_module) {
     for (const auto & id : lanelet_id_set) {
       if (isModuleRegisteredFromExistingAssociatedModule(id)) {
         return false;

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/src/manager.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/src/manager.hpp
@@ -19,7 +19,7 @@
 
 #include <autoware/behavior_velocity_planner_common/plugin_interface.hpp>
 #include <autoware/behavior_velocity_planner_common/plugin_wrapper.hpp>
-#include <autoware/behavior_velocity_planner_common/scene_module_interface.hpp>
+#include <autoware/behavior_velocity_rtc_interface/scene_module_interface_with_rtc.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include <tier4_planning_msgs/msg/path_with_lane_id.hpp>
@@ -42,8 +42,8 @@ private:
 
   void launchNewModules(const tier4_planning_msgs::msg::PathWithLaneId & path) override;
 
-  std::function<bool(const std::shared_ptr<SceneModuleInterface> &)> getModuleExpiredFunction(
-    const tier4_planning_msgs::msg::PathWithLaneId & path) override;
+  std::function<bool(const std::shared_ptr<SceneModuleInterfaceWithRTC> &)>
+  getModuleExpiredFunction(const tier4_planning_msgs::msg::PathWithLaneId & path) override;
 
   void modifyPathVelocity(tier4_planning_msgs::msg::PathWithLaneId * path) override;
 

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/src/scene.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/src/scene.cpp
@@ -44,7 +44,7 @@ TrafficLightModule::TrafficLightModule(
   const int64_t lane_id, const lanelet::TrafficLight & traffic_light_reg_elem,
   lanelet::ConstLanelet lane, const PlannerParam & planner_param, const rclcpp::Logger logger,
   const rclcpp::Clock::SharedPtr clock)
-: SceneModuleInterface(lane_id, logger, clock),
+: SceneModuleInterfaceWithRTC(lane_id, logger, clock),
   lane_id_(lane_id),
   traffic_light_reg_elem_(traffic_light_reg_elem),
   lane_(lane),

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/src/scene.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/src/scene.hpp
@@ -23,8 +23,8 @@
 #define EIGEN_MPL2_ONLY
 #include <Eigen/Core>
 #include <Eigen/Geometry>
-#include <autoware/behavior_velocity_planner_common/scene_module_interface.hpp>
 #include <autoware/behavior_velocity_planner_common/utilization/boost_geometry_helper.hpp>
+#include <autoware/behavior_velocity_rtc_interface/scene_module_interface_with_rtc.hpp>
 #include <autoware_lanelet2_extension/utility/query.hpp>
 #include <rclcpp/rclcpp.hpp>
 
@@ -33,7 +33,7 @@
 
 namespace autoware::behavior_velocity_planner
 {
-class TrafficLightModule : public SceneModuleInterface
+class TrafficLightModule : public SceneModuleInterfaceWithRTC
 {
 public:
   using TrafficSignal = autoware_perception_msgs::msg::TrafficLightGroup;

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_virtual_traffic_light_module/src/manager.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_virtual_traffic_light_module/src/manager.hpp
@@ -29,7 +29,7 @@
 
 namespace autoware::behavior_velocity_planner
 {
-class VirtualTrafficLightModuleManager : public SceneModuleManagerInterface
+class VirtualTrafficLightModuleManager : public SceneModuleManagerInterface<>
 {
 public:
   explicit VirtualTrafficLightModuleManager(rclcpp::Node & node);

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_walkway_module/src/manager.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_walkway_module/src/manager.hpp
@@ -35,7 +35,7 @@ namespace autoware::behavior_velocity_planner
 {
 using tier4_planning_msgs::msg::PathWithLaneId;
 
-class WalkwayModuleManager : public SceneModuleManagerInterface
+class WalkwayModuleManager : public SceneModuleManagerInterface<>
 {
 public:
   explicit WalkwayModuleManager(rclcpp::Node & node);


### PR DESCRIPTION
## Description

In order to split the tier4_msgs dependency from the pure behavior velocity planner 's common implementation, I split the behavior_velocity_planner_common into
- behavior_velocity_planne_common
    - mostly without tier4_msgs, especially RTC
- behavior_velocity_rtc_interface
    - can depend on tier4_msgs

The motivation is porting behavior_velocity_planner_common to Autoware.Core by removing the tier4_msgs dependency.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
