### PR TITLE
refactor(diffusion_planner,bevformer,vad): use launch arg paths

### DIFF
--- a/e2e/autoware_tensorrt_vad/config/vad_carla_tiny.param.yaml
+++ b/e2e/autoware_tensorrt_vad/config/vad_carla_tiny.param.yaml
@@ -39,7 +39,7 @@
     # ==========================================================================
     # Path to model-specific parameters (architecture, normalization, classes)
     # This file is downloaded via Ansible with the model weights
-    model_param_path: $(env HOME)/autoware_data/vad/v0.1/vad-carla-tiny.param.json
+    model_param_path: $(var model_path)/v0.1/vad-carla-tiny.param.json
 
     # ==========================================================================
     # CAMERA HARDWARE CONFIGURATION (Deployment-Specific)

--- a/perception/autoware_tensorrt_bevformer/config/bevformer.param.yaml
+++ b/perception/autoware_tensorrt_bevformer/config/bevformer.param.yaml
@@ -21,8 +21,8 @@
       num_query: 900
       num_classes: 10
       code_size: 10
-      engine_file: "$(env HOME)/autoware_data/tensorrt_bevformer/bevformer_small.engine"
-      onnx_file: "$(env HOME)/autoware_data/tensorrt_bevformer/bevformer_small.onnx"
+      engine_file: "$(var data_path)/bevformer_small.engine"
+      onnx_file: "$(var data_path)/bevformer_small.onnx"
       auto_convert: true
       workspace_size: 4096
       precision: "fp16"

--- a/planning/autoware_diffusion_planner/README.md
+++ b/planning/autoware_diffusion_planner/README.md
@@ -23,7 +23,7 @@ It is implemented as a ROS 2 component node, making it easy to integrate into Au
 Make sure that the directory specified in `planning/autoware_diffusion_planner/config/diffusion_planner.param.yaml` points to the correct model version and contains the required model weight and parameter files.
 
 ```bash
-$ ls ~/autoware_data/diffusion_planner/v3.1/
+$ ls ~/autoware_data/diffusion_planner/v4.0/
 diffusion_planner.onnx diffusion_planner.param.json
 ```
 

