### PR TITLE
feat(trajectory_safety_filter): add diagnostic

### DIFF
--- a/planning/autoware_trajectory_safety_filter/include/autoware/trajectory_safety_filter/trajectory_safety_filter_node.hpp
+++ b/planning/autoware_trajectory_safety_filter/include/autoware/trajectory_safety_filter/trajectory_safety_filter_node.hpp
@@ -95,8 +95,7 @@ private:
   pluginlib::ClassLoader<plugin::SafetyFilterInterface> plugin_loader_;
   std::vector<std::shared_ptr<plugin::SafetyFilterInterface>> plugins_;
   autoware::vehicle_info_utils::VehicleInfo vehicle_info_;
-  std::unique_ptr<DiagnosticsInterface> diagnostics_interface_ptr_ =
-    std::make_unique<DiagnosticsInterface>(this, "trajectory_safety_filter");
+  DiagnosticsInterface diagnostics_interface_{this, "trajectory_safety_filter"};
 };
 
 }  // namespace autoware::trajectory_safety_filter

--- a/planning/autoware_trajectory_safety_filter/src/trajectory_safety_filter_node.cpp
+++ b/planning/autoware_trajectory_safety_filter/src/trajectory_safety_filter_node.cpp
@@ -45,18 +45,18 @@ std::unordered_map<std::string, std::string> get_generator_uuid_to_name_map(
   return uuid_to_name;
 }
 
-bool has_diffusion_planner_trajectory(
-  const std::unordered_map<std::string, std::string> & uuid_to_name_map,
-  const autoware_internal_planning_msgs::msg::CandidateTrajectories & trajectories)
+bool has_trajectory_from_generator(
+  const std::unordered_map<std::string, std::string> & uuid_to_generator_name_map,
+  const autoware_internal_planning_msgs::msg::CandidateTrajectories & trajectories,
+  const std::string & generator_name_prefix)
 {
   return std::any_of(
     trajectories.candidate_trajectories.cbegin(), trajectories.candidate_trajectories.cend(),
-    [&uuid_to_name_map](
-      const autoware_internal_planning_msgs::msg::CandidateTrajectory & trajectory) {
+    [&](const autoware_internal_planning_msgs::msg::CandidateTrajectory & trajectory) {
       const auto generator_id_str = autoware_utils_uuid::to_hex_string(trajectory.generator_id);
-      const auto generator_name_it = uuid_to_name_map.find(generator_id_str);
-      return generator_name_it != uuid_to_name_map.end() &&
-             generator_name_it->second.rfind("Diffusion", 0) == 0;
+      const auto generator_name_it = uuid_to_generator_name_map.find(generator_id_str);
+      return generator_name_it != uuid_to_generator_name_map.end() &&
+             generator_name_it->second.rfind(generator_name_prefix, 0) == 0;
     });
 }
 }  // namespace
@@ -120,7 +120,7 @@ void TrajectorySafetyFilter::process(const CandidateTrajectories::ConstSharedPtr
     return;
   }
 
-  diagnostics_interface_ptr_->clear();
+  diagnostics_interface_.clear();
 
   // Create output message for filtered trajectories
   auto filtered_msg = std::make_unique<CandidateTrajectories>();
@@ -136,8 +136,9 @@ void TrajectorySafetyFilter::process(const CandidateTrajectories::ConstSharedPtr
     for (const auto & plugin : plugins_) {
       if (const auto res = plugin->is_feasible(trajectory.points, context); !res) {
         is_feasible = false;
-        RCLCPP_WARN(get_logger(), "Not feasible: %s", res.error().c_str());
-        diagnostics_interface_ptr_->add_key_value(plugin->get_name(), res.error());
+        RCLCPP_WARN_THROTTLE(
+          get_logger(), *get_clock(), 1000, "Not feasible: %s", res.error().c_str());
+        diagnostics_interface_.add_key_value(plugin->get_name(), res.error());
       }
     }
 
@@ -239,18 +240,17 @@ void TrajectorySafetyFilter::update_diagnostic(const CandidateTrajectories & fil
 {
   const auto uuid_to_name_map = get_generator_uuid_to_name_map(filtered_trajectories);
   if (filtered_trajectories.candidate_trajectories.empty()) {
-    diagnostics_interface_ptr_->update_level_and_message(
+    diagnostics_interface_.update_level_and_message(
       diagnostic_msgs::msg::DiagnosticStatus::ERROR, "No feasible trajectories found");
-  } else if (!has_diffusion_planner_trajectory(uuid_to_name_map, filtered_trajectories)) {
-    diagnostics_interface_ptr_->update_level_and_message(
+  } else if (!has_trajectory_from_generator(uuid_to_name_map, filtered_trajectories, "Diffusion")) {
+    diagnostics_interface_.update_level_and_message(
       diagnostic_msgs::msg::DiagnosticStatus::WARN,
       "All diffusion planner trajectories are infeasible");
   } else {
-    diagnostics_interface_ptr_->update_level_and_message(
-      diagnostic_msgs::msg::DiagnosticStatus::OK, "");
+    diagnostics_interface_.update_level_and_message(diagnostic_msgs::msg::DiagnosticStatus::OK, "");
   }
 
-  diagnostics_interface_ptr_->publish(this->get_clock()->now());
+  diagnostics_interface_.publish(this->get_clock()->now());
 }
 
 bool TrajectorySafetyFilter::validate_trajectory_basics(


### PR DESCRIPTION
## Description

Add publishing of the diagnostics to the traffic_rule_filter node.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

1. Checking the corresponding behavior via psim

## Notes for reviewers

None.

## Interface changes

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added | Pub | `/diagnostics` | ``   | Diagnostics topic |

## Effects on system behavior

The `safety_filter_node` publishes to the `/diagnostics` topic.