### PR TITLE
feat(traffic_light): support arrow-aware passing judgment on yellow signal in bvp's experimental module

### DIFF
--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/src/experimental/manager.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/src/experimental/manager.cpp
@@ -14,6 +14,8 @@
 
 #include "manager.hpp"
 
+#include <autoware/lanelet2_utils/intersection.hpp>
+
 #include <limits>
 #include <memory>
 #include <set>
@@ -41,6 +43,8 @@ TrafficLightModuleManager::TrafficLightModuleManager(rclcpp::Node & node)
     get_or_declare_parameter<double>(node, ns + ".yellow_lamp_period");
   planner_param_.yellow_light_stop_velocity =
     get_or_declare_parameter<double>(node, ns + ".yellow_light_stop_velocity");
+  planner_param_.enable_arrow_aware_yellow_passing =
+    get_or_declare_parameter<bool>(node, ns + ".enable_arrow_aware_yellow_passing");
   planner_param_.min_behind_dist_to_stop_for_restart_suppression =
     get_or_declare_parameter<double>(node, ns + ".restart_suppression.min_behind_distance_to_stop");
   planner_param_.max_behind_dist_to_stop_for_restart_suppression =
@@ -101,7 +105,8 @@ void TrafficLightModuleManager::launchNewModules(
   PathWithLaneId path_msg;
   path_msg.points = path.restore();
 
-  for (const auto & traffic_light_reg_elem : planning_utils::getRegElemMapOnPath<TrafficLight>(
+  for (const auto & traffic_light_reg_elem :
+       planning_utils::getRegElemMapOnPath<lanelet::autoware::AutowareTrafficLight>(
          path_msg, planner_data.route_handler_->getLaneletMapPtr(),
          planner_data.current_odometry->pose)) {
     const auto stop_line = traffic_light_reg_elem.first->stopLine();
@@ -113,15 +118,19 @@ void TrafficLightModuleManager::launchNewModules(
       continue;
     }
 
-    // Use lanelet_id to unregister module when the route is changed
+    const auto & lane = traffic_light_reg_elem.second;
+    const bool is_turn_lane = autoware::experimental::lanelet2_utils::is_left_direction(lane) ||
+                              autoware::experimental::lanelet2_utils::is_right_direction(lane);
+
+    const bool has_static_arrow = hasStaticArrow(traffic_light_reg_elem.first);
     const auto module_id = traffic_light_reg_elem.second.id();
-    auto existing_module = getRegisteredAssociatedModule(module_id, planner_data);
+    auto existing_module = this->getRegisteredAssociatedModule(module_id, planner_data);
     if (!existing_module) {
       registerModule(
         std::make_shared<TrafficLightModule>(
           module_id, *(traffic_light_reg_elem.first), traffic_light_reg_elem.second, *stop_line,
-          planner_param_, logger_.get_child("traffic_light_module"), clock_, time_keeper_,
-          planning_factor_interface_),
+          is_turn_lane, has_static_arrow, planner_param_, logger_.get_child("traffic_light_module"),
+          clock_, time_keeper_, planning_factor_interface_),
         planner_data);
       generate_uuid(module_id);
       updateRTCStatus(
@@ -147,7 +156,7 @@ TrafficLightModuleManager::getModuleExpiredFunction(
   return [this, lanelet_id_set, planner_data](
            [[maybe_unused]] const std::shared_ptr<SceneModuleInterfaceWithRTC> & scene_module) {
     for (const auto & id : lanelet_id_set) {
-      if (getRegisteredAssociatedModule(id, planner_data)) {
+      if (this->getRegisteredAssociatedModule(id, planner_data)) {
         return false;
       }
     }
@@ -207,6 +216,31 @@ bool TrafficLightModuleManager::hasSameTrafficLight(
       }
     }
   }
+  return false;
+}
+
+bool TrafficLightModuleManager::hasStaticArrow(
+  const std::shared_ptr<const lanelet::autoware::AutowareTrafficLight> & reg_elem) const
+{
+  for (const auto & light : reg_elem->trafficLights()) {
+    const auto & attributes = light.attributes();
+    if (attributes.find("subtype") != attributes.end()) {
+      const std::string subtype = attributes.at("subtype").value();
+      if (subtype.find("arrow") != std::string::npos) {
+        return true;
+      }
+    }
+  }
+
+  for (const auto & light_bulb_ls : reg_elem->lightBulbs()) {
+    for (const auto & node : light_bulb_ls) {
+      const auto & attributes = node.attributes();
+      if (attributes.find("arrow") != attributes.end()) {
+        return true;
+      }
+    }
+  }
+
   return false;
 }
 

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/src/experimental/manager.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/src/experimental/manager.hpp
@@ -15,6 +15,7 @@
 #ifndef EXPERIMENTAL__MANAGER_HPP_
 #define EXPERIMENTAL__MANAGER_HPP_
 
+#include "autoware_lanelet2_extension/regulatory_elements/autoware_traffic_light.hpp"
 #include "scene.hpp"
 
 #include <autoware/behavior_velocity_planner_common/experimental/plugin_wrapper.hpp>
@@ -69,6 +70,9 @@ private:
   bool hasSameTrafficLight(
     const lanelet::TrafficLightConstPtr element,
     const lanelet::TrafficLightConstPtr registered_element) const;
+
+  bool hasStaticArrow(
+    const std::shared_ptr<const lanelet::autoware::AutowareTrafficLight> & reg_elem) const;
 
   // Debug
   rclcpp::Publisher<autoware_perception_msgs::msg::TrafficLightGroup>::SharedPtr pub_tl_state_;

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/src/experimental/scene.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/src/experimental/scene.cpp
@@ -34,20 +34,26 @@ TrafficLightModule::TrafficLightModule(
   const lanelet::TrafficLight & traffic_light_reg_elem,  //
   lanelet::ConstLanelet lane,                            //
   const lanelet::ConstLineString3d & initial_stop_line,  //
-  const PlannerParam & planner_param, const rclcpp::Logger logger,
-  const rclcpp::Clock::SharedPtr clock,
+  const bool is_turn_lane, const bool has_static_arrow, const PlannerParam & planner_param,
+  const rclcpp::Logger logger, const rclcpp::Clock::SharedPtr clock,
   const std::shared_ptr<autoware_utils::TimeKeeper> time_keeper,
   const std::shared_ptr<planning_factor_interface::PlanningFactorInterface>
     planning_factor_interface)
 : SceneModuleInterfaceWithRTC(module_id, logger, clock, time_keeper, planning_factor_interface),
+  yellow_transition_state_(YellowState::kNotYellow),
+  looking_tl_state_{},
+  traffic_signal_stamp_(std::nullopt),
   traffic_light_reg_elem_(traffic_light_reg_elem),
   lane_(lane),
   stop_line_(initial_stop_line),
+  is_turn_lane_(is_turn_lane),
+  has_static_arrow_(has_static_arrow),
   state_(State::APPROACH),
   debug_data_(),
   is_prev_state_stop_(false)
 {
   planner_param_ = planner_param;
+  prev_looking_tl_state_.traffic_light_group_id = 0;
 }
 
 bool TrafficLightModule::modifyPathVelocity(
@@ -166,6 +172,9 @@ bool TrafficLightModule::modifyPathVelocity(
 
 bool TrafficLightModule::isStopSignal(const PlannerData & planner_data)
 {
+  // Store previous state before updating
+  prev_looking_tl_state_ = looking_tl_state_;
+
   updateTrafficSignal(planner_data);
 
   // If there is no upcoming traffic signal information,
@@ -182,8 +191,82 @@ bool TrafficLightModule::isStopSignal(const PlannerData & planner_data)
     return true;
   }
 
+  // Check if current state is yellow
+  const bool is_yellow_now = isTrafficSignalYellow();
+
+  // Override for yellow light on turn lanes with static arrows
+  if (planner_param_.enable_arrow_aware_yellow_passing) {
+    updateYellowState(is_yellow_now);
+
+    // Check if conditions are met (Green->Yellow, turn lane, static arrow)
+    if (
+      is_yellow_now && is_turn_lane_ && has_static_arrow_ &&
+      yellow_transition_state_ == YellowState::kFromGreen) {
+      // This is a "Green -> Yellow" sequence. This is the state we *do* want to override (pass).
+      return false;
+    }
+  }
+
   // Check if the current traffic signal state requires stopping
   return autoware::traffic_light_utils::isTrafficSignalStop(lane_, looking_tl_state_);
+}
+
+bool TrafficLightModule::isTrafficSignalYellow() const
+{
+  for (const auto & element : looking_tl_state_.elements) {
+    if (
+      element.color == TrafficSignalElement::AMBER &&
+      (element.status == TrafficSignalElement::SOLID_ON ||
+       element.status == TrafficSignalElement::UNKNOWN)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+void TrafficLightModule::updateYellowState(const bool is_yellow_now)
+{
+  if (is_yellow_now) {
+    // This is a yellow light. Check if this is the *start* of the yellow sequence.
+    if (yellow_transition_state_ == YellowState::kNotYellow) {
+      // This is the first frame of yellow. Determine how it started.
+      if (!prev_looking_tl_state_.elements.empty()) {
+        const bool prev_had_green_circle = std::any_of(
+          prev_looking_tl_state_.elements.begin(), prev_looking_tl_state_.elements.end(),
+          [](const auto & element) {
+            return element.shape == TrafficSignalElement::CIRCLE &&
+                   element.color == TrafficSignalElement::GREEN;
+          });
+
+        if (prev_had_green_circle) {
+          RCLCPP_DEBUG_THROTTLE(
+            logger_, *clock_, 1000, "[TrafficLight Debug]   -> Detected Green->Yellow transition.");
+          yellow_transition_state_ = YellowState::kFromGreen;
+        } else {
+          RCLCPP_DEBUG_THROTTLE(
+            logger_, *clock_, 1000,
+            "[TrafficLight Debug]   -> NO Green Circle found in prev state.");
+          yellow_transition_state_ = YellowState::kFromNonGreen;
+        }
+      } else {
+        // No previous traffic light state available; cannot determine transition origin.
+        RCLCPP_DEBUG_THROTTLE(
+          logger_, *clock_, 1000,
+          "[TrafficLight Debug]   -> Previous TL state unavailable; "
+          "treating Yellow transition as unsafe; defaulting to stop behavior.");
+        // Leave yellow_transition_state_ as kNotYellow so that no special passing logic is
+        // applied.
+      }
+    }
+  } else {
+    // Not yellow. Reset the state.
+    if (yellow_transition_state_ != YellowState::kNotYellow) {
+      RCLCPP_DEBUG_THROTTLE(
+        logger_, *clock_, 1000, "[TrafficLight Debug] Module %ld: Yellow ended. Resetting state.",
+        module_id_);
+    }
+    yellow_transition_state_ = YellowState::kNotYellow;
+  }
 }
 
 bool TrafficLightModule::willTrafficLightTurnRedBeforeReachingStopLine(

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/src/experimental/scene.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_traffic_light_module/src/experimental/scene.hpp
@@ -37,6 +37,12 @@ public:
 
   enum class State { APPROACH, GO_OUT };
 
+  enum class YellowState { kNotYellow, kFromGreen, kFromNonGreen };
+  // YellowState represents how the current yellow phase was reached:
+  // - kNotYellow     : not currently in a yellow state.
+  // - kFromGreen     : yellow reached from green; passing through may be allowed.
+  // - kFromNonGreen  : yellow reached from non-green; vehicle is expected to stop.
+
   struct DebugData
   {
     double base_link2front;
@@ -61,6 +67,8 @@ public:
     double yellow_light_stop_velocity;
     double stop_time_hysteresis;
     bool enable_pass_judge;
+    // Enable arrow-aware passing logic for yellow signals in turn lanes.
+    bool enable_arrow_aware_yellow_passing;
     // Restart Suppression Parameter
     double max_behind_dist_to_stop_for_restart_suppression;
     double min_behind_dist_to_stop_for_restart_suppression;
@@ -75,8 +83,9 @@ public:
   TrafficLightModule(
     const lanelet::Id module_id, const lanelet::TrafficLight & traffic_light_reg_elem,
     lanelet::ConstLanelet lane, const lanelet::ConstLineString3d & initial_stop_line,
-    const PlannerParam & planner_param, const rclcpp::Logger logger,
-    const rclcpp::Clock::SharedPtr clock,
+    // Map based information
+    const bool is_turn_lane, const bool has_static_arrow, const PlannerParam & planner_param,
+    const rclcpp::Logger logger, const rclcpp::Clock::SharedPtr clock,
     const std::shared_ptr<autoware_utils::TimeKeeper> time_keeper,
     const std::shared_ptr<planning_factor_interface::PlanningFactorInterface>
       planning_factor_interface);
@@ -98,8 +107,6 @@ public:
   void updateStopLine(const lanelet::ConstLineString3d & stop_line);
 
 private:
-  bool isStopSignal(const PlannerData & planner_data);
-
   bool willTrafficLightTurnRedBeforeReachingStopLine(
     const double & distance_to_stop_line, const PlannerData & planner_data) const;
 
@@ -115,12 +122,30 @@ private:
 
   void updateTrafficSignal(const PlannerData & planner_data);
 
+  bool isStopSignal(const PlannerData & planner_data);
+
+  // Store how the current yellow sequence started
+  YellowState yellow_transition_state_;
+
+  TrafficSignal looking_tl_state_;
+  std::optional<Time> traffic_signal_stamp_;
+
+  bool isTrafficSignalYellow() const;
+
+  void updateYellowState(const bool is_yellow_now);
+
   // Key Feature
   const lanelet::TrafficLight & traffic_light_reg_elem_;
   lanelet::ConstLanelet lane_;
   lanelet::ConstLineString3d
     stop_line_;  // Note: this stop_line_ may not be the one bound to the traffic light regulatory
                  // element. this is the one bound to the traffic light (line string)
+
+  // Map based information
+  // Whether the current lane is a left or right turn lane.
+  const bool is_turn_lane_;
+  // Whether the traffic light has a static arrow bulb defined in the map.
+  const bool has_static_arrow_;
 
   // State
   State state_;
@@ -139,10 +164,10 @@ private:
 
   std::optional<double> first_stop_point_s_;
 
-  std::optional<Time> traffic_signal_stamp_;
-
   // Traffic Light State
-  TrafficSignal looking_tl_state_;
+  TrafficSignal prev_looking_tl_state_;  // Store previous state
+
+  friend class TrafficLightModuleTest;
 };
 }  // namespace autoware::behavior_velocity_planner::experimental
 


### PR DESCRIPTION
## Description
`behavior_velocity_planner` is in the process of migrating from _index base_ to _arc-length base_ Trajectory calculation.
First, all related `src/*.cpp` are copied to `src/experimental/*.cpp` in PR #11555 .

After that, there are changes in `src/*.cpp` that do not have effect on `src/experimental/*.cpp` in bvp submodules.

This PR will identify the PRs that change `src/*.cpp` but not `src/experimental/*.cpp`

Target PRs for `traffic_light_module`: 
- [x] #11704 :white_check_mark: 

:heavy_check_mark: : simple sync
:white_check_mark: : change of logic (need well review)
## Related links

**Parent Issue:**
#12253 

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
Pass CI and Evaluator (https://evaluation.tier4.jp/evaluation/reports/c10702bb-c48c-5fcf-a91c-771fc338af76?project_id=autoware_dev)

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
