### PR TITLE
fix(lane_departure_checker): fix trajectory resampling logic to keep given interval

### DIFF
--- a/control/autoware_lane_departure_checker/src/lane_departure_checker_node/utils.cpp
+++ b/control/autoware_lane_departure_checker/src/lane_departure_checker_node/utils.cpp
@@ -120,9 +120,8 @@ TrajectoryPoints resampleTrajectory(const Trajectory & trajectory, const double 
 
     if (boost::geometry::distance(prev_point.to_2d(), next_point.to_2d()) >= interval) {
       resampled.push_back(traj_point);
+      prev_point = next_point;
     }
-
-    prev_point = next_point;
   }
   resampled.push_back(trajectory.points.back());
 

--- a/control/autoware_lane_departure_checker/test/test_resample_trajectory.cpp
+++ b/control/autoware_lane_departure_checker/test/test_resample_trajectory.cpp
@@ -92,5 +92,10 @@ INSTANTIATE_TEST_SUITE_P(
       "IntervalIsGreaterThanDistance",
       {{1.0, 0.0, 0.0}, {2.0, 0.0, 0.0}, {3.0, 0.0, 0.0}},
       1.5,
-      {{1.0, 0.0, 0.0}, {3.0, 0.0, 0.0}}}),
+      {{1.0, 0.0, 0.0}, {3.0, 0.0, 0.0}}},
+    ResampleTrajectoryTestParam{
+      "ConsecutiveSmallDistancesFollowedByLargeDistance",
+      {{0.0, 0.0, 0.0}, {0.7, 0.0, 0.0}, {1.3, 0.0, 0.0}, {3.0, 0.0, 0.0}},
+      1.0,
+      {{0.0, 0.0, 0.0}, {1.3, 0.0, 0.0}, {3.0, 0.0, 0.0}}}),
   ::testing::PrintToStringParamName());


### PR DESCRIPTION
## Description

Fixed a bug in the resampleTrajectory function where the `prev_point` was being updated even when a trajectory point was not added to the resampled trajectory. This caused incorrect distance calculations and potentially led to trajectory points being improperly filtered.

## Related links

**Private Links:**

- [TIERIV internal link](https://tier4.atlassian.net/browse/RT0-35625)

## How was this PR tested?

- run planning simulator 

green point: resampled points

behavior before the change:

https://github.com/user-attachments/assets/54df6b88-f6bb-42fd-8933-c506f03d8123

behvior after the change:

https://github.com/user-attachments/assets/dafb7948-3be1-48c5-85e2-7ead8f94bf15

- add unit test to detect bug in the original implementation

original code fails as follows
```
1: [ RUN      ] LaneDepartureCheckerTest/ResampleTrajectoryTest.test_resample_trajectory/ConsecutiveSmallDistancesFollowedByLargeDistance
1: /home/kyoichi-sugahara/workspace/pilot-auto/src/autoware/universe/control/autoware_lane_departure_checker/test/test_resample_trajectory.cpp:67: Failure
1: Expected equality of these values:
1:   resampled.size()
1:     Which is: 2
1:   p.expected_points.size()
1:     Which is: 3
1: [  FAILED  ] LaneDepartureCheckerTest/ResampleTrajectoryTest.test_resample_trajectory/ConsecutiveSmallDistancesFollowedByLargeDistance, where GetParam() = ConsecutiveSmallDistancesFollowedByLargeDistance (0 ms)
```

updated code succeed as follows

```
1: [ RUN      ] LaneDepartureCheckerTest/ResampleTrajectoryTest.test_resample_trajectory/ConsecutiveSmallDistancesFollowedByLargeDistance
1: [       OK ] LaneDepartureCheckerTest/ResampleTrajectoryTest.test_resample_trajectory/ConsecutiveSmallDistancesFollowedByLargeDistance (0 ms)
```


## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
