### PR TITLE
fix(motion_velocity_planner): remove unused function

### DIFF
--- a/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/utils.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/utils.hpp
@@ -87,17 +87,6 @@ inline geometry_msgs::msg::Point to_geom_pt(const Point2d & point)
 }
 
 /**
- * @brief Convert a ROS 3D point into a 2D point by discarding the z-component.
- *
- * @param point A ROS point with x, y, z coordinates.
- * @return A 2D point containing only the x and y values.
- */
-inline Point2d to_pt2d(const geometry_msgs::msg::Point & point)
-{
-  return {point.x, point.y};
-}
-
-/**
  * @brief Create grouped intervals of departure points for both sides of the ego vehicle.
  *
  * This function scans through the departure points on the left and right sides of the ego vehicle


### PR DESCRIPTION
## Description

Removed an unused function based on cppcheck
```
planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/utils.hpp:95:16: style: The function 'to_pt2d' is never used. [unusedFunction]
inline Point2d to_pt2d(const geometry_msgs::msg::Point & point)
               ^
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
