### PR TITLE
refactor(start_planner): replace getClosesetLanelet, fix undefined behavior for default-initialized Lanelet

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/clothoid_pull_out.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/clothoid_pull_out.cpp
@@ -28,8 +28,8 @@
 #include "autoware_utils/geometry/boost_polygon_utils.hpp"
 
 #include <autoware/interpolation/linear_interpolation.hpp>
+#include <autoware/lanelet2_utils/nn_search.hpp>
 #include <autoware/motion_utils/trajectory/path_shift.hpp>
-#include <autoware_lanelet2_extension/utility/query.hpp>
 #include <autoware_lanelet2_extension/utility/utilities.hpp>
 #include <autoware_utils/geometry/geometry.hpp>
 #include <autoware_utils/math/unit_conversion.hpp>
@@ -502,10 +502,12 @@ std::optional<PathWithLaneId> create_path_with_lane_id_from_clothoid_paths(
     if (!search_lanes.empty()) {
       // Find closest lanelet
       lanelet::Lanelet closest_lanelet;
-      if (lanelet::utils::query::getClosestLanelet(
-            search_lanes, path_point.point.pose, &closest_lanelet)) {
+      if (
+        const auto closest_lanelet_opt =
+          autoware::experimental::lanelet2_utils::get_closest_lanelet(
+            search_lanes, path_point.point.pose)) {
         // Get z value of closest point from lanelet centerline
-        const auto centerline = closest_lanelet.centerline();
+        const auto centerline = closest_lanelet_opt.value().centerline();
         if (!centerline.empty()) {
           double min_distance = std::numeric_limits<double>::max();
           double closest_z = all_clothoid_points[i].z;  // Default is original z value

--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/util.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/util.cpp
@@ -19,8 +19,8 @@
 #include "autoware/behavior_path_planner_common/utils/utils.hpp"
 #include "autoware/universe_utils/math/normalization.hpp"
 
+#include <autoware/lanelet2_utils/nn_search.hpp>
 #include <autoware/motion_utils/trajectory/path_with_lane_id.hpp>
-#include <autoware_lanelet2_extension/utility/query.hpp>
 #include <autoware_lanelet2_extension/utility/utilities.hpp>
 #include <autoware_utils/geometry/boost_geometry.hpp>
 #include <autoware_utils/math/unit_conversion.hpp>
@@ -240,9 +240,10 @@ std::vector<int64_t> get_lane_ids_from_pose(
   // 2. Fallback processing when no containing lane is found
   if (!found_containing_lane) {
     // 2.1 Find the closest lane
-    lanelet::Lanelet closest_lanelet{};
-    if (lanelet::utils::query::getClosestLanelet(candidate_lanes, pose, &closest_lanelet)) {
-      lane_ids = {closest_lanelet.id()};
+    if (
+      const auto closest_lanelet_opt =
+        autoware::experimental::lanelet2_utils::get_closest_lanelet(candidate_lanes, pose)) {
+      lane_ids = {closest_lanelet_opt.value().id()};
     } else if (!previous_lane_ids.empty()) {
       // 2.2 If closest lane is not found, inherit lane_ids from previous point
       lane_ids = previous_lane_ids;


### PR DESCRIPTION
## Description

lanelet::utils::query::getClosestLanelet would be deprecated, and lanelet2_utils::get_closest_lanelet will be used instead

lanelet2_extension function would be deprecated after this PR


## Related links

https://github.com/autowarefoundation/autoware_core/pull/796

## How was this PR tested?

[Evaluator](https://evaluation.tier4.jp/evaluation/reports/b0143835-be12-5288-945f-4c4aacce4981?project_id=autoware_dev)

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
