### PR TITLE
fix(goal_planner): fix geometric pull over

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/pull_over_planner/geometric_pull_over.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/pull_over_planner/geometric_pull_over.cpp
@@ -28,6 +28,7 @@ namespace autoware::behavior_path_planner
 GeometricPullOver::GeometricPullOver(
   rclcpp::Node & node, const GoalPlannerParameters & parameters, const bool is_forward)
 : PullOverPlannerBase{node, parameters},
+  parallel_parking_parameters_{parameters.parallel_parking_parameters},
   lane_departure_checker_{
     lane_departure_checker::Param{parameters.lane_departure_check_expansion_margin}, vehicle_info_},
   is_forward_{is_forward},


### PR DESCRIPTION
## Description

geometric pull over was broken with https://github.com/autowarefoundation/autoware.universe/pull/9832

parameter setting is missing 

![image](https://github.com/user-attachments/assets/72614eee-a1a9-44e2-b79c-90810bf4e0c9)


## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

psim 
geometric pull over works

![image](https://github.com/user-attachments/assets/e80a9783-004d-4dfd-980c-57679a4acb5b)



2025/01/16 https://evaluation.tier4.jp/evaluation/reports/5cc00185-60bd-5c1b-a93f-9fecf555346a/?project_id=prd_jt


## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
