### PR TITLE
fix(crosswalk): always choose the nearest stop pose (incl previous one)

### DIFF
--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/scene_crosswalk.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/scene_crosswalk.hpp
@@ -519,6 +519,15 @@ private:
       stop_watch_.toc("total_processing_time", false));
   }
 
+  void set_previous_stop_pose(const std::optional<StopPoseWithObjectUuids> & current_stop_pose)
+  {
+    if (!current_stop_pose) {
+      previous_stop_pose_.reset();
+      return;
+    }
+    previous_stop_pose_ = current_stop_pose;
+  }
+
   const int64_t module_id_;
 
   rclcpp::Publisher<autoware_internal_debug_msgs::msg::StringStamped>::SharedPtr
@@ -552,6 +561,8 @@ private:
   // occluded space time buffer
   std::optional<rclcpp::Time> current_initial_occlusion_time_;
   std::optional<rclcpp::Time> most_recent_occlusion_time_;
+
+  std::optional<StopPoseWithObjectUuids> previous_stop_pose_;
 
   struct
   {


### PR DESCRIPTION
## Description

This PR improves the stop pose calculation of the `crosswalk` module to make it more stable.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

Psim and perception replayer.

Evaluator ([TIER IV INTERNAL LINK](https://evaluation.tier4.jp/evaluation/reports/2196b6e8-9d63-50d3-9b5b-7c6ea350ed83?project_id=prd_jt))

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
