### PR TITLE
feat(trajectory_validator): support shadow mode

### DIFF
--- a/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/trajectory_validator_node.hpp
+++ b/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/trajectory_validator_node.hpp
@@ -72,6 +72,8 @@ private:
     const CandidateTrajectories & input_trajectories,
     const CandidateTrajectories & filtered_trajectories);
 
+  bool is_shadow_mode(const std::string & plugin_name) const;
+
   validator::ParamListener listener_;
   validator::Params params_;
 

--- a/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/trajectory_validator_node.hpp
+++ b/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/trajectory_validator_node.hpp
@@ -61,7 +61,7 @@ private:
 
   void map_callback(const LaneletMapBin::ConstSharedPtr msg);
 
-  void load_metric(const std::string & name);
+  void load_metric(const std::string & name, const bool is_shadow_mode = false);
 
   /**
    * @brief Unloads a metric plugin
@@ -71,8 +71,6 @@ private:
   void update_diagnostic(
     const CandidateTrajectories & input_trajectories,
     const CandidateTrajectories & filtered_trajectories);
-
-  bool is_shadow_mode(const std::string & plugin_name) const;
 
   validator::ParamListener listener_;
   validator::Params params_;

--- a/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/validator_interface.hpp
+++ b/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/validator_interface.hpp
@@ -57,10 +57,14 @@ public:
     vehicle_info_ptr_ = std::make_shared<VehicleInfo>(vehicle_info);
   }
 
+  void set_shadow_mode(const bool is_shadow_mode) { is_shadow_mode_ = is_shadow_mode; }
+
   [[nodiscard]] std::string get_name() const { return name_; }
+  [[nodiscard]] bool is_shadow_mode() const { return is_shadow_mode_; }
 
 protected:
   std::string name_;
+  bool is_shadow_mode_{false};
   std::shared_ptr<VehicleInfo> vehicle_info_ptr_;
 };
 }  // namespace autoware::trajectory_validator::plugin

--- a/planning/autoware_trajectory_validator/param/parameter_struct.yaml
+++ b/planning/autoware_trajectory_validator/param/parameter_struct.yaml
@@ -3,7 +3,13 @@ validator:
     type: string_array
     default_value: []
     description: metrics.
-    read_only: false
+    read_only: true
+
+  shadow_mode_filter_names:
+    type: string_array
+    default_value: []
+    description: List of filter names that run in which results are logged but do not affect trajectory feasibility.
+    read_only: true
 
   out_of_lane:
     time:

--- a/planning/autoware_trajectory_validator/src/trajectory_validator_node.cpp
+++ b/planning/autoware_trajectory_validator/src/trajectory_validator_node.cpp
@@ -77,8 +77,9 @@ TrajectoryValidator::TrajectoryValidator(const rclcpp::NodeOptions & options)
     load_metric(filter);
   }
 
+  constexpr bool shadow_mode = true;
   for (const auto & filter : params_.shadow_mode_filter_names) {
-    load_metric(filter);
+    load_metric(filter, shadow_mode);
   }
 
   sub_map_ = create_subscription<LaneletMapBin>(
@@ -153,7 +154,7 @@ void TrajectoryValidator::process(const CandidateTrajectories::ConstSharedPtr ms
           get_logger(), *get_clock(), 1000, "Not feasible: %s", res.error().c_str());
         diagnostics_interface_.add_key_value(plugin->get_name(), res.error());
 
-        if (is_shadow_mode(plugin->get_name())) {
+        if (plugin->is_shadow_mode()) {
           continue;
         }
 
@@ -187,7 +188,7 @@ void TrajectoryValidator::map_callback(const LaneletMapBin::ConstSharedPtr msg)
     autoware::experimental::lanelet2_utils::from_autoware_map_msgs(*msg));
 }
 
-void TrajectoryValidator::load_metric(const std::string & name)
+void TrajectoryValidator::load_metric(const std::string & name, const bool is_shadow_mode)
 {
   try {
     auto plugin = plugin_loader_.createSharedInstance(name);
@@ -200,6 +201,7 @@ void TrajectoryValidator::load_metric(const std::string & name)
     }
 
     plugin->set_vehicle_info(vehicle_info_);
+    plugin->set_shadow_mode(is_shadow_mode);
     plugin->update_parameters(params_);
 
     plugins_.push_back(plugin);
@@ -255,12 +257,6 @@ void TrajectoryValidator::update_diagnostic(
   }
 
   diagnostics_interface_.publish(this->get_clock()->now());
-}
-
-bool TrajectoryValidator::is_shadow_mode(const std::string & plugin_name) const
-{
-  const auto & names = params_.shadow_mode_filter_names;
-  return std::find(names.begin(), names.end(), plugin_name) != names.end();
 }
 }  // namespace autoware::trajectory_validator
 

--- a/planning/autoware_trajectory_validator/src/trajectory_validator_node.cpp
+++ b/planning/autoware_trajectory_validator/src/trajectory_validator_node.cpp
@@ -190,6 +190,8 @@ void TrajectoryValidator::map_callback(const LaneletMapBin::ConstSharedPtr msg)
 
 void TrajectoryValidator::load_metric(const std::string & name, const bool is_shadow_mode)
 {
+  if (name.empty()) return;
+
   try {
     auto plugin = plugin_loader_.createSharedInstance(name);
 

--- a/planning/autoware_trajectory_validator/src/trajectory_validator_node.cpp
+++ b/planning/autoware_trajectory_validator/src/trajectory_validator_node.cpp
@@ -77,6 +77,10 @@ TrajectoryValidator::TrajectoryValidator(const rclcpp::NodeOptions & options)
     load_metric(filter);
   }
 
+  for (const auto & filter : params_.shadow_mode_filter_names) {
+    load_metric(filter);
+  }
+
   sub_map_ = create_subscription<LaneletMapBin>(
     "~/input/lanelet2_map", rclcpp::QoS{1}.transient_local(),
     std::bind(&TrajectoryValidator::map_callback, this, std::placeholders::_1));
@@ -145,10 +149,15 @@ void TrajectoryValidator::process(const CandidateTrajectories::ConstSharedPtr ms
     bool is_feasible = true;
     for (const auto & plugin : plugins_) {
       if (const auto res = plugin->is_feasible(trajectory.points, context); !res) {
-        is_feasible = false;
         RCLCPP_WARN_THROTTLE(
           get_logger(), *get_clock(), 1000, "Not feasible: %s", res.error().c_str());
         diagnostics_interface_.add_key_value(plugin->get_name(), res.error());
+
+        if (is_shadow_mode(plugin->get_name())) {
+          continue;
+        }
+
+        is_feasible = false;
       }
     }
 
@@ -246,6 +255,12 @@ void TrajectoryValidator::update_diagnostic(
   }
 
   diagnostics_interface_.publish(this->get_clock()->now());
+}
+
+bool TrajectoryValidator::is_shadow_mode(const std::string & plugin_name) const
+{
+  const auto & names = params_.shadow_mode_filter_names;
+  return std::find(names.begin(), names.end(), plugin_name) != names.end();
 }
 }  // namespace autoware::trajectory_validator
 


### PR DESCRIPTION
## Description

This PR adds shadow mode support to the `trajectory_validator` node. Shadow mode allows specific validator filters to run and log their results without affecting the actual trajectory feasibility decision. This is useful for evaluating new or experimental filters in a production environment without impacting system behavior.

> **Note:** In the `feat/v4.3/e2e` branch this was referred to as "debug mode." The name `shadow_mode` is adopted here to align with internally used terminology.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added | `shadow_mode_filter_names`   | `string_array` | `[]`         | List of filter names that run in which results are logged but do not affect trajectory feasibility |

## Effects on system behavior

Filters listed under `shadow_mode_filter_names` will still execute and log warnings/diagnostics when they detect in feasible trajectory, but they will **not** filter the trajectory. This allows passive monitoring of new validators without influencing planning output.
