### PR TITLE
chore: bump version to 0.41.2

### DIFF
--- a/common/autoware_adapi_specs/CHANGELOG.rst
+++ b/common/autoware_adapi_specs/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_adapi_specs
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/common/autoware_adapi_specs/package.xml
+++ b/common/autoware_adapi_specs/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_adapi_specs</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The autoware_adapi_specs package</description>
   <maintainer email="isamu.takagi@tier4.jp">Takagi, Isamu</maintainer>
   <maintainer email="ryohsuke.mitsudome@tier4.jp">Ryohsuke Mitsudome</maintainer>

--- a/common/autoware_auto_common/CHANGELOG.rst
+++ b/common/autoware_auto_common/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_auto_common
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/common/autoware_auto_common/package.xml
+++ b/common/autoware_auto_common/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_auto_common</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>Miscellaneous helper functions</description>
   <maintainer email="opensource@apex.ai">Apex.AI, Inc.</maintainer>
   <maintainer email="tomoya.kimura@tier4.jp">Tomoya Kimura</maintainer>

--- a/common/autoware_component_interface_specs_universe/CHANGELOG.rst
+++ b/common/autoware_component_interface_specs_universe/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_component_interface_specs_universe
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/common/autoware_component_interface_specs_universe/package.xml
+++ b/common/autoware_component_interface_specs_universe/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_component_interface_specs_universe</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The autoware_component_interface_specs_universe package</description>
   <maintainer email="isamu.takagi@tier4.jp">Takagi, Isamu</maintainer>
   <maintainer email="yukihiro.saito@tier4.jp">Yukihiro Saito</maintainer>

--- a/common/autoware_component_interface_tools/CHANGELOG.rst
+++ b/common/autoware_component_interface_tools/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_component_interface_tools
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/common/autoware_component_interface_tools/package.xml
+++ b/common/autoware_component_interface_tools/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_component_interface_tools</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The autoware_component_interface_tools package</description>
   <maintainer email="isamu.takagi@tier4.jp">Takagi, Isamu</maintainer>
   <license>Apache License 2.0</license>

--- a/common/autoware_component_interface_utils/CHANGELOG.rst
+++ b/common/autoware_component_interface_utils/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_component_interface_utils
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/common/autoware_component_interface_utils/package.xml
+++ b/common/autoware_component_interface_utils/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_component_interface_utils</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The autoware_component_interface_utils package</description>
   <maintainer email="isamu.takagi@tier4.jp">Takagi, Isamu</maintainer>
   <maintainer email="yukihiro.saito@tier4.jp">Yukihiro Saito</maintainer>

--- a/common/autoware_fake_test_node/CHANGELOG.rst
+++ b/common/autoware_fake_test_node/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_fake_test_node
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/common/autoware_fake_test_node/package.xml
+++ b/common/autoware_fake_test_node/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_fake_test_node</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>A fake node that we can use in the integration-like cpp tests.</description>
   <maintainer email="opensource@apex.ai">Apex.AI, Inc.</maintainer>
   <maintainer email="tomoya.kimura@tier4.jp">Tomoya Kimura</maintainer>

--- a/common/autoware_global_parameter_loader/CHANGELOG.rst
+++ b/common/autoware_global_parameter_loader/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_global_parameter_loader
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/common/autoware_global_parameter_loader/package.xml
+++ b/common/autoware_global_parameter_loader/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_global_parameter_loader</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The autoware_global_parameter_loader package</description>
   <maintainer email="ryohsuke.mitsudome@tier4.jp">Ryohsuke Mitsudome</maintainer>
   <license>Apache License 2.0</license>

--- a/common/autoware_glog_component/CHANGELOG.rst
+++ b/common/autoware_glog_component/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_glog_component
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/common/autoware_glog_component/package.xml
+++ b/common/autoware_glog_component/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_glog_component</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The autoware_glog_component package</description>
   <maintainer email="takamasa.horibe@tier4.jp">Takamasa Horibe</maintainer>
   <license>Apache License 2.0</license>

--- a/common/autoware_goal_distance_calculator/CHANGELOG.rst
+++ b/common/autoware_goal_distance_calculator/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_goal_distance_calculator
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/common/autoware_goal_distance_calculator/package.xml
+++ b/common/autoware_goal_distance_calculator/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_goal_distance_calculator</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The autoware_goal_distance_calculator package</description>
   <maintainer email="taiki.tanaka@tier4.jp">Taiki Tanaka</maintainer>
   <license>Apache License 2.0</license>

--- a/common/autoware_grid_map_utils/CHANGELOG.rst
+++ b/common/autoware_grid_map_utils/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_grid_map_utils
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/common/autoware_grid_map_utils/package.xml
+++ b/common/autoware_grid_map_utils/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_grid_map_utils</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>Utilities for the grid_map library</description>
   <maintainer email="maxime.clement@tier4.jp">Maxime CLEMENT</maintainer>
   <license>Apache License 2.0</license>

--- a/common/autoware_interpolation/CHANGELOG.rst
+++ b/common/autoware_interpolation/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_interpolation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/common/autoware_interpolation/package.xml
+++ b/common/autoware_interpolation/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_interpolation</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The spline interpolation package</description>
   <maintainer email="fumiya.watanabe@tier4.jp">Fumiya Watanabe</maintainer>
   <maintainer email="takayuki.murooka@tier4.jp">Takayuki Murooka</maintainer>

--- a/common/autoware_motion_utils/CHANGELOG.rst
+++ b/common/autoware_motion_utils/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_motion_utils
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/common/autoware_motion_utils/package.xml
+++ b/common/autoware_motion_utils/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_motion_utils</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The autoware_motion_utils package</description>
   <maintainer email="satoshi.ota@tier4.jp">Satoshi Ota</maintainer>
   <maintainer email="takayuki.murooka@tier4.jp">Takayuki Murooka</maintainer>

--- a/common/autoware_object_recognition_utils/CHANGELOG.rst
+++ b/common/autoware_object_recognition_utils/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_object_recognition_utils
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/common/autoware_object_recognition_utils/package.xml
+++ b/common/autoware_object_recognition_utils/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_object_recognition_utils</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The autoware_object_recognition_utils package</description>
   <maintainer email="takayuki.murooka@tier4.jp">Takayuki Murooka</maintainer>
   <maintainer email="shunsuke.miura@tier4.jp">Shunsuke Miura</maintainer>

--- a/common/autoware_path_distance_calculator/CHANGELOG.rst
+++ b/common/autoware_path_distance_calculator/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_path_distance_calculator
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/common/autoware_path_distance_calculator/package.xml
+++ b/common/autoware_path_distance_calculator/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_path_distance_calculator</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The autoware_path_distance_calculator package</description>
   <maintainer email="isamu.takagi@tier4.jp">Takagi, Isamu</maintainer>
   <license>Apache License 2.0</license>

--- a/common/autoware_polar_grid/CHANGELOG.rst
+++ b/common/autoware_polar_grid/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_polar_grid
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/common/autoware_polar_grid/package.xml
+++ b/common/autoware_polar_grid/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_polar_grid</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The autoware_polar_grid package</description>
   <maintainer email="yukihiro.saito@tier4.jp">Yukihiro Saito</maintainer>
   <license>Apache License 2.0</license>

--- a/common/autoware_pyplot/CHANGELOG.rst
+++ b/common/autoware_pyplot/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_pyplot
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/common/autoware_pyplot/package.xml
+++ b/common/autoware_pyplot/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_pyplot</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>C++ interface for matplotlib based on pybind11</description>
   <maintainer email="mamoru.sobue@tier4.jp">Mamoru Sobue</maintainer>
   <maintainer email="yukinari.hisaki.2@tier4.jp">Yukinari Hisaki</maintainer>

--- a/common/autoware_signal_processing/CHANGELOG.rst
+++ b/common/autoware_signal_processing/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_signal_processing
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/common/autoware_signal_processing/package.xml
+++ b/common/autoware_signal_processing/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_signal_processing</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The signal processing package</description>
   <maintainer email="takayuki.murooka@tier4.jp">Takayuki Murooka</maintainer>
   <maintainer email="takamasa.horibe@tier4.jp">Takamasa Horibe</maintainer>

--- a/common/autoware_test_utils/CHANGELOG.rst
+++ b/common/autoware_test_utils/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_test_utils
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/common/autoware_test_utils/package.xml
+++ b/common/autoware_test_utils/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_test_utils</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>ROS 2 node for testing interface of the nodes in planning module</description>
   <maintainer email="kyoichi.sugahara@tier4.jp">Kyoichi Sugahara</maintainer>
   <maintainer email="takamasa.horibe@tier4.jp">Takamasa Horibe</maintainer>

--- a/common/autoware_testing/CHANGELOG.rst
+++ b/common/autoware_testing/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_testing
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/common/autoware_testing/package.xml
+++ b/common/autoware_testing/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_testing</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>Tools for handling standard tests based on ros_testing</description>
   <maintainer email="adam.dabrowski@robotec.ai">Adam Dabrowski</maintainer>
   <maintainer email="tomoya.kimura@tier4.jp">Tomoya Kimura</maintainer>

--- a/common/autoware_time_utils/CHANGELOG.rst
+++ b/common/autoware_time_utils/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_time_utils
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/common/autoware_time_utils/package.xml
+++ b/common/autoware_time_utils/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_time_utils</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>Simple conversion methods to/from std::chrono to simplify algorithm development</description>
   <maintainer email="christopherj.ho@gmail.com">Christopher Ho</maintainer>
   <maintainer email="tomoya.kimura@tier4.jp">Tomoya Kimura</maintainer>

--- a/common/autoware_traffic_light_recognition_marker_publisher/CHANGELOG.rst
+++ b/common/autoware_traffic_light_recognition_marker_publisher/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_traffic_light_recognition_marker_publisher
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/common/autoware_traffic_light_recognition_marker_publisher/package.xml
+++ b/common/autoware_traffic_light_recognition_marker_publisher/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_traffic_light_recognition_marker_publisher</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The autoware_traffic_light_recognition_marker_publisher package</description>
   <maintainer email="tomoya.kimura@tier4.jp">Tomoya Kimura</maintainer>
   <maintainer email="takeshi.miura@tier4.jp">Takeshi Miura</maintainer>

--- a/common/autoware_traffic_light_utils/CHANGELOG.rst
+++ b/common/autoware_traffic_light_utils/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_traffic_light_utils
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/common/autoware_traffic_light_utils/package.xml
+++ b/common/autoware_traffic_light_utils/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_traffic_light_utils</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The autoware_traffic_light_utils package</description>
   <maintainer email="kotaro.uetake@tier4.jp">Kotaro Uetake</maintainer>
   <maintainer email="shunsuke.miura@tier4.jp">Shunsuke Miura</maintainer>

--- a/common/autoware_trajectory/CHANGELOG.rst
+++ b/common/autoware_trajectory/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_trajectory
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/common/autoware_trajectory/package.xml
+++ b/common/autoware_trajectory/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_trajectory</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The autoware_trajectory package</description>
   <maintainer email="yukinari.hisaki.2@tier4.jp">Yukinari Hisaki</maintainer>
   <maintainer email="takayuki.murooka@tier4.jp">Takayuki Murooka</maintainer>

--- a/common/autoware_universe_utils/CHANGELOG.rst
+++ b/common/autoware_universe_utils/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_universe_utils
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/common/autoware_universe_utils/package.xml
+++ b/common/autoware_universe_utils/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_universe_utils</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The autoware_universe_utils package</description>
   <maintainer email="takamasa.horibe@tier4.jp">Takamasa Horibe</maintainer>
   <maintainer email="takayuki.murooka@tier4.jp">Takayuki Murooka</maintainer>

--- a/common/autoware_vehicle_info_utils/CHANGELOG.rst
+++ b/common/autoware_vehicle_info_utils/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_vehicle_info_utils
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/common/autoware_vehicle_info_utils/package.xml
+++ b/common/autoware_vehicle_info_utils/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_vehicle_info_utils</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The autoware_vehicle_info_utils package</description>
 
   <!-- maintainer -->

--- a/common/tier4_api_utils/CHANGELOG.rst
+++ b/common/tier4_api_utils/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package tier4_api_utils
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/common/tier4_api_utils/package.xml
+++ b/common/tier4_api_utils/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>tier4_api_utils</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The tier4_api_utils package</description>
   <maintainer email="isamu.takagi@tier4.jp">Takagi, Isamu</maintainer>
   <license>Apache License 2.0</license>

--- a/control/autoware_autonomous_emergency_braking/CHANGELOG.rst
+++ b/control/autoware_autonomous_emergency_braking/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_autonomous_emergency_braking
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/control/autoware_autonomous_emergency_braking/package.xml
+++ b/control/autoware_autonomous_emergency_braking/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_autonomous_emergency_braking</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>Autonomous Emergency Braking package as a ROS 2 node</description>
   <maintainer email="takamasa.horibe@tier4.jp">Takamasa Horibe</maintainer>
   <maintainer email="tomoya.kimura@tier4.jp">Tomoya Kimura</maintainer>

--- a/control/autoware_collision_detector/CHANGELOG.rst
+++ b/control/autoware_collision_detector/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_collision_detector
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/control/autoware_collision_detector/package.xml
+++ b/control/autoware_collision_detector/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_collision_detector</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The collision_detector package</description>
 
   <maintainer email="kyoichi.sugahara@tier4.jp">Kyoichi Sugahara</maintainer>

--- a/control/autoware_control_performance_analysis/CHANGELOG.rst
+++ b/control/autoware_control_performance_analysis/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_control_performance_analysis
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/control/autoware_control_performance_analysis/package.xml
+++ b/control/autoware_control_performance_analysis/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_control_performance_analysis</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>Controller Performance Evaluation</description>
   <maintainer email="berkay@leodrive.ai">Berkay Karaman</maintainer>
   <maintainer email="taiki.tanaka@tier4.jp">Taiki Tanaka</maintainer>

--- a/control/autoware_control_validator/CHANGELOG.rst
+++ b/control/autoware_control_validator/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_control_validator
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/control/autoware_control_validator/package.xml
+++ b/control/autoware_control_validator/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_control_validator</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>ros node for autoware_control_validator</description>
   <maintainer email="kyoichi.sugahara@tier4.jp">Kyoichi Sugahara</maintainer>
   <maintainer email="takamasa.horibe@tier4.jp">Takamasa Horibe</maintainer>

--- a/control/autoware_external_cmd_selector/CHANGELOG.rst
+++ b/control/autoware_external_cmd_selector/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_external_cmd_selector
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/control/autoware_external_cmd_selector/package.xml
+++ b/control/autoware_external_cmd_selector/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_external_cmd_selector</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The autoware_external_cmd_selector package</description>
   <maintainer email="taiki.tanaka@tier4.jp">Taiki Tanaka</maintainer>
   <maintainer email="tomoya.kimura@tier4.jp">Tomoya Kimura</maintainer>

--- a/control/autoware_joy_controller/CHANGELOG.rst
+++ b/control/autoware_joy_controller/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_joy_controller
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/control/autoware_joy_controller/package.xml
+++ b/control/autoware_joy_controller/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_joy_controller</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The autoware_joy_controller package</description>
   <maintainer email="taiki.tanaka@tier4.jp">Taiki Tanaka</maintainer>
   <maintainer email="tomoya.kimura@tier4.jp">Tomoya Kimura</maintainer>

--- a/control/autoware_lane_departure_checker/CHANGELOG.rst
+++ b/control/autoware_lane_departure_checker/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_lane_departure_checker
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/control/autoware_lane_departure_checker/package.xml
+++ b/control/autoware_lane_departure_checker/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_lane_departure_checker</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The autoware_lane_departure_checker package</description>
   <maintainer email="kyoichi.sugahara@tier4.jp">Kyoichi Sugahara</maintainer>
   <maintainer email="makoto.kurihara@tier4.jp">Makoto Kurihara</maintainer>

