### PR TITLE
fix(compare_map_segmentation): ignore Werror=array-bounds

### DIFF
--- a/perception/autoware_compare_map_segmentation/src/voxel_based_approximate_compare_map_filter/node.cpp
+++ b/perception/autoware_compare_map_segmentation/src/voxel_based_approximate_compare_map_filter/node.cpp
@@ -70,8 +70,13 @@ bool VoxelBasedApproximateDynamicMapLoader::is_close_to_map(
     map_cell_voxel_grid = current_voxel_grid_array_.at(map_grid_index)->map_cell_voxel_grid;
   }
 
-  const int index = map_cell_voxel_grid.getCentroidIndexAt(
-    map_cell_voxel_grid.getGridCoordinates(point.x, point.y, point.z));
+  const Eigen::Vector3i grid_coordinates =
+    map_cell_voxel_grid.getGridCoordinates(point.x, point.y, point.z);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Warray-bounds"
+  const int index = map_cell_voxel_grid.getCentroidIndexAt(grid_coordinates);
+#pragma GCC diagnostic pop
+
   return (index != -1);
 }
 


### PR DESCRIPTION
## Description

Compilation fails in jazzy.

```
    inlined from ‘virtual bool autoware::compare_map_segmentation::VoxelBasedApproximateDynamicMapLoader::is_close_to_map(const pcl::PointXYZ&, double)’ at /home/mfc/projects/autoware/src/universe/autoware_universe/perception/autoware_compare_map_segmentation/src/voxel_based_approximate_compare_map_filter/node.cpp:73:59:
/usr/lib/gcc/x86_64-linux-gnu/13/include/emmintrin.h:706:11: error: array subscript ‘const __m128i_u[0]’ is partly outside array bounds of ‘Eigen::Vector3i [1]’ {aka ‘Eigen::Matrix<int, 3, 1> [1]’} [-Werror=array-bounds=]
  706 |   return *__P;
      |           ^~~
/home/mfc/projects/autoware/src/universe/autoware_universe/perception/autoware_compare_map_segmentation/src/voxel_based_approximate_compare_map_filter/node.cpp: In member function ‘virtual bool autoware::compare_map_segmentation::VoxelBasedApproximateDynamicMapLoader::is_close_to_map(const pcl::PointXYZ&, double)’:
/home/mfc/projects/autoware/src/universe/autoware_universe/perception/autoware_compare_map_segmentation/src/voxel_based_approximate_compare_map_filter/node.cpp:74:43: note: at offset [0, 8] into object ‘<anonymous>’ of size 12
   74 |     map_cell_voxel_grid.getGridCoordinates(point.x, point.y, point.z));
      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~
```

Similar to here in the same file:

https://github.com/autowarefoundation/autoware_universe/blob/84564c056adea861336c8b432f77e438e5b01900/perception/autoware_compare_map_segmentation/src/voxel_based_approximate_compare_map_filter/node.cpp#L36-L41

## Related links

**Parent Issue:**

- https://github.com/autowarefoundation/autoware_universe/issues/11418

## How was this PR tested?

Compiles locally.

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.
