### PR TITLE
feat(carla_interface): implement turn_indicators

### DIFF
--- a/simulator/autoware_carla_interface/src/autoware_carla_interface/carla_ros.py
+++ b/simulator/autoware_carla_interface/src/autoware_carla_interface/carla_ros.py
@@ -17,7 +17,11 @@ import threading
 
 from autoware_vehicle_msgs.msg import ControlModeReport
 from autoware_vehicle_msgs.msg import GearReport
+from autoware_vehicle_msgs.msg import HazardLightsCommand
+from autoware_vehicle_msgs.msg import HazardLightsReport
 from autoware_vehicle_msgs.msg import SteeringReport
+from autoware_vehicle_msgs.msg import TurnIndicatorsCommand
+from autoware_vehicle_msgs.msg import TurnIndicatorsReport
 from autoware_vehicle_msgs.msg import VelocityReport
 from builtin_interfaces.msg import Time
 import carla
@@ -113,6 +117,12 @@ class carla_ros2_interface(object):
         self.pub_actuation_status = self.ros2_node.create_publisher(
             ActuationStatusStamped, "/vehicle/status/actuation_status", 1
         )
+        self.pub_turn_indicators_state = self.ros2_node.create_publisher(
+            TurnIndicatorsReport, "/vehicle/status/turn_indicators_status", 1
+        )
+        self.pub_hazard_lights_state = self.ros2_node.create_publisher(
+            HazardLightsReport, "/vehicle/status/hazard_lights_status", 1
+        )
 
     def _initialize_subscriptions(self):
         """Initialize all ROS 2 subscriptions."""
@@ -121,6 +131,18 @@ class carla_ros2_interface(object):
         )
         self.sub_vehicle_initialpose = self.ros2_node.create_subscription(
             PoseWithCovarianceStamped, "initialpose", self.initialpose_callback, 1
+        )
+        self.sub_turn_indicators = self.ros2_node.create_subscription(
+            TurnIndicatorsCommand,
+            "/control/command/turn_indicators_cmd",
+            self.turn_indicators_callback,
+            1,
+        )
+        self.sub_hazard_lights = self.ros2_node.create_subscription(
+            HazardLightsCommand,
+            "/control/command/hazard_lights_cmd",
+            self.hazard_lights_callback,
+            1,
         )
         self.current_control = carla.VehicleControl()
 
@@ -272,6 +294,8 @@ class carla_ros2_interface(object):
         self.ego_actor = None
         self.physics_control = None
         self.current_control = carla.VehicleControl()
+        self.current_turn_indicator = TurnIndicatorsCommand.DISABLE
+        self.current_hazard_lights = HazardLightsCommand.DISABLE
 
         # Thread synchronization (protects: current_control, ego_actor, timestamp, physics_control)
         self._state_lock = threading.Lock()
@@ -636,6 +660,45 @@ class carla_ros2_interface(object):
             out_cmd.brake = in_cmd.actuation.brake_cmd
             self.current_control = out_cmd
 
