### PR TITLE
fix(mpc_lateral_controller): use terminal velocity to extend trajectory

### DIFF
--- a/control/autoware_mpc_lateral_controller/src/mpc_utils.cpp
+++ b/control/autoware_mpc_lateral_controller/src/mpc_utils.cpp
@@ -463,9 +463,11 @@ void extendTrajectoryInYawDirection(
   auto extended_pose = autoware_traj.points.back().pose;
 
   constexpr double extend_dist = 10.0;
-  const double extend_vel = std::max(std::fabs(traj.vx.back()), 1.0);
+  const double extend_vel = traj.vx.back();
   const double x_offset = is_forward_shift ? interval : -interval;
-  const double dt = interval / extend_vel;
+  constexpr double min_vel_threshold = 0.1;
+  const double dt =
+    (std::fabs(extend_vel) < min_vel_threshold) ? 1.0e-4 : interval / std::fabs(extend_vel);
   const size_t num_extended_point = static_cast<size_t>(extend_dist / interval);
   for (size_t i = 0; i < num_extended_point; ++i) {
     extended_pose = autoware_utils::calc_offset_pose(extended_pose, x_offset, 0.0, 0.0);


### PR DESCRIPTION
## Description
This PR introduces improvements to the `extendTrajectoryInYawDirection` function in `mpc_utils.cpp` to enhance trajectory extension logic.

* Added an early return to handle the case where the input trajectory `traj` is empty, preventing potential runtime errors.
* Changed the extension velocity (`extend_vel`) to use the last velocity value from `traj.vx` instead of a hardcoded constant, making the extension behavior dynamic based on the actual trajectory.
* Introduced a minimum velocity threshold to avoid division by very small numbers or zero; if the velocity is below this threshold, a small default time step is used for `dt` calculation.

## Related links
None

## How was this PR tested?
- [x] Passed TIERIV's internal CI checks
  - [x] [Test link part 1](https://evaluation.tier4.jp/evaluation/reports/1dc27f9f-a27a-52da-9ef7-1da1cbc2942e?project_id=prd_jt)
  - [x] [Test link part 2](https://evaluation.tier4.jp/evaluation/reports/9ad4c595-844a-5972-b5a3-c7d4d6f03c20?project_id=prd_jt)
  - [x] [Test link part 3](https://evaluation.tier4.jp/evaluation/reports/5583376f-9d9b-5042-9b24-4dc7c1a49d16?project_id=prd_jt)


## Notes for reviewers
The minimum value`0.1` was selected as it is used in `calcMPCTrajectoryTime` function.

## Interface changes
None.

## Effects on system behavior
None.
