### PR TITLE
chore(autoware_map_projection_loader): show map error details

### DIFF
--- a/map/autoware_map_projection_loader/src/load_info_from_lanelet2_map.cpp
+++ b/map/autoware_map_projection_loader/src/load_info_from_lanelet2_map.cpp
@@ -21,6 +21,7 @@
 #include <lanelet2_io/Io.h>
 #include <lanelet2_projection/UTM.h>
 
+#include <sstream>
 #include <string>
 
 namespace autoware::map_projection_loader
@@ -31,11 +32,12 @@ autoware_map_msgs::msg::MapProjectorInfo load_info_from_lanelet2_map(const std::
   lanelet::projection::MGRSProjector projector{};
   const lanelet::LaneletMapPtr map = lanelet::load(filename, projector, &errors);
   if (!errors.empty()) {
-    std::string error_message = "Error occurred while loading lanelet2 map:\n";
+    std::stringstream ss;
+    ss << "Error occurred while loading lanelet2 map:\n";
     for (const auto & err : errors) {
-      error_message += "- " + err + "\n";
+      ss << "- " << err << "\n";
     }
-    throw std::runtime_error(error_message);
+    throw std::runtime_error(ss.str());
   }
 
   // If the lat & lon values in all the points of lanelet2 map are all zeros,

--- a/map/autoware_map_projection_loader/src/load_info_from_lanelet2_map.cpp
+++ b/map/autoware_map_projection_loader/src/load_info_from_lanelet2_map.cpp
@@ -31,7 +31,11 @@ autoware_map_msgs::msg::MapProjectorInfo load_info_from_lanelet2_map(const std::
   lanelet::projection::MGRSProjector projector{};
   const lanelet::LaneletMapPtr map = lanelet::load(filename, projector, &errors);
   if (!errors.empty()) {
-    throw std::runtime_error("Error occurred while loading lanelet2 map");
+    std::string error_message = "Error occurred while loading lanelet2 map:\n";
+    for (const auto & err : errors) {
+      error_message += "- " + err + "\n";
+    }
+    throw std::runtime_error(error_message);
   }
 
   // If the lat & lon values in all the points of lanelet2 map are all zeros,


### PR DESCRIPTION
## Description

Previously, when autoware_map_projection_loader failed to load a map file, it did not show the details of the error. In this PR I have added the codes to show the errors.

## Related links


<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
