### PR TITLE
fix(clang-tidy): add default cases to switches for bugprone-switch-missing-default-case

### DIFF
--- a/.clang-tidy-ci
+++ b/.clang-tidy-ci
@@ -16,7 +16,6 @@ Checks: "
   -bugprone-parent-virtual-call,
   -bugprone-reserved-identifier,
   -bugprone-signed-char-misuse,
-  -bugprone-switch-missing-default-case,
   -bugprone-unchecked-optional-access,
   -bugprone-unused-local-non-trivial-variable,
   -bugprone-unused-return-value"

--- a/control/autoware_operation_mode_transition_manager/src/data.cpp
+++ b/control/autoware_operation_mode_transition_manager/src/data.cpp
@@ -50,8 +50,9 @@ std::optional<OperationMode> toEnum(const ChangeOperationMode::Request & request
       return OperationMode::LOCAL;
     case ServiceMode::REMOTE:
       return OperationMode::REMOTE;
+    default:
+      return std::nullopt;
   }
-  return std::nullopt;
 }
 
 OperationModeValue toMsg(const OperationMode mode)

--- a/perception/autoware_lidar_apollo_instance_segmentation/src/debugger.cpp
+++ b/perception/autoware_lidar_apollo_instance_segmentation/src/debugger.cpp
@@ -84,6 +84,8 @@ void Debugger::publishColoredPointCloud(
         blue = 255;
         break;
       }
+      default:
+        break;
     }
 
     for (const auto & point : object_pointcloud) {

--- a/simulator/autoware_dummy_perception_publisher/src/node.cpp
+++ b/simulator/autoware_dummy_perception_publisher/src/node.cpp
@@ -402,6 +402,8 @@ void DummyPerceptionPublisherNode::objectCallback(
       }
       break;
     }
+    default:
+      break;
   }
 }
 

--- a/system/autoware_command_mode_switcher/src/common/selector_interface.cpp
+++ b/system/autoware_command_mode_switcher/src/common/selector_interface.cpp
@@ -85,6 +85,8 @@ void NetworkGateInterface::on_election_status(const ElectionStatus & msg)
       case ElectionStatus::PATH_NOT_FOUND:
       case ElectionStatus::SELF_INTERRUPTION:
         return std::nullopt;
+      default:
+        break;
     }
     switch (path) {
       case ElectionStatus::MAIN_ECU_TO_MAIN_VCU:

--- a/system/autoware_default_adapi_universe/src/compatibility/autoware_state.cpp
+++ b/system/autoware_default_adapi_universe/src/compatibility/autoware_state.cpp
@@ -137,9 +137,9 @@ void AutowareStateNode::on_timer()
       case AutowareState::DRIVING:            return "Driving";
       case AutowareState::ARRIVED_GOAL:       return "ArrivedGoal";
       case AutowareState::FINALIZING:         return "Finalizing";
+      default:                                return "Unknown(" + std::to_string(state) + ")";
     }
     // clang-format on
-    return "Unknown(" + std::to_string(state) + ")";
   };
 
   const auto state = convert_state();

--- a/visualization/tier4_planning_factor_rviz_plugin/src/planning_factor_rviz_plugin.cpp
+++ b/visualization/tier4_planning_factor_rviz_plugin/src/planning_factor_rviz_plugin.cpp
@@ -249,6 +249,8 @@ void PlanningFactorRvizPlugin::processMessage(
           add_marker(std::make_shared<visualization_msgs::msg::MarkerArray>(virtual_wall));
         }
         break;
+      default:
+        break;
     }
 
     if (show_safety_factors_.getBool()) {


### PR DESCRIPTION
## Description

Fixes 6 `bugprone-switch-missing-default-case` clang-tidy errors that were suppressed in #12432 and tracked in #12450.

Each affected switch statement was missing a `default:` case. The fixes add the appropriate fallback without changing any existing behavior:

| Package | File | Fix |
|---------|------|-----|
| `autoware_operation_mode_transition_manager` | `data.cpp` | `default: return std::nullopt;` (consolidates post-switch return) |
| `autoware_lidar_apollo_instance_segmentation` | `debugger.cpp` | `default: break;` |
| `autoware_dummy_perception_publisher` | `node.cpp` | `default: break;` |
| `autoware_command_mode_switcher` | `selector_interface.cpp` | `default: break;` |
| `autoware_default_adapi_universe` | `autoware_state.cpp` | `default: return "Unknown(...)";` (consolidates post-switch return) |
| `tier4_planning_factor_rviz_plugin` | `planning_factor_rviz_plugin.cpp` | `default: break;` |

The suppression line `-bugprone-switch-missing-default-case` is removed from `.clang-tidy-ci`, re-enabling the check in CI.

## How it was tested

- Built the 6 affected packages inside the Autoware Docker container (`universe-devel` image)
- Ran `clang-tidy-17` (the check requires LLVM 17+) with `bugprone-switch-missing-default-case` enabled on all 6 files
- Confirmed errors before fix, confirmed clean after fix on the 4 packages that could be fully built locally (the remaining 2 are blocked by missing CUDA/OMP headers in the stub build but are correct by inspection)

## Related issues

- Closes part of #12450
- Suppression introduced by #12432 (related to #12431)

## Interface changes

None.