### PR TITLE
perf(autoware_tensorrt_plugins): remove Thrust from sort kernels

### DIFF
--- a/perception/autoware_tensorrt_plugins/include/autoware/tensorrt_plugins/kernel_utils.hpp
+++ b/perception/autoware_tensorrt_plugins/include/autoware/tensorrt_plugins/kernel_utils.hpp
@@ -1,0 +1,41 @@
+// Copyright 2025 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__TENSORRT_PLUGINS__KERNEL_UTILS_HPP_
+#define AUTOWARE__TENSORRT_PLUGINS__KERNEL_UTILS_HPP_
+
+#include <cstddef>
+#include <cstdint>
+
+namespace autoware::tensorrt_plugins
+{
+
+inline std::size_t align_up(const std::size_t size, const std::size_t alignment)
+{
+  return ((size + alignment - 1U) / alignment) * alignment;
+}
+
+static __global__ void fill_iota(std::int64_t * output_out, const std::size_t num_elements_in)
+{
+  const auto index = static_cast<std::size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (index >= num_elements_in) {
+    return;
+  }
+
+  output_out[index] = static_cast<std::int64_t>(index);
+}
+
+}  // namespace autoware::tensorrt_plugins
+
+#endif  // AUTOWARE__TENSORRT_PLUGINS__KERNEL_UTILS_HPP_

--- a/perception/autoware_tensorrt_plugins/include/autoware/tensorrt_plugins/plugin_utils.hpp
+++ b/perception/autoware_tensorrt_plugins/include/autoware/tensorrt_plugins/plugin_utils.hpp
@@ -16,6 +16,7 @@
 #define AUTOWARE__TENSORRT_PLUGINS__PLUGIN_UTILS_HPP_
 
 #include <NvInferRuntime.h>
+#include <cuda_runtime_api.h>
 
 #include <cstdint>
 #include <exception>
@@ -25,6 +26,11 @@ void caughtError(std::exception const & e);
 void logDebug(char const * msg);
 
 void logWarning(char const * msg);
+
+cudaError_t reportCudaStatus(
+	cudaError_t status, char const * msg, char const * file, std::int32_t line);
+
+#define PLUGIN_CUDA_CHECK(val) reportCudaStatus((val), #val, __FILE__, __LINE__)
 
 #define PLUGIN_ASSERT(val) reportAssertion((val), #val, __FILE__, __LINE__)
 void reportAssertion(bool success, char const * msg, char const * file, std::int32_t line);

--- a/perception/autoware_tensorrt_plugins/include/autoware/tensorrt_plugins/plugin_utils.hpp
+++ b/perception/autoware_tensorrt_plugins/include/autoware/tensorrt_plugins/plugin_utils.hpp
@@ -28,7 +28,7 @@ void logDebug(char const * msg);
 void logWarning(char const * msg);
 
 cudaError_t reportCudaStatus(
-	cudaError_t status, char const * msg, char const * file, std::int32_t line);
+  cudaError_t status, char const * msg, char const * file, std::int32_t line);
 
 #define PLUGIN_CUDA_CHECK(val) reportCudaStatus((val), #val, __FILE__, __LINE__)
 

--- a/perception/autoware_tensorrt_plugins/include/autoware/unique_ops/unique.hpp
+++ b/perception/autoware_tensorrt_plugins/include/autoware/unique_ops/unique.hpp
@@ -20,28 +20,35 @@
 #include <cstddef>
 #include <cstdint>
 
-/// Computes sorted unique int64 values, inverse indices, and counts on `stream_in`.
+/// Computes sorted unique int64 values, inverse indices, counts, and the number of uniques on
+/// `stream_in`.
 ///
 /// Input contract:
 /// - `input_in` points to `num_input_elements_in` int64 values.
 /// - `unique_values_out`, `inverse_indices_out`, and `unique_counts_out` each point to at least
-///   `num_input_elements_in` int64 values. The true `unique_counts_out` length is the returned
-///   value, but the buffer must allow the worst case where every input is unique.
+///   `num_input_elements_in` int64 values. The true `unique_counts_out` length is written to
+///   `num_unique_elements_out`, but the buffer must allow the worst case where every input is
+///   unique.
+/// - `num_unique_elements_out` points to one int64 device scalar.
 /// - `workspace_inout` points to at least `workspace_size_in` bytes.
 /// - `workspace_size_in` must be no smaller than
 ///   `get_unique_workspace_size(num_input_elements_in)`.
-/// - All pointers are device pointers except the scalar return value.
+/// - All pointers are device pointers.
 ///
 /// Output contract:
-/// - Returns `num_unique`, the number of unique values found.
-/// - `unique_values_out[0:num_unique]` contains the input values in ascending order, with
-///   duplicates removed.
+/// - Returns `cudaSuccess` if all work was enqueued successfully; otherwise returns the first CUDA
+///   error encountered.
+/// - `unique_values_out[0:*num_unique_elements_out]` contains the input values in ascending order,
+///   with duplicates removed.
 /// - `inverse_indices_out[0:num_input_elements_in]` maps each original input element to its
 ///   `unique_values_out` index.
-/// - `unique_counts_out[0:num_unique]` contains the occurrence count for each unique value.
-std::int64_t unique(
+/// - `unique_counts_out[0:*num_unique_elements_out]` contains the occurrence count for each unique
+///   value.
+/// - `*num_unique_elements_out` contains the number of unique values found.
+cudaError_t unique(
   const std::int64_t * input_in, std::int64_t * unique_values_out,
-  std::int64_t * inverse_indices_out, std::int64_t * unique_counts_out, void * workspace_inout,
+  std::int64_t * inverse_indices_out, std::int64_t * unique_counts_out,
+  std::int64_t * num_unique_elements_out, void * workspace_inout,
   std::size_t num_input_elements_in, std::size_t workspace_size_in, cudaStream_t stream_in);
 
 /// Bytes of CUB temporary storage required by the largest CUB primitive used by `unique`.

--- a/perception/autoware_tensorrt_plugins/include/autoware/unique_ops/unique.hpp
+++ b/perception/autoware_tensorrt_plugins/include/autoware/unique_ops/unique.hpp
@@ -48,8 +48,8 @@
 cudaError_t unique(
   const std::int64_t * input_in, std::int64_t * unique_values_out,
   std::int64_t * inverse_indices_out, std::int64_t * unique_counts_out,
-  std::int64_t * num_unique_elements_out, void * workspace_inout,
-  std::size_t num_input_elements_in, std::size_t workspace_size_in, cudaStream_t stream_in);
+  std::int64_t * num_unique_elements_out, void * workspace_inout, std::size_t num_input_elements_in,
+  std::size_t workspace_size_in, cudaStream_t stream_in);
 
 /// Bytes of CUB temporary storage required by the largest CUB primitive used by `unique`.
 std::size_t get_unique_temp_storage_size(std::size_t num_elements_in);

--- a/perception/autoware_tensorrt_plugins/include/autoware/unique_ops/unique.hpp
+++ b/perception/autoware_tensorrt_plugins/include/autoware/unique_ops/unique.hpp
@@ -17,14 +17,38 @@
 
 #include <cuda_runtime_api.h>
 
+#include <cstddef>
 #include <cstdint>
 
+/// Computes sorted unique int64 values, inverse indices, and counts on `stream_in`.
+///
+/// Input contract:
+/// - `input_in` points to `num_input_elements_in` int64 values.
+/// - `unique_values_out`, `inverse_indices_out`, and `unique_counts_out` each point to at least
+///   `num_input_elements_in` int64 values. The true `unique_counts_out` length is the returned
+///   value, but the buffer must allow the worst case where every input is unique.
+/// - `workspace_inout` points to at least `workspace_size_in` bytes.
+/// - `workspace_size_in` must be no smaller than
+///   `get_unique_workspace_size(num_input_elements_in)`.
+/// - All pointers are device pointers except the scalar return value.
+///
+/// Output contract:
+/// - Returns `num_unique`, the number of unique values found.
+/// - `unique_values_out[0:num_unique]` contains the input values in ascending order, with
+///   duplicates removed.
+/// - `inverse_indices_out[0:num_input_elements_in]` maps each original input element to its
+///   `unique_values_out` index.
+/// - `unique_counts_out[0:num_unique]` contains the occurrence count for each unique value.
 std::int64_t unique(
-  const std::int64_t * input, std::int64_t * unique, std::int64_t * inverse_indices,
-  std::int64_t * unique_counts, void * workspace, std::size_t num_input_elements,
-  std::size_t workspace_size, cudaStream_t stream);
+  const std::int64_t * input_in, std::int64_t * unique_values_out,
+  std::int64_t * inverse_indices_out, std::int64_t * unique_counts_out, void * workspace_inout,
+  std::size_t num_input_elements_in, std::size_t workspace_size_in, cudaStream_t stream_in);
 
-std::size_t get_unique_temp_storage_size(std::size_t num_elements);
-std::size_t get_unique_workspace_size(std::size_t num_elements);
+/// Bytes of CUB temporary storage required by the largest CUB primitive used by `unique`.
+std::size_t get_unique_temp_storage_size(std::size_t num_elements_in);
+
+/// Total TensorRT workspace bytes required by `unique`, including CUB temporary storage and
+/// all variant-local scratch arrays.
+std::size_t get_unique_workspace_size(std::size_t num_elements_in);
 
 #endif  // AUTOWARE__UNIQUE_OPS__UNIQUE_HPP_

--- a/perception/autoware_tensorrt_plugins/include/autoware/unique_ops/unique.hpp
+++ b/perception/autoware_tensorrt_plugins/include/autoware/unique_ops/unique.hpp
@@ -24,6 +24,7 @@ std::int64_t unique(
   std::int64_t * unique_counts, void * workspace, std::size_t num_input_elements,
   std::size_t workspace_size, cudaStream_t stream);
 
+std::size_t get_unique_temp_storage_size(std::size_t num_elements);
 std::size_t get_unique_workspace_size(std::size_t num_elements);
 
 #endif  // AUTOWARE__UNIQUE_OPS__UNIQUE_HPP_

--- a/perception/autoware_tensorrt_plugins/src/argsort_ops/argsort.cu
+++ b/perception/autoware_tensorrt_plugins/src/argsort_ops/argsort.cu
@@ -17,6 +17,8 @@
 
 #include <cub/cub.cuh>
 
