### PR TITLE
feat(autoware_pointcloud_preprocessor): add ComposableNode support to filter launch files

### DIFF
--- a/sensing/autoware_pointcloud_preprocessor/CMakeLists.txt
+++ b/sensing/autoware_pointcloud_preprocessor/CMakeLists.txt
@@ -327,4 +327,8 @@ if(BUILD_TESTING)
     TIMEOUT "50"
   )
 
+  find_package(launch_testing_ament_cmake REQUIRED)
+  add_launch_test(test/test_voxel_grid_launch.py)
+  add_launch_test(test/test_voxel_grid_launch_composable.py)
+
 endif()

--- a/sensing/autoware_pointcloud_preprocessor/launch/crop_box_filter_node.launch.xml
+++ b/sensing/autoware_pointcloud_preprocessor/launch/crop_box_filter_node.launch.xml
@@ -4,11 +4,25 @@
   <arg name="input_frame" default="base_link"/>
   <arg name="output_frame" default="base_link"/>
   <arg name="crop_box_filter_param_file" default="$(find-pkg-share autoware_pointcloud_preprocessor)/config/crop_box_filter_node.param.yaml"/>
-  <node pkg="autoware_pointcloud_preprocessor" exec="crop_box_filter_node" name="crop_box_filter_node">
+  <arg name="container_name" default="" description="Container name for composable node. If empty, standalone node is launched."/>
+
+  <!-- Standalone mode: launch as a regular node when container_name is empty -->
+  <node pkg="autoware_pointcloud_preprocessor" exec="crop_box_filter_node" name="crop_box_filter_node" if="$(eval &quot;'$(var container_name)'==''&quot;)">
     <param from="$(var crop_box_filter_param_file)"/>
     <remap from="input" to="$(var input_topic_name)"/>
     <remap from="output" to="$(var output_topic_name)"/>
     <param name="input_frame" value="$(var input_frame)"/>
     <param name="output_frame" value="$(var output_frame)"/>
   </node>
+
+  <!-- Composable mode: load into existing container when container_name is specified -->
+  <load_composable_node target="$(var container_name)" if="$(eval &quot;'$(var container_name)'!=''&quot;)">
+    <composable_node pkg="autoware_pointcloud_preprocessor" plugin="autoware::pointcloud_preprocessor::CropBoxFilterComponent" name="crop_box_filter_node" namespace="">
+      <param from="$(var crop_box_filter_param_file)"/>
+      <remap from="input" to="$(var input_topic_name)"/>
+      <remap from="output" to="$(var output_topic_name)"/>
+      <param name="input_frame" value="$(var input_frame)"/>
+      <param name="output_frame" value="$(var output_frame)"/>
+    </composable_node>
+  </load_composable_node>
 </launch>

--- a/sensing/autoware_pointcloud_preprocessor/launch/ring_outlier_filter_node.launch.xml
+++ b/sensing/autoware_pointcloud_preprocessor/launch/ring_outlier_filter_node.launch.xml
@@ -4,11 +4,25 @@
   <arg name="input_frame" default=""/>
   <arg name="output_frame" default=""/>
   <arg name="ring_outlier_filter_param_file" default="$(find-pkg-share autoware_pointcloud_preprocessor)/config/ring_outlier_filter_node.param.yaml"/>
-  <node pkg="autoware_pointcloud_preprocessor" exec="ring_outlier_filter_node" name="ring_outlier_filter_node">
+  <arg name="container_name" default="" description="Container name for composable node. If empty, standalone node is launched."/>
+
+  <!-- Standalone mode: launch as a regular node when container_name is empty -->
+  <node pkg="autoware_pointcloud_preprocessor" exec="ring_outlier_filter_node" name="ring_outlier_filter_node" if="$(eval &quot;'$(var container_name)'==''&quot;)">
     <param from="$(var ring_outlier_filter_param_file)"/>
     <remap from="input" to="$(var input_topic_name)"/>
     <remap from="output" to="$(var output_topic_name)"/>
     <param name="input_frame" value="$(var input_frame)"/>
     <param name="output_frame" value="$(var output_frame)"/>
   </node>
