### PR TITLE
chore(autoware_simpl_prediction): remove cudnn dependency

### DIFF
--- a/perception/autoware_simpl_prediction/CMakeLists.txt
+++ b/perception/autoware_simpl_prediction/CMakeLists.txt
@@ -9,14 +9,13 @@ endif()
 find_package(autoware_cmake REQUIRED)
 autoware_package()
 
-# --- find CUDA/CUDNN/TensorRT dependencies ---
+# --- find CUDA/TensorRT dependencies ---
 find_package(CUDA)
 find_package(CUDAToolkit)
-find_package(CUDNN)
 find_package(TENSORRT)
 
 # --- check CUDA tools and TensorRT version ---
-if(CUDAToolkit_FOUND AND CUDNN_FOUND AND TENSORRT_FOUND)
+if(CUDAToolkit_FOUND AND TENSORRT_FOUND)
     set(CUDA_AVAILABLE TRUE)
     if(TENSORRT_VERSION VERSION_LESS 8.5)
         set(TENSORRT_AVAILABLE FALSE)
@@ -29,7 +28,7 @@ if(CUDAToolkit_FOUND AND CUDNN_FOUND AND TENSORRT_FOUND)
 else()
     set(CUDA_AVAILABLE FALSE)
     set(TENSORRT_AVAILABLE FALSE)
-    message(WARNING "CUDA, CUDNN and TensorRT libraries are not found.")
+    message(WARNING "CUDA and TensorRT libraries are not found.")
 endif()
 
 # --- link targets ---

--- a/perception/autoware_simpl_prediction/package.xml
+++ b/perception/autoware_simpl_prediction/package.xml
@@ -11,10 +11,8 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
-  <buildtool_depend>cudnn_cmake_module</buildtool_depend>
   <buildtool_depend>tensorrt_cmake_module</buildtool_depend>
 
-  <buildtool_export_depend>cudnn_cmake_module</buildtool_export_depend>
   <buildtool_export_depend>tensorrt_cmake_module</buildtool_export_depend>
 
   <depend>autoware_cuda_utils</depend>


### PR DESCRIPTION
## Description

Remove CUDNN as it is unused dependency.

## Related links

**Parent Issue:**

- https://github.com/autowarefoundation/autoware/issues/6729#issuecomment-3757777221

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
