### PR TITLE
feat(autoware_planning_test_manager): remove dependency of tier4_planning_msgs::msg::LateralOffset

### DIFF
--- a/common/autoware_test_utils/package.xml
+++ b/common/autoware_test_utils/package.xml
@@ -33,9 +33,7 @@
   <depend>std_srvs</depend>
   <depend>tf2_msgs</depend>
   <depend>tf2_ros</depend>
-  <depend>tier4_api_msgs</depend>
   <depend>tier4_planning_msgs</depend>
-  <depend>tier4_v2x_msgs</depend>
   <depend>unique_identifier_msgs</depend>
   <depend>yaml_cpp_vendor</depend>
 

--- a/planning/autoware_planning_test_manager/include/autoware_planning_test_manager/autoware_planning_test_manager.hpp
+++ b/planning/autoware_planning_test_manager/include/autoware_planning_test_manager/autoware_planning_test_manager.hpp
@@ -52,7 +52,6 @@
 #include <sensor_msgs/msg/point_cloud2.hpp>
 #include <std_msgs/msg/bool.hpp>
 #include <tf2_msgs/msg/tf_message.hpp>
-#include <tier4_planning_msgs/msg/lateral_offset.hpp>
 #include <tier4_planning_msgs/msg/path_with_lane_id.hpp>
 #include <tier4_planning_msgs/msg/scenario.hpp>
 #include <tier4_planning_msgs/msg/velocity_limit.hpp>
@@ -83,7 +82,6 @@ using nav_msgs::msg::OccupancyGrid;
 using nav_msgs::msg::Odometry;
 using sensor_msgs::msg::PointCloud2;
 using tf2_msgs::msg::TFMessage;
-using tier4_planning_msgs::msg::LateralOffset;
 using tier4_planning_msgs::msg::PathWithLaneId;
 using tier4_planning_msgs::msg::Scenario;
 using tier4_planning_msgs::msg::VelocityLimit;
@@ -119,7 +117,6 @@ public:
   void publishRoute(rclcpp::Node::SharedPtr target_node, std::string topic_name);
   void publishTF(rclcpp::Node::SharedPtr target_node, std::string topic_name);
   void publishInitialPoseTF(rclcpp::Node::SharedPtr target_node, std::string topic_name);
-  void publishLateralOffset(rclcpp::Node::SharedPtr target_node, std::string topic_name);
   void publishOperationModeState(rclcpp::Node::SharedPtr target_node, std::string topic_name);
   void publishTrafficSignals(rclcpp::Node::SharedPtr target_node, std::string topic_name);
 
@@ -189,7 +186,6 @@ private:
   rclcpp::Publisher<LaneletRoute>::SharedPtr route_pub_;
   rclcpp::Publisher<TFMessage>::SharedPtr TF_pub_;
   rclcpp::Publisher<TFMessage>::SharedPtr initial_pose_tf_pub_;
-  rclcpp::Publisher<LateralOffset>::SharedPtr lateral_offset_pub_;
   rclcpp::Publisher<OperationModeState>::SharedPtr operation_mode_state_pub_;
   rclcpp::Publisher<TrafficLightGroupArray>::SharedPtr traffic_signals_pub_;
 

--- a/planning/autoware_planning_test_manager/package.xml
+++ b/planning/autoware_planning_test_manager/package.xml
@@ -32,7 +32,6 @@
   <depend>tf2_msgs</depend>
   <depend>tf2_ros</depend>
   <depend>tier4_planning_msgs</depend>
-  <depend>tier4_v2x_msgs</depend>
   <depend>unique_identifier_msgs</depend>
   <depend>yaml_cpp_vendor</depend>
 

--- a/planning/autoware_planning_test_manager/src/autoware_planning_test_manager.cpp
+++ b/planning/autoware_planning_test_manager/src/autoware_planning_test_manager.cpp
@@ -153,13 +153,6 @@ void PlanningInterfaceTestManager::publishTF(
     autoware::test_utils::makeTFMsg(target_node, "base_link", "map"));
 }
 
-void PlanningInterfaceTestManager::publishLateralOffset(
-  rclcpp::Node::SharedPtr target_node, std::string topic_name)
-{
-  autoware::test_utils::publishToTargetNode(
-    test_node_, target_node, topic_name, lateral_offset_pub_, LateralOffset{});
-}
-
 void PlanningInterfaceTestManager::publishOperationModeState(
   rclcpp::Node::SharedPtr target_node, std::string topic_name)
 {

--- a/planning/behavior_path_planner/autoware_behavior_path_planner/src/test_utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner/src/test_utils.cpp
@@ -18,12 +18,32 @@
 #include <autoware_planning_test_manager/autoware_planning_test_manager.hpp>
 #include <autoware_test_utils/autoware_test_utils.hpp>
 
+#include <tier4_planning_msgs/msg/lateral_offset.hpp>
+
 #include <memory>
 #include <string>
 #include <vector>
 
 namespace autoware::behavior_path_planner
 {
+namespace
+{
+using tier4_planning_msgs::msg::LateralOffset;
+
+void publishLateralOffset(
+  std::shared_ptr<PlanningInterfaceTestManager> test_manager,
+  std::shared_ptr<BehaviorPathPlannerNode> test_target_node)
+{
+  auto test_node = test_manager->getTestNode();
+  const auto pub_lateral_offset = test_manager->getTestNode()->create_publisher<LateralOffset>(
+    "behavior_path_planner/input/lateral_offset", 1);
+  pub_lateral_offset->publish(LateralOffset{});
+  autoware::test_utils::spinSomeNodes(test_node, test_target_node, 3);
+  autoware::test_utils::publishToTargetNode(
+    test_node_, test_target_node, topic_name, lateral_offset_pub_, LateralOffset{});
+}
+}  // namespace
+
 std::shared_ptr<PlanningInterfaceTestManager> generateTestManager()
 {
   auto test_manager = std::make_shared<PlanningInterfaceTestManager>();
@@ -95,7 +115,6 @@ void publishMandatoryTopics(
   test_manager->publishMap(test_target_node, "behavior_path_planner/input/vector_map");
   test_manager->publishCostMap(test_target_node, "behavior_path_planner/input/costmap");
   test_manager->publishOperationModeState(test_target_node, "system/operation_mode/state");
-  test_manager->publishLateralOffset(
-    test_target_node, "behavior_path_planner/input/lateral_offset");
+  publishLateralOffset(test_manager, test_target_node);
 }
 }  // namespace autoware::behavior_path_planner

--- a/planning/behavior_path_planner/autoware_behavior_path_planner/src/test_utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner/src/test_utils.cpp
@@ -39,8 +39,6 @@ void publishLateralOffset(
     "behavior_path_planner/input/lateral_offset", 1);
   pub_lateral_offset->publish(LateralOffset{});
   autoware::test_utils::spinSomeNodes(test_node, test_target_node, 3);
-  autoware::test_utils::publishToTargetNode(
-    test_node_, test_target_node, topic_name, lateral_offset_pub_, LateralOffset{});
 }
 }  // namespace
 


### PR DESCRIPTION
## Description
depends on https://github.com/autowarefoundation/autoware.universe/pull/9963

LateralOffset is a very specific message type for the behavior_path_side_shift_module/behavior_path_planner packages.

Currently, the autoware_planning_test_manager package, which is a common package, depends on this specific message, which is unexpected.
This PR removed the dependency by moving the code from the autoware_planning_test_manager package to the specific planner package.
## Related links

## How was this PR tested?

Unit test passed.
## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
