### PR TITLE
fix(autoware_mission_planner_universe): make library name unique for goal_pose_visualizer

### DIFF
--- a/planning/autoware_mission_planner_universe/CMakeLists.txt
+++ b/planning/autoware_mission_planner_universe/CMakeLists.txt
@@ -4,11 +4,11 @@ project(autoware_mission_planner_universe)
 find_package(autoware_cmake REQUIRED)
 autoware_package()
 
-ament_auto_add_library(goal_pose_visualizer_component SHARED
+ament_auto_add_library(${PROJECT_NAME}_goal_pose_visualizer_component SHARED
   src/goal_pose_visualizer/goal_pose_visualizer.cpp
 )
 
-rclcpp_components_register_node(goal_pose_visualizer_component
+rclcpp_components_register_node(${PROJECT_NAME}_goal_pose_visualizer_component
   PLUGIN "autoware::mission_planner_universe::GoalPoseVisualizer"
   EXECUTABLE goal_pose_visualizer
 )


### PR DESCRIPTION
## Description

This PR resolves https://github.com/autowarefoundation/autoware_universe/issues/12340.

We have autoware_mission_planner package in autoware_core which creates the library for goal_pose_visualizer with the same name as the one from autoware_mission_planner_universe package. This causes name clash when we use --merge-install option with colcon build. 

This PR will change the library name so that we have unique library name. 

## Related links

- https://github.com/autowarefoundation/autoware_universe/issues/12340


<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

I built docker image locally and made sure that goal_pose_visualizer can be launched. 

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
