### PR TITLE
feat(autoware_velocity_smoother): porting from universe to core

### DIFF
--- a/planning/autoware_external_velocity_limit_selector/README.md
+++ b/planning/autoware_external_velocity_limit_selector/README.md
@@ -39,15 +39,15 @@ Example:
 
 | Name                                                | Type                                           | Description                                   |
 | --------------------------------------------------- | ---------------------------------------------- | --------------------------------------------- |
-| `~input/velocity_limit_from_api`                    | tier4_planning_msgs::VelocityLimit             | velocity limit from api                       |
-| `~input/velocity_limit_from_internal`               | tier4_planning_msgs::VelocityLimit             | velocity limit from autoware internal modules |
-| `~input/velocity_limit_clear_command_from_internal` | tier4_planning_msgs::VelocityLimitClearCommand | velocity limit clear command                  |
+| `~input/velocity_limit_from_api`                    | autoware_internal_planning_msgs::VelocityLimit             | velocity limit from api                       |
+| `~input/velocity_limit_from_internal`               | autoware_internal_planning_msgs::VelocityLimit             | velocity limit from autoware internal modules |
+| `~input/velocity_limit_clear_command_from_internal` | autoware_internal_planning_msgs::VelocityLimitClearCommand | velocity limit clear command                  |
 
 ## Outputs
 
 | Name                   | Type                               | Description                                       |
 | ---------------------- | ---------------------------------- | ------------------------------------------------- |
-| `~output/max_velocity` | tier4_planning_msgs::VelocityLimit | current information of the hardest velocity limit |
+| `~output/max_velocity` | autoware_internal_planning_msgs::VelocityLimit | current information of the hardest velocity limit |
 
 ## Parameters
 

--- a/planning/autoware_external_velocity_limit_selector/README.md
+++ b/planning/autoware_external_velocity_limit_selector/README.md
@@ -37,16 +37,16 @@ Example:
 
 ## Inputs
 
-| Name                                                | Type                                           | Description                                   |
-| --------------------------------------------------- | ---------------------------------------------- | --------------------------------------------- |
+| Name                                                | Type                                                       | Description                                   |
+| --------------------------------------------------- | ---------------------------------------------------------- | --------------------------------------------- |
 | `~input/velocity_limit_from_api`                    | autoware_internal_planning_msgs::VelocityLimit             | velocity limit from api                       |
 | `~input/velocity_limit_from_internal`               | autoware_internal_planning_msgs::VelocityLimit             | velocity limit from autoware internal modules |
 | `~input/velocity_limit_clear_command_from_internal` | autoware_internal_planning_msgs::VelocityLimitClearCommand | velocity limit clear command                  |
 
 ## Outputs
 
-| Name                   | Type                               | Description                                       |
-| ---------------------- | ---------------------------------- | ------------------------------------------------- |
+| Name                   | Type                                           | Description                                       |
+| ---------------------- | ---------------------------------------------- | ------------------------------------------------- |
 | `~output/max_velocity` | autoware_internal_planning_msgs::VelocityLimit | current information of the hardest velocity limit |
 
 ## Parameters

--- a/planning/autoware_external_velocity_limit_selector/include/autoware/external_velocity_limit_selector/external_velocity_limit_selector_node.hpp
+++ b/planning/autoware_external_velocity_limit_selector/include/autoware/external_velocity_limit_selector/external_velocity_limit_selector_node.hpp
@@ -19,8 +19,8 @@
 #include <rclcpp/rclcpp.hpp>
 
 #include <autoware_internal_debug_msgs/msg/string_stamped.hpp>
-#include <tier4_planning_msgs/msg/velocity_limit.hpp>
-#include <tier4_planning_msgs/msg/velocity_limit_clear_command.hpp>
+#include <autoware_internal_planning_msgs/msg/velocity_limit.hpp>
+#include <autoware_internal_planning_msgs/msg/velocity_limit_clear_command.hpp>
 
 #include <memory>
 #include <string>
