### PR TITLE
fix(autoware_simple_planning_simulator): fix dimension for DELAY_STEER_ACC_GEARED_WO_FALL_GUARD when set_initial_state()

### DIFF
--- a/simulator/autoware_simple_planning_simulator/src/simple_planning_simulator/simple_planning_simulator_core.cpp
+++ b/simulator/autoware_simple_planning_simulator/src/simple_planning_simulator/simple_planning_simulator_core.cpp
@@ -734,6 +734,7 @@ void SimplePlanningSimulator::set_initial_state(const Pose & pose, const Twist &
   const double vy = 0.0;
   const double steer = 0.0;
   const double accx = 0.0;
+  const double pedal_accx = 0.0;
 
   Eigen::VectorXd state(vehicle_model_ptr_->getDimX());
 
@@ -748,10 +749,11 @@ void SimplePlanningSimulator::set_initial_state(const Pose & pose, const Twist &
     state << x, y, yaw, vx, steer;
   } else if (vehicle_model_type_ == VehicleModelType::LEARNED_STEER_VEL) {
     state << x, y, yaw, yaw_rate, vx, vy, steer;
+  } else if (vehicle_model_type_ == VehicleModelType::DELAY_STEER_ACC_GEARED_WO_FALL_GUARD) {
+    state << x, y, yaw, vx, steer, accx, pedal_accx;
   } else if (  // NOLINT
     vehicle_model_type_ == VehicleModelType::DELAY_STEER_ACC ||
     vehicle_model_type_ == VehicleModelType::DELAY_STEER_ACC_GEARED ||
-    vehicle_model_type_ == VehicleModelType::DELAY_STEER_ACC_GEARED_WO_FALL_GUARD ||
     vehicle_model_type_ == VehicleModelType::DELAY_STEER_MAP_ACC_GEARED ||
     vehicle_model_type_ == VehicleModelType::ACTUATION_CMD ||
     vehicle_model_type_ == VehicleModelType::ACTUATION_CMD_VGR ||


### PR DESCRIPTION
## Description

The DELAY_STEER_ACC_GEARED_WO_FALL_GUARD has 7 dimension.
However,  6 parameter is given when initializing it in set_initial_state .
Therefore, Eigen asserts following errors and autoware_simple_planning_simulator_node process has died.
```
[autoware_simple_planning_simulator_node-57] autoware_simple_planning_simulator_node: /usr/include/eigen3/Eigen/src/Core/CommaInitializer.h:122: XprType& Eigen::CommaInitializer<MatrixType>::finished() [with XprType = Eigen::Matrix<double, -1, 1>]: Assertion `((m_row+m_currentBlockRows) == m_xpr.rows() || m_xpr.cols() == 0) && m_col == m_xpr.cols() && "Too few coefficients passed to comma initializer (operator<<)"' failed.
...
[ERROR] [autoware_simple_planning_simulator_node-57]: process has died...
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

In my environment, I checked Eigen assertion will no longer occurs when using psim.

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
