### PR TITLE
chore(universe_utils): disable convex_hull flaky tests

### DIFF
--- a/common/autoware_universe_utils/test/src/geometry/test_alt_geometry.cpp
+++ b/common/autoware_universe_utils/test/src/geometry/test_alt_geometry.cpp
@@ -52,8 +52,17 @@ TEST(alt_geometry, area)
   }
 }
 
-TEST(alt_geometry, convexHull)
+TEST(alt_geometry, DISABLED_convexHull)
 {
+  // FIXME(soblin): convex_hull algorithm can cause infinite-loop
+  /*
+    1: make_hull: p1=(2.000000, 1.300000), p2=(5.400000, 1.200000), points.size=7
+    1: make_hull: p1=(2.000000, 1.300000), p2=(4.100000, 3.000000), points.size=1
+    1: make_hull: p1=(2.000000, 1.300000), p2=(2.400000, 1.700000), points.size=1
+    1: make_hull: p1=(2.000000, 1.300000), p2=(2.400000, 1.700000), points.size=1
+    1: make_hull: p1=(2.000000, 1.300000), p2=(2.400000, 1.700000), points.size=1
+    ...
+   */
   using autoware::universe_utils::convex_hull;
   using autoware::universe_utils::alt::PointList2d;
   using autoware::universe_utils::alt::Points2d;
@@ -788,7 +797,7 @@ TEST(alt_geometry, areaRand)
   }
 }
 
-TEST(alt_geometry, convexHullRand)
+TEST(alt_geometry, DISABLED_convexHullRand)
 {
   std::vector<autoware::universe_utils::Polygon2d> polygons;
   constexpr auto polygons_nb = 100;


### PR DESCRIPTION
## Description

temporarily disable tests for `convex_hull` as reported in https://github.com/autowarefoundation/autoware_universe/issues/12270

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

(ADDED by @sasakisasaki ) Required CI passed as [this](https://github.com/autowarefoundation/autoware_universe/actions/runs/22931742577/job/66554600584?pr=12276).

Reviewed as [this my comment](https://github.com/autowarefoundation/autoware_universe/pull/12276#pullrequestreview-3926321304).

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
