### PR TITLE
fix(autoware_carla_interface): skip redundant world reload

### DIFF
--- a/simulator/autoware_carla_interface/src/autoware_carla_interface/carla_autoware.py
+++ b/simulator/autoware_carla_interface/src/autoware_carla_interface/carla_autoware.py
@@ -135,7 +135,7 @@ class InitializeInterface(object):
     def load_world(self):
         client = carla.Client(self.local_host, self.port)
         client.set_timeout(self.timeout)
-        client.load_world(self.carla_map)
+        client.load_world_if_different(self.carla_map)
 
         # Wait for the world to be fully loaded
         # This is critical for non-default maps that need time to load


### PR DESCRIPTION
## Description
Use CARLA's `load_world_if_different()` when initializing the CARLA interface so the world is not recreated when the requested map is already loaded.

This keeps the existing behavior when a different map is requested, while avoiding an unnecessary session reset for externally preloaded CARLA workflows.

## Tests
- Confirmed `carla.Client.load_world_if_different` exists in `carla==0.9.15` and `0.9.16`
- `python3 -m py_compile simulator/autoware_carla_interface/src/autoware_carla_interface/carla_autoware.py`