### PR TITLE
fix(cuda_pointcloud_preprocessor): ensure ordered twist/imu queues

### DIFF
--- a/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor_node.cpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor_node.cpp
@@ -204,10 +204,12 @@ void CudaPointcloudPreprocessorNode::imuCallback(
   const sensor_msgs::msg::Imu::ConstSharedPtr imu_msg)
 {
   while (!angular_velocity_queue_.empty()) {
+    /* *INDENT-OFF* */
     // for rosbag replay
-    bool backwards_time_jump_detected =
-      (rclcpp::Time(angular_velocity_queue_.front().header.stamp) >
-       rclcpp::Time(imu_msg->header.stamp));
+    bool backwards_time_jump_detected = rclcpp::Time(angular_velocity_queue_.front().header.stamp) >
+                                        rclcpp::Time(imu_msg->header.stamp);
+    /* *INDENT-ON* */
+
     bool is_queue_longer_than_1s =
       rclcpp::Time(angular_velocity_queue_.front().header.stamp) <
       rclcpp::Time(imu_msg->header.stamp) - rclcpp::Duration::from_seconds(1.0);


### PR DESCRIPTION
## Description

Although the twist/IMU handling logic in the CUDA preprocessor should be equivalent to the CPU version, there are often occurrences of the twist and IMU queues becoming unordered.

This PR ensures upon insertion of new messages that they are inserted in-order, even if they arrive out-of-order.

As to _why_ they arrive out-of-order: I have no idea. I have confirmed the insertion algorithms are logically identical to the CPU version, and the same rosbag has no issues on the CPU version. Even the same polling subscribers are used.
If anyone has a clue, please let me know :disguised_face: 

## How was this PR tested?

Tested with Pilot Auto X2 launch setup and [TIER IV Internal](https://console.mob.tier4.jp/projects/x2_dev/rosbag?viz=stream&agg=count&from_ts=1746340146&to_ts=1748932146&live=true&query=log_file_name%3A%28cfa23601-97c4-4d47-a37e-edfc7e080d8c_2025-05-29-17-00-12_p0900_11%29&file_id=e4c77db5-5700-4442-9317-9be5e85a77ca) rosbag, see below.
The time jumps observed in both videos are the result of my pitiful attempt at video compression and are not happening in reality.

<table>
<tr>
<th>Before</th><th>After</th>
</tr>
<tr>
<td>

https://github.com/user-attachments/assets/748a39cf-86e5-4213-a29b-1ac683b04fb7

</td>
<td>

https://github.com/user-attachments/assets/5b465538-a60b-4296-b953-195c3761286e

</td>
</tr>
</table>

## Notes for reviewers

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
