### PR TITLE
chore(stream_petr): remove invalid thrust stream policy for copy operations

### DIFF
--- a/perception/autoware_camera_streampetr/lib/postprocess/postprocess_kernel.cu
+++ b/perception/autoware_camera_streampetr/lib/postprocess/postprocess_kernel.cu
@@ -185,12 +185,11 @@ cudaError_t PostprocessCuda::generateDetectedBoxes3D_launch(
 
     // memcpy device to host
     det_boxes3d.resize(num_final_det_boxes3d);
-    thrust::copy(
-      thrust::device, final_det_boxes3d_d.begin(), final_det_boxes3d_d.end(), det_boxes3d.begin());
+    thrust::copy(final_det_boxes3d_d.begin(), final_det_boxes3d_d.end(), det_boxes3d.begin());
   } else {
     // memcpy device to host
     det_boxes3d.resize(num_det_boxes3d);
-    thrust::copy(thrust::device, det_boxes3d_d.begin(), det_boxes3d_d.end(), det_boxes3d.begin());
+    thrust::copy(det_boxes3d_d.begin(), det_boxes3d_d.end(), det_boxes3d.begin());
   }
 
   return cudaGetLastError();


### PR DESCRIPTION
## Description

Using stream-aware execution policy was causing the following error when multiple processes that use CUDA are running in the same GPU .
```
[autoware_camera_streampetr_node-1] terminate called after throwing an instance of 'thrust::system::system_error'
[autoware_camera_streampetr_node-1]   what():  __copy:: D->D: failed: cudaErrorInvalidValue: invalid argument
```
This issue was partially fixed in the previous PR https://github.com/autowarefoundation/autoware_universe/pull/11800, but it was not fully resolved. This PR resolves the remaining issues.

This error arises because the current code tries to copy from device to host memory using device execution policy. 

## Related links

## How was this PR tested?

Tested using various rosbags locally.

## Interface changes

None.

