### PR TITLE
fix(goal_planner): fix sudden path change after lane change

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/lane_change.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/lane_change.cpp
@@ -16,17 +16,68 @@
 
 #include "autoware/behavior_path_goal_planner_module/util.hpp"
 
+#include <autoware/route_handler/route_handler.hpp>
+
+#include <unordered_set>
 #include <vector>
 
 namespace autoware::behavior_path_planner
 {
 
+namespace
+{
+/**
+ * @brief Get lane sequence from current target lane to goal along route
+ * @details Collects lane IDs from current_target_lane_id to goal_lane_id by traversing
+ *          route. Always returns at least current_target_lane_id.
+ * @note This function is similar to RouteHandler::getLaneletSequenceAfter, but is defined
+ *       separately because it is a private method. The difference is that this function
+ *       searches until goal_lane_id without specifying forward_length.
+ * @param current_target_lane_id Current lane change target lane ID
+ * @param goal_lane_id Goal lane ID
+ * @param lanelet_map Lanelet map
+ * @param route_handler Route handler
+ * @return Vector of lane IDs from current target to goal (at least current_target_lane_id)
+ */
+[[nodiscard]] std::vector<lanelet::Id> get_lanelet_sequence_after(
+  const lanelet::Id current_target_lane_id, const lanelet::Id goal_lane_id,
+  const lanelet::LaneletMapConstPtr & lanelet_map,
+  const autoware::route_handler::RouteHandler & route_handler)
+{
+  std::vector<lanelet::Id> result;
+
+  auto current_lanelet = lanelet_map->laneletLayer.get(current_target_lane_id);
+  result.push_back(current_lanelet.id());
+  if (current_target_lane_id == goal_lane_id) return result;
+
+  std::unordered_set<lanelet::Id> visited;
+  visited.insert(current_target_lane_id);
+  lanelet::ConstLanelet next_lanelet;
+  while (route_handler.getNextLaneletWithinRoute(current_lanelet, &next_lanelet)) {
+    const auto next_id = next_lanelet.id();
+
+    if (visited.find(next_id) != visited.end()) break;
+
+    visited.insert(next_id);
+    result.push_back(next_id);
+
+    if (next_id == goal_lane_id) return result;
+
+    current_lanelet = next_lanelet;
+  }
+
+  return result;
+}
+}  // namespace
+
 LaneChangeContext::State LaneChangeContext::get_next_state(
   const autoware_internal_planning_msgs::msg::PathWithLaneId & path,
-  const lanelet::LaneletMapConstPtr lanelet_map,
-  lanelet::routing::RoutingGraphConstPtr routing_graph, const rclcpp::Time & now,
-  const lanelet::Id goal_lanelet_id) const
+  const autoware::route_handler::RouteHandler & route_handler, const rclcpp::Time & now) const
 {
+  const auto lanelet_map = route_handler.getLaneletMapPtr();
+  const auto routing_graph = route_handler.getRoutingGraphPtr();
+  const auto goal_lanelet_id = route_handler.getGoalLaneId();
+
   if (is_state<Completed>()) {
     return state_;
   }
@@ -48,22 +99,37 @@ LaneChangeContext::State LaneChangeContext::get_next_state(
       }
     }
     if (lane_ids.empty()) {
+      RCLCPP_WARN(
+        rclcpp::get_logger("behavior_path_planner.goal_planner.lane_change"),
+        "no lane ids on the path, judging as Aborted");
       return Aborted{};
     }
     const auto current_target_lane_id = is_state<Started>()
                                           ? std::get<Started>(state_).complete_lane()
                                           : std::get<Executing>(state_).complete_lane();
