### PR TITLE
feat(detection_area): implement unified handling for unstoppable situations

### DIFF
--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_detection_area_module/config/detection_area.param.yaml
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_detection_area_module/config/detection_area.param.yaml
@@ -18,9 +18,9 @@
         under_drivable: false
       use_dead_line: false
       dead_line_margin: 5.0
-      use_max_acceleration: true
-      max_acceleration: 1.0
-      use_pass_judge_line: false
+      unstoppable_policy: "go" # "go" or "force_stop" or "stop_after_stopline"
+      max_deceleration: 1.0
+      delay_response_time: 0.5
       state_clear_time: 2.0
       hold_stop_margin_distance: 0.0
       distance_to_judge_over_stop_line: 0.5

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_detection_area_module/config/detection_area.param.yaml
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_detection_area_module/config/detection_area.param.yaml
@@ -18,7 +18,7 @@
         under_drivable: false
       use_dead_line: false
       dead_line_margin: 5.0
-      unstoppable_policy: "go" # "go" or "force_stop" or "stop_after_stopline"
+      unstoppable_policy: "stop_after_stopline" # "go" or "force_stop" or "stop_after_stopline"
       max_deceleration: 1.0
       delay_response_time: 0.5
       state_clear_time: 2.0

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_detection_area_module/src/experimental/manager.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_detection_area_module/src/experimental/manager.cpp
@@ -35,12 +35,6 @@ DetectionAreaModuleManager::DetectionAreaModuleManager(rclcpp::Node & node)
   planner_param_.use_dead_line = get_or_declare_parameter<bool>(node, ns + ".use_dead_line");
   planner_param_.dead_line_margin =
     get_or_declare_parameter<double>(node, ns + ".dead_line_margin");
-  planner_param_.use_max_acceleration =
-    get_or_declare_parameter<bool>(node, ns + ".use_max_acceleration");
-  planner_param_.max_acceleration =
-    get_or_declare_parameter<double>(node, ns + ".max_acceleration");
-  planner_param_.use_pass_judge_line =
-    get_or_declare_parameter<bool>(node, ns + ".use_pass_judge_line");
   planner_param_.state_clear_time =
     get_or_declare_parameter<double>(node, ns + ".state_clear_time");
   planner_param_.hold_stop_margin_distance =
@@ -79,6 +73,14 @@ DetectionAreaModuleManager::DetectionAreaModuleManager(rclcpp::Node & node)
     get_or_declare_parameter<bool>(node, ns + ".target_filtering.over_drivable");
   planner_param_.target_filtering.under_drivable =
     get_or_declare_parameter<bool>(node, ns + ".target_filtering.under_drivable");
