### PR TITLE
fix: tf2 uses hpp headers in rolling (and is backported)

### DIFF
--- a/common/autoware_boundary_departure_checker/src/boundary_departure_checker.cpp
+++ b/common/autoware_boundary_departure_checker/src/boundary_departure_checker.cpp
@@ -24,13 +24,13 @@
 #include <autoware_utils/system/stop_watch.hpp>
 #include <range/v3/algorithm.hpp>
 #include <range/v3/view.hpp>
+#include <tf2/utils.hpp>
 #include <tl_expected/expected.hpp>
 
 #include <boost/geometry.hpp>
 
 #include <fmt/format.h>
 #include <lanelet2_core/geometry/Polygon.h>
-#include <tf2/utils.h>
 
 #include <algorithm>
 #include <memory>

--- a/common/autoware_boundary_departure_checker/src/boundary_departure_checker_abnormality.cpp
+++ b/common/autoware_boundary_departure_checker/src/boundary_departure_checker_abnormality.cpp
@@ -23,13 +23,13 @@
 #include <autoware_utils/system/stop_watch.hpp>
 #include <range/v3/algorithm.hpp>
 #include <range/v3/view.hpp>
+#include <tf2/utils.hpp>
 #include <tl_expected/expected.hpp>
 
 #include <boost/geometry.hpp>
 
 #include <fmt/format.h>
 #include <lanelet2_core/geometry/Polygon.h>
-#include <tf2/utils.h>
 
 #include <algorithm>
 #include <memory>

--- a/common/autoware_traffic_light_utils/include/autoware/traffic_light_utils/traffic_light_utils.hpp
+++ b/common/autoware_traffic_light_utils/include/autoware/traffic_light_utils/traffic_light_utils.hpp
@@ -15,6 +15,9 @@
 #ifndef AUTOWARE__TRAFFIC_LIGHT_UTILS__TRAFFIC_LIGHT_UTILS_HPP_
 #define AUTOWARE__TRAFFIC_LIGHT_UTILS__TRAFFIC_LIGHT_UTILS_HPP_
 
+#include <tf2/LinearMath/Matrix3x3.hpp>
+#include <tf2/LinearMath/Transform.hpp>
+
 #include "autoware_perception_msgs/msg/traffic_light_element.hpp"
 #include "autoware_perception_msgs/msg/traffic_light_group.hpp"
 #include "tier4_perception_msgs/msg/traffic_light.hpp"
@@ -24,8 +27,6 @@
 #include <lanelet2_core/primitives/Lanelet.h>
 #include <lanelet2_core/primitives/LineString.h>
 #include <lanelet2_core/primitives/Primitive.h>
-#include <tf2/LinearMath/Matrix3x3.h>
-#include <tf2/LinearMath/Transform.h>
 
 #include <vector>
 

--- a/common/autoware_universe_utils/include/autoware/universe_utils/geometry/geometry.hpp
+++ b/common/autoware_universe_utils/include/autoware/universe_utils/geometry/geometry.hpp
@@ -26,6 +26,7 @@
 
 #define EIGEN_MPL2_ONLY
 #include <Eigen/Core>
+#include <tf2/utils.hpp>
 
 #include <autoware_internal_planning_msgs/msg/path_with_lane_id.hpp>
 #include <autoware_planning_msgs/msg/path.hpp>
@@ -39,8 +40,6 @@
 #include <geometry_msgs/msg/twist_with_covariance.hpp>
 #include <geometry_msgs/msg/vector3.hpp>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
-
-#include <tf2/utils.h>
 
 // TODO(wep21): Remove these apis
 //              after they are implemented in ros2 geometry2.

--- a/common/autoware_universe_utils/src/geometry/boost_polygon_utils.cpp
+++ b/common/autoware_universe_utils/src/geometry/boost_polygon_utils.cpp
@@ -16,9 +16,9 @@
 
 #include "autoware/universe_utils/geometry/geometry.hpp"
 
-#include <boost/geometry/geometry.hpp>
+#include <tf2/utils.hpp>
 
