### PR TITLE
feat(trajectory_validator): publish plugins' processing time and debug markers

### DIFF
--- a/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/filters/safety/collision_filter.hpp
+++ b/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/filters/safety/collision_filter.hpp
@@ -39,7 +39,7 @@ struct CollisionParams
 class CollisionFilter : public plugin::ValidatorInterface
 {
 public:
-  CollisionFilter() : ValidatorInterface("CollisionFilter") {}
+  CollisionFilter() : ValidatorInterface("collision_filter") {}
 
   result_t is_feasible(const TrajectoryPoints & traj_points, const FilterContext & context) final;
 

--- a/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/trajectory_validator_node.hpp
+++ b/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/trajectory_validator_node.hpp
@@ -108,6 +108,12 @@ public:
   explicit TrajectoryValidator(const rclcpp::NodeOptions & node_options);
 
 private:
+  void subscribers();
+
+  void publishers();
+
+  tl::expected<FilterContext, std::string> take_data();
+
   void process(const CandidateTrajectories::ConstSharedPtr msg);
 
   void map_callback(const LaneletMapBin::ConstSharedPtr msg);
@@ -128,14 +134,24 @@ private:
    */
   void publish_validation_reports(const std::vector<ValidationReport> & reports);
 
+  void publish_plugins_debug_markers() const;
+  void publish_plugins_report_text(const geometry_msgs::msg::Pose & marker_pose);
+  void publish_debug(
+    const std::unordered_map<std::string, double> & processing_time,
+    const geometry_msgs::msg::Pose & marker_pose);
+  void publish_processing_time_text(
+    const std::unordered_map<std::string, double> & processing_time);
+  void publish_processing_time(const std::unordered_map<std::string, double> & processing_time);
+
+  // Parameters
   validator::ParamListener listener_;
   validator::Params params_;
 
-  rclcpp::Publisher<autoware_utils_debug::ProcessingTimeDetail>::SharedPtr
-    debug_processing_time_detail_pub_;
-  mutable std::shared_ptr<autoware_utils_debug::TimeKeeper> time_keeper_{nullptr};
+  // Plugin infrastructure
+  pluginlib::ClassLoader<plugin::ValidatorInterface> plugin_loader_;
+  std::vector<std::shared_ptr<plugin::ValidatorInterface>> plugins_;
 
-  rclcpp::Subscription<LaneletMapBin>::SharedPtr sub_map_;
+  // Subscribers
   autoware_utils_rclcpp::InterProcessPollingSubscriber<Odometry> sub_odometry_{
     this, "~/input/odometry"};
   autoware_utils_rclcpp::InterProcessPollingSubscriber<PredictedObjects> sub_objects_{
@@ -145,20 +161,22 @@ private:
   autoware_utils_rclcpp::InterProcessPollingSubscriber<
     autoware_perception_msgs::msg::TrafficLightGroupArray>
     sub_traffic_lights_{this, "~/input/traffic_signals"};
-
+  rclcpp::Subscription<LaneletMapBin>::SharedPtr sub_map_;
   rclcpp::Subscription<CandidateTrajectories>::SharedPtr sub_trajectories_;
 
+  // Publishers
   rclcpp::Publisher<CandidateTrajectories>::SharedPtr pub_trajectories_;
   std::shared_ptr<autoware_utils_debug::DebugPublisher> pub_validation_reports_;
+  rclcpp::Publisher<autoware_utils_debug::ProcessingTimeDetail>::SharedPtr
+    pub_processing_time_detail_;
+  std::shared_ptr<autoware_utils_debug::DebugPublisher> pub_debug_;
 
+  // Internal state
   std::shared_ptr<lanelet::LaneletMap> lanelet_map_ptr_;
-
-  pluginlib::ClassLoader<plugin::ValidatorInterface> plugin_loader_;
-  std::vector<std::shared_ptr<plugin::ValidatorInterface>> plugins_;
-  std::vector<EvaluationTable> evaluation_tables_;
-
   autoware::vehicle_info_utils::VehicleInfo vehicle_info_;
+  std::vector<EvaluationTable> evaluation_tables_;
   DiagnosticsInterface diagnostics_interface_{this, "trajectory_validator"};
+  mutable std::shared_ptr<autoware_utils_debug::TimeKeeper> time_keeper_{nullptr};
 };
 
 }  // namespace autoware::trajectory_validator

