### PR TITLE
fix: pedal_accx initialization for `DELAY_STEER_ACC_GEARED_WO_FALL_GUARD` model

### DIFF
--- a/simulator/autoware_simple_planning_simulator/src/simple_planning_simulator/simple_planning_simulator_core.cpp
+++ b/simulator/autoware_simple_planning_simulator/src/simple_planning_simulator/simple_planning_simulator_core.cpp
@@ -724,6 +724,7 @@ void SimplePlanningSimulator::set_initial_state(const Pose & pose, const Twist &
   const double vy = 0.0;
   const double steer = 0.0;
   const double accx = 0.0;
+  const double pedal_accx = 0.0;
 
   Eigen::VectorXd state(vehicle_model_ptr_->getDimX());
 
@@ -741,13 +742,14 @@ void SimplePlanningSimulator::set_initial_state(const Pose & pose, const Twist &
   } else if (  // NOLINT
     vehicle_model_type_ == VehicleModelType::DELAY_STEER_ACC ||
     vehicle_model_type_ == VehicleModelType::DELAY_STEER_ACC_GEARED ||
-    vehicle_model_type_ == VehicleModelType::DELAY_STEER_ACC_GEARED_WO_FALL_GUARD ||
     vehicle_model_type_ == VehicleModelType::DELAY_STEER_MAP_ACC_GEARED ||
     vehicle_model_type_ == VehicleModelType::ACTUATION_CMD ||
     vehicle_model_type_ == VehicleModelType::ACTUATION_CMD_VGR ||
     vehicle_model_type_ == VehicleModelType::ACTUATION_CMD_MECHANICAL ||
     vehicle_model_type_ == VehicleModelType::ACTUATION_CMD_STEER_MAP) {
     state << x, y, yaw, vx, steer, accx;
+  } else if (vehicle_model_type_ == VehicleModelType::DELAY_STEER_ACC_GEARED_WO_FALL_GUARD) {
+    state << x, y, yaw, vx, steer, accx, pedal_accx;
   }
   vehicle_model_ptr_->setState(state);
 


### PR DESCRIPTION

## Description

In `DELAY_STEER_ACC_GEARED_WO_FALL_GUARD` model, `PEDAL_ACCX`, the 7th state, was not explicitly initialized.
Off-course, defaultly, it's initialized with zero and it's expected behavior.
However, the current implementation performs a 6-dimensional assignment to a 7-dimensional vector, which can cause runtime errors in stricter builds such as Debug builds, and potentially cause errors in other builds as well.

## Related links

None

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.
