### PR TITLE
feat(mission_planner): tolerate goal footprint being inside the previous lanelets of closest lanelet

### DIFF
--- a/planning/autoware_mission_planner_universe/src/lanelet2_plugins/default_planner.cpp
+++ b/planning/autoware_mission_planner_universe/src/lanelet2_plugins/default_planner.cpp
@@ -207,6 +207,13 @@ bool DefaultPlanner::check_goal_footprint_inside_lanes(
     boost::geometry::correct(poly);
     ego_lanes.push_back(poly);
   }
+  // If the goal is on the very beginning of the closest_lanelet_to_goal, baselink ~ rear part of
+  // ego footprint is outside of it. To tolerate it, add previous lanelet
+  for (const auto & ll : route_handler_.getPreviousLanelets(closest_lanelet_to_goal)) {
+    boost::geometry::convert(ll.polygon2d().basicPolygon(), poly);
+    boost::geometry::correct(poly);
+    ego_lanes.push_back(poly);
+  }
 
   // check if goal footprint is in the ego lane
   universe_utils::MultiPolygon2d difference;


### PR DESCRIPTION
## Description

In addition to this PR https://github.com/autowarefoundation/autoware.universe/pull/8760, if the goal is just on the very beginning of a lanelet, ego's goal footprint becomes outside of the ego_lanes. To avoid this, I added previous lanelet of closest_goal_lanelet as well.

![image](https://github.com/user-attachments/assets/d91a0bf5-5080-478a-882f-df71583a8361)

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

- https://evaluation.tier4.jp/evaluation/reports/7f55984f-52be-5218-bd44-c119159844aa?project_id=prd_jt

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
