### PR TITLE
feat(control_validator): add yaw_deviation

### DIFF
--- a/control/autoware_control_validator/README.md
+++ b/control/autoware_control_validator/README.md
@@ -17,6 +17,7 @@ The listed features below does not always correspond to the latest implementatio
 
 - **Lateral jerk** : invalid when the lateral jerk exceeds the configured threshold. The validation uses the vehicle's velocity and steering angle rate to calculate the resulting lateral jerk. The calculation assumes constant velocity (acceleration is zero).
 - **Deviation check between reference trajectory and predicted trajectory** : invalid when the largest deviation between the predicted trajectory and reference trajectory is greater than the given threshold.
+- **Yaw deviation**: invalid when the difference between the yaw of the ego vehicle and the nearest (interpolated) trajectory yaw is greater than the given threshold.
 
 ![trajectory_deviation](./image/trajectory_deviation.drawio.svg)
 
@@ -63,12 +64,13 @@ The input trajectory is detected as invalid if the index exceeds the following t
 | :---------------------------------------- | :----- | :---------------------------------------------------------------------------------------------------------- | :------------ |
 | `thresholds.max_distance_deviation`       | double | invalid threshold of the max distance deviation between the predicted path and the reference trajectory [m] | 1.0           |
 | `thresholds.lateral_jerk`                 | double | invalid threshold of the lateral jerk for steering rate validation [m/s^3]                                  | 10.0          |
-| `thresholds.rolling_back_velocity`        | double | threshold velocity to valid the vehicle velocity [m/s]                                                      | 0.5           |
-| `thresholds.over_velocity_offset`         | double | threshold velocity offset to valid the vehicle velocity [m/s]                                               | 2.0           |
-| `thresholds.over_velocity_ratio`          | double | threshold ratio to valid the vehicle velocity [*]                                                           | 0.2           |
+| `thresholds.rolling_back_velocity`        | double | threshold velocity to validate the vehicle velocity [m/s]                                                   | 0.5           |
+| `thresholds.over_velocity_offset`         | double | threshold velocity offset to validate the vehicle velocity [m/s]                                            | 2.0           |
+| `thresholds.over_velocity_ratio`          | double | threshold ratio to validate the vehicle velocity [*]                                                        | 0.2           |
 | `thresholds.overrun_stop_point_dist`      | double | threshold distance to overrun stop point [m]                                                                | 0.8           |
-| `thresholds.acc_error_offset`             | double | threshold ratio to valid the vehicle acceleration [*]                                                       | 0.8           |
-| `thresholds.acc_error_scale`              | double | threshold acceleration to valid the vehicle acceleration [m]                                                | 0.2           |
+| `thresholds.acc_error_offset`             | double | threshold ratio to validate the vehicle acceleration [*]                                                    | 0.8           |
+| `thresholds.acc_error_scale`              | double | threshold acceleration to validate the vehicle acceleration [m]                                             | 0.2           |
 | `thresholds.will_overrun_stop_point_dist` | double | threshold distance to overrun stop point [m]                                                                | 1.0           |
 | `thresholds.assumed_limit_acc`            | double | assumed acceleration for over run estimation [m]                                                            | 5.0           |
 | `thresholds.assumed_delay_time`           | double | assumed delay for over run estimation [m]                                                                   | 0.2           |
+| `thresholds.yaw_deviation`                | double | threshold angle to validate the vehicle yaw related to the nearest trajectory yaw [rad]                     | 1.0           |

--- a/control/autoware_control_validator/config/control_validator.param.yaml
+++ b/control/autoware_control_validator/config/control_validator.param.yaml
@@ -20,6 +20,7 @@
       assumed_limit_acc: 5.0
       assumed_delay_time: 0.2
       nominal_latency: 0.01
+      yaw_deviation: 1.0
 
     acc_lpf_gain: 0.97 # Time constant 1.11s
     vel_lpf_gain: 0.9 # Time constant 0.33

--- a/control/autoware_control_validator/include/autoware/control_validator/control_validator.hpp
+++ b/control/autoware_control_validator/include/autoware/control_validator/control_validator.hpp
@@ -199,6 +199,24 @@ private:
 };
 
 /**
+ * @class YawValidator
+ * @brief Calculate whether the vehicle orientation deviated from the trajectory
+ */
+class YawValidator
+{
+public:
+  explicit YawValidator(rclcpp::Node & node)
+  : yaw_deviation_th_{get_or_declare_parameter<double>(node, "thresholds.yaw_deviation")} {};
+
+  void validate(
+    ControlValidatorStatus & res, const Trajectory & reference_trajectory,
+    const Odometry & kinematics);
+
+private:
+  const double yaw_deviation_th_;
+};
+
+/**
  * @class ControlValidator
  * @brief Validates control commands by comparing predicted trajectories against reference
  * trajectories.
@@ -289,6 +307,7 @@ private:
   AccelerationValidator acceleration_validator{*this};
   VelocityValidator velocity_validator{*this};
   OverrunValidator overrun_validator{*this};
+  YawValidator yaw_validator{*this};
 };
 }  // namespace autoware::control_validator
 

--- a/control/autoware_control_validator/msg/ControlValidatorStatus.msg
+++ b/control/autoware_control_validator/msg/ControlValidatorStatus.msg
@@ -9,6 +9,7 @@ bool is_valid_lateral_jerk
 bool has_overrun_stop_point
 bool will_overrun_stop_point
 bool is_valid_latency
+bool is_valid_yaw
 
 # values
 float64 max_distance_deviation
@@ -22,5 +23,6 @@ float64 dist_to_stop
 float64 pred_dist_to_stop
 float64 nearest_trajectory_vel
 float64 latency
+float64 yaw_deviation
 
 int64 invalid_count


### PR DESCRIPTION
## Description

Add the `yaw_deviation` metric to the `control_validator` to ensure the ego yaw did not deviate too much from the trajectory.

## Related links

Launch PR: https://github.com/autowarefoundation/autoware_launch/pull/1507

**Private Links:**

- [TIER IV internal link](https://tier4.atlassian.net/browse/RT1-10098)

## How was this PR tested?

Psim
Rosbags

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
