### PR TITLE
fix(autoware_pointcloud_preprocessor): empty input validation

### DIFF
--- a/sensing/autoware_pointcloud_preprocessor/schema/pickup_based_voxel_grid_downsample_filter_node.schema.json
+++ b/sensing/autoware_pointcloud_preprocessor/schema/pickup_based_voxel_grid_downsample_filter_node.schema.json
@@ -10,19 +10,19 @@
           "type": "number",
           "description": "voxel size along the x-axis [m]",
           "default": "1.0",
-          "minimum": 0
+          "exclusiveMinimum": 0.0
         },
         "voxel_size_y": {
           "type": "number",
           "description": "voxel size along the y-axis [m]",
           "default": "1.0",
-          "minimum": 0
+          "exclusiveMinimum": 0.0
         },
         "voxel_size_z": {
           "type": "number",
           "description": "voxel size along the z-axis [m]",
           "default": "1.0",
-          "minimum": 0
+          "exclusiveMinimum": 0.0
         }
       },
       "required": ["voxel_size_x", "voxel_size_y", "voxel_size_z"],

--- a/sensing/autoware_pointcloud_preprocessor/src/downsample_filter/pickup_based_voxel_grid_downsample_filter_node.cpp
+++ b/sensing/autoware_pointcloud_preprocessor/src/downsample_filter/pickup_based_voxel_grid_downsample_filter_node.cpp
@@ -98,9 +98,9 @@ void PickupBasedVoxelGridDownsampleFilterComponent::filter(
   voxel_map.reserve(input->data.size() / input->point_step);
 
   constexpr float large_num_offset = 100000.0;
-  const float inverse_voxel_size_x = 1.0f / voxel_size_x_;
-  const float inverse_voxel_size_y = 1.0f / voxel_size_y_;
-  const float inverse_voxel_size_z = 1.0f / voxel_size_z_;
+  const float inverse_voxel_size_x = 1.0 / voxel_size_x_;
+  const float inverse_voxel_size_y = 1.0 / voxel_size_y_;
+  const float inverse_voxel_size_z = 1.0 / voxel_size_z_;
 
   const int x_offset = input->fields[pcl::getFieldIndex(*input, "x")].offset;
   const int y_offset = input->fields[pcl::getFieldIndex(*input, "y")].offset;

--- a/sensing/autoware_pointcloud_preprocessor/src/downsample_filter/pickup_based_voxel_grid_downsample_filter_node.cpp
+++ b/sensing/autoware_pointcloud_preprocessor/src/downsample_filter/pickup_based_voxel_grid_downsample_filter_node.cpp
@@ -99,7 +99,9 @@ void PickupBasedVoxelGridDownsampleFilterComponent::filter(
   const float inverse_voxel_size_z = (voxel_size_z_ > 0.0f) ? (1.0f / voxel_size_z_) : max_inverse;
 
   if (voxel_size_x_ <= 0.0f || voxel_size_y_ <= 0.0f || voxel_size_z_ <= 0.0f) {
-      RCLCPP_ERROR_STREAM_THROTTLE(get_logger(), *get_clock(), 1000, "Some voxel sizes are 0. Those axes will not be used for downsampling.");
+    RCLCPP_ERROR_STREAM_THROTTLE(
+      get_logger(), *get_clock(), 1000,
+      "Some voxel sizes are 0. Those axes will not be used for downsampling.");
   }
 
   const int x_offset = input->fields[pcl::getFieldIndex(*input, "x")].offset;

--- a/sensing/autoware_pointcloud_preprocessor/src/downsample_filter/pickup_based_voxel_grid_downsample_filter_node.cpp
+++ b/sensing/autoware_pointcloud_preprocessor/src/downsample_filter/pickup_based_voxel_grid_downsample_filter_node.cpp
@@ -72,6 +72,10 @@ PickupBasedVoxelGridDownsampleFilterComponent::PickupBasedVoxelGridDownsampleFil
   voxel_size_x_ = declare_parameter<float>("voxel_size_x");
   voxel_size_y_ = declare_parameter<float>("voxel_size_y");
   voxel_size_z_ = declare_parameter<float>("voxel_size_z");
+  if (voxel_size_x_ <= 0.0f || voxel_size_y_ <= 0.0f || voxel_size_z_ <= 0.0f) {
+    RCLCPP_ERROR("Some voxel sizes are 0. Those axes will not be used for downsampling.");
+    rclcpp::shutdown();
+  }
 
   using std::placeholders::_1;
   set_param_res_ = this->add_on_set_parameters_callback(
@@ -94,15 +98,9 @@ void PickupBasedVoxelGridDownsampleFilterComponent::filter(
 
   constexpr float large_num_offset = 100000.0;
   constexpr float max_inverse = 2000.0f;
-  const float inverse_voxel_size_x = (voxel_size_x_ > 0.0f) ? (1.0f / voxel_size_x_) : max_inverse;
-  const float inverse_voxel_size_y = (voxel_size_y_ > 0.0f) ? (1.0f / voxel_size_y_) : max_inverse;
-  const float inverse_voxel_size_z = (voxel_size_z_ > 0.0f) ? (1.0f / voxel_size_z_) : max_inverse;
-
-  if (voxel_size_x_ <= 0.0f || voxel_size_y_ <= 0.0f || voxel_size_z_ <= 0.0f) {
-    RCLCPP_ERROR_STREAM_THROTTLE(
-      get_logger(), *get_clock(), 1000,
-      "Some voxel sizes are 0. Those axes will not be used for downsampling.");
-  }
+  const float inverse_voxel_size_x = 1.0f / voxel_size_x_;
+  const float inverse_voxel_size_y = 1.0f / voxel_size_y_;
+  const float inverse_voxel_size_z = 1.0f / voxel_size_z_;
 
   const int x_offset = input->fields[pcl::getFieldIndex(*input, "x")].offset;
   const int y_offset = input->fields[pcl::getFieldIndex(*input, "y")].offset;

--- a/sensing/autoware_pointcloud_preprocessor/src/downsample_filter/pickup_based_voxel_grid_downsample_filter_node.cpp
+++ b/sensing/autoware_pointcloud_preprocessor/src/downsample_filter/pickup_based_voxel_grid_downsample_filter_node.cpp
@@ -98,7 +98,8 @@ void PickupBasedVoxelGridDownsampleFilterComponent::filter(
   const float inverse_voxel_size_z = (voxel_size_z_ > 0) ? (1.0f / voxel_size_z_) : 0.0f;
 
   if (voxel_size_x_ <= 0 || voxel_size_y_ <= 0 || voxel_size_z_ <= 0) {
-      RCLCPP_DEBUG(get_logger(), "Some voxel sizes are 0. Those axes will not be used for downsampling.");
+    RCLCPP_DEBUG(
+      get_logger(), "Some voxel sizes are 0. Those axes will not be used for downsampling.");
   }
 
   const int x_offset = input->fields[pcl::getFieldIndex(*input, "x")].offset;

--- a/sensing/autoware_pointcloud_preprocessor/src/downsample_filter/pickup_based_voxel_grid_downsample_filter_node.cpp
+++ b/sensing/autoware_pointcloud_preprocessor/src/downsample_filter/pickup_based_voxel_grid_downsample_filter_node.cpp
@@ -97,7 +97,6 @@ void PickupBasedVoxelGridDownsampleFilterComponent::filter(
   voxel_map.reserve(input->data.size() / input->point_step);
 
   constexpr float large_num_offset = 100000.0;
-  constexpr float max_inverse = 2000.0f;
   const float inverse_voxel_size_x = 1.0f / voxel_size_x_;
   const float inverse_voxel_size_y = 1.0f / voxel_size_y_;
   const float inverse_voxel_size_z = 1.0f / voxel_size_z_;

--- a/sensing/autoware_pointcloud_preprocessor/src/downsample_filter/pickup_based_voxel_grid_downsample_filter_node.cpp
+++ b/sensing/autoware_pointcloud_preprocessor/src/downsample_filter/pickup_based_voxel_grid_downsample_filter_node.cpp
@@ -93,9 +93,13 @@ void PickupBasedVoxelGridDownsampleFilterComponent::filter(
   voxel_map.reserve(input->data.size() / input->point_step);
 
   constexpr float large_num_offset = 100000.0;
-  const float inverse_voxel_size_x = 1.0 / voxel_size_x_;
-  const float inverse_voxel_size_y = 1.0 / voxel_size_y_;
-  const float inverse_voxel_size_z = 1.0 / voxel_size_z_;
+  const float inverse_voxel_size_x = (voxel_size_x_ > 0) ? (1.0f / voxel_size_x_) : 0.0f;
+  const float inverse_voxel_size_y = (voxel_size_y_ > 0) ? (1.0f / voxel_size_y_) : 0.0f;
+  const float inverse_voxel_size_z = (voxel_size_z_ > 0) ? (1.0f / voxel_size_z_) : 0.0f;
+
+  if (voxel_size_x_ <= 0 || voxel_size_y_ <= 0 || voxel_size_z_ <= 0) {
+      RCLCPP_DEBUG(get_logger(), "Some voxel sizes are 0. Those axes will not be used for downsampling.");
+  }
 
   const int x_offset = input->fields[pcl::getFieldIndex(*input, "x")].offset;
   const int y_offset = input->fields[pcl::getFieldIndex(*input, "y")].offset;

--- a/sensing/autoware_pointcloud_preprocessor/src/downsample_filter/pickup_based_voxel_grid_downsample_filter_node.cpp
+++ b/sensing/autoware_pointcloud_preprocessor/src/downsample_filter/pickup_based_voxel_grid_downsample_filter_node.cpp
@@ -73,7 +73,7 @@ PickupBasedVoxelGridDownsampleFilterComponent::PickupBasedVoxelGridDownsampleFil
   voxel_size_y_ = declare_parameter<float>("voxel_size_y");
   voxel_size_z_ = declare_parameter<float>("voxel_size_z");
   if (voxel_size_x_ <= 0.0f || voxel_size_y_ <= 0.0f || voxel_size_z_ <= 0.0f) {
-    RCLCPP_ERROR("Invalid voxel sizes. It must be positive.");
+    RCLCPP_ERROR("Invalid voxel sizes. They must be positive.");
     rclcpp::shutdown();
   }
 

--- a/sensing/autoware_pointcloud_preprocessor/src/downsample_filter/pickup_based_voxel_grid_downsample_filter_node.cpp
+++ b/sensing/autoware_pointcloud_preprocessor/src/downsample_filter/pickup_based_voxel_grid_downsample_filter_node.cpp
@@ -72,10 +72,6 @@ PickupBasedVoxelGridDownsampleFilterComponent::PickupBasedVoxelGridDownsampleFil
   voxel_size_x_ = declare_parameter<float>("voxel_size_x");
   voxel_size_y_ = declare_parameter<float>("voxel_size_y");
   voxel_size_z_ = declare_parameter<float>("voxel_size_z");
-  if (voxel_size_x_ <= 0.0f || voxel_size_y_ <= 0.0f || voxel_size_z_ <= 0.0f) {
-    RCLCPP_ERROR("Invalid voxel sizes. They must be positive.");
-    rclcpp::shutdown();
-  }
 
   using std::placeholders::_1;
   set_param_res_ = this->add_on_set_parameters_callback(

--- a/sensing/autoware_pointcloud_preprocessor/src/downsample_filter/pickup_based_voxel_grid_downsample_filter_node.cpp
+++ b/sensing/autoware_pointcloud_preprocessor/src/downsample_filter/pickup_based_voxel_grid_downsample_filter_node.cpp
@@ -93,7 +93,7 @@ void PickupBasedVoxelGridDownsampleFilterComponent::filter(
   voxel_map.reserve(input->data.size() / input->point_step);
 
   constexpr float large_num_offset = 100000.0;
-  constexpr float max_inverse = 20000.0f;
+  constexpr float max_inverse = 2000.0f;
   const float inverse_voxel_size_x = (voxel_size_x_ > 0.0f) ? (1.0f / voxel_size_x_) : max_inverse;
   const float inverse_voxel_size_y = (voxel_size_y_ > 0.0f) ? (1.0f / voxel_size_y_) : max_inverse;
   const float inverse_voxel_size_z = (voxel_size_z_ > 0.0f) ? (1.0f / voxel_size_z_) : max_inverse;

--- a/sensing/autoware_pointcloud_preprocessor/src/downsample_filter/pickup_based_voxel_grid_downsample_filter_node.cpp
+++ b/sensing/autoware_pointcloud_preprocessor/src/downsample_filter/pickup_based_voxel_grid_downsample_filter_node.cpp
@@ -94,6 +94,7 @@ void PickupBasedVoxelGridDownsampleFilterComponent::filter(
   // std::unordered_map<VoxelKey, size_t, VoxelKeyHash, VoxelKeyEqual> voxel_map;
   robin_hood::unordered_map<VoxelKey, size_t, VoxelKeyHash, VoxelKeyEqual> voxel_map;
 
+  if (input->data.empty()) return;
   voxel_map.reserve(input->data.size() / input->point_step);
 
   constexpr float large_num_offset = 100000.0;

--- a/sensing/autoware_pointcloud_preprocessor/src/downsample_filter/pickup_based_voxel_grid_downsample_filter_node.cpp
+++ b/sensing/autoware_pointcloud_preprocessor/src/downsample_filter/pickup_based_voxel_grid_downsample_filter_node.cpp
@@ -93,13 +93,13 @@ void PickupBasedVoxelGridDownsampleFilterComponent::filter(
   voxel_map.reserve(input->data.size() / input->point_step);
 
   constexpr float large_num_offset = 100000.0;
-  const float inverse_voxel_size_x = (voxel_size_x_ > 0) ? (1.0f / voxel_size_x_) : 0.0f;
-  const float inverse_voxel_size_y = (voxel_size_y_ > 0) ? (1.0f / voxel_size_y_) : 0.0f;
-  const float inverse_voxel_size_z = (voxel_size_z_ > 0) ? (1.0f / voxel_size_z_) : 0.0f;
+  constexpr float max_inverse = 20000.0f;
+  const float inverse_voxel_size_x = (voxel_size_x_ > 0.0f) ? (1.0f / voxel_size_x_) : max_inverse;
+  const float inverse_voxel_size_y = (voxel_size_y_ > 0.0f) ? (1.0f / voxel_size_y_) : max_inverse;
+  const float inverse_voxel_size_z = (voxel_size_z_ > 0.0f) ? (1.0f / voxel_size_z_) : max_inverse;
 
-  if (voxel_size_x_ <= 0 || voxel_size_y_ <= 0 || voxel_size_z_ <= 0) {
-    RCLCPP_DEBUG(
-      get_logger(), "Some voxel sizes are 0. Those axes will not be used for downsampling.");
+  if (voxel_size_x_ <= 0.0f || voxel_size_y_ <= 0.0f || voxel_size_z_ <= 0.0f) {
+      RCLCPP_ERROR_STREAM_THROTTLE(get_logger(), *get_clock(), 1000, "Some voxel sizes are 0. Those axes will not be used for downsampling.");
   }
 
   const int x_offset = input->fields[pcl::getFieldIndex(*input, "x")].offset;

--- a/sensing/autoware_pointcloud_preprocessor/src/downsample_filter/pickup_based_voxel_grid_downsample_filter_node.cpp
+++ b/sensing/autoware_pointcloud_preprocessor/src/downsample_filter/pickup_based_voxel_grid_downsample_filter_node.cpp
@@ -73,7 +73,7 @@ PickupBasedVoxelGridDownsampleFilterComponent::PickupBasedVoxelGridDownsampleFil
   voxel_size_y_ = declare_parameter<float>("voxel_size_y");
   voxel_size_z_ = declare_parameter<float>("voxel_size_z");
   if (voxel_size_x_ <= 0.0f || voxel_size_y_ <= 0.0f || voxel_size_z_ <= 0.0f) {
-    RCLCPP_ERROR("Some voxel sizes are 0. Those axes will not be used for downsampling.");
+    RCLCPP_ERROR("Invalid voxel sizes. It must be positive.");
     rclcpp::shutdown();
   }
 


### PR DESCRIPTION
## Description
Fix crash in the `PickupBasedVoxelGridDownsampleFilterComponent` when processing empty point cloud data.
Additionally, add 0 validation

This PR includes
- Added early return for empty point cloud input to prevent potential memory access violations
- Added validation for voxel size parameters that shuts down the node if invalid values (≤ 0) are detected

We have encountered the following issue:

```
1739414563.6835113 [ERROR] [component_container_mt-1]: process has died [pid 440086, exit code -8, cmd '/home/autoware/pilot-auto.xx1/install/rclcpp_components/lib/rclcpp_components/component_container_mt --ros-args -r __node:=pointcloud_container -r __ns:=/ -p use_sim_time:=False -p wheel_radius:=0.31 -p wheel_width:=0.18 -p wheel_base:=2.75 -p wheel_tread:=1.485 -p front_overhang:=0.8 -p rear_overhang:=0.85 -p left_overhang:=0.105 -p right_overhang:=0.105 -p vehicle_height:=2.5 -p max_steer_angle:=0.55'].
1739414529.4452569 [component_container_mt-1] *** Aborted at 1739414529 (unix time) try "date -d @1739414529" if you are using GNU date ***
1739414529.5767205 [component_container_mt-1] PC: @ 0x0 (unknown)
1739414529.5980802 [component_container_mt-1] @ 0x7fb3897184d6 google::(anonymous namespace)::FailureSignalHandler()
1739414529.6045580 [component_container_mt-1] @ 0x7fb388fc8520 (unknown)
1739414529.6362243 [component_container_mt-1] @ 0x7fb36c63a03f autoware::pointcloud_preprocessor::PickupBasedVoxelGridDownsampleFilterComponent::filter()
1739414529.6881993 [component_container_mt-1] @ 0x7fb35fd402f4 autoware::pointcloud_preprocessor::Filter::computePublish()
1739414529.7159038 [component_container_mt-1] @ 0x7fb35fd41986 autoware::pointcloud_preprocessor::Filter::input_indices_callback()
1739414529.7236145 [component_container_mt-1] @ 0x7fb35fd6050f std::_Function_handler<>::_M_invoke()
1739414529.7259848 [component_container_mt-1] @ 0x7fb36c58f517 _ZNSt8__detail9__variant17__gen_vtable_implINS0_12_Multi_arrayIPFNS0_21__deduce_visit_resultIvEEOZN6rclcpp23AnySubscriptionCallbackIN11sensor_msgs3msg12PointCloud2_ISaIvEEESA_E22dispatch_intra_processESt10shared_ptrIKSB_ERKNS5_11MessageInfoEEUlOT_E_RSt7variantIJSt8functionIFvRSE_EESO_IFvSP_SI_EESO_IFvRKNS5_17SerializedMessageEEESO_IFvSW_SI_EESO_IFvSt10unique_ptrISB_St14default_deleteISB_EEEESO_IFvS14_SI_EESO_IFvS11_ISU_S12_ISU_EEEESO_IFvS1A_SI_EESO_IFvSF_EESO_IFvSF_SI_EESO_IFvSD_ISV_EEESO_IFvS1J_SI_EESO_IFvRKSF_EESO_IFvS1P_SI_EESO_IFvRKS1J_EESO_IFvS1V_SI_EESO_IFvSD_ISB_EEESO_IFvS20_SI_EESO_IFvSD_ISU_EEESO_IFvS25_SI_EEEEEJEEESt16integer_sequenceImJLm8EEEE14__visit_invokeESM_S2B_
1739414529.7283673 [component_container_mt-1] @ 0x7fb36c5bf465 rclcpp::experimental::SubscriptionIntraProcess<>::execute_impl<>()
1739414529.7308292 [component_container_mt-1] @ 0x7fb3895962c3 rclcpp::Executor::execute_any_executable()
1739414529.7646403 [component_container_mt-1] @ 0x7fb38959c432 rclcpp::executors::MultiThreadedExecutor::run()
1739414529.7795293 [component_container_mt-1] @ 0x7fb3892ab253 (unknown)
1739414529.7867830 [component_container_mt-1] @ 0x7fb38901aac3 (unknown)
1739414529.7937720 [component_container_mt-1] @ 0x7fb3890ac850 (unknown)
```

## Related links

**Parent Issue:**

<!-- ⬇️🟢

- [CompanyName internal link]()
⬆️🟢 -->

- [Internal link where identified the issue](https://star4.slack.com/archives/CEV8XMJBV/p1739414796679059?thread_ts=1739350767.269239&cid=CEV8XMJBV)

## How was this PR tested?

Tested on the robo taxi.

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
