### PR TITLE
feat: replace autoware_universe_utils with autoware_utils in autoware_route_handler

### DIFF
--- a/planning/autoware_route_handler/package.xml
+++ b/planning/autoware_route_handler/package.xml
@@ -27,7 +27,7 @@
   <depend>autoware_map_msgs</depend>
   <depend>autoware_planning_msgs</depend>
   <depend>autoware_test_utils</depend>
-  <depend>autoware_universe_utils</depend>
+  <depend>autoware_utils</depend>
   <depend>geometry_msgs</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>

--- a/planning/autoware_route_handler/src/route_handler.cpp
+++ b/planning/autoware_route_handler/src/route_handler.cpp
@@ -14,12 +14,12 @@
 
 #include "autoware/route_handler/route_handler.hpp"
 
-#include <autoware_utils/geometry/geometry.hpp>
 #include <autoware_lanelet2_extension/io/autoware_osm_parser.hpp>
 #include <autoware_lanelet2_extension/utility/message_conversion.hpp>
 #include <autoware_lanelet2_extension/utility/query.hpp>
 #include <autoware_lanelet2_extension/utility/route_checker.hpp>
 #include <autoware_lanelet2_extension/utility/utilities.hpp>
+#include <autoware_utils/geometry/geometry.hpp>
 #include <autoware_utils/math/normalization.hpp>
 #include <rclcpp/rclcpp.hpp>
 
