### PR TITLE
chore(autoware_velodyne_monitor): Remove "fmt" from CMakeLists.txt and package.xml

### DIFF
--- a/system/autoware_velodyne_monitor/CMakeLists.txt
+++ b/system/autoware_velodyne_monitor/CMakeLists.txt
@@ -2,7 +2,6 @@ cmake_minimum_required(VERSION 3.14)
 project(autoware_velodyne_monitor)
 
 find_package(autoware_cmake REQUIRED)
-find_package(fmt)
 autoware_package()
 
 ament_auto_add_library(${PROJECT_NAME} SHARED

--- a/system/autoware_velodyne_monitor/package.xml
+++ b/system/autoware_velodyne_monitor/package.xml
@@ -14,7 +14,6 @@
   <depend>crypto++</depend>
   <depend>diagnostic_msgs</depend>
   <depend>diagnostic_updater</depend>
-  <depend>fmt</depend>
   <depend>libcpprest-dev</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>


### PR DESCRIPTION
## Description
The code related to  `fmt` is removed but the package name is left in the CMakeLists.txt and packages.xml files. 

This PR removes the unnecessary `fmt` from CMakeLists.txt and packages.xml files. 

## Related links

`fmt` code usage is removed at this commit: https://github.com/autowarefoundation/autoware_universe/commit/b3b6b9fb0cd0a5c93ada227a668ce891862803cb#diff-df089b14cae36139e40c79eb8405364d8d65c651c6a71f4f8b799e2a85f23af2

## How was this PR tested?

`colcon build`

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

Should compile faster.
