### PR TITLE
perf(behavior_velocity_planner): replace getSortedLaneIdsFromPath

### DIFF
--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/src/utilization/util.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/src/utilization/util.cpp
@@ -562,16 +562,13 @@ std::set<int64_t> getLaneIdSetOnPath(
 
 std::vector<int64_t> getSortedLaneIdsFromPath(const PathWithLaneId & path)
 {
-  std::vector<int64_t> sorted_lane_ids;
+  std::unordered_set<int64_t> sorted_lane_ids;
   for (const auto & path_points : path.points) {
-    for (const auto lane_id : path_points.lane_ids)
-      if (
-        std::find(sorted_lane_ids.begin(), sorted_lane_ids.end(), lane_id) ==
-        sorted_lane_ids.end()) {
-        sorted_lane_ids.emplace_back(lane_id);
-      }
+    for (const auto lane_id : path_points.lane_ids) {
+      sorted_lane_ids.insert(lane_id);
+    }
   }
-  return sorted_lane_ids;
+  return std::vector<int64_t>(sorted_lane_ids.begin(), sorted_lane_ids.end());
 }
 
 std::vector<int64_t> getSubsequentLaneIdsSetOnPath(


### PR DESCRIPTION
Signed-off-by: Enigamict atsuki.takata@tier4.jp

## Description
cc @veqcc 
In getSortedLaneIdsFromPath(), we originally used std::find to check for duplicates in the lane_id array. However, the linear search with std::find was too expensive, as shown on the FlameGraph, which indicates that getSortedLaneIdsFromPath imposes a significant load.

![Screenshot from 2025-02-10 15-05-48](https://github.com/user-attachments/assets/2d3debd6-c023-40ab-93ec-f862d37f6d12)


To address this, we changed the duplicate-checking approach to use an unordered_set. Instead of conditionally calling emplace_back(lane_id) only if it is not found in sorted_lane_ids, we now use unordered_set::insert(). This reduces the overall computational cost by eliminating repeated linear searches.

We evaluated the performance impact using percentile metrics (50%, 75%, 90%, 95%, 99%) on BehaviorVelocityPlannerNode::generatePath.

| Percentile | Before (us) | After (us)     |
| ---------- | ----------- | -------------- |
| **50%**    | 9814.00     | 6357.50|
| **75%**    | 13143.25    | 8567.75|
| **90%**    | 15864.80    | 11829.50|
| **95%**    | 17400.50    | 13691.00|
| **99%**    | 20763.05    | 17032.05|

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