@@ -50,12 +50,12 @@ namespace autoware::route_handler
 {
 namespace
 {
-using autoware_utils::create_point;
-using autoware_utils::create_quaternion_from_yaw;
 using autoware_internal_planning_msgs::msg::PathPointWithLaneId;
 using autoware_internal_planning_msgs::msg::PathWithLaneId;
 using autoware_planning_msgs::msg::LaneletPrimitive;
 using autoware_planning_msgs::msg::Path;
+using autoware_utils::create_point;
+using autoware_utils::create_quaternion_from_yaw;
 using geometry_msgs::msg::Pose;
 using lanelet::utils::to2D;
 
@@ -114,9 +114,7 @@ PathWithLaneId removeOverlappingPoints(const PathWithLaneId & input_path)
     }
 
     constexpr double min_dist = 0.001;
-    if (
-      autoware_utils::calc_distance3d(filtered_path.points.back().point, pt.point) <
-      min_dist) {
+    if (autoware_utils::calc_distance3d(filtered_path.points.back().point, pt.point) < min_dist) {
       filtered_path.points.back().lane_ids.push_back(pt.lane_ids.front());
       filtered_path.points.back().point.longitudinal_velocity_mps = std::min(
         pt.point.longitudinal_velocity_mps,

--- a/planning/autoware_route_handler/src/route_handler.cpp
+++ b/planning/autoware_route_handler/src/route_handler.cpp
@@ -14,7 +14,7 @@
 
 #include "autoware/route_handler/route_handler.hpp"
 
-#include <autoware/universe_utils/geometry/geometry.hpp>
+#include <autoware_utils/geometry/geometry.hpp>
 #include <autoware_lanelet2_extension/io/autoware_osm_parser.hpp>
 #include <autoware_lanelet2_extension/utility/message_conversion.hpp>
 #include <autoware_lanelet2_extension/utility/query.hpp>
@@ -50,8 +50,8 @@ namespace autoware::route_handler
 {
 namespace
 {
-using autoware::universe_utils::createPoint;
-using autoware::universe_utils::createQuaternionFromYaw;
+using autoware_utils::create_point;
+using autoware_utils::create_quaternion_from_yaw;
 using autoware_internal_planning_msgs::msg::PathPointWithLaneId;
 using autoware_internal_planning_msgs::msg::PathWithLaneId;
 using autoware_planning_msgs::msg::LaneletPrimitive;
@@ -115,7 +115,7 @@ PathWithLaneId removeOverlappingPoints(const PathWithLaneId & input_path)
 
     constexpr double min_dist = 0.001;
     if (
-      autoware::universe_utils::calcDistance3d(filtered_path.points.back().point, pt.point) <
+      autoware_utils::calc_distance3d(filtered_path.points.back().point, pt.point) <
       min_dist) {
       filtered_path.points.back().lane_ids.push_back(pt.lane_ids.front());
       filtered_path.points.back().point.longitudinal_velocity_mps = std::min(
@@ -1642,14 +1642,14 @@ PathWithLaneId RouteHandler::getCenterLinePath(
     double angle{0.0};
     const auto & pts = reference_path.points;
     if (i + 1 < reference_path.points.size()) {
-      angle = autoware::universe_utils::calcAzimuthAngle(
+      angle = autoware_utils::calc_azimuth_angle(
         pts.at(i).point.pose.position, pts.at(i + 1).point.pose.position);
     } else if (i != 0) {
-      angle = autoware::universe_utils::calcAzimuthAngle(
+      angle = autoware_utils::calc_azimuth_angle(
         pts.at(i - 1).point.pose.position, pts.at(i).point.pose.position);
     }
     reference_path.points.at(i).point.pose.orientation =
-      autoware::universe_utils::createQuaternionFromYaw(angle);
+      autoware_utils::create_quaternion_from_yaw(angle);
   }
 
   return reference_path;
@@ -2104,8 +2104,8 @@ Pose RouteHandler::get_pose_from_2d_arc_length(
         const auto interpolated_pt = pt.basicPoint() * (1 - ratio) + next_pt.basicPoint() * ratio;
         const auto yaw = std::atan2(next_pt.y() - pt.y(), next_pt.x() - pt.x());
         Pose pose;
-        pose.position = createPoint(interpolated_pt.x(), interpolated_pt.y(), interpolated_pt.z());
-        pose.orientation = createQuaternionFromYaw(yaw);
+        pose.position = create_point(interpolated_pt.x(), interpolated_pt.y(), interpolated_pt.z());
+        pose.orientation = create_quaternion_from_yaw(yaw);
         return pose;
       }
       accumulated_distance2d += distance2d;

--- a/planning/autoware_route_handler/test/test_route_handler.cpp
+++ b/planning/autoware_route_handler/test/test_route_handler.cpp
@@ -14,7 +14,7 @@
 
 #include "test_route_handler.hpp"
 
-#include "autoware/universe_utils/geometry/geometry.hpp"
+#include "autoware_utils/geometry/geometry.hpp"
 
 #include <rclcpp/rclcpp.hpp>
 
@@ -54,10 +54,10 @@ TEST_F(TestRouteHandler, getLaneletSequenceWhenOverlappingRoute)
 
   geometry_msgs::msg::Pose start_pose;
   geometry_msgs::msg::Pose goal_pose;
-  start_pose.position = autoware::universe_utils::createPoint(3728.870361, 73739.281250, 0);
-  start_pose.orientation = autoware::universe_utils::createQuaternion(0, 0, -0.513117, 0.858319);
-  goal_pose.position = autoware::universe_utils::createPoint(3729.961182, 73727.328125, 0);
-  goal_pose.orientation = autoware::universe_utils::createQuaternion(0, 0, 0.234831, 0.972036);
+  start_pose.position = autoware_utils::create_point(3728.870361, 73739.281250, 0);
+  start_pose.orientation = autoware_utils::create_quaternion(0, 0, -0.513117, 0.858319);
+  goal_pose.position = autoware_utils::create_point(3729.961182, 73727.328125, 0);
+  goal_pose.orientation = autoware_utils::create_quaternion(0, 0, 0.234831, 0.972036);
 
   lanelet::ConstLanelets path_lanelets;
   ASSERT_TRUE(
@@ -88,17 +88,17 @@ TEST_F(TestRouteHandler, getClosestRouteLaneletFromLaneletWhenOverlappingRoute)
   geometry_msgs::msg::Pose search_pose;
 
   lanelet::ConstLanelet reference_lanelet;
-  reference_pose.position = autoware::universe_utils::createPoint(3730.88, 73735.3, 0);
+  reference_pose.position = autoware_utils::create_point(3730.88, 73735.3, 0);
   reference_pose.orientation =
-    autoware::universe_utils::createQuaternion(0, 0, -0.504626, 0.863338);
+    autoware_utils::create_quaternion(0, 0, -0.504626, 0.863338);
   const auto found_reference_lanelet =
     route_handler_->getClosestLaneletWithinRoute(reference_pose, &reference_lanelet);
   ASSERT_TRUE(found_reference_lanelet);
   ASSERT_EQ(reference_lanelet.id(), 168);
 
   lanelet::ConstLanelet closest_lanelet;
-  search_pose.position = autoware::universe_utils::createPoint(3736.89, 73730.8, 0);
-  search_pose.orientation = autoware::universe_utils::createQuaternion(0, 0, 0.223244, 0.974763);
+  search_pose.position = autoware_utils::create_point(3736.89, 73730.8, 0);
+  search_pose.orientation = autoware_utils::create_quaternion(0, 0, 0.223244, 0.974763);
   bool found_lanelet = route_handler_->getClosestLaneletWithinRoute(search_pose, &closest_lanelet);
   ASSERT_TRUE(found_lanelet);
   ASSERT_EQ(closest_lanelet.id(), 345);

--- a/planning/autoware_route_handler/test/test_route_handler.cpp
+++ b/planning/autoware_route_handler/test/test_route_handler.cpp
@@ -89,8 +89,7 @@ TEST_F(TestRouteHandler, getClosestRouteLaneletFromLaneletWhenOverlappingRoute)
 
   lanelet::ConstLanelet reference_lanelet;
   reference_pose.position = autoware_utils::create_point(3730.88, 73735.3, 0);
-  reference_pose.orientation =
-    autoware_utils::create_quaternion(0, 0, -0.504626, 0.863338);
+  reference_pose.orientation = autoware_utils::create_quaternion(0, 0, -0.504626, 0.863338);
   const auto found_reference_lanelet =
     route_handler_->getClosestLaneletWithinRoute(reference_pose, &reference_lanelet);
   ASSERT_TRUE(found_reference_lanelet);


### PR DESCRIPTION
## Description
This PR replace autoware_universe_utils with autoware_utils in autoware_route_handler as a preparation for porting to Autoware Core.

## Related links

**Parent Issue:**

- https://github.com/autowarefoundation/autoware.core/issues/190

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
https://evaluation.ci.tier4.jp/evaluation/reports/66ed5349-c25c-5022-b15f-103d0d026273?project_id=prd_jt

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
