### PR TITLE
fix(bevfusion): suppress -Werror for precomputed_features.cpp

### DIFF
--- a/perception/autoware_bevfusion/lib/preprocess/precomputed_features.cpp
+++ b/perception/autoware_bevfusion/lib/preprocess/precomputed_features.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// See https://github.com/autowarefoundation/autoware_universe/pull/11959 for details.
 #pragma GCC diagnostic ignored "-Warray-bounds"
 
 #include "autoware/bevfusion/preprocess/precomputed_features.hpp"


### PR DESCRIPTION
## Description

- Part of: https://github.com/autowarefoundation/autoware_universe/issues/11418

This was compiling before but somehow started giving these errors after:
- https://github.com/autowarefoundation/autoware_universe/pull/11887
- https://github.com/autowarefoundation/autoware_universe/pull/11953
- Or maybe any of the cuda related dependency PRs

Anyway this PR just disables that warning for this single file.

I tried to fix it too but it has gotten too complex. I will leave that to future.

## How was this PR tested?

### Before

Full error logs: https://gist.github.com/xmfcx/d872d111014a239714e28c8b2f454bbb

### After

Compiles with Jazzy & GCC 13.

## Interface changes

None.

## Effects on system behavior

None.
