### PR TITLE
feat(autoware_pointcloud_preprocessor): add concat status

### DIFF
--- a/perception/autoware_image_projection_based_fusion/include/autoware/image_projection_based_fusion/fusion_node.hpp
+++ b/perception/autoware_image_projection_based_fusion/include/autoware/image_projection_based_fusion/fusion_node.hpp
@@ -141,7 +141,8 @@ protected:
   // callback for rois subscription
   void rois_callback(const typename Msg2D::ConstSharedPtr rois_msg, const std::size_t rois_id);
 
-  void diagnostic_callback(const diagnostic_msgs::msg::DiagnosticArray::SharedPtr diagnostic_msg);
+  void concatenate_status_callback(
+    const diagnostic_msgs::msg::DiagnosticArray::SharedPtr diagnostic_msg);
 
   // Custom process methods
   virtual void postprocess(const Msg3D & processing_msg, ExportObj & output_msg);
@@ -156,7 +157,7 @@ protected:
 
   // 3d detection subscription
   typename rclcpp::Subscription<Msg3D>::SharedPtr msg3d_sub_;
-  rclcpp::Subscription<diagnostic_msgs::msg::DiagnosticArray>::SharedPtr sub_diag_;
+  rclcpp::Subscription<diagnostic_msgs::msg::DiagnosticArray>::SharedPtr sub_concatenate_status_;
 
   // parameters for out_of_scope filter
   float filter_scope_min_x_;

