### PR TITLE
ci(codecov): disable gcov plugin to speed up uploads

### DIFF
--- a/.github/workflows/build-and-test-differential.yaml
+++ b/.github/workflows/build-and-test-differential.yaml
@@ -143,6 +143,9 @@ jobs:
           flags: differential-${{ inputs.rosdistro }}-cuda
           token: ${{ secrets.codecov-token }}
           disable_search: true
+          # Disable gcov and xcode plugins, keeping only pycoverage.
+          # Default plugins: https://github.com/getsentry/prevent-cli/blob/45e518e5ca344c9fb7a5cbe596a21b7ab85a39ed/codecov-cli/README.md?plain=1#L178
+          plugins: pycoverage
 
       - name: Show disk space after the tasks
         run: df -h

--- a/.github/workflows/build-and-test-reusable.yaml
+++ b/.github/workflows/build-and-test-reusable.yaml
@@ -179,6 +179,9 @@ jobs:
           flags: ${{ inputs.codecov-flag }}
           token: ${{ secrets.codecov-token }}
           disable_search: true
+          # Disable gcov and xcode plugins, keeping only pycoverage.
+          # Default plugins: https://github.com/getsentry/prevent-cli/blob/45e518e5ca344c9fb7a5cbe596a21b7ab85a39ed/codecov-cli/README.md?plain=1#L178
+          plugins: pycoverage
 
       - name: Show disk space after the tasks
         run: df -h


### PR DESCRIPTION
- Adds `plugins: pycoverage` to the `codecov/codecov-action@v6` step in both `build-and-test-differential.yaml` and `build-and-test-reusable.yaml`
- By default, `codecov-cli` runs the `gcov`, `xcode`, and `pycoverage` plugins on every upload; explicitly listing only `pycoverage` disables the other two

## Why

The gcov plugin scans for and processes C++ coverage artifacts during the Codecov upload step, adding significant time to CI runs with no benefit given the current coverage reporting needs. Restricting the active plugin to `pycoverage` removes that overhead while keeping Python coverage reports intact.

## Related PRs

- #12413 - ci(workflow): merge upload-coverage job into build-and-test
- #12417 - ci(codecov): disable search and bump to v6
- #12418 - ci(codecov): limit differential upload to jazzy-cuda and disable global carryforward
- #12422 - ci(codecov): add upload-coverage param to limit coverage uploads

## Test plan

- [x] CI run: https://github.com/autowarefoundation/autoware_universe/actions/runs/24119663749
- [x] Confirm the Codecov PR comment still appears with Python coverage data
- [x] Confirm the step does not fail (`fail_ci_if_error: false` is already set, but the step should still succeed cleanly)

<img width="2458" height="1206" alt="image" src="https://github.com/user-attachments/assets/31f3ba54-ad5e-4ad8-8ad4-b78ec3657377" />

- Left: https://app.codecov.io/gh/autowarefoundation/autoware_universe/tree/main?flags%5B0%5D=total-jazzy-cuda
- Right: https://app.codecov.io/gh/autowarefoundation/autoware_universe/tree/ci%2Fcodecov-disable-gcov-plugin?flags%5B0%5D=daily-jazzy-amd64-cuda

They are pretty much identical (6 lines difference out of 130k)

Yet it takes 🐇 **6 seconds** now compared to 🐢 **~20 mins** before.

---

<img width="884" height="41" alt="image" src="https://github.com/user-attachments/assets/34bc634a-fd9f-4250-b831-5f47e422f11a" />

⬇️

<img width="881" height="49" alt="image" src="https://github.com/user-attachments/assets/e3774fd4-0281-4326-8191-d31d0a2a0ccd" />
