### PR TITLE
feat: default artifact paths to ~/autoware_data/ml_models

### DIFF
--- a/control/autoware_smart_mpc_trajectory_follower/README.md
+++ b/control/autoware_smart_mpc_trajectory_follower/README.md
@@ -40,7 +40,7 @@ In "mppi_ilqr" mode, the initial value of iLQR is given by the MPPI solution.
 To perform a simulation, run the following command:
 
 ```bash
-ros2 launch autoware_launch planning_simulator.launch.xml map_path:=$HOME/autoware_map/sample-map-planning vehicle_model:=sample_vehicle sensor_model:=sample_sensor_kit trajectory_follower_mode:=smart_mpc_trajectory_follower
+ros2 launch autoware_launch planning_simulator.launch.xml map_path:=$HOME/autoware_data/maps/sample-map-planning vehicle_model:=sample_vehicle sensor_model:=sample_sensor_kit trajectory_follower_mode:=smart_mpc_trajectory_follower
 ```
 
 > [!NOTE]

--- a/e2e/autoware_tensorrt_vad/README.md
+++ b/e2e/autoware_tensorrt_vad/README.md
@@ -36,7 +36,7 @@ This module replaces traditional localization, perception, and planning modules 
 Parameters can be set via configuration files:
 
 - Deployment configuration (node and interface parameters): `config/vad_carla_tiny.param.yaml`
-- Model architecture parameters: `vad-carla-tiny.param.json` (downloaded with model to `~/autoware_data/vad/v0.1/`)
+- Model architecture parameters: `vad-carla-tiny.param.json` (downloaded with model to `~/autoware_data/ml_models/vad/v0.1/`)
 
 ---
 
@@ -99,7 +99,7 @@ Then launch the E2E VAD system:
 
 ```bash
 ros2 launch autoware_launch e2e_simulator.launch.xml \
-  map_path:=$HOME/autoware_map/Town01 \
+  map_path:=$HOME/autoware_data/maps/Town01 \
   vehicle_model:=sample_vehicle \
   sensor_model:=carla_sensor_kit \
   simulator_type:=carla \
@@ -117,7 +117,7 @@ The VAD model files are automatically downloaded when setting up the Autoware de
 To download the latest models, simply run the provided setup script:
 [How to set up a development environment](https://autowarefoundation.github.io/autoware-documentation/main/installation/autoware/source-installation/#how-to-set-up-a-development-environment)
 
-The models will be downloaded to `~/autoware_data/vad/` by default.
+The models will be downloaded to `~/autoware_data/ml_models/vad/` by default.
 
 **Manual Download** (if needed):
 Models are hosted at: <https://awf.ml.dev.web.auto/planning/models/tensorrt_vad/carla_tiny/v0.1/>

--- a/e2e/autoware_tensorrt_vad/docs/design.md
+++ b/e2e/autoware_tensorrt_vad/docs/design.md
@@ -197,7 +197,7 @@ flowchart TD
 
 ### Separation between model architecture and deployment parameters
 
-- Model architecture parameters (network structure, normalization, training dataset classes) are defined in `vad-carla-tiny.param.json` (downloaded with model to `~/autoware_data/vad/v0.1/`)
+- Model architecture parameters (network structure, normalization, training dataset classes) are defined in `vad-carla-tiny.param.json` (downloaded with model to `~/autoware_data/ml_models/vad/v0.1/`)
 - Deployment parameters (hardware settings, file paths, detection thresholds) are configured in [`vad_carla_tiny.param.yaml`](../config/vad_carla_tiny.param.yaml)
   - Object class remapping parameters are added to [`object_class_remapper_carla_tiny.param.yaml`](../config/object_class_remapper_carla_tiny.param.yaml)
     - Following the precedent of [`autoware_bevfusion`](../../../perception/autoware_bevfusion/README.md)

--- a/e2e/autoware_tensorrt_vad/launch/vad_carla_tiny.launch.xml
+++ b/e2e/autoware_tensorrt_vad/launch/vad_carla_tiny.launch.xml
@@ -22,7 +22,7 @@
   <!-- ========================================
        Model and Plugin Paths
        ======================================== -->
-  <arg name="data_path" default="$(env HOME)/autoware_data" description="Root directory for data and models"/>
+  <arg name="data_path" default="$(env HOME)/autoware_data/ml_models" description="Root directory for data and models"/>
   <arg name="model_path" default="$(var data_path)/vad" description="VAD ONNX models and TensorRT engines directory"/>
   <arg name="plugins_path" default="$(find-pkg-share autoware_tensorrt_plugins)" description="Custom TensorRT plugins library"/>
 

--- a/localization/yabloc/README.md
+++ b/localization/yabloc/README.md
@@ -24,7 +24,7 @@ A sample command to run YabLoc is as follows
 
 ```shell
 ros2 launch autoware_launch logging_simulator.launch.xml \
