### PR TITLE
feat: tier4_debug_msgs changed to autoware_internal_debug_msgs in fil…

### DIFF
--- a/control/control_performance_analysis/package.xml
+++ b/control/control_performance_analysis/package.xml
@@ -25,6 +25,7 @@
   <build_depend>builtin_interfaces</build_depend>
 
   <depend>autoware_control_msgs</depend>
+  <depend>autoware_internal_debug_msgs</depend>
   <depend>autoware_motion_utils</depend>
   <depend>autoware_planning_msgs</depend>
   <depend>autoware_signal_processing</depend>
@@ -41,7 +42,6 @@
   <depend>tf2</depend>
   <depend>tf2_eigen</depend>
   <depend>tf2_ros</depend>
-  <depend>tier4_debug_msgs</depend>
   <exec_depend>autoware_global_parameter_loader</exec_depend>
   <exec_depend>builtin_interfaces</exec_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>

--- a/control/control_performance_analysis/scripts/control_performance_plot.py
+++ b/control/control_performance_analysis/scripts/control_performance_plot.py
@@ -17,13 +17,13 @@
 import argparse
 import math
 
+from autoware_internal_debug_msgs.msg import BoolStamped
 from control_performance_analysis.msg import DrivingMonitorStamped
 from control_performance_analysis.msg import ErrorStamped
 import matplotlib.pyplot as plt
 from nav_msgs.msg import Odometry
 import rclpy
 from rclpy.node import Node
-from tier4_debug_msgs.msg import BoolStamped
 
 parser = argparse.ArgumentParser()
 parser.add_argument("-i", "--interval", help="interval distance to plot")


### PR DESCRIPTION
…es control/control_performance_analysis

## Description

The tier4_debug_msgs have been replaced with autoware_internal_debug_msgs to enhance clarity and consistency in the codebase.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
