### PR TITLE
fix(lidar_apollo_instance_segmentation): add missing dep, clean up CMakeLists

### DIFF
--- a/perception/autoware_lidar_apollo_instance_segmentation/CMakeLists.txt
+++ b/perception/autoware_lidar_apollo_instance_segmentation/CMakeLists.txt
@@ -1,16 +1,8 @@
 cmake_minimum_required(VERSION 3.17)
 project(autoware_lidar_apollo_instance_segmentation)
 
-find_package(ament_cmake REQUIRED)
-find_package(autoware_perception_msgs REQUIRED)
-find_package(PCL REQUIRED COMPONENTS common)
-find_package(pcl_conversions REQUIRED)
-find_package(rclcpp REQUIRED)
-find_package(rclcpp_components REQUIRED)
-find_package(tf2_eigen REQUIRED)
-find_package(autoware_utils REQUIRED)
-find_package(autoware_internal_debug_msgs REQUIRED)
-find_package(tier4_perception_msgs REQUIRED)
+find_package(autoware_cmake REQUIRED)
+autoware_package()
 
 find_package(autoware_tensorrt_common)
 if(NOT ${autoware_tensorrt_common_FOUND})
@@ -25,7 +17,7 @@ if(NOT ${autoware_tensorrt_common_FOUND})
 endif()
 find_package(autoware_cuda_utils REQUIRED)
 
-add_library(${PROJECT_NAME} SHARED
+ament_auto_add_library(${PROJECT_NAME} SHARED
   src/node.cpp
   src/detector.cpp
   src/log_table.cpp
@@ -38,10 +30,6 @@ add_library(${PROJECT_NAME} SHARED
 target_include_directories(${PROJECT_NAME} PRIVATE
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
   "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>"
-  ${autoware_cuda_utils_INCLUDE_DIRS}
-  ${pcl_conversions_INCLUDE_DIRS}
-  ${autoware_utils_INCLUDE_DIRS}
-  ${autoware_perception_msgs_INCLUDE_DIRS}
 )
 
 target_link_libraries(${PROJECT_NAME}

--- a/perception/autoware_lidar_apollo_instance_segmentation/include/autoware/lidar_apollo_instance_segmentation/disjoint_set.hpp
+++ b/perception/autoware_lidar_apollo_instance_segmentation/include/autoware/lidar_apollo_instance_segmentation/disjoint_set.hpp
@@ -1,18 +1,16 @@
-/******************************************************************************
- * Copyright 2017 The Apollo Authors. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *****************************************************************************/
+// Copyright 2017 The Apollo Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #ifndef AUTOWARE__LIDAR_APOLLO_INSTANCE_SEGMENTATION__DISJOINT_SET_HPP_
 #define AUTOWARE__LIDAR_APOLLO_INSTANCE_SEGMENTATION__DISJOINT_SET_HPP_

--- a/perception/autoware_lidar_apollo_instance_segmentation/package.xml
+++ b/perception/autoware_lidar_apollo_instance_segmentation/package.xml
@@ -26,11 +26,12 @@
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>tf2_eigen</depend>
+  <depend>tf2_sensor_msgs</depend>
   <depend>tier4_perception_msgs</depend>
 
   <test_depend>ament_index_cpp</test_depend>
   <test_depend>ament_lint_auto</test_depend>
-  <test_depend>ament_lint_common</test_depend>
+  <test_depend>autoware_lint_common</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
## Description

- Part of: https://github.com/autowarefoundation/autoware_universe/issues/11418

As I was fixing, I cleaned up and simplified the cmakelists file. I hope it passes in humble too. 🤞

## How was this PR tested?

### Before

```bash
/home/mfc/projects/autoware/src/universe/autoware_universe/perception/autoware_lidar_apollo_instance_segmentation/src/detector.cpp:20:10: fatal error: tf2_sensor_msgs/tf2_sensor_msgs.hpp: No such file or directory
   20 | #include <tf2_sensor_msgs/tf2_sensor_msgs.hpp>
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

### After

Compiles locally with jazzy.

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.