@@ -30,9 +30,9 @@ namespace autoware::external_velocity_limit_selector
 {
 
 using autoware_internal_debug_msgs::msg::StringStamped;
-using tier4_planning_msgs::msg::VelocityLimit;
-using tier4_planning_msgs::msg::VelocityLimitClearCommand;
-using tier4_planning_msgs::msg::VelocityLimitConstraints;
+using autoware_internal_planning_msgs::msg::VelocityLimit;
+using autoware_internal_planning_msgs::msg::VelocityLimitClearCommand;
+using autoware_internal_planning_msgs::msg::VelocityLimitConstraints;
 
 using VelocityLimitTable = std::unordered_map<std::string, VelocityLimit>;
 

--- a/planning/autoware_external_velocity_limit_selector/package.xml
+++ b/planning/autoware_external_velocity_limit_selector/package.xml
@@ -18,10 +18,10 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_internal_debug_msgs</depend>
+  <depend>autoware_internal_planning_msgs</depend>
   <depend>generate_parameter_library</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
-  <depend>autoware_internal_planning_msgs</depend>
 
   <exec_depend>ros2cli</exec_depend>
   <exec_depend>topic_tools</exec_depend>

--- a/planning/autoware_external_velocity_limit_selector/package.xml
+++ b/planning/autoware_external_velocity_limit_selector/package.xml
@@ -21,7 +21,7 @@
   <depend>generate_parameter_library</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
-  <depend>tier4_planning_msgs</depend>
+  <depend>autoware_internal_planning_msgs</depend>
 
   <exec_depend>ros2cli</exec_depend>
   <exec_depend>topic_tools</exec_depend>

--- a/planning/autoware_external_velocity_limit_selector/test/test_external_velocity_limit_selector_node_launch.py
+++ b/planning/autoware_external_velocity_limit_selector/test/test_external_velocity_limit_selector_node_launch.py
@@ -18,6 +18,8 @@ import os
 import unittest
 
 from ament_index_python import get_package_share_directory
+from autoware_internal_planning_msgs.msg import VelocityLimit
+from autoware_internal_planning_msgs.msg import VelocityLimitClearCommand
 import launch
 from launch.actions import IncludeLaunchDescription
 from launch.launch_description_sources import AnyLaunchDescriptionSource
@@ -30,8 +32,6 @@ from rcl_interfaces.msg import ParameterValue
 from rcl_interfaces.srv import SetParameters
 import rclpy
 import rclpy.qos
-from autoware_internal_planning_msgs.msg import VelocityLimit
-from autoware_internal_planning_msgs.msg import VelocityLimitClearCommand
 
 logger = get_logger(__name__)
 

--- a/planning/autoware_external_velocity_limit_selector/test/test_external_velocity_limit_selector_node_launch.py
+++ b/planning/autoware_external_velocity_limit_selector/test/test_external_velocity_limit_selector_node_launch.py
@@ -30,8 +30,8 @@ from rcl_interfaces.msg import ParameterValue
 from rcl_interfaces.srv import SetParameters
 import rclpy
 import rclpy.qos
-from tier4_planning_msgs.msg import VelocityLimit
-from tier4_planning_msgs.msg import VelocityLimitClearCommand
+from autoware_internal_planning_msgs.msg import VelocityLimit
+from autoware_internal_planning_msgs.msg import VelocityLimitClearCommand
 
 logger = get_logger(__name__)
 

--- a/planning/autoware_obstacle_cruise_planner/include/autoware/obstacle_cruise_planner/type_alias.hpp
+++ b/planning/autoware_obstacle_cruise_planner/include/autoware/obstacle_cruise_planner/type_alias.hpp
@@ -31,8 +31,8 @@
 #include "nav_msgs/msg/odometry.hpp"
 #include "sensor_msgs/msg/point_cloud2.hpp"
 #include "tier4_planning_msgs/msg/stop_speed_exceeded.hpp"
-#include "tier4_planning_msgs/msg/velocity_limit.hpp"
-#include "tier4_planning_msgs/msg/velocity_limit_clear_command.hpp"
+#include "autoware_internal_planning_msgs/msg/velocity_limit.hpp"
+#include "autoware_internal_planning_msgs/msg/velocity_limit_clear_command.hpp"
 #include "visualization_msgs/msg/marker_array.hpp"
 
 #include <pcl/point_cloud.h>
@@ -54,8 +54,8 @@ using geometry_msgs::msg::Twist;
 using nav_msgs::msg::Odometry;
 using sensor_msgs::msg::PointCloud2;
 using tier4_planning_msgs::msg::StopSpeedExceeded;
-using tier4_planning_msgs::msg::VelocityLimit;
-using tier4_planning_msgs::msg::VelocityLimitClearCommand;
+using autoware_internal_planning_msgs::msg::VelocityLimit;
+using autoware_internal_planning_msgs::msg::VelocityLimitClearCommand;
 using visualization_msgs::msg::Marker;
 using visualization_msgs::msg::MarkerArray;
 namespace bg = boost::geometry;

--- a/planning/autoware_obstacle_cruise_planner/include/autoware/obstacle_cruise_planner/type_alias.hpp
+++ b/planning/autoware_obstacle_cruise_planner/include/autoware/obstacle_cruise_planner/type_alias.hpp
@@ -21,6 +21,8 @@
 
 #include "autoware_internal_debug_msgs/msg/float32_stamped.hpp"
 #include "autoware_internal_debug_msgs/msg/float64_stamped.hpp"
+#include "autoware_internal_planning_msgs/msg/velocity_limit.hpp"
+#include "autoware_internal_planning_msgs/msg/velocity_limit_clear_command.hpp"
 #include "autoware_perception_msgs/msg/predicted_object.hpp"
 #include "autoware_perception_msgs/msg/predicted_objects.hpp"
 #include "autoware_planning_msgs/msg/trajectory.hpp"
@@ -31,8 +33,6 @@
 #include "nav_msgs/msg/odometry.hpp"
 #include "sensor_msgs/msg/point_cloud2.hpp"
 #include "tier4_planning_msgs/msg/stop_speed_exceeded.hpp"
-#include "autoware_internal_planning_msgs/msg/velocity_limit.hpp"
-#include "autoware_internal_planning_msgs/msg/velocity_limit_clear_command.hpp"
 #include "visualization_msgs/msg/marker_array.hpp"
 
 #include <pcl/point_cloud.h>
@@ -41,6 +41,8 @@
 using autoware::vehicle_info_utils::VehicleInfo;
 using autoware_internal_debug_msgs::msg::Float32Stamped;
 using autoware_internal_debug_msgs::msg::Float64Stamped;
+using autoware_internal_planning_msgs::msg::VelocityLimit;
+using autoware_internal_planning_msgs::msg::VelocityLimitClearCommand;
 using autoware_perception_msgs::msg::ObjectClassification;
 using autoware_perception_msgs::msg::PredictedObject;
 using autoware_perception_msgs::msg::PredictedObjects;
@@ -54,8 +56,6 @@ using geometry_msgs::msg::Twist;
 using nav_msgs::msg::Odometry;
 using sensor_msgs::msg::PointCloud2;
 using tier4_planning_msgs::msg::StopSpeedExceeded;
-using autoware_internal_planning_msgs::msg::VelocityLimit;
-using autoware_internal_planning_msgs::msg::VelocityLimitClearCommand;
 using visualization_msgs::msg::Marker;
 using visualization_msgs::msg::MarkerArray;
 namespace bg = boost::geometry;

--- a/planning/autoware_obstacle_cruise_planner/package.xml
+++ b/planning/autoware_obstacle_cruise_planner/package.xml
@@ -19,6 +19,7 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_internal_debug_msgs</depend>
+  <depend>autoware_internal_planning_msgs</depend>
   <depend>autoware_interpolation</depend>
   <depend>autoware_lanelet2_extension</depend>
   <depend>autoware_motion_utils</depend>
@@ -42,7 +43,6 @@
   <depend>tier4_metric_msgs</depend>
   <depend>tier4_planning_msgs</depend>
   <depend>visualization_msgs</depend>
-  <depend>autoware_internal_planning_msgs</depend>
 
   <test_depend>ament_cmake_ros</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/planning/autoware_obstacle_cruise_planner/package.xml
+++ b/planning/autoware_obstacle_cruise_planner/package.xml
@@ -42,6 +42,7 @@
   <depend>tier4_metric_msgs</depend>
   <depend>tier4_planning_msgs</depend>
   <depend>visualization_msgs</depend>
+  <depend>autoware_internal_planning_msgs</depend>
 
   <test_depend>ament_cmake_ros</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/planning/autoware_obstacle_stop_planner/package.xml
+++ b/planning/autoware_obstacle_stop_planner/package.xml
@@ -22,6 +22,7 @@
 
   <depend>autoware_adapi_v1_msgs</depend>
   <depend>autoware_internal_debug_msgs</depend>
+  <depend>autoware_internal_planning_msgs</depend>
   <depend>autoware_motion_utils</depend>
   <depend>autoware_perception_msgs</depend>
   <depend>autoware_planning_factor_interface</depend>
@@ -44,7 +45,6 @@
   <depend>tf2_ros</depend>
   <depend>tier4_planning_msgs</depend>
   <depend>visualization_msgs</depend>
-  <depend>autoware_internal_planning_msgs</depend>
 
   <test_depend>ament_cmake_ros</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/planning/autoware_obstacle_stop_planner/package.xml
+++ b/planning/autoware_obstacle_stop_planner/package.xml
@@ -44,6 +44,7 @@
   <depend>tf2_ros</depend>
   <depend>tier4_planning_msgs</depend>
   <depend>visualization_msgs</depend>
+  <depend>autoware_internal_planning_msgs</depend>
 
   <test_depend>ament_cmake_ros</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/planning/autoware_obstacle_stop_planner/src/node.hpp
+++ b/planning/autoware_obstacle_stop_planner/src/node.hpp
@@ -34,6 +34,8 @@
 #include <autoware_internal_debug_msgs/msg/float32_multi_array_stamped.hpp>
 #include <autoware_internal_debug_msgs/msg/float32_stamped.hpp>
 #include <autoware_internal_debug_msgs/msg/float64_stamped.hpp>
+#include <autoware_internal_planning_msgs/msg/velocity_limit.hpp>
+#include <autoware_internal_planning_msgs/msg/velocity_limit_clear_command.hpp>
 #include <autoware_perception_msgs/msg/predicted_objects.hpp>
 #include <autoware_planning_msgs/msg/trajectory.hpp>
 #include <diagnostic_msgs/msg/diagnostic_status.hpp>
@@ -42,8 +44,6 @@
 #include <geometry_msgs/msg/twist_stamped.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
 #include <tier4_planning_msgs/msg/expand_stop_range.hpp>
-#include <autoware_internal_planning_msgs/msg/velocity_limit.hpp>
-#include <autoware_internal_planning_msgs/msg/velocity_limit_clear_command.hpp>
 
 #include <boost/assert.hpp>
 #include <boost/assign/list_of.hpp>
@@ -86,12 +86,12 @@ using autoware_internal_debug_msgs::msg::BoolStamped;
 using autoware_internal_debug_msgs::msg::Float32MultiArrayStamped;
 using autoware_internal_debug_msgs::msg::Float32Stamped;
 using autoware_internal_debug_msgs::msg::Float64Stamped;
+using autoware_internal_planning_msgs::msg::VelocityLimit;
+using autoware_internal_planning_msgs::msg::VelocityLimitClearCommand;
 using autoware_perception_msgs::msg::PredictedObjects;
 using autoware_planning_msgs::msg::Trajectory;
 using autoware_planning_msgs::msg::TrajectoryPoint;
 using tier4_planning_msgs::msg::ExpandStopRange;
-using autoware_internal_planning_msgs::msg::VelocityLimit;
-using autoware_internal_planning_msgs::msg::VelocityLimitClearCommand;
 
 using TrajectoryPoints = std::vector<TrajectoryPoint>;
 using PointCloud = pcl::PointCloud<pcl::PointXYZ>;

--- a/planning/autoware_obstacle_stop_planner/src/node.hpp
+++ b/planning/autoware_obstacle_stop_planner/src/node.hpp
@@ -42,8 +42,8 @@
 #include <geometry_msgs/msg/twist_stamped.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
 #include <tier4_planning_msgs/msg/expand_stop_range.hpp>
-#include <tier4_planning_msgs/msg/velocity_limit.hpp>
-#include <tier4_planning_msgs/msg/velocity_limit_clear_command.hpp>
+#include <autoware_internal_planning_msgs/msg/velocity_limit.hpp>
+#include <autoware_internal_planning_msgs/msg/velocity_limit_clear_command.hpp>
 
 #include <boost/assert.hpp>
 #include <boost/assign/list_of.hpp>
@@ -90,8 +90,8 @@ using autoware_perception_msgs::msg::PredictedObjects;
 using autoware_planning_msgs::msg::Trajectory;
 using autoware_planning_msgs::msg::TrajectoryPoint;
 using tier4_planning_msgs::msg::ExpandStopRange;
-using tier4_planning_msgs::msg::VelocityLimit;
-using tier4_planning_msgs::msg::VelocityLimitClearCommand;
+using autoware_internal_planning_msgs::msg::VelocityLimit;
+using autoware_internal_planning_msgs::msg::VelocityLimitClearCommand;
 
 using TrajectoryPoints = std::vector<TrajectoryPoint>;
 using PointCloud = pcl::PointCloud<pcl::PointXYZ>;

--- a/planning/autoware_remaining_distance_time_calculator/package.xml
+++ b/planning/autoware_remaining_distance_time_calculator/package.xml
@@ -12,6 +12,7 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_internal_msgs</depend>
+  <depend>autoware_internal_planning_msgs</depend>
   <depend>autoware_lanelet2_extension</depend>
   <depend>autoware_motion_utils</depend>
   <depend>autoware_planning_msgs</depend>
@@ -25,7 +26,6 @@
   <depend>rclcpp_components</depend>
   <depend>std_msgs</depend>
   <depend>tier4_planning_msgs</depend>
-  <depend>autoware_internal_planning_msgs</depend>
 
   <test_depend>ament_cmake_ros</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/planning/autoware_remaining_distance_time_calculator/package.xml
+++ b/planning/autoware_remaining_distance_time_calculator/package.xml
@@ -25,6 +25,7 @@
   <depend>rclcpp_components</depend>
   <depend>std_msgs</depend>
   <depend>tier4_planning_msgs</depend>
+  <depend>autoware_internal_planning_msgs</depend>
 
   <test_depend>ament_cmake_ros</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/planning/autoware_remaining_distance_time_calculator/src/remaining_distance_time_calculator_node.cpp
+++ b/planning/autoware_remaining_distance_time_calculator/src/remaining_distance_time_calculator_node.cpp
@@ -55,7 +55,7 @@ RemainingDistanceTimeCalculatorNode::RemainingDistanceTimeCalculatorNode(
   sub_route_ = create_subscription<LaneletRoute>(
     "~/input/route", qos_transient_local,
     std::bind(&RemainingDistanceTimeCalculatorNode::on_route, this, _1));
-  sub_planning_velocity_ = create_subscription<tier4_planning_msgs::msg::VelocityLimit>(
+  sub_planning_velocity_ = create_subscription<autoware_internal_planning_msgs::msg::VelocityLimit>(
     "/planning/scenario_planning/current_max_velocity", qos_transient_local,
     std::bind(&RemainingDistanceTimeCalculatorNode::on_velocity_limit, this, _1));
   sub_scenario_ = this->create_subscription<tier4_planning_msgs::msg::Scenario>(

--- a/planning/autoware_remaining_distance_time_calculator/src/remaining_distance_time_calculator_node.hpp
+++ b/planning/autoware_remaining_distance_time_calculator/src/remaining_distance_time_calculator_node.hpp
@@ -26,7 +26,7 @@
 #include <geometry_msgs/msg/vector3.hpp>
 #include <nav_msgs/msg/odometry.hpp>
 #include <tier4_planning_msgs/msg/scenario.hpp>
-#include <tier4_planning_msgs/msg/velocity_limit.hpp>
+#include <autoware_internal_planning_msgs/msg/velocity_limit.hpp>
 
 #include <lanelet2_core/Forward.h>
 #include <lanelet2_core/utility/Optional.h>
@@ -49,7 +49,7 @@ private:
   using LaneletRoute = autoware_planning_msgs::msg::LaneletRoute;
   using HADMapBin = autoware_map_msgs::msg::LaneletMapBin;
   using Odometry = nav_msgs::msg::Odometry;
-  using VelocityLimit = tier4_planning_msgs::msg::VelocityLimit;
+  using VelocityLimit = autoware_internal_planning_msgs::msg::VelocityLimit;
   using MissionRemainingDistanceTime = autoware_internal_msgs::msg::MissionRemainingDistanceTime;
 
   rclcpp::Subscription<LaneletRoute>::SharedPtr sub_route_;

--- a/planning/autoware_remaining_distance_time_calculator/src/remaining_distance_time_calculator_node.hpp
+++ b/planning/autoware_remaining_distance_time_calculator/src/remaining_distance_time_calculator_node.hpp
@@ -20,13 +20,13 @@
 #include <remaining_distance_time_calculator_parameters.hpp>
 
 #include <autoware_internal_msgs/msg/mission_remaining_distance_time.hpp>
+#include <autoware_internal_planning_msgs/msg/velocity_limit.hpp>
 #include <autoware_map_msgs/msg/lanelet_map_bin.hpp>
 #include <autoware_planning_msgs/msg/lanelet_route.hpp>
 #include <geometry_msgs/msg/pose.hpp>
 #include <geometry_msgs/msg/vector3.hpp>
 #include <nav_msgs/msg/odometry.hpp>
 #include <tier4_planning_msgs/msg/scenario.hpp>
-#include <autoware_internal_planning_msgs/msg/velocity_limit.hpp>
 
 #include <lanelet2_core/Forward.h>
 #include <lanelet2_core/utility/Optional.h>

--- a/planning/autoware_surround_obstacle_checker/README.md
+++ b/planning/autoware_surround_obstacle_checker/README.md
@@ -86,15 +86,15 @@ As mentioned in stop condition section, it prevents chattering by changing thres
 
 ### Output
 
-| Name                                    | Type                                                  | Description                                                                           |
-| --------------------------------------- | ----------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| Name                                    | Type                                                              | Description                                                                           |
+| --------------------------------------- | ----------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
 | `~/output/velocity_limit_clear_command` | `autoware_internal_planning_msgs::msg::VelocityLimitClearCommand` | Velocity limit clear command                                                          |
 | `~/output/max_velocity`                 | `autoware_internal_planning_msgs::msg::VelocityLimit`             | Velocity limit command                                                                |
-| `~/output/no_start_reason`              | `diagnostic_msgs::msg::DiagnosticStatus`              | No start reason                                                                       |
-| `~/debug/marker`                        | `visualization_msgs::msg::MarkerArray`                | Marker for visualization                                                              |
-| `~/debug/footprint`                     | `geometry_msgs::msg::PolygonStamped`                  | Ego vehicle base footprint for visualization                                          |
-| `~/debug/footprint_offset`              | `geometry_msgs::msg::PolygonStamped`                  | Ego vehicle footprint with `surround_check_distance` offset for visualization         |
-| `~/debug/footprint_recover_offset`      | `geometry_msgs::msg::PolygonStamped`                  | Ego vehicle footprint with `surround_check_recover_distance` offset for visualization |
+| `~/output/no_start_reason`              | `diagnostic_msgs::msg::DiagnosticStatus`                          | No start reason                                                                       |
+| `~/debug/marker`                        | `visualization_msgs::msg::MarkerArray`                            | Marker for visualization                                                              |
+| `~/debug/footprint`                     | `geometry_msgs::msg::PolygonStamped`                              | Ego vehicle base footprint for visualization                                          |
+| `~/debug/footprint_offset`              | `geometry_msgs::msg::PolygonStamped`                              | Ego vehicle footprint with `surround_check_distance` offset for visualization         |
+| `~/debug/footprint_recover_offset`      | `geometry_msgs::msg::PolygonStamped`                              | Ego vehicle footprint with `surround_check_recover_distance` offset for visualization |
 
 ## Parameters
 

--- a/planning/autoware_surround_obstacle_checker/README.md
+++ b/planning/autoware_surround_obstacle_checker/README.md
@@ -88,8 +88,8 @@ As mentioned in stop condition section, it prevents chattering by changing thres
 
 | Name                                    | Type                                                  | Description                                                                           |
 | --------------------------------------- | ----------------------------------------------------- | ------------------------------------------------------------------------------------- |
-| `~/output/velocity_limit_clear_command` | `tier4_planning_msgs::msg::VelocityLimitClearCommand` | Velocity limit clear command                                                          |
-| `~/output/max_velocity`                 | `tier4_planning_msgs::msg::VelocityLimit`             | Velocity limit command                                                                |
+| `~/output/velocity_limit_clear_command` | `autoware_internal_planning_msgs::msg::VelocityLimitClearCommand` | Velocity limit clear command                                                          |
+| `~/output/max_velocity`                 | `autoware_internal_planning_msgs::msg::VelocityLimit`             | Velocity limit command                                                                |
 | `~/output/no_start_reason`              | `diagnostic_msgs::msg::DiagnosticStatus`              | No start reason                                                                       |
 | `~/debug/marker`                        | `visualization_msgs::msg::MarkerArray`                | Marker for visualization                                                              |
 | `~/debug/footprint`                     | `geometry_msgs::msg::PolygonStamped`                  | Ego vehicle base footprint for visualization                                          |

--- a/planning/autoware_surround_obstacle_checker/package.xml
+++ b/planning/autoware_surround_obstacle_checker/package.xml
@@ -14,6 +14,7 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
   <buildtool_depend>eigen3_cmake_module</buildtool_depend>
 
+  <depend>autoware_internal_planning_msgs</depend>
   <depend>autoware_motion_utils</depend>
   <depend>autoware_perception_msgs</depend>
   <depend>autoware_planning_factor_interface</depend>
@@ -35,7 +36,6 @@
   <depend>tf2_geometry_msgs</depend>
   <depend>tf2_ros</depend>
   <depend>visualization_msgs</depend>
-  <depend>autoware_internal_planning_msgs</depend>
 
   <test_depend>ament_cmake_ros</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/planning/autoware_surround_obstacle_checker/package.xml
+++ b/planning/autoware_surround_obstacle_checker/package.xml
@@ -34,8 +34,8 @@
   <depend>tf2_eigen</depend>
   <depend>tf2_geometry_msgs</depend>
   <depend>tf2_ros</depend>
-  <depend>tier4_planning_msgs</depend>
   <depend>visualization_msgs</depend>
+  <depend>autoware_internal_planning_msgs</depend>
 
   <test_depend>ament_cmake_ros</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/planning/autoware_surround_obstacle_checker/src/node.hpp
+++ b/planning/autoware_surround_obstacle_checker/src/node.hpp
@@ -30,8 +30,8 @@
 #include <diagnostic_msgs/msg/key_value.hpp>
 #include <nav_msgs/msg/odometry.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
-#include <tier4_planning_msgs/msg/velocity_limit.hpp>
-#include <tier4_planning_msgs/msg/velocity_limit_clear_command.hpp>
+#include <autoware_internal_planning_msgs/msg/velocity_limit.hpp>
+#include <autoware_internal_planning_msgs/msg/velocity_limit_clear_command.hpp>
 #include <visualization_msgs/msg/marker_array.hpp>
 
 #include <tf2/utils.h>
@@ -52,8 +52,8 @@ using autoware::motion_utils::VehicleStopChecker;
 using autoware::vehicle_info_utils::VehicleInfo;
 using autoware_perception_msgs::msg::PredictedObjects;
 using autoware_perception_msgs::msg::Shape;
-using tier4_planning_msgs::msg::VelocityLimit;
-using tier4_planning_msgs::msg::VelocityLimitClearCommand;
+using autoware_internal_planning_msgs::msg::VelocityLimit;
+using autoware_internal_planning_msgs::msg::VelocityLimitClearCommand;
 
 using Obstacle = std::pair<double /* distance */, geometry_msgs::msg::Point>;
 

--- a/planning/autoware_surround_obstacle_checker/src/node.hpp
+++ b/planning/autoware_surround_obstacle_checker/src/node.hpp
@@ -25,13 +25,13 @@
 #include <rclcpp/rclcpp.hpp>
 
 #include <autoware_internal_debug_msgs/msg/float64_stamped.hpp>
+#include <autoware_internal_planning_msgs/msg/velocity_limit.hpp>
+#include <autoware_internal_planning_msgs/msg/velocity_limit_clear_command.hpp>
 #include <autoware_perception_msgs/msg/predicted_objects.hpp>
 #include <diagnostic_msgs/msg/diagnostic_status.hpp>
 #include <diagnostic_msgs/msg/key_value.hpp>
 #include <nav_msgs/msg/odometry.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
-#include <autoware_internal_planning_msgs/msg/velocity_limit.hpp>
-#include <autoware_internal_planning_msgs/msg/velocity_limit_clear_command.hpp>
 #include <visualization_msgs/msg/marker_array.hpp>
 
 #include <tf2/utils.h>
@@ -50,10 +50,10 @@ namespace autoware::surround_obstacle_checker
 
 using autoware::motion_utils::VehicleStopChecker;
 using autoware::vehicle_info_utils::VehicleInfo;
-using autoware_perception_msgs::msg::PredictedObjects;
-using autoware_perception_msgs::msg::Shape;
 using autoware_internal_planning_msgs::msg::VelocityLimit;
 using autoware_internal_planning_msgs::msg::VelocityLimitClearCommand;
+using autoware_perception_msgs::msg::PredictedObjects;
+using autoware_perception_msgs::msg::Shape;
 
 using Obstacle = std::pair<double /* distance */, geometry_msgs::msg::Point>;
 

--- a/planning/autoware_surround_obstacle_checker/surround_obstacle_checker-design.ja.md
+++ b/planning/autoware_surround_obstacle_checker/surround_obstacle_checker-design.ja.md
@@ -88,8 +88,8 @@ Stop condition の項で述べたように、状態によって障害物判定�
 
 | Name                                    | Type                                                  | Description                  |
 | --------------------------------------- | ----------------------------------------------------- | ---------------------------- |
-| `~/output/velocity_limit_clear_command` | `tier4_planning_msgs::msg::VelocityLimitClearCommand` | Velocity limit clear command |
-| `~/output/max_velocity`                 | `tier4_planning_msgs::msg::VelocityLimit`             | Velocity limit command       |
+| `~/output/velocity_limit_clear_command` | `autoware_internal_planning_msgs::msg::VelocityLimitClearCommand` | Velocity limit clear command |
+| `~/output/max_velocity`                 | `autoware_internal_planning_msgs::msg::VelocityLimit`             | Velocity limit command       |
 | `~/output/no_start_reason`              | `diagnostic_msgs::msg::DiagnosticStatus`              | No start reason              |
 | `~/debug/marker`                        | `visualization_msgs::msg::MarkerArray`                | Marker for visualization     |
 

--- a/planning/autoware_surround_obstacle_checker/surround_obstacle_checker-design.ja.md
+++ b/planning/autoware_surround_obstacle_checker/surround_obstacle_checker-design.ja.md
@@ -86,12 +86,12 @@ Stop condition の項で述べたように、状態によって障害物判定�
 
 ### Output
 
-| Name                                    | Type                                                  | Description                  |
-| --------------------------------------- | ----------------------------------------------------- | ---------------------------- |
+| Name                                    | Type                                                              | Description                  |
+| --------------------------------------- | ----------------------------------------------------------------- | ---------------------------- |
 | `~/output/velocity_limit_clear_command` | `autoware_internal_planning_msgs::msg::VelocityLimitClearCommand` | Velocity limit clear command |
 | `~/output/max_velocity`                 | `autoware_internal_planning_msgs::msg::VelocityLimit`             | Velocity limit command       |
-| `~/output/no_start_reason`              | `diagnostic_msgs::msg::DiagnosticStatus`              | No start reason              |
-| `~/debug/marker`                        | `visualization_msgs::msg::MarkerArray`                | Marker for visualization     |
+| `~/output/no_start_reason`              | `diagnostic_msgs::msg::DiagnosticStatus`                          | No start reason              |
+| `~/debug/marker`                        | `visualization_msgs::msg::MarkerArray`                            | Marker for visualization     |
 
 ## Parameters
 

--- a/planning/autoware_velocity_smoother/README.ja.md
+++ b/planning/autoware_velocity_smoother/README.ja.md
@@ -1,12 +1,12 @@
 # Velocity Smoother
 
-## Purpose
+## Overview
 
 `autoware_velocity_smoother`は目標軌道上の各点における望ましい車速を計画して出力するモジュールである。
 このモジュールは、速度の最大化と乗り心地の良さを両立するために、事前に指定された制限速度、制限加速度および制限躍度の範囲で車速を計画する。
 加速度や躍度の制限を与えることは車速の変化を滑らかにすることに対応するため、このモジュールを`autoware_velocity_smoother`と呼んでいる。
 
-## Inner-workings / Algorithms
+## Design
 
 ### Flow chart
 
@@ -237,14 +237,8 @@ Example:
 - 参照経路に設定されている制限速度を指定した減速度やジャークで達成不可能な場合、可能な範囲で速度、加速度、ジャークの逸脱量を抑えながら減速
 - 各逸脱量の重視の度合いはパラメータにより指定
 
-## (Optional) Error detection and handling
-
-## (Optional) Performance characterization
-
-## (Optional) References/External links
+## References/External links
 
 [1] B. Stellato, et al., "OSQP: an operator splitting solver for quadratic programs", Mathematical Programming Computation, 2020, [10.1007/s12532-020-00179-2](https://link.springer.com/article/10.1007/s12532-020-00179-2).
 
 [2] Y. Zhang, et al., "Toward a More Complete, Flexible, and Safer Speed Planning for Autonomous Driving via Convex Optimization", Sensors, vol. 18, no. 7, p. 2185, 2018, [10.3390/s18072185](https://doi.org/10.3390/s18072185)
-
-## (Optional) Future extensions / Unimplemented parts

--- a/planning/autoware_velocity_smoother/README.md
+++ b/planning/autoware_velocity_smoother/README.md
@@ -1,12 +1,12 @@
 # Velocity Smoother
 
-## Purpose
+## Overview
 
 `autoware_velocity_smoother` outputs a desired velocity profile on a reference trajectory.
 This module plans a velocity profile within the limitations of the velocity, the acceleration and the jerk to realize both the maximization of velocity and the ride quality.
 We call this module `autoware_velocity_smoother` because the limitations of the acceleration and the jerk means the smoothness of the velocity profile.
 
-## Inner-workings / Algorithms
+## Design
 
 ### Flow chart
 
@@ -262,14 +262,8 @@ Example:
 - If the velocity limit set in the reference path cannot be achieved by the designated constraints of the deceleration and the jerk, decelerate while suppressing the velocity, the acceleration and the jerk deviation as much as possible
 - The importance of the deviations is set in the config file
 
-## (Optional) Error detection and handling
-
-## (Optional) Performance characterization
-
-## (Optional) References/External links
+## References/External links
 
 [1] B. Stellato, et al., "OSQP: an operator splitting solver for quadratic programs", Mathematical Programming Computation, 2020, [10.1007/s12532-020-00179-2](https://link.springer.com/article/10.1007/s12532-020-00179-2).
 
 [2] Y. Zhang, et al., "Toward a More Complete, Flexible, and Safer Speed Planning for Autonomous Driving via Convex Optimization", Sensors, vol. 18, no. 7, p. 2185, 2018, [10.3390/s18072185](https://doi.org/10.3390/s18072185)
-
-## (Optional) Future extensions / Unimplemented parts

--- a/planning/autoware_velocity_smoother/include/autoware/velocity_smoother/node.hpp
+++ b/planning/autoware_velocity_smoother/include/autoware/velocity_smoother/node.hpp
@@ -18,6 +18,13 @@
 #include "autoware/motion_utils/trajectory/conversion.hpp"
 #include "autoware/motion_utils/trajectory/trajectory.hpp"
 #include "autoware/osqp_interface/osqp_interface.hpp"
+#include "autoware/velocity_smoother/resample.hpp"
+#include "autoware/velocity_smoother/smoother/analytical_jerk_constrained_smoother/analytical_jerk_constrained_smoother.hpp"
+#include "autoware/velocity_smoother/smoother/jerk_filtered_smoother.hpp"
+#include "autoware/velocity_smoother/smoother/l2_pseudo_jerk_smoother.hpp"
+#include "autoware/velocity_smoother/smoother/linf_pseudo_jerk_smoother.hpp"
+#include "autoware/velocity_smoother/smoother/smoother_base.hpp"
+#include "autoware/velocity_smoother/trajectory_utils.hpp"
 #include "autoware_utils/geometry/geometry.hpp"
 #include "autoware_utils/math/unit_conversion.hpp"
 #include "autoware_utils/ros/diagnostics_interface.hpp"
@@ -26,13 +33,6 @@
 #include "autoware_utils/ros/self_pose_listener.hpp"
 #include "autoware_utils/system/stop_watch.hpp"
 #include "autoware_utils/system/time_keeper.hpp"
-#include "autoware/velocity_smoother/resample.hpp"
-#include "autoware/velocity_smoother/smoother/analytical_jerk_constrained_smoother/analytical_jerk_constrained_smoother.hpp"
-#include "autoware/velocity_smoother/smoother/jerk_filtered_smoother.hpp"
-#include "autoware/velocity_smoother/smoother/l2_pseudo_jerk_smoother.hpp"
-#include "autoware/velocity_smoother/smoother/linf_pseudo_jerk_smoother.hpp"
-#include "autoware/velocity_smoother/smoother/smoother_base.hpp"
-#include "autoware/velocity_smoother/trajectory_utils.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "tf2/utils.h"
 #include "tf2_ros/transform_listener.h"
@@ -42,11 +42,11 @@
 #include "autoware_adapi_v1_msgs/msg/operation_mode_state.hpp"
 #include "autoware_internal_debug_msgs/msg/float32_stamped.hpp"
 #include "autoware_internal_debug_msgs/msg/float64_stamped.hpp"
+#include "autoware_internal_planning_msgs/msg/velocity_limit.hpp"  // temporary
 #include "autoware_planning_msgs/msg/trajectory.hpp"
 #include "autoware_planning_msgs/msg/trajectory_point.hpp"
 #include "geometry_msgs/msg/accel_with_covariance_stamped.hpp"
 #include "nav_msgs/msg/odometry.hpp"
-#include "autoware_internal_planning_msgs/msg/velocity_limit.hpp"  // temporary
 #include "visualization_msgs/msg/marker_array.hpp"
 
 #include <iostream>
@@ -61,15 +61,15 @@ namespace autoware::velocity_smoother
 using autoware_planning_msgs::msg::Trajectory;
 using autoware_planning_msgs::msg::TrajectoryPoint;
 using TrajectoryPoints = std::vector<TrajectoryPoint>;
-using autoware_utils::DiagnosticsInterface;
 using autoware_adapi_v1_msgs::msg::OperationModeState;
 using autoware_internal_debug_msgs::msg::Float32Stamped;
 using autoware_internal_debug_msgs::msg::Float64Stamped;
+using autoware_internal_planning_msgs::msg::VelocityLimit;  // temporary
+using autoware_utils::DiagnosticsInterface;
 using geometry_msgs::msg::AccelWithCovarianceStamped;
 using geometry_msgs::msg::Pose;
 using geometry_msgs::msg::PoseStamped;
 using nav_msgs::msg::Odometry;
-using autoware_internal_planning_msgs::msg::VelocityLimit;  // temporary
 using visualization_msgs::msg::MarkerArray;
 
 struct Motion
@@ -270,8 +270,7 @@ private:
   rclcpp::Publisher<Float32Stamped>::SharedPtr debug_closest_jerk_;
   rclcpp::Publisher<Float64Stamped>::SharedPtr debug_calculation_time_;
   rclcpp::Publisher<Float32Stamped>::SharedPtr debug_closest_max_velocity_;
-  rclcpp::Publisher<autoware_utils::ProcessingTimeDetail>::SharedPtr
-    debug_processing_time_detail_;
+  rclcpp::Publisher<autoware_utils::ProcessingTimeDetail>::SharedPtr debug_processing_time_detail_;
 
   // For Jerk Filtered Algorithm Debug
   rclcpp::Publisher<Trajectory>::SharedPtr pub_forward_filtered_trajectory_;

--- a/planning/autoware_velocity_smoother/include/autoware/velocity_smoother/node.hpp
+++ b/planning/autoware_velocity_smoother/include/autoware/velocity_smoother/node.hpp
@@ -18,14 +18,14 @@
 #include "autoware/motion_utils/trajectory/conversion.hpp"
 #include "autoware/motion_utils/trajectory/trajectory.hpp"
 #include "autoware/osqp_interface/osqp_interface.hpp"
-#include "autoware/universe_utils/geometry/geometry.hpp"
-#include "autoware/universe_utils/math/unit_conversion.hpp"
-#include "autoware/universe_utils/ros/diagnostics_interface.hpp"
-#include "autoware/universe_utils/ros/logger_level_configure.hpp"
-#include "autoware/universe_utils/ros/polling_subscriber.hpp"
-#include "autoware/universe_utils/ros/self_pose_listener.hpp"
-#include "autoware/universe_utils/system/stop_watch.hpp"
-#include "autoware/universe_utils/system/time_keeper.hpp"
+#include "autoware_utils/geometry/geometry.hpp"
+#include "autoware_utils/math/unit_conversion.hpp"
+#include "autoware_utils/ros/diagnostics_interface.hpp"
+#include "autoware_utils/ros/logger_level_configure.hpp"
+#include "autoware_utils/ros/polling_subscriber.hpp"
+#include "autoware_utils/ros/self_pose_listener.hpp"
+#include "autoware_utils/system/stop_watch.hpp"
+#include "autoware_utils/system/time_keeper.hpp"
 #include "autoware/velocity_smoother/resample.hpp"
 #include "autoware/velocity_smoother/smoother/analytical_jerk_constrained_smoother/analytical_jerk_constrained_smoother.hpp"
 #include "autoware/velocity_smoother/smoother/jerk_filtered_smoother.hpp"
@@ -37,7 +37,7 @@
 #include "tf2/utils.h"
 #include "tf2_ros/transform_listener.h"
 
-#include <autoware/universe_utils/ros/published_time_publisher.hpp>
+#include <autoware_utils/ros/published_time_publisher.hpp>
 
 #include "autoware_adapi_v1_msgs/msg/operation_mode_state.hpp"
 #include "autoware_internal_debug_msgs/msg/float32_stamped.hpp"
@@ -61,7 +61,7 @@ namespace autoware::velocity_smoother
 using autoware_planning_msgs::msg::Trajectory;
 using autoware_planning_msgs::msg::TrajectoryPoint;
 using TrajectoryPoints = std::vector<TrajectoryPoint>;
-using autoware::universe_utils::DiagnosticsInterface;
+using autoware_utils::DiagnosticsInterface;
 using autoware_adapi_v1_msgs::msg::OperationModeState;
 using autoware_internal_debug_msgs::msg::Float32Stamped;
 using autoware_internal_debug_msgs::msg::Float64Stamped;
@@ -90,14 +90,14 @@ private:
   rclcpp::Publisher<Trajectory>::SharedPtr pub_trajectory_;
   rclcpp::Publisher<MarkerArray>::SharedPtr pub_virtual_wall_;
   rclcpp::Subscription<Trajectory>::SharedPtr sub_current_trajectory_;
-  autoware::universe_utils::InterProcessPollingSubscriber<Odometry> sub_current_odometry_{
+  autoware_utils::InterProcessPollingSubscriber<Odometry> sub_current_odometry_{
     this, "/localization/kinematic_state"};
-  autoware::universe_utils::InterProcessPollingSubscriber<AccelWithCovarianceStamped>
+  autoware_utils::InterProcessPollingSubscriber<AccelWithCovarianceStamped>
     sub_current_acceleration_{this, "~/input/acceleration"};
-  autoware::universe_utils::InterProcessPollingSubscriber<
-    VelocityLimit, universe_utils::polling_policy::Newest>
+  autoware_utils::InterProcessPollingSubscriber<
+    VelocityLimit, autoware_utils::polling_policy::Newest>
     sub_external_velocity_limit_{this, "~/input/external_velocity_limit_mps"};
-  autoware::universe_utils::InterProcessPollingSubscriber<OperationModeState> sub_operation_mode_{
+  autoware_utils::InterProcessPollingSubscriber<OperationModeState> sub_operation_mode_{
     this, "~/input/operation_mode_state"};
 
   Odometry::ConstSharedPtr current_odometry_ptr_;  // current odometry
@@ -255,7 +255,7 @@ private:
   void initCommonParam();
 
   // debug
-  autoware::universe_utils::StopWatch<std::chrono::milliseconds> stop_watch_;
+  autoware_utils::StopWatch<std::chrono::milliseconds> stop_watch_;
   std::shared_ptr<rclcpp::Time> prev_time_;
   double prev_acc_;
   rclcpp::Publisher<Float32Stamped>::SharedPtr pub_dist_to_stopline_;
@@ -270,7 +270,7 @@ private:
   rclcpp::Publisher<Float32Stamped>::SharedPtr debug_closest_jerk_;
   rclcpp::Publisher<Float64Stamped>::SharedPtr debug_calculation_time_;
   rclcpp::Publisher<Float32Stamped>::SharedPtr debug_closest_max_velocity_;
-  rclcpp::Publisher<autoware::universe_utils::ProcessingTimeDetail>::SharedPtr
+  rclcpp::Publisher<autoware_utils::ProcessingTimeDetail>::SharedPtr
     debug_processing_time_detail_;
 
   // For Jerk Filtered Algorithm Debug
@@ -285,10 +285,10 @@ private:
   void flipVelocity(TrajectoryPoints & points) const;
   void publishStopWatchTime();
 
-  std::unique_ptr<autoware::universe_utils::LoggerLevelConfigure> logger_configure_;
-  std::unique_ptr<autoware::universe_utils::PublishedTimePublisher> published_time_publisher_;
+  std::unique_ptr<autoware_utils::LoggerLevelConfigure> logger_configure_;
+  std::unique_ptr<autoware_utils::PublishedTimePublisher> published_time_publisher_;
 
-  mutable std::shared_ptr<autoware::universe_utils::TimeKeeper> time_keeper_{nullptr};
+  mutable std::shared_ptr<autoware_utils::TimeKeeper> time_keeper_{nullptr};
 
   std::unique_ptr<DiagnosticsInterface> diagnostics_interface_{nullptr};
 };

--- a/planning/autoware_velocity_smoother/include/autoware/velocity_smoother/node.hpp
+++ b/planning/autoware_velocity_smoother/include/autoware/velocity_smoother/node.hpp
@@ -46,7 +46,7 @@
 #include "autoware_planning_msgs/msg/trajectory_point.hpp"
 #include "geometry_msgs/msg/accel_with_covariance_stamped.hpp"
 #include "nav_msgs/msg/odometry.hpp"
-#include "tier4_planning_msgs/msg/velocity_limit.hpp"  // temporary
+#include "autoware_internal_planning_msgs/msg/velocity_limit.hpp"  // temporary
 #include "visualization_msgs/msg/marker_array.hpp"
 
 #include <iostream>
@@ -69,7 +69,7 @@ using geometry_msgs::msg::AccelWithCovarianceStamped;
 using geometry_msgs::msg::Pose;
 using geometry_msgs::msg::PoseStamped;
 using nav_msgs::msg::Odometry;
-using tier4_planning_msgs::msg::VelocityLimit;  // temporary
+using autoware_internal_planning_msgs::msg::VelocityLimit;  // temporary
 using visualization_msgs::msg::MarkerArray;
 
 struct Motion

--- a/planning/autoware_velocity_smoother/include/autoware/velocity_smoother/smoother/analytical_jerk_constrained_smoother/analytical_jerk_constrained_smoother.hpp
+++ b/planning/autoware_velocity_smoother/include/autoware/velocity_smoother/smoother/analytical_jerk_constrained_smoother/analytical_jerk_constrained_smoother.hpp
@@ -16,7 +16,8 @@
 #define AUTOWARE__VELOCITY_SMOOTHER__SMOOTHER__ANALYTICAL_JERK_CONSTRAINED_SMOOTHER__ANALYTICAL_JERK_CONSTRAINED_SMOOTHER_HPP_  // NOLINT
 
 #include "autoware/motion_utils/trajectory/trajectory.hpp"
-#include "autoware/universe_utils/system/time_keeper.hpp"
+#include "autoware_utils/geometry/geometry.hpp"
+#include "autoware_utils/system/time_keeper.hpp"
 #include "autoware/velocity_smoother/smoother/analytical_jerk_constrained_smoother/velocity_planning_utils.hpp"
 #include "autoware/velocity_smoother/smoother/smoother_base.hpp"
 #include "rclcpp/rclcpp.hpp"
@@ -68,8 +69,8 @@ public:
   };
 
   explicit AnalyticalJerkConstrainedSmoother(
-    rclcpp::Node & node, const std::shared_ptr<autoware::universe_utils::TimeKeeper> time_keeper =
-                           std::make_shared<autoware::universe_utils::TimeKeeper>());
+    rclcpp::Node & node, const std::shared_ptr<autoware_utils::TimeKeeper> time_keeper =
+                           std::make_shared<autoware_utils::TimeKeeper>());
 
   bool apply(
     const double initial_vel, const double initial_acc, const TrajectoryPoints & input,

--- a/planning/autoware_velocity_smoother/include/autoware/velocity_smoother/smoother/analytical_jerk_constrained_smoother/analytical_jerk_constrained_smoother.hpp
+++ b/planning/autoware_velocity_smoother/include/autoware/velocity_smoother/smoother/analytical_jerk_constrained_smoother/analytical_jerk_constrained_smoother.hpp
@@ -16,10 +16,10 @@
 #define AUTOWARE__VELOCITY_SMOOTHER__SMOOTHER__ANALYTICAL_JERK_CONSTRAINED_SMOOTHER__ANALYTICAL_JERK_CONSTRAINED_SMOOTHER_HPP_  // NOLINT
 
 #include "autoware/motion_utils/trajectory/trajectory.hpp"
-#include "autoware_utils/geometry/geometry.hpp"
-#include "autoware_utils/system/time_keeper.hpp"
 #include "autoware/velocity_smoother/smoother/analytical_jerk_constrained_smoother/velocity_planning_utils.hpp"
 #include "autoware/velocity_smoother/smoother/smoother_base.hpp"
+#include "autoware_utils/geometry/geometry.hpp"
+#include "autoware_utils/system/time_keeper.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "tf2/utils.h"
 

--- a/planning/autoware_velocity_smoother/include/autoware/velocity_smoother/smoother/jerk_filtered_smoother.hpp
+++ b/planning/autoware_velocity_smoother/include/autoware/velocity_smoother/smoother/jerk_filtered_smoother.hpp
@@ -17,9 +17,9 @@
 
 #include "autoware/motion_utils/trajectory/trajectory.hpp"
 #include "autoware/qp_interface/qp_interface.hpp"
+#include "autoware/velocity_smoother/smoother/smoother_base.hpp"
 #include "autoware_utils/geometry/geometry.hpp"
 #include "autoware_utils/system/time_keeper.hpp"
-#include "autoware/velocity_smoother/smoother/smoother_base.hpp"
 
 #include "autoware_planning_msgs/msg/trajectory_point.hpp"
 

--- a/planning/autoware_velocity_smoother/include/autoware/velocity_smoother/smoother/jerk_filtered_smoother.hpp
+++ b/planning/autoware_velocity_smoother/include/autoware/velocity_smoother/smoother/jerk_filtered_smoother.hpp
@@ -17,8 +17,8 @@
 
 #include "autoware/motion_utils/trajectory/trajectory.hpp"
 #include "autoware/qp_interface/qp_interface.hpp"
-#include "autoware/universe_utils/geometry/geometry.hpp"
-#include "autoware/universe_utils/system/time_keeper.hpp"
+#include "autoware_utils/geometry/geometry.hpp"
+#include "autoware_utils/system/time_keeper.hpp"
 #include "autoware/velocity_smoother/smoother/smoother_base.hpp"
 
 #include "autoware_planning_msgs/msg/trajectory_point.hpp"
@@ -43,7 +43,7 @@ public:
   };
 
   explicit JerkFilteredSmoother(
-    rclcpp::Node & node, const std::shared_ptr<autoware::universe_utils::TimeKeeper> time_keeper);
+    rclcpp::Node & node, const std::shared_ptr<autoware_utils::TimeKeeper> time_keeper);
 
   bool apply(
     const double initial_vel, const double initial_acc, const TrajectoryPoints & input,

--- a/planning/autoware_velocity_smoother/include/autoware/velocity_smoother/smoother/l2_pseudo_jerk_smoother.hpp
+++ b/planning/autoware_velocity_smoother/include/autoware/velocity_smoother/smoother/l2_pseudo_jerk_smoother.hpp
@@ -17,8 +17,8 @@
 
 #include "autoware/motion_utils/trajectory/trajectory.hpp"
 #include "autoware/osqp_interface/osqp_interface.hpp"
-#include "autoware/universe_utils/geometry/geometry.hpp"
-#include "autoware/universe_utils/system/time_keeper.hpp"
+#include "autoware_utils/geometry/geometry.hpp"
+#include "autoware_utils/system/time_keeper.hpp"
 #include "autoware/velocity_smoother/smoother/smoother_base.hpp"
 
 #include "autoware_planning_msgs/msg/trajectory_point.hpp"
@@ -41,7 +41,7 @@ public:
   };
 
   explicit L2PseudoJerkSmoother(
-    rclcpp::Node & node, const std::shared_ptr<autoware::universe_utils::TimeKeeper> time_keeper);
+    rclcpp::Node & node, const std::shared_ptr<autoware_utils::TimeKeeper> time_keeper);
 
   bool apply(
     const double initial_vel, const double initial_acc, const TrajectoryPoints & input,

--- a/planning/autoware_velocity_smoother/include/autoware/velocity_smoother/smoother/l2_pseudo_jerk_smoother.hpp
+++ b/planning/autoware_velocity_smoother/include/autoware/velocity_smoother/smoother/l2_pseudo_jerk_smoother.hpp
@@ -17,9 +17,9 @@
 
 #include "autoware/motion_utils/trajectory/trajectory.hpp"
 #include "autoware/osqp_interface/osqp_interface.hpp"
+#include "autoware/velocity_smoother/smoother/smoother_base.hpp"
 #include "autoware_utils/geometry/geometry.hpp"
 #include "autoware_utils/system/time_keeper.hpp"
-#include "autoware/velocity_smoother/smoother/smoother_base.hpp"
 
 #include "autoware_planning_msgs/msg/trajectory_point.hpp"
 

--- a/planning/autoware_velocity_smoother/include/autoware/velocity_smoother/smoother/linf_pseudo_jerk_smoother.hpp
+++ b/planning/autoware_velocity_smoother/include/autoware/velocity_smoother/smoother/linf_pseudo_jerk_smoother.hpp
@@ -17,8 +17,8 @@
 
 #include "autoware/motion_utils/trajectory/trajectory.hpp"
 #include "autoware/osqp_interface/osqp_interface.hpp"
-#include "autoware/universe_utils/geometry/geometry.hpp"
-#include "autoware/universe_utils/system/time_keeper.hpp"
+#include "autoware_utils/geometry/geometry.hpp"
+#include "autoware_utils/system/time_keeper.hpp"
 #include "autoware/velocity_smoother/smoother/smoother_base.hpp"
 
 #include "autoware_planning_msgs/msg/trajectory_point.hpp"
@@ -41,7 +41,7 @@ public:
   };
 
   explicit LinfPseudoJerkSmoother(
-    rclcpp::Node & node, const std::shared_ptr<autoware::universe_utils::TimeKeeper> time_keeper);
+    rclcpp::Node & node, const std::shared_ptr<autoware_utils::TimeKeeper> time_keeper);
 
   bool apply(
     const double initial_vel, const double initial_acc, const TrajectoryPoints & input,

--- a/planning/autoware_velocity_smoother/include/autoware/velocity_smoother/smoother/linf_pseudo_jerk_smoother.hpp
+++ b/planning/autoware_velocity_smoother/include/autoware/velocity_smoother/smoother/linf_pseudo_jerk_smoother.hpp
@@ -17,9 +17,9 @@
 
 #include "autoware/motion_utils/trajectory/trajectory.hpp"
 #include "autoware/osqp_interface/osqp_interface.hpp"
+#include "autoware/velocity_smoother/smoother/smoother_base.hpp"
 #include "autoware_utils/geometry/geometry.hpp"
 #include "autoware_utils/system/time_keeper.hpp"
-#include "autoware/velocity_smoother/smoother/smoother_base.hpp"
 
 #include "autoware_planning_msgs/msg/trajectory_point.hpp"
 

--- a/planning/autoware_velocity_smoother/include/autoware/velocity_smoother/smoother/smoother_base.hpp
+++ b/planning/autoware_velocity_smoother/include/autoware/velocity_smoother/smoother/smoother_base.hpp
@@ -15,8 +15,8 @@
 #ifndef AUTOWARE__VELOCITY_SMOOTHER__SMOOTHER__SMOOTHER_BASE_HPP_
 #define AUTOWARE__VELOCITY_SMOOTHER__SMOOTHER__SMOOTHER_BASE_HPP_
 
-#include "autoware_utils/system/time_keeper.hpp"
 #include "autoware/velocity_smoother/resample.hpp"
+#include "autoware_utils/system/time_keeper.hpp"
 #include "rclcpp/rclcpp.hpp"
 
 #include "autoware_planning_msgs/msg/trajectory_point.hpp"

--- a/planning/autoware_velocity_smoother/include/autoware/velocity_smoother/smoother/smoother_base.hpp
+++ b/planning/autoware_velocity_smoother/include/autoware/velocity_smoother/smoother/smoother_base.hpp
@@ -15,7 +15,7 @@
 #ifndef AUTOWARE__VELOCITY_SMOOTHER__SMOOTHER__SMOOTHER_BASE_HPP_
 #define AUTOWARE__VELOCITY_SMOOTHER__SMOOTHER__SMOOTHER_BASE_HPP_
 
-#include "autoware/universe_utils/system/time_keeper.hpp"
+#include "autoware_utils/system/time_keeper.hpp"
 #include "autoware/velocity_smoother/resample.hpp"
 #include "rclcpp/rclcpp.hpp"
 
@@ -57,7 +57,7 @@ public:
   };
 
   explicit SmootherBase(
-    rclcpp::Node & node, const std::shared_ptr<autoware::universe_utils::TimeKeeper> time_keeper);
+    rclcpp::Node & node, const std::shared_ptr<autoware_utils::TimeKeeper> time_keeper);
   virtual ~SmootherBase() = default;
   virtual bool apply(
     const double initial_vel, const double initial_acc, const TrajectoryPoints & input,
@@ -91,7 +91,7 @@ public:
 
 protected:
   BaseParam base_param_;
-  mutable std::shared_ptr<autoware::universe_utils::TimeKeeper> time_keeper_{nullptr};
+  mutable std::shared_ptr<autoware_utils::TimeKeeper> time_keeper_{nullptr};
 };
 }  // namespace autoware::velocity_smoother
 

--- a/planning/autoware_velocity_smoother/package.xml
+++ b/planning/autoware_velocity_smoother/package.xml
@@ -28,7 +28,7 @@
   <depend>autoware_planning_msgs</depend>
   <depend>autoware_planning_test_manager</depend>
   <depend>autoware_qp_interface</depend>
-  <depend>autoware_universe_utils</depend>
+  <depend>autoware_utils</depend>
   <depend>autoware_vehicle_info_utils</depend>
   <depend>geometry_msgs</depend>
   <depend>nav_msgs</depend>

--- a/planning/autoware_velocity_smoother/package.xml
+++ b/planning/autoware_velocity_smoother/package.xml
@@ -22,6 +22,7 @@
   <buildtool_depend>eigen3_cmake_module</buildtool_depend>
 
   <depend>autoware_internal_debug_msgs</depend>
+  <depend>autoware_internal_planning_msgs</depend>
   <depend>autoware_interpolation</depend>
   <depend>autoware_motion_utils</depend>
   <depend>autoware_osqp_interface</depend>
@@ -35,7 +36,6 @@
   <depend>rclcpp</depend>
   <depend>tf2</depend>
   <depend>tf2_ros</depend>
-  <depend>autoware_internal_planning_msgs</depend>
 
   <test_depend>ament_cmake_ros</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/planning/autoware_velocity_smoother/package.xml
+++ b/planning/autoware_velocity_smoother/package.xml
@@ -35,7 +35,7 @@
   <depend>rclcpp</depend>
   <depend>tf2</depend>
   <depend>tf2_ros</depend>
-  <depend>tier4_planning_msgs</depend>
+  <depend>autoware_internal_planning_msgs</depend>
 
   <test_depend>ament_cmake_ros</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/planning/autoware_velocity_smoother/src/node.cpp
+++ b/planning/autoware_velocity_smoother/src/node.cpp
@@ -15,7 +15,7 @@
 #include "autoware/velocity_smoother/node.hpp"
 
 #include "autoware/motion_utils/marker/marker_helper.hpp"
-#include "autoware/universe_utils/ros/update_param.hpp"
+#include "autoware_utils/ros/update_param.hpp"
 #include "autoware/velocity_smoother/smoother/jerk_filtered_smoother.hpp"
 #include "autoware/velocity_smoother/smoother/l2_pseudo_jerk_smoother.hpp"
 #include "autoware/velocity_smoother/smoother/linf_pseudo_jerk_smoother.hpp"
@@ -50,10 +50,10 @@ VelocitySmootherNode::VelocitySmootherNode(const rclcpp::NodeOptions & node_opti
 
   // create time_keeper and its publisher
   // NOTE: This has to be called before setupSmoother to pass the time_keeper to the smoother.
-  debug_processing_time_detail_ = create_publisher<autoware::universe_utils::ProcessingTimeDetail>(
+  debug_processing_time_detail_ = create_publisher<autoware_utils::ProcessingTimeDetail>(
     "~/debug/processing_time_detail_ms", 1);
   time_keeper_ =
-    std::make_shared<autoware::universe_utils::TimeKeeper>(debug_processing_time_detail_);
+    std::make_shared<autoware_utils::TimeKeeper>(debug_processing_time_detail_);
 
   // create smoother
   setupSmoother(wheelbase_);
@@ -98,9 +98,9 @@ VelocitySmootherNode::VelocitySmootherNode(const rclcpp::NodeOptions & node_opti
 
   clock_ = get_clock();
 
-  logger_configure_ = std::make_unique<autoware::universe_utils::LoggerLevelConfigure>(this);
+  logger_configure_ = std::make_unique<autoware_utils::LoggerLevelConfigure>(this);
   published_time_publisher_ =
-    std::make_unique<autoware::universe_utils::PublishedTimePublisher>(this);
+    std::make_unique<autoware_utils::PublishedTimePublisher>(this);
 }
 
 void VelocitySmootherNode::setupSmoother(const double wheelbase)
@@ -317,7 +317,7 @@ void VelocitySmootherNode::publishTrajectory(const TrajectoryPoints & trajectory
 
 void VelocitySmootherNode::calcExternalVelocityLimit()
 {
-  autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_);
+  autoware_utils::ScopedTimeTrack st(__func__, *time_keeper_);
 
   if (!external_velocity_limit_ptr_) {
     external_velocity_limit_.acceleration_request.request = false;
@@ -439,7 +439,7 @@ bool VelocitySmootherNode::checkData() const
 
 void VelocitySmootherNode::onCurrentTrajectory(const Trajectory::ConstSharedPtr msg)
 {
-  autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_);
+  autoware_utils::ScopedTimeTrack st(__func__, *time_keeper_);
 
   RCLCPP_DEBUG(get_logger(), "========================= run start =========================");
   stop_watch_.tic();
@@ -448,10 +448,10 @@ void VelocitySmootherNode::onCurrentTrajectory(const Trajectory::ConstSharedPtr 
   base_traj_raw_ptr_ = msg;
 
   // receive data
-  current_odometry_ptr_ = sub_current_odometry_.takeData();
-  current_acceleration_ptr_ = sub_current_acceleration_.takeData();
-  external_velocity_limit_ptr_ = sub_external_velocity_limit_.takeData();
-  const auto operation_mode_ptr = sub_operation_mode_.takeData();
+  current_odometry_ptr_ = sub_current_odometry_.take_data();
+  current_acceleration_ptr_ = sub_current_acceleration_.take_data();
+  external_velocity_limit_ptr_ = sub_external_velocity_limit_.take_data();
+  const auto operation_mode_ptr = sub_operation_mode_.take_data();
   if (operation_mode_ptr) {
     operation_mode_ = *operation_mode_ptr;
   }
@@ -534,7 +534,7 @@ void VelocitySmootherNode::onCurrentTrajectory(const Trajectory::ConstSharedPtr 
 
 void VelocitySmootherNode::updateDataForExternalVelocityLimit()
 {
-  autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_);
+  autoware_utils::ScopedTimeTrack st(__func__, *time_keeper_);
 
   if (prev_output_.empty()) {
     return;
@@ -553,7 +553,7 @@ void VelocitySmootherNode::updateDataForExternalVelocityLimit()
 TrajectoryPoints VelocitySmootherNode::calcTrajectoryVelocity(
   const TrajectoryPoints & traj_input) const
 {
-  autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_);
+  autoware_utils::ScopedTimeTrack st(__func__, *time_keeper_);
 
   TrajectoryPoints output{};  // velocity is optimized by qp solver
 
@@ -602,7 +602,7 @@ bool VelocitySmootherNode::smoothVelocity(
   const TrajectoryPoints & input, const size_t input_closest,
   TrajectoryPoints & traj_smoothed) const
 {
-  autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_);
+  autoware_utils::ScopedTimeTrack st(__func__, *time_keeper_);
 
   if (input.empty()) {
     return false;  // cannot apply smoothing
@@ -721,7 +721,7 @@ bool VelocitySmootherNode::smoothVelocity(
 void VelocitySmootherNode::insertBehindVelocity(
   const size_t output_closest, const InitializeType type, TrajectoryPoints & output) const
 {
-  autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_);
+  autoware_utils::ScopedTimeTrack st(__func__, *time_keeper_);
 
   const bool keep_closest_vel_for_behind =
     (type == InitializeType::EGO_VELOCITY || type == InitializeType::LARGE_DEVIATION_REPLAN ||
@@ -785,7 +785,7 @@ void VelocitySmootherNode::publishStopDistance(const TrajectoryPoints & trajecto
 std::pair<Motion, VelocitySmootherNode::InitializeType> VelocitySmootherNode::calcInitialMotion(
   const TrajectoryPoints & input_traj, const size_t input_closest) const
 {
-  autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_);
+  autoware_utils::ScopedTimeTrack st(__func__, *time_keeper_);
 
   const double vehicle_speed = std::fabs(current_odometry_ptr_->twist.twist.linear.x);
   const double vehicle_acceleration = current_acceleration_ptr_->accel.accel.linear.x;
@@ -873,7 +873,7 @@ std::pair<Motion, VelocitySmootherNode::InitializeType> VelocitySmootherNode::ca
 void VelocitySmootherNode::overwriteStopPoint(
   const TrajectoryPoints & input, TrajectoryPoints & output) const
 {
-  autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_);
+  autoware_utils::ScopedTimeTrack st(__func__, *time_keeper_);
 
   const auto stop_idx = autoware::motion_utils::searchZeroVelocityIndex(input);
   if (!stop_idx) {
@@ -917,7 +917,7 @@ void VelocitySmootherNode::overwriteStopPoint(
 
 void VelocitySmootherNode::applyExternalVelocityLimit(TrajectoryPoints & traj) const
 {
-  autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_);
+  autoware_utils::ScopedTimeTrack st(__func__, *time_keeper_);
 
   if (traj.size() < 1) {
     return;
@@ -958,7 +958,7 @@ void VelocitySmootherNode::applyExternalVelocityLimit(TrajectoryPoints & traj) c
 
 void VelocitySmootherNode::applyStopApproachingVelocity(TrajectoryPoints & traj) const
 {
-  autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_);
+  autoware_utils::ScopedTimeTrack st(__func__, *time_keeper_);
 
   const auto stop_idx = autoware::motion_utils::searchZeroVelocityIndex(traj);
   if (!stop_idx) {
@@ -966,7 +966,7 @@ void VelocitySmootherNode::applyStopApproachingVelocity(TrajectoryPoints & traj)
   }
   double distance_sum = 0.0;
   for (size_t i = *stop_idx - 1; i < traj.size(); --i) {  // search backward
-    distance_sum += autoware::universe_utils::calcDistance2d(traj.at(i), traj.at(i + 1));
+    distance_sum += autoware_utils::calc_distance2d(traj.at(i), traj.at(i + 1));
     if (distance_sum > node_param_.stopping_distance) {
       break;
     }
@@ -1076,7 +1076,7 @@ double VelocitySmootherNode::calcTravelDistance() const
 
   if (prev_closest_point_) {
     const double travel_dist =
-      autoware::universe_utils::calcDistance2d(*prev_closest_point_, closest_point);
+      autoware_utils::calc_distance2d(*prev_closest_point_, closest_point);
     return travel_dist;
   }
 

--- a/planning/autoware_velocity_smoother/src/node.cpp
+++ b/planning/autoware_velocity_smoother/src/node.cpp
@@ -15,10 +15,10 @@
 #include "autoware/velocity_smoother/node.hpp"
 
 #include "autoware/motion_utils/marker/marker_helper.hpp"
-#include "autoware_utils/ros/update_param.hpp"
 #include "autoware/velocity_smoother/smoother/jerk_filtered_smoother.hpp"
 #include "autoware/velocity_smoother/smoother/l2_pseudo_jerk_smoother.hpp"
 #include "autoware/velocity_smoother/smoother/linf_pseudo_jerk_smoother.hpp"
+#include "autoware_utils/ros/update_param.hpp"
 
 #include <autoware_vehicle_info_utils/vehicle_info_utils.hpp>
 
@@ -50,10 +50,9 @@ VelocitySmootherNode::VelocitySmootherNode(const rclcpp::NodeOptions & node_opti
 
   // create time_keeper and its publisher
   // NOTE: This has to be called before setupSmoother to pass the time_keeper to the smoother.
-  debug_processing_time_detail_ = create_publisher<autoware_utils::ProcessingTimeDetail>(
-    "~/debug/processing_time_detail_ms", 1);
-  time_keeper_ =
-    std::make_shared<autoware_utils::TimeKeeper>(debug_processing_time_detail_);
+  debug_processing_time_detail_ =
+    create_publisher<autoware_utils::ProcessingTimeDetail>("~/debug/processing_time_detail_ms", 1);
+  time_keeper_ = std::make_shared<autoware_utils::TimeKeeper>(debug_processing_time_detail_);
 
   // create smoother
   setupSmoother(wheelbase_);
@@ -99,8 +98,7 @@ VelocitySmootherNode::VelocitySmootherNode(const rclcpp::NodeOptions & node_opti
   clock_ = get_clock();
 
   logger_configure_ = std::make_unique<autoware_utils::LoggerLevelConfigure>(this);
-  published_time_publisher_ =
-    std::make_unique<autoware_utils::PublishedTimePublisher>(this);
+  published_time_publisher_ = std::make_unique<autoware_utils::PublishedTimePublisher>(this);
 }
 
 void VelocitySmootherNode::setupSmoother(const double wheelbase)
@@ -1075,8 +1073,7 @@ double VelocitySmootherNode::calcTravelDistance() const
   const auto closest_point = calcProjectedTrajectoryPointFromEgo(prev_output_);
 
   if (prev_closest_point_) {
-    const double travel_dist =
-      autoware_utils::calc_distance2d(*prev_closest_point_, closest_point);
+    const double travel_dist = autoware_utils::calc_distance2d(*prev_closest_point_, closest_point);
     return travel_dist;
   }
 

--- a/planning/autoware_velocity_smoother/src/resample.cpp
+++ b/planning/autoware_velocity_smoother/src/resample.cpp
@@ -17,8 +17,8 @@
 #include "autoware/motion_utils/resample/resample.hpp"
 #include "autoware/motion_utils/trajectory/conversion.hpp"
 #include "autoware/motion_utils/trajectory/trajectory.hpp"
-#include "autoware_utils/geometry/geometry.hpp"
 #include "autoware/velocity_smoother/trajectory_utils.hpp"
+#include "autoware_utils/geometry/geometry.hpp"
 
 #include <algorithm>
 #include <vector>

--- a/planning/autoware_velocity_smoother/src/resample.cpp
+++ b/planning/autoware_velocity_smoother/src/resample.cpp
@@ -17,7 +17,7 @@
 #include "autoware/motion_utils/resample/resample.hpp"
 #include "autoware/motion_utils/trajectory/conversion.hpp"
 #include "autoware/motion_utils/trajectory/trajectory.hpp"
-#include "autoware/universe_utils/geometry/geometry.hpp"
+#include "autoware_utils/geometry/geometry.hpp"
 #include "autoware/velocity_smoother/trajectory_utils.hpp"
 
 #include <algorithm>
@@ -136,7 +136,7 @@ TrajectoryPoints resampleTrajectory(
   // add end point directly to consider the endpoint velocity.
   if (is_endpoint_included) {
     constexpr double ep_dist = 1.0E-3;
-    if (autoware::universe_utils::calcDistance2d(output.back(), input.back()) < ep_dist) {
+    if (autoware_utils::calc_distance2d(output.back(), input.back()) < ep_dist) {
       output.back() = input.back();
     } else {
       output.push_back(input.back());
@@ -256,7 +256,7 @@ TrajectoryPoints resampleTrajectory(
   // add end point directly to consider the endpoint velocity.
   if (is_endpoint_included) {
     constexpr double ep_dist = 1.0E-3;
-    if (autoware::universe_utils::calcDistance2d(output.back(), input.back()) < ep_dist) {
+    if (autoware_utils::calc_distance2d(output.back(), input.back()) < ep_dist) {
       output.back() = input.back();
     } else {
       output.push_back(input.back());

--- a/planning/autoware_velocity_smoother/src/smoother/analytical_jerk_constrained_smoother/analytical_jerk_constrained_smoother.cpp
+++ b/planning/autoware_velocity_smoother/src/smoother/analytical_jerk_constrained_smoother/analytical_jerk_constrained_smoother.cpp
@@ -16,7 +16,6 @@
 
 #include "autoware/motion_utils/resample/resample.hpp"
 #include "autoware/motion_utils/trajectory/conversion.hpp"
-#include "autoware/universe_utils/geometry/geometry.hpp"
 #include "autoware/velocity_smoother/trajectory_utils.hpp"
 
 #include <algorithm>
@@ -69,7 +68,7 @@ bool applyMaxVelocity(
 namespace autoware::velocity_smoother
 {
 AnalyticalJerkConstrainedSmoother::AnalyticalJerkConstrainedSmoother(
-  rclcpp::Node & node, const std::shared_ptr<autoware::universe_utils::TimeKeeper> time_keeper)
+  rclcpp::Node & node, const std::shared_ptr<autoware_utils::TimeKeeper> time_keeper)
 : SmootherBase(node, time_keeper)
 {
   auto & p = smoother_param_;
@@ -256,7 +255,7 @@ TrajectoryPoints AnalyticalJerkConstrainedSmoother::resampleTrajectory(
     const auto tp1 = input.at(i + 1);
 
     const double dist_thr = 0.001;  // 1mm
-    const double dist_tp0_tp1 = autoware::universe_utils::calcDistance2d(tp0, tp1);
+    const double dist_tp0_tp1 = autoware_utils::calc_distance2d(tp0, tp1);
     if (std::fabs(dist_tp0_tp1) < dist_thr) {
       output.push_back(input.at(i));
       continue;
@@ -359,7 +358,7 @@ TrajectoryPoints AnalyticalJerkConstrainedSmoother::applyLateralAccelerationFilt
     }
 
     if (
-      autoware::universe_utils::calcDistance2d(output.at(end_index), output.at(index)) <
+      autoware_utils::calc_distance2d(output.at(end_index), output.at(index)) <
       dist_threshold) {
       end_index = index;
       min_latacc_velocity = std::min(
@@ -445,7 +444,7 @@ bool AnalyticalJerkConstrainedSmoother::applyForwardJerkFilter(
   for (size_t i = start_index + 1; i < base_trajectory.size(); ++i) {
     const double prev_vel = output_trajectory.at(i - 1).longitudinal_velocity_mps;
     const double ds =
-      autoware::universe_utils::calcDistance2d(base_trajectory.at(i - 1), base_trajectory.at(i));
+      autoware_utils::calc_distance2d(base_trajectory.at(i - 1), base_trajectory.at(i));
     const double dt = ds / std::max(prev_vel, 1.0);
 
     const double prev_acc = output_trajectory.at(i - 1).acceleration_mps2;
@@ -491,7 +490,7 @@ bool AnalyticalJerkConstrainedSmoother::applyBackwardDecelFilter(
       }
     }
     for (size_t i = decel_target_index; i > start_index; --i) {
-      dist += autoware::universe_utils::calcDistance2d(
+      dist += autoware_utils::calc_distance2d(
         output_trajectory.at(i - 1), output_trajectory.at(i));
       dist_to_target.at(i - 1) = dist;
     }

--- a/planning/autoware_velocity_smoother/src/smoother/analytical_jerk_constrained_smoother/analytical_jerk_constrained_smoother.cpp
+++ b/planning/autoware_velocity_smoother/src/smoother/analytical_jerk_constrained_smoother/analytical_jerk_constrained_smoother.cpp
@@ -357,9 +357,7 @@ TrajectoryPoints AnalyticalJerkConstrainedSmoother::applyLateralAccelerationFilt
       continue;
     }
 
-    if (
-      autoware_utils::calc_distance2d(output.at(end_index), output.at(index)) <
-      dist_threshold) {
+    if (autoware_utils::calc_distance2d(output.at(end_index), output.at(index)) < dist_threshold) {
       end_index = index;
       min_latacc_velocity = std::min(
         static_cast<double>(output.at(index).longitudinal_velocity_mps), min_latacc_velocity);
@@ -490,8 +488,7 @@ bool AnalyticalJerkConstrainedSmoother::applyBackwardDecelFilter(
       }
     }
     for (size_t i = decel_target_index; i > start_index; --i) {
-      dist += autoware_utils::calc_distance2d(
-        output_trajectory.at(i - 1), output_trajectory.at(i));
+      dist += autoware_utils::calc_distance2d(output_trajectory.at(i - 1), output_trajectory.at(i));
       dist_to_target.at(i - 1) = dist;
     }
 

--- a/planning/autoware_velocity_smoother/src/smoother/analytical_jerk_constrained_smoother/velocity_planning_utils.cpp
+++ b/planning/autoware_velocity_smoother/src/smoother/analytical_jerk_constrained_smoother/velocity_planning_utils.cpp
@@ -15,7 +15,7 @@
 #include "autoware/velocity_smoother/smoother/analytical_jerk_constrained_smoother/velocity_planning_utils.hpp"
 
 #include "autoware/interpolation/linear_interpolation.hpp"
-#include "autoware/universe_utils/geometry/geometry.hpp"
+#include "autoware_utils/geometry/geometry.hpp"
 
 #include <algorithm>
 #include <vector>
@@ -226,7 +226,7 @@ bool calcStopVelocityWithConstantJerkAccLimit(
   std::vector<double> distances;
   distances.push_back(distance);
   for (size_t i = start_index; i < output_trajectory.size() - 1; ++i) {
-    distance += autoware::universe_utils::calcDistance2d(
+    distance += autoware_utils::calc_distance2d(
       output_trajectory.at(i), output_trajectory.at(i + 1));
     if (distance > xs.back()) {
       break;

--- a/planning/autoware_velocity_smoother/src/smoother/analytical_jerk_constrained_smoother/velocity_planning_utils.cpp
+++ b/planning/autoware_velocity_smoother/src/smoother/analytical_jerk_constrained_smoother/velocity_planning_utils.cpp
@@ -226,8 +226,8 @@ bool calcStopVelocityWithConstantJerkAccLimit(
   std::vector<double> distances;
   distances.push_back(distance);
   for (size_t i = start_index; i < output_trajectory.size() - 1; ++i) {
-    distance += autoware_utils::calc_distance2d(
-      output_trajectory.at(i), output_trajectory.at(i + 1));
+    distance +=
+      autoware_utils::calc_distance2d(output_trajectory.at(i), output_trajectory.at(i + 1));
     if (distance > xs.back()) {
       break;
     }

--- a/planning/autoware_velocity_smoother/src/smoother/jerk_filtered_smoother.cpp
+++ b/planning/autoware_velocity_smoother/src/smoother/jerk_filtered_smoother.cpp
@@ -449,8 +449,8 @@ TrajectoryPoints JerkFilteredSmoother::mergeFilteredTrajectory(
       merged.at(i).longitudinal_velocity_mps = current_vel;
       merged.at(i).acceleration_mps2 = current_acc;
 
-      const double ds = autoware_utils::calc_distance2d(
-        forward_filtered.at(i + 1), forward_filtered.at(i));
+      const double ds =
+        autoware_utils::calc_distance2d(forward_filtered.at(i + 1), forward_filtered.at(i));
       const double max_dt =
         std::pow(6.0 * ds / std::fabs(j_min), 1.0 / 3.0);  // assuming v0 = a0 = 0.
       const double dt = std::min(ds / std::max(current_vel, 1.0e-6), max_dt);

--- a/planning/autoware_velocity_smoother/src/smoother/jerk_filtered_smoother.cpp
+++ b/planning/autoware_velocity_smoother/src/smoother/jerk_filtered_smoother.cpp
@@ -33,7 +33,7 @@
 namespace autoware::velocity_smoother
 {
 JerkFilteredSmoother::JerkFilteredSmoother(
-  rclcpp::Node & node, const std::shared_ptr<autoware::universe_utils::TimeKeeper> time_keeper)
+  rclcpp::Node & node, const std::shared_ptr<autoware_utils::TimeKeeper> time_keeper)
 : SmootherBase(node, time_keeper)
 {
   auto & p = smoother_param_;
@@ -61,7 +61,7 @@ bool JerkFilteredSmoother::apply(
   const double v0, const double a0, const TrajectoryPoints & input, TrajectoryPoints & output,
   std::vector<TrajectoryPoints> & debug_trajectories, const bool publish_debug_trajs)
 {
-  autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_);
+  autoware_utils::ScopedTimeTrack st(__func__, *time_keeper_);
 
   output = input;
 
@@ -106,7 +106,7 @@ bool JerkFilteredSmoother::apply(
   const auto initial_traj_pose = filtered.front().pose;
 
   const auto resample = [&](const auto & trajectory) {
-    autoware::universe_utils::ScopedTimeTrack st("resample", *time_keeper_);
+    autoware_utils::ScopedTimeTrack st("resample", *time_keeper_);
 
     return resampling::resampleTrajectory(
       trajectory, v0, initial_traj_pose, std::numeric_limits<double>::max(),
@@ -360,7 +360,7 @@ TrajectoryPoints JerkFilteredSmoother::forwardJerkFilter(
   const double v0, const double a0, const double a_max, const double a_start, const double j_max,
   const TrajectoryPoints & input) const
 {
-  autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_);
+  autoware_utils::ScopedTimeTrack st(__func__, *time_keeper_);
 
   auto applyLimits = [&input, &a_start](double & v, double & a, size_t i) {
     double v_lim = input.at(i).longitudinal_velocity_mps;
@@ -391,7 +391,7 @@ TrajectoryPoints JerkFilteredSmoother::forwardJerkFilter(
   output.front().longitudinal_velocity_mps = current_vel;
   output.front().acceleration_mps2 = current_acc;
   for (size_t i = 1; i < input.size(); ++i) {
-    const double ds = autoware::universe_utils::calcDistance2d(input.at(i), input.at(i - 1));
+    const double ds = autoware_utils::calc_distance2d(input.at(i), input.at(i - 1));
     const double max_dt = std::pow(6.0 * ds / j_max, 1.0 / 3.0);  // assuming v0 = a0 = 0.
     const double dt = std::min(ds / std::max(current_vel, 1.0e-6), max_dt);
 
@@ -414,7 +414,7 @@ TrajectoryPoints JerkFilteredSmoother::backwardJerkFilter(
   const double v0, const double a0, const double a_min, const double a_stop, const double j_min,
   const TrajectoryPoints & input) const
 {
-  autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_);
+  autoware_utils::ScopedTimeTrack st(__func__, *time_keeper_);
 
   auto input_rev = input;
   std::reverse(input_rev.begin(), input_rev.end());
@@ -431,7 +431,7 @@ TrajectoryPoints JerkFilteredSmoother::mergeFilteredTrajectory(
   const double v0, const double a0, const double a_min, const double j_min,
   const TrajectoryPoints & forward_filtered, const TrajectoryPoints & backward_filtered) const
 {
-  autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_);
+  autoware_utils::ScopedTimeTrack st(__func__, *time_keeper_);
 
   TrajectoryPoints merged;
   merged = forward_filtered;
@@ -449,7 +449,7 @@ TrajectoryPoints JerkFilteredSmoother::mergeFilteredTrajectory(
       merged.at(i).longitudinal_velocity_mps = current_vel;
       merged.at(i).acceleration_mps2 = current_acc;
 
-      const double ds = autoware::universe_utils::calcDistance2d(
+      const double ds = autoware_utils::calc_distance2d(
         forward_filtered.at(i + 1), forward_filtered.at(i));
       const double max_dt =
         std::pow(6.0 * ds / std::fabs(j_min), 1.0 / 3.0);  // assuming v0 = a0 = 0.
@@ -485,7 +485,7 @@ TrajectoryPoints JerkFilteredSmoother::resampleTrajectory(
   const geometry_msgs::msg::Pose & current_pose, const double nearest_dist_threshold,
   const double nearest_yaw_threshold) const
 {
-  autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_);
+  autoware_utils::ScopedTimeTrack st(__func__, *time_keeper_);
 
   return resampling::resampleTrajectory(
     input, current_pose, nearest_dist_threshold, nearest_yaw_threshold, base_param_.resample_param,

--- a/planning/autoware_velocity_smoother/src/smoother/l2_pseudo_jerk_smoother.cpp
+++ b/planning/autoware_velocity_smoother/src/smoother/l2_pseudo_jerk_smoother.cpp
@@ -27,7 +27,7 @@
 namespace autoware::velocity_smoother
 {
 L2PseudoJerkSmoother::L2PseudoJerkSmoother(
-  rclcpp::Node & node, const std::shared_ptr<autoware::universe_utils::TimeKeeper> time_keeper)
+  rclcpp::Node & node, const std::shared_ptr<autoware_utils::TimeKeeper> time_keeper)
 : SmootherBase(node, time_keeper)
 {
   auto & p = smoother_param_;

--- a/planning/autoware_velocity_smoother/src/smoother/linf_pseudo_jerk_smoother.cpp
+++ b/planning/autoware_velocity_smoother/src/smoother/linf_pseudo_jerk_smoother.cpp
@@ -27,7 +27,7 @@
 namespace autoware::velocity_smoother
 {
 LinfPseudoJerkSmoother::LinfPseudoJerkSmoother(
-  rclcpp::Node & node, const std::shared_ptr<autoware::universe_utils::TimeKeeper> time_keeper)
+  rclcpp::Node & node, const std::shared_ptr<autoware_utils::TimeKeeper> time_keeper)
 : SmootherBase(node, time_keeper)
 {
   auto & p = smoother_param_;

--- a/planning/autoware_velocity_smoother/src/smoother/smoother_base.cpp
+++ b/planning/autoware_velocity_smoother/src/smoother/smoother_base.cpp
@@ -17,10 +17,10 @@
 #include "autoware/motion_utils/resample/resample.hpp"
 #include "autoware/motion_utils/trajectory/conversion.hpp"
 #include "autoware/motion_utils/trajectory/trajectory.hpp"
-#include "autoware_utils/geometry/geometry.hpp"
-#include "autoware_utils/math/unit_conversion.hpp"
 #include "autoware/velocity_smoother/resample.hpp"
 #include "autoware/velocity_smoother/trajectory_utils.hpp"
+#include "autoware_utils/geometry/geometry.hpp"
+#include "autoware_utils/math/unit_conversion.hpp"
 
 #include <algorithm>
 #include <cmath>
@@ -274,8 +274,7 @@ TrajectoryPoints SmootherBase::applySteeringRateLimit(
     const auto mean_vel =
       (output.at(i).longitudinal_velocity_mps + output.at(i + 1).longitudinal_velocity_mps) / 2.0;
     const auto target_mean_vel =
-      mean_vel *
-      (autoware_utils::deg2rad(base_param_.max_steering_angle_rate) / steer_rate);
+      mean_vel * (autoware_utils::deg2rad(base_param_.max_steering_angle_rate) / steer_rate);
 
     for (size_t k = 0; k < 2; k++) {
       auto & velocity = output.at(i + k).longitudinal_velocity_mps;

--- a/planning/autoware_velocity_smoother/src/smoother/smoother_base.cpp
+++ b/planning/autoware_velocity_smoother/src/smoother/smoother_base.cpp
@@ -17,8 +17,8 @@
 #include "autoware/motion_utils/resample/resample.hpp"
 #include "autoware/motion_utils/trajectory/conversion.hpp"
 #include "autoware/motion_utils/trajectory/trajectory.hpp"
-#include "autoware/universe_utils/geometry/geometry.hpp"
-#include "autoware/universe_utils/math/unit_conversion.hpp"
+#include "autoware_utils/geometry/geometry.hpp"
+#include "autoware_utils/math/unit_conversion.hpp"
 #include "autoware/velocity_smoother/resample.hpp"
 #include "autoware/velocity_smoother/trajectory_utils.hpp"
 
@@ -63,7 +63,7 @@ TrajectoryPoints applyPreProcess(
 }  // namespace
 
 SmootherBase::SmootherBase(
-  rclcpp::Node & node, const std::shared_ptr<autoware::universe_utils::TimeKeeper> time_keeper)
+  rclcpp::Node & node, const std::shared_ptr<autoware_utils::TimeKeeper> time_keeper)
 : time_keeper_(time_keeper)
 {
   auto & p = base_param_;
@@ -144,7 +144,7 @@ TrajectoryPoints SmootherBase::applyLateralAccelerationFilter(
   [[maybe_unused]] const double a0, [[maybe_unused]] const bool enable_smooth_limit,
   const bool use_resampling, const double input_points_interval) const
 {
-  autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_);
+  autoware_utils::ScopedTimeTrack st(__func__, *time_keeper_);
 
   if (input.size() < 3) {
     return input;  // cannot calculate lateral acc. do nothing.
@@ -214,7 +214,7 @@ TrajectoryPoints SmootherBase::applySteeringRateLimit(
   const TrajectoryPoints & input, const bool use_resampling,
   const double input_points_interval) const
 {
-  autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_);
+  autoware_utils::ScopedTimeTrack st(__func__, *time_keeper_);
 
   if (input.size() < 3) {
     return input;  // cannot calculate the desired velocity. do nothing.
@@ -267,7 +267,7 @@ TrajectoryPoints SmootherBase::applySteeringRateLimit(
     }
 
     const auto steer_rate = steer_rate_arr.at(i);
-    if (steer_rate < autoware::universe_utils::deg2rad(base_param_.max_steering_angle_rate)) {
+    if (steer_rate < autoware_utils::deg2rad(base_param_.max_steering_angle_rate)) {
       continue;
     }
 
@@ -275,7 +275,7 @@ TrajectoryPoints SmootherBase::applySteeringRateLimit(
       (output.at(i).longitudinal_velocity_mps + output.at(i + 1).longitudinal_velocity_mps) / 2.0;
     const auto target_mean_vel =
       mean_vel *
-      (autoware::universe_utils::deg2rad(base_param_.max_steering_angle_rate) / steer_rate);
+      (autoware_utils::deg2rad(base_param_.max_steering_angle_rate) / steer_rate);
 
     for (size_t k = 0; k < 2; k++) {
       auto & velocity = output.at(i + k).longitudinal_velocity_mps;

--- a/planning/autoware_velocity_smoother/src/trajectory_utils.cpp
+++ b/planning/autoware_velocity_smoother/src/trajectory_utils.cpp
@@ -16,7 +16,7 @@
 
 #include "autoware/interpolation/linear_interpolation.hpp"
 #include "autoware/motion_utils/trajectory/trajectory.hpp"
-#include "autoware/universe_utils/geometry/geometry.hpp"
+#include "autoware_utils/geometry/geometry.hpp"
 
 #include <algorithm>
 #include <limits>
@@ -34,7 +34,7 @@ inline void convertEulerAngleToMonotonic(std::vector<double> & a)
 {
   for (unsigned int i = 1; i < a.size(); ++i) {
     const double da = a[i] - a[i - 1];
-    a[i] = a[i - 1] + autoware::universe_utils::normalizeRadian(da);
+    a[i] = a[i - 1] + autoware_utils::normalize_radian(da);
   }
 }
 
@@ -87,7 +87,7 @@ TrajectoryPoint calcInterpolatedTrajectoryPoint(
   {
     const auto & seg_pt = trajectory.at(seg_idx);
     const auto & next_pt = trajectory.at(seg_idx + 1);
-    traj_p.pose = autoware::universe_utils::calcInterpolatedPose(seg_pt.pose, next_pt.pose, prop);
+    traj_p.pose = autoware_utils::calc_interpolated_pose(seg_pt.pose, next_pt.pose, prop);
     traj_p.longitudinal_velocity_mps = autoware::interpolation::lerp(
       seg_pt.longitudinal_velocity_mps, next_pt.longitudinal_velocity_mps, prop);
     traj_p.acceleration_mps2 =
@@ -110,7 +110,7 @@ TrajectoryPoints extractPathAroundIndex(
   {
     double dist_sum = 0.0;
     for (size_t i = index; i < trajectory.size() - 1; ++i) {
-      dist_sum += autoware::universe_utils::calcDistance2d(trajectory.at(i), trajectory.at(i + 1));
+      dist_sum += autoware_utils::calc_distance2d(trajectory.at(i), trajectory.at(i + 1));
       if (dist_sum > ahead_length) {
         ahead_index = i + 1;
         break;
@@ -123,7 +123,7 @@ TrajectoryPoints extractPathAroundIndex(
   {
     double dist_sum{0.0};
     for (size_t i = index; i != 0; --i) {
-      dist_sum += autoware::universe_utils::calcDistance2d(trajectory.at(i), trajectory[i - 1]);
+      dist_sum += autoware_utils::calc_distance2d(trajectory.at(i), trajectory[i - 1]);
       if (dist_sum > behind_length) {
         behind_index = i - 1;
         break;
@@ -152,7 +152,7 @@ std::vector<double> calcArclengthArray(const TrajectoryPoints & trajectory)
   for (unsigned int i = 1; i < trajectory.size(); ++i) {
     const TrajectoryPoint tp = trajectory.at(i);
     const TrajectoryPoint tp_prev = trajectory.at(i - 1);
-    dist += autoware::universe_utils::calcDistance2d(tp.pose, tp_prev.pose);
+    dist += autoware_utils::calc_distance2d(tp.pose, tp_prev.pose);
     arclength.at(i) = dist;
   }
   return arclength;
@@ -164,7 +164,7 @@ std::vector<double> calcTrajectoryIntervalDistance(const TrajectoryPoints & traj
   for (unsigned int i = 1; i < trajectory.size(); ++i) {
     const TrajectoryPoint tp = trajectory.at(i);
     const TrajectoryPoint tp_prev = trajectory.at(i - 1);
-    const double dist = autoware::universe_utils::calcDistance2d(tp.pose, tp_prev.pose);
+    const double dist = autoware_utils::calc_distance2d(tp.pose, tp_prev.pose);
     intervals.push_back(dist);
   }
   return intervals;
@@ -173,8 +173,8 @@ std::vector<double> calcTrajectoryIntervalDistance(const TrajectoryPoints & traj
 std::vector<double> calcTrajectoryCurvatureFrom3Points(
   const TrajectoryPoints & trajectory, size_t idx_dist)
 {
-  using autoware::universe_utils::calcCurvature;
-  using autoware::universe_utils::getPoint;
+  using autoware_utils::calc_curvature;
+  using autoware_utils::get_point;
 
   if (trajectory.size() < 3) {
     const std::vector<double> k_arr(trajectory.size(), 0.0);
@@ -194,11 +194,11 @@ std::vector<double> calcTrajectoryCurvatureFrom3Points(
 
   for (size_t i = 1; i + 1 < trajectory.size(); i++) {
     double curvature = 0.0;
-    const auto p0 = getPoint(trajectory.at(i - std::min(idx_dist, i)));
-    const auto p1 = getPoint(trajectory.at(i));
-    const auto p2 = getPoint(trajectory.at(i + std::min(idx_dist, trajectory.size() - 1 - i)));
+    const auto p0 = get_point(trajectory.at(i - std::min(idx_dist, i)));
+    const auto p1 = get_point(trajectory.at(i));
+    const auto p2 = get_point(trajectory.at(i + std::min(idx_dist, trajectory.size() - 1 - i)));
     try {
-      curvature = calcCurvature(p0, p1, p2);
+      curvature = calc_curvature(p0, p1, p2);
     } catch (std::exception const & e) {
       // ...code that handles the error...
       RCLCPP_WARN(
@@ -466,7 +466,7 @@ double calcStopDistance(const TrajectoryPoints & trajectory, const size_t closes
 
   // TODO(Horibe): use arc length distance
   const double stop_dist =
-    autoware::universe_utils::calcDistance2d(trajectory.at(*idx), trajectory.at(closest));
+    autoware_utils::calc_distance2d(trajectory.at(*idx), trajectory.at(closest));
 
   return stop_dist;
 }

--- a/planning/autoware_velocity_smoother/test/test_velocity_smoother_node_interface.cpp
+++ b/planning/autoware_velocity_smoother/test/test_velocity_smoother_node_interface.cpp
@@ -64,7 +64,7 @@ void publishMandatoryTopics(
     test_target_node, "/localization/kinematic_state", autoware::test_utils::makeOdometry());
   test_manager->publishInput(
     test_target_node, "velocity_smoother/input/external_velocity_limit_mps",
-    tier4_planning_msgs::msg::VelocityLimit{});
+    autoware_internal_planning_msgs::msg::VelocityLimit{});
   test_manager->publishInput(
     test_target_node, "velocity_smoother/input/operation_mode_state",
     autoware_adapi_v1_msgs::msg::OperationModeState{});

--- a/planning/behavior_path_planner/autoware_behavior_path_planner/include/autoware/behavior_path_planner/behavior_path_planner_node.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner/include/autoware/behavior_path_planner/behavior_path_planner_node.hpp
@@ -27,6 +27,7 @@
 
 #include <autoware_adapi_v1_msgs/msg/operation_mode_state.hpp>
 #include <autoware_internal_planning_msgs/msg/path_with_lane_id.hpp>
+#include <autoware_internal_planning_msgs/msg/velocity_limit.hpp>
 #include <autoware_map_msgs/msg/lanelet_map_bin.hpp>
 #include <autoware_perception_msgs/msg/predicted_objects.hpp>
 #include <autoware_planning_msgs/msg/lanelet_route.hpp>
@@ -43,7 +44,6 @@
 #include <tier4_planning_msgs/msg/scenario.hpp>
 #include <tier4_planning_msgs/msg/velocity_limit.hpp>
 #include <visualization_msgs/msg/marker.hpp>
-#include <autoware_internal_planning_msgs/msg/velocity_limit.hpp>
 
 #include <map>
 #include <memory>
@@ -114,7 +114,8 @@ private:
   autoware::universe_utils::InterProcessPollingSubscriber<OperationModeState>
     operation_mode_subscriber_{
       this, "/system/operation_mode/state", rclcpp::QoS{1}.transient_local()};
-  autoware::universe_utils::InterProcessPollingSubscriber<autoware_internal_planning_msgs::msg::VelocityLimit>
+  autoware::universe_utils::InterProcessPollingSubscriber<
+    autoware_internal_planning_msgs::msg::VelocityLimit>
     external_limit_max_velocity_subscriber_{this, "/planning/scenario_planning/max_velocity"};
 
   // publisher

--- a/planning/behavior_path_planner/autoware_behavior_path_planner/include/autoware/behavior_path_planner/behavior_path_planner_node.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner/include/autoware/behavior_path_planner/behavior_path_planner_node.hpp
@@ -43,6 +43,7 @@
 #include <tier4_planning_msgs/msg/scenario.hpp>
 #include <tier4_planning_msgs/msg/velocity_limit.hpp>
 #include <visualization_msgs/msg/marker.hpp>
+#include <autoware_internal_planning_msgs/msg/velocity_limit.hpp>
 
 #include <map>
 #include <memory>
@@ -113,7 +114,7 @@ private:
   autoware::universe_utils::InterProcessPollingSubscriber<OperationModeState>
     operation_mode_subscriber_{
       this, "/system/operation_mode/state", rclcpp::QoS{1}.transient_local()};
-  autoware::universe_utils::InterProcessPollingSubscriber<tier4_planning_msgs::msg::VelocityLimit>
+  autoware::universe_utils::InterProcessPollingSubscriber<autoware_internal_planning_msgs::msg::VelocityLimit>
     external_limit_max_velocity_subscriber_{this, "/planning/scenario_planning/max_velocity"};
 
   // publisher
@@ -158,7 +159,7 @@ private:
   void onOperationMode(const OperationModeState::ConstSharedPtr msg);
   void onLateralOffset(const LateralOffset::ConstSharedPtr msg);
   void on_external_velocity_limiter(
-    const tier4_planning_msgs::msg::VelocityLimit::ConstSharedPtr msg);
+    const autoware_internal_planning_msgs::msg::VelocityLimit::ConstSharedPtr msg);
 
   SetParametersResult onSetParam(const std::vector<rclcpp::Parameter> & parameters);
 

--- a/planning/behavior_path_planner/autoware_behavior_path_planner/package.xml
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner/package.xml
@@ -70,6 +70,7 @@
   <depend>tf2_ros</depend>
   <depend>tier4_planning_msgs</depend>
   <depend>visualization_msgs</depend>
+  <depend>autoware_internal_planning_msgs</depend>
 
   <test_depend>ament_cmake_ros</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/planning/behavior_path_planner/autoware_behavior_path_planner/package.xml
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner/package.xml
@@ -41,6 +41,7 @@
   <depend>autoware_freespace_planning_algorithms</depend>
   <depend>autoware_frenet_planner</depend>
   <depend>autoware_internal_debug_msgs</depend>
+  <depend>autoware_internal_planning_msgs</depend>
   <depend>autoware_interpolation</depend>
   <depend>autoware_lane_departure_checker</depend>
   <depend>autoware_lanelet2_extension</depend>
@@ -70,7 +71,6 @@
   <depend>tf2_ros</depend>
   <depend>tier4_planning_msgs</depend>
   <depend>visualization_msgs</depend>
-  <depend>autoware_internal_planning_msgs</depend>
 
   <test_depend>ament_cmake_ros</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/data_manager.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/data_manager.hpp
@@ -27,6 +27,7 @@
 #include <rclcpp/time.hpp>
 
 #include <autoware_adapi_v1_msgs/msg/operation_mode_state.hpp>
+#include <autoware_internal_planning_msgs/msg/detail/velocity_limit__struct.hpp>
 #include <autoware_internal_planning_msgs/msg/path_with_lane_id.hpp>
 #include <autoware_perception_msgs/msg/predicted_objects.hpp>
 #include <autoware_perception_msgs/msg/traffic_light_group_array.hpp>
@@ -39,7 +40,6 @@
 #include <nav_msgs/msg/occupancy_grid.hpp>
 #include <nav_msgs/msg/odometry.hpp>
 #include <tier4_planning_msgs/msg/lateral_offset.hpp>
-#include <autoware_internal_planning_msgs/msg/detail/velocity_limit__struct.hpp>
 
 #include <limits>
 #include <map>
@@ -65,8 +65,8 @@ using nav_msgs::msg::OccupancyGrid;
 using nav_msgs::msg::Odometry;
 using tier4_planning_msgs::msg::LateralOffset;
 using PlanResult = PathWithLaneId::SharedPtr;
-using lanelet::TrafficLight;
 using autoware_internal_planning_msgs::msg::VelocityLimit;
+using lanelet::TrafficLight;
 using unique_identifier_msgs::msg::UUID;
 
 struct TrafficSignalStamped

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/data_manager.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/data_manager.hpp
@@ -38,8 +38,8 @@
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <nav_msgs/msg/occupancy_grid.hpp>
 #include <nav_msgs/msg/odometry.hpp>
-#include <tier4_planning_msgs/msg/detail/velocity_limit__struct.hpp>
 #include <tier4_planning_msgs/msg/lateral_offset.hpp>
+#include <autoware_internal_planning_msgs/msg/detail/velocity_limit__struct.hpp>
 
 #include <limits>
 #include <map>
@@ -66,7 +66,7 @@ using nav_msgs::msg::Odometry;
 using tier4_planning_msgs::msg::LateralOffset;
 using PlanResult = PathWithLaneId::SharedPtr;
 using lanelet::TrafficLight;
-using tier4_planning_msgs::msg::VelocityLimit;
+using autoware_internal_planning_msgs::msg::VelocityLimit;
 using unique_identifier_msgs::msg::UUID;
 
 struct TrafficSignalStamped

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/package.xml
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/package.xml
@@ -65,6 +65,7 @@
   <depend>tf2</depend>
   <depend>tier4_planning_msgs</depend>
   <depend>visualization_msgs</depend>
+  <depend>autoware_internal_planning_msgs</depend>
 
   <test_depend>ament_cmake_ros</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/package.xml
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/package.xml
@@ -45,6 +45,7 @@
 
   <depend>autoware_adapi_v1_msgs</depend>
   <depend>autoware_freespace_planning_algorithms</depend>
+  <depend>autoware_internal_planning_msgs</depend>
   <depend>autoware_interpolation</depend>
   <depend>autoware_lane_departure_checker</depend>
   <depend>autoware_lanelet2_extension</depend>
@@ -65,7 +66,6 @@
   <depend>tf2</depend>
   <depend>tier4_planning_msgs</depend>
   <depend>visualization_msgs</depend>
-  <depend>autoware_internal_planning_msgs</depend>
 
   <test_depend>ament_cmake_ros</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/include/autoware/behavior_velocity_planner/node.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/include/autoware/behavior_velocity_planner/node.hpp
@@ -25,13 +25,13 @@
 
 #include <autoware_internal_debug_msgs/srv/string.hpp>
 #include <autoware_internal_planning_msgs/msg/path_with_lane_id.hpp>
+#include <autoware_internal_planning_msgs/msg/velocity_limit.hpp>
 #include <autoware_map_msgs/msg/lanelet_map_bin.hpp>
 #include <autoware_perception_msgs/msg/predicted_objects.hpp>
 #include <autoware_planning_msgs/msg/path.hpp>
 #include <nav_msgs/msg/occupancy_grid.hpp>
 #include <nav_msgs/msg/odometry.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
-#include <autoware_internal_planning_msgs/msg/velocity_limit.hpp>
 #include <visualization_msgs/msg/marker_array.hpp>
 
 #include <tf2_ros/buffer.h>
@@ -44,8 +44,8 @@
 
 namespace autoware::behavior_velocity_planner
 {
-using autoware_map_msgs::msg::LaneletMapBin;
 using autoware_internal_planning_msgs::msg::VelocityLimit;
+using autoware_map_msgs::msg::LaneletMapBin;
 
 class BehaviorVelocityPlannerNode : public rclcpp::Node
 {

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/include/autoware/behavior_velocity_planner/node.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/include/autoware/behavior_velocity_planner/node.hpp
@@ -31,7 +31,7 @@
 #include <nav_msgs/msg/occupancy_grid.hpp>
 #include <nav_msgs/msg/odometry.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
-#include <tier4_planning_msgs/msg/velocity_limit.hpp>
+#include <autoware_internal_planning_msgs/msg/velocity_limit.hpp>
 #include <visualization_msgs/msg/marker_array.hpp>
 
 #include <tf2_ros/buffer.h>
@@ -45,7 +45,7 @@
 namespace autoware::behavior_velocity_planner
 {
 using autoware_map_msgs::msg::LaneletMapBin;
-using tier4_planning_msgs::msg::VelocityLimit;
+using autoware_internal_planning_msgs::msg::VelocityLimit;
 
 class BehaviorVelocityPlannerNode : public rclcpp::Node
 {

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/package.xml
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/package.xml
@@ -34,6 +34,7 @@
 
   <depend>autoware_behavior_velocity_planner_common</depend>
   <depend>autoware_internal_debug_msgs</depend>
+  <depend>autoware_internal_planning_msgs</depend>
   <depend>autoware_lanelet2_extension</depend>
   <depend>autoware_map_msgs</depend>
   <depend>autoware_motion_utils</depend>
@@ -55,7 +56,6 @@
   <depend>tf2_eigen</depend>
   <depend>tf2_geometry_msgs</depend>
   <depend>tf2_ros</depend>
-  <depend>autoware_internal_planning_msgs</depend>
   <depend>visualization_msgs</depend>
 
   <test_depend>ament_cmake_ros</test_depend>

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/package.xml
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/package.xml
@@ -55,7 +55,7 @@
   <depend>tf2_eigen</depend>
   <depend>tf2_geometry_msgs</depend>
   <depend>tf2_ros</depend>
-  <depend>tier4_planning_msgs</depend>
+  <depend>autoware_internal_planning_msgs</depend>
   <depend>visualization_msgs</depend>
 
   <test_depend>ament_cmake_ros</test_depend>

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/src/test_utils.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/src/test_utils.cpp
@@ -119,7 +119,7 @@ void publishMandatoryTopics(
     autoware_perception_msgs::msg::TrafficLightGroupArray{});
   test_manager->publishInput(
     test_target_node, "behavior_velocity_planner_node/input/external_velocity_limit_mps",
-    tier4_planning_msgs::msg::VelocityLimit{});
+    autoware_internal_planning_msgs::msg::VelocityLimit{});
   test_manager->publishInput(
     test_target_node, "behavior_velocity_planner_node/input/occupancy_grid",
     autoware::test_utils::makeCostMapMsg());

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/include/autoware/behavior_velocity_planner_common/planner_data.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/include/autoware/behavior_velocity_planner_common/planner_data.hpp
@@ -20,6 +20,7 @@
 #include "autoware/velocity_smoother/smoother/smoother_base.hpp"
 #include "autoware_vehicle_info_utils/vehicle_info_utils.hpp"
 
+#include <autoware_internal_planning_msgs/msg/velocity_limit.hpp>
 #include <autoware_map_msgs/msg/lanelet_map_bin.hpp>
 #include <autoware_perception_msgs/msg/predicted_objects.hpp>
 #include <autoware_perception_msgs/msg/traffic_light_group_array.hpp>
@@ -29,7 +30,6 @@
 #include <nav_msgs/msg/occupancy_grid.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
 #include <std_msgs/msg/header.hpp>
-#include <autoware_internal_planning_msgs/msg/velocity_limit.hpp>
 
 #include <pcl/point_cloud.h>
 #include <pcl/point_types.h>

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/include/autoware/behavior_velocity_planner_common/planner_data.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/include/autoware/behavior_velocity_planner_common/planner_data.hpp
@@ -29,7 +29,7 @@
 #include <nav_msgs/msg/occupancy_grid.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
 #include <std_msgs/msg/header.hpp>
-#include <tier4_planning_msgs/msg/velocity_limit.hpp>
+#include <autoware_internal_planning_msgs/msg/velocity_limit.hpp>
 
 #include <pcl/point_cloud.h>
 #include <pcl/point_types.h>
@@ -62,7 +62,7 @@ struct PlannerData
 
   std::map<lanelet::Id, TrafficSignalStamped> traffic_light_id_map_raw_;
   std::map<lanelet::Id, TrafficSignalStamped> traffic_light_id_map_last_observed_;
-  std::optional<tier4_planning_msgs::msg::VelocityLimit> external_velocity_limit;
+  std::optional<autoware_internal_planning_msgs::msg::VelocityLimit> external_velocity_limit;
 
   bool is_simulation = false;
 

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/package.xml
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/package.xml
@@ -45,7 +45,7 @@
   <depend>tf2_eigen</depend>
   <depend>tf2_geometry_msgs</depend>
   <depend>tf2_ros</depend>
-  <depend>tier4_planning_msgs</depend>
+  <depend>autoware_internal_planning_msgs</depend>
   <depend>visualization_msgs</depend>
 
   <test_depend>ament_cmake_ros</test_depend>

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/package.xml
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/package.xml
@@ -21,6 +21,7 @@
 
   <depend>autoware_adapi_v1_msgs</depend>
   <depend>autoware_internal_debug_msgs</depend>
+  <depend>autoware_internal_planning_msgs</depend>
   <depend>autoware_interpolation</depend>
   <depend>autoware_lanelet2_extension</depend>
   <depend>autoware_map_msgs</depend>
@@ -45,7 +46,6 @@
   <depend>tf2_eigen</depend>
   <depend>tf2_geometry_msgs</depend>
   <depend>tf2_ros</depend>
-  <depend>autoware_internal_planning_msgs</depend>
   <depend>visualization_msgs</depend>
 
   <test_depend>ament_cmake_ros</test_depend>

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/test/src/test_trajectory_utils.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/test/src/test_trajectory_utils.cpp
@@ -77,7 +77,7 @@ TEST(smoothPath, nominal)
 
   planner_data->velocity_smoother_ =
     std::make_shared<autoware::velocity_smoother::JerkFilteredSmoother>(
-      *node, std::make_shared<autoware::universe_utils::TimeKeeper>());
+      *node, std::make_shared<autoware_utils::TimeKeeper>());
 
   // Input path
   PathWithLaneId in_path;

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_cruise_module/package.xml
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_cruise_module/package.xml
@@ -13,6 +13,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
+  <depend>autoware_internal_planning_msgs</depend>
   <depend>autoware_motion_utils</depend>
   <depend>autoware_motion_velocity_planner_common_universe</depend>
   <depend>autoware_osqp_interface</depend>
@@ -30,7 +31,6 @@
   <depend>tier4_metric_msgs</depend>
   <depend>tier4_planning_msgs</depend>
   <depend>visualization_msgs</depend>
-  <depend>autoware_internal_planning_msgs</depend>
 
   <test_depend>ament_cmake_ros</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_cruise_module/package.xml
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_cruise_module/package.xml
@@ -30,6 +30,7 @@
   <depend>tier4_metric_msgs</depend>
   <depend>tier4_planning_msgs</depend>
   <depend>visualization_msgs</depend>
+  <depend>autoware_internal_planning_msgs</depend>
 
   <test_depend>ament_cmake_ros</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_cruise_module/src/type_alias.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_cruise_module/src/type_alias.hpp
@@ -26,8 +26,8 @@
 #include "geometry_msgs/msg/twist.hpp"
 #include "nav_msgs/msg/odometry.hpp"
 #include "sensor_msgs/msg/point_cloud2.hpp"
-#include "tier4_planning_msgs/msg/velocity_limit.hpp"
-#include "tier4_planning_msgs/msg/velocity_limit_clear_command.hpp"
+#include "autoware_internal_planning_msgs/msg/velocity_limit.hpp"
+#include "autoware_internal_planning_msgs/msg/velocity_limit_clear_command.hpp"
 #include "visualization_msgs/msg/marker_array.hpp"
 #include <tier4_metric_msgs/msg/metric.hpp>
 #include <tier4_metric_msgs/msg/metric_array.hpp>
@@ -53,8 +53,8 @@ using autoware_planning_msgs::msg::TrajectoryPoint;
 using geometry_msgs::msg::Twist;
 using nav_msgs::msg::Odometry;
 using sensor_msgs::msg::PointCloud2;
-using tier4_planning_msgs::msg::VelocityLimit;
-using tier4_planning_msgs::msg::VelocityLimitClearCommand;
+using autoware_internal_planning_msgs::msg::VelocityLimit;
+using autoware_internal_planning_msgs::msg::VelocityLimitClearCommand;
 using visualization_msgs::msg::Marker;
 using visualization_msgs::msg::MarkerArray;
 namespace bg = boost::geometry;

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_cruise_module/src/type_alias.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_cruise_module/src/type_alias.hpp
@@ -20,14 +20,14 @@
 #include "autoware_internal_debug_msgs/msg/float32_multi_array_stamped.hpp"
 #include "autoware_internal_debug_msgs/msg/float32_stamped.hpp"
 #include "autoware_internal_debug_msgs/msg/float64_stamped.hpp"
+#include "autoware_internal_planning_msgs/msg/velocity_limit.hpp"
+#include "autoware_internal_planning_msgs/msg/velocity_limit_clear_command.hpp"
 #include "autoware_perception_msgs/msg/predicted_object.hpp"
 #include "autoware_perception_msgs/msg/predicted_objects.hpp"
 #include "autoware_planning_msgs/msg/trajectory.hpp"
 #include "geometry_msgs/msg/twist.hpp"
 #include "nav_msgs/msg/odometry.hpp"
 #include "sensor_msgs/msg/point_cloud2.hpp"
-#include "autoware_internal_planning_msgs/msg/velocity_limit.hpp"
-#include "autoware_internal_planning_msgs/msg/velocity_limit_clear_command.hpp"
 #include "visualization_msgs/msg/marker_array.hpp"
 #include <tier4_metric_msgs/msg/metric.hpp>
 #include <tier4_metric_msgs/msg/metric_array.hpp>
@@ -43,6 +43,8 @@ using autoware::vehicle_info_utils::VehicleInfo;
 using autoware_internal_debug_msgs::msg::Float32MultiArrayStamped;
 using autoware_internal_debug_msgs::msg::Float32Stamped;
 using autoware_internal_debug_msgs::msg::Float64Stamped;
+using autoware_internal_planning_msgs::msg::VelocityLimit;
+using autoware_internal_planning_msgs::msg::VelocityLimitClearCommand;
 using autoware_perception_msgs::msg::ObjectClassification;
 using autoware_perception_msgs::msg::PredictedObject;
 using autoware_perception_msgs::msg::PredictedObjects;
@@ -53,8 +55,6 @@ using autoware_planning_msgs::msg::TrajectoryPoint;
 using geometry_msgs::msg::Twist;
 using nav_msgs::msg::Odometry;
 using sensor_msgs::msg::PointCloud2;
-using autoware_internal_planning_msgs::msg::VelocityLimit;
-using autoware_internal_planning_msgs::msg::VelocityLimitClearCommand;
 using visualization_msgs::msg::Marker;
 using visualization_msgs::msg::MarkerArray;
 namespace bg = boost::geometry;

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_slow_down_module/package.xml
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_slow_down_module/package.xml
@@ -13,6 +13,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
+  <depend>autoware_internal_planning_msgs</depend>
   <depend>autoware_motion_utils</depend>
   <depend>autoware_motion_velocity_planner_common_universe</depend>
   <depend>autoware_perception_msgs</depend>
@@ -29,7 +30,6 @@
   <depend>tier4_metric_msgs</depend>
   <depend>tier4_planning_msgs</depend>
   <depend>visualization_msgs</depend>
-  <depend>autoware_internal_planning_msgs</depend>
 
   <test_depend>ament_cmake_ros</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_slow_down_module/package.xml
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_slow_down_module/package.xml
@@ -29,6 +29,7 @@
   <depend>tier4_metric_msgs</depend>
   <depend>tier4_planning_msgs</depend>
   <depend>visualization_msgs</depend>
+  <depend>autoware_internal_planning_msgs</depend>
 
   <test_depend>ament_cmake_ros</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_slow_down_module/src/type_alias.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_slow_down_module/src/type_alias.hpp
@@ -26,8 +26,8 @@
 #include "geometry_msgs/msg/twist.hpp"
 #include "nav_msgs/msg/odometry.hpp"
 #include "sensor_msgs/msg/point_cloud2.hpp"
-#include "tier4_planning_msgs/msg/velocity_limit.hpp"
-#include "tier4_planning_msgs/msg/velocity_limit_clear_command.hpp"
+#include "autoware_internal_planning_msgs/msg/velocity_limit.hpp"
+#include "autoware_internal_planning_msgs/msg/velocity_limit_clear_command.hpp"
 #include "visualization_msgs/msg/marker_array.hpp"
 #include <tier4_metric_msgs/msg/metric.hpp>
 #include <tier4_metric_msgs/msg/metric_array.hpp>
@@ -53,8 +53,8 @@ using autoware_planning_msgs::msg::TrajectoryPoint;
 using geometry_msgs::msg::Twist;
 using nav_msgs::msg::Odometry;
 using sensor_msgs::msg::PointCloud2;
-using tier4_planning_msgs::msg::VelocityLimit;
-using tier4_planning_msgs::msg::VelocityLimitClearCommand;
+using autoware_internal_planning_msgs::msg::VelocityLimit;
+using autoware_internal_planning_msgs::msg::VelocityLimitClearCommand;
 using visualization_msgs::msg::Marker;
 using visualization_msgs::msg::MarkerArray;
 namespace bg = boost::geometry;

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_slow_down_module/src/type_alias.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_slow_down_module/src/type_alias.hpp
@@ -20,14 +20,14 @@
 #include "autoware_internal_debug_msgs/msg/float32_multi_array_stamped.hpp"
 #include "autoware_internal_debug_msgs/msg/float32_stamped.hpp"
 #include "autoware_internal_debug_msgs/msg/float64_stamped.hpp"
+#include "autoware_internal_planning_msgs/msg/velocity_limit.hpp"
+#include "autoware_internal_planning_msgs/msg/velocity_limit_clear_command.hpp"
 #include "autoware_perception_msgs/msg/predicted_object.hpp"
 #include "autoware_perception_msgs/msg/predicted_objects.hpp"
 #include "autoware_planning_msgs/msg/trajectory.hpp"
 #include "geometry_msgs/msg/twist.hpp"
 #include "nav_msgs/msg/odometry.hpp"
 #include "sensor_msgs/msg/point_cloud2.hpp"
-#include "autoware_internal_planning_msgs/msg/velocity_limit.hpp"
-#include "autoware_internal_planning_msgs/msg/velocity_limit_clear_command.hpp"
 #include "visualization_msgs/msg/marker_array.hpp"
 #include <tier4_metric_msgs/msg/metric.hpp>
 #include <tier4_metric_msgs/msg/metric_array.hpp>
@@ -43,6 +43,8 @@ using autoware::vehicle_info_utils::VehicleInfo;
 using autoware_internal_debug_msgs::msg::Float32MultiArrayStamped;
 using autoware_internal_debug_msgs::msg::Float32Stamped;
 using autoware_internal_debug_msgs::msg::Float64Stamped;
+using autoware_internal_planning_msgs::msg::VelocityLimit;
+using autoware_internal_planning_msgs::msg::VelocityLimitClearCommand;
 using autoware_perception_msgs::msg::ObjectClassification;
 using autoware_perception_msgs::msg::PredictedObject;
 using autoware_perception_msgs::msg::PredictedObjects;
@@ -53,8 +55,6 @@ using autoware_planning_msgs::msg::TrajectoryPoint;
 using geometry_msgs::msg::Twist;
 using nav_msgs::msg::Odometry;
 using sensor_msgs::msg::PointCloud2;
-using autoware_internal_planning_msgs::msg::VelocityLimit;
-using autoware_internal_planning_msgs::msg::VelocityLimitClearCommand;
 using visualization_msgs::msg::Marker;
 using visualization_msgs::msg::MarkerArray;
 namespace bg = boost::geometry;

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_common_universe/include/autoware/motion_velocity_planner_common_universe/velocity_planning_result.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_common_universe/include/autoware/motion_velocity_planner_common_universe/velocity_planning_result.hpp
@@ -17,9 +17,9 @@
 
 #include <autoware/motion_utils/marker/virtual_wall_marker_creator.hpp>
 
-#include <geometry_msgs/msg/point.hpp>
 #include <autoware_internal_planning_msgs/msg/velocity_limit.hpp>
 #include <autoware_internal_planning_msgs/msg/velocity_limit_clear_command.hpp>
+#include <geometry_msgs/msg/point.hpp>
 #include <visualization_msgs/msg/marker_array.hpp>
 
 #include <string>
@@ -45,8 +45,8 @@ struct VelocityPlanningResult
   std::vector<geometry_msgs::msg::Point> stop_points{};
   std::vector<SlowdownInterval> slowdown_intervals{};
   std::optional<autoware_internal_planning_msgs::msg::VelocityLimit> velocity_limit{std::nullopt};
-  std::optional<autoware_internal_planning_msgs::msg::VelocityLimitClearCommand> velocity_limit_clear_command{
-    std::nullopt};
+  std::optional<autoware_internal_planning_msgs::msg::VelocityLimitClearCommand>
+    velocity_limit_clear_command{std::nullopt};
 };
 }  // namespace autoware::motion_velocity_planner
 

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_common_universe/include/autoware/motion_velocity_planner_common_universe/velocity_planning_result.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_common_universe/include/autoware/motion_velocity_planner_common_universe/velocity_planning_result.hpp
@@ -18,8 +18,8 @@
 #include <autoware/motion_utils/marker/virtual_wall_marker_creator.hpp>
 
 #include <geometry_msgs/msg/point.hpp>
-#include <tier4_planning_msgs/msg/velocity_limit.hpp>
-#include <tier4_planning_msgs/msg/velocity_limit_clear_command.hpp>
+#include <autoware_internal_planning_msgs/msg/velocity_limit.hpp>
+#include <autoware_internal_planning_msgs/msg/velocity_limit_clear_command.hpp>
 #include <visualization_msgs/msg/marker_array.hpp>
 
 #include <string>
@@ -44,8 +44,8 @@ struct VelocityPlanningResult
 {
   std::vector<geometry_msgs::msg::Point> stop_points{};
   std::vector<SlowdownInterval> slowdown_intervals{};
-  std::optional<tier4_planning_msgs::msg::VelocityLimit> velocity_limit{std::nullopt};
-  std::optional<tier4_planning_msgs::msg::VelocityLimitClearCommand> velocity_limit_clear_command{
+  std::optional<autoware_internal_planning_msgs::msg::VelocityLimit> velocity_limit{std::nullopt};
+  std::optional<autoware_internal_planning_msgs::msg::VelocityLimitClearCommand> velocity_limit_clear_command{
     std::nullopt};
 };
 }  // namespace autoware::motion_velocity_planner

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_common_universe/package.xml
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_common_universe/package.xml
@@ -32,6 +32,7 @@
   <depend>libboost-dev</depend>
   <depend>rclcpp</depend>
   <depend>visualization_msgs</depend>
+  <depend>autoware_internal_planning_msgs</depend>
 
   <test_depend>ament_cmake_ros</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_common_universe/package.xml
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_common_universe/package.xml
@@ -20,6 +20,7 @@
 
   <depend>autoware_behavior_velocity_planner_common</depend>
   <depend>autoware_internal_debug_msgs</depend>
+  <depend>autoware_internal_planning_msgs</depend>
   <depend>autoware_motion_utils</depend>
   <depend>autoware_object_recognition_utils</depend>
   <depend>autoware_perception_msgs</depend>
@@ -32,7 +33,6 @@
   <depend>libboost-dev</depend>
   <depend>rclcpp</depend>
   <depend>visualization_msgs</depend>
-  <depend>autoware_internal_planning_msgs</depend>
 
   <test_depend>ament_cmake_ros</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_node_universe/package.xml
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_node_universe/package.xml
@@ -19,6 +19,7 @@
   <build_depend>rosidl_default_generators</build_depend>
 
   <depend>autoware_internal_debug_msgs</depend>
+  <depend>autoware_internal_planning_msgs</depend>
   <depend>autoware_map_msgs</depend>
   <depend>autoware_motion_utils</depend>
   <depend>autoware_motion_velocity_planner_common_universe</depend>
@@ -42,7 +43,6 @@
   <depend>tf2_ros</depend>
   <depend>tier4_metric_msgs</depend>
   <depend>visualization_msgs</depend>
-  <depend>autoware_internal_planning_msgs</depend>
 
   <exec_depend>rosidl_default_runtime</exec_depend>
 

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_node_universe/package.xml
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_node_universe/package.xml
@@ -42,6 +42,7 @@
   <depend>tf2_ros</depend>
   <depend>tier4_metric_msgs</depend>
   <depend>visualization_msgs</depend>
+  <depend>autoware_internal_planning_msgs</depend>
 
   <exec_depend>rosidl_default_runtime</exec_depend>
 

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_node_universe/src/node.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_node_universe/src/node.hpp
@@ -33,8 +33,8 @@
 #include <nav_msgs/msg/occupancy_grid.hpp>
 #include <nav_msgs/msg/odometry.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
-#include <tier4_planning_msgs/msg/velocity_limit.hpp>
-#include <tier4_planning_msgs/msg/velocity_limit_clear_command.hpp>
+#include <autoware_internal_planning_msgs/msg/velocity_limit.hpp>
+#include <autoware_internal_planning_msgs/msg/velocity_limit_clear_command.hpp>
 #include <visualization_msgs/msg/marker_array.hpp>
 
 #include <tf2_ros/buffer.h>
@@ -52,8 +52,8 @@ using autoware_map_msgs::msg::LaneletMapBin;
 using autoware_motion_velocity_planner_node_universe::srv::LoadPlugin;
 using autoware_motion_velocity_planner_node_universe::srv::UnloadPlugin;
 using autoware_planning_msgs::msg::Trajectory;
-using tier4_planning_msgs::msg::VelocityLimit;
-using tier4_planning_msgs::msg::VelocityLimitClearCommand;
+using autoware_internal_planning_msgs::msg::VelocityLimit;
+using autoware_internal_planning_msgs::msg::VelocityLimitClearCommand;
 using TrajectoryPoints = std::vector<autoware_planning_msgs::msg::TrajectoryPoint>;
 
 class MotionVelocityPlannerNode : public rclcpp::Node

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_node_universe/src/node.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_node_universe/src/node.hpp
@@ -26,6 +26,8 @@
 #include <rclcpp/rclcpp.hpp>
 
 #include <autoware_internal_debug_msgs/msg/float64_stamped.hpp>
+#include <autoware_internal_planning_msgs/msg/velocity_limit.hpp>
+#include <autoware_internal_planning_msgs/msg/velocity_limit_clear_command.hpp>
 #include <autoware_map_msgs/msg/lanelet_map_bin.hpp>
 #include <autoware_perception_msgs/msg/predicted_objects.hpp>
 #include <autoware_perception_msgs/msg/traffic_signal_array.hpp>
@@ -33,8 +35,6 @@
 #include <nav_msgs/msg/occupancy_grid.hpp>
 #include <nav_msgs/msg/odometry.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
-#include <autoware_internal_planning_msgs/msg/velocity_limit.hpp>
-#include <autoware_internal_planning_msgs/msg/velocity_limit_clear_command.hpp>
 #include <visualization_msgs/msg/marker_array.hpp>
 
 #include <tf2_ros/buffer.h>
@@ -48,12 +48,12 @@
 
 namespace autoware::motion_velocity_planner
 {
+using autoware_internal_planning_msgs::msg::VelocityLimit;
+using autoware_internal_planning_msgs::msg::VelocityLimitClearCommand;
 using autoware_map_msgs::msg::LaneletMapBin;
 using autoware_motion_velocity_planner_node_universe::srv::LoadPlugin;
 using autoware_motion_velocity_planner_node_universe::srv::UnloadPlugin;
 using autoware_planning_msgs::msg::Trajectory;
-using autoware_internal_planning_msgs::msg::VelocityLimit;
-using autoware_internal_planning_msgs::msg::VelocityLimitClearCommand;
 using TrajectoryPoints = std::vector<autoware_planning_msgs::msg::TrajectoryPoint>;
 
 class MotionVelocityPlannerNode : public rclcpp::Node

--- a/system/autoware_mrm_comfortable_stop_operator/README.md
+++ b/system/autoware_mrm_comfortable_stop_operator/README.md
@@ -19,8 +19,8 @@ MRM comfortable stop operator is a node that generates comfortable stop commands
 | Name                                   | Type                                                  | Description                  |
 | -------------------------------------- | ----------------------------------------------------- | ---------------------------- |
 | `~/output/mrm/comfortable_stop/status` | `tier4_system_msgs::msg::MrmBehaviorStatus`           | MRM execution status         |
-| `~/output/velocity_limit`              | `tier4_planning_msgs::msg::VelocityLimit`             | Velocity limit command       |
-| `~/output/velocity_limit/clear`        | `tier4_planning_msgs::msg::VelocityLimitClearCommand` | Velocity limit clear command |
+| `~/output/velocity_limit`              | `autoware_internal_planning_msgs::msg::VelocityLimit`             | Velocity limit command       |
+| `~/output/velocity_limit/clear`        | `autoware_internal_planning_msgs::msg::VelocityLimitClearCommand` | Velocity limit clear command |
 
 ## Parameters
 

--- a/system/autoware_mrm_comfortable_stop_operator/README.md
+++ b/system/autoware_mrm_comfortable_stop_operator/README.md
@@ -16,9 +16,9 @@ MRM comfortable stop operator is a node that generates comfortable stop commands
 
 ### Output
 
-| Name                                   | Type                                                  | Description                  |
-| -------------------------------------- | ----------------------------------------------------- | ---------------------------- |
-| `~/output/mrm/comfortable_stop/status` | `tier4_system_msgs::msg::MrmBehaviorStatus`           | MRM execution status         |
+| Name                                   | Type                                                              | Description                  |
+| -------------------------------------- | ----------------------------------------------------------------- | ---------------------------- |
+| `~/output/mrm/comfortable_stop/status` | `tier4_system_msgs::msg::MrmBehaviorStatus`                       | MRM execution status         |
 | `~/output/velocity_limit`              | `autoware_internal_planning_msgs::msg::VelocityLimit`             | Velocity limit command       |
 | `~/output/velocity_limit/clear`        | `autoware_internal_planning_msgs::msg::VelocityLimitClearCommand` | Velocity limit clear command |
 

--- a/system/autoware_mrm_comfortable_stop_operator/include/autoware/mrm_comfortable_stop_operator/mrm_comfortable_stop_operator_core.hpp
+++ b/system/autoware_mrm_comfortable_stop_operator/include/autoware/mrm_comfortable_stop_operator/mrm_comfortable_stop_operator_core.hpp
@@ -20,9 +20,9 @@
 #include <vector>
 
 // Autoware
-#include <tier4_planning_msgs/msg/velocity_limit.hpp>
-#include <tier4_planning_msgs/msg/velocity_limit_clear_command.hpp>
-#include <tier4_planning_msgs/msg/velocity_limit_constraints.hpp>
+#include <autoware_internal_planning_msgs/msg/velocity_limit.hpp>
+#include <autoware_internal_planning_msgs/msg/velocity_limit_clear_command.hpp>
+#include <autoware_internal_planning_msgs/msg/velocity_limit_constraints.hpp>
 #include <tier4_system_msgs/msg/mrm_behavior_status.hpp>
 #include <tier4_system_msgs/srv/operate_mrm.hpp>
 
@@ -61,8 +61,8 @@ private:
 
   // Publisher
   rclcpp::Publisher<tier4_system_msgs::msg::MrmBehaviorStatus>::SharedPtr pub_status_;
-  rclcpp::Publisher<tier4_planning_msgs::msg::VelocityLimit>::SharedPtr pub_velocity_limit_;
-  rclcpp::Publisher<tier4_planning_msgs::msg::VelocityLimitClearCommand>::SharedPtr
+  rclcpp::Publisher<autoware_internal_planning_msgs::msg::VelocityLimit>::SharedPtr pub_velocity_limit_;
+  rclcpp::Publisher<autoware_internal_planning_msgs::msg::VelocityLimitClearCommand>::SharedPtr
     pub_velocity_limit_clear_command_;
 
   void publishStatus() const;

--- a/system/autoware_mrm_comfortable_stop_operator/include/autoware/mrm_comfortable_stop_operator/mrm_comfortable_stop_operator_core.hpp
+++ b/system/autoware_mrm_comfortable_stop_operator/include/autoware/mrm_comfortable_stop_operator/mrm_comfortable_stop_operator_core.hpp
@@ -61,7 +61,8 @@ private:
 
   // Publisher
   rclcpp::Publisher<tier4_system_msgs::msg::MrmBehaviorStatus>::SharedPtr pub_status_;
-  rclcpp::Publisher<autoware_internal_planning_msgs::msg::VelocityLimit>::SharedPtr pub_velocity_limit_;
+  rclcpp::Publisher<autoware_internal_planning_msgs::msg::VelocityLimit>::SharedPtr
+    pub_velocity_limit_;
   rclcpp::Publisher<autoware_internal_planning_msgs::msg::VelocityLimitClearCommand>::SharedPtr
     pub_velocity_limit_clear_command_;
 

--- a/system/autoware_mrm_comfortable_stop_operator/package.xml
+++ b/system/autoware_mrm_comfortable_stop_operator/package.xml
@@ -18,7 +18,7 @@
   <depend>rclcpp_components</depend>
   <depend>std_msgs</depend>
   <depend>std_srvs</depend>
-  <depend>tier4_planning_msgs</depend>
+  <depend>autoware_internal_planning_msgs</depend>
   <depend>tier4_system_msgs</depend>
 
   <test_depend>ament_lint_auto</test_depend>

--- a/system/autoware_mrm_comfortable_stop_operator/package.xml
+++ b/system/autoware_mrm_comfortable_stop_operator/package.xml
@@ -13,12 +13,12 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_adapi_v1_msgs</depend>
+  <depend>autoware_internal_planning_msgs</depend>
   <depend>autoware_universe_utils</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>std_msgs</depend>
   <depend>std_srvs</depend>
-  <depend>autoware_internal_planning_msgs</depend>
   <depend>tier4_system_msgs</depend>
 
   <test_depend>ament_lint_auto</test_depend>

--- a/system/autoware_mrm_comfortable_stop_operator/src/mrm_comfortable_stop_operator/mrm_comfortable_stop_operator_core.cpp
+++ b/system/autoware_mrm_comfortable_stop_operator/src/mrm_comfortable_stop_operator/mrm_comfortable_stop_operator_core.cpp
@@ -110,7 +110,8 @@ void MrmComfortableStopOperator::publishVelocityLimit() const
 
 void MrmComfortableStopOperator::publishVelocityLimitClearCommand() const
 {
-  auto velocity_limit_clear_command = autoware_internal_planning_msgs::msg::VelocityLimitClearCommand();
+  auto velocity_limit_clear_command =
+    autoware_internal_planning_msgs::msg::VelocityLimitClearCommand();
   velocity_limit_clear_command.stamp = this->now();
   velocity_limit_clear_command.command = true;
   velocity_limit_clear_command.sender = "mrm_comfortable_stop_operator";

--- a/system/autoware_mrm_comfortable_stop_operator/src/mrm_comfortable_stop_operator/mrm_comfortable_stop_operator_core.cpp
+++ b/system/autoware_mrm_comfortable_stop_operator/src/mrm_comfortable_stop_operator/mrm_comfortable_stop_operator_core.cpp
@@ -39,10 +39,10 @@ MrmComfortableStopOperator::MrmComfortableStopOperator(const rclcpp::NodeOptions
   // Publisher
   pub_status_ = create_publisher<tier4_system_msgs::msg::MrmBehaviorStatus>(
     "~/output/mrm/comfortable_stop/status", 1);
-  pub_velocity_limit_ = create_publisher<tier4_planning_msgs::msg::VelocityLimit>(
+  pub_velocity_limit_ = create_publisher<autoware_internal_planning_msgs::msg::VelocityLimit>(
     "~/output/velocity_limit", rclcpp::QoS{1}.transient_local());
   pub_velocity_limit_clear_command_ =
-    create_publisher<tier4_planning_msgs::msg::VelocityLimitClearCommand>(
+    create_publisher<autoware_internal_planning_msgs::msg::VelocityLimitClearCommand>(
       "~/output/velocity_limit/clear", rclcpp::QoS{1}.transient_local());
 
   // Timer
@@ -96,7 +96,7 @@ void MrmComfortableStopOperator::publishStatus() const
 
 void MrmComfortableStopOperator::publishVelocityLimit() const
 {
-  auto velocity_limit = tier4_planning_msgs::msg::VelocityLimit();
+  auto velocity_limit = autoware_internal_planning_msgs::msg::VelocityLimit();
   velocity_limit.stamp = this->now();
   velocity_limit.max_velocity = 0;
   velocity_limit.use_constraints = true;
@@ -110,7 +110,7 @@ void MrmComfortableStopOperator::publishVelocityLimit() const
 
 void MrmComfortableStopOperator::publishVelocityLimitClearCommand() const
 {
-  auto velocity_limit_clear_command = tier4_planning_msgs::msg::VelocityLimitClearCommand();
+  auto velocity_limit_clear_command = autoware_internal_planning_msgs::msg::VelocityLimitClearCommand();
   velocity_limit_clear_command.stamp = this->now();
   velocity_limit_clear_command.command = true;
   velocity_limit_clear_command.sender = "mrm_comfortable_stop_operator";

--- a/visualization/autoware_overlay_rviz_plugin/autoware_overlay_rviz_plugin/CMakeLists.txt
+++ b/visualization/autoware_overlay_rviz_plugin/autoware_overlay_rviz_plugin/CMakeLists.txt
@@ -69,7 +69,7 @@ ament_target_dependencies(${PROJECT_NAME} PUBLIC
   rviz_common
   rviz_rendering
   autoware_vehicle_msgs
-  tier4_planning_msgs
+  autoware_internal_planning_msgs
   autoware_perception_msgs
 )
 

--- a/visualization/autoware_overlay_rviz_plugin/autoware_overlay_rviz_plugin/README.md
+++ b/visualization/autoware_overlay_rviz_plugin/autoware_overlay_rviz_plugin/README.md
@@ -20,7 +20,7 @@ This plugin provides a visual and easy-to-understand display of vehicle speed, t
 | `/vehicle/status/hazard_status`                         | `autoware_vehicle_msgs::msg::HazardReport`              | The topic is status of hazard        |
 | `/vehicle/status/steering_status`                       | `autoware_vehicle_msgs::msg::SteeringReport`            | The topic is status of steering      |
 | `/vehicle/status/gear_status`                           | `autoware_vehicle_msgs::msg::GearReport`                | The topic is status of gear          |
-| `/planning/scenario_planning/current_max_velocity`      | `autoware_internal_planning_msgs::msg::VelocityLimit`               | The topic is velocity limit          |
+| `/planning/scenario_planning/current_max_velocity`      | `autoware_internal_planning_msgs::msg::VelocityLimit`   | The topic is velocity limit          |
 | `/perception/traffic_light_recognition/traffic_signals` | `autoware_perception_msgs::msg::TrafficLightGroupArray` | The topic is status of traffic light |
 
 ## Parameter

--- a/visualization/autoware_overlay_rviz_plugin/autoware_overlay_rviz_plugin/README.md
+++ b/visualization/autoware_overlay_rviz_plugin/autoware_overlay_rviz_plugin/README.md
@@ -20,7 +20,7 @@ This plugin provides a visual and easy-to-understand display of vehicle speed, t
 | `/vehicle/status/hazard_status`                         | `autoware_vehicle_msgs::msg::HazardReport`              | The topic is status of hazard        |
 | `/vehicle/status/steering_status`                       | `autoware_vehicle_msgs::msg::SteeringReport`            | The topic is status of steering      |
 | `/vehicle/status/gear_status`                           | `autoware_vehicle_msgs::msg::GearReport`                | The topic is status of gear          |
-| `/planning/scenario_planning/current_max_velocity`      | `tier4_planning_msgs::msg::VelocityLimit`               | The topic is velocity limit          |
+| `/planning/scenario_planning/current_max_velocity`      | `autoware_internal_planning_msgs::msg::VelocityLimit`               | The topic is velocity limit          |
 | `/perception/traffic_light_recognition/traffic_signals` | `autoware_perception_msgs::msg::TrafficLightGroupArray` | The topic is status of traffic light |
 
 ## Parameter

--- a/visualization/autoware_overlay_rviz_plugin/autoware_overlay_rviz_plugin/include/signal_display.hpp
+++ b/visualization/autoware_overlay_rviz_plugin/autoware_overlay_rviz_plugin/include/signal_display.hpp
@@ -110,7 +110,8 @@ private:
   rclcpp::Subscription<autoware_vehicle_msgs::msg::HazardLightsReport>::SharedPtr
     hazard_lights_sub_;
   rclcpp::Subscription<autoware_perception_msgs::msg::TrafficLightGroup>::SharedPtr traffic_sub_;
-  rclcpp::Subscription<autoware_internal_planning_msgs::msg::VelocityLimit>::SharedPtr speed_limit_sub_;
+  rclcpp::Subscription<autoware_internal_planning_msgs::msg::VelocityLimit>::SharedPtr
+    speed_limit_sub_;
 
   std::mutex property_mutex_;
 
@@ -121,7 +122,8 @@ private:
     const autoware_vehicle_msgs::msg::TurnIndicatorsReport::ConstSharedPtr & msg);
   void updateHazardLightsData(
     const autoware_vehicle_msgs::msg::HazardLightsReport::ConstSharedPtr & msg);
-  void updateSpeedLimitData(const autoware_internal_planning_msgs::msg::VelocityLimit::ConstSharedPtr msg);
+  void updateSpeedLimitData(
+    const autoware_internal_planning_msgs::msg::VelocityLimit::ConstSharedPtr msg);
   void updateTrafficLightData(
     const autoware_perception_msgs::msg::TrafficLightGroup::ConstSharedPtr msg);
   void drawWidget(QImage & hud);

--- a/visualization/autoware_overlay_rviz_plugin/autoware_overlay_rviz_plugin/include/signal_display.hpp
+++ b/visualization/autoware_overlay_rviz_plugin/autoware_overlay_rviz_plugin/include/signal_display.hpp
@@ -110,7 +110,7 @@ private:
   rclcpp::Subscription<autoware_vehicle_msgs::msg::HazardLightsReport>::SharedPtr
     hazard_lights_sub_;
   rclcpp::Subscription<autoware_perception_msgs::msg::TrafficLightGroup>::SharedPtr traffic_sub_;
-  rclcpp::Subscription<tier4_planning_msgs::msg::VelocityLimit>::SharedPtr speed_limit_sub_;
+  rclcpp::Subscription<autoware_internal_planning_msgs::msg::VelocityLimit>::SharedPtr speed_limit_sub_;
 
   std::mutex property_mutex_;
 
@@ -121,7 +121,7 @@ private:
     const autoware_vehicle_msgs::msg::TurnIndicatorsReport::ConstSharedPtr & msg);
   void updateHazardLightsData(
     const autoware_vehicle_msgs::msg::HazardLightsReport::ConstSharedPtr & msg);
-  void updateSpeedLimitData(const tier4_planning_msgs::msg::VelocityLimit::ConstSharedPtr msg);
+  void updateSpeedLimitData(const autoware_internal_planning_msgs::msg::VelocityLimit::ConstSharedPtr msg);
   void updateTrafficLightData(
     const autoware_perception_msgs::msg::TrafficLightGroup::ConstSharedPtr msg);
   void drawWidget(QImage & hud);

--- a/visualization/autoware_overlay_rviz_plugin/autoware_overlay_rviz_plugin/include/speed_limit_display.hpp
+++ b/visualization/autoware_overlay_rviz_plugin/autoware_overlay_rviz_plugin/include/speed_limit_display.hpp
@@ -23,8 +23,8 @@
 #include <rviz_common/properties/int_property.hpp>
 #include <rviz_common/ros_topic_display.hpp>
 
-#include "autoware_vehicle_msgs/msg/velocity_report.hpp"
 #include "autoware_internal_planning_msgs/msg/velocity_limit.hpp"
+#include "autoware_vehicle_msgs/msg/velocity_report.hpp"
 
 #include <OgreColourValue.h>
 #include <OgreMaterial.h>
@@ -41,7 +41,8 @@ public:
     QPainter & painter, const QRectF & backgroundRect, const QColor & color,
     const QColor & light_color, const QColor & dark_color, const QColor & bg_color,
     const float bg_alpha);
-  void updateSpeedLimitData(const autoware_internal_planning_msgs::msg::VelocityLimit::ConstSharedPtr msg);
+  void updateSpeedLimitData(
+    const autoware_internal_planning_msgs::msg::VelocityLimit::ConstSharedPtr msg);
   void updateSpeedData(const autoware_vehicle_msgs::msg::VelocityReport::ConstSharedPtr & msg);
 
 private:

--- a/visualization/autoware_overlay_rviz_plugin/autoware_overlay_rviz_plugin/include/speed_limit_display.hpp
+++ b/visualization/autoware_overlay_rviz_plugin/autoware_overlay_rviz_plugin/include/speed_limit_display.hpp
@@ -24,7 +24,7 @@
 #include <rviz_common/ros_topic_display.hpp>
 
 #include "autoware_vehicle_msgs/msg/velocity_report.hpp"
-#include <tier4_planning_msgs/msg/velocity_limit.hpp>
+#include "autoware_internal_planning_msgs/msg/velocity_limit.hpp"
 
 #include <OgreColourValue.h>
 #include <OgreMaterial.h>
@@ -41,7 +41,7 @@ public:
     QPainter & painter, const QRectF & backgroundRect, const QColor & color,
     const QColor & light_color, const QColor & dark_color, const QColor & bg_color,
     const float bg_alpha);
-  void updateSpeedLimitData(const tier4_planning_msgs::msg::VelocityLimit::ConstSharedPtr msg);
+  void updateSpeedLimitData(const autoware_internal_planning_msgs::msg::VelocityLimit::ConstSharedPtr msg);
   void updateSpeedData(const autoware_vehicle_msgs::msg::VelocityReport::ConstSharedPtr & msg);
 
 private:

--- a/visualization/autoware_overlay_rviz_plugin/autoware_overlay_rviz_plugin/package.xml
+++ b/visualization/autoware_overlay_rviz_plugin/autoware_overlay_rviz_plugin/package.xml
@@ -12,13 +12,13 @@
   <license>BSD-3-Clause</license>
 
   <depend>ament_index_cpp</depend>
+  <depend>autoware_internal_planning_msgs</depend>
   <depend>autoware_perception_msgs</depend>
   <depend>autoware_vehicle_msgs</depend>
   <depend>boost</depend>
   <depend>rviz_common</depend>
   <depend>rviz_ogre_vendor</depend>
   <depend>rviz_rendering</depend>
-  <depend>autoware_internal_planning_msgs</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>

--- a/visualization/autoware_overlay_rviz_plugin/autoware_overlay_rviz_plugin/package.xml
+++ b/visualization/autoware_overlay_rviz_plugin/autoware_overlay_rviz_plugin/package.xml
@@ -18,7 +18,7 @@
   <depend>rviz_common</depend>
   <depend>rviz_ogre_vendor</depend>
   <depend>rviz_rendering</depend>
-  <depend>tier4_planning_msgs</depend>
+  <depend>autoware_internal_planning_msgs</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>

--- a/visualization/autoware_overlay_rviz_plugin/autoware_overlay_rviz_plugin/src/signal_display.cpp
+++ b/visualization/autoware_overlay_rviz_plugin/autoware_overlay_rviz_plugin/src/signal_display.cpp
@@ -121,7 +121,7 @@ void SignalDisplay::onInitialize()
 
   speed_limit_topic_property_ = std::make_unique<rviz_common::properties::RosTopicProperty>(
     "Speed Limit Topic", "/planning/scenario_planning/current_max_velocity",
-    "tier4_planning_msgs/msg/VelocityLimit", "Topic for Speed Limit Data", this,
+    "autoware_internal_planning_msgs/msg/VelocityLimit", "Topic for Speed Limit Data", this,
     SLOT(topic_updated_speed_limit()));
   speed_limit_topic_property_->initialize(rviz_ros_node);
 
@@ -217,7 +217,7 @@ void SignalDisplay::updateTrafficLightData(
 }
 
 void SignalDisplay::updateSpeedLimitData(
-  const tier4_planning_msgs::msg::VelocityLimit::ConstSharedPtr msg)
+  const autoware_internal_planning_msgs::msg::VelocityLimit::ConstSharedPtr msg)
 {
   std::lock_guard<std::mutex> lock(property_mutex_);
 
@@ -438,10 +438,10 @@ void SignalDisplay::topic_updated_speed_limit()
   speed_limit_sub_.reset();
   auto rviz_ros_node = context_->getRosNodeAbstraction().lock();
   speed_limit_sub_ =
-    rviz_ros_node->get_raw_node()->create_subscription<tier4_planning_msgs::msg::VelocityLimit>(
+    rviz_ros_node->get_raw_node()->create_subscription<autoware_internal_planning_msgs::msg::VelocityLimit>(
       speed_limit_topic_property_->getTopicStd(),
       rclcpp::QoS(rclcpp::KeepLast(10)).transient_local(),
-      [this](const tier4_planning_msgs::msg::VelocityLimit::ConstSharedPtr msg) {
+      [this](const autoware_internal_planning_msgs::msg::VelocityLimit::ConstSharedPtr msg) {
         updateSpeedLimitData(msg);
       });
 }

--- a/visualization/autoware_overlay_rviz_plugin/autoware_overlay_rviz_plugin/src/signal_display.cpp
+++ b/visualization/autoware_overlay_rviz_plugin/autoware_overlay_rviz_plugin/src/signal_display.cpp
@@ -438,12 +438,13 @@ void SignalDisplay::topic_updated_speed_limit()
   speed_limit_sub_.reset();
   auto rviz_ros_node = context_->getRosNodeAbstraction().lock();
   speed_limit_sub_ =
-    rviz_ros_node->get_raw_node()->create_subscription<autoware_internal_planning_msgs::msg::VelocityLimit>(
-      speed_limit_topic_property_->getTopicStd(),
-      rclcpp::QoS(rclcpp::KeepLast(10)).transient_local(),
-      [this](const autoware_internal_planning_msgs::msg::VelocityLimit::ConstSharedPtr msg) {
-        updateSpeedLimitData(msg);
-      });
+    rviz_ros_node->get_raw_node()
+      ->create_subscription<autoware_internal_planning_msgs::msg::VelocityLimit>(
+        speed_limit_topic_property_->getTopicStd(),
+        rclcpp::QoS(rclcpp::KeepLast(10)).transient_local(),
+        [this](const autoware_internal_planning_msgs::msg::VelocityLimit::ConstSharedPtr msg) {
+          updateSpeedLimitData(msg);
+        });
 }
 
 void SignalDisplay::topic_updated_turn_signals()

--- a/visualization/autoware_overlay_rviz_plugin/autoware_overlay_rviz_plugin/src/speed_limit_display.cpp
+++ b/visualization/autoware_overlay_rviz_plugin/autoware_overlay_rviz_plugin/src/speed_limit_display.cpp
@@ -52,7 +52,7 @@ SpeedLimitDisplay::SpeedLimitDisplay() : current_limit(0.0), current_speed_(0.0)
 }
 
 void SpeedLimitDisplay::updateSpeedLimitData(
-  const tier4_planning_msgs::msg::VelocityLimit::ConstSharedPtr msg)
+  const autoware_internal_planning_msgs::msg::VelocityLimit::ConstSharedPtr msg)
 {
   current_limit = msg->max_velocity;
 }

--- a/visualization/tier4_planning_rviz_plugin/package.xml
+++ b/visualization/tier4_planning_rviz_plugin/package.xml
@@ -11,6 +11,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
+  <depend>autoware_internal_planning_msgs</depend>
   <depend>autoware_motion_utils</depend>
   <depend>autoware_planning_msgs</depend>
   <depend>autoware_universe_utils</depend>
@@ -25,7 +26,6 @@
   <depend>rviz_rendering</depend>
   <depend>tf2_geometry_msgs</depend>
   <depend>tf2_ros</depend>
-  <depend>autoware_internal_planning_msgs</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>

--- a/visualization/tier4_planning_rviz_plugin/package.xml
+++ b/visualization/tier4_planning_rviz_plugin/package.xml
@@ -25,7 +25,7 @@
   <depend>rviz_rendering</depend>
   <depend>tf2_geometry_msgs</depend>
   <depend>tf2_ros</depend>
-  <depend>tier4_planning_msgs</depend>
+  <depend>autoware_internal_planning_msgs</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>

--- a/visualization/tier4_planning_rviz_plugin/src/tools/max_velocity.cpp
+++ b/visualization/tier4_planning_rviz_plugin/src/tools/max_velocity.cpp
@@ -116,7 +116,7 @@ void MaxVelocityDisplay::subscribe()
   std::string topic_name = property_topic_name_->getStdString();
   if (topic_name.length() > 0 && topic_name != "/") {
     rclcpp::Node::SharedPtr raw_node = context_->getRosNodeAbstraction().lock()->get_raw_node();
-    max_vel_sub_ = raw_node->create_subscription<tier4_planning_msgs::msg::VelocityLimit>(
+    max_vel_sub_ = raw_node->create_subscription<autoware_internal_planning_msgs::msg::VelocityLimit>(
       topic_name, rclcpp::QoS{1}.transient_local(),
       std::bind(&MaxVelocityDisplay::processMessage, this, std::placeholders::_1));
   }
@@ -128,7 +128,7 @@ void MaxVelocityDisplay::unsubscribe()
 }
 
 void MaxVelocityDisplay::processMessage(
-  const tier4_planning_msgs::msg::VelocityLimit::ConstSharedPtr msg_ptr)
+  const autoware_internal_planning_msgs::msg::VelocityLimit::ConstSharedPtr msg_ptr)
 {
   if (!overlay_->isVisible()) {
     return;

--- a/visualization/tier4_planning_rviz_plugin/src/tools/max_velocity.cpp
+++ b/visualization/tier4_planning_rviz_plugin/src/tools/max_velocity.cpp
@@ -116,9 +116,10 @@ void MaxVelocityDisplay::subscribe()
   std::string topic_name = property_topic_name_->getStdString();
   if (topic_name.length() > 0 && topic_name != "/") {
     rclcpp::Node::SharedPtr raw_node = context_->getRosNodeAbstraction().lock()->get_raw_node();
-    max_vel_sub_ = raw_node->create_subscription<autoware_internal_planning_msgs::msg::VelocityLimit>(
-      topic_name, rclcpp::QoS{1}.transient_local(),
-      std::bind(&MaxVelocityDisplay::processMessage, this, std::placeholders::_1));
+    max_vel_sub_ =
+      raw_node->create_subscription<autoware_internal_planning_msgs::msg::VelocityLimit>(
+        topic_name, rclcpp::QoS{1}.transient_local(),
+        std::bind(&MaxVelocityDisplay::processMessage, this, std::placeholders::_1));
   }
 }
 

--- a/visualization/tier4_planning_rviz_plugin/src/tools/max_velocity.hpp
+++ b/visualization/tier4_planning_rviz_plugin/src/tools/max_velocity.hpp
@@ -63,7 +63,8 @@ private Q_SLOTS:
   void updateVisualization();
 
 protected:
-  void processMessage(const autoware_internal_planning_msgs::msg::VelocityLimit::ConstSharedPtr msg_ptr);
+  void processMessage(
+    const autoware_internal_planning_msgs::msg::VelocityLimit::ConstSharedPtr msg_ptr);
   jsk_rviz_plugins::OverlayObject::Ptr overlay_;
   rviz_common::properties::ColorProperty * property_text_color_;
   rviz_common::properties::IntProperty * property_left_;

--- a/visualization/tier4_planning_rviz_plugin/src/tools/max_velocity.hpp
+++ b/visualization/tier4_planning_rviz_plugin/src/tools/max_velocity.hpp
@@ -34,7 +34,7 @@
 #include <rviz_common/tool.hpp>
 #include <rviz_common/validate_floats.hpp>
 
-#include <tier4_planning_msgs/msg/velocity_limit.hpp>
+#include <autoware_internal_planning_msgs/msg/velocity_limit.hpp>
 
 #include <OgreBillboardSet.h>
 #include <OgreManualObject.h>
@@ -63,7 +63,7 @@ private Q_SLOTS:
   void updateVisualization();
 
 protected:
-  void processMessage(const tier4_planning_msgs::msg::VelocityLimit::ConstSharedPtr msg_ptr);
+  void processMessage(const autoware_internal_planning_msgs::msg::VelocityLimit::ConstSharedPtr msg_ptr);
   jsk_rviz_plugins::OverlayObject::Ptr overlay_;
   rviz_common::properties::ColorProperty * property_text_color_;
   rviz_common::properties::IntProperty * property_left_;
@@ -73,8 +73,8 @@ protected:
   rviz_common::properties::FloatProperty * property_value_scale_;
 
 private:
-  rclcpp::Subscription<tier4_planning_msgs::msg::VelocityLimit>::SharedPtr max_vel_sub_;
-  tier4_planning_msgs::msg::VelocityLimit::ConstSharedPtr last_msg_ptr_;
+  rclcpp::Subscription<autoware_internal_planning_msgs::msg::VelocityLimit>::SharedPtr max_vel_sub_;
+  autoware_internal_planning_msgs::msg::VelocityLimit::ConstSharedPtr last_msg_ptr_;
 };
 
 }  // namespace rviz_plugins

--- a/visualization/tier4_state_rviz_plugin/README.md
+++ b/visualization/tier4_state_rviz_plugin/README.md
@@ -20,18 +20,18 @@ This plugin also can engage from the panel.
 
 ### Output
 
-| Name                                               | Type                                               | Description                                        |
-| -------------------------------------------------- | -------------------------------------------------- | -------------------------------------------------- |
-| `/api/operation_mode/change_to_autonomous`         | `autoware_adapi_v1_msgs::srv::ChangeOperationMode` | The service to change operation mode to autonomous |
-| `/api/operation_mode/change_to_stop`               | `autoware_adapi_v1_msgs::srv::ChangeOperationMode` | The service to change operation mode to stop       |
-| `/api/operation_mode/change_to_local`              | `autoware_adapi_v1_msgs::srv::ChangeOperationMode` | The service to change operation mode to local      |
-| `/api/operation_mode/change_to_remote`             | `autoware_adapi_v1_msgs::srv::ChangeOperationMode` | The service to change operation mode to remote     |
-| `/api/operation_mode/enable_autoware_control`      | `autoware_adapi_v1_msgs::srv::ChangeOperationMode` | The service to enable vehicle control by Autoware  |
-| `/api/operation_mode/disable_autoware_control`     | `autoware_adapi_v1_msgs::srv::ChangeOperationMode` | The service to disable vehicle control by Autoware |
-| `/api/routing/clear_route`                         | `autoware_adapi_v1_msgs::srv::ClearRoute`          | The service to clear route state                   |
-| `/api/motion/accept_start`                         | `autoware_adapi_v1_msgs::srv::AcceptStart`         | The service to accept the vehicle to start         |
-| `/api/autoware/set/emergency`                      | `tier4_external_api_msgs::srv::SetEmergency`       | The service to set external emergency              |
-| `/planning/scenario_planning/max_velocity_default` | `autoware_internal_planning_msgs::msg::VelocityLimit`          | The topic to set maximum speed of the vehicle      |
+| Name                                               | Type                                                  | Description                                        |
+| -------------------------------------------------- | ----------------------------------------------------- | -------------------------------------------------- |
+| `/api/operation_mode/change_to_autonomous`         | `autoware_adapi_v1_msgs::srv::ChangeOperationMode`    | The service to change operation mode to autonomous |
+| `/api/operation_mode/change_to_stop`               | `autoware_adapi_v1_msgs::srv::ChangeOperationMode`    | The service to change operation mode to stop       |
+| `/api/operation_mode/change_to_local`              | `autoware_adapi_v1_msgs::srv::ChangeOperationMode`    | The service to change operation mode to local      |
+| `/api/operation_mode/change_to_remote`             | `autoware_adapi_v1_msgs::srv::ChangeOperationMode`    | The service to change operation mode to remote     |
+| `/api/operation_mode/enable_autoware_control`      | `autoware_adapi_v1_msgs::srv::ChangeOperationMode`    | The service to enable vehicle control by Autoware  |
+| `/api/operation_mode/disable_autoware_control`     | `autoware_adapi_v1_msgs::srv::ChangeOperationMode`    | The service to disable vehicle control by Autoware |
+| `/api/routing/clear_route`                         | `autoware_adapi_v1_msgs::srv::ClearRoute`             | The service to clear route state                   |
+| `/api/motion/accept_start`                         | `autoware_adapi_v1_msgs::srv::AcceptStart`            | The service to accept the vehicle to start         |
+| `/api/autoware/set/emergency`                      | `tier4_external_api_msgs::srv::SetEmergency`          | The service to set external emergency              |
+| `/planning/scenario_planning/max_velocity_default` | `autoware_internal_planning_msgs::msg::VelocityLimit` | The topic to set maximum speed of the vehicle      |
 
 ## HowToUse
 

--- a/visualization/tier4_state_rviz_plugin/README.md
+++ b/visualization/tier4_state_rviz_plugin/README.md
@@ -31,7 +31,7 @@ This plugin also can engage from the panel.
 | `/api/routing/clear_route`                         | `autoware_adapi_v1_msgs::srv::ClearRoute`          | The service to clear route state                   |
 | `/api/motion/accept_start`                         | `autoware_adapi_v1_msgs::srv::AcceptStart`         | The service to accept the vehicle to start         |
 | `/api/autoware/set/emergency`                      | `tier4_external_api_msgs::srv::SetEmergency`       | The service to set external emergency              |
-| `/planning/scenario_planning/max_velocity_default` | `tier4_planning_msgs::msg::VelocityLimit`          | The topic to set maximum speed of the vehicle      |
+| `/planning/scenario_planning/max_velocity_default` | `autoware_internal_planning_msgs::msg::VelocityLimit`          | The topic to set maximum speed of the vehicle      |
 
 ## HowToUse
 

--- a/visualization/tier4_state_rviz_plugin/package.xml
+++ b/visualization/tier4_state_rviz_plugin/package.xml
@@ -14,6 +14,7 @@
 
   <depend>ament_index_cpp</depend>
   <depend>autoware_adapi_v1_msgs</depend>
+  <depend>autoware_internal_planning_msgs</depend>
   <depend>autoware_motion_utils</depend>
   <depend>autoware_vehicle_msgs</depend>
   <depend>libqt5-core</depend>
@@ -24,7 +25,6 @@
   <depend>rviz_common</depend>
   <depend>tier4_control_msgs</depend>
   <depend>tier4_external_api_msgs</depend>
-  <depend>autoware_internal_planning_msgs</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>

--- a/visualization/tier4_state_rviz_plugin/package.xml
+++ b/visualization/tier4_state_rviz_plugin/package.xml
@@ -24,7 +24,7 @@
   <depend>rviz_common</depend>
   <depend>tier4_control_msgs</depend>
   <depend>tier4_external_api_msgs</depend>
-  <depend>tier4_planning_msgs</depend>
+  <depend>autoware_internal_planning_msgs</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>

--- a/visualization/tier4_state_rviz_plugin/src/autoware_state_panel.cpp
+++ b/visualization/tier4_state_rviz_plugin/src/autoware_state_panel.cpp
@@ -149,7 +149,7 @@ void AutowareStatePanel::onInitialize()
   client_emergency_stop_ = raw_node_->create_client<tier4_external_api_msgs::srv::SetEmergency>(
     "/api/autoware/set/emergency");
 
-  pub_velocity_limit_ = raw_node_->create_publisher<tier4_planning_msgs::msg::VelocityLimit>(
+  pub_velocity_limit_ = raw_node_->create_publisher<autoware_internal_planning_msgs::msg::VelocityLimit>(
     "/planning/scenario_planning/max_velocity_default", rclcpp::QoS{1}.transient_local());
 
   QObject::connect(segmented_button, &CustomSegmentedButton::buttonClicked, this, [this](int id) {
@@ -804,7 +804,7 @@ void AutowareStatePanel::onSwitchStateChanged(int state)
 
 void AutowareStatePanel::onClickVelocityLimit()
 {
-  auto velocity_limit = std::make_shared<tier4_planning_msgs::msg::VelocityLimit>();
+  auto velocity_limit = std::make_shared<autoware_internal_planning_msgs::msg::VelocityLimit>();
   velocity_limit->stamp = raw_node_->now();
   velocity_limit->max_velocity = velocity_limit_value_label_->text().toDouble() / 3.6;
   pub_velocity_limit_->publish(*velocity_limit);

--- a/visualization/tier4_state_rviz_plugin/src/autoware_state_panel.cpp
+++ b/visualization/tier4_state_rviz_plugin/src/autoware_state_panel.cpp
@@ -149,8 +149,9 @@ void AutowareStatePanel::onInitialize()
   client_emergency_stop_ = raw_node_->create_client<tier4_external_api_msgs::srv::SetEmergency>(
     "/api/autoware/set/emergency");
 
-  pub_velocity_limit_ = raw_node_->create_publisher<autoware_internal_planning_msgs::msg::VelocityLimit>(
-    "/planning/scenario_planning/max_velocity_default", rclcpp::QoS{1}.transient_local());
+  pub_velocity_limit_ =
+    raw_node_->create_publisher<autoware_internal_planning_msgs::msg::VelocityLimit>(
+      "/planning/scenario_planning/max_velocity_default", rclcpp::QoS{1}.transient_local());
 
   QObject::connect(segmented_button, &CustomSegmentedButton::buttonClicked, this, [this](int id) {
     const QList<QAbstractButton *> buttons = segmented_button->getButtonGroup()->buttons();

--- a/visualization/tier4_state_rviz_plugin/src/include/autoware_state_panel.hpp
+++ b/visualization/tier4_state_rviz_plugin/src/include/autoware_state_panel.hpp
@@ -49,12 +49,12 @@
 #include <autoware_adapi_v1_msgs/srv/change_operation_mode.hpp>
 #include <autoware_adapi_v1_msgs/srv/clear_route.hpp>
 #include <autoware_adapi_v1_msgs/srv/initialize_localization.hpp>
+#include <autoware_internal_planning_msgs/msg/velocity_limit.hpp>
 #include <autoware_vehicle_msgs/msg/gear_report.hpp>
 #include <diagnostic_msgs/msg/diagnostic_array.hpp>
 #include <diagnostic_msgs/msg/diagnostic_status.hpp>
 #include <tier4_external_api_msgs/msg/emergency.hpp>
 #include <tier4_external_api_msgs/srv/set_emergency.hpp>
-#include <autoware_internal_planning_msgs/msg/velocity_limit.hpp>
 
 #include <qlabel.h>
 
@@ -119,7 +119,8 @@ protected:
   rclcpp::Client<tier4_external_api_msgs::srv::SetEmergency>::SharedPtr client_emergency_stop_;
   rclcpp::Subscription<tier4_external_api_msgs::msg::Emergency>::SharedPtr sub_emergency_;
 
-  rclcpp::Publisher<autoware_internal_planning_msgs::msg::VelocityLimit>::SharedPtr pub_velocity_limit_;
+  rclcpp::Publisher<autoware_internal_planning_msgs::msg::VelocityLimit>::SharedPtr
+    pub_velocity_limit_;
 
   QLabel * velocity_limit_value_label_{nullptr};
   bool sliderIsDragging = false;

--- a/visualization/tier4_state_rviz_plugin/src/include/autoware_state_panel.hpp
+++ b/visualization/tier4_state_rviz_plugin/src/include/autoware_state_panel.hpp
@@ -54,7 +54,7 @@
 #include <diagnostic_msgs/msg/diagnostic_status.hpp>
 #include <tier4_external_api_msgs/msg/emergency.hpp>
 #include <tier4_external_api_msgs/srv/set_emergency.hpp>
-#include <tier4_planning_msgs/msg/velocity_limit.hpp>
+#include <autoware_internal_planning_msgs/msg/velocity_limit.hpp>
 
 #include <qlabel.h>
 
@@ -119,7 +119,7 @@ protected:
   rclcpp::Client<tier4_external_api_msgs::srv::SetEmergency>::SharedPtr client_emergency_stop_;
   rclcpp::Subscription<tier4_external_api_msgs::msg::Emergency>::SharedPtr sub_emergency_;
 
-  rclcpp::Publisher<tier4_planning_msgs::msg::VelocityLimit>::SharedPtr pub_velocity_limit_;
+  rclcpp::Publisher<autoware_internal_planning_msgs::msg::VelocityLimit>::SharedPtr pub_velocity_limit_;
 
   QLabel * velocity_limit_value_label_{nullptr};
   bool sliderIsDragging = false;


### PR DESCRIPTION
## Description
We are porting autoware_velocity_smoother to autoware.core, this PR: 

1. resolve the conflict when replace tire4 message 
2. replace autoware_universe_utils with autowre_utils
3. resolve the conflict when complie the whole autoware
4. refactor readme according to migrate guide

## Related links

 **Parent Issue:** -- https://github.com/autowarefoundation/autoware.core/issues/192



<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
**check box selected means passed**
- [x] test with concol build "colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release" for all packages
- [x] test with planning simulator

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
