### PR TITLE
docs(sensing): fix mkdocs macro rendering and links in sensing pages

### DIFF
--- a/sensing/autoware_cuda_pointcloud_preprocessor/docs/cuda-concatenate-data.md
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/docs/cuda-concatenate-data.md
@@ -1,6 +1,6 @@
 # cuda_concatenate_and_time_synchronize_node
 
-This package is a cuda accelerated version of the one available in [autoware_cuda_pointcloud_preprocessor](../../autoware_pointcloud_preprocessor).
+This package is a cuda accelerated version of the one available in [autoware_cuda_pointcloud_preprocessor](../../autoware_pointcloud_preprocessor/README.md).
 As this node is templated, the overall design, algorithm, inputs, and outputs are the same.
 
 The only change, corresponds to the pointcloud topics, which instead of using the standard `sensor_msgs::msg::PointCloud2` message type, they use the `cuda_blackboard` mechanism.

--- a/sensing/autoware_cuda_pointcloud_preprocessor/docs/cuda-pointcloud-preprocessor.md
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/docs/cuda-pointcloud-preprocessor.md
@@ -37,7 +37,7 @@ In addition to the individual algorithms previously mentioned, this node uses th
 
 ### Core Parameters
 
-{{ json_to_markdown("sensing/autoware_cuda_pointcloud_preprocessor/schema/cuda_pointcloud_preprocessor.schema.schema.json") }}
+{{ json_to_markdown("sensing/autoware_cuda_pointcloud_preprocessor/schema/cuda_pointcloud_preprocessor.schema.json") }}
 
 ## Assumptions / Known limits
 

--- a/sensing/autoware_cuda_pointcloud_preprocessor/docs/cuda-polar-voxel-outlier-filter.md
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/docs/cuda-polar-voxel-outlier-filter.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-This node is a CUDA accelerated version of the `PolarVoxelOutlierFilter` available in [autoware_cuda_pointcloud_preprocessor](../../autoware_pointcloud_preprocessor).
+This node is a CUDA accelerated version of the `PolarVoxelOutlierFilter` available in [autoware_cuda_pointcloud_preprocessor](../../autoware_pointcloud_preprocessor/README.md).
 
 ## Inner-workings / Algorithms
 

--- a/sensing/autoware_cuda_pointcloud_preprocessor/docs/cuda-voxel-grid-downsample.md
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/docs/cuda-voxel-grid-downsample.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-This node is a CUDA accelerated version of the `FasterVoxelGridDownsampleFilter` available in [autoware_cuda_pointcloud_preprocessor](../../autoware_pointcloud_preprocessor).
+This node is a CUDA accelerated version of the `FasterVoxelGridDownsampleFilter` available in [autoware_cuda_pointcloud_preprocessor](../../autoware_pointcloud_preprocessor/README.md).
 
 ## Inner-workings / Algorithms
 
@@ -28,7 +28,7 @@ This node reimplements of the function of `autoware::pointcloud_preprocessor::Fa
 
 ### Core Parameters
 
-{{ json_to_markdown("sensing/autoware_cuda_pointcloud_preprocessor/schema/cuda_voxel_grid_downsample_filter.schema.schema.json") }}
+{{ json_to_markdown("sensing/autoware_cuda_pointcloud_preprocessor/schema/cuda_voxel_grid_downsample_filter.schema.json") }}
 
 ## Assumptions / Known limits
 

--- a/sensing/autoware_pointcloud_preprocessor/docs/concatenate-data.md
+++ b/sensing/autoware_pointcloud_preprocessor/docs/concatenate-data.md
@@ -161,7 +161,7 @@ The concatenation node publishes detailed meta information about the concatenati
 ### Handling Serialized Configuration
 
 The `matching_strategy_config` field contains serialized configuration data for the matching strategy.
-If a strategy has its own configuration, it requires serialization and deserialization implementation based on the `StrategyConfig` class defined in [cloud_info.hpp](../include/autoware/pointcloud_preprocessor/concatenate_data/concatenation_info_manager.hpp).
+If a strategy has its own configuration, it requires serialization and deserialization implementation based on the `StrategyConfig` class defined in [concatenation_info_manager.hpp](https://github.com/autowarefoundation/autoware_universe/blob/main/sensing/autoware_pointcloud_preprocessor/include/autoware/pointcloud_preprocessor/concatenate_data/concatenation_info_manager.hpp).
 
 Here's how to work with serialized configuration for the Advanced strategy:
 

--- a/sensing/autoware_radar_objects_adapter/schema/radar_objects_adapter.schema.json
+++ b/sensing/autoware_radar_objects_adapter/schema/radar_objects_adapter.schema.json
@@ -44,14 +44,17 @@
           "properties": {
             "UNKNOWN": {
               "type": "string",
+              "description": "Radar class to map to UNKNOWN label.",
               "default": "UNKNOWN"
             },
             "CAR": {
               "type": "string",
+              "description": "Radar class to map to CAR label.",
               "default": "CAR"
             },
             "TRUCK": {
               "type": "string",
+              "description": "Radar class to map to TRUCK label.",
               "default": "TRUCK"
             },
             "MOTORCYCLE": {
@@ -66,10 +69,12 @@
             },
             "PEDESTRIAN": {
               "type": "string",
+              "description": "Radar class to map to PEDESTRIAN label.",
               "default": "PEDESTRIAN"
             },
             "ANIMAL": {
               "type": "string",
+              "description": "Radar class to map to ANIMAL label.",
               "default": "ANIMAL"
             },
             "HAZARD": {

--- a/sensing/autoware_radar_tracks_noise_filter/README.md
+++ b/sensing/autoware_radar_tracks_noise_filter/README.md
@@ -29,4 +29,4 @@ In y-axis threshold filter, if y-axis velocity of RadarTrack is more than `veloc
 
 ## Parameters
 
-{{ json_to_markdown("sensing/autoware_radar_tracks_noise_filter/schema/<radar_tracks_noise_filter.schema.json") }}
+{{ json_to_markdown("sensing/autoware_radar_tracks_noise_filter/schema/radar_tracks_noise_filter.schema.json") }}


### PR DESCRIPTION
Supersedes #10705 (closed PR). 
Supersedes #12110 to satisfy DCO (signed-off commit).

## Summary
- fix sensing docs macro schema path typos in CUDA pointcloud preprocessor docs
- fix malformed schema path in radar tracks noise filter README
- fix sensing relative links flagged by mkdocs in CUDA/pointcloud preprocessor docs
- add missing schema descriptions in radar objects adapter so json_to_markdown renders with the existing macro implementation

## Validation
- created a local venv with mkdocs dependencies from CI (autoware-github-actions/deploy-docs/mkdocs-requirements.txt)
- ran mkdocs build --strict and verified sensing-related macro/link warnings are resolved
