### PR TITLE
refactor(traffic_light_multi_camera_fusion): extract core logic from node

### DIFF
--- a/perception/autoware_traffic_light_multi_camera_fusion/CMakeLists.txt
+++ b/perception/autoware_traffic_light_multi_camera_fusion/CMakeLists.txt
@@ -9,13 +9,14 @@ include_directories(
 )
 
 ament_auto_add_library(${PROJECT_NAME} SHARED
+  src/traffic_light_multi_camera_fusion_node.cpp
   src/multi_camera_fusion.cpp
   src/traffic_light_multi_camera_fusion_process.cpp
   src/signal_validator.cpp
 )
 
 rclcpp_components_register_node(${PROJECT_NAME}
-  PLUGIN "autoware::traffic_light::MultiCameraFusion"
+  PLUGIN "autoware::traffic_light::MultiCameraFusionNode"
   EXECUTABLE traffic_light_multi_camera_fusion_node
 )
 

--- a/perception/autoware_traffic_light_multi_camera_fusion/CMakeLists.txt
+++ b/perception/autoware_traffic_light_multi_camera_fusion/CMakeLists.txt
@@ -9,7 +9,7 @@ include_directories(
 )
 
 ament_auto_add_library(${PROJECT_NAME} SHARED
-  src/traffic_light_multi_camera_fusion_node.cpp
+  src/multi_camera_fusion.cpp
   src/traffic_light_multi_camera_fusion_process.cpp
   src/signal_validator.cpp
 )

--- a/perception/autoware_traffic_light_multi_camera_fusion/design/TrafficLightMultiCameraFusion.node.yaml
+++ b/perception/autoware_traffic_light_multi_camera_fusion/design/TrafficLightMultiCameraFusion.node.yaml
@@ -8,7 +8,7 @@ package:
   provider: autoware
 
 launch:
-  plugin: autoware::traffic_light::MultiCameraFusion
+  plugin: autoware::traffic_light::MultiCameraFusionNode
   executable: traffic_light_multi_camera_fusion_node
   node_output: screen
 

