### PR TITLE
fix(autoware_multi_object_tracker): unknown object orientation

### DIFF
--- a/perception/autoware_multi_object_tracker/lib/object_model/shapes.cpp
+++ b/perception/autoware_multi_object_tracker/lib/object_model/shapes.cpp
@@ -26,6 +26,7 @@
 #include <tf2/utils.h>
 
 #include <algorithm>
+#include <limits>
 #include <string>
 #include <vector>
 
@@ -92,17 +93,20 @@ bool convertConvexHullToBoundingBox(
   }
 
   // look for bounding box boundary
-  float max_x = 0;
-  float max_y = 0;
-  float min_x = 0;
-  float min_y = 0;
-  float max_z = 0;
+  float max_x = -std::numeric_limits<float>::infinity();
+  float max_y = -std::numeric_limits<float>::infinity();
+  float min_x = std::numeric_limits<float>::infinity();
+  float min_y = std::numeric_limits<float>::infinity();
+  float max_z = -std::numeric_limits<float>::infinity();
+  float min_z = std::numeric_limits<float>::infinity();
+
   for (const auto & point : input_object.shape.footprint.points) {
     max_x = std::max(max_x, point.x);
     max_y = std::max(max_y, point.y);
     min_x = std::min(min_x, point.x);
     min_y = std::min(min_y, point.y);
     max_z = std::max(max_z, point.z);
+    min_z = std::min(min_z, point.z);
   }
 
   // calc new center
@@ -120,7 +124,7 @@ bool convertConvexHullToBoundingBox(
   output_object.shape.type = autoware_perception_msgs::msg::Shape::BOUNDING_BOX;
   output_object.shape.dimensions.x = max_x - min_x;
   output_object.shape.dimensions.y = max_y - min_y;
-  output_object.shape.dimensions.z = max_z;
+  output_object.shape.dimensions.z = max_z - min_z;
 
   return true;
 }

--- a/perception/autoware_multi_object_tracker/lib/tracker/model/unknown_tracker.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/model/unknown_tracker.cpp
@@ -144,6 +144,7 @@ bool UnknownTracker::measure(const types::DynamicObject & object, const rclcpp::
 {
   // update object shape
   object_.shape = object.shape;
+  object_.pose.orientation = object.pose.orientation;
 
   // check time gap
   const double dt = motion_model_.getDeltaTime(time);


### PR DESCRIPTION
## Description

Object shape process for polygon shape (generally for unknown object) should be processed after the object is transformed to world coordinate. 
This PR fixes [the previous PR ](https://github.com/autowarefoundation/autoware.universe/pull/10203)the polygon process before the transform.

BUG


https://github.com/user-attachments/assets/91b5d8c6-59fc-4524-9d11-b3674543f87d



Additionally, fix a bug to fit bounding box to the polygon.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
