### PR TITLE
test(autoware_traffic_light_visualization): add unit tests for TrafficLightVisualizer

### DIFF
--- a/perception/autoware_traffic_light_visualization/CMakeLists.txt
+++ b/perception/autoware_traffic_light_visualization/CMakeLists.txt
@@ -54,6 +54,22 @@ if(BUILD_TESTING)
     rclcpp
     visualization_msgs
   )
+
+  ament_add_gtest(test_traffic_light_map_visualizer_core
+    test/test_traffic_light_map_visualizer_core.cpp
+  )
+  target_include_directories(test_traffic_light_map_visualizer_core PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/src
+  )
+  target_link_libraries(test_traffic_light_map_visualizer_core
+    traffic_light_map_visualizer
+  )
+  ament_target_dependencies(test_traffic_light_map_visualizer_core
+    autoware_lanelet2_extension
+    autoware_perception_msgs
+    geometry_msgs
+    visualization_msgs
+  )
 endif()
 
 # Copy the assets directory to the installation directory

--- a/perception/autoware_traffic_light_visualization/test/test_traffic_light_map_visualizer_core.cpp
+++ b/perception/autoware_traffic_light_visualization/test/test_traffic_light_map_visualizer_core.cpp
@@ -38,6 +38,7 @@ using autoware_perception_msgs::msg::TrafficLightGroupArray;
 constexpr lanelet::Id test_group_id = 100;
 constexpr lanelet::Id another_test_group_id = 200;
 constexpr lanelet::Id non_existent_group_id = 999;
+constexpr lanelet::Id arbitrary_bulb_id = 42;
 
 Bulb make_bulb(lanelet::Id id, double x, double y, double z, uint8_t color)
 {
@@ -85,7 +86,7 @@ TEST(TrafficLightVisualizer, RedBulbDetectedProducesRedMarker)
 {
   BulbsByGroupId map_data;
   map_data.emplace(
-    test_group_id, std::vector<Bulb>{make_bulb(42, 0, 0, 0, TrafficLightElement::RED)});
+    test_group_id, std::vector<Bulb>{make_bulb(arbitrary_bulb_id, 0, 0, 0, TrafficLightElement::RED)});
   TrafficLightVisualizer visualizer{std::move(map_data)};
   auto detection = make_detection({make_group(test_group_id, {TrafficLightElement::RED})});
 
@@ -101,7 +102,7 @@ TEST(TrafficLightVisualizer, GreenBulbDetectedProducesGreenMarker)
 {
   BulbsByGroupId map_data;
   map_data.emplace(
-    test_group_id, std::vector<Bulb>{make_bulb(42, 0, 0, 0, TrafficLightElement::GREEN)});
+    test_group_id, std::vector<Bulb>{make_bulb(arbitrary_bulb_id, 0, 0, 0, TrafficLightElement::GREEN)});
   TrafficLightVisualizer visualizer{std::move(map_data)};
   auto detection = make_detection({make_group(test_group_id, {TrafficLightElement::GREEN})});
 
@@ -117,7 +118,7 @@ TEST(TrafficLightVisualizer, AmberBulbDetectedProducesYellowMarker)
 {
   BulbsByGroupId map_data;
   map_data.emplace(
-    test_group_id, std::vector<Bulb>{make_bulb(42, 0, 0, 0, TrafficLightElement::AMBER)});
+    test_group_id, std::vector<Bulb>{make_bulb(arbitrary_bulb_id, 0, 0, 0, TrafficLightElement::AMBER)});
   TrafficLightVisualizer visualizer{std::move(map_data)};
   auto detection = make_detection({make_group(test_group_id, {TrafficLightElement::AMBER})});
 
@@ -133,7 +134,7 @@ TEST(TrafficLightVisualizer, UnknownGroupIdProducesEmptyMarkers)
 {
   BulbsByGroupId map_data;
   map_data.emplace(
-    test_group_id, std::vector<Bulb>{make_bulb(42, 0, 0, 0, TrafficLightElement::RED)});
+    test_group_id, std::vector<Bulb>{make_bulb(arbitrary_bulb_id, 0, 0, 0, TrafficLightElement::RED)});
   TrafficLightVisualizer visualizer{std::move(map_data)};
   auto detection = make_detection({make_group(non_existent_group_id, {TrafficLightElement::RED})});
 
@@ -188,7 +189,7 @@ TEST(TrafficLightVisualizer, EmptyDetectionProducesEmptyMarkers)
 {
   BulbsByGroupId map_data;
   map_data.emplace(
-    test_group_id, std::vector<Bulb>{make_bulb(42, 0, 0, 0, TrafficLightElement::RED)});
+    test_group_id, std::vector<Bulb>{make_bulb(arbitrary_bulb_id, 0, 0, 0, TrafficLightElement::RED)});
   TrafficLightVisualizer visualizer{std::move(map_data)};
   auto detection = make_detection({});
 

--- a/perception/autoware_traffic_light_visualization/test/test_traffic_light_map_visualizer_core.cpp
+++ b/perception/autoware_traffic_light_visualization/test/test_traffic_light_map_visualizer_core.cpp
@@ -111,6 +111,19 @@ TEST(TrafficLightVisualizer, EmptyBulbsProducesEmptyMarkers)
   EXPECT_TRUE(markers.empty());
 }
 
+TEST(TrafficLightVisualizer, EmptyDetectionProducesEmptyMarkers)
+{
+  BulbsByGroupId map_data;
+  map_data.emplace(
+    test_group_id, std::vector<Bulb>{make_bulb(arbitrary_bulb_id, TrafficLightElement::RED)});
+  TrafficLightVisualizer visualizer{std::move(map_data)};
+  auto detection = make_detection({});
+
+  auto markers = visualizer.generate_markers(detection, builtin_interfaces::msg::Time{});
+
+  EXPECT_TRUE(markers.empty());
+}
+
 TEST(TrafficLightVisualizer, RedBulbDetectedProducesRedMarker)
 {
   BulbsByGroupId map_data;
@@ -190,6 +203,23 @@ TEST(TrafficLightVisualizer, UnknownGroupIdProducesEmptyMarkers)
   EXPECT_TRUE(markers.empty());
 }
 
+TEST(TrafficLightVisualizer, KnownAndUnknownGroupMixOnlyKnownProducesMarkers)
+{
+  BulbsByGroupId map_data;
+  map_data.emplace(
+    test_group_id, std::vector<Bulb>{make_bulb(arbitrary_bulb_id, TrafficLightElement::RED)});
+  TrafficLightVisualizer visualizer{std::move(map_data)};
+  auto detection = make_detection({
+    make_group(test_group_id, {TrafficLightElement::RED}),
+    make_group(non_existent_group_id, {TrafficLightElement::RED}),
+  });
+
+  auto markers = visualizer.generate_markers(detection, builtin_interfaces::msg::Time{});
+
+  ASSERT_EQ(markers.size(), 1u);
+  EXPECT_EQ(markers[0].id, arbitrary_bulb_id);
+}
+
 TEST(TrafficLightVisualizer, OnlyDetectedColorsAreShown)
 {
   BulbsByGroupId map_data;
@@ -206,6 +236,24 @@ TEST(TrafficLightVisualizer, OnlyDetectedColorsAreShown)
 
   ASSERT_EQ(markers.size(), 1u);
   EXPECT_EQ(markers[0].id, 1);
+}
+
+TEST(TrafficLightVisualizer, DetectionColorWithoutMapBulbIsIgnored)
+{
+  BulbsByGroupId map_data;
+  map_data.emplace(
+    test_group_id, std::vector<Bulb>{make_bulb(arbitrary_bulb_id, TrafficLightElement::RED)});
+  TrafficLightVisualizer visualizer{std::move(map_data)};
+  // detection contains colors not represented in the map (GREEN, UNKNOWN);
+  // only RED has a corresponding bulb and should produce a marker.
+  auto detection = make_detection({make_group(
+    test_group_id,
+    {TrafficLightElement::RED, TrafficLightElement::GREEN, TrafficLightElement::UNKNOWN})});
+
+  auto markers = visualizer.generate_markers(detection, builtin_interfaces::msg::Time{});
+
+  ASSERT_EQ(markers.size(), 1u);
+  EXPECT_EQ(markers[0].id, arbitrary_bulb_id);
 }
 
 TEST(TrafficLightVisualizer, TwoGroupsBothMatchedProduceFourMarkers)
