### PR TITLE
feat(autoware_goal_distance_calculator)!:  tier4_debug_msgs to autoware_internal_debug_msgs for autoware_goal_distance_calculator

### DIFF
--- a/common/autoware_goal_distance_calculator/Readme.md
+++ b/common/autoware_goal_distance_calculator/Readme.md
@@ -17,12 +17,12 @@ This node publishes deviation of self-pose from goal pose.
 
 ### Output
 
-| Name                     | Type                                    | Description                                                   |
-| ------------------------ | --------------------------------------- | ------------------------------------------------------------- |
-| `deviation/lateral`      | `tier4_debug_msgs::msg::Float64Stamped` | publish lateral deviation of self-pose from goal pose[m]      |
-| `deviation/longitudinal` | `tier4_debug_msgs::msg::Float64Stamped` | publish longitudinal deviation of self-pose from goal pose[m] |
-| `deviation/yaw`          | `tier4_debug_msgs::msg::Float64Stamped` | publish yaw deviation of self-pose from goal pose[rad]        |
-| `deviation/yaw_deg`      | `tier4_debug_msgs::msg::Float64Stamped` | publish yaw deviation of self-pose from goal pose[deg]        |
+| Name                     | Type                                                | Description                                                   |
+| ------------------------ | --------------------------------------------------- | ------------------------------------------------------------- |
+| `deviation/lateral`      | `autoware_internal_debug_msgs::msg::Float64Stamped` | publish lateral deviation of self-pose from goal pose[m]      |
+| `deviation/longitudinal` | `autoware_internal_debug_msgs::msg::Float64Stamped` | publish longitudinal deviation of self-pose from goal pose[m] |
+| `deviation/yaw`          | `autoware_internal_debug_msgs::msg::Float64Stamped` | publish yaw deviation of self-pose from goal pose[rad]        |
+| `deviation/yaw_deg`      | `autoware_internal_debug_msgs::msg::Float64Stamped` | publish yaw deviation of self-pose from goal pose[deg]        |
 
 ## Parameters
 

--- a/common/autoware_goal_distance_calculator/include/autoware/goal_distance_calculator/goal_distance_calculator_node.hpp
+++ b/common/autoware_goal_distance_calculator/include/autoware/goal_distance_calculator/goal_distance_calculator_node.hpp
@@ -22,9 +22,9 @@
 #include <autoware/universe_utils/ros/self_pose_listener.hpp>
 #include <rclcpp/rclcpp.hpp>
 
+#include <autoware_internal_debug_msgs/msg/float64_stamped.hpp>
 #include <autoware_planning_msgs/msg/lanelet_route.hpp>
 #include <geometry_msgs/msg/pose_stamped.hpp>
-#include <tier4_debug_msgs/msg/float64_stamped.hpp>
 
 #include <tf2_ros/transform_listener.h>
 

--- a/common/autoware_goal_distance_calculator/package.xml
+++ b/common/autoware_goal_distance_calculator/package.xml
@@ -10,12 +10,12 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
+  <depend>autoware_internal_debug_msgs</depend>
   <depend>autoware_planning_msgs</depend>
   <depend>autoware_universe_utils</depend>
   <depend>geometry_msgs</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
-  <depend>tier4_debug_msgs</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>

--- a/common/autoware_goal_distance_calculator/src/goal_distance_calculator_node.cpp
+++ b/common/autoware_goal_distance_calculator/src/goal_distance_calculator_node.cpp
@@ -18,7 +18,7 @@
 #include <rclcpp/rclcpp.hpp>
 #include <rclcpp/timer.hpp>
 
-#include <tier4_debug_msgs/msg/float64_stamped.hpp>
+#include <autoware_internal_debug_msgs/msg/float64_stamped.hpp>
 
 #include <chrono>
 #include <functional>
@@ -100,12 +100,13 @@ void GoalDistanceCalculatorNode::onTimer()
     using autoware::universe_utils::rad2deg;
     const auto & deviation = output.goal_deviation;
 
-    debug_publisher_.publish<tier4_debug_msgs::msg::Float64Stamped>(
+    debug_publisher_.publish<autoware_internal_debug_msgs::msg::Float64Stamped>(
       "deviation/lateral", deviation.lateral);
-    debug_publisher_.publish<tier4_debug_msgs::msg::Float64Stamped>(
+    debug_publisher_.publish<autoware_internal_debug_msgs::msg::Float64Stamped>(
       "deviation/longitudinal", deviation.longitudinal);
-    debug_publisher_.publish<tier4_debug_msgs::msg::Float64Stamped>("deviation/yaw", deviation.yaw);
-    debug_publisher_.publish<tier4_debug_msgs::msg::Float64Stamped>(
+    debug_publisher_.publish<autoware_internal_debug_msgs::msg::Float64Stamped>(
+      "deviation/yaw", deviation.yaw);
+    debug_publisher_.publish<autoware_internal_debug_msgs::msg::Float64Stamped>(
       "deviation/yaw_deg", rad2deg(deviation.yaw));
     RCLCPP_INFO_THROTTLE(
       this->get_logger(), *this->get_clock(), 1000,


### PR DESCRIPTION
## Description
 I have changed the tier4_debug_msgs to autoware_internal_debug_msgs by package 

## Related links

**Parent Issue:**

- https://github.com/autowarefoundation/autoware/issues/5580

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
