### PR TITLE
perf(road_user_stop): reduce the number of published debug markers

### DIFF
--- a/planning/motion_velocity_planner/autoware_motion_velocity_road_user_stop_module/src/debug.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_road_user_stop_module/src/debug.cpp
@@ -78,9 +78,8 @@ MarkerArray RoadUserStopModule::create_debug_marker_array() const
   if (!debug_data_.trajectory_polygons.empty()) {
     autoware_utils_debug::ScopedTimeTrack st_debug_marker(
       "create_debug_marker_array/trajectory_polygons", *time_keeper_);
-    int traj_poly_id = 0;
     Marker traj_poly_marker = createDefaultMarker(
-      "map", clock_->now(), "trajectory_polygons", traj_poly_id++, Marker::LINE_LIST,
+      "map", clock_->now(), "trajectory_polygons", 0, Marker::LINE_LIST,
       autoware::universe_utils::createMarkerScale(0.1, 0, 0),
       autoware::universe_utils::createMarkerColor(1.0, 1.0, 0.0, 0.5));  // Yellow color
 
@@ -94,9 +93,8 @@ MarkerArray RoadUserStopModule::create_debug_marker_array() const
   if (!debug_data_.trajectory_polygons_no_margin.empty()) {
     autoware_utils_debug::ScopedTimeTrack st_debug_marker(
       "create_debug_marker_array/trajectory_polygons_no_margin", *time_keeper_);
-    int traj_poly_id = 0;
     Marker traj_poly_marker = createDefaultMarker(
-      "map", clock_->now(), "trajectory_polygons_no_margin", traj_poly_id++, Marker::LINE_LIST,
+      "map", clock_->now(), "trajectory_polygons_no_margin", 0, Marker::LINE_LIST,
       autoware::universe_utils::createMarkerScale(0.1, 0, 0),
       autoware::universe_utils::createMarkerColor(1.0, 0.5, 0.0, 0.5));  // Orange color
 
@@ -111,9 +109,8 @@ MarkerArray RoadUserStopModule::create_debug_marker_array() const
   if (!debug_data_.object_polygons.empty()) {
     autoware_utils_debug::ScopedTimeTrack st_debug_marker(
       "create_debug_marker_array/object_polygons", *time_keeper_);
-    int obj_poly_id = 0;
     Marker obj_poly_marker = createDefaultMarker(
-      "map", clock_->now(), "object_polygons", obj_poly_id++, Marker::LINE_LIST,
+      "map", clock_->now(), "object_polygons", 0, Marker::LINE_LIST,
       autoware::universe_utils::createMarkerScale(0.15, 0, 0),
       autoware::universe_utils::createMarkerColor(0.8, 0.0, 0.8, 0.9));
 
@@ -128,9 +125,8 @@ MarkerArray RoadUserStopModule::create_debug_marker_array() const
   if (!debug_data_.polygons_for_vru.empty()) {
     autoware_utils_debug::ScopedTimeTrack st_debug_marker(
       "create_debug_marker_array/polygons_for_vru", *time_keeper_);
-    int vru_poly_id = 0;
     Marker vru_poly_marker = createDefaultMarker(
-      "map", clock_->now(), "polygons_for_vru", vru_poly_id++, Marker::LINE_LIST,
+      "map", clock_->now(), "polygons_for_vru", 0, Marker::LINE_LIST,
       autoware::universe_utils::createMarkerScale(0.15, 0, 0),
       autoware::universe_utils::createMarkerColor(0.5, 1.0, 0.5, 0.6));
 
@@ -145,9 +141,8 @@ MarkerArray RoadUserStopModule::create_debug_marker_array() const
   if (!debug_data_.polygons_for_opposing_traffic.empty()) {
     autoware_utils_debug::ScopedTimeTrack st_debug_marker(
       "create_debug_marker_array/polygons_for_opposing_traffic", *time_keeper_);
-    int opposing_poly_id = 0;
     Marker opposing_poly_marker = createDefaultMarker(
-      "map", clock_->now(), "polygons_for_opposing_traffic", opposing_poly_id++, Marker::LINE_LIST,
+      "map", clock_->now(), "polygons_for_opposing_traffic", 0, Marker::LINE_LIST,
       autoware::universe_utils::createMarkerScale(0.15, 0, 0),
       autoware::universe_utils::createMarkerColor(1.0, 0.5, 0.5, 0.6));
 


### PR DESCRIPTION
## Description

This PR reduces the time taken by the `road_user_stop` module to publish its debug markers.
To visualize many polygons, the module currently creates one `LINE_STRIP` debug marker for each polygon, which can result in more than 400 markers in my tests, leading to most of the module's runtime coming from publishing these markers.
With this PR, a single `LINE_LIST` marker is used to represent all polygons of a same namespace, leading the module to publish only 4 markers, greatly reducing the runtime of the node.

## Related links

## How was this PR tested?

Ran a [scenario](https://evaluation.tier4.jp/evaluation/reports/da9902df-eac3-5fa7-a86d-725180921490/tests/0a77fabb-c37b-5a99-bcd1-f27d4679344e/d93efd59-51a3-5e33-8288-57eee10de5a3/5c5e7d22-813d-51b7-bc52-372ef7684d23?project_id=prd_jt) that was failing due to the performance issue.

| Before | After |
| - | - |
| <img width="2404" height="1985" alt="image" src="https://github.com/user-attachments/assets/dc2360b0-b4a9-41d1-a7ae-d67b63defb26" /> | <img width="2404" height="1985" alt="image" src="https://github.com/user-attachments/assets/5a48f710-656f-4685-9e8b-0614bb8c7cdc" /> |

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

Slightly reduced runtime of the `road_user_stop` module.
