### PR TITLE
ci(workflow): reduce daily build matrix variants

### DIFF
--- a/.github/workflows/build-and-test-daily.yaml
+++ b/.github/workflows/build-and-test-daily.yaml
@@ -14,9 +14,14 @@ jobs:
         cuda: [false, true]
         arch: [amd64, arm64]
 
-        # Exclude Jazzy arm64 until autoware docker-build-and-push publishes native arm64 Jazzy images
         exclude:
-          - rosdistro: jazzy
+          # Humble is being phased out; only run CUDA amd64 as a minimal check
+          - rosdistro: humble
+            arch: arm64
+          - rosdistro: humble
+            cuda: false
+          # Non-CUDA arm64 has no deployment target; keep non-CUDA only on amd64 as a sanity check
+          - cuda: false
             arch: arm64
 
         include:


### PR DESCRIPTION
- Exclude Humble non-CUDA and arm64 variants (Humble is being phased out)
- Exclude non-CUDA arm64 variant (arm64 targets always have CUDA)
- Reduce daily CI from 6 variants to 4

## Why

The daily build matrix ran several variants that provided little value. Humble is being phased out and only needs a minimal CUDA amd64 check. Non-CUDA arm64 builds have no real deployment target since arm64 (Jetson) always has CUDA. The single jazzy/nocuda/amd64 variant is kept as a sanity check that CUDA packages still compile hollowly without CUDA.

## Variants after this PR

| rosdistro | cuda | arch |
|-----------|------|------|
| humble | true | amd64 |
| jazzy | false | amd64 |
| jazzy | true | amd64 |
| jazzy | true | arm64 |

---

## Test plan

- [ ] Trigger the workflow manually via `workflow_dispatch` and verify only 4 matrix jobs are spawned
   - https://github.com/autowarefoundation/autoware_universe/actions/runs/24034170479
- [ ] Verify the 4 jobs are: `humble/cuda/amd64`, `jazzy/nocuda/amd64`, `jazzy/cuda/amd64`, `jazzy/cuda/arm64`