### PR TITLE
feat(autoware_control_evaluator): add new steering metrics

### DIFF
--- a/evaluator/autoware_control_evaluator/include/autoware/control_evaluator/control_evaluator_node.hpp
+++ b/evaluator/autoware_control_evaluator/include/autoware/control_evaluator/control_evaluator_node.hpp
@@ -25,9 +25,11 @@
 #include <autoware_vehicle_info_utils/vehicle_info_utils.hpp>
 #include <rclcpp/rclcpp.hpp>
 
+#include "autoware_vehicle_msgs/msg/steering_report.hpp"
 #include "geometry_msgs/msg/accel_with_covariance_stamped.hpp"
 #include <autoware_internal_debug_msgs/msg/float64_stamped.hpp>
 #include <autoware_planning_msgs/msg/lanelet_route.hpp>
+#include <autoware_vehicle_msgs/msg/detail/steering_report__struct.hpp>
 #include <nav_msgs/msg/odometry.hpp>
 #include <tier4_metric_msgs/msg/metric.hpp>
 #include <tier4_metric_msgs/msg/metric_array.hpp>
@@ -45,6 +47,7 @@ using autoware::universe_utils::LineString2d;
 using autoware::universe_utils::Point2d;
 using autoware::vehicle_info_utils::VehicleInfo;
 using autoware_planning_msgs::msg::Trajectory;
+using autoware_vehicle_msgs::msg::SteeringReport;
 using geometry_msgs::msg::Point;
 using geometry_msgs::msg::Pose;
 using nav_msgs::msg::Odometry;
@@ -93,6 +96,8 @@ private:
     vector_map_subscriber_{this, "~/input/vector_map", rclcpp::QoS{1}.transient_local()};
   autoware::universe_utils::InterProcessPollingSubscriber<PathWithLaneId> behavior_path_subscriber_{
     this, "~/input/behavior_path"};
+  autoware::universe_utils::InterProcessPollingSubscriber<SteeringReport> steering_sub_{
+    this, "~/input/steering_report"};
 
   rclcpp::Publisher<autoware_internal_debug_msgs::msg::Float64Stamped>::SharedPtr
     processing_time_pub_;

--- a/evaluator/autoware_control_evaluator/include/autoware/control_evaluator/control_evaluator_node.hpp
+++ b/evaluator/autoware_control_evaluator/include/autoware/control_evaluator/control_evaluator_node.hpp
@@ -29,7 +29,6 @@
 #include "geometry_msgs/msg/accel_with_covariance_stamped.hpp"
 #include <autoware_internal_debug_msgs/msg/float64_stamped.hpp>
 #include <autoware_planning_msgs/msg/lanelet_route.hpp>
-#include <autoware_vehicle_msgs/msg/detail/steering_report__struct.hpp>
 #include <nav_msgs/msg/odometry.hpp>
 #include <tier4_metric_msgs/msg/metric.hpp>
 #include <tier4_metric_msgs/msg/metric_array.hpp>

--- a/evaluator/autoware_control_evaluator/include/autoware/control_evaluator/control_evaluator_node.hpp
+++ b/evaluator/autoware_control_evaluator/include/autoware/control_evaluator/control_evaluator_node.hpp
@@ -78,6 +78,7 @@ public:
   void AddLaneletInfoMsg(const Pose & ego_pose);
   void AddKinematicStateMetricMsg(
     const Odometry & odom, const AccelWithCovarianceStamped & accel_stamped);
+  void AddSteeringMetricMsg(const SteeringReport & steering_report);
 
   void onTimer();
 
@@ -97,7 +98,7 @@ private:
   autoware::universe_utils::InterProcessPollingSubscriber<PathWithLaneId> behavior_path_subscriber_{
     this, "~/input/behavior_path"};
   autoware::universe_utils::InterProcessPollingSubscriber<SteeringReport> steering_sub_{
-    this, "~/input/steering_report"};
+    this, "~/input/steering_status"};
 
   rclcpp::Publisher<autoware_internal_debug_msgs::msg::Float64Stamped>::SharedPtr
     processing_time_pub_;
