### PR TITLE
fix(behavior_path_static_obstacle_avoidance_module): pass full vehicle width to drivable area polygon generation

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/scene.cpp
@@ -1294,7 +1294,7 @@ BehaviorModuleOutput StaticObstacleAvoidanceModule::plan()
       parameters_->path_generation_method == "both") {
       current_drivable_area_info.obstacles =
         utils::static_obstacle_avoidance::generateObstaclePolygonsForDrivableArea(
-          clip_objects_, parameters_, planner_data_->parameters.vehicle_width / 2.0);
+          clip_objects_, parameters_, planner_data_->parameters.vehicle_width);
     }
 
     output.drivable_area_info = utils::combineDrivableAreaInfo(

--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/utils.cpp
@@ -2222,7 +2222,7 @@ void updateRoadShoulderDistance(
     o.avoid_margin = lateral_hard_margin + 0.5 * vehicle_width;
   }
   const auto extract_obstacles = generateObstaclePolygonsForDrivableArea(
-    clip_objects, parameters, planner_data->parameters.vehicle_width / 2.0);
+    clip_objects, parameters, planner_data->parameters.vehicle_width);
 
   auto tmp_path = data.reference_path;
   tmp_path.left_bound = data.left_bound;


### PR DESCRIPTION
## Description

Both call sites passed vehicle_width / 2.0 to generateObstaclePolygonsForDrivableArea, which then divided by 2.0 again internally — effectively subtracting only vehicle_width / 4.0. This inflated the obstacle polygon buffer by an extra vehicle_width / 4.0, making obstacle polygons too large and unnecessarily restricting the drivable area.

**Fix**: Pass the full vehicle_width so the internal /2.0 produces the correct half-width subtraction, and the vehicle_width contribution cancels out of the buffer formula as intended.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [TIERIV INTERNAL](https://github.com/tier4/autoware.universe.isuzu.erga2/pull/579)
⬆️🟢 -->

## How was this PR tested?

- PSim

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
