### PR TITLE
feat!: replace tier4_system_msgs with autoware_system_msgs for services

### DIFF
--- a/common/autoware_component_interface_specs_universe/include/autoware/component_interface_specs_universe/system.hpp
+++ b/common/autoware_component_interface_specs_universe/include/autoware/component_interface_specs_universe/system.hpp
@@ -19,8 +19,8 @@
 
 #include <autoware_adapi_v1_msgs/msg/mrm_state.hpp>
 #include <autoware_adapi_v1_msgs/msg/operation_mode_state.hpp>
-#include <tier4_system_msgs/srv/change_autoware_control.hpp>
-#include <tier4_system_msgs/srv/change_operation_mode.hpp>
+#include <autoware_system_msgs/srv/change_autoware_control.hpp>
+#include <autoware_system_msgs/srv/change_operation_mode.hpp>
 
 namespace autoware::component_interface_specs_universe::system
 {
@@ -36,13 +36,13 @@ struct MrmState
 
 struct ChangeAutowareControl
 {
-  using Service = tier4_system_msgs::srv::ChangeAutowareControl;
+  using Service = autoware_system_msgs::srv::ChangeAutowareControl;
   static constexpr char name[] = "/system/operation_mode/change_autoware_control";
 };
 
 struct ChangeOperationMode
 {
-  using Service = tier4_system_msgs::srv::ChangeOperationMode;
+  using Service = autoware_system_msgs::srv::ChangeOperationMode;
   static constexpr char name[] = "/system/operation_mode/change_operation_mode";
 };
 

--- a/common/autoware_component_interface_specs_universe/package.xml
+++ b/common/autoware_component_interface_specs_universe/package.xml
@@ -17,13 +17,13 @@
   <depend>autoware_perception_msgs</depend>
   <depend>autoware_planning_msgs</depend>
   <depend>autoware_vehicle_msgs</depend>
+  <depend>autoware_system_msgs</depend>
   <depend>nav_msgs</depend>
   <depend>rcl</depend>
   <depend>rclcpp</depend>
   <depend>rosidl_runtime_cpp</depend>
   <depend>tier4_control_msgs</depend>
   <depend>tier4_planning_msgs</depend>
-  <depend>tier4_system_msgs</depend>
   <depend>tier4_vehicle_msgs</depend>
 
   <test_depend>ament_cmake_gtest</test_depend>

--- a/common/autoware_component_interface_specs_universe/package.xml
+++ b/common/autoware_component_interface_specs_universe/package.xml
@@ -16,8 +16,8 @@
   <depend>autoware_map_msgs</depend>
   <depend>autoware_perception_msgs</depend>
   <depend>autoware_planning_msgs</depend>
-  <depend>autoware_vehicle_msgs</depend>
   <depend>autoware_system_msgs</depend>
+  <depend>autoware_vehicle_msgs</depend>
   <depend>nav_msgs</depend>
   <depend>rcl</depend>
   <depend>rclcpp</depend>

--- a/control/autoware_operation_mode_transition_manager/README.md
+++ b/control/autoware_operation_mode_transition_manager/README.md
@@ -53,8 +53,8 @@ Here we see that `autoware_operation_mode_transition_manager` has multiple state
 
 For the mode transition:
 
-- /system/operation_mode/change_autoware_control [`tier4_system_msgs/srv/ChangeAutowareControl`]: change operation mode to Autonomous
-- /system/operation_mode/change_operation_mode [`tier4_system_msgs/srv/ChangeOperationMode`]: change operation mode
+- /system/operation_mode/change_autoware_control [`autoware_system_msgs/srv/ChangeAutowareControl`]: change operation mode to Autonomous
+- /system/operation_mode/change_operation_mode [`autoware_system_msgs/srv/ChangeOperationMode`]: change operation mode
 
 For the transition availability/completion check:
 

--- a/control/autoware_operation_mode_transition_manager/package.xml
+++ b/control/autoware_operation_mode_transition_manager/package.xml
@@ -17,6 +17,7 @@
   <depend>autoware_component_interface_utils</depend>
   <depend>autoware_control_msgs</depend>
   <depend>autoware_motion_utils</depend>
+  <depend>autoware_system_msgs</depend>
   <depend>autoware_utils</depend>
   <depend>autoware_utils_rclcpp</depend>
   <depend>autoware_vehicle_info_utils</depend>
@@ -26,7 +27,6 @@
   <depend>rclcpp_components</depend>
   <depend>std_srvs</depend>
   <depend>tier4_control_msgs</depend>
-  <depend>tier4_system_msgs</depend>
   <depend>tier4_vehicle_msgs</depend>
 
   <test_depend>ament_cmake_gtest</test_depend>

--- a/control/autoware_operation_mode_transition_manager/src/data.hpp
+++ b/control/autoware_operation_mode_transition_manager/src/data.hpp
@@ -21,7 +21,7 @@
 #include <autoware_adapi_v1_msgs/srv/change_operation_mode.hpp>
 #include <autoware_vehicle_msgs/msg/control_mode_report.hpp>
 #include <autoware_vehicle_msgs/srv/control_mode_command.hpp>
-#include <tier4_system_msgs/srv/change_operation_mode.hpp>
+#include <autoware_system_msgs/srv/change_operation_mode.hpp>
 
 #include <cmath>
 #include <optional>
@@ -33,7 +33,7 @@ namespace autoware::operation_mode_transition_manager
 using ServiceResponse = autoware_adapi_v1_msgs::srv::ChangeOperationMode::Response;
 using OperationModeState = autoware_adapi_v1_msgs::msg::OperationModeState;
 using OperationModeValue = OperationModeState::_mode_type;
-using ChangeOperationMode = tier4_system_msgs::srv::ChangeOperationMode;
+using ChangeOperationMode = autoware_system_msgs::srv::ChangeOperationMode;
 using ControlModeCommand = autoware_vehicle_msgs::srv::ControlModeCommand;
 using ControlModeReport = autoware_vehicle_msgs::msg::ControlModeReport;
 

--- a/control/autoware_operation_mode_transition_manager/src/data.hpp
+++ b/control/autoware_operation_mode_transition_manager/src/data.hpp
@@ -19,9 +19,9 @@
 
 #include <autoware_adapi_v1_msgs/msg/operation_mode_state.hpp>
 #include <autoware_adapi_v1_msgs/srv/change_operation_mode.hpp>
+#include <autoware_system_msgs/srv/change_operation_mode.hpp>
 #include <autoware_vehicle_msgs/msg/control_mode_report.hpp>
 #include <autoware_vehicle_msgs/srv/control_mode_command.hpp>
-#include <autoware_system_msgs/srv/change_operation_mode.hpp>
 
 #include <cmath>
 #include <optional>


### PR DESCRIPTION
## Description
This replaces tier4_service_msgs services with autoware_service_msgs.
These services are called from AD API modules and should be treated as component interface.

This must be merged with https://github.com/tier4/tier4_ad_api_adaptor/pull/159
## Related links
- https://github.com/autowarefoundation/autoware_core/issues/541
- https://github.com/tier4/tier4_ad_api_adaptor/pull/159


<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

I tested locally with planning_simulator.

## Notes for reviewers

None.

## Interface changes

### Topic changes
| Version | Topic Type      | Topic Name        | Message Type        |
|:--------|:----------------|:------------------|:--------------------|
| Old     | Service | `/system/operation_mode/change_autoware_control` | `tier4_system_msgs::srv::ChangeAutowareControl` |
| New     | Service | `/system/operation_mode/change_autoware_control` | `autoware_system_msgs::srv::ChangeAutowareControl` |

| Version | Topic Type      | Topic Name        | Message Type        |
|:--------|:----------------|:------------------|:--------------------|
| Old     | Service | `/system/operation_mode/change_operation_mode` | `tier4_system_msgs::srv::ChangeOperationMode` |
| New     | Service | `/system/operation_mode/change_operation_mode` | `autoware_system_msgs::srv::ChangeOperationMode` |


## Effects on system behavior

None.
