### PR TITLE
feat(vehicle_cmd_gate): use throttle log

### DIFF
--- a/control/autoware_vehicle_cmd_gate/src/vehicle_cmd_gate.cpp
+++ b/control/autoware_vehicle_cmd_gate/src/vehicle_cmd_gate.cpp
@@ -342,14 +342,17 @@ bool VehicleCmdGate::isDataReady()
   // emergency state must be received before running
   if (use_emergency_handling_) {
     if (!emergency_state_heartbeat_received_time_) {
-      RCLCPP_WARN(get_logger(), "emergency_state_heartbeat_received_time_ is false");
+      RCLCPP_WARN_THROTTLE(
+        get_logger(), *get_clock(), 5000, "emergency_state_heartbeat_received_time_ is false");
       return false;
     }
   }
 
   if (check_external_emergency_heartbeat_) {
     if (!external_emergency_stop_heartbeat_received_time_) {
-      RCLCPP_WARN(get_logger(), "external_emergency_stop_heartbeat_received_time_ is false");
+      RCLCPP_WARN_THROTTLE(
+        get_logger(), *get_clock(), 5000,
+        "external_emergency_stop_heartbeat_received_time_ is false");
       return false;
     }
   }


### PR DESCRIPTION
## Description

Use throttle log because there are too many logs to read.

## Related links

**Private Links:**

- [TIER IV internal link](https://star4.slack.com/archives/C075BTE8TPB/p1744074295183139)

## How was this PR tested?

Check the vehicle drives in autonomous mode using simple planning simulator.

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
