### PR TITLE
fix(goal_planner): fix usage of last_previous_module_output

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/examples/plot_map_case1.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/examples/plot_map_case1.cpp
@@ -288,7 +288,7 @@ bool hasEnoughDistance(
 std::vector<PullOverPath> selectPullOverPaths(
   const std::vector<PullOverPath> & pull_over_path_candidates,
   const GoalCandidates & goal_candidates, const std::shared_ptr<const PlannerData> planner_data,
-  const GoalPlannerParameters & parameters, const BehaviorModuleOutput & previous_module_output)
+  const GoalPlannerParameters & parameters, const BehaviorModuleOutput & upstream_module_output)
 {
   using autoware::behavior_path_planner::utils::getExtendedCurrentLanesFromPath;
   using autoware::motion_utils::calcSignedArcLength;
@@ -313,15 +313,15 @@ std::vector<PullOverPath> selectPullOverPaths(
   }
 
   const double prev_path_front_to_goal_dist = calcSignedArcLength(
-    previous_module_output.path.points,
-    previous_module_output.path.points.front().point.pose.position, goal_pose.position);
+    upstream_module_output.path.points,
+    upstream_module_output.path.points.front().point.pose.position, goal_pose.position);
   const auto & long_tail_reference_path = [&]() {
     if (prev_path_front_to_goal_dist > backward_length) {
-      return previous_module_output.path;
+      return upstream_module_output.path;
     }
     // get road lanes which is at least backward_length[m] behind the goal
     const auto road_lanes = getExtendedCurrentLanesFromPath(
-      previous_module_output.path, planner_data, backward_length, 0.0, false);
+      upstream_module_output.path, planner_data, backward_length, 0.0, false);
     const auto goal_pose_length = lanelet::utils::getArcCoordinates(road_lanes, goal_pose).length;
     return planner_data->route_handler->getCenterLinePath(
       road_lanes, std::max(0.0, goal_pose_length - backward_length),

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/examples/plot_map_case2.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/examples/plot_map_case2.cpp
@@ -287,7 +287,7 @@ bool hasEnoughDistance(
 std::vector<PullOverPath> selectPullOverPaths(
   const std::vector<PullOverPath> & pull_over_path_candidates,
   const GoalCandidates & goal_candidates, const std::shared_ptr<const PlannerData> planner_data,
-  const GoalPlannerParameters & parameters, const BehaviorModuleOutput & previous_module_output)
+  const GoalPlannerParameters & parameters, const BehaviorModuleOutput & upstream_module_output)
 {
   using autoware::behavior_path_planner::utils::getExtendedCurrentLanesFromPath;
   using autoware::motion_utils::calcSignedArcLength;
@@ -312,15 +312,15 @@ std::vector<PullOverPath> selectPullOverPaths(
   }
 
   const double prev_path_front_to_goal_dist = calcSignedArcLength(
-    previous_module_output.path.points,
-    previous_module_output.path.points.front().point.pose.position, goal_pose.position);
+    upstream_module_output.path.points,
+    upstream_module_output.path.points.front().point.pose.position, goal_pose.position);
   const auto & long_tail_reference_path = [&]() {
     if (prev_path_front_to_goal_dist > backward_length) {
-      return previous_module_output.path;
+      return upstream_module_output.path;
     }
     // get road lanes which is at least backward_length[m] behind the goal
     const auto road_lanes = getExtendedCurrentLanesFromPath(
-      previous_module_output.path, planner_data, backward_length, 0.0, false);
+      upstream_module_output.path, planner_data, backward_length, 0.0, false);
     const auto goal_pose_length = lanelet::utils::getArcCoordinates(road_lanes, goal_pose).length;
     return planner_data->route_handler->getCenterLinePath(
       road_lanes, std::max(0.0, goal_pose_length - backward_length),

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/fixed_goal_planner_base.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/fixed_goal_planner_base.hpp
@@ -38,15 +38,15 @@ public:
   virtual BehaviorModuleOutput plan(
     const std::shared_ptr<const PlannerData> & planner_data) const = 0;
 
-  void setPreviousModuleOutput(const BehaviorModuleOutput & previous_module_output)
+  void setPreviousModuleOutput(const BehaviorModuleOutput & upstream_module_output)
   {
-    previous_module_output_ = previous_module_output;
+    upstream_module_output_ = upstream_module_output;
   }
 
-  BehaviorModuleOutput getPreviousModuleOutput() const { return previous_module_output_; }
+  BehaviorModuleOutput getPreviousModuleOutput() const { return upstream_module_output_; }
 
 protected:
-  BehaviorModuleOutput previous_module_output_;
+  BehaviorModuleOutput upstream_module_output_;
 };
 }  // namespace autoware::behavior_path_planner
 

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/goal_planner_module.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/goal_planner_module.hpp
@@ -133,12 +133,12 @@ bool isOnModifiedGoal(
   const GoalPlannerParameters & parameters);
 
 bool hasPreviousModulePathShapeChanged(
-  const BehaviorModuleOutput & previous_module_output,
-  const BehaviorModuleOutput & last_previous_module_output);
+  const BehaviorModuleOutput & upstream_module_output,
+  const BehaviorModuleOutput & last_upstream_module_output);
 bool hasDeviatedFromLastPreviousModulePath(
-  const PlannerData & planner_data, const BehaviorModuleOutput & last_previous_module_output);
+  const PlannerData & planner_data, const BehaviorModuleOutput & last_upstream_module_output);
 bool hasDeviatedFromCurrentPreviousModulePath(
-  const PlannerData & planner_data, const BehaviorModuleOutput & previous_module_output);
+  const PlannerData & planner_data, const BehaviorModuleOutput & upstream_module_output);
 
 bool needPathUpdate(
   const Pose & current_pose, const double path_update_duration, const rclcpp::Time & now,
@@ -189,6 +189,7 @@ public:
   void onTimer();
 
 private:
+  const GoalPlannerParameters parameters_;
   std::mutex & mutex_;
   const std::optional<LaneParkingRequest> & request_;
   LaneParkingResponse & response_;
@@ -196,6 +197,10 @@ private:
   rclcpp::Logger logger_;
 
   std::vector<std::shared_ptr<PullOverPlannerBase>> pull_over_planners_;
+  BehaviorModuleOutput
+    original_upstream_module_output_;  //<! upstream_module_output used for generating last
+                                       // pull_over_path_candidates(only updated when new candidates
+                                       // are generated)
 };
 
 class FreespaceParkingPlanner

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/pull_over_planner/bezier_pull_over.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/pull_over_planner/bezier_pull_over.hpp
@@ -36,11 +36,11 @@ public:
   std::optional<PullOverPath> plan(
     const GoalCandidate & modified_goal_pose, const size_t id,
     const std::shared_ptr<const PlannerData> planner_data,
-    const BehaviorModuleOutput & previous_module_output) override;
+    const BehaviorModuleOutput & upstream_module_output) override;
   std::vector<PullOverPath> plans(
     const GoalCandidate & modified_goal_pose, const size_t id,
     const std::shared_ptr<const PlannerData> planner_data,
-    const BehaviorModuleOutput & previous_module_output);
+    const BehaviorModuleOutput & upstream_module_output);
 
 private:
   const LaneDepartureChecker lane_departure_checker_;
