### PR TITLE
fix(stopline, traffic_light): fix planning factor distance value

### DIFF
--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_stop_line_module/src/scene.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_stop_line_module/src/scene.cpp
@@ -66,8 +66,8 @@ bool StopLineModule::modifyPathVelocity(PathWithLaneId * path)
 
   // TODO(soblin): PlanningFactorInterface use trajectory class
   planning_factor_interface_->add(
-    path->points, trajectory->compute(*stop_point).point.pose,
-    planner_data_->current_odometry->pose, planner_data_->current_odometry->pose,
+    path->points, planner_data_->current_odometry->pose,
+    trajectory->compute(*stop_point).point.pose, trajectory->compute(*stop_point).point.pose,
     autoware_internal_planning_msgs::msg::PlanningFactor::STOP,
     autoware_internal_planning_msgs::msg::SafetyFactorArray{}, true /*is_driving_forward*/, 0.0,
     0.0 /*shift distance*/, "stopline");

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/src/manager.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/src/manager.cpp
@@ -82,6 +82,7 @@ void TrafficLightModuleManager::modifyPathVelocity(
     virtual_wall_marker_creator_.add_virtual_walls(
       traffic_light_scene_module->createVirtualWalls());
   }
+  planning_factor_interface_->publish();
   pub_debug_->publish(debug_marker_array);
   pub_virtual_wall_->publish(virtual_wall_marker_creator_.create_markers(clock_->now()));
   pub_tl_state_->publish(tl_state);

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/src/scene.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/src/scene.cpp
@@ -299,7 +299,7 @@ autoware_internal_planning_msgs::msg::PathWithLaneId TrafficLightModule::insertS
     target_point_with_lane_id.point.pose, target_point_with_lane_id.point.pose,
     autoware_internal_planning_msgs::msg::PlanningFactor::STOP,
     autoware_internal_planning_msgs::msg::SafetyFactorArray{}, true /*is_driving_forward*/, 0.0,
-    0.0 /*shift distance*/, "");
+    0.0 /*shift distance*/, "traffic_light");
 
   return modified_path;
 }


### PR DESCRIPTION
## Description

Fixed the issue that
- PlanningFactor distance value of stopline is negative
- PlanningFactor distance value of traffic_light does not appear

## Related links

- https://tier4.atlassian.net/browse/RT0-35448?focusedCommentId=210107

## How was this PR tested?

See the attached video in the ticket

https://evaluation.tier4.jp/evaluation/reports/b7b812c4-d000-5be2-9f9a-b2c6a8f349be?project_id=prd_jt

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
