### PR TITLE
chore: jazzy-porting:fix autoware core build differential compile error

### DIFF
--- a/common/autoware_auto_common/CMakeLists.txt
+++ b/common/autoware_auto_common/CMakeLists.txt
@@ -21,7 +21,9 @@ if(BUILD_TESTING)
     test/test_type_name.cpp
     test/test_type_traits.cpp
   )
-  target_compile_options(${TEST_COMMON} PRIVATE -Wno-sign-conversion)
+    # -Wno-c++20-compat is used to suppress C++20 compatibility warnings.
+  # "error: identifier ‘char8_t’ is a keyword in C++20"
+  target_compile_options(${TEST_COMMON} PRIVATE -Wno-sign-conversion -Wno-c++20-compat)
   target_include_directories(${TEST_COMMON} PRIVATE include)
   ament_target_dependencies(${TEST_COMMON}
     builtin_interfaces


### PR DESCRIPTION
## Description
fix autoware core build differential compile error in this [pr](https://github.com/autowarefoundation/autoware_core/pull/738) 
surpress compiler error caused by char8_t  defination warning , because it is a key word in c++20
<img width="1899" height="621" alt="图片" src="https://github.com/user-attachments/assets/5222fcc1-010c-4a19-b596-541ffb15cec8" />

## Related links

**Parent Issue:**

- https://github.com/autowarefoundation/autoware_universe/issues/11418

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
