### PR TITLE
fix(traffic_light_module): remove required_time_to_departure parameter and update logic for traffic light prediction

### DIFF
--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/config/traffic_light.param.yaml
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/config/traffic_light.param.yaml
@@ -17,4 +17,3 @@
         use_remaining_time: false
         last_time_allowed_to_pass: 2.0 # [s] relative time against at the time of turn to red
         velocity_threshold: 0.5 # [m/s] change the decision logic whether the current velocity is faster or not
-        required_time_to_departure: 3.0 # [s] prevent low speed pass

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/src/manager.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/src/manager.cpp
@@ -56,8 +56,6 @@ TrafficLightModuleManager::TrafficLightModuleManager(rclcpp::Node & node)
     get_or_declare_parameter<double>(node, ns + ".v2i.last_time_allowed_to_pass");
   planner_param_.v2i_velocity_threshold =
     get_or_declare_parameter<double>(node, ns + ".v2i.velocity_threshold");
-  planner_param_.v2i_required_time_to_departure =
-    get_or_declare_parameter<double>(node, ns + ".v2i.required_time_to_departure");
   pub_tl_state_ = node.create_publisher<autoware_perception_msgs::msg::TrafficLightGroup>(
     "~/output/traffic_signal", 1);
 }

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/src/scene.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/src/scene.cpp
@@ -218,9 +218,10 @@ bool TrafficLightModule::willTrafficLightTurnRedBeforeReachingStopLine(
   const double & distance_to_stop_line) const
 {
   double ego_velocity = planner_data_->current_velocity->twist.linear.x;
-  double predicted_passing_stop_line_time = ego_velocity > planner_param_.v2i_velocity_threshold
-                                              ? distance_to_stop_line / ego_velocity
-                                              : planner_param_.v2i_required_time_to_departure;
+  if (ego_velocity < planner_param_.v2i_velocity_threshold) {
+    return false;
+  }
+  double predicted_passing_stop_line_time = distance_to_stop_line / ego_velocity;
 
   double seconds = predicted_passing_stop_line_time + planner_param_.v2i_last_time_allowed_to_pass;
 

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/src/scene.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/src/scene.hpp
@@ -72,7 +72,6 @@ public:
     bool v2i_use_remaining_time;
     double v2i_last_time_allowed_to_pass;
     double v2i_velocity_threshold;
-    double v2i_required_time_to_departure;
   };
 
 public:


### PR DESCRIPTION
## Description

Previously, the remaining time to reach the stop line was set as a parameter if the velocity was below the threshold. However, the V2I functionality prepares for a stop when the velocity is high, so it is not necessary to use it when the velocity is low.

## Related links

- https://github.com/autowarefoundation/autoware_launch/pull/1686
- https://tier4.atlassian.net/browse/T4DEV-39586
- https://star4.slack.com/archives/C074CCKN35E/p1761877734429579

## How was this PR tested?

psim + perception_reproducer ([rosbag](https://console.mob.tier4.jp/projects/x2_dev/rosbag?viz=stream&agg=count&from_ts=1759209552&to_ts=1761801552&live=true&query=project_id%3A%28x2_dev%29+environment_id%3A%288dc58113-7588-4e06-95f8-c9c77858eb67%29+vehicle_id%3A%2833381cfa-7d30-4e3e-b97c-fbe134ac2bf0%29&file_id=ccc5b016-60d6-45b3-88d2-fa182cc61e13))

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
