### PR TITLE
perf(behavior_path_planner): improve getOverlappedLaneletId

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/drivable_area_expansion/static_drivable_area.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/drivable_area_expansion/static_drivable_area.cpp
@@ -662,20 +662,15 @@ std::optional<size_t> getOverlappedLaneletId(const std::vector<DrivableLanes> & 
     return {};
   }
 
-  size_t overlapped_idx = lanes.size();
   for (size_t i = 0; i < lanes.size() - 2; ++i) {
     for (size_t j = i + 2; j < lanes.size(); ++j) {
       if (overlaps(lanes.at(i), lanes.at(j))) {
-        overlapped_idx = std::min(overlapped_idx, j);
+        return j;
       }
     }
   }
 
-  if (overlapped_idx == lanes.size()) {
-    return {};
-  }
-
-  return overlapped_idx;
+  return {};
 }
 
 std::vector<DrivableLanes> cutOverlappedLanes(


### PR DESCRIPTION
## Description

improve the `getOverlappedLaneletId` to early return

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

- https://evaluation.tier4.jp/evaluation/reports/41d4c96b-2121-5d10-8f17-dff2701358d2?project_id=prd_jt

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