@@ -239,52 +287,4 @@ TEST(TrafficLightVisualizer, TwoGroupsBothMatchedProduceFourMarkers)
   EXPECT_DOUBLE_EQ(by_id.at(2)->pose.position.x, 2.0);
   EXPECT_DOUBLE_EQ(by_id.at(3)->pose.position.x, 3.0);
   EXPECT_DOUBLE_EQ(by_id.at(4)->pose.position.x, 4.0);
-}
-
-TEST(TrafficLightVisualizer, EmptyDetectionProducesEmptyMarkers)
-{
-  BulbsByGroupId map_data;
-  map_data.emplace(
-    test_group_id, std::vector<Bulb>{make_bulb(arbitrary_bulb_id, TrafficLightElement::RED)});
-  TrafficLightVisualizer visualizer{std::move(map_data)};
-  auto detection = make_detection({});
-
-  auto markers = visualizer.generate_markers(detection, builtin_interfaces::msg::Time{});
-
-  EXPECT_TRUE(markers.empty());
-}
-
-TEST(TrafficLightVisualizer, DetectionColorWithoutMapBulbIsIgnored)
-{
-  BulbsByGroupId map_data;
-  map_data.emplace(
-    test_group_id, std::vector<Bulb>{make_bulb(arbitrary_bulb_id, TrafficLightElement::RED)});
-  TrafficLightVisualizer visualizer{std::move(map_data)};
-  // detection contains colors not represented in the map (GREEN, UNKNOWN);
-  // only RED has a corresponding bulb and should produce a marker.
-  auto detection = make_detection({make_group(
-    test_group_id,
-    {TrafficLightElement::RED, TrafficLightElement::GREEN, TrafficLightElement::UNKNOWN})});
-
-  auto markers = visualizer.generate_markers(detection, builtin_interfaces::msg::Time{});
-
-  ASSERT_EQ(markers.size(), 1u);
-  EXPECT_EQ(markers[0].id, arbitrary_bulb_id);
-}
-
-TEST(TrafficLightVisualizer, KnownAndUnknownGroupMixOnlyKnownProducesMarkers)
-{
-  BulbsByGroupId map_data;
-  map_data.emplace(
-    test_group_id, std::vector<Bulb>{make_bulb(arbitrary_bulb_id, TrafficLightElement::RED)});
-  TrafficLightVisualizer visualizer{std::move(map_data)};
-  auto detection = make_detection({
-    make_group(test_group_id, {TrafficLightElement::RED}),
-    make_group(non_existent_group_id, {TrafficLightElement::RED}),
-  });
-
-  auto markers = visualizer.generate_markers(detection, builtin_interfaces::msg::Time{});
-
-  ASSERT_EQ(markers.size(), 1u);
-  EXPECT_EQ(markers[0].id, arbitrary_bulb_id);
 }

--- a/perception/autoware_traffic_light_visualization/test/test_traffic_light_map_visualizer_core.cpp
+++ b/perception/autoware_traffic_light_visualization/test/test_traffic_light_map_visualizer_core.cpp
@@ -35,6 +35,10 @@ using autoware_perception_msgs::msg::TrafficLightElement;
 using autoware_perception_msgs::msg::TrafficLightGroup;
 using autoware_perception_msgs::msg::TrafficLightGroupArray;
 
