### PR TITLE
feat(lane_change): add text display for candidate path sampling metrics

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/structs/debug.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/structs/debug.hpp
@@ -31,7 +31,7 @@ namespace autoware::behavior_path_planner::lane_change
 {
 using utils::path_safety_checker::CollisionCheckDebugMap;
 
-struct LaneChangeMetricsDebug
+struct MetricsDebug
 {
   LaneChangePhaseMetrics prep_metric;
   std::vector<LaneChangePhaseMetrics> lc_metrics;
@@ -51,7 +51,7 @@ struct Debug
   lanelet::ConstLanelets current_lanes;
   lanelet::ConstLanelets target_lanes;
   lanelet::ConstLanelets target_backward_lanes;
-  std::vector<LaneChangeMetricsDebug> lane_change_metrics;
+  std::vector<MetricsDebug> lane_change_metrics;
   double collision_check_object_debug_lifetime{0.0};
   double distance_to_end_of_current_lane{std::numeric_limits<double>::max()};
   double distance_to_lane_change_finished{std::numeric_limits<double>::max()};

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/structs/debug.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/structs/debug.hpp
@@ -25,10 +25,20 @@
 
 #include <limits>
 #include <string>
+#include <vector>
 
 namespace autoware::behavior_path_planner::lane_change
 {
 using utils::path_safety_checker::CollisionCheckDebugMap;
+
+struct LaneChangeMetricsDebug
+{
+  LaneChangePhaseMetrics prep_metric;
+  std::vector<LaneChangePhaseMetrics> lc_metrics;
+  double max_prepare_length;
+  double max_lane_changing_length;
+};
+
 struct Debug
 {
   std::string module_type;
@@ -41,6 +51,7 @@ struct Debug
   lanelet::ConstLanelets current_lanes;
   lanelet::ConstLanelets target_lanes;
   lanelet::ConstLanelets target_backward_lanes;
+  std::vector<LaneChangeMetricsDebug> lane_change_metrics;
   double collision_check_object_debug_lifetime{0.0};
   double distance_to_end_of_current_lane{std::numeric_limits<double>::max()};
   double distance_to_lane_change_finished{std::numeric_limits<double>::max()};
@@ -64,6 +75,7 @@ struct Debug
     current_lanes.clear();
     target_lanes.clear();
     target_backward_lanes.clear();
+    lane_change_metrics.clear();
 
     collision_check_object_debug_lifetime = 0.0;
     distance_to_end_of_current_lane = std::numeric_limits<double>::max();

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/scene.cpp
@@ -1065,14 +1065,20 @@ std::vector<LaneChangePhaseMetrics> NormalLaneChange::get_lane_changing_metrics(
   });
 
   const auto max_path_velocity = prep_segment.points.back().point.longitudinal_velocity_mps;
-  return calculation::calc_shift_phase_metrics(
+  const auto lc_metrics = calculation::calc_shift_phase_metrics(
     common_data_ptr_, shift_length, prep_metric.velocity, max_path_velocity,
     prep_metric.sampled_lon_accel, max_lane_changing_length);
+
+  const auto max_prep_length = common_data_ptr_->transient_data.dist_to_terminal_start;
+  lane_change_debug_.lane_change_metrics.push_back(
+    {prep_metric, lc_metrics, max_prep_length, max_lane_changing_length});
+  return lc_metrics;
 }
 
 bool NormalLaneChange::get_lane_change_paths(LaneChangePaths & candidate_paths) const
 {
   lane_change_debug_.collision_check_objects.clear();
+  lane_change_debug_.lane_change_metrics.clear();
 
   if (!common_data_ptr_->is_lanes_available()) {
     RCLCPP_WARN(logger_, "lanes are not available. Not expected.");


### PR DESCRIPTION
## Description

Display candidate path sampling metrics for prepare phase and lane changing phase on rviz to help with debugging.

![Screenshot from 2024-12-27 11-01-01](https://github.com/user-attachments/assets/6d0f5a52-e918-43e3-90d3-8cc5dcb2a9ce)


## Related links

None.

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
- PSIM

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
