### PR TITLE
fix(autoware_trajectory_ranker): prevent node crash when performing inner product operation

### DIFF
--- a/planning/autoware_trajectory_ranker/include/autoware/trajectory_ranker/interface/data_interface.hpp
+++ b/planning/autoware_trajectory_ranker/include/autoware/trajectory_ranker/interface/data_interface.hpp
@@ -54,7 +54,7 @@ public:
     for (size_t i = 0; i < metrics_.size() && i < weight.size(); i++) {
       const auto & w = weight.at(i);
       const auto & metric = metrics_.at(i);
-      const size_t size = std::min(w.size(), metrics.size());
+      const size_t size = std::min(w.size(), metric.size());
       scores_.at(i) = std::inner_product(w.begin(), w.begin() + size, metric.begin(), 0.0f);
     }
   }


### PR DESCRIPTION
## Description

Trajectory ranker node might crashes due to an iterator mismatch when the metric vector has fewer elements than the weight vector while performing `inner_product` operation.

This PR adds a safety guard using `std::min` to ensure the computation only iterates up to the smallest available size between the weight and metric vectors.

```shell
[autoware_trajectory_ranker_node-28] *** Aborted at 1769755095 (unix time) try "date -d @1769755095" if you are using GNU date ***
[autoware_trajectory_ranker_node-28] PC: @                0x0 (unknown)
[autoware_trajectory_ranker_node-28] *** SIGSEGV (@0x0) received by PID 456105 (TID 0x72aec6a45680) from PID 0; stack trace: ***
[autoware_trajectory_ranker_node-28]     @     0x72aec72e84d6 google::(anonymous namespace)::FailureSignalHandler()
[autoware_trajectory_ranker_node-28]     @     0x72aec6842520 (unknown)
[autoware_trajectory_ranker_node-28]     @     0x72aec55ee9a4 autoware::trajectory_ranker::Evaluator::compress()
[autoware_trajectory_ranker_node-28]     @     0x72aec55f2696 autoware::trajectory_ranker::Evaluator::best()
[autoware_trajectory_ranker_node-28]     @     0x72aec55592c7 autoware::trajectory_ranker::TrajectoryRanker::score()
[autoware_trajectory_ranker_node-28]     @     0x72aec555a598 autoware::trajectory_ranker::TrajectoryRanker::process()
[autoware_trajectory_ranker_node-28]     @     0x72aec555ab52 _ZNSt17_Function_handlerIFvSt10shared_ptrIKN31autoware_internal_planning_msgs3msg22CandidateTrajectories_ISaIvEEEEEZN8autoware17trajectory_ranker16TrajectoryRankerC4ERKN6rclcpp11NodeOptionsEEUlS7_E1_E9_M_invokeERKSt9_Any_dataOS7_
[autoware_trajectory_ranker_node-28]     @     0x72aec5588832 _ZNSt8__detail9__variant17__gen_vtable_implINS0_12_Multi_arrayIPFNS0_21__deduce_visit_resultIvEEOZN6rclcpp23AnySubscriptionCallbackIN31autoware_internal_planning_msgs3msg22CandidateTrajectories_ISaIvEEESA_E8dispatchESt10shared_ptrISB_ERKNS5_11MessageInfoEEUlOT_E_RSt7variantIJSt8functionIFvRKSB_EESN_IFvSP_SH_EESN_IFvRKNS5_17SerializedMessageEEESN_IFvSW_SH_EESN_IFvSt10unique_ptrISB_St14default_deleteISB_EEEESN_IFvS14_SH_EESN_IFvS11_ISU_S12_ISU_EEEESN_IFvS1A_SH_EESN_IFvSD_ISO_EEESN_IFvS1F_SH_EESN_IFvSD_ISV_EEESN_IFvS1K_SH_EESN_IFvRKS1F_EESN_IFvS1Q_SH_EESN_IFvRKS1K_EESN_IFvS1W_SH_EESN_IFvSE_EESN_IFvSE_SH_EESN_IFvSD_ISU_EEESN_IFvS25_SH_EEEEEJEEESt16integer_sequenceImJLm8EEEE14__visit_invokeESL_S2B_
[autoware_trajectory_ranker_node-28]     @     0x72aec55d6845 rclcpp::Subscription<>::handle_message()
[autoware_trajectory_ranker_node-28]     @     0x72aec715dba0 rclcpp::Executor::execute_subscription()
[autoware_trajectory_ranker_node-28]     @     0x72aec715f10e rclcpp::Executor::execute_any_executable()
[autoware_trajectory_ranker_node-28]     @     0x72aec7165c90 rclcpp::executors::SingleThreadedExecutor::spin()
[autoware_trajectory_ranker_node-28]     @     0x5e9ae17aa486 main
[autoware_trajectory_ranker_node-28]     @     0x72aec6829d90 (unknown)
[autoware_trajectory_ranker_node-28]     @     0x72aec6829e40 __libc_start_main
[autoware_trajectory_ranker_node-28]     @     0x5e9ae17aae35 _start
[ERROR] [autoware_trajectory_ranker_node-28]: process has died [pid 456105, exit code -11, cmd '/home/zulfaqarazmi/autoware/pilot-auto.x2.re/install/autoware_trajectory_ranker/lib/autoware_trajectory_ranker/autoware_trajectory_ranker_node --ros-args -r __node:=trajectory_ranker_node -r __ns:=/planning/trajectory_selector -p use_sim_time:=False -p wheel_radius:=0.3725 -p wheel_width:=0.215 -p wheel_base:=4.76012 -p wheel_tread:=1.754 -p front_overhang:=0.95099 -p rear_overhang:=1.52579 -p left_overhang:=0.26878 -p right_overhang:=0.26878 -p vehicle_height:=3.08 -p max_steer_angle:=0.64 -p use_sim_time:=False -p wheel_radius:=0.3725 -p wheel_width:=0.215 -p wheel_base:=4.76012 -p wheel_tread:=1.754 -p front_overhang:=0.95099 -p rear_overhang:=1.52579 -p left_overhang:=0.26878 -p right_overhang:=0.26878 -p vehicle_height:=3.08 -p max_steer_angle:=0.64 --params-file /tmp/launch_params_q2zbn66b --params-file /home/zulfaqarazmi/autoware/pilot-auto.x2.re/install/autoware_trajectory_ranker/share/autoware_trajectory_ranker/config/metrics/trajectory_consistency.param.yaml -r ~/input/candidate_trajectories:=/planning/trajectory_selector/traffic_rule_filter/candidate_trajectories -r ~/output/scored_trajectories:=/planning/trajectory_selector/ranker/scored_trajectories -r ~/input/route:=/planning/mission_planning/route -r ~/input/vector_map:=/map/vector_map -r ~/input/odometry:=/localization/kinematic_state -r ~/input/objects:=/perception/object_recognition/objects'].
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
