### PR TITLE
fix(tier4_simulator_launch): fix a wrong package name: `fault_injection` => `autoware_fault_injection` 

### DIFF
--- a/launch/tier4_simulator_launch/launch/simulator.launch.xml
+++ b/launch/tier4_simulator_launch/launch/simulator.launch.xml
@@ -40,7 +40,7 @@
 
   <group if="$(var launch_simulator_perception_modules)">
     <group if="$(var scenario_simulation)">
-      <include file="$(find-pkg-share fault_injection)/launch/fault_injection.launch.xml">
+      <include file="$(find-pkg-share autoware_fault_injection)/launch/fault_injection.launch.xml">
         <arg name="config_file" value="$(var fault_injection_param_path)"/>
       </include>
     </group>


### PR DESCRIPTION
## Description

Fixes a wrong package name bug.

## How was this PR tested?

Now the test is ongoing on the evaluator as [this](https://evaluation.tier4.jp/evaluation/reports/0deef618-22c5-51ec-9492-f23f17aa19dd?project_id=prd_jt).