### PR TITLE
feat(path_optimizer): additional failure logging and failure mode handling

### DIFF
--- a/control/autoware_mpc_lateral_controller/src/qp_solver/qp_solver_osqp.cpp
+++ b/control/autoware_mpc_lateral_controller/src/qp_solver/qp_solver_osqp.cpp
@@ -54,11 +54,11 @@ bool QPSolverOSQP::solve(
   /* execute optimization */
   auto result = osqpsolver_.optimize(h_mat, osqpA, f, lower_bound, upper_bound);
 
-  std::vector<double> U_osqp = std::get<0>(result);
+  std::vector<double> U_osqp = result.primal_solution;
   u = Eigen::Map<Eigen::Matrix<double, Eigen::Dynamic, 1>>(
     &U_osqp[0], static_cast<Eigen::Index>(U_osqp.size()), 1);
 
-  const int status_val = std::get<3>(result);
+  const int status_val = result.solution_status;
   if (status_val != 1) {
     RCLCPP_WARN(logger_, "optimization failed : %s", osqpsolver_.getStatusMessage().c_str());
     return false;
@@ -71,7 +71,7 @@ bool QPSolverOSQP::solve(
   }
 
   // polish status: successful (1), unperformed (0), (-1) unsuccessful
-  int status_polish = std::get<2>(result);
+  int status_polish = result.polish_status;
   if (status_polish == -1 || status_polish == 0) {
     const auto s = (status_polish == 0) ? "Polish process is not performed in osqp."
                                         : "Polish process failed in osqp.";

--- a/planning/autoware_obstacle_cruise_planner/src/optimization_based_planner/velocity_optimizer.cpp
+++ b/planning/autoware_obstacle_cruise_planner/src/optimization_based_planner/velocity_optimizer.cpp
@@ -246,10 +246,11 @@ VelocityOptimizer::OptimizationResult VelocityOptimizer::optimize(const Optimiza
   }
 
   // execute optimization
-  const auto result = qp_solver_.optimize(P, A, q, lower_bound, upper_bound);
-  const std::vector<double> optval = std::get<0>(result);
+  const autoware::osqp_interface::OSQPResult result =
+    qp_solver_.optimize(P, A, q, lower_bound, upper_bound);
+  const std::vector<double> optval = result.primal_solution;
 
-  const int status_val = std::get<3>(result);
+  const int status_val = result.solution_status;
   if (status_val != 1)
     std::cerr << "optimization failed : " << qp_solver_.getStatusMessage().c_str() << std::endl;
 

--- a/planning/autoware_path_optimizer/include/autoware/path_optimizer/state_equation_generator.hpp
+++ b/planning/autoware_path_optimizer/include/autoware/path_optimizer/state_equation_generator.hpp
@@ -37,6 +37,16 @@ public:
     Eigen::VectorXd W;
   };
 
+  friend std::ostream & operator<<(std::ostream & os, const Matrix & matrix)
+  {
+    os << "Matrix: {\n";
+    os << "\tA:\n" << matrix.A << "\n";
+    os << "\tB:\n" << matrix.B << "\n";
+    os << "\tW:\n" << matrix.W << "\n";
+    os << "}\n";
+    return os;
+  }
+
   StateEquationGenerator() = default;
   StateEquationGenerator(
     const double wheel_base, const double max_steer_rad,

--- a/planning/autoware_path_optimizer/include/autoware/path_optimizer/utils/conditional_timer.hpp
+++ b/planning/autoware_path_optimizer/include/autoware/path_optimizer/utils/conditional_timer.hpp
@@ -1,0 +1,48 @@
+// Copyright 2025 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <chrono>
+#include <optional>
+
+class ConditionalTimer
+{
+public:
+  void update(bool condition)
+  {
+    if (condition && !start_time_.has_value()) {
+      // Condition met, start the timer
+      start_time_ = std::chrono::high_resolution_clock::now();
+    } else if (!condition && start_time_.has_value()) {
+      // Condition no longer met, stop the timer
+      start_time_ = std::nullopt;
+    }
+  }
+
+  std::chrono::duration<double> getElapsedTime() const
+  {
+    if (start_time_.has_value()) {
+      auto current_time = std::chrono::high_resolution_clock::now();
+      return current_time - *start_time_;
+    } else {
+      return std::chrono::duration<double>(0.0);
+      ;
+    }
+  }
+
+private:
+  std::optional<std::chrono::time_point<std::chrono::high_resolution_clock>> start_time_{
+    std::nullopt};
+};

--- a/planning/autoware_path_optimizer/src/node.cpp
+++ b/planning/autoware_path_optimizer/src/node.cpp
@@ -27,6 +27,7 @@
 #include <limits>
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace autoware::path_optimizer
@@ -89,7 +90,8 @@ std::vector<double> calcSegmentLengthVector(const std::vector<TrajectoryPoint> &
 PathOptimizer::PathOptimizer(const rclcpp::NodeOptions & node_options)
 : Node("path_optimizer", node_options),
   vehicle_info_(autoware::vehicle_info_utils::VehicleInfoUtils(*this).getVehicleInfo()),
-  debug_data_ptr_(std::make_shared<DebugData>())
+  debug_data_ptr_(std::make_shared<DebugData>()),
+  conditional_timer_(std::make_shared<ConditionalTimer>())
 {
   // interface publisher
   traj_pub_ = create_publisher<Trajectory>("~/output/path", 1);
@@ -134,6 +136,13 @@ PathOptimizer::PathOptimizer(const rclcpp::NodeOptions & node_options)
 
     // parameters for trajectory
     traj_param_ = TrajectoryParam(this);
+
+    // Diagnostics
+    {
+      updater_.setHardwareID("path_optimizer");
+      updater_.add(
+        "path_optimizer_emergency_stop", this, &PathOptimizer::onCheckPathOptimizationValid);
+    }
   }
 
   time_keeper_ = std::make_shared<autoware_utils::TimeKeeper>(debug_processing_time_detail_pub_);
@@ -267,6 +276,7 @@ void PathOptimizer::onPath(const Path::ConstSharedPtr path_ptr)
 
   // 5. publish debug data
   publishDebugData(planner_data.header);
+  updater_.force_update();
 
   // publish calculation_time
   // NOTE: This function must be called after measuring onPath calculation time
@@ -294,6 +304,20 @@ bool PathOptimizer::checkInputPath(const Path & path, rclcpp::Clock clock) const
   return true;
 }
 
+void PathOptimizer::onCheckPathOptimizationValid(diagnostic_updater::DiagnosticStatusWrapper & stat)
+{
+  if (is_optimization_failed_) {
+    const std::string error_msg =
+      "[Path Optimizer]: Emergency Brake due to prolonged MPT Optimizer failure";
+    const auto diag_level = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
+    stat.summary(diag_level, error_msg);
+  } else {
+    const std::string error_msg = "[Path Optimizer]: MPT Optimizer successful";
+    const auto diag_level = diagnostic_msgs::msg::DiagnosticStatus::OK;
+    stat.summary(diag_level, error_msg);
+  }
+}
+
 PlannerData PathOptimizer::createPlannerData(
   const Path & path, const Odometry::ConstSharedPtr ego_odom_ptr) const
 {
@@ -315,22 +339,15 @@ std::vector<TrajectoryPoint> PathOptimizer::generateOptimizedTrajectory(
 {
   autoware_utils::ScopedTimeTrack st(__func__, *time_keeper_);
 
-  const auto & input_traj_points = planner_data.traj_points;
-
   // 1. calculate trajectory with MPT
   //    NOTE: This function may return previously optimized trajectory points.
   //          Also, velocity on some points will not be updated for a logic purpose.
   auto optimized_traj_points = optimizeTrajectory(planner_data);
 
-  // 2. update velocity
-  //    NOTE: When optimization failed or is skipped, velocity in trajectory points must
-  //          be updated since velocity in input trajectory (path) may change.
-  applyInputVelocity(optimized_traj_points, input_traj_points, planner_data.ego_pose);
-
-  // 3. insert zero velocity when trajectory is over drivable area
+  // 2. insert zero velocity when trajectory is over drivable area
   insertZeroVelocityOutsideDrivableArea(planner_data, optimized_traj_points);
 
-  // 4. publish debug marker
+  // 3. publish debug marker
   publishDebugMarkerOfOptimization(optimized_traj_points);
 
   return optimized_traj_points;
@@ -339,6 +356,7 @@ std::vector<TrajectoryPoint> PathOptimizer::generateOptimizedTrajectory(
 std::vector<TrajectoryPoint> PathOptimizer::optimizeTrajectory(const PlannerData & planner_data)
 {
   autoware_utils::ScopedTimeTrack st(__func__, *time_keeper_);
+  is_optimization_failed_ = false;
   const auto & p = planner_data;
 
   // 1. check if replan (= optimization) is required
@@ -365,7 +383,23 @@ std::vector<TrajectoryPoint> PathOptimizer::optimizeTrajectory(const PlannerData
   //    with model predictive trajectory
   const auto mpt_traj = mpt_optimizer_ptr_->optimizeTrajectory(planner_data);
 
-  return mpt_traj;
+  const bool optimized_traj_failed = static_cast<bool>(mpt_traj);
+
+  conditional_timer_->update(optimized_traj_failed);
+
+  const double elapsed_time = conditional_timer_->getElapsedTime().count();
+  const bool elapsed_time_over_three_seconds = (elapsed_time > 3.0);
+
+  auto optimized_traj_points =
+    optimized_traj_failed && elapsed_time_over_three_seconds ? p.traj_points : std::move(*mpt_traj);
+  is_optimization_failed_ = optimized_traj_failed && elapsed_time_over_three_seconds;
+
+  // 3. update velocity
+  //    NOTE: When optimization failed or is skipped, velocity in trajectory points must
+  //          be updated since velocity in input trajectory (path) may change.
+  applyInputVelocity(optimized_traj_points, p.traj_points, planner_data.ego_pose);
+
+  return optimized_traj_points;
 }
 
 std::vector<TrajectoryPoint> PathOptimizer::getPrevOptimizedTrajectory(

--- a/planning/autoware_path_smoother/src/elastic_band.cpp
+++ b/planning/autoware_path_smoother/src/elastic_band.cpp
@@ -403,9 +403,9 @@ std::optional<std::vector<double>> EBPathSmoother::calcSmoothedTrajectory()
 
   // solve QP
   const auto result = osqp_solver_ptr_->optimize();
-  const auto optimized_points = std::get<0>(result);
+  const auto optimized_points = result.primal_solution;
 
-  const auto status = std::get<3>(result);
+  const auto status = result.solution_status;
 
   // check status
   if (status != 1) {

--- a/planning/autoware_velocity_smoother/src/smoother/l2_pseudo_jerk_smoother.cpp
+++ b/planning/autoware_velocity_smoother/src/smoother/l2_pseudo_jerk_smoother.cpp
@@ -193,8 +193,8 @@ bool L2PseudoJerkSmoother::apply(
 
   // [b0, b1, ..., bN, |  a0, a1, ..., aN, |
   //  delta0, delta1, ..., deltaN, | sigma0, sigma1, ..., sigmaN]
-  const std::vector<double> optval = std::get<0>(result);
-  const int status_val = std::get<3>(result);
+  const std::vector<double> optval = result.primal_solution;
+  const int status_val = result.solution_status;
   if (status_val != 1) {
     RCLCPP_WARN(logger_, "optimization failed : %s", qp_solver_.getStatusMessage().c_str());
     return false;

--- a/planning/autoware_velocity_smoother/src/smoother/linf_pseudo_jerk_smoother.cpp
+++ b/planning/autoware_velocity_smoother/src/smoother/linf_pseudo_jerk_smoother.cpp
@@ -208,8 +208,8 @@ bool LinfPseudoJerkSmoother::apply(
 
   // [b0, b1, ..., bN, |  a0, a1, ..., aN, |
   //  delta0, delta1, ..., deltaN, | sigma0, sigma1, ..., sigmaN]
-  const std::vector<double> optval = std::get<0>(result);
-  const int status_val = std::get<3>(result);
+  const std::vector<double> optval = result.primal_solution;
+  const int status_val = result.solution_status;
   if (status_val != 1) {
     RCLCPP_WARN(logger_, "optimization failed : %s", qp_solver_.getStatusMessage().c_str());
     return false;

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_cruise_module/src/optimization_based_planner/velocity_optimizer.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_cruise_module/src/optimization_based_planner/velocity_optimizer.cpp
@@ -248,10 +248,11 @@ VelocityOptimizer::OptimizationResult VelocityOptimizer::optimize(const Optimiza
   }
 
   // execute optimization
-  const auto result = qp_solver_.optimize(P, A, q, lower_bound, upper_bound);
-  const std::vector<double> optval = std::get<0>(result);
+  const autoware::osqp_interface::OSQPResult result =
+    qp_solver_.optimize(P, A, q, lower_bound, upper_bound);
+  const std::vector<double> optval = result.primal_solution;
 
-  const int status_val = std::get<3>(result);
+  const int status_val = result.solution_status;
   if (status_val != 1)
     std::cerr << "optimization failed : " << qp_solver_.getStatusMessage().c_str() << std::endl;
 

--- a/system/autoware_system_diagnostic_monitor/config/planning.yaml
+++ b/system/autoware_system_diagnostic_monitor/config/planning.yaml
@@ -9,6 +9,7 @@ units:
           - { type: link, link: /autoware/planning/topic_rate_check/route }
           - { type: link, link: /autoware/planning/topic_rate_check/trajectory }
           - { type: link, link: /autoware/planning/trajectory_validation }
+          - { type: link, link: /autoware/planning/emergency_stop }
 
   - path: /autoware/planning/trajectory_validation
     type: and
@@ -23,6 +24,11 @@ units:
       - { type: link, link: /autoware/planning/trajectory_validation/steering }
       - { type: link, link: /autoware/planning/trajectory_validation/steering_rate }
       - { type: link, link: /autoware/planning/trajectory_validation/velocity_deviation }
+
+  - path: /autoware/planning/emergency_stop
+    type: and
+    list:
+      - { type: link, link: /planning/path_optimizer_emergency_stop-error }
 
   - path: /autoware/planning/routing/state
     type: diag
@@ -88,3 +94,15 @@ units:
     type: diag
     node: planning_validator
     name: trajectory_validation_velocity_deviation
+
+  - path: /planning/path_optimizer_emergency_stop-error
+    type: warn-to-ok
+    item:
+      type: link
+      link: /planning/path_optimizer_emergency_stop
+
+  - path: /planning/path_optimizer_emergency_stop
+    type: diag
+    node: path_optimizer
+    name: path_optimizer_emergency_stop
+    timeout: 1.0


### PR DESCRIPTION
## Description
Returns the smoothed_points trajectory fed into MPT when the latter fails, triggers an emergency stop MRM after 3s.
## Related links

**Parent Issue:**
- [Link](https://tier4.atlassian.net/browse/RT1-9515)

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
