### PR TITLE
fix(diffusion_planner): fix `is_segment_inside`

### DIFF
--- a/planning/autoware_diffusion_planner/src/preprocessing/lane_segments.cpp
+++ b/planning/autoware_diffusion_planner/src/preprocessing/lane_segments.cpp
@@ -306,23 +306,15 @@ std::map<lanelet::Id, size_t> create_lane_id_to_array_index_map(
 
 bool is_segment_inside(const LaneSegment & segment, const double center_x, const double center_y)
 {
-  auto is_inside = [&](const double x, const double y) {
-    using autoware::diffusion_planner::constants::LANE_MASK_RANGE_M;
-    return (
-      x > center_x - LANE_MASK_RANGE_M && x < center_x + LANE_MASK_RANGE_M &&
-      y > center_y - LANE_MASK_RANGE_M && y < center_y + LANE_MASK_RANGE_M);
-  };
+  for (const auto & point : segment.centerline) {
+    if (
+      std::abs(point.x() - center_x) <= autoware::diffusion_planner::constants::LANE_MASK_RANGE_M &&
+      std::abs(point.y() - center_y) <= autoware::diffusion_planner::constants::LANE_MASK_RANGE_M) {
+      return true;
+    }
+  }
 
-  const double mean_x = segment.mean_point.x();
-  const double mean_y = segment.mean_point.y();
-  const double first_x = segment.centerline.front().x();
-  const double first_y = segment.centerline.front().y();
-  const double last_x = segment.centerline.back().x();
-  const double last_y = segment.centerline.back().y();
-
-  const bool inside =
-    is_inside(mean_x, mean_y) || is_inside(first_x, first_y) || is_inside(last_x, last_y);
-  return inside;
+  return false;
 }
 
 uint8_t identify_current_light_status(


### PR DESCRIPTION
## Description

This PR fixes the `is_segment_inside` function in the diffusion planner by changing the logic from checking only three representative points (mean, first, last) to checking all points in the segment's centerline.

## How was this PR tested?

### Before


https://github.com/user-attachments/assets/df0ecd44-81fe-4f2b-b90c-04fc402040f7


### After



https://github.com/user-attachments/assets/1dd4905e-951b-4fe5-9fbc-efc9317d31a4



## Notes for reviewers



None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
