### PR TITLE
refactor: fix leftover dependent autoware_utils from updating vehicle_info_utils

### DIFF
--- a/control/autoware_control_validator/src/control_validator.cpp
+++ b/control/autoware_control_validator/src/control_validator.cpp
@@ -19,6 +19,8 @@
 #include "autoware/motion_utils/trajectory/trajectory.hpp"
 #include "autoware_vehicle_info_utils/vehicle_info_utils.hpp"
 
+#include <autoware_utils_geometry/geometry.hpp>
+
 #include <angles/angles/angles.h>
 
 #include <algorithm>
@@ -133,7 +135,7 @@ void AccelerationValidator::validate(
 {
   desired_acc_lpf.filter(
     control_cmd.longitudinal.acceleration +
-    9.8 * autoware_utils::get_rpy(kinematic_state.pose.pose).y);
+    9.8 * autoware_utils_geometry::get_rpy(kinematic_state.pose.pose).y);
   measured_acc_lpf.filter(loc_acc.accel.accel.linear.x);
   if (std::abs(kinematic_state.twist.twist.linear.x) < 0.3) {
     desired_acc_lpf.reset(0.0);

--- a/planning/autoware_path_optimizer/include/autoware/path_optimizer/utils/geometry_utils.hpp
+++ b/planning/autoware_path_optimizer/include/autoware/path_optimizer/utils/geometry_utils.hpp
@@ -57,8 +57,8 @@ namespace geometry_utils
 template <typename T1, typename T2>
 bool isSamePoint(const T1 & t1, const T2 & t2)
 {
-  const auto p1 = autoware_utils::get_point(t1);
-  const auto p2 = autoware_utils::get_point(t2);
+  const auto p1 = autoware_utils_geometry::get_point(t1);
+  const auto p2 = autoware_utils_geometry::get_point(t2);
 
   constexpr double epsilon = 1e-6;
   if (epsilon < std::abs(p1.x - p2.x) || epsilon < std::abs(p1.y - p2.y)) {

--- a/planning/autoware_path_optimizer/package.xml
+++ b/planning/autoware_path_optimizer/package.xml
@@ -21,6 +21,7 @@
   <depend>autoware_planning_msgs</depend>
   <depend>autoware_planning_test_manager</depend>
   <depend>autoware_utils</depend>
+  <depend>autoware_utils_geometry</depend>
   <depend>autoware_vehicle_info_utils</depend>
   <depend>diagnostic_updater</depend>
   <depend>geometry_msgs</depend>

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_no_drivable_lane_module/package.xml
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_no_drivable_lane_module/package.xml
@@ -25,6 +25,7 @@
   <depend>autoware_planning_msgs</depend>
   <depend>autoware_route_handler</depend>
   <depend>autoware_utils</depend>
+  <depend>autoware_utils_geometry</depend>
   <depend>eigen</depend>
   <depend>geometry_msgs</depend>
   <depend>libboost-dev</depend>

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_no_drivable_lane_module/src/experimental/scene.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_no_drivable_lane_module/src/experimental/scene.cpp
@@ -15,6 +15,7 @@
 #include "scene.hpp"
 
 #include <autoware_utils/ros/marker_helper.hpp>
+#include <autoware_utils_geometry/geometry.hpp>
 
 #include <memory>
 #include <vector>
@@ -30,7 +31,7 @@ visualization_msgs::msg::MarkerArray createNoDrivableLaneMarkers(
   using autoware_utils::create_default_marker;
   using autoware_utils::create_marker_color;
   using autoware_utils::create_marker_scale;
-  using autoware_utils::create_point;
+  using autoware_utils_geometry::create_point;
   using visualization_msgs::msg::Marker;
 
   visualization_msgs::msg::MarkerArray msg;
@@ -68,7 +69,7 @@ visualization_msgs::msg::MarkerArray createNoDrivableLaneMarkers(
 }
 }  // namespace
 
-using autoware_utils::create_point;
+using autoware_utils_geometry::create_point;
 
 NoDrivableLaneModule::NoDrivableLaneModule(
   const lanelet::Id module_id, const lanelet::Id lane_id, const PlannerParam & planner_param,
@@ -204,7 +205,7 @@ void NoDrivableLaneModule::handle_approaching_state(
   }
 
   geometry_msgs::msg::Point stop_point =
-    autoware_utils::get_point(path->points.at(target_point_idx).point);
+    autoware_utils_geometry::get_point(path->points.at(target_point_idx).point);
 
   const auto & op_stop_pose =
     planning_utils::insertStopPoint(stop_point, target_segment_idx, *path);
@@ -263,7 +264,7 @@ void NoDrivableLaneModule::handle_inside_no_drivable_lane_state(
 
   // Get stop point and stop factor
   {
-    const auto & stop_pose = autoware_utils::get_pose(path->points.at(0));
+    const auto & stop_pose = autoware_utils_geometry::get_pose(path->points.at(0));
     planning_factor_interface_->add(
       path->points, planner_data.current_odometry->pose, stop_pose,
       autoware_internal_planning_msgs::msg::PlanningFactor::STOP,

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_speed_bump_module/package.xml
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_speed_bump_module/package.xml
@@ -21,6 +21,7 @@
   <depend>autoware_planning_msgs</depend>
   <depend>autoware_route_handler</depend>
   <depend>autoware_utils</depend>
+  <depend>autoware_utils_geometry</depend>
   <depend>eigen</depend>
   <depend>geometry_msgs</depend>
   <depend>libboost-dev</depend>

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_speed_bump_module/src/experimental/scene.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_speed_bump_module/src/experimental/scene.cpp
@@ -15,6 +15,7 @@
 #include "scene.hpp"
 
 #include <autoware_utils/ros/marker_helper.hpp>
+#include <autoware_utils_geometry/geometry.hpp>
 
 #include <iostream>
 #include <memory>
@@ -25,11 +26,11 @@ namespace autoware::behavior_velocity_planner::experimental
 {
 using autoware::motion_utils::calcSignedArcLength;
 using autoware_utils::append_marker_array;
-using autoware_utils::calc_offset_pose;
 using autoware_utils::create_default_marker;
 using autoware_utils::create_marker_color;
 using autoware_utils::create_marker_scale;
-using autoware_utils::create_point;
+using autoware_utils_geometry::calc_offset_pose;
+using autoware_utils_geometry::create_point;
 using geometry_msgs::msg::Point32;
 using visualization_msgs::msg::Marker;
 
@@ -255,7 +256,7 @@ autoware::motion_utils::VirtualWalls SpeedBumpModule::createVirtualWalls()
   wall.ns = std::to_string(module_id_) + "_";
   wall.style = autoware::motion_utils::VirtualWallType::slowdown;
   for (const auto & p : debug_data_.slow_start_poses) {
-    wall.pose = autoware_utils::calc_offset_pose(p, debug_data_.base_link2front, 0.0, 0.0);
+    wall.pose = autoware_utils_geometry::calc_offset_pose(p, debug_data_.base_link2front, 0.0, 0.0);
     virtual_walls.push_back(wall);
   }
   return virtual_walls;

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/package.xml
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/package.xml
@@ -30,6 +30,7 @@
   <depend>autoware_route_handler</depend>
   <depend>autoware_traffic_light_utils</depend>
   <depend>autoware_utils</depend>
+  <depend>autoware_utils_geometry</depend>
   <depend>eigen</depend>
   <depend>geometry_msgs</depend>
   <depend>pluginlib</depend>

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/src/experimental/scene.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/src/experimental/scene.cpp
@@ -18,6 +18,7 @@
 
 #include <autoware/traffic_light_utils/traffic_light_utils.hpp>
 #include <autoware/trajectory/utils/find_nearest.hpp>
+#include <autoware_utils_geometry/geometry.hpp>
 
 #ifdef ROS_DISTRO_GALACTIC
 #include <tf2_eigen/tf2_eigen.h>
@@ -359,13 +360,13 @@ autoware::motion_utils::VirtualWalls TrafficLightModule::createVirtualWalls()
 
   wall.style = autoware::motion_utils::VirtualWallType::deadline;
   for (const auto & p : debug_data_.dead_line_poses) {
-    wall.pose = autoware_utils::calc_offset_pose(p, debug_data_.base_link2front, 0.0, 0.0);
+    wall.pose = autoware_utils_geometry::calc_offset_pose(p, debug_data_.base_link2front, 0.0, 0.0);
     virtual_walls.push_back(wall);
   }
 
   wall.style = autoware::motion_utils::VirtualWallType::stop;
   for (const auto & p : debug_data_.stop_poses) {
-    wall.pose = autoware_utils::calc_offset_pose(p, debug_data_.base_link2front, 0.0, 0.0);
+    wall.pose = autoware_utils_geometry::calc_offset_pose(p, debug_data_.base_link2front, 0.0, 0.0);
     virtual_walls.push_back(wall);
   }
 

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_virtual_traffic_light_module/package.xml
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_virtual_traffic_light_module/package.xml
@@ -26,6 +26,7 @@
   <depend>autoware_planning_msgs</depend>
   <depend>autoware_route_handler</depend>
   <depend>autoware_utils</depend>
+  <depend>autoware_utils_geometry</depend>
   <depend>autoware_vehicle_info_utils</depend>
   <depend>geometry_msgs</depend>
   <depend>nlohmann-json-dev</depend>

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_virtual_traffic_light_module/src/experimental/scene.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_virtual_traffic_light_module/src/experimental/scene.hpp
@@ -18,6 +18,7 @@
 #include <autoware/behavior_velocity_planner_common/experimental/scene_module_interface.hpp>
 #include <autoware_lanelet2_extension/regulatory_elements/virtual_traffic_light.hpp>
 #include <autoware_utils/system/time_keeper.hpp>
+#include <autoware_utils_geometry/geometry.hpp>
 
 #include <tier4_v2x_msgs/msg/infrastructure_command_array.hpp>
 #include <tier4_v2x_msgs/msg/virtual_traffic_light_state_array.hpp>
@@ -47,10 +48,10 @@ public:
     std::string instrument_type{};
     std::string instrument_id{};
     std::vector<tier4_v2x_msgs::msg::KeyValue> custom_tags{};
-    autoware_utils::Point3d instrument_center{};
-    std::optional<autoware_utils::LineString3d> stop_line{};
-    autoware_utils::LineString3d start_line{};
-    std::vector<autoware_utils::LineString3d> end_lines{};
+    autoware_utils_geometry::Point3d instrument_center{};
+    std::optional<autoware_utils_geometry::LineString3d> stop_line{};
+    autoware_utils_geometry::LineString3d start_line{};
+    std::vector<autoware_utils_geometry::LineString3d> end_lines{};
     std::string stop_line_id_for_log{};
   };
 

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_walkway_module/package.xml
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_walkway_module/package.xml
@@ -25,6 +25,7 @@
   <depend>autoware_planning_msgs</depend>
   <depend>autoware_route_handler</depend>
   <depend>autoware_utils</depend>
+  <depend>autoware_utils_geometry</depend>
   <depend>autoware_vehicle_info_utils</depend>
   <depend>geometry_msgs</depend>
   <depend>libboost-dev</depend>

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_walkway_module/src/experimental/scene_walkway.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_walkway_module/src/experimental/scene_walkway.cpp
@@ -16,6 +16,7 @@
 
 #include <autoware_lanelet2_extension/regulatory_elements/crosswalk.hpp>
 #include <autoware_utils/ros/marker_helper.hpp>
+#include <autoware_utils_geometry/geometry.hpp>
 
 #include <cmath>
 #include <memory>
@@ -28,16 +29,16 @@ namespace bg = boost::geometry;
 using autoware::motion_utils::calcLongitudinalOffsetPose;
 using autoware::motion_utils::calcSignedArcLength;
 using autoware::motion_utils::findNearestSegmentIndex;
-using autoware_utils::create_point;
-using autoware_utils::get_pose;
+using autoware_utils_geometry::create_point;
+using autoware_utils_geometry::get_pose;
 
 namespace
 {
 using autoware_utils::append_marker_array;
-using autoware_utils::calc_offset_pose;
 using autoware_utils::create_default_marker;
 using autoware_utils::create_marker_color;
 using autoware_utils::create_marker_scale;
+using autoware_utils_geometry::calc_offset_pose;
 using visualization_msgs::msg::Marker;
 
 visualization_msgs::msg::MarkerArray createWalkwayMarkers(

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_cruise_module/package.xml
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_cruise_module/package.xml
@@ -23,6 +23,7 @@
   <depend>autoware_route_handler</depend>
   <depend>autoware_signal_processing</depend>
   <depend>autoware_utils</depend>
+  <depend>autoware_utils_geometry</depend>
   <depend>autoware_vehicle_info_utils</depend>
   <depend>geometry_msgs</depend>
   <depend>libboost-dev</depend>

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_cruise_module/src/type_alias.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_cruise_module/src/type_alias.hpp
@@ -17,6 +17,8 @@
 
 #include "autoware_vehicle_info_utils/vehicle_info_utils.hpp"
 
+#include <autoware_utils_geometry/geometry.hpp>
+
 #include "autoware_internal_debug_msgs/msg/float32_multi_array_stamped.hpp"
 #include "autoware_internal_debug_msgs/msg/float32_stamped.hpp"
 #include "autoware_internal_debug_msgs/msg/float64_stamped.hpp"
@@ -58,8 +60,8 @@ using unique_identifier_msgs::msg::UUID;
 using visualization_msgs::msg::Marker;
 using visualization_msgs::msg::MarkerArray;
 namespace bg = boost::geometry;
-using autoware_utils::Point2d;
-using autoware_utils::Polygon2d;
+using autoware_utils_geometry::Point2d;
+using autoware_utils_geometry::Polygon2d;
 using PointCloud = pcl::PointCloud<pcl::PointXYZ>;
 using autoware_internal_planning_msgs::msg::PlanningFactor;
 using autoware_internal_planning_msgs::msg::SafetyFactorArray;

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_slow_down_module/package.xml
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_slow_down_module/package.xml
@@ -23,6 +23,7 @@
   <depend>autoware_route_handler</depend>
   <depend>autoware_signal_processing</depend>
   <depend>autoware_utils</depend>
+  <depend>autoware_utils_geometry</depend>
   <depend>autoware_vehicle_info_utils</depend>
   <depend>geometry_msgs</depend>
   <depend>libboost-dev</depend>

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_slow_down_module/src/type_alias.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_slow_down_module/src/type_alias.hpp
@@ -17,6 +17,8 @@
 
 #include "autoware_vehicle_info_utils/vehicle_info_utils.hpp"
 
+#include <autoware_utils_geometry/geometry.hpp>
+
 #include "autoware_internal_debug_msgs/msg/float32_multi_array_stamped.hpp"
 #include "autoware_internal_debug_msgs/msg/float32_stamped.hpp"
 #include "autoware_internal_debug_msgs/msg/float64_stamped.hpp"
@@ -58,8 +60,8 @@ using unique_identifier_msgs::msg::UUID;
 using visualization_msgs::msg::Marker;
 using visualization_msgs::msg::MarkerArray;
 namespace bg = boost::geometry;
-using autoware_utils::Point2d;
-using autoware_utils::Polygon2d;
+using autoware_utils_geometry::Point2d;
+using autoware_utils_geometry::Polygon2d;
 using PointCloud = pcl::PointCloud<pcl::PointXYZ>;
 using autoware_internal_planning_msgs::msg::PlanningFactor;
 using autoware_internal_planning_msgs::msg::SafetyFactorArray;

--- a/planning/motion_velocity_planner/autoware_motion_velocity_road_user_stop_module/package.xml
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_road_user_stop_module/package.xml
@@ -23,6 +23,7 @@
   <depend>autoware_planning_msgs</depend>
   <depend>autoware_route_handler</depend>
   <depend>autoware_universe_utils</depend>
+  <depend>autoware_utils_geometry</depend>
   <depend>autoware_vehicle_info_utils</depend>
   <depend>generate_parameter_library</depend>
   <depend>geometry_msgs</depend>

--- a/planning/motion_velocity_planner/autoware_motion_velocity_road_user_stop_module/src/road_user_stop_module.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_road_user_stop_module/src/road_user_stop_module.cpp
@@ -32,6 +32,7 @@
 #include <autoware_lanelet2_extension/utility/query.hpp>
 #include <autoware_lanelet2_extension/utility/utilities.hpp>
 #include <autoware_utils_geometry/boost_polygon_utils.hpp>
+#include <autoware_utils_geometry/geometry.hpp>
 #include <autoware_utils_rclcpp/parameter.hpp>
 #include <autoware_utils_visualization/marker_helper.hpp>
 #include <pluginlib/class_list_macros.hpp>

--- a/planning/motion_velocity_planner/autoware_motion_velocity_road_user_stop_module/src/type_alias.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_road_user_stop_module/src/type_alias.hpp
@@ -15,6 +15,7 @@
 #ifndef TYPE_ALIAS_HPP_
 #define TYPE_ALIAS_HPP_
 
+#include <autoware_utils_geometry/geometry.hpp>
 #include <autoware_vehicle_info_utils/vehicle_info_utils.hpp>
 
 #include <autoware_internal_planning_msgs/msg/planning_factor.hpp>
@@ -37,7 +38,7 @@ using autoware_perception_msgs::msg::PredictedObject;
 using autoware_perception_msgs::msg::PredictedObjects;
 using autoware_perception_msgs::msg::Shape;
 using autoware_planning_msgs::msg::LaneletRoute;
-using autoware_utils::LineString2d;
+using autoware_utils_geometry::LineString2d;
 using autoware_utils_geometry::Polygon2d;
 using geometry_msgs::msg::Point;
 using geometry_msgs::msg::Pose;

--- a/planning/planning_validator/autoware_planning_validator_rear_collision_checker/package.xml
+++ b/planning/planning_validator/autoware_planning_validator_rear_collision_checker/package.xml
@@ -28,6 +28,7 @@
   <depend>autoware_route_handler</depend>
   <depend>autoware_signal_processing</depend>
   <depend>autoware_utils</depend>
+  <depend>autoware_utils_geometry</depend>
   <depend>autoware_vehicle_info_utils</depend>
   <depend>diagnostic_msgs</depend>
   <depend>eigen</depend>

--- a/planning/planning_validator/autoware_planning_validator_rear_collision_checker/src/structs.hpp
+++ b/planning/planning_validator/autoware_planning_validator_rear_collision_checker/src/structs.hpp
@@ -17,6 +17,7 @@
 
 #include <autoware_planning_validator_rear_collision_checker/rear_collision_checker_node_parameters.hpp>
 #include <autoware_utils/ros/marker_helper.hpp>
+#include <autoware_utils_geometry/geometry.hpp>
 #include <autoware_vehicle_info_utils/vehicle_info_utils.hpp>
 
 #include <autoware_internal_debug_msgs/msg/string_stamped.hpp>
@@ -110,9 +111,9 @@ using PointCloudObjects = std::vector<PointCloudObject>;
 
 struct DebugData
 {
-  autoware_utils::LineString3d reachable_line;
+  autoware_utils_geometry::LineString3d reachable_line;
 
-  autoware_utils::LineString3d stoppable_line;
+  autoware_utils_geometry::LineString3d stoppable_line;
 
   lanelet::ConstLanelets current_lanes;
 
@@ -128,7 +129,7 @@ struct DebugData
 
   Behavior shift_behavior{Behavior::NONE};
 
-  std::vector<autoware_utils::Polygon3d> hull_polygons;
+  std::vector<autoware_utils_geometry::Polygon3d> hull_polygons;
 
   std::vector<size_t> pointcloud_nums{};
 


### PR DESCRIPTION
## Description

- Should be merged before: https://github.com/autowarefoundation/autoware_core/pull/754

It is not a pretty PR. But it was necessary after pushing the PR above.

`autoware_vehicle_info_utils` leaked so many symbols all over place so I fix only the necessary ones in this PR.

In the future more renaming refactors are needed.

For now, it passes build & test.

## How was this PR tested?

Local build & CI.