### PR TITLE
ci(workflow): add clang-tidy job to build-and-test-reusable for jazzy

### DIFF
--- a/.github/workflows/build-and-test-reusable.yaml
+++ b/.github/workflows/build-and-test-reusable.yaml
@@ -184,8 +184,6 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
-        with:
-          fetch-depth: 1
 
       - name: Show disk space before the tasks
         run: df -h


### PR DESCRIPTION
- Add a `clang-tidy` job to the `build-and-test-reusable.yaml` workflow, matching the pattern from autoware_core
- The job runs only for the jazzy+cuda variant, after `build-and-test` succeeds

## Why

The `build-and-test-reusable.yaml` workflow (used by push-to-main and daily builds) had no clang-tidy step, unlike autoware_core's equivalent. This adds static analysis coverage for jazzy full builds, catching issues that the differential clang-tidy on PRs may miss (e.g. cross-package interactions). Restricted to the cuda variant since cuda packages cover non-cuda packages too.

---

## Test plan

- [ ] Trigger a `build-and-test-daily` dispatch against this branch and verify the `clang-tidy` job runs for jazzy-cuda only
   - https://github.com/autowarefoundation/autoware_universe/actions/runs/24007940523
- [ ] Verify `clang-tidy` is skipped for humble and non-cuda variants
- [ ] Check that `clang-tidy-result-jazzy-cuda` artifact is uploaded