### PR TITLE
fix(operation_mode_transition_manager): fix debug value update

### DIFF
--- a/control/autoware_operation_mode_transition_manager/src/state.cpp
+++ b/control/autoware_operation_mode_transition_manager/src/state.cpp
@@ -174,7 +174,8 @@ bool AutonomousMode::isModeChangeCompleted(const InputData & input_data)
   return is_system_stable;
 }
 
-bool AutonomousMode::hasDangerAcceleration(const Odometry & kinematics, const Control & control_cmd)
+bool AutonomousMode::hasDangerAcceleration(
+  const Odometry & kinematics, const Control & control_cmd) const
 {
   const bool is_stopping = std::abs(kinematics.twist.twist.linear.x) < 0.01;
   if (is_stopping) {

--- a/control/autoware_operation_mode_transition_manager/src/state.hpp
+++ b/control/autoware_operation_mode_transition_manager/src/state.hpp
@@ -74,7 +74,7 @@ public:
   DebugInfo getDebugInfo() override { return debug_info_; }
 
 private:
-  bool hasDangerAcceleration(const Odometry & kinematics, const Control & control_cmd);
+  bool hasDangerAcceleration(const Odometry & kinematics, const Control & control_cmd) const;
   std::pair<bool, bool> hasDangerLateralAcceleration(
     const Odometry & kinematics, const Control & control_cmd);
 


### PR DESCRIPTION
## Description

- Fixed an issue where debug info `engage_allowed_for_stopped_vehicle` was not being updated.
- Tried to group all assignments to debug info in one place.

## Related links

**Private Links:**

- [TIER IV internal link](https://star4.slack.com/archives/CRUE57C30/p1763451960148619?thread_ts=1763083842.689699&cid=CRUE57C30)

## How was this PR tested?

Change `operation_mode_transition_manager.param.yaml`
```
enable_engage_on_driving: true
check_engage_condition: true
allow_autonomous_in_stopped: true
```

Run planning simulation with `use_control_command_gate:=true`
Run `ros2 topic echo /control/autoware_operation_mode_transition_manager/debug_info`
Change to autonomous mode.
Check that `engage_allowed_for_stopped_vehicle` is false while the vehicle is driving.


## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
