### PR TITLE
fix(cuda_pointcloud_preprocessor): add missing initialization

### DIFF
--- a/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor.cu
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor.cu
@@ -101,6 +101,8 @@ CudaPointcloudPreprocessor::CudaPointcloudPreprocessor() : stream_(initialize_st
 
   device_transformed_points_.resize(num_organized_points_);
   device_crop_mask_.resize(num_organized_points_);
+  device_nan_mask_.resize(num_organized_points_);
+  device_mismatch_mask_.resize(num_organized_points_);
   device_ring_outlier_mask_.resize(num_organized_points_);
   device_indices_.resize(num_organized_points_);
 


### PR DESCRIPTION
## Description
This PR adds missing initialization lines for some thrust vectors.
Without this initialization, `autoware_cuda_pointcloud_preprocessor` triggers `cudaErrorIllegalAddress` on the specific cases.

## Related links

**Parent Issue:**

- [TIER IV INTERNAL](https://star4.slack.com/archives/C076E8EBJTG/p1775809333674269)

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
This modification was tested using the bench environment (please refer to the related link for the detail :pray: )

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
