### PR TITLE
feat(mkdocs.yaml): update the separator characters

### DIFF
--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -63,7 +63,9 @@ plugins:
       module_name: mkdocs_macros
   - mkdocs-video
   - same-dir
-  - search
+# https://squidfunk.github.io/mkdocs-material/plugins/search/#config.separator
+  - search:
+      separator: '[\s\-_,:!=\[\]()"/]+|(?!\b)(?=[A-Z][a-z])|\.(?!\d)|&[lg]t;'
 
 markdown_extensions:
   - abbr

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -63,7 +63,7 @@ plugins:
       module_name: mkdocs_macros
   - mkdocs-video
   - same-dir
-# https://squidfunk.github.io/mkdocs-material/plugins/search/#config.separator
+  # https://squidfunk.github.io/mkdocs-material/plugins/search/#config.separator
   - search:
       separator: '[\s\-_,:!=\[\]()"/]+|(?!\b)(?=[A-Z][a-z])|\.(?!\d)|&[lg]t;'
 


### PR DESCRIPTION
## Description

**Resolves:**
- https://github.com/autowarefoundation/autoware.universe/issues/10126

**Co-PR:**
- https://github.com/autowarefoundation/sync-file-templates/pull/30

Related:
- [Prefix packages with autoware_ #4097](https://github.com/orgs/autowarefoundation/discussions/4097#discussioncomment-10260260)
- https://squidfunk.github.io/mkdocs-material/plugins/search/#config.separator

## How was this PR tested?

Follow: https://autowarefoundation.github.io/autoware-documentation/main/contributing/documentation-guidelines/#2-running-an-mkdocs-server-in-your-local-environment

1. `cd`  into autoware.universe folder
2. `python3 -m pip install -U $(curl -fsSL https://raw.githubusercontent.com/autowarefoundation/autoware-github-actions/main/deploy-docs/mkdocs-requirements.txt)`
3. `mkdocs serve`

### Before

![image](https://github.com/user-attachments/assets/a829d5bc-5a2b-441e-9dd2-a4e54ac2a156)

### After

![image](https://github.com/user-attachments/assets/4662d112-1824-4b03-b6de-e1b420c15595)

## Notes for reviewers

I will also update the origin of this file from sync-files. But please merge this first.

## Interface changes

None.

## Effects on system behavior

None.
