### PR TITLE
fix(autoware_radar_threshold_filter): use sensor data qos

### DIFF
--- a/sensing/autoware_radar_threshold_filter/config/radar_threshold_filter.param.yaml
+++ b/sensing/autoware_radar_threshold_filter/config/radar_threshold_filter.param.yaml
@@ -16,3 +16,5 @@
       is_z_filter: false
       z_min: -2.0
       z_max: 5.0
+
+      max_queue_size: 5

--- a/sensing/autoware_radar_threshold_filter/src/radar_threshold_filter_node.cpp
+++ b/sensing/autoware_radar_threshold_filter/src/radar_threshold_filter_node.cpp
@@ -75,13 +75,16 @@ RadarThresholdFilterNode::RadarThresholdFilterNode(const rclcpp::NodeOptions & n
   node_param_.is_z_filter = declare_parameter<bool>("node_params.is_z_filter");
   node_param_.z_min = declare_parameter<double>("node_params.z_min");
   node_param_.z_max = declare_parameter<double>("node_params.z_max");
+  node_param_.max_queue_size = declare_parameter<long>("node_params.max_queue_size");
 
   // Subscriber
   sub_radar_ = create_subscription<RadarScan>(
-    "~/input/radar", rclcpp::QoS{1}, std::bind(&RadarThresholdFilterNode::onData, this, _1));
+    "~/input/radar", rclcpp::SensorDataQoS().keep_last(node_param_.max_queue_size),
+    std::bind(&RadarThresholdFilterNode::onData, this, _1));
 
   // Publisher
-  pub_radar_ = create_publisher<RadarScan>("~/output/radar", 1);
+  pub_radar_ = create_publisher<RadarScan>(
+    "~/output/radar", rclcpp::SensorDataQoS().keep_last(node_param_.max_queue_size));
 }
 
 rcl_interfaces::msg::SetParametersResult RadarThresholdFilterNode::onSetParam(
@@ -103,6 +106,7 @@ rcl_interfaces::msg::SetParametersResult RadarThresholdFilterNode::onSetParam(
       update_param(params, "node_params.is_z_filter", p.is_z_filter);
       update_param(params, "node_params.z_min", p.z_min);
       update_param(params, "node_params.z_max", p.z_max);
+      update_param(params, "node_params.max_queue_size", p.max_queue_size);
     }
   } catch (const rclcpp::exceptions::InvalidParameterTypeException & e) {
     result.successful = false;

--- a/sensing/autoware_radar_threshold_filter/src/radar_threshold_filter_node.cpp
+++ b/sensing/autoware_radar_threshold_filter/src/radar_threshold_filter_node.cpp
@@ -75,7 +75,7 @@ RadarThresholdFilterNode::RadarThresholdFilterNode(const rclcpp::NodeOptions & n
   node_param_.is_z_filter = declare_parameter<bool>("node_params.is_z_filter");
   node_param_.z_min = declare_parameter<double>("node_params.z_min");
   node_param_.z_max = declare_parameter<double>("node_params.z_max");
-  node_param_.max_queue_size = declare_parameter<long>("node_params.max_queue_size");
+  node_param_.max_queue_size = declare_parameter<int64_t>("node_params.max_queue_size");
 
   // Subscriber
   sub_radar_ = create_subscription<RadarScan>(

--- a/sensing/autoware_radar_threshold_filter/src/radar_threshold_filter_node.hpp
+++ b/sensing/autoware_radar_threshold_filter/src/radar_threshold_filter_node.hpp
@@ -48,6 +48,7 @@ public:
     bool is_z_filter{};
     double z_min{};
     double z_max{};
+    size_t max_queue_size{};
   };
 
 private:

--- a/sensing/autoware_radar_threshold_filter/test/radar_threshold_filter/test_radar_threshold_filter.cpp
+++ b/sensing/autoware_radar_threshold_filter/test/radar_threshold_filter/test_radar_threshold_filter.cpp
@@ -32,6 +32,7 @@ TEST(RadarThresholdFilter, isWithinThreshold)
   const double azimuth_max = 1.2;
   const double z_min = -2.0;
   const double z_max = 5.0;
+  const int64_t max_queue_size = 5;
   // amplitude filter
   {
     rclcpp::NodeOptions node_options;
@@ -48,6 +49,7 @@ TEST(RadarThresholdFilter, isWithinThreshold)
       {"node_params.is_z_filter", false},
       {"node_params.z_min", z_min},
       {"node_params.z_max", z_max},
+      {"node_params.max_queue_size", max_queue_size},
     });
 
     RadarThresholdFilterNode node(node_options);
@@ -78,6 +80,7 @@ TEST(RadarThresholdFilter, isWithinThreshold)
       {"node_params.is_z_filter", false},
       {"node_params.z_min", z_min},
       {"node_params.z_max", z_max},
+      {"node_params.max_queue_size", max_queue_size},
     });
 
     RadarThresholdFilterNode node(node_options);
@@ -107,6 +110,7 @@ TEST(RadarThresholdFilter, isWithinThreshold)
       {"node_params.is_z_filter", false},
       {"node_params.z_min", z_min},
       {"node_params.z_max", z_max},
+      {"node_params.max_queue_size", max_queue_size},
     });
 
     RadarThresholdFilterNode node(node_options);
@@ -135,6 +139,7 @@ TEST(RadarThresholdFilter, isWithinThreshold)
       {"node_params.is_z_filter", true},
       {"node_params.z_min", z_min},
       {"node_params.z_max", z_max},
+      {"node_params.max_queue_size", max_queue_size},
     });
 
     RadarThresholdFilterNode node(node_options);


### PR DESCRIPTION
## Description

Use SensorDataQoS for subscriber and publisher.

## Related links

**Parent Issue:**

- https://github.com/autowarefoundation/autoware.universe/issues/10155

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

Tested with a bag file which includes ARS 548 RadarScan data via the following launch:
```xml
<?xml version="1.0" encoding="UTF-8"?>
<launch>

  <push-ros-namespace namespace="radar_cloud"/>
  <group>

    <!--    Radar scan filter-->
    <group>
      <push-ros-namespace namespace="radarscan_filtering"/>
      <include
              file="$(find-pkg-share radar_threshold_filter)/launch/radar_threshold_filter.launch.xml">
        <arg name="input/radar" value="/sensing/radar/front/scan_raw"/>
        <arg name="output/radar" value="output/threshold_filtered_radar"/>
      </include>
    </group>

  </group>
<launch>
```

## Notes for reviewers

Used the same QoS setting as pointcloud_preprocessor:
- https://github.com/autowarefoundation/autoware.universe/blob/c9aa4093433f4e573c0898b393a5e98f883bdab7/sensing/autoware_pointcloud_preprocessor/src/filter.cpp#L173

## Interface changes

None.



### Topic changes

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub | `~/output/radar` | `RadarScan` | rclcpp::QoS{1} |
| New     | Pub | `~/output/radar` | `RadarScan` | rclcpp::SensorDataQoS().keep_last(node_param_.max_queue_size) |
| Old     | Sub | `~/input/radar` | `RadarScan` | rclcpp::QoS{1} |
| New     | Sub | `~/input/radar` | `RadarScan` | rclcpp::SensorDataQoS().keep_last(node_param_.max_queue_size) |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added | `max_queue_size`   | `long` | `5`         | History size of QoS profile. |



## Effects on system behavior

None.
