### PR TITLE
fix(run_out): adjust unfeasible stop points to become feasible

### DIFF
--- a/planning/motion_velocity_planner/autoware_motion_velocity_run_out_module/src/slowdown.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_run_out_module/src/slowdown.cpp
@@ -78,7 +78,6 @@ std::optional<geometry_msgs::msg::Point> calculate_stop_position(
   const auto & check_unfeasible_stop = [&](const auto stop_distance) -> bool {
     const auto stop_decel = (current_velocity * current_velocity) / (2 * stop_distance);
     if (stop_decel > params.stop_deceleration_limit) {
-      unfeasible_stop_deceleration = stop_decel;
       if (stop_decel > unfeasible_stop_deceleration.value_or(0.0)) {
         unfeasible_stop_deceleration = stop_decel;
       }


### PR DESCRIPTION
## Description

Previously, when a stop point was found to be unfeasible (i.e., breaking the deceleration limit), a diagnostic would be published but the stop point would still be used.
This PR modifies the stop points to become feasible by using the minimum stopping distance plus some assumed control delay.

## Related links

**Private Links:**

- [TIER IV JIRA](https://tier4.atlassian.net/browse/RT0-38018?focusedCommentId=249310&sourceType=mention)

## How was this PR tested?

Psim + Reproducer
Evaluator: https://evaluation.tier4.jp/evaluation/reports/87e015ec-b472-59c5-ba07-42e7e2e96561?project_id=x2_dev

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

`run_out` is less likely to publish unfeasible stop points.