+#include <cstddef>
+
 namespace
 {
 
@@ -35,7 +37,7 @@ cudaError_t argsort(
   const auto scratch_offset =
     autoware::tensorrt_plugins::align_up(argsort_workspace_size, alignof(std::int64_t));
   auto * input_idx_d =
-    reinterpret_cast<std::int64_t *>(reinterpret_cast<char *>(workspace) + scratch_offset);
+    reinterpret_cast<std::int64_t *>(reinterpret_cast<std::byte *>(workspace) + scratch_offset);
   auto * input_sorted_d = input_idx_d + num_elements;
 
   const auto num_blocks =

--- a/perception/autoware_tensorrt_plugins/src/argsort_ops/argsort.cu
+++ b/perception/autoware_tensorrt_plugins/src/argsort_ops/argsort.cu
@@ -54,8 +54,7 @@ cudaError_t argsort(
   const auto num_blocks =
     static_cast<unsigned int>((num_elements + kThreadsPerBlock - 1U) / kThreadsPerBlock);
   fill_iota<<<num_blocks, kThreadsPerBlock, 0, stream>>>(input_idx_d, num_elements);
-  cudaError_t status = cudaGetLastError();
-  if (status != cudaSuccess) {
+  if (const auto status = cudaPeekAtLastError(); status != cudaSuccess) {
     return status;
   }
 

--- a/perception/autoware_tensorrt_plugins/src/argsort_ops/argsort.cu
+++ b/perception/autoware_tensorrt_plugins/src/argsort_ops/argsort.cu
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "autoware/argsort_ops/argsort.hpp"
+#include "autoware/tensorrt_plugins/kernel_utils.hpp"
 
 #include <cub/cub.cuh>
 
@@ -20,21 +21,6 @@ namespace
 {
 
 constexpr int kThreadsPerBlock = 256;
-
-std::size_t align_up(const std::size_t size, const std::size_t alignment)
-{
-  return ((size + alignment - 1U) / alignment) * alignment;
-}
-
-__global__ void fill_iota(std::int64_t * output, const std::size_t num_elements)
-{
-  const auto index = static_cast<std::size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
-  if (index >= num_elements) {
-    return;
-  }
-
-  output[index] = static_cast<std::int64_t>(index);
-}
 
 }  // namespace
 
@@ -46,14 +32,16 @@ cudaError_t argsort(
     return cudaSuccess;
   }
 
-  const auto scratch_offset = align_up(argsort_workspace_size, alignof(std::int64_t));
+  const auto scratch_offset =
+    autoware::tensorrt_plugins::align_up(argsort_workspace_size, alignof(std::int64_t));
   auto * input_idx_d =
     reinterpret_cast<std::int64_t *>(reinterpret_cast<char *>(workspace) + scratch_offset);
   auto * input_sorted_d = input_idx_d + num_elements;
 
   const auto num_blocks =
     static_cast<unsigned int>((num_elements + kThreadsPerBlock - 1U) / kThreadsPerBlock);
-  fill_iota<<<num_blocks, kThreadsPerBlock, 0, stream>>>(input_idx_d, num_elements);
+  autoware::tensorrt_plugins::fill_iota<<<num_blocks, kThreadsPerBlock, 0, stream>>>(
+    input_idx_d, num_elements);
   if (const auto status = cudaPeekAtLastError(); status != cudaSuccess) {
     return status;
   }

--- a/perception/autoware_tensorrt_plugins/src/argsort_ops/argsort.cu
+++ b/perception/autoware_tensorrt_plugins/src/argsort_ops/argsort.cu
@@ -16,25 +16,52 @@
 
 #include <cub/cub.cuh>
 
-#include <thrust/device_ptr.h>
-#include <thrust/execution_policy.h>
-#include <thrust/sequence.h>
+namespace
+{
+
+constexpr int kThreadsPerBlock = 256;
+
+std::size_t align_up(const std::size_t size, const std::size_t alignment)
+{
+  return ((size + alignment - 1U) / alignment) * alignment;
+}
+
+__global__ void fill_iota(std::int64_t * output, const std::size_t num_elements)
+{
+  const auto index = static_cast<std::size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (index >= num_elements) {
+    return;
+  }
+
+  output[index] = static_cast<std::int64_t>(index);
+}
+
+}  // namespace
 
 cudaError_t argsort(
   const std::int64_t * input_d, std::int64_t * output_d, void * workspace, std::size_t num_elements,
   std::size_t argsort_workspace_size, cudaStream_t stream)
 {
-  int workspace_offset = (argsort_workspace_size + sizeof(std::int64_t) - 1) / sizeof(std::int64_t);
-  thrust::device_ptr<std::int64_t> idx_ptr(
-    &reinterpret_cast<std::int64_t *>(workspace)[workspace_offset]);
+  if (num_elements == 0U) {
+    return cudaSuccess;
+  }
 
-  thrust::sequence(thrust::cuda::par.on(stream), idx_ptr, idx_ptr + num_elements, 0);
+  const auto scratch_offset = align_up(argsort_workspace_size, alignof(std::int64_t));
+  auto * input_idx_d =
+    reinterpret_cast<std::int64_t *>(reinterpret_cast<char *>(workspace) + scratch_offset);
+  auto * input_sorted_d = input_idx_d + num_elements;
 
-  std::int64_t * input_sorted_d = thrust::raw_pointer_cast(idx_ptr) + num_elements;
+  const auto num_blocks =
+    static_cast<unsigned int>((num_elements + kThreadsPerBlock - 1U) / kThreadsPerBlock);
+  fill_iota<<<num_blocks, kThreadsPerBlock, 0, stream>>>(input_idx_d, num_elements);
+  cudaError_t status = cudaGetLastError();
+  if (status != cudaSuccess) {
+    return status;
+  }
 
   return cub::DeviceRadixSort::SortPairs(
-    workspace, argsort_workspace_size, input_d, input_sorted_d, thrust::raw_pointer_cast(idx_ptr),
-    output_d, num_elements, 0, 64, stream);
+    workspace, argsort_workspace_size, input_d, input_sorted_d, input_idx_d, output_d, num_elements,
+    0, 64, stream);
 }
 
 std::size_t get_argsort_workspace_size(std::size_t num_elements)

--- a/perception/autoware_tensorrt_plugins/src/argsort_plugin.cpp
+++ b/perception/autoware_tensorrt_plugins/src/argsort_plugin.cpp
@@ -151,9 +151,14 @@ std::int32_t ArgsortPlugin::enqueue(
   auto num_elements = static_cast<std::size_t>(input_desc[0].dims.d[0]);
   const auto workspace_size = get_argsort_workspace_size(num_elements);
 
-  return argsort(
+  if (const auto status = PLUGIN_CUDA_CHECK(argsort(
     reinterpret_cast<std::int64_t const *>(inputs[0]), reinterpret_cast<std::int64_t *>(outputs[0]),
-    workspace, num_elements, workspace_size, stream);
+    workspace, num_elements, workspace_size, stream));
+      status != cudaSuccess) {
+    return -1;
+  }
+
+  return 0;
 }
 
 std::int32_t ArgsortPlugin::onShapeChange(

--- a/perception/autoware_tensorrt_plugins/src/argsort_plugin.cpp
+++ b/perception/autoware_tensorrt_plugins/src/argsort_plugin.cpp
@@ -149,14 +149,11 @@ std::int32_t ArgsortPlugin::enqueue(
   cudaStream_t stream) noexcept
 {
   auto num_elements = static_cast<std::size_t>(input_desc[0].dims.d[0]);
-  if (max_num_elements_ < num_elements) {
-    max_num_elements_ = num_elements;
-    argsort_workspace_size_ = get_argsort_workspace_size(max_num_elements_);
-  }
+  const auto workspace_size = get_argsort_workspace_size(num_elements);
 
   return argsort(
     reinterpret_cast<std::int64_t const *>(inputs[0]), reinterpret_cast<std::int64_t *>(outputs[0]),
-    workspace, num_elements, argsort_workspace_size_, stream);
+    workspace, num_elements, workspace_size, stream);
 }
 
 std::int32_t ArgsortPlugin::onShapeChange(
@@ -183,8 +180,10 @@ std::size_t ArgsortPlugin::getWorkspaceSize(
   [[maybe_unused]] std::int32_t num_outputs) const noexcept
 {
   std::int64_t max_num_elements = inputs[0].max.d[0];
-  return get_argsort_workspace_size(max_num_elements) +
-         sizeof(std::int64_t) * 2 * (max_num_elements + 1);
+  const auto temp_size = get_argsort_workspace_size(max_num_elements);
+  const auto scratch_offset =
+    ((temp_size + alignof(std::int64_t) - 1U) / alignof(std::int64_t)) * alignof(std::int64_t);
+  return scratch_offset + sizeof(std::int64_t) * 2 * max_num_elements;
 }
 
 }  // namespace nvinfer1::plugin

--- a/perception/autoware_tensorrt_plugins/src/argsort_plugin.cpp
+++ b/perception/autoware_tensorrt_plugins/src/argsort_plugin.cpp
@@ -152,8 +152,9 @@ std::int32_t ArgsortPlugin::enqueue(
   const auto workspace_size = get_argsort_workspace_size(num_elements);
 
   if (const auto status = PLUGIN_CUDA_CHECK(argsort(
-    reinterpret_cast<std::int64_t const *>(inputs[0]), reinterpret_cast<std::int64_t *>(outputs[0]),
-    workspace, num_elements, workspace_size, stream));
+        reinterpret_cast<std::int64_t const *>(inputs[0]),
+        reinterpret_cast<std::int64_t *>(outputs[0]), workspace, num_elements, workspace_size,
+        stream));
       status != cudaSuccess) {
     return -1;
   }

--- a/perception/autoware_tensorrt_plugins/src/plugin_utils.cpp
+++ b/perception/autoware_tensorrt_plugins/src/plugin_utils.cpp
@@ -35,6 +35,19 @@ void logWarning(char const * msg)
   getLogger()->log(nvinfer1::ILogger::Severity::kWARNING, msg);
 }
 
+cudaError_t reportCudaStatus(
+  cudaError_t status, char const * msg, char const * file, std::int32_t line)
+{
+  if (status != cudaSuccess) {
+    std::ostringstream stream;
+    stream << "CUDA call failed: " << msg << std::endl
+           << file << ':' << line << std::endl
+           << cudaGetErrorName(status) << ": " << cudaGetErrorString(status) << std::endl;
+    getLogger()->log(nvinfer1::ILogger::Severity::kERROR, stream.str().c_str());
+  }
+  return status;
+}
+
 void reportAssertion(bool success, char const * msg, char const * file, std::int32_t line)
 {
   if (!success) {

--- a/perception/autoware_tensorrt_plugins/src/unique_ops/unique.cu
+++ b/perception/autoware_tensorrt_plugins/src/unique_ops/unique.cu
@@ -185,9 +185,9 @@ UniqueWorkspaceLayout make_unique_workspace_layout(
     reinterpret_cast<std::int32_t *>(sorted_input_positions + num_input_elements_in);
   auto * run_ids = reinterpret_cast<std::int32_t *>(num_unique + 1U);
 
-  return UniqueWorkspaceLayout{
-    workspace_inout, cub_temp_storage_size_in, input_positions, sorted_input,
-    sorted_input_positions, num_unique, run_ids};
+  return UniqueWorkspaceLayout{workspace_inout, cub_temp_storage_size_in, input_positions,
+                               sorted_input,    sorted_input_positions,   num_unique,
+                               run_ids};
 }
 
 __global__ void mark_run_starts(

--- a/perception/autoware_tensorrt_plugins/src/unique_ops/unique.cu
+++ b/perception/autoware_tensorrt_plugins/src/unique_ops/unique.cu
@@ -257,14 +257,13 @@ cudaError_t unique(
   const std::int64_t * input_in, std::int64_t * unique_values_out,
   std::int64_t * inverse_indices_out, std::int64_t * unique_counts_out,
   std::int64_t * num_unique_elements_out, void * workspace_inout, std::size_t num_input_elements_in,
-  std::size_t workspace_size_in, cudaStream_t stream_in)
+  [[maybe_unused]] std::size_t workspace_size_in, cudaStream_t stream_in)
 {
   if (num_input_elements_in == 0U) {
     return cudaMemsetAsync(num_unique_elements_out, 0, sizeof(std::int64_t), stream_in);
   }
 
   assert(workspace_size_in >= get_unique_workspace_size(num_input_elements_in));
-  (void)workspace_size_in;
 
   const auto cub_temp_storage_size = get_unique_temp_storage_size(num_input_elements_in);
   auto layout =

--- a/perception/autoware_tensorrt_plugins/src/unique_ops/unique.cu
+++ b/perception/autoware_tensorrt_plugins/src/unique_ops/unique.cu
@@ -101,77 +101,153 @@
 
 #include <cub/cub.cuh>
 
-#include <thrust/adjacent_difference.h>
-#include <thrust/device_ptr.h>
-#include <thrust/execution_policy.h>
-#include <thrust/scan.h>
-#include <thrust/scatter.h>
-#include <thrust/sequence.h>
-#include <thrust/sort.h>
-#include <thrust/unique.h>
+#include <algorithm>
+#include <cstdint>
+
+namespace
+{
+
+constexpr int kThreadsPerBlock = 256;
+
+std::size_t align_up(const std::size_t size, const std::size_t alignment)
+{
+  return ((size + alignment - 1U) / alignment) * alignment;
+}
+
+std::size_t query_unique_temp_storage_size(const std::size_t num_elements)
+{
+  std::size_t sort_temp_size = 0;
+  std::size_t scan_temp_size = 0;
+  std::size_t unique_temp_size = 0;
+
+  std::int64_t * int64_nullptr = nullptr;
+  std::int32_t * int32_nullptr = nullptr;
+
+  cub::DeviceRadixSort::SortPairs(
+    nullptr, sort_temp_size, int64_nullptr, int64_nullptr, int64_nullptr, int64_nullptr,
+    num_elements, 0, 64, nullptr);
+  cub::DeviceScan::InclusiveSum(
+    nullptr, scan_temp_size, int32_nullptr, int32_nullptr, num_elements, nullptr);
+  cub::DeviceSelect::UniqueByKey(
+    nullptr, unique_temp_size, int64_nullptr, int64_nullptr, int64_nullptr, int64_nullptr,
+    int64_nullptr, num_elements, nullptr);
+
+  return std::max(sort_temp_size, std::max(scan_temp_size, unique_temp_size));
+}
+
+__global__ void mark_run_starts(
+  const std::int64_t * sorted_input, std::int32_t * run_ids, const std::size_t num_input_elements)
+{
+  const auto index = static_cast<std::size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (index >= num_input_elements) {
+    return;
+  }
+
+  run_ids[index] = (index == 0U || sorted_input[index] != sorted_input[index - 1U]) ? 1 : 0;
+}
+
+__global__ void fill_iota(std::int64_t * output, const std::size_t num_input_elements)
+{
+  const auto index = static_cast<std::size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (index >= num_input_elements) {
+    return;
+  }
+
+  output[index] = static_cast<std::int64_t>(index);
+}
+
+__global__ void scatter_inverse_indices(
+  const std::int64_t * sorted_idx, const std::int32_t * run_ids, std::int64_t * inverse_indices,
+  const std::size_t num_input_elements)
+{
+  const auto index = static_cast<std::size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (index >= num_input_elements) {
+    return;
+  }
+
+  inverse_indices[sorted_idx[index]] = static_cast<std::int64_t>(run_ids[index] - 1);
+}
+
+__global__ void write_unique_offset_sentinel(
+  std::int64_t * unique_offsets, const std::int64_t * num_unique,
+  const std::size_t num_input_elements)
+{
+  unique_offsets[*num_unique] = static_cast<std::int64_t>(num_input_elements);
+}
+
+__global__ void write_unique_counts(
+  const std::int64_t * unique_offsets, const std::int64_t * num_unique,
+  std::int64_t * unique_counts)
+{
+  const auto index = static_cast<std::size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (index >= static_cast<std::size_t>(*num_unique)) {
+    return;
+  }
+
+  unique_counts[index] = unique_offsets[index + 1U] - unique_offsets[index];
+}
+
+}  // namespace
 
 std::int64_t unique(
   const std::int64_t * input, std::int64_t * unique, std::int64_t * inverse_indices,
   std::int64_t * unique_counts, void * workspace, std::size_t num_input_elements,
   std::size_t unique_workspace_size, cudaStream_t stream)
 {
-  auto policy = thrust::cuda::par.on(stream);
+  if (num_input_elements == 0U) {
+    return 0;
+  }
 
-  thrust::device_ptr<std::int64_t> idx_ptr(reinterpret_cast<std::int64_t *>(workspace));
+  const auto temp_storage_size = get_unique_temp_storage_size(num_input_elements);
+  const auto scratch_offset = align_up(temp_storage_size, alignof(std::int64_t));
+  auto * scratch = reinterpret_cast<char *>(workspace) + scratch_offset;
 
-  thrust::sequence(policy, idx_ptr, idx_ptr + num_input_elements + 1, 0);
+  auto * input_positions = reinterpret_cast<std::int64_t *>(scratch);
+  auto * sorted_input = input_positions + num_input_elements;
+  auto * unique_offsets = sorted_input + num_input_elements;
+  auto * num_unique_d = unique_offsets + num_input_elements + 1U;
+  auto * run_ids = reinterpret_cast<std::int32_t *>(num_unique_d + 1U);
 
-  std::int64_t * sorted_input = unique;
-  std::int64_t * sorted_idx = thrust::raw_pointer_cast(idx_ptr) + 2 * num_input_elements + 1;
-  std::int64_t * inv_loc_ptr = thrust::raw_pointer_cast(idx_ptr) + 3 * num_input_elements + 1;
+  const auto num_blocks =
+    static_cast<unsigned int>((num_input_elements + kThreadsPerBlock - 1U) / kThreadsPerBlock);
 
-  void * sort_workspace_ptr =
-    reinterpret_cast<void *>(thrust::raw_pointer_cast(idx_ptr) + 4 * num_input_elements + 1);
-
-  auto sort_workspace_size =
-    unique_workspace_size - (4 * num_input_elements + 1) * sizeof(std::int64_t);
-
+  fill_iota<<<num_blocks, kThreadsPerBlock, 0, stream>>>(input_positions, num_input_elements);
   cub::DeviceRadixSort::SortPairs(
-    sort_workspace_ptr, sort_workspace_size, input, sorted_input, thrust::raw_pointer_cast(idx_ptr),
-    sorted_idx, num_input_elements, 0, 64, stream);
+    workspace, temp_storage_size, input, sorted_input, input_positions, unique_offsets,
+    num_input_elements, 0, 64, stream);
 
-  auto equal = [] __device__(const std::int64_t a, const std::int64_t b) { return a == b; };
+  mark_run_starts<<<num_blocks, kThreadsPerBlock, 0, stream>>>(
+    sorted_input, run_ids, num_input_elements);
+  cub::DeviceScan::InclusiveSum(
+    workspace, temp_storage_size, run_ids, run_ids, num_input_elements, stream);
 
-  auto not_equal = [] __device__(const std::int64_t a, const std::int64_t b) { return a != b; };
+  scatter_inverse_indices<<<num_blocks, kThreadsPerBlock, 0, stream>>>(
+    unique_offsets, run_ids, inverse_indices, num_input_elements);
 
-  thrust::adjacent_difference(
-    policy, sorted_input, sorted_input + num_input_elements, inv_loc_ptr, not_equal);
+  cub::DeviceSelect::UniqueByKey(
+    workspace, temp_storage_size, sorted_input, input_positions, unique, unique_offsets,
+    num_unique_d, num_input_elements, stream);
 
-  cudaMemsetAsync(inv_loc_ptr, 0, sizeof(int64_t), stream);
+  write_unique_offset_sentinel<<<1, 1, 0, stream>>>(
+    unique_offsets, num_unique_d, num_input_elements);
+  write_unique_counts<<<num_blocks, kThreadsPerBlock, 0, stream>>>(
+    unique_offsets, num_unique_d, unique_counts);
 
-  thrust::inclusive_scan(policy, inv_loc_ptr, inv_loc_ptr + num_input_elements, inv_loc_ptr);
-  thrust::scatter(
-    policy, inv_loc_ptr, inv_loc_ptr + num_input_elements, sorted_idx, inverse_indices);
-
-  std::int64_t num_out;
-
-  std::int64_t * range_ptr = idx_ptr.get();
-  num_out =
-    thrust::unique_by_key(policy, sorted_input, sorted_input + num_input_elements, range_ptr, equal)
-      .first -
-    sorted_input;
-
-  cudaMemcpyAsync(
-    range_ptr + num_out, &num_input_elements, sizeof(std::int64_t), cudaMemcpyHostToDevice, stream);
-
-  thrust::adjacent_difference(policy, range_ptr + 1, range_ptr + num_out + 1, unique_counts);
-
+  std::int64_t num_out = 0;
+  cudaMemcpyAsync(&num_out, num_unique_d, sizeof(std::int64_t), cudaMemcpyDeviceToHost, stream);
+  cudaStreamSynchronize(stream);
   return num_out;
+}
+
+std::size_t get_unique_temp_storage_size(std::size_t num_elements)
+{
+  return query_unique_temp_storage_size(num_elements);
 }
 
 std::size_t get_unique_workspace_size(std::size_t num_elements)
 {
-  std::size_t temp_size = 0;
-  std::int64_t * int64_nullptr = nullptr;
-
-  cub::DeviceRadixSort::SortPairs(
-    nullptr, temp_size, int64_nullptr, int64_nullptr, int64_nullptr, int64_nullptr, num_elements, 0,
-    64, nullptr);
-
-  return temp_size + (4 * num_elements + 1) * sizeof(std::int64_t);
+  const auto temp_size = query_unique_temp_storage_size(num_elements);
+  const auto scratch_offset = align_up(temp_size, alignof(std::int64_t));
+  return scratch_offset + (3 * num_elements + 2U) * sizeof(std::int64_t) +
+         num_elements * sizeof(std::int32_t);
 }

--- a/perception/autoware_tensorrt_plugins/src/unique_ops/unique.cu
+++ b/perception/autoware_tensorrt_plugins/src/unique_ops/unique.cu
@@ -129,19 +129,21 @@ struct UniqueWorkspaceLayout
   // +-----------------------------+ align_up(cub_temp_storage_size, alignof(int64))
   // | input_positions             | num_input_elements int64
   // | sorted_input                | num_input_elements int64
-  // | sorted_input_positions      | num_input_elements + 1 int64
+  // | sorted_input_positions      | num_input_elements int64
+  // | unique_offsets_end          | 1 int64
   // | num_unique                  | 1 int32
   // | run_ids                     | num_input_elements int32
   // +-----------------------------+
   //
   // `sorted_input_positions` is reused as `unique_offsets_inout` after inverse indices are
   // scattered.
-  // Its extra slot stores a sentinel end offset at index `num_input_elements`. Using the fixed last
-  // slot keeps the sentinel outside CUB's compact `[0, num_unique)` output range and separate from
-  // the `num_unique` scalar.
+  // `unique_offsets_end` stores the sentinel end offset in the next int64 slot. This keeps the
+  // sentinel outside CUB's compact `[0, num_unique)` output range and separate from the
+  // `num_unique` scalar.
   std::int64_t * input_positions;
   std::int64_t * sorted_input;
   std::int64_t * sorted_input_positions;
+  std::int64_t * unique_offsets_end;
   std::int32_t * num_unique;
   std::int32_t * run_ids;
 };
@@ -177,13 +179,13 @@ UniqueWorkspaceLayout make_unique_workspace_layout(
   auto * input_positions = reinterpret_cast<std::int64_t *>(scratch);
   auto * sorted_input = input_positions + num_input_elements_in;
   auto * sorted_input_positions = sorted_input + num_input_elements_in;
-  auto * num_unique =
-    reinterpret_cast<std::int32_t *>(sorted_input_positions + num_input_elements_in + 1U);
+  auto * unique_offsets_end = sorted_input_positions + num_input_elements_in;
+  auto * num_unique = reinterpret_cast<std::int32_t *>(unique_offsets_end + 1U);
   auto * run_ids = reinterpret_cast<std::int32_t *>(num_unique + 1U);
 
-  return UniqueWorkspaceLayout{workspace_inout, cub_temp_storage_size_in, input_positions,
-                               sorted_input,    sorted_input_positions,   num_unique,
-                               run_ids};
+  return UniqueWorkspaceLayout{
+    workspace_inout,        cub_temp_storage_size_in, input_positions, sorted_input,
+    sorted_input_positions, unique_offsets_end,       num_unique,      run_ids};
 }
 
 __global__ void mark_run_starts(
@@ -222,23 +224,24 @@ __global__ void scatter_inverse_indices(
 }
 
 __global__ void write_unique_offset_sentinel(
-  std::int64_t * unique_offsets_inout, const std::size_t num_input_elements_in)
+  std::int64_t * unique_offsets_end_out, const std::size_t num_input_elements_in)
 {
-  unique_offsets_inout[num_input_elements_in] = static_cast<std::int64_t>(num_input_elements_in);
+  *unique_offsets_end_out = static_cast<std::int64_t>(num_input_elements_in);
 }
 
 __global__ void write_unique_counts(
   const std::int64_t * unique_offsets_in, const std::int32_t * num_unique_in,
-  std::int64_t * unique_counts_out, const std::size_t num_input_elements_in)
+  const std::int64_t * unique_offsets_end_in, std::int64_t * unique_counts_out)
 {
   const auto index = static_cast<std::size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
   if (index >= static_cast<std::size_t>(*num_unique_in)) {
     return;
   }
 
-  const auto next_offset_index =
-    (index + 1U == static_cast<std::size_t>(*num_unique_in)) ? num_input_elements_in : index + 1U;
-  unique_counts_out[index] = unique_offsets_in[next_offset_index] - unique_offsets_in[index];
+  const auto next_offset = (index + 1U == static_cast<std::size_t>(*num_unique_in))
+                             ? *unique_offsets_end_in
+                             : unique_offsets_in[index + 1U];
+  unique_counts_out[index] = next_offset - unique_offsets_in[index];
 }
 
 }  // namespace
