### PR TITLE
fix: add missing ament_index_cpp dependency

### DIFF
--- a/evaluator/autoware_kinematic_evaluator/CMakeLists.txt
+++ b/evaluator/autoware_kinematic_evaluator/CMakeLists.txt
@@ -29,11 +29,14 @@ rclcpp_components_register_node(${PROJECT_NAME}
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
+  find_package(ament_cmake_ros REQUIRED)
+  ament_auto_find_test_dependencies()
   ament_add_gtest(test_kinematic_evaluator
     test/test_kinematic_evaluator_node.cpp
   )
   target_link_libraries(test_kinematic_evaluator
     ${PROJECT_NAME}
+    ament_index_cpp::ament_index_cpp
   )
 endif()
 

--- a/evaluator/autoware_localization_evaluator/CMakeLists.txt
+++ b/evaluator/autoware_localization_evaluator/CMakeLists.txt
@@ -29,11 +29,15 @@ rclcpp_components_register_node(${PROJECT_NAME}
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
+  find_package(ament_cmake_ros REQUIRED)
+  ament_auto_find_test_dependencies()
+
   ament_add_gtest(test_localization_evaluator
     test/test_localization_evaluator_node.cpp
   )
   target_link_libraries(test_localization_evaluator
     ${PROJECT_NAME}
+    ament_index_cpp::ament_index_cpp
   )
 endif()
 

--- a/perception/autoware_bytetrack/package.xml
+++ b/perception/autoware_bytetrack/package.xml
@@ -17,6 +17,7 @@
   <buildtool_export_depend>cudnn_cmake_module</buildtool_export_depend>
   <buildtool_export_depend>tensorrt_cmake_module</buildtool_export_depend>
 
+  <depend>ament_index_cpp</depend>
   <depend>autoware_cuda_dependency_meta</depend>
   <depend>autoware_cuda_utils</depend>
   <depend>autoware_kalman_filter</depend>

--- a/perception/autoware_lidar_apollo_instance_segmentation/package.xml
+++ b/perception/autoware_lidar_apollo_instance_segmentation/package.xml
@@ -14,6 +14,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <depend>ament_index_cpp</depend>
   <depend>autoware_cuda_dependency_meta</depend>
   <depend>autoware_cuda_utils</depend>
   <depend>autoware_internal_debug_msgs</depend>
@@ -27,6 +28,7 @@
   <depend>tf2_eigen</depend>
   <depend>tier4_perception_msgs</depend>
 
+  <test_depend>ament_index_cpp</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
 

--- a/perception/autoware_predicted_path_postprocessor/CMakeLists.txt
+++ b/perception/autoware_predicted_path_postprocessor/CMakeLists.txt
@@ -18,6 +18,10 @@ target_include_directories(
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include/${PROJECT_NAME}>)
 
+target_link_libraries(${PROJECT_NAME}
+  ament_index_cpp::ament_index_cpp
+)
+
 rclcpp_components_register_node(
     ${PROJECT_NAME} PLUGIN
     "autoware::predicted_path_postprocessor::PredictedPathPostprocessorNode"
@@ -25,11 +29,15 @@ rclcpp_components_register_node(
 
 if(BUILD_TESTING)
     find_package(ament_cmake_ros REQUIRED)
+    ament_auto_find_test_dependencies()
 
     ament_add_ros_isolated_gtest(test_${PROJECT_NAME}
         test/test_refine_by_speed.cpp)
 
-    target_link_libraries(test_${PROJECT_NAME} ${PROJECT_NAME})
+    target_link_libraries(test_${PROJECT_NAME}
+      ${PROJECT_NAME}
+      ament_index_cpp::ament_index_cpp
+    )
 endif()
 
 ament_auto_package(INSTALL_TO_SHARE launch config)

--- a/perception/autoware_radar_object_tracker/package.xml
+++ b/perception/autoware_radar_object_tracker/package.xml
@@ -13,6 +13,7 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
   <buildtool_depend>eigen3_cmake_module</buildtool_depend>
 
+  <depend>ament_index_cpp</depend>
   <depend>autoware_kalman_filter</depend>
   <depend>autoware_lanelet2_utils</depend>
   <depend>autoware_object_recognition_utils</depend>

--- a/perception/autoware_traffic_light_classifier/package.xml
+++ b/perception/autoware_traffic_light_classifier/package.xml
@@ -17,6 +17,7 @@
   <build_depend>ament_cmake_gtest</build_depend>
   <build_depend>autoware_cmake</build_depend>
 
+  <depend>ament_index_cpp</depend>
   <depend>autoware_cuda_dependency_meta</depend>
   <depend>autoware_cuda_utils</depend>
   <depend>autoware_tensorrt_classifier</depend>

--- a/perception/autoware_traffic_light_visualization/package.xml
+++ b/perception/autoware_traffic_light_visualization/package.xml
@@ -13,6 +13,7 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
+  <depend>ament_index_cpp</depend>
   <depend>autoware_lanelet2_extension</depend>
   <depend>autoware_lanelet2_utils</depend>
   <depend>autoware_perception_msgs</depend>

--- a/sensing/autoware_calibration_status_classifier/CMakeLists.txt
+++ b/sensing/autoware_calibration_status_classifier/CMakeLists.txt
@@ -147,6 +147,10 @@ if(TRT_AVAIL AND CUDA_AVAIL AND CUDNN_AVAIL)
   if(BUILD_TESTING)
     find_package(ament_lint_auto REQUIRED)
     ament_lint_auto_find_test_dependencies()
+
+    find_package(ament_cmake_ros REQUIRED)
+    ament_auto_find_test_dependencies()
+
     find_package(OpenCV REQUIRED)
     find_package(ZLIB REQUIRED)
 
@@ -160,6 +164,7 @@ if(TRT_AVAIL AND CUDA_AVAIL AND CUDNN_AVAIL)
       ${PROJECT_NAME}_lib
       gtest
       gtest_main
+      ament_index_cpp::ament_index_cpp
     )
     ament_target_dependencies(test_preprocessing
       OpenCV
@@ -180,6 +185,7 @@ if(TRT_AVAIL AND CUDA_AVAIL AND CUDNN_AVAIL)
       ${PROJECT_NAME}_lib
       gtest
       gtest_main
+      ament_index_cpp::ament_index_cpp
     )
     ament_target_dependencies(test_model_inference
       OpenCV
@@ -200,6 +206,7 @@ if(TRT_AVAIL AND CUDA_AVAIL AND CUDNN_AVAIL)
       ${PROJECT_NAME}_lib
       gtest
       gtest_main
+      ament_index_cpp::ament_index_cpp
     )
     ament_target_dependencies(test_calibration_status_classifier
       OpenCV


### PR DESCRIPTION
## Description

- Part of: https://github.com/autowarefoundation/autoware_universe/issues/11418

## How was this PR tested?

### Before

So many errors like:

```bash
--- stderr: autoware_calibration_status_classifier
/home/mfc/projects/autoware/src/universe/autoware_universe/sensing/autoware_calibration_status_classifier/test/test_model_inference.cpp:17:10: fatal error: ament_index_cpp/get_package_share_directory.hpp: No such file or directory
   17 | #include <ament_index_cpp/get_package_share_directory.hpp>
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

### After

Compiles locally with jazzy.

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.