--- a/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/trajectory_validator_node.hpp
+++ b/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/trajectory_validator_node.hpp
@@ -108,10 +108,19 @@ public:
   explicit TrajectoryValidator(const rclcpp::NodeOptions & node_options);
 
 private:
+  /**
+   * @brief Initialise the node's subscribers.
+   */
   void subscribers();
 
+  /**
+   * @brief Initialise the node's publishers.
+   */
   void publishers();
 
+  /**
+   * @brief Gather the latest inputs required to run the filter plugins.
+   */
   tl::expected<FilterContext, std::string> take_data();
 
   void process(const CandidateTrajectories::ConstSharedPtr msg);
@@ -134,14 +143,35 @@ private:
    */
   void publish_validation_reports(const std::vector<ValidationReport> & reports);
 
-  void publish_plugins_debug_markers() const;
-  void publish_plugins_report_text(const geometry_msgs::msg::Pose & marker_pose);
+  /**
+   * @brief Publish the union of all debug information.
+   */
   void publish_debug(
     const std::unordered_map<std::string, double> & processing_time,
     const geometry_msgs::msg::Pose & marker_pose);
+
+  /**
+   * @brief Publish each plugin's debug markers.
+   */
+  void publish_plugins_debug_markers() const;
+
+  /**
+   * @brief Publish each plugin's filtering report in a single string stamped marker.
+   */
+  void publish_plugins_report_text(const geometry_msgs::msg::Pose & marker_pose);
+
+  /**
+   * @brief Publish each plugin's processing time as scalar value.
+   * @param processing_time Map of plugin name -> elapsed time in [ms].
+   */
+  void publish_processing_time(const std::unordered_map<std::string, double> & processing_time);
+
+  /**
+   * @brief Publish each plugin's processing time in a single string stamped marker.
+   * @param processing_time Map of plugin name -> elapsed time in [ms].
+   */
   void publish_processing_time_text(
     const std::unordered_map<std::string, double> & processing_time);
-  void publish_processing_time(const std::unordered_map<std::string, double> & processing_time);
 
   // Parameters
   validator::ParamListener listener_;

--- a/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/validator_interface.hpp
+++ b/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/validator_interface.hpp
@@ -23,6 +23,7 @@
 #include <tl_expected/expected.hpp>
 
 #include <autoware_planning_msgs/msg/trajectory_point.hpp>
+#include <visualization_msgs/msg/marker_array.hpp>
 
 #include <memory>
 #include <string>
@@ -79,11 +80,30 @@ public:
   [[nodiscard]] std::string get_name() const { return name_; }
   [[nodiscard]] bool is_shadow_mode() const { return is_shadow_mode_; }
 
+  [[nodiscard]] visualization_msgs::msg::MarkerArray take_debug_markers()
+  {
+    visualization_msgs::msg::MarkerArray output_markers;
+    output_markers.markers.reserve(debug_markers_.markers.size() + 1);
+
+    visualization_msgs::msg::Marker delete_all_marker;
+    delete_all_marker.action = visualization_msgs::msg::Marker::DELETEALL;
+    output_markers.markers.push_back(delete_all_marker);
+
+    std::move(
+      debug_markers_.markers.begin(), debug_markers_.markers.end(),
+      std::back_inserter(output_markers.markers));
+
+    debug_markers_.markers.clear();
+
+    return output_markers;
+  }
+
 protected:
   std::string name_;
   bool is_shadow_mode_{false};
   std::string category_;
   std::shared_ptr<VehicleInfo> vehicle_info_ptr_;
