### PR TITLE
fix(manual_lane_change_handler): add check for planner readiness before processing route

### DIFF
--- a/planning/autoware_manual_lane_change_handler/src/manual_lane_change_handler.cpp
+++ b/planning/autoware_manual_lane_change_handler/src/manual_lane_change_handler.cpp
@@ -102,6 +102,12 @@ void ManualLaneChangeHandler::route_callback(const LaneletRoute::ConstSharedPtr 
   auto route = *msg;
   planner_->updateRoute(*msg);
 
+  if (!planner_->ready()) {
+    RCLCPP_WARN(logger_, "Lanelet map not yet loaded; skipping primitive sort.");
+    current_route_ = std::make_shared<LaneletRoute>(route);
+    return;
+  }
+
   const auto & route_handler = planner_->getRouteHandler();
   std::for_each(route.segments.begin(), route.segments.end(), [&](auto & segment) {
     segment.primitives =


### PR DESCRIPTION
## Description
Added a check to ensure the planner is ready before processing the route. If the lanelet map is not loaded, a warning is logged and the function exits early to prevent errors during route handling.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
