### PR TITLE
fix(diffusion_planner): add `turn_indicator_batch_idx`

### DIFF
--- a/planning/autoware_diffusion_planner/src/diffusion_planner_core.cpp
+++ b/planning/autoware_diffusion_planner/src/diffusion_planner_core.cpp
@@ -345,13 +345,16 @@ PlannerOutput DiffusionPlannerCore::create_planner_output(
     agent_poses, frame_context.ego_centric_neighbor_histories, timestamp, batch_idx);
 
   // TurnIndicatorsCommand
-  // TODO(sakoda): Use the first logit as the main turn indicator command.
-  // There may be bugs in the current implementation.
+  // Use the first batch's logit as the main turn indicator command.
+  constexpr int64_t turn_indicator_batch_idx = 0;
+  const std::vector<float> first_turn_indicator_logit(
+    turn_indicator_logit.begin() + TURN_INDICATOR_OUTPUT_DIM * turn_indicator_batch_idx,
+    turn_indicator_logit.begin() + TURN_INDICATOR_OUTPUT_DIM * (turn_indicator_batch_idx + 1));
   const int64_t prev_report = turn_indicators_history_.empty()
                                 ? TurnIndicatorsReport::DISABLE
                                 : turn_indicators_history_.back().report;
   output.turn_indicator_command =
-    turn_indicator_manager_.evaluate(turn_indicator_logit, timestamp, prev_report);
+    turn_indicator_manager_.evaluate(first_turn_indicator_logit, timestamp, prev_report);
 
   return output;
 }


### PR DESCRIPTION
## Description

This PR fixes a bug in the diffusion planner's turn indicator logic by properly extracting the first batch's logit values before passing them to the turn indicator manager.

## How was this PR tested?

- [x] planning simulator
- [x] logging simulator

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.
