### PR TITLE
fix(staitc_obstacle_avoidance): fix crashes due to an exception

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/utils.cpp
@@ -583,7 +583,7 @@ std::optional<lanelet::ConstLineString3d> getNearestIntersectionRoadBorder(
   // extract road_border linestring
   std::vector<lanelet::ConstLineString3d> road_border_linestring;
   for (const auto & ls : linestrings) {
-    const lanelet::Attribute & type = ls.attribute(lanelet::AttributeName::Type);
+    const std::string type = ls.attributeOr(lanelet::AttributeName::Type, "none");
     if (type == "road_border") {
       road_border_linestring.push_back(ls);
     }


### PR DESCRIPTION
## Description
This PR fixes an issue where the `static_obstacle_avoidance` module crashes due to an exception.

## Related links
- https://star4.slack.com/archives/C04ATE0264Q/p1761888121600879
- https://star4.slack.com/archives/C074CCKN35E/p1762245505054929

## How was this PR tested?
- [CommonScenario_Basic](https://evaluation.tier4.jp/evaluation/reports/25cb3a05-d6cd-5805-ae56-5b666a3b91e3?project_id=prd_jt)
- [FuncVerificationScenario_Basic](https://evaluation.tier4.jp/evaluation/reports/ed8ba010-b812-5f1c-95bb-0a4a2f8eddb0?project_id=prd_jt)
- [ControlDLRCommon_Basic](https://evaluation.tier4.jp/evaluation/reports/70503f51-dfb3-560b-bc0b-6d342a85897d?project_id=prd_jt)

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
