### PR TITLE
ci(codecov): disable search and bump to v6

### DIFF
--- a/.github/workflows/build-and-test-differential-arm64.yaml
+++ b/.github/workflows/build-and-test-differential-arm64.yaml
@@ -101,13 +101,14 @@ jobs:
 
       - name: Upload coverage to CodeCov
         if: ${{ steps.test.outputs.coverage-report-files != '' }}
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v6
         with:
           files: ${{ steps.test.outputs.coverage-report-files }}
           fail_ci_if_error: false
           verbose: true
           flags: differential-arm64
           token: ${{ secrets.CODECOV_TOKEN }}
+          disable_search: true
 
       - name: Show disk space after the tasks
         run: df -h

--- a/.github/workflows/build-and-test-differential.yaml
+++ b/.github/workflows/build-and-test-differential.yaml
@@ -135,13 +135,14 @@ jobs:
 
       - name: Upload coverage to CodeCov
         if: ${{ steps.test.outputs.coverage-report-files != '' }}
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v6
         with:
           files: ${{ steps.test.outputs.coverage-report-files }}
           fail_ci_if_error: false
           verbose: true
           flags: differential${{ inputs.container-suffix }}
           token: ${{ secrets.codecov-token }}
+          disable_search: true
 
       - name: Show disk space after the tasks
         run: df -h

--- a/.github/workflows/build-and-test-packages-above-differential.yaml
+++ b/.github/workflows/build-and-test-packages-above-differential.yaml
@@ -136,13 +136,14 @@ jobs:
 
       - name: Upload coverage to CodeCov
         if: ${{ steps.test.outputs.coverage-report-files != '' }}
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v6
         with:
           files: ${{ steps.test.outputs.coverage-report-files }}
           fail_ci_if_error: false
           verbose: true
           flags: differential${{ inputs.container-suffix }}
           token: ${{ secrets.codecov-token }}
+          disable_search: true
 
       - name: Show disk space after the tasks
         run: df -h

--- a/.github/workflows/build-and-test-reusable.yaml
+++ b/.github/workflows/build-and-test-reusable.yaml
@@ -170,6 +170,7 @@ jobs:
           verbose: true
           flags: ${{ inputs.codecov-flag }}
           token: ${{ secrets.codecov-token }}
+          disable_search: true
 
       - name: Show disk space after the tasks
         run: df -h


### PR DESCRIPTION
## Summary

- Add `disable_search: true` to all four `codecov/codecov-action` steps across CI workflows
- Bump `codecov/codecov-action` from v4 to v6 in the three differential workflows
- Prevents the Codecov CLI from running its built-in gcov plugin, which redundantly re-scans every `.gcno` file before upload even when `files:` is explicitly provided
- On Jazzy (lcov 2.x), this scan was taking 25-60+ minutes and causing CUDA build jobs to time out

## Why

The Codecov CLI (v4/v6) enables a gcov plugin by default that walks all `.gcno` files and runs `gcov` on each one. This is redundant because `total_coverage.info` (produced by `colcon lcov-result`) already contains all coverage data -- lcov uses gcov internally.

On Jazzy, gcov 13 is significantly slower than gcov 11 (Humble), and with CUDA builds (~7000 `.gcno` files), the upload step exceeded the job timeout.

All affected steps already pass `files:` explicitly from the `colcon-test` action output, so disabling the search loses zero coverage data.

## Related

- autowarefoundation/autoware-github-actions#401 (lcov 2.x config fix)
- autowarefoundation/autoware-github-actions#399 (tracking issue)
- [Detailed analysis gist](https://gist.github.com/xmfcx/59f083778ce35a5e4caf8e9c28c7fc8d)

## Test plan

- [ ] Verify on that codecov upload completes in seconds with `disable_search: true`
   - https://github.com/autowarefoundation/autoware_universe/actions/runs/24071683635
- [ ] Confirm Codecov reports still show expected coverage flags after merge