-    if (
-      lane_ids.front() == current_target_lane_id &&
-      std::find(lane_ids.begin(), lane_ids.end(), goal_lanelet_id) != lane_ids.end()) {
+    const auto following_ids = get_lanelet_sequence_after(
+      current_target_lane_id, goal_lanelet_id, lanelet_map, route_handler);
+    const bool is_on_following_lanes =
+      std::find(following_ids.cbegin(), following_ids.cend(), lane_ids.front()) !=
+      following_ids.cend();
+    const bool has_goal_lane =
+      std::find(lane_ids.cbegin(), lane_ids.cend(), goal_lanelet_id) != lane_ids.cend();
+    if (is_on_following_lanes && has_goal_lane) {
       const auto & exec =
         is_state<Started>() ? Executing{std::get<Started>(state_)} : std::get<Executing>(state_);
       return Completed{exec};
     }
+
     return Aborted{};
   }
 
-  // Aborted or NotLaneChanging
+  if (is_lane_changing_path) {
+    RCLCPP_INFO(
+      rclcpp::get_logger("behavior_path_planner.goal_planner.lane_change"),
+      "lane change started to lane %ld", lane_change_complete_lane.value().id());
+  }
+
+  // Started or NotLaneChanging
   return is_lane_changing_path ? State{Started{lane_change_complete_lane.value().id(), now}}
                                : State{NotLaneChanging{}};
 }


### PR DESCRIPTION
## Description

Fixed an issue where the goal planner's path suddenly changed after a lane change.
This PR includes 3 changes. (1) fixes the Issue.

1)
The goal planner has a function to estimate the lane change status from the upstream module. Based on this estimation, the goal planner decides whether to regenerate the pull over path or continue using the existing one.

Currently, a lane change is considered "consistently" Completed only if the target lane ID of the lane change matches the front ID of the path from the upstream module. If they do not match, it's considered a "not consistent" transition, and thus judged as Aborted. In the case of a "not consistent" transition, the goal planner rejects the response and waits for a new candidate path to be generated in a separate thread, with a log like this:

```
        "lane change has been executed or cancelled while LaneParking thread was planning. "
        "lane change state transition: %s -> %s. Reject the response and wait for LaneParking "
        "thread to complete",
```

- the case causing path change issue

<img width="2152" height="1329" alt="image" src="https://github.com/user-attachments/assets/cee3536b-ab00-4a23-91c9-e7b541f420e6" />

- current logic

<img width="1922" height="1448" alt="image" src="https://github.com/user-attachments/assets/53a2e418-6dbe-4b02-b03e-b5723b94b79d" />

This PR improves the condition for Completed.
Due to the shape of the lane change path, Ego vehicle speed, and lane geometry, there is no guarantee that the path front will exactly match the lane change target lane at a specific moment; it is possible for it to pass beyond it. This PR changes the condition to judge the lane change as "consistently" Completed if the path front ID has passed the lane change target lane (meaning the front ID is the target lane or a lane following the target lane sequence).

- new logic

<img width="1641" height="1794" alt="image" src="https://github.com/user-attachments/assets/eabaa8e9-29f9-407a-a772-ef7d4a63e7dd" />

2)
Stop updating candidate paths if the current path is already "DECIDED".

3)
(minor): Added print statements for improved debuggability.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

https://tier4.atlassian.net/browse/T4DEV-33706

## How was this PR tested?

1) psim + perception_reproducer (try several times)

before

https://github.com/user-attachments/assets/a24e5180-272c-411d-9fc4-1205d0bf5cea


after


https://github.com/user-attachments/assets/6bf3c1fb-ee44-45b0-9b72-2b29bfa89de0

2) Evaluator 

:100:

- [[PR check (takeuchi)][Lexus][CommonScenario_Basic] planning test](https://evaluation.tier4.jp/evaluation/reports/87f69185-9c21-55b2-98e3-3cb92791c362?project_id=prd_jt)
- [[PR check (takeuchi)][Lexus][FuncVerificationScenario_Basic] planning test](https://evaluation.tier4.jp/evaluation/reports/20d1082f-26ab-5105-aab0-b029f359786f?project_id=prd_jt)
- [[PR check (takeuchi)][Lexus][ControlDLRCommon_Basic] DLR test](https://evaluation.tier4.jp/evaluation/reports/dacfc968-6378-5d44-9374-e366bba4c18e?project_id=prd_jt)




## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
