### PR TITLE
feat(run_out): add option for strict cutting of predicted paths

### DIFF
--- a/planning/motion_velocity_planner/autoware_motion_velocity_run_out_module/README.md
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_run_out_module/README.md
@@ -41,6 +41,8 @@ we prepare the following sets of geometries based on the parameters defined for 
 - polygons to ignore collisions (`ignore_collisions.polygon_types` and `ignore_collisions.lanelet_subtypes`);
 - segments to cut predicted paths (`cut_predicted_paths.polygon_types`, `cut_predicted_paths.linestring_types`, and `cut_predicted_paths.lanelet_subtypes`).
   - the rear segment of the current ego footprint is also added if `cut_predicted_paths.if_crossing_ego_from_behind` is set to `true`.
+- segments to strictly cut predicted paths (`cut_predicted_paths.strict_polygon_types`, `cut_predicted_paths.strict_linestring_types`, and `cut_predicted_paths.strict_lanelet_subtypes`).
+  - strict cutting means that the cut is always applied, regardless of any preserved distance or duration.
 
 The following figure shows an example where the polygons to ignore objects are shown in blue, to ignore collisions in green, and to cut predicted paths in red.
 
@@ -69,6 +71,7 @@ Next, the remaining predicted paths are cut according to the segments prepared i
 
 To guarantee that parts of the predicted paths are never ignored,
 parameters `preserved_duration` and `preserved_distance` can be used to set a minimum duration and/or distance that cannot be cut or ignored.
+This is not applied in the case of the strict cutting.
 
 The following figures shows an example where crosswalks are used to ignore pedestrians and to cut their predicted paths.
 

--- a/planning/motion_velocity_planner/autoware_motion_velocity_run_out_module/schema/run_out.schema.json
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_run_out_module/schema/run_out.schema.json
@@ -268,11 +268,26 @@
                       "linestring_types": {
                         "type": "array",
                         "description": "types of linestrings in the vector map used to cut predicted paths",
-                        "default": "['guard_rail']"
+                        "default": "['NONE']"
                       },
                       "lanelet_subtypes": {
                         "type": "array",
                         "description": "subtypes of lanelets in the vector map used to cut predicted paths",
+                        "default": "['NONE']"
+                      },
+                      "strict_polygon_types": {
+                        "type": "array",
+                        "description": "types of polygons in the vector map used to strictly cut predicted paths",
+                        "default": "['NONE']"
+                      },
+                      "strict_linestring_types": {
+                        "type": "array",
+                        "description": "types of linestrings in the vector map used to strictly cut predicted paths",
+                        "default": "['guard_rail']"
+                      },
+                      "strict_lanelet_subtypes": {
+                        "type": "array",
+                        "description": "subtypes of lanelets in the vector map used to strictly cut predicted paths",
                         "default": "['NONE']"
                       }
                     }

--- a/planning/motion_velocity_planner/autoware_motion_velocity_run_out_module/src/debug.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_run_out_module/src/debug.hpp
@@ -309,6 +309,20 @@ inline MarkerArray make_debug_filtering_data_marker(const FilteringData & data)
     m.points.push_back(p);
   }
   markers.markers.push_back(m);
+  m.ns = "filtering_data_strict_cut_predicted_paths";
+  m.points.clear();
+  m.type = Marker::LINE_LIST;
+  m.color = universe_utils::createMarkerColor(1.0, 1.0, 0.0, 0.75);
+  m.scale = universe_utils::createMarkerScale(0.2, 0.2, 0.2);
+  for (const auto & segment : data.strict_cut_predicted_paths_segments) {
+    p.x = segment.first.x();
+    p.y = segment.first.y();
+    m.points.push_back(p);
+    p.x = segment.second.x();
+    p.y = segment.second.y();
+    m.points.push_back(p);
+  }
+  markers.markers.push_back(m);
   m.ns = "filtering_data_ignore_objects";
   m.points.clear();
   m.color = universe_utils::createMarkerColor(0.0, 0.0, 1.0, 0.75);