+
+  // Unified unstoppable situation handling parameters
+  planner_param_.unstoppable_policy =
+    get_or_declare_parameter<std::string>(node, ns + ".unstoppable_policy");
+  planner_param_.max_deceleration =
+    get_or_declare_parameter<double>(node, ns + ".max_deceleration");
+  planner_param_.delay_response_time =
+    get_or_declare_parameter<double>(node, ns + ".delay_response_time");
 }
 
 void DetectionAreaModuleManager::launchNewModules(

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_detection_area_module/src/manager.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_detection_area_module/src/manager.cpp
@@ -41,12 +41,6 @@ DetectionAreaModuleManager::DetectionAreaModuleManager(rclcpp::Node & node)
   planner_param_.use_dead_line = get_or_declare_parameter<bool>(node, ns + ".use_dead_line");
   planner_param_.dead_line_margin =
     get_or_declare_parameter<double>(node, ns + ".dead_line_margin");
-  planner_param_.use_max_acceleration =
-    get_or_declare_parameter<bool>(node, ns + ".use_max_acceleration");
-  planner_param_.max_acceleration =
-    get_or_declare_parameter<double>(node, ns + ".max_acceleration");
-  planner_param_.use_pass_judge_line =
-    get_or_declare_parameter<bool>(node, ns + ".use_pass_judge_line");
   planner_param_.state_clear_time =
     get_or_declare_parameter<double>(node, ns + ".state_clear_time");
   planner_param_.hold_stop_margin_distance =
@@ -57,6 +51,14 @@ DetectionAreaModuleManager::DetectionAreaModuleManager(rclcpp::Node & node)
     get_or_declare_parameter<bool>(node, ns + ".suppress_pass_judge_when_stopping");
   planner_param_.enable_detected_obstacle_logging =
     get_or_declare_parameter<bool>(node, ns + ".enable_detected_obstacle_logging");
+
+  // Unified unstoppable situation handling parameters
+  planner_param_.unstoppable_policy =
+    get_or_declare_parameter<std::string>(node, ns + ".unstoppable_policy");
+  planner_param_.max_deceleration =
+    get_or_declare_parameter<double>(node, ns + ".max_deceleration");
+  planner_param_.delay_response_time =
+    get_or_declare_parameter<double>(node, ns + ".delay_response_time");
 
   // Target filtering parameters
   planner_param_.target_filtering.pointcloud =

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_detection_area_module/src/scene.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_detection_area_module/src/scene.cpp
@@ -83,6 +83,87 @@ void DetectionAreaModule::print_detected_obstacle(
     self_pose.position.z, obstacles_ss.str().c_str());
 }
 
+void DetectionAreaModule::finalizeStopPoint(
+  PathWithLaneId * path, const geometry_msgs::msg::Pose & stop_pose,
+  const geometry_msgs::msg::Pose & modified_stop_pose, const size_t modified_stop_line_seg_idx,
+  const geometry_msgs::msg::Pose & self_pose, const std::string & detection_source,
+  const std::string & policy_name, const State & prev_state)
+{
+  state_ = State::STOP;
+  if (prev_state != State::STOP) {
+    logInfo("state changed: GO -> STOP (%s)", policy_name.c_str());
+  }
+
+  if (planner_param_.enable_detected_obstacle_logging) {
+    print_detected_obstacle(debug_data_.obstacle_points, self_pose);
+  }
+
+  planning_utils::insertStopPoint(modified_stop_pose.position, modified_stop_line_seg_idx, *path);
+
+  // For virtual wall
+  debug_data_.stop_poses.push_back(stop_pose);
+
+  // Create StopReason
+  {
+    planning_factor_interface_->add(
+      path->points, planner_data_->current_odometry->pose, stop_pose,
+      autoware_internal_planning_msgs::msg::PlanningFactor::STOP,
+      autoware_internal_planning_msgs::msg::SafetyFactorArray{}, true /*is_driving_forward*/, 0.0,
+      0.0 /*shift distance*/, detection_source);
+  }
+}
+
+bool DetectionAreaModule::handleUnstoppableGoPolicy()
+{
+  logWarnThrottle(1000, "[detection_area] insufficient braking distance, policy: go");
+  setSafe(true);
+  return true;
+}
+
+bool DetectionAreaModule::handleUnstoppableForceStopPolicy(
+  PathWithLaneId * path, const geometry_msgs::msg::Pose & stop_pose,
+  const geometry_msgs::msg::Pose & modified_stop_pose, const size_t modified_stop_line_seg_idx,
+  const geometry_msgs::msg::Pose & self_pose, const std::string & detection_source)
+{
+  logWarnThrottle(
+    1000, "[detection_area] insufficient braking distance, policy: force_stop (emergency)");
+
+  finalizeStopPoint(
+    path, stop_pose, modified_stop_pose, modified_stop_line_seg_idx, self_pose, detection_source,
+    "force_stop", state_);
+
+  return true;
+}
+
+bool DetectionAreaModule::handleUnstoppableStopAfterLinePolicy(
+  PathWithLaneId * path, const PathWithLaneId & original_path,
+  const geometry_msgs::msg::Pose & stop_pose, geometry_msgs::msg::Pose & modified_stop_pose,
+  size_t & modified_stop_line_seg_idx, const geometry_msgs::msg::Pose & self_pose,
+  const double current_velocity, const double stop_dist, const std::string & detection_source)
+{
+  logWarnThrottle(
+    1000, "[detection_area] insufficient braking distance, policy: stop_after_stopline");
+
+  forward_offset_to_stop_line_ = std::max(
+    detection_area::feasible_stop_distance_by_max_acceleration(
+      current_velocity, planner_param_.max_deceleration) -
+      stop_dist,
+    0.0);
+
+  const auto offset_segment = arc_lane_utils::findOffsetSegment(
+    original_path, modified_stop_line_seg_idx, forward_offset_to_stop_line_);
+  if (offset_segment) {
+    modified_stop_pose = arc_lane_utils::calcTargetPose(original_path, *offset_segment);
+    modified_stop_line_seg_idx = offset_segment->first;
+  }
+
+  finalizeStopPoint(
+    path, stop_pose, modified_stop_pose, modified_stop_line_seg_idx, self_pose, detection_source,
+    "stop_after_stopline", state_);
+
+  return true;
+}
+
 bool DetectionAreaModule::modifyPathVelocity(PathWithLaneId * path)
 {
   // Store original path
@@ -232,59 +313,37 @@ bool DetectionAreaModule::modifyPathVelocity(PathWithLaneId * path)
     return true;
   }
 
