### PR TITLE
fix(fusion node): subscribe from concatenation info

### DIFF
--- a/launch/tier4_perception_launch/launch/object_recognition/detection/detection.launch.xml
+++ b/launch/tier4_perception_launch/launch/object_recognition/detection/detection.launch.xml
@@ -242,6 +242,7 @@
       <arg name="pipeline_ns" value="$(var irregular_object_detector_ns)"/>
       <arg name="fusion_camera_ids" value="$(var irregular_object_detector_fusion_camera_ids)"/>
       <arg name="image_topic_name" value="$(var image_topic_name)"/>
+      <arg name="input/concatenation_info" value="$(var input/concatenation_info)"/>
       <arg name="input/pointcloud" value="$(var input/pointcloud)"/>
       <arg name="output/objects" value="$(var irregular_object_pipeline/output/objects)"/>
       <arg name="irregular_object_detector_param_path" value="$(var irregular_object_detector_param_path)"/>

--- a/launch/tier4_perception_launch/launch/object_recognition/detection/detection.launch.xml
+++ b/launch/tier4_perception_launch/launch/object_recognition/detection/detection.launch.xml
@@ -84,6 +84,7 @@
   <arg name="input/camera8/image"/>
   <arg name="input/camera8/info"/>
   <arg name="input/camera8/rois"/>
+  <arg name="input/concatenation_info"/>
   <arg name="image_topic_name"/>
   <arg name="segmentation_pointcloud_fusion_camera_ids"/>
   <arg name="input/radar"/>
@@ -214,6 +215,7 @@
       <arg name="input/camera8/image" value="$(var input/camera8/image)"/>
       <arg name="input/camera8/info" value="$(var input/camera8/info)"/>
       <arg name="input/camera8/rois" value="$(var input/camera8/rois)"/>
+      <arg name="input/concatenation_info" value="$(var input/concatenation_info)"/>
       <arg name="input/pointcloud" value="$(var input/pointcloud)"/>
       <arg name="input/pointcloud_map/pointcloud" value="$(var pointcloud_filter/output/pointcloud)"/>
       <arg name="input/obstacle_segmentation/pointcloud" value="$(var input/obstacle_segmentation/pointcloud)"/>

--- a/launch/tier4_perception_launch/launch/object_recognition/detection/detector/camera_lidar_detector.launch.xml
+++ b/launch/tier4_perception_launch/launch/object_recognition/detection/detector/camera_lidar_detector.launch.xml
@@ -54,6 +54,8 @@
   <arg name="input/camera8/info"/>
   <arg name="input/camera8/rois"/>
 
+  <arg name="input/concatenation_info"/>
+
   <arg name="segmentation_pointcloud_fusion_camera_ids"/>
   <arg name="image_topic_name"/>
 
@@ -137,6 +139,7 @@
       <arg name="input/image7" value="$(var input/camera7/image)"/>
       <arg name="input/image8" value="$(var input/camera8/image)"/>
       <arg name="input/pointcloud" value="$(var pointpainting/input/pointcloud)"/>
+      <arg name="input/concatenation_info" value="$(var input/concatenation_info)"/>
       <arg name="output/objects" value="$(var pointpainting/output/objects)"/>
 
       <arg name="model_name" value="$(var lidar_detection_model_name)"/>
@@ -153,6 +156,7 @@
   <!-- Image_segmentation based filter, apply for camera0 only-->
   <group>
     <include file="$(find-pkg-share autoware_image_projection_based_fusion)/launch/segmentation_pointcloud_fusion.launch.py" if="$(var use_image_segmentation_based_filter)">
+      <arg name="input/concatenation_info" value="$(var input/concatenation_info)"/>
       <arg name="input/pointcloud" value="$(var segmentation_based_filtered/input/pointcloud)"/>
       <arg name="output/pointcloud" value="$(var segmentation_based_filtered/output/pointcloud)"/>
       <arg name="image_topic_name" value="$(var image_topic_name)"/>
@@ -215,6 +219,7 @@
           <arg name="input/image6" value="$(var input/camera6/image)"/>
           <arg name="input/image7" value="$(var input/camera7/image)"/>
           <arg name="input/image8" value="$(var input/camera8/image)"/>
+          <arg name="input/concatenation_info" value="$(var input/concatenation_info)"/>
           <arg name="input/clusters" value="$(var roi_cluster_fusion/input/clusters)"/>
           <arg name="output/clusters" value="$(var roi_cluster_fusion/output/clusters)"/>
           <arg name="param_path" value="$(var roi_cluster_fusion_param_path)"/>

--- a/launch/tier4_perception_launch/launch/object_recognition/detection/detector/camera_lidar_irregular_object_detector.launch.xml
+++ b/launch/tier4_perception_launch/launch/object_recognition/detection/detector/camera_lidar_irregular_object_detector.launch.xml
@@ -3,6 +3,7 @@
   <!-- Current namespace -->
   <arg name="ns" description="current namespace"/>
   <arg name="pipeline_ns" description="pipeline namespace"/>
+  <arg name="input/concatenation_info"/>
   <arg name="input/pointcloud"/>
   <arg name="fusion_camera_ids" default="[0]" description="camera IDs used for fusion"/>
   <arg name="image_topic_name" default="image_raw" description="topic name of camera image"/>
@@ -12,6 +13,7 @@
     <push-ros-namespace namespace="$(var pipeline_ns)"/>
     <group>
       <include file="$(find-pkg-share tier4_perception_launch)/launch/object_recognition/detection/detector/camera_lidar_irregular_object_detector.launch.py">
+        <arg name="input/concatenation_info" value="$(var input/concatenation_info)"/>
         <arg name="input/pointcloud" value="$(var input/pointcloud)"/>
         <arg name="output_topic" value="clusters"/>
         <arg name="pointcloud_container_name" value="$(var node/pointcloud_container)"/>

--- a/launch/tier4_perception_launch/launch/object_recognition/detection/merger/camera_lidar_merger.launch.xml
+++ b/launch/tier4_perception_launch/launch/object_recognition/detection/merger/camera_lidar_merger.launch.xml
@@ -103,6 +103,7 @@
       <arg name="input/image6" value="$(var input/camera6/image)"/>
       <arg name="input/image7" value="$(var input/camera7/image)"/>
       <arg name="input/image8" value="$(var input/camera8/image)"/>
+      <arg name="input/concatenation_info" value="$(var input/concatenation_info)"/>
       <arg name="input/objects" value="$(var detected_object_roi_filter/input/objects)"/>
       <arg name="output/objects" value="$(var detected_object_roi_filter/output/objects)"/>
       <arg name="param_path" value="$(var roi_detected_object_fusion_param_path)"/>

--- a/launch/tier4_perception_launch/launch/object_recognition/detection/merger/camera_lidar_radar_merger.launch.xml
+++ b/launch/tier4_perception_launch/launch/object_recognition/detection/merger/camera_lidar_radar_merger.launch.xml
@@ -115,6 +115,7 @@
       <arg name="input/image6" value="$(var input/camera6/image)"/>
       <arg name="input/image7" value="$(var input/camera7/image)"/>
       <arg name="input/image8" value="$(var input/camera8/image)"/>
+      <arg name="input/concatenation_info" value="$(var input/concatenation_info)"/>
       <arg name="input/objects" value="$(var detected_object_roi_filter/input/objects)"/>
       <arg name="output/objects" value="$(var detected_object_roi_filter/output/objects)"/>
       <arg name="param_path" value="$(var roi_detected_object_fusion_param_path)"/>

--- a/launch/tier4_perception_launch/launch/perception.launch.xml
+++ b/launch/tier4_perception_launch/launch/perception.launch.xml
@@ -123,6 +123,7 @@
   <arg name="segmentation_pointcloud_fusion_camera_ids" default="[0,1,5]" description="list of camera ids used for segmentation_pointcloud_fusion node"/>
   <arg name="ml_camera_lidar_merger_priority_mode" default="0" description="priority mode for ml and camera_lidar merger, options: `0: Object0`, `1: Object1`, `2: ConfidenceBased`, `3: ClassBased`"/>
   <arg name="pointcloud_container_name" default="pointcloud_container"/>
+  <arg name="input/concatenation_info" default="/sensing/lidar/concatenated/pointcloud_info"/>
 
   <!-- Pipeline junctions -->
   <arg name="use_vector_map" default="true" description="use vector map in prediction"/>
@@ -285,6 +286,7 @@
           <arg name="input/camera8/image" value="$(var image_raw8)"/>
           <arg name="input/camera8/info" value="$(var camera_info8)"/>
           <arg name="input/camera8/rois" value="$(var detection_rois8)"/>
+          <arg name="input/concatenation_info" value="$(var input/concatenation_info)"/>
           <arg name="input/pointcloud" value="$(var perception_pointcloud)"/>
           <arg name="node/pointcloud_container" value="$(var pointcloud_container_name)"/>
           <arg name="input/radar" value="$(var input/radar)"/>

--- a/perception/autoware_image_projection_based_fusion/README.md
+++ b/perception/autoware_image_projection_based_fusion/README.md
@@ -116,9 +116,8 @@ If the interval is less than the match threshold, the messages are considered ma
 
 If the concatenation node from the Autoware point cloud preprocessor is being used, enable this mode.
 The advanced mode parses diagnostics from the concatenation node to verify whether all point clouds have been successfully concatenated. If concatenation is incomplete, it dynamically adjusts `rois_timestamp_offsets` based on diagnostic messages.
-Instead of using a fixed threshold, this mode requires setting three parameters:
+Instead of using a fixed threshold, this mode requires setting two parameters:
 
-- `concatenation_info_topic` (a string, from pointcloud concatenation node)
 - `msg3d_noise_window` (a single value)
 - `rois_timestamp_noise_window` (a vector)
 
@@ -129,7 +128,6 @@ These parameters enforce stricter matching between the `RoI` messages and `msg3d
   ```bash
     matching_strategy:
       type: advanced
-      concatenation_info_topic: "/sensing/lidar/concatenated/pointcloud_info"
       msg3d_noise_window: 0.02
       rois_timestamp_noise_window: [0.01, 0.01, 0.01, 0.01, 0.01, 0.01]
   ```

--- a/perception/autoware_image_projection_based_fusion/README.md
+++ b/perception/autoware_image_projection_based_fusion/README.md
@@ -116,8 +116,9 @@ If the interval is less than the match threshold, the messages are considered ma
 
 If the concatenation node from the Autoware point cloud preprocessor is being used, enable this mode.
 The advanced mode parses diagnostics from the concatenation node to verify whether all point clouds have been successfully concatenated. If concatenation is incomplete, it dynamically adjusts `rois_timestamp_offsets` based on diagnostic messages.
-Instead of using a fixed threshold, this mode requires setting two parameters:
+Instead of using a fixed threshold, this mode requires setting three parameters:
 
+- `concatenation_info_topic` (a string, from pointcloud concatenation node)
 - `msg3d_noise_window` (a single value)
 - `rois_timestamp_noise_window` (a vector)
 
@@ -128,6 +129,7 @@ These parameters enforce stricter matching between the `RoI` messages and `msg3d
   ```bash
     matching_strategy:
       type: advanced
+      concatenation_info_topic: "/sensing/lidar/concatenated/pointcloud_info"
       msg3d_noise_window: 0.02
       rois_timestamp_noise_window: [0.01, 0.01, 0.01, 0.01, 0.01, 0.01]
   ```

--- a/perception/autoware_image_projection_based_fusion/config/fusion_common.param.yaml
+++ b/perception/autoware_image_projection_based_fusion/config/fusion_common.param.yaml
@@ -30,7 +30,6 @@
 
     publish_previous_but_late_output_msg: false
     rosbag_length: 10.0
