### PR TITLE
refactor: use boost version instead of ros version

### DIFF
--- a/control/autoware_autonomous_emergency_braking/src/node.cpp
+++ b/control/autoware_autonomous_emergency_braking/src/node.cpp
@@ -32,8 +32,9 @@
 #include <boost/geometry/algorithms/correct.hpp>
 #include <boost/geometry/algorithms/intersection.hpp>
 #include <boost/geometry/algorithms/within.hpp>
-// no longer needed in Jazzy
-#ifdef ROS_DISTRO_HUMBLE
+#include <boost/version.hpp>
+
+#if BOOST_VERSION < 107600  // Header removed in version 1.76.0 (Humble)
 #include <boost/geometry/strategies/agnostic/hull_graham_andrew.hpp>
 #endif
 

--- a/control/autoware_predicted_path_checker/src/predicted_path_checker_node/utils.cpp
+++ b/control/autoware_predicted_path_checker/src/predicted_path_checker_node/utils.cpp
@@ -18,8 +18,9 @@
 
 #include <boost/format.hpp>
 #include <boost/geometry/algorithms/convex_hull.hpp>
-// no longer needed in Jazzy
-#ifdef ROS_DISTRO_HUMBLE
+#include <boost/version.hpp>
+
+#if BOOST_VERSION < 107600  // Header removed in version 1.76.0 (Humble)
 #include <boost/geometry/strategies/agnostic/hull_graham_andrew.hpp>
 #endif
 


### PR DESCRIPTION
## Description

This PR use boost version (instead of ROS version) to include boost file of `hull_graham_andrew.hpp`

## Related links

https://github.com/autowarefoundation/autoware_universe/pull/11556#issuecomment-3758094925

## How was this PR tested?

colcon build

## Notes for reviewers

The same code is already used inside this repo, like:

https://github.com/autowarefoundation/autoware_universe/blob/1eecaa86f1959a4464f801b053cfb53e22255523/common/autoware_universe_utils/src/geometry/random_concave_polygon.cpp#L31-L33

## Interface changes

None.

## Effects on system behavior

The packages can be build with differenct boost versions.
