### PR TITLE
fix(traffic_light_occlusion_predictor): use array of bools instead

### DIFF
--- a/perception/autoware_traffic_light_occlusion_predictor/src/node.cpp
+++ b/perception/autoware_traffic_light_occlusion_predictor/src/node.cpp
@@ -44,7 +44,8 @@ TrafficLightOcclusionPredictorNode::TrafficLightOcclusionPredictorNode(
   const rclcpp::NodeOptions & node_options)
 : Node("traffic_light_occlusion_predictor_node", node_options),
   tf_buffer_(this->get_clock()),
-  tf_listener_(tf_buffer_)
+  tf_listener_(tf_buffer_),
+  subscribed_{}
 {
   using std::placeholders::_1;
   using std::placeholders::_2;
@@ -94,7 +95,7 @@ TrafficLightOcclusionPredictorNode::TrafficLightOcclusionPredictorNode(
       tier4_perception_msgs::msg::TrafficLightRoi::PEDESTRIAN_TRAFFIC_LIGHT),
     config_.max_image_cloud_delay, config_.max_wait_t);
 
-  subscribed_.resize(2, false);
+  subscribed_.fill(false);
 }
 
 void TrafficLightOcclusionPredictorNode::mapCallback(
@@ -181,7 +182,7 @@ void TrafficLightOcclusionPredictorNode::syncCallback(
     pub_msg->header = in_signal_msg->header;
     signal_pub_->publish(std::move(pub_msg));
     out_msg_.signals.clear();
-    std::fill(subscribed_.begin(), subscribed_.end(), false);
+    subscribed_.fill(false);
   }
 }
 }  // namespace autoware::traffic_light

--- a/perception/autoware_traffic_light_occlusion_predictor/src/node.hpp
+++ b/perception/autoware_traffic_light_occlusion_predictor/src/node.hpp
@@ -40,6 +40,7 @@
 #include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_listener.h>
 
+#include <array>
 #include <map>
 #include <memory>
 #include <mutex>
@@ -105,7 +106,7 @@ private:
   std::shared_ptr<SynchronizerType> synchronizer_;
   std::shared_ptr<SynchronizerType> synchronizer_ped_;
 
-  std::vector<bool> subscribed_;
+  std::array<bool, 2> subscribed_;
   std::vector<int> occlusion_ratios_;
   tier4_perception_msgs::msg::TrafficLightArray out_msg_;
 };


### PR DESCRIPTION
## Description

- Part of: https://github.com/autowarefoundation/autoware_universe/issues/11418

## How was this PR tested?

### Before

```bash
                 from /home/mfc/projects/autoware/src/universe/autoware_universe/perception/autoware_traffic_light_occlusion_predictor/src/node.cpp:17:
In static member function ‘static _Up* std::__copy_move<_IsMove, true, std::random_access_iterator_tag>::__copy_m(_Tp*, _Tp*, _Up*) [with _Tp = long unsigned int; _Up = long unsigned int; bool _IsMove = false]’,
    inlined from ‘_OI std::__copy_move_a2(_II, _II, _OI) [with bool _IsMove = false; _II = long unsigned int*; _OI = long unsigned int*]’ at /usr/include/c++/13/bits/stl_algobase.h:506:30,
    inlined from ‘_OI std::__copy_move_a1(_II, _II, _OI) [with bool _IsMove = false; _II = long unsigned int*; _OI = long unsigned int*]’ at /usr/include/c++/13/bits/stl_algobase.h:533:42,
    inlined from ‘_OI std::__copy_move_a(_II, _II, _OI) [with bool _IsMove = false; _II = long unsigned int*; _OI = long unsigned int*]’ at /usr/include/c++/13/bits/stl_algobase.h:540:31,
    inlined from ‘_OI std::copy(_II, _II, _OI) [with _II = long unsigned int*; _OI = long unsigned int*]’ at /usr/include/c++/13/bits/stl_algobase.h:633:7,
    inlined from ‘std::vector<bool, _Alloc>::iterator std::vector<bool, _Alloc>::_M_copy_aligned(const_iterator, const_iterator, iterator) [with _Alloc = std::allocator<bool>]’ at /usr/include/c++/13/bits/stl_bvector.h:1342:28,
    inlined from ‘void std::vector<bool, _Alloc>::_M_fill_insert(iterator, size_type, bool) [with _Alloc = std::allocator<bool>]’ at /usr/include/c++/13/bits/vector.tcc:879:34,
    inlined from ‘std::vector<bool, _Alloc>::iterator std::vector<bool, _Alloc>::insert(const_iterator, size_type, const bool&) [with _Alloc = std::allocator<bool>]’ at /usr/include/c++/13/bits/stl_bvector.h:1242:16,
    inlined from ‘void std::vector<bool, _Alloc>::resize(size_type, bool) [with _Alloc = std::allocator<bool>]’ at /usr/include/c++/13/bits/stl_bvector.h:1288:10,
    inlined from ‘autoware::traffic_light::TrafficLightOcclusionPredictorNode::TrafficLightOcclusionPredictorNode(const rclcpp::NodeOptions&)’ at /home/mfc/projects/autoware/src/universe/autoware_universe/perception/autoware_traffic_light_occlusion_predictor/src/node.cpp:97:21:
/usr/include/c++/13/bits/stl_algobase.h:437:30: error: ‘void* __builtin_memmove(void*, const void*, long unsigned int)’ forming offset 8 is out of the bounds [0, 8] [-Werror=array-bounds=]
  437 |             __builtin_memmove(__result, __first, sizeof(_Tp) * _Num);
```

Summary: `std::vector<bool>` is *bad* **because it is compact**. But *compact in a problematic way*.  Unlike other `std::vector<T>` specializations, `std::vector<bool>` **doesn't store actual `bool` values**. Instead, it packs bits together to save memory. And it causes issues with `jazzy` / `gcc 13`.

### After

Compiles locally with jazzy.

## Notes for reviewers

- Instead of `std::vector<bool>` it uses `std::array<bool, 2>`.
- Behavior should be same as before.

## Interface changes

None.

## Effects on system behavior

None.
