### PR TITLE
feat(start_planner_module): prevent departure if the previous traffic light (v2i) is green in high speed roads

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/README.md
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/README.md
@@ -432,18 +432,19 @@ Parameters under `target_filtering` are related to filtering target objects for 
 
 Parameters under `safety_check_params` define the configuration for safety check.
 
-| Name                                           | Unit | Type   | Description                                                                               | Default value |
-| :--------------------------------------------- | :--- | :----- | :---------------------------------------------------------------------------------------- | :------------ |
-| enable_safety_check                            | -    | bool   | Flag to enable safety check                                                               | true          |
-| check_all_predicted_path                       | -    | bool   | Flag to check all predicted paths                                                         | true          |
-| publish_debug_marker                           | -    | bool   | Flag to publish debug markers                                                             | false         |
-| rss_params.rear_vehicle_reaction_time          | [s]  | double | Reaction time for rear vehicles                                                           | 2.0           |
-| rss_params.rear_vehicle_safety_time_margin     | [s]  | double | Safety time margin for rear vehicles                                                      | 1.0           |
-| rss_params.lateral_distance_max_threshold      | [m]  | double | Maximum lateral distance threshold                                                        | 2.0           |
-| rss_params.longitudinal_distance_min_threshold | [m]  | double | Minimum longitudinal distance threshold                                                   | 3.0           |
-| rss_params.longitudinal_velocity_delta_time    | [s]  | double | Delta time for longitudinal velocity                                                      | 0.8           |
-| hysteresis_factor_expand_rate                  | -    | double | Rate to expand/shrink the hysteresis factor                                               | 1.0           |
-| collision_check_yaw_diff_threshold             | -    | double | Maximum yaw difference between ego and object when executing rss-based collision checking | 1.578         |
+| Name                                           | Unit  | Type   | Description                                                                                                          | Default value |
+| :--------------------------------------------- | :---- | :----- | :------------------------------------------------------------------------------------------------------------------- | :------------ |
+| enable_safety_check                            | -     | bool   | Flag to enable safety check                                                                                          | true          |
+| prev_light_check_distance                      | [m]   | double | Prevent departure if the previous traffic light (v2i) is green in high speed roads. Set to 0 to disable this feature | 0.0           |
+| threshold_speed_for_prev_light_check           | [kph] | double | Threshold to determine if the ego vehicle is about to pull out onto a high-speed road                                | 50.0          |
+| publish_debug_marker                           | -     | bool   | Flag to publish debug markers                                                                                        | false         |
+| rss_params.rear_vehicle_reaction_time          | [s]   | double | Reaction time for rear vehicles                                                                                      | 2.0           |
+| rss_params.rear_vehicle_safety_time_margin     | [s]   | double | Safety time margin for rear vehicles                                                                                 | 1.0           |
+| rss_params.lateral_distance_max_threshold      | [m]   | double | Maximum lateral distance threshold                                                                                   | 2.0           |
+| rss_params.longitudinal_distance_min_threshold | [m]   | double | Minimum longitudinal distance threshold                                                                              | 3.0           |
+| rss_params.longitudinal_velocity_delta_time    | [s]   | double | Delta time for longitudinal velocity                                                                                 | 0.8           |
+| hysteresis_factor_expand_rate                  | -     | double | Rate to expand/shrink the hysteresis factor                                                                          | 1.0           |
+| collision_check_yaw_diff_threshold             | -     | double | Maximum yaw difference between ego and object when executing rss-based collision checking                            | 1.578         |
 
 ## **Path Generation**
 

--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/config/start_planner.param.yaml
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/config/start_planner.param.yaml
@@ -144,6 +144,8 @@
         safety_check_params:
           # safety check configuration
           enable_safety_check: true
+          prev_light_check_distance: 0.0 # [m] Prevent departure if the previous traffic light (v2i) is green in high speed roads. Set to 0 to disable this feature
+          threshold_speed_for_prev_light_check: 50.0 # [kph] Threshold to determine if the ego vehicle is about to pull out onto a high-speed road
           # collision check parameters
           publish_debug_marker: false
           rss_params:

--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/include/autoware/behavior_path_start_planner_module/data_structs.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/include/autoware/behavior_path_start_planner_module/data_structs.hpp
@@ -166,6 +166,8 @@ struct StartPlannerParameters
   utils::path_safety_checker::EgoPredictedPathParams ego_predicted_path_params{};
   utils::path_safety_checker::ObjectsFilteringParams objects_filtering_params{};
   utils::path_safety_checker::SafetyCheckParams safety_check_params{};
+  double prev_light_check_distance{0.0};
+  double threshold_speed_for_prev_light_check{0.0};
 
   // surround moving obstacle check
   double search_radius{0.0};

--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/include/autoware/behavior_path_start_planner_module/start_planner_module.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/include/autoware/behavior_path_start_planner_module/start_planner_module.hpp
@@ -316,6 +316,8 @@ ego pose.
   // turn signal
   TurnSignalInfo calcTurnSignalInfo();
 
