### PR TITLE
fix(behavior_path_static_obstacle_avoidance_module): intersection no inline

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/scene.cpp
@@ -38,6 +38,16 @@
 #include <unordered_map>
 #include <vector>
 
+namespace
+{
+[[gnu::noinline]]
+bool intersects_ring_linestring(
+  const autoware_utils_geometry::LinearRing2d & ring, const lanelet::BasicLineString2d & line)
+{
+  return boost::geometry::intersects(ring, line);
+}
+}  // namespace
+
 namespace autoware::behavior_path_planner
 {
 namespace
@@ -1586,7 +1596,7 @@ bool StaticObstacleAvoidanceModule::is_operator_approval_required(
         autoware_utils::pose2transform(autoware_utils::get_pose(shifted_path.path.points.at(i)));
       const auto footprint = autoware_utils::transform_vector(
         planner_data_->parameters.vehicle_info.createFootprint(), transform);
-      if (boost::geometry::intersects(footprint, linestring)) {
+      if (intersects_ring_linestring(footprint, linestring)) {
         return true;
       }
     }


### PR DESCRIPTION
## Description

- **Part of:** https://github.com/autowarefoundation/autoware_universe/issues/11418

**Continuation to:**
- https://github.com/autowarefoundation/autoware_universe/pull/11926

I tried so many other things to fix this. But this turned out to be the cleanest and simplest solution.

Because of inlining, GCC 13 confuses internal boost functions to be maybe not initialized.
With the provided fix, we simply tell it not to inline that function specifically there.

## How was this PR tested?

### Before

```bash
In file included from /usr/include/boost/geometry/util/is_inverse_spheroidal_coordinates.hpp:19,
                 from /usr/include/boost/geometry/algorithms/detail/assign_values.hpp:42,
                 from /usr/include/boost/geometry/algorithms/detail/assign_box_corners.hpp:21,
                 from /usr/include/boost/geometry/algorithms/convert.hpp:36,
                 from /usr/include/boost/geometry/geometries/box.hpp:26,
                 from /usr/include/boost/geometry/geometries/geometries.hpp:21,
                 from /home/mfc/projects/autoware/install/autoware_utils_geometry/include/autoware_utils_geometry/boost_geometry.hpp:19,
                 from /home/mfc/projects/autoware/install/autoware_vehicle_info_utils/include/autoware/vehicle_info_utils/vehicle_info.hpp:18,
                 from /home/mfc/projects/autoware/install/autoware_vehicle_info_utils/include/autoware/vehicle_info_utils/vehicle_info_utils.hpp:18,
                 from /home/mfc/projects/autoware/install/autoware_vehicle_info_utils/include/autoware_vehicle_info_utils/vehicle_info_utils.hpp:21,
                 from /home/mfc/projects/autoware/install/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/parameters.hpp:18,
                 from /home/mfc/projects/autoware/install/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/data_manager.hpp:18,
                 from /home/mfc/projects/autoware/install/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/interface/scene_module_interface.hpp:18,
                 from /home/mfc/projects/autoware/src/universe/autoware_universe/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/include/autoware/behavior_path_static_obstacle_avoidance_module/scene.hpp:18,
                 from /home/mfc/projects/autoware/src/universe/autoware_universe/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/scene.cpp:15:
In static member function ‘static bool boost::geometry::math::detail::equals<Type, true>::apply(const Type&, const Type&, const Policy&) [with Policy = boost::geometry::math::detail::equals_default_policy; Type = double]’,
    inlined from ‘bool boost::geometry::math::equals(const T1&, const T2&) [with T1 = double; T2 = double]’ at /usr/include/boost/geometry/util/math.hpp:604:17,
    inlined from ‘static bool boost::geometry::strategy::within::detail::cartesian_winding_base<SideStrategy, CalculationType>::check_touch(const Point&, const PointOfSegment&, const PointOfSegment&, counter&, bool&, bool&) [with Point = boost::geometry::model::point<double, 2, boost::geometry::cs::cartesian>; PointOfSegment = autoware_utils_geometry::Point2d; SideStrategy = boost::geometry::strategy::side::side_by_triangle<void>; CalculationType = void]’ at /usr/include/boost/geometry/strategies/cartesian/point_in_poly_winding.hpp:167:27,
    inlined from ‘static int boost::geometry::strategy::within::detail::cartesian_winding_base<SideStrategy, CalculationType>::check_segment(const Point&, const PointOfSegment&, const PointOfSegment&, counter&, bool&, bool&) [with Point = boost::geometry::model::point<double, 2, boost::geometry::cs::cartesian>; PointOfSegment = autoware_utils_geometry::Point2d; SideStrategy = boost::geometry::strategy::side::side_by_triangle<void>; CalculationType = void]’ at /usr/include/boost/geometry/strategies/cartesian/point_in_poly_winding.hpp:146:24,
    inlined from ‘static bool boost::geometry::strategy::within::detail::cartesian_winding_base<SideStrategy, CalculationType>::apply(const Point&, const PointOfSegment&, const PointOfSegment&, counter&) [with Point = boost::geometry::model::point<double, 2, boost::geometry::cs::cartesian>; PointOfSegment = autoware_utils_geometry::Point2d; SideStrategy = boost::geometry::strategy::side::side_by_triangle<void>; CalculationType = void]’ at /usr/include/boost/geometry/strategies/cartesian/point_in_poly_winding.hpp:99:34,
    inlined from ‘int boost::geometry::detail::within::point_in_range(const Point&, const Range&, const Strategy&) [with Point = boost::geometry::model::point<double, 2, boost::geometry::cs::cartesian>; Range = boost::geometry::detail::closed_clockwise_view<const boost::geometry::model::ring<autoware_utils_geometry::Point2d>, boost::geometry::closed, boost::geometry::clockwise>; Strategy = boost::geometry::strategy::within::cartesian_winding<>]’ at /usr/include/boost/geometry/algorithms/detail/within/point_in_geometry.hpp:56:29,
    inlined from ‘static int boost::geometry::detail_dispatch::within::point_in_geometry<Ring, boost::geometry::ring_tag>::apply(const Point&, const Ring&, const Strategy&) [with Point = boost::geometry::model::point<double, 2, boost::geometry::cs::cartesian>; Strategy = boost::geometry::strategies::relate::cartesian<>; Ring = boost::geometry::model::ring<autoware_utils_geometry::Point2d>]’ at /usr/include/boost/geometry/algorithms/detail/within/point_in_geometry.hpp:183:46,
    inlined from ‘int boost::geometry::detail::within::point_in_geometry(const Point&, const Geometry&, const Strategy&) [with Point = boost::geometry::model::point<double, 2, boost::geometry::cs::cartesian>; Geometry = boost::geometry::model::ring<autoware_utils_geometry::Point2d>; Strategy = boost::geometry::strategies::relate::cartesian<>]’ at /usr/include/boost/geometry/algorithms/detail/within/point_in_geometry.hpp:353:71,
    inlined from ‘bool boost::geometry::detail::within::covered_by_point_geometry(const Point&, const Geometry&, const Strategy&) [with Point = boost::geometry::model::point<double, 2, boost::geometry::cs::cartesian>; Geometry = boost::geometry::model::ring<autoware_utils_geometry::Point2d>; Strategy = boost::geometry::strategies::relate::cartesian<>]’ at /usr/include/boost/geometry/algorithms/detail/within/point_in_geometry.hpp:365:29,
    inlined from ‘static bool boost::geometry::detail::covered_by::use_point_in_geometry::apply(const Geometry1&, const Geometry2&, const Strategy&) [with Geometry1 = boost::geometry::model::point<double, 2, boost::geometry::cs::cartesian>; Geometry2 = boost::geometry::model::ring<autoware_utils_geometry::Point2d>; Strategy = boost::geometry::strategies::relate::cartesian<>]’ at /usr/include/boost/geometry/algorithms/detail/covered_by/implementation.hpp:44:57,
    inlined from ‘static bool boost::geometry::resolve_strategy::covered_by<Strategy, IsUmbrella>::apply(const Geometry1&, const Geometry2&, const Strategy&) [with Geometry1 = boost::geometry::model::point<double, 2, boost::geometry::cs::cartesian>; Geometry2 = boost::geometry::model::ring<autoware_utils_geometry::Point2d>; Strategy = boost::geometry::strategies::relate::cartesian<>; bool IsUmbrella = true]’ at /usr/include/boost/geometry/algorithms/detail/covered_by/interface.hpp:74:21,
    inlined from ‘static bool boost::geometry::resolve_dynamic::covered_by<Geometry1, Geometry2, Tag1, Tag2>::apply(const Geometry1&, const Geometry2&, const Strategy&) [with Strategy = boost::geometry::strategies::relate::cartesian<>; Geometry1 = boost::geometry::model::point<double, 2, boost::geometry::cs::cartesian>; Geometry2 = boost::geometry::model::ring<autoware_utils_geometry::Point2d>; Tag1 = boost::geometry::point_tag; Tag2 = boost::geometry::ring_tag]’ at /usr/include/boost/geometry/algorithms/detail/covered_by/interface.hpp:138:21,
    inlined from ‘bool boost::geometry::covered_by(const Geometry1&, const Geometry2&, const Strategy&) [with Geometry1 = model::point<double, 2, cs::cartesian>; Geometry2 = model::ring<autoware_utils_geometry::Point2d>; Strategy = strategies::relate::cartesian<>]’ at /usr/include/boost/geometry/algorithms/detail/covered_by/interface.hpp:256:17,
    inlined from ‘static bool boost::geometry::detail::disjoint::disjoint_no_intersections_policy<Geometry1, Geometry2, Tag1, Tag1OrMulti>::apply(const Geometry1&, const Geometry2&, const Strategy&) [with Strategy = boost::geometry::strategies::relate::cartesian<>; Geometry1 = std::vector<Eigen::Matrix<double, 2, 1>, Eigen::aligned_allocator<Eigen::Matrix<double, 2, 1> > >; Geometry2 = boost::geometry::model::ring<autoware_utils_geometry::Point2d>; Tag1 = boost::geometry::linestring_tag; Tag1OrMulti = boost::geometry::linestring_tag]’ at /usr/include/boost/geometry/algorithms/detail/disjoint/linear_areal.hpp:78:38,
    inlined from ‘static bool boost::geometry::detail::disjoint::disjoint_linear_areal<Geometry1, Geometry2, NoIntersectionsPolicy>::apply(const Geometry1&, const Geometry2&, const Strategy&) [with Strategy = boost::geometry::strategies::relate::cartesian<>; Geometry1 = std::vector<Eigen::Matrix<double, 2, 1>, Eigen::aligned_allocator<Eigen::Matrix<double, 2, 1> > >; Geometry2 = boost::geometry::model::ring<autoware_utils_geometry::Point2d>; NoIntersectionsPolicy = boost::geometry::detail::disjoint::disjoint_no_intersections_policy<std::vector<Eigen::Matrix<double, 2, 1>, Eigen::aligned_allocator<Eigen::Matrix<double, 2, 1> > >, boost::geometry::model::ring<autoware_utils_geometry::Point2d>, boost::geometry::linestring_tag, boost::geometry::linestring_tag>]’ at /usr/include/boost/geometry/algorithms/detail/disjoint/linear_areal.hpp:123:44,
    inlined from ‘static bool boost::geometry::dispatch::disjoint<Geometry1, Geometry2, DimensionCount, Tag1, Tag2, true>::apply(const Geometry1&, const Geometry2&, const Strategy&) [with Strategy = boost::geometry::strategies::relate::cartesian<>; Geometry1 = boost::geometry::model::ring<autoware_utils_geometry::Point2d>; Geometry2 = std::vector<Eigen::Matrix<double, 2, 1>, Eigen::aligned_allocator<Eigen::Matrix<double, 2, 1> > >; long unsigned int DimensionCount = 2; Tag1 = boost::geometry::areal_tag; Tag2 = boost::geometry::linear_tag]’ at /usr/include/boost/geometry/algorithms/dispatch/disjoint.hpp:82:21,
    inlined from ‘static bool boost::geometry::resolve_strategy::disjoint<boost::geometry::default_strategy, false>::apply(const Geometry1&, const Geometry2&, boost::geometry::default_strategy) [with Geometry1 = boost::geometry::model::ring<autoware_utils_geometry::Point2d>; Geometry2 = std::vector<Eigen::Matrix<double, 2, 1>, Eigen::aligned_allocator<Eigen::Matrix<double, 2, 1> > >]’ at /usr/include/boost/geometry/algorithms/detail/disjoint/interface.hpp:97:25,
    inlined from ‘static bool boost::geometry::resolve_dynamic::disjoint<Geometry1, Geometry2, IsDynamic, IsCollection>::apply(const Geometry1&, const Geometry2&, const Strategy&) [with Strategy = boost::geometry::default_strategy; Geometry1 = boost::geometry::model::ring<autoware_utils_geometry::Point2d>; Geometry2 = std::vector<Eigen::Matrix<double, 2, 1>, Eigen::aligned_allocator<Eigen::Matrix<double, 2, 1> > >; bool IsDynamic = false; bool IsCollection = false]’ at /usr/include/boost/geometry/algorithms/detail/disjoint/interface.hpp:129:21,
    inlined from ‘bool boost::geometry::disjoint(const Geometry1&, const Geometry2&) [with Geometry1 = model::ring<autoware_utils_geometry::Point2d>; Geometry2 = std::vector<Eigen::Matrix<double, 2, 1>, Eigen::aligned_allocator<Eigen::Matrix<double, 2, 1> > >]’ at /usr/include/boost/geometry/algorithms/detail/disjoint/interface.hpp:231:21,
    inlined from ‘bool boost::geometry::intersects(const Geometry1&, const Geometry2&) [with Geometry1 = model::ring<autoware_utils_geometry::Point2d>; Geometry2 = std::vector<Eigen::Matrix<double, 2, 1>, Eigen::aligned_allocator<Eigen::Matrix<double, 2, 1> > >]’ at /usr/include/boost/geometry/algorithms/detail/intersects/interface.hpp:108:32,
    inlined from ‘autoware::behavior_path_planner::StaticObstacleAvoidanceModule::is_operator_approval_required(autoware::behavior_path_planner::ShiftedPath&, autoware::behavior_path_planner::DebugData&) const::<lambda(auto:315)> [with auto:315 = bool]’ at /home/mfc/projects/autoware/src/universe/autoware_universe/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/scene.cpp:1589:38:
/usr/include/boost/geometry/util/math.hpp:185:9: error: ‘p.boost::geometry::model::point<double, 2, boost::geometry::cs::cartesian>::m_values[0]’ may be used uninitialized [-Werror=maybe-uninitialized]
  185 |         if (a == b)
      |         ^~
In file included from /usr/include/boost/geometry/algorithms/detail/disjoint/implementation.hpp:26,
                 from /usr/include/boost/geometry/algorithms/disjoint.hpp:25,
                 from /usr/include/boost/geometry/algorithms/detail/overlay/pointlike_areal.hpp:21,
                 from /usr/include/boost/geometry/algorithms/detail/overlay/intersection_insert.hpp:36,
                 from /usr/include/boost/geometry/algorithms/detail/intersection/interface.hpp:17,
                 from /usr/include/boost/geometry/algorithms/detail/intersection/gc.hpp:16,
                 from /usr/include/boost/geometry/algorithms/difference.hpp:19,
                 from /usr/include/boost/geometry/algorithms/detail/relate/implementation_gc.hpp:18,
                 from /usr/include/boost/geometry/algorithms/detail/covered_by/implementation_gc.hpp:16,
                 from /usr/include/boost/geometry/algorithms/covered_by.hpp:25,
                 from /usr/include/boost/geometry/algorithms/detail/distance/multipoint_to_geometry.hpp:19,
                 from /usr/include/boost/geometry/algorithms/detail/distance/implementation.hpp:26,
                 from /usr/include/boost/geometry/algorithms/distance.hpp:24,
                 from /opt/ros/jazzy/include/lanelet2_core/geometry/Point.h:7,
                 from /opt/ros/jazzy/include/lanelet2_core/geometry/BoundingBox.h:4,
                 from /home/mfc/projects/autoware/install/autoware_route_handler/include/autoware/route_handler/route_handler.hpp:32,
                 from /home/mfc/projects/autoware/install/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/turn_signal_decider.hpp:22,
                 from /home/mfc/projects/autoware/install/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/data_manager.hpp:19:
/usr/include/boost/geometry/algorithms/detail/disjoint/linear_areal.hpp: In lambda function:
/usr/include/boost/geometry/algorithms/detail/disjoint/linear_areal.hpp:75:52: note: ‘p.boost::geometry::model::point<double, 2, boost::geometry::cs::cartesian>::m_values[0]’ was declared here
   75 |         typename helper_geometry<point_type>::type p;
      |                                                    ^
In function ‘bool boost::geometry::math::equals(const T1&, const T2&) [with T1 = double; T2 = double]’,
    inlined from ‘static bool boost::geometry::detail::within::point_point_generic<Dimension, DimensionCount>::apply(const Point1&, const Point2&) [with Point1 = boost::geometry::model::point<double, 2, boost::geometry::cs::cartesian>; Point2 = boost::geometry::model::point<double, 2, boost::geometry::cs::cartesian>; long unsigned int Dimension = 1; long unsigned int DimensionCount = 2]’ at /usr/include/boost/geometry/strategies/cartesian/point_in_point.hpp:51:37,
    inlined from ‘static bool boost::geometry::detail::within::point_point_generic<Dimension, DimensionCount>::apply(const Point1&, const Point2&) [with Point1 = boost::geometry::model::point<double, 2, boost::geometry::cs::cartesian>; Point2 = boost::geometry::model::point<double, 2, boost::geometry::cs::cartesian>; long unsigned int Dimension = 0; long unsigned int DimensionCount = 2]’ at /usr/include/boost/geometry/strategies/cartesian/point_in_point.hpp:56:70,
    inlined from ‘static bool boost::geometry::detail::within::point_point_generic<Dimension, DimensionCount>::apply(const Point1&, const Point2&) [with Point1 = autoware_utils_geometry::Point2d; Point2 = boost::geometry::model::point<double, 2, boost::geometry::cs::cartesian>; long unsigned int Dimension = 0; long unsigned int DimensionCount = 2]’ at /usr/include/boost/geometry/strategies/cartesian/point_in_point.hpp:49:24,
    inlined from ‘static bool boost::geometry::strategy::within::cartesian_point_point::apply(const Point1&, const Point2&) [with Point1 = autoware_utils_geometry::Point2d; Point2 = boost::geometry::model::point<double, 2, boost::geometry::cs::cartesian>]’ at /usr/include/boost/geometry/strategies/cartesian/point_in_point.hpp:87:21,
    inlined from ‘static bool boost::geometry::strategy::side::side_by_triangle<CalculationType>::equals_point_point(const P1&, const P2&) [with P1 = autoware_utils_geometry::Point2d; P2 = boost::geometry::model::point<double, 2, boost::geometry::cs::cartesian>; CalculationType = void]’ at /usr/include/boost/geometry/strategy/cartesian/side_by_triangle.hpp:234:62,
    inlined from ‘static PromotedType boost::geometry::strategy::side::side_by_triangle<CalculationType>::compute_side_value<CoordinateType, PromotedType, false>::apply(const P1&, const P2&, const P&, EpsPolicy&) [with P1 = autoware_utils_geometry::Point2d; P2 = autoware_utils_geometry::Point2d; P = boost::geometry::model::point<double, 2, boost::geometry::cs::cartesian>; EpsPolicy = boost::geometry::strategy::side::side_by_triangle<void>::eps_policy<boost::geometry::math::detail::equals_factor_policy<double, true> >; CoordinateType = double; PromotedType = double; CalculationType = void]’ at /usr/include/boost/geometry/strategy/cartesian/side_by_triangle.hpp:159:38,
    inlined from ‘static int boost::geometry::strategy::side::side_by_triangle<CalculationType>::apply(const P1&, const P2&, const P&) [with P1 = autoware_utils_geometry::Point2d; P2 = autoware_utils_geometry::Point2d; P = boost::geometry::model::point<double, 2, boost::geometry::cs::cartesian>; CalculationType = void]’ at /usr/include/boost/geometry/strategy/cartesian/side_by_triangle.hpp:222:21,
    inlined from ‘static bool boost::geometry::strategy::within::detail::cartesian_winding_base<SideStrategy, CalculationType>::apply(const Point&, const PointOfSegment&, const PointOfSegment&, counter&) [with Point = boost::geometry::model::point<double, 2, boost::geometry::cs::cartesian>; PointOfSegment = autoware_utils_geometry::Point2d; SideStrategy = boost::geometry::strategy::side::side_by_triangle<void>; CalculationType = void]’ at /usr/include/boost/geometry/strategies/cartesian/point_in_poly_winding.hpp:110:43,
    inlined from ‘int boost::geometry::detail::within::point_in_range(const Point&, const Range&, const Strategy&) [with Point = boost::geometry::model::point<double, 2, boost::geometry::cs::cartesian>; Range = boost::geometry::detail::closed_clockwise_view<const boost::geometry::model::ring<autoware_utils_geometry::Point2d>, boost::geometry::closed, boost::geometry::clockwise>; Strategy = boost::geometry::strategy::within::cartesian_winding<>]’ at /usr/include/boost/geometry/algorithms/detail/within/point_in_geometry.hpp:56:29,
    inlined from ‘static int boost::geometry::detail_dispatch::within::point_in_geometry<Ring, boost::geometry::ring_tag>::apply(const Point&, const Ring&, const Strategy&) [with Point = boost::geometry::model::point<double, 2, boost::geometry::cs::cartesian>; Strategy = boost::geometry::strategies::relate::cartesian<>; Ring = boost::geometry::model::ring<autoware_utils_geometry::Point2d>]’ at /usr/include/boost/geometry/algorithms/detail/within/point_in_geometry.hpp:183:46,
    inlined from ‘int boost::geometry::detail::within::point_in_geometry(const Point&, const Geometry&, const Strategy&) [with Point = boost::geometry::model::point<double, 2, boost::geometry::cs::cartesian>; Geometry = boost::geometry::model::ring<autoware_utils_geometry::Point2d>; Strategy = boost::geometry::strategies::relate::cartesian<>]’ at /usr/include/boost/geometry/algorithms/detail/within/point_in_geometry.hpp:353:71,
    inlined from ‘bool boost::geometry::detail::within::covered_by_point_geometry(const Point&, const Geometry&, const Strategy&) [with Point = boost::geometry::model::point<double, 2, boost::geometry::cs::cartesian>; Geometry = boost::geometry::model::ring<autoware_utils_geometry::Point2d>; Strategy = boost::geometry::strategies::relate::cartesian<>]’ at /usr/include/boost/geometry/algorithms/detail/within/point_in_geometry.hpp:365:29,
    inlined from ‘static bool boost::geometry::detail::covered_by::use_point_in_geometry::apply(const Geometry1&, const Geometry2&, const Strategy&) [with Geometry1 = boost::geometry::model::point<double, 2, boost::geometry::cs::cartesian>; Geometry2 = boost::geometry::model::ring<autoware_utils_geometry::Point2d>; Strategy = boost::geometry::strategies::relate::cartesian<>]’ at /usr/include/boost/geometry/algorithms/detail/covered_by/implementation.hpp:44:57,
    inlined from ‘static bool boost::geometry::resolve_strategy::covered_by<Strategy, IsUmbrella>::apply(const Geometry1&, const Geometry2&, const Strategy&) [with Geometry1 = boost::geometry::model::point<double, 2, boost::geometry::cs::cartesian>; Geometry2 = boost::geometry::model::ring<autoware_utils_geometry::Point2d>; Strategy = boost::geometry::strategies::relate::cartesian<>; bool IsUmbrella = true]’ at /usr/include/boost/geometry/algorithms/detail/covered_by/interface.hpp:74:21,
    inlined from ‘static bool boost::geometry::resolve_dynamic::covered_by<Geometry1, Geometry2, Tag1, Tag2>::apply(const Geometry1&, const Geometry2&, const Strategy&) [with Strategy = boost::geometry::strategies::relate::cartesian<>; Geometry1 = boost::geometry::model::point<double, 2, boost::geometry::cs::cartesian>; Geometry2 = boost::geometry::model::ring<autoware_utils_geometry::Point2d>; Tag1 = boost::geometry::point_tag; Tag2 = boost::geometry::ring_tag]’ at /usr/include/boost/geometry/algorithms/detail/covered_by/interface.hpp:138:21,
    inlined from ‘bool boost::geometry::covered_by(const Geometry1&, const Geometry2&, const Strategy&) [with Geometry1 = model::point<double, 2, cs::cartesian>; Geometry2 = model::ring<autoware_utils_geometry::Point2d>; Strategy = strategies::relate::cartesian<>]’ at /usr/include/boost/geometry/algorithms/detail/covered_by/interface.hpp:256:17,
    inlined from ‘static bool boost::geometry::detail::disjoint::disjoint_no_intersections_policy<Geometry1, Geometry2, Tag1, Tag1OrMulti>::apply(const Geometry1&, const Geometry2&, const Strategy&) [with Strategy = boost::geometry::strategies::relate::cartesian<>; Geometry1 = std::vector<Eigen::Matrix<double, 2, 1>, Eigen::aligned_allocator<Eigen::Matrix<double, 2, 1> > >; Geometry2 = boost::geometry::model::ring<autoware_utils_geometry::Point2d>; Tag1 = boost::geometry::linestring_tag; Tag1OrMulti = boost::geometry::linestring_tag]’ at /usr/include/boost/geometry/algorithms/detail/disjoint/linear_areal.hpp:78:38,
    inlined from ‘static bool boost::geometry::detail::disjoint::disjoint_linear_areal<Geometry1, Geometry2, NoIntersectionsPolicy>::apply(const Geometry1&, const Geometry2&, const Strategy&) [with Strategy = boost::geometry::strategies::relate::cartesian<>; Geometry1 = std::vector<Eigen::Matrix<double, 2, 1>, Eigen::aligned_allocator<Eigen::Matrix<double, 2, 1> > >; Geometry2 = boost::geometry::model::ring<autoware_utils_geometry::Point2d>; NoIntersectionsPolicy = boost::geometry::detail::disjoint::disjoint_no_intersections_policy<std::vector<Eigen::Matrix<double, 2, 1>, Eigen::aligned_allocator<Eigen::Matrix<double, 2, 1> > >, boost::geometry::model::ring<autoware_utils_geometry::Point2d>, boost::geometry::linestring_tag, boost::geometry::linestring_tag>]’ at /usr/include/boost/geometry/algorithms/detail/disjoint/linear_areal.hpp:123:44,
    inlined from ‘static bool boost::geometry::dispatch::disjoint<Geometry1, Geometry2, DimensionCount, Tag1, Tag2, true>::apply(const Geometry1&, const Geometry2&, const Strategy&) [with Strategy = boost::geometry::strategies::relate::cartesian<>; Geometry1 = boost::geometry::model::ring<autoware_utils_geometry::Point2d>; Geometry2 = std::vector<Eigen::Matrix<double, 2, 1>, Eigen::aligned_allocator<Eigen::Matrix<double, 2, 1> > >; long unsigned int DimensionCount = 2; Tag1 = boost::geometry::areal_tag; Tag2 = boost::geometry::linear_tag]’ at /usr/include/boost/geometry/algorithms/dispatch/disjoint.hpp:82:21,
    inlined from ‘static bool boost::geometry::resolve_strategy::disjoint<boost::geometry::default_strategy, false>::apply(const Geometry1&, const Geometry2&, boost::geometry::default_strategy) [with Geometry1 = boost::geometry::model::ring<autoware_utils_geometry::Point2d>; Geometry2 = std::vector<Eigen::Matrix<double, 2, 1>, Eigen::aligned_allocator<Eigen::Matrix<double, 2, 1> > >]’ at /usr/include/boost/geometry/algorithms/detail/disjoint/interface.hpp:97:25,
    inlined from ‘static bool boost::geometry::resolve_dynamic::disjoint<Geometry1, Geometry2, IsDynamic, IsCollection>::apply(const Geometry1&, const Geometry2&, const Strategy&) [with Strategy = boost::geometry::default_strategy; Geometry1 = boost::geometry::model::ring<autoware_utils_geometry::Point2d>; Geometry2 = std::vector<Eigen::Matrix<double, 2, 1>, Eigen::aligned_allocator<Eigen::Matrix<double, 2, 1> > >; bool IsDynamic = false; bool IsCollection = false]’ at /usr/include/boost/geometry/algorithms/detail/disjoint/interface.hpp:129:21,
    inlined from ‘bool boost::geometry::disjoint(const Geometry1&, const Geometry2&) [with Geometry1 = model::ring<autoware_utils_geometry::Point2d>; Geometry2 = std::vector<Eigen::Matrix<double, 2, 1>, Eigen::aligned_allocator<Eigen::Matrix<double, 2, 1> > >]’ at /usr/include/boost/geometry/algorithms/detail/disjoint/interface.hpp:231:21,
    inlined from ‘bool boost::geometry::intersects(const Geometry1&, const Geometry2&) [with Geometry1 = model::ring<autoware_utils_geometry::Point2d>; Geometry2 = std::vector<Eigen::Matrix<double, 2, 1>, Eigen::aligned_allocator<Eigen::Matrix<double, 2, 1> > >]’ at /usr/include/boost/geometry/algorithms/detail/intersects/interface.hpp:108:32,
    inlined from ‘autoware::behavior_path_planner::StaticObstacleAvoidanceModule::is_operator_approval_required(autoware::behavior_path_planner::ShiftedPath&, autoware::behavior_path_planner::DebugData&) const::<lambda(auto:315)> [with auto:315 = bool]’ at /home/mfc/projects/autoware/src/universe/autoware_universe/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/scene.cpp:1589:38:
/usr/include/boost/geometry/util/math.hpp:604:17: error: ‘p.boost::geometry::model::point<double, 2, boost::geometry::cs::cartesian>::m_values[1]’ may be used uninitialized [-Werror=maybe-uninitialized]
  601 |     return detail::equals
      |            ~~~~~~~~~~~~~~
  602 |         <
      |         ~        
  603 |             typename select_most_precise<T1, T2>::type
      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  604 |         >::apply(a, b, detail::equals_default_policy());
      |         ~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/boost/geometry/algorithms/detail/disjoint/linear_areal.hpp: In lambda function:
/usr/include/boost/geometry/algorithms/detail/disjoint/linear_areal.hpp:75:52: note: ‘p.boost::geometry::model::point<double, 2, boost::geometry::cs::cartesian>::m_values[1]’ was declared here
   75 |         typename helper_geometry<point_type>::type p;
      |                                                    ^
cc1plus: all warnings being treated as errors
gmake[2]: *** [CMakeFiles/autoware_behavior_path_static_obstacle_avoidance_module.dir/build.make:76: CMakeFiles/autoware_behavior_path_static_obstacle_avoidance_module.dir/src/scene.cpp.o] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:176: CMakeFiles/autoware_behavior_path_static_obstacle_avoidance_module.dir/all] Error 2
gmake: *** [Makefile:146: all] Error 2
---
--- stderr: autoware_behavior_path_static_obstacle_avoidance_module
In file included from /usr/include/boost/geometry/util/is_inverse_spheroidal_coordinates.hpp:19,
                 from /usr/include/boost/geometry/algorithms/detail/assign_values.hpp:42,
                 from /usr/include/boost/geometry/algorithms/detail/assign_box_corners.hpp:21,
                 from /usr/include/boost/geometry/algorithms/convert.hpp:36,
                 from /usr/include/boost/geometry/geometries/box.hpp:26,
                 from /usr/include/boost/geometry/geometries/geometries.hpp:21,
                 from /home/mfc/projects/autoware/install/autoware_utils_geometry/include/autoware_utils_geometry/boost_geometry.hpp:19,
                 from /home/mfc/projects/autoware/install/autoware_vehicle_info_utils/include/autoware/vehicle_info_utils/vehicle_info.hpp:18,
                 from /home/mfc/projects/autoware/install/autoware_vehicle_info_utils/include/autoware/vehicle_info_utils/vehicle_info_utils.hpp:18,
                 from /home/mfc/projects/autoware/install/autoware_vehicle_info_utils/include/autoware_vehicle_info_utils/vehicle_info_utils.hpp:21,
                 from /home/mfc/projects/autoware/install/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/parameters.hpp:18,
                 from /home/mfc/projects/autoware/install/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/data_manager.hpp:18,
                 from /home/mfc/projects/autoware/install/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/interface/scene_module_interface.hpp:18,
                 from /home/mfc/projects/autoware/src/universe/autoware_universe/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/include/autoware/behavior_path_static_obstacle_avoidance_module/scene.hpp:18,
                 from /home/mfc/projects/autoware/src/universe/autoware_universe/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/scene.cpp:15:
In static member function ‘static bool boost::geometry::math::detail::equals<Type, true>::apply(const Type&, const Type&, const Policy&) [with Policy = boost::geometry::math::detail::equals_default_policy; Type = double]’,
    inlined from ‘bool boost::geometry::math::equals(const T1&, const T2&) [with T1 = double; T2 = double]’ at /usr/include/boost/geometry/util/math.hpp:604:17,
    inlined from ‘static bool boost::geometry::strategy::within::detail::cartesian_winding_base<SideStrategy, CalculationType>::check_touch(const Point&, const PointOfSegment&, const PointOfSegment&, counter&, bool&, bool&) [with Point = boost::geometry::model::point<double, 2, boost::geometry::cs::cartesian>; PointOfSegment = autoware_utils_geometry::Point2d; SideStrategy = boost::geometry::strategy::side::side_by_triangle<void>; CalculationType = void]’ at /usr/include/boost/geometry/strategies/cartesian/point_in_poly_winding.hpp:167:27,
    inlined from ‘static int boost::geometry::strategy::within::detail::cartesian_winding_base<SideStrategy, CalculationType>::check_segment(const Point&, const PointOfSegment&, const PointOfSegment&, counter&, bool&, bool&) [with Point = boost::geometry::model::point<double, 2, boost::geometry::cs::cartesian>; PointOfSegment = autoware_utils_geometry::Point2d; SideStrategy = boost::geometry::strategy::side::side_by_triangle<void>; CalculationType = void]’ at /usr/include/boost/geometry/strategies/cartesian/point_in_poly_winding.hpp:146:24,
    inlined from ‘static bool boost::geometry::strategy::within::detail::cartesian_winding_base<SideStrategy, CalculationType>::apply(const Point&, const PointOfSegment&, const PointOfSegment&, counter&) [with Point = boost::geometry::model::point<double, 2, boost::geometry::cs::cartesian>; PointOfSegment = autoware_utils_geometry::Point2d; SideStrategy = boost::geometry::strategy::side::side_by_triangle<void>; CalculationType = void]’ at /usr/include/boost/geometry/strategies/cartesian/point_in_poly_winding.hpp:99:34,
    inlined from ‘int boost::geometry::detail::within::point_in_range(const Point&, const Range&, const Strategy&) [with Point = boost::geometry::model::point<double, 2, boost::geometry::cs::cartesian>; Range = boost::geometry::detail::closed_clockwise_view<const boost::geometry::model::ring<autoware_utils_geometry::Point2d>, boost::geometry::closed, boost::geometry::clockwise>; Strategy = boost::geometry::strategy::within::cartesian_winding<>]’ at /usr/include/boost/geometry/algorithms/detail/within/point_in_geometry.hpp:56:29,
    inlined from ‘static int boost::geometry::detail_dispatch::within::point_in_geometry<Ring, boost::geometry::ring_tag>::apply(const Point&, const Ring&, const Strategy&) [with Point = boost::geometry::model::point<double, 2, boost::geometry::cs::cartesian>; Strategy = boost::geometry::strategies::relate::cartesian<>; Ring = boost::geometry::model::ring<autoware_utils_geometry::Point2d>]’ at /usr/include/boost/geometry/algorithms/detail/within/point_in_geometry.hpp:183:46,
    inlined from ‘int boost::geometry::detail::within::point_in_geometry(const Point&, const Geometry&, const Strategy&) [with Point = boost::geometry::model::point<double, 2, boost::geometry::cs::cartesian>; Geometry = boost::geometry::model::ring<autoware_utils_geometry::Point2d>; Strategy = boost::geometry::strategies::relate::cartesian<>]’ at /usr/include/boost/geometry/algorithms/detail/within/point_in_geometry.hpp:353:71,
    inlined from ‘bool boost::geometry::detail::within::covered_by_point_geometry(const Point&, const Geometry&, const Strategy&) [with Point = boost::geometry::model::point<double, 2, boost::geometry::cs::cartesian>; Geometry = boost::geometry::model::ring<autoware_utils_geometry::Point2d>; Strategy = boost::geometry::strategies::relate::cartesian<>]’ at /usr/include/boost/geometry/algorithms/detail/within/point_in_geometry.hpp:365:29,
    inlined from ‘static bool boost::geometry::detail::covered_by::use_point_in_geometry::apply(const Geometry1&, const Geometry2&, const Strategy&) [with Geometry1 = boost::geometry::model::point<double, 2, boost::geometry::cs::cartesian>; Geometry2 = boost::geometry::model::ring<autoware_utils_geometry::Point2d>; Strategy = boost::geometry::strategies::relate::cartesian<>]’ at /usr/include/boost/geometry/algorithms/detail/covered_by/implementation.hpp:44:57,
    inlined from ‘static bool boost::geometry::resolve_strategy::covered_by<Strategy, IsUmbrella>::apply(const Geometry1&, const Geometry2&, const Strategy&) [with Geometry1 = boost::geometry::model::point<double, 2, boost::geometry::cs::cartesian>; Geometry2 = boost::geometry::model::ring<autoware_utils_geometry::Point2d>; Strategy = boost::geometry::strategies::relate::cartesian<>; bool IsUmbrella = true]’ at /usr/include/boost/geometry/algorithms/detail/covered_by/interface.hpp:74:21,
    inlined from ‘static bool boost::geometry::resolve_dynamic::covered_by<Geometry1, Geometry2, Tag1, Tag2>::apply(const Geometry1&, const Geometry2&, const Strategy&) [with Strategy = boost::geometry::strategies::relate::cartesian<>; Geometry1 = boost::geometry::model::point<double, 2, boost::geometry::cs::cartesian>; Geometry2 = boost::geometry::model::ring<autoware_utils_geometry::Point2d>; Tag1 = boost::geometry::point_tag; Tag2 = boost::geometry::ring_tag]’ at /usr/include/boost/geometry/algorithms/detail/covered_by/interface.hpp:138:21,
    inlined from ‘bool boost::geometry::covered_by(const Geometry1&, const Geometry2&, const Strategy&) [with Geometry1 = model::point<double, 2, cs::cartesian>; Geometry2 = model::ring<autoware_utils_geometry::Point2d>; Strategy = strategies::relate::cartesian<>]’ at /usr/include/boost/geometry/algorithms/detail/covered_by/interface.hpp:256:17,
    inlined from ‘static bool boost::geometry::detail::disjoint::disjoint_no_intersections_policy<Geometry1, Geometry2, Tag1, Tag1OrMulti>::apply(const Geometry1&, const Geometry2&, const Strategy&) [with Strategy = boost::geometry::strategies::relate::cartesian<>; Geometry1 = std::vector<Eigen::Matrix<double, 2, 1>, Eigen::aligned_allocator<Eigen::Matrix<double, 2, 1> > >; Geometry2 = boost::geometry::model::ring<autoware_utils_geometry::Point2d>; Tag1 = boost::geometry::linestring_tag; Tag1OrMulti = boost::geometry::linestring_tag]’ at /usr/include/boost/geometry/algorithms/detail/disjoint/linear_areal.hpp:78:38,
    inlined from ‘static bool boost::geometry::detail::disjoint::disjoint_linear_areal<Geometry1, Geometry2, NoIntersectionsPolicy>::apply(const Geometry1&, const Geometry2&, const Strategy&) [with Strategy = boost::geometry::strategies::relate::cartesian<>; Geometry1 = std::vector<Eigen::Matrix<double, 2, 1>, Eigen::aligned_allocator<Eigen::Matrix<double, 2, 1> > >; Geometry2 = boost::geometry::model::ring<autoware_utils_geometry::Point2d>; NoIntersectionsPolicy = boost::geometry::detail::disjoint::disjoint_no_intersections_policy<std::vector<Eigen::Matrix<double, 2, 1>, Eigen::aligned_allocator<Eigen::Matrix<double, 2, 1> > >, boost::geometry::model::ring<autoware_utils_geometry::Point2d>, boost::geometry::linestring_tag, boost::geometry::linestring_tag>]’ at /usr/include/boost/geometry/algorithms/detail/disjoint/linear_areal.hpp:123:44,
    inlined from ‘static bool boost::geometry::dispatch::disjoint<Geometry1, Geometry2, DimensionCount, Tag1, Tag2, true>::apply(const Geometry1&, const Geometry2&, const Strategy&) [with Strategy = boost::geometry::strategies::relate::cartesian<>; Geometry1 = boost::geometry::model::ring<autoware_utils_geometry::Point2d>; Geometry2 = std::vector<Eigen::Matrix<double, 2, 1>, Eigen::aligned_allocator<Eigen::Matrix<double, 2, 1> > >; long unsigned int DimensionCount = 2; Tag1 = boost::geometry::areal_tag; Tag2 = boost::geometry::linear_tag]’ at /usr/include/boost/geometry/algorithms/dispatch/disjoint.hpp:82:21,
    inlined from ‘static bool boost::geometry::resolve_strategy::disjoint<boost::geometry::default_strategy, false>::apply(const Geometry1&, const Geometry2&, boost::geometry::default_strategy) [with Geometry1 = boost::geometry::model::ring<autoware_utils_geometry::Point2d>; Geometry2 = std::vector<Eigen::Matrix<double, 2, 1>, Eigen::aligned_allocator<Eigen::Matrix<double, 2, 1> > >]’ at /usr/include/boost/geometry/algorithms/detail/disjoint/interface.hpp:97:25,
    inlined from ‘static bool boost::geometry::resolve_dynamic::disjoint<Geometry1, Geometry2, IsDynamic, IsCollection>::apply(const Geometry1&, const Geometry2&, const Strategy&) [with Strategy = boost::geometry::default_strategy; Geometry1 = boost::geometry::model::ring<autoware_utils_geometry::Point2d>; Geometry2 = std::vector<Eigen::Matrix<double, 2, 1>, Eigen::aligned_allocator<Eigen::Matrix<double, 2, 1> > >; bool IsDynamic = false; bool IsCollection = false]’ at /usr/include/boost/geometry/algorithms/detail/disjoint/interface.hpp:129:21,
    inlined from ‘bool boost::geometry::disjoint(const Geometry1&, const Geometry2&) [with Geometry1 = model::ring<autoware_utils_geometry::Point2d>; Geometry2 = std::vector<Eigen::Matrix<double, 2, 1>, Eigen::aligned_allocator<Eigen::Matrix<double, 2, 1> > >]’ at /usr/include/boost/geometry/algorithms/detail/disjoint/interface.hpp:231:21,
    inlined from ‘bool boost::geometry::intersects(const Geometry1&, const Geometry2&) [with Geometry1 = model::ring<autoware_utils_geometry::Point2d>; Geometry2 = std::vector<Eigen::Matrix<double, 2, 1>, Eigen::aligned_allocator<Eigen::Matrix<double, 2, 1> > >]’ at /usr/include/boost/geometry/algorithms/detail/intersects/interface.hpp:108:32,
    inlined from ‘autoware::behavior_path_planner::StaticObstacleAvoidanceModule::is_operator_approval_required(autoware::behavior_path_planner::ShiftedPath&, autoware::behavior_path_planner::DebugData&) const::<lambda(auto:315)> [with auto:315 = bool]’ at /home/mfc/projects/autoware/src/universe/autoware_universe/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/scene.cpp:1589:38:
/usr/include/boost/geometry/util/math.hpp:185:9: error: ‘p.boost::geometry::model::point<double, 2, boost::geometry::cs::cartesian>::m_values[0]’ may be used uninitialized [-Werror=maybe-uninitialized]
  185 |         if (a == b)
      |         ^~
In file included from /usr/include/boost/geometry/algorithms/detail/disjoint/implementation.hpp:26,
                 from /usr/include/boost/geometry/algorithms/disjoint.hpp:25,
                 from /usr/include/boost/geometry/algorithms/detail/overlay/pointlike_areal.hpp:21,
                 from /usr/include/boost/geometry/algorithms/detail/overlay/intersection_insert.hpp:36,
                 from /usr/include/boost/geometry/algorithms/detail/intersection/interface.hpp:17,
                 from /usr/include/boost/geometry/algorithms/detail/intersection/gc.hpp:16,
                 from /usr/include/boost/geometry/algorithms/difference.hpp:19,
                 from /usr/include/boost/geometry/algorithms/detail/relate/implementation_gc.hpp:18,
                 from /usr/include/boost/geometry/algorithms/detail/covered_by/implementation_gc.hpp:16,
                 from /usr/include/boost/geometry/algorithms/covered_by.hpp:25,
                 from /usr/include/boost/geometry/algorithms/detail/distance/multipoint_to_geometry.hpp:19,
                 from /usr/include/boost/geometry/algorithms/detail/distance/implementation.hpp:26,
                 from /usr/include/boost/geometry/algorithms/distance.hpp:24,
                 from /opt/ros/jazzy/include/lanelet2_core/geometry/Point.h:7,
                 from /opt/ros/jazzy/include/lanelet2_core/geometry/BoundingBox.h:4,
                 from /home/mfc/projects/autoware/install/autoware_route_handler/include/autoware/route_handler/route_handler.hpp:32,
                 from /home/mfc/projects/autoware/install/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/turn_signal_decider.hpp:22,
                 from /home/mfc/projects/autoware/install/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/data_manager.hpp:19:
/usr/include/boost/geometry/algorithms/detail/disjoint/linear_areal.hpp: In lambda function:
/usr/include/boost/geometry/algorithms/detail/disjoint/linear_areal.hpp:75:52: note: ‘p.boost::geometry::model::point<double, 2, boost::geometry::cs::cartesian>::m_values[0]’ was declared here
   75 |         typename helper_geometry<point_type>::type p;
      |                                                    ^
In function ‘bool boost::geometry::math::equals(const T1&, const T2&) [with T1 = double; T2 = double]’,
    inlined from ‘static bool boost::geometry::detail::within::point_point_generic<Dimension, DimensionCount>::apply(const Point1&, const Point2&) [with Point1 = boost::geometry::model::point<double, 2, boost::geometry::cs::cartesian>; Point2 = boost::geometry::model::point<double, 2, boost::geometry::cs::cartesian>; long unsigned int Dimension = 1; long unsigned int DimensionCount = 2]’ at /usr/include/boost/geometry/strategies/cartesian/point_in_point.hpp:51:37,
    inlined from ‘static bool boost::geometry::detail::within::point_point_generic<Dimension, DimensionCount>::apply(const Point1&, const Point2&) [with Point1 = boost::geometry::model::point<double, 2, boost::geometry::cs::cartesian>; Point2 = boost::geometry::model::point<double, 2, boost::geometry::cs::cartesian>; long unsigned int Dimension = 0; long unsigned int DimensionCount = 2]’ at /usr/include/boost/geometry/strategies/cartesian/point_in_point.hpp:56:70,
    inlined from ‘static bool boost::geometry::detail::within::point_point_generic<Dimension, DimensionCount>::apply(const Point1&, const Point2&) [with Point1 = autoware_utils_geometry::Point2d; Point2 = boost::geometry::model::point<double, 2, boost::geometry::cs::cartesian>; long unsigned int Dimension = 0; long unsigned int DimensionCount = 2]’ at /usr/include/boost/geometry/strategies/cartesian/point_in_point.hpp:49:24,
    inlined from ‘static bool boost::geometry::strategy::within::cartesian_point_point::apply(const Point1&, const Point2&) [with Point1 = autoware_utils_geometry::Point2d; Point2 = boost::geometry::model::point<double, 2, boost::geometry::cs::cartesian>]’ at /usr/include/boost/geometry/strategies/cartesian/point_in_point.hpp:87:21,
    inlined from ‘static bool boost::geometry::strategy::side::side_by_triangle<CalculationType>::equals_point_point(const P1&, const P2&) [with P1 = autoware_utils_geometry::Point2d; P2 = boost::geometry::model::point<double, 2, boost::geometry::cs::cartesian>; CalculationType = void]’ at /usr/include/boost/geometry/strategy/cartesian/side_by_triangle.hpp:234:62,
    inlined from ‘static PromotedType boost::geometry::strategy::side::side_by_triangle<CalculationType>::compute_side_value<CoordinateType, PromotedType, false>::apply(const P1&, const P2&, const P&, EpsPolicy&) [with P1 = autoware_utils_geometry::Point2d; P2 = autoware_utils_geometry::Point2d; P = boost::geometry::model::point<double, 2, boost::geometry::cs::cartesian>; EpsPolicy = boost::geometry::strategy::side::side_by_triangle<void>::eps_policy<boost::geometry::math::detail::equals_factor_policy<double, true> >; CoordinateType = double; PromotedType = double; CalculationType = void]’ at /usr/include/boost/geometry/strategy/cartesian/side_by_triangle.hpp:159:38,
    inlined from ‘static int boost::geometry::strategy::side::side_by_triangle<CalculationType>::apply(const P1&, const P2&, const P&) [with P1 = autoware_utils_geometry::Point2d; P2 = autoware_utils_geometry::Point2d; P = boost::geometry::model::point<double, 2, boost::geometry::cs::cartesian>; CalculationType = void]’ at /usr/include/boost/geometry/strategy/cartesian/side_by_triangle.hpp:222:21,
    inlined from ‘static bool boost::geometry::strategy::within::detail::cartesian_winding_base<SideStrategy, CalculationType>::apply(const Point&, const PointOfSegment&, const PointOfSegment&, counter&) [with Point = boost::geometry::model::point<double, 2, boost::geometry::cs::cartesian>; PointOfSegment = autoware_utils_geometry::Point2d; SideStrategy = boost::geometry::strategy::side::side_by_triangle<void>; CalculationType = void]’ at /usr/include/boost/geometry/strategies/cartesian/point_in_poly_winding.hpp:110:43,
    inlined from ‘int boost::geometry::detail::within::point_in_range(const Point&, const Range&, const Strategy&) [with Point = boost::geometry::model::point<double, 2, boost::geometry::cs::cartesian>; Range = boost::geometry::detail::closed_clockwise_view<const boost::geometry::model::ring<autoware_utils_geometry::Point2d>, boost::geometry::closed, boost::geometry::clockwise>; Strategy = boost::geometry::strategy::within::cartesian_winding<>]’ at /usr/include/boost/geometry/algorithms/detail/within/point_in_geometry.hpp:56:29,
    inlined from ‘static int boost::geometry::detail_dispatch::within::point_in_geometry<Ring, boost::geometry::ring_tag>::apply(const Point&, const Ring&, const Strategy&) [with Point = boost::geometry::model::point<double, 2, boost::geometry::cs::cartesian>; Strategy = boost::geometry::strategies::relate::cartesian<>; Ring = boost::geometry::model::ring<autoware_utils_geometry::Point2d>]’ at /usr/include/boost/geometry/algorithms/detail/within/point_in_geometry.hpp:183:46,
    inlined from ‘int boost::geometry::detail::within::point_in_geometry(const Point&, const Geometry&, const Strategy&) [with Point = boost::geometry::model::point<double, 2, boost::geometry::cs::cartesian>; Geometry = boost::geometry::model::ring<autoware_utils_geometry::Point2d>; Strategy = boost::geometry::strategies::relate::cartesian<>]’ at /usr/include/boost/geometry/algorithms/detail/within/point_in_geometry.hpp:353:71,
    inlined from ‘bool boost::geometry::detail::within::covered_by_point_geometry(const Point&, const Geometry&, const Strategy&) [with Point = boost::geometry::model::point<double, 2, boost::geometry::cs::cartesian>; Geometry = boost::geometry::model::ring<autoware_utils_geometry::Point2d>; Strategy = boost::geometry::strategies::relate::cartesian<>]’ at /usr/include/boost/geometry/algorithms/detail/within/point_in_geometry.hpp:365:29,
    inlined from ‘static bool boost::geometry::detail::covered_by::use_point_in_geometry::apply(const Geometry1&, const Geometry2&, const Strategy&) [with Geometry1 = boost::geometry::model::point<double, 2, boost::geometry::cs::cartesian>; Geometry2 = boost::geometry::model::ring<autoware_utils_geometry::Point2d>; Strategy = boost::geometry::strategies::relate::cartesian<>]’ at /usr/include/boost/geometry/algorithms/detail/covered_by/implementation.hpp:44:57,
    inlined from ‘static bool boost::geometry::resolve_strategy::covered_by<Strategy, IsUmbrella>::apply(const Geometry1&, const Geometry2&, const Strategy&) [with Geometry1 = boost::geometry::model::point<double, 2, boost::geometry::cs::cartesian>; Geometry2 = boost::geometry::model::ring<autoware_utils_geometry::Point2d>; Strategy = boost::geometry::strategies::relate::cartesian<>; bool IsUmbrella = true]’ at /usr/include/boost/geometry/algorithms/detail/covered_by/interface.hpp:74:21,
    inlined from ‘static bool boost::geometry::resolve_dynamic::covered_by<Geometry1, Geometry2, Tag1, Tag2>::apply(const Geometry1&, const Geometry2&, const Strategy&) [with Strategy = boost::geometry::strategies::relate::cartesian<>; Geometry1 = boost::geometry::model::point<double, 2, boost::geometry::cs::cartesian>; Geometry2 = boost::geometry::model::ring<autoware_utils_geometry::Point2d>; Tag1 = boost::geometry::point_tag; Tag2 = boost::geometry::ring_tag]’ at /usr/include/boost/geometry/algorithms/detail/covered_by/interface.hpp:138:21,
    inlined from ‘bool boost::geometry::covered_by(const Geometry1&, const Geometry2&, const Strategy&) [with Geometry1 = model::point<double, 2, cs::cartesian>; Geometry2 = model::ring<autoware_utils_geometry::Point2d>; Strategy = strategies::relate::cartesian<>]’ at /usr/include/boost/geometry/algorithms/detail/covered_by/interface.hpp:256:17,
    inlined from ‘static bool boost::geometry::detail::disjoint::disjoint_no_intersections_policy<Geometry1, Geometry2, Tag1, Tag1OrMulti>::apply(const Geometry1&, const Geometry2&, const Strategy&) [with Strategy = boost::geometry::strategies::relate::cartesian<>; Geometry1 = std::vector<Eigen::Matrix<double, 2, 1>, Eigen::aligned_allocator<Eigen::Matrix<double, 2, 1> > >; Geometry2 = boost::geometry::model::ring<autoware_utils_geometry::Point2d>; Tag1 = boost::geometry::linestring_tag; Tag1OrMulti = boost::geometry::linestring_tag]’ at /usr/include/boost/geometry/algorithms/detail/disjoint/linear_areal.hpp:78:38,
    inlined from ‘static bool boost::geometry::detail::disjoint::disjoint_linear_areal<Geometry1, Geometry2, NoIntersectionsPolicy>::apply(const Geometry1&, const Geometry2&, const Strategy&) [with Strategy = boost::geometry::strategies::relate::cartesian<>; Geometry1 = std::vector<Eigen::Matrix<double, 2, 1>, Eigen::aligned_allocator<Eigen::Matrix<double, 2, 1> > >; Geometry2 = boost::geometry::model::ring<autoware_utils_geometry::Point2d>; NoIntersectionsPolicy = boost::geometry::detail::disjoint::disjoint_no_intersections_policy<std::vector<Eigen::Matrix<double, 2, 1>, Eigen::aligned_allocator<Eigen::Matrix<double, 2, 1> > >, boost::geometry::model::ring<autoware_utils_geometry::Point2d>, boost::geometry::linestring_tag, boost::geometry::linestring_tag>]’ at /usr/include/boost/geometry/algorithms/detail/disjoint/linear_areal.hpp:123:44,
    inlined from ‘static bool boost::geometry::dispatch::disjoint<Geometry1, Geometry2, DimensionCount, Tag1, Tag2, true>::apply(const Geometry1&, const Geometry2&, const Strategy&) [with Strategy = boost::geometry::strategies::relate::cartesian<>; Geometry1 = boost::geometry::model::ring<autoware_utils_geometry::Point2d>; Geometry2 = std::vector<Eigen::Matrix<double, 2, 1>, Eigen::aligned_allocator<Eigen::Matrix<double, 2, 1> > >; long unsigned int DimensionCount = 2; Tag1 = boost::geometry::areal_tag; Tag2 = boost::geometry::linear_tag]’ at /usr/include/boost/geometry/algorithms/dispatch/disjoint.hpp:82:21,
    inlined from ‘static bool boost::geometry::resolve_strategy::disjoint<boost::geometry::default_strategy, false>::apply(const Geometry1&, const Geometry2&, boost::geometry::default_strategy) [with Geometry1 = boost::geometry::model::ring<autoware_utils_geometry::Point2d>; Geometry2 = std::vector<Eigen::Matrix<double, 2, 1>, Eigen::aligned_allocator<Eigen::Matrix<double, 2, 1> > >]’ at /usr/include/boost/geometry/algorithms/detail/disjoint/interface.hpp:97:25,
    inlined from ‘static bool boost::geometry::resolve_dynamic::disjoint<Geometry1, Geometry2, IsDynamic, IsCollection>::apply(const Geometry1&, const Geometry2&, const Strategy&) [with Strategy = boost::geometry::default_strategy; Geometry1 = boost::geometry::model::ring<autoware_utils_geometry::Point2d>; Geometry2 = std::vector<Eigen::Matrix<double, 2, 1>, Eigen::aligned_allocator<Eigen::Matrix<double, 2, 1> > >; bool IsDynamic = false; bool IsCollection = false]’ at /usr/include/boost/geometry/algorithms/detail/disjoint/interface.hpp:129:21,
    inlined from ‘bool boost::geometry::disjoint(const Geometry1&, const Geometry2&) [with Geometry1 = model::ring<autoware_utils_geometry::Point2d>; Geometry2 = std::vector<Eigen::Matrix<double, 2, 1>, Eigen::aligned_allocator<Eigen::Matrix<double, 2, 1> > >]’ at /usr/include/boost/geometry/algorithms/detail/disjoint/interface.hpp:231:21,
    inlined from ‘bool boost::geometry::intersects(const Geometry1&, const Geometry2&) [with Geometry1 = model::ring<autoware_utils_geometry::Point2d>; Geometry2 = std::vector<Eigen::Matrix<double, 2, 1>, Eigen::aligned_allocator<Eigen::Matrix<double, 2, 1> > >]’ at /usr/include/boost/geometry/algorithms/detail/intersects/interface.hpp:108:32,
    inlined from ‘autoware::behavior_path_planner::StaticObstacleAvoidanceModule::is_operator_approval_required(autoware::behavior_path_planner::ShiftedPath&, autoware::behavior_path_planner::DebugData&) const::<lambda(auto:315)> [with auto:315 = bool]’ at /home/mfc/projects/autoware/src/universe/autoware_universe/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/scene.cpp:1589:38:
/usr/include/boost/geometry/util/math.hpp:604:17: error: ‘p.boost::geometry::model::point<double, 2, boost::geometry::cs::cartesian>::m_values[1]’ may be used uninitialized [-Werror=maybe-uninitialized]
  601 |     return detail::equals
      |            ~~~~~~~~~~~~~~
  602 |         <
      |         ~        
  603 |             typename select_most_precise<T1, T2>::type
      |             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  604 |         >::apply(a, b, detail::equals_default_policy());
      |         ~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/boost/geometry/algorithms/detail/disjoint/linear_areal.hpp: In lambda function:
/usr/include/boost/geometry/algorithms/detail/disjoint/linear_areal.hpp:75:52: note: ‘p.boost::geometry::model::point<double, 2, boost::geometry::cs::cartesian>::m_values[1]’ was declared here
   75 |         typename helper_geometry<point_type>::type p;
      |                                                    ^
cc1plus: all warnings being treated as errors
```

### After

- Compiles successfully with GCC 13
- Passes all local tests
- Verified with ROS 2 Jazzy.

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.
