### PR TITLE
fix(autoware_pointcloud_preprocessor): prevent race condition

### DIFF
--- a/sensing/autoware_pointcloud_preprocessor/include/autoware/pointcloud_preprocessor/concatenate_data/cloud_collector.hpp
+++ b/sensing/autoware_pointcloud_preprocessor/include/autoware/pointcloud_preprocessor/concatenate_data/cloud_collector.hpp
@@ -59,7 +59,8 @@ public:
   void set_info(std::shared_ptr<CollectorInfoBase> collector_info);
   [[nodiscard]] std::shared_ptr<CollectorInfoBase> get_info() const;
   void show_debug_message(
-    const std::unordered_map<std::string, typename MsgTraits::PointCloudMessage::ConstSharedPtr> & topic_to_cloud_map,
+    const std::unordered_map<std::string, typename MsgTraits::PointCloudMessage::ConstSharedPtr> &
+      topic_to_cloud_map,
     const std::shared_ptr<CollectorInfoBase> & collector_info);
   void reset();
 

--- a/sensing/autoware_pointcloud_preprocessor/include/autoware/pointcloud_preprocessor/concatenate_data/concatenate_and_time_sync_node.hpp
+++ b/sensing/autoware_pointcloud_preprocessor/include/autoware/pointcloud_preprocessor/concatenate_data/concatenate_and_time_sync_node.hpp
@@ -113,7 +113,7 @@ private:
   std::unique_ptr<CollectorMatchingStrategy<MsgTraits>> collector_matching_strategy_;
 
   static constexpr const int num_of_collectors{3};
-  
+
   // Thread-safe initialization
   std::once_flag init_collectors_flag_;
   // Mutex to protect cloud_collectors_ list access

--- a/sensing/autoware_pointcloud_preprocessor/include/autoware/pointcloud_preprocessor/concatenate_data/concatenate_and_time_sync_node.ipp
+++ b/sensing/autoware_pointcloud_preprocessor/include/autoware/pointcloud_preprocessor/concatenate_data/concatenate_and_time_sync_node.ipp
@@ -215,14 +215,14 @@ void PointCloudConcatenateDataSynchronizerComponentTemplated<MsgTraits>::cloud_c
 
   {
     std::lock_guard<std::mutex> lock(collectors_mutex_);
-    
+
     // Reset finished collectors first
     for (auto & collector : cloud_collectors_) {
       if (collector->get_status() == CollectorStatus::Finished) {
         collector->reset();
       }
     }
-    
+
     if (!cloud_collectors_.empty()) {
       cloud_collector =
         collector_matching_strategy_->match_cloud_to_collector(cloud_collectors_, matching_params);


### PR DESCRIPTION
## Description

We are using previous version of the concatenate_data module (software version v4.2). During one of the tests, a segmentation fault occurred, likely related to a potential race condition. Although an older version of the package is in use, a detailed investigation of the current implementation was performed after observing this issue.

<img width="1705" height="394" alt="Screenshot from 2025-10-14 15-37-07" src="https://github.com/user-attachments/assets/7b785902-92b3-4d94-bd7b-b550e717711c" />


The point cloud nodes run inside a  point cloud multi-threaded component container that utilizes the container’s multi-threaded executor. Callbacks (timers, subs, etc.) may run in parallel.

The possibility of occurrence is very low, but in the current implementation, the following cases might cause a race condition:

1. `topic_to_cloud_map_` Data Race
**Problem:** Multiple threads accessing the pointcloud map concurrently:
- **Thread A**: Adding pointclouds via `process_pointcloud()`
- **Thread B**: Reading/copying map in `concatenate_callback()` (timer thread)
- **Result**: Map corruption, iterator invalidation, undefined behavior


2. Collector Status Race Condition
**Problem:** `status_` member modified without synchronization:
- **Thread A:** Checking status in main callback thread
- **Thread B:** Changing status in timer callback thread
- **Result:** Inconsistent status reads, duplicate processing

3. `cloud_collectors_` List Race Condition
**Problem:** Collector list accessed by multiple callbacks without protection:
- **Thread A:** `cloud_callback()` searching/modifying collectors
- **Thread B:** `manage_collector_list()` resetting finished collectors
- **Result:** List corruption, memory access violations

4. Initialization Race Condition
**Problem:** Non-thread-safe collector list initialization:
- Multiple threads could initialize collectors simultaneously
- **Result:** Duplicate initialization, resource leaks

5. `collector_info_` Access Race
**Problem:** Shared pointer accessed without synchronization:
- **Thread A:** Setting collector info via` set_info()`
- **Thread B:** Reading info via `get_info()`
- **Result:** Use-after-free, null pointer dereference

Relevant mutex/lock mechanisms have been added, and logging operations have been moved outside the lock to prevent potential deadlocks.

I may have missed some parts, could you please give me feedback after reviewing it?

## Related links

**Parent Issue:**

- Link


- [TIERIV internal link](https://tier4.atlassian.net/browse/ISSJP-3236)


## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
