### PR TITLE
feat(mission_planner): manual lane selection

### DIFF
--- a/autoware_planning_msgs/CMakeLists.txt
+++ b/autoware_planning_msgs/CMakeLists.txt
@@ -15,6 +15,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/PathPoint.msg"
   "msg/RouteState.msg"
   "srv/ClearRoute.srv"
+  "srv/SetLaneChangeOverride.srv"
   "srv/SetLaneletRoute.srv"
   "srv/SetWaypointRoute.srv"
   DEPENDENCIES

--- a/autoware_planning_msgs/srv/SetLaneChangeOverride.srv
+++ b/autoware_planning_msgs/srv/SetLaneChangeOverride.srv
@@ -1,0 +1,3 @@
+uint8 lane_change_direction
+---
+autoware_common_msgs/ResponseStatus status


### PR DESCRIPTION
## Description
Allows the user to force a lane change using an rviz UI.

## Related links

**Parent Issue:**

- [Link](https://tier4.atlassian.net/browse/RT1-10751)

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
Example use-cases:

[left-lane change.webm](https://github.com/user-attachments/assets/fad6ede7-122d-452d-b1de-4f2e23bd61dd)

Rejecting requests when the current lane does not have a shiftable lane:
[current_lane_reject.webm](https://github.com/user-attachments/assets/a56d5498-862f-4030-8e47-4c529d9bebe8)


## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
