### PR TITLE
fix(goal_planner): fix bezier path first yaw angle

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/pull_over_planner/bezier_pull_over.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/pull_over_planner/bezier_pull_over.cpp
@@ -188,12 +188,13 @@ std::vector<PullOverPath> BezierPullOver::generateBezierPath(
   std::vector<std::tuple<double, double, double>> params;
   const size_t n_sample_v_init = 2;
   const size_t n_sample_v_final = 2;
+  const double min_v_coeff = 0.1;
   const size_t n_sample_acc = 1;
   for (unsigned i = 0; i <= n_sample_v_init; ++i) {
     for (unsigned j = 0; j <= n_sample_v_final; j++) {
       for (unsigned k = 0; k <= n_sample_acc; k++) {
-        const double v_init_coeff = i * (1.0 / n_sample_v_init);
-        const double v_final_coeff = j * 0.25 / (1.0 / n_sample_v_final);
+        const double v_init_coeff = std::max(min_v_coeff, i * (1.0 / n_sample_v_init));
+        const double v_final_coeff = std::max(min_v_coeff, j * 0.25 / (1.0 / n_sample_v_final));
         const double acc_coeff = k * (10.0 / n_sample_acc);
         params.emplace_back(v_init_coeff, v_final_coeff, acc_coeff);
       }


### PR DESCRIPTION
## Description

There was a problem with the initial yaw of Bezier Pull Over path.

<img width="1786" height="1765" alt="image" src="https://github.com/user-attachments/assets/751b573a-ceb8-44c1-969b-3daead7711ce" />

The velocity coefficient (v_init_coeff) became zero when the Bezier curve was created. This made the curve's tangent vector a zero vector, which prevented the heading from being calculated correctly.

```
double Bezier::heading(const double t) const
{
  const Eigen::Vector2d vel = velocity(t);
  return std::atan2(vel.y(), vel.x());
}
```

In this PR, set min value (0.1) for v_init_coeff 


## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->



https://tier4.atlassian.net/browse/T4DEV-39729


## How was this PR tested?

psim

visualizer only bezier path debug arrow

before 

<img width="3832" height="2160" alt="image" src="https://github.com/user-attachments/assets/e58ee812-35ea-4e46-89cd-7ca116ebb767" />

after

<img width="1964" height="2028" alt="image" src="https://github.com/user-attachments/assets/a8068a63-f13d-45f4-be4a-74d64c82ec46" />


Evaluator (wip)

failed but not related to this PR

- [[PR check (takeuchi)][Lexus][CommonScenario_Basic] planning test](https://evaluation.tier4.jp/evaluation/reports/44603bad-45df-547b-a5a0-7d34182b934e?project_id=prd_jt)
- [[PR check (takeuchi)][Lexus][ControlDLRCommon_Basic] DLR test](https://evaluation.tier4.jp/evaluation/reports/3bdec1a2-f594-5a31-a039-110c3c92535b?project_id=prd_jt)
- [[PR check (takeuchi)][Lexus][FuncVerificationScenario_Basic] planning test](https://evaluation.tier4.jp/evaluation/reports/05bfe18e-4a29-55b4-939f-61a8b23a2f46?project_id=prd_jt)


## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
