### PR TITLE
refactor(lane_change, static_obstacle_avoidance): replace getClosesetLanelet, fix undefined behavior for default-initialized Lanelet

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/package.xml
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/package.xml
@@ -24,6 +24,7 @@
   <depend>autoware_behavior_path_planner</depend>
   <depend>autoware_behavior_path_planner_common</depend>
   <depend>autoware_frenet_planner</depend>
+  <depend>autoware_lanelet2_utils</depend>
   <depend>autoware_motion_utils</depend>
   <depend>autoware_rtc_interface</depend>
   <depend>autoware_utils</depend>

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/scene.cpp
@@ -24,10 +24,12 @@
 #include "autoware/behavior_path_planner_common/utils/traffic_light_utils.hpp"
 #include "autoware/behavior_path_planner_common/utils/utils.hpp"
 
+#include <autoware/lanelet2_utils/nn_search.hpp>
 #include <autoware/motion_utils/trajectory/path_shift.hpp>
 #include <autoware/motion_utils/trajectory/trajectory.hpp>
 #include <autoware_frenet_planner/frenet_planner.hpp>
 #include <autoware_frenet_planner/structures.hpp>
+#include <autoware_lanelet2_extension/utility/query.hpp>
 #include <autoware_lanelet2_extension/utility/utilities.hpp>
 #include <autoware_utils/geometry/boost_polygon_utils.hpp>
 #include <autoware_utils/math/unit_conversion.hpp>
