### PR TITLE
feat(static_obstacle_avoidance): add turn signal policy for candidate paths and refactor turn signal computation

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/config/static_obstacle_avoidance.param.yaml
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/config/static_obstacle_avoidance.param.yaml
@@ -283,7 +283,6 @@
       yield:
         enable: true                                    # [-]
         enable_during_shifting: false                   # [-]
-        enable_signalling_during_yield: false           # [-]
 
       # For stop maneuver
       stop:
@@ -313,6 +312,11 @@
         lateral_margin: "best_effort"                   # [-]
         # if true, module doesn't wait deceleration and outputs avoidance path by best effort margin.
         use_shorten_margin_immediately: true            # [-]
+        # policy for turn signal output during candidate path (waiting approval).
+        # "none"             : never output turn signal for candidate paths.
+        # "stopped_candidate": output turn signal only when vehicle is stopped and candidate path exists.
+        # "all_candidate"    : always output turn signal whenever a candidate path exists.
+        candidate_path_turn_signal: "none" # [-]
 
       # --------------------------------------
       # FOLLOWING PARAMETERS ARE FOR DEVELOPER

--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/include/autoware/behavior_path_static_obstacle_avoidance_module/data_structs.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/include/autoware/behavior_path_static_obstacle_avoidance_module/data_structs.hpp
@@ -131,11 +131,8 @@ struct AvoidanceParameters
   // enable yield maneuver.
   bool enable_yield_maneuver{false};
 
-  // enable yield maneuver during shifting.
+  // enable yield maneuver.
   bool enable_yield_maneuver_during_shifting{false};
-
-  // enable signalling during yield maneuver.
-  bool enable_signalling_during_yield{false};
 
   // use hatched road markings for avoidance
   bool use_hatched_road_markings{false};
@@ -336,6 +333,9 @@ struct AvoidanceParameters
 
   // policy
   std::string policy_lateral_margin{"best_effort"};
+
+  // policy for turn signal output during candidate path (waiting approval)
+  std::string policy_candidate_path_turn_signal{"stopped_candidate"};
 
   // path generation method.
   std::string path_generation_method{"shift_line_base"};

--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/include/autoware/behavior_path_static_obstacle_avoidance_module/parameter_helper.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/include/autoware/behavior_path_static_obstacle_avoidance_module/parameter_helper.hpp
@@ -338,8 +338,6 @@ AvoidanceParameters getParameter(rclcpp::Node * node)
     p.enable_yield_maneuver = get_or_declare_parameter<bool>(*node, ns + "enable");
     p.enable_yield_maneuver_during_shifting =
       get_or_declare_parameter<bool>(*node, ns + "enable_during_shifting");
-    p.enable_signalling_during_yield =
-      get_or_declare_parameter<bool>(*node, ns + "enable_signalling_during_yield");
   }
 
   // stop
@@ -359,6 +357,8 @@ AvoidanceParameters getParameter(rclcpp::Node * node)
     p.policy_lateral_margin = get_or_declare_parameter<std::string>(*node, ns + "lateral_margin");
     p.use_shorten_margin_immediately =
       get_or_declare_parameter<bool>(*node, ns + "use_shorten_margin_immediately");
+    p.policy_candidate_path_turn_signal =
+      get_or_declare_parameter<std::string>(*node, ns + "candidate_path_turn_signal");
 
     if (p.policy_approval != "per_shift_line" && p.policy_approval != "per_avoidance_maneuver") {
       throw std::domain_error("invalid policy. please select 'best_effort' or 'reliable'.");
@@ -370,6 +370,14 @@ AvoidanceParameters getParameter(rclcpp::Node * node)
 
     if (p.policy_lateral_margin != "best_effort" && p.policy_lateral_margin != "reliable") {
       throw std::domain_error("invalid policy. please select 'best_effort' or 'reliable'.");
+    }
+
+    if (
+      p.policy_candidate_path_turn_signal != "none" &&
+      p.policy_candidate_path_turn_signal != "stopped_candidate" &&
+      p.policy_candidate_path_turn_signal != "all_candidate") {
+      throw std::domain_error(
+        "invalid policy. please select 'none', 'stopped_candidate' or 'all_candidate'.");
     }
   }
 

