### PR TITLE
fix(detected_object_feature_remover): update autoware system design format to add parameter for convex hull conversion

### DIFF
--- a/perception/autoware_detected_object_feature_remover/design/DetectedObjectFeatureRemover.node.yaml
+++ b/perception/autoware_detected_object_feature_remover/design/DetectedObjectFeatureRemover.node.yaml
@@ -29,7 +29,7 @@ publishers:
 # parameters
 param_files: []
 
-param_values: 
+param_values:
   - name: run_convex_hull_conversion
     default: false
 

--- a/perception/autoware_detected_object_feature_remover/design/DetectedObjectFeatureRemover.node.yaml
+++ b/perception/autoware_detected_object_feature_remover/design/DetectedObjectFeatureRemover.node.yaml
@@ -29,7 +29,9 @@ publishers:
 # parameters
 param_files: []
 
-param_values: []
+param_values: 
+  - name: run_convex_hull_conversion
+    default: false
 
 # processes
 processes:


### PR DESCRIPTION
## Description

- Introduced existing parameter `run_convex_hull_conversion` to the autoware system design format  configuration.

NO LOGIC CHANGE

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
