### PR TITLE
chore(autoware_twist2accel): remove an unused dependency

### DIFF
--- a/localization/autoware_twist2accel/package.xml
+++ b/localization/autoware_twist2accel/package.xml
@@ -17,7 +17,6 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-  <depend>autoware_internal_debug_msgs</depend>
   <depend>autoware_signal_processing</depend>
   <depend>geometry_msgs</depend>
   <depend>nav_msgs</depend>

--- a/localization/autoware_twist2accel/src/twist2accel.hpp
+++ b/localization/autoware_twist2accel/src/twist2accel.hpp
@@ -19,7 +19,6 @@
 
 #include <rclcpp/rclcpp.hpp>
 
-#include <autoware_internal_debug_msgs/msg/bool_stamped.hpp>
 #include <geometry_msgs/msg/accel_with_covariance_stamped.hpp>
 #include <geometry_msgs/msg/twist_stamped.hpp>
 #include <geometry_msgs/msg/twist_with_covariance_stamped.hpp>


### PR DESCRIPTION
## Description

I merged https://github.com/autowarefoundation/autoware.universe/pull/9868, but I realize now that `autoware_internal_debug_msgs` is not used in `autoware_twist2accel`. So this pull request removes that dependency.

## Related links

None.

## How was this PR tested?

- [x] `planning_simulator` with [sample_map](https://autowarefoundation.github.io/autoware-documentation/main/tutorials/ad-hoc-simulation/planning-simulation/)
- [x] `logging_simulator` with [sample_rosbag](https://autowarefoundation.github.io/autoware-documentation/main/tutorials/ad-hoc-simulation/rosbag-replay-simulation/)

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
