### PR TITLE
fix(autoware_behavior_path_side_shift): stabilize side shift path

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/scene.cpp
@@ -275,7 +275,7 @@ BehaviorModuleOutput SideShiftModule::plan()
     RCLCPP_DEBUG(getLogger(), "change is not requested");
   }
 
-  // While SHIFTING, keep the entire shifted path fixed (no regenerate) until AFTER_SHIFT.
+  // While SHIFTING, keep the entire shifted path fixed until AFTER_SHIFT.
   ShiftedPath shifted_path;
   if (
     shift_status_ == SideShiftStatus::SHIFTING && !lateral_offset_change_request_ &&

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/scene.cpp
@@ -275,9 +275,15 @@ BehaviorModuleOutput SideShiftModule::plan()
     RCLCPP_DEBUG(getLogger(), "change is not requested");
   }
 
-  // Refine path
+  // While SHIFTING, keep the entire shifted path fixed (no regenerate) until AFTER_SHIFT.
   ShiftedPath shifted_path;
-  path_shifter_.generate(&shifted_path);
+  if (
+    shift_status_ == SideShiftStatus::SHIFTING && !lateral_offset_change_request_ &&
+    !prev_output_.path.points.empty()) {
+    shifted_path = prev_output_;
+  } else {
+    path_shifter_.generate(&shifted_path);
+  }
 
   if (shifted_path.path.points.empty()) {
     RCLCPP_ERROR(getLogger(), "Generated shift_path has no points");
@@ -322,9 +328,14 @@ CandidateOutput SideShiftModule::planCandidate() const
 
 BehaviorModuleOutput SideShiftModule::planWaitingApproval()
 {
-  // Refine path
   ShiftedPath shifted_path;
-  path_shifter_.generate(&shifted_path);
+  if (
+    shift_status_ == SideShiftStatus::SHIFTING && !lateral_offset_change_request_ &&
+    !prev_output_.path.points.empty()) {
+    shifted_path = prev_output_;
+  } else {
+    path_shifter_.generate(&shifted_path);
+  }
 
   // Reset orientation
   setOrientation(&shifted_path.path);


### PR DESCRIPTION
## Description

This PR stabilizes the path of the side_shift module.
Currently the path of the side_shift module changes dynamically during the shift because `path_shifter_.generate()` keeps changing the path while the side_shift module is in `SHIFTING` status.

## How was this PR tested?

- Checked that `colcon test` passes
- Checked the difference between PSim 
  - Published topics with an order of `-0.5 m` -> `-1.5` -> `0.0` -> `1.0` -> `0.0` (meters)

### Current Autoware

https://github.com/user-attachments/assets/d148c01c-f339-494f-809e-5ae8cf257bd0

### After PR applied

https://github.com/user-attachments/assets/108888a8-0a7f-49d5-abc5-cf2f638f8041

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

The side_shift modules quits editing the path while shifting.
