### PR TITLE
ci(build-depends.repos): separate repos for humble and nightly

### DIFF
--- a/.github/actions/combine-repos-action/README.md
+++ b/.github/actions/combine-repos-action/README.md
@@ -1,0 +1,43 @@
+# combine-repos-action
+
+## Description
+
+**Combine Repos Action** is a GitHub Action designed to merge two `.repos` files—a base file and an overlay file—into a single file. The overlay file takes precedence over the base file when duplicate repository entries exist. This is especially useful for projects that need to dynamically combine configuration files for dependency management or CI workflows.
+
+## Usage
+
+Below is an example of how to include it in your workflow:
+
+```yaml
+jobs:
+  combine:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Combine Repos Files
+        uses: ./.github/actions/combine-repos-action
+        with:
+          base_file: build_depends_humble.repos
+          overlay_file: build_depends_nightly.repos
+          output_file: build_depends.repos
+```
+
+In this example:
+
+- The action reads the `build_depends_humble.repos` file and the `build_depends_nightly.repos` file.
+- It merges them with overlay file taking precedence.
+- The resulting file is saved as `build_depends.repos` (or a custom filename if specified).
+
+## Inputs
+
+| Input          | Description                       | Required | Default          |
+| -------------- | --------------------------------- | -------- | ---------------- |
+| `base_file`    | Path to the base `.repos` file    | Yes      | -                |
+| `overlay_file` | Path to the overlay `.repos` file | Yes      | -                |
+| `output_file`  | Path for the combined output file | No       | `combined.repos` |
+
+## Outputs
+
+This action creates or updates the file specified by the `output_file` input with the combined contents of the two `.repos` files. The final file's content is also echoed to the workflow logs for easy verification.

--- a/.github/actions/combine-repos-action/action.yaml
+++ b/.github/actions/combine-repos-action/action.yaml
@@ -1,0 +1,48 @@
+name: Combine Repos Action
+description: Merge base and overlay .repos files, with overlay entries taking precedence.
+inputs:
+  base_file:
+    description: Path to the base .repos file
+    required: true
+  overlay_file:
+    description: Path to the overlay .repos file
+    required: true
+  output_file:
+    description: Path for the combined output file
+    required: false
+    default: combined.repos
+
+runs:
+  using: composite
+  steps:
+    - name: Install python3-pip
+      run: |
+        sudo apt-get -yqq update
+        sudo apt-get -yqq install python3-pip python-is-python3
+      shell: bash
+
+    - name: Display Python version
+      run: |
+        python --version
+        which pip
+        pip --version
+      shell: bash
+
+    - name: Install PyYAML dependency
+      run: pip install pyyaml
+      shell: bash
+
+    - name: Combine repos files
+      run: |
+        python "${GITHUB_ACTION_PATH}/combine-repos.py" \
+          --base "${{ inputs.base_file }}" \
+          --overlay "${{ inputs.overlay_file }}" \
+          --output "${{ inputs.output_file }}"
+      shell: bash
+
+    - name: Display combined repos file
+      run: |
+        echo "=== Combined .repos File Content ==="
+        cat "${{ inputs.output_file }}"
+        echo "===================================="
+      shell: bash

