### PR TITLE
fix: use `main` for `autoware_adapi_msgs`

### DIFF
--- a/build_depends_humble.repos
+++ b/build_depends_humble.repos
@@ -8,7 +8,7 @@ repositories:
   core/autoware_adapi_msgs:
     type: git
     url: https://github.com/autowarefoundation/autoware_adapi_msgs.git
-    version: 12287684e096a02d279299a7e6cb44740fc34467
+    version: main
   core/autoware_internal_msgs:
     type: git
     url: https://github.com/autowarefoundation/autoware_internal_msgs.git


### PR DESCRIPTION
## Description

When running CI build, we frequently use `main` for `autoware_adapi_msgs`. Recently we faced the CI issue in the following PR which can be resolved by using `main` for `autoware_adapi_msgs`.
- https://github.com/autowarefoundation/autoware_core/pull/670

## How was this PR tested?

We will tests by running CI. Will be updated after the tests.

## Notes for reviewers

Same as "Description"

## Interface changes

None.

## Effects on system behavior

CI build will use `main` for `autoware_adapi_msgs`.
