### PR TITLE
feat(behavior_velocity_traffic_light_module): use Trajectory instead of PathWithLaneId

### DIFF
--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/src/experimental/manager.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/src/experimental/manager.cpp
@@ -67,17 +67,16 @@ void TrafficLightModuleManager::modifyPathVelocity(
 
   autoware_perception_msgs::msg::TrafficLightGroup tl_state;
 
-  nearest_ref_stop_path_point_index_ = static_cast<int>(path.get_underlying_bases().size() - 1);
+  auto nearest_stop_point_s = std::numeric_limits<double>::max();
+
   for (const auto & scene_module : scene_modules_) {
     std::shared_ptr<TrafficLightModule> traffic_light_scene_module(
       std::dynamic_pointer_cast<TrafficLightModule>(scene_module));
     traffic_light_scene_module->modifyPathVelocity(path, left_bound, right_bound, planner_data);
 
-    if (
-      traffic_light_scene_module->getFirstRefStopPathPointIndex() <
-      nearest_ref_stop_path_point_index_) {
-      nearest_ref_stop_path_point_index_ =
-        traffic_light_scene_module->getFirstRefStopPathPointIndex();
+    const auto first_stop_point_s = traffic_light_scene_module->getFirstStopPointArcLength();
+    if (first_stop_point_s && *first_stop_point_s < nearest_stop_point_s) {
+      nearest_stop_point_s = *first_stop_point_s;
       if (
         traffic_light_scene_module->getTrafficLightModuleState() !=
         TrafficLightModule::State::GO_OUT) {

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/src/experimental/manager.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/src/experimental/manager.hpp
@@ -22,7 +22,6 @@
 
 #include <functional>
 #include <memory>
-#include <optional>
 #include <vector>
 
 namespace autoware::behavior_velocity_planner::experimental
@@ -73,11 +72,9 @@ private:
 
   // Debug
   rclcpp::Publisher<autoware_perception_msgs::msg::TrafficLightGroup>::SharedPtr pub_tl_state_;
-
-  std::optional<int> nearest_ref_stop_path_point_index_;
 };
 
-class TrafficLightModulePlugin : public experimental::PluginWrapper<TrafficLightModuleManager>
+class TrafficLightModulePlugin : public PluginWrapper<TrafficLightModuleManager>
 {
 };
 

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/src/experimental/scene.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/src/experimental/scene.hpp
@@ -34,6 +34,7 @@ public:
   using TrafficSignal = autoware_perception_msgs::msg::TrafficLightGroup;
   using TrafficSignalElement = autoware_perception_msgs::msg::TrafficLightElement;
   using Time = rclcpp::Time;
+
   enum class State { APPROACH, GO_OUT };
 
   struct DebugData
@@ -92,10 +93,7 @@ public:
 
   inline State getTrafficLightModuleState() const { return state_; }
 
-  inline std::optional<int> getFirstRefStopPathPointIndex() const
-  {
-    return first_ref_stop_path_point_index_;
-  }
+  inline std::optional<double> getFirstStopPointArcLength() const { return first_stop_point_s_; }
 
   void updateStopLine(const lanelet::ConstLineString3d & stop_line);
 
@@ -105,10 +103,8 @@ private:
   bool willTrafficLightTurnRedBeforeReachingStopLine(
     const double & distance_to_stop_line, const PlannerData & planner_data) const;
 
-  autoware_internal_planning_msgs::msg::PathWithLaneId insertStopPose(
-    const autoware_internal_planning_msgs::msg::PathWithLaneId & input,
-    const size_t & insert_target_point_idx, const Eigen::Vector2d & target_point,
-    const PlannerData & planner_data);
+  Trajectory insertStopVelocity(
+    const Trajectory & input, const double & stop_point_s, const PlannerData & planner_data);
 
   bool isPassthrough(const double & signed_arc_length, const PlannerData & planner_data) const;
 
@@ -141,7 +137,7 @@ private:
   // prevent stop chattering
   std::unique_ptr<Time> stop_signal_received_time_ptr_{};
 
-  std::optional<int> first_ref_stop_path_point_index_;
+  std::optional<double> first_stop_point_s_;
 
   std::optional<Time> traffic_signal_stamp_;
 

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/src/utils.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/src/utils.hpp
@@ -15,22 +15,26 @@
 #ifndef UTILS_HPP_
 #define UTILS_HPP_
 
+#define EIGEN_MPL2_ONLY
+
+#include <autoware/behavior_velocity_planner_common/utilization/boost_geometry_helper.hpp>
+#include <autoware/motion_utils/trajectory/path_with_lane_id.hpp>
+#include <autoware/trajectory/path_point_with_lane_id.hpp>
+
+#include <autoware_perception_msgs/msg/traffic_light_element.hpp>
+
+#include <lanelet2_core/primitives/Lanelet.h>
+#include <lanelet2_core/primitives/LineString.h>
+
 #include <optional>
 #include <utility>
 #include <vector>
 
-#define EIGEN_MPL2_ONLY
-#include <Eigen/Core>
-#include <Eigen/Geometry>
-#include <autoware/behavior_velocity_planner_common/utilization/boost_geometry_helper.hpp>
-#include <autoware/motion_utils/trajectory/path_with_lane_id.hpp>
-
-#include <autoware_perception_msgs/msg/traffic_light_element.hpp>
-
-#include <lanelet2_core/LaneletMap.h>
-
 namespace autoware::behavior_velocity_planner
 {
+
+using Trajectory = autoware::experimental::trajectory::Trajectory<
+  autoware_internal_planning_msgs::msg::PathPointWithLaneId>;
 
 /**
  * @brief create offset point.
@@ -78,6 +82,19 @@ auto calcStopPointAndInsertIndex(
   const autoware_internal_planning_msgs::msg::PathWithLaneId & input_path,
   const lanelet::ConstLineString3d & lanelet_stop_lines, const double & offset)
   -> std::optional<std::pair<size_t, Eigen::Vector2d>>;
+
+/**
+ * @brief find intersection point between path and stop line and return arc length.
+ * @param path input path.
+ * @param left_bound left bound.
+ * @param right_bound right bound.
+ * @param lanelet_stop_lines stop lines.
+ * @return arc length of stop point. if there is no intersection point, return std::nullopt.
+ */
+std::optional<double> calcStopPoint(
+  const Trajectory & path, const std::vector<geometry_msgs::msg::Point> & left_bound,
+  const std::vector<geometry_msgs::msg::Point> & right_bound,
+  const lanelet::ConstLineString3d & lanelet_stop_lines, const double & offset);
 
 /**
  * @brief check if the traffic signal is red stop.


### PR DESCRIPTION
## Description

This PR replaces `PathWithLaneId` in `behavior_velocity_traffic_light_module` with `Trajectory` to utilize new interface of `behavior_velocity_planner`.

## Related links

**Parent Issue:**

- https://github.com/autowarefoundation/autoware_core/issues/322

## How was this PR tested?

Psim

Evaluator: https://evaluation.tier4.jp/evaluation/reports/0041e67b-bd0b-5f1b-8ead-2560ce162c41?project_id=prd_jt 3800/3800

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