--- a/control/autoware_mpc_lateral_controller/CHANGELOG.rst
+++ b/control/autoware_mpc_lateral_controller/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_mpc_lateral_controller
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/control/autoware_mpc_lateral_controller/package.xml
+++ b/control/autoware_mpc_lateral_controller/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_mpc_lateral_controller</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>MPC-based lateral controller</description>
 
   <maintainer email="takamasa.horibe@tier4.jp">Takamasa Horibe</maintainer>

--- a/control/autoware_obstacle_collision_checker/CHANGELOG.rst
+++ b/control/autoware_obstacle_collision_checker/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_obstacle_collision_checker
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/control/autoware_obstacle_collision_checker/package.xml
+++ b/control/autoware_obstacle_collision_checker/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_obstacle_collision_checker</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The obstacle_collision_checker package</description>
   <maintainer email="taiki.tanaka@tier4.jp">Taiki Tanaka</maintainer>
   <maintainer email="tomoya.kimura@tier4.jp">Tomoya Kimura</maintainer>

--- a/control/autoware_operation_mode_transition_manager/CHANGELOG.rst
+++ b/control/autoware_operation_mode_transition_manager/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_operation_mode_transition_manager
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/control/autoware_operation_mode_transition_manager/package.xml
+++ b/control/autoware_operation_mode_transition_manager/package.xml
@@ -1,6 +1,6 @@
 <package format="3">
   <name>autoware_operation_mode_transition_manager</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The operation_mode_transition_manager package</description>
   <maintainer email="takamasa.horibe@tier4.jp">Takamasa Horibe</maintainer>
   <maintainer email="tomoya.kimura@tier4.jp">Tomoya Kimura</maintainer>

--- a/control/autoware_pid_longitudinal_controller/CHANGELOG.rst
+++ b/control/autoware_pid_longitudinal_controller/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_pid_longitudinal_controller
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/control/autoware_pid_longitudinal_controller/package.xml
+++ b/control/autoware_pid_longitudinal_controller/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_pid_longitudinal_controller</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>PID-based longitudinal controller</description>
 
   <maintainer email="takamasa.horibe@tier4.jp">Takamasa Horibe</maintainer>

--- a/control/autoware_predicted_path_checker/CHANGELOG.rst
+++ b/control/autoware_predicted_path_checker/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_predicted_path_checker
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/control/autoware_predicted_path_checker/package.xml
+++ b/control/autoware_predicted_path_checker/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_predicted_path_checker</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The predicted_path_checker package</description>
 
   <maintainer email="berkay@leodrive.ai">Berkay Karaman</maintainer>

--- a/control/autoware_pure_pursuit/CHANGELOG.rst
+++ b/control/autoware_pure_pursuit/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_pure_pursuit
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/control/autoware_pure_pursuit/package.xml
+++ b/control/autoware_pure_pursuit/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_pure_pursuit</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The pure_pursuit package</description>
   <maintainer email="takamasa.horibe@tier4.jp">Takamasa Horibe</maintainer>
   <maintainer email="takayuki.murooka@tier4.jp">Takayuki Murooka</maintainer>

--- a/control/autoware_shift_decider/CHANGELOG.rst
+++ b/control/autoware_shift_decider/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_shift_decider
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/control/autoware_shift_decider/package.xml
+++ b/control/autoware_shift_decider/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_shift_decider</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The autoware_shift_decider package</description>
   <maintainer email="takamasa.horibe@tier4.jp">Takamasa Horibe</maintainer>
   <maintainer email="takayuki.murooka@tier4.jp">Takayuki Murooka</maintainer>

--- a/control/autoware_smart_mpc_trajectory_follower/CHANGELOG.rst
+++ b/control/autoware_smart_mpc_trajectory_follower/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_smart_mpc_trajectory_follower
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/control/autoware_smart_mpc_trajectory_follower/package.xml
+++ b/control/autoware_smart_mpc_trajectory_follower/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_smart_mpc_trajectory_follower</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>Nodes to follow a trajectory by generating control commands using smart mpc</description>
 
   <!-- mpc longitudinal controller -->

--- a/control/autoware_trajectory_follower_base/CHANGELOG.rst
+++ b/control/autoware_trajectory_follower_base/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_trajectory_follower_base
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/control/autoware_trajectory_follower_base/package.xml
+++ b/control/autoware_trajectory_follower_base/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_trajectory_follower_base</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>Library for generating lateral and longitudinal controls following a trajectory</description>
 
   <!-- mpc longitudinal controller -->

--- a/control/autoware_trajectory_follower_node/CHANGELOG.rst
+++ b/control/autoware_trajectory_follower_node/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_trajectory_follower_node
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/control/autoware_trajectory_follower_node/package.xml
+++ b/control/autoware_trajectory_follower_node/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_trajectory_follower_node</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>Nodes to follow a trajectory by generating control commands separated into lateral and longitudinal commands</description>
 
   <!-- mpc longitudinal controller -->

--- a/control/autoware_vehicle_cmd_gate/CHANGELOG.rst
+++ b/control/autoware_vehicle_cmd_gate/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_vehicle_cmd_gate
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/control/autoware_vehicle_cmd_gate/package.xml
+++ b/control/autoware_vehicle_cmd_gate/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_vehicle_cmd_gate</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The vehicle_cmd_gate package</description>
   <maintainer email="takamasa.horibe@tier4.jp">Takamasa Horibe</maintainer>
   <maintainer email="tomoya.kimura@tier4.jp">Tomoya Kimura</maintainer>

--- a/evaluator/autoware_control_evaluator/CHANGELOG.rst
+++ b/evaluator/autoware_control_evaluator/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_control_evaluator
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/evaluator/autoware_control_evaluator/package.xml
+++ b/evaluator/autoware_control_evaluator/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_control_evaluator</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>ROS 2 node for evaluating control</description>
   <maintainer email="daniel.sanchez@tier4.jp">Daniel SANCHEZ</maintainer>
   <maintainer email="takayuki.murooka@tier4.jp">takayuki MUROOKA</maintainer>

--- a/evaluator/autoware_kinematic_evaluator/CHANGELOG.rst
+++ b/evaluator/autoware_kinematic_evaluator/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_kinematic_evaluator
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/evaluator/autoware_kinematic_evaluator/package.xml
+++ b/evaluator/autoware_kinematic_evaluator/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>autoware_kinematic_evaluator</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>kinematic evaluator ROS 2 node</description>
 
   <maintainer email="dominik.jargot@robotec.ai">Dominik Jargot</maintainer>

--- a/evaluator/autoware_localization_evaluator/CHANGELOG.rst
+++ b/evaluator/autoware_localization_evaluator/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_localization_evaluator
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/evaluator/autoware_localization_evaluator/package.xml
+++ b/evaluator/autoware_localization_evaluator/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>autoware_localization_evaluator</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>localization evaluator ROS 2 node</description>
 
   <maintainer email="dominik.jargot@robotec.ai">Dominik Jargot</maintainer>

--- a/evaluator/autoware_perception_online_evaluator/CHANGELOG.rst
+++ b/evaluator/autoware_perception_online_evaluator/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_perception_online_evaluator
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/evaluator/autoware_perception_online_evaluator/package.xml
+++ b/evaluator/autoware_perception_online_evaluator/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_perception_online_evaluator</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>ROS 2 node for evaluating perception</description>
   <maintainer email="fumiya.watanabe@tier4.jp">Fumiya Watanabe</maintainer>
   <maintainer email="kosuke.takeuchi@tier4.jp">Kosuke Takeuchi</maintainer>

--- a/evaluator/autoware_planning_evaluator/CHANGELOG.rst
+++ b/evaluator/autoware_planning_evaluator/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_planning_evaluator
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/evaluator/autoware_planning_evaluator/package.xml
+++ b/evaluator/autoware_planning_evaluator/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_planning_evaluator</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>ROS 2 node for evaluating planners</description>
   <maintainer email="maxime.clement@tier4.jp">Maxime CLEMENT</maintainer>
   <maintainer email="kyoichi.sugahara@tier4.jp">Kyoichi Sugahara</maintainer>

--- a/evaluator/autoware_scenario_simulator_v2_adapter/CHANGELOG.rst
+++ b/evaluator/autoware_scenario_simulator_v2_adapter/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_scenario_simulator_v2_adapter
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/evaluator/autoware_scenario_simulator_v2_adapter/package.xml
+++ b/evaluator/autoware_scenario_simulator_v2_adapter/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_scenario_simulator_v2_adapter</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>Node for converting autoware's messages into UserDefinedValue messages</description>
   <maintainer email="kyoichi.sugahara@tier4.jp">Kyoichi Sugahara</maintainer>
   <maintainer email="maxime.clement@tier4.jp">Maxime CLEMENT</maintainer>

--- a/launch/tier4_autoware_api_launch/CHANGELOG.rst
+++ b/launch/tier4_autoware_api_launch/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package tier4_autoware_api_launch
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/launch/tier4_autoware_api_launch/package.xml
+++ b/launch/tier4_autoware_api_launch/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>tier4_autoware_api_launch</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The tier4_autoware_api_launch package</description>
   <maintainer email="isamu.takagi@tier4.jp">Takagi, Isamu</maintainer>
   <maintainer email="ryohsuke.mitsudome@tier4.jp">Ryohsuke Mitsudome</maintainer>

--- a/launch/tier4_control_launch/CHANGELOG.rst
+++ b/launch/tier4_control_launch/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package tier4_control_launch
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/launch/tier4_control_launch/package.xml
+++ b/launch/tier4_control_launch/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>tier4_control_launch</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The tier4_control_launch package</description>
   <maintainer email="takamasa.horibe@tier4.jp">Takamasa Horibe</maintainer>
   <maintainer email="takayuki.murooka@tier4.jp">Takayuki Murooka</maintainer>

--- a/launch/tier4_localization_launch/CHANGELOG.rst
+++ b/launch/tier4_localization_launch/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package tier4_localization_launch
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/launch/tier4_localization_launch/package.xml
+++ b/launch/tier4_localization_launch/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>tier4_localization_launch</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The tier4_localization_launch package</description>
   <maintainer email="yamato.ando@tier4.jp">Yamato Ando</maintainer>
   <maintainer email="kento.yabuuchi.2@tier4.jp">Kento Yabuuchi</maintainer>

--- a/launch/tier4_map_launch/CHANGELOG.rst
+++ b/launch/tier4_map_launch/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package tier4_map_launch
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/launch/tier4_map_launch/package.xml
+++ b/launch/tier4_map_launch/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>tier4_map_launch</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The tier4_map_launch package</description>
   <maintainer email="ryu.yamamoto@tier4.jp">Ryu Yamamoto</maintainer>
   <maintainer email="kento.yabuuchi.2@tier4.jp">Kento Yabuuchi</maintainer>

--- a/launch/tier4_perception_launch/CHANGELOG.rst
+++ b/launch/tier4_perception_launch/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package tier4_perception_launch
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/launch/tier4_perception_launch/package.xml
+++ b/launch/tier4_perception_launch/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>tier4_perception_launch</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The tier4_perception_launch package</description>
   <maintainer email="yukihiro.saito@tier4.jp">Yukihiro Saito</maintainer>
   <maintainer email="shunsuke.miura@tier4.jp">Shunsuke Miura</maintainer>

--- a/launch/tier4_planning_launch/CHANGELOG.rst
+++ b/launch/tier4_planning_launch/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package tier4_planning_launch
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/launch/tier4_planning_launch/package.xml
+++ b/launch/tier4_planning_launch/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>tier4_planning_launch</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The tier4_planning_launch package</description>
   <!-- behavior path planner -->
   <!-- lane change module -->

--- a/launch/tier4_sensing_launch/CHANGELOG.rst
+++ b/launch/tier4_sensing_launch/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package tier4_sensing_launch
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/launch/tier4_sensing_launch/package.xml
+++ b/launch/tier4_sensing_launch/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>tier4_sensing_launch</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The tier4_sensing_launch package</description>
   <maintainer email="yukihiro.saito@tier4.jp">Yukihiro Saito</maintainer>
   <license>Apache License 2.0</license>

--- a/launch/tier4_simulator_launch/CHANGELOG.rst
+++ b/launch/tier4_simulator_launch/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package tier4_simulator_launch
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/launch/tier4_simulator_launch/package.xml
+++ b/launch/tier4_simulator_launch/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>tier4_simulator_launch</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The tier4_simulator_launch package</description>
   <maintainer email="keisuke.shima@tier4.jp">Keisuke Shima</maintainer>
   <maintainer email="takayuki.murooka@tier4.jp">Takayuki Murooka</maintainer>

--- a/launch/tier4_system_launch/CHANGELOG.rst
+++ b/launch/tier4_system_launch/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package tier4_system_launch
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/launch/tier4_system_launch/package.xml
+++ b/launch/tier4_system_launch/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>tier4_system_launch</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The tier4_system_launch package</description>
   <maintainer email="fumihito.ito@tier4.jp">Fumihito Ito</maintainer>
   <maintainer email="tetsuhiro.kawaguchi@tier4.jp">TetsuKawa</maintainer>

--- a/launch/tier4_vehicle_launch/CHANGELOG.rst
+++ b/launch/tier4_vehicle_launch/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package tier4_vehicle_launch
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/launch/tier4_vehicle_launch/package.xml
+++ b/launch/tier4_vehicle_launch/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>tier4_vehicle_launch</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The tier4_vehicle_launch package</description>
   <maintainer email="yukihiro.saito@tier4.jp">Yukihiro Saito</maintainer>
   <license>Apache License 2.0</license>

--- a/localization/autoware_ekf_localizer/CHANGELOG.rst
+++ b/localization/autoware_ekf_localizer/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_ekf_localizer
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/localization/autoware_ekf_localizer/package.xml
+++ b/localization/autoware_ekf_localizer/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_ekf_localizer</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The autoware_ekf_localizer package</description>
   <maintainer email="takamasa.horibe@tier4.jp">Takamasa Horibe</maintainer>
   <maintainer email="yamato.ando@tier4.jp">Yamato Ando</maintainer>

--- a/localization/autoware_geo_pose_projector/CHANGELOG.rst
+++ b/localization/autoware_geo_pose_projector/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_geo_pose_projector
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/localization/autoware_geo_pose_projector/package.xml
+++ b/localization/autoware_geo_pose_projector/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_geo_pose_projector</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The autoware_geo_pose_projector package</description>
   <maintainer email="yamato.ando@tier4.jp">Yamato Ando</maintainer>
   <maintainer email="masahiro.sakamoto@tier4.jp">Masahiro Sakamoto</maintainer>

--- a/localization/autoware_gyro_odometer/CHANGELOG.rst
+++ b/localization/autoware_gyro_odometer/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_gyro_odometer
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/localization/autoware_gyro_odometer/package.xml
+++ b/localization/autoware_gyro_odometer/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_gyro_odometer</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The autoware_gyro_odometer package as a ROS 2 node</description>
   <maintainer email="yamato.ando@tier4.jp">Yamato Ando</maintainer>
   <maintainer email="masahiro.sakamoto@tier4.jp">Masahiro Sakamoto</maintainer>

--- a/localization/autoware_landmark_based_localizer/autoware_ar_tag_based_localizer/CHANGELOG.rst
+++ b/localization/autoware_landmark_based_localizer/autoware_ar_tag_based_localizer/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_ar_tag_based_localizer
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/localization/autoware_landmark_based_localizer/autoware_ar_tag_based_localizer/package.xml
+++ b/localization/autoware_landmark_based_localizer/autoware_ar_tag_based_localizer/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_ar_tag_based_localizer</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The autoware_ar_tag_based_localizer package</description>
   <maintainer email="shintaro.sakoda@tier4.jp">Shintaro Sakoda</maintainer>
   <maintainer email="masahiro.sakamoto@tier4.jp">Masahiro Sakamoto</maintainer>

--- a/localization/autoware_landmark_based_localizer/autoware_landmark_manager/CHANGELOG.rst
+++ b/localization/autoware_landmark_based_localizer/autoware_landmark_manager/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_landmark_manager
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/localization/autoware_landmark_based_localizer/autoware_landmark_manager/package.xml
+++ b/localization/autoware_landmark_based_localizer/autoware_landmark_manager/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_landmark_manager</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The autoware_landmark_manager package</description>
   <maintainer email="shintaro.sakoda@tier4.jp">Shintaro Sakoda</maintainer>
   <maintainer email="masahiro.sakamoto@tier4.jp">Masahiro Sakamoto</maintainer>

