### PR TITLE
fix(elevation_map_loader): fix jazzy build

### DIFF
--- a/perception/autoware_elevation_map_loader/CMakeLists.txt
+++ b/perception/autoware_elevation_map_loader/CMakeLists.txt
@@ -1,8 +1,6 @@
 cmake_minimum_required(VERSION 3.14)
 project(autoware_elevation_map_loader)
 
-find_package(Qt5 REQUIRED COMPONENTS Widgets Gui Core)
-
 find_package(autoware_cmake REQUIRED)
 autoware_package()
 

--- a/perception/autoware_elevation_map_loader/package.xml
+++ b/perception/autoware_elevation_map_loader/package.xml
@@ -22,7 +22,6 @@
   <depend>grid_map_cv</depend>
   <depend>grid_map_pcl</depend>
   <depend>grid_map_ros</depend>
-  <depend>grid_map_rviz_plugin</depend>
   <depend>libpcl-all-dev</depend>
   <depend>map_msgs</depend>
   <depend>pcl_conversions</depend>
@@ -34,6 +33,8 @@
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>
+
+  <exec_depend>grid_map_rviz_plugin</exec_depend>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
## Description

- Part of: https://github.com/autowarefoundation/autoware_universe/issues/11418

This was quite annoying to fix.

This PR brings 3 fixes:
- ~Adds Qt5 to CMakeLists.txt~
   - Moves from `<depend>` to `<exec_depend>grid_map_rviz_plugin</exec_depend>`
- Uses `AUTOWARE_DEFAULT_SERVICES_QOS_PROFILE()`
- Fixes annoying boost polygon expansion bug in jazzy

## How was this PR tested?

### Before

#### Qt5 error

```bash
CMake Error at /opt/ros/jazzy/share/grid_map_rviz_plugin/cmake/ament_cmake_export_dependencies-extras.cmake:21 (find_package):
  Found package configuration file:

    /usr/lib/x86_64-linux-gnu/cmake/Qt5/Qt5Config.cmake

  but it set Qt5_FOUND to FALSE so package "Qt5" is considered to be NOT
  FOUND.  Reason given by package:

  The Qt5 package requires at least one component

Call Stack (most recent call first):
  /opt/ros/jazzy/share/grid_map_rviz_plugin/cmake/grid_map_rviz_pluginConfig.cmake:41 (include)
  /opt/ros/jazzy/share/ament_cmake_auto/cmake/ament_auto_find_build_dependencies.cmake:67 (find_package)
  /home/mfc/projects/autoware/install/autoware_cmake/share/autoware_cmake/cmake/autoware_package.cmake:74 (ament_auto_find_build_dependencies)
  CMakeLists.txt:5 (autoware_package)
                                                                  ^
```

#### Boost errors

```bash
/home/mfc/projects/autoware/src/universe/autoware_universe/perception/autoware_elevation_map_loader/src/elevation_map_loader_node.cpp:407:19:   required from here
/usr/include/boost/geometry/geometries/concepts/concept_type.hpp:24:5: error: static assertion failed: Not implemented for this Tag.
   24 |     BOOST_GEOMETRY_STATIC_ASSERT_FALSE("Not implemented for this Tag.", Tag);
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/boost/geometry/geometries/concepts/concept_type.hpp:24:5: note: ‘std::integral_constant<bool, false>::value’ evaluates to false
In file included from /usr/include/boost/concept/assert.hpp:35,
                 from /usr/include/boost/geometry/geometries/box.hpp:24,
                 from /usr/include/boost/geometry/geometries/geometries.hpp:21,
                 from /home/mfc/projects/autoware/install/autoware_utils_geometry/include/autoware_utils_geometry/boost_geometry.hpp:19:
/usr/include/boost/geometry/geometries/concepts/check.hpp: In instantiation of ‘constexpr void boost::geometry::concepts::check() [with Geometry = std::vector<lanelet::BasicPolygon2d>]’:
/usr/include/boost/geometry/algorithms/detail/buffer/interface.hpp:265:33:   required from ‘void boost::geometry::buffer(const GeometryIn&, GeometryOut&, const DistanceStrategy&, const SideStrategy&, const JoinStrategy&, const EndStrategy&, const PointStrategy&) [with GeometryIn = lanelet::BasicPolygon2d; GeometryOut = std::vector<lanelet::BasicPolygon2d>; DistanceStrategy = strategy::buffer::distance_symmetric<double>; SideStrategy = strategy::buffer::side_straight; JoinStrategy = strategy::buffer::join_miter; EndStrategy = strategy::buffer::end_flat; PointStrategy = strategy::buffer::point_square]’
/home/mfc/projects/autoware/src/universe/autoware_universe/perception/autoware_elevation_map_loader/src/elevation_map_loader_node.cpp:407:19:   required from here
/usr/include/boost/geometry/geometries/concepts/check.hpp:55:5: error: no type named ‘type’ in ‘struct boost::geometry::concepts::concept_type<std::vector<lanelet::BasicPolygon2d>, void>’
   55 |     BOOST_CONCEPT_ASSERT((typename concept_type<Geometry>::type));
      |     ^~~~~~~~~~~~~~~~~~~~
/usr/include/boost/geometry/algorithms/not_implemented.hpp: In instantiation of ‘struct boost::geometry::nyi::not_implemented_error<void>’:
/usr/include/boost/geometry/algorithms/not_implemented.hpp:58:8:   required from ‘struct boost::geometry::not_implemented<void>’
/usr/include/boost/geometry/algorithms/clear.hpp:95:8:   required from ‘struct boost::geometry::dispatch::clear<std::vector<lanelet::BasicPolygon2d>, void>’
/usr/include/boost/geometry/algorithms/clear.hpp:183:37:   required from ‘void boost::geometry::clear(Geometry&) [with Geometry = std::vector<lanelet::BasicPolygon2d>]’
/usr/include/boost/geometry/algorithms/detail/buffer/interface.hpp:267:20:   required from ‘void boost::geometry::buffer(const GeometryIn&, GeometryOut&, const DistanceStrategy&, const SideStrategy&, const JoinStrategy&, const EndStrategy&, const PointStrategy&) [with GeometryIn = lanelet::BasicPolygon2d; GeometryOut = std::vector<lanelet::BasicPolygon2d>; DistanceStrategy = strategy::buffer::distance_symmetric<double>; SideStrategy = strategy::buffer::side_straight; JoinStrategy = strategy::buffer::join_miter; EndStrategy = strategy::buffer::end_flat; PointStrategy = strategy::buffer::point_square]’
/home/mfc/projects/autoware/src/universe/autoware_universe/perception/autoware_elevation_map_loader/src/elevation_map_loader_node.cpp:407:19:   required from here
/usr/include/boost/geometry/algorithms/not_implemented.hpp:47:5: error: static assertion failed: This operation is not or not yet implemented.
```

### After

- Compiles successfully with GCC 13
- Passes all local tests
- Verified with ROS 2 Jazzy.

## Notes for reviewers

Qt and QoS fixes are trivial.

Only the boost change needs a look.

And for that I took this existing code as reference:

https://github.com/autowarefoundation/autoware_universe/blob/645fcef1d6e60b848883208d9960881a1fc3d85d/perception/autoware_detected_object_validation/src/lanelet_filter/lanelet_filter_base.cpp#L136-L154

To make it easier to review.

## Interface changes

None.

## Effects on system behavior

None.
