### PR TITLE
fix(crop_box_filter): make `output.is_dense=true`

### DIFF
--- a/sensing/autoware_pointcloud_preprocessor/src/crop_box_filter/crop_box_filter_node.cpp
+++ b/sensing/autoware_pointcloud_preprocessor/src/crop_box_filter/crop_box_filter_node.cpp
@@ -195,7 +195,7 @@ void CropBoxFilterComponent::faster_filter(
   output.fields = input->fields;
   output.is_bigendian = input->is_bigendian;
   output.point_step = input->point_step;
-  output.is_dense = input->is_dense;
+  output.is_dense = true;  // We filtered out the NaN values, the point cloud is now dense.
   output.width = static_cast<uint32_t>(output.data.size() / output.height / output.point_step);
   output.row_step = static_cast<uint32_t>(output.data.size() / output.height);
 


### PR DESCRIPTION
## Description

- **Related:** https://github.com/autowarefoundation/autoware_universe/pull/11853#issuecomment-3732164770

~This PR fixes the issue reported in the comment above.~

~Truth is, I'm not sure why this fixed the issue.~

If AWSIM itself is sending is_dense=false point clouds, it should trigger the warning at some point (because the is_valid check is done with the input point cloud) ~but this PR fixed the issue somehow~.

- I was just testing it before the warning-making PR merged 🤣 Now that https://github.com/autowarefoundation/autoware_universe/pull/11853 is merged, it is throwing warning again as it should.

But this PR is still truthful so I think can be merged. The NaN points are explicitly filtered in the node and the output should be `is_dense = true`.

## How was this PR tested?

~AWSIM test doesn't that warning anymore.~
It is still throwing the warning, this issue should be fixed on AWSIM itself. But the PR should still be merged.

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.
