### PR TITLE
feat(dummy_diag_publisher): update param setting

### DIFF
--- a/system/dummy_diag_publisher/include/dummy_diag_publisher/dummy_diag_publisher_core.hpp
+++ b/system/dummy_diag_publisher/include/dummy_diag_publisher/dummy_diag_publisher_core.hpp
@@ -60,9 +60,12 @@ private:
   DummyDiagConfig config_;
 
   RequiredDiags required_diags_;
-  void loadRequiredDiags();
+  rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr param_callback_handle_;
 
-  std::optional<Status> convertStrToStatus(std::string & status_str);
+  void loadRequiredDiags();
+  rcl_interfaces::msg::SetParametersResult onSetParams(const std::vector<rclcpp::Parameter> & parameters);
+
+  std::optional<Status> convertStrToStatus(const std::string & status_str);
   std::string convertStatusToStr(const Status & status);
   diagnostic_msgs::msg::DiagnosticStatus::_level_type convertStatusToLevel(const Status & status);
 

--- a/system/dummy_diag_publisher/include/dummy_diag_publisher/dummy_diag_publisher_core.hpp
+++ b/system/dummy_diag_publisher/include/dummy_diag_publisher/dummy_diag_publisher_core.hpp
@@ -63,7 +63,8 @@ private:
   rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr param_callback_handle_;
 
   void loadRequiredDiags();
-  rcl_interfaces::msg::SetParametersResult onSetParams(const std::vector<rclcpp::Parameter> & parameters);
+  rcl_interfaces::msg::SetParametersResult onSetParams(
+    const std::vector<rclcpp::Parameter> & parameters);
 
   std::optional<Status> convertStrToStatus(const std::string & status_str);
   std::string convertStatusToStr(const Status & status);

--- a/system/dummy_diag_publisher/package.xml
+++ b/system/dummy_diag_publisher/package.xml
@@ -11,8 +11,7 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-  <depend>autoware_universe_utils</depend>
-  <depend>diagnostic_updater</depend>
+  <depend>diagnostic_msgs</depend>
   <depend>fmt</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>

--- a/system/dummy_diag_publisher/src/dummy_diag_publisher_core.cpp
+++ b/system/dummy_diag_publisher/src/dummy_diag_publisher_core.cpp
@@ -21,6 +21,8 @@
 
 #define FMT_HEADER_ONLY
 #include <fmt/format.h>
+#include <sstream>
+#include <unordered_map>
 
 namespace
 {
@@ -37,7 +39,7 @@ std::vector<std::string> split(const std::string & str, const char delim)
 }  // namespace
 
 std::optional<DummyDiagPublisher::Status> DummyDiagPublisher::convertStrToStatus(
-  std::string & status_str)
+  const std::string & status_str)
 {
   static std::unordered_map<std::string, Status> const table = {
     {"OK", Status::OK}, {"Warn", Status::WARN}, {"Error", Status::ERROR}, {"Stale", Status::STALE}};
@@ -144,6 +146,56 @@ rclcpp::NodeOptions override_options(rclcpp::NodeOptions options)
     true);
 }
 
