### PR TITLE
fix(motion_velocity_planner_common): fix the calc_possible_min_dist_from_obj_to_traj_poly calculation

### DIFF
--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_common_universe/package.xml
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_common_universe/package.xml
@@ -7,6 +7,8 @@
 
   <maintainer email="maxime.clement@tier4.jp">Maxime Clement</maintainer>
   <maintainer email="alqudah.mohammad@tier4.jp">Alqudah Mohammad</maintainer>
+  <maintainer email="takayuki.murooka@tier4.jp">Takayuki Murooka</maintainer>
+  <maintainer email="yuki.takagi@tier4.jp">Yuki Takagi</maintainer>
 
   <license>Apache License 2.0</license>
 

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_common_universe/src/utils.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_common_universe/src/utils.cpp
@@ -169,7 +169,7 @@ double calc_possible_min_dist_from_obj_to_traj_poly(
   const double object_possible_max_dist =
     calc_object_possible_max_dist_from_center(object->predicted_object.shape);
   const double possible_min_dist_to_traj_poly =
-    std::abs(object->get_dist_to_traj_lateral(traj_points)) - vehicle_info.vehicle_width_m -
+    std::abs(object->get_dist_to_traj_lateral(traj_points)) - vehicle_info.vehicle_width_m / 2.0 -
     object_possible_max_dist;
   return possible_min_dist_to_traj_poly;
 }


### PR DESCRIPTION
## Description

The calculation of calc_possible_min_dist_from_obj_to_traj_poly was wrong, and this PR fixed the issue.

## Related links

## How was this PR tested?

planning simulator & scenario tests
## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
