### PR TITLE
fix(start_planner): keep blinker after switching from stop path to pull out path after engage

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/start_planner_module.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/start_planner_module.cpp
@@ -311,8 +311,17 @@ void StartPlannerModule::updateData()
 
   if (
     planner_data_->operation_mode->mode == OperationModeState::AUTONOMOUS &&
-    status_.driving_forward && !status_.first_engaged_and_driving_forward_time) {
-    status_.first_engaged_and_driving_forward_time = clock_->now();
+    status_.driving_forward && status_.found_pull_out_path) {
+    if (!status_.first_engaged_and_driving_forward_time) {
+      status_.first_engaged_and_driving_forward_time = clock_->now();
+      RCLCPP_INFO(
+        getLogger(),
+        "The vehicle switched to autonomous mode while a forward pull out path was found. "
+        "Start waiting for blinker turn on. time: %f",
+        status_.first_engaged_and_driving_forward_time->seconds());
+    }
+  } else {
+    status_.first_engaged_and_driving_forward_time = std::nullopt;
   }
 
   constexpr double moving_velocity_threshold = 0.1;


### PR DESCRIPTION
## Description

### Issue

The implementation included a 3-second waiting period between engaging (or setting to drive) and starting movement (or actual departure).

Scenario:
1. Place pedestrian in front of the vehicle.
2. Set a goal.
3. A stop path is generated.
4. Engage.
5. Remove the pedestrian.
6.  pull out path is generated. (turn on blinker)
7. Start driving

In a case like this, if the elapsed time between steps 4 and 6 is greater than the specified duration (e.g., 3 seconds), then step 7 is executed immediately.

### Solution

Wait for he specified duration (e.g., 3 seconds) from "6. A start path is generated." to "7. A start path is generated." by checking
`status_.found_pull_out_path` condition.

## Related links

- https://tier4.atlassian.net/browse/RT0-39766
- improve https://github.com/autowarefoundation/autoware_universe/pull/6558

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?


### Psim

**before**


https://github.com/user-attachments/assets/f20a3dc4-23c8-4a66-914e-9b5e1ee0a032

**after**

https://github.com/user-attachments/assets/3fdb3997-2ad4-446b-9987-619257845c80


https://github.com/user-attachments/assets/892b013d-fbe1-43df-a679-f081edfe4b93


https://github.com/user-attachments/assets/ece8f395-d75a-4d97-90ee-8b8e242dc063

### Evaluator

1 scenraio fail but not related this PR

- [[PR check (takeuchi)][Lexus][CommonScenario_Basic] planning test](https://evaluation.tier4.jp/evaluation/reports/94670b08-0004-5767-8984-5b825fd137cf?project_id=prd_jt)
- [[PR check (takeuchi)][Lexus][ControlDLRCommon_Basic] DLR test](https://evaluation.tier4.jp/evaluation/reports/cff5e1c1-01e0-5ca5-b2a7-011723e36585?project_id=prd_jt)
- [[PR check (takeuchi)][Lexus][FuncVerificationScenario_Basic] planning test](https://evaluation.tier4.jp/evaluation/reports/f1728c0e-aa3c-5503-ad23-b69183bfc4d7?project_id=prd_jt)

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
