### PR TITLE
fix(goal_planner): revert #11508

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/default_fixed_goal_planner.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/default_fixed_goal_planner.cpp
@@ -95,10 +95,7 @@ PathWithLaneId DefaultFixedGoalPlanner::modifyPathForSmoothGoalConnection(
   autoware_internal_planning_msgs::msg::PathWithLaneId refined_path;
   while (goal_search_radius >= 0 && !is_valid_path) {
     refined_path = utils::refinePathForGoal(
-      goal_search_radius, M_PI * 0.5, output_path_interval, path, refined_goal, goal_lane_id,
-      [&](int64_t lane_id) -> lanelet::ConstLanelet {
-        return planner_data->route_handler->getLaneletMapPtr()->laneletLayer.get(lane_id);
-      });
+      goal_search_radius, M_PI * 0.5, output_path_interval, path, refined_goal, goal_lane_id);
     if (isPathValid(refined_path, planner_data)) {
       is_valid_path = true;
     }

--- a/planning/behavior_path_planner/autoware_behavior_path_planner/test/test_utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner/test/test_utils.cpp
@@ -74,19 +74,19 @@ TEST(BehaviorPathPlanningUtilitiesBehaviorTest, setGoal)
   path.points.at(3).lane_ids.push_back(5);
   path.points.at(4).lane_ids.push_back(5);
 
-  auto get_lanelet_by_id = [&](int64_t lane_id) -> lanelet::ConstLanelet {
-    return {
-      lane_id, lanelet::LineString3d(lanelet::utils::getId()),
-      lanelet::LineString3d(lanelet::utils::getId())};
-  };
-
   PathWithLaneId path_with_goal;
   autoware::behavior_path_planner::utils::set_goal(
-    3.5, M_PI * 0.5, 2.0, path, path.points.back().point.pose, 5, get_lanelet_by_id,
-    &path_with_goal);
+    3.5, M_PI * 0.5, 2.0, path, path.points.back().point.pose, 5, &path_with_goal);
 
   // Check if skipped lane ids by smooth skip connection are filled in output path.
   EXPECT_EQ(path_with_goal.points.size(), 7U);
+  ASSERT_THAT(path_with_goal.points.at(0).lane_ids, testing::ElementsAre(0));
+  ASSERT_THAT(path_with_goal.points.at(1).lane_ids, testing::ElementsAre(1));
+  ASSERT_THAT(path_with_goal.points.at(2).lane_ids, testing::ElementsAre(1));
+  ASSERT_THAT(path_with_goal.points.at(3).lane_ids, testing::ElementsAre(1));
+  ASSERT_THAT(path_with_goal.points.at(4).lane_ids, testing::ElementsAre(2, 3, 4, 5));
+  ASSERT_THAT(path_with_goal.points.at(5).lane_ids, testing::ElementsAre(2, 3, 4, 5));
+  ASSERT_THAT(path_with_goal.points.at(6).lane_ids, testing::ElementsAre(5));
 }
 
 TEST(BehaviorPathPlanningUtilitiesBehaviorTest, expandLanelets)

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/utils/utils.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/utils/utils.hpp
@@ -287,15 +287,12 @@ std::optional<lanelet::ConstLanelet> getLeftLanelet(
  * @param [in] input original path
  * @param [in] goal original goal pose
  * @param [in] goal_lane_id [unused]
- * @param [in] route_handler Route handler.
  * @param [in] output_ptr output path with modified points for the goal
  */
 bool set_goal(
   const double search_radius_range, const double search_rad_range,
   const double output_path_interval, const PathWithLaneId & input, const Pose & goal,
-  const int64_t goal_lane_id,
-  const std::function<lanelet::ConstLanelet(int64_t)> & get_lanelet_by_id,
-  PathWithLaneId * output_ptr);
+  const int64_t goal_lane_id, PathWithLaneId * output_ptr);
 
 /**
  * @brief Recreate the goal pose to prevent the goal point being too far from the lanelet, which
@@ -315,14 +312,12 @@ const Pose refineGoal(const Pose & goal, const lanelet::ConstLanelet & goal_lane
  * @param input Input path.
  * @param goal Goal pose.
  * @param goal_lane_id Lane ID of goal lanelet.
- * @param get_lanelet_by_id Function to get lanelet by ID.
  * @return Recreated path
  */
 PathWithLaneId refinePathForGoal(
   const double search_radius_range, const double search_rad_range,
   const double output_path_interval, const PathWithLaneId & input, const Pose & goal,
-  const int64_t goal_lane_id,
-  const std::function<lanelet::ConstLanelet(int64_t)> & get_lanelet_by_id);
+  const int64_t goal_lane_id);
 
 bool isAllowedGoalModification(const std::shared_ptr<RouteHandler> & route_handler);
 bool checkOriginalGoalIsInShoulder(const std::shared_ptr<RouteHandler> & route_handler);

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/utils.cpp
@@ -35,7 +35,6 @@
 #include <lanelet2_routing/RoutingGraphContainer.h>
 
 #include <algorithm>
