### PR TITLE
ci(codecov): limit differential upload to jazzy-cuda and disable global carryforward

### DIFF
--- a/.github/workflows/build-and-test-differential-arm64.yaml
+++ b/.github/workflows/build-and-test-differential-arm64.yaml
@@ -99,16 +99,5 @@ jobs:
           target-packages: ${{ steps.get-modified-packages.outputs.modified-packages }}
           build-depends-repos: build_depends.repos
 
-      - name: Upload coverage to CodeCov
-        if: ${{ steps.test.outputs.coverage-report-files != '' }}
-        uses: codecov/codecov-action@v6
-        with:
-          files: ${{ steps.test.outputs.coverage-report-files }}
-          fail_ci_if_error: false
-          verbose: true
-          flags: differential-arm64
-          token: ${{ secrets.CODECOV_TOKEN }}
-          disable_search: true
-
       - name: Show disk space after the tasks
         run: df -h

--- a/.github/workflows/build-and-test-differential.yaml
+++ b/.github/workflows/build-and-test-differential.yaml
@@ -134,13 +134,13 @@ jobs:
           build-depends-repos: build_depends.repos
 
       - name: Upload coverage to CodeCov
-        if: ${{ steps.test.outputs.coverage-report-files != '' }}
+        if: ${{ steps.test.outputs.coverage-report-files != '' && inputs.container-suffix == '-cuda' && inputs.rosdistro == 'jazzy' }}
         uses: codecov/codecov-action@v6
         with:
           files: ${{ steps.test.outputs.coverage-report-files }}
           fail_ci_if_error: false
           verbose: true
-          flags: differential${{ inputs.container-suffix }}
+          flags: differential-${{ inputs.rosdistro }}-cuda
           token: ${{ secrets.codecov-token }}
           disable_search: true
 

--- a/.github/workflows/build-and-test-packages-above-differential.yaml
+++ b/.github/workflows/build-and-test-packages-above-differential.yaml
@@ -26,9 +26,6 @@ on:
         required: false
         default: ""
         type: string
-    secrets:
-      codecov-token:
-        required: true
 
 env:
   CC: /usr/lib/ccache/gcc
@@ -133,17 +130,6 @@ jobs:
           target-packages: ${{ steps.get-modified-packages.outputs.modified-packages }}
           build-depends-repos: build_depends.repos
           packages-above-repos: packages_above.repos
-
-      - name: Upload coverage to CodeCov
-        if: ${{ steps.test.outputs.coverage-report-files != '' }}
-        uses: codecov/codecov-action@v6
-        with:
-          files: ${{ steps.test.outputs.coverage-report-files }}
-          fail_ci_if_error: false
-          verbose: true
-          flags: differential${{ inputs.container-suffix }}
-          token: ${{ secrets.codecov-token }}
-          disable_search: true
 
       - name: Show disk space after the tasks
         run: df -h

--- a/.github/workflows/build-test-tidy-pr.yaml
+++ b/.github/workflows/build-test-tidy-pr.yaml
@@ -82,8 +82,6 @@ jobs:
       container: ${{ matrix.container }}
       run-condition: ${{ needs.require-label.outputs.result == 'true' }}
       runner: "['self-hosted', 'Linux', 'X64']"
-    secrets:
-      codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
   build-and-test-differential-cuda:
     if: ${{ always() }}

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -16,7 +16,7 @@ comment:
 
 flag_management:
   default_rules:
-    carryforward: true
+    carryforward: false
     statuses:
       - name_prefix: project-
         type: project
@@ -26,6 +26,9 @@ flag_management:
         type: patch
         target: 0% # Make CI always succeed
         threshold: 100% # Make CI always succeed
+  individual_flags:
+    - name: differential-jazzy-cuda
+      carryforward: true
 
 ignore:
   - "**/test/*"


### PR DESCRIPTION
## Summary

- Remove codecov upload from arm64 and packages-above-differential workflows
- Restrict differential upload to jazzy+cuda only (flag: `differential-jazzy-cuda`)
- Disable global carryforward in codecov.yaml; enable it only for `differential-jazzy-cuda`
- Clean up dead `codecov-token` secret from packages-above workflow and its caller

## Why

Every matrix variant was uploading separate coverage reports and all flags
carried stale data forward indefinitely, causing inflated or misleading
coverage on PRs that didn't trigger every job. A single authoritative upload
(jazzy+cuda) with targeted carryforward gives a cleaner coverage signal.

## Test plan

- [ ] Confirm only jazzy+cuda differential job uploads to Codecov
- [ ] Confirm packages-above jobs complete without codecov step
- [ ] Verify non-differential flags no longer show carryforward data on new commits
  - https://github.com/autowarefoundation/autoware_universe/actions/runs/24078513867