### PR TITLE
fix(lane_change): fix predicted path exceeding end point after approval

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/base_class.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/base_class.hpp
@@ -189,6 +189,7 @@ public:
     common_data_ptr_->lc_param_ptr = lane_change_parameters_;
     common_data_ptr_->lc_type = type_;
     common_data_ptr_->direction = direction_;
+    common_data_ptr_->current_acceleration = data->self_acceleration;
   }
 
   void setTimeKeeper(const std::shared_ptr<autoware_utils::TimeKeeper> & time_keeper)

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/scene.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/scene.hpp
@@ -161,13 +161,13 @@ protected:
     const LaneChangePath & lane_change_path,
     const std::vector<std::vector<PoseWithVelocityStamped>> & ego_predicted_paths,
     const lane_change::TargetObjects & collision_check_objects,
-    const utils::path_safety_checker::RSSparams & rss_params,
-    CollisionCheckDebugMap & debug_data) const;
+    const utils::path_safety_checker::RSSparams & rss_params, CollisionCheckDebugMap & debug_data,
+    const bool is_approved = false) const;
 
   bool is_colliding(
     const LaneChangePath & lane_change_path, const ExtendedPredictedObject & obj,
     const std::vector<PoseWithVelocityStamped> & ego_predicted_path, const RSSparams & rss_param,
-    CollisionCheckDebugMap & debug_data) const;
+    CollisionCheckDebugMap & debug_data, const bool is_approved) const;
 
   double get_max_velocity_for_safety_check() const;
 

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/structs/data.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/structs/data.hpp
@@ -23,6 +23,7 @@
 #include <autoware/route_handler/route_handler.hpp>
 #include <autoware_utils/math/unit_conversion.hpp>
 
+#include <geometry_msgs/msg/accel_with_covariance_stamped.hpp>
 #include <nav_msgs/msg/odometry.hpp>
 
 #include <lanelet2_core/primitives/Lanelet.h>
@@ -263,6 +264,7 @@ struct CommonData
 {
   RouteHandlerPtr route_handler_ptr;
   Odometry::ConstSharedPtr self_odometry_ptr;
+  geometry_msgs::msg::AccelWithCovarianceStamped::ConstSharedPtr current_acceleration;
   BppParamPtr bpp_param_ptr;
   LCParamPtr lc_param_ptr;
   LanesPtr lanes_ptr;
@@ -276,6 +278,11 @@ struct CommonData
   [[nodiscard]] const Pose & get_ego_pose() const { return self_odometry_ptr->pose.pose; }
 
   [[nodiscard]] const Twist & get_ego_twist() const { return self_odometry_ptr->twist.twist; }
+
+  [[nodiscard]] double get_current_accel() const
+  {
+    return current_acceleration->accel.accel.linear.x;
+  }
 
   [[nodiscard]] double get_ego_speed(bool use_norm = false) const
   {

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/utils.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/utils.hpp
@@ -120,6 +120,9 @@ std::vector<PoseWithVelocityStamped> convert_to_predicted_path(
   const CommonDataPtr & common_data_ptr, const LaneChangePath & lane_change_path,
   const double lane_changing_acceleration);
 
+std::vector<PoseWithVelocityStamped> convert_to_predicted_path(
+  const CommonDataPtr & common_data_ptr, const LaneChangePath & lane_change_path);
+
 bool isParkedObject(
   const PathWithLaneId & path, const RouteHandler & route_handler,
   const ExtendedPredictedObject & object, const double object_check_min_road_shoulder_width,
@@ -434,7 +437,7 @@ bool object_path_overlaps_lanes(
  */
 std::vector<std::vector<PoseWithVelocityStamped>> convert_to_predicted_paths(
   const CommonDataPtr & common_data_ptr, const LaneChangePath & lane_change_path,
-  const size_t deceleration_sampling_num);
+  const size_t deceleration_sampling_num, const bool is_approved = false);
 
 /**
  * @brief Validates whether a given pose is a valid starting point for a lane change.


### PR DESCRIPTION
## Description

In current lane change module, after the path is approved, the safety check continues evaluating beyond the lane change end point.

https://github.com/user-attachments/assets/d075b25d-8dd3-48eb-8416-0293e4eb3d97

In the video, we can see that the "red arrow" exceeded the lane change end point. 

<img width="2189" height="416" alt="image" src="https://github.com/user-attachments/assets/b203d14b-44ba-4c5e-9c56-d0c30077565d" />


This has caused unnecessary cancel.

This PR aims to fix this issue, by limiting the safety check up until lane change end point only.

## Related links

**Parent Issue:**

- [TIER IV Internal inquiry](https://star4.slack.com/archives/C074CCKN35E/p1756358769707399)

## How was this PR tested?

### After fix

https://github.com/user-attachments/assets/c8e2e674-49ba-4f6c-8690-46d0e93dfc76

#### Internal Degradation check

PR links Template

[TIER IV Internal Link - ControlDLR Test](https://evaluation.tier4.jp/evaluation/reports/042d4473-745d-52b5-b3fc-324693a2d2e6?project_id=prd_jt)
[TIER IV Internal Link - FuncVerification Test](https://evaluation.tier4.jp/evaluation/reports/7d0a09d3-c1df-506d-afbf-f0780278f638?project_id=prd_jt)
[TIER IV Internal Link - CommonScenario_Basic Test](https://evaluation.tier4.jp/evaluation/reports/60d097ff-3aaa-54d6-8db9-1ce3b1314297?project_id=prd_jt)


## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
