### PR TITLE
perf(autoware_tensorrt_plugins): use pinned memory for spconv output size buffer

### DIFF
--- a/perception/autoware_tensorrt_plugins/include/autoware/tensorrt_plugins/get_indices_pairs_implicit_gemm_plugin.hpp
+++ b/perception/autoware_tensorrt_plugins/include/autoware/tensorrt_plugins/get_indices_pairs_implicit_gemm_plugin.hpp
@@ -69,7 +69,7 @@ public:
   GetIndicesPairsImplicitGemmPlugin(
     const std::string & name, GetIndicesPairsImplicitGemmParameters const & params);
 
-  ~GetIndicesPairsImplicitGemmPlugin() override = default;
+  ~GetIndicesPairsImplicitGemmPlugin() override;
 
   // IPluginV3 Methods
 
@@ -137,6 +137,7 @@ private:
 
   std::string layer_name_;
   GetIndicesPairsImplicitGemmParameters params_;
+  std::int32_t * num_act_out_host_{nullptr};
   std::vector<nvinfer1::PluginField> data_to_serialize_;
   nvinfer1::PluginFieldCollection fc_to_serialize_;
 };

--- a/perception/autoware_tensorrt_plugins/include/autoware/tensorrt_plugins/get_indices_pairs_implicit_gemm_plugin.hpp
+++ b/perception/autoware_tensorrt_plugins/include/autoware/tensorrt_plugins/get_indices_pairs_implicit_gemm_plugin.hpp
@@ -15,6 +15,8 @@
 #ifndef AUTOWARE__TENSORRT_PLUGINS__GET_INDICES_PAIRS_IMPLICIT_GEMM_PLUGIN_HPP_
 #define AUTOWARE__TENSORRT_PLUGINS__GET_INDICES_PAIRS_IMPLICIT_GEMM_PLUGIN_HPP_
 
+#include "autoware/tensorrt_plugins/pinned_host_buffer.hpp"
+
 #include <NvInferRuntime.h>
 #include <NvInferRuntimePlugin.h>
 #include <cuda_runtime.h>
@@ -69,7 +71,7 @@ public:
   GetIndicesPairsImplicitGemmPlugin(
     const std::string & name, GetIndicesPairsImplicitGemmParameters const & params);
 
-  ~GetIndicesPairsImplicitGemmPlugin() override;
+  ~GetIndicesPairsImplicitGemmPlugin() override = default;
 
   // IPluginV3 Methods
 
@@ -137,7 +139,7 @@ private:
 
   std::string layer_name_;
   GetIndicesPairsImplicitGemmParameters params_;
-  std::int32_t * num_act_out_host_{nullptr};
+  autoware::tensorrt_plugins::PinnedHostBuffer<std::int32_t> num_act_out_host_;
   std::vector<nvinfer1::PluginField> data_to_serialize_;
   nvinfer1::PluginFieldCollection fc_to_serialize_;
 };

--- a/perception/autoware_tensorrt_plugins/include/autoware/tensorrt_plugins/get_indices_pairs_plugin.hpp
+++ b/perception/autoware_tensorrt_plugins/include/autoware/tensorrt_plugins/get_indices_pairs_plugin.hpp
@@ -15,6 +15,8 @@
 #ifndef AUTOWARE__TENSORRT_PLUGINS__GET_INDICES_PAIRS_PLUGIN_HPP_
 #define AUTOWARE__TENSORRT_PLUGINS__GET_INDICES_PAIRS_PLUGIN_HPP_
 
+#include "autoware/tensorrt_plugins/pinned_host_buffer.hpp"
+
 #include <NvInferRuntime.h>
 #include <NvInferRuntimePlugin.h>
 #include <cuda_runtime.h>
@@ -61,7 +63,7 @@ class GetIndicesPairsPlugin : public IPluginV3,
 public:
   GetIndicesPairsPlugin(const std::string & name, GetIndicesPairsParameters const & params);
 
-  ~GetIndicesPairsPlugin() override;
+  ~GetIndicesPairsPlugin() override = default;
 
   // IPluginV3 Methods
 
@@ -125,7 +127,7 @@ private:
 
   std::string layer_name_;
   GetIndicesPairsParameters params_;
-  std::int32_t * num_act_out_host_{nullptr};
+  autoware::tensorrt_plugins::PinnedHostBuffer<std::int32_t> num_act_out_host_;
   std::vector<nvinfer1::PluginField> data_to_serialize_;
   nvinfer1::PluginFieldCollection fc_to_serialize_;
 };

