### PR TITLE
fix: qos compatibility

### DIFF
--- a/perception/autoware_compare_map_segmentation/CMakeLists.txt
+++ b/perception/autoware_compare_map_segmentation/CMakeLists.txt
@@ -41,6 +41,7 @@ target_link_libraries(${PROJECT_NAME}
 )
 
 ament_target_dependencies(${PROJECT_NAME}
+  autoware_qos_utils
   grid_map_pcl
   grid_map_ros
   pcl_conversions
@@ -59,6 +60,7 @@ ament_target_dependencies(${PROJECT_NAME}
   std_msgs
   tf2
   tf2_ros
+  tf2_sensor_msgs
   visualization_msgs
 )
 

--- a/perception/autoware_compare_map_segmentation/lib/voxel_grid_map_loader.cpp
+++ b/perception/autoware_compare_map_segmentation/lib/voxel_grid_map_loader.cpp
@@ -14,6 +14,8 @@
 
 #include "autoware/compare_map_segmentation/voxel_grid_map_loader.hpp"
 
+#include <autoware/qos_utils/qos_compatibility.hpp>
+
 #include <limits>
 #include <memory>
 #include <string>
@@ -362,7 +364,7 @@ VoxelGridDynamicMapLoader::VoxelGridDynamicMapLoader(
   client_callback_group_ =
     node->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
   map_update_client_ = node->create_client<autoware_map_msgs::srv::GetDifferentialPointCloudMap>(
-    "map_loader_service", rmw_qos_profile_services_default, client_callback_group_);
+    "map_loader_service", AUTOWARE_DEFAULT_SERVICES_QOS_PROFILE(), client_callback_group_);
 
   while (!map_update_client_->wait_for_service(std::chrono::seconds(1)) && rclcpp::ok()) {
     RCLCPP_INFO(logger_, "service not available, waiting again ...");

--- a/perception/autoware_compare_map_segmentation/package.xml
+++ b/perception/autoware_compare_map_segmentation/package.xml
@@ -27,6 +27,7 @@
   <depend>autoware_map_msgs</depend>
   <depend>autoware_point_types</depend>
   <depend>autoware_pointcloud_preprocessor</depend>
+  <depend>autoware_qos_utils</depend>
   <depend>autoware_test_utils</depend>
   <depend>autoware_utils</depend>
   <depend>diagnostic_updater</depend>
@@ -44,6 +45,7 @@
   <depend>std_msgs</depend>
   <depend>tf2</depend>
   <depend>tf2_ros</depend>
+  <depend>tf2_sensor_msgs</depend>
   <depend>visualization_msgs</depend>
 
   <test_depend>ament_lint_auto</test_depend>

--- a/planning/autoware_mission_planner_universe/package.xml
+++ b/planning/autoware_mission_planner_universe/package.xml
@@ -23,6 +23,7 @@
   <depend>autoware_map_msgs</depend>
   <depend>autoware_motion_utils</depend>
   <depend>autoware_planning_msgs</depend>
+  <depend>autoware_qos_utils</depend>
   <depend>autoware_route_handler</depend>
   <depend>autoware_utils</depend>
   <depend>autoware_vehicle_info_utils</depend>

--- a/planning/autoware_mission_planner_universe/src/mission_planner/route_selector.cpp
+++ b/planning/autoware_mission_planner_universe/src/mission_planner/route_selector.cpp
@@ -15,6 +15,7 @@
 #include "route_selector.hpp"
 
 #include <autoware/mission_planner_universe/service_utils.hpp>
+#include <autoware/qos_utils/qos_compatibility.hpp>
 
 #include <array>
 #include <memory>
@@ -90,7 +91,7 @@ RouteSelector::RouteSelector(const rclcpp::NodeOptions & options)
 {
   using std::placeholders::_1;
   using std::placeholders::_2;
-  const auto service_qos = rmw_qos_profile_services_default;
+  const auto service_qos = AUTOWARE_DEFAULT_SERVICES_QOS_PROFILE();
   const auto durable_qos = rclcpp::QoS(1).transient_local();
 
   // Init main route interface.

--- a/planning/autoware_rtc_interface/package.xml
+++ b/planning/autoware_rtc_interface/package.xml
@@ -16,6 +16,7 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
+  <depend>autoware_qos_utils</depend>
   <depend>autoware_utils</depend>
   <depend>rclcpp</depend>
   <depend>tier4_rtc_msgs</depend>

--- a/planning/autoware_rtc_interface/src/rtc_interface.cpp
+++ b/planning/autoware_rtc_interface/src/rtc_interface.cpp
@@ -14,6 +14,8 @@
 
 #include "autoware/rtc_interface/rtc_interface.hpp"
 
+#include <autoware/qos_utils/qos_compatibility.hpp>
+
 #include <string>
 #include <vector>
 
@@ -140,11 +142,11 @@ RTCInterface::RTCInterface(rclcpp::Node * node, const std::string & name, const 
   srv_commands_ = node->create_service<CooperateCommands>(
     cooperate_commands_namespace_ + "/" + name,
     std::bind(&RTCInterface::onCooperateCommandService, this, _1, _2),
-    rmw_qos_profile_services_default, callback_group_);
+    AUTOWARE_DEFAULT_SERVICES_QOS_PROFILE(), callback_group_);
   srv_auto_mode_ = node->create_service<AutoMode>(
     enable_auto_mode_namespace_ + "/" + name,
-    std::bind(&RTCInterface::onAutoModeService, this, _1, _2), rmw_qos_profile_services_default,
-    callback_group_);
+    std::bind(&RTCInterface::onAutoModeService, this, _1, _2),
+    AUTOWARE_DEFAULT_SERVICES_QOS_PROFILE(), callback_group_);
 
   // Module
   module_ = getModuleType(name);


### PR DESCRIPTION
## Description

- Part of: https://github.com/autowarefoundation/autoware_universe/issues/11418

## How was this PR tested?

### Before

Many errors like these:

```bash
/home/mfc/projects/autoware/src/universe/autoware_universe/perception/autoware_compare_map_segmentation/lib/voxel_grid_map_loader.cpp:364:97: error: ‘typename rclcpp::Client<ServiceT>::SharedPtr rclcpp::Node::create_client(const std::string&, const rmw_qos_profile_t&, rclcpp::CallbackGroup::SharedPtr) [with ServiceT = autoware_map_msgs::srv::GetDifferentialPointCloudMap; typename rclcpp::Client<ServiceT>::SharedPtr = std::shared_ptr<rclcpp::Client<autoware_map_msgs::srv::GetDifferentialPointCloudMap> >; std::string = std::__cxx11::basic_string<char>; rmw_qos_profile_t = rmw_qos_profile_s; rclcpp::CallbackGroup::SharedPtr = std::shared_ptr<rclcpp::CallbackGroup>]’ is deprecated: use rclcpp::QoS instead of rmw_qos_profile_t [-Werror=deprecated-declarations]
  364 |   map_update_client_ = node->create_client<autoware_map_msgs::srv::GetDifferentialPointCloudMap>(
      |                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
  365 |     "map_loader_service", rmw_qos_profile_services_default, client_callback_group_);
      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~   

```

### After

Compiles locally with jazzy. (At least this error is gone for all these packages. `autoware_compare_map_segmentation` is still failing but that is a different kind of bug)

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.
