### PR TITLE
feat(trajectory_validator): uncrossable boundary departure filter

### DIFF
--- a/planning/autoware_trajectory_validator/CMakeLists.txt
+++ b/planning/autoware_trajectory_validator/CMakeLists.txt
@@ -34,6 +34,7 @@ rclcpp_components_register_node(${trajectory_validator_lib_target}
 )
 
 ament_auto_add_library(autoware_trajectory_validator_plugins SHARED
+  src/filters/safety/uncrossable_boundary_departure.cpp
   src/filters/safety/out_of_lane_filter.cpp
   src/filters/safety/vehicle_constraint_filter.cpp
   src/filters/traffic_rule/traffic_light_filter.cpp

--- a/planning/autoware_trajectory_validator/config/trajectory_validator.param.yaml
+++ b/planning/autoware_trajectory_validator/config/trajectory_validator.param.yaml
@@ -5,6 +5,7 @@
 
     shadow_mode_filter_names:
       [
+        "safety::UncrossableBoundaryDepartureFilter",
         "safety::OutOfLaneFilter",
         "safety::VehicleConstraintFilter",
         "traffic_rule::TrafficLightFilter",

--- a/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/filters/safety/uncrossable_boundary_departure.hpp
+++ b/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/filters/safety/uncrossable_boundary_departure.hpp
@@ -1,0 +1,46 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__TRAJECTORY_VALIDATOR__FILTERS__SAFETY__UNCROSSABLE_BOUNDARY_DEPARTURE_HPP_
+#define AUTOWARE__TRAJECTORY_VALIDATOR__FILTERS__SAFETY__UNCROSSABLE_BOUNDARY_DEPARTURE_HPP_
+
+#include "autoware/trajectory_validator/validator_interface.hpp"
+
+#include <autoware/boundary_departure_checker/uncrossable_boundary_checker.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+#include <memory>
+#include <string>
+namespace autoware::trajectory_validator::plugin::safety
+{
+class UncrossableBoundaryDepartureFilter : public plugin::ValidatorInterface
+{
+public:
+  UncrossableBoundaryDepartureFilter() : ValidatorInterface("uncrossable_boundary_departure_filter")
+  {
+  }
+
+  result_t is_feasible(const TrajectoryPoints & traj_points, const FilterContext & context) final;
+
+  void update_parameters(const validator::Params & params) final;
+
+private:
+  std::unique_ptr<boundary_departure_checker::UncrossableBoundaryChecker> checker_;
+  boundary_departure_checker::UncrossableBoundaryDepartureParam params_;
+
+  [[nodiscard]] std::optional<std::string> is_invalid_input(const FilterContext & context) const;
+};
+}  // namespace autoware::trajectory_validator::plugin::safety
+
+#endif  // AUTOWARE__TRAJECTORY_VALIDATOR__FILTERS__SAFETY__UNCROSSABLE_BOUNDARY_DEPARTURE_HPP_

--- a/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/filters/safety/uncrossable_boundary_departure.hpp
+++ b/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/filters/safety/uncrossable_boundary_departure.hpp
@@ -39,7 +39,7 @@ private:
   std::unique_ptr<boundary_departure_checker::UncrossableBoundaryChecker> checker_;
   boundary_departure_checker::UncrossableBoundaryDepartureParam params_;
 
-  [[nodiscard]] std::optional<std::string> is_invalid_input(const FilterContext & context) const;
+  tl::expected<void, std::string> validate_filter_context(const FilterContext & context) const;
 };
 }  // namespace autoware::trajectory_validator::plugin::safety
 

--- a/planning/autoware_trajectory_validator/package.xml
+++ b/planning/autoware_trajectory_validator/package.xml
@@ -23,6 +23,7 @@
 
   <exec_depend>rosidl_default_runtime</exec_depend>
 
