### PR TITLE
fix(planning_validator_rear_collision_checker): use autoware_utils_geometry type

### DIFF
--- a/planning/planning_validator/autoware_planning_validator_rear_collision_checker/src/utils.cpp
+++ b/planning/planning_validator/autoware_planning_validator_rear_collision_checker/src/utils.cpp
@@ -504,14 +504,22 @@ void cut_by_lanelets(const lanelet::ConstLanelets & lanelets, DetectionAreas & d
 {
   const auto combine_lanelet = lanelet::utils::combineLaneletsShape(lanelets);
 
+  const autoware_utils_geometry::Polygon2d combine_lanelet_boost = [&]() {
+    autoware_utils_geometry::Polygon2d poly;
+    boost::geometry::convert(combine_lanelet.polygon2d().basicPolygon(), poly);
+    return poly;
+  }();
+
   for (auto & [original, _] : detection_areas) {
     if (original.empty()) {
       continue;
     }
 
+    autoware_utils_geometry::Polygon2d orig_polygon_boost;
+    boost::geometry::convert(lanelet::utils::to2D(original), orig_polygon_boost);
+
     autoware_utils_geometry::MultiPolygon2d polygons2d;
-    boost::geometry::difference(
-      lanelet::utils::to2D(original), combine_lanelet.polygon2d().basicPolygon(), polygons2d);
+    boost::geometry::difference(orig_polygon_boost, combine_lanelet_boost, polygons2d);
 
     if (polygons2d.empty()) {
       continue;


### PR DESCRIPTION
- **Part of:** https://github.com/autowarefoundation/autoware_universe/issues/11418

Use `autoware_utils_geometry::MultiPolygon2d` instead of `lanelet::BasicPolygons2d` to store the output of `boost::geometry::difference()`.

Otherwise we get these errors:

```bash
   inlined from ‘void boost::geometry::detail::for_each_with_index(Container&, Function) [with Container = std::map<boost::geometry::ring_identifier, overlay::ring_properties<Eigen::Matrix<double, 2, 1>, double>, std::less<boost::geometry::ring_identifier>, std::allocator<std::pair<const boost::geometry::ring_identifier, overlay::ring_properties<Eigen::Matrix<double, 2, 1>, double> > > >; Function = overlay::assign_parents<boost::geometry::overlay_difference, lanelet::BasicPolygon2d, lanelet::BasicPolygon2d, std::deque<lanelet::BasicPolygon2d, std::allocator<lanelet::BasicPolygon2d> >, std::map<boost::geometry::ring_identifier, ring_properties<Eigen::Matrix<double, 2, 1>, double>, std::less<boost::geometry::ring_identifier>, std::allocator<std::pair<const boost::geometry::ring_identifier, ring_properties<Eigen::Matrix<double, 2, 1>, double> > > >, boost::geometry::strategies::relate::cartesian<> >(const lanelet::BasicPolygon2d&, const lanelet::BasicPolygon2d&, const std::deque<lanelet::BasicPolygon2d, std::allocator<lanelet::BasicPolygon2d> >&, std::map<boost::geometry::ring_identifier, ring_properties<Eigen::Matrix<double, 2, 1>, double>, std::less<boost::geometry::ring_identifier>, std::allocator<std::pair<const boost::geometry::ring_identifier, ring_properties<Eigen::Matrix<double, 2, 1>, double> > > >&, const boost::geometry::strategies::relate::cartesian<>&)::<lambda(std::size_t, const auto:159&)>]’ at /usr/include/boost/geometry/util/for_each_with_index.hpp:40:13,
    inlined from ‘void boost::geometry::detail::overlay::assign_parents(const Geometry1&, const Geometry2&, const RingCollection&, RingMap&, const Strategy&) [with boost::geometry::overlay_type OverlayType = boost::geometry::overlay_difference; Geometry1 = lanelet::BasicPolygon2d; Geometry2 = lanelet::BasicPolygon2d; RingCollection = std::deque<lanelet::BasicPolygon2d, std::allocator<lanelet::BasicPolygon2d> >; RingMap = std::map<boost::geometry::ring_identifier, ring_properties<Eigen::Matrix<double, 2, 1>, double>, std::less<boost::geometry::ring_identifier>, std::allocator<std::pair<const boost::geometry::ring_identifier, ring_properties<Eigen::Matrix<double, 2, 1>, double> > > >; Strategy = boost::geometry::strategies::relate::cartesian<>]’ at /usr/include/boost/geometry/algorithms/detail/overlay/assign_parents.hpp:277:28:
/usr/include/eigen3/Eigen/src/Core/PlainObjectBase.h:504:7: error: ‘<unnamed>.boost::geometry::detail::overlay::ring_info_helper<Eigen::Matrix<double, 2, 1, 0, 2, 1>, double>::envelope.boost::geometry::model::box<Eigen::Matrix<double, 2, 1, 0, 2, 1> >::m_min_corner.Eigen::Matrix<double, 2, 1, 0, 2, 1>::<unnamed>.Eigen::PlainObjectBase<Eigen::Matrix<double, 2, 1> >::m_storage’ may be used uninitialized [-Werror=maybe-uninitialized]
  504 |       m_storage = std::move(other.m_storage);
      |       ^~~~~~~~~
```
And many more, these are so complex to read.

## How was this PR tested?

Compiles successfully with GCC 13 and ROS 2 Jazzy.

## Interface changes

None.

## Effects on system behavior

None.
