### PR TITLE
test(planning): use test fixtures for planner unit tests so that rclcpp resources are destructed in the right order.

### DIFF
--- a/planning/autoware_freespace_planner/test/test_freespace_planner_node_interface.cpp
+++ b/planning/autoware_freespace_planner/test/test_freespace_planner_node_interface.cpp
@@ -66,11 +66,23 @@ void publishMandatoryTopics(
     autoware::test_utils::makeScenarioMsg(autoware_internal_planning_msgs::msg::Scenario::PARKING));
 }
 
-// the following tests are disable because they randomly fail
-TEST(PlanningModuleInterfaceTest, DISABLED_testPlanningInterfaceWithVariousTrajectoryInput)
+class PlanningModuleInterfaceTest : public ::testing::Test
 {
-  rclcpp::init(0, nullptr);
+protected:
+  void SetUp() override
+  {
+    rclcpp::init(0, nullptr);
+  }
 
+  void TearDown() override
+  {
+    (void)rclcpp::shutdown();
+  }
+};
+
+// the following tests are disable because they randomly fail
+TEST_F(PlanningModuleInterfaceTest, testPlanningInterfaceWithVariousTrajectoryInput)
+{
   auto test_manager = generateTestManager();
   auto test_target_node = generateNode();
   publishMandatoryTopics(test_manager, test_target_node);
@@ -85,12 +97,10 @@ TEST(PlanningModuleInterfaceTest, DISABLED_testPlanningInterfaceWithVariousTraje
   // test with empty route
   ASSERT_NO_THROW_WITH_ERROR_MSG(
     test_manager->testWithAbnormalRoute(test_target_node, input_route_topic));
-  rclcpp::shutdown();
 }
 
-TEST(PlanningModuleInterfaceTest, DISABLED_NodeTestWithOffTrackEgoPose)
+TEST_F(PlanningModuleInterfaceTest, NodeTestWithOffTrackEgoPose)
 {
-  rclcpp::init(0, nullptr);
   auto test_manager = generateTestManager();
   auto test_target_node = generateNode();
 
@@ -106,6 +116,4 @@ TEST(PlanningModuleInterfaceTest, DISABLED_NodeTestWithOffTrackEgoPose)
 
   ASSERT_NO_THROW_WITH_ERROR_MSG(
     test_manager->testWithOffTrackOdometry(test_target_node, input_odometry_topic));
-
-  rclcpp::shutdown();
 }

--- a/planning/autoware_freespace_planner/test/test_freespace_planner_node_interface.cpp
+++ b/planning/autoware_freespace_planner/test/test_freespace_planner_node_interface.cpp
@@ -69,15 +69,9 @@ void publishMandatoryTopics(
 class PlanningModuleInterfaceTest : public ::testing::Test
 {
 protected:
-  void SetUp() override
-  {
-    rclcpp::init(0, nullptr);
-  }
+  void SetUp() override { rclcpp::init(0, nullptr); }
 
-  void TearDown() override
-  {
-    (void)rclcpp::shutdown();
-  }
+  void TearDown() override { (void)rclcpp::shutdown(); }
 };
 
 // the following tests are disable because they randomly fail

--- a/planning/autoware_freespace_planner/test/test_freespace_planner_node_interface.cpp
+++ b/planning/autoware_freespace_planner/test/test_freespace_planner_node_interface.cpp
@@ -74,8 +74,8 @@ protected:
   void TearDown() override { (void)rclcpp::shutdown(); }
 };
 
-// the following tests are disable because they randomly fail
-TEST_F(PlanningModuleInterfaceTest, testPlanningInterfaceWithVariousTrajectoryInput)
+// the following tests are disabled because they randomly fail
+TEST_F(PlanningModuleInterfaceTest, DISABLED_testPlanningInterfaceWithVariousTrajectoryInput)
 {
   auto test_manager = generateTestManager();
   auto test_target_node = generateNode();
@@ -93,7 +93,7 @@ TEST_F(PlanningModuleInterfaceTest, testPlanningInterfaceWithVariousTrajectoryIn
     test_manager->testWithAbnormalRoute(test_target_node, input_route_topic));
 }
 
-TEST_F(PlanningModuleInterfaceTest, NodeTestWithOffTrackEgoPose)
+TEST_F(PlanningModuleInterfaceTest, DISABLED_NodeTestWithOffTrackEgoPose)
 {
   auto test_manager = generateTestManager();
   auto test_target_node = generateNode();

--- a/planning/autoware_path_optimizer/test/test_path_optimizer_node_interface.cpp
+++ b/planning/autoware_path_optimizer/test/test_path_optimizer_node_interface.cpp
@@ -27,15 +27,9 @@
 class PlanningModuleInterfaceTest : public ::testing::Test
 {
 protected:
-  void SetUp() override
-  {
-    rclcpp::init(0, nullptr);
-  }
+  void SetUp() override { rclcpp::init(0, nullptr); }
 
-  void TearDown() override
-  {
-    (void)rclcpp::shutdown();
-  }
+  void TearDown() override { (void)rclcpp::shutdown(); }
 };
 
 TEST_F(PlanningModuleInterfaceTest, NodeTestWithExceptionTrajectory)

--- a/planning/autoware_path_optimizer/test/test_path_optimizer_node_interface.cpp
+++ b/planning/autoware_path_optimizer/test/test_path_optimizer_node_interface.cpp
@@ -24,10 +24,22 @@
 #include <string>
 #include <vector>
 
-TEST(PlanningModuleInterfaceTest, NodeTestWithExceptionTrajectory)
+class PlanningModuleInterfaceTest : public ::testing::Test
 {
-  rclcpp::init(0, nullptr);
+protected:
+  void SetUp() override
+  {
+    rclcpp::init(0, nullptr);
+  }
 
+  void TearDown() override
+  {
+    (void)rclcpp::shutdown();
+  }
+};
+
+TEST_F(PlanningModuleInterfaceTest, NodeTestWithExceptionTrajectory)
+{
   auto test_manager =
     std::make_shared<autoware::planning_test_manager::PlanningInterfaceTestManager>();
 
@@ -66,6 +78,4 @@ TEST(PlanningModuleInterfaceTest, NodeTestWithExceptionTrajectory)
   // test with trajectory with empty/one point/overlapping point
   ASSERT_NO_THROW_WITH_ERROR_MSG(
     test_manager->testWithAbnormalPath(test_target_node, input_trajectory_topic));
-
-  rclcpp::shutdown();
 }

--- a/planning/autoware_path_smoother/test/test_autoware_path_smoother_node_interface.cpp
+++ b/planning/autoware_path_smoother/test/test_autoware_path_smoother_node_interface.cpp
@@ -27,15 +27,9 @@
 class PlanningModuleInterfaceTest : public ::testing::Test
 {
 protected:
-  void SetUp() override
-  {
-    rclcpp::init(0, nullptr);
-  }
+  void SetUp() override { rclcpp::init(0, nullptr); }
 
-  void TearDown() override
-  {
-    (void)rclcpp::shutdown();
-  }
+  void TearDown() override { (void)rclcpp::shutdown(); }
 };
 
 TEST_F(PlanningModuleInterfaceTest, NodeTestWithExceptionTrajectory)

--- a/planning/autoware_path_smoother/test/test_autoware_path_smoother_node_interface.cpp
+++ b/planning/autoware_path_smoother/test/test_autoware_path_smoother_node_interface.cpp
@@ -24,10 +24,22 @@
 #include <string>
 #include <vector>
 
-TEST(PlanningModuleInterfaceTest, NodeTestWithExceptionTrajectory)
+class PlanningModuleInterfaceTest : public ::testing::Test
 {
-  rclcpp::init(0, nullptr);
+protected:
+  void SetUp() override
+  {
+    rclcpp::init(0, nullptr);
+  }
 
+  void TearDown() override
+  {
+    (void)rclcpp::shutdown();
+  }
+};
+
+TEST_F(PlanningModuleInterfaceTest, NodeTestWithExceptionTrajectory)
+{
   auto test_manager =
     std::make_shared<autoware::planning_test_manager::PlanningInterfaceTestManager>();
 
@@ -68,6 +80,4 @@ TEST(PlanningModuleInterfaceTest, NodeTestWithExceptionTrajectory)
   // test with trajectory with empty/one point/overlapping point
   ASSERT_NO_THROW_WITH_ERROR_MSG(
     test_manager->testWithAbnormalPath(test_target_node, input_path_topic));
-
-  rclcpp::shutdown();
 }

--- a/planning/autoware_scenario_selector/test/test_autoware_scenario_selector_node_interface.cpp
+++ b/planning/autoware_scenario_selector/test/test_autoware_scenario_selector_node_interface.cpp
@@ -72,9 +72,22 @@ void publishMandatoryTopics(
     autoware_adapi_v1_msgs::msg::OperationModeState{});
 }
 
-TEST(PlanningModuleInterfaceTest, NodeTestWithExceptionTrajectoryLaneDrivingMode)
+class PlanningModuleInterfaceTest : public ::testing::Test
 {
-  rclcpp::init(0, nullptr);
+protected:
+  void SetUp() override
+  {
+    rclcpp::init(0, nullptr);
+  }
+
+  void TearDown() override
+  {
+    (void)rclcpp::shutdown();
+  }
+};
+
+TEST_F(PlanningModuleInterfaceTest, NodeTestWithExceptionTrajectoryLaneDrivingMode)
+{
   auto test_manager = generateTestManager();
   auto test_target_node = generateNode();
 
@@ -89,13 +102,10 @@ TEST(PlanningModuleInterfaceTest, NodeTestWithExceptionTrajectoryLaneDrivingMode
   // test for trajectory with empty/one point/overlapping point
   ASSERT_NO_THROW(
     test_manager->testWithAbnormalTrajectory(test_target_node, input_trajectory_topic));
-  rclcpp::shutdown();
 }
 
-TEST(PlanningModuleInterfaceTest, NodeTestWithExceptionTrajectoryParkingMode)
+TEST_F(PlanningModuleInterfaceTest, NodeTestWithExceptionTrajectoryParkingMode)
 {
-  rclcpp::init(0, nullptr);
-
   auto test_manager = generateTestManager();
   auto test_target_node = generateNode();
 
@@ -110,12 +120,10 @@ TEST(PlanningModuleInterfaceTest, NodeTestWithExceptionTrajectoryParkingMode)
   // test for trajectory with empty/one point/overlapping point
   ASSERT_NO_THROW(
     test_manager->testWithAbnormalTrajectory(test_target_node, input_trajectory_topic));
-  rclcpp::shutdown();
 }
 
-TEST(PlanningModuleInterfaceTest, NodeTestWithOffTrackEgoPose)
+TEST_F(PlanningModuleInterfaceTest, NodeTestWithOffTrackEgoPose)
 {
-  rclcpp::init(0, nullptr);
   auto test_manager = generateTestManager();
   auto test_target_node = generateNode();
 
@@ -129,6 +137,5 @@ TEST(PlanningModuleInterfaceTest, NodeTestWithOffTrackEgoPose)
   EXPECT_GE(test_manager->getReceivedTopicNum(), 1);
 
   ASSERT_NO_THROW(test_manager->testWithOffTrackOdometry(test_target_node, input_odometry_topic));
-  rclcpp::shutdown();
 }
 }  // namespace autoware::scenario_selector

--- a/planning/autoware_scenario_selector/test/test_autoware_scenario_selector_node_interface.cpp
+++ b/planning/autoware_scenario_selector/test/test_autoware_scenario_selector_node_interface.cpp
@@ -75,15 +75,9 @@ void publishMandatoryTopics(
 class PlanningModuleInterfaceTest : public ::testing::Test
 {
 protected:
-  void SetUp() override
-  {
-    rclcpp::init(0, nullptr);
-  }
+  void SetUp() override { rclcpp::init(0, nullptr); }
 
-  void TearDown() override
-  {
-    (void)rclcpp::shutdown();
-  }
+  void TearDown() override { (void)rclcpp::shutdown(); }
 };
 
 TEST_F(PlanningModuleInterfaceTest, NodeTestWithExceptionTrajectoryLaneDrivingMode)

--- a/planning/behavior_path_planner/autoware_behavior_path_avoidance_by_lane_change_module/test/test_behavior_path_planner_node_interface.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_avoidance_by_lane_change_module/test/test_behavior_path_planner_node_interface.cpp
@@ -25,10 +25,22 @@ using autoware::behavior_path_planner::generateNode;
 using autoware::behavior_path_planner::generateTestManager;
 using autoware::behavior_path_planner::publishMandatoryTopics;
 
-TEST(PlanningModuleInterfaceTest, NodeTestWithExceptionRoute)
+class PlanningModuleInterfaceTest : public ::testing::Test
 {
-  rclcpp::init(0, nullptr);
+protected:
+  void SetUp() override
+  {
+    rclcpp::init(0, nullptr);
+  }
 
+  void TearDown() override
+  {
+    (void)rclcpp::shutdown();
+  }
+};
+
+TEST_F(PlanningModuleInterfaceTest, NodeTestWithExceptionRoute)
+{
   auto test_manager = generateTestManager();
   auto test_target_node = generateNode(
     {"lane_change", "static_obstacle_avoidance", "avoidance_by_lane_change"},
@@ -45,13 +57,10 @@ TEST(PlanningModuleInterfaceTest, NodeTestWithExceptionRoute)
   // test with empty route
   ASSERT_NO_THROW_WITH_ERROR_MSG(
     test_manager->testWithAbnormalRoute(test_target_node, input_route_topic));
-  rclcpp::shutdown();
 }
 
-TEST(PlanningModuleInterfaceTest, NodeTestWithOffTrackEgoPose)
+TEST_F(PlanningModuleInterfaceTest, NodeTestWithOffTrackEgoPose)
 {
-  rclcpp::init(0, nullptr);
-
   auto test_manager = generateTestManager();
   auto test_target_node = generateNode(
     {"lane_change", "static_obstacle_avoidance", "avoidance_by_lane_change"},
@@ -70,6 +79,4 @@ TEST(PlanningModuleInterfaceTest, NodeTestWithOffTrackEgoPose)
 
   ASSERT_NO_THROW_WITH_ERROR_MSG(
     test_manager->testWithOffTrackOdometry(test_target_node, input_odometry_topic));
-
-  rclcpp::shutdown();
 }

--- a/planning/behavior_path_planner/autoware_behavior_path_avoidance_by_lane_change_module/test/test_behavior_path_planner_node_interface.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_avoidance_by_lane_change_module/test/test_behavior_path_planner_node_interface.cpp
@@ -28,49 +28,55 @@ using autoware::behavior_path_planner::publishMandatoryTopics;
 class PlanningModuleInterfaceTest : public ::testing::Test
 {
 protected:
-  void SetUp() override { rclcpp::init(0, nullptr); }
+  void SetUp() override {
+    rclcpp::init(0, nullptr);
+    test_manager_ = generateTestManager();
+    test_target_node_ = generateNode(
+      {"lane_change", "static_obstacle_avoidance", "avoidance_by_lane_change"},
+      {"autoware::behavior_path_planner::AvoidanceByLaneChangeModuleManager"});
+  }
 
-  void TearDown() override { (void)rclcpp::shutdown(); }
+  void TearDown() override {
+    test_target_node_.reset();
+    test_manager_.reset();
+    (void)rclcpp::shutdown();
+  }
+
+private:
+  std::shared_ptr<PlanningInterfaceTestManager> test_manager_;
+  std::shared_ptr<BehaviorPathPlannerNode> test_target_node_;
 };
 
 TEST_F(PlanningModuleInterfaceTest, NodeTestWithExceptionRoute)
 {
-  auto test_manager = generateTestManager();
-  auto test_target_node = generateNode(
-    {"lane_change", "static_obstacle_avoidance", "avoidance_by_lane_change"},
-    {"autoware::behavior_path_planner::AvoidanceByLaneChangeModuleManager"});
-  publishMandatoryTopics(test_manager, test_target_node);
+  publishMandatoryTopics(test_manager_, test_target_node_);
 
   const std::string input_route_topic = "behavior_path_planner/input/route";
 
   // test for normal trajectory
   ASSERT_NO_THROW_WITH_ERROR_MSG(
-    test_manager->testWithBehaviorNormalRoute(test_target_node, input_route_topic));
-  EXPECT_GE(test_manager->getReceivedTopicNum(), 1);
+    test_manager_->testWithBehaviorNormalRoute(test_target_node_, input_route_topic));
+  EXPECT_GE(test_manager_->getReceivedTopicNum(), 1);
 
   // test with empty route
   ASSERT_NO_THROW_WITH_ERROR_MSG(
-    test_manager->testWithAbnormalRoute(test_target_node, input_route_topic));
+    test_manager_->testWithAbnormalRoute(test_target_node_, input_route_topic));
 }
 
 TEST_F(PlanningModuleInterfaceTest, NodeTestWithOffTrackEgoPose)
 {
-  auto test_manager = generateTestManager();
-  auto test_target_node = generateNode(
-    {"lane_change", "static_obstacle_avoidance", "avoidance_by_lane_change"},
-    {"autoware::behavior_path_planner::AvoidanceByLaneChangeModuleManager"});
-  publishMandatoryTopics(test_manager, test_target_node);
+  publishMandatoryTopics(test_manager_, test_target_node_);
 
   const std::string input_route_topic = "behavior_path_planner/input/route";
   const std::string input_odometry_topic = "behavior_path_planner/input/odometry";
 
   // test for normal trajectory
   ASSERT_NO_THROW_WITH_ERROR_MSG(
-    test_manager->testWithBehaviorNormalRoute(test_target_node, input_route_topic));
+    test_manager_->testWithBehaviorNormalRoute(test_target_node_, input_route_topic));
 
   // make sure behavior_path_planner is running
-  EXPECT_GE(test_manager->getReceivedTopicNum(), 1);
+  EXPECT_GE(test_manager_->getReceivedTopicNum(), 1);
 
   ASSERT_NO_THROW_WITH_ERROR_MSG(
-    test_manager->testWithOffTrackOdometry(test_target_node, input_odometry_topic));
+    test_manager_->testWithOffTrackOdometry(test_target_node_, input_odometry_topic));
 }

