### PR TITLE
fix(diffusion_planner): removed `result.predictions.clear();`

### DIFF
--- a/planning/autoware_diffusion_planner/src/preprocessing/lane_segments.cpp
+++ b/planning/autoware_diffusion_planner/src/preprocessing/lane_segments.cpp
@@ -146,7 +146,6 @@ LaneSegmentContext::get_first_traffic_light_on_route(
       unknown_element.status = TrafficLightElement::UNKNOWN;
       unknown_element.confidence = 0.0f;
       result.elements = {unknown_element};
-      result.predictions.clear();
     }
     return result;
   }


### PR DESCRIPTION
## Description

The autoware_perception_msgs/TrafficLightGroup message type was updated to include a predictions array in the following PRs (v1.8.0 and later):

- https://github.com/autowarefoundation/autoware_msgs/pull/134
- https://github.com/autowarefoundation/autoware_msgs/pull/135

To maintain backward compatibility, this PR removes the line result.predictions.clear();. Since this line currently has no functional impact, removing it will not affect the system's behavior.

## How was this PR tested?

- [x] planning simulator
- [x] logging simulator

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.
