### PR TITLE
refactor(goal_planner): replace getClosesetLanelet, fix undefined behavior for default-initialized Lanelet

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/pull_over_planner/shift_pull_over.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/pull_over_planner/shift_pull_over.cpp
@@ -18,6 +18,7 @@
 #include "autoware/behavior_path_planner_common/utils/drivable_area_expansion/static_drivable_area.hpp"
 #include "autoware/behavior_path_planner_common/utils/path_utils.hpp"
 
+#include <autoware/lanelet2_utils/nn_search.hpp>
 #include <autoware/motion_utils/trajectory/path_shift.hpp>
 #include <autoware_lanelet2_extension/utility/query.hpp>
 #include <autoware_lanelet2_extension/utility/utilities.hpp>
@@ -213,9 +214,10 @@ std::optional<PullOverPath> ShiftPullOver::generatePullOverPath(
     PathPointWithLaneId p{};
     p.point.longitudinal_velocity_mps = 0.0;
     p.point.pose = goal_pose;
-    lanelet::Lanelet goal_lanelet{};
-    if (lanelet::utils::query::getClosestLanelet(lanes, goal_pose, &goal_lanelet)) {
-      p.lane_ids = {goal_lanelet.id()};
+    const auto goal_lanelet_opt =
+      autoware::experimental::lanelet2_utils::get_closest_lanelet(lanes, goal_pose);
+    if (goal_lanelet_opt) {
+      p.lane_ids = {goal_lanelet_opt.value().id()};
     } else {
       p.lane_ids = shifted_path.path.points.back().lane_ids;
     }
@@ -231,9 +233,10 @@ std::optional<PullOverPath> ShiftPullOver::generatePullOverPath(
     auto & point = shifted_path.path.points.at(i);
     point.point.longitudinal_velocity_mps =
       std::min(point.point.longitudinal_velocity_mps, static_cast<float>(pull_over_velocity));
-    lanelet::Lanelet lanelet{};
-    if (lanelet::utils::query::getClosestLanelet(lanes, point.point.pose, &lanelet)) {
-      point.lane_ids = {lanelet.id()};  // overwrite lane_ids
+    const auto lanelet_opt =
+      autoware::experimental::lanelet2_utils::get_closest_lanelet(lanes, point.point.pose);
+    if (lanelet_opt) {
+      point.lane_ids = {lanelet_opt.value().id()};  // overwrite lane_ids
     } else if (i > 0) {
       point.lane_ids = shifted_path.path.points.at(i - 1).lane_ids;
     }

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/util.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/util.cpp
@@ -21,6 +21,7 @@
 
 #include <Eigen/Core>
 #include <autoware/lanelet2_utils/geometry.hpp>
+#include <autoware/lanelet2_utils/nn_search.hpp>
 #include <autoware_lanelet2_extension/utility/message_conversion.hpp>
 #include <autoware_lanelet2_extension/utility/query.hpp>
 #include <autoware_lanelet2_extension/utility/utilities.hpp>
@@ -210,8 +211,14 @@ static double getOffsetToLanesBoundary(
   const lanelet::ConstLanelets & lanelet_sequence, const geometry_msgs::msg::Pose target_pose,
   const bool left_side)
 {
-  lanelet::ConstLanelet closest_lanelet;
-  lanelet::utils::query::getClosestLanelet(lanelet_sequence, target_pose, &closest_lanelet);
+  const auto closest_lanelet_opt =
+    autoware::experimental::lanelet2_utils::get_closest_lanelet(lanelet_sequence, target_pose);
+  if (!closest_lanelet_opt) {
+    throw std::runtime_error(
+      "erroneous implementation in getOffsetToLanesBoundary, closest_lanelet_opt is "
+      "not handled");
+  }
+  const auto & closest_lanelet = closest_lanelet_opt.value();
 
   // the boundary closer to ego. if left_side, take right boundary
   const auto & boundary3d = left_side ? closest_lanelet.rightBound() : closest_lanelet.leftBound();
@@ -887,8 +894,14 @@ std::optional<Pose> calcRefinedGoal(
     return {};
   }
 
-  lanelet::Lanelet closest_pull_over_lanelet{};
-  lanelet::utils::query::getClosestLanelet(pull_over_lanes, goal_pose, &closest_pull_over_lanelet);
+  const auto closest_pull_over_lanelet_opt =
+    autoware::experimental::lanelet2_utils::get_closest_lanelet(pull_over_lanes, goal_pose);
+  if (!closest_pull_over_lanelet_opt) {
+    throw std::runtime_error(
+      "erroneous implementation in calcRefinedGoal, closest_lanelet_opt is "
+      "not handled");
+  }
+  const auto & closest_pull_over_lanelet = closest_pull_over_lanelet_opt.value();
 
   // calc closest center line pose
   Pose center_pose{};


### PR DESCRIPTION
## Description

lanelet::utils::query::getClosestLanelet would be deprecated, and lanelet2_utils::get_closest_lanelet will be used instead

lanelet2_extension function would be deprecated after this PR

## Related links

https://github.com/autowarefoundation/autoware_core/pull/796
https://github.com/autowarefoundation/autoware_universe/pull/11990

## How was this PR tested?

- [CommonScenarioBasic](https://evaluation.tier4.jp/evaluation/reports/fc87e134-33c9-54bb-96dd-98a17ad0ee1a?project_id=autoware_dev)
- [FuncVerification](https://evaluation.tier4.jp/evaluation/reports/e91225ef-3349-59ea-adeb-856c9a46d6d3?project_id=prd_jt)
- [DLR](https://evaluation.tier4.jp/evaluation/reports/a0ab1961-ef6b-5f27-94af-1f0e58e09799?project_id=prd_jt)

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
