### PR TITLE
fix(start_planner): incorrect function call

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/clothoid_pull_out.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/clothoid_pull_out.cpp
@@ -1400,7 +1400,7 @@ std::optional<PullOutPath> ClothoidPullOut::plan(
 
     // crop backward path
     const size_t start_segment_idx =
-      autoware::motion_utils::findFirstNearestIndexWithSoftConstraints(
+      autoware::motion_utils::findFirstNearestSegmentIndexWithSoftConstraints(
         clothoid_path.points, start_pose, common_parameters.ego_nearest_dist_threshold,
         common_parameters.ego_nearest_yaw_threshold);
 

--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/shift_pull_out.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/shift_pull_out.cpp
@@ -128,7 +128,7 @@ std::optional<PullOutPath> ShiftPullOut::plan(
     // narrow place.
 
     const size_t start_segment_idx =
-      autoware::motion_utils::findFirstNearestIndexWithSoftConstraints(
+      autoware::motion_utils::findFirstNearestSegmentIndexWithSoftConstraints(
         shift_path.points, start_pose, common_parameters.ego_nearest_dist_threshold,
         common_parameters.ego_nearest_yaw_threshold);
 


### PR DESCRIPTION
## Description

Fix incorrect function calls in autoware behavior path planner modules that were searching for nearest points instead of nearest segment points.

"segment" refers to the front-side point of the line segment nearest to the point. However, the code was incorrectly calling the function that searches for the nearest point.

- Fixed function call from `findFirstNearestIndexWithSoftConstraints` to `findFirstNearestSegmentIndexWithSoftConstraints` in `clothoid_pull_out.cpp`
- Fixed function call from `findFirstNearestIndexWithSoftConstraints` to `findFirstNearestSegmentIndexWithSoftConstraints` in `shift_pull_out.cpp`

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

- [x] run psim to confirm trajectory can be generated
- [x] PASS TIER IV CI tests
  - [x] https://evaluation.tier4.jp/evaluation/reports/3f08f03a-4daa-5fc2-9343-89561aa22c97?project_id=prd_jt
  - [x] https://evaluation.tier4.jp/evaluation/reports/a288a80a-57c5-5537-b30e-1ae4fcf24d74?project_id=prd_jt
  - [x] https://evaluation.tier4.jp/evaluation/reports/4ccabb36-b17b-5a1c-8e81-68989c5ab1fb?project_id=prd_jt

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
