### PR TITLE
fix(smart_mpc_trajectory_follower): python3-torch into exec_depend with condition

### DIFF
--- a/control/autoware_smart_mpc_trajectory_follower/package.xml
+++ b/control/autoware_smart_mpc_trajectory_follower/package.xml
@@ -32,8 +32,8 @@
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
 
-  <exec_depend>ros2launch</exec_depend>
   <exec_depend condition="$ROS_DISTRO == humble">python3-torch</exec_depend>
+  <exec_depend>ros2launch</exec_depend>
 
   <test_depend>ament_cmake_ros</test_depend>
   <test_depend>ament_index_python</test_depend>


### PR DESCRIPTION
- **Part of:** https://github.com/autowarefoundation/autoware_universe/issues/11418
- **ROS Robotics Enhancement Proposal (REP) reference:** https://www.ros.org/reps/rep-0149.html#dependency-tags

Ubuntu 24.04 doesn't have a `sudo apt install python3-torch` package like it did in Ubuntu 22.04.

This is a python dependency so the build is not affected.

This PR at least eliminates the `rosdep install` errors in jazzy.

We should also update the README.md of this package to tell users to go through a complicated `venv` like procedure to hopefully somehow make this work (it is not a fun process).

After jazzy, this package should be made into a standalone package.

## How was this PR tested?

```bash
rosdep install -y --from-paths src --ignore-src --rosdistro $ROS_DISTRO
```
is successful in both jazzy and humble.

I specifically checked and confirmed that the `condition` tag is also functioning.

### Before this PR on jazzy

```
mfc@whale:~/projects/autoware$ rosdep install -y --from-paths src --ignore-src --rosdistro $ROS_DISTRO -r 
/usr/bin/rosdep:6: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
  from pkg_resources import load_entry_point
ERROR: the following packages/stacks could not have their rosdep keys resolved
to system dependencies:
autoware_agnocast_wrapper: Cannot locate rosdep definition for [agnocastlib]
tier4_localization_launch: Cannot locate rosdep definition for [eagleye_rt]
tier4_autoware_api_launch: Cannot locate rosdep definition for [tier4_deprecated_api_adapter]
autoware_cuda_pointcloud_preprocessor: Cannot locate rosdep definition for [agnocastlib]
autoware_ground_segmentation_cuda: Cannot locate rosdep definition for [agnocastlib]
Continuing to install resolvable dependencies...
executing command [sudo -H apt-get install -y python3-torch]
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Package python3-torch is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source

E: Package 'python3-torch' has no installation candidate
ERROR: the following rosdeps failed to install
  apt: command [sudo -H apt-get install -y python3-torch] failed
  apt: Failed to detect successful installation of [python3-torch]
```

## Interface changes

None.

## Effects on system behavior

None.