-  map_path:=$HOME/autoware_map/sample-map-rosbag\
+  map_path:=$HOME/autoware_data/maps/sample-map-rosbag\
   vehicle_model:=sample_vehicle \
   sensor_model:=sample_sensor_kit \
   pose_source:=yabloc

--- a/localization/yabloc/yabloc_pose_initializer/README.md
+++ b/localization/yabloc/yabloc_pose_initializer/README.md
@@ -10,10 +10,10 @@ It is also possible to download it manually. Even if the model is not downloaded
 To download and extract the model manually:
 
 ```bash
-$ mkdir -p ~/autoware_data/yabloc_pose_initializer/
-$ wget -P ~/autoware_data/yabloc_pose_initializer/ \
+$ mkdir -p ~/autoware_data/ml_models/yabloc_pose_initializer/
+$ wget -P ~/autoware_data/ml_models/yabloc_pose_initializer/ \
        https://autoware-files.s3.us-west-2.amazonaws.com/models/yabloc/136_road-segmentation-adas-0001/resources.tar.gz
-$ tar xzf ~/autoware_data/yabloc_pose_initializer/resources.tar.gz -C ~/autoware_data/yabloc_pose_initializer/
+$ tar xzf ~/autoware_data/ml_models/yabloc_pose_initializer/resources.tar.gz -C ~/autoware_data/ml_models/yabloc_pose_initializer/
 ```
 
 ## Note

--- a/localization/yabloc/yabloc_pose_initializer/launch/yabloc_pose_initializer.launch.xml
+++ b/localization/yabloc/yabloc_pose_initializer/launch/yabloc_pose_initializer.launch.xml
@@ -1,5 +1,5 @@
 <launch>
-  <arg name="data_path" default="$(env HOME)/autoware_data"/>
+  <arg name="data_path" default="$(env HOME)/autoware_data/ml_models"/>
   <arg name="model_path" default="$(var data_path)/yabloc_pose_initializer/saved_model/model_float32.pb"/>
 
   <node pkg="yabloc_pose_initializer" exec="yabloc_pose_initializer_node" output="both">

--- a/perception/autoware_bevfusion/README.md
+++ b/perception/autoware_bevfusion/README.md
@@ -69,7 +69,7 @@ This node assumes that the input pointcloud follows the `PointXYZIRC` layout def
 ## Trained Models
 
 You can download the onnx and config files in the following links.
