### PR TITLE
fix(obstacle_slow_down): suppress unnecessary virtual walls and planning factors

### DIFF
--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_slow_down_module/src/obstacle_slow_down_module.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_slow_down_module/src/obstacle_slow_down_module.cpp
@@ -729,7 +729,6 @@ std::vector<SlowdownInterval> ObstacleSlowDownModule::plan_slow_down(
     const auto slow_down_end_idx = dist_to_slow_down_start < dist_to_slow_down_end
                                      ? insert_point_in_trajectory(dist_to_slow_down_end)
                                      : std::nullopt;
-
     if (!slow_down_end_idx) {
       continue;
     }


### PR DESCRIPTION
## Description
In the current implementation, planning_factor and virtual_wall are output for objects closer than bstacle_filtering.max_lat_margin, even when no speed limit is applied (i.e., when the required slowdown speed is higher than the trajectory's velocity). This leads to the generation of many meaningless virtual walls, especially when obstacle_filtering.max_lat_margin is large.

To resolve this, this PR prevents the output of planning_factor and virtual_wall when it is clear that the trajectory's velocity will not be modified by MotionVelocityPlannerNode::insert_slowdown().

obstacle_stop wall can not be handled by this PR. (see https://github.com/autowarefoundation/autoware_core/blob/main/planning/motion_velocity_planner/autoware_motion_velocity_planner/src/node.cpp#L459-L474)

## Related links

## How was this PR tested?
tier4 scenario test
works well for some specific settings

## Notes for reviewers

None.

## Interface changes

None.



## Effects on system behavior

None.
