### PR TITLE
feat(behavior_path_planner_common): modify drivable area expansion to be able to avoid static objects

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_planner/config/drivable_area_expansion.param.yaml
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner/config/drivable_area_expansion.param.yaml
@@ -19,13 +19,15 @@
         extra_wheelbase: 0.0 # [m] extra length to add to the wheelbase
         extra_front_overhang: 0.5 # [m] extra length to add to the front overhang
         extra_width: 1.0 # [m] extra length to add to the width
-      dynamic_objects:
-        avoid: false # if true, the drivable area is not expanded in the predicted path of dynamic objects
+      object_exclusion:
+        exclude_static: false # if true, the drivable area is not expanded over static objects
+        exclude_dynamic: false # if true, the drivable area is not expanded in the predicted path of dynamic objects
+        stopped_object_velocity_threshold: 1.0 # [m/s] velocity threshold for static objects
         extra_footprint_offset:
-          front: 0.5 # [m] extra length to add to the front of the dynamic object footprint
-          rear: 0.5 # [m] extra length to add to the rear of the dynamic object footprint
-          left: 0.5 # [m] extra length to add to the left of the dynamic object footprint
-          right: 0.5 # [m] extra length to add to the rear of the dynamic object footprint
+          front: 0.5 # [m] extra length to add to the front of object footprint
+          rear: 0.5 # [m] extra length to add to the rear of object footprint
+          left: 0.5 # [m] extra length to add to the left of object footprint
+          right: 0.5 # [m] extra length to add to the rear of object footprint
       path_preprocessing:
         max_arc_length: 100.0 # [m] maximum arc length along the path where the ego footprint is projected (0.0 means no limit)
         resample_interval: 2.0 # [m] fixed interval between resampled path points (0.0 means path points are directly used)

--- a/planning/behavior_path_planner/autoware_behavior_path_planner/config/drivable_area_expansion.param.yaml
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner/config/drivable_area_expansion.param.yaml
@@ -20,14 +20,14 @@
         extra_front_overhang: 0.5 # [m] extra length to add to the front overhang
         extra_width: 1.0 # [m] extra length to add to the width
       object_exclusion:
-        exclude_static: false # if true, the drivable area is not expanded over static objects
+        exclude_static: true # if true, the drivable area is not expanded over static objects
         exclude_dynamic: false # if true, the drivable area is not expanded in the predicted path of dynamic objects
-        stopped_object_velocity_threshold: 1.0 # [m/s] velocity threshold for static objects
-        extra_footprint_offset:
-          front: 0.5 # [m] extra length to add to the front of object footprint
-          rear: 0.5 # [m] extra length to add to the rear of object footprint
-          left: 0.5 # [m] extra length to add to the left of object footprint
-          right: 0.5 # [m] extra length to add to the rear of object footprint
+        th_stopped_object_velocity: 1.0 # [m/s] velocity threshold for static objects
+        safety_margin:
+          front: 0.75 # [m] margin to add to the front of object footprint
+          rear: 0.75 # [m] margin to add to the rear of object footprint
+          left: 0.75 # [m] margin to add to the left of object footprint
+          right: 0.75 # [m] margin to add to the rear of object footprint
       path_preprocessing:
         max_arc_length: 100.0 # [m] maximum arc length along the path where the ego footprint is projected (0.0 means no limit)
         resample_interval: 2.0 # [m] fixed interval between resampled path points (0.0 means path points are directly used)

--- a/planning/behavior_path_planner/autoware_behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -807,8 +807,11 @@ SetParametersResult BehaviorPathPlannerNode::onSetParam(
       parameters, DrivableAreaExpansionParameters::ENABLED_PARAM,
       planner_data_->drivable_area_expansion_parameters.enabled);
     update_param(
+      parameters, DrivableAreaExpansionParameters::AVOID_STA_OBJECTS_PARAM,
+      planner_data_->drivable_area_expansion_parameters.object_exclusion.exclude_static);
+    update_param(
       parameters, DrivableAreaExpansionParameters::AVOID_DYN_OBJECTS_PARAM,
-      planner_data_->drivable_area_expansion_parameters.avoid_dynamic_objects);
+      planner_data_->drivable_area_expansion_parameters.object_exclusion.exclude_dynamic);
     update_param(
       parameters, DrivableAreaExpansionParameters::AVOID_LINESTRING_TYPES_PARAM,
       planner_data_->drivable_area_expansion_parameters.avoid_linestring_types);
