### PR TITLE
feat(autoware_behavior_velocity_planner_common): replace autoware_universe_utils with autoware_utils

### DIFF
--- a/planning/autoware_velocity_smoother/include/autoware/velocity_smoother/node.hpp
+++ b/planning/autoware_velocity_smoother/include/autoware/velocity_smoother/node.hpp
@@ -61,10 +61,10 @@ namespace autoware::velocity_smoother
 using autoware_planning_msgs::msg::Trajectory;
 using autoware_planning_msgs::msg::TrajectoryPoint;
 using TrajectoryPoints = std::vector<TrajectoryPoint>;
-using autoware_utils::DiagnosticsInterface;
 using autoware_adapi_v1_msgs::msg::OperationModeState;
 using autoware_internal_debug_msgs::msg::Float32Stamped;
 using autoware_internal_debug_msgs::msg::Float64Stamped;
+using autoware_utils::DiagnosticsInterface;
 using geometry_msgs::msg::AccelWithCovarianceStamped;
 using geometry_msgs::msg::Pose;
 using geometry_msgs::msg::PoseStamped;
@@ -270,8 +270,7 @@ private:
   rclcpp::Publisher<Float32Stamped>::SharedPtr debug_closest_jerk_;
   rclcpp::Publisher<Float64Stamped>::SharedPtr debug_calculation_time_;
   rclcpp::Publisher<Float32Stamped>::SharedPtr debug_closest_max_velocity_;
-  rclcpp::Publisher<autoware_utils::ProcessingTimeDetail>::SharedPtr
-    debug_processing_time_detail_;
+  rclcpp::Publisher<autoware_utils::ProcessingTimeDetail>::SharedPtr debug_processing_time_detail_;
 
   // For Jerk Filtered Algorithm Debug
   rclcpp::Publisher<Trajectory>::SharedPtr pub_forward_filtered_trajectory_;

--- a/planning/autoware_velocity_smoother/include/autoware/velocity_smoother/node.hpp
+++ b/planning/autoware_velocity_smoother/include/autoware/velocity_smoother/node.hpp
@@ -18,14 +18,6 @@
 #include "autoware/motion_utils/trajectory/conversion.hpp"
 #include "autoware/motion_utils/trajectory/trajectory.hpp"
 #include "autoware/osqp_interface/osqp_interface.hpp"
-#include "autoware/universe_utils/geometry/geometry.hpp"
-#include "autoware/universe_utils/math/unit_conversion.hpp"
-#include "autoware/universe_utils/ros/diagnostics_interface.hpp"
-#include "autoware/universe_utils/ros/logger_level_configure.hpp"
-#include "autoware/universe_utils/ros/polling_subscriber.hpp"
-#include "autoware/universe_utils/ros/self_pose_listener.hpp"
-#include "autoware/universe_utils/system/stop_watch.hpp"
-#include "autoware/universe_utils/system/time_keeper.hpp"
 #include "autoware/velocity_smoother/resample.hpp"
 #include "autoware/velocity_smoother/smoother/analytical_jerk_constrained_smoother/analytical_jerk_constrained_smoother.hpp"
 #include "autoware/velocity_smoother/smoother/jerk_filtered_smoother.hpp"
@@ -37,7 +29,15 @@
 #include "tf2/utils.h"
 #include "tf2_ros/transform_listener.h"
 
-#include <autoware/universe_utils/ros/published_time_publisher.hpp>
+#include <autoware_utils/geometry/geometry.hpp>
+#include <autoware_utils/math/unit_conversion.hpp>
+#include <autoware_utils/ros/diagnostics_interface.hpp>
+#include <autoware_utils/ros/logger_level_configure.hpp>
+#include <autoware_utils/ros/polling_subscriber.hpp>
+#include <autoware_utils/ros/published_time_publisher.hpp>
+#include <autoware_utils/ros/self_pose_listener.hpp>
+#include <autoware_utils/system/stop_watch.hpp>
+#include <autoware_utils/system/time_keeper.hpp>
 
 #include "autoware_adapi_v1_msgs/msg/operation_mode_state.hpp"
 #include "autoware_internal_debug_msgs/msg/float32_stamped.hpp"
@@ -61,7 +61,7 @@ namespace autoware::velocity_smoother
 using autoware_planning_msgs::msg::Trajectory;
 using autoware_planning_msgs::msg::TrajectoryPoint;
 using TrajectoryPoints = std::vector<TrajectoryPoint>;
-using autoware::universe_utils::DiagnosticsInterface;
+using autoware_utils::DiagnosticsInterface;
 using autoware_adapi_v1_msgs::msg::OperationModeState;
 using autoware_internal_debug_msgs::msg::Float32Stamped;
 using autoware_internal_debug_msgs::msg::Float64Stamped;
@@ -90,14 +90,14 @@ private:
   rclcpp::Publisher<Trajectory>::SharedPtr pub_trajectory_;
   rclcpp::Publisher<MarkerArray>::SharedPtr pub_virtual_wall_;
   rclcpp::Subscription<Trajectory>::SharedPtr sub_current_trajectory_;
-  autoware::universe_utils::InterProcessPollingSubscriber<Odometry> sub_current_odometry_{
+  autoware_utils::InterProcessPollingSubscriber<Odometry> sub_current_odometry_{
     this, "/localization/kinematic_state"};
-  autoware::universe_utils::InterProcessPollingSubscriber<AccelWithCovarianceStamped>
+  autoware_utils::InterProcessPollingSubscriber<AccelWithCovarianceStamped>
     sub_current_acceleration_{this, "~/input/acceleration"};
-  autoware::universe_utils::InterProcessPollingSubscriber<
-    VelocityLimit, universe_utils::polling_policy::Newest>
+  autoware_utils::InterProcessPollingSubscriber<
+    VelocityLimit, autoware_utils::polling_policy::Newest>
     sub_external_velocity_limit_{this, "~/input/external_velocity_limit_mps"};
-  autoware::universe_utils::InterProcessPollingSubscriber<OperationModeState> sub_operation_mode_{
+  autoware_utils::InterProcessPollingSubscriber<OperationModeState> sub_operation_mode_{
     this, "~/input/operation_mode_state"};
 
   Odometry::ConstSharedPtr current_odometry_ptr_;  // current odometry
@@ -255,7 +255,7 @@ private:
   void initCommonParam();
 
   // debug
-  autoware::universe_utils::StopWatch<std::chrono::milliseconds> stop_watch_;
+  autoware_utils::StopWatch<std::chrono::milliseconds> stop_watch_;
   std::shared_ptr<rclcpp::Time> prev_time_;
   double prev_acc_;
   rclcpp::Publisher<Float32Stamped>::SharedPtr pub_dist_to_stopline_;
@@ -270,7 +270,7 @@ private:
   rclcpp::Publisher<Float32Stamped>::SharedPtr debug_closest_jerk_;
   rclcpp::Publisher<Float64Stamped>::SharedPtr debug_calculation_time_;
   rclcpp::Publisher<Float32Stamped>::SharedPtr debug_closest_max_velocity_;
-  rclcpp::Publisher<autoware::universe_utils::ProcessingTimeDetail>::SharedPtr
+  rclcpp::Publisher<autoware_utils::ProcessingTimeDetail>::SharedPtr
     debug_processing_time_detail_;
 
   // For Jerk Filtered Algorithm Debug
@@ -285,10 +285,10 @@ private:
   void flipVelocity(TrajectoryPoints & points) const;
   void publishStopWatchTime();
 
-  std::unique_ptr<autoware::universe_utils::LoggerLevelConfigure> logger_configure_;
-  std::unique_ptr<autoware::universe_utils::PublishedTimePublisher> published_time_publisher_;
+  std::unique_ptr<autoware_utils::LoggerLevelConfigure> logger_configure_;
+  std::unique_ptr<autoware_utils::PublishedTimePublisher> published_time_publisher_;
 
-  mutable std::shared_ptr<autoware::universe_utils::TimeKeeper> time_keeper_{nullptr};
+  mutable std::shared_ptr<autoware_utils::TimeKeeper> time_keeper_{nullptr};
 
   std::unique_ptr<DiagnosticsInterface> diagnostics_interface_{nullptr};
 };

--- a/planning/autoware_velocity_smoother/include/autoware/velocity_smoother/smoother/analytical_jerk_constrained_smoother/analytical_jerk_constrained_smoother.hpp
+++ b/planning/autoware_velocity_smoother/include/autoware/velocity_smoother/smoother/analytical_jerk_constrained_smoother/analytical_jerk_constrained_smoother.hpp
@@ -16,9 +16,9 @@
 #define AUTOWARE__VELOCITY_SMOOTHER__SMOOTHER__ANALYTICAL_JERK_CONSTRAINED_SMOOTHER__ANALYTICAL_JERK_CONSTRAINED_SMOOTHER_HPP_  // NOLINT
 
 #include "autoware/motion_utils/trajectory/trajectory.hpp"
-#include "autoware_utils/system/time_keeper.hpp"
 #include "autoware/velocity_smoother/smoother/analytical_jerk_constrained_smoother/velocity_planning_utils.hpp"
 #include "autoware/velocity_smoother/smoother/smoother_base.hpp"
+#include "autoware_utils/system/time_keeper.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "tf2/utils.h"
 

--- a/planning/autoware_velocity_smoother/include/autoware/velocity_smoother/smoother/analytical_jerk_constrained_smoother/analytical_jerk_constrained_smoother.hpp
+++ b/planning/autoware_velocity_smoother/include/autoware/velocity_smoother/smoother/analytical_jerk_constrained_smoother/analytical_jerk_constrained_smoother.hpp
@@ -16,7 +16,7 @@
 #define AUTOWARE__VELOCITY_SMOOTHER__SMOOTHER__ANALYTICAL_JERK_CONSTRAINED_SMOOTHER__ANALYTICAL_JERK_CONSTRAINED_SMOOTHER_HPP_  // NOLINT
 
 #include "autoware/motion_utils/trajectory/trajectory.hpp"
-#include "autoware/universe_utils/system/time_keeper.hpp"
+#include "autoware_utils/system/time_keeper.hpp"
 #include "autoware/velocity_smoother/smoother/analytical_jerk_constrained_smoother/velocity_planning_utils.hpp"
 #include "autoware/velocity_smoother/smoother/smoother_base.hpp"
 #include "rclcpp/rclcpp.hpp"
@@ -68,8 +68,8 @@ public:
   };
 
   explicit AnalyticalJerkConstrainedSmoother(
-    rclcpp::Node & node, const std::shared_ptr<autoware::universe_utils::TimeKeeper> time_keeper =
-                           std::make_shared<autoware::universe_utils::TimeKeeper>());
+    rclcpp::Node & node, const std::shared_ptr<autoware_utils::TimeKeeper> time_keeper =
+                           std::make_shared<autoware_utils::TimeKeeper>());
 
   bool apply(
     const double initial_vel, const double initial_acc, const TrajectoryPoints & input,

--- a/planning/autoware_velocity_smoother/include/autoware/velocity_smoother/smoother/jerk_filtered_smoother.hpp
+++ b/planning/autoware_velocity_smoother/include/autoware/velocity_smoother/smoother/jerk_filtered_smoother.hpp
@@ -17,9 +17,9 @@
 
 #include "autoware/motion_utils/trajectory/trajectory.hpp"
 #include "autoware/qp_interface/qp_interface.hpp"
+#include "autoware/velocity_smoother/smoother/smoother_base.hpp"
 #include "autoware_utils/geometry/geometry.hpp"
 #include "autoware_utils/system/time_keeper.hpp"
-#include "autoware/velocity_smoother/smoother/smoother_base.hpp"
 
 #include "autoware_planning_msgs/msg/trajectory_point.hpp"
 

--- a/planning/autoware_velocity_smoother/include/autoware/velocity_smoother/smoother/jerk_filtered_smoother.hpp
+++ b/planning/autoware_velocity_smoother/include/autoware/velocity_smoother/smoother/jerk_filtered_smoother.hpp
@@ -17,8 +17,8 @@
 
 #include "autoware/motion_utils/trajectory/trajectory.hpp"
 #include "autoware/qp_interface/qp_interface.hpp"
-#include "autoware/universe_utils/geometry/geometry.hpp"
-#include "autoware/universe_utils/system/time_keeper.hpp"
+#include "autoware_utils/geometry/geometry.hpp"
+#include "autoware_utils/system/time_keeper.hpp"
 #include "autoware/velocity_smoother/smoother/smoother_base.hpp"
 
 #include "autoware_planning_msgs/msg/trajectory_point.hpp"
@@ -43,7 +43,7 @@ public:
   };
 
   explicit JerkFilteredSmoother(
-    rclcpp::Node & node, const std::shared_ptr<autoware::universe_utils::TimeKeeper> time_keeper);
+    rclcpp::Node & node, const std::shared_ptr<autoware_utils::TimeKeeper> time_keeper);
 
   bool apply(
     const double initial_vel, const double initial_acc, const TrajectoryPoints & input,

--- a/planning/autoware_velocity_smoother/include/autoware/velocity_smoother/smoother/l2_pseudo_jerk_smoother.hpp
+++ b/planning/autoware_velocity_smoother/include/autoware/velocity_smoother/smoother/l2_pseudo_jerk_smoother.hpp
@@ -17,8 +17,8 @@
 
 #include "autoware/motion_utils/trajectory/trajectory.hpp"
 #include "autoware/osqp_interface/osqp_interface.hpp"
-#include "autoware/universe_utils/geometry/geometry.hpp"
-#include "autoware/universe_utils/system/time_keeper.hpp"
+#include "autoware_utils/geometry/geometry.hpp"
+#include "autoware_utils/system/time_keeper.hpp"
 #include "autoware/velocity_smoother/smoother/smoother_base.hpp"
 
 #include "autoware_planning_msgs/msg/trajectory_point.hpp"
@@ -41,7 +41,7 @@ public:
   };
 
   explicit L2PseudoJerkSmoother(
-    rclcpp::Node & node, const std::shared_ptr<autoware::universe_utils::TimeKeeper> time_keeper);
+    rclcpp::Node & node, const std::shared_ptr<autoware_utils::TimeKeeper> time_keeper);
 
   bool apply(
     const double initial_vel, const double initial_acc, const TrajectoryPoints & input,

--- a/planning/autoware_velocity_smoother/include/autoware/velocity_smoother/smoother/l2_pseudo_jerk_smoother.hpp
+++ b/planning/autoware_velocity_smoother/include/autoware/velocity_smoother/smoother/l2_pseudo_jerk_smoother.hpp
@@ -17,9 +17,9 @@
 
 #include "autoware/motion_utils/trajectory/trajectory.hpp"
 #include "autoware/osqp_interface/osqp_interface.hpp"
+#include "autoware/velocity_smoother/smoother/smoother_base.hpp"
 #include "autoware_utils/geometry/geometry.hpp"
 #include "autoware_utils/system/time_keeper.hpp"
-#include "autoware/velocity_smoother/smoother/smoother_base.hpp"
 
 #include "autoware_planning_msgs/msg/trajectory_point.hpp"
 

--- a/planning/autoware_velocity_smoother/include/autoware/velocity_smoother/smoother/linf_pseudo_jerk_smoother.hpp
+++ b/planning/autoware_velocity_smoother/include/autoware/velocity_smoother/smoother/linf_pseudo_jerk_smoother.hpp
@@ -17,8 +17,8 @@
 
 #include "autoware/motion_utils/trajectory/trajectory.hpp"
 #include "autoware/osqp_interface/osqp_interface.hpp"
-#include "autoware/universe_utils/geometry/geometry.hpp"
-#include "autoware/universe_utils/system/time_keeper.hpp"
+#include "autoware_utils/geometry/geometry.hpp"
+#include "autoware_utils/system/time_keeper.hpp"
 #include "autoware/velocity_smoother/smoother/smoother_base.hpp"
 
 #include "autoware_planning_msgs/msg/trajectory_point.hpp"
@@ -41,7 +41,7 @@ public:
   };
 
   explicit LinfPseudoJerkSmoother(
-    rclcpp::Node & node, const std::shared_ptr<autoware::universe_utils::TimeKeeper> time_keeper);
+    rclcpp::Node & node, const std::shared_ptr<autoware_utils::TimeKeeper> time_keeper);
 
   bool apply(
     const double initial_vel, const double initial_acc, const TrajectoryPoints & input,

--- a/planning/autoware_velocity_smoother/include/autoware/velocity_smoother/smoother/linf_pseudo_jerk_smoother.hpp
+++ b/planning/autoware_velocity_smoother/include/autoware/velocity_smoother/smoother/linf_pseudo_jerk_smoother.hpp
@@ -17,9 +17,9 @@
 
 #include "autoware/motion_utils/trajectory/trajectory.hpp"
 #include "autoware/osqp_interface/osqp_interface.hpp"
+#include "autoware/velocity_smoother/smoother/smoother_base.hpp"
 #include "autoware_utils/geometry/geometry.hpp"
 #include "autoware_utils/system/time_keeper.hpp"
-#include "autoware/velocity_smoother/smoother/smoother_base.hpp"
 
 #include "autoware_planning_msgs/msg/trajectory_point.hpp"
 

--- a/planning/autoware_velocity_smoother/include/autoware/velocity_smoother/smoother/smoother_base.hpp
+++ b/planning/autoware_velocity_smoother/include/autoware/velocity_smoother/smoother/smoother_base.hpp
@@ -15,8 +15,8 @@
 #ifndef AUTOWARE__VELOCITY_SMOOTHER__SMOOTHER__SMOOTHER_BASE_HPP_
 #define AUTOWARE__VELOCITY_SMOOTHER__SMOOTHER__SMOOTHER_BASE_HPP_
 
-#include "autoware_utils/system/time_keeper.hpp"
 #include "autoware/velocity_smoother/resample.hpp"
+#include "autoware_utils/system/time_keeper.hpp"
 #include "rclcpp/rclcpp.hpp"
 
 #include "autoware_planning_msgs/msg/trajectory_point.hpp"

--- a/planning/autoware_velocity_smoother/include/autoware/velocity_smoother/smoother/smoother_base.hpp
+++ b/planning/autoware_velocity_smoother/include/autoware/velocity_smoother/smoother/smoother_base.hpp
@@ -15,7 +15,7 @@
 #ifndef AUTOWARE__VELOCITY_SMOOTHER__SMOOTHER__SMOOTHER_BASE_HPP_
 #define AUTOWARE__VELOCITY_SMOOTHER__SMOOTHER__SMOOTHER_BASE_HPP_
 
-#include "autoware/universe_utils/system/time_keeper.hpp"
+#include "autoware_utils/system/time_keeper.hpp"
 #include "autoware/velocity_smoother/resample.hpp"
 #include "rclcpp/rclcpp.hpp"
 
@@ -57,7 +57,7 @@ public:
   };
 
   explicit SmootherBase(
-    rclcpp::Node & node, const std::shared_ptr<autoware::universe_utils::TimeKeeper> time_keeper);
+    rclcpp::Node & node, const std::shared_ptr<autoware_utils::TimeKeeper> time_keeper);
   virtual ~SmootherBase() = default;
   virtual bool apply(
     const double initial_vel, const double initial_acc, const TrajectoryPoints & input,
@@ -91,7 +91,7 @@ public:
 
 protected:
   BaseParam base_param_;
-  mutable std::shared_ptr<autoware::universe_utils::TimeKeeper> time_keeper_{nullptr};
+  mutable std::shared_ptr<autoware_utils::TimeKeeper> time_keeper_{nullptr};
 };
 }  // namespace autoware::velocity_smoother
 

