### PR TITLE
feat(traffic_light_fine_detector)!: tier4_debug_msgs changed to autoware_internal_debug_msgs in traffic_light_fine_detector

### DIFF
--- a/perception/autoware_traffic_light_fine_detector/README.md
+++ b/perception/autoware_traffic_light_fine_detector/README.md
@@ -35,10 +35,10 @@ Based on the camera image and the global ROI array detected by `map_based_detect
 
 ### Output
 
-| Name                  | Type                                               | Description                  |
-| --------------------- | -------------------------------------------------- | ---------------------------- |
-| `~/output/rois`       | `tier4_perception_msgs::msg::TrafficLightRoiArray` | The detected accurate rois   |
-| `~/debug/exe_time_ms` | `tier4_debug_msgs::msg::Float32Stamped`            | The time taken for inference |
+| Name                  | Type                                                | Description                  |
+| --------------------- | --------------------------------------------------- | ---------------------------- |
+| `~/output/rois`       | `tier4_perception_msgs::msg::TrafficLightRoiArray`  | The detected accurate rois   |
+| `~/debug/exe_time_ms` | `autoware_internal_debug_msgs::msg::Float32Stamped` | The time taken for inference |
 
 ## Parameters
 

--- a/perception/autoware_traffic_light_fine_detector/package.xml
+++ b/perception/autoware_traffic_light_fine_detector/package.xml
@@ -14,6 +14,7 @@
 
   <build_depend>autoware_cmake</build_depend>
 
+  <depend>autoware_internal_debug_msgs</depend>
   <depend>autoware_tensorrt_yolox</depend>
   <depend>cv_bridge</depend>
   <depend>image_transport</depend>
@@ -21,7 +22,6 @@
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>sensor_msgs</depend>
-  <depend>tier4_debug_msgs</depend>
   <depend>tier4_perception_msgs</depend>
 
   <test_depend>autoware_lint_common</test_depend>

--- a/perception/autoware_traffic_light_fine_detector/src/traffic_light_fine_detector_node.cpp
+++ b/perception/autoware_traffic_light_fine_detector/src/traffic_light_fine_detector_node.cpp
@@ -104,8 +104,8 @@ TrafficLightFineDetectorNode::TrafficLightFineDetectorNode(const rclcpp::NodeOpt
 
   std::lock_guard<std::mutex> lock(connect_mutex_);
   output_roi_pub_ = this->create_publisher<TrafficLightRoiArray>("~/output/rois", 1);
-  exe_time_pub_ =
-    this->create_publisher<tier4_debug_msgs::msg::Float32Stamped>("~/debug/exe_time_ms", 1);
+  exe_time_pub_ = this->create_publisher<autoware_internal_debug_msgs::msg::Float32Stamped>(
+    "~/debug/exe_time_ms", 1);
   if (is_approximate_sync_) {
     approximate_sync_.reset(
       new ApproximateSync(ApproximateSyncPolicy(10), image_sub_, rough_roi_sub_, expect_roi_sub_));
@@ -211,7 +211,7 @@ void TrafficLightFineDetectorNode::callback(
   const auto exe_end_time = high_resolution_clock::now();
   const double exe_time =
     std::chrono::duration_cast<milliseconds>(exe_end_time - exe_start_time).count();
-  tier4_debug_msgs::msg::Float32Stamped exe_time_msg;
+  autoware_internal_debug_msgs::msg::Float32Stamped exe_time_msg;
   exe_time_msg.data = exe_time;
   exe_time_msg.stamp = this->now();
   exe_time_pub_->publish(exe_time_msg);

--- a/perception/autoware_traffic_light_fine_detector/src/traffic_light_fine_detector_node.hpp
+++ b/perception/autoware_traffic_light_fine_detector/src/traffic_light_fine_detector_node.hpp
@@ -22,9 +22,9 @@
 #include <opencv2/highgui/highgui.hpp>
 #include <rclcpp/rclcpp.hpp>
 
+#include <autoware_internal_debug_msgs/msg/float32_stamped.hpp>
 #include <sensor_msgs/image_encodings.hpp>
 #include <sensor_msgs/msg/image.hpp>
-#include <tier4_debug_msgs/msg/float32_stamped.hpp>
 #include <tier4_perception_msgs/msg/traffic_light_roi_array.hpp>
 
 #if __has_include(<cv_bridge/cv_bridge.hpp>)
@@ -148,7 +148,7 @@ private:
   message_filters::Subscriber<TrafficLightRoiArray> expect_roi_sub_;
   std::mutex connect_mutex_;
   rclcpp::Publisher<TrafficLightRoiArray>::SharedPtr output_roi_pub_;
-  rclcpp::Publisher<tier4_debug_msgs::msg::Float32Stamped>::SharedPtr exe_time_pub_;
+  rclcpp::Publisher<autoware_internal_debug_msgs::msg::Float32Stamped>::SharedPtr exe_time_pub_;
   rclcpp::TimerBase::SharedPtr timer_;
 
   typedef message_filters::sync_policies::ExactTime<


### PR DESCRIPTION
…es traffic_light_fine_detector

## Description

The tier4_debug_msgs have been replaced with autoware_internal_debug_msgs to enhance clarity and consistency in the codebase.


## Related links
**Parent Issue:**

- https://github.com/autowarefoundation/autoware/issues/5580


<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
Test are done in the following TIER IV internal evaluator:

https://evaluation.ci.tier4.jp/evaluation/reports/bfc0e074-207b-5ece-83e5-fb769f6f7272?project_id=prd_jt
https://evaluation.ci.tier4.jp/evaluation/reports/4df9332b-024e-5907-ada9-fbbcb8c20b3d?project_id=prd_jt
https://evaluation.ci.tier4.jp/evaluation/reports/ce1a0892-d8aa-5729-b25d-6d2d57bea034?project_id=prd_jt
## Notes for reviewers

None.

## Interface changes

### Topic changes

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type              |
|:--------|:----------------|:------------------|:--------------------|
| Old     | Pub | `~/debug/exe_time_ms` | `tier4_debug_msgs::msg::Float32Stamped`  |
| New     | Pub | `~/debug/exe_time_ms` | `autoware_internal_debug_msgs::msg::Float32Stamped`  |

## Effects on system behavior

None.