+rcl_interfaces::msg::SetParametersResult 
+  DummyDiagPublisher::onSetParams(const std::vector<rclcpp::Parameter> & parameters)
+{
+  rcl_interfaces::msg::SetParametersResult result;
+  result.successful = true;
+
+  for (const auto & parameter : parameters) {
+    bool param_found = false;
+    const auto & param_name = parameter.get_name();
+
+    for (auto & diag : required_diags_) {
+      if (param_name == diag.name + std::string(".status")) {
+        param_found = true;
+        auto new_status = convertStrToStatus(parameter.as_string());
+        if (new_status) {
+          diag.status = *new_status;
+          RCLCPP_INFO(this->get_logger(), "Updated %s status to: %s",
+                      diag.name.c_str(), parameter.as_string().c_str());
+        } else {
+          result.successful = false;
+          result.reason = "Invalid status value for: " + parameter.as_string();
+          RCLCPP_WARN(this->get_logger(), "Invalid status value for %s: %s",
+                      diag.name.c_str(), parameter.as_string().c_str());
+        }
+      } else if (param_name == diag.name + std::string(".is_active")) {
+        param_found = true;
+        try {
+          diag.is_active = parameter.as_bool();
+          RCLCPP_INFO(this->get_logger(), "Updated %s is_active to: %s",
+            diag.name.c_str(), diag.is_active ? "true" : "false");
+        } catch (const rclcpp::ParameterTypeException & e) {
+          result.successful = false;
+          result.reason = "Invalid is_active value for: " + parameter.as_string();
+          RCLCPP_WARN(this->get_logger(), "Invalid is_active value for %s: %s",
+                      diag.name.c_str(), parameter.as_string().c_str());
+        }
+      }
+    }
+
+    if (!param_found) {
+      result.successful = false;
+      result.reason = "Parameter not registered: " + parameter.get_name();
+      RCLCPP_WARN(this->get_logger(), "Attempted to set unregistered parameter: %s",
+                  parameter.get_name().c_str());
+    }
+  }
+
+  return result;
+}
+
 DummyDiagPublisher::DummyDiagPublisher(const rclcpp::NodeOptions & options)
 : Node("dummy_diag_publisher", override_options(options))
 
@@ -164,6 +216,11 @@ DummyDiagPublisher::DummyDiagPublisher(const rclcpp::NodeOptions & options)
 
   // Publisher
   pub_ = create_publisher<diagnostic_msgs::msg::DiagnosticArray>("/diagnostics", rclcpp::QoS(1));
+
+  // Parameter Callback Handle
+  param_callback_handle_ = this->add_on_set_parameters_callback(
+    std::bind(&DummyDiagPublisher::onSetParams, this, std::placeholders::_1)
+  );
 }
 
 #include <rclcpp_components/register_node_macro.hpp>

--- a/system/dummy_diag_publisher/src/dummy_diag_publisher_core.cpp
+++ b/system/dummy_diag_publisher/src/dummy_diag_publisher_core.cpp
@@ -21,6 +21,7 @@
 
 #define FMT_HEADER_ONLY
 #include <fmt/format.h>
+
 #include <sstream>
 #include <unordered_map>
 
@@ -146,8 +147,8 @@ rclcpp::NodeOptions override_options(rclcpp::NodeOptions options)
     true);
 }
 
-rcl_interfaces::msg::SetParametersResult 
-  DummyDiagPublisher::onSetParams(const std::vector<rclcpp::Parameter> & parameters)
+rcl_interfaces::msg::SetParametersResult DummyDiagPublisher::onSetParams(
+  const std::vector<rclcpp::Parameter> & parameters)
 {
   rcl_interfaces::msg::SetParametersResult result;
   result.successful = true;
@@ -162,25 +163,29 @@ rcl_interfaces::msg::SetParametersResult
         auto new_status = convertStrToStatus(parameter.as_string());
         if (new_status) {
           diag.status = *new_status;
-          RCLCPP_INFO(this->get_logger(), "Updated %s status to: %s",
-                      diag.name.c_str(), parameter.as_string().c_str());
+          RCLCPP_INFO(
+            this->get_logger(), "Updated %s status to: %s", diag.name.c_str(),
+            parameter.as_string().c_str());
         } else {
           result.successful = false;
           result.reason = "Invalid status value for: " + parameter.as_string();
-          RCLCPP_WARN(this->get_logger(), "Invalid status value for %s: %s",
-                      diag.name.c_str(), parameter.as_string().c_str());
+          RCLCPP_WARN(
+            this->get_logger(), "Invalid status value for %s: %s", diag.name.c_str(),
+            parameter.as_string().c_str());
         }
       } else if (param_name == diag.name + std::string(".is_active")) {
         param_found = true;
         try {
           diag.is_active = parameter.as_bool();
-          RCLCPP_INFO(this->get_logger(), "Updated %s is_active to: %s",
-            diag.name.c_str(), diag.is_active ? "true" : "false");
+          RCLCPP_INFO(
+            this->get_logger(), "Updated %s is_active to: %s", diag.name.c_str(),
+            diag.is_active ? "true" : "false");
         } catch (const rclcpp::ParameterTypeException & e) {
           result.successful = false;
           result.reason = "Invalid is_active value for: " + parameter.as_string();
-          RCLCPP_WARN(this->get_logger(), "Invalid is_active value for %s: %s",
-                      diag.name.c_str(), parameter.as_string().c_str());
+          RCLCPP_WARN(
+            this->get_logger(), "Invalid is_active value for %s: %s", diag.name.c_str(),
+            parameter.as_string().c_str());
         }
       }
     }
