### PR TITLE
feat(autoware_planning_test_manager): remove dependency of VirtualTrafficLightState and ExpandStopRange

### DIFF
--- a/planning/autoware_obstacle_stop_planner/test/test_autoware_obstacle_stop_planner_node_interface.cpp
+++ b/planning/autoware_obstacle_stop_planner/test/test_autoware_obstacle_stop_planner_node_interface.cpp
@@ -18,6 +18,8 @@
 #include <autoware_planning_test_manager/autoware_planning_test_manager.hpp>
 #include <autoware_test_utils/autoware_test_utils.hpp>
 
+#include <tier4_planning_msgs/msg/expand_stop_range.hpp>
+
 #include <gtest/gtest.h>
 
 #include <memory>
@@ -25,6 +27,7 @@
 
 using autoware::motion_planning::ObstacleStopPlannerNode;
 using autoware::planning_test_manager::PlanningInterfaceTestManager;
+using tier4_planning_msgs::msg::ExpandStopRange;
 
 std::shared_ptr<PlanningInterfaceTestManager> generateTestManager()
 {
@@ -66,8 +69,17 @@ void publishMandatoryTopics(
   test_manager->publishPointCloud(test_target_node, "obstacle_stop_planner/input/pointcloud");
   test_manager->publishAcceleration(test_target_node, "obstacle_stop_planner/input/acceleration");
   test_manager->publishPredictedObjects(test_target_node, "obstacle_stop_planner/input/objects");
-  test_manager->publishExpandStopRange(
-    test_target_node, "obstacle_stop_planner/input/expand_stop_range");
+}
+
+void publishExpandStopRange(
+  std::shared_ptr<PlanningInterfaceTestManager> test_manager,
+  std::shared_ptr<ObstacleStopPlannerNode> test_target_node)
+{
+  auto test_node = test_manager->getTestNode();
+  const auto expand_stop_range = test_manager->getTestNode()->create_publisher<ExpandStopRange>(
+    "obstacle_stop_planner/input/expand_stop_range", 1);
+  expand_stop_range->publish(ExpandStopRange{});
+  autoware::test_utils::spinSomeNodes(test_node, test_target_node, 3);
 }
 
 TEST(PlanningModuleInterfaceTest, NodeTestWithExceptionTrajectory)
@@ -78,6 +90,7 @@ TEST(PlanningModuleInterfaceTest, NodeTestWithExceptionTrajectory)
   auto test_target_node = generateNode();
 
   publishMandatoryTopics(test_manager, test_target_node);
+  publishExpandStopRange(test_manager, test_target_node);
 
   // test for normal trajectory
   ASSERT_NO_THROW_WITH_ERROR_MSG(test_manager->testWithNominalTrajectory(test_target_node));
@@ -97,6 +110,7 @@ TEST(PlanningModuleInterfaceTest, NodeTestWithOffTrackEgoPose)
   auto test_target_node = generateNode();
 
   publishMandatoryTopics(test_manager, test_target_node);
+  publishExpandStopRange(test_manager, test_target_node);
 
   // test for normal trajectory
   ASSERT_NO_THROW_WITH_ERROR_MSG(test_manager->testWithNominalTrajectory(test_target_node));

--- a/planning/autoware_planning_test_manager/include/autoware_planning_test_manager/autoware_planning_test_manager.hpp
+++ b/planning/autoware_planning_test_manager/include/autoware_planning_test_manager/autoware_planning_test_manager.hpp
@@ -52,14 +52,10 @@
 #include <sensor_msgs/msg/point_cloud2.hpp>
 #include <std_msgs/msg/bool.hpp>
 #include <tf2_msgs/msg/tf_message.hpp>
-#include <tier4_api_msgs/msg/crosswalk_status.hpp>
-#include <tier4_api_msgs/msg/intersection_status.hpp>
-#include <tier4_planning_msgs/msg/expand_stop_range.hpp>
 #include <tier4_planning_msgs/msg/lateral_offset.hpp>
 #include <tier4_planning_msgs/msg/path_with_lane_id.hpp>
 #include <tier4_planning_msgs/msg/scenario.hpp>
 #include <tier4_planning_msgs/msg/velocity_limit.hpp>
-#include <tier4_v2x_msgs/msg/virtual_traffic_light_state_array.hpp>
 
 #include <gtest/gtest.h>
 #include <tf2_ros/buffer.h>
@@ -87,14 +83,10 @@ using nav_msgs::msg::OccupancyGrid;
 using nav_msgs::msg::Odometry;
 using sensor_msgs::msg::PointCloud2;
 using tf2_msgs::msg::TFMessage;
-using tier4_api_msgs::msg::CrosswalkStatus;
-using tier4_api_msgs::msg::IntersectionStatus;
-using tier4_planning_msgs::msg::ExpandStopRange;
 using tier4_planning_msgs::msg::LateralOffset;
 using tier4_planning_msgs::msg::PathWithLaneId;
 using tier4_planning_msgs::msg::Scenario;
 using tier4_planning_msgs::msg::VelocityLimit;
-using tier4_v2x_msgs::msg::VirtualTrafficLightStateArray;
 
 enum class ModuleName {
   UNKNOWN = 0,
@@ -117,7 +109,6 @@ public:
   void publishPointCloud(rclcpp::Node::SharedPtr target_node, std::string topic_name);
   void publishAcceleration(rclcpp::Node::SharedPtr target_node, std::string topic_name);
   void publishPredictedObjects(rclcpp::Node::SharedPtr target_node, std::string topic_name);
-  void publishExpandStopRange(rclcpp::Node::SharedPtr target_node, std::string topic_name);
   void publishOccupancyGrid(rclcpp::Node::SharedPtr target_node, std::string topic_name);
   void publishCostMap(rclcpp::Node::SharedPtr target_node, std::string topic_name);
   void publishMap(rclcpp::Node::SharedPtr target_node, std::string topic_name);
@@ -131,7 +122,6 @@ public:
   void publishLateralOffset(rclcpp::Node::SharedPtr target_node, std::string topic_name);
   void publishOperationModeState(rclcpp::Node::SharedPtr target_node, std::string topic_name);
   void publishTrafficSignals(rclcpp::Node::SharedPtr target_node, std::string topic_name);
-  void publishVirtualTrafficLightState(rclcpp::Node::SharedPtr target_node, std::string topic_name);
 
   void setTrajectoryInputTopicName(std::string topic_name);
   void setParkingTrajectoryInputTopicName(std::string topic_name);
@@ -178,6 +168,7 @@ public:
   void testOffTrackFromTrajectory(rclcpp::Node::SharedPtr target_node);
 
   int getReceivedTopicNum();
+  rclcpp::Node::SharedPtr getTestNode() const;
 
 private:
   // Publisher (necessary for node running)
@@ -187,7 +178,6 @@ private:
   rclcpp::Publisher<PointCloud2>::SharedPtr point_cloud_pub_;
   rclcpp::Publisher<AccelWithCovarianceStamped>::SharedPtr acceleration_pub_;
   rclcpp::Publisher<PredictedObjects>::SharedPtr predicted_objects_pub_;
-  rclcpp::Publisher<ExpandStopRange>::SharedPtr expand_stop_range_pub_;
   rclcpp::Publisher<OccupancyGrid>::SharedPtr occupancy_grid_pub_;
   rclcpp::Publisher<OccupancyGrid>::SharedPtr cost_map_pub_;
   rclcpp::Publisher<LaneletMapBin>::SharedPtr map_pub_;
@@ -202,7 +192,6 @@ private:
   rclcpp::Publisher<LateralOffset>::SharedPtr lateral_offset_pub_;
   rclcpp::Publisher<OperationModeState>::SharedPtr operation_mode_state_pub_;
   rclcpp::Publisher<TrafficLightGroupArray>::SharedPtr traffic_signals_pub_;
-  rclcpp::Publisher<VirtualTrafficLightStateArray>::SharedPtr virtual_traffic_light_states_pub_;
 
   // Subscriber
   rclcpp::Subscription<Trajectory>::SharedPtr traj_sub_;

--- a/planning/autoware_planning_test_manager/package.xml
+++ b/planning/autoware_planning_test_manager/package.xml
@@ -31,7 +31,6 @@
   <depend>rclcpp</depend>
   <depend>tf2_msgs</depend>
   <depend>tf2_ros</depend>
-  <depend>tier4_api_msgs</depend>
   <depend>tier4_planning_msgs</depend>
   <depend>tier4_v2x_msgs</depend>
   <depend>unique_identifier_msgs</depend>

--- a/planning/autoware_planning_test_manager/src/autoware_planning_test_manager.cpp
+++ b/planning/autoware_planning_test_manager/src/autoware_planning_test_manager.cpp
@@ -71,13 +71,6 @@ void PlanningInterfaceTestManager::publishPredictedObjects(
     test_node_, target_node, topic_name, predicted_objects_pub_, PredictedObjects{});
 }
 
-void PlanningInterfaceTestManager::publishExpandStopRange(
-  rclcpp::Node::SharedPtr target_node, std::string topic_name)
-{
-  autoware::test_utils::publishToTargetNode(
-    test_node_, target_node, topic_name, expand_stop_range_pub_, ExpandStopRange{});
-}
-
 void PlanningInterfaceTestManager::publishOccupancyGrid(
   rclcpp::Node::SharedPtr target_node, std::string topic_name)
 {
@@ -179,14 +172,6 @@ void PlanningInterfaceTestManager::publishTrafficSignals(
 {
   autoware::test_utils::publishToTargetNode(
     test_node_, target_node, topic_name, traffic_signals_pub_, TrafficLightGroupArray{});
-}
-
-void PlanningInterfaceTestManager::publishVirtualTrafficLightState(
-  rclcpp::Node::SharedPtr target_node, std::string topic_name)
-{
-  autoware::test_utils::publishToTargetNode(
-    test_node_, target_node, topic_name, virtual_traffic_light_states_pub_,
-    VirtualTrafficLightStateArray{});
 }
 
 void PlanningInterfaceTestManager::publishInitialPoseTF(
@@ -469,6 +454,11 @@ void PlanningInterfaceTestManager::testWithAbnormalPath(rclcpp::Node::SharedPtr 
 int PlanningInterfaceTestManager::getReceivedTopicNum()
 {
   return count_;
+}
+
+rclcpp::Node::SharedPtr PlanningInterfaceTestManager::getTestNode() const
+{
+  return test_node_;
 }
 
 }  // namespace autoware::planning_test_manager

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_virtual_traffic_light_module/test/test_node_interface.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_virtual_traffic_light_module/test/test_node_interface.cpp
@@ -13,6 +13,9 @@
 // limitations under the License.
 
 #include <autoware/behavior_velocity_planner/test_utils.hpp>
+#include <autoware_test_utils/autoware_test_utils.hpp>
+
+#include <tier4_v2x_msgs/msg/virtual_traffic_light_state_array.hpp>
 
 #include <gtest/gtest.h>
 
@@ -23,6 +26,19 @@
 
 namespace autoware::behavior_velocity_planner
 {
+using tier4_v2x_msgs::msg::VirtualTrafficLightStateArray;
+
+void publishVirtualTrafficLightState(
+  std::shared_ptr<PlanningInterfaceTestManager> test_manager, rclcpp::Node::SharedPtr target_node)
+{
+  auto test_node = test_manager->getTestNode();
+  const auto pub_virtual_traffic_light =
+    test_manager->getTestNode()->create_publisher<VirtualTrafficLightStateArray>(
+      "behavior_velocity_planner_node/input/virtual_traffic_light_states", 1);
+  pub_virtual_traffic_light->publish(VirtualTrafficLightStateArray{});
+  autoware::test_utils::spinSomeNodes(test_node, target_node, 3);
+}
+
 TEST(PlanningModuleInterfaceTest, NodeTestWithExceptionPathWithLaneID)
 {
   rclcpp::init(0, nullptr);
@@ -35,8 +51,7 @@ TEST(PlanningModuleInterfaceTest, NodeTestWithExceptionPathWithLaneID)
   auto test_target_node = autoware::behavior_velocity_planner::generateNode(plugin_info_vec);
 
   autoware::behavior_velocity_planner::publishMandatoryTopics(test_manager, test_target_node);
-  test_manager->publishVirtualTrafficLightState(
-    test_target_node, "behavior_velocity_planner_node/input/virtual_traffic_light_states");
+  publishVirtualTrafficLightState(test_manager, test_target_node);
 
   // test with nominal path_with_lane_id
   ASSERT_NO_THROW_WITH_ERROR_MSG(test_manager->testWithNominalPathWithLaneId(test_target_node));
@@ -57,9 +72,9 @@ TEST(PlanningModuleInterfaceTest, NodeTestWithOffTrackEgoPose)
 
   auto test_manager = autoware::behavior_velocity_planner::generateTestManager();
   auto test_target_node = autoware::behavior_velocity_planner::generateNode(plugin_info_vec);
+
   autoware::behavior_velocity_planner::publishMandatoryTopics(test_manager, test_target_node);
-  test_manager->publishVirtualTrafficLightState(
-    test_target_node, "behavior_velocity_planner_node/input/virtual_traffic_light_states");
+  publishVirtualTrafficLightState(test_manager, test_target_node);
 
   // test for normal trajectory
   ASSERT_NO_THROW_WITH_ERROR_MSG(test_manager->testWithNominalPathWithLaneId(test_target_node));


### PR DESCRIPTION
## Description

VirtualTrafficLightState and ExpandStopRange are very specific message types for the planner package (behavior_velocity_virtual_traffic_light and obstacle_stop_planner respectively).

Currently, the autoware_planning_test_manager package, which is a common package,  depends on these specific messages, which is unexpected.
This PR removed the dependency by moving the code from the autoware_planning_test_manager package to the specific planner package.

## Related links

## How was this PR tested?

unit test passed.
## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