-#include <tf2/utils.h>
+#include <boost/geometry/geometry.hpp>
 
 namespace
 {

--- a/common/autoware_universe_utils/src/geometry/geometry.cpp
+++ b/common/autoware_universe_utils/src/geometry/geometry.cpp
@@ -17,10 +17,9 @@
 #include "autoware/universe_utils/geometry/gjk_2d.hpp"
 
 #include <Eigen/Geometry>
+#include <tf2/convert.hpp>
 
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
-
-#include <tf2/convert.h>
 
 #include <string>
 

--- a/common/autoware_universe_utils/src/geometry/pose_deviation.cpp
+++ b/common/autoware_universe_utils/src/geometry/pose_deviation.cpp
@@ -16,7 +16,7 @@
 
 #include "autoware/universe_utils/math/normalization.hpp"
 
-#include <tf2/utils.h>
+#include <tf2/utils.hpp>
 
 #define EIGEN_MPL2_ONLY
 #include <Eigen/Core>

--- a/common/autoware_universe_utils/src/ros/msg_operation.cpp
+++ b/common/autoware_universe_utils/src/ros/msg_operation.cpp
@@ -14,7 +14,7 @@
 
 #include "autoware/universe_utils/ros/msg_operation.hpp"
 
-#include <tf2/utils.h>
+#include <tf2/utils.hpp>
 
 #ifdef ROS_DISTRO_GALACTIC
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>

--- a/control/autoware_autonomous_emergency_braking/include/autoware/autonomous_emergency_braking/utils.hpp
+++ b/control/autoware_autonomous_emergency_braking/include/autoware/autonomous_emergency_braking/utils.hpp
@@ -18,6 +18,7 @@
 #include "autoware/autonomous_emergency_braking/node.hpp"
 
 #include <autoware_utils/geometry/boost_polygon_utils.hpp>
+#include <tf2/utils.hpp>
 
 #include <autoware_perception_msgs/msg/predicted_objects.hpp>
 #include <geometry_msgs/msg/detail/point__struct.hpp>
@@ -25,8 +26,6 @@
 #include <geometry_msgs/msg/pose.hpp>
 
 #include <boost/geometry/algorithms/correct.hpp>
-
-#include <tf2/utils.h>
 
 #include <string>
 #include <vector>

--- a/control/autoware_autonomous_emergency_braking/src/node.cpp
+++ b/control/autoware_autonomous_emergency_braking/src/node.cpp
@@ -24,6 +24,7 @@
 #include <autoware_utils/ros/update_param.hpp>
 #include <pcl_ros/transforms.hpp>
 #include <rclcpp/node.hpp>
+#include <tf2/utils.hpp>
 
 #include <geometry_msgs/msg/polygon.hpp>
 
@@ -41,7 +42,6 @@
 #include <pcl/point_types.h>
 #include <pcl/registration/gicp.h>
 #include <pcl/segmentation/extract_clusters.h>
-#include <tf2/utils.h>
 
 #include <algorithm>
 #include <cmath>

--- a/control/autoware_autonomous_emergency_braking/test/test.cpp
+++ b/control/autoware_autonomous_emergency_braking/test/test.cpp
@@ -19,6 +19,7 @@
 
 #include <rclcpp/rclcpp.hpp>
 #include <rclcpp/time.hpp>
+#include <tf2/LinearMath/Transform.hpp>
 
 #include <autoware_perception_msgs/msg/detail/shape__struct.hpp>
 #include <geometry_msgs/msg/detail/point__struct.hpp>
@@ -26,7 +27,6 @@
 
 #include <gtest/gtest.h>
 #include <pcl/memory.h>
-#include <tf2/LinearMath/Transform.h>
 
 #include <limits>
 #include <memory>

--- a/control/autoware_collision_detector/include/autoware/collision_detector/node.hpp
+++ b/control/autoware_collision_detector/include/autoware/collision_detector/node.hpp
@@ -21,6 +21,7 @@
 #include <diagnostic_updater/diagnostic_updater.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <rclcpp/subscription.hpp>
+#include <tf2/utils.hpp>
 
 #include <autoware_adapi_v1_msgs/msg/operation_mode_state.hpp>
 #include <autoware_perception_msgs/msg/predicted_objects.hpp>
@@ -31,7 +32,6 @@
 
 #include <boost/optional.hpp>
 
-#include <tf2/utils.h>
 #include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_listener.h>
 

--- a/control/autoware_control_performance_analysis/include/autoware/control_performance_analysis/control_performance_analysis_utils.hpp
+++ b/control/autoware_control_performance_analysis/include/autoware/control_performance_analysis/control_performance_analysis_utils.hpp
@@ -18,11 +18,10 @@
 #include <Eigen/Core>
 #include <Eigen/Geometry>
 #include <rclcpp/rclcpp.hpp>
+#include <tf2/utils.hpp>
 
 #include <geometry_msgs/msg/point.hpp>
 #include <geometry_msgs/msg/quaternion.hpp>
-
-#include <tf2/utils.h>
 
 #include <cmath>
 #include <utility>

--- a/control/autoware_control_validator/test/test_control_validator.cpp
+++ b/control/autoware_control_validator/test/test_control_validator.cpp
@@ -16,13 +16,13 @@
 
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <rclcpp/node_options.hpp>
+#include <tf2/LinearMath/Quaternion.hpp>
 
 #include <autoware_planning_msgs/msg/trajectory.hpp>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 
 #include <gtest/gtest-param-test.h>
 #include <gtest/gtest.h>
-#include <tf2/LinearMath/Quaternion.h>
 
 #include <cmath>
 #include <memory>

--- a/control/autoware_mpc_lateral_controller/include/autoware/mpc_lateral_controller/mpc_utils.hpp
+++ b/control/autoware_mpc_lateral_controller/include/autoware/mpc_lateral_controller/mpc_utils.hpp
@@ -16,9 +16,9 @@
 #define AUTOWARE__MPC_LATERAL_CONTROLLER__MPC_UTILS_HPP_
 
 #include "rclcpp/rclcpp.hpp"
-#include "tf2/utils.h"
 
 #include <Eigen/Core>
+#include <tf2/utils.hpp>
 
 #ifdef ROS_DISTRO_GALACTIC
 #include "tf2_geometry_msgs/tf2_geometry_msgs.h"

--- a/control/autoware_mpc_lateral_controller/src/mpc_lateral_controller.cpp
+++ b/control/autoware_mpc_lateral_controller/src/mpc_lateral_controller.cpp
@@ -21,8 +21,9 @@
 #include "autoware/mpc_lateral_controller/vehicle_model/vehicle_model_bicycle_kinematics.hpp"
 #include "autoware/mpc_lateral_controller/vehicle_model/vehicle_model_bicycle_kinematics_no_delay.hpp"
 #include "autoware_vehicle_info_utils/vehicle_info_utils.hpp"
-#include "tf2/utils.h"
 #include "tf2_ros/create_timer_ros.h"
+
+#include <tf2/utils.hpp>
 
 #include <algorithm>
 #include <deque>

--- a/control/autoware_obstacle_collision_checker/src/obstacle_collision_checker.cpp
+++ b/control/autoware_obstacle_collision_checker/src/obstacle_collision_checker.cpp
@@ -20,12 +20,12 @@
 #include <autoware_utils/system/stop_watch.hpp>
 #include <pcl_ros/transforms.hpp>
 #include <rclcpp/rclcpp.hpp>
+#include <tf2/utils.hpp>
 #include <tf2_eigen/tf2_eigen.hpp>
 
 #include <boost/geometry.hpp>
 
 #include <pcl_conversions/pcl_conversions.h>
-#include <tf2/utils.h>
 
 #include <vector>
 

--- a/control/autoware_pid_longitudinal_controller/include/autoware/pid_longitudinal_controller/longitudinal_controller_utils.hpp
+++ b/control/autoware_pid_longitudinal_controller/include/autoware/pid_longitudinal_controller/longitudinal_controller_utils.hpp
@@ -19,11 +19,11 @@
 #include "autoware/interpolation/spherical_linear_interpolation.hpp"
 #include "autoware/motion_utils/trajectory/conversion.hpp"
 #include "autoware/motion_utils/trajectory/trajectory.hpp"
-#include "tf2/utils.h"
 
 #include <Eigen/Core>
 #include <Eigen/Geometry>
 #include <experimental/optional>  // NOLINT
+#include <tf2/utils.hpp>
 
 #include "autoware_planning_msgs/msg/trajectory.hpp"
 #include "geometry_msgs/msg/pose.hpp"

--- a/control/autoware_pid_longitudinal_controller/include/autoware/pid_longitudinal_controller/pid_longitudinal_controller.hpp
+++ b/control/autoware_pid_longitudinal_controller/include/autoware/pid_longitudinal_controller/pid_longitudinal_controller.hpp
@@ -25,12 +25,12 @@
 #include "autoware_vehicle_info_utils/vehicle_info_utils.hpp"
 #include "diagnostic_updater/diagnostic_updater.hpp"
 #include "rclcpp/rclcpp.hpp"
-#include "tf2/utils.h"
 #include "tf2_ros/buffer.h"
 #include "tf2_ros/transform_listener.h"
 
 #include <Eigen/Core>
 #include <Eigen/Geometry>
+#include <tf2/utils.hpp>
 
 #include "autoware_adapi_v1_msgs/msg/operation_mode_state.hpp"
 #include "autoware_control_msgs/msg/longitudinal.hpp"

--- a/control/autoware_pid_longitudinal_controller/src/longitudinal_controller_utils.cpp
+++ b/control/autoware_pid_longitudinal_controller/src/longitudinal_controller_utils.cpp
@@ -15,10 +15,10 @@
 #include "autoware/pid_longitudinal_controller/longitudinal_controller_utils.hpp"
 
 #include "autoware_utils/geometry/geometry.hpp"
-#include "tf2/LinearMath/Matrix3x3.h"
-#include "tf2/LinearMath/Quaternion.h"
 
 #include <experimental/optional>  // NOLINT
+#include <tf2/LinearMath/Matrix3x3.hpp>
+#include <tf2/LinearMath/Quaternion.hpp>
 
 #include <utility>
 

--- a/control/autoware_pid_longitudinal_controller/test/test_longitudinal_controller_utils.cpp
+++ b/control/autoware_pid_longitudinal_controller/test/test_longitudinal_controller_utils.cpp
@@ -16,7 +16,8 @@
 #include "autoware/motion_utils/trajectory/conversion.hpp"
 #include "autoware/pid_longitudinal_controller/longitudinal_controller_utils.hpp"
 #include "gtest/gtest.h"
-#include "tf2/LinearMath/Quaternion.h"
+
+#include <tf2/LinearMath/Quaternion.hpp>
 
 #include "autoware_planning_msgs/msg/trajectory.hpp"
 #include "autoware_planning_msgs/msg/trajectory_point.hpp"

--- a/control/autoware_pure_pursuit/include/autoware/pure_pursuit/util/planning_utils.hpp
+++ b/control/autoware_pure_pursuit/include/autoware/pure_pursuit/util/planning_utils.hpp
@@ -22,13 +22,12 @@
 #include <Eigen/Core>
 #include <Eigen/Geometry>
 #include <rclcpp/rclcpp.hpp>
+#include <tf2/transform_datatypes.hpp>
+#include <tf2/utils.hpp>
 
 #include <autoware_planning_msgs/msg/trajectory.hpp>
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <geometry_msgs/msg/twist_stamped.hpp>
-
-#include <tf2/transform_datatypes.h>
-#include <tf2/utils.h>
 
 #ifdef ROS_DISTRO_GALACTIC
 #include <tf2_eigen/tf2_eigen.h>

--- a/control/autoware_trajectory_follower_node/include/autoware/trajectory_follower_node/controller_node.hpp
+++ b/control/autoware_trajectory_follower_node/include/autoware/trajectory_follower_node/controller_node.hpp
@@ -24,7 +24,6 @@
 #include "autoware_utils/system/stop_watch.hpp"
 #include "autoware_vehicle_info_utils/vehicle_info_utils.hpp"
 #include "rclcpp/rclcpp.hpp"
-#include "tf2/utils.h"
 #include "tf2_ros/buffer.h"
 #include "tf2_ros/transform_listener.h"
 
@@ -32,6 +31,7 @@
 #include <Eigen/Geometry>
 #include <autoware_utils/ros/published_time_publisher.hpp>
 #include <diagnostic_updater/diagnostic_updater.hpp>
+#include <tf2/utils.hpp>
 
 #include "autoware_control_msgs/msg/control.hpp"
 #include "autoware_control_msgs/msg/control_horizon.hpp"

--- a/evaluator/autoware_control_evaluator/test/test_control_evaluator_node.cpp
+++ b/evaluator/autoware_control_evaluator/test/test_control_evaluator_node.cpp
@@ -20,14 +20,13 @@
 
 #include <autoware/control_evaluator/control_evaluator_node.hpp>
 #include <autoware/planning_factor_interface/planning_factor_interface.hpp>
+#include <tf2/LinearMath/Quaternion.hpp>
 
 #include "autoware_planning_msgs/msg/trajectory.hpp"
 #include "geometry_msgs/msg/transform_stamped.hpp"
 #include <tier4_metric_msgs/msg/metric_array.hpp>
 
 #include "boost/lexical_cast.hpp"
-
-#include <tf2/LinearMath/Quaternion.h>
 
 #include <iostream>
 #include <memory>

--- a/localization/autoware_landmark_based_localizer/autoware_ar_tag_based_localizer/src/ar_tag_based_localizer.cpp
+++ b/localization/autoware_landmark_based_localizer/autoware_ar_tag_based_localizer/src/ar_tag_based_localizer.cpp
@@ -60,7 +60,7 @@
 #else
 #include <cv_bridge/cv_bridge.h>  // for ROS 2 Humble or older
 #endif
-#include <tf2/LinearMath/Transform.h>
+#include <tf2/LinearMath/Transform.hpp>
 
 #include <algorithm>
 #include <limits>

--- a/localization/autoware_localization_error_monitor/src/localization_error_monitor.cpp
+++ b/localization/autoware_localization_error_monitor/src/localization_error_monitor.cpp
@@ -17,8 +17,7 @@
 #include "diagnostics_helper.hpp"
 
 #include <Eigen/Dense>
-
-#include <tf2/utils.h>
+#include <tf2/utils.hpp>
 #ifdef ROS_DISTRO_GALACTIC
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 #else

--- a/localization/autoware_pose_instability_detector/src/pose_instability_detector.cpp
+++ b/localization/autoware_pose_instability_detector/src/pose_instability_detector.cpp
@@ -16,9 +16,9 @@
 
 #include "autoware_utils_geometry/geometry.hpp"
 
-#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+#include <tf2/LinearMath/Quaternion.hpp>
 
-#include <tf2/LinearMath/Quaternion.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 
 #include <algorithm>
 #include <cmath>

--- a/localization/yabloc/yabloc_particle_filter/src/common/mean.cpp
+++ b/localization/yabloc/yabloc_particle_filter/src/common/mean.cpp
@@ -17,11 +17,10 @@
 #include <Eigen/Geometry>
 #include <rclcpp/logger.hpp>
 #include <rclcpp/logging.hpp>
+#include <tf2/utils.hpp>
 #include <yabloc_common/pose_conversions.hpp>
 
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
-
-#include <tf2/utils.h>
 
 #include <algorithm>
 #include <cmath>

--- a/localization/yabloc/yabloc_particle_filter/src/prediction/predictor.cpp
+++ b/localization/yabloc/yabloc_particle_filter/src/prediction/predictor.cpp
@@ -20,11 +20,10 @@
 
 #include <Eigen/Core>
 #include <sophus/geometry.hpp>
+#include <tf2/utils.hpp>
 #include <yabloc_common/pose_conversions.hpp>
 
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
-
-#include <tf2/utils.h>
 
 #include <memory>
 #include <numeric>

--- a/map/autoware_map_tf_generator/src/pcd_map_tf_generator_node.cpp
+++ b/map/autoware_map_tf_generator/src/pcd_map_tf_generator_node.cpp
@@ -15,13 +15,13 @@
 #include "uniform_random.hpp"
 
 #include <rclcpp/rclcpp.hpp>
+#include <tf2/LinearMath/Quaternion.hpp>
 
 #include <sensor_msgs/msg/point_cloud2.hpp>
 
 #include <pcl/point_cloud.h>
 #include <pcl/point_types.h>
 #include <pcl_conversions/pcl_conversions.h>
-#include <tf2/LinearMath/Quaternion.h>
 #include <tf2_ros/static_transform_broadcaster.h>
 
 #include <memory>

--- a/map/autoware_map_tf_generator/src/vector_map_tf_generator_node.cpp
+++ b/map/autoware_map_tf_generator/src/vector_map_tf_generator_node.cpp
@@ -14,12 +14,12 @@
 
 #include <autoware_lanelet2_extension/utility/message_conversion.hpp>
 #include <rclcpp/rclcpp.hpp>
+#include <tf2/LinearMath/Quaternion.hpp>
 
 #include <autoware_map_msgs/msg/lanelet_map_bin.hpp>
 
 #include <lanelet2_core/LaneletMap.h>
 #include <lanelet2_core/geometry/Point.h>
-#include <tf2/LinearMath/Quaternion.h>
 #include <tf2_ros/static_transform_broadcaster.h>
 
 #include <memory>

--- a/perception/autoware_camera_streampetr/src/node.cpp
+++ b/perception/autoware_camera_streampetr/src/node.cpp
@@ -18,9 +18,8 @@
 
 #include <Eigen/Dense>
 #include <image_transport/image_transport.hpp>
-
-#include <tf2/LinearMath/Transform.h>
-#include <tf2/convert.h>
+#include <tf2/LinearMath/Transform.hpp>
+#include <tf2/convert.hpp>
 
 #include <algorithm>
 #include <cmath>

--- a/perception/autoware_detection_by_tracker/src/debugger/debugger.hpp
+++ b/perception/autoware_detection_by_tracker/src/debugger/debugger.hpp
@@ -19,16 +19,15 @@
 #include "autoware_utils/system/stop_watch.hpp"
 
 #include <rclcpp/rclcpp.hpp>
+#include <tf2/LinearMath/Transform.hpp>
+#include <tf2/convert.hpp>
+#include <tf2/transform_datatypes.hpp>
 
 #include "autoware_perception_msgs/msg/detected_objects.hpp"
 #include "autoware_perception_msgs/msg/tracked_objects.hpp"
 #include "tier4_perception_msgs/msg/detected_objects_with_feature.hpp"
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
-
-#include <tf2/LinearMath/Transform.h>
-#include <tf2/convert.h>
-#include <tf2/transform_datatypes.h>
 
 #ifdef ROS_DISTRO_GALACTIC
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>

--- a/perception/autoware_detection_by_tracker/src/detection_by_tracker_node.hpp
+++ b/perception/autoware_detection_by_tracker/src/detection_by_tracker_node.hpp
@@ -25,16 +25,15 @@
 #include "utils/utils.hpp"
 
 #include <rclcpp/rclcpp.hpp>
+#include <tf2/LinearMath/Transform.hpp>
+#include <tf2/convert.hpp>
+#include <tf2/transform_datatypes.hpp>
 
 #include "autoware_perception_msgs/msg/detected_objects.hpp"
 #include "autoware_perception_msgs/msg/tracked_objects.hpp"
 #include "tier4_perception_msgs/msg/detected_objects_with_feature.hpp"
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
-
-#include <tf2/LinearMath/Transform.h>
-#include <tf2/convert.h>
-#include <tf2/transform_datatypes.h>
 
 #ifdef ROS_DISTRO_GALACTIC
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>

--- a/perception/autoware_detection_by_tracker/src/tracker/tracker_handler.cpp
+++ b/perception/autoware_detection_by_tracker/src/tracker/tracker_handler.cpp
@@ -17,7 +17,7 @@
 #include "autoware_utils/geometry/geometry.hpp"
 #include "autoware_utils/math/normalization.hpp"
 
-#include <tf2/utils.h>
+#include <tf2/utils.hpp>
 
 namespace autoware::detection_by_tracker
 {

--- a/perception/autoware_ground_segmentation/src/ransac_ground_filter/node.hpp
+++ b/perception/autoware_ground_segmentation/src/ransac_ground_filter/node.hpp
@@ -19,6 +19,7 @@
 #include "autoware_utils/system/time_keeper.hpp"
 
 #include <managed_transform_buffer/managed_transform_buffer.hpp>
+#include <tf2/transform_datatypes.hpp>
 
 #include <geometry_msgs/msg/pose_array.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
@@ -27,7 +28,6 @@
 #include <pcl/filters/voxel_grid.h>
 #include <pcl/segmentation/sac_segmentation.h>
 #include <pcl_conversions/pcl_conversions.h>
-#include <tf2/transform_datatypes.h>
 
 #ifdef ROS_DISTRO_GALACTIC
 #include <tf2_eigen/tf2_eigen.h>

--- a/perception/autoware_ground_segmentation/src/ray_ground_filter/node.hpp
+++ b/perception/autoware_ground_segmentation/src/ray_ground_filter/node.hpp
@@ -47,12 +47,13 @@
 
 #include "autoware_utils/system/time_keeper.hpp"
 
+#include <tf2/transform_datatypes.hpp>
+
 #include <sensor_msgs/msg/point_cloud2.hpp>
 
 #include <pcl/filters/extract_indices.h>
 #include <pcl/filters/voxel_grid.h>
 #include <pcl_conversions/pcl_conversions.h>
-#include <tf2/transform_datatypes.h>
 
 #ifdef ROS_DISTRO_GALACTIC
 #include <tf2_eigen/tf2_eigen.h>

--- a/perception/autoware_ground_segmentation/src/scan_ground_filter/node.hpp
+++ b/perception/autoware_ground_segmentation/src/scan_ground_filter/node.hpp
@@ -22,13 +22,13 @@
 #include <autoware/pointcloud_preprocessor/transform_info.hpp>
 #include <autoware_utils/system/time_keeper.hpp>
 #include <autoware_vehicle_info_utils/vehicle_info.hpp>
+#include <tf2/transform_datatypes.hpp>
 
 #include <sensor_msgs/msg/point_cloud2.hpp>
 
 #include <pcl/filters/extract_indices.h>
 #include <pcl/filters/voxel_grid.h>
 #include <pcl_conversions/pcl_conversions.h>
-#include <tf2/transform_datatypes.h>
 
 #ifdef ROS_DISTRO_GALACTIC
 #include <tf2_eigen/tf2_eigen.h>

--- a/perception/autoware_map_based_prediction/include/map_based_prediction/map_based_prediction_node.hpp
+++ b/perception/autoware_map_based_prediction/include/map_based_prediction/map_based_prediction_node.hpp
@@ -29,6 +29,7 @@
 #include <autoware_utils/system/lru_cache.hpp>
 #include <autoware_utils/system/time_keeper.hpp>
 #include <rclcpp/rclcpp.hpp>
+#include <tf2/LinearMath/Quaternion.hpp>
 
 #include <geometry_msgs/msg/pose.hpp>
 #include <geometry_msgs/msg/pose_stamped.hpp>
@@ -40,7 +41,6 @@
 #include <lanelet2_routing/Forward.h>
 #include <lanelet2_routing/LaneletPath.h>
 #include <lanelet2_traffic_rules/TrafficRules.h>
-#include <tf2/LinearMath/Quaternion.h>
 
 #include <algorithm>
 #include <deque>

--- a/perception/autoware_map_based_prediction/include/map_based_prediction/path_generator.hpp
+++ b/perception/autoware_map_based_prediction/include/map_based_prediction/path_generator.hpp
@@ -20,6 +20,7 @@
 #include <Eigen/Eigen>
 #include <autoware_utils/system/time_keeper.hpp>
 #include <rclcpp/rclcpp.hpp>
+#include <tf2/LinearMath/Quaternion.hpp>
 
 #include <autoware_perception_msgs/msg/predicted_objects.hpp>
 #include <autoware_perception_msgs/msg/tracked_objects.hpp>
@@ -28,8 +29,6 @@
 #include <geometry_msgs/msg/quaternion.hpp>
 #include <geometry_msgs/msg/twist.hpp>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
-
-#include <tf2/LinearMath/Quaternion.h>
 
 #include <memory>
 #include <vector>

--- a/perception/autoware_map_based_prediction/include/map_based_prediction/utils.hpp
+++ b/perception/autoware_map_based_prediction/include/map_based_prediction/utils.hpp
@@ -21,13 +21,13 @@
 #include <autoware_utils/math/normalization.hpp>
 #include <autoware_utils/math/unit_conversion.hpp>
 #include <rclcpp/rclcpp.hpp>
+#include <tf2/utils.hpp>
 
 #include <autoware_perception_msgs/msg/predicted_objects.hpp>
 #include <autoware_perception_msgs/msg/tracked_objects.hpp>
 
 #include <lanelet2_core/LaneletMap.h>
 #include <lanelet2_core/geometry/LaneletMap.h>
-#include <tf2/utils.h>
 
 #include <deque>
 #include <memory>

--- a/perception/autoware_map_based_prediction/src/map_based_prediction_node.cpp
+++ b/perception/autoware_map_based_prediction/src/map_based_prediction_node.cpp
@@ -30,6 +30,7 @@
 #include <autoware_utils/math/constants.hpp>
 #include <autoware_utils/math/normalization.hpp>
 #include <autoware_utils/math/unit_conversion.hpp>
+#include <tf2/utils.hpp>
 
 #include <autoware_perception_msgs/msg/detected_objects.hpp>
 #include <diagnostic_msgs/msg/diagnostic_status.hpp>
@@ -44,7 +45,6 @@
 #include <lanelet2_core/geometry/LaneletMap.h>
 #include <lanelet2_core/geometry/Point.h>
 #include <lanelet2_routing/RoutingGraph.h>
-#include <tf2/utils.h>
 
 #include <algorithm>
 #include <chrono>

--- a/perception/autoware_multi_object_tracker/lib/object_model/shapes.cpp
+++ b/perception/autoware_multi_object_tracker/lib/object_model/shapes.cpp
@@ -17,13 +17,12 @@
 #include <Eigen/Geometry>
 #include <autoware_utils_geometry/boost_geometry.hpp>
 #include <autoware_utils_geometry/boost_polygon_utils.hpp>
+#include <tf2/utils.hpp>
 
 #include <autoware_perception_msgs/msg/shape.hpp>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 
 #include <boost/geometry.hpp>
-
-#include <tf2/utils.h>
 
 #include <algorithm>
 #include <cmath>

--- a/perception/autoware_multi_object_tracker/lib/tracker/model/pass_through_tracker.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/model/pass_through_tracker.cpp
@@ -22,9 +22,9 @@
 #include <Eigen/Geometry>
 #include <autoware/object_recognition_utils/object_recognition_utils.hpp>
 #include <autoware_utils_geometry/msg/covariance.hpp>
+#include <tf2/utils.hpp>
 
 #include <bits/stdc++.h>
-#include <tf2/utils.h>
 
 #ifdef ROS_DISTRO_GALACTIC
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>

--- a/perception/autoware_multi_object_tracker/lib/tracker/model/pedestrian_tracker.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/model/pedestrian_tracker.cpp
@@ -25,9 +25,9 @@
 #include <autoware_utils_geometry/boost_polygon_utils.hpp>
 #include <autoware_utils_math/normalization.hpp>
 #include <autoware_utils_math/unit_conversion.hpp>
+#include <tf2/utils.hpp>
 
 #include <bits/stdc++.h>
-#include <tf2/utils.h>
 
 #ifdef ROS_DISTRO_GALACTIC
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>

--- a/perception/autoware_multi_object_tracker/lib/tracker/model/unknown_tracker.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/model/unknown_tracker.cpp
@@ -21,9 +21,9 @@
 #include <autoware_utils_geometry/boost_polygon_utils.hpp>
 #include <autoware_utils_math/normalization.hpp>
 #include <autoware_utils_math/unit_conversion.hpp>
+#include <tf2/utils.hpp>
 
 #include <bits/stdc++.h>
-#include <tf2/utils.h>
 
 #include <cmath>
 

--- a/perception/autoware_multi_object_tracker/lib/tracker/model/vehicle_tracker.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/model/vehicle_tracker.cpp
@@ -25,9 +25,9 @@
 #include <autoware_utils_geometry/boost_polygon_utils.hpp>
 #include <autoware_utils_math/normalization.hpp>
 #include <autoware_utils_math/unit_conversion.hpp>
+#include <tf2/utils.hpp>
 
 #include <bits/stdc++.h>
-#include <tf2/utils.h>
 
 #ifdef ROS_DISTRO_GALACTIC
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>

--- a/perception/autoware_multi_object_tracker/lib/tracker/motion_model/bicycle_motion_model.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/motion_model/bicycle_motion_model.cpp
@@ -21,8 +21,7 @@
 #include <autoware_utils_geometry/msg/covariance.hpp>
 #include <autoware_utils_math/normalization.hpp>
 #include <autoware_utils_math/unit_conversion.hpp>
-
-#include <tf2/LinearMath/Quaternion.h>
+#include <tf2/LinearMath/Quaternion.hpp>
 
 #include <algorithm>
 

--- a/perception/autoware_multi_object_tracker/lib/tracker/motion_model/ctrv_motion_model.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/motion_model/ctrv_motion_model.cpp
@@ -24,8 +24,7 @@
 #include <autoware_utils_geometry/msg/covariance.hpp>
 #include <autoware_utils_math/normalization.hpp>
 #include <autoware_utils_math/unit_conversion.hpp>
-
-#include <tf2/LinearMath/Quaternion.h>
+#include <tf2/LinearMath/Quaternion.hpp>
 
 namespace autoware::multi_object_tracker
 {

--- a/perception/autoware_multi_object_tracker/lib/tracker/motion_model/cv_motion_model.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/motion_model/cv_motion_model.cpp
@@ -24,8 +24,7 @@
 #include <autoware_utils_geometry/msg/covariance.hpp>
 #include <autoware_utils_math/normalization.hpp>
 #include <autoware_utils_math/unit_conversion.hpp>
-
-#include <tf2/utils.h>
+#include <tf2/utils.hpp>
 
 namespace autoware::multi_object_tracker
 {

--- a/perception/autoware_multi_object_tracker/lib/tracker/motion_model/static_motion_model.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/motion_model/static_motion_model.cpp
@@ -21,8 +21,7 @@
 #include <autoware_utils_geometry/msg/covariance.hpp>
 #include <autoware_utils_math/normalization.hpp>
 #include <autoware_utils_math/unit_conversion.hpp>
-
-#include <tf2/utils.h>
+#include <tf2/utils.hpp>
 
 namespace autoware::multi_object_tracker
 {

--- a/perception/autoware_multi_object_tracker/lib/uncertainty/uncertainty_processor.cpp
+++ b/perception/autoware_multi_object_tracker/lib/uncertainty/uncertainty_processor.cpp
@@ -21,8 +21,7 @@
 #include <Eigen/Geometry>
 #include <autoware_utils_geometry/msg/covariance.hpp>
 #include <autoware_utils_math/unit_conversion.hpp>
-
-#include <tf2/utils.h>
+#include <tf2/utils.hpp>
 
 #include <algorithm>
 

--- a/perception/autoware_multi_object_tracker/src/multi_object_tracker_node.hpp
+++ b/perception/autoware_multi_object_tracker/src/multi_object_tracker_node.hpp
@@ -28,14 +28,13 @@
 
 #include <autoware_utils_debug/time_keeper.hpp>
 #include <rclcpp/rclcpp.hpp>
+#include <tf2/LinearMath/Transform.hpp>
+#include <tf2/convert.hpp>
+#include <tf2/transform_datatypes.hpp>
 
 #include "autoware_perception_msgs/msg/detected_objects.hpp"
 #include "autoware_perception_msgs/msg/tracked_objects.hpp"
 #include <geometry_msgs/msg/pose_stamped.hpp>
-
-#include <tf2/LinearMath/Transform.h>
-#include <tf2/convert.h>
-#include <tf2/transform_datatypes.h>
 
 #ifdef ROS_DISTRO_GALACTIC
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>

--- a/perception/autoware_object_merger/include/autoware/object_merger/object_association_merger_node.hpp
+++ b/perception/autoware_object_merger/include/autoware/object_merger/object_association_merger_node.hpp
@@ -22,15 +22,15 @@
 
 #include <autoware_utils/ros/diagnostics_interface.hpp>
 #include <rclcpp/rclcpp.hpp>
+#include <tf2/LinearMath/Transform.hpp>
+#include <tf2/convert.hpp>
+#include <tf2/transform_datatypes.hpp>
 
 #include "autoware_perception_msgs/msg/detected_objects.hpp"
 
 #include <message_filters/subscriber.h>
 #include <message_filters/sync_policies/approximate_time.h>
 #include <message_filters/synchronizer.h>
-#include <tf2/LinearMath/Transform.h>
-#include <tf2/convert.h>
-#include <tf2/transform_datatypes.h>
 
 #ifdef ROS_DISTRO_GALACTIC
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>

--- a/perception/autoware_radar_object_tracker/include/autoware_radar_object_tracker/utils/radar_object_tracker_utils.hpp
+++ b/perception/autoware_radar_object_tracker/include/autoware_radar_object_tracker/utils/radar_object_tracker_utils.hpp
@@ -38,9 +38,10 @@
 #else
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 #endif
-#include <tf2/LinearMath/Transform.h>
-#include <tf2/convert.h>
-#include <tf2/transform_datatypes.h>
+#include <tf2/LinearMath/Transform.hpp>
+#include <tf2/convert.hpp>
+#include <tf2/transform_datatypes.hpp>
+
 #include <tf2_ros/buffer.h>
 
 #include <string>

--- a/perception/autoware_radar_object_tracker/src/radar_object_tracker_node.hpp
+++ b/perception/autoware_radar_object_tracker/src/radar_object_tracker_node.hpp
@@ -22,6 +22,9 @@
 #include <autoware_lanelet2_extension/utility/utilities.hpp>
 #include <diagnostic_updater/diagnostic_updater.hpp>
 #include <rclcpp/rclcpp.hpp>
+#include <tf2/LinearMath/Transform.hpp>
+#include <tf2/convert.hpp>
+#include <tf2/transform_datatypes.hpp>
 
 #include "autoware_perception_msgs/msg/detected_objects.hpp"
 #include "autoware_perception_msgs/msg/tracked_objects.hpp"
@@ -33,9 +36,6 @@
 #include <lanelet2_core/geometry/Point.h>
 #include <lanelet2_routing/RoutingGraph.h>
 #include <lanelet2_traffic_rules/TrafficRulesFactory.h>
-#include <tf2/LinearMath/Transform.h>
-#include <tf2/convert.h>
-#include <tf2/transform_datatypes.h>
 
 #ifdef ROS_DISTRO_GALACTIC
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>

--- a/perception/autoware_radar_object_tracker/src/tracker/model/constant_turn_rate_motion_tracker.cpp
+++ b/perception/autoware_radar_object_tracker/src/tracker/model/constant_turn_rate_motion_tracker.cpp
@@ -25,10 +25,11 @@
 #include "autoware_utils_geometry/msg/covariance.hpp"
 #include "autoware_utils_math/unit_conversion.hpp"
 
+#include <tf2/LinearMath/Matrix3x3.hpp>
+#include <tf2/LinearMath/Quaternion.hpp>
+#include <tf2/utils.hpp>
+
 #include <bits/stdc++.h>
-#include <tf2/LinearMath/Matrix3x3.h>
-#include <tf2/LinearMath/Quaternion.h>
-#include <tf2/utils.h>
 
 #include <string>
 #include <vector>

--- a/perception/autoware_radar_object_tracker/src/tracker/model/linear_motion_tracker.cpp
+++ b/perception/autoware_radar_object_tracker/src/tracker/model/linear_motion_tracker.cpp
@@ -25,10 +25,11 @@
 #include "autoware_utils_geometry/msg/covariance.hpp"
 #include "autoware_utils_math/unit_conversion.hpp"
 
+#include <tf2/LinearMath/Matrix3x3.hpp>
+#include <tf2/LinearMath/Quaternion.hpp>
+#include <tf2/utils.hpp>
+
 #include <bits/stdc++.h>
-#include <tf2/LinearMath/Matrix3x3.h>
-#include <tf2/LinearMath/Quaternion.h>
-#include <tf2/utils.h>
 
 #include <string>
 #include <vector>

--- a/perception/autoware_radar_tracks_msgs_converter/src/radar_tracks_msgs_converter_node.cpp
+++ b/perception/autoware_radar_tracks_msgs_converter/src/radar_tracks_msgs_converter_node.cpp
@@ -18,7 +18,7 @@
 #include "autoware_utils/math/unit_conversion.hpp"
 #include "autoware_utils/ros/msg_covariance.hpp"
 
-#include <tf2/utils.h>
+#include <tf2/utils.hpp>
 
 #ifdef ROS_DISTRO_GALACTIC
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>

--- a/perception/autoware_shape_estimation/lib/corrector/utils.cpp
+++ b/perception/autoware_shape_estimation/lib/corrector/utils.cpp
@@ -18,9 +18,9 @@
 
 #include "autoware_utils/geometry/geometry.hpp"
 
-#include <tf2/LinearMath/Matrix3x3.h>
-#include <tf2/LinearMath/Quaternion.h>
-#include <tf2/utils.h>
+#include <tf2/LinearMath/Matrix3x3.hpp>
+#include <tf2/LinearMath/Quaternion.hpp>
+#include <tf2/utils.hpp>
 #ifdef ROS_DISTRO_GALACTIC
 #include <tf2_eigen/tf2_eigen.h>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>

--- a/perception/autoware_shape_estimation/lib/model/bounding_box.cpp
+++ b/perception/autoware_shape_estimation/lib/model/bounding_box.cpp
@@ -19,6 +19,7 @@
 #include <opencv2/core/core.hpp>
 #include <opencv2/highgui/highgui.hpp>
 #include <opencv2/imgproc/imgproc.hpp>
+#include <tf2/LinearMath/Quaternion.hpp>
 
 #include "autoware_perception_msgs/msg/shape.hpp"
 
@@ -27,7 +28,6 @@
 #include <pcl/point_cloud.h>
 #include <pcl/point_types.h>
 #include <pcl_conversions/pcl_conversions.h>
-#include <tf2/LinearMath/Quaternion.h>
 
 #ifdef ROS_DISTRO_GALACTIC
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>

--- a/perception/autoware_shape_estimation/lib/tensorrt_shape_estimator.cpp
+++ b/perception/autoware_shape_estimation/lib/tensorrt_shape_estimator.cpp
@@ -14,9 +14,9 @@
 
 #include "autoware/shape_estimation/tensorrt_shape_estimator.hpp"
 
-#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+#include <tf2/utils.hpp>
 
-#include <tf2/utils.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 
 #include <functional>
 #include <iostream>

--- a/perception/autoware_shape_estimation/src/shape_estimation_node.cpp
+++ b/perception/autoware_shape_estimation/src/shape_estimation_node.cpp
@@ -17,11 +17,11 @@
 #include "autoware/shape_estimation/shape_estimator.hpp"
 #include "autoware_utils/math/unit_conversion.hpp"
 
-#include "autoware_perception_msgs/msg/object_classification.hpp"
+#include <tf2/LinearMath/Matrix3x3.hpp>
+#include <tf2/LinearMath/Quaternion.hpp>
+#include <tf2/utils.hpp>
 
-#include <tf2/LinearMath/Matrix3x3.h>
-#include <tf2/LinearMath/Quaternion.h>
-#include <tf2/utils.h>
+#include "autoware_perception_msgs/msg/object_classification.hpp"
 
 #ifdef ROS_DISTRO_GALACTIC
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>

--- a/perception/autoware_tensorrt_bevdet/src/marker_utils.cpp
+++ b/perception/autoware_tensorrt_bevdet/src/marker_utils.cpp
@@ -14,9 +14,9 @@
 
 #include "autoware/tensorrt_bevdet/marker_utils.hpp"
 
-#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+#include <tf2/LinearMath/Quaternion.hpp>
 
-#include <tf2/LinearMath/Quaternion.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 
 #include <array>
 #include <map>

--- a/perception/autoware_tensorrt_bevformer/src/marker_utils.cpp
+++ b/perception/autoware_tensorrt_bevformer/src/marker_utils.cpp
@@ -30,9 +30,9 @@
 
 #include "marker_util.hpp"
 
-#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+#include <tf2/LinearMath/Quaternion.hpp>
 
-#include <tf2/LinearMath/Quaternion.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 
 #include <algorithm>
 #include <array>

--- a/perception/autoware_tensorrt_bevformer/src/ros_utils.cpp
+++ b/perception/autoware_tensorrt_bevformer/src/ros_utils.cpp
@@ -36,11 +36,10 @@
 #include <Eigen/Geometry>
 #include <opencv2/opencv.hpp>
 #include <rclcpp/logging.hpp>
+#include <tf2/LinearMath/Matrix3x3.hpp>
+#include <tf2/LinearMath/Quaternion.hpp>
 
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
-
-#include <tf2/LinearMath/Matrix3x3.h>
-#include <tf2/LinearMath/Quaternion.h>
 
 #include <algorithm>
 #include <cmath>

--- a/perception/autoware_tensorrt_bevformer/src/ros_utils.hpp
+++ b/perception/autoware_tensorrt_bevformer/src/ros_utils.hpp
@@ -36,13 +36,13 @@
 #include <Eigen/Core>
 #include <Eigen/Geometry>
 #include <opencv2/opencv.hpp>
+#include <tf2/LinearMath/Quaternion.hpp>
 
 #include <autoware_perception_msgs/msg/detected_objects.hpp>
 #include <geometry_msgs/msg/transform_stamped.hpp>
 #include <sensor_msgs/msg/camera_info.hpp>
 
 #include <cuda_runtime.h>
-#include <tf2/LinearMath/Quaternion.h>
 
 // TensorRT headers
 #pragma GCC diagnostic push

--- a/perception/autoware_tracking_object_merger/include/autoware/tracking_object_merger/utils/utils.hpp
+++ b/perception/autoware_tracking_object_merger/include/autoware/tracking_object_merger/utils/utils.hpp
@@ -20,6 +20,11 @@
 #include "autoware_utils/geometry/geometry.hpp"
 
 #include <rclcpp/rclcpp.hpp>
+#include <tf2/LinearMath/Quaternion.hpp>
+#include <tf2/LinearMath/Transform.hpp>
+#include <tf2/convert.hpp>
+#include <tf2/transform_datatypes.hpp>
+#include <tf2/utils.hpp>
 
 #include "autoware_perception_msgs/msg/object_classification.hpp"
 #include "autoware_perception_msgs/msg/shape.hpp"
@@ -29,12 +34,6 @@
 #include <geometry_msgs/msg/polygon.hpp>
 #include <geometry_msgs/msg/vector3.hpp>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
-
-#include <tf2/LinearMath/Quaternion.h>
-#include <tf2/LinearMath/Transform.h>
-#include <tf2/convert.h>
-#include <tf2/transform_datatypes.h>
-#include <tf2/utils.h>
 
 #include <cmath>
 #include <iostream>

--- a/perception/autoware_traffic_light_map_based_detector/src/traffic_light_map_based_detector_node.cpp
+++ b/perception/autoware_traffic_light_map_based_detector/src/traffic_light_map_based_detector_node.cpp
@@ -23,12 +23,12 @@
 #include <autoware_lanelet2_extension/visualization/visualization.hpp>
 #include <autoware_utils/math/normalization.hpp>
 #include <autoware_utils/math/unit_conversion.hpp>
+#include <tf2/LinearMath/Matrix3x3.hpp>
+#include <tf2/LinearMath/Transform.hpp>
 
 #include <lanelet2_core/Exceptions.h>
 #include <lanelet2_core/geometry/Point.h>
 #include <lanelet2_routing/RoutingGraphContainer.h>
-#include <tf2/LinearMath/Matrix3x3.h>
-#include <tf2/LinearMath/Transform.h>
 
 #include <algorithm>
 #include <memory>

--- a/perception/autoware_traffic_light_map_based_detector/src/traffic_light_map_based_detector_process.hpp
+++ b/perception/autoware_traffic_light_map_based_detector/src/traffic_light_map_based_detector_process.hpp
@@ -16,13 +16,13 @@
 #define TRAFFIC_LIGHT_MAP_BASED_DETECTOR_PROCESS_HPP_
 
 #include <opencv2/core.hpp>
+#include <tf2/LinearMath/Transform.hpp>
+#include <tf2/LinearMath/Vector3.hpp>
 
 #include <tier4_perception_msgs/msg/traffic_light_roi_array.hpp>
 
 #include <lanelet2_core/LaneletMap.h>
 #include <lanelet2_core/primitives/Lanelet.h>
-#include <tf2/LinearMath/Transform.h>
-#include <tf2/LinearMath/Vector3.h>
 
 #include <vector>
 

--- a/perception/autoware_traffic_light_occlusion_predictor/src/node.cpp
+++ b/perception/autoware_traffic_light_occlusion_predictor/src/node.cpp
@@ -23,13 +23,13 @@
 #include <autoware_lanelet2_extension/visualization/visualization.hpp>
 #include <autoware_utils/system/stop_watch.hpp>
 #include <rclcpp/rclcpp.hpp>
+#include <tf2/LinearMath/Matrix3x3.hpp>
+#include <tf2/LinearMath/Transform.hpp>
 
 #include <lanelet2_core/Exceptions.h>
 #include <lanelet2_core/geometry/Point.h>
 #include <lanelet2_projection/UTM.h>
 #include <lanelet2_routing/RoutingGraphContainer.h>
-#include <tf2/LinearMath/Matrix3x3.h>
-#include <tf2/LinearMath/Transform.h>
 
 #include <algorithm>
 #include <memory>

--- a/planning/autoware_costmap_generator/src/costmap_generator.cpp
+++ b/planning/autoware_costmap_generator/src/costmap_generator.cpp
@@ -53,12 +53,12 @@
 #include <pcl_ros/transforms.hpp>
 #include <rclcpp/clock.hpp>
 #include <rclcpp/logging.hpp>
+#include <tf2/time.hpp>
+#include <tf2/utils.hpp>
 #include <tf2_eigen/tf2_eigen.hpp>
 
 #include <lanelet2_core/Forward.h>
 #include <lanelet2_core/geometry/Polygon.h>
-#include <tf2/time.h>
-#include <tf2/utils.h>
 
 #include <memory>
 #include <string>

--- a/planning/autoware_costmap_generator/src/utils/object_map_utils.cpp
+++ b/planning/autoware_costmap_generator/src/utils/object_map_utils.cpp
@@ -34,8 +34,7 @@
 
 #include <autoware/grid_map_utils/polygon_iterator.hpp>
 #include <grid_map_core/Polygon.hpp>
-
-#include <tf2/time.h>
+#include <tf2/time.hpp>
 
 #include <string>
 #include <vector>

--- a/planning/autoware_costmap_generator/src/utils/objects_to_costmap.cpp
+++ b/planning/autoware_costmap_generator/src/utils/objects_to_costmap.cpp
@@ -46,9 +46,9 @@
 
 #include <autoware/grid_map_utils/polygon_iterator.hpp>
 #include <grid_map_core/TypeDefs.hpp>
+#include <tf2/utils.hpp>
 
 #include <Eigen/src/Core/util/Constants.h>
-#include <tf2/utils.h>
 
 #include <algorithm>
 #include <cmath>

--- a/planning/autoware_costmap_generator/test/test_objects_to_costmap.cpp
+++ b/planning/autoware_costmap_generator/test/test_objects_to_costmap.cpp
@@ -15,9 +15,9 @@
 #include <autoware/costmap_generator/utils/objects_to_costmap.hpp>
 #include <autoware_utils/geometry/geometry.hpp>
 #include <rclcpp/rclcpp.hpp>
+#include <tf2/utils.hpp>
 
 #include <gtest/gtest.h>
-#include <tf2/utils.h>
 
 #include <memory>
 

--- a/planning/autoware_diffusion_planner/test/postprocessing_utils_edge_case_test.cpp
+++ b/planning/autoware_diffusion_planner/test/postprocessing_utils_edge_case_test.cpp
@@ -20,11 +20,11 @@
 #include <autoware_utils/geometry/geometry.hpp>
 #include <autoware_utils_uuid/uuid_helper.hpp>
 #include <rclcpp/time.hpp>
+#include <tf2/utils.hpp>
 
 #include <autoware_perception_msgs/msg/tracked_objects.hpp>
 
 #include <gtest/gtest.h>
-#include <tf2/utils.h>
 
 #include <algorithm>
 #include <limits>

--- a/planning/autoware_freespace_planning_algorithms/include/autoware/freespace_planning_algorithms/abstract_algorithm.hpp
+++ b/planning/autoware_freespace_planning_algorithms/include/autoware/freespace_planning_algorithms/abstract_algorithm.hpp
@@ -18,11 +18,10 @@
 #include <autoware_utils/geometry/geometry.hpp>
 #include <autoware_utils/math/normalization.hpp>
 #include <autoware_vehicle_info_utils/vehicle_info_utils.hpp>
+#include <tf2/utils.hpp>
 
 #include <geometry_msgs/msg/pose_array.hpp>
 #include <nav_msgs/msg/occupancy_grid.hpp>
-
-#include <tf2/utils.h>
 
 #include <algorithm>
 #include <limits>

--- a/planning/autoware_freespace_planning_algorithms/include/autoware/freespace_planning_algorithms/kinematic_bicycle_model.hpp
+++ b/planning/autoware_freespace_planning_algorithms/include/autoware/freespace_planning_algorithms/kinematic_bicycle_model.hpp
@@ -17,8 +17,7 @@
 
 #include <autoware_utils/geometry/geometry.hpp>
 #include <autoware_vehicle_info_utils/vehicle_info_utils.hpp>
-
-#include <tf2/utils.h>
+#include <tf2/utils.hpp>
 
 #include <vector>
 

--- a/planning/autoware_freespace_planning_algorithms/include/autoware/freespace_planning_algorithms/rrtstar_core.hpp
+++ b/planning/autoware_freespace_planning_algorithms/include/autoware/freespace_planning_algorithms/rrtstar_core.hpp
@@ -17,7 +17,7 @@
 
 #include "autoware/freespace_planning_algorithms/reeds_shepp.hpp"
 
-#include <tf2/utils.h>
+#include <tf2/utils.hpp>
 
 #include <algorithm>
 #include <cmath>

--- a/planning/autoware_freespace_planning_algorithms/src/astar_search.cpp
+++ b/planning/autoware_freespace_planning_algorithms/src/astar_search.cpp
@@ -19,9 +19,8 @@
 
 #include <autoware_utils/geometry/geometry.hpp>
 #include <autoware_utils/math/unit_conversion.hpp>
-
-#include <tf2/LinearMath/Transform.h>
-#include <tf2/utils.h>
+#include <tf2/LinearMath/Transform.hpp>
+#include <tf2/utils.hpp>
 
 #include <limits>
 #include <memory>

--- a/planning/autoware_freespace_planning_algorithms/test/src/test_freespace_planning_algorithms.cpp
+++ b/planning/autoware_freespace_planning_algorithms/test/src/test_freespace_planning_algorithms.cpp
@@ -19,12 +19,12 @@
 #include <rclcpp/rclcpp.hpp>
 #include <rcpputils/filesystem_helper.hpp>
 #include <rosbag2_cpp/writer.hpp>
+#include <tf2/utils.hpp>
 
 #include <std_msgs/msg/float64.hpp>
 
 #include <gtest/gtest.h>
 #include <rcutils/time.h>
-#include <tf2/utils.h>
 
 #include <algorithm>
 #include <array>

--- a/planning/autoware_mission_planner_universe/src/lanelet2_plugins/default_planner.cpp
+++ b/planning/autoware_mission_planner_universe/src/lanelet2_plugins/default_planner.cpp
@@ -29,6 +29,7 @@
 #include <autoware_utils/math/unit_conversion.hpp>
 #include <autoware_utils/ros/marker_helper.hpp>
 #include <autoware_vehicle_info_utils/vehicle_info_utils.hpp>
+#include <tf2/utils.hpp>
 
 #include <boost/geometry/algorithms/correct.hpp>
 #include <boost/geometry/algorithms/difference.hpp>
@@ -38,7 +39,6 @@
 #include <lanelet2_core/LaneletMap.h>
 #include <lanelet2_core/geometry/BoundingBox.h>
 #include <lanelet2_core/geometry/Lanelet.h>
-#include <tf2/utils.h>
 
 #include <limits>
 #include <vector>

--- a/planning/autoware_mission_planner_universe/src/mission_planner/arrival_checker.cpp
+++ b/planning/autoware_mission_planner_universe/src/mission_planner/arrival_checker.cpp
@@ -17,8 +17,7 @@
 #include <autoware_utils/geometry/geometry.hpp>
 #include <autoware_utils/math/normalization.hpp>
 #include <autoware_utils/math/unit_conversion.hpp>
-
-#include <tf2/utils.h>
+#include <tf2/utils.hpp>
 
 namespace autoware::mission_planner_universe
 {

--- a/planning/autoware_mission_planner_universe/test/test_lanelet2_plugins_default_planner.cpp
+++ b/planning/autoware_mission_planner_universe/test/test_lanelet2_plugins_default_planner.cpp
@@ -17,6 +17,7 @@
 #include <autoware_test_utils/autoware_test_utils.hpp>
 #include <autoware_utils/geometry/boost_geometry.hpp>
 #include <autoware_utils/geometry/geometry.hpp>
+#include <tf2/utils.hpp>
 
 #include <boost/geometry/io/wkt/write.hpp>
 
@@ -27,7 +28,6 @@
 #include <lanelet2_core/primitives/Lanelet.h>
 #include <lanelet2_core/primitives/LineString.h>
 #include <lanelet2_core/primitives/Point.h>
-#include <tf2/utils.h>
 
 #include <memory>
 #include <string>

--- a/planning/autoware_path_optimizer/src/mpt_optimizer.cpp
+++ b/planning/autoware_path_optimizer/src/mpt_optimizer.cpp
@@ -21,9 +21,9 @@
 #include "autoware/path_optimizer/utils/trajectory_utils.hpp"
 #include "autoware_utils/geometry/geometry.hpp"
 #include "autoware_utils/math/normalization.hpp"
-#include "tf2/utils.h"
 
 #include <rclcpp/logging.hpp>
+#include <tf2/utils.hpp>
 
 #include <algorithm>
 #include <chrono>

--- a/planning/autoware_path_optimizer/src/utils/geometry_utils.cpp
+++ b/planning/autoware_path_optimizer/src/utils/geometry_utils.cpp
@@ -16,9 +16,9 @@
 
 #include "autoware/motion_utils/trajectory/trajectory.hpp"
 #include "autoware/path_optimizer/mpt_optimizer.hpp"
-#include "tf2/utils.h"
 
 #include <autoware_utils/geometry/boost_geometry.hpp>
+#include <tf2/utils.hpp>
 
 #include "autoware_planning_msgs/msg/path_point.hpp"
 #include "autoware_planning_msgs/msg/trajectory_point.hpp"

--- a/planning/autoware_path_optimizer/src/utils/trajectory_utils.cpp
+++ b/planning/autoware_path_optimizer/src/utils/trajectory_utils.cpp
@@ -19,7 +19,8 @@
 #include "autoware/motion_utils/trajectory/trajectory.hpp"
 #include "autoware/path_optimizer/mpt_optimizer.hpp"
 #include "autoware/path_optimizer/utils/geometry_utils.hpp"
-#include "tf2/utils.h"
+
+#include <tf2/utils.hpp>
 
 #include "autoware_planning_msgs/msg/path_point.hpp"
 #include "autoware_planning_msgs/msg/trajectory_point.hpp"

--- a/planning/autoware_path_smoother/src/elastic_band.cpp
+++ b/planning/autoware_path_smoother/src/elastic_band.cpp
@@ -19,10 +19,10 @@
 #include "autoware/path_smoother/type_alias.hpp"
 #include "autoware/path_smoother/utils/geometry_utils.hpp"
 #include "autoware/path_smoother/utils/trajectory_utils.hpp"
-#include "tf2/utils.h"
 
 #include <Eigen/Core>
 #include <Eigen/Sparse>
+#include <tf2/utils.hpp>
 
 #include <algorithm>
 #include <chrono>

--- a/planning/autoware_surround_obstacle_checker/src/node.hpp
+++ b/planning/autoware_surround_obstacle_checker/src/node.hpp
@@ -25,6 +25,7 @@
 #include <autoware_surround_obstacle_checker/surround_obstacle_checker_node_parameters.hpp>
 #include <autoware_vehicle_info_utils/vehicle_info_utils.hpp>
 #include <rclcpp/rclcpp.hpp>
+#include <tf2/utils.hpp>
 
 #include <autoware_internal_debug_msgs/msg/float64_stamped.hpp>
 #include <autoware_internal_planning_msgs/msg/velocity_limit.hpp>
@@ -36,7 +37,6 @@
 #include <sensor_msgs/msg/point_cloud2.hpp>
 #include <visualization_msgs/msg/marker_array.hpp>
 
-#include <tf2/utils.h>
 #include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_listener.h>
 

--- a/planning/autoware_trajectory_ranker/src/metrics/lateral_acceleration_metric.cpp
+++ b/planning/autoware_trajectory_ranker/src/metrics/lateral_acceleration_metric.cpp
@@ -14,7 +14,7 @@
 
 #include "autoware/trajectory_ranker/metrics/lateral_acceleration_metric.hpp"
 
-#include <tf2/utils.h>
+#include <tf2/utils.hpp>
 
 #include <algorithm>
 #include <cmath>

--- a/planning/autoware_trajectory_ranker/src/metrics/metrics_utils.cpp
+++ b/planning/autoware_trajectory_ranker/src/metrics/metrics_utils.cpp
@@ -20,9 +20,8 @@
 #include <autoware/motion_utils/trajectory/trajectory.hpp>
 #include <autoware_utils_geometry/geometry.hpp>
 #include <rclcpp/duration.hpp>
-
-#include <tf2/LinearMath/Vector3.h>
-#include <tf2/utils.h>
+#include <tf2/LinearMath/Vector3.hpp>
+#include <tf2/utils.hpp>
 
 #include <algorithm>
 #include <cmath>

--- a/planning/autoware_trajectory_ranker/src/metrics/steering_consistency_metric.cpp
+++ b/planning/autoware_trajectory_ranker/src/metrics/steering_consistency_metric.cpp
@@ -16,7 +16,7 @@
 
 #include "autoware/trajectory_ranker/metrics/metrics_utils.hpp"
 
-#include <tf2/utils.h>
+#include <tf2/utils.hpp>
 
 #include <algorithm>
 #include <cmath>

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/util.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/util.cpp
@@ -29,13 +29,13 @@
 #include <magic_enum.hpp>
 #include <range/v3/view/reverse.hpp>
 #include <rclcpp/rclcpp.hpp>
+#include <tf2/utils.hpp>
 
 #include <boost/geometry/algorithms/dispatch/distance.hpp>
 
 #include <lanelet2_core/LaneletMap.h>
 #include <lanelet2_core/primitives/Lanelet.h>
 #include <lanelet2_core/primitives/LineString.h>
-#include <tf2/utils.h>
 #include <tf2_ros/transform_listener.h>
 
 #include <algorithm>

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/interface.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/interface.hpp
@@ -25,12 +25,11 @@
 
 #include <autoware_utils/system/time_keeper.hpp>
 #include <rclcpp/rclcpp.hpp>
+#include <tf2/utils.hpp>
 
 #include <autoware_internal_planning_msgs/msg/path_with_lane_id.hpp>
 #include <geometry_msgs/msg/pose.hpp>
 #include <geometry_msgs/msg/twist.hpp>
-
-#include <tf2/utils.h>
 
 #include <memory>
 #include <string>

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/utils.cpp
@@ -45,6 +45,7 @@
 #include <range/v3/range/conversion.hpp>
 #include <range/v3/view.hpp>
 #include <rclcpp/rclcpp.hpp>
+#include <tf2/utils.hpp>
 
 #include <boost/geometry/algorithms/buffer.hpp>
 #include <boost/geometry/algorithms/detail/disjoint/interface.hpp>
@@ -55,7 +56,6 @@
 #include <lanelet2_core/geometry/LineString.h>
 #include <lanelet2_core/geometry/Point.h>
 #include <lanelet2_core/geometry/Polygon.h>
-#include <tf2/utils.h>
 #include <tf2_ros/transform_listener.h>
 
 #include <algorithm>

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/drivable_area_expansion/footprints.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/drivable_area_expansion/footprints.cpp
@@ -19,10 +19,9 @@
 
 #include <autoware_utils/geometry/boost_polygon_utils.hpp>
 #include <autoware_utils/geometry/geometry.hpp>
+#include <tf2/utils.hpp>
 
 #include <boost/geometry/strategies/transform/matrix_transformers.hpp>
-
-#include <tf2/utils.h>
 
 namespace autoware::behavior_path_planner::drivable_area_expansion
 {

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/path_safety_checker/safety_check.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/path_safety_checker/safety_check.cpp
@@ -20,13 +20,13 @@
 #include "autoware_utils/geometry/boost_polygon_utils.hpp"
 #include "autoware_utils/ros/uuid_helper.hpp"
 
+#include <tf2/utils.hpp>
+
 #include <boost/geometry/algorithms/correct.hpp>
 #include <boost/geometry/algorithms/intersects.hpp>
 #include <boost/geometry/algorithms/overlaps.hpp>
 #include <boost/geometry/algorithms/union.hpp>
 #include <boost/geometry/strategies/strategies.hpp>
-
-#include <tf2/utils.h>
 
 #include <algorithm>
 #include <cmath>

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/path_utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/path_utils.cpp
@@ -23,8 +23,7 @@
 #include <autoware_lanelet2_extension/utility/query.hpp>
 #include <autoware_lanelet2_extension/utility/utilities.hpp>
 #include <autoware_utils/geometry/geometry.hpp>
-
-#include <tf2/utils.h>
+#include <tf2/utils.hpp>
 
 #include <algorithm>
 #include <memory>

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/utils.cpp
@@ -17,8 +17,7 @@
 #include "autoware/behavior_path_planner_common/utils/utils.hpp"
 
 #include <rclcpp/rclcpp.hpp>
-
-#include <tf2/utils.h>
+#include <tf2/utils.hpp>
 
 #include <cmath>
 

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/test/test_side_shift_utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/test/test_side_shift_utils.cpp
@@ -13,11 +13,12 @@
 // limitations under the License.
 #include "autoware/behavior_path_side_shift_module/utils.hpp"
 
+#include <tf2/LinearMath/Quaternion.hpp>
+#include <tf2/utils.hpp>
+
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 
 #include <gtest/gtest.h>
-#include <tf2/LinearMath/Quaternion.h>
-#include <tf2/utils.h>
 
 #include <vector>
 

--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/include/autoware/behavior_path_start_planner_module/start_planner_module.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/include/autoware/behavior_path_start_planner_module/start_planner_module.hpp
@@ -31,12 +31,12 @@
 
 #include <autoware_vehicle_info_utils/vehicle_info.hpp>
 #include <autoware_vehicle_info_utils/vehicle_info_utils.hpp>
+#include <tf2/utils.hpp>
 
 #include <autoware_internal_debug_msgs/msg/string_stamped.hpp>
 #include <autoware_internal_planning_msgs/msg/path_with_lane_id.hpp>
 
 #include <lanelet2_core/Forward.h>
-#include <tf2/utils.h>
 
 #include <atomic>
 #include <deque>

--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/clothoid_pull_out.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/clothoid_pull_out.cpp
@@ -33,13 +33,12 @@
 #include <autoware_lanelet2_extension/utility/utilities.hpp>
 #include <autoware_utils/geometry/geometry.hpp>
 #include <autoware_utils/math/unit_conversion.hpp>
+#include <tf2/LinearMath/Quaternion.hpp>
+#include <tf2/utils.hpp>
 
 #include <geometry_msgs/msg/point.hpp>
 #include <geometry_msgs/msg/pose.hpp>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
-
-#include <tf2/LinearMath/Quaternion.h>
-#include <tf2/utils.h>
 
 #include <algorithm>
 #include <cmath>

--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/util.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/util.cpp
@@ -25,11 +25,11 @@
 #include <autoware_utils/geometry/boost_geometry.hpp>
 #include <autoware_utils/math/unit_conversion.hpp>
 #include <rclcpp/rclcpp.hpp>
+#include <tf2/utils.hpp>
 
 #include <boost/geometry/algorithms/dispatch/distance.hpp>
 
 #include <lanelet2_core/LaneletMap.h>
-#include <tf2/utils.h>
 #include <tf2_ros/transform_listener.h>
 
 #include <algorithm>

--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/test/include/start_planner_test_helper.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/test/include/start_planner_test_helper.hpp
@@ -18,13 +18,13 @@
 #include <autoware/pyplot/pyplot.hpp>
 #include <autoware/vehicle_info_utils/vehicle_info_utils.hpp>
 #include <rclcpp/rclcpp.hpp>
+#include <tf2/utils.hpp>
 
 #include <autoware_internal_planning_msgs/msg/path_with_lane_id.hpp>
 #include <autoware_planning_msgs/msg/lanelet_route.hpp>
 #include <geometry_msgs/msg/pose.hpp>
 
 #include <lanelet2_core/primitives/Lanelet.h>
-#include <tf2/utils.h>
 
 #include <memory>
 #include <set>

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/src/debug.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/src/debug.cpp
@@ -19,10 +19,9 @@
 #include <autoware/motion_utils/marker/virtual_wall_marker_creator.hpp>
 #include <autoware_utils_visualization/marker_helper.hpp>
 #include <range/v3/view/enumerate.hpp>
+#include <tf2/utils.hpp>
 
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
-
-#include <tf2/utils.h>
 
 #include <string>
 #include <tuple>

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_detection_area_module/src/manager.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_detection_area_module/src/manager.cpp
@@ -17,8 +17,7 @@
 #include <autoware/behavior_velocity_planner_common/utilization/util.hpp>
 #include <autoware_lanelet2_extension/utility/query.hpp>
 #include <autoware_utils/ros/parameter.hpp>
-
-#include <tf2/utils.h>
+#include <tf2/utils.hpp>
 
 #include <limits>
 #include <memory>

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_detection_area_module/src/scene.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_detection_area_module/src/scene.hpp
@@ -27,9 +27,9 @@
 #include <autoware/behavior_velocity_rtc_interface/scene_module_interface_with_rtc.hpp>
 #include <autoware_lanelet2_extension/regulatory_elements/detection_area.hpp>
 #include <rclcpp/rclcpp.hpp>
+#include <tf2/LinearMath/Transform.hpp>
 
 #include <lanelet2_core/LaneletMap.h>
-#include <tf2/LinearMath/Transform.h>
 
 namespace autoware::behavior_velocity_planner
 {

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/debug.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/debug.cpp
@@ -19,8 +19,7 @@
 #include <autoware/behavior_velocity_planner_common/utilization/util.hpp>
 #include <autoware/motion_utils/marker/virtual_wall_marker_creator.hpp>
 #include <autoware_utils/ros/marker_helper.hpp>
-
-#include <tf2/utils.h>
+#include <tf2/utils.hpp>
 
 #include <tuple>
 

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_occlusion_spot_module/src/grid_utils.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_occlusion_spot_module/src/grid_utils.hpp
@@ -24,6 +24,7 @@
 #include <grid_map_core/iterators/LineIterator.hpp>
 #include <grid_map_ros/GridMapRosConverter.hpp>
 #include <opencv2/opencv.hpp>
+#include <tf2/utils.hpp>
 
 #include <autoware_perception_msgs/msg/object_classification.hpp>
 #include <autoware_perception_msgs/msg/predicted_object.hpp>
@@ -39,7 +40,6 @@
 
 #include <lanelet2_core/geometry/Lanelet.h>
 #include <lanelet2_core/primitives/Lanelet.h>
-#include <tf2/utils.h>
 
 #ifdef ROS_DISTRO_GALACTIC
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_occlusion_spot_module/src/occlusion_spot_utils.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_occlusion_spot_module/src/occlusion_spot_utils.hpp
@@ -22,6 +22,7 @@
 #include <autoware_lanelet2_extension/utility/query.hpp>
 #include <autoware_lanelet2_extension/utility/utilities.hpp>
 #include <autoware_lanelet2_extension/visualization/visualization.hpp>
+#include <tf2/utils.hpp>
 
 #include <autoware_internal_planning_msgs/msg/path_with_lane_id.hpp>
 #include <autoware_perception_msgs/msg/object_classification.hpp>
@@ -32,7 +33,6 @@
 
 #include <lanelet2_core/LaneletMap.h>
 #include <lanelet2_core/geometry/LaneletMap.h>
-#include <tf2/utils.h>
 
 #ifdef ROS_DISTRO_GALACTIC
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_roundabout_module/src/debug.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_roundabout_module/src/debug.cpp
@@ -18,10 +18,9 @@
 #include <autoware/behavior_velocity_planner_common/utilization/util.hpp>
 #include <autoware/motion_utils/marker/virtual_wall_marker_creator.hpp>
 #include <autoware_utils/ros/marker_helper.hpp>
+#include <tf2/utils.hpp>
 
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
-
-#include <tf2/utils.h>
 
 #include <string>
 #include <tuple>

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_speed_bump_module/src/manager.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_speed_bump_module/src/manager.cpp
@@ -18,8 +18,7 @@
 #include <autoware_lanelet2_extension/regulatory_elements/speed_bump.hpp>
 #include <autoware_lanelet2_extension/utility/query.hpp>
 #include <autoware_utils/ros/parameter.hpp>
-
-#include <tf2/utils.h>
+#include <tf2/utils.hpp>
 
 #include <memory>
 #include <set>

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_template_module/src/manager.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_template_module/src/manager.cpp
@@ -16,8 +16,7 @@
 
 #include <autoware_lanelet2_extension/utility/query.hpp>
 #include <autoware_utils/ros/parameter.hpp>
-
-#include <tf2/utils.h>
+#include <tf2/utils.hpp>
 
 #include <memory>
 #include <set>

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/src/manager.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/src/manager.cpp
@@ -17,8 +17,7 @@
 #include <autoware/behavior_velocity_planner_common/utilization/util.hpp>
 #include <autoware/motion_utils/trajectory/trajectory.hpp>
 #include <autoware_utils/ros/parameter.hpp>
-
-#include <tf2/utils.h>
+#include <tf2/utils.hpp>
 
 #include <limits>
 #include <memory>

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/src/scene.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/src/scene.cpp
@@ -20,11 +20,10 @@
 #include <autoware/motion_utils/trajectory/trajectory.hpp>
 #include <autoware/traffic_light_utils/traffic_light_utils.hpp>
 #include <rclcpp/duration.hpp>
+#include <tf2/utils.hpp>
 
 #include <boost/geometry/algorithms/distance.hpp>
 #include <boost/geometry/algorithms/intersection.hpp>
-
-#include <tf2/utils.h>
 
 #include <memory>
 

--- a/planning/motion_velocity_planner/autoware_motion_velocity_dynamic_obstacle_stop_module/src/footprint.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_dynamic_obstacle_stop_module/src/footprint.cpp
@@ -15,13 +15,13 @@
 #include "footprint.hpp"
 
 #include <autoware_utils/geometry/boost_polygon_utils.hpp>
+#include <tf2/utils.hpp>
 
 #include <geometry_msgs/msg/pose.hpp>
 
 #include <boost/geometry/algorithms/envelope.hpp>
 
 #include <lanelet2_core/geometry/Polygon.h>
-#include <tf2/utils.h>
 
 #include <utility>
 #include <vector>

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_cruise_module/src/optimization_based_planner/optimization_based_planner.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_cruise_module/src/optimization_based_planner/optimization_based_planner.cpp
@@ -38,7 +38,7 @@
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 #endif
 
-#include <tf2/utils.h>
+#include <tf2/utils.hpp>
 
 namespace autoware::motion_velocity_planner
 {

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_velocity_limiter_module/src/obstacles.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_velocity_limiter_module/src/obstacles.cpp
@@ -17,12 +17,12 @@
 #include "occupancy_grid_utils.hpp"
 #include "pointcloud_utils.hpp"
 
+#include <tf2/utils.hpp>
+
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 
 #include <boost/assign.hpp>
 #include <boost/geometry.hpp>
-
-#include <tf2/utils.h>
 
 #include <algorithm>
 #include <vector>

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_velocity_limiter_module/src/parameters.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_velocity_limiter_module/src/parameters.hpp
@@ -19,8 +19,7 @@
 
 #include <rclcpp/logger.hpp>
 #include <rclcpp/node.hpp>
-
-#include <tf2/utils.h>
+#include <tf2/utils.hpp>
 
 #include <cstdint>
 #include <string>

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_velocity_limiter_module/src/trajectory_preprocessing.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_velocity_limiter_module/src/trajectory_preprocessing.cpp
@@ -18,11 +18,10 @@
 
 #include <autoware/motion_utils/trajectory/trajectory.hpp>
 #include <autoware_utils/geometry/geometry.hpp>
+#include <tf2/utils.hpp>
 
 #include <geometry_msgs/msg/detail/point__struct.hpp>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
-
-#include <tf2/utils.h>
 
 #include <optional>
 

--- a/planning/motion_velocity_planner/autoware_motion_velocity_road_user_stop_module/src/road_user_stop_module.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_road_user_stop_module/src/road_user_stop_module.cpp
@@ -35,6 +35,7 @@
 #include <autoware_utils_rclcpp/parameter.hpp>
 #include <autoware_utils_visualization/marker_helper.hpp>
 #include <pluginlib/class_list_macros.hpp>
+#include <tf2/utils.hpp>
 
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 
@@ -48,7 +49,6 @@
 #include <boost/geometry/strategies/buffer.hpp>
 
 #include <lanelet2_routing/RoutingGraphContainer.h>
-#include <tf2/utils.h>
 
 #include <algorithm>
 #include <cmath>

--- a/planning/motion_velocity_planner/autoware_motion_velocity_road_user_stop_module/src/utils.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_road_user_stop_module/src/utils.cpp
@@ -18,11 +18,10 @@
 #include <autoware/motion_velocity_planner_common/polygon_utils.hpp>
 #include <autoware_utils_geometry/boost_polygon_utils.hpp>
 #include <autoware_utils_geometry/geometry.hpp>
+#include <tf2/utils.hpp>
 
 #include <boost/geometry/algorithms/convex_hull.hpp>
 #include <boost/geometry/algorithms/correct.hpp>
-
-#include <tf2/utils.h>
 
 #include <limits>
 #include <utility>

--- a/planning/motion_velocity_planner/autoware_motion_velocity_run_out_module/src/collisions.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_run_out_module/src/collisions.cpp
@@ -23,6 +23,7 @@
 #include <autoware/universe_utils/geometry/geometry.hpp>
 #include <autoware/universe_utils/math/normalization.hpp>
 #include <rclcpp/logger.hpp>
+#include <tf2/utils.hpp>
 
 #include <autoware_perception_msgs/msg/predicted_object.hpp>
 #include <autoware_planning_msgs/msg/trajectory_point.hpp>
@@ -32,8 +33,6 @@
 #include <boost/geometry/algorithms/length.hpp>
 #include <boost/geometry/algorithms/within.hpp>
 #include <boost/geometry/index/predicates.hpp>
-
-#include <tf2/utils.h>
 
 #include <algorithm>
 #include <iomanip>

--- a/planning/sampling_based_planner/autoware_frenet_planner/src/frenet_planner/frenet_planner.cpp
+++ b/planning/sampling_based_planner/autoware_frenet_planner/src/frenet_planner/frenet_planner.cpp
@@ -21,11 +21,10 @@
 #include <autoware_sampler_common/structures.hpp>
 #include <autoware_sampler_common/transform/spline_transform.hpp>
 #include <eigen3/Eigen/Eigen>
+#include <tf2/utils.hpp>
 
 #include "autoware_planning_msgs/msg/path.hpp"
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
-
-#include <tf2/utils.h>
 
 #include <algorithm>
 #include <cmath>

--- a/planning/sampling_based_planner/autoware_path_sampler/src/utils/trajectory_utils.cpp
+++ b/planning/sampling_based_planner/autoware_path_sampler/src/utils/trajectory_utils.cpp
@@ -17,7 +17,8 @@
 #include "autoware/motion_utils/resample/resample.hpp"
 #include "autoware/motion_utils/trajectory/conversion.hpp"
 #include "autoware_path_sampler/utils/geometry_utils.hpp"
-#include "tf2/utils.h"
+
+#include <tf2/utils.hpp>
 
 #include "autoware_planning_msgs/msg/path_point.hpp"
 #include "autoware_planning_msgs/msg/trajectory_point.hpp"

--- a/sensing/autoware_calibration_status_classifier/include/autoware/calibration_status_classifier/camera_lidar_info_collector.hpp
+++ b/sensing/autoware_calibration_status_classifier/include/autoware/calibration_status_classifier/camera_lidar_info_collector.hpp
@@ -20,6 +20,8 @@
 
 #include <Eigen/Geometry>
 #include <rclcpp/rclcpp.hpp>
+#include <tf2/exceptions.hpp>
+#include <tf2/time.hpp>
 #include <tf2_eigen/tf2_eigen.hpp>
 
 #include <sensor_msgs/msg/camera_info.hpp>
@@ -27,8 +29,6 @@
 #include <sensor_msgs/msg/point_cloud2.hpp>
 
 #include <rmw/qos_profiles.h>
-#include <tf2/exceptions.h>
-#include <tf2/time.h>
 #include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_listener.h>
 

--- a/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor_node.hpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor_node.hpp
@@ -29,13 +29,13 @@
 #include <cuda_blackboard/cuda_blackboard_subscriber.hpp>
 #include <cuda_blackboard/cuda_pointcloud2.hpp>
 #include <rclcpp/rclcpp.hpp>
+#include <tf2/transform_datatypes.hpp>
 
 #include <geometry_msgs/msg/twist_with_covariance_stamped.hpp>
 #include <geometry_msgs/msg/vector3_stamped.hpp>
 #include <sensor_msgs/msg/imu.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
 
-#include <tf2/transform_datatypes.h>
 #include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_listener.h>
 

--- a/sensing/autoware_pointcloud_preprocessor/include/autoware/pointcloud_preprocessor/distortion_corrector/distortion_corrector.hpp
+++ b/sensing/autoware_pointcloud_preprocessor/include/autoware/pointcloud_preprocessor/distortion_corrector/distortion_corrector.hpp
@@ -19,16 +19,15 @@
 #include <managed_transform_buffer/managed_transform_buffer.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <sophus/se3.hpp>
+#include <tf2/LinearMath/Transform.hpp>
+#include <tf2/convert.hpp>
+#include <tf2/transform_datatypes.hpp>
 
 #include <geometry_msgs/msg/twist_stamped.hpp>
 #include <geometry_msgs/msg/twist_with_covariance_stamped.hpp>
 #include <sensor_msgs/msg/imu.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
 #include <sensor_msgs/point_cloud2_iterator.hpp>
-
-#include <tf2/LinearMath/Transform.h>
-#include <tf2/convert.h>
-#include <tf2/transform_datatypes.h>
 
 #ifdef ROS_DISTRO_GALACTIC
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>

--- a/simulator/autoware_dummy_perception_publisher/include/autoware/dummy_perception_publisher/node.hpp
+++ b/simulator/autoware_dummy_perception_publisher/include/autoware/dummy_perception_publisher/node.hpp
@@ -16,6 +16,9 @@
 #define AUTOWARE__DUMMY_PERCEPTION_PUBLISHER__NODE_HPP_
 
 #include <rclcpp/rclcpp.hpp>
+#include <tf2/LinearMath/Transform.hpp>
+#include <tf2/convert.hpp>
+#include <tf2/transform_datatypes.hpp>
 
 #include <autoware_perception_msgs/msg/detected_objects.hpp>
 #include <autoware_perception_msgs/msg/tracked_objects.hpp>
@@ -27,9 +30,6 @@
 #include <pcl/common/distances.h>
 #include <pcl/point_types.h>
 #include <pcl_conversions/pcl_conversions.h>
-#include <tf2/LinearMath/Transform.h>
-#include <tf2/convert.h>
-#include <tf2/transform_datatypes.h>
 
 #ifdef ROS_DISTRO_GALACTIC
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>

--- a/simulator/autoware_dummy_perception_publisher/include/autoware/dummy_perception_publisher/signed_distance_function.hpp
+++ b/simulator/autoware_dummy_perception_publisher/include/autoware/dummy_perception_publisher/signed_distance_function.hpp
@@ -15,7 +15,7 @@
 #ifndef AUTOWARE__DUMMY_PERCEPTION_PUBLISHER__SIGNED_DISTANCE_FUNCTION_HPP_
 #define AUTOWARE__DUMMY_PERCEPTION_PUBLISHER__SIGNED_DISTANCE_FUNCTION_HPP_
 
-#include <tf2/LinearMath/Transform.h>
+#include <tf2/LinearMath/Transform.hpp>
 
 #include <limits>
 #include <memory>

--- a/simulator/autoware_dummy_perception_publisher/src/movement_utils.cpp
+++ b/simulator/autoware_dummy_perception_publisher/src/movement_utils.cpp
@@ -19,9 +19,9 @@
 #include "autoware/trajectory/pose.hpp"
 #include "autoware_utils_geometry/geometry.hpp"
 
-#include <geometry_msgs/msg/transform.hpp>
+#include <tf2/LinearMath/Transform.hpp>
 
-#include <tf2/LinearMath/Transform.h>
+#include <geometry_msgs/msg/transform.hpp>
 
 #ifdef ROS_DISTRO_GALACTIC
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>

--- a/simulator/autoware_dummy_perception_publisher/src/node.cpp
+++ b/simulator/autoware_dummy_perception_publisher/src/node.cpp
@@ -19,6 +19,9 @@
 #include "autoware_utils_geometry/geometry.hpp"
 
 #include <autoware_utils_uuid/uuid_helper.hpp>
+#include <tf2/LinearMath/Quaternion.hpp>
+#include <tf2/LinearMath/Transform.hpp>
+#include <tf2/LinearMath/Vector3.hpp>
 
 #include <autoware_perception_msgs/msg/detail/tracked_objects__struct.hpp>
 #include <autoware_perception_msgs/msg/tracked_objects.hpp>
@@ -28,9 +31,6 @@
 #include <geometry_msgs/msg/detail/transform_stamped__struct.hpp>
 
 #include <pcl/filters/voxel_grid_occlusion_estimation.h>
-#include <tf2/LinearMath/Quaternion.h>
-#include <tf2/LinearMath/Transform.h>
-#include <tf2/LinearMath/Vector3.h>
 
 #include <cmath>
 #include <cstddef>

--- a/simulator/autoware_dummy_perception_publisher/src/pointcloud_creator.cpp
+++ b/simulator/autoware_dummy_perception_publisher/src/pointcloud_creator.cpp
@@ -16,10 +16,10 @@
 #include "autoware/dummy_perception_publisher/signed_distance_function.hpp"
 
 #include <pcl/impl/point_types.hpp>
+#include <tf2/LinearMath/Transform.hpp>
+#include <tf2/LinearMath/Vector3.hpp>
 
 #include <pcl/filters/voxel_grid_occlusion_estimation.h>
-#include <tf2/LinearMath/Transform.h>
-#include <tf2/LinearMath/Vector3.h>
 
 #include <functional>
 #include <limits>

--- a/simulator/autoware_dummy_perception_publisher/src/signed_distance_function.cpp
+++ b/simulator/autoware_dummy_perception_publisher/src/signed_distance_function.cpp
@@ -14,7 +14,7 @@
 
 #include "autoware/dummy_perception_publisher/signed_distance_function.hpp"
 
-#include <tf2/LinearMath/Vector3.h>
+#include <tf2/LinearMath/Vector3.hpp>
 
 #include <algorithm>
 #include <iostream>

--- a/simulator/autoware_dummy_perception_publisher/test/src/test_signed_distance_function.cpp
+++ b/simulator/autoware_dummy_perception_publisher/test/src/test_signed_distance_function.cpp
@@ -14,10 +14,11 @@
 
 #include "autoware/dummy_perception_publisher/signed_distance_function.hpp"
 
+#include <tf2/LinearMath/Quaternion.hpp>
+#include <tf2/LinearMath/Transform.hpp>
+#include <tf2/LinearMath/Vector3.hpp>
+
 #include <gtest/gtest.h>
-#include <tf2/LinearMath/Quaternion.h>
-#include <tf2/LinearMath/Transform.h>
-#include <tf2/LinearMath/Vector3.h>
 
 #include <cmath>
 #include <limits>

--- a/simulator/autoware_simple_planning_simulator/src/simple_planning_simulator/simple_planning_simulator_core.cpp
+++ b/simulator/autoware_simple_planning_simulator/src/simple_planning_simulator/simple_planning_simulator_core.cpp
@@ -25,11 +25,11 @@
 
 #include <autoware_lanelet2_extension/utility/message_conversion.hpp>
 #include <autoware_lanelet2_extension/utility/query.hpp>
+#include <tf2/LinearMath/Quaternion.hpp>
+#include <tf2/utils.hpp>
 
 #include <lanelet2_routing/RoutingGraph.h>
 #include <lanelet2_traffic_rules/TrafficRulesFactory.h>
-#include <tf2/LinearMath/Quaternion.h>
-#include <tf2/utils.h>
 
 #include <algorithm>
 #include <chrono>

--- a/simulator/autoware_simple_planning_simulator/test/test_simple_planning_simulator.cpp
+++ b/simulator/autoware_simple_planning_simulator/test/test_simple_planning_simulator.cpp
@@ -15,7 +15,8 @@
 #include "ament_index_cpp/get_package_share_directory.hpp"
 #include "autoware/simple_planning_simulator/simple_planning_simulator_core.hpp"
 #include "gtest/gtest.h"
-#include "tf2/utils.h"
+
+#include <tf2/utils.hpp>
 
 #include "tier4_vehicle_msgs/msg/actuation_command_stamped.hpp"
 

--- a/vehicle/autoware_accel_brake_map_calibrator/include/autoware_accel_brake_map_calibrator/accel_brake_map_calibrator_node.hpp
+++ b/vehicle/autoware_accel_brake_map_calibrator/include/autoware_accel_brake_map_calibrator/accel_brake_map_calibrator_node.hpp
@@ -24,9 +24,9 @@
 #include "autoware_utils/ros/transform_listener.hpp"
 #include "diagnostic_updater/diagnostic_updater.hpp"
 #include "rclcpp/rclcpp.hpp"
-#include "tf2/utils.h"
 
 #include <Eigen/Dense>
+#include <tf2/utils.hpp>
 
 #include "autoware_internal_debug_msgs/msg/float32_multi_array_stamped.hpp"
 #include "autoware_internal_debug_msgs/msg/float32_stamped.hpp"


### PR DESCRIPTION
## Description

Follow up of #11605 

Pinging @xmfcx and @mitsudome-r as mentioned [here](https://github.com/autowarefoundation/autoware_universe/pull/10586#issuecomment-3402455475).

## Related links

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
