### PR TITLE
feat(autoware_image_diagnostics): tier4_debug_msgs changed to autoware_internal_debug_msgs in autoware_image_diagnostics

### DIFF
--- a/sensing/autoware_image_diagnostics/README.md
+++ b/sensing/autoware_image_diagnostics/README.md
@@ -28,13 +28,13 @@ After all image's blocks state are evaluated, the whole image status is summariz
 
 ### Output
 
-| Name                                | Type                                    | Description                           |
-| ----------------------------------- | --------------------------------------- | ------------------------------------- |
-| `image_diag/debug/gray_image`       | `sensor_msgs::msg::Image`               | gray image                            |
-| `image_diag/debug/dft_image`        | `sensor_msgs::msg::Image`               | discrete Fourier transformation image |
-| `image_diag/debug/diag_block_image` | `sensor_msgs::msg::Image`               | each block state colorization         |
-| `image_diag/image_state_diag`       | `tier4_debug_msgs::msg::Int32Stamped`   | image diagnostics status value        |
-| `/diagnostics`                      | `diagnostic_msgs::msg::DiagnosticArray` | diagnostics                           |
+| Name                                | Type                                              | Description                           |
+| ----------------------------------- | ------------------------------------------------- | ------------------------------------- |
+| `image_diag/debug/gray_image`       | `sensor_msgs::msg::Image`                         | gray image                            |
+| `image_diag/debug/dft_image`        | `sensor_msgs::msg::Image`                         | discrete Fourier transformation image |
+| `image_diag/debug/diag_block_image` | `sensor_msgs::msg::Image`                         | each block state colorization         |
+| `image_diag/image_state_diag`       | `autoware_internal_debug_msgs::msg::Int32Stamped` | image diagnostics status value        |
+| `/diagnostics`                      | `diagnostic_msgs::msg::DiagnosticArray`           | diagnostics                           |
 
 ## Parameters
 

--- a/sensing/autoware_image_diagnostics/package.xml
+++ b/sensing/autoware_image_diagnostics/package.xml
@@ -12,6 +12,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
+  <depend>autoware_internal_debug_msgs</depend>
   <depend>autoware_universe_utils</depend>
   <depend>cv_bridge</depend>
   <depend>diagnostic_updater</depend>
@@ -19,7 +20,6 @@
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>sensor_msgs</depend>
-  <depend>tier4_debug_msgs</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>

--- a/sensing/autoware_image_diagnostics/src/image_diagnostics_node.cpp
+++ b/sensing/autoware_image_diagnostics/src/image_diagnostics_node.cpp
@@ -33,7 +33,7 @@ ImageDiagNode::ImageDiagNode(const rclcpp::NodeOptions & node_options)
   dft_image_pub_ = image_transport::create_publisher(this, "image_diag/debug/dft_image");
   gray_image_pub_ = image_transport::create_publisher(this, "image_diag/debug/gray_image");
 
-  image_state_pub_ = create_publisher<tier4_debug_msgs::msg::Int32Stamped>(
+  image_state_pub_ = create_publisher<autoware_internal_debug_msgs::msg::Int32Stamped>(
     "image_diag/image_state_diag", rclcpp::SensorDataQoS());
 
   updater_.setHardwareID("Image_Diagnostics");
@@ -225,7 +225,7 @@ void ImageDiagNode::ImageChecker(const sensor_msgs::msg::Image::ConstSharedPtr i
   } else {
     params_.diagnostic_status = 0;
   }
-  tier4_debug_msgs::msg::Int32Stamped image_state_out;
+  autoware_internal_debug_msgs::msg::Int32Stamped image_state_out;
   image_state_out.data = params_.diagnostic_status;
   image_state_pub_->publish(image_state_out);
 

--- a/sensing/autoware_image_diagnostics/src/image_diagnostics_node.hpp
+++ b/sensing/autoware_image_diagnostics/src/image_diagnostics_node.hpp
@@ -21,10 +21,10 @@
 #include <opencv2/imgproc/imgproc.hpp>
 #include <rclcpp/rclcpp.hpp>
 
+#include <autoware_internal_debug_msgs/msg/float32_multi_array_stamped.hpp>
+#include <autoware_internal_debug_msgs/msg/float32_stamped.hpp>
+#include <autoware_internal_debug_msgs/msg/int32_stamped.hpp>
 #include <sensor_msgs/msg/image.hpp>
-#include <tier4_debug_msgs/msg/float32_multi_array_stamped.hpp>
-#include <tier4_debug_msgs/msg/float32_stamped.hpp>
-#include <tier4_debug_msgs/msg/int32_stamped.hpp>
 
 #if __has_include(<cv_bridge/cv_bridge.hpp>)
 #include <cv_bridge/cv_bridge.hpp>
@@ -95,8 +95,9 @@ protected:
   image_transport::Publisher block_diag_image_pub_;
   image_transport::Publisher dft_image_pub_;
   image_transport::Publisher gray_image_pub_;
-  rclcpp::Publisher<tier4_debug_msgs::msg::Float32MultiArrayStamped>::SharedPtr average_pub_;
-  rclcpp::Publisher<tier4_debug_msgs::msg::Int32Stamped>::SharedPtr image_state_pub_;
+  rclcpp::Publisher<autoware_internal_debug_msgs::msg::Float32MultiArrayStamped>::SharedPtr
+    average_pub_;
+  rclcpp::Publisher<autoware_internal_debug_msgs::msg::Int32Stamped>::SharedPtr image_state_pub_;
 };
 
 }  // namespace autoware::image_diagnostics


### PR DESCRIPTION
…es sensing/autoware_image_diagnostics

## Description
The tier4_debug_msgs have been replaced with autoware_internal_debug_msgs to enhance clarity and consistency in the codebase.

## Related links

https://github.com/autowarefoundation/autoware/issues/5580

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
