### PR TITLE
feat(pid_longitudinal_controller): parameterize ff_scale limits

### DIFF
--- a/control/autoware_pid_longitudinal_controller/README.md
+++ b/control/autoware_pid_longitudinal_controller/README.md
@@ -215,6 +215,8 @@ AutonomouStuff Lexus RX 450h for under 40 km/h driving.
 | enable_integration_at_low_speed       | bool   | Whether to enable integration of acceleration errors when the vehicle speed is lower than `current_vel_threshold_pid_integration` or not.                          | false         |
 | current_vel_threshold_pid_integration | double | Velocity error is integrated for I-term only when the absolute value of current velocity is larger than this parameter. [m/s]                                      | 0.5           |
 | time_threshold_before_pid_integration | double | How much time without the vehicle moving must past to enable PID error integration. [s]                                                                            | 5.0           |
+| ff_scale_min                          | double | Minimum clamp value for feedforward scaling applied during the time-to-arclength conversion.                                                                       | 0.5           |
+| ff_scale_max                          | double | Maximum clamp value for feedforward scaling applied during the time-to-arclength conversion.                                                                       | 2.0           |
 | brake_keeping_acc                     | double | If `enable_brake_keeping_before_stop` is true, a certain acceleration is kept during DRIVE state before the ego stops [m/s^2] See [Brake keeping](#brake-keeping). | 0.2           |
 
 ### STOPPING Parameter (smooth stop)

--- a/control/autoware_pid_longitudinal_controller/config/autoware_pid_longitudinal_controller.param.yaml
+++ b/control/autoware_pid_longitudinal_controller/config/autoware_pid_longitudinal_controller.param.yaml
@@ -33,6 +33,8 @@
     enable_integration_at_low_speed: false
     current_vel_threshold_pid_integration: 0.5
     time_threshold_before_pid_integration: 2.0
+    ff_scale_min: 0.5
+    ff_scale_max: 2.0
     enable_brake_keeping_before_stop: false
     brake_keeping_acc: -0.2
 

--- a/control/autoware_pid_longitudinal_controller/include/autoware/pid_longitudinal_controller/pid_longitudinal_controller.hpp
+++ b/control/autoware_pid_longitudinal_controller/include/autoware/pid_longitudinal_controller/pid_longitudinal_controller.hpp
@@ -169,6 +169,8 @@ private:
   bool m_enable_integration_at_low_speed;
   double m_current_vel_threshold_pid_integrate;
   double m_time_threshold_before_pid_integrate;
+  double m_ff_scale_min{0.5};
+  double m_ff_scale_max{2.0};
   bool m_enable_brake_keeping_before_stop;
   double m_brake_keeping_acc;
 

--- a/control/autoware_pid_longitudinal_controller/schema/autoware_pid_longitudinal_controller.schema.json
+++ b/control/autoware_pid_longitudinal_controller/schema/autoware_pid_longitudinal_controller.schema.json
@@ -146,6 +146,16 @@
           "description": "How much time without the vehicle moving must past to enable PID error integration. [s]",
           "default": "2.0"
         },
+        "ff_scale_min": {
+          "type": "number",
+          "description": "minimum clamp value for feedforward scaling",
+          "default": "0.5"
+        },
+        "ff_scale_max": {
+          "type": "number",
+          "description": "maximum clamp value for feedforward scaling",
+          "default": "2.0"
+        },
         "enable_brake_keeping_before_stop": {
           "type": "boolean",
           "description": "flag to keep a certain acceleration during DRIVE state before the ego stops. See [Brake keeping]",

--- a/control/autoware_pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
+++ b/control/autoware_pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
@@ -112,6 +112,8 @@ PidLongitudinalController::PidLongitudinalController(
 
     m_time_threshold_before_pid_integrate =
       node.declare_parameter<double>("time_threshold_before_pid_integration");  // [s]
+    m_ff_scale_min = node.declare_parameter<double>("ff_scale_min");
+    m_ff_scale_max = node.declare_parameter<double>("ff_scale_max");
 
     m_enable_brake_keeping_before_stop =
       node.declare_parameter<bool>("enable_brake_keeping_before_stop");         // [-]
@@ -321,6 +323,8 @@ rcl_interfaces::msg::SetParametersResult PidLongitudinalController::paramCallbac
 
     update_param("current_vel_threshold_pid_integration", m_current_vel_threshold_pid_integrate);
     update_param("time_threshold_before_pid_integration", m_time_threshold_before_pid_integrate);
+    update_param("ff_scale_min", m_ff_scale_min);
+    update_param("ff_scale_max", m_ff_scale_max);
   }
 
   // stopping state
@@ -1159,10 +1163,9 @@ double PidLongitudinalController::applyVelocityFeedback(const ControlData & cont
   // Details: For accurate control, the feedforward should be calculated in the arclength coordinate
   // system, not in the time coordinate system. Otherwise, even if FF is applied, the vehicle speed
   // deviation will be bigger.
-  constexpr double ff_scale_max = 2.0;  // for safety
-  constexpr double ff_scale_min = 0.5;  // for safety
   const double ff_scale = std::clamp(
-    std::abs(current_vel) / std::max(std::abs(target_motion.vel), 0.1), ff_scale_min, ff_scale_max);
+    std::abs(current_vel) / std::max(std::abs(target_motion.vel), 0.1), m_ff_scale_min,
+    m_ff_scale_max);
   const double ff_acc =
     control_data.interpolated_traj.points.at(control_data.target_idx).acceleration_mps2 * ff_scale;
 

--- a/control/autoware_trajectory_follower_node/param/longitudinal/pid.param.yaml
+++ b/control/autoware_trajectory_follower_node/param/longitudinal/pid.param.yaml
@@ -33,6 +33,8 @@
     enable_integration_at_low_speed: false
     current_vel_threshold_pid_integration: 0.5
     time_threshold_before_pid_integration: 2.0
+    ff_scale_min: 0.5
+    ff_scale_max: 2.0
     enable_brake_keeping_before_stop: false
     brake_keeping_acc: -0.2
 


### PR DESCRIPTION
## Description
Parameterize the feedforward scaling clamp limits in the PID longitudinal controller. 

- add `ff_scale_min` / `ff_scale_max`
- update controller, config, schema, launcher config, and README

Default values keep the current behavior (`0.5`, `2.0`), and the scaling formula itself is unchanged.

## Related links
None

## How was this PR tested?
TIER IV internal tests
[FuncVerif_Basic](https://evaluation.tier4.jp/evaluation/reports/6596ec00-65de-596d-84b4-d3d74326d52f?project_id=prd_jt)
[DLR_Basic](https://evaluation.tier4.jp/evaluation/reports/2c2cf152-c8c2-5eb8-a449-c1fe3fa9b483?project_id=prd_jt)

## Notes for reviewers
None.

## Interface changes

### ROS Parameter Changes
#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added | `ff_scale_min`   | `double` | `0.5`         | Minimum clamp value for feedforward scaling applied during the time-to-arclength conversion. |
| Added | `ff_scale_max`   | `double` | `2.0`         | Maximum clamp value for feedforward scaling applied during the time-to-arclength conversion. |

## Effects on system behavior
None, since the default values are not changed
