### PR TITLE
perf(lidar_centerpoint): remove atomic functions by using warp shuffle primitives

### DIFF
--- a/perception/autoware_lidar_centerpoint/lib/preprocess/preprocess_kernel.cu
+++ b/perception/autoware_lidar_centerpoint/lib/preprocess/preprocess_kernel.cu
@@ -291,7 +291,8 @@ __global__ void generateFeatures_kernel(
   float y_val = (point_idx < points_num) ? pillarSM[pillar_idx_inBlock][1][point_idx] : 0.0f;
   float z_val = (point_idx < points_num) ? pillarSM[pillar_idx_inBlock][2][point_idx] : 0.0f;
   // 2. Parallel Reduction using Warp Shuffle
-  // Note that all threads in the warp participate in the reduction as there is no thread divergence.
+  // Note that all threads in the warp participate in the reduction as there is no thread
+  // divergence.
 #pragma unroll
   for (int offset = 16; offset > 0; (offset = offset >> 1)) {
     x_val += __shfl_down_sync(ALL_THREADS_IN_WARP_MASK, x_val, offset);


### PR DESCRIPTION
## Description

This PR improves performance of pre-processing for autoware_lidar_centerpoint by removing unnecessary atomic read/modify/write functions and replacing some of them with CUDA shuffle warp-primitives.

## Related links

**Parent Issue:**

- None

**Private Links:**

- [TIER IV internal link](https://tier4.atlassian.net/browse/T4DEV-51246)

## How was this PR tested?
- [ ] Build passed
- [ ] Existing unit tests passed
  - unit tests that require GPU are disabled and obsolete
- [ ] LiDAR data are processed correctly
  - Objects can be identified in the same way as before

## Notes for reviewers

This PR can be an example of performance improvement of data processing with CUDA.
The code looks a bit tricky, but the techniques used here are orthodox and proven.

Other functions than generateFeatures_kernel() can be improved more, but changes are kept minimum in this PR.

## Interface changes

None.

## Effects on system behavior

None.

The performance of pre-processing for autoware_lidar_centerpoint is improved.
