### PR TITLE
feat(autoware_universe_utils)!: tier4_debug_msgs changed to autoware_internal_debug_msgs in autoware_universe_utils

### DIFF
--- a/build_depends.repos
+++ b/build_depends.repos
@@ -32,7 +32,7 @@ repositories:
   core/autoware_internal_msgs:
     type: git
     url: https://github.com/autowarefoundation/autoware_internal_msgs.git
-    version: 1.3.0
+    version: 1.4.0
   # universe
   universe/external/tier4_autoware_msgs:
     type: git

--- a/common/autoware_universe_utils/include/autoware/universe_utils/ros/debug_traits.hpp
+++ b/common/autoware_universe_utils/include/autoware/universe_utils/ros/debug_traits.hpp
@@ -25,16 +25,6 @@
 #include <autoware_internal_debug_msgs/msg/int64_multi_array_stamped.hpp>
 #include <autoware_internal_debug_msgs/msg/int64_stamped.hpp>
 #include <autoware_internal_debug_msgs/msg/string_stamped.hpp>
-#include <tier4_debug_msgs/msg/bool_stamped.hpp>
-#include <tier4_debug_msgs/msg/float32_multi_array_stamped.hpp>
-#include <tier4_debug_msgs/msg/float32_stamped.hpp>
-#include <tier4_debug_msgs/msg/float64_multi_array_stamped.hpp>
-#include <tier4_debug_msgs/msg/float64_stamped.hpp>
-#include <tier4_debug_msgs/msg/int32_multi_array_stamped.hpp>
-#include <tier4_debug_msgs/msg/int32_stamped.hpp>
-#include <tier4_debug_msgs/msg/int64_multi_array_stamped.hpp>
-#include <tier4_debug_msgs/msg/int64_stamped.hpp>
-#include <tier4_debug_msgs/msg/string_stamped.hpp>
 
 #include <type_traits>
 
@@ -46,52 +36,54 @@ struct is_debug_message : std::false_type
 };
 
 template <>
-struct is_debug_message<tier4_debug_msgs::msg::BoolStamped> : std::true_type
+struct is_debug_message<autoware_internal_debug_msgs::msg::BoolStamped> : std::true_type
 {
 };
 
 template <>
-struct is_debug_message<tier4_debug_msgs::msg::Float32MultiArrayStamped> : std::true_type
+struct is_debug_message<autoware_internal_debug_msgs::msg::Float32MultiArrayStamped>
+: std::true_type
 {
 };
 
 template <>
-struct is_debug_message<tier4_debug_msgs::msg::Float32Stamped> : std::true_type
+struct is_debug_message<autoware_internal_debug_msgs::msg::Float32Stamped> : std::true_type
 {
 };
 
 template <>
-struct is_debug_message<tier4_debug_msgs::msg::Float64MultiArrayStamped> : std::true_type
+struct is_debug_message<autoware_internal_debug_msgs::msg::Float64MultiArrayStamped>
+: std::true_type
 {
 };
 
 template <>
-struct is_debug_message<tier4_debug_msgs::msg::Float64Stamped> : std::true_type
+struct is_debug_message<autoware_internal_debug_msgs::msg::Float64Stamped> : std::true_type
 {
 };
 
 template <>
-struct is_debug_message<tier4_debug_msgs::msg::Int32MultiArrayStamped> : std::true_type
+struct is_debug_message<autoware_internal_debug_msgs::msg::Int32MultiArrayStamped> : std::true_type
 {
 };
 
 template <>
-struct is_debug_message<tier4_debug_msgs::msg::Int32Stamped> : std::true_type
+struct is_debug_message<autoware_internal_debug_msgs::msg::Int32Stamped> : std::true_type
 {
 };
 
 template <>
-struct is_debug_message<tier4_debug_msgs::msg::Int64MultiArrayStamped> : std::true_type
+struct is_debug_message<autoware_internal_debug_msgs::msg::Int64MultiArrayStamped> : std::true_type
 {
 };
 
 template <>
-struct is_debug_message<tier4_debug_msgs::msg::Int64Stamped> : std::true_type
+struct is_debug_message<autoware_internal_debug_msgs::msg::Int64Stamped> : std::true_type
 {
 };
 
 template <>
-struct is_debug_message<tier4_debug_msgs::msg::StringStamped> : std::true_type
+struct is_debug_message<autoware_internal_debug_msgs::msg::StringStamped> : std::true_type
 {
 };
 

--- a/common/autoware_universe_utils/include/autoware/universe_utils/system/time_keeper.hpp
+++ b/common/autoware_universe_utils/include/autoware/universe_utils/system/time_keeper.hpp
@@ -18,9 +18,9 @@
 
 #include <rclcpp/publisher.hpp>
 
