### PR TITLE
feat(pid_long): apply slope compensation for stopped acc

### DIFF
--- a/control/autoware_pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
+++ b/control/autoware_pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
@@ -816,6 +816,12 @@ PidLongitudinalController::Motion PidLongitudinalController::calcCtrlCmd(
 
     m_debug_values.setValues(DebugValues::TYPE::ACC_CMD_ACC_LIMITED, ctrl_cmd_as_pedal_pos.acc);
     m_debug_values.setValues(DebugValues::TYPE::ACC_CMD_JERK_LIMITED, ctrl_cmd_as_pedal_pos.acc);
+
+    if (m_enable_slope_compensation) {
+      const double pitch_limited =
+        std::clamp(control_data.slope_angle, m_min_pitch_rad, m_max_pitch_rad);
+      ctrl_cmd_as_pedal_pos.acc -= 9.81 * std::sin(std::abs(pitch_limited));
+    }
     m_debug_values.setValues(DebugValues::TYPE::ACC_CMD_SLOPE_APPLIED, ctrl_cmd_as_pedal_pos.acc);
 
     RCLCPP_DEBUG(


### PR DESCRIPTION
## Description
Currently, stopped_acc does not take road slope into account. Therefore, it is necessary to set a value strong enough to hold the vehicle on the steepest expected slope.

This change adds deceleration value equivalent to the absolute value of the slope to the braking command. This allows for reliable stopping even if stopped_acc is set to a lower value (e.g., a value comparable to the slope).

## Related links


## How was this PR tested?
psim
Before: Uphill slope 10% with stopped_acc: 0.4
https://github.com/user-attachments/assets/8f85f115-03d5-49dc-b624-ed1d85d55195

After: Uphill slope 10% with stopped_acc: 0.4
https://github.com/user-attachments/assets/196bc272-2f3d-409f-9024-d90971f3ffff


Uphill slope 10% with stopped_acc: 3.4
<img width="986" height="1951" alt="image" src="https://github.com/user-attachments/assets/ceeaf4ca-d780-490a-bff7-93acbe4d3c51" />




## Notes for reviewers

None.

## Interface changes

None.



## Effects on system behavior

None.
