### PR TITLE
feat(autoware_deprecated_boundary_departure_checker): replace autoware_universe_utils with autoware_utils_geometry

### DIFF
--- a/common/autoware_deprecated_boundary_departure_checker/package.xml
+++ b/common/autoware_deprecated_boundary_departure_checker/package.xml
@@ -22,7 +22,6 @@
   <depend>autoware_motion_utils</depend>
   <depend>autoware_planning_msgs</depend>
   <depend>autoware_trajectory</depend>
-  <depend>autoware_universe_utils</depend>
   <depend>autoware_utils_debug</depend>
   <depend>autoware_utils_geometry</depend>
   <depend>autoware_utils_system</depend>

--- a/common/autoware_deprecated_boundary_departure_checker/src/footprint_generator/steering.cpp
+++ b/common/autoware_deprecated_boundary_departure_checker/src/footprint_generator/steering.cpp
@@ -14,7 +14,6 @@
 
 #include "autoware/deprecated/boundary_departure_checker/footprint_generator/steering.hpp"
 
-
 #include <autoware/interpolation/linear_interpolation.hpp>
 #include <autoware_utils_geometry/geometry.hpp>
 #include <autoware_vehicle_info_utils/vehicle_info.hpp>

--- a/common/autoware_deprecated_boundary_departure_checker/src/footprint_generator/steering.cpp
+++ b/common/autoware_deprecated_boundary_departure_checker/src/footprint_generator/steering.cpp
@@ -14,7 +14,6 @@
 
 #include "autoware/deprecated/boundary_departure_checker/footprint_generator/steering.hpp"
 
-#include "autoware/universe_utils/geometry/geometry.hpp"
 
 #include <autoware/interpolation/linear_interpolation.hpp>
 #include <autoware_utils_geometry/geometry.hpp>

--- a/common/autoware_deprecated_boundary_departure_checker/src/uncrossable_boundary_checker.cpp
+++ b/common/autoware_deprecated_boundary_departure_checker/src/uncrossable_boundary_checker.cpp
@@ -23,7 +23,7 @@
 #include <autoware/motion_utils/trajectory/trajectory.hpp>
 #include <autoware/trajectory/trajectory_point.hpp>
 #include <autoware/trajectory/utils/closest.hpp>
-#include <autoware/universe_utils/geometry/geometry.hpp>
+#include <autoware_utils_geometry/geometry.hpp>
 #include <autoware_utils_math/normalization.hpp>
 #include <autoware_utils_math/unit_conversion.hpp>
 #include <autoware_utils_system/stop_watch.hpp>

--- a/common/autoware_deprecated_boundary_departure_checker/src/utils.cpp
+++ b/common/autoware_deprecated_boundary_departure_checker/src/utils.cpp
@@ -21,7 +21,6 @@
 #include <autoware/motion_utils/trajectory/trajectory.hpp>
 #include <autoware/trajectory/trajectory_point.hpp>
 #include <autoware/trajectory/utils/closest.hpp>
-#include <autoware/universe_utils/geometry/geometry.hpp>
 #include <autoware_utils_geometry/boost_geometry.hpp>
 #include <autoware_utils_geometry/geometry.hpp>
 #include <autoware_utils_math/unit_conversion.hpp>
@@ -796,7 +795,7 @@ std::optional<std::pair<double, double>> is_point_shifted(
   const auto yaw_diff_rad = std::abs(curr_pt_yaw_rad - prev_pt_yaw_rad);
 
   const auto dist_m =
-    autoware::universe_utils::calcDistance2d(curr_iter_pt.position, prev_iter_pt.position);
+    autoware_utils_geometry::calc_distance2d(curr_iter_pt.position, prev_iter_pt.position);
   if (dist_m > th_shift_m || yaw_diff_rad > th_yaw_diff_rad) {
     return std::make_pair(dist_m, yaw_diff_rad);
   }

--- a/planning/autoware_trajectory_validator/package.xml
+++ b/planning/autoware_trajectory_validator/package.xml
@@ -31,6 +31,7 @@
   <depend>autoware_utils_debug</depend>
   <depend>autoware_utils_geometry</depend>
   <depend>autoware_utils_rclcpp</depend>
+  <depend>autoware_utils_diagnostics</depend>
   <depend>autoware_vehicle_info_utils</depend>
   <depend>generate_parameter_library</depend>
   <depend>geometry_msgs</depend>

--- a/planning/autoware_trajectory_validator/package.xml
+++ b/planning/autoware_trajectory_validator/package.xml
@@ -29,9 +29,9 @@
   <depend>autoware_planning_msgs</depend>
   <depend>autoware_traffic_light_utils</depend>
   <depend>autoware_utils_debug</depend>
+  <depend>autoware_utils_diagnostics</depend>
   <depend>autoware_utils_geometry</depend>
   <depend>autoware_utils_rclcpp</depend>
-  <depend>autoware_utils_diagnostics</depend>
   <depend>autoware_vehicle_info_utils</depend>
   <depend>generate_parameter_library</depend>
   <depend>geometry_msgs</depend>


### PR DESCRIPTION
## Description

Removes the `autoware_universe_utils` dependency from `autoware_deprecated_boundary_departure_checker` in the **common** module, migrating geometry-related usage to `autoware_utils_geometry` as part of #12376.

## Changes

**`common/autoware_deprecated_boundary_departure_checker/package.xml`**
- Removed `<depend>autoware_universe_utils</depend>`

**`common/autoware_deprecated_boundary_departure_checker/src/footprint_generator/steering.cpp`**
- Removed unused include: `autoware/universe_utils/geometry/geometry.hpp` (autoware_utils_geometry was already included)

**`common/autoware_deprecated_boundary_departure_checker/src/uncrossable_boundary_checker.cpp`**
- `autoware/universe_utils/geometry/geometry.hpp` → `autoware_utils_geometry/geometry.hpp`

**`common/autoware_deprecated_boundary_departure_checker/src/utils.cpp`**
- Removed duplicate include of `autoware/universe_utils/geometry/geometry.hpp`
- `autoware::universe_utils::calcDistance2d` → `autoware_utils_geometry::calc_distance2d`

## Related Issue

Addresses the **common** checklist item in #12376.

## Note

Rebased onto main after the package was renamed to `autoware_deprecated_boundary_departure_checker` in #12420.