### PR TITLE
fix(clang-tidy): re-enable bugprone-optional-value-conversion for universe utils

### DIFF
--- a/.clang-tidy-ci
+++ b/.clang-tidy-ci
@@ -12,6 +12,7 @@ Checks: "
   -bugprone-macro-parentheses,
   -bugprone-multi-level-implicit-pointer-conversion,
   -bugprone-narrowing-conversions,
+  -bugprone-optional-value-conversion,
   -bugprone-parent-virtual-call,
   -bugprone-reserved-identifier,
   -bugprone-signed-char-misuse,

--- a/.clang-tidy-ci
+++ b/.clang-tidy-ci
@@ -12,7 +12,6 @@ Checks: "
   -bugprone-macro-parentheses,
   -bugprone-multi-level-implicit-pointer-conversion,
   -bugprone-narrowing-conversions,
-  -bugprone-optional-value-conversion,
   -bugprone-parent-virtual-call,
   -bugprone-reserved-identifier,
   -bugprone-signed-char-misuse,

--- a/common/autoware_universe_utils/src/geometry/polygon_clip.cpp
+++ b/common/autoware_universe_utils/src/geometry/polygon_clip.cpp
@@ -177,7 +177,7 @@ void insert_vertex(
   }
 
   vertices[vertex_index].next = current_index;
-  vertices[vertex_index].prev = vertices[current_index].prev.value();
+  vertices[vertex_index].prev = vertices[current_index].prev;
   std::size_t prev_index = vertices[current_index].prev.value();
 
   if (prev_index != current_index) {


### PR DESCRIPTION
Re-enables `bugprone-optional-value-conversion` by removing its suppression from `.clang-tidy-ci`.

This PR fixes the reported error in `common/autoware_universe_utils`.

Refs #12450

## Fixes

`vertices[current_index].prev` is already an `std::optional<size_t>`, and `vertices[vertex_index].prev` is also an optional field.

This PR changes:

```cpp
vertices[vertex_index].prev = vertices[current_index].prev.value();
```

to:

```cpp
vertices[vertex_index].prev = vertices[current_index].prev;
```

This keeps behavior unchanged and avoids unnecessary optional unwrap and rewrap.

## Verification

```bash
pre-commit run clang-format --files \
  common/autoware_universe_utils/src/geometry/polygon_clip.cpp
```

Result:

```text
clang-format.............................................................Passed
```

```bash
colcon build --packages-up-to autoware_universe_utils \
  --cmake-args -DCMAKE_EXPORT_COMPILE_COMMANDS=1
```

```bash
run-clang-tidy -p build/ \
  -config="$(cat src/autoware_universe/.clang-tidy-ci)" \
  -export-fixes /tmp/clang-tidy-result/fixes.yaml \
  -j $(nproc) \
  autoware_universe_utils \
  > /tmp/clang-tidy-result/report.log 2>&1

grep -n "bugprone-optional-value-conversion" /tmp/clang-tidy-result/report.log | grep "error:" || echo "0 optional-value-conversion errors"
```

Result:

```text
0 optional-value-conversion errors
```