### PR TITLE
feat(start_planner): supprt rtc force approval to bypass safety check 

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/interface/scene_module_interface.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/interface/scene_module_interface.hpp
@@ -585,6 +585,44 @@ protected:
     return existApprovedRequest();
   }
 
+  /**
+   * @brief Checks if any registered module is currently forced activated.
+   *
+   * A module is considered 'force activated' if it has been commanded to ACTIVATE but is currently
+   * operating in an unsafe state or was explicitly requested, ignoring the normal 'safe' constraint
+   * for activation. This check bypasses the standard safety/auto-mode logic and focuses purely on
+   * an overriding command state (ACTIVATE) while the module is either WAITING_FOR_EXECUTION or
+   * RUNNING.
+   *
+   * @return bool True if at least one registered module is force-activated, false otherwise.
+   */
+  bool is_rtc_force_activated() const
+  {
+    return std::any_of(
+      rtc_interface_ptr_map_.begin(), rtc_interface_ptr_map_.end(), [&](const auto & rtc) {
+        const auto & [module_name, rtc_ptr] = rtc;
+        return rtc_ptr->isForceActivated(uuid_map_.at(module_name));
+      });
+  }
+
+  /**
+   * @brief Checks if any registered module is currently forced deactivated.
+   *
+   * A module is typically considered force deactivated if it
+   * has been commanded to DEACTIVATE despite potentially meeting conditions that would
+   * normally permit activation (e.g., overriding a 'safe' state).
+   *
+   * @return bool True if at least one registered module is force-deactivated, false otherwise.
+   */
+  bool is_rtc_force_deactivated() const
+  {
+    return std::any_of(
+      rtc_interface_ptr_map_.begin(), rtc_interface_ptr_map_.end(), [&](const auto & rtc) {
+        const auto & [module_name, rtc_ptr] = rtc;
+        return rtc_ptr->isForceDeactivated(uuid_map_.at(module_name));
+      });
+  }
+
   void removeRTCStatus()
   {
     for (const auto & [module_name, ptr] : rtc_interface_ptr_map_) {

--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/include/autoware/behavior_path_start_planner_module/start_planner_module.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/include/autoware/behavior_path_start_planner_module/start_planner_module.hpp
@@ -79,6 +79,7 @@ struct PullOutStatus
   std::optional<rclcpp::Time> first_engaged_and_driving_forward_time{std::nullopt};
   // record if the ego has departed from the start point
   bool has_departed{false};
+  bool is_safety_check_override_by_rtc{false};  // true if rtc is force activated
 
   PullOutStatus() = default;
 };
@@ -371,6 +372,7 @@ ego pose.
     const PredictedObjects & filtered_objects, const TargetObjectsOnLane & target_objects_on_lane,
     const std::vector<PoseWithVelocityStamped> & ego_predicted_path) const;
   bool isSafePath() const;
+  void check_force_approval();
   void setDrivableAreaInfo(BehaviorModuleOutput & output) const;
 
   // check if the goal is located behind the ego in the same route segment.


### PR DESCRIPTION
## Description

This PR adds force approval feature to start planner module.
When the module outputs unsafe candidate, the force approval feature allows safety operator to manually bypass the safety check result, thus approving the unsafe candidate.


## Related links

Prior PRs:

[feat(start planner): replace zero velocity with stop line on candidate path #11476](https://github.com/autowarefoundation/autoware_universe/pull/11476)
[feat(start planner): support transit from running state to waiting approval state when unsafe #11477](https://github.com/autowarefoundation/autoware_universe/pull/11477)

## How was this PR tested?

Steps:
1. Run PSIM and FOA.
2. Place ego vehicle on bus stop area, and goal pose at any arbitrary area.
3. Approve the path.
4. Place dynamic objects.
5. Check if module is now in waiting approval state.
6. Ensure the `FORCE` option is displayed in FOA.
7. Press `FORCE`
8. See if path is not approved.


### PSIM

#### 1. Force approval when driving forward

https://github.com/user-attachments/assets/7b3043dd-3a1a-4b67-93db-b50cd70abc53

#### 2. Force approval after driving backward

https://github.com/user-attachments/assets/d8b3dcfe-fd35-4e6d-b067-6e0e8d72ec40


### Interval evaluator

[TIER IV Internal Link - ControlDLR Test](https://evaluation.tier4.jp/evaluation/reports/8db33d5b-1617-5582-9d7f-031d52244a2e?project_id=prd_jt)
[TIER IV Internal Link - FuncVerification Test](https://evaluation.tier4.jp/evaluation/reports/4c29f5d9-c526-5aa0-9c90-68acffb57d8b?project_id=prd_jt)
[TIER IV Internal Link - CommonScenario_Basic Test](https://evaluation.tier4.jp/evaluation/reports/e8e22b42-17b9-5838-a25e-58b8c2ef25e6?project_id=prd_jt)

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
