### PR TITLE
feat(autoware_cuda_dependency_meta): pass -fno-lto compile flag to downstream packages of autoware_cuda_dependency_meta

### DIFF
--- a/common/autoware_cuda_dependency_meta/CMakeLists.txt
+++ b/common/autoware_cuda_dependency_meta/CMakeLists.txt
@@ -3,4 +3,4 @@ project(autoware_cuda_dependency_meta NONE)
 
 find_package(ament_cmake REQUIRED)
 
-ament_package()
+ament_package(CONFIG_EXTRAS autoware_cuda_dependency_meta-extras.cmake)

--- a/common/autoware_cuda_dependency_meta/autoware_cuda_dependency_meta-extras.cmake
+++ b/common/autoware_cuda_dependency_meta/autoware_cuda_dependency_meta-extras.cmake
@@ -1,0 +1,3 @@
+# NOTE(esteve): avoid "symbol `fatbinData' is already defined" errors
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fno-lto")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-lto")


### PR DESCRIPTION
## Description

This PR adds a `CONFIG_EXTRAS` file so that downstream dependencies disable LTO. The Debian packaging tools (`sbuild`, `fakeroot`, etc.) enable LTO by default for all packages, but that optimization is not supported in CUDA and causes link errors.

See https://forums.developer.nvidia.com/t/link-time-optimization-with-cuda-on-linux-flto/55530

## Related links

https://forums.developer.nvidia.com/t/link-time-optimization-with-cuda-on-linux-flto/55530

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
