### PR TITLE
feat(BEVFusion): move cuda stream creation to the beginning of BEVFusionTRT initialization

### DIFF
--- a/perception/autoware_bevfusion/lib/bevfusion_trt.cpp
+++ b/perception/autoware_bevfusion/lib/bevfusion_trt.cpp
@@ -49,7 +49,6 @@ BEVFusionTRT::BEVFusionTRT(
   for (std::int64_t i = 0; i < config_.num_cameras_; i++) {
     CHECK_CUDA_ERROR(cudaStreamCreate(&camera_streams_[i]));
   }
-
   vg_ptr_ = std::make_unique<VoxelGenerator>(densification_param, config_, stream_);
 
   stop_watch_ptr_ =


### PR DESCRIPTION
## Description
This PR moves cuda stream creation to the beginning of BEVFusionTRT initialization to avoid possible null pointers in cuda sream.

## How was this PR tested?
- Tested local 

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.
