### PR TITLE
fix(autoware_bluetooth_monitor): add respawn_delay to prevent rapid respawn loop

### DIFF
--- a/system/autoware_bluetooth_monitor/launch/bluetooth_monitor.launch.xml
+++ b/system/autoware_bluetooth_monitor/launch/bluetooth_monitor.launch.xml
@@ -1,6 +1,6 @@
 <launch>
   <arg name="bluetooth_monitor_param_file" default="$(find-pkg-share autoware_bluetooth_monitor)/config/bluetooth_monitor.param.yaml"/>
-  <node pkg="autoware_bluetooth_monitor" exec="autoware_bluetooth_monitor_node" output="log" respawn="true">
+  <node pkg="autoware_bluetooth_monitor" exec="autoware_bluetooth_monitor_node" output="log" respawn="true" respawn_delay="5.0">
     <param from="$(var bluetooth_monitor_param_file)"/>
   </node>
 </launch>


### PR DESCRIPTION
## Description

Add `respawn_delay="5.0"` to the launch file to prevent rapid respawn loops when the node crashes.

## Related Issue

- #11736

## Purpose

This addresses the Process Respawn Loop anti-pattern by ensuring a 5-second delay between node restarts, preventing:
- CPU usage spikes from rapid respawn cycles
- Log flooding from repeated crash/restart sequences
- System instability during transient failures

## Changes

- Added `respawn_delay="5.0"` attribute to the node element in `bluetooth_monitor.launch.xml`

## Future Improvements

In a future PR, we plan to implement retry logic with exponential backoff for socket connection errors in `bluetooth_monitor.cpp`. This will:
- Handle transient Bluetooth connection failures gracefully within the node
- Reduce unnecessary node crashes by retrying failed connections
- Provide configurable retry parameters (max retries, initial delay, max delay)

## Test

- [x] Built successfully in Docker (`colcon build`)
- [x] All existing tests pass (`colcon test`: 23 tests, 0 failures)