### PR TITLE
fix(autoware_motion_velocity_planner_common_universe): check optional before accessing

### DIFF
--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_common_universe/src/polygon_utils.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_common_universe/src/polygon_utils.cpp
@@ -150,6 +150,7 @@ std::optional<std::pair<geometry_msgs::msg::Point, double>> get_collision_point(
       max_collision_point = poly_vertex.point;
     }
   }
+  if (!max_collision_point) return std::nullopt;
   return std::make_pair(
     *max_collision_point,
     autoware::motion_utils::calcSignedArcLength(traj_points, 0, collision_info.first) -


### PR DESCRIPTION
## Description

Before accessing, it checks for the existence of optional and returns nullopt if it does not exist.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
