### PR TITLE
feat(autoware_detected_object_validation): use CallbackIsolatedAgnocastExecutor for obstacle_pointcloud_based_validator

### DIFF
--- a/perception/autoware_detected_object_validation/CMakeLists.txt
+++ b/perception/autoware_detected_object_validation/CMakeLists.txt
@@ -67,6 +67,8 @@ ament_auto_add_library(object_position_filter SHARED
 autoware_agnocast_wrapper_register_node(obstacle_pointcloud_based_validator
   PLUGIN "autoware::detected_object_validation::obstacle_pointcloud::ObstaclePointCloudBasedValidator"
   EXECUTABLE obstacle_pointcloud_based_validator_node
+  ROS2_EXECUTOR SingleThreadedExecutor
+  AGNOCAST_EXECUTOR CallbackIsolatedAgnocastExecutor
 )
 
 autoware_agnocast_wrapper_register_node(object_lanelet_filter


### PR DESCRIPTION
## Description

Add missing `ROS2_EXECUTOR` and `AGNOCAST_EXECUTOR` options for `obstacle_pointcloud_based_validator` that were overlooked in https://github.com/autowarefoundation/autoware_universe/pull/12329.

In #12329, the `obstacle_pointcloud_based_validator` target was converted from `rclcpp_components_register_node` to `autoware_agnocast_wrapper_register_node`, but the `ROS2_EXECUTOR SingleThreadedExecutor` and `AGNOCAST_EXECUTOR CallbackIsolatedAgnocastExecutor` options were not added. This PR adds those missing options.

## Related links

- **Parent Issue:** https://github.com/autowarefoundation/autoware_core/issues/968
- Fix for: https://github.com/autowarefoundation/autoware_universe/pull/12329
- [Autoware Discussion about adopting CIE](https://github.com/orgs/autowarefoundation/discussions/6813)
- [What is autoware_agnocast_wrapper?](https://github.com/autowarefoundation/autoware_core/blob/main/common/autoware_agnocast_wrapper/README.md)

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

When `ENABLE_AGNOCAST=0` (default), there is no change in behavior at all — the node runs with the standard ROS 2 executor exactly as before.

When `ENABLE_AGNOCAST=1`, the executor switches to `CallbackIsolatedAgnocastExecutor` (CIE). Internally, CIE creates a dedicated `rclcpp::executors::SingleThreadedExecutor` for each callback group, so the fundamental scheduling behavior within each group remains almost identical. The key difference is that, for nodes originally using `rclcpp::executors::SingleThreadedExecutor`, callback groups now run in parallel across separate threads, similar to `MultiThreadedExecutor`.