### PR TITLE
revert(start_planner): "ensure the pose is not behind the ego vehicle"

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/start_planner_module.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/start_planner_module.cpp
@@ -1159,18 +1159,6 @@ PathWithLaneId StartPlannerModule::getCurrentOutputPath()
       status_.prev_stop_path_after_approval = nullptr;
       return getCurrentPath();
     }
-    // update the stop pose if it goes behind the current ego pose
-    const double previous_stop_distance = autoware::motion_utils::calcSignedArcLength(
-      status_.prev_stop_path_after_approval->points,
-      planner_data_->self_odometry->pose.pose.position, stop_pose_->pose.position);
-    if (previous_stop_distance < 0.0) {
-      const auto ego_arc_length = autoware::motion_utils::calcSignedArcLength(
-        status_.prev_stop_path_after_approval->points, 0UL,
-        planner_data_->self_odometry->pose.pose.position);
-      stop_pose_->pose = utils::insertStopPoint(ego_arc_length, current_path).point.pose;
-
-      status_.prev_stop_path_after_approval = std::make_shared<PathWithLaneId>(current_path);
-    }
     return *status_.prev_stop_path_after_approval;
   }
 


### PR DESCRIPTION
## Description

Revert https://github.com/autowarefoundation/autoware_universe/pull/11548
Updating the stop pose when ego overruns it prevents using the `enable_overshoot_emergency` feature of the PID controller (see https://autowarefoundation.github.io/autoware_universe/main/control/autoware_pid_longitudinal_controller/#parameter-description).

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
