### PR TITLE
fix(autoware_tensorrt_plugins): correct CustomUnique count offset

### DIFF
--- a/perception/autoware_tensorrt_plugins/src/unique_ops/unique.cu
+++ b/perception/autoware_tensorrt_plugins/src/unique_ops/unique.cu
@@ -157,8 +157,8 @@ std::int64_t unique(
     sorted_input;
 
   cudaMemcpyAsync(
-    range_ptr + num_out * sizeof(int64_t), &num_input_elements, sizeof(std::int64_t),
-    cudaMemcpyHostToDevice, stream);
+    range_ptr + num_out, &num_input_elements, sizeof(std::int64_t), cudaMemcpyHostToDevice,
+    stream);
 
   thrust::adjacent_difference(policy, range_ptr + 1, range_ptr + num_out + 1, unique_counts);
 

--- a/perception/autoware_tensorrt_plugins/src/unique_ops/unique.cu
+++ b/perception/autoware_tensorrt_plugins/src/unique_ops/unique.cu
@@ -157,8 +157,7 @@ std::int64_t unique(
     sorted_input;
 
   cudaMemcpyAsync(
-    range_ptr + num_out, &num_input_elements, sizeof(std::int64_t), cudaMemcpyHostToDevice,
-    stream);
+    range_ptr + num_out, &num_input_elements, sizeof(std::int64_t), cudaMemcpyHostToDevice, stream);
 
   thrust::adjacent_difference(policy, range_ptr + 1, range_ptr + num_out + 1, unique_counts);
 


### PR DESCRIPTION
## Description

Fix the `range_ptr` computation in `CustomUnique` so the sentinel count is written at the correct
element offset instead of applying an extra `sizeof(int64_t)` multiplier to typed pointer
arithmetic.

## Related links

**Parent Issue:**

- None.

## How was this PR tested?

- Rebuilt a benchmarkable variant of the branch with:
  `colcon build --packages-select autoware_ptv3 autoware_tensorrt_plugins`

## Interface changes

None.

## Effects on system behavior

Fixes incorrect `unique_counts` output from the `CustomUnique` plugin when the final sentinel is
written to the wrong location.