+
+  <!-- Composable mode: load into existing container when container_name is specified -->
+  <load_composable_node target="$(var container_name)" if="$(eval &quot;'$(var container_name)'!=''&quot;)">
+    <composable_node pkg="autoware_pointcloud_preprocessor" plugin="autoware::pointcloud_preprocessor::RingOutlierFilterComponent" name="ring_outlier_filter_node" namespace="">
+      <param from="$(var ring_outlier_filter_param_file)"/>
+      <remap from="input" to="$(var input_topic_name)"/>
+      <remap from="output" to="$(var output_topic_name)"/>
+      <param name="input_frame" value="$(var input_frame)"/>
+      <param name="output_frame" value="$(var output_frame)"/>
+    </composable_node>
+  </load_composable_node>
 </launch>

--- a/sensing/autoware_pointcloud_preprocessor/launch/voxel_grid_downsample_filter_node.launch.xml
+++ b/sensing/autoware_pointcloud_preprocessor/launch/voxel_grid_downsample_filter_node.launch.xml
@@ -4,11 +4,25 @@
   <arg name="input_frame" default="base_link"/>
   <arg name="output_frame" default="base_link"/>
   <arg name="voxel_grid_downsample_filter_param_file" default="$(find-pkg-share autoware_pointcloud_preprocessor)/config/voxel_grid_downsample_filter_node.param.yaml"/>
-  <node pkg="autoware_pointcloud_preprocessor" exec="voxel_grid_downsample_filter_node" name="voxel_grid_downsample_filter_node">
+  <arg name="container_name" default="" description="Container name for composable node. If empty, standalone node is launched."/>
+
+  <!-- Standalone mode: launch as a regular node when container_name is empty -->
+  <node pkg="autoware_pointcloud_preprocessor" exec="voxel_grid_downsample_filter_node" name="voxel_grid_downsample_filter_node" if="$(eval &quot;'$(var container_name)'==''&quot;)">
     <param from="$(var voxel_grid_downsample_filter_param_file)"/>
     <remap from="input" to="$(var input_topic_name)"/>
     <remap from="output" to="$(var output_topic_name)"/>
     <param name="input_frame" value="$(var input_frame)"/>
     <param name="output_frame" value="$(var output_frame)"/>
   </node>
+
+  <!-- Composable mode: load into existing container when container_name is specified -->
+  <load_composable_node target="$(var container_name)" if="$(eval &quot;'$(var container_name)'!=''&quot;)">
+    <composable_node pkg="autoware_pointcloud_preprocessor" plugin="autoware::pointcloud_preprocessor::VoxelGridDownsampleFilterComponent" name="voxel_grid_downsample_filter_node" namespace="">
+      <param from="$(var voxel_grid_downsample_filter_param_file)"/>
+      <remap from="input" to="$(var input_topic_name)"/>
+      <remap from="output" to="$(var output_topic_name)"/>
+      <param name="input_frame" value="$(var input_frame)"/>
+      <param name="output_frame" value="$(var output_frame)"/>
+    </composable_node>
+  </load_composable_node>
 </launch>

--- a/sensing/autoware_pointcloud_preprocessor/package.xml
+++ b/sensing/autoware_pointcloud_preprocessor/package.xml
@@ -60,6 +60,8 @@
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>
+  <test_depend>launch_testing_ament_cmake</test_depend>
+  <test_depend>launch_testing</test_depend>
   <test_depend>ros_testing</test_depend>
 
   <export>

--- a/sensing/autoware_pointcloud_preprocessor/package.xml
+++ b/sensing/autoware_pointcloud_preprocessor/package.xml
@@ -60,8 +60,8 @@
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>
-  <test_depend>launch_testing_ament_cmake</test_depend>
   <test_depend>launch_testing</test_depend>
+  <test_depend>launch_testing_ament_cmake</test_depend>
   <test_depend>ros_testing</test_depend>
 
   <export>

