### PR TITLE
feat: tier4_debug_msgs changed to autoware_internal_debug_msgs in files localization/autoware_pose2twist

### DIFF
--- a/localization/autoware_pose2twist/README.md
+++ b/localization/autoware_pose2twist/README.md
@@ -17,11 +17,11 @@ The `twist.angular` is calculated as `relative_rotation_vector / dt` for each fi
 
 ### Output
 
-| Name      | Type                                  | Description                                   |
-| --------- | ------------------------------------- | --------------------------------------------- |
-| twist     | geometry_msgs::msg::TwistStamped      | twist calculated from the input pose history. |
-| linear_x  | tier4_debug_msgs::msg::Float32Stamped | linear-x field of the output twist.           |
-| angular_z | tier4_debug_msgs::msg::Float32Stamped | angular-z field of the output twist.          |
+| Name      | Type                                              | Description                                   |
+| --------- | ------------------------------------------------- | --------------------------------------------- |
+| twist     | geometry_msgs::msg::TwistStamped                  | twist calculated from the input pose history. |
+| linear_x  | autoware_internal_debug_msgs::msg::Float32Stamped | linear-x field of the output twist.           |
+| angular_z | autoware_internal_debug_msgs::msg::Float32Stamped | angular-z field of the output twist.          |
 
 ## Parameters
 

--- a/localization/autoware_pose2twist/package.xml
+++ b/localization/autoware_pose2twist/package.xml
@@ -17,11 +17,11 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
+  <depend>autoware_internal_debug_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>tf2_geometry_msgs</depend>
-  <depend>tier4_debug_msgs</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>

--- a/localization/autoware_pose2twist/src/pose2twist_core.cpp
+++ b/localization/autoware_pose2twist/src/pose2twist_core.cpp
@@ -29,9 +29,10 @@ Pose2Twist::Pose2Twist(const rclcpp::NodeOptions & options) : rclcpp::Node("pose
   durable_qos.transient_local();
 
   twist_pub_ = create_publisher<geometry_msgs::msg::TwistStamped>("twist", durable_qos);
-  linear_x_pub_ = create_publisher<tier4_debug_msgs::msg::Float32Stamped>("linear_x", durable_qos);
+  linear_x_pub_ =
+    create_publisher<autoware_internal_debug_msgs::msg::Float32Stamped>("linear_x", durable_qos);
   angular_z_pub_ =
-    create_publisher<tier4_debug_msgs::msg::Float32Stamped>("angular_z", durable_qos);
+    create_publisher<autoware_internal_debug_msgs::msg::Float32Stamped>("angular_z", durable_qos);
   // Note: this callback publishes topics above
   pose_sub_ = create_subscription<geometry_msgs::msg::PoseStamped>(
     "pose", queue_size, std::bind(&Pose2Twist::callback_pose, this, _1));
@@ -105,12 +106,12 @@ void Pose2Twist::callback_pose(geometry_msgs::msg::PoseStamped::SharedPtr pose_m
   twist_msg.header.frame_id = "base_link";
   twist_pub_->publish(twist_msg);
 
-  tier4_debug_msgs::msg::Float32Stamped linear_x_msg;
+  autoware_internal_debug_msgs::msg::Float32Stamped linear_x_msg;
   linear_x_msg.stamp = this->now();
   linear_x_msg.data = static_cast<float>(twist_msg.twist.linear.x);
   linear_x_pub_->publish(linear_x_msg);
 
-  tier4_debug_msgs::msg::Float32Stamped angular_z_msg;
+  autoware_internal_debug_msgs::msg::Float32Stamped angular_z_msg;
   angular_z_msg.stamp = this->now();
   angular_z_msg.data = static_cast<float>(twist_msg.twist.angular.z);
   angular_z_pub_->publish(angular_z_msg);

--- a/localization/autoware_pose2twist/src/pose2twist_core.hpp
+++ b/localization/autoware_pose2twist/src/pose2twist_core.hpp
@@ -17,9 +17,9 @@
 
 #include <rclcpp/rclcpp.hpp>
 
+#include <autoware_internal_debug_msgs/msg/float32_stamped.hpp>
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <geometry_msgs/msg/twist_stamped.hpp>
-#include <tier4_debug_msgs/msg/float32_stamped.hpp>
 
 #ifdef ROS_DISTRO_GALACTIC
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
@@ -44,8 +44,8 @@ private:
   rclcpp::Subscription<geometry_msgs::msg::PoseStamped>::SharedPtr pose_sub_;
 
   rclcpp::Publisher<geometry_msgs::msg::TwistStamped>::SharedPtr twist_pub_;
-  rclcpp::Publisher<tier4_debug_msgs::msg::Float32Stamped>::SharedPtr linear_x_pub_;
-  rclcpp::Publisher<tier4_debug_msgs::msg::Float32Stamped>::SharedPtr angular_z_pub_;
+  rclcpp::Publisher<autoware_internal_debug_msgs::msg::Float32Stamped>::SharedPtr linear_x_pub_;
+  rclcpp::Publisher<autoware_internal_debug_msgs::msg::Float32Stamped>::SharedPtr angular_z_pub_;
 };
 }  // namespace autoware::pose2twist
 


### PR DESCRIPTION
## Description

The tier4_debug_msgs have been replaced with autoware_internal_debug_msgs to enhance clarity and consistency in the codebase.


## Related links

None.

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

### Topic changes

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub | `linear_x` | `tier4_debug_msgs::msg::Float32Stamped` | linear-x field of the output twist. |
| New     | Pub | `linear_x` | `autoware_internal_debug_msgs::msg::Float32Stamped` | linear-x field of the output twist. |
| Old     | Pub | `angular_z` | `tier4_debug_msgs::msg::Float32Stamped` | angular-z field of the output twist. |
| New     | Pub | `angular_z` | `autoware_internal_debug_msgs::msg::Float32Stamped` | angular-z field of the output twist. |

## Effects on system behavior

None.
