### PR TITLE
fix(topic_state_monitor): cppcheck uninitMemberVar

### DIFF
--- a/system/autoware_topic_state_monitor/include/autoware/topic_state_monitor/topic_state_monitor.hpp
+++ b/system/autoware_topic_state_monitor/include/autoware/topic_state_monitor/topic_state_monitor.hpp
@@ -41,7 +41,7 @@ enum class TopicStatus : int8_t {
 class TopicStateMonitor
 {
 public:
-  explicit TopicStateMonitor(rclcpp::Node & node);
+  explicit TopicStateMonitor(rclcpp::Node & node, const Param & param);
 
   void setParam(const Param & param) { param_ = param; }
 

--- a/system/autoware_topic_state_monitor/src/topic_state_monitor/topic_state_monitor.cpp
+++ b/system/autoware_topic_state_monitor/src/topic_state_monitor/topic_state_monitor.cpp
@@ -16,8 +16,10 @@
 
 namespace autoware::topic_state_monitor
 {
-TopicStateMonitor::TopicStateMonitor(rclcpp::Node & node) : clock_(node.get_clock())
+TopicStateMonitor::TopicStateMonitor(rclcpp::Node & node, const Param & param)
+: clock_(node.get_clock())
 {
+  param_ = param;
 }
 
 void TopicStateMonitor::update()

--- a/system/autoware_topic_state_monitor/src/topic_state_monitor_core.cpp
+++ b/system/autoware_topic_state_monitor/src/topic_state_monitor_core.cpp
@@ -66,8 +66,7 @@ TopicStateMonitorNode::TopicStateMonitorNode(const rclcpp::NodeOptions & node_op
     this->add_on_set_parameters_callback(std::bind(&TopicStateMonitorNode::onParameter, this, _1));
 
   // Core
-  topic_state_monitor_ = std::make_unique<TopicStateMonitor>(*this);
-  topic_state_monitor_->setParam(param_);
+  topic_state_monitor_ = std::make_unique<TopicStateMonitor>(*this, param_);
 
   // Subscriber
   rclcpp::QoS qos = rclcpp::QoS{1};


### PR DESCRIPTION
## Description

Fix following cppcheck error to merge https://github.com/autowarefoundation/autoware_universe/pull/11308.
```
Error: /home/runner/work/autoware_universe/autoware_universe/system/autoware_topic_state_monitor/src/topic_state_monitor.cpp:19:20: warning: Member variable 'TopicStateMonitor::param_' is not initialized in the constructor. [uninitMemberVar]
TopicStateMonitor::TopicStateMonitor(rclcpp::Node & node) : clock_(node.get_clock())
```

## Related links

https://github.com/autowarefoundation/autoware_universe/pull/11308

## How was this PR tested?

Check CI passes.

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
