### PR TITLE
chore(tier4_traffic_light_rviz_plugin): change instantiation timing of traffic light publisher

### DIFF
--- a/visualization/tier4_traffic_light_rviz_plugin/src/traffic_light_publish_panel.cpp
+++ b/visualization/tier4_traffic_light_rviz_plugin/src/traffic_light_publish_panel.cpp
@@ -200,7 +200,7 @@ void TrafficLightPublishPanel::onSetTrafficLightState()
 void TrafficLightPublishPanel::onResetTrafficLightState()
 {
   extra_traffic_signals_.traffic_light_groups.clear();
-  enable_publish_ = false;
+  pub_traffic_signals_.reset();
 
   publish_button_->setText("PUBLISH");
   publish_button_->setStyleSheet("background-color: #FFFFFF");
@@ -208,8 +208,8 @@ void TrafficLightPublishPanel::onResetTrafficLightState()
 
 void TrafficLightPublishPanel::onPublishTrafficLightState()
 {
-  enable_publish_ = true;
-
+  pub_traffic_signals_ = raw_node_->create_publisher<TrafficLightGroupArray>(
+    "/perception/traffic_light_recognition/traffic_signals", rclcpp::QoS(1));
   publish_button_->setText("PUBLISHING...");
   publish_button_->setStyleSheet("background-color: #FFBF00");
 }
@@ -219,15 +219,11 @@ void TrafficLightPublishPanel::onInitialize()
   using std::placeholders::_1;
   raw_node_ = this->getDisplayContext()->getRosNodeAbstraction().lock()->get_raw_node();
 
-  pub_traffic_signals_ = raw_node_->create_publisher<TrafficLightGroupArray>(
-    "/perception/traffic_light_recognition/traffic_signals", rclcpp::QoS(1));
-
   sub_vector_map_ = raw_node_->create_subscription<LaneletMapBin>(
     "/map/vector_map", rclcpp::QoS{1}.transient_local(),
     std::bind(&TrafficLightPublishPanel::onVectorMap, this, _1));
   createWallTimer();
 
-  enable_publish_ = false;
   received_vector_map_ = false;
 }
 
@@ -248,7 +244,7 @@ void TrafficLightPublishPanel::createWallTimer()
 
 void TrafficLightPublishPanel::onTimer()
 {
-  if (enable_publish_) {
+  if (pub_traffic_signals_) {
     extra_traffic_signals_.stamp = rclcpp::Clock().now();
     pub_traffic_signals_->publish(extra_traffic_signals_);
   }

--- a/visualization/tier4_traffic_light_rviz_plugin/src/traffic_light_publish_panel.hpp
+++ b/visualization/tier4_traffic_light_rviz_plugin/src/traffic_light_publish_panel.hpp
@@ -76,7 +76,6 @@ protected:
 
   TrafficLightGroupArray extra_traffic_signals_;
 
-  bool enable_publish_{false};
   std::set<int> traffic_light_ids_;
   bool received_vector_map_{false};
 };


### PR DESCRIPTION
## Description

I would like to instantiate publisher only when `TrafficLightPublishPannel` plugin displays `PUBLISHING...`.

This change is related with #12077. The dummy publisher proposed at #12077 wants to know whether there is another publisher created by `TrafficLightPublishPannel` plugin.


## Related links

#12077

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

Launch Autoware with Planning simulator.

```bash
source ~/autoware/install/setup.bash
ros2 launch autoware_launch planning_simulator.launch.xml map_path:=$HOME/autoware_map/sample-map-planning vehicle_model:=autoware_sample_vehicle sensor_model:=autoware_sample_sensor_kit
```

Add `TrafficLightPublishPannel` as below.
https://autowarefoundation.github.io/autoware-documentation/main/demos/planning-sim/traffic-light/

Please check if `rviz2` does not have publisher of traffic light with `ros2 node info /rviz2`.
<img width="3626" height="1681" alt="Screenshot from 2026-03-02 22-15-57" src="https://github.com/user-attachments/assets/b2c38399-b978-48c1-883d-83694a68c169" />

Start publish and check if `rviz2` has publisher of traffic light with `ros2 node info /rviz2`.
<img width="3626" height="1681" alt="Screenshot from 2026-03-02 22-16-07" src="https://github.com/user-attachments/assets/253c235f-41f7-4cb7-88f5-17394012a072" />

Enter reset button and if `rviz2` does not have publisher of traffic light with `ros2 node info /rviz2`.
<img width="3626" height="1681" alt="Screenshot from 2026-03-02 22-16-14" src="https://github.com/user-attachments/assets/42a875ad-f735-47fa-86a5-3521be41c604" />



## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None. There are a slight change, timing of publisher creation, on RViz Plugin. 