### PR TITLE
fix(radar_tracks_msgs_converter): enhance thread safety and data handling

### DIFF
--- a/perception/autoware_radar_tracks_msgs_converter/src/radar_tracks_msgs_converter_node.cpp
+++ b/perception/autoware_radar_tracks_msgs_converter/src/radar_tracks_msgs_converter_node.cpp
@@ -227,8 +227,7 @@ bool RadarTracksMsgsConverterNode::isStaticObject(
 }
 
 TrackedObjects RadarTracksMsgsConverterNode::convertRadarTrackToTrackedObjects(
-  const RadarTracks::ConstSharedPtr & radar_data,
-  const Odometry::ConstSharedPtr & odometry_data)
+  const RadarTracks::ConstSharedPtr & radar_data, const Odometry::ConstSharedPtr & odometry_data)
 {
   TrackedObjects tracked_objects;
   tracked_objects.header = radar_data->header;
@@ -278,8 +277,7 @@ TrackedObjects RadarTracksMsgsConverterNode::convertRadarTrackToTrackedObjects(
     // kinematics setting
     TrackedObjectKinematics kinematics;
     kinematics.orientation_availability = TrackedObjectKinematics::AVAILABLE;
-    kinematics.is_stationary =
-      isStaticObject(radar_track, compensated_velocity, odometry_data);
+    kinematics.is_stationary = isStaticObject(radar_track, compensated_velocity, odometry_data);
     kinematics.pose_with_covariance.pose = transformed_pose_stamped.pose;
     kinematics.pose_with_covariance.covariance = convertPoseCovarianceMatrix(radar_track);
     // velocity of object is defined in the object coordinate

--- a/perception/autoware_radar_tracks_msgs_converter/src/radar_tracks_msgs_converter_node.hpp
+++ b/perception/autoware_radar_tracks_msgs_converter/src/radar_tracks_msgs_converter_node.hpp
@@ -98,8 +98,7 @@ private:
   // Core
   geometry_msgs::msg::PoseWithCovariance convertPoseWithCovariance();
   TrackedObjects convertRadarTrackToTrackedObjects(
-    const RadarTracks::ConstSharedPtr & radar_data,
-    const Odometry::ConstSharedPtr & odometry_data);
+    const RadarTracks::ConstSharedPtr & radar_data, const Odometry::ConstSharedPtr & odometry_data);
   DetectedObjects convertTrackedObjectsToDetectedObjects(TrackedObjects & objects);
   geometry_msgs::msg::Vector3 compensateVelocitySensorPosition(
     const radar_msgs::msg::RadarTrack & radar_track);


### PR DESCRIPTION
## Description

* Added mutex protection to shared data access in radar_tracks_msgs_converter_node.
* Updated methods to use local copies of radar and odometry data for thread-safe operations.
* Modified function signatures to accept radar and odometry data as parameters for better encapsulation.

This change improves the robustness of the radar tracks message converter by ensuring that data is accessed safely in a multi-threaded environment.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
