### PR TITLE
fix(clang-tidy): re-enable clang-diagnostic-delete-non-abstract-non-virtual-dtor

### DIFF
--- a/.clang-tidy-ci
+++ b/.clang-tidy-ci
@@ -28,7 +28,6 @@ ExtraArgs:
   - -Wno-c11-extensions
   - -Wno-unknown-warning-option
   - -Wno-deprecated-declarations
-  - -Wno-delete-non-abstract-non-virtual-dtor
   - -Wno-unused-private-field
   - -Wno-unused-but-set-variable
   - -Wno-deprecated-builtins

--- a/perception/autoware_lidar_apollo_instance_segmentation/include/autoware/lidar_apollo_instance_segmentation/feature_map.hpp
+++ b/perception/autoware_lidar_apollo_instance_segmentation/include/autoware/lidar_apollo_instance_segmentation/feature_map.hpp
@@ -41,6 +41,7 @@ public:
   virtual void initializeMap(std::vector<float> & map) = 0;
   virtual void resetMap(std::vector<float> & map) = 0;
   FeatureMapInterface(const int _channels, const int _width, const int _height, const int _range);
+  virtual ~FeatureMapInterface() = default;
 };
 
 struct FeatureMap : public FeatureMapInterface


### PR DESCRIPTION
Re-enables `clang-diagnostic-delete-non-abstract-non-virtual-dtor` by removing `-Wno-delete-non-abstract-non-virtual-dtor` from `.clang-tidy-ci`.

The check was suppressed in #12431 with 4 reported errors in `perception/autoware_lidar_apollo_instance_segmentation`. This PR fixes them.

Refs #12450

## Fixes

### `autoware_lidar_apollo_instance_segmentation`

`FeatureMapInterface` has virtual functions and is used as the base interface for `FeatureMap`, `FeatureMapWithConstant`, `FeatureMapWithIntensity`, and `FeatureMapWithConstantAndIntensity`.

This PR adds a virtual default destructor to the base interface:

```cpp
virtual ~FeatureMapInterface() = default;
```

This keeps behavior unchanged and allows derived objects to be safely destroyed through the base interface.

## Verification

```bash
pre-commit run clang-format --files \
  perception/autoware_lidar_apollo_instance_segmentation/include/autoware/lidar_apollo_instance_segmentation/feature_map.hpp
```

Result:

```text
clang-format.............................................................Passed
```

```bash
colcon build --packages-up-to autoware_lidar_apollo_instance_segmentation \
  --cmake-args -DCMAKE_EXPORT_COMPILE_COMMANDS=1
```

Result:

```text
Summary: 27 packages finished
```

```bash
run-clang-tidy -p build/ \
  -config="$(cat src/autoware_universe/.clang-tidy-ci)" \
  -export-fixes /tmp/clang-tidy-result/fixes.yaml \
  -j $(nproc) \
  autoware_lidar_apollo_instance_segmentation \
  > /tmp/clang-tidy-result/report.log 2>&1

grep -n "delete-non-abstract-non-virtual-dtor" /tmp/clang-tidy-result/report.log | grep "error:" || echo "0 non-virtual-dtor errors"
```

Result:

```text
0 non-virtual-dtor errors
```
