### PR TITLE
fix(point_cloud_preprocessor): use uint64_t to avoid size_t variance

### DIFF
--- a/sensing/autoware_pointcloud_preprocessor/include/autoware/pointcloud_preprocessor/filter.hpp
+++ b/sensing/autoware_pointcloud_preprocessor/include/autoware/pointcloud_preprocessor/filter.hpp
@@ -367,7 +367,8 @@ protected:
     }
 
     // Check: Data buffer size consistency
-    std::uint64_t expected_data_size = static_cast<std::uint64_t>(cloud->height) * expected_row_step;
+    std::uint64_t expected_data_size =
+      static_cast<std::uint64_t>(cloud->height) * expected_row_step;
 
     if (expected_data_size != cloud->data.size()) {
       RCLCPP_WARN_THROTTLE(


### PR DESCRIPTION
## Description

- Follow up from: https://github.com/autowarefoundation/autoware_universe/pull/11853#discussion_r2682461425

- Related: https://github.com/autowarefoundation/autoware_universe/issues/11858#issuecomment-3738796489

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
