### PR TITLE
fix(goal_planner): fix virtual wall and debug marker publishing

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/goal_planner_module.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/goal_planner_module.cpp
@@ -1063,7 +1063,9 @@ BehaviorModuleOutput GoalPlannerModule::plan()
         getLogger(), *clock_, 5000, " [pull_over] plan() is called without valid context_data");
     } else {
       auto & context_data_mut = context_data_.value();
-      return planPullOver(context_data_mut);
+      const auto output = planPullOver(context_data_mut);
+      set_longitudinal_planning_factor(output.path);
+      return output;
     }
   }
 
@@ -1746,9 +1748,6 @@ BehaviorModuleOutput GoalPlannerModule::planPullOverAsOutput(PullOverContextData
     }
   }
 
-  // For debug
-  setDebugData(context_data);
-
   if (!pull_over_path_with_velocity_opt) {
     return output;
   }
@@ -1773,6 +1772,7 @@ void GoalPlannerModule::postProcess()
     LaneParkingResponse{}, FreespaceParkingResponse{});
   const auto & context_data =
     context_data_.has_value() ? context_data_.value() : context_data_dummy;
+  setDebugData(context_data);
 
   const bool has_decided_path =
     path_decision_controller_.get_current_state().state == PathDecisionState::DecisionKind::DECIDED;
@@ -1791,8 +1791,6 @@ void GoalPlannerModule::postProcess()
   updatePlanningFactor(
     context_data, {pull_over_path.start_pose(), pull_over_path.modified_goal_pose()},
     {distance_to_path_change.first, distance_to_path_change.second});
-
-  set_longitudinal_planning_factor(pull_over_path.full_path());
 }
 
 BehaviorModuleOutput GoalPlannerModule::planWaitingApproval()
@@ -1807,7 +1805,9 @@ BehaviorModuleOutput GoalPlannerModule::planWaitingApproval()
         "planner");
     } else {
       auto & context_data_mut = context_data_.value();
-      return planPullOverAsCandidate(context_data_mut, "waiting approval");
+      const auto output = planPullOverAsCandidate(context_data_mut, "waiting approval");
+      set_longitudinal_planning_factor(output.path);
+      return output;
     }
   }
 


### PR DESCRIPTION
## Description

Currently goal planner does not publish virtual wall and debug marker at some conditions. For example not pull over path is found.
 
```
  if (!context_data.pull_over_path_opt) {
    return;
  }
```

before (stop wall is NOT published)

<img width="2649" height="1718" alt="image" src="https://github.com/user-attachments/assets/b609d0f9-d653-43ed-8207-39808a0ad02e" />

after (stop wall is published)

<img width="2649" height="1718" alt="image" src="https://github.com/user-attachments/assets/00795c1e-588c-447a-875d-4a65fd990d22" />



## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

wip:

some scenarios failed but not related to this PR

- [[PR check (takeuchi)][Lexus][CommonScenario_Basic] planning test](https://evaluation.tier4.jp/evaluation/reports/4d6a3c49-8080-5e30-b02a-8a85c738f84b?project_id=prd_jt)
- [[PR check (takeuchi)][Lexus][FuncVerificationScenario_Basic] planning test](https://evaluation.tier4.jp/evaluation/reports/481742bf-215f-58bf-8905-386c6d0238ed?project_id=prd_jt)
- [[PR check (takeuchi)][Lexus][ControlDLRCommon_Basic] DLR test](https://evaluation.tier4.jp/evaluation/reports/684762f2-9ebd-5cd7-9d1a-3dc16ea86766?project_id=prd_jt)

compare with baseline

https://evaluation.tier4.jp/evaluation/reports/tables/new?catalog_id=095ae8b3-a23b-4a08-8674-10a681449693&filter=&job_id=4d6a3c49-8080-5e30-b02a-8a85c738f84b&project_id=prd_jt&table_config=date%2Chide&target_ids=72cf9eeb-c09b-55ae-8b49-9448c2e2e668

https://star4.slack.com/archives/C04HK9T2E0N/p1760527967456399


## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
