### PR TITLE
fix(dynamic_obstacle_stop): publish processing time when early return

### DIFF
--- a/planning/motion_velocity_planner/autoware_motion_velocity_dynamic_obstacle_stop_module/src/dynamic_obstacle_stop_module.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_dynamic_obstacle_stop_module/src/dynamic_obstacle_stop_module.hpp
@@ -35,6 +35,7 @@ public:
   void init(rclcpp::Node & node, const std::string & module_name) override;
   void publish_planning_factor() override { planning_factor_interface_->publish(); };
   void update_parameters(const std::vector<rclcpp::Parameter> & parameters) override;
+  void publish_processing_time(const double processing_time_ms);
   VelocityPlanningResult plan(
     const std::vector<autoware_planning_msgs::msg::TrajectoryPoint> & raw_trajectory_points,
     const std::vector<autoware_planning_msgs::msg::TrajectoryPoint> & smoothed_trajectory_points,
@@ -47,7 +48,7 @@ private:
 
   inline static const std::string ns_ = "dynamic_obstacle_stop";
   std::string module_name_;
-  rclcpp::Clock::SharedPtr clock_{};
+  rclcpp::Clock::SharedPtr clock_;
 
   dynamic_obstacle_stop::PlannerParam params_;
   dynamic_obstacle_stop::ObjectStopDecisionMap object_map_;


### PR DESCRIPTION
## Description
Currently, the processing time for the `dynamic_obstacle_stop` may not be published if we do an early return in case the input trajectory does not have enough point.
With this PR, the processing time is always published.

## Related links

## How was this PR tested?

Psim

## Notes for reviewers

None.

## Effects on system behavior

None.
