### PR TITLE
docs(diffusion_planner): point artifact links at artifacts README

### DIFF
--- a/planning/autoware_diffusion_planner/README.md
+++ b/planning/autoware_diffusion_planner/README.md
@@ -27,7 +27,7 @@ $ ls ~/autoware_data/diffusion_planner/v3.1/
 diffusion_planner.onnx diffusion_planner.param.json
 ```
 
-This can be downloaded from [setup-dev-env.sh](https://github.com/autowarefoundation/autoware/blob/main/setup-dev-env.sh).
+This can be downloaded by following [Download artifacts](https://github.com/autowarefoundation/autoware/blob/main/ansible/roles/artifacts/README.md#download-artifacts).
 
 ### (2) Modify launch files
 
@@ -227,8 +227,7 @@ The model version is defined either by the directory name provided to the node o
   Incremented when **only the weight files are updated**.
   As long as the major version matches, the node remains compatible, and the new model can be used directly.
 
-To download the latest model, simply run the provided setup script:
-[How to set up a development environment](https://autowarefoundation.github.io/autoware-documentation/main/installation/autoware/source-installation/#how-to-set-up-a-development-environment)
+To download the latest model, follow [Download artifacts](https://github.com/autowarefoundation/autoware/blob/main/ansible/roles/artifacts/README.md#download-artifacts).
 
 ### Model Version History
 


### PR DESCRIPTION
- **Parent Issue:** autowarefoundation/autoware#7052
- Replaces two stale artifact-download links in [planning/autoware_diffusion_planner/README.md](https://github.com/autowarefoundation/autoware_universe/blob/b891653d6ed89154dc31448dd76b37042cc9ca4a/planning/autoware_diffusion_planner/README.md) (lines 30 and 230) that pointed at `setup-dev-env.sh` and the `autoware-documentation` source-installation page.
- Both now point at the canonical [artifacts role README#download-artifacts](https://github.com/autowarefoundation/autoware/blob/main/ansible/roles/artifacts/README.md#download-artifacts), which documents the `ansible-playbook autoware.dev_env.install_dev_env --tags artifacts` invocation.

## Why

`setup-dev-env.sh` is scheduled for removal on **2026-05-24** as part of the ansible entrypoint consolidation tracked in autowarefoundation/autoware#7052, and the autoware-documentation source-installation page is being updated alongside it. Once those land, both existing links 404; this redirects readers at the role-level README that survives the migration and shows the actual `--tags artifacts` command.

## Test plan

- [ ] Click both updated links in the rendered README and confirm they land at the `Download artifacts` section.