### PR TITLE
entropy uncertainty poc

### DIFF
--- a/perception/autoware_lidar_centerpoint/include/autoware/lidar_centerpoint/utils.hpp
+++ b/perception/autoware_lidar_centerpoint/include/autoware/lidar_centerpoint/utils.hpp
@@ -24,6 +24,7 @@ struct Box3D
   // initializer not allowed for __shared__ variable
   int label;
   float score;
+  float entropy;
   float x;
   float y;
   float z;

--- a/perception/autoware_lidar_centerpoint/src/node.cpp
+++ b/perception/autoware_lidar_centerpoint/src/node.cpp
@@ -232,6 +232,18 @@ void LidarCenterPointNode::pointCloudCallback(
       diagnostic_msgs::msg::DiagnosticStatus::WARN, message.str());
   }
 
+  if (!det_boxes3d.empty() && !class_names_.empty()) {
+    double entropy_sum = 0.0;
+    for (const auto & box3d : det_boxes3d) {
+      entropy_sum += box3d.entropy;
+    }
+    const double entropy_mean_sum = entropy_sum / static_cast<double>(det_boxes3d.size());
+    diagnostics_centerpoint_trt_->add_key_value(
+      "bbox_entropy_mean_sum", entropy_mean_sum);
+  } else {
+    diagnostics_centerpoint_trt_->add_key_value("bbox_entropy_mean_sum", 0.0);
+  }
+
   std::vector<autoware_perception_msgs::msg::DetectedObject> raw_objects;
   raw_objects.reserve(det_boxes3d.size());
   for (const auto & box3d : det_boxes3d) {

--- a/perception/autoware_lidar_centerpoint/src/node.cpp
+++ b/perception/autoware_lidar_centerpoint/src/node.cpp
@@ -238,8 +238,7 @@ void LidarCenterPointNode::pointCloudCallback(
       entropy_sum += box3d.entropy;
     }
     const double entropy_mean_sum = entropy_sum / static_cast<double>(det_boxes3d.size());
-    diagnostics_centerpoint_trt_->add_key_value(
-      "bbox_entropy_mean_sum", entropy_mean_sum);
+    diagnostics_centerpoint_trt_->add_key_value("bbox_entropy_mean_sum", entropy_mean_sum);
   } else {
     diagnostics_centerpoint_trt_->add_key_value("bbox_entropy_mean_sum", 0.0);
   }


### PR DESCRIPTION
## Description

This PR will introduce binary entropy diagnostic as a tool for uncertainty estimation in an entire frame of data.

Draft PR, will add evaluation shortly.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