@@ -112,8 +113,16 @@ private:
   // Metric
   const std::vector<Metric> metrics_ = {
     // collect all metrics
-    Metric::lateral_deviation,      Metric::yaw_deviation,      Metric::goal_longitudinal_deviation,
-    Metric::goal_lateral_deviation, Metric::goal_yaw_deviation,
+    Metric::lateral_deviation,
+    Metric::yaw_deviation,
+    Metric::goal_longitudinal_deviation,
+    Metric::goal_lateral_deviation,
+    Metric::goal_yaw_deviation,
+    Metric::left_boundary_distance,
+    Metric::right_boundary_distance,
+    Metric::steering_angle,
+    Metric::steering_rate,
+    Metric::steering_acceleration,
   };
 
   std::array<Accumulator<double>, static_cast<size_t>(Metric::SIZE)>
@@ -124,6 +133,9 @@ private:
   autoware::route_handler::RouteHandler route_handler_;
   rclcpp::TimerBase::SharedPtr timer_;
   std::optional<AccelWithCovarianceStamped> prev_acc_stamped_{std::nullopt};
+  std::optional<double> prev_steering_angle_{std::nullopt};
+  std::optional<double> prev_steering_rate_{std::nullopt};
+  std::optional<double> prev_steering_angle_timestamp_{std::nullopt};
 };
 }  // namespace control_diagnostics
 

--- a/evaluator/autoware_control_evaluator/include/autoware/control_evaluator/metrics/metric.hpp
+++ b/evaluator/autoware_control_evaluator/include/autoware/control_evaluator/metrics/metric.hpp
@@ -33,6 +33,9 @@ enum class Metric {
   goal_yaw_deviation,
   left_boundary_distance,
   right_boundary_distance,
+  steering_angle,
+  steering_rate,
+  steering_acceleration,
   SIZE,
 };
 
