### PR TITLE
fix(autoware_livox_tag_filter): add empty point cloud guard

### DIFF
--- a/sensing/livox/autoware_livox_tag_filter/src/livox_tag_filter_node.cpp
+++ b/sensing/livox/autoware_livox_tag_filter/src/livox_tag_filter_node.cpp
@@ -61,6 +61,12 @@ LivoxTagFilterNode::LivoxTagFilterNode(const rclcpp::NodeOptions & node_options)
 
 void LivoxTagFilterNode::onPointCloud(const sensor_msgs::msg::PointCloud2::ConstSharedPtr msg)
 {
+  // check for empty point cloud
+  if (msg->data.empty() || msg->width == 0 || msg->height == 0) {
+    RCLCPP_DEBUG(get_logger(), "Empty point cloud received, skipping processing");
+    return;
+  }
+
   pcl::PointCloud<LivoxPoint> points;
   pcl::fromROSMsg(*msg, points);
 


### PR DESCRIPTION
## Description

Add validation to check for empty point clouds before processing to prevent undefined behavior in PCL functions and potential crashes.

## Related links

**Parent Issue:**

- #11737

## How was this PR tested?

- Built successfully in Docker environment with `ghcr.io/autowarefoundation/autoware:universe-devel`
- All 11 tests passed (0 errors, 0 failures)

## Notes for reviewers

The fix follows the recommended pattern from issue #11737:
```cpp
if (msg->data.empty() || msg->width == 0 || msg->height == 0) {
  RCLCPP_DEBUG(get_logger(), "Empty point cloud received, skipping processing");
  return;
}
```

## Interface changes

None.

## Effects on system behavior

When empty point clouds are received, the node will now skip processing and return early instead of potentially causing undefined behavior in PCL functions.