### PR TITLE
feat(goal_planner): resample path interval for lane departure check accuracy

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/pull_over_planner/geometric_pull_over.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/pull_over_planner/geometric_pull_over.cpp
@@ -16,6 +16,7 @@
 
 #include "autoware/behavior_path_goal_planner_module/util.hpp"
 #include "autoware/behavior_path_planner_common/utils/drivable_area_expansion/static_drivable_area.hpp"
+#include "autoware/behavior_path_planner_common/utils/path_utils.hpp"
 
 #include <autoware_lanelet2_extension/utility/query.hpp>
 #include <autoware_lanelet2_extension/utility/utilities.hpp>
@@ -77,6 +78,10 @@ std::optional<PullOverPath> GeometricPullOver::plan(
   const auto arc_path = planner_.getArcPath();
 
   // check lane departure with road and shoulder lanes
+  // To improve the accuracy of lane departure detection, make the sampling interval finer
+  // todo: Implement lane departure detection that does not depend on the footprint
+  const auto resampled_arc_path =
+    utils::resamplePathWithSpline(arc_path, parameters_.center_line_path_interval / 2);
   if (lane_departure_checker_.checkPathWillLeaveLane({departure_check_lane}, arc_path)) return {};
 
   auto pull_over_path_opt = PullOverPath::create(

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/pull_over_planner/shift_pull_over.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/pull_over_planner/shift_pull_over.cpp
@@ -299,8 +299,12 @@ std::optional<PullOverPath> ShiftPullOver::generatePullOverPath(
 
   const auto departure_check_lane = goal_planner_utils::createDepartureCheckLanelet(
     pull_over_lanes, *planner_data->route_handler, left_side_parking_);
-  const bool is_in_lanes = !lane_departure_checker_.checkPathWillLeaveLane(
-    {departure_check_lane}, pull_over_path.parking_path());
+  // To improve the accuracy of lane departure detection, make the sampling interval finer
+  // todo: Implement lane departure detection that does not depend on the footprint
+  const auto resampled_parking_path = utils::resamplePathWithSpline(
+    pull_over_path.parking_path(), parameters_.center_line_path_interval / 2);
+  const bool is_in_lanes =
+    !lane_departure_checker_.checkPathWillLeaveLane({departure_check_lane}, resampled_parking_path);
 
   if (!is_in_parking_lots && !is_in_lanes) {
     return {};


### PR DESCRIPTION
## Description

currently the parking path point interval  for lane departure check is `center_line_path_interval: 1.0`
depending on resampled points sometimes departure can not be detected especialy cureve lane.


(footrpint in this image is not the exact path used for lane departure check. this is behavior path output.)

![image](https://github.com/user-attachments/assets/2062a92c-5617-43ae-9edf-b9f03401a46a)


this is just workaround but in this PR, resample path interval for lane departure check accuracy.

todo: Implement lane departure detection that does not depend on the footprint

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

psim

2025/02/03 https://evaluation.tier4.jp/evaluation/reports/71aaf71c-79ae-5e67-a543-cef7922ab219/?project_id=prd_jt
2025/02/03 https://evaluation.tier4.jp/evaluation/reports/df5389ba-1355-5c2a-a221-bc9f9dfed558/?project_id=prd_jt

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