@@ -188,8 +193,9 @@ rcl_interfaces::msg::SetParametersResult
     if (!param_found) {
       result.successful = false;
       result.reason = "Parameter not registered: " + parameter.get_name();
-      RCLCPP_WARN(this->get_logger(), "Attempted to set unregistered parameter: %s",
-                  parameter.get_name().c_str());
+      RCLCPP_WARN(
+        this->get_logger(), "Attempted to set unregistered parameter: %s",
+        parameter.get_name().c_str());
     }
   }
 
@@ -219,8 +225,7 @@ DummyDiagPublisher::DummyDiagPublisher(const rclcpp::NodeOptions & options)
 
   // Parameter Callback Handle
   param_callback_handle_ = this->add_on_set_parameters_callback(
-    std::bind(&DummyDiagPublisher::onSetParams, this, std::placeholders::_1)
-  );
+    std::bind(&DummyDiagPublisher::onSetParams, this, std::placeholders::_1));
 }
 
 #include <rclcpp_components/register_node_macro.hpp>

--- a/system/dummy_diag_publisher/src/dummy_diag_publisher_core.cpp
+++ b/system/dummy_diag_publisher/src/dummy_diag_publisher_core.cpp
@@ -23,7 +23,6 @@
 #include <fmt/format.h>
 
 #include <sstream>
-#include <unordered_map>
 
 namespace
 {


### PR DESCRIPTION
## Description
This PR adds param set function as described in the README and refactor slightly.

- add `param_callback_handle_` and `onSetParams`.
- delete unnecessary dependency packages.
- add `const`.

## Related links

**Private Links:**

- [TIRE IV internal link](https://star4.slack.com/archives/C0657FNJ5EG/p1734588501562049)

## How was this PR tested?

1. `$ ros2 launch dummy_diag_publisher dummy_diag_publisher.launch.xml `
2. `$ ros2 param set /dummy_diag_publisher dummy_diag_empty.is_active true` or `false`
3. `$ ros2 param set /dummy_diag_publisher dummy_diag_empty.status "Error"`, `Warn`, `OK`
4. confirm by `ros2 topic echo /diagnostics` or rqt_runtime_monitor

[Screencast from 2025年01月18日 11時49分20秒.webm](https://github.com/user-attachments/assets/f905ff0d-804a-49d1-a372-39a4bfe5e27f)

(in addition)

1. `$ ros2 launch autoware_launch planning_simulator.launch.xml map_path:=$HOME/autoware_map/sample-map-planning vehicle_model:=sample_vehicle sensor_model:=sample_sensor_kit`
2. `$ ros2 param set /dummy_diag_publisher "topic_state_monitor_pointcloud_map: map_topic_status".is_active true` or `false`
3. `$ ros2 param set /dummy_diag_publisher "topic_state_monitor_pointcloud_map: map_topic_status".status "Error"`, `Warn` or `OK`

Dummy "topic_state_monitor_pointcloud_map: map_topic_status" is defined in `autoware_launch/config/system/diagnostics/dummy_diag_publisher.param.yaml`.

> /**:
  ros__parameters:
    required_diags:
      # map
      ## /autoware/map/topic_rate_check/pointcloud_map
      "topic_state_monitor_pointcloud_map: map_topic_status": default

[Screencast from 2025年01月18日 14時13分53秒.webm](https://github.com/user-attachments/assets/89514121-dea0-42ec-9b62-6334695e4783)



## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.
