### PR TITLE
fix(autoware_pointcloud_preprocessor): inherit is_dense for concatenated pointcloud

### DIFF
--- a/sensing/autoware_pointcloud_preprocessor/src/concatenate_data/combine_cloud_handler.cpp
+++ b/sensing/autoware_pointcloud_preprocessor/src/concatenate_data/combine_cloud_handler.cpp
@@ -193,7 +193,7 @@ CombineCloudHandler<PointCloud2Traits>::combine_pointclouds(
       pcl::concatenatePointCloud(
         *concatenate_cloud_result.concatenate_cloud_ptr, *transformed_delay_compensated_cloud_ptr,
         *concatenate_cloud_result.concatenate_cloud_ptr);
-      is_concatenated_cloud_dense &= cloud->is_dense;
+      is_concatenated_cloud_dense = is_concatenated_cloud_dense && cloud->is_dense;
     }
 
     // update concatenation info


### PR DESCRIPTION
## Description
Related PR https://github.com/autowarefoundation/autoware_universe/pull/11853.

This PR fixes the warning about is_dense being false when running the [rosbag replay demo](https://autowarefoundation.github.io/autoware-documentation/main/demos/rosbag-replay-simulation/).

In original code, published topic from concatenate_pointclouds_node always have is_dense=false because [pcl::ConcatenatePointCloud](https://github.com/autowarefoundation/autoware_universe/blob/a1e9993a93bbda315566aa6ede82766f2be0245c/sensing/autoware_pointcloud_preprocessor/src/concatenate_data/combine_cloud_handler.cpp#L192) function always returns the field with false. After this fix, the node will publish topic with is_dense=true only when all the input pointclouds have is_dense=true. 

## Related links

Related PR https://github.com/autowarefoundation/autoware_universe/pull/11853

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
Tested with rosbag replay demo and made sure that the is_dense field in concatenated pointcloud is true.

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
