### PR TITLE
feat(diffusion_planner): add `max_num` for each class

### DIFF
--- a/planning/autoware_diffusion_planner/config/diffusion_planner.param.yaml
+++ b/planning/autoware_diffusion_planner/config/diffusion_planner.param.yaml
@@ -6,6 +6,9 @@
     planning_frequency_hz: 10.0
     ignore_neighbors: false
     ignore_unknown_neighbors: true
+    max_num_vehicle: 32
+    max_num_pedestrian: 32
+    max_num_bicycle: 32
     traffic_light_group_msg_timeout_seconds: 0.2
     batch_size: 1
     temperature: [0.0]

--- a/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/conversion/agent.hpp
+++ b/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/conversion/agent.hpp
@@ -138,9 +138,12 @@ struct AgentData
 {
   void update_histories(const TrackedObjects & objects, const bool ignore_unknown_agents);
 
-  // Transform histories, trim to max_num_agent, and return the processed vector.
+  // Transform histories, trim to max_num_agent (with per-class caps), and return the result.
+  // Histories are sorted by distance from ego (nearest first); for each class, once the
+  // per-class cap is reached, subsequent agents of that class are skipped.
   std::vector<AgentHistory> transformed_and_trimmed_histories(
-    const Eigen::Matrix4d & transform, size_t max_num_agent) const;
+    const Eigen::Matrix4d & transform, size_t max_num_agent, size_t max_num_vehicle,
+    size_t max_num_pedestrian, size_t max_num_bicycle) const;
 
 private:
   std::unordered_map<std::string, AgentHistory> histories_map_;

--- a/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/conversion/agent.hpp
+++ b/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/conversion/agent.hpp
@@ -140,10 +140,11 @@ struct AgentData
 
   // Transform histories, trim to max_num_agent (with per-class caps), and return the result.
   // Histories are sorted by distance from ego (nearest first); for each class, once the
-  // per-class cap is reached, subsequent agents of that class are skipped.
+  // per-class cap is reached, subsequent agents of that class are skipped. A non-positive
+  // per-class cap excludes that class entirely.
   std::vector<AgentHistory> transformed_and_trimmed_histories(
-    const Eigen::Matrix4d & transform, size_t max_num_agent, size_t max_num_vehicle,
-    size_t max_num_pedestrian, size_t max_num_bicycle) const;
+    const Eigen::Matrix4d & transform, int64_t max_num_agent, int64_t max_num_vehicle,
+    int64_t max_num_pedestrian, int64_t max_num_bicycle) const;
 
 private:
   std::unordered_map<std::string, AgentHistory> histories_map_;

--- a/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/diffusion_planner_core.hpp
+++ b/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/diffusion_planner_core.hpp
@@ -109,6 +109,9 @@ struct DiffusionPlannerParams
   double planning_frequency_hz;
   bool ignore_neighbors;
   bool ignore_unknown_neighbors;
+  int64_t max_num_vehicle;
+  int64_t max_num_pedestrian;
+  int64_t max_num_bicycle;
   double traffic_light_group_msg_timeout_seconds;
   int batch_size;
   std::vector<double> temperature_list;

--- a/planning/autoware_diffusion_planner/schema/diffusion_planner.schema.json
+++ b/planning/autoware_diffusion_planner/schema/diffusion_planner.schema.json
@@ -42,6 +42,24 @@
           "default": true,
           "description": "Ignore neighbor agents with unknown class"
         },
