### PR TITLE
fix(diffusion_planner): fix `build_only`

### DIFF
--- a/planning/autoware_diffusion_planner/config/diffusion_planner.param.yaml
+++ b/planning/autoware_diffusion_planner/config/diffusion_planner.param.yaml
@@ -8,7 +8,6 @@
     ignore_unknown_neighbors: true
     predict_neighbor_trajectory: true
     traffic_light_group_msg_timeout_seconds: 0.2
-    build_only: false
     batch_size: 1
     temperature: [0.0]
     velocity_smoothing_window: 8

--- a/planning/autoware_diffusion_planner/launch/diffusion_planner.launch.xml
+++ b/planning/autoware_diffusion_planner/launch/diffusion_planner.launch.xml
@@ -12,6 +12,7 @@
   <arg name="input_tracked_objects" default="~/input/tracked_objects"/>
   <arg name="input_vector_map" default="~/input/vector_map"/>
   <arg name="input_turn_indicators" default="~/input/turn_indicators"/>
+  <arg name="build_only" default="false" description="shutdown node after TensorRT engine file is built"/>
 
   <node pkg="autoware_diffusion_planner" exec="autoware_diffusion_planner_node" name="diffusion_planner_node" output="both">
     <param from="$(var diffusion_planner_param_path)" allow_substs="true"/>
@@ -26,5 +27,6 @@
     <remap from="~/input/tracked_objects" to="$(var input_tracked_objects)"/>
     <remap from="~/input/vector_map" to="$(var input_vector_map)"/>
     <remap from="~/input/turn_indicators" to="$(var input_turn_indicators)"/>
+    <param name="build_only" value="$(var build_only)"/>
   </node>
 </launch>


### PR DESCRIPTION
## Description

When running large-scale parallel tests, we can reduce wasted time by building the TensorRT engine in advance. This pull request will fix the launch file to handle the build_only argument.

