### PR TITLE
fix(astar_search): non-monotonic trajectories fix. Ensure that points between nodes are added in the correct order

### DIFF
--- a/planning/autoware_freespace_planning_algorithms/src/astar_search.cpp
+++ b/planning/autoware_freespace_planning_algorithms/src/astar_search.cpp
@@ -444,7 +444,7 @@ void AstarSearch::setPath(const AstarNode & goal_node)
     const auto parent_pose = node2pose(*node.parent);
     const double distance_2d = calc_distance2d(node2pose(node), parent_pose);
     const int n = static_cast<int>(distance_2d / min_expansion_dist_);
-    for (int i = 1; i < n; ++i) {
+    for (int i = n - 1; i >= 1; --i) {
       const double dist =
         ((distance_2d * i) / n) * (node.is_back == is_backward_search_ ? 1.0 : -1.0);
       const double steering = node.steering_index * steering_resolution_;


### PR DESCRIPTION
## Description

This fixes issue `non-monotonic trajectory generated by freespace planner`  #11788 

When the planner reconstructs the path from Goal to Start, it interpolates points between A* nodes.
The code was generating these interpolated points from "Parent to Node" (Start-side to Goal-side)
but pushing them into the list in a way that, after the final reversal, resulted in local reversals
within each segment.
Fix Applied:
I reversed the interpolation loop in astar_search.cpp. This ensures that points between nodes are
added in the correct order (Node-side to Parent-side during the backward collection), so the final
path is perfectly monotonic (Parent -> Interpolated -> Node).


## Related links
Parent issue:
https://github.com/autowarefoundation/autoware_universe/issues/11788

#4490: `Autoware sometimes stuck in the middle of a parking scenari` - Most of the situations like this are fixed.

#5938: `motion velocity smoother generate invalid trajectory from freespace planner output:` 
Motion velocity smoother doesn't get invalid backward trajectories, so even though the motion valocity planner still should be fixed, this fix removes the main cause of it.

This is also one of the PRs required to allow backwards driving:
https://github.com/orgs/autowarefoundation/discussions/6559

**Parent Issue:**
https://github.com/autowarefoundation/autoware_universe/issues/11788

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
Added regression unit tests that cover the issue. Also tested it in carla and on the real vehicle. 


TIER IV Internal Evaluator :100: 
- [[kosuke55][Lexus][MasterScenario] PR check](https://evaluation.tier4.jp/evaluation/reports/ff6e0610-828c-5466-9605-2f99c87eaa7e?project_id=autoware_dev)
- [[kosuke55][Lexus][DLR_Basic] PR check](https://evaluation.tier4.jp/evaluation/reports/e378d934-588c-501b-a1e1-41dd86c48bbe?project_id=prd_jt)
- [[kosuke55][Lexus][FuncVerif_Basic] PR check](https://evaluation.tier4.jp/evaluation/reports/25d44888-c218-5afa-9568-cc37bdb92f54?project_id=prd_jt)


<img width="985" height="907" alt="image" src="https://github.com/user-attachments/assets/1b804812-9288-4e6a-bd24-e0f9e89ae271" />


## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
