### PR TITLE
feat(lane_change): append candidate path index to metric debug table

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/scene.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/scene.hpp
@@ -135,7 +135,8 @@ protected:
   std::vector<LaneChangePhaseMetrics> get_prepare_metrics() const;
   std::vector<LaneChangePhaseMetrics> get_lane_changing_metrics(
     const PathWithLaneId & prep_segment, const LaneChangePhaseMetrics & prep_metrics,
-    const double shift_length, const double dist_to_reg_element) const;
+    const double shift_length, const double dist_to_reg_element,
+    lane_change::MetricsDebug & debug_metrics) const;
 
   bool get_lane_change_paths(LaneChangePaths & candidate_paths) const;
 

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/structs/debug.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/structs/debug.hpp
@@ -34,7 +34,7 @@ using utils::path_safety_checker::CollisionCheckDebugMap;
 struct MetricsDebug
 {
   LaneChangePhaseMetrics prep_metric;
-  std::vector<LaneChangePhaseMetrics> lc_metrics;
+  std::vector<std::pair<LaneChangePhaseMetrics, int>> lc_metrics;
   double max_prepare_length;
   double max_lane_changing_length;
 };

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/markers.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/markers.cpp
@@ -73,32 +73,6 @@ MarkerArray showAllValidLaneChangePath(
       marker.points.push_back(point.point.pose.position);
     }
 
-    const auto & info = lc_path.info;
-    auto text_marker = createDefaultMarker(
-      "map", current_time, ns_with_idx, ++id, visualization_msgs::msg::Marker::TEXT_VIEW_FACING,
-      createMarkerScale(0.1, 0.1, 0.8), colors::yellow());
-    const auto prep_idx = points.size() / 4;
-    text_marker.pose = points.at(prep_idx).point.pose;
-    text_marker.pose.position.z += 2.0;
-    text_marker.text = fmt::format(
-      "vel: {vel:.3f}[m/s] | lon_acc: {lon_acc:.3f}[m/s2] | t: {time:.3f}[s] | L: {length:.3f}[m]",
-      fmt::arg("vel", info.velocity.prepare),
-      fmt::arg("lon_acc", info.longitudinal_acceleration.prepare),
-      fmt::arg("time", info.duration.prepare), fmt::arg("length", info.length.prepare));
-    marker_array.markers.push_back(text_marker);
-
-    const auto lc_idx = points.size() / 2;
-    text_marker.id = ++id;
-    text_marker.pose = points.at(lc_idx).point.pose;
-    text_marker.text = fmt::format(
-      "vel: {vel:.3f}[m/s] | lon_acc: {lon_acc:.3f}[m/s2] | lat_acc: {lat_acc:.3f}[m/s2] | t: "
-      "{time:.3f}[s] | L: {length:.3f}[m]",
-      fmt::arg("vel", info.velocity.lane_changing),
-      fmt::arg("lon_acc", info.longitudinal_acceleration.lane_changing),
-      fmt::arg("lat_acc", info.lateral_acceleration), fmt::arg("time", info.duration.lane_changing),
-      fmt::arg("length", info.length.lane_changing));
-    marker_array.markers.push_back(text_marker);
-
     marker_array.markers.push_back(marker);
   }
   return marker_array;
@@ -206,26 +180,30 @@ MarkerArray ShowLaneChangeMetricsInfo(
     createMarkerScale(0.6, 0.6, 0.6), colors::yellow());
   text_marker.pose = autoware::universe_utils::calcOffsetPose(pose, 10.0, 15.0, 0.0);
 
-  text_marker.text = fmt::format("{:<12}", "") + fmt::format("{:^18}|", "lat_accel[m/s2]") +
-                     fmt::format("{:^18}|", "lon_accel[m/s2]") +
-                     fmt::format("{:^17}|", "velocity[m/s]") +
-                     fmt::format("{:^15}|", "duration[s]") + fmt::format("{:^15}|", "length[m]") +
-                     fmt::format("{:^20}\n", "max_length_th[m]");
+  text_marker.text =
+    fmt::format("{:<12}", "") + fmt::format("{:^18}|", "lat_accel[m/s2]") +
+    fmt::format("{:^18}|", "lon_accel[m/s2]") + fmt::format("{:^17}|", "velocity[m/s]") +
+    fmt::format("{:^15}|", "duration[s]") + fmt::format("{:^15}|", "length[m]") +
+    fmt::format("{:^20}|", "max_length_th[m]") + fmt::format("{:^15}\n", "path_index");
   for (const auto & metrics : debug_data.lane_change_metrics) {
-    text_marker.text += fmt::format("{:-<170}\n", "");
+    text_marker.text += fmt::format("{:-<190}\n", "");
     const auto & p_m = metrics.prep_metric;
     text_marker.text +=
       fmt::format("{:<17}", "prep_metrics:") + fmt::format("{:^10.3f}", p_m.lat_accel) +
       fmt::format("{:^21.3f}", p_m.actual_lon_accel) + fmt::format("{:^12.3f}", p_m.velocity) +
       fmt::format("{:^15.3f}", p_m.duration) + fmt::format("{:^15.3f}", p_m.length) +
-      fmt::format("{:^17.3f}\n", metrics.max_prepare_length);
+      fmt::format("{:^17.3f}", metrics.max_prepare_length) + fmt::format("{:^15}\n", "-");
     text_marker.text += fmt::format("{:<20}\n", "lc_metrics:");
-    for (const auto lc_m : metrics.lc_metrics) {
-      text_marker.text +=
-        fmt::format("{:<15}", "") + fmt::format("{:^10.3f}", lc_m.lat_accel) +
-        fmt::format("{:^21.3f}", lc_m.actual_lon_accel) + fmt::format("{:^12.3f}", lc_m.velocity) +
-        fmt::format("{:^15.3f}", lc_m.duration) + fmt::format("{:^15.3f}", lc_m.length) +
-        fmt::format("{:^17.3f}\n", metrics.max_lane_changing_length);
+    for (const auto & lc_m : metrics.lc_metrics) {
+      const auto & metric = lc_m.first;
+      const auto path_index = lc_m.second < 0 ? "-" : std::to_string(lc_m.second);
+      text_marker.text += fmt::format("{:<15}", "") + fmt::format("{:^10.3f}", metric.lat_accel) +
+                          fmt::format("{:^21.3f}", metric.actual_lon_accel) +
+                          fmt::format("{:^12.3f}", metric.velocity) +
+                          fmt::format("{:^15.3f}", metric.duration) +
+                          fmt::format("{:^15.3f}", metric.length) +
+                          fmt::format("{:^17.3f}", metrics.max_lane_changing_length) +
+                          fmt::format("{:^15}\n", path_index);
     }
   }
 


### PR DESCRIPTION
## Description

for each metrics sample in the debug table, append the corresponding candidate path index, as shown below.

![Screenshot from 2025-01-10 15-57-29](https://github.com/user-attachments/assets/cb07a373-a725-4d7e-b6d0-953c9538b681)

## Related links

None.

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
- PSIM

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
