### PR TITLE
refactor(autoware_traffic_light_multi_camera_fusion): rename functions to snake_case

### DIFF
--- a/perception/autoware_traffic_light_multi_camera_fusion/src/signal_validator.cpp
+++ b/perception/autoware_traffic_light_multi_camera_fusion/src/signal_validator.cpp
@@ -22,7 +22,7 @@ namespace autoware::traffic_light
 {
 namespace
 {
-inline StateKey signalLutToStateKey(const SignalLUT & lut)
+inline StateKey signal_lut_to_state_key(const SignalLUT & lut)
 {
   StateKey state_key;
   for (const auto & signal : lut) {
@@ -32,7 +32,7 @@ inline StateKey signalLutToStateKey(const SignalLUT & lut)
   return state_key;
 }
 
-inline SignalLUT createSignalLUT(const StateKey & state_key)
+inline SignalLUT create_signal_lut(const StateKey & state_key)
 {
   SignalLUT signal_lut;
 
@@ -43,7 +43,7 @@ inline SignalLUT createSignalLUT(const StateKey & state_key)
   return signal_lut;
 };
 
-inline SignalLUT extractCommonSignals(const SignalLUT & lut_a, const SignalLUT & lut_b)
+inline SignalLUT extract_common_signals(const SignalLUT & lut_a, const SignalLUT & lut_b)
 {
   SignalLUT common_lut;
 
@@ -71,7 +71,7 @@ inline SignalLUT extractCommonSignals(const SignalLUT & lut_a, const SignalLUT &
  * @param state_b Second StateKey.
  * @return Conflict status and common signals (StateKey).
  */
-ConflictStatus SignalValidator::checkConflict(const StateKey & state_a, const StateKey & state_b)
+ConflictStatus SignalValidator::check_conflict(const StateKey & state_a, const StateKey & state_b)
 {
   // check if states match across signals.
   //
@@ -83,8 +83,8 @@ ConflictStatus SignalValidator::checkConflict(const StateKey & state_a, const St
     return ConflictStatus{ConflictType::NO_CONFLICT, state_a};
   }
 
-  SignalLUT lut_a = createSignalLUT(state_a);
-  SignalLUT lut_b = createSignalLUT(state_b);
+  SignalLUT lut_a = create_signal_lut(state_a);
+  SignalLUT lut_b = create_signal_lut(state_b);
 
   constexpr std::pair<uint8_t, uint8_t> unknown_pair{
     TrafficLightElement::UNKNOWN, TrafficLightElement::UNKNOWN};
@@ -107,8 +107,8 @@ ConflictStatus SignalValidator::checkConflict(const StateKey & state_a, const St
     // however, the returned state key depends on the input order
     return ConflictStatus{ConflictType::NO_CONFLICT, state_a};
   } else {
-    const SignalLUT lut_common = extractCommonSignals(lut_a, lut_b);
-    const StateKey common_state_key = signalLutToStateKey(lut_common);
+    const SignalLUT lut_common = extract_common_signals(lut_a, lut_b);
+    const StateKey common_state_key = signal_lut_to_state_key(lut_common);
 
     // all matching cases are already handled.
     // only need to check for full or partial conflicts.

--- a/perception/autoware_traffic_light_multi_camera_fusion/src/signal_validator.hpp
+++ b/perception/autoware_traffic_light_multi_camera_fusion/src/signal_validator.hpp
@@ -53,9 +53,9 @@ class SignalValidator
 public:
   using TrafficLightElement = tier4_perception_msgs::msg::TrafficLightElement;
 
-  static ConflictStatus checkConflict(const StateKey & state_a, const StateKey & state_b);
+  static ConflictStatus check_conflict(const StateKey & state_a, const StateKey & state_b);
 
-  StateKey mergePartialMatch(const StateKey & state_a, const StateKey & state_b);
+  StateKey merge_partial_match(const StateKey & state_a, const StateKey & state_b);
 };
 
 }  // namespace autoware::traffic_light

--- a/perception/autoware_traffic_light_multi_camera_fusion/src/traffic_light_multi_camera_fusion_node.cpp
+++ b/perception/autoware_traffic_light_multi_camera_fusion/src/traffic_light_multi_camera_fusion_node.cpp
@@ -32,7 +32,7 @@ namespace autoware::traffic_light
 namespace
 {
 
-double probabilityToLogOdds(double prob)
+double probability_to_log_odds(double prob)
 {
   /**
    * @brief Converts a probability value to log-odds.
@@ -58,10 +58,10 @@ double probabilityToLogOdds(double prob)
 /**
  * @brief get the state key that has best log-odds.
  */
-inline StateKey getBestStatekey(const std::map<StateKey, double> & accumulated_log_odds)
+inline StateKey get_best_state_key(const std::map<StateKey, double> & accumulated_log_odds)
 {
   auto best_element = std::max_element(
-    accumulated_log_odds.begin(), accumulated_log_odds.end(), compareStateKeyLogOdds);
+    accumulated_log_odds.begin(), accumulated_log_odds.end(), compare_state_key_log_odds);
 
   StateKey best_state_key = best_element->first;
 
@@ -102,20 +102,20 @@ MultiCameraFusion::MultiCameraFusion(const rclcpp::NodeOptions & node_options)
         ExactSyncPolicy(10), *(cam_info_subs_.back()), *(roi_subs_.back()),
         *(signal_subs_.back())));
       exact_sync_subs_.back()->registerCallback(
-        std::bind(&MultiCameraFusion::trafficSignalRoiCallback, this, _1, _2, _3));
+        std::bind(&MultiCameraFusion::traffic_signal_roi_callback, this, _1, _2, _3));
     } else {
       approximate_sync_subs_.emplace_back(new ApproximateSync(
         ApproximateSyncPolicy(10), *(cam_info_subs_.back()), *(roi_subs_.back()),
         *(signal_subs_.back())));
       approximate_sync_subs_.back()->registerCallback(
-        std::bind(&MultiCameraFusion::trafficSignalRoiCallback, this, _1, _2, _3));
+        std::bind(&MultiCameraFusion::traffic_signal_roi_callback, this, _1, _2, _3));
     }
   }
 
   map_sub_ = create_subscription<autoware_map_msgs::msg::LaneletMapBin>(
     "~/input/vector_map", rclcpp::QoS{1}.transient_local(),
     [this](const autoware_map_msgs::msg::LaneletMapBin::ConstSharedPtr msg) {
-      this->mapCallback(msg);
+      this->map_callback(msg);
     });
   signal_pub_ = create_publisher<NewSignalArrayType>("~/output/traffic_signals", rclcpp::QoS{1});
 
@@ -127,7 +127,7 @@ MultiCameraFusion::MultiCameraFusion(const rclcpp::NodeOptions & node_options)
   }
 }
 