--- a/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/CHANGELOG.rst
+++ b/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_lidar_marker_localizer
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/package.xml
+++ b/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_lidar_marker_localizer</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The autoware_lidar_marker_localizer package</description>
   <maintainer email="yamato.ando@tier4.jp">Yamato Ando</maintainer>
   <maintainer email="shintaro.sakoda@tier4.jp">Shintaro Sakoda</maintainer>

--- a/localization/autoware_localization_error_monitor/CHANGELOG.rst
+++ b/localization/autoware_localization_error_monitor/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_localization_error_monitor
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/localization/autoware_localization_error_monitor/package.xml
+++ b/localization/autoware_localization_error_monitor/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_localization_error_monitor</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>ros node for monitoring localization error</description>
   <maintainer email="yamato.ando@tier4.jp">Yamato Ando</maintainer>
   <maintainer email="masahiro.sakamoto@tier4.jp">Masahiro Sakamoto</maintainer>

--- a/localization/autoware_ndt_scan_matcher/CHANGELOG.rst
+++ b/localization/autoware_ndt_scan_matcher/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_ndt_scan_matcher
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/localization/autoware_ndt_scan_matcher/package.xml
+++ b/localization/autoware_ndt_scan_matcher/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_ndt_scan_matcher</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The autoware_ndt_scan_matcher package</description>
   <maintainer email="yamato.ando@tier4.jp">Yamato Ando</maintainer>
   <maintainer email="kento.yabuuchi.2@tier4.jp">Kento Yabuuchi</maintainer>

--- a/localization/autoware_pose2twist/CHANGELOG.rst
+++ b/localization/autoware_pose2twist/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_pose2twist
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/localization/autoware_pose2twist/package.xml
+++ b/localization/autoware_pose2twist/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_pose2twist</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The autoware_pose2twist package</description>
   <maintainer email="yamato.ando@tier4.jp">Yamato Ando</maintainer>
   <maintainer email="masahiro.sakamoto@tier4.jp">Masahiro Sakamoto</maintainer>

--- a/localization/autoware_pose_covariance_modifier/CHANGELOG.rst
+++ b/localization/autoware_pose_covariance_modifier/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_pose_covariance_modifier
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/localization/autoware_pose_covariance_modifier/package.xml
+++ b/localization/autoware_pose_covariance_modifier/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_pose_covariance_modifier</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>Add a description.</description>
 
   <maintainer email="melike@leodrive.ai">Melike Tanrikulu</maintainer>

--- a/localization/autoware_pose_estimator_arbiter/CHANGELOG.rst
+++ b/localization/autoware_pose_estimator_arbiter/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_pose_estimator_arbiter
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/localization/autoware_pose_estimator_arbiter/package.xml
+++ b/localization/autoware_pose_estimator_arbiter/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_pose_estimator_arbiter</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The arbiter of multiple pose estimators</description>
   <maintainer email="yamato.ando@tier4.jp">Yamato Ando</maintainer>
   <maintainer email="kento.yabuuchi.2@tier4.jp">Kento Yabuuchi</maintainer>

--- a/localization/autoware_pose_initializer/CHANGELOG.rst
+++ b/localization/autoware_pose_initializer/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_pose_initializer
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/localization/autoware_pose_initializer/package.xml
+++ b/localization/autoware_pose_initializer/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_pose_initializer</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The autoware_pose_initializer package</description>
   <maintainer email="yamato.ando@tier4.jp">Yamato Ando</maintainer>
   <maintainer email="isamu.takagi@tier4.jp">Takagi, Isamu</maintainer>

--- a/localization/autoware_pose_instability_detector/CHANGELOG.rst
+++ b/localization/autoware_pose_instability_detector/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_pose_instability_detector
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/localization/autoware_pose_instability_detector/package.xml
+++ b/localization/autoware_pose_instability_detector/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_pose_instability_detector</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The autoware_pose_instability_detector package</description>
   <maintainer email="yamato.ando@tier4.jp">Yamato Ando</maintainer>
   <maintainer email="kento.yabuuchi.2@tier4.jp">Kento Yabuuchi</maintainer>

--- a/localization/autoware_stop_filter/CHANGELOG.rst
+++ b/localization/autoware_stop_filter/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_stop_filter
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/localization/autoware_stop_filter/package.xml
+++ b/localization/autoware_stop_filter/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_stop_filter</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The stop filter package</description>
   <maintainer email="yamato.ando@tier4.jp">Yamato Ando</maintainer>
   <maintainer email="masahiro.sakamoto@tier4.jp">Masahiro Sakamoto</maintainer>

--- a/localization/autoware_twist2accel/CHANGELOG.rst
+++ b/localization/autoware_twist2accel/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_twist2accel
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/localization/autoware_twist2accel/package.xml
+++ b/localization/autoware_twist2accel/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_twist2accel</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The acceleration estimation package</description>
   <maintainer email="yamato.ando@tier4.jp">Yamato Ando</maintainer>
   <maintainer email="masahiro.sakamoto@tier4.jp">Masahiro Sakamoto</maintainer>

--- a/localization/yabloc/yabloc_common/CHANGELOG.rst
+++ b/localization/yabloc/yabloc_common/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package yabloc_common
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/localization/yabloc/yabloc_common/package.xml
+++ b/localization/yabloc/yabloc_common/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>yabloc_common</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>YabLoc common library</description>
   <maintainer email="kento.yabuuchi.2@tier4.jp">Kento Yabuuchi</maintainer>
   <maintainer email="masahiro.sakamoto@tier4.jp">Masahiro Sakamoto</maintainer>

--- a/localization/yabloc/yabloc_image_processing/CHANGELOG.rst
+++ b/localization/yabloc/yabloc_image_processing/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package yabloc_image_processing
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/localization/yabloc/yabloc_image_processing/package.xml
+++ b/localization/yabloc/yabloc_image_processing/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>yabloc_image_processing</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>YabLoc image processing package</description>
   <maintainer email="kento.yabuuchi.2@tier4.jp">Kento Yabuuchi</maintainer>
   <maintainer email="masahiro.sakamoto@tier4.jp">Masahiro Sakamoto</maintainer>

--- a/localization/yabloc/yabloc_monitor/CHANGELOG.rst
+++ b/localization/yabloc/yabloc_monitor/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package yabloc_monitor
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/localization/yabloc/yabloc_monitor/package.xml
+++ b/localization/yabloc/yabloc_monitor/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>yabloc_monitor</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>YabLoc monitor package</description>
   <maintainer email="kento.yabuuchi.2@tier4.jp">Kento Yabuuchi</maintainer>
   <maintainer email="masahiro.sakamoto@tier4.jp">Masahiro Sakamoto</maintainer>

--- a/localization/yabloc/yabloc_particle_filter/CHANGELOG.rst
+++ b/localization/yabloc/yabloc_particle_filter/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package yabloc_particle_filter
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/localization/yabloc/yabloc_particle_filter/package.xml
+++ b/localization/yabloc/yabloc_particle_filter/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>yabloc_particle_filter</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>YabLoc particle filter package</description>
   <maintainer email="kento.yabuuchi.2@tier4.jp">Kento Yabuuchi</maintainer>
   <maintainer email="masahiro.sakamoto@tier4.jp">Masahiro Sakamoto</maintainer>

--- a/localization/yabloc/yabloc_pose_initializer/CHANGELOG.rst
+++ b/localization/yabloc/yabloc_pose_initializer/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package yabloc_pose_initializer
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/localization/yabloc/yabloc_pose_initializer/package.xml
+++ b/localization/yabloc/yabloc_pose_initializer/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>yabloc_pose_initializer</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The pose initializer</description>
   <maintainer email="kento.yabuuchi.2@tier4.jp">Kento Yabuuchi</maintainer>
   <maintainer email="masahiro.sakamoto@tier4.jp">Masahiro Sakamoto</maintainer>

--- a/map/autoware_lanelet2_map_visualizer/CHANGELOG.rst
+++ b/map/autoware_lanelet2_map_visualizer/CHANGELOG.rst
@@ -3,6 +3,11 @@ Changelog for package autoware_lanelet2_map_visualizer
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/map/autoware_lanelet2_map_visualizer/package.xml
+++ b/map/autoware_lanelet2_map_visualizer/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_lanelet2_map_visualizer</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The autoware_lanelet2_map_visualizer package</description>
   <maintainer email="yamato.ando@tier4.jp">Yamato Ando</maintainer>
   <maintainer email="ryu.yamamoto@tier4.jp">Ryu Yamamoto</maintainer>

--- a/map/autoware_map_height_fitter/CHANGELOG.rst
+++ b/map/autoware_map_height_fitter/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_map_height_fitter
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 * fix(autoware_map_height_fitter): find PCL package after autoware_package() is called (`#10070 <https://github.com/youtalk/autoware.universe/issues/10070>`_)

--- a/map/autoware_map_height_fitter/package.xml
+++ b/map/autoware_map_height_fitter/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_map_height_fitter</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The autoware_map_height_fitter package</description>
   <maintainer email="isamu.takagi@tier4.jp">Takagi, Isamu</maintainer>
   <maintainer email="yamato.ando@tier4.jp">Yamato Ando</maintainer>

--- a/map/autoware_map_loader/CHANGELOG.rst
+++ b/map/autoware_map_loader/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_map_loader
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/map/autoware_map_loader/package.xml
+++ b/map/autoware_map_loader/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_map_loader</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The autoware_map_loader package</description>
   <maintainer email="yamato.ando@tier4.jp">Yamato Ando</maintainer>
   <maintainer email="ryu.yamamoto@tier4.jp">Ryu Yamamoto</maintainer>

--- a/map/autoware_map_projection_loader/CHANGELOG.rst
+++ b/map/autoware_map_projection_loader/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_map_projection_loader
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/map/autoware_map_projection_loader/package.xml
+++ b/map/autoware_map_projection_loader/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_map_projection_loader</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>autoware_map_projection_loader package as a ROS 2 node</description>
   <maintainer email="yamato.ando@tier4.jp">Yamato Ando</maintainer>
   <maintainer email="masahiro.sakamoto@tier4.jp">Masahiro Sakamoto</maintainer>

--- a/map/autoware_map_tf_generator/CHANGELOG.rst
+++ b/map/autoware_map_tf_generator/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_map_tf_generator
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/map/autoware_map_tf_generator/package.xml
+++ b/map/autoware_map_tf_generator/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_map_tf_generator</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>map_tf_generator package as a ROS 2 node</description>
   <maintainer email="yamato.ando@tier4.jp">Yamato Ando</maintainer>
   <maintainer email="kento.yabuuchi.2@tier4.jp">Kento Yabuuchi</maintainer>

--- a/perception/autoware_bytetrack/CHANGELOG.rst
+++ b/perception/autoware_bytetrack/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_bytetrack
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/perception/autoware_bytetrack/package.xml
+++ b/perception/autoware_bytetrack/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_bytetrack</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>ByteTrack implementation ported toward Autoware</description>
   <maintainer email="manato.hirabayashi@tier4.jp">Manato HIRABAYASHI</maintainer>
   <maintainer email="yoshi.ri@tier4.jp">Yoshi RI</maintainer>

--- a/perception/autoware_cluster_merger/CHANGELOG.rst
+++ b/perception/autoware_cluster_merger/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_cluster_merger
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/perception/autoware_cluster_merger/package.xml
+++ b/perception/autoware_cluster_merger/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_cluster_merger</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The ROS 2 cluster merger package</description>
   <maintainer email="yukihiro.saito@tier4.jp">Yukihiro Saito</maintainer>
   <maintainer email="shunsuke.miura@tier4.jp">Shunsuke Miura</maintainer>

--- a/perception/autoware_compare_map_segmentation/CHANGELOG.rst
+++ b/perception/autoware_compare_map_segmentation/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_compare_map_segmentation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/perception/autoware_compare_map_segmentation/package.xml
+++ b/perception/autoware_compare_map_segmentation/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_compare_map_segmentation</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The ROS 2 autoware_compare_map_segmentation package</description>
   <maintainer email="abrahammonrroy@yahoo.com">amc-nu</maintainer>
   <maintainer email="yukihiro.saito@tier4.jp">Yukihiro Saito</maintainer>

--- a/perception/autoware_crosswalk_traffic_light_estimator/CHANGELOG.rst
+++ b/perception/autoware_crosswalk_traffic_light_estimator/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_crosswalk_traffic_light_estimator
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/perception/autoware_crosswalk_traffic_light_estimator/package.xml
+++ b/perception/autoware_crosswalk_traffic_light_estimator/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>autoware_crosswalk_traffic_light_estimator</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The autoware_crosswalk_traffic_light_estimator package</description>
 
   <maintainer email="satoshi.ota@tier4.jp">Satoshi Ota</maintainer>

--- a/perception/autoware_detected_object_feature_remover/CHANGELOG.rst
+++ b/perception/autoware_detected_object_feature_remover/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_detected_object_feature_remover
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/perception/autoware_detected_object_feature_remover/package.xml
+++ b/perception/autoware_detected_object_feature_remover/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_detected_object_feature_remover</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The autoware_detected_object_feature_remover package</description>
   <maintainer email="tomoya.kimura@tier4.jp">Tomoya Kimura</maintainer>
   <maintainer email="yoshi.ri@tier4.jp">Yoshi Ri</maintainer>

--- a/perception/autoware_detected_object_validation/CHANGELOG.rst
+++ b/perception/autoware_detected_object_validation/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_detected_object_validation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/perception/autoware_detected_object_validation/package.xml
+++ b/perception/autoware_detected_object_validation/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_detected_object_validation</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The ROS 2 detected_object_validation package</description>
   <maintainer email="yukihiro.saito@tier4.jp">Yukihiro Saito</maintainer>
   <maintainer email="shunsuke.miura@tier4.jp">Shunsuke Miura</maintainer>

--- a/perception/autoware_detection_by_tracker/CHANGELOG.rst
+++ b/perception/autoware_detection_by_tracker/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_detection_by_tracker
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/perception/autoware_detection_by_tracker/package.xml
+++ b/perception/autoware_detection_by_tracker/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_detection_by_tracker</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The ROS 2 autoware_detection_by_tracker package</description>
   <maintainer email="yukihiro.saito@tier4.jp">Yukihiro Saito</maintainer>
   <maintainer email="yoshi.ri@tier4.jp">Yoshi Ri</maintainer>

--- a/perception/autoware_elevation_map_loader/CHANGELOG.rst
+++ b/perception/autoware_elevation_map_loader/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_elevation_map_loader
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/perception/autoware_elevation_map_loader/package.xml
+++ b/perception/autoware_elevation_map_loader/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_elevation_map_loader</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The autoware_elevation_map_loader package</description>
   <maintainer email="kosuke.takeuchi@tier4.jp">Kosuke Takeuchi</maintainer>
   <maintainer email="taichi.higashide@tier4.jp">Taichi Higashide</maintainer>

--- a/perception/autoware_euclidean_cluster/CHANGELOG.rst
+++ b/perception/autoware_euclidean_cluster/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_euclidean_cluster
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/perception/autoware_euclidean_cluster/package.xml
+++ b/perception/autoware_euclidean_cluster/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_euclidean_cluster</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The autoware_euclidean_cluster package</description>
   <maintainer email="yukihiro.saito@tier4.jp">Yukihiro Saito</maintainer>
   <maintainer email="dai.nguyen@tier4.jp">Dai Nguyen</maintainer>

--- a/perception/autoware_ground_segmentation/CHANGELOG.rst
+++ b/perception/autoware_ground_segmentation/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_ground_segmentation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/perception/autoware_ground_segmentation/package.xml
+++ b/perception/autoware_ground_segmentation/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_ground_segmentation</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The ROS 2 autoware_ground_segmentation package</description>
   <maintainer email="abrahammonrroy@yahoo.com">amc-nu</maintainer>
   <maintainer email="yukihiro.saito@tier4.jp">Yukihiro Saito</maintainer>

