### PR TITLE
feat(autoware_probabilistic_occupancy_grid_map): use ApproximateTime synchronizer for pointcloud-based OGM

### DIFF
--- a/perception/autoware_probabilistic_occupancy_grid_map/src/pointcloud_based_occupancy_grid_map/pointcloud_based_occupancy_grid_map_node.cpp
+++ b/perception/autoware_probabilistic_occupancy_grid_map/src/pointcloud_based_occupancy_grid_map/pointcloud_based_occupancy_grid_map_node.cpp
@@ -64,14 +64,18 @@ PointcloudBasedOccupancyGridMapNode::PointcloudBasedOccupancyGridMapNode(
     this->declare_parameter<bool>("filter_obstacle_pointcloud_by_raw_pointcloud");
   const double map_length = this->declare_parameter<double>("map_length");
   const double map_resolution = this->declare_parameter<double>("map_resolution");
+  constexpr int approx_sync_queue_size = 10;
 
   /* Subscriber and publisher */
-  obstacle_pointcloud_sub_ptr_ = this->create_subscription<PointCloud2>(
-    "~/input/obstacle_pointcloud", rclcpp::SensorDataQoS{}.keep_last(1),
-    std::bind(&PointcloudBasedOccupancyGridMapNode::obstaclePointcloudCallback, this, _1));
-  raw_pointcloud_sub_ptr_ = this->create_subscription<PointCloud2>(
-    "~/input/raw_pointcloud", rclcpp::SensorDataQoS{}.keep_last(1),
-    std::bind(&PointcloudBasedOccupancyGridMapNode::rawPointcloudCallback, this, _1));
+  // Approximate time sync for obstacle/raw pointclouds
+  const auto qos_profile =
+    rclcpp::SensorDataQoS{}.keep_last(approx_sync_queue_size).get_rmw_qos_profile();
+  obstacle_pointcloud_sub_.subscribe(this, "~/input/obstacle_pointcloud", qos_profile);
+  raw_pointcloud_sub_.subscribe(this, "~/input/raw_pointcloud", qos_profile);
+  sync_ptr_ = std::make_shared<Sync>(
+    SyncPolicy(approx_sync_queue_size), obstacle_pointcloud_sub_, raw_pointcloud_sub_);
+  sync_ptr_->registerCallback(
+    std::bind(&PointcloudBasedOccupancyGridMapNode::onPointcloudApproximateSync, this, _1, _2));
 
   occupancy_grid_map_pub_ = create_publisher<OccupancyGrid>("~/output/occupancy_grid_map", 1);
 
@@ -151,24 +155,13 @@ PointcloudBasedOccupancyGridMapNode::PointcloudBasedOccupancyGridMapNode(
     this, "pointcloud_based_probabilistic_occupancy_grid_map");
 }
 
-void PointcloudBasedOccupancyGridMapNode::obstaclePointcloudCallback(
-  const PointCloud2::ConstSharedPtr & input_obstacle_msg)
+void PointcloudBasedOccupancyGridMapNode::onPointcloudApproximateSync(
+  const PointCloud2::ConstSharedPtr & input_obstacle_msg, const PointCloud2::ConstSharedPtr & input_raw_msg)
 {
+  // Keep the existing async upload/compute model, but trigger processing at approx-synced arrival.
   obstacle_pointcloud_.fromROSMsgAsync(input_obstacle_msg);
-
-  if (obstacle_pointcloud_.header.stamp == raw_pointcloud_.header.stamp) {
-    onPointcloudWithObstacleAndRaw();
-  }
-}
-
-void PointcloudBasedOccupancyGridMapNode::rawPointcloudCallback(
-  const PointCloud2::ConstSharedPtr & input_raw_msg)
-{
   raw_pointcloud_.fromROSMsgAsync(input_raw_msg);
-
-  if (obstacle_pointcloud_.header.stamp == raw_pointcloud_.header.stamp) {
-    onPointcloudWithObstacleAndRaw();
-  }
+  onPointcloudWithObstacleAndRaw();
 }
 
 void PointcloudBasedOccupancyGridMapNode::checkProcessingTime(double processing_time_ms)