@@ -44,6 +47,9 @@ static const std::unordered_map<std::string, Metric> str_to_metric = {
   {"goal_yaw_deviation", Metric::goal_yaw_deviation},
   {"left_boundary_distance", Metric::left_boundary_distance},
   {"right_boundary_distance", Metric::right_boundary_distance},
+  {"steering_angle", Metric::steering_angle},
+  {"steering_rate", Metric::steering_rate},
+  {"steering_acceleration", Metric::steering_acceleration},
 };
 
 static const std::unordered_map<Metric, std::string> metric_to_str = {
@@ -54,6 +60,9 @@ static const std::unordered_map<Metric, std::string> metric_to_str = {
   {Metric::goal_yaw_deviation, "goal_yaw_deviation"},
   {Metric::left_boundary_distance, "left_boundary_distance"},
   {Metric::right_boundary_distance, "right_boundary_distance"},
+  {Metric::steering_angle, "steering_angle"},
+  {Metric::steering_rate, "steering_rate"},
+  {Metric::steering_acceleration, "steering_acceleration"},
 };
 
 // Metrics descriptions
@@ -65,6 +74,9 @@ static const std::unordered_map<Metric, std::string> metric_descriptions = {
   {Metric::goal_yaw_deviation, "Yaw deviation from the goal point[rad]"},
   {Metric::left_boundary_distance, "Signed distance to the left boundary[m]"},
   {Metric::right_boundary_distance, "Signed distance to the right boundary[m]"},
+  {Metric::steering_angle, "Steering angle[rad]"},
+  {Metric::steering_rate, "Steering angle rate[rad/s]"},
+  {Metric::steering_acceleration, "Steering angle acceleration[rad/s^2]"},
 };
 
 namespace details

--- a/evaluator/autoware_control_evaluator/include/autoware/control_evaluator/metrics/metrics_utils.hpp
+++ b/evaluator/autoware_control_evaluator/include/autoware/control_evaluator/metrics/metrics_utils.hpp
@@ -14,6 +14,7 @@
 
 #ifndef AUTOWARE__CONTROL_EVALUATOR__METRICS__METRICS_UTILS_HPP_
 #define AUTOWARE__CONTROL_EVALUATOR__METRICS__METRICS_UTILS_HPP_
+
 #include <autoware/route_handler/route_handler.hpp>
 #include <autoware/universe_utils/geometry/boost_geometry.hpp>
 

--- a/evaluator/autoware_control_evaluator/include/autoware/control_evaluator/metrics/metrics_utils.hpp
+++ b/evaluator/autoware_control_evaluator/include/autoware/control_evaluator/metrics/metrics_utils.hpp
@@ -14,7 +14,6 @@
 
 #ifndef AUTOWARE__CONTROL_EVALUATOR__METRICS__METRICS_UTILS_HPP_
 #define AUTOWARE__CONTROL_EVALUATOR__METRICS__METRICS_UTILS_HPP_
-
 #include <autoware/route_handler/route_handler.hpp>
 #include <autoware/universe_utils/geometry/boost_geometry.hpp>
 

--- a/evaluator/autoware_control_evaluator/launch/control_evaluator.launch.xml
+++ b/evaluator/autoware_control_evaluator/launch/control_evaluator.launch.xml
@@ -6,6 +6,7 @@
   <arg name="input/vector_map" default="/map/vector_map"/>
   <arg name="input/route" default="/planning/mission_planning/route"/>
   <arg name="input/behavior_path" default="/planning/scenario_planning/lane_driving/behavior_planning/path_with_lane_id"/>
+  <arg name="input/steering_status" default="/vehicle/status/steering_status"/>
 
   <!-- control evaluator -->
   <group>
@@ -17,6 +18,7 @@
       <remap from="~/input/vector_map" to="$(var input/vector_map)"/>
       <remap from="~/input/route" to="$(var input/route)"/>
       <remap from="~/input/behavior_path" to="$(var input/behavior_path)"/>
+      <remap from="~/input/steering_status" to="$(var input/steering_status)"/>
     </node>
   </group>
 </launch>

--- a/evaluator/autoware_control_evaluator/package.xml
+++ b/evaluator/autoware_control_evaluator/package.xml
@@ -22,6 +22,7 @@
   <depend>autoware_test_utils</depend>
   <depend>autoware_universe_utils</depend>
   <depend>autoware_vehicle_info_utils</depend>
+  <depend>autoware_vehicle_msgs</depend>
   <depend>nav_msgs</depend>
   <depend>nlohmann-json-dev</depend>
   <depend>pluginlib</depend>
@@ -29,7 +30,6 @@
   <depend>rclcpp_components</depend>
   <depend>tf2</depend>
   <depend>tf2_ros</depend>
-  <depend>autoware_vehicle_msgs</depend>
   <depend>tier4_metric_msgs</depend>
   <depend>tier4_planning_msgs</depend>
 

--- a/evaluator/autoware_control_evaluator/package.xml
+++ b/evaluator/autoware_control_evaluator/package.xml
@@ -29,6 +29,7 @@
   <depend>rclcpp_components</depend>
   <depend>tf2</depend>
   <depend>tf2_ros</depend>
+  <depend>autoware_vehicle_msgs</depend>
   <depend>tier4_metric_msgs</depend>
   <depend>tier4_planning_msgs</depend>
 

--- a/evaluator/autoware_control_evaluator/src/control_evaluator_node.cpp
+++ b/evaluator/autoware_control_evaluator/src/control_evaluator_node.cpp
@@ -294,6 +294,7 @@ void ControlEvaluatorNode::onTimer()
   const auto odom = odometry_sub_.takeData();
   const auto acc = accel_sub_.takeData();
   const auto behavior_path = behavior_path_subscriber_.takeData();
+  const auto steering_ = steering_sub_.takeData();
 
   // calculate deviation metrics
   if (odom && traj && !traj->points.empty()) {
@@ -319,7 +320,9 @@ void ControlEvaluatorNode::onTimer()
     const Pose ego_pose = odom->pose.pose;
     AddBoundaryDistanceMetricMsg(*behavior_path, ego_pose);
   }
-
+  if (steering_) {
+    //TODO think and add metric(steering_angle, the difference between the steering angle and the previous steering angle,etc)
+  }
   // Publish metrics
   metrics_msg_.stamp = now();
   metrics_pub_->publish(metrics_msg_);

--- a/evaluator/autoware_control_evaluator/src/control_evaluator_node.cpp
+++ b/evaluator/autoware_control_evaluator/src/control_evaluator_node.cpp
@@ -361,9 +361,11 @@ void ControlEvaluatorNode::onTimer()
     const Pose ego_pose = odom->pose.pose;
     AddBoundaryDistanceMetricMsg(*behavior_path, ego_pose);
   }
