### PR TITLE
refactor(planning): replace toGeomMsg/toLaneletPoint to autoware_lanelet2_utils in lane_change/goal_planner

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/goal_planner_module.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/goal_planner_module.cpp
@@ -29,9 +29,9 @@
 #include "autoware/behavior_path_planner_common/utils/utils.hpp"
 #include "autoware_utils/geometry/boost_polygon_utils.hpp"
 
+#include <autoware/lanelet2_utils/conversion.hpp>
 #include <autoware/lanelet2_utils/geometry.hpp>
 #include <autoware/lanelet2_utils/nn_search.hpp>
-#include <autoware_lanelet2_extension/utility/message_conversion.hpp>
 #include <autoware_utils/math/normalization.hpp>
 #include <autoware_utils/system/stop_watch.hpp>
 #include <magic_enum.hpp>
@@ -2428,7 +2428,7 @@ bool GoalPlannerModule::isCrossingPossible(
   if (is_shoulder_lane) {
     Pose end_lane_pose{};
     end_lane_pose.orientation.w = 1.0;
-    end_lane_pose.position = lanelet::utils::conversion::toGeomMsgPt(end_lane.centerline().front());
+    end_lane_pose.position = experimental::lanelet2_utils::to_ros(end_lane.centerline().front());
     // NOTE: this line does not specify the /forward/backward length, so if the shoulders form a
     // loop, this returns all shoulder lanes in the loop
     end_lane_sequence = route_handler->getShoulderLaneletSequence(end_lane, end_lane_pose);
@@ -2612,7 +2612,7 @@ std::pair<bool, utils::path_safety_checker::CollisionCheckDebugMap> GoalPlannerM
     // generate first road lane pose
     Pose first_road_pose{};
     const auto first_road_point =
-      lanelet::utils::conversion::toGeomMsgPt(fist_road_lane.centerline().front());
+      experimental::lanelet2_utils::to_ros(fist_road_lane.centerline().front());
     const double lane_yaw = autoware::experimental::lanelet2_utils::get_lanelet_angle(
       fist_road_lane,
       autoware::experimental::lanelet2_utils::from_ros(first_road_point).basicPoint());

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/util.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/util.cpp
@@ -20,9 +20,9 @@
 #include "autoware_lanelet2_extension/regulatory_elements/bus_stop_area.hpp"
 
 #include <Eigen/Core>
+#include <autoware/lanelet2_utils/conversion.hpp>
 #include <autoware/lanelet2_utils/geometry.hpp>
 #include <autoware/lanelet2_utils/nn_search.hpp>
-#include <autoware_lanelet2_extension/utility/message_conversion.hpp>
 #include <autoware_lanelet2_extension/utility/query.hpp>
 #include <autoware_lanelet2_extension/utility/utilities.hpp>
 #include <autoware_utils/ros/marker_helper.hpp>
@@ -223,9 +223,9 @@ static double getOffsetToLanesBoundary(
   // the boundary closer to ego. if left_side, take right boundary
   const auto & boundary3d = left_side ? closest_lanelet.rightBound() : closest_lanelet.leftBound();
   const auto boundary = lanelet::utils::to2D(boundary3d);
-  using lanelet::utils::conversion::toLaneletPoint;
+  using experimental::lanelet2_utils::from_ros;
   const auto arc_coords = lanelet::geometry::toArcCoordinates(
-    boundary, lanelet::utils::to2D(toLaneletPoint(target_pose.position)).basicPoint());
+    boundary, lanelet::utils::to2D(from_ros(target_pose.position)).basicPoint());
   return arc_coords.distance;
 }
 
@@ -917,7 +917,7 @@ std::optional<Pose> calcRefinedGoal(
   Pose center_pose{};
   {
     // find position
-    const auto lanelet_point = lanelet::utils::conversion::toLaneletPoint(goal_pose.position);
+    const auto lanelet_point = experimental::lanelet2_utils::from_ros(goal_pose.position);
     const auto segment = autoware::experimental::lanelet2_utils::get_closest_segment(
       closest_pull_over_lanelet.centerline(), lanelet_point.basicPoint());
     const auto p1 = segment.front().basicPoint();

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/scene.cpp
@@ -24,13 +24,13 @@
 #include "autoware/behavior_path_planner_common/utils/traffic_light_utils.hpp"
 #include "autoware/behavior_path_planner_common/utils/utils.hpp"
 
+#include <autoware/lanelet2_utils/conversion.hpp>
 #include <autoware/lanelet2_utils/geometry.hpp>
 #include <autoware/lanelet2_utils/nn_search.hpp>
 #include <autoware/motion_utils/trajectory/path_shift.hpp>
 #include <autoware/motion_utils/trajectory/trajectory.hpp>
 #include <autoware_frenet_planner/frenet_planner.hpp>
 #include <autoware_frenet_planner/structures.hpp>
-#include <autoware_lanelet2_extension/utility/message_conversion.hpp>
 #include <autoware_lanelet2_extension/utility/query.hpp>
 #include <autoware_lanelet2_extension/utility/utilities.hpp>
 #include <autoware_utils/geometry/boost_polygon_utils.hpp>
@@ -816,7 +816,7 @@ bool NormalLaneChange::hasFinishedLaneChange() const
     const auto & lanes_polygon = common_data_ptr_->lanes_polygon_ptr->target;
     return !boost::geometry::disjoint(
       lanes_polygon,
-      lanelet::utils::to2D(lanelet::utils::conversion::toLaneletPoint(current_pose.position)));
+      lanelet::utils::to2D(experimental::lanelet2_utils::from_ros(current_pose.position)));
   }
 
   const auto yaw_deviation_to_centerline =

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/calculation.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/calculation.cpp
@@ -15,8 +15,8 @@
 
 #include <autoware/behavior_path_lane_change_module/utils/calculation.hpp>
 #include <autoware/behavior_path_planner_common/utils/utils.hpp>
+#include <autoware/lanelet2_utils/conversion.hpp>
 #include <autoware/motion_utils/trajectory/path_shift.hpp>
-#include <autoware_lanelet2_extension/utility/message_conversion.hpp>
 #include <autoware_lanelet2_extension/utility/utilities.hpp>
 
 #include <boost/geometry/algorithms/buffer.hpp>
@@ -165,7 +165,7 @@ double calc_ego_dist_to_lanes_start(
     return std::numeric_limits<double>::max();
   }
 
-  const auto target_front_pt = lanelet::utils::conversion::toGeomMsgPt(target_bound.front());
+  const auto target_front_pt = experimental::lanelet2_utils::to_ros(target_bound.front());
   const auto ego_position = common_data_ptr->get_ego_pose().position;
 
   return motion_utils::calcSignedArcLength(path.points, ego_position, target_front_pt);
@@ -489,7 +489,8 @@ std::vector<PhaseMetrics> calc_prepare_phase_metrics(
     if (prepare_length > max_length_threshold || prepare_length < min_length_threshold) {
       RCLCPP_DEBUG(
         get_logger(),
-        "Skip: prepare length out of expected range. length: %.5f, threshold min: %.5f, max: %.5f",
+        "Skip: prepare length out of expected range. length: %.5f, threshold min: %.5f, max: "
+        "%.5f",
         prepare_length, min_length_threshold, max_length_threshold);
       return true;
     }

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/utils.cpp
@@ -1458,8 +1458,8 @@ bool is_intersecting_no_lane_change_lines(
         const auto & path_p2 = path_segment[1].point.pose.position;
 
         for (size_t i = 0; i + 1 < line.size(); ++i) {
-          const auto line_p1 = lanelet::utils::conversion::toGeomMsgPt(line[i]);
-          const auto line_p2 = lanelet::utils::conversion::toGeomMsgPt(line[i + 1]);
+          const auto line_p1 = experimental::lanelet2_utils::to_ros(line[i]);
+          const auto line_p2 = experimental::lanelet2_utils::to_ros(line[i + 1]);
 
           if (autoware_utils_geometry::intersect(path_p1, path_p2, line_p1, line_p2)) {
             return true;


### PR DESCRIPTION
## Description

port `toLaneletPoint/toGeomMsgPt` to new functions

## Related links

- https://github.com/autowarefoundation/autoware_universe/pull/12089
- https://github.com/autowarefoundation/autoware_universe/pull/12090
- https://github.com/autowarefoundation/autoware_universe/pull/12091

## How was this PR tested?

- [CommonScenario](https://evaluation.tier4.jp/evaluation/reports/fa303998-5f95-59ba-8b7c-776933666a89?project_id=autoware_dev)
- [FuncVerification](https://evaluation.tier4.jp/evaluation/reports/b6c61cdb-01be-53b0-8dc6-66499136f20e?project_id=prd_jt)
- [DLR](https://evaluation.tier4.jp/evaluation/reports/0bbc4a97-1c4a-5903-a6c8-3c2d831fbb5f?project_id=prd_jt)

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
