### PR TITLE
chore(autoware_tensorrt_bevformer): remove cudnn dependency

### DIFF
--- a/perception/autoware_tensorrt_bevformer/CMakeLists.txt
+++ b/perception/autoware_tensorrt_bevformer/CMakeLists.txt
@@ -56,25 +56,7 @@ else()
   set(TRT_AVAIL OFF)
 endif()
 
-# CUDNN
-option(CUDNN_AVAIL "CUDNN available" OFF)
-find_library(CUDNN_LIBRARY
-  NAMES libcudnn.so libcudnn
-  PATHS $ENV{LD_LIBRARY_PATH} ${CUDNN_ROOT_DIR} ${CMAKE_INSTALL_PREFIX}
-  PATH_SUFFIXES lib lib64 bin
-)
-if(CUDNN_LIBRARY)
-  if(CUDA_VERBOSE)
-    message(STATUS "CUDNN is available!")
-    message(STATUS "CUDNN_LIBRARY: ${CUDNN_LIBRARY}")
-  endif()
-  set(CUDNN_AVAIL ON)
-else()
-  message("CUDNN is NOT available")
-  set(CUDNN_AVAIL OFF)
-endif()
-
-if(TRT_AVAIL AND CUDA_AVAIL AND CUDNN_AVAIL)
+if(TRT_AVAIL AND CUDA_AVAIL)
   find_package(ament_cmake_auto REQUIRED)
   ament_auto_find_build_dependencies()
 
@@ -106,7 +88,6 @@ if(TRT_AVAIL AND CUDA_AVAIL AND CUDNN_AVAIL)
       -Wno-unused-variable -Wno-unused-but-set-variable -Wno-comment -Wno-switch>
   )
   target_link_libraries(${TENSORRT_OPS_TARGET}
-    ${CUDNN_LIBRARY}
     ${NVINFER}
     ${NVONNXPARSER}
     ${CUDA_LIBRARIES}
@@ -155,7 +136,6 @@ if(TRT_AVAIL AND CUDA_AVAIL AND CUDNN_AVAIL)
     ${OpenCV_LIBRARIES}
     ${NVINFER}
     ${NVONNXPARSER}
-    ${CUDNN_LIBRARY}
     ${TENSORRT_OPS_TARGET}
     dl
   )
@@ -198,6 +178,6 @@ else()
   # Dependencies missing
   find_package(ament_cmake_auto REQUIRED)
   ament_auto_find_build_dependencies()
-  message(WARNING "Required dependencies (CUDA, TensorRT, CUDNN) not found. Skipping ${PROJECT_NAME} build.")
+  message(WARNING "Required dependencies (CUDA, TensorRT) not found. Skipping ${PROJECT_NAME} build.")
   ament_auto_package(INSTALL_TO_SHARE launch)
 endif()

--- a/perception/autoware_tensorrt_bevformer/README.md
+++ b/perception/autoware_tensorrt_bevformer/README.md
@@ -44,7 +44,6 @@ The core algorithm, named `BEVFormer`, unifies multi-view images into the BEV pe
 
 - **TensorRT** 10.8.0.43
 - **CUDA** 12.4
-- **cuDNN** 8.9.2
 
 ### Trained Model
 

--- a/perception/autoware_tensorrt_bevformer/TensorRT/common/checkMacrosPlugin.cpp
+++ b/perception/autoware_tensorrt_bevformer/TensorRT/common/checkMacrosPlugin.cpp
@@ -125,15 +125,6 @@ void throwCublasError(
 }
 
 // break-pointable
