### PR TITLE
feat(dummy_perception publisher): use object z as baselink coordinates

### DIFF
--- a/simulator/autoware_dummy_perception_publisher/src/node.cpp
+++ b/simulator/autoware_dummy_perception_publisher/src/node.cpp
@@ -336,7 +336,7 @@ void DummyPerceptionPublisherNode::objectCallback(
       try {
         ros_map2base_link = tf_buffer_.lookupTransform(
           "map", "base_link", rclcpp::Time(0), rclcpp::Duration::from_seconds(0.5));
-        object.initial_state.pose_covariance.pose.position.z =
+        object.initial_state.pose_covariance.pose.position.z +=
           ros_map2base_link.transform.translation.z + 0.5 * object.shape.dimensions.z;
       } catch (tf2::TransformException & ex) {
         RCLCPP_WARN_SKIPFIRST_THROTTLE(get_logger(), *get_clock(), 5000, "%s", ex.what());


### PR DESCRIPTION
## Description
Currently, the object spawn position is fixed to the ego vehicle's height, and the Z position set in RViz is ignored.
This update changes the behavior to interpret the Z position set in RViz as the height relative to the base_link frame.
Note that this has no impact on behavior when the base_link relative height is not used.

## Related links
Should be merged after the launch PR is merged.
https://github.com/autowarefoundation/autoware_launch/pull/1739

## How was this PR tested?
Before
<img width="2296" height="1060" alt="image" src="https://github.com/user-attachments/assets/3f13aeb6-9dc4-4575-ac53-69d5ea77d1e3" />


After
<img width="2224" height="1982" alt="image" src="https://github.com/user-attachments/assets/42501d81-003f-40ad-86ef-333cd283ec11" />



## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.
