### PR TITLE
fix(image_projection_based_fusion): add conditional include for jazzy

### DIFF
--- a/perception/autoware_image_projection_based_fusion/include/autoware/image_projection_based_fusion/camera_projection.hpp
+++ b/perception/autoware_image_projection_based_fusion/include/autoware/image_projection_based_fusion/camera_projection.hpp
@@ -22,7 +22,11 @@
 
 #include <sensor_msgs/msg/camera_info.hpp>
 
-#include <image_geometry/pinhole_camera_model.h>
+#if __has_include(<image_geometry/pinhole_camera_model.hpp>)
+#include <image_geometry/pinhole_camera_model.hpp>  // for ROS 2 Jazzy or newer
+#else
+#include <image_geometry/pinhole_camera_model.h>  // for ROS 2 Humble or older
+#endif
 
 #include <memory>
 

--- a/perception/autoware_image_projection_based_fusion/include/autoware/image_projection_based_fusion/utils/utils.hpp
+++ b/perception/autoware_image_projection_based_fusion/include/autoware/image_projection_based_fusion/utils/utils.hpp
@@ -43,7 +43,11 @@
 #include "tier4_perception_msgs/msg/detected_object_with_feature.hpp"
 #include <sensor_msgs/msg/camera_info.hpp>
 
-#include <image_geometry/pinhole_camera_model.h>
+#if __has_include(<image_geometry/pinhole_camera_model.hpp>)
+#include <image_geometry/pinhole_camera_model.hpp>  // for ROS 2 Jazzy or newer
+#else
+#include <image_geometry/pinhole_camera_model.h>  // for ROS 2 Humble or older
+#endif
 #include <pcl/point_cloud.h>
 #include <pcl/point_types.h>
 #include <pcl_conversions/pcl_conversions.h>


### PR DESCRIPTION
## Description

- Part of: https://github.com/autowarefoundation/autoware_universe/issues/11418
- Similar to: https://github.com/autowarefoundation/autoware_universe/pull/7603

## How was this PR tested?

### Before

```bash
gmake[2]: *** [CMakeFiles/autoware_image_projection_based_fusion.dir/build.make:90: CMakeFiles/autoware_image_projection_based_fusion.dir/src/fusion_collector.cpp.o] Error 1
In file included from /home/mfc/projects/autoware/src/universe/autoware_universe/perception/autoware_image_projection_based_fusion/include/autoware/image_projection_based_fusion/fusion_collector.hpp:17,
                 from /home/mfc/projects/autoware/src/universe/autoware_universe/perception/autoware_image_projection_based_fusion/include/autoware/image_projection_based_fusion/fusion_node.hpp:17,
                 from /home/mfc/projects/autoware/src/universe/autoware_universe/perception/autoware_image_projection_based_fusion/include/autoware/image_projection_based_fusion/utils/utils.hpp:35,
                 from /home/mfc/projects/autoware/src/universe/autoware_universe/perception/autoware_image_projection_based_fusion/src/utils/utils.cpp:15:
/home/mfc/projects/autoware/src/universe/autoware_universe/perception/autoware_image_projection_based_fusion/include/autoware/image_projection_based_fusion/camera_projection.hpp:25:10: fatal error: image_geometry/pinhole_camera_model.h: No such file or directory
   25 | #include <image_geometry/pinhole_camera_model.h>
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.                                                                                                  ^
```

### After

Compiles and passes the tests locally with jazzy.

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.
