### PR TITLE
fix(obstacle stop/slow_down): early return without point cloud

### DIFF
--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_slow_down_module/package.xml
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_slow_down_module/package.xml
@@ -8,6 +8,7 @@
   <maintainer email="takayuki.murooka@tier4.jp">Takayuki Murooka</maintainer>
   <maintainer email="yuki.takagi@tier4.jp">Yuki Takagi</maintainer>
   <maintainer email="maxime.clement@tier4.jp">Maxime Clement</maintainer>
+  <maintainer email="arjun.ram@tier4.jp">Arjun Ram</maintainer>
 
   <license>Apache License 2.0</license>
 

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_slow_down_module/src/obstacle_slow_down_module.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_slow_down_module/src/obstacle_slow_down_module.hpp
@@ -111,7 +111,7 @@ private:
     const std::vector<Polygon2d> & decimated_traj_polys_with_lat_margin,
     const std::shared_ptr<PlannerData::Object> object, const rclcpp::Time & predicted_objects_stamp,
     const double dist_from_obj_poly_to_traj_poly);
-  std::optional<SlowDownObstacle> create_slow_down_obstacle_for_point_cloud(
+  SlowDownObstacle create_slow_down_obstacle_for_point_cloud(
     const rclcpp::Time & stamp, const geometry_msgs::msg::Point & front_collision_point,
     const geometry_msgs::msg::Point & back_collision_point, const double lat_dist_to_traj);
   std::vector<SlowdownInterval> plan_slow_down(

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/package.xml
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/package.xml
@@ -8,6 +8,7 @@
   <maintainer email="takayuki.murooka@tier4.jp">Takayuki Murooka</maintainer>
   <maintainer email="yuki.takagi@tier4.jp">Yuki Takagi</maintainer>
   <maintainer email="maxime.clement@tier4.jp">Maxime Clement</maintainer>
+  <maintainer email="arjun.ram@tier4.jp">Arjun Ram</maintainer>
   <maintainer email="berkay@leodrive.ai">Berkay Karaman</maintainer>
 
   <license>Apache License 2.0</license>

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/src/obstacle_stop_module.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/src/obstacle_stop_module.hpp
@@ -68,7 +68,6 @@ private:
   // ros parameters
   bool ignore_crossing_obstacle_{};
   bool suppress_sudden_stop_{};
-  bool use_pointcloud_{false};
   CommonParam common_param_{};
   StopPlanningParam stop_planning_param_{};
   ObstacleFilteringParam obstacle_filtering_param_{};
@@ -187,7 +186,7 @@ private:
     const VehicleInfo & vehicle_info, const double dist_to_bumper,
     const TrajectoryPolygonCollisionCheck & trajectory_polygon_collision_check) const;
 
-  std::optional<StopObstacle> create_stop_obstacle_for_point_cloud(
+  StopObstacle create_stop_obstacle_for_point_cloud(
     const std::vector<TrajectoryPoint> & traj_points, const rclcpp::Time & stamp,
     const geometry_msgs::msg::Point & stop_point, const double dist_to_bumper) const;
 

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/src/parameters.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/src/parameters.hpp
@@ -120,8 +120,6 @@ struct ObstacleFilteringParam
       utils::get_target_object_type(node, "obstacle_stop.obstacle_filtering.object_type.inside.");
     outside_stop_object_types =
       utils::get_target_object_type(node, "obstacle_stop.obstacle_filtering.object_type.outside.");
-    use_pointcloud = get_or_declare_parameter<bool>(
-      node, "obstacle_stop.obstacle_filtering.object_type.pointcloud");
 
     obstacle_velocity_threshold_to_stop = get_or_declare_parameter<double>(
       node, "obstacle_stop.obstacle_filtering.obstacle_velocity_threshold_to_stop");


### PR DESCRIPTION
## Description

The obstacle_stop and obstacle_slow_down modules **without point cloud** were very heavy since the point cloud processing was not skipped.
This PR returns early without the point cloud processing when the point cloud is disabled.

TODO: With another PR, the heavy calculation of the point cloud processing should be handled.

before:
```
⏰ Worst Case Execution Time ⏰
100.00% plan: total 90.28 [ms], avg. 90.28 [ms], run count: 1
    ├── 6.85% filter_stop_obstacle_for_predicted_object: total 6.18 [ms], avg. 6.18 [ms], run count: 1
    │   ├── 6.84% for_each_object: total 6.18 [ms], avg. 1.54 [ms], run count: 4
    │   │   ├── 3.26% get_decimated_traj_polys: total 2.94 [ms], avg. 2.94 [ms], run count: 1
    │   │   ├── 3.31% get_dist_to_traj_poly: total 2.99 [ms], avg. 2.99 [ms], run count: 1
    │   │   ├── 0.01% filter_inside_stop_obstacle_for_predicted_object: total 0.01 [ms], avg. 0.01 [ms], run count: 1
    │   │   ├── 0.01% filter_outside_stop_obstacle_for_predicted_object: total 0.01 [ms], avg. 0.01 [ms], run count: 1
    │   │   └── 0.24% rest: 0.22 [ms]
    │   ├── 0.00% check_consistency: total 0.00 [ms], avg. 0.00 [ms], run count: 1
    │   └── 0.01% rest: 0.01 [ms]
    ├── 91.06% filter_stop_obstacle_for_point_cloud: total 82.20 [ms], avg. 82.20 [ms], run count: 1
    │   ├── 90.04% convert_point_cloud_to_stop_points: total 81.29 [ms], avg. 81.29 [ms], run count: 1
    │   └── 1.01% rest: 0.91 [ms]
    ├── 0.02% plan_stop: total 0.02 [ms], avg. 0.02 [ms], run count: 1
    ├── 1.51% publish_debug_info: total 1.37 [ms], avg. 1.37 [ms], run count: 1
    └── 0.56% rest: 0.51 [ms]
```

after:
```
⏰ Worst Case Execution Time ⏰
100.00% plan: total 8.13 [ms], avg. 8.13 [ms], run count: 1
    ├── 87.41% filter_stop_obstacle_for_predicted_object: total 7.10 [ms], avg. 7.10 [ms], run count: 1
    │   ├── 87.30% for_each_object: total 7.09 [ms], avg. 1.77 [ms], run count: 4
    │   │   ├── 27.96% get_decimated_traj_polys: total 2.27 [ms], avg. 0.57 [ms], run count: 4
    │   │   ├── 53.38% get_dist_to_traj_poly: total 4.34 [ms], avg. 1.08 [ms], run count: 4
    │   │   ├── 0.21% filter_inside_stop_obstacle_for_predicted_object: total 0.02 [ms], avg. 0.00 [ms], run count: 4
    │   │   ├── 0.34% filter_outside_stop_obstacle_for_predicted_object: total 0.03 [ms], avg. 0.01 [ms], run count: 4
    │   │   └── 5.40% rest: 0.44 [ms]
    │   ├── 0.01% check_consistency: total 0.00 [ms], avg. 0.00 [ms], run count: 1
    │   └── 0.10% rest: 0.01 [ms]
    ├── 0.01% filter_stop_obstacle_for_point_cloud: total 0.00 [ms], avg. 0.00 [ms], run count: 1
    ├── 0.21% plan_stop: total 0.02 [ms], avg. 0.02 [ms], run count: 1
    ├── 3.77% publish_debug_info: total 0.31 [ms], avg. 0.31 [ms], run count: 1
    └── 8.60% rest: 0.70 [ms]
```

## Related links


## How was this PR tested?

psim

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