-The files need to be placed inside `$(env HOME)/autoware_data/bevfusion`
+The files need to be placed inside `$(env HOME)/autoware_data/ml_models/bevfusion`
 
 - lidar-only model:
   - [onnx](https://awf.ml.dev.web.auto/perception/models/bevfusion/t4base_120m/v1/bevfusion_lidar.onnx)

--- a/perception/autoware_bevfusion/launch/bevfusion.launch.xml
+++ b/perception/autoware_bevfusion/launch/bevfusion.launch.xml
@@ -2,7 +2,7 @@
 <launch>
   <arg name="input/pointcloud" default="/sensing/lidar/concatenated/pointcloud"/>
   <arg name="output/objects" default="objects"/>
-  <arg name="data_path" default="$(env HOME)/autoware_data" description="packages data and artifacts directory path"/>
+  <arg name="data_path" default="$(env HOME)/autoware_data/ml_models" description="packages data and artifacts directory path"/>
   <arg name="model_name" default="bevfusion_lidar">
     <choice value="bevfusion_lidar"/>
     <choice value="bevfusion_camera_lidar"/>

--- a/perception/autoware_camera_streampetr/config/ml_package_camera_streampetr.param.yaml
+++ b/perception/autoware_camera_streampetr/config/ml_package_camera_streampetr.param.yaml
@@ -1,5 +1,5 @@
 # This is just an example file, the actual model param file comes with the model onnx files
-# and is stored in the artifacts directory (~/autoware_data/camera_streampetr by default).
+# and is stored in the artifacts directory (~/autoware_data/ml_models/camera_streampetr by default).
 
 /**:
   ros__parameters:

--- a/perception/autoware_camera_streampetr/launch/streampetr.launch.xml
+++ b/perception/autoware_camera_streampetr/launch/streampetr.launch.xml
@@ -1,6 +1,6 @@
 <launch>
   <arg name="build_only" default="false" description="shutdown node after TensorRT engine file is built"/>
-  <arg name="model_path" default="$(env HOME)/autoware_data/camera_streampetr"/>
+  <arg name="model_path" default="$(env HOME)/autoware_data/ml_models/camera_streampetr"/>
 
   <arg name="model_param_path" default="$(var model_path)/ml_package_camera_streampetr.param.yaml"/>
   <arg name="node_param_path" default="$(find-pkg-share autoware_camera_streampetr)/config/camera_streampetr.param.yaml"/>

--- a/perception/autoware_image_projection_based_fusion/README.md
+++ b/perception/autoware_image_projection_based_fusion/README.md
@@ -236,5 +236,5 @@ The `pointpainting_fusion` node has `build_only` option to build the TensorRT en
 Although it is preferred to move all the ROS parameters in `.param.yaml` file in Autoware Universe, the `build_only` option is not moved to the `.param.yaml` file for now, because it may be used as a flag to execute the build as a pre-task. You can execute with the following command:
 
 ```bash
-ros2 launch autoware_image_projection_based_fusion pointpainting_fusion.launch.xml model_name:=pointpainting model_path:=/home/autoware/autoware_data/image_projection_based_fusion model_param_path:=$(ros2 pkg prefix autoware_image_projection_based_fusion --share)/config/pointpainting.param.yaml build_only:=true
+ros2 launch autoware_image_projection_based_fusion pointpainting_fusion.launch.xml model_name:=pointpainting model_path:=/home/autoware/autoware_data/ml_models/image_projection_based_fusion model_param_path:=$(ros2 pkg prefix autoware_image_projection_based_fusion --share)/config/pointpainting.param.yaml build_only:=true
 ```

--- a/perception/autoware_image_projection_based_fusion/launch/pointpainting_fusion.launch.xml
+++ b/perception/autoware_image_projection_based_fusion/launch/pointpainting_fusion.launch.xml
@@ -20,7 +20,7 @@
   <arg name="input/camera_info8" default="/camera_info8"/>
   <arg name="input/pointcloud" default="/sensing/lidar/top/rectified/pointcloud"/>
   <arg name="output/objects" default="objects"/>
-  <arg name="data_path" default="$(env HOME)/autoware_data" description="packages data and artifacts directory path"/>
+  <arg name="data_path" default="$(env HOME)/autoware_data/ml_models" description="packages data and artifacts directory path"/>
   <arg name="model_name" default="pointpainting" description="options: `pointpainting`"/>
   <arg name="model_path" default="$(var data_path)/image_projection_based_fusion"/>
   <arg name="model_param_path" default="$(find-pkg-share autoware_image_projection_based_fusion)/config/pointpainting.param.yaml"/>

--- a/perception/autoware_lidar_apollo_instance_segmentation/launch/lidar_apollo_instance_segmentation.launch.xml
+++ b/perception/autoware_lidar_apollo_instance_segmentation/launch/lidar_apollo_instance_segmentation.launch.xml
@@ -8,7 +8,7 @@
   <arg if="$(eval &quot;'$(var model)'=='model_64'&quot;)" name="base_name" default="hdl-64"/>
   <arg if="$(eval &quot;'$(var model)'=='model_128'&quot;)" name="base_name" default="vls-128"/>
 
-  <arg name="data_path" default="$(env HOME)/autoware_data" description="packages data and artifacts directory path"/>
+  <arg name="data_path" default="$(env HOME)/autoware_data/ml_models" description="packages data and artifacts directory path"/>
   <arg name="onnx_file" default="$(var data_path)/lidar_apollo_instance_segmentation/$(var base_name).onnx"/>
   <arg name="param_file" default="$(find-pkg-share autoware_lidar_apollo_instance_segmentation)/config/$(var base_name).param.yaml"/>
 

--- a/perception/autoware_lidar_centerpoint/README.md
+++ b/perception/autoware_lidar_centerpoint/README.md
@@ -57,7 +57,7 @@ The `autoware_lidar_centerpoint` node has `build_only` option to build the Tenso
 Although it is preferred to move all the ROS parameters in `.param.yaml` file in Autoware Universe, the `build_only` option is not moved to the `.param.yaml` file for now, because it may be used as a flag to execute the build as a pre-task. You can execute with the following command:
 
 ```bash
-ros2 launch autoware_lidar_centerpoint lidar_centerpoint.launch.xml model_name:=centerpoint_tiny model_path:=/home/autoware/autoware_data/lidar_centerpoint model_param_path:=$(ros2 pkg prefix autoware_lidar_centerpoint --share)/config/centerpoint_tiny.param.yaml build_only:=true
+ros2 launch autoware_lidar_centerpoint lidar_centerpoint.launch.xml model_name:=centerpoint_tiny model_path:=/home/autoware/autoware_data/ml_models/lidar_centerpoint model_param_path:=$(ros2 pkg prefix autoware_lidar_centerpoint --share)/config/centerpoint_tiny.param.yaml build_only:=true
 ```
 
 ## Assumptions / Known limits

--- a/perception/autoware_lidar_centerpoint/launch/lidar_centerpoint.launch.xml
+++ b/perception/autoware_lidar_centerpoint/launch/lidar_centerpoint.launch.xml
@@ -2,7 +2,7 @@
 <launch>
   <arg name="input/pointcloud" default="/sensing/lidar/pointcloud"/>
   <arg name="output/objects" default="objects"/>
-  <arg name="data_path" default="$(env HOME)/autoware_data" description="packages data and artifacts directory path"/>
+  <arg name="data_path" default="$(env HOME)/autoware_data/ml_models" description="packages data and artifacts directory path"/>
   <arg name="node_name" default="lidar_centerpoint" description="node name for autoware_lidar_centerpoint_node"/>
   <arg name="model_name" default="centerpoint_tiny" description="options: `centerpoint`, `centerpoint_tiny` or `centerpoint_short_range`"/>
   <arg name="model_path" default="$(var data_path)/$(var node_name)"/>

--- a/perception/autoware_lidar_frnet/launch/lidar_frnet.launch.xml
+++ b/perception/autoware_lidar_frnet/launch/lidar_frnet.launch.xml
@@ -4,7 +4,7 @@
   <arg name="output/pointcloud/segmentation" default="~/segmentation"/>
   <arg name="output/pointcloud/visualization" default="~/visualization"/>
   <arg name="output/pointcloud/filtered" default="~/filtered"/>
-  <arg name="data_path" default="$(env HOME)/autoware_data" description="packages data and artifacts directory path"/>
+  <arg name="data_path" default="$(env HOME)/autoware_data/ml_models" description="packages data and artifacts directory path"/>
   <arg name="model_name" default="frnet" description="options: `frnet`"/>
   <arg name="sensor_model" default="ot128">
     <choice value="ot128" description="Hesai OT128"/>

--- a/perception/autoware_lidar_transfusion/launch/lidar_transfusion.launch.xml
+++ b/perception/autoware_lidar_transfusion/launch/lidar_transfusion.launch.xml
@@ -2,7 +2,7 @@
 <launch>
   <arg name="input/pointcloud" default="/sensing/lidar/pointcloud"/>
   <arg name="output/objects" default="objects"/>
-  <arg name="data_path" default="$(env HOME)/autoware_data" description="packages data and artifacts directory path"/>
+  <arg name="data_path" default="$(env HOME)/autoware_data/ml_models" description="packages data and artifacts directory path"/>
   <arg name="model_name" default="transfusion" description="options: `transfusion`"/>
   <arg name="model_path" default="$(var data_path)/lidar_transfusion"/>
   <arg name="model_param_path" default="$(find-pkg-share autoware_lidar_transfusion)/config/$(var model_name).param.yaml"/>

--- a/perception/autoware_ptv3/launch/ptv3.launch.xml
+++ b/perception/autoware_ptv3/launch/ptv3.launch.xml
@@ -5,7 +5,7 @@
   <arg name="output/pointcloud/visualization" default="~/visualization"/>
   <arg name="output/pointcloud/filtered" default="~/filtered"/>
 
-  <arg name="data_path" default="$(env HOME)/autoware_data" description="packages data and artifacts directory path"/>
+  <arg name="data_path" default="$(env HOME)/autoware_data/ml_models" description="packages data and artifacts directory path"/>
   <arg name="model_name" default="ptv3"/>
   <arg name="model_path" default="$(var data_path)/ptv3"/>
   <arg name="model_param_path" default="$(find-pkg-share autoware_ptv3)/config/$(var model_name).param.yaml"/>

--- a/perception/autoware_shape_estimation/launch/shape_estimation.launch.xml
+++ b/perception/autoware_shape_estimation/launch/shape_estimation.launch.xml
@@ -5,7 +5,7 @@
   <arg name="output/objects" default="shape_estimated_objects"/>
   <arg name="node_name" default="shape_estimation"/>
 
-  <arg name="data_path" default="$(env HOME)/autoware_data" description="packages data and artifacts directory path"/>
+  <arg name="data_path" default="$(env HOME)/autoware_data/ml_models" description="packages data and artifacts directory path"/>
   <arg name="model_path" default="$(var data_path)/shape_estimation/pointnet.onnx"/>
   <!-- Parameter -->
   <arg name="config_file" default="$(find-pkg-share autoware_shape_estimation)/config/shape_estimation.param.yaml"/>

--- a/perception/autoware_simpl_prediction/launch/simpl.launch.xml
+++ b/perception/autoware_simpl_prediction/launch/simpl.launch.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <launch>
   <!-- model parameters -->
-  <arg name="data_path" default="$(env HOME)/autoware_data"/>
+  <arg name="data_path" default="$(env HOME)/autoware_data/ml_models"/>
   <arg name="param_path" default="$(find-pkg-share autoware_simpl_prediction)/config/simpl.param.yaml"/>
 
   <!-- I/O topics -->

--- a/perception/autoware_tensorrt_bevdet/launch/tensorrt_bevdet.launch.xml
+++ b/perception/autoware_tensorrt_bevdet/launch/tensorrt_bevdet.launch.xml
@@ -19,7 +19,7 @@
   <arg name="input/img_back/camera_info" default="/nuscenes/CAM_BACK/camera_info"/>
   <arg name="input/img_back_right/camera_info" default="/nuscenes/CAM_BACK_RIGHT/camera_info"/>
 
-  <arg name="data_path" default="$(env HOME)/autoware_data"/>
+  <arg name="data_path" default="$(env HOME)/autoware_data/ml_models"/>
   <arg name="model_name" default="bevdet_one_lt_d"/>
   <arg name="model_path" default="$(var data_path)/tensorrt_bevdet"/>
   <arg name="model_config" default="$(find-pkg-share autoware_tensorrt_bevdet)/config/bevdet_r50_4dlongterm_depth.yaml"/>

--- a/perception/autoware_tensorrt_bevformer/README.md
+++ b/perception/autoware_tensorrt_bevformer/README.md
@@ -50,7 +50,7 @@ The core algorithm, named `BEVFormer`, unifies multi-view images into the BEV pe
 Download the [`bevformer_small.onnx`](https://multicorewareinc1-my.sharepoint.com/:u:/g/personal/naveen_sathiyaseelan_multicorewareinc_com/ERQSpS-BoAZGh4R4zNZhITcB58aqDW_tu9aKHLpit6aLAg?e=IZ5nZN) model to:
 
 ```bash
-$HOME/autoware_data/tensorrt_bevformer
+$HOME/autoware_data/ml_models/tensorrt_bevformer
 ```
 
 > **Note:** The **BEVFormer** model was trained on the **nuScenes** dataset for 24 epochs with temporal fusion enabled.

--- a/perception/autoware_tensorrt_bevformer/launch/bevformer.launch.xml
+++ b/perception/autoware_tensorrt_bevformer/launch/bevformer.launch.xml
@@ -21,7 +21,7 @@
   <arg name="input/img_back/camera_info" default="/nuscenes/CAM_BACK/camera_info"/>
   <arg name="input/img_back_right/camera_info" default="/nuscenes/CAM_BACK_RIGHT/camera_info"/>
 
-  <arg name="data_path" default="$(env HOME)/autoware_data/tensorrt_bevformer"/>
+  <arg name="data_path" default="$(env HOME)/autoware_data/ml_models/tensorrt_bevformer"/>
 
   <!-- TRT Engine and ONNX paths -->
   <arg name="onnx_file" default="$(var data_path)/bevformer_small.onnx"/>

--- a/perception/autoware_tensorrt_yolox/launch/yolox_s_plus_opt.launch.xml
+++ b/perception/autoware_tensorrt_yolox/launch/yolox_s_plus_opt.launch.xml
@@ -4,7 +4,7 @@
   <arg name="yolox_node_name" default="tensorrt_yolox"/>
   <arg name="image_transport_decompressor_node_name" default="image_transport_decompressor_node"/>
 
-  <arg name="data_path" default="$(env HOME)/autoware_data" description="packages data and artifacts directory path"/>
+  <arg name="data_path" default="$(env HOME)/autoware_data/ml_models" description="packages data and artifacts directory path"/>
 
   <arg name="input/image" default="/sensing/camera/camera0/image_rect_color"/>
   <arg name="output/objects" default="/perception/object_recognition/detection/rois0"/>

--- a/perception/autoware_tensorrt_yolox/launch/yolox_tiny.launch.xml
+++ b/perception/autoware_tensorrt_yolox/launch/yolox_tiny.launch.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <launch>
   <!-- cspell: ignore semseg -->
-  <arg name="data_path" default="$(env HOME)/autoware_data" description="packages data and artifacts directory path"/>
+  <arg name="data_path" default="$(env HOME)/autoware_data/ml_models" description="packages data and artifacts directory path"/>
 
   <arg name="input/image" default="/sensing/camera/camera0/image_rect_color"/>
   <arg name="output/objects" default="/perception/object_recognition/detection/rois0"/>

--- a/perception/autoware_tensorrt_yolox/launch/yolox_traffic_light_detector.launch.xml
+++ b/perception/autoware_tensorrt_yolox/launch/yolox_traffic_light_detector.launch.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <launch>
   <!-- cspell: ignore semseg -->
-  <arg name="data_path" default="$(env HOME)/autoware_data" description="packages data and artifacts directory path"/>
+  <arg name="data_path" default="$(env HOME)/autoware_data/ml_models" description="packages data and artifacts directory path"/>
 
   <arg name="input/image" default="/sensing/camera/camera6/image_raw"/>
   <arg name="output/objects" default="/perception/traffic_light_recognition/camera6/detection/rois"/>

--- a/perception/autoware_traffic_light_classifier/launch/car_traffic_light_classifier.launch.xml
+++ b/perception/autoware_traffic_light_classifier/launch/car_traffic_light_classifier.launch.xml
@@ -1,6 +1,6 @@
 <launch>
   <!-- cspell: ignore comlops -->
-  <arg name="data_path" default="$(env HOME)/autoware_data" description="packages data and artifacts directory path"/>
+  <arg name="data_path" default="$(env HOME)/autoware_data/ml_models" description="packages data and artifacts directory path"/>
 
   <arg name="input/image" default="~/image_raw"/>
   <arg name="input/rois" default="~/rois"/>

--- a/perception/autoware_traffic_light_classifier/launch/pedestrian_traffic_light_classifier.launch.xml
+++ b/perception/autoware_traffic_light_classifier/launch/pedestrian_traffic_light_classifier.launch.xml
@@ -1,6 +1,6 @@
 <launch>
   <!-- cspell: ignore comlops -->
-  <arg name="data_path" default="$(env HOME)/autoware_data" description="packages data and artifacts directory path"/>
+  <arg name="data_path" default="$(env HOME)/autoware_data/ml_models" description="packages data and artifacts directory path"/>
 
   <arg name="input/image" default="~/image_raw"/>
   <arg name="input/rois" default="~/rois"/>

--- a/perception/autoware_traffic_light_fine_detector/launch/traffic_light_fine_detector.launch.xml
+++ b/perception/autoware_traffic_light_fine_detector/launch/traffic_light_fine_detector.launch.xml
@@ -1,5 +1,5 @@
 <launch>
-  <arg name="data_path" default="$(env HOME)/autoware_data" description="packages data and artifacts directory path"/>
+  <arg name="data_path" default="$(env HOME)/autoware_data/ml_models" description="packages data and artifacts directory path"/>
 
   <arg name="input/image" default="/image_raw"/>
   <arg name="input/rois" default="/traffic_light_map_based_detector/output/rois"/>

--- a/planning/autoware_diffusion_planner/README.md
+++ b/planning/autoware_diffusion_planner/README.md
@@ -23,7 +23,7 @@ It is implemented as a ROS 2 component node, making it easy to integrate into Au
 Make sure that the directory specified in `planning/autoware_diffusion_planner/config/diffusion_planner.param.yaml` points to the correct model version and contains the required model weight and parameter files.
 
 ```bash
-$ ls ~/autoware_data/diffusion_planner/v4.0/
+$ ls ~/autoware_data/ml_models/diffusion_planner/v4.0/
 diffusion_planner.onnx diffusion_planner.param.json
 ```
 

--- a/planning/autoware_diffusion_planner/launch/diffusion_planner.launch.xml
+++ b/planning/autoware_diffusion_planner/launch/diffusion_planner.launch.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <launch>
   <arg name="diffusion_planner_param_path" default="$(find-pkg-share autoware_diffusion_planner)/config/diffusion_planner.param.yaml"/>
-  <arg name="data_path" default="$(env HOME)/autoware_data/diffusion_planner" description="diffusion planner artifacts (onnx model, args json) directory"/>
+  <arg name="data_path" default="$(env HOME)/autoware_data/ml_models/diffusion_planner" description="diffusion planner artifacts (onnx model, args json) directory"/>
   <arg name="output_trajectory" default="~/output/trajectory"/>
   <arg name="output_trajectories" default="~/output/trajectories"/>
   <arg name="output_predicted_objects" default="~/output/predicted_objects"/>

--- a/sensing/autoware_calibration_status_classifier/launch/calibration_status_classifier.launch.xml
+++ b/sensing/autoware_calibration_status_classifier/launch/calibration_status_classifier.launch.xml
@@ -4,7 +4,7 @@
   <arg name="input_angular_velocity" default="/sensing/vehicle_velocity_converter/twist_with_covariance"/>
   <arg name="input_objects" default="/perception/object_recognition/objects"/>
   <arg name="validate_calibration_srv" default="validate_calibration"/>
-  <arg name="data_path" default="$(env HOME)/autoware_data" description="packages data and artifacts directory path"/>
+  <arg name="data_path" default="$(env HOME)/autoware_data/ml_models" description="packages data and artifacts directory path"/>
   <arg name="model_name" default="calibration_status_classifier" description="options: `calibration_status_classifier"/>
   <arg name="model_path" default="$(var data_path)/calibration_status_classifier"/>
   <arg name="model_param_path" default="$(find-pkg-share autoware_calibration_status_classifier)/config/$(var model_name).param.yaml"/>

--- a/sensing/autoware_calibration_status_classifier/test/test_calibration_status_classifier.cpp
+++ b/sensing/autoware_calibration_status_classifier/test/test_calibration_status_classifier.cpp
@@ -48,7 +48,8 @@ protected:
     const char * home_env = std::getenv("HOME");
     std::filesystem::path home_path = home_env ? home_env : "/";
     std::filesystem::path onnx_path =
-      home_path / "autoware_data/calibration_status_classifier/calibration_status_classifier.onnx";
+      home_path /
+      "autoware_data/ml_models/calibration_status_classifier/calibration_status_classifier.onnx";
     if (!std::filesystem::exists(onnx_path)) {
       GTEST_SKIP() << "ONNX model file not found: " << onnx_path;
     }

--- a/sensing/autoware_calibration_status_classifier/test/test_model_inference.cpp
+++ b/sensing/autoware_calibration_status_classifier/test/test_model_inference.cpp
@@ -48,7 +48,8 @@ protected:
     const char * home_env = std::getenv("HOME");
     std::filesystem::path home_path = home_env ? home_env : "/";
     std::filesystem::path onnx_path =
-      home_path / "autoware_data/calibration_status_classifier/calibration_status_classifier.onnx";
+      home_path /
+      "autoware_data/ml_models/calibration_status_classifier/calibration_status_classifier.onnx";
     if (!std::filesystem::exists(onnx_path)) {
       GTEST_SKIP() << "ONNX model file not found: " << onnx_path;
     }

--- a/simulator/autoware_carla_interface/README.md
+++ b/simulator/autoware_carla_interface/README.md
@@ -28,10 +28,10 @@ This ros package enables communication between Autoware and CARLA for autonomous
 #### Map Setup
 
 1. Download the maps (y-axis inverted version) to an arbitrary location
-2. Create the map folder structure in `$HOME/autoware_map`:
-   - Rename `point_cloud/Town01.pcd` → `$HOME/autoware_map/Town01/pointcloud_map.pcd`
-   - Rename `vector_maps/lanelet2/Town01.osm` → `$HOME/autoware_map/Town01/lanelet2_map.osm`
-3. Create `$HOME/autoware_map/Town01/map_projector_info.yaml` with:
+2. Create the map folder structure in `$HOME/autoware_data/maps`:
+   - Rename `point_cloud/Town01.pcd` → `$HOME/autoware_data/maps/Town01/pointcloud_map.pcd`
+   - Rename `vector_maps/lanelet2/Town01.osm` → `$HOME/autoware_data/maps/Town01/lanelet2_map.osm`
+3. Create `$HOME/autoware_data/maps/Town01/map_projector_info.yaml` with:
 
    ```yaml
    projector_type: Local
@@ -57,7 +57,7 @@ colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release
 
    ```bash
    ros2 launch autoware_launch e2e_simulator.launch.xml \
-       map_path:=$HOME/autoware_map/Town01 \
+       map_path:=$HOME/autoware_data/maps/Town01 \
        vehicle_model:=sample_vehicle \
        sensor_model:=carla_sensor_kit \
        simulator_type:=carla
@@ -67,7 +67,7 @@ colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release
 
    ```bash
    ros2 launch autoware_launch e2e_simulator.launch.xml \
-       map_path:=$HOME/autoware_map/Town01 \
+       map_path:=$HOME/autoware_data/maps/Town01 \
        vehicle_model:=sample_vehicle \
        sensor_model:=carla_sensor_kit \
        simulator_type:=carla \


### PR DESCRIPTION
- **Parent Issue:** autowarefoundation/autoware#7068
- Roll every per-package `data_path` / `model_path` launch-arg default in `autoware_universe` from `$(env HOME)/autoware_data[/...]` to `$(env HOME)/autoware_data/ml_models[/...]` so standalone universe launches resolve artifacts under the new layout (22 launch files + 2 test files + 1 config comment + 4 README copy-paste examples for ML packages).
- Drive-by: migrate the `$HOME/autoware_map/<map>` examples in `smart_mpc_trajectory_follower`, `tensorrt_vad`, `yabloc`, and `carla_interface` READMEs to `$HOME/autoware_data/maps[/demos]/<map>`, retiring the legacy `~/autoware_map/` directory entirely.

## Why

The umbrella issue (autowarefoundation/autoware#7068) restructures the host data folder into asset-typed subdirectories: `~/autoware_data/{assets,maps,ml_models,recordings,scenarios}/`. The matching ansible-side change (autowarefoundation/autoware#7077) moves the `artifacts` role default to `~/autoware_data/ml_models/` and drops every reference to the legacy `~/autoware_map/`.

When a perception / localization / sensing / planning component is launched through `autoware_launch`, the parent overrides cascade and pin the new root (autowarefoundation/autoware_launch#1835), so end users running `planning_simulator.launch.xml` or `autoware.launch.xml` are unaffected. This PR closes the remaining gap: a user who runs `ros2 launch autoware_lidar_centerpoint lidar_centerpoint.launch.xml` (or any of the 22 standalone launches) directly will now find the artifacts under `~/autoware_data/ml_models/<pkg>/...` matching where the ansible role places them, and every README copy-paste example matches the new layout end-to-end.

Behaviour for users still on the legacy layout: pin the old root explicitly, e.g. `data_path:=$HOME/autoware_data` (or the per-package equivalent), and `map_path:=$HOME/autoware_map/<map>` for maps.

---

- Pairs with autowarefoundation/autoware#7077 (ansible artifacts role default + docker mounts).
- Pairs with autowarefoundation/autoware_launch#1835 (parent launch-arg defaults and `AutowareSample.system.yaml`).
- Pairs with autowarefoundation/autoware_tools#417 (tools-repo README map_path examples).
- Pairs with autowarefoundation/autoware_system_designer#53 (`vehicle_x.system.yaml`).
- Builds on autowarefoundation/autoware_universe#12521 (already merged) which removed the hardcoded `$(env HOME)/autoware_data/...` strings from the universe param YAMLs.

## Test plan

- [ ] Default cascades through the standalone launches:

  ```bash
  source /opt/ros/jazzy/setup.bash
  source install/setup.bash
  for f in \
    autoware_lidar_centerpoint:lidar_centerpoint.launch.xml \
    autoware_bevfusion:bevfusion.launch.xml \
    autoware_tensorrt_bevformer:bevformer.launch.xml \
    autoware_tensorrt_vad:vad_carla_tiny.launch.xml \
    autoware_diffusion_planner:diffusion_planner.launch.xml \
    autoware_camera_streampetr:streampetr.launch.xml \
    autoware_traffic_light_fine_detector:traffic_light_fine_detector.launch.xml; do
    pkg=${f%%:*}; lf=${f#*:}
    echo "=== $pkg/$lf ==="
    ros2 launch "$pkg" "$lf" --show-args 2>/dev/null | grep -E "(data_path|model_path)" | head -3
  done
  ```

  Expect every default to start with `$HOME/autoware_data/ml_models/`.

- [ ] Legacy override still resolves correctly:

  ```bash
  ros2 launch autoware_lidar_centerpoint lidar_centerpoint.launch.xml \
    data_path:=$HOME/autoware_data --show-args | grep data_path
  ```

  Expect `data_path` to drop back to `$HOME/autoware_data`.

- [ ] No remaining legacy references in launch / config / test / README files:

  ```bash
  grep -rnE '\$\(env HOME\)/autoware_data([/\":\s]|$)' --include='*.xml' --include='*.yaml' --include='*.cpp' . | grep -v ml_models
  grep -rnE '\$HOME/autoware_map|\$\(env HOME\)/autoware_map' --include='*.md' --include='*.xml' --include='*.yaml' .
  ```

  Both expect no output.
