### PR TITLE
refactor(diffusion_planner): add `FrameContext`

### DIFF
--- a/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/diffusion_planner_node.hpp
+++ b/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/diffusion_planner_node.hpp
@@ -232,7 +232,7 @@ private:
    * @brief Run inference on input data output is stored on member output_d_.
    * @param input_data_map Input data for the model.
    */
-  std::vector<float> do_inference_trt(InputDataMap & input_data_map);
+  std::vector<float> do_inference_trt(const InputDataMap & input_data_map);
 
   /**
    * @brief Get turn indicator logit from the last inference.

--- a/planning/autoware_diffusion_planner/src/diffusion_planner_node.cpp
+++ b/planning/autoware_diffusion_planner/src/diffusion_planner_node.cpp
@@ -678,23 +678,23 @@ void DiffusionPlanner::publish_predictions(
   }
 }
 
-std::vector<float> DiffusionPlanner::do_inference_trt(InputDataMap & input_data_map)
+std::vector<float> DiffusionPlanner::do_inference_trt(const InputDataMap & input_data_map)
 {
   autoware_utils_debug::ScopedTimeTrack st(__func__, *time_keeper_);
-  auto sampled_trajectories = input_data_map["sampled_trajectories"];
-  auto ego_history = input_data_map["ego_agent_past"];
-  auto ego_current_state = input_data_map["ego_current_state"];
-  auto neighbor_agents_past = input_data_map["neighbor_agents_past"];
-  auto static_objects = input_data_map["static_objects"];
-  auto lanes = input_data_map["lanes"];
-  auto lanes_speed_limit = input_data_map["lanes_speed_limit"];
-  auto route_lanes = input_data_map["route_lanes"];
-  auto route_lanes_speed_limit = input_data_map["route_lanes_speed_limit"];
-  auto polygons = input_data_map["polygons"];
-  auto line_strings = input_data_map["line_strings"];
-  auto goal_pose = input_data_map["goal_pose"];
-  auto ego_shape = input_data_map["ego_shape"];
-  auto turn_indicators = input_data_map["turn_indicators"];
+  const auto sampled_trajectories = input_data_map.at("sampled_trajectories");
+  const auto ego_history = input_data_map.at("ego_agent_past");
+  const auto ego_current_state = input_data_map.at("ego_current_state");
+  const auto neighbor_agents_past = input_data_map.at("neighbor_agents_past");
+  const auto static_objects = input_data_map.at("static_objects");
+  const auto lanes = input_data_map.at("lanes");
+  const auto lanes_speed_limit = input_data_map.at("lanes_speed_limit");
+  const auto route_lanes = input_data_map.at("route_lanes");
+  const auto route_lanes_speed_limit = input_data_map.at("route_lanes_speed_limit");
+  const auto polygons = input_data_map.at("polygons");
+  const auto line_strings = input_data_map.at("line_strings");
+  const auto goal_pose = input_data_map.at("goal_pose");
+  const auto ego_shape = input_data_map.at("ego_shape");
+  const auto turn_indicators = input_data_map.at("turn_indicators");
 
   // Allocate bool array for lane speed limits
   // Note: Using std::vector<uint8_t> instead of std::vector<bool> to ensure contiguous memory


### PR DESCRIPTION
## Description

Currently, the `autoware_diffusion_planner` node uses member variables `ego_kinematic_state_` and `ego_centric_neighbor_agent_data_` to pass information to `publish_debug_markers` and `publish_predictions`. This PR encapsulates these variables into a new `FrameContext` struct.

Following this change, the `autoware_diffusion_planner` node will only maintain historical data as member variables. Any variables used within a single frame will be managed as local variables within the `on_timer` callback.

## How was this PR tested?

Run the `planning_simulator`

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.
