### PR TITLE
refactor(goal_planner): remove enable_safety_check because it is default

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/README.md
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/README.md
@@ -384,7 +384,6 @@ In addition, the safety check has a time hysteresis, and if the path is judged "
 
 | Name                                 | Unit  | Type   | Description                                                                                              | Default value                |
 | :----------------------------------- | :---- | :----- | :------------------------------------------------------------------------------------------------------- | :--------------------------- |
-| enable_safety_check                  | [-]   | bool   | flag whether to use safety check                                                                         | true                         |
 | method                               | [-]   | string | method for safety check. `RSS` or `integral_predicted_polygon`                                           | `integral_predicted_polygon` |
 | keep_unsafe_time                     | [s]   | double | safety check Hysteresis time. if the path is judged "safe" for the time it is finally treated as "safe". | 3.0                          |
 | check_all_predicted_path             | -     | bool   | Flag to check all predicted paths                                                                        | true                         |

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/goal_planner_module.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/goal_planner_module.cpp
@@ -79,11 +79,6 @@ GoalPlannerModule::GoalPlannerModule(
   is_lane_parking_cb_running_{false},
   is_freespace_parking_cb_running_{false}
 {
-  // TODO(soblin): remove safety_check_params.enable_safety_check because it does not make sense
-  if (!parameters_.safety_check_params.enable_safety_check) {
-    throw std::domain_error("goal_planner never works without safety check");
-  }
-
   occupancy_grid_map_ = std::make_shared<OccupancyGridBasedCollisionDetector>();
 
   // planner when goal modification is not allowed

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/manager.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/manager.cpp
@@ -368,6 +368,10 @@ GoalPlannerParameters GoalPlannerModuleManager::initGoalPlannerParameters(
   {
     p.safety_check_params.enable_safety_check =
       node->declare_parameter<bool>(safety_check_ns + "enable_safety_check");
+    // NOTE(soblin): remove safety_check_params.enable_safety_check because it does not make sense
+    if (!p.safety_check_params.enable_safety_check) {
+      throw std::domain_error("goal_planner never works without safety check");
+    }
     p.safety_check_params.keep_unsafe_time =
       node->declare_parameter<double>(safety_check_ns + "keep_unsafe_time");
     p.safety_check_params.method = node->declare_parameter<std::string>(safety_check_ns + "method");
@@ -786,9 +790,6 @@ void GoalPlannerModuleManager::updateModuleParams(
   // SafetyCheckParams
   const std::string safety_check_ns = path_safety_check_ns + "safety_check_params.";
   {
-    updateParam<bool>(
-      parameters, safety_check_ns + "enable_safety_check",
-      p->safety_check_params.enable_safety_check);
     updateParam<double>(
       parameters, safety_check_ns + "keep_unsafe_time", p->safety_check_params.keep_unsafe_time);
     updateParam<std::string>(parameters, safety_check_ns + "method", p->safety_check_params.method);


### PR DESCRIPTION
## Description

goal_planner never works without PredictedObject, so enable_safety_check is treated as true.

depends https://github.com/autowarefoundation/autoware.universe/pull/10050

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

Psim works

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