--- a/perception/autoware_image_projection_based_fusion/CHANGELOG.rst
+++ b/perception/autoware_image_projection_based_fusion/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_image_projection_based_fusion
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/perception/autoware_image_projection_based_fusion/package.xml
+++ b/perception/autoware_image_projection_based_fusion/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_image_projection_based_fusion</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The autoware_image_projection_based_fusion package</description>
   <maintainer email="yukihiro.saito@tier4.jp">Yukihiro Saito</maintainer>
   <maintainer email="shunsuke.miura@tier4.jp">Shunsuke Miura</maintainer>

--- a/perception/autoware_lidar_apollo_instance_segmentation/CHANGELOG.rst
+++ b/perception/autoware_lidar_apollo_instance_segmentation/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_lidar_apollo_instance_segmentation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/perception/autoware_lidar_apollo_instance_segmentation/package.xml
+++ b/perception/autoware_lidar_apollo_instance_segmentation/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_lidar_apollo_instance_segmentation</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>autoware_lidar_apollo_instance_segmentation</description>
   <maintainer email="yoshi.ri@tier4.jp">Yoshi Ri</maintainer>
   <maintainer email="yukihiro.saito@tier4.jp">Yukihiro Saito</maintainer>

--- a/perception/autoware_lidar_centerpoint/CHANGELOG.rst
+++ b/perception/autoware_lidar_centerpoint/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_lidar_centerpoint
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/perception/autoware_lidar_centerpoint/package.xml
+++ b/perception/autoware_lidar_centerpoint/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_lidar_centerpoint</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The autoware_lidar_centerpoint package</description>
   <maintainer email="kenzo.lobos@tier4.jp">Kenzo Lobos-Tsunekawa</maintainer>
   <maintainer email="koji.minoda@tier4.jp">Koji Minoda</maintainer>

--- a/perception/autoware_lidar_transfusion/CHANGELOG.rst
+++ b/perception/autoware_lidar_transfusion/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_lidar_transfusion
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/perception/autoware_lidar_transfusion/package.xml
+++ b/perception/autoware_lidar_transfusion/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_lidar_transfusion</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The lidar_transfusion package</description>
   <maintainer email="amadeusz.szymko.2@tier4.jp">Amadeusz Szymko</maintainer>
   <maintainer email="kenzo.lobos@tier4.jp">Kenzo Lobos-Tsunekawa</maintainer>

--- a/perception/autoware_map_based_prediction/CHANGELOG.rst
+++ b/perception/autoware_map_based_prediction/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_map_based_prediction
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/perception/autoware_map_based_prediction/package.xml
+++ b/perception/autoware_map_based_prediction/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_map_based_prediction</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>This package implements a map_based_prediction</description>
   <maintainer email="tomoya.kimura@tier4.jp">Tomoya Kimura</maintainer>
   <maintainer email="yoshi.ri@tier4.jp">Yoshi Ri</maintainer>

--- a/perception/autoware_multi_object_tracker/CHANGELOG.rst
+++ b/perception/autoware_multi_object_tracker/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_multi_object_tracker
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/perception/autoware_multi_object_tracker/package.xml
+++ b/perception/autoware_multi_object_tracker/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_multi_object_tracker</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The ROS 2 autoware_multi_object_tracker package</description>
   <maintainer email="yukihiro.saito@tier4.jp">Yukihiro Saito</maintainer>
   <maintainer email="yoshi.ri@tier4.jp">Yoshi Ri</maintainer>

--- a/perception/autoware_object_merger/CHANGELOG.rst
+++ b/perception/autoware_object_merger/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_object_merger
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/perception/autoware_object_merger/package.xml
+++ b/perception/autoware_object_merger/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_object_merger</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The autoware_object_merger package</description>
   <maintainer email="yukihiro.saito@tier4.jp">Yukihiro Saito</maintainer>
   <maintainer email="yoshi.ri@tier4.jp">Yoshi Ri</maintainer>

--- a/perception/autoware_object_range_splitter/CHANGELOG.rst
+++ b/perception/autoware_object_range_splitter/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_object_range_splitter
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/perception/autoware_object_range_splitter/package.xml
+++ b/perception/autoware_object_range_splitter/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_object_range_splitter</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The autoware_object_range_splitter package</description>
   <maintainer email="yukihiro.saito@tier4.jp">Yukihiro Saito</maintainer>
   <maintainer email="yoshi.ri@tier4.jp">Yoshi Ri</maintainer>

--- a/perception/autoware_object_velocity_splitter/CHANGELOG.rst
+++ b/perception/autoware_object_velocity_splitter/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_object_velocity_splitter
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/perception/autoware_object_velocity_splitter/package.xml
+++ b/perception/autoware_object_velocity_splitter/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_object_velocity_splitter</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>autoware_object_velocity_splitter</description>
   <maintainer email="satoshi.tanaka@tier4.jp">Sathshi Tanaka</maintainer>
   <maintainer email="shunsuke.miura@tier4.jp">Shunsuke Miura</maintainer>

--- a/perception/autoware_occupancy_grid_map_outlier_filter/CHANGELOG.rst
+++ b/perception/autoware_occupancy_grid_map_outlier_filter/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_occupancy_grid_map_outlier_filter
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/perception/autoware_occupancy_grid_map_outlier_filter/package.xml
+++ b/perception/autoware_occupancy_grid_map_outlier_filter/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_occupancy_grid_map_outlier_filter</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The ROS 2 occupancy_grid_map_outlier_filter package</description>
   <maintainer email="abrahammonrroy@yahoo.com">amc-nu</maintainer>
   <maintainer email="yukihiro.saito@tier4.jp">Yukihiro Saito</maintainer>

--- a/perception/autoware_probabilistic_occupancy_grid_map/CHANGELOG.rst
+++ b/perception/autoware_probabilistic_occupancy_grid_map/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_probabilistic_occupancy_grid_map
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/perception/autoware_probabilistic_occupancy_grid_map/package.xml
+++ b/perception/autoware_probabilistic_occupancy_grid_map/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_probabilistic_occupancy_grid_map</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>generate probabilistic occupancy grid map</description>
   <maintainer email="yukihiro.saito@tier4.jp">Yukihiro Saito</maintainer>
   <maintainer email="yoshi.ri@tier4.jp">Yoshi Ri</maintainer>

--- a/perception/autoware_radar_crossing_objects_noise_filter/CHANGELOG.rst
+++ b/perception/autoware_radar_crossing_objects_noise_filter/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_radar_crossing_objects_noise_filter
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/perception/autoware_radar_crossing_objects_noise_filter/package.xml
+++ b/perception/autoware_radar_crossing_objects_noise_filter/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_radar_crossing_objects_noise_filter</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>autoware_radar_crossing_objects_noise_filter</description>
   <maintainer email="satoshi.tanaka@tier4.jp">Sathshi Tanaka</maintainer>
   <maintainer email="shunsuke.miura@tier4.jp">Shunsuke Miura</maintainer>

--- a/perception/autoware_radar_fusion_to_detected_object/CHANGELOG.rst
+++ b/perception/autoware_radar_fusion_to_detected_object/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_radar_fusion_to_detected_object
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/perception/autoware_radar_fusion_to_detected_object/package.xml
+++ b/perception/autoware_radar_fusion_to_detected_object/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_radar_fusion_to_detected_object</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>autoware_radar_fusion_to_detected_object</description>
   <maintainer email="satoshi.tanaka@tier4.jp">Satoshi Tanaka</maintainer>
   <maintainer email="shunsuke.miura@tier4.jp">Shunsuke Miura</maintainer>

--- a/perception/autoware_radar_object_clustering/CHANGELOG.rst
+++ b/perception/autoware_radar_object_clustering/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_radar_object_clustering
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/perception/autoware_radar_object_clustering/package.xml
+++ b/perception/autoware_radar_object_clustering/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_radar_object_clustering</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>autoware_radar_object_clustering</description>
   <maintainer email="satoshi.tanaka@tier4.jp">Sathshi Tanaka</maintainer>
   <maintainer email="shunsuke.miura@tier4.jp">Shunsuke Miura</maintainer>

--- a/perception/autoware_radar_object_tracker/CHANGELOG.rst
+++ b/perception/autoware_radar_object_tracker/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_radar_object_tracker
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/perception/autoware_radar_object_tracker/package.xml
+++ b/perception/autoware_radar_object_tracker/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_radar_object_tracker</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>Do tracking radar object</description>
   <maintainer email="yoshi.ri@tier4.jp">Yoshi Ri</maintainer>
   <maintainer email="yukihiro.saito@tier4.jp">Yukihiro Saito</maintainer>

--- a/perception/autoware_radar_tracks_msgs_converter/CHANGELOG.rst
+++ b/perception/autoware_radar_tracks_msgs_converter/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_radar_tracks_msgs_converter
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/perception/autoware_radar_tracks_msgs_converter/package.xml
+++ b/perception/autoware_radar_tracks_msgs_converter/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_radar_tracks_msgs_converter</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>autoware_radar_tracks_msgs_converter</description>
   <maintainer email="satoshi.tanaka@tier4.jp">Satoshi Tanaka</maintainer>
   <maintainer email="shunsuke.miura@tier4.jp">Shunsuke Miura</maintainer>

--- a/perception/autoware_raindrop_cluster_filter/CHANGELOG.rst
+++ b/perception/autoware_raindrop_cluster_filter/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_raindrop_cluster_filter
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/perception/autoware_raindrop_cluster_filter/package.xml
+++ b/perception/autoware_raindrop_cluster_filter/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_raindrop_cluster_filter</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The ROS 2 filter cluster package</description>
   <maintainer email="yukihiro.saito@tier4.jp">Yukihiro Saito</maintainer>
   <maintainer email="dai.nguyen@tier4.jp">Dai Nguyen</maintainer>

--- a/perception/autoware_shape_estimation/CHANGELOG.rst
+++ b/perception/autoware_shape_estimation/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_shape_estimation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/perception/autoware_shape_estimation/package.xml
+++ b/perception/autoware_shape_estimation/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_shape_estimation</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>This package implements a shape estimation algorithm as a ROS 2 node</description>
   <maintainer email="yukihiro.saito@tier4.jp">Yukihiro Saito</maintainer>
   <maintainer email="yoshi.ri@tier4.jp">Yoshi Ri</maintainer>

--- a/perception/autoware_simple_object_merger/CHANGELOG.rst
+++ b/perception/autoware_simple_object_merger/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_simple_object_merger
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/perception/autoware_simple_object_merger/package.xml
+++ b/perception/autoware_simple_object_merger/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>autoware_simple_object_merger</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>autoware_simple_object_merger</description>
   <maintainer email="satoshi.tanaka@tier4.jp">Sathshi Tanaka</maintainer>
   <maintainer email="shunsuke.miura@tier4.jp">Shunsuke Miura</maintainer>

--- a/perception/autoware_tensorrt_classifier/CHANGELOG.rst
+++ b/perception/autoware_tensorrt_classifier/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_tensorrt_classifier
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/perception/autoware_tensorrt_classifier/package.xml
+++ b/perception/autoware_tensorrt_classifier/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>autoware_tensorrt_classifier</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>tensorrt classifier wrapper</description>
 
   <author email="dan.umeda@tier4.jp">Dan Umeda</author>

--- a/perception/autoware_tensorrt_common/CHANGELOG.rst
+++ b/perception/autoware_tensorrt_common/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_tensorrt_common
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/perception/autoware_tensorrt_common/package.xml
+++ b/perception/autoware_tensorrt_common/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>autoware_tensorrt_common</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>tensorrt utility wrapper</description>
 
   <author email="taichi.higashide@tier4.jp">Taichi Higashide</author>

--- a/perception/autoware_tensorrt_yolox/CHANGELOG.rst
+++ b/perception/autoware_tensorrt_yolox/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_tensorrt_yolox
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/perception/autoware_tensorrt_yolox/package.xml
+++ b/perception/autoware_tensorrt_yolox/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>autoware_tensorrt_yolox</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>tensorrt library implementation for yolox</description>
 
   <author email="daisuke.nishimatsu@tier4.jp">Daisuke Nishimatsu</author>

--- a/perception/autoware_tracking_object_merger/CHANGELOG.rst
+++ b/perception/autoware_tracking_object_merger/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_tracking_object_merger
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/perception/autoware_tracking_object_merger/package.xml
+++ b/perception/autoware_tracking_object_merger/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_tracking_object_merger</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>merge tracking object</description>
   <maintainer email="yukihiro.saito@tier4.jp">Yukihiro Saito</maintainer>
   <maintainer email="yoshi.ri@tier4.jp">Yoshi Ri</maintainer>

--- a/perception/autoware_traffic_light_arbiter/CHANGELOG.rst
+++ b/perception/autoware_traffic_light_arbiter/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_traffic_light_arbiter
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/perception/autoware_traffic_light_arbiter/package.xml
+++ b/perception/autoware_traffic_light_arbiter/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_traffic_light_arbiter</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The autoware_traffic_light_arbiter package</description>
   <maintainer email="kenzo.lobos@tier4.jp">Kenzo Lobos-Tsunekawa</maintainer>
   <maintainer email="shunsuke.miura@tier4.jp">Shunsuke Miura</maintainer>

--- a/perception/autoware_traffic_light_classifier/CHANGELOG.rst
+++ b/perception/autoware_traffic_light_classifier/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_traffic_light_classifier
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/perception/autoware_traffic_light_classifier/package.xml
+++ b/perception/autoware_traffic_light_classifier/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_traffic_light_classifier</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The autoware_traffic_light_classifier package</description>
   <maintainer email="yukihiro.saito@tier4.jp">Yukihiro Saito</maintainer>
   <maintainer email="shunsuke.miura@tier4.jp">Shunsuke Miura</maintainer>

--- a/perception/autoware_traffic_light_fine_detector/CHANGELOG.rst
+++ b/perception/autoware_traffic_light_fine_detector/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_traffic_light_fine_detector
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/perception/autoware_traffic_light_fine_detector/package.xml
+++ b/perception/autoware_traffic_light_fine_detector/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_traffic_light_fine_detector</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The autoware_traffic_light_fine_detector package</description>
   <maintainer email="tao.zhong@tier4.jp">Tao Zhong</maintainer>
   <maintainer email="shunsuke.miura@tier4.jp">Shunsuke Miura</maintainer>

--- a/perception/autoware_traffic_light_map_based_detector/CHANGELOG.rst
+++ b/perception/autoware_traffic_light_map_based_detector/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_traffic_light_map_based_detector
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/perception/autoware_traffic_light_map_based_detector/package.xml
+++ b/perception/autoware_traffic_light_map_based_detector/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_traffic_light_map_based_detector</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The autoware_traffic_light_map_based_detector package</description>
   <maintainer email="yukihiro.saito@tier4.jp">Yukihiro Saito</maintainer>
   <maintainer email="shunsuke.miura@tier4.jp">Shunsuke Miura</maintainer>

--- a/perception/autoware_traffic_light_multi_camera_fusion/CHANGELOG.rst
+++ b/perception/autoware_traffic_light_multi_camera_fusion/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_traffic_light_multi_camera_fusion
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/perception/autoware_traffic_light_multi_camera_fusion/package.xml
+++ b/perception/autoware_traffic_light_multi_camera_fusion/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_traffic_light_multi_camera_fusion</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The autoware_traffic_light_multi_camera_fusion package</description>
   <maintainer email="tao.zhong@tier4.jp">Tao Zhong</maintainer>
   <maintainer email="shunsuke.miura@tier4.jp">Shunsuke Miura</maintainer>

--- a/perception/autoware_traffic_light_occlusion_predictor/CHANGELOG.rst
+++ b/perception/autoware_traffic_light_occlusion_predictor/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_traffic_light_occlusion_predictor
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/perception/autoware_traffic_light_occlusion_predictor/package.xml
+++ b/perception/autoware_traffic_light_occlusion_predictor/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_traffic_light_occlusion_predictor</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The autoware_traffic_light_occlusion_predictor package</description>
   <maintainer email="tao.zhong@tier4.jp">Tao Zhong</maintainer>
   <maintainer email="shunsuke.miura@tier4.jp">Shunsuke Miura</maintainer>

