### PR TITLE
fix(pipeline_latency_monitor): change diagnostic status from WARN to ERROR for latency threshold exceedance

### DIFF
--- a/system/autoware_pipeline_latency_monitor/README.md
+++ b/system/autoware_pipeline_latency_monitor/README.md
@@ -12,7 +12,7 @@ To calculate the total latency, the node works backward from the last step in th
 
 The total latency is the sum of these chronologically-consistent individual latencies. The node also allows for adding fixed offset values to the final sum.
 
-The calculated total latency is published continuously and also used to report diagnostic information. A WARN status is published if the latency exceeds a configurable threshold.
+The calculated total latency is published continuously and also used to report diagnostic information. An ERROR status is published if the latency exceeds a configurable threshold.
 
 ## Inputs / Outputs
 
@@ -28,19 +28,19 @@ Only 2 message types are currently supported.
 
 ### Output
 
-| Name                                | Type                                              | Description                                                                                                         |
-| ----------------------------------- | ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
-| `~/output/total_latency_ms`         | `autoware_internal_debug_msgs/msg/Float64Stamped` | The calculated total pipeline latency in milliseconds.                                                              |
-| `/diagnostics`                      | `diagnostic_msgs/DiagnosticArray`                 | Publishes the diagnostic status. Reports `OK` if the latency is within the threshold, and `WARN` if it is exceeded. |
-| `~/debug/<step_name>_latency_ms`    | `autoware_internal_debug_msgs/msg/Float64Stamped` | For each processing step, publishes the latest latency value received from its input topic.                         |
-| `~/debug/pipeline_total_latency_ms` | `autoware_internal_debug_msgs/msg/Float64Stamped` | A debug topic that also publishes the calculated total latency.                                                     |
+| Name                                | Type                                              | Description                                                                                                          |
+| ----------------------------------- | ------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| `~/output/total_latency_ms`         | `autoware_internal_debug_msgs/msg/Float64Stamped` | The calculated total pipeline latency in milliseconds.                                                               |
+| `/diagnostics`                      | `diagnostic_msgs/DiagnosticArray`                 | Publishes the diagnostic status. Reports `OK` if the latency is within the threshold, and `ERROR` if it is exceeded. |
+| `~/debug/<step_name>_latency_ms`    | `autoware_internal_debug_msgs/msg/Float64Stamped` | For each processing step, publishes the latest latency value received from its input topic.                          |
+| `~/debug/pipeline_total_latency_ms` | `autoware_internal_debug_msgs/msg/Float64Stamped` | A debug topic that also publishes the calculated total latency.                                                      |
 
 ## Parameters
 
 | Name                                              | Type       | Default Value | Description                                                                                                                                                          |
 | ------------------------------------------------- | ---------- | ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `update_rate`                                     | `double`   | 10            | The rate [Hz] at which the total latency is calculated and published.                                                                                                |
-| `latency_threshold_ms`                            | `double`   | 1000          | The latency threshold in milliseconds. If the total latency exceeds this value, a `WARN` diagnostic is reported.                                                     |
+| `latency_threshold_ms`                            | `double`   | 1000          | The latency threshold in milliseconds. If the total latency exceeds this value, an `ERROR` diagnostic is reported.                                                   |
 | `window_size`                                     | `int`      | 10            | The number of historical latency messages to store for each processing step.                                                                                         |
 | `processing_steps.sequence`                       | `string[]` | `[]`          | An array of names defining the ordered sequence of processing steps to measure.                                                                                      |
 | `processing_steps.<step_name>.topic`              | `string`   | -             | The input topic that provides the latency for this step.                                                                                                             |

--- a/system/autoware_pipeline_latency_monitor/src/pipeline_latency_monitor_node.cpp
+++ b/system/autoware_pipeline_latency_monitor/src/pipeline_latency_monitor_node.cpp
@@ -267,7 +267,7 @@ void PipelineLatencyMonitorNode::check_total_latency(
       diagnostic_msgs::msg::DiagnosticStatus::OK,
       "Some latency inputs not yet received: " + uninitialized_inputs);
   } else if (total_latency_ms_ > latency_threshold_ms_) {
-    stat.summary(diagnostic_msgs::msg::DiagnosticStatus::WARN, "Total latency exceeds threshold");
+    stat.summary(diagnostic_msgs::msg::DiagnosticStatus::ERROR, "Total latency exceeds threshold");
   } else {
     stat.summary(
       diagnostic_msgs::msg::DiagnosticStatus::OK, "Total latency within acceptable range");


### PR DESCRIPTION
## Description

Modified the pipeline_latency_monitor to output error-level diagnostics instead of warn-level when the total processing time exceeds the threshold.
This change does not include any modifications to the package logic or output other than the diagnostics error level.


## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

Intentionally set a small threshold value and confirmed using planning_simulator that error-level diagnostics are output when the threshold is exceeded.

before:
<img width="715" height="583" alt="image" src="https://github.com/user-attachments/assets/a2583672-4c3c-4b6a-8df1-e7e1378f80b1" />

after:
<img width="715" height="583" alt="image" src="https://github.com/user-attachments/assets/f2594e9b-c2f9-4e4f-b628-49a4301c6124" />


## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
