### PR TITLE
ci(build-and-test-reusable): partially revert dependency_ws addition

### DIFF
--- a/.github/workflows/build-and-test-reusable.yaml
+++ b/.github/workflows/build-and-test-reusable.yaml
@@ -130,18 +130,6 @@ jobs:
           overlay_file: build_depends_nightly.repos
           output_file: build_depends.repos
 
-      - name: Resolve exact dependencies
-        run: |
-          vcs import dependency_ws < build_depends.repos
-          vcs export dependency_ws --exact-with-tags > build-depends-exact.repos
-
-      - name: Build dependencies
-        uses: autowarefoundation/autoware-github-actions/colcon-build@v1
-        with:
-          rosdistro: ${{ env.rosdistro }}
-          cache-key-element: ${{ env.BUILD_TYPE_CUDA_STATE }}
-          base-paths: dependency_ws
-
       - name: Build
         if: ${{ steps.get-self-packages.outputs.self-packages != '' }}
         uses: autowarefoundation/autoware-github-actions/colcon-build@v1


### PR DESCRIPTION
## Description

- https://github.com/autowarefoundation/autoware_universe/pull/11133 was merged.

It caused this small bug:
<img width="1192" height="1081" alt="image" src="https://github.com/user-attachments/assets/a43c93a3-eb65-4a94-9f4f-19625759ea2b" />
https://github.com/autowarefoundation/autoware_universe/actions/runs/19414588706/job/55540978719

This PR reverts the part that caused the bug.

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
