### PR TITLE
refactor(`dummy_perception_publisher`): replace `tier4_simulation_msgs` by `autoware_simulation_msgs`

### DIFF
--- a/common/autoware_universe_designs/design/simulator/tier4_dummy_object_rviz_plugin/RvizPluginDummyObject.node.yaml
+++ b/common/autoware_universe_designs/design/simulator/tier4_dummy_object_rviz_plugin/RvizPluginDummyObject.node.yaml
@@ -17,7 +17,7 @@ subscribers: []
 
 publishers:
   - name: object
-    message_type: tier4_simulation_msgs/msg/DummyObject
+    message_type: autoware_simulation_msgs/msg/SimulatedObject
 
 # parameters
 param_files: []

--- a/simulator/autoware_dummy_perception_publisher/CMakeLists.txt
+++ b/simulator/autoware_dummy_perception_publisher/CMakeLists.txt
@@ -12,6 +12,7 @@ find_package(PCL REQUIRED COMPONENTS common filters)
 set(${PROJECT_NAME}_DEPENDENCIES
   autoware_perception_msgs
   autoware_point_types
+  autoware_simulation_msgs
   pcl_conversions
   rclcpp
   sensor_msgs

--- a/simulator/autoware_dummy_perception_publisher/README.md
+++ b/simulator/autoware_dummy_perception_publisher/README.md
@@ -83,7 +83,7 @@ The plugin uses `CommonParameters` for both vehicle and pedestrian object types.
 | `max_remapping_distance`     | double | maximum distance (meters) for remapping validation        |
 | `max_speed_difference_ratio` | double | maximum speed difference ratio tolerance                  |
 | `min_speed_ratio`            | double | minimum speed ratio relative to dummy object speed        |
-| `min_speed_ratio`            | double | minimum speed ratio relative to simulated object speed        |
-| `max_speed_ratio`            | double | maximum speed ratio relative to simulated object speed        |
+| `min_speed_ratio`            | double | minimum speed ratio relative to simulated object speed    |
+| `max_speed_ratio`            | double | maximum speed ratio relative to simulated object speed    |
 | `speed_check_threshold`      | double | speed threshold (m/s) above which speed checks apply      |
 | `path_selection_strategy`    | string | path selection strategy: "highest_confidence" or "random" |

--- a/simulator/autoware_dummy_perception_publisher/README.md
+++ b/simulator/autoware_dummy_perception_publisher/README.md
@@ -83,6 +83,7 @@ The plugin uses `CommonParameters` for both vehicle and pedestrian object types.
 | `max_remapping_distance`     | double | maximum distance (meters) for remapping validation        |
 | `max_speed_difference_ratio` | double | maximum speed difference ratio tolerance                  |
 | `min_speed_ratio`            | double | minimum speed ratio relative to dummy object speed        |
-| `max_speed_ratio`            | double | maximum speed ratio relative to dummy object speed        |
+| `min_speed_ratio`            | double | minimum speed ratio relative to simulated object speed        |
+| `max_speed_ratio`            | double | maximum speed ratio relative to simulated object speed        |
 | `speed_check_threshold`      | double | speed threshold (m/s) above which speed checks apply      |
 | `path_selection_strategy`    | string | path selection strategy: "highest_confidence" or "random" |

--- a/simulator/autoware_dummy_perception_publisher/README.md
+++ b/simulator/autoware_dummy_perception_publisher/README.md
@@ -20,7 +20,7 @@ The node uses a plugin-based architecture to handle different types of object mo
 All movement plugins inherit from `DummyObjectMovementBasePlugin` which provides:
 
 - Object management (add, delete operations)
-- Associated action type handling
+- Associated movement model handling
 - Common interface for object movement
 
 #### Object Action Handling

--- a/simulator/autoware_dummy_perception_publisher/README.md
+++ b/simulator/autoware_dummy_perception_publisher/README.md
@@ -29,7 +29,8 @@ All movement plugins inherit from `DummyObjectMovementBasePlugin` which provides
 - **MODIFY**: Handled directly by the node, bypassing plugin movement logic. Immediately replaces the object's position information across all plugins.
 - **DELETE**: The specified object is removed from all plugins.
 - **DELETEALL**: Clears all objects from all plugins.
-- **PREDICT**: New objects are created, they move in a straight line for a set time and then the predictions extracted from the perception module are used to dictate where the objects will move to. NOTE: for ease of calculation, acceleration is not taken into account when calculating the object's position, only its initial speed.
+
+The requested operation is selected via the `action` field in `autoware_simulation_msgs::msg::SimulatedObject`.
 
 ## Inputs / Outputs
 
@@ -38,7 +39,7 @@ All movement plugins inherit from `DummyObjectMovementBasePlugin` which provides
 | Name                | Type                                              | Description                                               |
 | ------------------- | ------------------------------------------------- | --------------------------------------------------------- |
 | `/tf`               | `tf2_msgs/TFMessage`                              | TF (self-pose)                                            |
-| `input/object`      | `tier4_simulation_msgs::msg::DummyObject`         | dummy detection objects                                   |
+| `input/object`      | `autoware_simulation_msgs::msg::SimulatedObject`  | dummy detection objects                                   |
 | `predicted_objects` | `autoware_perception_msgs::msg::PredictedObjects` | predicted objects (used by PredictedObjectMovementPlugin) |
 
 ### Output

--- a/simulator/autoware_dummy_perception_publisher/README.md
+++ b/simulator/autoware_dummy_perception_publisher/README.md
@@ -28,7 +28,7 @@ All movement plugins inherit from `DummyObjectMovementBasePlugin` which provides
 - **ADD**: New objects are created and they move in a straight line, acceleration and deceleration parameters can be used.
 - **MODIFY**: Handled directly by the node, bypassing plugin movement logic. Immediately replaces the object's position information across all plugins.
 - **DELETE**: The specified object is removed from all plugins.
-- **DELETEALL**: Clears all objects from all plugins.
+- **DELETE_ALL**: Clears all objects from all plugins.
 
 The requested operation is selected via the `action` field in `autoware_simulation_msgs::msg::SimulatedObject`.
 

--- a/simulator/autoware_dummy_perception_publisher/design/DummyPerceptionPublisher.node.yaml
+++ b/simulator/autoware_dummy_perception_publisher/design/DummyPerceptionPublisher.node.yaml
@@ -21,7 +21,7 @@ subscribers:
     message_type: tf2_msgs/msg/TFMessage
     global: /tf_static
   - name: dummy_objects
-    message_type: tier4_simulation_msgs/msg/DummyObject
+    message_type: autoware_simulation_msgs/msg/SimulatedObject
     remap_target: input/object
   - name: predicted_objects
     message_type: autoware_perception_msgs/msg/PredictedObjects

--- a/simulator/autoware_dummy_perception_publisher/include/autoware/dummy_perception_publisher/dummy_object_movement_base_plugin.hpp
+++ b/simulator/autoware_dummy_perception_publisher/include/autoware/dummy_perception_publisher/dummy_object_movement_base_plugin.hpp
@@ -64,7 +64,7 @@ public:
       }
     }
   }
-  bool set_dummy_object(const SimulatedObject & object)
+  bool set_simulated_object(const SimulatedObject & object)
   {
     // Check if the movement model matches
     if (object.movement_model != associated_movement_model_) {

--- a/simulator/autoware_dummy_perception_publisher/include/autoware/dummy_perception_publisher/dummy_object_movement_base_plugin.hpp
+++ b/simulator/autoware_dummy_perception_publisher/include/autoware/dummy_perception_publisher/dummy_object_movement_base_plugin.hpp
@@ -19,14 +19,14 @@
 
 #include <rclcpp/rclcpp.hpp>
 
-#include <tier4_simulation_msgs/msg/dummy_object.hpp>
+#include <autoware_simulation_msgs/msg/simulated_object.hpp>
 
 #include <algorithm>
 #include <vector>
 
 namespace autoware::dummy_perception_publisher::pluginlib
 {
-using tier4_simulation_msgs::msg::DummyObject;
+using autoware_simulation_msgs::msg::SimulatedObject;
 
 class DummyObjectMovementBasePlugin
 {
@@ -37,20 +37,20 @@ protected:
   [[nodiscard]] rclcpp::Node * get_node() const { return node_ptr_; }
 
 public:
-  std::vector<DummyObject> objects_;
-  uint8_t associated_action_type_{tier4_simulation_msgs::msg::DummyObject::ADD};
+  std::vector<SimulatedObject> objects_;
+  uint8_t associated_movement_model_{autoware_simulation_msgs::msg::SimulatedObject::STRAIGHT_LINE};
 
   explicit DummyObjectMovementBasePlugin(rclcpp::Node * node) : node_ptr_(node) {}
   virtual ~DummyObjectMovementBasePlugin() = default;
   virtual void initialize() = 0;
   virtual std::vector<ObjectInfo> move_objects() = 0;
-  [[nodiscard]] std::vector<DummyObject> get_objects() const { return objects_; }
+  [[nodiscard]] std::vector<SimulatedObject> get_objects() const { return objects_; }
   void clear_objects() { objects_.clear(); }
-  void modify_object(const DummyObject & object)
+  void modify_object(const SimulatedObject & object)
   {
     auto obj_it = std::find_if(
       objects_.begin(), objects_.end(),
-      [&object](const DummyObject & obj) { return obj.id.uuid == object.id.uuid; });
+      [&object](const SimulatedObject & obj) { return obj.id.uuid == object.id.uuid; });
     if (obj_it != objects_.end()) {
       *obj_it = object;
     }
@@ -64,16 +64,19 @@ public:
       }
     }
   }
-  bool set_dummy_object(const DummyObject & object)
+  bool set_dummy_object(const SimulatedObject & object)
   {
-    // Check if the action type matches
-    if (object.action != associated_action_type_) {
+    // Check if the movement model matches
+    if (object.movement_model != associated_movement_model_) {
       return false;
     }
     objects_.push_back(object);
     return true;
   }
-  void set_associated_action_type(uint8_t action_type) { associated_action_type_ = action_type; }
+  void set_associated_movement_model(uint8_t movement_model)
+  {
+    associated_movement_model_ = movement_model;
+  }
 };
 
 }  // namespace autoware::dummy_perception_publisher::pluginlib

--- a/simulator/autoware_dummy_perception_publisher/include/autoware/dummy_perception_publisher/movement_utils.hpp
+++ b/simulator/autoware_dummy_perception_publisher/include/autoware/dummy_perception_publisher/movement_utils.hpp
@@ -20,8 +20,8 @@
 #include <rclcpp/rclcpp.hpp>
 
 #include <autoware_perception_msgs/msg/predicted_object.hpp>
-#include <geometry_msgs/msg/pose.hpp>
 #include <autoware_simulation_msgs/msg/simulated_object.hpp>
+#include <geometry_msgs/msg/pose.hpp>
 
 namespace autoware::dummy_perception_publisher::utils
 {

--- a/simulator/autoware_dummy_perception_publisher/include/autoware/dummy_perception_publisher/movement_utils.hpp
+++ b/simulator/autoware_dummy_perception_publisher/include/autoware/dummy_perception_publisher/movement_utils.hpp
@@ -21,7 +21,7 @@
 
 #include <autoware_perception_msgs/msg/predicted_object.hpp>
 #include <geometry_msgs/msg/pose.hpp>
-#include <tier4_simulation_msgs/msg/dummy_object.hpp>
+#include <autoware_simulation_msgs/msg/simulated_object.hpp>
 
 namespace autoware::dummy_perception_publisher::utils
 {
@@ -31,23 +31,24 @@ class MovementUtils
 public:
   // Calculate position for straight-line movement
   static geometry_msgs::msg::Pose calculate_straight_line_position(
-    const tier4_simulation_msgs::msg::DummyObject & object, const rclcpp::Time & current_time);
+    const autoware_simulation_msgs::msg::SimulatedObject & object,
+    const rclcpp::Time & current_time);
 
   // Helper to stop at zero velocity
   static void stop_at_zero_velocity(double & current_vel, double initial_vel, double initial_acc);
 
   // Create a basic ObjectInfo with common fields populated
   static ObjectInfo create_basic_object_info(
-    const tier4_simulation_msgs::msg::DummyObject & object);
+    const autoware_simulation_msgs::msg::SimulatedObject & object);
 
   // Update ObjectInfo with calculated pose and velocity
   static void update_object_info_with_movement(
-    ObjectInfo & obj_info, const tier4_simulation_msgs::msg::DummyObject & object,
+    ObjectInfo & obj_info, const autoware_simulation_msgs::msg::SimulatedObject & object,
     const geometry_msgs::msg::Pose & current_pose, const rclcpp::Time & current_time);
 
   // Calculate position based on predicted trajectory path
   static geometry_msgs::msg::Pose calculate_trajectory_based_position(
-    const tier4_simulation_msgs::msg::DummyObject & object,
+    const autoware_simulation_msgs::msg::SimulatedObject & object,
     const autoware_perception_msgs::msg::PredictedObject & predicted_object,
     const rclcpp::Time & predicted_time, const rclcpp::Time & current_time);
 };

--- a/simulator/autoware_dummy_perception_publisher/include/autoware/dummy_perception_publisher/node.hpp
+++ b/simulator/autoware_dummy_perception_publisher/include/autoware/dummy_perception_publisher/node.hpp
@@ -28,7 +28,7 @@
 #include <autoware_perception_msgs/msg/tracked_objects.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