+  bool canDepartConsideringPrevLightInfo();
+
   void incrementPathIndex();
   PathWithLaneId getCurrentPath() const;
   void planWithPriority(

--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/data_structs.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/data_structs.cpp
@@ -276,6 +276,10 @@ StartPlannerParameters StartPlannerParameters::init(rclcpp::Node & node)
   {
     p.safety_check_params.enable_safety_check =
       get_or_declare_parameter<bool>(node, safety_check_ns + "enable_safety_check");
+    p.prev_light_check_distance =
+      get_or_declare_parameter<double>(node, safety_check_ns + "prev_light_check_distance");
+    p.threshold_speed_for_prev_light_check = get_or_declare_parameter<double>(
+      node, safety_check_ns + "threshold_speed_for_prev_light_check");
     p.safety_check_params.hysteresis_factor_expand_rate =
       get_or_declare_parameter<double>(node, safety_check_ns + "hysteresis_factor_expand_rate");
     p.safety_check_params.backward_path_length =

--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/manager.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/manager.cpp
@@ -336,6 +336,11 @@ void StartPlannerModuleManager::updateModuleParams(
       parameters, safety_check_ns + "enable_safety_check",
       p->safety_check_params.enable_safety_check);
     update_param<double>(
+      parameters, safety_check_ns + "prev_light_check_distance", p->prev_light_check_distance);
+    update_param<double>(
+      parameters, safety_check_ns + "threshold_speed_for_prev_light_check",
+      p->threshold_speed_for_prev_light_check);
+    update_param<double>(
       parameters, safety_check_ns + "hysteresis_factor_expand_rate",
       p->safety_check_params.hysteresis_factor_expand_rate);
     update_param<double>(

--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/start_planner_module.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/start_planner_module.cpp
@@ -21,6 +21,8 @@
 #include "autoware/behavior_path_start_planner_module/util.hpp"
 #include "autoware/motion_utils/trajectory/trajectory.hpp"
 
+#include <autoware/behavior_path_planner_common/utils/traffic_light_utils.hpp>
+#include <autoware/traffic_light_utils/traffic_light_utils.hpp>
 #include <autoware_lanelet2_extension/utility/message_conversion.hpp>
 #include <autoware_lanelet2_extension/utility/query.hpp>
 #include <autoware_lanelet2_extension/utility/utilities.hpp>
@@ -264,8 +266,10 @@ void StartPlannerModule::updateData()
     DEBUG_PRINT("StartPlannerModule::updateData() completed backward driving");
   }
 
-  status_.is_safe_dynamic_objects =
-    (!requiresDynamicObjectsCollisionDetection()) ? true : !hasCollisionWithDynamicObjects();
+  status_.is_safe_dynamic_objects = !requiresDynamicObjectsCollisionDetection() ? true
+                                    : !canDepartConsideringPrevLightInfo()
+                                      ? false
+                                      : !hasCollisionWithDynamicObjects();
 }
 
 bool StartPlannerModule::hasFinishedBackwardDriving() const
@@ -1541,6 +1545,9 @@ TurnSignalInfo StartPlannerModule::calcTurnSignalInfo()
   const auto path = getFullPath();
   if (path.points.empty()) return getPreviousModuleOutput().turn_signal_info;
 
+  if (requiresDynamicObjectsCollisionDetection() && !canDepartConsideringPrevLightInfo())
+    return getPreviousModuleOutput().turn_signal_info;
+
   const Pose & current_pose = planner_data_->self_odometry->pose.pose;
   const auto shift_start_idx = autoware::motion_utils::findNearestIndex(
     path.points, status_.pull_out_path.start_pose.position);
@@ -1608,6 +1615,112 @@ TurnSignalInfo StartPlannerModule::calcTurnSignalInfo()
     planner_data_->parameters.ego_nearest_yaw_threshold);
 
   return output_turn_signal_info;