--- a/perception/autoware_traffic_light_visualization/CHANGELOG.rst
+++ b/perception/autoware_traffic_light_visualization/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_traffic_light_visualization
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/perception/autoware_traffic_light_visualization/package.xml
+++ b/perception/autoware_traffic_light_visualization/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_traffic_light_visualization</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The autoware_traffic_light_visualization package</description>
   <maintainer email="yukihiro.saito@tier4.jp">Yukihiro Saito</maintainer>
   <maintainer email="tao.zhong@tier4.jp">Tao Zhong</maintainer>

--- a/perception/perception_utils/CHANGELOG.rst
+++ b/perception/perception_utils/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package perception_utils
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/perception/perception_utils/package.xml
+++ b/perception/perception_utils/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>perception_utils</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The perception_utils package</description>
   <maintainer email="shunsuke.miura@tier4.jp">Shunsuke Miura</maintainer>
   <maintainer email="yoshi.ri@tier4.jp">Yoshi Ri</maintainer>

--- a/planning/autoware_costmap_generator/CHANGELOG.rst
+++ b/planning/autoware_costmap_generator/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_costmap_generator
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/planning/autoware_costmap_generator/package.xml
+++ b/planning/autoware_costmap_generator/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_costmap_generator</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The autoware_costmap_generator package</description>
   <maintainer email="kosuke.takeuchi@tier4.jp">Kosuke Takeuchi</maintainer>
   <maintainer email="takamasa.horibe@tier4.jp">Takamasa Horibe</maintainer>

--- a/planning/autoware_external_velocity_limit_selector/CHANGELOG.rst
+++ b/planning/autoware_external_velocity_limit_selector/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_external_velocity_limit_selector
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/planning/autoware_external_velocity_limit_selector/package.xml
+++ b/planning/autoware_external_velocity_limit_selector/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_external_velocity_limit_selector</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The autoware_external_velocity_limit_selector ROS 2 package</description>
   <maintainer email="satoshi.ota@tier4.jp">Satoshi Ota</maintainer>
   <maintainer email="shinnosuke.hirakawa@tier4.jp">Shinnosuke Hirakawa</maintainer>

--- a/planning/autoware_freespace_planner/CHANGELOG.rst
+++ b/planning/autoware_freespace_planner/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_freespace_planner
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/planning/autoware_freespace_planner/package.xml
+++ b/planning/autoware_freespace_planner/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_freespace_planner</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The autoware_freespace_planner package</description>
   <maintainer email="kosuke.takeuchi@tier4.jp">Kosuke Takeuchi</maintainer>
   <maintainer email="takamasa.horibe@tier4.jp">Takamasa Horibe</maintainer>

--- a/planning/autoware_freespace_planning_algorithms/CHANGELOG.rst
+++ b/planning/autoware_freespace_planning_algorithms/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_freespace_planning_algorithms
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/planning/autoware_freespace_planning_algorithms/package.xml
+++ b/planning/autoware_freespace_planning_algorithms/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_freespace_planning_algorithms</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The autoware_freespace_planning_algorithms package</description>
   <maintainer email="kosuke.takeuchi@tier4.jp">Kosuke Takeuchi</maintainer>
   <maintainer email="takamasa.horibe@tier4.jp">Takamasa Horibe</maintainer>

--- a/planning/autoware_mission_planner_universe/CHANGELOG.rst
+++ b/planning/autoware_mission_planner_universe/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_mission_planner_universe
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/planning/autoware_mission_planner_universe/package.xml
+++ b/planning/autoware_mission_planner_universe/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_mission_planner_universe</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The autoware_mission_planner_universe package</description>
   <maintainer email="isamu.takagi@tier4.jp">Takagi, Isamu</maintainer>
   <maintainer email="kosuke.takeuchi@tier4.jp">Kosuke Takeuchi</maintainer>

--- a/planning/autoware_objects_of_interest_marker_interface/CHANGELOG.rst
+++ b/planning/autoware_objects_of_interest_marker_interface/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_objects_of_interest_marker_interface
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/planning/autoware_objects_of_interest_marker_interface/package.xml
+++ b/planning/autoware_objects_of_interest_marker_interface/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>autoware_objects_of_interest_marker_interface</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The autoware_objects_of_interest_marker_interface package</description>
 
   <maintainer email="fumiya.watanabe@tier4.jp">Fumiya Watanabe</maintainer>

--- a/planning/autoware_obstacle_cruise_planner/CHANGELOG.rst
+++ b/planning/autoware_obstacle_cruise_planner/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_obstacle_cruise_planner
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/planning/autoware_obstacle_cruise_planner/package.xml
+++ b/planning/autoware_obstacle_cruise_planner/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>autoware_obstacle_cruise_planner</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The autoware_obstacle_cruise_planner package</description>
 
   <maintainer email="takayuki.murooka@tier4.jp">Takayuki Murooka</maintainer>

--- a/planning/autoware_obstacle_stop_planner/CHANGELOG.rst
+++ b/planning/autoware_obstacle_stop_planner/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_obstacle_stop_planner
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/planning/autoware_obstacle_stop_planner/package.xml
+++ b/planning/autoware_obstacle_stop_planner/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_obstacle_stop_planner</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The autoware_obstacle_stop_planner package</description>
 
   <maintainer email="satoshi.ota@tier4.jp">Satoshi Ota</maintainer>

--- a/planning/autoware_path_optimizer/CHANGELOG.rst
+++ b/planning/autoware_path_optimizer/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_path_optimizer
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/planning/autoware_path_optimizer/package.xml
+++ b/planning/autoware_path_optimizer/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_path_optimizer</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The autoware_path_optimizer package</description>
   <maintainer email="takayuki.murooka@tier4.jp">Takayuki Murooka</maintainer>
   <maintainer email="kosuke.takeuchi@tier4.jp">Kosuke Takeuchi</maintainer>

--- a/planning/autoware_path_smoother/CHANGELOG.rst
+++ b/planning/autoware_path_smoother/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_path_smoother
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/planning/autoware_path_smoother/package.xml
+++ b/planning/autoware_path_smoother/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_path_smoother</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The autoware_path_smoother package</description>
   <maintainer email="takayuki.murooka@tier4.jp">Takayuki Murooka</maintainer>
   <maintainer email="maxime.clement@tier4.jp">Maxime CLEMENT</maintainer>

--- a/planning/autoware_planning_factor_interface/CHANGELOG.rst
+++ b/planning/autoware_planning_factor_interface/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_planning_factor_interface
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/planning/autoware_planning_factor_interface/package.xml
+++ b/planning/autoware_planning_factor_interface/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_planning_factor_interface</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The autoware_planning_factor_interface package</description>
   <maintainer email="satoshi.ota@tier4.jp">Satoshi Ota</maintainer>
   <maintainer email="mamoru.sobue@tier4.jp">Mamoru Sobue</maintainer>

--- a/planning/autoware_planning_test_manager/CHANGELOG.rst
+++ b/planning/autoware_planning_test_manager/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_planning_test_manager
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/planning/autoware_planning_test_manager/package.xml
+++ b/planning/autoware_planning_test_manager/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_planning_test_manager</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>ROS 2 node for testing interface of the nodes in planning module</description>
   <maintainer email="kyoichi.sugahara@tier4.jp">Kyoichi Sugahara</maintainer>
   <maintainer email="takamasa.horibe@tier4.jp">Takamasa Horibe</maintainer>

--- a/planning/autoware_planning_topic_converter/CHANGELOG.rst
+++ b/planning/autoware_planning_topic_converter/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_planning_topic_converter
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/planning/autoware_planning_topic_converter/package.xml
+++ b/planning/autoware_planning_topic_converter/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>autoware_planning_topic_converter</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The autoware_planning_topic_converter package</description>
 
   <maintainer email="satoshi.ota@tier4.jp">Satoshi OTA</maintainer>

--- a/planning/autoware_planning_validator/CHANGELOG.rst
+++ b/planning/autoware_planning_validator/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_planning_validator
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/planning/autoware_planning_validator/package.xml
+++ b/planning/autoware_planning_validator/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_planning_validator</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>ros node for autoware_planning_validator</description>
   <maintainer email="takamasa.horibe@tier4.jp">Takamasa Horibe</maintainer>
   <maintainer email="kosuke.takeuchi@tier4.jp">Kosuke Takeuchi</maintainer>

--- a/planning/autoware_remaining_distance_time_calculator/CHANGELOG.rst
+++ b/planning/autoware_remaining_distance_time_calculator/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_remaining_distance_time_calculator
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/planning/autoware_remaining_distance_time_calculator/package.xml
+++ b/planning/autoware_remaining_distance_time_calculator/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>autoware_remaining_distance_time_calculator</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>Calculates and publishes remaining distance and time of the mission.</description>
 
   <maintainer email="ahmed.ebrahim@leodrive.ai">Ahmed Ebrahim</maintainer>

--- a/planning/autoware_route_handler/CHANGELOG.rst
+++ b/planning/autoware_route_handler/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_route_handler
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/planning/autoware_route_handler/package.xml
+++ b/planning/autoware_route_handler/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_route_handler</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The route_handling package</description>
   <maintainer email="fumiya.watanabe@tier4.jp">Fumiya Watanabe</maintainer>
   <maintainer email="zulfaqar.azmi@tier4.jp">Zulfaqar Azmi</maintainer>

--- a/planning/autoware_rtc_interface/CHANGELOG.rst
+++ b/planning/autoware_rtc_interface/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_rtc_interface
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/planning/autoware_rtc_interface/package.xml
+++ b/planning/autoware_rtc_interface/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>autoware_rtc_interface</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The autoware_rtc_interface package</description>
 
   <maintainer email="fumiya.watanabe@tier4.jp">Fumiya Watanabe</maintainer>

--- a/planning/autoware_scenario_selector/CHANGELOG.rst
+++ b/planning/autoware_scenario_selector/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_scenario_selector
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/planning/autoware_scenario_selector/package.xml
+++ b/planning/autoware_scenario_selector/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_scenario_selector</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The autoware_scenario_selector ROS 2 package</description>
   <maintainer email="taiki.tanaka@tier4.jp">Taiki Tanaka</maintainer>
   <maintainer email="tomoya.kimura@tier4.jp">Tomoya Kimura</maintainer>

--- a/planning/autoware_surround_obstacle_checker/CHANGELOG.rst
+++ b/planning/autoware_surround_obstacle_checker/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_surround_obstacle_checker
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/planning/autoware_surround_obstacle_checker/package.xml
+++ b/planning/autoware_surround_obstacle_checker/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_surround_obstacle_checker</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The autoware_surround_obstacle_checker package</description>
   <maintainer email="satoshi.ota@tier4.jp">Satoshi Ota</maintainer>
   <maintainer email="go.sakayori@tier4.jp">Go Sakayori</maintainer>

--- a/planning/autoware_velocity_smoother/CHANGELOG.rst
+++ b/planning/autoware_velocity_smoother/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_velocity_smoother
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/planning/autoware_velocity_smoother/package.xml
+++ b/planning/autoware_velocity_smoother/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_velocity_smoother</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The autoware_velocity_smoother package</description>
 
   <maintainer email="fumiya.watanabe@tier4.jp">Fumiya Watanabe</maintainer>

--- a/planning/behavior_path_planner/autoware_behavior_path_avoidance_by_lane_change_module/CHANGELOG.rst
+++ b/planning/behavior_path_planner/autoware_behavior_path_avoidance_by_lane_change_module/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_behavior_path_avoidance_by_lane_change_module
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/planning/behavior_path_planner/autoware_behavior_path_avoidance_by_lane_change_module/package.xml
+++ b/planning/behavior_path_planner/autoware_behavior_path_avoidance_by_lane_change_module/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_behavior_path_avoidance_by_lane_change_module</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The behavior_path_avoidance_by_lane_change_module package</description>
 
   <maintainer email="satoshi.ota@tier4.jp">Satoshi Ota</maintainer>

--- a/planning/behavior_path_planner/autoware_behavior_path_dynamic_obstacle_avoidance_module/CHANGELOG.rst
+++ b/planning/behavior_path_planner/autoware_behavior_path_dynamic_obstacle_avoidance_module/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_behavior_path_dynamic_obstacle_avoidance_module
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/planning/behavior_path_planner/autoware_behavior_path_dynamic_obstacle_avoidance_module/package.xml
+++ b/planning/behavior_path_planner/autoware_behavior_path_dynamic_obstacle_avoidance_module/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_behavior_path_dynamic_obstacle_avoidance_module</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The autoware_behavior_path_dynamic_obstacle_avoidance_module package</description>
 
   <maintainer email="takayuki.murooka@tier4.jp">Takayuki Murooka</maintainer>

--- a/planning/behavior_path_planner/autoware_behavior_path_external_request_lane_change_module/CHANGELOG.rst
+++ b/planning/behavior_path_planner/autoware_behavior_path_external_request_lane_change_module/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_behavior_path_external_request_lane_change_module
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/planning/behavior_path_planner/autoware_behavior_path_external_request_lane_change_module/package.xml
+++ b/planning/behavior_path_planner/autoware_behavior_path_external_request_lane_change_module/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_behavior_path_external_request_lane_change_module</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The autoware_behavior_path_external_request_lane_change_module package</description>
 
   <maintainer email="fumiya.watanabe@tier4.jp">Fumiya Watanabe</maintainer>

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/CHANGELOG.rst
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_behavior_path_goal_planner_module
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/package.xml
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_behavior_path_goal_planner_module</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The autoware_behavior_path_goal_planner_module package</description>
 
   <maintainer email="kosuke.takeuchi@tier4.jp">Kosuke Takeuchi</maintainer>

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/CHANGELOG.rst
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_behavior_path_lane_change_module
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/package.xml
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_behavior_path_lane_change_module</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The autoware_behavior_path_lane_change_module package</description>
 
   <maintainer email="fumiya.watanabe@tier4.jp">Fumiya Watanabe</maintainer>

--- a/planning/behavior_path_planner/autoware_behavior_path_planner/CHANGELOG.rst
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_behavior_path_planner
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/planning/behavior_path_planner/autoware_behavior_path_planner/package.xml
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_behavior_path_planner</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The behavior_path_planner package</description>
 
   <!-- lane change module -->

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/CHANGELOG.rst
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_behavior_path_planner_common
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/package.xml
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_behavior_path_planner_common</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The autoware_behavior_path_planner_common package</description>
 
   <!-- turn signal decider -->

--- a/planning/behavior_path_planner/autoware_behavior_path_sampling_planner_module/CHANGELOG.rst
+++ b/planning/behavior_path_planner/autoware_behavior_path_sampling_planner_module/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_behavior_path_sampling_planner_module
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/planning/behavior_path_planner/autoware_behavior_path_sampling_planner_module/package.xml
+++ b/planning/behavior_path_planner/autoware_behavior_path_sampling_planner_module/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_behavior_path_sampling_planner_module</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The autoware_behavior_path_sampling_planner_module package</description>
 
   <maintainer email="daniel.sanchez@tier4.jp">Daniel Sanchez</maintainer>

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/CHANGELOG.rst
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_behavior_path_side_shift_module
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/package.xml
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_behavior_path_side_shift_module</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The autoware_behavior_path_side_shift_module package</description>
 
   <maintainer email="satoshi.ota@tier4.jp">Satoshi Ota</maintainer>

--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/CHANGELOG.rst
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_behavior_path_start_planner_module
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/package.xml
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_behavior_path_start_planner_module</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The autoware_behavior_path_start_planner_module package</description>
 
   <maintainer email="kosuke.takeuchi@tier4.jp">Kosuke Takeuchi</maintainer>

