### PR TITLE
fix(manual_lane_change_handler): remove unreadVariable

### DIFF
--- a/planning/autoware_manual_lane_change_handler/src/manual_lane_change_handler.cpp
+++ b/planning/autoware_manual_lane_change_handler/src/manual_lane_change_handler.cpp
@@ -294,9 +294,6 @@ LaneChangeRequestResult ManualLaneChangeHandler::process_lane_change_request(
 
     std::size_t current_index = std::distance(current_segment.primitives.begin(), current_it);
 
-    const auto current_lanelet = get_lanelet_by_id(current_it->id);
-    std::string current_turning_dir = current_lanelet.attributeOr("turn_direction", "none");
-
     const auto next_lanelet = get_lanelet_by_id(next_it->id);
     std::string next_turning_dir = next_lanelet.attributeOr("turn_direction", "none");
 


### PR DESCRIPTION
## Description

Removed an unread variable
```
planning/autoware_manual_lane_change_handler/src/manual_lane_change_handler.cpp:298:17: style: Variable 'current_turning_dir' is assigned a value that is never used. [unreadVariable]
    std::string current_turning_dir = current_lanelet.attributeOr("turn_direction", "none");
                ^
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
