### PR TITLE
ci(workflow): skip clang-tidy for arm64 daily builds

### DIFF
--- a/.github/workflows/build-and-test-daily.yaml
+++ b/.github/workflows/build-and-test-daily.yaml
@@ -57,6 +57,7 @@ jobs:
       container-suffix: ${{ matrix.container-suffix }}
       runner: ${{ matrix.runner }}
       build-pre-command: ${{ matrix.build-pre-command }}
+      arch: ${{ matrix.arch }}
       pull-ccache: true
       push-ccache: false
       concurrency-group: build-and-test-daily-${{ matrix.rosdistro }}-${{ matrix.arch }}-${{ matrix.cache-suffix }}-${{ github.ref }}-${{ github.run_id }}

--- a/.github/workflows/build-and-test-reusable.yaml
+++ b/.github/workflows/build-and-test-reusable.yaml
@@ -25,6 +25,10 @@ on:
         type: string
         default: ""
         required: false
+      arch:
+        type: string
+        default: amd64
+        required: false
       push-ccache:
         type: boolean
         default: false
@@ -177,7 +181,7 @@ jobs:
 
   clang-tidy:
     needs: build-and-test
-    if: ${{ inputs.rosdistro == 'jazzy' && inputs.container-suffix == '-cuda' }}
+    if: ${{ inputs.rosdistro == 'jazzy' && inputs.container-suffix == '-cuda' && inputs.arch == 'amd64' }}
     runs-on: ubuntu-latest
     container: ${{ inputs.container }}${{ inputs.container-suffix }}
     steps:


### PR DESCRIPTION
## Summary

- Follows up #12414 (reduced daily build matrix variants)
- Adds an `arch` input (default: `amd64`) to `build-and-test-reusable.yaml` and gates the `clang-tidy` job on `inputs.arch == 'amd64'`
- Passes `arch` from the daily workflow matrix to the reusable workflow

## Why

Clang-tidy only needs to run once per change, on amd64. The arm64 CUDA daily variant was inadvertently triggering a redundant clang-tidy run, wasting runner time without surfacing additional issues.

## Test plan

- [ ] Trigger the `build-and-test-daily` workflow manually and confirm clang-tidy only runs for `jazzy/cuda/amd64`, not `jazzy/cuda/arm64`
  - https://github.com/autowarefoundation/autoware_universe/actions/runs/24094835313
- [ ] Confirm the push-to-main `build-and-test` workflow (which does not pass `arch`) still triggers clang-tidy for jazzy, since `arch` defaults to `amd64`