### PR TITLE
feat(steer_offset_estimator): integrate twist estimation function to steer_offset_estimator node

### DIFF
--- a/vehicle/autoware_steer_offset_estimator/launch/steer_offset_estimator.launch.xml
+++ b/vehicle/autoware_steer_offset_estimator/launch/steer_offset_estimator.launch.xml
@@ -6,18 +6,12 @@
   <!-- get wheel base from vehicle info -->
   <include file="$(find-pkg-share autoware_global_parameter_loader)/launch/global_params.launch.py"/>
 
-  <!-- ndt twist publisher -->
-  <include file="$(find-pkg-share autoware_pose2twist)/launch/pose2twist.launch.xml">
-    <arg name="input_pose_topic" value="/localization/pose_estimator/pose"/>
-    <arg name="output_twist_topic" value="estimate_twist"/>
-  </include>
-
   <!-- steer offset estimator -->
   <node pkg="autoware_steer_offset_estimator" exec="steer_offset_estimator" name="steer_offset_estimator" output="screen">
     <param from="$(var config_file)"/>
     <param from="$(var initial_steer_offset_param_path)"/>
     <param name="initial_steer_offset_param_name" value="$(var initial_steer_offset_param_name)"/>
-    <remap from="~/input/twist" to="estimate_twist"/>
+    <remap from="~/input/pose" to="/localization/pose_estimator/pose"/>
     <remap from="~/input/steer" to="/vehicle/status/steering_status"/>
     <remap from="~/output/steering_offset" to="~/steering_offset"/>
     <remap from="~/output/steering_offset_covariance" to="~/steering_offset_covariance"/>


### PR DESCRIPTION
## Description

This PR refactors the autoware_steer_offset_estimator to calculate twist directly from pose differences instead of relying on external twist messages.  This change reduces the number of nodes and topics.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

tested by rosbag

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
