### PR TITLE
fix(behavior_velocity_planner_common): fix unregister process

### DIFF
--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/include/autoware/behavior_velocity_planner_common/scene_module_interface.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/include/autoware/behavior_velocity_planner_common/scene_module_interface.hpp
@@ -228,6 +228,7 @@ protected:
     auto itr = scene_modules_.begin();
     while (itr != scene_modules_.end()) {
       if (isModuleExpired(*itr)) {
+        registered_module_id_set_.erase((*itr)->getModuleId());
         itr = scene_modules_.erase(itr);
       } else {
         itr++;


### PR DESCRIPTION
## Description
This PR fix unregister process problem of behavior_velocity_plannner modules which introduced by https://github.com/autowarefoundation/autoware.universe/pull/9212

By the above PR, The variable `registered_module_id_set_` for RTC-independent modules was not being cleared.
This PR fix this issue.

## Related links


## How was this PR tested?
psim and tier4 scenario tests

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.
