### PR TITLE
ci(build-and-test): ensure sequential run and remove core limitation

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -6,8 +6,8 @@ on:
       - main
 
 concurrency:
-  # Ensures sequential execution of this workflow
-  group: ${{ github.workflow }}
+  # Ensure sequential execution of this workflow
+  group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: false
 
 env:
@@ -99,7 +99,6 @@ jobs:
           target-packages: ${{ steps.get-self-packages.outputs.self-packages }}
           build-depends-repos: build_depends.repos
           cache-key-element: ${{ env.BUILD_TYPE_CUDA_STATE }}
-          build-pre-command: taskset --cpu-list 0-5
 
       - name: Show ccache stats after build
         run: du -sh ${CCACHE_DIR} && ccache -s


### PR DESCRIPTION
## Description

For some reason, these workflows are getting canceled when a new one arrives. This PR attempts to ensure they all run without cancelling the old ones.

Will follow https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/control-the-concurrency-of-workflows-and-jobs#example-using-concurrency-and-the-default-behavior and use `group: ${{ github.workflow }}-${{ github.ref }}`.

Also removed the core limitation since this is running on 8c16t self hosted machines.

![image](https://github.com/user-attachments/assets/ed7c9cc3-cae5-4418-a305-0357144a406f)

![image](https://github.com/user-attachments/assets/5048d6a6-cc44-4703-9f19-0283bf267ea6)

> Canceling since a higher priority waiting request for build-and-test exists

## How was this PR tested?

build-and-test-daily works under the same machine without the core limitations just fine and much faster.

![image](https://github.com/user-attachments/assets/d69aa8b7-c18b-4cb7-a114-4aec81271589)

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.