--- a/planning/autoware_diffusion_planner/config/diffusion_planner.param.yaml
+++ b/planning/autoware_diffusion_planner/config/diffusion_planner.param.yaml
@@ -1,8 +1,8 @@
 /**:
   ros__parameters:
     plugins_path: $(find-pkg-share autoware_tensorrt_plugins)/plugins/libautoware_tensorrt_plugins.so
-    onnx_model_path: $(env HOME)/autoware_data/diffusion_planner/v4.0/diffusion_planner.onnx
-    args_path: $(env HOME)/autoware_data/diffusion_planner/v4.0/diffusion_planner.param.json
+    onnx_model_path: $(var data_path)/v4.0/diffusion_planner.onnx
+    args_path: $(var data_path)/v4.0/diffusion_planner.param.json
     planning_frequency_hz: 10.0
     ignore_neighbors: false
     ignore_unknown_neighbors: true

--- a/planning/autoware_diffusion_planner/launch/diffusion_planner.launch.xml
+++ b/planning/autoware_diffusion_planner/launch/diffusion_planner.launch.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <launch>
   <arg name="diffusion_planner_param_path" default="$(find-pkg-share autoware_diffusion_planner)/config/diffusion_planner.param.yaml"/>
+  <arg name="data_path" default="$(env HOME)/autoware_data/diffusion_planner" description="diffusion planner artifacts (onnx model, args json) directory"/>
   <arg name="output_trajectory" default="~/output/trajectory"/>
   <arg name="output_trajectories" default="~/output/trajectories"/>
   <arg name="output_predicted_objects" default="~/output/predicted_objects"/>

--- a/planning/autoware_diffusion_planner/schema/diffusion_planner.schema.json
+++ b/planning/autoware_diffusion_planner/schema/diffusion_planner.schema.json
@@ -11,19 +11,14 @@
           "default": "$(find-pkg-share autoware_tensorrt_plugins)/plugins/libautoware_tensorrt_plugins.so",
           "description": "Path to libautoware_tensorrt_plugins.so file for the diffusion planner"
         },
-        "artifact_dir": {
-          "type": "string",
-          "default": "$(env HOME)/autoware_data/diffusion_planner",
-          "description": "Path to the Artifact(onnx model, etc.) directory"
-        },
         "onnx_model_path": {
           "type": "string",
-          "default": "$(var artifact_dir)/diffusion_planner.onnx",
+          "default": "$(var data_path)/v4.0/diffusion_planner.onnx",
           "description": "Path to the ONNX model file for the diffusion planner"
         },
         "args_path": {
           "type": "string",
-          "default": "$(var artifact_dir)/diffusion_planner.param.json",
+          "default": "$(var data_path)/v4.0/diffusion_planner.param.json",
           "description": "Path to model argument/configuration file"
         },
         "planning_frequency_hz": {


### PR DESCRIPTION
- **Parent Issue:** autowarefoundation/autoware#7068
- Move the absolute `$(env HOME)/autoware_data/<model>` strings out of the param YAMLs for `autoware_diffusion_planner`, `autoware_tensorrt_bevformer`, and `autoware_tensorrt_vad`, and have each YAML reference a launch substitution.
- Add a `data_path` arg to `diffusion_planner.launch.xml`; drop the unused `artifact_dir` from the diffusion-planner schema and align its `onnx_model_path` / `args_path` defaults with the YAML.
- Drive-by: fix a stale `v3.1` reference in the diffusion-planner README to match the YAML default of `v4.0`.

## Why

Pure refactor, no path changes. The launch arg defaults still resolve to the same locations, so existing users see no behaviour change. The follow-up `~/autoware_data/` restructure (autowarefoundation/autoware#7068) can then flip each launch arg's default from a single place instead of patching three packages again.

---

## Files changed

- [`e2e/autoware_tensorrt_vad/config/vad_carla_tiny.param.yaml`](https://github.com/autowarefoundation/autoware_universe/blob/14636fcaec37c7b7d58eca35f852476926bba0b5/e2e/autoware_tensorrt_vad/config/vad_carla_tiny.param.yaml) `model_param_path` now uses `$(var model_path)` (the launch already declares it).
- [`perception/autoware_tensorrt_bevformer/config/bevformer.param.yaml`](https://github.com/autowarefoundation/autoware_universe/blob/14636fcaec37c7b7d58eca35f852476926bba0b5/perception/autoware_tensorrt_bevformer/config/bevformer.param.yaml) `model_params.engine_file` and `model_params.onnx_file` now use `$(var data_path)`.
- [`planning/autoware_diffusion_planner/launch/diffusion_planner.launch.xml`](https://github.com/autowarefoundation/autoware_universe/blob/14636fcaec37c7b7d58eca35f852476926bba0b5/planning/autoware_diffusion_planner/launch/diffusion_planner.launch.xml) adds the `data_path` arg defaulting to `$(env HOME)/autoware_data/diffusion_planner`.
- [`planning/autoware_diffusion_planner/config/diffusion_planner.param.yaml`](https://github.com/autowarefoundation/autoware_universe/blob/14636fcaec37c7b7d58eca35f852476926bba0b5/planning/autoware_diffusion_planner/config/diffusion_planner.param.yaml) `onnx_model_path` / `args_path` now use `$(var data_path)`.
- [`planning/autoware_diffusion_planner/schema/diffusion_planner.schema.json`](https://github.com/autowarefoundation/autoware_universe/blob/14636fcaec37c7b7d58eca35f852476926bba0b5/planning/autoware_diffusion_planner/schema/diffusion_planner.schema.json) drops `artifact_dir`; `onnx_model_path` / `args_path` defaults match the YAML.
- [`planning/autoware_diffusion_planner/README.md`](https://github.com/autowarefoundation/autoware_universe/blob/14636fcaec37c7b7d58eca35f852476926bba0b5/planning/autoware_diffusion_planner/README.md) `v3.1` -> `v4.0` in the prerequisites snippet.

## Test plan

- [ ] Build the affected packages from the workspace root:

  ```bash
  source /opt/ros/jazzy/setup.bash
  colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release \
    --packages-select autoware_diffusion_planner autoware_tensorrt_bevformer autoware_tensorrt_vad
  ```

  Expect: clean build, no schema/yaml errors.

- [ ] Confirm default behaviour is unchanged:

  ```bash
  source install/setup.bash
  ros2 launch autoware_diffusion_planner diffusion_planner.launch.xml --show-args | grep -E '(data_path|diffusion_planner_param_path)'
  ```

  Expect: `data_path` resolves to `$HOME/autoware_data/diffusion_planner` (legacy default).

- [ ] Confirm the override path works end-to-end:

  ```bash
  ros2 launch autoware_diffusion_planner diffusion_planner.launch.xml \
    data_path:=$HOME/autoware_data/ml_models/diffusion_planner --show-args
  ```

  Expect: `onnx_model_path` and `args_path` now point under `ml_models/diffusion_planner/v4.0/...`.

- [ ] BEVFormer and VAD: launch `bevformer.launch.xml` and `vad_carla_tiny.launch.xml` with `--show-args` and confirm the resolved `engine_file`/`onnx_file`/`model_param_path` match the launch-arg `data_path` / `model_path` defaults.