--- a/perception/autoware_traffic_light_multi_camera_fusion/src/multi_camera_fusion.cpp
+++ b/perception/autoware_traffic_light_multi_camera_fusion/src/multi_camera_fusion.cpp
@@ -250,7 +250,7 @@ void MultiCameraFusion::process_fused_record(
  */
 void MultiCameraFusion::update_group_info_for_element(
   GroupFusionInfoMap & group_fusion_info_map, const IdType & reg_ele_id,
-  const utils::FusionRecord & record)
+  const utils::FusionRecord & record) const
 {
   StateKey state_key;
   for (const auto & element : record.signal.elements) {
@@ -270,7 +270,7 @@ void MultiCameraFusion::update_group_info_for_element(
  * @brief Handles the log-odds accumulation logic.
  */
 void MultiCameraFusion::update_log_odds(
-  std::map<StateKey, double> & log_odds_map, const StateKey & state_key, double confidence)
+  std::map<StateKey, double> & log_odds_map, const StateKey & state_key, double confidence) const
 {
   // try_emplace ensures we only add the 0.0 prior (from a 0.5 probability) once.
   log_odds_map.try_emplace(state_key, 0.0);

--- a/perception/autoware_traffic_light_multi_camera_fusion/src/multi_camera_fusion.cpp
+++ b/perception/autoware_traffic_light_multi_camera_fusion/src/multi_camera_fusion.cpp
@@ -21,8 +21,6 @@
 #include <cmath>
 #include <map>
 #include <memory>
-#include <sstream>
-#include <string>
 #include <utility>
 #include <vector>
 
@@ -114,7 +112,7 @@ MultiCameraFusionResult MultiCameraFusion::fuse(
   MultiCameraFusionResult result;
   std::map<IdType, utils::FusionRecord> fused_record_map, grouped_record_map;
   multi_camera_fusion(fused_record_map);
-  group_fusion(fused_record_map, grouped_record_map, result.warnings);
+  group_fusion(fused_record_map, grouped_record_map, result.unmapped_traffic_light_ids);
 
   NewSignalArrayType msg_out;
   convert_output_msg(grouped_record_map, msg_out);
@@ -189,13 +187,14 @@ void MultiCameraFusion::multi_camera_fusion(
 
 void MultiCameraFusion::group_fusion(
   const std::map<IdType, utils::FusionRecord> & fused_record_map,
-  std::map<IdType, utils::FusionRecord> & grouped_record_map, std::vector<std::string> & warnings)
+  std::map<IdType, utils::FusionRecord> & grouped_record_map,
+  std::vector<IdType> & unmapped_traffic_light_ids)
 {
   grouped_record_map.clear();
 
   // Stage 1: Accumulate evidence from all fused records
   const std::map<IdType, GroupFusionInfo> group_fusion_info_map =
-    accumulate_group_evidence(fused_record_map, warnings);
+    accumulate_group_evidence(fused_record_map, unmapped_traffic_light_ids);
 
   // Stage 2: Determine the best state for each group from the accumulated evidence
   determine_best_group_state(group_fusion_info_map, grouped_record_map);
@@ -203,11 +202,11 @@ void MultiCameraFusion::group_fusion(
 
 GroupFusionInfoMap MultiCameraFusion::accumulate_group_evidence(
   const std::map<IdType, utils::FusionRecord> & fused_record_map,
-  std::vector<std::string> & warnings)
+  std::vector<IdType> & unmapped_traffic_light_ids)
 {
   GroupFusionInfoMap group_fusion_info_map;
   for (const auto & p : fused_record_map) {
-    process_fused_record(group_fusion_info_map, p.second, warnings);
+    process_fused_record(group_fusion_info_map, p.second, unmapped_traffic_light_ids);
   }
   return group_fusion_info_map;
 }
@@ -218,16 +217,14 @@ GroupFusionInfoMap MultiCameraFusion::accumulate_group_evidence(
  */
 void MultiCameraFusion::process_fused_record(
   GroupFusionInfoMap & group_fusion_info_map, const utils::FusionRecord & record,
-  std::vector<std::string> & warnings)
+  std::vector<IdType> & unmapped_traffic_light_ids)
 {
   const IdType roi_id = record.roi.traffic_light_id;
 
   // Guard Clause 1: Check if traffic light ID is in the map
   const auto it = traffic_light_id_to_regulatory_ele_id_.find(roi_id);
   if (it == traffic_light_id_to_regulatory_ele_id_.end()) {
-    std::ostringstream warning_stream;
-    warning_stream << "Found Traffic Light Id = " << roi_id << " which is not defined in Map";
-    warnings.emplace_back(warning_stream.str());
+    unmapped_traffic_light_ids.emplace_back(roi_id);
     return;
   }
 

--- a/perception/autoware_traffic_light_multi_camera_fusion/src/multi_camera_fusion.cpp
+++ b/perception/autoware_traffic_light_multi_camera_fusion/src/multi_camera_fusion.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "traffic_light_multi_camera_fusion_node.hpp"
+#include "multi_camera_fusion.hpp"
 
 #include <autoware/lanelet2_utils/conversion.hpp>
 #include <autoware_lanelet2_extension/utility/query.hpp>

--- a/perception/autoware_traffic_light_multi_camera_fusion/src/multi_camera_fusion.cpp
+++ b/perception/autoware_traffic_light_multi_camera_fusion/src/multi_camera_fusion.cpp
@@ -1,4 +1,4 @@
-// Copyright 2023 TIER IV, Inc.
+// Copyright 2026 TIER IV, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,15 +14,15 @@
 
 #include "multi_camera_fusion.hpp"
 
-#include <autoware/lanelet2_utils/conversion.hpp>
 #include <autoware_lanelet2_extension/utility/query.hpp>
+#include <rclcpp/time.hpp>
 
 #include <algorithm>
-#include <functional>
+#include <cmath>
 #include <map>
 #include <memory>
+#include <sstream>
 #include <string>
-#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -68,96 +68,13 @@ inline StateKey get_best_state_key(const std::map<StateKey, double> & accumulate
   return best_state_key;
 }
 
-}  // namespace
-
-MultiCameraFusion::MultiCameraFusion(const rclcpp::NodeOptions & node_options)
-: Node("traffic_light_multi_camera_fusion", node_options)
+std::map<lanelet::Id, std::vector<lanelet::Id>> build_traffic_light_id_to_regulatory_ele_id(
+  const lanelet::LaneletMapPtr & lanelet_map_ptr)
 {
-  using std::placeholders::_1;
-  using std::placeholders::_2;
-  using std::placeholders::_3;
-
-  std::vector<std::string> camera_namespaces =
-    this->declare_parameter<std::vector<std::string>>("camera_namespaces");
-  is_approximate_sync_ = this->declare_parameter<bool>("approximate_sync");
-  message_lifespan_ = this->declare_parameter<double>("message_lifespan");
-  prior_log_odds_ = this->declare_parameter<double>("prior_log_odds");
-
-  use_signal_consistency_check_ = this->declare_parameter<bool>("signal_consistency_check.enable");
-  publish_partial_matched_signal_ =
-    this->declare_parameter<bool>("signal_consistency_check.publish_partial_matched_signal");
-
-  for (const std::string & camera_ns : camera_namespaces) {
-    std::string signal_topic = camera_ns + "/classification/traffic_signals";
-    std::string roi_topic = camera_ns + "/detection/rois";
-    std::string cam_info_topic = camera_ns + "/camera_info";
-    roi_subs_.emplace_back(
-      new mf::Subscriber<RoiArrayType>(this, roi_topic, rclcpp::QoS{1}.get_rmw_qos_profile()));
-    signal_subs_.emplace_back(new mf::Subscriber<SignalArrayType>(
-      this, signal_topic, rclcpp::QoS{1}.get_rmw_qos_profile()));
-    cam_info_subs_.emplace_back(new mf::Subscriber<CamInfoType>(
-      this, cam_info_topic, rclcpp::SensorDataQoS().get_rmw_qos_profile()));
-    if (is_approximate_sync_ == false) {
-      exact_sync_subs_.emplace_back(new ExactSync(
-        ExactSyncPolicy(10), *(cam_info_subs_.back()), *(roi_subs_.back()),
-        *(signal_subs_.back())));
-      exact_sync_subs_.back()->registerCallback(
-        std::bind(&MultiCameraFusion::traffic_signal_roi_callback, this, _1, _2, _3));
-    } else {
-      approximate_sync_subs_.emplace_back(new ApproximateSync(
-        ApproximateSyncPolicy(10), *(cam_info_subs_.back()), *(roi_subs_.back()),
-        *(signal_subs_.back())));
-      approximate_sync_subs_.back()->registerCallback(
-        std::bind(&MultiCameraFusion::traffic_signal_roi_callback, this, _1, _2, _3));
-    }
+  std::map<lanelet::Id, std::vector<lanelet::Id>> traffic_light_id_to_regulatory_ele_id;
+  if (!lanelet_map_ptr) {
+    return traffic_light_id_to_regulatory_ele_id;
   }
-
-  map_sub_ = create_subscription<autoware_map_msgs::msg::LaneletMapBin>(
-    "~/input/vector_map", rclcpp::QoS{1}.transient_local(),
-    [this](const autoware_map_msgs::msg::LaneletMapBin::ConstSharedPtr msg) {
-      this->map_callback(msg);
-    });
-  signal_pub_ = create_publisher<NewSignalArrayType>("~/output/traffic_signals", rclcpp::QoS{1});
-
-  diagnostics_interface_ptr_ =
-    std::make_unique<autoware_utils::DiagnosticsInterface>(this, "traffic light conflict status");
-
-  if (use_signal_consistency_check_) {
-    signal_validator_ = std::make_unique<SignalValidator>();
-  }
-}
-
-void MultiCameraFusion::traffic_signal_roi_callback(
-  const CamInfoType::ConstSharedPtr cam_info_msg, const RoiArrayType::ConstSharedPtr roi_msg,
-  const SignalArrayType::ConstSharedPtr signal_msg)
-{
-  rclcpp::Time stamp(roi_msg->header.stamp);
-  /*
-  Insert the received record array to the table.
-  Attention should be payed that this record array might not have the newest timestamp
-  */
-  record_arr_set_.insert(
-    utils::FusionRecordArr{cam_info_msg->header, *cam_info_msg, *roi_msg, *signal_msg});
-
-  std::map<IdType, utils::FusionRecord> fused_record_map, grouped_record_map;
-  multi_camera_fusion(fused_record_map);
-  group_fusion(fused_record_map, grouped_record_map);
-
-  NewSignalArrayType msg_out;
-  convert_output_msg(grouped_record_map, msg_out);
-  msg_out.stamp = cam_info_msg->header.stamp;
-  signal_pub_->publish(msg_out);
-
-  if (conflicted_regulatory_element_status_.size() > 0) {
-    publish_diagnostics(stamp);
-  }
-}
-
-void MultiCameraFusion::map_callback(
-  const autoware_map_msgs::msg::LaneletMapBin::ConstSharedPtr input_msg)
-{
-  lanelet::LaneletMapPtr lanelet_map_ptr = autoware::experimental::lanelet2_utils::remove_const(
-    autoware::experimental::lanelet2_utils::from_autoware_map_msgs(*input_msg));
   lanelet::ConstLanelets all_lanelets = lanelet::utils::query::laneletLayer(lanelet_map_ptr);
   std::vector<lanelet::AutowareTrafficLightConstPtr> all_lanelet_traffic_lights =
     lanelet::utils::query::autowareTrafficLights(all_lanelets);
@@ -167,9 +84,45 @@ void MultiCameraFusion::map_callback(
 
     auto lights = tl->trafficLights();
     for (const auto & light : lights) {
-      traffic_light_id_to_regulatory_ele_id_[light.id()].emplace_back(tl->id());
+      traffic_light_id_to_regulatory_ele_id[light.id()].emplace_back(tl->id());
     }
   }
+  return traffic_light_id_to_regulatory_ele_id;
+}
+
+}  // namespace
+
+MultiCameraFusion::MultiCameraFusion(const MultiCameraFusionConfig & config)
+: config_(config),
+  traffic_light_id_to_regulatory_ele_id_(
+    build_traffic_light_id_to_regulatory_ele_id(config.lanelet_map_ptr))
+{
+  if (config_.use_signal_consistency_check) {
+    signal_validator_ = std::make_unique<SignalValidator>();
+  }
+}
+
+MultiCameraFusionResult MultiCameraFusion::fuse(
+  const CamInfoType & cam_info, const RoiArrayType & rois, const SignalArrayType & signals)
+{
+  /*
+  Insert the received record array to the table.
+  Attention should be payed that this record array might not have the newest timestamp
+  */
+  record_arr_set_.insert(utils::FusionRecordArr{cam_info.header, cam_info, rois, signals});
+
+  MultiCameraFusionResult result;
+  std::map<IdType, utils::FusionRecord> fused_record_map, grouped_record_map;
+  multi_camera_fusion(fused_record_map);
+  group_fusion(fused_record_map, grouped_record_map, result.warnings);
+
+  NewSignalArrayType msg_out;
+  convert_output_msg(grouped_record_map, msg_out);
+  msg_out.stamp = cam_info.header.stamp;
+  result.traffic_light_groups = msg_out;
+
+  result.conflicted_regulatory_element_status = conflicted_regulatory_element_status_;
+  return result;
 }
 
 void MultiCameraFusion::convert_output_msg(
@@ -192,13 +145,6 @@ void MultiCameraFusion::multi_camera_fusion(
   std::map<IdType, utils::FusionRecord> & fused_record_map)
 {
   fused_record_map.clear();
-  /*
-  this should not happen. Just in case
-  */
-  if (record_arr_set_.empty()) {
-    RCLCPP_ERROR(get_logger(), "record_arr_set_ is empty! This should not happen");
-    return;
-  }
   const rclcpp::Time & newest_stamp(record_arr_set_.rbegin()->header.stamp);
   for (auto it = record_arr_set_.begin(); it != record_arr_set_.end();) {
     /*
@@ -207,7 +153,7 @@ void MultiCameraFusion::multi_camera_fusion(
     */
     if (
       (newest_stamp - rclcpp::Time(it->header.stamp)) >
-      rclcpp::Duration::from_seconds(message_lifespan_)) {
+      rclcpp::Duration::from_seconds(config_.message_lifespan)) {
       it = record_arr_set_.erase(it);
     } else {
       /*
@@ -243,24 +189,25 @@ void MultiCameraFusion::multi_camera_fusion(
 
 void MultiCameraFusion::group_fusion(
   const std::map<IdType, utils::FusionRecord> & fused_record_map,
-  std::map<IdType, utils::FusionRecord> & grouped_record_map)
+  std::map<IdType, utils::FusionRecord> & grouped_record_map, std::vector<std::string> & warnings)
 {
   grouped_record_map.clear();
 
   // Stage 1: Accumulate evidence from all fused records
   const std::map<IdType, GroupFusionInfo> group_fusion_info_map =
-    accumulate_group_evidence(fused_record_map);
+    accumulate_group_evidence(fused_record_map, warnings);
 
   // Stage 2: Determine the best state for each group from the accumulated evidence
   determine_best_group_state(group_fusion_info_map, grouped_record_map);
 }
 
 GroupFusionInfoMap MultiCameraFusion::accumulate_group_evidence(
-  const std::map<IdType, utils::FusionRecord> & fused_record_map)
+  const std::map<IdType, utils::FusionRecord> & fused_record_map,
+  std::vector<std::string> & warnings)
 {
   GroupFusionInfoMap group_fusion_info_map;
   for (const auto & p : fused_record_map) {
-    process_fused_record(group_fusion_info_map, p.second);
+    process_fused_record(group_fusion_info_map, p.second, warnings);
   }
   return group_fusion_info_map;
 }
@@ -270,15 +217,17 @@ GroupFusionInfoMap MultiCameraFusion::accumulate_group_evidence(
  * (This function contains the logic from the outer loop)
  */
 void MultiCameraFusion::process_fused_record(
-  GroupFusionInfoMap & group_fusion_info_map, const utils::FusionRecord & record)
+  GroupFusionInfoMap & group_fusion_info_map, const utils::FusionRecord & record,
+  std::vector<std::string> & warnings)
 {
   const IdType roi_id = record.roi.traffic_light_id;
 
   // Guard Clause 1: Check if traffic light ID is in the map
   const auto it = traffic_light_id_to_regulatory_ele_id_.find(roi_id);
   if (it == traffic_light_id_to_regulatory_ele_id_.end()) {
-    RCLCPP_WARN_STREAM(
-      get_logger(), "Found Traffic Light Id = " << roi_id << " which is not defined in Map");
+    std::ostringstream warning_stream;
+    warning_stream << "Found Traffic Light Id = " << roi_id << " which is not defined in Map";
+    warnings.emplace_back(warning_stream.str());
     return;
   }
 
@@ -329,7 +278,7 @@ void MultiCameraFusion::update_log_odds(
   const double evidence_log_odds = probability_to_log_odds(confidence);
 
   // Accumulate evidence
-  log_odds_map[state_key] += evidence_log_odds - prior_log_odds_;
+  log_odds_map[state_key] += evidence_log_odds - config_.prior_log_odds;
 }
 
 /**
@@ -371,7 +320,7 @@ void MultiCameraFusion::determine_best_group_state(
       continue;
     }
 
-    if (!use_signal_consistency_check_ || group_info.accumulated_log_odds.size() == 1) {
+    if (!config_.use_signal_consistency_check || group_info.accumulated_log_odds.size() == 1) {
       // use the most probable one (the highest logarithmic odds) as the base
       const StateKey best_state_key = get_best_state_key(group_info.accumulated_log_odds);
       grouped_record_map[reg_ele_id] = group_info.best_record_for_state.at(best_state_key);
@@ -398,7 +347,7 @@ void MultiCameraFusion::determine_best_group_state(
         // we immediately exit the loop
         break;
       } else {  // partial conflict
-        if (publish_partial_matched_signal_) {
+        if (config_.publish_partial_matched_signal) {
           continue;
         } else {
           break;
@@ -407,7 +356,8 @@ void MultiCameraFusion::determine_best_group_state(
     }
 
     if (
-      conflict_result.conflict_type == ConflictType::CONFLICT || !publish_partial_matched_signal_) {
+      conflict_result.conflict_type == ConflictType::CONFLICT ||
+      !config_.publish_partial_matched_signal) {
       // use a fail-safe record as a fallback for this regulatory element.
 
       // use the most probable one (the highest logarithmic odds) as the base
@@ -449,26 +399,4 @@ void MultiCameraFusion::determine_best_group_state(
   }
 }
 
-void MultiCameraFusion::publish_diagnostics(rclcpp::Time stamp)
-{
-  diagnostics_interface_ptr_->clear();
-
-  // publish only conflicted RE status
-  for (const auto & conflicted_re : conflicted_regulatory_element_status_) {
-    diagnostics_interface_ptr_->add_key_value(
-      std::to_string(static_cast<int64_t>(conflicted_re.id)),
-      static_cast<int>(conflicted_re.conflict_type));
-  }
-
-  diagnostics_interface_ptr_->update_level_and_message(
-    diagnostic_msgs::msg::DiagnosticStatus::WARN,
-    "Detected traffic light signal conflict in the fusion process.");
-
-  diagnostics_interface_ptr_->publish(stamp);
-  conflicted_regulatory_element_status_.clear();
-}
-
 }  // namespace autoware::traffic_light
-
-#include <rclcpp_components/register_node_macro.hpp>
-RCLCPP_COMPONENTS_REGISTER_NODE(autoware::traffic_light::MultiCameraFusion)

--- a/perception/autoware_traffic_light_multi_camera_fusion/src/multi_camera_fusion.hpp
+++ b/perception/autoware_traffic_light_multi_camera_fusion/src/multi_camera_fusion.hpp
@@ -123,7 +123,7 @@ public:
 private:
   void multi_camera_fusion(std::map<IdType, utils::FusionRecord> & fused_record_map);
 
-  void convert_output_msg(
+  static void convert_output_msg(
     const std::map<IdType, utils::FusionRecord> & grouped_record_map, NewSignalArrayType & msg_out);
 
   void group_fusion(
@@ -151,18 +151,18 @@ private:
    */
   void update_group_info_for_element(
     GroupFusionInfoMap & group_fusion_info_map, const IdType & reg_ele_id,
-    const utils::FusionRecord & record);
+    const utils::FusionRecord & record) const;
 
   /**
    * @brief Handles the log-odds accumulation logic.
    */
   void update_log_odds(
-    std::map<StateKey, double> & log_odds_map, const StateKey & state_key, double confidence);
+    std::map<StateKey, double> & log_odds_map, const StateKey & state_key, double confidence) const;
 
   /**
    * @brief Handles the logic for tracking the best record for a given state.
    */
-  void update_best_record(
+  static void update_best_record(
     std::map<StateKey, utils::FusionRecord> & best_record_map, const StateKey & state_key,
     double confidence, const utils::FusionRecord & record);
 

--- a/perception/autoware_traffic_light_multi_camera_fusion/src/multi_camera_fusion.hpp
+++ b/perception/autoware_traffic_light_multi_camera_fusion/src/multi_camera_fusion.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 TIER IV, Inc.
+// Copyright 2026 TIER IV, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,10 +19,6 @@
 #include "traffic_light_multi_camera_fusion_process.hpp"
 #include "types.hpp"
 
-#include <autoware_utils/ros/diagnostics_interface.hpp>
-#include <rclcpp/rclcpp.hpp>
-
-#include <autoware_map_msgs/msg/lanelet_map_bin.hpp>
 #include <autoware_perception_msgs/msg/traffic_light_group.hpp>
 #include <autoware_perception_msgs/msg/traffic_light_group_array.hpp>
 #include <sensor_msgs/msg/camera_info.hpp>
@@ -32,21 +28,16 @@
 #include <tier4_perception_msgs/msg/traffic_light_roi_array.hpp>
 
 #include <lanelet2_core/Forward.h>
-#include <message_filters/subscriber.h>
-#include <message_filters/sync_policies/approximate_time.h>
-#include <message_filters/sync_policies/exact_time.h>
-#include <message_filters/synchronizer.h>
 
-#include <list>
 #include <map>
 #include <memory>
 #include <set>
+#include <string>
 #include <utility>
 #include <vector>
 
 namespace autoware::traffic_light
 {
-namespace mf = message_filters;
 
 inline bool is_unknown(const StateKey & state_key)
 {
@@ -86,7 +77,32 @@ struct ConflictInfo
 using GroupFusionInfoMap =
   std::map<tier4_perception_msgs::msg::TrafficLightRoi::_traffic_light_id_type, GroupFusionInfo>;
 
-class MultiCameraFusion : public rclcpp::Node
+struct MultiCameraFusionConfig
+{
+  /*
+  For every input message input_m, if the timestamp difference between input_m and the latest
+  message is smaller than message_lifespan, then input_m would be used for the fusion. Otherwise,
+  it would be discarded.
+  */
+  double message_lifespan{1.0};
+  /**
+   * @brief The prior log-odds for a traffic light state.
+   */
+  double prior_log_odds{0.0};
+  bool use_signal_consistency_check{false};
+  bool publish_partial_matched_signal{false};
+  lanelet::LaneletMapPtr lanelet_map_ptr{nullptr};
+};
+
+struct MultiCameraFusionResult
+{
+  autoware_perception_msgs::msg::TrafficLightGroupArray traffic_light_groups;
+  std::vector<ConflictInfo> conflicted_regulatory_element_status;
+  // Diagnostic messages forwarded to the Node for logging (Error-as-Value).
+  std::vector<std::string> warnings;
+};
+
+class MultiCameraFusion
 {
 public:
   using CamInfoType = sensor_msgs::msg::CameraInfo;
@@ -98,17 +114,13 @@ public:
   using NewSignalType = autoware_perception_msgs::msg::TrafficLightGroup;
   using NewSignalArrayType = autoware_perception_msgs::msg::TrafficLightGroupArray;
 
-  using RecordArrayType = std::pair<RoiArrayType, SignalArrayType>;
+  explicit MultiCameraFusion(const MultiCameraFusionConfig & config);
+  MultiCameraFusion() = default;
 
-  explicit MultiCameraFusion(const rclcpp::NodeOptions & node_options);
+  MultiCameraFusionResult fuse(
+    const CamInfoType & cam_info, const RoiArrayType & rois, const SignalArrayType & signals);
 
 private:
-  void traffic_signal_roi_callback(
-    const CamInfoType::ConstSharedPtr cam_info_msg, const RoiArrayType::ConstSharedPtr roi_msg,
-    const SignalArrayType::ConstSharedPtr signal_msg);
-
-  void map_callback(const autoware_map_msgs::msg::LaneletMapBin::ConstSharedPtr input_msg);
-
   void multi_camera_fusion(std::map<IdType, utils::FusionRecord> & fused_record_map);
 
   void convert_output_msg(
@@ -116,20 +128,23 @@ private:
 
   void group_fusion(
     const std::map<IdType, utils::FusionRecord> & fused_record_map,
-    std::map<IdType, utils::FusionRecord> & grouped_record_map);
+    std::map<IdType, utils::FusionRecord> & grouped_record_map,
+    std::vector<std::string> & warnings);
 
   /**
    * @brief Accumulates log-odds evidence for each traffic light group from individual fused
    * records.
    */
   GroupFusionInfoMap accumulate_group_evidence(
-    const std::map<IdType, utils::FusionRecord> & fused_record_map);
+    const std::map<IdType, utils::FusionRecord> & fused_record_map,
+    std::vector<std::string> & warnings);
 
   /**
    * @brief Processes a single fused record and updates the group_fusion_info_map.
    */
   void process_fused_record(
-    GroupFusionInfoMap & group_fusion_info_map, const utils::FusionRecord & record);
+    GroupFusionInfoMap & group_fusion_info_map, const utils::FusionRecord & record,
+    std::vector<std::string> & warnings);
 
   /**
    * @brief Updates the map for a single (element, regulatory_id) combination.
@@ -158,22 +173,7 @@ private:
     const std::map<IdType, GroupFusionInfo> & group_fusion_info_map,
     std::map<IdType, utils::FusionRecord> & grouped_record_map);
 
-  void publish_diagnostics(rclcpp::Time stamp);
-
-  using ExactSyncPolicy = mf::sync_policies::ExactTime<CamInfoType, RoiArrayType, SignalArrayType>;
-  using ExactSync = mf::Synchronizer<ExactSyncPolicy>;
-  using ApproximateSyncPolicy =
-    mf::sync_policies::ApproximateTime<CamInfoType, RoiArrayType, SignalArrayType>;
-  using ApproximateSync = mf::Synchronizer<ApproximateSyncPolicy>;
-
-  std::vector<std::unique_ptr<mf::Subscriber<SignalArrayType>>> signal_subs_;
-  std::vector<std::unique_ptr<mf::Subscriber<RoiArrayType>>> roi_subs_;
-  std::vector<std::unique_ptr<mf::Subscriber<CamInfoType>>> cam_info_subs_;
-  std::vector<std::unique_ptr<ExactSync>> exact_sync_subs_;
-  std::vector<std::unique_ptr<ApproximateSync>> approximate_sync_subs_;
-  rclcpp::Subscription<autoware_map_msgs::msg::LaneletMapBin>::SharedPtr map_sub_;
-
-  rclcpp::Publisher<NewSignalArrayType>::SharedPtr signal_pub_;
+  MultiCameraFusionConfig config_{};
   /*
   Mapping from traffic light instance id to regulatory element id (group id)
   */
@@ -183,24 +183,11 @@ private:
   Use multiset in case multiple cameras publish images at the exact same time.
   */
   std::multiset<utils::FusionRecordArr> record_arr_set_;
-  bool is_approximate_sync_;
-  /*
-  For every input message input_m, if the timestamp difference between input_m and the latest
-  message is smaller than message_lifespan_, then input_m would be used for the fusion. Otherwise,
-  it would be discarded.
-  */
-  double message_lifespan_;
-  /**
-   * @brief The prior log-odds for a traffic light state.
-   */
-  double prior_log_odds_;
-  bool use_signal_consistency_check_;
-  bool publish_partial_matched_signal_;
 
   std::unique_ptr<SignalValidator> signal_validator_;
   std::vector<ConflictInfo> conflicted_regulatory_element_status_{};
-
-  std::unique_ptr<autoware_utils::DiagnosticsInterface> diagnostics_interface_ptr_;
 };
+
 }  // namespace autoware::traffic_light
+
 #endif  // MULTI_CAMERA_FUSION_HPP_

--- a/perception/autoware_traffic_light_multi_camera_fusion/src/multi_camera_fusion.hpp
+++ b/perception/autoware_traffic_light_multi_camera_fusion/src/multi_camera_fusion.hpp
@@ -32,7 +32,6 @@
 #include <map>
 #include <memory>
 #include <set>
-#include <string>
 #include <utility>
 #include <vector>
 
@@ -98,8 +97,10 @@ struct MultiCameraFusionResult
 {
   autoware_perception_msgs::msg::TrafficLightGroupArray traffic_light_groups;
   std::vector<ConflictInfo> conflicted_regulatory_element_status;
-  // Diagnostic messages forwarded to the Node for logging (Error-as-Value).
-  std::vector<std::string> warnings;
+  // Traffic light IDs that were observed by a camera but are not registered in the loaded map.
+  // The Node logs a warning for each entry.
+  std::vector<tier4_perception_msgs::msg::TrafficLightRoi::_traffic_light_id_type>
+    unmapped_traffic_light_ids;
 };
 
 class MultiCameraFusion
@@ -129,7 +130,7 @@ private:
   void group_fusion(
     const std::map<IdType, utils::FusionRecord> & fused_record_map,
     std::map<IdType, utils::FusionRecord> & grouped_record_map,
-    std::vector<std::string> & warnings);
+    std::vector<IdType> & unmapped_traffic_light_ids);
 
   /**
    * @brief Accumulates log-odds evidence for each traffic light group from individual fused
@@ -137,14 +138,14 @@ private:
    */
   GroupFusionInfoMap accumulate_group_evidence(
     const std::map<IdType, utils::FusionRecord> & fused_record_map,
-    std::vector<std::string> & warnings);
+    std::vector<IdType> & unmapped_traffic_light_ids);
 
   /**
    * @brief Processes a single fused record and updates the group_fusion_info_map.
    */
   void process_fused_record(
     GroupFusionInfoMap & group_fusion_info_map, const utils::FusionRecord & record,
-    std::vector<std::string> & warnings);
+    std::vector<IdType> & unmapped_traffic_light_ids);
 
   /**
    * @brief Updates the map for a single (element, regulatory_id) combination.

--- a/perception/autoware_traffic_light_multi_camera_fusion/src/multi_camera_fusion.hpp
+++ b/perception/autoware_traffic_light_multi_camera_fusion/src/multi_camera_fusion.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef TRAFFIC_LIGHT_MULTI_CAMERA_FUSION_NODE_HPP_
-#define TRAFFIC_LIGHT_MULTI_CAMERA_FUSION_NODE_HPP_
+#ifndef MULTI_CAMERA_FUSION_HPP_
+#define MULTI_CAMERA_FUSION_HPP_
 
 #include "signal_validator.hpp"
 #include "traffic_light_multi_camera_fusion_process.hpp"
@@ -203,4 +203,4 @@ private:
   std::unique_ptr<autoware_utils::DiagnosticsInterface> diagnostics_interface_ptr_;
 };
 }  // namespace autoware::traffic_light
-#endif  // TRAFFIC_LIGHT_MULTI_CAMERA_FUSION_NODE_HPP_
+#endif  // MULTI_CAMERA_FUSION_HPP_

--- a/perception/autoware_traffic_light_multi_camera_fusion/src/traffic_light_multi_camera_fusion_node.cpp
+++ b/perception/autoware_traffic_light_multi_camera_fusion/src/traffic_light_multi_camera_fusion_node.cpp
@@ -88,8 +88,9 @@ void MultiCameraFusionNode::traffic_signal_roi_callback(
   rclcpp::Time stamp(roi_msg->header.stamp);
 
   const MultiCameraFusionResult result = fusion_.fuse(*cam_info_msg, *roi_msg, *signal_msg);
-  for (const auto & warning : result.warnings) {
-    RCLCPP_WARN_STREAM(get_logger(), warning);
+  for (const auto & unmapped_id : result.unmapped_traffic_light_ids) {
+    RCLCPP_WARN_STREAM(
+      get_logger(), "Found Traffic Light Id = " << unmapped_id << " which is not defined in Map");
   }
   signal_pub_->publish(result.traffic_light_groups);
 

--- a/perception/autoware_traffic_light_multi_camera_fusion/src/traffic_light_multi_camera_fusion_node.cpp
+++ b/perception/autoware_traffic_light_multi_camera_fusion/src/traffic_light_multi_camera_fusion_node.cpp
@@ -1,0 +1,131 @@
+// Copyright 2023 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "traffic_light_multi_camera_fusion_node.hpp"
+
+#include <autoware/lanelet2_utils/conversion.hpp>
+
+#include <functional>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace autoware::traffic_light
+{
+
+MultiCameraFusionNode::MultiCameraFusionNode(const rclcpp::NodeOptions & node_options)
+: Node("traffic_light_multi_camera_fusion", node_options)
+{
+  using std::placeholders::_1;
+  using std::placeholders::_2;
+  using std::placeholders::_3;
+
+  std::vector<std::string> camera_namespaces =
+    this->declare_parameter<std::vector<std::string>>("camera_namespaces");
+  const bool is_approximate_sync = this->declare_parameter<bool>("approximate_sync");
+
+  fusion_config_.message_lifespan = this->declare_parameter<double>("message_lifespan");
+  fusion_config_.prior_log_odds = this->declare_parameter<double>("prior_log_odds");
+
+  fusion_config_.use_signal_consistency_check =
+    this->declare_parameter<bool>("signal_consistency_check.enable");
+  fusion_config_.publish_partial_matched_signal =
+    this->declare_parameter<bool>("signal_consistency_check.publish_partial_matched_signal");
+
+  fusion_ = MultiCameraFusion(fusion_config_);
+
+  for (const std::string & camera_ns : camera_namespaces) {
+    std::string signal_topic = camera_ns + "/classification/traffic_signals";
+    std::string roi_topic = camera_ns + "/detection/rois";
+    std::string cam_info_topic = camera_ns + "/camera_info";
+    roi_subs_.emplace_back(
+      new mf::Subscriber<RoiArrayType>(this, roi_topic, rclcpp::QoS{1}.get_rmw_qos_profile()));
+    signal_subs_.emplace_back(new mf::Subscriber<SignalArrayType>(
+      this, signal_topic, rclcpp::QoS{1}.get_rmw_qos_profile()));
+    cam_info_subs_.emplace_back(new mf::Subscriber<CamInfoType>(
+      this, cam_info_topic, rclcpp::SensorDataQoS().get_rmw_qos_profile()));
+    if (is_approximate_sync == false) {
+      exact_sync_subs_.emplace_back(new ExactSync(
+        ExactSyncPolicy(10), *(cam_info_subs_.back()), *(roi_subs_.back()),
+        *(signal_subs_.back())));
+      exact_sync_subs_.back()->registerCallback(
+        std::bind(&MultiCameraFusionNode::traffic_signal_roi_callback, this, _1, _2, _3));
+    } else {
+      approximate_sync_subs_.emplace_back(new ApproximateSync(
+        ApproximateSyncPolicy(10), *(cam_info_subs_.back()), *(roi_subs_.back()),
+        *(signal_subs_.back())));
+      approximate_sync_subs_.back()->registerCallback(
+        std::bind(&MultiCameraFusionNode::traffic_signal_roi_callback, this, _1, _2, _3));
+    }
+  }
+
+  map_sub_ = create_subscription<autoware_map_msgs::msg::LaneletMapBin>(
+    "~/input/vector_map", rclcpp::QoS{1}.transient_local(),
+    [this](const autoware_map_msgs::msg::LaneletMapBin::ConstSharedPtr msg) {
+      this->map_callback(msg);
+    });
+  signal_pub_ = create_publisher<NewSignalArrayType>("~/output/traffic_signals", rclcpp::QoS{1});
+
+  diagnostics_interface_ptr_ =
+    std::make_unique<autoware_utils::DiagnosticsInterface>(this, "traffic light conflict status");
+}
+
+void MultiCameraFusionNode::traffic_signal_roi_callback(
+  const CamInfoType::ConstSharedPtr cam_info_msg, const RoiArrayType::ConstSharedPtr roi_msg,
+  const SignalArrayType::ConstSharedPtr signal_msg)
+{
+  rclcpp::Time stamp(roi_msg->header.stamp);
+
+  const MultiCameraFusionResult result = fusion_.fuse(*cam_info_msg, *roi_msg, *signal_msg);
+  for (const auto & warning : result.warnings) {
+    RCLCPP_WARN_STREAM(get_logger(), warning);
+  }
+  signal_pub_->publish(result.traffic_light_groups);
+
+  if (result.conflicted_regulatory_element_status.size() > 0) {
+    publish_diagnostics(result.conflicted_regulatory_element_status, stamp);
+  }
+}
+
+void MultiCameraFusionNode::map_callback(
+  const autoware_map_msgs::msg::LaneletMapBin::ConstSharedPtr input_msg)
+{
+  fusion_config_.lanelet_map_ptr = autoware::experimental::lanelet2_utils::remove_const(
+    autoware::experimental::lanelet2_utils::from_autoware_map_msgs(*input_msg));
+  fusion_ = MultiCameraFusion(fusion_config_);
+}
+
+void MultiCameraFusionNode::publish_diagnostics(
+  const std::vector<ConflictInfo> & conflicted_regulatory_element_status, rclcpp::Time stamp)
+{
+  diagnostics_interface_ptr_->clear();
+
+  // publish only conflicted RE status
+  for (const auto & conflicted_re : conflicted_regulatory_element_status) {
+    diagnostics_interface_ptr_->add_key_value(
+      std::to_string(static_cast<int64_t>(conflicted_re.id)),
+      static_cast<int>(conflicted_re.conflict_type));
+  }
+
+  diagnostics_interface_ptr_->update_level_and_message(
+    diagnostic_msgs::msg::DiagnosticStatus::WARN,
+    "Detected traffic light signal conflict in the fusion process.");
+
+  diagnostics_interface_ptr_->publish(stamp);
+}
+
+}  // namespace autoware::traffic_light
+
+#include <rclcpp_components/register_node_macro.hpp>
+RCLCPP_COMPONENTS_REGISTER_NODE(autoware::traffic_light::MultiCameraFusionNode)

--- a/perception/autoware_traffic_light_multi_camera_fusion/src/traffic_light_multi_camera_fusion_node.hpp
+++ b/perception/autoware_traffic_light_multi_camera_fusion/src/traffic_light_multi_camera_fusion_node.hpp
@@ -1,0 +1,92 @@
+// Copyright 2023 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef TRAFFIC_LIGHT_MULTI_CAMERA_FUSION_NODE_HPP_
+#define TRAFFIC_LIGHT_MULTI_CAMERA_FUSION_NODE_HPP_
+
+#include "multi_camera_fusion.hpp"
+
+#include <autoware_utils/ros/diagnostics_interface.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+#include <autoware_map_msgs/msg/lanelet_map_bin.hpp>
+#include <autoware_perception_msgs/msg/traffic_light_group.hpp>
+#include <autoware_perception_msgs/msg/traffic_light_group_array.hpp>
+#include <sensor_msgs/msg/camera_info.hpp>
+#include <tier4_perception_msgs/msg/traffic_light.hpp>
+#include <tier4_perception_msgs/msg/traffic_light_array.hpp>
+#include <tier4_perception_msgs/msg/traffic_light_roi.hpp>
+#include <tier4_perception_msgs/msg/traffic_light_roi_array.hpp>
+
+#include <message_filters/subscriber.h>
+#include <message_filters/sync_policies/approximate_time.h>
+#include <message_filters/sync_policies/exact_time.h>
+#include <message_filters/synchronizer.h>
+
+#include <memory>
+#include <utility>
+#include <vector>
+
+namespace autoware::traffic_light
+{
+namespace mf = message_filters;
+
+class MultiCameraFusionNode : public rclcpp::Node
+{
+public:
+  using CamInfoType = sensor_msgs::msg::CameraInfo;
+  using RoiType = tier4_perception_msgs::msg::TrafficLightRoi;
+  using SignalType = tier4_perception_msgs::msg::TrafficLight;
+  using SignalArrayType = tier4_perception_msgs::msg::TrafficLightArray;
+  using RoiArrayType = tier4_perception_msgs::msg::TrafficLightRoiArray;
+  using IdType = tier4_perception_msgs::msg::TrafficLightRoi::_traffic_light_id_type;
+  using NewSignalType = autoware_perception_msgs::msg::TrafficLightGroup;
+  using NewSignalArrayType = autoware_perception_msgs::msg::TrafficLightGroupArray;
+
+  using RecordArrayType = std::pair<RoiArrayType, SignalArrayType>;
+
+  explicit MultiCameraFusionNode(const rclcpp::NodeOptions & node_options);
+
+private:
+  void traffic_signal_roi_callback(
+    const CamInfoType::ConstSharedPtr cam_info_msg, const RoiArrayType::ConstSharedPtr roi_msg,
+    const SignalArrayType::ConstSharedPtr signal_msg);
+
+  void map_callback(const autoware_map_msgs::msg::LaneletMapBin::ConstSharedPtr input_msg);
+
+  void publish_diagnostics(
+    const std::vector<ConflictInfo> & conflicted_regulatory_element_status, rclcpp::Time stamp);
+
+  using ExactSyncPolicy = mf::sync_policies::ExactTime<CamInfoType, RoiArrayType, SignalArrayType>;
+  using ExactSync = mf::Synchronizer<ExactSyncPolicy>;
+  using ApproximateSyncPolicy =
+    mf::sync_policies::ApproximateTime<CamInfoType, RoiArrayType, SignalArrayType>;
+  using ApproximateSync = mf::Synchronizer<ApproximateSyncPolicy>;
+
+  std::vector<std::unique_ptr<mf::Subscriber<SignalArrayType>>> signal_subs_;
+  std::vector<std::unique_ptr<mf::Subscriber<RoiArrayType>>> roi_subs_;
+  std::vector<std::unique_ptr<mf::Subscriber<CamInfoType>>> cam_info_subs_;
+  std::vector<std::unique_ptr<ExactSync>> exact_sync_subs_;
+  std::vector<std::unique_ptr<ApproximateSync>> approximate_sync_subs_;
+  rclcpp::Subscription<autoware_map_msgs::msg::LaneletMapBin>::SharedPtr map_sub_;
+
+  rclcpp::Publisher<NewSignalArrayType>::SharedPtr signal_pub_;
+
+  MultiCameraFusionConfig fusion_config_{};
+  MultiCameraFusion fusion_{};
+
+  std::unique_ptr<autoware_utils::DiagnosticsInterface> diagnostics_interface_ptr_;
+};
+}  // namespace autoware::traffic_light
+#endif  // TRAFFIC_LIGHT_MULTI_CAMERA_FUSION_NODE_HPP_

--- a/perception/autoware_traffic_light_multi_camera_fusion/test/test_traffic_light_multi_camera_fusion_node.cpp
+++ b/perception/autoware_traffic_light_multi_camera_fusion/test/test_traffic_light_multi_camera_fusion_node.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "../src/multi_camera_fusion.hpp"
+#include "../src/traffic_light_multi_camera_fusion_node.hpp"
 
 #include <autoware/lanelet2_utils/conversion.hpp>
 #include <autoware_lanelet2_extension/regulatory_elements/autoware_traffic_light.hpp>
@@ -36,7 +36,7 @@
 #include <thread>
 #include <vector>
 
-using autoware::traffic_light::MultiCameraFusion;
+using autoware::traffic_light::MultiCameraFusionNode;
 using autoware_map_msgs::msg::LaneletMapBin;
 using autoware_perception_msgs::msg::TrafficLightGroupArray;
 using sensor_msgs::msg::CameraInfo;
@@ -109,7 +109,7 @@ protected:
       "signal_consistency_check.publish_partial_matched_signal",
       options.publish_partial_matched_signal);
 
-    node_ = std::make_shared<MultiCameraFusion>(node_options);
+    node_ = std::make_shared<MultiCameraFusionNode>(node_options);
     executor_->add_node(node_);
   }
 
@@ -221,7 +221,7 @@ protected:
     publish_signal(camera_index, stamp, frame_id, traffic_light_id, color, confidence);
   }
 
-  std::shared_ptr<MultiCameraFusion> node_;
+  std::shared_ptr<MultiCameraFusionNode> node_;
   std::shared_ptr<rclcpp::Node> test_node_;
   std::shared_ptr<rclcpp::executors::SingleThreadedExecutor> executor_;
 

--- a/perception/autoware_traffic_light_multi_camera_fusion/test/test_traffic_light_multi_camera_fusion_node.cpp
+++ b/perception/autoware_traffic_light_multi_camera_fusion/test/test_traffic_light_multi_camera_fusion_node.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "../src/traffic_light_multi_camera_fusion_node.hpp"
+#include "../src/multi_camera_fusion.hpp"
 
 #include <autoware/lanelet2_utils/conversion.hpp>
 #include <autoware_lanelet2_extension/regulatory_elements/autoware_traffic_light.hpp>

--- a/perception/autoware_traffic_light_multi_camera_fusion/test/test_utils.cpp
+++ b/perception/autoware_traffic_light_multi_camera_fusion/test/test_utils.cpp
@@ -20,7 +20,7 @@
 
 #include <unordered_map>
 
-TEST(is_unknown, normal)
+TEST(IsUnknown, Normal)
 {
   tier4_perception_msgs::msg::TrafficLight signal;
   tier4_perception_msgs::msg::TrafficLightElement element;
@@ -40,7 +40,7 @@ TEST(is_unknown, normal)
   EXPECT_FALSE(autoware::traffic_light::utils::is_unknown(signal));
 }
 
-TEST(at_or, normal)
+TEST(AtOr, Normal)
 {
   std::unordered_map<int, int> map;
   map[1] = 2;
@@ -54,7 +54,7 @@ namespace same_camera
 {
 
 // first condition
-TEST(compare_record, timestamp_check)
+TEST(CompareRecord, TimestampCheck)
 {
   // r1 is newer
   autoware::traffic_light::utils::FusionRecord r1;
@@ -158,7 +158,7 @@ TEST(compare_record, timestamp_check)
 }
 
 // second condition
-TEST(compare_record, unknown_check)
+TEST(CompareRecord, UnknownCheck)
 {
   // r1 is unknown
   autoware::traffic_light::utils::FusionRecord r1;
@@ -311,7 +311,7 @@ TEST(compare_record, unknown_check)
 }
 
 // third condition
-TEST(compare_record, visible_check)
+TEST(CompareRecord, VisibleCheck)
 {
   // r1 is better visible on top left
   autoware::traffic_light::utils::FusionRecord r1;
@@ -518,7 +518,7 @@ TEST(compare_record, visible_check)
 }
 
 // fourth condition
-TEST(compare_record, confidence_check)
+TEST(CompareRecord, ConfidenceCheck)
 {
   // r1 is higher confidence
   autoware::traffic_light::utils::FusionRecord r1;
@@ -629,7 +629,7 @@ namespace different_camera
 // first condition is nothing in different camera
 
 // second condition
-TEST(compare_record, unknown_check)
+TEST(CompareRecord, UnknownCheck)
 {
   // r1 is unknown
   autoware::traffic_light::utils::FusionRecord r1;
@@ -782,7 +782,7 @@ TEST(compare_record, unknown_check)
 }
 
 // third condition
-TEST(compare_record, visible_check)
+TEST(CompareRecord, VisibleCheck)
 {
   // r1 is better visible on top left
   autoware::traffic_light::utils::FusionRecord r1;
@@ -989,7 +989,7 @@ TEST(compare_record, visible_check)
 }
 
 // fourth condition
-TEST(compare_record, confidence_check)
+TEST(CompareRecord, ConfidenceCheck)
 {
   // r1 is higher confidence
   autoware::traffic_light::utils::FusionRecord r1;
@@ -1094,7 +1094,7 @@ TEST(compare_record, confidence_check)
 
 }  // namespace different_camera
 
-TEST(cal_visible_score, normal)
+TEST(CalVisibleScore, Normal)
 {
   // visible
   autoware::traffic_light::utils::FusionRecord r1;


### PR DESCRIPTION
## Description

Refactor `autoware_traffic_light_multi_camera_fusion` to extract the core fusion logic from the ROS2 Node into a standalone `MultiCameraFusion` class. The Node becomes a thin wrapper that only owns ROS2 plumbing (subscribers, publisher, diagnostics), and per-frame processing is delegated to the new class via `fuse(cam_info, rois, signals)`.

This makes the fusion logic unit-testable in isolation (no `rclcpp::Node` / `rclcpp::Logger` dependency), which is the prerequisite for adding unit tests in a follow-up PR.

### Commit structure (intentionally split for reviewability)

| # | Commit | Purpose |
|---|--------|---------|
| 1 | [refactor: rename node files to multi_camera_fusion](https://github.com/autowarefoundation/autoware_universe/commit/6fd0b6a37d4636ade52925c79b9c6899e2ca4350) | Pure rename. `git` detects as 99% / 97% rename. Only include paths, include guards, CMakeLists, and the test include path are updated to keep the build green. |
| 2 | [refactor: extract MultiCameraFusion logic](https://github.com/autowarefoundation/autoware_universe/commit/c2c1d8404414cc1f1fb2065b397df1dfdfaebfa6) | Splits the renamed file into `multi_camera_fusion.{cpp,hpp}` (pure-logic core class) and a freshly created `traffic_light_multi_camera_fusion_node.{cpp,hpp}` (Node wrapper). |

Reviewing commit 1 in isolation verifies that no logic moved; reviewing commit 2 then shows the symmetric "what was removed from the core file" vs. "what landed in the new Node file."

## Related links

**Parent Issue:**

- Link

## How was this PR tested?

`colcon build --packages-select autoware_traffic_light_multi_camera_fusion` and `colcon test ...` both pass:

- 45 existing unit tests (`autoware_traffic_light_multi_camera_fusion_test`)
- 3 integration tests (`autoware_traffic_light_multi_camera_fusion_node_test`)
- All linters: copyright, cppcheck, lint_cmake, xmllint, clang-format, cpplint, Lint Autoware System Design Format

## Notes for reviewers

- The plugin class registered in `CMakeLists.txt` and `design/TrafficLightMultiCameraFusion.node.yaml` is updated from `autoware::traffic_light::MultiCameraFusion` to `autoware::traffic_light::MultiCameraFusionNode`. The executable name (`traffic_light_multi_camera_fusion_node`) is unchanged, so launch files referring to the executable are unaffected.
- Behavior is preserved end-to-end; all pre-existing integration tests pass unmodified.

## Interface changes

None 

## Effects on system behavior

None
