### PR TITLE
fix: revert "fix(behavior_path_side_shift): preserve shifted path shap to prevent chattering (#12278)"

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/scene.cpp
@@ -264,30 +264,20 @@ void SideShiftModule::replaceShiftLine()
 
 BehaviorModuleOutput SideShiftModule::plan()
 {
-  bool should_regenerate_shifted_path = false;
-
   // Replace shift line
   if (
     lateral_offset_change_request_ && ((shift_status_ == SideShiftStatus::BEFORE_SHIFT) ||
                                        (shift_status_ == SideShiftStatus::AFTER_SHIFT))) {
-    should_regenerate_shifted_path = true;
+    replaceShiftLine();
   } else if (shift_status_ != SideShiftStatus::BEFORE_SHIFT) {
     RCLCPP_DEBUG(getLogger(), "ego is shifting");
   } else {
     RCLCPP_DEBUG(getLogger(), "change is not requested");
   }
 
-  // Preserve the shape during shifting by reusing the last generated path unless re-generation
-  // is explicitly required.
+  // Refine path
   ShiftedPath shifted_path;
-  if (should_regenerate_shifted_path || prev_output_.path.points.empty()) {
-    if (should_regenerate_shifted_path) {
-      replaceShiftLine();
-    }
-    path_shifter_.generate(&shifted_path);
-  } else {
-    shifted_path = prev_output_;
-  }
+  path_shifter_.generate(&shifted_path);
 
   if (shifted_path.path.points.empty()) {
     RCLCPP_ERROR(getLogger(), "Generated shift_path has no points");


### PR DESCRIPTION
## Description

This reverts commit 1b4472c60fed4f83b1a1a9de1705af0465bec2b5.
Since this fix doesn't disables the side shift module after the shift is done.
In other words, this fix will not turn `canTransitSuccessState` to `true`.

## Related links
PR to revert
- https://github.com/autowarefoundation/autoware_universe/pull/12278

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
