### PR TITLE
fix(compare_map_segmentation): ignore Werror=array-bounds (#12316)

### DIFF
--- a/perception/autoware_compare_map_segmentation/src/voxel_based_approximate_compare_map_filter/node.cpp
+++ b/perception/autoware_compare_map_segmentation/src/voxel_based_approximate_compare_map_filter/node.cpp
@@ -70,8 +70,13 @@ bool VoxelBasedApproximateDynamicMapLoader::is_close_to_map(
     map_cell_voxel_grid = current_voxel_grid_array_.at(map_grid_index)->map_cell_voxel_grid;
   }
 
-  const int index = map_cell_voxel_grid.getCentroidIndexAt(
-    map_cell_voxel_grid.getGridCoordinates(point.x, point.y, point.z));
+  const Eigen::Vector3i grid_coordinates =
+    map_cell_voxel_grid.getGridCoordinates(point.x, point.y, point.z);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Warray-bounds"
+  const int index = map_cell_voxel_grid.getCentroidIndexAt(grid_coordinates);
+#pragma GCC diagnostic pop
+
   return (index != -1);
 }
 


### PR DESCRIPTION
- Backport of https://github.com/autowarefoundation/autoware_universe/pull/12316 to the humble branch.

[docker-build-and-push-jazzy (amd64)](https://github.com/autowarefoundation/autoware/actions/runs/23283245879/job/67701069284#logs) is failing on the main autoware repository with the same error mentioned in the backported PR.

Will merge this and patch-release 0.50.2