### PR TITLE
chore(tier4_state_rviz_plugin): change ClearRoute button activation rule

### DIFF
--- a/visualization/tier4_state_rviz_plugin/src/autoware_state_panel.cpp
+++ b/visualization/tier4_state_rviz_plugin/src/autoware_state_panel.cpp
@@ -605,7 +605,7 @@ void AutowareStatePanel::onRoute(const RouteState::ConstSharedPtr msg)
       autoware::state_rviz_plugin::colors::default_colors.surface_container_low_pressed.c_str()),
     QColor(autoware::state_rviz_plugin::colors::default_colors.disabled_button_bg.c_str()),
     QColor(autoware::state_rviz_plugin::colors::default_colors.disabled_button_text.c_str()));
-  if (msg->state == RouteState::SET) {
+  if (msg->state == RouteState::SET || msg->state == RouteState::ARRIVED) {
     activateButton(clear_route_button_ptr_);
   } else {
     deactivateButton(clear_route_button_ptr_);


### PR DESCRIPTION
## Description

Based on the RouteState design,
this PR enables the Clear Route button to be pressed when the RouteState is `ARRIVED`.

<img width="681" height="131" alt="image" src="https://github.com/user-attachments/assets/3f030126-9b9e-406a-8be1-bfa3341a9265" />

from: https://autowarefoundation.github.io/autoware-documentation/pr-279/design/autoware-interfaces/ad-api/features/routing/

Before

<img width="478" height="609" alt="image" src="https://github.com/user-attachments/assets/e1234988-96c7-49df-895d-62732e2a199f" />

After

<img width="478" height="609" alt="image" src="https://github.com/user-attachments/assets/ba83238e-1461-481b-b1b7-9d9652160a5f" />


## Related links


<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

(ADDED by @sasakisasaki ) Tests looks performed well as above

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
