### PR TITLE
chore(autoware_tensorrt_classifier): remove cudnn dependency

### DIFF
--- a/perception/autoware_tensorrt_classifier/CMakeLists.txt
+++ b/perception/autoware_tensorrt_classifier/CMakeLists.txt
@@ -10,12 +10,11 @@ autoware_package()
 add_compile_options(-Wno-deprecated-declarations)
 
 find_package(CUDA)
-find_package(CUDNN)
 find_package(TENSORRT)
 find_package(OpenCV REQUIRED)
 
-if(NOT (${CUDA_FOUND} AND ${CUDNN_FOUND} AND ${TENSORRT_FOUND}))
-  message(WARNING "cuda, cudnn, tensorrt libraries are not found")
+if(NOT (${CUDA_FOUND} AND ${TENSORRT_FOUND}))
+  message(WARNING "cuda, tensorrt libraries are not found")
   return()
 endif()
 
@@ -64,8 +63,6 @@ endif()
 
 ament_export_include_directories(include)
 ament_export_dependencies(CUDA)
-ament_export_dependencies(cudnn_cmake_module)
-ament_export_dependencies(CUDNN)
 ament_export_dependencies(tensorrt_cmake_module)
 ament_export_dependencies(TENSORRT)
 

--- a/perception/autoware_tensorrt_classifier/package.xml
+++ b/perception/autoware_tensorrt_classifier/package.xml
@@ -13,10 +13,8 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-  <buildtool_depend>cudnn_cmake_module</buildtool_depend>
   <buildtool_depend>tensorrt_cmake_module</buildtool_depend>
 
-  <buildtool_export_depend>cudnn_cmake_module</buildtool_export_depend>
   <buildtool_export_depend>tensorrt_cmake_module</buildtool_export_depend>
 
   <build_depend>autoware_cmake</build_depend>


### PR DESCRIPTION
## Description

Remove CUDNN as it is unused dependency.

## Related links

**Parent Issue:**

- https://github.com/autowarefoundation/autoware/issues/6729#issuecomment-3757777221

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
