### PR TITLE
fix(autoware_velodyne_monitor): add respawn_delay to prevent rapid respawn loop

### DIFF
--- a/system/autoware_velodyne_monitor/launch/velodyne_monitor.launch.xml
+++ b/system/autoware_velodyne_monitor/launch/velodyne_monitor.launch.xml
@@ -2,7 +2,7 @@
   <arg name="velodyne_monitor_param_file" default="$(find-pkg-share autoware_velodyne_monitor)/config/VLP-16.param.yaml"/>
   <arg name="ip_address" default="192.168.1.201"/>
 
-  <node pkg="autoware_velodyne_monitor" exec="autoware_velodyne_monitor_node" name="velodyne_monitor" output="log" respawn="true">
+  <node pkg="autoware_velodyne_monitor" exec="autoware_velodyne_monitor_node" name="velodyne_monitor" output="log" respawn="true" respawn_delay="5.0">
     <param from="$(var velodyne_monitor_param_file)"/>
     <param name="ip_address" value="$(var ip_address)"/>
   </node>


### PR DESCRIPTION
## Description

Add `respawn_delay="5.0"` to the launch file to prevent rapid respawn loops when the node crashes.

## Related Issue

- #11736

## Purpose

This addresses the Process Respawn Loop anti-pattern by ensuring a 5-second delay between node restarts, preventing:
- CPU usage spikes from rapid respawn cycles
- Log flooding from repeated crash/restart sequences
- System instability during transient failures

## Changes

- Added `respawn_delay="5.0"` attribute to the node element in `velodyne_monitor.launch.xml`

## Future Improvements

In a future PR, we plan to implement HTTP retry logic with exponential backoff in `velodyne_monitor.cpp`. This will:
- Handle transient Velodyne sensor connection failures gracefully within the node
- Reduce unnecessary node crashes by retrying failed HTTP requests
- Provide configurable retry parameters (max retries, initial backoff, max backoff)

## Test

- [x] Built successfully in Docker (`colcon build`)
- [x] All existing tests pass (`colcon test`: 11 tests, 0 failures)