### PR TITLE
refactor(planning): replace toGeomMsg/toLaneletPoint to autoware_lanelet2_utils in static avoidance

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/utils.cpp
@@ -22,8 +22,8 @@
 #include "autoware/behavior_path_static_obstacle_avoidance_module/utils.hpp"
 
 #include <Eigen/Dense>
+#include <autoware/lanelet2_utils/conversion.hpp>
 #include <autoware/lanelet2_utils/nn_search.hpp>
-#include <autoware_lanelet2_extension/utility/message_conversion.hpp>
 #include <autoware_lanelet2_extension/utility/query.hpp>
 #include <autoware_utils_geometry/boost_geometry.hpp>
 #include <autoware_utils_uuid/uuid_helper.hpp>
@@ -305,8 +305,7 @@ bool isWithinIntersection(
   const auto & polygon = *polygon_opt;
 
   return boost::geometry::within(
-    lanelet::utils::to2D(lanelet::utils::conversion::toLaneletPoint(object.getPosition()))
-      .basicPoint(),
+    lanelet::utils::to2D(experimental::lanelet2_utils::from_ros(object.getPosition())).basicPoint(),
     lanelet::utils::to2D(polygon.basicPolygon()));
 }
 
@@ -321,18 +320,17 @@ bool isWithinFreespace(
   std::sort(polygons.begin(), polygons.end(), [&object](const auto & a, const auto & b) {
     const double a_distance = boost::geometry::distance(
       lanelet::utils::to2D(a).basicPolygon(),
-      lanelet::utils::to2D(lanelet::utils::conversion::toLaneletPoint(object.getPosition()))
+      lanelet::utils::to2D(experimental::lanelet2_utils::from_ros(object.getPosition()))
         .basicPoint());
     const double b_distance = boost::geometry::distance(
       lanelet::utils::to2D(b).basicPolygon(),
-      lanelet::utils::to2D(lanelet::utils::conversion::toLaneletPoint(object.getPosition()))
+      lanelet::utils::to2D(experimental::lanelet2_utils::from_ros(object.getPosition()))
         .basicPoint());
     return a_distance < b_distance;
   });
 
   return boost::geometry::within(
-    lanelet::utils::to2D(lanelet::utils::conversion::toLaneletPoint(object.getPosition()))
-      .basicPoint(),
+    lanelet::utils::to2D(experimental::lanelet2_utils::from_ros(object.getPosition())).basicPoint(),
     lanelet::utils::to2D(polygons.front().basicPolygon()));
 }
 
