### PR TITLE
fix(lane_change): fix end pose not connected to goal (RT1-9247)

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/path.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/path.cpp
@@ -732,12 +732,15 @@ void append_target_ref_to_candidate(
   const auto lc_end_idx =
     motion_utils::findNearestIndex(target_lane_ref_path, lc_end_pose.position);
   auto & candidate_path = frenet_candidate.path.points;
+  const auto & points = target_lane_ref_path;
   if (target_lane_ref_path.size() <= lc_end_idx + 2) {
+    for (const auto & pt : points | ranges::views::drop(lc_end_idx + 1)) {
+      candidate_path.push_back(pt);
+    }
     return;
   }
   const auto add_size = target_lane_ref_path.size() - (lc_end_idx + 1);
   candidate_path.reserve(candidate_path.size() + add_size);
-  const auto & points = target_lane_ref_path;
   for (const auto & [p2, p3] : ranges::views::zip(
          points | ranges::views::drop(lc_end_idx + 1),
          points | ranges::views::drop(lc_end_idx + 2))) {


### PR DESCRIPTION
## Description

fix lane change end pose not connected to goal when frenet planner is used

## Related links

**Parent Issue:**

- [feat(lane_change): improve the calculation of the target lateral velocity in Frenet frame #10078](https://github.com/autowarefoundation/autoware.universe/pull/10078)

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
