### PR TITLE
fix(trajectory_traffic_rule_filter): fix test for ROS Jazzy

### DIFF
--- a/planning/autoware_trajectory_traffic_rule_filter/include/autoware/trajectory_traffic_rule_filter/trajectory_traffic_rule_filter_node.hpp
+++ b/planning/autoware_trajectory_traffic_rule_filter/include/autoware/trajectory_traffic_rule_filter/trajectory_traffic_rule_filter_node.hpp
@@ -49,6 +49,8 @@ class TrajectoryTrafficRuleFilter : public rclcpp::Node
 public:
   explicit TrajectoryTrafficRuleFilter(const rclcpp::NodeOptions & node_options);
 
+  bool has_map() const { return lanelet_map_ptr_ != nullptr; }
+
 private:
   void process(const CandidateTrajectories::ConstSharedPtr msg);
 

--- a/planning/autoware_trajectory_traffic_rule_filter/src/trajectory_traffic_rule_filter_node.cpp
+++ b/planning/autoware_trajectory_traffic_rule_filter/src/trajectory_traffic_rule_filter_node.cpp
@@ -98,7 +98,7 @@ void TrajectoryTrafficRuleFilter::process(const CandidateTrajectories::ConstShar
   autoware_utils_debug::ScopedTimeTrack st(__func__, *time_keeper_);
 
   constexpr auto log_throttle_ms = 5000;
-  if (!lanelet_map_ptr_) {
+  if (!has_map()) {
     RCLCPP_WARN_THROTTLE(get_logger(), *get_clock(), log_throttle_ms, "waiting for lanelet_map");
     return;
   }

--- a/planning/autoware_trajectory_traffic_rule_filter/test/test_traffic_rule_filter_node.cpp
+++ b/planning/autoware_trajectory_traffic_rule_filter/test/test_traffic_rule_filter_node.cpp
@@ -59,6 +59,10 @@ protected:
     autoware_map_msgs::msg::LaneletMapBin map_bin_msg;
     map_pub_->publish(experimental::lanelet2_utils::to_autoware_map_msgs(map));
 
+    // Ensure the map callback is processed before any test publishes trajectories.
+    // Without this, the trajectory callback may fire first and early-return due to missing map.
+    spin_until([this] { return node_under_test_->has_map(); });
+
     tl_pub_ = test_node_->create_publisher<autoware_perception_msgs::msg::TrafficLightGroupArray>(
       "/trajectory_traffic_rule_filter_node/input/traffic_signals", 1);
 


### PR DESCRIPTION
## Description
It seems like the test for ROS 2 Jazzy tend to fail due to missing map.
https://github.com/autowarefoundation/autoware_core/actions/runs/23329785827/job/68010108438

I've added a has_map function to make sure that map is available before publishing other topics in the test.

## Related links

**Parent Issue:**

- https://github.com/autowarefoundation/autoware/issues/6695

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

I have ran colcon test locally in ROS 2 Jazzy environment.
It is also passing the CI check for this PR: https://github.com/autowarefoundation/autoware_universe/actions/runs/23470248716/job/68291164915?pr=12374
## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
