### PR TITLE
fix(planning): a typo in behavior_path_planner config yaml file

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/config/lane_change.param.yaml
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/config/lane_change.param.yaml
@@ -60,7 +60,7 @@
           lateral_distance_max_threshold: 0.5           # [m]
           longitudinal_distance_min_threshold: 1.0      # [m]
           longitudinal_velocity_delta_time: 0.0         # [s]
-          extended_polygon_policy: "along-path"         # [-] available options are `rectangle` or `along-path`
+          extended_polygon_policy: "along_path"         # [-] available options are `rectangle` or `along_path`
         execution:
           expected_front_deceleration: -1.0
           expected_rear_deceleration: -1.0


### PR DESCRIPTION
## Description

Fix a typo ("along-path" -> "along_path") in planning/behavior_path_planner/autoware_behavior_path_lane_change_module/config/lane_change.param.yaml .

This typo is reported as [WARN] in CI unit test "build-and-test-differential-arm64 (humble, -cuda)".
[WARN message](https://github.com/autowarefoundation/autoware_universe/actions/runs/22697546126/job/65807251252?pr=12238#step:13:4660)

At first, I thought this typo triggers failure of CI unit testing with the labels "run:build-and-test-differential" and "type:arm64", which are specified in [PR #12238](https://github.com/autowarefoundation/autoware_universe/pull/12238).

However, further investigation tells that the problem reported 2 lines below is more likely to be the true cause,
which I'm working on [PR #12254](https://github.com/autowarefoundation/autoware_universe/pull/12254).

> Warning: class_loader.ClassLoader: SEVERE WARNING!!! Attempting to unload library while objects created by this loader exist in the heap! You should delete your objects before attempting to unload the library or destroying the ClassLoader. The library will NOT be unloaded.
1:          at line 127 in ./src/class_loader.cpp

## Related links

**Parent Issue:**

- Link

## How was this PR tested?

- Other configuration yaml files and the source code use "along_path", not "along-path".
- CI unit test succeeds. 

## Notes for reviewers

Is this a real typo? Not an intentional one for testing purpose?
Will it do any real harm to Autoware products?

## Interface changes

None.

## Effects on system behavior

A lurking problem is fixed.
