### PR TITLE
fix(imu_corrector): remove non-periodic publish to /diagnostics topic

### DIFF
--- a/sensing/autoware_imu_corrector/src/gyro_bias_estimator.cpp
+++ b/sensing/autoware_imu_corrector/src/gyro_bias_estimator.cpp
@@ -40,7 +40,6 @@ GyroBiasEstimator::GyroBiasEstimator(const rclcpp::NodeOptions & options)
 {
   updater_.setHardwareID(get_name());
   updater_.add("gyro_bias_validator", this, &GyroBiasEstimator::update_diagnostics);
-  // diagnostic_updater is designed to be updated at the same rate as the timer
   updater_.setPeriod(diagnostics_updater_interval_sec_);
 
   gyro_bias_estimation_module_ = std::make_unique<GyroBiasEstimationModule>();
@@ -182,8 +181,6 @@ void GyroBiasEstimator::timer_callback()
     transform_vector3(gyro_bias_estimation_module_->get_bias_base_link(), *tf_base2imu_ptr);
 
   validate_gyro_bias();
-  updater_.force_update();
-  updater_.setPeriod(diagnostics_updater_interval_sec_);  // to reset timer inside the updater
 }
 
 void GyroBiasEstimator::validate_gyro_bias()


### PR DESCRIPTION
## Description

### Background
Publishing rate to /diagnostics from gyro_bias_estimator is set by `diagnostics_updater_interval_sec` and `setPeriod()`
However when gyro bias is updated, gyro_bias_estimator publish with `force_update() `and `setPeriod()` is executed again.

### Changes
Removed `force_update() `and `setPeriod()` in gyro_bias_estimator timer callback.

## Related links

**Private Links:**

- [TIERIV INTERNAL LINK](https://tier4.atlassian.net/browse/RT2-2025)

## How was this PR tested?

/diagnostics contents and publishing rate was checked by following procedure.

```
# terminal 1
~/autoware$ ros2 run autoware_imu_corrector gyro_bias_estimator_node --ros-args -r /gyro_bias_validator/input/imu_raw:=/sensing/imu/tamagawa/imu_raw -r /gyro_bias_validator/input/odom:=/localization/kinematic_state --params-file sensing/autoware_imu_corrector/config/gyro_bias_estimator.param.yaml --params-file sensing/autoware_imu_corrector/config/imu_corrector.param.yaml  -p  timer_callback_interval_sec:=0.5 -p diagnostics_updater_interval_sec:=2.0

# terminal 2
~/autoware$ ros2 run tf2_ros static_transform_publisher --x 0 --y 0 --z 0 --qx 0 --qy 0 --qz 0 --qw 1 --frame-id base_link --child-frame-id top_front_left/imu_link

# terminal 3
~/autoware$ ros2 bag play ~/tmp/1a96ba52-5739-4d03-9bcf-4c4ee00e138f/cfa23601-97c4-4d47-a37e-edfc7e080d8c_2024-12-20-15-44-56_p0900_38.db3 --topics /sensing/imu/tamagawa/imu_raw /localization/kinematic_state /tf
```

**before change**
```
~$ ros2 topic hz /diagnostics
average rate: 0.500
	min: 2.000s max: 2.000s std dev: 0.00003s window: 2
average rate: 0.615
	min: 0.500s max: 2.000s std dev: 0.64964s window: 4
average rate: 0.588
	min: 0.500s max: 2.000s std dev: 0.60012s window: 5
average rate: 0.571
	min: 0.500s max: 2.000s std dev: 0.55913s window: 6
```

**after change**
```
~$ ros2 topic hz /diagnostics
average rate: 0.500
	min: 2.000s max: 2.000s std dev: 0.00001s window: 2
average rate: 0.500
	min: 2.000s max: 2.000s std dev: 0.00007s window: 3
average rate: 0.500
	min: 2.000s max: 2.000s std dev: 0.00007s window: 4
average rate: 0.500
	min: 2.000s max: 2.000s std dev: 0.00008s window: 5
average rate: 0.500
	min: 2.000s max: 2.000s std dev: 0.00008s window: 6

~$ ros2 topic echo /diagnostics
header:
  stamp:
    sec: 1737080573
    nanosec: 532117472
  frame_id: ''
status:
- level: "\x01"
  name: 'gyro_bias_validator: gyro_bias_validator'
  message: Gyro bias may be incorrect. Please calibrate IMU and reflect the result in imu_corrector. You may also use the output of gyro_bi...
  hardware_id: gyro_bias_validator
  values:
  - key: gyro_bias_x_for_imu_corrector
    value: '-0.00391047'
  - key: gyro_bias_y_for_imu_corrector
    value: '-0.00466050'
  - key: gyro_bias_z_for_imu_corrector
    value: '0.00142520'
  - key: estimated_gyro_bias_x
    value: '-0.00391047'
  - key: estimated_gyro_bias_y
    value: '-0.00466050'
  - key: estimated_gyro_bias_z
    value: '0.00142520'
  - key: gyro_bias_threshold
    value: '0.00300000'
---

```

## Notes for reviewers

The original implementation aimed to publish to /diagnostics immediately when the gyro bias was updated.
However, this behavior can be achieved by setting a shorter diagnostics_updater_interval_sec.

## Interface changes

None.

## Effects on system behavior

- publishing rate to /diagnostics from gyro_bias_estimator will now be fixed.
- creation of a timer callback by calling setPeriod() in the gyro_bias_estimator timer callback will be suppressed.
