### PR TITLE
fix(tensorrt_bevformer): initialize Eigen::Translation3d

### DIFF
--- a/perception/autoware_tensorrt_bevformer/src/bevformer_node.cpp
+++ b/perception/autoware_tensorrt_bevformer/src/bevformer_node.cpp
@@ -412,7 +412,7 @@ void TRTBEVFormerNode::calculateSensor2LidarTransformsFromTF(
 
     // Get ego2global at camera timestamp
     Eigen::Quaterniond ego2global_rot_cam;
-    Eigen::Translation3d ego2global_trans_cam;
+    Eigen::Translation3d ego2global_trans_cam = Eigen::Translation3d::Identity();
     bool got_camera_transform = false;
     try {
       if (tf_buffer_->canTransform(


### PR DESCRIPTION
## Description

- Part of: https://github.com/autowarefoundation/autoware_universe/issues/11418

Initialized the maybe uninitialized `Eigen::Translation3d ego2global_trans_cam` with `Eigen::Translation3d::Identity();`

## How was this PR tested?

### Before

```bash
...
    inlined from ‘void autoware::tensorrt_bevformer::TRTBEVFormerNode::calculateSensor2LidarTransformsFromTF(const std::vector<std::shared_ptr<const sensor_msgs::msg::Image_<std::allocator<void> > > >&, const Eigen::Quaterniond&, const Eigen::Translation3d&)’ at /home/mfc/projects/autoware/src/universe/autoware_universe/perception/autoware_tensorrt_bevformer/src/bevformer_node.cpp:452:84:
/usr/include/eigen3/Eigen/src/Core/functors/BinaryFunctors.h:42:124: error: ‘ego2global_trans_cam.Eigen::Translation<double, 3>::m_coeffs.Eigen::Matrix<double, 3, 1, 0, 3, 1>::<unnamed>.Eigen::PlainObjectBase<Eigen::Matrix<double, 3, 1, 0, 3, 1> >::m_storage.Eigen::DenseStorage<double, 3, 3, 1, 0>::m_data.Eigen::internal::plain_array<double, 3, 0, 0>::array[2]’ may be used uninitialized [-Werror=maybe-uninitialized]
   42 |   EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE result_type operator() (const LhsScalar& a, const RhsScalar& b) const { return a + b; }
      |                                                                                                                            ^
/home/mfc/projects/autoware/src/universe/autoware_universe/perception/autoware_tensorrt_bevformer/src/bevformer_node.cpp: In member function ‘void autoware::tensorrt_bevformer::TRTBEVFormerNode::calculateSensor2LidarTransformsFromTF(const std::vector<std::shared_ptr<const sensor_msgs::msg::Image_<std::allocator<void> > > >&, const Eigen::Quaterniond&, const Eigen::Translation3d&)’:
/home/mfc/projects/autoware/src/universe/autoware_universe/perception/autoware_tensorrt_bevformer/src/bevformer_node.cpp:415:26: note: ‘ego2global_trans_cam.Eigen::Translation<double, 3>::m_coeffs.Eigen::Matrix<double, 3, 1, 0, 3, 1>::<unnamed>.Eigen::PlainObjectBase<Eigen::Matrix<double, 3, 1, 0, 3, 1> >::m_storage.Eigen::DenseStorage<double, 3, 3, 1, 0>::m_data.Eigen::internal::plain_array<double, 3, 0, 0>::array[2]’ was declared here
  415 |     Eigen::Translation3d ego2global_trans_cam;
      |                          ^~~~~~~~~~~~~~~~~~~~
cc1plus: all warnings being treated as errors
gmake[2]: *** [CMakeFiles/autoware_tensorrt_bevformer.dir/build.make:76: CMakeFiles/autoware_tensorrt_bevformer.dir/src/bevformer_node.cpp.o] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:167: CMakeFiles/autoware_tensorrt_bevformer.dir/all] Error 2
gmake: *** [Makefile:146: all] Error 2
---
--- stderr: autoware_tensorrt_bevformer
In file included from /usr/include/eigen3/Eigen/Geometry:42,
                 from /home/mfc/projects/autoware/src/universe/autoware_universe/perception/autoware_tensorrt_bevformer/src/bevformer_data_manager.hpp:37,
                 from /home/mfc/projects/autoware/src/universe/autoware_universe/perception/autoware_tensorrt_bevformer/src/bevformer_node.hpp:37,
                 from /home/mfc/projects/autoware/src/universe/autoware_universe/perception/autoware_tensorrt_bevformer/src/bevformer_node.cpp:33:
In member function ‘Eigen::QuaternionBase<Derived>::Matrix3 Eigen::QuaternionBase<Derived>::toRotationMatrix() const [with Derived = Eigen::Quaternion<double>]’,
    inlined from ‘void autoware::tensorrt_bevformer::TRTBEVFormerNode::calculateSensor2LidarTransformsFromTF(const std::vector<std::shared_ptr<const sensor_msgs::msg::Image_<std::allocator<void> > > >&, const Eigen::Quaterniond&, const Eigen::Translation3d&)’ at /home/mfc/projects/autoware/src/universe/autoware_universe/perception/autoware_tensorrt_bevformer/src/bevformer_node.cpp:439:71:
/usr/include/eigen3/Eigen/src/Geometry/Quaternion.h:608:16: error: ‘*(const double*)((char*)&ego2global_rot_cam + offsetof(Eigen::Quaterniond, Eigen::Quaternion<double, 0>::<unnamed>.Eigen::QuaternionBase<Eigen::Quaternion<double, 0> >::<unnamed>))’ may be used uninitialized [-Werror=maybe-uninitialized]
  608 |   const Scalar txz = tz*this->x();
      |                ^~~
/home/mfc/projects/autoware/src/universe/autoware_universe/perception/autoware_tensorrt_bevformer/src/bevformer_node.cpp: In member function ‘void autoware::tensorrt_bevformer::TRTBEVFormerNode::calculateSensor2LidarTransformsFromTF(const std::vector<std::shared_ptr<const sensor_msgs::msg::Image_<std::allocator<void> > > >&, const Eigen::Quaterniond&, const Eigen::Translation3d&)’:
/home/mfc/projects/autoware/src/universe/autoware_universe/perception/autoware_tensorrt_bevformer/src/bevformer_node.cpp:414:24: note: ‘*(const double*)((char*)&ego2global_rot_cam + offsetof(Eigen::Quaterniond, Eigen::Quaternion<double, 0>::<unnamed>.Eigen::QuaternionBase<Eigen::Quaternion<double, 0> >::<unnamed>))’ was declared here
  414 |     Eigen::Quaterniond ego2global_rot_cam;
      |                        ^~~~~~~~~~~~~~~~~~
In member function ‘Eigen::QuaternionBase<Derived>::Matrix3 Eigen::QuaternionBase<Derived>::toRotationMatrix() const [with Derived = Eigen::Quaternion<double>]’,
    inlined from ‘void autoware::tensorrt_bevformer::TRTBEVFormerNode::calculateSensor2LidarTransformsFromTF(const std::vector<std::shared_ptr<const sensor_msgs::msg::Image_<std::allocator<void> > > >&, const Eigen::Quaterniond&, const Eigen::Translation3d&)’ at /home/mfc/projects/autoware/src/universe/autoware_universe/perception/autoware_tensorrt_bevformer/src/bevformer_node.cpp:439:71:
/usr/include/eigen3/Eigen/src/Geometry/Quaternion.h:610:16: error: ‘*(double*)((char*)&ego2global_rot_cam + offsetof(Eigen::Quaterniond, Eigen::Quaternion<double, 0>::m_coeffs.Eigen::Matrix<double, 4, 1, 0, 4, 1>::<unnamed>.Eigen::PlainObjectBase<Eigen::Matrix<double, 4, 1, 0, 4, 1> >::m_storage.Eigen::DenseStorage<double, 4, 4, 1, 0>::m_data.Eigen::internal::plain_array<double, 4, 0, 16>::array[1]))’ may be used uninitialized [-Werror=maybe-uninitialized]
  610 |   const Scalar tyz = tz*this->y();
      |                ^~~
/home/mfc/projects/autoware/src/universe/autoware_universe/perception/autoware_tensorrt_bevformer/src/bevformer_node.cpp: In member function ‘void autoware::tensorrt_bevformer::TRTBEVFormerNode::calculateSensor2LidarTransformsFromTF(const std::vector<std::shared_ptr<const sensor_msgs::msg::Image_<std::allocator<void> > > >&, const Eigen::Quaterniond&, const Eigen::Translation3d&)’:
/home/mfc/projects/autoware/src/universe/autoware_universe/perception/autoware_tensorrt_bevformer/src/bevformer_node.cpp:414:24: note: ‘*(double*)((char*)&ego2global_rot_cam + offsetof(Eigen::Quaterniond, Eigen::Quaternion<double, 0>::m_coeffs.Eigen::Matrix<double, 4, 1, 0, 4, 1>::<unnamed>.Eigen::PlainObjectBase<Eigen::Matrix<double, 4, 1, 0, 4, 1> >::m_storage.Eigen::DenseStorage<double, 4, 4, 1, 0>::m_data.Eigen::internal::plain_array<double, 4, 0, 16>::array[1]))’ was declared here
  414 |     Eigen::Quaterniond ego2global_rot_cam;
      |                        ^~~~~~~~~~~~~~~~~~
In member function ‘Eigen::QuaternionBase<Derived>::Matrix3 Eigen::QuaternionBase<Derived>::toRotationMatrix() const [with Derived = Eigen::Quaternion<double>]’,
    inlined from ‘void autoware::tensorrt_bevformer::TRTBEVFormerNode::calculateSensor2LidarTransformsFromTF(const std::vector<std::shared_ptr<const sensor_msgs::msg::Image_<std::allocator<void> > > >&, const Eigen::Quaterniond&, const Eigen::Translation3d&)’ at /home/mfc/projects/autoware/src/universe/autoware_universe/perception/autoware_tensorrt_bevformer/src/bevformer_node.cpp:439:71:
/usr/include/eigen3/Eigen/src/Geometry/Quaternion.h:611:16: error: ‘ego2global_rot_cam.Eigen::Quaternion<double, 0>::m_coeffs.Eigen::Matrix<double, 4, 1, 0, 4, 1>::<unnamed>.Eigen::PlainObjectBase<Eigen::Matrix<double, 4, 1, 0, 4, 1> >::m_storage.Eigen::DenseStorage<double, 4, 4, 1, 0>::m_data.Eigen::internal::plain_array<double, 4, 0, 16>::array[2]’ may be used uninitialized [-Werror=maybe-uninitialized]
  611 |   const Scalar tzz = tz*this->z();
      |                ^~~
/home/mfc/projects/autoware/src/universe/autoware_universe/perception/autoware_tensorrt_bevformer/src/bevformer_node.cpp: In member function ‘void autoware::tensorrt_bevformer::TRTBEVFormerNode::calculateSensor2LidarTransformsFromTF(const std::vector<std::shared_ptr<const sensor_msgs::msg::Image_<std::allocator<void> > > >&, const Eigen::Quaterniond&, const Eigen::Translation3d&)’:
/home/mfc/projects/autoware/src/universe/autoware_universe/perception/autoware_tensorrt_bevformer/src/bevformer_node.cpp:414:24: note: ‘ego2global_rot_cam.Eigen::Quaternion<double, 0>::m_coeffs.Eigen::Matrix<double, 4, 1, 0, 4, 1>::<unnamed>.Eigen::PlainObjectBase<Eigen::Matrix<double, 4, 1, 0, 4, 1> >::m_storage.Eigen::DenseStorage<double, 4, 4, 1, 0>::m_data.Eigen::internal::plain_array<double, 4, 0, 16>::array[2]’ was declared here
  414 |     Eigen::Quaterniond ego2global_rot_cam;
      |                        ^~~~~~~~~~~~~~~~~~
In member function ‘Eigen::QuaternionBase<Derived>::Matrix3 Eigen::QuaternionBase<Derived>::toRotationMatrix() const [with Derived = Eigen::Quaternion<double>]’,
    inlined from ‘void autoware::tensorrt_bevformer::TRTBEVFormerNode::calculateSensor2LidarTransformsFromTF(const std::vector<std::shared_ptr<const sensor_msgs::msg::Image_<std::allocator<void> > > >&, const Eigen::Quaterniond&, const Eigen::Translation3d&)’ at /home/mfc/projects/autoware/src/universe/autoware_universe/perception/autoware_tensorrt_bevformer/src/bevformer_node.cpp:439:71:
/usr/include/eigen3/Eigen/src/Geometry/Quaternion.h:605:16: error: ‘*(double*)((char*)&ego2global_rot_cam + offsetof(Eigen::Quaterniond, Eigen::Quaternion<double, 0>::m_coeffs.Eigen::Matrix<double, 4, 1, 0, 4, 1>::<unnamed>.Eigen::PlainObjectBase<Eigen::Matrix<double, 4, 1, 0, 4, 1> >::m_storage.Eigen::DenseStorage<double, 4, 4, 1, 0>::m_data.Eigen::internal::plain_array<double, 4, 0, 16>::array[3]))’ may be used uninitialized [-Werror=maybe-uninitialized]
  605 |   const Scalar twz = tz*this->w();
      |                ^~~
/home/mfc/projects/autoware/src/universe/autoware_universe/perception/autoware_tensorrt_bevformer/src/bevformer_node.cpp: In member function ‘void autoware::tensorrt_bevformer::TRTBEVFormerNode::calculateSensor2LidarTransformsFromTF(const std::vector<std::shared_ptr<const sensor_msgs::msg::Image_<std::allocator<void> > > >&, const Eigen::Quaterniond&, const Eigen::Translation3d&)’:
/home/mfc/projects/autoware/src/universe/autoware_universe/perception/autoware_tensorrt_bevformer/src/bevformer_node.cpp:414:24: note: ‘*(double*)((char*)&ego2global_rot_cam + offsetof(Eigen::Quaterniond, Eigen::Quaternion<double, 0>::m_coeffs.Eigen::Matrix<double, 4, 1, 0, 4, 1>::<unnamed>.Eigen::PlainObjectBase<Eigen::Matrix<double, 4, 1, 0, 4, 1> >::m_storage.Eigen::DenseStorage<double, 4, 4, 1, 0>::m_data.Eigen::internal::plain_array<double, 4, 0, 16>::array[3]))’ was declared here
  414 |     Eigen::Quaterniond ego2global_rot_cam;
      |                        ^~~~~~~~~~~~~~~~~~
In file included from /usr/include/eigen3/Eigen/Core:253,
                 from /home/mfc/projects/autoware/src/universe/autoware_universe/perception/autoware_tensorrt_bevformer/src/bevformer_data_manager.hpp:36:
In member function ‘Eigen::internal::scalar_sum_op<LhsScalar, RhsScalar>::result_type Eigen::internal::scalar_sum_op<LhsScalar, RhsScalar>::operator()(const LhsScalar&, const RhsScalar&) const [with LhsScalar = double; RhsScalar = double]’,
    inlined from ‘Eigen::internal::binary_evaluator<Eigen::CwiseBinaryOp<BinaryOp, Lhs, Rhs>, Eigen::internal::IndexBased, Eigen::internal::IndexBased>::CoeffReturnType Eigen::internal::binary_evaluator<Eigen::CwiseBinaryOp<BinaryOp, Lhs, Rhs>, Eigen::internal::IndexBased, Eigen::internal::IndexBased>::coeff(Eigen::Index, Eigen::Index) const [with BinaryOp = Eigen::internal::scalar_sum_op<double, double>; Lhs = const Eigen::Product<Eigen::Matrix<double, 1, 3>, Eigen::Transpose<Eigen::Matrix<double, 3, 3> >, 0>; Rhs = const Eigen::Matrix<double, 1, 3>]’ at /usr/include/eigen3/Eigen/src/Core/CoreEvaluators.h:769:22,
    inlined from ‘void Eigen::internal::generic_dense_assignment_kernel<DstEvaluatorTypeT, SrcEvaluatorTypeT, Functor, Version>::assignCoeff(Eigen::Index, Eigen::Index) [with DstEvaluatorTypeT = Eigen::internal::evaluator<Eigen::Matrix<double, 1, 3> >; SrcEvaluatorTypeT = Eigen::internal::evaluator<Eigen::CwiseBinaryOp<Eigen::internal::scalar_sum_op<double, double>, const Eigen::Product<Eigen::Matrix<double, 1, 3>, Eigen::Transpose<Eigen::Matrix<double, 3, 3> >, 0>, const Eigen::Matrix<double, 1, 3> > >; Functor = Eigen::internal::assign_op<double, double>; int Version = 0]’ at /usr/include/eigen3/Eigen/src/Core/AssignEvaluator.h:654:63,
    inlined from ‘void Eigen::internal::generic_dense_assignment_kernel<DstEvaluatorTypeT, SrcEvaluatorTypeT, Functor, Version>::assignCoeffByOuterInner(Eigen::Index, Eigen::Index) [with DstEvaluatorTypeT = Eigen::internal::evaluator<Eigen::Matrix<double, 1, 3> >; SrcEvaluatorTypeT = Eigen::internal::evaluator<Eigen::CwiseBinaryOp<Eigen::internal::scalar_sum_op<double, double>, const Eigen::Product<Eigen::Matrix<double, 1, 3>, Eigen::Transpose<Eigen::Matrix<double, 3, 3> >, 0>, const Eigen::Matrix<double, 1, 3> > >; Functor = Eigen::internal::assign_op<double, double>; int Version = 0]’ at /usr/include/eigen3/Eigen/src/Core/AssignEvaluator.h:668:16,
    inlined from ‘static void Eigen::internal::copy_using_evaluator_DefaultTraversal_CompleteUnrolling<Kernel, Index, Stop>::run(Kernel&) [with Kernel = Eigen::internal::generic_dense_assignment_kernel<Eigen::internal::evaluator<Eigen::Matrix<double, 1, 3> >, Eigen::internal::evaluator<Eigen::CwiseBinaryOp<Eigen::internal::scalar_sum_op<double, double>, const Eigen::Product<Eigen::Matrix<double, 1, 3>, Eigen::Transpose<Eigen::Matrix<double, 3, 3> >, 0>, const Eigen::Matrix<double, 1, 3> > >, Eigen::internal::assign_op<double, double>, 0>; int Index = 2; int Stop = 3]’ at /usr/include/eigen3/Eigen/src/Core/AssignEvaluator.h:211:35,
    inlined from ‘static void Eigen::internal::dense_assignment_loop<Kernel, 3, 2>::run(Kernel&) [with Kernel = Eigen::internal::generic_dense_assignment_kernel<Eigen::internal::evaluator<Eigen::Matrix<double, 1, 3> >, Eigen::internal::evaluator<Eigen::CwiseBinaryOp<Eigen::internal::scalar_sum_op<double, double>, const Eigen::Product<Eigen::Matrix<double, 1, 3>, Eigen::Transpose<Eigen::Matrix<double, 3, 3> >, 0>, const Eigen::Matrix<double, 1, 3> > >, Eigen::internal::assign_op<double, double>, 0>]’ at /usr/include/eigen3/Eigen/src/Core/AssignEvaluator.h:456:92,
    inlined from ‘void Eigen::internal::call_dense_assignment_loop(DstXprType&, const SrcXprType&, const Functor&) [with DstXprType = Eigen::Matrix<double, 1, 3>; SrcXprType = Eigen::CwiseBinaryOp<scalar_sum_op<double, double>, const Eigen::Product<Eigen::Matrix<double, 1, 3>, Eigen::Transpose<Eigen::Matrix<double, 3, 3> >, 0>, const Eigen::Matrix<double, 1, 3> >; Functor = assign_op<double, double>]’ at /usr/include/eigen3/Eigen/src/Core/AssignEvaluator.h:785:37,
    inlined from ‘static void Eigen::internal::Assignment<DstXprType, SrcXprType, Functor, Eigen::internal::Dense2Dense, Weak>::run(DstXprType&, const SrcXprType&, const Functor&) [with DstXprType = Eigen::Matrix<double, 1, 3>; SrcXprType = Eigen::CwiseBinaryOp<Eigen::internal::scalar_sum_op<double, double>, const Eigen::Product<Eigen::Matrix<double, 1, 3>, Eigen::Transpose<Eigen::Matrix<double, 3, 3> >, 0>, const Eigen::Matrix<double, 1, 3> >; Functor = Eigen::internal::assign_op<double, double>; Weak = void]’ at /usr/include/eigen3/Eigen/src/Core/AssignEvaluator.h:954:31,
    inlined from ‘void Eigen::internal::call_assignment_no_alias(Dst&, const Src&, const Func&) [with Dst = Eigen::Matrix<double, 1, 3>; Src = Eigen::CwiseBinaryOp<scalar_sum_op<double, double>, const Eigen::Product<Eigen::Matrix<double, 1, 3>, Eigen::Transpose<Eigen::Matrix<double, 3, 3> >, 0>, const Eigen::Matrix<double, 1, 3> >; Func = assign_op<double, double>]’ at /usr/include/eigen3/Eigen/src/Core/AssignEvaluator.h:890:49,
    inlined from ‘Derived& Eigen::PlainObjectBase<Derived>::_set_noalias(const Eigen::DenseBase<OtherDerived>&) [with OtherDerived = Eigen::CwiseBinaryOp<Eigen::internal::scalar_sum_op<double, double>, const Eigen::Product<Eigen::Matrix<double, 1, 3>, Eigen::Transpose<Eigen::Matrix<double, 3, 3> >, 0>, const Eigen::Matrix<double, 1, 3> >; Derived = Eigen::Matrix<double, 1, 3>]’ at /usr/include/eigen3/Eigen/src/Core/PlainObjectBase.h:797:41,
    inlined from ‘void Eigen::PlainObjectBase<Derived>::_init1(const Eigen::DenseBase<ElseDerived>&) [with T = Eigen::CwiseBinaryOp<Eigen::internal::scalar_sum_op<double, double>, const Eigen::Product<Eigen::Matrix<double, 1, 3>, Eigen::Transpose<Eigen::Matrix<double, 3, 3> >, 0>, const Eigen::Matrix<double, 1, 3> >; OtherDerived = Eigen::CwiseBinaryOp<Eigen::internal::scalar_sum_op<double, double>, const Eigen::Product<Eigen::Matrix<double, 1, 3>, Eigen::Transpose<Eigen::Matrix<double, 3, 3> >, 0>, const Eigen::Matrix<double, 1, 3> >; Derived = Eigen::Matrix<double, 1, 3>]’ at /usr/include/eigen3/Eigen/src/Core/PlainObjectBase.h:883:25,
    inlined from ‘Eigen::Matrix<_Scalar, _Rows, _Cols, _Options, _MaxRows, _MaxCols>::Matrix(const T&) [with T = Eigen::CwiseBinaryOp<Eigen::internal::scalar_sum_op<double, double>, const Eigen::Product<Eigen::Matrix<double, 1, 3>, Eigen::Transpose<Eigen::Matrix<double, 3, 3> >, 0>, const Eigen::Matrix<double, 1, 3> >; _Scalar = double; int _Rows = 1; int _Cols = 3; int _Options = 1; int _MaxRows = 1; int _MaxCols = 3]’ at /usr/include/eigen3/Eigen/src/Core/Matrix.h:332:31,
    inlined from ‘Eigen::internal::product_evaluator<Eigen::Product<Lhs, Rhs, 1>, ProductTag, Eigen::DenseShape, Eigen::DenseShape>::product_evaluator(const XprType&) [with Lhs = Eigen::CwiseBinaryOp<Eigen::internal::scalar_sum_op<double, double>, const Eigen::Product<Eigen::Matrix<double, 1, 3>, Eigen::Transpose<Eigen::Matrix<double, 3, 3> >, 0>, const Eigen::Matrix<double, 1, 3> >; Rhs = Eigen::Matrix<double, 3, 3>; int ProductTag = 3]’ at /usr/include/eigen3/Eigen/src/Core/ProductEvaluators.h:500:7,
    inlined from ‘Eigen::internal::evaluator<Eigen::Product<Lhs, Rhs, Option> >::evaluator(const XprType&) [with Lhs = Eigen::CwiseBinaryOp<Eigen::internal::scalar_sum_op<double, double>, const Eigen::Product<Eigen::Matrix<double, 1, 3>, Eigen::Transpose<Eigen::Matrix<double, 3, 3> >, 0>, const Eigen::Matrix<double, 1, 3> >; Rhs = Eigen::Matrix<double, 3, 3>; int Options = 1]’ at /usr/include/eigen3/Eigen/src/Core/ProductEvaluators.h:35:90,
    inlined from ‘void Eigen::internal::call_dense_assignment_loop(DstXprType&, const SrcXprType&, const Functor&) [with DstXprType = Eigen::Matrix<double, 1, 3>; SrcXprType = Eigen::Product<Eigen::CwiseBinaryOp<scalar_sum_op<double, double>, const Eigen::Product<Eigen::Matrix<double, 1, 3>, Eigen::Transpose<Eigen::Matrix<double, 3, 3> >, 0>, const Eigen::Matrix<double, 1, 3> >, Eigen::Matrix<double, 3, 3>, 1>; Functor = assign_op<double, double>]’ at /usr/include/eigen3/Eigen/src/Core/AssignEvaluator.h:774:20,
    inlined from ‘static void Eigen::internal::Assignment<DstXprType, SrcXprType, Functor, Eigen::internal::Dense2Dense, Weak>::run(DstXprType&, const SrcXprType&, const Functor&) [with DstXprType = Eigen::Matrix<double, 1, 3>; SrcXprType = Eigen::Product<Eigen::CwiseBinaryOp<Eigen::internal::scalar_sum_op<double, double>, const Eigen::Product<Eigen::Matrix<double, 1, 3>, Eigen::Transpose<Eigen::Matrix<double, 3, 3> >, 0>, const Eigen::Matrix<double, 1, 3> >, Eigen::Matrix<double, 3, 3>, 1>; Functor = Eigen::internal::assign_op<double, double>; Weak = void]’ at /usr/include/eigen3/Eigen/src/Core/AssignEvaluator.h:954:31,
    inlined from ‘void Eigen::internal::call_assignment_no_alias(Dst&, const Src&, const Func&) [with Dst = Eigen::Matrix<double, 1, 3>; Src = Eigen::Product<Eigen::CwiseBinaryOp<scalar_sum_op<double, double>, const Eigen::Product<Eigen::Matrix<double, 1, 3>, Eigen::Transpose<Eigen::Matrix<double, 3, 3> >, 0>, const Eigen::Matrix<double, 1, 3> >, Eigen::Matrix<double, 3, 3>, 1>; Func = assign_op<double, double>]’ at /usr/include/eigen3/Eigen/src/Core/AssignEvaluator.h:890:49,
    inlined from ‘static void Eigen::internal::generic_product_impl<Lhs, Rhs, Eigen::DenseShape, Eigen::DenseShape, 3>::evalTo(Dst&, const Lhs&, const Rhs&) [with Dst = Eigen::Matrix<double, 1, 3>; Lhs = Eigen::CwiseBinaryOp<Eigen::internal::scalar_sum_op<double, double>, const Eigen::Product<Eigen::Matrix<double, 1, 3>, Eigen::Transpose<Eigen::Matrix<double, 3, 3> >, 0>, const Eigen::Matrix<double, 1, 3> >; Rhs = Eigen::Matrix<double, 3, 3>]’ at /usr/include/eigen3/Eigen/src/Core/ProductEvaluators.h:402:29,
    inlined from ‘static void Eigen::internal::Assignment<DstXprType, Eigen::Product<Lhs, Rhs, Options>, Eigen::internal::assign_op<Scalar, Scalar>, Eigen::internal::Dense2Dense, typename Eigen::internal::enable_if<((Options == Eigen::DefaultProduct) || (Options == Eigen::AliasFreeProduct))>::type>::run(DstXprType&, const SrcXprType&, const Eigen::internal::assign_op<Scalar, Scalar>&) [with DstXprType = Eigen::Matrix<double, 1, 3>; Lhs = Eigen::CwiseBinaryOp<Eigen::internal::scalar_sum_op<double, double>, const Eigen::Product<Eigen::Matrix<double, 1, 3>, Eigen::Transpose<Eigen::Matrix<double, 3, 3> >, 0>, const Eigen::Matrix<double, 1, 3> >; Rhs = Eigen::Matrix<double, 3, 3>; int Options = 0; Scalar = double]’ at /usr/include/eigen3/Eigen/src/Core/ProductEvaluators.h:148:43,
    inlined from ‘void Eigen::internal::call_assignment_no_alias(Dst&, const Src&, const Func&) [with Dst = Eigen::Matrix<double, 1, 3>; Src = Eigen::Product<Eigen::CwiseBinaryOp<scalar_sum_op<double, double>, const Eigen::Product<Eigen::Matrix<double, 1, 3>, Eigen::Transpose<Eigen::Matrix<double, 3, 3> >, 0>, const Eigen::Matrix<double, 1, 3> >, Eigen::Matrix<double, 3, 3>, 0>; Func = assign_op<double, double>]’ at /usr/include/eigen3/Eigen/src/Core/AssignEvaluator.h:890:49,
    inlined from ‘Derived& Eigen::PlainObjectBase<Derived>::_set_noalias(const Eigen::DenseBase<OtherDerived>&) [with OtherDerived = Eigen::Product<Eigen::CwiseBinaryOp<Eigen::internal::scalar_sum_op<double, double>, const Eigen::Product<Eigen::Matrix<double, 1, 3>, Eigen::Transpose<Eigen::Matrix<double, 3, 3> >, 0>, const Eigen::Matrix<double, 1, 3> >, Eigen::Matrix<double, 3, 3>, 0>; Derived = Eigen::Matrix<double, 1, 3>]’ at /usr/include/eigen3/Eigen/src/Core/PlainObjectBase.h:797:41,
    inlined from ‘Eigen::PlainObjectBase<Derived>::PlainObjectBase(const Eigen::DenseBase<OtherDerived>&) [with OtherDerived = Eigen::Product<Eigen::CwiseBinaryOp<Eigen::internal::scalar_sum_op<double, double>, const Eigen::Product<Eigen::Matrix<double, 1, 3>, Eigen::Transpose<Eigen::Matrix<double, 3, 3> >, 0>, const Eigen::Matrix<double, 1, 3> >, Eigen::Matrix<double, 3, 3>, 0>; Derived = Eigen::Matrix<double, 1, 3>]’ at /usr/include/eigen3/Eigen/src/Core/PlainObjectBase.h:594:19,
    inlined from ‘Eigen::Matrix<_Scalar, _Rows, _Cols, _Options, _MaxRows, _MaxCols>::Matrix(const Eigen::EigenBase<OtherDerived>&) [with OtherDerived = Eigen::Product<Eigen::CwiseBinaryOp<Eigen::internal::scalar_sum_op<double, double>, const Eigen::Product<Eigen::Matrix<double, 1, 3>, Eigen::Transpose<Eigen::Matrix<double, 3, 3> >, 0>, const Eigen::Matrix<double, 1, 3> >, Eigen::Matrix<double, 3, 3>, 0>; _Scalar = double; int _Rows = 1; int _Cols = 3; int _Options = 1; int _MaxRows = 1; int _MaxCols = 3]’ at /usr/include/eigen3/Eigen/src/Core/Matrix.h:423:29,
    inlined from ‘void autoware::tensorrt_bevformer::TRTBEVFormerNode::calculateSensor2LidarTransformsFromTF(const std::vector<std::shared_ptr<const sensor_msgs::msg::Image_<std::allocator<void> > > >&, const Eigen::Quaterniond&, const Eigen::Translation3d&)’ at /home/mfc/projects/autoware/src/universe/autoware_universe/perception/autoware_tensorrt_bevformer/src/bevformer_node.cpp:452:84:
/usr/include/eigen3/Eigen/src/Core/functors/BinaryFunctors.h:42:124: error: ‘ego2global_trans_cam.Eigen::Translation<double, 3>::m_coeffs.Eigen::Matrix<double, 3, 1, 0, 3, 1>::<unnamed>.Eigen::PlainObjectBase<Eigen::Matrix<double, 3, 1, 0, 3, 1> >::m_storage.Eigen::DenseStorage<double, 3, 3, 1, 0>::m_data.Eigen::internal::plain_array<double, 3, 0, 0>::array[2]’ may be used uninitialized [-Werror=maybe-uninitialized]
   42 |   EIGEN_DEVICE_FUNC EIGEN_STRONG_INLINE result_type operator() (const LhsScalar& a, const RhsScalar& b) const { return a + b; }
      |                                                                                                                            ^
```

### After

Compiles and passes the tests locally with jazzy.

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.
