### PR TITLE
feat(static_obstacle_avoidance): return original lane automatically

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/scene.cpp
@@ -610,6 +610,29 @@ void StaticObstacleAvoidanceModule::fillEgoStatus(
     return;
   }
 
+  /**
+   * If the yield maneuver is disabled, use unapproved_new_sl for avoidance path generation even if
+   * the shift line is unsafe.
+   */
+  if (!parameters_->enable_yield_maneuver) {
+    data.yield_required = false;
+    data.safe_shift_line = data.new_shift_line;
+    return;
+  }
+
+  /**
+   * TODO(Satoshi OTA) Think yield maneuver in the middle of avoidance.
+   * Even if it is determined that a yield is necessary, the yield maneuver is not executed
+   * if the avoidance has already been initiated.
+   */
+  if (!can_yield_maneuver) {
+    data.safe = true;  // overwrite safety judge.
+    data.yield_required = false;
+    data.safe_shift_line = data.new_shift_line;
+    RCLCPP_WARN_THROTTLE(getLogger(), *clock_, 500, "unsafe. but could not transit yield status.");
+    return;
+  }
+
   auto candidate_sl_force_activated = [&](const std::string & direction) {
     // If statement to avoid unnecessary warning occurring from isForceActivated function
     if (candidate_uuid_ == uuid_map_.at(direction)) {
@@ -646,29 +669,6 @@ void StaticObstacleAvoidanceModule::fillEgoStatus(
     data.yield_required = false;
     data.safe_shift_line = data.new_shift_line;
     RCLCPP_WARN_THROTTLE(getLogger(), *clock_, 5000, "unsafe but force executed");
-    return;
-  }
-
-  /**
-   * If the yield maneuver is disabled, use unapproved_new_sl for avoidance path generation even if
-   * the shift line is unsafe.
-   */
-  if (!parameters_->enable_yield_maneuver) {
-    data.yield_required = false;
-    data.safe_shift_line = data.new_shift_line;
-    return;
-  }
-
-  /**
-   * TODO(Satoshi OTA) Think yield maneuver in the middle of avoidance.
-   * Even if it is determined that a yield is necessary, the yield maneuver is not executed
-   * if the avoidance has already been initiated.
-   */
-  if (!can_yield_maneuver) {
-    data.safe = true;  // overwrite safety judge.
-    data.yield_required = false;
-    data.safe_shift_line = data.new_shift_line;
-    RCLCPP_WARN_THROTTLE(getLogger(), *clock_, 500, "unsafe. but could not transit yield status.");
     return;
   }
 


### PR DESCRIPTION
## Description

The static obstacle avoidance module doesn't generate return path automatically. This is an unexpected behavior.

https://github.com/user-attachments/assets/da943d7f-187a-4b69-af1b-da75b2b70ff1


## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

I confirmed that the module automatically switch path to return original lane.

https://github.com/user-attachments/assets/cc25f809-1a94-426e-91c5-04cec56655f8

- [ ] [PASS TIER IV INTERNAL SCENARIOS](https://evaluation.tier4.jp/evaluation/reports/b43e17a3-8b87-5563-8348-a57b8e93d1c5?project_id=prd_jt)

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
