### PR TITLE
refactor(planning): deprecate getClosestLanelet usage

### DIFF
--- a/planning/autoware_mission_planner_universe/src/mission_planner/mission_planner.cpp
+++ b/planning/autoware_mission_planner_universe/src/mission_planner/mission_planner.cpp
@@ -15,9 +15,9 @@
 #include "mission_planner.hpp"
 
 #include <autoware/lanelet2_utils/conversion.hpp>
+#include <autoware/lanelet2_utils/nn_search.hpp>
 #include <autoware/mission_planner_universe/service_utils.hpp>
 #include <autoware_lanelet2_extension/utility/message_conversion.hpp>
-#include <autoware_lanelet2_extension/utility/query.hpp>
 #include <autoware_lanelet2_extension/utility/utilities.hpp>
 
 #include <autoware_map_msgs/msg/lanelet_map_bin.hpp>
@@ -719,11 +719,13 @@ bool MissionPlanner::check_reroute_safety(
       start_lanelets.push_back(lanelet);
     }
     // closest lanelet in start lanelets
-    lanelet::ConstLanelet closest_lanelet;
-    if (!lanelet::utils::query::getClosestLanelet(start_lanelets, current_pose, &closest_lanelet)) {
+    const auto closest_lanelet_opt =
+      experimental::lanelet2_utils::get_closest_lanelet(start_lanelets, current_pose);
+    if (!closest_lanelet_opt) {
       RCLCPP_ERROR(get_logger(), "Check reroute safety failed. Cannot find the closest lanelet.");
       return false;
     }
+    const auto & closest_lanelet = closest_lanelet_opt.value();
 
     const auto & centerline_2d = lanelet::utils::to2D(closest_lanelet.centerline());
     const auto lanelet_point = lanelet::utils::conversion::toLaneletPoint(current_pose.position);
@@ -742,11 +744,13 @@ bool MissionPlanner::check_reroute_safety(
       start_lanelets.push_back(lanelet);
     }
     // closest lanelet in start lanelets
-    lanelet::ConstLanelet closest_lanelet;
-    if (!lanelet::utils::query::getClosestLanelet(start_lanelets, current_pose, &closest_lanelet)) {
+    const auto closest_lanelet_opt =
+      experimental::lanelet2_utils::get_closest_lanelet(start_lanelets, current_pose);
+    if (!closest_lanelet_opt) {
       RCLCPP_ERROR(get_logger(), "Check reroute safety failed. Cannot find the closest lanelet.");
       return false;
     }
+    const auto & closest_lanelet = closest_lanelet_opt.value();
 
     const auto & centerline_2d = lanelet::utils::to2D(closest_lanelet.centerline());
     const auto lanelet_point = lanelet::utils::conversion::toLaneletPoint(current_pose.position);

--- a/planning/autoware_remaining_distance_time_calculator/src/remaining_distance_time_calculator_node.cpp
+++ b/planning/autoware_remaining_distance_time_calculator/src/remaining_distance_time_calculator_node.cpp
@@ -15,6 +15,7 @@
 #include "remaining_distance_time_calculator_node.hpp"
 
 #include <autoware/lanelet2_utils/conversion.hpp>
+#include <autoware/lanelet2_utils/nn_search.hpp>
 #include <autoware_lanelet2_extension/utility/query.hpp>
 #include <autoware_lanelet2_extension/utility/utilities.hpp>
 #include <autoware_utils/geometry/geometry.hpp>
@@ -102,19 +103,23 @@ void RemainingDistanceTimeCalculatorNode::on_map(const HADMapBin::ConstSharedPtr
 
 void RemainingDistanceTimeCalculatorNode::compute_route()
 {
-  lanelet::ConstLanelet current_lanelet;
-  if (!lanelet::utils::query::getClosestLanelet(
-        road_lanes_, current_vehicle_pose_, &current_lanelet)) {
+  const auto current_lanelet_opt =
+    experimental::lanelet2_utils::get_closest_lanelet(road_lanes_, current_vehicle_pose_);
+  if (!current_lanelet_opt) {
     RCLCPP_WARN_STREAM_THROTTLE(
       this->get_logger(), *get_clock(), 3000, "Failed to find current lanelet.");
     return;
   }
+  const auto & current_lanelet = current_lanelet_opt.value();
 
-  if (!lanelet::utils::query::getClosestLanelet(road_lanes_, goal_pose_, &goal_lanelet_)) {
+  const auto goal_lanelet_opt =
+    experimental::lanelet2_utils::get_closest_lanelet(road_lanes_, goal_pose_);
+  if (!goal_lanelet_opt) {
     RCLCPP_WARN_STREAM_THROTTLE(
       this->get_logger(), *get_clock(), 3000, "Failed to find goal lanelet.");
     return;
   }
+  goal_lanelet_ = goal_lanelet_opt.value();
 
   const lanelet::Optional<lanelet::routing::Route> optional_route =
     routing_graph_ptr_->getRoute(current_lanelet, goal_lanelet_, 0);
@@ -186,14 +191,15 @@ void RemainingDistanceTimeCalculatorNode::on_timer()
 
 void RemainingDistanceTimeCalculatorNode::calculate_remaining_distance()
 {
-  lanelet::ConstLanelet current_lanelet;
-  if (!lanelet::utils::query::getClosestLanelet(
-        current_lanes_, current_vehicle_pose_, &current_lanelet)) {
+  const auto current_lanelet_opt =
+    experimental::lanelet2_utils::get_closest_lanelet(current_lanes_, current_vehicle_pose_);
+  if (!current_lanelet_opt) {
     RCLCPP_WARN_STREAM_THROTTLE(
       this->get_logger(), *get_clock(), 3000, "Failed to find current lanelet.");
 
     return;
   }
+  const auto & current_lanelet = current_lanelet_opt.value();
 
   if (
     current_lanes_.empty() || current_lanes_lengths_.empty() ||
@@ -217,8 +223,8 @@ void RemainingDistanceTimeCalculatorNode::calculate_remaining_distance()
 
   remaining_distance_ = std::invoke([&]() -> double {
     // remaining distance in current lanelet (if it is not the goal lanelet)
-    lanelet::ArcCoordinates arc_coord =
-      lanelet::utils::getArcCoordinates({current_lanelet}, current_vehicle_pose_);
+    lanelet::ArcCoordinates arc_coord = lanelet::utils::getArcCoordinates(
+      lanelet::ConstLanelets{current_lanelet}, current_vehicle_pose_);
     double this_lanelet_length = lanelet::geometry::length2d(current_lanelet);
     double dist_in_current_lanelet =
       (current_lanelet.id() != goal_lanelet_.id()) ? this_lanelet_length - arc_coord.length : 0.0;


### PR DESCRIPTION
## Description

lanelet::utils::query::getClosestLanelet would be deprecated, and lanelet2_utils::get_closest_lanelet will be used instead

lanelet2_extension function would be deprecated after this PR

## Related links

https://github.com/autowarefoundation/autoware_core/pull/796
https://github.com/autowarefoundation/autoware_universe/pull/11990
https://github.com/autowarefoundation/autoware_universe/pull/11993
https://github.com/autowarefoundation/autoware_universe/pull/12010

## How was this PR tested?

- [Common](https://evaluation.tier4.jp/evaluation/reports/7b25d288-c4b1-56f9-89d5-c8377b9567c4?project_id=autoware_dev)
- [DLR](https://evaluation.tier4.jp/evaluation/reports/bd6af998-ccb1-589b-99eb-3e6f11155004?project_id=prd_jt)
- [FuncVerification](https://evaluation.tier4.jp/evaluation/reports/e7314d99-ca96-5e2a-a4ec-dd7072306d75?project_id=prd_jt)

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