@@ -50,7 +50,7 @@ private:
   std::vector<PullOverPath> generateBezierPath(
     const GoalCandidate & goal_candidate, const size_t id,
     const std::shared_ptr<const PlannerData> planner_data,
-    const BehaviorModuleOutput & previous_module_output, const lanelet::ConstLanelets & road_lanes,
+    const BehaviorModuleOutput & upstream_module_output, const lanelet::ConstLanelets & road_lanes,
     const lanelet::ConstLanelets & shoulder_lanes, const double lateral_jerk) const;
 
   PathWithLaneId generateReferencePath(

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/pull_over_planner/freespace_pull_over.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/pull_over_planner/freespace_pull_over.hpp
@@ -41,7 +41,7 @@ public:
   std::optional<PullOverPath> plan(
     const GoalCandidate & modified_goal_pose, const size_t id,
     const std::shared_ptr<const PlannerData> planner_data,
-    const BehaviorModuleOutput & previous_module_output) override;
+    const BehaviorModuleOutput & upstream_module_output) override;
 
 protected:
   const double velocity_;

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/pull_over_planner/geometric_pull_over.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/pull_over_planner/geometric_pull_over.hpp
@@ -45,7 +45,7 @@ public:
   std::optional<PullOverPath> plan(
     const GoalCandidate & modified_goal_pose, const size_t id,
     const std::shared_ptr<const PlannerData> planner_data,
-    const BehaviorModuleOutput & previous_module_output) override;
+    const BehaviorModuleOutput & upstream_module_output) override;
 
   std::vector<PullOverPath> generatePullOverPaths(
     const lanelet::ConstLanelets & road_lanes, const lanelet::ConstLanelets & shoulder_lanes,

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/pull_over_planner/pull_over_planner_base.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/pull_over_planner/pull_over_planner_base.hpp
@@ -130,7 +130,7 @@ public:
   virtual std::optional<PullOverPath> plan(
     const GoalCandidate & modified_goal_pose, const size_t id,
     const std::shared_ptr<const PlannerData> planner_data,
-    const BehaviorModuleOutput & previous_module_output) = 0;
+    const BehaviorModuleOutput & upstream_module_output) = 0;
 
 protected:
   const autoware::vehicle_info_utils::VehicleInfo vehicle_info_;

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/pull_over_planner/shift_pull_over.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/pull_over_planner/shift_pull_over.hpp
@@ -38,7 +38,7 @@ public:
   std::optional<PullOverPath> plan(
     const GoalCandidate & modified_goal_pose, const size_t id,
     const std::shared_ptr<const PlannerData> planner_data,
-    const BehaviorModuleOutput & previous_module_output) override;
+    const BehaviorModuleOutput & upstream_module_output) override;
 
 protected:
   PathWithLaneId generateReferencePath(
@@ -49,7 +49,7 @@ protected:
   std::optional<PullOverPath> generatePullOverPath(
     const GoalCandidate & goal_candidate, const size_t id,
     const std::shared_ptr<const PlannerData> planner_data,
-    const BehaviorModuleOutput & previous_module_output, const lanelet::ConstLanelets & road_lanes,
+    const BehaviorModuleOutput & upstream_module_output, const lanelet::ConstLanelets & road_lanes,
     const lanelet::ConstLanelets & pull_over_lanes, const double lateral_jerk) const;
   static double calcBeforeShiftedArcLength(
     const PathWithLaneId & path, const double after_shifted_arc_length, const double dr);

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/thread_data.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/thread_data.hpp
@@ -32,35 +32,27 @@ class LaneParkingRequest
 {
 public:
   LaneParkingRequest(
-    const GoalPlannerParameters & parameters,
     const autoware::universe_utils::LinearRing2d & vehicle_footprint,
-    const GoalCandidates & goal_candidates, const BehaviorModuleOutput & previous_module_output)
-  : parameters_(parameters),
-    vehicle_footprint_(vehicle_footprint),
+    const GoalCandidates & goal_candidates, const BehaviorModuleOutput & upstream_module_output)
+  : vehicle_footprint_(vehicle_footprint),
     goal_candidates_(goal_candidates),
-    previous_module_output_(previous_module_output),
-    last_previous_module_output_(previous_module_output)
+    upstream_module_output_(upstream_module_output)
   {
   }
 
   void update(
     const PlannerData & planner_data, const ModuleStatus & current_status,
-    const BehaviorModuleOutput & previous_module_output,
+    const BehaviorModuleOutput & upstream_module_output,
     const std::optional<PullOverPath> & pull_over_path, const PathDecisionState & prev_data);
 
-  const GoalPlannerParameters parameters_;
   const autoware::universe_utils::LinearRing2d vehicle_footprint_;
   const GoalCandidates goal_candidates_;
 
   const std::shared_ptr<PlannerData> & get_planner_data() const { return planner_data_; }
   const ModuleStatus & get_current_status() const { return current_status_; }
-  const BehaviorModuleOutput & get_previous_module_output() const
+  const BehaviorModuleOutput & get_upstream_module_output() const
   {
-    return previous_module_output_;
-  }
-  const BehaviorModuleOutput & get_last_previous_module_output() const
-  {
-    return last_previous_module_output_;
+    return upstream_module_output_;
   }
   const std::optional<PullOverPath> & get_pull_over_path() const { return pull_over_path_; }
   const PathDecisionState & get_prev_data() const { return prev_data_; }
@@ -68,8 +60,7 @@ public:
 private:
   std::shared_ptr<PlannerData> planner_data_;
   ModuleStatus current_status_;
-  BehaviorModuleOutput previous_module_output_;
-  BehaviorModuleOutput last_previous_module_output_;
+  BehaviorModuleOutput upstream_module_output_;
   std::optional<PullOverPath> pull_over_path_;  //<! pull over path selected by main thread
   PathDecisionState prev_data_;
 };

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/goal_planner_module.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/goal_planner_module.cpp
@@ -150,17 +150,17 @@ bool isOnModifiedGoal(
 }
 
 bool hasPreviousModulePathShapeChanged(
-  const BehaviorModuleOutput & previous_module_output,
-  const BehaviorModuleOutput & last_previous_module_output)
+  const BehaviorModuleOutput & upstream_module_output,
+  const BehaviorModuleOutput & last_upstream_module_output)
 {
   // Calculate the lateral distance between each point of the current path and the nearest point of
   // the last path
   constexpr double LATERAL_DEVIATION_THRESH = 0.3;
-  for (const auto & p : previous_module_output.path.points) {
+  for (const auto & p : upstream_module_output.path.points) {
     const size_t nearest_seg_idx = autoware::motion_utils::findNearestSegmentIndex(
-      last_previous_module_output.path.points, p.point.pose.position);
-    const auto seg_front = last_previous_module_output.path.points.at(nearest_seg_idx);
-    const auto seg_back = last_previous_module_output.path.points.at(nearest_seg_idx + 1);
+      last_upstream_module_output.path.points, p.point.pose.position);
+    const auto seg_front = last_upstream_module_output.path.points.at(nearest_seg_idx);
+    const auto seg_back = last_upstream_module_output.path.points.at(nearest_seg_idx + 1);
     // Check if the target point is within the segment
     const Eigen::Vector3d segment_vec{
       seg_back.point.pose.position.x - seg_front.point.pose.position.x,
@@ -176,7 +176,7 @@ bool hasPreviousModulePathShapeChanged(
       continue;
     }
     const double lateral_distance = std::abs(autoware::motion_utils::calcLateralOffset(
-      last_previous_module_output.path.points, p.point.pose.position, nearest_seg_idx));
+      last_upstream_module_output.path.points, p.point.pose.position, nearest_seg_idx));
     if (lateral_distance > LATERAL_DEVIATION_THRESH) {
       return true;
     }
@@ -185,19 +185,19 @@ bool hasPreviousModulePathShapeChanged(
 }
 
 bool hasDeviatedFromLastPreviousModulePath(
-  const PlannerData & planner_data, const BehaviorModuleOutput & last_previous_module_output)
+  const PlannerData & planner_data, const BehaviorModuleOutput & last_upstream_module_output)
 {
   return std::abs(autoware::motion_utils::calcLateralOffset(
-           last_previous_module_output.path.points,
+           last_upstream_module_output.path.points,
            planner_data.self_odometry->pose.pose.position)) > 0.3;
 }
 
 bool hasDeviatedFromCurrentPreviousModulePath(
-  const PlannerData & planner_data, const BehaviorModuleOutput & previous_module_output)
+  const PlannerData & planner_data, const BehaviorModuleOutput & upstream_module_output)
 {
   constexpr double LATERAL_DEVIATION_THRESH = 0.3;
   return std::abs(autoware::motion_utils::calcLateralOffset(
-           previous_module_output.path.points, planner_data.self_odometry->pose.pose.position)) >
+           upstream_module_output.path.points, planner_data.self_odometry->pose.pose.position)) >
          LATERAL_DEVIATION_THRESH;
 }
 
