### PR TITLE
feat(intersection): use fixed threshold for checking stop duration

### DIFF
--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/config/intersection.param.yaml
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/config/intersection.param.yaml
@@ -11,7 +11,7 @@
         path_interpolation_ds: 0.1
         max_accel: -2.8
         max_jerk: -5.0
-        delay_response_time: 0.5
+        delay_response_time: 0.0
 
       stuck_vehicle:
         target_type:


### PR DESCRIPTION
## Description

For checking if ego stopped at staticallly defined pose for occlusion, use fixed value (1.0m) instead of `overshoot_margin`.

This is to handle the case where controller cannot approach the desired stop position within the overshoot_margin = 0.5m. Right now, this PR intends to avoid getting being stuck before 1.0m from "intersection" stop position.

## Related links

[conversation](https://star4.slack.com/archives/C03QW0GU6P7/p1761209088343189)

## How was this PR tested?

- [Common](https://evaluation.tier4.jp/evaluation/reports/a9034964-e224-5125-88db-dae4f1e72732?page_size=50&project_id=prd_jt)
- [DLR](https://evaluation.tier4.jp/evaluation/reports/4f17e5d7-e17a-5d2e-9493-cace499249fa?project_id=prd_jt)
- [FuncVerification](https://evaluation.tier4.jp/evaluation/reports/91439486-2777-5959-ba49-3f0493b30270?project_id=prd_jt)

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
