### PR TITLE
refactor(autoware_mpc_lateral_controller): remove unused config params

### DIFF
--- a/control/autoware_mpc_lateral_controller/param/lateral_controller_defaults.param.yaml
+++ b/control/autoware_mpc_lateral_controller/param/lateral_controller_defaults.param.yaml
@@ -50,8 +50,6 @@
     curvature_list_for_steer_rate_lim: [0.001, 0.002, 0.01]              # curvature list for steering angle rate limit interpolation in ascending order [/m]
     steer_rate_lim_dps_list_by_velocity: [60.0, 50.0, 40.0]             # steering angle rate limit list depending on velocity [deg/s]
     velocity_list_for_steer_rate_lim: [10.0, 15.0, 20.0]                  # velocity list for steering angle rate limit interpolation in ascending order [m/s]
-    acceleration_limit: 2.0          # acceleration limit for trajectory velocity modification [m/ss]
-    velocity_time_constant: 0.3      # velocity dynamics time constant  for trajectory velocity modification [s]
 
     # -- lowpass filter for noise reduction --
     steering_lpf_cutoff_hz: 3.0 # cutoff frequency of lowpass filter for steering command [Hz]

--- a/control/autoware_mpc_lateral_controller/schema/sub/vehicle_model.json
+++ b/control/autoware_mpc_lateral_controller/schema/sub/vehicle_model.json
@@ -52,16 +52,6 @@
           },
           "description": "velocity list for steering angle rate limit interpolation in ascending order [m/s]",
           "default": [10.0, 15.0, 20.0]
-        },
-        "acceleration_limit": {
-          "type": "number",
-          "description": "acceleration limit for trajectory velocity modification [m/ss]",
-          "default": 2.0
-        },
-        "velocity_time_constant": {
-          "type": "number",
-          "description": "velocity dynamics time constant for trajectory velocity modification [s]",
-          "default": 0.3
         }
       },
       "required": [
@@ -71,9 +61,7 @@
         "steer_rate_lim_dps_list_by_curvature",
         "curvature_list_for_steer_rate_lim",
         "steer_rate_lim_dps_list_by_velocity",
-        "velocity_list_for_steer_rate_lim",
-        "acceleration_limit",
-        "velocity_time_constant"
+        "velocity_list_for_steer_rate_lim"
       ],
       "additionalProperties": false
     }


### PR DESCRIPTION
## Description

Remove unused parameters from `autoware_mpc_lateral_controller` so that config matches the implementation.

The node reads `mpc_acceleration_limit` and `mpc_velocity_time_constant` (mpc_optimization); it does not read `acceleration_limit` nor `velocity_time_constant` under the vehicle model section.

- Removed from `param/lateral_controller_defaults.param.yaml`: `acceleration_limit`, `velocity_time_constant`
- Updated `schema/sub/vehicle_model.json` accordingly

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

- Confirmed that `mpc_lateral_controller.cpp` and `declareMPCparameters()` only use `mpc_acceleration_limit` and `mpc_velocity_time_constant`.
- Schema and param YAML validated.

## Notes for reviewers

None.

## Interface changes

### ROS Parameter Changes

#### Additions and removals

| Change type | Parameter Name          | Type     | Default Value | Description                                                         |
| :---------- | :----------------------- | :------- | :------------ | :------------------------------------------------------------------ |
| Removed     | `acceleration_limit`     | `double` | `2.0`         | Not read by the node (code uses `mpc_acceleration_limit` instead).   |
| Removed     | `velocity_time_constant` | `double` | `0.3`         | Not read by the node (code uses `mpc_velocity_time_constant` instead). |

## Effects on system behavior

None. Removed parameters were not used by the node.
