### PR TITLE
fix(yabloc_common): remove redundant semicolon

### DIFF
--- a/localization/yabloc/yabloc_common/include/yabloc_common/ground_server/util.hpp
+++ b/localization/yabloc/yabloc_common/include/yabloc_common/ground_server/util.hpp
@@ -41,7 +41,7 @@ void inline upsample_line_string(
     xyz.getVector3fMap() = (f + l * d);
     cloud->push_back(xyz);
   }
-};
+}
 
 std::vector<int> inline merge_indices(
   const std::vector<int> & indices1, const std::vector<int> & indices2)


### PR DESCRIPTION
## Description

This PR just removes an unnecessary semicolon.  I just happened to find it.

From my investigation, even with strict compiler options enabled, the newer compiler does not treat it as an error.

I have not verified it myself, but I heard that it causes an error when using gcc-10. [TIER IV INTERNAL ISSUES](https://star4.slack.com/archives/C03QU7K50D8/p1779264355927429?thread_ts=1778659929.846209&cid=C03QU7K50D8)

## Related links

**Parent Issue:**

- Nothing

## How was this PR tested?

I think the build-check CI is enough. 

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.