--- a/.github/actions/combine-repos-action/combine-repos.py
+++ b/.github/actions/combine-repos-action/combine-repos.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+import argparse
+import sys
+
+import yaml
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Merge base and overlay .repos files with overlay taking precedence."
+    )
+    parser.add_argument("--base", required=True, help="Path to the base .repos file")
+    parser.add_argument("--overlay", required=True, help="Path to the overlay .repos file")
+    parser.add_argument(
+        "--output",
+        default="combined.repos",
+        help="Path for the combined output file (default: combined.repos)",
+    )
+    args = parser.parse_args()
+
+    try:
+        with open(args.base, "r") as bf:
+            base_data = yaml.safe_load(bf)
+    except Exception as e:
+        sys.exit(f"Error reading base file '{args.base}': {e}")
+
+    try:
+        with open(args.overlay, "r") as of:
+            overlay_data = yaml.safe_load(of)
+    except Exception as e:
+        sys.exit(f"Error reading overlay file '{args.overlay}': {e}")
+
+    if "repositories" not in base_data:
+        sys.exit(f"Base file '{args.base}' is missing the 'repositories' key")
+    if overlay_data and "repositories" not in overlay_data:
+        sys.exit(f"Overlay file '{args.overlay}' is missing the 'repositories' key")
+
+    # Merge: overlay entries override base entries
+    merged_data = base_data.copy()
+    merged_data["repositories"].update(overlay_data.get("repositories", {}))
+
+    try:
+        with open(args.output, "w") as cf:
+            yaml.dump(merged_data, cf, default_flow_style=False)
+    except Exception as e:
+        sys.exit(f"Error writing to output file '{args.output}': {e}")
+
+    print(f"Successfully merged into {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/sync-files.yaml
+++ b/.github/sync-files.yaml
@@ -9,7 +9,6 @@
       dest: .github/pull_request_template.md
     - source: .github/stale.yml
     - source: .github/workflows/cancel-previous-workflows.yaml
-    - source: .github/workflows/check-build-depends.yaml
     - source: .github/workflows/clang-tidy-pr-comments.yaml
     - source: .github/workflows/clang-tidy-pr-comments-manually.yaml
     - source: .github/workflows/comment-on-pr.yaml

--- a/.github/workflows/build-and-test-daily-arm64.yaml
+++ b/.github/workflows/build-and-test-daily-arm64.yaml
@@ -24,7 +24,6 @@ jobs:
         include:
           - rosdistro: humble
             container: ghcr.io/autowarefoundation/autoware:universe-devel
-            build-depends-repos: build_depends.repos
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -54,13 +53,20 @@ jobs:
           echo "::notice::BUILD_TYPE_CUDA_STATE=$build_type_cuda_state"
         shell: bash
 
+      - name: Prepare build_depends.repos file
+        uses: ./.github/actions/combine-repos-action
+        with:
+          base_file: build_depends_humble.repos
+          overlay_file: build_depends_nightly.repos
+          output_file: build_depends.repos
+
       - name: Build
         if: ${{ steps.get-self-packages.outputs.self-packages != '' }}
         uses: autowarefoundation/autoware-github-actions/colcon-build@v1
         with:
           rosdistro: ${{ matrix.rosdistro }}
           target-packages: ${{ steps.get-self-packages.outputs.self-packages }}
-          build-depends-repos: ${{ matrix.build-depends-repos }}
+          build-depends-repos: build_depends.repos
           cache-key-element: ${{ env.BUILD_TYPE_CUDA_STATE }}
           build-pre-command: taskset --cpu-list 0-6
 
@@ -71,7 +77,7 @@ jobs:
         with:
           rosdistro: ${{ matrix.rosdistro }}
           target-packages: ${{ steps.get-self-packages.outputs.self-packages }}
-          build-depends-repos: ${{ matrix.build-depends-repos }}
+          build-depends-repos: build_depends.repos
 
       - name: Upload coverage to CodeCov
         if: ${{ steps.test.outputs.coverage-report-files != '' }}

--- a/.github/workflows/build-and-test-daily.yaml
+++ b/.github/workflows/build-and-test-daily.yaml
@@ -24,7 +24,6 @@ jobs:
         include:
           - rosdistro: humble
             container: ghcr.io/autowarefoundation/autoware:universe-devel
-            build-depends-repos: build_depends.repos
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -81,13 +80,20 @@ jobs:
           echo "::notice::BUILD_TYPE_CUDA_STATE=$build_type_cuda_state"
         shell: bash
 
+      - name: Prepare build_depends.repos file
+        uses: ./.github/actions/combine-repos-action
+        with:
+          base_file: build_depends_humble.repos
+          overlay_file: build_depends_nightly.repos
+          output_file: build_depends.repos
+
       - name: Build
         if: ${{ steps.get-self-packages.outputs.self-packages != '' }}
         uses: autowarefoundation/autoware-github-actions/colcon-build@v1
         with:
           rosdistro: ${{ matrix.rosdistro }}
           target-packages: ${{ steps.get-self-packages.outputs.self-packages }}
-          build-depends-repos: ${{ matrix.build-depends-repos }}
+          build-depends-repos: build_depends.repos
           cache-key-element: ${{ env.BUILD_TYPE_CUDA_STATE }}
 
       - name: Show ccache stats after build
@@ -101,7 +107,7 @@ jobs:
         with:
           rosdistro: ${{ matrix.rosdistro }}
           target-packages: ${{ steps.get-self-packages.outputs.self-packages }}
-          build-depends-repos: ${{ matrix.build-depends-repos }}
+          build-depends-repos: build_depends.repos
 
       - name: Upload coverage to CodeCov
         if: ${{ steps.test.outputs.coverage-report-files != '' }}

--- a/.github/workflows/build-and-test-differential-arm64.yaml
+++ b/.github/workflows/build-and-test-differential-arm64.yaml
@@ -34,7 +34,6 @@ jobs:
         include:
           - rosdistro: humble
             container: ghcr.io/autowarefoundation/autoware:universe-devel
-            build-depends-repos: build_depends.repos
     steps:
       - name: Set PR fetch depth
         run: echo "PR_FETCH_DEPTH=$(( ${{ github.event.pull_request.commits }} + 1 ))" >> "${GITHUB_ENV}"
@@ -68,13 +67,26 @@ jobs:
           echo "::notice::BUILD_TYPE_CUDA_STATE=$build_type_cuda_state"
         shell: bash
 
+      - name: Prepare build_depends.repos file (main branch)
+        if: ${{ github.event.pull_request.base.ref == 'main' }}
+        uses: ./.github/actions/combine-repos-action
+        with:
+          base_file: build_depends_humble.repos
+          overlay_file: build_depends_nightly.repos
+          output_file: build_depends.repos
+
+      - name: Prepare build_depends.repos file (humble branch)
+        if: ${{ github.event.pull_request.base.ref == 'humble' }}
+        run: cp build_depends_humble.repos build_depends.repos
+        shell: bash
+
       - name: Build
         if: ${{ steps.get-modified-packages.outputs.modified-packages != '' }}
         uses: autowarefoundation/autoware-github-actions/colcon-build@v1
         with:
           rosdistro: ${{ matrix.rosdistro }}
           target-packages: ${{ steps.get-modified-packages.outputs.modified-packages }}
-          build-depends-repos: ${{ matrix.build-depends-repos }}
+          build-depends-repos: build_depends.repos
           cache-key-element: ${{ env.BUILD_TYPE_CUDA_STATE }}
           build-pre-command: taskset --cpu-list 0-5
 
@@ -85,7 +97,7 @@ jobs:
         with:
           rosdistro: ${{ matrix.rosdistro }}
           target-packages: ${{ steps.get-modified-packages.outputs.modified-packages }}
-          build-depends-repos: ${{ matrix.build-depends-repos }}
+          build-depends-repos: build_depends.repos
 
       - name: Upload coverage to CodeCov
         if: ${{ steps.test.outputs.coverage-report-files != '' }}

--- a/.github/workflows/build-and-test-differential.yaml
+++ b/.github/workflows/build-and-test-differential.yaml
@@ -92,6 +92,19 @@ jobs:
           echo "::notice::BUILD_TYPE_CUDA_STATE=$build_type_cuda_state"
         shell: bash
 
+      - name: Prepare build_depends.repos file (main branch)
+        if: ${{ github.event.pull_request.base.ref == 'main' }}
+        uses: ./.github/actions/combine-repos-action
+        with:
+          base_file: build_depends_humble.repos
+          overlay_file: build_depends_nightly.repos
+          output_file: build_depends.repos
+
+      - name: Prepare build_depends.repos file (humble branch)
+        if: ${{ github.event.pull_request.base.ref == 'humble' }}
+        run: cp build_depends_humble.repos build_depends.repos
+        shell: bash
+
       - name: Build
         if: ${{ steps.get-modified-packages.outputs.modified-packages != '' }}
         uses: autowarefoundation/autoware-github-actions/colcon-build@v1

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -28,7 +28,6 @@ jobs:
         include:
           - rosdistro: humble
             container: ghcr.io/autowarefoundation/autoware:universe-devel
-            build-depends-repos: build_depends.repos
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -85,13 +84,20 @@ jobs:
           echo "::notice::BUILD_TYPE_CUDA_STATE=$build_type_cuda_state"
         shell: bash
 
+      - name: Prepare build_depends.repos file
+        uses: ./.github/actions/combine-repos-action
+        with:
+          base_file: build_depends_humble.repos
+          overlay_file: build_depends_nightly.repos
+          output_file: build_depends.repos
+
       - name: Build
         if: ${{ steps.get-self-packages.outputs.self-packages != '' }}
         uses: autowarefoundation/autoware-github-actions/colcon-build@v1
         with:
           rosdistro: ${{ matrix.rosdistro }}
           target-packages: ${{ steps.get-self-packages.outputs.self-packages }}
-          build-depends-repos: ${{ matrix.build-depends-repos }}
+          build-depends-repos: build_depends.repos
           cache-key-element: ${{ env.BUILD_TYPE_CUDA_STATE }}
           build-pre-command: taskset --cpu-list 0-5
 
@@ -115,7 +121,7 @@ jobs:
         with:
           rosdistro: ${{ matrix.rosdistro }}
           target-packages: ${{ steps.get-self-packages.outputs.self-packages }}
-          build-depends-repos: ${{ matrix.build-depends-repos }}
+          build-depends-repos: build_depends.repos
 
       - name: Upload coverage to CodeCov
         if: ${{ steps.test.outputs.coverage-report-files != '' }}

--- a/.github/workflows/check-build-depends.yaml
+++ b/.github/workflows/check-build-depends.yaml
@@ -1,7 +1,3 @@
-# This file is automatically synced from:
-# https://github.com/autowarefoundation/sync-file-templates
-# To make changes, update the source repository and follow the guidelines in its README.
-
 name: check-build-depends
 
 on:
@@ -21,7 +17,6 @@ jobs:
         include:
           - rosdistro: humble
             container: ros:humble
-            build-depends-repos: build_depends.repos
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -33,9 +28,22 @@ jobs:
         id: get-self-packages
         uses: autowarefoundation/autoware-github-actions/get-self-packages@v1
 
+      - name: Prepare build_depends.repos file (main branch)
+        if: ${{ github.event.pull_request.base.ref == 'main' }}
+        uses: ./.github/actions/combine-repos-action
+        with:
+          base_file: build_depends_humble.repos
+          overlay_file: build_depends_nightly.repos
+          output_file: build_depends.repos
+
+      - name: Prepare build_depends.repos file (humble branch)
+        if: ${{ github.event.pull_request.base.ref == 'humble' }}
+        run: cp build_depends_humble.repos build_depends.repos
+        shell: bash
+
       - name: Build
         uses: autowarefoundation/autoware-github-actions/colcon-build@v1
         with:
           rosdistro: ${{ matrix.rosdistro }}
           target-packages: ${{ steps.get-self-packages.outputs.self-packages }}
-          build-depends-repos: ${{ matrix.build-depends-repos }}
+          build-depends-repos: build_depends.repos

--- a/build_depends_humble.repos
+++ b/build_depends_humble.repos
@@ -1,10 +1,5 @@
 repositories:
   # core
-  # TODO(youtalk): Remove autoware_common when https://github.com/autowarefoundation/autoware/issues/4911 is closed
-  core/autoware_common:
-    type: git
-    url: https://github.com/autowarefoundation/autoware_common.git
-    version: remove-autoware-cmake-utils
   core/autoware_cmake:
     type: git
     url: https://github.com/autowarefoundation/autoware_cmake.git
@@ -16,11 +11,11 @@ repositories:
   core/autoware_lanelet2_extension:
     type: git
     url: https://github.com/autowarefoundation/autoware_lanelet2_extension.git
-    version: 0.6.1
+    version: 0.6.2
   core/autoware.core:
     type: git
     url: https://github.com/autowarefoundation/autoware.core.git
-    version: main
+    version: 0.2.0
   core/autoware_msgs:
     type: git
     url: https://github.com/autowarefoundation/autoware_msgs.git
@@ -42,19 +37,12 @@ repositories:
     type: git
     url: https://github.com/tier4/muSSP.git
     version: tier4/main
-  universe/external/ndt_omp:
-    type: git
-    url: https://github.com/tier4/ndt_omp.git
-    version: tier4/main
+  # Fix the version not to merge https://github.com/MORAI-Autonomous/MORAI-ROS2_morai_msgs/pull/9
   universe/external/morai_msgs:
     type: git
     url: https://github.com/MORAI-Autonomous/MORAI-ROS2_morai_msgs.git
-    version: main
+    version: e2e75fc1603a9798773e467a679edf68b448e705
   universe/external/glog:  # TODO: to use isGoogleInitialized() API in v0.6.0. Remove when the rosdep glog version is updated to v0.6.0 (already updated in Ubuntu 24.04)
     type: git
     url: https://github.com/tier4/glog.git
     version: v0.6.0_t4-ros
-  universe/external/ament_cmake: # TODO(mitsudome-r): remove when https://github.com/ament/ament_cmake/pull/448 is merged
-    type: git
-    url: https://github.com/autowarefoundation/ament_cmake.git
-    version: feat/faster_ament_libraries_deduplicate

--- a/build_depends_nightly.repos
+++ b/build_depends_nightly.repos
@@ -1,0 +1,25 @@
+# Expected usage: first import build_depends_$ROS_DISTRO.repos, then import this.
+
+repositories:
+  # core
+  core/autoware_utils:
+    type: git
+    url: https://github.com/autowarefoundation/autoware_utils.git
+    version: main
+  core/autoware.core:
+    type: git
+    url: https://github.com/autowarefoundation/autoware.core.git
+    version: main
+  core/autoware_adapi_msgs:
+    type: git
+    url: https://github.com/autowarefoundation/autoware_adapi_msgs.git
+    version: main
+  core/autoware_internal_msgs:
+    type: git
+    url: https://github.com/autowarefoundation/autoware_internal_msgs.git
+    version: main
+  # universe
+  universe/external/tier4_autoware_msgs:
+    type: git
+    url: https://github.com/tier4/tier4_autoware_msgs.git
+    version: tier4/universe


### PR DESCRIPTION
## Description

**Related Issue:**
- https://github.com/autowarefoundation/autoware/issues/5792

**Humble counterpart:**
- https://github.com/autowarefoundation/autoware.universe/pull/10146

`build_depends.repos` file is used for pulling the dependencies of this repository while building it, currently used by CI.

With the introduction of [`autoware-nightly.repos`](https://github.com/autowarefoundation/autoware/blob/cad73fb1a431937e674bfeb067a9e1dbab99840f/autoware-nightly.repos)  and pinning of the versions in [`autoware.repos`](https://github.com/autowarefoundation/autoware/blob/cad73fb1a431937e674bfeb067a9e1dbab99840f/autoware.repos), the management of this file became a bit complicated.

This repository has 2 branches: `main` and `humble`. This PR introduces the following configuration for both these:

### PRs against `main` branch & CI that operates on `main`

They should utilize `build_depends_humble.repos` that is overridden by `build_depends_nightly.repos`.

To simplify this, I've added a new action that will overlay one `.repos` file onto another.

Using this new `combine-repos-action` these CI workflows now use the overlaid `.repos` file.

The reason for not having 2 `.build_depends.repos` files with some duplicate information and going with override option is to simplify version maintenance.

### PRs against `humble` branch

These utilize `build_depends_humble.repos` as it is. The condition for this case is only triggered by `*-differential` workflows.

## How was this PR tested?

- **build-and-test-daily:** https://github.com/autowarefoundation/autoware.universe/actions/runs/13384761188
- **check-build-depends:** https://github.com/autowarefoundation/autoware.universe/actions/runs/13384698882/job/37379204369?pr=10148
