### PR TITLE
feat(autoware_tracking_object_merger)!: tier4_debug_msgs changed to autoware_internal_debug_msgs in autoware_tracking_object_merger

### DIFF
--- a/perception/autoware_tracking_object_merger/src/decorative_tracker_merger_node.cpp
+++ b/perception/autoware_tracking_object_merger/src/decorative_tracker_merger_node.cpp
@@ -247,9 +247,9 @@ void DecorativeTrackerMergerNode::mainObjectsCallback(
 
   published_time_publisher_->publish_if_subscribed(
     merged_object_pub_, tracked_objects.header.stamp);
-  processing_time_publisher_->publish<tier4_debug_msgs::msg::Float64Stamped>(
+  processing_time_publisher_->publish<autoware_internal_debug_msgs::msg::Float64Stamped>(
     "debug/cyclic_time_ms", stop_watch_ptr_->toc("cyclic_time", true));
-  processing_time_publisher_->publish<tier4_debug_msgs::msg::Float64Stamped>(
+  processing_time_publisher_->publish<autoware_internal_debug_msgs::msg::Float64Stamped>(
     "debug/processing_time_ms", stop_watch_ptr_->toc("processing_time", true));
 }
 


### PR DESCRIPTION
…es  perception/autoware_tracking_object_merger

## Description

The tier4_debug_msgs have been replaced with autoware_internal_debug_msgs to enhance clarity and consistency in the codebase.

https://github.com/autowarefoundation/autoware/issues/5580


## Related links

**Parent Issue:**

https://github.com/autowarefoundation/autoware/issues/5580

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
Test are done in the following TIER IV internal evaluator:

https://evaluation.ci.tier4.jp/evaluation/reports/bfc0e074-207b-5ece-83e5-fb769f6f7272?project_id=prd_jt
https://evaluation.ci.tier4.jp/evaluation/reports/4df9332b-024e-5907-ada9-fbbcb8c20b3d?project_id=prd_jt
https://evaluation.ci.tier4.jp/evaluation/reports/ce1a0892-d8aa-5729-b25d-6d2d57bea034?project_id=prd_jt
## Notes for reviewers

None.

## Interface changes

|  Topic Type      | Topic Name        | Old Message Type | New Message Type        |
|:---------------------|:------------------|:--------------------|:--------------------|
|  Pub | `debug/cyclic_time_ms` | `tier4_debug_msgs/Float64Stamped` | `autoware_internal_debug_msgs/Float64Stamped` |
|  Pub | `debug/processing_time_ms` |`tier4_debug_msgs/Float64Stamped` | `autoware_internal_debug_msgs/Float64Stamped`  |

## Effects on system behavior

None.
