### PR TITLE
fix: bound int 32 range for rqt_reconfigure older than 1.1.4

### DIFF
--- a/planning/planning_validator/autoware_planning_validator_intersection_collision_checker/param/intersection_collision_checker_node_parameters.yaml
+++ b/planning/planning_validator/autoware_planning_validator_intersection_collision_checker/param/intersection_collision_checker_node_parameters.yaml
@@ -82,7 +82,7 @@ intersection_collision_checker_node:
         min_size:
           type: int
           validation:
-            gt<>: [0]
+            bounds<>: [1, 2147483647]
       clustering:
         tolerance:
           type: double
@@ -95,11 +95,11 @@ intersection_collision_checker_node:
         min_size:
           type: int
           validation:
-            gt<>: [0]
+            bounds<>: [1, 2147483647]
         max_size:
           type: int
           validation:
-            gt<>: [0]
+            bounds<>: [1, 2147483647]
       velocity_estimation:
         max_acceleration:
           type: double
@@ -120,7 +120,7 @@ intersection_collision_checker_node:
         buffer_size:
           type: int
           validation:
-            gt<>: [0]
+            bounds<>: [1, 2147483647]
       latency:
         type: double
         validation:

--- a/planning/planning_validator/autoware_planning_validator_rear_collision_checker/param/rear_collision_checker_node_parameters.yaml
+++ b/planning/planning_validator/autoware_planning_validator_rear_collision_checker/param/rear_collision_checker_node_parameters.yaml
@@ -57,11 +57,11 @@ rear_collision_checker_node:
         min_cluster_size:
           type: int
           validation:
-            gt<>: [0]
+            bounds<>: [1, 2147483647]
         max_cluster_size:
           type: int
           validation:
-            gt<>: [0]
+            bounds<>: [1, 2147483647]
       velocity_estimation:
         observation_time:
           type: double


### PR DESCRIPTION
## Description

Set bounding range for parameters that only use int32

Background information 1:

https://github.com/PickNikRobotics/generate_parameter_library/pull/214

In generate parameter library, they have decided that they should be using int64 because ROS params are int64.

https://github.com/ros-visualization/rqt_reconfigure/pull/164

Only rqt_reconfigure version larger than 1.1.4 can fix this problem. To adapt to older version of the `rqt_reconfigure`, we can choose explicitly bound to input to int32 range instead of using `gt 0` 


## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

<img width="1917" height="1409" alt="image" src="https://github.com/user-attachments/assets/069291af-f4ed-4688-90ff-c00946205d75" />

<img width="973" height="61" alt="image" src="https://github.com/user-attachments/assets/d3e312d3-3110-49cc-ab25-e4612a3229e0" />

After update:

<img width="1277" height="1593" alt="image" src="https://github.com/user-attachments/assets/97aa9355-6d07-4567-b3ad-e86703bf0e84" />


## Notes for reviewers

None.

