### PR TITLE
feat(intersection_occlusion): adjustable occlusion wall position for intersection without traffic_light

### DIFF
--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/README.md
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/README.md
@@ -470,7 +470,6 @@ entity TargetObject {
 | `.ignore_parked_vehicle_speed_threshold`       | double   | [m/s] velocity threshold for checking parked vehicle                                        |
 | `.occlusion_detection_hold_time`               | double   | [s] hold time of occlusion detection                                                        |
 | `.temporal_stop_time_before_peeking`           | double   | [s] temporal stop duration at default_stopline before starting peeking                      |
-| `.temporal_stop_before_attention_area`         | bool     | [-] flag to temporarily stop at first_attention_stopline before peeking into attention_area |
 | `.creep_velocity_without_traffic_light`        | double   | [m/s] creep velocity to occlusion_wo_tl_pass_judge_line                                     |
 | `.static_occlusion_with_traffic_light_timeout` | double   | [s] the timeout duration for ignoring static occlusion at intersection with traffic light   |
 

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/config/intersection.param.yaml
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/config/intersection.param.yaml
@@ -106,7 +106,6 @@
         ignore_parked_vehicle_speed_threshold: 0.8333
         occlusion_detection_hold_time: 1.5
         temporal_stop_time_before_peeking: 0.1
-        temporal_stop_before_attention_area: false
         creep_velocity_without_traffic_light: 1.388
         static_occlusion_with_traffic_light_timeout: 0.5
 

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/decision_result.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/decision_result.hpp
@@ -90,7 +90,6 @@ struct PeekingTowardOcclusion
   //! if intersection_occlusion is disapproved externally through RTC, it indicates
   //! "is_forcefully_occluded"
   bool is_actually_occlusion_cleared{false};
-  bool temporal_stop_before_attention_required{false};
   size_t closest_idx{0};
   size_t collision_stopline_idx{0};
   size_t first_attention_stopline_idx{0};
@@ -108,7 +107,6 @@ struct PeekingTowardOcclusion
 struct OccludedCollisionStop
 {
   bool is_actually_occlusion_cleared{false};
-  bool temporal_stop_before_attention_required{false};
   size_t closest_idx{0};
   size_t collision_stopline_idx{0};
   size_t first_attention_stopline_idx{0};
@@ -126,7 +124,6 @@ struct OccludedAbsenceTrafficLight
 {
   bool is_actually_occlusion_cleared{false};
   bool collision_detected{false};
-  bool temporal_stop_before_attention_required{false};
   size_t closest_idx{0};
   size_t first_attention_area_stopline_idx{0};
   size_t peeking_limit_line_idx{0};

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/manager.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/manager.cpp
@@ -286,8 +286,6 @@ IntersectionModuleManager::IntersectionModuleManager(rclcpp::Node & node)
       get_or_declare_parameter<double>(node, ns + ".occlusion.occlusion_detection_hold_time");
     ip.occlusion.temporal_stop_time_before_peeking =
       get_or_declare_parameter<double>(node, ns + ".occlusion.temporal_stop_time_before_peeking");
-    ip.occlusion.temporal_stop_before_attention_area =
-      get_or_declare_parameter<bool>(node, ns + ".occlusion.temporal_stop_before_attention_area");
     ip.occlusion.creep_velocity_without_traffic_light = get_or_declare_parameter<double>(
       node, ns + ".occlusion.creep_velocity_without_traffic_light");
     ip.occlusion.static_occlusion_with_traffic_light_timeout = get_or_declare_parameter<double>(

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_intersection.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_intersection.hpp
@@ -173,7 +173,6 @@ public:
       double ignore_parked_vehicle_speed_threshold;
       double occlusion_detection_hold_time;
       double temporal_stop_time_before_peeking;
-      bool temporal_stop_before_attention_area;
       double creep_velocity_without_traffic_light;
       double static_occlusion_with_traffic_light_timeout;
     } occlusion;
@@ -484,9 +483,6 @@ private:
 
   //! debouncing for stable CLEARED decision
   StateMachine occlusion_stop_state_machine_;
-
-  //! debouncing for the brief stop at the boundary of attention area(if required by the flag)
-  StateMachine temporal_stop_before_attention_state_machine_;
 
   //! time counter for the stuck detection due to occlusion caused static objects
   StateMachine static_occlusion_timeout_state_machine_;


### PR DESCRIPTION
## Description

Setting `peeking_offset` at intersection without traffic light was not effective previously, so the wall position of "intersection_occlusion" is always at the boundary position by specification. I've changed the spec.

### before this PR

### after this PR

![image](https://github.com/user-attachments/assets/53bc6a9f-fa9b-460f-9a14-d3d9fbeef0ab)

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

https://evaluation.tier4.jp/evaluation/reports/6b936311-3ac7-570e-b6dd-9a4d1bde12ce?project_id=prd_jt

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