-#include <functional>
 #include <iostream>
 #include <limits>
 #include <memory>
@@ -63,6 +62,18 @@ double calcInterpolatedZ(
       ? next_z
       : closest_z + (next_z - closest_z) * closest_to_target_dist / seg_dist;
   return interpolated_z;
+}
+
+double calcInterpolatedVelocity(
+  const autoware_internal_planning_msgs::msg::PathWithLaneId & input, const size_t seg_idx)
+{
+  const double seg_dist =
+    autoware::motion_utils::calcSignedArcLength(input.points, seg_idx, seg_idx + 1);
+
+  const double closest_vel = input.points.at(seg_idx).point.longitudinal_velocity_mps;
+  const double next_vel = input.points.at(seg_idx + 1).point.longitudinal_velocity_mps;
+  const double interpolated_vel = std::abs(seg_dist) < 1e-06 ? next_vel : closest_vel;
+  return interpolated_vel;
 }
 }  // namespace
 
@@ -239,63 +250,11 @@ std::optional<size_t> findIndexOutOfGoalSearchRange(
   return min_dist_out_of_range_index;
 }
 
-template <typename Iterator>
-lanelet::ConstLanelets getUniqueLaneletsFromPath(
-  Iterator begin, Iterator end,
-  const std::function<lanelet::ConstLanelet(int64_t)> get_lanelet_by_id)
-{
-  std::set<int64_t> lanelet_ids;
-  for (auto it = begin; it != end; ++it) {
-    for (const auto & lane_id : it->lane_ids) {
-      lanelet_ids.insert(lane_id);
-    }
-  }
-  lanelet::ConstLanelets lanelets;
-  for (const auto & lane_id : lanelet_ids) {
-    lanelets.push_back(get_lanelet_by_id(lane_id));
-  }
-  return lanelets;
-}
-
-template <typename Iterator>
-void fillLaneIdsFromMap(Iterator begin, Iterator end, const lanelet::ConstLanelets & lanelets)
-{
-  for (auto it = begin; it != end; ++it) {
-    const auto point = it->point;
-    lanelet::ConstLanelet lanelet;
-    if (lanelet::utils::query::getClosestLanelet(lanelets, point.pose, &lanelet)) {
-      it->lane_ids = {lanelet.id()};
-    }
-  }
-}
-
-template <typename Iterator>
-void fillLongitudinalVelocityFromInputPath(Iterator begin, Iterator end, PathWithLaneId input)
-{
-  if (input.points.size() < 2) {
-    return;
-  }
-  input.points.pop_back();  // remove the last point because its velocity is 0.0
-  // refine lane_ids and longitudinal velocity from input path
-  for (auto it = begin; it != end; ++it) {
-    auto idx = autoware::motion_utils::findNearestIndex(input.points, it->point.pose, 3.0, M_PI_4);
-    if (idx) {
-      const auto & input_point = input.points.at(idx.value());
-      it->point.longitudinal_velocity_mps = input_point.point.longitudinal_velocity_mps;
-    } else {
-      const auto & input_point = input.points.back();
-      it->point.longitudinal_velocity_mps = input_point.point.longitudinal_velocity_mps;
-    }
-  }
-}
-
 // goal does not have z
 bool set_goal(
   const double search_radius_range, [[maybe_unused]] const double search_rad_range,
   const double output_path_interval, const PathWithLaneId & input, const Pose & goal,
-  const int64_t goal_lane_id,
-  const std::function<lanelet::ConstLanelet(int64_t)> & get_lanelet_by_id,
-  PathWithLaneId * output_ptr)
+  const int64_t goal_lane_id, PathWithLaneId * output_ptr)
 {
   try {
     if (input.points.empty()) {
@@ -310,6 +269,7 @@ bool set_goal(
     refined_goal.point.pose = goal;
     refined_goal.point.pose.position.z =
       calcInterpolatedZ(input, goal.position, closest_seg_idx_for_goal);
+    refined_goal.point.longitudinal_velocity_mps = 0.0;
 
     // Lambda function to create a refined goal point with interpolated z and velocity
     auto create_refined_goal_point = [&input,
@@ -320,6 +280,8 @@ bool set_goal(
         findNearestSegmentIndex(input.points, refined_point.point.pose, 3.0, M_PI_4);
       refined_point.point.pose.position.z =
         calcInterpolatedZ(input, refined_point.point.pose.position, closest_seg_idx);
+      refined_point.point.longitudinal_velocity_mps =
+        calcInterpolatedVelocity(input, closest_seg_idx);
       return refined_point;
     };
 
@@ -350,12 +312,35 @@ bool set_goal(
     output_ptr->points.push_back(pre_refined_mid_goal);
     output_ptr->points.push_back(refined_goal);
 
-    // NOTE: this lane ids and longitudinal velocity will be overwritten by the input path in the
-    // next step
-    for (size_t i = output_ptr->points.size() - 3; i < output_ptr->points.size(); ++i) {
-      output_ptr->points.at(i).lane_ids = input.points.back().lane_ids;
-      output_ptr->points.at(i).point.longitudinal_velocity_mps =
-        input.points.back().point.longitudinal_velocity_mps;
+    {  // fill skipped lane ids
+      // pre refined goal
+      auto & pre_goal = output_ptr->points.at(output_ptr->points.size() - 3);
+      for (size_t i = min_dist_out_of_circle_index + 1; i < input.points.size(); ++i) {
+        for (const auto target_lane_id : input.points.at(i).lane_ids) {
+          const bool is_lane_id_found =
+            std::find(pre_goal.lane_ids.begin(), pre_goal.lane_ids.end(), target_lane_id) !=
+            pre_goal.lane_ids.end();
+          if (!is_lane_id_found) {
+            pre_goal.lane_ids.push_back(target_lane_id);
+          }
+        }
+      }
+
+      // pre mid refined goal
+      auto & pre_mid_goal = output_ptr->points.at(output_ptr->points.size() - 2);
+      for (size_t i = min_dist_out_of_circle_index + 1; i < input.points.size(); ++i) {
+        for (const auto target_lane_id : input.points.at(i).lane_ids) {
+          const bool is_lane_id_found =
+            std::find(pre_mid_goal.lane_ids.begin(), pre_mid_goal.lane_ids.end(), target_lane_id) !=
+            pre_mid_goal.lane_ids.end();
+          if (!is_lane_id_found) {
+            pre_mid_goal.lane_ids.push_back(target_lane_id);
+          }
+        }
+      }
+
+      // goal
+      output_ptr->points.back().lane_ids = input.points.back().lane_ids;
     }
 
     output_ptr->left_bound = input.left_bound;
@@ -371,17 +356,6 @@ bool set_goal(
     // NOTE: remove the first point to keep the original path length
     output_ptr->points.erase(output_ptr->points.begin());
 
-    const auto lanelets = getUniqueLaneletsFromPath(
-      input.points.begin() + min_dist_out_of_circle_index + 1, input.points.end(),
-      get_lanelet_by_id);
-    fillLaneIdsFromMap(
-      output_ptr->points.begin() + min_dist_out_of_circle_index + 1, output_ptr->points.end(),
-      lanelets);
-    fillLongitudinalVelocityFromInputPath(
-      output_ptr->points.begin() + min_dist_out_of_circle_index + 1, output_ptr->points.end(),
-      input);
-
-    output_ptr->points.back().point.longitudinal_velocity_mps = 0.0;
     return true;
   } catch (std::out_of_range & ex) {
     RCLCPP_ERROR_STREAM(
@@ -433,8 +407,7 @@ const Pose refineGoal(const Pose & goal, const lanelet::ConstLanelet & goal_lane
 PathWithLaneId refinePathForGoal(
   const double search_radius_range, const double search_rad_range,
   const double output_path_interval, const PathWithLaneId & input, const Pose & goal,
-  const int64_t goal_lane_id,
-  const std::function<lanelet::ConstLanelet(int64_t)> & get_lanelet_by_id)
+  const int64_t goal_lane_id)
 {
   PathWithLaneId filtered_path = input;
   PathWithLaneId path_with_goal;
@@ -447,7 +420,7 @@ PathWithLaneId refinePathForGoal(
 
   if (set_goal(
         search_radius_range, search_rad_range, output_path_interval, filtered_path, goal,
-        goal_lane_id, get_lanelet_by_id, &path_with_goal)) {
+        goal_lane_id, &path_with_goal)) {
     return path_with_goal;
   }
   return filtered_path;

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/test/test_utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/test/test_utils.cpp
@@ -275,12 +275,7 @@ TEST_F(BehaviorPathPlanningUtilTest, refinePathForGoal)
   {
     const double search_radius_range = 1.0;
     const auto refined_path = refinePathForGoal(
-      search_radius_range, search_rad_range, output_path_interval, path, goal_pose, goal_lane_id,
-      [&](int64_t lane_id) -> lanelet::ConstLanelet {
-        return {
-          lane_id, lanelet::LineString3d(lanelet::utils::getId()),
-          lanelet::LineString3d(lanelet::utils::getId())};
-      });
+      search_radius_range, search_rad_range, output_path_interval, path, goal_pose, goal_lane_id);
     EXPECT_EQ(refined_path.points.size(), 8);
     EXPECT_DOUBLE_EQ(refined_path.points.back().point.longitudinal_velocity_mps, 0.0);
     EXPECT_DOUBLE_EQ(refined_path.points.back().point.pose.position.x, 5.2);


### PR DESCRIPTION

## Description

This reverts commit 98e1bec71bd6c7e783a5e099887a2cc87a92ce83.


## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
