### PR TITLE
perf(autoware_tensorrt_plugins): cache max sort workspace bounds

### DIFF
--- a/perception/autoware_tensorrt_plugins/CMakeLists.txt
+++ b/perception/autoware_tensorrt_plugins/CMakeLists.txt
@@ -147,6 +147,25 @@ if(TRT_AVAIL AND CUDA_AVAIL AND SPCONV_AVAIL)
       spconv::spconv
   )
 
+  if(BUILD_TESTING)
+    find_package(ament_cmake_gtest REQUIRED)
+
+    ament_add_gtest(reference_kernels_test
+      test/reference_kernels_test.cpp
+    )
+    if(TARGET reference_kernels_test)
+      target_link_libraries(reference_kernels_test
+        CUDA::cudart
+        cuda_ops
+      )
+      target_include_directories(reference_kernels_test PRIVATE
+        include
+        ${CUDA_INCLUDE_DIRS}
+      )
+      target_compile_definitions(reference_kernels_test PRIVATE _GLIBCXX_USE_CXX11_ABI=1)
+    endif()
+  endif()
+
   install(
     TARGETS ${PROJECT_NAME}
     DESTINATION share/${PROJECT_NAME}/plugins

--- a/perception/autoware_tensorrt_plugins/include/autoware/scatter_ops/segment_csr.h
+++ b/perception/autoware_tensorrt_plugins/include/autoware/scatter_ops/segment_csr.h
@@ -26,18 +26,10 @@
 #include <cuda_runtime.h>
 
 #include <tuple>
-#include <vector>
 
 template <typename scalar_t, ReductionType REDUCE>
 int32_t segment_csr_launch(
-  const scalar_t * src, const std::vector<int32_t> & src_size, const int64_t * indptr,
-  const std::vector<int32_t> & indptr_size, const scalar_t * base,
-  std::tuple<scalar_t *, int64_t *> out, cudaStream_t stream);
-
-template <typename scalar_t, ReductionType REDUCE>
-int32_t segment_csr_launch(
-  const scalar_t * src, const std::vector<int32_t> & src_size, const int64_t * indptr,
-  const std::vector<int32_t> & indptr_size, std::tuple<scalar_t *, int64_t *> out,
-  cudaStream_t stream);
+  const scalar_t * src, int32_t num_rows, int32_t num_cols, const int64_t * indptr,
+  int32_t indptr_size, std::tuple<scalar_t *, int64_t *> out, cudaStream_t stream);
 
 #endif  // AUTOWARE__SCATTER_OPS__SEGMENT_CSR_H_

--- a/perception/autoware_tensorrt_plugins/include/autoware/tensorrt_plugins/argsort_plugin.hpp
+++ b/perception/autoware_tensorrt_plugins/include/autoware/tensorrt_plugins/argsort_plugin.hpp
@@ -38,6 +38,7 @@ class ArgsortPlugin : public IPluginV3,
 {
 public:
   explicit ArgsortPlugin(const std::string & name) noexcept;
+  ArgsortPlugin(const std::string & name, std::int64_t max_num_elements) noexcept;
 
   ~ArgsortPlugin() override = default;
 
@@ -97,10 +98,11 @@ public:
 
 private:
   void initFieldsToSerialize();
+  void updateMaxNumElements(std::int64_t max_num_elements);
 
   std::string layer_name_;
-  std::size_t argsort_workspace_size_{0};
-  std::size_t max_num_elements_{0};
+  std::size_t max_temp_storage_size_{0};
+  std::int64_t max_num_elements_{0};
   std::vector<nvinfer1::PluginField> data_to_serialize_;
   nvinfer1::PluginFieldCollection fc_to_serialize_;
 };

--- a/perception/autoware_tensorrt_plugins/include/autoware/tensorrt_plugins/get_indices_pairs_implicit_gemm_plugin.hpp
+++ b/perception/autoware_tensorrt_plugins/include/autoware/tensorrt_plugins/get_indices_pairs_implicit_gemm_plugin.hpp
@@ -63,7 +63,7 @@ public:
   GetIndicesPairsImplicitGemmPlugin(
     const std::string & name, GetIndicesPairsImplicitGemmParameters const & params);
 
-  ~GetIndicesPairsImplicitGemmPlugin() override = default;
+  ~GetIndicesPairsImplicitGemmPlugin() override;
 
   // IPluginV3 Methods
 
@@ -131,6 +131,7 @@ private:
 
   std::string layer_name_;
   GetIndicesPairsImplicitGemmParameters params_;
+  std::int32_t * num_act_out_host_{nullptr};
   std::vector<nvinfer1::PluginField> data_to_serialize_;
   nvinfer1::PluginFieldCollection fc_to_serialize_;
 };

--- a/perception/autoware_tensorrt_plugins/include/autoware/tensorrt_plugins/get_indices_pairs_plugin.hpp
+++ b/perception/autoware_tensorrt_plugins/include/autoware/tensorrt_plugins/get_indices_pairs_plugin.hpp
@@ -61,7 +61,7 @@ class GetIndicesPairsPlugin : public IPluginV3,
 public:
   GetIndicesPairsPlugin(const std::string & name, GetIndicesPairsParameters const & params);
 
-  ~GetIndicesPairsPlugin() override = default;
+  ~GetIndicesPairsPlugin() override;
 
   // IPluginV3 Methods
 
@@ -125,6 +125,7 @@ private:
 
   std::string layer_name_;
   GetIndicesPairsParameters params_;
+  std::int32_t * num_act_out_host_{nullptr};
   std::vector<nvinfer1::PluginField> data_to_serialize_;
   nvinfer1::PluginFieldCollection fc_to_serialize_;
 };

--- a/perception/autoware_tensorrt_plugins/include/autoware/tensorrt_plugins/unique_plugin.hpp
+++ b/perception/autoware_tensorrt_plugins/include/autoware/tensorrt_plugins/unique_plugin.hpp
@@ -38,6 +38,7 @@ class UniquePlugin : public IPluginV3,
 {
 public:
   explicit UniquePlugin(const std::string & name) noexcept;
+  UniquePlugin(const std::string & name, std::int64_t max_num_elements) noexcept;
 
   ~UniquePlugin() override = default;
 
@@ -97,9 +98,11 @@ public:
 
 private:
   void initFieldsToSerialize();
+  void updateMaxNumElements(std::int64_t max_num_elements);
 
   std::string layer_name_;
-  std::size_t workspace_size_{0};
+  std::size_t max_temp_storage_size_{0};
+  std::int64_t max_num_elements_{0};
   std::vector<nvinfer1::PluginField> data_to_serialize_;
   nvinfer1::PluginFieldCollection fc_to_serialize_;
 };

--- a/perception/autoware_tensorrt_plugins/include/autoware/unique_ops/unique.hpp
+++ b/perception/autoware_tensorrt_plugins/include/autoware/unique_ops/unique.hpp
@@ -24,6 +24,7 @@ std::int64_t unique(
   std::int64_t * unique_counts, void * workspace, std::size_t num_input_elements,
   std::size_t workspace_size, cudaStream_t stream);
 
+std::size_t get_unique_temp_storage_size(std::size_t num_elements);
 std::size_t get_unique_workspace_size(std::size_t num_elements);
 
 #endif  // AUTOWARE__UNIQUE_OPS__UNIQUE_HPP_

--- a/perception/autoware_tensorrt_plugins/include/autoware/unique_ops/unique.hpp
+++ b/perception/autoware_tensorrt_plugins/include/autoware/unique_ops/unique.hpp
@@ -19,10 +19,10 @@
 
 #include <cstdint>
 
-std::int64_t unique(
+cudaError_t unique(
   const std::int64_t * input, std::int64_t * unique, std::int64_t * inverse_indices,
-  std::int64_t * unique_counts, void * workspace, std::size_t num_input_elements,
-  std::size_t workspace_size, cudaStream_t stream);
+  std::int64_t * unique_counts, std::int64_t * num_unique, void * workspace,
+  std::size_t num_input_elements, std::size_t workspace_size, cudaStream_t stream);
 
 std::size_t get_unique_temp_storage_size(std::size_t num_elements);
 std::size_t get_unique_workspace_size(std::size_t num_elements);

--- a/perception/autoware_tensorrt_plugins/package.xml
+++ b/perception/autoware_tensorrt_plugins/package.xml
@@ -20,8 +20,8 @@
   <depend>autoware_cuda_dependency_meta</depend>
   <depend>autoware_cuda_utils</depend>
 
-  <test_depend>ament_cmake_ros</test_depend>
   <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>ament_cmake_ros</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>
 

--- a/perception/autoware_tensorrt_plugins/package.xml
+++ b/perception/autoware_tensorrt_plugins/package.xml
@@ -21,6 +21,7 @@
   <depend>autoware_cuda_utils</depend>
 
   <test_depend>ament_cmake_ros</test_depend>
+  <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>
 

--- a/perception/autoware_tensorrt_plugins/src/argsort_ops/argsort.cu
+++ b/perception/autoware_tensorrt_plugins/src/argsort_ops/argsort.cu
@@ -16,25 +16,52 @@
 
 #include <cub/cub.cuh>
 
-#include <thrust/device_ptr.h>
-#include <thrust/execution_policy.h>
-#include <thrust/sequence.h>
+namespace
+{
+
+constexpr int kThreadsPerBlock = 256;
+
+std::size_t align_up(const std::size_t size, const std::size_t alignment)
+{
+  return ((size + alignment - 1U) / alignment) * alignment;
+}
+
+__global__ void fill_iota(std::int64_t * output, const std::size_t num_elements)
+{
+  const auto index = static_cast<std::size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (index >= num_elements) {
+    return;
+  }
+
+  output[index] = static_cast<std::int64_t>(index);
+}
+
+}  // namespace
 
 cudaError_t argsort(
   const std::int64_t * input_d, std::int64_t * output_d, void * workspace, std::size_t num_elements,
   std::size_t argsort_workspace_size, cudaStream_t stream)
 {
-  int workspace_offset = (argsort_workspace_size + sizeof(std::int64_t) - 1) / sizeof(std::int64_t);
-  thrust::device_ptr<std::int64_t> idx_ptr(
-    &reinterpret_cast<std::int64_t *>(workspace)[workspace_offset]);
+  if (num_elements == 0U) {
+    return cudaSuccess;
+  }
 
-  thrust::sequence(thrust::cuda::par.on(stream), idx_ptr, idx_ptr + num_elements, 0);
+  const auto scratch_offset = align_up(argsort_workspace_size, alignof(std::int64_t));
+  auto * input_idx_d =
+    reinterpret_cast<std::int64_t *>(reinterpret_cast<char *>(workspace) + scratch_offset);
+  auto * input_sorted_d = input_idx_d + num_elements;
 
-  std::int64_t * input_sorted_d = thrust::raw_pointer_cast(idx_ptr) + num_elements;
+  const auto num_blocks =
+    static_cast<unsigned int>((num_elements + kThreadsPerBlock - 1U) / kThreadsPerBlock);
+  fill_iota<<<num_blocks, kThreadsPerBlock, 0, stream>>>(input_idx_d, num_elements);
+  cudaError_t status = cudaGetLastError();
+  if (status != cudaSuccess) {
+    return status;
+  }
 
   return cub::DeviceRadixSort::SortPairs(
-    workspace, argsort_workspace_size, input_d, input_sorted_d, thrust::raw_pointer_cast(idx_ptr),
-    output_d, num_elements, 0, 64, stream);
+    workspace, argsort_workspace_size, input_d, input_sorted_d, input_idx_d, output_d, num_elements,
+    0, 64, stream);
 }
 
 std::size_t get_argsort_workspace_size(std::size_t num_elements)

