### PR TITLE
feat(control_evaluator): add lateral deviation between ego and centerline

### DIFF
--- a/evaluator/autoware_control_evaluator/include/autoware/control_evaluator/control_evaluator_node.hpp
+++ b/evaluator/autoware_control_evaluator/include/autoware/control_evaluator/control_evaluator_node.hpp
@@ -82,6 +82,7 @@ public:
     const Metric & metric, const double & metric_value, const bool & accumulate_metric = true);
   void AddLateralDeviationMetricMsg(const Trajectory & traj, const Point & ego_point);
   void AddYawDeviationMetricMsg(const Trajectory & traj, const Pose & ego_pose);
+  void AddLateralDeviationCenterlineMetricMsg(const Pose & ego_pose);
   void AddGoalDeviationMetricMsg(const Odometry & odom);
   void AddObjectMetricMsg(const Odometry & odom, const PredictedObjects & objects);
   void AddBoundaryDistanceMetricMsg(const PathWithLaneId & behavior_path, const Pose & ego_pose);
@@ -140,6 +141,7 @@ private:
     Metric::jerk,
     Metric::lateral_deviation,
     Metric::lateral_deviation_abs,
+    Metric::lateral_deviation_centerline,
     Metric::yaw_deviation,
     Metric::yaw_deviation_abs,
     Metric::goal_longitudinal_deviation,

--- a/evaluator/autoware_control_evaluator/include/autoware/control_evaluator/control_evaluator_node.hpp
+++ b/evaluator/autoware_control_evaluator/include/autoware/control_evaluator/control_evaluator_node.hpp
@@ -142,6 +142,7 @@ private:
     Metric::lateral_deviation,
     Metric::lateral_deviation_abs,
     Metric::lateral_deviation_centerline,
+    Metric::lateral_deviation_centerline_abs,
     Metric::yaw_deviation,
     Metric::yaw_deviation_abs,
     Metric::goal_longitudinal_deviation,

