### PR TITLE
fix(radar_tracks_noise_filter): fix launch file

### DIFF
--- a/sensing/autoware_radar_tracks_noise_filter/launch/radar_tracks_noise_filter.launch.xml
+++ b/sensing/autoware_radar_tracks_noise_filter/launch/radar_tracks_noise_filter.launch.xml
@@ -5,9 +5,9 @@
   <arg name="param_path" default="$(find-pkg-share autoware_radar_tracks_noise_filter)/config/radar_tracks_noise_filter.param.yaml"/>
 
   <node pkg="autoware_radar_tracks_noise_filter" exec="radar_tracks_noise_filter_node" name="radar_tracks_noise_filter" output="screen">
-    <remap from="~/input/tracks" to="$(arg input/tracks)"/>
-    <remap from="~/output/noise_tracks" to="$(arg output/noise_tracks)"/>
-    <remap from="~/output/filtered_tracks" to="$(arg output/filtered_tracks)"/>
-    <param file="$(arg param_path)"/>
+    <remap from="~/input/tracks" to="$(var input/tracks)"/>
+    <remap from="~/output/noise_tracks" to="$(var output/noise_tracks)"/>
+    <remap from="~/output/filtered_tracks" to="$(var output/filtered_tracks)"/>
+    <param from="$(var param_path)"/>
   </node>
 </launch>


### PR DESCRIPTION
## Description

This PR fix the syntax error in launch file caused by https://github.com/autowarefoundation/autoware.universe/pull/9992.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

```ros2 launch autoware_radar_tracks_noise_filter radar_tracks_noise_filter.launch.xml```
and
```ros2 launch autoware_launch logging_simulator.launch.xml sensing:=true ...```

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
