### PR TITLE
refactor(goal_planner): refactor planPullOverAsCandidate

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/goal_planner_module.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/goal_planner_module.cpp
@@ -1447,68 +1447,119 @@ BehaviorModuleOutput GoalPlannerModule::planPullOverAsCandidate(
   }
 
   BehaviorModuleOutput pull_over_output{};
-  // if pull over path candidates generation is not finished, use previous module output
-  auto pull_over_path_with_velocity_opt = context_data.pull_over_path_opt;
-  const bool is_freespace =
-    pull_over_path_with_velocity_opt &&
-    pull_over_path_with_velocity_opt.value().type() == PullOverPlannerType::FREESPACE;
-  const std::optional<GoalCandidate> modified_goal_opt =
-    pull_over_path_with_velocity_opt
-      ? std::make_optional<GoalCandidate>(pull_over_path_with_velocity_opt.value().modified_goal())
-      : std::nullopt;
-  const auto & last_path_update_time = context_data.last_path_update_time;
-  if (
-    path_decision_controller_.get_current_state().state ==
-      PathDecisionState::DecisionKind::NOT_DECIDED &&
-    !is_freespace &&
-    needPathUpdate(
-      planner_data_->self_odometry->pose.pose, 1.0 /*path_update_duration*/, clock_->now(),
-      modified_goal_opt, last_path_update_time, parameters_)) {
-    // if the final path is not decided and enough time has passed since last path update,
-    // select safe path from lane parking pull over path candidates
-    // and set it to thread_safe_data_
-    RCLCPP_INFO(getLogger(), "Update pull over path candidates");
+  {
+    auto pull_over_path_with_velocity_opt = context_data.pull_over_path_opt;
+    const bool is_freespace =
+      pull_over_path_with_velocity_opt &&
+      pull_over_path_with_velocity_opt.value().type() == PullOverPlannerType::FREESPACE;
+    const std::optional<GoalCandidate> modified_goal_opt =
+      pull_over_path_with_velocity_opt ? std::make_optional<GoalCandidate>(
+                                           pull_over_path_with_velocity_opt.value().modified_goal())
+                                       : std::nullopt;
+    const auto & last_path_update_time = context_data.last_path_update_time;
+    if (
+      path_decision_controller_.get_current_state().state ==
+        PathDecisionState::DecisionKind::NOT_DECIDED &&
+      !is_freespace &&
+      needPathUpdate(
+        planner_data_->self_odometry->pose.pose, 1.0 /*path_update_duration*/, clock_->now(),
+        modified_goal_opt, last_path_update_time, parameters_)) {
+      // if the final path is not decided and enough time has passed since last path update,
+      // select safe path from lane parking pull over path candidates
+      // and set it to thread_safe_data_
+      RCLCPP_INFO(getLogger(), "Update pull over path candidates");
 
-    context_data.pull_over_path_opt = std::nullopt;
-    context_data.last_path_update_time = std::nullopt;
-    context_data.last_path_idx_increment_time = std::nullopt;
-
-    // Select a path that is as safe as possible and has a high priority.
-    const auto & pull_over_path_candidates =
-      context_data.lane_parking_response.pull_over_path_candidates;
-    const auto lane_pull_over_path_opt = selectPullOverPath(
-      context_data, pull_over_path_candidates,
-      context_data.lane_parking_response.sorted_bezier_indices_opt);
-
-    // update thread_safe_data_
-    const auto & pull_over_path_opt =
-      lane_pull_over_path_opt ? lane_pull_over_path_opt
-                              : context_data.freespace_parking_response.freespace_pull_over_path;
-    if (pull_over_path_opt) {
-      const auto & pull_over_path = pull_over_path_opt.value();
-      /** TODO(soblin): since thread_safe_data::pull_over_path was used as a global variable,
-       * old code was setting deceleration to thread_safe_data::pull_over_path and setOutput()
-       * accessed to the velocity profile in thread_safe_data::pull_over_path, which is a very
-       * bad usage of member variable
-       *
-       * set this selected pull_over_path to ThreadSafeData, but actually RoadParking thread
-       * does not use pull_over_path, but only FreespaceParking thread use this selected
-       * pull_over_path. As the next action item, only set this selected pull_over_path to only
-       * FreespaceThreadSafeData.
-       */
-      context_data.pull_over_path_opt = pull_over_path;
-      context_data.last_path_update_time = clock_->now();
+      context_data.pull_over_path_opt = std::nullopt;
+      context_data.last_path_update_time = std::nullopt;
       context_data.last_path_idx_increment_time = std::nullopt;
 
-      RCLCPP_DEBUG(
-        getLogger(), "selected pull over path: path_id: %ld, goal_id: %ld", pull_over_path.id(),
-        pull_over_path.modified_goal().id);
-    }
-  }
+      // Select a path that is as safe as possible and has a high priority.
+      const auto & pull_over_path_candidates =
+        context_data.lane_parking_response.pull_over_path_candidates;
+      const auto lane_pull_over_path_opt = selectPullOverPath(
+        context_data, pull_over_path_candidates,
+        context_data.lane_parking_response.sorted_bezier_indices_opt);
 
-  if (pull_over_path_with_velocity_opt) {
-    path_candidate_ =
-      std::make_shared<PathWithLaneId>(pull_over_path_with_velocity_opt.value().full_path());
+      // update thread_safe_data_
+      const auto & pull_over_path_opt =
+        lane_pull_over_path_opt ? lane_pull_over_path_opt
+                                : context_data.freespace_parking_response.freespace_pull_over_path;
+      if (pull_over_path_opt) {
+        const auto & pull_over_path = pull_over_path_opt.value();
+        context_data.pull_over_path_opt = pull_over_path;
+        context_data.last_path_update_time = clock_->now();
+        context_data.last_path_idx_increment_time = std::nullopt;
+
+        if (pull_over_path_with_velocity_opt) {
+          auto & pull_over_path_with_velocity = pull_over_path_with_velocity_opt.value();
+          // copy the path for later setOutput()
+          pull_over_path_with_velocity = pull_over_path;
+          // modify the velocity for latest setOutput()
+          deceleratePath(pull_over_path_with_velocity);
+        }
+        RCLCPP_DEBUG(
+          getLogger(), "selected pull over path: path_id: %ld, goal_id: %ld", pull_over_path.id(),
+          pull_over_path.modified_goal().id);
+      }
+    }
+
+    // set output and status
+    {
+      pull_over_output.reference_path = getPreviousModuleOutput().reference_path;
+
+      if (!pull_over_path_with_velocity_opt) {
+        // situation : not safe against static objects use stop_path
+        // TODO(soblin): goal_candidates_.empty() is impossible
+        pull_over_output.path = generateStopPath(
+          context_data, (goal_candidates_.empty() ? "no goal candidate" : "no static safe path"));
+        RCLCPP_INFO_THROTTLE(
+          getLogger(), *clock_, 5000, "Not found safe pull_over path, generate stop path");
+        setDrivableAreaInfo(context_data, pull_over_output);
+      } else {
+        const auto & pull_over_path = pull_over_path_with_velocity_opt.value();
+        if (!context_data.is_stable_safe_path && isActivated()) {
+          // situation : not safe against dynamic objects after approval
+          // insert stop point in current path if ego is able to stop with acceleration and jerk
+          // constraints
+          pull_over_output.path = generateFeasibleStopPath(
+            pull_over_path.getCurrentPath(), "unsafe against dynamic objects");
+          RCLCPP_INFO_THROTTLE(
+            getLogger(), *clock_, 5000, "Not safe against dynamic objects, generate stop path");
+        } else {
+          // situation : (safe against static and dynamic objects) or (safe against static objects
+          // and before approval) don't stop keep stop if not enough time passed, because it takes
+          // time for the trajectory to be reflected
+          auto current_path = pull_over_path.getCurrentPath();
+          keepStoppedWithCurrentPath(context_data, current_path);
+          pull_over_output.path = current_path;
+        }
+
+        setModifiedGoal(context_data, pull_over_output);
+        setDrivableAreaInfo(context_data, pull_over_output);
+
+        // set hazard and turn signal
+        if (
+          path_decision_controller_.get_current_state().state ==
+            PathDecisionState::DecisionKind::DECIDED &&
+          isActivated()) {
+          setTurnSignalInfo(context_data, pull_over_output);
+        }
+      }
+    }
+
+    // return to lane parking if it is possible
+    if (is_freespace && canReturnToLaneParking(context_data)) {
+      if (pull_over_path_with_velocity_opt) {
+        context_data.pull_over_path_opt = pull_over_path_with_velocity_opt;
+        context_data.last_path_update_time = clock_->now();
+        context_data.last_path_idx_increment_time = std::nullopt;
+      }
+    }
+
+    if (pull_over_path_with_velocity_opt) {
+      path_candidate_ =
+        std::make_shared<PathWithLaneId>(pull_over_path_with_velocity_opt.value().full_path());
+    }
   }
 
   BehaviorModuleOutput output{};

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/goal_planner_module.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/goal_planner_module.cpp
@@ -1446,7 +1446,7 @@ BehaviorModuleOutput GoalPlannerModule::planPullOverAsCandidate(
     return stop_path;
   }
 
-  // NOTE: following block is intentionally duty to refactor only necesary block from
+  // NOTE: following block is intentionally dirty to refactor and extract only necessary codes in
   // planAsCandidate/planAsOutput/setOutput
   BehaviorModuleOutput pull_over_output{};
   {


### PR DESCRIPTION
## Description

bundle the code in planPulloverAsOutput and setOutput() to refactor planPulloverAsCandidate

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

- https://evaluation.tier4.jp/evaluation/reports/5e47c8a0-3a5c-5f24-ba62-8e7325ecabab?project_id=prd_jt 
- https://evaluation.tier4.jp/evaluation/reports/c49b2f74-3790-5db6-a76b-7fd8fe18eae7?project_id=prd_jt 

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