cf. [lidar_centerpoint.launch.xml](https://github.com/autowarefoundation/autoware_universe/blob/d3f02a5361f89f26f0f78cbef73ffaf161c8acb7/perception/autoware_lidar_centerpoint/launch/lidar_centerpoint.launch.xml)

## How was this PR tested?

```bash
shintarosakoda@dpc2304005:~/autoware$ source ./install/setup.bash 
shintarosakoda@dpc2304005:~/autoware$ ros2 launch autoware_diffusion_planner diffusion_planner.launch.xml build_only:=true
[INFO] [launch]: All log files can be found below /home/shintarosakoda/.ros/log/2025-12-11-18-01-26-551878-dpc2304005-1517134
[INFO] [launch]: Default logging verbosity is set to INFO
[INFO] [autoware_diffusion_planner_node-1]: process started with pid [1517135]
[autoware_diffusion_planner_node-1] [I] [TRT] [MemUsageChange] Init CUDA: CPU +0, GPU +0, now: CPU 36, GPU 1047 (MiB)
[autoware_diffusion_planner_node-1] [I] [TRT] [MemUsageChange] Init builder kernel library: CPU +2773, GPU +443, now: CPU 3011, GPU 1490 (MiB)
[autoware_diffusion_planner_node-1] [I] [TRT] ----------------------------------------------------------------
[autoware_diffusion_planner_node-1] [I] [TRT] Input filename:   /home/shintarosakoda/autoware_data/diffusion_planner/v2.0/diffusion_planner.onnx
[autoware_diffusion_planner_node-1] [I] [TRT] ONNX IR version:  0.0.9
[autoware_diffusion_planner_node-1] [I] [TRT] Opset version:    20
[autoware_diffusion_planner_node-1] [I] [TRT] Producer name:    pytorch
[autoware_diffusion_planner_node-1] [I] [TRT] Producer version: 2.6.0
[autoware_diffusion_planner_node-1] [I] [TRT] Domain:           
[autoware_diffusion_planner_node-1] [I] [TRT] Model version:    0
[autoware_diffusion_planner_node-1] [I] [TRT] Doc string:       
[autoware_diffusion_planner_node-1] [I] [TRT] ----------------------------------------------------------------
[autoware_diffusion_planner_node-1] [I] [TRT] Loaded plugin library: /home/shintarosakoda/autoware/install/autoware_tensorrt_plugins/share/autoware_tensorrt_plugins/plugins/libautoware_tensorrt_plugins.so
[autoware_diffusion_planner_node-1] [I] [TRT] The logger passed into createInferRuntime differs from one already provided for an existing builder, runtime, or refitter. Uses of the global logger, returned by nvinfer1::getLogger(), will return the existing value.
[autoware_diffusion_planner_node-1] [I] [TRT] The logger passed into createInferBuilder differs from one already provided for an existing builder, runtime, or refitter. Uses of the global logger, returned by nvinfer1::getLogger(), will return the existing value.
[autoware_diffusion_planner_node-1] [I] [TRT] ----------------------------------------------------------------
[autoware_diffusion_planner_node-1] [I] [TRT] Input filename:   /home/shintarosakoda/autoware_data/diffusion_planner/v2.0/diffusion_planner.onnx
[autoware_diffusion_planner_node-1] [I] [TRT] ONNX IR version:  0.0.9
[autoware_diffusion_planner_node-1] [I] [TRT] Opset version:    20
[autoware_diffusion_planner_node-1] [I] [TRT] Producer name:    pytorch
[autoware_diffusion_planner_node-1] [I] [TRT] Producer version: 2.6.0
[autoware_diffusion_planner_node-1] [I] [TRT] Domain:           
[autoware_diffusion_planner_node-1] [I] [TRT] Model version:    0
[autoware_diffusion_planner_node-1] [I] [TRT] Doc string:       
[autoware_diffusion_planner_node-1] [I] [TRT] ----------------------------------------------------------------
[autoware_diffusion_planner_node-1] [I] [TRT] Setting optimization profile for tensor: sampled_trajectories {min [1, 33, 81, 4], opt [1, 33, 81, 4], max [1, 33, 81, 4]}
[autoware_diffusion_planner_node-1] [I] [TRT] Setting optimization profile for tensor: ego_agent_past {min [1, 31, 4], opt [1, 31, 4], max [1, 31, 4]}
[autoware_diffusion_planner_node-1] [I] [TRT] Setting optimization profile for tensor: ego_current_state {min [1, 10], opt [1, 10], max [1, 10]}
[autoware_diffusion_planner_node-1] [I] [TRT] Setting optimization profile for tensor: neighbor_agents_past {min [1, 32, 31, 11], opt [1, 32, 31, 11], max [1, 32, 31, 11]}
[autoware_diffusion_planner_node-1] [I] [TRT] Setting optimization profile for tensor: static_objects {min [1, 5, 10], opt [1, 5, 10], max [1, 5, 10]}
[autoware_diffusion_planner_node-1] [I] [TRT] Setting optimization profile for tensor: lanes {min [1, 140, 20, 33], opt [1, 140, 20, 33], max [1, 140, 20, 33]}
[autoware_diffusion_planner_node-1] [I] [TRT] Setting optimization profile for tensor: lanes_speed_limit {min [1, 140, 1], opt [1, 140, 1], max [1, 140, 1]}
[autoware_diffusion_planner_node-1] [I] [TRT] Setting optimization profile for tensor: lanes_has_speed_limit {min [1, 140, 1], opt [1, 140, 1], max [1, 140, 1]}
[autoware_diffusion_planner_node-1] [I] [TRT] Setting optimization profile for tensor: route_lanes {min [1, 25, 20, 33], opt [1, 25, 20, 33], max [1, 25, 20, 33]}
[autoware_diffusion_planner_node-1] [I] [TRT] Setting optimization profile for tensor: polygons {min [1, 10, 40, 2], opt [1, 10, 40, 2], max [1, 10, 40, 2]}
[autoware_diffusion_planner_node-1] [I] [TRT] Setting optimization profile for tensor: line_strings {min [1, 10, 20, 2], opt [1, 10, 20, 2], max [1, 10, 20, 2]}
[autoware_diffusion_planner_node-1] [I] [TRT] Setting optimization profile for tensor: route_lanes_has_speed_limit {min [1, 25, 1], opt [1, 25, 1], max [1, 25, 1]}
[autoware_diffusion_planner_node-1] [I] [TRT] Setting optimization profile for tensor: route_lanes_speed_limit {min [1, 25, 1], opt [1, 25, 1], max [1, 25, 1]}
[autoware_diffusion_planner_node-1] [I] [TRT] Setting optimization profile for tensor: goal_pose {min [1, 4], opt [1, 4], max [1, 4]}
[autoware_diffusion_planner_node-1] [I] [TRT] Setting optimization profile for tensor: ego_shape {min [1, 3], opt [1, 3], max [1, 3]}
[autoware_diffusion_planner_node-1] [I] [TRT] Setting optimization profile for tensor: turn_indicators {min [1, 31], opt [1, 31], max [1, 31]}
[autoware_diffusion_planner_node-1] [I] [TRT] Starting to build engine
[autoware_diffusion_planner_node-1] [I] [TRT] Applying optimizations and building TensorRT CUDA engine. Please wait for a few minutes...
[autoware_diffusion_planner_node-1] [W] [TRT] [RemoveDeadLayers] Input Tensor turn_indicators is unused or used only at compile-time, but is not being removed.
[autoware_diffusion_planner_node-1] [I] [TRT] Local timing cache in use. Profiling results in this builder pass will not be stored.
[autoware_diffusion_planner_node-1] [I] [TRT] Compiler backend is used during engine build.
[autoware_diffusion_planner_node-1] [I] [TRT] Detected 16 inputs and 2 output network tensors.
[autoware_diffusion_planner_node-1] [I] [TRT] Applying optimizations and building TensorRT CUDA engine. Please wait for a few minutes...
[autoware_diffusion_planner_node-1] [I] [TRT] Applying optimizations and building TensorRT CUDA engine. Please wait for a few minutes...
[autoware_diffusion_planner_node-1] [I] [TRT] Applying optimizations and building TensorRT CUDA engine. Please wait for a few minutes...
[autoware_diffusion_planner_node-1] [I] [TRT] Applying optimizations and building TensorRT CUDA engine. Please wait for a few minutes...
[autoware_diffusion_planner_node-1] [I] [TRT] Applying optimizations and building TensorRT CUDA engine. Please wait for a few minutes...
[autoware_diffusion_planner_node-1] [I] [TRT] Applying optimizations and building TensorRT CUDA engine. Please wait for a few minutes...
[autoware_diffusion_planner_node-1] [I] [TRT] Applying optimizations and building TensorRT CUDA engine. Please wait for a few minutes...
[autoware_diffusion_planner_node-1] [I] [TRT] Applying optimizations and building TensorRT CUDA engine. Please wait for a few minutes...
[autoware_diffusion_planner_node-1] [I] [TRT] Applying optimizations and building TensorRT CUDA engine. Please wait for a few minutes...
[autoware_diffusion_planner_node-1] [I] [TRT] Total Host Persistent Memory: 160 bytes
[autoware_diffusion_planner_node-1] [I] [TRT] Total Device Persistent Memory: 0 bytes
[autoware_diffusion_planner_node-1] [I] [TRT] Max Scratch Memory: 198763008 bytes
[autoware_diffusion_planner_node-1] [I] [TRT] [BlockAssignment] Started assigning block shifts. This will take 33 steps to complete.
[autoware_diffusion_planner_node-1] [I] [TRT] [BlockAssignment] Algorithm ShiftNTopDown took 10.7983ms to assign 20 blocks to 33 nodes requiring 198966784 bytes.
[autoware_diffusion_planner_node-1] [I] [TRT] Total Activation Memory: 198966784 bytes
[autoware_diffusion_planner_node-1] [I] [TRT] Total Weights Memory: 61540480 bytes
[autoware_diffusion_planner_node-1] [I] [TRT] Compiler backend is used during engine execution.
[autoware_diffusion_planner_node-1] [I] [TRT] Engine generation completed in 46.2682 seconds.
[autoware_diffusion_planner_node-1] [I] [TRT] [MemUsageStats] Peak memory usage of TRT CPU/GPU memory allocators: CPU 0 MiB, GPU 58 MiB
[autoware_diffusion_planner_node-1] [I] [TRT] Loaded engine size: 67 MiB
[autoware_diffusion_planner_node-1] [I] [TRT] [MS] Running engine with multi stream info
[autoware_diffusion_planner_node-1] [I] [TRT] [MS] Number of aux streams is 5
[autoware_diffusion_planner_node-1] [I] [TRT] [MS] Number of total worker streams is 6
[autoware_diffusion_planner_node-1] [I] [TRT] [MS] The main stream provided by execute/enqueue calls is the first worker stream
[autoware_diffusion_planner_node-1] [I] [TRT] [MemUsageChange] TensorRT-managed allocation in IExecutionContext creation: CPU +0, GPU +190, now: CPU 0, GPU 248 (MiB)
[autoware_diffusion_planner_node-1] [I] [TRT] The profiling verbosity was set to ProfilingVerbosity::kLAYER_NAMES_ONLY when the engine was built, so only the layer names will be returned. Rebuild the engine with ProfilingVerbosity::kDETAILED to get more verbose layer information.
[autoware_diffusion_planner_node-1] [I] [TRT] Engine build completed
[autoware_diffusion_planner_node-1] [I] [TRT] Engine setup completed
[autoware_diffusion_planner_node-1] [INFO] [1765443740.842883325] [diffusion_planner_node]: Build only mode enabled. Exiting after loading model.
[INFO] [autoware_diffusion_planner_node-1]: process has finished cleanly [pid 1517135]
```

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