--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/CHANGELOG.rst
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_behavior_path_static_obstacle_avoidance_module
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/package.xml
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_behavior_path_static_obstacle_avoidance_module</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The autoware_behavior_path_static_obstacle_avoidance_module package</description>
 
   <maintainer email="takamasa.horibe@tier4.jp">Takamasa Horibe</maintainer>

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/CHANGELOG.rst
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_behavior_velocity_blind_spot_module
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/package.xml
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_behavior_velocity_blind_spot_module</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The autoware_behavior_velocity_blind_spot_module package</description>
 
   <maintainer email="mamoru.sobue@tier4.jp">Mamoru Sobue</maintainer>

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/CHANGELOG.rst
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_behavior_velocity_crosswalk_module
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/package.xml
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_behavior_velocity_crosswalk_module</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The autoware_behavior_velocity_crosswalk_module package</description>
 
   <maintainer email="satoshi.ota@tier4.jp">Satoshi Ota</maintainer>

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_detection_area_module/CHANGELOG.rst
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_detection_area_module/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_behavior_velocity_detection_area_module
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_detection_area_module/package.xml
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_detection_area_module/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_behavior_velocity_detection_area_module</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The autoware_behavior_velocity_detection_area_module package</description>
 
   <maintainer email="kyoichi.sugahara@tier4.jp">Kyoichi Sugahara</maintainer>

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/CHANGELOG.rst
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_behavior_velocity_intersection_module
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/package.xml
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_behavior_velocity_intersection_module</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The autoware_behavior_velocity_intersection_module package</description>
 
   <maintainer email="mamoru.sobue@tier4.jp">Mamoru Sobue</maintainer>

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_no_drivable_lane_module/CHANGELOG.rst
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_no_drivable_lane_module/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_behavior_velocity_no_drivable_lane_module
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_no_drivable_lane_module/package.xml
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_no_drivable_lane_module/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_behavior_velocity_no_drivable_lane_module</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The autoware_behavior_velocity_no_drivable_lane_module package</description>
 
   <maintainer email="ahmed.ebrahim@leodrive.ai">Ahmed Ebrahim</maintainer>

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_no_stopping_area_module/CHANGELOG.rst
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_no_stopping_area_module/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_behavior_velocity_no_stopping_area_module
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_no_stopping_area_module/package.xml
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_no_stopping_area_module/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_behavior_velocity_no_stopping_area_module</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The autoware_behavior_velocity_no_stopping_area_module package</description>
 
   <maintainer email="kosuke.takeuchi@tier4.jp">Kosuke Takeuchi</maintainer>

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_occlusion_spot_module/CHANGELOG.rst
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_occlusion_spot_module/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_behavior_velocity_occlusion_spot_module
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_occlusion_spot_module/package.xml
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_occlusion_spot_module/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_behavior_velocity_occlusion_spot_module</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The autoware_behavior_velocity_occlusion_spot_module package</description>
 
   <maintainer email="taiki.tanaka@tier4.jp">Taiki Tanaka</maintainer>

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/CHANGELOG.rst
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_behavior_velocity_planner
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/package.xml
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_behavior_velocity_planner</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The autoware_behavior_velocity_planner package</description>
 
   <maintainer email="mamoru.sobue@tier4.jp">Mamoru Sobue</maintainer>

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/CHANGELOG.rst
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_behavior_velocity_planner_common
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/package.xml
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_behavior_velocity_planner_common</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The autoware_behavior_velocity_planner_common package</description>
 
   <maintainer email="tomoya.kimura@tier4.jp">Tomoya Kimura</maintainer>

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_rtc_interface/CHANGELOG.rst
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_rtc_interface/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_behavior_velocity_rtc_interface
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_rtc_interface/package.xml
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_rtc_interface/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_behavior_velocity_rtc_interface</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The autoware_behavior_velocity_rtc_interface package</description>
 
   <maintainer email="mamoru.sobue@tier4.jp">Mamoru Sobue</maintainer>

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_run_out_module/CHANGELOG.rst
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_run_out_module/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_behavior_velocity_run_out_module
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_run_out_module/package.xml
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_run_out_module/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_behavior_velocity_run_out_module</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The autoware_behavior_velocity_run_out_module package</description>
 
   <maintainer email="tomohito.ando@tier4.jp">Tomohito Ando</maintainer>

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_speed_bump_module/CHANGELOG.rst
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_speed_bump_module/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_behavior_velocity_speed_bump_module
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_speed_bump_module/package.xml
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_speed_bump_module/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_behavior_velocity_speed_bump_module</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The autoware_behavior_velocity_speed_bump_module package</description>
 
   <maintainer email="tomoya.kimura@tier4.jp">Tomoya Kimura</maintainer>

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_stop_line_module/CHANGELOG.rst
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_stop_line_module/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_behavior_velocity_stop_line_module
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_stop_line_module/package.xml
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_stop_line_module/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_behavior_velocity_stop_line_module</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The autoware_behavior_velocity_stop_line_module package</description>
 
   <maintainer email="yukinari.hisaki.2@tier4.jp">Yukinari Hisaki</maintainer>

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_template_module/CHANGELOG.rst
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_template_module/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_behavior_velocity_template_module
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_template_module/package.xml
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_template_module/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_behavior_velocity_template_module</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The autoware_behavior_velocity_template_module package</description>
 
   <maintainer email="daniel.sanchez@tier4.jp">Daniel Sanchez</maintainer>

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/CHANGELOG.rst
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_behavior_velocity_traffic_light_module
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/package.xml
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_behavior_velocity_traffic_light_module</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The autoware_behavior_velocity_traffic_light_module package</description>
 
   <maintainer email="satoshi.ota@tier4.jp">Satoshi Ota</maintainer>

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_virtual_traffic_light_module/CHANGELOG.rst
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_virtual_traffic_light_module/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_behavior_velocity_virtual_traffic_light_module
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_virtual_traffic_light_module/package.xml
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_virtual_traffic_light_module/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_behavior_velocity_virtual_traffic_light_module</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The autoware_behavior_velocity_virtual_traffic_light_module package</description>
 
   <maintainer email="kosuke.takeuchi@tier4.jp">Kosuke Takeuchi</maintainer>

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_walkway_module/CHANGELOG.rst
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_walkway_module/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_behavior_velocity_walkway_module
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_walkway_module/package.xml
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_walkway_module/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_behavior_velocity_walkway_module</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The autoware_behavior_velocity_walkway_module package</description>
 
   <maintainer email="satoshi.ota@tier4.jp">Satoshi Ota</maintainer>

--- a/planning/motion_velocity_planner/autoware_motion_velocity_dynamic_obstacle_stop_module/CHANGELOG.rst
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_dynamic_obstacle_stop_module/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_motion_velocity_dynamic_obstacle_stop_module
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/planning/motion_velocity_planner/autoware_motion_velocity_dynamic_obstacle_stop_module/package.xml
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_dynamic_obstacle_stop_module/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_motion_velocity_dynamic_obstacle_stop_module</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>dynamic_obstacle_stop module to stop ego when in the immediate path of a dynamic object</description>
 
   <maintainer email="maxime.clement@tier4.jp">Maxime Clement</maintainer>

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_velocity_limiter_module/CHANGELOG.rst
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_velocity_limiter_module/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_motion_velocity_obstacle_velocity_limiter_module
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_velocity_limiter_module/package.xml
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_velocity_limiter_module/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>autoware_motion_velocity_obstacle_velocity_limiter_module</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>Package to adjust velocities of a trajectory in order for the ride to feel safe</description>
 
   <maintainer email="maxime.clement@tier4.jp">Maxime CLEMENT</maintainer>

--- a/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/CHANGELOG.rst
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_motion_velocity_out_of_lane_module
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/package.xml
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_out_of_lane_module/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_motion_velocity_out_of_lane_module</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The motion_velocity_out_of_lane_module package</description>
 
   <maintainer email="maxime.clement@tier4.jp">Maxime Clement</maintainer>

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_common_universe/CHANGELOG.rst
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_common_universe/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_motion_velocity_planner_common_universe
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_common_universe/package.xml
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_common_universe/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_motion_velocity_planner_common_universe</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>Common functions and interfaces for motion_velocity_planner modules</description>
 
   <maintainer email="maxime.clement@tier4.jp">Maxime Clement</maintainer>

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_node_universe/CHANGELOG.rst
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_node_universe/CHANGELOG.rst
@@ -2,6 +2,13 @@
 Changelog for package autoware_motion_velocity_planner_node_universe
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore(motion_velocity_planner_universe): fix build depends (`#10122 <https://github.com/autowarefoundation/autoware.universe/issues/10122>`_) (`#10139 <https://github.com/autowarefoundation/autoware.universe/issues/10139>`_)
+* chore(motion_velocity_planner_universe): fix build depends (`#10122 <https://github.com/autowarefoundation/autoware.universe/issues/10122>`_)
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Mamoru Sobue, Mete Fatih Cırıt, Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_node_universe/package.xml
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_node_universe/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_motion_velocity_planner_node_universe</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>Node of the motion_velocity_planner</description>
 
   <maintainer email="maxime.clement@tier4.jp">Maxime Clement</maintainer>

--- a/planning/sampling_based_planner/autoware_bezier_sampler/CHANGELOG.rst
+++ b/planning/sampling_based_planner/autoware_bezier_sampler/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_bezier_sampler
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/planning/sampling_based_planner/autoware_bezier_sampler/package.xml
+++ b/planning/sampling_based_planner/autoware_bezier_sampler/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>autoware_bezier_sampler</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>Package to sample trajectories using Bézier curves</description>
   <author email="maxime.clement@tier4.jp">Maxime CLEMENT</author>
   <maintainer email="maxime.clement@tier4.jp">Maxime CLEMENT</maintainer>

--- a/planning/sampling_based_planner/autoware_frenet_planner/CHANGELOG.rst
+++ b/planning/sampling_based_planner/autoware_frenet_planner/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_frenet_planner
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/planning/sampling_based_planner/autoware_frenet_planner/package.xml
+++ b/planning/sampling_based_planner/autoware_frenet_planner/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>autoware_frenet_planner</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The autoware_frenet_planner package for trajectory generation in Frenet frame</description>
   <author email="maxime.clement@tier4.jp">Maxime CLEMENT</author>
   <maintainer email="maxime.clement@tier4.jp">Maxime CLEMENT</maintainer>

--- a/planning/sampling_based_planner/autoware_path_sampler/CHANGELOG.rst
+++ b/planning/sampling_based_planner/autoware_path_sampler/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_path_sampler
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/planning/sampling_based_planner/autoware_path_sampler/package.xml
+++ b/planning/sampling_based_planner/autoware_path_sampler/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_path_sampler</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>Package for the sampling-based path planner</description>
   <maintainer email="maxime.clement@tier4.jp">Maxime CLEMENT</maintainer>
   <license>Apache License 2.0</license>

--- a/planning/sampling_based_planner/autoware_sampler_common/CHANGELOG.rst
+++ b/planning/sampling_based_planner/autoware_sampler_common/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_sampler_common
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/planning/sampling_based_planner/autoware_sampler_common/package.xml
+++ b/planning/sampling_based_planner/autoware_sampler_common/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>autoware_sampler_common</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>Common classes and functions for sampling based planners</description>
   <author email="maxime.clement@tier4.jp">Maxime CLEMENT</author>
   <maintainer email="maxime.clement@tier4.jp">Maxime CLEMENT</maintainer>

--- a/sensing/autoware_cuda_utils/CHANGELOG.rst
+++ b/sensing/autoware_cuda_utils/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_cuda_utils
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/sensing/autoware_cuda_utils/package.xml
+++ b/sensing/autoware_cuda_utils/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>autoware_cuda_utils</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>cuda utility library</description>
 
   <author email="daisuke.nishimatsu@tier4.jp">Daisuke Nishimatsu</author>

--- a/sensing/autoware_gnss_poser/CHANGELOG.rst
+++ b/sensing/autoware_gnss_poser/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_gnss_poser
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/sensing/autoware_gnss_poser/package.xml
+++ b/sensing/autoware_gnss_poser/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_gnss_poser</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The ROS 2 autoware_gnss_poser package</description>
   <maintainer email="yamato.ando@tier4.jp">Yamato Ando</maintainer>
   <maintainer email="masahiro.sakamoto@tier4.jp">Masahiro Sakamoto</maintainer>

--- a/sensing/autoware_image_diagnostics/CHANGELOG.rst
+++ b/sensing/autoware_image_diagnostics/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_image_diagnostics
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/sensing/autoware_image_diagnostics/package.xml
+++ b/sensing/autoware_image_diagnostics/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_image_diagnostics</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The autoware_image_diagnostics package</description>
   <maintainer email="dai.nguyen@tier4.jp">Dai Nguyen</maintainer>
   <maintainer email="yoshi.ri@tier4.jp">Yoshi Ri</maintainer>

--- a/sensing/autoware_image_transport_decompressor/CHANGELOG.rst
+++ b/sensing/autoware_image_transport_decompressor/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_image_transport_decompressor
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/sensing/autoware_image_transport_decompressor/package.xml
+++ b/sensing/autoware_image_transport_decompressor/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_image_transport_decompressor</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The image_transport_decompressor package</description>
   <maintainer email="yukihiro.saito@tier4.jp">Yukihiro Saito</maintainer>
   <maintainer email="kenzo.lobos@tier4.jp">Kenzo Lobos-Tsunekawa</maintainer>

--- a/sensing/autoware_imu_corrector/CHANGELOG.rst
+++ b/sensing/autoware_imu_corrector/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_imu_corrector
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/sensing/autoware_imu_corrector/package.xml
+++ b/sensing/autoware_imu_corrector/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_imu_corrector</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The ROS 2 autoware_imu_corrector package</description>
   <maintainer email="yamato.ando@tier4.jp">Yamato Ando</maintainer>
   <maintainer email="taiki.yamada@tier4.jp">Taiki Yamada</maintainer>

--- a/sensing/autoware_pcl_extensions/CHANGELOG.rst
+++ b/sensing/autoware_pcl_extensions/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_pcl_extensions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/sensing/autoware_pcl_extensions/package.xml
+++ b/sensing/autoware_pcl_extensions/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_pcl_extensions</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The autoware_pcl_extensions package</description>
   <maintainer email="ryu.yamamoto@tier4.jp">Ryu Yamamoto</maintainer>
   <maintainer email="kenzo.lobos@tier4.jp">Kenzo Lobos Tsunekawa</maintainer>

--- a/sensing/autoware_pointcloud_preprocessor/CHANGELOG.rst
+++ b/sensing/autoware_pointcloud_preprocessor/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_pointcloud_preprocessor
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/sensing/autoware_pointcloud_preprocessor/package.xml
+++ b/sensing/autoware_pointcloud_preprocessor/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_pointcloud_preprocessor</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The ROS 2 autoware_pointcloud_preprocessor package</description>
   <maintainer email="abrahammonrroy@yahoo.com">amc-nu</maintainer>
   <maintainer email="yukihiro.saito@tier4.jp">Yukihiro Saito</maintainer>

--- a/sensing/autoware_radar_scan_to_pointcloud2/CHANGELOG.rst
+++ b/sensing/autoware_radar_scan_to_pointcloud2/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_radar_scan_to_pointcloud2
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/sensing/autoware_radar_scan_to_pointcloud2/package.xml
+++ b/sensing/autoware_radar_scan_to_pointcloud2/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>autoware_radar_scan_to_pointcloud2</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>autoware_radar_scan_to_pointcloud2</description>
   <maintainer email="satoshi.tanaka@tier4.jp">Satoshi Tanaka</maintainer>
   <maintainer email="shunsuke.miura@tier4.jp">Shunsuke Miura</maintainer>

--- a/sensing/autoware_radar_static_pointcloud_filter/CHANGELOG.rst
+++ b/sensing/autoware_radar_static_pointcloud_filter/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_radar_static_pointcloud_filter
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/sensing/autoware_radar_static_pointcloud_filter/package.xml
+++ b/sensing/autoware_radar_static_pointcloud_filter/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>autoware_radar_static_pointcloud_filter</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>autoware_radar_static_pointcloud_filter</description>
   <maintainer email="satoshi.tanaka@tier4.jp">Satoshi Tanaka</maintainer>
   <maintainer email="shunsuke.miura@tier4.jp">Shunsuke Miura</maintainer>