+    def turn_indicators_callback(self, in_cmd):
+        """Store turn indicator command (thread-safe)."""
+        with self._state_lock:
+            self.current_turn_indicator = in_cmd.command
+
+    def hazard_lights_callback(self, in_cmd):
+        """Store hazard lights command (thread-safe)."""
+        with self._state_lock:
+            self.current_hazard_lights = in_cmd.command
+
+    def apply_light_state(self):
+        """
+        Apply turn indicator and hazard lights commands to CARLA ego vehicle.
+
+        Hazard takes priority over turn indicator. Other light bits (brake,
+        reverse, headlights, etc.) are preserved so we do not interfere with
+        anything CARLA or another module manages.
+
+        """
+        with self._state_lock:
+            if not self.ego_actor:
+                return
+            turn_cmd = self.current_turn_indicator
+            hazard_cmd = self.current_hazard_lights
+            current_state = int(self.ego_actor.get_light_state())
+
+            left_bit = int(carla.VehicleLightState.LeftBlinker)
+            right_bit = int(carla.VehicleLightState.RightBlinker)
+
+            new_state = current_state & ~left_bit & ~right_bit
+            if hazard_cmd == HazardLightsCommand.ENABLE:
+                new_state |= left_bit | right_bit
+            elif turn_cmd == TurnIndicatorsCommand.ENABLE_LEFT:
+                new_state |= left_bit
+            elif turn_cmd == TurnIndicatorsCommand.ENABLE_RIGHT:
+                new_state |= right_bit
+
+            self.ego_actor.set_light_state(carla.VehicleLightState(new_state))
+
     def ego_status(self):
         """
         Publish ego vehicle status.
@@ -656,6 +719,7 @@ class carla_ros2_interface(object):
             ego_angular_velocity = self.ego_actor.get_angular_velocity()
             steer_angle = self.ego_actor.get_wheel_steer_angle(carla.VehicleWheelLocation.FL_Wheel)
             control = self.ego_actor.get_control()
+            light_state = int(self.ego_actor.get_light_state())
 
         # convert velocity from cartesian to ego frame
         trans_mat = numpy.array(ego_transform.get_matrix()).reshape(4, 4)
@@ -691,11 +755,36 @@ class carla_ros2_interface(object):
         out_actuation_status.status.brake_status = control.brake
         out_actuation_status.status.steer_status = -control.steer
 
+        # Decode CARLA blinker bits into Autoware turn-indicator / hazard reports.
+        left_on = bool(light_state & int(carla.VehicleLightState.LeftBlinker))
+        right_on = bool(light_state & int(carla.VehicleLightState.RightBlinker))
+
+        out_turn_indicators_state = TurnIndicatorsReport()
+        out_turn_indicators_state.stamp = out_vel_state.header.stamp
+        if left_on and right_on:
+            # Both blinkers on => hazard mode; turn indicator reports DISABLE.
+            out_turn_indicators_state.report = TurnIndicatorsReport.DISABLE
+        elif left_on:
+            out_turn_indicators_state.report = TurnIndicatorsReport.ENABLE_LEFT
+        elif right_on:
+            out_turn_indicators_state.report = TurnIndicatorsReport.ENABLE_RIGHT
+        else:
+            out_turn_indicators_state.report = TurnIndicatorsReport.DISABLE
+
+        out_hazard_lights_state = HazardLightsReport()
+        out_hazard_lights_state.stamp = out_vel_state.header.stamp
+        if left_on and right_on:
+            out_hazard_lights_state.report = HazardLightsReport.ENABLE
+        else:
+            out_hazard_lights_state.report = HazardLightsReport.DISABLE
+
         self.pub_actuation_status.publish(out_actuation_status)
         self.pub_vel_state.publish(out_vel_state)
         self.pub_steering_state.publish(out_steering_state)
         self.pub_ctrl_mode.publish(out_ctrl_mode)
         self.pub_gear_state.publish(out_gear_state)
+        self.pub_turn_indicators_state.publish(out_turn_indicators_state)
+        self.pub_hazard_lights_state.publish(out_hazard_lights_state)
         self.sensor_registry.update_sensor_timestamp("status", self.timestamp)
 
     def run_step(self, input_data, timestamp):
@@ -750,6 +839,9 @@ class carla_ros2_interface(object):
                 self.imu(data[1])
             else:
                 self.logger.debug(f"No publisher for sensor '{key}' (type={sensor_type})")
+
+        # Push turn indicator / hazard lights to CARLA before reading status back.
+        self.apply_light_state()
 
         # Publish ego vehicle status
         self.ego_status()


### PR DESCRIPTION
## Description

`autoware_carla_interface` did not bridge turn indicator or hazard lights between Autoware and CARLA. As a result, downstream nodes that require `/vehicle/status/turn_indicators_status` (e.g. `autoware_diffusion_planner`, which subscribes to it as `~/input/turn_indicators`) could not run on the CARLA simulator.

This PR adds a round-trip path that mirrors the existing control flow:

1. Subscribe to `/control/command/turn_indicators_cmd` and `/control/command/hazard_lights_cmd`.
2. In each CARLA tick, translate the latest commands into `carla.VehicleLightState` and apply them via `ego_actor.set_light_state(...)`. Hazard takes priority over turn indicator. Other light bits (brake, reverse, headlights, etc.) are preserved.
3. Read the state back with `ego_actor.get_light_state()` in `ego_status()` and publish it as `TurnIndicatorsReport` / `HazardLightsReport`.

As a side benefit, the CARLA vehicle's blinkers now actually flash in the simulator, which helps visual debugging.

## How was this PR tested?

I have confirmed that CARLA 0.9.16 and OSS Autoware main with `diffusion_planner` work well.

```bash
ros2 launch autoware_launch e2e_simulator.launch.xml \
  map_path:=$HOME/autoware_data/maps/Town01 \
  vehicle_model:=sample_vehicle \
  sensor_model:=carla_sensor_kit \
  simulator_type:=carla \
  use_e2e_planning:=false \
  planning_setting:=diffusion_planner
```


https://github.com/user-attachments/assets/678255a1-3292-431d-8470-938b5021f8f9



## Notes for reviewers

The choice to mirror the existing `apply_control` → `get_*` round-trip (rather than echoing the command directly to the report topic) keeps the architecture consistent with how velocity/steering/gear are handled, and ensures the CARLA-side light state stays the single source of truth. The cost is one CARLA tick of latency on the report, which is negligible for indicator state.

## Interface changes

### Topic changes

#### Additions and removals

| Change type | Topic Type | Topic Name                              | Message Type                                     | Description                                                                       |
|:------------|:-----------|:----------------------------------------|:-------------------------------------------------|:----------------------------------------------------------------------------------|
| Added       | Sub        | `/control/command/turn_indicators_cmd`  | `autoware_vehicle_msgs/TurnIndicatorsCommand`    | Turn indicator command from `vehicle_cmd_gate`, forwarded to CARLA.               |
| Added       | Sub        | `/control/command/hazard_lights_cmd`    | `autoware_vehicle_msgs/HazardLightsCommand`      | Hazard lights command from `vehicle_cmd_gate`, forwarded to CARLA.                |
| Added       | Pub        | `/vehicle/status/turn_indicators_status`| `autoware_vehicle_msgs/TurnIndicatorsReport`     | Turn indicator state read back from CARLA via `get_light_state()`.                |
| Added       | Pub        | `/vehicle/status/hazard_lights_status`  | `autoware_vehicle_msgs/HazardLightsReport`       | Hazard lights state read back from CARLA via `get_light_state()`.                 |

## Effects on system behavior

Downstream consumers of `/vehicle/status/turn_indicators_status` and `/vehicle/status/hazard_lights_status` now receive valid messages when running on CARLA. In particular, `autoware_diffusion_planner` can be launched against the CARLA simulator without modification. Other planners that did not previously rely on these topics see no behavioral change. The CARLA ego vehicle's left/right blinker lights now reflect Autoware's commanded state.