@@ -345,7 +343,7 @@ bool isWithinFreespace(
 bool isOnEgoLane(const ObjectData & object, const std::shared_ptr<RouteHandler> & route_handler)
 {
   if (boost::geometry::within(
-        lanelet::utils::to2D(lanelet::utils::conversion::toLaneletPoint(object.getPosition()))
+        lanelet::utils::to2D(experimental::lanelet2_utils::from_ros(object.getPosition()))
           .basicPoint(),
         object.overhang_lanelet.polygon2d().basicPolygon())) {
     return true;
@@ -355,7 +353,7 @@ bool isOnEgoLane(const ObjectData & object, const std::shared_ptr<RouteHandler> 
   lanelet::ConstLanelets prev_lanelet;
   if (route_handler->getPreviousLaneletsWithinRoute(object.overhang_lanelet, &prev_lanelet)) {
     if (boost::geometry::within(
-          lanelet::utils::to2D(lanelet::utils::conversion::toLaneletPoint(object.getPosition()))
+          lanelet::utils::to2D(experimental::lanelet2_utils::from_ros(object.getPosition()))
             .basicPoint(),
           prev_lanelet.front().polygon2d().basicPolygon())) {
       return true;
@@ -366,7 +364,7 @@ bool isOnEgoLane(const ObjectData & object, const std::shared_ptr<RouteHandler> 
   lanelet::ConstLanelet next_lanelet;
   if (route_handler->getNextLaneletWithinRoute(object.overhang_lanelet, &next_lanelet)) {
     if (boost::geometry::within(
-          lanelet::utils::to2D(lanelet::utils::conversion::toLaneletPoint(object.getPosition()))
+          lanelet::utils::to2D(experimental::lanelet2_utils::from_ros(object.getPosition()))
             .basicPoint(),
           next_lanelet.polygon2d().basicPolygon())) {
       return true;
@@ -374,7 +372,7 @@ bool isOnEgoLane(const ObjectData & object, const std::shared_ptr<RouteHandler> 
   } else {
     for (const auto & lane : route_handler->getNextLanelets(object.overhang_lanelet)) {
       if (boost::geometry::within(
-            lanelet::utils::to2D(lanelet::utils::conversion::toLaneletPoint(object.getPosition()))
+            lanelet::utils::to2D(experimental::lanelet2_utils::from_ros(object.getPosition()))
               .basicPoint(),
             lane.polygon2d().basicPolygon())) {
         return true;
@@ -435,10 +433,10 @@ double getShiftableRatio(
   const ObjectData & object, const std::shared_ptr<RouteHandler> & route_handler,
   const std::shared_ptr<AvoidanceParameters> & parameters)
 {
+  using experimental::lanelet2_utils::from_ros;
   using lanelet::geometry::distance2d;
   using lanelet::geometry::toArcCoordinates;
   using lanelet::utils::to2D;
-  using lanelet::utils::conversion::toLaneletPoint;
 
   const auto centerline_pos =
     autoware::experimental::lanelet2_utils::get_closest_center_pose(
@@ -467,7 +465,7 @@ double getShiftableRatio(
 
     const auto center_to_left_boundary = distance2d(
       to2D(most_left_lanelet.leftBound().basicLineString()),
-      to2D(toLaneletPoint(centerline_pos)).basicPoint());
+      to2D(from_ros(centerline_pos)).basicPoint());
 
     double object_shiftable_distance =
       center_to_left_boundary - 0.5 * object.object.shape.dimensions.y;
@@ -477,7 +475,7 @@ double getShiftableRatio(
     if (sub_type == "road_shoulder") {
       // assuming it's parked vehicle if its CoG is within road shoulder lanelet.
       if (boost::geometry::within(
-            to2D(toLaneletPoint(object.getPosition())).basicPoint(),
+            to2D(from_ros(object.getPosition())).basicPoint(),
             most_left_lanelet.polygon2d().basicPolygon())) {
         return true;
       }
@@ -488,7 +486,7 @@ double getShiftableRatio(
 
     const auto arc_coordinates = toArcCoordinates(
       to2D(object.overhang_lanelet.centerline().basicLineString()),
-      to2D(toLaneletPoint(object.getPosition())).basicPoint());
+      to2D(from_ros(object.getPosition())).basicPoint());
     const auto shiftable_ratio = arc_coordinates.distance / object_shiftable_distance;
     return shiftable_ratio;
   }
@@ -514,7 +512,7 @@ double getShiftableRatio(
 
     const auto center_to_right_boundary = distance2d(
       to2D(most_right_lanelet.rightBound().basicLineString()),
-      to2D(toLaneletPoint(centerline_pos)).basicPoint());
+      to2D(from_ros(centerline_pos)).basicPoint());
 
     double object_shiftable_distance =
       center_to_right_boundary - 0.5 * object.object.shape.dimensions.y;
@@ -524,7 +522,7 @@ double getShiftableRatio(
     if (sub_type == "road_shoulder") {
       // assuming it's parked vehicle if its CoG is within road shoulder lanelet.
       if (boost::geometry::within(
-            to2D(toLaneletPoint(object.getPosition())).basicPoint(),
+            to2D(from_ros(object.getPosition())).basicPoint(),
             most_right_lanelet.polygon2d().basicPolygon())) {
         return true;
       }
@@ -535,7 +533,7 @@ double getShiftableRatio(
 
     const auto arc_coordinates = toArcCoordinates(
       to2D(object.overhang_lanelet.centerline().basicLineString()),
-      to2D(toLaneletPoint(object.getPosition())).basicPoint());
+      to2D(from_ros(object.getPosition())).basicPoint());
     const auto shiftable_ratio = -1.0 * arc_coordinates.distance / object_shiftable_distance;
     return shiftable_ratio;
   }
@@ -665,7 +663,6 @@ bool isParkedVehicle(
   using lanelet::geometry::distance2d;
   using lanelet::geometry::toArcCoordinates;
   using lanelet::utils::to2D;
-  using lanelet::utils::conversion::toLaneletPoint;
 
   if (object.is_within_intersection) {
     return false;


### PR DESCRIPTION
## Description

## Related links

https://github.com/autowarefoundation/autoware_universe/pull/12089

## How was this PR tested?

- [CommonScenario](https://evaluation.tier4.jp/evaluation/reports/fa303998-5f95-59ba-8b7c-776933666a89?project_id=autoware_dev)
- [FuncVerification](https://evaluation.tier4.jp/evaluation/reports/b6c61cdb-01be-53b0-8dc6-66499136f20e?project_id=prd_jt)
- [DLR](https://evaluation.tier4.jp/evaluation/reports/0bbc4a97-1c4a-5903-a6c8-3c2d831fbb5f?project_id=prd_jt)


## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