--- a/perception/autoware_tensorrt_plugins/src/argsort_plugin.cpp
+++ b/perception/autoware_tensorrt_plugins/src/argsort_plugin.cpp
@@ -149,14 +149,11 @@ std::int32_t ArgsortPlugin::enqueue(
   cudaStream_t stream) noexcept
 {
   auto num_elements = static_cast<std::size_t>(input_desc[0].dims.d[0]);
-  if (max_num_elements_ < num_elements) {
-    max_num_elements_ = num_elements;
-    argsort_workspace_size_ = get_argsort_workspace_size(max_num_elements_);
-  }
+  const auto workspace_size = get_argsort_workspace_size(num_elements);
 
   return argsort(
     reinterpret_cast<std::int64_t const *>(inputs[0]), reinterpret_cast<std::int64_t *>(outputs[0]),
-    workspace, num_elements, argsort_workspace_size_, stream);
+    workspace, num_elements, workspace_size, stream);
 }
 
 std::int32_t ArgsortPlugin::onShapeChange(
@@ -183,8 +180,10 @@ std::size_t ArgsortPlugin::getWorkspaceSize(
   [[maybe_unused]] std::int32_t num_outputs) const noexcept
 {
   std::int64_t max_num_elements = inputs[0].max.d[0];
-  return get_argsort_workspace_size(max_num_elements) +
-         sizeof(std::int64_t) * 2 * (max_num_elements + 1);
+  const auto temp_size = get_argsort_workspace_size(max_num_elements);
+  const auto scratch_offset =
+    ((temp_size + alignof(std::int64_t) - 1U) / alignof(std::int64_t)) * alignof(std::int64_t);
+  return scratch_offset + sizeof(std::int64_t) * 2 * max_num_elements;
 }
 
 }  // namespace nvinfer1::plugin

--- a/perception/autoware_tensorrt_plugins/src/argsort_plugin.cpp
+++ b/perception/autoware_tensorrt_plugins/src/argsort_plugin.cpp
@@ -20,6 +20,7 @@
 #include <NvInferRuntime.h>
 #include <NvInferRuntimePlugin.h>
 
+#include <algorithm>
 #include <cstdint>
 #include <cstring>
 #include <exception>
@@ -29,14 +30,50 @@
 namespace nvinfer1::plugin
 {
 
+namespace
+{
+
+std::size_t alignUp(const std::size_t size, const std::size_t alignment)
+{
+  return ((size + alignment - 1U) / alignment) * alignment;
+}
+
+std::size_t getTotalWorkspaceSize(
+  const std::size_t temp_storage_size, const std::size_t max_num_elements)
+{
+  return alignUp(temp_storage_size, alignof(std::int64_t)) +
+         sizeof(std::int64_t) * 2U * max_num_elements;
+}
+
+}  // namespace
+
 ArgsortPlugin::ArgsortPlugin(const std::string & name) noexcept : layer_name_{name}
 {
   initFieldsToSerialize();
 }
 
+ArgsortPlugin::ArgsortPlugin(const std::string & name, const std::int64_t max_num_elements) noexcept
+: layer_name_{name}
+{
+  updateMaxNumElements(max_num_elements);
+  initFieldsToSerialize();
+}
+
+void ArgsortPlugin::updateMaxNumElements(const std::int64_t max_num_elements)
+{
+  PLUGIN_ASSERT(max_num_elements >= 0);
+
+  max_num_elements_ = std::max(max_num_elements_, max_num_elements);
+  max_temp_storage_size_ = std::max(
+    max_temp_storage_size_,
+    get_argsort_workspace_size(static_cast<std::size_t>(max_num_elements_)));
+}
+
 void ArgsortPlugin::initFieldsToSerialize()
 {
   data_to_serialize_.clear();
+  data_to_serialize_.emplace_back(
+    "max_num_elements", &max_num_elements_, PluginFieldType::kINT64, 1);
   fc_to_serialize_.nbFields = data_to_serialize_.size();
   fc_to_serialize_.fields = data_to_serialize_.data();
 }
@@ -61,7 +98,7 @@ IPluginCapability * ArgsortPlugin::getCapabilityInterface(PluginCapabilityType t
 IPluginV3 * ArgsortPlugin::clone() noexcept
 {
   try {
-    IPluginV3 * const plugin{new ArgsortPlugin{layer_name_}};
+    IPluginV3 * const plugin{new ArgsortPlugin{layer_name_, max_num_elements_}};
     return plugin;
   } catch (std::exception const & e) {
     caughtError(e);
@@ -100,6 +137,7 @@ std::int32_t ArgsortPlugin::configurePlugin(
   PLUGIN_ASSERT(out[0].desc.dims.nbDims == 1);
 
   PLUGIN_ASSERT(out[0].desc.type == in[0].desc.type);
+  updateMaxNumElements(in[0].max.d[0]);
 
   return 0;
 }
@@ -149,11 +187,14 @@ std::int32_t ArgsortPlugin::enqueue(
   cudaStream_t stream) noexcept
 {
   auto num_elements = static_cast<std::size_t>(input_desc[0].dims.d[0]);
-  const auto workspace_size = get_argsort_workspace_size(num_elements);
+  PLUGIN_ASSERT(static_cast<std::int64_t>(num_elements) <= max_num_elements_);
+  const auto temp_storage_size = max_temp_storage_size_ == 0U
+                                   ? get_argsort_workspace_size(num_elements)
+                                   : max_temp_storage_size_;
 
   return argsort(
     reinterpret_cast<std::int64_t const *>(inputs[0]), reinterpret_cast<std::int64_t *>(outputs[0]),
-    workspace, num_elements, workspace_size, stream);
+    workspace, num_elements, temp_storage_size, stream);
 }
 
 std::int32_t ArgsortPlugin::onShapeChange(
@@ -179,11 +220,13 @@ std::size_t ArgsortPlugin::getWorkspaceSize(
   [[maybe_unused]] DynamicPluginTensorDesc const * outputs,
   [[maybe_unused]] std::int32_t num_outputs) const noexcept
 {
-  std::int64_t max_num_elements = inputs[0].max.d[0];
-  const auto temp_size = get_argsort_workspace_size(max_num_elements);
-  const auto scratch_offset =
-    ((temp_size + alignof(std::int64_t) - 1U) / alignof(std::int64_t)) * alignof(std::int64_t);
-  return scratch_offset + sizeof(std::int64_t) * 2 * max_num_elements;
+  const auto max_num_elements =
+    std::max(max_num_elements_, static_cast<std::int64_t>(inputs[0].max.d[0]));
+  const auto temp_storage_size =
+    max_temp_storage_size_ == 0U
+      ? get_argsort_workspace_size(static_cast<std::size_t>(max_num_elements))
+      : max_temp_storage_size_;
+  return getTotalWorkspaceSize(temp_storage_size, static_cast<std::size_t>(max_num_elements));
 }
 
 }  // namespace nvinfer1::plugin

--- a/perception/autoware_tensorrt_plugins/src/argsort_plugin_creator.cpp
+++ b/perception/autoware_tensorrt_plugins/src/argsort_plugin_creator.cpp
@@ -19,6 +19,8 @@
 
 #include <NvInferRuntimePlugin.h>
 
+#include <cstdint>
+#include <exception>
 #include <string>
 
 namespace nvinfer1::plugin
@@ -39,10 +41,32 @@ nvinfer1::PluginFieldCollection const * ArgsortPluginCreator::getFieldNames() no
 }
 
 IPluginV3 * ArgsortPluginCreator::createPlugin(
-  char const * name, [[maybe_unused]] PluginFieldCollection const * fc,
-  [[maybe_unused]] TensorRTPhase phase) noexcept
+  char const * name, PluginFieldCollection const * fc, TensorRTPhase phase) noexcept
 {
-  return new (std::nothrow) ArgsortPlugin(std::string(name));
+  try {
+    PLUGIN_VALIDATE(fc != nullptr);
+
+    if (phase == TensorRTPhase::kBUILD) {
+      PLUGIN_VALIDATE(fc->nbFields == 0);
+      return new (std::nothrow) ArgsortPlugin(std::string(name));
+    }
+
+    if (phase == TensorRTPhase::kRUNTIME) {
+      nvinfer1::PluginField const * fields{fc->fields};
+      PLUGIN_VALIDATE(fc->nbFields == 1);
+      PLUGIN_VALIDATE(fields[0].name != nullptr);
+      PLUGIN_VALIDATE(std::string(fields[0].name) == "max_num_elements");
+      PLUGIN_VALIDATE(fields[0].type == nvinfer1::PluginFieldType::kINT64);
+      PLUGIN_VALIDATE(fields[0].length == 1);
+
+      return new (std::nothrow)
+        ArgsortPlugin(std::string(name), *static_cast<std::int64_t const *>(fields[0].data));
+    }
+  } catch (std::exception const & e) {
+    caughtError(e);
+  }
+
+  return nullptr;
 }
 
 }  // namespace nvinfer1::plugin

--- a/perception/autoware_tensorrt_plugins/src/get_indices_pairs_implicit_gemm_plugin.cpp
+++ b/perception/autoware_tensorrt_plugins/src/get_indices_pairs_implicit_gemm_plugin.cpp
@@ -43,6 +43,16 @@ GetIndicesPairsImplicitGemmPlugin::GetIndicesPairsImplicitGemmPlugin(
 : layer_name_{name}, params_{params}
 {
   initFieldsToSerialize();
+  PLUGIN_ASSERT(
+    cudaMallocHost(reinterpret_cast<void **>(&num_act_out_host_), sizeof(std::int32_t)) ==
+    cudaSuccess);
+}
+
+GetIndicesPairsImplicitGemmPlugin::~GetIndicesPairsImplicitGemmPlugin()
+{
+  if (num_act_out_host_ != nullptr) {
+    cudaFreeHost(num_act_out_host_);
+  }
 }
 
 void GetIndicesPairsImplicitGemmPlugin::initFieldsToSerialize()
@@ -437,9 +447,10 @@ std::int32_t GetIndicesPairsImplicitGemmPlugin::enqueue(
 
   std::int32_t num_act_out_real = std::get<1>(pair_res);
   std::int32_t * num_act_out_data = static_cast<std::int32_t *>(outputs[4]);
+  *num_act_out_host_ = num_act_out_real;
 
   cudaError_t const status = cudaMemcpyAsync(
-    num_act_out_data, &num_act_out_real, sizeof(std::int32_t), cudaMemcpyHostToDevice, stream);
+    num_act_out_data, num_act_out_host_, sizeof(std::int32_t), cudaMemcpyHostToDevice, stream);
 
   return status;
 }

