### PR TITLE
feat: update `autoware_msgs` from `1.12.0` to `1.13.0`

### DIFF
--- a/build_depends_stable.repos
+++ b/build_depends_stable.repos
@@ -3,7 +3,7 @@ repositories:
   core/autoware_msgs:
     type: git
     url: https://github.com/autowarefoundation/autoware_msgs.git
-    version: 1.12.0
+    version: 1.13.0
   # TODO (isamu-takagi): Use a released version when autoware_universe uses a released version.
   core/autoware_adapi_msgs:
     type: git


### PR DESCRIPTION
## Description

This PR upgrade the version of `autoware_msgs` to 1.13.0. By this update, `autoware_msgs/autoware_vehicle_msgs` contains new messages:
- `ActuationCommand.msg`
- `ActuationCommandStamped.msg`
- `ActuationReport.msg`
- `ActuationReportStamped.msg`

This is a prerequisite for the following PR which replaces `tier4_vehicle_msgs` usage in `autoware_simple_planning_simulator` with `autoware_vehicle_msgs`.
- https://github.com/autowarefoundation/autoware_universe/pull/12530

## Related links

- https://github.com/orgs/autowarefoundation/discussions/6892
- https://github.com/autowarefoundation/autoware_msgs/pull/165

## How was this PR tested?

We will see if the required CIs succeed as this fix applies the changes for a file which is used only for required CIs.

## Interface changes

No topic or parameter changes. 

## Effects on system behavior

- `autoware_universe` will be able to use the added messages which are listed in "Description" section above.
- No runtime behavior change expected beyond message package migration.