### PR TITLE
docs(diffusion_planner): fix README.md

### DIFF
--- a/planning/autoware_diffusion_planner/README.md
+++ b/planning/autoware_diffusion_planner/README.md
@@ -46,18 +46,6 @@ diff --git a/autoware_launch/config/control/trajectory_follower/longitudinal/pid
 
      # state transition
      drive_state_stop_dist: 0.5
-diff --git a/autoware_launch/config/planning/preset/default_preset.yaml b/autoware_launch/config/planning/preset/default_preset.yaml
---- a/autoware_launch/config/planning/preset/default_preset.yaml
-+++ b/autoware_launch/config/planning/preset/default_preset.yaml
-@@ -52,7 +52,7 @@ launch:
-       default: "true"
-   - arg:
-       name: launch_traffic_light_module
--      default: "true"
-+      default: "false"
-   - arg:
-       name: launch_intersection_module
-       default: "true"
 diff --git a/autoware_launch/config/planning/scenario_planning/common/common.param.yaml b/autoware_launch/config/planning/scenario_planning/common/common.param.yaml
 --- a/autoware_launch/config/planning/scenario_planning/common/common.param.yaml
 +++ b/autoware_launch/config/planning/scenario_planning/common/common.param.yaml


### PR DESCRIPTION
## Description

Since tier4 launchers have been removed from the universe repository, the "How to use" section of `diffusion_planner` should be revised.

## Related links

- https://github.com/autowarefoundation/autoware_universe/pull/12001

## How was this PR tested?

- [x] planning_simulator

## Notes for reviewers

As a result, we have to change only `autoware_launch` to run `planning_simulator` with `diffusion_planner`, so it may be better to create a branch instead of showing the patch text.

## Interface changes

None.

## Effects on system behavior

None.