@@ -282,7 +282,8 @@ LaneParkingPlanner::LaneParkingPlanner(
   const std::optional<LaneParkingRequest> & request, LaneParkingResponse & response,
   std::atomic<bool> & is_lane_parking_cb_running, const rclcpp::Logger & logger,
   const GoalPlannerParameters & parameters)
-: mutex_(lane_parking_mutex),
+: parameters_(parameters),
+  mutex_(lane_parking_mutex),
   request_(request),
   response_(response),
   is_lane_parking_cb_running_(is_lane_parking_cb_running),
@@ -335,12 +336,10 @@ void LaneParkingPlanner::onTimer()
     return;
   }
   const auto & local_request = local_request_opt.value();
-  const auto & parameters = local_request.parameters_;
   const auto & goal_candidates = local_request.goal_candidates_;
   const auto & local_planner_data = local_request.get_planner_data();
   const auto & current_status = local_request.get_current_status();
-  const auto & previous_module_output = local_request.get_previous_module_output();
-  const auto & last_previous_module_output = local_request.get_last_previous_module_output();
+  const auto & upstream_module_output = local_request.get_upstream_module_output();
   const auto & pull_over_path_opt = local_request.get_pull_over_path();
   const auto & prev_data = local_request.get_prev_data();
 
@@ -371,19 +370,21 @@ void LaneParkingPlanner::onTimer()
         ? std::make_optional<GoalCandidate>(pull_over_path_opt.value().modified_goal())
         : std::nullopt;
     if (isOnModifiedGoal(
-          local_planner_data->self_odometry->pose.pose, modified_goal_opt, parameters)) {
+          local_planner_data->self_odometry->pose.pose, modified_goal_opt, parameters_)) {
       return false;
     }