--- a/perception/autoware_tensorrt_plugins/src/get_indices_pairs_plugin.cpp
+++ b/perception/autoware_tensorrt_plugins/src/get_indices_pairs_plugin.cpp
@@ -40,6 +40,16 @@ GetIndicesPairsPlugin::GetIndicesPairsPlugin(
 : layer_name_{name}, params_{params}
 {
   initFieldsToSerialize();
+  PLUGIN_ASSERT(
+    cudaMallocHost(reinterpret_cast<void **>(&num_act_out_host_), sizeof(std::int32_t)) ==
+    cudaSuccess);
+}
+
+GetIndicesPairsPlugin::~GetIndicesPairsPlugin()
+{
+  if (num_act_out_host_ != nullptr) {
+    cudaFreeHost(num_act_out_host_);
+  }
 }
 
 void GetIndicesPairsPlugin::initFieldsToSerialize()
@@ -290,11 +300,10 @@ std::int32_t GetIndicesPairsPlugin::enqueue(
   }
 
   std::int32_t * num_act_out_data = static_cast<std::int32_t *>(outputs[3]);
+  *num_act_out_host_ = num_act_out_real;
 
   cudaError_t const status = cudaMemcpyAsync(
-    num_act_out_data, &num_act_out_real, sizeof(std::int32_t), cudaMemcpyHostToDevice, stream);
-
-  cudaStreamSynchronize(stream);
+    num_act_out_data, num_act_out_host_, sizeof(std::int32_t), cudaMemcpyHostToDevice, stream);
 
   return status;
 }

--- a/perception/autoware_tensorrt_plugins/src/scatter_ops/segment_csr.cu
+++ b/perception/autoware_tensorrt_plugins/src/scatter_ops/segment_csr.cu
@@ -23,23 +23,16 @@
 #include "autoware/scatter_ops/segment_csr.h"
 #include "autoware/scatter_ops/utils.cuh"
 
-#include <numeric>
 #include <string>
 #include <tuple>
-#include <vector>
 
 #define THREADS 256
 #define BLOCKS(TB, N) (TB * N + THREADS - 1) / THREADS
 #define FULL_MASK 0xffffffff
-#define SEGMENT_CSR_LAUNCH_INSTANTIATION_TR(T, R)                                             \
-  template int32_t segment_csr_launch<T, R>(                                                  \
-    const T * src, const std::vector<int32_t> & src_size, const int64_t * indptr,             \
-    const std::vector<int32_t> & indptr_size, std::tuple<T *, int64_t *> out,                 \
-    cudaStream_t stream);                                                                     \
-  template int32_t segment_csr_launch<T, R>(                                                  \
-    const T * src, const std::vector<int32_t> & src_size, const int64_t * indptr,             \
-    const std::vector<int32_t> & indptr_size, const T * base, std::tuple<T *, int64_t *> out, \
-    cudaStream_t stream);
+#define SEGMENT_CSR_LAUNCH_INSTANTIATION_TR(T, R)                             \
+  template int32_t segment_csr_launch<T, R>(                                  \
+    const T * src, int32_t num_rows, int32_t num_cols, const int64_t * indptr, \
+    int32_t indptr_size, std::tuple<T *, int64_t *> out, cudaStream_t stream);
 #define SEGMENT_CSR_LAUNCH_INSTANTIATION(T)                   \
   SEGMENT_CSR_LAUNCH_INSTANTIATION_TR(T, ReductionType::SUM)  \
   SEGMENT_CSR_LAUNCH_INSTANTIATION_TR(T, ReductionType::MEAN) \
