### PR TITLE
feat: tier4_debug_msgs changed to autoware_internal_debug_msgs in files

### DIFF
--- a/sensing/autoware_gnss_poser/README.md
+++ b/sensing/autoware_gnss_poser/README.md
@@ -23,11 +23,11 @@ If the transformation from `base_link` to the antenna cannot be obtained, it out
 
 ### Output
 
-| Name                     | Type                                            | Description                                                    |
-| ------------------------ | ----------------------------------------------- | -------------------------------------------------------------- |
-| `~/output/pose`          | `geometry_msgs::msg::PoseStamped`               | vehicle pose calculated from gnss sensing data                 |
-| `~/output/gnss_pose_cov` | `geometry_msgs::msg::PoseWithCovarianceStamped` | vehicle pose with covariance calculated from gnss sensing data |
-| `~/output/gnss_fixed`    | `tier4_debug_msgs::msg::BoolStamped`            | gnss fix status                                                |
+| Name                     | Type                                             | Description                                                    |
+| ------------------------ | ------------------------------------------------ | -------------------------------------------------------------- |
+| `~/output/pose`          | `geometry_msgs::msg::PoseStamped`                | vehicle pose calculated from gnss sensing data                 |
+| `~/output/gnss_pose_cov` | `geometry_msgs::msg::PoseWithCovarianceStamped`  | vehicle pose with covariance calculated from gnss sensing data |
+| `~/output/gnss_fixed`    | `autoware_internal_debug_msgs::msg::BoolStamped` | gnss fix status                                                |
 
 ## Parameters
 

--- a/sensing/autoware_gnss_poser/include/autoware/gnss_poser/gnss_poser_node.hpp
+++ b/sensing/autoware_gnss_poser/include/autoware/gnss_poser/gnss_poser_node.hpp
@@ -18,11 +18,11 @@
 #include <autoware/component_interface_utils/rclcpp.hpp>
 #include <rclcpp/rclcpp.hpp>
 
+#include <autoware_internal_debug_msgs/msg/bool_stamped.hpp>
 #include <autoware_sensing_msgs/msg/gnss_ins_orientation_stamped.hpp>
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <geometry_msgs/msg/pose_with_covariance_stamped.hpp>
 #include <sensor_msgs/msg/nav_sat_fix.hpp>
-#include <tier4_debug_msgs/msg/bool_stamped.hpp>
 
 #include <boost/circular_buffer.hpp>
 
@@ -87,7 +87,7 @@ private:
 
   rclcpp::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr pose_pub_;
   rclcpp::Publisher<geometry_msgs::msg::PoseWithCovarianceStamped>::SharedPtr pose_cov_pub_;
-  rclcpp::Publisher<tier4_debug_msgs::msg::BoolStamped>::SharedPtr fixed_pub_;
+  rclcpp::Publisher<autoware_internal_debug_msgs::msg::BoolStamped>::SharedPtr fixed_pub_;
 
   MapProjectorInfo::Message projector_info_;
   const std::string base_frame_;

--- a/sensing/autoware_gnss_poser/package.xml
+++ b/sensing/autoware_gnss_poser/package.xml
@@ -22,6 +22,7 @@
   <depend>autoware_component_interface_specs</depend>
   <depend>autoware_component_interface_utils</depend>
   <depend>autoware_geography_utils</depend>
+  <depend>autoware_internal_debug_msgs</depend>
   <depend>autoware_sensing_msgs</depend>
   <depend>geographic_msgs</depend>
   <depend>geographiclib</depend>
@@ -32,7 +33,6 @@
   <depend>tf2</depend>
   <depend>tf2_geometry_msgs</depend>
   <depend>tf2_ros</depend>
-  <depend>tier4_debug_msgs</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>

--- a/sensing/autoware_gnss_poser/src/gnss_poser_node.cpp
+++ b/sensing/autoware_gnss_poser/src/gnss_poser_node.cpp
@@ -61,7 +61,8 @@ GNSSPoser::GNSSPoser(const rclcpp::NodeOptions & node_options)
   pose_pub_ = create_publisher<geometry_msgs::msg::PoseStamped>("gnss_pose", rclcpp::QoS{1});
   pose_cov_pub_ = create_publisher<geometry_msgs::msg::PoseWithCovarianceStamped>(
     "gnss_pose_cov", rclcpp::QoS{1});
-  fixed_pub_ = create_publisher<tier4_debug_msgs::msg::BoolStamped>("gnss_fixed", rclcpp::QoS{1});
+  fixed_pub_ =
+    create_publisher<autoware_internal_debug_msgs::msg::BoolStamped>("gnss_fixed", rclcpp::QoS{1});
 
   // Set msg_gnss_ins_orientation_stamped_ with temporary values (not to publish zero value
   // covariances)
@@ -99,7 +100,7 @@ void GNSSPoser::callback_nav_sat_fix(
   const bool is_status_fixed = is_fixed(nav_sat_fix_msg_ptr->status);
 
   // publish is_fixed topic
-  tier4_debug_msgs::msg::BoolStamped is_fixed_msg;
+  autoware_internal_debug_msgs::msg::BoolStamped is_fixed_msg;
   is_fixed_msg.stamp = this->now();
   is_fixed_msg.data = is_status_fixed;
   fixed_pub_->publish(is_fixed_msg);


### PR DESCRIPTION
sensing/autoware_gnss_poser

## Description
The tier4_debug_msgs have been replaced with autoware_internal_debug_msgs to enhance clarity and consistency in the codebase.

## Related links


https://github.com/autowarefoundation/autoware/issues/5580

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
