### PR TITLE
fix(diffusion_planner): remove `predict_neighbor_trajectory`

### DIFF
--- a/planning/autoware_diffusion_planner/config/diffusion_planner.param.yaml
+++ b/planning/autoware_diffusion_planner/config/diffusion_planner.param.yaml
@@ -6,7 +6,6 @@
     planning_frequency_hz: 10.0
     ignore_neighbors: false
     ignore_unknown_neighbors: true
-    predict_neighbor_trajectory: true
     traffic_light_group_msg_timeout_seconds: 0.2
     batch_size: 1
     temperature: [0.0]

--- a/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/diffusion_planner_core.hpp
+++ b/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/diffusion_planner_core.hpp
@@ -109,7 +109,6 @@ struct DiffusionPlannerParams
   double planning_frequency_hz;
   bool ignore_neighbors;
   bool ignore_unknown_neighbors;
-  bool predict_neighbor_trajectory;
   double traffic_light_group_msg_timeout_seconds;
   int batch_size;
   std::vector<double> temperature_list;

--- a/planning/autoware_diffusion_planner/schema/diffusion_planner.schema.json
+++ b/planning/autoware_diffusion_planner/schema/diffusion_planner.schema.json
@@ -42,11 +42,6 @@
           "default": true,
           "description": "Ignore neighbor agents with unknown class"
         },
-        "predict_neighbor_trajectory": {
-          "type": "boolean",
-          "default": true,
-          "description": "Predict trajectories for neighbor agents"
-        },
         "traffic_light_group_msg_timeout_seconds": {
           "type": "number",
           "default": 0.2,
@@ -125,7 +120,6 @@
         "onnx_model_path",
         "args_path",
         "planning_frequency_hz",
-        "predict_neighbor_trajectory",
         "traffic_light_group_msg_timeout_seconds",
         "batch_size",
         "temperature",

--- a/planning/autoware_diffusion_planner/src/diffusion_planner_node.cpp
+++ b/planning/autoware_diffusion_planner/src/diffusion_planner_node.cpp
@@ -102,8 +102,6 @@ void DiffusionPlanner::set_up_params()
   params_.ignore_neighbors = this->declare_parameter<bool>("ignore_neighbors", false);
   params_.ignore_unknown_neighbors =
     this->declare_parameter<bool>("ignore_unknown_neighbors", false);
-  params_.predict_neighbor_trajectory =
-    this->declare_parameter<bool>("predict_neighbor_trajectory", false);
   params_.traffic_light_group_msg_timeout_seconds =
     this->declare_parameter<double>("traffic_light_group_msg_timeout_seconds", 0.2);
   params_.batch_size = this->declare_parameter<int>("batch_size", 1);
@@ -148,8 +146,6 @@ SetParametersResult DiffusionPlanner::on_parameter(
     update_param<bool>(
       parameters, "ignore_unknown_neighbors", temp_params.ignore_unknown_neighbors);
     update_param<bool>(parameters, "ignore_neighbors", temp_params.ignore_neighbors);
-    update_param<bool>(
-      parameters, "predict_neighbor_trajectory", temp_params.predict_neighbor_trajectory);
     update_param<double>(
       parameters, "traffic_light_group_msg_timeout_seconds",
       temp_params.traffic_light_group_msg_timeout_seconds);
@@ -346,9 +342,7 @@ void DiffusionPlanner::on_timer()
 
   pub_trajectory_->publish(planner_output.trajectory);
   pub_trajectories_->publish(planner_output.candidate_trajectories);
-  if (params_.predict_neighbor_trajectory) {
-    pub_objects_->publish(planner_output.predicted_objects);
-  }
+  pub_objects_->publish(planner_output.predicted_objects);
   pub_turn_indicators_->publish(planner_output.turn_indicator_command);
 
   // Publish diagnostics

--- a/planning/autoware_diffusion_planner/test/diffusion_planner_integration_test.cpp
+++ b/planning/autoware_diffusion_planner/test/diffusion_planner_integration_test.cpp
@@ -50,7 +50,6 @@ protected:
        {"args_path", "/tmp/test_args.json"},
        {"timer_period", 0.1},
        {"ignore_unknown_neighbors", true},
-       {"predict_neighbor_trajectory", false},
        {"publish_debug_markers", false}});
 
     // Note: This will fail to initialize ONNX Runtime without a valid model


### PR DESCRIPTION
## Description

Remove the `predict_neighbor_trajectory` parameter from `autoware_diffusion_planner`.
This parameter was unnecessary because setting it to `false` did not reduce computation so much — neighbor trajectory prediction always runs regardless. Removing it simplifies the parameter interface.

## How was this PR tested?

- [x] planning simulator
- [x] logging_simulaor

## Notes for reviewers

None.

## Interface changes

### ROS Parameter Changes

#### Additions and removals

| Change type | Parameter Name | Type | Default Value | Description |
|:------------|:---------------|:-----|:--------------|:------------|
| Removed | `predict_neighbor_trajectory` | `bool` | `true` | Predict trajectories for neighbor agents |

## Effects on system behavior

Predicted neighbor trajectories are now always published. Previously, publishing could be disabled via the `predict_neighbor_trajectory` parameter, but disabling it provided no computational benefit since the prediction was always computed internally.