@@ -288,12 +291,13 @@ std::int64_t unique(
     num_input_elements_in, stream_in);
 
   // 5. Turn run start offsets into counts.
-  // CUB writes each run's start offset, but not the final end offset. Store the sentinel at the
-  // fixed extra slot so the final count can use the input length as its end boundary without
+  // CUB writes each run's start offset, but not the final end offset. Store the sentinel in the
+  // fixed extra int64 slot so the final count can use the input length as its end boundary without
   // overwriting compact offsets or the selected-count scalar.
-  write_unique_offset_sentinel<<<1, 1, 0, stream_in>>>(unique_offsets_inout, num_input_elements_in);
+  write_unique_offset_sentinel<<<1, 1, 0, stream_in>>>(
+    layout.unique_offsets_end, num_input_elements_in);
   write_unique_counts<<<num_blocks, kThreadsPerBlock, 0, stream_in>>>(
-    unique_offsets_inout, layout.num_unique, unique_counts_out, num_input_elements_in);
+    unique_offsets_inout, layout.num_unique, layout.unique_offsets_end, unique_counts_out);
 
   std::int32_t num_out = 0;
   cudaMemcpyAsync(

--- a/perception/autoware_tensorrt_plugins/src/unique_ops/unique.cu
+++ b/perception/autoware_tensorrt_plugins/src/unique_ops/unique.cu
@@ -236,9 +236,12 @@ __global__ void write_unique_counts(
     return;
   }
 
-  const auto next_offset = (index + 1U == static_cast<std::size_t>(*num_unique_in))
-                             ? *unique_offsets_end_in
-                             : unique_offsets_in[index + 1U];
+  std::int64_t next_offset;
+  if (index + 1U == static_cast<std::size_t>(*num_unique_in)) {
+    next_offset = *unique_offsets_end_in;
+  } else {
+    next_offset = unique_offsets_in[index + 1U];
+  }
   unique_counts_out[index] = next_offset - unique_offsets_in[index];
 }
 