+  <depend>autoware_boundary_departure_checker</depend>
   <depend>autoware_deprecated_boundary_departure_checker</depend>
   <depend>autoware_internal_planning_msgs</depend>
   <depend>autoware_lanelet2_utils</depend>

--- a/planning/autoware_trajectory_validator/param/parameter_struct.yaml
+++ b/planning/autoware_trajectory_validator/param/parameter_struct.yaml
@@ -92,3 +92,55 @@ validator:
         default_value: 2.0
         description: jerk limit to calculate the stop distance used as trajectory length limit
         read_only: false
+
+  boundary_departure:
+    lateral_margin_m:
+      type: double
+      default_value: 0.01
+      description: lateral margin [m]
+      read_only: false
+    longitudinal_margin_m:
+      type: double
+      default_value: 1.0
+      description: longitudinal margin [m]
+      read_only: false
+    max_deceleration_mps2:
+      type: double
+      default_value: -4.0
+      description: maximum deceleration [m/s^2]
+      read_only: false
+    max_jerk_mps3:
+      type: double
+      default_value: -5.0
+      description: maximum jerk [m/s^3]
+      read_only: false
+    brake_delay_s:
+      type: double
+      default_value: 1.0
+      description: brake delay [s]
+      read_only: false
+    time_to_departure_cutoff_s:
+      type: double
+      default_value: 2.0
+      description: time to departure cutoff [s]
+      read_only: false
+    on_time_buffer_s:
+      type: double
+      default_value: 0.15
+      description: buffer for activating departure detection [s]
+      read_only: false
+    off_time_buffer_s:
+      type: double
+      default_value: 0.15
+      description: buffer for deactivating departure detection [s]
+      read_only: false
+    enable_developer_marker:
+      type: bool
+      default_value: true
+      description: flag marker only for developer
+      read_only: false
+    boundary_types:
+      type: string_array
+      default_value: [road_border]
+      description: boundary types to detect
+      read_only: true

--- a/planning/autoware_trajectory_validator/plugins.xml
+++ b/planning/autoware_trajectory_validator/plugins.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0"?>
 <library path="autoware_trajectory_validator_plugins">
+  <class type="safety::UncrossableBoundaryDepartureFilter"
+    base_class_type="autoware::trajectory_validator::plugin::ValidatorInterface">
+    <description>
+      Filters trajectories that cross uncrossable boundaries
+    </description>
+  </class>
   <class type="safety::OutOfLaneFilter"
     base_class_type="autoware::trajectory_validator::plugin::ValidatorInterface">
     <description>

