### PR TITLE
fix(compare_map_segmentation): ignore -Warray-bounds

### DIFF
--- a/perception/autoware_compare_map_segmentation/lib/voxel_grid_map_loader.cpp
+++ b/perception/autoware_compare_map_segmentation/lib/voxel_grid_map_loader.cpp
@@ -97,7 +97,11 @@ bool VoxelGridMapLoader::is_close_to_neighbor_voxels(
   const pcl::PointXYZ & point, const double distance_threshold, VoxelGridPointXYZ & voxel,
   pcl::search::Search<pcl::PointXYZ>::Ptr tree)
 {
-  const int index = voxel.getCentroidIndexAt(voxel.getGridCoordinates(point.x, point.y, point.z));
+  const Eigen::Vector3i grid_coordinates = voxel.getGridCoordinates(point.x, point.y, point.z);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Warray-bounds"
+  const int index = voxel.getCentroidIndexAt(grid_coordinates);
+#pragma GCC diagnostic pop
   if (index != -1) {
     return true;
   }
@@ -281,8 +285,13 @@ bool VoxelGridMapLoader::is_in_voxel(
   const double distance_threshold, const FilteredPointCloudPtr & map,
   VoxelGridPointXYZ & voxel) const
 {
-  int voxel_index =
-    voxel.getCentroidIndexAt(voxel.getGridCoordinates(src_point.x, src_point.y, src_point.z));
+  const Eigen::Vector3i grid_coordinates =
+    voxel.getGridCoordinates(src_point.x, src_point.y, src_point.z);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Warray-bounds"
+  const int voxel_index = voxel.getCentroidIndexAt(grid_coordinates);
+#pragma GCC diagnostic pop
+
   if (voxel_index != -1) {  // not empty voxel
     const double dist_x = map->points.at(voxel_index).x - target_point.x;
     const double dist_y = map->points.at(voxel_index).y - target_point.y;

--- a/perception/autoware_compare_map_segmentation/src/voxel_based_approximate_compare_map_filter/node.cpp
+++ b/perception/autoware_compare_map_segmentation/src/voxel_based_approximate_compare_map_filter/node.cpp
@@ -33,8 +33,12 @@ bool VoxelBasedApproximateStaticMapLoader::is_close_to_map(
   if (voxel_map_ptr_ == nullptr) {
     return false;
   }
-  const int index =
-    voxel_grid_.getCentroidIndexAt(voxel_grid_.getGridCoordinates(point.x, point.y, point.z));
+  const Eigen::Vector3i grid_coordinates =
+    voxel_grid_.getGridCoordinates(point.x, point.y, point.z);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Warray-bounds"
+  const int index = voxel_grid_.getCentroidIndexAt(grid_coordinates);
+#pragma GCC diagnostic pop
   if (index == -1) {
     return false;
   } else {


### PR DESCRIPTION
## Description

- Part of: https://github.com/autowarefoundation/autoware_universe/issues/11418

- Same issue and same fix as: https://github.com/autowarefoundation/autoware_universe/pull/11917
  - Check this PR for explanation and solution. It's identical.

## How was this PR tested?

Compiles and passes the tests locally with jazzy.

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.
