### PR TITLE
fix(lane_change): prevent path distortion by resetting lane change module when ego is not in either current or target lanes

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/base_class.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/base_class.hpp
@@ -235,6 +235,8 @@ public:
 
   virtual bool is_near_regulatory_element() const = 0;
 
+  virtual bool is_ego_in_current_or_target_lanes() const = 0;
+
 protected:
   virtual bool isValidPath(const PathWithLaneId & path) const = 0;
 

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/scene.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/scene.hpp
@@ -194,6 +194,14 @@ protected:
 
   void update_dist_from_intersection();
 
+  /**
+   * @brief Check whether the ego vehicle is currently located in either the
+   *        current lanes or the target lanes used for lane change planning.
+   *
+   * @return true   ego vehicle is on one of the current or target lanelets.
+   */
+  bool is_ego_in_current_or_target_lanes() const final;
+
   std::vector<PathPointWithLaneId> path_after_intersection_;
   double stop_time_{0.0};
 };

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/utils.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/utils.hpp
@@ -479,5 +479,17 @@ std::vector<PoseWithVelocityStamped> convert_to_predicted_path(
 
 bool is_moving_object(
   const CommonDataPtr & common_data_ptr, const ExtendedPredictedObject & object);
+
+/**
+ * @brief Check whether a given lanelet exists in a specified collection of lanelets.
+ *
+ * @param lanelet_collections  Lanelets that define the lookup range.
+ * @param lanelet          Lanelet to check for membership in the target set.
+ * @return true            The lanelet is an element of target_lanelets.
+ *
+ * @note Comparison is performed by lanelet ID, not by geometric or semantic equality.
+ */
+bool is_lanelet_in_lanelet_collections(
+  const lanelet::ConstLanelets & lanelet_collections, const lanelet::ConstLanelet & lanelet);
 }  // namespace autoware::behavior_path_planner::utils::lane_change
 #endif  // AUTOWARE__BEHAVIOR_PATH_LANE_CHANGE_MODULE__UTILS__UTILS_HPP_

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/interface.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/interface.cpp
@@ -313,6 +313,10 @@ std::pair<LaneChangeStates, std::string_view> LaneChangeInterface::check_transit
     return {LaneChangeStates::Abort, "Aborting"};
   }
 
+  if (!module_type_->is_ego_in_current_or_target_lanes()) {
+    return {LaneChangeStates::Cancel, "EgoOutOfLanes"};
+  }
+
   if (isWaitingApproval()) {
     if (module_type_->is_near_regulatory_element()) {
       return {LaneChangeStates::Cancel, "CloseToRegElement"};

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/scene.cpp
@@ -2040,4 +2040,27 @@ void NormalLaneChange::update_dist_from_intersection()
   path_after_intersection_.clear();
   transient_data.dist_from_prev_intersection = std::numeric_limits<double>::max();
 }
+
+bool NormalLaneChange::is_ego_in_current_or_target_lanes() const
+{
+  lanelet::ConstLanelet current_lane;
+  if (!common_data_ptr_->route_handler_ptr->getClosestLaneletWithinRoute(
+        common_data_ptr_->get_ego_pose(), &current_lane)) {
+    return false;
+  }
+
+  const auto & current_lanes = get_current_lanes();
+  const auto in_current =
+    utils::lane_change::is_lanelet_in_lanelet_collections(current_lanes, current_lane);
+
+  if (in_current) {
+    return true;
+  }
+
+  const auto & target_lanes = get_target_lanes();
+  const auto in_target =
+    utils::lane_change::is_lanelet_in_lanelet_collections(target_lanes, current_lane);
+
+  return in_target;
+}
 }  // namespace autoware::behavior_path_planner

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/utils.cpp
@@ -1212,4 +1212,12 @@ bool is_moving_object(const CommonDataPtr & common_data_ptr, const ExtendedPredi
   return object.initial_twist.linear.x >
          common_data_ptr->lc_param_ptr->safety.th_stopped_object_velocity;
 }
+
+bool is_lanelet_in_lanelet_collections(
+  const lanelet::ConstLanelets & lanelet_collections, const lanelet::ConstLanelet & lanelet)
+{
+  return std::any_of(
+    lanelet_collections.begin(), lanelet_collections.end(),
+    [&](const auto & lane) { return lane.id() == lanelet.id(); });
+}
 }  // namespace autoware::behavior_path_planner::utils::lane_change


### PR DESCRIPTION
## Description

```
-----------------> Left lane
A | C | E
-----------------> Centerline 
B | D | F
-----------------> Right lane
```

An unexpected lateral movement (path distortion) occurs because the Lane Change planning system fails to reset its state after the driver manually overrides the maneuver and changes lanes.

**The sequence of the bug:**

1.  **Initial Plan (Current lane A $\to$ target lane F):** The Lane Change module decides that a lane change is needed and planner manager registers to execute it.
2.  **Planner Stops Checking:** Once the lane change is registered, the lane change module stops checking if a lane change is still required.
3.  **Driver Intervention (A $\to$ B):** The driver manually steers and moves the car into the desired lane (B), and the planned route updates immediately (e.g., to B $\to$ D).
4.  **Module Gets Stuck:** Because the lane change module stopped checking, the Lane Change module never realized the driver had already performed the required maneuver. It keeps running based on its old intent.
5.  **Delayed Distortion:** The module eventually applies its shifting command to the *new* route (B $\to$ D), causing the car to unexpectedly shift later on when it reaches the new lane.

This combination of factors leads to unexpected and confusing lateral movements on the path.

### ✅ Solution

The solution is to reset the Lane Change module as soon as the ego goes a new lane that is not part of current or target lanes.

## Related links

[TIER IV Internal ticket](https://tier4.atlassian.net/browse/T4DEV-39033v)

## How was this PR tested?

### Logging Simulator

| Before  | After |
| ------------- | ------------- 
| <video src="https://github.com/user-attachments/assets/97e284fb-683d-44e5-bbd3-e1d00400791b">  | <video src="https://github.com/user-attachments/assets/af2c2f74-aff9-4318-b7e9-d849b150a61a">|

### TIER IV Internal Evaluation

[TIER IV Internal Link - ControlDLR Test](https://evaluation.tier4.jp/evaluation/reports/1404b836-5ccd-5792-9832-1cede88078d8?project_id=prd_jt)
[TIER IV Internal Link - FuncVerification Test](https://evaluation.tier4.jp/evaluation/reports/83fe6e9f-d60f-56c8-be25-a98f21085a7d?project_id=prd_jt)
[TIER IV Internal Link - CommonScenario_Basic Test](https://evaluation.tier4.jp/evaluation/reports/2a2ec8a7-1c03-58e9-ac88-674c1b1c4e18?project_id=prd_jt)

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
