### PR TITLE
fix(autoware_processing_time_checker): remove unused function

### DIFF
--- a/system/autoware_processing_time_checker/src/digestible.hpp
+++ b/system/autoware_processing_time_checker/src/digestible.hpp
@@ -211,11 +211,6 @@ public:
   double quantile(double p) const;
 
   /**
-   * Return number of centroids in the t-digest
-   */
-  size_t centroid_count() const { return (*active).values.size(); }
-
-  /**
    * Retrieve the number of merged data points in the t-digest
    *
    * @return


### PR DESCRIPTION
## Description

Removed unused function based on cppcheck

```
system/autoware_processing_time_checker/src/digestible.hpp:216:10: style: The function 'centroid_count' is never used. [unusedFunction]
  size_t centroid_count() const { return (*active).values.size(); }
         ^
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
