### PR TITLE
feat(autoware_behavior_velocity_traffic_light_module): adjust velocity threshold for ensure stop at yellow light

### DIFF
--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/README.md
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/README.md
@@ -29,9 +29,9 @@ This module is activated when there is traffic light in ego lane.
 
 3. When vehicle current velocity is
 
-   - higher than 2.0m/s ⇒ pass judge(using next slide formula)
+   - higher than `yellow_light_stop_velocity` m/s ⇒ pass judge(using next slide formula)
 
-   - lower than 2.0m/s ⇒ stop
+   - lower than `yellow_light_stop_velocity` m/s ⇒ stop
 
 4. When it to be judged that vehicle can’t stop before stop line, autoware chooses one of the following behaviors
 
@@ -69,13 +69,14 @@ This module is activated when there is traffic light in ego lane.
 
 #### Module Parameters
 
-| Parameter              | Type   | Description                                                          |
-| ---------------------- | ------ | -------------------------------------------------------------------- |
-| `stop_margin`          | double | [m] margin before stop point                                         |
-| `tl_state_timeout`     | double | [s] time out for detected traffic light result.                      |
-| `stop_time_hysteresis` | double | [s] time threshold to decide stop planning for chattering prevention |
-| `yellow_lamp_period`   | double | [s] time for yellow lamp                                             |
-| `enable_pass_judge`    | bool   | [-] whether to use pass judge                                        |
+| Parameter                    | Type   | Description                                                          |
+| ---------------------------- | ------ | -------------------------------------------------------------------- |
+| `stop_margin`                | double | [m] margin before stop point                                         |
+| `tl_state_timeout`           | double | [s] time out for detected traffic light result.                      |
+| `stop_time_hysteresis`       | double | [s] time threshold to decide stop planning for chattering prevention |
+| `yellow_lamp_period`         | double | [s] time for yellow lamp                                             |
+| `yellow_light_stop_velocity` | double | [m/s] velocity threshold for always stopping at a yellow light.      |
+| `enable_pass_judge`          | bool   | [-] whether to use pass judge                                        |
 
 #### Flowchart
 

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/config/traffic_light.param.yaml
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/config/traffic_light.param.yaml
@@ -5,5 +5,6 @@
       tl_state_timeout: 1.0
       stop_time_hysteresis: 0.1
       yellow_lamp_period: 2.75
+      yellow_light_stop_velocity: 1.0 # Velocity threshold (m/s) below which the vehicle will always stop before the traffic light when the signal turns yellow, regardless of the pass_judge decision.
       enable_pass_judge: true
       enable_rtc: false # If set to true, the scene modules require approval from the rtc (request to cooperate) function. If set to false, the modules can be executed without requiring rtc approval

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/src/manager.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/src/manager.cpp
@@ -42,6 +42,8 @@ TrafficLightModuleManager::TrafficLightModuleManager(rclcpp::Node & node)
   planner_param_.enable_pass_judge = getOrDeclareParameter<bool>(node, ns + ".enable_pass_judge");
   planner_param_.yellow_lamp_period =
     getOrDeclareParameter<double>(node, ns + ".yellow_lamp_period");
+  planner_param_.yellow_light_stop_velocity =
+    getOrDeclareParameter<double>(node, ns + ".yellow_light_stop_velocity");
   pub_tl_state_ = node.create_publisher<autoware_perception_msgs::msg::TrafficLightGroup>(
     "~/output/traffic_signal", 1);
 }

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/src/scene.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/src/scene.cpp
@@ -213,7 +213,8 @@ bool TrafficLightModule::isPassthrough(const double & signed_arc_length) const
     delay_response_time);
 
   const bool distance_stoppable = pass_judge_line_distance < signed_arc_length;
-  const bool slow_velocity = planner_data_->current_velocity->twist.linear.x < 2.0;
+  const bool slow_velocity =
+    planner_data_->current_velocity->twist.linear.x < planner_param_.yellow_light_stop_velocity;
   const bool stoppable = distance_stoppable || slow_velocity;
   const bool reachable = signed_arc_length < reachable_distance;
 

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/src/scene.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/src/scene.hpp
@@ -61,6 +61,7 @@ public:
     double stop_margin;
     double tl_state_timeout;
     double yellow_lamp_period;
+    double yellow_light_stop_velocity;
     double stop_time_hysteresis;
     bool enable_pass_judge;
   };


### PR DESCRIPTION
## Description
To address the issue in the traffic_light module where the vehicle abruptly stops the moment the light changes from amber to green without performing a pass judge when the speed is below 2.0 m/s, we will adjust the speed threshold.

At the same time, the threshold for performing pass judge has been parameterized, considering potential requests to adjust it.

## Related links

[TIERIV internal link] https://tier4.atlassian.net/browse/RT0-33895


<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
We confirmed an improvement in the sudden deceleration behavior using the rosbag-based logging_simulator, where sudden deceleration had previously been occurring.

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

Improvements:

Enables pass judge to be applied even at low speeds (1.0 ~ 2.0 m/s), preventing unnecessary stops when the light changes from amber to green.
Ensures smoother driving and reduces unnecessary braking.
Considerations:

The modified pass judge logic may allow the vehicle to enter the intersection at low speeds.
Changes in stop-and-go behavior could result in different driving patterns compared to the previous implementation.