### PR TITLE
ci: use Code Build for clang-tidy-differential-cuda

### DIFF
--- a/.github/workflows/build-test-tidy-pr.yaml
+++ b/.github/workflows/build-test-tidy-pr.yaml
@@ -83,3 +83,4 @@ jobs:
       container: ghcr.io/autowarefoundation/autoware:universe-devel
       container-suffix: -cuda
       run-condition: ${{ needs.check-if-cuda-job-is-needed.outputs.cuda_job_is_needed == 'true' && needs.build-and-test-differential-cuda.result == 'success' }}
+      runner: codebuild-autoware-us-east-1-${{ github.run_id }}-${{ github.run_attempt }}-ubuntu-7.0-large


### PR DESCRIPTION
## Description

I have modified build-test-tidy-pr workflow to use AWs Code Build for build-and-test-differential-cuda in [this PR](https://github.com/autowarefoundation/autoware.universe/pull/10198), but I have forgotten to update the runner for clang-tidy-differential-cuda. 

This PR modifies the clang-tidy-differential-cuda to use AWS Code Build to avoid space disk issue

## Related links

- [Link](https://github.com/autowarefoundation/autoware.universe/pull/10198)

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