+}
+
+bool StartPlannerModule::canDepartConsideringPrevLightInfo()
+{
+  // No need to check or search previous traffic light info
+  if (status_.has_departed || parameters_->prev_light_check_distance <= 0.0) return true;
+
+  const auto & rh = planner_data_->route_handler;
+  const auto & lanelet_map_ptr = rh->getLaneletMapPtr();
+  const Pose & current_pose = planner_data_->self_odometry->pose.pose;
+
+  // Get max speed around ego current pose
+  const auto max_speed_around_ego = std::invoke([&]() -> std::optional<double> {
+    const auto vehicle_footprint = autoware_utils::transform_vector(
+      vehicle_info_.createFootprint(), autoware_utils::pose2transform(current_pose));
+    lanelet::BasicPolygon2d footprint_polygon;
+    for (const auto & point : vehicle_footprint) {
+      footprint_polygon.push_back({point.x(), point.y()});
+    }
+
+    // Find lanelets that intersect with the current vehicle footprint
+    const auto & lanelets_distance_pair = lanelet::geometry::findWithin2d(
+      planner_data_->route_handler->getLaneletMapPtr()->laneletLayer, footprint_polygon, 0.0);
+    if (lanelets_distance_pair.empty()) return {};
+
+    double max_speed = 0.0;
+    // Check intersecting lanelets and their neighbor lanelets
+    for (const auto & [_, lanelet] : lanelets_distance_pair) {
+      const double lanelet_speed = lanelet.attributeOr(lanelet::AttributeName::SpeedLimit, 0.0);
+      max_speed = std::max(max_speed, lanelet_speed);
+
+      const auto right_neighbor_lanelets =
+        lanelet_map_ptr->laneletLayer.findUsages(lanelet.rightBound());
+      for (const auto & right_lanelet : right_neighbor_lanelets) {
+        const double right_lanelet_speed =
+          right_lanelet.attributeOr(lanelet::AttributeName::SpeedLimit, 0.0);
+        max_speed = std::max(max_speed, right_lanelet_speed);
+      }
+    }
+    return max_speed;
+  });
+
+  if (!max_speed_around_ego) return true;
+
+  // Ego is not going to pull out into a high-speed road
+  if (max_speed_around_ego.value() < parameters_->threshold_speed_for_prev_light_check) return true;
+
+  lanelet::ConstLanelet current_lanelet;
+  rh->getClosestLaneletWithinRoute(current_pose, &current_lanelet);
+
+  // Calculate ego arc coordinates on current lanelet
+  const auto ego_arc_coordinate =
+    lanelet::utils::getArcCoordinates({current_lanelet}, current_pose);
+
+  const double search_distance_before_current_lanelet =
+    parameters_->prev_light_check_distance - ego_arc_coordinate.length;
+  if (search_distance_before_current_lanelet <= 0.0) return true;
+
+  std::vector<lanelet::ConstLanelets> lanelet_sequences =
+    rh->getPrecedingLaneletSequence(current_lanelet, search_distance_before_current_lanelet);
+  if (lanelet_sequences.empty()) return true;
+
+  // Get closest traffic light info within the allowed distance range
+  // This search considers only first straight lanelet with traffic light in the intersection
+  const auto traffic_signal_stamped = std::invoke([&]() -> std::optional<TrafficSignalStamped> {
+    for (auto & lanelet_sequence : lanelet_sequences) {
+      double distance_to_stop_line = 0.0;
+      std::reverse(lanelet_sequence.begin(), lanelet_sequence.end());
+      for (const auto & preceding_lanelet : lanelet_sequence) {
+        const std::string turn_direction = preceding_lanelet.attributeOr("turn_direction", "none");
+        const auto & tl_reg_elements =
+          preceding_lanelet.regulatoryElementsAs<lanelet::TrafficLight>();
+        if (turn_direction == "straight") {
+          for (const auto & reg_elem : tl_reg_elements) {
+            const auto tl_stop_line = reg_elem->stopLine();
+
+            if (!tl_stop_line.has_value()) continue;
+
+            distance_to_stop_line +=
+              lanelet::utils::getLaneletLength2d(preceding_lanelet) -
+              lanelet::geometry::toArcCoordinates(
+                lanelet::utils::to2D(preceding_lanelet.centerline()),
+                lanelet::utils::to2D(tl_stop_line.value()).front().basicPoint())
+                .length;
+
+            if (distance_to_stop_line <= search_distance_before_current_lanelet) {
+              return planner_data_->getTrafficSignal(reg_elem->id());
+            }
+          }
+        }
+        distance_to_stop_line += lanelet::utils::getLaneletLength2d(preceding_lanelet);
+      }
+    }
+    return {};
+  });
+
+  // Related traffic light info is not available
+  if (!traffic_signal_stamped) return true;
+
+  // Related traffic light is not green
+  if (!autoware::traffic_light_utils::hasTrafficLightCircleColor(
+        traffic_signal_stamped->signal.elements,
+        autoware_perception_msgs::msg::TrafficLightElement::GREEN))
+    return true;
+
+  return false;
 }
 
 bool StartPlannerModule::isSafePath() const


### PR DESCRIPTION
## Description

❗ Must be tested with and merged after following PRs:

- https://github.com/autowarefoundation/autoware_launch/pull/1550

This PR add the feature to prevent departure if the previous traffic light (v2i) is green in high speed roads

![BusStopPullOut-ConsiderPreviousTrafficLight](https://github.com/user-attachments/assets/8a68c779-110a-4a6c-b735-7f53258de246)

## Related links

**Parent Issue:**

- https://github.com/autowarefoundation/autoware_universe/issues/10963

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added | `prev_light_check_distance`   | `double` | `0.0`         | Prevent departure if the previous traffic light (v2i) is green in high speed roads. Set to 0 to disable this feature |
| Added | `threshold_speed_for_prev_light_check`   | `double` | `50.0`         |Threshold to determine if the ego vehicle is about to pull out onto a high-speed road  |

## Effects on system behavior

None.
