### PR TITLE
fix(map_based_prediction): use explicit Eigen init

### DIFF
--- a/perception/autoware_map_based_prediction/src/predictor_vru.cpp
+++ b/perception/autoware_map_based_prediction/src/predictor_vru.cpp
@@ -49,7 +49,8 @@ std::optional<CrosswalkEdgePoints> isReachableCrosswalkEdgePoints(
 
   const auto & obj_pos = object.kinematics.pose_with_covariance.pose.position;
 
-  CrosswalkEdgePoints ret{p1, {}, {}, p2, {}, {}};
+  CrosswalkEdgePoints ret{p1, Eigen::Vector2d::Zero(), Eigen::Vector2d::Zero(),
+                          p2, Eigen::Vector2d::Zero(), Eigen::Vector2d::Zero()};
   auto distance_pedestrian_to_p1 = std::hypot(p1.x() - obj_pos.x, p1.y() - obj_pos.y);
   auto distance_pedestrian_to_p2 = std::hypot(p2.x() - obj_pos.x, p2.y() - obj_pos.y);
 


### PR DESCRIPTION
## Description

- Part of: https://github.com/autowarefoundation/autoware_universe/issues/11418

Replaced:
```cpp
CrosswalkEdgePoints ret{p1, {}, {}, p2, {}, {}};
```
with

```cpp
CrosswalkEdgePoints ret{
  p1,
  Eigen::Vector2d::Zero(),
  Eigen::Vector2d::Zero(),
  p2,
  Eigen::Vector2d::Zero(),
  Eigen::Vector2d::Zero()
};
```

This way,

- `Eigen::Vector2d::Zero()` explicitly initializes SIMD storage
- GCC no longer detects uninitialized moves
- No ABI change
- No behavior change
- Fully compatible with ROS Jazzy + GCC 13

## How was this PR tested?

### Before

```bash
In file included from /usr/include/eigen3/Eigen/Core:294,
                 from /usr/include/eigen3/Eigen/Geometry:11,
                 from /opt/ros/jazzy/include/lanelet2_core/primitives/BoundingBox.h:8,
                 from /opt/ros/jazzy/include/lanelet2_core/primitives/LineString.h:5,
                 from /opt/ros/jazzy/include/lanelet2_core/primitives/CompoundLineString.h:5,
                 from /opt/ros/jazzy/include/lanelet2_core/primitives/CompoundPolygon.h:2,
                 from /opt/ros/jazzy/include/lanelet2_core/primitives/Area.h:10,
                 from /opt/ros/jazzy/include/lanelet2_core/LaneletMap.h:6,
                 from /home/mfc/projects/autoware/src/universe/autoware_universe/perception/autoware_map_based_prediction/include/map_based_prediction/data_structure.hpp:30,
                 from /home/mfc/projects/autoware/src/universe/autoware_universe/perception/autoware_map_based_prediction/include/map_based_prediction/predictor_vru.hpp:18,
                 from /home/mfc/projects/autoware/src/universe/autoware_universe/perception/autoware_map_based_prediction/src/predictor_vru.cpp:15:
In constructor ‘Eigen::PlainObjectBase<Derived>::PlainObjectBase(Eigen::PlainObjectBase<Derived>&&) [with Derived = Eigen::Matrix<double, 2, 1>]’,
    inlined from ‘Eigen::Matrix<_Scalar, _Rows, _Cols, _Options, _MaxRows, _MaxCols>::Matrix(Eigen::Matrix<_Scalar, _Rows, _Cols, _Options, _MaxRows, _MaxCols>&&) [with _Scalar = double; int _Rows = 2; int _Cols = 1; int _Options = 0; int _MaxRows = 2; int _MaxCols = 1]’ at /usr/include/eigen3/Eigen/src/Core/Matrix.h:274:30,
    inlined from ‘autoware::map_based_prediction::CrosswalkEdgePoints::CrosswalkEdgePoints(autoware::map_based_prediction::CrosswalkEdgePoints&&)’ at /home/mfc/projects/autoware/src/universe/autoware_universe/perception/autoware_map_based_prediction/include/map_based_prediction/path_generator.hpp:57:8,
    inlined from ‘constexpr std::_Optional_payload_base<_Tp>::_Storage<_Up, <anonymous> >::_Storage(std::in_place_t, _Args&& ...) [with _Args = {autoware::map_based_prediction::CrosswalkEdgePoints}; _Up = autoware::map_based_prediction::CrosswalkEdgePoints; bool <anonymous> = true; _Tp = autoware::map_based_prediction::CrosswalkEdgePoints]’ at /usr/include/c++/13/optional:214:8,
    inlined from ‘constexpr std::_Optional_payload_base<_Tp>::_Optional_payload_base(std::in_place_t, _Args&& ...) [with _Args = {autoware::map_based_prediction::CrosswalkEdgePoints}; _Tp = autoware::map_based_prediction::CrosswalkEdgePoints]’ at /usr/include/c++/13/optional:126:4,
    inlined from ‘constexpr std::_Optional_payload<autoware::map_based_prediction::CrosswalkEdgePoints, true, false, false>::_Optional_payload(std::in_place_t, _Args&& ...) [with _Args = {autoware::map_based_prediction::CrosswalkEdgePoints}][inherited from std::_Optional_payload_base<autoware::map_based_prediction::CrosswalkEdgePoints>]’ at /usr/include/c++/13/optional:399:42,
    inlined from ‘constexpr std::_Optional_base<_Tp, <anonymous>, <anonymous> >::_Optional_base(std::in_place_t, _Args&& ...) [with _Args = {autoware::map_based_prediction::CrosswalkEdgePoints}; typename std::enable_if<is_constructible_v<_Tp, _Args ...>, bool>::type <anonymous> = false; _Tp = autoware::map_based_prediction::CrosswalkEdgePoints; bool <anonymous> = false; bool <anonymous> = false]’ at /usr/include/c++/13/optional:523:4,
    inlined from ‘constexpr std::optional<_Tp>::optional(_Up&&) [with _Up = autoware::map_based_prediction::CrosswalkEdgePoints; typename std::enable_if<__and_v<std::__not_<std::is_same<std::optional<_Tp>, typename std::remove_cv<typename std::remove_reference<_Up>::type>::type> >, std::__not_<std::is_same<std::in_place_t, typename std::remove_cv<typename std::remove_reference<_Up>::type>::type> >, std::is_constructible<_T1, _U1>, std::is_convertible<_Iter, _Iterator> >, bool>::type <anonymous> = true; _Tp = autoware::map_based_prediction::CrosswalkEdgePoints]’ at /usr/include/c++/13/optional:751:47,
    inlined from ‘std::optional<autoware::map_based_prediction::CrosswalkEdgePoints> autoware::map_based_prediction::{anonymous}::isReachableCrosswalkEdgePoints(const autoware_perception_msgs::msg::TrackedObject&, const Eigen::Vector2d&, const Eigen::Vector2d&, const lanelet::ConstLanelets&, const lanelet::ConstLanelets&)’ at /home/mfc/projects/autoware/src/universe/autoware_universe/perception/autoware_map_based_prediction/src/predictor_vru.cpp:117:10,
    inlined from ‘autoware_perception_msgs::msg::PredictedObject autoware::map_based_prediction::PredictorVru::getPredictedObjectAsCrosswalkUser(const autoware_perception_msgs::msg::TrackedObject&)’ at /home/mfc/projects/autoware/src/universe/autoware_universe/perception/autoware_map_based_prediction/src/predictor_vru.cpp:639:51:
/usr/include/eigen3/Eigen/src/Core/PlainObjectBase.h:496:9: error: ‘*(__m128d*)((char*)&ret + offsetof(autoware::map_based_prediction::CrosswalkEdgePoints, autoware::map_based_prediction::CrosswalkEdgePoints::front_right_point.Eigen::Matrix<double, 2, 1, 0, 2, 1>::<unnamed>.Eigen::PlainObjectBase<Eigen::Matrix<double, 2, 1, 0, 2, 1> >::<unnamed>.Eigen::MatrixBase<Eigen::Matrix<double, 2, 1, 0, 2, 1> >::<unnamed>.Eigen::DenseBase<Eigen::Matrix<double, 2, 1, 0, 2, 1> >::<unnamed>.Eigen::DenseCoeffsBase<Eigen::Matrix<double, 2, 1, 0, 2, 1>, 3>::<unnamed>.Eigen::DenseCoeffsBase<Eigen::Matrix<double, 2, 1, 0, 2, 1>, 1>::<unnamed>.Eigen::DenseCoeffsBase<Eigen::Matrix<double, 2, 1, 0, 2, 1>, 0>::<unnamed>))’ may be used uninitialized [-Werror=maybe-uninitialized]
  496 |       : m_storage( std::move(other.m_storage) )
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

### After

Compiles and passes the tests locally with jazzy.

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.
