### PR TITLE
fix(goal_planner): fix iterator bug

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/goal_planner_module.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/goal_planner_module.cpp
@@ -2314,6 +2314,7 @@ std::optional<Pose> GoalPlannerModule::decelerateForTurnSignal(
       }
       point_it++;
     } else {
+      const auto distance = std::distance(path.points.begin(), point_it);
       const auto idx =
         insertDecelPoint(current_pose.position, *min_decel_distance, decel_vel, path.points);
       if (idx) {
@@ -2322,7 +2323,7 @@ std::optional<Pose> GoalPlannerModule::decelerateForTurnSignal(
           first_turn_signal_trigger_position = decel_point_it->point.pose;
         }
       }
-      point_it++;
+      point_it = path.points.begin() + distance + 1;
     }
   }
 


### PR DESCRIPTION
## Description

This fixes the bug introduced in https://github.com/autowarefoundation/autoware_universe/pull/11512.

In `decelerateForTurnSignal`, when `incertDecelPoint` for `current_pose` is succeeded, deceleration velocity is already inserted, so the loop must be termnated

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

https://evaluation.tier4.jp/evaluation/reports/c03b46bf-2c6e-5e16-aece-bd967029b6c2?project_id=prd_jt&state=failed


## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
