### PR TITLE
docs(yabloc_pose_initializer): switch artifact URL from Wasabi to AWS S3

### DIFF
--- a/localization/yabloc/yabloc_pose_initializer/README.md
+++ b/localization/yabloc/yabloc_pose_initializer/README.md
@@ -12,7 +12,7 @@ To download and extract the model manually:
 ```bash
 $ mkdir -p ~/autoware_data/yabloc_pose_initializer/
 $ wget -P ~/autoware_data/yabloc_pose_initializer/ \
-       https://s3.ap-northeast-2.wasabisys.com/pinto-model-zoo/136_road-segmentation-adas-0001/resources.tar.gz
+       https://autoware-files.s3.us-west-2.amazonaws.com/models/yabloc/136_road-segmentation-adas-0001/resources.tar.gz
 $ tar xzf ~/autoware_data/yabloc_pose_initializer/resources.tar.gz -C ~/autoware_data/yabloc_pose_initializer/
 ```
 


### PR DESCRIPTION
- Switch the manual download URL in the README from Wasabi S3 (Korea region) to the Autoware AWS S3 bucket
- Related Ansible-side fix: autowarefoundation/autoware#7002

## Why

The Wasabi S3 server was returning inconsistent content to different clients, causing checksum mismatches in CI. The same file is hosted on the Autoware AWS S3 bucket (`autoware-files.s3.us-west-2.amazonaws.com`) with a verified matching checksum (`sha256:1f660e...`).

---

- Parent issue: autowarefoundation/autoware#7001

## Test plan

- [x] Verify the URL returns HTTP 200: `curl -sI "https://autoware-files.s3.us-west-2.amazonaws.com/models/yabloc/136_road-segmentation-adas-0001/resources.tar.gz" | head -3`
- [x] Verify checksum matches: `curl -sL "https://autoware-files.s3.us-west-2.amazonaws.com/models/yabloc/136_road-segmentation-adas-0001/resources.tar.gz" | sha256sum` should output `1f660e15f95074bade32b1f80dbf618e9cee1f0b9f76d3f4671cb9be7f56eb3a`


```console
mfc@whale:/tmp/sdkfjsdkfj$ curl -sI "https://autoware-files.s3.us-west-2.amazonaws.com/models/yabloc/136_road-segmentation-adas-0001/resources.tar.gz"
HTTP/1.1 200 OK
x-amz-id-2: PJffWL9JLWdFDlknI90c8S6K/hvHang2b5MZDFV4uSo5RMfbjV/6TT/Wz6R3GkGqoj7aA8gpvU8=
x-amz-request-id: SPZ561H9SD6W2B97
Date: Fri, 10 Apr 2026 16:12:24 GMT
Last-Modified: Fri, 10 Apr 2026 16:05:38 GMT
ETag: "146ed8af689a30b898dc5369870c40fb"
x-amz-server-side-encryption: AES256
x-amz-version-id: uaDzmZnpDv1XtU.ehLfXUYgCv3DRiJvV
Accept-Ranges: bytes
Content-Type: application/x-gzip
Content-Length: 14198646
Server: AmazonS3

mfc@whale:/tmp/sdkfjsdkfj$ curl -sL "https://autoware-files.s3.us-west-2.amazonaws.com/models/yabloc/136_road-segmentation-adas-0001/resources.tar.gz" | sha256sum
1f660e15f95074bade32b1f80dbf618e9cee1f0b9f76d3f4671cb9be7f56eb3a  -
```