-#include <tier4_simulation_msgs/msg/dummy_object.hpp>
+#include <autoware_simulation_msgs/msg/simulated_object.hpp>
 #include <unique_identifier_msgs/msg/uuid.hpp>
 
 #include <pcl/common/distances.h>
@@ -45,7 +45,7 @@ namespace autoware::dummy_perception_publisher
 {
 using geometry_msgs::msg::PoseWithCovariance;
 using geometry_msgs::msg::TwistWithCovariance;
-using tier4_simulation_msgs::msg::DummyObject;
+using autoware_simulation_msgs::msg::SimulatedObject;
 
 class PointCloudCreator
 {
@@ -99,7 +99,7 @@ private:
   rclcpp::Publisher<autoware_perception_msgs::msg::DetectedObjects>::SharedPtr detected_object_pub_;
   rclcpp::Publisher<autoware_perception_msgs::msg::TrackedObjects>::SharedPtr
     ground_truth_objects_pub_;
-  rclcpp::Subscription<DummyObject>::SharedPtr object_sub_;
+  rclcpp::Subscription<SimulatedObject>::SharedPtr object_sub_;
   rclcpp::TimerBase::SharedPtr timer_;
   tf2_ros::Buffer tf_buffer_;
   tf2_ros::TransformListener tf_listener_;
@@ -115,7 +115,7 @@ private:
   std::mt19937 random_generator_;
 
   void timerCallback();
-  void objectCallback(const DummyObject::ConstSharedPtr msg);
+  void objectCallback(const SimulatedObject::ConstSharedPtr msg);
 
   pcl::PointCloud<autoware::point_types::PointXYZIRC> convertPointCloudXYZtoXYZIRC(
     const pcl::PointCloud<pcl::PointXYZ>::Ptr & input_cloud) const;

--- a/simulator/autoware_dummy_perception_publisher/include/autoware/dummy_perception_publisher/node.hpp
+++ b/simulator/autoware_dummy_perception_publisher/include/autoware/dummy_perception_publisher/node.hpp
@@ -26,9 +26,9 @@
 
 #include <autoware_perception_msgs/msg/detected_objects.hpp>
 #include <autoware_perception_msgs/msg/tracked_objects.hpp>
+#include <autoware_simulation_msgs/msg/simulated_object.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
-#include <autoware_simulation_msgs/msg/simulated_object.hpp>
 #include <unique_identifier_msgs/msg/uuid.hpp>
 
 #include <pcl/common/distances.h>
@@ -43,9 +43,9 @@
 
 namespace autoware::dummy_perception_publisher
 {
+using autoware_simulation_msgs::msg::SimulatedObject;
 using geometry_msgs::msg::PoseWithCovariance;
 using geometry_msgs::msg::TwistWithCovariance;
-using autoware_simulation_msgs::msg::SimulatedObject;
 
 class PointCloudCreator
 {

--- a/simulator/autoware_dummy_perception_publisher/include/autoware/dummy_perception_publisher/object_info.hpp
+++ b/simulator/autoware_dummy_perception_publisher/include/autoware/dummy_perception_publisher/object_info.hpp
@@ -19,7 +19,7 @@
 
 #include <autoware_perception_msgs/msg/predicted_objects.hpp>
 #include <autoware_perception_msgs/msg/tracked_objects.hpp>
-#include <tier4_simulation_msgs/msg/dummy_object.hpp>
+#include <autoware_simulation_msgs/msg/simulated_object.hpp>
 
 #include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_listener.h>
@@ -30,7 +30,7 @@ using autoware_perception_msgs::msg::TrackedObject;
 using geometry_msgs::msg::Pose;
 using geometry_msgs::msg::PoseWithCovariance;
 using geometry_msgs::msg::TwistWithCovariance;
-using tier4_simulation_msgs::msg::DummyObject;
+using autoware_simulation_msgs::msg::SimulatedObject;
 
 struct ObjectInfo
 {
@@ -52,7 +52,7 @@ struct ObjectInfo
   // convert to TrackedObject
   // (todo) currently need object input to get id and header information, but it should be removed
   [[nodiscard]] autoware_perception_msgs::msg::TrackedObject toTrackedObject(
-    const DummyObject & object) const;
+    const SimulatedObject & object) const;
 };
 }  // namespace autoware::dummy_perception_publisher
 

--- a/simulator/autoware_dummy_perception_publisher/include/autoware/dummy_perception_publisher/object_info.hpp
+++ b/simulator/autoware_dummy_perception_publisher/include/autoware/dummy_perception_publisher/object_info.hpp
@@ -27,10 +27,10 @@ namespace autoware::dummy_perception_publisher
 {
 using autoware_perception_msgs::msg::PredictedObject;
 using autoware_perception_msgs::msg::TrackedObject;
+using autoware_simulation_msgs::msg::SimulatedObject;
 using geometry_msgs::msg::Pose;
 using geometry_msgs::msg::PoseWithCovariance;
 using geometry_msgs::msg::TwistWithCovariance;
-using autoware_simulation_msgs::msg::SimulatedObject;
 
 struct ObjectInfo
 {

--- a/simulator/autoware_dummy_perception_publisher/include/autoware/dummy_perception_publisher/predicted_object_movement_plugin.hpp
+++ b/simulator/autoware_dummy_perception_publisher/include/autoware/dummy_perception_publisher/predicted_object_movement_plugin.hpp
@@ -66,8 +66,8 @@ struct PredictedObjectParameters
   CommonParameters vehicle_params;
 };
 
-// Tracking info of a single dummy object and its mapping to a predicted object
-struct PredictedDummyObjectInfo
+// Tracking info of a single simulated object and its mapping to a predicted object
+struct PredictedSimulatedObjectInfo
 {
   std::string predicted_uuid;
   std::optional<geometry_msgs::msg::Point> last_known_position;
@@ -80,12 +80,12 @@ struct PredictedDummyObjectInfo
 
 // Struct that holds all tracking info, to track multiple NPCs moving using predicted objects'
 // predicted paths
-struct PredictedDummyObjectsTrackingInfo
+struct PredictedSimulatedObjectsTrackingInfo
 {
   std::deque<PredictedObjects> predicted_objects_buffer;
   size_t max_buffer_size{50};  // Store last 5 seconds at 10Hz
-  // mapping between dummy object UUID (string) and its tracking info
-  std::map<std::string, PredictedDummyObjectInfo> dummy_predicted_info_map;
+  // mapping between simulated object UUID (string) and its tracking info
+  std::map<std::string, PredictedSimulatedObjectInfo> simulated_predicted_info_map;
 };
 class PredictedObjectMovementPlugin : public DummyObjectMovementBasePlugin
 {
@@ -99,41 +99,42 @@ public:
 
 private:
   rclcpp::Subscription<PredictedObjects>::SharedPtr predicted_objects_sub_;
-  PredictedDummyObjectsTrackingInfo predicted_dummy_objects_tracking_info_;
+  PredictedSimulatedObjectsTrackingInfo predicted_simulated_objects_tracking_info_;
   PredictedObjectParameters predicted_object_params_;
   std::mt19937 random_generator_;
 
   void predicted_objects_callback(const PredictedObjects::ConstSharedPtr msg);
   std::pair<PredictedObject, rclcpp::Time> find_matching_predicted_object(
     const unique_identifier_msgs::msg::UUID & object_id, const rclcpp::Time & current_time);
-  void update_dummy_to_predicted_mapping(
-    const std::vector<SimulatedObject> & dummy_objects, const PredictedObjects & predicted_objects);
+  void update_simulated_to_predicted_mapping(
+    const std::vector<SimulatedObject> & simulated_objects,
+    const PredictedObjects & predicted_objects);
 
   [[nodiscard]] bool is_valid_remapping_candidate(
-    const PredictedObject & candidate_prediction, const std::string & dummy_uuid_str,
+    const PredictedObject & candidate_prediction, const std::string & simulated_uuid_str,
     const geometry_msgs::msg::Point & expected_position);
   std::optional<geometry_msgs::msg::Point> calculate_expected_position(
     const autoware_perception_msgs::msg::PredictedPath & last_prediction,
-    const std::string & dummy_uuid_str);
+    const std::string & simulated_uuid_str);
 
   static std::set<std::string> collect_available_predicted_uuids(
     const PredictedObjects & predicted_objects,
     std::map<std::string, geometry_msgs::msg::Point> & predicted_positions);
   std::vector<std::string> find_disappeared_predicted_object_uuids(
     std::set<std::string> & available_predicted_uuids);
-  std::map<std::string, geometry_msgs::msg::Point> collect_dummy_object_positions(
-    const std::vector<SimulatedObject> & dummy_objects, const rclcpp::Time & current_time,
-    std::vector<std::string> & unmapped_dummy_uuids);
+  std::map<std::string, geometry_msgs::msg::Point> collect_simulated_object_positions(
+    const std::vector<SimulatedObject> & simulated_objects, const rclcpp::Time & current_time,
+    std::vector<std::string> & unmapped_simulated_uuids);
   std::optional<std::string> find_best_predicted_object_match(
-    const std::string & dummy_uuid, const geometry_msgs::msg::Point & dummy_position,
+    const std::string & simulated_uuid, const geometry_msgs::msg::Point & simulated_position,
     const std::set<std::string> & available_predicted_uuids,
     const std::map<std::string, geometry_msgs::msg::Point> & predicted_positions,
     const PredictedObjects & predicted_objects);
   void create_remapping_for_disappeared_objects(
-    const std::vector<std::string> & dummy_objects_to_remap,
+    const std::vector<std::string> & simulated_objects_to_remap,
     std::set<std::string> & available_predicted_uuids,
     const std::map<std::string, geometry_msgs::msg::Point> & predicted_positions,
-    const std::map<std::string, geometry_msgs::msg::Point> & dummy_positions,
+    const std::map<std::string, geometry_msgs::msg::Point> & simulated_positions,
     const PredictedObjects & predicted_objects);
 
   // Helper methods for creating ObjectInfo

--- a/simulator/autoware_dummy_perception_publisher/include/autoware/dummy_perception_publisher/predicted_object_movement_plugin.hpp
+++ b/simulator/autoware_dummy_perception_publisher/include/autoware/dummy_perception_publisher/predicted_object_movement_plugin.hpp
@@ -22,7 +22,7 @@
 #include <autoware_perception_msgs/msg/predicted_object.hpp>
 #include <autoware_perception_msgs/msg/predicted_objects.hpp>
 #include <autoware_perception_msgs/msg/tracked_objects.hpp>
-#include <tier4_simulation_msgs/msg/dummy_object.hpp>
+#include <autoware_simulation_msgs/msg/simulated_object.hpp>
 
 #include <deque>
 #include <map>
@@ -42,7 +42,7 @@ using geometry_msgs::msg::Point;
 using geometry_msgs::msg::Pose;
 using geometry_msgs::msg::PoseWithCovariance;
 using geometry_msgs::msg::TwistWithCovariance;
-using tier4_simulation_msgs::msg::DummyObject;
+using autoware_simulation_msgs::msg::SimulatedObject;
 
 struct CommonParameters
 {
@@ -107,7 +107,8 @@ private:
   std::pair<PredictedObject, rclcpp::Time> find_matching_predicted_object(
     const unique_identifier_msgs::msg::UUID & object_id, const rclcpp::Time & current_time);
   void update_dummy_to_predicted_mapping(
-    const std::vector<DummyObject> & dummy_objects, const PredictedObjects & predicted_objects);
+    const std::vector<SimulatedObject> & dummy_objects,
+    const PredictedObjects & predicted_objects);
 
   [[nodiscard]] bool is_valid_remapping_candidate(
     const PredictedObject & candidate_prediction, const std::string & dummy_uuid_str,
@@ -122,7 +123,7 @@ private:
   std::vector<std::string> find_disappeared_predicted_object_uuids(
     std::set<std::string> & available_predicted_uuids);
   std::map<std::string, geometry_msgs::msg::Point> collect_dummy_object_positions(
-    const std::vector<DummyObject> & dummy_objects, const rclcpp::Time & current_time,
+    const std::vector<SimulatedObject> & dummy_objects, const rclcpp::Time & current_time,
     std::vector<std::string> & unmapped_dummy_uuids);
   std::optional<std::string> find_best_predicted_object_match(
     const std::string & dummy_uuid, const geometry_msgs::msg::Point & dummy_position,
@@ -138,9 +139,9 @@ private:
 
   // Helper methods for creating ObjectInfo
   [[nodiscard]] ObjectInfo create_object_info_with_straight_line(
-    const DummyObject & object, const rclcpp::Time & current_time) const;
+    const SimulatedObject & object, const rclcpp::Time & current_time) const;
   [[nodiscard]] ObjectInfo create_object_info_with_predicted_path(
-    const DummyObject & object, const PredictedObject & predicted_object,
+    const SimulatedObject & object, const PredictedObject & predicted_object,
     const rclcpp::Time & predicted_time, const rclcpp::Time & current_time) const;
 };
 

--- a/simulator/autoware_dummy_perception_publisher/include/autoware/dummy_perception_publisher/predicted_object_movement_plugin.hpp
+++ b/simulator/autoware_dummy_perception_publisher/include/autoware/dummy_perception_publisher/predicted_object_movement_plugin.hpp
@@ -38,11 +38,11 @@ namespace autoware::dummy_perception_publisher::pluginlib
 
 using autoware_perception_msgs::msg::PredictedObject;
 using autoware_perception_msgs::msg::PredictedObjects;
+using autoware_simulation_msgs::msg::SimulatedObject;
 using geometry_msgs::msg::Point;
 using geometry_msgs::msg::Pose;
 using geometry_msgs::msg::PoseWithCovariance;
 using geometry_msgs::msg::TwistWithCovariance;
-using autoware_simulation_msgs::msg::SimulatedObject;
 
 struct CommonParameters
 {
@@ -107,8 +107,7 @@ private:
   std::pair<PredictedObject, rclcpp::Time> find_matching_predicted_object(
     const unique_identifier_msgs::msg::UUID & object_id, const rclcpp::Time & current_time);
   void update_dummy_to_predicted_mapping(
-    const std::vector<SimulatedObject> & dummy_objects,
-    const PredictedObjects & predicted_objects);
+    const std::vector<SimulatedObject> & dummy_objects, const PredictedObjects & predicted_objects);
 
   [[nodiscard]] bool is_valid_remapping_candidate(
     const PredictedObject & candidate_prediction, const std::string & dummy_uuid_str,

--- a/simulator/autoware_dummy_perception_publisher/package.xml
+++ b/simulator/autoware_dummy_perception_publisher/package.xml
@@ -21,6 +21,7 @@
 
   <depend>autoware_perception_msgs</depend>
   <depend>autoware_point_types</depend>
+  <depend>autoware_simulation_msgs</depend>
   <depend>autoware_trajectory</depend>
   <depend>autoware_utils_geometry</depend>
   <depend>autoware_utils_rclcpp</depend>
@@ -33,7 +34,6 @@
   <depend>tf2</depend>
   <depend>tf2_geometry_msgs</depend>
   <depend>tf2_ros</depend>
-  <depend>tier4_simulation_msgs</depend>
   <depend>unique_identifier_msgs</depend>
 
   <export>

--- a/simulator/autoware_dummy_perception_publisher/src/movement_utils.cpp
+++ b/simulator/autoware_dummy_perception_publisher/src/movement_utils.cpp
@@ -165,7 +165,7 @@ geometry_msgs::msg::Pose MovementUtils::calculate_trajectory_based_position(
   // Calculate elapsed time from predicted object timestamp to current time
   const double elapsed_time = (current_time - predicted_time).seconds();
 
-  // Calculate distance traveled based on elapsed time and dummy object speed
+  // Calculate distance traveled based on elapsed time and simulated object speed
   const double speed = object.initial_state.twist_covariance.twist.linear.x;
   const double distance_traveled = speed * elapsed_time;
 

--- a/simulator/autoware_dummy_perception_publisher/src/movement_utils.cpp
+++ b/simulator/autoware_dummy_perception_publisher/src/movement_utils.cpp
@@ -33,10 +33,10 @@ namespace autoware::dummy_perception_publisher::utils
 {
 using geometry_msgs::msg::Pose;
 using geometry_msgs::msg::Transform;
-using tier4_simulation_msgs::msg::DummyObject;
+using autoware_simulation_msgs::msg::SimulatedObject;
 
 geometry_msgs::msg::Pose MovementUtils::calculate_straight_line_position(
-  const DummyObject & object, const rclcpp::Time & current_time)
+  const SimulatedObject & object, const rclcpp::Time & current_time)
 {
   const auto & initial_pose = object.initial_state.pose_covariance.pose;
   const double initial_vel = std::clamp(
@@ -95,7 +95,7 @@ void MovementUtils::stop_at_zero_velocity(
   }
 }
 
-ObjectInfo MovementUtils::create_basic_object_info(const DummyObject & object)
+ObjectInfo MovementUtils::create_basic_object_info(const SimulatedObject & object)
 {
   ObjectInfo obj_info;
 
@@ -118,7 +118,7 @@ ObjectInfo MovementUtils::create_basic_object_info(const DummyObject & object)
 }
 
 void MovementUtils::update_object_info_with_movement(
-  ObjectInfo & obj_info, const DummyObject & object, const Pose & current_pose,
+  ObjectInfo & obj_info, const SimulatedObject & object, const Pose & current_pose,
   const rclcpp::Time & current_time)
 {
   // Calculate tf from map to moved_object
@@ -151,7 +151,7 @@ void MovementUtils::update_object_info_with_movement(
 }
 
 geometry_msgs::msg::Pose MovementUtils::calculate_trajectory_based_position(
-  const DummyObject & object,
+  const SimulatedObject & object,
   const autoware_perception_msgs::msg::PredictedObject & predicted_object,
   const rclcpp::Time & predicted_time, const rclcpp::Time & current_time)
 {

--- a/simulator/autoware_dummy_perception_publisher/src/movement_utils.cpp
+++ b/simulator/autoware_dummy_perception_publisher/src/movement_utils.cpp
@@ -31,9 +31,9 @@
 
 namespace autoware::dummy_perception_publisher::utils
 {
+using autoware_simulation_msgs::msg::SimulatedObject;
 using geometry_msgs::msg::Pose;
 using geometry_msgs::msg::Transform;
-using autoware_simulation_msgs::msg::SimulatedObject;
 
 geometry_msgs::msg::Pose MovementUtils::calculate_straight_line_position(
   const SimulatedObject & object, const rclcpp::Time & current_time)

--- a/simulator/autoware_dummy_perception_publisher/src/node.cpp
+++ b/simulator/autoware_dummy_perception_publisher/src/node.cpp
@@ -52,7 +52,7 @@ using geometry_msgs::msg::Point;
 using geometry_msgs::msg::PoseStamped;
 using geometry_msgs::msg::Transform;
 using geometry_msgs::msg::TransformStamped;
-using tier4_simulation_msgs::msg::DummyObject;
+using autoware_simulation_msgs::msg::SimulatedObject;
 
 DummyPerceptionPublisherNode::DummyPerceptionPublisherNode()
 : Node("dummy_perception_publisher"), tf_buffer_(this->get_clock()), tf_listener_(tf_buffer_)
@@ -91,7 +91,7 @@ DummyPerceptionPublisherNode::DummyPerceptionPublisherNode()
   detected_object_pub_ = this->create_publisher<autoware_perception_msgs::msg::DetectedObjects>(
     "output/dynamic_object", qos);
   pointcloud_pub_ = this->create_publisher<sensor_msgs::msg::PointCloud2>("output/points_raw", qos);
-  object_sub_ = this->create_subscription<tier4_simulation_msgs::msg::DummyObject>(
+  object_sub_ = this->create_subscription<autoware_simulation_msgs::msg::SimulatedObject>(
     "input/object", 100,
     std::bind(&DummyPerceptionPublisherNode::objectCallback, this, std::placeholders::_1));
 
@@ -166,7 +166,7 @@ void DummyPerceptionPublisherNode::timerCallback()
   static std::uniform_real_distribution<> detection_successful_random(0.0, 1.0);
 
   // merge objects and get object infos
-  std::vector<DummyObject> all_objects;
+  std::vector<SimulatedObject> all_objects;
   std::vector<ObjectInfo> obj_infos;
 
   for (const auto & plugin : movement_plugins_) {
@@ -295,9 +295,9 @@ void DummyPerceptionPublisherNode::timerCallback()
 }
 
 void DummyPerceptionPublisherNode::objectCallback(
-  const tier4_simulation_msgs::msg::DummyObject::ConstSharedPtr msg)
+  const autoware_simulation_msgs::msg::SimulatedObject::ConstSharedPtr msg)
 {
-  auto create_dummy_object = [&]() -> std::optional<DummyObject> {
+  auto create_dummy_object = [&]() -> std::optional<SimulatedObject> {
     tf2::Transform tf_input2map;
     tf2::Transform tf_input2object_origin;
     tf2::Transform tf_map2object_origin;
@@ -313,7 +313,7 @@ void DummyPerceptionPublisherNode::objectCallback(
     }
     tf2::fromMsg(msg->initial_state.pose_covariance.pose, tf_input2object_origin);
     tf_map2object_origin = tf_input2map.inverse() * tf_input2object_origin;
-    DummyObject object;
+    SimulatedObject object;
     object = *msg;
     tf2::toMsg(tf_map2object_origin, object.initial_state.pose_covariance.pose);
 
@@ -333,7 +333,7 @@ void DummyPerceptionPublisherNode::objectCallback(
     return object;
   };
 
-  auto get_modified_object_position = [&]() -> std::optional<DummyObject> {
+  auto get_modified_object_position = [&]() -> std::optional<SimulatedObject> {
     tf2::Transform tf_input2map;
     tf2::Transform tf_input2object_origin;
     tf2::Transform tf_map2object_origin;
@@ -349,7 +349,7 @@ void DummyPerceptionPublisherNode::objectCallback(
     }
     tf2::fromMsg(msg->initial_state.pose_covariance.pose, tf_input2object_origin);
     tf_map2object_origin = tf_input2map.inverse() * tf_input2object_origin;
-    DummyObject modified_object = *msg;
+    SimulatedObject modified_object = *msg;
     tf2::toMsg(tf_map2object_origin, modified_object.initial_state.pose_covariance.pose);
     if (!use_base_link_z_) {
       return modified_object;
@@ -368,8 +368,7 @@ void DummyPerceptionPublisherNode::objectCallback(
   };
 
   switch (msg->action) {
-    case tier4_simulation_msgs::msg::DummyObject::PREDICT:
-    case tier4_simulation_msgs::msg::DummyObject::ADD: {
+    case autoware_simulation_msgs::msg::SimulatedObject::ADD: {
       auto object = create_dummy_object();
       if (!object) {
         break;
@@ -381,13 +380,13 @@ void DummyPerceptionPublisherNode::objectCallback(
       }
       break;
     }
-    case tier4_simulation_msgs::msg::DummyObject::DELETE: {
+    case autoware_simulation_msgs::msg::SimulatedObject::DELETE: {
       for (auto & plugin : movement_plugins_) {
         plugin->delete_object(msg->id);
       }
       break;
     }
-    case tier4_simulation_msgs::msg::DummyObject::MODIFY: {
+    case autoware_simulation_msgs::msg::SimulatedObject::MODIFY: {
       auto modified_object = get_modified_object_position();
       if (modified_object) {
         for (auto & plugin : movement_plugins_) {
@@ -396,7 +395,7 @@ void DummyPerceptionPublisherNode::objectCallback(
       }
       break;
     }
-    case tier4_simulation_msgs::msg::DummyObject::DELETEALL: {
+    case autoware_simulation_msgs::msg::SimulatedObject::DELETE_ALL: {
       for (auto & plugin : movement_plugins_) {
         plugin->clear_objects();
       }

--- a/simulator/autoware_dummy_perception_publisher/src/node.cpp
+++ b/simulator/autoware_dummy_perception_publisher/src/node.cpp
@@ -401,6 +401,13 @@ void DummyPerceptionPublisherNode::objectCallback(
       }
       break;
     }
+    default: {
+      RCLCPP_WARN_THROTTLE(
+        get_logger(), *get_clock(), 5000,
+        "Received SimulatedObject with unknown action value %u; ignoring.",
+        static_cast<unsigned>(msg->action));
+      break;
+    }
   }
 }
 

--- a/simulator/autoware_dummy_perception_publisher/src/node.cpp
+++ b/simulator/autoware_dummy_perception_publisher/src/node.cpp
@@ -48,11 +48,11 @@ namespace autoware::dummy_perception_publisher
 
 using autoware_perception_msgs::msg::TrackedObject;
 using autoware_perception_msgs::msg::TrackedObjects;
+using autoware_simulation_msgs::msg::SimulatedObject;
 using geometry_msgs::msg::Point;
 using geometry_msgs::msg::PoseStamped;
 using geometry_msgs::msg::Transform;
 using geometry_msgs::msg::TransformStamped;
-using autoware_simulation_msgs::msg::SimulatedObject;
 
 DummyPerceptionPublisherNode::DummyPerceptionPublisherNode()
 : Node("dummy_perception_publisher"), tf_buffer_(this->get_clock()), tf_listener_(tf_buffer_)

--- a/simulator/autoware_dummy_perception_publisher/src/node.cpp
+++ b/simulator/autoware_dummy_perception_publisher/src/node.cpp
@@ -297,7 +297,7 @@ void DummyPerceptionPublisherNode::timerCallback()
 void DummyPerceptionPublisherNode::objectCallback(
   const autoware_simulation_msgs::msg::SimulatedObject::ConstSharedPtr msg)
 {
-  auto create_dummy_object = [&]() -> std::optional<SimulatedObject> {
+  auto create_simulated_object = [&]() -> std::optional<SimulatedObject> {
     tf2::Transform tf_input2map;
     tf2::Transform tf_input2object_origin;
     tf2::Transform tf_map2object_origin;
@@ -369,12 +369,12 @@ void DummyPerceptionPublisherNode::objectCallback(
 
   switch (msg->action) {
     case autoware_simulation_msgs::msg::SimulatedObject::ADD: {
-      auto object = create_dummy_object();
+      auto object = create_simulated_object();
       if (!object) {
         break;
       }
       for (auto & plugin : movement_plugins_) {
-        if (plugin->set_dummy_object(*object)) {
+        if (plugin->set_simulated_object(*object)) {
           break;
         }
       }

--- a/simulator/autoware_dummy_perception_publisher/src/object_info.cpp
+++ b/simulator/autoware_dummy_perception_publisher/src/object_info.cpp
@@ -17,10 +17,10 @@
 namespace autoware::dummy_perception_publisher
 {
 using autoware_perception_msgs::msg::TrackedObject;
-using tier4_simulation_msgs::msg::DummyObject;
+using autoware_simulation_msgs::msg::SimulatedObject;
 
 // Implementation of toTrackedObject method
-TrackedObject ObjectInfo::toTrackedObject(const DummyObject & object) const
+TrackedObject ObjectInfo::toTrackedObject(const SimulatedObject & object) const
 {
   TrackedObject tracked_object;
   tracked_object.kinematics.pose_with_covariance = pose_covariance_;

--- a/simulator/autoware_dummy_perception_publisher/src/predicted_object_movement_plugin.cpp
+++ b/simulator/autoware_dummy_perception_publisher/src/predicted_object_movement_plugin.cpp
@@ -74,45 +74,51 @@ void PredictedObjectMovementPlugin::predicted_objects_callback(
   const PredictedObjects::ConstSharedPtr msg)
 {
   // Add to buffer, removing oldest if necessary
-  auto & predicted_objects_buffer = predicted_dummy_objects_tracking_info_.predicted_objects_buffer;
-  if (predicted_objects_buffer.size() >= predicted_dummy_objects_tracking_info_.max_buffer_size) {
+  auto & predicted_objects_buffer =
+    predicted_simulated_objects_tracking_info_.predicted_objects_buffer;
+  if (predicted_objects_buffer.size() >=
+    predicted_simulated_objects_tracking_info_.max_buffer_size) {
     predicted_objects_buffer.pop_front();
   }
   predicted_objects_buffer.push_back(*msg);
 
-  // Update the dummy-to-predicted mapping based on euclidean distance
-  update_dummy_to_predicted_mapping(objects_, *msg);
+  // Update the simulated-to-predicted mapping based on euclidean distance
+  update_simulated_to_predicted_mapping(objects_, *msg);
 }
 std::map<std::string, geometry_msgs::msg::Point>
-PredictedObjectMovementPlugin::collect_dummy_object_positions(
-  const std::vector<SimulatedObject> & dummy_objects, const rclcpp::Time & current_time,
-  std::vector<std::string> & unmapped_dummy_uuids)
+PredictedObjectMovementPlugin::collect_simulated_object_positions(
+  const std::vector<SimulatedObject> & simulated_objects, const rclcpp::Time & current_time,
+  std::vector<std::string> & unmapped_simulated_uuids)
 {
-  std::map<std::string, Point> dummy_positions;
-  auto & dummy_predicted_info_map = predicted_dummy_objects_tracking_info_.dummy_predicted_info_map;
+  std::map<std::string, Point> simulated_positions;
+  auto & simulated_predicted_info_map =
+    predicted_simulated_objects_tracking_info_.simulated_predicted_info_map;
 
-  for (const auto & dummy_obj : dummy_objects) {
-    const auto dummy_uuid_str = autoware_utils_uuid::to_hex_string(dummy_obj.id);
+  for (const auto & simulated_obj : simulated_objects) {
+    const auto simulated_uuid_str = autoware_utils_uuid::to_hex_string(simulated_obj.id);
 
     // Use last known position if available (which includes straight-line calculated position)
     // Otherwise calculate current position using straight-line model
-    auto info_it = dummy_predicted_info_map.find(dummy_uuid_str);
+    auto info_it = simulated_predicted_info_map.find(simulated_uuid_str);
 
-    dummy_positions[dummy_uuid_str] =
-      (info_it != dummy_predicted_info_map.end() && info_it->second.last_known_position.has_value())
+    simulated_positions[simulated_uuid_str] =
+      (info_it != simulated_predicted_info_map.end() &&
+      info_it->second.last_known_position.has_value())
         ? info_it->second.last_known_position.value()
-        : utils::MovementUtils::calculate_straight_line_position(dummy_obj, current_time).position;
+        : utils::MovementUtils::calculate_straight_line_position(
+          simulated_obj, current_time).position;
 
-    if (info_it == dummy_predicted_info_map.end() || info_it->second.predicted_uuid.empty()) {
-      unmapped_dummy_uuids.push_back(dummy_uuid_str);
+    if (info_it == simulated_predicted_info_map.end() || info_it->second.predicted_uuid.empty()) {
+      unmapped_simulated_uuids.push_back(simulated_uuid_str);
     }
   }
 
-  return dummy_positions;
+  return simulated_positions;
 }
 
-void PredictedObjectMovementPlugin::update_dummy_to_predicted_mapping(
-  const std::vector<SimulatedObject> & dummy_objects, const PredictedObjects & predicted_objects)
+void PredictedObjectMovementPlugin::update_simulated_to_predicted_mapping(
+  const std::vector<SimulatedObject> & simulated_objects,
+  const PredictedObjects & predicted_objects)
 {
   const auto node_ptr = get_node();
   const rclcpp::Time current_time = node_ptr->now();
@@ -122,56 +128,62 @@ void PredictedObjectMovementPlugin::update_dummy_to_predicted_mapping(
   auto available_predicted_uuids =
     collect_available_predicted_uuids(predicted_objects, predicted_positions);
 
-  // Check for disappeared predicted objects and mark dummy objects for remapping
-  auto dummy_objects_to_remap = find_disappeared_predicted_object_uuids(available_predicted_uuids);
+  // Check for disappeared predicted objects and mark simulated objects for remapping
+  auto simulated_objects_to_remap =
+    find_disappeared_predicted_object_uuids(available_predicted_uuids);
 
-  // Update dummy object positions and find unmapped dummy objects
-  std::vector<std::string> unmapped_dummy_uuids;
-  auto dummy_positions =
-    collect_dummy_object_positions(dummy_objects, current_time, unmapped_dummy_uuids);
+  // Update simulated object positions and find unmapped simulated objects
+  std::vector<std::string> unmapped_simulated_uuids;
+  auto simulated_positions =
+    collect_simulated_object_positions(simulated_objects, current_time, unmapped_simulated_uuids);
 
-  // Handle remapping for dummy objects whose predicted objects disappeared
+  // Handle remapping for simulated objects whose predicted objects disappeared
   create_remapping_for_disappeared_objects(
-    dummy_objects_to_remap, available_predicted_uuids, predicted_positions, dummy_positions,
+    simulated_objects_to_remap, available_predicted_uuids, predicted_positions, simulated_positions,
     predicted_objects);
 
-  auto & dummy_predicted_info_map = predicted_dummy_objects_tracking_info_.dummy_predicted_info_map;
+  auto & simulated_predicted_info_map =
+    predicted_simulated_objects_tracking_info_.simulated_predicted_info_map;
 
-  // Map unmapped dummy objects to closest available predicted objects
-  for (const auto & dummy_uuid : unmapped_dummy_uuids) {
+  // Map unmapped simulated objects to closest available predicted objects
+  for (const auto & simulated_uuid : unmapped_simulated_uuids) {
     if (available_predicted_uuids.empty()) {
       break;
     }
 
-    const auto & dummy_pos = dummy_positions[dummy_uuid];
+    const auto & simulated_pos = simulated_positions[simulated_uuid];
     auto best_match = find_best_predicted_object_match(
-      dummy_uuid, dummy_pos, available_predicted_uuids, predicted_positions, predicted_objects);
+      simulated_uuid, simulated_pos, available_predicted_uuids, predicted_positions,
+      predicted_objects);
     if (best_match) {
-      dummy_predicted_info_map[dummy_uuid].predicted_uuid = *best_match;
-      dummy_predicted_info_map[dummy_uuid].mapping_timestamp = current_time;
+      simulated_predicted_info_map[simulated_uuid].predicted_uuid = *best_match;
+      simulated_predicted_info_map[simulated_uuid].mapping_timestamp = current_time;
       available_predicted_uuids.erase(*best_match);
     }
   }
 
-  std::set<std::string> current_dummy_uuids;
-  for (const auto & dummy_obj : dummy_objects) {
-    current_dummy_uuids.insert(autoware_utils_uuid::to_hex_string(dummy_obj.id));
+  std::set<std::string> current_simulated_uuids;
+  for (const auto & simulated_obj : simulated_objects) {
+    current_simulated_uuids.insert(autoware_utils_uuid::to_hex_string(simulated_obj.id));
   }
 
-  // Clean up mappings for dummy objects that no longer exist
-  for (auto it = dummy_predicted_info_map.begin(); it != dummy_predicted_info_map.end();) {
-    if (current_dummy_uuids.find(it->first) != current_dummy_uuids.end()) {
+  // Clean up mappings for simulated objects that no longer exist
+  for (
+    auto it = simulated_predicted_info_map.begin();
+    it != simulated_predicted_info_map.end();
+  ) {
+    if (current_simulated_uuids.find(it->first) != current_simulated_uuids.end()) {
       ++it;
       continue;
     }
-    it = dummy_predicted_info_map.erase(it);
+    it = simulated_predicted_info_map.erase(it);
   }
 
-  // Update last known positions for all dummy objects
-  for (const auto & dummy_obj : dummy_objects) {
-    const auto dummy_uuid_str = autoware_utils_uuid::to_hex_string(dummy_obj.id);
-    dummy_predicted_info_map[dummy_uuid_str].last_known_position =
-      dummy_obj.initial_state.pose_covariance.pose.position;
+  // Update last known positions for all simulated objects
+  for (const auto & simulated_obj : simulated_objects) {
+    const auto simulated_uuid_str = autoware_utils_uuid::to_hex_string(simulated_obj.id);
+    simulated_predicted_info_map[simulated_uuid_str].last_known_position =
+      simulated_obj.initial_state.pose_covariance.pose.position;
   }
 }
 
@@ -194,10 +206,11 @@ std::set<std::string> PredictedObjectMovementPlugin::collect_available_predicted
 std::vector<std::string> PredictedObjectMovementPlugin::find_disappeared_predicted_object_uuids(
   std::set<std::string> & available_predicted_uuids)
 {
-  std::vector<std::string> dummy_objects_to_remap;
-  auto & dummy_predicted_info_map = predicted_dummy_objects_tracking_info_.dummy_predicted_info_map;
-  for (const auto & mapping : dummy_predicted_info_map) {
-    const std::string & dummy_uuid = mapping.first;
+  std::vector<std::string> simulated_objects_to_remap;
+  auto & simulated_predicted_info_map =
+    predicted_simulated_objects_tracking_info_.simulated_predicted_info_map;
+  for (const auto & mapping : simulated_predicted_info_map) {
+    const std::string & simulated_uuid = mapping.first;
     const std::string & predicted_uuid = mapping.second.predicted_uuid;
 
     // Skip entries without a predicted UUID mapping
@@ -205,32 +218,33 @@ std::vector<std::string> PredictedObjectMovementPlugin::find_disappeared_predict
       continue;
     }
 
-    // If the predicted object ID no longer exists, mark dummy for remapping
+    // If the predicted object ID no longer exists, mark object for remapping
     if (available_predicted_uuids.find(predicted_uuid) == available_predicted_uuids.end()) {
-      dummy_objects_to_remap.push_back(dummy_uuid);
+      simulated_objects_to_remap.push_back(simulated_uuid);
     } else {
       // Remove already assigned predicted objects from available set
       available_predicted_uuids.erase(predicted_uuid);
     }
   }
 
-  return dummy_objects_to_remap;
+  return simulated_objects_to_remap;
 }
 
 void PredictedObjectMovementPlugin::create_remapping_for_disappeared_objects(
-  const std::vector<std::string> & dummy_objects_to_remap,
+  const std::vector<std::string> & simulated_objects_to_remap,
   std::set<std::string> & available_predicted_uuids,
   const std::map<std::string, geometry_msgs::msg::Point> & predicted_positions,
-  const std::map<std::string, geometry_msgs::msg::Point> & dummy_positions,
+  const std::map<std::string, geometry_msgs::msg::Point> & simulated_positions,
   const PredictedObjects & predicted_objects)
 {
   const auto node_ptr = get_node();
   const rclcpp::Time current_time = node_ptr->now();
-  auto & dummy_predicted_info_map = predicted_dummy_objects_tracking_info_.dummy_predicted_info_map;
+  auto & simulated_predicted_info_map =
+    predicted_simulated_objects_tracking_info_.simulated_predicted_info_map;
   // First, remove old mappings
-  for (const auto & dummy_uuid : dummy_objects_to_remap) {
-    auto it = dummy_predicted_info_map.find(dummy_uuid);
-    if (it != dummy_predicted_info_map.end()) {
+  for (const auto & simulated_uuid : simulated_objects_to_remap) {
+    auto it = simulated_predicted_info_map.find(simulated_uuid);
+    if (it != simulated_predicted_info_map.end()) {
       it->second.predicted_uuid.clear();
     }
   }
@@ -238,33 +252,34 @@ void PredictedObjectMovementPlugin::create_remapping_for_disappeared_objects(
   // Find best matches for all objects that need remapping
   std::vector<std::pair<std::string, double>> mapping_candidates;
 
-  for (const auto & dummy_uuid : dummy_objects_to_remap) {
+  for (const auto & simulated_uuid : simulated_objects_to_remap) {
     // Use last known position if available, otherwise use current position
     Point remapping_position;
-    auto current_pos_it = dummy_positions.find(dummy_uuid);
-    if (current_pos_it == dummy_positions.end()) {
+    auto current_pos_it = simulated_positions.find(simulated_uuid);
+    if (current_pos_it == simulated_positions.end()) {
       continue;
     }
-    auto info_it = dummy_predicted_info_map.find(dummy_uuid);
+    auto info_it = simulated_predicted_info_map.find(simulated_uuid);
 
     remapping_position =
-      (info_it != dummy_predicted_info_map.end() && info_it->second.last_known_position.has_value())
+      (info_it != simulated_predicted_info_map.end() &&
+      info_it->second.last_known_position.has_value())
         ? info_it->second.last_known_position.value()
         : current_pos_it->second;
     // Find closest available predicted object for remapping
     auto best_match = find_best_predicted_object_match(
-      dummy_uuid, remapping_position, available_predicted_uuids, predicted_positions,
+      simulated_uuid, remapping_position, available_predicted_uuids, predicted_positions,
       predicted_objects);
 
     if (best_match) {
       const double distance =
         calc_distance2d(remapping_position, predicted_positions.at(*best_match));
-      mapping_candidates.emplace_back(dummy_uuid + ":" + *best_match, distance);
+      mapping_candidates.emplace_back(simulated_uuid + ":" + *best_match, distance);
     }
   }
 
   // Sort candidates by distance to ensure closest matches get priority
-  // This is because multiple dummy objects may have the same best match
+  // This is because multiple simulated objects may have the same best match
   std::sort(
     mapping_candidates.begin(), mapping_candidates.end(),
     [](const auto & a, const auto & b) { return a.second < b.second; });
@@ -273,20 +288,20 @@ void PredictedObjectMovementPlugin::create_remapping_for_disappeared_objects(
   for (const auto & candidate : mapping_candidates) {
     const std::string & combined = candidate.first;
     const size_t colon_pos = combined.find(':');
-    const std::string dummy_uuid = combined.substr(0, colon_pos);
+    const std::string simulated_uuid = combined.substr(0, colon_pos);
     const std::string predicted_uuid = combined.substr(colon_pos + 1);
 
     // Only create mapping if predicted object is still available
     if (available_predicted_uuids.find(predicted_uuid) != available_predicted_uuids.end()) {
-      dummy_predicted_info_map[dummy_uuid].predicted_uuid = predicted_uuid;
-      dummy_predicted_info_map[dummy_uuid].mapping_timestamp = current_time;
+      simulated_predicted_info_map[simulated_uuid].predicted_uuid = predicted_uuid;
+      simulated_predicted_info_map[simulated_uuid].mapping_timestamp = current_time;
       available_predicted_uuids.erase(predicted_uuid);
     }
   }
 }
 
 std::optional<std::string> PredictedObjectMovementPlugin::find_best_predicted_object_match(
-  const std::string & dummy_uuid, const geometry_msgs::msg::Point & dummy_position,
+  const std::string & simulated_uuid, const geometry_msgs::msg::Point & simulated_position,
   const std::set<std::string> & available_predicted_uuids,
   const std::map<std::string, geometry_msgs::msg::Point> & predicted_positions,
   const PredictedObjects & predicted_objects)
@@ -313,12 +328,12 @@ std::optional<std::string> PredictedObjectMovementPlugin::find_best_predicted_ob
     const PredictedObject & candidate_pred_obj = *pred_obj;
 
     // In case of multiple valid candidates, choose the closest one
-    double distance = calc_distance2d(dummy_position, pred_pos);
+    double distance = calc_distance2d(simulated_position, pred_pos);
 
     // Check if there is a valid remapping candidate based on position and speed
     if (
       distance >= min_distance ||
-      !is_valid_remapping_candidate(candidate_pred_obj, dummy_uuid, dummy_position)) {
+      !is_valid_remapping_candidate(candidate_pred_obj, simulated_uuid, simulated_position)) {
       continue;
     }
 
@@ -334,26 +349,26 @@ std::optional<std::string> PredictedObjectMovementPlugin::find_best_predicted_ob
 }
 
 bool PredictedObjectMovementPlugin::is_valid_remapping_candidate(
-  const PredictedObject & candidate_prediction, const std::string & dummy_uuid_str,
+  const PredictedObject & candidate_prediction, const std::string & simulated_uuid_str,
   const geometry_msgs::msg::Point & expected_position)
 {
   // Perform various checks to validate if the candidate predicted object is a good match
-  // for the dummy object
-  auto dummy_it =
-    std::find_if(objects_.begin(), objects_.end(), [&dummy_uuid_str](const auto & obj) {
+  // for the simulated object
+  auto simulated_it =
+    std::find_if(objects_.begin(), objects_.end(), [&simulated_uuid_str](const auto & obj) {
       const auto uuid = autoware_utils_uuid::to_hex_string(obj.id);
-      return uuid == dummy_uuid_str;
+      return uuid == simulated_uuid_str;
     });
 
-  if (dummy_it == objects_.end()) {
+  if (simulated_it == objects_.end()) {
     return false;
   }
 
-  const auto & dummy_object = *dummy_it;
+  const auto & simulated_object = *simulated_it;
   // Check if this is a pedestrian object
 
   bool is_pedestrian =
-    (dummy_object.classification.label ==
+    (simulated_object.classification.label ==
      autoware_perception_msgs::msg::ObjectClassification::PEDESTRIAN);
 
   // Use class-specific thresholds
@@ -372,8 +387,9 @@ bool PredictedObjectMovementPlugin::is_valid_remapping_candidate(
     return false;
   }
 
-  // Get dummy object speed for comparison (reuse dummy_it from above)
-  const double dummy_speed = dummy_object.initial_state.twist_covariance.twist.linear.x;
+  // Get simulated object speed for comparison (reuse simulated_it from above)
+  const double simulated_speed =
+    simulated_object.initial_state.twist_covariance.twist.linear.x;
 
   // Get candidate predicted object speed
   const auto & candidate_twist =
@@ -391,31 +407,33 @@ bool PredictedObjectMovementPlugin::is_valid_remapping_candidate(
     is_pedestrian ? pedestrian_params.speed_check_threshold : vehicle_params.speed_check_threshold;
 
   auto is_within_speed_bounds = [&](double speed) {
-    return speed >= min_speed_ratio * dummy_speed && speed <= max_speed_ratio * dummy_speed;
+    return speed >= min_speed_ratio * simulated_speed &&
+      speed <= max_speed_ratio * simulated_speed;
   };
 
-  // Reject if candidate speed is too different when dummy speed is significant
-  if (dummy_speed > speed_check_threshold && !is_within_speed_bounds(candidate_speed)) {
+  // Reject if candidate speed is too different when simulated speed is significant
+  if (simulated_speed > speed_check_threshold && !is_within_speed_bounds(candidate_speed)) {
     RCLCPP_DEBUG(
       rclcpp::get_logger("dummy_perception_publisher"),
-      "Rejecting remapping candidate for object %s (%s) due to speed difference: dummy=%fm/s, "
+      "Rejecting remapping candidate for object %s (%s) due to speed difference: simulated=%fm/s, "
       "candidate=%fm/s",
-      dummy_uuid_str.c_str(), is_pedestrian ? "pedestrian" : "vehicle", dummy_speed,
+      simulated_uuid_str.c_str(), is_pedestrian ? "pedestrian" : "vehicle", simulated_speed,
       candidate_speed);
     return false;
   }
 
   // Compare speeds if both are significant
-  if (dummy_speed > 0.1 && candidate_speed > 0.1) {
+  if (simulated_speed > 0.1 && candidate_speed > 0.1) {
     const double speed_ratio =
-      std::max(dummy_speed / candidate_speed, candidate_speed / dummy_speed);
+      std::max(simulated_speed / candidate_speed, candidate_speed / simulated_speed);
     if (speed_ratio > max_speed_difference_ratio) {
       RCLCPP_DEBUG(
         rclcpp::get_logger("dummy_perception_publisher"),
-        "Rejecting remapping candidate for object %s (%s) due to speed difference: %fx (dummy: "
+        "Rejecting remapping candidate for object %s (%s) due to speed difference: %fx (simulated: "
         "%fm/s, "
         "candidate: %fm/s, max_ratio: %f)",
-        dummy_uuid_str.c_str(), is_pedestrian ? "pedestrian" : "vehicle", speed_ratio, dummy_speed,
+        simulated_uuid_str.c_str(), is_pedestrian ? "pedestrian" : "vehicle", speed_ratio,
+        simulated_speed,
         candidate_speed, max_speed_difference_ratio);
       return false;
     }
@@ -423,18 +441,19 @@ bool PredictedObjectMovementPlugin::is_valid_remapping_candidate(
 
   // Calculate expected position based on last known trajectory if available
   Point comparison_position = expected_position;
-  auto & dummy_predicted_info_map = predicted_dummy_objects_tracking_info_.dummy_predicted_info_map;
-  auto info_it = dummy_predicted_info_map.find(dummy_uuid_str);
+  auto & simulated_predicted_info_map =
+    predicted_simulated_objects_tracking_info_.simulated_predicted_info_map;
+  auto info_it = simulated_predicted_info_map.find(simulated_uuid_str);
   if (
-    info_it == dummy_predicted_info_map.end() ||
+    info_it == simulated_predicted_info_map.end() ||
     !info_it->second.last_used_prediction.has_value()) {
     return true;  // No last prediction, allow the match
   }
 
-  // Calculate where the dummy object should be based on its last known trajectory
+  // Calculate where the simulated object should be based on its last known trajectory
   const auto & last_trajectory =
     info_it->second.last_used_prediction.value().kinematics.predicted_paths.at(0);
-  const auto expected_pos = calculate_expected_position(last_trajectory, dummy_uuid_str);
+  const auto expected_pos = calculate_expected_position(last_trajectory, simulated_uuid_str);
   if (expected_pos.has_value()) {
     comparison_position = expected_pos.value();
   }
@@ -450,7 +469,7 @@ bool PredictedObjectMovementPlugin::is_valid_remapping_candidate(
       "Rejecting remapping candidate for object %s (%s) due to large distance: %fm > %fm "
       "(expected: %f, %f, "
       "candidate: %f, %f)",
-      dummy_uuid_str.c_str(), is_pedestrian ? "pedestrian" : "vehicle", distance,
+      simulated_uuid_str.c_str(), is_pedestrian ? "pedestrian" : "vehicle", distance,
       max_remapping_distance, comparison_position.x, comparison_position.y, candidate_pos.x,
       candidate_pos.y);
     return false;
@@ -461,25 +480,25 @@ bool PredictedObjectMovementPlugin::is_valid_remapping_candidate(
 
 std::optional<geometry_msgs::msg::Point> PredictedObjectMovementPlugin::calculate_expected_position(
   const autoware_perception_msgs::msg::PredictedPath & last_prediction,
-  const std::string & dummy_uuid_str)
+  const std::string & simulated_uuid_str)
 {
   // Check if we have predicted paths
   if (last_prediction.path.empty()) {
     return std::nullopt;
   }
 
-  // Find the dummy object by UUID
-  auto dummy_it =
-    std::find_if(objects_.begin(), objects_.end(), [&dummy_uuid_str](const auto & obj) {
+  // Find the simulated object by UUID
+  auto simulated_it =
+    std::find_if(objects_.begin(), objects_.end(), [&simulated_uuid_str](const auto & obj) {
       const auto uuid = autoware_utils_uuid::to_hex_string(obj.id);
-      return uuid == dummy_uuid_str;
+      return uuid == simulated_uuid_str;
     });
 
-  if (dummy_it == objects_.end()) {
+  if (simulated_it == objects_.end()) {
     return std::nullopt;
   }
 
-  const auto & dummy_object = *dummy_it;
+  const auto & simulated_object = *simulated_it;
 
   const auto & selected_path = last_prediction;
 
@@ -495,10 +514,11 @@ std::optional<geometry_msgs::msg::Point> PredictedObjectMovementPlugin::calculat
   // Calculate elapsed time from last prediction to current time
   const auto node_ptr = get_node();
   const auto current_time = node_ptr->now();
-  auto & dummy_predicted_info_map = predicted_dummy_objects_tracking_info_.dummy_predicted_info_map;
-  auto info_it = dummy_predicted_info_map.find(dummy_uuid_str);
+  auto & simulated_predicted_info_map =
+    predicted_simulated_objects_tracking_info_.simulated_predicted_info_map;
+  auto info_it = simulated_predicted_info_map.find(simulated_uuid_str);
   if (
-    info_it == dummy_predicted_info_map.end() ||
+    info_it == simulated_predicted_info_map.end() ||
     !info_it->second.last_used_prediction_time.has_value()) {
     return std::nullopt;
   }
@@ -506,8 +526,8 @@ std::optional<geometry_msgs::msg::Point> PredictedObjectMovementPlugin::calculat
   const double elapsed_time =
     (current_time - info_it->second.last_used_prediction_time.value()).seconds();
 
-  // Calculate distance traveled based on elapsed time and dummy object speed
-  const double speed = dummy_object.initial_state.twist_covariance.twist.linear.x;
+  // Calculate distance traveled based on elapsed time and simulated object speed
+  const double speed = simulated_object.initial_state.twist_covariance.twist.linear.x;
   const double distance_traveled = speed * elapsed_time;
 
   // Calculate cumulative distances along the path
@@ -600,10 +620,13 @@ PredictedObjectMovementPlugin::find_matching_predicted_object(
 
   const auto & obj_uuid_str = autoware_utils_uuid::to_hex_string(object_id);
 
-  // Check if this dummy object is mapped to a predicted object
-  auto & dummy_predicted_info_map = predicted_dummy_objects_tracking_info_.dummy_predicted_info_map;
-  auto mapping_it = dummy_predicted_info_map.find(obj_uuid_str);
-  if (mapping_it == dummy_predicted_info_map.end() || mapping_it->second.predicted_uuid.empty()) {
+  // Check if this object is mapped to a predicted object
+  auto & simulated_predicted_info_map =
+    predicted_simulated_objects_tracking_info_.simulated_predicted_info_map;
+  auto mapping_it = simulated_predicted_info_map.find(obj_uuid_str);
+  if (
+    mapping_it == simulated_predicted_info_map.end() ||
+    mapping_it->second.predicted_uuid.empty()) {
     return std::make_pair(empty_object, empty_time);
   }
 
@@ -612,11 +635,11 @@ PredictedObjectMovementPlugin::find_matching_predicted_object(
   // Check if we should keep using the current prediction for at least
   // min_predicted_path_keep_duration Check if we have a last used prediction and if we should keep
   // using it
-  auto info_it = dummy_predicted_info_map.find(obj_uuid_str);
-  if (info_it == dummy_predicted_info_map.end()) {
+  auto info_it = simulated_predicted_info_map.find(obj_uuid_str);
+  if (info_it == simulated_predicted_info_map.end()) {
     // Create entry if it doesn't exist (needed for later updates)
-    dummy_predicted_info_map[obj_uuid_str];
-    info_it = dummy_predicted_info_map.find(obj_uuid_str);
+    simulated_predicted_info_map[obj_uuid_str];
+    info_it = simulated_predicted_info_map.find(obj_uuid_str);
   }
 
   if (
@@ -638,7 +661,7 @@ PredictedObjectMovementPlugin::find_matching_predicted_object(
 
   // Time to update: find the closest prediction in the past
   const auto & predicted_objects_buffer =
-    predicted_dummy_objects_tracking_info_.predicted_objects_buffer;
+    predicted_simulated_objects_tracking_info_.predicted_objects_buffer;
 
   auto predicted_objects_buffer_itr = std::find_if(
     predicted_objects_buffer.rbegin(), predicted_objects_buffer.rend(),
@@ -725,9 +748,9 @@ PredictedObjectMovementPlugin::find_matching_predicted_object(
   }
 
   // Store this as the new prediction to use for some seconds
-  dummy_predicted_info_map[obj_uuid_str].last_used_prediction = modified_predicted_object;
-  dummy_predicted_info_map[obj_uuid_str].last_used_prediction_time = msg_time;
-  dummy_predicted_info_map[obj_uuid_str].prediction_update_timestamp = current_time;
+  simulated_predicted_info_map[obj_uuid_str].last_used_prediction = modified_predicted_object;
+  simulated_predicted_info_map[obj_uuid_str].last_used_prediction_time = msg_time;
+  simulated_predicted_info_map[obj_uuid_str].prediction_update_timestamp = current_time;
 
   return std::make_pair(modified_predicted_object, msg_time);
 }
@@ -746,8 +769,8 @@ std::vector<ObjectInfo> PredictedObjectMovementPlugin::move_objects()
     const bool matched_predicted =
       (!predicted_object.object_id.uuid.empty() &&
        !predicted_object.kinematics.predicted_paths.empty() && predicted_time.nanoseconds() > 0);
-    auto & dummy_predicted_info_map =
-      predicted_dummy_objects_tracking_info_.dummy_predicted_info_map;
+    auto & simulated_predicted_info_map =
+      predicted_simulated_objects_tracking_info_.simulated_predicted_info_map;
 
     ObjectInfo obj_info = [&]() {
       if (matched_predicted) {
@@ -756,16 +779,17 @@ std::vector<ObjectInfo> PredictedObjectMovementPlugin::move_objects()
       }
 
       // Check if we have a last used prediction for this object
-      const auto & dummy_uuid_str = autoware_utils_uuid::to_hex_string(object.id);
-      auto info_it = dummy_predicted_info_map.find(dummy_uuid_str);
+      const auto & simulated_uuid_str = autoware_utils_uuid::to_hex_string(object.id);
+      auto info_it = simulated_predicted_info_map.find(simulated_uuid_str);
 
       if (
-        info_it != dummy_predicted_info_map.end() &&
+        info_it != simulated_predicted_info_map.end() &&
         info_it->second.last_used_prediction.has_value() &&
         info_it->second.last_used_prediction_time.has_value()) {
         RCLCPP_DEBUG(
           rclcpp::get_logger("dummy_perception_publisher"),
-          "Using last known prediction for lost object with ID: %s", dummy_uuid_str.c_str());
+          "Using last known prediction for lost object with ID: %s",
+          simulated_uuid_str.c_str());
         return create_object_info_with_predicted_path(
           object, info_it->second.last_used_prediction.value(),
           info_it->second.last_used_prediction_time.value(), current_time);
@@ -773,18 +797,19 @@ std::vector<ObjectInfo> PredictedObjectMovementPlugin::move_objects()
 
       RCLCPP_DEBUG(
         rclcpp::get_logger("dummy_perception_publisher"),
-        "No matching predicted object found for dummy object with ID: %s", dummy_uuid_str.c_str());
+        "No matching predicted object found for object with ID: %s",
+        simulated_uuid_str.c_str());
       // Use straight-line motion for all other cases
       return create_object_info_with_straight_line(object, current_time);
     }();
     obj_infos.push_back(obj_info);
     // Update last known position based on calculated ObjectInfo position
-    const auto & dummy_uuid_str = autoware_utils_uuid::to_hex_string(object.id);
-    dummy_predicted_info_map[dummy_uuid_str].last_known_position =
+    const auto & simulated_uuid_str = autoware_utils_uuid::to_hex_string(object.id);
+    simulated_predicted_info_map[simulated_uuid_str].last_known_position =
       obj_info.pose_covariance_.pose.position;
 
     // Track object creation time if not already tracked
-    auto & info = dummy_predicted_info_map[dummy_uuid_str];
+    auto & info = simulated_predicted_info_map[simulated_uuid_str];
     if (!info.creation_timestamp.has_value()) {
       info.creation_timestamp = rclcpp::Time(object.header.stamp);
     }
@@ -832,7 +857,7 @@ ObjectInfo PredictedObjectMovementPlugin::create_object_info_with_predicted_path
   utils::MovementUtils::update_object_info_with_movement(
     obj_info, object, current_pose, current_time);
 
-  // Use dummy object's velocity consistently
+  // Use simulated object's velocity consistently
   obj_info.twist_covariance_.twist.linear.x = object.initial_state.twist_covariance.twist.linear.x;
 
   return obj_info;

--- a/simulator/autoware_dummy_perception_publisher/src/predicted_object_movement_plugin.cpp
+++ b/simulator/autoware_dummy_perception_publisher/src/predicted_object_movement_plugin.cpp
@@ -34,8 +34,7 @@ using autoware_utils_geometry::calc_distance2d;
 void PredictedObjectMovementPlugin::initialize()
 {
   using autoware_utils_rclcpp::get_or_declare_parameter;
-  set_associated_movement_model(
-    autoware_simulation_msgs::msg::SimulatedObject::PREDICTED_PATH);
+  set_associated_movement_model(autoware_simulation_msgs::msg::SimulatedObject::PREDICTED_PATH);
   // Declare prediction parameters
   auto node_ptr = get_node();
   predicted_object_params_.min_predicted_path_keep_duration =
@@ -113,8 +112,7 @@ PredictedObjectMovementPlugin::collect_dummy_object_positions(
 }
 
 void PredictedObjectMovementPlugin::update_dummy_to_predicted_mapping(
-  const std::vector<SimulatedObject> & dummy_objects,
-  const PredictedObjects & predicted_objects)
+  const std::vector<SimulatedObject> & dummy_objects, const PredictedObjects & predicted_objects)
 {
   const auto node_ptr = get_node();
   const rclcpp::Time current_time = node_ptr->now();

--- a/simulator/autoware_dummy_perception_publisher/src/predicted_object_movement_plugin.cpp
+++ b/simulator/autoware_dummy_perception_publisher/src/predicted_object_movement_plugin.cpp
@@ -34,7 +34,8 @@ using autoware_utils_geometry::calc_distance2d;
 void PredictedObjectMovementPlugin::initialize()
 {
   using autoware_utils_rclcpp::get_or_declare_parameter;
-  set_associated_action_type(tier4_simulation_msgs::msg::DummyObject::PREDICT);
+  set_associated_movement_model(
+    autoware_simulation_msgs::msg::SimulatedObject::PREDICTED_PATH);
   // Declare prediction parameters
   auto node_ptr = get_node();
   predicted_object_params_.min_predicted_path_keep_duration =
@@ -85,7 +86,7 @@ void PredictedObjectMovementPlugin::predicted_objects_callback(
 }
 std::map<std::string, geometry_msgs::msg::Point>
 PredictedObjectMovementPlugin::collect_dummy_object_positions(
-  const std::vector<DummyObject> & dummy_objects, const rclcpp::Time & current_time,
+  const std::vector<SimulatedObject> & dummy_objects, const rclcpp::Time & current_time,
   std::vector<std::string> & unmapped_dummy_uuids)
 {
   std::map<std::string, Point> dummy_positions;
@@ -112,7 +113,7 @@ PredictedObjectMovementPlugin::collect_dummy_object_positions(
 }
 
 void PredictedObjectMovementPlugin::update_dummy_to_predicted_mapping(
-  const std::vector<tier4_simulation_msgs::msg::DummyObject> & dummy_objects,
+  const std::vector<SimulatedObject> & dummy_objects,
   const PredictedObjects & predicted_objects)
 {
   const auto node_ptr = get_node();
@@ -794,7 +795,7 @@ std::vector<ObjectInfo> PredictedObjectMovementPlugin::move_objects()
 }
 
 ObjectInfo PredictedObjectMovementPlugin::create_object_info_with_straight_line(
-  const DummyObject & object, const rclcpp::Time & current_time) const
+  const SimulatedObject & object, const rclcpp::Time & current_time) const
 {
   // Create basic ObjectInfo with dimensions and covariances
   auto obj_info = utils::MovementUtils::create_basic_object_info(object);
@@ -811,7 +812,7 @@ ObjectInfo PredictedObjectMovementPlugin::create_object_info_with_straight_line(
 }
 
 ObjectInfo PredictedObjectMovementPlugin::create_object_info_with_predicted_path(
-  const DummyObject & object, const PredictedObject & predicted_object,
+  const SimulatedObject & object, const PredictedObject & predicted_object,
   const rclcpp::Time & predicted_time, const rclcpp::Time & current_time) const
 {
   // Create basic ObjectInfo with dimensions and covariances

--- a/simulator/autoware_dummy_perception_publisher/src/predicted_object_movement_plugin.cpp
+++ b/simulator/autoware_dummy_perception_publisher/src/predicted_object_movement_plugin.cpp
@@ -76,8 +76,8 @@ void PredictedObjectMovementPlugin::predicted_objects_callback(
   // Add to buffer, removing oldest if necessary
   auto & predicted_objects_buffer =
     predicted_simulated_objects_tracking_info_.predicted_objects_buffer;
-  if (predicted_objects_buffer.size() >=
-    predicted_simulated_objects_tracking_info_.max_buffer_size) {
+  if (
+    predicted_objects_buffer.size() >= predicted_simulated_objects_tracking_info_.max_buffer_size) {
     predicted_objects_buffer.pop_front();
   }
   predicted_objects_buffer.push_back(*msg);
@@ -103,10 +103,10 @@ PredictedObjectMovementPlugin::collect_simulated_object_positions(
 
     simulated_positions[simulated_uuid_str] =
       (info_it != simulated_predicted_info_map.end() &&
-      info_it->second.last_known_position.has_value())
+       info_it->second.last_known_position.has_value())
         ? info_it->second.last_known_position.value()
-        : utils::MovementUtils::calculate_straight_line_position(
-          simulated_obj, current_time).position;
+        : utils::MovementUtils::calculate_straight_line_position(simulated_obj, current_time)
+            .position;
 
     if (info_it == simulated_predicted_info_map.end() || info_it->second.predicted_uuid.empty()) {
       unmapped_simulated_uuids.push_back(simulated_uuid_str);
@@ -168,10 +168,7 @@ void PredictedObjectMovementPlugin::update_simulated_to_predicted_mapping(
   }
 
   // Clean up mappings for simulated objects that no longer exist
-  for (
-    auto it = simulated_predicted_info_map.begin();
-    it != simulated_predicted_info_map.end();
-  ) {
+  for (auto it = simulated_predicted_info_map.begin(); it != simulated_predicted_info_map.end();) {
     if (current_simulated_uuids.find(it->first) != current_simulated_uuids.end()) {
       ++it;
       continue;
@@ -261,11 +258,10 @@ void PredictedObjectMovementPlugin::create_remapping_for_disappeared_objects(
     }
     auto info_it = simulated_predicted_info_map.find(simulated_uuid);
 
-    remapping_position =
-      (info_it != simulated_predicted_info_map.end() &&
-      info_it->second.last_known_position.has_value())
-        ? info_it->second.last_known_position.value()
-        : current_pos_it->second;
+    remapping_position = (info_it != simulated_predicted_info_map.end() &&
+                          info_it->second.last_known_position.has_value())
+                           ? info_it->second.last_known_position.value()
+                           : current_pos_it->second;
     // Find closest available predicted object for remapping
     auto best_match = find_best_predicted_object_match(
       simulated_uuid, remapping_position, available_predicted_uuids, predicted_positions,
@@ -388,8 +384,7 @@ bool PredictedObjectMovementPlugin::is_valid_remapping_candidate(
   }
 
   // Get simulated object speed for comparison (reuse simulated_it from above)
-  const double simulated_speed =
-    simulated_object.initial_state.twist_covariance.twist.linear.x;
+  const double simulated_speed = simulated_object.initial_state.twist_covariance.twist.linear.x;
 
   // Get candidate predicted object speed
   const auto & candidate_twist =
@@ -407,8 +402,7 @@ bool PredictedObjectMovementPlugin::is_valid_remapping_candidate(
     is_pedestrian ? pedestrian_params.speed_check_threshold : vehicle_params.speed_check_threshold;
 
   auto is_within_speed_bounds = [&](double speed) {
-    return speed >= min_speed_ratio * simulated_speed &&
-      speed <= max_speed_ratio * simulated_speed;
+    return speed >= min_speed_ratio * simulated_speed && speed <= max_speed_ratio * simulated_speed;
   };
 
   // Reject if candidate speed is too different when simulated speed is significant
@@ -433,8 +427,7 @@ bool PredictedObjectMovementPlugin::is_valid_remapping_candidate(
         "%fm/s, "
         "candidate: %fm/s, max_ratio: %f)",
         simulated_uuid_str.c_str(), is_pedestrian ? "pedestrian" : "vehicle", speed_ratio,
-        simulated_speed,
-        candidate_speed, max_speed_difference_ratio);
+        simulated_speed, candidate_speed, max_speed_difference_ratio);
       return false;
     }
   }
@@ -625,8 +618,7 @@ PredictedObjectMovementPlugin::find_matching_predicted_object(
     predicted_simulated_objects_tracking_info_.simulated_predicted_info_map;
   auto mapping_it = simulated_predicted_info_map.find(obj_uuid_str);
   if (
-    mapping_it == simulated_predicted_info_map.end() ||
-    mapping_it->second.predicted_uuid.empty()) {
+    mapping_it == simulated_predicted_info_map.end() || mapping_it->second.predicted_uuid.empty()) {
     return std::make_pair(empty_object, empty_time);
   }
 
@@ -788,8 +780,7 @@ std::vector<ObjectInfo> PredictedObjectMovementPlugin::move_objects()
         info_it->second.last_used_prediction_time.has_value()) {
         RCLCPP_DEBUG(
           rclcpp::get_logger("dummy_perception_publisher"),
-          "Using last known prediction for lost object with ID: %s",
-          simulated_uuid_str.c_str());
+          "Using last known prediction for lost object with ID: %s", simulated_uuid_str.c_str());
         return create_object_info_with_predicted_path(
           object, info_it->second.last_used_prediction.value(),
           info_it->second.last_used_prediction_time.value(), current_time);
@@ -797,8 +788,7 @@ std::vector<ObjectInfo> PredictedObjectMovementPlugin::move_objects()
 
       RCLCPP_DEBUG(
         rclcpp::get_logger("dummy_perception_publisher"),
-        "No matching predicted object found for object with ID: %s",
-        simulated_uuid_str.c_str());
+        "No matching predicted object found for object with ID: %s", simulated_uuid_str.c_str());
       // Use straight-line motion for all other cases
       return create_object_info_with_straight_line(object, current_time);
     }();

--- a/simulator/autoware_dummy_perception_publisher/src/straight_line_object_movement_plugin.cpp
+++ b/simulator/autoware_dummy_perception_publisher/src/straight_line_object_movement_plugin.cpp
@@ -25,7 +25,7 @@ namespace autoware::dummy_perception_publisher::pluginlib
 
 void StraightLineObjectMovementPlugin::initialize()
 {
-  set_associated_action_type(tier4_simulation_msgs::msg::DummyObject::ADD);
+  set_associated_movement_model(autoware_simulation_msgs::msg::SimulatedObject::STRAIGHT_LINE);
 }
 
 std::vector<ObjectInfo> StraightLineObjectMovementPlugin::move_objects()

--- a/simulator/tier4_dummy_object_rviz_plugin/README.md
+++ b/simulator/tier4_dummy_object_rviz_plugin/README.md
@@ -15,8 +15,8 @@ The DeleteAllObjectsTool deletes the dummy cars, pedestrians, and obstacles disp
 
 ### Output
 
-| Name                                                 | Type                                      | Description                                     |
-| ---------------------------------------------------- | ----------------------------------------- | ----------------------------------------------- |
+| Name                                                 | Type                                             | Description                                     |
+| ---------------------------------------------------- | ------------------------------------------------ | ----------------------------------------------- |
 | `/simulation/dummy_perception_publisher/object_info` | `autoware_simulation_msgs::msg::SimulatedObject` | The topic on which to publish dummy object info |
 
 ## Parameter

--- a/simulator/tier4_dummy_object_rviz_plugin/README.md
+++ b/simulator/tier4_dummy_object_rviz_plugin/README.md
@@ -17,7 +17,7 @@ The DeleteAllObjectsTool deletes the dummy cars, pedestrians, and obstacles disp
 
 | Name                                                 | Type                                      | Description                                     |
 | ---------------------------------------------------- | ----------------------------------------- | ----------------------------------------------- |
-| `/simulation/dummy_perception_publisher/object_info` | `tier4_simulation_msgs::msg::DummyObject` | The topic on which to publish dummy object info |
+| `/simulation/dummy_perception_publisher/object_info` | `autoware_simulation_msgs::msg::SimulatedObject` | The topic on which to publish dummy object info |
 
 ## Parameter
 

--- a/simulator/tier4_dummy_object_rviz_plugin/package.xml
+++ b/simulator/tier4_dummy_object_rviz_plugin/package.xml
@@ -10,6 +10,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
+  <depend>autoware_simulation_msgs</depend>
   <depend>libboost-dev</depend>
   <depend>libqt5-core</depend>
   <depend>libqt5-gui</depend>
@@ -19,7 +20,6 @@
   <depend>rviz_default_plugins</depend>
   <depend>tf2_geometry_msgs</depend>
   <depend>tf2_ros</depend>
-  <depend>autoware_simulation_msgs</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>

--- a/simulator/tier4_dummy_object_rviz_plugin/package.xml
+++ b/simulator/tier4_dummy_object_rviz_plugin/package.xml
@@ -19,7 +19,7 @@
   <depend>rviz_default_plugins</depend>
   <depend>tf2_geometry_msgs</depend>
   <depend>tf2_ros</depend>
-  <depend>tier4_simulation_msgs</depend>
+  <depend>autoware_simulation_msgs</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>

--- a/simulator/tier4_dummy_object_rviz_plugin/src/tools/car_pose.cpp
+++ b/simulator/tier4_dummy_object_rviz_plugin/src/tools/car_pose.cpp
@@ -115,9 +115,9 @@ void CarInitialPoseTool::onInitialize()
   updateTopic();
 }
 
-DummyObject CarInitialPoseTool::createObjectMsg() const
+SimulatedObject CarInitialPoseTool::createObjectMsg() const
 {
-  DummyObject object{};
+  SimulatedObject object{};
   std::string fixed_frame = context_->getFixedFrame().toStdString();
 
   // header
@@ -211,9 +211,9 @@ void BusInitialPoseTool::onInitialize()
   updateTopic();
 }
 
-DummyObject BusInitialPoseTool::createObjectMsg() const
+SimulatedObject BusInitialPoseTool::createObjectMsg() const
 {
-  DummyObject object{};
+  SimulatedObject object{};
   std::string fixed_frame = context_->getFixedFrame().toStdString();
 
   // header
@@ -311,9 +311,9 @@ void BikeInitialPoseTool::onInitialize()
   updateTopic();
 }
 
-DummyObject BikeInitialPoseTool::createObjectMsg() const
+SimulatedObject BikeInitialPoseTool::createObjectMsg() const
 {
-  DummyObject object{};
+  SimulatedObject object{};
   std::string fixed_frame = context_->getFixedFrame().toStdString();
 
   // header

--- a/simulator/tier4_dummy_object_rviz_plugin/src/tools/car_pose.hpp
+++ b/simulator/tier4_dummy_object_rviz_plugin/src/tools/car_pose.hpp
@@ -55,14 +55,14 @@ namespace rviz_plugins
 
 using autoware_perception_msgs::msg::ObjectClassification;
 using autoware_perception_msgs::msg::Shape;
-using tier4_simulation_msgs::msg::DummyObject;
+using autoware_simulation_msgs::msg::SimulatedObject;
 
 class CarInitialPoseTool : public InteractiveObjectTool
 {
 public:
   CarInitialPoseTool();
   void onInitialize() override;
-  [[nodiscard]] DummyObject createObjectMsg() const override;
+  [[nodiscard]] SimulatedObject createObjectMsg() const override;
 };
 
 class BusInitialPoseTool : public InteractiveObjectTool
@@ -70,7 +70,7 @@ class BusInitialPoseTool : public InteractiveObjectTool
 public:
   BusInitialPoseTool();
   void onInitialize() override;
-  [[nodiscard]] DummyObject createObjectMsg() const override;
+  [[nodiscard]] SimulatedObject createObjectMsg() const override;
 };
 
 class BikeInitialPoseTool : public InteractiveObjectTool
@@ -78,7 +78,7 @@ class BikeInitialPoseTool : public InteractiveObjectTool
 public:
   BikeInitialPoseTool();
   void onInitialize() override;
-  [[nodiscard]] DummyObject createObjectMsg() const override;
+  [[nodiscard]] SimulatedObject createObjectMsg() const override;
 
 private:
   rviz_common::properties::EnumProperty * label_;

--- a/simulator/tier4_dummy_object_rviz_plugin/src/tools/delete_all_objects.cpp
+++ b/simulator/tier4_dummy_object_rviz_plugin/src/tools/delete_all_objects.cpp
@@ -75,7 +75,7 @@ void DeleteAllObjectsTool::updateTopic()
   rclcpp::Node::SharedPtr raw_node = context_->getRosNodeAbstraction().lock()->get_raw_node();
   dummy_object_info_pub_ =
     raw_node->create_publisher<autoware_simulation_msgs::msg::SimulatedObject>(
-    topic_property_->getStdString(), 1);
+      topic_property_->getStdString(), 1);
   clock_ = raw_node->get_clock();
 }
 

--- a/simulator/tier4_dummy_object_rviz_plugin/src/tools/delete_all_objects.cpp
+++ b/simulator/tier4_dummy_object_rviz_plugin/src/tools/delete_all_objects.cpp
@@ -73,7 +73,8 @@ void DeleteAllObjectsTool::onInitialize()
 void DeleteAllObjectsTool::updateTopic()
 {
   rclcpp::Node::SharedPtr raw_node = context_->getRosNodeAbstraction().lock()->get_raw_node();
-  dummy_object_info_pub_ = raw_node->create_publisher<tier4_simulation_msgs::msg::DummyObject>(
+  dummy_object_info_pub_ =
+    raw_node->create_publisher<autoware_simulation_msgs::msg::SimulatedObject>(
     topic_property_->getStdString(), 1);
   clock_ = raw_node->get_clock();
 }
@@ -82,7 +83,7 @@ void DeleteAllObjectsTool::updateTopic()
 void DeleteAllObjectsTool::onPoseSet(
   [[maybe_unused]] double x, [[maybe_unused]] double y, [[maybe_unused]] double theta)
 {
-  tier4_simulation_msgs::msg::DummyObject output_msg;
+  autoware_simulation_msgs::msg::SimulatedObject output_msg;
   std::string fixed_frame = context_->getFixedFrame().toStdString();
 
   // header
@@ -90,7 +91,7 @@ void DeleteAllObjectsTool::onPoseSet(
   output_msg.header.stamp = clock_->now();
 
   // action
-  output_msg.action = tier4_simulation_msgs::msg::DummyObject::DELETEALL;
+  output_msg.action = autoware_simulation_msgs::msg::SimulatedObject::DELETE_ALL;
 
   dummy_object_info_pub_->publish(output_msg);
 }

--- a/simulator/tier4_dummy_object_rviz_plugin/src/tools/delete_all_objects.hpp
+++ b/simulator/tier4_dummy_object_rviz_plugin/src/tools/delete_all_objects.hpp
@@ -57,7 +57,7 @@
 #include <rviz_default_plugins/tools/pose/pose_tool.hpp>
 #endif
 
-#include <tier4_simulation_msgs/msg/dummy_object.hpp>
+#include <autoware_simulation_msgs/msg/simulated_object.hpp>
 
 namespace rviz_plugins
 {
@@ -77,7 +77,8 @@ private Q_SLOTS:
 
 private:  // NOLINT for Qt
   rclcpp::Clock::SharedPtr clock_;
-  rclcpp::Publisher<tier4_simulation_msgs::msg::DummyObject>::SharedPtr dummy_object_info_pub_;
+  rclcpp::Publisher<autoware_simulation_msgs::msg::SimulatedObject>::SharedPtr
+    dummy_object_info_pub_;
 
   rviz_common::properties::StringProperty * topic_property_;
 };

--- a/simulator/tier4_dummy_object_rviz_plugin/src/tools/interactive_object.cpp
+++ b/simulator/tier4_dummy_object_rviz_plugin/src/tools/interactive_object.cpp
@@ -267,7 +267,7 @@ void InteractiveObjectTool::updateTopic()
 {
   rclcpp::Node::SharedPtr raw_node = context_->getRosNodeAbstraction().lock()->get_raw_node();
   dummy_object_info_pub_ =
-    raw_node->create_publisher<DummyObject>(topic_property_->getStdString(), 1);
+    raw_node->create_publisher<SimulatedObject>(topic_property_->getStdString(), 1);
   clock_ = raw_node->get_clock();
   move_tool_.initialize(context_);
   property_frame_->setFrameManager(context_->getFrameManager());
@@ -295,7 +295,10 @@ void InteractiveObjectTool::onPoseSet(double x, double y, double theta)
   output_msg.initial_state.accel_covariance.accel.linear.z = 0.0;
   output_msg.max_velocity = max_velocity_->getFloat();
   output_msg.min_velocity = min_velocity_->getFloat();
-  output_msg.action = predicted_property_->getBool() ? DummyObject::PREDICT : DummyObject::ADD;
+  output_msg.action = SimulatedObject::ADD;
+  output_msg.movement_model =
+    predicted_property_->getBool() ? SimulatedObject::PREDICTED_PATH :
+    SimulatedObject::STRAIGHT_LINE;
 
   dummy_object_info_pub_->publish(output_msg);
 }
@@ -307,7 +310,7 @@ void InteractiveObjectTool::publishObjectMsg(
   output_msg.action = action;
   output_msg.id.uuid = uuid;
 
-  if (action == DummyObject::DELETE) {
+  if (action == SimulatedObject::DELETE) {
     dummy_object_info_pub_->publish(output_msg);
     return;
   }
@@ -321,6 +324,9 @@ void InteractiveObjectTool::publishObjectMsg(
 
   tf2::toMsg(object_tf.get(), output_msg.initial_state.pose_covariance.pose);
   output_msg.initial_state.twist_covariance.twist = object_twist.get();
+  output_msg.movement_model =
+    predicted_property_->getBool() ? SimulatedObject::PREDICTED_PATH :
+    SimulatedObject::STRAIGHT_LINE;
 
   dummy_object_info_pub_->publish(output_msg);
 }
@@ -336,10 +342,10 @@ int InteractiveObjectTool::processMouseEvent(rviz_common::ViewportMouseEvent & e
     if (point) {
       if (event.shift()) {
         const auto uuid = objects_.create(point.value());
-        publishObjectMsg(uuid.get(), DummyObject::ADD);
+        publishObjectMsg(uuid.get(), SimulatedObject::ADD);
       } else if (event.alt()) {
         const auto uuid = objects_.remove(point.value());
-        publishObjectMsg(uuid.get(), DummyObject::DELETE);
+        publishObjectMsg(uuid.get(), SimulatedObject::DELETE);
       } else {
         objects_.select(point.value());
       }
@@ -349,7 +355,7 @@ int InteractiveObjectTool::processMouseEvent(rviz_common::ViewportMouseEvent & e
 
   if (event.rightUp()) {
     const auto uuid = objects_.reset();
-    publishObjectMsg(uuid.get(), DummyObject::MODIFY);
+    publishObjectMsg(uuid.get(), SimulatedObject::MODIFY);
     return 0;
   }
 
@@ -357,7 +363,7 @@ int InteractiveObjectTool::processMouseEvent(rviz_common::ViewportMouseEvent & e
     const auto point = get_point_from_mouse(event);
     if (point) {
       const auto uuid = objects_.update(point.value());
-      publishObjectMsg(uuid.get(), DummyObject::MODIFY);
+      publishObjectMsg(uuid.get(), SimulatedObject::MODIFY);
     }
     return 0;
   }
@@ -372,7 +378,8 @@ int InteractiveObjectTool::processKeyEvent(QKeyEvent * event, rviz_common::Rende
     if (objects_.getTargetObject()) {
       const auto uuid = objects_.getTargetUuid();
       if (uuid.has_value()) {
-        publishObjectMsg(uuid.value(), DummyObject::PREDICT);
+        predicted_property_->setBool(true);
+        publishObjectMsg(uuid.value(), SimulatedObject::MODIFY);
       }
     }
     return 0;

--- a/simulator/tier4_dummy_object_rviz_plugin/src/tools/interactive_object.cpp
+++ b/simulator/tier4_dummy_object_rviz_plugin/src/tools/interactive_object.cpp
@@ -296,9 +296,8 @@ void InteractiveObjectTool::onPoseSet(double x, double y, double theta)
   output_msg.max_velocity = max_velocity_->getFloat();
   output_msg.min_velocity = min_velocity_->getFloat();
   output_msg.action = SimulatedObject::ADD;
-  output_msg.movement_model =
-    predicted_property_->getBool() ? SimulatedObject::PREDICTED_PATH :
-    SimulatedObject::STRAIGHT_LINE;
+  output_msg.movement_model = predicted_property_->getBool() ? SimulatedObject::PREDICTED_PATH
+                                                             : SimulatedObject::STRAIGHT_LINE;
 
   dummy_object_info_pub_->publish(output_msg);
 }
@@ -324,9 +323,8 @@ void InteractiveObjectTool::publishObjectMsg(
 
   tf2::toMsg(object_tf.get(), output_msg.initial_state.pose_covariance.pose);
   output_msg.initial_state.twist_covariance.twist = object_twist.get();
-  output_msg.movement_model =
-    predicted_property_->getBool() ? SimulatedObject::PREDICTED_PATH :
-    SimulatedObject::STRAIGHT_LINE;
+  output_msg.movement_model = predicted_property_->getBool() ? SimulatedObject::PREDICTED_PATH
+                                                             : SimulatedObject::STRAIGHT_LINE;
 
   dummy_object_info_pub_->publish(output_msg);
 }

--- a/simulator/tier4_dummy_object_rviz_plugin/src/tools/interactive_object.hpp
+++ b/simulator/tier4_dummy_object_rviz_plugin/src/tools/interactive_object.hpp
@@ -61,9 +61,9 @@
 #include <rviz_default_plugins/tools/pose/pose_tool.hpp>
 #endif
 
+#include <autoware_simulation_msgs/msg/simulated_object.hpp>
 #include <geometry_msgs/msg/twist.hpp>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
-#include <autoware_simulation_msgs/msg/simulated_object.hpp>
 
 #include <boost/optional.hpp>
 

--- a/simulator/tier4_dummy_object_rviz_plugin/src/tools/interactive_object.hpp
+++ b/simulator/tier4_dummy_object_rviz_plugin/src/tools/interactive_object.hpp
@@ -63,7 +63,7 @@
 
 #include <geometry_msgs/msg/twist.hpp>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
-#include <tier4_simulation_msgs/msg/dummy_object.hpp>
+#include <autoware_simulation_msgs/msg/simulated_object.hpp>
 
 #include <boost/optional.hpp>
 
@@ -78,7 +78,7 @@ namespace rviz_plugins
 
 using autoware_perception_msgs::msg::ObjectClassification;
 using autoware_perception_msgs::msg::Shape;
-using tier4_simulation_msgs::msg::DummyObject;
+using autoware_simulation_msgs::msg::SimulatedObject;
 
 class InteractiveObject
 {
@@ -134,14 +134,14 @@ public:
   int processMouseEvent(rviz_common::ViewportMouseEvent & event) override;
   int processKeyEvent(QKeyEvent * event, rviz_common::RenderPanel * panel) override;
 
-  [[nodiscard]] virtual DummyObject createObjectMsg() const = 0;
+  [[nodiscard]] virtual SimulatedObject createObjectMsg() const = 0;
 
 protected Q_SLOTS:
   virtual void updateTopic();
 
 protected:  // NOLINT for Qt
   rclcpp::Clock::SharedPtr clock_;
-  rclcpp::Publisher<DummyObject>::SharedPtr dummy_object_info_pub_;
+  rclcpp::Publisher<SimulatedObject>::SharedPtr dummy_object_info_pub_;
 
   rviz_default_plugins::tools::MoveTool move_tool_;
 

--- a/simulator/tier4_dummy_object_rviz_plugin/src/tools/pedestrian_pose.cpp
+++ b/simulator/tier4_dummy_object_rviz_plugin/src/tools/pedestrian_pose.cpp
@@ -106,9 +106,9 @@ void PedestrianInitialPoseTool::onInitialize()
   updateTopic();
 }
 
-DummyObject PedestrianInitialPoseTool::createObjectMsg() const
+SimulatedObject PedestrianInitialPoseTool::createObjectMsg() const
 {
-  DummyObject object{};
+  SimulatedObject object{};
   std::string fixed_frame = context_->getFixedFrame().toStdString();
 
   // header

--- a/simulator/tier4_dummy_object_rviz_plugin/src/tools/pedestrian_pose.hpp
+++ b/simulator/tier4_dummy_object_rviz_plugin/src/tools/pedestrian_pose.hpp
@@ -55,14 +55,14 @@ namespace rviz_plugins
 
 using autoware_perception_msgs::msg::ObjectClassification;
 using autoware_perception_msgs::msg::Shape;
-using tier4_simulation_msgs::msg::DummyObject;
+using autoware_simulation_msgs::msg::SimulatedObject;
 
 class PedestrianInitialPoseTool : public InteractiveObjectTool
 {
 public:
   PedestrianInitialPoseTool();
   void onInitialize() override;
-  [[nodiscard]] DummyObject createObjectMsg() const override;
+  [[nodiscard]] SimulatedObject createObjectMsg() const override;
 };
 
 }  // namespace rviz_plugins

--- a/simulator/tier4_dummy_object_rviz_plugin/src/tools/unknown_pose.cpp
+++ b/simulator/tier4_dummy_object_rviz_plugin/src/tools/unknown_pose.cpp
@@ -101,9 +101,9 @@ void UnknownInitialPoseTool::onInitialize()
   updateTopic();
 }
 
-DummyObject UnknownInitialPoseTool::createObjectMsg() const
+SimulatedObject UnknownInitialPoseTool::createObjectMsg() const
 {
-  DummyObject object{};
+  SimulatedObject object{};
   std::string fixed_frame = context_->getFixedFrame().toStdString();
 
   // header

--- a/simulator/tier4_dummy_object_rviz_plugin/src/tools/unknown_pose.hpp
+++ b/simulator/tier4_dummy_object_rviz_plugin/src/tools/unknown_pose.hpp
@@ -50,14 +50,14 @@ namespace rviz_plugins
 
 using autoware_perception_msgs::msg::ObjectClassification;
 using autoware_perception_msgs::msg::Shape;
-using tier4_simulation_msgs::msg::DummyObject;
+using autoware_simulation_msgs::msg::SimulatedObject;
 
 class UnknownInitialPoseTool : public InteractiveObjectTool
 {
 public:
   UnknownInitialPoseTool();
   void onInitialize() override;
-  [[nodiscard]] DummyObject createObjectMsg() const override;
+  [[nodiscard]] SimulatedObject createObjectMsg() const override;
 };
 
 }  // namespace rviz_plugins


### PR DESCRIPTION
## Description
Replace `tier4_simulation_msgs` usage in `autoware_dummy_perception_publisher` and `tier4_dummy_object_rviz_plugin` with `autoware_simulation_msgs`. Update includes, type references, and routing logic to use `SimulatedObject` and the `movement_model` field.

## Related links
- https://github.com/orgs/autowarefoundation/discussions/6892
- https://github.com/autowarefoundation/autoware_universe/issues/12469

## How was this PR tested?

~~:warning: Though build succeeded, I found some suspicious behavior during running planning simulation. Thus, let me carefully do tests. Once the tests are done, let me make this PR "Ready for Review" :warning:~~
**=> Bug fix and tests should be done**

### Using Planning Simulator

I tested the functionality by using a planning simulator following [this tutorial](https://tier4.github.io/autoware-documentation/latest/tutorials/ad-hoc-simulation/planning-simulation/).

To test if the dummy objects are created, I performed:
- Launch planning simulator by,
```bash
$ source ~/autoware/install/setup.bash
$ ros2 launch autoware_launch planning_simulator.launch.xml map_path:=$HOME/autoware_map/sample-map-planning vehicle_model:=sample_vehicle sensor_model:=sample_sensor_kit
```
- Then initialize the ego pose and set the ego goal pose
- Put dummy car. The dummy car is created and running with following the direction that of initialized one.
- Put dummy Bus. The created dummy bus did not start running which is different from that of car's case.
- Put dummy pedestrian. The created dummy pedestrian did not start running which is different from that of car's case

I believe these observation is consistent that of without this PR.

### Using TIER IV Internal Scenario Simulator
- Tests passed
  - https://github.com/tier4/auto-evaluator/actions/runs/25152159154

## Notes for reviewers
- The plugin routing now uses `movement_model` (`STRAIGHT_LINE` / `PREDICTED_PATH`) since action is lifecycle-only (`ADD`/`MODIFY`/`DELETE`/`DELETE_ALL`).

## Interface changes
No topic or parameter changes. Message types used by the package are switched to `autoware_simulation_msgs/SimulatedObject`.

## Effects on system behavior
No runtime behavior change expected beyond message package migration.
