### PR TITLE
fix(planning): corrects typo in svg

### DIFF
--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_stop_line_module/docs/node_and_segment.drawio.svg
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_stop_line_module/docs/node_and_segment.drawio.svg
@@ -233,7 +233,7 @@
                 <br style="font-size: 16px"/>
                 = node(i) + node(i+1)
                 <br/>
-                = all segment has two points
+                = all segments have two points
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Description

Fixes a subject-verb agreement error in an SVG file in [Stop Line documentation](https://autowarefoundation.github.io/autoware.universe/main/planning/behavior_velocity_planner/autoware_behavior_velocity_stop_line_module/).

## Notes for reviewers

@yhisaki Please review this pull request when you have time.