### PR TITLE
feat(start_planner): output object_of_interest 

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/start_planner_module.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/start_planner_module.cpp
@@ -744,7 +744,8 @@ BehaviorModuleOutput StartPlannerModule::plan()
     updateRTCStatus(start_distance, finish_distance);
     planning_factor_interface_->add(
       start_distance, finish_distance, status_.pull_out_path.start_pose,
-      status_.pull_out_path.end_pose, planning_factor_direction, SafetyFactorArray{});
+      status_.pull_out_path.end_pose, planning_factor_direction,
+      utils::path_safety_checker::to_safety_factor_array(debug_data_.collision_check));
     setDebugData();
     return output;
   }
@@ -754,7 +755,8 @@ BehaviorModuleOutput StartPlannerModule::plan()
   updateRTCStatus(0.0, distance);
   planning_factor_interface_->add(
     0.0, distance, status_.pull_out_path.start_pose, status_.pull_out_path.end_pose,
-    planning_factor_direction, SafetyFactorArray{});
+    planning_factor_direction,
+    utils::path_safety_checker::to_safety_factor_array(debug_data_.collision_check));
 
   setDebugData();
 
@@ -849,7 +851,8 @@ BehaviorModuleOutput StartPlannerModule::planWaitingApproval()
     updateRTCStatus(start_distance, finish_distance);
     planning_factor_interface_->add(
       start_distance, finish_distance, status_.pull_out_path.start_pose,
-      status_.pull_out_path.end_pose, planning_factor_direction, SafetyFactorArray{});
+      status_.pull_out_path.end_pose, planning_factor_direction,
+      utils::path_safety_checker::to_safety_factor_array(debug_data_.collision_check));
     setDebugData();
 
     return output;
@@ -860,7 +863,8 @@ BehaviorModuleOutput StartPlannerModule::planWaitingApproval()
   updateRTCStatus(0.0, distance);
   planning_factor_interface_->add(
     0.0, distance, status_.pull_out_path.start_pose, status_.pull_out_path.end_pose,
-    planning_factor_direction, SafetyFactorArray{});
+    planning_factor_direction,
+    utils::path_safety_checker::to_safety_factor_array(debug_data_.collision_check));
 
   setDebugData();
 


### PR DESCRIPTION
## Description

Output safety factor with object_of_interest information for start_planner module output.  
This information can be visualized by PlaningFactorRvizPlugin which was merged in https://github.com/autowarefoundation/autoware.universe/pull/9999.

![Screenshot from 2025-01-30 17-29-12](https://github.com/user-attachments/assets/e61117db-c600-4cd3-a6fe-06c8c9551064)


## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

run psim and confimred markers are visualized for objects that act as stopping factors.

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
