### PR TITLE
ci(bnt-diff-packages-above): differentiate the cache key

### DIFF
--- a/.github/workflows/build-and-test-packages-above-differential.yaml
+++ b/.github/workflows/build-and-test-packages-above-differential.yaml
@@ -117,7 +117,7 @@ jobs:
           target-packages: ${{ steps.get-modified-packages.outputs.modified-packages }}
           build-depends-repos: build_depends.repos
           packages-above-repos: packages_above.repos
-          cache-key-element: ${{ env.BUILD_TYPE_CUDA_STATE }}
+          cache-key-element: ${{ env.BUILD_TYPE_CUDA_STATE }}-above
           build-pre-command: ${{ inputs.build-pre-command }}
 
       - name: Show ccache stats after build


### PR DESCRIPTION
## Issue & description

This cache key was reserved to the only build and test differential `cuda` or `nocuda`.
But with the introduction of the `-packages-above` version of this workflow, it is competing with the cache of the existing ones.
And it creates issues for restoring the correct cache.

---

[Here @build-and-test-differential-packages-above](https://github.com/autowarefoundation/autoware_universe/actions/runs/18508557993/job/52743612608?pr=8871#step:16:7155):

> ```
> Cache saved with key: build-X64-humble-nocuda-Release-533b22e56ac5b4306c92fc9a303fc5c57b26d66f
> ```

The `build-and-test-differential-packages-above` version created the cache first.

▶️ This cache is not even necessary, it is meant to be used by clang-tidy-differential but this workflow doesn't have one.
Since [colcon-build/action.yaml](https://github.com/autowarefoundation/autoware-github-actions/blob/20155d9fc583d5c5d79d965874e519356fd4c8bc/colcon-build/action.yaml) doesn't have a way to prevent caching in the first place, quickest solution is to just give it a new key name.

---

[Here @build-and-test-differential](https://github.com/autowarefoundation/autoware_universe/actions/runs/18508557993/job/52743612560?pr=8871#step:15:7098):

> ```
> Failed to save: Unable to reserve cache with key build-X64-humble-nocuda-Release-533b22e56ac5b4306c92fc9a303fc5c57b26d66f, another job may be creating this cache.
> Warning: Cache save failed.
> ```
> 

The cache failed to be created by the original `build-and-test-differential`.

---

[Here @clang-tidy-differential](https://github.com/autowarefoundation/autoware_universe/actions/runs/18508557993/job/52744436133?pr=8871#step:13:439):

> ```
> Run actions/cache/restore@v4
>   with:
>     key: build-X64-humble-nocuda-Release-533b22e56ac5b4306c92fc9a303fc5c57b26d66f
> ```

The `clang-tidy-differential` restored the wrong cache from the `build-and-test-differential-packages-above` instead of the correct `build-and-test-differential`.

---

This PR fixes that by differentiating the cache key for the `-above`.

## Related links

- Related PR: https://github.com/autowarefoundation/autoware_universe/pull/8871

## How was this PR tested?

It's so simple and predictable, no need.

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.
