### PR TITLE
fix(autoware_ground_segmentation): add empty point cloud guards

### DIFF
--- a/perception/autoware_ground_segmentation/src/ransac_ground_filter/node.cpp
+++ b/perception/autoware_ground_segmentation/src/ransac_ground_filter/node.cpp
@@ -224,6 +224,14 @@ void RANSACGroundFilterComponent::filter(
   if (time_keeper_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_);
 
   std::scoped_lock lock(mutex_);
+
+  // check for empty point cloud
+  if (input->data.empty() || input->width == 0 || input->height == 0) {
+    RCLCPP_DEBUG(get_logger(), "Empty point cloud received, skipping processing");
+    output = *input;
+    return;
+  }
+
   sensor_msgs::msg::PointCloud2::SharedPtr input_transformed_ptr(new sensor_msgs::msg::PointCloud2);
   if (!managed_tf_buffer_->transformPointcloud(
         base_frame_, *input, *input_transformed_ptr, input->header.stamp,

--- a/perception/autoware_ground_segmentation/src/ray_ground_filter/node.cpp
+++ b/perception/autoware_ground_segmentation/src/ray_ground_filter/node.cpp
@@ -337,6 +337,13 @@ void RayGroundFilterComponent::filter(
 
   std::scoped_lock lock(mutex_);
 
+  // check for empty point cloud
+  if (input->data.empty() || input->width == 0 || input->height == 0) {
+    RCLCPP_DEBUG(get_logger(), "Empty point cloud received, skipping processing");
+    output = *input;
+    return;
+  }
+
   pcl::PointCloud<PointType_>::Ptr current_sensor_cloud_ptr(new pcl::PointCloud<PointType_>);
   pcl::fromROSMsg(*input, *current_sensor_cloud_ptr);
 


### PR DESCRIPTION
## Description

Add validation to check for empty point clouds before processing to prevent undefined behavior in PCL functions and potential crashes.

- Add guard in `ray_ground_filter`
- Add guard in `ransac_ground_filter`

## Related links

**Parent Issue:**

- #11737

## How was this PR tested?

- Built successfully in Docker environment with `ghcr.io/autowarefoundation/autoware:universe-devel`
- All 44 tests passed (0 errors, 0 failures)

## Notes for reviewers

The fix follows the recommended pattern from issue #11737. For filter functions, the empty input is passed through to output:
```cpp
if (input->data.empty() || input->width == 0 || input->height == 0) {
  RCLCPP_DEBUG(get_logger(), "Empty point cloud received, skipping processing");
  output = *input;
  return;
}
```

## Interface changes

None.

## Effects on system behavior

When empty point clouds are received, the filter will now skip processing and pass through the empty input instead of potentially causing undefined behavior in PCL functions.