### PR TITLE
refactor(topic_state_monitor): simplify timer handling in TopicStateMonitorNode

### DIFF
--- a/system/autoware_topic_state_monitor/src/topic_state_monitor_core.cpp
+++ b/system/autoware_topic_state_monitor/src/topic_state_monitor_core.cpp
@@ -99,11 +99,7 @@ TopicStateMonitorNode::TopicStateMonitorNode(const rclcpp::NodeOptions & node_op
   // Diagnostic Updater
   updater_.setHardwareID("topic_state_monitor");
   updater_.add(node_param_.diag_name, this, &TopicStateMonitorNode::checkTopicStatus);
-
-  // Timer
-  const auto period_ns = rclcpp::Rate(node_param_.update_rate).period();
-  timer_ = rclcpp::create_timer(
-    this, get_clock(), period_ns, std::bind(&TopicStateMonitorNode::onTimer, this));
+  updater_.setPeriod(1.0 / node_param_.update_rate);
 }
 
 rcl_interfaces::msg::SetParametersResult TopicStateMonitorNode::onParameter(
@@ -125,12 +121,6 @@ rcl_interfaces::msg::SetParametersResult TopicStateMonitorNode::onParameter(
   }
 
   return result;
-}
-
-void TopicStateMonitorNode::onTimer()
-{
-  // Publish diagnostics
-  updater_.force_update();
 }
 
 void TopicStateMonitorNode::checkTopicStatus(diagnostic_updater::DiagnosticStatusWrapper & stat)

--- a/system/autoware_topic_state_monitor/src/topic_state_monitor_core.hpp
+++ b/system/autoware_topic_state_monitor/src/topic_state_monitor_core.hpp
@@ -65,10 +65,6 @@ private:
   rclcpp::GenericSubscription::SharedPtr sub_topic_;
   rclcpp::Subscription<tf2_msgs::msg::TFMessage>::SharedPtr sub_transform_;
 
-  // Timer
-  void onTimer();
-  rclcpp::TimerBase::SharedPtr timer_;
-
   // Diagnostic Updater
   diagnostic_updater::Updater updater_;
 


### PR DESCRIPTION
## Description

This PR refactors the timer handling in `TopicStateMonitorNode` to simplify the code by leveraging the built-in functionality of `diagnostic_updater::Updater`.

### Changes

- **Removed manual timer implementation**: Eliminated the custom `rclcpp::TimerBase` and `onTimer()` callback method that was manually calling `updater_.force_update()`
- **Simplified update mechanism**: Replaced the manual timer with `diagnostic_updater::Updater::setPeriod()` method, which directly configures the diagnostic update rate

### Benefits

- Maintains the same functionality while improving code maintainability

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

- [x] Verified that diagnostic messages are properly published to the `/diagnostics` topic
- [x] Verified that the diagnostic message frequency remains unchanged after the refactoring

### Verification of diagnostic message frequency

The diagnostic message frequency was verified using a command-line script to ensure that the refactoring did not change the behavior. The measurement confirmed that the frequency remains at the expected rate (10.0 Hz) as specified by the `update_rate` parameter.

<details>
<summary>Click to expand: Verification command</summary>

```bash
# Measure the diagnostic message frequency for a specific topic state monitor node
# Replace "control_command_control_cmd" with the appropriate diagnostic name if needed

timeout 15 ros2 topic echo /diagnostics --qos-profile services_default 2>/dev/null | \
  awk -v diag="control_command_control_cmd" '
    BEGIN { 
      last_time = 0
      count = 0
      sum = 0
      msg_sec = 0
      msg_nsec = 0
      found_diag = 0
    }
    /^header:/ {
      found_diag = 0
      msg_sec = 0
      msg_nsec = 0
    }
    /^  stamp:/ {
      in_stamp = 1
    }
    in_stamp && /^    sec:/ {
      msg_sec = $2
    }
    in_stamp && /^    nanosec:/ {
      msg_nsec = $2
      in_stamp = 0
    }
    /^  name:/ {
      if ($0 ~ diag) {
        found_diag = 1
      }
    }
    /^---$/ {
      if (found_diag && msg_sec > 0) {
        current_time = msg_sec + msg_nsec / 1e9
        if (last_time > 0) {
          interval = current_time - last_time
          if (interval > 0 && interval < 10) {
            freq = 1.0 / interval
            count++
            sum += interval
            printf "[%2d] Period: %.3f sec (%.2f Hz)\n", count, interval, freq
          }
        }
        last_time = current_time
      }
    }
    END {
      if (count > 0) {
        printf "\n=== Statistics ===\n"
        printf "Measurement count: %d\n", count
        printf "Average period: %.3f sec\n", sum / count
        printf "Average frequency: %.2f Hz\n", 1.0 / (sum / count)
      } else {
        printf "Diagnostic message not found\n"
      }
    }
  '
```

</details>

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

No functional changes. The diagnostic messages continue to be published at the same rate specified by `node_param_.update_rate`, but now using the `diagnostic_updater`'s internal timer mechanism instead of a manually managed timer.
