### PR TITLE
feat(autoware_image_projection_based_fusion)!: tier4_debug-msgs changed to autoware_internal_debug_msgs in autoware_image_projection_based_fusion

### DIFF
--- a/perception/autoware_image_projection_based_fusion/package.xml
+++ b/perception/autoware_image_projection_based_fusion/package.xml
@@ -17,6 +17,7 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_euclidean_cluster</depend>
+  <depend>autoware_internal_debug_msgs</depend>
   <depend>autoware_lidar_centerpoint</depend>
   <depend>autoware_object_recognition_utils</depend>
   <depend>autoware_perception_msgs</depend>

--- a/perception/autoware_image_projection_based_fusion/src/fusion_node.cpp
+++ b/perception/autoware_image_projection_based_fusion/src/fusion_node.cpp
@@ -19,8 +19,8 @@
 #include <Eigen/Core>
 #include <Eigen/Geometry>
 #include <autoware/image_projection_based_fusion/utils/utils.hpp>
-#include <autoware_internal_debug_msgs/msg/float64_stamped.hpp>
 
+#include <autoware_internal_debug_msgs/msg/float64_stamped.hpp>
 #include <tier4_perception_msgs/msg/detected_object_with_feature.hpp>
 
 #include <boost/optional.hpp>

--- a/perception/autoware_image_projection_based_fusion/src/fusion_node.cpp
+++ b/perception/autoware_image_projection_based_fusion/src/fusion_node.cpp
@@ -19,6 +19,7 @@
 #include <Eigen/Core>
 #include <Eigen/Geometry>
 #include <autoware/image_projection_based_fusion/utils/utils.hpp>
+#include <autoware_internal_debug_msgs/msg/float64_stamped.hpp>
 
 #include <tier4_perception_msgs/msg/detected_object_with_feature.hpp>
 
@@ -253,12 +254,12 @@ void FusionNode<Msg3D, Msg2D, ExportObj>::exportProcess()
         std::chrono::nanoseconds(
           (this->get_clock()->now() - cached_det3d_msg_ptr_->header.stamp).nanoseconds()))
         .count();
-    debug_publisher_->publish<tier4_debug_msgs::msg::Float64Stamped>(
+    debug_publisher_->publish<autoware_internal_debug_msgs::msg::Float64Stamped>(
       "debug/cyclic_time_ms", cyclic_time_ms);
-    debug_publisher_->publish<tier4_debug_msgs::msg::Float64Stamped>(
+    debug_publisher_->publish<autoware_internal_debug_msgs::msg::Float64Stamped>(
       "debug/processing_time_ms",
       processing_time_ms + stop_watch_ptr_->toc("processing_time", true));
-    debug_publisher_->publish<tier4_debug_msgs::msg::Float64Stamped>(
+    debug_publisher_->publish<autoware_internal_debug_msgs::msg::Float64Stamped>(
       "debug/pipeline_latency_ms", pipeline_latency_ms);
     processing_time_ms = 0;
   }
@@ -353,9 +354,9 @@ void FusionNode<Msg3D, Msg2D, ExportObj>::subCallback(
       // add timestamp interval for debug
       if (debug_internal_pub_) {
         double timestamp_interval_ms = (matched_stamp - timestamp_nsec) / 1e6;
-        debug_internal_pub_->publish<tier4_debug_msgs::msg::Float64Stamped>(
+        debug_internal_pub_->publish<autoware_internal_debug_msgs::msg::Float64Stamped>(
           "debug/roi" + std::to_string(roi_i) + "/timestamp_interval_ms", timestamp_interval_ms);
-        debug_internal_pub_->publish<tier4_debug_msgs::msg::Float64Stamped>(
+        debug_internal_pub_->publish<autoware_internal_debug_msgs::msg::Float64Stamped>(
           "debug/roi" + std::to_string(roi_i) + "/timestamp_interval_offset_ms",
           timestamp_interval_ms - det2d.input_offset_ms);
       }
@@ -418,9 +419,9 @@ void FusionNode<Msg3D, Msg2D, ExportObj>::roiCallback(
 
       if (debug_internal_pub_) {
         double timestamp_interval_ms = (timestamp_nsec - cached_det3d_msg_timestamp_) / 1e6;
-        debug_internal_pub_->publish<tier4_debug_msgs::msg::Float64Stamped>(
+        debug_internal_pub_->publish<autoware_internal_debug_msgs::msg::Float64Stamped>(
           "debug/roi" + std::to_string(roi_i) + "/timestamp_interval_ms", timestamp_interval_ms);
-        debug_internal_pub_->publish<tier4_debug_msgs::msg::Float64Stamped>(
+        debug_internal_pub_->publish<autoware_internal_debug_msgs::msg::Float64Stamped>(
           "debug/roi" + std::to_string(roi_i) + "/timestamp_interval_offset_ms",
           timestamp_interval_ms - det2d.input_offset_ms);
       }


### PR DESCRIPTION
…es perception/autoware_image_projection_based_fusion

## Description
The tier4_debug_msgs have been replaced with autoware_internal_debug_msgs to enhance clarity and consistency in the codebase.

## Related links
**Parent Issue:**

- https://github.com/autowarefoundation/autoware/issues/5580

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
Test are done in the following TIER IV internal evaluator:

https://evaluation.ci.tier4.jp/evaluation/reports/bfc0e074-207b-5ece-83e5-fb769f6f7272?project_id=prd_jt
https://evaluation.ci.tier4.jp/evaluation/reports/4df9332b-024e-5907-ada9-fbbcb8c20b3d?project_id=prd_jt
https://evaluation.ci.tier4.jp/evaluation/reports/ce1a0892-d8aa-5729-b25d-6d2d57bea034?project_id=prd_jt

AWSIM Test: https://github.com/autowarefoundation/autoware.universe/pull/9877#issuecomment-2608910505

## Notes for reviewers

None.

## Interface changes


### Topic changes


#### Modifications


|  Topic Type      | Topic Name        | Old Message Type | New Message Type        |
|:---------------------|:------------------|:--------------------|:--------------------|
|  Pub | `debug/cyclic_time_ms` | `tier4_debug_msgs/Float64Stamped` | `autoware_internal_debug_msgs/Float64Stamped` |
|  Pub | `debug/processing_time_ms` |`tier4_debug_msgs/Float64Stamped` | `autoware_internal_debug_msgs/Float64Stamped`  |
|  Pub | `debug/pipeline_latency_ms` | `tier4_debug_msgs/Float64Stamped` |`autoware_internal_debug_msgs/Float64Stamped`  |
|  Pub | `debug/roi/timestamp_interval_ms"` |`tier4_debug_msgs/Float64Stamped` | `autoware_internal_debug_msgs/Float64Stamped`  |
|  Pub | `debug/roi/timestamp_interval_offset_ms` | `tier4_debug_msgs/Float64Stamped` |`autoware_internal_debug_msgs/Float64Stamped`  |


## Effects on system behavior

None.