--- a/planning/motion_velocity_planner/autoware_motion_velocity_run_out_module/src/map_data.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_run_out_module/src/map_data.cpp
@@ -70,6 +70,11 @@ void add_ignore_and_cut_lanelets(
           data.cut_predicted_paths_segments.push_back(convert(ll.polygon2d().segment(i)));
         }
       }
+      if (contains_type(params.strict_cut_lanelet_subtypes, lanelet_subtype)) {
+        for (auto i = 0UL; i < ll.polygon2d().numSegments(); ++i) {
+          data.strict_cut_predicted_paths_segments.push_back(convert(ll.polygon2d().segment(i)));
+        }
+      }
       if (contains_type(params.ignore_objects_lanelet_subtypes, lanelet_subtype)) {
         universe_utils::LinearRing2d polygon;
         boost::geometry::convert(ll.polygon2d().basicPolygon(), polygon);
@@ -95,6 +100,12 @@ void add_ignore_and_cut_polygons(
       if (contains_type(params.cut_polygon_types, polygon_type)) {
         for (auto i = 0UL; i < p.numSegments(); ++i) {
           data_per_label[label].cut_predicted_paths_segments.push_back(convert(p.segment(i)));
+        }
+      }
+      if (contains_type(params.strict_cut_polygon_types, polygon_type)) {
+        for (auto i = 0UL; i < p.numSegments(); ++i) {
+          data_per_label[label].strict_cut_predicted_paths_segments.push_back(
+            convert(p.segment(i)));
         }
       }
       if (contains_type(params.ignore_objects_polygon_types, polygon_type)) {
@@ -127,6 +138,13 @@ void add_cut_segments(
       if (std::find(types.begin(), types.end(), attribute) != types.end()) {
         for (auto i = 0UL; i < ls.numSegments(); ++i) {
           data_per_label[label].cut_predicted_paths_segments.push_back(convert(ls.segment(i)));
+        }
+      }
+      const auto & strict_types = params.strict_cut_linestring_types;
+      if (std::find(strict_types.begin(), strict_types.end(), attribute) != strict_types.end()) {
+        for (auto i = 0UL; i < ls.numSegments(); ++i) {
+          data_per_label[label].strict_cut_predicted_paths_segments.push_back(
+            convert(ls.segment(i)));
         }
       }
     }
@@ -173,11 +191,17 @@ FilteringDataPerLabel calculate_filtering_data(
   for (const auto label : target_labels) {
     auto & data = data_per_label[label];
     std::vector<SegmentNode> nodes;
+    std::vector<SegmentNode> strict_nodes;
     nodes.reserve(data.cut_predicted_paths_segments.size());
+    strict_nodes.reserve(data.strict_cut_predicted_paths_segments.size());
     for (auto i = 0UL; i < data.cut_predicted_paths_segments.size(); ++i) {
       nodes.emplace_back(data.cut_predicted_paths_segments[i], i);
     }
+    for (auto i = 0UL; i < data.strict_cut_predicted_paths_segments.size(); ++i) {
+      strict_nodes.emplace_back(data.strict_cut_predicted_paths_segments[i], i);
+    }
     data.cut_predicted_paths_rtree = SegmentRtree(nodes);
+    data.strict_cut_predicted_paths_rtree = SegmentRtree(strict_nodes);
   }
   for (const auto label : target_labels) {
     auto & data = data_per_label[label];

--- a/planning/motion_velocity_planner/autoware_motion_velocity_run_out_module/src/parameters.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_run_out_module/src/parameters.hpp
@@ -47,6 +47,9 @@ struct ObjectParameters
   std::vector<std::string> cut_linestring_types;
   std::vector<std::string> cut_polygon_types;
   std::vector<std::string> cut_lanelet_subtypes;
+  std::vector<std::string> strict_cut_linestring_types;
+  std::vector<std::string> strict_cut_polygon_types;
+  std::vector<std::string> strict_cut_lanelet_subtypes;
   bool cut_if_crossing_ego_from_behind;
   double confidence_filtering_threshold;
   bool confidence_filtering_only_use_highest;
@@ -236,6 +239,15 @@ struct Parameters
       object_parameters_per_label[label].cut_linestring_types =
         get_object_parameter<std::vector<std::string>>(
           node, ns, label, ".cut_predicted_paths.linestring_types");
+      object_parameters_per_label[label].strict_cut_polygon_types =
+        get_object_parameter<std::vector<std::string>>(
+          node, ns, label, ".cut_predicted_paths.strict_polygon_types");
+      object_parameters_per_label[label].strict_cut_lanelet_subtypes =
+        get_object_parameter<std::vector<std::string>>(
+          node, ns, label, ".cut_predicted_paths.strict_lanelet_subtypes");
+      object_parameters_per_label[label].strict_cut_linestring_types =
+        get_object_parameter<std::vector<std::string>>(
+          node, ns, label, ".cut_predicted_paths.strict_linestring_types");
       object_parameters_per_label[label].cut_if_crossing_ego_from_behind =
         get_object_parameter<bool>(
           node, ns, label, ".cut_predicted_paths.if_crossing_ego_from_behind");
@@ -336,14 +348,14 @@ struct Parameters
         params, ns + str + ".cut_predicted_paths.if_crossing_ego_from_behind",
         object_parameters_per_label[label].cut_if_crossing_ego_from_behind);
       updateParam(
-        params, ns + str + ".cut_predicted_paths.lanelet_subtypes",
-        object_parameters_per_label[label].cut_lanelet_subtypes);
+        params, ns + str + ".cut_predicted_paths.strict_lanelet_subtypes",
+        object_parameters_per_label[label].strict_cut_lanelet_subtypes);
       updateParam(
-        params, ns + str + ".cut_predicted_paths.polygon_types",
-        object_parameters_per_label[label].cut_polygon_types);
+        params, ns + str + ".cut_predicted_paths.strict_polygon_types",
+        object_parameters_per_label[label].strict_cut_polygon_types);
       updateParam(
-        params, ns + str + ".cut_predicted_paths.linestring_types",
-        object_parameters_per_label[label].cut_linestring_types);
+        params, ns + str + ".cut_predicted_paths.strict_linestring_types",
+        object_parameters_per_label[label].strict_cut_linestring_types);
       updateParam(
         params, ns + str + ".standstill_duration_after_cut",
         object_parameters_per_label[label].standstill_duration_after_cut);

--- a/planning/motion_velocity_planner/autoware_motion_velocity_run_out_module/src/types.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_run_out_module/src/types.hpp
@@ -313,6 +313,8 @@ struct FilteringData
   PolygonRtree ignore_collisions_rtree;
   std::vector<universe_utils::Segment2d> cut_predicted_paths_segments;
   SegmentRtree cut_predicted_paths_rtree;
+  std::vector<universe_utils::Segment2d> strict_cut_predicted_paths_segments;
+  SegmentRtree strict_cut_predicted_paths_rtree;
 };
 using FilteringDataPerLabel = std::vector<FilteringData>;
 


### PR DESCRIPTION
## Description

Improve the predicted paths filtering used by the `run_out` module (`motion_velocity_planner`).
It is now possible to _strictly_ cut predicted paths based on map geometries (polygons, lanelets, or linestrings). This means that the cutting is always applied without considering the preserved distance or duration.

Required launch PR: https://github.com/autowarefoundation/autoware_launch/pull/1518

## Related links

**Private Links:**

- [TIER IV internal link](https://tier4.atlassian.net/browse/RT1-10414)

## How was this PR tested?

Psim

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added | `strict_polygon_types`   | `string array` | `["NONE"]`         | types of polygons in the vector map used to strictly cut predicted paths |
| Added | `strict_linestring_types`   | `string array` | `["guard_rail"]`         | types of linestrings in the vector map used to strictly cut predicted paths |
| Added | `strict_lanelet_subtypes`   | `string array` | `["NONE"]`         | subtypes of lanelets in the vector map used to strictly cut predicted paths |

## Effects on system behavior

More control over the map based predicted paths filtering.