@@ -650,11 +652,12 @@ void NormalLaneChange::insert_stop_point_on_current_lanes(
 PathWithLaneId NormalLaneChange::getReferencePath() const
 {
   autoware_utils::ScopedTimeTrack st(__func__, *time_keeper_);
-  lanelet::ConstLanelet closest_lanelet;
-  if (!lanelet::utils::query::getClosestLanelet(
-        get_target_lanes(), getEgoPose(), &closest_lanelet)) {
+  const auto closest_lanelet_opt =
+    autoware::experimental::lanelet2_utils::get_closest_lanelet(get_target_lanes(), getEgoPose());
+  if (!closest_lanelet_opt) {
     return prev_module_output_.reference_path;
   }
+  const auto & closest_lanelet = closest_lanelet_opt.value();
   auto reference_path = utils::getCenterLinePathFromLanelet(closest_lanelet, planner_data_);
   if (reference_path.points.empty()) {
     return prev_module_output_.reference_path;

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/utils.cpp
@@ -29,11 +29,11 @@
 #include <autoware_utils/geometry/boost_geometry.hpp>
 // for the svg mapper
 #include <autoware/behavior_path_planner_common/utils/path_safety_checker/objects_filtering.hpp>
+#include <autoware/lanelet2_utils/nn_search.hpp>
 #include <autoware/motion_utils/trajectory/interpolation.hpp>
 #include <autoware/motion_utils/trajectory/path_with_lane_id.hpp>
 #include <autoware/motion_utils/trajectory/trajectory.hpp>
 #include <autoware_frenet_planner/frenet_planner.hpp>
-#include <autoware_lanelet2_extension/utility/query.hpp>
 #include <autoware_lanelet2_extension/utility/utilities.hpp>
 #include <autoware_utils/geometry/boost_polygon_utils.hpp>
 #include <autoware_utils/geometry/geometry.hpp>
@@ -768,11 +768,13 @@ bool is_before_terminal(
 
 double calc_angle_to_lanelet_segment(const lanelet::ConstLanelets & lanelets, const Pose & pose)
 {
-  lanelet::ConstLanelet closest_lanelet;
+  const auto closest_lanelet_opt =
+    autoware::experimental::lanelet2_utils::get_closest_lanelet(lanelets, pose);
 
-  if (!lanelet::utils::query::getClosestLanelet(lanelets, pose, &closest_lanelet)) {
+  if (!closest_lanelet_opt) {
     return autoware_utils::deg2rad(180);
   }
+  const auto & closest_lanelet = closest_lanelet_opt.value();
   const auto closest_pose = autoware::experimental::lanelet2_utils::get_closest_center_pose(
     closest_lanelet, autoware::experimental::lanelet2_utils::from_ros(pose));
   return std::abs(autoware_utils::calc_yaw_deviation(closest_pose, pose));

--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/scene.cpp
@@ -24,7 +24,7 @@
 #include "autoware/behavior_path_static_obstacle_avoidance_module/debug.hpp"
 #include "autoware/behavior_path_static_obstacle_avoidance_module/utils.hpp"
 
-#include <autoware_lanelet2_extension/utility/message_conversion.hpp>
+#include <autoware/lanelet2_utils/nn_search.hpp>
 #include <autoware_lanelet2_extension/utility/utilities.hpp>
 #include <autoware_utils/geometry/geometry.hpp>
 #include <autoware_utils/system/time_keeper.hpp>
@@ -228,10 +228,9 @@ void StaticObstacleAvoidanceModule::fillFundamentalData(
   data.extend_lanelets = utils::static_obstacle_avoidance::getExtendLanes(
     data.current_lanelets, getEgoPose(), planner_data_);
 
-  lanelet::ConstLanelet closest_lanelet{};
-  if (lanelet::utils::query::getClosestLanelet(
-        data.current_lanelets, getEgoPose(), &closest_lanelet))
-    data.closest_lanelet = closest_lanelet;
+  const auto closest_lanelet_opt = autoware::experimental::lanelet2_utils::get_closest_lanelet(
+    data.current_lanelets, getEgoPose());
+  if (closest_lanelet_opt) data.closest_lanelet = closest_lanelet_opt.value();
 
   // expand drivable lanes
   const auto is_within_current_lane =

--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/utils.cpp
@@ -22,7 +22,7 @@
 #include "autoware/behavior_path_static_obstacle_avoidance_module/utils.hpp"
 
 #include <Eigen/Dense>
-#include <autoware_lanelet2_extension/utility/message_conversion.hpp>
+#include <autoware/lanelet2_utils/nn_search.hpp>
 #include <autoware_utils_geometry/boost_geometry.hpp>
 #include <autoware_utils_uuid/uuid_helper.hpp>
 
@@ -2543,12 +2543,13 @@ std::vector<ExtendedPredictedObject> getSafetyCheckTargetObjects(
     return ret;
   }();
 
-  lanelet::ConstLanelet closest_lanelet;
   const auto & ego_pose = planner_data->self_odometry->pose.pose;
-  if (!lanelet::utils::query::getClosestLanelet(
-        data.current_lanelets, ego_pose, &closest_lanelet)) {
+  const auto closest_lanelet_opt =
+    autoware::experimental::lanelet2_utils::get_closest_lanelet(data.current_lanelets, ego_pose);
+  if (!closest_lanelet_opt) {
     return {};
   }
+  const auto & closest_lanelet = closest_lanelet_opt.value();
 
   const auto is_moving = [&parameters](const auto & object) {
     const auto & object_twist = object.kinematics.initial_twist_with_covariance.twist;


### PR DESCRIPTION
## Description

lanelet::utils::query::getClosestLanelet would be deprecated, and lanelet2_utils::get_closest_lanelet will be used instead

lanelet2_extension function would be deprecated after this PR

## Related links

https://github.com/autowarefoundation/autoware_core/pull/796
https://github.com/autowarefoundation/autoware_universe/pull/11990
https://github.com/autowarefoundation/autoware_universe/pull/11993

## How was this PR tested?

[CommonScenarioBasic](https://evaluation.tier4.jp/evaluation/reports/fc87e134-33c9-54bb-96dd-98a17ad0ee1a?project_id=autoware_dev)
[FuncVerification](https://evaluation.tier4.jp/evaluation/reports/e91225ef-3349-59ea-adeb-856c9a46d6d3?project_id=prd_jt)
[DLR](https://evaluation.tier4.jp/evaluation/reports/a0ab1961-ef6b-5f27-94af-1f0e58e09799?project_id=prd_jt)

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