+constexpr lanelet::Id test_group_id = 100;
+constexpr lanelet::Id another_test_group_id = 200;
+constexpr lanelet::Id non_existent_group_id = 999;
+
 Bulb make_bulb(lanelet::Id id, double x, double y, double z, uint8_t color)
 {
   Bulb bulb;
@@ -70,7 +74,7 @@ TrafficLightGroupArray make_detection(std::vector<TrafficLightGroup> groups)
 TEST(TrafficLightVisualizer, EmptyBulbsProducesEmptyMarkers)
 {
   TrafficLightVisualizer visualizer{BulbsByGroupId{}};
-  auto detection = make_detection({make_group(100, {TrafficLightElement::RED})});
+  auto detection = make_detection({make_group(test_group_id, {TrafficLightElement::RED})});
 
   auto markers = visualizer.generate_markers(detection, builtin_interfaces::msg::Time{});
 
@@ -81,9 +85,9 @@ TEST(TrafficLightVisualizer, RedBulbDetectedProducesRedMarker)
 {
   BulbsByGroupId map_data;
   map_data.emplace(
-    100, std::vector<Bulb>{make_bulb(42, 1.0, 2.0, 3.0, TrafficLightElement::RED)});
+    test_group_id, std::vector<Bulb>{make_bulb(42, 1.0, 2.0, 3.0, TrafficLightElement::RED)});
   TrafficLightVisualizer visualizer{std::move(map_data)};
-  auto detection = make_detection({make_group(100, {TrafficLightElement::RED})});
+  auto detection = make_detection({make_group(test_group_id, {TrafficLightElement::RED})});
 
   auto markers = visualizer.generate_markers(detection, builtin_interfaces::msg::Time{});
 
@@ -97,9 +101,9 @@ TEST(TrafficLightVisualizer, GreenBulbDetectedProducesGreenMarker)
 {
   BulbsByGroupId map_data;
   map_data.emplace(
-    100, std::vector<Bulb>{make_bulb(42, 1.0, 2.0, 3.0, TrafficLightElement::GREEN)});
+    test_group_id, std::vector<Bulb>{make_bulb(42, 1.0, 2.0, 3.0, TrafficLightElement::GREEN)});
   TrafficLightVisualizer visualizer{std::move(map_data)};
-  auto detection = make_detection({make_group(100, {TrafficLightElement::GREEN})});
+  auto detection = make_detection({make_group(test_group_id, {TrafficLightElement::GREEN})});
 
   auto markers = visualizer.generate_markers(detection, builtin_interfaces::msg::Time{});
 
@@ -113,9 +117,9 @@ TEST(TrafficLightVisualizer, AmberBulbDetectedProducesYellowMarker)
 {
   BulbsByGroupId map_data;
   map_data.emplace(
-    100, std::vector<Bulb>{make_bulb(42, 1.0, 2.0, 3.0, TrafficLightElement::AMBER)});
+    test_group_id, std::vector<Bulb>{make_bulb(42, 1.0, 2.0, 3.0, TrafficLightElement::AMBER)});
   TrafficLightVisualizer visualizer{std::move(map_data)};
-  auto detection = make_detection({make_group(100, {TrafficLightElement::AMBER})});
+  auto detection = make_detection({make_group(test_group_id, {TrafficLightElement::AMBER})});
 
   auto markers = visualizer.generate_markers(detection, builtin_interfaces::msg::Time{});
 
@@ -129,9 +133,9 @@ TEST(TrafficLightVisualizer, UnknownGroupIdProducesEmptyMarkers)
 {
   BulbsByGroupId map_data;
   map_data.emplace(
-    100, std::vector<Bulb>{make_bulb(42, 1.0, 2.0, 3.0, TrafficLightElement::RED)});
+    test_group_id, std::vector<Bulb>{make_bulb(42, 1.0, 2.0, 3.0, TrafficLightElement::RED)});
   TrafficLightVisualizer visualizer{std::move(map_data)};
-  auto detection = make_detection({make_group(999, {TrafficLightElement::RED})});
+  auto detection = make_detection({make_group(non_existent_group_id, {TrafficLightElement::RED})});
 
   auto markers = visualizer.generate_markers(detection, builtin_interfaces::msg::Time{});
 
@@ -142,13 +146,13 @@ TEST(TrafficLightVisualizer, OnlyDetectedColorsAreShown)
 {
   BulbsByGroupId map_data;
   map_data.emplace(
-    100, std::vector<Bulb>{
+    test_group_id, std::vector<Bulb>{
            make_bulb(1, 1.0, 0.0, 0.0, TrafficLightElement::RED),
            make_bulb(2, 2.0, 0.0, 0.0, TrafficLightElement::GREEN),
            make_bulb(3, 3.0, 0.0, 0.0, TrafficLightElement::AMBER),
          });
   TrafficLightVisualizer visualizer{std::move(map_data)};
-  auto detection = make_detection({make_group(100, {TrafficLightElement::RED})});
+  auto detection = make_detection({make_group(test_group_id, {TrafficLightElement::RED})});
 
   auto markers = visualizer.generate_markers(detection, builtin_interfaces::msg::Time{});
 
@@ -160,19 +164,19 @@ TEST(TrafficLightVisualizer, TwoGroupsBothMatchedProduceFourMarkers)
 {
   BulbsByGroupId map_data;
   map_data.emplace(
-    100, std::vector<Bulb>{
+    test_group_id, std::vector<Bulb>{
            make_bulb(1, 0, 0, 0, TrafficLightElement::RED),
            make_bulb(2, 0, 0, 0, TrafficLightElement::GREEN),
          });
   map_data.emplace(
-    200, std::vector<Bulb>{
+    another_test_group_id, std::vector<Bulb>{
            make_bulb(3, 0, 0, 0, TrafficLightElement::RED),
            make_bulb(4, 0, 0, 0, TrafficLightElement::GREEN),
          });
   TrafficLightVisualizer visualizer{std::move(map_data)};
   auto detection = make_detection({
-    make_group(100, {TrafficLightElement::RED, TrafficLightElement::GREEN}),
-    make_group(200, {TrafficLightElement::RED, TrafficLightElement::GREEN}),
+    make_group(test_group_id, {TrafficLightElement::RED, TrafficLightElement::GREEN}),
+    make_group(another_test_group_id, {TrafficLightElement::RED, TrafficLightElement::GREEN}),
   });
 
   auto markers = visualizer.generate_markers(detection, builtin_interfaces::msg::Time{});
@@ -184,7 +188,7 @@ TEST(TrafficLightVisualizer, EmptyDetectionProducesEmptyMarkers)
 {
   BulbsByGroupId map_data;
   map_data.emplace(
-    100, std::vector<Bulb>{make_bulb(42, 1.0, 2.0, 3.0, TrafficLightElement::RED)});
+    test_group_id, std::vector<Bulb>{make_bulb(42, 1.0, 2.0, 3.0, TrafficLightElement::RED)});
   TrafficLightVisualizer visualizer{std::move(map_data)};
 
   auto markers = visualizer.generate_markers(make_detection({}), builtin_interfaces::msg::Time{});

--- a/perception/autoware_traffic_light_visualization/test/test_traffic_light_map_visualizer_core.cpp
+++ b/perception/autoware_traffic_light_visualization/test/test_traffic_light_map_visualizer_core.cpp
@@ -135,7 +135,7 @@ TEST(TrafficLightVisualizer, UnknownGroupIdProducesEmptyMarkers)
   map_data.emplace(
     test_group_id, std::vector<Bulb>{make_bulb(42, 1.0, 2.0, 3.0, TrafficLightElement::RED)});
   TrafficLightVisualizer visualizer{std::move(map_data)};
-  auto detection = make_detection({make_group(non_existent_group_id, {TrafficLightElement::RED})});
+  auto detection = make_detection({make_group(999, {TrafficLightElement::RED})});
 
   auto markers = visualizer.generate_markers(detection, builtin_interfaces::msg::Time{});
 
@@ -190,8 +190,9 @@ TEST(TrafficLightVisualizer, EmptyDetectionProducesEmptyMarkers)
   map_data.emplace(
     test_group_id, std::vector<Bulb>{make_bulb(42, 1.0, 2.0, 3.0, TrafficLightElement::RED)});
   TrafficLightVisualizer visualizer{std::move(map_data)};
+  auto detection = make_detection({});
 
-  auto markers = visualizer.generate_markers(make_detection({}), builtin_interfaces::msg::Time{});
+  auto markers = visualizer.generate_markers(detection, builtin_interfaces::msg::Time{});
 
   EXPECT_TRUE(markers.empty());
 }

--- a/perception/autoware_traffic_light_visualization/test/test_traffic_light_map_visualizer_core.cpp
+++ b/perception/autoware_traffic_light_visualization/test/test_traffic_light_map_visualizer_core.cpp
@@ -14,15 +14,18 @@
 
 #include "traffic_light_map_visualizer/traffic_light_visualizer.hpp"
 
+#include <builtin_interfaces/msg/time.hpp>
+
 #include <autoware_perception_msgs/msg/traffic_light_element.hpp>
 #include <autoware_perception_msgs/msg/traffic_light_group.hpp>
 #include <autoware_perception_msgs/msg/traffic_light_group_array.hpp>
-#include <builtin_interfaces/msg/time.hpp>
 #include <geometry_msgs/msg/point.hpp>
+#include <visualization_msgs/msg/marker.hpp>
 
 #include <gtest/gtest.h>
 
 #include <cstdint>
+#include <set>
 #include <utility>
 #include <vector>
 
@@ -34,6 +37,7 @@ using autoware::traffic_light::TrafficLightVisualizer;
 using autoware_perception_msgs::msg::TrafficLightElement;
 using autoware_perception_msgs::msg::TrafficLightGroup;
 using autoware_perception_msgs::msg::TrafficLightGroupArray;
+using visualization_msgs::msg::Marker;
 
 constexpr lanelet::Id test_group_id = 100;
 constexpr lanelet::Id another_test_group_id = 200;
@@ -70,6 +74,15 @@ TrafficLightGroupArray make_detection(std::vector<TrafficLightGroup> groups)
   return array;
 }
 
+std::set<int32_t> collect_marker_ids(const std::vector<Marker> & markers)
+{
+  std::set<int32_t> ids;
+  for (const auto & m : markers) {
+    ids.insert(m.id);
+  }
+  return ids;
+}
+
 }  // namespace
 
 TEST(TrafficLightVisualizer, EmptyBulbsProducesEmptyMarkers)
@@ -86,7 +99,8 @@ TEST(TrafficLightVisualizer, RedBulbDetectedProducesRedMarker)
 {
   BulbsByGroupId map_data;
   map_data.emplace(
-    test_group_id, std::vector<Bulb>{make_bulb(arbitrary_bulb_id, 0, 0, 0, TrafficLightElement::RED)});
+    test_group_id,
+    std::vector<Bulb>{make_bulb(arbitrary_bulb_id, 0, 0, 0, TrafficLightElement::RED)});
   TrafficLightVisualizer visualizer{std::move(map_data)};
   auto detection = make_detection({make_group(test_group_id, {TrafficLightElement::RED})});
 
@@ -102,7 +116,8 @@ TEST(TrafficLightVisualizer, GreenBulbDetectedProducesGreenMarker)
 {
   BulbsByGroupId map_data;
   map_data.emplace(
-    test_group_id, std::vector<Bulb>{make_bulb(arbitrary_bulb_id, 0, 0, 0, TrafficLightElement::GREEN)});
+    test_group_id,
+    std::vector<Bulb>{make_bulb(arbitrary_bulb_id, 0, 0, 0, TrafficLightElement::GREEN)});
   TrafficLightVisualizer visualizer{std::move(map_data)};
   auto detection = make_detection({make_group(test_group_id, {TrafficLightElement::GREEN})});
 
@@ -118,7 +133,8 @@ TEST(TrafficLightVisualizer, AmberBulbDetectedProducesYellowMarker)
 {
   BulbsByGroupId map_data;
   map_data.emplace(
-    test_group_id, std::vector<Bulb>{make_bulb(arbitrary_bulb_id, 0, 0, 0, TrafficLightElement::AMBER)});
+    test_group_id,
+    std::vector<Bulb>{make_bulb(arbitrary_bulb_id, 0, 0, 0, TrafficLightElement::AMBER)});
   TrafficLightVisualizer visualizer{std::move(map_data)};
   auto detection = make_detection({make_group(test_group_id, {TrafficLightElement::AMBER})});
 
@@ -152,7 +168,8 @@ TEST(TrafficLightVisualizer, UnknownGroupIdProducesEmptyMarkers)
 {
   BulbsByGroupId map_data;
   map_data.emplace(
-    test_group_id, std::vector<Bulb>{make_bulb(arbitrary_bulb_id, 0, 0, 0, TrafficLightElement::RED)});
+    test_group_id,
+    std::vector<Bulb>{make_bulb(arbitrary_bulb_id, 0, 0, 0, TrafficLightElement::RED)});
   TrafficLightVisualizer visualizer{std::move(map_data)};
   auto detection = make_detection({make_group(non_existent_group_id, {TrafficLightElement::RED})});
 
@@ -166,10 +183,10 @@ TEST(TrafficLightVisualizer, OnlyDetectedColorsAreShown)
   BulbsByGroupId map_data;
   map_data.emplace(
     test_group_id, std::vector<Bulb>{
-           make_bulb(1, 0, 0, 0, TrafficLightElement::RED),
-           make_bulb(2, 0, 0, 0, TrafficLightElement::GREEN),
-           make_bulb(3, 0, 0, 0, TrafficLightElement::AMBER),
-         });
+                     make_bulb(1, 0, 0, 0, TrafficLightElement::RED),
+                     make_bulb(2, 0, 0, 0, TrafficLightElement::GREEN),
+                     make_bulb(3, 0, 0, 0, TrafficLightElement::AMBER),
+                   });
   TrafficLightVisualizer visualizer{std::move(map_data)};
   auto detection = make_detection({make_group(test_group_id, {TrafficLightElement::RED})});
 
@@ -184,14 +201,14 @@ TEST(TrafficLightVisualizer, TwoGroupsBothMatchedProduceFourMarkers)
   BulbsByGroupId map_data;
   map_data.emplace(
     test_group_id, std::vector<Bulb>{
-           make_bulb(1, 0, 0, 0, TrafficLightElement::RED),
-           make_bulb(2, 0, 0, 0, TrafficLightElement::GREEN),
-         });
+                     make_bulb(1, 0, 0, 0, TrafficLightElement::RED),
+                     make_bulb(2, 0, 0, 0, TrafficLightElement::GREEN),
+                   });
   map_data.emplace(
     another_test_group_id, std::vector<Bulb>{
-           make_bulb(3, 0, 0, 0, TrafficLightElement::RED),
-           make_bulb(4, 0, 0, 0, TrafficLightElement::GREEN),
-         });
+                             make_bulb(3, 0, 0, 0, TrafficLightElement::RED),
+                             make_bulb(4, 0, 0, 0, TrafficLightElement::GREEN),
+                           });
   TrafficLightVisualizer visualizer{std::move(map_data)};
   auto detection = make_detection({
     make_group(test_group_id, {TrafficLightElement::RED, TrafficLightElement::GREEN}),
@@ -200,14 +217,16 @@ TEST(TrafficLightVisualizer, TwoGroupsBothMatchedProduceFourMarkers)
 
   auto markers = visualizer.generate_markers(detection, builtin_interfaces::msg::Time{});
 
-  EXPECT_EQ(markers.size(), 4u);
+  ASSERT_EQ(markers.size(), 4u);
+  EXPECT_EQ(collect_marker_ids(markers), (std::set<int32_t>{1, 2, 3, 4}));
 }
 
 TEST(TrafficLightVisualizer, EmptyDetectionProducesEmptyMarkers)
 {
   BulbsByGroupId map_data;
   map_data.emplace(
-    test_group_id, std::vector<Bulb>{make_bulb(arbitrary_bulb_id, 0, 0, 0, TrafficLightElement::RED)});
+    test_group_id,
+    std::vector<Bulb>{make_bulb(arbitrary_bulb_id, 0, 0, 0, TrafficLightElement::RED)});
   TrafficLightVisualizer visualizer{std::move(map_data)};
   auto detection = make_detection({});
 

--- a/perception/autoware_traffic_light_visualization/test/test_traffic_light_map_visualizer_core.cpp
+++ b/perception/autoware_traffic_light_visualization/test/test_traffic_light_map_visualizer_core.cpp
@@ -55,6 +55,12 @@ Bulb make_bulb(lanelet::Id id, double x, double y, double z, uint8_t color)
   return bulb;
 }
 
