### PR TITLE
fix(euclidean_cluster): ignore inline pcl eigen warning

### DIFF
--- a/perception/autoware_euclidean_cluster/lib/voxel_grid_based_euclidean_cluster.cpp
+++ b/perception/autoware_euclidean_cluster/lib/voxel_grid_based_euclidean_cluster.cpp
@@ -145,10 +145,11 @@ bool VoxelGridBasedEuclideanCluster::cluster(
     // for (size_t i = 0; i < pointcloud->points.size(); ++i) {
     // const auto & point = pointcloud->points.at(i);
 
+    const Eigen::Vector3i grid_coord = voxel_grid_.getGridCoordinates(point.x, point.y, point.z);
+
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Warray-bounds"
-    const int voxel_index =
-      voxel_grid_.getCentroidIndexAt(voxel_grid_.getGridCoordinates(point.x, point.y, point.z));
+    const int voxel_index = voxel_grid_.getCentroidIndexAt(grid_coord);
 #pragma GCC diagnostic pop
 
     auto voxel_to_cluster_map_it = voxel_to_cluster_map.find(voxel_index);


### PR DESCRIPTION
## Description

- Part of: https://github.com/autowarefoundation/autoware_universe/issues/11418

```cpp
    const int voxel_index =
      voxel_grid_.getCentroidIndexAt(voxel_grid_.getGridCoordinates(point.x, point.y, point.z));
```
This line is problematic.

Even if you split it into 2 steps:

```cpp
    const Eigen::Vector3i grid_coord = voxel_grid_.getGridCoordinates(point.x, point.y, point.z);
    const int voxel_index = voxel_grid_.getCentroidIndexAt(grid_coord);
```

The second step will give this issue:

```bash
/home/mfc/projects/autoware/src/universe/autoware_universe/perception/autoware_euclidean_cluster/lib/voxel_grid_based_euclidean_cluster.cpp:148:37:
/usr/lib/gcc/x86_64-linux-gnu/13/include/emmintrin.h:706:11: error: array subscript ‘const __m128i_u[0]’ is partly outside array bounds of ‘Eigen::Vector3i [1]’ {aka ‘Eigen::Matrix<int, 3, 1> [1]’} [-Werror=array-bounds=]
  706 |   return *__P;
      |           ^~~
```

This is due to `voxel_grid_.getCentroidIndexAt(grid_coord);` operation.

This inline operation uses comma initialization and rustles the feathers of GCC 13.
This is outside our project: 

> https://github.com/PointCloudLibrary/pcl/blob/f62c018b4fc7df3dc2c096918a8462a190f28bb8/filters/include/pcl/filters/voxel_grid.h#L363-L377
>
> ```cpp
>       /** \brief Returns the index in the downsampled cloud corresponding to a given set of coordinates.
>         * \param[in] ijk the coordinates (i,j,k) in the grid (-1 if empty)
>         */
>       inline int
>       getCentroidIndexAt (const Eigen::Vector3i &ijk) const
>       {
>         int idx = ((Eigen::Vector4i() << ijk, 0).finished() - min_b_).dot (divb_mul_);
>         if (idx < 0 || idx >= static_cast<int> (leaf_layout_.size ())) // this checks also if leaf_layout_.size () == 0 i.e. everything was computed as needed
>         {
>           //if (verbose)
>           //  PCL_ERROR ("[pcl::%s::getCentroidIndexAt] Specified coordinate is outside grid bounds, or leaf layout is not saved, make sure to call setSaveLeafLayout(true) and filter(output) first!\n", getClassName ().c_str ());
>           return (-1);
>         }
>         return (leaf_layout_[idx]);
>       }
> ```

## How was this PR tested?

### Before

```bash
In file included from /usr/include/eigen3/Eigen/src/Core/util/ConfigureVectorization.h:346,
                 from /usr/include/eigen3/Eigen/Core:22,
                 from /usr/include/eigen3/Eigen/StdVector:14,
                 from /usr/include/pcl-1.14/pcl/point_cloud.h:45,
                 from /home/mfc/projects/autoware/src/universe/autoware_universe/perception/autoware_euclidean_cluster/include/autoware/euclidean_cluster/euclidean_cluster_interface.hpp:22,
                 from /home/mfc/projects/autoware/src/universe/autoware_universe/perception/autoware_euclidean_cluster/include/autoware/euclidean_cluster/voxel_grid_based_euclidean_cluster.hpp:16,
                 from /home/mfc/projects/autoware/src/universe/autoware_universe/perception/autoware_euclidean_cluster/lib/voxel_grid_based_euclidean_cluster.cpp:15:
In function ‘__m128i _mm_loadu_si128(const __m128i_u*)’,
    inlined from ‘Packet Eigen::internal::ploadu(const typename unpacket_traits<T>::type*) [with Packet = eigen_packet_wrapper<__vector(2) long long int, 0>]’ at /usr/include/eigen3/Eigen/src/Core/arch/SSE/PacketMath.h:751:25,
    inlined from ‘Packet Eigen::internal::ploadt(const typename unpacket_traits<T>::type*) [with Packet = eigen_packet_wrapper<__vector(2) long long int, 0>; int Alignment = 0]’ at /usr/include/eigen3/Eigen/src/Core/GenericPacketMath.h:969:26,
    inlined from ‘PacketType Eigen::internal::evaluator<Eigen::PlainObjectBase<Derived> >::packet(Eigen::Index, Eigen::Index) const [with int LoadMode = 0; PacketType = Eigen::internal::eigen_packet_wrapper<__vector(2) long long int, 0>; Derived = Eigen::Matrix<int, 3, 1>]’ at /usr/include/eigen3/Eigen/src/Core/CoreEvaluators.h:238:42,
    inlined from ‘void Eigen::internal::generic_dense_assignment_kernel<DstEvaluatorTypeT, SrcEvaluatorTypeT, Functor, Version>::assignPacket(Eigen::Index, Eigen::Index) [with int StoreMode = 16; int LoadMode = 0; PacketType = Eigen::internal::eigen_packet_wrapper<__vector(2) long long int, 0>; DstEvaluatorTypeT = Eigen::internal::evaluator<Eigen::Block<Eigen::Matrix<int, 4, 1>, -1, -1, false> >; SrcEvaluatorTypeT = Eigen::internal::evaluator<Eigen::Matrix<int, 3, 1> >; Functor = Eigen::internal::assign_op<int, int>; int Version = 0]’ at /usr/include/eigen3/Eigen/src/Core/AssignEvaluator.h:675:116,
    inlined from ‘void Eigen::internal::generic_dense_assignment_kernel<DstEvaluatorTypeT, SrcEvaluatorTypeT, Functor, Version>::assignPacketByOuterInner(Eigen::Index, Eigen::Index) [with int StoreMode = 16; int LoadMode = 0; PacketType = Eigen::internal::eigen_packet_wrapper<__vector(2) long long int, 0>; DstEvaluatorTypeT = Eigen::internal::evaluator<Eigen::Block<Eigen::Matrix<int, 4, 1>, -1, -1, false> >; SrcEvaluatorTypeT = Eigen::internal::evaluator<Eigen::Matrix<int, 3, 1> >; Functor = Eigen::internal::assign_op<int, int>; int Version = 0]’ at /usr/include/eigen3/Eigen/src/Core/AssignEvaluator.h:689:48,
    inlined from ‘static void Eigen::internal::dense_assignment_loop<Kernel, 4, 0>::run(Kernel&) [with Kernel = Eigen::internal::generic_dense_assignment_kernel<Eigen::internal::evaluator<Eigen::Block<Eigen::Matrix<int, 4, 1>, -1, -1, false> >, Eigen::internal::evaluator<Eigen::Matrix<int, 3, 1> >, Eigen::internal::assign_op<int, int>, 0>]’ at /usr/include/eigen3/Eigen/src/Core/AssignEvaluator.h:572:86,
    inlined from ‘void Eigen::internal::call_dense_assignment_loop(DstXprType&, const SrcXprType&, const Functor&) [with DstXprType = Eigen::Block<Eigen::Matrix<int, 4, 1>, -1, -1, false>; SrcXprType = Eigen::Matrix<int, 3, 1>; Functor = assign_op<int, int>]’ at /usr/include/eigen3/Eigen/src/Core/AssignEvaluator.h:785:37,
    inlined from ‘static void Eigen::internal::Assignment<DstXprType, SrcXprType, Functor, Eigen::internal::Dense2Dense, Weak>::run(DstXprType&, const SrcXprType&, const Functor&) [with DstXprType = Eigen::Block<Eigen::Matrix<int, 4, 1>, -1, -1, false>; SrcXprType = Eigen::Matrix<int, 3, 1>; Functor = Eigen::internal::assign_op<int, int>; Weak = void]’ at /usr/include/eigen3/Eigen/src/Core/AssignEvaluator.h:954:31,
    inlined from ‘void Eigen::internal::call_assignment_no_alias(Dst&, const Src&, const Func&) [with Dst = Eigen::Block<Eigen::Matrix<int, 4, 1>, -1, -1, false>; Src = Eigen::Matrix<int, 3, 1>; Func = assign_op<int, int>]’ at /usr/include/eigen3/Eigen/src/Core/AssignEvaluator.h:890:49,
    inlined from ‘void Eigen::internal::call_assignment(Dst&, const Src&, const Func&, typename enable_if<(! evaluator_assume_aliasing<Src>::value), void*>::type) [with Dst = Eigen::Block<Eigen::Matrix<int, 4, 1>, -1, -1, false>; Src = Eigen::Matrix<int, 3, 1>; Func = assign_op<int, int>]’ at /usr/include/eigen3/Eigen/src/Core/AssignEvaluator.h:858:27,
    inlined from ‘void Eigen::internal::call_assignment(Dst&, const Src&) [with Dst = Eigen::Block<Eigen::Matrix<int, 4, 1>, -1, -1, false>; Src = Eigen::Matrix<int, 3, 1>]’ at /usr/include/eigen3/Eigen/src/Core/AssignEvaluator.h:836:18,
    inlined from ‘Derived& Eigen::MatrixBase<Derived>::operator=(const Eigen::DenseBase<OtherDerived>&) [with OtherDerived = Eigen::Matrix<int, 3, 1>; Derived = Eigen::Block<Eigen::Matrix<int, 4, 1>, -1, -1, false>]’ at /usr/include/eigen3/Eigen/src/Core/Assign.h:66:28,
    inlined from ‘Eigen::CommaInitializer<MatrixType>::CommaInitializer(XprType&, const Eigen::DenseBase<OtherDerived>&) [with OtherDerived = Eigen::Matrix<int, 3, 1>; XprType = Eigen::Matrix<int, 4, 1>]’ at /usr/include/eigen3/Eigen/src/Core/CommaInitializer.h:48:51,
    inlined from ‘Eigen::CommaInitializer<Derived> Eigen::DenseBase<Derived>::operator<<(const Eigen::DenseBase<OtherDerived>&) [with OtherDerived = Eigen::Matrix<int, 3, 1>; Derived = Eigen::Matrix<int, 4, 1>]’ at /usr/include/eigen3/Eigen/src/Core/CommaInitializer.h:159:72,
    inlined from ‘int pcl::VoxelGrid<PointT>::getCentroidIndexAt(const Eigen::Vector3i&) const [with PointT = pcl::PointXYZ]’ at /usr/include/pcl-1.14/pcl/filters/voxel_grid.h:369:45,
    inlined from ‘virtual bool autoware::euclidean_cluster::VoxelGridBasedEuclideanCluster::cluster(const sensor_msgs::msg::PointCloud2_<std::allocator<void> >::ConstSharedPtr&, tier4_perception_msgs::msg::DetectedObjectsWithFeature&)’ at /home/mfc/projects/autoware/src/universe/autoware_universe/perception/autoware_euclidean_cluster/lib/voxel_grid_based_euclidean_cluster.cpp:148:37:
/usr/lib/gcc/x86_64-linux-gnu/13/include/emmintrin.h:706:11: error: array subscript ‘const __m128i_u[0]’ is partly outside array bounds of ‘Eigen::Vector3i [1]’ {aka ‘Eigen::Matrix<int, 3, 1> [1]’} [-Werror=array-bounds=]
  706 |   return *__P;
      |           ^~~
```

### After

Compiles and passes the tests locally with jazzy.

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.
