### PR TITLE
fix(autoware_crosswalk_traffic_light_estimator): remove old traffic light groups

### DIFF
--- a/perception/autoware_crosswalk_traffic_light_estimator/src/node.cpp
+++ b/perception/autoware_crosswalk_traffic_light_estimator/src/node.cpp
@@ -472,8 +472,8 @@ void CrosswalkTrafficLightEstimatorNode::setCrosswalkTrafficSignal(
             .empty()) {  // unnecessary check because msg has detection but for safety
         out_signal.elements.push_back(base_traffic_signal_element);
       }
-      out_signal.elements[0].color =
-        updateAndGetColorState(detected);  // TODO(MasatoSaeki): determine what value is good for confidence
+      out_signal.elements[0].color = updateAndGetColorState(
+        detected);  // TODO(MasatoSaeki): determine what value is good for confidence
       continue;
     }
 


### PR DESCRIPTION
## Description

This PR prevents temporary duplication caused by [this feature](https://github.com/autowarefoundation/autoware_universe/pull/11397).

There are two fixed points.

1. Use `std::stable_sort` instead of `std::sort` in `removeDuplicateIds` to store the data uniquely.
2. Avoid duplicate about `output` in setCrosswalkTrafficSignal. (Actually it is sufficient to fix 1. point, but good to keep the data clean)

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

https://evaluation.ci.tier4.jp/evaluation/reports/022d9bbf-33c5-5868-9ec8-68f26c2006ae?project_id=prd_jt

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
