### PR TITLE
feat(pointpainting_fusion): enable cloud display on image

### DIFF
--- a/perception/autoware_image_projection_based_fusion/src/pointpainting_fusion/node.cpp
+++ b/perception/autoware_image_projection_based_fusion/src/pointpainting_fusion/node.cpp
@@ -316,54 +316,56 @@ dc   | dc dc dc  dc ||zc|
   // iterate points
   // Requires 'OMP_NUM_THREADS=N'
   omp_set_num_threads(omp_num_threads_);
-#pragma omp parallel for
-  for (int i = 0; i < iterations; i++) {
-    int stride = p_step * i;
-    unsigned char * data = &painted_pointcloud_msg.data[0];
-    unsigned char * output = &painted_pointcloud_msg.data[0];
-    // cppcheck-suppress-begin invalidPointerCast
-    float p_x = *reinterpret_cast<const float *>(&data[stride + x_offset]);
-    float p_y = *reinterpret_cast<const float *>(&data[stride + y_offset]);
-    float p_z = *reinterpret_cast<const float *>(&data[stride + z_offset]);
-    // cppcheck-suppress-end invalidPointerCast
-    point_lidar << p_x, p_y, p_z;
-    point_camera = lidar2cam_affine * point_lidar;
-    p_x = point_camera.x();
-    p_y = point_camera.y();
-    p_z = point_camera.z();
+  std::vector<std::vector<Eigen::Vector2d>> local_vectors(omp_num_threads_);
+#pragma omp parallel
+  {
+#pragma omp for
+    for (int i = 0; i < iterations; i++) {
+      int stride = p_step * i;
+      unsigned char * data = &painted_pointcloud_msg.data[0];
+      unsigned char * output = &painted_pointcloud_msg.data[0];
+      // cppcheck-suppress-begin invalidPointerCast
+      float p_x = *reinterpret_cast<const float *>(&data[stride + x_offset]);
+      float p_y = *reinterpret_cast<const float *>(&data[stride + y_offset]);
+      float p_z = *reinterpret_cast<const float *>(&data[stride + z_offset]);
+      // cppcheck-suppress-end invalidPointerCast
+      point_lidar << p_x, p_y, p_z;
+      point_camera = lidar2cam_affine * point_lidar;
+      p_x = point_camera.x();
+      p_y = point_camera.y();
+      p_z = point_camera.z();
 
-    if (camera_projectors_[image_id].isOutsideHorizontalView(p_x, p_z)) {
-      continue;
-    }
+      if (camera_projectors_[image_id].isOutsideHorizontalView(p_x, p_z)) {
+        continue;
+      }
 
-    // project
-    Eigen::Vector2d projected_point;
-    if (camera_projectors_[image_id].calcImageProjectedPoint(
-          cv::Point3d(p_x, p_y, p_z), projected_point)) {
-      // iterate 2d bbox
-      for (const auto & feature_object : objects) {
-        sensor_msgs::msg::RegionOfInterest roi = feature_object.feature.roi;
-        // paint current point if it is inside bbox
-        int label2d = feature_object.object.classification.front().label;
-        if (
-          !isUnknown(label2d) && isInsideBbox(projected_point.x(), projected_point.y(), roi, 1.0)) {
-          // cppcheck-suppress invalidPointerCast
-          auto p_class = reinterpret_cast<float *>(&output[stride + class_offset]);
-          for (const auto & cls : isClassTable_) {
-            // add up the class values if the point belongs to multiple classes
-            *p_class = cls.second(label2d) ? (class_index_[cls.first] + *p_class) : *p_class;
+      // project
+      Eigen::Vector2d projected_point;
+      if (camera_projectors_[image_id].calcImageProjectedPoint(
+            cv::Point3d(p_x, p_y, p_z), projected_point)) {
+        // iterate 2d bbox
+        for (const auto & feature_object : objects) {
+          sensor_msgs::msg::RegionOfInterest roi = feature_object.feature.roi;
+          // paint current point if it is inside bbox
+          int label2d = feature_object.object.classification.front().label;
+          if (
+            !isUnknown(label2d) &&
+            isInsideBbox(projected_point.x(), projected_point.y(), roi, 1.0)) {
+            // cppcheck-suppress invalidPointerCast
+            auto p_class = reinterpret_cast<float *>(&output[stride + class_offset]);
+            for (const auto & cls : isClassTable_) {
+              // add up the class values if the point belongs to multiple classes
+              *p_class = cls.second(label2d) ? (class_index_[cls.first] + *p_class) : *p_class;
+            }
           }
         }
+        if (debugger_) {
+          int thread_id = omp_get_thread_num();
+          local_vectors[thread_id].push_back(projected_point);
+        }
       }
-#if 0
-      // Parallelizing loop don't support push_back
-      if (debugger_) {
-        debug_image_points.push_back(projected_point);
-      }
-#endif
     }
   }
-
   if (debugger_) {
     std::unique_ptr<ScopedTimeTrack> inner_st_ptr;
     if (time_keeper_)
@@ -371,6 +373,10 @@ dc   | dc dc dc  dc ||zc|
 
     for (const auto & feature_object : input_roi_msg.feature_objects) {
       debug_image_rois.push_back(feature_object.feature.roi);
+    }
+
+    for (const auto & local_vec : local_vectors) {
+      debug_image_points.insert(debug_image_points.end(), local_vec.begin(), local_vec.end());
     }
 
     debugger_->image_rois_ = debug_image_rois;


### PR DESCRIPTION
## Description
The PointPainting fusion node disables plotting the point cloud on the image because it uses `push_back` within an OpenMP parallel loop.

> #if 0
      // Parallelizing loop don't support push_back
      if (debugger_) {
        debug_image_points.push_back(projected_point);
      }
#endif

This PR introduces a method to store the projected points in local vectors and merge them after the for-loop. These updates make it easier for developers and users to debug.

Before:
![Screenshot from 2024-12-27 15-33-27](https://github.com/user-attachments/assets/662752db-0610-47c8-99d9-ba3a9e69f8d5)

After
![Screenshot from 2024-12-27 13-57-35](https://github.com/user-attachments/assets/143ecf2a-48f4-45f4-b612-7f7255a50d01)


## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
Test with taxi rosbag. 


## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
