### PR TITLE
fix(mrm_handler): by clang-tidy with `bugprone-branch-clone`

### DIFF
--- a/system/autoware_mrm_handler/src/mrm_handler/mrm_handler_core.cpp
+++ b/system/autoware_mrm_handler/src/mrm_handler/mrm_handler_core.cpp
@@ -202,12 +202,12 @@ void MrmHandler::operateMrm()
     if (current_mrm_behavior == mrm_state_.behavior) {
       return;
     }
-    if (!requestMrmBehavior(mrm_state_.behavior, RequestType::CANCEL)) {
+    if (
+      !requestMrmBehavior(mrm_state_.behavior, RequestType::CANCEL) ||
+      !requestMrmBehavior(current_mrm_behavior, RequestType::CALL)) {
       handleFailedRequest();
-    } else if (requestMrmBehavior(current_mrm_behavior, RequestType::CALL)) {
-      mrm_state_.behavior = current_mrm_behavior;
     } else {
-      handleFailedRequest();
+      mrm_state_.behavior = current_mrm_behavior;
     }
     return;
   }


### PR DESCRIPTION
## Description

Refactor the code by using clang-tidy with `bugprone-branch-clone`, which is not applied for current `autoware_universe`
- Ref
  - https://clang.llvm.org/extra/clang-tidy/checks/bugprone/branch-clone.html

## How was this PR tested?

TO BE UPDATED after the tests

## Notes for reviewers

Currently we are using the following [`.clang-tidy-ci`](https://github.com/autowarefoundation/autoware/blob/c599c3357951d28e09ad9a3defecccdc89c63663/.clang-tidy-ci)
```
Checks: "
  -*,
  bugprone-*,
  -bugprone-branch-clone,
  -bugprone-easily-swappable-parameters,
  -bugprone-exception-escape,
  -bugprone-implicit-widening-of-multiplication-result,
  -bugprone-infinite-loop,
  -bugprone-integer-division,
  -bugprone-macro-parentheses,
  -bugprone-narrowing-conversions,
  -bugprone-parent-virtual-call,
  -bugprone-reserved-identifier,
  -bugprone-signed-char-misuse"

WarningsAsErrors: "*"

ExtraArgs:
  - -std=c++17
  - -Wno-c11-extensions
```

This means the following `bugprone-` checks are skipped for now.
```
  -bugprone-branch-clone,
  -bugprone-easily-swappable-parameters,
  -bugprone-exception-escape,
  -bugprone-implicit-widening-of-multiplication-result,
  -bugprone-infinite-loop,
  -bugprone-integer-division,
  -bugprone-macro-parentheses,
  -bugprone-narrowing-conversions,
  -bugprone-parent-virtual-call,
  -bugprone-reserved-identifier,
  -bugprone-signed-char-misuse
```

This PR is kind of preparation for adding the `  -bugprone-branch-clone,` check in CI.

## Effects on system behavior

None.