### PR TITLE
fix(static_obstacle_avoidance): ego doesn't keep stopping in unsafe condition

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/scene.cpp
@@ -1679,7 +1679,7 @@ void StaticObstacleAvoidanceModule::insertReturnDeadLine(
   const auto min_return_distance =
     helper_->getMinAvoidanceDistance(shift_length) + helper_->getNominalPrepareDistance(0.0);
   const auto to_stop_line = data.to_return_point - min_return_distance - buffer;
-  if (to_stop_line < 0.0) {
+  if (to_stop_line < -1.0 * parameters_->stop_buffer) {
     RCLCPP_WARN(getLogger(), "ego overran return shift dead line. do nothing.");
     return;
   }
@@ -1752,7 +1752,7 @@ void StaticObstacleAvoidanceModule::insertWaitPoint(
     return;
   }
 
-  if (data.to_stop_line < 0.0) {
+  if (data.to_stop_line < -1.0 * parameters_->stop_buffer) {
     RCLCPP_WARN(getLogger(), "ego overran avoidance dead line. do nothing.");
     return;
   }


### PR DESCRIPTION
## Description

Bug: The ego couldn't keep stopping in front of the avoidance target during yielding. This issue was caused by https://github.com/autowarefoundation/autoware.universe/pull/9089.

The purpose of https://github.com/autowarefoundation/autoware.universe/pull/9089 was removing stop line and preventing stuck when the ego obiously overrun the stop line. But it removed stop line even when it stopped properly since threre is no buffer.

https://github.com/user-attachments/assets/7867533b-d786-46a4-9b14-3dd18357b706

## Related links

**Parent Issue:**

- https://github.com/autowarefoundation/autoware.universe/pull/9089

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

Ego keeps stopping during yielding.

https://github.com/user-attachments/assets/bc59896d-a08e-4330-960f-370e6ce0e5a6

- [x] [PASS TIER IV INTERNAL SCENARIOS](https://evaluation.tier4.jp/evaluation/reports/8d61fc65-69b2-58b2-a7ce-91a69110c358?project_id=prd_jt)

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
