### PR TITLE
fix(boundary_departure): replaced duplicated function with motion_utils::calculate_stop_distance

### DIFF
--- a/common/autoware_boundary_departure_checker/include/autoware/boundary_departure_checker/utils.hpp
+++ b/common/autoware_boundary_departure_checker/include/autoware/boundary_departure_checker/utils.hpp
@@ -372,27 +372,6 @@ tl::expected<std::vector<lanelet::LineString3d>, std::string> get_uncrossable_li
  */
 TrajectoryPoints trim_pred_path(const TrajectoryPoints & ego_pred_traj, const double cutoff_time_s);
 
-/**
- * @brief Compute the longitudinal distance required to stop with jerk- and
- *        acceleration limits (“judge line”).
- *
- * @param velocity              Current longitudinal speed *v₀* [m/s].
- * @param acceleration          Current longitudinal acceleration *a₀* [m/s²].
- * @param max_stop_acceleration Maximum (most negative) braking acceleration
- *                              *a_brake* [m/s²] (e.g. −4.0).
- * @param max_stop_jerk         Maximum (most negative) braking jerk
- *                              *j_brake* [m/s³] (e.g. −10.0).
- * @param delay_response_time   Latency before any braking begins *t₁* [s].
- *
- * @return Minimum longitudinal distance [m] from the current pose to the
- *         stopping line that guarantees the vehicle can reach *v = 0* under the
- *         provided jerk and acceleration limits. Returns 0 m if the current
- *         velocity is already non-positive.
- */
-double calc_judge_line_dist_with_jerk_limit(
-  const double velocity, const double acceleration, const double max_stop_acceleration,
-  const double max_stop_jerk, const double delay_response_time);
-
 std::optional<double> calc_signed_lateral_distance_to_boundary(
   const lanelet::ConstLineString3d & boundary, const Pose & reference_pose);
 

--- a/common/autoware_boundary_departure_checker/src/uncrossable_boundary_departure_checker.cpp
+++ b/common/autoware_boundary_departure_checker/src/uncrossable_boundary_departure_checker.cpp
@@ -18,6 +18,7 @@
 #include "autoware/boundary_departure_checker/footprint_generator/footprint_manager.hpp"
 #include "autoware/boundary_departure_checker/utils.hpp"
 
+#include <autoware/motion_utils/distance/distance.hpp>
 #include <autoware/motion_utils/trajectory/interpolation.hpp>
 #include <autoware/motion_utils/trajectory/trajectory.hpp>
 #include <autoware/trajectory/trajectory_point.hpp>
@@ -431,19 +432,28 @@ Side<ProjectionsToBound> UncrossableBoundaryDepartureChecker::get_closest_projec
   autoware_utils_debug::ScopedTimeTrack st(__func__, *time_keeper_);
   const auto & th_trigger = param_.th_trigger;
 
-  const auto min_braking_dist = utils::calc_judge_line_dist_with_jerk_limit(
-    curr_vel, curr_acc, th_trigger.th_acc_mps2.max, th_trigger.th_jerk_mps3.max,
-    th_trigger.brake_delay_s);
+  const auto max_jerk = th_trigger.th_jerk_mps3.max;
+  const auto max_decel = th_trigger.th_acc_mps2.min;
+  const auto braking_delay = th_trigger.brake_delay_s;
 
