### PR TITLE
fix(autoware_universe_utils): fix test for boost geometry

### DIFF
--- a/common/autoware_universe_utils/test/src/geometry/test_geometry.cpp
+++ b/common/autoware_universe_utils/test/src/geometry/test_geometry.cpp
@@ -24,12 +24,12 @@
 
 #include <geometry_msgs/msg/point32.hpp>
 
-#include <boost/version.hpp>
 #include <boost/geometry/algorithms/correct.hpp>
 #include <boost/geometry/algorithms/difference.hpp>
 #include <boost/geometry/algorithms/distance.hpp>
 #include <boost/geometry/algorithms/union.hpp>
 #include <boost/geometry/io/wkt/write.hpp>
+#include <boost/version.hpp>
 
 #include <gtest/gtest.h>
 
@@ -2703,8 +2703,7 @@ TEST(geometry, UnionDifferenceIntersectPolygon)
 
 #if BOOST_VERSION >= 108300  // Boost 1.83+ fixed precision issues in polygon boolean operations
     EXPECT_TRUE(polygon_equal_vector(custom_union_poly, boost_union_result, epsilon));
-    EXPECT_TRUE(
-      polygon_equal_vector(custom_intersection_poly, boost_intersection_result, epsilon));
+    EXPECT_TRUE(polygon_equal_vector(custom_intersection_poly, boost_intersection_result, epsilon));
     EXPECT_TRUE(polygon_equal_vector(custom_difference_poly, boost_difference_result, epsilon));
 #else
     EXPECT_FALSE(polygon_equal_vector(custom_union_poly, boost_union_result, epsilon));


### PR DESCRIPTION
## Description
It seems like there were some [inaccuracy in boost union](https://github.com/autowarefoundation/autoware_universe/blob/d03dc13a9499d7a15d382f7cd903b9462dbbf9a1/common/autoware_universe_utils/test/src/geometry/test_geometry.cpp#L2665-L2666), but it seems like they were fixed in the latest version installed by default in Ubuntu 24.04. This is causing the [test to fail for Jazzy.](https://github.com/autowarefoundation/autoware_universe/actions/runs/23416552678/job/68113062185) 

This PR would change the expected results based on Boost version to fix the error.

Besides this issue, I think we already migrated majority of the library to autoware_utils repository already so I think we could consider removing the package in other PRs so we wouldn't have to maintain the unused library.

## Related links

**Parent Issue:**

- https://github.com/autowarefoundation/autoware/issues/6695

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
I've tested that the test passes on ROS Jazzy locally.

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
