### PR TITLE
feat(autoware_behavior_path_side_shift_module): add service to side shift and add publisher to know current shift length

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_planner/include/autoware/behavior_path_planner/behavior_path_planner_node.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner/include/autoware/behavior_path_planner/behavior_path_planner_node.hpp
@@ -108,8 +108,6 @@ private:
     this, "~/input/costmap"};
   autoware_utils::InterProcessPollingSubscriber<TrafficLightGroupArray> traffic_signals_subscriber_{
     this, "~/input/traffic_signals"};
-  autoware_utils::InterProcessPollingSubscriber<LateralOffset> lateral_offset_subscriber_{
-    this, "~/input/lateral_offset"};
   autoware_utils::InterProcessPollingSubscriber<OperationModeState> operation_mode_subscriber_{
     this, "/system/operation_mode/state", rclcpp::QoS{1}.transient_local()};
   autoware_utils::InterProcessPollingSubscriber<autoware_internal_planning_msgs::msg::VelocityLimit>
@@ -157,7 +155,6 @@ private:
 
   // data processing called from takeData()
   void onTrafficSignals(const TrafficLightGroupArray::ConstSharedPtr msg);
-  void onLateralOffset(const LateralOffset::ConstSharedPtr msg);
 
   SetParametersResult onSetParam(const std::vector<rclcpp::Parameter> & parameters);
 

--- a/planning/behavior_path_planner/autoware_behavior_path_planner/include/autoware/behavior_path_planner/behavior_path_planner_node.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner/include/autoware/behavior_path_planner/behavior_path_planner_node.hpp
@@ -69,7 +69,6 @@ using nav_msgs::msg::OccupancyGrid;
 using nav_msgs::msg::Odometry;
 using rcl_interfaces::msg::SetParametersResult;
 using tier4_planning_msgs::msg::AvoidanceDebugMsgArray;
-using tier4_planning_msgs::msg::LateralOffset;
 using tier4_planning_msgs::msg::RerouteAvailability;
 using visualization_msgs::msg::Marker;
 using visualization_msgs::msg::MarkerArray;

--- a/planning/behavior_path_planner/autoware_behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -820,20 +820,21 @@ void BehaviorPathPlannerNode::onTrafficSignals(const TrafficLightGroupArray::Con
 
 void BehaviorPathPlannerNode::onLateralOffset(const LateralOffset::ConstSharedPtr msg)
 {
-  if (!planner_data_->lateral_offset) {
-    planner_data_->lateral_offset = msg;
+  const auto current = planner_data_->get_lateral_offset();
+  if (!current) {
+    planner_data_->set_lateral_offset(msg);
     return;
   }
 
   const auto & new_offset = msg->lateral_offset;
-  const auto & old_offset = planner_data_->lateral_offset->lateral_offset;
+  const auto & old_offset = current->lateral_offset;
 
   // offset is not changed.
   if (std::abs(old_offset - new_offset) < 1e-4) {
     return;
   }
 
-  planner_data_->lateral_offset = msg;
+  planner_data_->set_lateral_offset(msg);
 }
 
 SetParametersResult BehaviorPathPlannerNode::onSetParam(

--- a/planning/behavior_path_planner/autoware_behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -251,13 +251,6 @@ void BehaviorPathPlannerNode::takeData()
       onTrafficSignals(msg);
     }
   }
-  // lateral_offset
-  {
-    const auto msg = lateral_offset_subscriber_.take_data();
-    if (msg) {
-      onLateralOffset(msg);
-    }
-  }
   // operation_mode
   {
     const auto msg = operation_mode_subscriber_.take_data();
@@ -816,25 +809,6 @@ void BehaviorPathPlannerNode::onTrafficSignals(const TrafficLightGroupArray::Con
     traffic_signal.signal = signal;
     planner_data_->traffic_light_id_map[signal.traffic_light_group_id] = traffic_signal;
   }
-}
-
-void BehaviorPathPlannerNode::onLateralOffset(const LateralOffset::ConstSharedPtr msg)
-{
-  const auto current = planner_data_->get_lateral_offset();
-  if (!current) {
-    planner_data_->set_lateral_offset(msg);
-    return;
-  }
-
-  const auto & new_offset = msg->lateral_offset;
-  const auto & old_offset = current->lateral_offset;
-
-  // offset is not changed.
-  if (std::abs(old_offset - new_offset) < 1e-4) {
-    return;
-  }
-
-  planner_data_->set_lateral_offset(msg);
 }
 
 SetParametersResult BehaviorPathPlannerNode::onSetParam(

--- a/planning/behavior_path_planner/autoware_behavior_path_planner/src/test_utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner/src/test_utils.cpp
@@ -18,8 +18,6 @@
 #include <autoware/planning_test_manager/autoware_planning_test_manager.hpp>
 #include <autoware_test_utils/autoware_test_utils.hpp>
 
-#include <tier4_planning_msgs/msg/lateral_offset.hpp>
-
 #include <memory>
 #include <string>
 #include <vector>
@@ -108,8 +106,5 @@ void publishMandatoryTopics(
   test_manager->publishInput(
     test_target_node, "system/operation_mode/state",
     autoware_adapi_v1_msgs::msg::OperationModeState{});
-  test_manager->publishInput(
-    test_target_node, "behavior_path_planner/input/lateral_offset",
-    tier4_planning_msgs::msg::LateralOffset{});
 }
 }  // namespace autoware::behavior_path_planner

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/data_manager.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/data_manager.hpp
@@ -39,7 +39,6 @@
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <nav_msgs/msg/occupancy_grid.hpp>
 #include <nav_msgs/msg/odometry.hpp>
-#include <tier4_planning_msgs/msg/lateral_offset.hpp>
 
 #include <limits>
 #include <map>
@@ -64,7 +63,6 @@ using geometry_msgs::msg::AccelWithCovarianceStamped;
 using geometry_msgs::msg::PoseStamped;
 using nav_msgs::msg::OccupancyGrid;
 using nav_msgs::msg::Odometry;
-using tier4_planning_msgs::msg::LateralOffset;
 using PlanResult = PathWithLaneId::SharedPtr;
 using autoware_internal_planning_msgs::msg::VelocityLimit;
 using lanelet::TrafficLight;
@@ -167,18 +165,6 @@ struct PlannerData
   OccupancyGrid::ConstSharedPtr occupancy_grid{};
   OccupancyGrid::ConstSharedPtr costmap{};
 
-  LateralOffset::ConstSharedPtr get_lateral_offset() const
-  {
-    std::lock_guard<std::mutex> lock(*lateral_offset_mutex_);
-    return lateral_offset_;
-  }
-
-  void set_lateral_offset(LateralOffset::ConstSharedPtr ptr)
-  {
-    std::lock_guard<std::mutex> lock(*lateral_offset_mutex_);
-    lateral_offset_ = std::move(ptr);
-  }
-
   OperationModeState::ConstSharedPtr operation_mode{};
   PathWithLaneId::SharedPtr prev_output_path{std::make_shared<PathWithLaneId>()};
   std::optional<PoseWithUuidStamped> prev_modified_goal{};
@@ -195,10 +181,6 @@ struct PlannerData
   mutable TurnSignalDecider turn_signal_decider;
 
 private:
-  mutable std::shared_ptr<std::mutex> lateral_offset_mutex_{std::make_shared<std::mutex>()};
-  LateralOffset::ConstSharedPtr lateral_offset_{};
-
-public:
   void init_parameters(rclcpp::Node & node)
   {
     parameters.traffic_light_signal_timeout =

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/data_manager.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/data_manager.hpp
@@ -179,8 +179,6 @@ struct PlannerData
   mutable std::vector<geometry_msgs::msg::Pose> drivable_area_expansion_prev_path_poses{};
   mutable std::vector<double> drivable_area_expansion_prev_curvatures{};
   mutable TurnSignalDecider turn_signal_decider;
-
-private:
   void init_parameters(rclcpp::Node & node)
   {
     parameters.traffic_light_signal_timeout =

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/data_manager.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/data_manager.hpp
@@ -43,7 +43,6 @@
 #include <limits>
 #include <map>
 #include <memory>
-#include <mutex>
 #include <string>
 #include <utility>
 #include <vector>

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/data_manager.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/data_manager.hpp
@@ -44,6 +44,7 @@
 #include <limits>
 #include <map>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <utility>
 #include <vector>
@@ -165,7 +166,19 @@ struct PlannerData
   PredictedObjects::ConstSharedPtr dynamic_object{};
   OccupancyGrid::ConstSharedPtr occupancy_grid{};
   OccupancyGrid::ConstSharedPtr costmap{};
-  LateralOffset::ConstSharedPtr lateral_offset{};
+
+  LateralOffset::ConstSharedPtr get_lateral_offset() const
+  {
+    std::lock_guard<std::mutex> lock(lateral_offset_mutex_);
+    return lateral_offset_;
+  }
+
+  void set_lateral_offset(LateralOffset::ConstSharedPtr ptr)
+  {
+    std::lock_guard<std::mutex> lock(lateral_offset_mutex_);
+    lateral_offset_ = std::move(ptr);
+  }
+
   OperationModeState::ConstSharedPtr operation_mode{};
   PathWithLaneId::SharedPtr prev_output_path{std::make_shared<PathWithLaneId>()};
   std::optional<PoseWithUuidStamped> prev_modified_goal{};
@@ -181,6 +194,11 @@ struct PlannerData
   mutable std::vector<double> drivable_area_expansion_prev_curvatures{};
   mutable TurnSignalDecider turn_signal_decider;
 
+private:
+  mutable std::mutex lateral_offset_mutex_{};
+  LateralOffset::ConstSharedPtr lateral_offset_{};
+
+public:
   void init_parameters(rclcpp::Node & node)
   {
     parameters.traffic_light_signal_timeout =

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/data_manager.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/data_manager.hpp
@@ -169,13 +169,13 @@ struct PlannerData
 
   LateralOffset::ConstSharedPtr get_lateral_offset() const
   {
-    std::lock_guard<std::mutex> lock(lateral_offset_mutex_);
+    std::lock_guard<std::mutex> lock(*lateral_offset_mutex_);
     return lateral_offset_;
   }
 
   void set_lateral_offset(LateralOffset::ConstSharedPtr ptr)
   {
-    std::lock_guard<std::mutex> lock(lateral_offset_mutex_);
+    std::lock_guard<std::mutex> lock(*lateral_offset_mutex_);
     lateral_offset_ = std::move(ptr);
   }
 
@@ -195,7 +195,7 @@ struct PlannerData
   mutable TurnSignalDecider turn_signal_decider;
 
 private:
-  mutable std::mutex lateral_offset_mutex_{};
+  mutable std::shared_ptr<std::mutex> lateral_offset_mutex_{std::make_shared<std::mutex>()};
   LateralOffset::ConstSharedPtr lateral_offset_{};
 
 public:

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/data_manager.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/data_manager.hpp
@@ -163,7 +163,6 @@ struct PlannerData
   PredictedObjects::ConstSharedPtr dynamic_object{};
   OccupancyGrid::ConstSharedPtr occupancy_grid{};
   OccupancyGrid::ConstSharedPtr costmap{};
-
   OperationModeState::ConstSharedPtr operation_mode{};
   PathWithLaneId::SharedPtr prev_output_path{std::make_shared<PathWithLaneId>()};
   std::optional<PoseWithUuidStamped> prev_modified_goal{};

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/CMakeLists.txt
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/CMakeLists.txt
@@ -9,6 +9,7 @@ ament_auto_add_library(${PROJECT_NAME} SHARED
   src/scene.cpp
   src/utils.cpp
   src/manager.cpp
+  src/validation.cpp
 )
 
 if(BUILD_TESTING)

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/config/side_shift.param.yaml
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/config/side_shift.param.yaml
@@ -7,5 +7,7 @@
       min_shifting_distance: 5.0
       min_shifting_speed: 5.56
       shift_request_time_limit: 1.0
-      unit_shift_amount: 0.5
+      max_shift_magnitude: 1.0
+      min_shift_gap: 0.001
+      unit_shift_amount: 0.1
       publish_debug_marker: false

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/config/side_shift.param.yaml
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/config/side_shift.param.yaml
@@ -7,5 +7,5 @@
       min_shifting_distance: 5.0
       min_shifting_speed: 5.56
       shift_request_time_limit: 1.0
+      unit_shift_amount: 0.5
       publish_debug_marker: false
-      direction_shift_amount: 0.5

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/config/side_shift.param.yaml
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/config/side_shift.param.yaml
@@ -8,3 +8,4 @@
       min_shifting_speed: 5.56
       shift_request_time_limit: 1.0
       publish_debug_marker: false
+      direction_shift_amount: 0.5

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/include/autoware/behavior_path_side_shift_module/data_structs.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/include/autoware/behavior_path_side_shift_module/data_structs.hpp
@@ -64,5 +64,15 @@ struct InsertedLateralOffsetState
   std::atomic<double> value{0.0};
 };
 
+/**
+ * @brief Shared state for the requested lateral offset [m] coming from external commands.
+ *        The manager owns this and passes it to the scene; the manager updates it when a new
+ *        lateral offset command is received; the scene reads it in updateData().
+ */
+struct RequestedLateralOffsetState
+{
+  std::atomic<double> value{0.0};
+};
+
 }  // namespace autoware::behavior_path_planner
 #endif  // AUTOWARE__BEHAVIOR_PATH_SIDE_SHIFT_MODULE__DATA_STRUCTS_HPP_

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/include/autoware/behavior_path_side_shift_module/data_structs.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/include/autoware/behavior_path_side_shift_module/data_structs.hpp
@@ -42,8 +42,9 @@ struct SideShiftParameters
   double drivable_area_height;
   double shift_request_time_limit;
   bool publish_debug_marker;
-  /** @brief Shift amount in meters when shift_mode is DIRECTION (used by SetLateralOffset service) */
-  double direction_shift_amount;
+  /** @brief Shift amount in meters when shift_mode is DIRECTION (used by SetLateralOffset service)
+   */
+  double unit_shift_amount;
 };
 
 struct SideShiftDebugData

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/include/autoware/behavior_path_side_shift_module/data_structs.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/include/autoware/behavior_path_side_shift_module/data_structs.hpp
@@ -41,10 +41,10 @@ struct SideShiftParameters
   double drivable_area_width;
   double drivable_area_height;
   double shift_request_time_limit;
-  bool publish_debug_marker;
-  /** @brief Shift amount in meters when shift_mode is DIRECTION (used by SetLateralOffset service)
-   */
+  double max_shift_magnitude;
+  double min_shift_gap;
   double unit_shift_amount;
+  bool publish_debug_marker;
 };
 
 struct SideShiftDebugData

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/include/autoware/behavior_path_side_shift_module/data_structs.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/include/autoware/behavior_path_side_shift_module/data_structs.hpp
@@ -19,6 +19,7 @@
 
 #include <tier4_planning_msgs/msg/lateral_offset.hpp>
 
