### PR TITLE
fix(trajectory_optimizer): correct kinematic enforcer indexing and plugin order

### DIFF
--- a/planning/autoware_trajectory_optimizer/config/trajectory_optimizer.param.yaml
+++ b/planning/autoware_trajectory_optimizer/config/trajectory_optimizer.param.yaml
@@ -5,11 +5,11 @@
       - "autoware::trajectory_optimizer::plugin::TrajectoryPointFixer"
       - "autoware::trajectory_optimizer::plugin::TrajectoryKinematicFeasibilityEnforcer"
       - "autoware::trajectory_optimizer::plugin::TrajectoryQPSmoother"
+      - "autoware::trajectory_optimizer::plugin::TrajectoryKinematicFeasibilityEnforcer"
       - "autoware::trajectory_optimizer::plugin::TrajectoryEBSmootherOptimizer"
       - "autoware::trajectory_optimizer::plugin::TrajectorySplineSmoother"
       - "autoware::trajectory_optimizer::plugin::TrajectoryVelocityOptimizer"
       - "autoware::trajectory_optimizer::plugin::TrajectoryExtender"
-      - "autoware::trajectory_optimizer::plugin::TrajectoryPointFixer"
 
     # Plugin activation flags - control runtime enable/disable
     use_akima_spline_interpolation: false


### PR DESCRIPTION
## Description
Fixed off-by-one error in kinematic feasibility enforcer segment distance calculation. The constraint evaluation needs distance from anchor to current point, while point placement needs distance from current to next point. Added explicit anchor-to-first-point distance and use segment_distances[i+1] for placement.

Reordered plugins to remove final TrajectoryPointFixer which was overriding heading alignments via resample_close_proximity_points, causing orientations mismatched with geometric heading direction.

# Fix Kinematic Enforcer Indexing and Plugin Order

## Summary

This PR fixes two critical issues in the trajectory optimizer:

1. Off-by-one error in kinematic feasibility enforcer's segment distance calculation
2. Plugin execution order causing heading misalignment

## Problem

### Issue 1: Incorrect Segment Distance Indexing

The kinematic feasibility enforcer had an off-by-one error when calculating segment distances. The algorithm performs forward propagation starting from the ego pose as anchor:

- **Constraint evaluation** requires distance from anchor to current point
- **Point placement** requires distance from current point to next point

The old code used the same distance for both operations, causing incorrect yaw rate constraint calculations for the first segment.

### Issue 2: TrajectoryPointFixer Breaking Heading Alignment

The final `TrajectoryPointFixer` plugin runs after the kinematic feasibility enforcer and uses `resample_close_proximity_points()` to handle clustered points. This function:

1. Projects close points (within 0.05m) onto a straight line
2. Assigns all clustered points the **same orientation** based on historical trajectory direction

This can override the heading alignments established by the kinematic enforcer, causing point orientations to not match their geometric heading direction (vector from point N to point N+1).

## Changes

### Kinematic Feasibility Enforcer

- Added explicit calculation of anchor-to-first-point distance and store as `segment_distances[0]`
- Use `segment_distances[i]` for constraint evaluation (distance from anchor to current point)
- Use `segment_distances[i+1]` for point placement (distance from current to next point)
- Improved variable naming for clarity (`s_anchor_current_point`, `s_original_current_next_point`)
- Fixed validation condition from `<= 1e-3` to `< 1e-3` for consistency

### Plugin Execution Order

Removed final `TrajectoryPointFixer` from plugin list to prevent heading override:

**Before:**

```yaml
- TrajectoryKinematicFeasibilityEnforcer
- TrajectoryQPSmoother
- TrajectoryKinematicFeasibilityEnforcer
- TrajectoryEBSmootherOptimizer
- TrajectorySplineSmoother
- TrajectoryVelocityOptimizer
- TrajectoryExtender
- TrajectoryPointFixer  # <-- Breaks heading alignment
```

**After:**

```yaml
- TrajectoryPointFixer
- TrajectoryKinematicFeasibilityEnforcer
- TrajectoryQPSmoother
- TrajectoryKinematicFeasibilityEnforcer  # <-- Final enforcement
- TrajectoryEBSmootherOptimizer
- TrajectorySplineSmoother
- TrajectoryVelocityOptimizer
- TrajectoryExtender
```

### Why Run Kinematic Enforcer Twice?

The kinematic feasibility enforcer runs twice in the pipeline:

1. **Before QP Smoother**: Enforces kinematic feasibility on the initial trajectory from the planner
2. **After QP Smoother**: Re-enforces constraints after QP optimization

The QP smoother optimizes for trajectory smoothness (minimizing jerk/acceleration) but does not respect Ackermann steering geometry or yaw rate limits. The second kinematic enforcer pass ensures the smoothed trajectory remains kinematically executable by the vehicle.


## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
Psim

Before: 
![Untitled Diagram drawio](https://github.com/user-attachments/assets/f6ee5414-7f74-4b14-a05d-49f7399ee2d7)


After: 
![fixed_enforcer_with_no_resampling drawio](https://github.com/user-attachments/assets/b5d7c653-c892-4cda-a6c8-12b5e260730d)


## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
