### PR TITLE
feat(autoware_tensorrt_yolox)!: tier4_debug_msgs changed to autoware_internal_debug_msgs in autoware_tensorrt_yolox

### DIFF
--- a/perception/autoware_tensorrt_yolox/package.xml
+++ b/perception/autoware_tensorrt_yolox/package.xml
@@ -20,6 +20,7 @@
   <buildtool_export_depend>tensorrt_cmake_module</buildtool_export_depend>
 
   <depend>autoware_cuda_utils</depend>
+  <depend>autoware_internal_debug_msgs</depend>
   <depend>autoware_object_recognition_utils</depend>
   <depend>autoware_perception_msgs</depend>
   <depend>autoware_tensorrt_common</depend>

--- a/perception/autoware_tensorrt_yolox/src/tensorrt_yolox_node.cpp
+++ b/perception/autoware_tensorrt_yolox/src/tensorrt_yolox_node.cpp
@@ -212,11 +212,11 @@ void TrtYoloXNode::onImage(const sensor_msgs::msg::Image::ConstSharedPtr msg)
         std::chrono::nanoseconds(
           (this->get_clock()->now() - out_objects.header.stamp).nanoseconds()))
         .count();
-    debug_publisher_->publish<tier4_debug_msgs::msg::Float64Stamped>(
+    debug_publisher_->publish<autoware_internal_debug_msgs::msg::Float64Stamped>(
       "debug/cyclic_time_ms", cyclic_time_ms);
-    debug_publisher_->publish<tier4_debug_msgs::msg::Float64Stamped>(
+    debug_publisher_->publish<autoware_internal_debug_msgs::msg::Float64Stamped>(
       "debug/processing_time_ms", processing_time_ms);
-    debug_publisher_->publish<tier4_debug_msgs::msg::Float64Stamped>(
+    debug_publisher_->publish<autoware_internal_debug_msgs::msg::Float64Stamped>(
       "debug/pipeline_latency_ms", pipeline_latency_ms);
   }
 


### PR DESCRIPTION
## Description

The tier4_debug_msgs have been replaced with autoware_internal_debug_msgs to enhance clarity and consistency in the codebase.


## Related links

**Parent Issue:**

- https://github.com/autowarefoundation/autoware/issues/5580


<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
Test are done in the following TIER IV internal evaluator:

https://evaluation.ci.tier4.jp/evaluation/reports/bfc0e074-207b-5ece-83e5-fb769f6f7272?project_id=prd_jt
https://evaluation.ci.tier4.jp/evaluation/reports/4df9332b-024e-5907-ada9-fbbcb8c20b3d?project_id=prd_jt
https://evaluation.ci.tier4.jp/evaluation/reports/ce1a0892-d8aa-5729-b25d-6d2d57bea034?project_id=prd_jt

https://github.com/autowarefoundation/autoware.universe/pull/9898#issuecomment-2608947790

## Notes for reviewers

None.

## Interface changes

### Topic changes

|  Topic Type      | Topic Name        | Old Message Type | New Message Type        |
|:---------------------|:------------------|:--------------------|:--------------------|
|  Pub | `debug/cyclic_time_ms` | `tier4_debug_msgs/Float64Stamped` | `autoware_internal_debug_msgs/Float64Stamped` |
|  Pub | `debug/processing_time_ms` |`tier4_debug_msgs/Float64Stamped` | `autoware_internal_debug_msgs/Float64Stamped`  |
|  Pub | `debug/pipeline_latency_ms` | `tier4_debug_msgs/Float64Stamped` |`autoware_internal_debug_msgs/Float64Stamped`  |

## Effects on system behavior

None.
