### PR TITLE
fix(pointcloud_preprocessor): correct latency unit in concatenate pointcloud

### DIFF
--- a/sensing/autoware_pointcloud_preprocessor/include/autoware/pointcloud_preprocessor/concatenate_data/concatenate_and_time_sync_node.ipp
+++ b/sensing/autoware_pointcloud_preprocessor/include/autoware/pointcloud_preprocessor/concatenate_data/concatenate_and_time_sync_node.ipp
@@ -340,9 +340,9 @@ void PointCloudConcatenateDataSynchronizerComponentTemplated<MsgTraits>::publish
   const double now_sec = this->get_clock()->now().seconds();
 
   for (const auto & [topic, stamp] : concatenated_cloud_result.topic_to_original_stamp_map) {
-    const double latency = (now_sec - stamp) * 1000.0;  // ms
-    topic_to_pipeline_latency_map[topic] = latency;
-    max_pipeline_latency = std::max(max_pipeline_latency, latency);
+    const double latency_ms = (now_sec - stamp) * 1000.0;  // ms
+    topic_to_pipeline_latency_map[topic] = latency_ms;
+    max_pipeline_latency = std::max(max_pipeline_latency, latency_ms);
   }
 
   diagnostic_info.publish_pointcloud = publish_pointcloud;
@@ -484,7 +484,8 @@ void PointCloudConcatenateDataSynchronizerComponentTemplated<MsgTraits>::check_c
     }
     const auto latency_it = diagnostic_info.topic_to_pipeline_latency_map.find(topic);
     if (latency_it != diagnostic_info.topic_to_pipeline_latency_map.end()) {
-      diagnostics_interface_->add_key_value("Latency (s): " + topic, latency_it->second);
+      double latency_ms = latency_it->second;
+      diagnostics_interface_->add_key_value("Latency (ms): " + topic, latency_ms);
     }
   }
 


### PR DESCRIPTION
## Description

The latency unit for the `pointcloud_concatnate` node in the `/diagnostics` topic is currently logged as **seconds**, but the actual unit is **milliseconds**. This PR addresses this discrepancy.

```sh
~/autoware$ ros2 topic echo /diagnostics | grep concatenate_data -B8 -A35
header:
  stamp:
    sec: 1585897256
    nanosec: 39398108
  frame_id: ''
status:
- level: "\0"
  name: 'concatenate_data: /sensing/lidar/concatenate_data'
  message: OK
  hardware_id: concatenate_data
  values:
  - key: Concatenated pointcloud timestamp
    value: '1585897255.844858885'
  - key: Minimum reference timestamp
    value: '1585897255.834858894'
  - key: Maximum reference timestamp
    value: '1585897255.854858875'
  - key: Processing time (ms)
    value: '8.485000'
  - key: Pipeline latency (ms)
    value: '194.539309'
  - key: 'Concatenated: /sensing/lidar/right/pointcloud_before_sync'
    value: 'True'
  - key: 'Timestamp: /sensing/lidar/right/pointcloud_before_sync'
    value: '1585897255.844858885'
  - key: 'Latency (s): /sensing/lidar/right/pointcloud_before_sync'
    value: '194.539309'
  - key: 'Concatenated: /sensing/lidar/top/pointcloud_before_sync'
    value: 'True'
  - key: 'Timestamp: /sensing/lidar/top/pointcloud_before_sync'
    value: '1585897255.859630585'
  - key: 'Latency (s): /sensing/lidar/top/pointcloud_before_sync'
    value: '179.767609'
  - key: 'Concatenated: /sensing/lidar/left/pointcloud_before_sync'
    value: 'True'
  - key: 'Timestamp: /sensing/lidar/left/pointcloud_before_sync'
    value: '1585897255.860926628'
  - key: 'Latency (s): /sensing/lidar/left/pointcloud_before_sync'
    value: '178.471565'
  - key: Pointcloud concatenation succeeded
    value: 'True'
```

## How was this PR tested?

Following commands were run in different terminals.
```
~/autoware$ ros2 launch autoware_launch logging_simulator.launch.xml map_path:=$HOME/autoware_map/sample-map-rosbag vehicle_model:=sample_vehicle sensor_model:=sample_sensor_kit

$ ros2 bag play ~/autoware_map/sample-rosbag/sample-rosbag_0.db3 -r 0.1

$ ros2 topic echo /diagnostics | grep concatenate_data -B8 -A35
```

And got following result. Please note the latency unit is modified to millisecond.

```sh
$ ros2 topic echo /diagnostics | grep concatenate_data -B10 -A30
header:
  stamp:
    sec: 1585897255
    nanosec: 937597620
  frame_id: ''
status:
- level: "\0"
  name: 'concatenate_data: /sensing/lidar/concatenate_data'
  message: OK
  hardware_id: concatenate_data
  values:
  - key: Concatenated pointcloud timestamp
    value: '1585897255.744067430'
  - key: Minimum reference timestamp
    value: '1585897255.734067440'
  - key: Maximum reference timestamp
    value: '1585897255.754067421'
  - key: Processing time (ms)
    value: '7.269000'
  - key: Pipeline latency (ms)
    value: '193.530321'
  - key: 'Concatenated: /sensing/lidar/right/pointcloud_before_sync'
    value: 'True'
  - key: 'Timestamp: /sensing/lidar/right/pointcloud_before_sync'
    value: '1585897255.744067430'
  - key: 'Latency (ms): /sensing/lidar/right/pointcloud_before_sync'
    value: '193.530321'
  - key: 'Concatenated: /sensing/lidar/top/pointcloud_before_sync'
    value: 'True'
  - key: 'Timestamp: /sensing/lidar/top/pointcloud_before_sync'
    value: '1585897255.759661913'
  - key: 'Latency (ms): /sensing/lidar/top/pointcloud_before_sync'
    value: '177.935839'
  - key: 'Concatenated: /sensing/lidar/left/pointcloud_before_sync'
    value: 'True'
  - key: 'Timestamp: /sensing/lidar/left/pointcloud_before_sync'
    value: '1585897255.761373043'
  - key: 'Latency (ms): /sensing/lidar/left/pointcloud_before_sync'
    value: '176.224709'
  - key: Pointcloud concatenation succeeded
    value: 'True'
```

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
