### PR TITLE
fix(autoware_map_height_fitter): find PCL package after autoware_package() is called

### DIFF
--- a/map/autoware_map_height_fitter/CMakeLists.txt
+++ b/map/autoware_map_height_fitter/CMakeLists.txt
@@ -2,8 +2,8 @@ cmake_minimum_required(VERSION 3.14)
 project(autoware_map_height_fitter)
 
 find_package(autoware_cmake REQUIRED)
-find_package(PCL REQUIRED COMPONENTS common)
 autoware_package()
+find_package(PCL REQUIRED COMPONENTS common)
 
 ament_auto_add_library(${PROJECT_NAME} SHARED
   src/map_height_fitter.cpp


### PR DESCRIPTION
## Description
This package fails to build with the autoware_utils 1.1.0.
(This package depends on autoware_utils via autoware_lanelet2_extension)

Since autoware_utils is now depending on pcl as well, it overwrites some of PCL related CMAKE variables.
In order to only import intended modules, PCL should be included after calling autoware_package().


## Related links
 - https://github.com/autowarefoundation/autoware/pull/5700

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
* checkout 1.1.0 for autoware_utils
* build autoware

I have tested locally that the build passes without an error.

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
