### PR TITLE
fix(goal_planner): prevent crash when output path is empty

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/goal_planner_module.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/goal_planner_module.cpp
@@ -1465,6 +1465,14 @@ void GoalPlannerModule::setModifiedGoal(
 void GoalPlannerModule::setTurnSignalInfo(
   const PullOverContextData & context_data, BehaviorModuleOutput & output)
 {
+  if (output.path.points.empty()) {
+    RCLCPP_WARN_THROTTLE(
+      getLogger(), *clock_, 5000,
+      "setTurnSignalInfo() received empty path. Keeping previous turn signal.");
+    output.turn_signal_info = getPreviousModuleOutput().turn_signal_info;
+    return;
+  }
+
   const auto original_signal = getPreviousModuleOutput().turn_signal_info;
   const auto new_signal = calcTurnSignalInfo(context_data);
   const auto current_seg_idx = planner_data_->findEgoSegmentIndex(output.path.points);
@@ -1478,6 +1486,14 @@ void GoalPlannerModule::setTurnSignalInfoForStopPath(
   const BehaviorModuleOutput & stop_path, const Pose & decel_start_pose,
   const std::optional<Pose> & stop_pose, BehaviorModuleOutput & output)
 {
+  if (stop_path.path.points.empty()) {
+    RCLCPP_WARN_THROTTLE(
+      getLogger(), *clock_, 5000,
+      "setTurnSignalInfoForStopPath() received empty stop path. Keeping previous turn signal.");
+    output.turn_signal_info = getPreviousModuleOutput().turn_signal_info;
+    return;
+  }
+
   const auto original_signal = getPreviousModuleOutput().turn_signal_info;
   const auto current_seg_idx = planner_data_->findEgoSegmentIndex(stop_path.path.points);
   auto preempt_turn_signal =


### PR DESCRIPTION
## Description

### Summary
When the vehicle is manually driven off-lane (e.g., into the shoulder) before `goal_planner` finalizes a trajectory, `GoalPlannerModule` can produce an **empty `PathWithLaneId`** (e.g., when `current_lanes` cannot be retrieved). `setTurnSignalInfo()` / `setTurnSignalInfoForStopPath()` then call ego-segment search on an empty container, triggering `autoware::motion_utils::validateNonEmpty()` → uncaught exception → `std::terminate()` / `abort()` and the planning container dies.

This PR adds **defensive guards** in those turn-signal setters: if the input path is empty, we **log a throttled warning** and **keep the previous `turn_signal_info`** instead of crashing.


<details><summary>stack trace log</summary>

```rb
15:06:36.955: component_container_mt-100 [stacktrace]

1773122796.9553499 [ERROR] [component_container_mt-100]: process has died [pid 218106, exit code -6, cmd '/home/autoware/pilot-auto.xx1/install/lib/rclcpp_components/component_container_mt --ros-args -r __node:=behavior_planning_container -r __ns:=/planning/scenario_planning/lane_driving/behavior_planning -p use_sim_time:=False -p wheel_radius:=0.31 -p wheel_width:=0.18 -p wheel_base:=2.75 -p wheel_tread:=1.485 -p front_overhang:=0.8 -p rear_overhang:=0.85 -p left_overhang:=0.105 -p right_overhang:=0.105 -p vehicle_height:=2.5 -p max_steer_angle:=0.55 -p use_sim_time:=False -p use_sim_time:=False -p use_sim_time:=False -p wheel_radius:=0.31 -p wheel_width:=0.18 -p wheel_base:=2.75 -p wheel_tread:=1.485 -p front_overhang:=0.8 -p rear_overhang:=0.85 -p left_overhang:=0.105 -p right_overhang:=0.105 -p vehicle_height:=2.5 -p max_steer_angle:=0.55 -p use_sim_time:=False -p wheel_radius:=0.31 -p wheel_width:=0.18 -p wheel_base:=2.75 -p wheel_tread:=1.485 -p front_overhang:=0.8 -p rear_overhang:=0.85 -p left_overhang:=0.105 -p right_overhang:=0.105 -p vehicle_height:=2.5 -p max_steer_angle:=0.55 -p use_sim_time:=False -p wheel_radius:=0.31 -p wheel_width:=0.18 -p wheel_base:=2.75 -p wheel_tread:=1.485 -p front_overhang:=0.8 -p rear_overhang:=0.85 -p left_overhang:=0.105 -p right_overhang:=0.105 -p vehicle_height:=2.5 -p max_steer_angle:=0.55 -p use_sim_time:=False -p wheel_radius:=0.31 -p wheel_width:=0.18 -p wheel_base:=2.75 -p wheel_tread:=1.485 -p front_overhang:=0.8 -p rear_overhang:=0.85 -p left_overhang:=0.105 -p right_overhang:=0.105 -p vehicle_height:=2.5 -p max_steer_angle:=0.55'].

1773122778.6539774 [component_container_mt-100] *** Aborted at 1773122778 (unix time) try "date -d @1773122778" if you are using GNU date ***

1773122778.6595631 [component_container_mt-100] PC: @ 0x0 (unknown)

1773122778.6651278 [component_container_mt-100] @ 0x7f1cf44c94d6 google::(anonymous namespace)::FailureSignalHandler()

1773122778.6698108 [component_container_mt-100] @ 0x7f1cf3d77520 (unknown)

1773122778.6742733 [component_container_mt-100] @ 0x7f1cf3dcb9fc pthread_kill

1773122778.6795955 [component_container_mt-100] @ 0x7f1cf3d77476 raise

1773122778.6842923 [component_container_mt-100] @ 0x7f1cf3d5d7f3 abort

1773122778.6889601 [component_container_mt-100] @ 0x7f1cf4022b9e (unknown)

1773122778.6937902 [component_container_mt-100] @ 0x7f1cf402e20c (unknown)

1773122778.6982930 [component_container_mt-100] @ 0x7f1cf402e277 std::terminate()

1773122778.7031226 [component_container_mt-100] @ 0x7f1cf402e4d8 __cxa_throw

1773122778.7069931 [component_container_mt-100] @ 0x7f1ce2caa069 autoware::motion_utils::validateNonEmpty<>()

1773122778.7104702 [component_container_mt-100] @ 0x7f1ce2cac898 autoware::motion_utils::findFirstNearestIndexWithSoftConstraints<>()

1773122778.7138989 [component_container_mt-100] @ 0x7f1ce2cc6ee4 autoware::motion_utils::findFirstNearestSegmentIndexWithSoftConstraints<>()

1773122778.7161415 [component_container_mt-100] @ 0x7f1ce1427245 autoware::behavior_path_planner::GoalPlannerModule::setTurnSignalInfo()

1773122778.7185931 [component_container_mt-100] @ 0x7f1ce1442d24 autoware::behavior_path_planner::GoalPlannerModule::planPullOver()

1773122778.7209961 [component_container_mt-100] @ 0x7f1ce1442f89 autoware::behavior_path_planner::GoalPlannerModule::plan()

1773122778.7235038 [component_container_mt-100] @ 0x7f1ce14475ed autoware::behavior_path_planner::SceneModuleInterface::run()

1773122778.7270365 [component_container_mt-100] @ 0x7f1ce3517115 autoware::behavior_path_planner::SubPlannerManager::run()

1773122778.7304688 [component_container_mt-100] @ 0x7f1ce351b948 autoware::behavior_path_planner::SubPlannerManager::runApprovedModules()

1773122778.7340124 [component_container_mt-100] @ 0x7f1ce3520072 autoware::behavior_path_planner::SubPlannerManager::propagateFull()

1773122778.7377343 [component_container_mt-100] @ 0x7f1ce3522a3c autoware::behavior_path_planner::PlannerManager::run()

1773122778.7413285 [component_container_mt-100] @ 0x7f1ce357ca81 autoware::behavior_path_planner::BehaviorPathPlannerNode::run()

1773122778.7454135 [component_container_mt-100] @ 0x7f1ce3587255 rclcpp::GenericTimer<>::execute_callback()

1773122778.7540145 [component_container_mt-100] @ 0x7f1cf4346ffe rclcpp::Executor::execute_any_executable()

1773122778.7566447 [component_container_mt-100] @ 0x7f1cf434d432 rclcpp::executors::MultiThreadedExecutor::run()

1773122778.7616723 [component_container_mt-100] @ 0x7f1cf405c253 (unknown)

1773122778.7659268 [component_container_mt-100] @ 0x7f1cf3dc9ac3 (unknown)

1773122778.7705772 [component_container_mt-100] @ 0x7f1cf3e5b8d0 (unknown)
```
</details>

### Changes
- Add empty-path checks in:
  - `GoalPlannerModule::setTurnSignalInfo()`
  - `GoalPlannerModule::setTurnSignalInfoForStopPath()`
- On empty path:
  - `RCLCPP_WARN_THROTTLE(...)`
  - `output.turn_signal_info = getPreviousModuleOutput().turn_signal_info;` and return

## Related links

[Internal ticket](https://tier4.atlassian.net/browse/T4DEV-50535)

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
