### PR TITLE
fix(autoware_compare_map_segmentation): use async service call in VoxelGridDynamicMapLoader to prevent deadlock

### DIFF
--- a/perception/autoware_compare_map_segmentation/lib/voxel_grid_map_loader.cpp
+++ b/perception/autoware_compare_map_segmentation/lib/voxel_grid_map_loader.cpp
@@ -507,7 +507,7 @@ void VoxelGridDynamicMapLoader::request_update_map(const geometry_msgs::msg::Poi
       rclcpp::Client<autoware_map_msgs::srv::GetDifferentialPointCloudMap>::SharedFuture future) {
       try {
         auto result = future.get();
-        if (result->new_pointcloud_with_ids.size() == 0 && result->ids_to_remove.size() == 0) {
+        if (result->new_pointcloud_with_ids.empty() && result->ids_to_remove.empty()) {
           return;
         }
         updateDifferentialMapCells(result->new_pointcloud_with_ids, result->ids_to_remove);


### PR DESCRIPTION
## Description

* Problem
The voxel_based_compare_map_filter_node would hang indefinitely, printing "Waiting for response...", when launched as a standalone node.
This occurred because the request_update_map function used a blocking wait_for loop inside a timer callback. When running with the default SingleThreadedExecutor (common for standalone nodes), this blocking wait prevented the executor from processing the service response, leading to a deadlock.

* Fix
Refactored VoxelGridDynamicMapLoader::request_update_map to use async_send_request with a callback lambda instead of a blocking wait.
Removed the blocking while (status != std::future_status::ready) loop.
Moved the response processing logic into the callback function.

* Effect
The node can now safely wait for the get_differential_pointcloud_map service response without blocking the execution thread. This ensures compatibility with both SingleThreadedExecutor (standalone launch) and MultiThreadedExecutor (component container launch).
## Related links

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
