### PR TITLE
fix(autoware_mission_planner_universe): add explicit test dependency

### DIFF
--- a/planning/autoware_mission_planner_universe/CMakeLists.txt
+++ b/planning/autoware_mission_planner_universe/CMakeLists.txt
@@ -44,6 +44,9 @@ if(BUILD_TESTING)
   target_link_libraries(test_${PROJECT_NAME}
     ${PROJECT_NAME}_lanelet2_plugins
   )
+  ament_target_dependencies(test_${PROJECT_NAME}
+    autoware_test_utils
+  )
 endif()
 
 ament_auto_package(


### PR DESCRIPTION
## Description

Not sure why it occurs only when we move this package out.

But fixes:
- https://github.com/autowarefoundation/autoware.core/pull/201#issuecomment-2716840238

Does anybody have any idea why it happens?

## How was this PR tested?

Build.