@@ -825,17 +828,20 @@ SetParametersResult BehaviorPathPlannerNode::onSetParam(
       parameters, DrivableAreaExpansionParameters::EGO_EXTRA_WIDTH,
       planner_data_->drivable_area_expansion_parameters.extra_width);
     update_param(
-      parameters, DrivableAreaExpansionParameters::DYN_OBJECTS_EXTRA_OFFSET_FRONT,
-      planner_data_->drivable_area_expansion_parameters.dynamic_objects_extra_front_offset);
+      parameters, DrivableAreaExpansionParameters::OBJECTS_EXTRA_OFFSET_FRONT,
+      planner_data_->drivable_area_expansion_parameters.object_exclusion.front_offset);
     update_param(
-      parameters, DrivableAreaExpansionParameters::DYN_OBJECTS_EXTRA_OFFSET_REAR,
-      planner_data_->drivable_area_expansion_parameters.dynamic_objects_extra_rear_offset);
+      parameters, DrivableAreaExpansionParameters::OBJECTS_EXTRA_OFFSET_REAR,
+      planner_data_->drivable_area_expansion_parameters.object_exclusion.rear_offset);
     update_param(
-      parameters, DrivableAreaExpansionParameters::DYN_OBJECTS_EXTRA_OFFSET_LEFT,
-      planner_data_->drivable_area_expansion_parameters.dynamic_objects_extra_left_offset);
+      parameters, DrivableAreaExpansionParameters::OBJECTS_EXTRA_OFFSET_LEFT,
+      planner_data_->drivable_area_expansion_parameters.object_exclusion.left_offset);
     update_param(
-      parameters, DrivableAreaExpansionParameters::DYN_OBJECTS_EXTRA_OFFSET_RIGHT,
-      planner_data_->drivable_area_expansion_parameters.dynamic_objects_extra_right_offset);
+      parameters, DrivableAreaExpansionParameters::OBJECTS_EXTRA_OFFSET_RIGHT,
+      planner_data_->drivable_area_expansion_parameters.object_exclusion.right_offset);
+    update_param(
+      parameters, DrivableAreaExpansionParameters::STOPPED_OBJ_VEL_THRESH,
+      planner_data_->drivable_area_expansion_parameters.object_exclusion.stopped_obj_vel_th);
     update_param(
       parameters, DrivableAreaExpansionParameters::MAX_EXP_DIST_PARAM,
       planner_data_->drivable_area_expansion_parameters.max_expansion_distance);

