### PR TITLE
fix(autoware_pid_longitudinal_controller): fix test for ROS 2 Jazzy

### DIFF
--- a/control/autoware_pid_longitudinal_controller/test/test_smooth_stop.cpp
+++ b/control/autoware_pid_longitudinal_controller/test/test_smooth_stop.cpp
@@ -16,6 +16,8 @@
 #include "gtest/gtest.h"
 #include "rclcpp/rclcpp.hpp"
 
+#include <chrono>
+#include <thread>
 #include <utility>
 #include <vector>
 
@@ -79,20 +81,18 @@ TEST(TestSmoothStop, calculate_stopping_acceleration)
   EXPECT_EQ(debug_values.getValue(DebugValues::TYPE::SMOOTH_STOP_MODE), 2);
 
   // if not running, weak accel for 0.5 seconds after the previous init or previous weak_acc
-  rclcpp::Rate rate_quart(1.0 / 0.25);
-  rclcpp::Rate rate_half(1.0 / 0.5);
   stop_dist = 0.0;
   current_vel = 0.0;
   accel =
     ss.calculate(stop_dist, current_vel, current_acc, velocity_history, delay_time, debug_values);
   EXPECT_EQ(accel, weak_acc);
   EXPECT_EQ(debug_values.getValue(DebugValues::TYPE::SMOOTH_STOP_MODE), 1);
-  rate_quart.sleep();
+  std::this_thread::sleep_for(std::chrono::milliseconds(250));
   accel =
     ss.calculate(stop_dist, current_vel, current_acc, velocity_history, delay_time, debug_values);
   EXPECT_EQ(accel, weak_acc);
   EXPECT_EQ(debug_values.getValue(DebugValues::TYPE::SMOOTH_STOP_MODE), 1);
-  rate_half.sleep();
+  std::this_thread::sleep_for(std::chrono::milliseconds(500));
   accel =
     ss.calculate(stop_dist, current_vel, current_acc, velocity_history, delay_time, debug_values);
   EXPECT_NE(accel, weak_acc);


### PR DESCRIPTION
## Description
autoware_pid_longitudinal_controller is failing in ROS 2 Jazzy colcon test CI check. 
https://github.com/autowarefoundation/autoware_universe/actions/runs/23465272858/job/68275989889

This is because rclcpp::Rate requires ROS context to be initialized (i.e. require `rclcpp::init()` ) before declaring the class. Since the test only use Rate for waiting purpose and doesn't require to look for use_sim_time parameter, I've modified to use sleep_for function instead. 

## Related links

**Parent Issue:**

- https://github.com/autowarefoundation/autoware/issues/6695

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
Ran colcon test locally in ROS Jazzy environment

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