--- a/sensing/autoware_radar_threshold_filter/CHANGELOG.rst
+++ b/sensing/autoware_radar_threshold_filter/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_radar_threshold_filter
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/sensing/autoware_radar_threshold_filter/package.xml
+++ b/sensing/autoware_radar_threshold_filter/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>autoware_radar_threshold_filter</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>autoware_radar_threshold_filter</description>
   <maintainer email="satoshi.tanaka@tier4.jp">Satoshi Tanaka</maintainer>
   <maintainer email="shunsuke.miura@tier4.jp">Shunsuke Miura</maintainer>

--- a/sensing/autoware_radar_tracks_noise_filter/CHANGELOG.rst
+++ b/sensing/autoware_radar_tracks_noise_filter/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_radar_tracks_noise_filter
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/sensing/autoware_radar_tracks_noise_filter/package.xml
+++ b/sensing/autoware_radar_tracks_noise_filter/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_radar_tracks_noise_filter</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>autoware_radar_tracks_noise_filter</description>
   <maintainer email="satoshi.tanaka@tier4.jp">Sathshi Tanaka</maintainer>
   <maintainer email="shunsuke.miura@tier4.jp">Shunsuke Miura</maintainer>

--- a/sensing/autoware_vehicle_velocity_converter/CHANGELOG.rst
+++ b/sensing/autoware_vehicle_velocity_converter/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_vehicle_velocity_converter
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/sensing/autoware_vehicle_velocity_converter/package.xml
+++ b/sensing/autoware_vehicle_velocity_converter/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_vehicle_velocity_converter</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The autoware_vehicle_velocity_converter package</description>
   <maintainer email="ryu.yamamoto@tier4.jp">Ryu Yamamoto</maintainer>
   <license>Apache License 2.0</license>

--- a/sensing/livox/autoware_livox_tag_filter/CHANGELOG.rst
+++ b/sensing/livox/autoware_livox_tag_filter/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_livox_tag_filter
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/sensing/livox/autoware_livox_tag_filter/package.xml
+++ b/sensing/livox/autoware_livox_tag_filter/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_livox_tag_filter</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The autoware_livox_tag_filter package</description>
   <maintainer email="ryohsuke.mitsudome@tier4.jp">Ryohsuke Mitsudome</maintainer>
   <maintainer email="kenzo.lobos@tier4.jp">Kenzo Lobos-Tsunekawa</maintainer>

--- a/simulator/autoware_carla_interface/CHANGELOG.rst
+++ b/simulator/autoware_carla_interface/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_carla_interface
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/simulator/autoware_carla_interface/package.xml
+++ b/simulator/autoware_carla_interface/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>autoware_carla_interface</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The carla autoware bridge package</description>
   <maintainer email="mradityagio@gmail.com">Muhammad Raditya GIOVANNI</maintainer>
   <maintainer email="maxime.clement@tier4.jp">Maxime CLEMENT</maintainer>

