### PR TITLE
fix(freespace_planner): build testing failure

### DIFF
--- a/planning/autoware_freespace_planner/test/test_freespace_planner_utils.cpp
+++ b/planning/autoware_freespace_planner/test/test_freespace_planner_utils.cpp
@@ -158,7 +158,7 @@ TEST(FreespacePlannerUtilsTest, testIsNearTarget)
   auto current_pose = target_pose;
   current_pose.position.x -= 1.0;
   current_pose.position.y += 1.0;
-  current_pose.orientation = autoware_utils::create_quaternion_from_yaw(M_PI_2 + eps);
+  current_pose.orientation = autoware_utils_geometry::create_quaternion_from_yaw(M_PI_2 + eps);
 
   const double th_distance_m = 0.5;
 
@@ -173,7 +173,7 @@ TEST(FreespacePlannerUtilsTest, testIsNearTarget)
   EXPECT_FALSE(
     autoware::freespace_planner::utils::is_near_target(target_pose, current_pose, th_distance_m));
 
-  current_pose.orientation = autoware_utils::create_quaternion_from_yaw(M_PI_4);
+  current_pose.orientation = autoware_utils_geometry::create_quaternion_from_yaw(M_PI_4);
   EXPECT_TRUE(
     autoware::freespace_planner::utils::is_near_target(target_pose, current_pose, th_distance_m));
 }


### PR DESCRIPTION
## Description

Fix BUILD_TESTING failure due to recent dependency reduction task.
https://github.com/autowarefoundation/autoware_universe/pull/11731#issue-3700673151

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