+
   if (steering_status) {
     AddSteeringMetricMsg(*steering_status);
   }
+
   // Publish metrics
   metrics_msg_.stamp = now();
   metrics_pub_->publish(metrics_msg_);

--- a/evaluator/autoware_control_evaluator/src/control_evaluator_node.cpp
+++ b/evaluator/autoware_control_evaluator/src/control_evaluator_node.cpp
@@ -244,6 +244,47 @@ void ControlEvaluatorNode::AddKinematicStateMetricMsg(
   return;
 }
 
+void ControlEvaluatorNode::AddSteeringMetricMsg(const SteeringReport & steering_status)
+{
+  // steering angle
+  double cur_steering_angle = steering_status.steering_tire_angle;
+  const double cur_t = static_cast<double>(steering_status.stamp.sec) +
+                       static_cast<double>(steering_status.stamp.nanosec) * 1e-9;
+  AddMetricMsg(Metric::steering_angle, cur_steering_angle);
+
+  if (!prev_steering_angle_timestamp_.has_value()) {
+    prev_steering_angle_timestamp_ = cur_t;
+    prev_steering_angle_ = cur_steering_angle;
+    return;
+  }
+
+  // d_t
+  const double dt = cur_t - prev_steering_angle_timestamp_.value();
+  if (dt < std::numeric_limits<double>::epsilon()) {
+    prev_steering_angle_timestamp_ = cur_t;
+    prev_steering_angle_ = cur_steering_angle;
+    return;
+  }
+
+  // steering rate
+  const double steering_rate = (cur_steering_angle - prev_steering_angle_.value()) / dt;
+  AddMetricMsg(Metric::steering_rate, steering_rate);
+
+  // steering acceleration
+  if (!prev_steering_rate_.has_value()) {
+    prev_steering_angle_timestamp_ = cur_t;
+    prev_steering_angle_ = cur_steering_angle;
+    prev_steering_rate_ = steering_rate;
+    return;
+  }
+  const double steering_acceleration = (steering_rate - prev_steering_rate_.value()) / dt;
+  AddMetricMsg(Metric::steering_acceleration, steering_acceleration);
+
+  prev_steering_angle_timestamp_ = cur_t;
+  prev_steering_angle_ = cur_steering_angle;
+  prev_steering_rate_ = steering_rate;
+}
+
 void ControlEvaluatorNode::AddLateralDeviationMetricMsg(
   const Trajectory & traj, const Point & ego_point)
 {
@@ -294,7 +335,7 @@ void ControlEvaluatorNode::onTimer()
   const auto odom = odometry_sub_.takeData();
   const auto acc = accel_sub_.takeData();
   const auto behavior_path = behavior_path_subscriber_.takeData();
-  const auto steering_ = steering_sub_.takeData();
+  const auto steering_status = steering_sub_.takeData();
 
   // calculate deviation metrics
   if (odom && traj && !traj->points.empty()) {
@@ -320,8 +361,8 @@ void ControlEvaluatorNode::onTimer()
     const Pose ego_pose = odom->pose.pose;
     AddBoundaryDistanceMetricMsg(*behavior_path, ego_pose);
   }
-  if (steering_) {
-    //TODO think and add metric(steering_angle, the difference between the steering angle and the previous steering angle,etc)
+  if (steering_status) {
+    AddSteeringMetricMsg(*steering_status);
   }
   // Publish metrics
   metrics_msg_.stamp = now();


### PR DESCRIPTION
## Description

- Add the metrics `steering_angle`, `steering_rate`, and `steering_acceleration`, which take info from `/vehicle/status/steering_status` as inputs.

```
  {Metric::steering_angle, "Steering angle[rad]"},
  {Metric::steering_rate, "Steering angle rate[rad/s]"},
  {Metric::steering_acceleration, "Steering angle acceleration[rad/s^2]"},
```



- By the new metrics, I observed that steering_acc is very unstable, possibly due to a potential problem with the controller not limiting it.

  - Here is a sample in Psim with statistics. [Uploading Screencast from 2025年01月22日 17時58分10秒.webm…]()

  - statistic results:

```json
{
    "goal_lateral_deviation/count": 4066,
    "goal_lateral_deviation/description": "Lateral deviation from the goal point[m]",
    "goal_lateral_deviation/max": 71.57552209610769,
    "goal_lateral_deviation/mean": 15.095354424273763,
    "goal_lateral_deviation/min": 0.04761014831880145,
    "goal_longitudinal_deviation/count": 4066,
    "goal_longitudinal_deviation/description": "Longitudinal deviation from the goal point[m]",
    "goal_longitudinal_deviation/max": 48.50298174670098,
    "goal_longitudinal_deviation/mean": 18.26058945189047,
    "goal_longitudinal_deviation/min": 0.0016048344136227848,
    "goal_yaw_deviation/count": 4066,
    "goal_yaw_deviation/description": "Yaw deviation from the goal point[rad]",
    "goal_yaw_deviation/max": 3.141439739072309,
    "goal_yaw_deviation/mean": 2.4573721775827067,
    "goal_yaw_deviation/min": 0.0009959786905762158,
    "lateral_deviation/count": 4037,
    "lateral_deviation/description": "Lateral deviation from the reference trajectory[m]",
    "lateral_deviation/max": 62.31623568037038,
    "lateral_deviation/mean": 0.26841448901392845,
    "lateral_deviation/min": 0.0001059528469253869,
    "left_boundary_distance/count": 4056,
    "left_boundary_distance/description": "Signed distance to the left boundary[m]",
    "left_boundary_distance/max": 29.61347099254557,
    "left_boundary_distance/mean": 1.2783057452624818,
    "left_boundary_distance/min": 0.0,
    "right_boundary_distance/count": 4056,
    "right_boundary_distance/description": "Signed distance to the right boundary[m]",
    "right_boundary_distance/max": 22.981874429434978,
    "right_boundary_distance/mean": 0.8003025301497705,
    "right_boundary_distance/min": -29.284892633860427,
    "steering_acceleration/count": 4267,
    "steering_acceleration/description": "Steering angle acceleration[rad/s^2]",
    "steering_acceleration/max": 10.53799197727243,
    "steering_acceleration/mean": -8.209054902784187e-05,
    "steering_acceleration/min": -11.719676851856809,
    "steering_angle/count": 4269,
    "steering_angle/description": "Steering angle[rad]",
    "steering_angle/max": 0.36725354194641113,
    "steering_angle/mean": -0.05339321038275664,
    "steering_angle/min": -0.6454648971557617,
    "steering_rate/count": 4268,
    "steering_rate/description": "Steering angle rate[rad/s]",
    "steering_rate/max": 1.1997751153093383,
    "steering_rate/mean": -0.0005450697894108572,
    "steering_rate/min": -0.8812904845608622,
    "yaw_deviation/count": 4037,
    "yaw_deviation/description": "Yaw deviation from the reference trajectory[rad]",
    "yaw_deviation/max": 3.125470616101369,
    "yaw_deviation/mean": 0.18996137215721864,
    "yaw_deviation/min": 8.843401220204328e-07
}
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
Psim:
[Screencast from 2025年01月23日 17時06分58秒.webm](https://github.com/user-attachments/assets/01ec80a8-1158-4245-9a19-1f7f6f598cb0)

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
