### PR TITLE
feat(TransFusion): move cuda stream init before init and cleaning point_d buffer

### DIFF
--- a/perception/autoware_lidar_transfusion/lib/transfusion_trt.cpp
+++ b/perception/autoware_lidar_transfusion/lib/transfusion_trt.cpp
@@ -40,7 +40,6 @@ TransfusionTRT::TransfusionTRT(
 : config_(std::move(config))
 {
   CHECK_CUDA_ERROR(cudaStreamCreate(&stream_));
-
   vg_ptr_ = std::make_unique<VoxelGenerator>(densification_param, config_, stream_);
   stop_watch_ptr_ = std::make_unique<autoware_utils::StopWatch<std::chrono::milliseconds>>();
   stop_watch_ptr_->tic("processing/inner");


### PR DESCRIPTION
## Description
This PR moves cuda stream creation before any initialization in TransFusion. To make it safer, it also cleans buffer of `points_d` in preprocessing. 

## How was this PR tested?
- Tested by local. 

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.
