### PR TITLE
feat(goal_planner): relax braking constraint at low speeds to improve goal position stability

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/goal_planner_module.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/goal_planner_module.cpp
@@ -2148,10 +2148,12 @@ bool GoalPlannerModule::hasEnoughDistance(
     return false;
   }
 
-  // If the stop line is subtly exceeded, it is assumed that there is not enough distance to the
-  // starting point of parking, so to prevent this, once the vehicle has stopped, it also has a
-  // stop_distance_buffer to allow for the amount exceeded.
-  const double buffer = is_stopped ? stop_distance_buffer_ : 0.0;
+  // The planned and actual stopping behaviors may vary. When this occurs, the vehicle might not be
+  // able to stop at the planned line while satisfying all constraints. A buffer should be added to
+  // account for control errors when the velocity is low.
+  constexpr double low_velocity_threshold = 1.39;
+  const bool is_low_velocity = std::abs(current_vel) < low_velocity_threshold;
+  const double buffer = is_low_velocity ? stop_distance_buffer_ : 0.0;
   if (distance_to_start + buffer < *current_to_stop_distance) {
     return false;
   }


### PR DESCRIPTION
## Description

We had a problem where the goal position frequently changed and was unstable. The primary reason for this was that the occupancy grid map based collision detection couldn't treat dynamic objects. This issue will be resolved by disabling that https://github.com/autowarefoundation/autoware_launch/pull/1620.

1. without any PR

https://github.com/user-attachments/assets/4765a056-0054-4703-a7e5-b444c5d4e367

However, there's another contributing factor: in a certain speed range, if the safety check consistently returns false (meaning DECEDING continues), the hasEnoughDistance function can also keep returning false. This is caused by a discrepancy between the planned speed and the actual speed. 

2. with  only https://github.com/autowarefoundation/autoware_launch/pull/1620

https://github.com/user-attachments/assets/e6c6e32c-b728-4e12-91a7-b6e31c23eb6c

To address this, the current Pull Request (PR) introduces a buffer to the stopping distance in the low-speed range, ensuring the deceleration rate is maintained despite the speed difference.

3. with https://github.com/autowarefoundation/autoware_launch/pull/1620 and this PR

https://github.com/user-attachments/assets/2d394837-5532-40ec-848d-b881bb2f70b5

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

- psim
- Evaluator :100: 
  - [[PR check (takeuchi)][Lexus][CommonScenario_Basic] planning test](https://evaluation.tier4.jp/evaluation/reports/7fc92b8c-b5e9-5a33-b625-bf2a1b79cc00?project_id=prd_jt)
  -  [[PR check (takeuchi)][Lexus][FuncVerificationScenario_Basic] planning test](https://evaluation.tier4.jp/evaluation/reports/88ca0bae-c662-56f1-a6c9-84085fa86ce5?project_id=prd_jt)
  - [[PR check (takeuchi)][Lexus][ControlDLRCommon_Basic] DLR test](https://evaluation.tier4.jp/evaluation/reports/6abe8c8e-c56f-558f-ad87-7c3b1aaf8e7c?project_id=prd_jt)



## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
