### PR TITLE
fix(map_based_prediction): fix unintentional accumulation of lanelets

### DIFF
--- a/perception/autoware_map_based_prediction/src/predictor_vru.cpp
+++ b/perception/autoware_map_based_prediction/src/predictor_vru.cpp
@@ -269,6 +269,7 @@ void PredictorVru::setLaneletMap(std::shared_ptr<lanelet::LaneletMap> lanelet_ma
   const auto all_lanelets = lanelet::utils::query::laneletLayer(lanelet_map_ptr_);
   const auto crosswalks = lanelet::utils::query::crosswalkLanelets(all_lanelets);
   const auto walkways = lanelet::utils::query::walkwayLanelets(all_lanelets);
+  crosswalks_.clear();
   crosswalks_.insert(crosswalks_.end(), crosswalks.begin(), crosswalks.end());
   crosswalks_.insert(crosswalks_.end(), walkways.begin(), walkways.end());
 


### PR DESCRIPTION
## Description
In `PredictorVru::setLaneletMap`, it will always accumulate the crosswalk or walkways lanelets when map gets updated.
It may work trouble-free with the current implementation in the current Autoware architecture, where the map is provided only once.
But in multiple map case (loading map like mapA -> mapB -> mapA -> ... for moving between 2 regions), it may potentially cause some extra latency since it will 
 linear scan the lanelets for each targeted objects: https://github.com/autowarefoundation/autoware_lanelet2_extension/blob/c8ff315d21fc2e62329a7272e3d49edfa88fc57e/autoware_lanelet2_extension/lib/query.cpp#L885


## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
Checked the logging simulator using the sample ROS bag.

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
