### PR TITLE
fix(lane_change): validate linestring tag for all path candidates

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/structs/data.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/structs/data.hpp
@@ -247,7 +247,7 @@ struct TransientData
   size_t current_path_seg_idx;   // index of nearest segment to ego along current path
   double current_path_velocity;  // velocity of the current path at the ego position along the path
 
-  std::vector<std::pair<double, double>> inverval_dist_no_lane_change_lines;
+  std::vector<std::pair<double, double>> interval_dist_no_lane_change_lines;
   double lane_change_prepare_duration{0.0};
 
   bool is_ego_near_current_terminal_start{false};

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/utils.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/include/autoware/behavior_path_lane_change_module/utils/utils.hpp
@@ -520,7 +520,7 @@ std::vector<lanelet::ConstLineString3d> get_no_lane_change_lines(
  * @param ego_pose              Current ego vehicle pose used as distance reference point.
  * @return Vector of distance intervals [start, end] representing no-lane-change zones.
  */
-std::vector<std::pair<double, double>> get_inverval_dist_no_lane_change_lines(
+std::vector<std::pair<double, double>> get_interval_dist_no_lane_change_lines(
   const std::vector<lanelet::ConstLineString3d> & no_lane_change_lines,
   const PathWithLaneId & centerline_path, const Pose & ego_pose);
 
@@ -534,7 +534,7 @@ std::vector<std::pair<double, double>> get_inverval_dist_no_lane_change_lines(
  * @return True if the distance point falls within at least one buffered interval, false otherwise.
  */
 bool is_intersecting_no_lane_change_lines(
-  const std::vector<std::pair<double, double>> & inverval_dist_no_lane_change_lines,
+  const std::vector<std::pair<double, double>> & interval_dist_no_lane_change_lines,
   const double expected_intersecting_dist, const double buffer);
 }  // namespace autoware::behavior_path_planner::utils::lane_change
 #endif  // AUTOWARE__BEHAVIOR_PATH_LANE_CHANGE_MODULE__UTILS__UTILS_HPP_

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/scene.cpp
@@ -215,8 +215,8 @@ void NormalLaneChange::update_transient_data(const bool is_approved)
   transient_data.in_turn_direction_lane =
     utils::lane_change::is_within_turn_direction_lanes(ego_lane, transient_data.current_footprint);
 
-  transient_data.inverval_dist_no_lane_change_lines =
-    utils::lane_change::get_inverval_dist_no_lane_change_lines(
+  transient_data.interval_dist_no_lane_change_lines =
+    utils::lane_change::get_interval_dist_no_lane_change_lines(
       common_data_ptr_->no_lane_change_lines, common_data_ptr_->current_lanes_path,
       common_data_ptr_->get_ego_pose());
 
@@ -1312,7 +1312,7 @@ bool NormalLaneChange::get_path_using_path_shifter(
 
     for (const auto & lc_metric : lane_changing_metrics) {
       if (utils::lane_change::is_intersecting_no_lane_change_lines(
-            common_data_ptr_->transient_data.inverval_dist_no_lane_change_lines,
+            common_data_ptr_->transient_data.interval_dist_no_lane_change_lines,
             prep_metric.length + lc_metric.length / 2.0,
             common_data_ptr_->lc_param_ptr->lane_change_finish_judge_buffer)) {
         continue;

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/utils.cpp
@@ -1284,7 +1284,7 @@ std::vector<lanelet::ConstLineString3d> get_no_lane_change_lines(
   return no_lane_change_lines;
 }
 
-std::vector<std::pair<double, double>> get_inverval_dist_no_lane_change_lines(
+std::vector<std::pair<double, double>> get_interval_dist_no_lane_change_lines(
   const std::vector<lanelet::ConstLineString3d> & no_lane_change_lines,
   const PathWithLaneId & centerline_path, const Pose & ego_pose)
 {
@@ -1313,10 +1313,10 @@ std::vector<std::pair<double, double>> get_inverval_dist_no_lane_change_lines(
 }
 
 bool is_intersecting_no_lane_change_lines(
-  const std::vector<std::pair<double, double>> & inverval_dist_no_lane_change_lines,
+  const std::vector<std::pair<double, double>> & interval_dist_no_lane_change_lines,
   const double expected_intersecting_dist, const double buffer)
 {
-  return ranges::any_of(inverval_dist_no_lane_change_lines, [&](const auto & interval) {
+  return ranges::any_of(interval_dist_no_lane_change_lines, [&](const auto & interval) {
     const auto [start, end] = interval;
     return expected_intersecting_dist >= (start - buffer) &&
            expected_intersecting_dist <= (end + buffer);


### PR DESCRIPTION
## Description

Adds `lane_change=no` linestring validation when generating candidate path.

## Related links

**Parent Issue:**

- [TIER IV internal slack inquiry](https://star4.slack.com/archives/C074CCKN35E/p1768550804165509)

## How was this PR tested?

1. Planning Simulator

|Before|After|
|:-:|:-:|
| <video src="https://github.com/user-attachments/assets/b24fa8f5-0dc9-4f9d-a2b3-94eafaf84a46"> | <video src="https://github.com/user-attachments/assets/08e6b000-7da5-441f-8186-ae4beec8086d"> |
| Candidate path crosses lane change prohibited area | Candidate path doesn't cross lane change prohibited area | 

2. TIER IV internal evaluation
[TIER IV Internal Link - ControlDLR Test](https://evaluation.tier4.jp/evaluation/reports/a20bbf98-72ac-5460-aab9-460c8520890e?project_id=prd_jt)
[TIER IV Internal Link - FuncVerification Test](https://evaluation.tier4.jp/evaluation/reports/ee085071-6058-5c2b-9eb5-7217908935b2?project_id=prd_jt)
[TIER IV Internal Link - CommonScenario_Basic Test](https://evaluation.tier4.jp/evaluation/reports/4697efc6-1c8e-50c2-82c3-fac80389efed?project_id=autoware_dev)


## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
