### PR TITLE
chore(autoware_probabilistic_occupancy_grid_map): fixed cuda use on non-cuda settings

### DIFF
--- a/perception/autoware_probabilistic_occupancy_grid_map/lib/updater/binary_bayes_filter_updater.cpp
+++ b/perception/autoware_probabilistic_occupancy_grid_map/lib/updater/binary_bayes_filter_updater.cpp
@@ -48,21 +48,23 @@ void OccupancyGridMapBBFUpdater::initRosParam(rclcpp::Node & node)
   v_ratio_ = node.declare_parameter<double>("v_ratio");
 
 #ifdef USE_CUDA
-  device_probability_matrix_ =
-    autoware::cuda_utils::make_unique<float[]>(Index::NUM_STATES * Index::NUM_STATES);
+  if (use_cuda_) {
+    device_probability_matrix_ =
+      autoware::cuda_utils::make_unique<float[]>(Index::NUM_STATES * Index::NUM_STATES);
 
-  std::vector<float> probability_matrix_vector;
-  probability_matrix_vector.resize(Index::NUM_STATES * Index::NUM_STATES);
+    std::vector<float> probability_matrix_vector;
+    probability_matrix_vector.resize(Index::NUM_STATES * Index::NUM_STATES);
 
-  for (size_t j = 0; j < Index::NUM_STATES; j++) {
-    for (size_t i = 0; i < Index::NUM_STATES; i++) {
-      probability_matrix_vector[j * Index::NUM_STATES + i] = probability_matrix_(j, i);
+    for (size_t j = 0; j < Index::NUM_STATES; j++) {
+      for (size_t i = 0; i < Index::NUM_STATES; i++) {
+        probability_matrix_vector[j * Index::NUM_STATES + i] = probability_matrix_(j, i);
+      }
     }
-  }
 
-  cudaMemcpyAsync(
-    device_probability_matrix_.get(), probability_matrix_vector.data(),
-    sizeof(float) * Index::NUM_STATES * Index::NUM_STATES, cudaMemcpyHostToDevice, stream_);
+    cudaMemcpyAsync(
+      device_probability_matrix_.get(), probability_matrix_vector.data(),
+      sizeof(float) * Index::NUM_STATES * Index::NUM_STATES, cudaMemcpyHostToDevice, stream_);
+  }
 #endif
 }
 


### PR DESCRIPTION
## Description
As per the title :bow: 
## Related links
Addressed [TIER IV INTERNAL LINK](https://star4.slack.com/archives/C076ZGRC15X/p1739320384217569)

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
