### PR TITLE
fix(behavior_path_dynamic_obstacle_avoidance_module): avoid dangling pointers

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_dynamic_obstacle_avoidance_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_dynamic_obstacle_avoidance_module/src/scene.cpp
@@ -103,8 +103,8 @@ void appendExtractedPolygonMarker(
 bool isEndPointsConnected(
   const lanelet::ConstLanelet & left_lane, const lanelet::ConstLanelet & right_lane)
 {
-  const auto & left_back_point_2d = right_lane.leftBound2d().back().basicPoint();
-  const auto & right_back_point_2d = left_lane.rightBound2d().back().basicPoint();
+  const auto left_back_point_2d = right_lane.leftBound2d().back().basicPoint();
+  const auto right_back_point_2d = left_lane.rightBound2d().back().basicPoint();
 
   constexpr double epsilon = 1e-5;
   return (right_back_point_2d - left_back_point_2d).norm() < epsilon;


### PR DESCRIPTION
## Description

- Part of: https://github.com/autowarefoundation/autoware_universe/issues/11418

This function returns a reference like: `const BasicPoint& basicPoint() const noexcept { return point2d(); }` so it is ending up possibly being a dangling pointer.

This PR simply makes it a value type.

## How was this PR tested?

### Before

```bash
/home/mfc/projects/autoware/src/universe/autoware_universe/planning/behavior_path_planner/autoware_behavior_path_dynamic_obstacle_avoidance_module/src/scene.cpp:106:16: error: possibly dangling reference to a temporary [-Werror=dangling-reference]
  106 |   const auto & left_back_point_2d = right_lane.leftBound2d().back().basicPoint();
      |                ^~~~~~~~~~~~~~~~~~

/home/mfc/projects/autoware/src/universe/autoware_universe/planning/behavior_path_planner/autoware_behavior_path_dynamic_obstacle_avoidance_module/src/scene.cpp:107:16: error: possibly dangling reference to a temporary [-Werror=dangling-reference]
  107 |   const auto & right_back_point_2d = left_lane.rightBound2d().back().basicPoint();
      |                ^~~~~~~~~~~~~~~~~~~
```

### After

- Compiles successfully with GCC 13
- Passes all local tests
- Verified with ROS 2 Jazzy.

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.