+  visualization_msgs::msg::MarkerArray debug_markers_;
 };
 }  // namespace autoware::trajectory_validator::plugin
 

--- a/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/validator_interface.hpp
+++ b/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/validator_interface.hpp
@@ -80,6 +80,9 @@ public:
   [[nodiscard]] std::string get_name() const { return name_; }
   [[nodiscard]] bool is_shadow_mode() const { return is_shadow_mode_; }
 
+  /**
+   * @brief Atomically retrieve and clear the plugin's accumulated debug markers.
+   */
   [[nodiscard]] visualization_msgs::msg::MarkerArray take_debug_markers()
   {
     visualization_msgs::msg::MarkerArray output_markers;

--- a/planning/autoware_trajectory_validator/src/filters/safety/out_of_lane_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/out_of_lane_filter.cpp
@@ -61,7 +61,7 @@ autoware_internal_planning_msgs::msg::PathWithLaneId convert_to_path_with_lane_i
 }
 }  // namespace
 
-OutOfLaneFilter::OutOfLaneFilter() : ValidatorInterface("OutOfLaneFilter")
+OutOfLaneFilter::OutOfLaneFilter() : ValidatorInterface("out_of_lane_filter")
 {
   // BoundaryDepartureChecker will be initialized when vehicle_info is set
 }

--- a/planning/autoware_trajectory_validator/src/filters/safety/vehicle_constraint_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/vehicle_constraint_filter.cpp
@@ -105,7 +105,7 @@ std::vector<std::optional<double>> to_steering_angles(
 }
 }  // namespace
 
-VehicleConstraintFilter::VehicleConstraintFilter() : ValidatorInterface("VehicleConstraintFilter")
+VehicleConstraintFilter::VehicleConstraintFilter() : ValidatorInterface("vehicle_constraint_filter")
 {
 }
 