--- a/planning/autoware_velocity_smoother/package.xml
+++ b/planning/autoware_velocity_smoother/package.xml
@@ -28,7 +28,7 @@
   <depend>autoware_planning_msgs</depend>
   <depend>autoware_planning_test_manager</depend>
   <depend>autoware_qp_interface</depend>
-  <depend>autoware_universe_utils</depend>
+  <depend>autoware_utils</depend>
   <depend>autoware_vehicle_info_utils</depend>
   <depend>geometry_msgs</depend>
   <depend>nav_msgs</depend>

--- a/planning/autoware_velocity_smoother/src/node.cpp
+++ b/planning/autoware_velocity_smoother/src/node.cpp
@@ -15,7 +15,7 @@
 #include "autoware/velocity_smoother/node.hpp"
 
 #include "autoware/motion_utils/marker/marker_helper.hpp"
-#include "autoware/universe_utils/ros/update_param.hpp"
+#include "autoware_utils/ros/update_param.hpp"
 #include "autoware/velocity_smoother/smoother/jerk_filtered_smoother.hpp"
 #include "autoware/velocity_smoother/smoother/l2_pseudo_jerk_smoother.hpp"
 #include "autoware/velocity_smoother/smoother/linf_pseudo_jerk_smoother.hpp"
@@ -50,10 +50,10 @@ VelocitySmootherNode::VelocitySmootherNode(const rclcpp::NodeOptions & node_opti
 
   // create time_keeper and its publisher
   // NOTE: This has to be called before setupSmoother to pass the time_keeper to the smoother.
-  debug_processing_time_detail_ = create_publisher<autoware::universe_utils::ProcessingTimeDetail>(
+  debug_processing_time_detail_ = create_publisher<autoware_utils::ProcessingTimeDetail>(
     "~/debug/processing_time_detail_ms", 1);
   time_keeper_ =
-    std::make_shared<autoware::universe_utils::TimeKeeper>(debug_processing_time_detail_);
+    std::make_shared<autoware_utils::TimeKeeper>(debug_processing_time_detail_);
 
   // create smoother
   setupSmoother(wheelbase_);
@@ -98,9 +98,9 @@ VelocitySmootherNode::VelocitySmootherNode(const rclcpp::NodeOptions & node_opti
 
   clock_ = get_clock();
 
-  logger_configure_ = std::make_unique<autoware::universe_utils::LoggerLevelConfigure>(this);
+  logger_configure_ = std::make_unique<autoware_utils::LoggerLevelConfigure>(this);
   published_time_publisher_ =
-    std::make_unique<autoware::universe_utils::PublishedTimePublisher>(this);
+    std::make_unique<autoware_utils::PublishedTimePublisher>(this);
 }
 
 void VelocitySmootherNode::setupSmoother(const double wheelbase)
@@ -317,7 +317,7 @@ void VelocitySmootherNode::publishTrajectory(const TrajectoryPoints & trajectory
 
 void VelocitySmootherNode::calcExternalVelocityLimit()
 {
-  autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_);
+  autoware_utils::ScopedTimeTrack st(__func__, *time_keeper_);
 
   if (!external_velocity_limit_ptr_) {
     external_velocity_limit_.acceleration_request.request = false;
@@ -439,7 +439,7 @@ bool VelocitySmootherNode::checkData() const
 
 void VelocitySmootherNode::onCurrentTrajectory(const Trajectory::ConstSharedPtr msg)
 {
-  autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_);
+  autoware_utils::ScopedTimeTrack st(__func__, *time_keeper_);
 
   RCLCPP_DEBUG(get_logger(), "========================= run start =========================");
   stop_watch_.tic();
@@ -448,10 +448,10 @@ void VelocitySmootherNode::onCurrentTrajectory(const Trajectory::ConstSharedPtr 
   base_traj_raw_ptr_ = msg;
 
   // receive data
-  current_odometry_ptr_ = sub_current_odometry_.takeData();
-  current_acceleration_ptr_ = sub_current_acceleration_.takeData();
-  external_velocity_limit_ptr_ = sub_external_velocity_limit_.takeData();
-  const auto operation_mode_ptr = sub_operation_mode_.takeData();
+  current_odometry_ptr_ = sub_current_odometry_.take_data();
+  current_acceleration_ptr_ = sub_current_acceleration_.take_data();
+  external_velocity_limit_ptr_ = sub_external_velocity_limit_.take_data();
+  const auto operation_mode_ptr = sub_operation_mode_.take_data();
   if (operation_mode_ptr) {
     operation_mode_ = *operation_mode_ptr;
   }
@@ -534,7 +534,7 @@ void VelocitySmootherNode::onCurrentTrajectory(const Trajectory::ConstSharedPtr 
 
 void VelocitySmootherNode::updateDataForExternalVelocityLimit()
 {
-  autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_);
+  autoware_utils::ScopedTimeTrack st(__func__, *time_keeper_);
 
   if (prev_output_.empty()) {
     return;
@@ -553,7 +553,7 @@ void VelocitySmootherNode::updateDataForExternalVelocityLimit()
 TrajectoryPoints VelocitySmootherNode::calcTrajectoryVelocity(
   const TrajectoryPoints & traj_input) const
 {
-  autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_);
+  autoware_utils::ScopedTimeTrack st(__func__, *time_keeper_);
 
   TrajectoryPoints output{};  // velocity is optimized by qp solver
 
@@ -602,7 +602,7 @@ bool VelocitySmootherNode::smoothVelocity(
   const TrajectoryPoints & input, const size_t input_closest,
   TrajectoryPoints & traj_smoothed) const
 {
-  autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_);
+  autoware_utils::ScopedTimeTrack st(__func__, *time_keeper_);
 
   if (input.empty()) {
     return false;  // cannot apply smoothing
@@ -721,7 +721,7 @@ bool VelocitySmootherNode::smoothVelocity(
 void VelocitySmootherNode::insertBehindVelocity(
   const size_t output_closest, const InitializeType type, TrajectoryPoints & output) const
 {
-  autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_);
+  autoware_utils::ScopedTimeTrack st(__func__, *time_keeper_);
 
   const bool keep_closest_vel_for_behind =
     (type == InitializeType::EGO_VELOCITY || type == InitializeType::LARGE_DEVIATION_REPLAN ||
@@ -785,7 +785,7 @@ void VelocitySmootherNode::publishStopDistance(const TrajectoryPoints & trajecto
 std::pair<Motion, VelocitySmootherNode::InitializeType> VelocitySmootherNode::calcInitialMotion(
   const TrajectoryPoints & input_traj, const size_t input_closest) const
 {
-  autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_);
+  autoware_utils::ScopedTimeTrack st(__func__, *time_keeper_);
 
   const double vehicle_speed = std::fabs(current_odometry_ptr_->twist.twist.linear.x);
   const double vehicle_acceleration = current_acceleration_ptr_->accel.accel.linear.x;
@@ -873,7 +873,7 @@ std::pair<Motion, VelocitySmootherNode::InitializeType> VelocitySmootherNode::ca
 void VelocitySmootherNode::overwriteStopPoint(
   const TrajectoryPoints & input, TrajectoryPoints & output) const
 {
-  autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_);
+  autoware_utils::ScopedTimeTrack st(__func__, *time_keeper_);
 
   const auto stop_idx = autoware::motion_utils::searchZeroVelocityIndex(input);
   if (!stop_idx) {
@@ -917,7 +917,7 @@ void VelocitySmootherNode::overwriteStopPoint(
 
 void VelocitySmootherNode::applyExternalVelocityLimit(TrajectoryPoints & traj) const
 {
-  autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_);
+  autoware_utils::ScopedTimeTrack st(__func__, *time_keeper_);
 
   if (traj.size() < 1) {
     return;
@@ -958,7 +958,7 @@ void VelocitySmootherNode::applyExternalVelocityLimit(TrajectoryPoints & traj) c
 
 void VelocitySmootherNode::applyStopApproachingVelocity(TrajectoryPoints & traj) const
 {
-  autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_);
+  autoware_utils::ScopedTimeTrack st(__func__, *time_keeper_);
 
   const auto stop_idx = autoware::motion_utils::searchZeroVelocityIndex(traj);
   if (!stop_idx) {
@@ -966,7 +966,7 @@ void VelocitySmootherNode::applyStopApproachingVelocity(TrajectoryPoints & traj)
   }
   double distance_sum = 0.0;
   for (size_t i = *stop_idx - 1; i < traj.size(); --i) {  // search backward
-    distance_sum += autoware::universe_utils::calcDistance2d(traj.at(i), traj.at(i + 1));
+    distance_sum += autoware_utils::calc_distance2d(traj.at(i), traj.at(i + 1));
     if (distance_sum > node_param_.stopping_distance) {
       break;
     }
@@ -1076,7 +1076,7 @@ double VelocitySmootherNode::calcTravelDistance() const
 
   if (prev_closest_point_) {
     const double travel_dist =
-      autoware::universe_utils::calcDistance2d(*prev_closest_point_, closest_point);
+      autoware_utils::calc_distance2d(*prev_closest_point_, closest_point);
     return travel_dist;
   }
 

--- a/planning/autoware_velocity_smoother/src/node.cpp
+++ b/planning/autoware_velocity_smoother/src/node.cpp
@@ -15,10 +15,10 @@
 #include "autoware/velocity_smoother/node.hpp"
 
 #include "autoware/motion_utils/marker/marker_helper.hpp"
-#include "autoware_utils/ros/update_param.hpp"
 #include "autoware/velocity_smoother/smoother/jerk_filtered_smoother.hpp"
 #include "autoware/velocity_smoother/smoother/l2_pseudo_jerk_smoother.hpp"
 #include "autoware/velocity_smoother/smoother/linf_pseudo_jerk_smoother.hpp"
+#include "autoware_utils/ros/update_param.hpp"
 
 #include <autoware_vehicle_info_utils/vehicle_info_utils.hpp>
 
@@ -50,10 +50,9 @@ VelocitySmootherNode::VelocitySmootherNode(const rclcpp::NodeOptions & node_opti
 
   // create time_keeper and its publisher
   // NOTE: This has to be called before setupSmoother to pass the time_keeper to the smoother.
-  debug_processing_time_detail_ = create_publisher<autoware_utils::ProcessingTimeDetail>(
-    "~/debug/processing_time_detail_ms", 1);
-  time_keeper_ =
-    std::make_shared<autoware_utils::TimeKeeper>(debug_processing_time_detail_);
+  debug_processing_time_detail_ =
+    create_publisher<autoware_utils::ProcessingTimeDetail>("~/debug/processing_time_detail_ms", 1);
+  time_keeper_ = std::make_shared<autoware_utils::TimeKeeper>(debug_processing_time_detail_);
 
   // create smoother
   setupSmoother(wheelbase_);
@@ -99,8 +98,7 @@ VelocitySmootherNode::VelocitySmootherNode(const rclcpp::NodeOptions & node_opti
   clock_ = get_clock();
 
   logger_configure_ = std::make_unique<autoware_utils::LoggerLevelConfigure>(this);
-  published_time_publisher_ =
-    std::make_unique<autoware_utils::PublishedTimePublisher>(this);
+  published_time_publisher_ = std::make_unique<autoware_utils::PublishedTimePublisher>(this);
 }
 
 void VelocitySmootherNode::setupSmoother(const double wheelbase)
@@ -1075,8 +1073,7 @@ double VelocitySmootherNode::calcTravelDistance() const
   const auto closest_point = calcProjectedTrajectoryPointFromEgo(prev_output_);
 
   if (prev_closest_point_) {
-    const double travel_dist =
-      autoware_utils::calc_distance2d(*prev_closest_point_, closest_point);
+    const double travel_dist = autoware_utils::calc_distance2d(*prev_closest_point_, closest_point);
     return travel_dist;
   }
 

--- a/planning/autoware_velocity_smoother/src/resample.cpp
+++ b/planning/autoware_velocity_smoother/src/resample.cpp
@@ -17,8 +17,8 @@
 #include "autoware/motion_utils/resample/resample.hpp"
 #include "autoware/motion_utils/trajectory/conversion.hpp"
 #include "autoware/motion_utils/trajectory/trajectory.hpp"
-#include "autoware_utils/geometry/geometry.hpp"
 #include "autoware/velocity_smoother/trajectory_utils.hpp"
+#include "autoware_utils/geometry/geometry.hpp"
 
 #include <algorithm>
 #include <vector>

--- a/planning/autoware_velocity_smoother/src/resample.cpp
+++ b/planning/autoware_velocity_smoother/src/resample.cpp
@@ -17,7 +17,7 @@
 #include "autoware/motion_utils/resample/resample.hpp"
 #include "autoware/motion_utils/trajectory/conversion.hpp"
 #include "autoware/motion_utils/trajectory/trajectory.hpp"
-#include "autoware/universe_utils/geometry/geometry.hpp"
+#include "autoware_utils/geometry/geometry.hpp"
 #include "autoware/velocity_smoother/trajectory_utils.hpp"
 
 #include <algorithm>
@@ -136,7 +136,7 @@ TrajectoryPoints resampleTrajectory(
   // add end point directly to consider the endpoint velocity.
   if (is_endpoint_included) {
     constexpr double ep_dist = 1.0E-3;
-    if (autoware::universe_utils::calcDistance2d(output.back(), input.back()) < ep_dist) {
+    if (autoware_utils::calc_distance2d(output.back(), input.back()) < ep_dist) {
       output.back() = input.back();
     } else {
       output.push_back(input.back());
@@ -256,7 +256,7 @@ TrajectoryPoints resampleTrajectory(
   // add end point directly to consider the endpoint velocity.
   if (is_endpoint_included) {
     constexpr double ep_dist = 1.0E-3;
-    if (autoware::universe_utils::calcDistance2d(output.back(), input.back()) < ep_dist) {
+    if (autoware_utils::calc_distance2d(output.back(), input.back()) < ep_dist) {
       output.back() = input.back();
     } else {
       output.push_back(input.back());

--- a/planning/autoware_velocity_smoother/src/smoother/analytical_jerk_constrained_smoother/analytical_jerk_constrained_smoother.cpp
+++ b/planning/autoware_velocity_smoother/src/smoother/analytical_jerk_constrained_smoother/analytical_jerk_constrained_smoother.cpp
@@ -16,7 +16,7 @@
 
 #include "autoware/motion_utils/resample/resample.hpp"
 #include "autoware/motion_utils/trajectory/conversion.hpp"
-#include "autoware/universe_utils/geometry/geometry.hpp"
+#include <autoware_utils/geometry/geometry.hpp>
 #include "autoware/velocity_smoother/trajectory_utils.hpp"
 
 #include <algorithm>
@@ -69,7 +69,7 @@ bool applyMaxVelocity(
 namespace autoware::velocity_smoother
 {
 AnalyticalJerkConstrainedSmoother::AnalyticalJerkConstrainedSmoother(
-  rclcpp::Node & node, const std::shared_ptr<autoware::universe_utils::TimeKeeper> time_keeper)
+  rclcpp::Node & node, const std::shared_ptr<autoware_utils::TimeKeeper> time_keeper)
 : SmootherBase(node, time_keeper)
 {
   auto & p = smoother_param_;
@@ -256,7 +256,7 @@ TrajectoryPoints AnalyticalJerkConstrainedSmoother::resampleTrajectory(
     const auto tp1 = input.at(i + 1);
 
     const double dist_thr = 0.001;  // 1mm
-    const double dist_tp0_tp1 = autoware::universe_utils::calcDistance2d(tp0, tp1);
+    const double dist_tp0_tp1 = autoware_utils::calc_distance2d(tp0, tp1);
     if (std::fabs(dist_tp0_tp1) < dist_thr) {
       output.push_back(input.at(i));
       continue;
@@ -359,7 +359,7 @@ TrajectoryPoints AnalyticalJerkConstrainedSmoother::applyLateralAccelerationFilt
     }
 
     if (
-      autoware::universe_utils::calcDistance2d(output.at(end_index), output.at(index)) <
+      autoware_utils::calc_distance2d(output.at(end_index), output.at(index)) <
       dist_threshold) {
       end_index = index;
       min_latacc_velocity = std::min(
@@ -445,7 +445,7 @@ bool AnalyticalJerkConstrainedSmoother::applyForwardJerkFilter(
   for (size_t i = start_index + 1; i < base_trajectory.size(); ++i) {
     const double prev_vel = output_trajectory.at(i - 1).longitudinal_velocity_mps;
     const double ds =
-      autoware::universe_utils::calcDistance2d(base_trajectory.at(i - 1), base_trajectory.at(i));
+      autoware_utils::calc_distance2d(base_trajectory.at(i - 1), base_trajectory.at(i));
     const double dt = ds / std::max(prev_vel, 1.0);
 
     const double prev_acc = output_trajectory.at(i - 1).acceleration_mps2;
@@ -491,7 +491,7 @@ bool AnalyticalJerkConstrainedSmoother::applyBackwardDecelFilter(
       }
     }
     for (size_t i = decel_target_index; i > start_index; --i) {
-      dist += autoware::universe_utils::calcDistance2d(
+      dist += autoware_utils::calc_distance2d(
         output_trajectory.at(i - 1), output_trajectory.at(i));
       dist_to_target.at(i - 1) = dist;
     }

--- a/planning/autoware_velocity_smoother/src/smoother/analytical_jerk_constrained_smoother/analytical_jerk_constrained_smoother.cpp
+++ b/planning/autoware_velocity_smoother/src/smoother/analytical_jerk_constrained_smoother/analytical_jerk_constrained_smoother.cpp
@@ -16,8 +16,9 @@
 
 #include "autoware/motion_utils/resample/resample.hpp"
 #include "autoware/motion_utils/trajectory/conversion.hpp"
-#include <autoware_utils/geometry/geometry.hpp>
 #include "autoware/velocity_smoother/trajectory_utils.hpp"
+
+#include <autoware_utils/geometry/geometry.hpp>
 
 #include <algorithm>
 #include <memory>
@@ -358,9 +359,7 @@ TrajectoryPoints AnalyticalJerkConstrainedSmoother::applyLateralAccelerationFilt
       continue;
     }
 
-    if (
-      autoware_utils::calc_distance2d(output.at(end_index), output.at(index)) <
-      dist_threshold) {
+    if (autoware_utils::calc_distance2d(output.at(end_index), output.at(index)) < dist_threshold) {
       end_index = index;
       min_latacc_velocity = std::min(
         static_cast<double>(output.at(index).longitudinal_velocity_mps), min_latacc_velocity);
@@ -491,8 +490,7 @@ bool AnalyticalJerkConstrainedSmoother::applyBackwardDecelFilter(
       }
     }
     for (size_t i = decel_target_index; i > start_index; --i) {
-      dist += autoware_utils::calc_distance2d(
-        output_trajectory.at(i - 1), output_trajectory.at(i));
+      dist += autoware_utils::calc_distance2d(output_trajectory.at(i - 1), output_trajectory.at(i));
       dist_to_target.at(i - 1) = dist;
     }
 

--- a/planning/autoware_velocity_smoother/src/smoother/analytical_jerk_constrained_smoother/velocity_planning_utils.cpp
+++ b/planning/autoware_velocity_smoother/src/smoother/analytical_jerk_constrained_smoother/velocity_planning_utils.cpp
@@ -15,7 +15,7 @@
 #include "autoware/velocity_smoother/smoother/analytical_jerk_constrained_smoother/velocity_planning_utils.hpp"
 
 #include "autoware/interpolation/linear_interpolation.hpp"
-#include "autoware/universe_utils/geometry/geometry.hpp"
+#include <autoware_utils/geometry/geometry.hpp>
 
 #include <algorithm>
 #include <vector>
@@ -226,7 +226,7 @@ bool calcStopVelocityWithConstantJerkAccLimit(
   std::vector<double> distances;
   distances.push_back(distance);
   for (size_t i = start_index; i < output_trajectory.size() - 1; ++i) {
-    distance += autoware::universe_utils::calcDistance2d(
+    distance += autoware_utils::calc_distance2d(
       output_trajectory.at(i), output_trajectory.at(i + 1));
     if (distance > xs.back()) {
       break;

--- a/planning/autoware_velocity_smoother/src/smoother/analytical_jerk_constrained_smoother/velocity_planning_utils.cpp
+++ b/planning/autoware_velocity_smoother/src/smoother/analytical_jerk_constrained_smoother/velocity_planning_utils.cpp
@@ -15,6 +15,7 @@
 #include "autoware/velocity_smoother/smoother/analytical_jerk_constrained_smoother/velocity_planning_utils.hpp"
 
 #include "autoware/interpolation/linear_interpolation.hpp"
+
 #include <autoware_utils/geometry/geometry.hpp>
 
 #include <algorithm>
@@ -226,8 +227,8 @@ bool calcStopVelocityWithConstantJerkAccLimit(
   std::vector<double> distances;
   distances.push_back(distance);
   for (size_t i = start_index; i < output_trajectory.size() - 1; ++i) {
-    distance += autoware_utils::calc_distance2d(
-      output_trajectory.at(i), output_trajectory.at(i + 1));
+    distance +=
+      autoware_utils::calc_distance2d(output_trajectory.at(i), output_trajectory.at(i + 1));
     if (distance > xs.back()) {
       break;
     }

--- a/planning/autoware_velocity_smoother/src/smoother/jerk_filtered_smoother.cpp
+++ b/planning/autoware_velocity_smoother/src/smoother/jerk_filtered_smoother.cpp
@@ -449,8 +449,8 @@ TrajectoryPoints JerkFilteredSmoother::mergeFilteredTrajectory(
       merged.at(i).longitudinal_velocity_mps = current_vel;
       merged.at(i).acceleration_mps2 = current_acc;
 
-      const double ds = autoware_utils::calc_distance2d(
-        forward_filtered.at(i + 1), forward_filtered.at(i));
+      const double ds =
+        autoware_utils::calc_distance2d(forward_filtered.at(i + 1), forward_filtered.at(i));
       const double max_dt =
         std::pow(6.0 * ds / std::fabs(j_min), 1.0 / 3.0);  // assuming v0 = a0 = 0.
       const double dt = std::min(ds / std::max(current_vel, 1.0e-6), max_dt);

--- a/planning/autoware_velocity_smoother/src/smoother/jerk_filtered_smoother.cpp
+++ b/planning/autoware_velocity_smoother/src/smoother/jerk_filtered_smoother.cpp
@@ -33,7 +33,7 @@
 namespace autoware::velocity_smoother
 {
 JerkFilteredSmoother::JerkFilteredSmoother(
-  rclcpp::Node & node, const std::shared_ptr<autoware::universe_utils::TimeKeeper> time_keeper)
+  rclcpp::Node & node, const std::shared_ptr<autoware_utils::TimeKeeper> time_keeper)
 : SmootherBase(node, time_keeper)
 {
   auto & p = smoother_param_;
@@ -61,7 +61,7 @@ bool JerkFilteredSmoother::apply(
   const double v0, const double a0, const TrajectoryPoints & input, TrajectoryPoints & output,
   std::vector<TrajectoryPoints> & debug_trajectories, const bool publish_debug_trajs)
 {
-  autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_);
+  autoware_utils::ScopedTimeTrack st(__func__, *time_keeper_);
 
   output = input;
 
@@ -106,7 +106,7 @@ bool JerkFilteredSmoother::apply(
   const auto initial_traj_pose = filtered.front().pose;
 
   const auto resample = [&](const auto & trajectory) {
-    autoware::universe_utils::ScopedTimeTrack st("resample", *time_keeper_);
+    autoware_utils::ScopedTimeTrack st("resample", *time_keeper_);
 
     return resampling::resampleTrajectory(
       trajectory, v0, initial_traj_pose, std::numeric_limits<double>::max(),
@@ -360,7 +360,7 @@ TrajectoryPoints JerkFilteredSmoother::forwardJerkFilter(
   const double v0, const double a0, const double a_max, const double a_start, const double j_max,
   const TrajectoryPoints & input) const
 {
-  autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_);
+  autoware_utils::ScopedTimeTrack st(__func__, *time_keeper_);
 
   auto applyLimits = [&input, &a_start](double & v, double & a, size_t i) {
     double v_lim = input.at(i).longitudinal_velocity_mps;
@@ -391,7 +391,7 @@ TrajectoryPoints JerkFilteredSmoother::forwardJerkFilter(
   output.front().longitudinal_velocity_mps = current_vel;
   output.front().acceleration_mps2 = current_acc;
   for (size_t i = 1; i < input.size(); ++i) {
-    const double ds = autoware::universe_utils::calcDistance2d(input.at(i), input.at(i - 1));
+    const double ds = autoware_utils::calc_distance2d(input.at(i), input.at(i - 1));
     const double max_dt = std::pow(6.0 * ds / j_max, 1.0 / 3.0);  // assuming v0 = a0 = 0.
     const double dt = std::min(ds / std::max(current_vel, 1.0e-6), max_dt);
 
@@ -414,7 +414,7 @@ TrajectoryPoints JerkFilteredSmoother::backwardJerkFilter(
   const double v0, const double a0, const double a_min, const double a_stop, const double j_min,
   const TrajectoryPoints & input) const
 {
-  autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_);
+  autoware_utils::ScopedTimeTrack st(__func__, *time_keeper_);
 
   auto input_rev = input;
   std::reverse(input_rev.begin(), input_rev.end());
@@ -431,7 +431,7 @@ TrajectoryPoints JerkFilteredSmoother::mergeFilteredTrajectory(
   const double v0, const double a0, const double a_min, const double j_min,
   const TrajectoryPoints & forward_filtered, const TrajectoryPoints & backward_filtered) const
 {
-  autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_);
+  autoware_utils::ScopedTimeTrack st(__func__, *time_keeper_);
 
   TrajectoryPoints merged;
   merged = forward_filtered;
@@ -449,7 +449,7 @@ TrajectoryPoints JerkFilteredSmoother::mergeFilteredTrajectory(
       merged.at(i).longitudinal_velocity_mps = current_vel;
       merged.at(i).acceleration_mps2 = current_acc;
 
-      const double ds = autoware::universe_utils::calcDistance2d(
+      const double ds = autoware_utils::calc_distance2d(
         forward_filtered.at(i + 1), forward_filtered.at(i));
       const double max_dt =
         std::pow(6.0 * ds / std::fabs(j_min), 1.0 / 3.0);  // assuming v0 = a0 = 0.
@@ -485,7 +485,7 @@ TrajectoryPoints JerkFilteredSmoother::resampleTrajectory(
   const geometry_msgs::msg::Pose & current_pose, const double nearest_dist_threshold,
   const double nearest_yaw_threshold) const
 {
-  autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_);
+  autoware_utils::ScopedTimeTrack st(__func__, *time_keeper_);
 
   return resampling::resampleTrajectory(
     input, current_pose, nearest_dist_threshold, nearest_yaw_threshold, base_param_.resample_param,

--- a/planning/autoware_velocity_smoother/src/smoother/l2_pseudo_jerk_smoother.cpp
+++ b/planning/autoware_velocity_smoother/src/smoother/l2_pseudo_jerk_smoother.cpp
@@ -27,7 +27,7 @@
 namespace autoware::velocity_smoother
 {
 L2PseudoJerkSmoother::L2PseudoJerkSmoother(
-  rclcpp::Node & node, const std::shared_ptr<autoware::universe_utils::TimeKeeper> time_keeper)
+  rclcpp::Node & node, const std::shared_ptr<autoware_utils::TimeKeeper> time_keeper)
 : SmootherBase(node, time_keeper)
 {
   auto & p = smoother_param_;

--- a/planning/autoware_velocity_smoother/src/smoother/linf_pseudo_jerk_smoother.cpp
+++ b/planning/autoware_velocity_smoother/src/smoother/linf_pseudo_jerk_smoother.cpp
@@ -27,7 +27,7 @@
 namespace autoware::velocity_smoother
 {
 LinfPseudoJerkSmoother::LinfPseudoJerkSmoother(
-  rclcpp::Node & node, const std::shared_ptr<autoware::universe_utils::TimeKeeper> time_keeper)
+  rclcpp::Node & node, const std::shared_ptr<autoware_utils::TimeKeeper> time_keeper)
 : SmootherBase(node, time_keeper)
 {
   auto & p = smoother_param_;

--- a/planning/autoware_velocity_smoother/src/smoother/smoother_base.cpp
+++ b/planning/autoware_velocity_smoother/src/smoother/smoother_base.cpp
@@ -17,10 +17,11 @@
 #include "autoware/motion_utils/resample/resample.hpp"
 #include "autoware/motion_utils/trajectory/conversion.hpp"
 #include "autoware/motion_utils/trajectory/trajectory.hpp"
-#include <autoware_utils/geometry/geometry.hpp>
-#include <autoware_utils/math/unit_conversion.hpp>
 #include "autoware/velocity_smoother/resample.hpp"
 #include "autoware/velocity_smoother/trajectory_utils.hpp"
+
+#include <autoware_utils/geometry/geometry.hpp>
+#include <autoware_utils/math/unit_conversion.hpp>
 
 #include <algorithm>
 #include <cmath>
@@ -274,8 +275,7 @@ TrajectoryPoints SmootherBase::applySteeringRateLimit(
     const auto mean_vel =
       (output.at(i).longitudinal_velocity_mps + output.at(i + 1).longitudinal_velocity_mps) / 2.0;
     const auto target_mean_vel =
-      mean_vel *
-      (autoware_utils::deg2rad(base_param_.max_steering_angle_rate) / steer_rate);
+      mean_vel * (autoware_utils::deg2rad(base_param_.max_steering_angle_rate) / steer_rate);
 
     for (size_t k = 0; k < 2; k++) {
       auto & velocity = output.at(i + k).longitudinal_velocity_mps;

--- a/planning/autoware_velocity_smoother/src/smoother/smoother_base.cpp
+++ b/planning/autoware_velocity_smoother/src/smoother/smoother_base.cpp
@@ -17,8 +17,8 @@
 #include "autoware/motion_utils/resample/resample.hpp"
 #include "autoware/motion_utils/trajectory/conversion.hpp"
 #include "autoware/motion_utils/trajectory/trajectory.hpp"
-#include "autoware/universe_utils/geometry/geometry.hpp"
-#include "autoware/universe_utils/math/unit_conversion.hpp"
+#include <autoware_utils/geometry/geometry.hpp>
+#include <autoware_utils/math/unit_conversion.hpp>
 #include "autoware/velocity_smoother/resample.hpp"
 #include "autoware/velocity_smoother/trajectory_utils.hpp"
 
@@ -63,7 +63,7 @@ TrajectoryPoints applyPreProcess(
 }  // namespace
 
 SmootherBase::SmootherBase(
-  rclcpp::Node & node, const std::shared_ptr<autoware::universe_utils::TimeKeeper> time_keeper)
+  rclcpp::Node & node, const std::shared_ptr<autoware_utils::TimeKeeper> time_keeper)
 : time_keeper_(time_keeper)
 {
   auto & p = base_param_;
@@ -144,7 +144,7 @@ TrajectoryPoints SmootherBase::applyLateralAccelerationFilter(
   [[maybe_unused]] const double a0, [[maybe_unused]] const bool enable_smooth_limit,
   const bool use_resampling, const double input_points_interval) const
 {
-  autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_);
+  autoware_utils::ScopedTimeTrack st(__func__, *time_keeper_);
 
   if (input.size() < 3) {
     return input;  // cannot calculate lateral acc. do nothing.
@@ -214,7 +214,7 @@ TrajectoryPoints SmootherBase::applySteeringRateLimit(
   const TrajectoryPoints & input, const bool use_resampling,
   const double input_points_interval) const
 {
-  autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_);
+  autoware_utils::ScopedTimeTrack st(__func__, *time_keeper_);
 
   if (input.size() < 3) {
     return input;  // cannot calculate the desired velocity. do nothing.
@@ -267,7 +267,7 @@ TrajectoryPoints SmootherBase::applySteeringRateLimit(
     }
 
     const auto steer_rate = steer_rate_arr.at(i);
-    if (steer_rate < autoware::universe_utils::deg2rad(base_param_.max_steering_angle_rate)) {
+    if (steer_rate < autoware_utils::deg2rad(base_param_.max_steering_angle_rate)) {
       continue;
     }
 
@@ -275,7 +275,7 @@ TrajectoryPoints SmootherBase::applySteeringRateLimit(
       (output.at(i).longitudinal_velocity_mps + output.at(i + 1).longitudinal_velocity_mps) / 2.0;
     const auto target_mean_vel =
       mean_vel *
-      (autoware::universe_utils::deg2rad(base_param_.max_steering_angle_rate) / steer_rate);
+      (autoware_utils::deg2rad(base_param_.max_steering_angle_rate) / steer_rate);
 
     for (size_t k = 0; k < 2; k++) {
       auto & velocity = output.at(i + k).longitudinal_velocity_mps;

--- a/planning/autoware_velocity_smoother/src/trajectory_utils.cpp
+++ b/planning/autoware_velocity_smoother/src/trajectory_utils.cpp
@@ -16,7 +16,7 @@
 
 #include "autoware/interpolation/linear_interpolation.hpp"
 #include "autoware/motion_utils/trajectory/trajectory.hpp"
-#include "autoware/universe_utils/geometry/geometry.hpp"
+#include "autoware_utils/geometry/geometry.hpp"
 
 #include <algorithm>
 #include <limits>
@@ -34,7 +34,7 @@ inline void convertEulerAngleToMonotonic(std::vector<double> & a)
 {
   for (unsigned int i = 1; i < a.size(); ++i) {
     const double da = a[i] - a[i - 1];
-    a[i] = a[i - 1] + autoware::universe_utils::normalizeRadian(da);
+    a[i] = a[i - 1] + autoware_utils::normalize_radian(da);
   }
 }
 
@@ -87,7 +87,7 @@ TrajectoryPoint calcInterpolatedTrajectoryPoint(
   {
     const auto & seg_pt = trajectory.at(seg_idx);
     const auto & next_pt = trajectory.at(seg_idx + 1);
-    traj_p.pose = autoware::universe_utils::calcInterpolatedPose(seg_pt.pose, next_pt.pose, prop);
+    traj_p.pose = autoware_utils::calc_interpolated_pose(seg_pt.pose, next_pt.pose, prop);
     traj_p.longitudinal_velocity_mps = autoware::interpolation::lerp(
       seg_pt.longitudinal_velocity_mps, next_pt.longitudinal_velocity_mps, prop);
     traj_p.acceleration_mps2 =
@@ -110,7 +110,7 @@ TrajectoryPoints extractPathAroundIndex(
   {
     double dist_sum = 0.0;
     for (size_t i = index; i < trajectory.size() - 1; ++i) {
-      dist_sum += autoware::universe_utils::calcDistance2d(trajectory.at(i), trajectory.at(i + 1));
+      dist_sum += autoware_utils::calc_distance2d(trajectory.at(i), trajectory.at(i + 1));
       if (dist_sum > ahead_length) {
         ahead_index = i + 1;
         break;
@@ -123,7 +123,7 @@ TrajectoryPoints extractPathAroundIndex(
   {
     double dist_sum{0.0};
     for (size_t i = index; i != 0; --i) {
-      dist_sum += autoware::universe_utils::calcDistance2d(trajectory.at(i), trajectory[i - 1]);
+      dist_sum += autoware_utils::calc_distance2d(trajectory.at(i), trajectory[i - 1]);
       if (dist_sum > behind_length) {
         behind_index = i - 1;
         break;
@@ -152,7 +152,7 @@ std::vector<double> calcArclengthArray(const TrajectoryPoints & trajectory)
   for (unsigned int i = 1; i < trajectory.size(); ++i) {
     const TrajectoryPoint tp = trajectory.at(i);
     const TrajectoryPoint tp_prev = trajectory.at(i - 1);
-    dist += autoware::universe_utils::calcDistance2d(tp.pose, tp_prev.pose);
+    dist += autoware_utils::calc_distance2d(tp.pose, tp_prev.pose);
     arclength.at(i) = dist;
   }
   return arclength;
@@ -164,7 +164,7 @@ std::vector<double> calcTrajectoryIntervalDistance(const TrajectoryPoints & traj
   for (unsigned int i = 1; i < trajectory.size(); ++i) {
     const TrajectoryPoint tp = trajectory.at(i);
     const TrajectoryPoint tp_prev = trajectory.at(i - 1);
-    const double dist = autoware::universe_utils::calcDistance2d(tp.pose, tp_prev.pose);
+    const double dist = autoware_utils::calc_distance2d(tp.pose, tp_prev.pose);
     intervals.push_back(dist);
   }
   return intervals;
@@ -173,8 +173,8 @@ std::vector<double> calcTrajectoryIntervalDistance(const TrajectoryPoints & traj
 std::vector<double> calcTrajectoryCurvatureFrom3Points(
   const TrajectoryPoints & trajectory, size_t idx_dist)
 {
-  using autoware::universe_utils::calcCurvature;
-  using autoware::universe_utils::getPoint;
+  using autoware_utils::calc_curvature;
+  using autoware_utils::get_point;
 
   if (trajectory.size() < 3) {
     const std::vector<double> k_arr(trajectory.size(), 0.0);
@@ -194,11 +194,11 @@ std::vector<double> calcTrajectoryCurvatureFrom3Points(
 
   for (size_t i = 1; i + 1 < trajectory.size(); i++) {
     double curvature = 0.0;
-    const auto p0 = getPoint(trajectory.at(i - std::min(idx_dist, i)));
-    const auto p1 = getPoint(trajectory.at(i));
-    const auto p2 = getPoint(trajectory.at(i + std::min(idx_dist, trajectory.size() - 1 - i)));
+    const auto p0 = get_point(trajectory.at(i - std::min(idx_dist, i)));
+    const auto p1 = get_point(trajectory.at(i));
+    const auto p2 = get_point(trajectory.at(i + std::min(idx_dist, trajectory.size() - 1 - i)));
     try {
-      curvature = calcCurvature(p0, p1, p2);
+      curvature = calc_curvature(p0, p1, p2);
     } catch (std::exception const & e) {
       // ...code that handles the error...
       RCLCPP_WARN(
@@ -466,7 +466,7 @@ double calcStopDistance(const TrajectoryPoints & trajectory, const size_t closes
 
   // TODO(Horibe): use arc length distance
   const double stop_dist =
-    autoware::universe_utils::calcDistance2d(trajectory.at(*idx), trajectory.at(closest));
+    autoware_utils::calc_distance2d(trajectory.at(*idx), trajectory.at(closest));
 
   return stop_dist;
 }

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/include/autoware/behavior_velocity_blind_spot_module/scene.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/include/autoware/behavior_velocity_blind_spot_module/scene.hpp
@@ -75,7 +75,7 @@ public:
     const int64_t module_id, const int64_t lane_id, const TurnDirection turn_direction,
     const std::shared_ptr<const PlannerData> planner_data, const PlannerParam & planner_param,
     const rclcpp::Logger logger, const rclcpp::Clock::SharedPtr clock,
-    const std::shared_ptr<universe_utils::TimeKeeper> time_keeper,
+    const std::shared_ptr<autoware_utils::TimeKeeper> time_keeper,
     const std::shared_ptr<planning_factor_interface::PlanningFactorInterface>
       planning_factor_interface);
 

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/src/scene.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/src/scene.cpp
@@ -41,7 +41,7 @@ BlindSpotModule::BlindSpotModule(
   const int64_t module_id, const int64_t lane_id, const TurnDirection turn_direction,
   const std::shared_ptr<const PlannerData> planner_data, const PlannerParam & planner_param,
   const rclcpp::Logger logger, const rclcpp::Clock::SharedPtr clock,
-  const std::shared_ptr<universe_utils::TimeKeeper> time_keeper,
+  const std::shared_ptr<autoware_utils::TimeKeeper> time_keeper,
   const std::shared_ptr<planning_factor_interface::PlanningFactorInterface>
     planning_factor_interface)
 : SceneModuleInterfaceWithRTC(module_id, logger, clock, time_keeper, planning_factor_interface),

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/scene_crosswalk.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/scene_crosswalk.cpp
@@ -176,7 +176,7 @@ CrosswalkModule::CrosswalkModule(
   const std::optional<int64_t> & reg_elem_id, const lanelet::LaneletMapPtr & lanelet_map_ptr,
   const PlannerParam & planner_param, const rclcpp::Logger & logger,
   const rclcpp::Clock::SharedPtr clock,
-  const std::shared_ptr<universe_utils::TimeKeeper> time_keeper,
+  const std::shared_ptr<autoware_utils::TimeKeeper> time_keeper,
   const std::shared_ptr<planning_factor_interface::PlanningFactorInterface>
     planning_factor_interface)
 : SceneModuleInterfaceWithRTC(module_id, logger, clock, time_keeper, planning_factor_interface),

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/scene_crosswalk.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/scene_crosswalk.hpp
@@ -51,7 +51,7 @@ namespace autoware::behavior_velocity_planner
 {
 namespace bg = boost::geometry;
 using autoware::universe_utils::Polygon2d;
-using autoware::universe_utils::StopWatch;
+using autoware_utils::StopWatch;
 using autoware_internal_planning_msgs::msg::PathWithLaneId;
 using autoware_perception_msgs::msg::ObjectClassification;
 using autoware_perception_msgs::msg::PredictedObject;
@@ -355,7 +355,7 @@ public:
     const std::optional<int64_t> & reg_elem_id, const lanelet::LaneletMapPtr & lanelet_map_ptr,
     const PlannerParam & planner_param, const rclcpp::Logger & logger,
     const rclcpp::Clock::SharedPtr clock,
-    const std::shared_ptr<universe_utils::TimeKeeper> time_keeper,
+    const std::shared_ptr<autoware_utils::TimeKeeper> time_keeper,
     const std::shared_ptr<planning_factor_interface::PlanningFactorInterface>
       planning_factor_interface);
 

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/scene_crosswalk.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/scene_crosswalk.hpp
@@ -51,12 +51,12 @@ namespace autoware::behavior_velocity_planner
 {
 namespace bg = boost::geometry;
 using autoware::universe_utils::Polygon2d;
-using autoware_utils::StopWatch;
 using autoware_internal_planning_msgs::msg::PathWithLaneId;
 using autoware_perception_msgs::msg::ObjectClassification;
 using autoware_perception_msgs::msg::PredictedObject;
 using autoware_perception_msgs::msg::PredictedObjects;
 using autoware_perception_msgs::msg::TrafficLightElement;
+using autoware_utils::StopWatch;
 using lanelet::autoware::Crosswalk;
 
 namespace

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_detection_area_module/src/scene.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_detection_area_module/src/scene.cpp
@@ -37,7 +37,7 @@ DetectionAreaModule::DetectionAreaModule(
   const lanelet::autoware::DetectionArea & detection_area_reg_elem,
   const PlannerParam & planner_param, const rclcpp::Logger & logger,
   const rclcpp::Clock::SharedPtr clock,
-  const std::shared_ptr<universe_utils::TimeKeeper> time_keeper,
+  const std::shared_ptr<autoware_utils::TimeKeeper> time_keeper,
   const std::shared_ptr<planning_factor_interface::PlanningFactorInterface>
     planning_factor_interface)
 : SceneModuleInterface(module_id, logger, clock, time_keeper, planning_factor_interface),

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_detection_area_module/src/scene.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_detection_area_module/src/scene.hpp
@@ -69,7 +69,7 @@ public:
     const lanelet::autoware::DetectionArea & detection_area_reg_elem,
     const PlannerParam & planner_param, const rclcpp::Logger & logger,
     const rclcpp::Clock::SharedPtr clock,
-    const std::shared_ptr<universe_utils::TimeKeeper> time_keeper,
+    const std::shared_ptr<autoware_utils::TimeKeeper> time_keeper,
     const std::shared_ptr<planning_factor_interface::PlanningFactorInterface>
       planning_factor_interface);
 

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_intersection.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_intersection.cpp
@@ -50,7 +50,7 @@ IntersectionModule::IntersectionModule(
   const PlannerParam & planner_param, const std::set<lanelet::Id> & associative_ids,
   const std::string & turn_direction, const bool has_traffic_light, rclcpp::Node & node,
   const rclcpp::Logger logger, const rclcpp::Clock::SharedPtr clock,
-  const std::shared_ptr<universe_utils::TimeKeeper> time_keeper,
+  const std::shared_ptr<autoware_utils::TimeKeeper> time_keeper,
   const std::shared_ptr<planning_factor_interface::PlanningFactorInterface>
     planning_factor_interface)
 : SceneModuleInterfaceWithRTC(module_id, logger, clock, time_keeper, planning_factor_interface),

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_intersection.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_intersection.hpp
@@ -306,7 +306,7 @@ public:
     const PlannerParam & planner_param, const std::set<lanelet::Id> & associative_ids,
     const std::string & turn_direction, const bool has_traffic_light, rclcpp::Node & node,
     const rclcpp::Logger logger, const rclcpp::Clock::SharedPtr clock,
-    const std::shared_ptr<universe_utils::TimeKeeper> time_keeper,
+    const std::shared_ptr<autoware_utils::TimeKeeper> time_keeper,
     const std::shared_ptr<planning_factor_interface::PlanningFactorInterface>
       planning_factor_interface);
 

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_merge_from_private_road.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_merge_from_private_road.cpp
@@ -43,7 +43,7 @@ MergeFromPrivateRoadModule::MergeFromPrivateRoadModule(
   [[maybe_unused]] std::shared_ptr<const PlannerData> planner_data,
   const PlannerParam & planner_param, const std::set<lanelet::Id> & associative_ids,
   const rclcpp::Logger logger, const rclcpp::Clock::SharedPtr clock,
-  const std::shared_ptr<universe_utils::TimeKeeper> time_keeper,
+  const std::shared_ptr<autoware_utils::TimeKeeper> time_keeper,
   const std::shared_ptr<planning_factor_interface::PlanningFactorInterface>
     planning_factor_interface)
 : SceneModuleInterface(module_id, logger, clock, time_keeper, planning_factor_interface),

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_merge_from_private_road.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_merge_from_private_road.hpp
@@ -62,7 +62,7 @@ public:
     const int64_t module_id, const int64_t lane_id, std::shared_ptr<const PlannerData> planner_data,
     const PlannerParam & planner_param, const std::set<lanelet::Id> & associative_ids,
     const rclcpp::Logger logger, const rclcpp::Clock::SharedPtr clock,
-    const std::shared_ptr<universe_utils::TimeKeeper> time_keeper,
+    const std::shared_ptr<autoware_utils::TimeKeeper> time_keeper,
     const std::shared_ptr<planning_factor_interface::PlanningFactorInterface>
       planning_factor_interface);
 

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_no_drivable_lane_module/src/scene.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_no_drivable_lane_module/src/scene.cpp
@@ -30,7 +30,7 @@ using autoware::universe_utils::createPoint;
 NoDrivableLaneModule::NoDrivableLaneModule(
   const int64_t module_id, const int64_t lane_id, const PlannerParam & planner_param,
   const rclcpp::Logger logger, const rclcpp::Clock::SharedPtr clock,
-  const std::shared_ptr<universe_utils::TimeKeeper> time_keeper,
+  const std::shared_ptr<autoware_utils::TimeKeeper> time_keeper,
   const std::shared_ptr<planning_factor_interface::PlanningFactorInterface>
     planning_factor_interface)
 : SceneModuleInterface(module_id, logger, clock, time_keeper, planning_factor_interface),

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_no_drivable_lane_module/src/scene.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_no_drivable_lane_module/src/scene.hpp
@@ -56,7 +56,7 @@ public:
   NoDrivableLaneModule(
     const int64_t module_id, const int64_t lane_id, const PlannerParam & planner_param,
     const rclcpp::Logger logger, const rclcpp::Clock::SharedPtr clock,
-    const std::shared_ptr<universe_utils::TimeKeeper> time_keeper,
+    const std::shared_ptr<autoware_utils::TimeKeeper> time_keeper,
     const std::shared_ptr<planning_factor_interface::PlanningFactorInterface>
       planning_factor_interface);
 

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_no_stopping_area_module/src/scene_no_stopping_area.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_no_stopping_area_module/src/scene_no_stopping_area.cpp
@@ -42,7 +42,7 @@ NoStoppingAreaModule::NoStoppingAreaModule(
   const lanelet::autoware::NoStoppingArea & no_stopping_area_reg_elem,
   const PlannerParam & planner_param, const rclcpp::Logger & logger,
   const rclcpp::Clock::SharedPtr clock,
-  const std::shared_ptr<universe_utils::TimeKeeper> time_keeper,
+  const std::shared_ptr<autoware_utils::TimeKeeper> time_keeper,
   const std::shared_ptr<planning_factor_interface::PlanningFactorInterface>
     planning_factor_interface)
 : SceneModuleInterfaceWithRTC(module_id, logger, clock, time_keeper, planning_factor_interface),

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_no_stopping_area_module/src/scene_no_stopping_area.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_no_stopping_area_module/src/scene_no_stopping_area.hpp
@@ -58,7 +58,7 @@ public:
     const lanelet::autoware::NoStoppingArea & no_stopping_area_reg_elem,
     const PlannerParam & planner_param, const rclcpp::Logger & logger,
     const rclcpp::Clock::SharedPtr clock,
-    const std::shared_ptr<universe_utils::TimeKeeper> time_keeper,
+    const std::shared_ptr<autoware_utils::TimeKeeper> time_keeper,
     const std::shared_ptr<planning_factor_interface::PlanningFactorInterface>
       planning_factor_interface);
 

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_occlusion_spot_module/src/scene_occlusion_spot.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_occlusion_spot_module/src/scene_occlusion_spot.cpp
@@ -65,7 +65,7 @@ OcclusionSpotModule::OcclusionSpotModule(
   const int64_t module_id, const std::shared_ptr<const PlannerData> & planner_data,
   const PlannerParam & planner_param, const rclcpp::Logger & logger,
   const rclcpp::Clock::SharedPtr clock,
-  const std::shared_ptr<universe_utils::TimeKeeper> time_keeper,
+  const std::shared_ptr<autoware_utils::TimeKeeper> time_keeper,
   const std::shared_ptr<planning_factor_interface::PlanningFactorInterface>
     planning_factor_interface)
 : SceneModuleInterface(module_id, logger, clock, time_keeper, planning_factor_interface),

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_occlusion_spot_module/src/scene_occlusion_spot.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_occlusion_spot_module/src/scene_occlusion_spot.hpp
@@ -49,7 +49,7 @@ public:
     const int64_t module_id, const std::shared_ptr<const PlannerData> & planner_data,
     const PlannerParam & planner_param, const rclcpp::Logger & logger,
     const rclcpp::Clock::SharedPtr clock,
-    const std::shared_ptr<universe_utils::TimeKeeper> time_keeper,
+    const std::shared_ptr<autoware_utils::TimeKeeper> time_keeper,
     const std::shared_ptr<planning_factor_interface::PlanningFactorInterface>
       planning_factor_interface);
 
@@ -64,7 +64,7 @@ public:
 private:
   // Parameter
   PlannerParam param_;
-  autoware::universe_utils::StopWatch<std::chrono::milliseconds> stop_watch_;
+  autoware_utils::StopWatch<std::chrono::milliseconds> stop_watch_;
   std::vector<lanelet::BasicPolygon2d> partition_lanelets_;
 
 protected:

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_occlusion_spot_module/test/src/test_grid_utils.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_occlusion_spot_module/test/src/test_grid_utils.cpp
@@ -16,7 +16,7 @@
 #include "utils.hpp"
 
 #include <autoware/behavior_velocity_planner_common/utilization/boost_geometry_helper.hpp>
-#include <autoware/universe_utils/system/stop_watch.hpp>
+#include <autoware_utils/system/stop_watch.hpp>
 
 #include <gtest/gtest.h>
 
@@ -87,7 +87,7 @@ TEST(compareTime, polygon_vs_line_iterator)
     }
   }
   const grid_map::Matrix & grid_data = grid["layer"];
-  autoware::universe_utils::StopWatch<std::chrono::milliseconds> stop_watch;
+  autoware_utils::StopWatch<std::chrono::milliseconds> stop_watch;
   stop_watch.tic("processing_time");
   size_t count = 0;
   [[maybe_unused]] double time = 0;

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/include/autoware/behavior_velocity_planner_common/scene_module_interface.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/include/autoware/behavior_velocity_planner_common/scene_module_interface.hpp
@@ -50,10 +50,10 @@ namespace autoware::behavior_velocity_planner
 
 using autoware::objects_of_interest_marker_interface::ColorName;
 using autoware::objects_of_interest_marker_interface::ObjectsOfInterestMarkerInterface;
-using autoware_utils::DebugPublisher;
-using autoware_utils::StopWatch;
 using autoware_internal_debug_msgs::msg::Float64Stamped;
 using autoware_internal_planning_msgs::msg::PathWithLaneId;
+using autoware_utils::DebugPublisher;
+using autoware_utils::StopWatch;
 using builtin_interfaces::msg::Time;
 using unique_identifier_msgs::msg::UUID;
 

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/include/autoware/behavior_velocity_planner_common/scene_module_interface.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/include/autoware/behavior_velocity_planner_common/scene_module_interface.hpp
@@ -21,10 +21,10 @@
 #include <autoware/motion_utils/trajectory/trajectory.hpp>
 #include <autoware/objects_of_interest_marker_interface/objects_of_interest_marker_interface.hpp>
 #include <autoware/planning_factor_interface/planning_factor_interface.hpp>
-#include <autoware/universe_utils/ros/debug_publisher.hpp>
-#include <autoware/universe_utils/ros/parameter.hpp>
-#include <autoware/universe_utils/system/stop_watch.hpp>
-#include <autoware/universe_utils/system/time_keeper.hpp>
+#include <autoware_utils/ros/debug_publisher.hpp>
+#include <autoware_utils/ros/parameter.hpp>
+#include <autoware_utils/system/stop_watch.hpp>
+#include <autoware_utils/system/time_keeper.hpp>
 #include <builtin_interfaces/msg/time.hpp>
 
 #include <autoware_internal_debug_msgs/msg/float64_stamped.hpp>
@@ -50,9 +50,8 @@ namespace autoware::behavior_velocity_planner
 
 using autoware::objects_of_interest_marker_interface::ColorName;
 using autoware::objects_of_interest_marker_interface::ObjectsOfInterestMarkerInterface;
-using autoware::universe_utils::DebugPublisher;
-using autoware::universe_utils::getOrDeclareParameter;
-using autoware::universe_utils::StopWatch;
+using autoware_utils::DebugPublisher;
+using autoware_utils::StopWatch;
 using autoware_internal_debug_msgs::msg::Float64Stamped;
 using autoware_internal_planning_msgs::msg::PathWithLaneId;
 using builtin_interfaces::msg::Time;
@@ -76,7 +75,7 @@ class SceneModuleInterface
 public:
   explicit SceneModuleInterface(
     const int64_t module_id, rclcpp::Logger logger, rclcpp::Clock::SharedPtr clock,
-    const std::shared_ptr<universe_utils::TimeKeeper> time_keeper,
+    const std::shared_ptr<autoware_utils::TimeKeeper> time_keeper,
     const std::shared_ptr<planning_factor_interface::PlanningFactorInterface>
       planning_factor_interface);
   virtual ~SceneModuleInterface() = default;
@@ -102,7 +101,7 @@ protected:
   rclcpp::Clock::SharedPtr clock_;
   std::shared_ptr<const PlannerData> planner_data_;
   std::vector<ObjectOfInterest> objects_of_interest_;
-  mutable std::shared_ptr<universe_utils::TimeKeeper> time_keeper_;
+  mutable std::shared_ptr<autoware_utils::TimeKeeper> time_keeper_;
   std::shared_ptr<planning_factor_interface::PlanningFactorInterface> planning_factor_interface_;
 
   void setObjectsOfInterestData(
@@ -141,10 +140,10 @@ public:
 
     processing_time_publisher_ = std::make_shared<DebugPublisher>(&node, "~/debug");
 
-    pub_processing_time_detail_ = node.create_publisher<universe_utils::ProcessingTimeDetail>(
+    pub_processing_time_detail_ = node.create_publisher<autoware_utils::ProcessingTimeDetail>(
       "~/debug/processing_time_detail_ms/" + std::string(module_name), 1);
 
-    time_keeper_ = std::make_shared<universe_utils::TimeKeeper>(pub_processing_time_detail_);
+    time_keeper_ = std::make_shared<autoware_utils::TimeKeeper>(pub_processing_time_detail_);
   }
 
   virtual ~SceneModuleManagerInterface() = default;
@@ -169,7 +168,7 @@ public:
 protected:
   virtual void modifyPathVelocity(autoware_internal_planning_msgs::msg::PathWithLaneId * path)
   {
-    universe_utils::ScopedTimeTrack st(
+    autoware_utils::ScopedTimeTrack st(
       "SceneModuleManagerInterface::modifyPathVelocity", *time_keeper_);
     StopWatch<std::chrono::milliseconds> stop_watch;
     stop_watch.tic("Total");
@@ -264,9 +263,9 @@ protected:
 
   std::shared_ptr<DebugPublisher> processing_time_publisher_;
 
-  rclcpp::Publisher<universe_utils::ProcessingTimeDetail>::SharedPtr pub_processing_time_detail_;
+  rclcpp::Publisher<autoware_utils::ProcessingTimeDetail>::SharedPtr pub_processing_time_detail_;
 
-  std::shared_ptr<universe_utils::TimeKeeper> time_keeper_;
+  std::shared_ptr<autoware_utils::TimeKeeper> time_keeper_;
 
   std::shared_ptr<planning_factor_interface::PlanningFactorInterface> planning_factor_interface_;
 };

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/include/autoware/behavior_velocity_planner_common/utilization/arc_lane_util.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/include/autoware/behavior_velocity_planner_common/utilization/arc_lane_util.hpp
@@ -40,9 +40,8 @@ inline geometry_msgs::msg::Point convertToGeomPoint(const autoware_utils::Point2
 
 namespace arc_lane_utils
 {
-using PathIndexWithPose = std::pair<size_t, geometry_msgs::msg::Pose>;  // front index, pose
-using PathIndexWithPoint2d =
-  std::pair<size_t, autoware_utils::Point2d>;                   // front index, point2d
+using PathIndexWithPose = std::pair<size_t, geometry_msgs::msg::Pose>;    // front index, pose
+using PathIndexWithPoint2d = std::pair<size_t, autoware_utils::Point2d>;  // front index, point2d
 using PathIndexWithPoint = std::pair<size_t, geometry_msgs::msg::Point>;  // front index, point2d
 using PathIndexWithOffset = std::pair<size_t, double>;                    // front index, offset
 
@@ -60,8 +59,7 @@ std::optional<PathIndexWithPoint> findCollisionSegment(
   const geometry_msgs::msg::Point & stop_line_p2)
 {
   for (size_t i = 0; i < path.points.size() - 1; ++i) {
-    const auto & p1 =
-      autoware_utils::get_point(path.points.at(i));  // Point before collision point
+    const auto & p1 = autoware_utils::get_point(path.points.at(i));  // Point before collision point
     const auto & p2 =
       autoware_utils::get_point(path.points.at(i + 1));  // Point after collision point
 
@@ -117,8 +115,7 @@ std::optional<PathIndexWithOffset> findBackwardOffsetSegment(
   double sum_length = 0.0;
   const auto start = static_cast<std::int32_t>(base_idx) - 1;
   for (std::int32_t i = start; i >= 0; --i) {
-    sum_length +=
-      autoware_utils::calc_distance2d(path.points.at(i), path.points.at(i + 1));
+    sum_length += autoware_utils::calc_distance2d(path.points.at(i), path.points.at(i + 1));
 
     // If it's over offset point, return front index and remain offset length
     /**

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/include/autoware/behavior_velocity_planner_common/utilization/arc_lane_util.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/include/autoware/behavior_velocity_planner_common/utilization/arc_lane_util.hpp
@@ -16,7 +16,7 @@
 #define AUTOWARE__BEHAVIOR_VELOCITY_PLANNER_COMMON__UTILIZATION__ARC_LANE_UTIL_HPP_
 
 #include <autoware/behavior_velocity_planner_common/utilization/boost_geometry_helper.hpp>
-#include <autoware/universe_utils/geometry/geometry.hpp>
+#include <autoware_utils/geometry/geometry.hpp>
 
 #include <autoware_internal_planning_msgs/msg/path_with_lane_id.hpp>
 
@@ -29,7 +29,7 @@
 namespace autoware::behavior_velocity_planner
 {
 
-inline geometry_msgs::msg::Point convertToGeomPoint(const autoware::universe_utils::Point2d & p)
+inline geometry_msgs::msg::Point convertToGeomPoint(const autoware_utils::Point2d & p)
 {
   geometry_msgs::msg::Point geom_p;
   geom_p.x = p.x();
@@ -42,7 +42,7 @@ namespace arc_lane_utils
 {
 using PathIndexWithPose = std::pair<size_t, geometry_msgs::msg::Pose>;  // front index, pose
 using PathIndexWithPoint2d =
-  std::pair<size_t, autoware::universe_utils::Point2d>;                   // front index, point2d
+  std::pair<size_t, autoware_utils::Point2d>;                   // front index, point2d
 using PathIndexWithPoint = std::pair<size_t, geometry_msgs::msg::Point>;  // front index, point2d
 using PathIndexWithOffset = std::pair<size_t, double>;                    // front index, offset
 
@@ -61,9 +61,9 @@ std::optional<PathIndexWithPoint> findCollisionSegment(
 {
   for (size_t i = 0; i < path.points.size() - 1; ++i) {
     const auto & p1 =
-      autoware::universe_utils::getPoint(path.points.at(i));  // Point before collision point
+      autoware_utils::get_point(path.points.at(i));  // Point before collision point
     const auto & p2 =
-      autoware::universe_utils::getPoint(path.points.at(i + 1));  // Point after collision point
+      autoware_utils::get_point(path.points.at(i + 1));  // Point after collision point
 
     const auto collision_point = checkCollision(p1, p2, stop_line_p1, stop_line_p2);
 
@@ -92,7 +92,7 @@ std::optional<PathIndexWithOffset> findForwardOffsetSegment(
   double sum_length = 0.0;
   for (size_t i = base_idx; i < path.points.size() - 1; ++i) {
     const double segment_length =
-      autoware::universe_utils::calcDistance2d(path.points.at(i), path.points.at(i + 1));
+      autoware_utils::calc_distance2d(path.points.at(i), path.points.at(i + 1));
 
     // If it's over offset point, return front index and remain offset length
     /**
@@ -118,7 +118,7 @@ std::optional<PathIndexWithOffset> findBackwardOffsetSegment(
   const auto start = static_cast<std::int32_t>(base_idx) - 1;
   for (std::int32_t i = start; i >= 0; --i) {
     sum_length +=
-      autoware::universe_utils::calcDistance2d(path.points.at(i), path.points.at(i + 1));
+      autoware_utils::calc_distance2d(path.points.at(i), path.points.at(i + 1));
 
     // If it's over offset point, return front index and remain offset length
     /**
@@ -146,13 +146,13 @@ std::optional<PathIndexWithOffset> findOffsetSegment(
     return findForwardOffsetSegment(
       path, collision_idx,
       offset_length +
-        autoware::universe_utils::calcDistance2d(path.points.at(collision_idx), collision_point));
+        autoware_utils::calc_distance2d(path.points.at(collision_idx), collision_point));
   }
 
   return findBackwardOffsetSegment(
     path, collision_idx + 1,
     -offset_length +
-      autoware::universe_utils::calcDistance2d(path.points.at(collision_idx + 1), collision_point));
+      autoware_utils::calc_distance2d(path.points.at(collision_idx + 1), collision_point));
 }
 
 std::optional<PathIndexWithOffset> findOffsetSegment(
@@ -186,8 +186,8 @@ geometry_msgs::msg::Pose calcTargetPose(const T & path, const PathIndexWithOffse
   target_pose.position.x = target_point_2d.x();
   target_pose.position.y = target_point_2d.y();
   target_pose.position.z = interpolated_z;
-  const double yaw = autoware::universe_utils::calcAzimuthAngle(p_front, p_back);
-  target_pose.orientation = autoware::universe_utils::createQuaternionFromYaw(yaw);
+  const double yaw = autoware_utils::calc_azimuth_angle(p_front, p_back);
+  target_pose.orientation = autoware_utils::create_quaternion_from_yaw(yaw);
   return target_pose;
 }
 

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/include/autoware/behavior_velocity_planner_common/utilization/boost_geometry_helper.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/include/autoware/behavior_velocity_planner_common/utilization/boost_geometry_helper.hpp
@@ -15,7 +15,7 @@
 #ifndef AUTOWARE__BEHAVIOR_VELOCITY_PLANNER_COMMON__UTILIZATION__BOOST_GEOMETRY_HELPER_HPP_
 #define AUTOWARE__BEHAVIOR_VELOCITY_PLANNER_COMMON__UTILIZATION__BOOST_GEOMETRY_HELPER_HPP_
 
-#include <autoware/universe_utils/geometry/boost_geometry.hpp>
+#include <autoware_utils/geometry/boost_geometry.hpp>
 
 #include <autoware_internal_planning_msgs/msg/path_point_with_lane_id.hpp>
 #include <autoware_planning_msgs/msg/path_point.hpp>
@@ -50,9 +50,9 @@ namespace autoware::behavior_velocity_planner
 {
 namespace bg = boost::geometry;
 
-using Point2d = autoware::universe_utils::Point2d;
-using LineString2d = autoware::universe_utils::LineString2d;
-using Polygon2d = autoware::universe_utils::Polygon2d;
+using Point2d = autoware_utils::Point2d;
+using LineString2d = autoware_utils::LineString2d;
+using Polygon2d = autoware_utils::Polygon2d;
 
 template <class T>
 Point2d to_bg2d(const T & p)

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/include/autoware/behavior_velocity_planner_common/utilization/util.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/include/autoware/behavior_velocity_planner_common/utilization/util.hpp
@@ -15,7 +15,7 @@
 #ifndef AUTOWARE__BEHAVIOR_VELOCITY_PLANNER_COMMON__UTILIZATION__UTIL_HPP_
 #define AUTOWARE__BEHAVIOR_VELOCITY_PLANNER_COMMON__UTILIZATION__UTIL_HPP_
 
-#include "autoware/universe_utils/geometry/boost_geometry.hpp"
+#include <autoware_utils/geometry/boost_geometry.hpp>
 
 #include <autoware_internal_planning_msgs/msg/path_with_lane_id.hpp>
 #include <autoware_perception_msgs/msg/predicted_objects.hpp>
@@ -62,9 +62,9 @@ struct TrafficSignalStamped
 };
 
 using Pose = geometry_msgs::msg::Pose;
-using Point2d = autoware::universe_utils::Point2d;
-using LineString2d = autoware::universe_utils::LineString2d;
-using Polygon2d = autoware::universe_utils::Polygon2d;
+using Point2d = autoware_utils::Point2d;
+using LineString2d = autoware_utils::LineString2d;
+using Polygon2d = autoware_utils::Polygon2d;
 using BasicPolygons2d = std::vector<lanelet::BasicPolygon2d>;
 using Polygons2d = std::vector<Polygon2d>;
 using autoware_internal_planning_msgs::msg::PathPointWithLaneId;

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/package.xml
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/package.xml
@@ -30,7 +30,7 @@
   <depend>autoware_planning_factor_interface</depend>
   <depend>autoware_planning_msgs</depend>
   <depend>autoware_route_handler</depend>
-  <depend>autoware_universe_utils</depend>
+  <depend>autoware_utils</depend>
   <depend>autoware_vehicle_info_utils</depend>
   <depend>autoware_velocity_smoother</depend>
   <depend>diagnostic_msgs</depend>

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/src/scene_module_interface.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/src/scene_module_interface.cpp
@@ -14,7 +14,7 @@
 
 #include <autoware/behavior_velocity_planner_common/scene_module_interface.hpp>
 #include <autoware/motion_utils/trajectory/trajectory.hpp>
-#include <autoware/universe_utils/system/time_keeper.hpp>
+#include <autoware_utils/system/time_keeper.hpp>
 
 #include <algorithm>
 #include <limits>
@@ -26,7 +26,7 @@ namespace autoware::behavior_velocity_planner
 
 SceneModuleInterface::SceneModuleInterface(
   const int64_t module_id, rclcpp::Logger logger, rclcpp::Clock::SharedPtr clock,
-  const std::shared_ptr<universe_utils::TimeKeeper> time_keeper,
+  const std::shared_ptr<autoware_utils::TimeKeeper> time_keeper,
   const std::shared_ptr<planning_factor_interface::PlanningFactorInterface>
     planning_factor_interface)
 : module_id_(module_id),

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/src/utilization/arc_lane_util.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/src/utilization/arc_lane_util.cpp
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include <autoware/behavior_velocity_planner_common/utilization/arc_lane_util.hpp>
-#include <autoware/universe_utils/geometry/geometry.hpp>
 
 #include <autoware_internal_planning_msgs/msg/path_with_lane_id.hpp>
 

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/src/utilization/debug.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/src/utilization/debug.cpp
@@ -34,7 +34,8 @@ visualization_msgs::msg::MarkerArray createPolygonMarkerArray(
     auto marker = create_default_marker(
       "map", now, ns, static_cast<int32_t>(module_id), visualization_msgs::msg::Marker::LINE_STRIP,
       create_marker_scale(static_cast<float>(x), static_cast<float>(y), static_cast<float>(z)),
-      create_marker_color(static_cast<float>(r), static_cast<float>(g), static_cast<float>(b), 0.8f));
+      create_marker_color(
+        static_cast<float>(r), static_cast<float>(g), static_cast<float>(b), 0.8f));
     marker.lifetime = rclcpp::Duration::from_seconds(0.3);
 
     for (const auto & p : polygon.points) {
@@ -116,7 +117,8 @@ visualization_msgs::msg::MarkerArray createPointsMarkerArray(
 
   auto marker = create_default_marker(
     "map", now, ns, 0, visualization_msgs::msg::Marker::SPHERE, create_marker_scale(x, y, z),
-    create_marker_color(static_cast<float>(r), static_cast<float>(g), static_cast<float>(b), 0.999f));
+    create_marker_color(
+      static_cast<float>(r), static_cast<float>(g), static_cast<float>(b), 0.999f));
   marker.lifetime = rclcpp::Duration::from_seconds(0.3);
   for (size_t i = 0; i < points.size(); ++i) {
     marker.id = static_cast<int32_t>(i + planning_utils::bitShift(module_id));

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/src/utilization/debug.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/src/utilization/debug.cpp
@@ -14,15 +14,15 @@
 
 #include <autoware/behavior_velocity_planner_common/utilization/debug.hpp>
 #include <autoware/behavior_velocity_planner_common/utilization/util.hpp>
-#include <autoware/universe_utils/ros/marker_helper.hpp>
+#include <autoware_utils/ros/marker_helper.hpp>
 
 #include <string>
 #include <vector>
 namespace autoware::behavior_velocity_planner::debug
 {
-using autoware::universe_utils::createDefaultMarker;
-using autoware::universe_utils::createMarkerColor;
-using autoware::universe_utils::createMarkerScale;
+using autoware_utils::create_default_marker;
+using autoware_utils::create_marker_color;
+using autoware_utils::create_marker_scale;
 
 visualization_msgs::msg::MarkerArray createPolygonMarkerArray(
   const geometry_msgs::msg::Polygon & polygon, const std::string & ns, const int64_t module_id,

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/src/utilization/debug.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/src/utilization/debug.cpp
@@ -31,10 +31,10 @@ visualization_msgs::msg::MarkerArray createPolygonMarkerArray(
 {
   visualization_msgs::msg::MarkerArray msg;
   {
-    auto marker = createDefaultMarker(
+    auto marker = create_default_marker(
       "map", now, ns, static_cast<int32_t>(module_id), visualization_msgs::msg::Marker::LINE_STRIP,
-      createMarkerScale(static_cast<float>(x), static_cast<float>(y), static_cast<float>(z)),
-      createMarkerColor(static_cast<float>(r), static_cast<float>(g), static_cast<float>(b), 0.8f));
+      create_marker_scale(static_cast<float>(x), static_cast<float>(y), static_cast<float>(z)),
+      create_marker_color(static_cast<float>(r), static_cast<float>(g), static_cast<float>(b), 0.8f));
     marker.lifetime = rclcpp::Duration::from_seconds(0.3);
 
     for (const auto & p : polygon.points) {
@@ -63,21 +63,21 @@ visualization_msgs::msg::MarkerArray createPathMarkerArray(
   for (size_t i = 0; i < path.points.size(); ++i) {
     const auto & p = path.points.at(i);
 
-    auto marker = createDefaultMarker(
+    auto marker = create_default_marker(
       "map", now, ns, static_cast<int32_t>(planning_utils::bitShift(lane_id) + i),
       visualization_msgs::msg::Marker::ARROW,
-      createMarkerScale(static_cast<float>(x), static_cast<float>(y), static_cast<float>(z)),
-      createMarkerColor(
+      create_marker_scale(static_cast<float>(x), static_cast<float>(y), static_cast<float>(z)),
+      create_marker_color(
         static_cast<float>(r), static_cast<float>(g), static_cast<float>(b), 0.999f));
     marker.lifetime = rclcpp::Duration::from_seconds(0.3);
     marker.pose = p.point.pose;
 
     if (std::find(p.lane_ids.begin(), p.lane_ids.end(), lane_id) != p.lane_ids.end()) {
       // if p.lane_ids has lane_id
-      marker.color = createMarkerColor(
+      marker.color = create_marker_color(
         static_cast<float>(r), static_cast<float>(g), static_cast<float>(b), 0.999f);
     } else {
-      marker.color = createMarkerColor(0.5, 0.5, 0.5, 0.999);
+      marker.color = create_marker_color(0.5, 0.5, 0.5, 0.999);
     }
     msg.markers.push_back(marker);
   }
@@ -91,9 +91,9 @@ visualization_msgs::msg::MarkerArray createObjectsMarkerArray(
 {
   visualization_msgs::msg::MarkerArray msg;
 
-  auto marker = createDefaultMarker(
-    "map", now, ns, 0, visualization_msgs::msg::Marker::CUBE, createMarkerScale(3.0, 1.0, 1.0),
-    createMarkerColor(static_cast<float>(r), static_cast<float>(g), static_cast<float>(b), 0.8f));
+  auto marker = create_default_marker(
+    "map", now, ns, 0, visualization_msgs::msg::Marker::CUBE, create_marker_scale(3.0, 1.0, 1.0),
+    create_marker_color(static_cast<float>(r), static_cast<float>(g), static_cast<float>(b), 0.8f));
   marker.lifetime = rclcpp::Duration::from_seconds(1.0);
 
   for (size_t i = 0; i < objects.objects.size(); ++i) {
@@ -114,9 +114,9 @@ visualization_msgs::msg::MarkerArray createPointsMarkerArray(
 {
   visualization_msgs::msg::MarkerArray msg;
 
-  auto marker = createDefaultMarker(
-    "map", now, ns, 0, visualization_msgs::msg::Marker::SPHERE, createMarkerScale(x, y, z),
-    createMarkerColor(static_cast<float>(r), static_cast<float>(g), static_cast<float>(b), 0.999f));
+  auto marker = create_default_marker(
+    "map", now, ns, 0, visualization_msgs::msg::Marker::SPHERE, create_marker_scale(x, y, z),
+    create_marker_color(static_cast<float>(r), static_cast<float>(g), static_cast<float>(b), 0.999f));
   marker.lifetime = rclcpp::Duration::from_seconds(0.3);
   for (size_t i = 0; i < points.size(); ++i) {
     marker.id = static_cast<int32_t>(i + planning_utils::bitShift(module_id));

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/src/utilization/path_utilization.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/src/utilization/path_utilization.cpp
@@ -15,7 +15,7 @@
 #include <autoware/behavior_velocity_planner_common/utilization/path_utilization.hpp>
 #include <autoware/motion_utils/resample/resample.hpp>
 #include <autoware/motion_utils/trajectory/trajectory.hpp>
-#include <autoware/universe_utils/geometry/geometry.hpp>
+#include <autoware_utils/geometry/geometry.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include <algorithm>
@@ -77,7 +77,7 @@ autoware_planning_msgs::msg::Path interpolatePath(
       v.push_back(path_point.longitudinal_velocity_mps);
       if (idx != 0) {
         const auto path_point_prev = path.points.at(idx - 1);
-        s += autoware::universe_utils::calcDistance2d(path_point_prev.pose, path_point.pose);
+        s += autoware_utils::calc_distance2d(path_point_prev.pose, path_point.pose);
       }
       if (s > path_len) {
         break;

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/src/utilization/util.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/src/utilization/util.cpp
@@ -16,7 +16,7 @@
 
 #include "autoware/behavior_velocity_planner_common/utilization/boost_geometry_helper.hpp"
 #include "autoware/motion_utils/trajectory/trajectory.hpp"
-#include "autoware/universe_utils/geometry/geometry.hpp"
+#include "autoware_utils/geometry/geometry.hpp"
 #include "autoware_lanelet2_extension/utility/query.hpp"
 
 #include <autoware_planning_msgs/msg/path_point.hpp>
@@ -50,9 +50,9 @@ size_t calcPointIndexFromSegmentIndex(
   const size_t next_point_idx = seg_idx + 1;
 
   const double prev_dist =
-    autoware::universe_utils::calcDistance2d(point, points.at(prev_point_idx));
+    autoware_utils::calc_distance2d(point, points.at(prev_point_idx));
   const double next_dist =
-    autoware::universe_utils::calcDistance2d(point, points.at(next_point_idx));
+    autoware_utils::calc_distance2d(point, points.at(next_point_idx));
 
   if (prev_dist < next_dist) {
     return prev_point_idx;
@@ -66,7 +66,7 @@ PathPoint getLerpPathPointWithLaneId(const PathPoint p0, const PathPoint p1, con
 {
   auto lerp = [](const double a, const double b, const double t) { return a + t * (b - a); };
   PathPoint p;
-  p.pose = autoware::universe_utils::calcInterpolatedPose(p0, p1, ratio);
+  p.pose = autoware_utils::calc_interpolated_pose(p0, p1, ratio);
   const double v = lerp(p0.longitudinal_velocity_mps, p1.longitudinal_velocity_mps, ratio);
   p.longitudinal_velocity_mps = static_cast<float>(v);
   return p;
@@ -88,7 +88,7 @@ geometry_msgs::msg::Pose transformRelCoordinate2D(
   res.position.y = ((-1.0) * std::sin(yaw) * trans_p.x) + (std::cos(yaw) * trans_p.y);
   res.position.z = target.position.z - origin.position.z;
   res.orientation =
-    autoware::universe_utils::createQuaternionFromYaw(tf2::getYaw(target.orientation) - yaw);
+    autoware_utils::create_quaternion_from_yaw(tf2::getYaw(target.orientation) - yaw);
 
   return res;
 }
@@ -98,8 +98,8 @@ geometry_msgs::msg::Pose transformRelCoordinate2D(
 namespace autoware::behavior_velocity_planner::planning_utils
 {
 using autoware::motion_utils::calcSignedArcLength;
-using autoware::universe_utils::calcDistance2d;
-using autoware::universe_utils::calcOffsetPose;
+using autoware_utils::calcDistance2d;
+using autoware_utils::calcOffsetPose;
 using autoware_planning_msgs::msg::PathPoint;
 
 size_t calcSegmentIndexFromPointIndex(
@@ -312,7 +312,7 @@ geometry_msgs::msg::Pose getAheadPose(
   for (size_t i = start_idx; i < path.points.size() - 1; ++i) {
     const geometry_msgs::msg::Pose p0 = path.points.at(i).point.pose;
     const geometry_msgs::msg::Pose p1 = path.points.at(i + 1).point.pose;
-    curr_dist += autoware::universe_utils::calcDistance2d(p0, p1);
+    curr_dist += autoware_utils::calc_distance2d(p0, p1);
     if (curr_dist > ahead_dist) {
       const double dl = std::max(curr_dist - prev_dist, 0.0001 /* avoid 0 divide */);
       const double w_p0 = (curr_dist - ahead_dist) / dl;
@@ -625,7 +625,7 @@ std::optional<geometry_msgs::msg::Pose> insertDecelPoint(
     output.points.at(i).point.longitudinal_velocity_mps =
       std::min(original_velocity, target_velocity);
   }
-  return autoware::universe_utils::getPose(output.points.at(insert_idx.value()));
+  return autoware_utils::get_pose(output.points.at(insert_idx.value()));
 }
 
 // TODO(murooka): remove this function for u-turn and crossing-path
@@ -641,7 +641,7 @@ std::optional<geometry_msgs::msg::Pose> insertStopPoint(
     return {};
   }
 
-  return autoware::universe_utils::getPose(output.points.at(insert_idx.value()));
+  return autoware_utils::get_pose(output.points.at(insert_idx.value()));
 }
 
 std::optional<geometry_msgs::msg::Pose> insertStopPoint(
@@ -654,7 +654,7 @@ std::optional<geometry_msgs::msg::Pose> insertStopPoint(
     return {};
   }
 
-  return autoware::universe_utils::getPose(output.points.at(insert_idx.value()));
+  return autoware_utils::get_pose(output.points.at(insert_idx.value()));
 }
 
 std::set<lanelet::Id> getAssociativeIntersectionLanelets(

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/src/utilization/util.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/src/utilization/util.cpp
@@ -97,8 +97,8 @@ namespace autoware::behavior_velocity_planner::planning_utils
 {
 using autoware::motion_utils::calcSignedArcLength;
 using autoware_planning_msgs::msg::PathPoint;
-using autoware_utils::calcDistance2d;
-using autoware_utils::calcOffsetPose;
+using autoware_utils::calc_distance2d;
+using autoware_utils::calc_offset_pose;
 
 size_t calcSegmentIndexFromPointIndex(
   const std::vector<autoware_internal_planning_msgs::msg::PathPointWithLaneId> & points,
@@ -125,7 +125,7 @@ size_t calcSegmentIndexFromPointIndex(
 Point2d calculateOffsetPoint2d(
   const geometry_msgs::msg::Pose & pose, const double offset_x, const double offset_y)
 {
-  return to_bg2d(calcOffsetPose(pose, offset_x, offset_y, 0.0));
+  return to_bg2d(calc_offset_pose(pose, offset_x, offset_y, 0.0));
 }
 
 bool createDetectionAreaPolygons(
@@ -163,7 +163,7 @@ bool createDetectionAreaPolygons(
   if (dist_to_nearest > eps) {
     // interpolate ego point
     const auto & pp = path.points;
-    const double ds = calcDistance2d(pp.at(target_seg_idx), pp.at(target_seg_idx + 1));
+    const double ds = calc_distance2d(pp.at(target_seg_idx), pp.at(target_seg_idx + 1));
     const double dist_to_target_seg =
       calcSignedArcLength(path.points, target_seg_idx, target_pose.position, target_seg_idx);
     const double ratio = dist_to_target_seg / ds;
@@ -184,7 +184,7 @@ bool createDetectionAreaPolygons(
   LineString2d right_outer_bound = {calculateOffsetPoint2d(p0.pose, min_len, -offset_right - eps)};
   for (size_t s = first_idx; s <= max_index; s++) {
     const auto p1 = path.points.at(s).point;
-    const double ds = calcDistance2d(p0, p1);
+    const double ds = calc_distance2d(p0, p1);
     dist_sum += ds;
     length += ds;
     // calculate the distance that obstacles can move until ego reach the trajectory point
@@ -274,7 +274,7 @@ void insertVelocity(
   int max_idx =
     std::min(static_cast<int>(insert_index + 1), static_cast<int>(path.points.size() - 1));
   for (int i = min_idx; i <= max_idx; i++) {
-    if (calcDistance2d(path.points.at(static_cast<size_t>(i)), path_point) < min_distance) {
+    if (calc_distance2d(path.points.at(static_cast<size_t>(i)), path_point) < min_distance) {
       path.points.at(i).point.longitudinal_velocity_mps = v;
       already_has_path_point = true;
       insert_index = static_cast<size_t>(i);

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/src/utilization/util.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/src/utilization/util.cpp
@@ -16,8 +16,8 @@
 
 #include "autoware/behavior_velocity_planner_common/utilization/boost_geometry_helper.hpp"
 #include "autoware/motion_utils/trajectory/trajectory.hpp"
-#include "autoware_utils/geometry/geometry.hpp"
 #include "autoware_lanelet2_extension/utility/query.hpp"
+#include "autoware_utils/geometry/geometry.hpp"
 
 #include <autoware_planning_msgs/msg/path_point.hpp>
 
@@ -49,10 +49,8 @@ size_t calcPointIndexFromSegmentIndex(
   const size_t prev_point_idx = seg_idx;
   const size_t next_point_idx = seg_idx + 1;
 
-  const double prev_dist =
-    autoware_utils::calc_distance2d(point, points.at(prev_point_idx));
-  const double next_dist =
-    autoware_utils::calc_distance2d(point, points.at(next_point_idx));
+  const double prev_dist = autoware_utils::calc_distance2d(point, points.at(prev_point_idx));
+  const double next_dist = autoware_utils::calc_distance2d(point, points.at(next_point_idx));
 
   if (prev_dist < next_dist) {
     return prev_point_idx;
@@ -98,9 +96,9 @@ geometry_msgs::msg::Pose transformRelCoordinate2D(
 namespace autoware::behavior_velocity_planner::planning_utils
 {
 using autoware::motion_utils::calcSignedArcLength;
+using autoware_planning_msgs::msg::PathPoint;
 using autoware_utils::calcDistance2d;
 using autoware_utils::calcOffsetPose;
-using autoware_planning_msgs::msg::PathPoint;
 
 size_t calcSegmentIndexFromPointIndex(
   const std::vector<autoware_internal_planning_msgs::msg::PathPointWithLaneId> & points,

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/test/src/test_trajectory_utils.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/test/src/test_trajectory_utils.cpp
@@ -77,7 +77,7 @@ TEST(smoothPath, nominal)
 
   planner_data->velocity_smoother_ =
     std::make_shared<autoware::velocity_smoother::JerkFilteredSmoother>(
-      *node, std::make_shared<autoware::universe_utils::TimeKeeper>());
+      *node, std::make_shared<autoware_utils::TimeKeeper>());
 
   // Input path
   PathWithLaneId in_path;

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_rtc_interface/include/autoware/behavior_velocity_rtc_interface/scene_module_interface_with_rtc.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_rtc_interface/include/autoware/behavior_velocity_rtc_interface/scene_module_interface_with_rtc.hpp
@@ -53,7 +53,7 @@ class SceneModuleInterfaceWithRTC : public SceneModuleInterface
 public:
   explicit SceneModuleInterfaceWithRTC(
     const int64_t module_id, rclcpp::Logger logger, rclcpp::Clock::SharedPtr clock,
-    const std::shared_ptr<universe_utils::TimeKeeper> time_keeper,
+    const std::shared_ptr<autoware_utils::TimeKeeper> time_keeper,
     const std::shared_ptr<planning_factor_interface::PlanningFactorInterface>
       planning_factor_interface);
   virtual ~SceneModuleInterfaceWithRTC() = default;

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_rtc_interface/src/scene_module_interface_with_rtc.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_rtc_interface/src/scene_module_interface_with_rtc.cpp
@@ -28,7 +28,7 @@ namespace autoware::behavior_velocity_planner
 
 SceneModuleInterfaceWithRTC::SceneModuleInterfaceWithRTC(
   const int64_t module_id, rclcpp::Logger logger, rclcpp::Clock::SharedPtr clock,
-  const std::shared_ptr<universe_utils::TimeKeeper> time_keeper,
+  const std::shared_ptr<autoware_utils::TimeKeeper> time_keeper,
   const std::shared_ptr<planning_factor_interface::PlanningFactorInterface>
     planning_factor_interface)
 : SceneModuleInterface(module_id, logger, clock, time_keeper, planning_factor_interface),

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_run_out_module/src/scene.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_run_out_module/src/scene.cpp
@@ -47,7 +47,7 @@ RunOutModule::RunOutModule(
   const PlannerParam & planner_param, const rclcpp::Logger logger,
   std::unique_ptr<DynamicObstacleCreator> dynamic_obstacle_creator,
   const std::shared_ptr<RunOutDebug> & debug_ptr, const rclcpp::Clock::SharedPtr clock,
-  const std::shared_ptr<universe_utils::TimeKeeper> time_keeper,
+  const std::shared_ptr<autoware_utils::TimeKeeper> time_keeper,
   const std::shared_ptr<planning_factor_interface::PlanningFactorInterface>
     planning_factor_interface)
 : SceneModuleInterface(module_id, logger, clock, time_keeper, planning_factor_interface),

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_run_out_module/src/scene.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_run_out_module/src/scene.hpp
@@ -48,7 +48,7 @@ public:
     const PlannerParam & planner_param, const rclcpp::Logger logger,
     std::unique_ptr<DynamicObstacleCreator> dynamic_obstacle_creator,
     const std::shared_ptr<RunOutDebug> & debug_ptr, const rclcpp::Clock::SharedPtr clock,
-    const std::shared_ptr<universe_utils::TimeKeeper> time_keeper,
+    const std::shared_ptr<autoware_utils::TimeKeeper> time_keeper,
     const std::shared_ptr<planning_factor_interface::PlanningFactorInterface>
       planning_factor_interface);
 

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_speed_bump_module/src/scene.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_speed_bump_module/src/scene.cpp
@@ -35,7 +35,7 @@ SpeedBumpModule::SpeedBumpModule(
   const int64_t module_id, const int64_t lane_id,
   const lanelet::autoware::SpeedBump & speed_bump_reg_elem, const PlannerParam & planner_param,
   const rclcpp::Logger & logger, const rclcpp::Clock::SharedPtr clock,
-  const std::shared_ptr<universe_utils::TimeKeeper> time_keeper,
+  const std::shared_ptr<autoware_utils::TimeKeeper> time_keeper,
   const std::shared_ptr<planning_factor_interface::PlanningFactorInterface>
     planning_factor_interface)
 : SceneModuleInterface(module_id, logger, clock, time_keeper, planning_factor_interface),

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_speed_bump_module/src/scene.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_speed_bump_module/src/scene.hpp
@@ -56,7 +56,7 @@ public:
     const int64_t module_id, const int64_t lane_id,
     const lanelet::autoware::SpeedBump & speed_bump_reg_elem, const PlannerParam & planner_param,
     const rclcpp::Logger & logger, const rclcpp::Clock::SharedPtr clock,
-    const std::shared_ptr<universe_utils::TimeKeeper> time_keeper,
+    const std::shared_ptr<autoware_utils::TimeKeeper> time_keeper,
     const std::shared_ptr<planning_factor_interface::PlanningFactorInterface>
       planning_factor_interface);
 

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_stop_line_module/src/scene.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_stop_line_module/src/scene.cpp
@@ -32,7 +32,7 @@ namespace autoware::behavior_velocity_planner
 StopLineModule::StopLineModule(
   const int64_t module_id, lanelet::ConstLineString3d stop_line, const PlannerParam & planner_param,
   const rclcpp::Logger & logger, const rclcpp::Clock::SharedPtr clock,
-  const std::shared_ptr<universe_utils::TimeKeeper> & time_keeper,
+  const std::shared_ptr<autoware_utils::TimeKeeper> & time_keeper,
   const std::shared_ptr<planning_factor_interface::PlanningFactorInterface> &
     planning_factor_interface)
 : SceneModuleInterface(module_id, logger, clock, time_keeper, planning_factor_interface),

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_stop_line_module/src/scene.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_stop_line_module/src/scene.hpp
@@ -71,7 +71,7 @@ public:
     const int64_t module_id, lanelet::ConstLineString3d stop_line,
     const PlannerParam & planner_param, const rclcpp::Logger & logger,
     const rclcpp::Clock::SharedPtr clock,
-    const std::shared_ptr<universe_utils::TimeKeeper> & time_keeper,
+    const std::shared_ptr<autoware_utils::TimeKeeper> & time_keeper,
     const std::shared_ptr<planning_factor_interface::PlanningFactorInterface> &
       planning_factor_interface);
 

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_stop_line_module/test/test_scene.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_stop_line_module/test/test_scene.cpp
@@ -75,7 +75,7 @@ protected:
 
     module_ = std::make_shared<StopLineModule>(
       1, stop_line_, planner_param_, rclcpp::get_logger("test_logger"), clock_,
-      std::make_shared<autoware::universe_utils::TimeKeeper>(),
+      std::make_shared<autoware_utils::TimeKeeper>(),
       std::make_shared<autoware::planning_factor_interface::PlanningFactorInterface>(
         node_.get(), "test_stopline"));
 

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_template_module/src/scene.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_template_module/src/scene.cpp
@@ -27,7 +27,7 @@ namespace autoware::behavior_velocity_planner
 
 TemplateModule::TemplateModule(
   const int64_t module_id, const rclcpp::Logger & logger, const rclcpp::Clock::SharedPtr clock,
-  const std::shared_ptr<universe_utils::TimeKeeper> time_keeper,
+  const std::shared_ptr<autoware_utils::TimeKeeper> time_keeper,
   const std::shared_ptr<planning_factor_interface::PlanningFactorInterface>
     planning_factor_interface)
 : SceneModuleInterface(module_id, logger, clock, time_keeper, planning_factor_interface)

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_template_module/src/scene.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_template_module/src/scene.hpp
@@ -30,7 +30,7 @@ class TemplateModule : public SceneModuleInterface
 public:
   TemplateModule(
     const int64_t module_id, const rclcpp::Logger & logger, const rclcpp::Clock::SharedPtr clock,
-    const std::shared_ptr<universe_utils::TimeKeeper> time_keeper,
+    const std::shared_ptr<autoware_utils::TimeKeeper> time_keeper,
     const std::shared_ptr<planning_factor_interface::PlanningFactorInterface>
       planning_factor_interface);
 

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/src/scene.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/src/scene.cpp
@@ -44,7 +44,7 @@ TrafficLightModule::TrafficLightModule(
   const int64_t lane_id, const lanelet::TrafficLight & traffic_light_reg_elem,
   lanelet::ConstLanelet lane, const PlannerParam & planner_param, const rclcpp::Logger logger,
   const rclcpp::Clock::SharedPtr clock,
-  const std::shared_ptr<universe_utils::TimeKeeper> time_keeper,
+  const std::shared_ptr<autoware_utils::TimeKeeper> time_keeper,
   const std::shared_ptr<planning_factor_interface::PlanningFactorInterface>
     planning_factor_interface)
 : SceneModuleInterfaceWithRTC(lane_id, logger, clock, time_keeper, planning_factor_interface),

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/src/scene.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/src/scene.hpp
@@ -71,7 +71,7 @@ public:
     const int64_t lane_id, const lanelet::TrafficLight & traffic_light_reg_elem,
     lanelet::ConstLanelet lane, const PlannerParam & planner_param, const rclcpp::Logger logger,
     const rclcpp::Clock::SharedPtr clock,
-    const std::shared_ptr<universe_utils::TimeKeeper> time_keeper,
+    const std::shared_ptr<autoware_utils::TimeKeeper> time_keeper,
     const std::shared_ptr<planning_factor_interface::PlanningFactorInterface>
       planning_factor_interface);
 

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_virtual_traffic_light_module/src/scene.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_virtual_traffic_light_module/src/scene.cpp
@@ -40,7 +40,7 @@ VirtualTrafficLightModule::VirtualTrafficLightModule(
   const lanelet::autoware::VirtualTrafficLight & reg_elem, lanelet::ConstLanelet lane,
   const PlannerParam & planner_param, const rclcpp::Logger logger,
   const rclcpp::Clock::SharedPtr clock,
-  const std::shared_ptr<universe_utils::TimeKeeper> time_keeper,
+  const std::shared_ptr<autoware_utils::TimeKeeper> time_keeper,
   const std::shared_ptr<planning_factor_interface::PlanningFactorInterface>
     planning_factor_interface)
 : SceneModuleInterface(module_id, logger, clock, time_keeper, planning_factor_interface),

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_virtual_traffic_light_module/src/scene.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_virtual_traffic_light_module/src/scene.hpp
@@ -83,7 +83,7 @@ public:
     const lanelet::autoware::VirtualTrafficLight & reg_elem, lanelet::ConstLanelet lane,
     const PlannerParam & planner_param, const rclcpp::Logger logger,
     const rclcpp::Clock::SharedPtr clock,
-    const std::shared_ptr<universe_utils::TimeKeeper> time_keeper,
+    const std::shared_ptr<autoware_utils::TimeKeeper> time_keeper,
     const std::shared_ptr<planning_factor_interface::PlanningFactorInterface>
       planning_factor_interface);
 

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_virtual_traffic_light_module/src/utils.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_virtual_traffic_light_module/src/utils.hpp
@@ -16,9 +16,9 @@
 #define UTILS_HPP_
 
 #include <autoware/behavior_velocity_planner_common/utilization/arc_lane_util.hpp>
-#include <autoware_lanelet2_extension/regulatory_elements/virtual_traffic_light.hpp>
 #include <autoware/universe_utils/geometry/boost_geometry.hpp>
 #include <autoware/universe_utils/geometry/geometry.hpp>
+#include <autoware_lanelet2_extension/regulatory_elements/virtual_traffic_light.hpp>
 
 #include <autoware_internal_planning_msgs/msg/path_with_lane_id.hpp>
 #include <tier4_v2x_msgs/msg/key_value.hpp>

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_virtual_traffic_light_module/src/utils.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_virtual_traffic_light_module/src/utils.hpp
@@ -17,6 +17,8 @@
 
 #include <autoware/behavior_velocity_planner_common/utilization/arc_lane_util.hpp>
 #include <autoware_lanelet2_extension/regulatory_elements/virtual_traffic_light.hpp>
+#include <autoware/universe_utils/geometry/boost_geometry.hpp>
+#include <autoware/universe_utils/geometry/geometry.hpp>
 
 #include <autoware_internal_planning_msgs/msg/path_with_lane_id.hpp>
 #include <tier4_v2x_msgs/msg/key_value.hpp>

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_walkway_module/src/scene_walkway.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_walkway_module/src/scene_walkway.cpp
@@ -35,7 +35,7 @@ WalkwayModule::WalkwayModule(
   const int64_t module_id, const lanelet::LaneletMapPtr & lanelet_map_ptr,
   const PlannerParam & planner_param, const bool use_regulatory_element,
   const rclcpp::Logger & logger, const rclcpp::Clock::SharedPtr clock,
-  const std::shared_ptr<universe_utils::TimeKeeper> time_keeper,
+  const std::shared_ptr<autoware_utils::TimeKeeper> time_keeper,
   const std::shared_ptr<planning_factor_interface::PlanningFactorInterface>
     planning_factor_interface)
 : SceneModuleInterface(module_id, logger, clock, time_keeper, planning_factor_interface),

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_walkway_module/src/scene_walkway.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_walkway_module/src/scene_walkway.hpp
@@ -45,7 +45,7 @@ public:
     const int64_t module_id, const lanelet::LaneletMapPtr & lanelet_map_ptr,
     const PlannerParam & planner_param, const bool use_regulatory_element,
     const rclcpp::Logger & logger, const rclcpp::Clock::SharedPtr clock,
-    const std::shared_ptr<universe_utils::TimeKeeper> time_keeper,
+    const std::shared_ptr<autoware_utils::TimeKeeper> time_keeper,
     const std::shared_ptr<planning_factor_interface::PlanningFactorInterface>
       planning_factor_interface);
 


### PR DESCRIPTION
## Description
This PR replace autoware_universe_utils with autoware_utils in autoware_route_handler as a preparation for porting to Autoware Core.

## Related links

**Parent Issue:**

- https://github.com/autowarefoundation/autoware.core/issues/190

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
