### PR TITLE
fix(smart_mpc_trajectory_follower): remove cmake pip install command

### DIFF
--- a/control/autoware_smart_mpc_trajectory_follower/CMakeLists.txt
+++ b/control/autoware_smart_mpc_trajectory_follower/CMakeLists.txt
@@ -11,9 +11,6 @@ autoware_package()
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-ignored-optimization-argument")
 
-execute_process(COMMAND bash -c "pip3 install numba==0.58.1 --force-reinstall")
-execute_process(COMMAND bash -c "pip3 install GPy")
-
 pybind11_add_module(proxima_calc SHARED
   ${PROJECT_NAME}/src/proxima_calc.cpp
 )

--- a/control/autoware_smart_mpc_trajectory_follower/README.md
+++ b/control/autoware_smart_mpc_trajectory_follower/README.md
@@ -17,6 +17,14 @@ This technology makes it relatively easy to operate model predictive control, wh
   </a>
 </p>
 
+## Requirements
+
+It's recommended to install these in a virtual environment.
+
+```bash
+pip3 install numba==0.58.1 GPy
+```
+
 ## Provided features
 
 This package provides smart MPC logic for path-following control as well as mechanisms for learning and evaluation. These features are described below.


### PR DESCRIPTION
## Description

- Resolves https://github.com/autowarefoundation/autoware_universe/issues/11943

## Background (from the issue)

After looking into this package’s `CMakeLists.txt`, I noticed the following lines:

https://github.com/autowarefoundation/autoware_universe/blob/0446229b26093de8535aeb1bda9a0810ce9bcfa8/control/autoware_smart_mpc_trajectory_follower/CMakeLists.txt#L14-L15

This means **building this package will unconditionally run `pip install` on the user’s system**.

Let that sink in for a moment.

* This **mutates the user’s global Python environment**
* It **force-reinstalls** a specific version of `numba`
* It bypasses virtualenvs, rosdep, system package managers, and user intent
* It makes the build **non-reproducible, non-hermetic, and fragile**
* It can silently break *unrelated* Python projects on the same machine

CMake is a *build system*, not a package manager, and certainly not a place to execute side-effectful system-wide installs. This violates pretty much every expectation users have when running `colcon build`.

This absolutely needs to be fixed before it causes real damage to someone’s environment.

## How was this PR tested?

Not much to test here. It's a python package, the python package dependency installation step is moved from CMakeLists.txt to the README.md.

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.
