### PR TITLE
fix(control_evaluator): add check route handler readiness

### DIFF
--- a/evaluator/autoware_control_evaluator/src/control_evaluator_node.cpp
+++ b/evaluator/autoware_control_evaluator/src/control_evaluator_node.cpp
@@ -435,7 +435,7 @@ void ControlEvaluatorNode::onTimer()
   }
 
   // add boundary distance metrics
-  if (odom && behavior_path) {
+  if (odom && behavior_path && route_handler_.isHandlerReady()) {
     const Pose ego_pose = odom->pose.pose;
     AddBoundaryDistanceMetricMsg(*behavior_path, ego_pose);
   }


### PR DESCRIPTION
## Description

`RouteHandler` has field  `lanelet_map_ptr_` which is `nullptr` when object is created using default constructor. This field is set only when `setMap(..)` method call. Using `RouteHandler` without checking if handler is ready can cause segmentation fault error. 

This fix adds check before function call that uses `RouteHandler`. 

## Related links

**Parent Issue:**

- None

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

- run planning and control modules
- set goal
- restart control launch.

Some of tests with this sequence result in segmentation fault error:
```
ERROR] [control_evaluator-3]: process has died [pid 22050, exit code -11 (...)].
```

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
