### PR TITLE
fix(image_projection_based_fusion): remove mutex

### DIFF
--- a/perception/autoware_image_projection_based_fusion/include/autoware/image_projection_based_fusion/fusion_node.hpp
+++ b/perception/autoware_image_projection_based_fusion/include/autoware/image_projection_based_fusion/fusion_node.hpp
@@ -40,7 +40,6 @@
 
 #include <map>
 #include <memory>
-#include <mutex>
 #include <set>
 #include <string>
 #include <utility>
@@ -127,7 +126,6 @@ private:
   // cache for fusion
   int64_t cached_det3d_msg_timestamp_;
   typename Msg3D::SharedPtr cached_det3d_msg_ptr_;
-  std::mutex mutex_cached_msgs_;
 
 protected:
   void setDet2DStatus(std::size_t rois_number);


### PR DESCRIPTION
## Description
Since [callback group](https://docs.ros.org/en/foxy/How-To-Guides/Using-callback-groups.html) is not set in the `autoware_image_projection_based_fusion`, all the callbacks are in a same group.
Therefore, the mutex is not necessary.

This PR do not contain any logic change.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
Tested in a local environment.

lidar_detection_model: pointpainting

tested
* pointpainting fusion
* roi cluster fusion
* roi detected-object fusion
* roi pointcloud fusion

not tested
* segment pointcloud fusion

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