-  // Ignore objects if braking distance is not enough
-  if (planner_param_.use_pass_judge_line) {
-    const auto current_velocity = planner_data_->current_velocity->twist.linear.x;
-    const double pass_judge_line_distance = planning_utils::calcJudgeLineDistWithAccLimit(
-      current_velocity, planner_data_->max_stop_acceleration_threshold,
-      planner_data_->delay_response_time);
-    if (
-      state_ != State::STOP &&
-      !detection_area::has_enough_braking_distance(
-        self_pose, stop_point->second, pass_judge_line_distance, current_velocity)) {
-      logWarnThrottle(1000, "[detection_area] vehicle is over stop border");
-      setSafe(true);
-      return true;
+  // Unified unstoppable situation handling
+  const auto current_velocity = planner_data_->current_velocity->twist.linear.x;
+  const double required_braking_distance = planning_utils::calcJudgeLineDistWithAccLimit(
+    current_velocity, -planner_param_.max_deceleration, planner_param_.delay_response_time);
+
+  const bool has_enough_distance = detection_area::has_enough_braking_distance(
+    self_pose, stop_point->second, required_braking_distance, current_velocity);
+
+  // Apply unstoppable policy when braking distance is insufficient (only on GO->STOP transition)
+  if (state_ != State::STOP && !has_enough_distance) {
+    if (planner_param_.unstoppable_policy == "go") {
+      return handleUnstoppableGoPolicy();
+    }
+
+    if (planner_param_.unstoppable_policy == "force_stop") {
+      return handleUnstoppableForceStopPolicy(
+        path, stop_pose, modified_stop_pose, modified_stop_line_seg_idx, self_pose,
+        detection_source);
+    }
+
+    if (planner_param_.unstoppable_policy == "stop_after_stopline") {
+      return handleUnstoppableStopAfterLinePolicy(
+        path, original_path, stop_pose, modified_stop_pose, modified_stop_line_seg_idx, self_pose,
+        current_velocity, stop_dist, detection_source);
     }
   }
 
-  // Insert stop point
-  state_ = State::STOP;
-  if (prev_state != State::STOP) {
-    if (planner_param_.use_max_acceleration) {
-      forward_offset_to_stop_line_ = std::max(
-        detection_area::feasible_stop_distance_by_max_acceleration(
-          planner_data_->current_velocity->twist.linear.x, planner_param_.max_acceleration) -
-          stop_dist,
-        0.0);
-
-      const auto offset_segment = arc_lane_utils::findOffsetSegment(
-        original_path, modified_stop_line_seg_idx, forward_offset_to_stop_line_);
-      if (offset_segment) {
-        modified_stop_pose = arc_lane_utils::calcTargetPose(original_path, *offset_segment);
-        modified_stop_line_seg_idx = offset_segment->first;
-      }
-    }
-    logInfo("state changed: GO -> STOP");
-  }
-
-  if (state_ == State::STOP && planner_param_.enable_detected_obstacle_logging) {
-    print_detected_obstacle(debug_data_.obstacle_points, self_pose);
-  }
-
-  planning_utils::insertStopPoint(modified_stop_pose.position, modified_stop_line_seg_idx, *path);
-
-  // For virtual wall
-  debug_data_.stop_poses.push_back(stop_point->second);
-
-  // Create StopReason
-  {
-    planning_factor_interface_->add(
-      path->points, planner_data_->current_odometry->pose, stop_pose,
-      autoware_internal_planning_msgs::msg::PlanningFactor::STOP,
-      autoware_internal_planning_msgs::msg::SafetyFactorArray{}, true /*is_driving_forward*/, 0.0,
-      0.0 /*shift distance*/, detection_source);
-  }
+  // Normal case: sufficient braking distance OR already in STOP state
+  finalizeStopPoint(
+    path, stop_pose, modified_stop_pose, modified_stop_line_seg_idx, self_pose, detection_source,
+    "normal", prev_state);
 
   return true;
 }

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_detection_area_module/src/scene.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_detection_area_module/src/scene.hpp
@@ -18,6 +18,7 @@
 #include <boost/optional.hpp>
 
 #include <memory>
+#include <string>
 #include <utility>
 #include <vector>
 
@@ -57,14 +58,16 @@ public:
     double stop_margin;
     bool use_dead_line;
     double dead_line_margin;
-    bool use_max_acceleration;
-    double max_acceleration;
-    bool use_pass_judge_line;
     double state_clear_time;
     double hold_stop_margin_distance;
     double distance_to_judge_over_stop_line;
     bool suppress_pass_judge_when_stopping;
     bool enable_detected_obstacle_logging;
+
+    // Unified unstoppable situation handling
+    std::string unstoppable_policy;  // "go", "force_stop", or "stop_after_stopline"
+    double max_deceleration;
+    double delay_response_time;
 
     struct TargetFiltering
     {
@@ -135,6 +138,63 @@ private:
   void print_detected_obstacle(
     const std::vector<geometry_msgs::msg::Point> & obstacle_points,
     const geometry_msgs::msg::Pose & self_pose) const;
+
+  /**
+   * @brief Finalize stop point by inserting it, logging, and creating stop reason
+   * @param path Path to modify
+   * @param stop_pose Original stop pose
+   * @param modified_stop_pose Modified stop pose to insert
+   * @param modified_stop_line_seg_idx Modified stop line segment index
+   * @param self_pose Current vehicle pose
+   * @param detection_source Source of detection
+   * @param policy_name Name of policy being applied (for logging)
+   * @param prev_state Previous state before this operation
+   */
+  void finalizeStopPoint(
+    PathWithLaneId * path, const geometry_msgs::msg::Pose & stop_pose,
+    const geometry_msgs::msg::Pose & modified_stop_pose, const size_t modified_stop_line_seg_idx,
+    const geometry_msgs::msg::Pose & self_pose, const std::string & detection_source,
+    const std::string & policy_name, const State & prev_state);
+
+  /**
+   * @brief Handle "go" policy for unstoppable situation
+   * @return true if should pass through
+   */
+  bool handleUnstoppableGoPolicy();
+
+  /**
+   * @brief Handle "force_stop" policy for unstoppable situation
+   * @param path Path to modify
+   * @param stop_pose Original stop pose
+   * @param modified_stop_pose Modified stop pose
+   * @param modified_stop_line_seg_idx Modified stop line segment index
+   * @param self_pose Current vehicle pose
+   * @param detection_source Source of detection
+   * @return true if stop point was inserted
+   */
+  bool handleUnstoppableForceStopPolicy(
+    PathWithLaneId * path, const geometry_msgs::msg::Pose & stop_pose,
+    const geometry_msgs::msg::Pose & modified_stop_pose, const size_t modified_stop_line_seg_idx,
+    const geometry_msgs::msg::Pose & self_pose, const std::string & detection_source);
+
+  /**
+   * @brief Handle "stop_after_stopline" policy for unstoppable situation
+   * @param path Path to modify
+   * @param original_path Original path
+   * @param stop_pose Original stop pose
+   * @param modified_stop_pose Modified stop pose (will be updated)
+   * @param modified_stop_line_seg_idx Modified stop line segment index (will be updated)
+   * @param self_pose Current vehicle pose
+   * @param current_velocity Current vehicle velocity
+   * @param stop_dist Distance to stop line
+   * @param detection_source Source of detection
+   * @return true if stop point was inserted
+   */
+  bool handleUnstoppableStopAfterLinePolicy(
+    PathWithLaneId * path, const PathWithLaneId & original_path,
+    const geometry_msgs::msg::Pose & stop_pose, geometry_msgs::msg::Pose & modified_stop_pose,
+    size_t & modified_stop_line_seg_idx, const geometry_msgs::msg::Pose & self_pose,
+    const double current_velocity, const double stop_dist, const std::string & detection_source);
 };
 }  // namespace autoware::behavior_velocity_planner
 


