### PR TITLE
fix(mpc_lateral_controller):  correct variable used for yaw input

### DIFF
--- a/control/autoware_mpc_lateral_controller/src/mpc_utils.cpp
+++ b/control/autoware_mpc_lateral_controller/src/mpc_utils.cpp
@@ -174,7 +174,7 @@ bool linearInterpMPCTrajectory(
     out_traj.x = lerp_arc_length(in_traj.x);
     out_traj.y = lerp_arc_length(in_traj.y);
     out_traj.z = lerp_arc_length(in_traj.z);
-    out_traj.yaw = lerp_arc_length(in_traj.yaw);
+    out_traj.yaw = lerp_arc_length(in_traj_yaw);
     out_traj.vx = lerp_arc_length(in_traj.vx);
     out_traj.k = lerp_arc_length(in_traj.k);
     out_traj.smooth_k = lerp_arc_length(in_traj.smooth_k);


### PR DESCRIPTION
## Description
This pull request makes a minor fix to the `linearInterpMPCTrajectory` function to ensure the correct variable is used for yaw interpolation. Improves code clarity and prevents potential bugs if upstream monotonic conversion is removed in the future

## Related links
None

## How was this PR tested?
Build successfully and able to run PSim

## Notes for reviewers
The behavior of the MPC would not change, since the trajectory yaw is transferred to monotonic [here](https://github.com/autowarefoundation/autoware_universe/blob/main/control/autoware_mpc_lateral_controller/src/mpc.cpp#L256).

## Interface changes
None.

## Effects on system behavior
None.
