### PR TITLE
fix(cuda_scan_ground_segmentation): add missing include

### DIFF
--- a/perception/autoware_ground_segmentation_cuda/src/cuda_scan_ground_segmentation/cuda_scan_ground_segmentation_filter.cu
+++ b/perception/autoware_ground_segmentation_cuda/src/cuda_scan_ground_segmentation/cuda_scan_ground_segmentation_filter.cu
@@ -23,6 +23,7 @@
 #include <sys/time.h>
 
 #include <algorithm>
+#include <cfloat>
 #include <cmath>
 #include <memory>
 #include <optional>


### PR DESCRIPTION
## Description

- Follow up on: https://github.com/autowarefoundation/autoware_universe/pull/11371

It failed compilation for me. (I checked, it actually passed in CI)

This adds missing include for `FLT_MAX` usage, `#include <cfloat>`

```console
mfc@whale:~/projects/autoware$ nvcc -V
nvcc: NVIDIA (R) Cuda compiler driver
Copyright (c) 2005-2025 NVIDIA Corporation
Built on Fri_Feb_21_20:23:50_PST_2025
Cuda compilation tools, release 12.8, V12.8.93
Build cuda_12.8.r12.8/compiler.35583870_0
```

https://github.com/autowarefoundation/autoware/blob/8085940071de40222441e61a47b53468eed13ac6/amd64.env#L10-L12

Maybe it would compile for `CUDA 12.4` but it is better to be on the safe side.

### Error

```
/home/mfc/projects/autoware/src/universe/autoware_universe/perception/autoware_ground_segmentation_cuda/src/cuda_scan_ground_segmentation/cuda_scan_ground_segmentation_filter.cu(46): error: identifier "FLT_MAX" is undefined
      new_cell.gnd_height_min = FLT_MAX;
                                ^

/home/mfc/projects/autoware/src/universe/autoware_universe/perception/autoware_ground_segmentation_cuda/src/cuda_scan_ground_segmentation/cuda_scan_ground_segmentation_filter.cu(286): error: identifier "FLT_MAX" is undefined
    float t_gnd_height_min = FLT_MAX;
                             ^

2 errors detected in the compilation of "/home/mfc/projects/autoware/src/universe/autoware_universe/perception/autoware_ground_segmentation_cuda/src/cuda_scan_ground_segmentation/cuda_scan_ground_segmentation_filter.cu".
CMake Error at cuda_ground_segmentation_lib_generated_cuda_scan_ground_segmentation_filter.cu.o.Release.cmake:280 (message):
  Error generating file
  /home/mfc/projects/autoware/build/autoware_ground_segmentation_cuda/CMakeFiles/cuda_ground_segmentation_lib.dir/src/cuda_scan_ground_segmentation/./cuda_ground_segmentation_lib_generated_cuda_scan_ground_segmentation_filter.cu.o
```

## How was this PR tested?

Locally and in CI.