-
     # matching strategy
     matching_strategy:
       type: advanced

--- a/perception/autoware_image_projection_based_fusion/config/fusion_common.param.yaml
+++ b/perception/autoware_image_projection_based_fusion/config/fusion_common.param.yaml
@@ -31,12 +31,10 @@
     publish_previous_but_late_output_msg: false
     rosbag_length: 10.0
 
-    # concatenation info topic for advanced matching strategy
-    concatenation_info_topic: "/sensing/lidar/concatenated/pointcloud_info"
-
     # matching strategy
     matching_strategy:
       type: advanced
+      concatenation_info_topic: "/sensing/lidar/concatenated/pointcloud_info"
       msg3d_noise_window: 0.02
       rois_timestamp_noise_window: [0.01, 0.01, 0.01, 0.01, 0.01, 0.01]
       # type: naive

--- a/perception/autoware_image_projection_based_fusion/config/fusion_common.param.yaml
+++ b/perception/autoware_image_projection_based_fusion/config/fusion_common.param.yaml
@@ -33,7 +33,6 @@
     # matching strategy
     matching_strategy:
       type: advanced
-      concatenation_info_topic: "/sensing/lidar/concatenated/pointcloud_info"
       msg3d_noise_window: 0.02
       rois_timestamp_noise_window: [0.01, 0.01, 0.01, 0.01, 0.01, 0.01]
       # type: naive

--- a/perception/autoware_image_projection_based_fusion/config/fusion_common.param.yaml
+++ b/perception/autoware_image_projection_based_fusion/config/fusion_common.param.yaml
@@ -30,6 +30,10 @@
 
     publish_previous_but_late_output_msg: false
     rosbag_length: 10.0
+
+    # concatenation info topic for advanced matching strategy
+    concatenation_info_topic: "/sensing/lidar/concatenated/pointcloud_info"
+
     # matching strategy
     matching_strategy:
       type: advanced

--- a/perception/autoware_image_projection_based_fusion/include/autoware/image_projection_based_fusion/fusion_matching_strategy.hpp
+++ b/perception/autoware_image_projection_based_fusion/include/autoware/image_projection_based_fusion/fusion_matching_strategy.hpp
@@ -18,6 +18,8 @@
 
 #include <rclcpp/rclcpp.hpp>
 
+#include <autoware_sensing_msgs/msg/concatenated_point_cloud_info.hpp>
+
 #include <cstddef>
 #include <list>
 #include <memory>
@@ -124,9 +126,10 @@ public:
     std::shared_ptr<FusionCollector<Msg3D, Msg2D, ExportObj>> & collector,
     const std::shared_ptr<MatchingContextBase> & matching_context) override;
 
-  double get_concatenated_offset(
+  double get_concatenation_offset(
     const double & msg3d_timestamp,
-    const std::optional<std::unordered_map<std::string, std::string>> & concatenated_status);
+    const std::optional<autoware_sensing_msgs::msg::ConcatenatedPointCloudInfo::SharedPtr> &
+      concatenation_info_msg);
 
   double extract_fractional(double timestamp);
   void update_fractional_timestamp_set(double new_timestamp);

--- a/perception/autoware_image_projection_based_fusion/include/autoware/image_projection_based_fusion/fusion_node.hpp
+++ b/perception/autoware_image_projection_based_fusion/include/autoware/image_projection_based_fusion/fusion_node.hpp
@@ -27,7 +27,7 @@
 #include <rclcpp/rclcpp.hpp>
 
 #include <autoware_perception_msgs/msg/detected_objects.hpp>
-#include <diagnostic_msgs/msg/diagnostic_array.hpp>
+#include <autoware_sensing_msgs/msg/concatenated_point_cloud_info.hpp>
 #include <diagnostic_msgs/msg/diagnostic_status.hpp>
 #include <sensor_msgs/msg/camera_info.hpp>
 #include <sensor_msgs/msg/image.hpp>
@@ -75,8 +75,8 @@ public:
     typename Msg3D::SharedPtr & output_det3d_msg,
     std::unordered_map<std::size_t, double> id_to_stamp_map,
     std::shared_ptr<FusionCollectorInfoBase> collector_info);
-  std::optional<std::unordered_map<std::string, std::string>> find_concatenation_status(
-    double timestamp);
+  std::optional<autoware_sensing_msgs::msg::ConcatenatedPointCloudInfo::SharedPtr>
+  find_concatenation_info(double timestamp);
   void show_diagnostic_message(
     std::unordered_map<std::size_t, double> id_to_stamp_map,
     std::shared_ptr<FusionCollectorInfoBase> collector_info);
@@ -117,7 +117,8 @@ private:
   std::unordered_map<std::size_t, double> id_to_offset_map_;
 
   // timestamp: (key, value)
-  std::unordered_map<double, std::unordered_map<std::string, std::string>> concatenated_status_map_;
+  std::unordered_map<double, autoware_sensing_msgs::msg::ConcatenatedPointCloudInfo::SharedPtr>
+    concatenated_info_map_;
 
   diagnostic_updater::Updater diagnostic_updater_{this};
   std::shared_ptr<FusionCollectorInfoBase> diagnostic_collector_info_;
@@ -141,7 +142,8 @@ protected:
   // callback for rois subscription
   void rois_callback(const typename Msg2D::ConstSharedPtr rois_msg, const std::size_t rois_id);
 
-  void diagnostic_callback(const diagnostic_msgs::msg::DiagnosticArray::SharedPtr diagnostic_msg);
+  void concatenation_info_callback(
+    const autoware_sensing_msgs::msg::ConcatenatedPointCloudInfo::SharedPtr concatenation_info_msg);
 
   // Custom process methods
   virtual void postprocess(const Msg3D & processing_msg, ExportObj & output_msg);
@@ -156,7 +158,8 @@ protected:
 
   // 3d detection subscription
   typename rclcpp::Subscription<Msg3D>::SharedPtr msg3d_sub_;
-  rclcpp::Subscription<diagnostic_msgs::msg::DiagnosticArray>::SharedPtr sub_diag_;
+  rclcpp::Subscription<autoware_sensing_msgs::msg::ConcatenatedPointCloudInfo>::SharedPtr
+    sub_concatenation_info_;
 
   // parameters for out_of_scope filter
   float filter_scope_min_x_;

--- a/perception/autoware_image_projection_based_fusion/include/autoware/image_projection_based_fusion/fusion_node.hpp
+++ b/perception/autoware_image_projection_based_fusion/include/autoware/image_projection_based_fusion/fusion_node.hpp
@@ -28,7 +28,6 @@
 
 #include <autoware_perception_msgs/msg/detected_objects.hpp>
 #include <autoware_sensing_msgs/msg/concatenated_point_cloud_info.hpp>
-#include <diagnostic_msgs/msg/diagnostic_status.hpp>
 #include <sensor_msgs/msg/camera_info.hpp>
 #include <sensor_msgs/msg/image.hpp>
 #include <sensor_msgs/point_cloud2_iterator.hpp>

--- a/perception/autoware_image_projection_based_fusion/launch/roi_cluster_fusion.launch.xml
+++ b/perception/autoware_image_projection_based_fusion/launch/roi_cluster_fusion.launch.xml
@@ -19,6 +19,7 @@
   <arg name="input/rois8" default="rois8"/>
   <arg name="input/camera_info8" default="/camera_info8"/>
   <arg name="input/clusters" default="clusters"/>
+  <arg name="input/concatenation_info" default="/sensing/lidar/concatenated/pointcloud_info"/>
   <arg name="output/clusters" default="labeled_clusters"/>
   <arg name="param_path" default="$(find-pkg-share autoware_image_projection_based_fusion)/config/roi_cluster_fusion.param.yaml"/>
   <arg name="sync_param_path" default="$(find-pkg-share autoware_image_projection_based_fusion)/config/fusion_common.param.yaml"/>
@@ -39,6 +40,7 @@
       <param from="$(var param_path)"/>
       <param from="$(var sync_param_path)"/>
       <remap from="input" to="$(var input/clusters)"/>
+      <remap from="input/concatenation_info" to="$(var input/concatenation_info)"/>
       <remap from="output" to="$(var output/clusters)"/>
 
       <!-- rois, camera and info -->

--- a/perception/autoware_image_projection_based_fusion/launch/roi_detected_object_fusion.launch.xml
+++ b/perception/autoware_image_projection_based_fusion/launch/roi_detected_object_fusion.launch.xml
@@ -19,6 +19,7 @@
   <arg name="input/rois8" default="rois8"/>
   <arg name="input/camera_info8" default="/camera_info8"/>
   <arg name="input/objects" default="objects"/>
+  <arg name="input/concatenation_info" default="/sensing/lidar/concatenated/pointcloud_info"/>
   <arg name="output/objects" default="fused_objects"/>
   <arg name="param_path" default="$(find-pkg-share autoware_image_projection_based_fusion)/config/roi_detected_object_fusion.param.yaml"/>
   <arg name="sync_param_path" default="$(find-pkg-share autoware_image_projection_based_fusion)/config/fusion_common.param.yaml"/>
@@ -43,6 +44,7 @@
       <param from="$(var sync_param_path)"/>
       <param from="$(var param_path)"/>
       <remap from="input" to="$(var input/objects)"/>
+      <remap from="input/concatenation_info" to="$(var input/concatenation_info)"/>
       <remap from="output" to="$(var output/objects)"/>
 
       <!-- rois, camera and info -->

--- a/perception/autoware_image_projection_based_fusion/launch/roi_pointcloud_fusion.launch.xml
+++ b/perception/autoware_image_projection_based_fusion/launch/roi_pointcloud_fusion.launch.xml
@@ -20,6 +20,7 @@
   <arg name="input/rois8" default="rois8"/>
   <arg name="input/camera_info8" default="/camera_info8"/>
   <arg name="input/pointcloud" default="/perception/object_recognition/detection/pointcloud_map_filtered/pointcloud"/>
+  <arg name="input/concatenation_info" default="/sensing/lidar/concatenated/pointcloud_info"/>
   <arg name="output/clusters" default="output/clusters"/>
   <arg name="debug/clusters" default="roi_pointcloud_fusion/debug/clusters"/>
   <arg name="param_path" default="$(find-pkg-share autoware_image_projection_based_fusion)/config/roi_pointcloud_fusion.param.yaml"/>
@@ -43,6 +44,7 @@
         <param from="$(var param_path)"/>
         <param from="$(var sync_param_path)" allow_substs="true"/>
         <remap from="input" to="$(var input/pointcloud)"/>
+        <remap from="input/concatenation_info" to="$(var input/concatenation_info)"/>
         <remap from="output" to="$(var output/clusters)"/>
         <remap from="debug/clusters" to="$(var debug/clusters)"/>
 

--- a/perception/autoware_image_projection_based_fusion/launch/segmentation_pointcloud_fusion.launch.py
+++ b/perception/autoware_image_projection_based_fusion/launch/segmentation_pointcloud_fusion.launch.py
@@ -130,6 +130,7 @@ def generate_launch_description():
         launch_arguments.append(DeclareLaunchArgument(name, default_value=default_value))
 
     add_launch_arg("input/pointcloud", "pointcloud_map_filtered/pointcloud")
+    add_launch_arg("input/concatenation_info", "/sensing/lidar/concatenated/pointcloud_info")
     add_launch_arg("output/pointcloud", "segmentation_based_filtered/pointcloud")
     add_launch_arg("use_intra_process", "True")
     add_launch_arg("use_multithread", "True")

