### PR TITLE
fix(clang-tidy): re-enable bugprone-multi-level-implicit-pointer-conversion

### DIFF
--- a/.clang-tidy-ci
+++ b/.clang-tidy-ci
@@ -10,7 +10,6 @@ Checks: "
   -bugprone-infinite-loop,
   -bugprone-integer-division,
   -bugprone-macro-parentheses,
-  -bugprone-multi-level-implicit-pointer-conversion,
   -bugprone-narrowing-conversions,
   -bugprone-optional-value-conversion,
   -bugprone-parent-virtual-call,

--- a/common/autoware_universe_utils/src/system/backtrace.cpp
+++ b/common/autoware_universe_utils/src/system/backtrace.cpp
@@ -47,7 +47,7 @@ void print_backtrace()
   }
   RCLCPP_DEBUG_STREAM(rclcpp::get_logger("autoware_universe_utils"), ss.str());
 
-  free(symbol_list);
+  free(reinterpret_cast<void *>(symbol_list));
 }
 
 }  // namespace autoware::universe_utils

--- a/e2e/autoware_tensorrt_vad/lib/networks/preprocess/multi_camera_preprocess.cpp
+++ b/e2e/autoware_tensorrt_vad/lib/networks/preprocess/multi_camera_preprocess.cpp
@@ -38,11 +38,11 @@ void MultiCameraPreprocessor::cleanup_cuda_resources()
     d_resized_buffer_ = nullptr;
   }
   if (d_input_image_ptrs_) {
-    cudaFree(d_input_image_ptrs_);
+    cudaFree(reinterpret_cast<void *>(d_input_image_ptrs_));
     d_input_image_ptrs_ = nullptr;
   }
   if (d_resized_image_ptrs_) {
-    cudaFree(d_resized_image_ptrs_);
+    cudaFree(reinterpret_cast<void *>(d_resized_image_ptrs_));
     d_resized_image_ptrs_ = nullptr;
   }
 }


### PR DESCRIPTION
Re-enables `bugprone-multi-level-implicit-pointer-conversion` by removing its suppression from `.clang-tidy-ci`.

The check was suppressed in #12431 with 3 reported errors. This PR fixes all affected packages.

Refs #12450

## Fixes

### `autoware_universe_utils`

`backtrace_symbols()` returns `char **`, which was passed directly to `free()`. This PR makes the multilevel pointer conversion explicit:

```cpp
free(reinterpret_cast<void *>(symbol_list));
```

### `autoware_tensorrt_vad`

`d_input_image_ptrs_` and `d_resized_image_ptrs_` are `uint8_t **` buffers passed to `cudaFree()`. This PR makes the multilevel pointer conversions explicit:

```cpp
cudaFree(reinterpret_cast<void *>(d_input_image_ptrs_));
cudaFree(reinterpret_cast<void *>(d_resized_image_ptrs_));
```

## Verification

```bash
pre-commit run clang-format --files \
  common/autoware_universe_utils/src/system/backtrace.cpp \
  e2e/autoware_tensorrt_vad/lib/networks/preprocess/multi_camera_preprocess.cpp
```

Result:

```text
clang-format.............................................................Passed
```

```bash
colcon build --packages-up-to \
  autoware_tensorrt_vad \
  autoware_universe_utils \
  --cmake-args -DCMAKE_EXPORT_COMPILE_COMMANDS=1
```

Result:

```text
Summary: 33 packages finished
```

```bash
run-clang-tidy -p build/ \
  -config="$(cat src/autoware_universe/.clang-tidy-ci)" \
  -export-fixes /tmp/clang-tidy-result/fixes.yaml \
  -j $(nproc) \
  autoware_tensorrt_vad \
  autoware_universe_utils \
  > /tmp/clang-tidy-result/report.log 2>&1

grep -n "bugprone-multi-level-implicit-pointer-conversion" /tmp/clang-tidy-result/report.log | grep "error:" || echo "0 multi-level pointer conversion errors"
```

Result:

```text
0 multi-level pointer conversion errors
```
