### PR TITLE
fix(crosswalk): update the previous stop pose before using it

### DIFF
--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/scene_crosswalk.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/scene_crosswalk.cpp
@@ -1268,7 +1268,7 @@ CrosswalkModule::getNearestStopFactorAndReason(
     return {std::nullopt, ""};
   }
   constexpr auto previous_stop_reuse_margin =
-    3.0;  // [m] reuse the previous stop pose if it is within the margin
+    1.0;  // [m] reuse the previous stop pose if it is within the margin
   const auto dist_to_stop = get_distance_to_stop(nearest_stop_and_reason->first);
   if (previous_stop_pose_) {
     const auto previous_stop_arc_length = motion_utils::calcSignedArcLength(


### PR DESCRIPTION
## Description

Fix an issue with the `crosswalk` that could insert a stop pose that was calculated for a previous path, leading to yaw or distance deviation issues.
This PR fixes the issue by always re-projecting the stop pose on the updated path.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

Psim + rosbag
Evaluator (TIER IV INTERNAL LINK): https://evaluation.tier4.jp/evaluation/reports/be5ee509-7353-53a5-b828-0d950fbea994?project_id=prd_jt

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
