### PR TITLE
fix(goal_planner): hasPreviousModulePathShapeChanged die

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/util.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/util.cpp
@@ -1011,12 +1011,23 @@ bool hasPreviousModulePathShapeChanged(
   const BehaviorModuleOutput & upstream_module_output,
   const BehaviorModuleOutput & last_upstream_module_output)
 {
+  if (last_upstream_module_output.path.points.size() < 2) {
+    return false;
+  }
+
   // Calculate the lateral distance between each point of the current path and the nearest point of
   // the last path
   constexpr double LATERAL_DEVIATION_THRESH = 0.1;
   for (const auto & p : upstream_module_output.path.points) {
     const size_t nearest_seg_idx = autoware::motion_utils::findNearestSegmentIndex(
       last_upstream_module_output.path.points, p.point.pose.position);
+
+    if (nearest_seg_idx + 1 >= last_upstream_module_output.path.points.size()) {
+      // In case the path is curved, nearest_seg_idx may not be monotonically increasing,
+      // so use continue instead of break here.
+      continue;
+    }
+
     const auto seg_front = last_upstream_module_output.path.points.at(nearest_seg_idx);
     const auto seg_back = last_upstream_module_output.path.points.at(nearest_seg_idx + 1);
     // Check if the target point is within the segment


### PR DESCRIPTION
## Description

Fix out_of_range  node crash.  This PR add size check. 

```
[openscenario_interpreter_node-3] [component_container_mt-25] terminate called after throwing an instance of 'std::out_of_range'
[openscenario_interpreter_node-3] [component_container_mt-25]   what():  vector::_M_range_check: __n (which is 51) >= this->size() (which is 50)
[openscenario_interpreter_node-3] [component_container_mt-25] *** Aborted at 1761760426 (unix time) try "date -d @1761760426" if you are using GNU date ***
[openscenario_interpreter_node-3] [component_container_mt-25] PC: @                0x0 (unknown)
[openscenario_interpreter_node-3] [component_container_mt-25] *** SIGABRT (@0x3e8000002fa) received by PID 762 (TID 0x7f433b9f8640) from PID 762; stack trace: ***
[openscenario_interpreter_node-3] [component_container_mt-25]     @     0x7f43521954d6 google::(anonymous namespace)::FailureSignalHandler()
[openscenario_interpreter_node-3] [component_container_mt-25]     @     0x7f4351a49520 (unknown)
[openscenario_interpreter_node-3] [component_container_mt-25]     @     0x7f4351a9d9fc pthread_kill
[openscenario_interpreter_node-3] [component_container_mt-25]     @     0x7f4351a49476 raise
[openscenario_interpreter_node-3] [component_container_mt-25]     @     0x7f4351a2f7f3 abort
[openscenario_interpreter_node-3] [component_container_mt-25]     @     0x7f4351cf2b9e (unknown)
[openscenario_interpreter_node-3] [component_container_mt-25]     @     0x7f4351cfe20c (unknown)
[openscenario_interpreter_node-3] [component_container_mt-25]     @     0x7f4351cfe277 std::terminate()
[openscenario_interpreter_node-3] [component_container_mt-25]     @     0x7f4351cfe4d8 __cxa_throw
[openscenario_interpreter_node-3] [component_container_mt-25]     @     0x7f4351cf54cd (unknown)
[openscenario_interpreter_node-3] [component_container_mt-25]     @     0x7f4302421a45 autoware::behavior_path_planner::goal_planner_utils::hasPreviousModulePathShapeChanged()
[openscenario_interpreter_node-3] [component_container_mt-25]     @     0x7f4302421deb autoware::behavior_path_planner::goal_planner_utils::should_regenerate_path_candidates()
[openscenario_interpreter_node-3] [component_container_mt-25]     @     0x7f430249034e autoware::behavior_path_planner::GoalPlannerModule::updateData()
[openscenario_interpreter_node-3] [component_container_mt-25]     @     0x7f4303d98cda autoware::behavior_path_planner::SceneModuleManagerInterface::isExecutionRequested()
[openscenario_interpreter_node-3] [component_container_mt-25]     @     0x7f4303d70e56 autoware::behavior_path_planner::SubPlannerManager::getRequestModules()
[openscenario_interpreter_node-3] [component_container_mt-25]     @     0x7f4303d7bd4b autoware::behavior_path_planner::SubPlannerManager::propagateFull()
[openscenario_interpreter_node-3] [component_container_mt-25]     @     0x7f4303d7e6cc autoware::behavior_path_planner::PlannerManager::run()
[openscenario_interpreter_node-3] [component_container_mt-25]     @     0x7f4303ddb2e1 autoware::behavior_path_planner::BehaviorPathPlannerNode::run()
[openscenario_interpreter_node-3] [component_container_mt-25]     @     0x7f4303de2f25 rclcpp::GenericTimer<>::execute_callback()
[openscenario_interpreter_node-3] [component_container_mt-25]     @     0x7f4352012ffe rclcpp::Executor::execute_any_executable()
[openscenario_interpreter_node-3] [component_container_mt-25]     @     0x7f4352019432 rclcpp::executors::MultiThreadedExecutor::run()
[openscenario_interpreter_node-3] [component_container_mt-25]     @     0x7f4351d2c253 (unknown)
[openscenario_interpreter_node-3] [component_container_mt-25]     @     0x7f4351a9bac3 (unknown)
[openscenario_interpreter_node-3] [component_container_mt-25]     @     0x7f4351b2ca74 cloneh
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

https://tier4.atlassian.net/browse/T4DEV-39689

## How was this PR tested?

Evaluator
- [[PR check (takeuchi)][Lexus][ControlDLRCommon_Basic] DLR test](https://evaluation.tier4.jp/evaluation/reports/d1e69b58-63c6-5efe-8f7c-957ce71ca0df?project_id=prd_jt) 💯
- [[PR check (takeuchi)][Lexus][FuncVerificationScenario_Basic] planning test](https://evaluation.tier4.jp/evaluation/reports/c5627658-0c2d-57fc-bbca-33d802991c7b?project_id=prd_jt) 💯
- [[PR check (takeuchi)][Lexus][CommonScenario_Basic] planning test](https://evaluation.tier4.jp/evaluation/reports/4b57841b-7707-56c2-b215-4b2b8691dcda?project_id=prd_jt)
  - 1 fails but not related
## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
