### PR TITLE
fix(planning_validator): remove unused function

### DIFF
--- a/planning/planning_validator/autoware_planning_validator_intersection_collision_checker/include/autoware/planning_validator_intersection_collision_checker/utils.hpp
+++ b/planning/planning_validator/autoware_planning_validator_intersection_collision_checker/include/autoware/planning_validator_intersection_collision_checker/utils.hpp
@@ -35,9 +35,6 @@
 namespace autoware::planning_validator::collision_checker_utils
 {
 
-TrajectoryPoints trim_trajectory_points(
-  const TrajectoryPoints & trajectory_points, const geometry_msgs::msg::Pose & start_pose);
-
 void set_trajectory_lanelets(
   const TrajectoryPoints & trajectory_points, const RouteHandler & route_handler,
   const geometry_msgs::msg::Pose & ego_pose, EgoLanelets & lanelets);

--- a/planning/planning_validator/autoware_planning_validator_intersection_collision_checker/src/utils.cpp
+++ b/planning/planning_validator/autoware_planning_validator_intersection_collision_checker/src/utils.cpp
@@ -48,14 +48,6 @@ bool is_turn_lanelet(const lanelet::ConstLanelet & ll)
 }
 }  // namespace
 
-TrajectoryPoints trim_trajectory_points(
-  const TrajectoryPoints & trajectory_points, const geometry_msgs::msg::Pose & start_pose)
-{
-  const auto nearest_idx =
-    autoware::motion_utils::findNearestIndex(trajectory_points, start_pose.position);
-  return TrajectoryPoints(trajectory_points.begin() + nearest_idx, trajectory_points.end());
-}
-
 void set_trajectory_lanelets(
   const TrajectoryPoints & trajectory_points, const RouteHandler & route_handler,
   const geometry_msgs::msg::Pose & ego_pose, EgoLanelets & lanelets)


### PR DESCRIPTION
## Description

Removed an unused function based on cppcheck
```
planning/planning_validator/autoware_planning_validator_intersection_collision_checker/src/utils.cpp:51:18: style: The function 'trim_trajectory_points' is never used. [unusedFunction]
TrajectoryPoints trim_trajectory_points(
                 ^
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