--- a/perception/autoware_tensorrt_plugins/include/autoware/tensorrt_plugins/get_indices_pairs_plugin.hpp
+++ b/perception/autoware_tensorrt_plugins/include/autoware/tensorrt_plugins/get_indices_pairs_plugin.hpp
@@ -61,7 +61,7 @@ class GetIndicesPairsPlugin : public IPluginV3,
 public:
   GetIndicesPairsPlugin(const std::string & name, GetIndicesPairsParameters const & params);
 
-  ~GetIndicesPairsPlugin() override = default;
+  ~GetIndicesPairsPlugin() override;
 
   // IPluginV3 Methods
 
@@ -125,6 +125,7 @@ private:
 
   std::string layer_name_;
   GetIndicesPairsParameters params_;
+  std::int32_t * num_act_out_host_{nullptr};
   std::vector<nvinfer1::PluginField> data_to_serialize_;
   nvinfer1::PluginFieldCollection fc_to_serialize_;
 };

--- a/perception/autoware_tensorrt_plugins/include/autoware/tensorrt_plugins/pinned_host_buffer.hpp
+++ b/perception/autoware_tensorrt_plugins/include/autoware/tensorrt_plugins/pinned_host_buffer.hpp
@@ -1,0 +1,85 @@
+// Copyright 2025 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__TENSORRT_PLUGINS__PINNED_HOST_BUFFER_HPP_
+#define AUTOWARE__TENSORRT_PLUGINS__PINNED_HOST_BUFFER_HPP_
+
+#include "autoware/tensorrt_plugins/plugin_utils.hpp"
+
+#include <cuda_runtime_api.h>
+
+#include <cstddef>
+#include <utility>
+
+namespace autoware::tensorrt_plugins
+{
+
+/// RAII owner of a page-locked (pinned) host allocation obtained via `cudaMallocHost`.
+///
+/// Pinned host memory is needed whenever a host scalar is the source/destination of an async
+/// stream copy: the buffer must outlive the (asynchronous) copy, which a plain stack variable does
+/// not guarantee without a blocking `cudaStreamSynchronize`. Holding one of these as a plugin
+/// member keeps such copies stream-ordered while tying the allocation's lifetime to the plugin's.
+///
+/// Move-only: ownership is unique, so the buffer is freed exactly once.
+template <typename T>
+class PinnedHostBuffer
+{
+public:
+  /// Allocates `count` elements of pinned host memory. Aborts (via `PLUGIN_ASSERT`) on failure.
+  explicit PinnedHostBuffer(std::size_t count = 1U)
+  {
+    PLUGIN_ASSERT(
+      cudaMallocHost(reinterpret_cast<void **>(&data_), count * sizeof(T)) == cudaSuccess);
+  }
+
+  ~PinnedHostBuffer() { reset(); }
+
+  PinnedHostBuffer(const PinnedHostBuffer &) = delete;
+  PinnedHostBuffer & operator=(const PinnedHostBuffer &) = delete;
+
+  PinnedHostBuffer(PinnedHostBuffer && other) noexcept
+  : data_{std::exchange(other.data_, nullptr)}
+  {
+  }
+
+  PinnedHostBuffer & operator=(PinnedHostBuffer && other) noexcept
+  {
+    if (this != &other) {
+      reset();
+      data_ = std::exchange(other.data_, nullptr);
+    }
+    return *this;
+  }
+
+  [[nodiscard]] T * get() const noexcept { return data_; }
+  T & operator*() const noexcept { return *data_; }
+  T * operator->() const noexcept { return data_; }
+  T & operator[](std::size_t index) const noexcept { return data_[index]; }
+
+private:
+  void reset() noexcept
+  {
+    if (data_ != nullptr) {
+      cudaFreeHost(data_);
+      data_ = nullptr;
+    }
+  }
+
+  T * data_{nullptr};
+};
+
+}  // namespace autoware::tensorrt_plugins
+
+#endif  // AUTOWARE__TENSORRT_PLUGINS__PINNED_HOST_BUFFER_HPP_

--- a/perception/autoware_tensorrt_plugins/include/autoware/tensorrt_plugins/pinned_host_buffer.hpp
+++ b/perception/autoware_tensorrt_plugins/include/autoware/tensorrt_plugins/pinned_host_buffer.hpp
@@ -32,7 +32,8 @@ namespace autoware::tensorrt_plugins
 ///
 /// This class makes lifetime management of such pinned host buffers easy and safe.
 ///
