### PR TITLE
fix(occupancy_grid_map_outlier_filter): fix funcArgNamesDifferent

### DIFF
--- a/perception/autoware_occupancy_grid_map_outlier_filter/src/occupancy_grid_map_outlier_filter_node.hpp
+++ b/perception/autoware_occupancy_grid_map_outlier_filter/src/occupancy_grid_map_outlier_filter_node.hpp
@@ -74,8 +74,7 @@ public:
 
 private:
   void onOccupancyGridMapAndPointCloud2(
-    const OccupancyGrid::ConstSharedPtr & input_occupancy_grid_map,
-    const PointCloud2::ConstSharedPtr & input_pointcloud);
+    const OccupancyGrid::ConstSharedPtr & input_ogm, const PointCloud2::ConstSharedPtr & input_pc);
   void filterByOccupancyGridMap(
     const OccupancyGrid & occupancy_grid_map, const PointCloud2 & pointcloud,
     PointCloud2 & high_confidence, PointCloud2 & low_confidence, PointCloud2 & out_ogm);


### PR DESCRIPTION
## Description

Fixed `funcArgNamesDifferent`
```
perception/autoware_occupancy_grid_map_outlier_filter/src/occupancy_grid_map_outlier_filter_node.cpp:315:41: style: inconclusive: Function 'onOccupancyGridMapAndPointCloud2' argument 1 names different: declaration 'input_occupancy_grid_map' definition 'input_ogm'. [funcArgNamesDifferent]
  const OccupancyGrid::ConstSharedPtr & input_ogm, const PointCloud2::ConstSharedPtr & input_pc)
                                        ^
perception/autoware_occupancy_grid_map_outlier_filter/src/occupancy_grid_map_outlier_filter_node.hpp:77:43: note: Function 'onOccupancyGridMapAndPointCloud2' argument 1 names different: declaration 'input_occupancy_grid_map' definition 'input_ogm'.
    const OccupancyGrid::ConstSharedPtr & input_occupancy_grid_map,
                                          ^
perception/autoware_occupancy_grid_map_outlier_filter/src/occupancy_grid_map_outlier_filter_node.cpp:315:41: note: Function 'onOccupancyGridMapAndPointCloud2' argument 1 names different: declaration 'input_occupancy_grid_map' definition 'input_ogm'.
  const OccupancyGrid::ConstSharedPtr & input_ogm, const PointCloud2::ConstSharedPtr & input_pc)
                                        ^
perception/autoware_occupancy_grid_map_outlier_filter/src/occupancy_grid_map_outlier_filter_node.cpp:315:88: style: inconclusive: Function 'onOccupancyGridMapAndPointCloud2' argument 2 names different: declaration 'input_pointcloud' definition 'input_pc'. [funcArgNamesDifferent]
  const OccupancyGrid::ConstSharedPtr & input_ogm, const PointCloud2::ConstSharedPtr & input_pc)
                                                                                       ^
perception/autoware_occupancy_grid_map_outlier_filter/src/occupancy_grid_map_outlier_filter_node.hpp:78:41: note: Function 'onOccupancyGridMapAndPointCloud2' argument 2 names different: declaration 'input_pointcloud' definition 'input_pc'.
    const PointCloud2::ConstSharedPtr & input_pointcloud);
                                        ^
perception/autoware_occupancy_grid_map_outlier_filter/src/occupancy_grid_map_outlier_filter_node.cpp:315:88: note: Function 'onOccupancyGridMapAndPointCloud2' argument 2 names different: declaration 'input_pointcloud' definition 'input_pc'.
  const OccupancyGrid::ConstSharedPtr & input_ogm, const PointCloud2::ConstSharedPtr & input_pc)
                                                                                       ^
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
