### PR TITLE
refactor(goal_planner): remove use_object_recognition because it is default

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/config/goal_planner.param.yaml
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/config/goal_planner.param.yaml
@@ -39,7 +39,6 @@
 
       # object recognition
       object_recognition:
-        use_object_recognition: true
         collision_check_soft_margins: [5.0, 4.5, 4.0, 3.5, 3.0, 2.5, 2.0, 1.5, 1.0]  # the maximum margin when ego and objects are oriented.
         collision_check_hard_margins: [0.6]  # this should be larger than `surround_check_distance` of surround_obstacle_checker
         object_recognition_collision_check_max_extra_stopping_margin: 1.0

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/goal_planner_parameters.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/goal_planner_parameters.hpp
@@ -77,7 +77,6 @@ struct GoalPlannerParameters
   int obstacle_threshold{0};
 
   // object recognition
-  bool use_object_recognition{false};
   std::vector<double> object_recognition_collision_check_soft_margins{};
   std::vector<double> object_recognition_collision_check_hard_margins{};
   double object_recognition_collision_check_max_extra_stopping_margin{0.0};

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/decision_state.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/decision_state.cpp
@@ -175,16 +175,13 @@ PathDecisionState PathDecisionStateController::get_next_state(
 
   // if object recognition for path collision check is enabled, transition to DECIDING to check
   // collision for a certain period of time. Otherwise, transition to DECIDED directly.
-  if (parameters.use_object_recognition) {
-    RCLCPP_DEBUG(
-      logger_,
-      "[DecidingPathStatus]: NOT_DECIDED->DECIDING. start checking collision for certain "
-      "period of time");
-    next_state.state = PathDecisionState::DecisionKind::DECIDING;
-    next_state.deciding_start_time = now;
-    return next_state;
-  }
-  return {PathDecisionState::DecisionKind::DECIDED, std::nullopt};
+  RCLCPP_DEBUG(
+    logger_,
+    "[DecidingPathStatus]: NOT_DECIDED->DECIDING. start checking collision for certain "
+    "period of time");
+  next_state.state = PathDecisionState::DecisionKind::DECIDING;
+  next_state.deciding_start_time = now;
+  return next_state;
 }
 
 }  // namespace autoware::behavior_path_planner

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/goal_planner_module.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/goal_planner_module.cpp
@@ -637,9 +637,6 @@ void FreespaceParkingPlanner::onTimer()
 
 std::pair<LaneParkingResponse, FreespaceParkingResponse> GoalPlannerModule::syncWithThreads()
 {
-  assert(goal_candidates_);
-  const auto & goal_candidates = goal_candidates_.value();
-
   // In PlannerManager::run(), it calls SceneModuleInterface::setData and
   // SceneModuleInterface::setPreviousModuleOutput before module_ptr->run().
   // Then module_ptr->run() invokes GoalPlannerModule::updateData and then
@@ -659,7 +656,7 @@ std::pair<LaneParkingResponse, FreespaceParkingResponse> GoalPlannerModule::sync
     std::lock_guard<std::mutex> guard(lane_parking_mutex_);
     if (!lane_parking_request_) {
       lane_parking_request_.emplace(
-        vehicle_footprint_, goal_candidates, getPreviousModuleOutput(), use_bus_stop_area_);
+        vehicle_footprint_, goal_candidates_, getPreviousModuleOutput(), use_bus_stop_area_);
     }
     // NOTE: for the above reasons, PlannerManager/behavior_path_planner_node ensure that
     // planner_data_ is not nullptr, so it is OK to copy as value
@@ -690,7 +687,7 @@ std::pair<LaneParkingResponse, FreespaceParkingResponse> GoalPlannerModule::sync
     std::lock_guard<std::mutex> guard(freespace_parking_mutex_);
     if (!freespace_parking_request_) {
       freespace_parking_request_.emplace(
-        parameters_, vehicle_footprint_, goal_candidates, *planner_data_);
+        parameters_, vehicle_footprint_, goal_candidates_, *planner_data_);
     }
     constexpr double stuck_time = 5.0;
     freespace_parking_request_.value().update(
@@ -732,7 +729,6 @@ void GoalPlannerModule::updateData()
         });
     goal_candidates_ = generateGoalCandidates(goal_searcher_.value(), use_bus_stop_area_);
   }
