### PR TITLE
fix(run_out): fix div by 0, out of range, in interpolated_point_at_time

### DIFF
--- a/planning/motion_velocity_planner/autoware_motion_velocity_run_out_module/src/slowdown.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_run_out_module/src/slowdown.cpp
@@ -40,12 +40,15 @@ geometry_msgs::msg::Point interpolated_point_at_time(
     [&](const autoware_planning_msgs::msg::TrajectoryPoint & t) {
       return rclcpp::Duration(t.time_from_start).seconds() >= time;
     });
+  if (prev_it == trajectory.end()) {
+    return trajectory.back().pose.position;
+  }
   const auto prev_time = rclcpp::Duration(prev_it->time_from_start).seconds();
-  if (prev_time == time) {
+  if (std::next(prev_it) == trajectory.end() || std::abs(prev_time - time) < 1e-3) {
     return prev_it->pose.position;
   }
   const auto next_time = rclcpp::Duration(std::next(prev_it)->time_from_start).seconds();
-  if (next_time == prev_time) {
+  if (std::abs(next_time - prev_time) < 1e-3) {
     return std::next(prev_it)->pose.position;
   }
   const auto t_delta = next_time - prev_time;


### PR DESCRIPTION
## Description

Fix function `interpolated_point_at_time` in the `run_out` module to avoid divisions by zero or access to out of range elements.
These bugs could cause the returned point to contain `NaN` values.

## Related links

**Private Links:**

- [TIER IV internal link](https://tier4.atlassian.net/browse/T4DEV-39391)

## How was this PR tested?

Bags where the issue was originally recorded.
Evaluator: https://evaluation.tier4.jp/evaluation/reports/c2dac10e-d16b-59a2-994c-8f92e96bd807?project_id=prd_jt

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
