### PR TITLE
fix(autoware_path_optimizer): fixed an issue with early return and A/B switching to use acados or not

### DIFF
--- a/planning/autoware_path_optimizer/src/mpt_optimizer.cpp
+++ b/planning/autoware_path_optimizer/src/mpt_optimizer.cpp
@@ -506,7 +506,6 @@ std::optional<std::vector<TrajectoryPoint>> MPTOptimizer::optimizeTrajectory(
 
   // 1. calculate reference points
   auto [ref_points, ref_points_spline] = calcReferencePoints(planner_data, traj_points);
-  ref_points_spline.updateCurvatureSpline();
   if (ref_points.size() < 2) {
     RCLCPP_INFO_EXPRESSION(
       logger_, enable_debug_info_, "return std::nullopt since ref_points size is less than 2.");
@@ -533,18 +532,6 @@ std::optional<std::vector<TrajectoryPoint>> MPTOptimizer::optimizeTrajectory(
     return std::nullopt;
   }
 
-  const size_t D_x = state_equation_generator_.getDimX();
-  const size_t D_u = state_equation_generator_.getDimU();
-
-  const size_t N_ref = ref_points.size();
-  const size_t N_x = N_ref * D_x;
-  const size_t N_u = (N_ref - 1) * D_u;
-
-  const auto & optimized_states = optimized_variables->segment(0, N_x);
-  const auto & optimized_steering = optimized_variables->segment(N_x, N_u);
-  publishOptimizedSteering(optimized_steering);
-  publishOptimizedStates(optimized_states, N_ref);
-
   // 7. convert to points with validation
   auto mpt_traj_points = calcMPTPoints(ref_points, *optimized_variables, mpt_mat);
   if (!mpt_traj_points) {
@@ -552,44 +539,59 @@ std::optional<std::vector<TrajectoryPoint>> MPTOptimizer::optimizeTrajectory(
     return std::nullopt;
   }
 
-  if (!mpt_param_.use_acados) {
-    return mpt_traj_points;
+  std::optional<std::vector<TrajectoryPoint>> output_trajectory = mpt_traj_points;
+
+  if (mpt_param_.use_acados) {
+    ref_points_spline.updateCurvatureSpline();
+
+    const size_t D_x = state_equation_generator_.getDimX();
+    const size_t D_u = state_equation_generator_.getDimU();
+    const size_t N_ref = ref_points.size();
+    const size_t N_x = N_ref * D_x;
+    const size_t N_u = (N_ref - 1) * D_u;
+    const auto & optimized_states = optimized_variables->segment(0, N_x);
+    const auto & optimized_steering = optimized_variables->segment(N_x, N_u);
+    publishOptimizedSteering(optimized_steering);
+    publishOptimizedStates(optimized_states, N_ref);
+
+    // 8. run acados mpt (optional)
+    std::optional<std::vector<TrajectoryPoint>> acados_traj_points;
+    AcadosSolution acados_result;
+
+    time_keeper_->start_track("runAcadosMPT");
+    acados_result = runAcadosMPT(ref_points, ref_points_spline, p.ego_pose);
+    time_keeper_->end_track("runAcadosMPT");
+
+    acados_traj_points = convertAcadosSolutionToTrajectory(ref_points, acados_result);
+
+    if (!acados_traj_points) {
+      RCLCPP_WARN(logger_, "Failed to convert Acados solution to trajectory");
+      return std::nullopt;
+    }
+
+    updateDebugDataAndPublishAcadosSteering(acados_result, ref_points, *acados_traj_points);
+
+    // 9.b. publish acados trajectory for debug
+    publishAcadosTrajectory(*acados_traj_points, p.header);
+
+    publishAcadosStates(acados_result);
+
+    publishReferenceTrajectory(ref_points, p.header);
+
+    publishReferenceSteeringAngles(ref_points_spline);
+
+    output_trajectory = std::move(acados_traj_points);
   }
 
-  // 8. run acados mpt (optional)
-  std::optional<std::vector<TrajectoryPoint>> acados_traj_points;
-  AcadosSolution acados_result;
-
-  time_keeper_->start_track("runAcadosMPT");
-  acados_result = runAcadosMPT(ref_points, ref_points_spline, p.ego_pose);
-  time_keeper_->end_track("runAcadosMPT");
-
-  // Convert Acados solution to trajectory points
-  acados_traj_points = convertAcadosSolutionToTrajectory(ref_points, acados_result);
-
-  if (!acados_traj_points) {
-    RCLCPP_WARN(logger_, "Failed to convert Acados solution to trajectory");
-    return std::nullopt;
-  }
-
-  updateDebugDataAndPublishAcadosSteering(acados_result, ref_points, *acados_traj_points);
-
-  publishAcadosTrajectory(*acados_traj_points, p.header);
-
-  publishAcadosStates(acados_result);
-
-  publishReferenceTrajectory(ref_points, p.header);
-
-  publishReferenceSteeringAngles(ref_points_spline);
-
-  // 9. publish trajectories for debug
+  // 9.a. publish trajectories for debug
   publishDebugTrajectories(p.header, ref_points, *mpt_traj_points);
 
   debug_data_ptr_->ref_points = ref_points;
   prev_ref_points_ptr_ = std::make_shared<std::vector<ReferencePoint>>(ref_points);
   prev_optimized_traj_points_ptr_ =
     std::make_shared<std::vector<TrajectoryPoint>>(*mpt_traj_points);
-  return acados_traj_points;
+
+  return output_trajectory;
 }
 
 std::optional<std::vector<TrajectoryPoint>> MPTOptimizer::getPrevOptimizedTrajectoryPoints() const
@@ -1063,14 +1065,23 @@ MPTOptimizer::calcReferencePoints(
   // NOTE: This must be after calculation of bounds and delta arc length
   updateExtraPoints(ref_points);
 
-  // 9. crop forward
-  ref_points = autoware::motion_utils::cropForwardPoints(
-    ref_points, p.ego_pose.position, ego_seg_idx, forward_traj_length);
+  // 9. crop forward — pre-acados used resize(); acados path uses cropForwardPoints
+  if (mpt_param_.use_acados) {
+    ref_points = autoware::motion_utils::cropForwardPoints(
+      ref_points, p.ego_pose.position, ego_seg_idx, forward_traj_length);
 
-  if (ref_points_spline.getSize() == 0) {
+    if (ref_points_spline.getSize() == 0) {
+      return std::make_pair(ref_points, ref_points_spline);
+    }
+
     return std::make_pair(ref_points, ref_points_spline);
   }
 
+  if (static_cast<size_t>(mpt_param_.num_points) < ref_points.size()) {
+    ref_points.resize(mpt_param_.num_points);
+  }
+
+  ref_points_spline = autoware::interpolation::SplineInterpolationPoints2d(ref_points);
   return std::make_pair(ref_points, ref_points_spline);
 }
 


### PR DESCRIPTION
## Description
1. optimizeTrajectory
Call ref_points_spline.updateCurvatureSpline() only if mpt_param_.use_acados.
Publish OSQP steering/states only when use_acados.
After a valid mpt_traj_points, set output_trajectory to OSQP by default, run the acados block only if use_acados, then always run the shared tail: publishDebugTrajectories, update debug_data_ptr_ and prev_* from *mpt_traj_points (same as before for fix-point / warm start), and return output_trajectory (OSQP or acados).

2. calcReferencePoints (step 9)
If use_acados: keep cropForwardPoints and the existing early return.
If not: use resize(mpt_param_.num_points), rebuild ref_points_spline from ref_points, then return the pair.

## Related links

**Parent Issue:**

- [Link](https://tier4.atlassian.net/browse/T4DEV-40103)

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
Succesful evaluator run: https://evaluation.tier4.jp/evaluation/reports/4586a9dd-7dba-5dfe-8918-ac8ced7ec94c?project_id=autoware_dev
## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