+#include <atomic>
 #include <memory>
 #include <string>
 #include <vector>
@@ -41,6 +42,8 @@ struct SideShiftParameters
   double drivable_area_height;
   double shift_request_time_limit;
   bool publish_debug_marker;
+  /** @brief Shift amount in meters when shift_mode is DIRECTION (used by SetLateralOffset service) */
+  double direction_shift_amount;
 };
 
 struct SideShiftDebugData
@@ -48,6 +51,16 @@ struct SideShiftDebugData
   std::shared_ptr<PathShifter> path_shifter{};
   ShiftLineArray shift_lines{};
   double current_request{0.0};
+};
+
+/**
+ * @brief Shared state for the inserted (actually applied) lateral offset [m].
+ *        The manager owns this and passes it to the scene; the scene updates it
+ *        whenever inserted_lateral_offset_ changes; the manager reads it periodically to publish.
+ */
+struct InsertedLateralOffsetState
+{
+  std::atomic<double> value{0.0};
 };
 
 }  // namespace autoware::behavior_path_planner

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/include/autoware/behavior_path_side_shift_module/manager.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/include/autoware/behavior_path_side_shift_module/manager.hpp
@@ -21,8 +21,9 @@
 
 #include <rclcpp/rclcpp.hpp>
 
-#include <autoware_planning_msgs/srv/set_lateral_offset.hpp>
 #include <tier4_planning_msgs/msg/lateral_offset.hpp>
+#include <tier4_planning_msgs/srv/detail/set_lateral_offset__struct.hpp>
+#include <tier4_planning_msgs/srv/set_lateral_offset.hpp>
 
 #include <memory>
 #include <string>
@@ -31,6 +32,7 @@
 
 namespace autoware::behavior_path_planner
 {
+using SetLateralOffset = tier4_planning_msgs::srv::SetLateralOffset;
 
 class SideShiftModuleManager : public SceneModuleManagerInterface
 {
@@ -51,14 +53,14 @@ public:
 
 private:
   void onSetLateralOffset(
-    const autoware_planning_msgs::srv::SetLateralOffset::Request::SharedPtr request,
-    autoware_planning_msgs::srv::SetLateralOffset::Response::SharedPtr response);
+    const tier4_planning_msgs::srv::SetLateralOffset::Request::SharedPtr request,
+    tier4_planning_msgs::srv::SetLateralOffset::Response::SharedPtr response);
 
   void publishInsertedLateralOffsetTimerCallback();
 
   std::shared_ptr<SideShiftParameters> parameters_;
   std::shared_ptr<InsertedLateralOffsetState> inserted_lateral_offset_state_;
-  rclcpp::Service<autoware_planning_msgs::srv::SetLateralOffset>::SharedPtr set_lateral_offset_srv_;
+  rclcpp::Service<tier4_planning_msgs::srv::SetLateralOffset>::SharedPtr set_lateral_offset_srv_;
   rclcpp::Publisher<tier4_planning_msgs::msg::LateralOffset>::SharedPtr lateral_offset_publisher_;
   rclcpp::TimerBase::SharedPtr lateral_offset_publish_timer_;
 };

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/include/autoware/behavior_path_side_shift_module/manager.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/include/autoware/behavior_path_side_shift_module/manager.hpp
@@ -46,7 +46,7 @@ public:
     return std::make_unique<SideShiftModule>(
       name_, *node_, parameters_, rtc_interface_ptr_map_,
       objects_of_interest_marker_interface_ptr_map_, planning_factor_interface_,
-      inserted_lateral_offset_state_);
+      inserted_lateral_offset_state_, requested_lateral_offset_state_);
   }
 
   void updateModuleParams(const std::vector<rclcpp::Parameter> & parameters) override;
@@ -56,12 +56,16 @@ private:
     const tier4_planning_msgs::srv::SetLateralOffset::Request::SharedPtr request,
     tier4_planning_msgs::srv::SetLateralOffset::Response::SharedPtr response);
 
+  void onLateralOffset(const tier4_planning_msgs::msg::LateralOffset::ConstSharedPtr msg);
+
   void publishInsertedLateralOffsetTimerCallback();
 
   std::shared_ptr<SideShiftParameters> parameters_;
   std::shared_ptr<InsertedLateralOffsetState> inserted_lateral_offset_state_;
+  std::shared_ptr<RequestedLateralOffsetState> requested_lateral_offset_state_;
   rclcpp::Service<tier4_planning_msgs::srv::SetLateralOffset>::SharedPtr set_lateral_offset_srv_;
   rclcpp::Publisher<tier4_planning_msgs::msg::LateralOffset>::SharedPtr lateral_offset_publisher_;
+  rclcpp::Subscription<tier4_planning_msgs::msg::LateralOffset>::SharedPtr lateral_offset_sub_;
   rclcpp::TimerBase::SharedPtr lateral_offset_publish_timer_;
 };
 

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/include/autoware/behavior_path_side_shift_module/manager.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/include/autoware/behavior_path_side_shift_module/manager.hpp
@@ -16,9 +16,12 @@
 #define AUTOWARE__BEHAVIOR_PATH_SIDE_SHIFT_MODULE__MANAGER_HPP_
 
 #include "autoware/behavior_path_planner_common/interface/scene_module_manager_interface.hpp"
+#include "autoware/behavior_path_side_shift_module/data_structs.hpp"
 #include "autoware/behavior_path_side_shift_module/scene.hpp"
 
+#include <autoware_planning_msgs/srv/set_lateral_offset.hpp>
 #include <rclcpp/rclcpp.hpp>
+#include <tier4_planning_msgs/msg/lateral_offset.hpp>
 
 #include <memory>
 #include <string>
@@ -39,13 +42,24 @@ public:
   {
     return std::make_unique<SideShiftModule>(
       name_, *node_, parameters_, rtc_interface_ptr_map_,
-      objects_of_interest_marker_interface_ptr_map_, planning_factor_interface_);
+      objects_of_interest_marker_interface_ptr_map_, planning_factor_interface_,
+      inserted_lateral_offset_state_);
   }
 
   void updateModuleParams(const std::vector<rclcpp::Parameter> & parameters) override;
 
 private:
+  void onSetLateralOffset(
+    const autoware_planning_msgs::srv::SetLateralOffset::Request::SharedPtr request,
+    autoware_planning_msgs::srv::SetLateralOffset::Response::SharedPtr response);
+
+  void publishInsertedLateralOffsetTimerCallback();
+
   std::shared_ptr<SideShiftParameters> parameters_;
+  std::shared_ptr<InsertedLateralOffsetState> inserted_lateral_offset_state_;
+  rclcpp::Service<autoware_planning_msgs::srv::SetLateralOffset>::SharedPtr set_lateral_offset_srv_;
+  rclcpp::Publisher<tier4_planning_msgs::msg::LateralOffset>::SharedPtr lateral_offset_publisher_;
+  rclcpp::TimerBase::SharedPtr lateral_offset_publish_timer_;
 };
 
 }  // namespace autoware::behavior_path_planner

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/include/autoware/behavior_path_side_shift_module/manager.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/include/autoware/behavior_path_side_shift_module/manager.hpp
@@ -19,8 +19,9 @@
 #include "autoware/behavior_path_side_shift_module/data_structs.hpp"
 #include "autoware/behavior_path_side_shift_module/scene.hpp"
 
-#include <autoware_planning_msgs/srv/set_lateral_offset.hpp>
 #include <rclcpp/rclcpp.hpp>
+
+#include <autoware_planning_msgs/srv/set_lateral_offset.hpp>
 #include <tier4_planning_msgs/msg/lateral_offset.hpp>
 
 #include <memory>

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/include/autoware/behavior_path_side_shift_module/manager.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/include/autoware/behavior_path_side_shift_module/manager.hpp
@@ -22,7 +22,6 @@
 #include <rclcpp/rclcpp.hpp>
 
 #include <tier4_planning_msgs/msg/lateral_offset.hpp>
-#include <tier4_planning_msgs/srv/detail/set_lateral_offset__struct.hpp>
 #include <tier4_planning_msgs/srv/set_lateral_offset.hpp>
 
 #include <memory>

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/include/autoware/behavior_path_side_shift_module/scene.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/include/autoware/behavior_path_side_shift_module/scene.hpp
@@ -45,7 +45,8 @@ public:
     std::unordered_map<std::string, std::shared_ptr<ObjectsOfInterestMarkerInterface>> &
       objects_of_interest_marker_interface_ptr_map,
     const std::shared_ptr<PlanningFactorInterface> planning_factor_interface,
-    const std::shared_ptr<InsertedLateralOffsetState> & inserted_lateral_offset_state = nullptr);
+    const std::shared_ptr<InsertedLateralOffsetState> & inserted_lateral_offset_state = nullptr,
+    const std::shared_ptr<RequestedLateralOffsetState> & requested_lateral_offset_state = nullptr);
 
   bool isExecutionRequested() const override;
   bool isExecutionReady() const override;
@@ -124,6 +125,9 @@ private:
 
   /** Shared state updated by this scene and read by the manager for publishing. */
   std::shared_ptr<InsertedLateralOffsetState> inserted_lateral_offset_state_;
+
+  /** Shared state updated by the manager and read by this scene. */
+  std::shared_ptr<RequestedLateralOffsetState> requested_lateral_offset_state_;
 
   // debug
   mutable SideShiftDebugData debug_data_;

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/include/autoware/behavior_path_side_shift_module/scene.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/include/autoware/behavior_path_side_shift_module/scene.hpp
@@ -22,7 +22,6 @@
 #include <rclcpp/rclcpp.hpp>
 
 #include <autoware_internal_planning_msgs/msg/path_with_lane_id.hpp>
-#include <tier4_planning_msgs/msg/lateral_offset.hpp>
 
 #include <memory>
 #include <string>
@@ -35,7 +34,6 @@ namespace autoware::behavior_path_planner
 using autoware_internal_planning_msgs::msg::PathWithLaneId;
 using geometry_msgs::msg::Pose;
 using nav_msgs::msg::OccupancyGrid;
-using tier4_planning_msgs::msg::LateralOffset;
 
 class SideShiftModule : public SceneModuleInterface
 {
@@ -46,7 +44,8 @@ public:
     const std::unordered_map<std::string, std::shared_ptr<RTCInterface>> & rtc_interface_ptr_map,
     std::unordered_map<std::string, std::shared_ptr<ObjectsOfInterestMarkerInterface>> &
       objects_of_interest_marker_interface_ptr_map,
-    const std::shared_ptr<PlanningFactorInterface> planning_factor_interface);
+    const std::shared_ptr<PlanningFactorInterface> planning_factor_interface,
+    const std::shared_ptr<InsertedLateralOffsetState> & inserted_lateral_offset_state = nullptr);
 
   bool isExecutionRequested() const override;
   bool isExecutionReady() const override;
@@ -122,6 +121,9 @@ private:
   mutable rclcpp::Time last_requested_shift_change_time_{clock_->now()};
 
   rclcpp::Time latest_lateral_offset_stamp_;
+
+  /** Shared state updated by this scene and read by the manager for publishing. */
+  std::shared_ptr<InsertedLateralOffsetState> inserted_lateral_offset_state_;
 
   // debug
   mutable SideShiftDebugData debug_data_;

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/include/autoware/behavior_path_side_shift_module/validation.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/include/autoware/behavior_path_side_shift_module/validation.hpp
@@ -29,13 +29,14 @@ constexpr std::optional<double> DEFAULT_MAX_RAW_SHIFT_MAGNITUDE = 3.0;
  * @brief Example validation for SetLateralOffset service request.
  * @param request SetLateralOffset service request (uses Request::RAW_VALUE, Request::DIRECTION,
  *        Request::RESET, Request::LEFT, Request::RIGHT from the message)
