### PR TITLE
feat(lane_change_module): set none planning_factor behavior

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/interface.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/interface.cpp
@@ -284,7 +284,7 @@ bool LaneChangeInterface::canTransitFailureState()
         if (module_type_->getDirection() == Direction::RIGHT) {
           return PlanningFactor::SHIFT_RIGHT;
         }
-        return PlanningFactor::UNKNOWN;
+        return PlanningFactor::NONE;
       });
 
       planning_factor_interface_->add(
@@ -437,7 +437,7 @@ void LaneChangeInterface::updateSteeringFactorPtr(const BehaviorModuleOutput & o
     if (module_type_->getDirection() == Direction::RIGHT) {
       return PlanningFactor::SHIFT_RIGHT;
     }
-    return PlanningFactor::UNKNOWN;
+    return PlanningFactor::NONE;
   });
 
   const auto & lane_change_debug = module_type_->getDebugData();


### PR DESCRIPTION
## Description
Change the behavior of "planning_factor" from UNKNOWN to NONE when it is neither right nor left.

## Related links

## How was this PR tested?
do nothing,
only ci test in github

## Notes for reviewers

None.

## Interface changes

None.


## Effects on system behavior

None.
