### PR TITLE
fix(crosswalk): set object classification label before making decision

### DIFF
--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/scene_crosswalk.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/scene_crosswalk.hpp
@@ -328,12 +328,12 @@ public:
       }
 
       // update object state
+      objects.at(uuid).classification = classification;
       objects.at(uuid).transitState(
         now, position, vel, is_ego_yielding, collision_point, planner_param, crosswalk_polygon,
         is_object_away_from_path, ego_crosswalk_passage_direction);
       objects.at(uuid).collision_point = collision_point;
       objects.at(uuid).position = position;
-      objects.at(uuid).classification = classification;
       objects.at(uuid).last_detection_time = now;
     }
     void finalize(const rclcpp::Time & now, const PlannerParam & planner_param)


### PR DESCRIPTION
## Description

This PR fixes a bug in the crosswalk module where an object's classification label was updated _after_ decisions were made based on it.

The `ObjectInfo::transitState()` function uses an object's classification label (e.g., `CAR`, `PEDESTRIAN`) to make decisions. However, this label was being set after `transitState()` was called.
This resulted in the function using stale data for one iteration:
- On an object's first appearance, its label was the default `UNKNOWN`.
- If an object's classification changed (e.g., from `CAR` to `PEDESTRIAN`), the decision was still based on the old label for one cycle.

This PR fixes this bug by updating the classification label before calling `transitState()`.

## Related links

**Private Links:**

- [TIER IV internal link](https://tier4.atlassian.net/browse/T4DEV-33824)

## How was this PR tested?

- Psim.
- Psim + Replayer.
- Evaluator: https://evaluation.tier4.jp/evaluation/reports/55cc5de9-6ee3-512d-af74-d73ced3e2964?project_id=x2_dev

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