@@ -50,8 +43,8 @@
 
 template <typename scalar_t, ReductionType REDUCE, int TB>
 __global__ void segment_csr_kernel(
-  const scalar_t * src, const int64_t * indptr, const int64_t * indptr_size, int32_t indptr_dim,
-  scalar_t * out, int64_t * arg_out, size_t N, size_t E)
+  const scalar_t * src, const int64_t * indptr, scalar_t * out, int64_t * arg_out,
+  size_t num_segments)
 {
   // Each warp processes exactly `32/TB` rows and aggregates all row values
   // via a parallel reduction.
@@ -59,18 +52,16 @@ __global__ void segment_csr_kernel(
   int thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
   int row_idx = thread_idx / TB;
   int lane_idx = thread_idx & (TB - 1);
-  if (row_idx >= N) return;
+  if (row_idx >= num_segments) return;
 
-  int offset = indptr_to_offset(indptr_size, indptr_dim, row_idx);
-  int64_t row_start = __ldg(indptr + offset);
-  int64_t row_end = __ldg(indptr + offset + 1);
+  int64_t row_start = __ldg(indptr + row_idx);
+  int64_t row_end = __ldg(indptr + row_idx + 1);
 
   scalar_t val = Reducer<scalar_t, REDUCE>::init();
-  int64_t arg, arg_tmp;
+  int64_t arg{0}, arg_tmp{0};
 
-  offset = (row_idx / (indptr_size[indptr_dim - 1] - 1)) * E;
   for (int64_t src_idx = row_start + lane_idx; src_idx < row_end; src_idx += TB)
-    Reducer<scalar_t, REDUCE>::update(&val, src[offset + src_idx], &arg, src_idx);
+    Reducer<scalar_t, REDUCE>::update(&val, src[src_idx], &arg, src_idx);
 
 #pragma unroll
   for (int i = TB / 2; i > 0; i /= 2) {
@@ -90,28 +81,26 @@ __global__ void segment_csr_kernel(
 
 template <typename scalar_t, ReductionType REDUCE>
 __global__ void segment_csr_broadcast_kernel(
-  const scalar_t * src, const int64_t * indptr, const int64_t * indptr_size, int32_t indptr_dim,
-  scalar_t * out, int64_t * arg_out, size_t N, size_t K, size_t E)
+  const scalar_t * src, const int64_t * indptr, scalar_t * out, int64_t * arg_out,
+  size_t num_segments, size_t num_cols)
 {
   // Each thread processes exactly one row. It turned out that is more
   // efficient than using shared memory due to avoiding synchronization
   // barriers.
 
   int thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
-  int row_idx = thread_idx / K;
-  int lane_idx = thread_idx % K;
-  if (thread_idx >= N * K) return;
+  int row_idx = thread_idx / num_cols;
+  int lane_idx = thread_idx % num_cols;
+  if (thread_idx >= num_segments * num_cols) return;
 
-  int offset = indptr_to_offset(indptr_size, indptr_dim, row_idx);
-  int64_t row_start = __ldg(indptr + offset);
-  int64_t row_end = __ldg(indptr + offset + 1);
+  int64_t row_start = __ldg(indptr + row_idx);
+  int64_t row_end = __ldg(indptr + row_idx + 1);
 
   scalar_t val = Reducer<scalar_t, REDUCE>::init();
-  int64_t arg;
+  int64_t arg{0};
 
-  offset = (row_idx / (indptr_size[indptr_dim - 1] - 1)) * E * K;
   for (int64_t src_idx = row_start; src_idx < row_end; src_idx++)
-    Reducer<scalar_t, REDUCE>::update(&val, src[offset + K * src_idx + lane_idx], &arg, src_idx);
+    Reducer<scalar_t, REDUCE>::update(&val, src[num_cols * src_idx + lane_idx], &arg, src_idx);
 
   if (arg_out != nullptr)
     Reducer<scalar_t, REDUCE>::write(
@@ -124,71 +113,29 @@ __global__ void segment_csr_broadcast_kernel(
 //! \todo expand index
 template <typename scalar_t, ReductionType REDUCE>
 int32_t segment_csr_launch(
-  const scalar_t * src, const std::vector<int32_t> & src_size, const int64_t * indptr,
-  const std::vector<int32_t> & indptr_size, const scalar_t * base,
-  std::tuple<scalar_t *, int64_t *> out, cudaStream_t stream)
+  const scalar_t * src, int32_t num_rows, int32_t num_cols, const int64_t * indptr,
+  int32_t indptr_size, std::tuple<scalar_t *, int64_t *> out, cudaStream_t stream)
 {
-  if (src_size.size() < indptr_size.size()) return -1;
+  if (num_rows < 0 || num_cols < 0 || indptr_size < 0) return -1;
 
-  if (!std::equal(indptr_size.begin(), indptr_size.end() - 1, src_size.begin())) return -1;
-
-  auto dim = indptr_size.size() - 1;
-
-  auto _mul = [](int a, int b) { return a * b; };
-  auto src_numel = std::accumulate(src_size.begin(), src_size.end(), 1, _mul);
-  auto indptr_numel = std::accumulate(indptr_size.begin(), indptr_size.end(), 1, _mul);
-  auto out_numel = src_numel / src_size[dim] * std::max<int32_t>(indptr_size[dim] - 1, 0);
-
-  cudaMemcpyAsync(
-    std::get<0>(out), base, sizeof(scalar_t) * out_numel, cudaMemcpyDeviceToDevice, stream);
-
+  auto num_segments = std::max<int32_t>(indptr_size - 1, 0);
+  auto out_numel = static_cast<size_t>(num_segments) * static_cast<size_t>(num_cols);
   if ((REDUCE == ReductionType::MIN || REDUCE == ReductionType::MAX) && std::get<1>(out) != nullptr)
     fill_kernel<int64_t>
-      <<<BLOCKS(1, out_numel), THREADS, 0, stream>>>(std::get<1>(out), out_numel, src_size[dim]);
+      <<<BLOCKS(1, out_numel), THREADS, 0, stream>>>(std::get<1>(out), out_numel, num_rows);
 
-  if (src_numel == 0) return 0;
+  if (num_segments == 0 || num_cols == 0) return 0;
 
-  auto N = max(indptr_size[dim] - 1, 0) * (indptr_numel / indptr_size[dim]);
-  auto K = out_numel / N;
-  auto E = src_size[dim];
-  int64_t * indptr_size_dev;
-  cudaMallocAsync(&indptr_size_dev, sizeof(int64_t) * indptr_size.size(), stream);
-  cudaMemcpyAsync(
-    indptr_size_dev, indptr_size.data(), sizeof(int64_t) * indptr_size.size(),
-    cudaMemcpyHostToDevice, stream);
+  fill_kernel<scalar_t><<<BLOCKS(1, out_numel), THREADS, 0, stream>>>(
+    std::get<0>(out), out_numel, static_cast<scalar_t>(0));
 
-  if (K == 1)
-    segment_csr_kernel<scalar_t, REDUCE, 1><<<BLOCKS(32, N), THREADS, 0, stream>>>(
-      src, indptr, indptr_size_dev, indptr_size.size(), std::get<0>(out), std::get<1>(out), N, E);
+  if (num_cols == 1)
+    segment_csr_kernel<scalar_t, REDUCE, 1><<<BLOCKS(32, num_segments), THREADS, 0, stream>>>(
+      src, indptr, std::get<0>(out), std::get<1>(out), num_segments);
   else
-    segment_csr_broadcast_kernel<scalar_t, REDUCE><<<BLOCKS(1, N * K), THREADS, 0, stream>>>(
-      src, indptr, indptr_size_dev, indptr_size.size(), std::get<0>(out), std::get<1>(out), N, K,
-      E);
-
-  cudaFreeAsync(indptr_size_dev, stream);
-  return 0;
-}
-
-template <typename scalar_t, ReductionType REDUCE>
-int32_t segment_csr_launch(
-  const scalar_t * src, const std::vector<int32_t> & src_size, const int64_t * indptr,
-  const std::vector<int32_t> & indptr_size, std::tuple<scalar_t *, int64_t *> out,
-  cudaStream_t stream)
-{
-  auto dim = indptr_size.size() - 1;
-  auto src_numel =
-    std::accumulate(src_size.begin(), src_size.end(), 1, [](int a, int b) { return a * b; });
-  auto out_numel = src_numel / src_size[dim] * std::max<int32_t>(indptr_size[dim] - 1, 0);
-
-  scalar_t * base;
-  cudaMallocAsync(&base, sizeof(scalar_t) * out_numel, stream);
-  fill_kernel<scalar_t><<<BLOCKS(1, out_numel), THREADS, 0, stream>>>(base, out_numel, (scalar_t)0);
-
-  auto status =
-    segment_csr_launch<scalar_t, REDUCE>(src, src_size, indptr, indptr_size, base, out, stream);
-  if (status != 0) return status;
-
-  cudaFreeAsync(base, stream);
+    segment_csr_broadcast_kernel<scalar_t, REDUCE>
+      <<<BLOCKS(1, num_segments * num_cols), THREADS, 0, stream>>>(
+        src, indptr, std::get<0>(out), std::get<1>(out), num_segments, num_cols);
   return 0;
 }
 

--- a/perception/autoware_tensorrt_plugins/src/scatter_ops/segment_csr.cu
+++ b/perception/autoware_tensorrt_plugins/src/scatter_ops/segment_csr.cu
@@ -29,8 +29,8 @@
 #define THREADS 256
 #define BLOCKS(TB, N) (TB * N + THREADS - 1) / THREADS
 #define FULL_MASK 0xffffffff
-#define SEGMENT_CSR_LAUNCH_INSTANTIATION_TR(T, R)                             \
-  template int32_t segment_csr_launch<T, R>(                                  \
+#define SEGMENT_CSR_LAUNCH_INSTANTIATION_TR(T, R)                              \
+  template int32_t segment_csr_launch<T, R>(                                   \
     const T * src, int32_t num_rows, int32_t num_cols, const int64_t * indptr, \
     int32_t indptr_size, std::tuple<T *, int64_t *> out, cudaStream_t stream);
 #define SEGMENT_CSR_LAUNCH_INSTANTIATION(T)                   \

--- a/perception/autoware_tensorrt_plugins/src/segment_csr_plugin.cpp
+++ b/perception/autoware_tensorrt_plugins/src/segment_csr_plugin.cpp
@@ -27,7 +27,6 @@
 #include <exception>
 #include <string>
 #include <tuple>
-#include <vector>
 namespace nvinfer1::plugin
 {
 
@@ -178,9 +177,9 @@ std::int32_t SegmentCSRPlugin::enqueue(
   void const * const * inputs, void * const * outputs, [[maybe_unused]] void * workspace,
   cudaStream_t stream) noexcept
 {
-  std::vector<int32_t> src_size{
-    static_cast<int32_t>(input_desc[0].dims.d[0]), static_cast<int32_t>(input_desc[0].dims.d[1])};
-  std::vector<int32_t> indptr_size{static_cast<int32_t>(input_desc[1].dims.d[0])};
+  const auto num_rows = static_cast<int32_t>(input_desc[0].dims.d[0]);
+  const auto num_cols = static_cast<int32_t>(input_desc[0].dims.d[1]);
+  const auto indptr_size = static_cast<int32_t>(input_desc[1].dims.d[0]);
 
   std::int32_t result = 0;
 
@@ -192,8 +191,8 @@ std::int32_t SegmentCSRPlugin::enqueue(
       std::make_tuple(static_cast<float *>(outputs[0]), nullptr);
 
     AT_DISPATCH_REDUCTION_TYPES(reduce_, [&] {
-      result =
-        segment_csr_launch<float, REDUCE>(src_ptr, src_size, indptr_ptr, indptr_size, out, stream);
+      result = segment_csr_launch<float, REDUCE>(
+        src_ptr, num_rows, num_cols, indptr_ptr, indptr_size, out, stream);
     });
   } else if (input_desc[0].type == nvinfer1::DataType::kHALF) {
     const half * src_ptr = reinterpret_cast<const half *>(inputs[0]);
@@ -203,8 +202,8 @@ std::int32_t SegmentCSRPlugin::enqueue(
       std::make_tuple(static_cast<half *>(outputs[0]), nullptr);
 
     AT_DISPATCH_REDUCTION_TYPES(reduce_, [&] {
-      result =
-        segment_csr_launch<half, REDUCE>(src_ptr, src_size, indptr_ptr, indptr_size, out, stream);
+      result = segment_csr_launch<half, REDUCE>(
+        src_ptr, num_rows, num_cols, indptr_ptr, indptr_size, out, stream);
     });
   }
 

--- a/perception/autoware_tensorrt_plugins/src/unique_ops/unique.cu
+++ b/perception/autoware_tensorrt_plugins/src/unique_ops/unique.cu
@@ -176,7 +176,8 @@ __global__ void write_unique_offset_sentinel(
 }
 
 __global__ void write_unique_counts(
-  const std::int64_t * unique_offsets, const std::int64_t * num_unique, std::int64_t * unique_counts)
+  const std::int64_t * unique_offsets, const std::int64_t * num_unique,
+  std::int64_t * unique_counts)
 {
   const auto index = static_cast<std::size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
   if (index >= static_cast<std::size_t>(*num_unique)) {
@@ -191,15 +192,13 @@ __global__ void write_unique_counts(
 cudaError_t unique(
   const std::int64_t * input, std::int64_t * unique, std::int64_t * inverse_indices,
   std::int64_t * unique_counts, std::int64_t * num_unique, void * workspace,
-  std::size_t num_input_elements, std::size_t unique_workspace_size, cudaStream_t stream)
+  std::size_t num_input_elements, std::size_t unique_temp_storage_size, cudaStream_t stream)
 {
-  (void)unique_workspace_size;
   if (num_input_elements == 0U) {
     return cudaMemsetAsync(num_unique, 0, sizeof(std::int64_t), stream);
   }
 
-  const auto temp_storage_size = get_unique_temp_storage_size(num_input_elements);
-  const auto scratch_offset = align_up(temp_storage_size, alignof(std::int64_t));
+  const auto scratch_offset = align_up(unique_temp_storage_size, alignof(std::int64_t));
   auto * scratch = reinterpret_cast<char *>(workspace) + scratch_offset;
 
   auto * input_positions = reinterpret_cast<std::int64_t *>(scratch);
@@ -217,7 +216,7 @@ cudaError_t unique(
   }
 
   status = cub::DeviceRadixSort::SortPairs(
-    workspace, temp_storage_size, input, sorted_input, input_positions, unique_offsets,
+    workspace, unique_temp_storage_size, input, sorted_input, input_positions, unique_offsets,
     num_input_elements, 0, 64, stream);
   if (status != cudaSuccess) {
     return status;
@@ -231,7 +230,7 @@ cudaError_t unique(
   }
 
   status = cub::DeviceScan::InclusiveSum(
-    workspace, temp_storage_size, run_ids, run_ids, num_input_elements, stream);
+    workspace, unique_temp_storage_size, run_ids, run_ids, num_input_elements, stream);
   if (status != cudaSuccess) {
     return status;
   }
@@ -244,14 +243,13 @@ cudaError_t unique(
   }
 
   status = cub::DeviceSelect::UniqueByKey(
-    workspace, temp_storage_size, sorted_input, input_positions, unique, unique_offsets,
+    workspace, unique_temp_storage_size, sorted_input, input_positions, unique, unique_offsets,
     num_unique, num_input_elements, stream);
   if (status != cudaSuccess) {
     return status;
   }
 
-  write_unique_offset_sentinel<<<1, 1, 0, stream>>>(
-    unique_offsets, num_unique, num_input_elements);
+  write_unique_offset_sentinel<<<1, 1, 0, stream>>>(unique_offsets, num_unique, num_input_elements);
   status = cudaGetLastError();
   if (status != cudaSuccess) {
     return status;

--- a/perception/autoware_tensorrt_plugins/src/unique_ops/unique.cu
+++ b/perception/autoware_tensorrt_plugins/src/unique_ops/unique.cu
@@ -101,78 +101,152 @@
 
 #include <cub/cub.cuh>
 
-#include <thrust/adjacent_difference.h>
-#include <thrust/device_ptr.h>
-#include <thrust/execution_policy.h>
-#include <thrust/scan.h>
-#include <thrust/scatter.h>
-#include <thrust/sequence.h>
-#include <thrust/sort.h>
-#include <thrust/unique.h>
+#include <algorithm>
+#include <cstdint>
+
+namespace
+{
+
+constexpr int kThreadsPerBlock = 256;
+
+std::size_t align_up(const std::size_t size, const std::size_t alignment)
+{
+  return ((size + alignment - 1U) / alignment) * alignment;
+}
+
+std::size_t query_unique_temp_storage_size(const std::size_t num_elements)
+{
+  std::size_t sort_temp_size = 0;
+  std::size_t scan_temp_size = 0;
+  std::size_t unique_temp_size = 0;
+
+  std::int64_t * int64_nullptr = nullptr;
+  std::int32_t * int32_nullptr = nullptr;
+
+  cub::DeviceRadixSort::SortPairs(
+    nullptr, sort_temp_size, int64_nullptr, int64_nullptr, int64_nullptr, int64_nullptr,
+    num_elements, 0, 64, nullptr);
+  cub::DeviceScan::InclusiveSum(
+    nullptr, scan_temp_size, int32_nullptr, int32_nullptr, num_elements, nullptr);
+  cub::DeviceSelect::UniqueByKey(
+    nullptr, unique_temp_size, int64_nullptr, int64_nullptr, int64_nullptr, int64_nullptr,
+    int64_nullptr, num_elements, nullptr);
+
+  return std::max(sort_temp_size, std::max(scan_temp_size, unique_temp_size));
+}
+
+__global__ void mark_run_starts(
+  const std::int64_t * sorted_input, std::int32_t * run_ids, const std::size_t num_input_elements)
+{
+  const auto index = static_cast<std::size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (index >= num_input_elements) {
+    return;
+  }
+
+  run_ids[index] = (index == 0U || sorted_input[index] != sorted_input[index - 1U]) ? 1 : 0;
+}
+
+__global__ void fill_iota(std::int64_t * output, const std::size_t num_input_elements)
+{
+  const auto index = static_cast<std::size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (index >= num_input_elements) {
+    return;
+  }
+
+  output[index] = static_cast<std::int64_t>(index);
+}
+
+__global__ void scatter_inverse_indices(
+  const std::int64_t * sorted_idx, const std::int32_t * run_ids, std::int64_t * inverse_indices,
+  const std::size_t num_input_elements)
+{
+  const auto index = static_cast<std::size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (index >= num_input_elements) {
+    return;
+  }
+
+  inverse_indices[sorted_idx[index]] = static_cast<std::int64_t>(run_ids[index] - 1);
+}
+
+__global__ void write_unique_offset_sentinel(
+  std::int64_t * unique_offsets, const std::int64_t * num_unique,
+  const std::size_t num_input_elements)
+{
+  unique_offsets[*num_unique] = static_cast<std::int64_t>(num_input_elements);
+}
+
+__global__ void write_unique_counts(
+  const std::int64_t * unique_offsets, const std::int64_t * num_unique, std::int64_t * unique_counts)
+{
+  const auto index = static_cast<std::size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (index >= static_cast<std::size_t>(*num_unique)) {
+    return;
+  }
+
+  unique_counts[index] = unique_offsets[index + 1U] - unique_offsets[index];
+}
+
+}  // namespace
 
 std::int64_t unique(
   const std::int64_t * input, std::int64_t * unique, std::int64_t * inverse_indices,
   std::int64_t * unique_counts, void * workspace, std::size_t num_input_elements,
   std::size_t unique_workspace_size, cudaStream_t stream)
 {
-  auto policy = thrust::cuda::par.on(stream);
+  if (num_input_elements == 0U) {
+    return 0;
+  }
 
-  thrust::device_ptr<std::int64_t> idx_ptr(reinterpret_cast<std::int64_t *>(workspace));
+  const auto temp_storage_size = get_unique_temp_storage_size(num_input_elements);
+  const auto scratch_offset = align_up(temp_storage_size, alignof(std::int64_t));
+  auto * scratch = reinterpret_cast<char *>(workspace) + scratch_offset;
 
-  thrust::sequence(policy, idx_ptr, idx_ptr + num_input_elements + 1, 0);
+  auto * input_positions = reinterpret_cast<std::int64_t *>(scratch);
+  auto * sorted_input = input_positions + num_input_elements;
+  auto * unique_offsets = sorted_input + num_input_elements;
+  auto * num_unique_d = unique_offsets + num_input_elements + 1U;
+  auto * run_ids = reinterpret_cast<std::int32_t *>(num_unique_d + 1U);
 
-  std::int64_t * sorted_input = unique;
-  std::int64_t * sorted_idx = thrust::raw_pointer_cast(idx_ptr) + 2 * num_input_elements + 1;
-  std::int64_t * inv_loc_ptr = thrust::raw_pointer_cast(idx_ptr) + 3 * num_input_elements + 1;
+  const auto num_blocks =
+    static_cast<unsigned int>((num_input_elements + kThreadsPerBlock - 1U) / kThreadsPerBlock);
 
-  void * sort_workspace_ptr =
-    reinterpret_cast<void *>(thrust::raw_pointer_cast(idx_ptr) + 4 * num_input_elements + 1);
-
-  auto sort_workspace_size =
-    unique_workspace_size - (4 * num_input_elements + 1) * sizeof(std::int64_t);
-
+  fill_iota<<<num_blocks, kThreadsPerBlock, 0, stream>>>(input_positions, num_input_elements);
   cub::DeviceRadixSort::SortPairs(
-    sort_workspace_ptr, sort_workspace_size, input, sorted_input, thrust::raw_pointer_cast(idx_ptr),
-    sorted_idx, num_input_elements, 0, 64, stream);
+    workspace, temp_storage_size, input, sorted_input, input_positions, unique_offsets,
+    num_input_elements, 0, 64, stream);
 
-  auto equal = [] __device__(const std::int64_t a, const std::int64_t b) { return a == b; };
+  mark_run_starts<<<num_blocks, kThreadsPerBlock, 0, stream>>>(
+    sorted_input, run_ids, num_input_elements);
+  cub::DeviceScan::InclusiveSum(
+    workspace, temp_storage_size, run_ids, run_ids, num_input_elements, stream);
 
-  auto not_equal = [] __device__(const std::int64_t a, const std::int64_t b) { return a != b; };
+  scatter_inverse_indices<<<num_blocks, kThreadsPerBlock, 0, stream>>>(
+    unique_offsets, run_ids, inverse_indices, num_input_elements);
 
-  thrust::adjacent_difference(
-    policy, sorted_input, sorted_input + num_input_elements, inv_loc_ptr, not_equal);
+  cub::DeviceSelect::UniqueByKey(
+    workspace, temp_storage_size, sorted_input, input_positions, unique, unique_offsets,
+    num_unique_d, num_input_elements, stream);
 
-  cudaMemsetAsync(inv_loc_ptr, 0, sizeof(int64_t), stream);
+  write_unique_offset_sentinel<<<1, 1, 0, stream>>>(
+    unique_offsets, num_unique_d, num_input_elements);
+  write_unique_counts<<<num_blocks, kThreadsPerBlock, 0, stream>>>(
+    unique_offsets, num_unique_d, unique_counts);
 
-  thrust::inclusive_scan(policy, inv_loc_ptr, inv_loc_ptr + num_input_elements, inv_loc_ptr);
-  thrust::scatter(
-    policy, inv_loc_ptr, inv_loc_ptr + num_input_elements, sorted_idx, inverse_indices);
-
-  std::int64_t num_out;
-
-  std::int64_t * range_ptr = idx_ptr.get();
-  num_out =
-    thrust::unique_by_key(policy, sorted_input, sorted_input + num_input_elements, range_ptr, equal)
-      .first -
-    sorted_input;
-
-  cudaMemcpyAsync(
-    range_ptr + num_out * sizeof(int64_t), &num_input_elements, sizeof(std::int64_t),
-    cudaMemcpyHostToDevice, stream);
-
-  thrust::adjacent_difference(policy, range_ptr + 1, range_ptr + num_out + 1, unique_counts);
-
+  std::int64_t num_out = 0;
+  cudaMemcpyAsync(&num_out, num_unique_d, sizeof(std::int64_t), cudaMemcpyDeviceToHost, stream);
+  cudaStreamSynchronize(stream);
   return num_out;
+}
+
+std::size_t get_unique_temp_storage_size(std::size_t num_elements)
+{
+  return query_unique_temp_storage_size(num_elements);
 }
 
 std::size_t get_unique_workspace_size(std::size_t num_elements)
 {
-  std::size_t temp_size = 0;
-  std::int64_t * int64_nullptr = nullptr;
-
-  cub::DeviceRadixSort::SortPairs(
-    nullptr, temp_size, int64_nullptr, int64_nullptr, int64_nullptr, int64_nullptr, num_elements, 0,
-    64, nullptr);
-
-  return temp_size + (4 * num_elements + 1) * sizeof(std::int64_t);
+  const auto temp_size = query_unique_temp_storage_size(num_elements);
+  const auto scratch_offset = align_up(temp_size, alignof(std::int64_t));
+  return scratch_offset + (3 * num_elements + 2U) * sizeof(std::int64_t) +
+         num_elements * sizeof(std::int32_t);
 }

--- a/perception/autoware_tensorrt_plugins/src/unique_ops/unique.cu
+++ b/perception/autoware_tensorrt_plugins/src/unique_ops/unique.cu
@@ -188,13 +188,14 @@ __global__ void write_unique_counts(
 
 }  // namespace
 
-std::int64_t unique(
+cudaError_t unique(
   const std::int64_t * input, std::int64_t * unique, std::int64_t * inverse_indices,
-  std::int64_t * unique_counts, void * workspace, std::size_t num_input_elements,
-  std::size_t unique_workspace_size, cudaStream_t stream)
+  std::int64_t * unique_counts, std::int64_t * num_unique, void * workspace,
+  std::size_t num_input_elements, std::size_t unique_workspace_size, cudaStream_t stream)
 {
+  (void)unique_workspace_size;
   if (num_input_elements == 0U) {
-    return 0;
+    return cudaMemsetAsync(num_unique, 0, sizeof(std::int64_t), stream);
   }
 
   const auto temp_storage_size = get_unique_temp_storage_size(num_input_elements);
@@ -204,38 +205,61 @@ std::int64_t unique(
   auto * input_positions = reinterpret_cast<std::int64_t *>(scratch);
   auto * sorted_input = input_positions + num_input_elements;
   auto * unique_offsets = sorted_input + num_input_elements;
-  auto * num_unique_d = unique_offsets + num_input_elements + 1U;
-  auto * run_ids = reinterpret_cast<std::int32_t *>(num_unique_d + 1U);
+  auto * run_ids = reinterpret_cast<std::int32_t *>(unique_offsets + num_input_elements + 1U);
 
   const auto num_blocks =
     static_cast<unsigned int>((num_input_elements + kThreadsPerBlock - 1U) / kThreadsPerBlock);
 
   fill_iota<<<num_blocks, kThreadsPerBlock, 0, stream>>>(input_positions, num_input_elements);
-  cub::DeviceRadixSort::SortPairs(
+  cudaError_t status = cudaGetLastError();
+  if (status != cudaSuccess) {
+    return status;
+  }
+
+  status = cub::DeviceRadixSort::SortPairs(
     workspace, temp_storage_size, input, sorted_input, input_positions, unique_offsets,
     num_input_elements, 0, 64, stream);
+  if (status != cudaSuccess) {
+    return status;
+  }
 
   mark_run_starts<<<num_blocks, kThreadsPerBlock, 0, stream>>>(
     sorted_input, run_ids, num_input_elements);
-  cub::DeviceScan::InclusiveSum(
+  status = cudaGetLastError();
+  if (status != cudaSuccess) {
+    return status;
+  }
+
+  status = cub::DeviceScan::InclusiveSum(
     workspace, temp_storage_size, run_ids, run_ids, num_input_elements, stream);
+  if (status != cudaSuccess) {
+    return status;
+  }
 
   scatter_inverse_indices<<<num_blocks, kThreadsPerBlock, 0, stream>>>(
     unique_offsets, run_ids, inverse_indices, num_input_elements);
+  status = cudaGetLastError();
+  if (status != cudaSuccess) {
+    return status;
+  }
 
-  cub::DeviceSelect::UniqueByKey(
+  status = cub::DeviceSelect::UniqueByKey(
     workspace, temp_storage_size, sorted_input, input_positions, unique, unique_offsets,
-    num_unique_d, num_input_elements, stream);
+    num_unique, num_input_elements, stream);
+  if (status != cudaSuccess) {
+    return status;
+  }
 
   write_unique_offset_sentinel<<<1, 1, 0, stream>>>(
-    unique_offsets, num_unique_d, num_input_elements);
-  write_unique_counts<<<num_blocks, kThreadsPerBlock, 0, stream>>>(
-    unique_offsets, num_unique_d, unique_counts);
+    unique_offsets, num_unique, num_input_elements);
+  status = cudaGetLastError();
+  if (status != cudaSuccess) {
+    return status;
+  }
 
-  std::int64_t num_out = 0;
-  cudaMemcpyAsync(&num_out, num_unique_d, sizeof(std::int64_t), cudaMemcpyDeviceToHost, stream);
-  cudaStreamSynchronize(stream);
-  return num_out;
+  write_unique_counts<<<num_blocks, kThreadsPerBlock, 0, stream>>>(
+    unique_offsets, num_unique, unique_counts);
+  return cudaGetLastError();
 }
 
 std::size_t get_unique_temp_storage_size(std::size_t num_elements)
@@ -247,6 +271,6 @@ std::size_t get_unique_workspace_size(std::size_t num_elements)
 {
   const auto temp_size = query_unique_temp_storage_size(num_elements);
   const auto scratch_offset = align_up(temp_size, alignof(std::int64_t));
-  return scratch_offset + (3 * num_elements + 2U) * sizeof(std::int64_t) +
+  return scratch_offset + (3 * num_elements + 1U) * sizeof(std::int64_t) +
          num_elements * sizeof(std::int32_t);
 }

--- a/perception/autoware_tensorrt_plugins/src/unique_plugin.cpp
+++ b/perception/autoware_tensorrt_plugins/src/unique_plugin.cpp
@@ -164,11 +164,12 @@ std::int32_t UniquePlugin::enqueue(
   cudaStream_t stream) noexcept
 {
   std::int64_t num_elements = input_desc[0].dims.d[0];
+  const auto workspace_size = get_unique_workspace_size(static_cast<std::size_t>(num_elements));
 
   std::int64_t num_unique_elements = unique(
     reinterpret_cast<const std::int64_t *>(inputs[0]), reinterpret_cast<std::int64_t *>(outputs[0]),
     reinterpret_cast<std::int64_t *>(outputs[1]), reinterpret_cast<std::int64_t *>(outputs[2]),
-    workspace, num_elements, workspace_size_, stream);
+    workspace, num_elements, workspace_size, stream);
 
   cudaMemcpyAsync(
     reinterpret_cast<std::int64_t *>(outputs[3]), &num_unique_elements, sizeof(std::int64_t),

--- a/perception/autoware_tensorrt_plugins/src/unique_plugin.cpp
+++ b/perception/autoware_tensorrt_plugins/src/unique_plugin.cpp
@@ -165,19 +165,10 @@ std::int32_t UniquePlugin::enqueue(
 {
   std::int64_t num_elements = input_desc[0].dims.d[0];
   const auto workspace_size = get_unique_workspace_size(static_cast<std::size_t>(num_elements));
-
-  std::int64_t num_unique_elements = unique(
+  return unique(
     reinterpret_cast<const std::int64_t *>(inputs[0]), reinterpret_cast<std::int64_t *>(outputs[0]),
     reinterpret_cast<std::int64_t *>(outputs[1]), reinterpret_cast<std::int64_t *>(outputs[2]),
-    workspace, num_elements, workspace_size, stream);
-
-  cudaMemcpyAsync(
-    reinterpret_cast<std::int64_t *>(outputs[3]), &num_unique_elements, sizeof(std::int64_t),
-    cudaMemcpyHostToDevice, stream);
-
-  cudaStreamSynchronize(stream);
-
-  return 0;
+    reinterpret_cast<std::int64_t *>(outputs[3]), workspace, num_elements, workspace_size, stream);
 }
 
 std::int32_t UniquePlugin::onShapeChange(

--- a/perception/autoware_tensorrt_plugins/src/unique_plugin.cpp
+++ b/perception/autoware_tensorrt_plugins/src/unique_plugin.cpp
@@ -20,6 +20,7 @@
 #include <NvInferRuntime.h>
 #include <NvInferRuntimePlugin.h>
 
+#include <algorithm>
 #include <cstdint>
 #include <exception>
 #include <string>
@@ -28,14 +29,51 @@
 namespace nvinfer1::plugin
 {
 
+namespace
+{
+
+std::size_t alignUp(const std::size_t size, const std::size_t alignment)
+{
+  return ((size + alignment - 1U) / alignment) * alignment;
+}
+
+std::size_t getTotalWorkspaceSize(
+  const std::size_t temp_storage_size, const std::size_t max_num_elements)
+{
+  return alignUp(temp_storage_size, alignof(std::int64_t)) +
+         (3U * max_num_elements + 1U) * sizeof(std::int64_t) +
+         max_num_elements * sizeof(std::int32_t);
+}
+
+}  // namespace
+
 UniquePlugin::UniquePlugin(const std::string & name) noexcept : layer_name_(name)
 {
   initFieldsToSerialize();
 }
 
+UniquePlugin::UniquePlugin(const std::string & name, const std::int64_t max_num_elements) noexcept
+: layer_name_(name)
+{
+  updateMaxNumElements(max_num_elements);
+  initFieldsToSerialize();
+}
+
+void UniquePlugin::updateMaxNumElements(const std::int64_t max_num_elements)
+{
+  PLUGIN_ASSERT(max_num_elements >= 0);
+
+  max_num_elements_ = std::max(max_num_elements_, max_num_elements);
+  max_temp_storage_size_ = std::max(
+    max_temp_storage_size_,
+    get_unique_temp_storage_size(static_cast<std::size_t>(max_num_elements_)));
+}
+
 void UniquePlugin::initFieldsToSerialize()
 {
   data_to_serialize_.clear();
+  data_to_serialize_.emplace_back(
+    "max_num_elements", &max_num_elements_, PluginFieldType::kINT64, 1);
   fc_to_serialize_.nbFields = data_to_serialize_.size();
   fc_to_serialize_.fields = data_to_serialize_.data();
 }
@@ -60,7 +98,7 @@ IPluginCapability * UniquePlugin::getCapabilityInterface(PluginCapabilityType ty
 IPluginV3 * UniquePlugin::clone() noexcept
 {
   try {
-    IPluginV3 * const plugin{new UniquePlugin{layer_name_}};
+    IPluginV3 * const plugin{new UniquePlugin{layer_name_, max_num_elements_}};
     return plugin;
   } catch (std::exception const & e) {
     caughtError(e);
@@ -105,6 +143,7 @@ std::int32_t UniquePlugin::configurePlugin(
   PLUGIN_ASSERT(out[1].desc.type == in[0].desc.type);
   PLUGIN_ASSERT(out[2].desc.type == in[0].desc.type);
   PLUGIN_ASSERT(out[3].desc.type == in[0].desc.type);
+  updateMaxNumElements(in[0].max.d[0]);
 
   return 0;
 }
@@ -164,11 +203,16 @@ std::int32_t UniquePlugin::enqueue(
   cudaStream_t stream) noexcept
 {
   std::int64_t num_elements = input_desc[0].dims.d[0];
-  const auto workspace_size = get_unique_workspace_size(static_cast<std::size_t>(num_elements));
+  PLUGIN_ASSERT(num_elements <= max_num_elements_);
+  const auto temp_storage_size =
+    max_temp_storage_size_ == 0U
+      ? get_unique_temp_storage_size(static_cast<std::size_t>(num_elements))
+      : max_temp_storage_size_;
   return unique(
     reinterpret_cast<const std::int64_t *>(inputs[0]), reinterpret_cast<std::int64_t *>(outputs[0]),
     reinterpret_cast<std::int64_t *>(outputs[1]), reinterpret_cast<std::int64_t *>(outputs[2]),
-    reinterpret_cast<std::int64_t *>(outputs[3]), workspace, num_elements, workspace_size, stream);
+    reinterpret_cast<std::int64_t *>(outputs[3]), workspace, num_elements, temp_storage_size,
+    stream);
 }
 
 std::int32_t UniquePlugin::onShapeChange(
@@ -194,7 +238,13 @@ std::size_t UniquePlugin::getWorkspaceSize(
   [[maybe_unused]] DynamicPluginTensorDesc const * outputs,
   [[maybe_unused]] std::int32_t num_outputs) const noexcept
 {
-  return get_unique_workspace_size(inputs[0].max.d[0]);
+  const auto max_num_elements =
+    std::max(max_num_elements_, static_cast<std::int64_t>(inputs[0].max.d[0]));
+  const auto temp_storage_size =
+    max_temp_storage_size_ == 0U
+      ? get_unique_temp_storage_size(static_cast<std::size_t>(max_num_elements))
+      : max_temp_storage_size_;
+  return getTotalWorkspaceSize(temp_storage_size, static_cast<std::size_t>(max_num_elements));
 }
 
 }  // namespace nvinfer1::plugin

--- a/perception/autoware_tensorrt_plugins/src/unique_plugin_creator.cpp
+++ b/perception/autoware_tensorrt_plugins/src/unique_plugin_creator.cpp
@@ -14,10 +14,13 @@
 
 #include "autoware/tensorrt_plugins/unique_plugin_creator.hpp"
 
+#include "autoware/tensorrt_plugins/plugin_utils.hpp"
 #include "autoware/tensorrt_plugins/unique_plugin.hpp"
 
 #include <NvInferRuntimePlugin.h>
 
+#include <cstdint>
+#include <exception>
 #include <string>
 
 namespace nvinfer1::plugin
@@ -39,10 +42,32 @@ nvinfer1::PluginFieldCollection const * UniquePluginCreator::getFieldNames() noe
 }
 
 IPluginV3 * UniquePluginCreator::createPlugin(
-  char const * name, [[maybe_unused]] PluginFieldCollection const * fc,
-  [[maybe_unused]] TensorRTPhase phase) noexcept
+  char const * name, PluginFieldCollection const * fc, TensorRTPhase phase) noexcept
 {
-  return new (std::nothrow) UniquePlugin(std::string(name));
+  try {
+    PLUGIN_VALIDATE(fc != nullptr);
+
+    if (phase == TensorRTPhase::kBUILD) {
+      PLUGIN_VALIDATE(fc->nbFields == 0);
+      return new (std::nothrow) UniquePlugin(std::string(name));
+    }
+
+    if (phase == TensorRTPhase::kRUNTIME) {
+      nvinfer1::PluginField const * fields{fc->fields};
+      PLUGIN_VALIDATE(fc->nbFields == 1);
+      PLUGIN_VALIDATE(fields[0].name != nullptr);
+      PLUGIN_VALIDATE(std::string(fields[0].name) == "max_num_elements");
+      PLUGIN_VALIDATE(fields[0].type == nvinfer1::PluginFieldType::kINT64);
+      PLUGIN_VALIDATE(fields[0].length == 1);
+
+      return new (std::nothrow)
+        UniquePlugin(std::string(name), *static_cast<std::int64_t const *>(fields[0].data));
+    }
+  } catch (std::exception const & e) {
+    caughtError(e);
+  }
+
+  return nullptr;
 }
 
 }  // namespace nvinfer1::plugin

--- a/perception/autoware_tensorrt_plugins/test/reference_kernels_test.cpp
+++ b/perception/autoware_tensorrt_plugins/test/reference_kernels_test.cpp
@@ -261,15 +261,19 @@ TEST(ReferenceKernelsTest, UniqueMatchesCpuReference)
   DeviceBuffer<std::int64_t> unique_d(input.size());
   DeviceBuffer<std::int64_t> inverse_d(input.size());
   DeviceBuffer<std::int64_t> counts_d(input.size());
+  DeviceBuffer<std::int64_t> num_unique_d(1U);
   DeviceBuffer<std::uint8_t> workspace_d(get_unique_workspace_size(input.size()));
 
   copyToDevice(input_d.get(), input);
 
-  const auto num_unique = unique(
-    input_d.get(), unique_d.get(), inverse_d.get(), counts_d.get(), workspace_d.get(), input.size(),
-    get_unique_workspace_size(input.size()), stream.get());
+  ASSERT_EQ(
+    unique(
+      input_d.get(), unique_d.get(), inverse_d.get(), counts_d.get(), num_unique_d.get(),
+      workspace_d.get(), input.size(), get_unique_workspace_size(input.size()), stream.get()),
+    cudaSuccess);
   ASSERT_EQ(cudaStreamSynchronize(stream.get()), cudaSuccess);
 
+  const auto num_unique = copyToHost(num_unique_d.get(), 1U).front();
   const auto unique_values = copyToHost(unique_d.get(), static_cast<std::size_t>(num_unique));
   const auto inverse_indices = copyToHost(inverse_d.get(), input.size());
   const auto counts = copyToHost(counts_d.get(), static_cast<std::size_t>(num_unique));

--- a/perception/autoware_tensorrt_plugins/test/reference_kernels_test.cpp
+++ b/perception/autoware_tensorrt_plugins/test/reference_kernels_test.cpp
@@ -16,9 +16,8 @@
 #include "autoware/scatter_ops/segment_csr.h"
 #include "autoware/unique_ops/unique.hpp"
 
-#include <gtest/gtest.h>
-
 #include <cuda_runtime_api.h>
+#include <gtest/gtest.h>
 
 #include <algorithm>
 #include <cmath>
@@ -107,8 +106,8 @@ template <typename T>
 std::vector<T> copyToHost(const T * device_ptr, const std::size_t element_count)
 {
   std::vector<T> host_values(element_count);
-  const cudaError_t status = cudaMemcpy(
-    host_values.data(), device_ptr, sizeof(T) * element_count, cudaMemcpyDeviceToHost);
+  const cudaError_t status =
+    cudaMemcpy(host_values.data(), device_ptr, sizeof(T) * element_count, cudaMemcpyDeviceToHost);
   if (status != cudaSuccess) {
     throw std::runtime_error(cudaGetErrorString(status));
   }
@@ -269,7 +268,7 @@ TEST(ReferenceKernelsTest, UniqueMatchesCpuReference)
   ASSERT_EQ(
     unique(
       input_d.get(), unique_d.get(), inverse_d.get(), counts_d.get(), num_unique_d.get(),
-      workspace_d.get(), input.size(), get_unique_workspace_size(input.size()), stream.get()),
+      workspace_d.get(), input.size(), get_unique_temp_storage_size(input.size()), stream.get()),
     cudaSuccess);
   ASSERT_EQ(cudaStreamSynchronize(stream.get()), cudaSuccess);
 
@@ -291,8 +290,8 @@ TEST(ReferenceKernelsTest, SegmentCsrMeanMatchesCpuReference)
 
   const std::size_t rows = 6U;
   const std::size_t cols = 2U;
-  const std::vector<float> src{
-    1.0F, 2.0F, 3.0F, 4.0F, 5.0F, 6.0F, 7.0F, 8.0F, 9.0F, 10.0F, 11.0F, 12.0F};
+  const std::vector<float> src{1.0F, 2.0F, 3.0F, 4.0F,  5.0F,  6.0F,
+                               7.0F, 8.0F, 9.0F, 10.0F, 11.0F, 12.0F};
   const std::vector<std::int64_t> indptr{0, 2, 5, 6};
   const auto reference = makeSegmentReferenceMean(src, rows, cols, indptr);
 
@@ -305,11 +304,10 @@ TEST(ReferenceKernelsTest, SegmentCsrMeanMatchesCpuReference)
   copyToDevice(indptr_d.get(), indptr);
 
   ASSERT_EQ(
-    (
-      segment_csr_launch<float, MEAN>(
-        src_d.get(), static_cast<std::int32_t>(rows), static_cast<std::int32_t>(cols),
-        indptr_d.get(), static_cast<std::int32_t>(indptr.size()),
-        std::make_tuple(out_d.get(), static_cast<std::int64_t *>(nullptr)), stream.get())),
+    (segment_csr_launch<float, MEAN>(
+      src_d.get(), static_cast<std::int32_t>(rows), static_cast<std::int32_t>(cols), indptr_d.get(),
+      static_cast<std::int32_t>(indptr.size()),
+      std::make_tuple(out_d.get(), static_cast<std::int64_t *>(nullptr)), stream.get())),
     0);
   ASSERT_EQ(cudaStreamSynchronize(stream.get()), cudaSuccess);
 
@@ -324,8 +322,8 @@ TEST(ReferenceKernelsTest, SegmentCsrMaxMatchesCpuReference)
 
   const std::size_t rows = 6U;
   const std::size_t cols = 2U;
-  const std::vector<float> src{
-    1.0F, 6.0F, 3.0F, 4.0F, 5.0F, 9.0F, 7.0F, 8.0F, 2.0F, 10.0F, 11.0F, 12.0F};
+  const std::vector<float> src{1.0F, 6.0F, 3.0F, 4.0F,  5.0F,  9.0F,
+                               7.0F, 8.0F, 2.0F, 10.0F, 11.0F, 12.0F};
   const std::vector<std::int64_t> indptr{0, 2, 5, 6};
   const auto reference = makeSegmentReferenceMax(src, rows, cols, indptr);
 
@@ -338,11 +336,10 @@ TEST(ReferenceKernelsTest, SegmentCsrMaxMatchesCpuReference)
   copyToDevice(indptr_d.get(), indptr);
 
   ASSERT_EQ(
-    (
-      segment_csr_launch<float, MAX>(
-        src_d.get(), static_cast<std::int32_t>(rows), static_cast<std::int32_t>(cols),
-        indptr_d.get(), static_cast<std::int32_t>(indptr.size()),
-        std::make_tuple(out_d.get(), static_cast<std::int64_t *>(nullptr)), stream.get())),
+    (segment_csr_launch<float, MAX>(
+      src_d.get(), static_cast<std::int32_t>(rows), static_cast<std::int32_t>(cols), indptr_d.get(),
+      static_cast<std::int32_t>(indptr.size()),
+      std::make_tuple(out_d.get(), static_cast<std::int64_t *>(nullptr)), stream.get())),
     0);
   ASSERT_EQ(cudaStreamSynchronize(stream.get()), cudaSuccess);
 

--- a/perception/autoware_tensorrt_plugins/test/reference_kernels_test.cpp
+++ b/perception/autoware_tensorrt_plugins/test/reference_kernels_test.cpp
@@ -1,0 +1,226 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/argsort_ops/argsort.hpp"
+#include "autoware/unique_ops/unique.hpp"
+
+#include <gtest/gtest.h>
+
+#include <cuda_runtime_api.h>
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <map>
+#include <stdexcept>
+#include <vector>
+
+namespace
+{
+
+class CudaStreamGuard
+{
+public:
+  CudaStreamGuard()
+  {
+    const cudaError_t status = cudaStreamCreate(&stream_);
+    if (status != cudaSuccess) {
+      throw std::runtime_error(cudaGetErrorString(status));
+    }
+  }
+
+  ~CudaStreamGuard()
+  {
+    if (stream_ != nullptr) {
+      cudaStreamDestroy(stream_);
+    }
+  }
+
+  cudaStream_t get() const { return stream_; }
+
+private:
+  cudaStream_t stream_{nullptr};
+};
+
+template <typename T>
+class DeviceBuffer
+{
+public:
+  explicit DeviceBuffer(std::size_t element_count) : element_count_(element_count)
+  {
+    const cudaError_t status = cudaMalloc(&data_, sizeof(T) * element_count_);
+    if (status != cudaSuccess) {
+      throw std::runtime_error(cudaGetErrorString(status));
+    }
+  }
+
+  ~DeviceBuffer()
+  {
+    if (data_ != nullptr) {
+      cudaFree(data_);
+    }
+  }
+
+  T * get() const { return static_cast<T *>(data_); }
+
+private:
+  void * data_{nullptr};
+  std::size_t element_count_{0U};
+};
+
+int getCudaDeviceCount()
+{
+  int device_count = 0;
+  const cudaError_t status = cudaGetDeviceCount(&device_count);
+  if (status != cudaSuccess) {
+    throw std::runtime_error(cudaGetErrorString(status));
+  }
+  return device_count;
+}
+
+template <typename T>
+void copyToDevice(T * device_ptr, const std::vector<T> & host_values)
+{
+  const cudaError_t status = cudaMemcpy(
+    device_ptr, host_values.data(), sizeof(T) * host_values.size(), cudaMemcpyHostToDevice);
+  if (status != cudaSuccess) {
+    throw std::runtime_error(cudaGetErrorString(status));
+  }
+}
+
+template <typename T>
+std::vector<T> copyToHost(const T * device_ptr, const std::size_t element_count)
+{
+  std::vector<T> host_values(element_count);
+  const cudaError_t status = cudaMemcpy(
+    host_values.data(), device_ptr, sizeof(T) * element_count, cudaMemcpyDeviceToHost);
+  if (status != cudaSuccess) {
+    throw std::runtime_error(cudaGetErrorString(status));
+  }
+  return host_values;
+}
+
+std::size_t getArgsortTotalWorkspaceSize(const std::size_t num_elements)
+{
+  const auto temp_size = get_argsort_workspace_size(num_elements);
+  const auto scratch_offset =
+    ((temp_size + alignof(std::int64_t) - 1U) / alignof(std::int64_t)) * alignof(std::int64_t);
+  return scratch_offset + sizeof(std::int64_t) * 2U * num_elements;
+}
+
+std::vector<std::int64_t> makeArgsortReference(const std::vector<std::int64_t> & input)
+{
+  std::vector<std::int64_t> indices(input.size());
+  for (std::size_t index = 0; index < input.size(); ++index) {
+    indices[index] = static_cast<std::int64_t>(index);
+  }
+
+  std::stable_sort(
+    indices.begin(), indices.end(),
+    [&input](const std::int64_t lhs, const std::int64_t rhs) { return input[lhs] < input[rhs]; });
+
+  return indices;
+}
+
+struct UniqueReference
+{
+  std::vector<std::int64_t> unique_values;
+  std::vector<std::int64_t> inverse_indices;
+  std::vector<std::int64_t> counts;
+};
+
+UniqueReference makeUniqueReference(const std::vector<std::int64_t> & input)
+{
+  UniqueReference reference;
+  reference.unique_values = input;
+  std::sort(reference.unique_values.begin(), reference.unique_values.end());
+  reference.unique_values.erase(
+    std::unique(reference.unique_values.begin(), reference.unique_values.end()),
+    reference.unique_values.end());
+
+  std::map<std::int64_t, std::int64_t> value_to_index;
+  for (std::size_t index = 0; index < reference.unique_values.size(); ++index) {
+    value_to_index.emplace(reference.unique_values[index], static_cast<std::int64_t>(index));
+  }
+  reference.counts.resize(reference.unique_values.size(), 0);
+
+  reference.inverse_indices.reserve(input.size());
+  for (const auto value : input) {
+    const auto index = value_to_index.at(value);
+    reference.inverse_indices.push_back(index);
+    reference.counts[static_cast<std::size_t>(index)] += 1;
+  }
+
+  return reference;
+}
+
+TEST(ReferenceKernelsTest, ArgsortMatchesCpuReference)
+{
+  if (getCudaDeviceCount() == 0) {
+    GTEST_SKIP() << "CUDA device not available";
+  }
+
+  const std::vector<std::int64_t> input{7, 3, 7, 5, 3, 3, 9, 5, 11, 7};
+  const auto reference = makeArgsortReference(input);
+
+  CudaStreamGuard stream;
+  DeviceBuffer<std::int64_t> input_d(input.size());
+  DeviceBuffer<std::int64_t> output_d(input.size());
+  DeviceBuffer<std::uint8_t> workspace_d(getArgsortTotalWorkspaceSize(input.size()));
+
+  copyToDevice(input_d.get(), input);
+
+  ASSERT_EQ(
+    argsort(
+      input_d.get(), output_d.get(), workspace_d.get(), input.size(),
+      get_argsort_workspace_size(input.size()), stream.get()),
+    cudaSuccess);
+  ASSERT_EQ(cudaStreamSynchronize(stream.get()), cudaSuccess);
+
+  EXPECT_EQ(copyToHost(output_d.get(), input.size()), reference);
+}
+
+TEST(ReferenceKernelsTest, UniqueMatchesCpuReference)
+{
+  if (getCudaDeviceCount() == 0) {
+    GTEST_SKIP() << "CUDA device not available";
+  }
+
+  const std::vector<std::int64_t> input{7, 3, 7, 5, 3, 3, 9, 5, 11, 7};
+  const UniqueReference reference = makeUniqueReference(input);
+
+  CudaStreamGuard stream;
+  DeviceBuffer<std::int64_t> input_d(input.size());
+  DeviceBuffer<std::int64_t> unique_d(input.size());
+  DeviceBuffer<std::int64_t> inverse_d(input.size());
+  DeviceBuffer<std::int64_t> counts_d(input.size());
+  DeviceBuffer<std::uint8_t> workspace_d(get_unique_workspace_size(input.size()));
+
+  copyToDevice(input_d.get(), input);
+
+  const auto num_unique = unique(
+    input_d.get(), unique_d.get(), inverse_d.get(), counts_d.get(), workspace_d.get(), input.size(),
+    get_unique_workspace_size(input.size()), stream.get());
+  ASSERT_EQ(cudaStreamSynchronize(stream.get()), cudaSuccess);
+
+  const auto unique_values = copyToHost(unique_d.get(), static_cast<std::size_t>(num_unique));
+  const auto inverse_indices = copyToHost(inverse_d.get(), input.size());
+  const auto counts = copyToHost(counts_d.get(), static_cast<std::size_t>(num_unique));
+
+  EXPECT_EQ(unique_values, reference.unique_values);
+  EXPECT_EQ(inverse_indices, reference.inverse_indices);
+  EXPECT_EQ(counts, reference.counts);
+}
+
+}  // namespace

--- a/perception/autoware_tensorrt_plugins/test/reference_kernels_test.cpp
+++ b/perception/autoware_tensorrt_plugins/test/reference_kernels_test.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "autoware/argsort_ops/argsort.hpp"
+#include "autoware/scatter_ops/segment_csr.h"
 #include "autoware/unique_ops/unique.hpp"
 
 #include <gtest/gtest.h>
@@ -20,10 +21,13 @@
 #include <cuda_runtime_api.h>
 
 #include <algorithm>
+#include <cmath>
 #include <cstddef>
 #include <cstdint>
+#include <limits>
 #include <map>
 #include <stdexcept>
+#include <tuple>
 #include <vector>
 
 namespace
@@ -165,6 +169,58 @@ UniqueReference makeUniqueReference(const std::vector<std::int64_t> & input)
   return reference;
 }
 
+std::vector<float> makeSegmentReferenceMean(
+  const std::vector<float> & src, const std::size_t rows, const std::size_t cols,
+  const std::vector<std::int64_t> & indptr)
+{
+  std::vector<float> out((indptr.size() - 1U) * cols, 0.0F);
+  for (std::size_t segment = 0; segment + 1U < indptr.size(); ++segment) {
+    const auto start = static_cast<std::size_t>(indptr[segment]);
+    const auto end = static_cast<std::size_t>(indptr[segment + 1U]);
+    const auto count = std::max<std::size_t>(end - start, 1U);
+    for (std::size_t col = 0; col < cols; ++col) {
+      float accum = 0.0F;
+      for (std::size_t row = start; row < end; ++row) {
+        accum += src[row * cols + col];
+      }
+      out[segment * cols + col] = accum / static_cast<float>(count);
+    }
+  }
+  (void)rows;
+  return out;
+}
+
+std::vector<float> makeSegmentReferenceMax(
+  const std::vector<float> & src, const std::size_t rows, const std::size_t cols,
+  const std::vector<std::int64_t> & indptr)
+{
+  std::vector<float> out((indptr.size() - 1U) * cols, 0.0F);
+  for (std::size_t segment = 0; segment + 1U < indptr.size(); ++segment) {
+    const auto start = static_cast<std::size_t>(indptr[segment]);
+    const auto end = static_cast<std::size_t>(indptr[segment + 1U]);
+    for (std::size_t col = 0; col < cols; ++col) {
+      float best = 0.0F;
+      if (start < end) {
+        best = -std::numeric_limits<float>::infinity();
+        for (std::size_t row = start; row < end; ++row) {
+          best = std::max(best, src[row * cols + col]);
+        }
+      }
+      out[segment * cols + col] = best;
+    }
+  }
+  (void)rows;
+  return out;
+}
+
+void expectFloatVectorsEqual(const std::vector<float> & actual, const std::vector<float> & expected)
+{
+  ASSERT_EQ(actual.size(), expected.size());
+  for (std::size_t index = 0; index < actual.size(); ++index) {
+    EXPECT_FLOAT_EQ(actual[index], expected[index]) << "index=" << index;
+  }
+}
+
 TEST(ReferenceKernelsTest, ArgsortMatchesCpuReference)
 {
   if (getCudaDeviceCount() == 0) {
@@ -221,6 +277,72 @@ TEST(ReferenceKernelsTest, UniqueMatchesCpuReference)
   EXPECT_EQ(unique_values, reference.unique_values);
   EXPECT_EQ(inverse_indices, reference.inverse_indices);
   EXPECT_EQ(counts, reference.counts);
+}
+
+TEST(ReferenceKernelsTest, SegmentCsrMeanMatchesCpuReference)
+{
+  if (getCudaDeviceCount() == 0) {
+    GTEST_SKIP() << "CUDA device not available";
+  }
+
+  const std::size_t rows = 6U;
+  const std::size_t cols = 2U;
+  const std::vector<float> src{
+    1.0F, 2.0F, 3.0F, 4.0F, 5.0F, 6.0F, 7.0F, 8.0F, 9.0F, 10.0F, 11.0F, 12.0F};
+  const std::vector<std::int64_t> indptr{0, 2, 5, 6};
+  const auto reference = makeSegmentReferenceMean(src, rows, cols, indptr);
+
+  CudaStreamGuard stream;
+  DeviceBuffer<float> src_d(src.size());
+  DeviceBuffer<std::int64_t> indptr_d(indptr.size());
+  DeviceBuffer<float> out_d(reference.size());
+
+  copyToDevice(src_d.get(), src);
+  copyToDevice(indptr_d.get(), indptr);
+
+  ASSERT_EQ(
+    (
+      segment_csr_launch<float, MEAN>(
+        src_d.get(), static_cast<std::int32_t>(rows), static_cast<std::int32_t>(cols),
+        indptr_d.get(), static_cast<std::int32_t>(indptr.size()),
+        std::make_tuple(out_d.get(), static_cast<std::int64_t *>(nullptr)), stream.get())),
+    0);
+  ASSERT_EQ(cudaStreamSynchronize(stream.get()), cudaSuccess);
+
+  expectFloatVectorsEqual(copyToHost(out_d.get(), reference.size()), reference);
+}
+
+TEST(ReferenceKernelsTest, SegmentCsrMaxMatchesCpuReference)
+{
+  if (getCudaDeviceCount() == 0) {
+    GTEST_SKIP() << "CUDA device not available";
+  }
+
+  const std::size_t rows = 6U;
+  const std::size_t cols = 2U;
+  const std::vector<float> src{
+    1.0F, 6.0F, 3.0F, 4.0F, 5.0F, 9.0F, 7.0F, 8.0F, 2.0F, 10.0F, 11.0F, 12.0F};
+  const std::vector<std::int64_t> indptr{0, 2, 5, 6};
+  const auto reference = makeSegmentReferenceMax(src, rows, cols, indptr);
+
+  CudaStreamGuard stream;
+  DeviceBuffer<float> src_d(src.size());
+  DeviceBuffer<std::int64_t> indptr_d(indptr.size());
+  DeviceBuffer<float> out_d(reference.size());
+
+  copyToDevice(src_d.get(), src);
+  copyToDevice(indptr_d.get(), indptr);
+
+  ASSERT_EQ(
+    (
+      segment_csr_launch<float, MAX>(
+        src_d.get(), static_cast<std::int32_t>(rows), static_cast<std::int32_t>(cols),
+        indptr_d.get(), static_cast<std::int32_t>(indptr.size()),
+        std::make_tuple(out_d.get(), static_cast<std::int64_t *>(nullptr)), stream.get())),
+    0);
+  ASSERT_EQ(cudaStreamSynchronize(stream.get()), cudaSuccess);
+
+  expectFloatVectorsEqual(copyToHost(out_d.get(), reference.size()), reference);
 }
 
 }  // namespace


### PR DESCRIPTION
## Summary

Builds on the stream-ordered variant by caching the maximum sort-workspace bounds used by the TensorRT plugins.

This draft PR corresponds to the benchmarked variant `ptv3-t18-no-thrust-no-alloc-no-sync-maxnumel-47bf5656f-20260506`.
All PRs in this cohort target `main`; each later PR contains the changes benchmarked in the earlier ones.

## Cohort

- [perf(autoware_tensorrt_plugins): remove Thrust from sort kernels](https://github.com/autowarefoundation/autoware_universe/pull/12554) (`ptv3-t18-no-thrust-c8f76ed-20260506`)
- [perf(autoware_tensorrt_plugins): keep SegmentCSR allocation-free](https://github.com/autowarefoundation/autoware_universe/pull/12555) (`ptv3-t18-no-thrust-no-alloc-e9515b790-20260506`)
- [perf(autoware_tensorrt_plugins): keep plugin outputs stream-ordered](https://github.com/autowarefoundation/autoware_universe/pull/12556) (`ptv3-t18-no-thrust-no-alloc-no-sync-13f3672a0-20260506`)
- [perf(autoware_tensorrt_plugins): cache max sort workspace bounds](https://github.com/autowarefoundation/autoware_universe/pull/12557) (`ptv3-t18-no-thrust-no-alloc-no-sync-maxnumel-47bf5656f-20260506`)
- [fix(ptv3): set TensorRT max auxiliary streams to 1](https://github.com/autowarefoundation/autoware_universe/pull/12558) (`ptv3-t18-no-thrust-no-alloc-no-sync-maxnumel-maxauxstreams1`)

## Benchmarks

Source report: `reports/2026-05-07_22-20-12/report.md`

### Total Latency Summary

| Variant | Measurement | CPU mean (ms) | CPU p95 (ms) | CPU faster vs baseline | GPU mean (ms) | GPU p95 (ms) | GPU faster vs baseline | Mean voxels |
| --- | --- | --- | --- | --- | --- | --- | --- | --- |
| ptv3-t18 | series (7 x 50) | 29.117 | 31.755 | +0.0% | 28.020 | 30.598 | +0.0% | 120572 |
| ptv3-t18-no-thrust-c8f76ed-20260506 | series (7 x 50) | 27.559 | 28.502 | +5.7% | 26.416 | 27.306 | +6.1% | 120572 |
| ptv3-t18-no-thrust-no-alloc-e9515b790-20260506 | series (7 x 50) | 26.874 | 28.863 | +8.3% | 25.741 | 27.665 | +8.9% | 120572 |
| ptv3-t18-no-thrust-no-alloc-no-sync-13f3672a0-20260506 | series (7 x 50) | 26.278 | 27.471 | +10.8% | 25.140 | 26.288 | +11.5% | 120572 |
| ptv3-t18-no-thrust-no-alloc-no-sync-maxnumel-47bf5656f-20260506 | series (7 x 50) | 26.214 | 26.642 | +11.1% | 25.084 | 25.488 | +11.7% | 120572 |
| ptv3-t18-no-thrust-no-alloc-no-sync-maxnumel-maxauxstreams1 | series (7 x 50) | 25.378 | 25.984 | +14.7% | 24.230 | 24.792 | +15.6% | 120572 |
| ptv3-t18-no-thrust-no-alloc-no-sync-maxnumel-maxauxstreams3 | series (7 x 50) | 26.809 | 28.083 | +8.6% | 25.614 | 26.849 | +9.4% | 120572 |

### Relative Performance

![Relative performance graph](https://gist.githubusercontent.com/mojomex/6f459b5cc9195af7f71da160b440d808/raw/91873107e00025448f00fd1f6152ce416b3e9604/ptv3_relative_to_baseline.svg)

