### PR TITLE
chore(autoware_shape_estimation): remove cudnn dependency

### DIFF
--- a/perception/autoware_shape_estimation/CMakeLists.txt
+++ b/perception/autoware_shape_estimation/CMakeLists.txt
@@ -14,7 +14,6 @@ find_package(OpenCV REQUIRED)
 find_package(Eigen3 REQUIRED)
 
 find_package(CUDA)
-find_package(CUDNN)
 find_package(TENSORRT)
 
 set(SHAPE_ESTIMATION_DEPENDENCIES
@@ -41,7 +40,7 @@ set(${PROJECT_NAME}_SOURCES
   lib/corrector/reference_shape_size_corrector.cpp
 )
 
-if(${CUDA_FOUND} AND ${CUDNN_FOUND} AND ${TENSORRT_FOUND})
+if(${CUDA_FOUND} AND ${TENSORRT_FOUND})
   message("CUDA found, including CUDA-specific sources")
   list(APPEND ${PROJECT_NAME}_SOURCES lib/tensorrt_shape_estimator.cpp)
   add_definitions(-DUSE_CUDA)
@@ -62,7 +61,7 @@ target_include_directories(${PROJECT_NAME}_lib
   "${EIGEN3_INCLUDE_DIR}"
 )
 
-if(${CUDA_FOUND} AND ${CUDNN_FOUND} AND ${TENSORRT_FOUND})
+if(${CUDA_FOUND} AND ${TENSORRT_FOUND})
 target_include_directories(${PROJECT_NAME}_lib
   SYSTEM PUBLIC
   "${TENSORRT_INCLUDE_DIRS}"
@@ -87,7 +86,7 @@ target_link_libraries(${PROJECT_NAME}
   ${PROJECT_NAME}_lib
 )
 
-if(${CUDA_FOUND} AND ${CUDNN_FOUND} AND ${TENSORRT_FOUND})
+if(${CUDA_FOUND} AND ${TENSORRT_FOUND})
   target_link_libraries(${PROJECT_NAME}
     ${TENSORRT_LIBRARIES}
   )

--- a/perception/autoware_shape_estimation/package.xml
+++ b/perception/autoware_shape_estimation/package.xml
@@ -14,10 +14,8 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
-  <buildtool_depend>cudnn_cmake_module</buildtool_depend>
   <buildtool_depend>tensorrt_cmake_module</buildtool_depend>
 
-  <buildtool_export_depend>cudnn_cmake_module</buildtool_export_depend>
   <buildtool_export_depend>tensorrt_cmake_module</buildtool_export_depend>
 
   <depend>autoware_cuda_dependency_meta</depend>


### PR DESCRIPTION
## Description

Remove CUDNN as it is unused dependency.

## Related links

**Parent Issue:**

- https://github.com/autowarefoundation/autoware/issues/6729#issuecomment-3757777221

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
