### PR TITLE
fix(goal_planner): invert lane boundary of neighbor opposite lanelets when generating departure check lane

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/util.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/util.cpp
@@ -715,13 +715,8 @@ lanelet::Lanelet createDepartureCheckLanelet(
     lanelet::Points3d points;
     const auto & bound = left_side_parking ? (is_outer ? lane.leftBound() : lane.rightBound())
                                            : (is_outer ? lane.rightBound() : lane.leftBound());
-    if (invert) {
-      for (const auto & pt : bound.invert()) {
-        points.push_back(lanelet::Point3d(pt));
-      }
-      return points;
-    }
-    for (const auto & pt : bound) {
+    const auto ego_oriented_bound = invert ? bound.invert() : bound;
+    for (const auto & pt : ego_oriented_bound) {
       points.push_back(lanelet::Point3d(pt));
     }
     return points;

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/util.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/util.cpp
@@ -709,33 +709,43 @@ lanelet::Lanelet createDepartureCheckLanelet(
   const lanelet::ConstLanelets & pull_over_lanes, const route_handler::RouteHandler & route_handler,
   const bool left_side_parking)
 {
-  const auto getBoundPoints =
-    [&](const lanelet::ConstLanelet & lane, const bool is_outer) -> lanelet::Points3d {
+  const auto getBoundPoints = [&](
+                                const lanelet::ConstLanelet & lane, const bool is_outer,
+                                const bool invert) -> lanelet::Points3d {
     lanelet::Points3d points;
     const auto & bound = left_side_parking ? (is_outer ? lane.leftBound() : lane.rightBound())
                                            : (is_outer ? lane.rightBound() : lane.leftBound());
+    if (invert) {
+      for (const auto & pt : bound.invert()) {
+        points.push_back(lanelet::Point3d(pt));
+      }
+      return points;
+    }
     for (const auto & pt : bound) {
       points.push_back(lanelet::Point3d(pt));
     }
     return points;
   };
 
-  const auto getMostInnerLane = [&](const lanelet::ConstLanelet & lane) -> lanelet::ConstLanelet {
+  const auto getMostInnerLane =
+    [&](const lanelet::ConstLanelet & lane) -> std::pair<lanelet::ConstLanelet, bool> {
     const auto getInnerLane =
       left_side_parking ? &RouteHandler::getMostRightLanelet : &RouteHandler::getMostLeftLanelet;
     const auto getOppositeLane = left_side_parking ? &RouteHandler::getRightOppositeLanelets
                                                    : &RouteHandler::getLeftOppositeLanelets;
     const auto inner_lane = (route_handler.*getInnerLane)(lane, true, true);
     const auto opposite_lanes = (route_handler.*getOppositeLane)(inner_lane);
-    return opposite_lanes.empty() ? inner_lane : opposite_lanes.front();
+    return std::make_pair(
+      opposite_lanes.empty() ? inner_lane : opposite_lanes.front(), !opposite_lanes.empty());
   };
 
   lanelet::Points3d outer_bound_points{};
   lanelet::Points3d inner_bound_points{};
   for (const auto & lane : pull_over_lanes) {
-    const auto current_outer_bound_points = getBoundPoints(lane, true);
-    const auto most_inner_lane = getMostInnerLane(lane);
-    const auto current_inner_bound_points = getBoundPoints(most_inner_lane, false);
+    const auto current_outer_bound_points = getBoundPoints(lane, true, false);
+    const auto most_inner_lane_info = getMostInnerLane(lane);
+    const auto current_inner_bound_points =
+      getBoundPoints(most_inner_lane_info.first, false, most_inner_lane_info.second);
     outer_bound_points = combineLanePoints(outer_bound_points, current_outer_bound_points);
     inner_bound_points = combineLanePoints(inner_bound_points, current_inner_bound_points);
   }


### PR DESCRIPTION
## Description
When creating departure_check_lane for the search function in goal_searcher. If the inner lane is opposite, it should be inverted before generating the new lane. Otherwise, the generated polygon for departure_check_lane can not be used with "within" function.

## Related links

**Before PR**

[Link](https://youtu.be/7AyDrwKAs5M)

**After PR**

[Link](https://youtu.be/P8heUlGxtbg)

**Parent Issue:**

- https://github.com/autowarefoundation/autoware.universe/issues/10206

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
PSim

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
