### PR TITLE
fix(behavior_path_planner_common): add missing boost includes

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/turn_signal_decider.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/turn_signal_decider.cpp
@@ -27,6 +27,9 @@
 #include <autoware_utils/math/normalization.hpp>
 #include <autoware_utils/math/unit_conversion.hpp>
 
+#include <boost/algorithm/string/classification.hpp>
+#include <boost/algorithm/string/split.hpp>
+
 #include <algorithm>
 #include <limits>
 #include <memory>

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/drivable_area_expansion/map_utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/drivable_area_expansion/map_utils.cpp
@@ -14,6 +14,7 @@
 
 #include "autoware/behavior_path_planner_common/utils/drivable_area_expansion/map_utils.hpp"
 
+#include <boost/geometry/algorithms/distance.hpp>
 #include <boost/geometry/strategies/strategies.hpp>
 
 #include <lanelet2_core/Attribute.h>


### PR DESCRIPTION
## Description

- Part of: https://github.com/autowarefoundation/autoware_universe/issues/11418

Simply add missing boost includes.

## How was this PR tested?

### Before

Many boost errors on Jazzy.

### After

- Compiles successfully with GCC 13
- Passes all local tests
- Verified with ROS 2 Jazzy.

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.
