### PR TITLE
feat(goal_planner): change debug marker color when DECIDING

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/goal_planner_module.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/goal_planner_module.cpp
@@ -2660,7 +2660,7 @@ void GoalPlannerModule::setDebugData(const PullOverContextData & context_data)
     const auto color = state == PathDecisionState::DecisionKind::DECIDED
                          ? create_marker_color(1.0, 1.0, 0.0, 0.999)  // yellow
                        : state == PathDecisionState::DecisionKind::DECIDING
-                         ? create_marker_color(0.5, 1.0, 0.0, 0.999)   // yellow-green
+                         ? create_marker_color(1.0, 0.5, 0.0, 0.999)   // orange
                          : create_marker_color(0.0, 1.0, 0.0, 0.999);  // green
     const double z = planner_data_->route_handler->getGoalPose().position.z;
     add_info_marker(


### PR DESCRIPTION
## Description

Add color for pull_over_area when DECIDING state

NOT_DECIDED
<img width="2000" height="796" alt="image" src="https://github.com/user-attachments/assets/2cdd6045-3f77-468b-9c5e-7960fc75d5ea" />

DECIDING

<img width="1536" height="806" alt="image" src="https://github.com/user-attachments/assets/03f12554-2324-415c-be00-ae92fdc768bc" />


DECIDED

<img width="2000" height="796" alt="image" src="https://github.com/user-attachments/assets/46690a6a-848c-4bff-bd47-93fe09eac952" />


https://github.com/user-attachments/assets/a6552df1-17c7-4837-9849-32e8dcd7e5bd

(with: https://github.com/autowarefoundation/autoware_universe/pull/11530)

https://github.com/user-attachments/assets/c13f38ce-6594-499e-9366-e9cf0a98dd5f






## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

- [[PR check (takeuchi)][Lexus][CommonScenario_Basic] planning test](https://evaluation.tier4.jp/evaluation/reports/90b1cbb8-6bf3-50b1-8313-ab0b26088e88?project_id=prd_jt)
- [[PR check (takeuchi)][Lexus][ControlDLRCommon_Basic] DLR test](https://evaluation.tier4.jp/evaluation/reports/0cc71294-b13b-5d79-8359-e86c56ddb6ca?project_id=prd_jt)
- [[PR check (takeuchi)][Lexus][FuncVerificationScenario_Basic] planning test](https://evaluation.tier4.jp/evaluation/reports/ae66143b-934d-5f8f-b059-fadb2702cd07?project_id=prd_jt)

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
