### PR TITLE
fix(autoware_tensorrt_bevformer): initialize ego2global_rot_cam to identity

### DIFF
--- a/perception/autoware_tensorrt_bevformer/src/bevformer_node.cpp
+++ b/perception/autoware_tensorrt_bevformer/src/bevformer_node.cpp
@@ -411,7 +411,7 @@ void TRTBEVFormerNode::calculateSensor2LidarTransformsFromTF(
     Eigen::RowVector3d l2e_t_s = cams2ego_trans_[i].cast<double>().vector().transpose();
 
     // Get ego2global at camera timestamp
-    Eigen::Quaterniond ego2global_rot_cam;
+    Eigen::Quaterniond ego2global_rot_cam = Eigen::Quaterniond::Identity();
     Eigen::Translation3d ego2global_trans_cam = Eigen::Translation3d::Identity();
     bool got_camera_transform = false;
     try {


### PR DESCRIPTION
## Summary
- `ego2global_rot_cam` was declared without initialization, causing `-Werror=maybe-uninitialized` when built with `--coverage` (as CI does).
- Initialize it to `Eigen::Quaterniond::Identity()`, matching the pattern already used for `ego2global_trans_cam` on the next line.

## How to reproduce
The default local build (`colcon build`) does not trigger this because `-Werror=maybe-uninitialized` only fires under `--coverage`. CI uses:
```bash
colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS='--coverage'
```
CI failure: https://github.com/autowarefoundation/autoware_universe/actions/runs/23348065420/job/68039152250#step:15:23123

## Test plan
- [ ] CI passes with `--coverage` flag