--- a/sensing/autoware_pointcloud_preprocessor/test/test_voxel_grid_launch.py
+++ b/sensing/autoware_pointcloud_preprocessor/test/test_voxel_grid_launch.py
@@ -1,0 +1,93 @@
+# Copyright 2025 TIER IV, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import time
+import unittest
+
+from ament_index_python.packages import get_package_share_directory
+import launch
+from launch.actions import IncludeLaunchDescription
+from launch.actions import TimerAction
+from launch.launch_description_sources import AnyLaunchDescriptionSource
+import launch_testing
+import launch_testing.actions
+import pytest
+import rclpy
+
+
+@pytest.mark.launch_test
+def generate_test_description():
+    """Generate launch description for standalone mode test."""
+    launch_file = os.path.join(
+        get_package_share_directory("autoware_pointcloud_preprocessor"),
+        "launch",
+        "voxel_grid_downsample_filter_node.launch.xml",
+    )
+
+    # Launch in standalone mode (container_name is empty by default)
+    node_launch = IncludeLaunchDescription(
+        AnyLaunchDescriptionSource(launch_file),
+    )
+
+    return launch.LaunchDescription(
+        [
+            node_launch,
+            # Shutdown after 3 seconds
+            TimerAction(period=3.0, actions=[launch.actions.Shutdown()]),
+            launch_testing.actions.ReadyToTest(),
+        ]
+    )
+
+
+class TestLaunchStandalone(unittest.TestCase):
+    """Test standalone mode launch (container_name is empty)."""
+
+    @classmethod
+    def setUpClass(cls):
+        rclpy.init()
+
+    @classmethod
+    def tearDownClass(cls):
+        rclpy.shutdown()
+
+    def setUp(self):
+        self.test_node = rclpy.create_node("test_node")
+
+    def tearDown(self):
+        self.test_node.destroy_node()
+
+    def test_node_exists(self):
+        """Test that the node is running."""
+        # Wait for node to be discovered
+        end_time = time.time() + 2.0
+        node_found = False
+
+        while time.time() < end_time and not node_found:
+            node_names = self.test_node.get_node_names()
+            if "voxel_grid_downsample_filter_node" in node_names:
+                node_found = True
+            else:
+                rclpy.spin_once(self.test_node, timeout_sec=0.1)
+
+        self.assertTrue(node_found, "voxel_grid_downsample_filter_node not found")
+
+
+@launch_testing.post_shutdown_test()
+class TestProcessOutput(unittest.TestCase):
+    """Test process exit code after shutdown."""
+
+    def test_exit_code(self, proc_info):
+        """Check that all processes exit with code 0."""
+        launch_testing.asserts.assertExitCodes(proc_info)

