### PR TITLE
fix(.repos): update `autoware_cmake` version to fix CI error

### DIFF
--- a/build_depends_humble.repos
+++ b/build_depends_humble.repos
@@ -16,7 +16,7 @@ repositories:
   core/autoware_cmake:
     type: git
     url: https://github.com/autowarefoundation/autoware_cmake.git
-    version: main
+    version: 1.1.0
   core/autoware_utils:
     type: git
     url: https://github.com/autowarefoundation/autoware_utils.git


### PR DESCRIPTION
## Description

This PR fixes the following CI error that shows `autoware_ament_auto_package` is not found. This issue can be solved by using the latest `autoware_cmake`.

```
CMake Error at CMakeLists.txt:38 (autoware_ament_auto_package):
  Unknown CMake command "autoware_ament_auto_package".

-- Configuring incomplete, errors occurred!
See also "/__w/autoware_universe/autoware_universe/build/autoware_pyplot/CMakeFiles/CMakeOutput.log".
See also "/__w/autoware_universe/autoware_universe/build/autoware_pyplot/CMakeFiles/CMakeError.log".
---
--- stderr: autoware_pyplot
CMake Error at CMakeLists.txt:38 (autoware_ament_auto_package):
  Unknown CMake command "autoware_ament_auto_package".
```

## How was this PR tested?

~~(Will be updated after finishing tests) We'll check if this fix can solve the issue via CI run.~~
→ Build succeeded in CI
- https://github.com/autowarefoundation/autoware_universe/actions/runs/19285259089/job/55144789165

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

Humble build will use `autoware_cmake` with its version `1.1.0`
