### PR TITLE
fix(segmentation_pointcloud_fusion): fix typo of defaut camera info topic

### DIFF
--- a/perception/autoware_image_projection_based_fusion/launch/segmentation_pointcloud_fusion.launch.xml
+++ b/perception/autoware_image_projection_based_fusion/launch/segmentation_pointcloud_fusion.launch.xml
@@ -3,19 +3,19 @@
   <arg name="input/mask0" default="/perception/object_recognition/detection/mask0"/>
   <arg name="input/camera_info0" default="/sensing/camera/camera0/camera_info"/>
   <arg name="input/mask1" default="/perception/object_recognition/detection/mask1"/>
-  <arg name="input/camera_info1" default="/sensing/camera/camera0/camera_info"/>
+  <arg name="input/camera_info1" default="/sensing/camera/camera1/camera_info"/>
   <arg name="input/mask2" default="/perception/object_recognition/detection/mask2"/>
-  <arg name="input/camera_info2" default="/sensing/camera/camera0/camera_info"/>
+  <arg name="input/camera_info2" default="/sensing/camera/camera2/camera_info"/>
   <arg name="input/mask3" default="/perception/object_recognition/detection/mask3"/>
-  <arg name="input/camera_info3" default="/sensing/camera/camera0/camera_info"/>
+  <arg name="input/camera_info3" default="/sensing/camera/camera3/camera_info"/>
   <arg name="input/mask4" default="/perception/object_recognition/detection/mask4"/>
-  <arg name="input/camera_info4" default="/sensing/camera/camera0/camera_info"/>
+  <arg name="input/camera_info4" default="/sensing/camera/camera4/camera_info"/>
   <arg name="input/mask5" default="/perception/object_recognition/detection/mask5"/>
-  <arg name="input/camera_info5" default="/sensing/camera/camera0/camera_info"/>
+  <arg name="input/camera_info5" default="/sensing/camera/camera5/camera_info"/>
   <arg name="input/mask6" default="/perception/object_recognition/detection/mask6"/>
-  <arg name="input/camera_info6" default="/sensing/camera/camera0/camera_info"/>
+  <arg name="input/camera_info6" default="/sensing/camera/camera6/camera_info"/>
   <arg name="input/mask7" default="/perception/object_recognition/detection/mask7"/>
-  <arg name="input/camera_info7" default="/sensing/camera/camera0/camera_info"/>
+  <arg name="input/camera_info7" default="/sensing/camera/camera7/camera_info"/>
   <arg name="input/pointcloud" default="/sensing/lidar/top/outlier_filtered/pointcloud"/>
   <arg name="output/pointcloud" default="output/pointcloud"/>
   <arg name="sync_param_path" default="$(find-pkg-share autoware_image_projection_based_fusion)/config/fusion_common.param.yaml"/>


### PR DESCRIPTION
## Description
- Fix typo in  "segmentation_pointcloud_fusion.launch.xml".
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