- * @param direction_shift_amount Shift amount in meters for DIRECTION mode (must be >= 0)
+ * @param current_inserted_lateral_offset Current inserted lateral offset [m] (scene's state)
+ * @param direction_shift_amount Shift increment in meters for DIRECTION mode (must be >= 0)
  * @param max_raw_shift_magnitude Optional max |shift_value| for RAW_VALUE; nullopt to skip
  * @return Computed lateral offset in meters, or nullopt if validation failed
  */
 std::optional<double> validateAndComputeLateralOffset(
   const autoware_planning_msgs::srv::SetLateralOffset::Request & request,
-  double direction_shift_amount,
+  double current_inserted_lateral_offset, double direction_shift_amount,
   std::optional<double> max_raw_shift_magnitude = DEFAULT_MAX_RAW_SHIFT_MAGNITUDE);
 
 }  // namespace autoware::behavior_path_planner

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/include/autoware/behavior_path_side_shift_module/validation.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/include/autoware/behavior_path_side_shift_module/validation.hpp
@@ -30,13 +30,13 @@ constexpr std::optional<double> DEFAULT_MAX_RAW_SHIFT_MAGNITUDE = 3.0;
  * @param request SetLateralOffset service request (uses Request::RAW_VALUE, Request::DIRECTION,
  *        Request::RESET, Request::LEFT, Request::RIGHT from the message)
  * @param current_inserted_lateral_offset Current inserted lateral offset [m] (scene's state)
- * @param direction_shift_amount Shift increment in meters for DIRECTION mode (must be >= 0)
+ * @param unit_shift_amount Shift increment in meters for DIRECTION mode (must be >= 0)
  * @param max_raw_shift_magnitude Optional max |shift_value| for RAW_VALUE; nullopt to skip
  * @return Computed lateral offset in meters, or nullopt if validation failed
  */
 std::optional<double> validateAndComputeLateralOffset(
   const autoware_planning_msgs::srv::SetLateralOffset::Request & request,
-  double current_inserted_lateral_offset, double direction_shift_amount,
+  double current_inserted_lateral_offset, double unit_shift_amount,
   std::optional<double> max_raw_shift_magnitude = DEFAULT_MAX_RAW_SHIFT_MAGNITUDE);
 
 }  // namespace autoware::behavior_path_planner

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/include/autoware/behavior_path_side_shift_module/validation.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/include/autoware/behavior_path_side_shift_module/validation.hpp
@@ -1,0 +1,49 @@
+// Copyright 2023 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__BEHAVIOR_PATH_SIDE_SHIFT_MODULE__VALIDATION_HPP_
+#define AUTOWARE__BEHAVIOR_PATH_SIDE_SHIFT_MODULE__VALIDATION_HPP_
+
+#include <optional>
+
+namespace autoware::behavior_path_planner
+{
+
+/** Constants matching SetLateralOffset.srv */
+constexpr uint8_t SHIFT_MODE_RAW_VALUE = 1;
+constexpr uint8_t SHIFT_MODE_DIRECTION = 2;
+constexpr uint8_t SHIFT_DIRECTION_RESET = 0;
+constexpr uint8_t SHIFT_DIRECTION_LEFT = 1;
+constexpr uint8_t SHIFT_DIRECTION_RIGHT = 2;
+
+/** Optional max magnitude for RAW_VALUE (meters). Use nullopt to skip range check. */
+constexpr std::optional<double> DEFAULT_MAX_RAW_SHIFT_MAGNITUDE = 3.0;
+
+/**
+ * @brief Example validation for SetLateralOffset service request.
+ * @param shift_mode RAW_VALUE (1) or DIRECTION (2)
+ * @param shift_value Used when shift_mode is RAW_VALUE (meters; positive = left)
+ * @param shift_direction_value RESET (0), LEFT (1), RIGHT (2) when shift_mode is DIRECTION
+ * @param direction_shift_amount Shift amount in meters for DIRECTION mode (must be >= 0)
+ * @param max_raw_shift_magnitude Optional max |shift_value| for RAW_VALUE; nullopt to skip
+ * @return Computed lateral offset in meters, or nullopt if validation failed
+ */
+std::optional<double> validateAndComputeLateralOffset(
+  uint8_t shift_mode, float shift_value, uint8_t shift_direction_value,
+  double direction_shift_amount,
+  std::optional<double> max_raw_shift_magnitude = DEFAULT_MAX_RAW_SHIFT_MAGNITUDE);
+
+}  // namespace autoware::behavior_path_planner
+
+#endif  // AUTOWARE__BEHAVIOR_PATH_SIDE_SHIFT_MODULE__VALIDATION_HPP_

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/include/autoware/behavior_path_side_shift_module/validation.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/include/autoware/behavior_path_side_shift_module/validation.hpp
@@ -15,15 +15,19 @@
 #ifndef AUTOWARE__BEHAVIOR_PATH_SIDE_SHIFT_MODULE__VALIDATION_HPP_
 #define AUTOWARE__BEHAVIOR_PATH_SIDE_SHIFT_MODULE__VALIDATION_HPP_
 
-#include <autoware_planning_msgs/srv/set_lateral_offset.hpp>
+#include "autoware/behavior_path_side_shift_module/manager.hpp"
+
+#include <tier4_planning_msgs/srv/detail/set_lateral_offset__struct.hpp>
+#include <tier4_planning_msgs/srv/set_lateral_offset.hpp>
 
 #include <optional>
 
 namespace autoware::behavior_path_planner
 {
+using SetLateralOffset = tier4_planning_msgs::srv::SetLateralOffset;
 
 /** Optional max magnitude for RAW_VALUE (meters). Use nullopt to skip range check. */
-constexpr std::optional<double> DEFAULT_MAX_RAW_SHIFT_MAGNITUDE = 3.0;
+constexpr std::optional<double> default_max_raw_shift_magnitude = 2.0;
 
 /**
  * @brief Example validation for SetLateralOffset service request.
@@ -35,9 +39,9 @@ constexpr std::optional<double> DEFAULT_MAX_RAW_SHIFT_MAGNITUDE = 3.0;
  * @return Computed lateral offset in meters, or nullopt if validation failed
  */
 std::optional<double> validateAndComputeLateralOffset(
-  const autoware_planning_msgs::srv::SetLateralOffset::Request & request,
-  double current_inserted_lateral_offset, double unit_shift_amount,
-  std::optional<double> max_raw_shift_magnitude = DEFAULT_MAX_RAW_SHIFT_MAGNITUDE);
+  const SetLateralOffset::Request & request, double current_inserted_lateral_offset,
+  double unit_shift_amount,
+  std::optional<double> max_raw_shift_magnitude = default_max_raw_shift_magnitude);
 
 }  // namespace autoware::behavior_path_planner
 

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/include/autoware/behavior_path_side_shift_module/validation.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/include/autoware/behavior_path_side_shift_module/validation.hpp
@@ -21,13 +21,11 @@
 #include <tier4_planning_msgs/srv/set_lateral_offset.hpp>
 
 #include <optional>
+#include <utility>
 
 namespace autoware::behavior_path_planner
 {
 using SetLateralOffset = tier4_planning_msgs::srv::SetLateralOffset;
-
-/** Optional max magnitude for RAW_VALUE (meters). Use nullopt to skip range check. */
-constexpr std::optional<double> default_max_raw_shift_magnitude = 2.0;
 
 /**
  * @brief Example validation for SetLateralOffset service request.
@@ -36,12 +34,19 @@ constexpr std::optional<double> default_max_raw_shift_magnitude = 2.0;
  * @param current_inserted_lateral_offset Current inserted lateral offset [m] (scene's state)
  * @param unit_shift_amount Shift increment in meters for DIRECTION mode (must be >= 0)
  * @param max_raw_shift_magnitude Optional max |shift_value| for RAW_VALUE; nullopt to skip
- * @return Computed lateral offset in meters, or nullopt if validation failed
+ * @return Computed lateral offset in meters, and its status_code reflecting the validation results
  */
-std::optional<double> validateAndComputeLateralOffset(
+std::pair<uint16_t, double> validateAndComputeLateralOffset(
   const SetLateralOffset::Request & request, double current_inserted_lateral_offset,
-  double unit_shift_amount,
-  std::optional<double> max_raw_shift_magnitude = default_max_raw_shift_magnitude);
+  double unit_shift_amount, double max_shift_magnitude, double min_shift_gap);
+
+/**
+ * @brief Get the status message identical to te status code
+ *
+ * @param status_code
+ * @return const char* status message
+ */
+const char * getStatusMessage(uint16_t status_code);
 
 }  // namespace autoware::behavior_path_planner
 

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/include/autoware/behavior_path_side_shift_module/validation.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/include/autoware/behavior_path_side_shift_module/validation.hpp
@@ -15,32 +15,26 @@
 #ifndef AUTOWARE__BEHAVIOR_PATH_SIDE_SHIFT_MODULE__VALIDATION_HPP_
 #define AUTOWARE__BEHAVIOR_PATH_SIDE_SHIFT_MODULE__VALIDATION_HPP_
 
