### PR TITLE
feat(goal_planner): consider previous module signal when preempt signal before stop

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/goal_planner_module.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/goal_planner_module.hpp
@@ -345,7 +345,12 @@ private:
   std::optional<rclcpp::Time> decided_time_{};
 
   // save the frontmost deceleration start position before approve phase
-  std::optional<Pose> blinker_decel_start_pose_{};
+  struct BlinkerBeforePullOver
+  {
+    Pose desired;
+    std::optional<Pose> required;
+  };
+  std::optional<BlinkerBeforePullOver> blinker_before_pull_over_{};
 
   // debug
   mutable GoalPlannerDebugData debug_data_;
@@ -437,9 +442,10 @@ private:
     const PullOverContextData & context_data, BehaviorModuleOutput & output) const;
   void setTurnSignalInfo(const PullOverContextData & context_data, BehaviorModuleOutput & output);
   void setTurnSignalInfoForStopPath(
-    const BehaviorModuleOutput & stop_path, const Pose & blinker_decel_start_pose,
-    BehaviorModuleOutput & output);
-  void set_blinker_decel_start_pose(const std::optional<Pose> & blinker_decel_start_pose);
+    const BehaviorModuleOutput & stop_path, const Pose & decel_start_pose,
+    const std::optional<Pose> & stop_pose, BehaviorModuleOutput & output);
+  void set_blinker_decel_start_pose(
+    const std::optional<Pose> & decel_start_pose, const std::optional<Pose> & stop_pose);
 
   // new turn signal
   TurnSignalInfo calcTurnSignalInfo(const PullOverContextData & context_data);

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/goal_planner_module.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/goal_planner_module.cpp
@@ -1439,22 +1439,31 @@ void GoalPlannerModule::setTurnSignalInfo(
 }
 
 void GoalPlannerModule::setTurnSignalInfoForStopPath(
-  const BehaviorModuleOutput & stop_path, const Pose & blinker_decel_start_pose,
-  BehaviorModuleOutput & output)
+  const BehaviorModuleOutput & stop_path, const Pose & decel_start_pose,
+  const std::optional<Pose> & stop_pose, BehaviorModuleOutput & output)
 {
+  const auto original_signal = getPreviousModuleOutput().turn_signal_info;
+  const auto current_seg_idx = planner_data_->findEgoSegmentIndex(stop_path.path.points);
   auto preempt_turn_signal =
-    TurnSignalInfo(blinker_decel_start_pose, stop_path.path.points.back().point.pose);
+    TurnSignalInfo(decel_start_pose, stop_path.path.points.back().point.pose);
+  if (stop_pose) {
+    // if stop_pose is available, use it as required start
+    preempt_turn_signal.required_start_point = stop_pose.value();
+  }
   preempt_turn_signal.turn_signal.command = parameters_.parking_policy == ParkingPolicy::LEFT_SIDE
                                               ? TurnIndicatorsCommand::ENABLE_LEFT
                                               : TurnIndicatorsCommand::ENABLE_RIGHT;
-  output.turn_signal_info = preempt_turn_signal;
+  output.turn_signal_info = planner_data_->turn_signal_decider.overwrite_turn_signal(
+    stop_path.path, getEgoPose(), current_seg_idx, original_signal, preempt_turn_signal,
+    planner_data_->parameters.ego_nearest_dist_threshold,
+    planner_data_->parameters.ego_nearest_yaw_threshold);
 }
 
 void GoalPlannerModule::set_blinker_decel_start_pose(
-  const std::optional<Pose> & blinker_decel_start_pose)
+  const std::optional<Pose> & decel_start_pose, const std::optional<Pose> & stop_pose)
 {
-  if (!blinker_decel_start_pose_ && blinker_decel_start_pose) {
-    blinker_decel_start_pose_ = blinker_decel_start_pose.value();
+  if (!blinker_before_pull_over_ && decel_start_pose) {
+    blinker_before_pull_over_ = {decel_start_pose.value(), stop_pose};
   }
 }
 
@@ -1528,13 +1537,15 @@ BehaviorModuleOutput GoalPlannerModule::planPullOver(PullOverContextData & conte
                                                                              : "too far goal";
     auto stop_output = planPullOverAsCandidate(context_data, detail);
     const bool started_deceleration_for_blinker =
-      blinker_decel_start_pose_ &&
+      blinker_before_pull_over_ &&
       autoware::motion_utils::findNearestIndex(
         stop_output.path.points, planner_data_->self_odometry->pose.pose) >=
         autoware::motion_utils::findNearestIndex(
-          stop_output.path.points, blinker_decel_start_pose_.value());
+          stop_output.path.points, blinker_before_pull_over_->desired);
     if (started_deceleration_for_blinker) {
-      setTurnSignalInfoForStopPath(stop_output, blinker_decel_start_pose_.value(), stop_output);
+      setTurnSignalInfoForStopPath(
+        stop_output, blinker_before_pull_over_->desired, blinker_before_pull_over_->required,
+        stop_output);
     }
     return stop_output;
   }
@@ -1915,7 +1926,7 @@ PathWithLaneId GoalPlannerModule::generateStopPath(
     return decel_pose;
   });
   if (!stop_pose_opt.has_value()) {
-    set_blinker_decel_start_pose(decel_pose);
+    set_blinker_decel_start_pose(decel_pose, std::nullopt);
     const auto feasible_stop_path =
       generateFeasibleStopPath(getPreviousModuleOutput().path, detail);
     return feasible_stop_path;
@@ -1939,7 +1950,7 @@ PathWithLaneId GoalPlannerModule::generateStopPath(
                             autoware::motion_utils::findNearestIndex(
                               feasible_stop_path.points, decel_start_point.value()))
                           .point.pose;
-      set_blinker_decel_start_pose(std::make_optional<Pose>(pose));
+      set_blinker_decel_start_pose(std::make_optional<Pose>(pose), stop_pose);
     }
     return feasible_stop_path;
   }
@@ -1947,7 +1958,7 @@ PathWithLaneId GoalPlannerModule::generateStopPath(
   // slow down for turn signal, insert stop point to stop_pose
   auto stop_path = extended_prev_path;
   const auto blinker_decel_start_pose = decelerateForTurnSignal(stop_pose, stop_path);
-  set_blinker_decel_start_pose(blinker_decel_start_pose);
+  set_blinker_decel_start_pose(blinker_decel_start_pose, stop_pose);
   stop_pose_ = PoseWithDetail(stop_pose, detail);
 
   // slow down before the search area.


### PR DESCRIPTION
## Description

In addition to https://github.com/autowarefoundation/autoware_universe/pull/11512, the turn signal before starting pull_over should resepct previous module's signal

https://github.com/user-attachments/assets/340fba9a-fb90-471f-b4fb-9070bedcc034

## Related links

https://tier4.atlassian.net/browse/RT0-39673

## How was this PR tested?

- [FuncVeficiation](https://evaluation.tier4.jp/evaluation/reports/4d0b0a4f-7c7a-55b1-b727-cb23dfe1aefc?project_id=prd_jt)
- [DLR](https://evaluation.tier4.jp/evaluation/reports/c6d50562-c6bf-50e1-aed3-7d655d10ca45?project_id=prd_jt)
- [Common](https://evaluation.tier4.jp/evaluation/reports/42f8b6cd-b092-58c8-b1c4-664baa01ed84?project_id=prd_jt)

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