--- a/planning/autoware_trajectory_validator/src/filters/traffic_rule/traffic_light_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/traffic_rule/traffic_light_filter.cpp
@@ -91,7 +91,7 @@ std::optional<std::string> is_invalid_input(
 namespace autoware::trajectory_validator::plugin::traffic_rule
 {
 
-TrafficLightFilter::TrafficLightFilter() : ValidatorInterface("TrafficLightFilter")
+TrafficLightFilter::TrafficLightFilter() : ValidatorInterface("traffic_light_filter")
 {
 }
 

--- a/planning/autoware_trajectory_validator/src/trajectory_validator_node.cpp
+++ b/planning/autoware_trajectory_validator/src/trajectory_validator_node.cpp
@@ -341,6 +341,8 @@ void TrajectoryValidator::publish_debug(
   const std::unordered_map<std::string, double> & processing_time,
   const geometry_msgs::msg::Pose & marker_pose)
 {
+  autoware_utils_debug::ScopedTimeTrack st(__func__, *time_keeper_);
+
   publish_plugins_debug_markers();
   publish_plugins_report_text(marker_pose);
   publish_processing_time(processing_time);
@@ -349,6 +351,8 @@ void TrajectoryValidator::publish_debug(
 
 void TrajectoryValidator::publish_plugins_debug_markers() const
 {
+  autoware_utils_debug::ScopedTimeTrack st(__func__, *time_keeper_);
+
   for (const auto & plugin : plugins_) {
     auto plugin_markers = plugin->take_debug_markers();
     pub_debug_->publish<visualization_msgs::msg::MarkerArray>(
@@ -358,6 +362,8 @@ void TrajectoryValidator::publish_plugins_debug_markers() const
 
 void TrajectoryValidator::publish_plugins_report_text(const geometry_msgs::msg::Pose & marker_pose)
 {
+  autoware_utils_debug::ScopedTimeTrack st(__func__, *time_keeper_);
+
   std::unordered_map<std::string, int> used_filters;
   for (const auto & eval : evaluation_tables_) {
     for (const auto & [category, evaluations] : eval.evaluations) {
@@ -413,6 +419,8 @@ void TrajectoryValidator::publish_plugins_report_text(const geometry_msgs::msg::
 void TrajectoryValidator::publish_processing_time(
   const std::unordered_map<std::string, double> & processing_time)
 {
+  autoware_utils_debug::ScopedTimeTrack st(__func__, *time_keeper_);
+
   for (const auto & [key, value] : processing_time) {
     if (key == "Total") {
       pub_debug_->publish<autoware_internal_debug_msgs::msg::Float64Stamped>(
@@ -427,6 +435,8 @@ void TrajectoryValidator::publish_processing_time(
 void TrajectoryValidator::publish_processing_time_text(
   const std::unordered_map<std::string, double> & processing_time)
 {
+  autoware_utils_debug::ScopedTimeTrack st(__func__, *time_keeper_);
+
   fmt::memory_buffer out;
   auto time_report = std::back_inserter(out);
   fmt::format_to(time_report, "\n--- Trajectory Validator Processing Time Report ---\n");

--- a/planning/autoware_trajectory_validator/src/trajectory_validator_node.cpp
+++ b/planning/autoware_trajectory_validator/src/trajectory_validator_node.cpp
@@ -93,7 +93,7 @@ void TrajectoryValidator::publishers()
   pub_trajectories_ = create_publisher<CandidateTrajectories>("~/output/trajectories", 1);
 
   pub_processing_time_detail_ = create_publisher<autoware_utils_debug::ProcessingTimeDetail>(
-    "~/debug/processing_time_detail_ms/feasible_trajectory_filter", 1);
+    "~/debug/processing_time_detail_ms/trajectory_validator_node", 1);
   time_keeper_ = std::make_shared<autoware_utils_debug::TimeKeeper>(pub_processing_time_detail_);
 
   pub_validation_reports_ = std::make_shared<autoware_utils_debug::DebugPublisher>(this, "~/debug");

--- a/planning/autoware_trajectory_validator/src/trajectory_validator_node.cpp
+++ b/planning/autoware_trajectory_validator/src/trajectory_validator_node.cpp
@@ -17,7 +17,9 @@
 #include "autoware/trajectory_validator/filter_context.hpp"
 #include "autoware/trajectory_validator/validator_interface.hpp"
 
+#include <autoware_utils_system/stop_watch.hpp>
 #include <autoware_utils_uuid/uuid_helper.hpp>
+#include <autoware_utils_visualization/marker_helper.hpp>
 
 #include <autoware_internal_planning_msgs/msg/detail/candidate_trajectory__struct.hpp>
 
@@ -67,6 +69,16 @@ TrajectoryValidator::TrajectoryValidator(const rclcpp::NodeOptions & options)
     load_metric(filter, shadow_mode);
   }
 
+  std::sort(plugins_.begin(), plugins_.end(), [](const auto & plugin1, const auto & plugin2) {
+    return plugin1->get_name() < plugin2->get_name();
+  });
+
+  subscribers();
+  publishers();
+}
+
+void TrajectoryValidator::subscribers()
+{
   sub_map_ = create_subscription<LaneletMapBin>(
     "~/input/lanelet2_map", rclcpp::QoS{1}.transient_local(),
     std::bind(&TrajectoryValidator::map_callback, this, std::placeholders::_1));
@@ -74,45 +86,69 @@ TrajectoryValidator::TrajectoryValidator(const rclcpp::NodeOptions & options)
   sub_trajectories_ = create_subscription<CandidateTrajectories>(
     "~/input/trajectories", 1,
     std::bind(&TrajectoryValidator::process, this, std::placeholders::_1));
-
-  pub_trajectories_ = create_publisher<CandidateTrajectories>("~/output/trajectories", 1);
-
-  debug_processing_time_detail_pub_ = create_publisher<autoware_utils_debug::ProcessingTimeDetail>(
-    "~/debug/processing_time_detail_ms/feasible_trajectory_filter", 1);
-  time_keeper_ =
-    std::make_shared<autoware_utils_debug::TimeKeeper>(debug_processing_time_detail_pub_);
-
-  pub_validation_reports_ = std::make_shared<autoware_utils_debug::DebugPublisher>(this, "~/debug");
 }
 
-void TrajectoryValidator::process(const CandidateTrajectories::ConstSharedPtr msg)
+void TrajectoryValidator::publishers()
 {
-  autoware_utils_debug::ScopedTimeTrack st(__func__, *time_keeper_);
+  pub_trajectories_ = create_publisher<CandidateTrajectories>("~/output/trajectories", 1);
 
-  // Prepare context for filters
+  pub_processing_time_detail_ = create_publisher<autoware_utils_debug::ProcessingTimeDetail>(
+    "~/debug/processing_time_detail_ms/feasible_trajectory_filter", 1);
+  time_keeper_ = std::make_shared<autoware_utils_debug::TimeKeeper>(pub_processing_time_detail_);
+
+  pub_validation_reports_ = std::make_shared<autoware_utils_debug::DebugPublisher>(this, "~/debug");
+  pub_debug_ = std::make_shared<autoware_utils_debug::DebugPublisher>(this, "~/debug");
+}
+
+tl::expected<FilterContext, std::string> TrajectoryValidator::take_data()
+{
   FilterContext context;
 
   context.odometry = sub_odometry_.take_data();
   if (!context.odometry) {
-    return;
+    return tl::make_unexpected("Failed to take odometry data");
   }
 
   context.predicted_objects = sub_objects_.take_data();
   if (!context.predicted_objects) {
-    return;
+    return tl::make_unexpected("Failed to take predicted objects data");
   }
 
   context.acceleration = sub_acceleration_.take_data();
   if (!context.acceleration) {
-    return;
+    return tl::make_unexpected("Failed to take acceleration data");
   }
 
   context.traffic_light_signals = sub_traffic_lights_.take_data();
 
   context.lanelet_map = lanelet_map_ptr_;
   if (!context.lanelet_map) {
+    return tl::make_unexpected("Lanelet map is not available");
+  }
+
+  if (context.lanelet_map->laneletLayer.empty()) {
+    return tl::make_unexpected("Lanelet map does not contain any lanelets");
+  }
+
+  return context;
+}
+
+void TrajectoryValidator::process(const CandidateTrajectories::ConstSharedPtr msg)
+{
+  autoware_utils_debug::ScopedTimeTrack st(__func__, *time_keeper_);
+
+  autoware_utils_system::StopWatch<std::chrono::milliseconds> stop_watch;
+  std::unordered_map<std::string, double> processing_time_ms;
+
+  stop_watch.tic("Total");
+
+  auto context_opt = take_data();
+  if (!context_opt) {
+    RCLCPP_WARN_THROTTLE(get_logger(), *get_clock(), 1000, "%s", context_opt.error().c_str());
     return;
   }
+
+  const FilterContext & context = context_opt.value();
 
   if (listener_.is_old(params_)) {
     params_ = listener_.get_params();
@@ -130,13 +166,11 @@ void TrajectoryValidator::process(const CandidateTrajectories::ConstSharedPtr ms
   // Create output message for filtered trajectories
   const auto uuid_to_name = get_generator_uuid_to_name_map(*msg);
 
-  auto filtered_msg = std::make_unique<CandidateTrajectories>();
+  CandidateTrajectories filtered_msg;
 
   std::vector<ValidationReport> reports;
 
   for (const auto & trajectory : msg->candidate_trajectories) {
-    // Apply each filter to the trajectory
-
     EvaluationTable table;
     const auto hex_generator_id = autoware_utils_uuid::to_hex_string(trajectory.generator_id);
     table.generator_id = hex_generator_id;
@@ -146,6 +180,7 @@ void TrajectoryValidator::process(const CandidateTrajectories::ConstSharedPtr ms
       PluginEvaluation evaluation;
       evaluation.plugin_name = plugin->get_name();
       evaluation.is_shadow_mode = plugin->is_shadow_mode();
+      stop_watch.tic(evaluation.plugin_name);
 
       const auto res = plugin->is_feasible(trajectory.points, context);
       if (!res) {
@@ -159,6 +194,7 @@ void TrajectoryValidator::process(const CandidateTrajectories::ConstSharedPtr ms
         }
         metrics.insert(metrics.end(), val.metrics.begin(), val.metrics.end());
       }
+      processing_time_ms[evaluation.plugin_name] += stop_watch.toc(evaluation.plugin_name);
 
       if (!evaluation.is_feasible) {
         RCLCPP_WARN_THROTTLE(
@@ -173,7 +209,7 @@ void TrajectoryValidator::process(const CandidateTrajectories::ConstSharedPtr ms
 
     evaluation_tables_.push_back(table);
 
-    if (table.all_acceptable()) filtered_msg->candidate_trajectories.push_back(trajectory);
+    if (table.all_acceptable()) filtered_msg.candidate_trajectories.push_back(trajectory);
 
     const auto all_feasible = table.all_feasible();
     if (all_feasible) ++num_feasible_trajectories;
@@ -188,19 +224,25 @@ void TrajectoryValidator::process(const CandidateTrajectories::ConstSharedPtr ms
   }
 
   // Also filter generator_info to match kept trajectories
-  for (const auto & traj : filtered_msg->candidate_trajectories) {
+  for (const auto & traj : filtered_msg.candidate_trajectories) {
     auto it = std::find_if(
       msg->generator_info.begin(), msg->generator_info.end(),
       [&](const auto & info) { return traj.generator_id.uuid == info.generator_id.uuid; });
 
     if (it != msg->generator_info.end()) {
-      filtered_msg->generator_info.push_back(*it);
+      filtered_msg.generator_info.push_back(*it);
     }
   }
 
+  pub_trajectories_->publish(filtered_msg);
+
   update_diagnostic(*msg, num_feasible_trajectories);
+
   publish_validation_reports(reports);
-  pub_trajectories_->publish(*filtered_msg);
+
+  processing_time_ms["Total"] = stop_watch.toc("Total");
+
+  publish_debug(processing_time_ms, context.odometry->pose.pose);
 }
 
 void TrajectoryValidator::map_callback(const LaneletMapBin::ConstSharedPtr msg)
@@ -217,6 +259,11 @@ void TrajectoryValidator::load_metric(const std::string & name, const bool is_sh
 
   try {
     auto plugin = plugin_loader_.createSharedInstance(name);
+
+    if (!plugin) {
+      RCLCPP_ERROR_STREAM(get_logger(), "Failed to create plugin instance for '" << name << "'.");
+      return;
+    }
 
     for (const auto & p : plugins_) {
       if (plugin->get_name() == p->get_name()) {
@@ -288,6 +335,119 @@ void TrajectoryValidator::publish_validation_reports(const std::vector<Validatio
 {
   auto msg = autoware_trajectory_validator::build<ValidationReportArray>().reports(reports);
   pub_validation_reports_->publish<ValidationReportArray>("validation_reports", msg);
+}
+
+void TrajectoryValidator::publish_debug(
+  const std::unordered_map<std::string, double> & processing_time,
+  const geometry_msgs::msg::Pose & marker_pose)
+{
+  publish_plugins_debug_markers();
+  publish_plugins_report_text(marker_pose);
+  publish_processing_time(processing_time);
+  publish_processing_time_text(processing_time);
+}
+
+void TrajectoryValidator::publish_plugins_debug_markers() const
+{
+  for (const auto & plugin : plugins_) {
+    auto plugin_markers = plugin->take_debug_markers();
+    pub_debug_->publish<visualization_msgs::msg::MarkerArray>(
+      "markers/" + plugin->get_name(), plugin_markers);
+  }
+}
+
+void TrajectoryValidator::publish_plugins_report_text(const geometry_msgs::msg::Pose & marker_pose)
+{
+  std::unordered_map<std::string, int> used_filters;
+  for (const auto & eval : evaluation_tables_) {
+    for (const auto & [category, evaluations] : eval.evaluations) {
+      for (const auto & plugin_eval : evaluations) {
+        if (!plugin_eval.is_feasible) {
+          used_filters[plugin_eval.plugin_name]++;
+        }
+      }
+    }
+  }
+
+  fmt::memory_buffer out;
+  auto out_it = std::back_inserter(out);
+
+  fmt::format_to(out_it, "{:^50}\n", "--- Trajectory Validator Filtering Result ---");
+
+  int skip_counter = 0;
+  for (const auto & plugin : plugins_) {
+    if (!plugin) continue;
+
+    const auto & name = plugin->get_name();
+    const auto it = used_filters.find(name);
+
+    if (it != used_filters.end()) {
+      fmt::format_to(out_it, "- {}: {} path(s) filtered\n", name, it->second);
+    } else {
+      ++skip_counter;
+    }
+  }
+
+  for (int i = 0; i < skip_counter; ++i) {
+    fmt::format_to(out_it, "\n");
+  }
+
+  fmt::format_to(out_it, "-----------------------------------");
+
+  auto plugin_report_text = autoware_utils_visualization::create_default_marker(
+    "map", get_clock()->now(), "plugin_report", 0,
+    visualization_msgs::msg::Marker::TEXT_VIEW_FACING,
+    autoware_utils_visualization::create_marker_scale(0.0, 0.0, 0.4),
+    autoware_utils_visualization::create_marker_color(1., 1., 1., 0.999));
+
+  plugin_report_text.pose = marker_pose;
+  plugin_report_text.pose.position.z += vehicle_info_.vehicle_height_m;
+  plugin_report_text.text = fmt::to_string(out);
+
+  visualization_msgs::msg::MarkerArray plugin_report_text_marker;
+  plugin_report_text_marker.markers.push_back(plugin_report_text);
+  pub_debug_->publish<visualization_msgs::msg::MarkerArray>(
+    "plugin_report_text", plugin_report_text_marker);
+}
+
+void TrajectoryValidator::publish_processing_time(
+  const std::unordered_map<std::string, double> & processing_time)
+{
+  for (const auto & [key, value] : processing_time) {
+    if (key == "Total") {
+      pub_debug_->publish<autoware_internal_debug_msgs::msg::Float64Stamped>(
+        "processing_time_ms", value);
+      continue;
+    }
+    pub_debug_->publish<autoware_internal_debug_msgs::msg::Float64Stamped>(
+      key + "/processing_time_ms", value);
+  }
+}
+
+void TrajectoryValidator::publish_processing_time_text(
+  const std::unordered_map<std::string, double> & processing_time)
+{
+  fmt::memory_buffer out;
+  auto time_report = std::back_inserter(out);
+  fmt::format_to(time_report, "\n--- Trajectory Validator Processing Time Report ---\n");
+
+  const auto get_time = [&](const auto & key) {
+    auto it = processing_time.find(key);
+    return (it != processing_time.end()) ? it->second : 0.0;
+  };
+
+  fmt::format_to(time_report, "Total: {:.2f} ms\n", get_time("Total"));
+
+  for (const auto & plugin : plugins_) {
+    if (!plugin) continue;
+
+    const auto & plugin_name = plugin->get_name();
+
+    fmt::format_to(time_report, "- {}: {:.2f} ms\n", plugin_name, get_time(plugin_name));
+  }
+
+  pub_debug_->publish<autoware_internal_debug_msgs::msg::StringStamped>(
+    "processing_time_text", fmt::to_string(out));
 }
 }  // namespace autoware::trajectory_validator
 


### PR DESCRIPTION
## Description

This PR improves the debug/observability of `autoware_trajectory_validator`.

**What you get after this PR:**

- We can visualize **how long each filter plugin takes** (CollisionFilter, OutOfLaneFilter, VehicleConstraintFilter, TrafficLightFilter), both as a number topic (for external visualization) and as `StringStamped` in RViz.
- **Debug markers** — added support for debug markers and publish them separated based on plugin.
- Minor refactoring: subscriber setup, publisher setup, and context fetching are each moved into their own small function.

**Small behaviour change to be aware of:**

- Plugin names are now `snake_case` (e.g. `CollisionFilter` → `collision_filter`) to avoid unnecessary string processing.

## Related links


**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

Run PSIM + diffusion planner.

<img width="913" height="1037" alt="image" src="https://github.com/user-attachments/assets/09f0c542-21d0-4380-a5a7-05ff17d74539" />


## Notes for reviewers

None.

## Interface changes

None.


### Topic changes

#### Additions and removals

##### Processing time (per-plugin, numeric)

| Change type | Topic Type | Topic Name | Message Type | Description |
|:--|:--|:--|:--|:--|
| Added | Pub | `/planning/trajectory_selector/trajectory_validator_node/debug/collision_filter/processing_time_ms` | `autoware_internal_debug_msgs/Float64Stamped` | Elapsed time in milliseconds spent inside the `collision_filter` plugin. |
| Added | Pub | `/planning/trajectory_selector/trajectory_validator_node/debug/out_of_lane_filter/processing_time_ms` | `autoware_internal_debug_msgs/Float64Stamped` | Elapsed time in milliseconds spent inside the `out_of_lane_filter` plugin. |
| Added | Pub | `/planning/trajectory_selector/trajectory_validator_node/debug/traffic_light_filter/processing_time_ms` | `autoware_internal_debug_msgs/Float64Stamped` | Elapsed time in milliseconds spent inside the `traffic_light_filter` plugin. |
| Added | Pub | `/planning/trajectory_selector/trajectory_validator_node/debug/vehicle_constraint_filter/processing_time_ms` | `autoware_internal_debug_msgs/Float64Stamped` | Elapsed time in milliseconds spent inside the `vehicle_constraint_filter` plugin. |

##### Processing time (node-level / aggregate)

| Change type | Topic Type | Topic Name | Message Type | Description |
|:--|:--|:--|:--|:--|
| Added | Pub | `/planning/trajectory_selector/trajectory_validator_node/debug/processing_time_ms` | `autoware_internal_debug_msgs/Float64Stamped` | Total time in milliseconds spent in one `TrajectoryValidator` tick (sum of all plugins plus node overhead). |
| Added | Pub | `/planning/trajectory_selector/trajectory_validator_node/debug/processing_time_text` | `autoware_internal_debug_msgs::msg::StringStamped` | RViz text overlay showing per-plugin processing time for on-screen inspection. |

##### Plugin report

| Change type | Topic Type | Topic Name | Message Type | Description |
|:--|:--|:--|:--|:--|
| Added | Pub | `/planning/trajectory_selector/trajectory_validator_node/debug/plugin_report_text` | `visualization_msgs/MarkerArray` | Each plugin's validation result, visualized at the ego pose. |

##### Per-plugin debug markers

| Change type | Topic Type | Topic Name | Message Type | Description |
|:--|:--|:--|:--|:--|
| Added | Pub | `/planning/trajectory_selector/trajectory_validator_node/debug/markers/collision_filter` | `visualization_msgs/MarkerArray` | Debug markers produced by the `collision_filter` plugin. |
| Added | Pub | `/planning/trajectory_selector/trajectory_validator_node/debug/markers/out_of_lane_filter` | `visualization_msgs/MarkerArray` | Debug markers produced by the `out_of_lane_filter` plugin. |
| Added | Pub | `/planning/trajectory_selector/trajectory_validator_node/debug/markers/traffic_light_filter` | `visualization_msgs/MarkerArray` | Debug markers produced by the `traffic_light_filter` plugin. |
| Added | Pub | `/planning/trajectory_selector/trajectory_validator_node/debug/markers/vehicle_constraint_filter` | `visualization_msgs/MarkerArray` | Debug markers produced by the `vehicle_constraint_filter` plugin. |

## Effects on system behavior

None.