+#include <autoware_internal_debug_msgs/msg/processing_time_node.hpp>
+#include <autoware_internal_debug_msgs/msg/processing_time_tree.hpp>
 #include <std_msgs/msg/string.hpp>
-#include <tier4_debug_msgs/msg/processing_time_node.hpp>
-#include <tier4_debug_msgs/msg/processing_time_tree.hpp>
 
 #include <memory>
 #include <ostream>
@@ -61,9 +61,10 @@ public:
   /**
    * @brief Construct a ProcessingTimeTree message from the node and its children
    *
-   * @return tier4_debug_msgs::msg::ProcessingTimeTree Constructed ProcessingTimeTree message
+   * @return autoware_internal_debug_msgs::msg::ProcessingTimeTree Constructed ProcessingTimeTree
+   * message
    */
-  tier4_debug_msgs::msg::ProcessingTimeTree to_msg() const;
+  autoware_internal_debug_msgs::msg::ProcessingTimeTree to_msg() const;
 
   /**
    * @brief Get the parent node
@@ -111,7 +112,8 @@ private:
 };
 
 using ProcessingTimeDetail =
-  tier4_debug_msgs::msg::ProcessingTimeTree;  //!< Alias for the ProcessingTimeTree message
+  autoware_internal_debug_msgs::msg::ProcessingTimeTree;  //!< Alias for the ProcessingTimeTree
+                                                          //!< message
 
 /**
  * @brief Class for tracking and reporting the processing time of various functions

--- a/common/autoware_universe_utils/package.xml
+++ b/common/autoware_universe_utils/package.xml
@@ -13,6 +13,7 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_internal_debug_msgs</depend>
+  <depend>autoware_internal_debug_msgs</depend>
   <depend>autoware_internal_msgs</depend>
   <depend>autoware_perception_msgs</depend>
   <depend>autoware_planning_msgs</depend>
@@ -27,7 +28,6 @@
   <depend>tf2</depend>
   <depend>tf2_eigen</depend>
   <depend>tf2_geometry_msgs</depend>
-  <depend>tier4_debug_msgs</depend>
   <depend>tier4_planning_msgs</depend>
   <depend>unique_identifier_msgs</depend>
   <depend>visualization_msgs</depend>

--- a/common/autoware_universe_utils/package.xml
+++ b/common/autoware_universe_utils/package.xml
@@ -13,7 +13,6 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_internal_debug_msgs</depend>
-  <depend>autoware_internal_debug_msgs</depend>
   <depend>autoware_internal_msgs</depend>
   <depend>autoware_perception_msgs</depend>
   <depend>autoware_planning_msgs</depend>

--- a/common/autoware_universe_utils/src/system/time_keeper.cpp
+++ b/common/autoware_universe_utils/src/system/time_keeper.cpp
@@ -67,15 +67,17 @@ std::string ProcessingTimeNode::to_string() const
   return oss.str();
 }
 
-tier4_debug_msgs::msg::ProcessingTimeTree ProcessingTimeNode::to_msg() const
+autoware_internal_debug_msgs::msg::ProcessingTimeTree ProcessingTimeNode::to_msg() const
 {
-  tier4_debug_msgs::msg::ProcessingTimeTree time_tree_msg;
+  autoware_debug_msgs::msg::ProcessingTimeTree time_tree_msg;
 
-  std::function<void(const ProcessingTimeNode &, tier4_debug_msgs::msg::ProcessingTimeTree &, int)>
+  std::function<void(
+    const ProcessingTimeNode &, autoware_internal_debug_msgs::msg::ProcessingTimeTree &, int)>
     construct_msg = [&](
                       const ProcessingTimeNode & node,
-                      tier4_debug_msgs::msg::ProcessingTimeTree & tree_msg, int parent_id) {
-      tier4_debug_msgs::msg::ProcessingTimeNode time_node_msg;
+                      autoware_internal_debug_msgs::msg::ProcessingTimeTree & tree_msg,
+                      int parent_id) {
+      autoware_internal_debug_msgs::msg::ProcessingTimeNode time_node_msg;
       time_node_msg.name = node.name_;
       time_node_msg.processing_time = node.processing_time_;
       time_node_msg.id = static_cast<int>(tree_msg.nodes.size() + 1);


### PR DESCRIPTION
## Description
The tier4_debug_msgs have been replaced with autoware_internal_debug_msgs to enhance clarity and consistency in the codebase.

## Related links

**Parent Issue:**

- https://github.com/autowarefoundation/autoware/issues/5580

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