+// Overload for tests where the bulb's position is irrelevant.
+Bulb make_bulb(lanelet::Id id, uint8_t color)
+{
+  return make_bulb(id, 0.0, 0.0, 0.0, color);
+}
+
 TrafficLightGroup make_group(lanelet::Id group_id, const std::vector<uint8_t> & colors)
 {
   TrafficLightGroup group;
@@ -99,8 +105,7 @@ TEST(TrafficLightVisualizer, RedBulbDetectedProducesRedMarker)
 {
   BulbsByGroupId map_data;
   map_data.emplace(
-    test_group_id,
-    std::vector<Bulb>{make_bulb(arbitrary_bulb_id, 0, 0, 0, TrafficLightElement::RED)});
+    test_group_id, std::vector<Bulb>{make_bulb(arbitrary_bulb_id, TrafficLightElement::RED)});
   TrafficLightVisualizer visualizer{std::move(map_data)};
   auto detection = make_detection({make_group(test_group_id, {TrafficLightElement::RED})});
 
@@ -116,8 +121,7 @@ TEST(TrafficLightVisualizer, GreenBulbDetectedProducesGreenMarker)
 {
   BulbsByGroupId map_data;
   map_data.emplace(
-    test_group_id,
-    std::vector<Bulb>{make_bulb(arbitrary_bulb_id, 0, 0, 0, TrafficLightElement::GREEN)});
+    test_group_id, std::vector<Bulb>{make_bulb(arbitrary_bulb_id, TrafficLightElement::GREEN)});
   TrafficLightVisualizer visualizer{std::move(map_data)};
   auto detection = make_detection({make_group(test_group_id, {TrafficLightElement::GREEN})});
 
@@ -133,8 +137,7 @@ TEST(TrafficLightVisualizer, AmberBulbDetectedProducesYellowMarker)
 {
   BulbsByGroupId map_data;
   map_data.emplace(
-    test_group_id,
-    std::vector<Bulb>{make_bulb(arbitrary_bulb_id, 0, 0, 0, TrafficLightElement::AMBER)});
+    test_group_id, std::vector<Bulb>{make_bulb(arbitrary_bulb_id, TrafficLightElement::AMBER)});
   TrafficLightVisualizer visualizer{std::move(map_data)};
   auto detection = make_detection({make_group(test_group_id, {TrafficLightElement::AMBER})});
 
@@ -168,8 +171,7 @@ TEST(TrafficLightVisualizer, UnknownGroupIdProducesEmptyMarkers)
 {
   BulbsByGroupId map_data;
   map_data.emplace(
-    test_group_id,
-    std::vector<Bulb>{make_bulb(arbitrary_bulb_id, 0, 0, 0, TrafficLightElement::RED)});
+    test_group_id, std::vector<Bulb>{make_bulb(arbitrary_bulb_id, TrafficLightElement::RED)});
   TrafficLightVisualizer visualizer{std::move(map_data)};
   auto detection = make_detection({make_group(non_existent_group_id, {TrafficLightElement::RED})});
 
@@ -183,9 +185,9 @@ TEST(TrafficLightVisualizer, OnlyDetectedColorsAreShown)
   BulbsByGroupId map_data;
   map_data.emplace(
     test_group_id, std::vector<Bulb>{
-                     make_bulb(1, 0, 0, 0, TrafficLightElement::RED),
-                     make_bulb(2, 0, 0, 0, TrafficLightElement::GREEN),
-                     make_bulb(3, 0, 0, 0, TrafficLightElement::AMBER),
+                     make_bulb(1, TrafficLightElement::RED),
+                     make_bulb(2, TrafficLightElement::GREEN),
+                     make_bulb(3, TrafficLightElement::AMBER),
                    });
   TrafficLightVisualizer visualizer{std::move(map_data)};
   auto detection = make_detection({make_group(test_group_id, {TrafficLightElement::RED})});
@@ -201,13 +203,13 @@ TEST(TrafficLightVisualizer, TwoGroupsBothMatchedProduceFourMarkers)
   BulbsByGroupId map_data;
   map_data.emplace(
     test_group_id, std::vector<Bulb>{
-                     make_bulb(1, 0, 0, 0, TrafficLightElement::RED),
-                     make_bulb(2, 0, 0, 0, TrafficLightElement::GREEN),
+                     make_bulb(1, TrafficLightElement::RED),
+                     make_bulb(2, TrafficLightElement::GREEN),
                    });
   map_data.emplace(
     another_test_group_id, std::vector<Bulb>{
-                             make_bulb(3, 0, 0, 0, TrafficLightElement::RED),
-                             make_bulb(4, 0, 0, 0, TrafficLightElement::GREEN),
+                             make_bulb(3, TrafficLightElement::RED),
+                             make_bulb(4, TrafficLightElement::GREEN),
                            });
   TrafficLightVisualizer visualizer{std::move(map_data)};
   auto detection = make_detection({
@@ -225,8 +227,7 @@ TEST(TrafficLightVisualizer, EmptyDetectionProducesEmptyMarkers)
 {
   BulbsByGroupId map_data;
   map_data.emplace(
-    test_group_id,
-    std::vector<Bulb>{make_bulb(arbitrary_bulb_id, 0, 0, 0, TrafficLightElement::RED)});
+    test_group_id, std::vector<Bulb>{make_bulb(arbitrary_bulb_id, TrafficLightElement::RED)});
   TrafficLightVisualizer visualizer{std::move(map_data)};
   auto detection = make_detection({});
 

--- a/perception/autoware_traffic_light_visualization/test/test_traffic_light_map_visualizer_core.cpp
+++ b/perception/autoware_traffic_light_visualization/test/test_traffic_light_map_visualizer_core.cpp
@@ -172,24 +172,6 @@ TEST(TrafficLightVisualizer, AmberBulbDetectedProducesYellowMarker)
   EXPECT_FLOAT_EQ(markers[0].color.b, 0.0f);
 }
 
-TEST(TrafficLightVisualizer, MarkerInheritsBulbIdAndPosition)
-{
-  BulbsByGroupId map_data;
-  map_data.emplace(
-    test_group_id,
-    std::vector<Bulb>{make_bulb(arbitrary_bulb_id, 1.5, 2.5, 3.5, TrafficLightElement::RED)});
-  TrafficLightVisualizer visualizer{std::move(map_data)};
-  auto detection = make_detection({make_group(test_group_id, {TrafficLightElement::RED})});
-
-  auto markers = visualizer.generate_markers(detection, builtin_interfaces::msg::Time{});
-
-  ASSERT_EQ(markers.size(), 1u);
-  EXPECT_EQ(markers[0].id, arbitrary_bulb_id);
-  EXPECT_DOUBLE_EQ(markers[0].pose.position.x, 1.5);
-  EXPECT_DOUBLE_EQ(markers[0].pose.position.y, 2.5);
-  EXPECT_DOUBLE_EQ(markers[0].pose.position.z, 3.5);
-}
-
 TEST(TrafficLightVisualizer, UnknownGroupIdProducesEmptyMarkers)
 {
   BulbsByGroupId map_data;

--- a/perception/autoware_traffic_light_visualization/test/test_traffic_light_map_visualizer_core.cpp
+++ b/perception/autoware_traffic_light_visualization/test/test_traffic_light_map_visualizer_core.cpp
@@ -35,25 +35,15 @@ using autoware_perception_msgs::msg::TrafficLightElement;
 using autoware_perception_msgs::msg::TrafficLightGroup;
 using autoware_perception_msgs::msg::TrafficLightGroupArray;
 
-geometry_msgs::msg::Point make_point(double x, double y, double z)
-{
-  geometry_msgs::msg::Point p;
-  p.x = x;
-  p.y = y;
-  p.z = z;
-  return p;
-}
-
 Bulb make_bulb(lanelet::Id id, double x, double y, double z, uint8_t color)
 {
-  return Bulb{id, make_point(x, y, z), color};
-}
-
-TrafficLightElement make_element(uint8_t color)
-{
-  TrafficLightElement element;
-  element.color = color;
-  return element;
+  Bulb bulb;
+  bulb.id = id;
+  bulb.position.x = x;
+  bulb.position.y = y;
+  bulb.position.z = z;
+  bulb.color = color;
+  return bulb;
 }
 
 TrafficLightGroup make_group(lanelet::Id group_id, const std::vector<uint8_t> & colors)
@@ -61,7 +51,9 @@ TrafficLightGroup make_group(lanelet::Id group_id, const std::vector<uint8_t> & 
   TrafficLightGroup group;
   group.traffic_light_group_id = group_id;
   for (auto color : colors) {
-    group.elements.push_back(make_element(color));
+    TrafficLightElement element;
+    element.color = color;
+    group.elements.push_back(element);
   }
   return group;
 }

--- a/perception/autoware_traffic_light_visualization/test/test_traffic_light_map_visualizer_core.cpp
+++ b/perception/autoware_traffic_light_visualization/test/test_traffic_light_map_visualizer_core.cpp
@@ -130,6 +130,24 @@ TEST(TrafficLightVisualizer, AmberBulbDetectedProducesYellowMarker)
   EXPECT_FLOAT_EQ(markers[0].color.b, 0.0f);
 }
 
+TEST(TrafficLightVisualizer, MarkerInheritsBulbIdAndPosition)
+{
+  BulbsByGroupId map_data;
+  map_data.emplace(
+    test_group_id,
+    std::vector<Bulb>{make_bulb(arbitrary_bulb_id, 1.5, 2.5, 3.5, TrafficLightElement::RED)});
+  TrafficLightVisualizer visualizer{std::move(map_data)};
+  auto detection = make_detection({make_group(test_group_id, {TrafficLightElement::RED})});
+
+  auto markers = visualizer.generate_markers(detection, builtin_interfaces::msg::Time{});
+
+  ASSERT_EQ(markers.size(), 1u);
+  EXPECT_EQ(markers[0].id, arbitrary_bulb_id);
+  EXPECT_DOUBLE_EQ(markers[0].pose.position.x, 1.5);
+  EXPECT_DOUBLE_EQ(markers[0].pose.position.y, 2.5);
+  EXPECT_DOUBLE_EQ(markers[0].pose.position.z, 3.5);
+}
+
 TEST(TrafficLightVisualizer, UnknownGroupIdProducesEmptyMarkers)
 {
   BulbsByGroupId map_data;

--- a/perception/autoware_traffic_light_visualization/test/test_traffic_light_map_visualizer_core.cpp
+++ b/perception/autoware_traffic_light_visualization/test/test_traffic_light_map_visualizer_core.cpp
@@ -1,0 +1,201 @@
+// Copyright 2026 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "traffic_light_map_visualizer/traffic_light_visualizer.hpp"
+
+#include <autoware_perception_msgs/msg/traffic_light_element.hpp>
+#include <autoware_perception_msgs/msg/traffic_light_group.hpp>
+#include <autoware_perception_msgs/msg/traffic_light_group_array.hpp>
+#include <builtin_interfaces/msg/time.hpp>
+#include <geometry_msgs/msg/point.hpp>
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <utility>
+#include <vector>
+
+namespace
+{
+using autoware::traffic_light::Bulb;
+using autoware::traffic_light::BulbsByGroupId;
+using autoware::traffic_light::TrafficLightVisualizer;
+using autoware_perception_msgs::msg::TrafficLightElement;
+using autoware_perception_msgs::msg::TrafficLightGroup;
+using autoware_perception_msgs::msg::TrafficLightGroupArray;
+
+geometry_msgs::msg::Point make_point(double x, double y, double z)
+{
+  geometry_msgs::msg::Point p;
+  p.x = x;
+  p.y = y;
+  p.z = z;
+  return p;
+}
+
+Bulb make_bulb(lanelet::Id id, double x, double y, double z, uint8_t color)
+{
+  return Bulb{id, make_point(x, y, z), color};
+}
+
+TrafficLightElement make_element(uint8_t color)
+{
+  TrafficLightElement element;
+  element.color = color;
+  return element;
+}
+
+TrafficLightGroup make_group(lanelet::Id group_id, const std::vector<uint8_t> & colors)
+{
+  TrafficLightGroup group;
+  group.traffic_light_group_id = group_id;
+  for (auto color : colors) {
+    group.elements.push_back(make_element(color));
+  }
+  return group;
+}
+
+TrafficLightGroupArray make_detection(std::vector<TrafficLightGroup> groups)
+{
+  TrafficLightGroupArray array;
+  array.traffic_light_groups = std::move(groups);
+  return array;
+}
+
+}  // namespace
+
+TEST(TrafficLightVisualizer, EmptyBulbsProducesEmptyMarkers)
+{
+  TrafficLightVisualizer visualizer{BulbsByGroupId{}};
+  auto detection = make_detection({make_group(100, {TrafficLightElement::RED})});
+
+  auto markers = visualizer.generate_markers(detection, builtin_interfaces::msg::Time{});
+
+  EXPECT_TRUE(markers.empty());
+}
+
+TEST(TrafficLightVisualizer, RedBulbDetectedProducesRedMarker)
+{
+  BulbsByGroupId map_data;
+  map_data.emplace(
+    100, std::vector<Bulb>{make_bulb(42, 1.0, 2.0, 3.0, TrafficLightElement::RED)});
+  TrafficLightVisualizer visualizer{std::move(map_data)};
+  auto detection = make_detection({make_group(100, {TrafficLightElement::RED})});
+
+  auto markers = visualizer.generate_markers(detection, builtin_interfaces::msg::Time{});
+
+  ASSERT_EQ(markers.size(), 1u);
+  EXPECT_FLOAT_EQ(markers[0].color.r, 1.0f);
+  EXPECT_FLOAT_EQ(markers[0].color.g, 0.0f);
+  EXPECT_FLOAT_EQ(markers[0].color.b, 0.0f);
+}
+
+TEST(TrafficLightVisualizer, GreenBulbDetectedProducesGreenMarker)
+{
+  BulbsByGroupId map_data;
+  map_data.emplace(
+    100, std::vector<Bulb>{make_bulb(42, 1.0, 2.0, 3.0, TrafficLightElement::GREEN)});
+  TrafficLightVisualizer visualizer{std::move(map_data)};
+  auto detection = make_detection({make_group(100, {TrafficLightElement::GREEN})});
+
+  auto markers = visualizer.generate_markers(detection, builtin_interfaces::msg::Time{});
+
+  ASSERT_EQ(markers.size(), 1u);
+  EXPECT_FLOAT_EQ(markers[0].color.r, 0.0f);
+  EXPECT_FLOAT_EQ(markers[0].color.g, 1.0f);
+  EXPECT_FLOAT_EQ(markers[0].color.b, 0.0f);
+}
+
+TEST(TrafficLightVisualizer, AmberBulbDetectedProducesYellowMarker)
+{
+  BulbsByGroupId map_data;
+  map_data.emplace(
+    100, std::vector<Bulb>{make_bulb(42, 1.0, 2.0, 3.0, TrafficLightElement::AMBER)});
+  TrafficLightVisualizer visualizer{std::move(map_data)};
+  auto detection = make_detection({make_group(100, {TrafficLightElement::AMBER})});
+
+  auto markers = visualizer.generate_markers(detection, builtin_interfaces::msg::Time{});
+
+  ASSERT_EQ(markers.size(), 1u);
+  EXPECT_FLOAT_EQ(markers[0].color.r, 1.0f);
+  EXPECT_FLOAT_EQ(markers[0].color.g, 1.0f);
+  EXPECT_FLOAT_EQ(markers[0].color.b, 0.0f);
+}
+
+TEST(TrafficLightVisualizer, UnknownGroupIdProducesEmptyMarkers)
+{
+  BulbsByGroupId map_data;
+  map_data.emplace(
+    100, std::vector<Bulb>{make_bulb(42, 1.0, 2.0, 3.0, TrafficLightElement::RED)});
+  TrafficLightVisualizer visualizer{std::move(map_data)};
+  auto detection = make_detection({make_group(999, {TrafficLightElement::RED})});
+
+  auto markers = visualizer.generate_markers(detection, builtin_interfaces::msg::Time{});
+
+  EXPECT_TRUE(markers.empty());
+}
+
+TEST(TrafficLightVisualizer, OnlyDetectedColorsAreShown)
+{
+  BulbsByGroupId map_data;
+  map_data.emplace(
+    100, std::vector<Bulb>{
+           make_bulb(1, 1.0, 0.0, 0.0, TrafficLightElement::RED),
+           make_bulb(2, 2.0, 0.0, 0.0, TrafficLightElement::GREEN),
+           make_bulb(3, 3.0, 0.0, 0.0, TrafficLightElement::AMBER),
+         });
+  TrafficLightVisualizer visualizer{std::move(map_data)};
+  auto detection = make_detection({make_group(100, {TrafficLightElement::RED})});
+
+  auto markers = visualizer.generate_markers(detection, builtin_interfaces::msg::Time{});
+
+  ASSERT_EQ(markers.size(), 1u);
+  EXPECT_EQ(markers[0].id, 1);
+}
+
+TEST(TrafficLightVisualizer, TwoGroupsBothMatchedProduceFourMarkers)
+{
+  BulbsByGroupId map_data;
+  map_data.emplace(
+    100, std::vector<Bulb>{
+           make_bulb(1, 0, 0, 0, TrafficLightElement::RED),
+           make_bulb(2, 0, 0, 0, TrafficLightElement::GREEN),
+         });
+  map_data.emplace(
+    200, std::vector<Bulb>{
+           make_bulb(3, 0, 0, 0, TrafficLightElement::RED),
+           make_bulb(4, 0, 0, 0, TrafficLightElement::GREEN),
+         });
+  TrafficLightVisualizer visualizer{std::move(map_data)};
+  auto detection = make_detection({
+    make_group(100, {TrafficLightElement::RED, TrafficLightElement::GREEN}),
+    make_group(200, {TrafficLightElement::RED, TrafficLightElement::GREEN}),
+  });
+
+  auto markers = visualizer.generate_markers(detection, builtin_interfaces::msg::Time{});
+
+  EXPECT_EQ(markers.size(), 4u);
+}
+
+TEST(TrafficLightVisualizer, EmptyDetectionProducesEmptyMarkers)
+{
+  BulbsByGroupId map_data;
+  map_data.emplace(
+    100, std::vector<Bulb>{make_bulb(42, 1.0, 2.0, 3.0, TrafficLightElement::RED)});
+  TrafficLightVisualizer visualizer{std::move(map_data)};
+
+  auto markers = visualizer.generate_markers(make_detection({}), builtin_interfaces::msg::Time{});
+
+  EXPECT_TRUE(markers.empty());
+}

--- a/perception/autoware_traffic_light_visualization/test/test_traffic_light_map_visualizer_core.cpp
+++ b/perception/autoware_traffic_light_visualization/test/test_traffic_light_map_visualizer_core.cpp
@@ -85,7 +85,7 @@ TEST(TrafficLightVisualizer, RedBulbDetectedProducesRedMarker)
 {
   BulbsByGroupId map_data;
   map_data.emplace(
-    test_group_id, std::vector<Bulb>{make_bulb(42, 1.0, 2.0, 3.0, TrafficLightElement::RED)});
+    test_group_id, std::vector<Bulb>{make_bulb(42, 0, 0, 0, TrafficLightElement::RED)});
   TrafficLightVisualizer visualizer{std::move(map_data)};
   auto detection = make_detection({make_group(test_group_id, {TrafficLightElement::RED})});
 
@@ -101,7 +101,7 @@ TEST(TrafficLightVisualizer, GreenBulbDetectedProducesGreenMarker)
 {
   BulbsByGroupId map_data;
   map_data.emplace(
-    test_group_id, std::vector<Bulb>{make_bulb(42, 1.0, 2.0, 3.0, TrafficLightElement::GREEN)});
+    test_group_id, std::vector<Bulb>{make_bulb(42, 0, 0, 0, TrafficLightElement::GREEN)});
   TrafficLightVisualizer visualizer{std::move(map_data)};
   auto detection = make_detection({make_group(test_group_id, {TrafficLightElement::GREEN})});
 
@@ -117,7 +117,7 @@ TEST(TrafficLightVisualizer, AmberBulbDetectedProducesYellowMarker)
 {
   BulbsByGroupId map_data;
   map_data.emplace(
-    test_group_id, std::vector<Bulb>{make_bulb(42, 1.0, 2.0, 3.0, TrafficLightElement::AMBER)});
+    test_group_id, std::vector<Bulb>{make_bulb(42, 0, 0, 0, TrafficLightElement::AMBER)});
   TrafficLightVisualizer visualizer{std::move(map_data)};
   auto detection = make_detection({make_group(test_group_id, {TrafficLightElement::AMBER})});
 
@@ -133,7 +133,7 @@ TEST(TrafficLightVisualizer, UnknownGroupIdProducesEmptyMarkers)
 {
   BulbsByGroupId map_data;
   map_data.emplace(
-    test_group_id, std::vector<Bulb>{make_bulb(42, 1.0, 2.0, 3.0, TrafficLightElement::RED)});
+    test_group_id, std::vector<Bulb>{make_bulb(42, 0, 0, 0, TrafficLightElement::RED)});
   TrafficLightVisualizer visualizer{std::move(map_data)};
   auto detection = make_detection({make_group(non_existent_group_id, {TrafficLightElement::RED})});
 
@@ -147,9 +147,9 @@ TEST(TrafficLightVisualizer, OnlyDetectedColorsAreShown)
   BulbsByGroupId map_data;
   map_data.emplace(
     test_group_id, std::vector<Bulb>{
-           make_bulb(1, 1.0, 0.0, 0.0, TrafficLightElement::RED),
-           make_bulb(2, 2.0, 0.0, 0.0, TrafficLightElement::GREEN),
-           make_bulb(3, 3.0, 0.0, 0.0, TrafficLightElement::AMBER),
+           make_bulb(1, 0, 0, 0, TrafficLightElement::RED),
+           make_bulb(2, 0, 0, 0, TrafficLightElement::GREEN),
+           make_bulb(3, 0, 0, 0, TrafficLightElement::AMBER),
          });
   TrafficLightVisualizer visualizer{std::move(map_data)};
   auto detection = make_detection({make_group(test_group_id, {TrafficLightElement::RED})});
@@ -188,7 +188,7 @@ TEST(TrafficLightVisualizer, EmptyDetectionProducesEmptyMarkers)
 {
   BulbsByGroupId map_data;
   map_data.emplace(
-    test_group_id, std::vector<Bulb>{make_bulb(42, 1.0, 2.0, 3.0, TrafficLightElement::RED)});
+    test_group_id, std::vector<Bulb>{make_bulb(42, 0, 0, 0, TrafficLightElement::RED)});
   TrafficLightVisualizer visualizer{std::move(map_data)};
   auto detection = make_detection({});
 

--- a/perception/autoware_traffic_light_visualization/test/test_traffic_light_map_visualizer_core.cpp
+++ b/perception/autoware_traffic_light_visualization/test/test_traffic_light_map_visualizer_core.cpp
@@ -25,6 +25,7 @@
 #include <gtest/gtest.h>
 
 #include <cstdint>
+#include <map>
 #include <set>
 #include <utility>
 #include <vector>
@@ -87,6 +88,15 @@ std::set<int32_t> collect_marker_ids(const std::vector<Marker> & markers)
     ids.insert(m.id);
   }
   return ids;
+}
+
+std::map<int32_t, const Marker *> index_markers_by_id(const std::vector<Marker> & markers)
+{
+  std::map<int32_t, const Marker *> by_id;
+  for (const auto & m : markers) {
+    by_id[m.id] = &m;
+  }
+  return by_id;
 }
 
 }  // namespace
