### PR TITLE
fix(start_planner): preventing RTC start value from publishing negative value

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/clothoid_pull_out.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/clothoid_pull_out.cpp
@@ -1445,8 +1445,9 @@ std::optional<PullOutPath> ClothoidPullOut::plan(
       std::make_pair(initial_velocity, acceleration));
     pull_out_path.partial_paths.push_back(clothoid_path);  // Use validated and cropped path
 
-    pull_out_path.start_pose =
-      clothoid_path.points.empty() ? start_pose : clothoid_path.points.front().point.pose;
+    pull_out_path.start_pose = resampled_combined_path.points.empty()
+                                 ? start_pose
+                                 : resampled_combined_path.points.front().point.pose;
     pull_out_path.end_pose = target_pose;
 
     RCLCPP_INFO(

--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/start_planner_module.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/start_planner_module.cpp
@@ -879,7 +879,7 @@ BehaviorModuleOutput StartPlannerModule::plan()
     const double finish_distance = autoware::motion_utils::calcSignedArcLength(
       path.points, planner_data_->self_odometry->pose.pose.position,
       status_.pull_out_path.end_pose.position);
-    updateRTCStatus(start_distance, finish_distance);
+    updateRTCStatus((start_distance < 0.0 ? 0.0 : start_distance), finish_distance);
 
     const auto start_idx = autoware::motion_utils::findNearestIndex(
       path.points, status_.pull_out_path.start_pose.position);
@@ -1039,7 +1039,7 @@ BehaviorModuleOutput StartPlannerModule::planWaitingApproval()
     const double finish_distance = autoware::motion_utils::calcSignedArcLength(
       stop_path.points, planner_data_->self_odometry->pose.pose.position,
       status_.pull_out_path.end_pose.position);
-    updateRTCStatus(start_distance, finish_distance);
+    updateRTCStatus((start_distance < 0.0 ? 0.0 : start_distance), finish_distance);
 
     const auto start_idx = autoware::motion_utils::findNearestIndex(
       stop_path.points, status_.pull_out_path.start_pose.position);


### PR DESCRIPTION
## Description

RTC support for the start planner will be added in the latest Autoware version.
The first step is to make the feature compatible with RTC tools.

Due to a limitation in the RTC tools, any start position smaller than -2.0 does not publish an RTC service.
To support this, this PR addresses the following two points:

1. Clothoid start position fix:
Previously, the clothoid always started at -3.0 m, but it should actually start ahead of the ego vehicle.
This PR corrects the start pose published by the clothoid planner.

2. Start planner transition fix:
The start planner can now transition to the waiting for approval state from this [PR](https://github.com/autowarefoundation/autoware_universe/pull/11482).
Since this may affect RTC behavior, any negative start position value is now set to 0.0.


| Before  | After |
| ------------- | ------------- 
| <video src="https://github.com/user-attachments/assets/8a7fb0a7-8259-4697-b984-b077474a6583">  | <video src="https://github.com/user-attachments/assets/38a2ed1a-142c-48fa-8952-0a14daadb393">|
|    | <video src="https://github.com/user-attachments/assets/dd412b21-c7cf-4155-aa0d-e835e5ca4907">|

## Related links

- [TIER IV internal discussion](https://star4.slack.com/archives/CRUE57C30/p1761727677301739)

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

1. PSIM
2. TIER IV Interval Evaluation: 
[TIER IV Internal Link - ControlDLR Test](https://evaluation.tier4.jp/evaluation/reports/1bb18881-026b-55bf-ab14-2ce6cdcdd62d?project_id=prd_jt)
[TIER IV Internal Link - FuncVerification Test](https://evaluation.tier4.jp/evaluation/reports/b72ea353-381e-5bdd-a734-d89172a99ef2?project_id=prd_jt)
[TIER IV Internal Link - CommonScenario_Basic Test](https://evaluation.tier4.jp/evaluation/reports/7e8669f4-8a0f-5787-bb01-0608ad03c84d?project_id=prd_jt)

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