+        "max_num_vehicle": {
+          "type": "integer",
+          "default": 32,
+          "minimum": 0,
+          "description": "Maximum number of VEHICLE neighbors to include in the model input. Nearest agents are kept; once the cap is reached, additional vehicles are skipped."
+        },
+        "max_num_pedestrian": {
+          "type": "integer",
+          "default": 32,
+          "minimum": 0,
+          "description": "Maximum number of PEDESTRIAN neighbors to include in the model input. Nearest agents are kept; once the cap is reached, additional pedestrians are skipped."
+        },
+        "max_num_bicycle": {
+          "type": "integer",
+          "default": 32,
+          "minimum": 0,
+          "description": "Maximum number of BICYCLE neighbors to include in the model input. Nearest agents are kept; once the cap is reached, additional bicycles are skipped."
+        },
         "traffic_light_group_msg_timeout_seconds": {
           "type": "number",
           "default": 0.2,

--- a/planning/autoware_diffusion_planner/src/conversion/agent.cpp
+++ b/planning/autoware_diffusion_planner/src/conversion/agent.cpp
@@ -119,8 +119,8 @@ void AgentData::update_histories(const TrackedObjects & objects, const bool igno
 }
 
 std::vector<AgentHistory> AgentData::transformed_and_trimmed_histories(
-  const Eigen::Matrix4d & transform, size_t max_num_agent, size_t max_num_vehicle,
-  size_t max_num_pedestrian, size_t max_num_bicycle) const
+  const Eigen::Matrix4d & transform, int64_t max_num_agent, int64_t max_num_vehicle,
+  int64_t max_num_pedestrian, int64_t max_num_bicycle) const
 {
   std::vector<AgentHistory> histories;
   histories.reserve(histories_map_.size());
@@ -140,12 +140,12 @@ std::vector<AgentHistory> AgentData::transformed_and_trimmed_histories(
   });
 
   std::vector<AgentHistory> filtered;
-  filtered.reserve(std::min(histories.size(), max_num_agent));
-  size_t num_vehicle = 0;
-  size_t num_pedestrian = 0;
-  size_t num_bicycle = 0;
+  filtered.reserve(std::min<size_t>(histories.size(), std::max<int64_t>(0, max_num_agent)));
+  int64_t num_vehicle = 0;
+  int64_t num_pedestrian = 0;
+  int64_t num_bicycle = 0;
   for (auto & history : histories) {
-    if (filtered.size() >= max_num_agent) {
+    if (static_cast<int64_t>(filtered.size()) >= max_num_agent) {
       break;
     }
     const AgentLabel label = history.get_latest_state().label;

--- a/planning/autoware_diffusion_planner/src/conversion/agent.cpp
+++ b/planning/autoware_diffusion_planner/src/conversion/agent.cpp
@@ -19,6 +19,7 @@
 
 #include <algorithm>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace autoware::diffusion_planner

--- a/planning/autoware_diffusion_planner/src/conversion/agent.cpp
+++ b/planning/autoware_diffusion_planner/src/conversion/agent.cpp
@@ -119,7 +119,8 @@ void AgentData::update_histories(const TrackedObjects & objects, const bool igno
 }
 
 std::vector<AgentHistory> AgentData::transformed_and_trimmed_histories(
-  const Eigen::Matrix4d & transform, size_t max_num_agent) const
+  const Eigen::Matrix4d & transform, size_t max_num_agent, size_t max_num_vehicle,
+  size_t max_num_pedestrian, size_t max_num_bicycle) const
 {
   std::vector<AgentHistory> histories;
   histories.reserve(histories_map_.size());
@@ -137,11 +138,36 @@ std::vector<AgentHistory> AgentData::transformed_and_trimmed_histories(
       std::hypot(b.get_latest_state().pose(0, 3), b.get_latest_state().pose(1, 3));
     return a_dist < b_dist;
   });
-  if (histories.size() > max_num_agent) {
-    histories.erase(
-      histories.begin() + static_cast<std::ptrdiff_t>(max_num_agent), histories.end());
+
+  std::vector<AgentHistory> filtered;
+  filtered.reserve(std::min(histories.size(), max_num_agent));
+  size_t num_vehicle = 0;
+  size_t num_pedestrian = 0;
+  size_t num_bicycle = 0;
+  for (auto & history : histories) {
+    if (filtered.size() >= max_num_agent) {
+      break;
+    }
+    const AgentLabel label = history.get_latest_state().label;
+    if (label == AgentLabel::VEHICLE) {
+      if (num_vehicle >= max_num_vehicle) {
+        continue;
+      }
+      ++num_vehicle;
+    } else if (label == AgentLabel::PEDESTRIAN) {
+      if (num_pedestrian >= max_num_pedestrian) {
+        continue;
+      }
+      ++num_pedestrian;
+    } else if (label == AgentLabel::BICYCLE) {
+      if (num_bicycle >= max_num_bicycle) {
+        continue;
+      }
+      ++num_bicycle;
+    }
+    filtered.push_back(std::move(history));
   }
-  return histories;
+  return filtered;
 }
 
 }  // namespace autoware::diffusion_planner