--- a/sensing/autoware_pointcloud_preprocessor/test/test_voxel_grid_launch_composable.py
+++ b/sensing/autoware_pointcloud_preprocessor/test/test_voxel_grid_launch_composable.py
@@ -1,0 +1,109 @@
+# Copyright 2025 TIER IV, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import time
+import unittest
+
+from ament_index_python.packages import get_package_share_directory
+import launch
+from launch.actions import IncludeLaunchDescription
+from launch.actions import TimerAction
+from launch.launch_description_sources import AnyLaunchDescriptionSource
+from launch_ros.actions import ComposableNodeContainer
+import launch_testing
+import launch_testing.actions
+import pytest
+import rclpy
+
+
+@pytest.mark.launch_test
+def generate_test_description():
+    """Generate launch description for composable mode test."""
+    # First, create a container
+    container = ComposableNodeContainer(
+        name="test_container",
+        namespace="",
+        package="rclcpp_components",
+        executable="component_container",
+        composable_node_descriptions=[],
+        output="screen",
+    )
+
+    launch_file = os.path.join(
+        get_package_share_directory("autoware_pointcloud_preprocessor"),
+        "launch",
+        "voxel_grid_downsample_filter_node.launch.xml",
+    )
+
+    # Launch with container_name specified to load into existing container
+    node_launch = IncludeLaunchDescription(
+        AnyLaunchDescriptionSource(launch_file),
+        launch_arguments={"container_name": "/test_container"}.items(),
+    )
+
+    return launch.LaunchDescription(
+        [
+            container,
+            # Delay node loading to ensure container is ready
+            TimerAction(period=1.0, actions=[node_launch]),
+            # Shutdown after 5 seconds
+            TimerAction(period=5.0, actions=[launch.actions.Shutdown()]),
+            launch_testing.actions.ReadyToTest(),
+        ]
+    )
+
+
+class TestLaunchComposable(unittest.TestCase):
+    """Test composable mode launch (load into existing container)."""
+
+    @classmethod
+    def setUpClass(cls):
+        rclpy.init()
+
+    @classmethod
+    def tearDownClass(cls):
+        rclpy.shutdown()
+
+    def setUp(self):
+        self.test_node = rclpy.create_node("test_node")
+
+    def tearDown(self):
+        self.test_node.destroy_node()
+
+    def test_node_exists(self):
+        """Test that the node is running inside the container."""
+        # Wait for node to be discovered
+        end_time = time.time() + 3.0
+        node_found = False
+
+        while time.time() < end_time and not node_found:
+            node_names = self.test_node.get_node_names()
+            if "voxel_grid_downsample_filter_node" in node_names:
+                node_found = True
+            else:
+                rclpy.spin_once(self.test_node, timeout_sec=0.1)
+
+        self.assertTrue(
+            node_found, "voxel_grid_downsample_filter_node not found in container"
+        )
+
+
+@launch_testing.post_shutdown_test()
+class TestProcessOutput(unittest.TestCase):
+    """Test process exit code after shutdown."""
+
+    def test_exit_code(self, proc_info):
+        """Check that all processes exit with code 0."""
+        launch_testing.asserts.assertExitCodes(proc_info)

--- a/sensing/autoware_pointcloud_preprocessor/test/test_voxel_grid_launch_composable.py
+++ b/sensing/autoware_pointcloud_preprocessor/test/test_voxel_grid_launch_composable.py
@@ -95,9 +95,7 @@ class TestLaunchComposable(unittest.TestCase):
             else:
                 rclpy.spin_once(self.test_node, timeout_sec=0.1)
 
-        self.assertTrue(
-            node_found, "voxel_grid_downsample_filter_node not found in container"
-        )
+        self.assertTrue(node_found, "voxel_grid_downsample_filter_node not found in container")
 
 
 @launch_testing.post_shutdown_test()


### PR DESCRIPTION
## Description

Add `container_name` argument to filter launch files to support loading nodes into an existing ComposableNodeContainer, addressing the Node/Callback Explosion anti-pattern identified in #11738.

Updated launch files:
- `voxel_grid_downsample_filter_node.launch.xml`
- `crop_box_filter_node.launch.xml`
- `ring_outlier_filter_node.launch.xml`

When `container_name` is empty (default), the node is launched as a standalone node (same behavior as before). When `container_name` is specified, the node is loaded into the existing container using `load_composable_node`.

## Related links

**Parent Issue:**

- #11738

## How was this PR tested?

- Added launch tests for `voxel_grid_downsample_filter_node.launch.xml` as a representative:
  - `test_voxel_grid_launch.py`: Tests standalone mode (container_name is empty)
  - `test_voxel_grid_launch_composable.py`: Tests composable mode (loads into existing container)
- Built and tested with Docker using `colcon build` and `colcon test`

## Notes for reviewers

None.

## Interface changes

### ROS Parameter Changes

#### Additions and removals

| Change type | Parameter Name   | Type     | Default Value | Description                                                                 |
|:------------|:-----------------|:---------|:--------------|:----------------------------------------------------------------------------|
| Added       | `container_name` | `string` | `""`          | Container name for composable node. If empty, standalone node is launched. |

## Effects on system behavior

None. Default behavior (standalone node) is preserved when `container_name` is not specified.