### PR TITLE
feat(obstacle_slow_down): process only closest valid obstacle

### DIFF
--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_slow_down_module/src/obstacle_slow_down_module.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_slow_down_module/src/obstacle_slow_down_module.cpp
@@ -890,7 +890,8 @@ std::vector<SlowdownInterval> ObstacleSlowDownModule::plan_slow_down(
     new_prev_slow_down_output.push_back(
       SlowDownOutput{
         obstacle.uuid, slow_down_traj_points, slow_down_start_idx, slow_down_end_idx,
-        stable_slow_down_vel, feasible_slow_down_vel, obstacle.stable_dist_to_traj_poly.value(), obstacle_motion});
+        stable_slow_down_vel, feasible_slow_down_vel, obstacle.stable_dist_to_traj_poly.value(),
+        obstacle_motion});
   }
 
   // update prev_slow_down_output_


### PR DESCRIPTION
## Description

This PR optimizes the `obstacle_slow_down` module to react only to the closest valid obstacle instead of all obstacles in the ego lane, while preserving tracking history for all obstacles. This significantly reduces computational cost, especially in traffic jam scenarios, without losing the hysteresis and low-pass filtering benefits that depend on obstacle tracking history.

## Background

Currently, the `obstacle_slow_down` module processes **all obstacles** in the ego lane and applies slow-down velocity planning for each of them. This causes:
- **Unnecessary computational cost**, especially in traffic jam scenarios with many vehicles ahead
- **Multiple slow-down reactions** to obstacles at different distances, which is redundant since slowing down for the closest obstacle is sufficient

However, simply processing only the closest obstacle would lose tracking history for other obstacles, which is needed for:
- **Hysteresis in motion state determination** (Moving/Static classification)
- **Low-pass filtering of velocity** for smooth transitions


<img width="50%" alt="Screenshot from 2025-11-28 10-57-41" src="https://github.com/user-attachments/assets/883ef66b-506f-442c-ad4e-87b730f28c89" />


## Changes

### Main modifications in `obstacle_slow_down_module.cpp`:

1. **Sort obstacles by distance** before processing 
   - Obstacles are sorted by their distance from ego to prioritize closer ones

2. **Process obstacles sequentially until finding the first valid one** 
   - Loop through sorted obstacles in order of distance
   - For obstacles before the first valid one: perform heavy computation (distance calculation, trajectory insertion)
   - For obstacles after the first valid one: skip heavy computation and only preserve previous tracking history

3. **Apply slow-down planning only to the first valid obstacle** 
   - Once a valid obstacle is found and slow-down planning is applied, set `slow_down_applied = true`
   - Subsequent obstacles skip heavy computation and only preserve their previous output for tracking history

4. **Preserve tracking history for all obstacles** 
   - After the first valid obstacle is processed, remaining obstacles preserve their previous output
   - This maintains hysteresis and low-pass filtering behavior for all tracked obstacles

## Performance Impact

### Computational Complexity

**Before:**
- Loop iterations: n times (n = number of obstacles)
- Heavy computation per iteration: distance calculation, trajectory insertion, etc.
- Total complexity: **O(n × C)** where C is the cost of heavy computation

**After:**
- Sorting: O(n log n)
- Loop iterations: n times (all obstacles processed)
- Heavy computation: only for obstacles until the first valid one (k obstacles, typically k << n)
- Light computation: for remaining obstacles (n - k), only history preservation
- Total complexity: **O(n log n + k × C + (n - k))** ≈ **O(n log n + k × C)** where k << n

### Real-world improvement:
- **Traffic jam scenario (10 vehicles, first valid at 3rd)**: 10C → 10 log 10 + 3C ≈ 33 + 3C (significant reduction)
- **Normal scenario (3 vehicles, first valid at 1st)**: 3C → 3 log 3 + C ≈ 5 + C (noticeable reduction)
- **Single obstacle**: C → C (negligible overhead from sorting)

Since the per-obstacle computation (C) is expensive, this change provides **substantial performance improvement**, especially in scenarios with multiple obstacles.



## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
We tested this feature with robo taxi at Odaiba on November 28.

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior
- The module now reacts only to the **closest valid obstacle** in the ego lane
- If the closest obstacle is skipped (e.g., invalid slow-down conditions), the module evaluates the next closest one, and so on
- **Tracking history is preserved for all obstacles**, maintaining hysteresis and low-pass filtering behavior
- This maintains robustness while significantly reducing computational cost


<img width="50%" alt="Screenshot from 2025-11-29 19-04-04" src="https://github.com/user-attachments/assets/ffce6ff6-1b45-4a1c-830b-ef48e4214528" />

