### PR TITLE
fix(autoware_compare_map_segmentation): add missing launch param

### DIFF
--- a/perception/autoware_compare_map_segmentation/launch/voxel_based_compare_map_filter.launch.xml
+++ b/perception/autoware_compare_map_segmentation/launch/voxel_based_compare_map_filter.launch.xml
@@ -12,5 +12,6 @@
     <remap from="map" to="$(var input_map)"/>
     <remap from="output" to="$(var output)"/>
     <param from="$(var voxel_based_compare_map_filter_param_file)"/>
+    <remap from="map_loader_service" to="$(var map_loader_service)"/>
   </node>
 </launch>


### PR DESCRIPTION
## Description

- To add missing launch param when testing `autoware_compare_map_segmentation`'s `voxel_based_compare_map_filter.launch.xml` standalone.

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

- Terminal 1: execute compare_map `ros2 launch autoware_compare_map_segmentation voxel_based_compare_map_filter.launch.xml`
- Terminal 2: run map_loader: `ros2 launch autoware_launch tier4_map_component.launch.xml map_path:=$HOME/sample_autoware/sample-map/ pointcloud_map_file:=pointcloud_map.pcd lanelet2_map_file:=lanelet2_map.osm`

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