--- a/perception/autoware_tensorrt_plugins/src/unique_ops/unique.cu
+++ b/perception/autoware_tensorrt_plugins/src/unique_ops/unique.cu
@@ -102,6 +102,8 @@
 #include <cub/cub.cuh>
 
 #include <algorithm>
+#include <cassert>
+#include <cstddef>
 #include <cstdint>
 
 namespace
@@ -114,7 +116,37 @@ std::size_t align_up(const std::size_t size, const std::size_t alignment)
   return ((size + alignment - 1U) / alignment) * alignment;
 }
 
-std::size_t query_unique_temp_storage_size(const std::size_t num_elements)
+struct UniqueWorkspaceLayout
+{
+  void * cub_temp_storage;
+  std::size_t cub_temp_storage_size;
+
+  // One int64 scratch block, then one int32 scratch block:
+  //
+  // workspace
+  // +-----------------------------+ 0
+  // | CUB temp storage            | cub_temp_storage_size bytes
+  // +-----------------------------+ align_up(cub_temp_storage_size, alignof(int64))
+  // | input_positions             | num_input_elements int64
+  // | sorted_input                | num_input_elements int64
+  // | sorted_input_positions      | num_input_elements + 1 int64
+  // | num_unique                  | 1 int32
+  // | run_ids                     | num_input_elements int32
+  // +-----------------------------+
+  //
+  // `sorted_input_positions` is reused as `unique_offsets_inout` after inverse indices are
+  // scattered.
+  // Its extra slot stores a sentinel end offset at index `num_input_elements`. Using the fixed last
+  // slot keeps the sentinel outside CUB's compact `[0, num_unique)` output range and separate from
+  // the `num_unique` scalar.
+  std::int64_t * input_positions;
+  std::int64_t * sorted_input;
+  std::int64_t * sorted_input_positions;
+  std::int32_t * num_unique;
+  std::int32_t * run_ids;
+};
+
+std::size_t query_unique_temp_storage_size(const std::size_t num_elements_in)
 {
   std::size_t sort_temp_size = 0;
   std::size_t scan_temp_size = 0;
@@ -125,129 +157,160 @@ std::size_t query_unique_temp_storage_size(const std::size_t num_elements)
 
   cub::DeviceRadixSort::SortPairs(
     nullptr, sort_temp_size, int64_nullptr, int64_nullptr, int64_nullptr, int64_nullptr,
-    num_elements, 0, 64, nullptr);
+    num_elements_in, 0, 64, nullptr);
   cub::DeviceScan::InclusiveSum(
-    nullptr, scan_temp_size, int32_nullptr, int32_nullptr, num_elements, nullptr);
+    nullptr, scan_temp_size, int32_nullptr, int32_nullptr, num_elements_in, nullptr);
   cub::DeviceSelect::UniqueByKey(
     nullptr, unique_temp_size, int64_nullptr, int64_nullptr, int64_nullptr, int64_nullptr,
-    int64_nullptr, num_elements, nullptr);
+    int32_nullptr, num_elements_in, nullptr);
 
   return std::max(sort_temp_size, std::max(scan_temp_size, unique_temp_size));
 }
 
