### PR TITLE
refactor(evaluator): migrate deprecated getClosestLanelet()

### DIFF
--- a/evaluator/autoware_control_evaluator/package.xml
+++ b/evaluator/autoware_control_evaluator/package.xml
@@ -18,6 +18,7 @@
 
   <depend>autoware_boundary_departure_checker</depend>
   <depend>autoware_internal_planning_msgs</depend>
+  <depend>autoware_lanelet2_utils</depend>
   <depend>autoware_motion_utils</depend>
   <depend>autoware_perception_msgs</depend>
   <depend>autoware_planning_factor_interface</depend>

--- a/evaluator/autoware_control_evaluator/src/control_evaluator_node.cpp
+++ b/evaluator/autoware_control_evaluator/src/control_evaluator_node.cpp
@@ -18,7 +18,7 @@
 
 #include <autoware/boundary_departure_checker/conversion.hpp>
 #include <autoware/boundary_departure_checker/utils.hpp>
-#include <autoware_lanelet2_extension/utility/query.hpp>
+#include <autoware/lanelet2_utils/nn_search.hpp>
 #include <autoware_lanelet2_extension/utility/utilities.hpp>
 #include <autoware_utils/geometry/boost_polygon_utils.hpp>
 #include <autoware_utils/geometry/geometry.hpp>
@@ -224,8 +224,12 @@ void ControlEvaluatorNode::AddLaneletInfoMsg(const Pose & ego_pose)
 {
   const auto current_lanelets = metrics::utils::get_current_lanes(route_handler_, ego_pose);
   const auto arc_coordinates = lanelet::utils::getArcCoordinates(current_lanelets, ego_pose);
-  lanelet::ConstLanelet current_lane;
-  lanelet::utils::query::getClosestLanelet(current_lanelets, ego_pose, &current_lane);
+  const auto current_lane_opt =
+    autoware::experimental::lanelet2_utils::get_closest_lanelet(current_lanelets, ego_pose);
+  if (!current_lane_opt) {
+    return;
+  }
+  const auto & current_lane = current_lane_opt.value();
 
   const std::string base_name = "ego_lane_info/";
   MetricMsg metric_msg;
@@ -253,8 +257,6 @@ void ControlEvaluatorNode::AddBoundaryDistanceMetricMsg(
   const PathWithLaneId & behavior_path, const Pose & ego_pose)
 {
   const auto current_lanelets = metrics::utils::get_current_lanes(route_handler_, ego_pose);
-  lanelet::ConstLanelet current_lane;
-  lanelet::utils::query::getClosestLanelet(current_lanelets, ego_pose, &current_lane);
   const auto local_vehicle_footprint = vehicle_info_.createFootprint();
   const auto current_vehicle_footprint = autoware_utils::transform_vector(
     local_vehicle_footprint, autoware_utils::pose2transform(ego_pose));

--- a/evaluator/autoware_planning_evaluator/src/planning_evaluator_node.cpp
+++ b/evaluator/autoware_planning_evaluator/src/planning_evaluator_node.cpp
@@ -17,7 +17,7 @@
 #include "autoware/planning_evaluator/metrics/metric.hpp"
 #include "autoware/planning_evaluator/metrics/output_metric.hpp"
 
-#include <autoware_lanelet2_extension/utility/query.hpp>
+#include <autoware/lanelet2_utils/nn_search.hpp>
 #include <autoware_lanelet2_extension/utility/utilities.hpp>
 #include <autoware_utils/geometry/geometry.hpp>
 #include <nlohmann/json.hpp>
@@ -225,8 +225,12 @@ void PlanningEvaluatorNode::AddLaneletMetricMsg(const Odometry::ConstSharedPtr e
     return closest_lanelets;
   }();
   const auto arc_coordinates = lanelet::utils::getArcCoordinates(current_lanelets, ego_pose);
-  lanelet::ConstLanelet current_lane;
-  lanelet::utils::query::getClosestLanelet(current_lanelets, ego_pose, &current_lane);
+  const auto current_lane_opt =
+    autoware::experimental::lanelet2_utils::get_closest_lanelet(current_lanelets, ego_pose);
+  if (!current_lane_opt) {
+    return;
+  }
+  const auto & current_lane = current_lane_opt.value();
 
   // push_back lanelet info to MetricArrayMsg
   const std::string base_name = "ego_lane_info/";


### PR DESCRIPTION
## Description

`getClosestLanelet` will be deprecated in lanelet2_extension package. It will be replaced by `get_closest_lanelet` function in lanelet2_utils package which is well tested

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
