### PR TITLE
fix(intersection): use collision stopline index instead of closest index

### DIFF
--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/include/autoware/behavior_velocity_intersection_module/decision_result.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/include/autoware/behavior_velocity_intersection_module/decision_result.hpp
@@ -125,6 +125,7 @@ struct OccludedAbsenceTrafficLight
   bool collision_detected{false};
   bool temporal_stop_before_attention_required{false};
   size_t closest_idx{0};
+  size_t collision_stopline_idx{0};
   size_t occlusion_stopline_idx{0};
   size_t peeking_limit_line_idx{0};
   std::string occlusion_report;

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/experimental/scene_intersection.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/experimental/scene_intersection.cpp
@@ -598,6 +598,7 @@ DecisionResult IntersectionModule::modifyPathVelocityDetail(
       has_collision_with_margin,
       temporal_stop_before_creep_required,
       closest_idx,
+      collision_stopline_idx,
       occlusion_stopline_idx,
       first_attention_stopline_idx,
       occlusion_diag,
@@ -1218,7 +1219,7 @@ void reactRTCApprovalByDecisionResult(
     "OccludedAbsenceTrafficLight, approval = (default: %d, occlusion: %d)", rtc_default_approved,
     rtc_occlusion_approved);
   if (!rtc_default_approved && decision_result.collision_stop_tolerable) {
-    const auto stopline_idx = decision_result.closest_idx;
+    const auto stopline_idx = decision_result.collision_stopline_idx;
     planning_utils::setVelocityFromIndex(stopline_idx, 0.0, path);
 
     const auto stop_pose = path->points.at(stopline_idx).point.pose;

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_intersection.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_intersection.cpp
@@ -469,6 +469,7 @@ DecisionResult IntersectionModule::modifyPathVelocityDetail(PathWithLaneId * pat
       has_collision_with_margin,
       temporal_stop_before_creep_required,
       closest_idx,
+      collision_stopline_idx,
       occlusion_stopline_idx,
       first_attention_stopline_idx,
       occlusion_diag,
@@ -1089,7 +1090,7 @@ void reactRTCApprovalByDecisionResult(
     "OccludedAbsenceTrafficLight, approval = (default: %d, occlusion: %d)", rtc_default_approved,
     rtc_occlusion_approved);
   if (!rtc_default_approved && decision_result.collision_stop_tolerable) {
-    const auto stopline_idx = decision_result.closest_idx;
+    const auto stopline_idx = decision_result.collision_stopline_idx;
     planning_utils::setVelocityFromIndex(stopline_idx, 0.0, path);
 
     const auto stop_pose = path->points.at(stopline_idx).point.pose;


### PR DESCRIPTION
## Description

Using the closest index does not account for braking distance. In this PR, the collision stopline is used instead.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

[[PR check][Lexus][FuncVerificationScenario_Basic] planning test](https://evaluation.tier4.jp/evaluation/reports/1cb31260-b312-58d8-9c45-a3e0454e91c3?project_id=prd_jt)
[[PR check][Lexus][CommonScenario_Basic][deprecated-behavior-planning] planning test](https://evaluation.tier4.jp/evaluation/reports/3dcf3957-afcf-5596-b610-2fe0ae019af1?project_id=prd_jt)
[[PR check][Lexus][CommonScenario_Basic] planning test](https://evaluation.tier4.jp/evaluation/reports/40fb6c93-57ec-50ea-8f87-7b8b30171717?project_id=prd_jt)
[[PR check][Lexus][ControlDLRCommon_Basic] DLR test](https://evaluation.tier4.jp/evaluation/reports/e0dd15f8-ee60-502c-99c5-583c5617a1fd?project_id=prd_jt)
[[PR check][Lexus][ControlDLRCommon_Basic][deprecated-behavior-planning] DLR test](https://evaluation.tier4.jp/evaluation/reports/c2109f14-8115-5215-b3f6-f1dc40ae6b4f?project_id=prd_jt)
[[PR check][Lexus][FuncVerificationScenario_Basic][deprecated-behavior-planning] planning test](https://evaluation.tier4.jp/evaluation/reports/3330db0a-fd22-5c66-8869-cba2a31430d6?project_id=prd_jt)


## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
