### PR TITLE
feat(autoware_path_optimizer)!: tier4_debug_msgs changed to autoware-internal_debug_msgs in autoware_path_optimizer

### DIFF
--- a/planning/autoware_path_optimizer/include/autoware/path_optimizer/type_alias.hpp
+++ b/planning/autoware_path_optimizer/include/autoware/path_optimizer/type_alias.hpp
@@ -15,6 +15,7 @@
 #ifndef AUTOWARE__PATH_OPTIMIZER__TYPE_ALIAS_HPP_
 #define AUTOWARE__PATH_OPTIMIZER__TYPE_ALIAS_HPP_
 
+#include "autoware_internal_debug_msgs/msg/float64_stamped.hpp"
 #include "autoware_internal_debug_msgs/msg/string_stamped.hpp"
 #include "autoware_planning_msgs/msg/path.hpp"
 #include "autoware_planning_msgs/msg/path_point.hpp"
@@ -25,7 +26,6 @@
 #include "geometry_msgs/msg/twist.hpp"
 #include "nav_msgs/msg/odometry.hpp"
 #include "std_msgs/msg/header.hpp"
-#include "tier4_debug_msgs/msg/float64_stamped.hpp"
 #include "visualization_msgs/msg/marker_array.hpp"
 
 namespace autoware::path_optimizer
@@ -43,8 +43,8 @@ using nav_msgs::msg::Odometry;
 using visualization_msgs::msg::Marker;
 using visualization_msgs::msg::MarkerArray;
 // debug
+using autoware_internal_debug_msgs::msg::Float64Stamped;
 using autoware_internal_debug_msgs::msg::StringStamped;
-using tier4_debug_msgs::msg::Float64Stamped;
 }  // namespace autoware::path_optimizer
 
 #endif  // AUTOWARE__PATH_OPTIMIZER__TYPE_ALIAS_HPP_

--- a/planning/autoware_path_optimizer/package.xml
+++ b/planning/autoware_path_optimizer/package.xml
@@ -15,7 +15,6 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_internal_debug_msgs</depend>
-  <depend>autoware_internal_debug_msgs</depend>
   <depend>autoware_interpolation</depend>
   <depend>autoware_motion_utils</depend>
   <depend>autoware_osqp_interface</depend>

--- a/planning/autoware_path_optimizer/package.xml
+++ b/planning/autoware_path_optimizer/package.xml
@@ -15,6 +15,7 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_internal_debug_msgs</depend>
+  <depend>autoware_internal_debug_msgs</depend>
   <depend>autoware_interpolation</depend>
   <depend>autoware_motion_utils</depend>
   <depend>autoware_osqp_interface</depend>
@@ -28,7 +29,6 @@
   <depend>rclcpp_components</depend>
   <depend>std_msgs</depend>
   <depend>tf2_ros</depend>
-  <depend>tier4_debug_msgs</depend>
   <depend>tier4_planning_msgs</depend>
   <depend>visualization_msgs</depend>
 

--- a/planning/autoware_path_optimizer/scripts/calculation_time_plotter.py
+++ b/planning/autoware_path_optimizer/scripts/calculation_time_plotter.py
@@ -17,10 +17,10 @@
 import argparse
 from collections import deque
 
+from autoware_internal_debug_msgs.msg import StringStamped
 import matplotlib.pyplot as plt
 import rclpy
 from rclpy.node import Node
-from tier4_debug_msgs.msg import StringStamped
 
 
 class CalculationCostAnalyzer(Node):


### PR DESCRIPTION
…es planning/autoware_path_optimizer

## Description

The tier4_debug_msgs have been replaced with autoware_internal_debug_msgs to enhance clarity and consistency in the codebase.


## Related links

https://github.com/autowarefoundation/autoware/issues/5580


**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