--- a/perception/autoware_image_projection_based_fusion/launch/segmentation_pointcloud_fusion.launch.py
+++ b/perception/autoware_image_projection_based_fusion/launch/segmentation_pointcloud_fusion.launch.py
@@ -92,13 +92,16 @@ class SegmentationPointcloudFusion:
             point_project_to_unrectified_image
         )
 
-    def create_segmentation_pointcloud_fusion_node(self, input_topic, output_topic):
+    def create_segmentation_pointcloud_fusion_node(
+        self, input_topic, concat_info_topic, output_topic
+    ):
         node = Node(
             package="autoware_image_projection_based_fusion",
             executable="segmentation_pointcloud_fusion_node",
             name="segmentation_pointcloud_fusion",
             remappings=[
                 ("input", input_topic),
+                ("input/concatenation_info", concat_info_topic),
                 ("output", output_topic),
             ],
             parameters=[
@@ -112,7 +115,9 @@ class SegmentationPointcloudFusion:
 def launch_setup(context, *args, **kwargs):
     pipeline = SegmentationPointcloudFusion(context)
     segmentation_pointcloud_fusion_node = pipeline.create_segmentation_pointcloud_fusion_node(
-        LaunchConfiguration("input/pointcloud"), LaunchConfiguration("output/pointcloud")
+        LaunchConfiguration("input/pointcloud"),
+        LaunchConfiguration("input/concatenation_info"),
+        LaunchConfiguration("output/pointcloud"),
     )
     # TODO(badai-nguyen): add option of using container
     return [segmentation_pointcloud_fusion_node]

--- a/perception/autoware_image_projection_based_fusion/launch/segmentation_pointcloud_fusion.launch.xml
+++ b/perception/autoware_image_projection_based_fusion/launch/segmentation_pointcloud_fusion.launch.xml
@@ -19,6 +19,7 @@
   <arg name="input/mask8" default="/perception/object_recognition/detection/mask8"/>
   <arg name="input/camera_info8" default="/sensing/camera/camera8/camera_info"/>
   <arg name="input/pointcloud" default="/sensing/lidar/top/outlier_filtered/pointcloud"/>
+  <arg name="input/concatenation_info" default="/sensing/lidar/concatenated/pointcloud_info"/>
   <arg name="output/pointcloud" default="output/pointcloud"/>
   <arg name="sync_param_path" default="$(find-pkg-share autoware_image_projection_based_fusion)/config/fusion_common.param.yaml"/>
   <arg name="semantic_segmentation_based_filter_param_path" default="$(find-pkg-share autoware_image_projection_based_fusion)/config/segmentation_pointcloud_fusion.param.yaml"/>
@@ -37,6 +38,7 @@
       <param from="$(var semantic_segmentation_based_filter_param_path)"/>
       <param from="$(var sync_param_path)"/>
       <remap from="input" to="$(var input/pointcloud)"/>
+      <remap from="input/concatenation_info" to="$(var input/concatenation_info)"/>
       <remap from="output" to="$(var output/pointcloud)"/>
 
       <!-- rois, camera and info -->

--- a/perception/autoware_image_projection_based_fusion/package.xml
+++ b/perception/autoware_image_projection_based_fusion/package.xml
@@ -22,6 +22,8 @@
   <depend>autoware_object_recognition_utils</depend>
   <depend>autoware_perception_msgs</depend>
   <depend>autoware_point_types</depend>
+  <depend>autoware_pointcloud_preprocessor</depend>
+  <depend>autoware_sensing_msgs</depend>
   <depend>autoware_utils</depend>
   <depend>cv_bridge</depend>
   <depend>diagnostic_msgs</depend>

--- a/perception/autoware_image_projection_based_fusion/src/fusion_matching_strategy.cpp
+++ b/perception/autoware_image_projection_based_fusion/src/fusion_matching_strategy.cpp
@@ -18,6 +18,7 @@
 #include "autoware/image_projection_based_fusion/fusion_node.hpp"
 #include "autoware/image_projection_based_fusion/fusion_types.hpp"
 
+#include <autoware/pointcloud_preprocessor/concatenate_data/concatenation_info_manager.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include <cmath>
@@ -219,10 +220,10 @@ AdvancedMatchingStrategy<Msg3D, Msg2D, ExportObj>::match_msg3d_to_collector(
   const std::list<std::shared_ptr<FusionCollector<Msg3D, Msg2D, ExportObj>>> & fusion_collectors,
   const std::shared_ptr<Msg3dMatchingContext> & matching_context)
 {
-  auto concatenated_status =
-    ros2_parent_node_->find_concatenation_status(matching_context->msg3d_timestamp);
+  auto concatenation_info =
+    ros2_parent_node_->find_concatenation_info(matching_context->msg3d_timestamp);
 
-  double offset = get_concatenated_offset(matching_context->msg3d_timestamp, concatenated_status);
+  double offset = get_concatenation_offset(matching_context->msg3d_timestamp, concatenation_info);
   double adjusted_timestamp = matching_context->msg3d_timestamp - offset;
 
   for (const auto & fusion_collector : fusion_collectors) {
@@ -256,9 +257,9 @@ void AdvancedMatchingStrategy<Msg3D, Msg2D, ExportObj>::set_collector_info(
     auto msg3d_matching_context =
       std::dynamic_pointer_cast<Msg3dMatchingContext>(matching_context)) {
     auto concatenated_status =
-      ros2_parent_node_->find_concatenation_status(msg3d_matching_context->msg3d_timestamp);
+      ros2_parent_node_->find_concatenation_info(msg3d_matching_context->msg3d_timestamp);
     double offset =
-      get_concatenated_offset(msg3d_matching_context->msg3d_timestamp, concatenated_status);
+      get_concatenation_offset(msg3d_matching_context->msg3d_timestamp, concatenated_status);
 
     auto info = std::make_shared<AdvancedCollectorInfo>(
       msg3d_matching_context->msg3d_timestamp - offset, msg3d_noise_window_);
@@ -282,50 +283,42 @@ void AdvancedMatchingStrategy<Msg3D, Msg2D, ExportObj>::set_collector_info(
 }
 
 template <class Msg3D, class Msg2D, class ExportObj>
-double AdvancedMatchingStrategy<Msg3D, Msg2D, ExportObj>::get_concatenated_offset(
+double AdvancedMatchingStrategy<Msg3D, Msg2D, ExportObj>::get_concatenation_offset(
   const double & msg3d_timestamp,
-  const std::optional<std::unordered_map<std::string, std::string>> & concatenated_status)
+  const std::optional<autoware_sensing_msgs::msg::ConcatenatedPointCloudInfo::SharedPtr> &
+    concatenation_info_msg)
 {
   double offset = 0.0;
 
-  if (concatenated_status.has_value()) {
-    bool concatenation_success = false;
-    const auto & status_map = concatenated_status.value();
+  if (concatenation_info_msg.has_value()) {
+    const auto & concatenation_info = concatenation_info_msg.value();
 
-    // Find required keys in the map
-    auto concat_success_it = status_map.find("Pointcloud concatenation succeeded");
-
-    if (concat_success_it != status_map.end()) {
-      concatenation_success = (concat_success_it->second == "True");
-      if (concatenation_success && database_created_) {
-        return offset;  // 0.0
-      }
+    auto concatenation_success = concatenation_info->concatenation_success;
+    if (concatenation_success && database_created_) {
+      return offset;  // 0.0
     }
 
-    auto ref_min_it = status_map.find("Minimum reference timestamp");
-    auto ref_max_it = status_map.find("Maximum reference timestamp");
-    if (ref_min_it != status_map.end() && ref_max_it != status_map.end()) {
-      try {
-        double reference_min = std::stod(ref_min_it->second);
-        double reference_max = std::stod(ref_max_it->second);
+    auto deserialized_cfg = autoware::pointcloud_preprocessor::StrategyAdvancedConfig(
+      concatenation_info->matching_strategy_config);
 
-        if (!concatenation_success && msg3d_timestamp > reference_max) {
-          offset = msg3d_timestamp - (reference_min + (reference_max - reference_min) / 2);
-        } else if (!database_created_ && concatenation_success) {
-          auto concat_cloud_it = status_map.find("Concatenated pointcloud timestamp");
-          if (concat_cloud_it != status_map.end()) {
-            double concatenated_cloud_timestamp = std::stod(concat_cloud_it->second);
-            update_fractional_timestamp_set(concatenated_cloud_timestamp);
-            success_status_counter_++;
-            offset = 0.0;
+    auto reference_timestamp_min_msg = deserialized_cfg.reference_timestamp_min_msg;
+    auto reference_timestamp_max_msg = deserialized_cfg.reference_timestamp_max_msg;
 
-            if (success_status_counter_ > success_threshold) {
-              database_created_ = true;
-            }
-          }
-        }
-      } catch (const std::exception & e) {
-        RCLCPP_ERROR(ros2_parent_node_->get_logger(), "Failed to parse timestamp: %s", e.what());
+    auto reference_timestamp_min = rclcpp::Time(reference_timestamp_min_msg).seconds();
+    auto reference_timestamp_max = rclcpp::Time(reference_timestamp_max_msg).seconds();
+
+    if (!concatenation_success && msg3d_timestamp > reference_timestamp_max) {
+      offset = msg3d_timestamp -
+               (reference_timestamp_min + (reference_timestamp_max - reference_timestamp_min) / 2);
+    } else if (!database_created_ && concatenation_success) {
+      auto concatenated_cloud_timestamp = rclcpp::Time(concatenation_info->header.stamp).seconds();
+
+      update_fractional_timestamp_set(concatenated_cloud_timestamp);
+      success_status_counter_++;
+      offset = 0.0;
+
+      if (success_status_counter_ > success_threshold) {
+        database_created_ = true;
       }
     }
   } else {

--- a/perception/autoware_image_projection_based_fusion/src/fusion_matching_strategy.cpp
+++ b/perception/autoware_image_projection_based_fusion/src/fusion_matching_strategy.cpp
@@ -298,11 +298,11 @@ double AdvancedMatchingStrategy<Msg3D, Msg2D, ExportObj>::get_concatenation_offs
       return offset;  // 0.0
     }
 
-    auto deserialized_cfg = autoware::pointcloud_preprocessor::StrategyAdvancedConfig(
+    auto matching_strategy_config = autoware::pointcloud_preprocessor::StrategyAdvancedConfig(
       concatenation_info->matching_strategy_config);
 
-    auto reference_timestamp_min_msg = deserialized_cfg.reference_timestamp_min_msg;
-    auto reference_timestamp_max_msg = deserialized_cfg.reference_timestamp_max_msg;
+    auto reference_timestamp_min_msg = matching_strategy_config.reference_timestamp_min_msg;
+    auto reference_timestamp_max_msg = matching_strategy_config.reference_timestamp_max_msg;
 
     auto reference_timestamp_min = rclcpp::Time(reference_timestamp_min_msg).seconds();
     auto reference_timestamp_max = rclcpp::Time(reference_timestamp_max_msg).seconds();

--- a/perception/autoware_image_projection_based_fusion/src/fusion_node.cpp
+++ b/perception/autoware_image_projection_based_fusion/src/fusion_node.cpp
@@ -201,9 +201,13 @@ void FusionNode<Msg3D, Msg2D, ExportObj>::initialize_strategy()
   } else if (matching_strategy_ == "advanced") {
     fusion_matching_strategy_ = std::make_unique<AdvancedMatchingStrategy<Msg3D, Msg2D, ExportObj>>(
       std::dynamic_pointer_cast<FusionNode>(shared_from_this()), id_to_offset_map_);
-    // subscribe diagnostics
-    sub_diag_ = this->create_subscription<diagnostic_msgs::msg::DiagnosticArray>(
-      "/diagnostics", 10, std::bind(&FusionNode::diagnostic_callback, this, std::placeholders::_1));
+    // subscribe concatenation_info
+    auto concatenation_info_topic = declare_parameter<std::string>(
+      "concatenation_info_topic", "/sensing/lidar/concatenated/pointcloud_info");
+    sub_concatenation_info_ =
+      this->create_subscription<autoware_sensing_msgs::msg::ConcatenatedPointCloudInfo>(
+        concatenation_info_topic, 10,
+        std::bind(&FusionNode::concatenation_info_callback, this, std::placeholders::_1));
   } else {
     throw std::runtime_error("Matching strategy must be 'advanced' or 'naive'");
   }
@@ -515,36 +519,22 @@ void FusionNode<Msg3D, Msg2D, ExportObj>::rois_callback(
 }
 
 template <class Msg3D, class Msg2D, class ExportObj>
-void FusionNode<Msg3D, Msg2D, ExportObj>::diagnostic_callback(
-  const diagnostic_msgs::msg::DiagnosticArray::SharedPtr diagnostic_msg)
+void FusionNode<Msg3D, Msg2D, ExportObj>::concatenation_info_callback(
+  const autoware_sensing_msgs::msg::ConcatenatedPointCloudInfo::SharedPtr concatenation_info_msg)
 {
-  for (const auto & status : diagnostic_msg->status) {
-    // Filter for the concatenate_and_time_sync_node diagnostic message
-    if (status.name == std::string_view("concatenate_data: /sensing/lidar/concatenate_data")) {
-      std::optional<double> concatenate_timestamp_opt;
-
-      // First pass: Locate concatenated_cloud_timestamp
-      for (const auto & value : status.values) {
-        if (value.key == std::string_view("Concatenated pointcloud timestamp")) {
-          try {
-            concatenate_timestamp_opt = std::stod(value.value);
-          } catch (const std::exception & e) {
-            RCLCPP_ERROR(get_logger(), "Error parsing concatenated cloud timestamp: %s", e.what());
-          }
-        }
-      }
-
-      // Second pass: Fill key-value map only if timestamp was valid
-      if (concatenate_timestamp_opt.has_value()) {
-        std::unordered_map<std::string, std::string> key_value_map;
-        for (const auto & value : status.values) {
-          key_value_map.emplace(value.key, value.value);
-        }
-
-        concatenated_status_map_.emplace(
-          concatenate_timestamp_opt.value(), std::move(key_value_map));
-      }
-    }
+  if (
+    concatenation_info_msg->matching_strategy ==
+    autoware_sensing_msgs::msg::ConcatenatedPointCloudInfo::STRATEGY_NAIVE) {
+    RCLCPP_WARN_THROTTLE(
+      get_logger(), *get_clock(), 1000,
+      "Set the concatenation node's matching strategy to 'advanced' in "
+      "autoware_pointcloud_preprocessor to enable advanced matching in the fusion node.");
+    return;
+  } else if (
+    concatenation_info_msg->matching_strategy ==
+    autoware_sensing_msgs::msg::ConcatenatedPointCloudInfo::STRATEGY_ADVANCED) {
+    double concatenate_timestamp = rclcpp::Time(concatenation_info_msg->header.stamp).seconds();
+    concatenated_info_map_.emplace(concatenate_timestamp, concatenation_info_msg);
   }
 }
 
@@ -553,13 +543,13 @@ void FusionNode<Msg3D, Msg2D, ExportObj>::manage_concatenated_status_map(double 
 {
   constexpr double threshold_seconds = 1.0;  // Define threshold as a constant
 
-  // Remove old entries from concatenated_status_map_
-  auto it = concatenated_status_map_.begin();
-  while (it != concatenated_status_map_.end()) {
+  // Remove old entries from concatenated_info_map_
+  auto it = concatenated_info_map_.begin();
+  while (it != concatenated_info_map_.end()) {
     if (current_timestamp - it->first > threshold_seconds) {
       RCLCPP_DEBUG(
         get_logger(), "Removing old concatenation status for timestamp: %.9f", it->first);
-      it = concatenated_status_map_.erase(it);
+      it = concatenated_info_map_.erase(it);
     } else {
       ++it;
     }
@@ -644,11 +634,11 @@ void FusionNode<Msg3D, Msg2D, ExportObj>::manage_collector_list()
 }
 
 template <class Msg3D, class Msg2D, class ExportObj>
-std::optional<std::unordered_map<std::string, std::string>>
-FusionNode<Msg3D, Msg2D, ExportObj>::find_concatenation_status(double timestamp)
+std::optional<autoware_sensing_msgs::msg::ConcatenatedPointCloudInfo::SharedPtr>
+FusionNode<Msg3D, Msg2D, ExportObj>::find_concatenation_info(double timestamp)
 {
-  auto it = concatenated_status_map_.find(timestamp);
-  if (it != concatenated_status_map_.end()) {
+  auto it = concatenated_info_map_.find(timestamp);
+  if (it != concatenated_info_map_.end()) {
     return it->second;
   }
   return std::nullopt;

--- a/perception/autoware_image_projection_based_fusion/src/fusion_node.cpp
+++ b/perception/autoware_image_projection_based_fusion/src/fusion_node.cpp
@@ -202,11 +202,9 @@ void FusionNode<Msg3D, Msg2D, ExportObj>::initialize_strategy()
     fusion_matching_strategy_ = std::make_unique<AdvancedMatchingStrategy<Msg3D, Msg2D, ExportObj>>(
       std::dynamic_pointer_cast<FusionNode>(shared_from_this()), id_to_offset_map_);
     // subscribe concatenation_info
-    auto concatenation_info_topic =
-      declare_parameter<std::string>("matching_strategy.concatenation_info_topic");
     sub_concatenation_info_ =
       this->create_subscription<autoware_sensing_msgs::msg::ConcatenatedPointCloudInfo>(
-        concatenation_info_topic, rclcpp::SensorDataQoS().keep_last(10),
+        "input/concatenation_info", rclcpp::SensorDataQoS().keep_last(10),
         std::bind(&FusionNode::concatenation_info_callback, this, std::placeholders::_1));
   } else {
     throw std::runtime_error("Matching strategy must be 'advanced' or 'naive'");

--- a/perception/autoware_image_projection_based_fusion/src/fusion_node.cpp
+++ b/perception/autoware_image_projection_based_fusion/src/fusion_node.cpp
@@ -202,8 +202,8 @@ void FusionNode<Msg3D, Msg2D, ExportObj>::initialize_strategy()
     fusion_matching_strategy_ = std::make_unique<AdvancedMatchingStrategy<Msg3D, Msg2D, ExportObj>>(
       std::dynamic_pointer_cast<FusionNode>(shared_from_this()), id_to_offset_map_);
     // subscribe concatenation_info
-    auto concatenation_info_topic = declare_parameter<std::string>(
-      "concatenation_info_topic", "/sensing/lidar/concatenated/pointcloud_info");
+    auto concatenation_info_topic =
+      declare_parameter<std::string>("matching_strategy.concatenation_info_topic");
     sub_concatenation_info_ =
       this->create_subscription<autoware_sensing_msgs::msg::ConcatenatedPointCloudInfo>(
         concatenation_info_topic, rclcpp::SensorDataQoS().keep_last(10),
@@ -522,6 +522,8 @@ template <class Msg3D, class Msg2D, class ExportObj>
 void FusionNode<Msg3D, Msg2D, ExportObj>::concatenation_info_callback(
   const autoware_sensing_msgs::msg::ConcatenatedPointCloudInfo::SharedPtr concatenation_info_msg)
 {
+  RCLCPP_INFO(get_logger(), "concatenation_info_callback");
+
   if (
     concatenation_info_msg->matching_strategy ==
     autoware_sensing_msgs::msg::ConcatenatedPointCloudInfo::STRATEGY_NAIVE) {

--- a/perception/autoware_image_projection_based_fusion/src/fusion_node.cpp
+++ b/perception/autoware_image_projection_based_fusion/src/fusion_node.cpp
@@ -206,7 +206,7 @@ void FusionNode<Msg3D, Msg2D, ExportObj>::initialize_strategy()
       "concatenation_info_topic", "/sensing/lidar/concatenated/pointcloud_info");
     sub_concatenation_info_ =
       this->create_subscription<autoware_sensing_msgs::msg::ConcatenatedPointCloudInfo>(
-        concatenation_info_topic, 10,
+        concatenation_info_topic, rclcpp::SensorDataQoS().keep_last(10),
         std::bind(&FusionNode::concatenation_info_callback, this, std::placeholders::_1));
   } else {
     throw std::runtime_error("Matching strategy must be 'advanced' or 'naive'");

--- a/perception/autoware_image_projection_based_fusion/src/fusion_node.cpp
+++ b/perception/autoware_image_projection_based_fusion/src/fusion_node.cpp
@@ -522,8 +522,6 @@ template <class Msg3D, class Msg2D, class ExportObj>
 void FusionNode<Msg3D, Msg2D, ExportObj>::concatenation_info_callback(
   const autoware_sensing_msgs::msg::ConcatenatedPointCloudInfo::SharedPtr concatenation_info_msg)
 {
-  RCLCPP_INFO(get_logger(), "concatenation_info_callback");
-
   if (
     concatenation_info_msg->matching_strategy ==
     autoware_sensing_msgs::msg::ConcatenatedPointCloudInfo::STRATEGY_NAIVE) {

--- a/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_concatenate_data/cuda_combine_cloud_handler.hpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_concatenate_data/cuda_combine_cloud_handler.hpp
@@ -50,7 +50,8 @@ public:
   ConcatenatedCloudResult<CudaPointCloud2Traits> combine_pointclouds(
     std::unordered_map<
       std::string, typename CudaPointCloud2Traits::PointCloudMessage::ConstSharedPtr> &
-      topic_to_cloud_map);
+      topic_to_cloud_map,
+    const std::shared_ptr<CollectorInfoBase> & collector_info);
 
   void allocate_pointclouds() override;
 };

--- a/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_concatenate_data/cuda_combine_cloud_handler.cpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_concatenate_data/cuda_combine_cloud_handler.cpp
@@ -17,7 +17,7 @@
 #include "autoware/cuda_pointcloud_preprocessor/cuda_concatenate_data/cuda_combine_cloud_handler_kernel.hpp"
 #include "autoware/cuda_pointcloud_preprocessor/cuda_concatenate_data/cuda_traits.hpp"
 
-#include <autoware/pointcloud_preprocessor/concatenate_data/concatenation_info.hpp>
+#include <autoware/pointcloud_preprocessor/concatenate_data/concatenation_info_manager.hpp>
 #include <cuda_blackboard/cuda_pointcloud2.hpp>
 
 #include <cuda_runtime.h>
@@ -113,7 +113,7 @@ CombineCloudHandler<CudaPointCloud2Traits>::combine_pointclouds(
     std::make_unique<cuda_blackboard::CudaPointCloud2>();
   concatenate_cloud_result.concatenation_info_ptr =
     std::make_unique<autoware_sensing_msgs::msg::ConcatenatedPointCloudInfo>(
-      concatenation_info_.reset_and_get_base_info());
+      concatenation_info_manager_.reset_and_get_base_info());
 
   // Reserve space based on the total size of the pointcloud data to speed up the concatenation
   // process
@@ -181,7 +181,7 @@ CombineCloudHandler<CudaPointCloud2Traits>::combine_pointclouds(
       reinterpret_cast<PointTypeStruct *>(cloud->data.get()), num_points, transform_struct,
       output_points + concatenated_start_index, stream);
     concatenated_start_index += num_points;
-    concatenation_info_.update_source_from_point_cloud(
+    concatenation_info_manager_.update_source_from_point_cloud(
       *cloud, topic, autoware_sensing_msgs::msg::SourcePointCloudInfo::STATUS_OK,
       *concatenate_cloud_result.concatenation_info_ptr);
   }
@@ -281,7 +281,7 @@ CombineCloudHandler<CudaPointCloud2Traits>::combine_pointclouds(
 
   concatenate_cloud_result.concatenate_cloud_ptr->header.stamp = oldest_stamp;
 
-  concatenation_info_.set_result(
+  concatenation_info_manager_.set_result(
     *concatenate_cloud_result.concatenate_cloud_ptr,
     *concatenate_cloud_result.concatenation_info_ptr);
 

--- a/sensing/autoware_pointcloud_preprocessor/docs/concatenate-data.md
+++ b/sensing/autoware_pointcloud_preprocessor/docs/concatenate-data.md
@@ -161,7 +161,7 @@ The concatenation node publishes detailed meta information about the concatenati
 ### Handling Serialized Configuration
 
 The `matching_strategy_config` field contains serialized configuration data for the matching strategy.
-If a strategy has its own configuration, it requires serialization and deserialization implementation based on the `StrategyConfig` class defined in [cloud_info.hpp](../include/autoware/pointcloud_preprocessor/concatenate_data/concatenation_info.hpp).
+If a strategy has its own configuration, it requires serialization and deserialization implementation based on the `StrategyConfig` class defined in [cloud_info.hpp](../include/autoware/pointcloud_preprocessor/concatenate_data/concatenation_info_manager.hpp).
 
 Here's how to work with serialized configuration for the Advanced strategy:
 
@@ -169,7 +169,7 @@ Here's how to work with serialized configuration for the Advanced strategy:
 
 ```cpp
 auto cfg = StrategyAdvancedConfig(reference_timestamp_min, reference_timestamp_max);
-ConcatenationInfo::set_config(cfg.serialize(), concatenation_info_msg);
+ConcatenationInfoManager::set_config(cfg.serialize(), concatenation_info_msg);
 ```
 
 #### Deserialization Example

--- a/sensing/autoware_pointcloud_preprocessor/include/autoware/pointcloud_preprocessor/concatenate_data/cloud_collector.hpp
+++ b/sensing/autoware_pointcloud_preprocessor/include/autoware/pointcloud_preprocessor/concatenate_data/cloud_collector.hpp
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include "collector_info.hpp"
 #include "combine_cloud_handler.hpp"
 
 #include <memory>
@@ -28,29 +29,6 @@ class PointCloudConcatenateDataSynchronizerComponentTemplated;
 
 template <typename MsgTraits>
 class CombineCloudHandler;
-
-struct CollectorInfoBase
-{
-  virtual ~CollectorInfoBase() = default;
-};
-
-struct NaiveCollectorInfo : public CollectorInfoBase
-{
-  double timestamp;
-
-  explicit NaiveCollectorInfo(double timestamp = 0.0) : timestamp(timestamp) {}
-};
-
-struct AdvancedCollectorInfo : public CollectorInfoBase
-{
-  double timestamp;
-  double noise_window;
-
-  explicit AdvancedCollectorInfo(double timestamp = 0.0, double noise_window = 0.0)
-  : timestamp(timestamp), noise_window(noise_window)
-  {
-  }
-};
 
 enum class CollectorStatus { Idle, Processing, Finished };
 template <typename MsgTraits>

--- a/sensing/autoware_pointcloud_preprocessor/include/autoware/pointcloud_preprocessor/concatenate_data/cloud_collector.ipp
+++ b/sensing/autoware_pointcloud_preprocessor/include/autoware/pointcloud_preprocessor/concatenate_data/cloud_collector.ipp
@@ -128,7 +128,7 @@ ConcatenatedCloudResult<MsgTraits> CloudCollector<MsgTraits>::concatenate_pointc
   std::unordered_map<std::string, typename MsgTraits::PointCloudMessage::ConstSharedPtr>
     topic_to_cloud_map)
 {
-  return combine_cloud_handler_->combine_pointclouds(topic_to_cloud_map);
+  return combine_cloud_handler_->combine_pointclouds(topic_to_cloud_map, collector_info_);
 }
 
 template <typename MsgTraits>

--- a/sensing/autoware_pointcloud_preprocessor/include/autoware/pointcloud_preprocessor/concatenate_data/collector_info.hpp
+++ b/sensing/autoware_pointcloud_preprocessor/include/autoware/pointcloud_preprocessor/concatenate_data/collector_info.hpp
@@ -1,0 +1,43 @@
+// Copyright 2025 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+namespace autoware::pointcloud_preprocessor
+{
+
+struct CollectorInfoBase
+{
+  virtual ~CollectorInfoBase() = default;
+};
+
+struct NaiveCollectorInfo : public CollectorInfoBase
+{
+  double timestamp;
+
+  explicit NaiveCollectorInfo(double timestamp = 0.0) : timestamp(timestamp) {}
+};
+
+struct AdvancedCollectorInfo : public CollectorInfoBase
+{
+  double timestamp;
+  double noise_window;
+
+  explicit AdvancedCollectorInfo(double timestamp = 0.0, double noise_window = 0.0)
+  : timestamp(timestamp), noise_window(noise_window)
+  {
+  }
+};
+
+}  // namespace autoware::pointcloud_preprocessor

--- a/sensing/autoware_pointcloud_preprocessor/include/autoware/pointcloud_preprocessor/concatenate_data/combine_cloud_handler.hpp
+++ b/sensing/autoware_pointcloud_preprocessor/include/autoware/pointcloud_preprocessor/concatenate_data/combine_cloud_handler.hpp
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include "collector_info.hpp"
 #include "combine_cloud_handler_base.hpp"
 #include "traits.hpp"
 
@@ -47,11 +48,12 @@ public:
   {
   }
 
-  virtual ~CombineCloudHandler() {}
+  virtual ~CombineCloudHandler() = default;
 
   ConcatenatedCloudResult<PointCloud2Traits> combine_pointclouds(
     std::unordered_map<std::string, typename PointCloud2Traits::PointCloudMessage::ConstSharedPtr> &
-      topic_to_cloud_map);
+      topic_to_cloud_map,
+    const std::shared_ptr<CollectorInfoBase> & collector_info);
 
   void allocate_pointclouds() override {};
 

--- a/sensing/autoware_pointcloud_preprocessor/include/autoware/pointcloud_preprocessor/concatenate_data/combine_cloud_handler_base.hpp
+++ b/sensing/autoware_pointcloud_preprocessor/include/autoware/pointcloud_preprocessor/concatenate_data/combine_cloud_handler_base.hpp
@@ -14,7 +14,7 @@
 
 #pragma once
 
-#include "concatenation_info.hpp"
+#include "concatenation_info_manager.hpp"
 #include "traits.hpp"
 
 #include <deque>
@@ -59,7 +59,8 @@ public:
     publish_synchronized_pointcloud_(publish_synchronized_pointcloud),
     keep_input_frame_in_synchronized_pointcloud_(keep_input_frame_in_synchronized_pointcloud),
     managed_tf_buffer_(std::make_unique<managed_transform_buffer::ManagedTransformBuffer>()),
-    concatenation_info_(node.get_parameter("matching_strategy.type").as_string(), input_topics)
+    concatenation_info_manager_(
+      node.get_parameter("matching_strategy.type").as_string(), input_topics)
   {
   }
 
@@ -83,7 +84,7 @@ protected:
   bool publish_synchronized_pointcloud_;
   bool keep_input_frame_in_synchronized_pointcloud_;
   std::unique_ptr<managed_transform_buffer::ManagedTransformBuffer> managed_tf_buffer_{nullptr};
-  ConcatenationInfo concatenation_info_;
+  ConcatenationInfoManager concatenation_info_manager_;
 
   std::deque<geometry_msgs::msg::TwistStamped> twist_queue_;
 };

--- a/sensing/autoware_pointcloud_preprocessor/include/autoware/pointcloud_preprocessor/concatenate_data/concatenate_pointclouds.hpp
+++ b/sensing/autoware_pointcloud_preprocessor/include/autoware/pointcloud_preprocessor/concatenate_data/concatenate_pointclouds.hpp
@@ -52,7 +52,7 @@
 #ifndef AUTOWARE__POINTCLOUD_PREPROCESSOR__CONCATENATE_DATA__CONCATENATE_POINTCLOUDS_HPP_
 #define AUTOWARE__POINTCLOUD_PREPROCESSOR__CONCATENATE_DATA__CONCATENATE_POINTCLOUDS_HPP_
 
-#include "concatenation_info.hpp"
+#include "concatenation_info_manager.hpp"
 
 #include <deque>
 #include <map>
@@ -144,7 +144,7 @@ private:
   std::vector<std::string> input_topics_;
 
   std::unique_ptr<managed_transform_buffer::ManagedTransformBuffer> managed_tf_buffer_{nullptr};
-  std::unique_ptr<ConcatenationInfo> concatenation_info_{nullptr};
+  std::unique_ptr<ConcatenationInfoManager> concatenation_info_manager_{nullptr};
 
   std::deque<geometry_msgs::msg::TwistStamped::ConstSharedPtr> twist_ptr_queue_;
 

--- a/sensing/autoware_pointcloud_preprocessor/include/autoware/pointcloud_preprocessor/concatenate_data/concatenation_info_manager.hpp
+++ b/sensing/autoware_pointcloud_preprocessor/include/autoware/pointcloud_preprocessor/concatenate_data/concatenation_info_manager.hpp
@@ -12,9 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef AUTOWARE__POINTCLOUD_PREPROCESSOR__CONCATENATE_DATA__CONCATENATION_INFO_MANAGER_HPP_
-#define AUTOWARE__POINTCLOUD_PREPROCESSOR__CONCATENATE_DATA__CONCATENATION_INFO_MANAGER_HPP_
-
+#pragma once
 #include <builtin_interfaces/msg/time.hpp>
 
 #include <autoware_sensing_msgs/msg/concatenated_point_cloud_info.hpp>
@@ -396,5 +394,3 @@ private:
 };
 
 }  // namespace autoware::pointcloud_preprocessor
-
-#endif  // AUTOWARE__POINTCLOUD_PREPROCESSOR__CONCATENATE_DATA__CONCATENATION_INFO_MANAGER_HPP_

--- a/sensing/autoware_pointcloud_preprocessor/include/autoware/pointcloud_preprocessor/concatenate_data/concatenation_info_manager.hpp
+++ b/sensing/autoware_pointcloud_preprocessor/include/autoware/pointcloud_preprocessor/concatenate_data/concatenation_info_manager.hpp
@@ -63,10 +63,10 @@ struct StrategyAdvancedConfig : public StrategyConfig
    * @param reference_timestamp_max Maximum reference timestamp for concatenation window
    */
   StrategyAdvancedConfig(
-    const builtin_interfaces::msg::Time & reference_timestamp_min,
-    const builtin_interfaces::msg::Time & reference_timestamp_max)
-  : reference_timestamp_min(reference_timestamp_min),
-    reference_timestamp_max(reference_timestamp_max)
+    const builtin_interfaces::msg::Time & reference_timestamp_min_msg,
+    const builtin_interfaces::msg::Time & reference_timestamp_max_msg)
+  : reference_timestamp_min_msg(reference_timestamp_min_msg),
+    reference_timestamp_max_msg(reference_timestamp_max_msg)
   {
   }
 
@@ -78,7 +78,8 @@ struct StrategyAdvancedConfig : public StrategyConfig
   explicit StrategyAdvancedConfig(const std::vector<uint8_t> & serialized_data)
   {
     if (
-      serialized_data.size() != sizeof(reference_timestamp_min) + sizeof(reference_timestamp_max)) {
+      serialized_data.size() !=
+      sizeof(reference_timestamp_min_msg) + sizeof(reference_timestamp_max_msg)) {
       throw std::invalid_argument("Invalid serialized data size for StrategyAdvancedConfig");
     }
 
@@ -86,12 +87,14 @@ struct StrategyAdvancedConfig : public StrategyConfig
 
     // Deserialize reference_timestamp_min
     std::memcpy(
-      &reference_timestamp_min, serialized_data.data() + offset, sizeof(reference_timestamp_min));
-    offset += sizeof(reference_timestamp_min);
+      &reference_timestamp_min_msg, serialized_data.data() + offset,
+      sizeof(reference_timestamp_min_msg));
+    offset += sizeof(reference_timestamp_min_msg);
 
     // Deserialize reference_timestamp_max
     std::memcpy(
-      &reference_timestamp_max, serialized_data.data() + offset, sizeof(reference_timestamp_max));
+      &reference_timestamp_max_msg, serialized_data.data() + offset,
+      sizeof(reference_timestamp_max_msg));
   }
 
   /**
@@ -101,29 +104,29 @@ struct StrategyAdvancedConfig : public StrategyConfig
   [[nodiscard]] std::vector<uint8_t> serialize() const final
   {
     std::vector<uint8_t> serialized;
-    serialized.reserve(sizeof(reference_timestamp_min) + sizeof(reference_timestamp_max));
+    serialized.reserve(sizeof(reference_timestamp_min_msg) + sizeof(reference_timestamp_max_msg));
 
     // Serialize reference_timestamp_min
     const auto * reference_timestamp_min_ptr =
-      reinterpret_cast<const uint8_t *>(&reference_timestamp_min);
+      reinterpret_cast<const uint8_t *>(&reference_timestamp_min_msg);
     serialized.insert(
       serialized.end(), reference_timestamp_min_ptr,
-      reference_timestamp_min_ptr + sizeof(reference_timestamp_min));
+      reference_timestamp_min_ptr + sizeof(reference_timestamp_min_msg));
 
     // Serialize reference_timestamp_max
     const auto * reference_timestamp_max_ptr =
-      reinterpret_cast<const uint8_t *>(&reference_timestamp_max);
+      reinterpret_cast<const uint8_t *>(&reference_timestamp_max_msg);
     serialized.insert(
       serialized.end(), reference_timestamp_max_ptr,
-      reference_timestamp_max_ptr + sizeof(reference_timestamp_max));
+      reference_timestamp_max_ptr + sizeof(reference_timestamp_max_msg));
 
     return serialized;
   }
 
   //! Minimum reference timestamp for concatenation time window
-  builtin_interfaces::msg::Time reference_timestamp_min;
+  builtin_interfaces::msg::Time reference_timestamp_min_msg;
   //! Maximum reference timestamp for concatenation time window
-  builtin_interfaces::msg::Time reference_timestamp_max;
+  builtin_interfaces::msg::Time reference_timestamp_max_msg;
 };
 
 /**

--- a/sensing/autoware_pointcloud_preprocessor/include/autoware/pointcloud_preprocessor/concatenate_data/concatenation_info_manager.hpp
+++ b/sensing/autoware_pointcloud_preprocessor/include/autoware/pointcloud_preprocessor/concatenate_data/concatenation_info_manager.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef AUTOWARE__POINTCLOUD_PREPROCESSOR__CONCATENATE_DATA__CONCATENATION_INFO_HPP_
-#define AUTOWARE__POINTCLOUD_PREPROCESSOR__CONCATENATE_DATA__CONCATENATION_INFO_HPP_
+#ifndef AUTOWARE__POINTCLOUD_PREPROCESSOR__CONCATENATE_DATA__CONCATENATION_INFO_MANAGER_HPP_
+#define AUTOWARE__POINTCLOUD_PREPROCESSOR__CONCATENATE_DATA__CONCATENATION_INFO_MANAGER_HPP_
 
 #include <builtin_interfaces/msg/time.hpp>
 
@@ -148,7 +148,7 @@ const std::unordered_map<std::string, uint8_t> matching_strategy_name_map = {
  * @note This class is designed for single-threaded use and should be reset
  *       between concatenation cycles using reset_and_get_base_info().
  */
-class ConcatenationInfo
+class ConcatenationInfoManager
 {
 public:
   /**
@@ -158,14 +158,14 @@ public:
    * @param input_topics List of input topic names to track for concatenation
    * @throws std::invalid_argument if matching_strategy_name is not recognized
    */
-  ConcatenationInfo(
+  ConcatenationInfoManager(
     const std::string & matching_strategy_name, const std::vector<std::string> & input_topics)
   : concatenated_point_cloud_info_base_msg_(
       create_concatenation_info_base(matching_strategy_name, input_topics)),
     num_expected_sources_(concatenated_point_cloud_info_base_msg_.source_info.size())
   {
   }
-  ~ConcatenationInfo() = default;
+  ~ConcatenationInfoManager() = default;
 
   /**
    * @brief Reset internal state and get base concatenation info message.
@@ -394,4 +394,4 @@ private:
 
 }  // namespace autoware::pointcloud_preprocessor
 
-#endif  // AUTOWARE__POINTCLOUD_PREPROCESSOR__CONCATENATE_DATA__CONCATENATION_INFO_HPP_
+#endif  // AUTOWARE__POINTCLOUD_PREPROCESSOR__CONCATENATE_DATA__CONCATENATION_INFO_MANAGER_HPP_

--- a/sensing/autoware_pointcloud_preprocessor/src/concatenate_data/combine_cloud_handler.cpp
+++ b/sensing/autoware_pointcloud_preprocessor/src/concatenate_data/combine_cloud_handler.cpp
@@ -250,7 +250,6 @@ CombineCloudHandler<PointCloud2Traits>::combine_pointclouds(
       serialized_config, *concatenate_cloud_result.concatenation_info_ptr);
   }
 
-  // Set strategy configuration for advanced mode
   concatenation_info_manager_.set_result(
     *concatenate_cloud_result.concatenate_cloud_ptr,
     *concatenate_cloud_result.concatenation_info_ptr);

--- a/sensing/autoware_pointcloud_preprocessor/src/concatenate_data/combine_cloud_handler.cpp
+++ b/sensing/autoware_pointcloud_preprocessor/src/concatenate_data/combine_cloud_handler.cpp
@@ -112,6 +112,7 @@ void CombineCloudHandler<PointCloud2Traits>::correct_pointcloud_motion(
     adjust_to_old_data_transform, *transformed_cloud_ptr, *transformed_delay_compensated_cloud_ptr);
 }
 
+// TODO(vividf): refactor this function for readability
 ConcatenatedCloudResult<PointCloud2Traits>
 CombineCloudHandler<PointCloud2Traits>::combine_pointclouds(
   std::unordered_map<std::string, PointCloud2Traits::PointCloudMessage::ConstSharedPtr> &
@@ -139,7 +140,7 @@ CombineCloudHandler<PointCloud2Traits>::combine_pointclouds(
     std::make_unique<sensor_msgs::msg::PointCloud2>();
   concatenate_cloud_result.concatenation_info_ptr =
     std::make_unique<autoware_sensing_msgs::msg::ConcatenatedPointCloudInfo>(
-      concatenation_info_.reset_and_get_base_info());
+      concatenation_info_manager_.reset_and_get_base_info());
   {
     // Normally, pcl::concatenatePointCloud() copies the field layout (e.g., XYZIRC)
     // from the non-empty point cloud when given one empty and one non-empty input.
@@ -188,7 +189,7 @@ CombineCloudHandler<PointCloud2Traits>::combine_pointclouds(
       pcl::concatenatePointCloud(
         *concatenate_cloud_result.concatenate_cloud_ptr, *transformed_delay_compensated_cloud_ptr,
         *concatenate_cloud_result.concatenate_cloud_ptr);
-      concatenation_info_.update_source_from_point_cloud(
+      concatenation_info_manager_.update_source_from_point_cloud(
         *transformed_delay_compensated_cloud_ptr, topic,
         autoware_sensing_msgs::msg::SourcePointCloudInfo::STATUS_OK,
         *concatenate_cloud_result.concatenation_info_ptr);
@@ -224,7 +225,7 @@ CombineCloudHandler<PointCloud2Traits>::combine_pointclouds(
     }
   }
   concatenate_cloud_result.concatenate_cloud_ptr->header.stamp = oldest_stamp;
-  concatenation_info_.set_result(
+  concatenation_info_manager_.set_result(
     *concatenate_cloud_result.concatenate_cloud_ptr,
     *concatenate_cloud_result.concatenation_info_ptr);
 

--- a/sensing/autoware_pointcloud_preprocessor/src/concatenate_data/concatenate_pointclouds.cpp
+++ b/sensing/autoware_pointcloud_preprocessor/src/concatenate_data/concatenate_pointclouds.cpp
@@ -98,7 +98,8 @@ PointCloudConcatenationComponent::PointCloudConcatenationComponent(
 
   // Cloud info
   {
-    concatenation_info_ = std::make_unique<ConcatenationInfo>("naive", input_topics_);
+    concatenation_info_manager_ =
+      std::make_unique<ConcatenationInfoManager>("naive", input_topics_);
   }
 
   // Output Publishers
@@ -259,9 +260,9 @@ void PointCloudConcatenationComponent::combineClouds(
       if (concatenation_info_ptr == nullptr) {
         concatenation_info_ptr =
           std::make_shared<autoware_sensing_msgs::msg::ConcatenatedPointCloudInfo>(
-            concatenation_info_->reset_and_get_base_info());
+            concatenation_info_manager_->reset_and_get_base_info());
       }
-      concatenation_info_->update_source_from_point_cloud(
+      concatenation_info_manager_->update_source_from_point_cloud(
         *transformed_cloud_ptr, e.first,
         autoware_sensing_msgs::msg::SourcePointCloudInfo::STATUS_OK, *concatenation_info_ptr);
     } else {
@@ -269,7 +270,7 @@ void PointCloudConcatenationComponent::combineClouds(
     }
   }
   if (concatenation_info_ptr != nullptr && concat_cloud_ptr != nullptr) {
-    concatenation_info_->set_result(*concat_cloud_ptr, *concatenation_info_ptr);
+    concatenation_info_manager_->set_result(*concat_cloud_ptr, *concatenation_info_ptr);
   }
 }
 

--- a/sensing/autoware_pointcloud_preprocessor/test/test_concatenation_info.cpp
+++ b/sensing/autoware_pointcloud_preprocessor/test/test_concatenation_info.cpp
@@ -225,10 +225,10 @@ TEST_F(ConcatenationInfoTest, UpdateConcatenatedPointCloudConfig)
   // Verify we can deserialize it back
   auto deserialized_cfg =
     StrategyAdvancedConfig(concatenated_point_cloud_info_msg.matching_strategy_config);
-  EXPECT_EQ(deserialized_cfg.reference_timestamp_min.sec, reference_timestamp_min.sec);
-  EXPECT_EQ(deserialized_cfg.reference_timestamp_min.nanosec, reference_timestamp_min.nanosec);
-  EXPECT_EQ(deserialized_cfg.reference_timestamp_max.sec, reference_timestamp_max.sec);
-  EXPECT_EQ(deserialized_cfg.reference_timestamp_max.nanosec, reference_timestamp_max.nanosec);
+  EXPECT_EQ(deserialized_cfg.reference_timestamp_min_msg.sec, reference_timestamp_min.sec);
+  EXPECT_EQ(deserialized_cfg.reference_timestamp_min_msg.nanosec, reference_timestamp_min.nanosec);
+  EXPECT_EQ(deserialized_cfg.reference_timestamp_max_msg.sec, reference_timestamp_max.sec);
+  EXPECT_EQ(deserialized_cfg.reference_timestamp_max_msg.nanosec, reference_timestamp_max.nanosec);
 }
 
 TEST_F(ConcatenationInfoTest, StrategyAdvancedConfigInvalidSerializedData)

--- a/sensing/autoware_pointcloud_preprocessor/test/test_concatenation_info.cpp
+++ b/sensing/autoware_pointcloud_preprocessor/test/test_concatenation_info.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <autoware/pointcloud_preprocessor/concatenate_data/concatenation_info.hpp>
+#include <autoware/pointcloud_preprocessor/concatenate_data/concatenation_info_manager.hpp>
 #include <builtin_interfaces/msg/time.hpp>
 
 #include <autoware_sensing_msgs/msg/concatenated_point_cloud_info.hpp>
@@ -29,7 +29,7 @@
 #include <string>
 #include <vector>
 
-using autoware::pointcloud_preprocessor::ConcatenationInfo;
+using autoware::pointcloud_preprocessor::ConcatenationInfoManager;
 using autoware::pointcloud_preprocessor::StrategyAdvancedConfig;
 
 class ConcatenationInfoTest : public ::testing::Test
@@ -92,9 +92,9 @@ protected:
 
 TEST_F(ConcatenationInfoTest, ConstructorAndGetConcatInfoBase)
 {
-  ConcatenationInfo concatenation_info(strategy_name_, input_topics_);
+  ConcatenationInfoManager concatenation_info_manager(strategy_name_, input_topics_);
 
-  auto concatenated_point_cloud_info_msg = concatenation_info.reset_and_get_base_info();
+  auto concatenated_point_cloud_info_msg = concatenation_info_manager.reset_and_get_base_info();
 
   // Check that source_info is populated with correct topics
   ASSERT_EQ(concatenated_point_cloud_info_msg.source_info.size(), input_topics_.size());
@@ -117,16 +117,17 @@ TEST_F(ConcatenationInfoTest, ConstructorAndGetConcatInfoBase)
 TEST_F(ConcatenationInfoTest, InvalidMatchingStrategy)
 {
   EXPECT_THROW(
-    ConcatenationInfo concatenation_info("invalid_strategy", input_topics_), std::invalid_argument);
+    ConcatenationInfoManager concatenation_info_manager("invalid_strategy", input_topics_),
+    std::invalid_argument);
 }
 
 TEST_F(ConcatenationInfoTest, ApplySourceWithPointCloud)
 {
-  ConcatenationInfo concatenation_info(strategy_name_, input_topics_);
-  auto concatenated_point_cloud_info_msg = concatenation_info.reset_and_get_base_info();
+  ConcatenationInfoManager concatenation_info_manager(strategy_name_, input_topics_);
+  auto concatenated_point_cloud_info_msg = concatenation_info_manager.reset_and_get_base_info();
 
   // Apply point cloud to first topic
-  concatenation_info.update_source_from_point_cloud(
+  concatenation_info_manager.update_source_from_point_cloud(
     test_cloud_1_, input_topics_[0], autoware_sensing_msgs::msg::SourcePointCloudInfo::STATUS_OK,
     concatenated_point_cloud_info_msg);
 
@@ -141,7 +142,7 @@ TEST_F(ConcatenationInfoTest, ApplySourceWithPointCloud)
   EXPECT_EQ(first_source.length, test_cloud_1_.width * test_cloud_1_.height);
 
   // Apply second point cloud
-  concatenation_info.update_source_from_point_cloud(
+  concatenation_info_manager.update_source_from_point_cloud(
     test_cloud_2_, input_topics_[1], autoware_sensing_msgs::msg::SourcePointCloudInfo::STATUS_OK,
     concatenated_point_cloud_info_msg);
 
@@ -153,11 +154,11 @@ TEST_F(ConcatenationInfoTest, ApplySourceWithPointCloud)
 
 TEST_F(ConcatenationInfoTest, ApplySourceWithPointCloudNonOkStatus)
 {
-  ConcatenationInfo concatenation_info(strategy_name_, input_topics_);
-  auto concatenated_point_cloud_info_msg = concatenation_info.reset_and_get_base_info();
+  ConcatenationInfoManager concatenation_info_manager(strategy_name_, input_topics_);
+  auto concatenated_point_cloud_info_msg = concatenation_info_manager.reset_and_get_base_info();
 
   // Apply point cloud with ERROR status
-  concatenation_info.update_source_from_point_cloud(
+  concatenation_info_manager.update_source_from_point_cloud(
     test_cloud_1_, input_topics_[0],
     autoware_sensing_msgs::msg::SourcePointCloudInfo::STATUS_INVALID,
     concatenated_point_cloud_info_msg);
@@ -172,10 +173,10 @@ TEST_F(ConcatenationInfoTest, ApplySourceWithPointCloudNonOkStatus)
 
 TEST_F(ConcatenationInfoTest, ApplySourceWithHeader)
 {
-  ConcatenationInfo concatenation_info(strategy_name_, input_topics_);
-  auto concatenated_point_cloud_info_msg = concatenation_info.reset_and_get_base_info();
+  ConcatenationInfoManager concatenation_info_manager(strategy_name_, input_topics_);
+  auto concatenated_point_cloud_info_msg = concatenation_info_manager.reset_and_get_base_info();
 
-  concatenation_info.update_source_from_header(
+  concatenation_info_manager.update_source_from_header(
     test_header_, input_topics_[0],
     autoware_sensing_msgs::msg::SourcePointCloudInfo::STATUS_INVALID,
     concatenated_point_cloud_info_msg);
@@ -189,10 +190,10 @@ TEST_F(ConcatenationInfoTest, ApplySourceWithHeader)
 
 TEST_F(ConcatenationInfoTest, ApplySourceWithStatus)
 {
-  ConcatenationInfo concatenation_info(strategy_name_, input_topics_);
-  auto concatenated_point_cloud_info_msg = concatenation_info.reset_and_get_base_info();
+  ConcatenationInfoManager concatenation_info_manager(strategy_name_, input_topics_);
+  auto concatenated_point_cloud_info_msg = concatenation_info_manager.reset_and_get_base_info();
 
-  concatenation_info.update_source_from_status(
+  concatenation_info_manager.update_source_from_status(
     input_topics_[0], autoware_sensing_msgs::msg::SourcePointCloudInfo::STATUS_TIMEOUT,
     concatenated_point_cloud_info_msg);
 
@@ -203,8 +204,8 @@ TEST_F(ConcatenationInfoTest, ApplySourceWithStatus)
 
 TEST_F(ConcatenationInfoTest, UpdateConcatenatedPointCloudConfig)
 {
-  ConcatenationInfo concatenation_info(strategy_name_, input_topics_);
-  auto concatenated_point_cloud_info_msg = concatenation_info.reset_and_get_base_info();
+  ConcatenationInfoManager concatenation_info_manager(strategy_name_, input_topics_);
+  auto concatenated_point_cloud_info_msg = concatenation_info_manager.reset_and_get_base_info();
 
   // Create AdvancedStrategy config with test timestamps
   builtin_interfaces::msg::Time reference_timestamp_min;
@@ -216,7 +217,7 @@ TEST_F(ConcatenationInfoTest, UpdateConcatenatedPointCloudConfig)
   reference_timestamp_max.nanosec = 900000000;
 
   auto cfg = StrategyAdvancedConfig(reference_timestamp_min, reference_timestamp_max);
-  ConcatenationInfo::set_config(cfg.serialize(), concatenated_point_cloud_info_msg);
+  ConcatenationInfoManager::set_config(cfg.serialize(), concatenated_point_cloud_info_msg);
 
   // Verify that the config was serialized and stored
   EXPECT_FALSE(concatenated_point_cloud_info_msg.matching_strategy_config.empty());
@@ -240,11 +241,11 @@ TEST_F(ConcatenationInfoTest, StrategyAdvancedConfigInvalidSerializedData)
 
 TEST_F(ConcatenationInfoTest, ApplySourceWithNonExistentTopic)
 {
-  ConcatenationInfo concatenation_info(strategy_name_, input_topics_);
-  auto concatenated_point_cloud_info_msg = concatenation_info.reset_and_get_base_info();
+  ConcatenationInfoManager concatenation_info_manager(strategy_name_, input_topics_);
+  auto concatenated_point_cloud_info_msg = concatenation_info_manager.reset_and_get_base_info();
 
   EXPECT_THROW(
-    concatenation_info.update_source_from_point_cloud(
+    concatenation_info_manager.update_source_from_point_cloud(
       test_cloud_1_, "/non_existent_topic",
       autoware_sensing_msgs::msg::SourcePointCloudInfo::STATUS_OK,
       concatenated_point_cloud_info_msg),
@@ -253,8 +254,8 @@ TEST_F(ConcatenationInfoTest, ApplySourceWithNonExistentTopic)
 
 TEST_F(ConcatenationInfoTest, NaiveStrategy)
 {
-  ConcatenationInfo concatenation_info("naive", input_topics_);
-  auto concatenated_point_cloud_info_msg = concatenation_info.reset_and_get_base_info();
+  ConcatenationInfoManager concatenation_info_manager("naive", input_topics_);
+  auto concatenated_point_cloud_info_msg = concatenation_info_manager.reset_and_get_base_info();
 
   EXPECT_EQ(
     concatenated_point_cloud_info_msg.matching_strategy,
@@ -263,21 +264,21 @@ TEST_F(ConcatenationInfoTest, NaiveStrategy)
 
 TEST_F(ConcatenationInfoTest, MultiplePointCloudIndexing)
 {
-  ConcatenationInfo concatenation_info(strategy_name_, input_topics_);
-  auto concatenated_point_cloud_info_msg = concatenation_info.reset_and_get_base_info();
+  ConcatenationInfoManager concatenation_info_manager(strategy_name_, input_topics_);
+  auto concatenated_point_cloud_info_msg = concatenation_info_manager.reset_and_get_base_info();
 
   // Apply cloud 1
-  concatenation_info.update_source_from_point_cloud(
+  concatenation_info_manager.update_source_from_point_cloud(
     test_cloud_1_, input_topics_[0], autoware_sensing_msgs::msg::SourcePointCloudInfo::STATUS_OK,
     concatenated_point_cloud_info_msg);
 
   // Apply cloud 3 (out of order)
-  concatenation_info.update_source_from_point_cloud(
+  concatenation_info_manager.update_source_from_point_cloud(
     test_cloud_3_, input_topics_[2], autoware_sensing_msgs::msg::SourcePointCloudInfo::STATUS_OK,
     concatenated_point_cloud_info_msg);
 
   // Apply cloud 2
-  concatenation_info.update_source_from_point_cloud(
+  concatenation_info_manager.update_source_from_point_cloud(
     test_cloud_2_, input_topics_[1], autoware_sensing_msgs::msg::SourcePointCloudInfo::STATUS_OK,
     concatenated_point_cloud_info_msg);
 
@@ -307,16 +308,16 @@ TEST_F(ConcatenationInfoTest, MultiplePointCloudIndexing)
 TEST_F(ConcatenationInfoTest, EmptyInputTopics)
 {
   std::vector<std::string> empty_topics;
-  ConcatenationInfo concatenation_info(strategy_name_, empty_topics);
-  auto concatenated_point_cloud_info_msg = concatenation_info.reset_and_get_base_info();
+  ConcatenationInfoManager concatenation_info_manager(strategy_name_, empty_topics);
+  auto concatenated_point_cloud_info_msg = concatenation_info_manager.reset_and_get_base_info();
 
   EXPECT_EQ(concatenated_point_cloud_info_msg.source_info.size(), 0u);
 }
 
 TEST_F(ConcatenationInfoTest, UpdateConcatenatedPointCloudResultCheckSuccess)
 {
-  ConcatenationInfo concatenation_info(strategy_name_, input_topics_);
-  auto concatenated_point_cloud_info_msg = concatenation_info.reset_and_get_base_info();
+  ConcatenationInfoManager concatenation_info_manager(strategy_name_, input_topics_);
+  auto concatenated_point_cloud_info_msg = concatenation_info_manager.reset_and_get_base_info();
 
   // Create concatenated cloud for the result
   sensor_msgs::msg::PointCloud2 concatenated_cloud;
@@ -325,16 +326,16 @@ TEST_F(ConcatenationInfoTest, UpdateConcatenatedPointCloudResultCheckSuccess)
   concatenated_cloud.header.stamp.nanosec = 555666777;
 
   // Add only 2 out of 3 clouds with STATUS_OK
-  concatenation_info.update_source_from_point_cloud(
+  concatenation_info_manager.update_source_from_point_cloud(
     test_cloud_1_, input_topics_[0], autoware_sensing_msgs::msg::SourcePointCloudInfo::STATUS_OK,
     concatenated_point_cloud_info_msg);
 
-  concatenation_info.update_source_from_point_cloud(
+  concatenation_info_manager.update_source_from_point_cloud(
     test_cloud_2_, input_topics_[1], autoware_sensing_msgs::msg::SourcePointCloudInfo::STATUS_OK,
     concatenated_point_cloud_info_msg);
 
   // Update result - should not be successful since we only have 2/3 clouds
-  concatenation_info.set_result(concatenated_cloud, concatenated_point_cloud_info_msg);
+  concatenation_info_manager.set_result(concatenated_cloud, concatenated_point_cloud_info_msg);
 
   // Check header is updated
   EXPECT_EQ(concatenated_point_cloud_info_msg.header.frame_id, concatenated_cloud.header.frame_id);
@@ -348,12 +349,12 @@ TEST_F(ConcatenationInfoTest, UpdateConcatenatedPointCloudResultCheckSuccess)
   EXPECT_FALSE(concatenated_point_cloud_info_msg.concatenation_success);
 
   // Now add the third cloud
-  concatenation_info.update_source_from_point_cloud(
+  concatenation_info_manager.update_source_from_point_cloud(
     test_cloud_3_, input_topics_[2], autoware_sensing_msgs::msg::SourcePointCloudInfo::STATUS_OK,
     concatenated_point_cloud_info_msg);
 
   // Update result again - should be successful since we now have all 3/3 clouds
-  concatenation_info.set_result(concatenated_cloud, concatenated_point_cloud_info_msg);
+  concatenation_info_manager.set_result(concatenated_cloud, concatenated_point_cloud_info_msg);
 
   // Check concatenation is now successful (3/3 clouds)
   EXPECT_TRUE(concatenated_point_cloud_info_msg.concatenation_success);
@@ -361,22 +362,22 @@ TEST_F(ConcatenationInfoTest, UpdateConcatenatedPointCloudResultCheckSuccess)
 
 TEST_F(ConcatenationInfoTest, UpdateConcatenatedPointCloudResultWithMixedStatus)
 {
-  ConcatenationInfo concatenation_info(strategy_name_, input_topics_);
-  auto concatenated_point_cloud_info_msg = concatenation_info.reset_and_get_base_info();
+  ConcatenationInfoManager concatenation_info_manager(strategy_name_, input_topics_);
+  auto concatenated_point_cloud_info_msg = concatenation_info_manager.reset_and_get_base_info();
 
   // Add one cloud with STATUS_OK
-  concatenation_info.update_source_from_point_cloud(
+  concatenation_info_manager.update_source_from_point_cloud(
     test_cloud_1_, input_topics_[0], autoware_sensing_msgs::msg::SourcePointCloudInfo::STATUS_OK,
     concatenated_point_cloud_info_msg);
 
   // Add one cloud with STATUS_INVALID (should not count towards valid_cloud_count_)
-  concatenation_info.update_source_from_point_cloud(
+  concatenation_info_manager.update_source_from_point_cloud(
     test_cloud_2_, input_topics_[1],
     autoware_sensing_msgs::msg::SourcePointCloudInfo::STATUS_INVALID,
     concatenated_point_cloud_info_msg);
 
   // Add one cloud with STATUS_TIMEOUT (should not count towards valid_cloud_count_)
-  concatenation_info.update_source_from_status(
+  concatenation_info_manager.update_source_from_status(
     input_topics_[2], autoware_sensing_msgs::msg::SourcePointCloudInfo::STATUS_TIMEOUT,
     concatenated_point_cloud_info_msg);
 
@@ -387,7 +388,7 @@ TEST_F(ConcatenationInfoTest, UpdateConcatenatedPointCloudResultWithMixedStatus)
   concatenated_cloud.header.stamp.nanosec = 555666777;
 
   // Update result - should not be successful since we only have 1/3 valid clouds
-  concatenation_info.set_result(concatenated_cloud, concatenated_point_cloud_info_msg);
+  concatenation_info_manager.set_result(concatenated_cloud, concatenated_point_cloud_info_msg);
 
   // Check concatenation is not successful (1/3 valid clouds)
   EXPECT_FALSE(concatenated_point_cloud_info_msg.concatenation_success);
@@ -395,17 +396,17 @@ TEST_F(ConcatenationInfoTest, UpdateConcatenatedPointCloudResultWithMixedStatus)
 
 TEST_F(ConcatenationInfoTest, ApplySourceTwiceThrows)
 {
-  ConcatenationInfo concatenation_info(strategy_name_, input_topics_);
-  auto concatenated_point_cloud_info_msg = concatenation_info.reset_and_get_base_info();
+  ConcatenationInfoManager concatenation_info_manager(strategy_name_, input_topics_);
+  auto concatenated_point_cloud_info_msg = concatenation_info_manager.reset_and_get_base_info();
 
   // Apply first cloud successfully
-  concatenation_info.update_source_from_point_cloud(
+  concatenation_info_manager.update_source_from_point_cloud(
     test_cloud_1_, input_topics_[0], autoware_sensing_msgs::msg::SourcePointCloudInfo::STATUS_OK,
     concatenated_point_cloud_info_msg);
 
   // Try to apply second cloud to same topic - should throw
   EXPECT_THROW(
-    concatenation_info.update_source_from_point_cloud(
+    concatenation_info_manager.update_source_from_point_cloud(
       test_cloud_1_, input_topics_[0], autoware_sensing_msgs::msg::SourcePointCloudInfo::STATUS_OK,
       concatenated_point_cloud_info_msg),
     std::runtime_error);
@@ -413,21 +414,21 @@ TEST_F(ConcatenationInfoTest, ApplySourceTwiceThrows)
 
 TEST_F(ConcatenationInfoTest, TwoIterationsOfSettingCloudInfo)
 {
-  ConcatenationInfo concatenation_info(strategy_name_, input_topics_);
+  ConcatenationInfoManager concatenation_info_manager(strategy_name_, input_topics_);
 
   // First iteration - apply only partial clouds (invalid result)
-  auto concatenated_point_cloud_info_msg_1 = concatenation_info.reset_and_get_base_info();
+  auto concatenated_point_cloud_info_msg_1 = concatenation_info_manager.reset_and_get_base_info();
 
-  concatenation_info.update_source_from_point_cloud(
+  concatenation_info_manager.update_source_from_point_cloud(
     test_cloud_1_, input_topics_[0], autoware_sensing_msgs::msg::SourcePointCloudInfo::STATUS_OK,
     concatenated_point_cloud_info_msg_1);
 
-  concatenation_info.update_source_from_point_cloud(
+  concatenation_info_manager.update_source_from_point_cloud(
     test_cloud_2_, input_topics_[1],
     autoware_sensing_msgs::msg::SourcePointCloudInfo::STATUS_INVALID,
     concatenated_point_cloud_info_msg_1);
 
-  concatenation_info.update_source_from_status(
+  concatenation_info_manager.update_source_from_status(
     input_topics_[2], autoware_sensing_msgs::msg::SourcePointCloudInfo::STATUS_TIMEOUT,
     concatenated_point_cloud_info_msg_1);
 
@@ -437,7 +438,7 @@ TEST_F(ConcatenationInfoTest, TwoIterationsOfSettingCloudInfo)
   concatenated_cloud_1.header.stamp.sec = 1234567892;
   concatenated_cloud_1.header.stamp.nanosec = 111222333;
 
-  concatenation_info.set_result(concatenated_cloud_1, concatenated_point_cloud_info_msg_1);
+  concatenation_info_manager.set_result(concatenated_cloud_1, concatenated_point_cloud_info_msg_1);
 
   // Check first iteration results - should be invalid (only 1/3 valid clouds)
   EXPECT_EQ(
@@ -462,17 +463,17 @@ TEST_F(ConcatenationInfoTest, TwoIterationsOfSettingCloudInfo)
     0u);  // Should remain 0 due to INVALID status
 
   // Second iteration - fresh start with new concatenated_point_cloud_info_msg (valid result)
-  auto concatenated_point_cloud_info_msg_2 = concatenation_info.reset_and_get_base_info();
+  auto concatenated_point_cloud_info_msg_2 = concatenation_info_manager.reset_and_get_base_info();
 
-  concatenation_info.update_source_from_point_cloud(
+  concatenation_info_manager.update_source_from_point_cloud(
     test_cloud_1_, input_topics_[0], autoware_sensing_msgs::msg::SourcePointCloudInfo::STATUS_OK,
     concatenated_point_cloud_info_msg_2);
 
-  concatenation_info.update_source_from_point_cloud(
+  concatenation_info_manager.update_source_from_point_cloud(
     test_cloud_2_, input_topics_[1], autoware_sensing_msgs::msg::SourcePointCloudInfo::STATUS_OK,
     concatenated_point_cloud_info_msg_2);
 
-  concatenation_info.update_source_from_point_cloud(
+  concatenation_info_manager.update_source_from_point_cloud(
     test_cloud_3_, input_topics_[2], autoware_sensing_msgs::msg::SourcePointCloudInfo::STATUS_OK,
     concatenated_point_cloud_info_msg_2);
 
@@ -482,7 +483,7 @@ TEST_F(ConcatenationInfoTest, TwoIterationsOfSettingCloudInfo)
   concatenated_cloud_2.header.stamp.sec = 1234567893;
   concatenated_cloud_2.header.stamp.nanosec = 444555666;
 
-  concatenation_info.set_result(concatenated_cloud_2, concatenated_point_cloud_info_msg_2);
+  concatenation_info_manager.set_result(concatenated_cloud_2, concatenated_point_cloud_info_msg_2);
 
   // Check second iteration results - should be valid (all 3/3 clouds)
   EXPECT_EQ(


### PR DESCRIPTION
## Description
This PR eliminates the subscription to `/diagnostic`, which was increasing CPU usage in advanced mode. The node now subscribes directly to `concatenation_info` for improved efficiency.

Note that the algorithm itself has not changed. This PR only moves the value into the defined config field within concatenation_info, which the fusion node then subscribes to directly.



## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
* Test with sample rosbag.
* Test with a large vehicle rosbag. 

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
