### PR TITLE
feat!: replace tier4_planning_msgs service with autoware_planning_msgs

### DIFF
--- a/build_depends_humble.repos
+++ b/build_depends_humble.repos
@@ -3,7 +3,7 @@ repositories:
   core/autoware_msgs:
     type: git
     url: https://github.com/autowarefoundation/autoware_msgs.git
-    version: 1.8.0
+    version: 1.9.0
   # TODO (isamu-takagi): Use a released version when autoware_universe uses a released version.
   core/autoware_adapi_msgs:
     type: git

--- a/common/autoware_component_interface_specs_universe/include/autoware/component_interface_specs_universe/planning.hpp
+++ b/common/autoware_component_interface_specs_universe/include/autoware/component_interface_specs_universe/planning.hpp
@@ -18,38 +18,38 @@
 #include <rclcpp/qos.hpp>
 
 #include <autoware_planning_msgs/msg/lanelet_route.hpp>
+#include <autoware_planning_msgs/msg/route_state.hpp>
 #include <autoware_planning_msgs/msg/trajectory.hpp>
-#include <tier4_planning_msgs/msg/route_state.hpp>
-#include <tier4_planning_msgs/srv/clear_route.hpp>
-#include <tier4_planning_msgs/srv/set_lanelet_route.hpp>
-#include <tier4_planning_msgs/srv/set_waypoint_route.hpp>
+#include <autoware_planning_msgs/srv/clear_route.hpp>
+#include <autoware_planning_msgs/srv/set_lanelet_route.hpp>
+#include <autoware_planning_msgs/srv/set_waypoint_route.hpp>
 
 namespace autoware::component_interface_specs_universe::planning
 {
 
 struct SetLaneletRoute
 {
-  using Service = tier4_planning_msgs::srv::SetLaneletRoute;
-  static constexpr char name[] = "/planning/mission_planning/route_selector/main/set_lanelet_route";
+  using Service = autoware_planning_msgs::srv::SetLaneletRoute;
+  static constexpr char name[] = "/planning/set_lanelet_route";
 };
 
 struct SetWaypointRoute
 {
-  using Service = tier4_planning_msgs::srv::SetWaypointRoute;
+  using Service = autoware_planning_msgs::srv::SetWaypointRoute;
   static constexpr char name[] =
-    "/planning/mission_planning/route_selector/main/set_waypoint_route";
+    "/planning/set_waypoint_route";
 };
 
 struct ClearRoute
 {
-  using Service = tier4_planning_msgs::srv::ClearRoute;
-  static constexpr char name[] = "/planning/mission_planning/route_selector/main/clear_route";
+  using Service = autoware_planning_msgs::srv::ClearRoute;
+  static constexpr char name[] = "/planning/clear_route";
 };
 
 struct RouteState
 {
-  using Message = tier4_planning_msgs::msg::RouteState;
-  static constexpr char name[] = "/planning/mission_planning/route_selector/main/state";
+  using Message = autoware_planning_msgs::msg::RouteState;
+  static constexpr char name[] = "/planning/route_state";
   static constexpr size_t depth = 1;
   static constexpr auto reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
   static constexpr auto durability = RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL;
@@ -58,7 +58,7 @@ struct RouteState
 struct LaneletRoute
 {
   using Message = autoware_planning_msgs::msg::LaneletRoute;
-  static constexpr char name[] = "/planning/mission_planning/route_selector/main/route";
+  static constexpr char name[] = "/planning/route";
   static constexpr size_t depth = 1;
   static constexpr auto reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
   static constexpr auto durability = RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL;

--- a/common/autoware_component_interface_specs_universe/include/autoware/component_interface_specs_universe/planning.hpp
+++ b/common/autoware_component_interface_specs_universe/include/autoware/component_interface_specs_universe/planning.hpp
@@ -36,8 +36,7 @@ struct SetLaneletRoute
 struct SetWaypointRoute
 {
   using Service = autoware_planning_msgs::srv::SetWaypointRoute;
-  static constexpr char name[] =
-    "/planning/set_waypoint_route";
+  static constexpr char name[] = "/planning/set_waypoint_route";
 };
 
 struct ClearRoute

--- a/planning/autoware_mission_planner_universe/launch/mission_planner.launch.xml
+++ b/planning/autoware_mission_planner_universe/launch/mission_planner.launch.xml
@@ -1,6 +1,11 @@
 <launch>
   <arg name="modified_goal_topic_name" default="/planning/scenario_planning/modified_goal"/>
   <arg name="map_topic_name" default="/map/vector_map"/>
+  <arg name="route_topic_name" default="/planning/route"/>
+  <arg name="route_state_topic_name" default="/planning/route_state"/>
+  <arg name="clear_route_service_name" default="/planning/clear_route"/>
+  <arg name="set_lanelet_route_service_name" default="/planning/set_lanelet_route"/>
+  <arg name="set_waypoint_route_service_name" default="/planning/set_waypoint_route"/>
   <arg name="visualization_topic_name" default="/planning/mission_planning/route_marker"/>
   <arg name="mission_planner_param_path" default="$(find-pkg-share autoware_mission_planner_universe)/config/mission_planner.param.yaml"/>
 
@@ -22,6 +27,12 @@
       <remap from="~/planner/set_waypoint_route" to="mission_planner/set_waypoint_route"/>
       <remap from="~/planner/route" to="route"/>
       <remap from="~/planner/state" to="state"/>
+      <!-- Main route interface -->
+      <remap from="~/main/clear_route" to="$(var clear_route_service_name)"/>
+      <remap from="~/main/set_lanelet_route" to="$(var set_lanelet_route_service_name)"/>
+      <remap from="~/main/set_waypoint_route" to="$(var set_waypoint_route_service_name)"/>
+      <remap from="~/main/route" to="$(var route_topic_name)"/>
+      <remap from="~/main/state" to="$(var route_state_topic_name)"/>
     </composable_node>
     <composable_node pkg="autoware_glog_component" plugin="autoware::glog_component::GlogComponent" name="glog_component" namespace=""/>
   </node_container>

--- a/planning/autoware_mission_planner_universe/src/mission_planner/mission_planner.hpp
+++ b/planning/autoware_mission_planner_universe/src/mission_planner/mission_planner.hpp
@@ -30,12 +30,12 @@
 #include <autoware_adapi_v1_msgs/srv/set_route_points.hpp>
 #include <autoware_internal_debug_msgs/msg/float64_stamped.hpp>
 #include <autoware_planning_msgs/msg/lanelet_route.hpp>
+#include <autoware_planning_msgs/msg/route_state.hpp>
+#include <autoware_planning_msgs/srv/clear_route.hpp>
+#include <autoware_planning_msgs/srv/set_lanelet_route.hpp>
+#include <autoware_planning_msgs/srv/set_waypoint_route.hpp>
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <tier4_planning_msgs/msg/reroute_availability.hpp>
-#include <tier4_planning_msgs/msg/route_state.hpp>
-#include <tier4_planning_msgs/srv/clear_route.hpp>
-#include <tier4_planning_msgs/srv/set_lanelet_route.hpp>
-#include <tier4_planning_msgs/srv/set_waypoint_route.hpp>
 #include <visualization_msgs/msg/marker_array.hpp>
 
 #include <tf2_ros/buffer.h>
@@ -54,15 +54,15 @@ using autoware_planning_msgs::msg::LaneletPrimitive;
 using autoware_planning_msgs::msg::LaneletRoute;
 using autoware_planning_msgs::msg::LaneletSegment;
 using autoware_planning_msgs::msg::PoseWithUuidStamped;
+using autoware_planning_msgs::msg::RouteState;
+using autoware_planning_msgs::srv::ClearRoute;
+using autoware_planning_msgs::srv::SetLaneletRoute;
+using autoware_planning_msgs::srv::SetWaypointRoute;
 using geometry_msgs::msg::Pose;
 using geometry_msgs::msg::PoseStamped;
 using nav_msgs::msg::Odometry;
 using std_msgs::msg::Header;
 using tier4_planning_msgs::msg::RerouteAvailability;
-using tier4_planning_msgs::msg::RouteState;
-using tier4_planning_msgs::srv::ClearRoute;
-using tier4_planning_msgs::srv::SetLaneletRoute;
-using tier4_planning_msgs::srv::SetWaypointRoute;
 using unique_identifier_msgs::msg::UUID;
 using visualization_msgs::msg::MarkerArray;
 

--- a/planning/autoware_mission_planner_universe/src/mission_planner/route_selector.hpp
+++ b/planning/autoware_mission_planner_universe/src/mission_planner/route_selector.hpp
@@ -20,10 +20,10 @@
 
 #include <autoware_internal_debug_msgs/msg/float64_stamped.hpp>
 #include <autoware_planning_msgs/msg/lanelet_route.hpp>
-#include <tier4_planning_msgs/msg/route_state.hpp>
-#include <tier4_planning_msgs/srv/clear_route.hpp>
-#include <tier4_planning_msgs/srv/set_lanelet_route.hpp>
-#include <tier4_planning_msgs/srv/set_waypoint_route.hpp>
+#include <autoware_planning_msgs/msg/route_state.hpp>
+#include <autoware_planning_msgs/srv/clear_route.hpp>
+#include <autoware_planning_msgs/srv/set_lanelet_route.hpp>
+#include <autoware_planning_msgs/srv/set_waypoint_route.hpp>
 
 #include <optional>
 #include <variant>
@@ -33,10 +33,10 @@ namespace autoware::mission_planner_universe
 
 using autoware_common_msgs::msg::ResponseStatus;
 using autoware_planning_msgs::msg::LaneletRoute;
-using tier4_planning_msgs::msg::RouteState;
-using tier4_planning_msgs::srv::ClearRoute;
-using tier4_planning_msgs::srv::SetLaneletRoute;
-using tier4_planning_msgs::srv::SetWaypointRoute;
+using autoware_planning_msgs::msg::RouteState;
+using autoware_planning_msgs::srv::ClearRoute;
+using autoware_planning_msgs::srv::SetLaneletRoute;
+using autoware_planning_msgs::srv::SetWaypointRoute;
 using unique_identifier_msgs::msg::UUID;
 
 class RouteInterface

--- a/system/autoware_default_adapi_universe/src/utils/route_conversion.hpp
+++ b/system/autoware_default_adapi_universe/src/utils/route_conversion.hpp
@@ -23,10 +23,10 @@
 #include <autoware_adapi_v1_msgs/srv/set_route.hpp>
 #include <autoware_adapi_v1_msgs/srv/set_route_points.hpp>
 #include <autoware_planning_msgs/msg/lanelet_route.hpp>
-#include <tier4_planning_msgs/msg/route_state.hpp>
-#include <tier4_planning_msgs/srv/clear_route.hpp>
-#include <tier4_planning_msgs/srv/set_lanelet_route.hpp>
-#include <tier4_planning_msgs/srv/set_waypoint_route.hpp>
+#include <autoware_planning_msgs/msg/route_state.hpp>
+#include <autoware_planning_msgs/srv/clear_route.hpp>
+#include <autoware_planning_msgs/srv/set_lanelet_route.hpp>
+#include <autoware_planning_msgs/srv/set_waypoint_route.hpp>
 
 namespace autoware::default_adapi::conversion
 {
@@ -37,19 +37,19 @@ ExternalRoute create_empty_route(const rclcpp::Time & stamp);
 ExternalRoute convert_route(const InternalRoute & internal);
 
 using ExternalState = autoware_adapi_v1_msgs::msg::RouteState;
-using InternalState = tier4_planning_msgs::msg::RouteState;
+using InternalState = autoware_planning_msgs::msg::RouteState;
 ExternalState convert_state(const InternalState & internal);
 
 using ExternalClearRequest = autoware_adapi_v1_msgs::srv::ClearRoute::Request::SharedPtr;
-using InternalClearRequest = tier4_planning_msgs::srv::ClearRoute::Request::SharedPtr;
+using InternalClearRequest = autoware_planning_msgs::srv::ClearRoute::Request::SharedPtr;
 InternalClearRequest convert_request(const ExternalClearRequest & external);
 
 using ExternalLaneletRequest = autoware_adapi_v1_msgs::srv::SetRoute::Request::SharedPtr;
-using InternalLaneletRequest = tier4_planning_msgs::srv::SetLaneletRoute::Request::SharedPtr;
+using InternalLaneletRequest = autoware_planning_msgs::srv::SetLaneletRoute::Request::SharedPtr;
 InternalLaneletRequest convert_request(const ExternalLaneletRequest & external);
 
 using ExternalWaypointRequest = autoware_adapi_v1_msgs::srv::SetRoutePoints::Request::SharedPtr;
-using InternalWaypointRequest = tier4_planning_msgs::srv::SetWaypointRoute::Request::SharedPtr;
+using InternalWaypointRequest = autoware_planning_msgs::srv::SetWaypointRoute::Request::SharedPtr;
 InternalWaypointRequest convert_request(const ExternalWaypointRequest & external);
 
 using ExternalResponse = autoware_adapi_v1_msgs::msg::ResponseStatus;


### PR DESCRIPTION
## Description
This replaces tier4_planning_msgs services with autoware_planning_msgs.
These services are called from RVIZ via AD API modules, and should be treated as component interface.

This PR includes the following modification
 - replace tier4_planning_msgs services with autoware_planning_msgs for routing
 - rename service namespace for set_route and clear_route sevices so that they are directly under /planning namespace. 
 - update build_depends_humble.repos to use the message from latest autoware_msgs release.
 
## Related links

- https://github.com/autowarefoundation/autoware_core/issues/541
- https://github.com/autowarefoundation/autoware_msgs/pull/138

## How was this PR tested?

I have built locally and confirmed that planning modules works fine with planning_simulator. 
![image](https://github.com/user-attachments/assets/2b2e8200-5002-4417-b86d-db4dca2b9354)

I also tested with TIER IV's evaluator (TIER IV internal link)
https://evaluation.ci.tier4.jp/evaluation/reports/f904f6b2-0920-586a-8881-c845c71af084?project_id=prd_jt
## Notes for reviewers

None.

## Interface changes

### Topic Modifications

| Version | Topic Type      | Topic Name        | Message Type        |
|:--------|:----------------|:------------------|:--------------------|
| Old     | Srv | `/planning/mission_planning/route_selector/main/set_lanelet_route` | `tier4_planning_msgs::srv::SetLaneletRoute` |
| New     | Srv | `/planning/set_lanelet_route` | `autoware_planning_msgs::srv::SetLaneletRoute` |

| Version | Topic Type      | Topic Name        | Message Type        |
|:--------|:----------------|:------------------|:--------------------|
| Old     | Srv | `/planning/mission_planning/route_selector/main/set_waypoint_route` | `tier4_planning_msgs::srv::SetWaypointRoute` |
| New     | Srv | `/planning/set_waypoint_route` | `autoware_planning_msgs::srv::SetWaypointRoute` |

| Version | Topic Type      | Topic Name        | Message Type        |
|:--------|:----------------|:------------------|:--------------------|
| Old     | Srv | `/planning/mission_planning/route_selector/main/clear_route` | `tier4_planning_msgs::srv::ClearRoute` |
| New     | Srv | `/planning/clear_route` | `autoware_planning_msgs::srv::ClearRoute` |

| Version | Topic Type      | Topic Name        | Message Type        |
|:--------|:----------------|:------------------|:--------------------|
| Old     | Topic | `/planning/mission_planning/route_selector/main/route` | `autoware_planning_msgs::msg::LaneletRoute` |
| New     | Topic | `/planning/route` | `autoware_planning_msgs::msg::LaneletRoute` |



## Effects on system behavior

None.
