### PR TITLE
fix(autoware_multi_object_tracker): bicycle motion model bug fix

### DIFF
--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/motion_model/bicycle_motion_model.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/motion_model/bicycle_motion_model.hpp
@@ -59,8 +59,7 @@ private:
     double wheel_pos_ratio =
       (lf_ratio + lr_ratio) /
       lr_ratio;  // [-] distance ratio of the wheel base over center-to-rear-wheel
-    double wheel_pos_ratio_sq =
-      wheel_pos_ratio * wheel_pos_ratio;  // [-] square of wheel_pos_ratio
+    double wheel_pos_ratio_sq = wheel_pos_ratio * wheel_pos_ratio;  // [-] square of wheel_pos_ratio
     double wheel_gamma_front =
       (0.5 - lf_ratio) / (lf_ratio + lr_ratio);  // [-] protrusion from front wheel position ratio
     double wheel_gamma_rear =

--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/motion_model/bicycle_motion_model.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/motion_model/bicycle_motion_model.hpp
@@ -59,6 +59,8 @@ private:
     double wheel_pos_ratio =
       (lf_ratio + lr_ratio) /
       lr_ratio;  // [-] distance ratio of the wheel base over center-to-rear-wheel
+    double wheel_pos_ratio_sq =
+      wheel_pos_ratio * wheel_pos_ratio;  // [-] square of wheel_pos_ratio
     double wheel_gamma_front =
       (0.5 - lf_ratio) / (lf_ratio + lr_ratio);  // [-] protrusion from front wheel position ratio
     double wheel_gamma_rear =

--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/motion_model/bicycle_motion_model.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/motion_model/bicycle_motion_model.hpp
@@ -53,7 +53,6 @@ private:
     double wheel_base_ratio_inv =
       1 / (lf_ratio + lr_ratio);  // [-] inverse of the sum of lf_ratio and lr_ratio
     double max_vel = 27.8;        // [m/s] maximum velocity, 100km/h
-    double max_slip = 0.5236;     // [rad] maximum slip angle, 30deg
     double max_reverse_vel =
       -1.389;  // [m/s] maximum reverse velocity, -5km/h. The value is expected to be negative
     double wheel_pos_ratio =

