### PR TITLE
feat: organize cuda point cloud processing scattered on different launch files

### DIFF
--- a/control/autoware_autonomous_emergency_braking/config/autonomous_emergency_braking.param.yaml
+++ b/control/autoware_autonomous_emergency_braking/config/autonomous_emergency_braking.param.yaml
@@ -9,6 +9,7 @@
     use_predicted_object_data: false
     use_object_velocity_calculation: true
     check_autoware_state: true
+    use_cuda_filtering: false
     imu_path_lat_dev_threshold: 1.75
     min_generated_imu_path_length: 0.5
     max_generated_imu_path_length: 10.0

--- a/control/autoware_autonomous_emergency_braking/include/autoware/autonomous_emergency_braking/node.hpp
+++ b/control/autoware_autonomous_emergency_braking/include/autoware/autonomous_emergency_braking/node.hpp
@@ -561,6 +561,7 @@ public:
   bool use_predicted_object_data_;
   bool use_object_velocity_calculation_;
   bool check_autoware_state_;
+  bool use_cuda_filtering_;
   double imu_path_lat_dev_threshold_;
   double path_footprint_extra_margin_;
   double speed_calculation_expansion_margin_;

--- a/control/autoware_autonomous_emergency_braking/launch/autoware_autonomous_emergency_braking.launch.xml
+++ b/control/autoware_autonomous_emergency_braking/launch/autoware_autonomous_emergency_braking.launch.xml
@@ -5,12 +5,69 @@
   <arg name="input_imu" default="/sensing/imu/imu_data"/>
   <arg name="input_predicted_trajectory" default="/control/trajectory_follower/lateral/predicted_trajectory"/>
   <arg name="input_objects" default="/perception/object_recognition/objects"/>
+  <arg name="use_cuda_filtering" default="false"/>
 
+  <!-- Container for composable nodes -->
+  <arg name="aeb_container_name" default="/pointcloud_container" description="container name for AEB composable nodes"/>
+  <arg name="use_intra_process" default="true" description="use ROS 2 component container communication"/>
+
+  <!-- CUDA filter parameters (used when use_cuda_filtering is enabled) -->
+  <arg name="detection_range_min_height" default="0.0"/>
+  <arg name="detection_range_max_height" default="2.0"/>
+  <arg name="voxel_grid_x" default="0.1"/>
+  <arg name="voxel_grid_y" default="0.1"/>
+  <arg name="voxel_grid_z" default="0.5"/>
+
+  <!-- Intermediate topics for CUDA filtering pipeline -->
+  <arg name="cuda_height_filtered_pointcloud" default="$(var input_pointcloud)/cuda_height_filtered"/>
+  <arg name="cuda_filtered_pointcloud" default="$(var input_pointcloud)/cuda_filtered"/>
+
+  <!-- CUDA Crop Box Filter for height filtering (replaces PassThrough filter) -->
+  <!-- This filters points by height (z-axis) with large X/Y range (±500m) -->
+  <group if="$(var use_cuda_filtering)">
+    <load_composable_node target="$(var aeb_container_name)">
+      <composable_node pkg="autoware_cuda_pointcloud_preprocessor" plugin="autoware::cuda_pointcloud_preprocessor::CudaCropBoxFilterNode" name="aeb_cuda_height_filter">
+        <param name="min_x" value="-500.0"/>
+        <param name="max_x" value="500.0"/>
+        <param name="min_y" value="-500.0"/>
+        <param name="max_y" value="500.0"/>
+        <param name="min_z" value="$(var detection_range_min_height)"/>
+        <param name="max_z" value="$(var detection_range_max_height)"/>
+        <param name="negative" value="false"/>
+        <param name="output_point_xyzircaedt" value="true"/>
+        <param name="max_mem_pool_size_in_byte" value="1000000000"/>
+        <remap from="~/input/pointcloud" to="$(var input_pointcloud)"/>
+        <remap from="~/input/pointcloud/cuda" to="$(var input_pointcloud)/cuda"/>
+        <remap from="~/output/pointcloud" to="$(var cuda_height_filtered_pointcloud)"/>
+        <remap from="~/output/pointcloud/cuda" to="$(var cuda_height_filtered_pointcloud)/cuda"/>
+      </composable_node>
+
+      <!-- CUDA Voxel Grid Downsample Filter (replaces PCL VoxelGrid filter) -->
+      <!-- Outputs PointXYZIRC for AEB node (which uses CPU processing) -->
+      <composable_node pkg="autoware_cuda_pointcloud_preprocessor" plugin="autoware::cuda_pointcloud_preprocessor::CudaVoxelGridDownsampleFilterNode" name="aeb_cuda_voxel_grid_filter">
+        <param name="voxel_size_x" value="$(var voxel_grid_x)"/>
+        <param name="voxel_size_y" value="$(var voxel_grid_y)"/>
+        <param name="voxel_size_z" value="$(var voxel_grid_z)"/>
+        <param name="output_point_xyzircaedt" value="false"/>
+        <param name="max_mem_pool_size_in_byte" value="1000000000"/>
+        <remap from="~/input/pointcloud" to="$(var cuda_height_filtered_pointcloud)"/>
+        <remap from="~/input/pointcloud/cuda" to="$(var cuda_height_filtered_pointcloud)/cuda"/>
+        <remap from="~/output/pointcloud" to="$(var cuda_filtered_pointcloud)"/>
+        <remap from="~/output/pointcloud/cuda" to="$(var cuda_filtered_pointcloud)/cuda"/>
+        <extra_arg name="use_intra_process_comms" value="$(var use_intra_process)"/>
+      </composable_node>
+    </load_composable_node>
+  </group>
+
+  <!-- AEB Node -->
   <node pkg="autoware_autonomous_emergency_braking" exec="autoware_autonomous_emergency_braking" name="autonomous_emergency_braking" output="screen">
     <!-- load config files -->
     <param from="$(var param_path)"/>
     <!-- remap topic name -->
-    <remap from="~/input/pointcloud" to="$(var input_pointcloud)"/>
+    <!-- When use_cuda_filtering is enabled, pointcloud is already filtered by CUDA filters -->
+    <!-- When use_cuda_filtering is disabled, pointcloud goes through CPU filtering in AEB node -->
+    <remap from="~/input/pointcloud" to="$(var cuda_filtered_pointcloud)" if="$(var use_cuda_filtering)"/>
+    <remap from="~/input/pointcloud" to="$(var input_pointcloud)" unless="$(var use_cuda_filtering)"/>
     <remap from="~/input/velocity" to="$(var input_velocity)"/>
     <remap from="~/input/imu" to="$(var input_imu)"/>
     <remap from="~/input/odometry" to="$(var input_odometry)"/>

--- a/control/autoware_autonomous_emergency_braking/schema/autonomous_emergency_braking.schema.json
+++ b/control/autoware_autonomous_emergency_braking/schema/autonomous_emergency_braking.schema.json
@@ -46,6 +46,11 @@
           "description": "Flag to enable or disable Autoware state check.",
           "default": true
         },
+        "use_cuda_filtering": {
+          "type": "boolean",
+          "description": "Flag to use CUDA-based pointcloud filtering instead of CPU-based filtering. When enabled, pointcloud filtering (height filter and voxel grid) is performed by CUDA filters before reaching AEB node.",
+          "default": false
+        },
         "imu_path_lat_dev_threshold": {
           "type": "number",
           "description": "Lateral deviation threshold for the IMU path.",

--- a/launch/tier4_localization_launch/launch/util/util.launch.xml
+++ b/launch/tier4_localization_launch/launch/util/util.launch.xml
@@ -1,33 +1,66 @@
 <launch>
   <!-- topic -->
   <arg name="output/pointcloud" default="downsample/pointcloud" description="final output topic name"/>
-
+  <arg name="cuda_pointclouds" default="false"/>
   <!-- container -->
   <arg name="localization_pointcloud_container_name" default="/pointcloud_container" description="container name of main lidar used for localization"/>
 
   <!-- whether use intra-process -->
   <arg name="use_intra_process" default="true" description="use ROS 2 component container communication"/>
 
-  <load_composable_node target="$(var localization_pointcloud_container_name)">
-    <composable_node pkg="autoware_pointcloud_preprocessor" plugin="autoware::pointcloud_preprocessor::CropBoxFilterComponent" name="crop_box_filter_measurement_range">
-      <param from="$(var ndt_scan_matcher/pointcloud_preprocessor/crop_box_filter_measurement_range_param_path)"/>
-      <remap from="input" to="$(var input_pointcloud)"/>
-      <remap from="output" to="measurement_range/pointcloud"/>
-      <extra_arg name="use_intra_process_comms" value="$(var use_intra_process)"/>
-    </composable_node>
+  <group unless="$(var cuda_pointclouds)">
+    <load_composable_node target="$(var localization_pointcloud_container_name)">
+      <composable_node pkg="autoware_pointcloud_preprocessor" plugin="autoware::pointcloud_preprocessor::CropBoxFilterComponent" name="crop_box_filter_measurement_range">
+        <param from="$(var ndt_scan_matcher/pointcloud_preprocessor/crop_box_filter_measurement_range_param_path)"/>
+        <remap from="input" to="$(var input_pointcloud)"/>
+        <remap from="output" to="measurement_range/pointcloud"/>
+        <extra_arg name="use_intra_process_comms" value="$(var use_intra_process)"/>
+      </composable_node>
 
-    <composable_node pkg="autoware_pointcloud_preprocessor" plugin="autoware::pointcloud_preprocessor::VoxelGridDownsampleFilterComponent" name="voxel_grid_downsample_filter">
-      <param from="$(var ndt_scan_matcher/pointcloud_preprocessor/voxel_grid_downsample_filter_param_path)"/>
-      <remap from="input" to="measurement_range/pointcloud"/>
-      <remap from="output" to="voxel_grid_downsample/pointcloud"/>
-      <extra_arg name="use_intra_process_comms" value="$(var use_intra_process)"/>
-    </composable_node>
+      <composable_node pkg="autoware_pointcloud_preprocessor" plugin="autoware::pointcloud_preprocessor::VoxelGridDownsampleFilterComponent" name="voxel_grid_downsample_filter">
+        <param from="$(var ndt_scan_matcher/pointcloud_preprocessor/voxel_grid_downsample_filter_param_path)"/>
+        <remap from="input" to="measurement_range/pointcloud"/>
+        <remap from="output" to="voxel_grid_downsample/pointcloud"/>
+        <extra_arg name="use_intra_process_comms" value="$(var use_intra_process)"/>
+      </composable_node>
 
-    <composable_node pkg="autoware_pointcloud_preprocessor" plugin="autoware::pointcloud_preprocessor::RandomDownsampleFilterComponent" name="random_downsample_filter">
-      <param from="$(var ndt_scan_matcher/pointcloud_preprocessor/random_downsample_filter_param_path)"/>
-      <remap from="input" to="voxel_grid_downsample/pointcloud"/>
-      <remap from="output" to="$(var output/pointcloud)"/>
-      <extra_arg name="use_intra_process_comms" value="$(var use_intra_process)"/>
-    </composable_node>
-  </load_composable_node>
+      <composable_node pkg="autoware_pointcloud_preprocessor" plugin="autoware::pointcloud_preprocessor::RandomDownsampleFilterComponent" name="random_downsample_filter">
+        <param from="$(var ndt_scan_matcher/pointcloud_preprocessor/random_downsample_filter_param_path)"/>
+        <remap from="input" to="voxel_grid_downsample/pointcloud"/>
+        <remap from="output" to="$(var output/pointcloud)"/>
+        <extra_arg name="use_intra_process_comms" value="$(var use_intra_process)"/>
+      </composable_node>
+    </load_composable_node>
+  </group>
+
+  <group if="$(var cuda_pointclouds)">
+    <load_composable_node target="$(var localization_pointcloud_container_name)">
+      <composable_node pkg="autoware_cuda_pointcloud_preprocessor" plugin="autoware::cuda_pointcloud_preprocessor::CudaCropBoxFilterNode" name="crop_box_filter_measurement_range">
+        <param from="$(var ndt_scan_matcher/pointcloud_preprocessor/crop_box_filter_measurement_range_param_path)"/>
+        <param name="output_point_xyzircaedt" value="true"/>
+        <remap from="~/input/pointcloud" to="$(var input_pointcloud)"/>
+        <remap from="~/input/pointcloud/cuda" to="$(var input_pointcloud)/cuda"/>
+        <remap from="~/output/pointcloud" to="measurement_range/pointcloud"/>
+        <remap from="~/output/pointcloud/cuda" to="measurement_range/pointcloud/cuda"/>
+      </composable_node>
+
+      <composable_node pkg="autoware_cuda_pointcloud_preprocessor" plugin="autoware::cuda_pointcloud_preprocessor::CudaVoxelGridDownsampleFilterNode" name="voxel_grid_downsample_filter">
+        <param from="$(var ndt_scan_matcher/pointcloud_preprocessor/voxel_grid_downsample_filter_param_path)"/>
+        <param name="output_point_xyzircaedt" value="true"/>
+        <remap from="~/input/pointcloud" to="measurement_range/pointcloud"/>
+        <remap from="~/input/pointcloud/cuda" to="measurement_range/pointcloud/cuda"/>
+        <remap from="~/output/pointcloud" to="measurement_range/pointcloud"/>
+        <remap from="~/output/pointcloud/cuda" to="voxel_grid_downsample/pointcloud/cuda"/>
+      </composable_node>
+
+      <composable_node pkg="autoware_cuda_pointcloud_preprocessor" plugin="autoware::cuda_pointcloud_preprocessor::CudaRandomDownsampleFilterNode" name="random_downsample_filter">
+        <param from="$(var ndt_scan_matcher/pointcloud_preprocessor/random_downsample_filter_param_path)"/>
+        <param name="output_point_xyzircaedt" value="false"/>
+        <remap from="~/input/pointcloud" to="voxel_grid_downsample/pointcloud"/>
+        <remap from="~/input/pointcloud/cuda" to="voxel_grid_downsample/pointcloud/cuda"/>
+        <remap from="~/output/pointcloud" to="$(var output/pointcloud)"/>
+        <remap from="~/output/pointcloud/cuda" to="$(var output/pointcloud)/cuda"/>
+      </composable_node>
+    </load_composable_node>
+  </group>
 </launch>

--- a/launch/tier4_localization_launch/launch/util/util.launch.xml
+++ b/launch/tier4_localization_launch/launch/util/util.launch.xml
@@ -49,7 +49,7 @@
         <param name="output_point_xyzircaedt" value="true"/>
         <remap from="~/input/pointcloud" to="measurement_range/pointcloud"/>
         <remap from="~/input/pointcloud/cuda" to="measurement_range/pointcloud/cuda"/>
-        <remap from="~/output/pointcloud" to="measurement_range/pointcloud"/>
+        <remap from="~/output/pointcloud" to="voxel_grid_downsample/pointcloud"/>
         <remap from="~/output/pointcloud/cuda" to="voxel_grid_downsample/pointcloud/cuda"/>
       </composable_node>
 

--- a/launch/tier4_perception_launch/launch/perception.launch.xml
+++ b/launch/tier4_perception_launch/launch/perception.launch.xml
@@ -186,6 +186,7 @@
   <arg name="output/tracker_merged_objects" default="/perception/object_recognition/detection/objects"/>
   <!-- Downsample pointcloud for perception usage -->
   <arg name="downsample_perception_common_pointcloud" default="false"/>
+  <arg name="cuda_pointclouds" default="false"/>
   <arg name="common_downsample_voxel_size_x" default="0.05"/>
   <arg name="common_downsample_voxel_size_y" default="0.05"/>
   <arg name="common_downsample_voxel_size_z" default="0.05"/>
@@ -199,21 +200,42 @@
     <let name="perception_pointcloud" value="$(var downsampled_pointcloud)" if="$(var downsample_perception_common_pointcloud)"/>
     <group if="$(var downsample_perception_common_pointcloud)">
       <push-ros-namespace namespace="common"/>
-      <load_composable_node target="$(var pointcloud_container_name)">
-        <composable_node
-          pkg="autoware_pointcloud_preprocessor"
-          plugin="autoware::pointcloud_preprocessor::PickupBasedVoxelGridDownsampleFilterComponent"
-          name="pointcloud_downsample_node"
-          namespace=""
-        >
-          <remap from="input" to="$(var input/pointcloud)"/>
-          <remap from="output" to="$(var downsampled_pointcloud)"/>
-          <param name="voxel_size_x" value="$(var common_downsample_voxel_size_x)"/>
-          <param name="voxel_size_y" value="$(var common_downsample_voxel_size_y)"/>
-          <param name="voxel_size_z" value="$(var common_downsample_voxel_size_z)"/>
-          <extra_arg name="use_intra_process_comms" value="true"/>
-        </composable_node>
-      </load_composable_node>
+      <group unless="$(var cuda_pointclouds)">
+        <load_composable_node target="$(var pointcloud_container_name)">
+          <composable_node
+            pkg="autoware_pointcloud_preprocessor"
+            plugin="autoware::pointcloud_preprocessor::PickupBasedVoxelGridDownsampleFilterComponent"
+            name="pointcloud_downsample_node"
+            namespace=""
+          >
+            <remap from="input" to="$(var input/pointcloud)"/>
+            <remap from="output" to="$(var downsampled_pointcloud)"/>
+            <param name="voxel_size_x" value="$(var common_downsample_voxel_size_x)"/>
+            <param name="voxel_size_y" value="$(var common_downsample_voxel_size_y)"/>
+            <param name="voxel_size_z" value="$(var common_downsample_voxel_size_z)"/>
+            <extra_arg name="use_intra_process_comms" value="true"/>
+          </composable_node>
+        </load_composable_node>
+      </group>
+
+      <group if="$(var cuda_pointclouds)">
+        <load_composable_node target="$(var pointcloud_container_name)">
+          <composable_node
+            pkg="autoware_cuda_pointcloud_preprocessor"
+            plugin="autoware::cuda_pointcloud_preprocessor::CudaVoxelGridDownsampleFilterNode"
+            name="pointcloud_downsample_node"
+            namespace=""
+          >
+            <remap from="~/input/pointcloud" to="$(var input/pointcloud)"/>
+            <remap from="~/input/pointcloud/cuda" to="$(var input/pointcloud)/cuda"/>
+            <remap from="~/output/pointcloud" to="$(var downsampled_pointcloud)"/>
+            <remap from="~/output/pointcloud/cuda" to="$(var downsampled_pointcloud)/cuda"/>
+            <param name="voxel_size_x" value="$(var common_downsample_voxel_size_x)"/>
+            <param name="voxel_size_y" value="$(var common_downsample_voxel_size_y)"/>
+            <param name="voxel_size_z" value="$(var common_downsample_voxel_size_z)"/>
+          </composable_node>
+        </load_composable_node>
+      </group>
     </group>
 
     <!-- Object segmentation module -->

--- a/planning/autoware_costmap_generator/include/autoware/costmap_generator/costmap_generator.hpp
+++ b/planning/autoware_costmap_generator/include/autoware/costmap_generator/costmap_generator.hpp
@@ -92,6 +92,7 @@ private:
   lanelet::LaneletMapPtr lanelet_map_;
   PredictedObjects::ConstSharedPtr objects_;
   sensor_msgs::msg::PointCloud2::ConstSharedPtr points_;
+  grid_map_msgs::msg::GridMap::ConstSharedPtr cuda_costmap_;
 
   grid_map::GridMap costmap_;
   std::shared_ptr<autoware_utils::TimeKeeper> time_keeper_;
@@ -109,6 +110,8 @@ private:
     this, "~/input/objects"};
   autoware_utils::InterProcessPollingSubscriber<autoware_internal_planning_msgs::msg::Scenario>
     sub_scenario_{this, "~/input/scenario"};
+  autoware_utils::InterProcessPollingSubscriber<grid_map_msgs::msg::GridMap> sub_cuda_costmap_{
+    this, "~/input/cuda_costmap"};
 
   rclcpp::TimerBase::SharedPtr timer_;
 

