### PR TITLE
feat: add area support for route planning and fix DCO signoff

### DIFF
--- a/planning/autoware_manual_lane_change_handler/src/manual_lane_change_handler.cpp
+++ b/planning/autoware_manual_lane_change_handler/src/manual_lane_change_handler.cpp
@@ -62,6 +62,10 @@ ManualLaneChangeHandler::sort_primitives_left_to_right(
 {
   using Primitive = autoware_planning_msgs::msg::LaneletPrimitive;
 
+  if (preferred_primitive.primitive_type == "area") {
+    return primitives;
+  }
+
   std::deque<Primitive> sorted_primitives;
 
   auto find_primitive = [&](lanelet::Id id) -> std::optional<Primitive> {
@@ -103,8 +107,16 @@ void ManualLaneChangeHandler::route_callback(const LaneletRoute::ConstSharedPtr 
   route_handler_.setRoute(*msg);
 
   std::for_each(route.segments.begin(), route.segments.end(), [&](auto & segment) {
+<<<<<<< HEAD
     segment.primitives = sort_primitives_left_to_right(
       route_handler_, segment.preferred_primitive, segment.primitives);
+=======
+    if (segment.preferred_primitive.primitive_type == "area") {
+      return;
+    }
+    segment.primitives =
+      sort_primitives_left_to_right(route_handler, segment.preferred_primitive, segment.primitives);
+>>>>>>> ea1746328 (fix(manual_lane_change_handler): guard lane-only APIs when route has areas)
   });
 
   if (!current_route_) {
@@ -151,6 +163,13 @@ void ManualLaneChangeHandler::set_preferred_lane(
   if (!reroute_availability || !reroute_availability->availability) {
     res->status.success = false;
     res->status.message = "Not in lane driving state. Wait for the current scenario to end.";
+    return;
+  }
+
+  if (current_route_->segments.front().preferred_primitive.primitive_type == "area") {
+    res->status.success = false;
+    res->status.message =
+      "Manual lane change is not supported when the first route segment is an area.";
     return;
   }
 

--- a/planning/autoware_manual_lane_change_handler/src/manual_lane_change_handler.cpp
+++ b/planning/autoware_manual_lane_change_handler/src/manual_lane_change_handler.cpp
@@ -110,8 +110,8 @@ void ManualLaneChangeHandler::route_callback(const LaneletRoute::ConstSharedPtr 
     if (segment.preferred_primitive.primitive_type == "area") {
       return;
     }
-    segment.primitives =
-      sort_primitives_left_to_right(route_handler_, segment.preferred_primitive, segment.primitives);
+    segment.primitives = sort_primitives_left_to_right(
+      route_handler_, segment.preferred_primitive, segment.primitives);
   });
 
   if (!current_route_) {

--- a/planning/autoware_manual_lane_change_handler/src/manual_lane_change_handler.cpp
+++ b/planning/autoware_manual_lane_change_handler/src/manual_lane_change_handler.cpp
@@ -107,16 +107,11 @@ void ManualLaneChangeHandler::route_callback(const LaneletRoute::ConstSharedPtr 
   route_handler_.setRoute(*msg);
 
   std::for_each(route.segments.begin(), route.segments.end(), [&](auto & segment) {
-<<<<<<< HEAD
-    segment.primitives = sort_primitives_left_to_right(
-      route_handler_, segment.preferred_primitive, segment.primitives);
-=======
     if (segment.preferred_primitive.primitive_type == "area") {
       return;
     }
     segment.primitives =
-      sort_primitives_left_to_right(route_handler, segment.preferred_primitive, segment.primitives);
->>>>>>> ea1746328 (fix(manual_lane_change_handler): guard lane-only APIs when route has areas)
+      sort_primitives_left_to_right(route_handler_, segment.preferred_primitive, segment.primitives);
   });
 
   if (!current_route_) {

--- a/planning/autoware_mission_planner_universe/src/lanelet2_plugins/default_planner.cpp
+++ b/planning/autoware_mission_planner_universe/src/lanelet2_plugins/default_planner.cpp
@@ -30,6 +30,9 @@
 #include <autoware_vehicle_info_utils/vehicle_info_utils.hpp>
 #include <tf2/utils.hpp>
 
+#include <geometry_msgs/msg/point.hpp>
+#include <visualization_msgs/msg/marker.hpp>
+
 #include <boost/geometry/algorithms/correct.hpp>
 #include <boost/geometry/algorithms/difference.hpp>
 #include <boost/geometry/algorithms/is_empty.hpp>
@@ -38,9 +41,6 @@
 #include <lanelet2_core/LaneletMap.h>
 #include <lanelet2_core/geometry/BoundingBox.h>
 #include <lanelet2_core/geometry/Lanelet.h>
-
-#include <geometry_msgs/msg/point.hpp>
-#include <visualization_msgs/msg/marker.hpp>
 
 #include <limits>
 #include <vector>
@@ -128,8 +128,7 @@ PlannerPlugin::MarkerArray DefaultPlanner::visualize(
   visualization_msgs::msg::MarkerArray area_markers;
   int area_id = 0;
 
-  const std_msgs::msg::ColorRGBA cl_end =
-    autoware_utils::create_marker_color(0.2, 0.2, 0.4, 0.05);
+  const std_msgs::msg::ColorRGBA cl_end = autoware_utils::create_marker_color(0.2, 0.2, 0.4, 0.05);
   const std_msgs::msg::ColorRGBA cl_goal =
     autoware_utils::create_marker_color(0.2, 0.4, 0.4, goal_lanelet_transparency);
 
@@ -147,8 +146,9 @@ PlannerPlugin::MarkerArray DefaultPlanner::visualize(
         m.scale.x = 0.08;
         const bool is_preferred = route_section.preferred_primitive.id == prim.id;
 <<<<<<< HEAD
-        m.color = is_preferred ? autoware_utils::create_marker_color(0.2, 0.5, 0.5, goal_lanelet_transparency)
-                               : autoware_utils::create_marker_color(0.4, 0.9, 0.5, 0.75);
+        m.color = is_preferred
+                    ? autoware_utils::create_marker_color(0.2, 0.5, 0.5, goal_lanelet_transparency)
+                    : autoware_utils::create_marker_color(0.4, 0.9, 0.5, 0.75);
 =======
         m.color = is_preferred ? cl_goal : cl_end;
 >>>>>>> ae645f875 (feat(mission_planner): visualize route area segments as LINE_STRIP in RViz)
@@ -441,13 +441,13 @@ PlannerPlugin::LaneletRoute DefaultPlanner::plan(const RoutePoints & points)
     }
     RCLCPP_INFO(
       logger,
-      "[DefaultPlanner] Route segments for message: total=%zu (lane_segments=%zu, area_segments=%zu)",
+      "[DefaultPlanner] Route segments for message: total=%zu (lane_segments=%zu, "
+      "area_segments=%zu)",
       route_sections.size(), n_lane_seg, n_area_seg);
     for (size_t si = 0; si < route_sections.size(); ++si) {
       const auto & seg = route_sections[si];
       RCLCPP_DEBUG(
-        logger,
-        "[DefaultPlanner]   segment[%zu] preferred id=%ld type=%s primitives=%zu", si,
+        logger, "[DefaultPlanner]   segment[%zu] preferred id=%ld type=%s primitives=%zu", si,
         seg.preferred_primitive.id, seg.preferred_primitive.primitive_type.c_str(),
         seg.primitives.size());
     }

--- a/planning/autoware_mission_planner_universe/src/lanelet2_plugins/default_planner.cpp
+++ b/planning/autoware_mission_planner_universe/src/lanelet2_plugins/default_planner.cpp
@@ -145,13 +145,7 @@ PlannerPlugin::MarkerArray DefaultPlanner::visualize(
         m.type = visualization_msgs::msg::Marker::LINE_STRIP;
         m.scale.x = 0.08;
         const bool is_preferred = route_section.preferred_primitive.id == prim.id;
-<<<<<<< HEAD
-        m.color = is_preferred
-                    ? autoware_utils::create_marker_color(0.2, 0.5, 0.5, goal_lanelet_transparency)
-                    : autoware_utils::create_marker_color(0.4, 0.9, 0.5, 0.75);
-=======
         m.color = is_preferred ? cl_goal : cl_end;
->>>>>>> ae645f875 (feat(mission_planner): visualize route area segments as LINE_STRIP in RViz)
         for (const auto & ls : area.outerBound()) {
           for (const auto & pt : ls) {
             geometry_msgs::msg::Point p;

--- a/planning/autoware_mission_planner_universe/src/lanelet2_plugins/default_planner.cpp
+++ b/planning/autoware_mission_planner_universe/src/lanelet2_plugins/default_planner.cpp
@@ -485,7 +485,7 @@ geometry_msgs::msg::Pose DefaultPlanner::refine_goal_height(
 {
   const auto & pref = route_sections.back().preferred_primitive;
   const auto goal_pt = experimental::lanelet2_utils::from_ros(goal.position);
-  double goal_height = goal.position.z;
+  double goal_height;
 
   if (pref.primitive_type == "area") {
     const auto area = route_handler_.getAreaFromId(pref.id);

--- a/planning/autoware_mission_planner_universe/src/lanelet2_plugins/default_planner.cpp
+++ b/planning/autoware_mission_planner_universe/src/lanelet2_plugins/default_planner.cpp
@@ -39,6 +39,9 @@
 #include <lanelet2_core/geometry/BoundingBox.h>
 #include <lanelet2_core/geometry/Lanelet.h>
 
+#include <geometry_msgs/msg/point.hpp>
+#include <visualization_msgs/msg/marker.hpp>
+
 #include <limits>
 #include <vector>
 
@@ -122,11 +125,43 @@ PlannerPlugin::MarkerArray DefaultPlanner::visualize(
   lanelet::ConstLanelets end_lanelets;
   lanelet::ConstLanelets goal_lanelets;
 
+  visualization_msgs::msg::MarkerArray area_markers;
+  int area_id = 0;
+
   for (const auto & route_section : route.segments) {
-    for (const auto & lane_id : route_section.primitives) {
-      auto lanelet = route_handler_.getLaneletsFromId(lane_id.id);
+    for (const auto & prim : route_section.primitives) {
+      if (prim.primitive_type == "area") {
+        const auto area = route_handler_.getAreaFromId(prim.id);
+        visualization_msgs::msg::Marker m;
+        m.header.frame_id = "map";
+        m.header.stamp = node_->now();
+        m.ns = "route_areas";
+        m.id = area_id++;
+        m.action = visualization_msgs::msg::Marker::ADD;
+        m.type = visualization_msgs::msg::Marker::LINE_STRIP;
+        m.scale.x = 0.08;
+        const bool is_preferred = route_section.preferred_primitive.id == prim.id;
+        m.color = is_preferred ? autoware_utils::create_marker_color(0.2, 0.5, 0.5, goal_lanelet_transparency)
+                               : autoware_utils::create_marker_color(0.4, 0.9, 0.5, 0.75);
+        for (const auto & ls : area.outerBound()) {
+          for (const auto & pt : ls) {
+            geometry_msgs::msg::Point p;
+            p.x = pt.x();
+            p.y = pt.y();
+            p.z = pt.z();
+            m.points.push_back(p);
+          }
+        }
+        if (!m.points.empty()) {
+          m.points.push_back(m.points.front());
+        }
+        area_markers.markers.push_back(m);
+        continue;
+      }
+
+      auto lanelet = route_handler_.getLaneletsFromId(prim.id);
       route_lanelets.push_back(lanelet);
-      if (route_section.preferred_primitive.id == lane_id.id) {
+      if (route_section.preferred_primitive.id == prim.id) {
         goal_lanelets.push_back(lanelet);
       } else {
         end_lanelets.push_back(lanelet);
@@ -143,6 +178,7 @@ PlannerPlugin::MarkerArray DefaultPlanner::visualize(
     autoware_utils::create_marker_color(0.2, 0.4, 0.4, goal_lanelet_transparency);
 
   visualization_msgs::msg::MarkerArray route_marker_array;
+  insert_marker_array(&route_marker_array, area_markers);
   insert_marker_array(
     &route_marker_array,
     lanelet::visualization::laneletsBoundaryAsMarkerArray(route_lanelets, cl_ll_borders, false));
@@ -384,7 +420,32 @@ PlannerPlugin::LaneletRoute DefaultPlanner::plan(const RoutePoints & points)
     }
   }
   route_handler_.setRouteLanelets(all_route_lanelets);
-  route_sections = route_handler_.createMapSegments(all_route_lanelets);
+  route_sections =
+    route_handler_.createMapSegmentsFromLaneletOrAreaPath(all_route_lanelets_or_areas);
+
+  {
+    size_t n_lane_seg = 0;
+    size_t n_area_seg = 0;
+    for (const auto & seg : route_sections) {
+      if (seg.preferred_primitive.primitive_type == "area") {
+        ++n_area_seg;
+      } else {
+        ++n_lane_seg;
+      }
+    }
+    RCLCPP_INFO(
+      logger,
+      "[DefaultPlanner] Route segments for message: total=%zu (lane_segments=%zu, area_segments=%zu)",
+      route_sections.size(), n_lane_seg, n_area_seg);
+    for (size_t si = 0; si < route_sections.size(); ++si) {
+      const auto & seg = route_sections[si];
+      RCLCPP_DEBUG(
+        logger,
+        "[DefaultPlanner]   segment[%zu] preferred id=%ld type=%s primitives=%zu", si,
+        seg.preferred_primitive.id, seg.preferred_primitive.primitive_type.c_str(),
+        seg.primitives.size());
+    }
+  }
 
   auto goal_pose = points.back();
   if (param_.enable_correct_goal_pose) {
@@ -416,10 +477,23 @@ PlannerPlugin::LaneletRoute DefaultPlanner::plan(const RoutePoints & points)
 geometry_msgs::msg::Pose DefaultPlanner::refine_goal_height(
   const Pose & goal, const RouteSections & route_sections)
 {
-  const auto goal_lane_id = route_sections.back().preferred_primitive.id;
-  const auto goal_lanelet = route_handler_.getLaneletsFromId(goal_lane_id);
-  const auto goal_lanelet_pt = experimental::lanelet2_utils::from_ros(goal.position);
-  const auto goal_height = project_goal_to_map(goal_lanelet, goal_lanelet_pt);
+  const auto & pref = route_sections.back().preferred_primitive;
+  const auto goal_pt = experimental::lanelet2_utils::from_ros(goal.position);
+  double goal_height = goal.position.z;
+
+  if (pref.primitive_type == "area") {
+    const auto area = route_handler_.getAreaFromId(pref.id);
+    goal_height = project_goal_to_area(area, goal_pt);
+    RCLCPP_DEBUG(
+      node_->get_logger(), "[DefaultPlanner] refine_goal_height: goal on area id=%ld z=%.3f",
+      pref.id, goal_height);
+  } else {
+    const auto goal_lanelet = route_handler_.getLaneletsFromId(pref.id);
+    goal_height = project_goal_to_map(goal_lanelet, goal_pt);
+    RCLCPP_DEBUG(
+      node_->get_logger(), "[DefaultPlanner] refine_goal_height: goal on lane id=%ld z=%.3f",
+      pref.id, goal_height);
+  }
 
   Pose refined_goal = goal;
   refined_goal.position.z = goal_height;

--- a/planning/autoware_mission_planner_universe/src/lanelet2_plugins/default_planner.cpp
+++ b/planning/autoware_mission_planner_universe/src/lanelet2_plugins/default_planner.cpp
@@ -128,6 +128,11 @@ PlannerPlugin::MarkerArray DefaultPlanner::visualize(
   visualization_msgs::msg::MarkerArray area_markers;
   int area_id = 0;
 
+  const std_msgs::msg::ColorRGBA cl_end =
+    autoware_utils::create_marker_color(0.2, 0.2, 0.4, 0.05);
+  const std_msgs::msg::ColorRGBA cl_goal =
+    autoware_utils::create_marker_color(0.2, 0.4, 0.4, goal_lanelet_transparency);
+
   for (const auto & route_section : route.segments) {
     for (const auto & prim : route_section.primitives) {
       if (prim.primitive_type == "area") {
@@ -141,8 +146,12 @@ PlannerPlugin::MarkerArray DefaultPlanner::visualize(
         m.type = visualization_msgs::msg::Marker::LINE_STRIP;
         m.scale.x = 0.08;
         const bool is_preferred = route_section.preferred_primitive.id == prim.id;
+<<<<<<< HEAD
         m.color = is_preferred ? autoware_utils::create_marker_color(0.2, 0.5, 0.5, goal_lanelet_transparency)
                                : autoware_utils::create_marker_color(0.4, 0.9, 0.5, 0.75);
+=======
+        m.color = is_preferred ? cl_goal : cl_end;
+>>>>>>> ae645f875 (feat(mission_planner): visualize route area segments as LINE_STRIP in RViz)
         for (const auto & ls : area.outerBound()) {
           for (const auto & pt : ls) {
             geometry_msgs::msg::Point p;
@@ -173,9 +182,6 @@ PlannerPlugin::MarkerArray DefaultPlanner::visualize(
     autoware_utils::create_marker_color(0.8, 0.99, 0.8, 0.15);
   const std_msgs::msg::ColorRGBA cl_ll_borders =
     autoware_utils::create_marker_color(1.0, 1.0, 1.0, 0.999);
-  const std_msgs::msg::ColorRGBA cl_end = autoware_utils::create_marker_color(0.2, 0.2, 0.4, 0.05);
-  const std_msgs::msg::ColorRGBA cl_goal =
-    autoware_utils::create_marker_color(0.2, 0.4, 0.4, goal_lanelet_transparency);
 
   visualization_msgs::msg::MarkerArray route_marker_array;
   insert_marker_array(&route_marker_array, area_markers);

--- a/planning/autoware_mission_planner_universe/src/lanelet2_plugins/default_planner.cpp
+++ b/planning/autoware_mission_planner_universe/src/lanelet2_plugins/default_planner.cpp
@@ -346,21 +346,41 @@ PlannerPlugin::LaneletRoute DefaultPlanner::plan(const RoutePoints & points)
   LaneletRoute route_msg;
   RouteSections route_sections;
 
-  lanelet::ConstLanelets all_route_lanelets;
+  lanelet::ConstLaneletOrAreas all_route_lanelets_or_areas;
   for (std::size_t i = 1; i < points.size(); i++) {
     const auto start_check_point = points.at(i - 1);
     const auto goal_check_point = points.at(i);
 
-    lanelet::ConstLanelets path_lanelets;
+    lanelet::ConstLaneletOrAreas path_lanelets_or_areas;
     if (!route_handler_.planPathLaneletsBetweenCheckpoints(
-          start_check_point, goal_check_point, &path_lanelets, param_.consider_no_drivable_lanes)) {
+          start_check_point, goal_check_point, &path_lanelets_or_areas,
+          param_.consider_no_drivable_lanes)) {
       RCLCPP_WARN(logger, "Failed to plan route.");
       return route_msg;
     }
 
-    for (const auto & lane : path_lanelets) {
-      if (!all_route_lanelets.empty() && lane.id() == all_route_lanelets.back().id()) continue;
-      all_route_lanelets.push_back(lane);
+    for (const auto & elem : path_lanelets_or_areas) {
+      if (
+        !all_route_lanelets_or_areas.empty() &&
+        elem.id() == all_route_lanelets_or_areas.back().id())
+        continue;
+      all_route_lanelets_or_areas.push_back(elem);
+    }
+  }
+
+  for (const auto & elem : all_route_lanelets_or_areas) {
+    if (elem.isLanelet()) {
+      RCLCPP_INFO(logger, "Planned lanelet id: %ld", elem.id());
+    } else if (elem.isArea()) {
+      RCLCPP_INFO(logger, "Planned area id: %ld", elem.id());
+    }
+  }
+
+  // Extract only lanelets for setRouteLanelets (it requires ConstLanelets)
+  lanelet::ConstLanelets all_route_lanelets;
+  for (const auto & elem : all_route_lanelets_or_areas) {
+    if (elem.isLanelet()) {
+      all_route_lanelets.push_back(static_cast<const lanelet::ConstLanelet &>(elem));
     }
   }
   route_handler_.setRouteLanelets(all_route_lanelets);

--- a/planning/autoware_mission_planner_universe/src/lanelet2_plugins/utility_functions.cpp
+++ b/planning/autoware_mission_planner_universe/src/lanelet2_plugins/utility_functions.cpp
@@ -23,6 +23,8 @@
 #include <boost/geometry.hpp>
 
 #include <lanelet2_core/geometry/Lanelet.h>
+#include <lanelet2_core/geometry/Point.h>
+#include <lanelet2_core/primitives/Area.h>
 
 #include <limits>
 #include <vector>
@@ -125,6 +127,24 @@ double project_goal_to_map(
     autoware::experimental::lanelet2_utils::get_fine_centerline(lanelet_component);
   lanelet::BasicPoint3d project = lanelet::geometry::project(center_line, goal_point.basicPoint());
   return project.z();
+}
+
+double project_goal_to_area(
+  const lanelet::ConstArea & area, const lanelet::ConstPoint3d & goal_point)
+{
+  double min_d2 = std::numeric_limits<double>::max();
+  double best_z = goal_point.z();
+  const auto g2 = lanelet::utils::to2D(goal_point);
+  for (const auto & ls : area.outerBound()) {
+    for (const auto & pt : ls) {
+      const double d2 = lanelet::geometry::distance2d(g2, lanelet::utils::to2D(pt));
+      if (d2 < min_d2) {
+        min_d2 = d2;
+        best_z = pt.z();
+      }
+    }
+  }
+  return best_z;
 }
 
 geometry_msgs::msg::Pose get_closest_centerline_pose(

--- a/planning/autoware_mission_planner_universe/src/lanelet2_plugins/utility_functions.hpp
+++ b/planning/autoware_mission_planner_universe/src/lanelet2_plugins/utility_functions.hpp
@@ -25,6 +25,7 @@
 #include <visualization_msgs/msg/marker_array.hpp>
 
 #include <lanelet2_core/LaneletMap.h>
+#include <lanelet2_core/primitives/Area.h>
 #include <lanelet2_core/primitives/LaneletSequence.h>
 
 #include <vector>
@@ -59,6 +60,9 @@ bool is_in_parking_lot(
   const lanelet::ConstPolygons3d & parking_lots, const lanelet::ConstPoint3d & point);
 double project_goal_to_map(
   const lanelet::ConstLanelet & lanelet_component, const lanelet::ConstPoint3d & goal_point);
+/** @brief Use the nearest vertex on the area outer boundary (2D) for goal height. */
+double project_goal_to_area(
+  const lanelet::ConstArea & area, const lanelet::ConstPoint3d & goal_point);
 geometry_msgs::msg::Pose get_closest_centerline_pose(
   const lanelet::ConstLanelets & road_lanelets, const geometry_msgs::msg::Pose & point,
   autoware::vehicle_info_utils::VehicleInfo vehicle_info);

--- a/planning/autoware_mission_planner_universe/src/mission_planner/mission_planner.cpp
+++ b/planning/autoware_mission_planner_universe/src/mission_planner/mission_planner.cpp
@@ -508,6 +508,21 @@ void MissionPlanner::change_route(const LaneletRoute & route)
   goal.pose = route.goal_pose;
   goal.uuid = route.uuid;
 
+  {
+    size_t n_area = 0;
+    size_t n_lane = 0;
+    for (const auto & seg : route.segments) {
+      if (seg.preferred_primitive.primitive_type == "area") {
+        ++n_area;
+      } else {
+        ++n_lane;
+      }
+    }
+    RCLCPP_INFO(
+      get_logger(), "[MissionPlanner] Publishing route: segments=%zu (lane=%zu, area=%zu)",
+      route.segments.size(), n_lane, n_area);
+  }
+
   current_route_ = std::make_shared<LaneletRoute>(route);
   planner_->updateRoute(route);
   arrival_checker_.set_goal(goal);

--- a/planning/autoware_remaining_distance_time_calculator/src/remaining_distance_time_calculator_node.cpp
+++ b/planning/autoware_remaining_distance_time_calculator/src/remaining_distance_time_calculator_node.cpp
@@ -28,6 +28,7 @@
 
 #include <algorithm>
 #include <cstddef>
+#include <exception>
 #include <functional>
 #include <iterator>
 #include <memory>
@@ -99,18 +100,42 @@ void RemainingDistanceTimeCalculatorNode::on_map(const HADMapBin::ConstSharedPtr
   lanelet::ConstLanelets all_lanelets = lanelet::utils::query::laneletLayer(lanelet_map_ptr_);
   road_lanes_ = lanelet::utils::query::roadLanelets(all_lanelets);
   is_graph_ready_ = true;
+
+  if (has_received_route_) {
+    compute_route();
+  }
+}
+
+bool RemainingDistanceTimeCalculatorNode::build_lane_sequence_from_route(
+  lanelet::ConstLanelets * out_lanelets) const
+{
+  out_lanelets->clear();
+  if (!cached_route_msg_ || !lanelet_map_ptr_) {
+    return false;
+  }
+  out_lanelets->reserve(cached_route_msg_->segments.size());
+  for (const auto & seg : cached_route_msg_->segments) {
+    const auto & pref = seg.preferred_primitive;
+    if (pref.primitive_type != "lane") {
+      // Area segments connect lanelets in the mission graph but have no centerline length here.
+      continue;
+    }
+    try {
+      out_lanelets->push_back(lanelet_map_ptr_->laneletLayer.get(pref.id));
+    } catch (const std::exception & e) {
+      RCLCPP_WARN_STREAM(
+        this->get_logger(),
+        "Remaining distance: route lane id " << pref.id << " not in map: " << e.what());
+    }
+  }
+  return !out_lanelets->empty();
 }
 
 void RemainingDistanceTimeCalculatorNode::compute_route()
 {
-  const auto current_lanelet_opt =
-    experimental::lanelet2_utils::get_closest_lanelet(road_lanes_, current_vehicle_pose_);
-  if (!current_lanelet_opt) {
-    RCLCPP_WARN_STREAM_THROTTLE(
-      this->get_logger(), *get_clock(), 3000, "Failed to find current lanelet.");
+  if (!is_graph_ready_ || !lanelet_map_ptr_) {
     return;
   }
-  const auto & current_lanelet = current_lanelet_opt.value();
 
   const auto goal_lanelet_opt =
     experimental::lanelet2_utils::get_closest_lanelet(road_lanes_, goal_pose_);
@@ -120,6 +145,37 @@ void RemainingDistanceTimeCalculatorNode::compute_route()
     return;
   }
   goal_lanelet_ = goal_lanelet_opt.value();
+
+  // Lane–area–lane missions: lane-only RoutingGraph::getRoute() has no path through the Area,
+  // so it fails even though LaneletRoute is valid. Use lane sequence from the published route.
+  bool mission_route_has_area = false;
+  if (cached_route_msg_) {
+    for (const auto & seg : cached_route_msg_->segments) {
+      if (seg.preferred_primitive.primitive_type == "area") {
+        mission_route_has_area = true;
+        break;
+      }
+    }
+  }
+  lanelet::ConstLanelets route_lanelets;
+  if (mission_route_has_area && build_lane_sequence_from_route(&route_lanelets)) {
+    current_lanes_ = std::move(route_lanelets);
+    current_lanes_lengths_.clear();
+    current_lanes_lengths_.reserve(current_lanes_.size());
+    for (const auto & llt : current_lanes_) {
+      current_lanes_lengths_.push_back(lanelet::geometry::length2d(llt));
+    }
+    return;
+  }
+
+  const auto current_lanelet_opt =
+    experimental::lanelet2_utils::get_closest_lanelet(road_lanes_, current_vehicle_pose_);
+  if (!current_lanelet_opt) {
+    RCLCPP_WARN_STREAM_THROTTLE(
+      this->get_logger(), *get_clock(), 3000, "Failed to find current lanelet.");
+    return;
+  }
+  const auto & current_lanelet = current_lanelet_opt.value();
 
   const lanelet::Optional<lanelet::routing::Route> optional_route =
     routing_graph_ptr_->getRoute(current_lanelet, goal_lanelet_, 0);
@@ -145,6 +201,7 @@ void RemainingDistanceTimeCalculatorNode::compute_route()
 void RemainingDistanceTimeCalculatorNode::on_route(const LaneletRoute::ConstSharedPtr & msg)
 {
   goal_pose_ = msg->goal_pose;
+  cached_route_msg_ = msg;
   has_received_route_ = true;
   compute_route();
 }

--- a/planning/autoware_remaining_distance_time_calculator/src/remaining_distance_time_calculator_node.hpp
+++ b/planning/autoware_remaining_distance_time_calculator/src/remaining_distance_time_calculator_node.hpp
@@ -84,6 +84,7 @@ private:
 
   bool has_received_route_;
   bool has_received_scenario_;
+  LaneletRoute::ConstSharedPtr cached_route_msg_;
   double velocity_limit_;
 
   double remaining_distance_;
@@ -100,6 +101,8 @@ private:
   void on_velocity_limit(const VelocityLimit::ConstSharedPtr & msg);
   void on_scenario(const autoware_internal_planning_msgs::msg::Scenario::ConstSharedPtr & msg);
   void compute_route();
+  /** @brief Fill lanelets from cached mission route (lane segments only; skips area connectors). */
+  bool build_lane_sequence_from_route(lanelet::ConstLanelets * out_lanelets) const;
 
   /**
    * @brief calculate mission remaining distance


### PR DESCRIPTION

**Note**
This PR is a duplicate/recreated version of #12381 to address the failed DCO signoff check on one commit.
Original PR: https://github.com/autowarefoundation/autoware_universe/pull/12381

The implementation and commit history were cherry-picked from original branch by creating a new branch with properly signed-off commits.
 
## Description

Universe updates for **mission routes that can include Lanelet2 Area segments** (`LaneletPrimitive.primitive_type == "area"`).

- **Mission planner (`default_planner`):** Plans with **area-inclusive** `RouteHandler` APIs, builds **`LaneletRoute.segments`** with mixed **lane** and **area** primitives, and **refines goal Z** when the last segment is an **area**. Lane-only **`setRouteLanelets`** still receives only lanelets; full **L–A–L** topology is carried in **segments**.
- **Remaining distance / time calculator:** If the subscribed route contains an **area** segment, derives the **lane** list from **`LaneletRoute`** (skipping areas for arc length) instead of lane-only **`RoutingGraph::getRoute`**, and **recomputes** when the **map** arrives after the **route**.

## Related links

**Parent Issue:**

- Tier IV  Internal [Issue link](https://tier4.atlassian.net/browse/T4DEV-51269)

**Related PRs**

- [autoware_core](https://github.com/autowarefoundation/autoware_core/pull/993)
- [autoware_lanelet2_extension](https://github.com/autowarefoundation/autoware_lanelet2_extension/pull/104)

**Design Documents**

Tier IV Internal [Design Document: Area Visualization](https://tier4.atlassian.net/wiki/spaces/SI/pages/5070815408/Detailed+Design+Document+Lanelet2+Routing+Area+Visualization+in+RViz)
Tier IV Internal [Design Document: Route Serach through Areas](https://tier4.atlassian.net/wiki/spaces/SI/pages/5077074153/Detailed+Design+Document+Lanelet2+Area+Support+for+Route+Finding)
<!-- ⬇️🟢
**Private Links:**


⬆️🟢 -->

## How was this PR tested?

- **colcon** build of affected packages.  
- Sim or logging with a map where mission path is **lane → area → lane**; confirm route publication and remaining-distance behavior without spurious “failed to find route” warnings from lane-only recomputation.
- Evaluator Results [link1](https://evaluation.tier4.jp/evaluation/reports/cc0b9e8e-52a2-53b9-b800-2398e8949fc3?project_id=prd_jt), [link2](https://evaluation.tier4.jp/evaluation/reports/27a7c480-59dc-581e-9f3b-a26f9a660a62?project_id=prd_jt), [link3](https://evaluation.tier4.jp/evaluation/reports/563bc244-631a-5ed6-a0c9-2ea5d4519af7?project_id=autoware_dev).

## Notes for reviewers

Please check **segment** handling and **RouteHandler** usage in mission planner; remaining-distance path is gated on presence of any **area** segment in the cached route.

## Interface changes

No new topics or message types. **`LaneletRoute`** **payload** may include **`area`** segments when the map and routing rules allow.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

Missions that **only** connect via **Areas** can get a **published route** where pure lane routing could not. Subscribers that ignore **`primitive_type`** or only use **`getRoute`** may still misbehave. **Trajectory / behavior** through the connector is **not** defined by this PR alone.