### PR TITLE
fix(autoware_component_monitor): treat suffix-less RES as KiB

### DIFF
--- a/system/autoware_component_monitor/CMakeLists.txt
+++ b/system/autoware_component_monitor/CMakeLists.txt
@@ -22,6 +22,10 @@ if(BUILD_TESTING)
   ament_add_ros_isolated_gtest(test_unit_conversions test/test_unit_conversions.cpp)
   target_link_libraries(test_unit_conversions ${PROJECT_NAME})
   target_include_directories(test_unit_conversions PRIVATE src)
+
+  ament_add_ros_isolated_gtest(test_top_memory_parser test/test_top_memory_parser.cpp)
+  target_link_libraries(test_top_memory_parser ${PROJECT_NAME})
+  target_include_directories(test_top_memory_parser PRIVATE src)
 endif()
 
 ament_auto_package(

--- a/system/autoware_component_monitor/src/component_monitor_node.cpp
+++ b/system/autoware_component_monitor/src/component_monitor_node.cpp
@@ -14,6 +14,7 @@
 
 #include "component_monitor_node.hpp"
 
+#include "top_memory_parser.hpp"
 #include "unit_conversions.hpp"
 
 #include <rclcpp/rclcpp.hpp>
@@ -145,31 +146,7 @@ ComponentMonitor::VecVecStr ComponentMonitor::parse_lines_into_words(
 
 std::uint64_t ComponentMonitor::parse_memory_res(const std::string & mem_res)
 {
-  // example 1: 12.3g
-  // example 2: 123 (without suffix, just bytes)
-  // NOLINTNEXTLINE(readability/casting)
-  static const std::unordered_map<char, std::function<std::uint64_t(double)>> unit_map{
-    {'k', unit_conversions::kib_to_bytes<double>}, {'m', unit_conversions::mib_to_bytes<double>},
-    {'g', unit_conversions::gib_to_bytes<double>}, {'t', unit_conversions::tib_to_bytes<double>},
-    {'p', unit_conversions::pib_to_bytes<double>}, {'e', unit_conversions::eib_to_bytes<double>}};
-
-  if (std::isdigit(mem_res.back())) {
-    return std::stoull(mem_res);  // Handle plain bytes without any suffix
-  }
-
-  // Extract the numeric part and the unit suffix
-  double value = std::stod(mem_res.substr(0, mem_res.size() - 1));
-  char suffix = mem_res.back();
-
-  // Find the appropriate function from the map
-  auto it = unit_map.find(suffix);
-  if (it != unit_map.end()) {
-    const auto & conversion_function = it->second;
-    return conversion_function(value);
-  }
-
-  // Throw an exception or handle the error as needed if the suffix is not recognized
-  throw std::runtime_error("Unsupported unit suffix: " + std::string(1, suffix));
+  return parse_top_res_to_bytes(mem_res);
 }
 
 }  // namespace autoware::component_monitor

--- a/system/autoware_component_monitor/src/component_monitor_node.hpp
+++ b/system/autoware_component_monitor/src/component_monitor_node.hpp
@@ -87,9 +87,10 @@ private:
    *
    * This function handles memory size strings with suffixes to denote
    * the units (e.g., "k" for kibibytes, "m" for mebibytes, etc.).
-   * If the string has no suffix, it is interpreted as plain bytes.
+   * If the string has no suffix, it is interpreted as KiB (procps `top` task area format).
    *
-   * @param mem_res A string representing the memory resource with a unit suffix or just bytes.
+   * @param mem_res A string representing the memory resource with a unit suffix, or without suffix
+   * (KiB).
    * @return uint64_t The memory size in bytes.
    *
    * @exception std::runtime_error Thrown if the suffix is not recognized.

--- a/system/autoware_component_monitor/src/top_memory_parser.hpp
+++ b/system/autoware_component_monitor/src/top_memory_parser.hpp
@@ -1,0 +1,73 @@
+// Copyright 2026 The Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef TOP_MEMORY_PARSER_HPP_
+#define TOP_MEMORY_PARSER_HPP_
+
+#include "unit_conversions.hpp"
+
+#include <cctype>
+#include <cstdint>
+#include <functional>
+#include <stdexcept>
+#include <string>
+#include <unordered_map>
+
+namespace autoware::component_monitor
+{
+
+/**
+ * @brief Parse RES memory string produced by procps `top` and convert to bytes.
+ *
+ * `top` may print memory in two formats:
+ * - With a suffix (e.g., "25.3m", "1.2g") according to the task-area scaling (`-e`).
+ * - Without a suffix (e.g., "29548"). In that case, the value is in KiB.
+ *
+ * The current component monitor uses `top -b -n 1 -E k -p <pid>`; note `-E` only affects the
+ * summary section, while the task area (where RES is shown) follows `-e` scaling/defaults.
+ */
+inline std::uint64_t parse_top_res_to_bytes(const std::string & mem_res)
+{
+  if (mem_res.empty()) {
+    throw std::runtime_error("Empty RES string");
+  }
+
+  // example 1: 12.3g
+  // example 2: 25944 (without suffix, KiB)
+  static const std::unordered_map<char, std::function<std::uint64_t(double)>> unit_map{
+    {'k', unit_conversions::kib_to_bytes<double>}, {'m', unit_conversions::mib_to_bytes<double>},
+    {'g', unit_conversions::gib_to_bytes<double>}, {'t', unit_conversions::tib_to_bytes<double>},
+    {'p', unit_conversions::pib_to_bytes<double>}, {'e', unit_conversions::eib_to_bytes<double>},
+  };
+
+  const unsigned char last_uc = static_cast<unsigned char>(mem_res.back());
+  if (std::isdigit(last_uc)) {
+    // procps `top` prints RES without a suffix in KiB (not bytes).
+    return unit_conversions::kib_to_bytes(std::stoull(mem_res));
+  }
+
+  const double value = std::stod(mem_res.substr(0, mem_res.size() - 1));
+  const char suffix = static_cast<char>(std::tolower(last_uc));
+
+  const auto it = unit_map.find(suffix);
+  if (it != unit_map.end()) {
+    return it->second(value);
+  }
+
+  throw std::runtime_error("Unsupported unit suffix: " + std::string(1, mem_res.back()));
+}
+
+}  // namespace autoware::component_monitor
+
+#endif  // TOP_MEMORY_PARSER_HPP_

--- a/system/autoware_component_monitor/test/test_top_memory_parser.cpp
+++ b/system/autoware_component_monitor/test/test_top_memory_parser.cpp
@@ -1,0 +1,36 @@
+// Copyright 2026 The Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "top_memory_parser.hpp"
+
+#include <gtest/gtest.h>
+
+namespace autoware::component_monitor
+{
+
+TEST(TopMemoryParser, NoSuffixIsKiB)
+{
+  EXPECT_EQ(parse_top_res_to_bytes("0"), 0U);
+  EXPECT_EQ(parse_top_res_to_bytes("18872"), 18872ULL * 1024ULL);
+}
+
+TEST(TopMemoryParser, SuffixParsing)
+{
+  EXPECT_EQ(parse_top_res_to_bytes("1k"), 1024U);
+  EXPECT_EQ(parse_top_res_to_bytes("1m"), 1024ULL * 1024ULL);
+  EXPECT_EQ(parse_top_res_to_bytes("1g"), 1024ULL * 1024ULL * 1024ULL);
+  EXPECT_EQ(parse_top_res_to_bytes("1T"), 1024ULL * 1024ULL * 1024ULL * 1024ULL);
+}
+
+}  // namespace autoware::component_monitor


### PR DESCRIPTION
## Description
Fix autoware_component_monitor memory parsing for top RES values without a unit suffix.

top may print the RES column as a plain integer which is KiB, but the previous implementation interpreted suffix-less values as bytes, under-reporting RSS by ~1024x for small processes. This PR treats suffix-less RES values as KiB and adds a unit test for the parser.

## Related links

**Parent Issue:**

[#12215](https://github.com/autowarefoundation/autoware_universe/issues/12215)

## How was this PR tested?
```bash
colcon test --packages-select autoware_component_monitor
```

## Notes for reviewers

* The change is limited to RES parsing (process_memory_bytes) and keeps suffix handling (k/m/g/...) intact.  
* Added test_top_memory_parser to cover both suffix-less and suffixed inputs.  


## Interface changes

None.

## Effects on system behavior

process_memory_bytes will increase by ~1024x in cases where top prints RES without a suffix (previously under-reported).
