### PR TITLE
chore(autoware_tensorrt_common): remove cudnn dependency

### DIFF
--- a/perception/autoware_tensorrt_common/CMakeLists.txt
+++ b/perception/autoware_tensorrt_common/CMakeLists.txt
@@ -2,17 +2,15 @@ cmake_minimum_required(VERSION 3.17)
 project(autoware_tensorrt_common)
 
 find_package(ament_cmake REQUIRED)
-find_package(cudnn_cmake_module REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(tensorrt_cmake_module REQUIRED)
 
 find_package(CUDA)
 find_package(CUDAToolkit)
-find_package(CUDNN)
 find_package(TENSORRT)
 
-if(NOT (CUDAToolkit_FOUND AND CUDNN_FOUND AND TENSORRT_FOUND))
-  message(WARNING "cuda, cudnn, tensorrt libraries are not found")
+if(NOT (CUDAToolkit_FOUND AND TENSORRT_FOUND))
+  message(WARNING "cuda, tensorrt libraries are not found")
   return()
 endif()
 
@@ -77,8 +75,6 @@ ament_export_targets(export_${PROJECT_NAME})
 ament_export_dependencies(
   "CUDA"
   "CUDAToolkit"
-  "cudnn_cmake_module"
-  "CUDNN"
   "rclcpp"
   "tensorrt_cmake_module"
   "TENSORRT"

--- a/perception/autoware_tensorrt_common/package.xml
+++ b/perception/autoware_tensorrt_common/package.xml
@@ -15,7 +15,6 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-  <buildtool_depend>cudnn_cmake_module</buildtool_depend>
   <buildtool_depend>tensorrt_cmake_module</buildtool_depend>
 
   <depend>autoware_cuda_dependency_meta</depend>


### PR DESCRIPTION
## Description

Remove CUDNN as it is unused dependency.

## Related links

**Parent Issue:**

- https://github.com/autowarefoundation/autoware/issues/6729#issuecomment-3757777221

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
