### PR TITLE
feat(safety_filter): subscribe to acceleration

### DIFF
--- a/planning/autoware_trajectory_safety_filter/include/autoware/trajectory_safety_filter/filter_context.hpp
+++ b/planning/autoware_trajectory_safety_filter/include/autoware/trajectory_safety_filter/filter_context.hpp
@@ -16,6 +16,7 @@
 #define AUTOWARE__TRAJECTORY_SAFETY_FILTER__FILTER_CONTEXT_HPP_
 
 #include <autoware_perception_msgs/msg/predicted_objects.hpp>
+#include <geometry_msgs/msg/accel_with_covariance_stamped.hpp>
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <geometry_msgs/msg/twist_stamped.hpp>
 #include <nav_msgs/msg/odometry.hpp>
@@ -35,6 +36,7 @@ namespace autoware::trajectory_safety_filter
 struct FilterContext
 {
   nav_msgs::msg::Odometry::ConstSharedPtr odometry;
+  geometry_msgs::msg::AccelWithCovarianceStamped::ConstSharedPtr acceleration;
   std::shared_ptr<lanelet::LaneletMap> lanelet_map;
   autoware_perception_msgs::msg::PredictedObjects::ConstSharedPtr predicted_objects;
 };

--- a/planning/autoware_trajectory_safety_filter/include/autoware/trajectory_safety_filter/trajectory_safety_filter_node.hpp
+++ b/planning/autoware_trajectory_safety_filter/include/autoware/trajectory_safety_filter/trajectory_safety_filter_node.hpp
@@ -31,6 +31,7 @@
 #include <autoware_perception_msgs/msg/predicted_objects.hpp>
 #include <autoware_planning_msgs/msg/lanelet_route.hpp>
 #include <autoware_planning_msgs/msg/trajectory_point.hpp>
+#include <geometry_msgs/msg/accel_with_covariance_stamped.hpp>
 #include <nav_msgs/msg/odometry.hpp>
 
 #include <memory>
@@ -44,6 +45,7 @@ using autoware_internal_planning_msgs::msg::CandidateTrajectory;
 using autoware_map_msgs::msg::LaneletMapBin;
 using autoware_perception_msgs::msg::PredictedObjects;
 using autoware_planning_msgs::msg::TrajectoryPoint;
+using geometry_msgs::msg::AccelWithCovarianceStamped;
 using nav_msgs::msg::Odometry;
 
 class TrajectorySafetyFilter : public rclcpp::Node
@@ -78,6 +80,8 @@ private:
     this, "~/input/odometry"};
   autoware_utils_rclcpp::InterProcessPollingSubscriber<PredictedObjects> sub_objects_{
     this, "~/input/objects"};
+  autoware_utils_rclcpp::InterProcessPollingSubscriber<AccelWithCovarianceStamped>
+    sub_acceleration_{this, "~/input/acceleration"};
 
   rclcpp::Subscription<CandidateTrajectories>::SharedPtr sub_trajectories_;
 

--- a/planning/autoware_trajectory_safety_filter/launch/trajectory_safety_filter.launch.xml
+++ b/planning/autoware_trajectory_safety_filter/launch/trajectory_safety_filter.launch.xml
@@ -6,6 +6,7 @@
   <arg name="input_vector_map" default="~/input/vector_map"/>
   <arg name="input_odometry" default="~/input/odometry"/>
   <arg name="input_objects" default="~/input/objects"/>
+  <arg name="input_acceleration" default="~/input/acceleration"/>
 
   <node pkg="autoware_trajectory_safety_filter" exec="autoware_trajectory_safety_filter_node" name="trajectory_safety_filter_node" output="screen">
     <param from="$(var trajectory_safety_filter_param_path)" allow_substs="true"/>
@@ -14,5 +15,6 @@
     <remap from="~/input/lanelet2_map" to="$(var input_vector_map)"/>
     <remap from="~/input/odometry" to="$(var input_odometry)"/>
     <remap from="~/input/objects" to="$(var input_objects)"/>
+    <remap from="~/input/acceleration" to="$(var input_acceleration)"/>
   </node>
 </launch>

--- a/planning/autoware_trajectory_safety_filter/src/trajectory_safety_filter_node.cpp
+++ b/planning/autoware_trajectory_safety_filter/src/trajectory_safety_filter_node.cpp
@@ -78,6 +78,11 @@ void TrajectorySafetyFilter::process(const CandidateTrajectories::ConstSharedPtr
     return;
   }
 
+  context.acceleration = sub_acceleration_.take_data();
+  if (!context.acceleration) {
+    return;
+  }
+
   context.lanelet_map = lanelet_map_ptr_;
   if (!context.lanelet_map) {
     return;


### PR DESCRIPTION
## Description

Subscribe to acceleration.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