--- a/planning/behavior_path_planner/autoware_behavior_path_avoidance_by_lane_change_module/test/test_behavior_path_planner_node_interface.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_avoidance_by_lane_change_module/test/test_behavior_path_planner_node_interface.cpp
@@ -28,15 +28,9 @@ using autoware::behavior_path_planner::publishMandatoryTopics;
 class PlanningModuleInterfaceTest : public ::testing::Test
 {
 protected:
-  void SetUp() override
-  {
-    rclcpp::init(0, nullptr);
-  }
+  void SetUp() override { rclcpp::init(0, nullptr); }
 
-  void TearDown() override
-  {
-    (void)rclcpp::shutdown();
-  }
+  void TearDown() override { (void)rclcpp::shutdown(); }
 };
 
 TEST_F(PlanningModuleInterfaceTest, NodeTestWithExceptionRoute)

--- a/planning/behavior_path_planner/autoware_behavior_path_avoidance_by_lane_change_module/test/test_behavior_path_planner_node_interface.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_avoidance_by_lane_change_module/test/test_behavior_path_planner_node_interface.cpp
@@ -28,7 +28,8 @@ using autoware::behavior_path_planner::publishMandatoryTopics;
 class PlanningModuleInterfaceTest : public ::testing::Test
 {
 protected:
-  void SetUp() override {
+  void SetUp() override
+  {
     rclcpp::init(0, nullptr);
     test_manager_ = generateTestManager();
     test_target_node_ = generateNode(
@@ -36,7 +37,8 @@ protected:
       {"autoware::behavior_path_planner::AvoidanceByLaneChangeModuleManager"});
   }
 
-  void TearDown() override {
+  void TearDown() override
+  {
     test_target_node_.reset();
     test_manager_.reset();
     (void)rclcpp::shutdown();

--- a/planning/behavior_path_planner/autoware_behavior_path_avoidance_by_lane_change_module/test/test_behavior_path_planner_node_interface.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_avoidance_by_lane_change_module/test/test_behavior_path_planner_node_interface.cpp
@@ -42,7 +42,7 @@ protected:
     (void)rclcpp::shutdown();
   }
 
-private:
+protected:
   std::shared_ptr<PlanningInterfaceTestManager> test_manager_;
   std::shared_ptr<BehaviorPathPlannerNode> test_target_node_;
 };

--- a/planning/behavior_path_planner/autoware_behavior_path_dynamic_obstacle_avoidance_module/test/test_behavior_path_planner_node_interface.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_dynamic_obstacle_avoidance_module/test/test_behavior_path_planner_node_interface.cpp
@@ -22,9 +22,22 @@ using autoware::behavior_path_planner::generateNode;
 using autoware::behavior_path_planner::generateTestManager;
 using autoware::behavior_path_planner::publishMandatoryTopics;
 
-TEST(PlanningModuleInterfaceTest, NodeTestWithExceptionRoute)
+class PlanningModuleInterfaceTest : public ::testing::Test
 {
-  rclcpp::init(0, nullptr);
+protected:
+  void SetUp() override
+  {
+    rclcpp::init(0, nullptr);
+  }
+
+  void TearDown() override
+  {
+    (void)rclcpp::shutdown();
+  }
+};
+
+TEST_F(PlanningModuleInterfaceTest, NodeTestWithExceptionRoute)
+{
   auto test_manager = generateTestManager();
   auto test_target_node = generateNode(
     {"dynamic_obstacle_avoidance"},
@@ -42,13 +55,10 @@ TEST(PlanningModuleInterfaceTest, NodeTestWithExceptionRoute)
   // test with empty route
   ASSERT_NO_THROW_WITH_ERROR_MSG(
     test_manager->testWithAbnormalRoute(test_target_node, input_route_topic));
-  rclcpp::shutdown();
 }
 
-TEST(PlanningModuleInterfaceTest, NodeTestWithOffTrackEgoPose)
+TEST_F(PlanningModuleInterfaceTest, NodeTestWithOffTrackEgoPose)
 {
-  rclcpp::init(0, nullptr);
-
   auto test_manager = generateTestManager();
   auto test_target_node = generateNode(
     {"dynamic_obstacle_avoidance"},
@@ -67,6 +77,4 @@ TEST(PlanningModuleInterfaceTest, NodeTestWithOffTrackEgoPose)
 
   ASSERT_NO_THROW_WITH_ERROR_MSG(
     test_manager->testWithOffTrackOdometry(test_target_node, input_odometry_topic));
-
-  rclcpp::shutdown();
 }

--- a/planning/behavior_path_planner/autoware_behavior_path_dynamic_obstacle_avoidance_module/test/test_behavior_path_planner_node_interface.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_dynamic_obstacle_avoidance_module/test/test_behavior_path_planner_node_interface.cpp
@@ -25,15 +25,9 @@ using autoware::behavior_path_planner::publishMandatoryTopics;
 class PlanningModuleInterfaceTest : public ::testing::Test
 {
 protected:
-  void SetUp() override
-  {
-    rclcpp::init(0, nullptr);
-  }
+  void SetUp() override { rclcpp::init(0, nullptr); }
 
-  void TearDown() override
-  {
-    (void)rclcpp::shutdown();
-  }
+  void TearDown() override { (void)rclcpp::shutdown(); }
 };
 
 TEST_F(PlanningModuleInterfaceTest, NodeTestWithExceptionRoute)

--- a/planning/behavior_path_planner/autoware_behavior_path_external_request_lane_change_module/test/test_behavior_path_planner_node_interface.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_external_request_lane_change_module/test/test_behavior_path_planner_node_interface.cpp
@@ -25,10 +25,22 @@ using autoware::behavior_path_planner::generateNode;
 using autoware::behavior_path_planner::generateTestManager;
 using autoware::behavior_path_planner::publishMandatoryTopics;
 
-TEST(PlanningModuleInterfaceTest, NodeTestWithExceptionRoute)
+class PlanningModuleInterfaceTest : public ::testing::Test
 {
-  rclcpp::init(0, nullptr);
+protected:
+  void SetUp() override
+  {
+    rclcpp::init(0, nullptr);
+  }
 
+  void TearDown() override
+  {
+    (void)rclcpp::shutdown();
+  }
+};
+
+TEST_F(PlanningModuleInterfaceTest, NodeTestWithExceptionRoute)
+{
   auto test_manager = generateTestManager();
   auto test_target_node = generateNode(
     {"lane_change"},
@@ -46,13 +58,10 @@ TEST(PlanningModuleInterfaceTest, NodeTestWithExceptionRoute)
   // test with empty route
   ASSERT_NO_THROW_WITH_ERROR_MSG(
     test_manager->testWithAbnormalRoute(test_target_node, input_route_topic));
-  rclcpp::shutdown();
 }
 
-TEST(PlanningModuleInterfaceTest, NodeTestWithOffTrackEgoPose)
+TEST_F(PlanningModuleInterfaceTest, NodeTestWithOffTrackEgoPose)
 {
-  rclcpp::init(0, nullptr);
-
   auto test_manager = generateTestManager();
   auto test_target_node = generateNode(
     {"lane_change"},
@@ -72,6 +81,4 @@ TEST(PlanningModuleInterfaceTest, NodeTestWithOffTrackEgoPose)
 
   ASSERT_NO_THROW_WITH_ERROR_MSG(
     test_manager->testWithOffTrackOdometry(test_target_node, input_odometry_topic));
-
-  rclcpp::shutdown();
 }

--- a/planning/behavior_path_planner/autoware_behavior_path_external_request_lane_change_module/test/test_behavior_path_planner_node_interface.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_external_request_lane_change_module/test/test_behavior_path_planner_node_interface.cpp
@@ -28,15 +28,9 @@ using autoware::behavior_path_planner::publishMandatoryTopics;
 class PlanningModuleInterfaceTest : public ::testing::Test
 {
 protected:
-  void SetUp() override
-  {
-    rclcpp::init(0, nullptr);
-  }
+  void SetUp() override { rclcpp::init(0, nullptr); }
 
-  void TearDown() override
-  {
-    (void)rclcpp::shutdown();
-  }
+  void TearDown() override { (void)rclcpp::shutdown(); }
 };
 
 TEST_F(PlanningModuleInterfaceTest, NodeTestWithExceptionRoute)

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/test/test_planning_factor.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/test/test_planning_factor.cpp
@@ -186,10 +186,12 @@ public:
 
   void TearDown() override
   {
-    test_manager_ = nullptr;
-    test_target_node_ = nullptr;
-    sub_planning_factor_ = nullptr;
-    planning_factor_msg_ = nullptr;
+    sub_planning_factor_.reset();
+    planning_factor_msg_.reset();
+    test_manager_.reset();
+    test_node_.reset();
+    test_target_node_.reset();
+
     rclcpp::shutdown();
   }
 

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/test/test_behavior_path_planner_node_interface.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/test/test_behavior_path_planner_node_interface.cpp
@@ -25,10 +25,22 @@ using autoware::behavior_path_planner::generateNode;
 using autoware::behavior_path_planner::generateTestManager;
 using autoware::behavior_path_planner::publishMandatoryTopics;
 
-TEST(PlanningModuleInterfaceTest, NodeTestWithExceptionRoute)
+class PlanningModuleInterfaceTest : public ::testing::Test
 {
-  rclcpp::init(0, nullptr);
+protected:
+  void SetUp() override
+  {
+    rclcpp::init(0, nullptr);
+  }
 
+  void TearDown() override
+  {
+    (void)rclcpp::shutdown();
+  }
+};
+
+TEST_F(PlanningModuleInterfaceTest, NodeTestWithExceptionRoute)
+{
   auto test_manager = generateTestManager();
   auto test_target_node = generateNode(
     {"lane_change"}, {"autoware::behavior_path_planner::LaneChangeRightModuleManager",
@@ -46,13 +58,10 @@ TEST(PlanningModuleInterfaceTest, NodeTestWithExceptionRoute)
   // test with empty route
   ASSERT_NO_THROW_WITH_ERROR_MSG(
     test_manager->testWithAbnormalRoute(test_target_node, input_route_topic));
-  rclcpp::shutdown();
 }
 
-TEST(PlanningModuleInterfaceTest, NodeTestWithOffTrackEgoPose)
+TEST_F(PlanningModuleInterfaceTest, NodeTestWithOffTrackEgoPose)
 {
-  rclcpp::init(0, nullptr);
-
   auto test_manager = generateTestManager();
   auto test_target_node = generateNode(
     {"lane_change"}, {"autoware::behavior_path_planner::LaneChangeRightModuleManager",
@@ -71,6 +80,4 @@ TEST(PlanningModuleInterfaceTest, NodeTestWithOffTrackEgoPose)
 
   ASSERT_NO_THROW_WITH_ERROR_MSG(
     test_manager->testWithOffTrackOdometry(test_target_node, input_odometry_topic));
-
-  rclcpp::shutdown();
 }

--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/test/test_behavior_path_planner_node_interface.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/test/test_behavior_path_planner_node_interface.cpp
@@ -28,15 +28,9 @@ using autoware::behavior_path_planner::publishMandatoryTopics;
 class PlanningModuleInterfaceTest : public ::testing::Test
 {
 protected:
-  void SetUp() override
-  {
-    rclcpp::init(0, nullptr);
-  }
+  void SetUp() override { rclcpp::init(0, nullptr); }
 
-  void TearDown() override
-  {
-    (void)rclcpp::shutdown();
-  }
+  void TearDown() override { (void)rclcpp::shutdown(); }
 };
 
 TEST_F(PlanningModuleInterfaceTest, NodeTestWithExceptionRoute)

--- a/planning/behavior_path_planner/autoware_behavior_path_planner/test/test_autoware_behavior_path_planner_node_interface.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner/test/test_autoware_behavior_path_planner_node_interface.cpp
@@ -29,15 +29,9 @@ using autoware::behavior_path_planner::publishMandatoryTopics;
 class PlanningModuleInterfaceTest : public ::testing::Test
 {
 protected:
-  void SetUp() override
-  {
-    rclcpp::init(0, nullptr);
-  }
+  void SetUp() override { rclcpp::init(0, nullptr); }
 
-  void TearDown() override
-  {
-    (void)rclcpp::shutdown();
-  }
+  void TearDown() override { (void)rclcpp::shutdown(); }
 };
 
 TEST_F(PlanningModuleInterfaceTest, NodeTestWithExceptionRoute)

--- a/planning/behavior_path_planner/autoware_behavior_path_planner/test/test_autoware_behavior_path_planner_node_interface.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner/test/test_autoware_behavior_path_planner_node_interface.cpp
@@ -26,9 +26,22 @@ using autoware::behavior_path_planner::generateNode;
 using autoware::behavior_path_planner::generateTestManager;
 using autoware::behavior_path_planner::publishMandatoryTopics;
 
-TEST(PlanningModuleInterfaceTest, NodeTestWithExceptionRoute)
+class PlanningModuleInterfaceTest : public ::testing::Test
 {
-  rclcpp::init(0, nullptr);
+protected:
+  void SetUp() override
+  {
+    rclcpp::init(0, nullptr);
+  }
+
+  void TearDown() override
+  {
+    (void)rclcpp::shutdown();
+  }
+};
+
+TEST_F(PlanningModuleInterfaceTest, NodeTestWithExceptionRoute)
+{
   auto test_manager = generateTestManager();
   auto test_target_node = generateNode({}, {});
 
@@ -44,13 +57,10 @@ TEST(PlanningModuleInterfaceTest, NodeTestWithExceptionRoute)
   // test with empty route
   ASSERT_NO_THROW_WITH_ERROR_MSG(
     test_manager->testWithAbnormalRoute(test_target_node, input_route_topic));
-  rclcpp::shutdown();
 }
 
-TEST(PlanningModuleInterfaceTest, NodeTestWithOffTrackEgoPose)
+TEST_F(PlanningModuleInterfaceTest, NodeTestWithOffTrackEgoPose)
 {
-  rclcpp::init(0, nullptr);
-
   auto test_manager = generateTestManager();
   auto test_target_node = generateNode({}, {});
   publishMandatoryTopics(test_manager, test_target_node);
@@ -67,6 +77,4 @@ TEST(PlanningModuleInterfaceTest, NodeTestWithOffTrackEgoPose)
 
   ASSERT_NO_THROW_WITH_ERROR_MSG(
     test_manager->testWithOffTrackOdometry(test_target_node, input_odometry_topic));
-
-  rclcpp::shutdown();
 }

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/test/test_behavior_path_planner_node_interface.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/test/test_behavior_path_planner_node_interface.cpp
@@ -28,15 +28,9 @@ using autoware::behavior_path_planner::publishMandatoryTopics;
 class PlanningModuleInterfaceTest : public ::testing::Test
 {
 protected:
-  void SetUp() override
-  {
-    rclcpp::init(0, nullptr);
-  }
+  void SetUp() override { rclcpp::init(0, nullptr); }
 
-  void TearDown() override
-  {
-    (void)rclcpp::shutdown();
-  }
+  void TearDown() override { (void)rclcpp::shutdown(); }
 };
 
 TEST_F(PlanningModuleInterfaceTest, NodeTestWithExceptionRoute)

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/test/test_behavior_path_planner_node_interface.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/test/test_behavior_path_planner_node_interface.cpp
@@ -25,9 +25,22 @@ using autoware::behavior_path_planner::generateNode;
 using autoware::behavior_path_planner::generateTestManager;
 using autoware::behavior_path_planner::publishMandatoryTopics;
 
-TEST(PlanningModuleInterfaceTest, NodeTestWithExceptionRoute)
+class PlanningModuleInterfaceTest : public ::testing::Test
 {
-  rclcpp::init(0, nullptr);
+protected:
+  void SetUp() override
+  {
+    rclcpp::init(0, nullptr);
+  }
+
+  void TearDown() override
+  {
+    (void)rclcpp::shutdown();
+  }
+};
+
+TEST_F(PlanningModuleInterfaceTest, NodeTestWithExceptionRoute)
+{
   auto test_manager = generateTestManager();
   auto test_target_node =
     generateNode({"side_shift"}, {"autoware::behavior_path_planner::SideShiftModuleManager"});
@@ -44,13 +57,10 @@ TEST(PlanningModuleInterfaceTest, NodeTestWithExceptionRoute)
   // test with empty route
   ASSERT_NO_THROW_WITH_ERROR_MSG(
     test_manager->testWithAbnormalRoute(test_target_node, input_route_topic));
-  rclcpp::shutdown();
 }
 
-TEST(PlanningModuleInterfaceTest, NodeTestWithOffTrackEgoPose)
+TEST_F(PlanningModuleInterfaceTest, NodeTestWithOffTrackEgoPose)
 {
-  rclcpp::init(0, nullptr);
-
   auto test_manager = generateTestManager();
   auto test_target_node =
     generateNode({"side_shift"}, {"autoware::behavior_path_planner::SideShiftModuleManager"});
@@ -68,6 +78,4 @@ TEST(PlanningModuleInterfaceTest, NodeTestWithOffTrackEgoPose)
 
   ASSERT_NO_THROW_WITH_ERROR_MSG(
     test_manager->testWithOffTrackOdometry(test_target_node, input_odometry_topic));
-
-  rclcpp::shutdown();
 }

--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/test/test_behavior_path_planner_node_interface.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/test/test_behavior_path_planner_node_interface.cpp
@@ -22,10 +22,22 @@ using autoware::behavior_path_planner::generateNode;
 using autoware::behavior_path_planner::generateTestManager;
 using autoware::behavior_path_planner::publishMandatoryTopics;
 
-TEST(PlanningModuleInterfaceTest, NodeTestWithExceptionRoute)
+class PlanningModuleInterfaceTest : public ::testing::Test
 {
-  rclcpp::init(0, nullptr);
+protected:
+  void SetUp() override
+  {
+    rclcpp::init(0, nullptr);
+  }
 
+  void TearDown() override
+  {
+    (void)rclcpp::shutdown();
+  }
+};
+
+TEST_F(PlanningModuleInterfaceTest, NodeTestWithExceptionRoute)
+{
   auto test_manager = generateTestManager();
   auto test_target_node = generateNode(
     {"static_obstacle_avoidance"},
@@ -42,13 +54,10 @@ TEST(PlanningModuleInterfaceTest, NodeTestWithExceptionRoute)
   // test with empty route
   ASSERT_NO_THROW_WITH_ERROR_MSG(
     test_manager->testWithAbnormalRoute(test_target_node, input_route_topic));
-  rclcpp::shutdown();
 }
 
-TEST(PlanningModuleInterfaceTest, NodeTestWithOffTrackEgoPose)
+TEST_F(PlanningModuleInterfaceTest, NodeTestWithOffTrackEgoPose)
 {
-  rclcpp::init(0, nullptr);
-
   auto test_manager = generateTestManager();
   auto test_target_node = generateNode(
     {"static_obstacle_avoidance"},
@@ -67,6 +76,4 @@ TEST(PlanningModuleInterfaceTest, NodeTestWithOffTrackEgoPose)
 
   ASSERT_NO_THROW_WITH_ERROR_MSG(
     test_manager->testWithOffTrackOdometry(test_target_node, input_odometry_topic));
-
-  rclcpp::shutdown();
 }

--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/test/test_behavior_path_planner_node_interface.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/test/test_behavior_path_planner_node_interface.cpp
@@ -25,15 +25,9 @@ using autoware::behavior_path_planner::publishMandatoryTopics;
 class PlanningModuleInterfaceTest : public ::testing::Test
 {
 protected:
-  void SetUp() override
-  {
-    rclcpp::init(0, nullptr);
-  }
+  void SetUp() override { rclcpp::init(0, nullptr); }
 
-  void TearDown() override
-  {
-    (void)rclcpp::shutdown();
-  }
+  void TearDown() override { (void)rclcpp::shutdown(); }
 };
 
 TEST_F(PlanningModuleInterfaceTest, NodeTestWithExceptionRoute)

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/test/test_node_interface.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/test/test_node_interface.cpp
@@ -26,15 +26,9 @@ namespace autoware::behavior_velocity_planner
 class PlanningModuleInterfaceTest : public ::testing::Test
 {
 protected:
-  void SetUp() override
-  {
-    rclcpp::init(0, nullptr);
-  }
+  void SetUp() override { rclcpp::init(0, nullptr); }
 
-  void TearDown() override
-  {
-    (void)rclcpp::shutdown();
-  }
+  void TearDown() override { (void)rclcpp::shutdown(); }
 };
 
 TEST_F(PlanningModuleInterfaceTest, NodeTestWithExceptionPathWithLaneID)

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/test/test_node_interface.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_blind_spot_module/test/test_node_interface.cpp
@@ -23,9 +23,22 @@
 
 namespace autoware::behavior_velocity_planner
 {
-TEST(PlanningModuleInterfaceTest, NodeTestWithExceptionPathWithLaneID)
+class PlanningModuleInterfaceTest : public ::testing::Test
 {
-  rclcpp::init(0, nullptr);
+protected:
+  void SetUp() override
+  {
+    rclcpp::init(0, nullptr);
+  }
+
+  void TearDown() override
+  {
+    (void)rclcpp::shutdown();
+  }
+};
+
+TEST_F(PlanningModuleInterfaceTest, NodeTestWithExceptionPathWithLaneID)
+{
   auto test_manager = autoware::behavior_velocity_planner::generateTestManager();
   auto test_target_node = autoware::behavior_velocity_planner::generateNode({});
 
@@ -42,13 +55,10 @@ TEST(PlanningModuleInterfaceTest, NodeTestWithExceptionPathWithLaneID)
   // test with empty path_with_lane_id
   ASSERT_NO_THROW_WITH_ERROR_MSG(
     test_manager->testWithAbnormalPathWithLaneId(test_target_node, input_path_with_lane_id_topic));
-  rclcpp::shutdown();
 }
 
-TEST(PlanningModuleInterfaceTest, NodeTestWithOffTrackEgoPose)
+TEST_F(PlanningModuleInterfaceTest, NodeTestWithOffTrackEgoPose)
 {
-  rclcpp::init(0, nullptr);
-
   const auto plugin_info_vec = {autoware::behavior_velocity_planner::PluginInfo{
     "blind_spot", "autoware::behavior_velocity_planner::BlindSpotModulePlugin"}};
 
@@ -69,7 +79,5 @@ TEST(PlanningModuleInterfaceTest, NodeTestWithOffTrackEgoPose)
 
   ASSERT_NO_THROW_WITH_ERROR_MSG(
     test_manager->testWithOffTrackOdometry(test_target_node, input_odometry_topic));
-
-  rclcpp::shutdown();
 }
 }  // namespace autoware::behavior_velocity_planner

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/test/test_node_interface.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/test/test_node_interface.cpp
@@ -26,15 +26,9 @@ namespace autoware::behavior_velocity_planner
 class PlanningModuleInterfaceTest : public ::testing::Test
 {
 protected:
-  void SetUp() override
-  {
-    rclcpp::init(0, nullptr);
-  }
+  void SetUp() override { rclcpp::init(0, nullptr); }
 
-  void TearDown() override
-  {
-    (void)rclcpp::shutdown();
-  }
+  void TearDown() override { (void)rclcpp::shutdown(); }
 };
 
 TEST_F(PlanningModuleInterfaceTest, NodeTestWithExceptionPathWithLaneID)

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/test/test_node_interface.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/test/test_node_interface.cpp
@@ -23,9 +23,22 @@
 
 namespace autoware::behavior_velocity_planner
 {
-TEST(PlanningModuleInterfaceTest, NodeTestWithExceptionPathWithLaneID)
+class PlanningModuleInterfaceTest : public ::testing::Test
 {
-  rclcpp::init(0, nullptr);
+protected:
+  void SetUp() override
+  {
+    rclcpp::init(0, nullptr);
+  }
+
+  void TearDown() override
+  {
+    (void)rclcpp::shutdown();
+  }
+};
+
+TEST_F(PlanningModuleInterfaceTest, NodeTestWithExceptionPathWithLaneID)
+{
   auto test_manager = autoware::behavior_velocity_planner::generateTestManager();
   auto test_target_node = autoware::behavior_velocity_planner::generateNode({});
 
@@ -42,13 +55,10 @@ TEST(PlanningModuleInterfaceTest, NodeTestWithExceptionPathWithLaneID)
   // test with empty path_with_lane_id
   ASSERT_NO_THROW_WITH_ERROR_MSG(
     test_manager->testWithAbnormalPathWithLaneId(test_target_node, input_path_with_lane_id_topic));
-  rclcpp::shutdown();
 }
 
-TEST(PlanningModuleInterfaceTest, NodeTestWithOffTrackEgoPose)
+TEST_F(PlanningModuleInterfaceTest, NodeTestWithOffTrackEgoPose)
 {
-  rclcpp::init(0, nullptr);
-
   const auto plugin_info_vec = {autoware::behavior_velocity_planner::PluginInfo{
     "crosswalk", "autoware::behavior_velocity_planner::CrosswalkModulePlugin"}};
 
@@ -69,7 +79,5 @@ TEST(PlanningModuleInterfaceTest, NodeTestWithOffTrackEgoPose)
 
   ASSERT_NO_THROW_WITH_ERROR_MSG(
     test_manager->testWithOffTrackOdometry(test_target_node, input_odometry_topic));
-
-  rclcpp::shutdown();
 }
 }  // namespace autoware::behavior_velocity_planner

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_detection_area_module/test/test_node_interface.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_detection_area_module/test/test_node_interface.cpp
@@ -26,15 +26,9 @@ namespace autoware::behavior_velocity_planner
 class PlanningModuleInterfaceTest : public ::testing::Test
 {
 protected:
-  void SetUp() override
-  {
-    rclcpp::init(0, nullptr);
-  }
+  void SetUp() override { rclcpp::init(0, nullptr); }
 
-  void TearDown() override
-  {
-    (void)rclcpp::shutdown();
-  }
+  void TearDown() override { (void)rclcpp::shutdown(); }
 };
 
 TEST_F(PlanningModuleInterfaceTest, NodeTestWithExceptionPathWithLaneID)

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_detection_area_module/test/test_node_interface.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_detection_area_module/test/test_node_interface.cpp
@@ -23,9 +23,22 @@
 
 namespace autoware::behavior_velocity_planner
 {
-TEST(PlanningModuleInterfaceTest, NodeTestWithExceptionPathWithLaneID)
+class PlanningModuleInterfaceTest : public ::testing::Test
 {
-  rclcpp::init(0, nullptr);
+protected:
+  void SetUp() override
+  {
+    rclcpp::init(0, nullptr);
+  }
+
+  void TearDown() override
+  {
+    (void)rclcpp::shutdown();
+  }
+};
+
+TEST_F(PlanningModuleInterfaceTest, NodeTestWithExceptionPathWithLaneID)
+{
   auto test_manager = autoware::behavior_velocity_planner::generateTestManager();
   auto test_target_node = autoware::behavior_velocity_planner::generateNode({});
 
@@ -42,13 +55,10 @@ TEST(PlanningModuleInterfaceTest, NodeTestWithExceptionPathWithLaneID)
   // test with empty path_with_lane_id
   ASSERT_NO_THROW_WITH_ERROR_MSG(
     test_manager->testWithAbnormalPathWithLaneId(test_target_node, input_path_with_lane_id_topic));
-  rclcpp::shutdown();
 }
 
-TEST(PlanningModuleInterfaceTest, NodeTestWithOffTrackEgoPose)
+TEST_F(PlanningModuleInterfaceTest, NodeTestWithOffTrackEgoPose)
 {
-  rclcpp::init(0, nullptr);
-
   const auto plugin_info_vec = {autoware::behavior_velocity_planner::PluginInfo{
     "detection_area", "autoware::behavior_velocity_planner::DetectionAreaModulePlugin"}};
 
@@ -69,7 +79,5 @@ TEST(PlanningModuleInterfaceTest, NodeTestWithOffTrackEgoPose)
 
   ASSERT_NO_THROW_WITH_ERROR_MSG(
     test_manager->testWithOffTrackOdometry(test_target_node, input_odometry_topic));
-
-  rclcpp::shutdown();
 }
 }  // namespace autoware::behavior_velocity_planner

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/test/test_node_interface.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/test/test_node_interface.cpp
@@ -26,15 +26,9 @@ namespace autoware::behavior_velocity_planner
 class PlanningModuleInterfaceTest : public ::testing::Test
 {
 protected:
-  void SetUp() override
-  {
-    rclcpp::init(0, nullptr);
-  }
+  void SetUp() override { rclcpp::init(0, nullptr); }
 
-  void TearDown() override
-  {
-    (void)rclcpp::shutdown();
-  }
+  void TearDown() override { (void)rclcpp::shutdown(); }
 };
 
 TEST_F(PlanningModuleInterfaceTest, NodeTestWithExceptionPathWithLaneID)

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/test/test_node_interface.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/test/test_node_interface.cpp
@@ -23,9 +23,22 @@
 
 namespace autoware::behavior_velocity_planner
 {
-TEST(PlanningModuleInterfaceTest, NodeTestWithExceptionPathWithLaneID)
+class PlanningModuleInterfaceTest : public ::testing::Test
 {
-  rclcpp::init(0, nullptr);
+protected:
+  void SetUp() override
+  {
+    rclcpp::init(0, nullptr);
+  }
+
+  void TearDown() override
+  {
+    (void)rclcpp::shutdown();
+  }
+};
+
+TEST_F(PlanningModuleInterfaceTest, NodeTestWithExceptionPathWithLaneID)
+{
   auto test_manager = autoware::behavior_velocity_planner::generateTestManager();
   auto test_target_node = autoware::behavior_velocity_planner::generateNode({});
 
@@ -42,13 +55,10 @@ TEST(PlanningModuleInterfaceTest, NodeTestWithExceptionPathWithLaneID)
   // test with empty path_with_lane_id
   ASSERT_NO_THROW_WITH_ERROR_MSG(
     test_manager->testWithAbnormalPathWithLaneId(test_target_node, input_path_with_lane_id_topic));
-  rclcpp::shutdown();
 }
 
-TEST(PlanningModuleInterfaceTest, NodeTestWithOffTrackEgoPose)
+TEST_F(PlanningModuleInterfaceTest, NodeTestWithOffTrackEgoPose)
 {
-  rclcpp::init(0, nullptr);
-
   const auto plugin_info_vec = {autoware::behavior_velocity_planner::PluginInfo{
     "intersection", "autoware::behavior_velocity_planner::IntersectionModulePlugin"}};
 
@@ -69,7 +79,5 @@ TEST(PlanningModuleInterfaceTest, NodeTestWithOffTrackEgoPose)
 
   ASSERT_NO_THROW_WITH_ERROR_MSG(
     test_manager->testWithOffTrackOdometry(test_target_node, input_odometry_topic));
-
-  rclcpp::shutdown();
 }
 }  // namespace autoware::behavior_velocity_planner

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_no_stopping_area_module/test/test_node_interface.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_no_stopping_area_module/test/test_node_interface.cpp
@@ -26,15 +26,9 @@ namespace autoware::behavior_velocity_planner
 class PlanningModuleInterfaceTest : public ::testing::Test
 {
 protected:
-  void SetUp() override
-  {
-    rclcpp::init(0, nullptr);
-  }
+  void SetUp() override { rclcpp::init(0, nullptr); }
 
-  void TearDown() override
-  {
-    (void)rclcpp::shutdown();
-  }
+  void TearDown() override { (void)rclcpp::shutdown(); }
 };
 
 TEST_F(PlanningModuleInterfaceTest, NodeTestWithExceptionPathWithLaneID)

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_no_stopping_area_module/test/test_node_interface.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_no_stopping_area_module/test/test_node_interface.cpp
@@ -23,9 +23,22 @@
 
 namespace autoware::behavior_velocity_planner
 {
-TEST(PlanningModuleInterfaceTest, NodeTestWithExceptionPathWithLaneID)
+class PlanningModuleInterfaceTest : public ::testing::Test
 {
-  rclcpp::init(0, nullptr);
+protected:
+  void SetUp() override
+  {
+    rclcpp::init(0, nullptr);
+  }
+
+  void TearDown() override
+  {
+    (void)rclcpp::shutdown();
+  }
+};
+
+TEST_F(PlanningModuleInterfaceTest, NodeTestWithExceptionPathWithLaneID)
+{
   auto test_manager = autoware::behavior_velocity_planner::generateTestManager();
   auto test_target_node = autoware::behavior_velocity_planner::generateNode({});
 
@@ -42,13 +55,10 @@ TEST(PlanningModuleInterfaceTest, NodeTestWithExceptionPathWithLaneID)
   // test with empty path_with_lane_id
   ASSERT_NO_THROW_WITH_ERROR_MSG(
     test_manager->testWithAbnormalPathWithLaneId(test_target_node, input_path_with_lane_id_topic));
-  rclcpp::shutdown();
 }
 
-TEST(PlanningModuleInterfaceTest, NodeTestWithOffTrackEgoPose)
+TEST_F(PlanningModuleInterfaceTest, NodeTestWithOffTrackEgoPose)
 {
-  rclcpp::init(0, nullptr);
-
   const auto plugin_info_vec = {autoware::behavior_velocity_planner::PluginInfo{
     "no_stopping_area", "autoware::behavior_velocity_planner::NoStoppingAreaModulePlugin"}};
 
@@ -69,7 +79,5 @@ TEST(PlanningModuleInterfaceTest, NodeTestWithOffTrackEgoPose)
 
   ASSERT_NO_THROW_WITH_ERROR_MSG(
     test_manager->testWithOffTrackOdometry(test_target_node, input_odometry_topic));
-
-  rclcpp::shutdown();
 }
 }  // namespace autoware::behavior_velocity_planner

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/test/test_node_interface.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/test/test_node_interface.cpp
@@ -26,15 +26,9 @@ namespace autoware::behavior_velocity_planner
 class PlanningModuleInterfaceTest : public ::testing::Test
 {
 protected:
-  void SetUp() override
-  {
-    rclcpp::init(0, nullptr);
-  }
+  void SetUp() override { rclcpp::init(0, nullptr); }
 
-  void TearDown() override
-  {
-    (void)rclcpp::shutdown();
-  }
+  void TearDown() override { (void)rclcpp::shutdown(); }
 };
 
 TEST_F(PlanningModuleInterfaceTest, NodeTestWithExceptionPathWithLaneID)

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/test/test_node_interface.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/test/test_node_interface.cpp
@@ -23,9 +23,22 @@
 
 namespace autoware::behavior_velocity_planner
 {
-TEST(PlanningModuleInterfaceTest, NodeTestWithExceptionPathWithLaneID)
+class PlanningModuleInterfaceTest : public ::testing::Test
 {
-  rclcpp::init(0, nullptr);
+protected:
+  void SetUp() override
+  {
+    rclcpp::init(0, nullptr);
+  }
+
+  void TearDown() override
+  {
+    (void)rclcpp::shutdown();
+  }
+};
+
+TEST_F(PlanningModuleInterfaceTest, NodeTestWithExceptionPathWithLaneID)
+{
   auto test_manager = autoware::behavior_velocity_planner::generateTestManager();
   auto test_target_node = autoware::behavior_velocity_planner::generateNode({});
 
@@ -42,13 +55,10 @@ TEST(PlanningModuleInterfaceTest, NodeTestWithExceptionPathWithLaneID)
   // test with empty path_with_lane_id
   ASSERT_NO_THROW_WITH_ERROR_MSG(
     test_manager->testWithAbnormalPathWithLaneId(test_target_node, input_path_with_lane_id_topic));
-  rclcpp::shutdown();
 }
 
-TEST(PlanningModuleInterfaceTest, NodeTestWithOffTrackEgoPose)
+TEST_F(PlanningModuleInterfaceTest, NodeTestWithOffTrackEgoPose)
 {
-  rclcpp::init(0, nullptr);
-
   const auto plugin_info_vec = {autoware::behavior_velocity_planner::PluginInfo{
     "traffic_light", "autoware::behavior_velocity_planner::TrafficLightModulePlugin"}};
 
@@ -69,7 +79,5 @@ TEST(PlanningModuleInterfaceTest, NodeTestWithOffTrackEgoPose)
 
   ASSERT_NO_THROW_WITH_ERROR_MSG(
     test_manager->testWithOffTrackOdometry(test_target_node, input_odometry_topic));
-
-  rclcpp::shutdown();
 }
 }  // namespace autoware::behavior_velocity_planner

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_virtual_traffic_light_module/test/test_node_interface.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_virtual_traffic_light_module/test/test_node_interface.cpp
@@ -39,10 +39,22 @@ void publishVirtualTrafficLightState(
   autoware::test_utils::spinSomeNodes(test_node, target_node, 3);
 }
 
-TEST(PlanningModuleInterfaceTest, NodeTestWithExceptionPathWithLaneID)
+class PlanningModuleInterfaceTest : public ::testing::Test
 {
-  rclcpp::init(0, nullptr);
+protected:
+  void SetUp() override
+  {
+    rclcpp::init(0, nullptr);
+  }
 
+  void TearDown() override
+  {
+    (void)rclcpp::shutdown();
+  }
+};
+
+TEST_F(PlanningModuleInterfaceTest, NodeTestWithExceptionPathWithLaneID)
+{
   const auto plugin_info_vec = {autoware::behavior_velocity_planner::PluginInfo{
     "virtual_traffic_light",
     "autoware::behavior_velocity_planner::VirtualTrafficLightModulePlugin"}};
@@ -64,13 +76,10 @@ TEST(PlanningModuleInterfaceTest, NodeTestWithExceptionPathWithLaneID)
   // test with empty path_with_lane_id
   ASSERT_NO_THROW_WITH_ERROR_MSG(
     test_manager->testWithAbnormalPathWithLaneId(test_target_node, input_path_with_lane_id_topic));
-  rclcpp::shutdown();
 }
 
-TEST(PlanningModuleInterfaceTest, NodeTestWithOffTrackEgoPose)
+TEST_F(PlanningModuleInterfaceTest, NodeTestWithOffTrackEgoPose)
 {
-  rclcpp::init(0, nullptr);
-
   const auto plugin_info_vec = {autoware::behavior_velocity_planner::PluginInfo{
     "virtual_traffic_light",
     "autoware::behavior_velocity_planner::VirtualTrafficLightModulePlugin"}};
@@ -94,7 +103,5 @@ TEST(PlanningModuleInterfaceTest, NodeTestWithOffTrackEgoPose)
 
   ASSERT_NO_THROW_WITH_ERROR_MSG(
     test_manager->testWithOffTrackOdometry(test_target_node, input_odometry_topic));
-
-  rclcpp::shutdown();
 }
 }  // namespace autoware::behavior_velocity_planner

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_virtual_traffic_light_module/test/test_node_interface.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_virtual_traffic_light_module/test/test_node_interface.cpp
@@ -42,15 +42,9 @@ void publishVirtualTrafficLightState(
 class PlanningModuleInterfaceTest : public ::testing::Test
 {
 protected:
-  void SetUp() override
-  {
-    rclcpp::init(0, nullptr);
-  }
+  void SetUp() override { rclcpp::init(0, nullptr); }
 
-  void TearDown() override
-  {
-    (void)rclcpp::shutdown();
-  }
+  void TearDown() override { (void)rclcpp::shutdown(); }
 };
 
 TEST_F(PlanningModuleInterfaceTest, NodeTestWithExceptionPathWithLaneID)

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_walkway_module/test/test_node_interface.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_walkway_module/test/test_node_interface.cpp
@@ -26,15 +26,9 @@ namespace autoware::behavior_velocity_planner
 class PlanningModuleInterfaceTest : public ::testing::Test
 {
 protected:
-  void SetUp() override
-  {
-    rclcpp::init(0, nullptr);
-  }
+  void SetUp() override { rclcpp::init(0, nullptr); }
 
-  void TearDown() override
-  {
-    (void)rclcpp::shutdown();
-  }
+  void TearDown() override { (void)rclcpp::shutdown(); }
 };
 
 TEST_F(PlanningModuleInterfaceTest, NodeTestWithExceptionPathWithLaneID)

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_walkway_module/test/test_node_interface.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_walkway_module/test/test_node_interface.cpp
@@ -23,9 +23,22 @@
 
 namespace autoware::behavior_velocity_planner
 {
-TEST(PlanningModuleInterfaceTest, NodeTestWithExceptionPathWithLaneID)
+class PlanningModuleInterfaceTest : public ::testing::Test
 {
-  rclcpp::init(0, nullptr);
+protected:
+  void SetUp() override
+  {
+    rclcpp::init(0, nullptr);
+  }
+
+  void TearDown() override
+  {
+    (void)rclcpp::shutdown();
+  }
+};
+
+TEST_F(PlanningModuleInterfaceTest, NodeTestWithExceptionPathWithLaneID)
+{
   auto test_manager = autoware::behavior_velocity_planner::generateTestManager();
   auto test_target_node = autoware::behavior_velocity_planner::generateNode({});
 
@@ -42,13 +55,10 @@ TEST(PlanningModuleInterfaceTest, NodeTestWithExceptionPathWithLaneID)
   // test with empty path_with_lane_id
   ASSERT_NO_THROW_WITH_ERROR_MSG(
     test_manager->testWithAbnormalPathWithLaneId(test_target_node, input_path_with_lane_id_topic));
-  rclcpp::shutdown();
 }
 
-TEST(PlanningModuleInterfaceTest, NodeTestWithOffTrackEgoPose)
+TEST_F(PlanningModuleInterfaceTest, NodeTestWithOffTrackEgoPose)
 {
-  rclcpp::init(0, nullptr);
-
   const auto plugin_info_vec = {autoware::behavior_velocity_planner::PluginInfo{
     "walkway", "autoware::behavior_velocity_planner::WalkwayModulePlugin"}};
 
@@ -69,7 +79,5 @@ TEST(PlanningModuleInterfaceTest, NodeTestWithOffTrackEgoPose)
 
   ASSERT_NO_THROW_WITH_ERROR_MSG(
     test_manager->testWithOffTrackOdometry(test_target_node, input_odometry_topic));
-
-  rclcpp::shutdown();
 }
 }  // namespace autoware::behavior_velocity_planner

--- a/planning/planning_validator/autoware_planning_validator/test/src/test_planning_validator_node_interface.cpp
+++ b/planning/planning_validator/autoware_planning_validator/test/src/test_planning_validator_node_interface.cpp
@@ -80,15 +80,9 @@ void publishMandatoryTopics(
 class PlanningModuleInterfaceTest : public ::testing::Test
 {
 protected:
-  void SetUp() override
-  {
-    rclcpp::init(0, nullptr);
-  }
+  void SetUp() override { rclcpp::init(0, nullptr); }
 
-  void TearDown() override
-  {
-    (void)rclcpp::shutdown();
-  }
+  void TearDown() override { (void)rclcpp::shutdown(); }
 };
 
 TEST_F(PlanningModuleInterfaceTest, NodeTestWithExceptionTrajectory)

--- a/planning/planning_validator/autoware_planning_validator/test/src/test_planning_validator_node_interface.cpp
+++ b/planning/planning_validator/autoware_planning_validator/test/src/test_planning_validator_node_interface.cpp
@@ -77,7 +77,21 @@ void publishMandatoryTopics(
     autoware::test_utils::makeBehaviorNormalRoute());
 }
 
-TEST(PlanningModuleInterfaceTest, NodeTestWithExceptionTrajectory)
+class PlanningModuleInterfaceTest : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    rclcpp::init(0, nullptr);
+  }
+
+  void TearDown() override
+  {
+    (void)rclcpp::shutdown();
+  }
+};
+
+TEST_F(PlanningModuleInterfaceTest, NodeTestWithExceptionTrajectory)
 {
   auto test_manager = generateTestManager();
   auto test_target_node = generateNode();
@@ -95,7 +109,7 @@ TEST(PlanningModuleInterfaceTest, NodeTestWithExceptionTrajectory)
     test_manager->testWithAbnormalTrajectory(test_target_node, input_trajectory_topic));
 }
 
-TEST(PlanningModuleInterfaceTest, NodeTestWithOffTrackEgoPose)
+TEST_F(PlanningModuleInterfaceTest, NodeTestWithOffTrackEgoPose)
 {
   auto test_manager = generateTestManager();
   auto test_target_node = generateNode();


### PR DESCRIPTION
## Description

This PR fixes "SEVERE WARNING" messages observed during the execution of unit tests in `behavior_path_planner` and `autoware_freespace_planner`.

The warning `class_loader.ClassLoader: SEVERE WARNING!!! Attempting to unload library while objects created by this loader exist in the heap!` occurs when `rclcpp::shutdown()` is called directly in the test body while objects (like nodes loaded via plugins) are still in scope.
(The warning can be found in the test results of [PR 12251](https://github.com/autowarefoundation/autoware_universe/pull/12251) )

To resolve this, the tests have been refactored to use a Google Test fixture (`PlanningModuleInterfaceTest`). The `rclcpp` initialization and shutdown are now handled in `SetUp()` and `TearDown()` respectively. This ensures that the test body scope is exited (and local objects are destroyed) before `rclcpp::shutdown()` is invoked.

Additionally, this stability improvement allows us to re-enable the `DISABLED_` tests in `autoware_freespace_planner`, which were previously disabled due to random failures likely caused by this lifecycle issue.

Affected packages:
- `autoware_behavior_path_avoidance_by_lane_change_module`
- `autoware_behavior_path_dynamic_obstacle_avoidance_module`
- `autoware_behavior_path_external_request_lane_change_module`
- `autoware_behavior_path_lane_change_module`
- `autoware_behavior_path_planner`
- `autoware_behavior_path_side_shift_module`
- `autoware_behavior_path_static_obstacle_avoidance_module`
- `autoware_freespace_planner`

## Related links

**Parent Issue:**

- Link

## How was this PR tested?

Ran unit tests for the affected packages to verify the warnings are resolved and tests pass.

```bash
colcon test --packages-select \
  autoware_behavior_path_avoidance_by_lane_change_module \
  autoware_behavior_path_dynamic_obstacle_avoidance_module \
  autoware_behavior_path_external_request_lane_change_module \
  autoware_behavior_path_lane_change_module \
  autoware_behavior_path_planner \
  autoware_behavior_path_side_shift_module \
  autoware_behavior_path_static_obstacle_avoidance_module \
  autoware_freespace_planner \
  --event-handlers console_direct+
```

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