-void MultiCameraFusion::trafficSignalRoiCallback(
+void MultiCameraFusion::traffic_signal_roi_callback(
   const CamInfoType::ConstSharedPtr cam_info_msg, const RoiArrayType::ConstSharedPtr roi_msg,
   const SignalArrayType::ConstSharedPtr signal_msg)
 {
@@ -140,20 +140,20 @@ void MultiCameraFusion::trafficSignalRoiCallback(
     utils::FusionRecordArr{cam_info_msg->header, *cam_info_msg, *roi_msg, *signal_msg});
 
   std::map<IdType, utils::FusionRecord> fused_record_map, grouped_record_map;
-  multiCameraFusion(fused_record_map);
-  groupFusion(fused_record_map, grouped_record_map);
+  multi_camera_fusion(fused_record_map);
+  group_fusion(fused_record_map, grouped_record_map);
 
   NewSignalArrayType msg_out;
-  convertOutputMsg(grouped_record_map, msg_out);
+  convert_output_msg(grouped_record_map, msg_out);
   msg_out.stamp = cam_info_msg->header.stamp;
   signal_pub_->publish(msg_out);
 
   if (conflicted_regulatory_element_status_.size() > 0) {
-    publishDiagnostics(stamp);
+    publish_diagnostics(stamp);
   }
 }
 
-void MultiCameraFusion::mapCallback(
+void MultiCameraFusion::map_callback(
   const autoware_map_msgs::msg::LaneletMapBin::ConstSharedPtr input_msg)
 {
   lanelet::LaneletMapPtr lanelet_map_ptr = autoware::experimental::lanelet2_utils::remove_const(
@@ -172,7 +172,7 @@ void MultiCameraFusion::mapCallback(
   }
 }
 
-void MultiCameraFusion::convertOutputMsg(
+void MultiCameraFusion::convert_output_msg(
   const std::map<IdType, utils::FusionRecord> & grouped_record_map, NewSignalArrayType & msg_out)
 {
   msg_out.traffic_light_groups.clear();
@@ -182,13 +182,14 @@ void MultiCameraFusion::convertOutputMsg(
     NewSignalType signal_out;
     signal_out.traffic_light_group_id = reg_ele_id;
     for (const auto & ele : signal.elements) {
-      signal_out.elements.push_back(utils::convertT4toAutoware(ele));
+      signal_out.elements.push_back(utils::convert_t4_to_autoware(ele));
     }
     msg_out.traffic_light_groups.push_back(signal_out);
   }
 }
 
-void MultiCameraFusion::multiCameraFusion(std::map<IdType, utils::FusionRecord> & fused_record_map)
+void MultiCameraFusion::multi_camera_fusion(
+  std::map<IdType, utils::FusionRecord> & fused_record_map)
 {
   fused_record_map.clear();
   /*
@@ -231,7 +232,7 @@ void MultiCameraFusion::multiCameraFusion(std::map<IdType, utils::FusionRecord> 
         */
         if (
           fused_record_map.find(roi.traffic_light_id) == fused_record_map.end() ||
-          utils::compareRecord(record, fused_record_map[roi.traffic_light_id]) >= 0) {
+          utils::compare_record(record, fused_record_map[roi.traffic_light_id]) >= 0) {
           fused_record_map[roi.traffic_light_id] = record;
         }
       }
@@ -240,7 +241,7 @@ void MultiCameraFusion::multiCameraFusion(std::map<IdType, utils::FusionRecord> 
   }
 }
 
-void MultiCameraFusion::groupFusion(
+void MultiCameraFusion::group_fusion(
   const std::map<IdType, utils::FusionRecord> & fused_record_map,
   std::map<IdType, utils::FusionRecord> & grouped_record_map)
 {
@@ -248,18 +249,18 @@ void MultiCameraFusion::groupFusion(
 
   // Stage 1: Accumulate evidence from all fused records
   const std::map<IdType, GroupFusionInfo> group_fusion_info_map =
-    accumulateGroupEvidence(fused_record_map);
+    accumulate_group_evidence(fused_record_map);
 
   // Stage 2: Determine the best state for each group from the accumulated evidence
-  determineBestGroupState(group_fusion_info_map, grouped_record_map);
+  determine_best_group_state(group_fusion_info_map, grouped_record_map);
 }
 
-GroupFusionInfoMap MultiCameraFusion::accumulateGroupEvidence(
+GroupFusionInfoMap MultiCameraFusion::accumulate_group_evidence(
   const std::map<IdType, utils::FusionRecord> & fused_record_map)
 {
   GroupFusionInfoMap group_fusion_info_map;
   for (const auto & p : fused_record_map) {
-    processFusedRecord(group_fusion_info_map, p.second);
+    process_fused_record(group_fusion_info_map, p.second);
   }
   return group_fusion_info_map;
 }
@@ -268,7 +269,7 @@ GroupFusionInfoMap MultiCameraFusion::accumulateGroupEvidence(
  * @brief Processes a single fused record and updates the group_fusion_info_map.
  * (This function contains the logic from the outer loop)
  */
-void MultiCameraFusion::processFusedRecord(
+void MultiCameraFusion::process_fused_record(
   GroupFusionInfoMap & group_fusion_info_map, const utils::FusionRecord & record)
 {
   const IdType roi_id = record.roi.traffic_light_id;
@@ -291,14 +292,14 @@ void MultiCameraFusion::processFusedRecord(
   // Loop over all regulatory IDs associated with this traffic light
   for (const auto & reg_ele_id : reg_ele_id_vec) {
     // Delegate the innermost logic to another helper
-    updateGroupInfoForElement(group_fusion_info_map, reg_ele_id, record);
+    update_group_info_for_element(group_fusion_info_map, reg_ele_id, record);
   }
 }
 
 /**
  * @brief Updates the map for a single (element, regulatory_id) combination.
  */
-void MultiCameraFusion::updateGroupInfoForElement(
+void MultiCameraFusion::update_group_info_for_element(
   GroupFusionInfoMap & group_fusion_info_map, const IdType & reg_ele_id,
   const utils::FusionRecord & record)
 {
@@ -306,26 +307,26 @@ void MultiCameraFusion::updateGroupInfoForElement(
   for (const auto & element : record.signal.elements) {
     state_key.emplace_back(std::make_pair(element.color, element.shape));
   }
-  const double confidence = utils::getMinConfidence(record.signal);
+  const double confidence = utils::get_min_confidence(record.signal);
   auto & group_info = group_fusion_info_map[reg_ele_id];
 
   // Update Log-Odds
-  updateLogOdds(group_info.accumulated_log_odds, state_key, confidence);
+  update_log_odds(group_info.accumulated_log_odds, state_key, confidence);
 
   // Update Best Record
-  updateBestRecord(group_info.best_record_for_state, state_key, confidence, record);
+  update_best_record(group_info.best_record_for_state, state_key, confidence, record);
 }
 
 /**
  * @brief Handles the log-odds accumulation logic.
  */
-void MultiCameraFusion::updateLogOdds(
+void MultiCameraFusion::update_log_odds(
   std::map<StateKey, double> & log_odds_map, const StateKey & state_key, double confidence)
 {
   // try_emplace ensures we only add the 0.0 prior (from a 0.5 probability) once.
   log_odds_map.try_emplace(state_key, 0.0);
 
-  const double evidence_log_odds = probabilityToLogOdds(confidence);
+  const double evidence_log_odds = probability_to_log_odds(confidence);
 
   // Accumulate evidence
   log_odds_map[state_key] += evidence_log_odds - prior_log_odds_;
@@ -334,7 +335,7 @@ void MultiCameraFusion::updateLogOdds(
 /**
  * @brief Handles the logic for tracking the best record for a given state.
  */
-void MultiCameraFusion::updateBestRecord(
+void MultiCameraFusion::update_best_record(
   std::map<StateKey, utils::FusionRecord> & best_record_map, const StateKey & state_key,
   double confidence, const utils::FusionRecord & record)
 {
@@ -351,12 +352,12 @@ void MultiCameraFusion::updateBestRecord(
     return;
   }
 
-  if (confidence > utils::getMinConfidence(existing_record.signal)) {
+  if (confidence > utils::get_min_confidence(existing_record.signal)) {
     best_record_map[state_key] = record;
   }
 }
 
-void MultiCameraFusion::determineBestGroupState(
+void MultiCameraFusion::determine_best_group_state(
   const std::map<IdType, GroupFusionInfo> & group_fusion_info_map,
   std::map<IdType, utils::FusionRecord> & grouped_record_map)
 {
@@ -372,7 +373,7 @@ void MultiCameraFusion::determineBestGroupState(
 
     if (!use_signal_consistency_check_ || group_info.accumulated_log_odds.size() == 1) {
       // use the most probable one (the highest logarithmic odds) as the base
-      const StateKey best_state_key = getBestStatekey(group_info.accumulated_log_odds);
+      const StateKey best_state_key = get_best_state_key(group_info.accumulated_log_odds);
       grouped_record_map[reg_ele_id] = group_info.best_record_for_state.at(best_state_key);
 
       continue;
@@ -389,7 +390,7 @@ void MultiCameraFusion::determineBestGroupState(
     // check if conflicts exist among the signals within the same regulatory element id
     for (++log_odds_it; log_odds_it != group_info.accumulated_log_odds.end(); ++log_odds_it) {
       const StateKey & competitor_state = (*log_odds_it).first;
-      conflict_result = signal_validator_->checkConflict(running_state, competitor_state);
+      conflict_result = signal_validator_->check_conflict(running_state, competitor_state);
       running_state = conflict_result.common_state_key;
 
       if (conflict_result.conflict_type == ConflictType::CONFLICT) {
@@ -410,23 +411,23 @@ void MultiCameraFusion::determineBestGroupState(
       // use a fail-safe record as a fallback for this regulatory element.
 
       // use the most probable one (the highest logarithmic odds) as the base
-      const StateKey best_state_key = getBestStatekey(group_info.accumulated_log_odds);
+      const StateKey best_state_key = get_best_state_key(group_info.accumulated_log_odds);
 
       // set the best record that signal is overwritten with fail-safe record
       grouped_record_map[reg_ele_id] =
-        utils::generateFailsafeRecord(group_info.best_record_for_state.at(best_state_key));
+        utils::generate_failsafe_record(group_info.best_record_for_state.at(best_state_key));
     } else {
       // partially conflicted and allowed to publish the matched signals
 
       // rebuild the record based on the matched signals
       // copy the base data from the best original record, but replace the elements
-      const StateKey best_state_key = getBestStatekey(group_info.accumulated_log_odds);
+      const StateKey best_state_key = get_best_state_key(group_info.accumulated_log_odds);
       utils::FusionRecord merged_record = group_info.best_record_for_state.at(best_state_key);
 
       merged_record.signal.elements.clear();
 
       const double min_confidence =
-        utils::getMinConfidence(group_info.best_record_for_state.at(best_state_key).signal);
+        utils::get_min_confidence(group_info.best_record_for_state.at(best_state_key).signal);
       for (const auto & elem : running_state) {
         tier4_perception_msgs::msg::TrafficLightElement new_elem;
         new_elem.color = elem.first;
@@ -448,7 +449,7 @@ void MultiCameraFusion::determineBestGroupState(
   }
 }
 
-void MultiCameraFusion::publishDiagnostics(rclcpp::Time stamp)
+void MultiCameraFusion::publish_diagnostics(rclcpp::Time stamp)
 {
   diagnostics_interface_ptr_->clear();
 

--- a/perception/autoware_traffic_light_multi_camera_fusion/src/traffic_light_multi_camera_fusion_node.hpp
+++ b/perception/autoware_traffic_light_multi_camera_fusion/src/traffic_light_multi_camera_fusion_node.hpp
@@ -48,20 +48,20 @@ namespace autoware::traffic_light
 {
 namespace mf = message_filters;
 
-inline bool isUnknown(const StateKey & state_key)
+inline bool is_unknown(const StateKey & state_key)
 {
   return state_key.size() == 1 &&
          state_key[0].first == tier4_perception_msgs::msg::TrafficLightElement::UNKNOWN;
 }
 
-inline bool compareStateKeyLogOdds(
+inline bool compare_state_key_log_odds(
   const std::pair<StateKey, double> & key1, const std::pair<StateKey, double> & key2)
 {
   // Ordering rule:
   // 1. Unknown StateKey is always lower priority
   // 2. Otherwise, smaller log-odds comes first
-  const bool key1_is_unknown = isUnknown(key1.first);
-  const bool key2_is_unknown = isUnknown(key2.first);
+  const bool key1_is_unknown = is_unknown(key1.first);
+  const bool key2_is_unknown = is_unknown(key2.first);
   if (key1_is_unknown && !key2_is_unknown) {
     return true;
   }
@@ -103,18 +103,18 @@ public:
   explicit MultiCameraFusion(const rclcpp::NodeOptions & node_options);
 
 private:
-  void trafficSignalRoiCallback(
+  void traffic_signal_roi_callback(
     const CamInfoType::ConstSharedPtr cam_info_msg, const RoiArrayType::ConstSharedPtr roi_msg,
     const SignalArrayType::ConstSharedPtr signal_msg);
 
-  void mapCallback(const autoware_map_msgs::msg::LaneletMapBin::ConstSharedPtr input_msg);
+  void map_callback(const autoware_map_msgs::msg::LaneletMapBin::ConstSharedPtr input_msg);
 
-  void multiCameraFusion(std::map<IdType, utils::FusionRecord> & fused_record_map);
+  void multi_camera_fusion(std::map<IdType, utils::FusionRecord> & fused_record_map);
 
-  void convertOutputMsg(
+  void convert_output_msg(
     const std::map<IdType, utils::FusionRecord> & grouped_record_map, NewSignalArrayType & msg_out);
 
-  void groupFusion(
+  void group_fusion(
     const std::map<IdType, utils::FusionRecord> & fused_record_map,
     std::map<IdType, utils::FusionRecord> & grouped_record_map);
 
@@ -122,43 +122,43 @@ private:
    * @brief Accumulates log-odds evidence for each traffic light group from individual fused
    * records.
    */
-  GroupFusionInfoMap accumulateGroupEvidence(
+  GroupFusionInfoMap accumulate_group_evidence(
     const std::map<IdType, utils::FusionRecord> & fused_record_map);
 
   /**
    * @brief Processes a single fused record and updates the group_fusion_info_map.
    */
-  void processFusedRecord(
+  void process_fused_record(
     GroupFusionInfoMap & group_fusion_info_map, const utils::FusionRecord & record);
 
   /**
    * @brief Updates the map for a single (element, regulatory_id) combination.
    */
-  void updateGroupInfoForElement(
+  void update_group_info_for_element(
     GroupFusionInfoMap & group_fusion_info_map, const IdType & reg_ele_id,
     const utils::FusionRecord & record);
 
   /**
    * @brief Handles the log-odds accumulation logic.
    */
-  void updateLogOdds(
+  void update_log_odds(
     std::map<StateKey, double> & log_odds_map, const StateKey & state_key, double confidence);
 
   /**
    * @brief Handles the logic for tracking the best record for a given state.
    */
-  void updateBestRecord(
+  void update_best_record(
     std::map<StateKey, utils::FusionRecord> & best_record_map, const StateKey & state_key,
     double confidence, const utils::FusionRecord & record);
 
   /**
    * @brief Determines the best state for each group based on accumulated evidence.
    */
-  void determineBestGroupState(
+  void determine_best_group_state(
     const std::map<IdType, GroupFusionInfo> & group_fusion_info_map,
     std::map<IdType, utils::FusionRecord> & grouped_record_map);
 
-  void publishDiagnostics(rclcpp::Time stamp);
+  void publish_diagnostics(rclcpp::Time stamp);
 
   using ExactSyncPolicy = mf::sync_policies::ExactTime<CamInfoType, RoiArrayType, SignalArrayType>;
   using ExactSync = mf::Synchronizer<ExactSyncPolicy>;

--- a/perception/autoware_traffic_light_multi_camera_fusion/src/traffic_light_multi_camera_fusion_process.cpp
+++ b/perception/autoware_traffic_light_multi_camera_fusion/src/traffic_light_multi_camera_fusion_process.cpp
@@ -73,7 +73,7 @@ const std::unordered_map<
      {tier4_perception_msgs::msg::TrafficLightElement::FLASHING,
       autoware_perception_msgs::msg::TrafficLightElement::FLASHING}});
 
-double getMinConfidence(const tier4_perception_msgs::msg::TrafficLight & signal)
+double get_min_confidence(const tier4_perception_msgs::msg::TrafficLight & signal)
 {
   // Normally, we should check whether the elements are empty,
   // but we already know they are not, so we skip the check here
@@ -83,7 +83,7 @@ double getMinConfidence(const tier4_perception_msgs::msg::TrafficLight & signal)
     ->confidence;
 }
 
-int compareRecord(const FusionRecord & r1, const FusionRecord & r2)
+int compare_record(const FusionRecord & r1, const FusionRecord & r2)
 {
   /*
   r1 will be checked
@@ -100,8 +100,8 @@ int compareRecord(const FusionRecord & r1, const FusionRecord & r2)
   if (r1.header.frame_id == r2.header.frame_id && std::abs(t1 - t2) >= dt_thres) {
     return t1 < t2 ? -1 : 1;
   }
-  bool r1_is_unknown = isUnknown(r1.signal);
-  bool r2_is_unknown = isUnknown(r2.signal);
+  bool r1_is_unknown = is_unknown(r1.signal);
+  bool r2_is_unknown = is_unknown(r2.signal);
   /*
   if both are unknown, they are of the same priority
   */
@@ -113,18 +113,18 @@ int compareRecord(const FusionRecord & r1, const FusionRecord & r2)
     */
     return r1_is_unknown ? -1 : 1;
   }
-  int visible_score_1 = calVisibleScore(r1);
-  int visible_score_2 = calVisibleScore(r2);
+  int visible_score_1 = cal_visible_score(r1);
+  int visible_score_2 = cal_visible_score(r2);
   if (visible_score_1 == visible_score_2) {
-    double confidence_1 = getMinConfidence(r1.signal);
-    double confidence_2 = getMinConfidence(r2.signal);
+    double confidence_1 = get_min_confidence(r1.signal);
+    double confidence_2 = get_min_confidence(r2.signal);
     return confidence_1 < confidence_2 ? -1 : 1;
   } else {
     return visible_score_1 < visible_score_2 ? -1 : 1;
   }
 }
 
-autoware_perception_msgs::msg::TrafficLightElement convertT4toAutoware(
+autoware_perception_msgs::msg::TrafficLightElement convert_t4_to_autoware(
   const tier4_perception_msgs::msg::TrafficLightElement & input)
 {
   // clang-format on
@@ -140,7 +140,7 @@ autoware_perception_msgs::msg::TrafficLightElement convertT4toAutoware(
   return output;
 }
 
-int calVisibleScore(const FusionRecord & record)
+int cal_visible_score(const FusionRecord & record)
 {
   const uint32_t boundary = 5;
   uint32_t x1 = record.roi.roi.x_offset;
@@ -156,7 +156,7 @@ int calVisibleScore(const FusionRecord & record)
   }
 }
 
-FusionRecord generateFailsafeRecord(FusionRecord base_record)
+FusionRecord generate_failsafe_record(FusionRecord base_record)
 {
   // return unknown record for a fail safe
   FusionRecord fail_safe_signal;

--- a/perception/autoware_traffic_light_multi_camera_fusion/src/traffic_light_multi_camera_fusion_process.hpp
+++ b/perception/autoware_traffic_light_multi_camera_fusion/src/traffic_light_multi_camera_fusion_process.hpp
@@ -53,7 +53,7 @@ struct FusionRecordArr
   }
 };
 
-inline bool isUnknown(const tier4_perception_msgs::msg::TrafficLight & signal)
+inline bool is_unknown(const tier4_perception_msgs::msg::TrafficLight & signal)
 {
   return signal.elements.size() == 1 &&
          signal.elements[0].color == tier4_perception_msgs::msg::TrafficLightElement::UNKNOWN &&
@@ -66,10 +66,10 @@ V at_or(const std::unordered_map<K, V> & map, const K & key, const V & value)
   return map.count(key) ? map.at(key) : value;
 }
 
-double getMinConfidence(const tier4_perception_msgs::msg::TrafficLight & signal);
-int compareRecord(const FusionRecord & r1, const FusionRecord & r2);
+double get_min_confidence(const tier4_perception_msgs::msg::TrafficLight & signal);
+int compare_record(const FusionRecord & r1, const FusionRecord & r2);
 
-autoware_perception_msgs::msg::TrafficLightElement convertT4toAutoware(
+autoware_perception_msgs::msg::TrafficLightElement convert_t4_to_autoware(
   const tier4_perception_msgs::msg::TrafficLightElement & input);
 
 /**
@@ -79,8 +79,8 @@ autoware_perception_msgs::msg::TrafficLightElement convertT4toAutoware(
  * @param record    fusion record
  * @return 0 if traffic light is truncated, otherwise 1
  */
-int calVisibleScore(const FusionRecord & record);
-FusionRecord generateFailsafeRecord(FusionRecord base_record);
+int cal_visible_score(const FusionRecord & record);
+FusionRecord generate_failsafe_record(FusionRecord base_record);
 
 }  // namespace utils
 }  // namespace autoware::traffic_light

--- a/perception/autoware_traffic_light_multi_camera_fusion/test/test_signal_validator.cpp
+++ b/perception/autoware_traffic_light_multi_camera_fusion/test/test_signal_validator.cpp
@@ -41,7 +41,7 @@ TEST_F(SignalValidatorCheckConflict, RedCircle_RedCircle)
   StateKey input_a = {{TrafficLightElement::RED, TrafficLightElement::CIRCLE}};
   StateKey input_b = {{TrafficLightElement::RED, TrafficLightElement::CIRCLE}};
 
-  ConflictStatus result = validator.checkConflict(input_a, input_b);
+  ConflictStatus result = validator.check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::NO_CONFLICT;
@@ -58,7 +58,7 @@ TEST_F(SignalValidatorCheckConflict, RedCircle_GreenCircle)
   StateKey input_a = {{TrafficLightElement::RED, TrafficLightElement::CIRCLE}};
   StateKey input_b = {{TrafficLightElement::GREEN, TrafficLightElement::CIRCLE}};
 
-  ConflictStatus result = validator.checkConflict(input_a, input_b);
+  ConflictStatus result = validator.check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::CONFLICT;
@@ -76,7 +76,7 @@ TEST_F(SignalValidatorCheckConflict, GreenCircle_RedCircle)
   StateKey input_a = {{TrafficLightElement::GREEN, TrafficLightElement::CIRCLE}};
   StateKey input_b = {{TrafficLightElement::RED, TrafficLightElement::CIRCLE}};
 
-  ConflictStatus result = validator.checkConflict(input_a, input_b);
+  ConflictStatus result = validator.check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::CONFLICT;
@@ -97,7 +97,7 @@ TEST_F(SignalValidatorCheckConflict, RedCircleGreenLeftarrow_RedCircleGreenLefta
     {TrafficLightElement::RED, TrafficLightElement::CIRCLE},
     {TrafficLightElement::GREEN, TrafficLightElement::LEFT_ARROW}};
 
-  ConflictStatus result = validator.checkConflict(input_a, input_b);
+  ConflictStatus result = validator.check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::NO_CONFLICT;
@@ -126,7 +126,7 @@ TEST_F(SignalValidatorCheckConflict, RedCircleMultipleMatchedArrows_RedCircleMul
     {TrafficLightElement::GREEN, TrafficLightElement::RIGHT_ARROW},
     {TrafficLightElement::GREEN, TrafficLightElement::DOWN_LEFT_ARROW}};
 
-  ConflictStatus result = validator.checkConflict(input_a, input_b);
+  ConflictStatus result = validator.check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::NO_CONFLICT;
@@ -154,7 +154,7 @@ TEST_F(SignalValidatorCheckConflict, RedCircleGreenLeftarrow_GreenCircleGreenLef
     {TrafficLightElement::GREEN, TrafficLightElement::LEFT_ARROW},
   };
 
-  ConflictStatus result = validator.checkConflict(input_a, input_b);
+  ConflictStatus result = validator.check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::PARTIAL_CONFLICT;
@@ -178,7 +178,7 @@ TEST_F(SignalValidatorCheckConflict, RedCircleGreenLeftarrow_RedCircleRedLeftarr
     {TrafficLightElement::RED, TrafficLightElement::LEFT_ARROW},
   };
 
-  ConflictStatus result = validator.checkConflict(input_a, input_b);
+  ConflictStatus result = validator.check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::PARTIAL_CONFLICT;
@@ -199,7 +199,7 @@ TEST_F(SignalValidatorCheckConflict, GreenLeftarrowRedCircle_RedCircle)
     {TrafficLightElement::RED, TrafficLightElement::CIRCLE},
   };
 
-  ConflictStatus result = validator.checkConflict(input_a, input_b);
+  ConflictStatus result = validator.check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::PARTIAL_CONFLICT;
@@ -220,7 +220,7 @@ TEST_F(SignalValidatorCheckConflict, RedCircle_GreenLeftarrowRedCircle)
     {TrafficLightElement::GREEN, TrafficLightElement::LEFT_ARROW},
     {TrafficLightElement::RED, TrafficLightElement::CIRCLE}};
 
-  ConflictStatus result = validator.checkConflict(input_a, input_b);
+  ConflictStatus result = validator.check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::PARTIAL_CONFLICT;
@@ -247,7 +247,7 @@ TEST_F(SignalValidatorCheckConflict, RedCircleMultipleArrows_RedCircleMultipleAr
     {TrafficLightElement::GREEN, TrafficLightElement::RIGHT_ARROW},
     {TrafficLightElement::GREEN, TrafficLightElement::DOWN_ARROW}};
 
-  ConflictStatus result = validator.checkConflict(input_a, input_b);
+  ConflictStatus result = validator.check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::PARTIAL_CONFLICT;
@@ -271,7 +271,7 @@ TEST_F(SignalValidatorCheckConflict, RedCircleGreendownarrow_GreenUparrow)
     {TrafficLightElement::GREEN, TrafficLightElement::DOWN_ARROW}};
   StateKey input_b = {{TrafficLightElement::GREEN, TrafficLightElement::UP_ARROW}};
 
-  ConflictStatus result = validator.checkConflict(input_a, input_b);
+  ConflictStatus result = validator.check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::CONFLICT;
@@ -291,7 +291,7 @@ TEST_F(SignalValidatorCheckConflict, WhiteCross_WhiteCross)
   StateKey input_a = {{TrafficLightElement::WHITE, TrafficLightElement::CROSS}};
   StateKey input_b = {{TrafficLightElement::WHITE, TrafficLightElement::CROSS}};
 
-  ConflictStatus result = validator.checkConflict(input_a, input_b);
+  ConflictStatus result = validator.check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::NO_CONFLICT;
@@ -308,7 +308,7 @@ TEST_F(SignalValidatorCheckConflict, WhiteCross_WhiteCIRCLE)
   StateKey input_a = {{TrafficLightElement::WHITE, TrafficLightElement::CROSS}};
   StateKey input_b = {{TrafficLightElement::WHITE, TrafficLightElement::CIRCLE}};
 
-  ConflictStatus result = validator.checkConflict(input_a, input_b);
+  ConflictStatus result = validator.check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::CONFLICT;
@@ -327,7 +327,7 @@ TEST_F(SignalValidatorCheckConflict, AmberCross_AmberCrossGreenUparrow)
     {TrafficLightElement::AMBER, TrafficLightElement::CROSS},
     {TrafficLightElement::GREEN, TrafficLightElement::UP_ARROW}};
 
-  ConflictStatus result = validator.checkConflict(input_a, input_b);
+  ConflictStatus result = validator.check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::PARTIAL_CONFLICT;
@@ -348,7 +348,7 @@ TEST_F(SignalValidatorCheckConflict, AllMismatch)
     {TrafficLightElement::GREEN, TrafficLightElement::LEFT_ARROW},
   };
 
-  ConflictStatus result = validator.checkConflict(input_a, input_b);
+  ConflictStatus result = validator.check_conflict(input_a, input_b);
 
   StateKey expected_common_state_key = {};
 
@@ -366,7 +366,7 @@ TEST_F(SignalValidatorCheckConflict, GreenUparrow_GreenUparrow)
   StateKey input_a = {{TrafficLightElement::GREEN, TrafficLightElement::UP_ARROW}};
   StateKey input_b = {{TrafficLightElement::GREEN, TrafficLightElement::UP_ARROW}};
 
-  ConflictStatus result = validator.checkConflict(input_a, input_b);
+  ConflictStatus result = validator.check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::NO_CONFLICT;
@@ -388,7 +388,7 @@ TEST_F(SignalValidatorCheckConflict, GreenUparrowGreenRightarrow_GreenUparrowGre
     {TrafficLightElement::GREEN, TrafficLightElement::UP_ARROW},
     {TrafficLightElement::GREEN, TrafficLightElement::RIGHT_ARROW}};
 
-  ConflictStatus result = validator.checkConflict(input_a, input_b);
+  ConflictStatus result = validator.check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::NO_CONFLICT;
@@ -407,7 +407,7 @@ TEST_F(SignalValidatorCheckConflict, RedUparrow_GreenUparrow)
   StateKey input_a = {{TrafficLightElement::RED, TrafficLightElement::UP_ARROW}};
   StateKey input_b = {{TrafficLightElement::GREEN, TrafficLightElement::UP_ARROW}};
 
-  ConflictStatus result = validator.checkConflict(input_a, input_b);
+  ConflictStatus result = validator.check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::CONFLICT;
@@ -424,7 +424,7 @@ TEST_F(SignalValidatorCheckConflict, RedUparrow_RedDownleftarrow)
   StateKey input_a = {{TrafficLightElement::RED, TrafficLightElement::UP_ARROW}};
   StateKey input_b = {{TrafficLightElement::RED, TrafficLightElement::DOWN_LEFT_ARROW}};
 
-  ConflictStatus result = validator.checkConflict(input_a, input_b);
+  ConflictStatus result = validator.check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::CONFLICT;
@@ -443,7 +443,7 @@ TEST_F(SignalValidatorCheckConflict, RedUparrowRedDownleftarrow_RedDownleftarrow
     {TrafficLightElement::RED, TrafficLightElement::DOWN_LEFT_ARROW}};
   StateKey input_b = {{TrafficLightElement::RED, TrafficLightElement::DOWN_LEFT_ARROW}};
 
-  ConflictStatus result = validator.checkConflict(input_a, input_b);
+  ConflictStatus result = validator.check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::PARTIAL_CONFLICT;
@@ -463,7 +463,7 @@ TEST_F(SignalValidatorCheckConflict, RedDownleftarrow_RedUparrowRedDownleftarrow
     {TrafficLightElement::RED, TrafficLightElement::UP_ARROW},
     {TrafficLightElement::RED, TrafficLightElement::DOWN_LEFT_ARROW}};
 
-  ConflictStatus result = validator.checkConflict(input_a, input_b);
+  ConflictStatus result = validator.check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::PARTIAL_CONFLICT;
@@ -484,7 +484,7 @@ TEST_F(SignalValidatorCheckConflict, RedCircle_Unknown)
   StateKey input_a = {{TrafficLightElement::RED, TrafficLightElement::CIRCLE}};
   StateKey input_b = {{TrafficLightElement::UNKNOWN, TrafficLightElement::UNKNOWN}};
 
-  ConflictStatus result = validator.checkConflict(input_a, input_b);
+  ConflictStatus result = validator.check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::NO_CONFLICT;
@@ -501,7 +501,7 @@ TEST_F(SignalValidatorCheckConflict, RedUparrow_Unknown)
   StateKey input_a = {{TrafficLightElement::RED, TrafficLightElement::UP_ARROW}};
   StateKey input_b = {{TrafficLightElement::UNKNOWN, TrafficLightElement::UNKNOWN}};
 
-  ConflictStatus result = validator.checkConflict(input_a, input_b);
+  ConflictStatus result = validator.check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::NO_CONFLICT;
@@ -518,7 +518,7 @@ TEST_F(SignalValidatorCheckConflict, Unknown_Unknown)
   StateKey input_a = {{TrafficLightElement::UNKNOWN, TrafficLightElement::UNKNOWN}};
   StateKey input_b = {{TrafficLightElement::UNKNOWN, TrafficLightElement::UNKNOWN}};
 
-  ConflictStatus result = validator.checkConflict(input_a, input_b);
+  ConflictStatus result = validator.check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::NO_CONFLICT;
@@ -536,7 +536,7 @@ TEST_F(SignalValidatorCheckConflict, RedCircle_NoDetection)
   StateKey input_a = {{TrafficLightElement::RED, TrafficLightElement::CIRCLE}};
   StateKey input_b = {};
 
-  ConflictStatus result = validator.checkConflict(input_a, input_b);
+  ConflictStatus result = validator.check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::NO_CONFLICT;
@@ -553,7 +553,7 @@ TEST_F(SignalValidatorCheckConflict, NoDetection_RedCircle)
   StateKey input_a = {};
   StateKey input_b = {{TrafficLightElement::RED, TrafficLightElement::CIRCLE}};
 
-  ConflictStatus result = validator.checkConflict(input_a, input_b);
+  ConflictStatus result = validator.check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::NO_CONFLICT;
@@ -570,7 +570,7 @@ TEST_F(SignalValidatorCheckConflict, RedUparrow_NoDetection)
   StateKey input_a = {{TrafficLightElement::RED, TrafficLightElement::UP_ARROW}};
   StateKey input_b = {};
 
-  ConflictStatus result = validator.checkConflict(input_a, input_b);
+  ConflictStatus result = validator.check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::NO_CONFLICT;
@@ -589,7 +589,7 @@ TEST_F(SignalValidatorCheckConflict, Unknown_NoDetection)
 
   // unknown and missing inputs will be treated as same,
   // but the returned state key depend on the input order
-  ConflictStatus result = validator.checkConflict(input_a, input_b);
+  ConflictStatus result = validator.check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::NO_CONFLICT;
@@ -609,7 +609,7 @@ TEST_F(SignalValidatorCheckConflict, NoDetection_Unknown)
 
   // unknown and missing inputs will be treated as same,
   // but the returned state key depend on the input order
-  ConflictStatus result = validator.checkConflict(input_a, input_b);
+  ConflictStatus result = validator.check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::NO_CONFLICT;
@@ -631,7 +631,7 @@ TEST_F(SignalValidatorCheckConflict, RedCircleRedCircle_RedCircle)
     {TrafficLightElement::RED, TrafficLightElement::CIRCLE}};
   StateKey input_b = {{TrafficLightElement::RED, TrafficLightElement::CIRCLE}};
 
-  ConflictStatus result = validator.checkConflict(input_a, input_b);
+  ConflictStatus result = validator.check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::PARTIAL_CONFLICT;
@@ -650,7 +650,7 @@ TEST_F(SignalValidatorCheckConflict, RedCircleGreenCircle_RedCircle)
     {TrafficLightElement::GREEN, TrafficLightElement::CIRCLE}};
   StateKey input_b = {{TrafficLightElement::RED, TrafficLightElement::CIRCLE}};
 
-  ConflictStatus result = validator.checkConflict(input_a, input_b);
+  ConflictStatus result = validator.check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::PARTIAL_CONFLICT;
@@ -674,7 +674,7 @@ TEST_F(
     {TrafficLightElement::GREEN, TrafficLightElement::DOWN_RIGHT_ARROW},
     {TrafficLightElement::GREEN, TrafficLightElement::DOWN_RIGHT_ARROW}};
 
-  ConflictStatus result = validator.checkConflict(input_a, input_b);
+  ConflictStatus result = validator.check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::PARTIAL_CONFLICT;
@@ -696,7 +696,7 @@ TEST_F(SignalValidatorCheckConflict, EmptyInputs_1)
   StateKey input_a = {{TrafficLightElement::RED, TrafficLightElement::CIRCLE}};
   StateKey input_b = {};
 
-  ConflictStatus result = validator.checkConflict(input_a, input_b);
+  ConflictStatus result = validator.check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::NO_CONFLICT;
@@ -713,7 +713,7 @@ TEST_F(SignalValidatorCheckConflict, EmptyInputs_2)
   StateKey input_a = {};
   StateKey input_b = {{TrafficLightElement::RED, TrafficLightElement::CIRCLE}};
 
-  ConflictStatus result = validator.checkConflict(input_a, input_b);
+  ConflictStatus result = validator.check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::NO_CONFLICT;
@@ -729,7 +729,7 @@ TEST_F(SignalValidatorCheckConflict, EmptyInputs_3)
   StateKey input_a = {};
   StateKey input_b = {};
 
-  ConflictStatus result = validator.checkConflict(input_a, input_b);
+  ConflictStatus result = validator.check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::NO_CONFLICT;

--- a/perception/autoware_traffic_light_multi_camera_fusion/test/test_utils.cpp
+++ b/perception/autoware_traffic_light_multi_camera_fusion/test/test_utils.cpp
@@ -20,7 +20,7 @@
 
 #include <unordered_map>
 
-TEST(isUnknown, normal)
+TEST(is_unknown, normal)
 {
   tier4_perception_msgs::msg::TrafficLight signal;
   tier4_perception_msgs::msg::TrafficLightElement element;
@@ -29,7 +29,7 @@ TEST(isUnknown, normal)
     element.shape = tier4_perception_msgs::msg::TrafficLightElement::UNKNOWN;
     signal.elements.push_back(element);
   }
-  EXPECT_TRUE(autoware::traffic_light::utils::isUnknown(signal));
+  EXPECT_TRUE(autoware::traffic_light::utils::is_unknown(signal));
 
   {
     signal.elements.clear();
@@ -37,7 +37,7 @@ TEST(isUnknown, normal)
     element.shape = tier4_perception_msgs::msg::TrafficLightElement::CIRCLE;
     signal.elements.push_back(element);
   }
-  EXPECT_FALSE(autoware::traffic_light::utils::isUnknown(signal));
+  EXPECT_FALSE(autoware::traffic_light::utils::is_unknown(signal));
 }
 
 TEST(at_or, normal)
@@ -54,7 +54,7 @@ namespace same_camera
 {
 
 // first condition
-TEST(compareRecord, timestamp_check)
+TEST(compare_record, timestamp_check)
 {
   // r1 is newer
   autoware::traffic_light::utils::FusionRecord r1;
@@ -105,7 +105,7 @@ TEST(compareRecord, timestamp_check)
     element.confidence = 0.8;
     r2.signal.elements.push_back(element);
   }
-  EXPECT_EQ(autoware::traffic_light::utils::compareRecord(r1, r2), 1);
+  EXPECT_EQ(autoware::traffic_light::utils::compare_record(r1, r2), 1);
 
   // r2 is newer
   {
@@ -154,11 +154,11 @@ TEST(compareRecord, timestamp_check)
     element.confidence = 0.8;
     r2.signal.elements.push_back(element);
   }
-  EXPECT_EQ(autoware::traffic_light::utils::compareRecord(r1, r2), -1);
+  EXPECT_EQ(autoware::traffic_light::utils::compare_record(r1, r2), -1);
 }
 
 // second condition
-TEST(compareRecord, unknown_check)
+TEST(compare_record, unknown_check)
 {
   // r1 is unknown
   autoware::traffic_light::utils::FusionRecord r1;
@@ -209,7 +209,7 @@ TEST(compareRecord, unknown_check)
     element.confidence = 0.8;
     r2.signal.elements.push_back(element);
   }
-  EXPECT_EQ(autoware::traffic_light::utils::compareRecord(r1, r2), -1);
+  EXPECT_EQ(autoware::traffic_light::utils::compare_record(r1, r2), -1);
 
   // r2 is unknown
   {
@@ -258,7 +258,7 @@ TEST(compareRecord, unknown_check)
     element.confidence = 0.0;
     r2.signal.elements.push_back(element);
   }
-  EXPECT_EQ(autoware::traffic_light::utils::compareRecord(r1, r2), 1);
+  EXPECT_EQ(autoware::traffic_light::utils::compare_record(r1, r2), 1);
 
   // both of r1 and r2 is unknown
   {
@@ -307,11 +307,11 @@ TEST(compareRecord, unknown_check)
     element.confidence = 0.0;
     r2.signal.elements.push_back(element);
   }
-  EXPECT_EQ(autoware::traffic_light::utils::compareRecord(r1, r2), 0);
+  EXPECT_EQ(autoware::traffic_light::utils::compare_record(r1, r2), 0);
 }
 
 // third condition
-TEST(compareRecord, visible_check)
+TEST(compare_record, visible_check)
 {
   // r1 is better visible on top left
   autoware::traffic_light::utils::FusionRecord r1;
@@ -363,7 +363,7 @@ TEST(compareRecord, visible_check)
     element.confidence = 0.8;
     r2.signal.elements.push_back(element);
   }
-  EXPECT_EQ(autoware::traffic_light::utils::compareRecord(r1, r2), 1);
+  EXPECT_EQ(autoware::traffic_light::utils::compare_record(r1, r2), 1);
 
   // r1 is better visible on bottom left
   {
@@ -413,7 +413,7 @@ TEST(compareRecord, visible_check)
     element.confidence = 0.8;
     r2.signal.elements.push_back(element);
   }
-  EXPECT_EQ(autoware::traffic_light::utils::compareRecord(r1, r2), 1);
+  EXPECT_EQ(autoware::traffic_light::utils::compare_record(r1, r2), 1);
 
   // r2 is better visible on top left
   {
@@ -463,7 +463,7 @@ TEST(compareRecord, visible_check)
     element.confidence = 0.8;
     r2.signal.elements.push_back(element);
   }
-  EXPECT_EQ(autoware::traffic_light::utils::compareRecord(r1, r2), -1);
+  EXPECT_EQ(autoware::traffic_light::utils::compare_record(r1, r2), -1);
 
   // r2 is better visible on bottom left
   {
@@ -514,11 +514,11 @@ TEST(compareRecord, visible_check)
     element.confidence = 0.8;
     r2.signal.elements.push_back(element);
   }
-  EXPECT_EQ(autoware::traffic_light::utils::compareRecord(r1, r2), -1);
+  EXPECT_EQ(autoware::traffic_light::utils::compare_record(r1, r2), -1);
 }
 
 // fourth condition
-TEST(compareRecord, confidence_check)
+TEST(compare_record, confidence_check)
 {
   // r1 is higher confidence
   autoware::traffic_light::utils::FusionRecord r1;
@@ -569,7 +569,7 @@ TEST(compareRecord, confidence_check)
     element.confidence = 0.8;
     r2.signal.elements.push_back(element);
   }
-  EXPECT_EQ(autoware::traffic_light::utils::compareRecord(r1, r2), 1);
+  EXPECT_EQ(autoware::traffic_light::utils::compare_record(r1, r2), 1);
 
   // r2 is higher confidence
   {
@@ -618,7 +618,7 @@ TEST(compareRecord, confidence_check)
     element.confidence = 0.95;
     r2.signal.elements.push_back(element);
   }
-  EXPECT_EQ(autoware::traffic_light::utils::compareRecord(r1, r2), -1);
+  EXPECT_EQ(autoware::traffic_light::utils::compare_record(r1, r2), -1);
 }
 
 }  // namespace same_camera
@@ -629,7 +629,7 @@ namespace different_camera
 // first condition is nothing in different camera
 
 // second condition
-TEST(compareRecord, unknown_check)
+TEST(compare_record, unknown_check)
 {
   // r1 is unknown
   autoware::traffic_light::utils::FusionRecord r1;
@@ -680,7 +680,7 @@ TEST(compareRecord, unknown_check)
     element.confidence = 0.8;
     r2.signal.elements.push_back(element);
   }
-  EXPECT_EQ(autoware::traffic_light::utils::compareRecord(r1, r2), -1);
+  EXPECT_EQ(autoware::traffic_light::utils::compare_record(r1, r2), -1);
 
   // r2 is unknown
   {
@@ -729,7 +729,7 @@ TEST(compareRecord, unknown_check)
     element.confidence = 0.0;
     r2.signal.elements.push_back(element);
   }
-  EXPECT_EQ(autoware::traffic_light::utils::compareRecord(r1, r2), 1);
+  EXPECT_EQ(autoware::traffic_light::utils::compare_record(r1, r2), 1);
 
   // both of r1 and r2 is unknown
   {
@@ -778,11 +778,11 @@ TEST(compareRecord, unknown_check)
     element.confidence = 0.0;
     r2.signal.elements.push_back(element);
   }
-  EXPECT_EQ(autoware::traffic_light::utils::compareRecord(r1, r2), 0);
+  EXPECT_EQ(autoware::traffic_light::utils::compare_record(r1, r2), 0);
 }
 
 // third condition
-TEST(compareRecord, visible_check)
+TEST(compare_record, visible_check)
 {
   // r1 is better visible on top left
   autoware::traffic_light::utils::FusionRecord r1;
@@ -834,7 +834,7 @@ TEST(compareRecord, visible_check)
     element.confidence = 0.8;
     r2.signal.elements.push_back(element);
   }
-  EXPECT_EQ(autoware::traffic_light::utils::compareRecord(r1, r2), 1);
+  EXPECT_EQ(autoware::traffic_light::utils::compare_record(r1, r2), 1);
 
   // r1 is better visible on bottom left
   {
@@ -884,7 +884,7 @@ TEST(compareRecord, visible_check)
     element.confidence = 0.8;
     r2.signal.elements.push_back(element);
   }
-  EXPECT_EQ(autoware::traffic_light::utils::compareRecord(r1, r2), 1);
+  EXPECT_EQ(autoware::traffic_light::utils::compare_record(r1, r2), 1);
 
   // r2 is better visible on top left
   {
@@ -934,7 +934,7 @@ TEST(compareRecord, visible_check)
     element.confidence = 0.8;
     r2.signal.elements.push_back(element);
   }
-  EXPECT_EQ(autoware::traffic_light::utils::compareRecord(r1, r2), -1);
+  EXPECT_EQ(autoware::traffic_light::utils::compare_record(r1, r2), -1);
 
   // r2 is better visible on bottom left
   {
@@ -985,11 +985,11 @@ TEST(compareRecord, visible_check)
     element.confidence = 0.8;
     r2.signal.elements.push_back(element);
   }
-  EXPECT_EQ(autoware::traffic_light::utils::compareRecord(r1, r2), -1);
+  EXPECT_EQ(autoware::traffic_light::utils::compare_record(r1, r2), -1);
 }
 
 // fourth condition
-TEST(compareRecord, confidence_check)
+TEST(compare_record, confidence_check)
 {
   // r1 is higher confidence
   autoware::traffic_light::utils::FusionRecord r1;
@@ -1040,7 +1040,7 @@ TEST(compareRecord, confidence_check)
     element.confidence = 0.8;
     r2.signal.elements.push_back(element);
   }
-  EXPECT_EQ(autoware::traffic_light::utils::compareRecord(r1, r2), 1);
+  EXPECT_EQ(autoware::traffic_light::utils::compare_record(r1, r2), 1);
 
   // r2 is higher confidence
   {
@@ -1089,12 +1089,12 @@ TEST(compareRecord, confidence_check)
     element.confidence = 0.95;
     r2.signal.elements.push_back(element);
   }
-  EXPECT_EQ(autoware::traffic_light::utils::compareRecord(r1, r2), -1);
+  EXPECT_EQ(autoware::traffic_light::utils::compare_record(r1, r2), -1);
 }
 
 }  // namespace different_camera
 
-TEST(calVisibleScore, normal)
+TEST(cal_visible_score, normal)
 {
   // visible
   autoware::traffic_light::utils::FusionRecord r1;
@@ -1121,7 +1121,7 @@ TEST(calVisibleScore, normal)
     element.confidence = 0.9;
     r1.signal.elements.push_back(element);
   }
-  EXPECT_EQ(autoware::traffic_light::utils::calVisibleScore(r1), 1);
+  EXPECT_EQ(autoware::traffic_light::utils::cal_visible_score(r1), 1);
 
   // invisible by left top
   {
@@ -1148,7 +1148,7 @@ TEST(calVisibleScore, normal)
     element.confidence = 0.9;
     r1.signal.elements.push_back(element);
   }
-  EXPECT_EQ(autoware::traffic_light::utils::calVisibleScore(r1), 0);
+  EXPECT_EQ(autoware::traffic_light::utils::cal_visible_score(r1), 0);
 
   // invisible by right top
   {
@@ -1175,7 +1175,7 @@ TEST(calVisibleScore, normal)
     element.confidence = 0.9;
     r1.signal.elements.push_back(element);
   }
-  EXPECT_EQ(autoware::traffic_light::utils::calVisibleScore(r1), 0);
+  EXPECT_EQ(autoware::traffic_light::utils::cal_visible_score(r1), 0);
 
   // invisible by left bottom
   {
@@ -1202,7 +1202,7 @@ TEST(calVisibleScore, normal)
     element.confidence = 0.9;
     r1.signal.elements.push_back(element);
   }
-  EXPECT_EQ(autoware::traffic_light::utils::calVisibleScore(r1), 0);
+  EXPECT_EQ(autoware::traffic_light::utils::cal_visible_score(r1), 0);
 
   // invisible by right bottom
   {
@@ -1229,7 +1229,7 @@ TEST(calVisibleScore, normal)
     element.confidence = 0.9;
     r1.signal.elements.push_back(element);
   }
-  EXPECT_EQ(autoware::traffic_light::utils::calVisibleScore(r1), 0);
+  EXPECT_EQ(autoware::traffic_light::utils::cal_visible_score(r1), 0);
 }
 
 int main(int argc, char ** argv)


### PR DESCRIPTION
## Description

Rename camelCase function names to snake_case in the `autoware_traffic_light_multi_camera_fusion` package to follow the Autoware C++ coding guideline:
<https://autowarefoundation.github.io/autoware-documentation/main/contributing/coding-guidelines/languages/cpp/#use-lower-snake-case-for-function-names-required-partially-automated>

Test suite/case names in `test_utils.cpp` are aligned to PascalCase to match the other test suites in this package and comply with Google Test naming guidance. No behavior changes.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

- `colcon build --packages-select autoware_traffic_light_multi_camera_fusion`
- `colcon test --packages-select autoware_traffic_light_multi_camera_fusion --event-handlers console_cohesion+` — all 6 tests pass.


## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