--- a/planning/autoware_diffusion_planner/src/diffusion_planner_core.cpp
+++ b/planning/autoware_diffusion_planner/src/diffusion_planner_core.cpp
@@ -123,8 +123,8 @@ std::optional<FrameContext> DiffusionPlannerCore::create_frame_context(
   // Update neighbor agent data
   agent_data_.update_histories(*effective_objects, params_.ignore_unknown_neighbors);
   const auto processed_neighbor_histories = agent_data_.transformed_and_trimmed_histories(
-    map_to_ego_transform, MAX_NUM_NEIGHBORS, params_.max_num_vehicle,
-    params_.max_num_pedestrian, params_.max_num_bicycle);
+    map_to_ego_transform, MAX_NUM_NEIGHBORS, params_.max_num_vehicle, params_.max_num_pedestrian,
+    params_.max_num_bicycle);
 
   // Update traffic light map
   const auto & traffic_light_msg_timeout_s = params_.traffic_light_group_msg_timeout_seconds;

--- a/planning/autoware_diffusion_planner/src/diffusion_planner_core.cpp
+++ b/planning/autoware_diffusion_planner/src/diffusion_planner_core.cpp
@@ -123,9 +123,8 @@ std::optional<FrameContext> DiffusionPlannerCore::create_frame_context(
   // Update neighbor agent data
   agent_data_.update_histories(*effective_objects, params_.ignore_unknown_neighbors);
   const auto processed_neighbor_histories = agent_data_.transformed_and_trimmed_histories(
-    map_to_ego_transform, MAX_NUM_NEIGHBORS, static_cast<size_t>(params_.max_num_vehicle),
-    static_cast<size_t>(params_.max_num_pedestrian),
-    static_cast<size_t>(params_.max_num_bicycle));
+    map_to_ego_transform, MAX_NUM_NEIGHBORS, params_.max_num_vehicle,
+    params_.max_num_pedestrian, params_.max_num_bicycle);
 
   // Update traffic light map
   const auto & traffic_light_msg_timeout_s = params_.traffic_light_group_msg_timeout_seconds;

