### PR TITLE
feat(autoware_cuda_pointcloud_preprocessor): update nvcc flags

### DIFF
--- a/sensing/autoware_cuda_pointcloud_preprocessor/CMakeLists.txt
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/CMakeLists.txt
@@ -48,16 +48,18 @@ include_directories(
     ${CUDA_INCLUDE_DIRS}
 )
 
-# cSpell: ignore expt gencode
+# cSpell: ignore expt
 list(APPEND CUDA_NVCC_FLAGS "--expt-relaxed-constexpr -diag-suppress 20012")
-list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_75,code=sm_75")
 list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_86,code=sm_86")
 list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_87,code=sm_87")
 list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_89,code=sm_89")
-# NOTE(knzo25): PTX support for newer GPUs until we can compile directly
-list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_89,code=compute_89")
-# TODO(knzo25): enable when the driver supports it
-# list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_120,code=sm_120")
+if(CUDA_VERSION VERSION_LESS "13.0")
+  list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_101,code=sm_101")
+else()  # CUDA 13.0 renamed SM101 to SM110
+  list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_110,code=sm_110")
+endif()
+list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_120,code=sm_120")
+list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_120,code=compute_120")
 
 # __host__ or __device__ annotation on lambda requires --extended-lambda nvcc flag
 list(APPEND CUDA_NVCC_FLAGS "--extended-lambda")


### PR DESCRIPTION
## Description

- Adjust gencode flags for SM 86-120 to avoid JIT overhead and enable architecture-specific optimizations on modern GPUs.
- Handle CUDA 13.0 SM101 -> SM110 rename.

## Related links

**Parent Issue:**

- https://github.com/autowarefoundation/autoware/issues/6789

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

Selected SMs assures trade-off between binary size and potential target devices (skipped server-like SMs).

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
