### PR TITLE
fix(autoware_trajectory_optimizer): prevent yaw spikes when creating splines 

### DIFF
--- a/planning/autoware_trajectory_optimizer/src/trajectory_optimizer_plugins/plugin_utils/trajectory_spline_smoother_utils.cpp
+++ b/planning/autoware_trajectory_optimizer/src/trajectory_optimizer_plugins/plugin_utils/trajectory_spline_smoother_utils.cpp
@@ -64,16 +64,17 @@ void apply_spline(
 
   TrajectoryPoints output_points{};
   output_points.reserve(static_cast<size_t>(1 + trajectory_interpolation_util->length() / ds));
-  double s{};
-  for (s = 0.0; s <= trajectory_interpolation_util->length(); s += ds) {
+  double last_s{0.0};
+  for (auto s = 0.0; s <= trajectory_interpolation_util->length(); s += ds) {
     auto p = trajectory_interpolation_util->compute(s);
     if (!autoware::trajectory_optimizer::utils::validate_point(p)) {
       continue;
     }
     output_points.push_back(p);
+    last_s = s;
   }
 
-  if (trajectory_interpolation_util->length() - s > min_interpolation_step) {
+  if (trajectory_interpolation_util->length() - last_s > min_interpolation_step) {
     output_points.push_back(
       trajectory_interpolation_util->compute(trajectory_interpolation_util->length()));
   }


### PR DESCRIPTION

## Description
This PR removes the direct copying of the starting and final trajectory points of the original trajectory. Instead, these points are also calculated using the smoothing util 
## Related links
Related to issue reported here: https://github.com/autowarefoundation/autoware_universe/pull/12021
**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
PSim
## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
