### PR TITLE
fix(traffic_light_multi_camera_fusion): use minimum confidence across signal elements

### DIFF
--- a/perception/autoware_traffic_light_multi_camera_fusion/src/traffic_light_multi_camera_fusion_node.cpp
+++ b/perception/autoware_traffic_light_multi_camera_fusion/src/traffic_light_multi_camera_fusion_node.cpp
@@ -306,7 +306,7 @@ void MultiCameraFusion::updateGroupInfoForElement(
   for (const auto & element : record.signal.elements) {
     state_key.emplace_back(std::make_pair(element.color, element.shape));
   }
-  const double confidence = record.signal.elements[0].confidence;  // Same value for all elements
+  const double confidence = utils::getMinConfidence(record.signal);
   auto & group_info = group_fusion_info_map[reg_ele_id];
 
   // Update Log-Odds
@@ -351,7 +351,7 @@ void MultiCameraFusion::updateBestRecord(
     return;
   }
 
-  if (confidence > existing_record.signal.elements[0].confidence) {
+  if (confidence > utils::getMinConfidence(existing_record.signal)) {
     best_record_map[state_key] = record;
   }
 }
@@ -425,13 +425,14 @@ void MultiCameraFusion::determineBestGroupState(
 
       merged_record.signal.elements.clear();
 
+      const double min_confidence =
+        utils::getMinConfidence(group_info.best_record_for_state.at(best_state_key).signal);
       for (const auto & elem : running_state) {
         tier4_perception_msgs::msg::TrafficLightElement new_elem;
         new_elem.color = elem.first;
         new_elem.shape = elem.second;
-        // keep the confidence of the base record
-        new_elem.confidence =
-          group_info.best_record_for_state.at(best_state_key).signal.elements[0].confidence;
+        // keep the min confidence of the base record
+        new_elem.confidence = min_confidence;
 
         merged_record.signal.elements.push_back(new_elem);
       }

--- a/perception/autoware_traffic_light_multi_camera_fusion/src/traffic_light_multi_camera_fusion_process.cpp
+++ b/perception/autoware_traffic_light_multi_camera_fusion/src/traffic_light_multi_camera_fusion_process.cpp
@@ -73,6 +73,16 @@ const std::unordered_map<
      {tier4_perception_msgs::msg::TrafficLightElement::FLASHING,
       autoware_perception_msgs::msg::TrafficLightElement::FLASHING}});
 
+double getMinConfidence(const tier4_perception_msgs::msg::TrafficLight & signal)
+{
+  // Normally, we should check whether the elements are empty,
+  // but we already know they are not, so we skip the check here
+  return std::min_element(
+           signal.elements.begin(), signal.elements.end(),
+           [](const auto & a, const auto & b) { return a.confidence < b.confidence; })
+    ->confidence;
+}
+
 int compareRecord(const FusionRecord & r1, const FusionRecord & r2)
 {
   /*
@@ -106,8 +116,8 @@ int compareRecord(const FusionRecord & r1, const FusionRecord & r2)
   int visible_score_1 = calVisibleScore(r1);
   int visible_score_2 = calVisibleScore(r2);
   if (visible_score_1 == visible_score_2) {
-    double confidence_1 = r1.signal.elements[0].confidence;
-    double confidence_2 = r2.signal.elements[0].confidence;
+    double confidence_1 = getMinConfidence(r1.signal);
+    double confidence_2 = getMinConfidence(r2.signal);
     return confidence_1 < confidence_2 ? -1 : 1;
   } else {
     return visible_score_1 < visible_score_2 ? -1 : 1;

--- a/perception/autoware_traffic_light_multi_camera_fusion/src/traffic_light_multi_camera_fusion_process.hpp
+++ b/perception/autoware_traffic_light_multi_camera_fusion/src/traffic_light_multi_camera_fusion_process.hpp
@@ -66,6 +66,7 @@ V at_or(const std::unordered_map<K, V> & map, const K & key, const V & value)
   return map.count(key) ? map.at(key) : value;
 }
 
+double getMinConfidence(const tier4_perception_msgs::msg::TrafficLight & signal);
 int compareRecord(const FusionRecord & r1, const FusionRecord & r2);
 
 autoware_perception_msgs::msg::TrafficLightElement convertT4toAutoware(


### PR DESCRIPTION
## Description
This PR will change the confident update from taking the first element to minimum of the confidence.

In the https://github.com/autowarefoundation/autoware_universe/pull/12302 , it introduced a new model that detect the traffic light bulbs. This model will output confidence of each traffic light bulb, so we need to handle this in some plausible manner (in this PR, taking the min).

This PR will not change the behavior of existing method (model) since it was outputting the same confidence among the bulbs in the same traffic light.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
