### PR TITLE
fix(autoware_motion_velocity_obstacle_velocity_limiter_module): remove cppcheck suppressions

### DIFF
--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_velocity_limiter_module/benchmarks/collision_checker_benchmark.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_velocity_limiter_module/benchmarks/collision_checker_benchmark.cpp
@@ -76,12 +76,10 @@ int main()
         const auto naive_constr_end = std::chrono::system_clock::now();
         const auto rtt_check_start = std::chrono::system_clock::now();
         for (const auto & polygon : polygons)
-          // cppcheck-suppress unreadVariable
           const auto rtree_result = rtree_collision_checker.intersections(polygon);
         const auto rtt_check_end = std::chrono::system_clock::now();
         const auto naive_check_start = std::chrono::system_clock::now();
         for (const auto & polygon : polygons)
-          // cppcheck-suppress unreadVariable
           const auto naive_result = naive_collision_checker.intersections(polygon);
         const auto naive_check_end = std::chrono::system_clock::now();
         const auto rtt_constr_time =


### PR DESCRIPTION
## Description

The last `cppcheck-weekly` CI detected something wrong in `autoware_motion_velocity_obstacle_velocity_limiter_module`.
https://github.com/autowarefoundation/autoware.universe/actions/runs/12624163932

I decided to ignore `benchmarks` directories instead of fixing the warnings.
Thus, I removed cppcheck-related suppressions from `autoware_motion_velocity_obstacle_velocity_limiter_module/benchmarks/`

## Related links

`benchmarks` directories will be ignored by cppcheck with the following PR
https://github.com/autowarefoundation/autoware.universe/pull/9842

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
