### PR TITLE
refactor(autoware_universe): use autoware_ament_auto_package in planning packages

### DIFF
--- a/control/autoware_shift_decider/CMakeLists.txt
+++ b/control/autoware_shift_decider/CMakeLists.txt
@@ -21,7 +21,7 @@ rclcpp_components_register_node(${PROJECT_NAME}_node
   EXECUTABLE ${PROJECT_NAME}
 )
 
-ament_auto_package(
+autoware_ament_auto_package(
   INSTALL_TO_SHARE
   launch
   config

--- a/perception/autoware_simpl_prediction/CMakeLists.txt
+++ b/perception/autoware_simpl_prediction/CMakeLists.txt
@@ -77,4 +77,4 @@ if(BUILD_TESTING)
     target_link_libraries(test_simpl ${PROJECT_NAME})
 endif()
 
-ament_auto_package(INSTALL_TO_SHARE launch config)
+autoware_ament_auto_package(INSTALL_TO_SHARE launch config)

--- a/planning/autoware_external_velocity_limit_selector/CMakeLists.txt
+++ b/planning/autoware_external_velocity_limit_selector/CMakeLists.txt
@@ -28,7 +28,7 @@ if(BUILD_TESTING)
   )
 endif()
 
-ament_auto_package(INSTALL_TO_SHARE
+autoware_ament_auto_package(INSTALL_TO_SHARE
   launch
   config
 )

--- a/planning/autoware_freespace_planner/CMakeLists.txt
+++ b/planning/autoware_freespace_planner/CMakeLists.txt
@@ -25,7 +25,7 @@ if(BUILD_TESTING)
   )
 endif()
 
-ament_auto_package(
+autoware_ament_auto_package(
   INSTALL_TO_SHARE
   launch
   config

--- a/planning/autoware_path_smoother/CMakeLists.txt
+++ b/planning/autoware_path_smoother/CMakeLists.txt
@@ -30,7 +30,7 @@ if(BUILD_TESTING)
   )
 endif()
 
-ament_auto_package(
+autoware_ament_auto_package(
   INSTALL_TO_SHARE
     launch
     config

--- a/planning/autoware_scenario_selector/CMakeLists.txt
+++ b/planning/autoware_scenario_selector/CMakeLists.txt
@@ -24,7 +24,7 @@ if(BUILD_TESTING)
   )
 endif()
 
-ament_auto_package(INSTALL_TO_SHARE
+autoware_ament_auto_package(INSTALL_TO_SHARE
   launch
   config
 )

--- a/planning/sampling_based_planner/autoware_bezier_sampler/CMakeLists.txt
+++ b/planning/sampling_based_planner/autoware_bezier_sampler/CMakeLists.txt
@@ -17,6 +17,6 @@ if(BUILD_TESTING)
   ament_lint_auto_find_test_dependencies()
 endif()
 
-ament_auto_package(
+autoware_ament_auto_package(
   INSTALL_TO_SHARE
 )


### PR DESCRIPTION
## Description

This PR replaces `ament_auto_package()` with `autoware_ament_auto_package()` for warned planning-related packages in `autoware_universe` that emitted scoped header installation warnings during the clean build investigation.

Updated packages:
- `autoware_shift_decider`
- `autoware_simpl_prediction`
- `autoware_external_velocity_limit_selector`
- `autoware_freespace_planner`
- `autoware_path_smoother`
- `autoware_scenario_selector`
- `autoware_bezier_sampler`

## How was this PR tested?

Tested with:

```bash
colcon build --base-paths ~/autoware_scoped_headers/autoware/src --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release --packages-up-to \
autoware_external_velocity_limit_selector \
autoware_simpl_prediction \
autoware_freespace_planner \
autoware_shift_decider \
autoware_scenario_selector \
autoware_bezier_sampler \
autoware_path_smoother
```

The target packages built successfully.

## Notes for reviewers

This is part of the follow-up work after adding `USE_SCOPED_HEADER_INSTALL_DIR` support to `autoware_cmake`.

## Effects on system behavior

No functional behavior change is intended. This updates the package macro to the Autoware wrapper for the scoped header migration work.
