### PR TITLE
feat(lidar_marker_localizer): add pcd input validator to lidar marker localizer

### DIFF
--- a/localization/autoware_landmark_based_localizer/autoware_landmark_manager/include/autoware/landmark_manager/landmark_manager.hpp
+++ b/localization/autoware_landmark_based_localizer/autoware_landmark_manager/include/autoware/landmark_manager/landmark_manager.hpp
@@ -43,6 +43,9 @@ public:
   void parse_landmarks(
     const autoware_map_msgs::msg::LaneletMapBin::ConstSharedPtr & msg,
     const std::string & target_subtype);
+  void parse_landmarks(
+    const autoware_map_msgs::msg::LaneletMapBin::ConstSharedPtr & msg,
+    const std::string & target_subtype, const std::vector<std::string> target_ids);
 
   [[nodiscard]] std::vector<landmark_manager::Landmark> get_landmarks() const;
 

--- a/localization/autoware_landmark_based_localizer/autoware_landmark_manager/src/landmark_manager.cpp
+++ b/localization/autoware_landmark_based_localizer/autoware_landmark_manager/src/landmark_manager.cpp
@@ -53,11 +53,6 @@ void LandmarkManager::parse_landmarks(
     const auto & v1 = vertices[1];
     const auto & v2 = vertices[2];
     const auto & v3 = vertices[3];
-    // const double volume = (v1 - v0).cross(v2 - v0).dot(v3 - v0) / 6.0;
-    // const double volume_threshold = 1e-3;
-    // if (volume > volume_threshold) {
-    //   continue;
-    // }
 
     // Calculate the center of the quadrilateral
     const auto center = (v0 + v1 + v2 + v3) / 4.0;
@@ -114,11 +109,6 @@ void LandmarkManager::parse_landmarks(
     const auto & v1 = vertices[1];
     const auto & v2 = vertices[2];
     const auto & v3 = vertices[3];
-    // const double volume = (v1 - v0).cross(v2 - v0).dot(v3 - v0) / 6.0;
-    // const double volume_threshold = 1e-3;
-    // if (volume > volume_threshold) {
-    //   continue;
-    // }
 
     // Calculate the center of the quadrilateral
     const auto center = (v0 + v1 + v2 + v3) / 4.0;
@@ -227,11 +217,6 @@ geometry_msgs::msg::Pose LandmarkManager::calculate_new_self_pose(
     // convert base_link to map
     const Pose detected_landmark_on_map =
       autoware_utils_geometry::transform_pose(detected_landmark_on_base_link, self_pose);
-
-    // match to map
-    // if (landmarks_map_.count(landmark.id) == 0) {
-    //   continue;
-    // }
 
     // check all poses
     // for (const Pose mapped_landmark_on_map : landmarks_map_.at(landmark.id)) {

--- a/localization/autoware_landmark_based_localizer/autoware_landmark_manager/src/landmark_manager.cpp
+++ b/localization/autoware_landmark_based_localizer/autoware_landmark_manager/src/landmark_manager.cpp
@@ -53,11 +53,72 @@ void LandmarkManager::parse_landmarks(
     const auto & v1 = vertices[1];
     const auto & v2 = vertices[2];
     const auto & v3 = vertices[3];
-    const double volume = (v1 - v0).cross(v2 - v0).dot(v3 - v0) / 6.0;
-    const double volume_threshold = 1e-3;
-    if (volume > volume_threshold) {
+    // const double volume = (v1 - v0).cross(v2 - v0).dot(v3 - v0) / 6.0;
+    // const double volume_threshold = 1e-3;
+    // if (volume > volume_threshold) {
+    //   continue;
+    // }
+
+    // Calculate the center of the quadrilateral
+    const auto center = (v0 + v1 + v2 + v3) / 4.0;
+
+    // Define axes
+    const auto x_axis = (v1 - v0).normalized();
+    const auto y_axis = (v2 - v1).normalized();
+    const auto z_axis = x_axis.cross(y_axis).normalized();
+
+    // Construct rotation matrix and convert it to quaternion
+    Eigen::Matrix3d rotation_matrix;
+    rotation_matrix << x_axis, y_axis, z_axis;
+    const Eigen::Quaterniond q{rotation_matrix};
+
+    // Create Pose
+    geometry_msgs::msg::Pose pose;
+    pose.position.x = center.x();
+    pose.position.y = center.y();
+    pose.position.z = center.z();
+    pose.orientation.x = q.x();
+    pose.orientation.y = q.y();
+    pose.orientation.z = q.z();
+    pose.orientation.w = q.w();
+
+    // Add
+    landmarks_map_[landmark_id].push_back(pose);
+  }
+}
+
+void LandmarkManager::parse_landmarks(
+  const autoware_map_msgs::msg::LaneletMapBin::ConstSharedPtr & msg,
+  const std::string & target_subtype, const std::vector<std::string> target_ids)
+{
+  std::vector<lanelet::Polygon3d> landmarks =
+    lanelet::localization::parseLandmarkPolygons(msg, target_subtype);
+  for (const lanelet::Polygon3d & poly : landmarks) {
+    // Get landmark_id
+    const std::string landmark_id = poly.attributeOr("marker_id", "none");
+
+    auto find_it = std::find(std::begin(target_ids), std::end(target_ids), landmark_id);
+    if (find_it == std::end(target_ids)) {
       continue;
     }
+
+    // Get 4 vertices
+    const auto & vertices = poly.basicPolygon();
+    if (vertices.size() != 4) {
+      continue;
+    }
+
+    // 4 vertices represent the landmark vertices in counterclockwise order
+    // Calculate the volume by considering it as a tetrahedron
+    const auto & v0 = vertices[0];
+    const auto & v1 = vertices[1];
+    const auto & v2 = vertices[2];
+    const auto & v3 = vertices[3];
+    // const double volume = (v1 - v0).cross(v2 - v0).dot(v3 - v0) / 6.0;
+    // const double volume_threshold = 1e-3;
+    // if (volume > volume_threshold) {
+    //   continue;
+    // }
 
     // Calculate the center of the quadrilateral
     const auto center = (v0 + v1 + v2 + v3) / 4.0;
@@ -168,47 +229,50 @@ geometry_msgs::msg::Pose LandmarkManager::calculate_new_self_pose(
       autoware_utils_geometry::transform_pose(detected_landmark_on_base_link, self_pose);
 
     // match to map
-    if (landmarks_map_.count(landmark.id) == 0) {
-      continue;
-    }
+    // if (landmarks_map_.count(landmark.id) == 0) {
+    //   continue;
+    // }
 
     // check all poses
-    for (const Pose mapped_landmark_on_map : landmarks_map_.at(landmark.id)) {
-      // check distance
-      const double curr_distance = autoware_utils_geometry::calc_distance3d(
-        mapped_landmark_on_map.position, detected_landmark_on_map.position);
-      if (curr_distance > min_distance) {
-        continue;
-      }
+    // for (const Pose mapped_landmark_on_map : landmarks_map_.at(landmark.id)) {
+    for (const auto & [landmark_id_str, landmark_poses] : landmarks_map_) {
+      for (const auto & mapped_landmark_on_map : landmark_poses) {
+        // check distance
+        const double curr_distance = autoware_utils_geometry::calc_distance3d(
+          mapped_landmark_on_map.position, detected_landmark_on_map.position);
+        if (curr_distance > min_distance) {
+          continue;
+        }
 
-      if (consider_orientation) {
-        const Eigen::Affine3d landmark_pose =
-          autoware::localization_util::pose_to_affine3d(mapped_landmark_on_map);
-        const Eigen::Affine3d landmark_to_base_link =
-          autoware::localization_util::pose_to_affine3d(detected_landmark_on_base_link).inverse();
-        const Eigen::Affine3d new_self_pose_eigen = landmark_pose * landmark_to_base_link;
+        if (consider_orientation) {
+          const Eigen::Affine3d landmark_pose =
+            autoware::localization_util::pose_to_affine3d(mapped_landmark_on_map);
+          const Eigen::Affine3d landmark_to_base_link =
+            autoware::localization_util::pose_to_affine3d(detected_landmark_on_base_link).inverse();
+          const Eigen::Affine3d new_self_pose_eigen = landmark_pose * landmark_to_base_link;
 
-        const Pose new_self_pose =
-          autoware::localization_util::matrix4f_to_pose(new_self_pose_eigen.matrix().cast<float>());
+          const Pose new_self_pose = autoware::localization_util::matrix4f_to_pose(
+            new_self_pose_eigen.matrix().cast<float>());
 
-        // update
-        min_distance = curr_distance;
-        min_new_self_pose = new_self_pose;
-      } else {
-        const double diff_x =
-          mapped_landmark_on_map.position.x - detected_landmark_on_map.position.x;
-        const double diff_y =
-          mapped_landmark_on_map.position.y - detected_landmark_on_map.position.y;
-        const double diff_z =
-          mapped_landmark_on_map.position.z - detected_landmark_on_map.position.z;
-        Pose new_self_pose = self_pose;
-        new_self_pose.position.x += diff_x;
-        new_self_pose.position.y += diff_y;
-        new_self_pose.position.z += diff_z;
+          // update
+          min_distance = curr_distance;
+          min_new_self_pose = new_self_pose;
+        } else {
+          const double diff_x =
+            mapped_landmark_on_map.position.x - detected_landmark_on_map.position.x;
+          const double diff_y =
+            mapped_landmark_on_map.position.y - detected_landmark_on_map.position.y;
+          const double diff_z =
+            mapped_landmark_on_map.position.z - detected_landmark_on_map.position.z;
+          Pose new_self_pose = self_pose;
+          new_self_pose.position.x += diff_x;
+          new_self_pose.position.y += diff_y;
+          new_self_pose.position.z += diff_z;
 
-        // update
-        min_distance = curr_distance;
-        min_new_self_pose = new_self_pose;
+          // update
+          min_distance = curr_distance;
+          min_new_self_pose = new_self_pose;
+        }
       }
     }
   }

--- a/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/CMakeLists.txt
+++ b/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/CMakeLists.txt
@@ -27,6 +27,14 @@ rclcpp_components_register_node(${PROJECT_NAME}
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
+  find_package(ament_cmake_gtest REQUIRED)
+  ament_add_gtest(test_lidar_marker_localizer test/test_lidar_marker_localizer.cpp)
+  target_include_directories(test_lidar_marker_localizer PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
+  target_link_libraries(test_lidar_marker_localizer
+    ${PROJECT_NAME}
+    ${PCL_LIBRARIES}
+  )
+  ament_target_dependencies(test_lidar_marker_localizer rclcpp rclcpp_components)
 endif()
 
 ament_auto_package(INSTALL_TO_SHARE

--- a/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/README.md
+++ b/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/README.md
@@ -8,11 +8,11 @@
 
 #### Input
 
-| Name                   | Type                                            | Description      |
-| :--------------------- | :---------------------------------------------- | :--------------- |
-| `~/input/lanelet2_map` | `autoware_map_msgs::msg::HADMapBin`             | Data of lanelet2 |
-| `~/input/pointcloud`   | `sensor_msgs::msg::PointCloud2`                 | PointType: `PointXYZIRC` is recommended in Autoware, but `PointXYZIRADRT` are also supported in this node.[^1]   |
-| `~/input/ekf_pose`     | `geometry_msgs::msg::PoseWithCovarianceStamped` | EKF Pose         |
+| Name                   | Type                                            | Description                                                                                                    |
+| :--------------------- | :---------------------------------------------- | :------------------------------------------------------------------------------------------------------------- |
+| `~/input/lanelet2_map` | `autoware_map_msgs::msg::HADMapBin`             | Data of lanelet2                                                                                               |
+| `~/input/pointcloud`   | `sensor_msgs::msg::PointCloud2`                 | PointType: `PointXYZIRC` is recommended in Autoware, but `PointXYZIRADRT` are also supported in this node.[^1] |
+| `~/input/ekf_pose`     | `geometry_msgs::msg::PoseWithCovarianceStamped` | EKF Pose                                                                                                       |
 
 [^1]: Assumed `ring` of `PointXYZIRADRT` as `channel` of `PointXYZIRC`.
 
@@ -31,14 +31,13 @@
 
 The following debug topics are also published if `enable_save_log` parameter is set to `true`.
 
-| Name                                 | Type                              | Description                                 |
-| :----------------------------------- | :-------------------------------- | :------------------------------------------ |
-| `~/debug/center_intensity_grid`      | `nav_msgs::msg::OccupancyGrid`    | Center intensity grid for debug             |
-| `~/debug/positive_grid`              | `nav_msgs::msg::OccupancyGrid`    | Positive match grid for debug               |
-| `~/debug/negative_grid`              | `nav_msgs::msg::OccupancyGrid`    | Negative match grid for debug               |
-| `~/debug/matched_grid`               | `nav_msgs::msg::OccupancyGrid`    | Matched pattern grid for debug              |
-| `~/debug/vote_grid`                  | `nav_msgs::msg::OccupancyGrid`    | Vote grid for marker detection debug        |
-
+| Name                            | Type                           | Description                          |
+| :------------------------------ | :----------------------------- | :----------------------------------- |
+| `~/debug/center_intensity_grid` | `nav_msgs::msg::OccupancyGrid` | Center intensity grid for debug      |
+| `~/debug/positive_grid`         | `nav_msgs::msg::OccupancyGrid` | Positive match grid for debug        |
+| `~/debug/negative_grid`         | `nav_msgs::msg::OccupancyGrid` | Negative match grid for debug        |
+| `~/debug/matched_grid`          | `nav_msgs::msg::OccupancyGrid` | Matched pattern grid for debug       |
+| `~/debug/vote_grid`             | `nav_msgs::msg::OccupancyGrid` | Vote grid for marker detection debug |
 
 ## Parameters
 

--- a/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/README.md
+++ b/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/README.md
@@ -21,23 +21,21 @@
 | Name                            | Type                                            | Description                                                        |
 | :------------------------------ | :---------------------------------------------- | :----------------------------------------------------------------- |
 | `~/output/pose_with_covariance` | `geometry_msgs::msg::PoseWithCovarianceStamped` | Estimated pose                                                     |
-| `~/debug/pose_with_covariance`  | `geometry_msgs::msg::PoseWithCovarianceStamped` | [debug topic] Estimated pose                                       |
-| `~/debug/marker_detected`       | `geometry_msgs::msg::PoseArray`                 | [debug topic] Detected marker poses                                |
-| `~/debug/marker_mapped`         | `visualization_msgs::msg::MarkerArray`          | [debug topic] Loaded landmarks to visualize in Rviz as thin boards |
-| `~/debug/marker_pointcloud`     | `sensor_msgs::msg::PointCloud2`                 | [debug topic] PointCloud of the detected marker                    |
 | `/diagnostics`                  | `diagnostic_msgs::msg::DiagnosticArray`         | Diagnostics outputs                                                |
 
 ##### For debug
 
-The following debug topics are also published if `enable_save_log` parameter is set to `true`.
-
-| Name                            | Type                           | Description                          |
-| :------------------------------ | :----------------------------- | :----------------------------------- |
-| `~/debug/center_intensity_grid` | `nav_msgs::msg::OccupancyGrid` | Center intensity grid for debug      |
-| `~/debug/positive_grid`         | `nav_msgs::msg::OccupancyGrid` | Positive match grid for debug        |
-| `~/debug/negative_grid`         | `nav_msgs::msg::OccupancyGrid` | Negative match grid for debug        |
-| `~/debug/matched_grid`          | `nav_msgs::msg::OccupancyGrid` | Matched pattern grid for debug       |
-| `~/debug/vote_grid`             | `nav_msgs::msg::OccupancyGrid` | Vote grid for marker detection debug |
+| Name                             | Type                                            | Description                                                        |
+| :--------------------------------| :-----------------------------------------------| :------------------------------------------------------------------|
+| `~/debug/pose_with_covariance`   | `geometry_msgs::msg::PoseWithCovarianceStamped` | Estimated pose                                                     |
+| `~/debug/marker_detected`        | `geometry_msgs::msg::PoseArray`                 | Detected marker poses                                              |
+| `~/debug/marker_mapped`          | `visualization_msgs::msg::MarkerArray`          | Loaded landmarks to visualize in Rviz as thin boards               |
+| `~/debug/marker_pointcloud`      | `sensor_msgs::msg::PointCloud2`                 | PointCloud of the detected marker                                  |
+| `~/debug/center_intensity_grid`  | `nav_msgs::msg::OccupancyGrid`                  | Center intensity grid for debug                                    |
+| `~/debug/positive_grid`          | `nav_msgs::msg::OccupancyGrid`                  | Positive match grid for debug                                      |
+| `~/debug/negative_grid`          | `nav_msgs::msg::OccupancyGrid`                  | Negative match grid for debug                                      |
+| `~/debug/matched_grid`           | `nav_msgs::msg::OccupancyGrid`                  | Matched pattern grid for debug                                     |
+| `~/debug/vote_grid`              | `nav_msgs::msg::OccupancyGrid`                  | Vote grid for marker detection debug                               |
 
 ## Parameters
 

--- a/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/README.md
+++ b/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/README.md
@@ -18,24 +18,24 @@
 
 #### Output
 
-| Name                            | Type                                            | Description                                                        |
-| :------------------------------ | :---------------------------------------------- | :----------------------------------------------------------------- |
-| `~/output/pose_with_covariance` | `geometry_msgs::msg::PoseWithCovarianceStamped` | Estimated pose                                                     |
-| `/diagnostics`                  | `diagnostic_msgs::msg::DiagnosticArray`         | Diagnostics outputs                                                |
+| Name                            | Type                                            | Description         |
+| :------------------------------ | :---------------------------------------------- | :------------------ |
+| `~/output/pose_with_covariance` | `geometry_msgs::msg::PoseWithCovarianceStamped` | Estimated pose      |
+| `/diagnostics`                  | `diagnostic_msgs::msg::DiagnosticArray`         | Diagnostics outputs |
 
 ##### For debug
 
-| Name                             | Type                                            | Description                                                        |
-| :--------------------------------| :-----------------------------------------------| :------------------------------------------------------------------|
-| `~/debug/pose_with_covariance`   | `geometry_msgs::msg::PoseWithCovarianceStamped` | Estimated pose                                                     |
-| `~/debug/marker_detected`        | `geometry_msgs::msg::PoseArray`                 | Detected marker poses                                              |
-| `~/debug/marker_mapped`          | `visualization_msgs::msg::MarkerArray`          | Loaded landmarks to visualize in Rviz as thin boards               |
-| `~/debug/marker_pointcloud`      | `sensor_msgs::msg::PointCloud2`                 | PointCloud of the detected marker                                  |
-| `~/debug/center_intensity_grid`  | `nav_msgs::msg::OccupancyGrid`                  | Center intensity grid for debug                                    |
-| `~/debug/positive_grid`          | `nav_msgs::msg::OccupancyGrid`                  | Positive match grid for debug                                      |
-| `~/debug/negative_grid`          | `nav_msgs::msg::OccupancyGrid`                  | Negative match grid for debug                                      |
-| `~/debug/matched_grid`           | `nav_msgs::msg::OccupancyGrid`                  | Matched pattern grid for debug                                     |
-| `~/debug/vote_grid`              | `nav_msgs::msg::OccupancyGrid`                  | Vote grid for marker detection debug                               |
+| Name                            | Type                                            | Description                                          |
+| :------------------------------ | :---------------------------------------------- | :--------------------------------------------------- |
+| `~/debug/pose_with_covariance`  | `geometry_msgs::msg::PoseWithCovarianceStamped` | Estimated pose                                       |
+| `~/debug/marker_detected`       | `geometry_msgs::msg::PoseArray`                 | Detected marker poses                                |
+| `~/debug/marker_mapped`         | `visualization_msgs::msg::MarkerArray`          | Loaded landmarks to visualize in Rviz as thin boards |
+| `~/debug/marker_pointcloud`     | `sensor_msgs::msg::PointCloud2`                 | PointCloud of the detected marker                    |
+| `~/debug/center_intensity_grid` | `nav_msgs::msg::OccupancyGrid`                  | Center intensity grid for debug                      |
+| `~/debug/positive_grid`         | `nav_msgs::msg::OccupancyGrid`                  | Positive match grid for debug                        |
+| `~/debug/negative_grid`         | `nav_msgs::msg::OccupancyGrid`                  | Negative match grid for debug                        |
+| `~/debug/matched_grid`          | `nav_msgs::msg::OccupancyGrid`                  | Matched pattern grid for debug                       |
+| `~/debug/vote_grid`             | `nav_msgs::msg::OccupancyGrid`                  | Vote grid for marker detection debug                 |
 
 ## Parameters
 

--- a/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/README.md
+++ b/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/README.md
@@ -11,8 +11,10 @@
 | Name                   | Type                                            | Description      |
 | :--------------------- | :---------------------------------------------- | :--------------- |
 | `~/input/lanelet2_map` | `autoware_map_msgs::msg::HADMapBin`             | Data of lanelet2 |
-| `~/input/pointcloud`   | `sensor_msgs::msg::PointCloud2`                 | PointCloud       |
+| `~/input/pointcloud`   | `sensor_msgs::msg::PointCloud2`                 | PointType: `PointXYZIRC` is recommended in Autoware, but `PointXYZIRADRT` are also supported in this node.[^1]   |
 | `~/input/ekf_pose`     | `geometry_msgs::msg::PoseWithCovarianceStamped` | EKF Pose         |
+
+[^1]: Assumed `ring` of `PointXYZIRADRT` as `channel` of `PointXYZIRC`.
 
 #### Output
 
@@ -24,6 +26,19 @@
 | `~/debug/marker_mapped`         | `visualization_msgs::msg::MarkerArray`          | [debug topic] Loaded landmarks to visualize in Rviz as thin boards |
 | `~/debug/marker_pointcloud`     | `sensor_msgs::msg::PointCloud2`                 | [debug topic] PointCloud of the detected marker                    |
 | `/diagnostics`                  | `diagnostic_msgs::msg::DiagnosticArray`         | Diagnostics outputs                                                |
+
+##### For debug
+
+The following debug topics are also published if `enable_save_log` parameter is set to `true`.
+
+| Name                                 | Type                              | Description                                 |
+| :----------------------------------- | :-------------------------------- | :------------------------------------------ |
+| `~/debug/center_intensity_grid`      | `nav_msgs::msg::OccupancyGrid`    | Center intensity grid for debug             |
+| `~/debug/positive_grid`              | `nav_msgs::msg::OccupancyGrid`    | Positive match grid for debug               |
+| `~/debug/negative_grid`              | `nav_msgs::msg::OccupancyGrid`    | Negative match grid for debug               |
+| `~/debug/matched_grid`               | `nav_msgs::msg::OccupancyGrid`    | Matched pattern grid for debug              |
+| `~/debug/vote_grid`                  | `nav_msgs::msg::OccupancyGrid`    | Vote grid for marker detection debug        |
+
 
 ## Parameters
 

--- a/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/README.md
+++ b/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/README.md
@@ -126,4 +126,4 @@ The reflectors were installed by [Taisei Corporation](https://www.taisei.co.jp/e
 
 - [TIER IV](https://tier4.jp/en/)
 - [Taisei Corporation](https://www.taisei.co.jp/english/)
-- [Yuri Shimizu](https://github.com/YuriShimizu824)
+  - [Yuri Shimizu](https://github.com/YuriShimizu824)

--- a/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/config/lidar_marker_localizer.param.yaml
+++ b/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/config/lidar_marker_localizer.param.yaml
@@ -1,5 +1,7 @@
 /**:
   ros__parameters:
+    enable_read_all_target_ids: true
+    target_ids: ["0000", "0001", "0002", "0003", "0004", "0005"]
 
     # marker name
     marker_name: "reflector"

--- a/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/config/lidar_marker_localizer.param.yaml
+++ b/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/config/lidar_marker_localizer.param.yaml
@@ -41,13 +41,11 @@
                       0.0,  0.0,  0.0,  0.0,        0.00007569, 0.0,
                       0.0,  0.0,  0.0,  0.0,        0.0,        0.00030625]
 
-    # for visualize the detected marker pointcloud
-    marker_width: 0.8
-
     # for save log
     enable_save_log: false
     save_file_directory_path: detected_reflector_intensity
     save_file_name: detected_reflector_intensity
     save_frame_id: velodyne_top
+    ## for visualize the detected marker pointcloud
     radius_for_extracting_marker_pointcloud: 0.4 # [m] within
     queue_size_for_debug_pub_msg: 10 # Queue size for debug publishers

--- a/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/config/lidar_marker_localizer.param.yaml
+++ b/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/config/lidar_marker_localizer.param.yaml
@@ -17,6 +17,7 @@
     vote_threshold_for_detect_marker: 20
     marker_to_vehicle_offset_y: 0.0
     marker_height_from_ground: 1.075
+    reference_ring_number: 255 # set to 255 to disable ring filtering
 
     # for interpolate algorithm
     self_pose_timeout_sec: 1.0

--- a/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/config/lidar_marker_localizer.param.yaml
+++ b/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/config/lidar_marker_localizer.param.yaml
@@ -15,6 +15,7 @@
     positive_match_num_threshold: 3
     negative_match_num_threshold: 3
     vote_threshold_for_detect_marker: 20
+    marker_to_vehicle_offset_y: 0.0
     marker_height_from_ground: 1.075
 
     # for interpolate algorithm
@@ -23,6 +24,7 @@
 
     # for validation
     limit_distance_from_self_pose_to_nearest_marker: 2.0
+    limit_distance_from_self_pose_to_nearest_marker_y: 1.0
     limit_distance_from_self_pose_to_marker: 2.0
 
     # base_covariance

--- a/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/config/lidar_marker_localizer.param.yaml
+++ b/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/config/lidar_marker_localizer.param.yaml
@@ -46,3 +46,4 @@
     save_file_name: detected_reflector_intensity
     save_frame_id: velodyne_top
     radius_for_extracting_marker_pointcloud: 0.4 # [m] within
+    queue_size_for_debug_pub_msg: 10 # Queue size for debug publishers

--- a/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/config/lidar_marker_localizer.param.yaml
+++ b/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/config/lidar_marker_localizer.param.yaml
@@ -2,6 +2,7 @@
   ros__parameters:
     enable_read_all_target_ids: true
     target_ids: ["0000", "0001", "0002", "0003", "0004", "0005"]
+    queue_size_for_output_pose: 10 # Queue size for output/pose_with_covariance publisher
 
     # marker name
     marker_name: "reflector"

--- a/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/config/lidar_marker_localizer.param.yaml
+++ b/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/config/lidar_marker_localizer.param.yaml
@@ -45,3 +45,4 @@
     save_file_directory_path: detected_reflector_intensity
     save_file_name: detected_reflector_intensity
     save_frame_id: velodyne_top
+    radius_for_extracting_marker_pointcloud: 0.4 # [m] within

--- a/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/config/lidar_marker_localizer.param.yaml
+++ b/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/config/lidar_marker_localizer.param.yaml
@@ -18,6 +18,8 @@
     vote_threshold_for_detect_marker: 20
     marker_to_vehicle_offset_y: 0.0
     marker_height_from_ground: 1.075
+    lower_ring_id_init: 128
+    upper_ring_id_init: 0
     reference_ring_number: 255 # set to 255 to disable ring filtering
 
     # for interpolate algorithm

--- a/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/config/lidar_marker_localizer.param.yaml
+++ b/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/config/lidar_marker_localizer.param.yaml
@@ -8,6 +8,7 @@
     marker_name: "reflector"
 
     # for marker detection algorithm
+    road_surface_mode: false
     resolution: 0.05
     # A sequence of high/low intensity to perform pattern matching.
     # 1: high intensity (positive match), 0: not consider, -1: low intensity (negative match)

--- a/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/package.xml
+++ b/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/package.xml
@@ -17,9 +17,9 @@
   <depend>autoware_localization_util</depend>
   <depend>autoware_map_msgs</depend>
   <depend>autoware_point_types</depend>
+  <depend>autoware_pointcloud_preprocessor</depend>
   <depend>autoware_qos_utils</depend>
   <depend>autoware_utils</depend>
-  <depend>autoware_pointcloud_preprocessor</depend>
   <depend>pcl_conversions</depend>
   <depend>pcl_ros</depend>
   <depend>rclcpp</depend>

--- a/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/package.xml
+++ b/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/package.xml
@@ -18,8 +18,7 @@
   <depend>autoware_map_msgs</depend>
   <depend>autoware_point_types</depend>
   <depend>autoware_qos_utils</depend>
-  <depend>autoware_utils_diagnostics</depend>
-  <depend>autoware_utils_geometry</depend>
+  <depend>autoware_utils</depend>
   <depend>autoware_pointcloud_preprocessor</depend>
   <depend>pcl_conversions</depend>
   <depend>pcl_ros</depend>

--- a/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/package.xml
+++ b/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/package.xml
@@ -20,6 +20,7 @@
   <depend>autoware_qos_utils</depend>
   <depend>autoware_utils_diagnostics</depend>
   <depend>autoware_utils_geometry</depend>
+  <depend>autoware_pointcloud_preprocessor</depend>
   <depend>pcl_conversions</depend>
   <depend>pcl_ros</depend>
   <depend>rclcpp</depend>

--- a/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/schema/lidar_marker_localizer.schema.json
+++ b/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/schema/lidar_marker_localizer.schema.json
@@ -6,6 +6,29 @@
     "lidar_marker_localizer": {
       "type": "object",
       "properties": {
+        "enable_read_all_target_ids": {
+          "type": "boolean",
+          "description": "",
+          "default": true
+        },
+        "target_ids": {
+          "type": "array",
+          "description": "List of target marker IDs to be detected.",
+          "default": [
+            "0000",
+            "0001",
+            "0002",
+            "0003",
+            "0004",
+            "0005"
+          ]
+        },
+        "queue_size_for_output_pose": {
+          "type": "number",
+          "description": "Queue size for output/pose_with_covariance publisher",
+          "default": 10,
+          "minimum": 0
+        },
         "marker_name": {
           "type": "string",
           "description": "The name of the markers listed in the HD map.",
@@ -20,7 +43,19 @@
         "intensity_pattern": {
           "type": "array",
           "description": "A sequence of high/low intensity to perform pattern matching. 1: high intensity (positive match), 0: not consider, -1: low intensity (negative match)",
-          "default": [-1, -1, 0, 1, 1, 1, 1, 1, 0, -1, -1]
+          "default": [
+            -1,
+            -1,
+            0,
+            1,
+            1,
+            1,
+            1,
+            1,
+            0,
+            -1,
+            -1
+          ]
         },
         "match_intensity_difference_threshold": {
           "type": "number",
@@ -48,7 +83,7 @@
         },
         "marker_to_vehicle_offset_y": {
           "type": "number",
-          "description": "Y-axiz offset from the center of the marker to vehicle. [m]",
+          "description": "Y-axis offset from the center of the marker to vehicle. [m]",
           "default": 0.0
         },
         "marker_height_from_ground": {
@@ -56,10 +91,22 @@
           "description": "Height from the ground to the center of the marker. [m]",
           "default": 1.075
         },
+        "lower_ring_id_init": {
+          "type": "number",
+          "description": "Initial value when searching for the lowest ring ID within the point cloud",
+          "default": 128,
+          "minimum": 0
+        },
+        "upper_ring_id_init": {
+          "type": "number",
+          "description": "Initial value when searching for the highest ring ID within the point cloud",
+          "default": 0,
+          "minimum": 0
+        },
         "reference_ring_number": {
           "type": "number",
           "description": "Reference ring number when detecting the marker. Set 255 to disable ring filtering",
-          "default": 5
+          "default": 255
         },
         "self_pose_timeout_sec": {
           "type": "number",
@@ -95,9 +142,42 @@
           "type": "array",
           "description": "Output covariance in the base_link coordinate.",
           "default": [
-            0.04, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.04, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.01, 0.0, 0.0,
-            0.0, 0.0, 0.0, 0.0, 0.00007569, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.00007569, 0.0, 0.0, 0.0,
-            0.0, 0.0, 0.0, 0.00030625
+            0.04,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.04,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.01,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.00007569,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.00007569,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.00030625
           ]
         },
         "marker_width": {
@@ -125,6 +205,18 @@
           "type": "string",
           "description": "",
           "default": "velodyne_top"
+        },
+        "radius_for_extracting_marker_pointcloud": {
+          "type": "number",
+          "description": "Only points closer than this value to the marker center on the xy plane are extracted as the “marker point cloud”. [m]",
+          "default": 0.4,
+          "minimum": 0.0
+        },
+        "queue_size_for_debug_pub_msg": {
+          "type": "number",
+          "description": "Queue size for debug publishers",
+          "default": 10,
+          "minimum": 0.0
         }
       },
       "required": [
@@ -160,10 +252,14 @@
           "$ref": "#/definitions/lidar_marker_localizer"
         }
       },
-      "required": ["ros__parameters"],
+      "required": [
+        "ros__parameters"
+      ],
       "additionalProperties": false
     }
   },
-  "required": ["/**"],
+  "required": [
+    "/**"
+  ],
   "additionalProperties": false
 }

--- a/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/schema/lidar_marker_localizer.schema.json
+++ b/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/schema/lidar_marker_localizer.schema.json
@@ -14,14 +14,7 @@
         "target_ids": {
           "type": "array",
           "description": "List of target marker IDs to be detected.",
-          "default": [
-            "0000",
-            "0001",
-            "0002",
-            "0003",
-            "0004",
-            "0005"
-          ]
+          "default": ["0000", "0001", "0002", "0003", "0004", "0005"]
         },
         "queue_size_for_output_pose": {
           "type": "number",
@@ -48,19 +41,7 @@
         "intensity_pattern": {
           "type": "array",
           "description": "A sequence of high/low intensity to perform pattern matching. 1: high intensity (positive match), 0: not consider, -1: low intensity (negative match)",
-          "default": [
-            -1,
-            -1,
-            0,
-            1,
-            1,
-            1,
-            1,
-            1,
-            0,
-            -1,
-            -1
-          ]
+          "default": [-1, -1, 0, 1, 1, 1, 1, 1, 0, -1, -1]
         },
         "match_intensity_difference_threshold": {
           "type": "number",
@@ -147,42 +128,9 @@
           "type": "array",
           "description": "Output covariance in the base_link coordinate.",
           "default": [
-            0.04,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.04,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.01,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.00007569,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.00007569,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.00030625
+            0.04, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.04, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.01, 0.0, 0.0,
+            0.0, 0.0, 0.0, 0.0, 0.00007569, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.00007569, 0.0, 0.0, 0.0,
+            0.0, 0.0, 0.0, 0.00030625
           ]
         },
         "enable_save_log": {
@@ -250,14 +198,10 @@
           "$ref": "#/definitions/lidar_marker_localizer"
         }
       },
-      "required": [
-        "ros__parameters"
-      ],
+      "required": ["ros__parameters"],
       "additionalProperties": false
     }
   },
-  "required": [
-    "/**"
-  ],
+  "required": ["/**"],
   "additionalProperties": false
 }

--- a/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/schema/lidar_marker_localizer.schema.json
+++ b/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/schema/lidar_marker_localizer.schema.json
@@ -14,7 +14,14 @@
         "target_ids": {
           "type": "array",
           "description": "List of target marker IDs to be detected.",
-          "default": ["0000", "0001", "0002", "0003", "0004", "0005"]
+          "default": [
+            "0000",
+            "0001",
+            "0002",
+            "0003",
+            "0004",
+            "0005"
+          ]
         },
         "queue_size_for_output_pose": {
           "type": "number",
@@ -41,7 +48,19 @@
         "intensity_pattern": {
           "type": "array",
           "description": "A sequence of high/low intensity to perform pattern matching. 1: high intensity (positive match), 0: not consider, -1: low intensity (negative match)",
-          "default": [-1, -1, 0, 1, 1, 1, 1, 1, 0, -1, -1]
+          "default": [
+            -1,
+            -1,
+            0,
+            1,
+            1,
+            1,
+            1,
+            1,
+            0,
+            -1,
+            -1
+          ]
         },
         "match_intensity_difference_threshold": {
           "type": "number",
@@ -128,16 +147,43 @@
           "type": "array",
           "description": "Output covariance in the base_link coordinate.",
           "default": [
-            0.04, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.04, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.01, 0.0, 0.0,
-            0.0, 0.0, 0.0, 0.0, 0.00007569, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.00007569, 0.0, 0.0, 0.0,
-            0.0, 0.0, 0.0, 0.00030625
+            0.04,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.04,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.01,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.00007569,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.00007569,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.00030625
           ]
-        },
-        "marker_width": {
-          "type": "number",
-          "description": "Width of a marker. This param is used for visualizing the detected marker pointcloud[m]",
-          "default": 0.8,
-          "minimum": 0.0
         },
         "enable_save_log": {
           "type": "boolean",
@@ -188,7 +234,6 @@
         "limit_distance_from_self_pose_to_nearest_marker_y",
         "limit_distance_from_self_pose_to_marker",
         "base_covariance",
-        "marker_width",
         "enable_save_log",
         "save_file_directory_path",
         "save_file_name",
@@ -205,10 +250,14 @@
           "$ref": "#/definitions/lidar_marker_localizer"
         }
       },
-      "required": ["ros__parameters"],
+      "required": [
+        "ros__parameters"
+      ],
       "additionalProperties": false
     }
   },
-  "required": ["/**"],
+  "required": [
+    "/**"
+  ],
   "additionalProperties": false
 }

--- a/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/schema/lidar_marker_localizer.schema.json
+++ b/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/schema/lidar_marker_localizer.schema.json
@@ -27,6 +27,11 @@
           "description": "The name of the markers listed in the HD map.",
           "default": "reflector"
         },
+        "road_surface_mode": {
+          "type": "boolean",
+          "description": "Enable road surface mode for marker detection.",
+          "default": false
+        },
         "resolution": {
           "type": "number",
           "description": "Grid size for marker detection algorithm. [m]",

--- a/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/schema/lidar_marker_localizer.schema.json
+++ b/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/schema/lidar_marker_localizer.schema.json
@@ -46,6 +46,11 @@
           "default": 20,
           "minimum": 0
         },
+        "marker_to_vehicle_offset_y": {
+          "type": "number",
+          "description": "Y-axiz offset from the center of the marker to vehicle. [m]",
+          "default": 0.0
+        },
         "marker_height_from_ground": {
           "type": "number",
           "description": "Height from the ground to the center of the marker. [m]",
@@ -118,6 +123,7 @@
         "positive_match_num_threshold",
         "negative_match_num_threshold",
         "vote_threshold_for_detect_marker",
+        "marker_to_vehicle_offset_y",
         "self_pose_timeout_sec",
         "self_pose_distance_tolerance_m",
         "limit_distance_from_self_pose_to_nearest_marker",

--- a/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/schema/lidar_marker_localizer.schema.json
+++ b/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/schema/lidar_marker_localizer.schema.json
@@ -14,14 +14,7 @@
         "target_ids": {
           "type": "array",
           "description": "List of target marker IDs to be detected.",
-          "default": [
-            "0000",
-            "0001",
-            "0002",
-            "0003",
-            "0004",
-            "0005"
-          ]
+          "default": ["0000", "0001", "0002", "0003", "0004", "0005"]
         },
         "queue_size_for_output_pose": {
           "type": "number",
@@ -43,19 +36,7 @@
         "intensity_pattern": {
           "type": "array",
           "description": "A sequence of high/low intensity to perform pattern matching. 1: high intensity (positive match), 0: not consider, -1: low intensity (negative match)",
-          "default": [
-            -1,
-            -1,
-            0,
-            1,
-            1,
-            1,
-            1,
-            1,
-            0,
-            -1,
-            -1
-          ]
+          "default": [-1, -1, 0, 1, 1, 1, 1, 1, 0, -1, -1]
         },
         "match_intensity_difference_threshold": {
           "type": "number",
@@ -142,42 +123,9 @@
           "type": "array",
           "description": "Output covariance in the base_link coordinate.",
           "default": [
-            0.04,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.04,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.01,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.00007569,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.00007569,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.0,
-            0.00030625
+            0.04, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.04, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.01, 0.0, 0.0,
+            0.0, 0.0, 0.0, 0.0, 0.00007569, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.00007569, 0.0, 0.0, 0.0,
+            0.0, 0.0, 0.0, 0.00030625
           ]
         },
         "marker_width": {
@@ -252,14 +200,10 @@
           "$ref": "#/definitions/lidar_marker_localizer"
         }
       },
-      "required": [
-        "ros__parameters"
-      ],
+      "required": ["ros__parameters"],
       "additionalProperties": false
     }
   },
-  "required": [
-    "/**"
-  ],
+  "required": ["/**"],
   "additionalProperties": false
 }

--- a/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/schema/lidar_marker_localizer.schema.json
+++ b/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/schema/lidar_marker_localizer.schema.json
@@ -56,6 +56,11 @@
           "description": "Height from the ground to the center of the marker. [m]",
           "default": 1.075
         },
+        "reference_ring_number": {
+          "type": "number",
+          "description": "Reference ring number when detecting the marker. Set 255 to disable ring filtering",
+          "default": 5
+        },
         "self_pose_timeout_sec": {
           "type": "number",
           "description": "Timeout for self pose. [sec]",
@@ -72,6 +77,12 @@
           "type": "number",
           "description": "Distance limit for the purpose of determining whether the node should detect a marker. [m]",
           "default": 2.0,
+          "minimum": 0.0
+        },
+        "limit_distance_from_self_pose_to_nearest_marker_y": {
+          "type": "number",
+          "description": "Y-axis distance limit for the purpose of determining whether the node should detect a marker. [m]",
+          "default": 1.0,
           "minimum": 0.0
         },
         "limit_distance_from_self_pose_to_marker": {
@@ -124,9 +135,12 @@
         "negative_match_num_threshold",
         "vote_threshold_for_detect_marker",
         "marker_to_vehicle_offset_y",
+        "marker_height_from_ground",
+        "reference_ring_number",
         "self_pose_timeout_sec",
         "self_pose_distance_tolerance_m",
         "limit_distance_from_self_pose_to_nearest_marker",
+        "limit_distance_from_self_pose_to_nearest_marker_y",
         "limit_distance_from_self_pose_to_marker",
         "base_covariance",
         "marker_width",

--- a/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/src/lidar_marker_localizer.cpp
+++ b/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/src/lidar_marker_localizer.cpp
@@ -54,6 +54,7 @@ LidarMarkerLocalizer::LidarMarkerLocalizer(const rclcpp::NodeOptions & node_opti
     this->declare_parameter<int64_t>("queue_size_for_output_pose");
 
   param_.marker_name = this->declare_parameter<std::string>("marker_name");
+  param_.road_surface_mode = this->declare_parameter<bool>("road_surface_mode");
   param_.resolution = this->declare_parameter<double>("resolution");
   param_.intensity_pattern = this->declare_parameter<std::vector<int64_t>>("intensity_pattern");
   param_.match_intensity_difference_threshold =

--- a/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/src/lidar_marker_localizer.cpp
+++ b/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/src/lidar_marker_localizer.cpp
@@ -17,6 +17,7 @@
 #include <autoware/point_types/types.hpp>
 #include <autoware/pointcloud_preprocessor/utility/memory.hpp>
 #include <autoware_utils/geometry/geometry.hpp>
+#include <autoware_utils/ros/diagnostics_interface.hpp>
 #include <autoware_utils/transform/transforms.hpp>
 #include <pcl_ros/transforms.hpp>
 #include <rclcpp/qos.hpp>

--- a/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/src/lidar_marker_localizer.cpp
+++ b/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/src/lidar_marker_localizer.cpp
@@ -313,7 +313,7 @@ void LidarMarkerLocalizer::main_process(const PointCloud2::ConstSharedPtr & poin
   result.header.frame_id = "map";
   result.pose.pose.position.x = new_self_pose.position.x;
   result.pose.pose.position.y = new_self_pose.position.y;
-  result.pose.pose.position.z = self_pose.position.z;
+  result.pose.pose.position.z = new_self_pose.position.z;
   result.pose.pose.orientation = self_pose.orientation;
 
   // set covariance

--- a/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/src/lidar_marker_localizer.cpp
+++ b/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/src/lidar_marker_localizer.cpp
@@ -16,7 +16,8 @@
 
 #include <autoware/point_types/types.hpp>
 #include <autoware/pointcloud_preprocessor/utility/memory.hpp>
-#include <autoware_utils_geometry/geometry.hpp>
+#include <autoware_utils/geometry/geometry.hpp>
+#include <autoware_utils/transform/transforms.hpp>
 #include <pcl_ros/transforms.hpp>
 #include <rclcpp/qos.hpp>
 
@@ -148,7 +149,7 @@ LidarMarkerLocalizer::LidarMarkerLocalizer(const rclcpp::NodeOptions & node_opti
   tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf_buffer_, this, false);
 
   diagnostics_interface_.reset(
-    new autoware_utils_diagnostics::DiagnosticsInterface(this, "marker_detection_status"));
+    new autoware_utils::DiagnosticsInterface(this, "marker_detection_status"));
 }
 
 void LidarMarkerLocalizer::initialize_diagnostics()
@@ -272,7 +273,7 @@ void LidarMarkerLocalizer::main_process(const PointCloud2::ConstSharedPtr & poin
   // (4) check distance to the nearest marker
   const landmark_manager::Landmark nearest_marker = get_nearest_landmark(self_pose, map_landmarks);
   const Pose nearest_marker_pose_on_base_link =
-    autoware_utils_geometry::inverse_transform_pose(nearest_marker.pose, self_pose);
+    autoware_utils::inverse_transform_pose(nearest_marker.pose, self_pose);
 
   const double distance_from_self_pose_to_nearest_marker =
     std::abs(nearest_marker_pose_on_base_link.position.x);
@@ -314,8 +315,7 @@ void LidarMarkerLocalizer::main_process(const PointCloud2::ConstSharedPtr & poin
     pose_array_msg.header.stamp = sensor_ros_time;
     pose_array_msg.header.frame_id = "map";
     for (const landmark_manager::Landmark & landmark : detected_landmarks) {
-      const Pose detected_marker_on_map =
-        autoware_utils_geometry::transform_pose(landmark.pose, self_pose);
+      const Pose detected_marker_on_map = autoware_utils::transform_pose(landmark.pose, self_pose);
       pose_array_msg.poses.push_back(detected_marker_on_map);
     }
     pub_marker_detected_->publish(pose_array_msg);
@@ -590,7 +590,7 @@ std::vector<landmark_manager::Landmark> LidarMarkerLocalizer::detect_landmarks(
       marker_pose_on_base_link.position.y = reference_ring_y[i];
       marker_pose_on_base_link.position.z = param_.marker_height_from_ground;
       marker_pose_on_base_link.orientation =
-        autoware_utils_geometry::create_quaternion_from_rpy(M_PI_2, 0.0, 0.0);  // TODO(YamatoAndo)
+        autoware_utils::create_quaternion_from_rpy(M_PI_2, 0.0, 0.0);  // TODO(YamatoAndo)
       detected_landmarks.push_back(landmark_manager::Landmark{"0", marker_pose_on_base_link});
     }
   }
@@ -639,7 +639,7 @@ landmark_manager::Landmark LidarMarkerLocalizer::get_nearest_landmark(
 
   for (const auto & landmark : landmarks) {
     const double curr_distance =
-      autoware_utils_geometry::calc_distance3d(landmark.pose.position, self_pose.position);
+      autoware_utils::calc_distance3d(landmark.pose.position, self_pose.position);
 
     if (curr_distance > min_distance) {
       continue;
@@ -878,7 +878,7 @@ void LidarMarkerLocalizer::transform_sensor_measurement(
   }
 
   const geometry_msgs::msg::PoseStamped target_to_source_pose_stamped =
-    autoware_utils_geometry::transform2pose(transform);
+    autoware_utils::transform2pose(transform);
   const Eigen::Matrix4f base_to_sensor_matrix =
     autoware::localization_util::pose_to_matrix4f(target_to_source_pose_stamped.pose);
   pcl_ros::transformPointCloud(

--- a/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/src/lidar_marker_localizer.cpp
+++ b/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/src/lidar_marker_localizer.cpp
@@ -15,6 +15,7 @@
 #include "lidar_marker_localizer.hpp"
 
 #include <autoware/point_types/types.hpp>
+#include <autoware/pointcloud_preprocessor/utility/memory.hpp>
 #include <autoware_utils_geometry/geometry.hpp>
 #include <pcl_ros/transforms.hpp>
 #include <rclcpp/qos.hpp>
@@ -193,6 +194,21 @@ void LidarMarkerLocalizer::main_process(const PointCloud2::ConstSharedPtr & poin
 {
   const builtin_interfaces::msg::Time sensor_ros_time = points_msg_ptr->header.stamp;
 
+  // (0) Determine point cloud type
+  const bool is_xyziradrt =
+    autoware::pointcloud_preprocessor::utils::is_data_layout_compatible_with_point_xyziradrt(
+      *points_msg_ptr);
+  const bool is_xyzirc =
+    autoware::pointcloud_preprocessor::utils::is_data_layout_compatible_with_point_xyzirc(
+      *points_msg_ptr);
+
+  if (!is_xyziradrt && !is_xyzirc) {
+    RCLCPP_WARN_STREAM_THROTTLE(
+      this->get_logger(), *this->get_clock(), 1000,
+      "Unknown point cloud type. Cannot process this point cloud.");
+    return;
+  }
+
   // (1) check if the map have be received
   const std::vector<landmark_manager::Landmark> map_landmarks = landmark_manager_.get_landmarks();
   const bool is_received_map = !map_landmarks.empty();
@@ -227,8 +243,12 @@ void LidarMarkerLocalizer::main_process(const PointCloud2::ConstSharedPtr & poin
   const Pose self_pose = interpolate_result.value().interpolated_pose.pose.pose;
 
   // (3) detect marker
-  const std::vector<landmark_manager::Landmark> detected_landmarks =
-    detect_landmarks(points_msg_ptr);
+  std::vector<landmark_manager::Landmark> detected_landmarks;
+  if (is_xyziradrt) {
+    detected_landmarks = detect_landmarks<autoware::point_types::PointXYZIRADRT>(points_msg_ptr);
+  } else {
+    detected_landmarks = detect_landmarks<autoware::point_types::PointXYZIRC>(points_msg_ptr);
+  }
 
   const bool is_detected_marker = !detected_landmarks.empty();
   diagnostics_interface_->add_key_value("detect_marker_num", detected_landmarks.size());
@@ -351,14 +371,27 @@ void LidarMarkerLocalizer::service_trigger_node(
   res->success = true;
 }
 
+// Helper functions to get ring/channel ID from different point types
+namespace
+{
+inline uint16_t get_ring_id(const autoware::point_types::PointXYZIRC & point)
+{
+  return point.channel;
+}
+
+inline uint16_t get_ring_id(const autoware::point_types::PointXYZIRADRT & point)
+{
+  return point.ring;
+}
+}  // namespace
+
+template <typename PointT>
 std::vector<landmark_manager::Landmark> LidarMarkerLocalizer::detect_landmarks(
   const PointCloud2::ConstSharedPtr & points_msg_ptr)
 {
   // TODO(YamatoAndo)
   // Transform sensor_frame to base_link
-
-  pcl::PointCloud<autoware::point_types::PointXYZIRC>::Ptr points_ptr(
-    new pcl::PointCloud<autoware::point_types::PointXYZIRC>);
+  typename pcl::PointCloud<PointT>::Ptr points_ptr(new pcl::PointCloud<PointT>);
   pcl::fromROSMsg(*points_msg_ptr, *points_ptr);
 
   if (points_ptr->empty()) {
@@ -366,12 +399,20 @@ std::vector<landmark_manager::Landmark> LidarMarkerLocalizer::detect_landmarks(
     return std::vector<landmark_manager::Landmark>{};
   }
 
-  std::vector<pcl::PointCloud<autoware::point_types::PointXYZIRC>> ring_points(128);
+  uint16_t lower_ring_id = 128;
+  uint16_t upper_ring_id = 0;
+  for (const auto & point : points_ptr->points) {
+    lower_ring_id = std::min(get_ring_id(point), lower_ring_id);
+    upper_ring_id = std::max(get_ring_id(point), upper_ring_id);
+  }
+  uint16_t ring_num = upper_ring_id - lower_ring_id + 1;
+
+  std::vector<pcl::PointCloud<PointT>> ring_points(ring_num);
 
   float min_x = std::numeric_limits<float>::max();
   float max_x = std::numeric_limits<float>::lowest();
-  for (const autoware::point_types::PointXYZIRC & point : points_ptr->points) {
-    ring_points[point.channel].push_back(point);
+  for (const auto & point : points_ptr->points) {
+    ring_points[get_ring_id(point) - lower_ring_id].push_back(point);
     min_x = std::min(min_x, point.x);
     max_x = std::max(max_x, point.x);
   }
@@ -389,18 +430,20 @@ std::vector<landmark_manager::Landmark> LidarMarkerLocalizer::detect_landmarks(
   std::vector<int> vote(bin_num, 0);
   std::vector<float> reference_ring_y(bin_num, std::numeric_limits<float>::max());
 
-  // for each channel
-  for (const pcl::PointCloud<autoware::point_types::PointXYZIRC> & one_ring : ring_points) {
+  // for each ring
+  for (const auto & one_ring : ring_points) {
     std::vector<double> intensity_sum(bin_num, 0.0);
     std::vector<int> intensity_num(bin_num, 0);
     std::vector<double> average_intensity(bin_num, 0.0);
+    const size_t ring_id =
+      get_ring_id(one_ring.front()) - get_ring_id(ring_points.front().points.front());
 
-    for (const autoware::point_types::PointXYZIRC & point : one_ring.points) {
+    for (const auto & point : one_ring.points) {
       const int bin_index = static_cast<int>((point.x - min_x) / param_.resolution);
       intensity_sum[bin_index] += point.intensity;
       intensity_num[bin_index]++;
       if (
-        (point.ring == param_.reference_ring_number) ||
+        (get_ring_id(point) == param_.reference_ring_number) ||
         (param_.reference_ring_number == std::numeric_limits<uint8_t>::max())) {
         reference_ring_y[bin_index] = std::min(reference_ring_y[bin_index], point.y);
       }
@@ -612,6 +655,8 @@ void LidarMarkerLocalizer::save_detected_marker_log(
   csv_file.close();
 }
 
+// Transform pointcloud from source_frame to target_frame
+// If PointType would be used in this function, this function should be templated
 void LidarMarkerLocalizer::transform_sensor_measurement(
   const std::string & source_frame, const std::string & target_frame,
   const sensor_msgs::msg::PointCloud2::SharedPtr & sensor_points_input_ptr,
@@ -641,6 +686,12 @@ void LidarMarkerLocalizer::transform_sensor_measurement(
   pcl_ros::transformPointCloud(
     base_to_sensor_matrix, *sensor_points_input_ptr, *sensor_points_output_ptr);
 }
+
+// Explicit instantiation
+template std::vector<landmark_manager::Landmark> LidarMarkerLocalizer::detect_landmarks<
+  autoware::point_types::PointXYZIRC>(const PointCloud2::ConstSharedPtr &);
+template std::vector<landmark_manager::Landmark> LidarMarkerLocalizer::detect_landmarks<
+  autoware::point_types::PointXYZIRADRT>(const PointCloud2::ConstSharedPtr &);
 
 }  // namespace autoware::lidar_marker_localizer
 

--- a/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/src/lidar_marker_localizer.cpp
+++ b/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/src/lidar_marker_localizer.cpp
@@ -85,6 +85,8 @@ LidarMarkerLocalizer::LidarMarkerLocalizer(const rclcpp::NodeOptions & node_opti
   param_.save_frame_id = this->declare_parameter<std::string>("save_frame_id");
   param_.radius_for_extracting_marker_pointcloud =
     this->declare_parameter<double>("radius_for_extracting_marker_pointcloud");
+  param_.queue_size_for_debug_pub_msg =
+    this->declare_parameter<int64_t>("queue_size_for_debug_pub_msg");
 
   ekf_pose_buffer_ = std::make_unique<autoware::localization_util::SmartPoseBuffer>(
     this->get_logger(), param_.self_pose_timeout_sec, param_.self_pose_distance_tolerance_m);
@@ -111,14 +113,28 @@ LidarMarkerLocalizer::LidarMarkerLocalizer(const rclcpp::NodeOptions & node_opti
 
   pub_base_link_pose_with_covariance_on_map_ =
     this->create_publisher<PoseWithCovarianceStamped>("~/output/pose_with_covariance", 10);
-  rclcpp::QoS qos_marker = rclcpp::QoS(rclcpp::KeepLast(10));
+  rclcpp::QoS qos_marker = rclcpp::QoS(rclcpp::KeepLast(param_.queue_size_for_debug_pub_msg));
   qos_marker.transient_local();
   qos_marker.reliable();
   pub_marker_mapped_ = this->create_publisher<MarkerArray>("~/debug/marker_mapped", qos_marker);
-  pub_marker_detected_ = this->create_publisher<PoseArray>("~/debug/marker_detected", 10);
-  pub_debug_pose_with_covariance_ =
-    this->create_publisher<PoseWithCovarianceStamped>("~/debug/pose_with_covariance", 10);
-  pub_marker_pointcloud_ = this->create_publisher<PointCloud2>("~/debug/marker_pointcloud", 10);
+  pub_marker_detected_ = this->create_publisher<PoseArray>(
+    "~/debug/marker_detected", param_.queue_size_for_debug_pub_msg);
+  pub_debug_pose_with_covariance_ = this->create_publisher<PoseWithCovarianceStamped>(
+    "~/debug/pose_with_covariance", param_.queue_size_for_debug_pub_msg);
+  pub_marker_pointcloud_ = this->create_publisher<PointCloud2>(
+    "~/debug/marker_pointcloud", param_.queue_size_for_debug_pub_msg);
+
+  pub_center_intensity_grid = this->create_publisher<nav_msgs::msg::OccupancyGrid>(
+    "~/debug/center_intensity_grid", param_.queue_size_for_debug_pub_msg);
+  pub_positive_grid = this->create_publisher<nav_msgs::msg::OccupancyGrid>(
+    "~/debug/positive_grid", param_.queue_size_for_debug_pub_msg);
+  pub_negative_grid = this->create_publisher<nav_msgs::msg::OccupancyGrid>(
+    "~/debug/negative_grid", param_.queue_size_for_debug_pub_msg);
+  pub_matched_grid = this->create_publisher<nav_msgs::msg::OccupancyGrid>(
+    "~/debug/matched_grid", param_.queue_size_for_debug_pub_msg);
+  pub_vote_grid = this->create_publisher<nav_msgs::msg::OccupancyGrid>(
+    "~/debug/vote_grid", param_.queue_size_for_debug_pub_msg);
+
   service_trigger_node_ = this->create_service<SetBool>(
     "~/service/trigger_node_srv",
     std::bind(&LidarMarkerLocalizer::service_trigger_node, this, _1, _2),
@@ -432,8 +448,35 @@ std::vector<landmark_manager::Landmark> LidarMarkerLocalizer::detect_landmarks(
   }
 
   // initialize variables
+  constexpr int max_vote_percentage = 100;  // Maximum vote percentage for visualization
   std::vector<int> vote(bin_num, 0);
   std::vector<float> reference_ring_y(bin_num, std::numeric_limits<float>::max());
+
+  nav_msgs::msg::OccupancyGrid center_intensity_grid_msg;
+  center_intensity_grid_msg.header = points_msg_ptr->header;
+  center_intensity_grid_msg.header.frame_id = "base_link";
+  center_intensity_grid_msg.info.map_load_time = center_intensity_grid_msg.header.stamp;
+  center_intensity_grid_msg.info.resolution = param_.resolution;
+  center_intensity_grid_msg.info.width = bin_num;
+  center_intensity_grid_msg.info.height = ring_num;
+  center_intensity_grid_msg.info.origin.position.x = min_x;
+  center_intensity_grid_msg.info.origin.position.y = param_.marker_to_vehicle_offset_y;
+  center_intensity_grid_msg.info.origin.position.z =
+    param_.marker_height_from_ground +
+    center_intensity_grid_msg.info.height * center_intensity_grid_msg.info.resolution / 2.0;
+  center_intensity_grid_msg.info.origin.orientation =
+    autoware_utils_geometry::create_quaternion_from_rpy(-M_PI / 2.0, 0.0, 0.0);
+  center_intensity_grid_msg.data = std::vector<int8_t>(
+    center_intensity_grid_msg.info.width * center_intensity_grid_msg.info.height, -1);
+
+  nav_msgs::msg::OccupancyGrid positive_grid_msg;
+  positive_grid_msg = center_intensity_grid_msg;
+
+  nav_msgs::msg::OccupancyGrid negative_grid_msg;
+  negative_grid_msg = center_intensity_grid_msg;
+
+  nav_msgs::msg::OccupancyGrid matched_grid_msg;
+  matched_grid_msg = center_intensity_grid_msg;
 
   // for each ring
   for (const auto & one_ring : ring_points) {
@@ -513,9 +556,19 @@ std::vector<landmark_manager::Landmark> LidarMarkerLocalizer::detect_landmarks(
           // ignore param_.intensity_pattern[j] == 0
         }
       }
+      const size_t bin_position = i + param_.intensity_pattern.size() / 2 + ring_id * bin_num;
+      center_intensity_grid_msg.data[bin_position] =
+        std::min(static_cast<int>(center_intensity), max_vote_percentage);
+      positive_grid_msg.data[bin_position] = std::min(
+        static_cast<int>(pos * (max_vote_percentage / param_.positive_match_num_threshold)),
+        max_vote_percentage);
+      negative_grid_msg.data[bin_position] = std::min(
+        static_cast<int>(neg * (max_vote_percentage / param_.negative_match_num_threshold)),
+        max_vote_percentage);
 
       if (
         pos >= param_.positive_match_num_threshold && neg >= param_.negative_match_num_threshold) {
+        matched_grid_msg.data[bin_position] = max_vote_percentage;
         vote[i]++;
       }
     }
@@ -536,6 +589,38 @@ std::vector<landmark_manager::Landmark> LidarMarkerLocalizer::detect_landmarks(
       detected_landmarks.push_back(landmark_manager::Landmark{"0", marker_pose_on_base_link});
     }
   }
+
+  nav_msgs::msg::OccupancyGrid vote_grid_msg;
+  vote_grid_msg.header = points_msg_ptr->header;
+  vote_grid_msg.header.frame_id = "base_link";
+  vote_grid_msg.info.map_load_time = vote_grid_msg.header.stamp;
+  vote_grid_msg.info.resolution = param_.resolution;
+  vote_grid_msg.info.width = bin_num;
+  vote_grid_msg.info.height = 1;
+  vote_grid_msg.info.origin.position.x = min_x;
+  vote_grid_msg.info.origin.position.y = (param_.marker_to_vehicle_offset_y >= 0.0) ? 1.0 : -1.0;
+  vote_grid_msg.info.origin.position.z = 0.0;
+  vote_grid_msg.info.origin.orientation.x = 0.0;
+  vote_grid_msg.info.origin.orientation.y = 0.0;
+  vote_grid_msg.info.origin.orientation.z = 0.0;
+  vote_grid_msg.info.origin.orientation.w = 1.0;
+  vote_grid_msg.data = std::vector<int8_t>(vote_grid_msg.info.width * vote_grid_msg.info.height);
+
+  int vote_max = 1;  // NOTE: set non-zero to avoid zero division error
+  for (int i = 0; i < bin_num; i++) {
+    vote_max = std::max(vote[i], vote_max);
+  }
+
+  for (size_t i = 0; i < bin_num - param_.intensity_pattern.size(); i++) {
+    const size_t bin_position = i + param_.intensity_pattern.size() / 2;
+    vote_grid_msg.data[bin_position] = vote[i] * (max_vote_percentage / vote_max);
+  }
+
+  pub_center_intensity_grid->publish(center_intensity_grid_msg);
+  pub_positive_grid->publish(positive_grid_msg);
+  pub_negative_grid->publish(negative_grid_msg);
+  pub_matched_grid->publish(matched_grid_msg);
+  pub_vote_grid->publish(vote_grid_msg);
 
   return detected_landmarks;
 }

--- a/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/src/lidar_marker_localizer.cpp
+++ b/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/src/lidar_marker_localizer.cpp
@@ -64,6 +64,8 @@ LidarMarkerLocalizer::LidarMarkerLocalizer(const rclcpp::NodeOptions & node_opti
     this->declare_parameter<int64_t>("vote_threshold_for_detect_marker");
   param_.marker_to_vehicle_offset_y = this->declare_parameter<double>("marker_to_vehicle_offset_y");
   param_.marker_height_from_ground = this->declare_parameter<double>("marker_height_from_ground");
+  param_.lower_ring_id_init = this->declare_parameter<int64_t>("lower_ring_id_init");
+  param_.upper_ring_id_init = this->declare_parameter<int64_t>("upper_ring_id_init");
   param_.self_pose_timeout_sec = this->declare_parameter<double>("self_pose_timeout_sec");
   param_.self_pose_distance_tolerance_m =
     this->declare_parameter<double>("self_pose_distance_tolerance_m");
@@ -422,8 +424,9 @@ std::vector<landmark_manager::Landmark> LidarMarkerLocalizer::detect_landmarks(
     return std::vector<landmark_manager::Landmark>{};
   }
 
-  uint16_t lower_ring_id = 128;
-  uint16_t upper_ring_id = 0;
+  // Use parameters for initial lower/upper ring id
+  uint16_t lower_ring_id = static_cast<uint16_t>(param_.lower_ring_id_init);
+  uint16_t upper_ring_id = static_cast<uint16_t>(param_.upper_ring_id_init);
   for (const auto & point : points_ptr->points) {
     lower_ring_id = std::min(get_ring_id(point), lower_ring_id);
     upper_ring_id = std::max(get_ring_id(point), upper_ring_id);

--- a/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/src/lidar_marker_localizer.cpp
+++ b/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/src/lidar_marker_localizer.cpp
@@ -40,12 +40,6 @@
 namespace autoware::lidar_marker_localizer
 {
 
-landmark_manager::Landmark get_nearest_landmark(
-  const geometry_msgs::msg::Pose & self_pose,
-  const std::vector<landmark_manager::Landmark> & landmarks);
-std::array<double, 36> rotate_covariance(
-  const std::array<double, 36> & src_covariance, const Eigen::Matrix3d & rotation);
-
 LidarMarkerLocalizer::LidarMarkerLocalizer(const rclcpp::NodeOptions & node_options)
 : Node("lidar_marker_localizer", node_options), is_activated_(false)
 {
@@ -546,9 +540,9 @@ std::vector<landmark_manager::Landmark> LidarMarkerLocalizer::detect_landmarks(
   return detected_landmarks;
 }
 
-landmark_manager::Landmark get_nearest_landmark(
+landmark_manager::Landmark LidarMarkerLocalizer::get_nearest_landmark(
   const geometry_msgs::msg::Pose & self_pose,
-  const std::vector<landmark_manager::Landmark> & landmarks)
+  const std::vector<landmark_manager::Landmark> & landmarks) const
 {
   landmark_manager::Landmark nearest_landmark;
   double min_distance = std::numeric_limits<double>::max();
@@ -567,8 +561,8 @@ landmark_manager::Landmark get_nearest_landmark(
   return nearest_landmark;
 }
 
-std::array<double, 36> rotate_covariance(
-  const std::array<double, 36> & src_covariance, const Eigen::Matrix3d & rotation)
+std::array<double, 36> LidarMarkerLocalizer::rotate_covariance(
+  const std::array<double, 36> & src_covariance, const Eigen::Matrix3d & rotation) const
 {
   std::array<double, 36> ret_covariance = src_covariance;
 

--- a/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/src/lidar_marker_localizer.cpp
+++ b/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/src/lidar_marker_localizer.cpp
@@ -443,11 +443,13 @@ std::vector<landmark_manager::Landmark> LidarMarkerLocalizer::detect_landmarks(
     // Use actual range when parameter range is invalid
     lower_ring_id = actual_min_ring_id;
     upper_ring_id = actual_max_ring_id;
-  } else if (actual_min_ring_id != param_lower_ring_id || actual_max_ring_id != param_upper_ring_id) {
+  } else if (
+    actual_min_ring_id != param_lower_ring_id || actual_max_ring_id != param_upper_ring_id) {
     // Check if pointcloud contains rings not matching the configured filter range
     RCLCPP_WARN_STREAM_THROTTLE(
       this->get_logger(), *this->get_clock(), 1000,
-      "Pointcloud contains rings not matching the configured filter range. Narrowing down the range. "
+      "Pointcloud contains rings not matching the configured filter range. Narrowing down the "
+      "range. "
         << "Actual range: [" << actual_min_ring_id << ", " << actual_max_ring_id
         << "], Configured range: [" << param_lower_ring_id << ", " << param_upper_ring_id << "]");
     // Use narrowed-down range for ring filter
@@ -619,7 +621,8 @@ std::vector<landmark_manager::Landmark> LidarMarkerLocalizer::detect_landmarks(
           // ignore param_.intensity_pattern[j] == 0
         }
       }
-      const size_t bin_position = i + param_.intensity_pattern.size() / 2 + ring_array_index * bin_num;
+      const size_t bin_position =
+        i + param_.intensity_pattern.size() / 2 + ring_array_index * bin_num;
       center_intensity_grid_msg.data[bin_position] =
         std::min(static_cast<int>(center_intensity), max_vote_percentage);
       positive_grid_msg.data[bin_position] = std::min(

--- a/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/src/lidar_marker_localizer.cpp
+++ b/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/src/lidar_marker_localizer.cpp
@@ -89,6 +89,8 @@ LidarMarkerLocalizer::LidarMarkerLocalizer(const rclcpp::NodeOptions & node_opti
     this->declare_parameter<std::string>("save_file_directory_path");
   param_.save_file_name = this->declare_parameter<std::string>("save_file_name");
   param_.save_frame_id = this->declare_parameter<std::string>("save_frame_id");
+  param_.radius_for_extracting_marker_pointcloud =
+    this->declare_parameter<double>("radius_for_extracting_marker_pointcloud");
 
   ekf_pose_buffer_ = std::make_unique<autoware::localization_util::SmartPoseBuffer>(
     this->get_logger(), param_.self_pose_timeout_sec, param_.self_pose_distance_tolerance_m);
@@ -327,6 +329,17 @@ void LidarMarkerLocalizer::main_process(const PointCloud2::ConstSharedPtr & poin
     return;
   }
 
+  const landmark_manager::Landmark nearest_detected_landmark =
+    get_nearest_landmark(self_pose, detected_landmarks);
+
+  if (is_xyziradrt) {
+    save_intensity<autoware::point_types::PointXYZIRADRT>(
+      points_msg_ptr, nearest_detected_landmark.pose);
+  } else {
+    save_intensity<autoware::point_types::PointXYZIRC>(
+      points_msg_ptr, nearest_detected_landmark.pose);
+  }
+
   // (5) Apply diff pose to self pose
   // only x and y is changed
   PoseWithCovarianceStamped result;
@@ -349,8 +362,6 @@ void LidarMarkerLocalizer::main_process(const PointCloud2::ConstSharedPtr & poin
   pub_debug_pose_with_covariance_->publish(result);
 
   // for debug
-  const landmark_manager::Landmark nearest_detected_landmark =
-    get_nearest_landmark(self_pose, detected_landmarks);
   const auto marker_pointcloud_msg_ptr =
     extract_marker_pointcloud(points_msg_ptr, nearest_detected_landmark.pose);
   pub_marker_pointcloud_->publish(*marker_pointcloud_msg_ptr);
@@ -659,6 +670,105 @@ void LidarMarkerLocalizer::save_detected_marker_log(
   csv_file.close();
 }
 
+template <typename PointT>
+void LidarMarkerLocalizer::save_intensity(
+  const sensor_msgs::msg::PointCloud2::ConstSharedPtr & points_msg_ptr, const Pose marker_pose)
+{
+  // convert from ROSMsg to PCL
+  typename pcl::PointCloud<PointT>::Ptr points_ptr(new pcl::PointCloud<PointT>);
+  pcl::fromROSMsg(*points_msg_ptr, *points_ptr);
+
+  typename pcl::PointCloud<PointT>::Ptr marker_points_ptr(new pcl::PointCloud<PointT>);
+  pcl::PointCloud<pcl::PointXYZI>::Ptr marker_points_xyzi_ptr(new pcl::PointCloud<pcl::PointXYZI>);
+  std::vector<int> ring_array;
+
+  // extract marker pointcloud
+  for (const auto & point : points_ptr->points) {
+    const double xy_distance = std::sqrt(
+      std::pow(point.x - marker_pose.position.x, 2.0) +
+      std::pow(point.y - marker_pose.position.y, 2.0));
+    if (xy_distance < param_.radius_for_extracting_marker_pointcloud) {
+      marker_points_ptr->push_back(point);
+
+      pcl::PointXYZI xyzi;
+      xyzi.x = point.x;
+      xyzi.y = point.y;
+      xyzi.z = point.z;
+      xyzi.intensity = point.intensity;
+      marker_points_xyzi_ptr->push_back(xyzi);
+
+      ring_array.push_back(get_ring_id(point));
+    }
+  }
+
+  // Convert PCL to ROS message for transformation
+  sensor_msgs::msg::PointCloud2::SharedPtr marker_points_xyzi_msg_ptr(
+    new sensor_msgs::msg::PointCloud2);
+  pcl::toROSMsg(*marker_points_xyzi_ptr, *marker_points_xyzi_msg_ptr);
+  marker_points_xyzi_msg_ptr->header = points_msg_ptr->header;
+
+  // transform input_frame to save_frame_id
+  sensor_msgs::msg::PointCloud2::SharedPtr marker_points_msg_sensor_frame_ptr(
+    new sensor_msgs::msg::PointCloud2);
+  transform_sensor_measurement(
+    param_.save_frame_id, points_msg_ptr->header.frame_id, marker_points_xyzi_msg_ptr,
+    marker_points_msg_sensor_frame_ptr);
+
+  // Convert back to PCL for processing
+  pcl::PointCloud<pcl::PointXYZI>::Ptr marker_points_sensor_frame_ptr(
+    new pcl::PointCloud<pcl::PointXYZI>);
+  pcl::fromROSMsg(*marker_points_msg_sensor_frame_ptr, *marker_points_sensor_frame_ptr);
+
+  // visualize for debug
+  marker_points_sensor_frame_ptr->width = marker_points_sensor_frame_ptr->size();
+  marker_points_sensor_frame_ptr->height = 1;
+  marker_points_sensor_frame_ptr->is_dense = false;
+
+  PointCloud2 viz_pointcloud_msg;
+  pcl::toROSMsg(*marker_points_sensor_frame_ptr, viz_pointcloud_msg);
+  viz_pointcloud_msg.header = points_msg_ptr->header;
+  viz_pointcloud_msg.header.frame_id = param_.save_frame_id;
+
+  pub_marker_pointcloud_->publish(viz_pointcloud_msg);
+
+  if (!param_.enable_save_log) {
+    return;
+  }
+
+  // to csv format
+  std::stringstream log_message;
+  size_t i = 0;
+  log_message << "point.position.x,point.position.y,point.position.z,point.intensity,point.ring"
+              << std::endl;
+  for (const auto & point : marker_points_sensor_frame_ptr->points) {
+    log_message << point.x;
+    log_message << "," << point.y;
+    log_message << "," << point.z;
+    log_message << "," << point.intensity;
+    log_message << "," << ring_array.at(i++);
+    log_message << std::endl;
+  }
+
+  // create file name
+  const double times_seconds = rclcpp::Time(points_msg_ptr->header.stamp).seconds();
+  double time_integer_tmp = 0.0;
+  double time_decimal = std::modf(times_seconds, &time_integer_tmp);
+  auto time_integer = static_cast<int64_t>(time_integer_tmp);
+  struct tm * time_info{};
+  time_info = std::localtime(&time_integer);
+  std::stringstream file_name;
+  file_name << param_.save_file_name << std::put_time(time_info, "%Y%m%d-%H%M%S") << "-"
+            << std::setw(3) << std::setfill('0') << static_cast<int>((time_decimal) * 1000)
+            << ".csv";
+
+  // write log_message to file
+  std::filesystem::path save_file_directory_path = param_.save_file_directory_path;
+  std::filesystem::create_directories(save_file_directory_path);
+  std::ofstream csv_file(save_file_directory_path.append(file_name.str()));
+  csv_file << log_message.str();
+  csv_file.close();
+}
+
 // Transform pointcloud from source_frame to target_frame
 // If PointType would be used in this function, this function should be templated
 void LidarMarkerLocalizer::transform_sensor_measurement(
@@ -696,6 +806,10 @@ template std::vector<landmark_manager::Landmark> LidarMarkerLocalizer::detect_la
   autoware::point_types::PointXYZIRC>(const PointCloud2::ConstSharedPtr &);
 template std::vector<landmark_manager::Landmark> LidarMarkerLocalizer::detect_landmarks<
   autoware::point_types::PointXYZIRADRT>(const PointCloud2::ConstSharedPtr &);
+template void LidarMarkerLocalizer::save_intensity<autoware::point_types::PointXYZIRC>(
+  const sensor_msgs::msg::PointCloud2::ConstSharedPtr &, const Pose);
+template void LidarMarkerLocalizer::save_intensity<autoware::point_types::PointXYZIRADRT>(
+  const sensor_msgs::msg::PointCloud2::ConstSharedPtr &, const Pose);
 
 }  // namespace autoware::lidar_marker_localizer
 

--- a/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/src/lidar_marker_localizer.cpp
+++ b/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/src/lidar_marker_localizer.cpp
@@ -76,6 +76,7 @@ LidarMarkerLocalizer::LidarMarkerLocalizer(const rclcpp::NodeOptions & node_opti
     this->declare_parameter<double>("limit_distance_from_self_pose_to_nearest_marker_y");
   param_.limit_distance_from_self_pose_to_marker =
     this->declare_parameter<double>("limit_distance_from_self_pose_to_marker");
+  param_.reference_ring_number = this->declare_parameter<int64_t>("reference_ring_number");
   std::vector<double> base_covariance =
     this->declare_parameter<std::vector<double>>("base_covariance");
   for (std::size_t i = 0; i < base_covariance.size(); ++i) {
@@ -386,7 +387,7 @@ std::vector<landmark_manager::Landmark> LidarMarkerLocalizer::detect_landmarks(
 
   // initialize variables
   std::vector<int> vote(bin_num, 0);
-  std::vector<float> min_y(bin_num, std::numeric_limits<float>::max());
+  std::vector<float> reference_ring_y(bin_num, std::numeric_limits<float>::max());
 
   // for each channel
   for (const pcl::PointCloud<autoware::point_types::PointXYZIRC> & one_ring : ring_points) {
@@ -398,7 +399,11 @@ std::vector<landmark_manager::Landmark> LidarMarkerLocalizer::detect_landmarks(
       const int bin_index = static_cast<int>((point.x - min_x) / param_.resolution);
       intensity_sum[bin_index] += point.intensity;
       intensity_num[bin_index]++;
-      min_y[bin_index] = std::min(min_y[bin_index], point.y);
+      if (
+        (point.ring == param_.reference_ring_number) ||
+        (param_.reference_ring_number == std::numeric_limits<uint8_t>::max())) {
+        reference_ring_y[bin_index] = std::min(reference_ring_y[bin_index], point.y);
+      }
     }
 
     // calc average
@@ -472,7 +477,7 @@ std::vector<landmark_manager::Landmark> LidarMarkerLocalizer::detect_landmarks(
         static_cast<double>(i) + static_cast<double>(param_.intensity_pattern.size()) / 2.0;
       Pose marker_pose_on_base_link;
       marker_pose_on_base_link.position.x = bin_position * param_.resolution + min_x;
-      marker_pose_on_base_link.position.y = min_y[i];
+      marker_pose_on_base_link.position.y = reference_ring_y[i];
       marker_pose_on_base_link.position.z = param_.marker_height_from_ground;
       marker_pose_on_base_link.orientation =
         autoware_utils_geometry::create_quaternion_from_rpy(M_PI_2, 0.0, 0.0);  // TODO(YamatoAndo)

--- a/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/src/lidar_marker_localizer.cpp
+++ b/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/src/lidar_marker_localizer.cpp
@@ -48,6 +48,8 @@ LidarMarkerLocalizer::LidarMarkerLocalizer(const rclcpp::NodeOptions & node_opti
 
   param_.enable_read_all_target_ids = this->declare_parameter<bool>("enable_read_all_target_ids");
   param_.target_ids = this->declare_parameter<std::vector<std::string>>("target_ids");
+  param_.queue_size_for_output_pose =
+    this->declare_parameter<int64_t>("queue_size_for_output_pose");
 
   param_.marker_name = this->declare_parameter<std::string>("marker_name");
   param_.resolution = this->declare_parameter<double>("resolution");
@@ -111,8 +113,8 @@ LidarMarkerLocalizer::LidarMarkerLocalizer(const rclcpp::NodeOptions & node_opti
     "~/input/lanelet2_map", rclcpp::QoS(10).durability(rclcpp::DurabilityPolicy::TransientLocal),
     std::bind(&LidarMarkerLocalizer::map_bin_callback, this, _1));
 
-  pub_base_link_pose_with_covariance_on_map_ =
-    this->create_publisher<PoseWithCovarianceStamped>("~/output/pose_with_covariance", 10);
+  pub_base_link_pose_with_covariance_on_map_ = this->create_publisher<PoseWithCovarianceStamped>(
+    "~/output/pose_with_covariance", param_.queue_size_for_output_pose);
   rclcpp::QoS qos_marker = rclcpp::QoS(rclcpp::KeepLast(param_.queue_size_for_debug_pub_msg));
   qos_marker.transient_local();
   qos_marker.reliable();

--- a/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/src/lidar_marker_localizer.cpp
+++ b/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/src/lidar_marker_localizer.cpp
@@ -541,16 +541,17 @@ std::vector<landmark_manager::Landmark> LidarMarkerLocalizer::detect_landmarks(
   matched_grid_msg = center_intensity_grid_msg;
 
   // for each ring
+  // ring_array_index for grid positioning (0-based index in ring_points)
+  size_t ring_array_index = 0;
   for (const auto & one_ring : ring_points) {
     if (one_ring.empty()) {
+      ring_array_index++;
       continue;
     }
 
     std::vector<double> intensity_sum(bin_num, 0.0);
     std::vector<int> intensity_num(bin_num, 0);
     std::vector<double> average_intensity(bin_num, 0.0);
-    const size_t ring_id =
-      get_ring_id(one_ring.front()) - get_ring_id(ring_points.front().points.front());
 
     for (const auto & point : one_ring.points) {
       const int bin_index = static_cast<int>((point.x - min_x) / param_.resolution);
@@ -618,7 +619,7 @@ std::vector<landmark_manager::Landmark> LidarMarkerLocalizer::detect_landmarks(
           // ignore param_.intensity_pattern[j] == 0
         }
       }
-      const size_t bin_position = i + param_.intensity_pattern.size() / 2 + ring_id * bin_num;
+      const size_t bin_position = i + param_.intensity_pattern.size() / 2 + ring_array_index * bin_num;
       center_intensity_grid_msg.data[bin_position] =
         std::min(static_cast<int>(center_intensity), max_vote_percentage);
       positive_grid_msg.data[bin_position] = std::min(
@@ -634,6 +635,7 @@ std::vector<landmark_manager::Landmark> LidarMarkerLocalizer::detect_landmarks(
         vote[i]++;
       }
     }
+    ring_array_index++;
   }
 
   std::vector<landmark_manager::Landmark> detected_landmarks;

--- a/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/src/lidar_marker_localizer.cpp
+++ b/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/src/lidar_marker_localizer.cpp
@@ -51,6 +51,9 @@ LidarMarkerLocalizer::LidarMarkerLocalizer(const rclcpp::NodeOptions & node_opti
   using std::placeholders::_1;
   using std::placeholders::_2;
 
+  param_.enable_read_all_target_ids = this->declare_parameter<bool>("enable_read_all_target_ids");
+  param_.target_ids = this->declare_parameter<std::vector<std::string>>("target_ids");
+
   param_.marker_name = this->declare_parameter<std::string>("marker_name");
   param_.resolution = this->declare_parameter<double>("resolution");
   param_.intensity_pattern = this->declare_parameter<std::vector<int64_t>>("intensity_pattern");
@@ -145,7 +148,11 @@ void LidarMarkerLocalizer::initialize_diagnostics()
 
 void LidarMarkerLocalizer::map_bin_callback(const HADMapBin::ConstSharedPtr & map_bin_msg_ptr)
 {
-  landmark_manager_.parse_landmarks(map_bin_msg_ptr, param_.marker_name);
+  if (param_.enable_read_all_target_ids) {
+    landmark_manager_.parse_landmarks(map_bin_msg_ptr, param_.marker_name);
+  } else {
+    landmark_manager_.parse_landmarks(map_bin_msg_ptr, param_.marker_name, param_.target_ids);
+  }
   const MarkerArray marker_msg = landmark_manager_.get_landmarks_as_marker_array_msg();
   pub_marker_mapped_->publish(marker_msg);
 }

--- a/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/src/lidar_marker_localizer.cpp
+++ b/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/src/lidar_marker_localizer.cpp
@@ -65,12 +65,15 @@ LidarMarkerLocalizer::LidarMarkerLocalizer(const rclcpp::NodeOptions & node_opti
     this->declare_parameter<int64_t>("negative_match_num_threshold");
   param_.vote_threshold_for_detect_marker =
     this->declare_parameter<int64_t>("vote_threshold_for_detect_marker");
+  param_.marker_to_vehicle_offset_y = this->declare_parameter<double>("marker_to_vehicle_offset_y");
   param_.marker_height_from_ground = this->declare_parameter<double>("marker_height_from_ground");
   param_.self_pose_timeout_sec = this->declare_parameter<double>("self_pose_timeout_sec");
   param_.self_pose_distance_tolerance_m =
     this->declare_parameter<double>("self_pose_distance_tolerance_m");
   param_.limit_distance_from_self_pose_to_nearest_marker =
     this->declare_parameter<double>("limit_distance_from_self_pose_to_nearest_marker");
+  param_.limit_distance_from_self_pose_to_nearest_marker_y =
+    this->declare_parameter<double>("limit_distance_from_self_pose_to_nearest_marker_y");
   param_.limit_distance_from_self_pose_to_marker =
     this->declare_parameter<double>("limit_distance_from_self_pose_to_marker");
   std::vector<double> base_covariance =
@@ -239,9 +242,16 @@ void LidarMarkerLocalizer::main_process(const PointCloud2::ConstSharedPtr & poin
   diagnostics_interface_->add_key_value(
     "distance_self_pose_to_nearest_marker", distance_from_self_pose_to_nearest_marker);
 
+  const double distance_from_self_pose_to_nearest_marker_y =
+    std::abs(nearest_marker_pose_on_base_link.position.y - param_.marker_to_vehicle_offset_y);
+  diagnostics_interface_->add_key_value(
+    "distance_from_self_pose_to_nearest_marker_y", distance_from_self_pose_to_nearest_marker_y);
+
   const bool is_exist_marker_within_self_pose =
-    distance_from_self_pose_to_nearest_marker <
-    param_.limit_distance_from_self_pose_to_nearest_marker;
+    (distance_from_self_pose_to_nearest_marker <
+     param_.limit_distance_from_self_pose_to_nearest_marker) &&
+    (distance_from_self_pose_to_nearest_marker_y <
+     param_.limit_distance_from_self_pose_to_nearest_marker_y);
 
   if (!is_detected_marker) {
     if (!is_exist_marker_within_self_pose) {

--- a/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/src/lidar_marker_localizer.cpp
+++ b/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/src/lidar_marker_localizer.cpp
@@ -357,13 +357,13 @@ void LidarMarkerLocalizer::main_process(const PointCloud2::ConstSharedPtr & poin
   }
 
   // (5) Apply diff pose to self pose
-  // only x and y is changed
+  // if z is needed to be corrected, set new_self_pose.position.z
   PoseWithCovarianceStamped result;
   result.header.stamp = sensor_ros_time;
   result.header.frame_id = "map";
   result.pose.pose.position.x = new_self_pose.position.x;
   result.pose.pose.position.y = new_self_pose.position.y;
-  result.pose.pose.position.z = new_self_pose.position.z;
+  result.pose.pose.position.z = self_pose.position.z;
   result.pose.pose.orientation = self_pose.orientation;
 
   // set covariance

--- a/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/src/lidar_marker_localizer.cpp
+++ b/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/src/lidar_marker_localizer.cpp
@@ -432,6 +432,10 @@ std::vector<landmark_manager::Landmark> LidarMarkerLocalizer::detect_landmarks(
 
   // for each ring
   for (const auto & one_ring : ring_points) {
+    if (one_ring.empty()) {
+      continue;
+    }
+
     std::vector<double> intensity_sum(bin_num, 0.0);
     std::vector<int> intensity_num(bin_num, 0);
     std::vector<double> average_intensity(bin_num, 0.0);

--- a/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/src/lidar_marker_localizer.cpp
+++ b/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/src/lidar_marker_localizer.cpp
@@ -467,12 +467,28 @@ std::vector<landmark_manager::Landmark> LidarMarkerLocalizer::detect_landmarks(
   center_intensity_grid_msg.info.width = bin_num;
   center_intensity_grid_msg.info.height = ring_num;
   center_intensity_grid_msg.info.origin.position.x = min_x;
-  center_intensity_grid_msg.info.origin.position.y = param_.marker_to_vehicle_offset_y;
-  center_intensity_grid_msg.info.origin.position.z =
-    param_.marker_height_from_ground +
-    center_intensity_grid_msg.info.height * center_intensity_grid_msg.info.resolution / 2.0;
-  center_intensity_grid_msg.info.origin.orientation =
-    autoware_utils_geometry::create_quaternion_from_rpy(-M_PI / 2.0, 0.0, 0.0);
+  if (param_.road_surface_mode) {
+    center_intensity_grid_msg.info.origin.position.y =
+      param_.marker_to_vehicle_offset_y -
+      center_intensity_grid_msg.info.height * center_intensity_grid_msg.info.resolution / 2.0;
+    center_intensity_grid_msg.info.origin.position.z = param_.marker_height_from_ground;
+    if (param_.marker_to_vehicle_offset_y >= 0) {
+      center_intensity_grid_msg.info.origin.position.y +=
+        center_intensity_grid_msg.info.height * center_intensity_grid_msg.info.resolution;
+      center_intensity_grid_msg.info.origin.orientation =
+        autoware_utils_geometry::create_quaternion_from_rpy(M_PI, 0.0, 0.0);
+    } else {
+      center_intensity_grid_msg.info.origin.orientation =
+        autoware_utils_geometry::create_quaternion_from_rpy(0.0, 0.0, 0.0);
+    }
+  } else {
+    center_intensity_grid_msg.info.origin.position.y = param_.marker_to_vehicle_offset_y;
+    center_intensity_grid_msg.info.origin.position.z =
+      param_.marker_height_from_ground +
+      center_intensity_grid_msg.info.height * center_intensity_grid_msg.info.resolution / 2.0;
+    center_intensity_grid_msg.info.origin.orientation =
+      autoware_utils_geometry::create_quaternion_from_rpy(-M_PI / 2.0, 0.0, 0.0);
+  }
   center_intensity_grid_msg.data = std::vector<int8_t>(
     center_intensity_grid_msg.info.width * center_intensity_grid_msg.info.height, -1);
 
@@ -589,7 +605,11 @@ std::vector<landmark_manager::Landmark> LidarMarkerLocalizer::detect_landmarks(
         static_cast<double>(i) + static_cast<double>(param_.intensity_pattern.size()) / 2.0;
       Pose marker_pose_on_base_link;
       marker_pose_on_base_link.position.x = bin_position * param_.resolution + min_x;
-      marker_pose_on_base_link.position.y = reference_ring_y[i];
+      if (param_.road_surface_mode) {
+        marker_pose_on_base_link.position.y = param_.marker_to_vehicle_offset_y;
+      } else {
+        marker_pose_on_base_link.position.y = reference_ring_y[i];
+      }
       marker_pose_on_base_link.position.z = param_.marker_height_from_ground;
       marker_pose_on_base_link.orientation =
         autoware_utils::create_quaternion_from_rpy(M_PI_2, 0.0, 0.0);  // TODO(YamatoAndo)
@@ -770,9 +790,14 @@ void LidarMarkerLocalizer::save_intensity(
 
   // extract marker pointcloud
   for (const auto & point : points_ptr->points) {
-    const double xy_distance = std::sqrt(
+    double xy_distance = std::sqrt(
       std::pow(point.x - marker_pose.position.x, 2.0) +
       std::pow(point.y - marker_pose.position.y, 2.0));
+    if (param_.road_surface_mode) {
+      xy_distance = std::sqrt(
+        std::pow(point.x - marker_pose.position.x, 2.0) +
+        std::pow(point.z - marker_pose.position.z, 2.0));
+    }
     if (xy_distance < param_.radius_for_extracting_marker_pointcloud) {
       marker_points_ptr->push_back(point);
 

--- a/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/src/lidar_marker_localizer.hpp
+++ b/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/src/lidar_marker_localizer.hpp
@@ -103,6 +103,7 @@ private:
 
   void initialize_diagnostics();
   void main_process(const PointCloud2::ConstSharedPtr & points_msg_ptr);
+  template <typename PointType>
   std::vector<landmark_manager::Landmark> detect_landmarks(
     const PointCloud2::ConstSharedPtr & points_msg_ptr);
   sensor_msgs::msg::PointCloud2::SharedPtr extract_marker_pointcloud(

--- a/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/src/lidar_marker_localizer.hpp
+++ b/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/src/lidar_marker_localizer.hpp
@@ -92,7 +92,6 @@ protected:
     double limit_distance_from_self_pose_to_marker;
     std::array<double, 36> base_covariance;
 
-    double marker_width;
     // Parameters for initial lower/upper ring id
     int64_t lower_ring_id_init;
     int64_t upper_ring_id_init;

--- a/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/src/lidar_marker_localizer.hpp
+++ b/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/src/lidar_marker_localizer.hpp
@@ -71,12 +71,14 @@ class LidarMarkerLocalizer : public rclcpp::Node
     int64_t positive_match_num_threshold;
     int64_t negative_match_num_threshold;
     int64_t vote_threshold_for_detect_marker;
+    double marker_to_vehicle_offset_y;
     double marker_height_from_ground;
 
     double self_pose_timeout_sec;
     double self_pose_distance_tolerance_m;
 
     double limit_distance_from_self_pose_to_nearest_marker;
+    double limit_distance_from_self_pose_to_nearest_marker_y;
     double limit_distance_from_self_pose_to_marker;
     std::array<double, 36> base_covariance;
 

--- a/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/src/lidar_marker_localizer.hpp
+++ b/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/src/lidar_marker_localizer.hpp
@@ -73,6 +73,7 @@ class LidarMarkerLocalizer : public rclcpp::Node
     int64_t vote_threshold_for_detect_marker;
     double marker_to_vehicle_offset_y;
     double marker_height_from_ground;
+    int64_t reference_ring_number;
 
     double self_pose_timeout_sec;
     double self_pose_distance_tolerance_m;

--- a/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/src/lidar_marker_localizer.hpp
+++ b/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/src/lidar_marker_localizer.hpp
@@ -25,6 +25,7 @@
 
 #include <autoware_map_msgs/msg/lanelet_map_bin.hpp>
 #include <geometry_msgs/msg/pose_array.hpp>
+#include <nav_msgs/msg/occupancy_grid.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
 #include <std_srvs/srv/set_bool.hpp>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
@@ -90,6 +91,7 @@ class LidarMarkerLocalizer : public rclcpp::Node
     std::string save_file_name;
     std::string save_frame_id;
     double radius_for_extracting_marker_pointcloud;
+    int64_t queue_size_for_debug_pub_msg;
   };
 
 public:
@@ -140,6 +142,12 @@ private:
   rclcpp::Publisher<PointCloud2>::SharedPtr pub_marker_pointcloud_;
 
   std::shared_ptr<autoware_utils_diagnostics::DiagnosticsInterface> diagnostics_interface_;
+
+  rclcpp::Publisher<nav_msgs::msg::OccupancyGrid>::SharedPtr pub_center_intensity_grid;
+  rclcpp::Publisher<nav_msgs::msg::OccupancyGrid>::SharedPtr pub_positive_grid;
+  rclcpp::Publisher<nav_msgs::msg::OccupancyGrid>::SharedPtr pub_negative_grid;
+  rclcpp::Publisher<nav_msgs::msg::OccupancyGrid>::SharedPtr pub_matched_grid;
+  rclcpp::Publisher<nav_msgs::msg::OccupancyGrid>::SharedPtr pub_vote_grid;
 
   Param param_;
   bool is_activated_;

--- a/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/src/lidar_marker_localizer.hpp
+++ b/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/src/lidar_marker_localizer.hpp
@@ -64,6 +64,8 @@ class LidarMarkerLocalizer : public rclcpp::Node
   {
     bool enable_read_all_target_ids;
     std::vector<std::string> target_ids;
+    int64_t queue_size_for_output_pose;
+
     std::string marker_name;
 
     double resolution;

--- a/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/src/lidar_marker_localizer.hpp
+++ b/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/src/lidar_marker_localizer.hpp
@@ -68,6 +68,7 @@ class LidarMarkerLocalizer : public rclcpp::Node
 
     std::string marker_name;
 
+    bool road_surface_mode;
     double resolution;
     std::vector<int64_t> intensity_pattern;
     int64_t match_intensity_difference_threshold;

--- a/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/src/lidar_marker_localizer.hpp
+++ b/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/src/lidar_marker_localizer.hpp
@@ -87,6 +87,9 @@ class LidarMarkerLocalizer : public rclcpp::Node
     std::array<double, 36> base_covariance;
 
     double marker_width;
+    // Parameters for initial lower/upper ring id
+    int64_t lower_ring_id_init;
+    int64_t upper_ring_id_init;
 
     bool enable_save_log;
     std::string save_file_directory_path;

--- a/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/src/lidar_marker_localizer.hpp
+++ b/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/src/lidar_marker_localizer.hpp
@@ -61,6 +61,8 @@ class LidarMarkerLocalizer : public rclcpp::Node
 
   struct Param
   {
+    bool enable_read_all_target_ids;
+    std::vector<std::string> target_ids;
     std::string marker_name;
 
     double resolution;

--- a/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/src/lidar_marker_localizer.hpp
+++ b/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/src/lidar_marker_localizer.hpp
@@ -60,6 +60,11 @@ class LidarMarkerLocalizer : public rclcpp::Node
   using SetBool = std_srvs::srv::SetBool;
   using DiagnosticStatus = diagnostic_msgs::msg::DiagnosticStatus;
 
+public:
+  explicit LidarMarkerLocalizer(const rclcpp::NodeOptions & node_options);
+
+protected:
+  // For test subclass access
   struct Param
   {
     bool enable_read_all_target_ids;
@@ -100,8 +105,11 @@ class LidarMarkerLocalizer : public rclcpp::Node
     int64_t queue_size_for_debug_pub_msg;
   };
 
-public:
-  explicit LidarMarkerLocalizer(const rclcpp::NodeOptions & node_options);
+  Param & mutable_param() { return param_; }
+  const Param & param() const { return param_; }
+  template <typename PointType>
+  std::vector<landmark_manager::Landmark> detect_landmarks(
+    const PointCloud2::ConstSharedPtr & points_msg_ptr);
 
 private:
   void self_pose_callback(const PoseWithCovarianceStamped::ConstSharedPtr & self_pose_msg_ptr);
@@ -112,9 +120,6 @@ private:
 
   void initialize_diagnostics();
   void main_process(const PointCloud2::ConstSharedPtr & points_msg_ptr);
-  template <typename PointType>
-  std::vector<landmark_manager::Landmark> detect_landmarks(
-    const PointCloud2::ConstSharedPtr & points_msg_ptr);
   sensor_msgs::msg::PointCloud2::SharedPtr extract_marker_pointcloud(
     const sensor_msgs::msg::PointCloud2::ConstSharedPtr & points_msg_ptr,
     const geometry_msgs::msg::Pose marker_pose) const;

--- a/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/src/lidar_marker_localizer.hpp
+++ b/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/src/lidar_marker_localizer.hpp
@@ -111,6 +111,11 @@ private:
     const sensor_msgs::msg::PointCloud2::ConstSharedPtr & points_msg_ptr,
     const geometry_msgs::msg::Pose marker_pose) const;
   void save_detected_marker_log(const sensor_msgs::msg::PointCloud2::SharedPtr & points_msg_ptr);
+  landmark_manager::Landmark get_nearest_landmark(
+    const geometry_msgs::msg::Pose & self_pose,
+    const std::vector<landmark_manager::Landmark> & landmarks) const;
+  std::array<double, 36> rotate_covariance(
+    const std::array<double, 36> & src_covariance, const Eigen::Matrix3d & rotation) const;
   template <typename PointT>
   void save_intensity(const PointCloud2::ConstSharedPtr & points_msg_ptr, const Pose marker_pose);
 

--- a/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/src/lidar_marker_localizer.hpp
+++ b/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/src/lidar_marker_localizer.hpp
@@ -17,7 +17,7 @@
 
 #include "autoware/localization_util/smart_pose_buffer.hpp"
 #include "autoware/qos_utils/qos_compatibility.hpp"
-#include "autoware_utils_diagnostics/diagnostics_interface.hpp"
+#include <autoware_utils/ros/diagnostics_interface.hpp>
 
 #include <autoware/landmark_manager/landmark_manager.hpp>
 #include <rclcpp/rclcpp.hpp>
@@ -146,7 +146,7 @@ private:
   rclcpp::Publisher<PoseWithCovarianceStamped>::SharedPtr pub_debug_pose_with_covariance_;
   rclcpp::Publisher<PointCloud2>::SharedPtr pub_marker_pointcloud_;
 
-  std::shared_ptr<autoware_utils_diagnostics::DiagnosticsInterface> diagnostics_interface_;
+  std::shared_ptr<autoware_utils::DiagnosticsInterface> diagnostics_interface_;
 
   rclcpp::Publisher<nav_msgs::msg::OccupancyGrid>::SharedPtr pub_center_intensity_grid;
   rclcpp::Publisher<nav_msgs::msg::OccupancyGrid>::SharedPtr pub_positive_grid;

--- a/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/src/lidar_marker_localizer.hpp
+++ b/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/src/lidar_marker_localizer.hpp
@@ -17,9 +17,9 @@
 
 #include "autoware/localization_util/smart_pose_buffer.hpp"
 #include "autoware/qos_utils/qos_compatibility.hpp"
-#include <autoware_utils/ros/diagnostics_interface.hpp>
 
 #include <autoware/landmark_manager/landmark_manager.hpp>
+#include <autoware_utils/ros/diagnostics_interface.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <tf2_eigen/tf2_eigen.hpp>
 

--- a/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/src/lidar_marker_localizer.hpp
+++ b/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/src/lidar_marker_localizer.hpp
@@ -89,6 +89,7 @@ class LidarMarkerLocalizer : public rclcpp::Node
     std::string save_file_directory_path;
     std::string save_file_name;
     std::string save_frame_id;
+    double radius_for_extracting_marker_pointcloud;
   };
 
 public:
@@ -110,6 +111,8 @@ private:
     const sensor_msgs::msg::PointCloud2::ConstSharedPtr & points_msg_ptr,
     const geometry_msgs::msg::Pose marker_pose) const;
   void save_detected_marker_log(const sensor_msgs::msg::PointCloud2::SharedPtr & points_msg_ptr);
+  template <typename PointT>
+  void save_intensity(const PointCloud2::ConstSharedPtr & points_msg_ptr, const Pose marker_pose);
 
   void transform_sensor_measurement(
     const std::string & source_frame, const std::string & target_frame,

--- a/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/test/test_lidar_marker_localizer.cpp
+++ b/localization/autoware_landmark_based_localizer/autoware_lidar_marker_localizer/test/test_lidar_marker_localizer.cpp
@@ -1,0 +1,171 @@
+// Copyright 2023 Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "lidar_marker_localizer.hpp"
+
+#include <autoware/point_types/types.hpp>
+
+#include <gtest/gtest.h>
+
+#include <limits>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace autoware::lidar_marker_localizer
+{
+
+class TestableLidarMarkerLocalizer : public LidarMarkerLocalizer
+{
+public:
+  using LidarMarkerLocalizer::LidarMarkerLocalizer;
+
+  template <typename PointT>
+  auto callDetectLandmarks(const sensor_msgs::msg::PointCloud2::ConstSharedPtr & points_msg_ptr)
+  {
+    return this->detect_landmarks<PointT>(points_msg_ptr);
+  }
+
+  Param & public_mutable_param() { return mutable_param(); }
+  const Param & public_param() const { return param(); }
+};
+
+class LidarMarkerLocalizerTest : public ::testing::Test
+{
+protected:
+  rclcpp::NodeOptions node_options;
+  std::shared_ptr<TestableLidarMarkerLocalizer> localizer;
+
+  void SetUp() override
+  {
+    node_options.parameter_overrides(
+      {{"enable_read_all_target_ids", false},
+       {"target_ids", std::vector<std::string>{}},
+       {"queue_size_for_output_pose", 1},
+       {"marker_name", std::string("")},
+       {"road_surface_mode", false},
+       {"resolution", 1.0},
+       {"intensity_pattern", std::vector<int64_t>{}},
+       {"match_intensity_difference_threshold", 1},
+       {"positive_match_num_threshold", 1},
+       {"negative_match_num_threshold", 1},
+       {"vote_threshold_for_detect_marker", 1},
+       {"marker_to_vehicle_offset_y", 0.0},
+       {"marker_height_from_ground", 0.0},
+       {"reference_ring_number", 0},
+       {"marker_width", 0.8},
+       {"self_pose_timeout_sec", 1.0},
+       {"self_pose_distance_tolerance_m", 1.0},
+       {"limit_distance_from_self_pose_to_nearest_marker", 1.0},
+       {"limit_distance_from_self_pose_to_nearest_marker_y", 1.0},
+       {"limit_distance_from_self_pose_to_marker", 1.0},
+       {"base_covariance", std::vector<double>(36, 0.0)},
+       {"lower_ring_id_init", 0},
+       {"upper_ring_id_init", 0},
+       {"enable_save_log", false},
+       {"save_file_directory_path", std::string("")},
+       {"save_file_name", std::string("")},
+       {"save_frame_id", std::string("")},
+       {"radius_for_extracting_marker_pointcloud", 1.0},
+       {"queue_size_for_debug_pub_msg", 1}});
+    localizer = std::make_shared<TestableLidarMarkerLocalizer>(node_options);
+  }
+};  // class LidarMarkerLocalizerTest : public ::testing::Test
+
+TEST_F(LidarMarkerLocalizerTest, Initialization)
+{
+  ASSERT_NE(localizer, nullptr);
+}
+
+TEST_F(LidarMarkerLocalizerTest, DetectLandmarksRoadSurfaceModeSwitch)
+{
+  // ダミーPointCloud2生成
+  sensor_msgs::msg::PointCloud2 cloud;
+  cloud.header.frame_id = "base_link";
+  cloud.header.stamp.sec = 0;
+  cloud.header.stamp.nanosec = 0;
+  // 必要なフィールドをセット
+  cloud.height = 1;
+  cloud.width = 2;
+  cloud.is_dense = true;
+  cloud.is_bigendian = false;
+  cloud.point_step =
+    sizeof(float) * 4 + sizeof(uint16_t) + sizeof(float);  // x, y, z, intensity, channel, dummy
+  cloud.row_step = cloud.point_step * cloud.width;
+  cloud.fields.resize(5);
+  cloud.fields[0].name = "x";
+  cloud.fields[0].offset = 0;
+  cloud.fields[0].datatype = sensor_msgs::msg::PointField::FLOAT32;
+  cloud.fields[0].count = 1;
+  cloud.fields[1].name = "y";
+  cloud.fields[1].offset = 4;
+  cloud.fields[1].datatype = sensor_msgs::msg::PointField::FLOAT32;
+  cloud.fields[1].count = 1;
+  cloud.fields[2].name = "z";
+  cloud.fields[2].offset = 8;
+  cloud.fields[2].datatype = sensor_msgs::msg::PointField::FLOAT32;
+  cloud.fields[2].count = 1;
+  cloud.fields[3].name = "intensity";
+  cloud.fields[3].offset = 12;
+  cloud.fields[3].datatype = sensor_msgs::msg::PointField::FLOAT32;
+  cloud.fields[3].count = 1;
+  cloud.fields[4].name = "channel";
+  cloud.fields[4].offset = 16;
+  cloud.fields[4].datatype = sensor_msgs::msg::PointField::UINT16;
+  cloud.fields[4].count = 1;
+  cloud.data.resize(cloud.row_step * cloud.height);
+
+  // パラメータセット
+  auto & param = localizer->public_mutable_param();
+  param.lower_ring_id_init = 0;
+  param.upper_ring_id_init = 0;
+  param.resolution = 1.0;
+  param.intensity_pattern = {1, 1};
+  param.positive_match_num_threshold = 1;
+  param.negative_match_num_threshold = 1;
+  param.match_intensity_difference_threshold = 1;
+  param.vote_threshold_for_detect_marker = 0;
+  param.marker_to_vehicle_offset_y = 123.0f;
+  param.marker_height_from_ground = 2.0f;
+  param.reference_ring_number = std::numeric_limits<uint8_t>::max();
+
+  // road_surface_mode OFF
+  param.road_surface_mode = false;
+  auto result_off = localizer->callDetectLandmarks<autoware::point_types::PointXYZIRC>(
+    std::make_shared<sensor_msgs::msg::PointCloud2>(cloud));
+  // OFF時はLandmarkのyがreference_ring_y（ダミーなのでmax値）
+  if (!result_off.empty()) {
+    EXPECT_EQ(result_off[0].pose.position.y, std::numeric_limits<float>::max());
+  }
+
+  // road_surface_mode ON
+  param.road_surface_mode = true;
+  auto result_on = localizer->callDetectLandmarks<autoware::point_types::PointXYZIRC>(
+    std::make_shared<sensor_msgs::msg::PointCloud2>(cloud));
+  // ON時はLandmarkのyがmarker_to_vehicle_offset_y
+  if (!result_on.empty()) {
+    EXPECT_EQ(result_on[0].pose.position.y, param.marker_to_vehicle_offset_y);
+  }
+}
+
+}  // namespace autoware::lidar_marker_localizer
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+  ::testing::InitGoogleTest(&argc, argv);
+  int ret = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return ret;
+}

--- a/localization/autoware_pose_estimator_arbiter/README.md
+++ b/localization/autoware_pose_estimator_arbiter/README.md
@@ -195,6 +195,7 @@ Please see the table below for details.
 | `pose_source:=yabloc_ndt_ndt_ndt`           | `["ndt","yabloc"]`                                            |
 | `pose_source:=ndt_yabloc_eagleye`           | `["ndt","yabloc","eagleye"]`                                  |
 | `pose_source:=ndt_yabloc_nan_eagleye_artag` | `["ndt","yabloc","eagleye","artag"]`                          |
+| `pose_source:=ndt_lidar-marker` | `["ndt","lidar-marker"]`                          |
 
 </details>
 
@@ -256,6 +257,7 @@ This table's usage is described from three perspectives:
 |     ndt, eagleye, artag     | ndt                           | true          | false            | true           | /sensing/gnss/pose_with_covariance           |
 |   yabloc, eagleye, artag    | yabloc                        | false         | true             | true           | /sensing/gnss/pose_with_covariance           |
 | ndt, yabloc, eagleye, artag | ndt                           | true          | true             | true           | /sensing/gnss/pose_with_covariance           |
+| ndt, lidar-marker | ndt                           | true          | false            | true           | /sensing/gnss/pose_with_covariance           |
 
 </details>
 

--- a/localization/autoware_pose_estimator_arbiter/README.md
+++ b/localization/autoware_pose_estimator_arbiter/README.md
@@ -195,7 +195,7 @@ Please see the table below for details.
 | `pose_source:=yabloc_ndt_ndt_ndt`           | `["ndt","yabloc"]`                                            |
 | `pose_source:=ndt_yabloc_eagleye`           | `["ndt","yabloc","eagleye"]`                                  |
 | `pose_source:=ndt_yabloc_nan_eagleye_artag` | `["ndt","yabloc","eagleye","artag"]`                          |
-| `pose_source:=ndt_lidar-marker` | `["ndt","lidar-marker"]`                          |
+| `pose_source:=ndt_lidar-marker`             | `["ndt","lidar-marker"]`                                      |
 
 </details>
 
@@ -257,7 +257,7 @@ This table's usage is described from three perspectives:
 |     ndt, eagleye, artag     | ndt                           | true          | false            | true           | /sensing/gnss/pose_with_covariance           |
 |   yabloc, eagleye, artag    | yabloc                        | false         | true             | true           | /sensing/gnss/pose_with_covariance           |
 | ndt, yabloc, eagleye, artag | ndt                           | true          | true             | true           | /sensing/gnss/pose_with_covariance           |
-| ndt, lidar-marker | ndt                           | true          | false            | true           | /sensing/gnss/pose_with_covariance           |
+|      ndt, lidar-marker      | ndt                           | true          | false            | true           | /sensing/gnss/pose_with_covariance           |
 
 </details>
 

--- a/localization/autoware_pose_estimator_arbiter/launch/pose_estimator_arbiter.launch.xml
+++ b/localization/autoware_pose_estimator_arbiter/launch/pose_estimator_arbiter.launch.xml
@@ -5,6 +5,13 @@
 
   <node pkg="autoware_pose_estimator_arbiter" exec="autoware_pose_estimator_arbiter_node" output="both">
     <param name="pose_sources" value="$(var pose_sources)"/>
+    <!-- modify lidar_marker_instance_names value following the lidar system that uses lidar_marker_localizer -->
+    <!-- It must correspond to the description in "launch/tier4_localization_launch/launch/pose_twist_estimator/pose_twist_estimator.launch.xml" -->
+    <param name="lidar_marker_instance_names" value="[
+      /localization/pose_estimator/lidar_marker_localizer/top_left,
+      /localization/pose_estimator/lidar_marker_localizer/top_right
+    ]"
+    />
 
     <!-- ndt -->
     <remap from="~/input/ndt/pointcloud" to="$(var input_pointcloud)"/>

--- a/localization/autoware_pose_estimator_arbiter/launch/pose_estimator_arbiter.launch.xml
+++ b/localization/autoware_pose_estimator_arbiter/launch/pose_estimator_arbiter.launch.xml
@@ -10,8 +10,7 @@
     <param name="lidar_marker_instance_names" value="[
       /localization/pose_estimator/lidar_marker_localizer/top_left,
       /localization/pose_estimator/lidar_marker_localizer/top_right
-    ]"
-    />
+    ]"/>
 
     <!-- ndt -->
     <remap from="~/input/ndt/pointcloud" to="$(var input_pointcloud)"/>

--- a/localization/autoware_pose_estimator_arbiter/src/pose_estimator_arbiter_core.cpp
+++ b/localization/autoware_pose_estimator_arbiter/src/pose_estimator_arbiter_core.cpp
@@ -16,6 +16,7 @@
 #include "pose_estimator_type.hpp"
 #include "stopper/stopper_artag.hpp"
 #include "stopper/stopper_eagleye.hpp"
+#include "stopper/stopper_lidar_marker.hpp"
 #include "stopper/stopper_ndt.hpp"
 #include "stopper/stopper_yabloc.hpp"
 #include "switch_rule/enable_all_rule.hpp"
@@ -100,6 +101,15 @@ PoseEstimatorArbiter::PoseEstimatorArbiter(const rclcpp::NodeOptions & options)
       PoseEstimatorType::artag, std::make_shared<stopper::StopperArTag>(this, shared_data_));
     sub_artag_input_ = create_subscription<Image>(
       "~/input/artag/image", sensor_qos, shared_data_->artag_input_image.create_callback());
+  }
+  if (is_running(PoseEstimatorType::lidar_marker)) {
+    // Get list of lidar_marker_localizer instance names from parameter
+    std::vector<std::string> lidar_marker_instance_names =
+      this->declare_parameter<std::vector<std::string>>("lidar_marker_instance_names");
+
+    stoppers_.emplace(
+      PoseEstimatorType::lidar_marker, std::make_shared<stopper::StopperLidarMarker>(
+                                         this, shared_data_, lidar_marker_instance_names));
   }
 
   // Subscribers for switch rule

--- a/localization/autoware_pose_estimator_arbiter/src/pose_estimator_type.hpp
+++ b/localization/autoware_pose_estimator_arbiter/src/pose_estimator_type.hpp
@@ -15,9 +15,33 @@
 #ifndef POSE_ESTIMATOR_TYPE_HPP_
 #define POSE_ESTIMATOR_TYPE_HPP_
 
+#include <magic_enum.hpp>
+
 namespace autoware::pose_estimator_arbiter
 {
-enum class PoseEstimatorType : int { ndt = 1, yabloc = 2, eagleye = 4, artag = 8 };
+enum class PoseEstimatorType : int {
+  ndt = 1,
+  yabloc = 2,
+  eagleye = 4,
+  artag = 8,
+  lidar_marker = 16
+};
 }  // namespace autoware::pose_estimator_arbiter
+
+// Customize magic_enum to use "lidar-marker" string for lidar_marker enum
+namespace magic_enum::customize
+{
+template <>
+constexpr customize_t enum_name<autoware::pose_estimator_arbiter::PoseEstimatorType>(
+  autoware::pose_estimator_arbiter::PoseEstimatorType value) noexcept
+{
+  switch (value) {
+    case autoware::pose_estimator_arbiter::PoseEstimatorType::lidar_marker:
+      return "lidar-marker";
+    default:
+      return default_tag;
+  }
+}
+}  // namespace magic_enum::customize
 
 #endif  // POSE_ESTIMATOR_TYPE_HPP_

--- a/localization/autoware_pose_estimator_arbiter/src/shared_data.hpp
+++ b/localization/autoware_pose_estimator_arbiter/src/shared_data.hpp
@@ -88,6 +88,7 @@ public:
   CallbackInvokingVariable<Image::ConstSharedPtr> artag_input_image;
   CallbackInvokingVariable<PointCloud2::ConstSharedPtr> ndt_input_points;
   CallbackInvokingVariable<Image::ConstSharedPtr> yabloc_input_image;
+  // lidar_marker does not need input relay (directly subscribes to pointcloud)
 
   // Used for switch rule
   CallbackInvokingVariable<PoseCovStamped::ConstSharedPtr> localization_pose_cov;

--- a/localization/autoware_pose_estimator_arbiter/src/stopper/base_stopper.hpp
+++ b/localization/autoware_pose_estimator_arbiter/src/stopper/base_stopper.hpp
@@ -30,7 +30,7 @@ public:
   using SharedPtr = std::shared_ptr<BaseStopper>;
 
   explicit BaseStopper(rclcpp::Node * node, std::shared_ptr<const SharedData> shared_data)
-  : logger_(node->get_logger()), shared_data_(std::move(shared_data))
+  : node_(node), logger_(node->get_logger()), shared_data_(std::move(shared_data))
   {
   }
 
@@ -45,6 +45,7 @@ public:
   virtual void set_enable(bool enabled) = 0;
 
 protected:
+  rclcpp::Node * node_;
   rclcpp::Logger logger_;
   std::shared_ptr<const SharedData> shared_data_{nullptr};
 };

--- a/localization/autoware_pose_estimator_arbiter/src/stopper/stopper_lidar_marker.hpp
+++ b/localization/autoware_pose_estimator_arbiter/src/stopper/stopper_lidar_marker.hpp
@@ -1,0 +1,63 @@
+// Copyright 2023 Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef STOPPER__STOPPER_LIDAR_MARKER_HPP_
+#define STOPPER__STOPPER_LIDAR_MARKER_HPP_
+
+#include "stopper/base_stopper.hpp"
+
+#include <std_srvs/srv/set_bool.hpp>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace autoware::pose_estimator_arbiter::stopper
+{
+class StopperLidarMarker : public BaseStopper
+{
+  using SetBool = std_srvs::srv::SetBool;
+
+public:
+  explicit StopperLidarMarker(
+    rclcpp::Node * node, const std::shared_ptr<const SharedData> shared_data,
+    const std::vector<std::string> & instance_names)
+  : BaseStopper(node, shared_data)
+  {
+    for (const auto & instance_name : instance_names) {
+      auto client = node->create_client<SetBool>(instance_name + "/trigger_node_srv");
+      trigger_clients_.push_back(client);
+    }
+  }
+
+  void set_enable(bool enabled) override
+  {
+    auto request = std::make_shared<SetBool::Request>();
+    request->data = enabled;
+
+    for (auto & client : trigger_clients_) {
+      if (!client->wait_for_service(std::chrono::seconds(1))) {
+        RCLCPP_WARN(node_->get_logger(), "Service %s not available", client->get_service_name());
+        continue;
+      }
+      client->async_send_request(request);
+    }
+  }
+
+private:
+  std::vector<rclcpp::Client<SetBool>::SharedPtr> trigger_clients_;
+};
+}  // namespace autoware::pose_estimator_arbiter::stopper
+
+#endif  // STOPPER__STOPPER_LIDAR_MARKER_HPP_

--- a/localization/autoware_pose_estimator_arbiter/src/switch_rule/enable_all_rule.cpp
+++ b/localization/autoware_pose_estimator_arbiter/src/switch_rule/enable_all_rule.cpp
@@ -35,10 +35,9 @@ EnableAllRule::EnableAllRule(
 std::unordered_map<PoseEstimatorType, bool> EnableAllRule::update()
 {
   return {
-    {PoseEstimatorType::ndt, true},
-    {PoseEstimatorType::yabloc, true},
-    {PoseEstimatorType::eagleye, true},
-    {PoseEstimatorType::artag, true},
+    {PoseEstimatorType::ndt, true},          {PoseEstimatorType::yabloc, true},
+    {PoseEstimatorType::eagleye, true},      {PoseEstimatorType::artag, true},
+    {PoseEstimatorType::lidar_marker, true},
   };
 }
 


### PR DESCRIPTION
## Description

This PR improves the ring ID range validation and filtering logic in `lidar_marker_localizer` to enhance robustness against invalid parameter settings and pointcloud range mismatches.


### 1. Add ring ID range validation and filtering ([15df717](https://github.com/autowarefoundation/autoware.universe/commit/15df717c17))

<!-- ⬇️🟢
**Benefits:**
- Prevents array index out-of-bounds access
- Improves robustness against parameter configuration errors
- Better debuggability with informative warning messages
⬆️🟢 -->

### 2. Simplify grid position calculation logic ([0a50088](https://github.com/autowarefoundation/autoware.universe/commit/0a5008804a))

<!-- ⬇️🟢
**Benefits:**
- More accurate grid position calculation
- Clearer behavior when empty rings exist
- Improved code understandability
⬆️🟢 -->

### 3. Add test cases for parameter range validation ([be81cb2](https://github.com/autowarefoundation/autoware.universe/commit/be81cb2eee))

**Added tests:**
- `ValidateParameterRange`: Verify handling of invalid parameter range (`upper < lower`)
- `CheckPointcloudRingsNotMatchingConfiguredFilterRange`: Verify case where actual range is wider than configured range
- `CheckPointcloudRingsNarrowerThanConfiguredFilterRange`: Verify case where actual range is narrower than configured range

<!-- ⬇️🟢
**Benefits:**
- Ensures correctness of changes
- Prevents future regressions
- Improves test coverage
⬆️🟢 -->


## Related links

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

- All test cases pass successfully
- the following replay test was done.
1. Build Autoware.
2. Manually apply the changes of this pull-request.
3. Rebuild Autoware.
4. Run unit tests  `colcon test --packages-select autoware_lidar_marker_localizer` and confirm the result `colcon test-result --all --verbose --test-result-base build/autoware_lidar_marker_localizer`
5. launch with `pose_source:=ndt_lidar-marker` option and replay [Sample rosbag and map](https://drive.google.com/file/d/1FuGKbkWrvL_iKmtb45PO9SZl1vAaJFVG/view?usp=sharing) .
6. Confirm lidar-marker detection.

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