-    if (hasDeviatedFromCurrentPreviousModulePath(*local_planner_data, previous_module_output)) {
+    if (hasDeviatedFromCurrentPreviousModulePath(*local_planner_data, upstream_module_output)) {
       RCLCPP_DEBUG(getLogger(), "has deviated from current previous module path");
       return false;
     }
-    if (hasPreviousModulePathShapeChanged(previous_module_output, last_previous_module_output)) {
+    if (hasPreviousModulePathShapeChanged(
+          upstream_module_output, original_upstream_module_output_)) {
       RCLCPP_DEBUG(getLogger(), "has previous module path shape changed");
       return true;
     }
     if (
-      hasDeviatedFromLastPreviousModulePath(*local_planner_data, last_previous_module_output) &&
+      hasDeviatedFromLastPreviousModulePath(
+        *local_planner_data, original_upstream_module_output_) &&
       current_state != PathDecisionState::DecisionKind::DECIDED) {
       RCLCPP_DEBUG(getLogger(), "has deviated from last previous module path");
       return true;
@@ -400,8 +401,8 @@ void LaneParkingPlanner::onTimer()
 
   // generate valid pull over path candidates and calculate closest start pose
   const auto current_lanes = utils::getExtendedCurrentLanes(
-    local_planner_data, parameters.backward_goal_search_length,
-    parameters.forward_goal_search_length,
+    local_planner_data, parameters_.backward_goal_search_length,
+    parameters_.forward_goal_search_length,
     /*forward_only_in_route*/ false);
   std::vector<PullOverPath> path_candidates{};
   std::optional<Pose> closest_start_pose{};
@@ -410,7 +411,7 @@ void LaneParkingPlanner::onTimer()
                                     const std::shared_ptr<PullOverPlannerBase> & planner,
                                     const GoalCandidate & goal_candidate) {
     const auto pull_over_path = planner->plan(
-      goal_candidate, path_candidates.size(), local_planner_data, previous_module_output);
+      goal_candidate, path_candidates.size(), local_planner_data, upstream_module_output);
     if (pull_over_path) {
       // calculate absolute maximum curvature of parking path(start pose to end pose) for path
       // priority
@@ -428,13 +429,13 @@ void LaneParkingPlanner::onTimer()
 
   // todo: currently non centerline input path is supported only by shift pull over
   const bool is_center_line_input_path = goal_planner_utils::isReferencePath(
-    previous_module_output.reference_path, previous_module_output.path, 0.1);
+    upstream_module_output.reference_path, upstream_module_output.path, 0.1);
   RCLCPP_DEBUG(
     getLogger(), "the input path of pull over planner is center line: %d",
     is_center_line_input_path);
 
   // plan candidate paths and set them to the member variable
-  if (parameters.path_priority == "efficient_path") {
+  if (parameters_.path_priority == "efficient_path") {
     for (const auto & planner : pull_over_planners_) {
       // todo: temporary skip NON SHIFT planner when input path is not center line
       if (!is_center_line_input_path && planner->getPlannerType() != PullOverPlannerType::SHIFT) {
@@ -444,7 +445,7 @@ void LaneParkingPlanner::onTimer()
         planCandidatePaths(planner, goal_candidate);
       }
     }
-  } else if (parameters.path_priority == "close_goal") {
+  } else if (parameters_.path_priority == "close_goal") {
     for (const auto & goal_candidate : goal_candidates) {
       for (const auto & planner : pull_over_planners_) {
         // todo: temporary skip NON SHIFT planner when input path is not center line
@@ -457,14 +458,15 @@ void LaneParkingPlanner::onTimer()
   } else {
     RCLCPP_ERROR(
       getLogger(), "path_priority should be efficient_path or close_goal, but %s is given.",
-      parameters.path_priority.c_str());
+      parameters_.path_priority.c_str());
     throw std::domain_error("[pull_over] invalid path_priority");
   }
 
   // set response
   {
+    original_upstream_module_output_ = upstream_module_output;
     std::lock_guard<std::mutex> guard(mutex_);
-    response_.pull_over_path_candidates = path_candidates;
+    response_.pull_over_path_candidates = std::move(path_candidates);
     response_.closest_start_pose = closest_start_pose;
     RCLCPP_INFO(
       getLogger(), "generated %lu pull over path candidates",
@@ -562,7 +564,7 @@ std::pair<LaneParkingResponse, FreespaceParkingResponse> GoalPlannerModule::sync
   // In PlannerManager::run(), it calls SceneModuleInterface::setData and
   // SceneModuleInterface::setPreviousModuleOutput before module_ptr->run().
   // Then module_ptr->run() invokes GoalPlannerModule::updateData and then
-  // planWaitingApproval()/plan(), so we can copy latest current_status/previous_module_output to
+  // planWaitingApproval()/plan(), so we can copy latest current_status/upstream_module_output to
   // lane_parking_request/freespace_parking_request
 
   std::optional<PullOverPath> pull_over_path =
@@ -578,7 +580,7 @@ std::pair<LaneParkingResponse, FreespaceParkingResponse> GoalPlannerModule::sync
     std::lock_guard<std::mutex> guard(lane_parking_mutex_);
     if (!lane_parking_request_) {
       lane_parking_request_.emplace(
-        *parameters_, vehicle_footprint_, goal_candidates_, getPreviousModuleOutput());
+        vehicle_footprint_, goal_candidates_, getPreviousModuleOutput());
     }
     // NOTE: for the above reasons, PlannerManager/behavior_path_planner_node ensure that
     // planner_data_ is not nullptr, so it is OK to copy as value

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/pull_over_planner/freespace_pull_over.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/pull_over_planner/freespace_pull_over.cpp
@@ -60,7 +60,7 @@ FreespacePullOver::FreespacePullOver(
 std::optional<PullOverPath> FreespacePullOver::plan(
   const GoalCandidate & modified_goal_pose, const size_t id,
   const std::shared_ptr<const PlannerData> planner_data,
-  [[maybe_unused]] const BehaviorModuleOutput & previous_module_output)
+  [[maybe_unused]] const BehaviorModuleOutput & upstream_module_output)
 {
   const Pose & current_pose = planner_data->self_odometry->pose.pose;
 

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/pull_over_planner/geometric_pull_over.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/pull_over_planner/geometric_pull_over.cpp
@@ -40,7 +40,7 @@ GeometricPullOver::GeometricPullOver(
 std::optional<PullOverPath> GeometricPullOver::plan(
   const GoalCandidate & modified_goal_pose, const size_t id,
   const std::shared_ptr<const PlannerData> planner_data,
-  [[maybe_unused]] const BehaviorModuleOutput & previous_module_output)
+  [[maybe_unused]] const BehaviorModuleOutput & upstream_module_output)
 {
   const auto & route_handler = planner_data->route_handler;
 

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/pull_over_planner/shift_pull_over.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/pull_over_planner/shift_pull_over.cpp
@@ -41,7 +41,7 @@ ShiftPullOver::ShiftPullOver(
 std::optional<PullOverPath> ShiftPullOver::plan(
   const GoalCandidate & modified_goal_pose, const size_t id,
   const std::shared_ptr<const PlannerData> planner_data,
-  const BehaviorModuleOutput & previous_module_output)
+  const BehaviorModuleOutput & upstream_module_output)
 {
   const auto & route_handler = planner_data->route_handler;
   const double min_jerk = parameters_.minimum_lateral_jerk;
@@ -52,7 +52,7 @@ std::optional<PullOverPath> ShiftPullOver::plan(
   const double jerk_resolution = std::abs(max_jerk - min_jerk) / shift_sampling_num;
 
   const auto road_lanes = utils::getExtendedCurrentLanesFromPath(
-    previous_module_output.path, planner_data, backward_search_length, forward_search_length,
+    upstream_module_output.path, planner_data, backward_search_length, forward_search_length,
     /*forward_only_in_route*/ false);
 
   const auto pull_over_lanes = goal_planner_utils::getPullOverLanes(
@@ -64,7 +64,7 @@ std::optional<PullOverPath> ShiftPullOver::plan(
   // find safe one from paths with different jerk
   for (double lateral_jerk = min_jerk; lateral_jerk <= max_jerk; lateral_jerk += jerk_resolution) {
     const auto pull_over_path = generatePullOverPath(
-      modified_goal_pose, id, planner_data, previous_module_output, road_lanes, pull_over_lanes,
+      modified_goal_pose, id, planner_data, upstream_module_output, road_lanes, pull_over_lanes,
       lateral_jerk);
     if (!pull_over_path) continue;
     return pull_over_path;
@@ -134,7 +134,7 @@ std::optional<PathWithLaneId> ShiftPullOver::cropPrevModulePath(
 std::optional<PullOverPath> ShiftPullOver::generatePullOverPath(
   const GoalCandidate & goal_candidate, const size_t id,
   const std::shared_ptr<const PlannerData> planner_data,
-  const BehaviorModuleOutput & previous_module_output, const lanelet::ConstLanelets & road_lanes,
+  const BehaviorModuleOutput & upstream_module_output, const lanelet::ConstLanelets & road_lanes,
   const lanelet::ConstLanelets & pull_over_lanes, const double lateral_jerk) const
 {
   const double pull_over_velocity = parameters_.pull_over_velocity;
@@ -151,7 +151,7 @@ std::optional<PullOverPath> ShiftPullOver::generatePullOverPath(
     generateReferencePath(planner_data, road_lanes, shift_end_pose),
     parameters_.center_line_path_interval);
   const auto prev_module_path = utils::resamplePathWithSpline(
-    previous_module_output.path, parameters_.center_line_path_interval);
+    upstream_module_output.path, parameters_.center_line_path_interval);
   const auto prev_module_path_terminal_pose = prev_module_path.points.back().point.pose;
 
   // process previous module path for path shifter input path

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/thread_data.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/thread_data.cpp
@@ -21,14 +21,13 @@ namespace autoware::behavior_path_planner
 
 void LaneParkingRequest::update(
   const PlannerData & planner_data, const ModuleStatus & current_status,
-  const BehaviorModuleOutput & previous_module_output,
+  const BehaviorModuleOutput & upstream_module_output,
   const std::optional<PullOverPath> & pull_over_path, const PathDecisionState & prev_data)
 {
   planner_data_ = std::make_shared<PlannerData>(planner_data);
   planner_data_->route_handler = std::make_shared<RouteHandler>(*(planner_data.route_handler));
   current_status_ = current_status;
-  last_previous_module_output_ = previous_module_output_;
-  previous_module_output_ = previous_module_output;
+  upstream_module_output_ = upstream_module_output;
   pull_over_path_ = pull_over_path;
   prev_data_ = prev_data;
 }


### PR DESCRIPTION
## Description

- rename `previous_module_output` to `upstream_module_output`
- save `last_upsream_module_output` in LaneParkingPlanner as the upsream_module_output used for generating pull over path candidates

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

- https://evaluation.tier4.jp/evaluation/reports/695b64fd-6cdb-579f-af19-1e5304b804a9?project_id=prd_jt
  - base: https://evaluation.tier4.jp/evaluation/reports/68884626-8bf7-5005-b5d5-7fefa9a878f8?project_id=prd_jt

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
