### PR TITLE
fix(roi_cluster_fusion): fix bug in debug mode

### DIFF
--- a/perception/autoware_image_projection_based_fusion/src/roi_cluster_fusion/node.cpp
+++ b/perception/autoware_image_projection_based_fusion/src/roi_cluster_fusion/node.cpp
@@ -103,6 +103,7 @@ void RoiClusterFusionNode::fuse_on_single_image(
   std::vector<sensor_msgs::msg::RegionOfInterest> debug_image_rois;
   std::vector<Eigen::Vector2d> debug_obstacle_points;
   std::vector<sensor_msgs::msg::RegionOfInterest> debug_obstacle_rois;
+  std::vector<double> debug_max_iou_for_image_rois;
 
   for (std::size_t i = 0; i < input_cluster_msg.feature_objects.size(); ++i) {
     if (input_cluster_msg.feature_objects.at(i).feature.cluster.data.empty()) {
@@ -210,7 +211,7 @@ void RoiClusterFusionNode::fuse_on_single_image(
       }
     }
     if (debugger_) debug_image_rois.push_back(feature_obj.feature.roi);
-    if (debugger_) debugger_->max_iou_for_image_rois_.push_back(max_iou);
+    if (debugger_) debug_max_iou_for_image_rois.push_back(max_iou);
   }
 
   // note: debug objects are safely cleared in fusion_node.cpp
@@ -219,6 +220,7 @@ void RoiClusterFusionNode::fuse_on_single_image(
     debugger_->image_rois_ = debug_image_rois;
     debugger_->obstacle_rois_ = debug_obstacle_rois;
     debugger_->obstacle_points_ = debug_obstacle_points;
+    debugger_->max_iou_for_image_rois_ = debug_max_iou_for_image_rois;
     debugger_->publishImage(det2d_status.id, input_rois_msg.header.stamp);
   }
 }


### PR DESCRIPTION
## Description
- This is a quick fix for a bug in the debug mode of `roi_cluster_fusion`.
- The ROIs from YOLOX, the obstacle point cloud, and the cluster ROIs were being duplicated and incorrectly projected.
- `debugger_` usage might be revised more carefully.
- How to reproduce:
  - Run logging_simulator with  [debug_mode: true](https://github.com/autowarefoundation/autoware_launch/blob/2bb1b82b79c70c8a690e2b297aee41e05acac38a/autoware_launch/config/perception/object_recognition/detection/image_projection_based_fusion/fusion_common.param.yaml#L26)
  - Check debug image such as: `/perception/object_recognition/detection/clustering/camera_lidar_fusion/roi_cluster_fusion/debug/image_raw_x`
  - Make sure `/sensing/camera/camera_x/image_raw` is also published
<img width="720" height="414" alt="image" src="https://github.com/user-attachments/assets/86fbf8e1-bcef-4f54-9ce6-232d0e348611" />


## Related links

**Parent Issue:**

- [TIER IV internal link](https://tier4.atlassian.net/browse/RT1-10798)
<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

- Confirmed by logging_simulator that the debug image is correct
[Screencast from 2025年07月24日 17時09分15秒.webm](https://github.com/user-attachments/assets/fb4534a6-e22c-450c-bc8d-f8c2ff6477d1)



## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
