### PR TITLE
fix(autoware_ptv3): bad cmake variable syntax

### DIFF
--- a/perception/autoware_ptv3/CMakeLists.txt
+++ b/perception/autoware_ptv3/CMakeLists.txt
@@ -111,7 +111,7 @@ if(TRT_AVAIL AND CUDA_AVAIL)
   target_include_directories(${PROJECT_NAME}_lib
     SYSTEM PUBLIC
     ${CUDA_INCLUDE_DIRS}
-    $(autoware_point_types_INCLUDE_DIRS)
+    ${autoware_point_types_INCLUDE_DIRS}
   )
 
   ament_auto_add_library(${PROJECT_NAME}_component SHARED


### PR DESCRIPTION
## Description

`$()` is not a proper cmake variable substitution and breaks when using ninja generator.

## Related links

**Parent Issue:**

- [Link](https://github.com/autowarefoundation/autoware_universe/issues/12512)

## How was this PR tested?

```bash
$ rm build/autoware_ptv3 -r
$ colcon build --symlink-install --event-handlers=console_cohesion+ --packages-select autoware_ptv3 --cmake-args -GNinja
Starting >>> autoware_ptv3
[Processing: autoware_ptv3]                             
[Processing: autoware_ptv3]                                     
[Processing: autoware_ptv3]                                       
--- output: autoware_ptv3                                         
-- The C compiler identification is GNU 11.4.0
-- The CXX compiler identification is GNU 11.4.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Found autoware_cmake: 1.1.0 (/workspace/install/autoware_cmake/share/autoware_cmake/cmake)
-- Found Python3: /usr/bin/python3 (found version "3.10.12") found components: Interpreter 
-- Override CMake install command with custom implementation using symlinks instead of copying resources
-- Found TinyXML2: /usr/lib/x86_64-linux-gnu/libtinyxml2.so  
-- Found rosidl_generator_c: 3.1.8 (/opt/ros/humble/share/rosidl_generator_c/cmake)
-- Found rosidl_adapter: 3.1.8 (/opt/ros/humble/share/rosidl_adapter/cmake)
-- Found rosidl_generator_cpp: 3.1.8 (/opt/ros/humble/share/rosidl_generator_cpp/cmake)
-- Using all available rosidl_typesupport_c: rosidl_typesupport_fastrtps_c;rosidl_typesupport_introspection_c
-- Using all available rosidl_typesupport_cpp: rosidl_typesupport_fastrtps_cpp;rosidl_typesupport_introspection_cpp
-- Found rmw_implementation_cmake: 6.1.2 (/opt/ros/humble/share/rmw_implementation_cmake/cmake)
-- Found rmw_cyclonedds_cpp: 1.3.4 (/opt/ros/humble/share/rmw_cyclonedds_cpp/cmake)
-- Using RMW implementation 'rmw_cyclonedds_cpp' as default
-- Looking for pthread.h
-- Looking for pthread.h - found
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success
-- Found Threads: TRUE  
-- Found eigen3_cmake_module: 0.1.1 (/opt/ros/humble/share/eigen3_cmake_module/cmake)
-- Found Eigen3: TRUE (found version "3.4.0") 
-- Ensuring Eigen3 include directory is part of orocos-kdl CMake target
-- Checking for module 'eigen3'
--   Found eigen3, version 3.4.0
-- Found Eigen: /usr/include/eigen3 (Required is at least version "3.1") 
-- Eigen found (include: /usr/include/eigen3, version: 3.4.0)
-- Checking for module 'flann'
--   Found flann, version 1.9.1
-- Found FLANN: /usr/lib/x86_64-linux-gnu/libflann_cpp.so  
-- FLANN found (include: /usr/include, lib: /usr/lib/x86_64-linux-gnu/libflann_cpp.so)
-- Checking for module 'libusb-1.0'
--   Found libusb-1.0, version 1.0.25
-- Found libusb: /usr/lib/x86_64-linux-gnu/libusb-1.0.so  
-- OpenNI found (version: 1.5.4.0, include: /usr/include/ni, lib: /usr/lib/libOpenNI.so;libusb::libusb)
-- OpenNI2 found (version: 2.2.0.33, include: /usr/include/openni2, lib: /usr/lib/x86_64-linux-gnu/libOpenNI2.so;libusb::libusb)
-- Eigen found (include: /usr/include/eigen3, version: 3.4.0)
-- OpenNI found (version: 1.5.4.0, include: /usr/include/ni, lib: /usr/lib/libOpenNI.so;libusb::libusb)
-- OpenNI2 found (version: 2.2.0.33, include: /usr/include/openni2, lib: /usr/lib/x86_64-linux-gnu/libOpenNI2.so;libusb::libusb)
-- Found Qhull version 8.0.2
-- OpenNI found (version: 1.5.4.0, include: /usr/include/ni, lib: /usr/lib/libOpenNI.so;libusb::libusb)
-- Found PCL_COMMON: /usr/lib/x86_64-linux-gnu/libpcl_common.so  
-- Found PCL_KDTREE: /usr/lib/x86_64-linux-gnu/libpcl_kdtree.so  
-- Found PCL_OCTREE: /usr/lib/x86_64-linux-gnu/libpcl_octree.so  
-- Found PCL_SEARCH: /usr/lib/x86_64-linux-gnu/libpcl_search.so  
-- Found PCL_SAMPLE_CONSENSUS: /usr/lib/x86_64-linux-gnu/libpcl_sample_consensus.so  
-- Found PCL_FILTERS: /usr/lib/x86_64-linux-gnu/libpcl_filters.so  
-- Found PCL_2D: /usr/include/pcl-1.12  
-- Found PCL_GEOMETRY: /usr/include/pcl-1.12  
-- Found PCL_IO: /usr/lib/x86_64-linux-gnu/libpcl_io.so  
-- Found PCL_FEATURES: /usr/lib/x86_64-linux-gnu/libpcl_features.so  
-- Found PCL_ML: /usr/lib/x86_64-linux-gnu/libpcl_ml.so  
-- Found PCL_SEGMENTATION: /usr/lib/x86_64-linux-gnu/libpcl_segmentation.so  
-- Found PCL_VISUALIZATION: /usr/lib/x86_64-linux-gnu/libpcl_visualization.so  
-- Found PCL_SURFACE: /usr/lib/x86_64-linux-gnu/libpcl_surface.so  
-- Found PCL_REGISTRATION: /usr/lib/x86_64-linux-gnu/libpcl_registration.so  
-- Found PCL_KEYPOINTS: /usr/lib/x86_64-linux-gnu/libpcl_keypoints.so  
-- Found PCL_TRACKING: /usr/lib/x86_64-linux-gnu/libpcl_tracking.so  
-- Found PCL_RECOGNITION: /usr/lib/x86_64-linux-gnu/libpcl_recognition.so  
-- Found PCL_STEREO: /usr/lib/x86_64-linux-gnu/libpcl_stereo.so  
-- Found PCL_APPS: /usr/lib/x86_64-linux-gnu/libpcl_apps.so  
-- Found PCL_IN_HAND_SCANNER: /usr/include/pcl-1.12  
-- Found PCL_MODELER: /usr/include/pcl-1.12  
-- Found PCL_POINT_CLOUD_EDITOR: /usr/include/pcl-1.12  
-- Found PCL_OUTOFCORE: /usr/lib/x86_64-linux-gnu/libpcl_outofcore.so  
-- Found PCL_PEOPLE: /usr/lib/x86_64-linux-gnu/libpcl_people.so  
-- Found TensorRT headers at /usr/include/x86_64-linux-gnu
-- Found TensorRT libs at /usr/lib/x86_64-linux-gnu/libnvinfer.so;/usr/lib/x86_64-linux-gnu/libnvinfer_plugin.so;/usr/lib/x86_64-linux-gnu/libnvonnxparser.so
-- Found ament_lint_auto: 0.12.15 (/opt/ros/humble/share/ament_lint_auto/cmake)
-- Found CUDA: /usr/local/cuda (found version "12.8") 
In this package, headers install destination is set to `include` by ament_auto_package. It is recommended to install `include/autoware_ptv3` instead and will be the default behavior of ament_auto_package from ROS 2 Kilted Kaiju. On distributions before Kilted, ament_auto_package behaves the same way when you use USE_SCOPED_HEADER_INSTALL_DIR option.
-- Added test 'copyright' to check source files copyright and LICENSE
-- Added test 'cppcheck' to perform static code analysis on C / C++ code
-- Configured cppcheck include dirs: /workspace/src/universe/autoware_universe/perception/autoware_ptv3/include
-- Configured cppcheck exclude dirs and/or files: 
-- Added test 'lint_cmake' to check CMake code style
-- Added test 'xmllint' to check XML markup files
-- Configuring done
-- Generating done
-- Build files have been written to: /workspace/build/autoware_ptv3

[0/9] Building NVCC (Device) object CMakeFiles/autoware_ptv3_cuda_lib.dir/lib/preprocess/autoware_ptv3_cuda_lib_generated_preprocess_kernel.cu.o
[0/9] Building CXX object CMakeFiles/autoware_ptv3_node.dir/rclcpp_components/node_main_autoware_ptv3_node.cpp.o
[0/9] Building NVCC (Device) object CMakeFiles/autoware_ptv3_cuda_lib.dir/lib/postprocess/autoware_ptv3_cuda_lib_generated_postprocess_kernel.cu.o
[1/9] Building CXX object CMakeFiles/autoware_ptv3_node.dir/rclcpp_components/node_main_autoware_ptv3_node.cpp.o
[1/9] Linking CXX executable autoware_ptv3_node
[2/9] Linking CXX executable autoware_ptv3_node
[3/9] Building NVCC (Device) object CMakeFiles/autoware_ptv3_cuda_lib.dir/lib/postprocess/autoware_ptv3_cuda_lib_generated_postprocess_kernel.cu.o
[4/9] Building NVCC (Device) object CMakeFiles/autoware_ptv3_cuda_lib.dir/lib/preprocess/autoware_ptv3_cuda_lib_generated_preprocess_kernel.cu.o
[4/9] Linking CXX shared library libautoware_ptv3_cuda_lib.so
[4/9] Building CXX object CMakeFiles/autoware_ptv3_lib.dir/lib/ptv3_trt.cpp.o
[4/9] Building CXX object CMakeFiles/autoware_ptv3_component.dir/src/ptv3_node.cpp.o
[5/9] Linking CXX shared library libautoware_ptv3_cuda_lib.so
[6/9] Building CXX object CMakeFiles/autoware_ptv3_lib.dir/lib/ptv3_trt.cpp.o
[6/9] Linking CXX shared library libautoware_ptv3_lib.so
[7/9] Building CXX object CMakeFiles/autoware_ptv3_component.dir/src/ptv3_node.cpp.o
[8/9] Linking CXX shared library libautoware_ptv3_lib.so
[8/9] Linking CXX shared library libautoware_ptv3_component.so
[9/9] Linking CXX shared library libautoware_ptv3_component.so
-- Install configuration: ""
-- Execute custom install script
-- Up-to-date symlink: /workspace/install/autoware_ptv3/lib/autoware_ptv3/autoware_ptv3_node
-- Up-to-date symlink: /workspace/install/autoware_ptv3/lib/libautoware_ptv3_cuda_lib.so
-- Up-to-date symlink: /workspace/install/autoware_ptv3/include/autoware/ptv3/postprocess/postprocess_kernel.hpp
-- Up-to-date symlink: /workspace/install/autoware_ptv3/include/autoware/ptv3/preprocess/point_type.hpp
-- Up-to-date symlink: /workspace/install/autoware_ptv3/include/autoware/ptv3/preprocess/preprocess_kernel.hpp
-- Up-to-date symlink: /workspace/install/autoware_ptv3/include/autoware/ptv3/ptv3_config.hpp
-- Up-to-date symlink: /workspace/install/autoware_ptv3/include/autoware/ptv3/ptv3_node.hpp
-- Up-to-date symlink: /workspace/install/autoware_ptv3/include/autoware/ptv3/ptv3_trt.hpp
-- Up-to-date symlink: /workspace/install/autoware_ptv3/include/autoware/ptv3/ros_utils.hpp
-- Up-to-date symlink: /workspace/install/autoware_ptv3/include/autoware/ptv3/utils.hpp
-- Up-to-date symlink: /workspace/install/autoware_ptv3/include/autoware/ptv3/visibility_control.hpp
-- Up-to-date symlink: /workspace/install/autoware_ptv3/share/autoware_ptv3/environment/library_path.sh
-- Up-to-date symlink: /workspace/install/autoware_ptv3/share/autoware_ptv3/environment/library_path.dsv
-- Up-to-date symlink: /workspace/install/autoware_ptv3/lib/libautoware_ptv3_lib.so
-- Up-to-date symlink: /workspace/install/autoware_ptv3/lib/libautoware_ptv3_component.so
-- Up-to-date symlink: /workspace/install/autoware_ptv3/share/autoware_ptv3/launch/ptv3.launch.xml
-- Up-to-date symlink: /workspace/install/autoware_ptv3/share/autoware_ptv3/config/ml_package_ptv3.param.yaml
-- Up-to-date symlink: /workspace/install/autoware_ptv3/share/autoware_ptv3/config/ptv3.param.yaml
-- Up-to-date symlink: /workspace/install/autoware_ptv3/share/ament_index/resource_index/package_run_dependencies/autoware_ptv3
-- Up-to-date symlink: /workspace/install/autoware_ptv3/share/ament_index/resource_index/parent_prefix_path/autoware_ptv3
-- Up-to-date symlink: /workspace/install/autoware_ptv3/share/autoware_ptv3/environment/ament_prefix_path.sh
-- Up-to-date symlink: /workspace/install/autoware_ptv3/share/autoware_ptv3/environment/ament_prefix_path.dsv
-- Up-to-date symlink: /workspace/install/autoware_ptv3/share/autoware_ptv3/environment/path.sh
-- Up-to-date symlink: /workspace/install/autoware_ptv3/share/autoware_ptv3/environment/path.dsv
-- Up-to-date symlink: /workspace/install/autoware_ptv3/share/autoware_ptv3/local_setup.bash
-- Up-to-date symlink: /workspace/install/autoware_ptv3/share/autoware_ptv3/local_setup.sh
-- Up-to-date symlink: /workspace/install/autoware_ptv3/share/autoware_ptv3/local_setup.zsh
-- Up-to-date symlink: /workspace/install/autoware_ptv3/share/autoware_ptv3/local_setup.dsv
-- Symlinking: /workspace/install/autoware_ptv3/share/autoware_ptv3/package.dsv
-- Up-to-date symlink: /workspace/install/autoware_ptv3/share/ament_index/resource_index/packages/autoware_ptv3
-- Up-to-date symlink: /workspace/install/autoware_ptv3/share/ament_index/resource_index/rclcpp_components/autoware_ptv3
-- Up-to-date symlink: /workspace/install/autoware_ptv3/share/autoware_ptv3/cmake/ament_cmake_export_dependencies-extras.cmake
-- Up-to-date symlink: /workspace/install/autoware_ptv3/share/autoware_ptv3/cmake/ament_cmake_export_include_directories-extras.cmake
-- Up-to-date symlink: /workspace/install/autoware_ptv3/share/autoware_ptv3/cmake/ament_cmake_export_libraries-extras.cmake
-- Up-to-date symlink: /workspace/install/autoware_ptv3/share/autoware_ptv3/cmake/autoware_ptv3Config.cmake
-- Up-to-date symlink: /workspace/install/autoware_ptv3/share/autoware_ptv3/cmake/autoware_ptv3Config-version.cmake
-- Up-to-date symlink: /workspace/install/autoware_ptv3/share/autoware_ptv3/package.xml
---
--- stderr: autoware_ptv3
In this package, headers install destination is set to `include` by ament_auto_package. It is recommended to install `include/autoware_ptv3` instead and will be the default behavior of ament_auto_package from ROS 2 Kilted Kaiju. On distributions before Kilted, ament_auto_package behaves the same way when you use USE_SCOPED_HEADER_INSTALL_DIR option.
---
Finished <<< autoware_ptv3 [1min 40s]

Summary: 1 package finished [1min 42s]
  1 package had stderr output: autoware_ptv3
```

## Notes for reviewers

None.

## Effects on system behavior

`autoware_point_types_INCLUDE_DIRS` now properly included. That being said, it was not properly included so maybe this include is not necessary in the first place. At least it does not break compilation with ninja.