@@ -203,13 +213,13 @@ TEST(TrafficLightVisualizer, TwoGroupsBothMatchedProduceFourMarkers)
   BulbsByGroupId map_data;
   map_data.emplace(
     test_group_id, std::vector<Bulb>{
-                     make_bulb(1, TrafficLightElement::RED),
-                     make_bulb(2, TrafficLightElement::GREEN),
+                     make_bulb(1, 1.0, 0.0, 0.0, TrafficLightElement::RED),
+                     make_bulb(2, 2.0, 0.0, 0.0, TrafficLightElement::GREEN),
                    });
   map_data.emplace(
     another_test_group_id, std::vector<Bulb>{
-                             make_bulb(3, TrafficLightElement::RED),
-                             make_bulb(4, TrafficLightElement::GREEN),
+                             make_bulb(3, 3.0, 0.0, 0.0, TrafficLightElement::RED),
+                             make_bulb(4, 4.0, 0.0, 0.0, TrafficLightElement::GREEN),
                            });
   TrafficLightVisualizer visualizer{std::move(map_data)};
   auto detection = make_detection({
@@ -221,6 +231,14 @@ TEST(TrafficLightVisualizer, TwoGroupsBothMatchedProduceFourMarkers)
 
   ASSERT_EQ(markers.size(), 4u);
   EXPECT_EQ(collect_marker_ids(markers), (std::set<int32_t>{1, 2, 3, 4}));
+
+  // Each marker carries its own bulb's position (guards against e.g. copying
+  // bulbs[0].position to all markers).
+  const auto by_id = index_markers_by_id(markers);
+  EXPECT_DOUBLE_EQ(by_id.at(1)->pose.position.x, 1.0);
+  EXPECT_DOUBLE_EQ(by_id.at(2)->pose.position.x, 2.0);
+  EXPECT_DOUBLE_EQ(by_id.at(3)->pose.position.x, 3.0);
+  EXPECT_DOUBLE_EQ(by_id.at(4)->pose.position.x, 4.0);
 }
 
 TEST(TrafficLightVisualizer, EmptyDetectionProducesEmptyMarkers)
@@ -234,4 +252,59 @@ TEST(TrafficLightVisualizer, EmptyDetectionProducesEmptyMarkers)
   auto markers = visualizer.generate_markers(detection, builtin_interfaces::msg::Time{});
 
   EXPECT_TRUE(markers.empty());
+}
+
+TEST(TrafficLightVisualizer, DetectionColorWithoutMapBulbIsIgnored)
+{
+  BulbsByGroupId map_data;
+  map_data.emplace(
+    test_group_id, std::vector<Bulb>{make_bulb(arbitrary_bulb_id, TrafficLightElement::RED)});
+  TrafficLightVisualizer visualizer{std::move(map_data)};
+  // detection contains colors not represented in the map (GREEN, UNKNOWN);
+  // only RED has a corresponding bulb and should produce a marker.
+  auto detection = make_detection({make_group(
+    test_group_id,
+    {TrafficLightElement::RED, TrafficLightElement::GREEN, TrafficLightElement::UNKNOWN})});
+
+  auto markers = visualizer.generate_markers(detection, builtin_interfaces::msg::Time{});
+
+  ASSERT_EQ(markers.size(), 1u);
+  EXPECT_EQ(markers[0].id, arbitrary_bulb_id);
+}
+
+TEST(TrafficLightVisualizer, KnownAndUnknownGroupMixOnlyKnownProducesMarkers)
+{
+  BulbsByGroupId map_data;
+  map_data.emplace(
+    test_group_id, std::vector<Bulb>{make_bulb(arbitrary_bulb_id, TrafficLightElement::RED)});
+  TrafficLightVisualizer visualizer{std::move(map_data)};
+  auto detection = make_detection({
+    make_group(test_group_id, {TrafficLightElement::RED}),
+    make_group(non_existent_group_id, {TrafficLightElement::RED}),
+  });
+
+  auto markers = visualizer.generate_markers(detection, builtin_interfaces::msg::Time{});
+
+  ASSERT_EQ(markers.size(), 1u);
+  EXPECT_EQ(markers[0].id, arbitrary_bulb_id);
+}
+
+TEST(TrafficLightVisualizer, MarkerHeaderCarriesStampAndMapFrame)
+{
+  BulbsByGroupId map_data;
+  map_data.emplace(
+    test_group_id, std::vector<Bulb>{make_bulb(arbitrary_bulb_id, TrafficLightElement::RED)});
+  TrafficLightVisualizer visualizer{std::move(map_data)};
+  auto detection = make_detection({make_group(test_group_id, {TrafficLightElement::RED})});
+
+  builtin_interfaces::msg::Time stamp;
+  stamp.sec = 42;
+  stamp.nanosec = 123456789;
+
+  auto markers = visualizer.generate_markers(detection, stamp);
+
+  ASSERT_EQ(markers.size(), 1u);
+  EXPECT_EQ(markers[0].header.frame_id, "map");
+  EXPECT_EQ(markers[0].header.stamp.sec, 42);
+  EXPECT_EQ(markers[0].header.stamp.nanosec, 123456789u);
 }

