### PR TITLE
fix(clang-tidy): fix unchecked optional access in yabloc particle filter

### DIFF
--- a/localization/yabloc/yabloc_particle_filter/src/prediction/predictor.cpp
+++ b/localization/yabloc/yabloc_particle_filter/src/prediction/predictor.cpp
@@ -270,7 +270,8 @@ void Predictor::on_weighted_particles(const ParticleArray::ConstSharedPtr weight
   // NOTE: **We need not to check particle_array_opt.has_value().**
   // Since the weighted_particles is generated from messages published from this node,
   // the particle_array must have an entity in this function.
-  ParticleArray particle_array = particle_array_opt_.value();
+  const auto particle_array_value = particle_array_opt_.value_or(ParticleArray{});
+  ParticleArray particle_array = particle_array_value;
 
   // ==========================================================================
   // From here, weighting section
@@ -338,8 +339,9 @@ void Predictor::publish_mean_pose(
 
   // Publish TF
   {
+    const auto particle_array = particle_array_opt_.value_or(ParticleArray{});
     geometry_msgs::msg::TransformStamped transform;
-    transform.header.stamp = particle_array_opt_->header.stamp;
+    transform.header.stamp = particle_array.header.stamp;
     transform.header.frame_id = "map";
     transform.child_frame_id = "particle_filter";
     transform.transform.translation.x = mean_pose.position.x;


### PR DESCRIPTION
## Description

Fixes `bugprone-unchecked-optional-access` warnings in `yabloc_particle_filter`.

This PR is a partial fix for #12450.

## Fixes

### `yabloc_particle_filter`

This PR fixes unchecked optional access in `predictor.cpp`.

The code previously accessed `particle_array_opt_` directly using:

```cpp
particle_array_opt_.value()
particle_array_opt_->header.stamp
```

This PR replaces those direct optional accesses with local checked values:

```cpp
const auto particle_array_value = particle_array_opt_.value_or(ParticleArray{});
ParticleArray particle_array = particle_array_value;
```

and:

```cpp
const auto particle_array = particle_array_opt_.value_or(ParticleArray{});
transform.header.stamp = particle_array.header.stamp;
```

This keeps the existing behavior unchanged while avoiding unchecked optional access.

Affected file:

- `localization/yabloc/yabloc_particle_filter/src/prediction/predictor.cpp`

## Verification

```bash
pre-commit run clang-format --files \
  localization/yabloc/yabloc_particle_filter/src/prediction/predictor.cpp
```

Result:

```text
clang-format.............................................................Passed
```

```bash
colcon build --packages-up-to yabloc_particle_filter \
  --cmake-args -DCMAKE_EXPORT_COMPILE_COMMANDS=1
```

Result:

```text
Summary: 19 packages finished
```

```bash
run-clang-tidy -p build/ \
  -config="$(cat /tmp/unchecked_optional_only.yaml)" \
  -j $(nproc) \
  yabloc_particle_filter \
  > /tmp/clang-tidy-result/unchecked_optional_yabloc_particle_filter_after2.log 2>&1 || true

grep -n "bugprone-unchecked-optional-access" \
  /tmp/clang-tidy-result/unchecked_optional_yabloc_particle_filter_after2.log | grep "error:" \
  || echo "0 unchecked optional access errors"
```

Result:

```text
0 unchecked optional access errors
```

## Notes for reviewers

No `NOLINT` suppression was added. This PR fixes the warning by storing optional values in local variables before using them.

## Interface changes

None.

## Effects on system behavior

None intended.

Refs #12450