--- a/perception/autoware_image_projection_based_fusion/src/fusion_node.cpp
+++ b/perception/autoware_image_projection_based_fusion/src/fusion_node.cpp
@@ -502,27 +502,31 @@ template <class Msg3D, class Msg2D, class ExportObj>
 void FusionNode<Msg3D, Msg2D, ExportObj>::concatenate_status_callback(
   const diagnostic_msgs::msg::DiagnosticArray::SharedPtr diagnostic_msg)
 {
-  std::optional<double> concatenate_timestamp_opt;
+  if (!diagnostic_msg) return;
 
-  // First pass: Locate concatenated_cloud_timestamp
-  for (const auto & value : status.values) {
-    if (value.key == std::string_view("Concatenated pointcloud timestamp")) {
-      try {
-        concatenate_timestamp_opt = std::stod(value.value);
-      } catch (const std::exception & e) {
-        RCLCPP_ERROR(get_logger(), "Error parsing concatenated cloud timestamp: %s", e.what());
+  for (const auto & status : diagnostic_msg->status) {
+    std::optional<double> concatenate_timestamp_opt;
+
+    // First pass: Locate concatenated_cloud_timestamp
+    for (const auto & value : status.values) {
+      if (value.key == "Concatenated pointcloud timestamp") {
+        try {
+          concatenate_timestamp_opt = std::stod(value.value);
+        } catch (const std::exception & e) {
+          RCLCPP_ERROR(get_logger(), "Error parsing concatenated cloud timestamp: %s", e.what());
+        }
       }
     }
-  }
 
-  // Second pass: Fill key-value map only if timestamp was valid
-  if (concatenate_timestamp_opt.has_value()) {
-    std::unordered_map<std::string, std::string> key_value_map;
-    for (const auto & value : status.values) {
-      key_value_map.emplace(value.key, value.value);
+    // Second pass: Fill key-value map only if timestamp was valid
+    if (concatenate_timestamp_opt.has_value()) {
+      std::unordered_map<std::string, std::string> key_value_map;
+      for (const auto & value : status.values) {
+        key_value_map.emplace(value.key, value.value);
+      }
+
+      concatenated_status_map_.emplace(concatenate_timestamp_opt.value(), std::move(key_value_map));
     }
-
-    concatenated_status_map_.emplace(concatenate_timestamp_opt.value(), std::move(key_value_map));
   }
 }
 

--- a/perception/autoware_image_projection_based_fusion/src/fusion_node.cpp
+++ b/perception/autoware_image_projection_based_fusion/src/fusion_node.cpp
@@ -201,7 +201,7 @@ void FusionNode<Msg3D, Msg2D, ExportObj>::initialize_strategy()
   } else if (matching_strategy_ == "advanced") {
     fusion_matching_strategy_ = std::make_unique<AdvancedMatchingStrategy<Msg3D, Msg2D, ExportObj>>(
       std::dynamic_pointer_cast<FusionNode>(shared_from_this()), id_to_offset_map_);
-    // subscribe concatentate status
+    // subscribe concatenate status
     sub_concatenate_status_ = this->create_subscription<diagnostic_msgs::msg::DiagnosticArray>(
       "/concatenate_status", 10,
       std::bind(&FusionNode::concatenate_status_callback, this, std::placeholders::_1));

--- a/sensing/autoware_pointcloud_preprocessor/include/autoware/pointcloud_preprocessor/concatenate_data/concatenate_and_time_sync_node.hpp
+++ b/sensing/autoware_pointcloud_preprocessor/include/autoware/pointcloud_preprocessor/concatenate_data/concatenate_and_time_sync_node.hpp
@@ -130,10 +130,13 @@ private:
   std::unique_ptr<autoware_utils::StopWatch<std::chrono::milliseconds>> stop_watch_ptr_;
 
   std::unique_ptr<autoware_utils::DiagnosticsInterface> diagnostics_interface_;
+  std::unique_ptr<autoware_utils::DiagnosticsInterface> concatenate_status_interface_;
+
   void publish_debug_message(
     const double processing_time, const double cyclic_time,
     const std::unordered_map<std::string, double> & topic_to_pipeline_latency_map);
-  void check_concat_status(const DiagnosticInfo & diagnostic_info);
+  void check_concat_status(
+    const DiagnosticInfo & diagnostic_info, autoware_utils::DiagnosticsInterface * interface);
 
   void initialize_pub_sub();
 

--- a/sensing/autoware_pointcloud_preprocessor/include/autoware/pointcloud_preprocessor/concatenate_data/concatenate_and_time_sync_node.ipp
+++ b/sensing/autoware_pointcloud_preprocessor/include/autoware/pointcloud_preprocessor/concatenate_data/concatenate_and_time_sync_node.ipp
@@ -440,6 +440,12 @@ template <typename MsgTraits>
 void PointCloudConcatenateDataSynchronizerComponentTemplated<MsgTraits>::check_concat_status(
   const DiagnosticInfo & diagnostic_info, autoware_utils::DiagnosticsInterface * interface)
 {
+  if (!interface) {
+    RCLCPP_ERROR_STREAM_THROTTLE(this->get_logger(), *this->get_clock(), 1000,
+    "Interface is nullptr. Skipping diagnostics update.");
+    return;
+  }
+
   interface->clear();
 
   const bool should_publish_diag = diagnostic_info.publish_pointcloud || diagnostic_info.drop_previous_but_late_pointcloud;

--- a/sensing/autoware_pointcloud_preprocessor/package.xml
+++ b/sensing/autoware_pointcloud_preprocessor/package.xml
@@ -32,7 +32,6 @@
   <depend>autoware_pcl_extensions</depend>
   <depend>autoware_point_types</depend>
   <depend>autoware_utils</depend>
-  <depend>autoware_utils_diagnostics</depend>
   <depend>autoware_vehicle_msgs</depend>
   <depend>cgal</depend>
   <depend>cv_bridge</depend>

--- a/sensing/autoware_pointcloud_preprocessor/package.xml
+++ b/sensing/autoware_pointcloud_preprocessor/package.xml
@@ -32,6 +32,7 @@
   <depend>autoware_pcl_extensions</depend>
   <depend>autoware_point_types</depend>
   <depend>autoware_utils</depend>
+  <depend>autoware_utils_diagnostics</depend>
   <depend>autoware_vehicle_msgs</depend>
   <depend>cgal</depend>
   <depend>cv_bridge</depend>


### PR DESCRIPTION
## Description
As discussed in the internal channel, we would like to avoid having the fusion node subscribe to the /diagnostics topic.
To address this, this PR introduces a new topic, /concatenate_status, which provides the necessary pointcloud concatenation status for downstream modules.
In addition, this change helps reduce latency, as the fusion node no longer needs to filter through hundreds of unrelated diagnostic messages.

Note that this PR needs to be merged together with https://github.com/autowarefoundation/autoware_utils/pull/75

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
Internal rosbag

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