--- a/planning/autoware_diffusion_planner/src/diffusion_planner_core.cpp
+++ b/planning/autoware_diffusion_planner/src/diffusion_planner_core.cpp
@@ -122,8 +122,10 @@ std::optional<FrameContext> DiffusionPlannerCore::create_frame_context(
 
   // Update neighbor agent data
   agent_data_.update_histories(*effective_objects, params_.ignore_unknown_neighbors);
-  const auto processed_neighbor_histories =
-    agent_data_.transformed_and_trimmed_histories(map_to_ego_transform, NEIGHBOR_SHAPE[1]);
+  const auto processed_neighbor_histories = agent_data_.transformed_and_trimmed_histories(
+    map_to_ego_transform, MAX_NUM_NEIGHBORS, static_cast<size_t>(params_.max_num_vehicle),
+    static_cast<size_t>(params_.max_num_pedestrian),
+    static_cast<size_t>(params_.max_num_bicycle));
 
   // Update traffic light map
   const auto & traffic_light_msg_timeout_s = params_.traffic_light_group_msg_timeout_seconds;

--- a/planning/autoware_diffusion_planner/src/diffusion_planner_node.cpp
+++ b/planning/autoware_diffusion_planner/src/diffusion_planner_node.cpp
@@ -107,6 +107,9 @@ void DiffusionPlanner::set_up_params()
   params_.ignore_neighbors = this->declare_parameter<bool>("ignore_neighbors", false);
   params_.ignore_unknown_neighbors =
     this->declare_parameter<bool>("ignore_unknown_neighbors", false);
+  params_.max_num_vehicle = this->declare_parameter<int64_t>("max_num_vehicle", 32);
+  params_.max_num_pedestrian = this->declare_parameter<int64_t>("max_num_pedestrian", 32);
+  params_.max_num_bicycle = this->declare_parameter<int64_t>("max_num_bicycle", 32);
   params_.traffic_light_group_msg_timeout_seconds =
     this->declare_parameter<double>("traffic_light_group_msg_timeout_seconds", 0.2);
   params_.batch_size = this->declare_parameter<int>("batch_size", 1);
@@ -168,6 +171,9 @@ SetParametersResult DiffusionPlanner::on_parameter(
     update_param<bool>(
       parameters, "ignore_unknown_neighbors", temp_params.ignore_unknown_neighbors);
     update_param<bool>(parameters, "ignore_neighbors", temp_params.ignore_neighbors);
+    update_param<int64_t>(parameters, "max_num_vehicle", temp_params.max_num_vehicle);
+    update_param<int64_t>(parameters, "max_num_pedestrian", temp_params.max_num_pedestrian);
+    update_param<int64_t>(parameters, "max_num_bicycle", temp_params.max_num_bicycle);
     update_param<double>(
       parameters, "traffic_light_group_msg_timeout_seconds",
       temp_params.traffic_light_group_msg_timeout_seconds);

--- a/planning/autoware_diffusion_planner/test/postprocessing_utils_edge_case_test.cpp
+++ b/planning/autoware_diffusion_planner/test/postprocessing_utils_edge_case_test.cpp
@@ -76,7 +76,9 @@ TEST_F(PostprocessingUtilsEdgeCaseTest, CreatePredictedObjects_EmptyAgentData)
   constexpr int64_t batch_idx = 0;
   auto result = postprocess::create_predicted_objects(
     agent_poses,
-    agent_data.transformed_and_trimmed_histories(Eigen::Matrix4d::Identity(), NEIGHBOR_SHAPE[1]),
+    agent_data.transformed_and_trimmed_histories(
+      Eigen::Matrix4d::Identity(), MAX_NUM_NEIGHBORS, MAX_NUM_NEIGHBORS, MAX_NUM_NEIGHBORS,
+      MAX_NUM_NEIGHBORS),
     stamp, batch_idx);
 
   EXPECT_EQ(result.objects.size(), 0);
@@ -106,10 +108,76 @@ TEST_F(PostprocessingUtilsEdgeCaseTest, CreatePredictedObjects_MorePredictionsTh
   constexpr int64_t batch_idx = 0;
   auto result = postprocess::create_predicted_objects(
     agent_poses,
-    agent_data.transformed_and_trimmed_histories(Eigen::Matrix4d::Identity(), NEIGHBOR_SHAPE[1]),
+    agent_data.transformed_and_trimmed_histories(
+      Eigen::Matrix4d::Identity(), MAX_NUM_NEIGHBORS, MAX_NUM_NEIGHBORS, MAX_NUM_NEIGHBORS,
+      MAX_NUM_NEIGHBORS),
     stamp, batch_idx);
 
   EXPECT_EQ(result.objects.size(), 1);
+}
+
+// Test: per-class caps in transformed_and_trimmed_histories
+TEST_F(PostprocessingUtilsEdgeCaseTest, TransformedAndTrimmedHistories_PerClassCaps)
+{
+  // Arrange: 10 VEHICLE + 10 PEDESTRIAN + 10 BICYCLE objects around ego, each with a
+  // unique id and an increasing distance so the sort order is deterministic.
+  auto make_object = [](double x, double y, uint8_t label) {
+    TrackedObject obj;
+    obj.object_id = autoware_utils_uuid::generate_uuid();
+    obj.kinematics.pose_with_covariance.pose.position.x = x;
+    obj.kinematics.pose_with_covariance.pose.position.y = y;
+    obj.kinematics.pose_with_covariance.pose.orientation =
+      autoware_utils::create_quaternion_from_yaw(0.0);
+    autoware_perception_msgs::msg::ObjectClassification classification;
+    classification.label = label;
+    classification.probability = 1.0;
+    obj.classification.push_back(classification);
+    obj.existence_probability = 0.9;
+    return obj;
+  };
+
+  TrackedObjects objects;
+  objects.header.stamp = rclcpp::Time(0);
+  for (int i = 0; i < 10; ++i) {
+    const double d = static_cast<double>(i + 1);
+    objects.objects.push_back(
+      make_object(d, 0.0, autoware_perception_msgs::msg::ObjectClassification::CAR));
+    objects.objects.push_back(
+      make_object(0.0, d, autoware_perception_msgs::msg::ObjectClassification::PEDESTRIAN));
+    objects.objects.push_back(
+      make_object(-d, 0.0, autoware_perception_msgs::msg::ObjectClassification::BICYCLE));
+  }
+
+  AgentData agent_data;
+  agent_data.update_histories(objects, false);
+
+  const size_t max_num_vehicle = 3;
+  const size_t max_num_pedestrian = 4;
+  const size_t max_num_bicycle = 2;
+
+  // Act
+  const auto histories = agent_data.transformed_and_trimmed_histories(
+    Eigen::Matrix4d::Identity(), MAX_NUM_NEIGHBORS, max_num_vehicle, max_num_pedestrian,
+    max_num_bicycle);
+
+  // Assert: each class is capped to its limit and the total matches the sum.
+  size_t num_vehicle = 0;
+  size_t num_pedestrian = 0;
+  size_t num_bicycle = 0;
+  for (const auto & history : histories) {
+    const auto label = history.get_latest_state().label;
+    if (label == AgentLabel::VEHICLE) {
+      ++num_vehicle;
+    } else if (label == AgentLabel::PEDESTRIAN) {
+      ++num_pedestrian;
+    } else if (label == AgentLabel::BICYCLE) {
+      ++num_bicycle;
+    }
+  }
+  EXPECT_EQ(num_vehicle, max_num_vehicle);
+  EXPECT_EQ(num_pedestrian, max_num_pedestrian);
+  EXPECT_EQ(num_bicycle, max_num_bicycle);
+  EXPECT_EQ(histories.size(), max_num_vehicle + max_num_pedestrian + max_num_bicycle);
 }
 
 }  // namespace autoware::diffusion_planner::test


### PR DESCRIPTION
## Description

This pull request will add three new parameters `max_num_vehicle`, `max_num_pedestrian`, and `max_num_bicycle` to cap the number of neighbor agents the diffusion planner feeds into the model.

### Background

Depending on the experiment location, the surrounding environment can contain a very large number of agents. In particular, in pedestrian-heavy areas, the neighbor input slots can end up almost entirely filled with pedestrians, leaving no room for vehicles.

From a planning perspective, however, vehicles are often more important than pedestrians. Without a way to balance the input across classes, the model can lose visibility of nearby vehicles simply because pedestrians are crowding them out of the input tensor.

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added | `max_num_vehicle`   | `int` | `32`         | Maximum number of VEHICLE neighbors to include in the model input. Nearest agents are kept; once the cap is reached, additional vehicles are skipped. |
| Added | `max_num_pedestrian`   | `int` | `32`         | Maximum number of PEDESTRIAN neighbors to include in the model input. Nearest agents are kept; once the cap is reached, additional pedestrians are skipped. |
| Added | `max_num_bicycle`   | `int` | `32`         | Maximum number of BICYCLE neighbors to include in the model input. Nearest agents are kept; once the cap is reached, additional bicycles are skipped. |

## Effects on system behavior

None.