-/// Read more: https://docs.nvidia.com/cuda/cuda-programming-guide/02-basics/asynchronous-execution.html#launching-memory-transfers-in-cuda-streams
+/// Read more:
+/// https://docs.nvidia.com/cuda/cuda-programming-guide/02-basics/asynchronous-execution.html#launching-memory-transfers-in-cuda-streams
 ///
 /// Move-only: ownership is unique, so the buffer is freed exactly once.
 template <typename T>
@@ -51,8 +52,7 @@ public:
   PinnedHostBuffer(const PinnedHostBuffer &) = delete;
   PinnedHostBuffer & operator=(const PinnedHostBuffer &) = delete;
 
-  PinnedHostBuffer(PinnedHostBuffer && other) noexcept
-  : data_{std::exchange(other.data_, nullptr)}
+  PinnedHostBuffer(PinnedHostBuffer && other) noexcept : data_{std::exchange(other.data_, nullptr)}
   {
   }
 

--- a/perception/autoware_tensorrt_plugins/include/autoware/tensorrt_plugins/pinned_host_buffer.hpp
+++ b/perception/autoware_tensorrt_plugins/include/autoware/tensorrt_plugins/pinned_host_buffer.hpp
@@ -1,4 +1,4 @@
-// Copyright 2025 TIER IV, Inc.
+// Copyright 2026 TIER IV, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -27,10 +27,12 @@ namespace autoware::tensorrt_plugins
 
 /// RAII owner of a page-locked (pinned) host allocation obtained via `cudaMallocHost`.
 ///
-/// Pinned host memory is needed whenever a host scalar is the source/destination of an async
-/// stream copy: the buffer must outlive the (asynchronous) copy, which a plain stack variable does
-/// not guarantee without a blocking `cudaStreamSynchronize`. Holding one of these as a plugin
-/// member keeps such copies stream-ordered while tying the allocation's lifetime to the plugin's.
+/// `cudaMemcpyAsync` is only asynchronous if the host memory is pinned, so performance can be
+/// improved by using pinned host memory in some cases.
+///
+/// This class makes lifetime management of such pinned host buffers easy and safe.
+///
+/// Read more: https://docs.nvidia.com/cuda/cuda-programming-guide/02-basics/asynchronous-execution.html#launching-memory-transfers-in-cuda-streams
 ///
 /// Move-only: ownership is unique, so the buffer is freed exactly once.
 template <typename T>

--- a/perception/autoware_tensorrt_plugins/src/get_indices_pairs_implicit_gemm_plugin.cpp
+++ b/perception/autoware_tensorrt_plugins/src/get_indices_pairs_implicit_gemm_plugin.cpp
@@ -437,8 +437,8 @@ std::int32_t GetIndicesPairsImplicitGemmPlugin::enqueue(
   }
 
   std::int32_t num_act_out_real = std::get<1>(pair_res);
-  std::int32_t * num_act_out_data = static_cast<std::int32_t *>(outputs[4]);
   *num_act_out_host_ = num_act_out_real;
