### PR TITLE
feat(planning_evaluator): add trajectory validation metrics for autoware_trajectory_validator

### DIFF
--- a/evaluator/autoware_planning_evaluator/README.md
+++ b/evaluator/autoware_planning_evaluator/README.md
@@ -49,7 +49,8 @@ These files also provide string conversions and human-readable descriptions for 
 6. [Planning Factor Metrics](#planning-factor-metrics)
 7. [Steering Metrics](#steering-metrics)
 8. [Blinker Metrics](#blinker-metrics)
-9. [Other Information](#other-information)
+9. [Trajectory validation metrics](#trajectory-validation-metrics)
+10. [Other Information](#other-information)
 
 ## Detailed Metrics
 
@@ -288,6 +289,28 @@ Metrics are calculated and publish only when the node receives a steering report
     - `/count_in_duration/min`, `/count_in_duration/max`, `/count_in_duration/mean`: the statistics of the published keep_duration.
     - `/count`: total number of changes.
 
+### Trajectory validation metrics
+
+Accumulates validation results from `autoware_trajectory_validator` (`ValidationReportArray`).
+
+Metrics are calculated and published only when the node receives a message on `~/input/validation_reports`.
+
+#### Implemented metrics
+
+- **`trajectory_validation`**: Error span statistics for each candidate trajectory and for each metric row reported by validators.
+  - **Scopes** (prefixed by `trajectory_validation/` in published names):
+    - `/{generator_name}`: whole-trajectory result from `ValidationReport.level`.
+    - `/{generator_name}/{validator_name}/{metric_name}`: per-row result from each `MetricReport`.
+  - Parameters:
+    - `trajectory_validation.count_warn_as_error`: if `true`, both WARN and ERROR count as error; if `false`, only ERROR.
+  - Sub-metrics to publish (value-based):
+    - `/{scope}/error_duration`: current accumulated duration of the active error span for that scope (seconds).
+    - `/{scope}/error_count`: number of error episodes (transitions into error) for that scope.
+  - Sub-metrics to output:
+    - `/{scope}/error_duration/min`, `/{scope}/error_duration/max`, `/{scope}/error_duration/mean`: statistics over completed error-span durations.
+    - `/{scope}/error_duration/total`: sum of all completed error-span durations (seconds).
+    - `/{scope}/error_count`: total error episodes.
+
 ### Other Information
 
 Additional useful information related to planning:
@@ -322,6 +345,7 @@ Additional useful information related to planning:
 | `~/input/acceleration`           | `geometry_msgs::msg::AccelWithCovarianceStamped`            | Current acceleration of the vehicle               |
 | `~/input/steering_status`        | `autoware_vehicle_msgs::msg::SteeringReport`                | Current steering of the vehicle                   |
 | `~/input/turn_indicators_status` | `autoware_vehicle_msgs::msg::TurnIndicatorsReport`          | Current blinker status of the vehicle             |
+| `~/input/validation_reports`     | `autoware_trajectory_validator::msg::ValidationReportArray` | Trajectory validation reports                     |
 | `{topic_prefix}/{module_name}`   | `autoware_internal_planning_msgs::msg::PlanningFactorArray` | Planning factors of each module to evaluate       |
 
 ### Outputs

--- a/evaluator/autoware_planning_evaluator/README.md
+++ b/evaluator/autoware_planning_evaluator/README.md
@@ -300,7 +300,7 @@ Metrics are calculated and published only when the node receives a message on `~
 - **`trajectory_validation`**: Error span statistics for each candidate trajectory and for each metric row reported by validators.
   - **Scopes** (prefixed by `trajectory_validation/` in published names):
     - `/{generator_name}`: whole-trajectory result from `ValidationReport.level`.
-    - `/{generator_name}/{validator_name}/{metric_name}`: per-row result from each `MetricReport`.
+    - `/{generator_name}/{validator_name}/{metric_name}`: per-row result from each `MetricReport` (names matching `check_*_<object-uuid>` patterns may be excluded; see implementation).
   - Parameters:
     - `trajectory_validation.count_warn_as_error`: if `true`, both WARN and ERROR count as error; if `false`, only ERROR.
   - Sub-metrics to publish (value-based):

--- a/evaluator/autoware_planning_evaluator/config/planning_evaluator.param.yaml
+++ b/evaluator/autoware_planning_evaluator/config/planning_evaluator.param.yaml
@@ -30,6 +30,7 @@
       - abnormal_stop_decision
       - blinker_change_count
       - steer_change_count
+      - trajectory_validation
 
     metrics_for_output:
       - curvature
@@ -59,6 +60,7 @@
       - abnormal_stop_decision
       - blinker_change_count
       - steer_change_count
+      - trajectory_validation
 
     trajectory:
       min_point_dist_m: 0.1 # [m] minimum distance between two successive points to use for angle calculation
@@ -118,3 +120,7 @@
     steer_change_count:
       window_duration_s: 5.0 # [s] window duration of counting steer change for publishing
       steer_rate_margin: 0.2 # [rad/s] margin of steer_rate around 0 to count as steer change
+
+    trajectory_validation:
+      # If true, WARN counts as error for report-level and each MetricReport; if false, only ERROR.
+      count_warn_as_error: false

--- a/evaluator/autoware_planning_evaluator/include/autoware/planning_evaluator/metric_accumulators/trajectory_validation_accumulator.hpp
+++ b/evaluator/autoware_planning_evaluator/include/autoware/planning_evaluator/metric_accumulators/trajectory_validation_accumulator.hpp
@@ -1,0 +1,111 @@
+// Copyright 2025 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__PLANNING_EVALUATOR__METRIC_ACCUMULATORS__TRAJECTORY_VALIDATION_ACCUMULATOR_HPP_
+#define AUTOWARE__PLANNING_EVALUATOR__METRIC_ACCUMULATORS__TRAJECTORY_VALIDATION_ACCUMULATOR_HPP_
+
+#include "autoware/planning_evaluator/metrics/metric.hpp"
+#include "autoware/planning_evaluator/metrics/output_metric.hpp"
+
+#include <autoware_utils/math/accumulator.hpp>
+#include <nlohmann/json.hpp>
+
+#include <autoware_trajectory_validator/msg/validation_report_array.hpp>
+#include <tier4_metric_msgs/msg/metric.hpp>
+#include <tier4_metric_msgs/msg/metric_array.hpp>
+
+#include <optional>
+#include <string>
+#include <unordered_map>
+
+namespace planning_diagnostics
+{
+using autoware_utils::Accumulator;
+using autoware_trajectory_validator::msg::ValidationReportArray;
+using MetricMsg = tier4_metric_msgs::msg::Metric;
+using MetricArrayMsg = tier4_metric_msgs::msg::MetricArray;
+using json = nlohmann::json;
+
+/**
+ * @class TrajectoryValidationAccumulator
+ * @brief Accumulates trajectory validation error statistics from ValidationReportArray.
+ *
+ * Two scopes (published under metric_to_str(Metric::trajectory_validation) + "/" + <scope> + "/…"):
+ * 1) Whole trajectory (per candidate / generator), from ValidationReport.level —
+ *    <scope> = <generator_name>
+ * 2) Each MetricReport row —
+ *    <scope> = <generator_name>/<validator_name>/<metric_name>
+ *    Per generator, metric scopes already present in stats (keys `gen/validator/metric` in
+ *    stats_by_scope_) are updated every report; missing rows are treated as OK for that step.
+ *
+ * `count_warn_as_error`: if false, only ERROR(2); if true, WARN(1) also counts as error.
+ */
+class TrajectoryValidationAccumulator
+{
+public:
+  struct Parameters
+  {
+    bool count_warn_as_error = false;
+  } parameters;
+
+  TrajectoryValidationAccumulator() = default;
+  ~TrajectoryValidationAccumulator() = default;
+
+  /**
+   * @brief Consume a new validation report array (one message may contain multiple trajectories).
+   */
+  void update(const ValidationReportArray & msg);
+
+  /**
+   * @brief Append live metrics for publishing (names follow the scheme in the class comment).
+   */
+  bool addMetricMsg(const Metric & metric, MetricArrayMsg & metrics_msg);
+
+  /**
+   * @brief Final statistics for output.json (min/max/mean/total error_duration, error_count, etc.).
+   */
+  json getOutputJson(const OutputMetric & output_metric);
+
+  static std::string makeMetricScopeKey(
+    const std::string & generator_name, const std::string & validator_name,
+    const std::string & metric_name)
+  {
+    return generator_name + "/" + validator_name + "/" + metric_name;
+  }
+
+private:
+  struct ErrorSpanStats
+  {
+    double current_error_duration_s{0.0};
+    uint64_t error_count{0};
+    /// Sum of completed error-span durations (seconds); complements min/max/mean samples.
+    double completed_error_duration_total_s_{0.0};
+    Accumulator<double> error_duration_accumulator;
+    bool state_updated{false};
+    bool in_error_{false};
+    /// Stamp of the last report step applied to this scope (trajectory_stamp seconds).
+    std::optional<double> last_update_time_s_;
+
+    /// `current_time_s` is ValidationReport.trajectory_stamp for this step; dt is derived inside.
+    void update(bool is_error, double current_time_s);
+    /// Move ongoing error duration into the accumulator (e.g. before final JSON export).
+    void flushOpenErrorForJson();
+  };
+
+  std::unordered_map<std::string, ErrorSpanStats> stats_by_scope_;
+};
+
+}  // namespace planning_diagnostics
+
+#endif  // AUTOWARE__PLANNING_EVALUATOR__METRIC_ACCUMULATORS__TRAJECTORY_VALIDATION_ACCUMULATOR_HPP_

--- a/evaluator/autoware_planning_evaluator/include/autoware/planning_evaluator/metric_accumulators/trajectory_validation_accumulator.hpp
+++ b/evaluator/autoware_planning_evaluator/include/autoware/planning_evaluator/metric_accumulators/trajectory_validation_accumulator.hpp
@@ -18,10 +18,10 @@
 #include "autoware/planning_evaluator/metrics/metric.hpp"
 #include "autoware/planning_evaluator/metrics/output_metric.hpp"
 
+#include <autoware_trajectory_validator/msg/validation_report_array.hpp>
 #include <autoware_utils/math/accumulator.hpp>
 #include <nlohmann/json.hpp>
 
-#include <autoware_trajectory_validator/msg/validation_report_array.hpp>
 #include <tier4_metric_msgs/msg/metric.hpp>
 #include <tier4_metric_msgs/msg/metric_array.hpp>
 
@@ -31,8 +31,8 @@
 
 namespace planning_diagnostics
 {
-using autoware_utils::Accumulator;
 using autoware_trajectory_validator::msg::ValidationReportArray;
+using autoware_utils::Accumulator;
 using MetricMsg = tier4_metric_msgs::msg::Metric;
 using MetricArrayMsg = tier4_metric_msgs::msg::MetricArray;
 using json = nlohmann::json;
@@ -51,8 +51,9 @@ using json = nlohmann::json;
  *
  * `count_warn_as_error`: if false, only ERROR(2); if true, WARN(1) also counts as error.
  *
- * Metric rows whose `metric_name` matches `check_*_<32-hex UUID>` (optional `_<suffix>`) are skipped
- * (object-id-specific checks); see `shouldCollectMetricRow` in trajectory_validation_accumulator.cpp.
+ * Metric rows whose `metric_name` matches `check_*_<32-hex UUID>` (optional `_<suffix>`) are
+ * skipped (object-id-specific checks); see `shouldCollectMetricRow` in
+ * trajectory_validation_accumulator.cpp.
  */
 class TrajectoryValidationAccumulator
 {

--- a/evaluator/autoware_planning_evaluator/include/autoware/planning_evaluator/metric_accumulators/trajectory_validation_accumulator.hpp
+++ b/evaluator/autoware_planning_evaluator/include/autoware/planning_evaluator/metric_accumulators/trajectory_validation_accumulator.hpp
@@ -50,6 +50,9 @@ using json = nlohmann::json;
  *    stats_by_scope_) are updated every report; missing rows are treated as OK for that step.
  *
  * `count_warn_as_error`: if false, only ERROR(2); if true, WARN(1) also counts as error.
+ *
+ * Metric rows whose `metric_name` matches `check_*_<32-hex UUID>` (optional `_<suffix>`) are skipped
+ * (object-id-specific checks); see `shouldCollectMetricRow` in trajectory_validation_accumulator.cpp.
  */
 class TrajectoryValidationAccumulator
 {

--- a/evaluator/autoware_planning_evaluator/include/autoware/planning_evaluator/metrics/metric.hpp
+++ b/evaluator/autoware_planning_evaluator/include/autoware/planning_evaluator/metrics/metric.hpp
@@ -55,6 +55,7 @@ enum class Metric {
   abnormal_stop_decision,
   blinker_change_count,
   steer_change_count,
+  trajectory_validation,
   SIZE,
 };
 
@@ -88,7 +89,8 @@ static const std::unordered_map<std::string, Metric> str_to_metric = {
   {"stop_decision", Metric::stop_decision},
   {"abnormal_stop_decision", Metric::abnormal_stop_decision},
   {"blinker_change_count", Metric::blinker_change_count},
-  {"steer_change_count", Metric::steer_change_count}};
+  {"steer_change_count", Metric::steer_change_count},
+  {"trajectory_validation", Metric::trajectory_validation}};
 
 static const std::unordered_map<Metric, std::string> metric_to_str = {
   {Metric::curvature, "curvature"},
@@ -117,7 +119,8 @@ static const std::unordered_map<Metric, std::string> metric_to_str = {
   {Metric::stop_decision, "stop_decision"},
   {Metric::abnormal_stop_decision, "abnormal_stop_decision"},
   {Metric::blinker_change_count, "blinker_change_count"},
-  {Metric::steer_change_count, "steer_change_count"}};
+  {Metric::steer_change_count, "steer_change_count"},
+  {Metric::trajectory_validation, "trajectory_validation"}};
 
 // Metrics descriptions
 static const std::unordered_map<Metric, std::string> metric_descriptions = {
@@ -151,7 +154,10 @@ static const std::unordered_map<Metric, std::string> metric_descriptions = {
    "module"},
   {Metric::blinker_change_count, "Count of blinker changes in recent `window_duration_s` seconds"},
   {Metric::steer_change_count,
-   "Count of steer_rate positive/negative changes in recent `window_duration_s` seconds"}};
+   "Count of steer_rate positive/negative changes in recent `window_duration_s` seconds"},
+  {Metric::trajectory_validation,
+   "Trajectory validation error_duration[s] and error_count per trajectory (generator) and per "
+   "MetricReport row"}};
 
 namespace details
 {

--- a/evaluator/autoware_planning_evaluator/include/autoware/planning_evaluator/metrics/output_metric.hpp
+++ b/evaluator/autoware_planning_evaluator/include/autoware/planning_evaluator/metrics/output_metric.hpp
@@ -53,6 +53,7 @@ enum class OutputMetric {
   abnormal_stop_decision,
   blinker_change_count,
   steer_change_count,
+  trajectory_validation,
   SIZE,
 };
 
@@ -87,7 +88,8 @@ static const std::unordered_map<std::string, OutputMetric> str_to_output_metric 
   {"stop_decision", OutputMetric::stop_decision},
   {"abnormal_stop_decision", OutputMetric::abnormal_stop_decision},
   {"blinker_change_count", OutputMetric::blinker_change_count},
-  {"steer_change_count", OutputMetric::steer_change_count}};
+  {"steer_change_count", OutputMetric::steer_change_count},
+  {"trajectory_validation", OutputMetric::trajectory_validation}};
 
 static const std::unordered_map<OutputMetric, std::string> output_metric_to_str = {
   {OutputMetric::curvature, "curvature"},
@@ -117,7 +119,8 @@ static const std::unordered_map<OutputMetric, std::string> output_metric_to_str 
   {OutputMetric::stop_decision, "stop_decision"},
   {OutputMetric::abnormal_stop_decision, "abnormal_stop_decision"},
   {OutputMetric::blinker_change_count, "blinker_change_count"},
-  {OutputMetric::steer_change_count, "steer_change_count"}};
+  {OutputMetric::steer_change_count, "steer_change_count"},
+  {OutputMetric::trajectory_validation, "trajectory_validation"}};
 
 // OutputMetrics descriptions
 static const std::unordered_map<OutputMetric, std::string> output_metric_descriptions = {
@@ -157,7 +160,10 @@ static const std::unordered_map<OutputMetric, std::string> output_metric_descrip
   {OutputMetric::blinker_change_count,
    "Statics of published blinker_change_count metrics and total count of blink changes"},
   {OutputMetric::steer_change_count,
-   "Statics of published steer_change_count metrics and total count of steer changes"}};
+   "Statics of published steer_change_count metrics and total count of steer changes"},
+  {OutputMetric::trajectory_validation,
+   "Statics of trajectory validation error_duration (min/max/mean/total of completed spans), "
+   "error_count per trajectory scope and per metric row"}};
 
 namespace details
 {

--- a/evaluator/autoware_planning_evaluator/include/autoware/planning_evaluator/metrics_accumulator.hpp
+++ b/evaluator/autoware_planning_evaluator/include/autoware/planning_evaluator/metrics_accumulator.hpp
@@ -19,9 +19,9 @@
 #include "autoware/planning_evaluator/metric_accumulators/common_accumulator.hpp"
 #include "autoware/planning_evaluator/metric_accumulators/planning_factor_accumulator.hpp"
 #include "autoware/planning_evaluator/metric_accumulators/steer_accumulator.hpp"
+#include "autoware/planning_evaluator/metric_accumulators/trajectory_validation_accumulator.hpp"
 #include "autoware/planning_evaluator/metrics/metric.hpp"
 #include "autoware/planning_evaluator/metrics/output_metric.hpp"
-#include "metrics/metric.hpp"
 
 #include <autoware_utils/math/accumulator.hpp>
 #include <nlohmann/json.hpp>
@@ -57,7 +57,7 @@ public:
   void setPlanningFactors(
     const std::string & module_name, const PlanningFactorArray & planning_factors);
 
-  void addMetricMsg(const Metric & metric, MetricArrayMsg & metrics_msg) const;
+  void addMetricMsg(const Metric & metric, MetricArrayMsg & metrics_msg);
 
   void addMetricMsg(
     const Metric & metric, MetricArrayMsg & metrics_msg, const std::string & module_name);
@@ -65,6 +65,7 @@ public:
   json getOutputJson(const OutputMetric & output_metric);
 
   PlanningFactorAccumulator planning_factor_accumulator;
+  TrajectoryValidationAccumulator trajectory_validation_accumulator;
   BlinkerAccumulator blinker_accumulator;
   SteerAccumulator steer_accumulator;
   std::unordered_map<OutputMetric, CommonAccumulator> common_accumulators;

--- a/evaluator/autoware_planning_evaluator/include/autoware/planning_evaluator/planning_evaluator_node.hpp
+++ b/evaluator/autoware_planning_evaluator/include/autoware/planning_evaluator/planning_evaluator_node.hpp
@@ -25,6 +25,7 @@
 #include "tf2_ros/transform_listener.h"
 
 #include <autoware/route_handler/route_handler.hpp>
+#include <autoware_trajectory_validator/msg/validation_report_array.hpp>
 #include <autoware_utils/math/accumulator.hpp>
 #include <autoware_utils/ros/polling_subscriber.hpp>
 #include <autoware_utils/system/stop_watch.hpp>
@@ -70,6 +71,7 @@ using LaneletMapBin = autoware_map_msgs::msg::LaneletMapBin;
 using autoware_internal_planning_msgs::msg::PlanningFactor;
 using autoware_internal_planning_msgs::msg::PlanningFactorArray;
 using autoware_planning_msgs::msg::LaneletRoute;
+using autoware_trajectory_validator::msg::ValidationReportArray;
 using geometry_msgs::msg::AccelWithCovarianceStamped;
 /**
  * @brief Node for planning evaluation
@@ -132,6 +134,11 @@ public:
    */
   void onPlanningFactors(
     const PlanningFactorArray::ConstSharedPtr planning_factors, const std::string & module_name);
+
+  /**
+   * @brief validation reports from trajectory_validator (remapped ~/input/validation_reports)
+   */
+  void onValidationReports(const ValidationReportArray::ConstSharedPtr reports_msg);
 
   /**
    * @brief add the given metric statistic
@@ -200,6 +207,8 @@ private:
     this, "~/input/steering_status"};
   autoware_utils::InterProcessPollingSubscriber<TurnIndicatorsReport> blinker_sub_{
     this, "~/input/turn_indicators_status"};
+  autoware_utils::InterProcessPollingSubscriber<ValidationReportArray> validation_reports_sub_{
+    this, "~/input/validation_reports"};
 
   std::unordered_map<
     std::string, autoware_utils::InterProcessPollingSubscriber<PlanningFactorArray>>

--- a/evaluator/autoware_planning_evaluator/launch/planning_evaluator.launch.xml
+++ b/evaluator/autoware_planning_evaluator/launch/planning_evaluator.launch.xml
@@ -11,6 +11,7 @@
   <arg name="input/route_topic" default="/planning/mission_planning/route"/>
   <arg name="input/turn_indicators_status" default="/vehicle/status/turn_indicators_status"/>
   <arg name="input/steering_status" default="/vehicle/status/steering_status"/>
+  <arg name="input/validation_reports" default="/planning/trajectory_selector/trajectory_validator_node/debug/validation_reports"/>
 
   <!-- planning evaluator -->
   <group>
@@ -28,6 +29,7 @@
       <remap from="~/input/vector_map" to="$(var input/map_topic)"/>
       <remap from="~/input/turn_indicators_status" to="$(var input/turn_indicators_status)"/>
       <remap from="~/input/steering_status" to="$(var input/steering_status)"/>
+      <remap from="~/input/validation_reports" to="$(var input/validation_reports)"/>
     </node>
   </group>
 </launch>

--- a/evaluator/autoware_planning_evaluator/package.xml
+++ b/evaluator/autoware_planning_evaluator/package.xml
@@ -21,6 +21,7 @@
   <depend>autoware_planning_factor_interface</depend>
   <depend>autoware_planning_msgs</depend>
   <depend>autoware_route_handler</depend>
+  <depend>autoware_trajectory_validator</depend>
   <depend>autoware_utils</depend>
   <depend>autoware_vehicle_info_utils</depend>
   <depend>autoware_vehicle_msgs</depend>

--- a/evaluator/autoware_planning_evaluator/schema/autoware_planning_evaluator.schema.json
+++ b/evaluator/autoware_planning_evaluator/schema/autoware_planning_evaluator.schema.json
@@ -44,7 +44,8 @@
             "stop_decision",
             "abnormal_stop_decision",
             "blinker_change_count",
-            "steer_change_count"
+            "steer_change_count",
+            "trajectory_validation"
           ]
         },
         "metrics_for_output": {
@@ -80,7 +81,8 @@
             "stop_decision",
             "abnormal_stop_decision",
             "blinker_change_count",
-            "steer_change_count"
+            "steer_change_count",
+            "trajectory_validation"
           ]
         },
         "trajectory": {

--- a/evaluator/autoware_planning_evaluator/src/metric_accumulators/trajectory_validation_accumulator.cpp
+++ b/evaluator/autoware_planning_evaluator/src/metric_accumulators/trajectory_validation_accumulator.cpp
@@ -28,7 +28,8 @@ bool levelIndicatesError(const uint8_t level, const bool count_warn_as_error)
   return count_warn_as_error && level == 1;
 }
 
-/// Skip one-off object-id rows: metric_name like check_<prefix>_<32-hex> or check_<...>_<32-hex>_<suffix>.
+/// Skip one-off object-id rows: metric_name like check_<prefix>_<32-hex> or
+/// check_<...>_<32-hex>_<suffix>.
 bool shouldCollectMetricRow(
   [[maybe_unused]] const std::string & validator_name, const std::string & metric_name)
 {

--- a/evaluator/autoware_planning_evaluator/src/metric_accumulators/trajectory_validation_accumulator.cpp
+++ b/evaluator/autoware_planning_evaluator/src/metric_accumulators/trajectory_validation_accumulator.cpp
@@ -1,0 +1,162 @@
+// Copyright 2025 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/planning_evaluator/metric_accumulators/trajectory_validation_accumulator.hpp"
+
+namespace planning_diagnostics
+{
+namespace
+{
+bool levelIndicatesError(const uint8_t level, const bool count_warn_as_error)
+{
+  if (level >= 2) {
+    return true;
+  }
+  return count_warn_as_error && level == 1;
+}
+
+bool isMetricScopeUnderGenerator(const std::string & scope, const std::string & gen)
+{
+  const std::string prefix = gen + "/";
+  return scope.size() > prefix.size() && scope.compare(0, prefix.size(), prefix) == 0;
+}
+}  // namespace
+
+void TrajectoryValidationAccumulator::ErrorSpanStats::update(
+  const bool is_error, const double current_time_s)
+{
+  double dt = 0.0;
+  if (last_update_time_s_.has_value()) {
+    dt = current_time_s - last_update_time_s_.value();
+    if (dt < 0.0) {
+      dt = 0.0;
+    }
+  }
+  last_update_time_s_ = current_time_s;
+
+  if (is_error) {
+    if (!in_error_) {
+      in_error_ = true;
+      error_count++;
+      current_error_duration_s = 0.0;
+    } else {
+      current_error_duration_s += dt;
+    }
+  } else if (in_error_) {
+    error_duration_accumulator.add(current_error_duration_s);
+    completed_error_duration_total_s_ += current_error_duration_s;
+    in_error_ = false;
+    current_error_duration_s = 0.0;
+  }
+  state_updated = true;
+}
+
+void TrajectoryValidationAccumulator::ErrorSpanStats::flushOpenErrorForJson()
+{
+  if (!in_error_) {
+    return;
+  }
+  error_duration_accumulator.add(current_error_duration_s);
+  completed_error_duration_total_s_ += current_error_duration_s;
+  current_error_duration_s = 0.0;
+  in_error_ = false;
+}
+
+void TrajectoryValidationAccumulator::update(const ValidationReportArray & msg)
+{
+  if (msg.reports.empty()) {
+    return;
+  }
+
+  for (const auto & report : msg.reports) {
+    const std::string & gen = report.generator_name;
+    const auto & stamp = report.trajectory_stamp;
+    const double report_time_s =
+      static_cast<double>(stamp.sec) + static_cast<double>(stamp.nanosec) * 1e-9;
+
+    const bool warn_as_err = parameters.count_warn_as_error;
+    const bool traj_err = levelIndicatesError(report.level, warn_as_err);
+    stats_by_scope_[gen].update(traj_err, report_time_s);
+
+    // Rows in this report (last row wins if the same scope appears more than once).
+    std::unordered_map<std::string, bool> present_error_by_scope;
+    for (const auto & row : report.metrics) {
+      const std::string scope = gen + "/" + row.validator_name + "/" + row.metric_name;
+      present_error_by_scope[scope] = levelIndicatesError(row.level, warn_as_err);
+    }
+
+    for (const auto & [scope, m_err] : present_error_by_scope) {
+      stats_by_scope_[scope].update(m_err, report_time_s);
+    }
+
+    for (const auto & entry : stats_by_scope_) {
+      const std::string & scope = entry.first;
+      if (!isMetricScopeUnderGenerator(scope, gen)) {
+        continue;
+      }
+      if (present_error_by_scope.count(scope) != 0) {
+        continue;
+      }
+      stats_by_scope_[scope].update(false, report_time_s);
+    }
+  }
+}
+
+bool TrajectoryValidationAccumulator::addMetricMsg(
+  const Metric & metric, MetricArrayMsg & metrics_msg)
+{
+  if (metric != Metric::trajectory_validation) {
+    return false;
+  }
+  const std::string base = metric_to_str.at(Metric::trajectory_validation) + "/";
+  MetricMsg m;
+  bool any = false;
+  for (auto & [scope, st] : stats_by_scope_) {
+    if (!st.state_updated) {
+      continue;
+    }
+    m.name = base + scope + "/error_duration";
+    m.value = std::to_string(st.current_error_duration_s);
+    metrics_msg.metric_array.push_back(m);
+    m.name = base + scope + "/error_count";
+    m.value = std::to_string(st.error_count);
+    metrics_msg.metric_array.push_back(m);
+    st.state_updated = false;
+    any = true;
+  }
+  return any;
+}
+
+json TrajectoryValidationAccumulator::getOutputJson(const OutputMetric & output_metric)
+{
+  json j;
+  if (output_metric != OutputMetric::trajectory_validation) {
+    return j;
+  }
+  for (auto & [scope, st] : stats_by_scope_) {
+    st.flushOpenErrorForJson();
+    if (st.error_duration_accumulator.count() > 0) {
+      j[scope + "/error_duration/min"] = st.error_duration_accumulator.min();
+      j[scope + "/error_duration/max"] = st.error_duration_accumulator.max();
+      j[scope + "/error_duration/mean"] = st.error_duration_accumulator.mean();
+      j[scope + "/error_duration/total"] = st.completed_error_duration_total_s_;
+    }
+    if (st.error_count > 0) {
+      j[scope + "/error_count"] = st.error_count;
+    }
+  }
+  return j;
+}
+
+}  // namespace planning_diagnostics

--- a/evaluator/autoware_planning_evaluator/src/metric_accumulators/trajectory_validation_accumulator.cpp
+++ b/evaluator/autoware_planning_evaluator/src/metric_accumulators/trajectory_validation_accumulator.cpp
@@ -14,6 +14,8 @@
 
 #include "autoware/planning_evaluator/metric_accumulators/trajectory_validation_accumulator.hpp"
 
+#include <regex>
+
 namespace planning_diagnostics
 {
 namespace
@@ -24,6 +26,16 @@ bool levelIndicatesError(const uint8_t level, const bool count_warn_as_error)
     return true;
   }
   return count_warn_as_error && level == 1;
+}
+
+/// Skip one-off object-id rows: metric_name like check_<prefix>_<32-hex> or check_<...>_<32-hex>_<suffix>.
+bool shouldCollectMetricRow(
+  [[maybe_unused]] const std::string & validator_name, const std::string & metric_name)
+{
+  if (std::regex_match(metric_name, std::regex{R"(^check_.*_[0-9a-fA-F]{32}(?:_.*)?$)"})) {
+    return false;
+  }
+  return true;
 }
 
 bool isMetricScopeUnderGenerator(const std::string & scope, const std::string & gen)
@@ -92,6 +104,9 @@ void TrajectoryValidationAccumulator::update(const ValidationReportArray & msg)
     // Rows in this report (last row wins if the same scope appears more than once).
     std::unordered_map<std::string, bool> present_error_by_scope;
     for (const auto & row : report.metrics) {
+      if (!shouldCollectMetricRow(row.validator_name, row.metric_name)) {
+        continue;
+      }
       const std::string scope = gen + "/" + row.validator_name + "/" + row.metric_name;
       present_error_by_scope[scope] = levelIndicatesError(row.level, warn_as_err);
     }

--- a/evaluator/autoware_planning_evaluator/src/metrics_accumulator.cpp
+++ b/evaluator/autoware_planning_evaluator/src/metrics_accumulator.cpp
@@ -58,7 +58,7 @@ void MetricsAccumulator::setPlanningFactors(
   planning_factor_accumulator.update(module_name, planning_factors, ego_odometry_);
 }
 
-void MetricsAccumulator::addMetricMsg(const Metric & metric, MetricArrayMsg & metrics_msg) const
+void MetricsAccumulator::addMetricMsg(const Metric & metric, MetricArrayMsg & metrics_msg)
 {
   switch (metric) {
     case Metric::blinker_change_count:
@@ -66,6 +66,9 @@ void MetricsAccumulator::addMetricMsg(const Metric & metric, MetricArrayMsg & me
       return;
     case Metric::steer_change_count:
       steer_accumulator.addMetricMsg(metric, metrics_msg);
+      return;
+    case Metric::trajectory_validation:
+      trajectory_validation_accumulator.addMetricMsg(metric, metrics_msg);
       return;
     default:
       return;
@@ -96,6 +99,9 @@ json MetricsAccumulator::getOutputJson(const OutputMetric & output_metric)
     case OutputMetric::stop_decision:
     case OutputMetric::abnormal_stop_decision:
       return planning_factor_accumulator.getOutputJson(output_metric);
+
+    case OutputMetric::trajectory_validation:
+      return trajectory_validation_accumulator.getOutputJson(output_metric);
 
     default:
       if (common_accumulators.find(output_metric) == common_accumulators.end()) {

--- a/evaluator/autoware_planning_evaluator/src/planning_evaluator_node.cpp
+++ b/evaluator/autoware_planning_evaluator/src/planning_evaluator_node.cpp
@@ -98,6 +98,9 @@ PlanningEvaluatorNode::PlanningEvaluatorNode(const rclcpp::NodeOptions & node_op
   metrics_accumulator_.blinker_accumulator.parameters.window_duration_s =
     declare_parameter<double>("blinker_change_count.window_duration_s");
 
+  metrics_accumulator_.trajectory_validation_accumulator.parameters.count_warn_as_error =
+    declare_parameter<bool>("trajectory_validation.count_warn_as_error", false);
+
   // Parameters for node
   output_metrics_ = declare_parameter<bool>("output_metrics");
   ego_frame_str_ = declare_parameter<std::string>("ego_frame");
@@ -374,6 +377,10 @@ void PlanningEvaluatorNode::onTimer()
       onPlanningFactors(planning_factors, module_name);
     }
   }
+  {
+    const auto reports = validation_reports_sub_.take_data();
+    onValidationReports(reports);
+  }
   // Publish metrics
   metrics_msg_.stamp = now();
   metrics_pub_->publish(metrics_msg_);
@@ -545,6 +552,18 @@ void PlanningEvaluatorNode::onPlanningFactors(
   }
   if (metrics_for_publish_.count(Metric::abnormal_stop_decision) != 0) {
     metrics_accumulator_.addMetricMsg(Metric::abnormal_stop_decision, metrics_msg_, module_name);
+  }
+}
+
+void PlanningEvaluatorNode::onValidationReports(
+  const ValidationReportArray::ConstSharedPtr reports_msg)
+{
+  if (!reports_msg) {
+    return;
+  }
+  metrics_accumulator_.trajectory_validation_accumulator.update(*reports_msg);
+  if (metrics_for_publish_.count(Metric::trajectory_validation) != 0) {
+    metrics_accumulator_.addMetricMsg(Metric::trajectory_validation, metrics_msg_);
   }
 }
 


### PR DESCRIPTION
## Description
This PR adds a new **`trajectory_validation`** metric family to `autoware_planning_evaluator` to count/accumulate error times/ error duration of each trajectory / each trajectory_filter / each trajectory_filter's sub metric.

- Parent ticket: https://tier4.atlassian.net/browse/T4DEV-52083
- This PR requires https://github.com/autowarefoundation/autoware_universe/pull/12445

### New Parameter
 `trajectory_validation.count_warn_as_error` (default `false`): when `true`, both WARN and ERROR count as error; when `false`, only ERROR (level ≥ 2) does.
 

### New Metrics

**New Metrics Published**

  - Whole trajectory (per `generator_name` candidate) ERROR
    - `trajectory_validation/<generator_name>/error_duration` — accumulated duration (seconds, string) while the report-level state is in error.
    - `trajectory_validation/<generator_name>/error_count` — number of error episodes (transitions into error).
    - Derived from `ValidationReport.level` (whether WARN counts as error is controlled by `count_warn_as_error`).
  - Per validator metric row (`MetricReport`)
    - `trajectory_validation/<generator_name>/<validator_name>/<metric_name>/error_duration`
    - `trajectory_validation/<generator_name>/<validator_name>/<metric_name>/error_count`
    - Derived from each row’s `level`.
  - For a given generator, if a scope under that generator **does not appear** in the current `report.metrics`, that timestep is treated as **non-error** for that scope.

**New JSON Outputs**

- For each scope (whole trajectory `<generator_name>` or sub-metric `<generator_name>/<validator_name>/<metric_name>`), when there is data to export:
  - `.../error_count` — total error episodes for that scope.
  - `.../error_duration/min`, `.../error_duration/max`, `.../error_duration/mean` — statistics over error-span durations (seconds).
  - `.../error_duration/total` — sum of error-span durations (seconds)

### Other
- `package.xml`: add dependency on **`autoware_trajectory_validator`**.
- `metrics_accumulator.hpp` / `.cpp`: wire accumulator; `addMetricMsg` is no longer `const` (mutable accumulator state).
- README: documents the new metric, scopes, parameters, and input topic.


## How was this PR tested?
Psim

**Sample message publishing**:
```bash
---
stamp:
  sec: 1776678762
  nanosec: 72261663
metric_array:
...
- name: trajectory_validation/MinimumRuleBasedPlanner/uncrossable_boundary_departure_filter/check_critical_departure/error_duration
  unit: ''
  value: '0.000000'
- name: trajectory_validation/MinimumRuleBasedPlanner/uncrossable_boundary_departure_filter/check_critical_departure/error_count
  unit: ''
  value: '0'
- name: trajectory_validation/MinimumRuleBasedPlanner/vehicle_constraint_filter/check_steering_rate/error_duration
  unit: ''
  value: '0.000000'
- name: trajectory_validation/MinimumRuleBasedPlanner/vehicle_constraint_filter/check_steering_rate/error_count
  unit: ''
  value: '0'
- name: trajectory_validation/MinimumRuleBasedPlanner/uncrossable_boundary_departure_filter/trajectory_feasibility/error_duration
  unit: ''
  value: '0.000000'
- name: trajectory_validation/MinimumRuleBasedPlanner/uncrossable_boundary_departure_filter/trajectory_feasibility/error_count
  unit: ''
  value: '0'
- name: trajectory_validation/MinimumRuleBasedPlanner/collision_check_filter/trajectory_feasibility/error_duration
  unit: ''
  value: '0.000000'
- name: trajectory_validation/MinimumRuleBasedPlanner/collision_check_filter/trajectory_feasibility/error_count
  unit: ''
  value: '1'
- name: trajectory_validation/MinimumRuleBasedPlanner/traffic_light_filter/trajectory_feasibility/error_duration
  unit: ''
  value: '20.998604'
- name: trajectory_validation/MinimumRuleBasedPlanner/traffic_light_filter/trajectory_feasibility/error_count
  unit: ''
  value: '1'
- name: trajectory_validation/MinimumRuleBasedPlanner/vehicle_constraint_filter/check_acceleration/error_duration
  unit: ''
  value: '0.000000'
- name: trajectory_validation/MinimumRuleBasedPlanner/vehicle_constraint_filter/check_acceleration/error_count
  unit: ''
  value: '0'
- name: trajectory_validation/MinimumRuleBasedPlanner/vehicle_constraint_filter/check_steering_angle/error_duration
  unit: ''
  value: '0.000000'
- name: trajectory_validation/MinimumRuleBasedPlanner/vehicle_constraint_filter/check_steering_angle/error_count
  unit: ''
  value: '0'
- name: trajectory_validation/MinimumRuleBasedPlanner/vehicle_constraint_filter/trajectory_feasibility/error_duration
  unit: ''
  value: '0.000000'
- name: trajectory_validation/MinimumRuleBasedPlanner/vehicle_constraint_filter/trajectory_feasibility/error_count
  unit: ''
  value: '0'
- name: trajectory_validation/MinimumRuleBasedPlanner/vehicle_constraint_filter/check_speed/error_duration
  unit: ''
  value: '0.000000'
- name: trajectory_validation/MinimumRuleBasedPlanner/vehicle_constraint_filter/check_speed/error_count
  unit: ''
  value: '0'
- name: trajectory_validation/MinimumRuleBasedPlanner/vehicle_constraint_filter/check_deceleration/error_duration
  unit: ''
  value: '0.000000'
- name: trajectory_validation/MinimumRuleBasedPlanner/vehicle_constraint_filter/check_deceleration/error_count
  unit: ''
  value: '0'
- name: trajectory_validation/MinimumRuleBasedPlanner/error_duration
  unit: ''
  value: '20.998604'
- name: trajectory_validation/MinimumRuleBasedPlanner/error_count
  unit: ''
  value: '1'
---

```

**Sample output JSON**:
```json
{
...
    "trajectory_validation/MinimumRuleBasedPlanner/collision_check_filter/trajectory_feasibility/error_count": 1,
    "trajectory_validation/MinimumRuleBasedPlanner/collision_check_filter/trajectory_feasibility/error_duration/max": 0.500004768371582,
    "trajectory_validation/MinimumRuleBasedPlanner/collision_check_filter/trajectory_feasibility/error_duration/mean": 0.500004768371582,
    "trajectory_validation/MinimumRuleBasedPlanner/collision_check_filter/trajectory_feasibility/error_duration/min": 0.500004768371582,
    "trajectory_validation/MinimumRuleBasedPlanner/collision_check_filter/trajectory_feasibility/error_duration/total": 0.500004768371582,
    "trajectory_validation/MinimumRuleBasedPlanner/error_count": 1,
    "trajectory_validation/MinimumRuleBasedPlanner/error_duration/max": 191.99864196777344,
    "trajectory_validation/MinimumRuleBasedPlanner/error_duration/mean": 191.99864196777344,
    "trajectory_validation/MinimumRuleBasedPlanner/error_duration/min": 191.99864196777344,
    "trajectory_validation/MinimumRuleBasedPlanner/error_duration/total": 191.99864196777344,
    "trajectory_validation/MinimumRuleBasedPlanner/traffic_light_filter/trajectory_feasibility/error_count": 1,
    "trajectory_validation/MinimumRuleBasedPlanner/traffic_light_filter/trajectory_feasibility/error_duration/max": 191.99864196777344,
    "trajectory_validation/MinimumRuleBasedPlanner/traffic_light_filter/trajectory_feasibility/error_duration/mean": 191.99864196777344,
    "trajectory_validation/MinimumRuleBasedPlanner/traffic_light_filter/trajectory_feasibility/error_duration/min": 191.99864196777344,
    "trajectory_validation/MinimumRuleBasedPlanner/traffic_light_filter/trajectory_feasibility/error_duration/total": 191.99864196777344,
...
}
```

## Related links
None.

## Notes for reviewers

## Interface changes

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added | Sub | `~/input/validation_reports` | `autoware_trajectory_validator::msg::ValidationReportArray`   | Receive ValidationReportArray |

## Effects on system behavior
None
