### PR TITLE
fix(freespace_planning_algorithms): conform to new SerializedBagMessage

### DIFF
--- a/planning/autoware_freespace_planning_algorithms/test/src/test_freespace_planning_algorithms.cpp
+++ b/planning/autoware_freespace_planning_algorithms/test/src/test_freespace_planning_algorithms.cpp
@@ -160,7 +160,13 @@ void add_message_to_rosbag(
   writer.create_topic(tm);
 
   auto bag_message = std::make_shared<rosbag2_storage::SerializedBagMessage>();
+
+#ifdef ROS_DISTRO_HUMBLE
   auto ret = rcutils_system_time_now(&bag_message->time_stamp);
+#else
+  auto ret = rcutils_system_time_now(&bag_message->recv_timestamp);
+#endif
+
   if (ret != RCL_RET_OK) {
     RCLCPP_ERROR(rclcpp::get_logger("saveToBag"), "couldn't assign time rosbag message");
   }


### PR DESCRIPTION
## Description

- Part of: https://github.com/autowarefoundation/autoware_universe/issues/11418


Humble API:
https://github.com/ros2/rosbag2/blob/humble/rosbag2_storage/include/rosbag2_storage/serialized_bag_message.hpp

```cpp
struct SerializedBagMessage
{
  std::shared_ptr<rcutils_uint8_array_t> serialized_data;
  rcutils_time_point_value_t time_stamp;
  std::string topic_name;
};
```

Jazzy API:
https://github.com/ros2/rosbag2/blob/jazzy/rosbag2_storage/include/rosbag2_storage/serialized_bag_message.hpp

```cpp
struct SerializedBagMessage
{
  std::shared_ptr<rcutils_uint8_array_t> serialized_data;
  /**
   * @brief Nanosecond timestamp when this message was received.
   */
  rcutils_time_point_value_t recv_timestamp;
  /**
   * @brief Nanosecond timestamp when this message was initially published. If
   * not available, this will be set to recv_timestamp.
   */
  rcutils_time_point_value_t send_timestamp;
  std::string topic_name;
};
```

> not available, this will be set to recv_timestamp.

So `recv_timestamp` is equivalent to the old `time_stamp` (most of the time).

This test doesn't even care what it is tbh.

## How was this PR tested?

### Before

```bash
/home/mfc/projects/autoware/src/universe/autoware_universe/planning/autoware_freespace_planning_algorithms/test/src/test_freespace_planning_algorithms.cpp:163:52: error: ‘using std::__shared_ptr_access<rosbag2_storage::SerializedBagMessage, __gnu_cxx::_S_atomic, false, false>::element_type = struct rosbag2_storage::SerializedBagMessage’ {aka ‘struct rosbag2_storage::SerializedBagMessage’} has no member named ‘time_stamp’
  163 |   auto ret = rcutils_system_time_now(&bag_message->time_stamp);
      |                                                    ^~~~~~~~~~
```

### After

Compiles and passes the tests locally with jazzy.

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.