--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/include/autoware/behavior_path_static_obstacle_avoidance_module/scene.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/include/autoware/behavior_path_static_obstacle_avoidance_module/scene.hpp
@@ -30,6 +30,7 @@
 
 #include <limits>
 #include <memory>
+#include <optional>
 #include <set>
 #include <string>
 #include <unordered_map>
@@ -445,8 +446,19 @@ private:
    */
   bool is_operator_approval_required(ShiftedPath & shifted_path, DebugData & debug) const;
 
-  auto getTurnSignal(const ShiftedPath & spline_shift_path, const ShiftedPath & linear_shift_path)
-    -> TurnSignalInfo;
+  auto getTurnSignal(
+    const ShiftedPath & spline_shift_path, const ShiftedPath & linear_shift_path,
+    const ShiftLineArray & shift_lines) const
+    -> std::pair<TurnSignalInfo, std::optional<std::string>>;
+
+  /**
+   * @brief Generate spline/linear shifted paths from a shifter and compute turn signal.
+   * @param shifter PathShifter already configured with desired shift lines.
+   * @param reference_path Reference path used as the base for shifting.
+   * @return Computed TurnSignalInfo and an optional UUID string to be added to ignore_signal_ids_.
+   */
+  auto computeTurnSignalFromShifter(PathShifter & shifter, const PathWithLaneId & reference_path)
+    const -> std::pair<TurnSignalInfo, std::optional<std::string>>;
 
   // post process
 

--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/schema/static_obstacle_avoidance.schema.json
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/schema/static_obstacle_avoidance.schema.json
@@ -1358,14 +1358,9 @@
               "type": "boolean",
               "description": "Flag to enable yield maneuver during shifting.",
               "default": "false"
-            },
-            "enable_signalling_during_yield": {
-              "type": "boolean",
-              "description": "Flag to enable signalling during yield maneuver.",
-              "default": "false"
             }
           },
-          "required": ["enable", "enable_during_shifting", "enable_signalling_during_yield"],
+          "required": ["enable", "enable_during_shifting"],
           "additionalProperties": false
         },
         "cancel": {
@@ -1421,6 +1416,12 @@
               "type": "boolean",
               "description": "if true, module doesn't wait deceleration and outputs avoidance path by best effort margin.",
               "default": "true"
+            },
+            "candidate_path_turn_signal": {
+              "type": "string",
+              "enum": ["none", "stopped_candidate", "all_candidate"],
+              "description": "policy for turn signal output during planWaitingApproval (candidate path). 'none': never output turn signal for candidate paths. 'stopped_candidate': output turn signal only when the vehicle is stopped and a candidate path exists (default behavior). 'all_candidate': always output turn signal whenever a candidate path exists.",
+              "default": "none"
             }
           },
           "required": ["make_approval_request"],

