### PR TITLE
fix(path_sampler): avoid redundant matrix transpose

### DIFF
--- a/planning/sampling_based_planner/autoware_path_sampler/src/prepare_inputs.cpp
+++ b/planning/sampling_based_planner/autoware_path_sampler/src/prepare_inputs.cpp
@@ -118,13 +118,12 @@ autoware::sampler_common::transform::Spline2D preparePathSpline(
   if (smooth_path) {
     // TODO(Maxime CLEMENT): this version using Eigen::Spline is unreliable and sometimes crashes
     constexpr auto spline_dim = 3;
-    Eigen::MatrixXd control_points(path.size(), 2);
+    Eigen::MatrixXd control_points(2, path.size());
     for (auto i = 0lu; i < path.size(); ++i) {
       const auto & point = path[i];
-      control_points(i, 0) = point.pose.position.x;
-      control_points(i, 1) = point.pose.position.y;
+      control_points(0, i) = point.pose.position.x;
+      control_points(1, i) = point.pose.position.y;
     }
-    control_points.transposeInPlace();
     const auto nb_knots = path.size() + spline_dim + 3;
     Eigen::RowVectorXd knots(nb_knots);
     constexpr auto repeat_end_knots = 3lu;


### PR DESCRIPTION
## Description

- Part of: https://github.com/autowarefoundation/autoware_universe/issues/11418

`Eigen::MatrixXd::transposeInPlace()` can trigger a `-Wmaybe-uninitialized` error with GCC 13 when used on dynamically sized matrices, causing the build to fail under `-Werror`.

In this case, the transpose is unnecessary. The control points matrix can be constructed directly in the layout expected by `Eigen::Spline` (`2 × N`) instead of building an `N × 2` matrix and transposing it afterward.

This PR constructs the matrix in the correct shape from the start and removes the in-place transpose entirely.

## How was this PR tested?

### Before

```bash
    inlined from ‘void Eigen::DenseBase<Derived>::transposeInPlace() [with Derived = Eigen::Matrix<double, -1, -1>]’ at /usr/include/eigen3/Eigen/src/Core/Transpose.h:348:53,
    inlined from ‘autoware::sampler_common::transform::Spline2D autoware::path_sampler::preparePathSpline(const std::vector<autoware_planning_msgs::msg::TrajectoryPoint_<std::allocator<void> >, std::allocator<autoware_planning_msgs::msg::TrajectoryPoint_<std::allocator<void> > > >&, bool)’ at /home/mfc/projects/autoware/src/universe/autoware_universe/planning/sampling_based_planner/autoware_path_sampler/src/prepare_inputs.cpp:127:36:
/usr/lib/gcc/x86_64-linux-gnu/13/include/emmintrin.h:169:19: error: ‘*(__int128 unsigned*)result’ may be used uninitialized [-Werror=maybe-uninitialized]
  169 |   *(__m128d *)__P = __A;
      |   ~~~~~~~~~~~~~~~~^~~~~
cc1plus: all warnings being treated as errors                                                                      ^
```

### After

- Compiles successfully with GCC 13
- Passes all local tests
- Verified with ROS 2 Jazzy.

## Notes for reviewers

The change improves correctness and robustness by avoiding unnecessary in-place transposition.

## Interface changes

None.

## Effects on system behavior

None.
