### PR TITLE
refactor(autoware_traffic_light_map_based_detector): rename functions to snake_case

### DIFF
--- a/perception/autoware_traffic_light_map_based_detector/src/traffic_light_map_based_detector.cpp
+++ b/perception/autoware_traffic_light_map_based_detector/src/traffic_light_map_based_detector.cpp
@@ -42,10 +42,10 @@ TrafficLightMapBasedDetector::TrafficLightMapBasedDetector(
   if (config_.max_detection_range <= 0) {
     throw std::invalid_argument("max_detection_range must be positive");
   }
-  setMap(map_msg);
+  set_map(map_msg);
 }
 
-void TrafficLightMapBasedDetector::setMap(const autoware_map_msgs::msg::LaneletMapBin & map_msg)
+void TrafficLightMapBasedDetector::set_map(const autoware_map_msgs::msg::LaneletMapBin & map_msg)
 {
   lanelet_map_ptr_ = autoware::experimental::lanelet2_utils::remove_const(
     autoware::experimental::lanelet2_utils::from_autoware_map_msgs(map_msg));
@@ -89,7 +89,7 @@ void TrafficLightMapBasedDetector::setMap(const autoware_map_msgs::msg::LaneletM
     std::make_shared<const lanelet::routing::RoutingGraphContainer>(overall_graphs);
 }
 
-std::optional<SetRouteError> TrafficLightMapBasedDetector::setRoute(
+std::optional<SetRouteError> TrafficLightMapBasedDetector::set_route(
   const autoware_planning_msgs::msg::LaneletRoute & route_msg)
 {
   lanelet::ConstLanelets route_lanelets;
@@ -150,7 +150,7 @@ std::optional<SetRouteError> TrafficLightMapBasedDetector::setRoute(
   return std::nullopt;
 }
 
-const tf2::Transform & findClosestTransform(
+const tf2::Transform & find_closest_transform(
   const std::vector<StampedTransform> & samples, const rclcpp::Time & target_time)
 {
   const auto closest_iter = std::min_element(
@@ -181,18 +181,18 @@ DetectionResult TrafficLightMapBasedDetector::detect(
   // Use route traffic lights if available, otherwise all traffic lights
   std::vector<lanelet::ConstLineString3d> visible_traffic_lights;
   if (route_traffic_lights_ptr_ != nullptr) {
-    getVisibleTrafficLights(
+    get_visible_traffic_lights(
       *route_traffic_lights_ptr_, tf_map2camera_samples, pinhole_camera_model,
       visible_traffic_lights);
   } else {
-    getVisibleTrafficLights(
+    get_visible_traffic_lights(
       *all_traffic_lights_ptr_, tf_map2camera_samples, pinhole_camera_model,
       visible_traffic_lights);
   }
 
   // set all offset to zero when calculating the expect roi
   const tf2::Transform tf_map2camera_closest =
-    findClosestTransform(tf_map2camera_samples, camera_info.header.stamp);
+    find_closest_transform(tf_map2camera_samples, camera_info.header.stamp);
   TrafficLightMapBasedDetectorConfig expect_roi_config = config_;
   expect_roi_config.max_vibration_depth = 0;
   expect_roi_config.max_vibration_height = 0;
@@ -202,12 +202,12 @@ DetectionResult TrafficLightMapBasedDetector::detect(
 
   for (const auto & traffic_light : visible_traffic_lights) {
     tier4_perception_msgs::msg::TrafficLightRoi rough_roi, expect_roi;
-    if (!getTrafficLightRoi(
+    if (!get_traffic_light_roi(
           tf_map2camera_closest, pinhole_camera_model, traffic_light, expect_roi_config,
           expect_roi)) {
       continue;
     }
-    if (!getTrafficLightRoi(
+    if (!get_traffic_light_roi(
           tf_map2camera_samples, pinhole_camera_model, traffic_light, config_, rough_roi)) {
       continue;
     }
@@ -216,12 +216,12 @@ DetectionResult TrafficLightMapBasedDetector::detect(
   }
 
   result.markers =
-    createTrafficLightMarkers(tf_map2camera_closest, camera_info.header, visible_traffic_lights);
+    create_traffic_light_markers(tf_map2camera_closest, camera_info.header, visible_traffic_lights);
 
   return result;
 }
 
-void TrafficLightMapBasedDetector::getVisibleTrafficLights(
+void TrafficLightMapBasedDetector::get_visible_traffic_lights(
   const TrafficLightSet & all_traffic_lights,
   const std::vector<StampedTransform> & tf_map2camera_samples,
   const image_geometry::PinholeCameraModel & pinhole_camera_model,
@@ -248,19 +248,19 @@ void TrafficLightMapBasedDetector::getVisibleTrafficLights(
     for (const auto & sample : tf_map2camera_samples) {
       const auto & tf_map2camera = sample.transform;
       // check distance range
-      if (!utils::isInDistanceRange(
+      if (!utils::is_in_distance_range(
             traffic_light_center, tf_map2camera.getOrigin(), config_.max_detection_range)) {
         continue;
       }
 
       // check angle range
       // adjust tl_yaw so that perpendicular to ray means 0 angle difference
-      double traffic_light_yaw = utils::getTrafficLightYaw(traffic_light);
+      double traffic_light_yaw = utils::get_traffic_light_yaw(traffic_light);
       traffic_light_yaw =
         autoware_utils::normalize_radian(traffic_light_yaw + M_PI_2);  // adjust to perpendicular
       // get camera yaw
-      const double camera_yaw = utils::getCameraYaw(tf_map2camera);
-      if (!utils::isInAngleRange(traffic_light_yaw, camera_yaw, max_angle_range)) {
+      const double camera_yaw = utils::get_camera_yaw(tf_map2camera);
+      if (!utils::is_in_angle_range(traffic_light_yaw, camera_yaw, max_angle_range)) {
         continue;
       }
 
@@ -270,8 +270,8 @@ void TrafficLightMapBasedDetector::getVisibleTrafficLights(
       tf2::Vector3 bottom_right_camera_optical =
         tf_map2camera.inverse() * traffic_light_utils::getTrafficLightBottomRight(traffic_light);
       if (
-        !utils::isInImageFrame(pinhole_camera_model, top_left_camera_optical) &&
-        !utils::isInImageFrame(pinhole_camera_model, bottom_right_camera_optical)) {
+        !utils::is_in_image_frame(pinhole_camera_model, top_left_camera_optical) &&
+        !utils::is_in_image_frame(pinhole_camera_model, bottom_right_camera_optical)) {
         continue;
       }
       visible_traffic_lights.push_back(traffic_light);
@@ -280,7 +280,7 @@ void TrafficLightMapBasedDetector::getVisibleTrafficLights(
   }
 }
 
-bool TrafficLightMapBasedDetector::getTrafficLightRoi(
+bool TrafficLightMapBasedDetector::get_traffic_light_roi(
   const tf2::Transform & tf_map2camera,
   const image_geometry::PinholeCameraModel & pinhole_camera_model,
   const lanelet::ConstLineString3d traffic_light, const TrafficLightMapBasedDetectorConfig & config,
@@ -298,7 +298,7 @@ bool TrafficLightMapBasedDetector::getTrafficLightRoi(
     tf2::Vector3 top_left_map = traffic_light_utils::getTrafficLightTopLeft(traffic_light);
     tf2::Vector3 top_left_camera_optical = tf_map2camera.inverse() * top_left_map;
     // max vibration
-    tf2::Vector3 margin = utils::getVibrationMargin(
+    tf2::Vector3 margin = utils::get_vibration_margin(
       top_left_camera_optical.z(), config.max_vibration_pitch, config.max_vibration_yaw,
       config.max_vibration_height, config.max_vibration_width, config.max_vibration_depth);
     tf2::Vector3 point3d = top_left_camera_optical - margin;
@@ -307,8 +307,8 @@ bool TrafficLightMapBasedDetector::getTrafficLightRoi(
     }
     // enlarged target position in camera coordinate
     {
-      cv::Point2d point2d = utils::calcRawImagePointFromPoint3D(pinhole_camera_model, point3d);
-      utils::roundInImageFrame(
+      cv::Point2d point2d = utils::calc_raw_image_point_from_point_3d(pinhole_camera_model, point3d);
+      utils::round_in_image_frame(
         pinhole_camera_model.cameraInfo().width, pinhole_camera_model.cameraInfo().height, point2d);
       roi.roi.x_offset = point2d.x;
       roi.roi.y_offset = point2d.y;
@@ -320,7 +320,7 @@ bool TrafficLightMapBasedDetector::getTrafficLightRoi(
     tf2::Vector3 bottom_right_map = traffic_light_utils::getTrafficLightBottomRight(traffic_light);
     tf2::Vector3 bottom_right_camera_optical = tf_map2camera.inverse() * bottom_right_map;
     // max vibration
-    tf2::Vector3 margin = utils::getVibrationMargin(
+    tf2::Vector3 margin = utils::get_vibration_margin(
       bottom_right_camera_optical.z(), config.max_vibration_pitch, config.max_vibration_yaw,
       config.max_vibration_height, config.max_vibration_width, config.max_vibration_depth);
     tf2::Vector3 point3d = bottom_right_camera_optical + margin;
@@ -329,8 +329,8 @@ bool TrafficLightMapBasedDetector::getTrafficLightRoi(
     }
     // enlarged target position in camera coordinate
     {
-      cv::Point2d point2d = utils::calcRawImagePointFromPoint3D(pinhole_camera_model, point3d);
-      utils::roundInImageFrame(
+      cv::Point2d point2d = utils::calc_raw_image_point_from_point_3d(pinhole_camera_model, point3d);
+      utils::round_in_image_frame(
         pinhole_camera_model.cameraInfo().width, pinhole_camera_model.cameraInfo().height, point2d);
       roi.roi.width = point2d.x - roi.roi.x_offset;
       roi.roi.height = point2d.y - roi.roi.y_offset;
@@ -343,7 +343,7 @@ bool TrafficLightMapBasedDetector::getTrafficLightRoi(
   return true;
 }
 
-bool TrafficLightMapBasedDetector::getTrafficLightRoi(
+bool TrafficLightMapBasedDetector::get_traffic_light_roi(
   const std::vector<StampedTransform> & tf_map2camera_samples,
   const image_geometry::PinholeCameraModel & pinhole_camera_model,
   const lanelet::ConstLineString3d traffic_light, const TrafficLightMapBasedDetectorConfig & config,
@@ -353,7 +353,7 @@ bool TrafficLightMapBasedDetector::getTrafficLightRoi(
   for (const auto & sample : tf_map2camera_samples) {
     const auto & tf_map2camera = sample.transform;
     tier4_perception_msgs::msg::TrafficLightRoi roi;
-    if (getTrafficLightRoi(tf_map2camera, pinhole_camera_model, traffic_light, config, roi)) {
+    if (get_traffic_light_roi(tf_map2camera, pinhole_camera_model, traffic_light, config, roi)) {
       rois.push_back(roi);
     }
   }
@@ -361,13 +361,13 @@ bool TrafficLightMapBasedDetector::getTrafficLightRoi(
     return false;
   }
   out_roi = rois.front();
-  utils::computeBoundingRoi(
+  utils::compute_bounding_roi(
     pinhole_camera_model.cameraInfo().width, pinhole_camera_model.cameraInfo().height, rois,
     out_roi);
   return true;
 }
 
-visualization_msgs::msg::MarkerArray TrafficLightMapBasedDetector::createTrafficLightMarkers(
+visualization_msgs::msg::MarkerArray TrafficLightMapBasedDetector::create_traffic_light_markers(
   const tf2::Transform & tf_map2camera, const std_msgs::msg::Header & camera_header,
   const std::vector<lanelet::ConstLineString3d> & visible_traffic_lights)
 {

--- a/perception/autoware_traffic_light_map_based_detector/src/traffic_light_map_based_detector.cpp
+++ b/perception/autoware_traffic_light_map_based_detector/src/traffic_light_map_based_detector.cpp
@@ -307,7 +307,8 @@ bool TrafficLightMapBasedDetector::get_traffic_light_roi(
     }
     // enlarged target position in camera coordinate
     {
-      cv::Point2d point2d = utils::calc_raw_image_point_from_point_3d(pinhole_camera_model, point3d);
+      cv::Point2d point2d =
+        utils::calc_raw_image_point_from_point_3d(pinhole_camera_model, point3d);
       utils::round_in_image_frame(
         pinhole_camera_model.cameraInfo().width, pinhole_camera_model.cameraInfo().height, point2d);
       roi.roi.x_offset = point2d.x;
@@ -329,7 +330,8 @@ bool TrafficLightMapBasedDetector::get_traffic_light_roi(
     }
     // enlarged target position in camera coordinate
     {
-      cv::Point2d point2d = utils::calc_raw_image_point_from_point_3d(pinhole_camera_model, point3d);
+      cv::Point2d point2d =
+        utils::calc_raw_image_point_from_point_3d(pinhole_camera_model, point3d);
       utils::round_in_image_frame(
         pinhole_camera_model.cameraInfo().width, pinhole_camera_model.cameraInfo().height, point2d);
       roi.roi.width = point2d.x - roi.roi.x_offset;

--- a/perception/autoware_traffic_light_map_based_detector/src/traffic_light_map_based_detector.hpp
+++ b/perception/autoware_traffic_light_map_based_detector/src/traffic_light_map_based_detector.hpp
@@ -89,7 +89,7 @@ public:
     const TrafficLightMapBasedDetectorConfig & config,
     const autoware_map_msgs::msg::LaneletMapBin & map_msg);
 
-  std::optional<SetRouteError> setRoute(
+  std::optional<SetRouteError> set_route(
     const autoware_planning_msgs::msg::LaneletRoute & route_msg);
 
   DetectionResult detect(
@@ -97,7 +97,7 @@ public:
     const sensor_msgs::msg::CameraInfo & camera_info) const;
 
 private:
-  void setMap(const autoware_map_msgs::msg::LaneletMapBin & map_msg);
+  void set_map(const autoware_map_msgs::msg::LaneletMapBin & map_msg);
 
   /**
    * @brief Filter traffic lights that are visible from the camera
@@ -107,7 +107,7 @@ private:
    * @param pinhole_camera_model    pinhole model calculated from camera_info
    * @param visible_traffic_lights  the visible traffic lights output
    */
-  void getVisibleTrafficLights(
+  void get_visible_traffic_lights(
     const TrafficLightSet & all_traffic_lights,
     const std::vector<StampedTransform> & tf_map2camera_samples,
     const image_geometry::PinholeCameraModel & pinhole_camera_model,
@@ -124,7 +124,7 @@ private:
    * @return true                 the computation succeeded
    * @return false                the computation failed
    */
-  bool getTrafficLightRoi(
+  bool get_traffic_light_roi(
     const tf2::Transform & tf_map2camera,
     const image_geometry::PinholeCameraModel & pinhole_camera_model,
     const lanelet::ConstLineString3d traffic_light,
@@ -142,7 +142,7 @@ private:
    * @return true                 the computation succeeded
    * @return false                the computation failed
    */
-  bool getTrafficLightRoi(
+  bool get_traffic_light_roi(
     const std::vector<StampedTransform> & tf_map2camera_samples,
     const image_geometry::PinholeCameraModel & pinhole_camera_model,
     const lanelet::ConstLineString3d traffic_light,
@@ -157,7 +157,7 @@ private:
    * @param visible_traffic_lights  the visible traffic light object vector
    * @return visualization marker array
    */
-  static visualization_msgs::msg::MarkerArray createTrafficLightMarkers(
+  static visualization_msgs::msg::MarkerArray create_traffic_light_markers(
     const tf2::Transform & tf_map2camera, const std_msgs::msg::Header & camera_header,
     const std::vector<lanelet::ConstLineString3d> & visible_traffic_lights);
 

--- a/perception/autoware_traffic_light_map_based_detector/src/traffic_light_map_based_detector_node.cpp
+++ b/perception/autoware_traffic_light_map_based_detector/src/traffic_light_map_based_detector_node.cpp
@@ -63,13 +63,13 @@ MapBasedDetector::MapBasedDetector(const rclcpp::NodeOptions & node_options)
   // subscribers
   map_sub_ = create_subscription<autoware_map_msgs::msg::LaneletMapBin>(
     "~/input/vector_map", rclcpp::QoS{1}.transient_local(),
-    std::bind(&MapBasedDetector::mapCallback, this, _1));
+    std::bind(&MapBasedDetector::map_callback, this, _1));
   camera_info_sub_ = create_subscription<sensor_msgs::msg::CameraInfo>(
     "~/input/camera_info", rclcpp::SensorDataQoS(),
-    std::bind(&MapBasedDetector::cameraInfoCallback, this, _1));
+    std::bind(&MapBasedDetector::camera_info_callback, this, _1));
   route_sub_ = create_subscription<autoware_planning_msgs::msg::LaneletRoute>(
     "~/input/route", rclcpp::QoS{1}.transient_local(),
-    std::bind(&MapBasedDetector::routeCallback, this, _1));
+    std::bind(&MapBasedDetector::route_callback, this, _1));
 
   // publishers
   roi_pub_ =
@@ -79,7 +79,7 @@ MapBasedDetector::MapBasedDetector(const rclcpp::NodeOptions & node_options)
   viz_pub_ = this->create_publisher<visualization_msgs::msg::MarkerArray>("~/debug/markers", 1);
 }
 
-bool MapBasedDetector::getTransform(
+bool MapBasedDetector::get_transform(
   const rclcpp::Time & t, const std::string & frame_id, tf2::Transform & tf) const
 {
   try {
@@ -92,7 +92,7 @@ bool MapBasedDetector::getTransform(
   return true;
 }
 
-void MapBasedDetector::cameraInfoCallback(
+void MapBasedDetector::camera_info_callback(
   const sensor_msgs::msg::CameraInfo::ConstSharedPtr input_msg)
 {
   if (!detector_) {
@@ -108,13 +108,13 @@ void MapBasedDetector::cameraInfoCallback(
   rclcpp::Duration interval = rclcpp::Duration::from_seconds(0.01);
   for (auto t = t1; t <= t2; t += interval) {
     tf2::Transform tf;
-    if (getTransform(t, input_msg->header.frame_id, tf)) {
+    if (get_transform(t, input_msg->header.frame_id, tf)) {
       tf_map2camera_samples.push_back({t, tf});
     }
   }
   /* Camera pose at the exact moment */
   tf2::Transform tf_map2camera;
-  if (!getTransform(
+  if (!get_transform(
         rclcpp::Time(input_msg->header.stamp), input_msg->header.frame_id, tf_map2camera)) {
     RCLCPP_WARN_THROTTLE(
       get_logger(), *get_clock(), 5000, "failed to get transform from map frame to camera frame");
@@ -129,20 +129,20 @@ void MapBasedDetector::cameraInfoCallback(
   viz_pub_->publish(result.markers);
 }
 
-void MapBasedDetector::mapCallback(
+void MapBasedDetector::map_callback(
   const autoware_map_msgs::msg::LaneletMapBin::ConstSharedPtr input_msg)
 {
   detector_ = std::make_unique<TrafficLightMapBasedDetector>(detector_config_, *input_msg);
 }
 
-void MapBasedDetector::routeCallback(
+void MapBasedDetector::route_callback(
   const autoware_planning_msgs::msg::LaneletRoute::ConstSharedPtr input_msg)
 {
   if (!detector_) {
     RCLCPP_WARN(get_logger(), "failed to set traffic lights in route: map not received");
     return;
   }
-  auto error = detector_->setRoute(*input_msg);
+  auto error = detector_->set_route(*input_msg);
   if (error) {
     RCLCPP_ERROR(get_logger(), "%s", error->message.c_str());
   }

--- a/perception/autoware_traffic_light_map_based_detector/src/traffic_light_map_based_detector_node.hpp
+++ b/perception/autoware_traffic_light_map_based_detector/src/traffic_light_map_based_detector_node.hpp
@@ -58,11 +58,11 @@ private:
   TrafficLightMapBasedDetectorConfig detector_config_;
   TransformSamplingConfig transform_sampling_config_;
 
-  bool getTransform(
+  bool get_transform(
     const rclcpp::Time & t, const std::string & frame_id, tf2::Transform & tf) const;
-  void mapCallback(const autoware_map_msgs::msg::LaneletMapBin::ConstSharedPtr input_msg);
-  void cameraInfoCallback(const sensor_msgs::msg::CameraInfo::ConstSharedPtr input_msg);
-  void routeCallback(const autoware_planning_msgs::msg::LaneletRoute::ConstSharedPtr input_msg);
+  void map_callback(const autoware_map_msgs::msg::LaneletMapBin::ConstSharedPtr input_msg);
+  void camera_info_callback(const sensor_msgs::msg::CameraInfo::ConstSharedPtr input_msg);
+  void route_callback(const autoware_planning_msgs::msg::LaneletRoute::ConstSharedPtr input_msg);
 };
 }  // namespace autoware::traffic_light
 #endif  // TRAFFIC_LIGHT_MAP_BASED_DETECTOR_NODE_HPP_

--- a/perception/autoware_traffic_light_map_based_detector/src/traffic_light_map_based_detector_process.cpp
+++ b/perception/autoware_traffic_light_map_based_detector/src/traffic_light_map_based_detector_process.cpp
@@ -57,7 +57,8 @@ bool is_in_distance_range(
   return sq_dist < (max_distance_range * max_distance_range);
 }
 
-bool is_in_angle_range(const double & tl_yaw, const double & camera_yaw, const double max_angle_range)
+bool is_in_angle_range(
+  const double & tl_yaw, const double & camera_yaw, const double max_angle_range)
 {
   Eigen::Vector2d vec1, vec2;
   vec1 << std::cos(tl_yaw), std::sin(tl_yaw);

--- a/perception/autoware_traffic_light_map_based_detector/src/traffic_light_map_based_detector_process.cpp
+++ b/perception/autoware_traffic_light_map_based_detector/src/traffic_light_map_based_detector_process.cpp
@@ -29,27 +29,27 @@ namespace autoware::traffic_light
 namespace utils
 {
 
-cv::Point2d calcRawImagePointFromPoint3D(
+cv::Point2d calc_raw_image_point_from_point_3d(
   const image_geometry::PinholeCameraModel & pinhole_camera_model, const cv::Point3d & point3d)
 {
   cv::Point2d rectified_image_point = pinhole_camera_model.project3dToPixel(point3d);
   return pinhole_camera_model.unrectifyPoint(rectified_image_point);
 }
 
-cv::Point2d calcRawImagePointFromPoint3D(
+cv::Point2d calc_raw_image_point_from_point_3d(
   const image_geometry::PinholeCameraModel & pinhole_camera_model, const tf2::Vector3 & point3d)
 {
-  return calcRawImagePointFromPoint3D(
+  return calc_raw_image_point_from_point_3d(
     pinhole_camera_model, cv::Point3d(point3d.x(), point3d.y(), point3d.z()));
 }
 
-void roundInImageFrame(const uint32_t & width, const uint32_t & height, cv::Point2d & point)
+void round_in_image_frame(const uint32_t & width, const uint32_t & height, cv::Point2d & point)
 {
   point.x = std::max(std::min(point.x, static_cast<double>(static_cast<int>(width) - 1)), 0.0);
   point.y = std::max(std::min(point.y, static_cast<double>(static_cast<int>(height) - 1)), 0.0);
 }
 
-bool isInDistanceRange(
+bool is_in_distance_range(
   const tf2::Vector3 & p1, const tf2::Vector3 & p2, const double max_distance_range)
 {
   const double sq_dist =
@@ -57,7 +57,7 @@ bool isInDistanceRange(
   return sq_dist < (max_distance_range * max_distance_range);
 }
 
-bool isInAngleRange(const double & tl_yaw, const double & camera_yaw, const double max_angle_range)
+bool is_in_angle_range(const double & tl_yaw, const double & camera_yaw, const double max_angle_range)
 {
   Eigen::Vector2d vec1, vec2;
   vec1 << std::cos(tl_yaw), std::sin(tl_yaw);
@@ -66,14 +66,14 @@ bool isInAngleRange(const double & tl_yaw, const double & camera_yaw, const doub
   return std::fabs(diff_angle) < max_angle_range;
 }
 
-bool isInImageFrame(
+bool is_in_image_frame(
   const image_geometry::PinholeCameraModel & pinhole_camera_model, const tf2::Vector3 & point)
 {
   if (point.z() <= 0.0) {
     return false;
   }
 
-  cv::Point2d point2d = calcRawImagePointFromPoint3D(pinhole_camera_model, point);
+  cv::Point2d point2d = calc_raw_image_point_from_point_3d(pinhole_camera_model, point);
   if (0 <= point2d.x && point2d.x < pinhole_camera_model.cameraInfo().width) {
     if (0 <= point2d.y && point2d.y < pinhole_camera_model.cameraInfo().height) {
       return true;
@@ -82,7 +82,7 @@ bool isInImageFrame(
   return false;
 }
 
-tf2::Vector3 getVibrationMargin(
+tf2::Vector3 get_vibration_margin(
   const double depth, const double margin_pitch, const double margin_yaw,
   const double margin_height, const double margin_width, const double margin_depth)
 {
@@ -93,7 +93,7 @@ tf2::Vector3 getVibrationMargin(
   return tf2::Vector3(x, y, z);
 }
 
-void computeBoundingRoi(
+void compute_bounding_roi(
   const uint32_t & width, const uint32_t & height,
   const std::vector<tier4_perception_msgs::msg::TrafficLightRoi> & rois,
   tier4_perception_msgs::msg::TrafficLightRoi & max_roi)
@@ -114,14 +114,14 @@ void computeBoundingRoi(
   max_roi.roi.height = y2 - y1;
 }
 
-double getTrafficLightYaw(const lanelet::ConstLineString3d & traffic_light)
+double get_traffic_light_yaw(const lanelet::ConstLineString3d & traffic_light)
 {
   const auto & tl_tl = traffic_light.front();
   const auto & tl_br = traffic_light.back();
   return autoware_utils::normalize_radian(std::atan2(tl_br.y() - tl_tl.y(), tl_br.x() - tl_tl.x()));
 }
 
-double getCameraYaw(const tf2::Transform & tf_map2camera)
+double get_camera_yaw(const tf2::Transform & tf_map2camera)
 {
   tf2::Vector3 ray_camera_optical(0, 0, 1);
   tf2::Matrix3x3 map2camera_optical(tf_map2camera.getRotation());

--- a/perception/autoware_traffic_light_map_based_detector/src/traffic_light_map_based_detector_process.hpp
+++ b/perception/autoware_traffic_light_map_based_detector/src/traffic_light_map_based_detector_process.hpp
@@ -48,7 +48,8 @@ void round_in_image_frame(const uint32_t & width, const uint32_t & height, cv::P
 bool is_in_distance_range(
   const tf2::Vector3 & p1, const tf2::Vector3 & p2, const double max_distance_range);
 
-bool is_in_angle_range(const double & tl_yaw, const double & camera_yaw, const double max_angle_range);
+bool is_in_angle_range(
+  const double & tl_yaw, const double & camera_yaw, const double max_angle_range);
 
 bool is_in_image_frame(
   const image_geometry::PinholeCameraModel & pinhole_camera_model, const tf2::Vector3 & point);

--- a/perception/autoware_traffic_light_map_based_detector/src/traffic_light_map_based_detector_process.hpp
+++ b/perception/autoware_traffic_light_map_based_detector/src/traffic_light_map_based_detector_process.hpp
@@ -37,35 +37,35 @@ namespace autoware::traffic_light
 namespace utils
 {
 
-cv::Point2d calcRawImagePointFromPoint3D(
+cv::Point2d calc_raw_image_point_from_point_3d(
   const image_geometry::PinholeCameraModel & pinhole_camera_model, const cv::Point3d & point3d);
 
-cv::Point2d calcRawImagePointFromPoint3D(
+cv::Point2d calc_raw_image_point_from_point_3d(
   const image_geometry::PinholeCameraModel & pinhole_camera_model, const tf2::Vector3 & point3d);
 
-void roundInImageFrame(const uint32_t & width, const uint32_t & height, cv::Point2d & point);
+void round_in_image_frame(const uint32_t & width, const uint32_t & height, cv::Point2d & point);
 
-bool isInDistanceRange(
+bool is_in_distance_range(
   const tf2::Vector3 & p1, const tf2::Vector3 & p2, const double max_distance_range);
 
-bool isInAngleRange(const double & tl_yaw, const double & camera_yaw, const double max_angle_range);
+bool is_in_angle_range(const double & tl_yaw, const double & camera_yaw, const double max_angle_range);
 
-bool isInImageFrame(
+bool is_in_image_frame(
   const image_geometry::PinholeCameraModel & pinhole_camera_model, const tf2::Vector3 & point);
 
 // Calculated in the camera optical frame but yaw and pitch are in the camera frame
-tf2::Vector3 getVibrationMargin(
+tf2::Vector3 get_vibration_margin(
   const double depth, const double margin_pitch, const double margin_yaw,
   const double margin_height, const double margin_width, const double margin_depth);
 
-void computeBoundingRoi(
+void compute_bounding_roi(
   const uint32_t & width, const uint32_t & height,
   const std::vector<tier4_perception_msgs::msg::TrafficLightRoi> & rois,
   tier4_perception_msgs::msg::TrafficLightRoi & max_roi);
 
-double getTrafficLightYaw(const lanelet::ConstLineString3d & traffic_light);
+double get_traffic_light_yaw(const lanelet::ConstLineString3d & traffic_light);
 
-double getCameraYaw(const tf2::Transform & tf_map2camera);
+double get_camera_yaw(const tf2::Transform & tf_map2camera);
 
 }  // namespace utils
 }  // namespace autoware::traffic_light

--- a/perception/autoware_traffic_light_map_based_detector/test/test_traffic_light_map_based_detector.cpp
+++ b/perception/autoware_traffic_light_map_based_detector/test/test_traffic_light_map_based_detector.cpp
@@ -425,7 +425,7 @@ TEST(TrafficLightMapBasedDetectorTest, SetRouteWithUnknownLaneletIdReturnsError)
   TrafficLightMapBasedDetector detector(config, map);
 
   // Act
-  const auto error = detector.setRoute(make_route(99999999));
+  const auto error = detector.set_route(make_route(99999999));
 
   // Assert
   ASSERT_TRUE(error.has_value());
@@ -445,7 +445,7 @@ TEST(TrafficLightMapBasedDetectorTest, SetRouteWithKnownLaneletIdSucceedsAndDete
   const auto route = make_route(get_road_lanelet_ids(map)[0]);
 
   // Act
-  const auto error = detector.setRoute(route);
+  const auto error = detector.set_route(route);
   const auto result = detector.detect(tf_samples, camera_info);
 
   // Assert

--- a/perception/autoware_traffic_light_map_based_detector/test/test_utils.cpp
+++ b/perception/autoware_traffic_light_map_based_detector/test/test_utils.cpp
@@ -22,83 +22,83 @@
 
 #include <vector>
 
-TEST(roundInImageFrame, no_round)
+TEST(RoundInImageFrameTest, NoRound)
 {
   const uint32_t width = 1440;
   const uint32_t height = 1080;
   cv::Point2d point2d(1.0, 2.0);
-  autoware::traffic_light::utils::roundInImageFrame(width, height, point2d);
+  autoware::traffic_light::utils::round_in_image_frame(width, height, point2d);
   EXPECT_EQ(point2d.x, 1.0);
   EXPECT_EQ(point2d.y, 2.0);
 }
 
-TEST(roundInImageFrame, out_of_range_bottom_right)
+TEST(RoundInImageFrameTest, OutOfRangeBottomRight)
 {
   const uint32_t width = 1440;
   const uint32_t height = 1080;
   cv::Point2d point2d(1500.0, 1100.0);
-  autoware::traffic_light::utils::roundInImageFrame(width, height, point2d);
+  autoware::traffic_light::utils::round_in_image_frame(width, height, point2d);
   EXPECT_EQ(point2d.x, 1439.0);
   EXPECT_EQ(point2d.y, 1079.0);
 }
 
-TEST(roundInImageFrame, out_of_range_top_left)
+TEST(RoundInImageFrameTest, OutOfRangeTopLeft)
 {
   const uint32_t width = 1440;
   const uint32_t height = 1080;
   cv::Point2d point2d(-1.5, -2.5);
-  autoware::traffic_light::utils::roundInImageFrame(width, height, point2d);
+  autoware::traffic_light::utils::round_in_image_frame(width, height, point2d);
   EXPECT_EQ(point2d.x, 0.0);
   EXPECT_EQ(point2d.y, 0.0);
 }
 
-TEST(isInDistanceRange, in_range)
+TEST(IsInDistanceRangeTest, InRange)
 {
   const tf2::Vector3 v1(1.0, 1.0, 3.0);
   const tf2::Vector3 v2(4.0, 5.0, 6.0);
   const double max_distance_range = 6.0;
-  const bool result = autoware::traffic_light::utils::isInDistanceRange(v1, v2, max_distance_range);
+  const bool result = autoware::traffic_light::utils::is_in_distance_range(v1, v2, max_distance_range);
   EXPECT_TRUE(result);
 }
 
-TEST(isInDistanceRange, out_of_range)
+TEST(IsInDistanceRangeTest, OutOfRange)
 {
   const tf2::Vector3 v1(1.0, 1.0, 3.0);
   const tf2::Vector3 v2(4.0, 5.0, 6.0);
   const double max_distance_range = 5.0;
-  const bool result = autoware::traffic_light::utils::isInDistanceRange(v1, v2, max_distance_range);
+  const bool result = autoware::traffic_light::utils::is_in_distance_range(v1, v2, max_distance_range);
   EXPECT_FALSE(result);
 }
 
-TEST(isInAngleRange, in_range)
+TEST(IsInAngleRangeTest, InRange)
 {
   const double tl_yaw = M_PI / 2;
   const double camera_yaw = M_PI;
   const double max_angle_range = M_PI;
   const bool result =
-    autoware::traffic_light::utils::isInAngleRange(tl_yaw, camera_yaw, max_angle_range);
+    autoware::traffic_light::utils::is_in_angle_range(tl_yaw, camera_yaw, max_angle_range);
   EXPECT_TRUE(result);
 }
 
-TEST(isInAngleRange, out_of_range)
+TEST(IsInAngleRangeTest, OutOfRange)
 {
   const double tl_yaw = M_PI / 2;
   const double camera_yaw = M_PI;
   const double max_angle_range = M_PI / 4;
-  bool result = autoware::traffic_light::utils::isInAngleRange(tl_yaw, camera_yaw, max_angle_range);
+  bool result = autoware::traffic_light::utils::is_in_angle_range(tl_yaw, camera_yaw, max_angle_range);
   EXPECT_FALSE(result);
 }
 
-TEST(isInAngleRange, in_range_boundary)
+TEST(IsInAngleRangeTest, InRangeBoundary)
 {
   const double tl_yaw = M_PI - M_PI / 16;
   const double camera_yaw = -M_PI + M_PI / 16;
   const double max_angle_range = M_PI / 4;
-  bool result = autoware::traffic_light::utils::isInAngleRange(tl_yaw, camera_yaw, max_angle_range);
+  bool result = autoware::traffic_light::utils::is_in_angle_range(tl_yaw, camera_yaw, max_angle_range);
   EXPECT_TRUE(result);
 }
 
-TEST(getVibrationMargin, calculate)
+TEST(GetVibrationMarginTest, Calculate)
 {
   const tf2::Vector3 position(10.0, 20.0, 100.0);
   const double margin_pitch = 0.01745329251;  // 1 degree in radians
@@ -107,7 +107,7 @@ TEST(getVibrationMargin, calculate)
   const double margin_width = 0.4;
   const double margin_depth = 0.5;
 
-  const tf2::Vector3 result = autoware::traffic_light::utils::getVibrationMargin(
+  const tf2::Vector3 result = autoware::traffic_light::utils::get_vibration_margin(
     position.z(), margin_pitch, margin_yaw, margin_height, margin_width, margin_depth);
 
   EXPECT_FLOAT_EQ(result.x(), 1.945240643);
@@ -115,7 +115,7 @@ TEST(getVibrationMargin, calculate)
   EXPECT_FLOAT_EQ(result.z(), 0.25);
 }
 
-TEST(computeBoundingRoi, select)
+TEST(ComputeBoundingRoiTest, Select)
 {
   const uint32_t width = 1440;
   const uint32_t height = 1080;
@@ -146,7 +146,7 @@ TEST(computeBoundingRoi, select)
     rois.push_back(roi);
   }
 
-  autoware::traffic_light::utils::computeBoundingRoi(width, height, rois, max_roi);
+  autoware::traffic_light::utils::compute_bounding_roi(width, height, rois, max_roi);
   EXPECT_EQ(max_roi.roi.x_offset, 0);
   EXPECT_EQ(max_roi.roi.y_offset, 0);
   const uint32_t expected_width = 10 + 160 - 0;
@@ -155,12 +155,12 @@ TEST(computeBoundingRoi, select)
   EXPECT_EQ(max_roi.roi.height, expected_height);
 }
 
-TEST(getCameraYaw, calculate)
+TEST(GetCameraYawTest, Calculate)
 {
   tf2::Quaternion q;
   q.setRPY(M_PI / 2.0, 0.0, 0.0);
   const tf2::Transform tf_map2camera(q, tf2::Vector3(1.0, 2.0, 3.0));
-  const double result = autoware::traffic_light::utils::getCameraYaw(tf_map2camera);
+  const double result = autoware::traffic_light::utils::get_camera_yaw(tf_map2camera);
   const double expected_yaw = -M_PI / 2.0;
   EXPECT_FLOAT_EQ(result, expected_yaw);
 }

--- a/perception/autoware_traffic_light_map_based_detector/test/test_utils.cpp
+++ b/perception/autoware_traffic_light_map_based_detector/test/test_utils.cpp
@@ -57,7 +57,8 @@ TEST(IsInDistanceRangeTest, InRange)
   const tf2::Vector3 v1(1.0, 1.0, 3.0);
   const tf2::Vector3 v2(4.0, 5.0, 6.0);
   const double max_distance_range = 6.0;
-  const bool result = autoware::traffic_light::utils::is_in_distance_range(v1, v2, max_distance_range);
+  const bool result =
+    autoware::traffic_light::utils::is_in_distance_range(v1, v2, max_distance_range);
   EXPECT_TRUE(result);
 }
 
@@ -66,7 +67,8 @@ TEST(IsInDistanceRangeTest, OutOfRange)
   const tf2::Vector3 v1(1.0, 1.0, 3.0);
   const tf2::Vector3 v2(4.0, 5.0, 6.0);
   const double max_distance_range = 5.0;
-  const bool result = autoware::traffic_light::utils::is_in_distance_range(v1, v2, max_distance_range);
+  const bool result =
+    autoware::traffic_light::utils::is_in_distance_range(v1, v2, max_distance_range);
   EXPECT_FALSE(result);
 }
 
@@ -85,7 +87,8 @@ TEST(IsInAngleRangeTest, OutOfRange)
   const double tl_yaw = M_PI / 2;
   const double camera_yaw = M_PI;
   const double max_angle_range = M_PI / 4;
-  bool result = autoware::traffic_light::utils::is_in_angle_range(tl_yaw, camera_yaw, max_angle_range);
+  bool result =
+    autoware::traffic_light::utils::is_in_angle_range(tl_yaw, camera_yaw, max_angle_range);
   EXPECT_FALSE(result);
 }
 
@@ -94,7 +97,8 @@ TEST(IsInAngleRangeTest, InRangeBoundary)
   const double tl_yaw = M_PI - M_PI / 16;
   const double camera_yaw = -M_PI + M_PI / 16;
   const double max_angle_range = M_PI / 4;
-  bool result = autoware::traffic_light::utils::is_in_angle_range(tl_yaw, camera_yaw, max_angle_range);
+  bool result =
+    autoware::traffic_light::utils::is_in_angle_range(tl_yaw, camera_yaw, max_angle_range);
   EXPECT_TRUE(result);
 }
 


### PR DESCRIPTION
## Description

Rename camelCase function names to snake_case in the `autoware_traffic_light_map_based_detector` package to follow the Autoware C++ coding guideline:
<https://autowarefoundation.github.io/autoware-documentation/main/contributing/coding-guidelines/languages/cpp/#use-lower-snake-case-for-function-names-required-partially-automated>

Test suite/case names in `test_utils.cpp` are aligned to PascalCase to match the other test suites in this package and comply with Google Test naming guidance. No behavior changes.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

- `colcon build --packages-select autoware_traffic_light_map_based_detector`
- `colcon test --packages-select autoware_traffic_light_map_based_detector --event-handlers console_cohesion+` — all 7 tests pass.


## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
