### PR TITLE
refactor(traffic_light_occlusion_predictor): rename synchronizer_ to synchronizer_car_

### DIFF
--- a/perception/autoware_traffic_light_occlusion_predictor/src/node.cpp
+++ b/perception/autoware_traffic_light_occlusion_predictor/src/node.cpp
@@ -74,7 +74,7 @@ TrafficLightOcclusionPredictorNode::TrafficLightOcclusionPredictorNode(
   const std::vector<std::string> topics{
     "~/input/car/traffic_signals", "~/input/rois", "~/input/camera_info", "~/input/cloud"};
   const std::vector<rclcpp::QoS> qos(topics.size(), rclcpp::SensorDataQoS());
-  synchronizer_ = std::make_shared<SynchronizerType>(
+  synchronizer_car_ = std::make_shared<SynchronizerType>(
     this, topics, qos,
     std::bind(
       &TrafficLightOcclusionPredictorNode::syncCallback, this, _1, _2, _3, _4,

--- a/perception/autoware_traffic_light_occlusion_predictor/src/node.hpp
+++ b/perception/autoware_traffic_light_occlusion_predictor/src/node.hpp
@@ -128,7 +128,7 @@ private:
     sensor_msgs::msg::CameraInfo, sensor_msgs::msg::PointCloud2>
     SynchronizerType;
 
-  std::shared_ptr<SynchronizerType> synchronizer_;
+  std::shared_ptr<SynchronizerType> synchronizer_car_;
   std::shared_ptr<SynchronizerType> synchronizer_ped_;
 
   /**


### PR DESCRIPTION
## Description

Simple rename of a variable.

- `synchronizer_car_` is for car traffic lights 🚗🚦
- `synchronizer_ped_` is for pedestrian traffic lights 🚶🚦

Follow up from:
- https://github.com/autowarefoundation/autoware_universe/pull/11883#issuecomment-3760095924
- https://github.com/autowarefoundation/autoware_universe/pull/11913
- https://github.com/autowarefoundation/autoware_universe/pull/11914

## How was this PR tested?

CI and local build in jazzy.

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.
