### PR TITLE
fix(autoware_static_centerline_generator): fix bugprone-exception-escape

### DIFF
--- a/planning/autoware_static_centerline_generator/src/main.cpp
+++ b/planning/autoware_static_centerline_generator/src/main.cpp
@@ -14,38 +14,46 @@
 
 #include "static_centerline_generator_node.hpp"
 
+#include <iostream>
 #include <memory>
 #include <string>
 
 int main(int argc, char * argv[])
 {
-  rclcpp::init(argc, argv);
+  try {
+    rclcpp::init(argc, argv);
 
-  // initialize node
-  rclcpp::NodeOptions node_options;
-  auto node =
-    std::make_shared<autoware::static_centerline_generator::StaticCenterlineGeneratorNode>(
-      node_options);
+    // initialize node
+    rclcpp::NodeOptions node_options;
+    auto node =
+      std::make_shared<autoware::static_centerline_generator::StaticCenterlineGeneratorNode>(
+        node_options);
 
-  // get ros parameter
-  const auto mode = node->declare_parameter<std::string>("mode");
+    // get ros parameter
+    const auto mode = node->declare_parameter<std::string>("mode");
 
-  // process
-  if (mode == "AUTO") {
-    node->generate_centerline();
-    node->validate();
-    node->save_map();
-  } else if (mode == "GUI") {
-    node->generate_centerline();
-  } else if (mode == "VMB") {
-    // Do nothing
-  } else {
-    throw std::invalid_argument("The `mode` is invalid.");
+    // process
+    if (mode == "AUTO") {
+      node->generate_centerline();
+      node->validate();
+      node->save_map();
+    } else if (mode == "GUI") {
+      node->generate_centerline();
+    } else if (mode == "VMB") {
+      // Do nothing
+    } else {
+      throw std::invalid_argument("The `mode` is invalid.");
+    }
+
+    // NOTE: spin node to keep showing debug path/trajectory in rviz with transient local
+    rclcpp::spin(node);
+    rclcpp::shutdown();
+  } catch (const std::exception & e) {
+    std::cerr << "Exception in main(): " << e.what() << std::endl;
+    return {};
+  } catch (...) {
+    std::cerr << "Unknown exception in main()" << std::endl;
+    return {};
   }
-
-  // NOTE: spin node to keep showing debug path/trajectory in rviz with transient local
-  rclcpp::spin(node);
-  rclcpp::shutdown();
-
   return 0;
 }


### PR DESCRIPTION
## Description
This is a fix based on clang-tidy `bugprone-exception-escape` error.

```
/home/emb4/autoware/autoware/src/universe/autoware.universe/planning/autoware_static_centerline_generator/src/main.cpp:20:5: error: an exception may be thrown in function 'main' which should not throw exceptions [bugprone-exception-escape,-warnings-as-errors]
int main(int argc, char * argv[])
    ^
```
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
