### PR TITLE
fix(path_optimizer): fix possible zero division

### DIFF
--- a/planning/autoware_path_optimizer/src/utils/geometry_utils.cpp
+++ b/planning/autoware_path_optimizer/src/utils/geometry_utils.cpp
@@ -51,7 +51,7 @@ geometry_msgs::msg::Point getStartPoint(
 {
   const size_t segment_idx = autoware::motion_utils::findNearestSegmentIndex(bound, point);
   const auto & curr_seg_point = bound.at(segment_idx);
-  const auto & next_seg_point = bound.at(segment_idx);
+  const auto & next_seg_point = bound.at(segment_idx + 1);
   const Eigen::Vector2d first_to_target{point.x - curr_seg_point.x, point.y - curr_seg_point.y};
   const Eigen::Vector2d first_to_second{
     next_seg_point.x - curr_seg_point.x, next_seg_point.y - curr_seg_point.y};


### PR DESCRIPTION
## Description

Below code can cause zero division because the vector is zero.

https://github.com/autowarefoundation/autoware.universe/blob/fc763acd1f1cdcda1358976a963da5f367e61bb6/planning/autoware_path_optimizer/src/utils/geometry_utils.cpp#L53-L54

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

- https://evaluation.tier4.jp/evaluation/reports/cf85a61a-237c-578c-b86f-87bf1e884e2b?project_id=prd_jt&state=failed

All fail cases are from simulator

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
