### PR TITLE
fix(lane_change): turn signal when valid path is not available

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/scene.cpp
@@ -347,16 +347,20 @@ TurnSignalInfo NormalLaneChange::get_current_turn_signal_info() const
     return original_turn_signal_info;
   }
 
-  const auto & path = prev_module_output_.path;
+  const auto & prev_path = prev_module_output_.path.points;
+  if (prev_path.empty()) {
+    return original_turn_signal_info;
+  }
+
   const auto & original_command = original_turn_signal_info.turn_signal.command;
   if (
-    !path.points.empty() && original_command != TurnIndicatorsCommand::DISABLE &&
+    original_command != TurnIndicatorsCommand::DISABLE &&
     original_command != TurnIndicatorsCommand::NO_COMMAND) {
     return get_terminal_turn_signal_info();
   }
 
   if (!status_.is_valid_path) {
-    return get_turn_signal(getEgoPose(), prev_module_output_.path.points.back().point.pose);
+    return get_turn_signal(getEgoPose(), prev_path.back().point.pose);
   }
 
   set_signal_activation_time();


### PR DESCRIPTION
## Description

When the LC module fails to find a valid path, it was incorrectly populating its turn signal information with an invalid `desired_end_point`. This corrupted value caused a subsequent computation error in the turn signal decider, which then overrode the LC turn signal command with an invalid output.

To solve this problem, if no valid path is found, the LC module will use the previous planning module's path end point as the fallback value for the `desired_end_point`.

This ensures the turn signal decider always receives a valid coordinate for computation, preventing the invalid override and preserving the intended turn signal command.

## Related links

**Parent Issue:**

- [TIER IV internal issue link](https://tier4.atlassian.net/browse/T4DEV-31840)


## How was this PR tested?

### 1. Test with scenario simulator using 

- [TIER IV internal scenario](https://evaluation.ci.tier4.jp/evaluation/reports/c41410a1-491e-5fd0-8c65-4adc488639d5/tests/65a3e2aa-2a8b-5c58-a1e1-2ae45b3ad362/905651e9-4ae1-50eb-b62c-c5dcb5c00a16/46594be5-a665-5917-9f6b-95052b8ed703?project_id=x2_dev)

### 2. TIER IV internal evaluation

[TIER IV Internal Link - ControlDLR Test](https://evaluation.tier4.jp/evaluation/reports/d3f18d64-d3fd-5da5-923e-2f33746a0a85?project_id=prd_jt)
[TIER IV Internal Link - FuncVerification Test](https://evaluation.tier4.jp/evaluation/reports/98682873-8354-53e0-a760-37f812d8da00?project_id=prd_jt)
[TIER IV Internal Link - CommonScenario_Basic Test](https://evaluation.tier4.jp/evaluation/reports/6238dbb5-0f85-55c0-a17a-1c8a9658d610?project_id=prd_jt)

📝 **failed sceenarios are unrelated to lane change's turn signal.**

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
