### PR TITLE
feat(steer_offset_estimator): load initial steer offset from arbitrary file and publish steering_offset_error

### DIFF
--- a/vehicle/autoware_steer_offset_estimator/config/steer_offset.param.yaml
+++ b/vehicle/autoware_steer_offset_estimator/config/steer_offset.param.yaml
@@ -1,0 +1,3 @@
+/**:
+  ros__parameters:
+    steer_offset: 0.0  # [rad] offset for steering angle collection

--- a/vehicle/autoware_steer_offset_estimator/include/autoware_steer_offset_estimator/steer_offset_estimator_node.hpp
+++ b/vehicle/autoware_steer_offset_estimator/include/autoware_steer_offset_estimator/steer_offset_estimator_node.hpp
@@ -37,6 +37,7 @@ class SteerOffsetEstimatorNode : public rclcpp::Node
 private:
   rclcpp::Publisher<Float32Stamped>::SharedPtr pub_steer_offset_;
   rclcpp::Publisher<Float32Stamped>::SharedPtr pub_steer_offset_cov_;
+  rclcpp::Publisher<Float32Stamped>::SharedPtr pub_steer_offset_error_;
   rclcpp::Subscription<TwistStamped>::SharedPtr sub_twist_;
   rclcpp::Subscription<Steering>::SharedPtr sub_steer_;
   rclcpp::TimerBase::SharedPtr timer_;
@@ -47,6 +48,7 @@ private:
   double update_hz_;
   double estimated_steer_offset_{0.0};
   double covariance_;
+  double initial_steer_offset_;
   double forgetting_factor_;
   double valid_min_velocity_;
   double valid_max_steer_;

--- a/vehicle/autoware_steer_offset_estimator/launch/steer_offset_estimator.launch.xml
+++ b/vehicle/autoware_steer_offset_estimator/launch/steer_offset_estimator.launch.xml
@@ -1,22 +1,26 @@
 <launch>
   <!-- Parameter -->
   <arg name="config_file" default="$(find-pkg-share autoware_steer_offset_estimator)/config/steer_offset_estimator.param.yaml"/>
-
+  <arg name="initial_steer_offset_param_path" default="$(find-pkg-share autoware_steer_offset_estimator)/config/steer_offset.param.yaml"/>
+  <arg name="initial_steer_offset_param_name" default="steer_offset"/>
   <!-- get wheel base from vehicle info -->
   <include file="$(find-pkg-share autoware_global_parameter_loader)/launch/global_params.launch.py"/>
 
   <!-- ndt twist publisher -->
   <include file="$(find-pkg-share autoware_pose2twist)/launch/pose2twist.launch.xml">
     <arg name="input_pose_topic" value="/localization/pose_estimator/pose"/>
-    <arg name="output_twist_topic" value="/estimate_twist"/>
+    <arg name="output_twist_topic" value="estimate_twist"/>
   </include>
 
   <!-- steer offset estimator -->
   <node pkg="autoware_steer_offset_estimator" exec="steer_offset_estimator" name="steer_offset_estimator" output="screen">
     <param from="$(var config_file)"/>
-    <remap from="~/input/twist" to="$(var output_twist_topic)"/>
+    <param from="$(var initial_steer_offset_param_path)"/>
+    <param name="initial_steer_offset_param_name" value="$(var initial_steer_offset_param_name)"/>
+    <remap from="~/input/twist" to="estimate_twist"/>
     <remap from="~/input/steer" to="/vehicle/status/steering_status"/>
-    <remap from="~/output/steering_offset" to="/vehicle/status/steering_offset"/>
-    <remap from="~/output/steering_offset_covariance" to="/vehicle/status/steering_offset_covariance"/>
+    <remap from="~/output/steering_offset" to="~/steering_offset"/>
+    <remap from="~/output/steering_offset_covariance" to="~/steering_offset_covariance"/>
+    <remap from="~/output/steering_offset_error" to="~/steering_offset_error"/>
   </node>
 </launch>


### PR DESCRIPTION
## Description

Added steering offset error monitoring to the autoware_steer_offset_estimator package.

Publishes the difference between estimated and initial steering offset (estimated_steer_offset - initial_steer_offset)

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