--- a/simulator/autoware_carla_interface/setup.py
+++ b/simulator/autoware_carla_interface/setup.py
@@ -8,7 +8,7 @@ package_name = "autoware_carla_interface"
 
 setup(
     name=package_name,
-    version="0.41.1",
+    version="0.41.2",
     packages=find_packages(where="src"),
     data_files=[
         ("share/ament_index/resource_index/packages", [f"resource/{package_name}"]),

--- a/simulator/autoware_dummy_perception_publisher/CHANGELOG.rst
+++ b/simulator/autoware_dummy_perception_publisher/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_dummy_perception_publisher
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/simulator/autoware_dummy_perception_publisher/package.xml
+++ b/simulator/autoware_dummy_perception_publisher/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_dummy_perception_publisher</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The autoware_dummy_perception_publisher package</description>
   <maintainer email="yukihiro.saito@tier4.jp">Yukihiro Saito</maintainer>
   <maintainer email="junya.sasaki@tier4.jp">Junya Sasaki</maintainer>

--- a/simulator/autoware_fault_injection/CHANGELOG.rst
+++ b/simulator/autoware_fault_injection/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_fault_injection
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/simulator/autoware_fault_injection/package.xml
+++ b/simulator/autoware_fault_injection/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_fault_injection</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The fault_injection package</description>
   <maintainer email="keisuke.shima@tier4.jp">Keisuke Shima</maintainer>
   <maintainer email="junya.sasaki@tier4.jp">Junya Sasaki</maintainer>

--- a/simulator/autoware_learning_based_vehicle_model/CHANGELOG.rst
+++ b/simulator/autoware_learning_based_vehicle_model/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_learning_based_vehicle_model
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/simulator/autoware_learning_based_vehicle_model/package.xml
+++ b/simulator/autoware_learning_based_vehicle_model/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_learning_based_vehicle_model</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>autoware_learning_based_vehicle_model for simple_planning_simulator</description>
   <maintainer email="maxime.clement@tier4.jp">Maxime Clement</maintainer>
   <maintainer email="nagy.tomas@tier4.jp">Tomas Nagy</maintainer>

--- a/simulator/autoware_simple_planning_simulator/CHANGELOG.rst
+++ b/simulator/autoware_simple_planning_simulator/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_simple_planning_simulator
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/simulator/autoware_simple_planning_simulator/package.xml
+++ b/simulator/autoware_simple_planning_simulator/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_simple_planning_simulator</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>simple_planning_simulator as a ROS 2 node</description>
   <maintainer email="takamasa.horibe@tier4.jp">Takamasa Horibe</maintainer>
   <maintainer email="tomoya.kimura@tier4.jp">Tomoya Kimura</maintainer>

--- a/simulator/autoware_vehicle_door_simulator/CHANGELOG.rst
+++ b/simulator/autoware_vehicle_door_simulator/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_vehicle_door_simulator
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/simulator/autoware_vehicle_door_simulator/package.xml
+++ b/simulator/autoware_vehicle_door_simulator/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_vehicle_door_simulator</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The vehicle_door_simulator package</description>
   <maintainer email="isamu.takagi@tier4.jp">Takagi, Isamu</maintainer>
   <maintainer email="junya.sasaki@tier4.jp">Junya Sasaki</maintainer>

--- a/simulator/tier4_dummy_object_rviz_plugin/CHANGELOG.rst
+++ b/simulator/tier4_dummy_object_rviz_plugin/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package tier4_dummy_object_rviz_plugin
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/simulator/tier4_dummy_object_rviz_plugin/package.xml
+++ b/simulator/tier4_dummy_object_rviz_plugin/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>tier4_dummy_object_rviz_plugin</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The tier4_dummy_object_rviz_plugin package</description>
   <maintainer email="yukihiro.saito@tier4.jp">Yukihiro Saito</maintainer>
   <license>Apache License 2.0</license>

--- a/system/autoware_bluetooth_monitor/CHANGELOG.rst
+++ b/system/autoware_bluetooth_monitor/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_bluetooth_monitor
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/system/autoware_bluetooth_monitor/package.xml
+++ b/system/autoware_bluetooth_monitor/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_bluetooth_monitor</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>Bluetooth alive monitoring</description>
   <maintainer email="fumihito.ito@tier4.jp">Fumihito Ito</maintainer>
   <maintainer email="junya.sasaki@tier4.jp">Junya Sasaki</maintainer>

--- a/system/autoware_component_monitor/CHANGELOG.rst
+++ b/system/autoware_component_monitor/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_component_monitor
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/system/autoware_component_monitor/package.xml
+++ b/system/autoware_component_monitor/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_component_monitor</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>A ROS 2 package to monitor system usage of component containers.</description>
   <maintainer email="memin@leodrive.ai">Mehmet Emin Başoğlu</maintainer>
   <maintainer email="baris@leodrive.ai">Barış Zeren</maintainer>

--- a/system/autoware_component_state_monitor/CHANGELOG.rst
+++ b/system/autoware_component_state_monitor/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_component_state_monitor
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/system/autoware_component_state_monitor/package.xml
+++ b/system/autoware_component_state_monitor/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_component_state_monitor</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The autoware_component_state_monitor package</description>
   <maintainer email="isamu.takagi@tier4.jp">Takagi, Isamu</maintainer>
   <maintainer email="junya.sasaki@tier4.jp">Junya Sasaki</maintainer>

--- a/system/autoware_default_adapi/CHANGELOG.rst
+++ b/system/autoware_default_adapi/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_default_adapi
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/system/autoware_default_adapi/package.xml
+++ b/system/autoware_default_adapi/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_default_adapi</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The autoware_default_adapi package</description>
   <maintainer email="isamu.takagi@tier4.jp">Takagi, Isamu</maintainer>
   <maintainer email="ryohsuke.mitsudome@tier4.jp">Ryohsuke Mitsudome</maintainer>

--- a/system/autoware_default_adapi_helpers/autoware_adapi_adaptors/CHANGELOG.rst
+++ b/system/autoware_default_adapi_helpers/autoware_adapi_adaptors/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_ad_api_adaptors
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/system/autoware_default_adapi_helpers/autoware_adapi_adaptors/package.xml
+++ b/system/autoware_default_adapi_helpers/autoware_adapi_adaptors/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_adapi_adaptors</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The adapi_adaptors package</description>
   <maintainer email="isamu.takagi@tier4.jp">Takagi, Isamu</maintainer>
   <maintainer email="ryohsuke.mitsudome@tier4.jp">Ryohsuke Mitsudome</maintainer>

--- a/system/autoware_default_adapi_helpers/autoware_adapi_visualizers/CHANGELOG.rst
+++ b/system/autoware_default_adapi_helpers/autoware_adapi_visualizers/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_ad_api_visualizers
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/system/autoware_default_adapi_helpers/autoware_adapi_visualizers/package.xml
+++ b/system/autoware_default_adapi_helpers/autoware_adapi_visualizers/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_adapi_visualizers</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The adapi_visualizers package</description>
   <maintainer email="isamu.takagi@tier4.jp">Takagi, Isamu</maintainer>
   <maintainer email="ryohsuke.mitsudome@tier4.jp">Ryohsuke Mitsudome</maintainer>

--- a/system/autoware_default_adapi_helpers/autoware_adapi_visualizers/setup.py
+++ b/system/autoware_default_adapi_helpers/autoware_adapi_visualizers/setup.py
@@ -11,7 +11,7 @@ package_name = "autoware_adapi_visualizers"
 
 setup(
     name=package_name,
-    version="0.41.1",
+    version="0.41.2",
     packages=[package_name],
     data_files=[
         ("share/ament_index/resource_index/packages", [f"resource/{package_name}"]),

--- a/system/autoware_default_adapi_helpers/autoware_automatic_pose_initializer/CHANGELOG.rst
+++ b/system/autoware_default_adapi_helpers/autoware_automatic_pose_initializer/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_automatic_pose_initializer
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/system/autoware_default_adapi_helpers/autoware_automatic_pose_initializer/package.xml
+++ b/system/autoware_default_adapi_helpers/autoware_automatic_pose_initializer/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_automatic_pose_initializer</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The automatic_pose_initializer package</description>
   <maintainer email="isamu.takagi@tier4.jp">Takagi, Isamu</maintainer>
   <maintainer email="ryohsuke.mitsudome@tier4.jp">Ryohsuke Mitsudome</maintainer>

--- a/system/autoware_diagnostic_graph_aggregator/CHANGELOG.rst
+++ b/system/autoware_diagnostic_graph_aggregator/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_diagnostic_graph_aggregator
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/system/autoware_diagnostic_graph_aggregator/package.xml
+++ b/system/autoware_diagnostic_graph_aggregator/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_diagnostic_graph_aggregator</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The diagnostic_graph_aggregator package</description>
   <maintainer email="isamu.takagi@tier4.jp">Takagi, Isamu</maintainer>
   <maintainer email="junya.sasaki@tier4.jp">Junya Sasaki</maintainer>

--- a/system/autoware_diagnostic_graph_utils/CHANGELOG.rst
+++ b/system/autoware_diagnostic_graph_utils/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_diagnostic_graph_utils
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/system/autoware_diagnostic_graph_utils/package.xml
+++ b/system/autoware_diagnostic_graph_utils/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_diagnostic_graph_utils</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The autoware_diagnostic_graph_utils package</description>
   <maintainer email="isamu.takagi@tier4.jp">Takagi, Isamu</maintainer>
   <maintainer email="junya.sasaki@tier4.jp">Junya Sasaki</maintainer>

--- a/system/autoware_dummy_diag_publisher/CHANGELOG.rst
+++ b/system/autoware_dummy_diag_publisher/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_dummy_diag_publisher
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/system/autoware_dummy_diag_publisher/package.xml
+++ b/system/autoware_dummy_diag_publisher/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_dummy_diag_publisher</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The dummy_diag_publisher ROS 2 package</description>
   <maintainer email="fumihito.ito@tier4.jp">Fumihito Ito</maintainer>
   <maintainer email="tetsuhiro.kawaguchi@tier4.jp">TetsuKawa</maintainer>

--- a/system/autoware_dummy_infrastructure/CHANGELOG.rst
+++ b/system/autoware_dummy_infrastructure/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_dummy_infrastructure
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/system/autoware_dummy_infrastructure/package.xml
+++ b/system/autoware_dummy_infrastructure/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_dummy_infrastructure</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>autoware_dummy_infrastructure</description>
   <maintainer email="ryohsuke.mitsudome@tier4.jp">Ryohsuke Mitsudome</maintainer>
   <maintainer email="junya.sasaki@tier4.jp">Junya Sasaki</maintainer>

--- a/system/autoware_duplicated_node_checker/CHANGELOG.rst
+++ b/system/autoware_duplicated_node_checker/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_duplicated_node_checker
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/system/autoware_duplicated_node_checker/package.xml
+++ b/system/autoware_duplicated_node_checker/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_duplicated_node_checker</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>A package to find out nodes with common names</description>
   <maintainer email="shumpei.wakabayashi@tier4.jp">Shumpei Wakabayashi</maintainer>
   <maintainer email="uken.ryu@tier4.jp">yliuhb</maintainer>

--- a/system/autoware_hazard_status_converter/CHANGELOG.rst
+++ b/system/autoware_hazard_status_converter/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_hazard_status_converter
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/system/autoware_hazard_status_converter/package.xml
+++ b/system/autoware_hazard_status_converter/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_hazard_status_converter</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The autoware_hazard_status_converter package</description>
   <maintainer email="isamu.takagi@tier4.jp">Takagi, Isamu</maintainer>
   <maintainer email="junya.sasaki@tier4.jp">Junya Sasaki</maintainer>

--- a/system/autoware_mrm_comfortable_stop_operator/CHANGELOG.rst
+++ b/system/autoware_mrm_comfortable_stop_operator/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_mrm_comfortable_stop_operator
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/system/autoware_mrm_comfortable_stop_operator/package.xml
+++ b/system/autoware_mrm_comfortable_stop_operator/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_mrm_comfortable_stop_operator</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The MRM comfortable stop operator package</description>
   <maintainer email="makoto.kurihara@tier4.jp">Makoto Kurihara</maintainer>
   <maintainer email="tomohito.ando@tier4.jp">Tomohito Ando</maintainer>

--- a/system/autoware_mrm_emergency_stop_operator/CHANGELOG.rst
+++ b/system/autoware_mrm_emergency_stop_operator/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_mrm_emergency_stop_operator
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/system/autoware_mrm_emergency_stop_operator/package.xml
+++ b/system/autoware_mrm_emergency_stop_operator/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_mrm_emergency_stop_operator</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The MRM emergency stop operator package</description>
   <maintainer email="makoto.kurihara@tier4.jp">Makoto Kurihara</maintainer>
   <maintainer email="tomohito.ando@tier4.jp">Tomohito Ando</maintainer>

--- a/system/autoware_mrm_handler/CHANGELOG.rst
+++ b/system/autoware_mrm_handler/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_mrm_handler
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/system/autoware_mrm_handler/package.xml
+++ b/system/autoware_mrm_handler/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_mrm_handler</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The mrm_handler ROS 2 package</description>
   <maintainer email="makoto.kurihara@tier4.jp">Makoto Kurihara</maintainer>
   <maintainer email="ryuta.kambe@tier4.jp">Ryuta Kambe</maintainer>

--- a/system/autoware_processing_time_checker/CHANGELOG.rst
+++ b/system/autoware_processing_time_checker/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_processing_time_checker
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/system/autoware_processing_time_checker/package.xml
+++ b/system/autoware_processing_time_checker/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_processing_time_checker</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>A package to find out nodes with common names</description>
   <maintainer email="takayuki.murooka@tier4.jp">Takayuki Murooka</maintainer>
   <maintainer email="kosuke.takeuchi@tier4.jp">Kosuke Takeuchi</maintainer>

--- a/system/autoware_system_diagnostic_monitor/CHANGELOG.rst
+++ b/system/autoware_system_diagnostic_monitor/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_system_diagnostic_monitor
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/system/autoware_system_diagnostic_monitor/package.xml
+++ b/system/autoware_system_diagnostic_monitor/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_system_diagnostic_monitor</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The autoware_system_diagnostic_monitor package</description>
   <maintainer email="isamu.takagi@tier4.jp">Takagi, Isamu</maintainer>
   <maintainer email="junya.sasaki@tier4.jp">Junya Sasaki</maintainer>

--- a/system/autoware_system_monitor/CHANGELOG.rst
+++ b/system/autoware_system_monitor/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_system_monitor
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/system/autoware_system_monitor/package.xml
+++ b/system/autoware_system_monitor/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_system_monitor</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The system_monitor package</description>
   <maintainer email="fumihito.ito@tier4.jp">Fumihito Ito</maintainer>
   <maintainer email="tetsuhiro.kawaguchi@tier4.jp">TetsuKawa</maintainer>

--- a/system/autoware_topic_relay_controller/CHANGELOG.rst
+++ b/system/autoware_topic_relay_controller/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_topic_relay_controller
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/system/autoware_topic_relay_controller/package.xml
+++ b/system/autoware_topic_relay_controller/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_topic_relay_controller</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The topic_relay_controller ROS 2 package</description>
   <maintainer email="makoto.kurihara@tier4.jp">Makoto Kurihara</maintainer>
   <maintainer email="tetsuhiro.kawaguchi@tier4.jp">Tetsuhiro Kawaguchi</maintainer>

--- a/system/autoware_topic_state_monitor/CHANGELOG.rst
+++ b/system/autoware_topic_state_monitor/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_topic_state_monitor
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/system/autoware_topic_state_monitor/package.xml
+++ b/system/autoware_topic_state_monitor/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_topic_state_monitor</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The autoware_topic_state_monitor package</description>
   <maintainer email="ryohsuke.mitsudome@tier4.jp">Ryohsuke Mitsudome</maintainer>
   <maintainer email="junya.sasaki@tier4.jp">Junya Sasaki</maintainer>

--- a/system/autoware_velodyne_monitor/CHANGELOG.rst
+++ b/system/autoware_velodyne_monitor/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_velodyne_monitor
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/system/autoware_velodyne_monitor/package.xml
+++ b/system/autoware_velodyne_monitor/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_velodyne_monitor</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The autoware_velodyne_monitor package</description>
   <maintainer email="fumihito.ito@tier4.jp">Fumihito Ito</maintainer>
   <maintainer email="junya.sasaki@tier4.jp">Junya Sasaki</maintainer>

--- a/tools/reaction_analyzer/CHANGELOG.rst
+++ b/tools/reaction_analyzer/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package reaction_analyzer
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/tools/reaction_analyzer/package.xml
+++ b/tools/reaction_analyzer/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>reaction_analyzer</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>Analyzer that measures reaction times of the nodes</description>
 
   <maintainer email="berkay@leodrive.ai">Berkay Karaman</maintainer>

--- a/vehicle/autoware_accel_brake_map_calibrator/CHANGELOG.rst
+++ b/vehicle/autoware_accel_brake_map_calibrator/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_accel_brake_map_calibrator
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/vehicle/autoware_accel_brake_map_calibrator/package.xml
+++ b/vehicle/autoware_accel_brake_map_calibrator/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_accel_brake_map_calibrator</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The accel_brake_map_calibrator</description>
   <maintainer email="tomoya.kimura@tier4.jp">Tomoya Kimura</maintainer>
   <maintainer email="taiki.tanaka@tier4.jp">Taiki Tanaka</maintainer>

--- a/vehicle/autoware_external_cmd_converter/CHANGELOG.rst
+++ b/vehicle/autoware_external_cmd_converter/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_external_cmd_converter
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/vehicle/autoware_external_cmd_converter/package.xml
+++ b/vehicle/autoware_external_cmd_converter/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_external_cmd_converter</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The autoware_external_cmd_converter package</description>
   <maintainer email="takamasa.horibe@tier4.jp">Takamasa Horibe</maintainer>
   <maintainer email="eiki.nagata.2@tier4.jp">Eiki Nagata</maintainer>

--- a/vehicle/autoware_raw_vehicle_cmd_converter/CHANGELOG.rst
+++ b/vehicle/autoware_raw_vehicle_cmd_converter/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_raw_vehicle_cmd_converter
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/vehicle/autoware_raw_vehicle_cmd_converter/package.xml
+++ b/vehicle/autoware_raw_vehicle_cmd_converter/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_raw_vehicle_cmd_converter</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The autoware_raw_vehicle_cmd_converter package</description>
   <maintainer email="takamasa.horibe@tier4.jp">Takamasa Horibe</maintainer>
   <maintainer email="taiki.tanaka@tier4.jp">Tanaka Taiki</maintainer>

--- a/vehicle/autoware_steer_offset_estimator/CHANGELOG.rst
+++ b/vehicle/autoware_steer_offset_estimator/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_steer_offset_estimator
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/vehicle/autoware_steer_offset_estimator/package.xml
+++ b/vehicle/autoware_steer_offset_estimator/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>autoware_steer_offset_estimator</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The steer_offset_estimator</description>
   <maintainer email="taiki.tanaka@tier4.jp">Taiki Tanaka</maintainer>
   <license>Apache License 2.0</license>

--- a/visualization/autoware_bag_time_manager_rviz_plugin/CHANGELOG.rst
+++ b/visualization/autoware_bag_time_manager_rviz_plugin/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_bag_time_manager_rviz_plugin
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/visualization/autoware_bag_time_manager_rviz_plugin/package.xml
+++ b/visualization/autoware_bag_time_manager_rviz_plugin/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_bag_time_manager_rviz_plugin</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>Rviz plugin to publish and control the ros bag</description>
   <maintainer email="taiki.tanaka@tier4.jp">Taiki Tanaka</maintainer>
   <maintainer email="junya.sasaki@tier4.jp">Junya Sasaki</maintainer>

--- a/visualization/autoware_overlay_rviz_plugin/autoware_mission_details_overlay_rviz_plugin/CHANGELOG.rst
+++ b/visualization/autoware_overlay_rviz_plugin/autoware_mission_details_overlay_rviz_plugin/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_mission_details_overlay_rviz_plugin
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/visualization/autoware_overlay_rviz_plugin/autoware_mission_details_overlay_rviz_plugin/package.xml
+++ b/visualization/autoware_overlay_rviz_plugin/autoware_mission_details_overlay_rviz_plugin/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_mission_details_overlay_rviz_plugin</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>
     RViz2 plugin for 2D overlays for mission details in the 3D view. Mainly a port of the JSK overlay plugin
         (https://github.com/jsk-ros-pkg/jsk_visualization).

--- a/visualization/autoware_overlay_rviz_plugin/autoware_overlay_rviz_plugin/CHANGELOG.rst
+++ b/visualization/autoware_overlay_rviz_plugin/autoware_overlay_rviz_plugin/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_overlay_rviz_plugin
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/visualization/autoware_overlay_rviz_plugin/autoware_overlay_rviz_plugin/package.xml
+++ b/visualization/autoware_overlay_rviz_plugin/autoware_overlay_rviz_plugin/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_overlay_rviz_plugin</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>
     RViz2 plugin for 2D overlays in the 3D view. Mainly a port of the JSK overlay plugin
         (https://github.com/jsk-ros-pkg/jsk_visualization).

--- a/visualization/autoware_overlay_rviz_plugin/autoware_string_stamped_overlay_rviz_plugin/CHANGELOG.rst
+++ b/visualization/autoware_overlay_rviz_plugin/autoware_string_stamped_overlay_rviz_plugin/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_string_stamped_rviz_plugin
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/visualization/autoware_overlay_rviz_plugin/autoware_string_stamped_overlay_rviz_plugin/package.xml
+++ b/visualization/autoware_overlay_rviz_plugin/autoware_string_stamped_overlay_rviz_plugin/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_string_stamped_rviz_plugin</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>
     RViz2 plugin for 2D overlays in the 3D view. Mainly a port of the JSK overlay plugin
         (https://github.com/jsk-ros-pkg/jsk_visualization).

--- a/visualization/autoware_perception_rviz_plugin/CHANGELOG.rst
+++ b/visualization/autoware_perception_rviz_plugin/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package autoware_perception_rviz_plugin
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/visualization/autoware_perception_rviz_plugin/package.xml
+++ b/visualization/autoware_perception_rviz_plugin/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_perception_rviz_plugin</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>Contains plugins to visualize object detection outputs</description>
   <maintainer email="opensource@apex.ai">Apex.AI, Inc.</maintainer>
   <maintainer email="taiki.tanaka@tier4.jp">Taiki Tanaka</maintainer>

--- a/visualization/tier4_adapi_rviz_plugin/CHANGELOG.rst
+++ b/visualization/tier4_adapi_rviz_plugin/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package tier4_adapi_rviz_plugin
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/visualization/tier4_adapi_rviz_plugin/package.xml
+++ b/visualization/tier4_adapi_rviz_plugin/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>tier4_adapi_rviz_plugin</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The autoware adapi rviz plugin package</description>
   <maintainer email="isamu.takagi@tier4.jp">Takagi, Isamu</maintainer>
   <maintainer email="hiroki.ota@tier4.jp">Hiroki OTA</maintainer>

--- a/visualization/tier4_camera_view_rviz_plugin/CHANGELOG.rst
+++ b/visualization/tier4_camera_view_rviz_plugin/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package tier4_camera_view_rviz_plugin
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/visualization/tier4_camera_view_rviz_plugin/package.xml
+++ b/visualization/tier4_camera_view_rviz_plugin/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>tier4_camera_view_rviz_plugin</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The autoware camera view rviz plugin package</description>
   <maintainer email="uken.ryu@tier4.jp">Yuxuan Liu</maintainer>
   <maintainer email="makoto.ybauta@tier4.jp">Makoto Yabuta</maintainer>

--- a/visualization/tier4_datetime_rviz_plugin/CHANGELOG.rst
+++ b/visualization/tier4_datetime_rviz_plugin/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package tier4_datetime_rviz_plugin
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/visualization/tier4_datetime_rviz_plugin/package.xml
+++ b/visualization/tier4_datetime_rviz_plugin/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>tier4_datetime_rviz_plugin</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The tier4_datetime_rviz_plugin package</description>
   <maintainer email="isamu.takagi@tier4.jp">Takagi, Isamu</maintainer>
   <license>Apache License 2.0</license>

--- a/visualization/tier4_localization_rviz_plugin/CHANGELOG.rst
+++ b/visualization/tier4_localization_rviz_plugin/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package tier4_localization_rviz_plugin
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/visualization/tier4_localization_rviz_plugin/package.xml
+++ b/visualization/tier4_localization_rviz_plugin/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>tier4_localization_rviz_plugin</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The tier4_localization_rviz_plugin package</description>
   <maintainer email="isamu.takagi@tier4.jp">Takagi, Isamu</maintainer>
   <maintainer email="takamasa.horibe@tier4.jp">Takamasa Horibe</maintainer>

--- a/visualization/tier4_planning_factor_rviz_plugin/CHANGELOG.rst
+++ b/visualization/tier4_planning_factor_rviz_plugin/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package tier4_planning_factor_rviz_plugin
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/visualization/tier4_planning_factor_rviz_plugin/package.xml
+++ b/visualization/tier4_planning_factor_rviz_plugin/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>tier4_planning_factor_rviz_plugin</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The tier4_planning_factor_rviz_plugin package</description>
   <maintainer email="satoshi.ota@tier4.jp">Satoshi Ota</maintainer>
   <maintainer email="mamoru.sobue@tier4.jp">Mamoru Sobue</maintainer>

--- a/visualization/tier4_planning_rviz_plugin/CHANGELOG.rst
+++ b/visualization/tier4_planning_rviz_plugin/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package tier4_planning_rviz_plugin
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/visualization/tier4_planning_rviz_plugin/package.xml
+++ b/visualization/tier4_planning_rviz_plugin/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>tier4_planning_rviz_plugin</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The tier4_planning_rviz_plugin package</description>
   <maintainer email="yukihiro.saito@tier4.jp">Yukihiro Saito</maintainer>
   <maintainer email="takayuki.murooka@tier4.jp">Takayuki Murooka</maintainer>

--- a/visualization/tier4_state_rviz_plugin/CHANGELOG.rst
+++ b/visualization/tier4_state_rviz_plugin/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package tier4_state_rviz_plugin
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/visualization/tier4_state_rviz_plugin/package.xml
+++ b/visualization/tier4_state_rviz_plugin/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>tier4_state_rviz_plugin</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The autoware state rviz plugin package</description>
   <maintainer email="hiroki.ota@tier4.jp">Hiroki OTA</maintainer>
   <maintainer email="isamu.takagi@tier4.jp">Takagi, Isamu</maintainer>

--- a/visualization/tier4_system_rviz_plugin/CHANGELOG.rst
+++ b/visualization/tier4_system_rviz_plugin/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package tier4_system_rviz_plugin
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/visualization/tier4_system_rviz_plugin/package.xml
+++ b/visualization/tier4_system_rviz_plugin/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>tier4_system_rviz_plugin</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The tier4_vehicle_rviz_plugin package</description>
   <maintainer email="koji.minoda@tier4.jp">Koji Minoda</maintainer>
   <license>Apache License 2.0</license>

--- a/visualization/tier4_traffic_light_rviz_plugin/CHANGELOG.rst
+++ b/visualization/tier4_traffic_light_rviz_plugin/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package tier4_traffic_light_rviz_plugin
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/visualization/tier4_traffic_light_rviz_plugin/package.xml
+++ b/visualization/tier4_traffic_light_rviz_plugin/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>tier4_traffic_light_rviz_plugin</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The autoware state rviz plugin package</description>
   <maintainer email="satoshi.ota@tier4.jp">Satoshi OTA</maintainer>
   <license>Apache License 2.0</license>

--- a/visualization/tier4_vehicle_rviz_plugin/CHANGELOG.rst
+++ b/visualization/tier4_vehicle_rviz_plugin/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package tier4_vehicle_rviz_plugin
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.41.2 (2025-02-19)
+-------------------
+* chore: bump version to 0.41.1 (`#10088 <https://github.com/autowarefoundation/autoware.universe/issues/10088>`_)
+* Contributors: Ryohsuke Mitsudome
+
 0.41.1 (2025-02-10)
 -------------------
 

--- a/visualization/tier4_vehicle_rviz_plugin/package.xml
+++ b/visualization/tier4_vehicle_rviz_plugin/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>tier4_vehicle_rviz_plugin</name>
-  <version>0.41.1</version>
+  <version>0.41.2</version>
   <description>The tier4_vehicle_rviz_plugin package</description>
   <maintainer email="yukihiro.saito@tier4.jp">Yukihiro Saito</maintainer>
   <license>Apache License 2.0</license>


### PR DESCRIPTION
## Description

We've fixed the build bug and build-depends ci. Now bumping the patch version.

## Related links

**Parent Issue:**

- https://github.com/autowarefoundation/autoware/issues/5792

## How was this PR tested?

## Notes for reviewers

This PR was generated with:
```
# create a new branch at humble
catkin_generate_changelog
# commit the changes with a dummy name
catkin_prepare_release --bump patch --no-push
# then squash last 2 commits, push, create the PR against humble
```

## Interface changes

None.

## Effects on system behavior

None.
