### PR TITLE
fix(behavior_path_start_planner_module): add missing dependencies to CMakeLists

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/CMakeLists.txt
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/CMakeLists.txt
@@ -18,9 +18,6 @@ ament_auto_add_library(${PROJECT_NAME} SHARED
 )
 
 if(BUILD_TESTING)
-  find_package(ament_lint_auto REQUIRED)
-  ament_lint_auto_find_test_dependencies()
-
   find_package(ament_cmake_ros REQUIRED)
   ament_auto_find_test_dependencies()
 


### PR DESCRIPTION
## Description

- **Part of:** https://github.com/autowarefoundation/autoware_universe/issues/11418

- Similar to: https://github.com/autowarefoundation/autoware_core/blob/646ce7b30b9be1b127df12f4f9676a516a6bfabc/common/autoware_lanelet2_utils/CMakeLists.txt#L71-L84

## How was this PR tested?

### Before

So many linking errors to `autoware_pyplot`.

### After

Compiles successfully with GCC 13 and ROS 2 Jazzy.

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.