### PR DESCRIPTION
## Description

* Previously, when the vehicle could not stop at the stop line in a detection area, the behavior was controlled by two boolean parameters that selected among three options: (1) shift the stopping position forward, (2) pass through without stopping, or (3) force a stop. These options have now been consolidated into a single parameter called *unstoppable_policy*.

* The acceleration parameter used to determine whether the vehicle can stop at the stop line was taken from the common parameters in *behavior_velocity*. This can now be configured independently using the parameters of the detection area.

---


**Normal Case**

[Screencast from 11-11-2025 05:54:41 PM.webm](https://github.com/user-attachments/assets/348014e3-6ba5-47da-81f5-cb048b243a57)

**Unstoppable Situations**

[Screencast from 11-11-2025 05:24:09 PM.webm](https://github.com/user-attachments/assets/9ee27db3-e1cb-4593-bcda-9a108f5faee2)


## Related links

- https://github.com/autowarefoundation/autoware_launch/pull/1701

## How was this PR tested?

- [[PR check][Lexus][FuncVerificationScenario_Basic][deprecated-behavior-planning] planning test](https://evaluation.tier4.jp/evaluation/reports/abc2feb9-fa8a-5c20-935d-6aa2436229e3?project_id=prd_jt)
- [[PR check][Lexus][CommonScenario_Basic][deprecated-behavior-planning] planning test](https://evaluation.tier4.jp/evaluation/reports/4f37bd0d-07a5-5fa3-a5f7-2095de9eaff0?project_id=prd_jt)
- [[PR check][Lexus][ControlDLRCommon_Basic][deprecated-behavior-planning] DLR test](https://evaluation.tier4.jp/evaluation/reports/8fe9c412-287c-57b8-895d-88acc7c5d853?project_id=prd_jt)
- [[PR check][Lexus][FuncVerificationScenario_Basic] planning test](https://evaluation.tier4.jp/evaluation/reports/f313005a-1192-5be7-8418-562db8d41b32?project_id=prd_jt)
- [[PR check][Lexus][CommonScenario_Basic] planning test](https://evaluation.tier4.jp/evaluation/reports/eebe5e02-25bc-583c-92b9-55e4f9deee4f?project_id=prd_jt)
- [[PR check][Lexus][ControlDLRCommon_Basic] DLR test](https://evaluation.tier4.jp/evaluation/reports/06ef47bc-3f5c-5ae5-9a7f-12eded6d3511?project_id=prd_jt)

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
