### PR TITLE
fix(behavior_path_planner): recover route lanelet after manual override 

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_planner/src/planner_manager.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner/src/planner_manager.cpp
@@ -260,6 +260,30 @@ void PlannerManager::updateCurrentRouteLanelet(
   const auto & pose = data->self_odometry->pose.pose;
   const auto p = data->parameters;
 
+  const bool skip_global_route_snap =
+    data->operation_mode && data->operation_mode->mode == OperationModeState::AUTONOMOUS &&
+    data->operation_mode->is_autoware_control_enabled;
+
+  const auto snap_to_global_route_if_ego_out = [&]() {
+    if (skip_global_route_snap) {
+      return;
+    }
+    if (!current_route_lanelet_->has_value()) {
+      return;
+    }
+    if (!utils::isEgoOutOfRoute(
+          pose, current_route_lanelet_->value(), data->prev_modified_goal, route_handler)) {
+      return;
+    }
+    lanelet::ConstLanelet constrained{};
+    if (route_handler->getClosestLaneletWithConstrainsWithinRoute(
+          pose, &constrained, p.ego_nearest_dist_threshold, p.ego_nearest_yaw_threshold)) {
+      *current_route_lanelet_ = constrained;
+      return;
+    }
+    resetCurrentRouteLanelet(data);
+  };
+
   constexpr double extra_margin = 10.0;
   const auto backward_length =
     std::max(p.backward_path_length, p.backward_path_length + extra_margin);
@@ -270,6 +294,7 @@ void PlannerManager::updateCurrentRouteLanelet(
         pose, current_route_lanelet_->value(), &closest_lane, p.ego_nearest_dist_threshold,
         p.ego_nearest_yaw_threshold)) {
     *current_route_lanelet_ = closest_lane;
+    snap_to_global_route_if_ego_out();
     return;
   }
 
@@ -281,10 +306,12 @@ void PlannerManager::updateCurrentRouteLanelet(
   if (opt.has_value()) {
     closest_lane = *opt;
     *current_route_lanelet_ = closest_lane;
+    snap_to_global_route_if_ego_out();
   } else if (const auto opt_constraint =
                experimental::lanelet2_utils::get_closest_lanelet(lanelet_sequence, pose);
              opt_constraint) {
     *current_route_lanelet_ = opt_constraint.value();
+    snap_to_global_route_if_ego_out();
   } else if (!is_any_approved_module_running) {
     resetCurrentRouteLanelet(data);
   }
@@ -903,8 +930,9 @@ SlotOutput SubPlannerManager::runApprovedModules(
   if (std::any_of(approved_module_ptrs_.begin(), approved_module_ptrs_.end(), [](const auto & m) {
         return m->getCurrentStatus() == ModuleStatus::SUCCESS &&
                m->isCurrentRouteLaneletToBeReset();
-      }))
+      })) {
     resetCurrentRouteLanelet(data);
+  }
 
   // remove success module immediately.
   for (auto success_itr = std::find_if(

--- a/planning/behavior_path_planner/autoware_behavior_path_planner/src/planner_manager.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner/src/planner_manager.cpp
@@ -281,7 +281,9 @@ void PlannerManager::updateCurrentRouteLanelet(
       *current_route_lanelet_ = constrained;
       return;
     }
-    resetCurrentRouteLanelet(data);
+    if (!is_any_approved_module_running) {
+      resetCurrentRouteLanelet(data);
+    }
   };
 
   constexpr double extra_margin = 10.0;


### PR DESCRIPTION
## Description

### Summary

Improves how **Behavior Path Planner** updates **`current_route_lanelet_`** after local/graph-based lane selection, and fixes a **control-flow bug** in approved-module handling. Together this reduces cases where planning gets **stuck on a stale path** after the driver **overrides** a lane-change-related trajectory in **manual** driving.

### Background / Motivation

When a **lane change** is active or recently generated a path, the planner can leave a **terminal or lane-change-specific trajectory** in the pipeline. If the driver then **drives manually** and **ignores** that geometry (large lateral offset, overshoot, etc.), the system may **fail to regenerate** a coherent route-aligned path for a while.

In those situations the **trajectory can remain stuck at the lane-change end path**, so the stack does not promptly recover to a normal route-following reference. That lengthens the **manual-driving segment** and effectively **shrinks the autonomous-driving segment** until something else forces a clean state.

This change aims to **recover the current route lanelet and reference alignment** more reliably when ego is still on the route but local updates disagree with strict **out-of-route** checks, while **respecting the existing policy** of not blindly calling **`resetCurrentRouteLanelet`** when an **approved** scene module is **running or waiting for approval** (so we do not override module-held route state without the same guards as the legacy fallback chain).

### What changed

- After graph-based lane updates, **`snap_to_global_route_if_ego_out`** reconciles with **`getClosestLaneletWithConstrainsWithinRoute`** when **`isEgoOutOfRoute`** is still true, using the same distance/yaw thresholds as elsewhere in BPP.
- In **AUTONOMOUS** mode with **Autoware control enabled**, skip the harsh **unconstrained** global snap path to avoid over-snapping on small lateral error.
- **`resetCurrentRouteLanelet`** inside the snap helper runs only when **`!is_any_approved_module_running`**, matching the **`lanelet_sequence`** fallback so approved modules are not overridden unintentionally.
- **`if` / `else if`** chain for sequence fallbacks; final reset only when no approved module is running/waiting.
- **Bugfix:** add missing braces so **`resetCurrentRouteLanelet`** in **`runApprovedModules`** runs only when the **`std::any_of`** condition is true.



## Related links

[TIER IV internal ticket](https://tier4.atlassian.net/browse/T4DEV-51089)

## How was this PR tested?
TIER IV internal simulator test
- [[shmpwk][Lexus][FuncVerif_Basic] PR check](https://evaluation.tier4.jp/evaluation/reports/68666668-2f93-5edf-b38d-74f968e04db5?project_id=autoware_dev) 155/155 :heavy_check_mark: 
- [[shmpwk][Lexus][DLR_Basic] PR check](https://evaluation.tier4.jp/evaluation/reports/703efd01-3e03-55f8-ad24-3145547de42a?project_id=autoware_dev) 4/4 :heavy_check_mark: 
- [[shmpwk][Lexus][MasterScenario] PR check](https://evaluation.tier4.jp/evaluation/reports/30c8f2ba-41f0-5ad2-8ded-18a207ec3047?project_id=autoware_dev) 4288/4289 :heavy_check_mark: 
  - I retried one failed scenario and it passed: [Retry for https://evaluation.tier4.jp/evaluation/reports/30c8f2ba-41f0-5ad2-8ded-18a207ec3047?projec](https://evaluation.tier4.jp/evaluation/reports/1d046c41-1b18-5fee-b963-ece8d8f46ef1?project_id=autoware_dev) 

Also tested with taxi vehicle. It worked great.

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
