### PR TITLE
fix(autoware_tensorrt_yolox): add missing cstdint include and ament_index_cpp test dependency

### DIFF
--- a/perception/autoware_tensorrt_yolox/include/autoware/tensorrt_yolox/label.hpp
+++ b/perception/autoware_tensorrt_yolox/include/autoware/tensorrt_yolox/label.hpp
@@ -15,6 +15,7 @@
 #ifndef AUTOWARE__TENSORRT_YOLOX__LABEL_HPP_
 #define AUTOWARE__TENSORRT_YOLOX__LABEL_HPP_
 
+#include <cstdint>
 #include <optional>
 #include <string>
 #include <unordered_map>

--- a/perception/autoware_tensorrt_yolox/package.xml
+++ b/perception/autoware_tensorrt_yolox/package.xml
@@ -36,6 +36,7 @@
 
   <exec_depend>autoware_image_transport_decompressor</exec_depend>
 
+  <test_depend>ament_index_cpp</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>
 


### PR DESCRIPTION
- Closes #12399
- Add `#include <cstdint>` to [`label.hpp`](https://github.com/autowarefoundation/autoware_universe/blob/7bc268af7b8f3e93b4a065c163ce16fe55f0f474/perception/autoware_tensorrt_yolox/include/autoware/tensorrt_yolox/label.hpp) for `uint32_t`
- Add `<test_depend>ament_index_cpp</test_depend>` to [`package.xml`](https://github.com/autowarefoundation/autoware_universe/blob/7bc268af7b8f3e93b4a065c163ce16fe55f0f474/perception/autoware_tensorrt_yolox/package.xml) for `test_label.cpp`

## Why

`autoware_tensorrt_yolox` fails to compile on Ubuntu 24.04 / ROS 2 Jazzy because `label.hpp` uses `uint32_t` without including `<cstdint>`, and the test depends on `ament_index_cpp` which is not declared in `package.xml`.

---

## Test plan

- [ ] `colcon build --packages-select autoware_tensorrt_yolox` compiles without errors