### PR TITLE
refactor(autoware_trajectory_optimizer): reuse function to copy original orientation

### DIFF
--- a/planning/autoware_trajectory_optimizer/include/autoware/trajectory_optimizer/utils.hpp
+++ b/planning/autoware_trajectory_optimizer/include/autoware/trajectory_optimizer/utils.hpp
@@ -84,12 +84,12 @@ void copy_trajectory_orientation(
  * @param traj_points The trajectory points to be interpolated.
  * @param interpolation_resolution_m Interpolation resolution for Akima spline.
  * @param max_distance_discrepancy_m Maximum position deviation allowed for orientation copying.
- * @param copy_original_orientation Flag to indicate if orientation from original trajectory should
- * be copied.
+ * @param preserve_original_orientation Flag to indicate if orientation from original trajectory
+ * should be copied.
  */
 void apply_spline(
   TrajectoryPoints & traj_points, const double interpolation_resolution_m,
-  const double max_distance_discrepancy_m, const bool copy_original_orientation);
+  const double max_distance_discrepancy_m, const bool preserve_original_orientation);
 
 /**
  * @brief Gets the logger for the trajectory optimizer.

--- a/planning/autoware_trajectory_optimizer/src/utils.cpp
+++ b/planning/autoware_trajectory_optimizer/src/utils.cpp
@@ -300,7 +300,7 @@ void copy_trajectory_orientation(
 
 void apply_spline(
   TrajectoryPoints & traj_points, const double interpolation_resolution_m,
-  const double max_distance_discrepancy_m, const bool copy_original_orientation)
+  const double max_distance_discrepancy_m, const bool preserve_original_orientation)
 {
   constexpr size_t minimum_points_for_akima_spline = 5;
   if (traj_points.size() < minimum_points_for_akima_spline) {
@@ -349,16 +349,9 @@ void apply_spline(
     output_points.push_back(original_trajectory_last_point);
   }
 
-  if (copy_original_orientation) {
-    for (auto & out_point : output_points) {
-      const auto nearest_index_opt = autoware::motion_utils::findNearestIndex(
-        original_traj_points, out_point.pose, max_distance_discrepancy_m, M_PI);
-      if (!nearest_index_opt.has_value()) {
-        continue;
-      }
-      const auto nearest_index = nearest_index_opt.value();
-      out_point.pose.orientation = original_traj_points.at(nearest_index).pose.orientation;
-    }
+  if (preserve_original_orientation) {
+    copy_trajectory_orientation(
+      original_traj_points, output_points, max_distance_discrepancy_m, M_PI);
   }
 
   traj_points = output_points;

--- a/planning/autoware_trajectory_optimizer/tests/test_trajectory_optimizer.cpp
+++ b/planning/autoware_trajectory_optimizer/tests/test_trajectory_optimizer.cpp
@@ -110,9 +110,9 @@ TEST_F(TrajectoryOptimizerUtilsTest, ApplySpline)
   TrajectoryPoints points = create_sample_trajectory();
   const double interpolation_resolution_m = 0.1;
   const double max_distance_discrepancy_m = 5.0;
-  const bool copy_original_orientation = true;
+  const bool preserve_original_orientation = true;
   autoware::trajectory_optimizer::utils::apply_spline(
-    points, interpolation_resolution_m, max_distance_discrepancy_m, copy_original_orientation);
+    points, interpolation_resolution_m, max_distance_discrepancy_m, preserve_original_orientation);
   ASSERT_GE(points.size(), 2);
 }
 


### PR DESCRIPTION

## Description
Small PR it replaces repeated code by utilizing the utils function to copy over orientations.
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
Psim
## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
