### PR TITLE
fix(clang-tidy): fix unchecked optional access in imu corrector

### DIFF
--- a/sensing/autoware_imu_corrector/src/gyro_bias_estimator.cpp
+++ b/sensing/autoware_imu_corrector/src/gyro_bias_estimator.cpp
@@ -720,13 +720,18 @@ void GyroBiasEstimator::timer_callback()
 
 void GyroBiasEstimator::validate_gyro_bias()
 {
+  if (!gyro_bias_) {
+    return;
+  }
+  const auto & gyro_bias = *gyro_bias_;
+
   // Calculate diagnostics key-values
-  diagnostics_info_.gyro_bias_x_for_imu_corrector = gyro_bias_.value().x;
-  diagnostics_info_.gyro_bias_y_for_imu_corrector = gyro_bias_.value().y;
-  diagnostics_info_.gyro_bias_z_for_imu_corrector = gyro_bias_.value().z;
-  diagnostics_info_.estimated_gyro_bias_x = gyro_bias_.value().x - angular_velocity_offset_x_;
-  diagnostics_info_.estimated_gyro_bias_y = gyro_bias_.value().y - angular_velocity_offset_y_;
-  diagnostics_info_.estimated_gyro_bias_z = gyro_bias_.value().z - angular_velocity_offset_z_;
+  diagnostics_info_.gyro_bias_x_for_imu_corrector = gyro_bias.x;
+  diagnostics_info_.gyro_bias_y_for_imu_corrector = gyro_bias.y;
+  diagnostics_info_.gyro_bias_z_for_imu_corrector = gyro_bias.z;
+  diagnostics_info_.estimated_gyro_bias_x = gyro_bias.x - angular_velocity_offset_x_;
+  diagnostics_info_.estimated_gyro_bias_y = gyro_bias.y - angular_velocity_offset_y_;
+  diagnostics_info_.estimated_gyro_bias_z = gyro_bias.z - angular_velocity_offset_z_;
 
   // Validation
   const bool is_bias_small_enough =
@@ -793,8 +798,8 @@ void GyroBiasEstimator::update_diagnostics(diagnostic_updater::DiagnosticStatusW
   stat.add("min_allowed_scale", (min_allowed_scale_));
   stat.add("max_allowed_scale", (max_allowed_scale_));
 
-  if (gyro_bias_.has_value()) {
-    stat.add("gyro_yaw_rate_", f(gyro_yaw_rate_ - gyro_bias_not_rotated_.value().z));
+  if (gyro_bias_ && gyro_bias_not_rotated_) {
+    stat.add("gyro_yaw_rate_", f(gyro_yaw_rate_ - gyro_bias_not_rotated_->z));
     stat.add("ndt_yaw_rate_", f(ndt_yaw_rate_));
   }
 


### PR DESCRIPTION
## Description

Fixes `bugprone-unchecked-optional-access` warnings in `autoware_imu_corrector`.

This PR is a partial fix for #12450.

## Fixes

### `autoware_imu_corrector`

This PR fixes unchecked optional access in `gyro_bias_estimator.cpp`.

The code previously accessed optional gyro bias values directly using `.value()`:

```cpp
gyro_bias_.value()
gyro_bias_not_rotated_.value()
```

This PR replaces those direct optional accesses with explicit checks and safe dereferencing.

Affected file:

- `sensing/autoware_imu_corrector/src/gyro_bias_estimator.cpp`

## Verification

```bash
pre-commit run clang-format --files \
  sensing/autoware_imu_corrector/src/gyro_bias_estimator.cpp
```

Result:

```text
clang-format.............................................................Passed
```

```bash
colcon build --packages-up-to autoware_imu_corrector \
  --cmake-args -DCMAKE_EXPORT_COMPILE_COMMANDS=1
```

Result:

```text
Summary: 24 packages finished
```

```bash
run-clang-tidy -p build/ \
  -config="$(cat /tmp/unchecked_optional_only.yaml)" \
  -j $(nproc) \
  autoware_imu_corrector \
  > /tmp/clang-tidy-result/unchecked_optional_imu_corrector_after.log 2>&1 || true

grep -n "bugprone-unchecked-optional-access" \
  /tmp/clang-tidy-result/unchecked_optional_imu_corrector_after.log | grep "error:" \
  || echo "0 unchecked optional access errors"
```

Result:

```text
0 unchecked optional access errors
```

## Notes for reviewers

No `NOLINT` suppression was added. This PR fixes the warnings by checking optionals before dereferencing.

## Interface changes

None.

## Effects on system behavior

None intended.

Refs #12450