### PR TITLE
refactor(autoware_traffic_light_map_based_detector): simplify detect() and unify ROI computation

### DIFF
--- a/perception/autoware_traffic_light_map_based_detector/src/traffic_light_map_based_detector.cpp
+++ b/perception/autoware_traffic_light_map_based_detector/src/traffic_light_map_based_detector.cpp
@@ -16,7 +16,7 @@
 
 #include <autoware/lanelet2_utils/conversion.hpp>
 #include <autoware/traffic_light_utils/traffic_light_utils.hpp>
-#include <autoware_lanelet2_extension/visualization/visualization.hpp>
+#include <autoware_lanelet2_extension/utility/query.hpp>
 #include <autoware_utils/math/normalization.hpp>
 #include <autoware_utils/math/unit_conversion.hpp>
 

--- a/perception/autoware_traffic_light_map_based_detector/src/traffic_light_map_based_detector.cpp
+++ b/perception/autoware_traffic_light_map_based_detector/src/traffic_light_map_based_detector.cpp
@@ -199,10 +199,8 @@ DetectionResult TrafficLightMapBasedDetector::detect(
   image_geometry::PinholeCameraModel pinhole_camera_model;
   pinhole_camera_model.fromCameraInfo(camera_info);
 
-  std::vector<lanelet::ConstLineString3d> visible_traffic_lights;
-  get_visible_traffic_lights(
-    select_target_traffic_lights(), tf_map2camera_samples, pinhole_camera_model,
-    visible_traffic_lights);
+  const auto visible_traffic_lights = get_visible_traffic_lights(
+    select_target_traffic_lights(), tf_map2camera_samples, pinhole_camera_model);
 
   const tf2::Transform tf_map2camera_closest =
     find_closest_transform(tf_map2camera_samples, camera_info.header.stamp);
@@ -229,12 +227,12 @@ DetectionResult TrafficLightMapBasedDetector::detect(
   return result;
 }
 
-void TrafficLightMapBasedDetector::get_visible_traffic_lights(
+std::vector<lanelet::ConstLineString3d> TrafficLightMapBasedDetector::get_visible_traffic_lights(
   const TrafficLightSet & all_traffic_lights,
   const std::vector<StampedTransform> & tf_map2camera_samples,
-  const image_geometry::PinholeCameraModel & pinhole_camera_model,
-  std::vector<lanelet::ConstLineString3d> & visible_traffic_lights) const
+  const image_geometry::PinholeCameraModel & pinhole_camera_model) const
 {
+  std::vector<lanelet::ConstLineString3d> visible_traffic_lights;
   for (const auto & traffic_light : all_traffic_lights) {
     if (
       traffic_light.hasAttribute("subtype") == false ||
@@ -286,6 +284,7 @@ void TrafficLightMapBasedDetector::get_visible_traffic_lights(
       break;
     }
   }
+  return visible_traffic_lights;
 }
 
 bool TrafficLightMapBasedDetector::get_traffic_light_roi(

--- a/perception/autoware_traffic_light_map_based_detector/src/traffic_light_map_based_detector.cpp
+++ b/perception/autoware_traffic_light_map_based_detector/src/traffic_light_map_based_detector.cpp
@@ -163,6 +163,27 @@ const tf2::Transform & find_closest_transform(
   return closest_iter->transform;
 }
 
+const TrafficLightMapBasedDetector::TrafficLightSet &
+TrafficLightMapBasedDetector::select_target_traffic_lights() const
+{
+  if (route_traffic_lights_ptr_ != nullptr) {
+    return *route_traffic_lights_ptr_;
+  }
+  return *all_traffic_lights_ptr_;
+}
+
+TrafficLightMapBasedDetectorConfig make_expect_roi_config(
+  const TrafficLightMapBasedDetectorConfig & base_config)
+{
+  TrafficLightMapBasedDetectorConfig expect_roi_config = base_config;
+  expect_roi_config.max_vibration_depth = 0;
+  expect_roi_config.max_vibration_height = 0;
+  expect_roi_config.max_vibration_width = 0;
+  expect_roi_config.max_vibration_yaw = 0;
+  expect_roi_config.max_vibration_pitch = 0;
+  return expect_roi_config;
+}
+
 DetectionResult TrafficLightMapBasedDetector::detect(
   const std::vector<StampedTransform> & tf_map2camera_samples,
   const sensor_msgs::msg::CameraInfo & camera_info) const
@@ -178,27 +199,14 @@ DetectionResult TrafficLightMapBasedDetector::detect(
   image_geometry::PinholeCameraModel pinhole_camera_model;
   pinhole_camera_model.fromCameraInfo(camera_info);
 
-  // Use route traffic lights if available, otherwise all traffic lights
   std::vector<lanelet::ConstLineString3d> visible_traffic_lights;
-  if (route_traffic_lights_ptr_ != nullptr) {
-    get_visible_traffic_lights(
-      *route_traffic_lights_ptr_, tf_map2camera_samples, pinhole_camera_model,
-      visible_traffic_lights);
-  } else {
-    get_visible_traffic_lights(
-      *all_traffic_lights_ptr_, tf_map2camera_samples, pinhole_camera_model,
-      visible_traffic_lights);
-  }
+  get_visible_traffic_lights(
+    select_target_traffic_lights(), tf_map2camera_samples, pinhole_camera_model,
+    visible_traffic_lights);
 
-  // set all offset to zero when calculating the expect roi
   const tf2::Transform tf_map2camera_closest =
     find_closest_transform(tf_map2camera_samples, camera_info.header.stamp);
-  TrafficLightMapBasedDetectorConfig expect_roi_config = config_;
-  expect_roi_config.max_vibration_depth = 0;
-  expect_roi_config.max_vibration_height = 0;
-  expect_roi_config.max_vibration_width = 0;
-  expect_roi_config.max_vibration_yaw = 0;
-  expect_roi_config.max_vibration_pitch = 0;
+  const auto expect_roi_config = make_expect_roi_config(config_);
 
   for (const auto & traffic_light : visible_traffic_lights) {
     tier4_perception_msgs::msg::TrafficLightRoi rough_roi, expect_roi;

--- a/perception/autoware_traffic_light_map_based_detector/src/traffic_light_map_based_detector.cpp
+++ b/perception/autoware_traffic_light_map_based_detector/src/traffic_light_map_based_detector.cpp
@@ -27,6 +27,7 @@
 #include <algorithm>
 #include <cstdlib>
 #include <memory>
+#include <optional>
 #include <stdexcept>
 #include <string>
 #include <vector>
@@ -150,7 +151,7 @@ std::optional<SetRouteError> TrafficLightMapBasedDetector::set_route(
   return std::nullopt;
 }
 
-const tf2::Transform & find_closest_transform(
+const StampedTransform & find_closest_transform(
   const std::vector<StampedTransform> & samples, const rclcpp::Time & target_time)
 {
   const auto closest_iter = std::min_element(
@@ -160,7 +161,7 @@ const tf2::Transform & find_closest_transform(
       const auto diff_rhs = std::abs((rhs.stamp - target_time).nanoseconds());
       return diff_lhs < diff_rhs;
     });
-  return closest_iter->transform;
+  return *closest_iter;
 }
 
 const TrafficLightMapBasedDetector::TrafficLightSet &
@@ -202,27 +203,27 @@ DetectionResult TrafficLightMapBasedDetector::detect(
   const auto visible_traffic_lights = get_visible_traffic_lights(
     select_target_traffic_lights(), tf_map2camera_samples, pinhole_camera_model);
 
-  const tf2::Transform tf_map2camera_closest =
+  const StampedTransform tf_map2camera_closest =
     find_closest_transform(tf_map2camera_samples, camera_info.header.stamp);
   const auto expect_roi_config = make_expect_roi_config(config_);
 
   for (const auto & traffic_light : visible_traffic_lights) {
-    tier4_perception_msgs::msg::TrafficLightRoi rough_roi, expect_roi;
-    if (!get_traffic_light_roi(
-          tf_map2camera_closest, pinhole_camera_model, traffic_light, expect_roi_config,
-          expect_roi)) {
+    const auto expect_roi = get_traffic_light_roi(
+      {tf_map2camera_closest}, pinhole_camera_model, traffic_light, expect_roi_config);
+    if (!expect_roi) {
       continue;
     }
-    if (!get_traffic_light_roi(
-          tf_map2camera_samples, pinhole_camera_model, traffic_light, config_, rough_roi)) {
+    const auto rough_roi =
+      get_traffic_light_roi(tf_map2camera_samples, pinhole_camera_model, traffic_light, config_);
+    if (!rough_roi) {
       continue;
     }
-    result.rough_rois.rois.push_back(rough_roi);
-    result.expect_rois.rois.push_back(expect_roi);
+    result.rough_rois.rois.push_back(*rough_roi);
+    result.expect_rois.rois.push_back(*expect_roi);
   }
 
-  result.markers =
-    create_traffic_light_markers(tf_map2camera_closest, camera_info.header, visible_traffic_lights);
+  result.markers = create_traffic_light_markers(
+    tf_map2camera_closest.transform, camera_info.header, visible_traffic_lights);
 
   return result;
 }
@@ -287,12 +288,14 @@ std::vector<lanelet::ConstLineString3d> TrafficLightMapBasedDetector::get_visibl
   return visible_traffic_lights;
 }
 
-bool TrafficLightMapBasedDetector::get_traffic_light_roi(
+std::optional<tier4_perception_msgs::msg::TrafficLightRoi>
+TrafficLightMapBasedDetector::project_traffic_light_to_roi(
   const tf2::Transform & tf_map2camera,
   const image_geometry::PinholeCameraModel & pinhole_camera_model,
-  const lanelet::ConstLineString3d traffic_light, const TrafficLightMapBasedDetectorConfig & config,
-  tier4_perception_msgs::msg::TrafficLightRoi & roi) const
+  const lanelet::ConstLineString3d traffic_light,
+  const TrafficLightMapBasedDetectorConfig & config) const
 {
+  tier4_perception_msgs::msg::TrafficLightRoi roi;
   roi.traffic_light_id = traffic_light.id();
   if (pedestrian_traffic_light_id_.find(traffic_light.id()) != pedestrian_traffic_light_id_.end()) {
     roi.traffic_light_type = tier4_perception_msgs::msg::TrafficLightRoi::PEDESTRIAN_TRAFFIC_LIGHT;
@@ -310,7 +313,7 @@ bool TrafficLightMapBasedDetector::get_traffic_light_roi(
       config.max_vibration_height, config.max_vibration_width, config.max_vibration_depth);
     tf2::Vector3 point3d = top_left_camera_optical - margin;
     if (point3d.z() <= 0.0) {
-      return false;
+      return std::nullopt;
     }
     // enlarged target position in camera coordinate
     {
@@ -333,7 +336,7 @@ bool TrafficLightMapBasedDetector::get_traffic_light_roi(
       config.max_vibration_height, config.max_vibration_width, config.max_vibration_depth);
     tf2::Vector3 point3d = bottom_right_camera_optical + margin;
     if (point3d.z() <= 0.0) {
-      return false;
+      return std::nullopt;
     }
     // enlarged target position in camera coordinate
     {
@@ -346,34 +349,35 @@ bool TrafficLightMapBasedDetector::get_traffic_light_roi(
     }
 
     if (roi.roi.width < 1 || roi.roi.height < 1) {
-      return false;
+      return std::nullopt;
     }
   }
-  return true;
+  return roi;
 }
 
-bool TrafficLightMapBasedDetector::get_traffic_light_roi(
+std::optional<tier4_perception_msgs::msg::TrafficLightRoi>
+TrafficLightMapBasedDetector::get_traffic_light_roi(
   const std::vector<StampedTransform> & tf_map2camera_samples,
   const image_geometry::PinholeCameraModel & pinhole_camera_model,
-  const lanelet::ConstLineString3d traffic_light, const TrafficLightMapBasedDetectorConfig & config,
-  tier4_perception_msgs::msg::TrafficLightRoi & out_roi) const
+  const lanelet::ConstLineString3d traffic_light,
+  const TrafficLightMapBasedDetectorConfig & config) const
 {
   std::vector<tier4_perception_msgs::msg::TrafficLightRoi> rois;
   for (const auto & sample : tf_map2camera_samples) {
-    const auto & tf_map2camera = sample.transform;
-    tier4_perception_msgs::msg::TrafficLightRoi roi;
-    if (get_traffic_light_roi(tf_map2camera, pinhole_camera_model, traffic_light, config, roi)) {
-      rois.push_back(roi);
+    if (
+      auto projected = project_traffic_light_to_roi(
+        sample.transform, pinhole_camera_model, traffic_light, config)) {
+      rois.push_back(*projected);
     }
   }
   if (rois.empty()) {
-    return false;
+    return std::nullopt;
   }
-  out_roi = rois.front();
+  tier4_perception_msgs::msg::TrafficLightRoi out_roi = rois.front();
   utils::compute_bounding_roi(
     pinhole_camera_model.cameraInfo().width, pinhole_camera_model.cameraInfo().height, rois,
     out_roi);
-  return true;
+  return out_roi;
 }
 
 visualization_msgs::msg::MarkerArray TrafficLightMapBasedDetector::create_traffic_light_markers(

--- a/perception/autoware_traffic_light_map_based_detector/src/traffic_light_map_based_detector.hpp
+++ b/perception/autoware_traffic_light_map_based_detector/src/traffic_light_map_based_detector.hpp
@@ -100,6 +100,14 @@ private:
   void set_map(const autoware_map_msgs::msg::LaneletMapBin & map_msg);
 
   /**
+   * @brief Select the traffic light set to use as detection targets
+   *
+   * Returns the route-restricted set when a route has been provided, otherwise
+   * falls back to all traffic lights in the map.
+   */
+  const TrafficLightSet & select_target_traffic_lights() const;
+
+  /**
    * @brief Filter traffic lights that are visible from the camera
    *
    * @param all_traffic_lights      all the traffic lights in the route or in the map

--- a/perception/autoware_traffic_light_map_based_detector/src/traffic_light_map_based_detector.hpp
+++ b/perception/autoware_traffic_light_map_based_detector/src/traffic_light_map_based_detector.hpp
@@ -113,13 +113,12 @@ private:
    * @param all_traffic_lights      all the traffic lights in the route or in the map
    * @param tf_map2camera_samples   the stamped transformation samples from map to camera
    * @param pinhole_camera_model    pinhole model calculated from camera_info
-   * @param visible_traffic_lights  the visible traffic lights output
+   * @return                        the visible traffic lights
    */
-  void get_visible_traffic_lights(
+  std::vector<lanelet::ConstLineString3d> get_visible_traffic_lights(
     const TrafficLightSet & all_traffic_lights,
     const std::vector<StampedTransform> & tf_map2camera_samples,
-    const image_geometry::PinholeCameraModel & pinhole_camera_model,
-    std::vector<lanelet::ConstLineString3d> & visible_traffic_lights) const;
+    const image_geometry::PinholeCameraModel & pinhole_camera_model) const;
 
   /**
    * @brief Compute the traffic light ROI from a single transform

--- a/perception/autoware_traffic_light_map_based_detector/src/traffic_light_map_based_detector.hpp
+++ b/perception/autoware_traffic_light_map_based_detector/src/traffic_light_map_based_detector.hpp
@@ -127,16 +127,13 @@ private:
    * @param pinhole_camera_model  pinhole model calculated from camera_info
    * @param traffic_light         lanelet traffic light object
    * @param config                offset configuration
-   * @param roi                   computed result
-   * @return true                 the computation succeeded
-   * @return false                the computation failed
+   * @return                      the projected ROI, or std::nullopt if the projection fails
    */
-  bool get_traffic_light_roi(
+  std::optional<tier4_perception_msgs::msg::TrafficLightRoi> project_traffic_light_to_roi(
     const tf2::Transform & tf_map2camera,
     const image_geometry::PinholeCameraModel & pinhole_camera_model,
     const lanelet::ConstLineString3d traffic_light,
-    const TrafficLightMapBasedDetectorConfig & config,
-    tier4_perception_msgs::msg::TrafficLightRoi & roi) const;
+    const TrafficLightMapBasedDetectorConfig & config) const;
 
   /**
    * @brief Compute the bounding ROI from multiple transforms
@@ -145,16 +142,14 @@ private:
    * @param pinhole_camera_model  pinhole model calculated from camera_info
    * @param traffic_light         lanelet traffic light object
    * @param config                offset configuration
-   * @param out_roi               computed result
-   * @return true                 the computation succeeded
-   * @return false                the computation failed
+   * @return                      the bounding ROI, or std::nullopt if no sample yields a valid
+   *                              projection
    */
-  bool get_traffic_light_roi(
+  std::optional<tier4_perception_msgs::msg::TrafficLightRoi> get_traffic_light_roi(
     const std::vector<StampedTransform> & tf_map2camera_samples,
     const image_geometry::PinholeCameraModel & pinhole_camera_model,
     const lanelet::ConstLineString3d traffic_light,
-    const TrafficLightMapBasedDetectorConfig & config,
-    tier4_perception_msgs::msg::TrafficLightRoi & out_roi) const;
+    const TrafficLightMapBasedDetectorConfig & config) const;
 
   /**
    * @brief Create visualization markers for visible traffic lights


### PR DESCRIPTION
## Description

This PR is a behavior-preserving refactor of `TrafficLightMapBasedDetector` that focuses on clarifying the detection pipeline used by `detect()`. No functional change is intended.

Changes:

- Split the previous overload of `get_traffic_light_roi()` into:
  - `project_traffic_light_to_roi()` — single transform → `std::optional<TrafficLightRoi>`.
  - `get_traffic_light_roi()` — `std::vector<StampedTransform>` → `std::optional<TrafficLightRoi>` for the bounding ROI; the single-transform case is now handled as a one-element vector.
- Changed `get_visible_traffic_lights()` to return `std::vector<lanelet::ConstLineString3d>` by value instead of writing through an output parameter.
- Reduced `detect()` to orchestration logic by extracting small helpers for traffic-light-set selection and expect-ROI config construction

## Related links

**Parent Issue:**

- N/A (internal refactor)

## How was this PR tested?

- `colcon build --packages-select autoware_traffic_light_map_based_detector`
- `colcon test --packages-select autoware_traffic_light_map_based_detector --event-handlers console_cohesion+` — all tests pass (gtest, copyright, cppcheck, lint_cmake, xmllint, etc.).

## Notes for reviewers

None

## Interface changes

None

## Effects on system behavior

None. This change is intended to be behavior-preserving and is covered by the existing test suite.
