### PR TITLE
feat(control_cmd_gate): change QoS durability for hazard and turn indicator commands

### DIFF
--- a/control/autoware_control_command_gate/src/command/subscription.cpp
+++ b/control/autoware_control_command_gate/src/command/subscription.cpp
@@ -25,6 +25,7 @@ CommandSubscription::CommandSubscription(uint16_t id, const std::string & name, 
   using std::placeholders::_1;
   const auto control_qos = rclcpp::QoS(5);
   const auto volatile_qos = rclcpp::QoS(1);
+  const auto transient_qos = rclcpp::QoS(1).transient_local();
   const auto prefix = "~/inputs/" + name + "/";
 
   sub_control_ = node.create_subscription<Control>(
@@ -32,10 +33,10 @@ CommandSubscription::CommandSubscription(uint16_t id, const std::string & name, 
   sub_gear_ = node.create_subscription<GearCommand>(
     prefix + "gear", volatile_qos, std::bind(&CommandSubscription::on_gear, this, _1));
   sub_turn_indicators_ = node.create_subscription<TurnIndicatorsCommand>(
-    prefix + "turn_indicators", volatile_qos,
+    prefix + "turn_indicators", transient_qos,
     std::bind(&CommandSubscription::on_turn_indicators, this, _1));
   sub_hazard_lights_ = node.create_subscription<HazardLightsCommand>(
-    prefix + "hazard_lights", volatile_qos,
+    prefix + "hazard_lights", transient_qos,
     std::bind(&CommandSubscription::on_hazard_lights, this, _1));
 }
 

--- a/planning/autoware_hazard_lights_selector/src/node.cpp
+++ b/planning/autoware_hazard_lights_selector/src/node.cpp
@@ -36,9 +36,10 @@ HazardLightsSelector::HazardLightsSelector(const rclcpp::NodeOptions & node_opti
       std::bind(&HazardLightsSelector::on_hazard_lights_command_from_system, this, _1));
 
   // Publisher
+  const auto transient_qos = rclcpp::QoS(1).transient_local();
   pub_hazard_lights_command_ =
     this->create_publisher<autoware_vehicle_msgs::msg::HazardLightsCommand>(
-      "output/hazard_lights_command", 1);
+      "output/hazard_lights_command", transient_qos);
 
   // Timer
   timer_ = rclcpp::create_timer(

--- a/planning/behavior_path_planner/autoware_behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -47,11 +47,11 @@ BehaviorPathPlannerNode::BehaviorPathPlannerNode(const rclcpp::NodeOptions & nod
   }
 
   // publisher
+  const auto durable_qos = rclcpp::QoS(1).transient_local();
   path_publisher_ = create_publisher<PathWithLaneId>("~/output/path", 1);
   turn_signal_publisher_ =
-    create_publisher<TurnIndicatorsCommand>("~/output/turn_indicators_cmd", 1);
+    create_publisher<TurnIndicatorsCommand>("~/output/turn_indicators_cmd", durable_qos);
   hazard_signal_publisher_ = create_publisher<HazardLightsCommand>("~/output/hazard_lights_cmd", 1);
-  const auto durable_qos = rclcpp::QoS(1).transient_local();
   modified_goal_publisher_ =
     create_publisher<PoseWithUuidStamped>("~/output/modified_goal", durable_qos);
   reroute_availability_publisher_ =


### PR DESCRIPTION
## Description
Fix durability configuration to prevent the topic loss dependent on node launch order.
## Related links


**Private Links:**
- [TIER IV internal link](https://tier4.atlassian.net/browse/T4DEV-12719)


## How was this PR tested?
Run planning_simulator with control_cmd_gate
change control_mode
check each control/vehicle command topic
## Notes for reviewers

Need to merge following PR before merge this PR
- [TIER IV internal link](https://github.com/tier4/redundancy_switcher_interface/pull/105)

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
