### PR TITLE
fix(clang-tidy): re-enable bugprone-optional-value-conversion for road user stop module

### DIFF
--- a/.clang-tidy-ci
+++ b/.clang-tidy-ci
@@ -12,6 +12,7 @@ Checks: "
   -bugprone-macro-parentheses,
   -bugprone-multi-level-implicit-pointer-conversion,
   -bugprone-narrowing-conversions,
+  -bugprone-optional-value-conversion,
   -bugprone-parent-virtual-call,
   -bugprone-reserved-identifier,
   -bugprone-signed-char-misuse,

--- a/.clang-tidy-ci
+++ b/.clang-tidy-ci
@@ -12,7 +12,6 @@ Checks: "
   -bugprone-macro-parentheses,
   -bugprone-multi-level-implicit-pointer-conversion,
   -bugprone-narrowing-conversions,
-  -bugprone-optional-value-conversion,
   -bugprone-parent-virtual-call,
   -bugprone-reserved-identifier,
   -bugprone-signed-char-misuse,

--- a/planning/motion_velocity_planner/autoware_motion_velocity_road_user_stop_module/src/road_user_stop_module.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_road_user_stop_module/src/road_user_stop_module.cpp
@@ -907,7 +907,7 @@ std::optional<Point> RoadUserStopModule::plan_stop(
         continue;
       }
     }
-    determined_zero_vel_dist = candidate_zero_vel_dist.value();
+    determined_zero_vel_dist = candidate_zero_vel_dist;
     determined_stop_obstacle = stop_obstacle;
     determined_desired_stop_margin = desired_stop_margin;
   }
@@ -1090,7 +1090,7 @@ std::optional<Point> RoadUserStopModule::calc_stop_point(
   autoware_utils_visualization::append_marker_array(markers, &debug_data_.stop_wall_marker);
 
   // update debug data
-  debug_data_.stop_index = zero_vel_idx.value();
+  debug_data_.stop_index = zero_vel_idx;
   debug_data_.stop_point = stop_point;
 
   // update virtual wall position for the object in TrackedObject


### PR DESCRIPTION
Re-enables `bugprone-optional-value-conversion` by removing its suppression from `.clang-tidy-ci`.

This PR fixes the 2 reported errors in `planning/motion_velocity_planner/autoware_motion_velocity_road_user_stop_module`.

Refs #12450

## Fixes

### `autoware_motion_velocity_road_user_stop_module`

The code dereferenced optionals and assigned the contained value back into optional fields, causing unnecessary optional unwrap and rewrap.

This PR changes:

```cpp
determined_zero_vel_dist = candidate_zero_vel_dist.value();
debug_data_.stop_index = zero_vel_idx.value();
```

to:

```cpp
determined_zero_vel_dist = candidate_zero_vel_dist;
debug_data_.stop_index = zero_vel_idx;
```

This keeps behavior unchanged and avoids the optional value conversion warning.

## Verification

```bash
pre-commit run clang-format --files \
  planning/motion_velocity_planner/autoware_motion_velocity_road_user_stop_module/src/road_user_stop_module.cpp
```

Result:

```text
clang-format.............................................................Passed
```

```bash
colcon build --packages-up-to autoware_motion_velocity_road_user_stop_module \
  --cmake-args -DCMAKE_EXPORT_COMPILE_COMMANDS=1
```

Result:

```text
Summary: 45 packages finished
```

```bash
run-clang-tidy -p build/ \
  -config="$(cat src/autoware_universe/.clang-tidy-ci)" \
  -export-fixes /tmp/clang-tidy-result/fixes.yaml \
  -j $(nproc) \
  autoware_motion_velocity_road_user_stop_module \
  > /tmp/clang-tidy-result/report.log 2>&1

grep -n "bugprone-optional-value-conversion" /tmp/clang-tidy-result/report.log | grep "error:" || echo "0 optional-value-conversion errors"
```

Result:

```text
0 optional-value-conversion errors
```