### PR TITLE
chore(diffusion_planner): change default values

### DIFF
--- a/planning/autoware_diffusion_planner/config/diffusion_planner.param.yaml
+++ b/planning/autoware_diffusion_planner/config/diffusion_planner.param.yaml
@@ -12,7 +12,7 @@
     batch_size: 1
     temperature: [0.0]
     velocity_smoothing_window: 8
-    stopping_threshold: 0.0
+    stopping_threshold: 0.3
     debug_params:
       publish_debug_route: true
       publish_debug_map: false

--- a/planning/autoware_diffusion_planner/schema/diffusion_planner.schema.json
+++ b/planning/autoware_diffusion_planner/schema/diffusion_planner.schema.json
@@ -81,7 +81,7 @@
         },
         "stopping_threshold": {
           "type": "number",
-          "default": 0.0,
+          "default": 0.3,
           "description": "Threshold for keeping the stopping state [m/s]"
         },
         "debug_params": {

--- a/planning/autoware_diffusion_planner/src/diffusion_planner_node.cpp
+++ b/planning/autoware_diffusion_planner/src/diffusion_planner_node.cpp
@@ -129,7 +129,7 @@ void DiffusionPlanner::set_up_params()
   params_.temperature_list = this->declare_parameter<std::vector<double>>("temperature", {0.0});
   params_.velocity_smoothing_window =
     this->declare_parameter<int64_t>("velocity_smoothing_window", 8);
-  params_.stopping_threshold = this->declare_parameter<double>("stopping_threshold", 0.0);
+  params_.stopping_threshold = this->declare_parameter<double>("stopping_threshold", 0.3);
 
   // debug params
   debug_params_.publish_debug_map =


### PR DESCRIPTION
## Description

This PR updates default parameter values for the diffusion planner module. The changes modify the temperature parameter for trajectory sampling from 0.5 to 0.0, and the stopping threshold from 0.0 to 0.3 m/s.

## How was this PR tested?

Run `diffusion_planner`

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
