### PR TITLE
feat: visualization related packages support jazzy

### DIFF
--- a/visualization/tier4_camera_view_rviz_plugin/src/bird_eye_view_controller.cpp
+++ b/visualization/tier4_camera_view_rviz_plugin/src/bird_eye_view_controller.cpp
@@ -151,7 +151,8 @@ void BirdEyeViewController::handleMouseEvent(rviz_common::ViewportMouseEvent & e
 
 void BirdEyeViewController::orientCamera()
 {
-  camera_->setOrientation(
+  auto camera_parent = getCameraParent(camera_);
+  camera_parent->setOrientation(
     Ogre::Quaternion(Ogre::Radian(angle_property_->getFloat()), Ogre::Vector3::UNIT_Z));
 }
 

--- a/visualization/tier4_perception_rviz_plugin/CMakeLists.txt
+++ b/visualization/tier4_perception_rviz_plugin/CMakeLists.txt
@@ -5,6 +5,9 @@ find_package(autoware_cmake REQUIRED)
 autoware_package()
 
 find_package(Qt5 REQUIRED COMPONENTS Widgets)
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+
 set(OD_PLUGIN_LIB_SRC
   src/object_detection/detected_objects_wf_display.cpp
   src/object_detection/detected_objects_wf_helper.cpp
@@ -12,21 +15,13 @@ set(OD_PLUGIN_LIB_SRC
 
 set(OD_PLUGIN_LIB_HEADERS
   include/tier4_perception_rviz_plugin/visibility_control.hpp
-)
-
-set(OD_PLUGIN_LIB_HEADERS_TO_WRAP
   include/tier4_perception_rviz_plugin/object_detection/detected_objects_wf_display.hpp
   include/tier4_perception_rviz_plugin/object_detection/detected_objects_wf_helper.hpp
 )
 
-foreach(header "${OD_PLUGIN_LIB_HEADERS_TO_WRAP}")
-  qt5_wrap_cpp(OD_PLUGIN_LIB_HEADERS_MOC "${header}")
-endforeach()
-
 ament_auto_add_library(${PROJECT_NAME} SHARED
   ${COMMON_SRC}
   ${OD_PLUGIN_LIB_HEADERS}
-  ${OD_PLUGIN_LIB_HEADERS_MOC}
   ${OD_PLUGIN_LIB_SRC}
 )
 target_link_libraries(${PROJECT_NAME}


### PR DESCRIPTION
## Description

This PR fixes compilation errors in two visualization packages:
- `tier4_perception_rviz_plugin`: Qt MOC (Meta-Object Compiler) configuration issue
- `tier4_camera_view_rviz_plugin`: Ogre deprecated API usage

### Issue 1: tier4_perception_rviz_plugin - Qt MOC Configuration Error

The package was using manual `qt5_wrap_cpp()` to handle Qt MOC processing, which generated incorrect file paths and caused build failures:
autoware/build/tier4_perception_rviz_plugin/include/tier4_perception_rviz_plugin/object_detection/moc_detected_objects_wf_helper.cpp_parameters: not found

The `detected_objects_wf_display.hpp` header file contains the `Q_OBJECT` macro (line 51), which requires MOC processing to enable Qt's meta-object system (signals/slots, properties, reflection).

### Issue 2: tier4_camera_view_rviz_plugin - Ogre Deprecated API

The code was directly calling `Camera::setOrientation()`, which is deprecated in newer versions of Ogre:
error: 'void Ogre::Camera::setOrientation(const Ogre::Quaternion&)' is deprecated [-Werror=deprecated-declarations]
This caused compilation to fail because warnings are treated as errors (`-Werror=deprecated-declarations`).

## Solution

### Fix 1: Switch to CMake AUTOMOC

Replaced manual `qt5_wrap_cpp()` with CMake's automatic MOC processing:

- Added `set(CMAKE_AUTOMOC ON)` to enable automatic MOC detection
- Added `set(CMAKE_INCLUDE_CURRENT_DIR ON)` to ensure headers are found
- Removed manual `qt5_wrap_cpp()` loop
- Added header files directly to the library source list; CMake automatically detects `Q_OBJECT` and processes them

**Benefits:**
- CMake automatically scans for Qt macros and generates MOC files
- Eliminates path generation issues
- Follows modern CMake best practices
- More maintainable and less error-prone

### Fix 2: Use SceneNode for Camera Orientation

Changed from directly setting orientation on the Camera to using the Camera's parent SceneNode:

- Replaced `camera_->setOrientation()` with `getCameraParent(camera_)->setOrientation()`
- This follows Ogre's recommended architecture where transformations are applied to SceneNodes, not directly to Cameras

**Benefits:**
- Uses non-deprecated API
- Aligns with Ogre's scene graph architecture
- More correct approach (SceneNodes manage transformations, Cameras inherit them)

## Changes

### Modified Files

1. **`universe/autoware_universe/visualization/tier4_perception_rviz_plugin/CMakeLists.txt`**
   - Replaced manual `qt5_wrap_cpp()` with `CMAKE_AUTOMOC ON`
   - Added `CMAKE_INCLUDE_CURRENT_DIR ON`
   - Simplified header file handling

2. **`universe/autoware_universe/visualization/tier4_camera_view_rviz_plugin/src/bird_eye_view_controller.cpp`**
   - Changed `camera_->setOrientation()` to `getCameraParent(camera_)->setOrientation()`
   - Updated `orientCamera()` method to use SceneNode-based approach


## Related links

**Parent Issue:**

- Link https://github.com/autowarefoundation/autoware_universe/issues/11418

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
1. test with docker file produce by pr in autoware -- https://github.com/autowarefoundation/autoware/pull/6453
2. use rosdep install dependency packages automatically

**build command**
`colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release --symlink-install --packages-up-to <all-packages-under-visualization-folder>`
## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
