### PR TITLE
fix(pid): fix a bug that acceleration feedback does not go in the correct direction when reverse

### DIFF
--- a/control/autoware_pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
+++ b/control/autoware_pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
@@ -864,8 +864,8 @@ PidLongitudinalController::Motion PidLongitudinalController::calcCtrlCmd(
 
     // calc acc feedback
     const double vel_sign = (control_data.shift == Shift::Forward)
-                            ? 1.0
-                            : (control_data.shift == Shift::Reverse ? -1.0 : 0.0);
+                              ? 1.0
+                              : (control_data.shift == Shift::Reverse ? -1.0 : 0.0);
     const double acc_err = control_data.current_motion.acc * vel_sign - raw_ctrl_cmd.acc;
     m_debug_values.setValues(DebugValues::TYPE::ERROR_ACC, acc_err);
     m_lpf_acc_error->filter(acc_err);


### PR DESCRIPTION
## Description

When the vehicle is reversing, the PID controller does not correctly handle the acceleration feedback.

`control_data.current_motion.acc = m_current_accel.accel.accel.linear.x;` directly comes from localization topics. So it will be minus, when we are accelerating in reverse mode.


`raw_ctrl_cmd.acc` comes from `applyVelocityFeedback`, where we have moderated the driving direction.  It will be plus when we are accelerating in reverse mode.

The computation of `acc_err` should revert the current acceleration when we are reversing.

## Related links

**Parent Issue:**

- Link

**Private Links:**

- [CompanyName internal link](https://tier4.atlassian.net/browse/RT0-37856)


## How was this PR tested?

Tested in  PSim.

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