-  auto & goal_candidates_mut = goal_candidates_.value();
 
   const lanelet::ConstLanelets current_lanes =
     utils::getCurrentLanesFromPath(getPreviousModuleOutput().reference_path, planner_data_);
@@ -1031,7 +1027,7 @@ BehaviorModuleOutput GoalPlannerModule::plan()
   universe_utils::ScopedTimeTrack st(__func__, *time_keeper_);
 
   if (utils::isAllowedGoalModification(planner_data_->route_handler)) {
-    if (!context_data_ || !goal_candidates_) {
+    if (!context_data_) {
       RCLCPP_WARN_THROTTLE(
         getLogger(), *clock_, 5000, " [pull_over] plan() is called without valid context_data");
     } else {
@@ -1225,9 +1221,6 @@ std::optional<PullOverPath> GoalPlannerModule::selectPullOverPath(
 {
   universe_utils::ScopedTimeTrack st(__func__, *time_keeper_);
 
-  assert(goal_candidates_);
-  const auto & goal_candidates = goal_candidates_.value();
-
   const auto & goal_pose = planner_data_->route_handler->getOriginalGoalPose();
   const double backward_length =
     parameters_.backward_goal_search_length + parameters_.decide_path_distance;
@@ -1331,16 +1324,13 @@ void GoalPlannerModule::setOutput(
 {
   universe_utils::ScopedTimeTrack st(__func__, *time_keeper_);
 
-  assert(!goal_candidates_);
-  const auto & goal_candidates = goal_candidates_.value();
-
   output.reference_path = getPreviousModuleOutput().reference_path;
 
   if (!selected_pull_over_path_with_velocity_opt) {
     // situation : not safe against static objects use stop_path
     // TODO(soblin): goal_candidates_.empty() is impossible
     output.path = generateStopPath(
-      context_data, (goal_candidates.empty() ? "no goal candidate" : "no static safe path"));
+      context_data, (goal_candidates_.empty() ? "no goal candidate" : "no static safe path"));
     RCLCPP_INFO_THROTTLE(
       getLogger(), *clock_, 5000, "Not found safe pull_over path, generate stop path");
     setDrivableAreaInfo(context_data, output);
@@ -1464,14 +1454,11 @@ BehaviorModuleOutput GoalPlannerModule::planPullOver(PullOverContextData & conte
 {
   universe_utils::ScopedTimeTrack st(__func__, *time_keeper_);
 
-  assert(goal_candidates_);
-  const auto & goal_candidates = goal_candidates_.value();
-
   const auto current_state = path_decision_controller_.get_current_state();
   if (current_state.state != PathDecisionState::DecisionKind::DECIDED) {
     const bool is_stable_safe = current_state.is_stable_safe;
     const std::string detail =
-      goal_candidates.empty()                                                ? "no goal candidate"
+      goal_candidates_.empty()                                               ? "no goal candidate"
       : context_data.lane_parking_response.pull_over_path_candidates.empty() ? "no path candidate"
       : !context_data.pull_over_path_opt                                     ? "no static safe path"
       : !is_stable_safe ? "unsafe against dynamic objects"
@@ -1663,7 +1650,7 @@ BehaviorModuleOutput GoalPlannerModule::planWaitingApproval()
   universe_utils::ScopedTimeTrack st(__func__, *time_keeper_);
 
   if (utils::isAllowedGoalModification(planner_data_->route_handler)) {
-    if (!context_data_ || !goal_candidates_) {
+    if (!context_data_) {
       RCLCPP_WARN_THROTTLE(
         getLogger(), *clock_, 5000,
         " [pull_over] planWaitingApproval() is called without valid context_data. use fixed goal "
@@ -2092,12 +2079,9 @@ void GoalPlannerModule::deceleratePath(PullOverPath & pull_over_path) const
 {
   universe_utils::ScopedTimeTrack st(__func__, *time_keeper_);
 
-  assert(goal_candidates_);
-  const auto & goal_candidates = goal_candidates_.value();
-
   // decelerate before the search area start
   const auto closest_goal_candidate =
-    goal_searcher_->getClosetGoalCandidateAlongLanes(goal_candidates, planner_data_);
+    goal_searcher_->getClosetGoalCandidateAlongLanes(goal_candidates_, planner_data_);
   const auto decel_pose = calcLongitudinalOffsetPose(
     pull_over_path.full_path().points, closest_goal_candidate.goal_pose.position,
     -approximate_pull_over_distance_);
@@ -2448,9 +2432,6 @@ void GoalPlannerModule::setDebugData(const PullOverContextData & context_data)
 {
   universe_utils::ScopedTimeTrack st(__func__, *time_keeper_);
 
-  assert(goal_candidates_);
-  const auto & goal_candidates = goal_candidates_.value();
-
   debug_marker_.markers.clear();
 
   using autoware::motion_utils::createStopVirtualWallMarker;
@@ -2484,7 +2465,7 @@ void GoalPlannerModule::setDebugData(const PullOverContextData & context_data)
       goal_searcher_->getAreaPolygons(), header, color, z));
 
     // Visualize goal candidates
-    add(goal_planner_utils::createGoalCandidatesMarkerArray(goal_candidates, color));
+    add(goal_planner_utils::createGoalCandidatesMarkerArray(goal_candidates_, color));
 
     // Visualize objects extraction polygon
     auto marker = autoware::universe_utils::createDefaultMarker(

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/goal_searcher.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/goal_searcher.cpp
@@ -444,12 +444,10 @@ bool GoalSearcher::checkCollision(
     }
   }
 
-  if (parameters_.use_object_recognition) {
-    if (utils::checkCollisionBetweenFootprintAndObjects(
-          vehicle_footprint_, pose, objects,
-          parameters_.object_recognition_collision_check_hard_margins.back())) {
-      return true;
-    }
+  if (utils::checkCollisionBetweenFootprintAndObjects(
+        vehicle_footprint_, pose, objects,
+        parameters_.object_recognition_collision_check_hard_margins.back())) {
+    return true;
   }
   return false;
 }

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/manager.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/manager.cpp
@@ -106,7 +106,6 @@ GoalPlannerParameters GoalPlannerModuleManager::initGoalPlannerParameters(
   // object recognition
   {
     const std::string ns = base_ns + "object_recognition.";
-    p.use_object_recognition = node->declare_parameter<bool>(ns + "use_object_recognition");
     p.object_recognition_collision_check_soft_margins =
       node->declare_parameter<std::vector<double>>(ns + "collision_check_soft_margins");
     p.object_recognition_collision_check_hard_margins =
@@ -513,7 +512,6 @@ void GoalPlannerModuleManager::updateModuleParams(
   {
     const std::string ns = base_ns + "object_recognition.";
 
-    updateParam<bool>(parameters, ns + "use_object_recognition", p->use_object_recognition);
     updateParam(
       parameters, ns + "object_recognition_collision_check_max_extra_stopping_margin",
       p->object_recognition_collision_check_max_extra_stopping_margin);


### PR DESCRIPTION
## Description

depends: https://github.com/autowarefoundation/autoware.universe/pull/10049

launcher PR: https://github.com/autowarefoundation/autoware_launch/pull/1318

## Related links

https://tier4.atlassian.net/browse/RT1-6895

## How was this PR tested?

- https://evaluation.tier4.jp/evaluation/reports/8e03bb7d-df42-5616-927c-cd4b52faaffa?project_id=prd_jt&state=failed
- 
## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
