### PR TITLE
feat(autoware_cuda_pointcloud_preprocessor): diagnostic for cuda pointcloud preprocessor

### DIFF
--- a/sensing/autoware_cuda_pointcloud_preprocessor/CMakeLists.txt
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/CMakeLists.txt
@@ -24,6 +24,7 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 
 if(BUILD_TESTING)
+    list(APPEND AMENT_LINT_AUTO_EXCLUDE ament_cmake_uncrustify)
     find_package(ament_lint_auto REQUIRED)
     ament_lint_auto_find_test_dependencies()
 endif()

--- a/sensing/autoware_cuda_pointcloud_preprocessor/config/cuda_pointcloud_preprocessor.param.yaml
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/config/cuda_pointcloud_preprocessor.param.yaml
@@ -5,6 +5,8 @@
     use_3d_distortion_correction: false
     distance_ratio: 1.03
     object_length_threshold: 0.05
+    processing_time_threshold_sec: 0.01
+    timestamp_mismatch_fraction_threshold: 0.01
 
     crop_box.min_x: [0.0]
     crop_box.min_y: [0.0]

--- a/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/common_kernels.hpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/common_kernels.hpp
@@ -27,9 +27,9 @@ void transformPointsLaunch(
   TransformStruct transform, int threads_per_block, int blocks_per_grid, cudaStream_t & stream);
 
 void cropBoxLaunch(
-  InputPointType * d_points, std::uint32_t * output_mask, std::uint8_t * nan_mask, int num_points,
-  const CropBoxParameters * crop_box_parameters_ptr, int num_crop_boxes, int threads_per_block,
-  int blocks_per_grid, cudaStream_t & stream);
+  InputPointType * d_points, std::uint32_t * output_crop_mask, std::uint8_t * output_nan_mask,
+  int num_points, const CropBoxParameters * crop_box_parameters_ptr, int num_crop_boxes,
+  int threads_per_block, int blocks_per_grid, cudaStream_t & stream);
 
 void combineMasksLaunch(
   const std::uint32_t * mask1, const std::uint32_t * mask2, int num_points,

--- a/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/common_kernels.hpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/common_kernels.hpp
@@ -27,7 +27,7 @@ void transformPointsLaunch(
   TransformStruct transform, int threads_per_block, int blocks_per_grid, cudaStream_t & stream);
 
 void cropBoxLaunch(
-  InputPointType * d_points, std::uint32_t * output_mask, int num_points,
+  InputPointType * d_points, std::uint32_t * output_mask, std::uint8_t * nan_mask, int num_points,
   const CropBoxParameters * crop_box_parameters_ptr, int num_crop_boxes, int threads_per_block,
   int blocks_per_grid, cudaStream_t & stream);
 

--- a/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_concatenate_data/cuda_combine_cloud_handler.hpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_concatenate_data/cuda_combine_cloud_handler.hpp
@@ -25,7 +25,6 @@
 namespace autoware::pointcloud_preprocessor
 {
 
-/* *INDENT-OFF* */
 template <>
 class CombineCloudHandler<CudaPointCloud2Traits> : public CombineCloudHandlerBase
 {
@@ -55,6 +54,5 @@ public:
 
   void allocate_pointclouds() override;
 };
-/* *INDENT-ON* */
 
 }  // namespace autoware::pointcloud_preprocessor

--- a/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_concatenate_data/cuda_combine_cloud_handler_kernel.hpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_concatenate_data/cuda_combine_cloud_handler_kernel.hpp
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/* *INDENT-OFF* */
 #ifndef AUTOWARE__CUDA_POINTCLOUD_PREPROCESSOR__CUDA_CONCATENATE_DATA__CUDA_COMBINE_CLOUD_HANDLER_KERNEL_HPP_
 #define AUTOWARE__CUDA_POINTCLOUD_PREPROCESSOR__CUDA_CONCATENATE_DATA__CUDA_COMBINE_CLOUD_HANDLER_KERNEL_HPP_
 
@@ -56,4 +55,3 @@ void transform_launch(
 }  // namespace autoware::pointcloud_preprocessor
 
 #endif  // AUTOWARE__CUDA_POINTCLOUD_PREPROCESSOR__CUDA_CONCATENATE_DATA__CUDA_COMBINE_CLOUD_HANDLER_KERNEL_HPP_
-/* *INDENT-ON* */

--- a/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_concatenate_data/cuda_concatenate_and_time_sync_node.hpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_concatenate_data/cuda_concatenate_and_time_sync_node.hpp
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/* *INDENT-OFF* */
 #ifndef AUTOWARE__CUDA_POINTCLOUD_PREPROCESSOR__CUDA_CONCATENATE_DATA__CUDA_CONCATENATE_AND_TIME_SYNC_NODE_HPP_
 #define AUTOWARE__CUDA_POINTCLOUD_PREPROCESSOR__CUDA_CONCATENATE_DATA__CUDA_CONCATENATE_AND_TIME_SYNC_NODE_HPP_
 
@@ -44,4 +43,3 @@ public:
 }  // namespace autoware::cuda_pointcloud_preprocessor
 
 #endif  // AUTOWARE__CUDA_POINTCLOUD_PREPROCESSOR__CUDA_CONCATENATE_DATA__CUDA_CONCATENATE_AND_TIME_SYNC_NODE_HPP_
-/* *INDENT-ON* */

--- a/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_downsample_filter/cuda_voxel_grid_downsample_filter.hpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_downsample_filter/cuda_voxel_grid_downsample_filter.hpp
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/* *INDENT-OFF* */
 #ifndef AUTOWARE__CUDA_POINTCLOUD_PREPROCESSOR__CUDA_DOWNSAMPLE_FILTER__CUDA_VOXEL_GRID_DOWNSAMPLE_FILTER_HPP_
 #define AUTOWARE__CUDA_POINTCLOUD_PREPROCESSOR__CUDA_DOWNSAMPLE_FILTER__CUDA_VOXEL_GRID_DOWNSAMPLE_FILTER_HPP_
 
@@ -124,4 +123,3 @@ private:
 }  // namespace autoware::cuda_pointcloud_preprocessor
 
 #endif  // AUTOWARE__CUDA_POINTCLOUD_PREPROCESSOR__CUDA_DOWNSAMPLE_FILTER__CUDA_VOXEL_GRID_DOWNSAMPLE_FILTER_HPP_
-/* *INDENT-ON* */

--- a/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_downsample_filter/cuda_voxel_grid_downsample_filter_node.hpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_downsample_filter/cuda_voxel_grid_downsample_filter_node.hpp
@@ -26,7 +26,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/* *INDENT-OFF* */
 #ifndef AUTOWARE__CUDA_POINTCLOUD_PREPROCESSOR__CUDA_DOWNSAMPLE_FILTER__CUDA_VOXEL_GRID_DOWNSAMPLE_FILTER_NODE_HPP_
 #define AUTOWARE__CUDA_POINTCLOUD_PREPROCESSOR__CUDA_DOWNSAMPLE_FILTER__CUDA_VOXEL_GRID_DOWNSAMPLE_FILTER_NODE_HPP_
 
@@ -63,4 +62,3 @@ private:
 }  // namespace autoware::cuda_pointcloud_preprocessor
 
 #endif  // AUTOWARE__CUDA_POINTCLOUD_PREPROCESSOR__CUDA_DOWNSAMPLE_FILTER__CUDA_VOXEL_GRID_DOWNSAMPLE_FILTER_NODE_HPP_
-/* *INDENT-ON* */

--- a/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_downsample_filter/thrust_custom_allocator.hpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_downsample_filter/thrust_custom_allocator.hpp
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/* *INDENT-OFF* */
 #ifndef AUTOWARE__CUDA_POINTCLOUD_PREPROCESSOR__CUDA_DOWNSAMPLE_FILTER__THRUST_CUSTOM_ALLOCATOR_HPP_
 #define AUTOWARE__CUDA_POINTCLOUD_PREPROCESSOR__CUDA_DOWNSAMPLE_FILTER__THRUST_CUSTOM_ALLOCATOR_HPP_
 
@@ -61,4 +60,3 @@ private:
 }  // namespace autoware::cuda_pointcloud_preprocessor
 
 #endif  // AUTOWARE__CUDA_POINTCLOUD_PREPROCESSOR__CUDA_DOWNSAMPLE_FILTER__THRUST_CUSTOM_ALLOCATOR_HPP_
-/* *INDENT-ON* */

--- a/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor.hpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor.hpp
@@ -50,7 +50,10 @@ public:
   void setUndistortionType(const UndistortionType & undistortion_type);
 
   void preallocateOutput();
