### PR TITLE
fix(autoware_universe_utils): fix procedure to check if point is on edge

### DIFF
--- a/common/autoware_universe_utils/src/geometry/alt_geometry.cpp
+++ b/common/autoware_universe_utils/src/geometry/alt_geometry.cpp
@@ -263,28 +263,30 @@ bool covered_by(const alt::Point2d & point, const alt::ConvexPolygon2d & poly)
     return false;
   }
 
-  double cross;
   for (auto it = vertices.cbegin(); it != std::prev(vertices.cend()); ++it) {
     const auto & p1 = *it;
     const auto & p2 = *std::next(it);
 
-    if (p1.y() <= point.y() && p2.y() >= point.y()) {  // upward edge
-      cross = (p2 - p1).cross(point - p1);
-      if (cross > 0) {  // point is to the left of edge
-        winding_number++;
-        continue;
-      }
-    } else if (p1.y() >= point.y() && p2.y() <= point.y()) {  // downward edge
-      cross = (p2 - p1).cross(point - p1);
-      if (cross < 0) {  // point is to the left of edge
-        winding_number--;
-        continue;
-      }
-    } else {
+    const auto is_upward_edge = p1.y() <= point.y() && p2.y() >= point.y();
+    const auto is_downward_edge = p1.y() >= point.y() && p2.y() <= point.y();
+
+    if (!is_upward_edge && !is_downward_edge) {
       continue;
     }
 
-    if (std::abs(cross) < epsilon) {  // point is on edge
+    const auto start_vec = point - p1;
+    const auto end_vec = point - p2;
+    const auto cross = start_vec.cross(end_vec);
+
+    if (is_upward_edge && cross > 0) {  // point is to the left of edge
+      winding_number++;
+      continue;
+    } else if (is_downward_edge && cross < 0) {  // point is to the left of edge
+      winding_number--;
+      continue;
+    }
+
+    if (std::abs(cross) < epsilon && start_vec.dot(end_vec) <= 0.) {  // point is on edge
       return true;
     }
   }
@@ -600,28 +602,30 @@ bool within(const alt::Point2d & point, const alt::ConvexPolygon2d & poly)
     return false;
   }
 
-  double cross;
   for (auto it = vertices.cbegin(); it != std::prev(vertices.cend()); ++it) {
     const auto & p1 = *it;
     const auto & p2 = *std::next(it);
 
-    if (p1.y() < point.y() && p2.y() > point.y()) {  // upward edge
-      cross = (p2 - p1).cross(point - p1);
-      if (cross > 0) {  // point is to the left of edge
-        winding_number++;
-        continue;
-      }
-    } else if (p1.y() > point.y() && p2.y() < point.y()) {  // downward edge
-      cross = (p2 - p1).cross(point - p1);
-      if (cross < 0) {  // point is to the left of edge
-        winding_number--;
-        continue;
-      }
-    } else {
+    const auto is_upward_edge = p1.y() < point.y() && p2.y() > point.y();
+    const auto is_downward_edge = p1.y() > point.y() && p2.y() < point.y();
+
+    if (!is_upward_edge && !is_downward_edge) {
       continue;
     }
 
-    if (std::abs(cross) < epsilon) {  // point is on edge
+    const auto start_vec = point - p1;
+    const auto end_vec = point - p2;
+    const auto cross = start_vec.cross(end_vec);
+
+    if (is_upward_edge && cross > 0) {  // point is to the left of edge
+      winding_number++;
+      continue;
+    } else if (is_downward_edge && cross < 0) {  // point is to the left of edge
+      winding_number--;
+      continue;
+    }
+
+    if (std::abs(cross) < epsilon && start_vec.dot(end_vec) <= 0.) {  // point is on edge
       return false;
     }
   }

--- a/common/autoware_universe_utils/test/src/geometry/test_alt_geometry.cpp
+++ b/common/autoware_universe_utils/test/src/geometry/test_alt_geometry.cpp
@@ -164,6 +164,17 @@ TEST(alt_geometry, coveredBy)
 
     EXPECT_TRUE(result);
   }
+
+  {  // The point is on the extended line of an edge of the polygon
+    const Point2d point = {0.0, 0.0};
+    const Point2d p1 = {3.0, 0.0};
+    const Point2d p2 = {3.0, 1.0};
+    const Point2d p3 = {4.0, 1.0};
+    const Point2d p4 = {4.0, 0.0};
+    const auto result = covered_by(point, ConvexPolygon2d::create({p1, p2, p3, p4}).value());
+
+    EXPECT_FALSE(result);
+  }
 }
 
 TEST(alt_geometry, disjoint)
@@ -669,6 +680,17 @@ TEST(alt_geometry, within)
     const Point2d p2 = {2.0, -1.0};
     const Point2d p3 = {0.0, -1.0};
     const Point2d p4 = {0.0, 1.0};
+    const auto result = within(point, ConvexPolygon2d::create({p1, p2, p3, p4}).value());
+
+    EXPECT_FALSE(result);
+  }
+
+  {  // The point is on the extended line of an edge of the polygon
+    const Point2d point = {0.0, 0.0};
+    const Point2d p1 = {3.0, 0.0};
+    const Point2d p2 = {3.0, 1.0};
+    const Point2d p3 = {4.0, 1.0};
+    const Point2d p4 = {4.0, 0.0};
     const auto result = within(point, ConvexPolygon2d::create({p1, p2, p3, p4}).value());
 
     EXPECT_FALSE(result);


### PR DESCRIPTION
## Description

This PR fixes the procedure in `covered_by()` and `within()` functions to check if the given point is on any edge of the given polygon.

## Related links

internal: https://star4.slack.com/archives/C0575HP7NJG/p1741675912882399

## How was this PR tested?

```
colcon test --packages-select autoware_universe_utils --event-handlers console_cohesion+
```

Benchmark results with 100 randomly generated polygons with 9 vertices:
|function|Boost|alternative|
|---|---|---|
|`covered_by()`|14.29ms|10.38ms|
|`within()`|47.20ms|1.63ms|

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
