### PR TITLE
ci: fix handling of container suffix for build-and-test workflows

### DIFF
--- a/.github/workflows/build-and-test-daily.yaml
+++ b/.github/workflows/build-and-test-daily.yaml
@@ -48,7 +48,7 @@ jobs:
     uses: ./.github/workflows/build-and-test-reusable.yaml
     with:
       rosdistro: ${{ matrix.rosdistro }}
-      container: ${{ matrix.container-base }}${{ matrix.container-suffix }}
+      container: ${{ matrix.container-base }}
       container-suffix: ${{ matrix.container-suffix }}
       runner: ${{ matrix.runner }}
       build-pre-command: ${{ matrix.build-pre-command }}

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -15,10 +15,10 @@ jobs:
         include:
           # ROS distribution specific configurations
           - rosdistro: humble
-            container: ghcr.io/autowarefoundation/autoware:universe-devel-cuda
+            container: ghcr.io/autowarefoundation/autoware:universe-devel
 
           - rosdistro: jazzy
-            container: ghcr.io/autowarefoundation/autoware:universe-devel-jazzy-amd64-cuda
+            container: ghcr.io/autowarefoundation/autoware:universe-devel-jazzy-amd64
 
     uses: ./.github/workflows/build-and-test-reusable.yaml
     with:


### PR DESCRIPTION
## Description

I've noticed that build-and-test CI check was failing due to wrong image name.
https://github.com/autowarefoundation/autoware_universe/actions/runs/23234272107/job/67534366005

The build-and-test-reusable.yaml takes `-cuda` as ${container-suffix} argument and attach this internally when pulling the image so there is no need to attach it when passing the container name

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
