### PR TITLE
fix(diffusion_planner): change the default parameters

### DIFF
--- a/planning/autoware_diffusion_planner/config/diffusion_planner.param.yaml
+++ b/planning/autoware_diffusion_planner/config/diffusion_planner.param.yaml
@@ -13,7 +13,7 @@
     build_only: false
     batch_size: 1
     temperature: [0.5]
-    velocity_smoothing_window: 1
+    velocity_smoothing_window: 8
     debug_params:
-      publish_debug_route: false
+      publish_debug_route: true
       publish_debug_map: false

--- a/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/diffusion_planner_node.hpp
+++ b/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/diffusion_planner_node.hpp
@@ -120,7 +120,7 @@ struct DiffusionPlannerParams
 };
 struct DiffusionPlannerDebugParams
 {
-  bool publish_debug_route{false};
+  bool publish_debug_route{true};
   bool publish_debug_map{false};
 };
 

--- a/planning/autoware_diffusion_planner/schema/diffusion_planner.schema.json
+++ b/planning/autoware_diffusion_planner/schema/diffusion_planner.schema.json
@@ -80,7 +80,7 @@
         },
         "velocity_smoothing_window": {
           "type": "integer",
-          "default": 1,
+          "default": 8,
           "minimum": 1,
           "description": "Window size for velocity smoothing. Set to 1 to disable smoothing."
         },
@@ -94,7 +94,7 @@
             },
             "publish_debug_route": {
               "type": "boolean",
-              "default": false,
+              "default": true,
               "description": "Publish debug route markers"
             }
           },

--- a/planning/autoware_diffusion_planner/src/diffusion_planner_node.cpp
+++ b/planning/autoware_diffusion_planner/src/diffusion_planner_node.cpp
@@ -131,13 +131,13 @@ void DiffusionPlanner::set_up_params()
   params_.batch_size = this->declare_parameter<int>("batch_size", 1);
   params_.temperature_list = this->declare_parameter<std::vector<double>>("temperature", {0.5});
   params_.velocity_smoothing_window =
-    this->declare_parameter<int64_t>("velocity_smoothing_window", 1);
+    this->declare_parameter<int64_t>("velocity_smoothing_window", 8);
 
   // debug params
   debug_params_.publish_debug_map =
     this->declare_parameter<bool>("debug_params.publish_debug_map", false);
   debug_params_.publish_debug_route =
-    this->declare_parameter<bool>("debug_params.publish_debug_route", false);
+    this->declare_parameter<bool>("debug_params.publish_debug_route", true);
 }
 
 SetParametersResult DiffusionPlanner::on_parameter(

--- a/planning/autoware_diffusion_planner/test/postprocessing_utils_test.cpp
+++ b/planning/autoware_diffusion_planner/test/postprocessing_utils_test.cpp
@@ -44,7 +44,7 @@ TEST(PostprocessingUtilsTest, CreateTrajectoryAndMultipleTrajectories)
   rclcpp::Time stamp(123, 0);
 
   auto expected_points = prediction_shape[2];
-  const int64_t velocity_smoothing_window = 1;
+  const int64_t velocity_smoothing_window = 8;
   auto traj =
     postprocess::create_ego_trajectory(data, stamp, transform, 0, velocity_smoothing_window);
   ASSERT_EQ(traj.points.size(), expected_points);


### PR DESCRIPTION
## Description

This PR updates default parameter values for the diffusion planner.

- Changed `velocity_smoothing_window` default from 1 to 8
- Changed `publish_debug_route` default from false to true

Empirically, setting `velocity_smoothing_window` to 8 is effective for speed and acceleration planning, and `publish_debug_route` is useful for debugging with little additional computational cost.

## How was this PR tested?

Run `autoware_diffusion_planner`

## Notes for reviewers

None.

## Interface changes

### ROS Parameter Changes

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `velocity_smoothing_window` | `int` | `1`         | Window size for velocity smoothing. Set to 1 to disable smoothing |
| New     | `velocity_smoothing_window` | `int` | `8`         | Window size for velocity smoothing. Set to 1 to disable smoothing |
| Old     | `publish_debug_route` | `bool` | `false`         | Publish debug route markers |
| New     | `publish_debug_route` | `bool` | `true`         | Publish debug route markers |

## Effects on system behavior

None.
