### PR TITLE
fix(diffusion_planner): add `vehicle_info_param_path` to fix `build_only`

### DIFF
--- a/planning/autoware_diffusion_planner/launch/diffusion_planner.launch.xml
+++ b/planning/autoware_diffusion_planner/launch/diffusion_planner.launch.xml
@@ -2,6 +2,7 @@
 <launch>
   <arg name="diffusion_planner_param_path" default="$(find-pkg-share autoware_diffusion_planner)/config/diffusion_planner.param.yaml"/>
   <arg name="data_path" default="$(env HOME)/autoware_data/ml_models/diffusion_planner" description="diffusion planner artifacts (onnx model, args json) directory"/>
+  <arg name="vehicle_info_param_path" default="$(find-pkg-share autoware_vehicle_info_utils)/config/vehicle_info.param.yaml"/>
   <arg name="output_trajectory" default="~/output/trajectory"/>
   <arg name="output_trajectories" default="~/output/trajectories"/>
   <arg name="output_predicted_objects" default="~/output/predicted_objects"/>
@@ -18,6 +19,7 @@
 
   <node pkg="autoware_diffusion_planner" exec="autoware_diffusion_planner_node" name="diffusion_planner_node" output="both">
     <param from="$(var diffusion_planner_param_path)" allow_substs="true"/>
+    <param from="$(var vehicle_info_param_path)" allow_substs="true"/>
     <remap from="~/output/trajectory" to="$(var output_trajectory)"/>
     <remap from="~/output/trajectories" to="$(var output_trajectories)"/>
     <remap from="~/output/predicted_objects" to="$(var output_predicted_objects)"/>


### PR DESCRIPTION
## Description

The current `autoware_diffusion_planner` cannot be launched independently because it is missing `vehicle_info_param_path`.

This is inconvenient because we sometimes want to run a single node with `build_only:=true` to pre-build the TRT engine.

```bash
~/autoware$ ros2 launch autoware_diffusion_planner diffusion_planner.launch.xml build_only:=true
[INFO] [launch]: All log files can be found below /home/shintarosakoda/.ros/log/2026-05-19-18-27-17-307075-dpc2304005-1866920
[INFO] [launch]: Default logging verbosity is set to INFO
[INFO] [autoware_diffusion_planner_node-1]: process started with pid [1866924]
[autoware_diffusion_planner_node-1] terminate called after throwing an instance of 'rclcpp::exceptions::UninitializedStaticallyTypedParameterException'
[autoware_diffusion_planner_node-1]   what():  Statically typed parameter 'wheel_radius' must be initialized.
[ERROR] [autoware_diffusion_planner_node-1]: process has died [pid 1866924, exit code -6, cmd '/home/shintarosakoda/autoware/install/autoware_diffusion_planner/lib/autoware_diffusion_planner/autoware_diffusion_planner_node --ros-args -r __node:=diffusion_planner_node --params-file /tmp/launch_params_ln6cos9z --params-file /tmp/launch_params_f190i55x -r ~/output/trajectory:=~/output/trajectory -r ~/output/trajectories:=~/output/trajectories -r ~/output/predicted_objects:=~/output/predicted_objects -r ~/output/turn_indicators:=~/output/turn_indicators -r ~/output/debug/traffic_signal:=~/output/debug/traffic_signal -r ~/input/odometry:=~/input/odometry -r ~/input/acceleration:=~/input/acceleration -r ~/input/route:=~/input/route -r ~/input/traffic_signals:=~/input/traffic_signals -r ~/input/tracked_objects:=~/input/tracked_objects -r ~/input/vector_map:=~/input/vector_map -r ~/input/turn_indicators:=~/input/turn_indicators'].
```

## How was this PR tested?

```bash
ros2 launch autoware_diffusion_planner diffusion_planner.launch.xml build_only:=true
```

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
