### PR TITLE
fix(lidar_frnet): implement custom destructor for LidarFRNet to manage CUDA stream resources

### DIFF
--- a/perception/autoware_lidar_frnet/include/autoware/lidar_frnet/lidar_frnet.hpp
+++ b/perception/autoware_lidar_frnet/include/autoware/lidar_frnet/lidar_frnet.hpp
@@ -52,7 +52,7 @@ public:
     const utils::NetworkParams & network_params,
     const utils::PreprocessingParams & preprocessing_params,
     const utils::PostprocessingParams & postprocessing_params, const rclcpp::Logger & logger);
-  ~LidarFRNet() = default;
+  ~LidarFRNet();
 
   bool process(
     const sensor_msgs::msg::PointCloud2 & cloud_in, sensor_msgs::msg::PointCloud2 & cloud_seg_out,

--- a/perception/autoware_lidar_frnet/lib/lidar_frnet.cpp
+++ b/perception/autoware_lidar_frnet/lib/lidar_frnet.cpp
@@ -80,6 +80,14 @@ LidarFRNet::LidarFRNet(
   stop_watch_ptr_->tic("processing/inner");
 }
 
+LidarFRNet::~LidarFRNet()
+{
+  if (stream_) {
+    cudaStreamSynchronize(stream_);
+    cudaStreamDestroy(stream_);
+  }
+}
+
 bool LidarFRNet::process(
   const sensor_msgs::msg::PointCloud2 & cloud_in, sensor_msgs::msg::PointCloud2 & cloud_seg_out,
   sensor_msgs::msg::PointCloud2 & cloud_viz_out, sensor_msgs::msg::PointCloud2 & cloud_filtered,


### PR DESCRIPTION
## Description

TBD

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

TBD

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
