### PR TITLE
chore(traffic_light_multi_camera_fusion): read parameters from yaml file

### DIFF
--- a/launch/tier4_perception_launch/launch/perception.launch.xml
+++ b/launch/tier4_perception_launch/launch/perception.launch.xml
@@ -35,6 +35,7 @@
   <arg name="occupancy_grid_map_updater"/>
   <arg name="occupancy_grid_map_updater_param_path"/>
   <arg name="traffic_light_arbiter_param_path"/>
+  <arg name="traffic_light_multi_camera_fusion_param_path"/>
   <arg name="lidar_detection_model"/>
 
   <!-- ML model parameters -->
@@ -310,6 +311,7 @@
         <arg name="fusion_only" value="$(var traffic_light_recognition/fusion_only)"/>
         <arg name="all_camera_namespaces" value="$(var all_traffic_light_camera)"/>
         <arg name="traffic_light_arbiter_param_path" value="$(var traffic_light_arbiter_param_path)"/>
+        <arg name="traffic_light_multi_camera_fusion_param_path" value="$(var traffic_light_multi_camera_fusion_param_path)"/>
         <arg name="traffic_light_fine_detector_model_path" value="$(var traffic_light_fine_detector_model_path)"/>
         <arg name="traffic_light_fine_detector_model_name" value="$(var traffic_light_fine_detector_model_name)"/>
         <arg name="traffic_light_classifier_model_path" value="$(var traffic_light_classifier_model_path)"/>

--- a/launch/tier4_perception_launch/launch/traffic_light_recognition/traffic_light.launch.xml
+++ b/launch/tier4_perception_launch/launch/traffic_light_recognition/traffic_light.launch.xml
@@ -58,6 +58,7 @@
   <group>
     <include file="$(find-pkg-share autoware_traffic_light_multi_camera_fusion)/launch/traffic_light_multi_camera_fusion.launch.xml">
       <arg name="param_path" value="$(var traffic_light_multi_camera_fusion_param_path)"/>
+      <arg name="all_camera_namespaces" value="$(var all_camera_namespaces)"/>
       <arg name="input/vector_map" value="/map/vector_map"/>
       <arg name="output/traffic_signals" value="$(var internal/traffic_signals)"/>
     </include>

--- a/launch/tier4_perception_launch/launch/traffic_light_recognition/traffic_light.launch.xml
+++ b/launch/tier4_perception_launch/launch/traffic_light_recognition/traffic_light.launch.xml
@@ -56,13 +56,11 @@
 
   <!-- traffic_light_multi_camera_fusion -->
   <group>
-    <node pkg="autoware_traffic_light_multi_camera_fusion" exec="traffic_light_multi_camera_fusion_node" name="traffic_light_multi_camera_fusion" output="screen">
-      <param name="camera_namespaces" value="$(var all_camera_namespaces)"/>
-      <param name="message_lifespan" value="0.09"/>
-      <param name="approximate_sync" value="false"/>
-      <remap from="~/input/vector_map" to="/map/vector_map"/>
-      <remap from="~/output/traffic_signals" to="$(var internal/traffic_signals)"/>
-    </node>
+    <include file="$(find-pkg-share autoware_traffic_light_multi_camera_fusion)/launch/traffic_light_multi_camera_fusion.launch.xml">
+        <arg name="param_path" value="$(var traffic_light_multi_camera_fusion_param_path)"/>
+        <arg name="input/vector_map" value="/map/vector_map"/>
+        <arg name="output/traffic_signals" value="$(var internal/traffic_signals)"/>
+    </include>
   </group>
 
   <!-- V2X fusion -->

--- a/launch/tier4_perception_launch/launch/traffic_light_recognition/traffic_light.launch.xml
+++ b/launch/tier4_perception_launch/launch/traffic_light_recognition/traffic_light.launch.xml
@@ -57,8 +57,8 @@
   <!-- traffic_light_multi_camera_fusion -->
   <group>
     <include file="$(find-pkg-share autoware_traffic_light_multi_camera_fusion)/launch/traffic_light_multi_camera_fusion.launch.xml">
+      <arg name="camera_namespaces" value="$(var all_camera_namespaces)"/>
       <arg name="param_path" value="$(var traffic_light_multi_camera_fusion_param_path)"/>
-      <arg name="all_camera_namespaces" value="$(var all_camera_namespaces)"/>
       <arg name="input/vector_map" value="/map/vector_map"/>
       <arg name="output/traffic_signals" value="$(var internal/traffic_signals)"/>
     </include>

--- a/launch/tier4_perception_launch/launch/traffic_light_recognition/traffic_light.launch.xml
+++ b/launch/tier4_perception_launch/launch/traffic_light_recognition/traffic_light.launch.xml
@@ -57,9 +57,9 @@
   <!-- traffic_light_multi_camera_fusion -->
   <group>
     <include file="$(find-pkg-share autoware_traffic_light_multi_camera_fusion)/launch/traffic_light_multi_camera_fusion.launch.xml">
