### PR TITLE
feat(planning_validator): add diag to check planning component latency

### DIFF
--- a/planning/autoware_planning_validator/config/planning_validator.param.yaml
+++ b/planning/autoware_planning_validator/config/planning_validator.param.yaml
@@ -27,6 +27,7 @@
       velocity_deviation: 100.0
       distance_deviation: 100.0
       longitudinal_distance_deviation: 1.0
+      nominal_latency: 0.1
 
     parameters:
       # The required trajectory length is calculated as the distance needed

--- a/planning/autoware_planning_validator/include/autoware/planning_validator/planning_validator.hpp
+++ b/planning/autoware_planning_validator/include/autoware/planning_validator/planning_validator.hpp
@@ -59,6 +59,7 @@ struct ValidationParams
   double velocity_deviation_threshold;
   double distance_deviation_threshold;
   double longitudinal_distance_deviation_threshold;
+  double nominal_latency_threshold;
 
   // parameters
   double forward_trajectory_length_acceleration;
@@ -86,6 +87,7 @@ public:
   bool checkValidDistanceDeviation(const Trajectory & trajectory);
   bool checkValidLongitudinalDistanceDeviation(const Trajectory & trajectory);
   bool checkValidForwardTrajectoryLength(const Trajectory & trajectory);
+  bool checkValidLatency(const Trajectory & trajectory);
 
 private:
   void setupDiag();

--- a/planning/autoware_planning_validator/msg/PlanningValidatorStatus.msg
+++ b/planning/autoware_planning_validator/msg/PlanningValidatorStatus.msg
@@ -15,6 +15,7 @@ bool is_valid_velocity_deviation
 bool is_valid_distance_deviation
 bool is_valid_longitudinal_distance_deviation
 bool is_valid_forward_trajectory_length
+bool is_valid_latency
 
 # values
 int64 trajectory_size
@@ -31,5 +32,6 @@ float64 distance_deviation
 float64 longitudinal_distance_deviation
 float64 forward_trajectory_length_required
 float64 forward_trajectory_length_measured
+float64 latency
 
 int64 invalid_count


### PR DESCRIPTION
## Description

I added a feature to calculate control component latency and to publish error diagnostic if it is larger than threshold.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

- [x] I confirmed planning validator output error diag when I set very small threshold `nominal_latency_threshold`.
- [x] [PASS TIER IV INTERNAL SCENARIOS](https://evaluation.tier4.jp/evaluation/reports/78be54f2-c80d-53b8-a406-be6408bb539d/tests/ccd37b86-2cc3-5130-a6ea-b47258f0a625?project_id=prd_jt)


## Notes for reviewers

None.

## Interface changes

Add new field to publish current latency.

```patch
diff --git a/planning/autoware_planning_validator/msg/PlanningValidatorStatus.msg b/planning/autoware_planning_validator/msg/PlanningValidatorStatus.msg
index cf127347a6..d1d493761d 100644
--- a/planning/autoware_planning_validator/msg/PlanningValidatorStatus.msg
+++ b/planning/autoware_planning_validator/msg/PlanningValidatorStatus.msg
@@ -15,6 +15,7 @@ bool is_valid_velocity_deviation
 bool is_valid_distance_deviation
 bool is_valid_longitudinal_distance_deviation
 bool is_valid_forward_trajectory_length
+bool is_valid_latency
 
 # values
 int64 trajectory_size
@@ -31,5 +32,6 @@ float64 distance_deviation
 float64 longitudinal_distance_deviation
 float64 forward_trajectory_length_required
 float64 forward_trajectory_length_measured
+float64 latency
 
 int64 invalid_count
```

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
