### PR TITLE
fix(steer_offset_estimator): fix offset update publishing condition

### DIFF
--- a/vehicle/autoware_steer_offset_estimator/src/node.cpp
+++ b/vehicle/autoware_steer_offset_estimator/src/node.cpp
@@ -192,10 +192,10 @@ void SteerOffsetEstimatorNode::publish_data(const SteerOffsetEstimationUpdated &
   pub_float(pub_steer_offset_, result.offset);
   pub_float(pub_steer_offset_covariance_, result.covariance);
 
-  if (is_publish_update(result)) {
-    pub_float(pub_steer_offset_update_, result.offset);
-    last_offset_update_ = result.offset;
-    log_offset_update(result);
+  if (is_publish_update()) {
+    pub_float(pub_steer_offset_update_, latest_reliable_result_->offset);
+    last_offset_update_ = latest_reliable_result_->offset;
+    log_offset_update(latest_reliable_result_.value());
   }
 
   autoware_internal_debug_msgs::msg::StringStamped debug_info;
@@ -210,11 +210,13 @@ void SteerOffsetEstimatorNode::publish_data(const SteerOffsetEstimationUpdated &
   pub_debug_info_->publish(debug_info);
 }
 
-bool SteerOffsetEstimatorNode::is_publish_update(const SteerOffsetEstimationUpdated & result) const
+bool SteerOffsetEstimatorNode::is_publish_update() const
 {
-  const double diff = std::abs(result.offset - last_offset_update_);
-  return diff > calibration_params_.update_offset_th &&
-         result.covariance < calibration_params_.covariance_th;
+  if (!latest_reliable_result_) {
+    return false;
+  }
+  const double diff = std::abs(latest_reliable_result_->offset - last_offset_update_);
+  return diff > calibration_params_.update_offset_th;
 }
 
 void SteerOffsetEstimatorNode::log_offset_update(const SteerOffsetEstimationUpdated & result) const

--- a/vehicle/autoware_steer_offset_estimator/src/node.hpp
+++ b/vehicle/autoware_steer_offset_estimator/src/node.hpp
@@ -153,10 +153,9 @@ private:
 
   /**
    * @brief Check if an offset update should be published
-   * @param result The latest steer offset estimation result
-   * @return true if the offset should be published, false otherwise
+   * @return true if offset update should be published, false otherwise
    */
-  bool is_publish_update(const SteerOffsetEstimationUpdated & result) const;
+  bool is_publish_update() const;
 
   /**
    * @brief Log value of most recent offset update


### PR DESCRIPTION
## Description

use latest_reliable_result for publishing offset update which takes into account covariance and steady driving duration.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