--- a/perception/autoware_multi_object_tracker/lib/tracker/motion_model/bicycle_motion_model.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/motion_model/bicycle_motion_model.cpp
@@ -274,7 +274,7 @@ bool BicycleMotionModel::updateStatePoseRear(
   C(2, IDX::X2) = 1.0;
   C(3, IDX::Y2) = 1.0;
 
-  constexpr double uncertainty_multiplier = 4.0;  // additional uncertainty for unmeasured position
+  constexpr double uncertainty_multiplier = 9.0;  // additional uncertainty for unmeasured position
   Eigen::Matrix<double, DIM_Y, DIM_Y> R = Eigen::Matrix<double, DIM_Y, DIM_Y>::Zero();
   R(0, 0) = pose_cov[XYZRPY_COV_IDX::X_X];
   R(0, 1) = pose_cov[XYZRPY_COV_IDX::X_Y];

--- a/perception/autoware_multi_object_tracker/lib/tracker/motion_model/bicycle_motion_model.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/motion_model/bicycle_motion_model.cpp
@@ -454,7 +454,7 @@ bool BicycleMotionModel::limitStates()
     const double vel_long_abs = std::abs(X_t(IDX::U));
     const double vel_lat_limit_accel =
       acc_lat_max * wheel_base / std::max(vel_long_abs, vel_long_eps);
-    const double vel_lat_limit_slip = vel_long_abs * std::tan(motion_params_.max_slip);
+    const double vel_lat_limit_slip = vel_long_abs * std::tan(motion_params_.q_max_slip_angle);
     const double vel_lat_limit_adjusted =
       std::min(vel_lat_limit_accel, vel_lat_limit_slip) * motion_params_.wheel_pos_ratio;
     if (std::abs(X_t(IDX::V)) > vel_lat_limit_adjusted) {

--- a/perception/autoware_multi_object_tracker/lib/tracker/motion_model/bicycle_motion_model.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/motion_model/bicycle_motion_model.cpp
@@ -455,8 +455,7 @@ bool BicycleMotionModel::limitStates()
     const double vel_lat_limit_accel =
       acc_lat_max * wheel_base / std::max(vel_long_abs, vel_long_eps);
     const double vel_lat_limit_slip = vel_long_abs * std::tan(motion_params_.q_max_slip_angle);
-    const double vel_lat_limit_adjusted =
-      std::min(vel_lat_limit_accel, vel_lat_limit_slip) * motion_params_.wheel_pos_ratio;
+    const double vel_lat_limit_adjusted = std::min(vel_lat_limit_accel, vel_lat_limit_slip);
     if (std::abs(X_t(IDX::V)) > vel_lat_limit_adjusted) {
       // limit lateral velocity
       X_t(IDX::V) = X_t(IDX::V) < 0 ? -vel_lat_limit_adjusted : vel_lat_limit_adjusted;

--- a/perception/autoware_multi_object_tracker/lib/tracker/motion_model/bicycle_motion_model.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/motion_model/bicycle_motion_model.cpp
@@ -440,13 +440,17 @@ bool BicycleMotionModel::limitStates()
   }
 
   // maximum lateral velocity by lateral acceleration limitations
-  // a_max = vel_long^2 * vel_lat / wheel_base
-  // vel_lat_limit = a_max * wheel_base / vel_long^2
+  // a_lat = vel_long * (V / wheel_base)  ->  V_limit = a_lat_max * wheel_base / |vel_long|
+  // vel_long is floored at vel_long_min to avoid div-by-zero and enforce a cap at low/zero speed
   {
     const double wheel_base = std::hypot(X_t(IDX::X2) - X_t(IDX::X1), X_t(IDX::Y2) - X_t(IDX::Y1));
-    constexpr double acc_lat_max = 9.81 * 0.5;  // [m/s^2] maximum lateral acceleration (0.5g);
-    const double vel_lat_limit = acc_lat_max * wheel_base / (X_t(IDX::U) * X_t(IDX::U));
-    const double vel_lat_limit_adjusted = vel_lat_limit * motion_params_.wheel_pos_ratio;
+    constexpr double acc_lat_max = 9.81 * 0.5;  // [m/s^2] maximum lateral acceleration (0.5g)
+    constexpr double vel_long_min = 1.0;         // [m/s] speed floor: prevents singularity and caps lat vel at low speed
+    constexpr double vel_lat_abs_max = 5.0;      // [m/s] hard absolute cap on lateral velocity
+    const double vel_long_eff = std::max(std::abs(X_t(IDX::U)), vel_long_min);
+    const double vel_lat_limit = acc_lat_max * wheel_base / vel_long_eff;
+    const double vel_lat_limit_adjusted =
+      std::min(vel_lat_limit, vel_lat_abs_max) * motion_params_.wheel_pos_ratio;
     if (std::abs(X_t(IDX::V)) > vel_lat_limit_adjusted) {
       // limit lateral velocity
       X_t(IDX::V) = X_t(IDX::V) < 0 ? -vel_lat_limit_adjusted : vel_lat_limit_adjusted;

--- a/perception/autoware_multi_object_tracker/lib/tracker/motion_model/bicycle_motion_model.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/motion_model/bicycle_motion_model.cpp
@@ -533,7 +533,6 @@ bool BicycleMotionModel::predictStateStep(const double dt, KalmanFilter & ekf) c
   const double & vel_long = X_t(IDX::U);
   const double & vel_lat = X_t(IDX::V);
 
-  const double yaw = std::atan2(y2 - y1, x2 - x1);
   const double wheel_base = std::hypot(x2 - x1, y2 - y1);
   const double sin_yaw = (y2 - y1) / wheel_base;
   const double cos_yaw = (x2 - x1) / wheel_base;
@@ -608,18 +607,21 @@ bool BicycleMotionModel::predictStateStep(const double dt, KalmanFilter & ekf) c
   const double q_cov_long2 = q_cov_long + motion_params_.q_cov_length * dt2;
   const double q_cov_lat2 = q_cov_lat + q_stddev_head * q_stddev_head;
 
+  const double sin_yaw_sq = sin_yaw * sin_yaw;
+  const double cos_yaw_sq = cos_yaw * cos_yaw;
+  const double sin_cos_yaw = sin_yaw * cos_yaw;
+
   StateMat Q;
   Q.setZero();
-  const double sin_2yaw = std::sin(2.0 * yaw);
-  Q(IDX::X1, IDX::X1) = (q_cov_long * cos_yaw * cos_yaw + q_cov_lat * sin_yaw * sin_yaw);
-  Q(IDX::X1, IDX::Y1) = (0.5f * (q_cov_long - q_cov_lat) * sin_2yaw);
+  Q(IDX::X1, IDX::X1) = (q_cov_long * cos_yaw_sq + q_cov_lat * sin_yaw_sq);
+  Q(IDX::X1, IDX::Y1) = ((q_cov_long - q_cov_lat) * sin_cos_yaw);
   Q(IDX::Y1, IDX::X1) = Q(IDX::X1, IDX::Y1);
-  Q(IDX::Y1, IDX::Y1) = (q_cov_long * sin_yaw * sin_yaw + q_cov_lat * cos_yaw * cos_yaw);
+  Q(IDX::Y1, IDX::Y1) = (q_cov_long * sin_yaw_sq + q_cov_lat * cos_yaw_sq);
 
-  Q(IDX::X2, IDX::X2) = (q_cov_long2 * cos_yaw * cos_yaw + q_cov_lat2 * sin_yaw * sin_yaw);
-  Q(IDX::X2, IDX::Y2) = (0.5f * (q_cov_long2 - q_cov_lat2) * sin_2yaw);
+  Q(IDX::X2, IDX::X2) = (q_cov_long2 * cos_yaw_sq + q_cov_lat2 * sin_yaw_sq);
+  Q(IDX::X2, IDX::Y2) = ((q_cov_long2 - q_cov_lat2) * sin_cos_yaw);
   Q(IDX::Y2, IDX::X2) = Q(IDX::X2, IDX::Y2);
-  Q(IDX::Y2, IDX::Y2) = (q_cov_long2 * sin_yaw * sin_yaw + q_cov_lat2 * cos_yaw * cos_yaw);
+  Q(IDX::Y2, IDX::Y2) = (q_cov_long2 * sin_yaw_sq + q_cov_lat2 * cos_yaw_sq);
 
   // covariance between X1 and X2, Y1 and Y2, shares the same covariance of rear axle
   constexpr double cross_coefficient =
@@ -663,6 +665,9 @@ bool BicycleMotionModel::getPredictedState(
   const double wheel_base_inv_sq = wheel_base_inv * wheel_base_inv;
   const double sin_yaw = (X(IDX::Y2) - X(IDX::Y1)) * wheel_base_inv;
   const double cos_yaw = (X(IDX::X2) - X(IDX::X1)) * wheel_base_inv;
+  const double sin_yaw_sq = sin_yaw * sin_yaw;
+  const double cos_yaw_sq = cos_yaw * cos_yaw;
+  const double sin_cos_yaw = sin_yaw * cos_yaw;
 
   // set position
   pose.position.x = (X(IDX::X1) * motion_params_.lf_ratio + X(IDX::X2) * motion_params_.lr_ratio) *
@@ -693,9 +698,15 @@ bool BicycleMotionModel::getPredictedState(
   pose_cov[XYZRPY_COV_IDX::X_Y] = P(IDX::X1, IDX::Y1);
   pose_cov[XYZRPY_COV_IDX::Y_X] = P(IDX::Y1, IDX::X1);
   pose_cov[XYZRPY_COV_IDX::Y_Y] = P(IDX::Y1, IDX::Y1);
+  // Jacobian: d(yaw)/d[X1,Y1,X2,Y2] = (1/L)*[sin_yaw, -cos_yaw, -sin_yaw, cos_yaw]
+  // YAW_YAW = J * P_sub * J^T (full 4x4 block, P symmetric so off-diag terms double)
   pose_cov[XYZRPY_COV_IDX::YAW_YAW] =
-    (P(IDX::X2, IDX::X2) * sin_yaw * sin_yaw + P(IDX::Y2, IDX::Y2) * cos_yaw * cos_yaw) *
-    wheel_base_inv_sq;
+    wheel_base_inv_sq *
+    (sin_yaw_sq * P(IDX::X1, IDX::X1) - 2.0 * sin_cos_yaw * P(IDX::X1, IDX::Y1) -
+     2.0 * sin_yaw_sq * P(IDX::X1, IDX::X2) + 2.0 * sin_cos_yaw * P(IDX::X1, IDX::Y2) +
+     cos_yaw_sq * P(IDX::Y1, IDX::Y1) + 2.0 * sin_cos_yaw * P(IDX::Y1, IDX::X2) -
+     2.0 * cos_yaw_sq * P(IDX::Y1, IDX::Y2) + sin_yaw_sq * P(IDX::X2, IDX::X2) -
+     2.0 * sin_cos_yaw * P(IDX::X2, IDX::Y2) + cos_yaw_sq * P(IDX::Y2, IDX::Y2));
   pose_cov[XYZRPY_COV_IDX::Z_Z] = default_cov;
   pose_cov[XYZRPY_COV_IDX::ROLL_ROLL] = default_cov;
   pose_cov[XYZRPY_COV_IDX::PITCH_PITCH] = default_cov;

--- a/perception/autoware_multi_object_tracker/lib/tracker/motion_model/bicycle_motion_model.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/motion_model/bicycle_motion_model.cpp
@@ -67,6 +67,7 @@ void BicycleMotionModel::setMotionParams(
 
   motion_params_.wheel_pos_ratio =
     (motion_params_.lf_ratio + motion_params_.lr_ratio) / motion_params_.lr_ratio;
+  motion_params_.wheel_pos_ratio_sq = motion_params_.wheel_pos_ratio * motion_params_.wheel_pos_ratio;
   motion_params_.wheel_gamma_front =
     (0.5 - motion_params_.lf_ratio) / (motion_params_.lf_ratio + motion_params_.lr_ratio);
   motion_params_.wheel_gamma_rear =
@@ -106,7 +107,7 @@ bool BicycleMotionModel::initialize(
   P(IDX::Y2, IDX::X2) = pose_cov[XYZRPY_COV_IDX::Y_X];
   P(IDX::Y2, IDX::Y2) = pose_cov[XYZRPY_COV_IDX::Y_Y];
   P(IDX::U, IDX::U) = vel_long_cov;
-  P(IDX::V, IDX::V) = vel_lat_cov * motion_params_.wheel_pos_ratio;
+  P(IDX::V, IDX::V) = vel_lat_cov * motion_params_.wheel_pos_ratio_sq;
 
   return MotionModel::initialize(time, X, P);
 }
@@ -239,7 +240,7 @@ bool BicycleMotionModel::updateStatePoseHeadVel(
   R(3, 2) = pose_cov[XYZRPY_COV_IDX::Y_X];
   R(3, 3) = pose_cov[XYZRPY_COV_IDX::Y_Y];
   R(4, 4) = twist_cov[XYZRPY_COV_IDX::X_X];
-  R(5, 5) = twist_cov[XYZRPY_COV_IDX::Y_Y] * motion_params_.wheel_pos_ratio;
+  R(5, 5) = twist_cov[XYZRPY_COV_IDX::Y_Y] * motion_params_.wheel_pos_ratio_sq;
 
   return ekf_.update(Y, C, R);
 }
@@ -659,6 +660,8 @@ bool BicycleMotionModel::getPredictedState(
   const double wheel_base = std::hypot(X(IDX::X2) - X(IDX::X1), X(IDX::Y2) - X(IDX::Y1));
   const double wheel_base_inv = 1.0 / wheel_base;
   const double wheel_base_inv_sq = wheel_base_inv * wheel_base_inv;
+  const double sin_yaw = (X(IDX::Y2) - X(IDX::Y1)) * wheel_base_inv;
+  const double cos_yaw = (X(IDX::X2) - X(IDX::X1)) * wheel_base_inv;
 
   // set position
   pose.position.x = (X(IDX::X1) * motion_params_.lf_ratio + X(IDX::X2) * motion_params_.lr_ratio) *
@@ -689,18 +692,16 @@ bool BicycleMotionModel::getPredictedState(
   pose_cov[XYZRPY_COV_IDX::X_Y] = P(IDX::X1, IDX::Y1);
   pose_cov[XYZRPY_COV_IDX::Y_X] = P(IDX::Y1, IDX::X1);
   pose_cov[XYZRPY_COV_IDX::Y_Y] = P(IDX::Y1, IDX::Y1);
-  pose_cov[XYZRPY_COV_IDX::YAW_YAW] = P(IDX::X2, IDX::X2) * cos(yaw) * wheel_base_inv_sq +
-                                      P(IDX::Y2, IDX::Y2) * sin(yaw) * wheel_base_inv_sq;
+  pose_cov[XYZRPY_COV_IDX::YAW_YAW] = (P(IDX::X2, IDX::X2) * sin_yaw * sin_yaw +
+                                       P(IDX::Y2, IDX::Y2) * cos_yaw * cos_yaw) * wheel_base_inv_sq;
   pose_cov[XYZRPY_COV_IDX::Z_Z] = default_cov;
   pose_cov[XYZRPY_COV_IDX::ROLL_ROLL] = default_cov;
   pose_cov[XYZRPY_COV_IDX::PITCH_PITCH] = default_cov;
 
   // set twist covariance
   twist_cov[XYZRPY_COV_IDX::X_X] = P(IDX::U, IDX::U);
-  twist_cov[XYZRPY_COV_IDX::Y_Y] = P(IDX::V, IDX::V);
-  twist_cov[XYZRPY_COV_IDX::YAW_YAW] =
-    P(IDX::V, IDX::V) * wheel_base_inv_sq /
-    (motion_params_.wheel_pos_ratio * motion_params_.wheel_pos_ratio);
+  twist_cov[XYZRPY_COV_IDX::Y_Y] = P(IDX::V, IDX::V) / motion_params_.wheel_pos_ratio_sq;
+  twist_cov[XYZRPY_COV_IDX::YAW_YAW] = P(IDX::V, IDX::V) * wheel_base_inv_sq;
   twist_cov[XYZRPY_COV_IDX::Z_Z] = default_cov;
   twist_cov[XYZRPY_COV_IDX::ROLL_ROLL] = default_cov;
   twist_cov[XYZRPY_COV_IDX::PITCH_PITCH] = default_cov;

--- a/perception/autoware_multi_object_tracker/lib/tracker/motion_model/bicycle_motion_model.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/motion_model/bicycle_motion_model.cpp
@@ -440,13 +440,14 @@ bool BicycleMotionModel::limitStates()
   }
 
   // maximum lateral velocity by lateral acceleration limitations
-  // a_lat = vel_long * (V / wheel_base)  ->  V_limit = a_lat_max * wheel_base / |vel_long|
-  // vel_long is floored at vel_long_min to avoid div-by-zero and enforce a cap at low/zero speed
+  // a_lat = vel_long * vel_lat / wheel_base
+  // vel_lat_limit = a_lat_max * wheel_base / vel_long  (vel_long floored at vel_long_min)
   {
     const double wheel_base = std::hypot(X_t(IDX::X2) - X_t(IDX::X1), X_t(IDX::Y2) - X_t(IDX::Y1));
     constexpr double acc_lat_max = 9.81 * 0.5;  // [m/s^2] maximum lateral acceleration (0.5g)
-    constexpr double vel_long_min = 1.0;         // [m/s] speed floor: prevents singularity and caps lat vel at low speed
-    constexpr double vel_lat_abs_max = 5.0;      // [m/s] hard absolute cap on lateral velocity
+    constexpr double vel_long_min =
+      1.0;  // [m/s] speed floor: prevents singularity and caps lat vel at low speed
+    constexpr double vel_lat_abs_max = 5.0;  // [m/s] hard absolute cap on lateral velocity
     const double vel_long_eff = std::max(std::abs(X_t(IDX::U)), vel_long_min);
     const double vel_lat_limit = acc_lat_max * wheel_base / vel_long_eff;
     const double vel_lat_limit_adjusted =

--- a/perception/autoware_multi_object_tracker/lib/tracker/motion_model/bicycle_motion_model.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/motion_model/bicycle_motion_model.cpp
@@ -439,19 +439,22 @@ bool BicycleMotionModel::limitStates()
     X_t(IDX::U) = X_t(IDX::U) < 0 ? -motion_params_.max_vel : motion_params_.max_vel;
   }
 
-  // maximum lateral velocity by lateral acceleration limitations
-  // a_lat = vel_long * vel_lat / wheel_base
-  // vel_lat_limit = a_lat_max * wheel_base / vel_long  (vel_long floored at vel_long_min)
+  // maximum lateral velocity: limited by the tighter of two physical constraints
+  // (1) lateral acceleration: a_lat = vel_long * vel_lat / wheel_base
+  //     -> vel_lat_limit = a_lat_max * wheel_base / vel_long  (tighter at high speed)
+  // (2) slip angle:          slip = atan(vel_lat / vel_long) <= max_slip
+  //     -> vel_lat_limit = vel_long * tan(max_slip)           (tighter at low speed, -> 0 when
+  //     stopped)
   {
     const double wheel_base = std::hypot(X_t(IDX::X2) - X_t(IDX::X1), X_t(IDX::Y2) - X_t(IDX::Y1));
     constexpr double acc_lat_max = 9.81 * 0.5;  // [m/s^2] maximum lateral acceleration (0.5g)
-    constexpr double vel_long_min =
-      1.0;  // [m/s] speed floor: prevents singularity and caps lat vel at low speed
-    constexpr double vel_lat_abs_max = 5.0;  // [m/s] hard absolute cap on lateral velocity
-    const double vel_long_eff = std::max(std::abs(X_t(IDX::U)), vel_long_min);
-    const double vel_lat_limit = acc_lat_max * wheel_base / vel_long_eff;
+    constexpr double vel_long_eps = 1e-6;       // [m/s] epsilon to guard against division by zero
+    const double vel_long_abs = std::abs(X_t(IDX::U));
+    const double vel_lat_limit_accel =
+      acc_lat_max * wheel_base / std::max(vel_long_abs, vel_long_eps);
+    const double vel_lat_limit_slip = vel_long_abs * std::tan(motion_params_.max_slip);
     const double vel_lat_limit_adjusted =
-      std::min(vel_lat_limit, vel_lat_abs_max) * motion_params_.wheel_pos_ratio;
+      std::min(vel_lat_limit_accel, vel_lat_limit_slip) * motion_params_.wheel_pos_ratio;
     if (std::abs(X_t(IDX::V)) > vel_lat_limit_adjusted) {
       // limit lateral velocity
       X_t(IDX::V) = X_t(IDX::V) < 0 ? -vel_lat_limit_adjusted : vel_lat_limit_adjusted;

--- a/perception/autoware_multi_object_tracker/lib/tracker/motion_model/bicycle_motion_model.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/motion_model/bicycle_motion_model.cpp
@@ -67,7 +67,8 @@ void BicycleMotionModel::setMotionParams(
 
   motion_params_.wheel_pos_ratio =
     (motion_params_.lf_ratio + motion_params_.lr_ratio) / motion_params_.lr_ratio;
-  motion_params_.wheel_pos_ratio_sq = motion_params_.wheel_pos_ratio * motion_params_.wheel_pos_ratio;
+  motion_params_.wheel_pos_ratio_sq =
+    motion_params_.wheel_pos_ratio * motion_params_.wheel_pos_ratio;
   motion_params_.wheel_gamma_front =
     (0.5 - motion_params_.lf_ratio) / (motion_params_.lf_ratio + motion_params_.lr_ratio);
   motion_params_.wheel_gamma_rear =
@@ -692,8 +693,9 @@ bool BicycleMotionModel::getPredictedState(
   pose_cov[XYZRPY_COV_IDX::X_Y] = P(IDX::X1, IDX::Y1);
   pose_cov[XYZRPY_COV_IDX::Y_X] = P(IDX::Y1, IDX::X1);
   pose_cov[XYZRPY_COV_IDX::Y_Y] = P(IDX::Y1, IDX::Y1);
-  pose_cov[XYZRPY_COV_IDX::YAW_YAW] = (P(IDX::X2, IDX::X2) * sin_yaw * sin_yaw +
-                                       P(IDX::Y2, IDX::Y2) * cos_yaw * cos_yaw) * wheel_base_inv_sq;
+  pose_cov[XYZRPY_COV_IDX::YAW_YAW] =
+    (P(IDX::X2, IDX::X2) * sin_yaw * sin_yaw + P(IDX::Y2, IDX::Y2) * cos_yaw * cos_yaw) *
+    wheel_base_inv_sq;
   pose_cov[XYZRPY_COV_IDX::Z_Z] = default_cov;
   pose_cov[XYZRPY_COV_IDX::ROLL_ROLL] = default_cov;
   pose_cov[XYZRPY_COV_IDX::PITCH_PITCH] = default_cov;


### PR DESCRIPTION
## Description

Fixes several physical correctness and numerical accuracy issues in `BicycleMotionModel`.

This fixes improve yaw stability of slow vehicles, and yaw traceability of high speed vehicles.


* before

https://github.com/user-attachments/assets/bbfc18f0-81e6-48e1-938c-2480a082d6b6



* after


https://github.com/user-attachments/assets/2c45287f-c6fb-4527-93c4-7a001e1c6b36



### Critical
* Lateral velocity limit (`limitStates`)

The previous formula was dimensionally incorrect (`[m²/s³]` instead of `[m/s]`) and had no meaningful low-speed behavior.

| | Formula |
|---|---|
| Before | `v_lat_limit = a_lat_max * L / v_long²` |
| After | `v_lat_limit = min(a_lat_max * L / \|v_long\|, \|v_long\| * tan(slip_max))` |

The two constraints come from independent physical bounds:
- Lateral acceleration: `a_lat = v_long * v_lat / L  ≤  a_lat_max`  → `v_lat ≤ a_lat_max * L / |v_long|`
- Slip angle: `slip = atan(v_lat / v_long) ≤ slip_max`  → `v_lat ≤ |v_long| * tan(slip_max)`

Taking the minimum enforces the tighter one at each speed. The slip-angle term dominates at low speed and forces the limit to zero as the vehicle stops. A small epsilon (`1e-6 m/s`) guards against division by zero.



---

### Mild


* Unmeasured position uncertainty (`updateStatePoseRear`)

When only the rear position is observed, the front position noise is inflated by a scalar multiplier on the measurement covariance.

| | Multiplier | Effective bound |
|---|---|---|
| Before | `4.0` | ±2σ |
| After | `9.0` | ±3σ |

This value is as same as  `updateStatePoseFront`. The larger value reduces overconfident data association at the unobserved (front) end of the object. 

---

### Minor

* Yaw covariance error propagation (`getPredictedState`)

Yaw is `ψ = atan2(Y2−Y1, X2−X1)`. Applying the Jacobian rule gives partial derivatives `∂ψ/∂X2 = −sin(ψ)/L` and `∂ψ/∂Y2 = cos(ψ)/L`, so the variance is:

| | Formula |
|---|---|
| Before | `P_ψ = (cos(ψ) * P_X2 + sin(ψ) * P_Y2) / L²` |
| After | `P_ψ = (sin²(ψ) * P_X2 + cos²(ψ) * P_Y2) / L²` |

The previous formula used first-order terms instead of their squares, which is incorrect for variance propagation.

* Covariance scaling on input (`initialize`, `updateStatePoseHeadVel`)

The internal state `V` is physical lateral velocity scaled by `wheel_pos_ratio r` (i.e., `V = v_lat * r`). Covariance transforms as the square of the scale factor.

| | Formula |
|---|---|
| Before | `P_V = P_v_lat * r` |
| After | `P_V = P_v_lat * r²` |


* Covariance de-scaling on output (`getPredictedState`)

When publishing, the stored `P_V` must be converted back to physical units via the inverse transform.

| Output | Before | After |
|---|---|---|
| Lateral velocity `P_v_lat` | `P_V` | `P_V / r²` |
| Yaw rate `P_ω`, where `ω = V / L` | `P_V / (L² * r²)` | `P_V / L²` |

The previous yaw-rate formula applied an extra `/ r²` that double-counted the scaling already baked into `P_V`.



### 

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
tested by evaluator 
- [TIER IV INTERNAL](https://evaluation.tier4.jp/evaluation/reports/97b87881-79f7-5ea9-a327-19bbfb5adb6c?project_id=x2_dev) 
- [TIER IV INTERNAL](https://evaluation.tier4.jp/evaluation/reports/bae15d25-d319-5b48-a034-db7f2dec279a?project_id=x2_dev)

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
