### PR TITLE
feat(system): replace autoware_universe_utils with specific autoware_utils sub-packages

### DIFF
--- a/system/autoware_command_mode_decider/package.xml
+++ b/system/autoware_command_mode_decider/package.xml
@@ -16,6 +16,7 @@
   <depend>autoware_internal_debug_msgs</depend>
   <depend>autoware_system_msgs</depend>
   <depend>autoware_utils_rclcpp</depend>
+  <depend>autoware_vehicle_msgs</depend>
   <depend>diagnostic_updater</depend>
   <depend>pluginlib</depend>
   <depend>rclcpp</depend>

--- a/system/autoware_command_mode_decider/package.xml
+++ b/system/autoware_command_mode_decider/package.xml
@@ -15,7 +15,7 @@
   <depend>autoware_command_mode_types</depend>
   <depend>autoware_internal_debug_msgs</depend>
   <depend>autoware_system_msgs</depend>
-  <depend>autoware_universe_utils</depend>
+  <depend>autoware_utils_rclcpp</depend>
   <depend>diagnostic_updater</depend>
   <depend>pluginlib</depend>
   <depend>rclcpp</depend>

--- a/system/autoware_command_mode_decider/src/command_mode_decider_base.hpp
+++ b/system/autoware_command_mode_decider/src/command_mode_decider_base.hpp
@@ -18,7 +18,7 @@
 #include "autoware_command_mode_decider/plugin.hpp"
 #include "autoware_command_mode_decider/status.hpp"
 
-#include <autoware/universe_utils/ros/polling_subscriber.hpp>
+#include <autoware_utils_rclcpp/polling_subscriber.hpp>
 #include <diagnostic_updater/diagnostic_updater.hpp>
 #include <pluginlib/class_loader.hpp>
 #include <rclcpp/rclcpp.hpp>

--- a/system/autoware_pipeline_latency_monitor/package.xml
+++ b/system/autoware_pipeline_latency_monitor/package.xml
@@ -24,7 +24,7 @@
   <depend>autoware_internal_debug_msgs</depend>
   <depend>autoware_planning_msgs</depend>
   <depend>autoware_planning_validator</depend>
-  <depend>autoware_universe_utils</depend>
+  <depend>autoware_utils_debug</depend>
   <depend>diagnostic_msgs</depend>
   <depend>diagnostic_updater</depend>
   <depend>rclcpp</depend>

--- a/system/autoware_pipeline_latency_monitor/src/pipeline_latency_monitor_node.cpp
+++ b/system/autoware_pipeline_latency_monitor/src/pipeline_latency_monitor_node.cpp
@@ -124,7 +124,7 @@ PipelineLatencyMonitorNode::PipelineLatencyMonitorNode(const rclcpp::NodeOptions
 
   // Create debug publisher
   debug_publisher_ =
-    std::make_unique<autoware::universe_utils::DebugPublisher>(this, "pipeline_latency_monitor");
+    std::make_unique<autoware_utils_debug::DebugPublisher>(this, "pipeline_latency_monitor");
 
   // Setup diagnostic updater
   diagnostic_updater_.setHardwareID("pipeline_latency_monitor");

--- a/system/autoware_pipeline_latency_monitor/src/pipeline_latency_monitor_node.hpp
+++ b/system/autoware_pipeline_latency_monitor/src/pipeline_latency_monitor_node.hpp
@@ -15,7 +15,7 @@
 #ifndef PIPELINE_LATENCY_MONITOR_NODE_HPP_
 #define PIPELINE_LATENCY_MONITOR_NODE_HPP_
 
-#include <autoware/universe_utils/ros/debug_publisher.hpp>
+#include <autoware_utils_debug/debug_publisher.hpp>
 #include <diagnostic_updater/diagnostic_updater.hpp>
 #include <rclcpp/rclcpp.hpp>
 
@@ -79,7 +79,7 @@ private:
     total_latency_pub_;
 
   // Debug publisher
-  std::unique_ptr<autoware::universe_utils::DebugPublisher> debug_publisher_;
+  std::unique_ptr<autoware_utils_debug::DebugPublisher> debug_publisher_;
 
   // Diagnostic updater
   diagnostic_updater::Updater diagnostic_updater_;


### PR DESCRIPTION
## Description

Removes the `autoware_universe_utils` dependency from the **system** module by migrating:
- `autoware_command_mode_decider` to `autoware_utils_rclcpp`
- `autoware_pipeline_latency_monitor` to `autoware_utils_debug`

This is part of #12376.

## Changes

### `system/autoware_command_mode_decider/package.xml`
- `autoware_universe_utils` → `autoware_utils_rclcpp`

### `system/autoware_command_mode_decider/src/command_mode_decider_base.hpp`
- `autoware/universe_utils/ros/polling_subscriber.hpp`
  → `autoware_utils_rclcpp/polling_subscriber.hpp`

### `system/autoware_pipeline_latency_monitor/package.xml`
- `autoware_universe_utils` → `autoware_utils_debug`

### `system/autoware_pipeline_latency_monitor/src/pipeline_latency_monitor_node.hpp`
- `autoware/universe_utils/ros/debug_publisher.hpp`
  → `autoware_utils_debug/debug_publisher.hpp`
- `autoware::universe_utils::DebugPublisher`
  → `autoware_utils_debug::DebugPublisher`

### `system/autoware_pipeline_latency_monitor/src/pipeline_latency_monitor_node.cpp`
- `autoware::universe_utils::DebugPublisher`
  → `autoware_utils_debug::DebugPublisher`

## Related Issue

Addresses the **system** checklist item in #12376.