### PR TITLE
fix(run_out): fix  numerical stability in run_out interpolation

### DIFF
--- a/planning/motion_velocity_planner/autoware_motion_velocity_run_out_module/src/slowdown.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_run_out_module/src/slowdown.cpp
@@ -46,7 +46,7 @@ geometry_msgs::msg::Point interpolated_point_at_time(
   }
   const auto next_time = rclcpp::Duration(std::next(prev_it)->time_from_start).seconds();
   if (next_time == prev_time) {
-    return next_time->pose.position;
+    return std::next(prev_it)->pose.position;
   }
   const auto t_delta = next_time - prev_time;
   const auto t_diff = time - prev_time;


### PR DESCRIPTION
## Description

If the `time_from_start` is not increasing, we return the point earlier.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