--- a/evaluator/autoware_control_evaluator/include/autoware/control_evaluator/metrics/metric.hpp
+++ b/evaluator/autoware_control_evaluator/include/autoware/control_evaluator/metrics/metric.hpp
@@ -138,8 +138,7 @@ static const std::unordered_map<Metric, std::string> metric_descriptions = {
   {Metric::lateral_deviation_centerline,
    "Lateral deviation from the centerline[m], positive value means the ego is on the left side of "
    "the centerline"},
-  {Metric::lateral_deviation_centerline_abs,
-   "Absolute lateral deviation from the centerline[m]"},
+  {Metric::lateral_deviation_centerline_abs, "Absolute lateral deviation from the centerline[m]"},
   {Metric::yaw_deviation,
    "Yaw deviation from the reference trajectory[rad], positive value means the ego is "
    "counterclockwise from the reference trajectory"},

--- a/evaluator/autoware_control_evaluator/include/autoware/control_evaluator/metrics/metric.hpp
+++ b/evaluator/autoware_control_evaluator/include/autoware/control_evaluator/metrics/metric.hpp
@@ -32,6 +32,7 @@ enum class Metric {
   jerk,
   lateral_deviation,
   lateral_deviation_abs,
+  lateral_deviation_centerline,
   yaw_deviation,
   yaw_deviation_abs,
   goal_longitudinal_deviation,
@@ -64,6 +65,7 @@ static const std::unordered_map<std::string, Metric> str_to_metric = {
   {"jerk", Metric::jerk},
   {"lateral_deviation", Metric::lateral_deviation},
   {"lateral_deviation_abs", Metric::lateral_deviation_abs},
+  {"lateral_deviation_centerline", Metric::lateral_deviation_centerline},
   {"yaw_deviation", Metric::yaw_deviation},
   {"yaw_deviation_abs", Metric::yaw_deviation_abs},
   {"goal_longitudinal_deviation", Metric::goal_longitudinal_deviation},
@@ -95,6 +97,7 @@ static const std::unordered_map<Metric, std::string> metric_to_str = {
   {Metric::jerk, "jerk"},
   {Metric::lateral_deviation, "lateral_deviation"},
   {Metric::lateral_deviation_abs, "lateral_deviation_abs"},
+  {Metric::lateral_deviation_centerline, "lateral_deviation_centerline"},
   {Metric::yaw_deviation, "yaw_deviation"},
   {Metric::yaw_deviation_abs, "yaw_deviation_abs"},
   {Metric::goal_longitudinal_deviation, "goal_longitudinal_deviation"},
@@ -129,6 +132,9 @@ static const std::unordered_map<Metric, std::string> metric_descriptions = {
    "Lateral deviation from the reference trajectory[m], positive value means the ego is on the "
    "left side of the reference trajectory"},
   {Metric::lateral_deviation_abs, "Absolute lateral deviation from the reference trajectory[m]"},
+  {Metric::lateral_deviation_centerline,
+   "Lateral deviation from the centerline[m], positive value means the ego is on the left side of "
+   "the centerline"},
   {Metric::yaw_deviation,
    "Yaw deviation from the reference trajectory[rad], positive value means the ego is "
    "counterclockwise from the reference trajectory"},

--- a/evaluator/autoware_control_evaluator/include/autoware/control_evaluator/metrics/metric.hpp
+++ b/evaluator/autoware_control_evaluator/include/autoware/control_evaluator/metrics/metric.hpp
@@ -33,6 +33,7 @@ enum class Metric {
   lateral_deviation,
   lateral_deviation_abs,
   lateral_deviation_centerline,
+  lateral_deviation_centerline_abs,
   yaw_deviation,
   yaw_deviation_abs,
   goal_longitudinal_deviation,
@@ -66,6 +67,7 @@ static const std::unordered_map<std::string, Metric> str_to_metric = {
   {"lateral_deviation", Metric::lateral_deviation},
   {"lateral_deviation_abs", Metric::lateral_deviation_abs},
   {"lateral_deviation_centerline", Metric::lateral_deviation_centerline},
+  {"lateral_deviation_centerline_abs", Metric::lateral_deviation_centerline_abs},
   {"yaw_deviation", Metric::yaw_deviation},
   {"yaw_deviation_abs", Metric::yaw_deviation_abs},
   {"goal_longitudinal_deviation", Metric::goal_longitudinal_deviation},
@@ -98,6 +100,7 @@ static const std::unordered_map<Metric, std::string> metric_to_str = {
   {Metric::lateral_deviation, "lateral_deviation"},
   {Metric::lateral_deviation_abs, "lateral_deviation_abs"},
   {Metric::lateral_deviation_centerline, "lateral_deviation_centerline"},
+  {Metric::lateral_deviation_centerline_abs, "lateral_deviation_centerline_abs"},
   {Metric::yaw_deviation, "yaw_deviation"},
   {Metric::yaw_deviation_abs, "yaw_deviation_abs"},
   {Metric::goal_longitudinal_deviation, "goal_longitudinal_deviation"},
@@ -135,6 +138,8 @@ static const std::unordered_map<Metric, std::string> metric_descriptions = {
   {Metric::lateral_deviation_centerline,
    "Lateral deviation from the centerline[m], positive value means the ego is on the left side of "
    "the centerline"},
+  {Metric::lateral_deviation_centerline_abs,
+   "Absolute lateral deviation from the centerline[m]"},
   {Metric::yaw_deviation,
    "Yaw deviation from the reference trajectory[rad], positive value means the ego is "
    "counterclockwise from the reference trajectory"},

--- a/evaluator/autoware_control_evaluator/src/control_evaluator_node.cpp
+++ b/evaluator/autoware_control_evaluator/src/control_evaluator_node.cpp
@@ -459,6 +459,15 @@ void ControlEvaluatorNode::AddYawDeviationMetricMsg(const Trajectory & traj, con
   AddMetricMsg(Metric::yaw_deviation_abs, metric_value_abs);
 }
 
+void ControlEvaluatorNode::AddLateralDeviationCenterlineMetricMsg(const Pose & ego_pose)
+{
+  const auto current_lanelets = metrics::utils::get_current_lanes(route_handler_, ego_pose);
+  const auto arc_coordinates =
+    autoware::experimental::lanelet2_utils::get_arc_coordinates(current_lanelets, ego_pose);
+  const auto metric_value = arc_coordinates.distance;
+  AddMetricMsg(Metric::lateral_deviation_centerline, metric_value);
+}
+
 void ControlEvaluatorNode::AddGoalDeviationMetricMsg(const Odometry & odom)
 {
   const Pose ego_pose = odom.pose.pose;
@@ -637,6 +646,7 @@ void ControlEvaluatorNode::onTimer()
     if (route_handler_.isHandlerReady()) {
       // add goal deviation metrics
       AddLaneletInfoMsg(ego_pose);
+      AddLateralDeviationCenterlineMetricMsg(ego_pose);
       AddGoalDeviationMetricMsg(*odom);
 
       // add boundary distance metrics

--- a/evaluator/autoware_control_evaluator/src/control_evaluator_node.cpp
+++ b/evaluator/autoware_control_evaluator/src/control_evaluator_node.cpp
@@ -464,8 +464,11 @@ void ControlEvaluatorNode::AddLateralDeviationCenterlineMetricMsg(const Pose & e
   const auto current_lanelets = metrics::utils::get_current_lanes(route_handler_, ego_pose);
   const auto arc_coordinates =
     autoware::experimental::lanelet2_utils::get_arc_coordinates(current_lanelets, ego_pose);
-  const auto metric_value = arc_coordinates.distance;
+  const double metric_value = arc_coordinates.distance;
+  const double metric_value_abs = std::abs(metric_value);
+
   AddMetricMsg(Metric::lateral_deviation_centerline, metric_value);
+  AddMetricMsg(Metric::lateral_deviation_centerline_abs, metric_value_abs);
 }
 
 void ControlEvaluatorNode::AddGoalDeviationMetricMsg(const Odometry & odom)


### PR DESCRIPTION
## Description

I added lateral deviation between EGO and Centerline to  control_evaluator.

- LEFT side offset : Positive
- RIGHT side offset : Negative

### Metrics Name

- `lateral_deviaton_centerline`
- `lateral_deviation_centerline_abs`

## Related links

- [TIER IV Internal link](https://star4.slack.com/archives/C05PZ7MF3H6/p1779092685389079?thread_ts=1778570528.740889&cid=C05PZ7MF3H6)

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

### Evaluator Test

[[Kazunori-Nakajima][Lexus][MustPassOnly] PR 12598 check](https://evaluation.tier4.jp/evaluation/reports/e3f28f48-3f9d-5896-b5c2-dcf6f13cea06?project_id=autoware_dev)

- Build Check: OK :heavy_check_mark: 
- Simple Tests: ALL PASS :heavy_check_mark: 

[Archive Check](https://evaluation.tier4.jp/evaluation/reports/e3f28f48-3f9d-5896-b5c2-dcf6f13cea06/tests/f71ac002-fce3-5d2b-abf2-95bbd9d2dda0/729e09e5-08ff-5b4d-a2d8-ff957b7e5b45/8c5f7dfe-6b3d-536b-96e3-453ad999672a?project_id=autoware_dev): OK :heavy_check_mark: 

<img width="1777" height="115" alt="image" src="https://github.com/user-attachments/assets/173407c2-29e0-4933-85bf-6d8107e12040" />


### Local test

https://github.com/user-attachments/assets/12af629f-18c3-4a8b-b26d-31aae7b385e5

- LEFT side offset : Positive
<img width="2275" height="1359" alt="image" src="https://github.com/user-attachments/assets/2cd163ab-c056-4809-9847-925342d6e833" />

- RIGHT side offset : Negative
<img width="2108" height="1400" alt="image" src="https://github.com/user-attachments/assets/b420b61e-1721-4f14-bcf6-444ed641a54b" />

- ABS
<img width="3833" height="2140" alt="image (8)" src="https://github.com/user-attachments/assets/d6748ffa-6033-4748-88fc-e1fa3a6b9fa3" />


## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
