### PR TITLE
fix(blind_spot): when intersection is private, attention area lanelets are also private

### DIFF
--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/src/util.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/src/util.cpp
@@ -492,7 +492,6 @@ generate_blind_side_lanelets_before_turning(
       return std::make_pair(road_lanelets, blind_side_lanelets);
     }
     const auto & prev_lane = prev_lane_opt.value();
-
     road_lanelets.insert(road_lanelets.begin(), prev_lane);
     blind_side_lanelets.insert(
       blind_side_lanelets.begin(), blind_side_getter_function(route_handler, prev_lane));


### PR DESCRIPTION
## Description

When intersection lanelet is private, the attention areas will only connects to private lanelets. 

## Related links

**Parent Issue:**

- [TIER IV Internal Link - Issue's ticket](https://tier4.atlassian.net/browse/RT0-39021) 

## How was this PR tested?

- Internal evaluation

[TIER IV Internal Link - ControlDLR Test](https://evaluation.tier4.jp/evaluation/reports/369e033b-3f4e-5552-9b25-5b43ab8a6455?project_id=prd_jt)
[TIER IV Internal Link - FuncVerification Test](https://evaluation.tier4.jp/evaluation/reports/c1b33777-37d7-5f6f-a9ce-58e3ca06211d?project_id=prd_jt)
[TIER IV Internal Link - CommonScenario_Basic Test](https://evaluation.tier4.jp/evaluation/reports/8a7093dc-554a-53e7-ac5a-1ea900d6b8d7?project_id=prd_jt)

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
