### PR TITLE
feat(obstacle_slow_down): update velocity calclation

### DIFF
--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_slow_down_module/README.md
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_slow_down_module/README.md
@@ -61,7 +61,7 @@ The following low-pass filters will be applied.
 
 - `slow_down_planning.lpf_gain_slow_down_vel`
   - slow down velocity
-- `slow_down_planning.lpf_gain_lat_dist`
+- `slow_down_planning.lpf_gain_lateral_distance`
   - lateral distance of obstacles to the ego's trajectory to calculate the target velocity
 - `slow_down_planning.lpf_gain_dist_to_slow_down`
   - distance to the slow down point

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_slow_down_module/config/obstacle_slow_down.param.yaml
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_slow_down_module/config/obstacle_slow_down.param.yaml
@@ -5,8 +5,8 @@
         slow_down_min_acc: -1.0         # slow down min deceleration [m/ss]
         slow_down_min_jerk: -1.0        # slow down min jerk [m/sss]
 
-        lpf_gain_slow_down_vel: 0.99 # low-pass filter gain for slow down velocity
-        lpf_gain_lat_dist: 0.999 # low-pass filter gain for lateral distance from obstacle to ego's path
+        lpf_gain_slow_down_vel: 0.9 # low-pass filter gain for slow down velocity
+        lpf_gain_lateral_distance: 0.7 # low-pass filter gain for lateral distance from obstacle to ego's path
         lpf_gain_dist_to_slow_down: 0.7 # low-pass filter gain for distance to slow down start
 
         time_margin_on_target_velocity: 1.5 # [s]

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_slow_down_module/src/parameters.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_slow_down_module/src/parameters.hpp
@@ -151,7 +151,7 @@ struct SlowDownPlanningParam
   double slow_down_min_jerk{};
 
   double lpf_gain_slow_down_vel{};
-  double lpf_gain_lat_dist{};
+  double lpf_gain_lateral_distance{};
   double lpf_gain_dist_to_slow_down{};
 
   double time_margin_on_target_velocity{};
@@ -172,8 +172,8 @@ struct SlowDownPlanningParam
 
     lpf_gain_slow_down_vel = get_or_declare_parameter<double>(
       node, "obstacle_slow_down.slow_down_planning.lpf_gain_slow_down_vel");
-    lpf_gain_lat_dist = get_or_declare_parameter<double>(
-      node, "obstacle_slow_down.slow_down_planning.lpf_gain_lat_dist");
+    lpf_gain_lateral_distance = get_or_declare_parameter<double>(
+      node, "obstacle_slow_down.slow_down_planning.lpf_gain_lateral_distance");
     lpf_gain_dist_to_slow_down = get_or_declare_parameter<double>(
       node, "obstacle_slow_down.slow_down_planning.lpf_gain_dist_to_slow_down");
     time_margin_on_target_velocity = get_or_declare_parameter<double>(

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_slow_down_module/src/types.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_slow_down_module/src/types.hpp
@@ -80,6 +80,8 @@ struct SlowDownObstacle
   double lat_velocity{};            // lateral velocity against ego's trajectory
 
   double dist_to_traj_poly{};  // for efficient calculation
+  // TODO(takagi): remove mutable by refactoring the previous output usage.
+  mutable std::optional<double> stable_dist_to_traj_poly{};
   geometry_msgs::msg::Point front_collision_point{};
   geometry_msgs::msg::Point back_collision_point{};
   ObjectClassification classification{};


### PR DESCRIPTION
## Description
**Feature Change: Modified the Calculation Formula for the Deceleration Point**
Previously, the calculated deceleration point for an approaching vehicle would move closer to the ego vehicle with each calculation cycle. This occurred because as the ego vehicle began to slow down, subsequent calculations would use this new, lower speed, pushing the required deceleration point closer. This often led to abrupt deceleration or a failure to slow down in time.

To address this, the logic now anticipates the ego vehicle's speed drop from its current value to the target speed. From this potential speed range, it selects the speed that establishes a stable, worst-case deceleration point from the outset.

This change mitigates the issue of the deceleration point creeping closer and now creeping far. Note: The deceleration point may still shift due to the acceleration or deceleration of other vehicles.


**Fix: Used the Correct Parameter**
Corrected an instance where common_param_.min_accel was used instead of the appropriate parameter, slow_down_planning_param_.slow_down_min_acc. This did not affect behavior when using default parameters, as both have the same value.


**Fix/Improvement: Improved the Value-Holding Mechanism for Deceleration Constraint Logic**
Previously, the value-holding mechanism within the deceleration-constrained speed planning logic could not account for shifts in the deceleration point's position. A formula has been added to adjust the previously calculated maximum deceleration speed based on changes in the deceleration point's location.


**Fix: Fixed Bug in Low-Pass Filter for Lateral Distance Calculation**
Fixed an issue where a section intended to function as a low-pass filter (LPF) was incorrectly outputting a simple weighted average of the previous and current values. This was caused by internal values not being updated correctly. Although this is a bug fix, it is also a breaking change, as existing default parameter values will no longer function appropriately. Consequently, the parameter name has been changed.

## Related links
launch PR: https://github.com/autowarefoundation/autoware_launch/pull/1674

## How was this PR tested?
psim and tier4 scenario test

## Notes for reviewers

None.

## Interface changes

None.



## Effects on system behavior

None.