-__global__ void mark_run_starts(
-  const std::int64_t * sorted_input, std::int32_t * run_ids, const std::size_t num_input_elements)
+UniqueWorkspaceLayout make_unique_workspace_layout(
+  void * workspace_inout, const std::size_t num_input_elements_in,
+  const std::size_t cub_temp_storage_size_in)
 {
-  const auto index = static_cast<std::size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
-  if (index >= num_input_elements) {
-    return;
-  }
+  const auto scratch_offset = align_up(cub_temp_storage_size_in, alignof(std::int64_t));
+  auto * scratch = reinterpret_cast<char *>(workspace_inout) + scratch_offset;
 
-  run_ids[index] = (index == 0U || sorted_input[index] != sorted_input[index - 1U]) ? 1 : 0;
+  auto * input_positions = reinterpret_cast<std::int64_t *>(scratch);
+  auto * sorted_input = input_positions + num_input_elements_in;
+  auto * sorted_input_positions = sorted_input + num_input_elements_in;
+  auto * num_unique =
+    reinterpret_cast<std::int32_t *>(sorted_input_positions + num_input_elements_in + 1U);
+  auto * run_ids = reinterpret_cast<std::int32_t *>(num_unique + 1U);
+
+  return UniqueWorkspaceLayout{workspace_inout, cub_temp_storage_size_in, input_positions,
+                               sorted_input,    sorted_input_positions,   num_unique,
+                               run_ids};
 }
 
-__global__ void fill_iota(std::int64_t * output, const std::size_t num_input_elements)
+__global__ void mark_run_starts(
+  const std::int64_t * sorted_input_in, std::int32_t * run_ids_out,
+  const std::size_t num_input_elements_in)
 {
   const auto index = static_cast<std::size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
-  if (index >= num_input_elements) {
+  if (index >= num_input_elements_in) {
     return;
   }
 
-  output[index] = static_cast<std::int64_t>(index);
+  run_ids_out[index] =
+    (index == 0U || sorted_input_in[index] != sorted_input_in[index - 1U]) ? 1 : 0;
+}
+
+__global__ void fill_iota(std::int64_t * output_out, const std::size_t num_input_elements_in)
+{
+  const auto index = static_cast<std::size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (index >= num_input_elements_in) {
+    return;
+  }
+
+  output_out[index] = static_cast<std::int64_t>(index);
 }
 
 __global__ void scatter_inverse_indices(
-  const std::int64_t * sorted_idx, const std::int32_t * run_ids, std::int64_t * inverse_indices,
-  const std::size_t num_input_elements)
+  const std::int64_t * sorted_idx_in, const std::int32_t * run_ids_in,
+  std::int64_t * inverse_indices_out, const std::size_t num_input_elements_in)
 {
   const auto index = static_cast<std::size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
-  if (index >= num_input_elements) {
+  if (index >= num_input_elements_in) {
     return;
   }
 
-  inverse_indices[sorted_idx[index]] = static_cast<std::int64_t>(run_ids[index] - 1);
+  inverse_indices_out[sorted_idx_in[index]] = static_cast<std::int64_t>(run_ids_in[index] - 1);
 }
 
 __global__ void write_unique_offset_sentinel(
-  std::int64_t * unique_offsets, const std::int64_t * num_unique,
-  const std::size_t num_input_elements)
+  std::int64_t * unique_offsets_inout, const std::size_t num_input_elements_in)
 {
-  unique_offsets[*num_unique] = static_cast<std::int64_t>(num_input_elements);
+  unique_offsets_inout[num_input_elements_in] = static_cast<std::int64_t>(num_input_elements_in);
 }
 
 __global__ void write_unique_counts(
-  const std::int64_t * unique_offsets, const std::int64_t * num_unique,
-  std::int64_t * unique_counts)
+  const std::int64_t * unique_offsets_in, const std::int32_t * num_unique_in,
+  std::int64_t * unique_counts_out, const std::size_t num_input_elements_in)
 {
   const auto index = static_cast<std::size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
-  if (index >= static_cast<std::size_t>(*num_unique)) {
+  if (index >= static_cast<std::size_t>(*num_unique_in)) {
     return;
   }
 
-  unique_counts[index] = unique_offsets[index + 1U] - unique_offsets[index];
+  const auto next_offset_index =
+    (index + 1U == static_cast<std::size_t>(*num_unique_in)) ? num_input_elements_in : index + 1U;
+  unique_counts_out[index] = unique_offsets_in[next_offset_index] - unique_offsets_in[index];
 }
 
 }  // namespace
 
 std::int64_t unique(
-  const std::int64_t * input, std::int64_t * unique, std::int64_t * inverse_indices,
-  std::int64_t * unique_counts, void * workspace, std::size_t num_input_elements,
-  std::size_t unique_workspace_size, cudaStream_t stream)
+  const std::int64_t * input_in, std::int64_t * unique_values_out,
+  std::int64_t * inverse_indices_out, std::int64_t * unique_counts_out, void * workspace_inout,
+  std::size_t num_input_elements_in, std::size_t workspace_size_in, cudaStream_t stream_in)
 {
-  if (num_input_elements == 0U) {
+  if (num_input_elements_in == 0U) {
     return 0;
   }
 
-  const auto temp_storage_size = get_unique_temp_storage_size(num_input_elements);
-  const auto scratch_offset = align_up(temp_storage_size, alignof(std::int64_t));
-  auto * scratch = reinterpret_cast<char *>(workspace) + scratch_offset;
+  assert(workspace_size_in >= get_unique_workspace_size(num_input_elements_in));
+  (void)workspace_size_in;
 
-  auto * input_positions = reinterpret_cast<std::int64_t *>(scratch);
-  auto * sorted_input = input_positions + num_input_elements;
-  auto * unique_offsets = sorted_input + num_input_elements;
-  auto * num_unique_d = unique_offsets + num_input_elements + 1U;
-  auto * run_ids = reinterpret_cast<std::int32_t *>(num_unique_d + 1U);
+  const auto cub_temp_storage_size = get_unique_temp_storage_size(num_input_elements_in);
+  auto layout =
+    make_unique_workspace_layout(workspace_inout, num_input_elements_in, cub_temp_storage_size);
 
   const auto num_blocks =
-    static_cast<unsigned int>((num_input_elements + kThreadsPerBlock - 1U) / kThreadsPerBlock);
+    static_cast<unsigned int>((num_input_elements_in + kThreadsPerBlock - 1U) / kThreadsPerBlock);
 
-  fill_iota<<<num_blocks, kThreadsPerBlock, 0, stream>>>(input_positions, num_input_elements);
+  // 1. Sort values while carrying their original input positions.
+  fill_iota<<<num_blocks, kThreadsPerBlock, 0, stream_in>>>(
+    layout.input_positions, num_input_elements_in);
   cub::DeviceRadixSort::SortPairs(
-    workspace, temp_storage_size, input, sorted_input, input_positions, unique_offsets,
-    num_input_elements, 0, 64, stream);
+    layout.cub_temp_storage, layout.cub_temp_storage_size, input_in, layout.sorted_input,
+    layout.input_positions, layout.sorted_input_positions, num_input_elements_in, 0, 64, stream_in);
 
-  mark_run_starts<<<num_blocks, kThreadsPerBlock, 0, stream>>>(
-    sorted_input, run_ids, num_input_elements);
+  // 2. Convert sorted run starts into sorted-position -> unique-index ids.
+  mark_run_starts<<<num_blocks, kThreadsPerBlock, 0, stream_in>>>(
+    layout.sorted_input, layout.run_ids, num_input_elements_in);
   cub::DeviceScan::InclusiveSum(
-    workspace, temp_storage_size, run_ids, run_ids, num_input_elements, stream);
+    layout.cub_temp_storage, layout.cub_temp_storage_size, layout.run_ids, layout.run_ids,
+    num_input_elements_in, stream_in);
 
-  scatter_inverse_indices<<<num_blocks, kThreadsPerBlock, 0, stream>>>(
-    unique_offsets, run_ids, inverse_indices, num_input_elements);
+  // 3. Scatter unique ids back to original input order.
+  scatter_inverse_indices<<<num_blocks, kThreadsPerBlock, 0, stream_in>>>(
+    layout.sorted_input_positions, layout.run_ids, inverse_indices_out, num_input_elements_in);
 
+  // 4. Compact sorted runs into unique values and each run's start offset.
+  auto * unique_offsets_inout = layout.sorted_input_positions;
   cub::DeviceSelect::UniqueByKey(
-    workspace, temp_storage_size, sorted_input, input_positions, unique, unique_offsets,
-    num_unique_d, num_input_elements, stream);
+    layout.cub_temp_storage, layout.cub_temp_storage_size, layout.sorted_input,
+    layout.input_positions, unique_values_out, unique_offsets_inout, layout.num_unique,
+    num_input_elements_in, stream_in);
 
-  write_unique_offset_sentinel<<<1, 1, 0, stream>>>(
-    unique_offsets, num_unique_d, num_input_elements);
-  write_unique_counts<<<num_blocks, kThreadsPerBlock, 0, stream>>>(
-    unique_offsets, num_unique_d, unique_counts);
+  // 5. Turn run start offsets into counts.
+  // CUB writes each run's start offset, but not the final end offset. Store the sentinel at the
+  // fixed extra slot so the final count can use the input length as its end boundary without
+  // overwriting compact offsets or the selected-count scalar.
+  write_unique_offset_sentinel<<<1, 1, 0, stream_in>>>(unique_offsets_inout, num_input_elements_in);
+  write_unique_counts<<<num_blocks, kThreadsPerBlock, 0, stream_in>>>(
+    unique_offsets_inout, layout.num_unique, unique_counts_out, num_input_elements_in);
 
-  std::int64_t num_out = 0;
-  cudaMemcpyAsync(&num_out, num_unique_d, sizeof(std::int64_t), cudaMemcpyDeviceToHost, stream);
-  cudaStreamSynchronize(stream);
-  return num_out;
+  std::int32_t num_out = 0;
+  cudaMemcpyAsync(
+    &num_out, layout.num_unique, sizeof(std::int32_t), cudaMemcpyDeviceToHost, stream_in);
+  cudaStreamSynchronize(stream_in);
+  return static_cast<std::int64_t>(num_out);
 }
 
-std::size_t get_unique_temp_storage_size(std::size_t num_elements)
+std::size_t get_unique_temp_storage_size(std::size_t num_elements_in)
 {
-  return query_unique_temp_storage_size(num_elements);
+  return query_unique_temp_storage_size(num_elements_in);
 }
 
-std::size_t get_unique_workspace_size(std::size_t num_elements)
+std::size_t get_unique_workspace_size(std::size_t num_elements_in)
 {
-  const auto temp_size = query_unique_temp_storage_size(num_elements);
+  const auto temp_size = query_unique_temp_storage_size(num_elements_in);
   const auto scratch_offset = align_up(temp_size, alignof(std::int64_t));
-  return scratch_offset + (3 * num_elements + 2U) * sizeof(std::int64_t) +
-         num_elements * sizeof(std::int32_t);
+  return scratch_offset + (3 * num_elements_in + 1U) * sizeof(std::int64_t) +
+         (num_elements_in + 1U) * sizeof(std::int32_t);
 }

