### PR TITLE
chore(planning_evaluator): on the worst only

### DIFF
--- a/evaluator/autoware_planning_evaluator/config/planning_evaluator.param.yaml
+++ b/evaluator/autoware_planning_evaluator/config/planning_evaluator.param.yaml
@@ -68,7 +68,7 @@
         max_time_s: 3.0 # [s] maximum time ahead of ego along the trajectory to use for calculation
 
     obstacle: # parameters for obstacle metrics calculation
-      worst_only: false # if true, only the worst obstacle metric value is published
+      worst_only: true # if true, only the worst obstacle metric value is published
       use_ego_traj_vel: false # if true, the planned trajectory velocity is used
       collision_thr_m: 0.0 # [m] distance threshold to consider a collision occurs between object footprints and ego trajectory footprints
       stop_velocity_mps: 0.2777 # [m/s] velocity threshold to consider the object or ego is static, used for speed up the calculation


### PR DESCRIPTION
## Description
Off publishing object-related metrics for each object.

Because this feature caused a node death of `autoware_scenario_simulator_v2_adapter_node` during the CI tests.

We can trigger this feature on the real world tests.


```bash
[openscenario_interpreter_node-3] [component_container_mt-27] [WARN] [1768877460.757628737] [planning.scenario_planning.lane_driving.motion_planning.motion_velocity_planner]: Initializing previous route pointer.. Reset output.
[openscenario_interpreter_node-3] [autoware_scenario_simulator_v2_adapter_node-62] terminate called after throwing an instance of 'rclcpp::exceptions::InvalidTopicNameError'
[openscenario_interpreter_node-3] [autoware_scenario_simulator_v2_adapter_node-62]   what():  Invalid topic name: topic name token must not start with a number:
[openscenario_interpreter_node-3] [autoware_scenario_simulator_v2_adapter_node-62]   '/planning/planning_evaluator/metrics/obstacle_distance/0cbd96a7ef87640ddfdd667cb09d5583'
[openscenario_interpreter_node-3] [autoware_scenario_simulator_v2_adapter_node-62]                                                           ^
[openscenario_interpreter_node-3] [autoware_scenario_simulator_v2_adapter_node-62] 
[openscenario_interpreter_node-3] [logging_node-15] [INFO] [1768877460.819614287] [logging_diag_graph]: The target mode is available now.
[openscenario_interpreter_node-3] [ERROR] [autoware_scenario_simulator_v2_adapter_node-62]: process has died [pid 2559, exit code -6, cmd '/home/autoware/pilot-auto/install/lib/autoware_scenario_simulator_v2_adapter/autoware_scenario_simulator_v2_adapter_node --ros-args -p use_sim_time:=False -p wheel_radius:=0.383 -p wheel_width:=0.235 -p wheel_base:=2.79 -p wheel_tread:=1.64 -p front_overhang:=1.0 -p rear_overhang:=1.1 -p left_overhang:=0.128 -p right_overhang:=0.128 -p vehicle_height:=2.5 -p max_steer_angle:=0.7 -p use_sim_time:=False -p use_sim_time:=False -p use_sim_time:=False -p wheel_radius:=0.383 -p wheel_width:=0.235 -p wheel_base:=2.79 -p wheel_tread:=1.64 -p front_overhang:=1.0 -p rear_overhang:=1.1 -p left_overhang:=0.128 -p right_overhang:=0.128 -p vehicle_height:=2.5 -p max_steer_angle:=0.7 -p use_sim_time:=False -p wheel_radius:=0.383 -p wheel_width:=0.235 -p wheel_base:=2.79 -p wheel_tread:=1.64 -p front_overhang:=1.0 -p rear_overhang:=1.1 -p left_overhang:=0.128 -p right_overhang:=0.128 -p vehicle_height:=2.5 -p max_steer_angle:=0.7 -p use_sim_time:=False -p wheel_radius:=0.383 -p wheel_width:=0.235 -p wheel_base:=2.79 -p wheel_tread:=1.64 -p front_overhang:=1.0 -p rear_overhang:=1.1 -p left_overhang:=0.128 -p right_overhang:=0.128 -p vehicle_height:=2.5 -p max_steer_angle:=0.7 --params-file /tmp/launch_params_gynu_vkb'].
```

## Related links
- Related PR:  https://github.com/autowarefoundation/autoware_universe/pull/11761
- Failed Sample: Failed sample: [F-01-11100_case04_cmn_general](https://evaluation.ci.tier4.jp/evaluation/reports/efe14a68-46cd-5fc6-9043-6df8ddf78d87/tests/1bdc9dcf-bb96-53f2-bd8d-6730d540ee00/f20eb1f9-5613-5cef-b7f5-8cdbd8bdebaf/e561b44b-a895-5d91-ab15-876e3f8d1bb5?project_id=autoware_dev)
- Tier4 internal discussion: https://star4.slack.com/archives/C04HK9T2E0N/p1768882489571889?thread_ts=1768881831.196419&cid=C04HK9T2E0N
## How was this PR tested?
[Evaluator](https://evaluation.tier4.jp/evaluation/reports/8ddc3f94-9abf-56a8-9108-65fc0e1a3852?project_id=autoware_dev)

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
