### PR TITLE
feat(autoware_probabilistic_occupancy_grid_map): improved data handling on the ogm

### DIFF
--- a/perception/autoware_probabilistic_occupancy_grid_map/include/autoware/probabilistic_occupancy_grid_map/costmap_2d/occupancy_grid_map_base.hpp
+++ b/perception/autoware_probabilistic_occupancy_grid_map/include/autoware/probabilistic_occupancy_grid_map/costmap_2d/occupancy_grid_map_base.hpp
@@ -102,6 +102,8 @@ public:
 
   bool isCudaEnabled() const;
 
+  void setCudaStream(const cudaStream_t & stream);
+
   const autoware::cuda_utils::CudaUniquePtr<std::uint8_t[]> & getDeviceCostmap() const;
 
   void copyDeviceCostmapToHost() const;

--- a/perception/autoware_probabilistic_occupancy_grid_map/include/autoware/probabilistic_occupancy_grid_map/utils/cuda_pointcloud.hpp
+++ b/perception/autoware_probabilistic_occupancy_grid_map/include/autoware/probabilistic_occupancy_grid_map/utils/cuda_pointcloud.hpp
@@ -24,31 +24,37 @@
 class CudaPointCloud2 : public sensor_msgs::msg::PointCloud2
 {
 public:
-  void fromROSMsgAsync(const sensor_msgs::msg::PointCloud2 & msg)
+  void fromROSMsgAsync(const sensor_msgs::msg::PointCloud2::ConstSharedPtr & msg_ptr)
   {
     // cSpell: ignore knzo25
     // NOTE(knzo25): replace this with the cuda blackboard later
-    header = msg.header;
-    fields = msg.fields;
-    height = msg.height;
-    width = msg.width;
-    is_bigendian = msg.is_bigendian;
-    point_step = msg.point_step;
-    row_step = msg.row_step;
-    is_dense = msg.is_dense;
+    cudaStreamSynchronize(stream);
+    internal_msg_ = msg_ptr;
 
-    if (!data || capacity_ < msg.data.size()) {
-      capacity_ = 1024 * (msg.data.size() / 1024 + 1);
+    header = msg_ptr->header;
+    fields = msg_ptr->fields;
+    height = msg_ptr->height;
+    width = msg_ptr->width;
+    is_bigendian = msg_ptr->is_bigendian;
+    point_step = msg_ptr->point_step;
+    row_step = msg_ptr->row_step;
+    is_dense = msg_ptr->is_dense;
+
+    if (!data || capacity_ < msg_ptr->data.size()) {
+      const int factor = 4096 * point_step;
+      capacity_ = factor * (msg_ptr->data.size() / factor + 1);
       data = autoware::cuda_utils::make_unique<std::uint8_t[]>(capacity_);
     }
 
-    cudaMemcpyAsync(data.get(), msg.data.data(), msg.data.size(), cudaMemcpyHostToDevice, stream);
+    cudaMemcpyAsync(
+      data.get(), msg_ptr->data.data(), msg_ptr->data.size(), cudaMemcpyHostToDevice, stream);
   }
 
   autoware::cuda_utils::CudaUniquePtr<std::uint8_t[]> data;
   cudaStream_t stream;
 
 private:
+  sensor_msgs::msg::PointCloud2::ConstSharedPtr internal_msg_;
   std::size_t capacity_{0};
 };
 

--- a/perception/autoware_probabilistic_occupancy_grid_map/lib/costmap_2d/occupancy_grid_map_fixed.cpp
+++ b/perception/autoware_probabilistic_occupancy_grid_map/lib/costmap_2d/occupancy_grid_map_fixed.cpp
@@ -125,14 +125,12 @@ void OccupancyGridMapFixedBlindSpot::updateWithPointCloud(
   const std::size_t num_raw_points = raw_pointcloud.width * raw_pointcloud.height;
   float range_resolution_inv = 1.0 / map_res;
 
-  cudaStreamSynchronize(stream_);
-
   map_fixed::prepareTensorLaunch(
     reinterpret_cast<const float *>(raw_pointcloud.data.get()), num_raw_points,
     raw_pointcloud.point_step / sizeof(float), angle_bin_size, range_bin_size, min_height_,
     max_height_, min_angle_, angle_increment_inv_, range_resolution_inv, device_rotation_map_.get(),
     device_translation_map_.get(), device_rotation_scan_.get(), device_translation_scan_.get(),
-    raw_points_tensor_.get(), raw_pointcloud.stream);
+    raw_points_tensor_.get(), stream_);
 
   const std::size_t num_obstacle_points = obstacle_pointcloud.width * obstacle_pointcloud.height;
 
@@ -141,27 +139,23 @@ void OccupancyGridMapFixedBlindSpot::updateWithPointCloud(
     obstacle_pointcloud.point_step / sizeof(float), angle_bin_size, range_bin_size, min_height_,
     max_height_, min_angle_, angle_increment_inv_, range_resolution_inv, device_rotation_map_.get(),
     device_translation_map_.get(), device_rotation_scan_.get(), device_translation_scan_.get(),
-    obstacle_points_tensor_.get(), obstacle_pointcloud.stream);
+    obstacle_points_tensor_.get(), stream_);
 
   map_fixed::fillEmptySpaceLaunch(
     raw_points_tensor_.get(), angle_bin_size, range_bin_size, range_resolution_inv,
     scan_origin.position.x, scan_origin.position.y, origin_x_, origin_y_, num_cells_x, num_cells_y,
-    cost_value::FREE_SPACE, device_costmap_.get(), raw_pointcloud.stream);
-
-  cudaStreamSynchronize(obstacle_pointcloud.stream);
+    cost_value::FREE_SPACE, device_costmap_.get(), stream_);
 
   map_fixed::fillUnknownSpaceLaunch(
     raw_points_tensor_.get(), obstacle_points_tensor_.get(), distance_margin_, angle_bin_size,
     range_bin_size, range_resolution_inv, scan_origin.position.x, scan_origin.position.y, origin_x_,
     origin_y_, num_cells_x, num_cells_y, cost_value::FREE_SPACE, cost_value::NO_INFORMATION,
-    device_costmap_.get(), raw_pointcloud.stream);
+    device_costmap_.get(), stream_);
 
   map_fixed::fillObstaclesLaunch(
     obstacle_points_tensor_.get(), distance_margin_, angle_bin_size, range_bin_size,
     range_resolution_inv, origin_x_, origin_y_, num_cells_x, num_cells_y,
-    cost_value::LETHAL_OBSTACLE, device_costmap_.get(), raw_pointcloud.stream);
-
-  cudaStreamSynchronize(raw_pointcloud.stream);
+    cost_value::LETHAL_OBSTACLE, device_costmap_.get(), stream_);
 }
 
 void OccupancyGridMapFixedBlindSpot::initRosParam(rclcpp::Node & node)

