### PR TITLE
fix(diffusion_planner): traffic_light_id_map

### DIFF
--- a/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/diffusion_planner_node.hpp
+++ b/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/diffusion_planner_node.hpp
@@ -109,7 +109,6 @@ struct FrameContext
   geometry_msgs::msg::AccelWithCovarianceStamped ego_acceleration;
   Eigen::Matrix4d ego_to_map_transform;
   AgentData ego_centric_neighbor_agent_data;
-  std::map<lanelet::Id, TrafficSignalStamped> traffic_light_id_map;
 };
 
 struct DiffusionPlannerParams
@@ -296,6 +295,7 @@ private:
   std::deque<Pose> ego_history_;
   std::deque<TurnIndicatorsReport> turn_indicators_history_;
   std::optional<AgentData> agent_data_{std::nullopt};
+  std::map<lanelet::Id, TrafficSignalStamped> traffic_light_id_map_;
 
   // Node parameters
   OnSetParametersCallbackHandle::SharedPtr set_param_res_;


### PR DESCRIPTION
## Description

I made a mistake in https://github.com/autowarefoundation/autoware_universe/pull/11805, specifically in the changes at https://github.com/autowarefoundation/autoware_universe/pull/11805/changes/b6058db6f9ba83df47e5c5015a1aa8ee5ba058c8.

`traffic_light_id_map` is not frame data, but history data. This pull request will fix that bug.

## How was this PR tested?

Run the planning simulator ant the logging simulator.

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.