+#include <autoware_planning_msgs/srv/set_lateral_offset.hpp>
+
 #include <optional>
 
 namespace autoware::behavior_path_planner
 {
-
-/** Constants matching SetLateralOffset.srv */
-constexpr uint8_t SHIFT_MODE_RAW_VALUE = 1;
-constexpr uint8_t SHIFT_MODE_DIRECTION = 2;
-constexpr uint8_t SHIFT_DIRECTION_RESET = 0;
-constexpr uint8_t SHIFT_DIRECTION_LEFT = 1;
-constexpr uint8_t SHIFT_DIRECTION_RIGHT = 2;
 
 /** Optional max magnitude for RAW_VALUE (meters). Use nullopt to skip range check. */
 constexpr std::optional<double> DEFAULT_MAX_RAW_SHIFT_MAGNITUDE = 3.0;
 
 /**
  * @brief Example validation for SetLateralOffset service request.
- * @param shift_mode RAW_VALUE (1) or DIRECTION (2)
- * @param shift_value Used when shift_mode is RAW_VALUE (meters; positive = left)
- * @param shift_direction_value RESET (0), LEFT (1), RIGHT (2) when shift_mode is DIRECTION
+ * @param request SetLateralOffset service request (uses Request::RAW_VALUE, Request::DIRECTION,
+ *        Request::RESET, Request::LEFT, Request::RIGHT from the message)
  * @param direction_shift_amount Shift amount in meters for DIRECTION mode (must be >= 0)
  * @param max_raw_shift_magnitude Optional max |shift_value| for RAW_VALUE; nullopt to skip
  * @return Computed lateral offset in meters, or nullopt if validation failed
  */
 std::optional<double> validateAndComputeLateralOffset(
-  uint8_t shift_mode, float shift_value, uint8_t shift_direction_value,
+  const autoware_planning_msgs::srv::SetLateralOffset::Request & request,
   double direction_shift_amount,
   std::optional<double> max_raw_shift_magnitude = DEFAULT_MAX_RAW_SHIFT_MAGNITUDE);
 

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/include/autoware/behavior_path_side_shift_module/validation.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/include/autoware/behavior_path_side_shift_module/validation.hpp
@@ -35,7 +35,7 @@ using SetLateralOffset = tier4_planning_msgs::srv::SetLateralOffset;
  * @param request SetLateralOffset service request (uses Request::RAW_VALUE, Request::DIRECTION,
  *        Request::RESET, Request::LEFT, Request::RIGHT from the message)
  * @param current_inserted_lateral_offset Current inserted lateral offset [m]
- * @param parameters Parameters used for the side shift mdule
+ * @param parameters Parameters used for the side shift module
  * @return Computed lateral offset in meters, and its status_code reflecting the validation results
  */
 std::pair<uint16_t, double> validateAndComputeLateralOffset(
@@ -46,7 +46,7 @@ std::pair<uint16_t, double> validateAndComputeLateralOffset(
  * @brief Validation of the lateral offset when its value (in meters) is directly sent
  * @param lateral_offset The lateral offset sent from the user
  * @param current_inserted_lateral_offset Current inserted lateral offset [m]
- * @param parameters Parameters used for the side shift mdule
+ * @param parameters Parameters used for the side shift module
  * @return Computed lateral offset in meters, and its status_code reflecting the validation results
  */
 std::pair<uint16_t, double> validateRawValue(
@@ -56,7 +56,7 @@ std::pair<uint16_t, double> validateRawValue(
 /**
  * @brief Validation of the lateral offset when LEFT command is sent
  * @param current_inserted_lateral_offset Current inserted lateral offset [m]
- * @param parameters Parameters used for the side shift mdule
+ * @param parameters Parameters used for the side shift module
  * @return Computed lateral offset in meters, and its status_code reflecting the validation results
  */
 std::pair<uint16_t, double> validateShiftLeft(
@@ -66,7 +66,7 @@ std::pair<uint16_t, double> validateShiftLeft(
 /**
  * @brief Validation of the lateral offset when RIGHT command is sent
  * @param current_inserted_lateral_offset Current inserted lateral offset [m]
- * @param parameters Parameters used for the side shift mdule
+ * @param parameters Parameters used for the side shift module
  * @return Computed lateral offset in meters, and its status_code reflecting the validation results
  */
 std::pair<uint16_t, double> validateShiftRight(

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/include/autoware/behavior_path_side_shift_module/validation.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/include/autoware/behavior_path_side_shift_module/validation.hpp
@@ -15,11 +15,14 @@
 #ifndef AUTOWARE__BEHAVIOR_PATH_SIDE_SHIFT_MODULE__VALIDATION_HPP_
 #define AUTOWARE__BEHAVIOR_PATH_SIDE_SHIFT_MODULE__VALIDATION_HPP_
 
+#include "autoware/behavior_path_side_shift_module/data_structs.hpp"
 #include "autoware/behavior_path_side_shift_module/manager.hpp"
 
 #include <tier4_planning_msgs/srv/detail/set_lateral_offset__struct.hpp>
 #include <tier4_planning_msgs/srv/set_lateral_offset.hpp>
 
+#include <cstdint>
+#include <memory>
 #include <optional>
 #include <utility>
 
@@ -37,8 +40,20 @@ using SetLateralOffset = tier4_planning_msgs::srv::SetLateralOffset;
  * @return Computed lateral offset in meters, and its status_code reflecting the validation results
  */
 std::pair<uint16_t, double> validateAndComputeLateralOffset(
-  const SetLateralOffset::Request & request, double current_inserted_lateral_offset,
-  double unit_shift_amount, double max_shift_magnitude, double min_shift_gap);
+  const SetLateralOffset::Request & request, const double current_inserted_lateral_offset,
+  const std::shared_ptr<SideShiftParameters> & parameters);
+
+std::pair<uint16_t, double> validateRawValue(
+  const double current_inserted_lateral_offset, const double lateral_offset,
+  const std::shared_ptr<SideShiftParameters> & parameters);
+
+std::pair<uint16_t, double> validateShiftLeft(
+  const double current_inserted_lateral_offset,
+  const std::shared_ptr<SideShiftParameters> & parameters);
+
+std::pair<uint16_t, double> validateShiftRight(
+  const double current_inserted_lateral_offset,
+  const std::shared_ptr<SideShiftParameters> & parameters);
 
 /**
  * @brief Get the status message identical to te status code

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/include/autoware/behavior_path_side_shift_module/validation.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/include/autoware/behavior_path_side_shift_module/validation.hpp
@@ -31,26 +31,44 @@ namespace autoware::behavior_path_planner
 using SetLateralOffset = tier4_planning_msgs::srv::SetLateralOffset;
 
 /**
- * @brief Example validation for SetLateralOffset service request.
+ * @brief Validation for SetLateralOffset service request.
  * @param request SetLateralOffset service request (uses Request::RAW_VALUE, Request::DIRECTION,
  *        Request::RESET, Request::LEFT, Request::RIGHT from the message)
- * @param current_inserted_lateral_offset Current inserted lateral offset [m] (scene's state)
- * @param unit_shift_amount Shift increment in meters for DIRECTION mode (must be >= 0)
- * @param max_raw_shift_magnitude Optional max |shift_value| for RAW_VALUE; nullopt to skip
+ * @param current_inserted_lateral_offset Current inserted lateral offset [m]
+ * @param parameters Parameters used for the side shift mdule
  * @return Computed lateral offset in meters, and its status_code reflecting the validation results
  */
 std::pair<uint16_t, double> validateAndComputeLateralOffset(
   const SetLateralOffset::Request & request, const double current_inserted_lateral_offset,
   const std::shared_ptr<SideShiftParameters> & parameters);
 
+/**
+ * @brief Validation of the lateral offset when its value (in meters) is directly sent
+ * @param lateral_offset The lateral offset sent from the user
+ * @param current_inserted_lateral_offset Current inserted lateral offset [m]
+ * @param parameters Parameters used for the side shift mdule
+ * @return Computed lateral offset in meters, and its status_code reflecting the validation results
+ */
 std::pair<uint16_t, double> validateRawValue(
-  const double current_inserted_lateral_offset, const double lateral_offset,
+  const double lateral_offset, const double current_inserted_lateral_offset,
   const std::shared_ptr<SideShiftParameters> & parameters);
 
+/**
+ * @brief Validation of the lateral offset when LEFT command is sent
+ * @param current_inserted_lateral_offset Current inserted lateral offset [m]
+ * @param parameters Parameters used for the side shift mdule
+ * @return Computed lateral offset in meters, and its status_code reflecting the validation results
+ */
 std::pair<uint16_t, double> validateShiftLeft(
   const double current_inserted_lateral_offset,
   const std::shared_ptr<SideShiftParameters> & parameters);
 
+/**
+ * @brief Validation of the lateral offset when RIGHT command is sent
+ * @param current_inserted_lateral_offset Current inserted lateral offset [m]
+ * @param parameters Parameters used for the side shift mdule
+ * @return Computed lateral offset in meters, and its status_code reflecting the validation results
+ */
 std::pair<uint16_t, double> validateShiftRight(
   const double current_inserted_lateral_offset,
   const std::shared_ptr<SideShiftParameters> & parameters);

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/package.xml
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/package.xml
@@ -19,6 +19,7 @@
 
   <depend>autoware_behavior_path_planner</depend>
   <depend>autoware_behavior_path_planner_common</depend>
+  <depend>autoware_common_msgs</depend>
   <depend>autoware_motion_utils</depend>
   <depend>autoware_planning_msgs</depend>
   <depend>autoware_utils</depend>

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/manager.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/manager.cpp
@@ -14,10 +14,13 @@
 
 #include "autoware/behavior_path_side_shift_module/manager.hpp"
 
+#include "autoware/behavior_path_side_shift_module/validation.hpp"
 #include "autoware_utils/ros/update_param.hpp"
 
+#include <autoware_common_msgs/msg/response_status.hpp>
 #include <rclcpp/rclcpp.hpp>
 
+#include <chrono>
 #include <memory>
 #include <string>
 #include <vector>
@@ -41,19 +44,69 @@ void SideShiftModuleManager::init(rclcpp::Node * node)
   p.min_shifting_speed = node->declare_parameter<double>(ns + "min_shifting_speed");
   p.shift_request_time_limit = node->declare_parameter<double>(ns + "shift_request_time_limit");
   p.publish_debug_marker = node->declare_parameter<bool>(ns + "publish_debug_marker");
+  p.direction_shift_amount = node->declare_parameter<double>(ns + "direction_shift_amount");
 
   parameters_ = std::make_shared<SideShiftParameters>(p);
+  inserted_lateral_offset_state_ = std::make_shared<InsertedLateralOffsetState>();
+
+  set_lateral_offset_srv_ = node->create_service<autoware_planning_msgs::srv::SetLateralOffset>(
+    "~/set_lateral_offset",
+    std::bind(&SideShiftModuleManager::onSetLateralOffset, this, std::placeholders::_1, std::placeholders::_2));
+
+  lateral_offset_publisher_ =
+    node->create_publisher<tier4_planning_msgs::msg::LateralOffset>("~/output/lateral_offset", 1);
+
+  const auto period = std::chrono::milliseconds(100);  // 10 Hz
+  lateral_offset_publish_timer_ =
+    node->create_wall_timer(period, std::bind(&SideShiftModuleManager::publishInsertedLateralOffsetTimerCallback, this));
+}
+
+void SideShiftModuleManager::onSetLateralOffset(
+  const autoware_planning_msgs::srv::SetLateralOffset::Request::SharedPtr request,
+  autoware_planning_msgs::srv::SetLateralOffset::Response::SharedPtr response)
+{
+  const auto lateral_offset_opt = validateAndComputeLateralOffset(
+    request->shift_mode, request->shift_value, request->shift_direction_value,
+    parameters_->direction_shift_amount);
+
+  if (!lateral_offset_opt) {
+    response->status.success = false;
+    response->status.code = autoware_common_msgs::msg::ResponseStatus::PARAMETER_ERROR;
+    response->status.message = "SetLateralOffset: validation failed (invalid shift_mode, shift_value, or shift_direction_value)";
+    return;
+  }
+
+  const double lateral_offset = *lateral_offset_opt;
+
+  tier4_planning_msgs::msg::LateralOffset msg;
+  msg.stamp = node_->now();
+  msg.lateral_offset = static_cast<float>(lateral_offset);
+  planner_data_->lateral_offset = std::make_shared<tier4_planning_msgs::msg::LateralOffset>(msg);
+
+  response->status.success = true;
+  response->status.code = 0;
+  response->status.message = "";
+}
+
+void SideShiftModuleManager::publishInsertedLateralOffsetTimerCallback()
+{
+  if (!lateral_offset_publisher_ || !inserted_lateral_offset_state_) {
+    return;
+  }
+  tier4_planning_msgs::msg::LateralOffset msg;
+  msg.stamp = node_->now();
+  msg.lateral_offset = static_cast<float>(inserted_lateral_offset_state_->value.load());
+  lateral_offset_publisher_->publish(msg);
 }
 
 void SideShiftModuleManager::updateModuleParams(
-  [[maybe_unused]] const std::vector<rclcpp::Parameter> & parameters)
+  const std::vector<rclcpp::Parameter> & parameters)
 {
   using autoware_utils::update_param;
 
-  [[maybe_unused]] auto p = parameters_;
-
-  [[maybe_unused]] const std::string ns = "side_shift.";
-  // update_param<bool>(parameters, ns + ..., ...);
+  auto p = parameters_;
+  const std::string ns = "side_shift.";
+  update_param<double>(parameters, ns + "direction_shift_amount", p->direction_shift_amount);
 
   std::for_each(observers_.begin(), observers_.end(), [&p](const auto & observer) {
     if (!observer.expired()) observer.lock()->updateModuleParams(p);

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/manager.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/manager.cpp
@@ -17,10 +17,13 @@
 #include "autoware/behavior_path_side_shift_module/validation.hpp"
 #include "autoware_utils/ros/update_param.hpp"
 
+#include <rclcpp/create_timer.hpp>
+#include <rclcpp/logging.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include <autoware_common_msgs/msg/response_status.hpp>
 
+#include <algorithm>
 #include <chrono>
 #include <memory>
 #include <string>
@@ -50,7 +53,7 @@ void SideShiftModuleManager::init(rclcpp::Node * node)
   parameters_ = std::make_shared<SideShiftParameters>(p);
   inserted_lateral_offset_state_ = std::make_shared<InsertedLateralOffsetState>();
 
-  set_lateral_offset_srv_ = node->create_service<autoware_planning_msgs::srv::SetLateralOffset>(
+  set_lateral_offset_srv_ = node->create_service<SetLateralOffset>(
     "~/set_lateral_offset", std::bind(
                               &SideShiftModuleManager::onSetLateralOffset, this,
                               std::placeholders::_1, std::placeholders::_2));
@@ -59,19 +62,32 @@ void SideShiftModuleManager::init(rclcpp::Node * node)
     node->create_publisher<tier4_planning_msgs::msg::LateralOffset>("~/output/lateral_offset", 1);
 
   const auto period = std::chrono::milliseconds(100);  // 10 Hz
-  lateral_offset_publish_timer_ = node->create_wall_timer(
-    period, std::bind(&SideShiftModuleManager::publishInsertedLateralOffsetTimerCallback, this));
+  lateral_offset_publish_timer_ = rclcpp::create_timer(
+    node_, node_->get_clock(), period,
+    std::bind(&SideShiftModuleManager::publishInsertedLateralOffsetTimerCallback, this));
 }
 
 void SideShiftModuleManager::onSetLateralOffset(
-  const autoware_planning_msgs::srv::SetLateralOffset::Request::SharedPtr request,
-  autoware_planning_msgs::srv::SetLateralOffset::Response::SharedPtr response)
+  const SetLateralOffset::Request::SharedPtr request,
+  SetLateralOffset::Response::SharedPtr response)
 {
+  RCLCPP_INFO(node_->get_logger(), "Service called!");
+  if (!planner_data_) {
+    response->status.success = false;
+    response->status.code = autoware_common_msgs::msg::ResponseStatus::SERVICE_UNREADY;
+    response->status.message = "SetLateralOffset: side_shift module is not ready!";
+    return;
+  }
+
   const double current_inserted =
     inserted_lateral_offset_state_ ? inserted_lateral_offset_state_->value.load() : 0.0;
 
+  RCLCPP_INFO(node_->get_logger(), "current inserted defined!");
+
   const auto lateral_offset_opt =
     validateAndComputeLateralOffset(*request, current_inserted, parameters_->unit_shift_amount);
+
+  RCLCPP_INFO(node_->get_logger(), "lateral offset opt defined!");
 
   if (!lateral_offset_opt) {
     response->status.success = false;
@@ -82,16 +98,29 @@ void SideShiftModuleManager::onSetLateralOffset(
     return;
   }
 
+  RCLCPP_INFO(node_->get_logger(), "!!lateral_offset_opt");
+
   const double lateral_offset = *lateral_offset_opt;
 
-  tier4_planning_msgs::msg::LateralOffset msg;
-  msg.stamp = node_->now();
-  msg.lateral_offset = static_cast<float>(lateral_offset);
-  planner_data_->set_lateral_offset(std::make_shared<tier4_planning_msgs::msg::LateralOffset>(msg));
+  RCLCPP_INFO(node_->get_logger(), "lateral_offset defined! (%lf)", lateral_offset);
+
+  auto msg = std::make_shared<tier4_planning_msgs::msg::LateralOffset>();
+  msg->lateral_offset = static_cast<float>(lateral_offset);
+  RCLCPP_INFO(node_->get_logger(), "msg->lateral_offset defined!");
+  msg->stamp = node_->now();
+  RCLCPP_INFO(node_->get_logger(), "node_->now() defined!");
+  RCLCPP_INFO(node_->get_logger(), "msg defined!");
+
+  if (!planner_data_) {
+    RCLCPP_ERROR(node_->get_logger(), "planner_data_ is null!");
+  }
+
+  planner_data_->set_lateral_offset(msg);
+  RCLCPP_INFO(node_->get_logger(), "set_lateral_offset!");
 
   response->status.success = true;
   response->status.code = 0;
-  response->status.message = "";
+  response->status.message = "Successfully set lateral offset.";
 }
 
 void SideShiftModuleManager::publishInsertedLateralOffsetTimerCallback()
@@ -103,6 +132,11 @@ void SideShiftModuleManager::publishInsertedLateralOffsetTimerCallback()
   msg.stamp = node_->now();
   msg.lateral_offset = static_cast<float>(inserted_lateral_offset_state_->value.load());
   lateral_offset_publisher_->publish(msg);
+
+  if (planner_data_ && planner_data_->get_lateral_offset())
+    RCLCPP_INFO(
+      node_->get_logger(), "planner_data->lateral_offset (%f m)",
+      planner_data_->get_lateral_offset()->lateral_offset);
 }
 
 void SideShiftModuleManager::updateModuleParams(const std::vector<rclcpp::Parameter> & parameters)

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/manager.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/manager.cpp
@@ -81,7 +81,8 @@ void SideShiftModuleManager::onSetLateralOffset(
   tier4_planning_msgs::msg::LateralOffset msg;
   msg.stamp = node_->now();
   msg.lateral_offset = static_cast<float>(lateral_offset);
-  planner_data_->lateral_offset = std::make_shared<tier4_planning_msgs::msg::LateralOffset>(msg);
+  planner_data_->set_lateral_offset(
+    std::make_shared<tier4_planning_msgs::msg::LateralOffset>(msg));
 
   response->status.success = true;
   response->status.code = 0;

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/manager.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/manager.cpp
@@ -65,8 +65,11 @@ void SideShiftModuleManager::onSetLateralOffset(
   const autoware_planning_msgs::srv::SetLateralOffset::Request::SharedPtr request,
   autoware_planning_msgs::srv::SetLateralOffset::Response::SharedPtr response)
 {
+  const double current_inserted =
+    inserted_lateral_offset_state_ ? inserted_lateral_offset_state_->value.load() : 0.0;
+
   const auto lateral_offset_opt =
-    validateAndComputeLateralOffset(*request, parameters_->direction_shift_amount);
+    validateAndComputeLateralOffset(*request, current_inserted, parameters_->direction_shift_amount);
 
   if (!lateral_offset_opt) {
     response->status.success = false;

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/manager.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/manager.cpp
@@ -17,8 +17,9 @@
 #include "autoware/behavior_path_side_shift_module/validation.hpp"
 #include "autoware_utils/ros/update_param.hpp"
 
-#include <autoware_common_msgs/msg/response_status.hpp>
 #include <rclcpp/rclcpp.hpp>
+
+#include <autoware_common_msgs/msg/response_status.hpp>
 
 #include <chrono>
 #include <memory>
@@ -44,21 +45,22 @@ void SideShiftModuleManager::init(rclcpp::Node * node)
   p.min_shifting_speed = node->declare_parameter<double>(ns + "min_shifting_speed");
   p.shift_request_time_limit = node->declare_parameter<double>(ns + "shift_request_time_limit");
   p.publish_debug_marker = node->declare_parameter<bool>(ns + "publish_debug_marker");
-  p.direction_shift_amount = node->declare_parameter<double>(ns + "direction_shift_amount");
+  p.unit_shift_amount = node->declare_parameter<double>(ns + "unit_shift_amount");
 
   parameters_ = std::make_shared<SideShiftParameters>(p);
   inserted_lateral_offset_state_ = std::make_shared<InsertedLateralOffsetState>();
 
   set_lateral_offset_srv_ = node->create_service<autoware_planning_msgs::srv::SetLateralOffset>(
-    "~/set_lateral_offset",
-    std::bind(&SideShiftModuleManager::onSetLateralOffset, this, std::placeholders::_1, std::placeholders::_2));
+    "~/set_lateral_offset", std::bind(
+                              &SideShiftModuleManager::onSetLateralOffset, this,
+                              std::placeholders::_1, std::placeholders::_2));
 
   lateral_offset_publisher_ =
     node->create_publisher<tier4_planning_msgs::msg::LateralOffset>("~/output/lateral_offset", 1);
 
   const auto period = std::chrono::milliseconds(100);  // 10 Hz
-  lateral_offset_publish_timer_ =
-    node->create_wall_timer(period, std::bind(&SideShiftModuleManager::publishInsertedLateralOffsetTimerCallback, this));
+  lateral_offset_publish_timer_ = node->create_wall_timer(
+    period, std::bind(&SideShiftModuleManager::publishInsertedLateralOffsetTimerCallback, this));
 }
 
 void SideShiftModuleManager::onSetLateralOffset(
@@ -69,12 +71,14 @@ void SideShiftModuleManager::onSetLateralOffset(
     inserted_lateral_offset_state_ ? inserted_lateral_offset_state_->value.load() : 0.0;
 
   const auto lateral_offset_opt =
-    validateAndComputeLateralOffset(*request, current_inserted, parameters_->direction_shift_amount);
+    validateAndComputeLateralOffset(*request, current_inserted, parameters_->unit_shift_amount);
 
   if (!lateral_offset_opt) {
     response->status.success = false;
     response->status.code = autoware_common_msgs::msg::ResponseStatus::PARAMETER_ERROR;
-    response->status.message = "SetLateralOffset: validation failed (invalid shift_mode, shift_value, or shift_direction_value)";
+    response->status.message =
+      "SetLateralOffset: validation failed (invalid shift_mode, shift_value, or "
+      "shift_direction_value)";
     return;
   }
 
@@ -83,8 +87,7 @@ void SideShiftModuleManager::onSetLateralOffset(
   tier4_planning_msgs::msg::LateralOffset msg;
   msg.stamp = node_->now();
   msg.lateral_offset = static_cast<float>(lateral_offset);
-  planner_data_->set_lateral_offset(
-    std::make_shared<tier4_planning_msgs::msg::LateralOffset>(msg));
+  planner_data_->set_lateral_offset(std::make_shared<tier4_planning_msgs::msg::LateralOffset>(msg));
 
   response->status.success = true;
   response->status.code = 0;
@@ -102,14 +105,13 @@ void SideShiftModuleManager::publishInsertedLateralOffsetTimerCallback()
   lateral_offset_publisher_->publish(msg);
 }
 
-void SideShiftModuleManager::updateModuleParams(
-  const std::vector<rclcpp::Parameter> & parameters)
+void SideShiftModuleManager::updateModuleParams(const std::vector<rclcpp::Parameter> & parameters)
 {
   using autoware_utils::update_param;
 
   auto p = parameters_;
   const std::string ns = "side_shift.";
-  update_param<double>(parameters, ns + "direction_shift_amount", p->direction_shift_amount);
+  update_param<double>(parameters, ns + "unit_shift_amount", p->unit_shift_amount);
 
   std::for_each(observers_.begin(), observers_.end(), [&p](const auto & observer) {
     if (!observer.expired()) observer.lock()->updateModuleParams(p);

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/manager.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/manager.cpp
@@ -47,8 +47,10 @@ void SideShiftModuleManager::init(rclcpp::Node * node)
   p.min_shifting_distance = node->declare_parameter<double>(ns + "min_shifting_distance");
   p.min_shifting_speed = node->declare_parameter<double>(ns + "min_shifting_speed");
   p.shift_request_time_limit = node->declare_parameter<double>(ns + "shift_request_time_limit");
-  p.publish_debug_marker = node->declare_parameter<bool>(ns + "publish_debug_marker");
+  p.max_shift_magnitude = node->declare_parameter<double>(ns + "max_shift_magnitude");
+  p.min_shift_gap = node->declare_parameter<double>(ns + "min_shift_gap");
   p.unit_shift_amount = node->declare_parameter<double>(ns + "unit_shift_amount");
+  p.publish_debug_marker = node->declare_parameter<bool>(ns + "publish_debug_marker");
 
   parameters_ = std::make_shared<SideShiftParameters>(p);
   inserted_lateral_offset_state_ = std::make_shared<InsertedLateralOffsetState>();
@@ -76,52 +78,30 @@ void SideShiftModuleManager::onSetLateralOffset(
   const SetLateralOffset::Request::SharedPtr request,
   SetLateralOffset::Response::SharedPtr response)
 {
-  RCLCPP_INFO(node_->get_logger(), "Service called!");
-  if (!planner_data_) {
+  if (!planner_data_ || !planner_data_->route_handler->isHandlerReady()) {
     response->status.success = false;
     response->status.code = autoware_common_msgs::msg::ResponseStatus::SERVICE_UNREADY;
-    response->status.message = "SetLateralOffset: side_shift module is not ready!";
+    response->status.message = getStatusMessage(response->status.code);
     return;
   }
 
   const double current_inserted =
     inserted_lateral_offset_state_ ? inserted_lateral_offset_state_->value.load() : 0.0;
 
-  RCLCPP_INFO(node_->get_logger(), "current inserted defined!");
+  const auto [status_code, lateral_offset] = validateAndComputeLateralOffset(
+    *request, current_inserted, parameters_->unit_shift_amount, parameters_->max_shift_magnitude,
+    parameters_->min_shift_gap);
 
-  const auto lateral_offset_opt =
-    validateAndComputeLateralOffset(*request, current_inserted, parameters_->unit_shift_amount);
+  // WARN_EXCEEDED_LIMIT will be treated as success since the shift itself will be performed
+  response->status.success =
+    (status_code == SetLateralOffset::Response::SUCCESS ||
+     status_code == SetLateralOffset::Response::WARN_EXCEEDED_LIMIT);
+  response->status.code = status_code;
+  response->status.message = getStatusMessage(status_code);
 
-  RCLCPP_INFO(node_->get_logger(), "lateral offset opt defined!");
-
-  if (!lateral_offset_opt) {
-    response->status.success = false;
-    response->status.code = autoware_common_msgs::msg::ResponseStatus::PARAMETER_ERROR;
-    response->status.message =
-      "SetLateralOffset: validation failed (invalid shift_mode, shift_value, or "
-      "shift_direction_value)";
-    return;
+  if (response->status.success) {
+    requested_lateral_offset_state_->value.store(lateral_offset);
   }
-
-  RCLCPP_INFO(node_->get_logger(), "!!lateral_offset_opt");
-
-  const double lateral_offset = *lateral_offset_opt;
-
-  RCLCPP_INFO(node_->get_logger(), "lateral_offset defined! (%lf)", lateral_offset);
-
-  auto msg = std::make_shared<tier4_planning_msgs::msg::LateralOffset>();
-  msg->lateral_offset = static_cast<float>(lateral_offset);
-  RCLCPP_INFO(node_->get_logger(), "msg->lateral_offset defined!");
-  msg->stamp = node_->now();
-  RCLCPP_INFO(node_->get_logger(), "node_->now() defined!");
-  RCLCPP_INFO(node_->get_logger(), "msg defined!");
-
-  // NOTE: The validated lateral offset is exposed to external components via the output topic.
-  lateral_offset_publisher_->publish(*msg);
-
-  response->status.success = true;
-  response->status.code = 0;
-  response->status.message = "Successfully set lateral offset.";
 }
 
 void SideShiftModuleManager::publishInsertedLateralOffsetTimerCallback()
@@ -142,11 +122,14 @@ void SideShiftModuleManager::onLateralOffset(
     return;
   }
 
-  constexpr double THRESHOLD = 1.0e-3;
   const double new_offset = static_cast<double>(msg->lateral_offset);
   const double current = requested_lateral_offset_state_->value.load();
 
-  if (std::abs(new_offset - current) < THRESHOLD) {
+  if (std::abs(new_offset) > parameters_->max_shift_magnitude) {
+    return;
+  }
+
+  if (std::abs(new_offset - current) < parameters_->min_shift_gap) {
     return;
   }
 

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/manager.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/manager.cpp
@@ -65,9 +65,8 @@ void SideShiftModuleManager::onSetLateralOffset(
   const autoware_planning_msgs::srv::SetLateralOffset::Request::SharedPtr request,
   autoware_planning_msgs::srv::SetLateralOffset::Response::SharedPtr response)
 {
-  const auto lateral_offset_opt = validateAndComputeLateralOffset(
-    request->shift_mode, request->shift_value, request->shift_direction_value,
-    parameters_->direction_shift_amount);
+  const auto lateral_offset_opt =
+    validateAndComputeLateralOffset(*request, parameters_->direction_shift_amount);
 
   if (!lateral_offset_opt) {
     response->status.success = false;

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/manager.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/manager.cpp
@@ -52,6 +52,7 @@ void SideShiftModuleManager::init(rclcpp::Node * node)
 
   parameters_ = std::make_shared<SideShiftParameters>(p);
   inserted_lateral_offset_state_ = std::make_shared<InsertedLateralOffsetState>();
+  requested_lateral_offset_state_ = std::make_shared<RequestedLateralOffsetState>();
 
   set_lateral_offset_srv_ = node->create_service<SetLateralOffset>(
     "~/set_lateral_offset", std::bind(
@@ -60,6 +61,10 @@ void SideShiftModuleManager::init(rclcpp::Node * node)
 
   lateral_offset_publisher_ =
     node->create_publisher<tier4_planning_msgs::msg::LateralOffset>("~/output/lateral_offset", 1);
+
+  lateral_offset_sub_ = node->create_subscription<tier4_planning_msgs::msg::LateralOffset>(
+    "~/input/lateral_offset", rclcpp::QoS{1},
+    std::bind(&SideShiftModuleManager::onLateralOffset, this, std::placeholders::_1));
 
   const auto period = std::chrono::milliseconds(100);  // 10 Hz
   lateral_offset_publish_timer_ = rclcpp::create_timer(
@@ -111,12 +116,8 @@ void SideShiftModuleManager::onSetLateralOffset(
   RCLCPP_INFO(node_->get_logger(), "node_->now() defined!");
   RCLCPP_INFO(node_->get_logger(), "msg defined!");
 
-  if (!planner_data_) {
-    RCLCPP_ERROR(node_->get_logger(), "planner_data_ is null!");
-  }
-
-  planner_data_->set_lateral_offset(msg);
-  RCLCPP_INFO(node_->get_logger(), "set_lateral_offset!");
+  // NOTE: The validated lateral offset is exposed to external components via the output topic.
+  lateral_offset_publisher_->publish(*msg);
 
   response->status.success = true;
   response->status.code = 0;
@@ -132,11 +133,24 @@ void SideShiftModuleManager::publishInsertedLateralOffsetTimerCallback()
   msg.stamp = node_->now();
   msg.lateral_offset = static_cast<float>(inserted_lateral_offset_state_->value.load());
   lateral_offset_publisher_->publish(msg);
+}
 
-  if (planner_data_ && planner_data_->get_lateral_offset())
-    RCLCPP_INFO(
-      node_->get_logger(), "planner_data->lateral_offset (%f m)",
-      planner_data_->get_lateral_offset()->lateral_offset);
+void SideShiftModuleManager::onLateralOffset(
+  const tier4_planning_msgs::msg::LateralOffset::ConstSharedPtr msg)
+{
+  if (!requested_lateral_offset_state_) {
+    return;
+  }
+
+  constexpr double THRESHOLD = 1.0e-3;
+  const double new_offset = static_cast<double>(msg->lateral_offset);
+  const double current = requested_lateral_offset_state_->value.load();
+
+  if (std::abs(new_offset - current) < THRESHOLD) {
+    return;
+  }
+
+  requested_lateral_offset_state_->value.store(new_offset);
 }
 
 void SideShiftModuleManager::updateModuleParams(const std::vector<rclcpp::Parameter> & parameters)

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/manager.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/manager.cpp
@@ -88,9 +88,8 @@ void SideShiftModuleManager::onSetLateralOffset(
   const double current_inserted =
     inserted_lateral_offset_state_ ? inserted_lateral_offset_state_->value.load() : 0.0;
 
-  const auto [status_code, lateral_offset] = validateAndComputeLateralOffset(
-    *request, current_inserted, parameters_->unit_shift_amount, parameters_->max_shift_magnitude,
-    parameters_->min_shift_gap);
+  const auto [status_code, lateral_offset] =
+    validateAndComputeLateralOffset(*request, current_inserted, parameters_);
 
   // WARN_EXCEEDED_LIMIT will be treated as success since the shift itself will be performed
   response->status.success =
@@ -106,9 +105,6 @@ void SideShiftModuleManager::onSetLateralOffset(
 
 void SideShiftModuleManager::publishInsertedLateralOffsetTimerCallback()
 {
-  if (!lateral_offset_publisher_ || !inserted_lateral_offset_state_) {
-    return;
-  }
   tier4_planning_msgs::msg::LateralOffset msg;
   msg.stamp = node_->now();
   msg.lateral_offset = static_cast<float>(inserted_lateral_offset_state_->value.load());
@@ -118,35 +114,22 @@ void SideShiftModuleManager::publishInsertedLateralOffsetTimerCallback()
 void SideShiftModuleManager::onLateralOffset(
   const tier4_planning_msgs::msg::LateralOffset::ConstSharedPtr msg)
 {
-  if (!requested_lateral_offset_state_) {
-    return;
-  }
+  const auto new_offset = static_cast<double>(msg->lateral_offset);
 
-  const double new_offset = static_cast<double>(msg->lateral_offset);
-  const double current = requested_lateral_offset_state_->value.load();
+  const auto validation_result =
+    validateRawValue(inserted_lateral_offset_state_->value.load(), new_offset, parameters_);
 
-  if (std::abs(new_offset) > parameters_->max_shift_magnitude) {
-    return;
-  }
-
-  if (std::abs(new_offset - current) < parameters_->min_shift_gap) {
-    return;
-  }
-
-  requested_lateral_offset_state_->value.store(new_offset);
+  requested_lateral_offset_state_->value.store(validation_result.second);
 }
 
-void SideShiftModuleManager::updateModuleParams(const std::vector<rclcpp::Parameter> & parameters)
+void SideShiftModuleManager::updateModuleParams(
+  [[maybe_unused]] const std::vector<rclcpp::Parameter> & parameters)
 {
   using autoware_utils::update_param;
 
-  auto p = parameters_;
-  const std::string ns = "side_shift.";
-  update_param<double>(parameters, ns + "unit_shift_amount", p->unit_shift_amount);
-
-  std::for_each(observers_.begin(), observers_.end(), [&p](const auto & observer) {
-    if (!observer.expired()) observer.lock()->updateModuleParams(p);
-  });
+  [[maybe_unused]] auto p = parameters_;
+  [[maybe_unused]] const std::string ns = "side_shift.";
+  // update_param<bool>(parameters, ns + ..., ...);
 }
 
 }  // namespace autoware::behavior_path_planner

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/manager.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/manager.cpp
@@ -117,7 +117,7 @@ void SideShiftModuleManager::onLateralOffset(
   const auto new_offset = static_cast<double>(msg->lateral_offset);
 
   const auto validation_result =
-    validateRawValue(inserted_lateral_offset_state_->value.load(), new_offset, parameters_);
+    validateRawValue(new_offset, inserted_lateral_offset_state_->value.load(), parameters_);
 
   requested_lateral_offset_state_->value.store(validation_result.second);
 }

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/manager.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/manager.cpp
@@ -128,8 +128,13 @@ void SideShiftModuleManager::updateModuleParams(
   using autoware_utils::update_param;
 
   [[maybe_unused]] auto p = parameters_;
+
   [[maybe_unused]] const std::string ns = "side_shift.";
   // update_param<bool>(parameters, ns + ..., ...);
+
+  std::for_each(observers_.begin(), observers_.end(), [&p](const auto & observer) {
+    if (!observer.expired()) observer.lock()->updateModuleParams(p);
+  });
 }
 
 }  // namespace autoware::behavior_path_planner

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/scene.cpp
@@ -68,6 +68,9 @@ void SideShiftModule::initVariables()
   path_shifter_ = PathShifter{};
   resetPathCandidate();
   resetPathReference();
+  if (requested_lateral_offset_state_) {
+    requested_lateral_offset_state_->value.store(0.0);
+  }
   if (inserted_lateral_offset_state_) {
     inserted_lateral_offset_state_->value.store(0.0);
   }

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/scene.cpp
@@ -69,6 +69,10 @@ void SideShiftModule::initVariables()
   if (inserted_lateral_offset_state_) {
     inserted_lateral_offset_state_->value.store(0.0);
   }
+  // auto zero_msg = std::make_shared<tier4_planning_msgs::msg::LateralOffset>();
+  // zero_msg->stamp = clock_->now();
+  // zero_msg->lateral_offset = 0.0;
+  // planner_data_->set_lateral_offset(zero_msg);
 }
 
 void SideShiftModule::processOnEntry()

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/scene.cpp
@@ -44,10 +44,12 @@ SideShiftModule::SideShiftModule(
   std::unordered_map<std::string, std::shared_ptr<ObjectsOfInterestMarkerInterface>> &
     objects_of_interest_marker_interface_ptr_map,
   const std::shared_ptr<PlanningFactorInterface> planning_factor_interface,
-  const std::shared_ptr<InsertedLateralOffsetState> & inserted_lateral_offset_state)
+  const std::shared_ptr<InsertedLateralOffsetState> & inserted_lateral_offset_state,
+  const std::shared_ptr<RequestedLateralOffsetState> & requested_lateral_offset_state)
 : SceneModuleInterface{name, node, rtc_interface_ptr_map, objects_of_interest_marker_interface_ptr_map, planning_factor_interface},  // NOLINT
   parameters_{parameters},
-  inserted_lateral_offset_state_{inserted_lateral_offset_state}
+  inserted_lateral_offset_state_{inserted_lateral_offset_state},
+  requested_lateral_offset_state_{requested_lateral_offset_state}
 {
 }
 
@@ -69,10 +71,6 @@ void SideShiftModule::initVariables()
   if (inserted_lateral_offset_state_) {
     inserted_lateral_offset_state_->value.store(0.0);
   }
-  // auto zero_msg = std::make_shared<tier4_planning_msgs::msg::LateralOffset>();
-  // zero_msg->stamp = clock_->now();
-  // zero_msg->lateral_offset = 0.0;
-  // planner_data_->set_lateral_offset(zero_msg);
 }
 
 void SideShiftModule::processOnEntry()
@@ -189,13 +187,15 @@ bool SideShiftModule::canTransitSuccessState()
 
 void SideShiftModule::updateData()
 {
-  {
-    const auto lateral_offset = planner_data_->get_lateral_offset();
-    if (lateral_offset != nullptr && lateral_offset->stamp != latest_lateral_offset_stamp_) {
+  if (requested_lateral_offset_state_) {
+    const double requested = requested_lateral_offset_state_->value.load();
+    // Only react when the requested value actually changes meaningfully.
+    constexpr double REQUEST_THRESHOLD = 1.0e-4;
+    if (std::fabs(requested - requested_lateral_offset_) > REQUEST_THRESHOLD) {
       if (isReadyForNextRequest(parameters_->shift_request_time_limit)) {
         lateral_offset_change_request_ = true;
-        requested_lateral_offset_ = lateral_offset->lateral_offset;
-        latest_lateral_offset_stamp_ = lateral_offset->stamp;
+        requested_lateral_offset_ = requested;
+        latest_lateral_offset_stamp_ = clock_->now();
       }
     }
   }

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/scene.cpp
@@ -43,9 +43,11 @@ SideShiftModule::SideShiftModule(
   const std::unordered_map<std::string, std::shared_ptr<RTCInterface>> & rtc_interface_ptr_map,
   std::unordered_map<std::string, std::shared_ptr<ObjectsOfInterestMarkerInterface>> &
     objects_of_interest_marker_interface_ptr_map,
-  const std::shared_ptr<PlanningFactorInterface> planning_factor_interface)
+  const std::shared_ptr<PlanningFactorInterface> planning_factor_interface,
+  const std::shared_ptr<InsertedLateralOffsetState> & inserted_lateral_offset_state)
 : SceneModuleInterface{name, node, rtc_interface_ptr_map, objects_of_interest_marker_interface_ptr_map, planning_factor_interface},  // NOLINT
-  parameters_{parameters}
+  parameters_{parameters},
+  inserted_lateral_offset_state_{inserted_lateral_offset_state}
 {
 }
 
@@ -64,6 +66,9 @@ void SideShiftModule::initVariables()
   path_shifter_ = PathShifter{};
   resetPathCandidate();
   resetPathReference();
+  if (inserted_lateral_offset_state_) {
+    inserted_lateral_offset_state_->value.store(0.0);
+  }
 }
 
 void SideShiftModule::processOnEntry()
@@ -259,8 +264,9 @@ void SideShiftModule::replaceShiftLine()
   lateral_offset_change_request_ = false;
   inserted_lateral_offset_ = requested_lateral_offset_;
   inserted_shift_line_ = new_sl;
-
-  return;
+  if (inserted_lateral_offset_state_) {
+    inserted_lateral_offset_state_->value.store(inserted_lateral_offset_);
+  }
 }
 
 BehaviorModuleOutput SideShiftModule::plan()

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/scene.cpp
@@ -187,9 +187,7 @@ void SideShiftModule::updateData()
 {
   {
     const auto lateral_offset = planner_data_->get_lateral_offset();
-    if (
-      lateral_offset != nullptr &&
-      lateral_offset->stamp != latest_lateral_offset_stamp_) {
+    if (lateral_offset != nullptr && lateral_offset->stamp != latest_lateral_offset_stamp_) {
       if (isReadyForNextRequest(parameters_->shift_request_time_limit)) {
         lateral_offset_change_request_ = true;
         requested_lateral_offset_ = lateral_offset->lateral_offset;

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/scene.cpp
@@ -185,13 +185,16 @@ bool SideShiftModule::canTransitSuccessState()
 
 void SideShiftModule::updateData()
 {
-  if (
-    planner_data_->lateral_offset != nullptr &&
-    planner_data_->lateral_offset->stamp != latest_lateral_offset_stamp_) {
-    if (isReadyForNextRequest(parameters_->shift_request_time_limit)) {
-      lateral_offset_change_request_ = true;
-      requested_lateral_offset_ = planner_data_->lateral_offset->lateral_offset;
-      latest_lateral_offset_stamp_ = planner_data_->lateral_offset->stamp;
+  {
+    const auto lateral_offset = planner_data_->get_lateral_offset();
+    if (
+      lateral_offset != nullptr &&
+      lateral_offset->stamp != latest_lateral_offset_stamp_) {
+      if (isReadyForNextRequest(parameters_->shift_request_time_limit)) {
+        lateral_offset_change_request_ = true;
+        requested_lateral_offset_ = lateral_offset->lateral_offset;
+        latest_lateral_offset_stamp_ = lateral_offset->stamp;
+      }
     }
   }
 

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/scene.cpp
@@ -190,16 +190,14 @@ bool SideShiftModule::canTransitSuccessState()
 
 void SideShiftModule::updateData()
 {
-  if (requested_lateral_offset_state_) {
-    const double requested = requested_lateral_offset_state_->value.load();
-    // Only react when the requested value actually changes meaningfully.
-    constexpr double REQUEST_THRESHOLD = 1.0e-4;
-    if (std::fabs(requested - requested_lateral_offset_) > REQUEST_THRESHOLD) {
-      if (isReadyForNextRequest(parameters_->shift_request_time_limit)) {
-        lateral_offset_change_request_ = true;
-        requested_lateral_offset_ = requested;
-        latest_lateral_offset_stamp_ = clock_->now();
-      }
+  const double requested = requested_lateral_offset_state_->value.load();
+  // Only react when the requested value actually changes meaningfully.
+  constexpr double REQUEST_THRESHOLD = 1.0e-4;
+  if (std::fabs(requested - requested_lateral_offset_) > REQUEST_THRESHOLD) {
+    if (isReadyForNextRequest(parameters_->shift_request_time_limit)) {
+      lateral_offset_change_request_ = true;
+      requested_lateral_offset_ = requested;
+      latest_lateral_offset_stamp_ = clock_->now();
     }
   }
 

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/scene.cpp
@@ -270,9 +270,7 @@ void SideShiftModule::replaceShiftLine()
   lateral_offset_change_request_ = false;
   inserted_lateral_offset_ = requested_lateral_offset_;
   inserted_shift_line_ = new_sl;
-  if (inserted_lateral_offset_state_) {
-    inserted_lateral_offset_state_->value.store(inserted_lateral_offset_);
-  }
+  inserted_lateral_offset_state_->value.store(inserted_lateral_offset_);
 }
 
 BehaviorModuleOutput SideShiftModule::plan()

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/validation.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/validation.cpp
@@ -20,27 +20,30 @@ namespace autoware::behavior_path_planner
 {
 
 std::optional<double> validateAndComputeLateralOffset(
-  uint8_t shift_mode, float shift_value, uint8_t shift_direction_value,
+  const autoware_planning_msgs::srv::SetLateralOffset::Request & request,
   double direction_shift_amount, std::optional<double> max_raw_shift_magnitude)
 {
-  if (shift_mode == SHIFT_MODE_RAW_VALUE) {
-    if (max_raw_shift_magnitude && std::fabs(static_cast<double>(shift_value)) > *max_raw_shift_magnitude) {
+  using Request = autoware_planning_msgs::srv::SetLateralOffset::Request;
+
+  if (request.shift_mode == Request::RAW_VALUE) {
+    if (max_raw_shift_magnitude &&
+        std::fabs(static_cast<double>(request.shift_value)) > *max_raw_shift_magnitude) {
       return std::nullopt;
     }
-    return static_cast<double>(shift_value);
+    return static_cast<double>(request.shift_value);
   }
 
-  if (shift_mode == SHIFT_MODE_DIRECTION) {
-    if (shift_direction_value == SHIFT_DIRECTION_RESET) {
+  if (request.shift_mode == Request::DIRECTION) {
+    if (request.shift_direction_value == Request::RESET) {
       return 0.0;
     }
-    if (shift_direction_value == SHIFT_DIRECTION_LEFT) {
+    if (request.shift_direction_value == Request::LEFT) {
       if (direction_shift_amount < 0.0) {
         return std::nullopt;
       }
       return direction_shift_amount;
     }
-    if (shift_direction_value == SHIFT_DIRECTION_RIGHT) {
+    if (request.shift_direction_value == Request::RIGHT) {
       if (direction_shift_amount < 0.0) {
         return std::nullopt;
       }

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/validation.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/validation.cpp
@@ -21,7 +21,8 @@ namespace autoware::behavior_path_planner
 
 std::optional<double> validateAndComputeLateralOffset(
   const autoware_planning_msgs::srv::SetLateralOffset::Request & request,
-  double direction_shift_amount, std::optional<double> max_raw_shift_magnitude)
+  double current_inserted_lateral_offset, double direction_shift_amount,
+  std::optional<double> max_raw_shift_magnitude)
 {
   using Request = autoware_planning_msgs::srv::SetLateralOffset::Request;
 
@@ -41,13 +42,13 @@ std::optional<double> validateAndComputeLateralOffset(
       if (direction_shift_amount < 0.0) {
         return std::nullopt;
       }
-      return direction_shift_amount;
+      return current_inserted_lateral_offset + direction_shift_amount;
     }
     if (request.shift_direction_value == Request::RIGHT) {
       if (direction_shift_amount < 0.0) {
         return std::nullopt;
       }
-      return -direction_shift_amount;
+      return current_inserted_lateral_offset - direction_shift_amount;
     }
     return std::nullopt;
   }

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/validation.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/validation.cpp
@@ -21,14 +21,15 @@ namespace autoware::behavior_path_planner
 
 std::optional<double> validateAndComputeLateralOffset(
   const autoware_planning_msgs::srv::SetLateralOffset::Request & request,
-  double current_inserted_lateral_offset, double direction_shift_amount,
+  double current_inserted_lateral_offset, double unit_shift_amount,
   std::optional<double> max_raw_shift_magnitude)
 {
   using Request = autoware_planning_msgs::srv::SetLateralOffset::Request;
 
   if (request.shift_mode == Request::RAW_VALUE) {
-    if (max_raw_shift_magnitude &&
-        std::fabs(static_cast<double>(request.shift_value)) > *max_raw_shift_magnitude) {
+    if (
+      max_raw_shift_magnitude &&
+      std::fabs(static_cast<double>(request.shift_value)) > *max_raw_shift_magnitude) {
       return std::nullopt;
     }
     return static_cast<double>(request.shift_value);
@@ -39,16 +40,16 @@ std::optional<double> validateAndComputeLateralOffset(
       return 0.0;
     }
     if (request.shift_direction_value == Request::LEFT) {
-      if (direction_shift_amount < 0.0) {
+      if (unit_shift_amount < 0.0) {
         return std::nullopt;
       }
-      return current_inserted_lateral_offset + direction_shift_amount;
+      return current_inserted_lateral_offset + unit_shift_amount;
     }
     if (request.shift_direction_value == Request::RIGHT) {
-      if (direction_shift_amount < 0.0) {
+      if (unit_shift_amount < 0.0) {
         return std::nullopt;
       }
-      return current_inserted_lateral_offset - direction_shift_amount;
+      return current_inserted_lateral_offset - unit_shift_amount;
     }
     return std::nullopt;
   }

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/validation.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/validation.cpp
@@ -14,44 +14,111 @@
 
 #include "autoware/behavior_path_side_shift_module/validation.hpp"
 
+#include "autoware/behavior_path_side_shift_module/manager.hpp"
+
+#include <autoware_common_msgs/msg/response_status.hpp>
+
 #include <cmath>
+#include <utility>
 
 namespace autoware::behavior_path_planner
 {
+using ResponseStatus = autoware_common_msgs::msg::ResponseStatus;
 
-std::optional<double> validateAndComputeLateralOffset(
+std::pair<uint16_t, double> validateAndComputeLateralOffset(
   const SetLateralOffset::Request & request, double current_inserted_lateral_offset,
-  double unit_shift_amount, std::optional<double> max_raw_shift_magnitude)
+  double unit_shift_amount, double max_shift_magnitude, double min_shift_gap)
 {
   if (request.shift_mode == SetLateralOffset::Request::RAW_VALUE) {
-    if (
-      max_raw_shift_magnitude &&
-      std::fabs(static_cast<double>(request.shift_value)) > *max_raw_shift_magnitude) {
-      return std::nullopt;
+    if (std::fabs(static_cast<double>(request.shift_value)) > max_shift_magnitude) {
+      return {SetLateralOffset::Response::ERROR_EXCEEDED_LIMIT, 0.0};
     }
-    return static_cast<double>(request.shift_value);
+    if (
+      std::fabs(static_cast<double>(request.shift_value) - current_inserted_lateral_offset) <
+      min_shift_gap) {
+      return {
+        SetLateralOffset::Response::ERROR_SHIFT_GAP_TOO_SMALL, current_inserted_lateral_offset};
+    }
+    return {SetLateralOffset::Response::SUCCESS, static_cast<double>(request.shift_value)};
   }
 
   if (request.shift_mode == SetLateralOffset::Request::DIRECTION) {
     if (request.shift_direction_value == SetLateralOffset::Request::RESET) {
-      return 0.0;
+      return {SetLateralOffset::Response::SUCCESS, 0.0};
     }
+
+    if (unit_shift_amount < 0.0) {
+      return {ResponseStatus::PARAMETER_ERROR, 0.0};
+    }
+
     if (request.shift_direction_value == SetLateralOffset::Request::LEFT) {
-      if (unit_shift_amount < 0.0) {
-        return std::nullopt;
+      if (current_inserted_lateral_offset >= max_shift_magnitude) {
+        return {SetLateralOffset::Response::ERROR_EXCEEDED_LIMIT, max_shift_magnitude};
       }
-      return current_inserted_lateral_offset + unit_shift_amount;
+
+      const double request_offset = current_inserted_lateral_offset + unit_shift_amount;
+      if (std::fabs(request_offset) >= max_shift_magnitude) {
+        return {SetLateralOffset::Response::WARN_EXCEEDED_LIMIT, max_shift_magnitude};
+      }
+      if (std::fabs(request_offset - current_inserted_lateral_offset) < min_shift_gap) {
+        return {
+          SetLateralOffset::Response::ERROR_SHIFT_GAP_TOO_SMALL, current_inserted_lateral_offset};
+      }
+
+      return {SetLateralOffset::Response::SUCCESS, request_offset};
     }
+
     if (request.shift_direction_value == SetLateralOffset::Request::RIGHT) {
-      if (unit_shift_amount < 0.0) {
-        return std::nullopt;
+      if (current_inserted_lateral_offset <= -max_shift_magnitude) {
+        return {SetLateralOffset::Response::ERROR_EXCEEDED_LIMIT, -max_shift_magnitude};
       }
-      return current_inserted_lateral_offset - unit_shift_amount;
+
+      const double request_offset = current_inserted_lateral_offset - unit_shift_amount;
+      if (std::fabs(request_offset) >= max_shift_magnitude) {
+        return {SetLateralOffset::Response::WARN_EXCEEDED_LIMIT, -max_shift_magnitude};
+      }
+      if (std::fabs(request_offset - current_inserted_lateral_offset) < min_shift_gap) {
+        return {
+          SetLateralOffset::Response::ERROR_SHIFT_GAP_TOO_SMALL, current_inserted_lateral_offset};
+      }
+
+      return {SetLateralOffset::Response::SUCCESS, request_offset};
     }
-    return std::nullopt;
+
+    return {SetLateralOffset::Response::ERROR_INVALID_DIRECTION, 0.0};
   }
 
-  return std::nullopt;
+  return {SetLateralOffset::Response::ERROR_INVALID_MODE, 0.0};
+}
+
+const char * getStatusMessage(uint16_t status_code)
+{
+  switch (status_code) {
+    case SetLateralOffset::Response::SUCCESS:
+      return "Updated successfully";
+    case SetLateralOffset::Response::ERROR_UNKNOWN:
+      return "Unknown error occured";
+    case SetLateralOffset::Response::ERROR_INVALID_MODE:
+      return "Invalid mode have been requested";
+    case SetLateralOffset::Response::ERROR_INVALID_DIRECTION:
+      return "Invalid direction have been requested";
+    case SetLateralOffset::Response::ERROR_EXCEEDED_LIMIT:
+      return "The vehicle cannot shift further than request";
+    case SetLateralOffset::Response::ERROR_SHIFT_GAP_TOO_SMALL:
+      return "The requested shift length differs too small from the current shift length";
+    case SetLateralOffset::Response::ERROR_MODULES_CONFLICTING:
+      return "Other modules are running in the behavior_path_planner";
+    case SetLateralOffset::Response::WARN_UNKNOWN:
+      return "Unknown warning occured";
+    case SetLateralOffset::Response::WARN_EXCEEDED_LIMIT:
+      return "The shift length reached limit. Shifted to the possible end.";
+    case ResponseStatus::SERVICE_UNREADY:
+      return "The side_shift module is not ready";
+    case ResponseStatus::PARAMETER_ERROR:
+      return "Invalid parameters defined in the side_shift module";
+    default:
+      return "Unknown status_code";
+  }
 }
 
 }  // namespace autoware::behavior_path_planner

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/validation.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/validation.cpp
@@ -1,0 +1,55 @@
+// Copyright 2023 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/behavior_path_side_shift_module/validation.hpp"
+
+#include <cmath>
+
+namespace autoware::behavior_path_planner
+{
+
+std::optional<double> validateAndComputeLateralOffset(
+  uint8_t shift_mode, float shift_value, uint8_t shift_direction_value,
+  double direction_shift_amount, std::optional<double> max_raw_shift_magnitude)
+{
+  if (shift_mode == SHIFT_MODE_RAW_VALUE) {
+    if (max_raw_shift_magnitude && std::fabs(static_cast<double>(shift_value)) > *max_raw_shift_magnitude) {
+      return std::nullopt;
+    }
+    return static_cast<double>(shift_value);
+  }
+
+  if (shift_mode == SHIFT_MODE_DIRECTION) {
+    if (shift_direction_value == SHIFT_DIRECTION_RESET) {
+      return 0.0;
+    }
+    if (shift_direction_value == SHIFT_DIRECTION_LEFT) {
+      if (direction_shift_amount < 0.0) {
+        return std::nullopt;
+      }
+      return direction_shift_amount;
+    }
+    if (shift_direction_value == SHIFT_DIRECTION_RIGHT) {
+      if (direction_shift_amount < 0.0) {
+        return std::nullopt;
+      }
+      return -direction_shift_amount;
+    }
+    return std::nullopt;
+  }
+
+  return std::nullopt;
+}
+
+}  // namespace autoware::behavior_path_planner

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/validation.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/validation.cpp
@@ -20,13 +20,10 @@ namespace autoware::behavior_path_planner
 {
 
 std::optional<double> validateAndComputeLateralOffset(
-  const autoware_planning_msgs::srv::SetLateralOffset::Request & request,
-  double current_inserted_lateral_offset, double unit_shift_amount,
-  std::optional<double> max_raw_shift_magnitude)
+  const SetLateralOffset::Request & request, double current_inserted_lateral_offset,
+  double unit_shift_amount, std::optional<double> max_raw_shift_magnitude)
 {
-  using Request = autoware_planning_msgs::srv::SetLateralOffset::Request;
-
-  if (request.shift_mode == Request::RAW_VALUE) {
+  if (request.shift_mode == SetLateralOffset::Request::RAW_VALUE) {
     if (
       max_raw_shift_magnitude &&
       std::fabs(static_cast<double>(request.shift_value)) > *max_raw_shift_magnitude) {
@@ -35,17 +32,17 @@ std::optional<double> validateAndComputeLateralOffset(
     return static_cast<double>(request.shift_value);
   }
 
-  if (request.shift_mode == Request::DIRECTION) {
-    if (request.shift_direction_value == Request::RESET) {
+  if (request.shift_mode == SetLateralOffset::Request::DIRECTION) {
+    if (request.shift_direction_value == SetLateralOffset::Request::RESET) {
       return 0.0;
     }
-    if (request.shift_direction_value == Request::LEFT) {
+    if (request.shift_direction_value == SetLateralOffset::Request::LEFT) {
       if (unit_shift_amount < 0.0) {
         return std::nullopt;
       }
       return current_inserted_lateral_offset + unit_shift_amount;
     }
-    if (request.shift_direction_value == Request::RIGHT) {
+    if (request.shift_direction_value == SetLateralOffset::Request::RIGHT) {
       if (unit_shift_amount < 0.0) {
         return std::nullopt;
       }

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/validation.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/validation.cpp
@@ -19,6 +19,7 @@
 #include <autoware_common_msgs/msg/response_status.hpp>
 
 #include <cmath>
+#include <memory>
 #include <utility>
 
 namespace autoware::behavior_path_planner
@@ -26,20 +27,12 @@ namespace autoware::behavior_path_planner
 using ResponseStatus = autoware_common_msgs::msg::ResponseStatus;
 
 std::pair<uint16_t, double> validateAndComputeLateralOffset(
-  const SetLateralOffset::Request & request, double current_inserted_lateral_offset,
-  double unit_shift_amount, double max_shift_magnitude, double min_shift_gap)
+  const SetLateralOffset::Request & request, const double current_inserted_lateral_offset,
+  const std::shared_ptr<SideShiftParameters> & parameters)
 {
   if (request.shift_mode == SetLateralOffset::Request::RAW_VALUE) {
-    if (std::fabs(static_cast<double>(request.shift_value)) > max_shift_magnitude) {
-      return {SetLateralOffset::Response::ERROR_EXCEEDED_LIMIT, 0.0};
-    }
-    if (
-      std::fabs(static_cast<double>(request.shift_value) - current_inserted_lateral_offset) <
-      min_shift_gap) {
-      return {
-        SetLateralOffset::Response::ERROR_SHIFT_GAP_TOO_SMALL, current_inserted_lateral_offset};
-    }
-    return {SetLateralOffset::Response::SUCCESS, static_cast<double>(request.shift_value)};
+    return validateRawValue(
+      current_inserted_lateral_offset, static_cast<double>(request.shift_value), parameters);
   }
 
   if (request.shift_mode == SetLateralOffset::Request::DIRECTION) {
@@ -47,48 +40,77 @@ std::pair<uint16_t, double> validateAndComputeLateralOffset(
       return {SetLateralOffset::Response::SUCCESS, 0.0};
     }
 
-    if (unit_shift_amount < 0.0) {
+    if (parameters->unit_shift_amount <= 0.0) {
       return {ResponseStatus::PARAMETER_ERROR, 0.0};
     }
 
     if (request.shift_direction_value == SetLateralOffset::Request::LEFT) {
-      if (current_inserted_lateral_offset >= max_shift_magnitude) {
-        return {SetLateralOffset::Response::ERROR_EXCEEDED_LIMIT, max_shift_magnitude};
-      }
-
-      const double request_offset = current_inserted_lateral_offset + unit_shift_amount;
-      if (std::fabs(request_offset) >= max_shift_magnitude) {
-        return {SetLateralOffset::Response::WARN_EXCEEDED_LIMIT, max_shift_magnitude};
-      }
-      if (std::fabs(request_offset - current_inserted_lateral_offset) < min_shift_gap) {
-        return {
-          SetLateralOffset::Response::ERROR_SHIFT_GAP_TOO_SMALL, current_inserted_lateral_offset};
-      }
-
-      return {SetLateralOffset::Response::SUCCESS, request_offset};
+      return validateShiftLeft(current_inserted_lateral_offset, parameters);
     }
 
     if (request.shift_direction_value == SetLateralOffset::Request::RIGHT) {
-      if (current_inserted_lateral_offset <= -max_shift_magnitude) {
-        return {SetLateralOffset::Response::ERROR_EXCEEDED_LIMIT, -max_shift_magnitude};
-      }
-
-      const double request_offset = current_inserted_lateral_offset - unit_shift_amount;
-      if (std::fabs(request_offset) >= max_shift_magnitude) {
-        return {SetLateralOffset::Response::WARN_EXCEEDED_LIMIT, -max_shift_magnitude};
-      }
-      if (std::fabs(request_offset - current_inserted_lateral_offset) < min_shift_gap) {
-        return {
-          SetLateralOffset::Response::ERROR_SHIFT_GAP_TOO_SMALL, current_inserted_lateral_offset};
-      }
-
-      return {SetLateralOffset::Response::SUCCESS, request_offset};
+      return validateShiftRight(current_inserted_lateral_offset, parameters);
     }
 
     return {SetLateralOffset::Response::ERROR_INVALID_DIRECTION, 0.0};
   }
 
   return {SetLateralOffset::Response::ERROR_INVALID_MODE, 0.0};
+}
+
+std::pair<uint16_t, double> validateRawValue(
+  const double current_inserted_lateral_offset, const double lateral_offset,
+  const std::shared_ptr<SideShiftParameters> & parameters)
+{
+  if (std::fabs(lateral_offset) > parameters->max_shift_magnitude) {
+    return {SetLateralOffset::Response::ERROR_EXCEEDED_LIMIT, current_inserted_lateral_offset};
+  }
+
+  if (std::fabs(lateral_offset - current_inserted_lateral_offset) < parameters->min_shift_gap) {
+    return {SetLateralOffset::Response::ERROR_SHIFT_GAP_TOO_SMALL, current_inserted_lateral_offset};
+  }
+
+  return {SetLateralOffset::Response::SUCCESS, lateral_offset};
+}
+
+std::pair<uint16_t, double> validateShiftLeft(
+  const double current_inserted_lateral_offset,
+  const std::shared_ptr<SideShiftParameters> & parameters)
+{
+  if (current_inserted_lateral_offset >= parameters->max_shift_magnitude) {
+    return {SetLateralOffset::Response::ERROR_EXCEEDED_LIMIT, parameters->max_shift_magnitude};
+  }
+
+  const double request_offset = current_inserted_lateral_offset + parameters->unit_shift_amount;
+  if (std::fabs(request_offset) >= parameters->max_shift_magnitude) {
+    return {SetLateralOffset::Response::WARN_EXCEEDED_LIMIT, parameters->max_shift_magnitude};
+  }
+
+  if (std::fabs(request_offset - current_inserted_lateral_offset) < parameters->min_shift_gap) {
+    return {SetLateralOffset::Response::ERROR_SHIFT_GAP_TOO_SMALL, current_inserted_lateral_offset};
+  }
+
+  return {SetLateralOffset::Response::SUCCESS, request_offset};
+}
+
+std::pair<uint16_t, double> validateShiftRight(
+  const double current_inserted_lateral_offset,
+  const std::shared_ptr<SideShiftParameters> & parameters)
+{
+  if (current_inserted_lateral_offset <= -parameters->max_shift_magnitude) {
+    return {SetLateralOffset::Response::ERROR_EXCEEDED_LIMIT, -parameters->max_shift_magnitude};
+  }
+
+  const double request_offset = current_inserted_lateral_offset - parameters->unit_shift_amount;
+  if (std::fabs(request_offset) >= parameters->max_shift_magnitude) {
+    return {SetLateralOffset::Response::WARN_EXCEEDED_LIMIT, -parameters->max_shift_magnitude};
+  }
+
+  if (std::fabs(request_offset - current_inserted_lateral_offset) < parameters->min_shift_gap) {
+    return {SetLateralOffset::Response::ERROR_SHIFT_GAP_TOO_SMALL, current_inserted_lateral_offset};
+  }
+
+  return {SetLateralOffset::Response::SUCCESS, request_offset};
 }
 
 const char * getStatusMessage(uint16_t status_code)

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/validation.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/validation.cpp
@@ -32,7 +32,7 @@ std::pair<uint16_t, double> validateAndComputeLateralOffset(
 {
   if (request.shift_mode == SetLateralOffset::Request::RAW_VALUE) {
     return validateRawValue(
-      current_inserted_lateral_offset, static_cast<double>(request.shift_value), parameters);
+      static_cast<double>(request.shift_value), current_inserted_lateral_offset, parameters);
   }
 
   if (request.shift_mode == SetLateralOffset::Request::DIRECTION) {
@@ -59,7 +59,7 @@ std::pair<uint16_t, double> validateAndComputeLateralOffset(
 }
 
 std::pair<uint16_t, double> validateRawValue(
-  const double current_inserted_lateral_offset, const double lateral_offset,
+  const double lateral_offset, const double current_inserted_lateral_offset,
   const std::shared_ptr<SideShiftParameters> & parameters)
 {
   if (std::fabs(lateral_offset) > parameters->max_shift_magnitude) {

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/validation.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/validation.cpp
@@ -119,7 +119,7 @@ const char * getStatusMessage(uint16_t status_code)
     case SetLateralOffset::Response::SUCCESS:
       return "Updated successfully";
     case SetLateralOffset::Response::ERROR_UNKNOWN:
-      return "Unknown error occured";
+      return "Unknown error occurred";
     case SetLateralOffset::Response::ERROR_INVALID_MODE:
       return "Invalid mode have been requested";
     case SetLateralOffset::Response::ERROR_INVALID_DIRECTION:


### PR DESCRIPTION
## Description

The `side_shift` module of the `autoware_behavior_path_planner` is somewhat a special module that is outside the frame of Dynamic Driving Tasks (DDT) because this module is aimed to modify the path laterally by a human hand.

Currently this feature obtains its shift length from a **topic**, however this will not tell the operator to know whether the requested shift_length is successfully received or not. Hence, this PR adds a new service to `autoware_behavior_path_side_shift_module`.

In addition the newly implemented service not only accepts direct shift length, but also adds a new shift mode that can send whether to go left or right. If this shift mode is selected the vehicle will shift its path with the shift length stated in the `unit_shift_amount` parameter. This unit shift will be accumulated as the shift request with the same direction has come. 

## Related links

- (autoware_launch) https://github.com/autowarefoundation/autoware_launch/pull/1800
- (tier4_autoware_msgs) https://github.com/tier4/tier4_autoware_msgs/pull/210

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

- Tested that `colcon test` passes.
- Tested that the expected behavior is shown. (Look the video below)


https://github.com/user-attachments/assets/cf7e3b48-c0fa-41df-b301-00e467b1903c



| Time | What is happening |
| --- | --- |
|  0:00 - 0:13 | The publisher constantly publishing the current lateral offset |
| 0:14 - 0:19 | Called the service in `RAW_VALUE` mode with `1.0` meter |
| 0:20 - 0:31 | Called the service in `RAW_VALUE` mode with `-1.0` meter |
| 0:32 - 0:40 | Called the service in `DIRECTION` mode and select `RESET(=0)` |
| 0:41 - 0:49 | Called the service in `DIRECTION` mode and select `LEFT(=1)` several times. This shifts the path `0.1` meter each |
| 0:50 - 0:52 | RESET again |
| 0:53 - 1:02 | Called the service in `DIRECTION` mode and select `RIGHT(=2)` several times. This shifts the path `0.1` meter each |
| 1:02 - 1:05  | RESET again |
| 1:06 - 1:15 | Called the service in `RAW_VALUE` mode with `3.0` meters but the request declined since it exceeds threshold. |

 

## Notes for reviewers

I've moved the lateral_offset subscriber to the side_shift module to
- Handle the `requested_lateral_offset_` from both topic and service correctly
- Try not to edit the `planner_data_` from the module side
- In the name of modularity 

Therefore, the `lateral_offset` field is removed from the `planner_data_`

## Interface changes

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added  | Srv | `~/set_lateral_offset` | `tier4_planning_msgs/SetLateralOffset`   | Set the lateral offset, or select LEFT, RIGHT, RESET to shift. See for further explanation. |
| Added | Pub | `~/output/lateral_offset` | `tier4_planning_msgs/LateralOffset` | The current lateral_offset (in meters) |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added | `max_shift_magnitude`   | `double` | `1.0` [m]        | Maximum shift length the side_shift module can perform for safety reasons |
| Added | `min_shift_gap`   | `double` | `0.001` [m]        | Minimum gap that the previous lateral offset and the current lateral offset can have in order not to have a very small shift path |
| Added | `unit_shift_amount`   | `double` | `0.1` [m]        | The shift length once a LEFT or RIGHT command is requested from the `set_lateral_offset` service. |

## Effects on system behavior

1. The `autoware_behavior_path_side_shift_module` accepts ROS 2 service inputs
2. The side shift module will not shift the path more than `max_shift_magnitude` meters
