### PR TITLE
fix(path_optimizer): eliminate redundant move

### DIFF
--- a/planning/autoware_path_optimizer/src/node.cpp
+++ b/planning/autoware_path_optimizer/src/node.cpp
@@ -388,7 +388,7 @@ std::vector<TrajectoryPoint> PathOptimizer::optimizeTrajectory(const PlannerData
 
   auto optimized_traj_points = [&]() {
     if (mpt_traj) {
-      return std::move(*mpt_traj);
+      return *mpt_traj;
     }
     if (elapsed_time_over_three_seconds) {
       return p.traj_points;


### PR DESCRIPTION
## Description

- Part of: https://github.com/autowarefoundation/autoware_universe/issues/11418

## How was this PR tested?

### Before

```bash
/home/mfc/projects/autoware/src/universe/autoware_universe/planning/autoware_path_optimizer/src/node.cpp:391:23: error: redundant move in return statement [-Werror=redundant-move]
  391 |       return std::move(*mpt_traj);
      |              ~~~~~~~~~^~~~~~~~~~~
```

### After

Compiles locally with jazzy.

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.