+  auto * num_act_out_data = static_cast<std::int32_t *>(outputs[4]);
 
   cudaError_t const status = cudaMemcpyAsync(
     num_act_out_data, num_act_out_host_.get(), sizeof(std::int32_t), cudaMemcpyHostToDevice,

--- a/perception/autoware_tensorrt_plugins/src/get_indices_pairs_implicit_gemm_plugin.cpp
+++ b/perception/autoware_tensorrt_plugins/src/get_indices_pairs_implicit_gemm_plugin.cpp
@@ -43,16 +43,6 @@ GetIndicesPairsImplicitGemmPlugin::GetIndicesPairsImplicitGemmPlugin(
 : layer_name_{name}, params_{params}
 {
   initFieldsToSerialize();
-  PLUGIN_ASSERT(
-    cudaMallocHost(reinterpret_cast<void **>(&num_act_out_host_), sizeof(std::int32_t)) ==
-    cudaSuccess);
-}
-
-GetIndicesPairsImplicitGemmPlugin::~GetIndicesPairsImplicitGemmPlugin()
-{
-  if (num_act_out_host_ != nullptr) {
-    cudaFreeHost(num_act_out_host_);
-  }
 }
 
 void GetIndicesPairsImplicitGemmPlugin::initFieldsToSerialize()
@@ -451,7 +441,8 @@ std::int32_t GetIndicesPairsImplicitGemmPlugin::enqueue(
   *num_act_out_host_ = num_act_out_real;
 
   cudaError_t const status = cudaMemcpyAsync(
-    num_act_out_data, num_act_out_host_, sizeof(std::int32_t), cudaMemcpyHostToDevice, stream);
+    num_act_out_data, num_act_out_host_.get(), sizeof(std::int32_t), cudaMemcpyHostToDevice,
+    stream);
 
   return status;
 }

--- a/perception/autoware_tensorrt_plugins/src/get_indices_pairs_implicit_gemm_plugin.cpp
+++ b/perception/autoware_tensorrt_plugins/src/get_indices_pairs_implicit_gemm_plugin.cpp
@@ -43,6 +43,16 @@ GetIndicesPairsImplicitGemmPlugin::GetIndicesPairsImplicitGemmPlugin(
 : layer_name_{name}, params_{params}
 {
   initFieldsToSerialize();
+  PLUGIN_ASSERT(
+    cudaMallocHost(reinterpret_cast<void **>(&num_act_out_host_), sizeof(std::int32_t)) ==
+    cudaSuccess);
+}
+
+GetIndicesPairsImplicitGemmPlugin::~GetIndicesPairsImplicitGemmPlugin()
+{
+  if (num_act_out_host_ != nullptr) {
+    cudaFreeHost(num_act_out_host_);
+  }
 }
 
 void GetIndicesPairsImplicitGemmPlugin::initFieldsToSerialize()
@@ -438,9 +448,10 @@ std::int32_t GetIndicesPairsImplicitGemmPlugin::enqueue(
 
   std::int32_t num_act_out_real = std::get<1>(pair_res);
   std::int32_t * num_act_out_data = static_cast<std::int32_t *>(outputs[4]);
+  *num_act_out_host_ = num_act_out_real;
 
   cudaError_t const status = cudaMemcpyAsync(
-    num_act_out_data, &num_act_out_real, sizeof(std::int32_t), cudaMemcpyHostToDevice, stream);
+    num_act_out_data, num_act_out_host_, sizeof(std::int32_t), cudaMemcpyHostToDevice, stream);
 
   return status;
 }

--- a/perception/autoware_tensorrt_plugins/src/get_indices_pairs_plugin.cpp
+++ b/perception/autoware_tensorrt_plugins/src/get_indices_pairs_plugin.cpp
@@ -289,8 +289,8 @@ std::int32_t GetIndicesPairsPlugin::enqueue(
       stream);
   }
 
-  std::int32_t * num_act_out_data = static_cast<std::int32_t *>(outputs[3]);
   *num_act_out_host_ = num_act_out_real;
+  auto * num_act_out_data = static_cast<std::int32_t *>(outputs[3]);
 
   cudaError_t const status = cudaMemcpyAsync(
     num_act_out_data, num_act_out_host_.get(), sizeof(std::int32_t), cudaMemcpyHostToDevice,

--- a/perception/autoware_tensorrt_plugins/src/get_indices_pairs_plugin.cpp
+++ b/perception/autoware_tensorrt_plugins/src/get_indices_pairs_plugin.cpp
@@ -40,6 +40,16 @@ GetIndicesPairsPlugin::GetIndicesPairsPlugin(
 : layer_name_{name}, params_{params}
 {
   initFieldsToSerialize();
+  PLUGIN_ASSERT(
+    cudaMallocHost(reinterpret_cast<void **>(&num_act_out_host_), sizeof(std::int32_t)) ==
+    cudaSuccess);
+}
+
+GetIndicesPairsPlugin::~GetIndicesPairsPlugin()
+{
+  if (num_act_out_host_ != nullptr) {
+    cudaFreeHost(num_act_out_host_);
+  }
 }
 
 void GetIndicesPairsPlugin::initFieldsToSerialize()
@@ -290,11 +300,10 @@ std::int32_t GetIndicesPairsPlugin::enqueue(
   }
 
   std::int32_t * num_act_out_data = static_cast<std::int32_t *>(outputs[3]);
+  *num_act_out_host_ = num_act_out_real;
 
   cudaError_t const status = cudaMemcpyAsync(
-    num_act_out_data, &num_act_out_real, sizeof(std::int32_t), cudaMemcpyHostToDevice, stream);
-
-  cudaStreamSynchronize(stream);
+    num_act_out_data, num_act_out_host_, sizeof(std::int32_t), cudaMemcpyHostToDevice, stream);
 
   return status;
 }

