### PR TITLE
feat(autoware_traffic_light_arbiter): properly (bilaterally) treat priority

### DIFF
--- a/perception/autoware_traffic_light_arbiter/src/traffic_light_arbiter.cpp
+++ b/perception/autoware_traffic_light_arbiter/src/traffic_light_arbiter.cpp
@@ -275,7 +275,8 @@ void TrafficLightArbiter::arbitrateAndPublish(const builtin_interfaces::msg::Tim
 
         if (
           !success &&
-          (iter_element.confidence < element.confidence || iter_priority < element_priority)) {
+          (element_priority > iter_priority ||
+           (element_priority == iter_priority && element.confidence > iter_element.confidence))) {
           iter->second = elements_and_priority;
         }
       }

--- a/perception/autoware_traffic_light_arbiter/test/test_node.cpp
+++ b/perception/autoware_traffic_light_arbiter/test/test_node.cpp
@@ -833,13 +833,13 @@ TEST(TrafficLightArbiterTest, testPerceptionPriorityWithExternalPredictions)
     TrafficSignal traffic_light_group;
     traffic_light_group.traffic_light_group_id = 1012;
 
-    // GREEN circle element with lower confidence
+    // GREEN circle element with higher confidence
     {
       TrafficElement element;
       element.color = TrafficElement::GREEN;
       element.shape = TrafficElement::CIRCLE;
       element.status = TrafficElement::SOLID_ON;
-      element.confidence = 0.6;
+      element.confidence = 1.0;  // higher confidence than perception element
       traffic_light_group.elements.push_back(element);
     }
 


### PR DESCRIPTION
## Description

The function `get_highest_confidence_elements` was not idempotent with respect to the order of elements in the input array. Priority and confidence are considered independent variables and not hierarchical and the one that comes last was chosen for either higher confidence or higher priority. It worked before, because only unilateral priority (external) was present and the external signal would come last in the input vector. 

## Related links

PR for source priority [here](https://github.com/autowarefoundation/autoware_universe/pull/11494)

- Link

**Private Links:**

- [TIER IV slack link](https://star4.slack.com/archives/CRUE57C30/p1760674868258049?thread_ts=1757046327.934149&cid=CRUE57C30)

## How was this PR tested?

Unit test was modified to cover the previous issue

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
