### PR TITLE
fix(yabloc_common): avoid maybe-uninitialized build error on NVIDIA DRIVE AGX Thor

### DIFF
--- a/localization/yabloc/yabloc_common/src/ground_server/ground_server_core.cpp
+++ b/localization/yabloc/yabloc_common/src/ground_server/ground_server_core.cpp
@@ -206,8 +206,8 @@ GroundServer::GroundPlane GroundServer::estimate_ground(const Point & point)
   last_indices_ = indices;
 
   // Estimate normal vector using covariance matrix around the target point
-  Eigen::Matrix3f covariance;
-  Eigen::Vector4f centroid;
+  Eigen::Matrix3f covariance = Eigen::Matrix3f::Zero();
+  Eigen::Vector4f centroid = Eigen::Vector4f::Zero();
   pcl::compute3DCentroid(*cloud_, indices, centroid);
   pcl::computeCovarianceMatrix(*cloud_, indices, centroid, covariance);
 


### PR DESCRIPTION
## Description

Avoided `maybe-uninitialized` warning/error by explicitly initializing `Eigen::Matrix3f`.
This error only happens on NVIDIA DRIVE AGX Thor and when -O3 optimization is used.

```
--- stderr: yabloc_common                                 
In file included from /usr/include/eigen3/Eigen/Core:171,
                 from /home/autoware/autoware/src/universe/autoware_universe/localization/yabloc/yabloc_common/include/yabloc_common/ground_server/filter/moving_averaging.hpp:18,
                 from /home/autoware/autoware/src/universe/autoware_universe/localization/yabloc/yabloc_common/include/yabloc_common/ground_server/ground_server.hpp:18,
                 from /home/autoware/autoware/src/universe/autoware_universe/localization/yabloc/yabloc_common/src/ground_server/ground_server_core.cpp:15:
In function ‘typename Eigen::internal::enable_if<(Eigen::NumTraits<T>::IsSigned || Eigen::NumTraits<T>::IsComplex), typename Eigen::NumTraits<T>::Real>::type Eigen::numext::abs(const T&) [with T = float]’,
    inlined from ‘const Eigen::internal::scalar_abs_op<Scalar>::result_type Eigen::internal::scalar_abs_op<Scalar>::operator()(const Scalar&) const [with Scalar = float]’ at /usr/include/eigen3/Eigen/src/Core/functors/UnaryFunctors.h:44:114,
    inlined from ‘Eigen::internal::unary_evaluator<Eigen::CwiseUnaryOp<UnaryOp, ArgType>, Eigen::internal::IndexBased>::CoeffReturnType Eigen::internal::unary_evaluator<Eigen::CwiseUnaryOp<UnaryOp, ArgType>, Eigen::internal::IndexBased>::coeff(Eigen::Index, Eigen::Index) const [with UnaryOp = Eigen::internal::scalar_abs_op<float>; ArgType = const Eigen::Matrix<float, 3, 3>]’ at /usr/include/eigen3/Eigen/src/Core/CoreEvaluators.h:583:22,
    inlined from ‘Eigen::internal::redux_evaluator<_XprType>::CoeffReturnType Eigen::internal::redux_evaluator<_XprType>::coeffByOuterInner(Eigen::Index, Eigen::Index) const [with _XprType = Eigen::CwiseUnaryOp<Eigen::internal::scalar_abs_op<float>, const Eigen::Matrix<float, 3, 3> >]’ at /usr/include/eigen3/Eigen/src/Core/Redux.h:381:23,
    inlined from ‘static Eigen::internal::redux_novec_unroller<Func, Evaluator, Start, 1>::Scalar Eigen::internal::redux_novec_unroller<Func, Evaluator, Start, 1>::run(const Evaluator&, const Func&) [with Func = Eigen::internal::scalar_max_op<float, float, 0>; Evaluator = Eigen::internal::redux_evaluator<Eigen::CwiseUnaryOp<Eigen::internal::scalar_abs_op<float>, const Eigen::Matrix<float, 3, 3> > >; int Start = 8]’ at /usr/include/eigen3/Eigen/src/Core/Redux.h:128:34,
    inlined from ‘static Eigen::internal::redux_impl<Func, Evaluator, 3, 2>::Scalar Eigen::internal::redux_impl<Func, Evaluator, 3, 2>::run(const Evaluator&, const Func&, const XprType&) [with XprType = Eigen::CwiseUnaryOp<Eigen::internal::scalar_abs_op<float>, const Eigen::Matrix<float, 3, 3> >; Func = Eigen::internal::scalar_max_op<float, float, 0>; Evaluator = Eigen::internal::redux_evaluator<Eigen::CwiseUnaryOp<Eigen::internal::scalar_abs_op<float>, const Eigen::Matrix<float, 3, 3> > >]’ at /usr/include/eigen3/Eigen/src/Core/Redux.h:346:103,
    inlined from ‘typename Eigen::internal::traits<T>::Scalar Eigen::DenseBase<Derived>::redux(const Func&) const [with BinaryOp = Eigen::internal::scalar_max_op<float, float, 0>; Derived = Eigen::CwiseUnaryOp<Eigen::internal::scalar_abs_op<float>, const Eigen::Matrix<float, 3, 3> >]’ at /usr/include/eigen3/Eigen/src/Core/Redux.h:418:56,
    inlined from ‘typename Eigen::internal::traits<T>::Scalar Eigen::DenseBase<Derived>::maxCoeff() const [with int NaNPropagation = 0; Derived = Eigen::CwiseUnaryOp<Eigen::internal::scalar_abs_op<float>, const Eigen::Matrix<float, 3, 3> >]’ at /usr/include/eigen3/Eigen/src/Core/Redux.h:448:25,
    inlined from ‘typename Eigen::internal::traits<T>::Scalar Eigen::DenseBase<Derived>::maxCoeff() const [with Derived = Eigen::CwiseUnaryOp<Eigen::internal::scalar_abs_op<float>, const Eigen::Matrix<float, 3, 3> >]’ at /usr/include/eigen3/Eigen/src/Core/DenseBase.h:466:37,
    inlined from ‘void pcl::eigen33(const Matrix&, typename Matrix::Scalar&, Vector&) [with Matrix = Eigen::Matrix<float, 3, 3>; Vector = Eigen::Matrix<float, 3, 1>]’ at /usr/include/pcl-1.14/pcl/common/impl/eigen.hpp:301:43,
    inlined from ‘void pcl::solvePlaneParameters(const Eigen::Matrix3f&, float&, float&, float&, float&)’ at /usr/include/pcl-1.14/pcl/features/impl/feature.hpp:79:16,
    inlined from ‘void pcl::solvePlaneParameters(const Eigen::Matrix3f&, const Eigen::Vector4f&, Eigen::Vector4f&, float&)’ at /usr/include/pcl-1.14/pcl/features/impl/feature.hpp:56:24,
    inlined from ‘yabloc::ground_server::GroundServer::GroundPlane yabloc::ground_server::GroundServer::estimate_ground(const Point&)’ at /home/autoware/autoware/src/universe/autoware_universe/localization/yabloc/yabloc_common/src/ground_server/ground_server_core.cpp:217:28:
/usr/include/eigen3/Eigen/src/Core/MathFunctions.h:1511:13: error: ‘covariance.Eigen::Matrix<float, 3, 3, 0, 3, 3>::<unnamed>.Eigen::PlainObjectBase<Eigen::Matrix<float, 3, 3, 0, 3, 3> >::m_storage.Eigen::DenseStorage<float, 9, 3, 3, 0>::m_data.Eigen::internal::plain_array<float, 9, 0, 0>::array[8]’ may be used uninitialized [-Werror=maybe-uninitialized]
 1511 |   return abs(x);
      |          ~~~^~~
/home/autoware/autoware/src/universe/autoware_universe/localization/yabloc/yabloc_common/src/ground_server/ground_server_core.cpp: In member function ‘yabloc::ground_server::GroundServer::GroundPlane yabloc::ground_server::GroundServer::estimate_ground(const Point&)’:
/home/autoware/autoware/src/universe/autoware_universe/localization/yabloc/yabloc_common/src/ground_server/ground_server_core.cpp:209:19: note: ‘covariance’ declared here
  209 |   Eigen::Matrix3f covariance;
      |                   ^~~~~~~~~~
In file included from /usr/include/eigen3/Eigen/src/Core/util/ConfigureVectorization.h:392,
                 from /usr/include/eigen3/Eigen/Core:22:
In function ‘float32x2_t vld1_f32(const float32_t*)’,
    inlined from ‘Packet Eigen::internal::ploadu(const typename unpacket_traits<T>::type*) [with Packet = __Float32x2_t]’ at /usr/include/eigen3/Eigen/src/Core/arch/NEON/PacketMath.h:1710:45,
    inlined from ‘Packet Eigen::internal::ploadt(const typename unpacket_traits<T>::type*) [with Packet = __Float32x2_t; int Alignment = 0]’ at /usr/include/eigen3/Eigen/src/Core/GenericPacketMath.h:969:26,
    inlined from ‘PacketType Eigen::internal::evaluator<Eigen::PlainObjectBase<Derived> >::packet(Eigen::Index, Eigen::Index) const [with int LoadMode = 0; PacketType = __Float32x2_t; Derived = Eigen::Matrix<float, 3, 3>]’ at /usr/include/eigen3/Eigen/src/Core/CoreEvaluators.h:238:42,
    inlined from ‘PacketType Eigen::internal::unary_evaluator<Eigen::CwiseUnaryOp<UnaryOp, ArgType>, Eigen::internal::IndexBased>::packet(Eigen::Index, Eigen::Index) const [with int LoadMode = 0; PacketType = __Float32x2_t; UnaryOp = Eigen::internal::scalar_abs_op<float>; ArgType = const Eigen::Matrix<float, 3, 3>]’ at /usr/include/eigen3/Eigen/src/Core/CoreEvaluators.h:596:81,
    inlined from ‘PacketType Eigen::internal::redux_evaluator<_XprType>::packetByOuterInner(Eigen::Index, Eigen::Index) const [with int LoadMode = 0; PacketType = __Float32x2_t; _XprType = Eigen::CwiseUnaryOp<Eigen::internal::scalar_abs_op<float>, const Eigen::Matrix<float, 3, 3> >]’ at /usr/include/eigen3/Eigen/src/Core/Redux.h:386:54,
    inlined from ‘static PacketType Eigen::internal::redux_vec_unroller<Func, Evaluator, Start, 1>::run(const Evaluator&, const Func&) [with PacketType = __Float32x2_t; Func = Eigen::internal::scalar_max_op<float, float, 0>; Evaluator = Eigen::internal::redux_evaluator<Eigen::CwiseUnaryOp<Eigen::internal::scalar_abs_op<float>, const Eigen::Matrix<float, 3, 3> > >; int Start = 3]’ at /usr/include/eigen3/Eigen/src/Core/Redux.h:177:66,
    inlined from ‘static PacketType Eigen::internal::redux_vec_unroller<Func, Evaluator, Start, Length>::run(const Evaluator&, const Func&) [with PacketType = __Float32x2_t; Func = Eigen::internal::scalar_max_op<float, float, 0>; Evaluator = Eigen::internal::redux_evaluator<Eigen::CwiseUnaryOp<Eigen::internal::scalar_abs_op<float>, const Eigen::Matrix<float, 3, 3> > >; int Start = 2; int Length = 2]’ at /usr/include/eigen3/Eigen/src/Core/Redux.h:159:111,
    inlined from ‘static PacketType Eigen::internal::redux_vec_unroller<Func, Evaluator, Start, Length>::run(const Evaluator&, const Func&) [with PacketType = __Float32x2_t; Func = Eigen::internal::scalar_max_op<float, float, 0>; Evaluator = Eigen::internal::redux_evaluator<Eigen::CwiseUnaryOp<Eigen::internal::scalar_abs_op<float>, const Eigen::Matrix<float, 3, 3> > >; int Start = 0; int Length = 4]’ at /usr/include/eigen3/Eigen/src/Core/Redux.h:159:111,
    inlined from ‘static Eigen::internal::redux_impl<Func, Evaluator, 3, 2>::Scalar Eigen::internal::redux_impl<Func, Evaluator, 3, 2>::run(const Evaluator&, const Func&, const XprType&) [with XprType = Eigen::CwiseUnaryOp<Eigen::internal::scalar_abs_op<float>, const Eigen::Matrix<float, 3, 3> >; Func = Eigen::internal::scalar_max_op<float, float, 0>; Evaluator = Eigen::internal::redux_evaluator<Eigen::CwiseUnaryOp<Eigen::internal::scalar_abs_op<float>, const Eigen::Matrix<float, 3, 3> > >]’ at /usr/include/eigen3/Eigen/src/Core/Redux.h:344:115,
    inlined from ‘typename Eigen::internal::traits<T>::Scalar Eigen::DenseBase<Derived>::redux(const Func&) const [with BinaryOp = Eigen::internal::scalar_max_op<float, float, 0>; Derived = Eigen::CwiseUnaryOp<Eigen::internal::scalar_abs_op<float>, const Eigen::Matrix<float, 3, 3> >]’ at /usr/include/eigen3/Eigen/src/Core/Redux.h:418:56,
    inlined from ‘typename Eigen::internal::traits<T>::Scalar Eigen::DenseBase<Derived>::maxCoeff() const [with int NaNPropagation = 0; Derived = Eigen::CwiseUnaryOp<Eigen::internal::scalar_abs_op<float>, const Eigen::Matrix<float, 3, 3> >]’ at /usr/include/eigen3/Eigen/src/Core/Redux.h:448:25,
    inlined from ‘typename Eigen::internal::traits<T>::Scalar Eigen::DenseBase<Derived>::maxCoeff() const [with Derived = Eigen::CwiseUnaryOp<Eigen::internal::scalar_abs_op<float>, const Eigen::Matrix<float, 3, 3> >]’ at /usr/include/eigen3/Eigen/src/Core/DenseBase.h:466:37,
    inlined from ‘void pcl::eigen33(const Matrix&, typename Matrix::Scalar&, Vector&) [with Matrix = Eigen::Matrix<float, 3, 3>; Vector = Eigen::Matrix<float, 3, 1>]’ at /usr/include/pcl-1.14/pcl/common/impl/eigen.hpp:301:43,
    inlined from ‘void pcl::solvePlaneParameters(const Eigen::Matrix3f&, float&, float&, float&, float&)’ at /usr/include/pcl-1.14/pcl/features/impl/feature.hpp:79:16,
    inlined from ‘void pcl::solvePlaneParameters(const Eigen::Matrix3f&, const Eigen::Vector4f&, Eigen::Vector4f&, float&)’ at /usr/include/pcl-1.14/pcl/features/impl/feature.hpp:56:24,
    inlined from ‘yabloc::ground_server::GroundServer::GroundPlane yabloc::ground_server::GroundServer::estimate_ground(const Point&)’ at /home/autoware/autoware/src/universe/autoware_universe/localization/yabloc/yabloc_common/src/ground_server/ground_server_core.cpp:217:28:
/usr/lib/gcc/aarch64-linux-gnu/13/include/arm_neon.h:12213:36: error: ‘*(__Float32x2_t*)((char*)&covariance + offsetof(Eigen::Matrix3f, Eigen::Matrix<float, 3, 3, 0, 3, 3>::<unnamed>.Eigen::PlainObjectBase<Eigen::Matrix<float, 3, 3, 0, 3, 3> >::m_storage.Eigen::DenseStorage<float, 9, 3, 3, 0>::m_data.Eigen::internal::plain_array<float, 9, 0, 0>::array[6]))’ may be used uninitialized [-Werror=maybe-uninitialized]
12213 |   return __builtin_aarch64_ld1v2sf ((const __builtin_aarch64_simd_sf *) __a);
      |          ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/autoware/autoware/src/universe/autoware_universe/localization/yabloc/yabloc_common/src/ground_server/ground_server_core.cpp: In member function ‘yabloc::ground_server::GroundServer::GroundPlane yabloc::ground_server::GroundServer::estimate_ground(const Point&)’:
/home/autoware/autoware/src/universe/autoware_universe/localization/yabloc/yabloc_common/src/ground_server/ground_server_core.cpp:209:19: note: ‘covariance’ declared here
  209 |   Eigen::Matrix3f covariance;
      |                   ^~~~~~~~~~
In function ‘typename Eigen::internal::enable_if<(Eigen::NumTraits<T>::IsSigned || Eigen::NumTraits<T>::IsComplex), typename Eigen::NumTraits<T>::Real>::type Eigen::numext::abs(const T&) [with T = float]’,
    inlined from ‘const Eigen::internal::scalar_abs_op<Scalar>::result_type Eigen::internal::scalar_abs_op<Scalar>::operator()(const Scalar&) const [with Scalar = float]’ at /usr/include/eigen3/Eigen/src/Core/functors/UnaryFunctors.h:44:114,
    inlined from ‘Eigen::internal::unary_evaluator<Eigen::CwiseUnaryOp<UnaryOp, ArgType>, Eigen::internal::IndexBased>::CoeffReturnType Eigen::internal::unary_evaluator<Eigen::CwiseUnaryOp<UnaryOp, ArgType>, Eigen::internal::IndexBased>::coeff(Eigen::Index, Eigen::Index) const [with UnaryOp = Eigen::internal::scalar_abs_op<float>; ArgType = const Eigen::Matrix<float, 3, 3>]’ at /usr/include/eigen3/Eigen/src/Core/CoreEvaluators.h:583:22,
    inlined from ‘Eigen::internal::redux_evaluator<_XprType>::CoeffReturnType Eigen::internal::redux_evaluator<_XprType>::coeffByOuterInner(Eigen::Index, Eigen::Index) const [with _XprType = Eigen::CwiseUnaryOp<Eigen::internal::scalar_abs_op<float>, const Eigen::Matrix<float, 3, 3> >]’ at /usr/include/eigen3/Eigen/src/Core/Redux.h:381:23,
    inlined from ‘static Eigen::internal::redux_novec_unroller<Func, Evaluator, Start, 1>::Scalar Eigen::internal::redux_novec_unroller<Func, Evaluator, Start, 1>::run(const Evaluator&, const Func&) [with Func = Eigen::internal::scalar_max_op<float, float, 0>; Evaluator = Eigen::internal::redux_evaluator<Eigen::CwiseUnaryOp<Eigen::internal::scalar_abs_op<float>, const Eigen::Matrix<float, 3, 3> > >; int Start = 8]’ at /usr/include/eigen3/Eigen/src/Core/Redux.h:128:34,
    inlined from ‘static Eigen::internal::redux_impl<Func, Evaluator, 3, 2>::Scalar Eigen::internal::redux_impl<Func, Evaluator, 3, 2>::run(const Evaluator&, const Func&, const XprType&) [with XprType = Eigen::CwiseUnaryOp<Eigen::internal::scalar_abs_op<float>, const Eigen::Matrix<float, 3, 3> >; Func = Eigen::internal::scalar_max_op<float, float, 0>; Evaluator = Eigen::internal::redux_evaluator<Eigen::CwiseUnaryOp<Eigen::internal::scalar_abs_op<float>, const Eigen::Matrix<float, 3, 3> > >]’ at /usr/include/eigen3/Eigen/src/Core/Redux.h:346:103,
    inlined from ‘typename Eigen::internal::traits<T>::Scalar Eigen::DenseBase<Derived>::redux(const Func&) const [with BinaryOp = Eigen::internal::scalar_max_op<float, float, 0>; Derived = Eigen::CwiseUnaryOp<Eigen::internal::scalar_abs_op<float>, const Eigen::Matrix<float, 3, 3> >]’ at /usr/include/eigen3/Eigen/src/Core/Redux.h:418:56,
    inlined from ‘typename Eigen::internal::traits<T>::Scalar Eigen::DenseBase<Derived>::maxCoeff() const [with int NaNPropagation = 0; Derived = Eigen::CwiseUnaryOp<Eigen::internal::scalar_abs_op<float>, const Eigen::Matrix<float, 3, 3> >]’ at /usr/include/eigen3/Eigen/src/Core/Redux.h:448:25,
    inlined from ‘typename Eigen::internal::traits<T>::Scalar Eigen::DenseBase<Derived>::maxCoeff() const [with Derived = Eigen::CwiseUnaryOp<Eigen::internal::scalar_abs_op<float>, const Eigen::Matrix<float, 3, 3> >]’ at /usr/include/eigen3/Eigen/src/Core/DenseBase.h:466:37,
    inlined from ‘void pcl::eigen33(const Matrix&, typename Matrix::Scalar&, Vector&) [with Matrix = Eigen::Matrix<float, 3, 3>; Vector = Eigen::Matrix<float, 3, 1>]’ at /usr/include/pcl-1.14/pcl/common/impl/eigen.hpp:301:43,
    inlined from ‘void pcl::solvePlaneParameters(const Eigen::Matrix3f&, float&, float&, float&, float&)’ at /usr/include/pcl-1.14/pcl/features/impl/feature.hpp:79:16,
    inlined from ‘void pcl::solvePlaneParameters(const Eigen::Matrix3f&, const Eigen::Vector4f&, Eigen::Vector4f&, float&)’ at /usr/include/pcl-1.14/pcl/features/impl/feature.hpp:56:24,
    inlined from ‘yabloc::ground_server::GroundServer::GroundPlane yabloc::ground_server::GroundServer::estimate_ground(const Point&)’ at /home/autoware/autoware/src/universe/autoware_universe/localization/yabloc/yabloc_common/src/ground_server/ground_server_core.cpp:217:28:
/usr/include/eigen3/Eigen/src/Core/MathFunctions.h:1511:13: error: ‘covariance.Eigen::Matrix<float, 3, 3, 0, 3, 3>::<unnamed>.Eigen::PlainObjectBase<Eigen::Matrix<float, 3, 3, 0, 3, 3> >::m_storage.Eigen::DenseStorage<float, 9, 3, 3, 0>::m_data.Eigen::internal::plain_array<float, 9, 0, 0>::array[8]’ may be used uninitialized [-Werror=maybe-uninitialized]
 1511 |   return abs(x);
      |          ~~~^~~
/home/autoware/autoware/src/universe/autoware_universe/localization/yabloc/yabloc_common/src/ground_server/ground_server_core.cpp: In member function ‘yabloc::ground_server::GroundServer::GroundPlane yabloc::ground_server::GroundServer::estimate_ground(const Point&)’:
/home/autoware/autoware/src/universe/autoware_universe/localization/yabloc/yabloc_common/src/ground_server/ground_server_core.cpp:209:19: note: ‘covariance’ declared here
  209 |   Eigen::Matrix3f covariance;
      |                   ^~~~~~~~~~
In function ‘float32x2_t vld1_f32(const float32_t*)’,
    inlined from ‘Packet Eigen::internal::ploadu(const typename unpacket_traits<T>::type*) [with Packet = __Float32x2_t]’ at /usr/include/eigen3/Eigen/src/Core/arch/NEON/PacketMath.h:1710:45,
    inlined from ‘Packet Eigen::internal::ploadt(const typename unpacket_traits<T>::type*) [with Packet = __Float32x2_t; int Alignment = 0]’ at /usr/include/eigen3/Eigen/src/Core/GenericPacketMath.h:969:26,
    inlined from ‘PacketType Eigen::internal::evaluator<Eigen::PlainObjectBase<Derived> >::packet(Eigen::Index, Eigen::Index) const [with int LoadMode = 0; PacketType = __Float32x2_t; Derived = Eigen::Matrix<float, 3, 3>]’ at /usr/include/eigen3/Eigen/src/Core/CoreEvaluators.h:238:42,
    inlined from ‘PacketType Eigen::internal::unary_evaluator<Eigen::CwiseUnaryOp<UnaryOp, ArgType>, Eigen::internal::IndexBased>::packet(Eigen::Index, Eigen::Index) const [with int LoadMode = 0; PacketType = __Float32x2_t; UnaryOp = Eigen::internal::scalar_abs_op<float>; ArgType = const Eigen::Matrix<float, 3, 3>]’ at /usr/include/eigen3/Eigen/src/Core/CoreEvaluators.h:596:81,
    inlined from ‘PacketType Eigen::internal::redux_evaluator<_XprType>::packetByOuterInner(Eigen::Index, Eigen::Index) const [with int LoadMode = 0; PacketType = __Float32x2_t; _XprType = Eigen::CwiseUnaryOp<Eigen::internal::scalar_abs_op<float>, const Eigen::Matrix<float, 3, 3> >]’ at /usr/include/eigen3/Eigen/src/Core/Redux.h:386:54,
    inlined from ‘static PacketType Eigen::internal::redux_vec_unroller<Func, Evaluator, Start, 1>::run(const Evaluator&, const Func&) [with PacketType = __Float32x2_t; Func = Eigen::internal::scalar_max_op<float, float, 0>; Evaluator = Eigen::internal::redux_evaluator<Eigen::CwiseUnaryOp<Eigen::internal::scalar_abs_op<float>, const Eigen::Matrix<float, 3, 3> > >; int Start = 3]’ at /usr/include/eigen3/Eigen/src/Core/Redux.h:177:66,
    inlined from ‘static PacketType Eigen::internal::redux_vec_unroller<Func, Evaluator, Start, Length>::run(const Evaluator&, const Func&) [with PacketType = __Float32x2_t; Func = Eigen::internal::scalar_max_op<float, float, 0>; Evaluator = Eigen::internal::redux_evaluator<Eigen::CwiseUnaryOp<Eigen::internal::scalar_abs_op<float>, const Eigen::Matrix<float, 3, 3> > >; int Start = 2; int Length = 2]’ at /usr/include/eigen3/Eigen/src/Core/Redux.h:159:111,
    inlined from ‘static PacketType Eigen::internal::redux_vec_unroller<Func, Evaluator, Start, Length>::run(const Evaluator&, const Func&) [with PacketType = __Float32x2_t; Func = Eigen::internal::scalar_max_op<float, float, 0>; Evaluator = Eigen::internal::redux_evaluator<Eigen::CwiseUnaryOp<Eigen::internal::scalar_abs_op<float>, const Eigen::Matrix<float, 3, 3> > >; int Start = 0; int Length = 4]’ at /usr/include/eigen3/Eigen/src/Core/Redux.h:159:111,
    inlined from ‘static Eigen::internal::redux_impl<Func, Evaluator, 3, 2>::Scalar Eigen::internal::redux_impl<Func, Evaluator, 3, 2>::run(const Evaluator&, const Func&, const XprType&) [with XprType = Eigen::CwiseUnaryOp<Eigen::internal::scalar_abs_op<float>, const Eigen::Matrix<float, 3, 3> >; Func = Eigen::internal::scalar_max_op<float, float, 0>; Evaluator = Eigen::internal::redux_evaluator<Eigen::CwiseUnaryOp<Eigen::internal::scalar_abs_op<float>, const Eigen::Matrix<float, 3, 3> > >]’ at /usr/include/eigen3/Eigen/src/Core/Redux.h:344:115,
    inlined from ‘typename Eigen::internal::traits<T>::Scalar Eigen::DenseBase<Derived>::redux(const Func&) const [with BinaryOp = Eigen::internal::scalar_max_op<float, float, 0>; Derived = Eigen::CwiseUnaryOp<Eigen::internal::scalar_abs_op<float>, const Eigen::Matrix<float, 3, 3> >]’ at /usr/include/eigen3/Eigen/src/Core/Redux.h:418:56,
    inlined from ‘typename Eigen::internal::traits<T>::Scalar Eigen::DenseBase<Derived>::maxCoeff() const [with int NaNPropagation = 0; Derived = Eigen::CwiseUnaryOp<Eigen::internal::scalar_abs_op<float>, const Eigen::Matrix<float, 3, 3> >]’ at /usr/include/eigen3/Eigen/src/Core/Redux.h:448:25,
    inlined from ‘typename Eigen::internal::traits<T>::Scalar Eigen::DenseBase<Derived>::maxCoeff() const [with Derived = Eigen::CwiseUnaryOp<Eigen::internal::scalar_abs_op<float>, const Eigen::Matrix<float, 3, 3> >]’ at /usr/include/eigen3/Eigen/src/Core/DenseBase.h:466:37,
    inlined from ‘void pcl::eigen33(const Matrix&, typename Matrix::Scalar&, Vector&) [with Matrix = Eigen::Matrix<float, 3, 3>; Vector = Eigen::Matrix<float, 3, 1>]’ at /usr/include/pcl-1.14/pcl/common/impl/eigen.hpp:301:43,
    inlined from ‘void pcl::solvePlaneParameters(const Eigen::Matrix3f&, float&, float&, float&, float&)’ at /usr/include/pcl-1.14/pcl/features/impl/feature.hpp:79:16,
    inlined from ‘void pcl::solvePlaneParameters(const Eigen::Matrix3f&, const Eigen::Vector4f&, Eigen::Vector4f&, float&)’ at /usr/include/pcl-1.14/pcl/features/impl/feature.hpp:56:24,
    inlined from ‘yabloc::ground_server::GroundServer::GroundPlane yabloc::ground_server::GroundServer::estimate_ground(const Point&)’ at /home/autoware/autoware/src/universe/autoware_universe/localization/yabloc/yabloc_common/src/ground_server/ground_server_core.cpp:217:28:
/usr/lib/gcc/aarch64-linux-gnu/13/include/arm_neon.h:12213:36: error: ‘*(__Float32x2_t*)((char*)&covariance + offsetof(Eigen::Matrix3f, Eigen::Matrix<float, 3, 3, 0, 3, 3>::<unnamed>.Eigen::PlainObjectBase<Eigen::Matrix<float, 3, 3, 0, 3, 3> >::m_storage.Eigen::DenseStorage<float, 9, 3, 3, 0>::m_data.Eigen::internal::plain_array<float, 9, 0, 0>::array[6]))’ may be used uninitialized [-Werror=maybe-uninitialized]
12213 |   return __builtin_aarch64_ld1v2sf ((const __builtin_aarch64_simd_sf *) __a);
      |          ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/autoware/autoware/src/universe/autoware_universe/localization/yabloc/yabloc_common/src/ground_server/ground_server_core.cpp: In member function ‘yabloc::ground_server::GroundServer::GroundPlane yabloc::ground_server::GroundServer::estimate_ground(const Point&)’:
/home/autoware/autoware/src/universe/autoware_universe/localization/yabloc/yabloc_common/src/ground_server/ground_server_core.cpp:209:19: note: ‘covariance’ declared here
  209 |   Eigen::Matrix3f covariance;
      |                   ^~~~~~~~~~
cc1plus: all warnings being treated as errors
gmake[2]: *** [CMakeFiles/yabloc_common.dir/build.make:188: CMakeFiles/yabloc_common.dir/src/ground_server/ground_server_core.cpp.o] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:141: CMakeFiles/yabloc_common.dir/all] Error 2
gmake: *** [Makefile:146: all] Error 2
---
Failed   <<< yabloc_common [24.7s, exited with code 2]
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

I have confirmed that the build succeded.

## Notes for reviewers

The compiler version is
```
$ g++ --version
g++ (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0
```

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