--- a/perception/autoware_tensorrt_plugins/src/get_indices_pairs_plugin.cpp
+++ b/perception/autoware_tensorrt_plugins/src/get_indices_pairs_plugin.cpp
@@ -40,16 +40,6 @@ GetIndicesPairsPlugin::GetIndicesPairsPlugin(
 : layer_name_{name}, params_{params}
 {
   initFieldsToSerialize();
-  PLUGIN_ASSERT(
-    cudaMallocHost(reinterpret_cast<void **>(&num_act_out_host_), sizeof(std::int32_t)) ==
-    cudaSuccess);
-}
-
-GetIndicesPairsPlugin::~GetIndicesPairsPlugin()
-{
-  if (num_act_out_host_ != nullptr) {
-    cudaFreeHost(num_act_out_host_);
-  }
 }
 
 void GetIndicesPairsPlugin::initFieldsToSerialize()
@@ -303,7 +293,8 @@ std::int32_t GetIndicesPairsPlugin::enqueue(
   *num_act_out_host_ = num_act_out_real;
 
   cudaError_t const status = cudaMemcpyAsync(
-    num_act_out_data, num_act_out_host_, sizeof(std::int32_t), cudaMemcpyHostToDevice, stream);
+    num_act_out_data, num_act_out_host_.get(), sizeof(std::int32_t), cudaMemcpyHostToDevice,
+    stream);
 
   return status;
 }


### PR DESCRIPTION
## Summary

Introduces a `PinnedHostBuffer` RAII wrapper around `cudaMallocHost`/`cudaFreeHost` and uses it for the spconv output-size buffer in `GetIndicesPairsPlugin` and `GetIndicesPairsImplicitGemmPlugin`. Built on the no-Thrust sort-kernel work (#12554, merged).

Benchmarked variant: `ptv3-t18-trtperf-3-pr12556-b6356d78-20260603`.

## Cohort

All target `main`. #12554 has **landed**; #12555 and #12556 are independent siblings that each branch directly off the #12554 squash-merge, so both already contain #12554.

- [perf(autoware_tensorrt_plugins): remove Thrust from sort kernels](https://github.com/autowarefoundation/autoware_universe/pull/12554) — merged
- [perf(autoware_tensorrt_plugins): keep SegmentCSR allocation-free](https://github.com/autowarefoundation/autoware_universe/pull/12555)
- [perf(autoware_tensorrt_plugins): use pinned memory for spconv output size buffer](https://github.com/autowarefoundation/autoware_universe/pull/12556)

## Benchmarks

PTv3-T18, benchmark series (7 replicates × 50 iterations), RTX 4000 SFF Ada. Source report: `reports/2026-06-03_16-51-04/report.md`.

All four points sit on one `autoware_universe` lineage rooted at the **landed #12554** squash-merge (`merge-base(12555, 12556) = f15e433ab4`), so each variant is measured **as built**: the #12555 and #12556 rows **already include #12554**, and "faster vs baseline" is the combined effect. To isolate a single PR, compare its row against the **+#12554** row.

| Variant (`autoware_universe`) | Contains | GPU mean (ms) | GPU p95 (ms) | Faster vs pre-12554 baseline |
| --- | --- | --- | --- | --- |
| `…-0-base` (`7d47ca4553`) | pre-#12554 baseline | 29.21 | 31.30 | — |
| `…-1-pr12554` (`f15e433ab4`) | #12554 | 26.86 | 27.06 | +8.8% |
| `…-2-pr12555` (`5bded66f5c`) | #12554 + #12555 | 26.14 | 27.11 | +11.8% |
| `…-3-pr12556` (`b6356d78ab`) | #12554 + #12556 | 27.15 | 27.83 | +7.6% |

**Isolated effect of #12556** (vs +#12554): 26.86 → 27.15 ms = **−1.1%** — a slight regression on this PTv3-T18 path; the pinned-buffer change does not help here.

### Relative performance vs baseline

![Relative performance vs pre-12554 baseline](https://gist.githubusercontent.com/mojomex/b00aa898163bde234e97566987a6a0b7/raw/ptv3_trtperf_relative_to_baseline.svg)

CPU-side totals equal the GPU totals shown (the harness reports a single GPU-synchronised total); `num_voxels` is not captured in this run. Full stage breakdown + provenance (per-variant commit and engine SHA256): see the source report.