--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/manager.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/manager.cpp
@@ -210,6 +210,8 @@ void StaticObstacleAvoidanceModuleManager::updateModuleParams(
     update_param<std::string>(parameters, ns + "lateral_margin", p->policy_lateral_margin);
     update_param<bool>(
       parameters, ns + "use_shorten_margin_immediately", p->use_shorten_margin_immediately);
+    update_param<std::string>(
+      parameters, ns + "candidate_path_turn_signal", p->policy_candidate_path_turn_signal);
 
     if (p->policy_approval != "per_shift_line" && p->policy_approval != "per_avoidance_maneuver") {
       RCLCPP_ERROR(
@@ -227,6 +229,16 @@ void StaticObstacleAvoidanceModuleManager::updateModuleParams(
       RCLCPP_ERROR(
         rclcpp::get_logger(__func__),
         "invalid lateral margin policy. Please select 'best_effort' or 'reliable'.");
+    }
+
+    if (
+      p->policy_candidate_path_turn_signal != "none" &&
+      p->policy_candidate_path_turn_signal != "stopped_candidate" &&
+      p->policy_candidate_path_turn_signal != "all_candidate") {
+      RCLCPP_ERROR(
+        rclcpp::get_logger(__func__),
+        "invalid candidate_path_turn_signal policy. Please select 'none', 'stopped_candidate' or "
+        "'all_candidate'.");
     }
   }
 

--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/scene.cpp
@@ -38,8 +38,8 @@
 #include <set>
 #include <string>
 #include <unordered_map>
+#include <utility>
 #include <vector>
-
 namespace autoware::behavior_path_planner
 {
 namespace
@@ -1016,18 +1016,13 @@ PathWithLaneId StaticObstacleAvoidanceModule::extendBackwardLength(
 }
 
 auto StaticObstacleAvoidanceModule::getTurnSignal(
-  const ShiftedPath & spline_shift_path, const ShiftedPath & linear_shift_path) -> TurnSignalInfo
+  const ShiftedPath & spline_shift_path, const ShiftedPath & linear_shift_path,
+  const ShiftLineArray & shift_lines) const -> std::pair<TurnSignalInfo, std::optional<std::string>>
 {
   using autoware::motion_utils::calcSignedArcLength;
 
   const auto is_ignore_signal = [this](const UUID & uuid) {
     return ignore_signal_ids_.find(to_hex_string(uuid)) != ignore_signal_ids_.end();
-  };
-
-  const auto update_ignore_signal = [this](const UUID & uuid, const bool is_ignore) {
-    if (is_ignore) {
-      ignore_signal_ids_.insert(to_hex_string(uuid));
-    }
   };
 
   const auto is_large_deviation = [this](const auto & path) {
@@ -1038,43 +1033,19 @@ auto StaticObstacleAvoidanceModule::getTurnSignal(
     return std::abs(lateral_deviation) > threshold;
   };
 
-  auto shift_lines = path_shifter_.getShiftLines();
-  auto selected_spline_shift_path = spline_shift_path;
-  auto selected_linear_shift_path = linear_shift_path;
-  if (parameters_->enable_signalling_during_yield && avoid_data_.yield_required) {
-    if (avoid_data_.candidate_path.path.points.empty()) {
-      return getPreviousModuleOutput().turn_signal_info;
-    }
-
-    selected_spline_shift_path = avoid_data_.candidate_path;
-    selected_linear_shift_path = avoid_data_.candidate_path;
-
-    shift_lines.clear();
-    for (const auto & al : avoid_data_.safe_shift_line) {
-      shift_lines.push_back(al);
-    }
-  }
-
-  const auto & ref_points = path_shifter_.getReferencePath().points;
-  if (ref_points.empty()) {
-    return getPreviousModuleOutput().turn_signal_info;
-  }
-
-  const size_t ego_idx = planner_data_->findEgoIndex(ref_points);
-
   std::vector<ShiftLine> shift_lines_after_ego;
   for (const auto & s : shift_lines) {
-    if (s.end_idx >= ego_idx) {
+    if (s.end_idx >= planner_data_->findEgoIndex(spline_shift_path.path.points)) {
       shift_lines_after_ego.push_back(s);
     }
   }
 
   if (shift_lines_after_ego.empty()) {
-    return getPreviousModuleOutput().turn_signal_info;
+    return {getPreviousModuleOutput().turn_signal_info, std::nullopt};
   }
 
-  if (is_large_deviation(selected_spline_shift_path.path)) {
-    return getPreviousModuleOutput().turn_signal_info;
+  if (is_large_deviation(spline_shift_path.path)) {
+    return {getPreviousModuleOutput().turn_signal_info, std::nullopt};
   }
 
   const auto target_shift_line = [&]() {
@@ -1097,14 +1068,17 @@ auto StaticObstacleAvoidanceModule::getTurnSignal(
       }
 
       // different side shift
+      const auto & points = path_shifter_.getReferencePath().points;
+      const size_t idx = planner_data_->findEgoIndex(points);
+
       // output turn signal for near shift line.
-      if (calcSignedArcLength(ref_points, ego_idx, s1.start_idx) > 0.0) {
+      if (calcSignedArcLength(points, idx, s1.start_idx) > 0.0) {
         return s1;
       }
 
       // output turn signal for far shift line.
       if (
-        calcSignedArcLength(ref_points, ego_idx, s2.start_idx) <
+        calcSignedArcLength(points, idx, s2.start_idx) <
         getEgoSpeed() * parameters_->max_prepare_time) {
         return s2;
       }
@@ -1117,7 +1091,7 @@ auto StaticObstacleAvoidanceModule::getTurnSignal(
   }();
 
   if (is_ignore_signal(target_shift_line.id)) {
-    return getPreviousModuleOutput().turn_signal_info;
+    return {getPreviousModuleOutput().turn_signal_info, std::nullopt};
   }
 
   const auto original_signal = getPreviousModuleOutput().turn_signal_info;
@@ -1126,17 +1100,30 @@ auto StaticObstacleAvoidanceModule::getTurnSignal(
   constexpr bool egos_lane_is_shifted = true;
 
   const auto [new_signal, is_ignore] = planner_data_->getBehaviorTurnSignalInfo(
-    selected_linear_shift_path, target_shift_line, avoid_data_.current_lanelets,
-    helper_->getEgoShift(), is_driving_forward, egos_lane_is_shifted);
+    linear_shift_path, target_shift_line, avoid_data_.current_lanelets, helper_->getEgoShift(),
+    is_driving_forward, egos_lane_is_shifted);
 
-  update_ignore_signal(target_shift_line.id, is_ignore);
+  const std::optional<std::string> new_ignore_id =
+    is_ignore ? std::optional<std::string>{to_hex_string(target_shift_line.id)} : std::nullopt;
 
-  const auto current_seg_idx =
-    planner_data_->findEgoSegmentIndex(selected_spline_shift_path.path.points);
-  return planner_data_->turn_signal_decider.overwrite_turn_signal(
-    selected_spline_shift_path.path, getEgoPose(), current_seg_idx, original_signal, new_signal,
-    planner_data_->parameters.ego_nearest_dist_threshold,
-    planner_data_->parameters.ego_nearest_yaw_threshold);
+  const auto current_seg_idx = planner_data_->findEgoSegmentIndex(spline_shift_path.path.points);
+  return {
+    planner_data_->turn_signal_decider.overwrite_turn_signal(
+      spline_shift_path.path, getEgoPose(), current_seg_idx, original_signal, new_signal,
+      planner_data_->parameters.ego_nearest_dist_threshold,
+      planner_data_->parameters.ego_nearest_yaw_threshold),
+    new_ignore_id};
+}
+
+auto StaticObstacleAvoidanceModule::computeTurnSignalFromShifter(
+  PathShifter & shifter, const PathWithLaneId & reference_path) const
+  -> std::pair<TurnSignalInfo, std::optional<std::string>>
+{
+  ShiftedPath spline_path = utils::static_obstacle_avoidance::toShiftedPath(reference_path);
+  ShiftedPath linear_path = utils::static_obstacle_avoidance::toShiftedPath(reference_path);
+  shifter.generate(&spline_path, true, SHIFT_TYPE::SPLINE);
+  shifter.generate(&linear_path, true, SHIFT_TYPE::LINEAR);
+  return getTurnSignal(spline_path, linear_path, shifter.getShiftLines());
 }
 
 BehaviorModuleOutput StaticObstacleAvoidanceModule::plan()
@@ -1186,7 +1173,12 @@ BehaviorModuleOutput StaticObstacleAvoidanceModule::plan()
 
   // turn signal
   {
-    output.turn_signal_info = getTurnSignal(spline_shift_path, linear_shift_path);
+    auto [turn_signal, new_ignore_id] =
+      getTurnSignal(spline_shift_path, linear_shift_path, path_shifter_.getShiftLines());
+    if (new_ignore_id) {
+      ignore_signal_ids_.insert(*new_ignore_id);
+    }
+    output.turn_signal_info = turn_signal;
   }
 
   // sparse resampling for computational cost
@@ -1316,12 +1308,35 @@ BehaviorModuleOutput StaticObstacleAvoidanceModule::planWaitingApproval()
   autoware_utils::ScopedTimeTrack st(__func__, *time_keeper_);
   BehaviorModuleOutput out = plan();
 
-  const bool is_no_shift_lines =
-    !(parameters_->enable_signalling_during_yield && avoid_data_.yield_required)
-      ? path_shifter_.getShiftLines().empty()
-      : avoid_data_.safe_shift_line.empty();
-  if (is_no_shift_lines) {
-    out.turn_signal_info = getPreviousModuleOutput().turn_signal_info;
+  if (path_shifter_.getShiftLines().empty()) {
+    const auto & candidate_shift_lines = avoid_data_.safe_shift_line;
+    const auto & turn_signal_policy = parameters_->policy_candidate_path_turn_signal;
+
+    // Determine whether to compute turn signal from candidate shift lines.
+    // "none"             : never output turn signal for candidate paths.
+    // "stopped_candidate": output turn signal only when vehicle is stopped (current default).
+    // "all_candidate"    : always output turn signal when candidate path exists.
+    const bool should_output_candidate_turn_signal = [&]() {
+      const bool has_candidates = !candidate_shift_lines.empty();
+      const bool always_signal = turn_signal_policy == "all_candidate";
+      const bool signal_when_stopped =
+        turn_signal_policy == "stopped_candidate" && helper_->isVehicleStopped();
+      return has_candidates && (always_signal || signal_when_stopped);
+    }();
+
+    if (should_output_candidate_turn_signal) {
+      // Compute turn signal from candidate shift lines before approval.
+      auto candidate_shifter = path_shifter_;
+      addNewShiftLines(candidate_shifter, candidate_shift_lines);
+      auto [turn_signal, new_ignore_id] =
+        computeTurnSignalFromShifter(candidate_shifter, avoid_data_.reference_path);
+      if (new_ignore_id) {
+        ignore_signal_ids_.insert(*new_ignore_id);
+      }
+      out.turn_signal_info = turn_signal;
+    } else {
+      out.turn_signal_info = getPreviousModuleOutput().turn_signal_info;
+    }
   }
 
   path_candidate_ = std::make_shared<PathWithLaneId>(planCandidate().path_candidate);


### PR DESCRIPTION
## Description

Add `policy_candidate_path_turn_signal` parameter to control turn signal output behavior during `planWaitingApproval` (while a candidate avoidance path awaits operator approval), and refactor `getTurnSignal` to make it `const`.

### Revert https://github.com/autowarefoundation/autoware_universe/pull/11778

In [this PR](https://github.com/autowarefoundation/autoware_universe/pull/11778), the turn signal was output only for candidate paths during yield operations. This PR generalizes that behavior, adding an option to output turn signals for all candidate paths.

### Refactoring: `getTurnSignal`

- Added explicit `shift_lines` argument (previously always read `path_shifter_.getShiftLines()` internally) to enable reuse for both active and candidate shifts
- Made `const` by removing the internal mutation of `ignore_signal_ids_`: the UUID to suppress is now returned as `std::optional<std::string>` and callers perform the insertion
- Extracted `computeTurnSignalFromShifter` helper to eliminate duplicated path generation logic between `plan()` and `planWaitingApproval()`

## Related links

- https://github.com/autowarefoundation/autoware_launch/pull/1765

## How was this PR tested?

**all_candidate**

[Screencast from 02-19-2026 05:55:39 PM.webm](https://github.com/user-attachments/assets/4183acb8-6256-452f-8c98-f80bedb2e337)

**stopped_candidate**

[Screencast from 02-19-2026 05:58:34 PM.webm](https://github.com/user-attachments/assets/28910b63-4406-4732-80a9-e1c15144cec1)

**none**

[Screencast from 02-19-2026 05:57:09 PM.webm](https://github.com/user-attachments/assets/3b4775bf-e024-4f6a-ab52-080e2f857f6b)


[[yhisaki][Lexus][MasterScenario] PR check](https://evaluation.tier4.jp/evaluation/reports/5f420ae1-19bd-5879-871a-ce7186098f9b?project_id=autoware_dev)

[feat/avoidance-candidate-turn-signal-policy](https://evaluation.tier4.jp/evaluation/reports/f68e06a5-62c4-50ab-abc3-c723270bd1a9?project_id=prd_jt)

[feat/avoidance-candidate-turn-signal-policy](https://evaluation.tier4.jp/evaluation/reports/17466d5a-fa67-536a-88da-6f39733ada19?project_id=prd_jt)

## Notes for reviewers

None.

## Interface changes

### ROS Parameter Changes

#### Additions and removals

| Change type | Parameter Name | Type | Default Value | Description |
|:------------|:---------------|:-----|:--------------|:------------|
| Added | `avoidance.policy.candidate_path_turn_signal` | `string` | `"none"` | Policy for turn signal output during candidate path presentation. Select `none`, `stopped_candidate`, or `all_candidate`. |
| Removed | `avoidance.yield.enable_signalling_during_yield` | `bool` | `false` | Superseded by `candidate_path_turn_signal`. |

## Effects on system behavior

None. The default value `"none"` preserves the existing behavior.