--- a/planning/autoware_trajectory_validator/src/filters/safety/uncrossable_boundary_departure.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/uncrossable_boundary_departure.cpp
@@ -1,0 +1,101 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/trajectory_validator/filters/safety/uncrossable_boundary_departure.hpp"
+
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace autoware::trajectory_validator::plugin::safety
+{
+UncrossableBoundaryDepartureFilter::result_t UncrossableBoundaryDepartureFilter::is_feasible(
+  const TrajectoryPoints & traj_points, const FilterContext & context)
+{
+  if (const auto has_invalid_input = is_invalid_input(context)) {
+    return tl::make_unexpected(*has_invalid_input);
+  }
+
+  if (!checker_) {
+    checker_ = std::make_unique<boundary_departure_checker::UncrossableBoundaryChecker>(
+      context.lanelet_map, params_, *vehicle_info_ptr_);
+  }
+
+  boundary_departure_checker::EgoDynamicState ego_state;
+  ego_state.pose_with_cov = context.odometry->pose;
+  ego_state.velocity = context.odometry->twist.twist.linear.x;
+  ego_state.acceleration = context.acceleration->accel.accel.linear.x;
+  ego_state.current_time_s = rclcpp::Time(context.odometry->header.stamp).seconds();
+
+  auto status = checker_->update_departure_status(traj_points, ego_state);
+
+  const bool is_feasible = status.status != boundary_departure_checker::DepartureType::CRITICAL;
+
+  if (!is_feasible) {
+    std::move(
+      status.debug_markers.markers.begin(), status.debug_markers.markers.end(),
+      std::back_inserter(debug_markers_.markers));
+  }
+
+  std::vector<MetricReport> metrics{
+    autoware_trajectory_validator::build<MetricReport>()
+      .validator_name(get_name())
+      .validator_category(category())
+      .metric_name("check_critical_departure")
+      .metric_value(is_feasible ? 1.0 : 0.0)
+      .level(!is_feasible ? MetricReport::ERROR : MetricReport::OK)};
+
+  return ValidationResult{is_feasible, std::move(metrics)};
+}
+
+void UncrossableBoundaryDepartureFilter::update_parameters(const validator::Params & params)
+{
+  params_.lateral_margin_m = params.boundary_departure.lateral_margin_m;
+  params_.longitudinal_margin_m = params.boundary_departure.longitudinal_margin_m;
+  params_.max_deceleration_mps2 = params.boundary_departure.max_deceleration_mps2;
+  params_.max_jerk_mps3 = params.boundary_departure.max_jerk_mps3;
+  params_.brake_delay_s = params.boundary_departure.brake_delay_s;
+  params_.time_to_departure_cutoff_s = params.boundary_departure.time_to_departure_cutoff_s;
+  params_.on_time_buffer_s = params.boundary_departure.on_time_buffer_s;
+  params_.off_time_buffer_s = params.boundary_departure.off_time_buffer_s;
+  params_.enable_developer_marker = params.boundary_departure.enable_developer_marker;
+  params_.boundary_types_to_detect = params.boundary_departure.boundary_types;
+
+  if (checker_) {
+    checker_->update_parameters(params_);
+  }
+}
+
+std::optional<std::string> UncrossableBoundaryDepartureFilter::is_invalid_input(
+  const FilterContext & context) const
+{
+  if (!context.lanelet_map || context.lanelet_map->lineStringLayer.empty()) {
+    return "Lanelet map is not available in the context.";
+  }
+
+  if (!vehicle_info_ptr_) {
+    return "Vehicle info is not set.";
+  }
+
+  return std::nullopt;
+}
+}  // namespace autoware::trajectory_validator::plugin::safety
+
+#include <pluginlib/class_list_macros.hpp>
+namespace safety = autoware::trajectory_validator::plugin::safety;
+
+PLUGINLIB_EXPORT_CLASS(
+  safety::UncrossableBoundaryDepartureFilter,
+  autoware::trajectory_validator::plugin::ValidatorInterface)

