### PR TITLE
fix(goal_planner): failed to generate candidate paths when entering another lane for avoidance

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/util.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/util.hpp
@@ -318,9 +318,26 @@ std::optional<lanelet::ConstLanelet> find_last_lane_change_completed_lanelet(
   const lanelet::routing::RoutingGraphConstPtr routing_graph);
 
 /**
- * @brief generate lanelets with which pull over path is aligned
- * @note if lane changing path is detected, this returns lanelets aligned with later part of the
- * lane changing path
+ * @brief Get reference road lane sequence that covers both the path length and goal search range
+ *
+ * @param path The path with lane IDs from upstream module
+ * @param planner_data Shared pointer to planner data containing route handler and parameters
+ * @param backward_length Distance to extend backward from lane_change_complete_lane
+ *                        Expected: backward_path_length + backward_goal_search_length
+ *                        - Covers both path length and goal search range backward
+ *                        - Sum is used because which is longer is unknown
+ *                        - Backward lanes are necessary for path generation
+ * @param forward_length Distance to extend forward from goal_lane
+ *                       Expected: forward_goal_search_length
+ *                       - Covers goal search range beyond the path length forward
+ *
+ * @return Continuous lanelet sequence from (lane_change_complete_lane - backward_length) to
+ *         (goal_lane + forward_length) if goal_lane is reachable from lane_change_complete_lane.
+ *         Otherwise, returns sequence from (lane_change_complete_lane - backward_length) to
+ *         the end of lane_change_complete_lane's sequence (until loop or no next lane).
+ *
+ * @note If lane changing path is detected, this returns lanelets aligned with the later part
+ *       of the lane changing path (lane_change_complete_lane)
  */
 lanelet::ConstLanelets get_reference_lanelets_for_pullover(
   const PathWithLaneId & path, const std::shared_ptr<const PlannerData> & planner_data,

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/pull_over_planner/bezier_pull_over.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/pull_over_planner/bezier_pull_over.cpp
@@ -48,6 +48,7 @@ std::optional<PullOverPath> BezierPullOver::plan(
   [[maybe_unused]] const BehaviorModuleOutput & upstream_module_output)
 {
   const auto & route_handler = planner_data->route_handler;
+  const double backward_path_length = planner_data->parameters.backward_path_length;
   const double min_jerk = parameters_.minimum_lateral_jerk;
   const double max_jerk = parameters_.maximum_lateral_jerk;
   const double backward_search_length = parameters_.backward_goal_search_length;
@@ -57,7 +58,8 @@ std::optional<PullOverPath> BezierPullOver::plan(
     std::abs(max_jerk - min_jerk) / shift_sampling_num;
 
   const auto road_lanes = goal_planner_utils::get_reference_lanelets_for_pullover(
-    upstream_module_output.path, planner_data, backward_search_length, forward_search_length);
+    upstream_module_output.path, planner_data, backward_path_length + backward_search_length,
+    forward_search_length);
 
   const auto pull_over_lanes = goal_planner_utils::getPullOverLanes(
     *route_handler, left_side_parking_, backward_search_length, forward_search_length);
@@ -92,10 +94,11 @@ std::vector<PullOverPath> BezierPullOver::plans(
   const int shift_sampling_num = parameters_.shift_sampling_num;
   [[maybe_unused]] const double jerk_resolution =
     std::abs(max_jerk - min_jerk) / shift_sampling_num;
+  const double backward_path_length = planner_data->parameters.backward_path_length;
 
-  const auto road_lanes = utils::getExtendedCurrentLanesFromPath(
-    upstream_module_output.path, planner_data, backward_search_length, forward_search_length,
-    /*forward_only_in_route*/ false);
+  const auto road_lanes = goal_planner_utils::get_reference_lanelets_for_pullover(
+    upstream_module_output.path, planner_data, backward_search_length + backward_path_length,
+    forward_search_length);
 
   const auto pull_over_lanes = goal_planner_utils::getPullOverLanes(
     *route_handler, left_side_parking_, backward_search_length, forward_search_length);

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/pull_over_planner/geometric_pull_over.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/pull_over_planner/geometric_pull_over.cpp
@@ -48,11 +48,13 @@ std::optional<PullOverPath> GeometricPullOver::plan(
   [[maybe_unused]] const BehaviorModuleOutput & upstream_module_output)
 {
   const auto & route_handler = planner_data->route_handler;
+  const double backward_path_length = planner_data->parameters.backward_path_length;
 
   const auto & goal_pose = modified_goal_pose.goal_pose;
   // prepare road nad shoulder lanes
   const auto road_lanes = goal_planner_utils::get_reference_lanelets_for_pullover(
-    upstream_module_output.path, planner_data, parameters_.backward_goal_search_length,
+    upstream_module_output.path, planner_data,
+    backward_path_length + parameters_.backward_goal_search_length,
     parameters_.forward_goal_search_length);
   const auto pull_over_lanes = goal_planner_utils::getPullOverLanes(
     *route_handler, left_side_parking_, parameters_.backward_goal_search_length,

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/pull_over_planner/shift_pull_over.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/pull_over_planner/shift_pull_over.cpp
@@ -47,6 +47,7 @@ std::optional<PullOverPath> ShiftPullOver::plan(
   const BehaviorModuleOutput & upstream_module_output)
 {
   const auto & route_handler = planner_data->route_handler;
+  const double backward_path_length = planner_data->parameters.backward_path_length;
   const double min_jerk = parameters_.minimum_lateral_jerk;
   const double max_jerk = parameters_.maximum_lateral_jerk;
   const double backward_search_length = parameters_.backward_goal_search_length;
@@ -55,7 +56,8 @@ std::optional<PullOverPath> ShiftPullOver::plan(
   const double jerk_resolution = std::abs(max_jerk - min_jerk) / shift_sampling_num;
 
   const auto road_lanes = goal_planner_utils::get_reference_lanelets_for_pullover(
-    upstream_module_output.path, planner_data, backward_search_length, forward_search_length);
+    upstream_module_output.path, planner_data, backward_path_length + backward_search_length,
+    forward_search_length);
 
   const auto pull_over_lanes = goal_planner_utils::getPullOverLanes(
     *route_handler, left_side_parking_, backward_search_length, forward_search_length);

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/util.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/util.cpp
@@ -1146,36 +1146,70 @@ lanelet::ConstLanelets get_reference_lanelets_for_pullover(
 {
   const auto & routing_graph = planner_data->route_handler->getRoutingGraphPtr();
   const auto & lanelet_map = planner_data->route_handler->getLaneletMapPtr();
+  const auto & route_handler = planner_data->route_handler;
+
+  const auto goal_lane_id = planner_data->route_handler->getGoalLaneId();
+
   const auto lane_change_complete_lane =
     find_last_lane_change_completed_lanelet(path, lanelet_map, routing_graph);
+
   if (!lane_change_complete_lane) {
     return utils::getExtendedCurrentLanesFromPath(
       path, planner_data, backward_length, forward_length,
       /*forward_only_in_route*/ false);
   }
-  auto route_lanes = planner_data->route_handler->getLaneletSequence(
-    *lane_change_complete_lane, backward_length, forward_length);
-  const double remaining_distance =
-    forward_length + backward_length - lanelet::utils::getLaneletLength3d(route_lanes);
-  if (route_lanes.empty() || remaining_distance <= 0.0) {
-    return route_lanes;
+
+  const auto extend_forward = [&](
+                                const lanelet::ConstLanelet & start_lane, const double distance,
+                                lanelet::ConstLanelets & result) {
+    double acc_dist = 0.0;
+    auto current_lane = start_lane;
+    while (acc_dist < distance) {
+      const auto nexts = routing_graph->following(current_lane);
+      if (nexts.empty()) {
+        break;
+      }
+      current_lane = nexts.front();
+      if (lanelet::utils::contains(result, current_lane)) {
+        // loop detected
+        break;
+      }
+      result.push_back(current_lane);
+      acc_dist += lanelet::utils::getLaneletLength3d(current_lane);
+    }
+  };
+
+  lanelet::ConstLanelets route_lanes;
+
+  // Add backward lanes from lane_change_complete_lane
+  const auto backward_lanes = route_handler->getPrecedingLaneletSequence(
+    *lane_change_complete_lane, backward_length, {*lane_change_complete_lane});
+  for (auto it = backward_lanes.rbegin(); it != backward_lanes.rend(); ++it) {
+    route_lanes.insert(route_lanes.end(), it->begin(), it->end());
   }
-  double acc_dist = 0.0;
-  auto last_lanelet = route_lanes.back();
-  while (acc_dist < remaining_distance) {
-    const auto nexts = routing_graph->following(last_lanelet);
+
+  route_lanes.push_back(*lane_change_complete_lane);
+
+  // Extend forward from lane_change_complete_lane
+  auto current_lane = *lane_change_complete_lane;
+  while (true) {
+    const auto nexts = routing_graph->following(current_lane);
     if (nexts.empty()) {
       break;
     }
-    const auto & next = nexts.front();
-    if (lanelet::utils::contains(route_lanes, next)) {
-      // loop
+    current_lane = nexts.front();
+    if (lanelet::utils::contains(route_lanes, current_lane)) {
+      // loop detected
       break;
     }
-    last_lanelet = next;
-    route_lanes.push_back(next);
-    acc_dist += lanelet::utils::getLaneletLength3d(next);
+    route_lanes.push_back(current_lane);
+
+    if (current_lane.id() == goal_lane_id) {
+      extend_forward(current_lane, forward_length, route_lanes);
+      break;
+    }
   }
+
   return route_lanes;
 }
 }  // namespace autoware::behavior_path_planner::goal_planner_utils


### PR DESCRIPTION
## Description

Fix an issue where the pull over path could not be generated while the vehicle was moving into an adjacent lane for an avoidance maneuver.

This was mainly due to two problems:
- bezier_pull_over uses `getExtendedCurrentLanesFromPath`, which incorrectly retrieves the sequence of the current lanes duraing avoidance. This sequence is not adjacent to the pull-over's target lane.
<img width="2938" height="126" alt="image" src="https://github.com/user-attachments/assets/b0942b4c-c42c-4080-9261-cadea456f6ee" />
- `get_reference_lanelets_for_pullover` retrieves the lanelets around the `lane_change_complete_lane` for the goal search range. This range is sometimes too short for path generation.

In this PR, I modified `get_reference_lanelets_for_pullover` to correctly retrieve the lanelets from the `lane_change_complete_lane` up to the `goal_lane` and then extend them forward and backward. All pull over planners now use this function.



## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

DRL

- before

<img width="1034" height="833" alt="image" src="https://github.com/user-attachments/assets/54734102-4147-441b-a752-e037956fa0e2" />


https://github.com/user-attachments/assets/bef6af0b-6531-4b61-8fd3-df72b5c9e4ee


- after

<img width="1034" height="833" alt="image" src="https://github.com/user-attachments/assets/9e6e0d37-c51e-4025-90d5-2a7985fbfdf4" />



https://github.com/user-attachments/assets/3e37a02b-ff45-4f0a-87e8-b8e63cccd2f2

 Evaluator

some scenario fails but not related this PR

- [[PR check (takeuchi)][Lexus][CommonScenario_Basic] planning test](https://evaluation.tier4.jp/evaluation/reports/01f0c2a1-09c5-5ba8-a93e-619084a461dd?project_id=prd_jt)
- [[PR check (takeuchi)][Lexus][FuncVerificationScenario_Basic] planning test](https://evaluation.tier4.jp/evaluation/reports/42c974f5-ed95-535a-9361-ec35d47ca6c5?project_id=prd_jt)
- [[PR check (takeuchi)][Lexus][ControlDLRCommon_Basic] DLR test](https://evaluation.tier4.jp/evaluation/reports/872e5d66-e4c6-5c70-97f5-2b06e713d2e1?project_id=prd_jt)

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