--- a/perception/autoware_traffic_light_visualization/test/test_traffic_light_map_visualizer_core.cpp
+++ b/perception/autoware_traffic_light_visualization/test/test_traffic_light_map_visualizer_core.cpp
@@ -135,7 +135,7 @@ TEST(TrafficLightVisualizer, UnknownGroupIdProducesEmptyMarkers)
   map_data.emplace(
     test_group_id, std::vector<Bulb>{make_bulb(42, 1.0, 2.0, 3.0, TrafficLightElement::RED)});
   TrafficLightVisualizer visualizer{std::move(map_data)};
-  auto detection = make_detection({make_group(999, {TrafficLightElement::RED})});
+  auto detection = make_detection({make_group(non_existent_group_id, {TrafficLightElement::RED})});
 
   auto markers = visualizer.generate_markers(detection, builtin_interfaces::msg::Time{});
 

--- a/perception/autoware_traffic_light_visualization/test/test_traffic_light_map_visualizer_core.cpp
+++ b/perception/autoware_traffic_light_visualization/test/test_traffic_light_map_visualizer_core.cpp
@@ -288,23 +288,3 @@ TEST(TrafficLightVisualizer, KnownAndUnknownGroupMixOnlyKnownProducesMarkers)
   ASSERT_EQ(markers.size(), 1u);
   EXPECT_EQ(markers[0].id, arbitrary_bulb_id);
 }
