### PR TITLE
feat(tensorrt_common): expose execution context via getContext()

### DIFF
--- a/perception/autoware_tensorrt_common/include/autoware/tensorrt_common/tensorrt_common.hpp
+++ b/perception/autoware_tensorrt_common/include/autoware/tensorrt_common/tensorrt_common.hpp
@@ -312,6 +312,16 @@ public:
   bool enqueueV3(cudaStream_t stream);
 
   /**
+   * @brief Get the underlying TensorRT execution context.
+   *
+   * This is useful for advanced features such as CUDA Graph capture,
+   * where callers need to call context->setAuxStreams() before capture.
+   *
+   * @return Raw pointer to the execution context (owned by TrtCommon).
+   */
+  [[nodiscard]] nvinfer1::IExecutionContext * getContext() const noexcept;
+
+  /**
    * @brief Print per-layer information.
    */
   void printProfiling() const;

--- a/perception/autoware_tensorrt_common/src/tensorrt_common.cpp
+++ b/perception/autoware_tensorrt_common/src/tensorrt_common.cpp
@@ -447,6 +447,11 @@ bool TrtCommon::enqueueV3(cudaStream_t stream)
   return context_->enqueueV3(stream);
 }
 
+nvinfer1::IExecutionContext * TrtCommon::getContext() const noexcept
+{
+  return context_.get();
+}
+
 void TrtCommon::printProfiling() const
 {
   logger_->log(


### PR DESCRIPTION
## Description

Add public `getContext()` accessor to `TrtCommon` that returns the underlying
`nvinfer1::IExecutionContext*`. This enables downstream packages to perform
advanced TRT optimizations such as one-time tensor binding, `setMaxAuxStreams(0)`,
and CUDA Graph capture — operations that require direct context access.

## Related links

Parent Issue: N/A

## How was this PR tested?

- Built `autoware_tensorrt_common` with `colcon build --packages-select autoware_tensorrt_common`
- Downstream package (`autoware_diffusion_planner`) compiles and runs correctly using `getContext()`
- Additive-only change — existing callers are unaffected

## Notes for reviewers

This is a minimal, additive API change (1 new method, no existing behavior modified).
It is required by the diffusion planner TRT optimization PR, which uses `getContext()` for:
1. `setInputShape()` / `setTensorAddress()` — bind-once optimization
2. `getEngine().getBuilderConfig().setMaxAuxStreams(0)` — scratch memory reduction
3. CUDA Graph capture on supported architectures (e.g., Ada)

## Interface changes

- Added `nvinfer1::IExecutionContext * getContext() const noexcept` to `TrtCommon`

## Effects on system behavior

None. Existing packages are unaffected.