### PR TITLE
fix(.repos): use `main` for `autoware_cmake` in nightly repos

### DIFF
--- a/build_depends_nightly.repos
+++ b/build_depends_nightly.repos
@@ -10,6 +10,10 @@ repositories:
     type: git
     url: https://github.com/autowarefoundation/autoware_core.git
     version: main
+  core/autoware_cmake:
+    type: git
+    url: https://github.com/autowarefoundation/autoware_cmake.git
+    version: main
   core/autoware_adapi_msgs:
     type: git
     url: https://github.com/autowarefoundation/autoware_adapi_msgs.git


### PR DESCRIPTION
## Description

This PR intends to use `main` for `autoware_cmake` to prevent CI issue observed as shown in [this PR](https://github.com/autowarefoundation/autoware_universe/pull/11623)

## How was this PR tested?

We will do tests by CI run. Let me update the status of tests.
→ Build succeeded as [this CI](https://github.com/autowarefoundation/autoware_universe/actions/runs/19285734103/job/55146184425?pr=11624)

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

Nightly build will use `main` for `autoware_cmake`
