### PR TITLE
fix(manual_lane_change_handler): remove unusedVariable

### DIFF
--- a/planning/autoware_manual_lane_change_handler/src/manual_lane_change_handler.cpp
+++ b/planning/autoware_manual_lane_change_handler/src/manual_lane_change_handler.cpp
@@ -213,7 +213,6 @@ LaneChangeRequestResult ManualLaneChangeHandler::process_lane_change_request(
     : req->lane_change_direction == SetPreferredLane::Request::RIGHT ? DIRECTION::MANUAL_RIGHT
                                                                      : DIRECTION::AUTO;
   if (override_direction == DIRECTION::AUTO) {
-    std::vector<autoware_planning_msgs::msg::LaneletPrimitive> preferred_primitives;
     shift_number_ = 0;
 
     autoware_internal_debug_msgs::msg::Int32Stamped shift_msg;


### PR DESCRIPTION
## Description

Removed an unsed variable 
```
planning/autoware_manual_lane_change_handler/src/manual_lane_change_handler.cpp:216:64: style: Unused variable: preferred_primitives [unusedVariable]
    std::vector<autoware_planning_msgs::msg::LaneletPrimitive> preferred_primitives;
                                                               ^
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
