### PR TITLE
ci(codecov): add upload-coverage param to limit coverage uploads

### DIFF
--- a/.github/workflows/build-and-test-daily.yaml
+++ b/.github/workflows/build-and-test-daily.yaml
@@ -60,6 +60,7 @@ jobs:
       pull-ccache: true
       push-ccache: false
       concurrency-group: build-and-test-daily-${{ matrix.rosdistro }}-${{ matrix.arch }}-${{ matrix.cache-suffix }}-${{ github.ref }}-${{ github.run_id }}
+      upload-coverage: ${{ matrix.rosdistro == 'jazzy' && matrix.arch == 'amd64' && matrix.cuda }}
       codecov-flag: daily-${{ matrix.rosdistro }}-${{ matrix.arch }}-${{ matrix.cache-suffix }}
     secrets:
       codecov-token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/build-and-test-reusable.yaml
+++ b/.github/workflows/build-and-test-reusable.yaml
@@ -41,6 +41,10 @@ on:
         type: boolean
         default: false
         required: false
+      upload-coverage:
+        type: boolean
+        default: false
+        required: false
       codecov-flag:
         type: string
         default: temp
@@ -162,7 +166,7 @@ jobs:
           build-depends-repos: build_depends.repos
 
       - name: Upload coverage to CodeCov
-        if: ${{ steps.test.outputs.coverage-report-files != '' }}
+        if: ${{ steps.test.outputs.coverage-report-files != '' && inputs.upload-coverage }}
         uses: codecov/codecov-action@v6
         with:
           files: ${{ steps.test.outputs.coverage-report-files }}

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -30,6 +30,7 @@ jobs:
       cancel-in-progress: false
       pull-ccache: false
       push-ccache: true
+      upload-coverage: ${{ matrix.rosdistro == 'jazzy' }}
       codecov-flag: total-${{ matrix.rosdistro }}-cuda
     secrets:
       codecov-token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Summary

- Adds an `upload-coverage` boolean input (default `false`) to `build-and-test-reusable.yaml` so callers explicitly opt in to Codecov uploads instead of uploading from every matrix leg that produces coverage artifacts.
- In `build-and-test.yaml` (on-push to main), uploads are restricted to the `jazzy` leg only.
- In `build-and-test-daily.yaml` (nightly schedule), uploads are restricted to the single `jazzy + amd64 + CUDA` combination, eliminating redundant uploads from humble, arm64, and non-CUDA legs.

## Why

Previously, every matrix leg that produced coverage artifact files would unconditionally upload to Codecov. This resulted in multiple redundant reports, causing noisy or inaccurate aggregate coverage data. By gating uploads behind an explicit opt-in parameter, only the canonical builds contribute coverage, making reports consistent and easier to interpret.

## Before / After

### `build-and-test.yaml` (on-push)

| Matrix leg | Before | After |
|---|---|---|
| jazzy | ✅ | ✅ |
| humble | ✅ | ❌ |

### `build-and-test-daily.yaml` (nightly)

| Matrix leg | Before | After |
|---|---|---|
| jazzy / amd64 / cuda | ✅ | ✅ |
| jazzy / amd64 / no-cuda | ✅ | ❌ |
| jazzy / arm64 / cuda | ✅ | ❌ |
| humble / amd64 / cuda | ✅ | ❌ |

## Test plan

- [ ] Manual daily dispatch run: https://github.com/autowarefoundation/autoware_universe/actions/runs/24086916015
  - Confirm only the `jazzy / amd64 / cuda` matrix leg executes the upload step; all others skip it.
- [ ] Verify the on-push `build-and-test` workflow shows the Codecov upload step skipped for `humble` and executed for `jazzy`.
- [ ] Check Codecov dashboard for no duplicate flag reports after the first post-merge run.