-  [[nodiscard]] int getLatestMismatchCount() const { return latest_mismatch_count_; }
+  [[nodiscard]] int getLatestMismatchCount() const
+  {
+    return static_cast<int>(latest_mismatch_count_);
+  }
 
   std::unique_ptr<cuda_blackboard::CudaPointCloud2> process(
     const sensor_msgs::msg::PointCloud2::ConstSharedPtr input_pointcloud_msg_ptr,
@@ -80,7 +83,7 @@ private:
   const int threads_per_block_{256};
   cudaMemPool_t device_memory_pool_;
 
-  int latest_mismatch_count_{0};
+  std::uint32_t latest_mismatch_count_{0};
 
   // Organizing buffers
   thrust::device_vector<InputPointType> device_input_points_;
@@ -99,6 +102,7 @@ private:
   thrust::device_vector<InputPointType> device_transformed_points_{};
   thrust::device_vector<OutputPointType> device_output_points_{};
   thrust::device_vector<std::uint32_t> device_crop_mask_{};
+  thrust::device_vector<std::uint8_t> device_mismatch_mask_{};
   thrust::device_vector<std::uint32_t> device_ring_outlier_mask_{};
   thrust::device_vector<std::uint32_t> device_indices_{};
   thrust::device_vector<TwistStruct2D> device_twist_2d_structs_{};

--- a/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor.hpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor.hpp
@@ -50,6 +50,7 @@ public:
   void setUndistortionType(const UndistortionType & undistortion_type);
 
   void preallocateOutput();
+  [[nodiscard]] int getLatestMismatchCount() const { return latest_mismatch_count_; }
 
   std::unique_ptr<cuda_blackboard::CudaPointCloud2> process(
     const sensor_msgs::msg::PointCloud2::ConstSharedPtr input_pointcloud_msg_ptr,
@@ -78,6 +79,8 @@ private:
   int max_blocks_per_grid_{};
   const int threads_per_block_{256};
   cudaMemPool_t device_memory_pool_;
+
+  int latest_mismatch_count_{0};
 
   // Organizing buffers
   thrust::device_vector<InputPointType> device_input_points_;

--- a/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor.hpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor.hpp
@@ -37,6 +37,13 @@
 namespace autoware::cuda_pointcloud_preprocessor
 {
 
+struct ProcessingStats
+{
+  int mismatch_count{0};
+  int num_crop_box_passed_points{0};
+  int num_nan_points{0};
+};
+
 class CudaPointcloudPreprocessor
 {
 public:
@@ -50,12 +57,7 @@ public:
   void setUndistortionType(const UndistortionType & undistortion_type);
 
   void preallocateOutput();
-  [[nodiscard]] int getMismatchCount() const { return static_cast<int>(mismatch_count_); }
-  [[nodiscard]] int getCropBoxPassedPoints() const
-  {
-    return static_cast<int>(num_crop_box_passed_points_);
-  }
-  [[nodiscard]] int getNumNanPoints() const { return static_cast<int>(num_nan_points_); }
+  [[nodiscard]] ProcessingStats getProcessingStats() const { return stats_; }
 
   std::unique_ptr<cuda_blackboard::CudaPointCloud2> process(
     const sensor_msgs::msg::PointCloud2::ConstSharedPtr input_pointcloud_msg_ptr,
@@ -85,9 +87,7 @@ private:
   const int threads_per_block_{256};
   cudaMemPool_t device_memory_pool_;
 
-  std::uint32_t mismatch_count_{0};
-  std::uint32_t num_crop_box_passed_points_{0};
-  std::uint32_t num_nan_points_{0};
+  ProcessingStats stats_;
 
   // Organizing buffers
   thrust::device_vector<InputPointType> device_input_points_;

--- a/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor.hpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor.hpp
@@ -50,10 +50,12 @@ public:
   void setUndistortionType(const UndistortionType & undistortion_type);
 
   void preallocateOutput();
-  [[nodiscard]] int getLatestMismatchCount() const
+  [[nodiscard]] int getMismatchCount() const { return static_cast<int>(mismatch_count_); }
+  [[nodiscard]] int getCropBoxPassedPoints() const
   {
-    return static_cast<int>(latest_mismatch_count_);
+    return static_cast<int>(num_crop_box_passed_points_);
   }
+  [[nodiscard]] int getNumNanPoints() const { return static_cast<int>(num_nan_points_); }
 
   std::unique_ptr<cuda_blackboard::CudaPointCloud2> process(
     const sensor_msgs::msg::PointCloud2::ConstSharedPtr input_pointcloud_msg_ptr,
@@ -83,7 +85,9 @@ private:
   const int threads_per_block_{256};
   cudaMemPool_t device_memory_pool_;
 
-  std::uint32_t latest_mismatch_count_{0};
+  std::uint32_t mismatch_count_{0};
+  std::uint32_t num_crop_box_passed_points_{0};
+  std::uint32_t num_nan_points_{0};
 
   // Organizing buffers
   thrust::device_vector<InputPointType> device_input_points_;
@@ -102,6 +106,7 @@ private:
   thrust::device_vector<InputPointType> device_transformed_points_{};
   thrust::device_vector<OutputPointType> device_output_points_{};
   thrust::device_vector<std::uint32_t> device_crop_mask_{};
+  thrust::device_vector<std::uint8_t> device_nan_mask_{};
   thrust::device_vector<std::uint8_t> device_mismatch_mask_{};
   thrust::device_vector<std::uint32_t> device_ring_outlier_mask_{};
   thrust::device_vector<std::uint32_t> device_indices_{};

--- a/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor.hpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor.hpp
@@ -60,7 +60,7 @@ public:
   [[nodiscard]] ProcessingStats getProcessingStats() const { return stats_; }
 
   std::unique_ptr<cuda_blackboard::CudaPointCloud2> process(
-    const sensor_msgs::msg::PointCloud2::ConstSharedPtr input_pointcloud_msg_ptr,
+    const sensor_msgs::msg::PointCloud2 & input_pointcloud_msg,
     const geometry_msgs::msg::TransformStamped & transform_msg,
     const std::deque<geometry_msgs::msg::TwistWithCovarianceStamped> & twist_queue,
     const std::deque<geometry_msgs::msg::Vector3Stamped> & angular_velocity_queue,

--- a/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor_node.hpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor_node.hpp
@@ -115,7 +115,7 @@ private:
   tf2_ros::TransformListener tf2_listener_;
 
   // Diagnostic
-  std::unique_ptr<autoware_utils_diagnostics::DiagnosticsInterface> diagnostics_interface_;
+  std::unique_ptr<autoware_utils::DiagnosticsInterface> diagnostics_interface_;
 
   std::string base_frame_;
   double processing_time_threshold_sec_;

--- a/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor_node.hpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor_node.hpp
@@ -99,6 +99,9 @@ private:
   std::unique_ptr<autoware_utils_diagnostics::DiagnosticsInterface> diagnostics_interface_;
 
   std::string base_frame_;
+  double processing_time_threshold_sec_;
+  double timestamp_mismatch_fraction_threshold_;
+  bool use_3d_undistortion_;
   std::deque<geometry_msgs::msg::TwistWithCovarianceStamped> twist_queue_;
   std::deque<geometry_msgs::msg::Vector3Stamped> angular_velocity_queue_;
 

--- a/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor_node.hpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor_node.hpp
@@ -41,13 +41,12 @@
 #include <deque>
 #include <memory>
 #include <string>
+#include <utility>
 
-/* *INDENT-OFF* */
 #define CHECK_OFFSET(structure1, structure2, field)             \
   static_assert(                                                \
     offsetof(structure1, field) == offsetof(structure2, field), \
     "Offset of " #field " in " #structure1 " does not match expected offset.")
-/* *INDENT-ON* */
 
 namespace autoware::cuda_pointcloud_preprocessor
 {

--- a/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor_node.hpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor_node.hpp
@@ -95,7 +95,8 @@ private:
   // Helper Functions
 
   void validatePointcloudLayout(const sensor_msgs::msg::PointCloud2 & input_pointcloud_msg);
-  double getFirstPointTimestamp(const sensor_msgs::msg::PointCloud2 & input_pointcloud_msg);
+  std::pair<double, std::uint32_t> getFirstPointTimeInfo(
+    const sensor_msgs::msg::PointCloud2 & input_pointcloud_msg);
 
   void updateTwistQueue(double first_point_stamp);
   void updateImuQueue(double first_point_stamp);
@@ -103,7 +104,8 @@ private:
     const std::string & source_frame);
   std::unique_ptr<cuda_blackboard::CudaPointCloud2> processPointcloud(
     const sensor_msgs::msg::PointCloud2 & input_pointcloud_msg,
-    const geometry_msgs::msg::TransformStamped & transform_msg);
+    const geometry_msgs::msg::TransformStamped & transform_msg,
+    const std::uint32_t first_point_rel_stamp);
 
   void publishDiagnostics(
     const sensor_msgs::msg::PointCloud2 & input_pointcloud_msg,

--- a/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor_node.hpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor_node.hpp
@@ -22,6 +22,7 @@
 #include <autoware/universe_utils/ros/debug_publisher.hpp>
 #include <autoware/universe_utils/ros/polling_subscriber.hpp>
 #include <autoware/universe_utils/system/stop_watch.hpp>
+#include <autoware_utils/ros/diagnostics_interface.hpp>
 #include <cuda_blackboard/cuda_adaptation.hpp>
 #include <cuda_blackboard/cuda_blackboard_publisher.hpp>
 #include <cuda_blackboard/cuda_blackboard_subscriber.hpp>
@@ -93,6 +94,9 @@ private:
 
   tf2_ros::Buffer tf2_buffer_;
   tf2_ros::TransformListener tf2_listener_;
+
+  // Diagnostic
+  std::unique_ptr<autoware_utils_diagnostics::DiagnosticsInterface> diagnostics_interface_;
 
   std::string base_frame_;
   std::deque<geometry_msgs::msg::TwistWithCovarianceStamped> twist_queue_;

--- a/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor_node.hpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor_node.hpp
@@ -94,21 +94,19 @@ private:
 
   // Helper Functions
 
-  void validatePointcloudLayout(
-    const sensor_msgs::msg::PointCloud2::ConstSharedPtr & input_pointcloud_msg_ptr);
-  double getFirstPointTimestamp(
-    const sensor_msgs::msg::PointCloud2::ConstSharedPtr & input_pointcloud_msg_ptr);
+  void validatePointcloudLayout(const sensor_msgs::msg::PointCloud2 & input_pointcloud_msg);
+  double getFirstPointTimestamp(const sensor_msgs::msg::PointCloud2 & input_pointcloud_msg);
 
   void updateTwistQueue(double first_point_stamp);
   void updateImuQueue(double first_point_stamp);
   std::optional<geometry_msgs::msg::TransformStamped> lookupTransformToBase(
     const std::string & source_frame);
   std::unique_ptr<cuda_blackboard::CudaPointCloud2> processPointcloud(
-    const sensor_msgs::msg::PointCloud2::ConstSharedPtr & input_pointcloud_msg_ptr,
+    const sensor_msgs::msg::PointCloud2 & input_pointcloud_msg,
     const geometry_msgs::msg::TransformStamped & transform_msg);
 
   void publishDiagnostics(
-    const sensor_msgs::msg::PointCloud2::ConstSharedPtr & input_pointcloud_msg_ptr,
+    const sensor_msgs::msg::PointCloud2 & input_pointcloud_msg,
     const std::unique_ptr<cuda_blackboard::CudaPointCloud2> & output_pointcloud_ptr);
 
   tf2_ros::Buffer tf2_buffer_;

--- a/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor_node.hpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor_node.hpp
@@ -19,10 +19,10 @@
 #include "autoware/cuda_pointcloud_preprocessor/point_types.hpp"
 
 #include <autoware/point_types/types.hpp>
-#include <autoware/universe_utils/ros/debug_publisher.hpp>
-#include <autoware/universe_utils/ros/polling_subscriber.hpp>
-#include <autoware/universe_utils/system/stop_watch.hpp>
+#include <autoware_utils/ros/debug_publisher.hpp>
 #include <autoware_utils/ros/diagnostics_interface.hpp>
+#include <autoware_utils/ros/polling_subscriber.hpp>
+#include <autoware_utils/system/stop_watch.hpp>
 #include <cuda_blackboard/cuda_adaptation.hpp>
 #include <cuda_blackboard/cuda_blackboard_publisher.hpp>
 #include <cuda_blackboard/cuda_blackboard_subscriber.hpp>
@@ -118,18 +118,20 @@ private:
   std::unique_ptr<autoware_utils::DiagnosticsInterface> diagnostics_interface_;
 
   std::string base_frame_;
+  bool use_3d_undistortion_;
+  bool use_imu_;
   double processing_time_threshold_sec_;
   double timestamp_mismatch_fraction_threshold_;
-  bool use_3d_undistortion_;
+
   std::deque<geometry_msgs::msg::TwistWithCovarianceStamped> twist_queue_;
   std::deque<geometry_msgs::msg::Vector3Stamped> angular_velocity_queue_;
 
   // Subscribers
-  autoware::universe_utils::InterProcessPollingSubscriber<
-    sensor_msgs::msg::Imu, autoware::universe_utils::polling_policy::All>::SharedPtr imu_sub_;
-  autoware::universe_utils::InterProcessPollingSubscriber<
-    geometry_msgs::msg::TwistWithCovarianceStamped,
-    autoware::universe_utils::polling_policy::All>::SharedPtr twist_sub_;
+  autoware_utils::InterProcessPollingSubscriber<
+    sensor_msgs::msg::Imu, autoware_utils::polling_policy::All>::SharedPtr imu_sub_;
+  autoware_utils::InterProcessPollingSubscriber<
+    geometry_msgs::msg::TwistWithCovarianceStamped, autoware_utils::polling_policy::All>::SharedPtr
+    twist_sub_;
   rclcpp::Subscription<sensor_msgs::msg::PointCloud2>::SharedPtr pointcloud_sub_{};
 
   // CUDA pub
@@ -137,8 +139,8 @@ private:
 
   std::unique_ptr<CudaPointcloudPreprocessor> cuda_pointcloud_preprocessor_;
 
-  std::unique_ptr<autoware::universe_utils::StopWatch<std::chrono::milliseconds>> stop_watch_ptr_;
-  std::unique_ptr<autoware::universe_utils::DebugPublisher> debug_publisher_;
+  std::unique_ptr<autoware_utils::StopWatch<std::chrono::milliseconds>> stop_watch_ptr_;
+  std::unique_ptr<autoware_utils::DebugPublisher> debug_publisher_;
 };
 
 }  // namespace autoware::cuda_pointcloud_preprocessor

--- a/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor_node.hpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor_node.hpp
@@ -92,6 +92,25 @@ private:
     const geometry_msgs::msg::TwistWithCovarianceStamped::ConstSharedPtr pointcloud_msg);
   void imuCallback(const sensor_msgs::msg::Imu::ConstSharedPtr imu_msg);
 
+  // Helper Functions
+
+  void validatePointcloudLayout(
+    const sensor_msgs::msg::PointCloud2::ConstSharedPtr & input_pointcloud_msg_ptr);
+  double getFirstPointTimestamp(
+    const sensor_msgs::msg::PointCloud2::ConstSharedPtr & input_pointcloud_msg_ptr);
+
+  void updateTwistQueue(double first_point_stamp);
+  void updateImuQueue(double first_point_stamp);
+  std::optional<geometry_msgs::msg::TransformStamped> lookupTransformToBase(
+    const std::string & source_frame);
+  std::unique_ptr<cuda_blackboard::CudaPointCloud2> processPointcloud(
+    const sensor_msgs::msg::PointCloud2::ConstSharedPtr & input_pointcloud_msg_ptr,
+    const geometry_msgs::msg::TransformStamped & transform_msg);
+
+  void publishDiagnostics(
+    const sensor_msgs::msg::PointCloud2::ConstSharedPtr & input_pointcloud_msg_ptr,
+    const std::unique_ptr<cuda_blackboard::CudaPointCloud2> & output_pointcloud_ptr);
+
   tf2_ros::Buffer tf2_buffer_;
   tf2_ros::TransformListener tf2_listener_;
 

--- a/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor_node.hpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor_node.hpp
@@ -93,7 +93,6 @@ private:
   void imuCallback(const sensor_msgs::msg::Imu::ConstSharedPtr imu_msg);
 
   // Helper Functions
-
   void validatePointcloudLayout(const sensor_msgs::msg::PointCloud2 & input_pointcloud_msg);
   std::pair<double, std::uint32_t> getFirstPointTimeInfo(
     const sensor_msgs::msg::PointCloud2 & input_pointcloud_msg);

--- a/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/types.hpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/types.hpp
@@ -78,7 +78,6 @@ struct RingOutlierFilterParameters
   float object_length_threshold{std::nanf("")};
 };
 
-/* *INDENT-OFF* */
 template <typename T>
 class MemoryPoolAllocator
 {
@@ -98,8 +97,6 @@ public:
 protected:
   cudaMemPool_t m_pool;
 };
-/* *INDENT-ON* */
-
 }  // namespace autoware::cuda_pointcloud_preprocessor
 
 #endif  // AUTOWARE__CUDA_POINTCLOUD_PREPROCESSOR__TYPES_HPP_

--- a/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/undistort_kernels.hpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/undistort_kernels.hpp
@@ -30,11 +30,11 @@ namespace autoware::cuda_pointcloud_preprocessor
 {
 void undistort2DLaunch(
   InputPointType * input_points, int num_points, TwistStruct2D * twist_structs, int num_twists,
-  int threads_per_block, int blocks_per_grid, cudaStream_t & stream);
+  int * mismatch_count, int threads_per_block, int blocks_per_grid, cudaStream_t & stream);
 
 void undistort3DLaunch(
   InputPointType * input_points, int num_points, TwistStruct3D * twist_structs, int num_twists,
-  int threads_per_block, int blocks_per_grid, cudaStream_t & stream);
+  int * mismatch_count, int threads_per_block, int blocks_per_grid, cudaStream_t & stream);
 
 void setupTwist2DStructs(
   const std::deque<geometry_msgs::msg::TwistWithCovarianceStamped> & twist_queue,

--- a/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/undistort_kernels.hpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/undistort_kernels.hpp
@@ -30,11 +30,11 @@ namespace autoware::cuda_pointcloud_preprocessor
 {
 void undistort2DLaunch(
   InputPointType * input_points, int num_points, TwistStruct2D * twist_structs, int num_twists,
-  int * mismatch_count, int threads_per_block, int blocks_per_grid, cudaStream_t & stream);
+  std::uint8_t * mismatch_mask, int threads_per_block, int blocks_per_grid, cudaStream_t & stream);
 
 void undistort3DLaunch(
   InputPointType * input_points, int num_points, TwistStruct3D * twist_structs, int num_twists,
-  int * mismatch_count, int threads_per_block, int blocks_per_grid, cudaStream_t & stream);
+  std::uint8_t * mismatch_mask, int threads_per_block, int blocks_per_grid, cudaStream_t & stream);
 
 void setupTwist2DStructs(
   const std::deque<geometry_msgs::msg::TwistWithCovarianceStamped> & twist_queue,

--- a/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/undistort_kernels.hpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/undistort_kernels.hpp
@@ -30,11 +30,13 @@ namespace autoware::cuda_pointcloud_preprocessor
 {
 void undistort2DLaunch(
   InputPointType * input_points, int num_points, TwistStruct2D * twist_structs, int num_twists,
-  std::uint8_t * mismatch_mask, int threads_per_block, int blocks_per_grid, cudaStream_t & stream);
+  std::uint8_t * output_mismatch_mask, int threads_per_block, int blocks_per_grid,
+  cudaStream_t & stream);
 
 void undistort3DLaunch(
   InputPointType * input_points, int num_points, TwistStruct3D * twist_structs, int num_twists,
-  std::uint8_t * mismatch_mask, int threads_per_block, int blocks_per_grid, cudaStream_t & stream);
+  std::uint8_t * output_mismatch_mask, int threads_per_block, int blocks_per_grid,
+  cudaStream_t & stream);
 
 void setupTwist2DStructs(
   const std::deque<geometry_msgs::msg::TwistWithCovarianceStamped> & twist_queue,

--- a/sensing/autoware_cuda_pointcloud_preprocessor/package.xml
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/package.xml
@@ -16,7 +16,6 @@
   <depend>autoware_cuda_utils</depend>
   <depend>autoware_point_types</depend>
   <depend>autoware_pointcloud_preprocessor</depend>
-  <depend>autoware_universe_utils</depend>
   <depend>autoware_utils</depend>
   <depend>cuda_blackboard</depend>
   <depend>diagnostic_msgs</depend>

--- a/sensing/autoware_cuda_pointcloud_preprocessor/package.xml
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/package.xml
@@ -17,6 +17,7 @@
   <depend>autoware_point_types</depend>
   <depend>autoware_pointcloud_preprocessor</depend>
   <depend>autoware_universe_utils</depend>
+  <depend>autoware_utils</depend>
   <depend>cuda_blackboard</depend>
   <depend>diagnostic_msgs</depend>
   <depend>rclcpp</depend>

--- a/sensing/autoware_cuda_pointcloud_preprocessor/schema/cuda_pointcloud_preprocessor.schema.json
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/schema/cuda_pointcloud_preprocessor.schema.json
@@ -33,6 +33,16 @@
           "default": "0.05",
           "minimum": 0.0
         },
+        "processing_time_threshold_sec": {
+          "type": "number",
+          "description": "Threshold in seconds. If the processing time of the node exceeds this value, a diagnostic warning will be issued.",
+          "default": 0.01
+        },
+        "timestamp_mismatch_fraction_threshold": {
+          "type": "number",
+          "description": "Threshold for the fraction of points that lack corresponding twist or IMU data within the allowed timestamp tolerance.",
+          "default": 0.01
+        },
         "crop_box.min_x": {
           "type": "array",
           "description": "An array in which each element is the minimum x value in a crop box",
@@ -70,6 +80,8 @@
         "use_3d_distortion_correction",
         "distance_ratio",
         "object_length_threshold",
+        "processing_time_threshold_sec",
+        "timestamp_mismatch_fraction_threshold",
         "crop_box.min_x",
         "crop_box.min_y",
         "crop_box.min_z",

--- a/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_concatenate_data/cuda_cloud_collector.cpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_concatenate_data/cuda_cloud_collector.cpp
@@ -16,7 +16,5 @@
 
 #include "autoware/cuda_pointcloud_preprocessor/cuda_concatenate_data/cuda_traits.hpp"
 
-/* *INDENT-OFF* */
 template class autoware::pointcloud_preprocessor::CloudCollector<
   autoware::pointcloud_preprocessor::CudaPointCloud2Traits>;
-/* *INDENT-ON* */

--- a/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_concatenate_data/cuda_collector_matching_strategy.cpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_concatenate_data/cuda_collector_matching_strategy.cpp
@@ -15,9 +15,7 @@
 #include "autoware/cuda_pointcloud_preprocessor/cuda_concatenate_data/cuda_traits.hpp"
 #include "autoware/pointcloud_preprocessor/concatenate_data/collector_matching_strategy.hpp"
 
-/* *INDENT-OFF* */
 template class autoware::pointcloud_preprocessor::NaiveMatchingStrategy<
   autoware::pointcloud_preprocessor::CudaPointCloud2Traits>;
 template class autoware::pointcloud_preprocessor::AdvancedMatchingStrategy<
   autoware::pointcloud_preprocessor::CudaPointCloud2Traits>;
-/* *INDENT-ON* */

--- a/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_concatenate_data/cuda_combine_cloud_handler.cpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_concatenate_data/cuda_combine_cloud_handler.cpp
@@ -101,6 +101,8 @@ CombineCloudHandler<CudaPointCloud2Traits>::combine_pointclouds(
 
   for (const auto & [topic, cloud] : topic_to_cloud_map) {
     pc_stamps.emplace_back(cloud->header.stamp);
+    concatenate_cloud_result.topic_to_original_stamp_map[topic] =
+      rclcpp::Time(cloud->header.stamp).seconds();
   }
 
   std::sort(pc_stamps.begin(), pc_stamps.end(), std::greater<rclcpp::Time>());

--- a/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_concatenate_data/cuda_combine_cloud_handler.cpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_concatenate_data/cuda_combine_cloud_handler.cpp
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/* *INDENT-OFF* */
 #include "autoware/cuda_pointcloud_preprocessor/cuda_concatenate_data/cuda_combine_cloud_handler.hpp"
 
 #include "autoware/cuda_pointcloud_preprocessor/cuda_concatenate_data/cuda_combine_cloud_handler_kernel.hpp"
@@ -282,4 +281,3 @@ CombineCloudHandler<CudaPointCloud2Traits>::combine_pointclouds(
 
 template class autoware::pointcloud_preprocessor::CombineCloudHandler<
   autoware::pointcloud_preprocessor::CudaPointCloud2Traits>;
-/* *INDENT-ON* */

--- a/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_concatenate_data/cuda_concatenate_and_time_sync_node.cpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_concatenate_data/cuda_concatenate_and_time_sync_node.cpp
@@ -12,9 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/* *INDENT-OFF* */
 #include "autoware/cuda_pointcloud_preprocessor/cuda_concatenate_data/cuda_concatenate_and_time_sync_node.hpp"
-/* *INDENT-ON* */
 
 #include "autoware/cuda_pointcloud_preprocessor/cuda_concatenate_data/cuda_cloud_collector.hpp"
 #include "autoware/cuda_pointcloud_preprocessor/cuda_concatenate_data/cuda_traits.hpp"
@@ -28,7 +26,6 @@
 namespace autoware::pointcloud_preprocessor
 {
 
-/* *INDENT-OFF* */
 template <>
 void PointCloudConcatenateDataSynchronizerComponentTemplated<
   CudaPointCloud2Traits>::initialize_pub_sub()
@@ -65,7 +62,6 @@ void PointCloudConcatenateDataSynchronizerComponentTemplated<
     RCLCPP_DEBUG_STREAM(get_logger(), " - " << input_topic);
   }
 }
-/* *INDENT-ON* */
 
 }  // namespace autoware::pointcloud_preprocessor
 

--- a/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_downsample_filter/cuda_voxel_grid_downsample_filter_node.cpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_downsample_filter/cuda_voxel_grid_downsample_filter_node.cpp
@@ -12,9 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/* *INDENT-OFF* */
 #include "autoware/cuda_pointcloud_preprocessor/cuda_downsample_filter/cuda_voxel_grid_downsample_filter_node.hpp"
-/* *INDENT-ON* */
 
 #include "autoware/pointcloud_preprocessor/utility/memory.hpp"
 
@@ -37,7 +35,6 @@ CudaVoxelGridDownsampleFilterNode::CudaVoxelGridDownsampleFilterNode(
     return;
   }
 
-  /* *INDENT-OFF* */
   sub_ =
     std::make_shared<cuda_blackboard::CudaBlackboardSubscriber<cuda_blackboard::CudaPointCloud2>>(
       *this, "~/input/pointcloud",
@@ -47,7 +44,6 @@ CudaVoxelGridDownsampleFilterNode::CudaVoxelGridDownsampleFilterNode(
   pub_ =
     std::make_unique<cuda_blackboard::CudaBlackboardPublisher<cuda_blackboard::CudaPointCloud2>>(
       *this, "~/output/pointcloud");
-  /* *INDENT-ON* */
 
   cuda_voxel_grid_downsample_filter_ = std::make_unique<CudaVoxelGridDownsampleFilter>(
     voxel_size_x, voxel_size_y, voxel_size_z, max_mem_pool_size_in_byte);

--- a/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_pointcloud_preprocessor/common_kernels.cu
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_pointcloud_preprocessor/common_kernels.cu
@@ -37,7 +37,8 @@ __global__ void transformPointsKernel(
 }
 
 __global__ void cropBoxKernel(
-  InputPointType * __restrict__ d_points, std::uint32_t * __restrict__ output_mask, int num_points,
+  InputPointType * __restrict__ d_points, std::uint32_t * __restrict__ output_mask,
+  std::uint8_t * __restrict__ nan_mask, int num_points,
   const CropBoxParameters * __restrict__ crop_box_parameters_ptr, int num_crop_boxes)
 {
   for (int idx = blockIdx.x * blockDim.x + threadIdx.x; idx < num_points;
@@ -49,7 +50,12 @@ __global__ void cropBoxKernel(
     const float y = d_points[idx].y;
     const float z = d_points[idx].z;
 
-    std::uint32_t mask = 1;
+    if (!isfinite(x) || !isfinite(y) || !isfinite(z)) {
+      nan_mask[idx] = 1;
+      continue;
+    }
+
+    std::uint32_t passed_crop_box_mask = 1;
 
     for (int i = 0; i < num_crop_boxes; i++) {
       const CropBoxParameters & crop_box_parameters = crop_box_parameters_ptr[i];
@@ -59,11 +65,11 @@ __global__ void cropBoxKernel(
       const float & max_x = crop_box_parameters.max_x;
       const float & max_y = crop_box_parameters.max_y;
       const float & max_z = crop_box_parameters.max_z;
-      mask &=
+      passed_crop_box_mask &=
         (x <= min_x || x >= max_x) || (y <= min_y || y >= max_y) || (z <= min_z || z >= max_z);
     }
 
-    output_mask[idx] = mask;
+    output_mask[idx] = passed_crop_box_mask;
   }
 }
 
@@ -104,12 +110,12 @@ void transformPointsLaunch(
 }
 
 void cropBoxLaunch(
-  InputPointType * d_points, std::uint32_t * output_mask, int num_points,
+  InputPointType * d_points, std::uint32_t * output_mask, std::uint8_t * nan_mask, int num_points,
   const CropBoxParameters * crop_box_parameters_ptr, int num_crop_boxes, int threads_per_block,
   int blocks_per_grid, cudaStream_t & stream)
 {
   cropBoxKernel<<<blocks_per_grid, threads_per_block, 0, stream>>>(
-    d_points, output_mask, num_points, crop_box_parameters_ptr, num_crop_boxes);
+    d_points, output_mask, nan_mask, num_points, crop_box_parameters_ptr, num_crop_boxes);
 }
 
 void combineMasksLaunch(

--- a/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_pointcloud_preprocessor/common_kernels.cu
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_pointcloud_preprocessor/common_kernels.cu
@@ -110,12 +110,13 @@ void transformPointsLaunch(
 }
 
 void cropBoxLaunch(
-  InputPointType * d_points, std::uint32_t * output_mask, std::uint8_t * nan_mask, int num_points,
-  const CropBoxParameters * crop_box_parameters_ptr, int num_crop_boxes, int threads_per_block,
-  int blocks_per_grid, cudaStream_t & stream)
+  InputPointType * d_points, std::uint32_t * output_crop_mask, std::uint8_t * output_nan_mask,
+  int num_points, const CropBoxParameters * crop_box_parameters_ptr, int num_crop_boxes,
+  int threads_per_block, int blocks_per_grid, cudaStream_t & stream)
 {
   cropBoxKernel<<<blocks_per_grid, threads_per_block, 0, stream>>>(
-    d_points, output_mask, nan_mask, num_points, crop_box_parameters_ptr, num_crop_boxes);
+    d_points, output_crop_mask, output_nan_mask, num_points, crop_box_parameters_ptr,
+    num_crop_boxes);
 }
 
 void combineMasksLaunch(

--- a/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_pointcloud_preprocessor/common_kernels.cu
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_pointcloud_preprocessor/common_kernels.cu
@@ -37,8 +37,8 @@ __global__ void transformPointsKernel(
 }
 
 __global__ void cropBoxKernel(
-  InputPointType * __restrict__ d_points, std::uint32_t * __restrict__ output_mask,
-  std::uint8_t * __restrict__ nan_mask, int num_points,
+  InputPointType * __restrict__ d_points, std::uint32_t * __restrict__ output_crop_mask,
+  std::uint8_t * __restrict__ output_nan_mask, int num_points,
   const CropBoxParameters * __restrict__ crop_box_parameters_ptr, int num_crop_boxes)
 {
   for (int idx = blockIdx.x * blockDim.x + threadIdx.x; idx < num_points;
@@ -51,7 +51,7 @@ __global__ void cropBoxKernel(
     const float z = d_points[idx].z;
 
     if (!isfinite(x) || !isfinite(y) || !isfinite(z)) {
-      nan_mask[idx] = 1;
+      output_nan_mask[idx] = 1;
       continue;
     }
 
@@ -69,7 +69,7 @@ __global__ void cropBoxKernel(
         (x <= min_x || x >= max_x) || (y <= min_y || y >= max_y) || (z <= min_z || z >= max_z);
     }
 
-    output_mask[idx] = passed_crop_box_mask;
+    output_crop_mask[idx] = passed_crop_box_mask;
   }
 }
 

--- a/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor.cu
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor.cu
@@ -499,9 +499,9 @@ std::unique_ptr<cuda_blackboard::CudaPointCloud2> CudaPointcloudPreprocessor::pr
   std::uint32_t mismatch_count = thrust::count(
     thrust::device, device_mismatch_mask, device_mismatch_mask + num_organized_points_, 1);
 
-  this->num_nan_points_ = num_nan_points;
-  this->num_crop_box_passed_points_ = num_crop_box_passed_points;
-  this->mismatch_count_ = mismatch_count;
+  stats_.num_nan_points = static_cast<int>(num_nan_points);
+  stats_.num_crop_box_passed_points = static_cast<int>(num_crop_box_passed_points);
+  stats_.mismatch_count = static_cast<int>(mismatch_count);
 
   if (num_output_points > 0) {
     extractPointsLaunch(

--- a/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor.cu
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor.cu
@@ -27,6 +27,7 @@
 
 #include <cuda_runtime.h>
 #include <tf2/utils.h>
+#include <thrust/count.h>
 #include <thrust/execution_policy.h>
 #include <thrust/reduce.h>
 #include <thrust/scan.h>
@@ -256,6 +257,8 @@ void CudaPointcloudPreprocessor::organizePointcloud()
       device_transformed_points_.begin(), device_transformed_points_.end(), InputPointType{});
     device_crop_mask_.resize(num_organized_points_);
     thrust::fill(device_crop_mask_.begin(), device_crop_mask_.end(), 0);
+    device_mismatch_mask_.resize(num_organized_points_);
+    thrust::fill(device_mismatch_mask_.begin(), device_mismatch_mask_.end(), 0);
     device_ring_outlier_mask_.resize(num_organized_points_);
     thrust::fill(device_ring_outlier_mask_.begin(), device_ring_outlier_mask_.end(), 0);
     device_indices_.resize(num_organized_points_);
@@ -369,6 +372,7 @@ std::unique_ptr<cuda_blackboard::CudaPointCloud2> CudaPointcloudPreprocessor::pr
   thrust::fill(
     device_transformed_points_.begin(), device_transformed_points_.end(), InputPointType{});
   thrust::fill(device_ring_outlier_mask_.begin(), device_ring_outlier_mask_.end(), 0);
+  thrust::fill(device_mismatch_mask_.begin(), device_mismatch_mask_.end(), 0);
   thrust::fill(device_crop_mask_.begin(), device_crop_mask_.end(), 0);
 
   tf2::Quaternion rotation_quaternion(
@@ -415,6 +419,7 @@ std::unique_ptr<cuda_blackboard::CudaPointCloud2> CudaPointcloudPreprocessor::pr
   InputPointType * device_transformed_points =
     thrust::raw_pointer_cast(device_transformed_points_.data());
   std::uint32_t * device_crop_mask = thrust::raw_pointer_cast(device_crop_mask_.data());
+  std::uint8_t * device_mismatch_mask = thrust::raw_pointer_cast(device_mismatch_mask_.data());
   std::uint32_t * device_ring_outlier_mask =
     thrust::raw_pointer_cast(device_ring_outlier_mask_.data());
   std::uint32_t * device_indices = thrust::raw_pointer_cast(device_indices_.data());
@@ -438,20 +443,17 @@ std::unique_ptr<cuda_blackboard::CudaPointCloud2> CudaPointcloudPreprocessor::pr
   }
 
   // Undistortion
-  int * d_mismatch_count;
-  cudaMalloc(&d_mismatch_count, sizeof(int));
-  cudaMemsetAsync(d_mismatch_count, 0, sizeof(int), stream_);
   if (
     undistortion_type_ == UndistortionType::Undistortion3D && device_twist_3d_structs_.size() > 0) {
     undistort3DLaunch(
       device_transformed_points, num_organized_points_, device_twist_3d_structs,
-      device_twist_3d_structs_.size(), d_mismatch_count, threads_per_block_, blocks_per_grid,
+      device_twist_3d_structs_.size(), device_mismatch_mask, threads_per_block_, blocks_per_grid,
       stream_);
   } else if (
     undistortion_type_ == UndistortionType::Undistortion2D && device_twist_2d_structs_.size() > 0) {
     undistort2DLaunch(
       device_transformed_points, num_organized_points_, device_twist_2d_structs,
-      device_twist_2d_structs_.size(), d_mismatch_count, threads_per_block_, blocks_per_grid,
+      device_twist_2d_structs_.size(), device_mismatch_mask, threads_per_block_, blocks_per_grid,
       stream_);
   }
 
@@ -480,7 +482,13 @@ std::unique_ptr<cuda_blackboard::CudaPointCloud2> CudaPointcloudPreprocessor::pr
   cudaMemcpyAsync(
     &num_output_points, device_indices + num_organized_points_ - 1, sizeof(std::uint32_t),
     cudaMemcpyDeviceToHost, stream_);
+
   cudaStreamSynchronize(stream_);
+
+  std::uint32_t mismatch_count_host = thrust::count(
+    thrust::device, device_mismatch_mask, device_mismatch_mask + num_organized_points_, 1);
+
+  this->latest_mismatch_count_ = mismatch_count_host;
 
   if (num_output_points > 0) {
     extractPointsLaunch(
@@ -490,12 +498,6 @@ std::unique_ptr<cuda_blackboard::CudaPointCloud2> CudaPointcloudPreprocessor::pr
   }
 
   cudaStreamSynchronize(stream_);
-
-  int mismatch_count_host = 0;
-  cudaMemcpy(&mismatch_count_host, d_mismatch_count, sizeof(int), cudaMemcpyDeviceToHost);
-  cudaFree(d_mismatch_count);
-
-  this->latest_mismatch_count_ = mismatch_count_host;
 
   // Copy the transformed points back
   output_pointcloud_ptr_->row_step = num_output_points * sizeof(OutputPointType);

--- a/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor.cu
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor.cu
@@ -491,13 +491,13 @@ std::unique_ptr<cuda_blackboard::CudaPointCloud2> CudaPointcloudPreprocessor::pr
 
   // Get information and extract points after filters
   std::uint32_t num_crop_box_passed_points =
-    thrust::count(thrust::device, device_crop_mask, device_crop_mask + num_organized_points_, 1);
+    thrust::count(thrust::device, device_crop_mask_.begin(), device_crop_mask_.end(), 1);
 
   std::uint32_t num_nan_points =
-    thrust::count(thrust::device, device_nan_mask, device_nan_mask + num_organized_points_, 1);
+    thrust::count(thrust::device, device_nan_mask_.begin(), device_nan_mask_.end(), 1);
 
-  std::uint32_t mismatch_count = thrust::count(
-    thrust::device, device_mismatch_mask, device_mismatch_mask + num_organized_points_, 1);
+  std::uint32_t mismatch_count =
+    thrust::count(thrust::device, device_mismatch_mask_.begin(), device_mismatch_mask_.end(), 1);
 
   stats_.num_nan_points = static_cast<int>(num_nan_points);
   stats_.num_crop_box_passed_points = static_cast<int>(num_crop_box_passed_points);

--- a/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor_node.cpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor_node.cpp
@@ -267,11 +267,11 @@ void CudaPointcloudPreprocessorNode::pointcloudCallback(
   const auto transform_msg_opt = lookupTransformToBase(input_pointcloud_msg.header.frame_id);
   if (!transform_msg_opt.has_value()) return;
 
-  auto output_pointcloud = processPointcloud(input_pointcloud_msg, *transform_msg_opt);
-  output_pointcloud->header.frame_id = base_frame_;
+  auto output_pointcloud_ptr = processPointcloud(input_pointcloud_msg, *transform_msg_opt);
+  output_pointcloud_ptr->header.frame_id = base_frame_;
 
-  publishDiagnostics(input_pointcloud_msg, output_pointcloud);
-  pub_->publish(std::move(output_pointcloud));
+  publishDiagnostics(input_pointcloud_msg, output_pointcloud_ptr);
+  pub_->publish(std::move(output_pointcloud_ptr));
 
   cuda_pointcloud_preprocessor_->preallocateOutput();
 }

--- a/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor_node.cpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor_node.cpp
@@ -16,6 +16,11 @@
 
 #include "autoware/cuda_pointcloud_preprocessor/memory.hpp"
 #include "autoware/cuda_pointcloud_preprocessor/point_types.hpp"
+#include "autoware/pointcloud_preprocessor/diagnostics/crop_box_diagnostics.hpp"
+#include "autoware/pointcloud_preprocessor/diagnostics/distortion_corrector_diagnostics.hpp"
+#include "autoware/pointcloud_preprocessor/diagnostics/latency_diagnostics.hpp"
+#include "autoware/pointcloud_preprocessor/diagnostics/pass_rate_diagnostics.hpp"
+#include "autoware/pointcloud_preprocessor/distortion_corrector/distortion_corrector.hpp"
 
 #include <autoware/point_types/types.hpp>
 
@@ -99,6 +104,9 @@ CudaPointcloudPreprocessorNode::CudaPointcloudPreprocessorNode(
   pub_ =
     std::make_unique<cuda_blackboard::CudaBlackboardPublisher<cuda_blackboard::CudaPointCloud2>>(
       *this, "~/output/pointcloud");
+  diagnostics_interface_ =
+    std::make_unique<autoware_utils::DiagnosticsInterface>(this, this->get_fully_qualified_name());
+
   /* *INDENT-ON* */
 
   // Subscriber
@@ -306,6 +314,58 @@ void CudaPointcloudPreprocessorNode::pointcloudCallback(
     input_pointcloud_msg_ptr, transform_msg, twist_queue_, angular_velocity_queue_,
     first_point_rel_stamp);
   output_pointcloud_ptr->header.frame_id = base_frame_;
+
+  const double processing_time_ms = stop_watch_ptr_->toc("processing_time", true);
+
+  const double pipeline_latency_ms =
+    std::chrono::duration<double, std::milli>(
+      std::chrono::nanoseconds(
+        (this->get_clock()->now() - input_pointcloud_msg_ptr->header.stamp).nanoseconds()))
+      .count();
+
+  const int input_point_count =
+    static_cast<int>(input_pointcloud_msg_ptr->width * input_pointcloud_msg_ptr->height);
+  // const int output_point_count =
+  //   static_cast<int>(output_pointcloud_ptr->width * output_pointcloud_ptr->height);
+  const int output_point_count = static_cast<int>(50000);
+
+  const int skipped_nan_count = 0;
+
+  auto processing_time_threshold_ms_ = 0.05;
+
+  auto latency_diag = std::make_shared<autoware::pointcloud_preprocessor::LatencyDiagnostics>(
+    input_pointcloud_msg_ptr->header.stamp, processing_time_ms, pipeline_latency_ms,
+    processing_time_threshold_ms_);
+
+  auto pass_rate_diag = std::make_shared<autoware::pointcloud_preprocessor::PassRateDiagnostics>(
+    input_point_count, output_point_count);
+
+  auto crop_box_diag =
+    std::make_shared<autoware::pointcloud_preprocessor::CropBoxDiagnostics>(skipped_nan_count);
+
+  diagnostics_interface_->clear();
+
+  std::vector<std::shared_ptr<const autoware::pointcloud_preprocessor::DiagnosticsBase>>
+    diagnostics = {latency_diag, pass_rate_diag, crop_box_diag};
+
+  int worst_level = diagnostic_msgs::msg::DiagnosticStatus::OK;
+  std::string message;
+
+  for (const auto & diag : diagnostics) {
+    diag->add_to_interface(*diagnostics_interface_);
+    if (const auto status = diag->evaluate_status()) {
+      worst_level = std::max(worst_level, status->first);
+      if (!message.empty()) {
+        message += " / ";
+      }
+      message += status->second;
+    }
+  }
+  if (message.empty()) {
+    message = "CudaPointcloudPreprocessor operating normally";
+  }
+  diagnostics_interface_->update_level_and_message(static_cast<int8_t>(worst_level), message);
+  diagnostics_interface_->publish(this->get_clock()->now());
 
   // Publish
   pub_->publish(std::move(output_pointcloud_ptr));

--- a/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor_node.cpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor_node.cpp
@@ -292,6 +292,18 @@ void CudaPointcloudPreprocessorNode::validatePointcloudLayout(
     "PointStruct and PointXYZIRCAEDT must have the same size");
 }
 
+/**
+ * @brief Get the first point's timestamp information from a PointCloud2 message.
+ *
+ * This function extracts the relative timestamp (`time_stamp` field) of the first point in the
+ * point cloud and calculates its absolute timestamp by adding it to the message's header timestamp.
+ *
+ * @param input_pointcloud_msg The input PointCloud2 message, which must include a "time_stamp"
+ * field.
+ * @return std::pair<double, std::uint32_t>
+ *   - first: The absolute timestamp of the first point (in seconds).
+ *   - second: The relative timestamp of the first point (in nanoseconds).
+ */
 std::pair<double, std::uint32_t> CudaPointcloudPreprocessorNode::getFirstPointTimeInfo(
   const sensor_msgs::msg::PointCloud2 & input_pointcloud_msg)
 {

--- a/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor_node.cpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor_node.cpp
@@ -365,7 +365,7 @@ void CudaPointcloudPreprocessorNode::publishDiagnostics(
       .count();
 
   const auto input_point_count =
-    static_cast<int>(input_pointcloud_msg_ptr->width * input_pointcloud_msg_ptr->height);
+    static_cast<int>(input_pointcloud_msg.width * input_pointcloud_msg.height);
   const auto output_point_count =
     static_cast<int>(output_pointcloud_ptr->width * output_pointcloud_ptr->height);
   const auto stats = cuda_pointcloud_preprocessor_->getProcessingStats();

--- a/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor_node.cpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor_node.cpp
@@ -367,14 +367,15 @@ void CudaPointcloudPreprocessorNode::publishDiagnostics(
     static_cast<int>(input_pointcloud_msg_ptr->width * input_pointcloud_msg_ptr->height);
   const int output_point_count =
     static_cast<int>(output_pointcloud_ptr->width * output_pointcloud_ptr->height);
-  // TODO(vividf): fix this
-  const int skipped_nan_count = 0;
+  const int skipped_nan_count = cuda_pointcloud_preprocessor_->getNumNanPoints();
 
-  const int mismatch_count = cuda_pointcloud_preprocessor_->getLatestMismatchCount();
-  // TODO(vividf): use the number of points after cropbox instead of ring
-  const float mismatch_fraction = output_point_count > 0 ? static_cast<float>(mismatch_count) /
-                                                             static_cast<float>(output_point_count)
-                                                         : 0.0f;
+  const int mismatch_count = cuda_pointcloud_preprocessor_->getMismatchCount();
+  const int num_undistorted_points = cuda_pointcloud_preprocessor_->getCropBoxPassedPoints();
+
+  const float mismatch_fraction =
+    output_point_count > 0
+      ? static_cast<float>(mismatch_count) / static_cast<float>(num_undistorted_points)
+      : 0.0f;
 
   auto latency_diag = std::make_shared<autoware::pointcloud_preprocessor::LatencyDiagnostics>(
     input_pointcloud_msg_ptr->header.stamp, processing_time_ms, pipeline_latency_ms,

--- a/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor_node.cpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor_node.cpp
@@ -344,12 +344,12 @@ std::unique_ptr<cuda_blackboard::CudaPointCloud2> CudaPointcloudPreprocessorNode
 {
   sensor_msgs::PointCloud2ConstIterator<std::uint32_t> iter_stamp(
     *input_pointcloud_msg_ptr, "time_stamp");
-  std::uint32_t first_rel_stamp =
+  std::uint32_t first_point_rel_stamp =
     input_pointcloud_msg_ptr->width * input_pointcloud_msg_ptr->height > 0 ? *iter_stamp : 0;
 
   return cuda_pointcloud_preprocessor_->process(
     input_pointcloud_msg_ptr, transform_msg, twist_queue_, angular_velocity_queue_,
-    first_rel_stamp);
+    first_point_rel_stamp);
 }
 
 void CudaPointcloudPreprocessorNode::publishDiagnostics(
@@ -400,7 +400,7 @@ void CudaPointcloudPreprocessorNode::publishDiagnostics(
 
   for (const auto & diag : diagnostics) {
     diag->add_to_interface(*diagnostics_interface_);
-    if (const auto status = diag->evaluate_status()) {
+    if (const auto status = diag->evaluate_status(); status.has_value()) {
       worst_level = std::max(worst_level, status->first);
       if (!message.empty()) {
         message += " / ";

--- a/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor_node.cpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor_node.cpp
@@ -77,7 +77,6 @@ CudaPointcloudPreprocessorNode::CudaPointcloudPreprocessorNode(
   const auto crop_box_max_y_vector = declare_parameter<std::vector<double>>("crop_box.max_y");
   const auto crop_box_max_z_vector = declare_parameter<std::vector<double>>("crop_box.max_z");
 
-  /* *INDENT-OFF* */
   if (
     crop_box_min_x_vector.size() != crop_box_min_y_vector.size() ||
     crop_box_min_x_vector.size() != crop_box_min_z_vector.size() ||
@@ -86,7 +85,6 @@ CudaPointcloudPreprocessorNode::CudaPointcloudPreprocessorNode(
     crop_box_min_x_vector.size() != crop_box_max_z_vector.size()) {
     throw std::runtime_error("Crop box parameters must have the same size");
   }
-  /* *INDENT-ON* */
 
   std::vector<CropBoxParameters> crop_box_parameters;
 
@@ -102,14 +100,11 @@ CudaPointcloudPreprocessorNode::CudaPointcloudPreprocessorNode(
   }
 
   // Publisher
-  /* *INDENT-OFF* */
   pub_ =
     std::make_unique<cuda_blackboard::CudaBlackboardPublisher<cuda_blackboard::CudaPointCloud2>>(
       *this, "~/output/pointcloud");
   diagnostics_interface_ =
     std::make_unique<autoware_utils::DiagnosticsInterface>(this, this->get_fully_qualified_name());
-
-  /* *INDENT-ON* */
 
   // Subscriber
   rclcpp::SubscriptionOptions sub_options;
@@ -134,11 +129,9 @@ CudaPointcloudPreprocessorNode::CudaPointcloudPreprocessorNode(
       create_subscription(this, "~/input/imu", rclcpp::QoS(TWIST_QUEUE_SIZE));
   }
 
-  /* *INDENT-OFF* */
   CudaPointcloudPreprocessor::UndistortionType undistortion_type =
     use_3d_undistortion_ ? CudaPointcloudPreprocessor::UndistortionType::Undistortion3D
                          : CudaPointcloudPreprocessor::UndistortionType::Undistortion2D;
-  /* *INDENT-ON* */
 
   cuda_pointcloud_preprocessor_ = std::make_unique<CudaPointcloudPreprocessor>();
   cuda_pointcloud_preprocessor_->setRingOutlierFilterParameters(ring_outlier_filter_parameters);
@@ -214,11 +207,9 @@ void CudaPointcloudPreprocessorNode::imuCallback(
   const sensor_msgs::msg::Imu::ConstSharedPtr imu_msg)
 {
   while (!angular_velocity_queue_.empty()) {
-    /* *INDENT-OFF* */
     // for rosbag replay
     bool backwards_time_jump_detected = rclcpp::Time(angular_velocity_queue_.front().header.stamp) >
                                         rclcpp::Time(imu_msg->header.stamp);
-    /* *INDENT-ON* */
 
     bool is_queue_longer_than_1s =
       rclcpp::Time(angular_velocity_queue_.front().header.stamp) <

--- a/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor_node.cpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor_node.cpp
@@ -273,6 +273,8 @@ void CudaPointcloudPreprocessorNode::pointcloudCallback(
   publishDiagnostics(input_pointcloud_msg, output_pointcloud_ptr);
   pub_->publish(std::move(output_pointcloud_ptr));
 
+  // Preallocate buffer for the next run.
+  // This is intentionally done after publish() to avoid adding latency to the current cycle.
   cuda_pointcloud_preprocessor_->preallocateOutput();
 }
 

--- a/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor_node.cpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor_node.cpp
@@ -383,17 +383,11 @@ void CudaPointcloudPreprocessorNode::pointcloudCallback(
   // Publish
   pub_->publish(std::move(output_pointcloud_ptr));
 
-  if (debug_publisher_) {
-    const double processing_time_ms = stop_watch_ptr_->toc("processing_time", true);
-    debug_publisher_->publish<tier4_debug_msgs::msg::Float64Stamped>(
-      "debug/processing_time_ms", processing_time_ms);
-
-    double now_stamp_seconds = rclcpp::Time(this->get_clock()->now()).seconds();
-    double cloud_stamp_seconds = rclcpp::Time(input_pointcloud_msg_ptr->header.stamp).seconds();
-
-    debug_publisher_->publish<tier4_debug_msgs::msg::Float64Stamped>(
-      "debug/latency_ms", 1000.f * (now_stamp_seconds - cloud_stamp_seconds));
-  }
+  // Debug publisher
+  debug_publisher_->publish<tier4_debug_msgs::msg::Float64Stamped>(
+    "debug/processing_time_ms", processing_time_ms);
+  debug_publisher_->publish<tier4_debug_msgs::msg::Float64Stamped>(
+    "debug/latency_ms", pipeline_latency_ms);
 
   // Preallocate for next iteration
   cuda_pointcloud_preprocessor_->preallocateOutput();

--- a/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_pointcloud_preprocessor/undistort_kernels.cu
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_pointcloud_preprocessor/undistort_kernels.cu
@@ -146,18 +146,20 @@ __global__ void undistort3DKernel(
 
 void undistort2DLaunch(
   InputPointType * input_points, int num_points, TwistStruct2D * twist_structs, int num_twists,
-  std::uint8_t * mismatch_mask, int threads_per_block, int blocks_per_grid, cudaStream_t & stream)
+  std::uint8_t * output_mismatch_mask, int threads_per_block, int blocks_per_grid,
+  cudaStream_t & stream)
 {
   undistort2DKernel<<<blocks_per_grid, threads_per_block, 0, stream>>>(
-    input_points, num_points, twist_structs, num_twists, mismatch_mask);
+    input_points, num_points, twist_structs, num_twists, output_mismatch_mask);
 }
 
 void undistort3DLaunch(
   InputPointType * input_points, int num_points, TwistStruct3D * twist_structs, int num_twists,
-  std::uint8_t * mismatch_mask, int threads_per_block, int blocks_per_grid, cudaStream_t & stream)
+  std::uint8_t * output_mismatch_mask, int threads_per_block, int blocks_per_grid,
+  cudaStream_t & stream)
 {
   undistort3DKernel<<<blocks_per_grid, threads_per_block, 0, stream>>>(
-    input_points, num_points, twist_structs, num_twists, mismatch_mask);
+    input_points, num_points, twist_structs, num_twists, output_mismatch_mask);
 }
 
 void setupTwist2DStructs(

--- a/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_pointcloud_preprocessor/undistort_kernels.cu
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_pointcloud_preprocessor/undistort_kernels.cu
@@ -68,7 +68,7 @@ __host__ __device__ Eigen::Matrix4f transformationMatrixFromVelocity(
 
 __global__ void undistort2DKernel(
   InputPointType * input_points, int num_points, TwistStruct2D * twist_structs, int num_twists,
-  std::uint8_t * __restrict__ mismatch_mask)
+  std::uint8_t * __restrict__ output_mismatch_mask)
 {
   int idx = blockIdx.x * blockDim.x + threadIdx.x;
   if (idx < num_points) {
@@ -91,7 +91,7 @@ __global__ void undistort2DKernel(
       point.time_stamp > twist.last_stamp_nsec ? point.time_stamp - twist.last_stamp_nsec : 0;
     double dt = 1e-9 * (dt_nsec);
 
-    mismatch_mask[idx] = static_cast<std::uint8_t>(dt > time_diff_threshold);
+    output_mismatch_mask[idx] = static_cast<std::uint8_t>(dt > time_diff_threshold);
 
     theta += twist.v_theta * dt;
     float d = twist.v_x * dt;
@@ -108,7 +108,7 @@ __global__ void undistort2DKernel(
 
 __global__ void undistort3DKernel(
   InputPointType * input_points, int num_points, TwistStruct3D * twist_structs, int num_twists,
-  std::uint8_t * __restrict__ mismatch_mask)
+  std::uint8_t * __restrict__ output_mismatch_mask)
 {
   int idx = blockIdx.x * blockDim.x + threadIdx.x;
   if (idx < num_points) {
@@ -131,7 +131,7 @@ __global__ void undistort3DKernel(
       point.time_stamp > twist.last_stamp_nsec ? point.time_stamp - twist.last_stamp_nsec : 0;
     double dt = 1e-9 * (dt_nsec);
 
-    mismatch_mask[idx] = static_cast<std::uint8_t>(dt > time_diff_threshold);
+    output_mismatch_mask[idx] = static_cast<std::uint8_t>(dt > time_diff_threshold);
 
     Eigen::Matrix4f transform =
       cum_transform_buffer_map * transformationMatrixFromVelocity(v_map, w_map, dt);

--- a/sensing/autoware_pointcloud_preprocessor/src/concatenate_data/combine_cloud_handler.cpp
+++ b/sensing/autoware_pointcloud_preprocessor/src/concatenate_data/combine_cloud_handler.cpp
@@ -126,6 +126,8 @@ CombineCloudHandler<PointCloud2Traits>::combine_pointclouds(
 
   for (const auto & [topic, cloud] : topic_to_cloud_map) {
     pc_stamps.emplace_back(cloud->header.stamp);
+    concatenate_cloud_result.topic_to_original_stamp_map[topic] =
+      rclcpp::Time(cloud->header.stamp).seconds();
   }
   std::sort(pc_stamps.begin(), pc_stamps.end(), std::greater<rclcpp::Time>());
   const auto oldest_stamp = pc_stamps.back();
@@ -165,9 +167,6 @@ CombineCloudHandler<PointCloud2Traits>::combine_pointclouds(
     managed_tf_buffer_->transformPointcloud(
       output_frame_, *xyzirc_cloud, *transformed_cloud_ptr, xyzirc_cloud->header.stamp,
       rclcpp::Duration::from_seconds(1.0), node_.get_logger());
-
-    concatenate_cloud_result.topic_to_original_stamp_map[topic] =
-      rclcpp::Time(cloud->header.stamp).seconds();
 
     // compensate pointcloud
     std::unique_ptr<sensor_msgs::msg::PointCloud2> transformed_delay_compensated_cloud_ptr;


### PR DESCRIPTION
## Description
Diagnostics for the CUDA pointcloud preprocessor and the CUDA concatenate node.


## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
![Screenshot from 2025-06-10 22-06-23](https://github.com/user-attachments/assets/d0ee8a74-f737-4a9c-b268-fadd1b3cc788)



## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
