### PR TITLE
fix(roi_pointcloud_fusion): add fusion option per class

### DIFF
--- a/perception/autoware_image_projection_based_fusion/config/roi_pointcloud_fusion.param.yaml
+++ b/perception/autoware_image_projection_based_fusion/config/roi_pointcloud_fusion.param.yaml
@@ -6,7 +6,7 @@
     roi_scale_factor: 1.0
     max_object_size: 2.0
     override_class_with_unknown: false
-    enable_fusion_per_class:
+    fusion_enabled_classes:
       UNKNOWN: true
       CAR: false
       BUS: false

--- a/perception/autoware_image_projection_based_fusion/include/autoware/image_projection_based_fusion/roi_pointcloud_fusion/node.hpp
+++ b/perception/autoware_image_projection_based_fusion/include/autoware/image_projection_based_fusion/roi_pointcloud_fusion/node.hpp
@@ -47,7 +47,7 @@ private:
   int min_cluster_size_{1};
   int max_cluster_size_{20};
   double max_object_size_{2.0};
-  std::unordered_map<uint8_t, bool> enable_fusion_per_class_;
+  std::unordered_map<uint8_t, bool> fusion_enabled_classes_;
   double cluster_2d_tolerance_;
   double roi_scale_factor_{1.0};
   bool override_class_with_unknown_{false};

--- a/perception/autoware_image_projection_based_fusion/schema/roi_pointcloud_fusion.schema.json
+++ b/perception/autoware_image_projection_based_fusion/schema/roi_pointcloud_fusion.schema.json
@@ -6,7 +6,7 @@
     "roi_pointcloud_fusion": {
       "type": "object",
       "properties": {
-        "enable_fusion_per_class": {
+        "fusion_enabled_classes": {
           "type": "object",
           "properties": {
             "UNKNOWN": {
@@ -98,7 +98,7 @@
         }
       },
       "required": [
-        "enable_fusion_per_class",
+        "fusion_enabled_classes",
         "override_class_with_unknown",
         "min_cluster_size",
         "cluster_2d_tolerance",

--- a/perception/autoware_image_projection_based_fusion/src/roi_pointcloud_fusion/node.cpp
+++ b/perception/autoware_image_projection_based_fusion/src/roi_pointcloud_fusion/node.cpp
@@ -48,8 +48,8 @@ RoiPointCloudFusionNode::RoiPointCloudFusionNode(const rclcpp::NodeOptions & opt
      {"BICYCLE", Classification::BICYCLE},
      {"PEDESTRIAN", Classification::PEDESTRIAN}}};
   for (const auto & [class_name, label] : fusion_class_names) {
-    enable_fusion_per_class_[label] =
-      declare_parameter<bool>("enable_fusion_per_class." + class_name);
+    fusion_enabled_classes_[label] =
+      declare_parameter<bool>("fusion_enabled_classes." + class_name);
   }
   min_cluster_size_ = declare_parameter<int>("min_cluster_size");
   max_cluster_size_ = declare_parameter<int>("max_cluster_size");
@@ -78,11 +78,11 @@ void RoiPointCloudFusionNode::fuse_on_single_image(
   std::vector<DetectedObjectWithFeature> output_objs;
   std::vector<sensor_msgs::msg::RegionOfInterest> debug_image_rois;
   std::vector<Eigen::Vector2d> debug_image_points;
-  // select ROIs for fusion by per-class enable_fusion_per_class flag
+  // select ROIs for fusion by per-class fusion_enabled_classes flag
   for (const auto & feature_obj : input_rois_msg.feature_objects) {
     const uint8_t roi_label = getHighestProbLabel(feature_obj.object.classification);
-    const auto it = enable_fusion_per_class_.find(roi_label);
-    const bool fuse_this_class = (it != enable_fusion_per_class_.end() && it->second);
+    const bool fuse_this_class =
+      fusion_enabled_classes_.count(roi_label) && fusion_enabled_classes_.at(roi_label);
     if (!fuse_this_class) {
       continue;
     }


### PR DESCRIPTION
## Description
- This PR replaces the global “fuse unknown only” flag in ROI pointcloud fusion with per-class fusion options
- Need merging after https://github.com/autowarefoundation/autoware_launch/pull/1783 merged
## Related links

**Parent Issue:**

- [TIERIV internal link](https://tier4.atlassian.net/browse/T4DEV-50154)

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

- Run test and compare with based model on [Internal Evaluator](https://evaluation.tier4.jp/evaluation/reports/tables/new?catalog_id=14b1d54b-5c9f-4cbf-a7e1-0eebceb1d30f&filter=&job_id=5cf0cc05-d02c-50de-b43b-182860c8e7ba&project_id=x2_dev&table_config=date&target_ids=32441c3a-f351-5dfa-9320-bc8c49351517): 

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