--- a/perception/autoware_probabilistic_occupancy_grid_map/lib/updater/binary_bayes_filter_updater.cpp
+++ b/perception/autoware_probabilistic_occupancy_grid_map/lib/updater/binary_bayes_filter_updater.cpp
@@ -56,9 +56,9 @@ void OccupancyGridMapBBFUpdater::initRosParam(rclcpp::Node & node)
     }
   }
 
-  cudaMemcpy(
+  cudaMemcpyAsync(
     device_probability_matrix_.get(), probability_matrix_vector.data(),
-    sizeof(float) * Index::NUM_STATES * Index::NUM_STATES, cudaMemcpyHostToDevice);
+    sizeof(float) * Index::NUM_STATES * Index::NUM_STATES, cudaMemcpyHostToDevice, stream_);
 }
 
 inline unsigned char OccupancyGridMapBBFUpdater::applyBBF(
@@ -103,12 +103,6 @@ bool OccupancyGridMapBBFUpdater::update(
       Index::NUM_STATES, Index::FREE, Index::OCCUPIED, cost_value::FREE_SPACE,
       cost_value::LETHAL_OBSTACLE, cost_value::NO_INFORMATION, v_ratio_,
       getSizeInCellsX() * getSizeInCellsY(), device_costmap_.get(), stream_);
-
-    cudaMemcpy(
-      costmap_, device_costmap_.get(), getSizeInCellsX() * getSizeInCellsY() * sizeof(std::uint8_t),
-      cudaMemcpyDeviceToHost);
-
-    cudaStreamSynchronize(stream_);
   } else {
     for (unsigned int x = 0; x < getSizeInCellsX(); x++) {
       for (unsigned int y = 0; y < getSizeInCellsY(); y++) {

--- a/perception/autoware_probabilistic_occupancy_grid_map/lib/updater/log_odds_bayes_filter_updater.cpp
+++ b/perception/autoware_probabilistic_occupancy_grid_map/lib/updater/log_odds_bayes_filter_updater.cpp
@@ -73,12 +73,6 @@ bool OccupancyGridMapLOBFUpdater::update(
     applyLOBFLaunch(
       single_frame_occupancy_grid_map.getDeviceCostmap().get(), cost_value::NO_INFORMATION,
       getSizeInCellsX() * getSizeInCellsY(), device_costmap_.get(), stream_);
-
-    cudaMemcpy(
-      costmap_, device_costmap_.get(), getSizeInCellsX() * getSizeInCellsY() * sizeof(std::uint8_t),
-      cudaMemcpyDeviceToHost);
-
-    cudaStreamSynchronize(stream_);
   } else {
     for (unsigned int x = 0; x < getSizeInCellsX(); x++) {
       for (unsigned int y = 0; y < getSizeInCellsY(); y++) {


### PR DESCRIPTION

## Description


Through a better use of the data and streams, this PR decreases the processing time from 8ms to 4ms when using the full concatenated pointcloud
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