-        <arg name="param_path" value="$(var traffic_light_multi_camera_fusion_param_path)"/>
-        <arg name="input/vector_map" value="/map/vector_map"/>
-        <arg name="output/traffic_signals" value="$(var internal/traffic_signals)"/>
+      <arg name="param_path" value="$(var traffic_light_multi_camera_fusion_param_path)"/>
+      <arg name="input/vector_map" value="/map/vector_map"/>
+      <arg name="output/traffic_signals" value="$(var internal/traffic_signals)"/>
     </include>
   </group>
 

--- a/perception/autoware_traffic_light_multi_camera_fusion/config/traffic_light_multi_camera_fusion.param.yaml
+++ b/perception/autoware_traffic_light_multi_camera_fusion/config/traffic_light_multi_camera_fusion.param.yaml
@@ -1,5 +1,4 @@
 /**:
   ros__parameters:
-    camera_namespaces: $(var all_traffic_light_camera)
     message_lifespan: 0.09
     approximate_sync: false

--- a/perception/autoware_traffic_light_multi_camera_fusion/config/traffic_light_multi_camera_fusion.param.yaml
+++ b/perception/autoware_traffic_light_multi_camera_fusion/config/traffic_light_multi_camera_fusion.param.yaml
@@ -1,5 +1,5 @@
 /**:
   ros__parameters:
-    camera_namespaces: ["camera6", "camera7"]
+    camera_namespaces: $(var all_traffic_light_camera)
     message_lifespan: 0.09
     approximate_sync: false

--- a/perception/autoware_traffic_light_multi_camera_fusion/launch/traffic_light_multi_camera_fusion.launch.xml
+++ b/perception/autoware_traffic_light_multi_camera_fusion/launch/traffic_light_multi_camera_fusion.launch.xml
@@ -3,12 +3,12 @@
   <arg name="input/vector_map" default="/map/vector_map"/>
   <arg name="param_path" default="$(find-pkg-share autoware_traffic_light_multi_camera_fusion)/config/traffic_light_multi_camera_fusion.param.yaml"/>
   <arg name="output/traffic_signals" default="/perception/traffic_light_recognition/traffic_signals"/>
-  <arg name="all_camera_namespaces" default="[camera6, camera7]"/>
+  <arg name="camera_namespaces" default="[camera6, camera7]"/>
 
   <node pkg="autoware_traffic_light_multi_camera_fusion" exec="traffic_light_multi_camera_fusion_node" name="traffic_light_multi_camera_fusion" output="screen">
     <remap from="~/input/vector_map" to="$(var input/vector_map)"/>
     <remap from="~/output/traffic_signals" to="$(var output/traffic_signals)"/>
     <param from="$(var param_path)"/>
-    <param name="camera_namespaces" value="$(var all_camera_namespaces)"/>
+    <param name="camera_namespaces" value="$(var camera_namespaces)"/>
   </node>
 </launch>

--- a/perception/autoware_traffic_light_multi_camera_fusion/launch/traffic_light_multi_camera_fusion.launch.xml
+++ b/perception/autoware_traffic_light_multi_camera_fusion/launch/traffic_light_multi_camera_fusion.launch.xml
@@ -3,11 +3,12 @@
   <arg name="input/vector_map" default="/map/vector_map"/>
   <arg name="param_path" default="$(find-pkg-share autoware_traffic_light_multi_camera_fusion)/config/traffic_light_multi_camera_fusion.param.yaml"/>
   <arg name="output/traffic_signals" default="/perception/traffic_light_recognition/traffic_signals"/>
-  <arg name="all_traffic_light_camera" default="[camera6, camera7]"/>
+  <arg name="all_camera_namespaces" default="[camera6, camera7]"/>
 
   <node pkg="autoware_traffic_light_multi_camera_fusion" exec="traffic_light_multi_camera_fusion_node" name="traffic_light_multi_camera_fusion" output="screen">
     <remap from="~/input/vector_map" to="$(var input/vector_map)"/>
     <remap from="~/output/traffic_signals" to="$(var output/traffic_signals)"/>
-    <param from="$(var param_path)" allow_substs="true"/>
+    <param from="$(var param_path)"/>
+    <param name="camera_namespaces" value="$(var all_camera_namespaces)"/>
   </node>
 </launch>

--- a/perception/autoware_traffic_light_multi_camera_fusion/launch/traffic_light_multi_camera_fusion.launch.xml
+++ b/perception/autoware_traffic_light_multi_camera_fusion/launch/traffic_light_multi_camera_fusion.launch.xml
@@ -7,6 +7,6 @@
   <node pkg="autoware_traffic_light_multi_camera_fusion" exec="traffic_light_multi_camera_fusion_node" name="traffic_light_multi_camera_fusion" output="screen">
     <remap from="~/input/vector_map" to="$(var input/vector_map)"/>
     <remap from="~/output/traffic_signals" to="$(var output/traffic_signals)"/>
-    <param from="$(var param_path)"/>
+    <param from="$(var param_path)" allow_substs="true"/>
   </node>
 </launch>

--- a/perception/autoware_traffic_light_multi_camera_fusion/launch/traffic_light_multi_camera_fusion.launch.xml
+++ b/perception/autoware_traffic_light_multi_camera_fusion/launch/traffic_light_multi_camera_fusion.launch.xml
@@ -3,6 +3,7 @@
   <arg name="input/vector_map" default="/map/vector_map"/>
   <arg name="param_path" default="$(find-pkg-share autoware_traffic_light_multi_camera_fusion)/config/traffic_light_multi_camera_fusion.param.yaml"/>
   <arg name="output/traffic_signals" default="/perception/traffic_light_recognition/traffic_signals"/>
+  <arg name="all_traffic_light_camera" default="[camera6, camera7]"/>
 
   <node pkg="autoware_traffic_light_multi_camera_fusion" exec="traffic_light_multi_camera_fusion_node" name="traffic_light_multi_camera_fusion" output="screen">
     <remap from="~/input/vector_map" to="$(var input/vector_map)"/>

--- a/perception/autoware_traffic_light_multi_camera_fusion/schema/traffic_light_multi_camera_fusion.schema.json
+++ b/perception/autoware_traffic_light_multi_camera_fusion/schema/traffic_light_multi_camera_fusion.schema.json
@@ -7,12 +7,9 @@
       "type": "object",
       "properties": {
         "camera_namespaces": {
-          "type": "array",
+          "type": "string",
           "description": "Camera namespaces to be fused.",
-          "items": {
-            "type": "string"
-          },
-          "default": []
+          "default": "[]"
         },
         "message_lifespan": {
           "type": "number",

--- a/perception/autoware_traffic_light_multi_camera_fusion/schema/traffic_light_multi_camera_fusion.schema.json
+++ b/perception/autoware_traffic_light_multi_camera_fusion/schema/traffic_light_multi_camera_fusion.schema.json
@@ -6,11 +6,6 @@
     "autoware_traffic_light_multi_camera_fusion": {
       "type": "object",
       "properties": {
-        "camera_namespaces": {
-          "type": "string",
-          "description": "Camera namespaces to be fused.",
-          "default": "[]"
-        },
         "message_lifespan": {
           "type": "number",
           "description": "The maximum timestamp span to be fused.",

--- a/perception/autoware_traffic_light_multi_camera_fusion/schema/traffic_light_multi_camera_fusion.schema.json
+++ b/perception/autoware_traffic_light_multi_camera_fusion/schema/traffic_light_multi_camera_fusion.schema.json
@@ -17,7 +17,7 @@
           "default": false
         }
       },
-      "required": ["camera_namespaces", "message_lifespan", "approximate_sync"],
+      "required": ["message_lifespan", "approximate_sync"],
       "additionalProperties": false
     }
   },


### PR DESCRIPTION
## Description
PR for launcher: https://github.com/autowarefoundation/autoware_launch/pull/1331

Currently, the parameters for `traffic_light_multi_camera_fusion` are [hardcoded in the launch file](https://github.com/autowarefoundation/autoware.universe/blob/b4d9155fbe78aaf35f976af808b2ca62d1727d1f/launch/tier4_perception_launch/launch/traffic_light_recognition/traffic_light.launch.xml#L61-L62), preventing modifications from the launch file.
To resolve this issue, I modified it to read parameters from a YAML file in `autoware_launch`.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
I modified the parameters in  like this,

**tier4_perception_component.launch.xml**
```xml
  <arg name="all_traffic_light_camera" default="[camera4, camera5, camera6, camera7]" description="choose camera which use for traffic light recognition"/>
```

**traffic_light_multi_camera_fusion.param.yaml**
```yaml
/**:
  ros__parameters:
    message_lifespan: 0.2
    approximate_sync: false
```

and I confirmed parameters are properly passed when I launched logging_simulator.launch.xml.

```shell
$ ros2 param dump /perception/traffic_light_recognition/traffic_light_multi_camera_fusion
/perception/traffic_light_recognition/traffic_light_multi_camera_fusion:
  ros__parameters:
    approximate_sync: false
    camera_namespaces:
    - camera4
    - camera5
    - camera6
    - camera7
    message_lifespan: 0.2
    qos_overrides:
      /clock:
        subscription:
          depth: 1
          durability: volatile
          history: keep_last
          reliability: best_effort
      /parameter_events:
        publisher:
          depth: 1000
          durability: volatile
          history: keep_last
          reliability: reliable
    use_sim_time: true
```


## Notes for reviewers
The default values in the parameter file is the same as the one in `autoware.universe`.
https://github.com/TomohitoAndo/autoware.universe/blob/614ac8e762e644aec1b1d2b74b87755c27f1a453/perception/autoware_traffic_light_multi_camera_fusion/config/traffic_light_multi_camera_fusion.param.yaml


## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
