### PR TITLE
ci(workflow): merge upload-coverage job into build-and-test

### DIFF
--- a/.github/workflows/build-and-test-reusable.yaml
+++ b/.github/workflows/build-and-test-reusable.yaml
@@ -61,8 +61,6 @@ jobs:
   build-and-test:
     runs-on: ${{ fromJson(inputs.runner) }}
     container: ${{ inputs.container }}${{ inputs.container-suffix }}
-    outputs:
-      coverage-files: ${{ steps.test.outputs.coverage-report-files }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -163,15 +161,15 @@ jobs:
           target-packages: ${{ steps.get-self-packages.outputs.self-packages }}
           build-depends-repos: build_depends.repos
 
-      # Cache lcov/coverage directories for next job
-      - name: Upload coverage artifacts
+      - name: Upload coverage to CodeCov
         if: ${{ steps.test.outputs.coverage-report-files != '' }}
-        uses: actions/upload-artifact@v4
+        uses: codecov/codecov-action@v6
         with:
-          name: coverage-${{ inputs.codecov-flag }}-${{ inputs.rosdistro }}
-          path: |
-            build
-            lcov
+          files: ${{ steps.test.outputs.coverage-report-files }}
+          fail_ci_if_error: false
+          verbose: true
+          flags: ${{ inputs.codecov-flag }}
+          token: ${{ secrets.codecov-token }}
 
       - name: Show disk space after the tasks
         run: df -h
@@ -226,25 +224,3 @@ jobs:
 
       - name: Show disk space after the tasks
         run: df -h
-
-  upload-coverage:
-    runs-on: ubuntu-latest
-    needs: build-and-test
-    if: ${{ needs.build-and-test.outputs.coverage-files != '' }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Download coverage artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: coverage-${{ inputs.codecov-flag }}-${{ inputs.rosdistro }}
-
-      - name: Upload coverage to CodeCov
-        uses: codecov/codecov-action@v4
-        with:
-          files: ${{ needs.build-and-test.outputs.coverage-files }}
-          fail_ci_if_error: false
-          verbose: true
-          flags: ${{ inputs.codecov-flag }}
-          token: ${{ secrets.codecov-token }}


### PR DESCRIPTION
- Upload coverage directly to CodeCov within the `build-and-test` job instead of using a separate `upload-coverage` job with artifact upload/download
- Remove the artifact round-trip (`upload-artifact` + `download-artifact`) and the extra `ubuntu-latest` runner
- Bump `codecov-action` from v4 to v6

## Why

The separate `upload-coverage` job added unnecessary complexity -- it required uploading the entire `build` and `lcov` directories as artifacts, spinning up a new runner, downloading them, and then uploading to CodeCov. Uploading directly from the build job is simpler, faster, and consistent with how the differential workflows already handle coverage.

---

- Verification run: https://github.com/autowarefoundation/autoware_universe/actions/runs/24033523117

## Test plan

- [ ] CI passes on this PR
- [ ] CodeCov report is generated and visible on the PR
- [ ] Verify coverage flags match expected values in [CodeCov dashboard](https://app.codecov.io/gh/autowarefoundation/autoware_universe)