### PR TITLE
build(autoware_cuda_pointcloud_preprocessor): react to ENABLE_AGNOCAST env var

### DIFF
--- a/sensing/autoware_cuda_pointcloud_preprocessor/CMakeLists.txt
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/CMakeLists.txt
@@ -13,8 +13,8 @@ elseif(CMAKE_BUILD_TYPE STREQUAL "Debug")
   set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS} "-g -G")
 endif()
 
-if(USE_AGNOCAST AND NOT agnocastlib_FOUND)
-  message(FATAL_ERROR "agnocastlib is required when USE_AGNOCAST is enabled")
+if("$ENV{ENABLE_AGNOCAST}" AND NOT agnocastlib_FOUND)
+  message(FATAL_ERROR "agnocastlib is required when Agnocast is enabled")
 endif()
 
 ament_auto_find_build_dependencies()
@@ -28,7 +28,8 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     add_compile_options(-Wall -Wextra -Wpedantic -Wunused-function)
 endif()
 
-if(USE_AGNOCAST)
+if("$ENV{ENABLE_AGNOCAST}")
+    message("Agnocast support is enabled")
     add_definitions(-DUSE_AGNOCAST_ENABLED)
 endif()
 
@@ -90,7 +91,7 @@ target_include_directories(cuda_pointcloud_preprocessor_lib SYSTEM PRIVATE
   ${autoware_cuda_utils_INCLUDE_DIRS}
 )
 
-if(USE_AGNOCAST)
+if("$ENV{ENABLE_AGNOCAST}")
     target_include_directories(cuda_pointcloud_preprocessor_lib SYSTEM PRIVATE
         ${autoware_agnocast_wrapper_INCLUDE_DIRS}
         ${agnocastlib_INCLUDE_DIRS}


### PR DESCRIPTION
## Description

This PR removes the `-DUSE_AGNOCAST` CMake option and adds support for the environment variable `ENABLE_AGNOCAST`.

## Related links

- [TIER IV INTERNAL LINK](https://star4.slack.com/archives/CRUE57C30/p1755828375355709?thread_ts=1755669594.416389&cid=CRUE57C30) -- internal request

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

Tested on my local machine (build+run) with `ENABLE_AGNOCAST=0` and `ENABLE_AGNOCAST=1`.

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