-void throwCudnnError(
-  const char * file, const char * function, int line, int status, const char * msg)
-{
-  CudnnError error(file, function, line, status, msg);
-  error.log(gLogError);
-  throw error;
-}
-
-// break-pointable
 void throwPluginError(
   char const * file, char const * function, int line, int status, char const * msg)
 {

--- a/perception/autoware_tensorrt_bevformer/TensorRT/common/checkMacrosPlugin.h
+++ b/perception/autoware_tensorrt_bevformer/TensorRT/common/checkMacrosPlugin.h
@@ -29,7 +29,7 @@
  * limitations under the License.
  */
 
-// cspell:ignore BEVFORMER, CHECKMACROSPLUGIN, CUBLASASSERT, CUDNNASSERT, CUASSERT, CUERROR
+// cspell:ignore BEVFORMER, CHECKMACROSPLUGIN, CUBLASASSERT, CUASSERT, CUERROR
 
 #ifndef PERCEPTION__AUTOWARE_TENSORRT_BEVFORMER__TENSORRT__COMMON__CHECKMACROSPLUGIN_H_  // NOLINT
 #define PERCEPTION__AUTOWARE_TENSORRT_BEVFORMER__TENSORRT__COMMON__CHECKMACROSPLUGIN_H_  // NOLINT
@@ -114,8 +114,6 @@ void logError(const char * msg, const char * file, const char * fn, int line);
 
 [[noreturn]] void throwCudaError(
   const char * file, const char * function, int line, int status, const char * msg = nullptr);
-[[noreturn]] void throwCudnnError(
-  const char * file, const char * function, int line, int status, const char * msg = nullptr);
 [[noreturn]] void throwCublasError(
   const char * file, const char * function, int line, int status, const char * msg = nullptr);
 [[noreturn]] void throwPluginError(
@@ -145,15 +143,6 @@ class CudaError : public TRTException
 public:
   CudaError(const char * fl, const char * fn, int ln, int stat, const char * msg = nullptr)
   : TRTException(fl, fn, ln, stat, msg, "Cuda")
-  {
-  }
-};
-
-class CudnnError : public TRTException
-{
-public:
-  CudnnError(const char * fl, const char * fn, int ln, int stat, const char * msg = nullptr)
-  : TRTException(fl, fn, ln, stat, msg, "Cudnn")
   {
   }
 };
@@ -217,29 +206,12 @@ inline void caughtError(const std::exception & e)
     }                            \
   } while (0)
 
-#define PLUGIN_CHECK_CUDNN(call)          \
-  do {                                    \
-    cudnnStatus_t status = call;          \
-    if (status != CUDNN_STATUS_SUCCESS) { \
-      return status;                      \
-    }                                     \
-  } while (0)
-
 #define PLUGIN_CUBLASASSERT(status_)                                       \
   {                                                                        \
     auto s_ = status_;                                                     \
     if (s_ != CUBLAS_STATUS_SUCCESS) {                                     \
       nvinfer1::plugin::throwCublasError(__FILE__, FN_NAME, __LINE__, s_); \
     }                                                                      \
-  }
-
-#define PLUGIN_CUDNNASSERT(status_)                                            \
-  {                                                                            \
-    auto s_ = status_;                                                         \
-    if (s_ != CUDNN_STATUS_SUCCESS) {                                          \
-      const char * msg = cudnnGetErrorString(s_);                              \
-      nvinfer1::plugin::throwCudnnError(__FILE__, FN_NAME, __LINE__, s_, msg); \
-    }                                                                          \
   }
 
 #define PLUGIN_CUASSERT(status_)                                              \

--- a/perception/autoware_tensorrt_bevformer/TensorRT/common/cuda_helper.cu
+++ b/perception/autoware_tensorrt_bevformer/TensorRT/common/cuda_helper.cu
@@ -105,21 +105,6 @@ template void memcpyPermute<float>(
 template void memcpyPermute<half>(
   half * dst, const half * src, int * src_size, int * permute, int src_dim, cudaStream_t stream);
 
-cudnnStatus_t convert_trt2cudnn_dtype(nvinfer1::DataType trt_dtype, cudnnDataType_t * cudnn_dtype)
-{
-  switch (trt_dtype) {
-    case nvinfer1::DataType::kFLOAT:
-      *cudnn_dtype = CUDNN_DATA_FLOAT;
-      break;
-    case nvinfer1::DataType::kHALF:
-      *cudnn_dtype = CUDNN_DATA_HALF;
-      break;
-    default:
-      return CUDNN_STATUS_BAD_PARAM;
-  }
-  return CUDNN_STATUS_SUCCESS;
-}
-
 template <>
 cublasStatus_t cublasGemmWrap<float>(
   cublasHandle_t handle, cublasOperation_t transa, cublasOperation_t transb, int m, int n, int k,

--- a/perception/autoware_tensorrt_bevformer/TensorRT/common/helper.h
+++ b/perception/autoware_tensorrt_bevformer/TensorRT/common/helper.h
@@ -39,14 +39,11 @@
 #define PERCEPTION__AUTOWARE_TENSORRT_BEVFORMER__TENSORRT__COMMON__HELPER_H_  // NOLINT
 
 #include <NvInferRuntime.h>
-#include <cudnn.h>
 
 #include <cstdio>
 #include <iostream>
 #include <stdexcept>
 #include <string>
-
-cudnnStatus_t convert_trt2cudnn_dtype(nvinfer1::DataType trt_dtype, cudnnDataType_t * cudnn_dtype);
 
 // Enumerator for status
 typedef enum {


### PR DESCRIPTION
## Description

Remove CUDNN as it is unused dependency.

## Related links

**Parent Issue:**

- https://github.com/autowarefoundation/autoware/issues/6729#issuecomment-3757777221

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
