### PR TITLE
fix(autoware_freespace_planning_algorithms): check collision at intermediate arc points during A* expansion

### DIFF
--- a/planning/autoware_freespace_planning_algorithms/src/astar_search.cpp
+++ b/planning/autoware_freespace_planning_algorithms/src/astar_search.cpp
@@ -338,6 +338,23 @@ void AstarSearch::expandNodes(AstarNode & current_node, const bool is_back)
     AstarNode * next_node = &graph_[getKey(next_index)];
     if (next_node->status == NodeStatus::Closed || detectCollision(next_index)) continue;
 
+    // Check intermediate points along the arc for collision
+    const double abs_distance = std::abs(distance);
+    if (astar_param_.adapt_expansion_distance && abs_distance > min_expansion_dist_) {
+      const int n = static_cast<int>(abs_distance / min_expansion_dist_);
+      bool has_intermediate_collision = false;
+      for (int j = 1; j < n; ++j) {
+        const double intermediate_dist = (abs_distance * j / n) * direction;
+        const auto intermediate_pose = kinematic_bicycle_model::getPose(
+          current_pose, collision_vehicle_shape_.base_length, steering, intermediate_dist);
+        if (detectCollision(intermediate_pose)) {
+          has_intermediate_collision = true;
+          break;
+        }
+      }
+      if (has_intermediate_collision) continue;
+    }
+
     const auto obs_edt = getObstacleEDT(next_index);
     const bool is_direction_switch =
       (current_node.parent != nullptr) && (is_back != current_node.is_back);


### PR DESCRIPTION
## Summary
- When `adapt_expansion_distance` is enabled, A* node expansion only checked collision at arc endpoints. `setPath()` later interpolates waypoints between nodes, but these intermediate poses were never validated during search.
- On arm64, floating-point differences caused the planner to produce paths where interpolated waypoints clipped obstacles near tight gaps (between parked cars), failing the post-hoc `hasObstacleOnTrajectory` check in `AstarSearchTestSuite.MultiCurvature`.
- This adds intermediate collision checks along the arc in `expandNodes`, using the same `min_expansion_dist_` spacing that `setPath` uses for interpolation. Expansions where any intermediate point collides are now rejected, ensuring the output trajectory is collision-free on all architectures.

## Test plan
- [x] `colcon build --packages-select autoware_freespace_planning_algorithms` passes
- [x] `colcon test --packages-select autoware_freespace_planning_algorithms` passes (all 9 tests, 0 failures)
- [x] `pre-commit` passes
- [x] Verify arm64 CI passes: https://github.com/autowarefoundation/autoware_universe/actions/runs/23863866816
  - It actually passed for arm finally 🥳 https://github.com/autowarefoundation/autoware_universe/actions/runs/23863866816/job/69577508424#step:17:9771
  - The failures are not related to this PR's scope.
    
<img width="1241" height="908" alt="image" src="https://github.com/user-attachments/assets/4969e2ca-ac7d-48ce-a757-f1c3db83470f" />