### PR TITLE
fix(autoware_traffic_light_selector): add camera_info into message_filter

### DIFF
--- a/perception/autoware_traffic_light_selector/src/traffic_light_selector_node.cpp
+++ b/perception/autoware_traffic_light_selector/src/traffic_light_selector_node.cpp
@@ -50,7 +50,8 @@ TrafficLightSelectorNode::TrafficLightSelectorNode(const rclcpp::NodeOptions & n
   using std::placeholders::_2;
   using std::placeholders::_3;
   using std::placeholders::_4;
-  sync_.registerCallback(std::bind(&TrafficLightSelectorNode::objectsCallback, this, _1, _2, _3, _4));
+  sync_.registerCallback(
+    std::bind(&TrafficLightSelectorNode::objectsCallback, this, _1, _2, _3, _4));
 
   // Publisher
   pub_traffic_light_rois_ =

--- a/perception/autoware_traffic_light_selector/src/traffic_light_selector_node.cpp
+++ b/perception/autoware_traffic_light_selector/src/traffic_light_selector_node.cpp
@@ -33,8 +33,8 @@ TrafficLightSelectorNode::TrafficLightSelectorNode(const rclcpp::NodeOptions & n
   detected_rois_sub_(this, "input/detected_rois", rclcpp::QoS{1}.get_rmw_qos_profile()),
   rough_rois_sub_(this, "input/rough_rois", rclcpp::QoS{1}.get_rmw_qos_profile()),
   expected_rois_sub_(this, "input/expect_rois", rclcpp::QoS{1}.get_rmw_qos_profile()),
-  sync_(SyncPolicy(10), detected_rois_sub_, rough_rois_sub_, expected_rois_sub_),
-  camera_info_subscribed_(false)
+  camera_info_sub_(this, "input/camera_info", rclcpp::SensorDataQoS().get_rmw_qos_profile()),
+  sync_(SyncPolicy(10), detected_rois_sub_, rough_rois_sub_, expected_rois_sub_, camera_info_sub_)
 {
   {
     stop_watch_ptr_ =
@@ -49,40 +49,23 @@ TrafficLightSelectorNode::TrafficLightSelectorNode(const rclcpp::NodeOptions & n
   using std::placeholders::_1;
   using std::placeholders::_2;
   using std::placeholders::_3;
-  sync_.registerCallback(std::bind(&TrafficLightSelectorNode::objectsCallback, this, _1, _2, _3));
+  using std::placeholders::_4;
+  sync_.registerCallback(std::bind(&TrafficLightSelectorNode::objectsCallback, this, _1, _2, _3, _4));
 
-  camera_info_sub_ = create_subscription<sensor_msgs::msg::CameraInfo>(
-    "input/camera_info", rclcpp::SensorDataQoS(),
-    std::bind(&TrafficLightSelectorNode::cameraInfoCallback, this, _1));
   // Publisher
   pub_traffic_light_rois_ =
     create_publisher<TrafficLightRoiArray>("output/traffic_rois", rclcpp::QoS{1});
 }
 
-void TrafficLightSelectorNode::cameraInfoCallback(
-  const sensor_msgs::msg::CameraInfo::ConstSharedPtr input_msg)
-{
-  std::lock_guard<std::mutex> lock(mutex_);
-  if (camera_info_subscribed_) {
-    return;
-  }
-  image_width_ = input_msg->width;
-  image_height_ = input_msg->height;
-  camera_info_subscribed_ = true;
-  RCLCPP_INFO(get_logger(), "camera_info received");
-}
-
 void TrafficLightSelectorNode::objectsCallback(
   const DetectedObjectsWithFeature::ConstSharedPtr & detected_traffic_light_msg,
   const TrafficLightRoiArray::ConstSharedPtr & rough_rois_msg,
-  const TrafficLightRoiArray::ConstSharedPtr & expected_rois_msg)
+  const TrafficLightRoiArray::ConstSharedPtr & expected_rois_msg,
+  const sensor_msgs::msg::CameraInfo::ConstSharedPtr & camera_info_msg)
 {
   stop_watch_ptr_->toc("processing_time", true);
-  mutex_.lock();
-  if (!camera_info_subscribed_) {
-    return;
-  }
-  mutex_.unlock();
+  uint32_t image_width = camera_info_msg->width;
+  uint32_t image_height = camera_info_msg->height;
   std::map<int, sensor_msgs::msg::RegionOfInterest> rough_rois_map;
   for (const auto & roi : rough_rois_msg->rois) {
     rough_rois_map[roi.traffic_light_id] = roi.roi;
@@ -103,9 +86,9 @@ void TrafficLightSelectorNode::objectsCallback(
     expect_rois.push_back(expected_roi.roi);
   }
   cv::Mat expect_roi_img =
-    utils::createBinaryImageFromRois(expect_rois, cv::Size(image_width_, image_height_));
+    utils::createBinaryImageFromRois(expect_rois, cv::Size(image_width, image_height));
   cv::Mat det_roi_img =
-    utils::createBinaryImageFromRois(det_rois, cv::Size(image_width_, image_height_));
+    utils::createBinaryImageFromRois(det_rois, cv::Size(image_width, image_height));
   // for (const auto expect_roi : expect_rois) {
   for (const auto & expect_traffic_roi : expected_rois_msg->rois) {
     const auto & expect_roi = expect_traffic_roi.roi;
@@ -139,10 +122,10 @@ void TrafficLightSelectorNode::objectsCallback(
       // fit top lef corner of detected roi to inside of image
       detected_roi_shifted.x_offset = std::clamp(
         static_cast<int>(detected_roi.feature.roi.x_offset) - det_roi_shift_x, 0,
-        static_cast<int>(image_width_ - detected_roi.feature.roi.width));
+        static_cast<int>(image_width - detected_roi.feature.roi.width));
       detected_roi_shifted.y_offset = std::clamp(
         static_cast<int>(detected_roi.feature.roi.y_offset) - det_roi_shift_y, 0,
-        static_cast<int>(image_height_ - detected_roi.feature.roi.height));
+        static_cast<int>(image_height - detected_roi.feature.roi.height));
 
       double iou = utils::getGenIoU(expect_roi.roi, detected_roi_shifted);
       if (iou > max_iou) {

--- a/perception/autoware_traffic_light_selector/src/traffic_light_selector_node.hpp
+++ b/perception/autoware_traffic_light_selector/src/traffic_light_selector_node.hpp
@@ -35,7 +35,6 @@
 #include <tf2_ros/transform_listener.h>
 
 #include <memory>
-#include <mutex>
 
 namespace autoware::traffic_light
 {
@@ -58,27 +57,22 @@ private:
   message_filters::Subscriber<DetectedObjectsWithFeature> detected_rois_sub_;
   message_filters::Subscriber<TrafficLightRoiArray> rough_rois_sub_;
   message_filters::Subscriber<TrafficLightRoiArray> expected_rois_sub_;
+  message_filters::Subscriber<sensor_msgs::msg::CameraInfo> camera_info_sub_;
   typedef message_filters::sync_policies::ApproximateTime<
-    DetectedObjectsWithFeature, TrafficLightRoiArray, TrafficLightRoiArray>
+    DetectedObjectsWithFeature, TrafficLightRoiArray, TrafficLightRoiArray, sensor_msgs::msg::CameraInfo>
     SyncPolicy;
   typedef message_filters::Synchronizer<SyncPolicy> Sync;
   Sync sync_;
   void objectsCallback(
     const DetectedObjectsWithFeature::ConstSharedPtr & detected_rois_msg,
     const TrafficLightRoiArray::ConstSharedPtr & rough_rois_msg,
-    const TrafficLightRoiArray::ConstSharedPtr & expect_rois_msg);
+    const TrafficLightRoiArray::ConstSharedPtr & expect_rois_msg,
+    const sensor_msgs::msg::CameraInfo::ConstSharedPtr & camera_info_msg);
 
-  void cameraInfoCallback(const sensor_msgs::msg::CameraInfo::ConstSharedPtr input_msg);
   // Publisher
   rclcpp::Publisher<TrafficLightRoiArray>::SharedPtr pub_traffic_light_rois_;
-  // Subscribe camera_info to get width and height of image
-  rclcpp::Subscription<sensor_msgs::msg::CameraInfo>::SharedPtr camera_info_sub_;
-  bool camera_info_subscribed_;
-  uint32_t image_width_;
-  uint32_t image_height_;
-  double max_iou_threshold_;
 
-  std::mutex mutex_;
+  double max_iou_threshold_;
 
   std::unique_ptr<autoware::universe_utils::StopWatch<std::chrono::milliseconds>> stop_watch_ptr_;
   std::unique_ptr<autoware::universe_utils::DebugPublisher> debug_publisher_;

--- a/perception/autoware_traffic_light_selector/src/traffic_light_selector_node.hpp
+++ b/perception/autoware_traffic_light_selector/src/traffic_light_selector_node.hpp
@@ -59,7 +59,8 @@ private:
   message_filters::Subscriber<TrafficLightRoiArray> expected_rois_sub_;
   message_filters::Subscriber<sensor_msgs::msg::CameraInfo> camera_info_sub_;
   typedef message_filters::sync_policies::ApproximateTime<
-    DetectedObjectsWithFeature, TrafficLightRoiArray, TrafficLightRoiArray, sensor_msgs::msg::CameraInfo>
+    DetectedObjectsWithFeature, TrafficLightRoiArray, TrafficLightRoiArray,
+    sensor_msgs::msg::CameraInfo>
     SyncPolicy;
   typedef message_filters::Synchronizer<SyncPolicy> Sync;
   Sync sync_;

--- a/perception/autoware_traffic_light_selector/src/traffic_light_selector_node.hpp
+++ b/perception/autoware_traffic_light_selector/src/traffic_light_selector_node.hpp
@@ -35,6 +35,7 @@
 #include <tf2_ros/transform_listener.h>
 
 #include <memory>
+#include <mutex>
 
 namespace autoware::traffic_light
 {
@@ -73,9 +74,11 @@ private:
   // Subscribe camera_info to get width and height of image
   rclcpp::Subscription<sensor_msgs::msg::CameraInfo>::SharedPtr camera_info_sub_;
   bool camera_info_subscribed_;
-  uint32_t image_width_{1280};
-  uint32_t image_height_{960};
-  double max_iou_threshold_{0.0};
+  uint32_t image_width_;
+  uint32_t image_height_;
+  double max_iou_threshold_;
+
+  std::mutex mutex_;
 
   std::unique_ptr<autoware::universe_utils::StopWatch<std::chrono::milliseconds>> stop_watch_ptr_;
   std::unique_ptr<autoware::universe_utils::DebugPublisher> debug_publisher_;


### PR DESCRIPTION
## Description

add camera_info into message_filter.
If we do not add it, have to handle with mutex to be thread safe. And subscribe topics have same timestamp, So It is efficienfy to subscribe together.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

I checked this PR on my local PC and merging below PR.
- https://github.com/autowarefoundation/autoware.universe/pull/9731
- https://github.com/autowarefoundation/autoware_launch/pull/1310

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