-
-TEST(TrafficLightVisualizer, MarkerHeaderCarriesStampAndMapFrame)
-{
-  BulbsByGroupId map_data;
-  map_data.emplace(
-    test_group_id, std::vector<Bulb>{make_bulb(arbitrary_bulb_id, TrafficLightElement::RED)});
-  TrafficLightVisualizer visualizer{std::move(map_data)};
-  auto detection = make_detection({make_group(test_group_id, {TrafficLightElement::RED})});
-
-  builtin_interfaces::msg::Time stamp;
-  stamp.sec = 42;
-  stamp.nanosec = 123456789;
-
-  auto markers = visualizer.generate_markers(detection, stamp);
-
-  ASSERT_EQ(markers.size(), 1u);
-  EXPECT_EQ(markers[0].header.frame_id, "map");
-  EXPECT_EQ(markers[0].header.stamp.sec, 42);
-  EXPECT_EQ(markers[0].header.stamp.nanosec, 123456789u);
-}

--- a/perception/autoware_traffic_light_visualization/test/test_traffic_light_map_visualizer_core.cpp
+++ b/perception/autoware_traffic_light_visualization/test/test_traffic_light_map_visualizer_core.cpp
@@ -81,24 +81,6 @@ TrafficLightGroupArray make_detection(std::vector<TrafficLightGroup> groups)
   return array;
 }
 