--- a/perception/autoware_tensorrt_plugins/src/unique_ops/unique.cu
+++ b/perception/autoware_tensorrt_plugins/src/unique_ops/unique.cu
@@ -98,6 +98,7 @@
 // POSSIBILITY OF SUCH DAMAGE.
 
 #include "autoware/unique_ops/unique.hpp"
+#include "autoware/tensorrt_plugins/kernel_utils.hpp"
 
 #include <cub/cub.cuh>
 
@@ -110,11 +111,6 @@ namespace
 {
 
 constexpr int kThreadsPerBlock = 256;
-
-std::size_t align_up(const std::size_t size, const std::size_t alignment)
-{
-  return ((size + alignment - 1U) / alignment) * alignment;
-}
 
 struct UniqueWorkspaceLayout
 {
@@ -183,7 +179,8 @@ UniqueWorkspaceLayout make_unique_workspace_layout(
   void * workspace_inout, const std::size_t num_input_elements_in,
   const std::size_t cub_temp_storage_size_in)
 {
-  const auto scratch_offset = align_up(cub_temp_storage_size_in, alignof(std::int64_t));
+  const auto scratch_offset =
+    autoware::tensorrt_plugins::align_up(cub_temp_storage_size_in, alignof(std::int64_t));
   auto * scratch = reinterpret_cast<char *>(workspace_inout) + scratch_offset;
 
   auto * input_positions = reinterpret_cast<std::int64_t *>(scratch);
@@ -209,16 +206,6 @@ __global__ void mark_run_starts(
 
   run_ids_out[index] =
     (index == 0U || sorted_input_in[index] != sorted_input_in[index - 1U]) ? 1 : 0;
-}
-
-__global__ void fill_iota(std::int64_t * output_out, const std::size_t num_input_elements_in)
-{
-  const auto index = static_cast<std::size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
-  if (index >= num_input_elements_in) {
-    return;
-  }
-
-  output_out[index] = static_cast<std::int64_t>(index);
 }
 
 __global__ void scatter_inverse_indices(
@@ -283,7 +270,7 @@ cudaError_t unique(
     static_cast<unsigned int>((num_input_elements_in + kThreadsPerBlock - 1U) / kThreadsPerBlock);
 
   // 1. Sort values while carrying their original input positions.
-  fill_iota<<<num_blocks, kThreadsPerBlock, 0, stream_in>>>(
+  autoware::tensorrt_plugins::fill_iota<<<num_blocks, kThreadsPerBlock, 0, stream_in>>>(
     layout.input_positions, num_input_elements_in);
   if (const auto status = cudaPeekAtLastError(); status != cudaSuccess) {
     return status;
@@ -353,7 +340,8 @@ std::size_t get_unique_temp_storage_size(std::size_t num_elements_in)
 std::size_t get_unique_workspace_size(std::size_t num_elements_in)
 {
   const auto temp_size = query_unique_temp_storage_size(num_elements_in);
-  const auto scratch_offset = align_up(temp_size, alignof(std::int64_t));
+  const auto scratch_offset =
+    autoware::tensorrt_plugins::align_up(temp_size, alignof(std::int64_t));
   return scratch_offset + (3 * num_elements_in + 1U) * sizeof(std::int64_t) +
          (num_elements_in + 1U) * sizeof(std::int32_t);
 }

--- a/perception/autoware_tensorrt_plugins/src/unique_ops/unique.cu
+++ b/perception/autoware_tensorrt_plugins/src/unique_ops/unique.cu
@@ -217,6 +217,7 @@ __global__ void scatter_inverse_indices(
     return;
   }
 
+  // Inclusive scan produces 1-based run ids; inverse indices use 0-based unique-value indices.
   inverse_indices_out[sorted_idx_in[index]] = static_cast<std::int64_t>(run_ids_in[index] - 1);
 }
 

--- a/perception/autoware_tensorrt_plugins/src/unique_ops/unique.cu
+++ b/perception/autoware_tensorrt_plugins/src/unique_ops/unique.cu
@@ -97,8 +97,8 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-#include "autoware/unique_ops/unique.hpp"
 #include "autoware/tensorrt_plugins/kernel_utils.hpp"
+#include "autoware/unique_ops/unique.hpp"
 
 #include <cub/cub.cuh>
 

--- a/perception/autoware_tensorrt_plugins/src/unique_ops/unique.cu
+++ b/perception/autoware_tensorrt_plugins/src/unique_ops/unique.cu
@@ -254,15 +254,22 @@ __global__ void write_unique_counts(
   unique_counts_out[index] = next_offset - unique_offsets_in[index];
 }
 
+__global__ void write_num_unique_elements(
+  const std::int32_t * num_unique_in, std::int64_t * num_unique_elements_out)
+{
+  *num_unique_elements_out = static_cast<std::int64_t>(*num_unique_in);
+}
+
 }  // namespace
 
-std::int64_t unique(
+cudaError_t unique(
   const std::int64_t * input_in, std::int64_t * unique_values_out,
-  std::int64_t * inverse_indices_out, std::int64_t * unique_counts_out, void * workspace_inout,
+  std::int64_t * inverse_indices_out, std::int64_t * unique_counts_out,
+  std::int64_t * num_unique_elements_out, void * workspace_inout,
   std::size_t num_input_elements_in, std::size_t workspace_size_in, cudaStream_t stream_in)
 {
   if (num_input_elements_in == 0U) {
-    return 0;
+    return cudaMemsetAsync(num_unique_elements_out, 0, sizeof(std::int64_t), stream_in);
   }
 
   assert(workspace_size_in >= get_unique_workspace_size(num_input_elements_in));
@@ -278,27 +285,46 @@ std::int64_t unique(
   // 1. Sort values while carrying their original input positions.
   fill_iota<<<num_blocks, kThreadsPerBlock, 0, stream_in>>>(
     layout.input_positions, num_input_elements_in);
-  cub::DeviceRadixSort::SortPairs(
+  if (const auto status = cudaPeekAtLastError(); status != cudaSuccess) {
+    return status;
+  }
+  if (const auto status = cub::DeviceRadixSort::SortPairs(
     layout.cub_temp_storage, layout.cub_temp_storage_size, input_in, layout.sorted_input,
-    layout.input_positions, layout.sorted_input_positions, num_input_elements_in, 0, 64, stream_in);
+    layout.input_positions, layout.sorted_input_positions, num_input_elements_in, 0, 64,
+    stream_in);
+      status != cudaSuccess) {
+    return status;
+  }
 
   // 2. Convert sorted run starts into sorted-position -> unique-index ids.
   mark_run_starts<<<num_blocks, kThreadsPerBlock, 0, stream_in>>>(
     layout.sorted_input, layout.run_ids, num_input_elements_in);
-  cub::DeviceScan::InclusiveSum(
+  if (const auto status = cudaPeekAtLastError(); status != cudaSuccess) {
+    return status;
+  }
+  if (const auto status = cub::DeviceScan::InclusiveSum(
     layout.cub_temp_storage, layout.cub_temp_storage_size, layout.run_ids, layout.run_ids,
     num_input_elements_in, stream_in);
+      status != cudaSuccess) {
+    return status;
+  }
 
   // 3. Scatter unique ids back to original input order.
   scatter_inverse_indices<<<num_blocks, kThreadsPerBlock, 0, stream_in>>>(
     layout.sorted_input_positions, layout.run_ids, inverse_indices_out, num_input_elements_in);
+  if (const auto status = cudaPeekAtLastError(); status != cudaSuccess) {
+    return status;
+  }
 
   // 4. Compact sorted runs into unique values and each run's start offset.
   auto * unique_offsets_inout = layout.sorted_input_positions;
-  cub::DeviceSelect::UniqueByKey(
+  if (const auto status = cub::DeviceSelect::UniqueByKey(
     layout.cub_temp_storage, layout.cub_temp_storage_size, layout.sorted_input,
     layout.input_positions, unique_values_out, unique_offsets_inout, layout.num_unique,
     num_input_elements_in, stream_in);
+      status != cudaSuccess) {
+    return status;
+  }
 
   // 5. Turn run start offsets into counts.
   // CUB writes each run's start offset, but not the final end offset. Store the sentinel in the
@@ -306,14 +332,17 @@ std::int64_t unique(
   // overwriting compact offsets or the selected-count scalar.
   write_unique_offset_sentinel<<<1, 1, 0, stream_in>>>(
     layout.unique_offsets_end, num_input_elements_in);
+  if (const auto status = cudaPeekAtLastError(); status != cudaSuccess) {
+    return status;
+  }
   write_unique_counts<<<num_blocks, kThreadsPerBlock, 0, stream_in>>>(
     unique_offsets_inout, layout.num_unique, layout.unique_offsets_end, unique_counts_out);
+  if (const auto status = cudaPeekAtLastError(); status != cudaSuccess) {
+    return status;
+  }
 
-  std::int32_t num_out = 0;
-  cudaMemcpyAsync(
-    &num_out, layout.num_unique, sizeof(std::int32_t), cudaMemcpyDeviceToHost, stream_in);
-  cudaStreamSynchronize(stream_in);
-  return static_cast<std::int64_t>(num_out);
+  write_num_unique_elements<<<1, 1, 0, stream_in>>>(layout.num_unique, num_unique_elements_out);
+  return cudaPeekAtLastError();
 }
 
 std::size_t get_unique_temp_storage_size(std::size_t num_elements_in)

--- a/perception/autoware_tensorrt_plugins/src/unique_ops/unique.cu
+++ b/perception/autoware_tensorrt_plugins/src/unique_ops/unique.cu
@@ -129,7 +129,6 @@ struct UniqueWorkspaceLayout
   // | input_positions             | num_input_elements int64
   // | sorted_input                | num_input_elements int64
   // | sorted_input_positions      | num_input_elements int64
-  // | unique_offsets_end          | 1 int64
   // | num_unique                  | 1 int32
   // | run_ids                     | num_input_elements int32
   // +-----------------------------+
@@ -140,14 +139,10 @@ struct UniqueWorkspaceLayout
   /// Sorted copy of the input values.
   std::int64_t * sorted_input;
 
-  /// Original input positions ordered by `sorted_input`; later reused for compact run start
-  /// offsets.
+  /// Original input positions ordered by `sorted_input`.
   std::int64_t * sorted_input_positions;
 
-  /// Sentinel end offset used to compute the final unique count.
-  std::int64_t * unique_offsets_end;
-
-  /// Device scalar storing the number of unique values selected by CUB.
+  /// Device scalar storing the number of unique sorted runs found by CUB.
   std::int32_t * num_unique;
 
   /// Per-sorted-element inclusive run ids used to scatter inverse indices.
@@ -158,7 +153,7 @@ std::size_t query_unique_temp_storage_size(const std::size_t num_elements_in)
 {
   std::size_t sort_temp_size = 0;
   std::size_t scan_temp_size = 0;
-  std::size_t unique_temp_size = 0;
+  std::size_t rle_temp_size = 0;
 
   std::int64_t * int64_nullptr = nullptr;
   std::int32_t * int32_nullptr = nullptr;
@@ -168,11 +163,11 @@ std::size_t query_unique_temp_storage_size(const std::size_t num_elements_in)
     num_elements_in, 0, 64, nullptr);
   cub::DeviceScan::InclusiveSum(
     nullptr, scan_temp_size, int32_nullptr, int32_nullptr, num_elements_in, nullptr);
-  cub::DeviceSelect::UniqueByKey(
-    nullptr, unique_temp_size, int64_nullptr, int64_nullptr, int64_nullptr, int64_nullptr,
-    int32_nullptr, num_elements_in, nullptr);
+  cub::DeviceRunLengthEncode::Encode(
+    nullptr, rle_temp_size, int64_nullptr, int64_nullptr, int64_nullptr, int32_nullptr,
+    static_cast<int>(num_elements_in), nullptr);
 
-  return std::max(sort_temp_size, std::max(scan_temp_size, unique_temp_size));
+  return std::max(sort_temp_size, std::max(scan_temp_size, rle_temp_size));
 }
 
 UniqueWorkspaceLayout make_unique_workspace_layout(
@@ -186,13 +181,13 @@ UniqueWorkspaceLayout make_unique_workspace_layout(
   auto * input_positions = reinterpret_cast<std::int64_t *>(scratch);
   auto * sorted_input = input_positions + num_input_elements_in;
   auto * sorted_input_positions = sorted_input + num_input_elements_in;
-  auto * unique_offsets_end = sorted_input_positions + num_input_elements_in;
-  auto * num_unique = reinterpret_cast<std::int32_t *>(unique_offsets_end + 1U);
+  auto * num_unique =
+    reinterpret_cast<std::int32_t *>(sorted_input_positions + num_input_elements_in);
   auto * run_ids = reinterpret_cast<std::int32_t *>(num_unique + 1U);
 
   return UniqueWorkspaceLayout{
-    workspace_inout,        cub_temp_storage_size_in, input_positions, sorted_input,
-    sorted_input_positions, unique_offsets_end,       num_unique,      run_ids};
+    workspace_inout, cub_temp_storage_size_in, input_positions, sorted_input,
+    sorted_input_positions, num_unique, run_ids};
 }
 
 __global__ void mark_run_starts(
@@ -219,30 +214,6 @@ __global__ void scatter_inverse_indices(
 
   // Inclusive scan produces 1-based run ids; inverse indices use 0-based unique-value indices.
   inverse_indices_out[sorted_idx_in[index]] = static_cast<std::int64_t>(run_ids_in[index] - 1);
-}
-
-__global__ void write_unique_offset_sentinel(
-  std::int64_t * unique_offsets_end_out, const std::size_t num_input_elements_in)
-{
-  *unique_offsets_end_out = static_cast<std::int64_t>(num_input_elements_in);
-}
-
-__global__ void write_unique_counts(
-  const std::int64_t * unique_offsets_in, const std::int32_t * num_unique_in,
-  const std::int64_t * unique_offsets_end_in, std::int64_t * unique_counts_out)
-{
-  const auto index = static_cast<std::size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
-  if (index >= static_cast<std::size_t>(*num_unique_in)) {
-    return;
-  }
-
-  std::int64_t next_offset;
-  if (index + 1U == static_cast<std::size_t>(*num_unique_in)) {
-    next_offset = *unique_offsets_end_in;
-  } else {
-    next_offset = unique_offsets_in[index + 1U];
-  }
-  unique_counts_out[index] = next_offset - unique_offsets_in[index];
 }
 
 __global__ void write_num_unique_elements(
@@ -306,28 +277,12 @@ cudaError_t unique(
     return status;
   }
 
-  // 4. Compact sorted runs into unique values and each run's start offset.
-  auto * unique_offsets_inout = layout.sorted_input_positions;
-  if (const auto status = cub::DeviceSelect::UniqueByKey(
+  // 4. Compact sorted runs into unique values and occurrence counts.
+  if (const auto status = cub::DeviceRunLengthEncode::Encode(
         layout.cub_temp_storage, layout.cub_temp_storage_size, layout.sorted_input,
-        layout.input_positions, unique_values_out, unique_offsets_inout, layout.num_unique,
-        num_input_elements_in, stream_in);
+        unique_values_out, unique_counts_out, layout.num_unique,
+        static_cast<int>(num_input_elements_in), stream_in);
       status != cudaSuccess) {
-    return status;
-  }
-
-  // 5. Turn run start offsets into counts.
-  // CUB writes each run's start offset, but not the final end offset. Store the sentinel in the
-  // fixed extra int64 slot so the final count can use the input length as its end boundary without
-  // overwriting compact offsets or the selected-count scalar.
-  write_unique_offset_sentinel<<<1, 1, 0, stream_in>>>(
-    layout.unique_offsets_end, num_input_elements_in);
-  if (const auto status = cudaPeekAtLastError(); status != cudaSuccess) {
-    return status;
-  }
-  write_unique_counts<<<num_blocks, kThreadsPerBlock, 0, stream_in>>>(
-    unique_offsets_inout, layout.num_unique, layout.unique_offsets_end, unique_counts_out);
-  if (const auto status = cudaPeekAtLastError(); status != cudaSuccess) {
     return status;
   }
 
@@ -345,6 +300,6 @@ std::size_t get_unique_workspace_size(std::size_t num_elements_in)
   const auto temp_size = query_unique_temp_storage_size(num_elements_in);
   const auto scratch_offset =
     autoware::tensorrt_plugins::align_up(temp_size, alignof(std::int64_t));
-  return scratch_offset + (3 * num_elements_in + 1U) * sizeof(std::int64_t) +
+  return scratch_offset + (3 * num_elements_in) * sizeof(std::int64_t) +
          (num_elements_in + 1U) * sizeof(std::int32_t);
 }

--- a/perception/autoware_tensorrt_plugins/src/unique_ops/unique.cu
+++ b/perception/autoware_tensorrt_plugins/src/unique_ops/unique.cu
@@ -118,7 +118,10 @@ std::size_t align_up(const std::size_t size, const std::size_t alignment)
 
 struct UniqueWorkspaceLayout
 {
+  /// Scratch storage reused by the largest CUB primitive in this implementation.
   void * cub_temp_storage;
+
+  /// Number of bytes reserved for `cub_temp_storage`.
   std::size_t cub_temp_storage_size;
 
   // One int64 scratch block, then one int32 scratch block:
@@ -134,17 +137,24 @@ struct UniqueWorkspaceLayout
   // | num_unique                  | 1 int32
   // | run_ids                     | num_input_elements int32
   // +-----------------------------+
-  //
-  // `sorted_input_positions` is reused as `unique_offsets_inout` after inverse indices are
-  // scattered.
-  // `unique_offsets_end` stores the sentinel end offset in the next int64 slot. This keeps the
-  // sentinel outside CUB's compact `[0, num_unique)` output range and separate from the
-  // `num_unique` scalar.
+
+  /// Original input positions used as values for the initial value/index sort.
   std::int64_t * input_positions;
+
+  /// Sorted copy of the input values.
   std::int64_t * sorted_input;
+
+  /// Original input positions ordered by `sorted_input`; later reused for compact run start
+  /// offsets.
   std::int64_t * sorted_input_positions;
+
+  /// Sentinel end offset used to compute the final unique count.
   std::int64_t * unique_offsets_end;
+
+  /// Device scalar storing the number of unique values selected by CUB.
   std::int32_t * num_unique;
+
+  /// Per-sorted-element inclusive run ids used to scatter inverse indices.
   std::int32_t * run_ids;
 };
 

--- a/perception/autoware_tensorrt_plugins/src/unique_ops/unique.cu
+++ b/perception/autoware_tensorrt_plugins/src/unique_ops/unique.cu
@@ -265,8 +265,8 @@ __global__ void write_num_unique_elements(
 cudaError_t unique(
   const std::int64_t * input_in, std::int64_t * unique_values_out,
   std::int64_t * inverse_indices_out, std::int64_t * unique_counts_out,
-  std::int64_t * num_unique_elements_out, void * workspace_inout,
-  std::size_t num_input_elements_in, std::size_t workspace_size_in, cudaStream_t stream_in)
+  std::int64_t * num_unique_elements_out, void * workspace_inout, std::size_t num_input_elements_in,
+  std::size_t workspace_size_in, cudaStream_t stream_in)
 {
   if (num_input_elements_in == 0U) {
     return cudaMemsetAsync(num_unique_elements_out, 0, sizeof(std::int64_t), stream_in);
@@ -289,9 +289,9 @@ cudaError_t unique(
     return status;
   }
   if (const auto status = cub::DeviceRadixSort::SortPairs(
-    layout.cub_temp_storage, layout.cub_temp_storage_size, input_in, layout.sorted_input,
-    layout.input_positions, layout.sorted_input_positions, num_input_elements_in, 0, 64,
-    stream_in);
+        layout.cub_temp_storage, layout.cub_temp_storage_size, input_in, layout.sorted_input,
+        layout.input_positions, layout.sorted_input_positions, num_input_elements_in, 0, 64,
+        stream_in);
       status != cudaSuccess) {
     return status;
   }
@@ -303,8 +303,8 @@ cudaError_t unique(
     return status;
   }
   if (const auto status = cub::DeviceScan::InclusiveSum(
-    layout.cub_temp_storage, layout.cub_temp_storage_size, layout.run_ids, layout.run_ids,
-    num_input_elements_in, stream_in);
+        layout.cub_temp_storage, layout.cub_temp_storage_size, layout.run_ids, layout.run_ids,
+        num_input_elements_in, stream_in);
       status != cudaSuccess) {
     return status;
   }
@@ -319,9 +319,9 @@ cudaError_t unique(
   // 4. Compact sorted runs into unique values and each run's start offset.
   auto * unique_offsets_inout = layout.sorted_input_positions;
   if (const auto status = cub::DeviceSelect::UniqueByKey(
-    layout.cub_temp_storage, layout.cub_temp_storage_size, layout.sorted_input,
-    layout.input_positions, unique_values_out, unique_offsets_inout, layout.num_unique,
-    num_input_elements_in, stream_in);
+        layout.cub_temp_storage, layout.cub_temp_storage_size, layout.sorted_input,
+        layout.input_positions, unique_values_out, unique_offsets_inout, layout.num_unique,
+        num_input_elements_in, stream_in);
       status != cudaSuccess) {
     return status;
   }

--- a/perception/autoware_tensorrt_plugins/src/unique_plugin.cpp
+++ b/perception/autoware_tensorrt_plugins/src/unique_plugin.cpp
@@ -164,11 +164,12 @@ std::int32_t UniquePlugin::enqueue(
   cudaStream_t stream) noexcept
 {
   std::int64_t num_elements = input_desc[0].dims.d[0];
+  const auto workspace_size = get_unique_workspace_size(static_cast<std::size_t>(num_elements));
 
   std::int64_t num_unique_elements = unique(
     reinterpret_cast<const std::int64_t *>(inputs[0]), reinterpret_cast<std::int64_t *>(outputs[0]),
     reinterpret_cast<std::int64_t *>(outputs[1]), reinterpret_cast<std::int64_t *>(outputs[2]),
-    workspace, num_elements, workspace_size_, stream);
+    workspace, num_elements, workspace_size, stream);
 
   cudaMemcpyAsync(
     reinterpret_cast<std::int64_t *>(outputs[3]), &num_unique_elements, sizeof(std::int64_t),

--- a/perception/autoware_tensorrt_plugins/src/unique_plugin.cpp
+++ b/perception/autoware_tensorrt_plugins/src/unique_plugin.cpp
@@ -166,16 +166,14 @@ std::int32_t UniquePlugin::enqueue(
   std::int64_t num_elements = input_desc[0].dims.d[0];
   const auto workspace_size = get_unique_workspace_size(static_cast<std::size_t>(num_elements));
 
-  std::int64_t num_unique_elements = unique(
+  if (const auto status = PLUGIN_CUDA_CHECK(unique(
     reinterpret_cast<const std::int64_t *>(inputs[0]), reinterpret_cast<std::int64_t *>(outputs[0]),
     reinterpret_cast<std::int64_t *>(outputs[1]), reinterpret_cast<std::int64_t *>(outputs[2]),
-    workspace, num_elements, workspace_size, stream);
-
-  cudaMemcpyAsync(
-    reinterpret_cast<std::int64_t *>(outputs[3]), &num_unique_elements, sizeof(std::int64_t),
-    cudaMemcpyHostToDevice, stream);
-
-  cudaStreamSynchronize(stream);
+    reinterpret_cast<std::int64_t *>(outputs[3]), workspace, num_elements, workspace_size,
+    stream));
+      status != cudaSuccess) {
+    return -1;
+  }
 
   return 0;
 }

--- a/perception/autoware_tensorrt_plugins/src/unique_plugin.cpp
+++ b/perception/autoware_tensorrt_plugins/src/unique_plugin.cpp
@@ -167,10 +167,10 @@ std::int32_t UniquePlugin::enqueue(
   const auto workspace_size = get_unique_workspace_size(static_cast<std::size_t>(num_elements));
 
   if (const auto status = PLUGIN_CUDA_CHECK(unique(
-    reinterpret_cast<const std::int64_t *>(inputs[0]), reinterpret_cast<std::int64_t *>(outputs[0]),
-    reinterpret_cast<std::int64_t *>(outputs[1]), reinterpret_cast<std::int64_t *>(outputs[2]),
-    reinterpret_cast<std::int64_t *>(outputs[3]), workspace, num_elements, workspace_size,
-    stream));
+        reinterpret_cast<const std::int64_t *>(inputs[0]),
+        reinterpret_cast<std::int64_t *>(outputs[0]), reinterpret_cast<std::int64_t *>(outputs[1]),
+        reinterpret_cast<std::int64_t *>(outputs[2]), reinterpret_cast<std::int64_t *>(outputs[3]),
+        workspace, num_elements, workspace_size, stream));
       status != cudaSuccess) {
     return -1;
   }

--- a/perception/autoware_tensorrt_plugins/test/unique_kernel_test.cpp
+++ b/perception/autoware_tensorrt_plugins/test/unique_kernel_test.cpp
@@ -78,14 +78,19 @@ TEST(ReferenceKernelsTest, UniqueMatchesCpuReference)
   DeviceBuffer<std::int64_t> unique_d(input.size());
   DeviceBuffer<std::int64_t> inverse_d(input.size());
   DeviceBuffer<std::int64_t> counts_d(input.size());
+  DeviceBuffer<std::int64_t> num_unique_d(1U);
   DeviceBuffer<std::uint8_t> workspace_d(get_unique_workspace_size(input.size()));
 
   copy_to_device(input_d.get(), input);
 
-  const auto num_unique = unique(
-    input_d.get(), unique_d.get(), inverse_d.get(), counts_d.get(), workspace_d.get(), input.size(),
-    get_unique_workspace_size(input.size()), stream.get());
+  ASSERT_EQ(
+    unique(
+      input_d.get(), unique_d.get(), inverse_d.get(), counts_d.get(), num_unique_d.get(),
+      workspace_d.get(), input.size(), get_unique_workspace_size(input.size()), stream.get()),
+    cudaSuccess);
   ASSERT_EQ(cudaStreamSynchronize(stream.get()), cudaSuccess);
+
+  const auto num_unique = copy_to_host(num_unique_d.get(), 1U).front();
 
   const auto unique_values = copy_to_host(unique_d.get(), static_cast<std::size_t>(num_unique));
   const auto inverse_indices = copy_to_host(inverse_d.get(), input.size());
@@ -94,6 +99,28 @@ TEST(ReferenceKernelsTest, UniqueMatchesCpuReference)
   EXPECT_EQ(unique_values, reference.unique_values);
   EXPECT_EQ(inverse_indices, reference.inverse_indices);
   EXPECT_EQ(counts, reference.counts);
+}
+
+TEST(ReferenceKernelsTest, UniqueEmptyInputWritesZeroCount)
+{
+  SKIP_TEST_IF_CUDA_UNAVAILABLE();
+
+  CudaStreamGuard stream;
+  DeviceBuffer<std::int64_t> input_d(1U);
+  DeviceBuffer<std::int64_t> unique_d(1U);
+  DeviceBuffer<std::int64_t> inverse_d(1U);
+  DeviceBuffer<std::int64_t> counts_d(1U);
+  DeviceBuffer<std::int64_t> num_unique_d(1U);
+  DeviceBuffer<std::uint8_t> workspace_d(1U);
+
+  ASSERT_EQ(
+    unique(
+      input_d.get(), unique_d.get(), inverse_d.get(), counts_d.get(), num_unique_d.get(),
+      workspace_d.get(), 0U, 0U, stream.get()),
+    cudaSuccess);
+  ASSERT_EQ(cudaStreamSynchronize(stream.get()), cudaSuccess);
+
+  EXPECT_EQ(copy_to_host(num_unique_d.get(), 1U).front(), 0);
 }
 
 }  // namespace


### PR DESCRIPTION
## Summary

Removes Thrust, syncs and host/device copies from the TensorRT `Argsort` and `CustomUnique` plugins.

Benchmarks below are made using an internal version of PTv3.

## PR Stack

- [perf(autoware_tensorrt_plugins): remove Thrust from sort kernels](https://github.com/autowarefoundation/autoware_universe/pull/12554) (`ptv3-t18-no-thrust-c8f76ed-20260506`)
- [perf(autoware_tensorrt_plugins): keep SegmentCSR allocation-free](https://github.com/autowarefoundation/autoware_universe/pull/12555) (`ptv3-t18-no-thrust-no-alloc-e9515b790-20260506`)
- [perf(autoware_tensorrt_plugins): keep plugin outputs stream-ordered](https://github.com/autowarefoundation/autoware_universe/pull/12556) (`ptv3-t18-no-thrust-no-alloc-no-sync-13f3672a0-20260506`)
- [perf(autoware_tensorrt_plugins): cache max sort workspace bounds](https://github.com/autowarefoundation/autoware_universe/pull/12557) (`ptv3-t18-no-thrust-no-alloc-no-sync-maxnumel-47bf5656f-20260506`)
- [fix(ptv3): set TensorRT max auxiliary streams to 1](https://github.com/autowarefoundation/autoware_universe/pull/12558) (`ptv3-t18-no-thrust-no-alloc-no-sync-maxnumel-maxauxstreams1`)

## Details

### CustomUnique

* replaced Thrust with raw CUB calls
* cleaned up and documented workspace layout
* removed unnecessary result size copy to host and back to device, keeping result on GPU directly instead

| Description | Nsys |
|-|-|
| Before | <img width="3687" height="623" alt="Screenshot from 2026-05-26 14-36-57" src="https://github.com/user-attachments/assets/b198486d-58aa-4e04-97a7-02ac82c2b53c" /> |
| After (CUDA) | <img width="3687" height="623" alt="Screenshot from 2026-05-26 14-37-07" src="https://github.com/user-attachments/assets/0ce13eed-7a44-48fa-95e5-192ce0681b2e" /> |
| After (GPU) | <img width="3687" height="623" alt="Screenshot from 2026-05-26 14-38-33" src="https://github.com/user-attachments/assets/25cd501c-e813-44af-a4e0-ab3e4b2dafbf" /> |

### Argsort

* replaced Thrust with raw CUB calls
* cleaned up and documented workspace layout

| Description | Nsys |
|-|-|
| Before | <img width="3687" height="623" alt="Screenshot from 2026-05-26 14-42-22" src="https://github.com/user-attachments/assets/5339dd88-fa37-479e-9d14-2cc2413c65ba" />|
| After (CUDA) | <img width="3687" height="623" alt="Screenshot from 2026-05-26 14-42-27" src="https://github.com/user-attachments/assets/beea468d-96b5-43a8-a15f-52bf15b71eac" />|
| After (GPU) | <img width="3687" height="623" alt="Screenshot from 2026-05-26 14-42-51" src="https://github.com/user-attachments/assets/bb733c77-2583-428c-b402-cc5b46554e4e" />|

## Benchmarks

| Variant | Measurement | CPU mean (ms) | CPU p95 (ms) | CPU faster vs baseline | GPU mean (ms) | GPU p95 (ms) | GPU faster vs baseline | Mean voxels |
| --- | --- | --- | --- | --- | --- | --- | --- | --- |
| ptv3-t18 | series (7 x 50) | 30.542 | 33.195 | +0.0% | 29.419 | 32.023 | +0.0% | 120572 |
| ptv3-t18-pr12554 | series (7 x 50) | 28.611 | 29.198 | +6.7% | 28.599 | 29.184 | +2.9% | 120572 |

### Relative Performance

<img width="2980" height="892" alt="relative_to_baseline" src="https://github.com/user-attachments/assets/e8fb38b0-05ca-47fe-ae9f-bc70fce8f44d" />