-  const auto max_braking_dist = utils::calc_judge_line_dist_with_jerk_limit(
-    curr_vel, curr_acc, th_trigger.th_acc_mps2.min, th_trigger.th_jerk_mps3.min,
-    th_trigger.brake_delay_s);
+  const auto min_braking_dist_opt =
+    motion_utils::calculate_stop_distance(curr_vel, curr_acc, max_decel, max_jerk, braking_delay);
+
+  const auto min_jerk = th_trigger.th_jerk_mps3.min;
+  const auto min_decel = th_trigger.th_acc_mps2.min;
+
+  const auto max_braking_dist_opt =
+    motion_utils::calculate_stop_distance(curr_vel, curr_acc, min_decel, min_jerk, braking_delay);
+
+  if (!min_braking_dist_opt || !max_braking_dist_opt) {
+    return {};
+  }
 
   Side<ProjectionsToBound> min_to_bound;
 
   for (const auto side_key : g_side_keys) {
     auto closest_projections_opt = utils::get_closest_projections_for_side(
-      projections_to_bound, param_, min_braking_dist, max_braking_dist, side_key);
+      projections_to_bound, param_, *min_braking_dist_opt, *max_braking_dist_opt, side_key);
 
     if (closest_projections_opt) {
       min_to_bound[side_key] = std::move(*closest_projections_opt);

--- a/common/autoware_boundary_departure_checker/src/utils.cpp
+++ b/common/autoware_boundary_departure_checker/src/utils.cpp
@@ -703,39 +703,6 @@ TrajectoryPoints trim_pred_path(const TrajectoryPoints & ego_pred_traj, const do
   return trimmed_traj;
 }
 
-// copied form core/mvp_common. will removed once this function is moved to motion_utils
-double calc_judge_line_dist_with_jerk_limit(
-  const double velocity, const double acceleration, const double max_stop_acceleration,
-  const double max_stop_jerk, const double delay_response_time)
-{
-  if (velocity <= 0.0) {
-    return 0.0;
-  }
-
-  const double t1 = delay_response_time;
-  const double x1 = velocity * t1;
-
-  const double v2 = velocity + (std::pow(max_stop_acceleration, 2) - std::pow(acceleration, 2)) /
-                                 (2.0 * max_stop_jerk);
-
-  if (v2 <= 0.0) {
-    const double t2 = -1.0 *
-                      (max_stop_acceleration +
-                       std::sqrt(acceleration * acceleration - 2.0 * max_stop_jerk * velocity)) /
-                      max_stop_jerk;
-    const double x2 =
-      velocity * t2 + acceleration * std::pow(t2, 2) / 2.0 + max_stop_jerk * std::pow(t2, 3) / 6.0;
-    return std::max(0.0, x1 + x2);
-  }
-
-  const double t2 = (max_stop_acceleration - acceleration) / max_stop_jerk;
-  const double x2 =
-    velocity * t2 + acceleration * std::pow(t2, 2) / 2.0 + max_stop_jerk * std::pow(t2, 3) / 6.0;
-
-  const double x3 = -1.0 * std::pow(v2, 2) / (2.0 * max_stop_acceleration);
-  return std::max(0.0, x1 + x2 + x3);
-}
-
 std::optional<double> calc_signed_lateral_distance_to_boundary(
   const lanelet::ConstLineString3d & boundary, const Pose & reference_pose)
 {

--- a/common/autoware_boundary_departure_checker/test/test_uncrossable_boundary_checker.cpp
+++ b/common/autoware_boundary_departure_checker/test/test_uncrossable_boundary_checker.cpp
@@ -16,6 +16,8 @@
 #include "autoware/boundary_departure_checker/utils.hpp"
 #include "test_plot_utils.hpp"
 
+#include <autoware/motion_utils/distance/distance.hpp>
+
 #include <gtest/gtest.h>
 #include <pybind11/embed.h>
 #include <pybind11/stl.h>
@@ -193,8 +195,10 @@ TEST(UncrossableBoundaryUtilsTest, TestCalcJudgeLineDist)
   constexpr double delay_time = 1.0;
 
   constexpr double v_test = 10.0;
-  const double dist = utils::calc_judge_line_dist_with_jerk_limit(
+  const auto dist_opt = motion_utils::calculate_stop_distance(
     v_test, acceleration, max_stop_accel, max_stop_jerk, delay_time);
+  ASSERT_TRUE(dist_opt.has_value());
+  const double dist = dist_opt.value();
   EXPECT_GT(dist, 22.5);
 
   BDC_PLOT_RESULT({
@@ -204,9 +208,12 @@ TEST(UncrossableBoundaryUtilsTest, TestCalcJudgeLineDist)
     std::vector<double> distances;
     for (double v = 0.0; v <= 20.0; v += 1.0) {
       velocities.push_back(v);
-      distances.push_back(
-        utils::calc_judge_line_dist_with_jerk_limit(
-          v, acceleration, max_stop_accel, max_stop_jerk, delay_time));
+
+      if (
+        const auto dist_it_opt = motion_utils::calculate_stop_distance(
+          v, acceleration, max_stop_accel, max_stop_jerk, delay_time)) {
+        distances.push_back(*dist_it_opt);
+      }
     }
 
     plt.plot(Args(velocities, distances), Kwargs("marker"_a = "o"));

--- a/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/boundary_departure_prevention_module.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/boundary_departure_prevention_module.cpp
@@ -684,11 +684,11 @@ std::pair<int8_t, std::string> BoundaryDeparturePreventionModule::get_diagnostic
       const auto & th_trigger = node_param_.bdc_param.th_trigger;
       const auto braking_start_vel =
         std::clamp(curr_vel, th_trigger.th_vel_mps.min, th_trigger.th_vel_mps.max);
-      const auto braking_dist =
-        boundary_departure_checker::utils::calc_judge_line_dist_with_jerk_limit(
-          braking_start_vel, 0.0, th_trigger.th_acc_mps2.min, th_trigger.th_jerk_mps3.max,
-          th_trigger.brake_delay_s);
-      return (pt.ego_dist_on_ref_traj - ego_dist_on_traj) <= braking_dist;
+      const auto braking_dist_opt = motion_utils::calculate_stop_distance(
+        braking_start_vel, 0.0, th_trigger.th_acc_mps2.min, th_trigger.th_jerk_mps3.max,
+        th_trigger.brake_delay_s);
+      return (pt.ego_dist_on_ref_traj - ego_dist_on_traj) <=
+             braking_dist_opt.value_or(std::numeric_limits<double>::min());
     };
 
     const auto critical_departure_points = output_.abnormalities_data.critical_departure_points;


### PR DESCRIPTION
## Description

Removed duplicated function from boundary departure, and replace it with the `motion_utils::calculate_stop_distance`.

## Related links

**Parent Issue:**

## How was this PR tested?

1. Build success and no test failure.
2. TIER IV internal evaluation
[TIER IV Internal Link - DLR_Basic](https://evaluation.tier4.jp/evaluation/reports/be97c4b2-a66e-5bb2-8737-dc66d6ddfb51?project_id=prd_jt)
[TIER IV Internal Link - FuncVerif_Basic](https://evaluation.tier4.jp/evaluation/reports/a3f1eb52-7874-5c08-be00-54687e66dd17?project_id=prd_jt)
[TIER IV Internal Link - Master](https://evaluation.tier4.jp/evaluation/reports/10b837a2-3607-5f3a-a917-8845ee454593?project_id=autoware_dev)


## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
