### PR TITLE
revert: feat(compare_map_filter) apply agnocast publisher to `voxel_compare_map_filter`

### DIFF
--- a/perception/autoware_compare_map_segmentation/CMakeLists.txt
+++ b/perception/autoware_compare_map_segmentation/CMakeLists.txt
@@ -9,7 +9,6 @@ find_package(Eigen3 REQUIRED)
 find_package(Boost REQUIRED)
 find_package(PCL REQUIRED)
 find_package(pcl_conversions REQUIRED)
-find_package(autoware_agnocast_wrapper REQUIRED)
 find_package(OpenMP)
 
 include_directories(
@@ -34,10 +33,6 @@ add_library(${PROJECT_NAME} SHARED
   src/lanelet_elevation_filter/grid_processor.cpp
 )
 
-target_include_directories(${PROJECT_NAME} PRIVATE
-  ${autoware_agnocast_wrapper_INCLUDE_DIRS}
-)
-
 target_link_libraries(${PROJECT_NAME}
   autoware_pointcloud_preprocessor::pointcloud_preprocessor_filter_base
   ${Boost_LIBRARIES}
@@ -46,7 +41,6 @@ target_link_libraries(${PROJECT_NAME}
 )
 
 ament_target_dependencies(${PROJECT_NAME}
-  autoware_agnocast_wrapper
   autoware_qos_utils
   grid_map_pcl
   grid_map_ros
@@ -77,8 +71,6 @@ if(OPENMP_FOUND)
   )
 endif()
 
-autoware_agnocast_wrapper_setup(${PROJECT_NAME})
-
 # ========== Compare Map Filter ==========
 # -- Distance Based Compare Map Filter --
 rclcpp_components_register_node(${PROJECT_NAME}
@@ -91,11 +83,9 @@ rclcpp_components_register_node(${PROJECT_NAME}
   EXECUTABLE voxel_based_approximate_compare_map_filter_node)
 
 # -- Voxel Based Compare Map Filter --
-autoware_agnocast_wrapper_register_node(${PROJECT_NAME}
+rclcpp_components_register_node(${PROJECT_NAME}
   PLUGIN "autoware::compare_map_segmentation::VoxelBasedCompareMapFilterComponent"
-  EXECUTABLE voxel_based_compare_map_filter_node
-  AGNOCAST_EXECUTOR SingleThreadedAgnocastExecutor
-)
+  EXECUTABLE voxel_based_compare_map_filter_node)
 
 # -- Voxel Distance Based Compare Map Filter --
 rclcpp_components_register_node(${PROJECT_NAME}

--- a/perception/autoware_compare_map_segmentation/launch/voxel_based_compare_map_filter.launch.xml
+++ b/perception/autoware_compare_map_segmentation/launch/voxel_based_compare_map_filter.launch.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <launch>
-  <include file="$(find-pkg-share autoware_agnocast_wrapper)/launch/agnocast_env.launch.xml"/>
   <arg name="voxel_based_compare_map_filter_param_file" default="$(find-pkg-share autoware_compare_map_segmentation)/config/voxel_based_compare_map_filter.param.yaml"/>
   <arg name="input" default="/input" description="input topic name"/>
   <arg name="input_map" default="/map" description="input map topic name"/>
@@ -9,7 +8,6 @@
   <arg name="map_loader_service" default="/map/get_differential_pointcloud_map" description="map loader service name"/>
 
   <node pkg="autoware_compare_map_segmentation" exec="voxel_based_compare_map_filter_node" name="voxel_based_compare_map_filter_node" output="screen">
-    <env name="LD_PRELOAD" value="$(var ld_preload_value)"/>
     <remap from="input" to="$(var input)"/>
     <remap from="map" to="$(var input_map)"/>
     <remap from="output" to="$(var output)"/>

--- a/perception/autoware_compare_map_segmentation/package.xml
+++ b/perception/autoware_compare_map_segmentation/package.xml
@@ -22,7 +22,6 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>ament_index_cpp</depend>
-  <depend>autoware_agnocast_wrapper</depend>
   <depend>autoware_internal_debug_msgs</depend>
   <depend>autoware_lanelet2_utils</depend>
   <depend>autoware_map_msgs</depend>

--- a/perception/autoware_compare_map_segmentation/src/voxel_based_compare_map_filter/node.cpp
+++ b/perception/autoware_compare_map_segmentation/src/voxel_based_compare_map_filter/node.cpp
@@ -77,9 +77,6 @@ VoxelBasedCompareMapFilterComponent::VoxelBasedCompareMapFilterComponent(
   }
   tf_input_frame_ = *(voxel_grid_map_loader_->tf_map_input_frame_);
   RCLCPP_INFO(this->get_logger(), "tf_map_input_frame: %s", tf_input_frame_.c_str());
-
-  agnocast_pub_output_ = AUTOWARE_CREATE_PUBLISHER2(
-    PointCloud2, "output", rclcpp::SensorDataQoS().keep_last(max_queue_size_));
 }
 
 void VoxelBasedCompareMapFilterComponent::checkStatus(
@@ -209,20 +206,6 @@ bool VoxelBasedCompareMapFilterComponent::convert_output_costly(
     }
   }
   return true;
-}
-
-// TODO(Koichi98): Remove this override once the filter base class supports agnocast_wrapper::Node.
-void VoxelBasedCompareMapFilterComponent::compute_publish(
-  const PointCloud2ConstPtr & input, const IndicesPtr & indices)
-{
-  auto output = std::make_unique<PointCloud2>();
-  filter(input, indices, *output);
-  if (!convert_output_costly(output)) return;
-  output->header.stamp = input->header.stamp;
-  auto agnocast_output = ALLOCATE_OUTPUT_MESSAGE_UNIQUE(agnocast_pub_output_);
-  *agnocast_output = *output;
-  agnocast_pub_output_->publish(std::move(agnocast_output));
-  published_time_publisher_->publish_if_subscribed(pub_output_, input->header.stamp);
 }
 
 void VoxelBasedCompareMapFilterComponent::filter(

--- a/perception/autoware_compare_map_segmentation/src/voxel_based_compare_map_filter/node.hpp
+++ b/perception/autoware_compare_map_segmentation/src/voxel_based_compare_map_filter/node.hpp
@@ -18,7 +18,6 @@
 #include "autoware/compare_map_segmentation/voxel_grid_map_loader.hpp"
 #include "autoware/pointcloud_preprocessor/filter.hpp"
 
-#include <autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp>
 #include <autoware_utils/ros/diagnostics_interface.hpp>
 #include <diagnostic_updater/diagnostic_updater.hpp>
 
@@ -47,12 +46,8 @@ protected:
     const PointCloud2ConstPtr cloud, const PointIndicesConstPtr indices) override;
 
   bool convert_output_costly(std::unique_ptr<PointCloud2> & output) override;
-  // TODO(Koichi98): Remove this override once the filter base class
-  // supports agnocast_wrapper::Node.
-  void compute_publish(const PointCloud2ConstPtr & input, const IndicesPtr & indices) override;
 
 private:
-  AUTOWARE_PUBLISHER_PTR(PointCloud2) agnocast_pub_output_;
   // pcl::SegmentDifferences<pcl::PointXYZ> impl_;
 
   // interfaces


### PR DESCRIPTION
## Description
This reverts commit d702d678392837529fad335c4fce38cfff95f64b merged in https://github.com/autowarefoundation/autoware_universe/pull/12304.

Since the application of `agnocast_wrapper::Node` to `euclidean_cluster` has been postponed (see https://github.com/autowarefoundation/autoware_universe/pull/12303), the Agnocast migration of publishers/subscriptions in surrounding nodes is also being reverted.                                                                                                                                                                      

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
I did built test and ran logging simulator with sample rosbag.

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