--- a/perception/autoware_probabilistic_occupancy_grid_map/src/pointcloud_based_occupancy_grid_map/pointcloud_based_occupancy_grid_map_node.cpp
+++ b/perception/autoware_probabilistic_occupancy_grid_map/src/pointcloud_based_occupancy_grid_map/pointcloud_based_occupancy_grid_map_node.cpp
@@ -156,7 +156,8 @@ PointcloudBasedOccupancyGridMapNode::PointcloudBasedOccupancyGridMapNode(
 }
 
 void PointcloudBasedOccupancyGridMapNode::onPointcloudApproximateSync(
-  const PointCloud2::ConstSharedPtr & input_obstacle_msg, const PointCloud2::ConstSharedPtr & input_raw_msg)
+  const PointCloud2::ConstSharedPtr & input_obstacle_msg,
+  const PointCloud2::ConstSharedPtr & input_raw_msg)
 {
   // Keep the existing async upload/compute model, but trigger processing at approx-synced arrival.
   obstacle_pointcloud_.fromROSMsgAsync(input_obstacle_msg);

--- a/perception/autoware_probabilistic_occupancy_grid_map/src/pointcloud_based_occupancy_grid_map/pointcloud_based_occupancy_grid_map_node.hpp
+++ b/perception/autoware_probabilistic_occupancy_grid_map/src/pointcloud_based_occupancy_grid_map/pointcloud_based_occupancy_grid_map_node.hpp
@@ -26,15 +26,15 @@
 #include <autoware_utils/system/time_keeper.hpp>
 #include <builtin_interfaces/msg/time.hpp>
 #include <laser_geometry/laser_geometry.hpp>
-#include <message_filters/subscriber.h>
-#include <message_filters/sync_policies/approximate_time.h>
-#include <message_filters/synchronizer.h>
 #include <rclcpp/rclcpp.hpp>
 
 #include <sensor_msgs/msg/laser_scan.hpp>
 #include <sensor_msgs/point_cloud2_iterator.hpp>
 
 #include <cuda_runtime.h>
+#include <message_filters/subscriber.h>
+#include <message_filters/sync_policies/approximate_time.h>
+#include <message_filters/synchronizer.h>
 #include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_listener.h>
 


### PR DESCRIPTION
## Description

### Summary
This PR replaces the strict timestamp equality check between `obstacle_pointcloud` and `raw_pointcloud` with a `message_filters::Synchronizer` using the `ApproximateTime` policy in the pointcloud-based probabilistic occupancy grid map node. This improves robustness against small timestamp jitter and reduces missed processing triggers, helping stabilize the output rate (e.g., 10 Hz).


### Why
- Exact timestamp matching is fragile in real systems where sensor and transport timing jitter exists.
- Approximate time sync reduces “dropouts” where processing never triggers because stamps are not identical.
- Queue size fixed at 10 provides a simple, stable default without adding tuning surface.

## Related links

[TIER IV internal ticket](https://tier4.atlassian.net/browse/T4DEV-44446)


## How was this PR tested?

I verified in the real taxi environment:

**Before** : The output of pointcloud-based OGM map was sometimes delayed relative to the input pointclouds.
- Output: `/perception/occupancy_grid_map/*/map`
- Input: `/perception/occupancy_grid_map/*/downsample/pointcloud`


![OGM sync](https://github.com/user-attachments/assets/7f0aa794-4da3-4c2b-88c1-ffd525a265e2)



**After** : The delay in the OGM output has been eliminated, and it is now synchronized with the input.


![OGM sync (2)](https://github.com/user-attachments/assets/a6471292-556b-4dc1-bbdc-57e465e1b989)
![OGM sync (1)](https://github.com/user-attachments/assets/0348bb26-2c48-4bab-a657-c91613916a36)


## Notes for reviewers
This part came from https://github.com/autowarefoundation/autoware_universe/pull/10060 by @knzo25.
~~I believe there is no intention to synchronize two input pointclouds exactly by looking at that PR.~~

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