--- a/sensing/autoware_cuda_pointcloud_preprocessor/CMakeLists.txt
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/CMakeLists.txt
@@ -79,7 +79,9 @@ cuda_add_library(cuda_pointcloud_preprocessor_lib SHARED
   src/cuda_pointcloud_preprocessor/outlier_kernels.cu
   src/cuda_pointcloud_preprocessor/undistort_kernels.cu
   src/cuda_downsample_filter/cuda_voxel_grid_downsample_filter.cu
+  src/cuda_downsample_filter/cuda_random_downsample_filter.cu
   src/cuda_outlier_filter/cuda_polar_voxel_outlier_filter.cu
+  src/cuda_cropbox_filter/cuda_crop_box_filter.cu
 )
 
 target_link_libraries(cuda_pointcloud_preprocessor_lib
@@ -118,7 +120,9 @@ ament_auto_add_library(cuda_pointcloud_preprocessor SHARED
   src/cuda_concatenate_data/cuda_concatenate_and_time_sync_node.cpp
   src/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor_node.cpp
   src/cuda_downsample_filter/cuda_voxel_grid_downsample_filter_node.cpp
+  src/cuda_downsample_filter/cuda_random_downsample_filter_node.cpp
   src/cuda_outlier_filter/cuda_polar_voxel_outlier_filter_node.cpp
+  src/cuda_cropbox_filter/cuda_crop_box_filter_node.cpp
 )
 
 target_link_libraries(cuda_pointcloud_preprocessor
@@ -148,6 +152,18 @@ rclcpp_components_register_node(cuda_pointcloud_preprocessor
 rclcpp_components_register_node(cuda_pointcloud_preprocessor
   PLUGIN "autoware::cuda_pointcloud_preprocessor::CudaPolarVoxelOutlierFilterNode"
   EXECUTABLE cuda_polar_voxel_outlier_filter_node
+)
+
+# ========== CropBox filter ==========
+rclcpp_components_register_node(cuda_pointcloud_preprocessor
+  PLUGIN "autoware::cuda_pointcloud_preprocessor::CudaCropBoxFilterNode"
+  EXECUTABLE cuda_crop_box_filter_node
+)
+
+# ========== Random downsample filter ==========
+rclcpp_components_register_node(cuda_pointcloud_preprocessor
+  PLUGIN "autoware::cuda_pointcloud_preprocessor::CudaRandomDownsampleFilterNode"
+  EXECUTABLE cuda_random_downsample_filter_node
 )
 
 ################################################################################

--- a/sensing/autoware_cuda_pointcloud_preprocessor/CMakeLists.txt
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/CMakeLists.txt
@@ -82,6 +82,7 @@ cuda_add_library(cuda_pointcloud_preprocessor_lib SHARED
   src/cuda_downsample_filter/cuda_random_downsample_filter.cu
   src/cuda_outlier_filter/cuda_polar_voxel_outlier_filter.cu
   src/cuda_cropbox_filter/cuda_crop_box_filter.cu
+  src/cuda_pointcloud2costmap_filter/cuda_pointcloud2costmap_filter.cu
 )
 
 target_link_libraries(cuda_pointcloud_preprocessor_lib
@@ -102,6 +103,8 @@ target_include_directories(cuda_pointcloud_preprocessor_lib SYSTEM PRIVATE
   ${tf2_INCLUDE_DIRS}
   ${tf2_msgs_INCLUDE_DIRS}
   ${autoware_cuda_utils_INCLUDE_DIRS}
+  ${grid_map_ros_INCLUDE_DIRS}
+  ${grid_map_msgs_INCLUDE_DIRS}
 )
 
 if("$ENV{ENABLE_AGNOCAST}")
@@ -123,6 +126,7 @@ ament_auto_add_library(cuda_pointcloud_preprocessor SHARED
   src/cuda_downsample_filter/cuda_random_downsample_filter_node.cpp
   src/cuda_outlier_filter/cuda_polar_voxel_outlier_filter_node.cpp
   src/cuda_cropbox_filter/cuda_crop_box_filter_node.cpp
+  src/cuda_pointcloud2costmap_filter/cuda_pointcloud2costmap_filter_node.cpp
 )
 
 target_link_libraries(cuda_pointcloud_preprocessor
@@ -166,6 +170,12 @@ rclcpp_components_register_node(cuda_pointcloud_preprocessor
   EXECUTABLE cuda_random_downsample_filter_node
 )
 
+# ========== Pointcloud2Costmap filter ==========
+rclcpp_components_register_node(cuda_pointcloud_preprocessor
+  PLUGIN "autoware::cuda_pointcloud_preprocessor::CudaPointcloud2CostmapFilterNode"
+  EXECUTABLE cuda_pointcloud2costmap_filter_node
+)
+
 ################################################################################
 # Install
 install(DIRECTORY launch config
@@ -176,6 +186,65 @@ install(
   TARGETS cuda_pointcloud_preprocessor_lib
   LIBRARY DESTINATION lib
 )
+
+################################################################################
+# Tests
+if(BUILD_TESTING)
+    find_package(ament_cmake_gtest REQUIRED)
+    find_package(PCL REQUIRED)
+    ament_find_gtest()
+
+    # Test library for CUDA filters
+    cuda_add_library(test_cuda_pointcloud_preprocessor_lib SHARED
+      test/test_cuda_crop_box_filter.cu
+      test/test_cuda_random_downsample_filter.cu
+      test/test_cuda_pointcloud2costmap_filter.cu
+    )
+
+    target_link_libraries(test_cuda_pointcloud_preprocessor_lib
+      cuda_pointcloud_preprocessor_lib
+      ${CUDA_LIBRARIES}
+      ${PCL_LIBRARIES}
+    )
+
+    target_include_directories(test_cuda_pointcloud_preprocessor_lib SYSTEM PRIVATE
+      $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+      $<INSTALL_INTERFACE:include>
+      ${GTEST_INCLUDE_DIRS}
+      ${autoware_pointcloud_preprocessor_INCLUDE_DIRS}
+      ${autoware_point_types_INCLUDE_DIRS}
+      ${autoware_sensing_msgs_INCLUDE_DIRS}
+      ${cuda_blackboard_INCLUDE_DIRS}
+      ${sensor_msgs_INCLUDE_DIRS}
+      ${autoware_cuda_utils_INCLUDE_DIRS}
+      ${grid_map_ros_INCLUDE_DIRS}
+      ${grid_map_msgs_INCLUDE_DIRS}
+      ${PCL_INCLUDE_DIRS}
+    )
+
+    # Link dependencies from package.xml using ament_target_dependencies
+    # This ensures cuda_blackboard, autoware_cuda_utils, and autoware_pointcloud_preprocessor are linked
+    # autoware_pointcloud_preprocessor is needed to resolve undefined symbols from concatenate_data
+    # (which is transitively linked through cuda_pointcloud_preprocessor_lib)
+    ament_target_dependencies(test_cuda_pointcloud_preprocessor_lib
+      cuda_blackboard
+      autoware_cuda_utils
+      autoware_pointcloud_preprocessor
+    )
+
+    # Test executable that links to the test library
+    add_executable(test_cuda_pointcloud_preprocessor
+      test/test_main.cpp
+    )
+
+    target_link_libraries(test_cuda_pointcloud_preprocessor
+      test_cuda_pointcloud_preprocessor_lib
+      ${GTEST_LIBRARIES}
+      ${GTEST_MAIN_LIBRARIES}
+    )
+
+    ament_add_gtest_test(test_cuda_pointcloud_preprocessor)
+endif()
 
 ament_auto_package()
 

--- a/sensing/autoware_cuda_pointcloud_preprocessor/config/cuda_crop_box_filter.param.yaml
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/config/cuda_crop_box_filter.param.yaml
@@ -1,13 +1,11 @@
 /**:
   ros__parameters:
-    # Crop box parameters (arrays for multiple boxes)
-    min_x: [-1.0]
-    min_y: [-1.0]
-    min_z: [-1.0]
-    max_x: [1.0]
-    max_y: [1.0]
-    max_z: [1.0]
-    # Negative flag for each box (optional, defaults to false if not provided)
-    negative: [0]
+    min_x: -1.0
+    min_y: -1.0
+    min_z: -1.0
+    max_x: 1.0
+    max_y: 1.0
+    max_z: 1.0
+    negative: 1
     # Memory pool size in bytes (default: 1GB)
     max_mem_pool_size_in_byte: 1000000000

--- a/sensing/autoware_cuda_pointcloud_preprocessor/config/cuda_crop_box_filter.param.yaml
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/config/cuda_crop_box_filter.param.yaml
@@ -1,0 +1,13 @@
+/**:
+  ros__parameters:
+    # Crop box parameters (arrays for multiple boxes)
+    min_x: [-1.0]
+    min_y: [-1.0]
+    min_z: [-1.0]
+    max_x: [1.0]
+    max_y: [1.0]
+    max_z: [1.0]
+    # Negative flag for each box (optional, defaults to false if not provided)
+    negative: [0]
+    # Memory pool size in bytes (default: 1GB)
+    max_mem_pool_size_in_byte: 1000000000

--- a/sensing/autoware_cuda_pointcloud_preprocessor/config/cuda_crop_box_filter.param.yaml
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/config/cuda_crop_box_filter.param.yaml
@@ -1,11 +1,15 @@
 /**:
   ros__parameters:
+    # Crop box parameters (single box)
     min_x: -1.0
     min_y: -1.0
     min_z: -1.0
     max_x: 1.0
     max_y: 1.0
     max_z: 1.0
-    negative: 1
+    # Negative flag (false = keep points inside box, true = keep points outside box)
+    negative: true
+    # Force output to PointXYZIRCAEDT format (default: false, outputs PointXYZIRC)
+    output_point_xyzircaedt: false
     # Memory pool size in bytes (default: 1GB)
     max_mem_pool_size_in_byte: 1000000000

--- a/sensing/autoware_cuda_pointcloud_preprocessor/config/cuda_pointcloud2costmap_filter.param.yaml
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/config/cuda_pointcloud2costmap_filter.param.yaml
@@ -1,0 +1,18 @@
+/**:
+  ros__parameters:
+    # Costmap frame
+    costmap_frame: "map"
+    # Grid parameters
+    grid_length_x: 70.0  # [m]
+    grid_length_y: 70.0  # [m]
+    grid_resolution: 0.3  # [m]
+    grid_position_x: 0.0  # [m]
+    grid_position_y: 0.0  # [m]
+    # Height thresholds
+    maximum_height_thres: 2.5  # [m] ignore points with z value above this
+    minimum_height_thres: 0.0  # [m] ignore points with z value below this
+    # Costmap value range
+    grid_min_value: 0.0
+    grid_max_value: 1.0
+    # Memory pool size in bytes (default: 1GB)
+    max_mem_pool_size_in_byte: 1000000000

--- a/sensing/autoware_cuda_pointcloud_preprocessor/config/cuda_random_downsample_filter.param.yaml
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/config/cuda_random_downsample_filter.param.yaml
@@ -1,0 +1,6 @@
+/**:
+  ros__parameters:
+    # Number of points to sample
+    sample_num: 10000
+    # Memory pool size in bytes (default: 1GB)
+    max_mem_pool_size_in_byte: 1000000000

--- a/sensing/autoware_cuda_pointcloud_preprocessor/config/cuda_random_downsample_filter.param.yaml
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/config/cuda_random_downsample_filter.param.yaml
@@ -2,5 +2,7 @@
   ros__parameters:
     # Number of points to sample
     sample_num: 10000
+    # Force output to PointXYZIRCAEDT format (default: false, outputs PointXYZIRC)
+    output_point_xyzircaedt: false
     # Memory pool size in bytes (default: 1GB)
     max_mem_pool_size_in_byte: 1000000000

--- a/sensing/autoware_cuda_pointcloud_preprocessor/config/cuda_voxel_grid_downsample_filter.param.yaml
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/config/cuda_voxel_grid_downsample_filter.param.yaml
@@ -1,6 +1,10 @@
 /**:
   ros__parameters:
-
+    # Voxel size along each axis [m]
     voxel_size_x: 0.3
     voxel_size_y: 0.3
     voxel_size_z: 0.1
+    # Force output to PointXYZIRCAEDT format (default: false, outputs PointXYZIRC)
+    output_point_xyzircaedt: false
+    # Memory pool size in bytes (default: 1GB)
+    max_mem_pool_size_in_byte: 1000000000

--- a/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/common_kernels.hpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/common_kernels.hpp
@@ -40,6 +40,15 @@ void extractPointsLaunch(
   OutputPointType * output_points, int threads_per_block, int blocks_per_grid,
   cudaStream_t & stream);
 
+void extractInputPointsLaunch(
+  InputPointType * input_points, std::uint32_t * masks, std::uint32_t * indices, int num_points,
+  InputPointType * output_points, int threads_per_block, int blocks_per_grid,
+  cudaStream_t & stream);
+
+void convertPointXYZIRCToInputPointTypeLaunch(
+  const OutputPointType * input_points, InputPointType * output_points, int num_points,
+  int threads_per_block, int blocks_per_grid, cudaStream_t & stream);
+
 }  // namespace autoware::cuda_pointcloud_preprocessor
 
 #endif  // AUTOWARE__CUDA_POINTCLOUD_PREPROCESSOR__COMMON_KERNELS_HPP_

--- a/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_cropbox_filter/cuda_crop_box_filter.hpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_cropbox_filter/cuda_crop_box_filter.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef AUTOWARE__CUDA_POINTCLOUD_PREPROCESSOR__CUDA_FILTER__CUDA_CROP_BOX_FILTER_HPP_
-#define AUTOWARE__CUDA_POINTCLOUD_PREPROCESSOR__CUDA_FILTER__CUDA_CROP_BOX_FILTER_HPP_
+#ifndef AUTOWARE__CUDA_POINTCLOUD_PREPROCESSOR__CUDA_CROPBOX_FILTER__CUDA_CROP_BOX_FILTER_HPP_
+#define AUTOWARE__CUDA_POINTCLOUD_PREPROCESSOR__CUDA_CROPBOX_FILTER__CUDA_CROP_BOX_FILTER_HPP_
 
 #include "autoware/cuda_pointcloud_preprocessor/common_kernels.hpp"
 #include "autoware/cuda_pointcloud_preprocessor/point_types.hpp"
@@ -65,4 +65,4 @@ private:
 
 }  // namespace autoware::cuda_pointcloud_preprocessor
 
-#endif  // AUTOWARE__CUDA_POINTCLOUD_PREPROCESSOR__CUDA_FILTER__CUDA_CROP_BOX_FILTER_HPP_
+#endif  // AUTOWARE__CUDA_POINTCLOUD_PREPROCESSOR__CUDA_CROPBOX_FILTER__CUDA_CROP_BOX_FILTER_HPP_

--- a/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_cropbox_filter/cuda_crop_box_filter.hpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_cropbox_filter/cuda_crop_box_filter.hpp
@@ -1,0 +1,68 @@
+// Copyright 2025 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__CUDA_POINTCLOUD_PREPROCESSOR__CUDA_FILTER__CUDA_CROP_BOX_FILTER_HPP_
+#define AUTOWARE__CUDA_POINTCLOUD_PREPROCESSOR__CUDA_FILTER__CUDA_CROP_BOX_FILTER_HPP_
+
+#include "autoware/cuda_pointcloud_preprocessor/common_kernels.hpp"
+#include "autoware/cuda_pointcloud_preprocessor/point_types.hpp"
+#include "autoware/cuda_pointcloud_preprocessor/types.hpp"
+#include "autoware/cuda_utils/cuda_check_error.hpp"
+
+#include <cuda_blackboard/cuda_pointcloud2.hpp>
+#include <cuda_blackboard/cuda_unique_ptr.hpp>
+
+#include <cuda_runtime.h>
+#include <thrust/device_vector.h>
+#include <thrust/execution_policy.h>
+#include <thrust/fill.h>
+#include <thrust/scan.h>
+
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+namespace autoware::cuda_pointcloud_preprocessor
+{
+
+class CudaCropBoxFilter
+{
+public:
+  explicit CudaCropBoxFilter(
+    const CropBoxParameters crop_box_parameters, int64_t max_mem_pool_size_in_byte = 1e9,
+    bool output_point_xyzircaedt = false);
+  ~CudaCropBoxFilter() = default;
+
+  std::unique_ptr<cuda_blackboard::CudaPointCloud2> filter(
+    const cuda_blackboard::CudaPointCloud2::ConstSharedPtr & input_points);
+
+private:
+  template <typename T>
+  T * allocateBufferFromPool(size_t num_elements);
+
+  template <typename T>
+  void returnBufferToPool(T * buffer);
+
+  CropBoxParameters crop_box_parameters_;
+  bool output_point_xyzircaedt_;
+
+  cudaStream_t stream_{};
+  cudaMemPool_t mem_pool_{};
+
+  static constexpr int threads_per_block_ = 512;
+};
+
+}  // namespace autoware::cuda_pointcloud_preprocessor
+
+#endif  // AUTOWARE__CUDA_POINTCLOUD_PREPROCESSOR__CUDA_FILTER__CUDA_CROP_BOX_FILTER_HPP_

--- a/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_cropbox_filter/cuda_crop_box_filter_node.hpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_cropbox_filter/cuda_crop_box_filter_node.hpp
@@ -1,0 +1,50 @@
+// Copyright 2025 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__CUDA_POINTCLOUD_PREPROCESSOR__CUDA_FILTER__CUDA_CROP_BOX_FILTER_NODE_HPP_
+#define AUTOWARE__CUDA_POINTCLOUD_PREPROCESSOR__CUDA_FILTER__CUDA_CROP_BOX_FILTER_NODE_HPP_
+
+#include "cuda_crop_box_filter.hpp"
+
+#include <cuda_blackboard/cuda_adaptation.hpp>
+#include <cuda_blackboard/cuda_blackboard_publisher.hpp>
+#include <cuda_blackboard/cuda_blackboard_subscriber.hpp>
+#include <cuda_blackboard/cuda_pointcloud2.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+#include <memory>
+
+namespace autoware::cuda_pointcloud_preprocessor
+{
+class CudaCropBoxFilterNode : public rclcpp::Node
+{
+public:
+  explicit CudaCropBoxFilterNode(const rclcpp::NodeOptions & node_options);
+
+private:
+  void cudaPointcloudCallback(const cuda_blackboard::CudaPointCloud2::ConstSharedPtr msg);
+
+  // CUDA sub
+  std::shared_ptr<cuda_blackboard::CudaBlackboardSubscriber<cuda_blackboard::CudaPointCloud2>>
+    sub_{};
+
+  // CUDA pub
+  std::unique_ptr<cuda_blackboard::CudaBlackboardPublisher<cuda_blackboard::CudaPointCloud2>>
+    pub_{};
+
+  std::unique_ptr<CudaCropBoxFilter> cuda_crop_box_filter_{};
+};
+}  // namespace autoware::cuda_pointcloud_preprocessor
+
+#endif  // AUTOWARE__CUDA_POINTCLOUD_PREPROCESSOR__CUDA_FILTER__CUDA_CROP_BOX_FILTER_NODE_HPP_

--- a/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_downsample_filter/cuda_random_downsample_filter.hpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_downsample_filter/cuda_random_downsample_filter.hpp
@@ -1,0 +1,60 @@
+// Copyright 2025 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__CUDA_POINTCLOUD_PREPROCESSOR__CUDA_DOWNSAMPLE_FILTER__CUDA_RANDOM_DOWNSAMPLE_FILTER_HPP_
+#define AUTOWARE__CUDA_POINTCLOUD_PREPROCESSOR__CUDA_DOWNSAMPLE_FILTER__CUDA_RANDOM_DOWNSAMPLE_FILTER_HPP_
+
+#include "autoware/cuda_pointcloud_preprocessor/point_types.hpp"
+#include "autoware/cuda_utils/cuda_check_error.hpp"
+
+#include <cuda_blackboard/cuda_pointcloud2.hpp>
+#include <cuda_blackboard/cuda_unique_ptr.hpp>
+
+#include <cuda_runtime.h>
+
+#include <cstdint>
+#include <memory>
+
+namespace autoware::cuda_pointcloud_preprocessor
+{
+
+class CudaRandomDownsampleFilter
+{
+public:
+  explicit CudaRandomDownsampleFilter(
+    size_t sample_num, int64_t max_mem_pool_size_in_byte = 1e9,
+    bool output_point_xyzircaedt = false);
+  ~CudaRandomDownsampleFilter() = default;
+
+  std::unique_ptr<cuda_blackboard::CudaPointCloud2> filter(
+    const cuda_blackboard::CudaPointCloud2::ConstSharedPtr & input_points);
+
+private:
+  template <typename T>
+  T * allocateBufferFromPool(size_t num_elements);
+
+  template <typename T>
+  void returnBufferToPool(T * buffer);
+
+  size_t sample_num_;
+  bool output_point_xyzircaedt_;
+  cudaStream_t stream_{};
+  cudaMemPool_t mem_pool_{};
+
+  static constexpr int threads_per_block_ = 512;
+};
+
+}  // namespace autoware::cuda_pointcloud_preprocessor
+
+#endif  // AUTOWARE__CUDA_POINTCLOUD_PREPROCESSOR__CUDA_DOWNSAMPLE_FILTER__CUDA_RANDOM_DOWNSAMPLE_FILTER_HPP_

--- a/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_downsample_filter/cuda_random_downsample_filter_node.hpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_downsample_filter/cuda_random_downsample_filter_node.hpp
@@ -1,0 +1,50 @@
+// Copyright 2025 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__CUDA_POINTCLOUD_PREPROCESSOR__CUDA_DOWNSAMPLE_FILTER__CUDA_RANDOM_DOWNSAMPLE_FILTER_NODE_HPP_
+#define AUTOWARE__CUDA_POINTCLOUD_PREPROCESSOR__CUDA_DOWNSAMPLE_FILTER__CUDA_RANDOM_DOWNSAMPLE_FILTER_NODE_HPP_
+
+#include "cuda_random_downsample_filter.hpp"
+
+#include <cuda_blackboard/cuda_adaptation.hpp>
+#include <cuda_blackboard/cuda_blackboard_publisher.hpp>
+#include <cuda_blackboard/cuda_blackboard_subscriber.hpp>
+#include <cuda_blackboard/cuda_pointcloud2.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+#include <memory>
+
+namespace autoware::cuda_pointcloud_preprocessor
+{
+class CudaRandomDownsampleFilterNode : public rclcpp::Node
+{
+public:
+  explicit CudaRandomDownsampleFilterNode(const rclcpp::NodeOptions & node_options);
+
+private:
+  void cudaPointcloudCallback(const cuda_blackboard::CudaPointCloud2::ConstSharedPtr msg);
+
+  // CUDA sub
+  std::shared_ptr<cuda_blackboard::CudaBlackboardSubscriber<cuda_blackboard::CudaPointCloud2>>
+    sub_{};
+
+  // CUDA pub
+  std::unique_ptr<cuda_blackboard::CudaBlackboardPublisher<cuda_blackboard::CudaPointCloud2>>
+    pub_{};
+
+  std::unique_ptr<CudaRandomDownsampleFilter> cuda_random_downsample_filter_{};
+};
+}  // namespace autoware::cuda_pointcloud_preprocessor
+
+#endif  // AUTOWARE__CUDA_POINTCLOUD_PREPROCESSOR__CUDA_DOWNSAMPLE_FILTER__CUDA_RANDOM_DOWNSAMPLE_FILTER_NODE_HPP_

--- a/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_downsample_filter/cuda_voxel_grid_downsample_filter.hpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_downsample_filter/cuda_voxel_grid_downsample_filter.hpp
@@ -85,7 +85,7 @@ public:
 
   explicit CudaVoxelGridDownsampleFilter(
     const float voxel_size_x, const float voxel_size_y, const float voxel_size_z,
-    const int64_t max_mem_pool_size_in_byte);
+    const int64_t max_mem_pool_size_in_byte, bool output_point_xyzircaedt = false);
   ~CudaVoxelGridDownsampleFilter() = default;
 
   std::unique_ptr<cuda_blackboard::CudaPointCloud2> filter(
@@ -114,6 +114,7 @@ private:
     decltype(OutputPointType::channel) * channel_field_dev);
 
   VoxelInfo voxel_info_{};
+  bool output_point_xyzircaedt_;
 
   cudaStream_t stream_{};
   cudaMemPool_t mem_pool_{};

--- a/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_pointcloud2costmap_filter/cuda_pointcloud2costmap_filter.hpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_pointcloud2costmap_filter/cuda_pointcloud2costmap_filter.hpp
@@ -1,0 +1,122 @@
+// Copyright 2025 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__CUDA_POINTCLOUD_PREPROCESSOR__CUDA_POINTCLOUD2COSTMAP_FILTER__CUDA_POINTCLOUD2COSTMAP_FILTER_HPP_
+#define AUTOWARE__CUDA_POINTCLOUD_PREPROCESSOR__CUDA_POINTCLOUD2COSTMAP_FILTER__CUDA_POINTCLOUD2COSTMAP_FILTER_HPP_
+
+#include "autoware/cuda_pointcloud_preprocessor/point_types.hpp"
+#include "autoware/cuda_pointcloud_preprocessor/types.hpp"
+#include "autoware/cuda_utils/cuda_check_error.hpp"
+
+#include <cuda_blackboard/cuda_pointcloud2.hpp>
+#include <cuda_blackboard/cuda_unique_ptr.hpp>
+#include <grid_map_ros/grid_map_ros.hpp>
+
+#include <cuda_runtime.h>
+#include <thrust/device_ptr.h>
+#include <thrust/device_vector.h>
+#include <thrust/execution_policy.h>
+#include <thrust/fill.h>
+#include <thrust/reduce.h>
+#include <thrust/sort.h>
+
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+namespace autoware::cuda_pointcloud_preprocessor
+{
+
+// CUDA kernel parameters struct (device-side)
+struct CostmapGridParams
+{
+  float grid_length_x;
+  float grid_length_y;
+  float grid_resolution;
+  float grid_position_x;
+  float grid_position_y;
+  float maximum_height_thres;
+  float minimum_height_thres;
+  float grid_min_value;
+  float grid_max_value;
+  int32_t grid_size_x;
+  int32_t grid_size_y;
+};
+
+// Host-side costmap parameters struct
+struct CostmapParameters
+{
+  double grid_length_x;
+  double grid_length_y;
+  double grid_resolution;
+  double grid_position_x;
+  double grid_position_y;
+  double maximum_height_thres;
+  double minimum_height_thres;
+  double grid_min_value;
+  double grid_max_value;
+};
+
+struct GridCellData
+{
+  float z_min;
+  float z_max;
+  int32_t point_count;
+};
+
+class CudaPointcloud2CostmapFilter
+{
+public:
+  explicit CudaPointcloud2CostmapFilter(
+    const CostmapParameters & costmap_parameters, int64_t max_mem_pool_size_in_byte = 1e9);
+  ~CudaPointcloud2CostmapFilter() = default;
+
+  /// \brief Generate costmap from pointcloud
+  /// \param[in] input_points: Input pointcloud in costmap frame
+  /// \param[out] costmap_matrix: Output costmap as grid_map::Matrix
+  void generateCostmap(
+    const cuda_blackboard::CudaPointCloud2::ConstSharedPtr & input_points,
+    grid_map::Matrix & costmap_matrix);
+
+private:
+  template <typename T>
+  T * allocateBufferFromPool(size_t num_elements);
+
+  template <typename T>
+  void returnBufferToPool(T * buffer);
+
+  CostmapParameters costmap_parameters_;
+  int32_t grid_size_x_;
+  int32_t grid_size_y_;
+
+  cudaStream_t stream_{};
+  cudaMemPool_t mem_pool_{};
+
+  static constexpr int threads_per_block_ = 512;
+};
+
+// CUDA kernel launch functions
+void assignPointsToGridCellsLaunch(
+  const InputPointType * input_points, int32_t * grid_indices, int num_points,
+  const CostmapGridParams * params, int threads_per_block, int blocks_per_grid,
+  cudaStream_t & stream);
+
+void calculateCostmapFromGridCellsLaunch(
+  const InputPointType * input_points, const int32_t * grid_indices, float * costmap_data,
+  int num_points, const CostmapGridParams * params, int threads_per_block, int blocks_per_grid,
+  cudaStream_t & stream);
+
+}  // namespace autoware::cuda_pointcloud_preprocessor
+
+#endif  // AUTOWARE__CUDA_POINTCLOUD_PREPROCESSOR__CUDA_POINTCLOUD2COSTMAP_FILTER__CUDA_POINTCLOUD2COSTMAP_FILTER_HPP_

--- a/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_pointcloud2costmap_filter/cuda_pointcloud2costmap_filter_node.hpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_pointcloud2costmap_filter/cuda_pointcloud2costmap_filter_node.hpp
@@ -12,25 +12,29 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef AUTOWARE__CUDA_POINTCLOUD_PREPROCESSOR__CUDA_CROPBOX_FILTER__CUDA_CROP_BOX_FILTER_NODE_HPP_
-#define AUTOWARE__CUDA_POINTCLOUD_PREPROCESSOR__CUDA_CROPBOX_FILTER__CUDA_CROP_BOX_FILTER_NODE_HPP_
+#ifndef AUTOWARE__CUDA_POINTCLOUD_PREPROCESSOR__CUDA_POINTCLOUD2COSTMAP_FILTER__CUDA_POINTCLOUD2COSTMAP_FILTER_NODE_HPP_
+#define AUTOWARE__CUDA_POINTCLOUD_PREPROCESSOR__CUDA_POINTCLOUD2COSTMAP_FILTER__CUDA_POINTCLOUD2COSTMAP_FILTER_NODE_HPP_
 
-#include "cuda_crop_box_filter.hpp"
+#include "cuda_pointcloud2costmap_filter.hpp"
 
 #include <cuda_blackboard/cuda_adaptation.hpp>
 #include <cuda_blackboard/cuda_blackboard_publisher.hpp>
 #include <cuda_blackboard/cuda_blackboard_subscriber.hpp>
 #include <cuda_blackboard/cuda_pointcloud2.hpp>
+#include <grid_map_ros/GridMapRosConverter.hpp>
 #include <rclcpp/rclcpp.hpp>
 
+#include <grid_map_msgs/msg/grid_map.hpp>
+
 #include <memory>
+#include <string>
 
 namespace autoware::cuda_pointcloud_preprocessor
 {
-class CudaCropBoxFilterNode : public rclcpp::Node
+class CudaPointcloud2CostmapFilterNode : public rclcpp::Node
 {
 public:
-  explicit CudaCropBoxFilterNode(const rclcpp::NodeOptions & node_options);
+  explicit CudaPointcloud2CostmapFilterNode(const rclcpp::NodeOptions & node_options);
 
 private:
   void cudaPointcloudCallback(const cuda_blackboard::CudaPointCloud2::ConstSharedPtr msg);
@@ -39,12 +43,15 @@ private:
   std::shared_ptr<cuda_blackboard::CudaBlackboardSubscriber<cuda_blackboard::CudaPointCloud2>>
     sub_{};
 
-  // CUDA pub
-  std::unique_ptr<cuda_blackboard::CudaBlackboardPublisher<cuda_blackboard::CudaPointCloud2>>
-    pub_{};
+  // ROS pub for grid_map
+  rclcpp::Publisher<grid_map_msgs::msg::GridMap>::SharedPtr pub_costmap_{};
 
-  std::unique_ptr<CudaCropBoxFilter> cuda_crop_box_filter_{};
+  std::unique_ptr<CudaPointcloud2CostmapFilter> cuda_pointcloud2costmap_filter_{};
+
+  // Costmap parameters
+  CostmapParameters costmap_params_;
+  std::string costmap_frame_;
 };
 }  // namespace autoware::cuda_pointcloud_preprocessor
 
-#endif  // AUTOWARE__CUDA_POINTCLOUD_PREPROCESSOR__CUDA_CROPBOX_FILTER__CUDA_CROP_BOX_FILTER_NODE_HPP_
+#endif  // AUTOWARE__CUDA_POINTCLOUD_PREPROCESSOR__CUDA_POINTCLOUD2COSTMAP_FILTER__CUDA_POINTCLOUD2COSTMAP_FILTER_NODE_HPP_

--- a/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/types.hpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/types.hpp
@@ -17,6 +17,7 @@
 
 #include <cmath>
 #include <cstdint>
+#include <type_traits>
 
 namespace autoware::cuda_pointcloud_preprocessor
 {
@@ -67,7 +68,23 @@ struct CropBoxParameters
   float max_y;
   float min_z;
   float max_z;
+  std::uint8_t negative;  // if 1, remove points within the box from the pointcloud; otherwise (0),
+                          // remove points outside the box.
+
+  // Explicitly default constructor and destructor to ensure triviality for Thrust compatibility
+  CropBoxParameters() = default;
+  ~CropBoxParameters() = default;
+  CropBoxParameters(const CropBoxParameters &) = default;
+  CropBoxParameters & operator=(const CropBoxParameters &) = default;
 };
+
+// Verify at compile time that CropBoxParameters is compatible with Thrust device_vector
+static_assert(
+  std::is_trivially_destructible<CropBoxParameters>::value,
+  "CropBoxParameters must be trivially destructible for device_vector");
+static_assert(
+  std::is_trivially_copyable<CropBoxParameters>::value,
+  "CropBoxParameters must be trivially copyable for device_vector");
 
 struct RingOutlierFilterParameters
 {

--- a/sensing/autoware_cuda_pointcloud_preprocessor/launch/cuda_crop_box_filter.launch.xml
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/launch/cuda_crop_box_filter.launch.xml
@@ -1,0 +1,22 @@
+<launch>
+  <arg name="input/pointcloud" default="/sensing/lidar/top/pointcloud_raw"/>
+  <arg name="output/pointcloud" default="/sensing/lidar/top/cropped"/>
+  <arg name="debug" default="false">
+    <choice value="true"/>
+    <choice value="false"/>
+  </arg>
+
+  <arg name="cuda_crop_box_filter_param_file" default="$(find-pkg-share autoware_cuda_pointcloud_preprocessor)/config/cuda_crop_box_filter.param.yaml"/>
+
+  <node pkg="autoware_cuda_pointcloud_preprocessor" exec="cuda_crop_box_filter_node" name="cuda_crop_box_filter" output="screen" unless="$(var debug)">
+    <remap from="~/input/pointcloud" to="$(var input/pointcloud)"/>
+    <remap from="~/output/pointcloud" to="$(var output/pointcloud)"/>
+    <param from="$(var cuda_crop_box_filter_param_file)"/>
+  </node>
+
+  <node pkg="autoware_cuda_pointcloud_preprocessor" exec="cuda_crop_box_filter_node" name="cuda_crop_box_filter" output="screen" launch-prefix="gnome-terminal -- cuda-gdb --args" if="$(var debug)">
+    <remap from="~/input/pointcloud" to="$(var input/pointcloud)"/>
+    <remap from="~/output/pointcloud" to="$(var output/pointcloud)"/>
+    <param from="$(var cuda_crop_box_filter_param_file)"/>
+  </node>
+</launch>

--- a/sensing/autoware_cuda_pointcloud_preprocessor/launch/cuda_pointcloud2costmap_filter.launch.xml
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/launch/cuda_pointcloud2costmap_filter.launch.xml
@@ -1,0 +1,29 @@
+<launch>
+  <arg name="input/pointcloud" default="/sensing/lidar/top/pointcloud_raw"/>
+  <arg name="output/grid_map" default="/perception/costmap_generator/cuda_costmap"/>
+  <arg name="debug" default="false">
+    <choice value="true"/>
+    <choice value="false"/>
+  </arg>
+
+  <arg name="cuda_pointcloud2costmap_filter_param_file" default="$(find-pkg-share autoware_cuda_pointcloud_preprocessor)/config/cuda_pointcloud2costmap_filter.param.yaml"/>
+
+  <node pkg="autoware_cuda_pointcloud_preprocessor" exec="cuda_pointcloud2costmap_filter_node" name="cuda_pointcloud2costmap_filter" output="screen" unless="$(var debug)">
+    <remap from="~/input/pointcloud" to="$(var input/pointcloud)"/>
+    <remap from="~/output/grid_map" to="$(var output/grid_map)"/>
+    <param from="$(var cuda_pointcloud2costmap_filter_param_file)"/>
+  </node>
+
+  <node
+    pkg="autoware_cuda_pointcloud_preprocessor"
+    exec="cuda_pointcloud2costmap_filter_node"
+    name="cuda_pointcloud2costmap_filter"
+    output="screen"
+    launch-prefix="gnome-terminal -- cuda-gdb --args"
+    if="$(var debug)"
+  >
+    <remap from="~/input/pointcloud" to="$(var input/pointcloud)"/>
+    <remap from="~/output/grid_map" to="$(var output/grid_map)"/>
+    <param from="$(var cuda_pointcloud2costmap_filter_param_file)"/>
+  </node>
+</launch>

--- a/sensing/autoware_cuda_pointcloud_preprocessor/launch/cuda_random_downsample_filter.launch.xml
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/launch/cuda_random_downsample_filter.launch.xml
@@ -1,0 +1,29 @@
+<launch>
+  <arg name="input/pointcloud" default="/sensing/lidar/top/pointcloud_raw"/>
+  <arg name="output/pointcloud" default="/sensing/lidar/top/random_downsampled"/>
+  <arg name="debug" default="false">
+    <choice value="true"/>
+    <choice value="false"/>
+  </arg>
+
+  <arg name="cuda_random_downsample_filter_param_file" default="$(find-pkg-share autoware_cuda_pointcloud_preprocessor)/config/cuda_random_downsample_filter.param.yaml"/>
+
+  <node pkg="autoware_cuda_pointcloud_preprocessor" exec="cuda_random_downsample_filter_node" name="cuda_random_downsample_filter" output="screen" unless="$(var debug)">
+    <remap from="~/input/pointcloud" to="$(var input/pointcloud)"/>
+    <remap from="~/output/pointcloud" to="$(var output/pointcloud)"/>
+    <param from="$(var cuda_random_downsample_filter_param_file)"/>
+  </node>
+
+  <node
+    pkg="autoware_cuda_pointcloud_preprocessor"
+    exec="cuda_random_downsample_filter_node"
+    name="cuda_random_downsample_filter"
+    output="screen"
+    launch-prefix="gnome-terminal -- cuda-gdb --args"
+    if="$(var debug)"
+  >
+    <remap from="~/input/pointcloud" to="$(var input/pointcloud)"/>
+    <remap from="~/output/pointcloud" to="$(var output/pointcloud)"/>
+    <param from="$(var cuda_random_downsample_filter_param_file)"/>
+  </node>
+</launch>

--- a/sensing/autoware_cuda_pointcloud_preprocessor/package.xml
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/package.xml
@@ -25,6 +25,8 @@
   <depend>autoware_utils</depend>
   <depend>cuda_blackboard</depend>
   <depend>diagnostic_msgs</depend>
+  <depend>grid_map_msgs</depend>
+  <depend>grid_map_ros</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>sensor_msgs</depend>

--- a/sensing/autoware_cuda_pointcloud_preprocessor/schema/cuda_crop_box_filter.schema.json
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/schema/cuda_crop_box_filter.schema.json
@@ -1,0 +1,74 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Parameters for the cuda_crop_box_filter",
+  "type": "object",
+  "definitions": {
+    "cuda_crop_box_filter": {
+      "type": "object",
+      "properties": {
+        "min_x": {
+          "type": "number",
+          "description": "Minimum x value of the crop box [m]",
+          "default": -1.0
+        },
+        "min_y": {
+          "type": "number",
+          "description": "Minimum y value of the crop box [m]",
+          "default": -1.0
+        },
+        "min_z": {
+          "type": "number",
+          "description": "Minimum z value of the crop box [m]",
+          "default": -1.0
+        },
+        "max_x": {
+          "type": "number",
+          "description": "Maximum x value of the crop box [m]",
+          "default": 1.0
+        },
+        "max_y": {
+          "type": "number",
+          "description": "Maximum y value of the crop box [m]",
+          "default": 1.0
+        },
+        "max_z": {
+          "type": "number",
+          "description": "Maximum z value of the crop box [m]",
+          "default": 1.0
+        },
+        "negative": {
+          "type": "boolean",
+          "description": "If false, keep points inside the box. If true, keep points outside the box.",
+          "default": false
+        },
+        "output_point_xyzircaedt": {
+          "type": "boolean",
+          "description": "Force output to PointXYZIRCAEDT format for continuous CUDA processing. If false, outputs PointXYZIRC format for Autoware .",
+          "default": false
+        },
+        "max_mem_pool_size_in_byte": {
+          "type": "number",
+          "description": "Maximum size of GPU memory pool [bytes]",
+          "default": 1000000000,
+          "minimum": 0
+        }
+      },
+      "required": ["min_x", "min_y", "min_z", "max_x", "max_y", "max_z", "negative"],
+      "additionalProperties": false
+    }
+  },
+  "properties": {
+    "/**": {
+      "type": "object",
+      "properties": {
+        "ros__parameters": {
+          "$ref": "#/definitions/cuda_crop_box_filter"
+        }
+      },
+      "required": ["ros__parameters"],
+      "additionalProperties": false
+    }
+  },
+  "required": ["/**"],
+  "additionalProperties": false
+}

--- a/sensing/autoware_cuda_pointcloud_preprocessor/schema/cuda_random_downsample_filter.schema.json
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/schema/cuda_random_downsample_filter.schema.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Parameters for the cuda_random_downsample_filter",
+  "type": "object",
+  "definitions": {
+    "cuda_random_downsample_filter": {
+      "type": "object",
+      "properties": {
+        "sample_num": {
+          "type": "integer",
+          "description": "Number of points to randomly sample from the input point cloud",
+          "default": 10000,
+          "minimum": 1
+        },
+        "output_point_xyzircaedt": {
+          "type": "boolean",
+          "description": "Force output to PointXYZIRCAEDT format for continuous CUDA processing. If false, outputs PointXYZIRC format for Autoware usage.",
+          "default": false
+        },
+        "max_mem_pool_size_in_byte": {
+          "type": "number",
+          "description": "Maximum size of GPU memory pool [bytes]",
+          "default": 1000000000,
+          "minimum": 0
+        }
+      },
+      "required": ["sample_num"],
+      "additionalProperties": false
+    }
+  },
+  "properties": {
+    "/**": {
+      "type": "object",
+      "properties": {
+        "ros__parameters": {
+          "$ref": "#/definitions/cuda_random_downsample_filter"
+        }
+      },
+      "required": ["ros__parameters"],
+      "additionalProperties": false
+    }
+  },
+  "required": ["/**"],
+  "additionalProperties": false
+}

--- a/sensing/autoware_cuda_pointcloud_preprocessor/schema/cuda_voxel_grid_downsample_filter.schema.json
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/schema/cuda_voxel_grid_downsample_filter.schema.json
@@ -26,9 +26,14 @@
         },
         "max_mem_pool_size_in_byte": {
           "type": "number",
-          "description": "maximum size of GPU memory pool",
-          "default": "1000000000",
+          "description": "Maximum size of GPU memory pool [bytes]",
+          "default": 1000000000,
           "minimum": 0
+        },
+        "output_point_xyzircaedt": {
+          "type": "boolean",
+          "description": "Force output to PointXYZIRCAEDT format for continuous CUDA processing. If false, outputs PointXYZIRC format for Autoware usage.",
+          "default": false
         }
       },
       "required": ["voxel_size_x", "voxel_size_y", "voxel_size_z"],

--- a/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_cropbox_filter/cuda_crop_box_filter.cu
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_cropbox_filter/cuda_crop_box_filter.cu
@@ -1,0 +1,267 @@
+// Copyright 2025 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/cuda_pointcloud_preprocessor/common_kernels.hpp"
+#include "autoware/cuda_pointcloud_preprocessor/cuda_cropbox_filter/cuda_crop_box_filter.hpp"
+#include "autoware/cuda_pointcloud_preprocessor/point_types.hpp"
+#include "autoware/cuda_pointcloud_preprocessor/types.hpp"
+#include "autoware/cuda_utils/cuda_check_error.hpp"
+
+#include <sensor_msgs/msg/point_field.hpp>
+
+#include <thrust/device_ptr.h>
+#include <thrust/device_vector.h>
+#include <thrust/execution_policy.h>
+#include <thrust/fill.h>
+#include <thrust/scan.h>
+
+#include <cstdint>
+#include <memory>
+#include <string>
+
+namespace autoware::cuda_pointcloud_preprocessor
+{
+
+CudaCropBoxFilter::CudaCropBoxFilter(
+  const CropBoxParameters crop_box_parameters, int64_t max_mem_pool_size_in_byte,
+  bool output_point_xyzircaedt)
+: crop_box_parameters_(crop_box_parameters), output_point_xyzircaedt_(output_point_xyzircaedt)
+{
+  CHECK_CUDA_ERROR(cudaStreamCreate(&stream_));
+
+  // Create memory pool to make repeated allocation efficient
+  {
+    int current_device_id = 0;
+    CHECK_CUDA_ERROR(cudaGetDevice(&current_device_id));
+    cudaMemPoolProps pool_props = {};
+    pool_props.allocType = cudaMemAllocationTypePinned;
+    pool_props.location.id = current_device_id;
+    pool_props.location.type = cudaMemLocationTypeDevice;
+    CHECK_CUDA_ERROR(cudaMemPoolCreate(&mem_pool_, &pool_props));
+
+    // Configure the memory pool reusing allocation
+    uint64_t pool_release_threshold = max_mem_pool_size_in_byte;
+    CHECK_CUDA_ERROR(cudaMemPoolSetAttribute(
+      mem_pool_, cudaMemPoolAttrReleaseThreshold, static_cast<void *>(&pool_release_threshold)));
+  }
+}
+
+template <typename T>
+T * CudaCropBoxFilter::allocateBufferFromPool(size_t num_elements)
+{
+  T * buffer{};
+  CHECK_CUDA_ERROR(cudaMallocFromPoolAsync(&buffer, num_elements * sizeof(T), mem_pool_, stream_));
+  CHECK_CUDA_ERROR(cudaMemsetAsync(buffer, 0, num_elements * sizeof(T), stream_));
+  return buffer;
+}
+
+template <typename T>
+void CudaCropBoxFilter::returnBufferToPool(T * buffer)
+{
+  CHECK_CUDA_ERROR(cudaFreeAsync(buffer, stream_));
+}
+
+std::unique_ptr<cuda_blackboard::CudaPointCloud2> CudaCropBoxFilter::filter(
+  const cuda_blackboard::CudaPointCloud2::ConstSharedPtr & input_points)
+{
+  const size_t num_points = input_points->width * input_points->height;
+
+  if (num_points == 0) {
+    auto output = std::make_unique<cuda_blackboard::CudaPointCloud2>();
+    output->header = input_points->header;
+    output->width = 0;
+    output->height = 1;
+    output->fields = input_points->fields;
+    output->is_bigendian = input_points->is_bigendian;
+    output->point_step = input_points->point_step;
+    output->row_step = 0;
+    output->is_dense = input_points->is_dense;
+    output->data.reset();
+    return output;
+  }
+
+  // Validate that data pointer is not null
+  if (!input_points->data) {
+    throw std::runtime_error("Input pointcloud data pointer is null.");
+  }
+
+  // Check input format and handle conversion if needed
+  const bool is_point_xyzirc = (input_points->point_step == sizeof(OutputPointType));
+  const bool is_point_xyzircaedt = (input_points->point_step == sizeof(InputPointType));
+
+  if (!is_point_xyzirc && !is_point_xyzircaedt) {
+    throw std::runtime_error(
+      "Input pointcloud point_step does not match expected format. "
+      "Expected PointXYZIRC (" +
+      std::to_string(sizeof(OutputPointType)) + " bytes) or PointXYZIRCAEDT (" +
+      std::to_string(sizeof(InputPointType)) + " bytes), but got " +
+      std::to_string(input_points->point_step) + " bytes.");
+  }
+
+  // Allocate device buffers
+  InputPointType * device_input_points = allocateBufferFromPool<InputPointType>(num_points);
+  std::uint32_t * device_crop_mask = allocateBufferFromPool<std::uint32_t>(num_points);
+  std::uint8_t * device_nan_mask = allocateBufferFromPool<std::uint8_t>(num_points);
+  std::uint32_t * device_indices = allocateBufferFromPool<std::uint32_t>(num_points);
+  CropBoxParameters * device_crop_box_params = allocateBufferFromPool<CropBoxParameters>(1);
+
+  // Copy and convert input points to device
+  // Note: cuda_blackboard::CudaPointCloud2::data is already on device memory when received
+  // from CudaBlackboardSubscriber, so we use DeviceToDevice copy
+  if (is_point_xyzirc) {
+    // Convert PointXYZIRC to PointXYZIRCAEDT format
+    OutputPointType * device_temp_points = allocateBufferFromPool<OutputPointType>(num_points);
+    CHECK_CUDA_ERROR(cudaMemcpyAsync(
+      device_temp_points, input_points->data.get(), num_points * sizeof(OutputPointType),
+      cudaMemcpyDeviceToDevice, stream_));
+
+    // Convert to InputPointType format
+    const int blocks_per_grid_convert = (num_points + threads_per_block_ - 1) / threads_per_block_;
+    convertPointXYZIRCToInputPointTypeLaunch(
+      device_temp_points, device_input_points, static_cast<int>(num_points), threads_per_block_,
+      blocks_per_grid_convert, stream_);
+
+    // Free temporary buffer
+    returnBufferToPool(device_temp_points);
+  } else {
+    // Direct copy for PointXYZIRCAEDT format
+    CHECK_CUDA_ERROR(cudaMemcpyAsync(
+      device_input_points, input_points->data.get(), num_points * sizeof(InputPointType),
+      cudaMemcpyDeviceToDevice, stream_));
+  }
+
+  // Copy crop box parameters to device
+  CHECK_CUDA_ERROR(cudaMemcpyAsync(
+    device_crop_box_params, &crop_box_parameters_, sizeof(CropBoxParameters),
+    cudaMemcpyHostToDevice, stream_));
+
+  // Initialize masks
+  thrust::fill(
+    thrust::cuda::par_nosync.on(stream_), thrust::device_ptr<std::uint32_t>(device_crop_mask),
+    thrust::device_ptr<std::uint32_t>(device_crop_mask + num_points), 0U);
+  thrust::fill(
+    thrust::cuda::par_nosync.on(stream_), thrust::device_ptr<std::uint8_t>(device_nan_mask),
+    thrust::device_ptr<std::uint8_t>(device_nan_mask + num_points), 0);
+
+  // Launch crop box kernel
+  const int blocks_per_grid = (num_points + threads_per_block_ - 1) / threads_per_block_;
+  cropBoxLaunch(
+    device_input_points, device_crop_mask, device_nan_mask, static_cast<int>(num_points),
+    device_crop_box_params, 1, threads_per_block_, blocks_per_grid, stream_);
+
+  // Compute indices for output points using inclusive scan
+  thrust::inclusive_scan(
+    thrust::cuda::par_nosync.on(stream_), thrust::device_ptr<std::uint32_t>(device_crop_mask),
+    thrust::device_ptr<std::uint32_t>(device_crop_mask + num_points),
+    thrust::device_ptr<std::uint32_t>(device_indices));
+
+  // Get number of output points
+  int num_output_points = 0;
+  if (num_points > 0) {
+    CHECK_CUDA_ERROR(cudaMemcpyAsync(
+      &num_output_points, device_indices + num_points - 1, sizeof(int), cudaMemcpyDeviceToHost,
+      stream_));
+  }
+
+  CHECK_CUDA_ERROR(cudaStreamSynchronize(stream_));
+
+  // Allocate output point cloud
+  auto output = std::make_unique<cuda_blackboard::CudaPointCloud2>();
+  if (num_output_points > 0) {
+    if (output_point_xyzircaedt_) {
+      // Output PointXYZIRCAEDT format
+      output->data =
+        cuda_blackboard::make_unique<std::uint8_t[]>(num_output_points * sizeof(InputPointType));
+
+      // Extract points directly using the already-allocated device buffers
+      const int blocks_per_grid_extract =
+        (num_points + threads_per_block_ - 1) / threads_per_block_;
+      extractInputPointsLaunch(
+        device_input_points, device_crop_mask, device_indices, static_cast<int>(num_points),
+        reinterpret_cast<InputPointType *>(output->data.get()), threads_per_block_,
+        blocks_per_grid_extract, stream_);
+    } else {
+      // Output PointXYZIRC format (default)
+      output->data =
+        cuda_blackboard::make_unique<std::uint8_t[]>(num_output_points * sizeof(OutputPointType));
+
+      // Extract points directly using the already-allocated device buffers
+      const int blocks_per_grid_extract =
+        (num_points + threads_per_block_ - 1) / threads_per_block_;
+      extractPointsLaunch(
+        device_input_points, device_crop_mask, device_indices, static_cast<int>(num_points),
+        reinterpret_cast<OutputPointType *>(output->data.get()), threads_per_block_,
+        blocks_per_grid_extract, stream_);
+    }
+  } else {
+    output->data.reset();
+  }
+
+  // Set output metadata
+  output->header = input_points->header;
+  output->width = num_output_points;
+  output->height = 1;
+  output->point_step = output_point_xyzircaedt_ ? sizeof(InputPointType) : sizeof(OutputPointType);
+  output->row_step = num_output_points * output->point_step;
+  output->is_dense = true;
+  output->is_bigendian = input_points->is_bigendian;
+
+  // Set point fields
+  auto make_point_field = [](
+                            const std::string name, const uint32_t offset, const uint8_t datatype,
+                            const uint32_t count) -> sensor_msgs::msg::PointField {
+    sensor_msgs::msg::PointField field;
+    field.name = name;
+    field.offset = offset;
+    field.datatype = datatype;
+    field.count = count;
+    return field;
+  };
+
+  output->fields.clear();
+  output->fields.push_back(make_point_field("x", 0, sensor_msgs::msg::PointField::FLOAT32, 1));
+  output->fields.push_back(make_point_field("y", 4, sensor_msgs::msg::PointField::FLOAT32, 1));
+  output->fields.push_back(make_point_field("z", 8, sensor_msgs::msg::PointField::FLOAT32, 1));
+  output->fields.push_back(
+    make_point_field("intensity", 12, sensor_msgs::msg::PointField::UINT8, 1));
+  output->fields.push_back(
+    make_point_field("return_type", 13, sensor_msgs::msg::PointField::UINT8, 1));
+  output->fields.push_back(
+    make_point_field("channel", 14, sensor_msgs::msg::PointField::UINT16, 1));
+
+  if (output_point_xyzircaedt_) {
+    // Add extended fields for PointXYZIRCAEDT
+    output->fields.push_back(
+      make_point_field("azimuth", 16, sensor_msgs::msg::PointField::FLOAT32, 1));
+    output->fields.push_back(
+      make_point_field("elevation", 20, sensor_msgs::msg::PointField::FLOAT32, 1));
+    output->fields.push_back(
+      make_point_field("distance", 24, sensor_msgs::msg::PointField::FLOAT32, 1));
+    output->fields.push_back(
+      make_point_field("time_stamp", 28, sensor_msgs::msg::PointField::UINT32, 1));
+  }
+
+  // Return buffers to pool
+  returnBufferToPool(device_input_points);
+  returnBufferToPool(device_crop_mask);
+  returnBufferToPool(device_nan_mask);
+  returnBufferToPool(device_indices);
+  returnBufferToPool(device_crop_box_params);
+
+  CHECK_CUDA_ERROR(cudaStreamSynchronize(stream_));
+
+  return output;
+}
+
+}  // namespace autoware::cuda_pointcloud_preprocessor

--- a/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_cropbox_filter/cuda_crop_box_filter_node.cpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_cropbox_filter/cuda_crop_box_filter_node.cpp
@@ -1,0 +1,116 @@
+// Copyright 2025 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/cuda_pointcloud_preprocessor/cuda_cropbox_filter/cuda_crop_box_filter_node.hpp"
+
+#include "autoware/cuda_pointcloud_preprocessor/cuda_cropbox_filter/cuda_crop_box_filter.hpp"
+#include "autoware/cuda_pointcloud_preprocessor/point_types.hpp"
+#include "autoware/cuda_pointcloud_preprocessor/types.hpp"
+#include "autoware/pointcloud_preprocessor/utility/memory.hpp"
+
+namespace autoware::cuda_pointcloud_preprocessor
+{
+CudaCropBoxFilterNode::CudaCropBoxFilterNode(const rclcpp::NodeOptions & node_options)
+: Node("cuda_crop_box_filter", node_options)
+{
+  // Set initial parameters
+  const auto min_x = declare_parameter<double>("min_x");
+  const auto min_y = declare_parameter<double>("min_y");
+  const auto min_z = declare_parameter<double>("min_z");
+  const auto max_x = declare_parameter<double>("max_x");
+  const auto max_y = declare_parameter<double>("max_y");
+  const auto max_z = declare_parameter<double>("max_z");
+  const auto negative = declare_parameter<bool>("negative");
+  const bool output_point_xyzircaedt = declare_parameter<bool>("output_point_xyzircaedt", false);
+  int64_t max_mem_pool_size_in_byte = declare_parameter<int64_t>("max_mem_pool_size_in_byte", 1e9);
+
+  if (max_mem_pool_size_in_byte < 0) {
+    RCLCPP_ERROR(
+      this->get_logger(), "Invalid pool size was specified. The value should be positive");
+    return;
+  }
+
+  // Build crop box parameters
+  CropBoxParameters crop_box_parameter;
+  crop_box_parameter.min_x = static_cast<float>(min_x);
+  crop_box_parameter.min_y = static_cast<float>(min_y);
+  crop_box_parameter.min_z = static_cast<float>(min_z);
+  crop_box_parameter.max_x = static_cast<float>(max_x);
+  crop_box_parameter.max_y = static_cast<float>(max_y);
+  crop_box_parameter.max_z = static_cast<float>(max_z);
+  crop_box_parameter.negative = negative ? 1 : 0;
+
+  sub_ =
+    std::make_shared<cuda_blackboard::CudaBlackboardSubscriber<cuda_blackboard::CudaPointCloud2>>(
+      *this, "~/input/pointcloud",
+      std::bind(&CudaCropBoxFilterNode::cudaPointcloudCallback, this, std::placeholders::_1));
+
+  pub_ =
+    std::make_unique<cuda_blackboard::CudaBlackboardPublisher<cuda_blackboard::CudaPointCloud2>>(
+      *this, "~/output/pointcloud");
+
+  cuda_crop_box_filter_ = std::make_unique<CudaCropBoxFilter>(
+    crop_box_parameter, max_mem_pool_size_in_byte, output_point_xyzircaedt);
+}
+
+void CudaCropBoxFilterNode::cudaPointcloudCallback(
+  const cuda_blackboard::CudaPointCloud2::ConstSharedPtr msg)
+{
+  // Validate point_step matches one of the supported formats
+  constexpr size_t point_xyzirc_size = sizeof(OutputPointType);
+  constexpr size_t point_xyzircaedt_size = sizeof(InputPointType);
+  const bool is_point_xyzirc = (msg->point_step == point_xyzirc_size);
+  const bool is_point_xyzircaedt = (msg->point_step == point_xyzircaedt_size);
+
+  if (!is_point_xyzirc && !is_point_xyzircaedt) {
+    RCLCPP_ERROR_THROTTLE(
+      this->get_logger(), *this->get_clock(), 5000,
+      "Point cloud point_step mismatch! Expected PointXYZIRC (%zu bytes) or "
+      "PointXYZIRCAEDT (%zu bytes), but got %u bytes. Point cloud will be skipped.",
+      point_xyzirc_size, point_xyzircaedt_size, msg->point_step);
+    return;
+  }
+
+  // Validate data pointer
+  if (!msg->data) {
+    RCLCPP_ERROR_THROTTLE(
+      this->get_logger(), *this->get_clock(), 5000,
+      "Point cloud data pointer is null! Point cloud will be skipped.");
+    return;
+  }
+
+  // Process the point cloud with error handling
+  try {
+    auto output_pointcloud_ptr = cuda_crop_box_filter_->filter(msg);
+    if (output_pointcloud_ptr) {
+      pub_->publish(std::move(output_pointcloud_ptr));
+    } else {
+      RCLCPP_WARN_THROTTLE(
+        this->get_logger(), *this->get_clock(), 5000,
+        "Filter returned null output. Point cloud not published.");
+    }
+  } catch (const std::exception & e) {
+    RCLCPP_ERROR_THROTTLE(
+      this->get_logger(), *this->get_clock(), 5000,
+      "Exception in filter processing: %s. Point cloud will be skipped.", e.what());
+  } catch (...) {
+    RCLCPP_ERROR_THROTTLE(
+      this->get_logger(), *this->get_clock(), 5000,
+      "Unknown exception in filter processing. Point cloud will be skipped.");
+  }
+}
+}  // namespace autoware::cuda_pointcloud_preprocessor
+
+#include "rclcpp_components/register_node_macro.hpp"
+RCLCPP_COMPONENTS_REGISTER_NODE(autoware::cuda_pointcloud_preprocessor::CudaCropBoxFilterNode)

--- a/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_downsample_filter/cuda_random_downsample_filter.cu
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_downsample_filter/cuda_random_downsample_filter.cu
@@ -1,0 +1,313 @@
+// Copyright 2025 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/cuda_pointcloud_preprocessor/common_kernels.hpp"
+#include "autoware/cuda_pointcloud_preprocessor/cuda_downsample_filter/cuda_random_downsample_filter.hpp"
+#include "autoware/cuda_pointcloud_preprocessor/point_types.hpp"
+#include "autoware/cuda_utils/cuda_check_error.hpp"
+
+#include <sensor_msgs/msg/point_field.hpp>
+
+#include <thrust/device_ptr.h>
+#include <thrust/device_vector.h>
+#include <thrust/execution_policy.h>
+#include <thrust/random.h>
+#include <thrust/sequence.h>
+#include <thrust/shuffle.h>
+
+#include <cstdint>
+#include <memory>
+#include <random>
+#include <string>
+
+namespace autoware::cuda_pointcloud_preprocessor
+{
+namespace
+{
+__global__ void randomSampleKernel(
+  const InputPointType * __restrict__ input_points, OutputPointType * __restrict__ output_points,
+  const std::uint32_t * __restrict__ selected_indices, size_t num_samples)
+{
+  size_t idx = blockIdx.x * blockDim.x + threadIdx.x;
+  if (idx >= num_samples) {
+    return;
+  }
+
+  const std::uint32_t input_idx = selected_indices[idx];
+  const InputPointType & input_point = input_points[input_idx];
+  OutputPointType & output_point = output_points[idx];
+
+  output_point.x = input_point.x;
+  output_point.y = input_point.y;
+  output_point.z = input_point.z;
+  output_point.intensity = input_point.intensity;
+  output_point.return_type = input_point.return_type;
+  output_point.channel = input_point.channel;
+}
+
+__global__ void randomSampleInputKernel(
+  const InputPointType * __restrict__ input_points, InputPointType * __restrict__ output_points,
+  const std::uint32_t * __restrict__ selected_indices, size_t num_samples)
+{
+  size_t idx = blockIdx.x * blockDim.x + threadIdx.x;
+  if (idx >= num_samples) {
+    return;
+  }
+
+  const std::uint32_t input_idx = selected_indices[idx];
+  // Copy all fields including extended ones
+  output_points[idx] = input_points[input_idx];
+}
+
+}  // namespace
+
+CudaRandomDownsampleFilter::CudaRandomDownsampleFilter(
+  size_t sample_num, int64_t max_mem_pool_size_in_byte, bool output_point_xyzircaedt)
+: sample_num_(sample_num), output_point_xyzircaedt_(output_point_xyzircaedt)
+{
+  CHECK_CUDA_ERROR(cudaStreamCreate(&stream_));
+
+  // Create memory pool
+  {
+    int current_device_id = 0;
+    CHECK_CUDA_ERROR(cudaGetDevice(&current_device_id));
+    cudaMemPoolProps pool_props = {};
+    pool_props.allocType = cudaMemAllocationTypePinned;
+    pool_props.location.id = current_device_id;
+    pool_props.location.type = cudaMemLocationTypeDevice;
+    CHECK_CUDA_ERROR(cudaMemPoolCreate(&mem_pool_, &pool_props));
+
+    uint64_t pool_release_threshold = max_mem_pool_size_in_byte;
+    CHECK_CUDA_ERROR(cudaMemPoolSetAttribute(
+      mem_pool_, cudaMemPoolAttrReleaseThreshold, static_cast<void *>(&pool_release_threshold)));
+  }
+}
+
+template <typename T>
+T * CudaRandomDownsampleFilter::allocateBufferFromPool(size_t num_elements)
+{
+  T * buffer{};
+  CHECK_CUDA_ERROR(cudaMallocFromPoolAsync(&buffer, num_elements * sizeof(T), mem_pool_, stream_));
+  CHECK_CUDA_ERROR(cudaMemsetAsync(buffer, 0, num_elements * sizeof(T), stream_));
+  return buffer;
+}
+
+template <typename T>
+void CudaRandomDownsampleFilter::returnBufferToPool(T * buffer)
+{
+  CHECK_CUDA_ERROR(cudaFreeAsync(buffer, stream_));
+}
+
+std::unique_ptr<cuda_blackboard::CudaPointCloud2> CudaRandomDownsampleFilter::filter(
+  const cuda_blackboard::CudaPointCloud2::ConstSharedPtr & input_points)
+{
+  const size_t num_input_points = input_points->width * input_points->height;
+
+  if (num_input_points == 0) {
+    auto output = std::make_unique<cuda_blackboard::CudaPointCloud2>();
+    output->header = input_points->header;
+    output->width = 0;
+    output->height = 1;
+    output->fields = input_points->fields;
+    output->is_bigendian = input_points->is_bigendian;
+    output->point_step = input_points->point_step;
+    output->row_step = 0;
+    output->is_dense = input_points->is_dense;
+    output->data.reset();
+    return output;
+  }
+
+  // Determine actual number of samples (cannot exceed input size)
+  const size_t num_samples = std::min(sample_num_, num_input_points);
+
+  if (num_samples == 0) {
+    auto output = std::make_unique<cuda_blackboard::CudaPointCloud2>();
+    output->header = input_points->header;
+    output->width = 0;
+    output->height = 1;
+    output->fields = input_points->fields;
+    output->is_bigendian = input_points->is_bigendian;
+    output->point_step = input_points->point_step;
+    output->row_step = 0;
+    output->is_dense = input_points->is_dense;
+    output->data.reset();
+    return output;
+  }
+
+  // Validate that data pointer is not null
+  if (!input_points->data) {
+    throw std::runtime_error("Input pointcloud data pointer is null.");
+  }
+
+  // Check input format and handle conversion if needed
+  const bool is_point_xyzirc = (input_points->point_step == sizeof(OutputPointType));
+  const bool is_point_xyzircaedt = (input_points->point_step == sizeof(InputPointType));
+
+  if (!is_point_xyzirc && !is_point_xyzircaedt) {
+    throw std::runtime_error(
+      "Input pointcloud point_step does not match expected format. "
+      "Expected PointXYZIRC (" +
+      std::to_string(sizeof(OutputPointType)) + " bytes) or PointXYZIRCAEDT (" +
+      std::to_string(sizeof(InputPointType)) + " bytes), but got " +
+      std::to_string(input_points->point_step) + " bytes.");
+  }
+
+  // Generate random seed
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  uint32_t seed = static_cast<uint32_t>(gen());
+
+  // Allocate device buffers
+  InputPointType * device_input_points = allocateBufferFromPool<InputPointType>(num_input_points);
+  // Allocate full index array for shuffling
+  std::uint32_t * device_all_indices = allocateBufferFromPool<std::uint32_t>(num_input_points);
+  std::uint32_t * device_selected_indices = allocateBufferFromPool<std::uint32_t>(num_samples);
+
+  // Copy and convert input points to device
+  // Note: cuda_blackboard::CudaPointCloud2::data is already on device memory when received
+  // from CudaBlackboardSubscriber, so we use DeviceToDevice copy
+  if (is_point_xyzirc) {
+    // Convert PointXYZIRC to PointXYZIRCAEDT format
+    OutputPointType * device_temp_points =
+      allocateBufferFromPool<OutputPointType>(num_input_points);
+    CHECK_CUDA_ERROR(cudaMemcpyAsync(
+      device_temp_points, input_points->data.get(), num_input_points * sizeof(OutputPointType),
+      cudaMemcpyDeviceToDevice, stream_));
+
+    // Convert to InputPointType format
+    const int blocks_per_grid_convert =
+      (num_input_points + threads_per_block_ - 1) / threads_per_block_;
+    convertPointXYZIRCToInputPointTypeLaunch(
+      device_temp_points, device_input_points, static_cast<int>(num_input_points),
+      threads_per_block_, blocks_per_grid_convert, stream_);
+
+    // Free temporary buffer
+    returnBufferToPool(device_temp_points);
+  } else {
+    // Direct copy for PointXYZIRCAEDT format
+    CHECK_CUDA_ERROR(cudaMemcpyAsync(
+      device_input_points, input_points->data.get(), num_input_points * sizeof(InputPointType),
+      cudaMemcpyDeviceToDevice, stream_));
+  }
+
+  // Generate sequence of indices [0, 1, 2, ..., num_input_points-1]
+  thrust::sequence(
+    thrust::cuda::par_nosync.on(stream_), thrust::device_ptr<std::uint32_t>(device_all_indices),
+    thrust::device_ptr<std::uint32_t>(device_all_indices + num_input_points), 0);
+
+  // Shuffle the indices using random number generator
+  thrust::default_random_engine rng(seed);
+  thrust::shuffle(
+    thrust::cuda::par_nosync.on(stream_), thrust::device_ptr<std::uint32_t>(device_all_indices),
+    thrust::device_ptr<std::uint32_t>(device_all_indices + num_input_points), rng);
+
+  // Copy first num_samples indices to selected_indices
+  CHECK_CUDA_ERROR(cudaMemcpyAsync(
+    device_selected_indices, device_all_indices, num_samples * sizeof(std::uint32_t),
+    cudaMemcpyDeviceToDevice, stream_));
+
+  // Allocate output buffer based on output format
+  void * device_output_points = nullptr;
+  if (output_point_xyzircaedt_) {
+    device_output_points = allocateBufferFromPool<InputPointType>(num_samples);
+  } else {
+    device_output_points = allocateBufferFromPool<OutputPointType>(num_samples);
+  }
+
+  // Sample points using random indices
+  const int blocks_per_grid_sample = (num_samples + threads_per_block_ - 1) / threads_per_block_;
+  if (output_point_xyzircaedt_) {
+    randomSampleInputKernel<<<blocks_per_grid_sample, threads_per_block_, 0, stream_>>>(
+      device_input_points, static_cast<InputPointType *>(device_output_points),
+      device_selected_indices, num_samples);
+  } else {
+    randomSampleKernel<<<blocks_per_grid_sample, threads_per_block_, 0, stream_>>>(
+      device_input_points, static_cast<OutputPointType *>(device_output_points),
+      device_selected_indices, num_samples);
+  }
+
+  // Allocate output point cloud
+  auto output = std::make_unique<cuda_blackboard::CudaPointCloud2>();
+  const size_t output_point_size =
+    output_point_xyzircaedt_ ? sizeof(InputPointType) : sizeof(OutputPointType);
+  output->data = cuda_blackboard::make_unique<std::uint8_t[]>(num_samples * output_point_size);
+
+  // Copy output points from device
+  // Note: cuda_blackboard::make_unique creates device memory, so we use DeviceToDevice copy
+  CHECK_CUDA_ERROR(cudaMemcpyAsync(
+    output->data.get(), device_output_points, num_samples * output_point_size,
+    cudaMemcpyDeviceToDevice, stream_));
+
+  CHECK_CUDA_ERROR(cudaStreamSynchronize(stream_));
+
+  // Set output metadata
+  output->header = input_points->header;
+  output->width = num_samples;
+  output->height = 1;
+  output->point_step = output_point_size;
+  output->row_step = num_samples * output_point_size;
+  output->is_dense = true;
+  output->is_bigendian = input_points->is_bigendian;
+
+  // Set point fields
+  auto make_point_field = [](
+                            const std::string name, const uint32_t offset, const uint8_t datatype,
+                            const uint32_t count) -> sensor_msgs::msg::PointField {
+    sensor_msgs::msg::PointField field;
+    field.name = name;
+    field.offset = offset;
+    field.datatype = datatype;
+    field.count = count;
+    return field;
+  };
+
+  output->fields.clear();
+  output->fields.push_back(make_point_field("x", 0, sensor_msgs::msg::PointField::FLOAT32, 1));
+  output->fields.push_back(make_point_field("y", 4, sensor_msgs::msg::PointField::FLOAT32, 1));
+  output->fields.push_back(make_point_field("z", 8, sensor_msgs::msg::PointField::FLOAT32, 1));
+  output->fields.push_back(
+    make_point_field("intensity", 12, sensor_msgs::msg::PointField::UINT8, 1));
+  output->fields.push_back(
+    make_point_field("return_type", 13, sensor_msgs::msg::PointField::UINT8, 1));
+  output->fields.push_back(
+    make_point_field("channel", 14, sensor_msgs::msg::PointField::UINT16, 1));
+
+  if (output_point_xyzircaedt_) {
+    // Add extended fields for PointXYZIRCAEDT
+    output->fields.push_back(
+      make_point_field("azimuth", 16, sensor_msgs::msg::PointField::FLOAT32, 1));
+    output->fields.push_back(
+      make_point_field("elevation", 20, sensor_msgs::msg::PointField::FLOAT32, 1));
+    output->fields.push_back(
+      make_point_field("distance", 24, sensor_msgs::msg::PointField::FLOAT32, 1));
+    output->fields.push_back(
+      make_point_field("time_stamp", 28, sensor_msgs::msg::PointField::UINT32, 1));
+  }
+
+  // Return buffers to pool
+  returnBufferToPool(device_input_points);
+  returnBufferToPool(device_all_indices);
+  returnBufferToPool(device_selected_indices);
+  if (output_point_xyzircaedt_) {
+    returnBufferToPool(static_cast<InputPointType *>(device_output_points));
+  } else {
+    returnBufferToPool(static_cast<OutputPointType *>(device_output_points));
+  }
+
+  CHECK_CUDA_ERROR(cudaStreamSynchronize(stream_));
+
+  return output;
+}
+
+}  // namespace autoware::cuda_pointcloud_preprocessor

--- a/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_downsample_filter/cuda_random_downsample_filter_node.cpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_downsample_filter/cuda_random_downsample_filter_node.cpp
@@ -1,0 +1,101 @@
+// Copyright 2025 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/cuda_pointcloud_preprocessor/cuda_downsample_filter/cuda_random_downsample_filter_node.hpp"
+
+#include "autoware/cuda_pointcloud_preprocessor/cuda_downsample_filter/cuda_random_downsample_filter.hpp"
+#include "autoware/cuda_pointcloud_preprocessor/point_types.hpp"
+#include "autoware/pointcloud_preprocessor/utility/memory.hpp"
+
+namespace autoware::cuda_pointcloud_preprocessor
+{
+CudaRandomDownsampleFilterNode::CudaRandomDownsampleFilterNode(
+  const rclcpp::NodeOptions & node_options)
+: Node("cuda_random_downsample_filter", node_options)
+{
+  // Set initial parameters
+  size_t sample_num = static_cast<size_t>(declare_parameter<int64_t>("sample_num"));
+  const bool output_point_xyzircaedt = declare_parameter<bool>("output_point_xyzircaedt", false);
+  int64_t max_mem_pool_size_in_byte = declare_parameter<int64_t>("max_mem_pool_size_in_byte", 1e9);
+  if (max_mem_pool_size_in_byte < 0) {
+    RCLCPP_ERROR(
+      this->get_logger(), "Invalid pool size was specified. The value should be positive");
+    return;
+  }
+
+  sub_ =
+    std::make_shared<cuda_blackboard::CudaBlackboardSubscriber<cuda_blackboard::CudaPointCloud2>>(
+      *this, "~/input/pointcloud",
+      std::bind(
+        &CudaRandomDownsampleFilterNode::cudaPointcloudCallback, this, std::placeholders::_1));
+
+  pub_ =
+    std::make_unique<cuda_blackboard::CudaBlackboardPublisher<cuda_blackboard::CudaPointCloud2>>(
+      *this, "~/output/pointcloud");
+
+  cuda_random_downsample_filter_ = std::make_unique<CudaRandomDownsampleFilter>(
+    sample_num, max_mem_pool_size_in_byte, output_point_xyzircaedt);
+}
+
+void CudaRandomDownsampleFilterNode::cudaPointcloudCallback(
+  const cuda_blackboard::CudaPointCloud2::ConstSharedPtr msg)
+{
+  // Validate point_step matches one of the supported formats
+  constexpr size_t point_xyzirc_size = sizeof(OutputPointType);
+  constexpr size_t point_xyzircaedt_size = sizeof(InputPointType);
+  const bool is_point_xyzirc = (msg->point_step == point_xyzirc_size);
+  const bool is_point_xyzircaedt = (msg->point_step == point_xyzircaedt_size);
+
+  if (!is_point_xyzirc && !is_point_xyzircaedt) {
+    RCLCPP_ERROR_THROTTLE(
+      this->get_logger(), *this->get_clock(), 5000,
+      "Point cloud point_step mismatch! Expected PointXYZIRC (%zu bytes) or "
+      "PointXYZIRCAEDT (%zu bytes), but got %u bytes. Point cloud will be skipped.",
+      point_xyzirc_size, point_xyzircaedt_size, msg->point_step);
+    return;
+  }
+
+  // Validate data pointer
+  if (!msg->data) {
+    RCLCPP_ERROR_THROTTLE(
+      this->get_logger(), *this->get_clock(), 5000,
+      "Point cloud data pointer is null! Point cloud will be skipped.");
+    return;
+  }
+
+  // Process the point cloud with error handling
+  try {
+    auto output_pointcloud_ptr = cuda_random_downsample_filter_->filter(msg);
+    if (output_pointcloud_ptr) {
+      pub_->publish(std::move(output_pointcloud_ptr));
+    } else {
+      RCLCPP_WARN_THROTTLE(
+        this->get_logger(), *this->get_clock(), 5000,
+        "Filter returned null output. Point cloud not published.");
+    }
+  } catch (const std::exception & e) {
+    RCLCPP_ERROR_THROTTLE(
+      this->get_logger(), *this->get_clock(), 5000,
+      "Exception in filter processing: %s. Point cloud will be skipped.", e.what());
+  } catch (...) {
+    RCLCPP_ERROR_THROTTLE(
+      this->get_logger(), *this->get_clock(), 5000,
+      "Unknown exception in filter processing. Point cloud will be skipped.");
+  }
+}
+}  // namespace autoware::cuda_pointcloud_preprocessor
+
+#include "rclcpp_components/register_node_macro.hpp"
+RCLCPP_COMPONENTS_REGISTER_NODE(
+  autoware::cuda_pointcloud_preprocessor::CudaRandomDownsampleFilterNode)

--- a/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_downsample_filter/cuda_voxel_grid_downsample_filter.cu
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_downsample_filter/cuda_voxel_grid_downsample_filter.cu
@@ -164,11 +164,42 @@ __global__ void packCentroidKernel(
   dst->channel =
     voxel_info_dev.input_channel_offset.is_valid ? *channel_field : 0;  // dummy laser channel ID
 }
+
+__global__ void packCentroidInputKernel(
+  const CudaVoxelGridDownsampleFilter::Centroid * __restrict__ centroids,
+  const size_t num_valid_voxel, const size_t output_point_step, uint8_t * __restrict__ output,
+  uint8_t * __restrict__ return_type_field, uint16_t * __restrict__ channel_field)
+{
+  size_t index = blockIdx.x * blockDim.x + threadIdx.x;
+  if (index >= num_valid_voxel) {
+    return;
+  }
+
+  auto dst = getElementPointer<InputPointType>(output, index, output_point_step, 0);
+
+  dst->x = static_cast<decltype(InputPointType::x)>(centroids[index].x / centroids[index].count);
+  dst->y = static_cast<decltype(InputPointType::y)>(centroids[index].y / centroids[index].count);
+  dst->z = static_cast<decltype(InputPointType::z)>(centroids[index].z / centroids[index].count);
+  dst->intensity =
+    static_cast<decltype(InputPointType::intensity)>(centroids[index].i / centroids[index].count);
+  // Since `return_type` and `channel` fields cannot be accumulated, fill the representative values
+  // for `return_type` and `channel` fields if they are available in the input pointcloud.
+  dst->return_type =
+    voxel_info_dev.input_return_type_offset.is_valid ? *return_type_field : 0;  // 0: UNKNOWN
+  dst->channel =
+    voxel_info_dev.input_channel_offset.is_valid ? *channel_field : 0;  // dummy laser channel ID
+  // Initialize extended fields with default values
+  dst->azimuth = 0.0f;
+  dst->elevation = 0.0f;
+  dst->distance = 1.0f;  // Non-zero default
+  dst->time_stamp = 0U;
+}
 }  // namespace
 
 CudaVoxelGridDownsampleFilter::CudaVoxelGridDownsampleFilter(
   const float voxel_size_x, const float voxel_size_y, const float voxel_size_z,
-  const int64_t max_mem_pool_size_in_byte)
+  const int64_t max_mem_pool_size_in_byte, bool output_point_xyzircaedt)
+: output_point_xyzircaedt_(output_point_xyzircaedt)
 {
   voxel_info_.voxel_size.x = voxel_size_x;
   voxel_info_.voxel_size.y = voxel_size_y;
@@ -264,8 +295,10 @@ std::unique_ptr<cuda_blackboard::CudaPointCloud2> CudaVoxelGridDownsampleFilter:
 
   // Allocate region actually result filtered pointcloud requires and fill them
   auto filtered_output = std::make_unique<cuda_blackboard::CudaPointCloud2>();
+  const size_t output_point_size =
+    output_point_xyzircaedt_ ? sizeof(InputPointType) : sizeof(OutputPointType);
   filtered_output->data =
-    cuda_blackboard::make_unique<std::uint8_t[]>(num_valid_voxel * sizeof(OutputPointType));
+    cuda_blackboard::make_unique<std::uint8_t[]>(num_valid_voxel * output_point_size);
 
   // Calculate actual voxel-filtered points
   auto centroid_buffer_dev = allocateBufferFromPool<Centroid>(num_valid_voxel * sizeof(Centroid));
@@ -301,9 +334,20 @@ std::unique_ptr<cuda_blackboard::CudaPointCloud2> CudaVoxelGridDownsampleFilter:
       "return_type", voxel_info_.output_offsets[4], sensor_msgs::msg::PointField::UINT8, 1));
     filtered_output->fields.push_back(generate_point_field(
       "channel", voxel_info_.output_offsets[5], sensor_msgs::msg::PointField::UINT16, 1));
+    if (output_point_xyzircaedt_) {
+      // Add extended fields for PointXYZIRCAEDT
+      filtered_output->fields.push_back(
+        generate_point_field("azimuth", 16, sensor_msgs::msg::PointField::FLOAT32, 1));
+      filtered_output->fields.push_back(
+        generate_point_field("elevation", 20, sensor_msgs::msg::PointField::FLOAT32, 1));
+      filtered_output->fields.push_back(
+        generate_point_field("distance", 24, sensor_msgs::msg::PointField::FLOAT32, 1));
+      filtered_output->fields.push_back(
+        generate_point_field("time_stamp", 28, sensor_msgs::msg::PointField::UINT32, 1));
+    }
     filtered_output->is_bigendian = input_points->is_bigendian;
-    filtered_output->point_step = sizeof(OutputPointType);
-    filtered_output->row_step = sizeof(OutputPointType) * num_valid_voxel;
+    filtered_output->point_step = output_point_size;
+    filtered_output->row_step = output_point_size * num_valid_voxel;
     filtered_output->is_dense = input_points->is_dense;
   }
 
@@ -559,8 +603,14 @@ void CudaVoxelGridDownsampleFilter::getCentroid(
   }
 
   dim3 grid_dim_voxel((num_valid_voxel + block_dim.x - 1) / block_dim.x);
-  packCentroidKernel<<<grid_dim_voxel, block_dim, 0, stream_>>>(
-    buffer_dev, num_valid_voxel, sizeof(OutputPointType), output_points->data.get(),
-    return_type_field_dev, channel_field_dev);
+  if (output_point_xyzircaedt_) {
+    packCentroidInputKernel<<<grid_dim_voxel, block_dim, 0, stream_>>>(
+      buffer_dev, num_valid_voxel, sizeof(InputPointType), output_points->data.get(),
+      return_type_field_dev, channel_field_dev);
+  } else {
+    packCentroidKernel<<<grid_dim_voxel, block_dim, 0, stream_>>>(
+      buffer_dev, num_valid_voxel, sizeof(OutputPointType), output_points->data.get(),
+      return_type_field_dev, channel_field_dev);
+  }
 }
 }  // namespace autoware::cuda_pointcloud_preprocessor

--- a/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_downsample_filter/cuda_voxel_grid_downsample_filter_node.cpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_downsample_filter/cuda_voxel_grid_downsample_filter_node.cpp
@@ -26,6 +26,7 @@ CudaVoxelGridDownsampleFilterNode::CudaVoxelGridDownsampleFilterNode(
   float voxel_size_x = declare_parameter<float>("voxel_size_x");
   float voxel_size_y = declare_parameter<float>("voxel_size_y");
   float voxel_size_z = declare_parameter<float>("voxel_size_z");
+  const bool output_point_xyzircaedt = declare_parameter<bool>("output_point_xyzircaedt", false);
   int64_t max_mem_pool_size_in_byte = declare_parameter<int64_t>(
     "max_mem_pool_size_in_byte",
     1e9);  // 1GB in default
@@ -46,7 +47,7 @@ CudaVoxelGridDownsampleFilterNode::CudaVoxelGridDownsampleFilterNode(
       *this, "~/output/pointcloud");
 
   cuda_voxel_grid_downsample_filter_ = std::make_unique<CudaVoxelGridDownsampleFilter>(
-    voxel_size_x, voxel_size_y, voxel_size_z, max_mem_pool_size_in_byte);
+    voxel_size_x, voxel_size_y, voxel_size_z, max_mem_pool_size_in_byte, output_point_xyzircaedt);
 }
 
 void CudaVoxelGridDownsampleFilterNode::cudaPointcloudCallback(
@@ -58,8 +59,8 @@ void CudaVoxelGridDownsampleFilterNode::cudaPointcloudCallback(
   if (!pointcloud_preprocessor::utils::is_data_layout_compatible_with_point_xyzi(msg->fields)) {
     // This filter assumes float for intensity data type, though the filter supports
     // other data types for the intensity field, so here just outputs a WARN message.
-    RCLCPP_WARN(
-      this->get_logger(),
+    RCLCPP_WARN_THROTTLE(
+      this->get_logger(), *this->get_clock(), 5000,
       "Input pointcloud data layout is not compatible with PointXYZI. "
       "The output result may not be correct");
   }

--- a/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_pointcloud2costmap_filter/cuda_pointcloud2costmap_filter.cu
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_pointcloud2costmap_filter/cuda_pointcloud2costmap_filter.cu
@@ -1,0 +1,317 @@
+// Copyright 2025 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/cuda_pointcloud_preprocessor/common_kernels.hpp"
+#include "autoware/cuda_pointcloud_preprocessor/cuda_pointcloud2costmap_filter/cuda_pointcloud2costmap_filter.hpp"
+#include "autoware/cuda_pointcloud_preprocessor/point_types.hpp"
+#include "autoware/cuda_utils/cuda_check_error.hpp"
+
+#include <thrust/device_ptr.h>
+#include <thrust/fill.h>
+
+#include <cmath>
+#include <cstdint>
+#include <memory>
+
+namespace autoware::cuda_pointcloud_preprocessor
+{
+
+// CUDA kernels for pointcloud to costmap conversion
+__global__ void assignPointsToGridCellsKernel(
+  const InputPointType * __restrict__ input_points, int32_t * __restrict__ grid_indices,
+  int num_points, const CostmapGridParams * __restrict__ params)
+{
+  int idx = blockIdx.x * blockDim.x + threadIdx.x;
+  if (idx < num_points) {
+    const InputPointType & point = input_points[idx];
+    const float x = point.x;
+    const float y = point.y;
+
+    // Check if point is valid
+    if (!isfinite(x) || !isfinite(y)) {
+      grid_indices[idx] = -1;  // Invalid index
+      return;
+    }
+
+    // Calculate grid index following the same logic as CPU version
+    // From points_to_costmap.cpp: fetchGridIndexFromPoint
+    const float origin_x_offset = params->grid_length_x / 2.0f - params->grid_position_x;
+    const float origin_y_offset = params->grid_length_y / 2.0f - params->grid_position_y;
+
+    // Coordinate conversion for making index. Set bottom left to the origin of coordinate (0, 0)
+    float mapped_x = (params->grid_length_x - origin_x_offset - x) / params->grid_resolution;
+    float mapped_y = (params->grid_length_y - origin_y_offset - y) / params->grid_resolution;
+
+    int32_t mapped_x_ind = static_cast<int32_t>(ceilf(mapped_x));
+    int32_t mapped_y_ind = static_cast<int32_t>(ceilf(mapped_y));
+
+    // Check if index is valid
+    if (
+      mapped_x_ind >= 0 && mapped_x_ind < params->grid_size_x && mapped_y_ind >= 0 &&
+      mapped_y_ind < params->grid_size_y) {
+      // Store as linear index: x * grid_size_y + y
+      grid_indices[idx] = mapped_x_ind * params->grid_size_y + mapped_y_ind;
+    } else {
+      grid_indices[idx] = -1;  // Invalid index
+    }
+  }
+}
+
+__global__ void calculateCostmapFromGridCellsKernel(
+  const InputPointType * __restrict__ input_points, const int32_t * __restrict__ grid_indices,
+  float * __restrict__ costmap_data, int num_points, const CostmapGridParams * __restrict__ params)
+{
+  // First, initialize all costmap cells to min_value
+  int grid_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  int total_grid_cells = params->grid_size_x * params->grid_size_y;
+  if (grid_idx < total_grid_cells) {
+    costmap_data[grid_idx] = params->grid_min_value;
+  }
+
+  __syncthreads();
+
+  // Then, for each point, check if it should contribute to costmap
+  int point_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  if (point_idx < num_points) {
+    const int32_t grid_cell_idx = grid_indices[point_idx];
+    if (grid_cell_idx < 0 || grid_cell_idx >= total_grid_cells) {
+      return;  // Invalid grid cell
+    }
+
+    const InputPointType & point = input_points[point_idx];
+    const float z = point.z;
+
+    // Check if z is within height thresholds
+    if (z <= params->maximum_height_thres && z >= params->minimum_height_thres) {
+      // Use atomic operation to set costmap value to max_value
+      // This ensures thread safety when multiple points map to the same cell
+      atomicExch(&costmap_data[grid_cell_idx], params->grid_max_value);
+    }
+  }
+}
+
+// Kernel launch functions
+void assignPointsToGridCellsLaunch(
+  const InputPointType * input_points, int32_t * grid_indices, int num_points,
+  const CostmapGridParams * params, int threads_per_block, int blocks_per_grid,
+  cudaStream_t & stream)
+{
+  assignPointsToGridCellsKernel<<<blocks_per_grid, threads_per_block, 0, stream>>>(
+    input_points, grid_indices, num_points, params);
+}
+
+void calculateCostmapFromGridCellsLaunch(
+  const InputPointType * input_points, const int32_t * grid_indices, float * costmap_data,
+  int num_points, const CostmapGridParams * params, int threads_per_block, int blocks_per_grid,
+  cudaStream_t & stream)
+{
+  // Calculate blocks for grid cells (for initialization)
+  int total_grid_cells = params->grid_size_x * params->grid_size_y;
+  int blocks_for_grid = (total_grid_cells + threads_per_block - 1) / threads_per_block;
+
+  // Use max of blocks_for_grid and blocks_per_grid to handle both initialization and point
+  // processing
+  int total_blocks = (blocks_for_grid > blocks_per_grid) ? blocks_for_grid : blocks_per_grid;
+
+  calculateCostmapFromGridCellsKernel<<<total_blocks, threads_per_block, 0, stream>>>(
+    input_points, grid_indices, costmap_data, num_points, params);
+}
+
+CudaPointcloud2CostmapFilter::CudaPointcloud2CostmapFilter(
+  const CostmapParameters & costmap_parameters, int64_t max_mem_pool_size_in_byte)
+: costmap_parameters_(costmap_parameters)
+{
+  // Calculate grid size
+  grid_size_x_ = static_cast<int32_t>(
+    std::ceil(costmap_parameters.grid_length_x / costmap_parameters.grid_resolution));
+  grid_size_y_ = static_cast<int32_t>(
+    std::ceil(costmap_parameters.grid_length_y / costmap_parameters.grid_resolution));
+
+  CHECK_CUDA_ERROR(cudaStreamCreate(&stream_));
+
+  // Create memory pool to make repeated allocation efficient
+  {
+    int current_device_id = 0;
+    CHECK_CUDA_ERROR(cudaGetDevice(&current_device_id));
+    cudaMemPoolProps pool_props = {};
+    pool_props.allocType = cudaMemAllocationTypePinned;
+    pool_props.location.id = current_device_id;
+    pool_props.location.type = cudaMemLocationTypeDevice;
+    CHECK_CUDA_ERROR(cudaMemPoolCreate(&mem_pool_, &pool_props));
+
+    // Configure the memory pool reusing allocation
+    uint64_t pool_release_threshold = max_mem_pool_size_in_byte;
+    CHECK_CUDA_ERROR(cudaMemPoolSetAttribute(
+      mem_pool_, cudaMemPoolAttrReleaseThreshold, static_cast<void *>(&pool_release_threshold)));
+  }
+}
+
+template <typename T>
+T * CudaPointcloud2CostmapFilter::allocateBufferFromPool(size_t num_elements)
+{
+  T * buffer{};
+  CHECK_CUDA_ERROR(cudaMallocFromPoolAsync(&buffer, num_elements * sizeof(T), mem_pool_, stream_));
+  CHECK_CUDA_ERROR(cudaMemsetAsync(buffer, 0, num_elements * sizeof(T), stream_));
+  return buffer;
+}
+
+template <typename T>
+void CudaPointcloud2CostmapFilter::returnBufferToPool(T * buffer)
+{
+  CHECK_CUDA_ERROR(cudaFreeAsync(buffer, stream_));
+}
+
+void CudaPointcloud2CostmapFilter::generateCostmap(
+  const cuda_blackboard::CudaPointCloud2::ConstSharedPtr & input_points,
+  grid_map::Matrix & costmap_matrix)
+{
+  const size_t num_points = input_points->width * input_points->height;
+
+  if (num_points == 0) {
+    // Initialize costmap with min_value
+    costmap_matrix =
+      grid_map::Matrix::Constant(grid_size_x_, grid_size_y_, costmap_parameters_.grid_min_value);
+    return;
+  }
+
+  // Validate that data pointer is not null
+  if (!input_points->data) {
+    throw std::runtime_error("Input pointcloud data pointer is null.");
+  }
+
+  // Check input format
+  const bool is_point_xyzirc = (input_points->point_step == sizeof(OutputPointType));
+  const bool is_point_xyzircaedt = (input_points->point_step == sizeof(InputPointType));
+
+  if (!is_point_xyzirc && !is_point_xyzircaedt) {
+    throw std::runtime_error(
+      "Input pointcloud point_step does not match expected format. "
+      "Expected PointXYZIRC (" +
+      std::to_string(sizeof(OutputPointType)) + " bytes) or PointXYZIRCAEDT (" +
+      std::to_string(sizeof(InputPointType)) + " bytes), but got " +
+      std::to_string(input_points->point_step) + " bytes.");
+  }
+
+  // Allocate device buffers
+  InputPointType * device_input_points = allocateBufferFromPool<InputPointType>(num_points);
+  int32_t * device_grid_indices = allocateBufferFromPool<int32_t>(num_points);
+  float * device_costmap_data = allocateBufferFromPool<float>(grid_size_x_ * grid_size_y_);
+  CostmapGridParams * device_params = allocateBufferFromPool<CostmapGridParams>(1);
+
+  // Copy and convert input points to device
+  if (is_point_xyzirc) {
+    // Convert PointXYZIRC to PointXYZIRCAEDT format
+    OutputPointType * device_temp_points = allocateBufferFromPool<OutputPointType>(num_points);
+    CHECK_CUDA_ERROR(cudaMemcpyAsync(
+      device_temp_points, input_points->data.get(), num_points * sizeof(OutputPointType),
+      cudaMemcpyDeviceToDevice, stream_));
+
+    // Convert to InputPointType format
+    const int blocks_per_grid_convert = (num_points + threads_per_block_ - 1) / threads_per_block_;
+    convertPointXYZIRCToInputPointTypeLaunch(
+      device_temp_points, device_input_points, static_cast<int>(num_points), threads_per_block_,
+      blocks_per_grid_convert, stream_);
+
+    // Free temporary buffer
+    returnBufferToPool(device_temp_points);
+  } else {
+    // Direct copy for PointXYZIRCAEDT format
+    CHECK_CUDA_ERROR(cudaMemcpyAsync(
+      device_input_points, input_points->data.get(), num_points * sizeof(InputPointType),
+      cudaMemcpyDeviceToDevice, stream_));
+  }
+
+  // Prepare costmap parameters for device
+  CostmapGridParams host_params;
+  host_params.grid_length_x = static_cast<float>(costmap_parameters_.grid_length_x);
+  host_params.grid_length_y = static_cast<float>(costmap_parameters_.grid_length_y);
+  host_params.grid_resolution = static_cast<float>(costmap_parameters_.grid_resolution);
+  host_params.grid_position_x = static_cast<float>(costmap_parameters_.grid_position_x);
+  host_params.grid_position_y = static_cast<float>(costmap_parameters_.grid_position_y);
+  host_params.maximum_height_thres = static_cast<float>(costmap_parameters_.maximum_height_thres);
+  host_params.minimum_height_thres = static_cast<float>(costmap_parameters_.minimum_height_thres);
+  host_params.grid_min_value = static_cast<float>(costmap_parameters_.grid_min_value);
+  host_params.grid_max_value = static_cast<float>(costmap_parameters_.grid_max_value);
+  host_params.grid_size_x = grid_size_x_;
+  host_params.grid_size_y = grid_size_y_;
+
+  // Copy parameters to device
+  CHECK_CUDA_ERROR(cudaMemcpyAsync(
+    device_params, &host_params, sizeof(CostmapGridParams), cudaMemcpyHostToDevice, stream_));
+
+  // Initialize grid indices to -1 (invalid)
+  thrust::fill(
+    thrust::cuda::par_nosync.on(stream_), thrust::device_ptr<int32_t>(device_grid_indices),
+    thrust::device_ptr<int32_t>(device_grid_indices + num_points), -1);
+
+  // Assign points to grid cells
+  const int blocks_per_grid = (num_points + threads_per_block_ - 1) / threads_per_block_;
+  assignPointsToGridCellsLaunch(
+    device_input_points, device_grid_indices, static_cast<int>(num_points), device_params,
+    threads_per_block_, blocks_per_grid, stream_);
+
+  // Calculate costmap from grid cells
+  calculateCostmapFromGridCellsLaunch(
+    device_input_points, device_grid_indices, device_costmap_data, static_cast<int>(num_points),
+    device_params, threads_per_block_, blocks_per_grid, stream_);
+
+  // Synchronize stream
+  CHECK_CUDA_ERROR(cudaStreamSynchronize(stream_));
+
+  // Copy costmap data back to host
+  std::vector<float> host_costmap_data(grid_size_x_ * grid_size_y_);
+  CHECK_CUDA_ERROR(cudaMemcpyAsync(
+    host_costmap_data.data(), device_costmap_data, grid_size_x_ * grid_size_y_ * sizeof(float),
+    cudaMemcpyDeviceToHost, stream_));
+
+  CHECK_CUDA_ERROR(cudaStreamSynchronize(stream_));
+
+  // Convert to grid_map::Matrix
+  // grid_map::Matrix uses (row, col) indexing where row is x and col is y
+  // (matching the CPU implementation: gridmap_data(x_ind, y_ind))
+  costmap_matrix = grid_map::Matrix(grid_size_x_, grid_size_y_);
+  for (int x = 0; x < grid_size_x_; ++x) {
+    for (int y = 0; y < grid_size_y_; ++y) {
+      // Linear index: x * grid_size_y + y
+      costmap_matrix(x, y) = host_costmap_data[x * grid_size_y_ + y];
+    }
+  }
+
+  // Return buffers to pool
+  returnBufferToPool(device_input_points);
+  returnBufferToPool(device_grid_indices);
+  returnBufferToPool(device_costmap_data);
+  returnBufferToPool(device_params);
+
+  CHECK_CUDA_ERROR(cudaStreamSynchronize(stream_));
+}
+
+// Explicit template instantiations
+template InputPointType * CudaPointcloud2CostmapFilter::allocateBufferFromPool<InputPointType>(
+  size_t);
+template OutputPointType * CudaPointcloud2CostmapFilter::allocateBufferFromPool<OutputPointType>(
+  size_t);
+template int32_t * CudaPointcloud2CostmapFilter::allocateBufferFromPool<int32_t>(size_t);
+template float * CudaPointcloud2CostmapFilter::allocateBufferFromPool<float>(size_t);
+template CostmapGridParams *
+CudaPointcloud2CostmapFilter::allocateBufferFromPool<CostmapGridParams>(size_t);
+
+template void CudaPointcloud2CostmapFilter::returnBufferToPool<InputPointType>(InputPointType *);
+template void CudaPointcloud2CostmapFilter::returnBufferToPool<OutputPointType>(OutputPointType *);
+template void CudaPointcloud2CostmapFilter::returnBufferToPool<int32_t>(int32_t *);
+template void CudaPointcloud2CostmapFilter::returnBufferToPool<float>(float *);
+template void CudaPointcloud2CostmapFilter::returnBufferToPool<CostmapGridParams>(
+  CostmapGridParams *);
+
+}  // namespace autoware::cuda_pointcloud_preprocessor

--- a/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_pointcloud2costmap_filter/cuda_pointcloud2costmap_filter_node.cpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_pointcloud2costmap_filter/cuda_pointcloud2costmap_filter_node.cpp
@@ -1,0 +1,126 @@
+// Copyright 2025 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/cuda_pointcloud_preprocessor/cuda_pointcloud2costmap_filter/cuda_pointcloud2costmap_filter_node.hpp"
+
+#include "autoware/cuda_pointcloud_preprocessor/cuda_pointcloud2costmap_filter/cuda_pointcloud2costmap_filter.hpp"
+#include "autoware/cuda_pointcloud_preprocessor/point_types.hpp"
+#include "autoware/cuda_pointcloud_preprocessor/types.hpp"
+
+#include <grid_map_ros/GridMapRosConverter.hpp>
+
+namespace autoware::cuda_pointcloud_preprocessor
+{
+CudaPointcloud2CostmapFilterNode::CudaPointcloud2CostmapFilterNode(
+  const rclcpp::NodeOptions & node_options)
+: Node("cuda_pointcloud2costmap_filter", node_options)
+{
+  // Get costmap parameters
+  costmap_frame_ = declare_parameter<std::string>("costmap_frame", "map");
+  costmap_params_.grid_length_x = declare_parameter<double>("grid_length_x", 100.0);
+  costmap_params_.grid_length_y = declare_parameter<double>("grid_length_y", 100.0);
+  costmap_params_.grid_resolution = declare_parameter<double>("grid_resolution", 0.5);
+  costmap_params_.grid_position_x = declare_parameter<double>("grid_position_x", 0.0);
+  costmap_params_.grid_position_y = declare_parameter<double>("grid_position_y", 0.0);
+  costmap_params_.maximum_height_thres = declare_parameter<double>("maximum_height_thres", 2.0);
+  costmap_params_.minimum_height_thres = declare_parameter<double>("minimum_height_thres", -2.0);
+  costmap_params_.grid_min_value = declare_parameter<double>("grid_min_value", 0.0);
+  costmap_params_.grid_max_value = declare_parameter<double>("grid_max_value", 1.0);
+
+  int64_t max_mem_pool_size_in_byte = declare_parameter<int64_t>("max_mem_pool_size_in_byte", 1e9);
+
+  if (max_mem_pool_size_in_byte < 0) {
+    RCLCPP_ERROR(
+      this->get_logger(), "Invalid pool size was specified. The value should be positive");
+    return;
+  }
+
+  // Create subscriber
+  sub_ =
+    std::make_shared<cuda_blackboard::CudaBlackboardSubscriber<cuda_blackboard::CudaPointCloud2>>(
+      *this, "~/input/pointcloud",
+      std::bind(
+        &CudaPointcloud2CostmapFilterNode::cudaPointcloudCallback, this, std::placeholders::_1));
+
+  // Create publisher
+  pub_costmap_ = this->create_publisher<grid_map_msgs::msg::GridMap>("~/output/grid_map", 1);
+
+  // Create filter
+  cuda_pointcloud2costmap_filter_ =
+    std::make_unique<CudaPointcloud2CostmapFilter>(costmap_params_, max_mem_pool_size_in_byte);
+}
+
+void CudaPointcloud2CostmapFilterNode::cudaPointcloudCallback(
+  const cuda_blackboard::CudaPointCloud2::ConstSharedPtr msg)
+{
+  // Validate point_step matches one of the supported formats
+  constexpr size_t point_xyzirc_size = sizeof(OutputPointType);
+  constexpr size_t point_xyzircaedt_size = sizeof(InputPointType);
+  const bool is_point_xyzirc = (msg->point_step == point_xyzirc_size);
+  const bool is_point_xyzircaedt = (msg->point_step == point_xyzircaedt_size);
+
+  if (!is_point_xyzirc && !is_point_xyzircaedt) {
+    RCLCPP_ERROR_THROTTLE(
+      this->get_logger(), *this->get_clock(), 5000,
+      "Point cloud point_step mismatch! Expected PointXYZIRC (%zu bytes) or "
+      "PointXYZIRCAEDT (%zu bytes), but got %u bytes. Point cloud will be skipped.",
+      point_xyzirc_size, point_xyzircaedt_size, msg->point_step);
+    return;
+  }
+
+  // Validate data pointer
+  if (!msg->data) {
+    RCLCPP_ERROR_THROTTLE(
+      this->get_logger(), *this->get_clock(), 5000,
+      "Point cloud data pointer is null! Point cloud will be skipped.");
+    return;
+  }
+
+  // Process the point cloud with error handling
+  try {
+    // Create grid map
+    grid_map::GridMap grid_map;
+    grid_map.setFrameId(costmap_frame_);
+    grid_map.setGeometry(
+      grid_map::Length(costmap_params_.grid_length_x, costmap_params_.grid_length_y),
+      costmap_params_.grid_resolution,
+      grid_map::Position(costmap_params_.grid_position_x, costmap_params_.grid_position_y));
+    grid_map.add("points", costmap_params_.grid_min_value);
+
+    // Generate costmap
+    grid_map::Matrix costmap_matrix;
+    cuda_pointcloud2costmap_filter_->generateCostmap(msg, costmap_matrix);
+    grid_map["points"] = costmap_matrix;
+
+    // Set timestamp
+    grid_map.setTimestamp(rclcpp::Time(msg->header.stamp).nanoseconds());
+
+    // Convert to message and publish
+    auto grid_map_msg = grid_map::GridMapRosConverter::toMessage(grid_map);
+    pub_costmap_->publish(*grid_map_msg);
+  } catch (const std::exception & e) {
+    RCLCPP_ERROR_THROTTLE(
+      this->get_logger(), *this->get_clock(), 5000,
+      "Exception in costmap generation: %s. Costmap will not be published.", e.what());
+  } catch (...) {
+    RCLCPP_ERROR_THROTTLE(
+      this->get_logger(), *this->get_clock(), 5000,
+      "Unknown exception in costmap generation. Costmap will not be published.");
+  }
+}
+}  // namespace autoware::cuda_pointcloud_preprocessor
+
+#include "rclcpp_components/register_node_macro.hpp"
+RCLCPP_COMPONENTS_REGISTER_NODE(
+  autoware::cuda_pointcloud_preprocessor::CudaPointcloud2CostmapFilterNode)

--- a/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_pointcloud_preprocessor/common_kernels.cu
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_pointcloud_preprocessor/common_kernels.cu
@@ -65,8 +65,16 @@ __global__ void cropBoxKernel(
       const float & max_x = crop_box_parameters.max_x;
       const float & max_y = crop_box_parameters.max_y;
       const float & max_z = crop_box_parameters.max_z;
-      passed_crop_box_mask &=
-        (x <= min_x || x >= max_x) || (y <= min_y || y >= max_y) || (z <= min_z || z >= max_z);
+      const std::uint8_t negative = crop_box_parameters.negative;
+
+      // Check if point is inside the box
+      bool point_is_inside =
+        (x > min_x && x < max_x) && (y > min_y && y < max_y) && (z > min_z && z < max_z);
+
+      // If negative mode (negative == 1): remove points within the box → preserve points outside
+      // If positive mode (negative == 0): remove points outside the box → preserve points inside
+      bool should_preserve = (negative != 0) ? !point_is_inside : point_is_inside;
+      passed_crop_box_mask &= (should_preserve ? 1 : 0);
     }
 
     output_crop_mask[idx] = passed_crop_box_mask;
@@ -98,6 +106,46 @@ __global__ void extractPointsKernel(
     output_point.intensity = input_point.intensity;
     output_point.return_type = input_point.return_type;
     output_point.channel = input_point.channel;
+  }
+}
+
+__global__ void extractInputPointsKernel(
+  InputPointType * __restrict__ input_points, std::uint32_t * __restrict__ masks,
+  std::uint32_t * __restrict__ indices, int num_points, InputPointType * __restrict__ output_points)
+{
+  int idx = blockIdx.x * blockDim.x + threadIdx.x;
+  if (idx < num_points && masks[idx] == 1) {
+    InputPointType & input_point = input_points[idx];
+    InputPointType & output_point = output_points[indices[idx] - 1];
+    // Copy all fields including extended ones
+    output_point = input_point;
+  }
+}
+
+__global__ void convertPointXYZIRCToInputPointTypeKernel(
+  const OutputPointType * __restrict__ input_points, InputPointType * __restrict__ output_points,
+  int num_points)
+{
+  int idx = blockIdx.x * blockDim.x + threadIdx.x;
+  if (idx < num_points) {
+    const OutputPointType & input_point = input_points[idx];
+    InputPointType & output_point = output_points[idx];
+
+    // Copy common fields
+    output_point.x = input_point.x;
+    output_point.y = input_point.y;
+    output_point.z = input_point.z;
+    output_point.intensity = input_point.intensity;
+    output_point.return_type = input_point.return_type;
+    output_point.channel = input_point.channel;
+
+    // Initialize extended fields with default values
+    // Set distance to 1.0f so points are not skipped by crop box kernel
+    // (which checks if distance == 0.0f)
+    output_point.azimuth = 0.0f;
+    output_point.elevation = 0.0f;
+    output_point.distance = 1.0f;  // Non-zero so point is not skipped
+    output_point.time_stamp = 0U;
   }
 }
 
@@ -134,6 +182,22 @@ void extractPointsLaunch(
 {
   extractPointsKernel<<<blocks_per_grid, threads_per_block, 0, stream>>>(
     input_points, masks, indices, num_points, output_points);
+}
+
+void extractInputPointsLaunch(
+  InputPointType * input_points, std::uint32_t * masks, std::uint32_t * indices, int num_points,
+  InputPointType * output_points, int threads_per_block, int blocks_per_grid, cudaStream_t & stream)
+{
+  extractInputPointsKernel<<<blocks_per_grid, threads_per_block, 0, stream>>>(
+    input_points, masks, indices, num_points, output_points);
+}
+
+void convertPointXYZIRCToInputPointTypeLaunch(
+  const OutputPointType * input_points, InputPointType * output_points, int num_points,
+  int threads_per_block, int blocks_per_grid, cudaStream_t & stream)
+{
+  convertPointXYZIRCToInputPointTypeKernel<<<blocks_per_grid, threads_per_block, 0, stream>>>(
+    input_points, output_points, num_points);
 }
 
 }  // namespace autoware::cuda_pointcloud_preprocessor

--- a/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor_node.cpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor_node.cpp
@@ -102,7 +102,7 @@ CudaPointcloudPreprocessorNode::CudaPointcloudPreprocessorNode(
     parameters.max_y = static_cast<float>(crop_box_max_y_vector.at(i));
     parameters.max_z = static_cast<float>(crop_box_max_z_vector.at(i));
     parameters.negative = static_cast<uint8_t>(
-      crop_box_max_z_vector.at(i));  // Default to positive mode (preserve inside)
+      crop_box_negative_vector.at(i));  // Default to positive mode (preserve inside)
     crop_box_parameters.push_back(parameters);
   }
 

--- a/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor_node.cpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor_node.cpp
@@ -80,6 +80,7 @@ CudaPointcloudPreprocessorNode::CudaPointcloudPreprocessorNode(
   const auto crop_box_max_x_vector = declare_parameter<std::vector<double>>("crop_box.max_x");
   const auto crop_box_max_y_vector = declare_parameter<std::vector<double>>("crop_box.max_y");
   const auto crop_box_max_z_vector = declare_parameter<std::vector<double>>("crop_box.max_z");
+  const auto crop_box_negative_vector = declare_parameter<std::vector<int>>("crop_box.negative");
 
   if (
     crop_box_min_x_vector.size() != crop_box_min_y_vector.size() ||
@@ -93,13 +94,15 @@ CudaPointcloudPreprocessorNode::CudaPointcloudPreprocessorNode(
   std::vector<CropBoxParameters> crop_box_parameters;
 
   for (std::size_t i = 0; i < crop_box_min_x_vector.size(); i++) {
-    CropBoxParameters parameters{};
+    CropBoxParameters parameters;
     parameters.min_x = static_cast<float>(crop_box_min_x_vector.at(i));
     parameters.min_y = static_cast<float>(crop_box_min_y_vector.at(i));
     parameters.min_z = static_cast<float>(crop_box_min_z_vector.at(i));
     parameters.max_x = static_cast<float>(crop_box_max_x_vector.at(i));
     parameters.max_y = static_cast<float>(crop_box_max_y_vector.at(i));
     parameters.max_z = static_cast<float>(crop_box_max_z_vector.at(i));
+    parameters.negative = static_cast<uint8_t>(
+      crop_box_max_z_vector.at(i));  // Default to positive mode (preserve inside)
     crop_box_parameters.push_back(parameters);
   }
 

--- a/sensing/autoware_cuda_pointcloud_preprocessor/test/test_cuda_crop_box_filter.cu
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/test/test_cuda_crop_box_filter.cu
@@ -1,0 +1,359 @@
+// Copyright 2025 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/cuda_pointcloud_preprocessor/common_kernels.hpp"
+#include "autoware/cuda_pointcloud_preprocessor/point_types.hpp"
+#include "autoware/cuda_pointcloud_preprocessor/types.hpp"
+#include "autoware/cuda_utils/cuda_check_error.hpp"
+#include "autoware/cuda_utils/cuda_gtest_utils.hpp"
+
+#include <gtest/gtest.h>
+#include <pcl/filters/crop_box.h>
+#include <pcl/point_cloud.h>
+#include <pcl/point_types.h>
+#include <thrust/device_ptr.h>
+#include <thrust/device_vector.h>
+#include <thrust/execution_policy.h>
+#include <thrust/scan.h>
+
+#include <algorithm>
+#include <cmath>
+#include <memory>
+#include <random>
+#include <vector>
+
+namespace autoware::cuda_pointcloud_preprocessor
+{
+
+class CudaCropBoxFilterTest : public autoware::cuda_utils::CudaTest
+{
+protected:
+  void SetUp() override
+  {
+    autoware::cuda_utils::CudaTest::SetUp();
+    rng_.seed(42);
+    CHECK_CUDA_ERROR(cudaStreamCreate(&stream_));
+  }
+
+  void TearDown() override
+  {
+    if (stream_) {
+      cudaStreamDestroy(stream_);
+    }
+    autoware::cuda_utils::CudaTest::TearDown();
+  }
+
+  // Helper function to create a test point cloud with random points
+  pcl::PointCloud<pcl::PointXYZ>::Ptr createTestPointCloud(
+    size_t num_points, float min_x = -10.0f, float max_x = 10.0f, float min_y = -10.0f,
+    float max_y = 10.0f, float min_z = -5.0f, float max_z = 5.0f)
+  {
+    pcl::PointCloud<pcl::PointXYZ>::Ptr cloud(new pcl::PointCloud<pcl::PointXYZ>);
+    cloud->points.reserve(num_points);
+
+    std::uniform_real_distribution<float> dist_x(min_x, max_x);
+    std::uniform_real_distribution<float> dist_y(min_y, max_y);
+    std::uniform_real_distribution<float> dist_z(min_z, max_z);
+
+    for (size_t i = 0; i < num_points; ++i) {
+      pcl::PointXYZ point;
+      point.x = dist_x(rng_);
+      point.y = dist_y(rng_);
+      point.z = dist_z(rng_);
+      cloud->points.push_back(point);
+    }
+
+    cloud->width = num_points;
+    cloud->height = 1;
+    cloud->is_dense = true;
+    return cloud;
+  }
+
+  // Convert PCL PointXYZ to InputPointType (on host)
+  std::vector<InputPointType> convertToInputPointType(
+    const pcl::PointCloud<pcl::PointXYZ>::Ptr & pcl_cloud)
+  {
+    std::vector<InputPointType> input_points;
+    input_points.reserve(pcl_cloud->points.size());
+
+    for (const auto & pcl_point : pcl_cloud->points) {
+      InputPointType point;
+      point.x = pcl_point.x;
+      point.y = pcl_point.y;
+      point.z = pcl_point.z;
+      point.intensity = 128;
+      point.return_type = 0;
+      point.channel = 0;
+      point.azimuth = 0.0f;
+      point.elevation = 0.0f;
+      point.distance = 1.0f;  // Non-zero so point is not skipped
+      point.time_stamp = 0U;
+      input_points.push_back(point);
+    }
+
+    return input_points;
+  }
+
+  // Convert OutputPointType to PCL PointXYZ (on host)
+  pcl::PointCloud<pcl::PointXYZ>::Ptr convertToPCL(
+    const std::vector<OutputPointType> & output_points)
+  {
+    pcl::PointCloud<pcl::PointXYZ>::Ptr cloud(new pcl::PointCloud<pcl::PointXYZ>);
+    cloud->points.reserve(output_points.size());
+
+    for (const auto & point : output_points) {
+      pcl::PointXYZ pcl_point;
+      pcl_point.x = point.x;
+      pcl_point.y = point.y;
+      pcl_point.z = point.z;
+      cloud->points.push_back(pcl_point);
+    }
+
+    cloud->width = cloud->points.size();
+    cloud->height = 1;
+    cloud->is_dense = true;
+    return cloud;
+  }
+
+  // Apply CUDA crop box kernel directly
+  pcl::PointCloud<pcl::PointXYZ>::Ptr applyCUDACropBoxKernel(
+    const pcl::PointCloud<pcl::PointXYZ>::Ptr & input_cloud, const CropBoxParameters & crop_params)
+  {
+    const size_t num_points = input_cloud->points.size();
+    if (num_points == 0) {
+      return std::make_shared<pcl::PointCloud<pcl::PointXYZ>>();
+    }
+
+    // Convert to InputPointType
+    std::vector<InputPointType> host_input_points = convertToInputPointType(input_cloud);
+
+    // Allocate device memory
+    thrust::device_vector<InputPointType> device_input_points(host_input_points);
+    thrust::device_vector<std::uint32_t> device_crop_mask(num_points, 0);
+    thrust::device_vector<std::uint8_t> device_nan_mask(num_points, 0);
+    thrust::device_vector<std::uint32_t> device_indices(num_points, 0);
+    thrust::device_vector<CropBoxParameters> device_crop_params(1, crop_params);
+
+    // Launch crop box kernel
+    const int threads_per_block = 512;
+    const int blocks_per_grid = (num_points + threads_per_block - 1) / threads_per_block;
+    cropBoxLaunch(
+      thrust::raw_pointer_cast(device_input_points.data()),
+      thrust::raw_pointer_cast(device_crop_mask.data()),
+      thrust::raw_pointer_cast(device_nan_mask.data()), static_cast<int>(num_points),
+      thrust::raw_pointer_cast(device_crop_params.data()), 1, threads_per_block, blocks_per_grid,
+      stream_);
+
+    // Compute indices using inclusive scan
+    thrust::inclusive_scan(
+      thrust::cuda::par_nosync.on(stream_), device_crop_mask.begin(), device_crop_mask.end(),
+      device_indices.begin());
+
+    // Get number of output points
+    int num_output_points = 0;
+    if (num_points > 0) {
+      std::uint32_t last_index = 0;
+      CHECK_CUDA_ERROR(cudaMemcpyAsync(
+        &last_index, thrust::raw_pointer_cast(device_indices.data() + num_points - 1),
+        sizeof(std::uint32_t), cudaMemcpyDeviceToHost, stream_));
+      CHECK_CUDA_ERROR(cudaStreamSynchronize(stream_));
+      num_output_points = static_cast<int>(last_index);
+    }
+
+    if (num_output_points == 0) {
+      return std::make_shared<pcl::PointCloud<pcl::PointXYZ>>();
+    }
+
+    // Extract points
+    thrust::device_vector<OutputPointType> device_output_points(num_output_points);
+    extractPointsLaunch(
+      thrust::raw_pointer_cast(device_input_points.data()),
+      thrust::raw_pointer_cast(device_crop_mask.data()),
+      thrust::raw_pointer_cast(device_indices.data()), static_cast<int>(num_points),
+      thrust::raw_pointer_cast(device_output_points.data()), threads_per_block, blocks_per_grid,
+      stream_);
+
+    CHECK_CUDA_ERROR(cudaStreamSynchronize(stream_));
+
+    // Copy back to host
+    std::vector<OutputPointType> host_output_points(num_output_points);
+    thrust::copy(
+      device_output_points.begin(), device_output_points.end(), host_output_points.begin());
+
+    return convertToPCL(host_output_points);
+  }
+
+  // Helper function to apply PCL crop box filter
+  pcl::PointCloud<pcl::PointXYZ>::Ptr applyPCLCropBox(
+    const pcl::PointCloud<pcl::PointXYZ>::Ptr & input_cloud, float min_x, float max_x, float min_y,
+    float max_y, float min_z, float max_z, bool negative = false)
+  {
+    pcl::PointCloud<pcl::PointXYZ>::Ptr output_cloud(new pcl::PointCloud<pcl::PointXYZ>);
+    pcl::CropBox<pcl::PointXYZ> crop_box;
+    crop_box.setInputCloud(input_cloud);
+    crop_box.setMin(Eigen::Vector4f(min_x, min_y, min_z, 1.0f));
+    crop_box.setMax(Eigen::Vector4f(max_x, max_y, max_z, 1.0f));
+    crop_box.setNegative(negative);
+    crop_box.filter(*output_cloud);
+    return output_cloud;
+  }
+
+  std::mt19937 rng_;
+  cudaStream_t stream_{};
+};
+
+TEST_F(CudaCropBoxFilterTest, BasicCropBoxFilter)
+{
+  // Create test point cloud
+  const size_t num_points = 1000;
+  auto pcl_input = createTestPointCloud(num_points, -10.0f, 10.0f, -10.0f, 10.0f, -5.0f, 5.0f);
+
+  // Define crop box parameters
+  CropBoxParameters crop_params;
+  crop_params.min_x = -5.0f;
+  crop_params.max_x = 5.0f;
+  crop_params.min_y = -5.0f;
+  crop_params.max_y = 5.0f;
+  crop_params.min_z = -2.0f;
+  crop_params.max_z = 2.0f;
+  crop_params.negative = 0;  // Positive mode: keep points inside
+
+  // Apply CUDA kernel
+  auto cuda_output = applyCUDACropBoxKernel(pcl_input, crop_params);
+
+  // Apply PCL filter for comparison
+  auto pcl_output = applyPCLCropBox(
+    pcl_input, crop_params.min_x, crop_params.max_x, crop_params.min_y, crop_params.max_y,
+    crop_params.min_z, crop_params.max_z, false);
+
+  // Compare results
+  EXPECT_EQ(cuda_output->points.size(), pcl_output->points.size())
+    << "CUDA and PCL should produce the same number of output points";
+
+  // Sort points by x, y, z for comparison (order may differ)
+  auto sortPoints = [](const pcl::PointXYZ & a, const pcl::PointXYZ & b) {
+    if (a.x != b.x) return a.x < b.x;
+    if (a.y != b.y) return a.y < b.y;
+    return a.z < b.z;
+  };
+
+  std::sort(cuda_output->points.begin(), cuda_output->points.end(), sortPoints);
+  std::sort(pcl_output->points.begin(), pcl_output->points.end(), sortPoints);
+
+  // Compare point coordinates (with tolerance for floating point)
+  const float tolerance = 1e-5f;
+  for (size_t i = 0; i < std::min(cuda_output->points.size(), pcl_output->points.size()); ++i) {
+    EXPECT_NEAR(cuda_output->points[i].x, pcl_output->points[i].x, tolerance);
+    EXPECT_NEAR(cuda_output->points[i].y, pcl_output->points[i].y, tolerance);
+    EXPECT_NEAR(cuda_output->points[i].z, pcl_output->points[i].z, tolerance);
+  }
+}
+
+TEST_F(CudaCropBoxFilterTest, NegativeCropBoxFilter)
+{
+  // Create test point cloud
+  const size_t num_points = 1000;
+  auto pcl_input = createTestPointCloud(num_points, -10.0f, 10.0f, -10.0f, 10.0f, -5.0f, 5.0f);
+
+  // Define crop box parameters (negative mode: remove points inside)
+  CropBoxParameters crop_params;
+  crop_params.min_x = -5.0f;
+  crop_params.max_x = 5.0f;
+  crop_params.min_y = -5.0f;
+  crop_params.max_y = 5.0f;
+  crop_params.min_z = -2.0f;
+  crop_params.max_z = 2.0f;
+  crop_params.negative = 1;  // Negative mode: remove points inside
+
+  // Apply CUDA kernel
+  auto cuda_output = applyCUDACropBoxKernel(pcl_input, crop_params);
+
+  // Apply PCL filter for comparison
+  auto pcl_output = applyPCLCropBox(
+    pcl_input, crop_params.min_x, crop_params.max_x, crop_params.min_y, crop_params.max_y,
+    crop_params.min_z, crop_params.max_z, true);
+
+  // Compare results
+  EXPECT_EQ(cuda_output->points.size(), pcl_output->points.size())
+    << "CUDA and PCL should produce the same number of output points in negative mode";
+}
+
+TEST_F(CudaCropBoxFilterTest, EmptyInput)
+{
+  // Test with empty point cloud
+  auto pcl_input = createTestPointCloud(0);
+
+  CropBoxParameters crop_params;
+  crop_params.min_x = -5.0f;
+  crop_params.max_x = 5.0f;
+  crop_params.min_y = -5.0f;
+  crop_params.max_y = 5.0f;
+  crop_params.min_z = -2.0f;
+  crop_params.max_z = 2.0f;
+  crop_params.negative = 0;
+
+  auto cuda_output = applyCUDACropBoxKernel(pcl_input, crop_params);
+
+  EXPECT_EQ(cuda_output->points.size(), 0);
+}
+
+TEST_F(CudaCropBoxFilterTest, AllPointsInside)
+{
+  // Create point cloud with all points inside crop box
+  const size_t num_points = 100;
+  auto pcl_input = createTestPointCloud(num_points, -2.0f, 2.0f, -2.0f, 2.0f, -1.0f, 1.0f);
+
+  CropBoxParameters crop_params;
+  crop_params.min_x = -5.0f;
+  crop_params.max_x = 5.0f;
+  crop_params.min_y = -5.0f;
+  crop_params.max_y = 5.0f;
+  crop_params.min_z = -5.0f;
+  crop_params.max_z = 5.0f;
+  crop_params.negative = 0;
+
+  auto cuda_output = applyCUDACropBoxKernel(pcl_input, crop_params);
+  auto pcl_output = applyPCLCropBox(
+    pcl_input, crop_params.min_x, crop_params.max_x, crop_params.min_y, crop_params.max_y,
+    crop_params.min_z, crop_params.max_z, false);
+
+  EXPECT_EQ(cuda_output->points.size(), pcl_output->points.size());
+  EXPECT_EQ(cuda_output->points.size(), num_points);
+}
+
+TEST_F(CudaCropBoxFilterTest, AllPointsOutside)
+{
+  // Create point cloud with all points outside crop box
+  const size_t num_points = 100;
+  auto pcl_input = createTestPointCloud(num_points, 10.0f, 20.0f, 10.0f, 20.0f, 10.0f, 20.0f);
+
+  CropBoxParameters crop_params;
+  crop_params.min_x = -5.0f;
+  crop_params.max_x = 5.0f;
+  crop_params.min_y = -5.0f;
+  crop_params.max_y = 5.0f;
+  crop_params.min_z = -5.0f;
+  crop_params.max_z = 5.0f;
+  crop_params.negative = 0;
+
+  auto cuda_output = applyCUDACropBoxKernel(pcl_input, crop_params);
+  auto pcl_output = applyPCLCropBox(
+    pcl_input, crop_params.min_x, crop_params.max_x, crop_params.min_y, crop_params.max_y,
+    crop_params.min_z, crop_params.max_z, false);
+
+  EXPECT_EQ(cuda_output->points.size(), pcl_output->points.size());
+  EXPECT_EQ(cuda_output->points.size(), 0);
+}
+
+}  // namespace autoware::cuda_pointcloud_preprocessor

--- a/sensing/autoware_cuda_pointcloud_preprocessor/test/test_cuda_pointcloud2costmap_filter.cu
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/test/test_cuda_pointcloud2costmap_filter.cu
@@ -1,0 +1,432 @@
+// Copyright 2025 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/cuda_pointcloud_preprocessor/cuda_pointcloud2costmap_filter/cuda_pointcloud2costmap_filter.hpp"
+#include "autoware/cuda_pointcloud_preprocessor/point_types.hpp"
+#include "autoware/cuda_utils/cuda_check_error.hpp"
+#include "autoware/cuda_utils/cuda_gtest_utils.hpp"
+
+#include <grid_map_ros/grid_map_ros.hpp>
+
+#include <gtest/gtest.h>
+#include <pcl/point_cloud.h>
+#include <pcl/point_types.h>
+#include <thrust/device_ptr.h>
+#include <thrust/device_vector.h>
+#include <thrust/execution_policy.h>
+#include <thrust/fill.h>
+
+#include <algorithm>
+#include <cmath>
+#include <memory>
+#include <random>
+#include <vector>
+
+namespace autoware::cuda_pointcloud_preprocessor
+{
+
+class CudaPointcloud2CostmapFilterTest : public autoware::cuda_utils::CudaTest
+{
+protected:
+  void SetUp() override
+  {
+    autoware::cuda_utils::CudaTest::SetUp();
+    rng_.seed(42);
+    CHECK_CUDA_ERROR(cudaStreamCreate(&stream_));
+  }
+
+  void TearDown() override
+  {
+    if (stream_) {
+      cudaStreamDestroy(stream_);
+    }
+    autoware::cuda_utils::CudaTest::TearDown();
+  }
+
+  // Helper function to create a test point cloud
+  pcl::PointCloud<pcl::PointXYZ>::Ptr createTestPointCloud(
+    size_t num_points, float center_x = 0.0f, float center_y = 0.0f, float center_z = 0.0f,
+    float spread = 10.0f)
+  {
+    pcl::PointCloud<pcl::PointXYZ>::Ptr cloud(new pcl::PointCloud<pcl::PointXYZ>);
+    cloud->points.reserve(num_points);
+
+    std::uniform_real_distribution<float> dist_x(center_x - spread, center_x + spread);
+    std::uniform_real_distribution<float> dist_y(center_y - spread, center_y + spread);
+    std::uniform_real_distribution<float> dist_z(center_z - 1.0f, center_z + 1.0f);
+
+    for (size_t i = 0; i < num_points; ++i) {
+      pcl::PointXYZ point;
+      point.x = dist_x(rng_);
+      point.y = dist_y(rng_);
+      point.z = dist_z(rng_);
+      cloud->points.push_back(point);
+    }
+
+    cloud->width = num_points;
+    cloud->height = 1;
+    cloud->is_dense = true;
+    return cloud;
+  }
+
+  // Convert PCL PointXYZ to InputPointType (on host)
+  std::vector<InputPointType> convertToInputPointType(
+    const pcl::PointCloud<pcl::PointXYZ>::Ptr & pcl_cloud)
+  {
+    std::vector<InputPointType> input_points;
+    input_points.reserve(pcl_cloud->points.size());
+
+    for (const auto & pcl_point : pcl_cloud->points) {
+      InputPointType point;
+      point.x = pcl_point.x;
+      point.y = pcl_point.y;
+      point.z = pcl_point.z;
+      point.intensity = 128;
+      point.return_type = 0;
+      point.channel = 0;
+      point.azimuth = 0.0f;
+      point.elevation = 0.0f;
+      point.distance = 1.0f;
+      point.time_stamp = 0U;
+      input_points.push_back(point);
+    }
+
+    return input_points;
+  }
+
+  // Apply CUDA costmap kernel directly
+  grid_map::Matrix applyCUDACostmapKernel(
+    const pcl::PointCloud<pcl::PointXYZ>::Ptr & input_cloud,
+    const CostmapParameters & costmap_params)
+  {
+    const size_t num_points = input_cloud->points.size();
+
+    // Calculate grid size
+    int grid_size_x =
+      static_cast<int>(std::ceil(costmap_params.grid_length_x / costmap_params.grid_resolution));
+    int grid_size_y =
+      static_cast<int>(std::ceil(costmap_params.grid_length_y / costmap_params.grid_resolution));
+
+    if (num_points == 0) {
+      // Initialize costmap with min_value
+      return grid_map::Matrix::Constant(grid_size_x, grid_size_y, costmap_params.grid_min_value);
+    }
+
+    // Convert to InputPointType
+    std::vector<InputPointType> host_input_points = convertToInputPointType(input_cloud);
+
+    // Prepare costmap parameters for device
+    CostmapGridParams host_params;
+    host_params.grid_length_x = static_cast<float>(costmap_params.grid_length_x);
+    host_params.grid_length_y = static_cast<float>(costmap_params.grid_length_y);
+    host_params.grid_resolution = static_cast<float>(costmap_params.grid_resolution);
+    host_params.grid_position_x = static_cast<float>(costmap_params.grid_position_x);
+    host_params.grid_position_y = static_cast<float>(costmap_params.grid_position_y);
+    host_params.maximum_height_thres = static_cast<float>(costmap_params.maximum_height_thres);
+    host_params.minimum_height_thres = static_cast<float>(costmap_params.minimum_height_thres);
+    host_params.grid_min_value = static_cast<float>(costmap_params.grid_min_value);
+    host_params.grid_max_value = static_cast<float>(costmap_params.grid_max_value);
+    host_params.grid_size_x = grid_size_x;
+    host_params.grid_size_y = grid_size_y;
+
+    // Allocate device memory
+    thrust::device_vector<InputPointType> device_input_points(host_input_points);
+    thrust::device_vector<int32_t> device_grid_indices(num_points, -1);
+    thrust::device_vector<float> device_costmap_data(grid_size_x * grid_size_y);
+    thrust::device_vector<CostmapGridParams> device_params(1, host_params);
+
+    // Initialize grid indices to -1 (invalid)
+    thrust::fill(device_grid_indices.begin(), device_grid_indices.end(), -1);
+
+    // Assign points to grid cells
+    const int threads_per_block = 512;
+    const int blocks_per_grid = (num_points + threads_per_block - 1) / threads_per_block;
+    assignPointsToGridCellsLaunch(
+      thrust::raw_pointer_cast(device_input_points.data()),
+      thrust::raw_pointer_cast(device_grid_indices.data()), static_cast<int>(num_points),
+      thrust::raw_pointer_cast(device_params.data()), threads_per_block, blocks_per_grid, stream_);
+
+    // Calculate costmap from grid cells
+    calculateCostmapFromGridCellsLaunch(
+      thrust::raw_pointer_cast(device_input_points.data()),
+      thrust::raw_pointer_cast(device_grid_indices.data()),
+      thrust::raw_pointer_cast(device_costmap_data.data()), static_cast<int>(num_points),
+      thrust::raw_pointer_cast(device_params.data()), threads_per_block, blocks_per_grid, stream_);
+
+    CHECK_CUDA_ERROR(cudaStreamSynchronize(stream_));
+
+    // Copy costmap data back to host
+    std::vector<float> host_costmap_data(grid_size_x * grid_size_y);
+    thrust::copy(device_costmap_data.begin(), device_costmap_data.end(), host_costmap_data.begin());
+
+    // Convert to grid_map::Matrix
+    grid_map::Matrix costmap_matrix(grid_size_x, grid_size_y);
+    for (int x = 0; x < grid_size_x; ++x) {
+      for (int y = 0; y < grid_size_y; ++y) {
+        // Linear index: x * grid_size_y + y
+        costmap_matrix(x, y) = host_costmap_data[x * grid_size_y + y];
+      }
+    }
+
+    return costmap_matrix;
+  }
+
+  // Helper function to create reference costmap using CPU implementation logic
+  grid_map::Matrix createReferenceCostmap(
+    const pcl::PointCloud<pcl::PointXYZ>::Ptr & input_cloud, double grid_length_x,
+    double grid_length_y, double grid_resolution, double grid_position_x, double grid_position_y,
+    double maximum_height_thres, double minimum_height_thres, double grid_min_value,
+    double grid_max_value)
+  {
+    // Calculate grid size
+    int grid_size_x = static_cast<int>(std::ceil(grid_length_x / grid_resolution));
+    int grid_size_y = static_cast<int>(std::ceil(grid_length_y / grid_resolution));
+
+    grid_map::Matrix costmap = grid_map::Matrix::Constant(grid_size_x, grid_size_y, grid_min_value);
+
+    // Assign points to grid cells (following CPU implementation logic)
+    for (const auto & point : input_cloud->points) {
+      // Calculate grid index (following fetchGridIndexFromPoint logic)
+      const double origin_x_offset = grid_length_x / 2.0 - grid_position_x;
+      const double origin_y_offset = grid_length_y / 2.0 - grid_position_y;
+      double mapped_x = (grid_length_x - origin_x_offset - point.x) / grid_resolution;
+      double mapped_y = (grid_length_y - origin_y_offset - point.y) / grid_resolution;
+
+      int mapped_x_ind = static_cast<int>(std::ceil(mapped_x));
+      int mapped_y_ind = static_cast<int>(std::ceil(mapped_y));
+
+      // Check if index is valid
+      if (
+        mapped_x_ind >= 0 && mapped_x_ind < grid_size_x && mapped_y_ind >= 0 &&
+        mapped_y_ind < grid_size_y) {
+        // Check height threshold
+        if (point.z <= maximum_height_thres && point.z >= minimum_height_thres) {
+          costmap(mapped_x_ind, mapped_y_ind) = grid_max_value;
+        }
+      }
+    }
+
+    return costmap;
+  }
+
+  // Helper function to compare two costmaps
+  void compareCostmaps(
+    const grid_map::Matrix & costmap1, const grid_map::Matrix & costmap2, const std::string & name)
+  {
+    EXPECT_EQ(costmap1.rows(), costmap2.rows()) << name << ": Costmap rows should match";
+    EXPECT_EQ(costmap1.cols(), costmap2.cols()) << name << ": Costmap cols should match";
+
+    if (costmap1.rows() == costmap2.rows() && costmap1.cols() == costmap2.cols()) {
+      int matching_cells = 0;
+      int total_cells = costmap1.rows() * costmap1.cols();
+
+      for (int i = 0; i < costmap1.rows(); ++i) {
+        for (int j = 0; j < costmap1.cols(); ++j) {
+          if (std::abs(costmap1(i, j) - costmap2(i, j)) < 1e-5) {
+            matching_cells++;
+          }
+        }
+      }
+
+      // Allow some tolerance for floating point differences
+      double match_ratio = static_cast<double>(matching_cells) / total_cells;
+      EXPECT_GT(match_ratio, 0.95) << name << ": At least 95% of cells should match";
+    }
+  }
+
+  std::mt19937 rng_;
+  cudaStream_t stream_{};
+};
+
+TEST_F(CudaPointcloud2CostmapFilterTest, BasicCostmapGeneration)
+{
+  // Create test point cloud
+  const size_t num_points = 1000;
+  auto pcl_input = createTestPointCloud(num_points, 0.0f, 0.0f, 0.0f, 10.0f);
+
+  // Define costmap parameters
+  CostmapParameters costmap_params;
+  costmap_params.grid_length_x = 20.0;
+  costmap_params.grid_length_y = 20.0;
+  costmap_params.grid_resolution = 0.5;
+  costmap_params.grid_position_x = 0.0;
+  costmap_params.grid_position_y = 0.0;
+  costmap_params.maximum_height_thres = 2.0;
+  costmap_params.minimum_height_thres = -2.0;
+  costmap_params.grid_min_value = 0.0;
+  costmap_params.grid_max_value = 100.0;
+
+  // Apply CUDA kernel
+  grid_map::Matrix cuda_costmap = applyCUDACostmapKernel(pcl_input, costmap_params);
+
+  // Create reference costmap
+  grid_map::Matrix reference_costmap = createReferenceCostmap(
+    pcl_input, costmap_params.grid_length_x, costmap_params.grid_length_y,
+    costmap_params.grid_resolution, costmap_params.grid_position_x, costmap_params.grid_position_y,
+    costmap_params.maximum_height_thres, costmap_params.minimum_height_thres,
+    costmap_params.grid_min_value, costmap_params.grid_max_value);
+
+  // Compare costmaps
+  compareCostmaps(cuda_costmap, reference_costmap, "BasicCostmapGeneration");
+}
+
+TEST_F(CudaPointcloud2CostmapFilterTest, EmptyInput)
+{
+  // Test with empty point cloud
+  auto pcl_input = createTestPointCloud(0);
+
+  CostmapParameters costmap_params;
+  costmap_params.grid_length_x = 20.0;
+  costmap_params.grid_length_y = 20.0;
+  costmap_params.grid_resolution = 0.5;
+  costmap_params.grid_position_x = 0.0;
+  costmap_params.grid_position_y = 0.0;
+  costmap_params.maximum_height_thres = 2.0;
+  costmap_params.minimum_height_thres = -2.0;
+  costmap_params.grid_min_value = 0.0;
+  costmap_params.grid_max_value = 100.0;
+
+  grid_map::Matrix cuda_costmap = applyCUDACostmapKernel(pcl_input, costmap_params);
+
+  // Should be initialized with min_value
+  int grid_size_x =
+    static_cast<int>(std::ceil(costmap_params.grid_length_x / costmap_params.grid_resolution));
+  int grid_size_y =
+    static_cast<int>(std::ceil(costmap_params.grid_length_y / costmap_params.grid_resolution));
+
+  EXPECT_EQ(cuda_costmap.rows(), grid_size_x);
+  EXPECT_EQ(cuda_costmap.cols(), grid_size_y);
+
+  // All cells should be min_value
+  for (int i = 0; i < cuda_costmap.rows(); ++i) {
+    for (int j = 0; j < cuda_costmap.cols(); ++j) {
+      EXPECT_NEAR(cuda_costmap(i, j), costmap_params.grid_min_value, 1e-5);
+    }
+  }
+}
+
+TEST_F(CudaPointcloud2CostmapFilterTest, HeightThresholdFiltering)
+{
+  // Create point cloud with points at different heights
+  pcl::PointCloud<pcl::PointXYZ> pcl_cloud;
+  // Points within height threshold
+  for (int i = 0; i < 100; ++i) {
+    pcl::PointXYZ point;
+    point.x = static_cast<float>(i % 10) - 5.0f;
+    point.y = static_cast<float>(i / 10) - 5.0f;
+    point.z = 0.5f;  // Within threshold
+    pcl_cloud.points.push_back(point);
+  }
+  // Points outside height threshold
+  for (int i = 0; i < 50; ++i) {
+    pcl::PointXYZ point;
+    point.x = static_cast<float>(i % 10) - 5.0f;
+    point.y = static_cast<float>(i / 10) - 5.0f;
+    point.z = 5.0f;  // Outside threshold (too high)
+    pcl_cloud.points.push_back(point);
+  }
+  for (int i = 0; i < 50; ++i) {
+    pcl::PointXYZ point;
+    point.x = static_cast<float>(i % 10) - 5.0f;
+    point.y = static_cast<float>(i / 10) - 5.0f;
+    point.z = -5.0f;  // Outside threshold (too low)
+    pcl_cloud.points.push_back(point);
+  }
+
+  pcl_cloud.width = pcl_cloud.points.size();
+  pcl_cloud.height = 1;
+  pcl_cloud.is_dense = true;
+
+  pcl::PointCloud<pcl::PointXYZ>::Ptr pcl_input(new pcl::PointCloud<pcl::PointXYZ>(pcl_cloud));
+
+  CostmapParameters costmap_params;
+  costmap_params.grid_length_x = 20.0;
+  costmap_params.grid_length_y = 20.0;
+  costmap_params.grid_resolution = 1.0;
+  costmap_params.grid_position_x = 0.0;
+  costmap_params.grid_position_y = 0.0;
+  costmap_params.maximum_height_thres = 2.0;
+  costmap_params.minimum_height_thres = -2.0;
+  costmap_params.grid_min_value = 0.0;
+  costmap_params.grid_max_value = 100.0;
+
+  grid_map::Matrix cuda_costmap = applyCUDACostmapKernel(pcl_input, costmap_params);
+
+  // Create reference
+  grid_map::Matrix reference_costmap = createReferenceCostmap(
+    pcl_input, costmap_params.grid_length_x, costmap_params.grid_length_y,
+    costmap_params.grid_resolution, costmap_params.grid_position_x, costmap_params.grid_position_y,
+    costmap_params.maximum_height_thres, costmap_params.minimum_height_thres,
+    costmap_params.grid_min_value, costmap_params.grid_max_value);
+
+  compareCostmaps(cuda_costmap, reference_costmap, "HeightThresholdFiltering");
+}
+
+TEST_F(CudaPointcloud2CostmapFilterTest, DifferentGridPositions)
+{
+  // Test with different grid positions
+  const size_t num_points = 500;
+  auto pcl_input = createTestPointCloud(num_points, 5.0f, 5.0f, 0.0f, 5.0f);
+
+  CostmapParameters costmap_params;
+  costmap_params.grid_length_x = 20.0;
+  costmap_params.grid_length_y = 20.0;
+  costmap_params.grid_resolution = 0.5;
+  costmap_params.grid_position_x = 5.0;  // Offset position
+  costmap_params.grid_position_y = 5.0;
+  costmap_params.maximum_height_thres = 2.0;
+  costmap_params.minimum_height_thres = -2.0;
+  costmap_params.grid_min_value = 0.0;
+  costmap_params.grid_max_value = 100.0;
+
+  grid_map::Matrix cuda_costmap = applyCUDACostmapKernel(pcl_input, costmap_params);
+
+  grid_map::Matrix reference_costmap = createReferenceCostmap(
+    pcl_input, costmap_params.grid_length_x, costmap_params.grid_length_y,
+    costmap_params.grid_resolution, costmap_params.grid_position_x, costmap_params.grid_position_y,
+    costmap_params.maximum_height_thres, costmap_params.minimum_height_thres,
+    costmap_params.grid_min_value, costmap_params.grid_max_value);
+
+  compareCostmaps(cuda_costmap, reference_costmap, "DifferentGridPositions");
+}
+
+TEST_F(CudaPointcloud2CostmapFilterTest, DifferentResolutions)
+{
+  // Test with different grid resolutions
+  const size_t num_points = 1000;
+  auto pcl_input = createTestPointCloud(num_points, 0.0f, 0.0f, 0.0f, 10.0f);
+
+  CostmapParameters costmap_params;
+  costmap_params.grid_length_x = 20.0;
+  costmap_params.grid_length_y = 20.0;
+  costmap_params.grid_resolution = 0.2;  // Higher resolution
+  costmap_params.grid_position_x = 0.0;
+  costmap_params.grid_position_y = 0.0;
+  costmap_params.maximum_height_thres = 2.0;
+  costmap_params.minimum_height_thres = -2.0;
+  costmap_params.grid_min_value = 0.0;
+  costmap_params.grid_max_value = 100.0;
+
+  grid_map::Matrix cuda_costmap = applyCUDACostmapKernel(pcl_input, costmap_params);
+
+  grid_map::Matrix reference_costmap = createReferenceCostmap(
+    pcl_input, costmap_params.grid_length_x, costmap_params.grid_length_y,
+    costmap_params.grid_resolution, costmap_params.grid_position_x, costmap_params.grid_position_y,
+    costmap_params.maximum_height_thres, costmap_params.minimum_height_thres,
+    costmap_params.grid_min_value, costmap_params.grid_max_value);
+
+  compareCostmaps(cuda_costmap, reference_costmap, "DifferentResolutions");
+}
+
+}  // namespace autoware::cuda_pointcloud_preprocessor

--- a/sensing/autoware_cuda_pointcloud_preprocessor/test/test_cuda_random_downsample_filter.cu
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/test/test_cuda_random_downsample_filter.cu
@@ -1,0 +1,356 @@
+// Copyright 2025 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/cuda_pointcloud_preprocessor/common_kernels.hpp"
+#include "autoware/cuda_pointcloud_preprocessor/cuda_downsample_filter/cuda_random_downsample_filter.hpp"
+#include "autoware/cuda_pointcloud_preprocessor/point_types.hpp"
+#include "autoware/cuda_utils/cuda_check_error.hpp"
+#include "autoware/cuda_utils/cuda_gtest_utils.hpp"
+
+#include <gtest/gtest.h>
+#include <pcl/filters/random_sample.h>
+#include <pcl/point_cloud.h>
+#include <pcl/point_types.h>
+#include <thrust/device_ptr.h>
+#include <thrust/device_vector.h>
+#include <thrust/execution_policy.h>
+#include <thrust/random.h>
+#include <thrust/sequence.h>
+#include <thrust/shuffle.h>
+
+#include <algorithm>
+#include <cmath>
+#include <memory>
+#include <random>
+#include <set>
+#include <vector>
+
+namespace autoware::cuda_pointcloud_preprocessor
+{
+namespace
+{
+// Copy the kernel from the implementation file for testing
+__global__ void randomSampleKernel(
+  const InputPointType * __restrict__ input_points, OutputPointType * __restrict__ output_points,
+  const std::uint32_t * __restrict__ selected_indices, size_t num_samples)
+{
+  size_t idx = blockIdx.x * blockDim.x + threadIdx.x;
+  if (idx >= num_samples) {
+    return;
+  }
+
+  const std::uint32_t input_idx = selected_indices[idx];
+  const InputPointType & input_point = input_points[input_idx];
+  OutputPointType & output_point = output_points[idx];
+
+  output_point.x = input_point.x;
+  output_point.y = input_point.y;
+  output_point.z = input_point.z;
+  output_point.intensity = input_point.intensity;
+  output_point.return_type = input_point.return_type;
+  output_point.channel = input_point.channel;
+}
+}  // namespace
+
+class CudaRandomDownsampleFilterTest : public autoware::cuda_utils::CudaTest
+{
+protected:
+  void SetUp() override
+  {
+    autoware::cuda_utils::CudaTest::SetUp();
+    rng_.seed(42);
+    CHECK_CUDA_ERROR(cudaStreamCreate(&stream_));
+  }
+
+  void TearDown() override
+  {
+    if (stream_) {
+      cudaStreamDestroy(stream_);
+    }
+    autoware::cuda_utils::CudaTest::TearDown();
+  }
+
+  // Helper function to create a test point cloud
+  pcl::PointCloud<pcl::PointXYZ>::Ptr createTestPointCloud(size_t num_points)
+  {
+    pcl::PointCloud<pcl::PointXYZ>::Ptr cloud(new pcl::PointCloud<pcl::PointXYZ>);
+    cloud->points.reserve(num_points);
+
+    std::uniform_real_distribution<float> dist(-10.0f, 10.0f);
+
+    for (size_t i = 0; i < num_points; ++i) {
+      pcl::PointXYZ point;
+      point.x = dist(rng_);
+      point.y = dist(rng_);
+      point.z = dist(rng_);
+      cloud->points.push_back(point);
+    }
+
+    cloud->width = num_points;
+    cloud->height = 1;
+    cloud->is_dense = true;
+    return cloud;
+  }
+
+  // Convert PCL PointXYZ to InputPointType (on host)
+  std::vector<InputPointType> convertToInputPointType(
+    const pcl::PointCloud<pcl::PointXYZ>::Ptr & pcl_cloud)
+  {
+    std::vector<InputPointType> input_points;
+    input_points.reserve(pcl_cloud->points.size());
+
+    for (const auto & pcl_point : pcl_cloud->points) {
+      InputPointType point;
+      point.x = pcl_point.x;
+      point.y = pcl_point.y;
+      point.z = pcl_point.z;
+      point.intensity = 128;
+      point.return_type = 0;
+      point.channel = 0;
+      point.azimuth = 0.0f;
+      point.elevation = 0.0f;
+      point.distance = 1.0f;
+      point.time_stamp = 0U;
+      input_points.push_back(point);
+    }
+
+    return input_points;
+  }
+
+  // Convert OutputPointType to PCL PointXYZ (on host)
+  pcl::PointCloud<pcl::PointXYZ>::Ptr convertToPCL(
+    const std::vector<OutputPointType> & output_points)
+  {
+    pcl::PointCloud<pcl::PointXYZ>::Ptr cloud(new pcl::PointCloud<pcl::PointXYZ>);
+    cloud->points.reserve(output_points.size());
+
+    for (const auto & point : output_points) {
+      pcl::PointXYZ pcl_point;
+      pcl_point.x = point.x;
+      pcl_point.y = point.y;
+      pcl_point.z = point.z;
+      cloud->points.push_back(pcl_point);
+    }
+
+    cloud->width = cloud->points.size();
+    cloud->height = 1;
+    cloud->is_dense = true;
+    return cloud;
+  }
+
+  // Apply CUDA random downsample kernel directly
+  pcl::PointCloud<pcl::PointXYZ>::Ptr applyCUDARandomDownsampleKernel(
+    const pcl::PointCloud<pcl::PointXYZ>::Ptr & input_cloud, size_t sample_num)
+  {
+    const size_t num_input_points = input_cloud->points.size();
+    if (num_input_points == 0) {
+      return std::make_shared<pcl::PointCloud<pcl::PointXYZ>>();
+    }
+
+    const size_t num_samples = std::min(sample_num, num_input_points);
+    if (num_samples == 0) {
+      return std::make_shared<pcl::PointCloud<pcl::PointXYZ>>();
+    }
+
+    // Convert to InputPointType
+    std::vector<InputPointType> host_input_points = convertToInputPointType(input_cloud);
+
+    // Allocate device memory
+    thrust::device_vector<InputPointType> device_input_points(host_input_points);
+    thrust::device_vector<std::uint32_t> device_all_indices(num_input_points);
+    thrust::device_vector<std::uint32_t> device_selected_indices(num_samples);
+
+    // Generate sequence of indices [0, 1, 2, ..., num_input_points-1]
+    thrust::sequence(device_all_indices.begin(), device_all_indices.end(), 0);
+
+    // Shuffle the indices using random number generator
+    std::random_device rd;
+    std::mt19937 gen(rd());
+    uint32_t seed = static_cast<uint32_t>(gen());
+    thrust::default_random_engine rng(seed);
+    thrust::shuffle(device_all_indices.begin(), device_all_indices.end(), rng);
+
+    // Copy first num_samples indices to selected_indices
+    thrust::copy(
+      device_all_indices.begin(), device_all_indices.begin() + num_samples,
+      device_selected_indices.begin());
+
+    // Allocate output buffer
+    thrust::device_vector<OutputPointType> device_output_points(num_samples);
+
+    // Sample points using random indices
+    const int threads_per_block = 512;
+    const int blocks_per_grid = (num_samples + threads_per_block - 1) / threads_per_block;
+    randomSampleKernel<<<blocks_per_grid, threads_per_block, 0, stream_>>>(
+      thrust::raw_pointer_cast(device_input_points.data()),
+      thrust::raw_pointer_cast(device_output_points.data()),
+      thrust::raw_pointer_cast(device_selected_indices.data()), num_samples);
+
+    CHECK_CUDA_ERROR(cudaStreamSynchronize(stream_));
+
+    // Copy back to host
+    std::vector<OutputPointType> host_output_points(num_samples);
+    thrust::copy(
+      device_output_points.begin(), device_output_points.end(), host_output_points.begin());
+
+    return convertToPCL(host_output_points);
+  }
+
+  // Helper function to apply PCL random sample filter
+  pcl::PointCloud<pcl::PointXYZ>::Ptr applyPCLRandomSample(
+    const pcl::PointCloud<pcl::PointXYZ>::Ptr & input_cloud, size_t sample_num)
+  {
+    pcl::PointCloud<pcl::PointXYZ>::Ptr output_cloud(new pcl::PointCloud<pcl::PointXYZ>);
+    pcl::RandomSample<pcl::PointXYZ> filter;
+    filter.setInputCloud(input_cloud);
+    filter.setSample(sample_num);
+    filter.filter(*output_cloud);
+    return output_cloud;
+  }
+
+  // Helper function to create a set of point coordinates for comparison
+  std::set<std::tuple<float, float, float>> createPointSet(
+    const pcl::PointCloud<pcl::PointXYZ>::Ptr & cloud)
+  {
+    std::set<std::tuple<float, float, float>> point_set;
+    for (const auto & point : cloud->points) {
+      point_set.insert(std::make_tuple(point.x, point.y, point.z));
+    }
+    return point_set;
+  }
+
+  std::mt19937 rng_;
+  cudaStream_t stream_{};
+};
+
+TEST_F(CudaRandomDownsampleFilterTest, BasicRandomDownsample)
+{
+  // Create test point cloud
+  const size_t num_input_points = 1000;
+  const size_t sample_num = 500;
+  auto pcl_input = createTestPointCloud(num_input_points);
+
+  // Apply CUDA kernel
+  auto cuda_output = applyCUDARandomDownsampleKernel(pcl_input, sample_num);
+
+  // Apply PCL filter for comparison
+  auto pcl_output = applyPCLRandomSample(pcl_input, sample_num);
+
+  // Check that output sizes match (should be sample_num or less)
+  EXPECT_EQ(cuda_output->points.size(), pcl_output->points.size())
+    << "CUDA and PCL should produce the same number of output points";
+  EXPECT_LE(cuda_output->points.size(), sample_num);
+  EXPECT_LE(cuda_output->points.size(), num_input_points);
+
+  // Verify that all output points are from the input (order may differ)
+  auto input_set = createPointSet(pcl_input);
+  auto cuda_output_set = createPointSet(cuda_output);
+  auto pcl_output_set = createPointSet(pcl_output);
+
+  // All CUDA output points should be in input
+  for (const auto & point : cuda_output_set) {
+    EXPECT_NE(input_set.find(point), input_set.end())
+      << "CUDA output point should be in input cloud";
+  }
+
+  // All PCL output points should be in input
+  for (const auto & point : pcl_output_set) {
+    EXPECT_NE(input_set.find(point), input_set.end())
+      << "PCL output point should be in input cloud";
+  }
+}
+
+TEST_F(CudaRandomDownsampleFilterTest, SampleNumLargerThanInput)
+{
+  // When sample_num > input size, should return all input points
+  const size_t num_input_points = 100;
+  const size_t sample_num = 500;  // Larger than input
+  auto pcl_input = createTestPointCloud(num_input_points);
+
+  auto cuda_output = applyCUDARandomDownsampleKernel(pcl_input, sample_num);
+  auto pcl_output = applyPCLRandomSample(pcl_input, sample_num);
+
+  // Both should return all input points (or sample_num, whichever is smaller)
+  EXPECT_EQ(cuda_output->points.size(), pcl_output->points.size());
+  EXPECT_EQ(cuda_output->points.size(), num_input_points);
+}
+
+TEST_F(CudaRandomDownsampleFilterTest, EmptyInput)
+{
+  // Test with empty point cloud
+  auto pcl_input = createTestPointCloud(0);
+
+  auto cuda_output = applyCUDARandomDownsampleKernel(pcl_input, 100);
+
+  EXPECT_EQ(cuda_output->points.size(), 0);
+}
+
+TEST_F(CudaRandomDownsampleFilterTest, SampleNumZero)
+{
+  // When sample_num is 0, should return empty cloud
+  const size_t num_input_points = 100;
+  const size_t sample_num = 0;
+  auto pcl_input = createTestPointCloud(num_input_points);
+
+  auto cuda_output = applyCUDARandomDownsampleKernel(pcl_input, sample_num);
+
+  EXPECT_EQ(cuda_output->points.size(), 0);
+}
+
+TEST_F(CudaRandomDownsampleFilterTest, SampleNumEqualsInput)
+{
+  // When sample_num == input size, should return all points (but order may differ)
+  const size_t num_input_points = 100;
+  const size_t sample_num = num_input_points;
+  auto pcl_input = createTestPointCloud(num_input_points);
+
+  auto cuda_output = applyCUDARandomDownsampleKernel(pcl_input, sample_num);
+  auto pcl_output = applyPCLRandomSample(pcl_input, sample_num);
+
+  // Should have same number of points
+  EXPECT_EQ(cuda_output->points.size(), pcl_output->points.size());
+  EXPECT_EQ(cuda_output->points.size(), num_input_points);
+
+  // Verify all points are present (using sets to ignore order)
+  auto input_set = createPointSet(pcl_input);
+  auto cuda_output_set = createPointSet(cuda_output);
+  auto pcl_output_set = createPointSet(pcl_output);
+
+  EXPECT_EQ(input_set.size(), cuda_output_set.size());
+  EXPECT_EQ(input_set.size(), pcl_output_set.size());
+}
+
+TEST_F(CudaRandomDownsampleFilterTest, LargePointCloud)
+{
+  // Test with larger point cloud
+  const size_t num_input_points = 10000;
+  const size_t sample_num = 1000;
+  auto pcl_input = createTestPointCloud(num_input_points);
+
+  auto cuda_output = applyCUDARandomDownsampleKernel(pcl_input, sample_num);
+  auto pcl_output = applyPCLRandomSample(pcl_input, sample_num);
+
+  EXPECT_EQ(cuda_output->points.size(), pcl_output->points.size());
+  EXPECT_LE(cuda_output->points.size(), sample_num);
+
+  // Verify all output points are from input
+  auto input_set = createPointSet(pcl_input);
+  auto cuda_output_set = createPointSet(cuda_output);
+
+  for (const auto & point : cuda_output_set) {
+    EXPECT_NE(input_set.find(point), input_set.end());
+  }
+}
+
+}  // namespace autoware::cuda_pointcloud_preprocessor

--- a/sensing/autoware_cuda_pointcloud_preprocessor/test/test_main.cpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/test/test_main.cpp
@@ -1,0 +1,21 @@
+// Copyright 2025 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+int main(int argc, char ** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## Description

This is an attempt to organize cuda point cloud processings scattered on different launch files and sub-nodes.

If we are perfecting the system to certain level, we should consider centralized all the pointcloud processing into GPU and the central node container.

- [x] Brief description on customized point cloud usage outside the touch of sensing teams.
- [x] Implement the `negative` parameters for cropbox launch and formulate cropbox as a standalone launchable node.
- [x] Implement the CUDA random downsample nodes for localization launch.
- [x] Add the option `output_point_xyzircaedt_`, existing CUDA kernel requires XYZIRCAEDT fields (and also the inner of cuda_pointcloud_processor), but topics flowing along the ROS system is XYZIRC. Add this option to allow flexible integration.
- [x] Test the system working with certain project launch for localization/perception downsampling, and verify the output contains no significant error.
- [x] Extend to Planning node filter usage.
- [ ] Coding documentation.
- [ ] Full correctness-performance testing.

This PR is posted mainly because I would like to push colaborations above components to improve the system status.


### Current Customized Point Cloud Processing

Continue in comments. https://github.com/autowarefoundation/autoware_universe/pull/11719#issuecomment-3605968939

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
