### PR TITLE
fix(multi_object_tracker): conform to updated TopicMetadata type

### DIFF
--- a/perception/autoware_multi_object_tracker/test/test_utils.cpp
+++ b/perception/autoware_multi_object_tracker/test/test_utils.cpp
@@ -167,12 +167,22 @@ RosbagWriterHelper::RosbagWriterHelper(bool enabled, const std::string & storage
   std::cout << "Rosbag opened successfully." << std::endl;
   // Register topics
   const auto serialization_format = rmw_get_serialization_format();
-  writer_->create_topic(
-    {"/perception/object_recognition/detection/objects",
-     "autoware_perception_msgs/msg/DetectedObjects", serialization_format, ""});
-  writer_->create_topic(
-    {"/perception/object_recognition/tracking/objects",
-     "autoware_perception_msgs/msg/TrackedObjects", serialization_format, ""});
+
+  {
+    rosbag2_storage::TopicMetadata topic_metadata_det;
+    topic_metadata_det.name = "/perception/object_recognition/detection/objects";
+    topic_metadata_det.type = "autoware_perception_msgs/msg/DetectedObjects";
+    topic_metadata_det.serialization_format = serialization_format;
+    writer_->create_topic(topic_metadata_det);
+  }
+
+  {
+    rosbag2_storage::TopicMetadata topic_metadata_rec;
+    topic_metadata_rec.name = "/perception/object_recognition/tracking/objects";
+    topic_metadata_rec.type = "autoware_perception_msgs/msg/TrackedObjects";
+    topic_metadata_rec.serialization_format = serialization_format;
+    writer_->create_topic(topic_metadata_rec);
+  }
   std::cout << "Topics registered successfully." << std::endl;
 }
 


### PR DESCRIPTION
## Description

- Part of: https://github.com/autowarefoundation/autoware_universe/issues/11418

Humble API:
https://github.com/ros2/rosbag2/blob/humble/rosbag2_storage/include/rosbag2_storage/topic_metadata.hpp

```cpp
struct TopicMetadata
{
  std::string name;
  std::string type;
  std::string serialization_format;
  // Serialized std::vector<rclcpp::QoS> as a YAML string
  std::string offered_qos_profiles;
};
```

Jazzy API:
https://github.com/ros2/rosbag2/blob/jazzy/rosbag2_storage/include/rosbag2_storage/topic_metadata.hpp

```cpp
struct TopicMetadata
{
  uint16_t id = 0;  // Topic id returned by storage
  std::string name;
  std::string type;
  std::string serialization_format;
  std::vector<rclcpp::QoS> offered_qos_profiles;
  // REP-2011 type description hash if available for topic, "" otherwise.
  std::string type_description_hash;
};
```

Since most fields were left empty/default, I updated the initialization method to conform both APIs.

## How was this PR tested?

### Before

```bash
/opt/ros/jazzy/include/rosbag2_cpp/rosbag2_cpp/writer.hpp:113:8: note:   candidate expects 2 arguments, 1 provided
/home/mfc/projects/autoware/src/universe/autoware_universe/perception/autoware_multi_object_tracker/test/test_utils.cpp:173:24: error: no matching function for call to ‘rosbag2_cpp::Writer::create_topic(<brace-enclosed initializer list>)’
  173 |   writer_->create_topic(
      |   ~~~~~~~~~~~~~~~~~~~~~^
  174 |     {"/perception/object_recognition/tracking/objects",
      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  175 |      "autoware_perception_msgs/msg/TrackedObjects", serialization_format, ""});
```

### After

Compiles and test passes locally with jazzy.

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.