-std::set<int32_t> collect_marker_ids(const std::vector<Marker> & markers)
-{
-  std::set<int32_t> ids;
-  for (const auto & m : markers) {
-    ids.insert(m.id);
-  }
-  return ids;
-}
-
-std::map<int32_t, const Marker *> index_markers_by_id(const std::vector<Marker> & markers)
-{
-  std::map<int32_t, const Marker *> by_id;
-  for (const auto & m : markers) {
-    by_id[m.id] = &m;
-  }
-  return by_id;
-}
-
 }  // namespace
 
 TEST(TrafficLightVisualizer, EmptyBulbsProducesEmptyMarkers)
@@ -240,6 +222,9 @@ TEST(TrafficLightVisualizer, DetectionColorWithoutMapBulbIsIgnored)
 
 TEST(TrafficLightVisualizer, TwoGroupsBothMatchedProduceFourMarkers)
 {
+  // Setup convention: bulb id N is placed at x = N.0. The id-to-x correlation
+  // makes the position assertions below readable and guards against position
+  // aliasing (e.g. copying bulbs[0].position to all markers).
   BulbsByGroupId map_data;
   map_data.emplace(
     test_group_id, std::vector<Bulb>{
@@ -260,13 +245,16 @@ TEST(TrafficLightVisualizer, TwoGroupsBothMatchedProduceFourMarkers)
   auto markers = visualizer.generate_markers(detection, builtin_interfaces::msg::Time{});
 
   ASSERT_EQ(markers.size(), 4u);
-  EXPECT_EQ(collect_marker_ids(markers), (std::set<int32_t>{1, 2, 3, 4}));
 
-  // Each marker carries its own bulb's position (guards against e.g. copying
-  // bulbs[0].position to all markers).
-  const auto by_id = index_markers_by_id(markers);
-  EXPECT_DOUBLE_EQ(by_id.at(1)->pose.position.x, 1.0);
-  EXPECT_DOUBLE_EQ(by_id.at(2)->pose.position.x, 2.0);
-  EXPECT_DOUBLE_EQ(by_id.at(3)->pose.position.x, 3.0);
-  EXPECT_DOUBLE_EQ(by_id.at(4)->pose.position.x, 4.0);
+  std::set<int32_t> marker_ids;
+  std::map<int32_t, const Marker *> markers_by_bulb_id;
+  for (const auto & marker : markers) {
+    marker_ids.insert(marker.id);
+    markers_by_bulb_id[marker.id] = &marker;
+  }
+  EXPECT_EQ(marker_ids, (std::set<int32_t>{1, 2, 3, 4}));
+  EXPECT_DOUBLE_EQ(markers_by_bulb_id.at(1)->pose.position.x, 1.0);
+  EXPECT_DOUBLE_EQ(markers_by_bulb_id.at(2)->pose.position.x, 2.0);
+  EXPECT_DOUBLE_EQ(markers_by_bulb_id.at(3)->pose.position.x, 3.0);
+  EXPECT_DOUBLE_EQ(markers_by_bulb_id.at(4)->pose.position.x, 4.0);
 }


### PR DESCRIPTION
## Description

Add unit tests for `TrafficLightVisualizer::generate_markers` covering the pure logic layer introduced in #12553. The tests verify marker generation directly against the `BulbsByGroupId` interface without going through the ROS node, complementing the end-to-end characterization test from #12487.

10 test cases covering:
- empty input (empty bulbs / empty detection)
- RED / GREEN / AMBER bulb detected → corresponding colored marker
- unknown group ID → empty markers
- mixed known and unknown groups → only known produces markers
- detection contains only one of multiple bulb colors → only that bulb is shown
- detection contains a color without a corresponding map bulb → ignored
- two groups both matched → four markers with correct per-bulb positions (guards against position aliasing)

## Related links

**Parent Issue:**

- None (follow-up to #12553, which introduced the `Bulb` struct and decoupled `TrafficLightVisualizer` from lanelet types)

## How was this PR tested?

```bash
colcon build --packages-select autoware_traffic_light_visualization \
  --cmake-args -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=ON
colcon test --packages-select autoware_traffic_light_visualization \
  --event-handlers console_direct+
```

All 10 new unit tests pass, plus the existing 5 characterization tests continue to pass.

## Notes for reviewers

This PR is the third of a planned sequence to incrementally refactor `traffic_light_map_visualizer`:
- #12487 (MERGED): characterization test as the safety net
- #12511 (MERGED): extract `TrafficLightVisualizer` class
- #12553 (MERGED): introduce `Bulb` struct, decouple from lanelet
- **This PR**: unit tests for `TrafficLightVisualizer::generate_markers`
- Follow-ups: unit tests for `extract_bulbs`, a Node-level smoke test, and test layout reorganization

The new test file is placed at `test/test_traffic_light_map_visualizer_core.cpp` next to the existing characterization test. A follow-up PR will reorganize the test directory layout to mirror `src/`.

## Interface changes

None.

## Effects on system behavior

None (test-only change).