--- a/planning/behavior_path_planner/autoware_behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -828,16 +828,16 @@ SetParametersResult BehaviorPathPlannerNode::onSetParam(
       parameters, DrivableAreaExpansionParameters::EGO_EXTRA_WIDTH,
       planner_data_->drivable_area_expansion_parameters.extra_width);
     update_param(
-      parameters, DrivableAreaExpansionParameters::OBJECTS_EXTRA_OFFSET_FRONT,
+      parameters, DrivableAreaExpansionParameters::OBJECTS_SAFE_MARGIN_FRONT,
       planner_data_->drivable_area_expansion_parameters.object_exclusion.front_offset);
     update_param(
-      parameters, DrivableAreaExpansionParameters::OBJECTS_EXTRA_OFFSET_REAR,
+      parameters, DrivableAreaExpansionParameters::OBJECTS_SAFE_MARGIN_REAR,
       planner_data_->drivable_area_expansion_parameters.object_exclusion.rear_offset);
     update_param(
-      parameters, DrivableAreaExpansionParameters::OBJECTS_EXTRA_OFFSET_LEFT,
+      parameters, DrivableAreaExpansionParameters::OBJECTS_SAFE_MARGIN_LEFT,
       planner_data_->drivable_area_expansion_parameters.object_exclusion.left_offset);
     update_param(
-      parameters, DrivableAreaExpansionParameters::OBJECTS_EXTRA_OFFSET_RIGHT,
+      parameters, DrivableAreaExpansionParameters::OBJECTS_SAFE_MARGIN_RIGHT,
       planner_data_->drivable_area_expansion_parameters.object_exclusion.right_offset);
     update_param(
       parameters, DrivableAreaExpansionParameters::STOPPED_OBJ_VEL_THRESH,

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/docs/behavior_path_planner_drivable_area_design.md
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/docs/behavior_path_planner_drivable_area_design.md
@@ -43,11 +43,13 @@ Currently, when clipping left bound or right bound, it can clip the bound more t
 | ego.extra_wheel_base                         | [m]   | double       | extra ego wheelbase                                                                                     | 0.0                          |
 | ego.extra_front_overhang                     | [m]   | double       | extra ego overhang                                                                                      | 0.5                          |
 | ego.extra_width                              | [m]   | double       | extra ego width                                                                                         | 1.0                          |
-| dynamic_objects.avoid                        | [-]   | boolean      | if true, the drivable area is not expanded in the predicted path of dynamic objects                     | true                         |
-| dynamic_objects.extra_footprint_offset.front | [m]   | double       | extra length to add to the front of the ego footprint                                                   | 0.5                          |
-| dynamic_objects.extra_footprint_offset.rear  | [m]   | double       | extra length to add to the rear of the ego footprint                                                    | 0.5                          |
-| dynamic_objects.extra_footprint_offset.left  | [m]   | double       | extra length to add to the left of the ego footprint                                                    | 0.5                          |
-| dynamic_objects.extra_footprint_offset.right | [m]   | double       | extra length to add to the rear of the ego footprint                                                    | 0.5                          |
+| object_exclusion.exclude_static              | [-]   | boolean      | if true, the drivable area is not expanded over static objects                                          | true                         |
+| object_exclusion.exclude_dynamic             | [-]   | boolean      | if true, the drivable area is not expanded in the predicted path of dynamic objects                     | true                         |
+| object_exclusion.th_stopped_object_velocity  | [m/s] | double       | extra length to add to the front of the ego footprint                                                   | 0.5                          |
+| object_exclusion.safety_margin.front         | [m]   | double       | extra length to add to the front of the ego footprint                                                   | 0.5                          |
+| object_exclusion.safety_margin.rear          | [m]   | double       | extra length to add to the rear of the ego footprint                                                    | 0.5                          |
+| object_exclusion.safety_margin.left          | [m]   | double       | extra length to add to the left of the ego footprint                                                    | 0.5                          |
+| object_exclusion.safety_margin.right         | [m]   | double       | extra length to add to the rear of the ego footprint                                                    | 0.5                          |
 | path_preprocessing.max_arc_length            | [m]   | double       | maximum arc length along the path where the ego footprint is projected (0.0 means no limit)             | 100.0                        |
 | path_preprocessing.resample_interval         | [m]   | double       | fixed interval between resampled path points (0.0 means path points are directly used)                  | 2.0                          |
 | path_preprocessing.reuse_max_deviation       | [m]   | double       | if the path changes by more than this value, the curvatures are recalculated. Otherwise they are reused | 0.5                          |
@@ -133,9 +135,14 @@ This equation was derived from the work of [Lim, H., Kim, C., and Jo, A., "Model
 
 ![min width](../images/drivable_area/DynamicDrivableArea-MinWidth.drawio.svg)
 
-##### 3 Calculate maximum expansion distances of each bound point based on dynamic objects and linestring of the vector map (optional)
+##### 3 Calculate maximum expansion distances of each bound point based on detected objects and linestring of the vector map (optional)
 
-For each drivable area bound point, we calculate its maximum expansion distance as its distance to the closest "obstacle" (either a map linestring with type `avoid_linestrings.type`, or a dynamic object footprint if `dynamic_objects.avoid` is set to `true`).
+For each drivable area bound point, we calculate its maximum expansion distance as its distance to the closest "obstacle" which could be:
+
+1. Map linestring with type `avoid_linestrings.type`.
+2. Static object footprint (if `object_exclusion.exclude_static` is set to `true`).
+3. Dynamic object path footprint (if `object_exclusion.exclude_dynamic` is set to `true`).
+
 If `max_expansion_distance` is not `0.0`, it is use here if smaller than the distance to the closest obstacle.
 
 ![max distances](../images/drivable_area/DynamicDrivableArea-MaxWidth.drawio.svg)

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/docs/behavior_path_planner_drivable_area_design.md
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/docs/behavior_path_planner_drivable_area_design.md
@@ -49,7 +49,7 @@ Currently, when clipping left bound or right bound, it can clip the bound more t
 | object_exclusion.safety_margin.front         | [m]   | double       | extra length to add to the front of the ego footprint                                                   | 0.5                          |
 | object_exclusion.safety_margin.rear          | [m]   | double       | extra length to add to the rear of the ego footprint                                                    | 0.5                          |
 | object_exclusion.safety_margin.left          | [m]   | double       | extra length to add to the left of the ego footprint                                                    | 0.5                          |
-| object_exclusion.safety_margin.right         | [m]   | double       | extra length to add to the rear of the ego footprint                                                    | 0.5                          |
+| object_exclusion.safety_margin.right         | [m]   | double       | extra length to add to the right of the ego footprint                                                    | 0.5                          |
 | path_preprocessing.max_arc_length            | [m]   | double       | maximum arc length along the path where the ego footprint is projected (0.0 means no limit)             | 100.0                        |
 | path_preprocessing.resample_interval         | [m]   | double       | fixed interval between resampled path points (0.0 means path points are directly used)                  | 2.0                          |
 | path_preprocessing.reuse_max_deviation       | [m]   | double       | if the path changes by more than this value, the curvatures are recalculated. Otherwise they are reused | 0.5                          |

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/docs/behavior_path_planner_drivable_area_design.md
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/docs/behavior_path_planner_drivable_area_design.md
@@ -32,29 +32,29 @@ Currently, when clipping left bound or right bound, it can clip the bound more t
 
 ### Dynamic expansion
 
-| Name                                         | Unit  | Type         | Description                                                                                             | Default value                |
-| :------------------------------------------- | :---- | :----------- | :------------------------------------------------------------------------------------------------------ | :--------------------------- |
-| enabled                                      | [-]   | boolean      | if true, dynamically expand the drivable area based on the path curvature                               | true                         |
-| print_runtime                                | [-]   | boolean      | if true, runtime is logged by the node                                                                  | true                         |
-| max_expansion_distance                       | [m]   | double       | maximum distance by which the original drivable area can be expanded (no limit if set to 0)             | 0.0                          |
-| smoothing.curvature_average_window           | [-]   | int          | window size used for smoothing the curvatures using a moving window average                             | 3                            |
-| smoothing.max_bound_rate                     | [m/m] | double       | maximum rate of change of the bound lateral distance over its arc length                                | 1.0                          |
-| smoothing.arc_length_range                   | [m]   | double       | arc length range where an expansion distance is initially applied                                       | 2.0                          |
-| ego.extra_wheel_base                         | [m]   | double       | extra ego wheelbase                                                                                     | 0.0                          |
-| ego.extra_front_overhang                     | [m]   | double       | extra ego overhang                                                                                      | 0.5                          |
-| ego.extra_width                              | [m]   | double       | extra ego width                                                                                         | 1.0                          |
-| object_exclusion.exclude_static              | [-]   | boolean      | if true, the drivable area is not expanded over static objects                                          | true                         |
-| object_exclusion.exclude_dynamic             | [-]   | boolean      | if true, the drivable area is not expanded in the predicted path of dynamic objects                     | true                         |
-| object_exclusion.th_stopped_object_velocity  | [m/s] | double       | extra length to add to the front of the ego footprint                                                   | 0.5                          |
-| object_exclusion.safety_margin.front         | [m]   | double       | extra length to add to the front of the ego footprint                                                   | 0.5                          |
-| object_exclusion.safety_margin.rear          | [m]   | double       | extra length to add to the rear of the ego footprint                                                    | 0.5                          |
-| object_exclusion.safety_margin.left          | [m]   | double       | extra length to add to the left of the ego footprint                                                    | 0.5                          |
-| object_exclusion.safety_margin.right         | [m]   | double       | extra length to add to the right of the ego footprint                                                    | 0.5                          |
-| path_preprocessing.max_arc_length            | [m]   | double       | maximum arc length along the path where the ego footprint is projected (0.0 means no limit)             | 100.0                        |
-| path_preprocessing.resample_interval         | [m]   | double       | fixed interval between resampled path points (0.0 means path points are directly used)                  | 2.0                          |
-| path_preprocessing.reuse_max_deviation       | [m]   | double       | if the path changes by more than this value, the curvatures are recalculated. Otherwise they are reused | 0.5                          |
-| avoid_linestring.types                       | [-]   | string array | linestring types in the lanelet maps that will not be crossed when expanding the drivable area          | ["road_border", "curbstone"] |
-| avoid_linestring.distance                    | [m]   | double       | distance to keep between the drivable area and the linestrings to avoid                                 | 0.0                          |
+| Name                                        | Unit  | Type         | Description                                                                                             | Default value                |
+| :------------------------------------------ | :---- | :----------- | :------------------------------------------------------------------------------------------------------ | :--------------------------- |
+| enabled                                     | [-]   | boolean      | if true, dynamically expand the drivable area based on the path curvature                               | true                         |
+| print_runtime                               | [-]   | boolean      | if true, runtime is logged by the node                                                                  | true                         |
+| max_expansion_distance                      | [m]   | double       | maximum distance by which the original drivable area can be expanded (no limit if set to 0)             | 0.0                          |
+| smoothing.curvature_average_window          | [-]   | int          | window size used for smoothing the curvatures using a moving window average                             | 3                            |
+| smoothing.max_bound_rate                    | [m/m] | double       | maximum rate of change of the bound lateral distance over its arc length                                | 1.0                          |
+| smoothing.arc_length_range                  | [m]   | double       | arc length range where an expansion distance is initially applied                                       | 2.0                          |
+| ego.extra_wheel_base                        | [m]   | double       | extra ego wheelbase                                                                                     | 0.0                          |
+| ego.extra_front_overhang                    | [m]   | double       | extra ego overhang                                                                                      | 0.5                          |
+| ego.extra_width                             | [m]   | double       | extra ego width                                                                                         | 1.0                          |
+| object_exclusion.exclude_static             | [-]   | boolean      | if true, the drivable area is not expanded over static objects                                          | true                         |
+| object_exclusion.exclude_dynamic            | [-]   | boolean      | if true, the drivable area is not expanded in the predicted path of dynamic objects                     | true                         |
+| object_exclusion.th_stopped_object_velocity | [m/s] | double       | velocity threshold for static objects                                                                   | 1.0                          |
+| object_exclusion.safety_margin.front        | [m]   | double       | extra length to add to the front of the object footprint                                                | 0.75                         |
+| object_exclusion.safety_margin.rear         | [m]   | double       | extra length to add to the rear of the object footprint                                                 | 0.75                         |
+| object_exclusion.safety_margin.left         | [m]   | double       | extra length to add to the left of the object footprint                                                 | 0.75                         |
+| object_exclusion.safety_margin.right        | [m]   | double       | extra length to add to the right of the object footprint                                                | 0.75                         |
+| path_preprocessing.max_arc_length           | [m]   | double       | maximum arc length along the path where the ego footprint is projected (0.0 means no limit)             | 100.0                        |
+| path_preprocessing.resample_interval        | [m]   | double       | fixed interval between resampled path points (0.0 means path points are directly used)                  | 2.0                          |
+| path_preprocessing.reuse_max_deviation      | [m]   | double       | if the path changes by more than this value, the curvatures are recalculated. Otherwise they are reused | 0.5                          |
+| avoid_linestring.types                      | [-]   | string array | linestring types in the lanelet maps that will not be crossed when expanding the drivable area          | ["road_border", "curbstone"] |
+| avoid_linestring.distance                   | [m]   | double       | distance to keep between the drivable area and the linestrings to avoid                                 | 0.0                          |
 
 ## Inner-workings / Algorithms
 

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/utils/drivable_area_expansion/parameters.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/utils/drivable_area_expansion/parameters.hpp
@@ -33,16 +33,16 @@ struct DrivableAreaExpansionParameters
   static constexpr auto EGO_EXTRA_FRONT_OVERHANG = "dynamic_expansion.ego.extra_front_overhang";
   static constexpr auto EGO_EXTRA_WHEELBASE = "dynamic_expansion.ego.extra_wheelbase";
   static constexpr auto EGO_EXTRA_WIDTH = "dynamic_expansion.ego.extra_width";
-  static constexpr auto OBJECTS_EXTRA_OFFSET_FRONT =
-    "dynamic_expansion.object_exclusion.extra_footprint_offset.front";
-  static constexpr auto OBJECTS_EXTRA_OFFSET_REAR =
-    "dynamic_expansion.object_exclusion.extra_footprint_offset.rear";
-  static constexpr auto OBJECTS_EXTRA_OFFSET_LEFT =
-    "dynamic_expansion.object_exclusion.extra_footprint_offset.left";
-  static constexpr auto OBJECTS_EXTRA_OFFSET_RIGHT =
-    "dynamic_expansion.object_exclusion.extra_footprint_offset.right";
+  static constexpr auto OBJECTS_SAFE_MARGIN_FRONT =
+    "dynamic_expansion.object_exclusion.safety_margin.front";
+  static constexpr auto OBJECTS_SAFE_MARGIN_REAR =
+    "dynamic_expansion.object_exclusion.safety_margin.rear";
+  static constexpr auto OBJECTS_SAFE_MARGIN_LEFT =
+    "dynamic_expansion.object_exclusion.safety_margin.left";
+  static constexpr auto OBJECTS_SAFE_MARGIN_RIGHT =
+    "dynamic_expansion.object_exclusion.safety_margin.right";
   static constexpr auto STOPPED_OBJ_VEL_THRESH =
-    "dynamic_expansion.object_exclusion.stopped_object_velocity_threshold";
+    "dynamic_expansion.object_exclusion.th_stopped_object_velocity";
   static constexpr auto MAX_EXP_DIST_PARAM = "dynamic_expansion.max_expansion_distance";
   static constexpr auto RESAMPLE_INTERVAL_PARAM =
     "dynamic_expansion.path_preprocessing.resample_interval";
@@ -121,10 +121,10 @@ struct DrivableAreaExpansionParameters
     object_exclusion.exclude_static = node.declare_parameter<bool>(AVOID_STA_OBJECTS_PARAM);
     object_exclusion.exclude_dynamic = node.declare_parameter<bool>(AVOID_DYN_OBJECTS_PARAM);
     object_exclusion.stopped_obj_vel_th = node.declare_parameter<double>(STOPPED_OBJ_VEL_THRESH);
-    object_exclusion.front_offset = node.declare_parameter<double>(OBJECTS_EXTRA_OFFSET_FRONT);
-    object_exclusion.rear_offset = node.declare_parameter<double>(OBJECTS_EXTRA_OFFSET_REAR);
-    object_exclusion.left_offset = node.declare_parameter<double>(OBJECTS_EXTRA_OFFSET_LEFT);
-    object_exclusion.right_offset = node.declare_parameter<double>(OBJECTS_EXTRA_OFFSET_RIGHT);
+    object_exclusion.front_offset = node.declare_parameter<double>(OBJECTS_SAFE_MARGIN_FRONT);
+    object_exclusion.rear_offset = node.declare_parameter<double>(OBJECTS_SAFE_MARGIN_REAR);
+    object_exclusion.left_offset = node.declare_parameter<double>(OBJECTS_SAFE_MARGIN_LEFT);
+    object_exclusion.right_offset = node.declare_parameter<double>(OBJECTS_SAFE_MARGIN_RIGHT);
     avoid_linestring_types =
       node.declare_parameter<std::vector<std::string>>(AVOID_LINESTRING_TYPES_PARAM);
     avoid_linestring_dist = node.declare_parameter<double>(AVOID_LINESTRING_DIST_PARAM);

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/utils/drivable_area_expansion/parameters.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/utils/drivable_area_expansion/parameters.hpp
@@ -50,8 +50,10 @@ struct DrivableAreaExpansionParameters
     "dynamic_expansion.path_preprocessing.max_arc_length";
   static constexpr auto MAX_REUSE_DEVIATION_PARAM =
     "dynamic_expansion.path_preprocessing.reuse_max_deviation";
-  static constexpr auto AVOID_STA_OBJECTS_PARAM = "dynamic_expansion.object_exclusion.exclude_static";
-  static constexpr auto AVOID_DYN_OBJECTS_PARAM = "dynamic_expansion.object_exclusion.exclude_dynamic";
+  static constexpr auto AVOID_STA_OBJECTS_PARAM =
+    "dynamic_expansion.object_exclusion.exclude_static";
+  static constexpr auto AVOID_DYN_OBJECTS_PARAM =
+    "dynamic_expansion.object_exclusion.exclude_dynamic";
   static constexpr auto AVOID_LINESTRING_TYPES_PARAM = "dynamic_expansion.avoid_linestring.types";
   static constexpr auto AVOID_LINESTRING_DIST_PARAM = "dynamic_expansion.avoid_linestring.distance";
   static constexpr auto SMOOTHING_CURVATURE_WINDOW_PARAM =
@@ -83,7 +85,8 @@ struct DrivableAreaExpansionParameters
   double min_bound_interval{};
   bool print_runtime{};
 
-  struct ObjectExclusion{
+  struct ObjectExclusion
+  {
     bool exclude_static{};
     bool exclude_dynamic{};
     double front_offset{};

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/utils/drivable_area_expansion/parameters.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/utils/drivable_area_expansion/parameters.hpp
@@ -33,14 +33,16 @@ struct DrivableAreaExpansionParameters
   static constexpr auto EGO_EXTRA_FRONT_OVERHANG = "dynamic_expansion.ego.extra_front_overhang";
   static constexpr auto EGO_EXTRA_WHEELBASE = "dynamic_expansion.ego.extra_wheelbase";
   static constexpr auto EGO_EXTRA_WIDTH = "dynamic_expansion.ego.extra_width";
-  static constexpr auto DYN_OBJECTS_EXTRA_OFFSET_FRONT =
-    "dynamic_expansion.dynamic_objects.extra_footprint_offset.front";
-  static constexpr auto DYN_OBJECTS_EXTRA_OFFSET_REAR =
-    "dynamic_expansion.dynamic_objects.extra_footprint_offset.rear";
-  static constexpr auto DYN_OBJECTS_EXTRA_OFFSET_LEFT =
-    "dynamic_expansion.dynamic_objects.extra_footprint_offset.left";
-  static constexpr auto DYN_OBJECTS_EXTRA_OFFSET_RIGHT =
-    "dynamic_expansion.dynamic_objects.extra_footprint_offset.right";
+  static constexpr auto OBJECTS_EXTRA_OFFSET_FRONT =
+    "dynamic_expansion.object_exclusion.extra_footprint_offset.front";
+  static constexpr auto OBJECTS_EXTRA_OFFSET_REAR =
+    "dynamic_expansion.object_exclusion.extra_footprint_offset.rear";
+  static constexpr auto OBJECTS_EXTRA_OFFSET_LEFT =
+    "dynamic_expansion.object_exclusion.extra_footprint_offset.left";
+  static constexpr auto OBJECTS_EXTRA_OFFSET_RIGHT =
+    "dynamic_expansion.object_exclusion.extra_footprint_offset.right";
+  static constexpr auto STOPPED_OBJ_VEL_THRESH =
+    "dynamic_expansion.object_exclusion.stopped_object_velocity_threshold";
   static constexpr auto MAX_EXP_DIST_PARAM = "dynamic_expansion.max_expansion_distance";
   static constexpr auto RESAMPLE_INTERVAL_PARAM =
     "dynamic_expansion.path_preprocessing.resample_interval";
@@ -48,7 +50,8 @@ struct DrivableAreaExpansionParameters
     "dynamic_expansion.path_preprocessing.max_arc_length";
   static constexpr auto MAX_REUSE_DEVIATION_PARAM =
     "dynamic_expansion.path_preprocessing.reuse_max_deviation";
-  static constexpr auto AVOID_DYN_OBJECTS_PARAM = "dynamic_expansion.dynamic_objects.avoid";
+  static constexpr auto AVOID_STA_OBJECTS_PARAM = "dynamic_expansion.object_exclusion.exclude_static";
+  static constexpr auto AVOID_DYN_OBJECTS_PARAM = "dynamic_expansion.object_exclusion.exclude_dynamic";
   static constexpr auto AVOID_LINESTRING_TYPES_PARAM = "dynamic_expansion.avoid_linestring.types";
   static constexpr auto AVOID_LINESTRING_DIST_PARAM = "dynamic_expansion.avoid_linestring.distance";
   static constexpr auto SMOOTHING_CURVATURE_WINDOW_PARAM =
@@ -72,18 +75,24 @@ struct DrivableAreaExpansionParameters
   double extra_width{};
   int curvature_average_window{};
   double max_bound_rate{};
-  double dynamic_objects_extra_left_offset{};
-  double dynamic_objects_extra_right_offset{};
-  double dynamic_objects_extra_rear_offset{};
-  double dynamic_objects_extra_front_offset{};
   double max_expansion_distance{};
   double max_path_arc_length{};
   double resample_interval{};
   double arc_length_range{};
   double max_reuse_deviation{};
   double min_bound_interval{};
-  bool avoid_dynamic_objects{};
   bool print_runtime{};
+
+  struct ObjectExclusion{
+    bool exclude_static{};
+    bool exclude_dynamic{};
+    double front_offset{};
+    double rear_offset{};
+    double left_offset{};
+    double right_offset{};
+    double stopped_obj_vel_th{};
+  } object_exclusion;
+
   std::vector<std::string> avoid_linestring_types{};
   autoware::vehicle_info_utils::VehicleInfo vehicle_info;
 
@@ -109,17 +118,15 @@ struct DrivableAreaExpansionParameters
     max_path_arc_length = node.declare_parameter<double>(MAX_PATH_ARC_LENGTH_PARAM);
     resample_interval = node.declare_parameter<double>(RESAMPLE_INTERVAL_PARAM);
     max_reuse_deviation = node.declare_parameter<double>(MAX_REUSE_DEVIATION_PARAM);
-    dynamic_objects_extra_front_offset =
-      node.declare_parameter<double>(DYN_OBJECTS_EXTRA_OFFSET_FRONT);
-    dynamic_objects_extra_rear_offset =
-      node.declare_parameter<double>(DYN_OBJECTS_EXTRA_OFFSET_REAR);
-    dynamic_objects_extra_left_offset =
-      node.declare_parameter<double>(DYN_OBJECTS_EXTRA_OFFSET_LEFT);
-    dynamic_objects_extra_right_offset =
-      node.declare_parameter<double>(DYN_OBJECTS_EXTRA_OFFSET_RIGHT);
+    object_exclusion.exclude_static = node.declare_parameter<bool>(AVOID_STA_OBJECTS_PARAM);
+    object_exclusion.exclude_dynamic = node.declare_parameter<bool>(AVOID_DYN_OBJECTS_PARAM);
+    object_exclusion.stopped_obj_vel_th = node.declare_parameter<double>(STOPPED_OBJ_VEL_THRESH);
+    object_exclusion.front_offset = node.declare_parameter<double>(OBJECTS_EXTRA_OFFSET_FRONT);
+    object_exclusion.rear_offset = node.declare_parameter<double>(OBJECTS_EXTRA_OFFSET_REAR);
+    object_exclusion.left_offset = node.declare_parameter<double>(OBJECTS_EXTRA_OFFSET_LEFT);
+    object_exclusion.right_offset = node.declare_parameter<double>(OBJECTS_EXTRA_OFFSET_RIGHT);
     avoid_linestring_types =
       node.declare_parameter<std::vector<std::string>>(AVOID_LINESTRING_TYPES_PARAM);
-    avoid_dynamic_objects = node.declare_parameter<bool>(AVOID_DYN_OBJECTS_PARAM);
     avoid_linestring_dist = node.declare_parameter<double>(AVOID_LINESTRING_DIST_PARAM);
     min_bound_interval = node.declare_parameter<double>(MIN_BOUND_INTERVAL);
     print_runtime = node.declare_parameter<bool>(PRINT_RUNTIME_PARAM);

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/drivable_area_expansion/footprints.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/drivable_area_expansion/footprints.cpp
@@ -15,7 +15,6 @@
 #include "autoware/behavior_path_planner_common/utils/drivable_area_expansion/footprints.hpp"
 
 #include "autoware/behavior_path_planner_common/utils/drivable_area_expansion/parameters.hpp"
-
 #include "autoware/behavior_path_planner_common/utils/path_safety_checker/objects_filtering.hpp"
 
 #include <autoware_utils/geometry/boost_polygon_utils.hpp>
@@ -74,11 +73,14 @@ MultiPolygon2d create_object_footprints(
       continue;
     }
 
-    if (params.object_exclusion.exclude_static && velocity_filter(
-        object.kinematics.initial_twist_with_covariance.twist, -std::numeric_limits<double>::epsilon(),
-        params.object_exclusion.stopped_obj_vel_th)) {
-      footprints.push_back(create_footprint(object.kinematics.initial_pose_with_covariance.pose, base_footprint));
-    } 
+    if (
+      params.object_exclusion.exclude_static &&
+      velocity_filter(
+        object.kinematics.initial_twist_with_covariance.twist,
+        -std::numeric_limits<double>::epsilon(), params.object_exclusion.stopped_obj_vel_th)) {
+      footprints.push_back(
+        create_footprint(object.kinematics.initial_pose_with_covariance.pose, base_footprint));
+    }
   }
   return footprints;
 }

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/drivable_area_expansion/footprints.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/drivable_area_expansion/footprints.cpp
@@ -16,6 +16,8 @@
 
 #include "autoware/behavior_path_planner_common/utils/drivable_area_expansion/parameters.hpp"
 
+#include "autoware/behavior_path_planner_common/utils/path_safety_checker/objects_filtering.hpp"
+
 #include <autoware_utils/geometry/boost_polygon_utils.hpp>
 #include <autoware_utils/geometry/geometry.hpp>
 
@@ -44,21 +46,39 @@ MultiPolygon2d create_object_footprints(
   const autoware_perception_msgs::msg::PredictedObjects & objects,
   const DrivableAreaExpansionParameters & params)
 {
+  using behavior_path_planner::utils::path_safety_checker::filter::velocity_filter;
+
   MultiPolygon2d footprints;
-  if (params.avoid_dynamic_objects) {
-    for (const auto & object : objects.objects) {
-      const auto front = object.shape.dimensions.x / 2 + params.dynamic_objects_extra_front_offset;
-      const auto rear = -object.shape.dimensions.x / 2 - params.dynamic_objects_extra_rear_offset;
-      const auto left = object.shape.dimensions.y / 2 + params.dynamic_objects_extra_left_offset;
-      const auto right = -object.shape.dimensions.y / 2 - params.dynamic_objects_extra_right_offset;
-      Polygon2d base_footprint;
-      base_footprint.outer() = {
-        Point2d{front, left}, Point2d{front, right}, Point2d{rear, right}, Point2d{rear, left},
-        Point2d{front, left}};
+  if (!params.object_exclusion.exclude_dynamic && !params.object_exclusion.exclude_static) {
+    return footprints;
+  }
+
+  auto get_base_footprint = [&](const auto & object) {
+    const auto front = object.shape.dimensions.x / 2 + params.object_exclusion.front_offset;
+    const auto rear = -object.shape.dimensions.x / 2 - params.object_exclusion.rear_offset;
+    const auto left = object.shape.dimensions.y / 2 + params.object_exclusion.left_offset;
+    const auto right = -object.shape.dimensions.y / 2 - params.object_exclusion.right_offset;
+    Polygon2d footprint;
+    footprint.outer() = {
+      Point2d{front, left}, Point2d{front, right}, Point2d{rear, right}, Point2d{rear, left},
+      Point2d{front, left}};
+    return footprint;
+  };
+
+  for (const auto & object : objects.objects) {
+    const auto base_footprint = get_base_footprint(object);
+    if (params.object_exclusion.exclude_dynamic) {
       for (const auto & path : object.kinematics.predicted_paths)
         for (const auto & pose : path.path)
           footprints.push_back(create_footprint(pose, base_footprint));
+      continue;
     }
+
+    if (params.object_exclusion.exclude_static && velocity_filter(
+        object.kinematics.initial_twist_with_covariance.twist, -std::numeric_limits<double>::epsilon(),
+        params.object_exclusion.stopped_obj_vel_th)) {
+      footprints.push_back(create_footprint(object.kinematics.initial_pose_with_covariance.pose, base_footprint));
+    } 
   }
   return footprints;
 }

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/test/test_drivable_area_expansion.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/test/test_drivable_area_expansion.cpp
@@ -215,7 +215,7 @@ TEST(DrivableAreaExpansionProjection, expand_drivable_area)
   }
   {  // parameters
     params.enabled = true;
-    params.avoid_dynamic_objects = false;
+    params.object_exclusion.exclude_dynamic = false;
     params.avoid_linestring_dist = 0.0;
     params.avoid_linestring_types = {};
     params.max_expansion_distance = 0.0;  // means no limit

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/test/test_footprints.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/test/test_footprints.cpp
@@ -104,18 +104,19 @@ TEST(FootprintTest, create_object_footprints)
   objects.objects.push_back(object);
 
   autoware::behavior_path_planner::drivable_area_expansion::DrivableAreaExpansionParameters params;
-  params.avoid_dynamic_objects = false;
-  params.dynamic_objects_extra_front_offset = 0.5;
-  params.dynamic_objects_extra_rear_offset = 0.5;
-  params.dynamic_objects_extra_left_offset = 0.5;
-  params.dynamic_objects_extra_right_offset = 0.5;
+  params.object_exclusion.exclude_static = false;
+  params.object_exclusion.exclude_dynamic = false;
+  params.object_exclusion.front_offset = 0.5;
+  params.object_exclusion.rear_offset = 0.5;
+  params.object_exclusion.left_offset = 0.5;
+  params.object_exclusion.right_offset = 0.5;
 
   // Condition: doesn't avoid dynamic objects
   auto footprints = create_object_footprints(objects, params);
   EXPECT_TRUE(footprints.empty());
 
   // Condition: single object and single point path
-  params.avoid_dynamic_objects = true;
+  params.object_exclusion.exclude_dynamic = true;
   footprints = create_object_footprints(objects, params);
 
   ASSERT_EQ(footprints.size(), 1);


### PR DESCRIPTION
## Description

Drivable area expansion has the option to avoid expanding in the path of dynamic objects. However this feature is disabled by default as it can be unstable and put too much restriction on Ego motion around corners and tight turns.

At tight turns drivable area is expanded considerably specially in case of large Ego vehicle, and Ego can exceed its current lane boundaries, as a result there is a higher chance of collision if there are nearby obstacles and the point of turning, like shown in the image below.
![Screenshot from 2025-03-04 09-33-07](https://github.com/user-attachments/assets/fa760a5d-dbeb-45f7-b52a-425744bf1927)

To address this, this PR modifies the drivable area expansion to able to avoid static objects explicitly without having to avoid all dynamic objects.

The following image shows the behavior with and without this feature.
![Untitled drawing](https://github.com/user-attachments/assets/4b9b7c9a-8da1-4962-9038-2f00a2f8c84c)


## Related links

- [Launcher PR](https://github.com/autowarefoundation/autoware_launch/pull/1353)

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
- PSIM
- [Internal TIER IV Evaluator](https://evaluation.tier4.jp/evaluation/reports/f184d3ee-0890-5bf5-aba7-87705ae175f7?project_id=prd_jt)

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

🔴⬆️ -->

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added | `object_exclusion.exclude_static` | `bool` | `true` | if true, the drivable area is not expanded over static objects |
| Added | `object_exclusion.th_stopped_object_velocity` | `double` | `1.0` | [m/s] velocity threshold for static objects |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old | `dynamic_objects.avoid` | `bool` | `false` | if true, the drivable area is not expanded in the predicted path of dynamic objects |
| Old | `dynamic_objects.extra_footprint_offset.front` | `double` | `0.5` | [m] extra length to add to the front of the dynamic object footprint |
| Old | `dynamic_objects.extra_footprint_offset.rear` | `double` | `0.5` | [m] extra length to add to the rear of the dynamic object footprint |
| Old | `dynamic_objects.extra_footprint_offset.left` | `double` | `0.5` | [m] extra length to add to the left of the dynamic object footprint |
| Old | `dynamic_objects.extra_footprint_offset.right` | `double` | `0.5` | [m] extra length to add to the right of the dynamic object footprint |
| New | `object_exclusion.exclude_dynamic` | `bool` | `false` | if true, the drivable area is not expanded in the predicted path of dynamic objects |
| New | `object_exclusion.safety_margin.front` | `double` | `0.75` | [m] extra length to add to the front of the dynamic object footprint |
| New | `object_exclusion.safety_margin.rear` | `double` | `0.75` | [m] extra length to add to the rear of the dynamic object footprint |
| New | `object_exclusion.safety_margin.left` | `double` | `0.75` | [m] extra length to add to the left of the dynamic object footprint |
| New | `object_exclusion.safety_margin.right` | `double` | `0.75` | [m] extra length to add to the right of the dynamic object footprint |

## Effects on system behavior

At tight turns, when drivable area is expanded it will keep a safe distance from static objects.
