### PR TITLE
fix(occupancy_grid_map_outlier_filter): fix funcArgNamesDifferent

### DIFF
--- a/perception/autoware_occupancy_grid_map_outlier_filter/src/occupancy_grid_map_outlier_filter_node.hpp
+++ b/perception/autoware_occupancy_grid_map_outlier_filter/src/occupancy_grid_map_outlier_filter_node.hpp
@@ -55,8 +55,8 @@ public:
   void filter(
     const PointCloud2 & input, const Pose & pose, PointCloud2 & output, PointCloud2 & outlier);
   void filter(
-    const PointCloud2 & high_conf_input, const PointCloud2 & low_conf_input, const Pose & pose,
-    PointCloud2 & output, PointCloud2 & outlier);
+    const PointCloud2 & high_conf_xyz_cloud, const PointCloud2 & low_conf_xyz_cloud,
+    const Pose & pose, PointCloud2 & output, PointCloud2 & outlier);
 
 private:
   float search_radius_;


### PR DESCRIPTION
## Description

Fixed `funcArgNamesDifferent`
```
perception/autoware_occupancy_grid_map_outlier_filter/src/occupancy_grid_map_outlier_filter_node.cpp:163:23: style: inconclusive: Function 'filter' argument 1 names different: declaration 'high_conf_input' definition 'high_conf_xyz_cloud'. [funcArgNamesDifferent]
  const PointCloud2 & high_conf_xyz_cloud, const PointCloud2 & low_conf_xyz_cloud,
                      ^
perception/autoware_occupancy_grid_map_outlier_filter/src/occupancy_grid_map_outlier_filter_node.hpp:58:25: note: Function 'filter' argument 1 names different: declaration 'high_conf_input' definition 'high_conf_xyz_cloud'.
    const PointCloud2 & high_conf_input, const PointCloud2 & low_conf_input, const Pose & pose,
                        ^
perception/autoware_occupancy_grid_map_outlier_filter/src/occupancy_grid_map_outlier_filter_node.cpp:163:23: note: Function 'filter' argument 1 names different: declaration 'high_conf_input' definition 'high_conf_xyz_cloud'.
  const PointCloud2 & high_conf_xyz_cloud, const PointCloud2 & low_conf_xyz_cloud,
                      ^
perception/autoware_occupancy_grid_map_outlier_filter/src/occupancy_grid_map_outlier_filter_node.cpp:163:64: style: inconclusive: Function 'filter' argument 2 names different: declaration 'low_conf_input' definition 'low_conf_xyz_cloud'. [funcArgNamesDifferent]
  const PointCloud2 & high_conf_xyz_cloud, const PointCloud2 & low_conf_xyz_cloud,
                                                               ^
perception/autoware_occupancy_grid_map_outlier_filter/src/occupancy_grid_map_outlier_filter_node.hpp:58:62: note: Function 'filter' argument 2 names different: declaration 'low_conf_input' definition 'low_conf_xyz_cloud'.
    const PointCloud2 & high_conf_input, const PointCloud2 & low_conf_input, const Pose & pose,
                                                             ^
perception/autoware_occupancy_grid_map_outlier_filter/src/occupancy_grid_map_outlier_filter_node.cpp:163:64: note: Function 'filter' argument 2 names different: declaration 'low_conf_input' definition 'low_conf_xyz_cloud'.
  const PointCloud2 & high_conf_xyz_cloud, const PointCloud2 & low_conf_xyz_cloud,
                                                               ^
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
