### PR TITLE
fix(autoware_radar_scan_to_pointcloud2): use sensor data qos

### DIFF
--- a/sensing/autoware_radar_scan_to_pointcloud2/config/radar_scan_to_pointcloud2.param.yaml
+++ b/sensing/autoware_radar_scan_to_pointcloud2/config/radar_scan_to_pointcloud2.param.yaml
@@ -2,3 +2,4 @@
   ros__parameters:
     publish_amplitude_pointcloud: true
     publish_doppler_pointcloud: false
+    max_queue_size: 5

--- a/sensing/autoware_radar_scan_to_pointcloud2/schema/radar_scan_to_pointcloud2.schema.json
+++ b/sensing/autoware_radar_scan_to_pointcloud2/schema/radar_scan_to_pointcloud2.schema.json
@@ -15,9 +15,15 @@
           "type": "boolean",
           "description": "Whether publish radar pointcloud whose intensity is doppler velocity.",
           "default": "false"
+        },
+        "max_queue_size": {
+          "type": "integer",
+          "default": "5",
+          "minimum": 1,
+          "description": "Max queue size of input/output topics."
         }
       },
-      "required": ["publish_amplitude_pointcloud", "publish_doppler_pointcloud"]
+      "required": ["publish_amplitude_pointcloud", "publish_doppler_pointcloud", "max_queue_size"]
     }
   },
   "properties": {

--- a/sensing/autoware_radar_scan_to_pointcloud2/src/radar_scan_to_pointcloud2_node.cpp
+++ b/sensing/autoware_radar_scan_to_pointcloud2/src/radar_scan_to_pointcloud2_node.cpp
@@ -106,19 +106,23 @@ RadarScanToPointcloud2Node::RadarScanToPointcloud2Node(const rclcpp::NodeOptions
   node_param_.publish_amplitude_pointcloud =
     declare_parameter<bool>("publish_amplitude_pointcloud");
   node_param_.publish_doppler_pointcloud = declare_parameter<bool>("publish_doppler_pointcloud");
+  node_param_.max_queue_size = declare_parameter<long>("max_queue_size");
 
   // Subscriber
   sub_radar_ = create_subscription<RadarScan>(
-    "~/input/radar", rclcpp::QoS{1}, std::bind(&RadarScanToPointcloud2Node::onData, this, _1));
+    "~/input/radar", rclcpp::SensorDataQoS().keep_last(node_param_.max_queue_size),
+    std::bind(&RadarScanToPointcloud2Node::onData, this, _1));
 
   {
     rclcpp::PublisherOptions pub_options;
     pub_options.qos_overriding_options = rclcpp::QosOverridingOptions::with_default_policies();
     // Publisher
-    pub_amplitude_pointcloud_ =
-      create_publisher<PointCloud2>("~/output/amplitude_pointcloud", 1, pub_options);
-    pub_doppler_pointcloud_ =
-      create_publisher<PointCloud2>("~/output/doppler_pointcloud", 1, pub_options);
+    pub_amplitude_pointcloud_ = create_publisher<PointCloud2>(
+      "~/output/amplitude_pointcloud",
+      rclcpp::SensorDataQoS().keep_last(node_param_.max_queue_size), pub_options);
+    pub_doppler_pointcloud_ = create_publisher<PointCloud2>(
+      "~/output/doppler_pointcloud", rclcpp::SensorDataQoS().keep_last(node_param_.max_queue_size),
+      pub_options);
   }
 }
 
@@ -131,6 +135,7 @@ rcl_interfaces::msg::SetParametersResult RadarScanToPointcloud2Node::onSetParam(
     auto & p = node_param_;
     update_param(params, "publish_amplitude_pointcloud", p.publish_amplitude_pointcloud);
     update_param(params, "publish_doppler_pointcloud", p.publish_doppler_pointcloud);
+    update_param(params, "max_queue_size", p.max_queue_size);
   } catch (const rclcpp::exceptions::InvalidParameterTypeException & e) {
     result.successful = false;
     result.reason = e.what();

--- a/sensing/autoware_radar_scan_to_pointcloud2/src/radar_scan_to_pointcloud2_node.cpp
+++ b/sensing/autoware_radar_scan_to_pointcloud2/src/radar_scan_to_pointcloud2_node.cpp
@@ -106,7 +106,7 @@ RadarScanToPointcloud2Node::RadarScanToPointcloud2Node(const rclcpp::NodeOptions
   node_param_.publish_amplitude_pointcloud =
     declare_parameter<bool>("publish_amplitude_pointcloud");
   node_param_.publish_doppler_pointcloud = declare_parameter<bool>("publish_doppler_pointcloud");
-  node_param_.max_queue_size = declare_parameter<long>("max_queue_size");
+  node_param_.max_queue_size = declare_parameter<int64_t>("max_queue_size");
 
   // Subscriber
   sub_radar_ = create_subscription<RadarScan>(

--- a/sensing/autoware_radar_scan_to_pointcloud2/src/radar_scan_to_pointcloud2_node.hpp
+++ b/sensing/autoware_radar_scan_to_pointcloud2/src/radar_scan_to_pointcloud2_node.hpp
@@ -39,6 +39,7 @@ public:
   {
     bool publish_amplitude_pointcloud{};
     bool publish_doppler_pointcloud{};
+    size_t max_queue_size{};
   };
 
 private:


### PR DESCRIPTION
## Description

Use SensorDataQoS for subscriber and publisher.

## Related links

**Parent Issue:**

- https://github.com/autowarefoundation/autoware.universe/issues/10155

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

Tested with a bag file which includes ARS 548 RadarScan data via the following launch:
```xml
<?xml version="1.0" encoding="UTF-8"?>
<launch>

  <push-ros-namespace namespace="radar_cloud"/>
  <group>

    <!--    Radar scan filter-->
    <group>
      <push-ros-namespace namespace="radarscan_filtering"/>
      <include file="$(find-pkg-share radar_scan_to_pointcloud2)/launch/radar_scan_to_pointcloud2.launch.xml">
        <arg name="input/radar" value="/sensing/radar/front/scan_raw"/>
        <arg name="output/amplitude_pointcloud" value="raw/output/amplitude_pointcloud"/>
        <arg name="output/doppler_pointcloud" value="raw/output/doppler_pointcloud"/>
      </include>
    </group>

  </group>
<launch>
```

## Notes for reviewers

Used the same QoS setting as pointcloud_preprocessor:
- https://github.com/autowarefoundation/autoware.universe/blob/c9aa4093433f4e573c0898b393a5e98f883bdab7/sensing/autoware_pointcloud_preprocessor/src/filter.cpp#L173

## Interface changes

None.



### Topic changes

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub | `~/output/amplitude_pointcloud` | `RadarScan` | rclcpp::QoS{1} |
| New     | Pub | `~/output/amplitude_pointcloud` | `RadarScan` | rclcpp::SensorDataQoS().keep_last(node_param_.max_queue_size) |
| Old     | Pub | `~/output/doppler_pointcloud` | `RadarScan` | rclcpp::QoS{1} |
| New     | Pub | `~/output/doppler_pointcloud` | `RadarScan` | rclcpp::SensorDataQoS().keep_last(node_param_.max_queue_size) |
| Old     | Sub | `~/input/radar` | `RadarScan` | rclcpp::QoS{1} |
| New     | Sub | `~/input/radar` | `RadarScan` | rclcpp::SensorDataQoS().keep_last(node_param_.max_queue_size) |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added | `max_queue_size`   | `long` | `5`         | History size of QoS profile. |



## Effects on system behavior

None.
