### PR TITLE
fix(clang-tidy): re-enable clang-diagnostic-deprecated-builtins

### DIFF
--- a/.clang-tidy-ci
+++ b/.clang-tidy-ci
@@ -31,4 +31,3 @@ ExtraArgs:
   - -Wno-delete-non-abstract-non-virtual-dtor
   - -Wno-unused-private-field
   - -Wno-unused-but-set-variable
-  - -Wno-deprecated-builtins

--- a/sensing/autoware_pointcloud_preprocessor/src/downsample_filter/robin_hood.h
+++ b/sensing/autoware_pointcloud_preprocessor/src/downsample_filter/robin_hood.h
@@ -229,7 +229,7 @@ static Counts & counts()
 
 // workaround missing "is_trivially_copyable" in g++ < 5.0
 // See https://stackoverflow.com/a/31798726/48181
-#if defined(__GNUC__) && __GNUC__ < 5
+#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 5
 #define ROBIN_HOOD_IS_TRIVIALLY_COPYABLE(...) __has_trivial_copy(__VA_ARGS__)
 #else
 #define ROBIN_HOOD_IS_TRIVIALLY_COPYABLE(...) std::is_trivially_copyable<__VA_ARGS__>::value

--- a/sensing/autoware_pointcloud_preprocessor/src/downsample_filter/robin_hood.h
+++ b/sensing/autoware_pointcloud_preprocessor/src/downsample_filter/robin_hood.h
@@ -227,13 +227,7 @@ static Counts & counts()
 #define ROBIN_HOOD_PRIVATE_DEFINITION_BROKEN_CONSTEXPR() 0
 #endif
 
-// workaround missing "is_trivially_copyable" in g++ < 5.0
-// See https://stackoverflow.com/a/31798726/48181
-#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 5
-#define ROBIN_HOOD_IS_TRIVIALLY_COPYABLE(...) __has_trivial_copy(__VA_ARGS__)
-#else
 #define ROBIN_HOOD_IS_TRIVIALLY_COPYABLE(...) std::is_trivially_copyable<__VA_ARGS__>::value
-#endif
 
 // helpers for C++ versions, see https://gcc.gnu.org/onlinedocs/cpp/Standard-Predefined-Macros.html
 #define ROBIN_HOOD_PRIVATE_DEFINITION_CXX() __cplusplus


### PR DESCRIPTION
Re-enables `clang-diagnostic-deprecated-builtins` by removing `-Wno-deprecated-builtins` from `.clang-tidy-ci`.

The check was suppressed in #12431 with 1 reported error in `sensing/autoware_pointcloud_preprocessor`. This PR fixes it.

Refs #12450

## Fixes

### `autoware_pointcloud_preprocessor`

`robin_hood.h` used the old GCC workaround branch for `__has_trivial_copy` when `__GNUC__ < 5`.

Since clang also defines `__GNUC__`, clang entered this branch and reported:

```text
builtin __has_trivial_copy is deprecated; use __is_trivially_copyable instead
```

This PR keeps the old workaround for real GCC `< 5`, but excludes clang from that branch:

```cpp
#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 5
```

So clang uses the existing modern branch:

```cpp
std::is_trivially_copyable<...>::value
```

## Verification

```bash
colcon build --packages-up-to autoware_pointcloud_preprocessor \
  --cmake-args -DCMAKE_EXPORT_COMPILE_COMMANDS=1
```

Result:

```text
Summary: 35 packages finished
```

```bash
run-clang-tidy -p build/ \
  -config="$(cat src/autoware_universe/.clang-tidy-ci)" \
  -export-fixes /tmp/clang-tidy-result/fixes.yaml \
  -j $(nproc) \
  autoware_pointcloud_preprocessor \
  > /tmp/clang-tidy-result/report.log 2>&1

grep -n "deprecated-builtins" /tmp/clang-tidy-result/report.log || echo "0 deprecated-builtins errors"
```

Result:

```text
0 deprecated-builtins errors
```