--- a/planning/autoware_trajectory_validator/src/filters/safety/uncrossable_boundary_departure.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/uncrossable_boundary_departure.cpp
@@ -24,8 +24,8 @@ namespace autoware::trajectory_validator::plugin::safety
 UncrossableBoundaryDepartureFilter::result_t UncrossableBoundaryDepartureFilter::is_feasible(
   const TrajectoryPoints & traj_points, const FilterContext & context)
 {
-  if (const auto has_invalid_input = is_invalid_input(context)) {
-    return tl::make_unexpected(*has_invalid_input);
+  if (const auto validate_context = validate_filter_context(context); !validate_context) {
+    return tl::make_unexpected(validate_context.error());
   }
 
   if (!checker_) {
@@ -78,18 +78,18 @@ void UncrossableBoundaryDepartureFilter::update_parameters(const validator::Para
   }
 }
 
-std::optional<std::string> UncrossableBoundaryDepartureFilter::is_invalid_input(
+tl::expected<void, std::string> UncrossableBoundaryDepartureFilter::validate_filter_context(
   const FilterContext & context) const
 {
   if (!context.lanelet_map || context.lanelet_map->lineStringLayer.empty()) {
-    return "Lanelet map is not available in the context.";
+    return tl::make_unexpected("Lanelet map is not available in the context.");
   }
 
   if (!vehicle_info_ptr_) {
-    return "Vehicle info is not set.";
+    return tl::make_unexpected("Vehicle info is not set.");
   }
 
-  return std::nullopt;
+  return {};
 }
 }  // namespace autoware::trajectory_validator::plugin::safety
 


### PR DESCRIPTION
## Description
Adds a new `safety::UncrossableBoundaryDepartureFilter` plugin to `autoware_trajectory_validator`. The filter wraps `autoware_boundary_departure_checker::UncrossableBoundaryChecker` and rejects candidate trajectories whose predicted departure status is `CRITICAL` against the configured uncrossable boundary types (default: `road_border`).

On each `is_feasible` call, the filter:
- Validates that the lanelet map and vehicle info are available.
- Lazily constructs the `UncrossableBoundaryChecker` on first use.
- Builds an `EgoDynamicState` from `context.odometry` and `context.acceleration`.
- Runs `update_departure_status` over the candidate `TrajectoryPoints`.
- Emits a `check_critical_departure` metric (`OK` / `ERROR`) and forwards debug markers when a critical departure is detected.

The filter is exported via `pluginlib` and added to `shadow_mode_filter_names` in `trajectory_validator.param.yaml`, so it runs in shadow mode and does not affect trajectory selection.

## Related links
**Parent Issue:**
- Link
<!-- ⬇️🟢
**Private Links:**
- [CompanyName internal link]()
⬆️🟢 -->
## How was this PR tested?
<!-- fill in: simulation scenario(s), bag replay, unit tests, etc. -->
## Notes for reviewers
- The filter is registered only in `shadow_mode_filter_names`; promotion to an active filter is out of scope for this PR.
- `boundary_departure.boundary_types` is `read_only` and defaults to `[road_border]`.
- New runtime dependency on `autoware_boundary_departure_checker`.
## Interface changes
<!-- ⬇️🔴
### Topic changes
#### Additions and removals
| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |
#### Modifications
| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |
🔴⬆️ -->
### ROS Parameter Changes
#### Additions and removals
| Change type | Parameter Name                                       | Type           | Default Value   | Description                                       |
|:------------|:-----------------------------------------------------|:---------------|:----------------|:--------------------------------------------------|
| Added       | `boundary_departure.lateral_margin_m`                | `double`       | `0.01`          | lateral margin [m]                                |
| Added       | `boundary_departure.longitudinal_margin_m`           | `double`       | `1.0`           | longitudinal margin [m]                           |
| Added       | `boundary_departure.max_deceleration_mps2`           | `double`       | `-4.0`          | maximum deceleration [m/s^2]                      |
| Added       | `boundary_departure.max_jerk_mps3`                   | `double`       | `-5.0`          | maximum jerk [m/s^3]                              |
| Added       | `boundary_departure.brake_delay_s`                   | `double`       | `1.0`           | brake delay [s]                                   |
| Added       | `boundary_departure.time_to_departure_cutoff_s`      | `double`       | `2.0`           | time to departure cutoff [s]                      |
| Added       | `boundary_departure.on_time_buffer_s`                | `double`       | `0.15`          | buffer for activating departure detection [s]     |
| Added       | `boundary_departure.off_time_buffer_s`               | `double`       | `0.15`          | buffer for deactivating departure detection [s]   |
| Added       | `boundary_departure.enable_developer_marker`         | `bool`         | `true`          | flag marker only for developer                    |
| Added       | `boundary_departure.boundary_types`                  | `string_array` | `[road_border]` | boundary types to detect (read-only)              |
| Added       | entry in `shadow_mode_filter_names`                  | `string_array` | —               | adds `safety::UncrossableBoundaryDepartureFilter` |
## Effects on system behavior
None. The filter is registered in `shadow_mode_filter_names`, so its result is reported as metrics only and does not influence trajectory selection.