### PR TITLE
fix(goal_planner): ignore use bus_stop_area flag if there are no BusStopArea on the pull over lanes

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/goal_planner_module.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/goal_planner_module.hpp
@@ -195,7 +195,7 @@ private:
   bool switch_bezier_{false};
   void normal_pullover_planning_helper(
     const std::shared_ptr<PlannerData> planner_data, const GoalCandidates & goal_candidates,
-    const BehaviorModuleOutput & upstream_module_output,
+    const BehaviorModuleOutput & upstream_module_output, const bool use_bus_stop_area,
     const lanelet::ConstLanelets current_lanelets, std::optional<Pose> & closest_start_pose,
     std::vector<PullOverPath> & path_candidates);
   void bezier_planning_helper(

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/goal_searcher.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/goal_searcher.hpp
@@ -60,6 +60,8 @@ public:
 
   MultiPolygon2d getAreaPolygons() const { return area_polygons_; }
 
+  bool bus_stop_area_available() const { return !bus_stop_area_polygons_.empty(); }
+
 private:
   GoalSearcher(
     const GoalPlannerParameters & parameters, const LinearRing2d & vehicle_footprint,

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/goal_searcher.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/goal_searcher.cpp
@@ -227,9 +227,8 @@ GoalCandidates GoalSearcher::search(
         vehicle_footprint_, autoware_utils::pose2transform(search_pose));
 
       if (
-        parameters_.bus_stop_area.use_bus_stop_area &&
-        !goal_planner_utils::isWithinAreas(
-          transformed_vehicle_footprint, bus_stop_area_polygons_)) {
+        use_bus_stop_area && !goal_planner_utils::isWithinAreas(
+                               transformed_vehicle_footprint, bus_stop_area_polygons_)) {
         continue;
       }
 


### PR DESCRIPTION
## Description

even if the flag `use_bus_stop_area` is true, if there are no BusStopArea polygons on the designated pull over lanes, fallback to normal mode and pull over on normal road shoulder lanes.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

tested with `use_bus_stop_area` = true.

### without BusStopArea

shift planner works

![image](https://github.com/user-attachments/assets/bed1bec6-56e0-4e0d-91f0-0bc1f0f163a2)

### with BusStopArea

bezier planner works

![image](https://github.com/user-attachments/assets/0666021b-e275-48f7-9f1c-bc724814bf54)

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
