### PR TITLE
fix(autoware_scenario_simulator_v2_adapter): skip publishing metrics with UUID

### DIFF
--- a/evaluator/autoware_planning_evaluator/config/planning_evaluator.param.yaml
+++ b/evaluator/autoware_planning_evaluator/config/planning_evaluator.param.yaml
@@ -68,7 +68,7 @@
         max_time_s: 3.0 # [s] maximum time ahead of ego along the trajectory to use for calculation
 
     obstacle: # parameters for obstacle metrics calculation
-      worst_only: true # if true, only the worst obstacle metric value is published
+      worst_only: false # if true, only the worst obstacle metric value is published
       use_ego_traj_vel: false # if true, the planned trajectory velocity is used
       collision_thr_m: 0.0 # [m] distance threshold to consider a collision occurs between object footprints and ego trajectory footprints
       stop_velocity_mps: 0.2777 # [m/s] velocity threshold to consider the object or ego is static, used for speed up the calculation

--- a/evaluator/autoware_planning_evaluator/include/autoware/planning_evaluator/obstacle_metrics_calculator.hpp
+++ b/evaluator/autoware_planning_evaluator/include/autoware/planning_evaluator/obstacle_metrics_calculator.hpp
@@ -191,7 +191,7 @@ class ObstacleMetricsCalculator
 public:
   struct Parameters
   {
-    bool worst_only = true;
+    bool worst_only = false;
 
     // for metrics calculation
     bool use_ego_traj_vel = false;

--- a/evaluator/autoware_scenario_simulator_v2_adapter/src/converter_node.cpp
+++ b/evaluator/autoware_scenario_simulator_v2_adapter/src/converter_node.cpp
@@ -74,8 +74,12 @@ MetricConverter::MetricConverter(const rclcpp::NodeOptions & node_options)
 void MetricConverter::onMetrics(
   const MetricArray::ConstSharedPtr metrics_msg, const std::string & base_topic_name)
 {
+  static const std::regex uuid_pattern{R"(\/[0-9a-fA-F]{32}(\/|$))"};
   for (const auto & metric : metrics_msg->metric_array) {
     std::string metric_name = base_topic_name + (metric.name.empty() ? "" : "/" + metric.name);
+    if (std::regex_search(metric_name, uuid_pattern)) {
+      continue;
+    }
     const auto valid_topic_name = removeInvalidTopicString(metric_name);
     getPublisher(valid_topic_name)->publish(createUserDefinedValue(metric));
   }


### PR DESCRIPTION
## Description

autoware_scenario_simulator_v2_adapter are trying to create massive topics for publishing metrics with UUID, which is unnecessary and unacceptable, this PR skip those publishing, and then we can disable `worst_only` of planning_evaluator's obstacle metrics

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
Psim


## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
