### PR TITLE
test(autoware_traffic_light_arbiter): add characterization test suite

### DIFF
--- a/perception/autoware_traffic_light_arbiter/CMakeLists.txt
+++ b/perception/autoware_traffic_light_arbiter/CMakeLists.txt
@@ -18,6 +18,9 @@ if(BUILD_TESTING)
   ament_auto_add_gtest(${PROJECT_NAME}_test
     test/test_node.cpp
   )
+  ament_auto_add_gtest(${PROJECT_NAME}_characteristic_test
+    test/test_traffic_arbiter_characteristic.cpp
+  )
 endif()
 
 autoware_ament_auto_package(INSTALL_TO_SHARE launch config)

--- a/perception/autoware_traffic_light_arbiter/test/test_traffic_arbiter_characteristic.cpp
+++ b/perception/autoware_traffic_light_arbiter/test/test_traffic_arbiter_characteristic.cpp
@@ -404,32 +404,25 @@ protected:
     return group ? group->predictions.size() : SIZE_MAX;
   }
 
-  // Publish-count specs: some contracts hinge on whether the arbiter emits
-  // a message at all, independent of the content. We count callbacks on
-  // the output subscription and expose these helpers so each contract is
-  // named at the call site.
-
-  // Snapshot the running publish count. Capture before an action that
-  // should not trigger a publish, then pair with expect_no_publish_since().
-  std::size_t publish_count() const { return arbiter_publish_count_; }
+  // Publish-count specs: a handful of contracts cannot be expressed by
+  // observing the published content alone, because they hinge on whether
+  // the arbiter emitted any message at all. For those, we count callbacks
+  // on the output subscription. Tests whose spec can be expressed as
+  // "the next publish contains X (and not the value that would have been
+  // emitted if the spec were violated)" should compare content via
+  // observed_* instead — content checks are stronger because they verify
+  // the user-visible behavior.
 
   // Spec: the arbiter has not emitted any TrafficLightGroupArray yet.
-  // Used when an early-return path is expected (e.g., perception arrived
-  // before the vector_map).
+  // Content-only checks cannot distinguish "subscriber never received
+  // anything" from "subscriber received a default-constructed payload",
+  // so the count is the only direct test of the early-return contract.
   void expect_no_publish() { EXPECT_EQ(arbiter_publish_count_, 0u); }
 
   // Spec: the arbiter has emitted at least one TrafficLightGroupArray.
   // Used when the published content is expected to be empty so a
   // content-based check cannot tell "no publish" from "empty publish".
   void expect_publish_happened() { ASSERT_GE(arbiter_publish_count_, 1u); }
-
-  // Spec: the arbiter has not emitted any new TrafficLightGroupArray
-  // since `baseline`. Used after an action whose contract is "this input
-  // must be dropped before reaching arbitrateAndPublish".
-  void expect_no_publish_since(std::size_t baseline)
-  {
-    EXPECT_EQ(arbiter_publish_count_, baseline);
-  }
 
   // Wrapped in std::optional because LaneletMapBin (a generated ROS msg)
   // has no usable default constructor that can be invoked at static storage
@@ -947,22 +940,21 @@ TEST_F(ArbiterCharacteristic, multipleExternalSourcesAccumulate)
 
 TEST_F(ArbiterCharacteristic, externalDelayToleranceDropsStaleMessage)
 {
-  // Arrange: establish a perception baseline so we can detect any extra publish.
+  // Arrange: seed a perception value (RED). If the stale external below were
+  // ever accepted, the output would change to GREEN — the content check at
+  // the bottom is what pins "stale dropped".
   start_arbiter(false, "confidence");  // priority-based mode, "confidence" priority
   publish_map();
   publish_perception(make_signal_array(
     t0_, map_ids::vehicle_signal_a,
     {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)}));
-  const auto baseline = publish_count();
 
   // Act: external_delay_tolerance defaults to 5.0s; 20s in the past is well past it.
   publish_external(make_signal_array(
     offset_time(t0_, -20.0), map_ids::vehicle_signal_a,
     {make_traffic_light_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE)}));
 
-  // Assert: stale external message must be dropped before arbitrateAndPublish runs.
-  expect_no_publish_since(baseline);
-  // Last publish must still reflect the earlier perception value.
+  // Assert: the stale GREEN never propagates; the published color stays RED.
   EXPECT_EQ(observed_color(map_ids::vehicle_signal_a), TrafficLightElement::RED);
 }
 

--- a/perception/autoware_traffic_light_arbiter/test/test_traffic_arbiter_characteristic.cpp
+++ b/perception/autoware_traffic_light_arbiter/test/test_traffic_arbiter_characteristic.cpp
@@ -311,8 +311,7 @@ protected:
     executor_ = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
     executor_->add_node(arbiter_);
     executor_->add_node(test_node_);
-    // Allow discovery to settle before any publish so transient_local replay works.
-    spinFor(std::chrono::milliseconds(200));
+    spinFor(std::chrono::milliseconds(150));
   }
 
   void publishMap() { publishMap(*map_bin_); }

--- a/perception/autoware_traffic_light_arbiter/test/test_traffic_arbiter_characteristic.cpp
+++ b/perception/autoware_traffic_light_arbiter/test/test_traffic_arbiter_characteristic.cpp
@@ -1105,7 +1105,6 @@ TEST_F(ArbiterCharacteristic, externalDelayToleranceDropsStaleMessage)
     {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE)}));
   publishPerception(perception_traffic_signal);
   const auto baseline_count = arbiter_publish_count_;
-  ASSERT_GE(baseline_count, 1u);
 
   // external_delay_tolerance defaults to 5.0s; 20s in the past is well past it.
   TrafficLightGroupArray stale_external_traffic_signal;

--- a/perception/autoware_traffic_light_arbiter/test/test_traffic_arbiter_characteristic.cpp
+++ b/perception/autoware_traffic_light_arbiter/test/test_traffic_arbiter_characteristic.cpp
@@ -773,38 +773,18 @@ TEST_F(ArbiterCharacteristic, signalMatchingIgnoresConfidenceInEquivalence)
 // Pins the arbitration spec when Signal Matching is off: for each
 // regulatory-element id the arbiter walks every shape independently and
 // resolves the chosen element through a two-stage comparison
-// (priority flag first, confidence tiebreaker second). The longest path
-// combines single-side passthrough and shape-wise CONFIDENCE selection in
-// a single test:
+// (priority flag first, confidence tiebreaker second). Each scenario is
+// exercised by a dedicated test:
 //   - both sources agree on shape         -> CONFIDENCE picks higher value
-//   - only one source contributes a shape -> passes through unchanged
+//   - only external contributes (per id)  -> passes through (multi-shape preserved)
+//   - only perception contributes (per id) -> passes through
 //   - off-map id                          -> dropped (WARN+skip)
 // ---------------------------------------------------------------------------
-TEST_F(ArbiterCharacteristic, priorityBasedConfidenceLongestPath)
-{
-  // Scenario inputs and expectations:
-  //   - Publish order: external -> perception.
-  //
-  // vehicle_signal_a:
-  //   external:   GREEN/CIRCLE/0.7
-  //   perception: GREEN/CIRCLE/0.9
-  //   expected:   CONFIDENCE picks perception (0.9 > 0.7)
-  //
-  // vehicle_signal_b:
-  //   external:   RED/CIRCLE/0.5 + GREEN/RIGHT_ARROW
-  //   perception: (none)
-  //   expected:   external only, both shapes pass through
-  //
-  // vehicle_signal_c:
-  //   external:   (none)
-  //   perception: GREEN/CIRCLE/0.8
-  //   expected:   perception only, passes
-  //
-  // kOffMapProbeId:
-  //   external:   RED/CIRCLE/0.9
-  //   perception: (none)
-  //   expected:   dropped (WARN+skip)
 
+// Both sources contribute the same shape for the same id; under CONFIDENCE
+// the higher-confidence element wins (here, perception 0.9 over external 0.7).
+TEST_F(ArbiterCharacteristic, priorityBasedConfidencePicksHigherValue)
+{
   // Arrange
   startArbiter(false, "confidence");  // priority-based mode, "confidence" priority
   publishMap();
@@ -815,19 +795,84 @@ TEST_F(ArbiterCharacteristic, priorityBasedConfidenceLongestPath)
   external_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
     map_ids::vehicle_signal_a,
     {makeTrafficLightElement(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.7f)}));
-  external_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
-    map_ids::vehicle_signal_b,
-    {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.5f),
-     makeTrafficLightElement(TrafficLightElement::GREEN, TrafficLightElement::RIGHT_ARROW, 0.3f)}));
-  external_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
-    kOffMapProbeId,
-    {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.9f)}));
 
   TrafficLightGroupArray perception_traffic_signal;
   perception_traffic_signal.stamp = t0;
   perception_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
     map_ids::vehicle_signal_a,
     {makeTrafficLightElement(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.9f)}));
+
+  // Act
+  publishExternal(external_traffic_signal);
+  publishPerception(perception_traffic_signal);
+
+  // Assert
+  ASSERT_GE(arbiter_publish_count_, 1u);
+  const auto * group =
+    findTrafficLightGroup(latest_arbitrated_traffic_signal_, map_ids::vehicle_signal_a);
+  ASSERT_NE(group, nullptr);
+  ASSERT_EQ(group->elements.size(), 1u);
+  EXPECT_EQ(group->elements[0].color, TrafficLightElement::GREEN);
+  EXPECT_NEAR(group->elements[0].confidence, 0.9f, kConfidenceEpsilon);
+}
+
+// Only external contributes an id (perception silent). Both shapes survive
+// shape-wise selection and pass through unchanged.
+TEST_F(ArbiterCharacteristic, priorityBasedExternalOnlyPassesThrough)
+{
+  // Arrange
+  startArbiter(false, "confidence");  // priority-based mode, "confidence" priority
+  publishMap();
+  const auto t0 = arbiter_->now();
+
+  TrafficLightGroupArray external_traffic_signal;
+  external_traffic_signal.stamp = t0;
+  external_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
+    map_ids::vehicle_signal_b,
+    {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.5f),
+     makeTrafficLightElement(TrafficLightElement::GREEN, TrafficLightElement::RIGHT_ARROW, 0.3f)}));
+
+  // Send a separate id from perception so the arbiter publishes after both
+  // callbacks have settled (the test then inspects vehicle_signal_b output).
+  TrafficLightGroupArray perception_traffic_signal;
+  perception_traffic_signal.stamp = t0;
+  perception_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
+    map_ids::vehicle_signal_a,
+    {makeTrafficLightElement(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.9f)}));
+
+  // Act
+  publishExternal(external_traffic_signal);
+  publishPerception(perception_traffic_signal);
+
+  // Assert
+  ASSERT_GE(arbiter_publish_count_, 1u);
+  const auto * group =
+    findTrafficLightGroup(latest_arbitrated_traffic_signal_, map_ids::vehicle_signal_b);
+  ASSERT_NE(group, nullptr);
+  ASSERT_EQ(group->elements.size(), 2u);
+  EXPECT_NE(findTrafficLightElement(*group, TrafficLightElement::CIRCLE), nullptr);
+  EXPECT_NE(findTrafficLightElement(*group, TrafficLightElement::RIGHT_ARROW), nullptr);
+}
+
+// Only perception contributes an id (external silent). The element flows
+// through unmodified.
+TEST_F(ArbiterCharacteristic, priorityBasedPerceptionOnlyPassesThrough)
+{
+  // Arrange
+  startArbiter(false, "confidence");  // priority-based mode, "confidence" priority
+  publishMap();
+  const auto t0 = arbiter_->now();
+
+  // External must publish something for the arbiter to settle; use a
+  // different id so vehicle_signal_c is perception-only.
+  TrafficLightGroupArray external_traffic_signal;
+  external_traffic_signal.stamp = t0;
+  external_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
+    map_ids::vehicle_signal_a,
+    {makeTrafficLightElement(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.7f)}));
+
+  TrafficLightGroupArray perception_traffic_signal;
+  perception_traffic_signal.stamp = t0;
   perception_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
     map_ids::vehicle_signal_c,
     {makeTrafficLightElement(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.8f)}));
@@ -837,36 +882,45 @@ TEST_F(ArbiterCharacteristic, priorityBasedConfidenceLongestPath)
   publishPerception(perception_traffic_signal);
 
   // Assert
+  ASSERT_GE(arbiter_publish_count_, 1u);
+  const auto * group =
+    findTrafficLightGroup(latest_arbitrated_traffic_signal_, map_ids::vehicle_signal_c);
+  ASSERT_NE(group, nullptr);
+  ASSERT_EQ(group->elements.size(), 1u);
+  EXPECT_EQ(group->elements[0].color, TrafficLightElement::GREEN);
+  EXPECT_NEAR(group->elements[0].confidence, 0.8f, kConfidenceEpsilon);
+}
 
-  // vehicle_signal_a: both sources agree on shape; CONFIDENCE picks perception (0.9 > 0.7).
-  {
-    const auto * group =
-      findTrafficLightGroup(latest_arbitrated_traffic_signal_, map_ids::vehicle_signal_a);
-    ASSERT_NE(group, nullptr);
-    ASSERT_EQ(group->elements.size(), 1u);
-    EXPECT_EQ(group->elements[0].color, TrafficLightElement::GREEN);
-    EXPECT_NEAR(group->elements[0].confidence, 0.9f, kConfidenceEpsilon);
-  }
-  // vehicle_signal_b: external only with two shapes; both survive shape-wise selection.
-  {
-    const auto * group =
-      findTrafficLightGroup(latest_arbitrated_traffic_signal_, map_ids::vehicle_signal_b);
-    ASSERT_NE(group, nullptr);
-    ASSERT_EQ(group->elements.size(), 2u);
-    EXPECT_NE(findTrafficLightElement(*group, TrafficLightElement::CIRCLE), nullptr);
-    EXPECT_NE(findTrafficLightElement(*group, TrafficLightElement::RIGHT_ARROW), nullptr);
-  }
-  // vehicle_signal_c: perception only, flows through unmodified.
-  {
-    const auto * group =
-      findTrafficLightGroup(latest_arbitrated_traffic_signal_, map_ids::vehicle_signal_c);
-    ASSERT_NE(group, nullptr);
-    ASSERT_EQ(group->elements.size(), 1u);
-    EXPECT_EQ(group->elements[0].color, TrafficLightElement::GREEN);
-    EXPECT_NEAR(group->elements[0].confidence, 0.8f, kConfidenceEpsilon);
-  }
-  // kOffMapProbeId: not on the map -> dropped (WARN+skip).
+// An id not in the vector map is silently dropped (WARN log only) by
+// add_signal_function before reaching the per-shape selection.
+TEST_F(ArbiterCharacteristic, priorityBasedOffMapIdDropped)
+{
+  // Arrange
+  startArbiter(false, "confidence");  // priority-based mode, "confidence" priority
+  publishMap();
+  const auto t0 = arbiter_->now();
+
+  TrafficLightGroupArray external_traffic_signal;
+  external_traffic_signal.stamp = t0;
+  external_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
+    kOffMapProbeId,
+    {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.9f)}));
+
+  TrafficLightGroupArray perception_traffic_signal;
+  perception_traffic_signal.stamp = t0;
+  perception_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
+    map_ids::vehicle_signal_a,
+    {makeTrafficLightElement(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.9f)}));
+
+  // Act
+  publishExternal(external_traffic_signal);
+  publishPerception(perception_traffic_signal);
+
+  // Assert
+  ASSERT_GE(arbiter_publish_count_, 1u);
   EXPECT_EQ(findTrafficLightGroup(latest_arbitrated_traffic_signal_, kOffMapProbeId), nullptr);
+  EXPECT_NE(
+    findTrafficLightGroup(latest_arbitrated_traffic_signal_, map_ids::vehicle_signal_a), nullptr);
 }
 
 // ---------------------------------------------------------------------------

--- a/perception/autoware_traffic_light_arbiter/test/test_traffic_arbiter_characteristic.cpp
+++ b/perception/autoware_traffic_light_arbiter/test/test_traffic_arbiter_characteristic.cpp
@@ -317,6 +317,7 @@ protected:
     map_pub_->publish(bin);
     spin_for();
   }
+
   // --- Act helpers -------------------------------------------------------
   void publish_perception(const TrafficLightGroupArray & msg)
   {
@@ -788,6 +789,8 @@ TEST_F(ArbiterCharacteristic, priorityBasedOffMapIdDropped)
 //    input validation, priority overrides, predictions.
 // ---------------------------------------------------------------------------
 
+// Before the vector_map arrives, arbitrateAndPublish early-returns and no
+// TrafficLightGroupArray is emitted.
 TEST_F(ArbiterCharacteristic, perceptionBeforeMapProducesNoOutput)
 {
   // Arrange (intentionally no publish_map())
@@ -847,6 +850,9 @@ TEST_F(ArbiterCharacteristic, unknownSourcePriorityFallsBackToConfidence)
   EXPECT_NEAR(observed_confidence(map_ids::vehicle_signal_a), 0.9f, kConfidenceEpsilon);
 }
 
+// With source_priority=perception, the perception value wins even when its
+// confidence is much lower than external's. Pins the PERCEPTION priority
+// branch in arbitrateAndPublish.
 TEST_F(ArbiterCharacteristic, priorityFlagOverridesHigherConfidence)
 {
   // Arrange
@@ -911,6 +917,9 @@ TEST_F(ArbiterCharacteristic, multipleExternalSourcesAccumulate)
   EXPECT_EQ(observed_color(map_ids::vehicle_signal_b), TrafficLightElement::RED);
 }
 
+// An external message whose stamp is older than external_delay_tolerance
+// is dropped before reaching arbitrateAndPublish, so the last published
+// content stays as the earlier perception value.
 TEST_F(ArbiterCharacteristic, externalDelayToleranceDropsStaleMessage)
 {
   // Arrange: seed a perception value (RED). If the stale external below were
@@ -931,6 +940,9 @@ TEST_F(ArbiterCharacteristic, externalDelayToleranceDropsStaleMessage)
   EXPECT_EQ(observed_color(map_ids::vehicle_signal_a), TrafficLightElement::RED);
 }
 
+// When perception arrives past external_time_tolerance after a stored
+// external entry, cleanupExpiredExternalSignals purges that entry so the
+// upcoming publish reflects only perception.
 TEST_F(ArbiterCharacteristic, externalTimeToleranceCleanupOnPerception)
 {
   // Arrange: seed an external entry that should be purged by the perception
@@ -976,6 +988,8 @@ TEST_F(ArbiterCharacteristic, perceptionTimeToleranceClearsLatestPerception)
   EXPECT_EQ(observed_color(map_ids::vehicle_signal_a), TrafficLightElement::GREEN);
 }
 
+// Predictions sent on only one side propagate to the arbitrated output
+// with their information_source preserved.
 TEST_F(ArbiterCharacteristic, predictionsFromSingleSidePropagate)
 {
   // Arrange

--- a/perception/autoware_traffic_light_arbiter/test/test_traffic_arbiter_characteristic.cpp
+++ b/perception/autoware_traffic_light_arbiter/test/test_traffic_arbiter_characteristic.cpp
@@ -375,19 +375,7 @@ protected:
 };
 
 // ---------------------------------------------------------------------------
-// A. Signal Matching mode - arbitration rules across source agreement.
-//
-// Pins the full Signal Matching behavior spec: the arbiter degrades
-// gracefully as the agreement between sources weakens, falling back to
-// UNKNOWN when the signals disagree and dropping ids that are not on the
-// map. Each validation outcome of SignalMatchValidator is exercised by
-// a dedicated test:
-//   - matched (color & shape agree) -> perception passes through
-//   - color mismatch                -> UNKNOWN over the shared shape
-//   - element-count mismatch        -> UNKNOWN over the shape union
-//   - off-map id                    -> dropped (WARN+skip)
-// (Confidence is omitted in element constructors because Signal Matching
-// never reads it; the 1.0f default applies.)
+// A. Signal Matching mode (enable_signal_matching=true)
 // ---------------------------------------------------------------------------
 
 // Matched: external and perception agree on color and shape. Perception
@@ -767,18 +755,7 @@ TEST_F(ArbiterCharacteristic, signalMatchingIgnoresConfidenceInEquivalence)
 }
 
 // ---------------------------------------------------------------------------
-// B. Priority-based mode - per-shape element selection driven by
-//    source_priority and confidence.
-//
-// Pins the arbitration spec when Signal Matching is off: for each
-// regulatory-element id the arbiter walks every shape independently and
-// resolves the chosen element through a two-stage comparison
-// (priority flag first, confidence tiebreaker second). Each scenario is
-// exercised by a dedicated test:
-//   - both sources agree on shape         -> CONFIDENCE picks higher value
-//   - only external contributes (per id)  -> passes through (multi-shape preserved)
-//   - only perception contributes (per id) -> passes through
-//   - off-map id                          -> dropped (WARN+skip)
+// B. Priority-based mode (enable_signal_matching=false)
 // ---------------------------------------------------------------------------
 
 // Both sources contribute the same shape for the same id; under CONFIDENCE
@@ -924,12 +901,8 @@ TEST_F(ArbiterCharacteristic, priorityBasedOffMapIdDropped)
 }
 
 // ---------------------------------------------------------------------------
-// C. Focused specifications - boundary conditions, input validation, and
-//    isolated arbitration rules.
-//
-// Each test pins a single contract that the longest-path tests above do not
-// exercise: map availability, parameter validation, time tolerances,
-// priority overrides, equivalence semantics, and prediction passthrough.
+// C. Focused specifications — boundary cases, time tolerances,
+//    input validation, priority overrides, predictions.
 // ---------------------------------------------------------------------------
 
 TEST_F(ArbiterCharacteristic, perceptionBeforeMapProducesNoOutput)

--- a/perception/autoware_traffic_light_arbiter/test/test_traffic_arbiter_characteristic.cpp
+++ b/perception/autoware_traffic_light_arbiter/test/test_traffic_arbiter_characteristic.cpp
@@ -341,6 +341,31 @@ protected:
     }
   }
 
+  // Return the first element's color/shape/confidence for the given id in
+  // the latest arbitrated output. When the id is absent or has no
+  // elements, return a sentinel value (UINT8_MAX / -1.0f) that is never
+  // valid, so EXPECT_EQ at the call site fails loudly.
+  uint8_t observedColor(lanelet::Id signal_id) const
+  {
+    const auto * group = findTrafficLightGroup(latest_arbitrated_traffic_signal_, signal_id);
+    return (group && !group->elements.empty()) ? group->elements[0].color : UINT8_MAX;
+  }
+  uint8_t observedShape(lanelet::Id signal_id) const
+  {
+    const auto * group = findTrafficLightGroup(latest_arbitrated_traffic_signal_, signal_id);
+    return (group && !group->elements.empty()) ? group->elements[0].shape : UINT8_MAX;
+  }
+  float observedConfidence(lanelet::Id signal_id) const
+  {
+    const auto * group = findTrafficLightGroup(latest_arbitrated_traffic_signal_, signal_id);
+    return (group && !group->elements.empty()) ? group->elements[0].confidence : -1.0f;
+  }
+  std::size_t observedPredictionCount(lanelet::Id signal_id) const
+  {
+    const auto * group = findTrafficLightGroup(latest_arbitrated_traffic_signal_, signal_id);
+    return group ? group->predictions.size() : SIZE_MAX;
+  }
+
   // Wrapped in std::optional because LaneletMapBin (a generated ROS msg)
   // has no usable default constructor that can be invoked at static storage
   // duration; we initialise it during SetUpTestSuite().
@@ -410,12 +435,8 @@ TEST_F(ArbiterCharacteristic, signalMatchingMatchedPassesThrough)
   publishPerception(perception_traffic_signal);
 
   // Assert
-  const auto * group =
-    findTrafficLightGroup(latest_arbitrated_traffic_signal_, map_ids::vehicle_signal_a);
-  ASSERT_NE(group, nullptr);
-  ASSERT_EQ(group->elements.size(), 1u);
-  EXPECT_EQ(group->elements[0].color, TrafficLightElement::RED);
-  EXPECT_EQ(group->predictions.size(), 2u);
+  EXPECT_EQ(observedColor(map_ids::vehicle_signal_a), TrafficLightElement::RED);
+  EXPECT_EQ(observedPredictionCount(map_ids::vehicle_signal_a), 2u);
 }
 
 // Color mismatch: external GREEN/CIRCLE vs perception RED/CIRCLE.
@@ -444,12 +465,8 @@ TEST_F(ArbiterCharacteristic, signalMatchingColorMismatchProducesUnknown)
   publishPerception(perception_traffic_signal);
 
   // Assert
-  const auto * group =
-    findTrafficLightGroup(latest_arbitrated_traffic_signal_, map_ids::vehicle_signal_b);
-  ASSERT_NE(group, nullptr);
-  ASSERT_EQ(group->elements.size(), 1u);
-  EXPECT_EQ(group->elements[0].color, TrafficLightElement::UNKNOWN);
-  EXPECT_EQ(group->elements[0].shape, TrafficLightElement::CIRCLE);
+  EXPECT_EQ(observedColor(map_ids::vehicle_signal_b), TrafficLightElement::UNKNOWN);
+  EXPECT_EQ(observedShape(map_ids::vehicle_signal_b), TrafficLightElement::CIRCLE);
 }
 
 // Element-count mismatch: external has only CIRCLE while perception has
@@ -553,11 +570,7 @@ TEST_F(ArbiterCharacteristic, signalMatchingPedestrianFallbackUsesSourcePriority
   publishPerception(perception_traffic_signal);
 
   // Assert: external priority wins despite its lower confidence.
-  const auto * group =
-    findTrafficLightGroup(latest_arbitrated_traffic_signal_, map_ids::pedestrian_signal);
-  ASSERT_NE(group, nullptr);
-  ASSERT_EQ(group->elements.size(), 1u);
-  EXPECT_EQ(group->elements[0].color, TrafficLightElement::RED);
+  EXPECT_EQ(observedColor(map_ids::pedestrian_signal), TrafficLightElement::RED);
 }
 
 // Symmetric counterpart of the external-priority pedestrian test: with
@@ -590,11 +603,7 @@ TEST_F(ArbiterCharacteristic, signalMatchingPedestrianPerceptionPriority)
   publishPerception(perception_traffic_signal);
 
   // Assert: perception priority wins despite its lower confidence.
-  const auto * group =
-    findTrafficLightGroup(latest_arbitrated_traffic_signal_, map_ids::pedestrian_signal);
-  ASSERT_NE(group, nullptr);
-  ASSERT_EQ(group->elements.size(), 1u);
-  EXPECT_EQ(group->elements[0].color, TrafficLightElement::GREEN);
+  EXPECT_EQ(observedColor(map_ids::pedestrian_signal), TrafficLightElement::GREEN);
 }
 
 // Pedestrian + CONFIDENCE: get_highest_confidence_signal walks each shape and
@@ -624,12 +633,8 @@ TEST_F(ArbiterCharacteristic, signalMatchingPedestrianConfidenceMode)
   publishPerception(perception_traffic_signal);
 
   // Assert: CONFIDENCE picks the higher-confidence element (perception 0.9)
-  const auto * group =
-    findTrafficLightGroup(latest_arbitrated_traffic_signal_, map_ids::pedestrian_signal);
-  ASSERT_NE(group, nullptr);
-  ASSERT_EQ(group->elements.size(), 1u);
-  EXPECT_EQ(group->elements[0].color, TrafficLightElement::RED);
-  EXPECT_NEAR(group->elements[0].confidence, 0.9f, kConfidenceEpsilon);
+  EXPECT_EQ(observedColor(map_ids::pedestrian_signal), TrafficLightElement::RED);
+  EXPECT_NEAR(observedConfidence(map_ids::pedestrian_signal), 0.9f, kConfidenceEpsilon);
 }
 
 // Pedestrian id with a single source: get_highest_confidence_signal early-
@@ -654,11 +659,7 @@ TEST_F(ArbiterCharacteristic, signalMatchingPedestrianSingleSourcePasses)
   publishPerception(perception_traffic_signal);
 
   // Assert: perception passes through unchanged (no UNKNOWN translation)
-  const auto * group =
-    findTrafficLightGroup(latest_arbitrated_traffic_signal_, map_ids::pedestrian_signal);
-  ASSERT_NE(group, nullptr);
-  ASSERT_EQ(group->elements.size(), 1u);
-  EXPECT_EQ(group->elements[0].color, TrafficLightElement::GREEN);
+  EXPECT_EQ(observedColor(map_ids::pedestrian_signal), TrafficLightElement::GREEN);
 }
 
 // In Signal Matching mode, a non-pedestrian id that arrives on only one side
@@ -696,22 +697,10 @@ TEST_F(ArbiterCharacteristic, signalMatchingSingleSourceNonPedestrianYieldsUnkno
   publishPerception(perception_traffic_signal);
 
   // Assert
-  {
-    const auto * group =
-      findTrafficLightGroup(latest_arbitrated_traffic_signal_, map_ids::vehicle_signal_a);
-    ASSERT_NE(group, nullptr);
-    ASSERT_EQ(group->elements.size(), 1u);
-    EXPECT_EQ(group->elements[0].color, TrafficLightElement::UNKNOWN);
-    EXPECT_EQ(group->elements[0].shape, TrafficLightElement::CIRCLE);
-  }
-  {
-    const auto * group =
-      findTrafficLightGroup(latest_arbitrated_traffic_signal_, map_ids::vehicle_signal_b);
-    ASSERT_NE(group, nullptr);
-    ASSERT_EQ(group->elements.size(), 1u);
-    EXPECT_EQ(group->elements[0].color, TrafficLightElement::UNKNOWN);
-    EXPECT_EQ(group->elements[0].shape, TrafficLightElement::CIRCLE);
-  }
+  EXPECT_EQ(observedColor(map_ids::vehicle_signal_a), TrafficLightElement::UNKNOWN);
+  EXPECT_EQ(observedShape(map_ids::vehicle_signal_a), TrafficLightElement::CIRCLE);
+  EXPECT_EQ(observedColor(map_ids::vehicle_signal_b), TrafficLightElement::UNKNOWN);
+  EXPECT_EQ(observedShape(map_ids::vehicle_signal_b), TrafficLightElement::CIRCLE);
 }
 
 // Signal Matching does not consult the confidence field when checking
@@ -742,12 +731,8 @@ TEST_F(ArbiterCharacteristic, signalMatchingIgnoresConfidenceInEquivalence)
   publishPerception(perception_traffic_signal);
 
   // Assert
-  const auto * group =
-    findTrafficLightGroup(latest_arbitrated_traffic_signal_, map_ids::vehicle_signal_a);
-  ASSERT_NE(group, nullptr);
-  ASSERT_EQ(group->elements.size(), 1u);
-  EXPECT_EQ(group->elements[0].color, TrafficLightElement::RED);
-  EXPECT_NEAR(group->elements[0].confidence, 0.90f, kConfidenceEpsilon);
+  EXPECT_EQ(observedColor(map_ids::vehicle_signal_a), TrafficLightElement::RED);
+  EXPECT_NEAR(observedConfidence(map_ids::vehicle_signal_a), 0.90f, kConfidenceEpsilon);
 }
 
 // ---------------------------------------------------------------------------
@@ -780,12 +765,8 @@ TEST_F(ArbiterCharacteristic, priorityBasedConfidencePicksHigherValue)
   publishPerception(perception_traffic_signal);
 
   // Assert
-  const auto * group =
-    findTrafficLightGroup(latest_arbitrated_traffic_signal_, map_ids::vehicle_signal_a);
-  ASSERT_NE(group, nullptr);
-  ASSERT_EQ(group->elements.size(), 1u);
-  EXPECT_EQ(group->elements[0].color, TrafficLightElement::GREEN);
-  EXPECT_NEAR(group->elements[0].confidence, 0.9f, kConfidenceEpsilon);
+  EXPECT_EQ(observedColor(map_ids::vehicle_signal_a), TrafficLightElement::GREEN);
+  EXPECT_NEAR(observedConfidence(map_ids::vehicle_signal_a), 0.9f, kConfidenceEpsilon);
 }
 
 // Only external contributes an id (perception silent). Both shapes survive
@@ -853,12 +834,8 @@ TEST_F(ArbiterCharacteristic, priorityBasedPerceptionOnlyPassesThrough)
   publishPerception(perception_traffic_signal);
 
   // Assert
-  const auto * group =
-    findTrafficLightGroup(latest_arbitrated_traffic_signal_, map_ids::vehicle_signal_c);
-  ASSERT_NE(group, nullptr);
-  ASSERT_EQ(group->elements.size(), 1u);
-  EXPECT_EQ(group->elements[0].color, TrafficLightElement::GREEN);
-  EXPECT_NEAR(group->elements[0].confidence, 0.8f, kConfidenceEpsilon);
+  EXPECT_EQ(observedColor(map_ids::vehicle_signal_c), TrafficLightElement::GREEN);
+  EXPECT_NEAR(observedConfidence(map_ids::vehicle_signal_c), 0.8f, kConfidenceEpsilon);
 }
 
 // An id not in the vector map is silently dropped (WARN log only) by
@@ -970,12 +947,8 @@ TEST_F(ArbiterCharacteristic, unknownSourcePriorityFallsBackToConfidence)
   publishPerception(perception_traffic_signal);
 
   // Assert: CONFIDENCE behavior - the higher-confidence perception wins.
-  const auto * group =
-    findTrafficLightGroup(latest_arbitrated_traffic_signal_, map_ids::vehicle_signal_a);
-  ASSERT_NE(group, nullptr);
-  ASSERT_EQ(group->elements.size(), 1u);
-  EXPECT_EQ(group->elements[0].color, TrafficLightElement::GREEN);
-  EXPECT_NEAR(group->elements[0].confidence, 0.9f, kConfidenceEpsilon);
+  EXPECT_EQ(observedColor(map_ids::vehicle_signal_a), TrafficLightElement::GREEN);
+  EXPECT_NEAR(observedConfidence(map_ids::vehicle_signal_a), 0.9f, kConfidenceEpsilon);
 }
 
 TEST_F(ArbiterCharacteristic, priorityFlagOverridesHigherConfidence)
@@ -1004,11 +977,7 @@ TEST_F(ArbiterCharacteristic, priorityFlagOverridesHigherConfidence)
   publishPerception(perception_traffic_signal);
 
   // Assert: perception priority wins despite its lower confidence.
-  const auto * group =
-    findTrafficLightGroup(latest_arbitrated_traffic_signal_, map_ids::vehicle_signal_a);
-  ASSERT_NE(group, nullptr);
-  ASSERT_EQ(group->elements.size(), 1u);
-  EXPECT_EQ(group->elements[0].color, TrafficLightElement::GREEN);
+  EXPECT_EQ(observedColor(map_ids::vehicle_signal_a), TrafficLightElement::GREEN);
 }
 
 // Symmetric counterpart of priorityFlagOverridesHigherConfidence: with
@@ -1041,11 +1010,7 @@ TEST_F(ArbiterCharacteristic, priorityFlagFromExternalOverridesHigherConfidence)
   publishPerception(perception_traffic_signal);
 
   // Assert: external priority wins despite its lower confidence.
-  const auto * group =
-    findTrafficLightGroup(latest_arbitrated_traffic_signal_, map_ids::vehicle_signal_a);
-  ASSERT_NE(group, nullptr);
-  ASSERT_EQ(group->elements.size(), 1u);
-  EXPECT_EQ(group->elements[0].color, TrafficLightElement::RED);
+  EXPECT_EQ(observedColor(map_ids::vehicle_signal_a), TrafficLightElement::RED);
 }
 
 // Successive external publishes that carry different ids accumulate in the
@@ -1082,14 +1047,8 @@ TEST_F(ArbiterCharacteristic, multipleExternalSourcesAccumulate)
 
   // Assert 2: both vehicle_signal_a and vehicle_signal_b appear in the output.
   EXPECT_EQ(latest_arbitrated_traffic_signal_.traffic_light_groups.size(), 2u);
-  const auto * group_a =
-    findTrafficLightGroup(latest_arbitrated_traffic_signal_, map_ids::vehicle_signal_a);
-  const auto * group_b =
-    findTrafficLightGroup(latest_arbitrated_traffic_signal_, map_ids::vehicle_signal_b);
-  ASSERT_NE(group_a, nullptr);
-  ASSERT_NE(group_b, nullptr);
-  EXPECT_EQ(group_a->elements[0].color, TrafficLightElement::GREEN);
-  EXPECT_EQ(group_b->elements[0].color, TrafficLightElement::RED);
+  EXPECT_EQ(observedColor(map_ids::vehicle_signal_a), TrafficLightElement::GREEN);
+  EXPECT_EQ(observedColor(map_ids::vehicle_signal_b), TrafficLightElement::RED);
 }
 
 TEST_F(ArbiterCharacteristic, externalDelayToleranceDropsStaleMessage)
@@ -1119,10 +1078,7 @@ TEST_F(ArbiterCharacteristic, externalDelayToleranceDropsStaleMessage)
   // Assert
   EXPECT_EQ(arbiter_publish_count_, baseline_count)
     << "Stale external message must be dropped before arbitrateAndPublish runs";
-  const auto * group =
-    findTrafficLightGroup(latest_arbitrated_traffic_signal_, map_ids::vehicle_signal_a);
-  ASSERT_NE(group, nullptr);
-  EXPECT_EQ(group->elements[0].color, TrafficLightElement::RED)
+  EXPECT_EQ(observedColor(map_ids::vehicle_signal_a), TrafficLightElement::RED)
     << "Last publish must reflect perception";
 }
 
@@ -1151,11 +1107,7 @@ TEST_F(ArbiterCharacteristic, externalTimeToleranceCleanupOnPerception)
   publishPerception(perception_traffic_signal);
 
   // Assert
-  const auto * group =
-    findTrafficLightGroup(latest_arbitrated_traffic_signal_, map_ids::vehicle_signal_a);
-  ASSERT_NE(group, nullptr);
-  ASSERT_EQ(group->elements.size(), 1u);
-  EXPECT_EQ(group->elements[0].color, TrafficLightElement::GREEN);
+  EXPECT_EQ(observedColor(map_ids::vehicle_signal_a), TrafficLightElement::GREEN);
 }
 
 // onExternalMsg compares its own stamp to latest_perception_msg_.stamp; if
@@ -1188,11 +1140,7 @@ TEST_F(ArbiterCharacteristic, perceptionTimeToleranceClearsLatestPerception)
   publishExternal(external_traffic_signal);
 
   // Assert: stale perception was wiped, output reflects only external.
-  const auto * group =
-    findTrafficLightGroup(latest_arbitrated_traffic_signal_, map_ids::vehicle_signal_a);
-  ASSERT_NE(group, nullptr);
-  ASSERT_EQ(group->elements.size(), 1u);
-  EXPECT_EQ(group->elements[0].color, TrafficLightElement::GREEN);
+  EXPECT_EQ(observedColor(map_ids::vehicle_signal_a), TrafficLightElement::GREEN);
 }
 
 TEST_F(ArbiterCharacteristic, predictionsFromSingleSidePropagate)
@@ -1215,10 +1163,9 @@ TEST_F(ArbiterCharacteristic, predictionsFromSingleSidePropagate)
   publishPerception(perception_traffic_signal);
 
   // Assert
+  ASSERT_EQ(observedPredictionCount(map_ids::vehicle_signal_a), 1u);
   const auto * group =
     findTrafficLightGroup(latest_arbitrated_traffic_signal_, map_ids::vehicle_signal_a);
-  ASSERT_NE(group, nullptr);
-  ASSERT_EQ(group->predictions.size(), 1u);
   EXPECT_EQ(
     group->predictions[0].information_source,
     PredictedTrafficLightState::INFORMATION_SOURCE_INTERNAL_ESTIMATION);

--- a/perception/autoware_traffic_light_arbiter/test/test_traffic_arbiter_characteristic.cpp
+++ b/perception/autoware_traffic_light_arbiter/test/test_traffic_arbiter_characteristic.cpp
@@ -380,44 +380,25 @@ protected:
 // Pins the full Signal Matching behavior spec: the arbiter degrades
 // gracefully as the agreement between sources weakens, falling back to
 // UNKNOWN when the signals disagree and dropping ids that are not on the
-// map. All validation outcomes of SignalMatchValidator are exercised in
-// a single publish (4 ids):
+// map. Each validation outcome of SignalMatchValidator is exercised by
+// a dedicated test:
 //   - matched (color & shape agree) -> perception passes through
 //   - color mismatch                -> UNKNOWN over the shared shape
 //   - element-count mismatch        -> UNKNOWN over the shape union
 //   - off-map id                    -> dropped (WARN+skip)
+// (Confidence is omitted in element constructors because Signal Matching
+// never reads it; the 1.0f default applies.)
 // ---------------------------------------------------------------------------
-TEST_F(ArbiterCharacteristic, signalMatchingAllValidationOutcomes)
-{
-  // Scenario inputs and expectations (confidence is omitted everywhere
-  // because Signal Matching never reads it; the 1.0f default applies):
-  //
-  // vehicle_signal_a:
-  //   external:   RED/CIRCLE + V2I prediction
-  //   perception: RED/CIRCLE + INTERNAL prediction
-  //   expected:   matched -> perception passes through; both predictions merged (2 total)
-  //
-  // vehicle_signal_b:
-  //   external:   GREEN/CIRCLE
-  //   perception: RED/CIRCLE
-  //   expected:   color mismatch -> UNKNOWN
-  //
-  // vehicle_signal_c:
-  //   external:   RED/CIRCLE
-  //   perception: RED/CIRCLE + GREEN/RIGHT_ARROW
-  //   expected:   element-count mismatch -> UNKNOWN over shape union
-  //
-  // kOffMapProbeId:
-  //   external:   RED/CIRCLE
-  //   perception: (none)
-  //   expected:   dropped (WARN+skip)
 
+// Matched: external and perception agree on color and shape. Perception
+// passes through verbatim, and predictions from both sides are merged.
+TEST_F(ArbiterCharacteristic, signalMatchingMatchedPassesThrough)
+{
   // Arrange
   startArbiter(true, "confidence");  // signal matching mode, "confidence" priority
   publishMap();
   const auto t0 = arbiter_->now();
 
-  // Message from external source like a V2I unit.
   TrafficLightGroupArray external_traffic_signal;
   external_traffic_signal.stamp = t0;
   external_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
@@ -426,17 +407,7 @@ TEST_F(ArbiterCharacteristic, signalMatchingAllValidationOutcomes)
     {makeTrafficLightPrediction(
       external_traffic_signal.stamp, TrafficLightElement::GREEN, TrafficLightElement::CIRCLE,
       PredictedTrafficLightState::INFORMATION_SOURCE_V2I)}));
-  external_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
-    map_ids::vehicle_signal_b,
-    {makeTrafficLightElement(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE)}));
-  external_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
-    map_ids::vehicle_signal_c,
-    {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE)}));
-  external_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
-    kOffMapProbeId,
-    {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE)}));
 
-  // Message from internal source like a perception module.
   TrafficLightGroupArray perception_traffic_signal;
   perception_traffic_signal.stamp = t0;
   perception_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
@@ -445,9 +416,73 @@ TEST_F(ArbiterCharacteristic, signalMatchingAllValidationOutcomes)
     {makeTrafficLightPrediction(
       perception_traffic_signal.stamp, TrafficLightElement::RED, TrafficLightElement::CIRCLE,
       PredictedTrafficLightState::INFORMATION_SOURCE_INTERNAL_ESTIMATION)}));
+
+  // Act
+  publishExternal(external_traffic_signal);
+  publishPerception(perception_traffic_signal);
+
+  // Assert
+  ASSERT_GE(arbiter_publish_count_, 1u);
+  const auto * group =
+    findTrafficLightGroup(latest_arbitrated_traffic_signal_, map_ids::vehicle_signal_a);
+  ASSERT_NE(group, nullptr);
+  ASSERT_EQ(group->elements.size(), 1u);
+  EXPECT_EQ(group->elements[0].color, TrafficLightElement::RED);
+  EXPECT_EQ(group->predictions.size(), 2u);
+}
+
+// Color mismatch: external GREEN/CIRCLE vs perception RED/CIRCLE.
+// Validator falls back to UNKNOWN over the shared shape.
+TEST_F(ArbiterCharacteristic, signalMatchingColorMismatchProducesUnknown)
+{
+  // Arrange
+  startArbiter(true, "confidence");  // signal matching mode, "confidence" priority
+  publishMap();
+  const auto t0 = arbiter_->now();
+
+  TrafficLightGroupArray external_traffic_signal;
+  external_traffic_signal.stamp = t0;
+  external_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
+    map_ids::vehicle_signal_b,
+    {makeTrafficLightElement(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE)}));
+
+  TrafficLightGroupArray perception_traffic_signal;
+  perception_traffic_signal.stamp = t0;
   perception_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
     map_ids::vehicle_signal_b,
     {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE)}));
+
+  // Act
+  publishExternal(external_traffic_signal);
+  publishPerception(perception_traffic_signal);
+
+  // Assert
+  ASSERT_GE(arbiter_publish_count_, 1u);
+  const auto * group =
+    findTrafficLightGroup(latest_arbitrated_traffic_signal_, map_ids::vehicle_signal_b);
+  ASSERT_NE(group, nullptr);
+  ASSERT_EQ(group->elements.size(), 1u);
+  EXPECT_EQ(group->elements[0].color, TrafficLightElement::UNKNOWN);
+  EXPECT_EQ(group->elements[0].shape, TrafficLightElement::CIRCLE);
+}
+
+// Element-count mismatch: external has only CIRCLE while perception has
+// CIRCLE + RIGHT_ARROW. Validator produces UNKNOWN over the shape union.
+TEST_F(ArbiterCharacteristic, signalMatchingElementCountMismatchProducesUnknown)
+{
+  // Arrange
+  startArbiter(true, "confidence");  // signal matching mode, "confidence" priority
+  publishMap();
+  const auto t0 = arbiter_->now();
+
+  TrafficLightGroupArray external_traffic_signal;
+  external_traffic_signal.stamp = t0;
+  external_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
+    map_ids::vehicle_signal_c,
+    {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE)}));
+
+  TrafficLightGroupArray perception_traffic_signal;
+  perception_traffic_signal.stamp = t0;
   perception_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
     map_ids::vehicle_signal_c,
     {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE),
@@ -459,39 +494,51 @@ TEST_F(ArbiterCharacteristic, signalMatchingAllValidationOutcomes)
 
   // Assert
   ASSERT_GE(arbiter_publish_count_, 1u);
+  const auto * group =
+    findTrafficLightGroup(latest_arbitrated_traffic_signal_, map_ids::vehicle_signal_c);
+  ASSERT_NE(group, nullptr);
+  ASSERT_EQ(group->elements.size(), 2u);
+  EXPECT_NE(findTrafficLightElement(*group, TrafficLightElement::CIRCLE), nullptr);
+  EXPECT_NE(findTrafficLightElement(*group, TrafficLightElement::RIGHT_ARROW), nullptr);
+  for (const auto & element : group->elements) {
+    EXPECT_EQ(element.color, TrafficLightElement::UNKNOWN);
+  }
+}
 
-  // vehicle_signal_a: matched -> perception passes through, predictions merged.
-  {
-    const auto * group =
-      findTrafficLightGroup(latest_arbitrated_traffic_signal_, map_ids::vehicle_signal_a);
-    ASSERT_NE(group, nullptr);
-    ASSERT_EQ(group->elements.size(), 1u);
-    EXPECT_EQ(group->elements[0].color, TrafficLightElement::RED);
-    EXPECT_EQ(group->predictions.size(), 2u);
-  }
-  // vehicle_signal_b: color mismatch -> UNKNOWN over the shared shape.
-  {
-    const auto * group =
-      findTrafficLightGroup(latest_arbitrated_traffic_signal_, map_ids::vehicle_signal_b);
-    ASSERT_NE(group, nullptr);
-    ASSERT_EQ(group->elements.size(), 1u);
-    EXPECT_EQ(group->elements[0].color, TrafficLightElement::UNKNOWN);
-    EXPECT_EQ(group->elements[0].shape, TrafficLightElement::CIRCLE);
-  }
-  // vehicle_signal_c: element-count mismatch -> UNKNOWN over shape union.
-  {
-    const auto * group =
-      findTrafficLightGroup(latest_arbitrated_traffic_signal_, map_ids::vehicle_signal_c);
-    ASSERT_NE(group, nullptr);
-    ASSERT_EQ(group->elements.size(), 2u);
-    EXPECT_NE(findTrafficLightElement(*group, TrafficLightElement::CIRCLE), nullptr);
-    EXPECT_NE(findTrafficLightElement(*group, TrafficLightElement::RIGHT_ARROW), nullptr);
-    for (const auto & element : group->elements) {
-      EXPECT_EQ(element.color, TrafficLightElement::UNKNOWN);
-    }
-  }
-  // kOffMapProbeId: not on the map -> dropped (WARN+skip).
+// Off-map id: an id not present in the vector map is silently dropped
+// (WARN log only) by add_signal_function before reaching the validator.
+// An on-map id is also included to confirm normal ids still pass through.
+TEST_F(ArbiterCharacteristic, signalMatchingOffMapIdDropped)
+{
+  // Arrange
+  startArbiter(true, "confidence");  // signal matching mode, "confidence" priority
+  publishMap();
+  const auto t0 = arbiter_->now();
+
+  TrafficLightGroupArray external_traffic_signal;
+  external_traffic_signal.stamp = t0;
+  external_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
+    kOffMapProbeId,
+    {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE)}));
+  external_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
+    map_ids::vehicle_signal_a,
+    {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE)}));
+
+  TrafficLightGroupArray perception_traffic_signal;
+  perception_traffic_signal.stamp = t0;
+  perception_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
+    map_ids::vehicle_signal_a,
+    {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE)}));
+
+  // Act
+  publishExternal(external_traffic_signal);
+  publishPerception(perception_traffic_signal);
+
+  // Assert
+  ASSERT_GE(arbiter_publish_count_, 1u);
   EXPECT_EQ(findTrafficLightGroup(latest_arbitrated_traffic_signal_, kOffMapProbeId), nullptr);
+  EXPECT_NE(
+    findTrafficLightGroup(latest_arbitrated_traffic_signal_, map_ids::vehicle_signal_a), nullptr);
 }
 
 // Pedestrian path bypasses element matching; with source_priority=external

--- a/perception/autoware_traffic_light_arbiter/test/test_traffic_arbiter_characteristic.cpp
+++ b/perception/autoware_traffic_light_arbiter/test/test_traffic_arbiter_characteristic.cpp
@@ -964,9 +964,9 @@ TEST_F(ArbiterCharacteristic, externalDelayToleranceDropsStaleMessage)
     t0_, map_ids::vehicle_signal_a,
     {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)}));
 
-  // Act: stamp is well past external_delay_tolerance in the past.
+  // Act: stamp is past external_delay_tolerance in the past.
   publish_external(make_signal_array(
-    offset_time(t0_, -(kDefaultExternalDelayTolerance + 15.0)), map_ids::vehicle_signal_a,
+    offset_time(t0_, -(kDefaultExternalDelayTolerance + 1.0)), map_ids::vehicle_signal_a,
     {make_traffic_light_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE)}));
 
   // Assert: the stale GREEN never propagates; the published color stays RED.

--- a/perception/autoware_traffic_light_arbiter/test/test_traffic_arbiter_characteristic.cpp
+++ b/perception/autoware_traffic_light_arbiter/test/test_traffic_arbiter_characteristic.cpp
@@ -467,10 +467,8 @@ protected:
   // tests that derive from this class.
   static constexpr float kConfidenceEpsilon = 1e-5f;
 
-  // Default tolerance parameters declared on the arbiter (mirrors
-  // config/traffic_light_arbiter.param.yaml). Time-tolerance tests pick
-  // offsets relative to these so the relationship is explicit at the
-  // call site (e.g., offset_time(t0_, -(kDefaultExternalDelayTolerance + 15.0))).
+  // Default tolerance values declared on the arbiter (mirrors
+  // config/traffic_light_arbiter.param.yaml).
   static constexpr double kDefaultExternalDelayTolerance = 5.0;
   static constexpr double kDefaultExternalTimeTolerance = 5.0;
   static constexpr double kDefaultPerceptionTimeTolerance = 1.0;

--- a/perception/autoware_traffic_light_arbiter/test/test_traffic_arbiter_characteristic.cpp
+++ b/perception/autoware_traffic_light_arbiter/test/test_traffic_arbiter_characteristic.cpp
@@ -59,7 +59,6 @@ namespace map_ids
 {
 constexpr lanelet::Id vehicle_signal_a = 1001;
 constexpr lanelet::Id vehicle_signal_b = 1002;
-constexpr lanelet::Id vehicle_signal_c = 1003;
 constexpr lanelet::Id pedestrian_signal = 2001;
 
 // Intentionally not installed on the map; used by tests as the "off-map id"
@@ -98,7 +97,7 @@ LineString3d make_traffic_light_bulb()
 }
 
 // Builds the minimal map required to drive every code path under test:
-// three road lanelets each carrying one Traffic Light, plus one crosswalk
+// two road lanelets each carrying one Traffic Light, plus one crosswalk
 // lanelet carrying the pedestrian Traffic Light.
 //
 // Test map summary (top-down view).
@@ -106,8 +105,7 @@ LineString3d make_traffic_light_bulb()
 //
 //   left bound  right bound   Lanelet      Traffic Light id
 //   ----------  -----------   ----------   --------------------------
-//        12          11       crosswalk    2001 (pedestrian_signal)
-//         8           5       road3        1003 (vehicle_signal_c)
+//         8           5       crosswalk    2001 (pedestrian_signal)
 //         4           1       road2        1002 (vehicle_signal_b)
 //         0          -3       road1        1001 (vehicle_signal_a)
 //
@@ -116,8 +114,7 @@ LaneletMapBin build_minimal_map_bin()
 {
   Lanelet road1 = make_lanelet(0.0, -3.0, AttributeValueString::Road);
   Lanelet road2 = make_lanelet(4.0, 1.0, AttributeValueString::Road);
-  Lanelet road3 = make_lanelet(8.0, 5.0, AttributeValueString::Road);
-  Lanelet crosswalk = make_lanelet(12.0, 11.0, AttributeValueString::Crosswalk);
+  Lanelet crosswalk = make_lanelet(8.0, 5.0, AttributeValueString::Crosswalk);
 
   road1.addRegulatoryElement(
     TrafficLight::make(
@@ -125,15 +122,11 @@ LaneletMapBin build_minimal_map_bin()
   road2.addRegulatoryElement(
     TrafficLight::make(
       map_ids::vehicle_signal_b, {}, LineStringsOrPolygons3d{make_traffic_light_bulb()}));
-  road3.addRegulatoryElement(
-    TrafficLight::make(
-      map_ids::vehicle_signal_c, {}, LineStringsOrPolygons3d{make_traffic_light_bulb()}));
   crosswalk.addRegulatoryElement(
     TrafficLight::make(
       map_ids::pedestrian_signal, {}, LineStringsOrPolygons3d{make_traffic_light_bulb()}));
 
-  const LaneletMapConstPtr map{
-    utils::createMap(Lanelets{road1, road2, road3, crosswalk}).release()};
+  const LaneletMapConstPtr map{utils::createMap(Lanelets{road1, road2, crosswalk}).release()};
   auto bin = ::autoware::experimental::lanelet2_utils::to_autoware_map_msgs(map);
   bin.header.frame_id = "base_link";
   return bin;
@@ -508,20 +501,20 @@ TEST_F(ArbiterCharacteristic, signalMatchingElementCountMismatchProducesUnknown)
 
   // Act
   publish_external(make_signal_array(
-    t0_, map_ids::vehicle_signal_c,
+    t0_, map_ids::vehicle_signal_b,
     {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)}));
   publish_perception(make_signal_array(
-    t0_, map_ids::vehicle_signal_c,
+    t0_, map_ids::vehicle_signal_b,
     {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE),
      make_traffic_light_element(TrafficLightElement::GREEN, TrafficLightElement::RIGHT_ARROW)}));
 
   // Assert: shape union has both CIRCLE and RIGHT_ARROW, both as UNKNOWN.
-  EXPECT_EQ(observed_element_count(map_ids::vehicle_signal_c), 2u);
+  EXPECT_EQ(observed_element_count(map_ids::vehicle_signal_b), 2u);
   EXPECT_EQ(
-    observed_color_of_shape(map_ids::vehicle_signal_c, TrafficLightElement::CIRCLE),
+    observed_color_of_shape(map_ids::vehicle_signal_b, TrafficLightElement::CIRCLE),
     TrafficLightElement::UNKNOWN);
   EXPECT_EQ(
-    observed_color_of_shape(map_ids::vehicle_signal_c, TrafficLightElement::RIGHT_ARROW),
+    observed_color_of_shape(map_ids::vehicle_signal_b, TrafficLightElement::RIGHT_ARROW),
     TrafficLightElement::UNKNOWN);
 }
 
@@ -750,17 +743,17 @@ TEST_F(ArbiterCharacteristic, priorityBasedPerceptionOnlyPassesThrough)
   publish_map();
 
   // Act: external must publish something for the arbiter to settle; use a
-  // different id so vehicle_signal_c is perception-only.
+  // different id so vehicle_signal_b is perception-only.
   publish_external(make_signal_array(
     t0_, map_ids::vehicle_signal_a,
     {make_traffic_light_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.7f)}));
   publish_perception(make_signal_array(
-    t0_, map_ids::vehicle_signal_c,
+    t0_, map_ids::vehicle_signal_b,
     {make_traffic_light_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.8f)}));
 
   // Assert
-  EXPECT_EQ(observed_color(map_ids::vehicle_signal_c), TrafficLightElement::GREEN);
-  EXPECT_NEAR(observed_confidence(map_ids::vehicle_signal_c), 0.8f, kConfidenceEpsilon);
+  EXPECT_EQ(observed_color(map_ids::vehicle_signal_b), TrafficLightElement::GREEN);
+  EXPECT_NEAR(observed_confidence(map_ids::vehicle_signal_b), 0.8f, kConfidenceEpsilon);
 }
 
 // An id not in the vector map is silently dropped (WARN log only) by

--- a/perception/autoware_traffic_light_arbiter/test/test_traffic_arbiter_characteristic.cpp
+++ b/perception/autoware_traffic_light_arbiter/test/test_traffic_arbiter_characteristic.cpp
@@ -291,7 +291,7 @@ protected:
     test_node_.reset();
   }
 
-  // --- Arrange -----------------------------------------------------------
+  // --- Arrange helpers ---------------------------------------------------
   void start_arbiter(bool enable_signal_matching, const std::string & source_priority)
   {
     rclcpp::NodeOptions options;
@@ -317,7 +317,7 @@ protected:
     map_pub_->publish(bin);
     spin_for();
   }
-  // --- Act ---------------------------------------------------------------
+  // --- Act helpers -------------------------------------------------------
   void publish_perception(const TrafficLightGroupArray & msg)
   {
     perception_pub_->publish(msg);
@@ -338,7 +338,7 @@ protected:
     }
   }
 
-  // --- Assert ------------------------------------------------------------
+  // --- Assert helpers ----------------------------------------------------
   // Look up a TrafficLightGroup or TrafficLightElement in the latest
   // arbitrated output. Returns nullptr when not present.
   const TrafficLightGroup * find_traffic_light_group(lanelet::Id id) const
@@ -642,18 +642,12 @@ TEST_F(ArbiterCharacteristic, signalMatchingPedestrianSingleSourcePasses)
 // external-only) exercise distinct branches in SignalMatchValidator.
 TEST_F(ArbiterCharacteristic, signalMatchingSingleSourceNonPedestrianYieldsUnknown)
 {
-  // Scenario inputs and expectations:
-  //
-  //   id                external      perception   expected outcome
-  //   ----------------  ------------  -----------  -----------------------------
-  //   vehicle_signal_a  (none)        RED/CIRCLE   perception-only -> UNKNOWN/CIRCLE
-  //   vehicle_signal_b  GREEN/CIRCLE  (none)       external-only   -> UNKNOWN/CIRCLE
-
   // Arrange
   start_arbiter(true, "confidence");  // signal matching mode, "confidence" priority
   publish_map();
 
-  // Act: each side carries a different id, so each id has only one source.
+  // Act: each side carries a different id, so each id has only one source
+  // (vehicle_signal_a is perception-only, vehicle_signal_b is external-only).
   publish_external(make_signal_array(
     t0_, map_ids::vehicle_signal_b,
     {make_traffic_light_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE)}));

--- a/perception/autoware_traffic_light_arbiter/test/test_traffic_arbiter_characteristic.cpp
+++ b/perception/autoware_traffic_light_arbiter/test/test_traffic_arbiter_characteristic.cpp
@@ -61,11 +61,11 @@ constexpr lanelet::Id vehicle_signal_a = 1001;
 constexpr lanelet::Id vehicle_signal_b = 1002;
 constexpr lanelet::Id vehicle_signal_c = 1003;
 constexpr lanelet::Id pedestrian_signal = 2001;
-}  // namespace map_ids
 
 // Intentionally not installed on the map; used by tests as the "off-map id"
 // probe to exercise the WARN+skip branch in arbitrateAndPublish.
-constexpr lanelet::Id kOffMapProbeId = 9999;
+constexpr lanelet::Id off_map_probe = 9999;
+}  // namespace map_ids
 
 // --- Map construction --------------------------------------------------
 
@@ -111,7 +111,7 @@ LineString3d make_traffic_light_bulb()
 //         4           1       road2        1002 (vehicle_signal_b)
 //         0          -3       road1        1001 (vehicle_signal_a)
 //
-// Probe id intentionally absent from the map: 9999 (kOffMapProbeId)
+// Probe id intentionally absent from the map: 9999 (map_ids::off_map_probe)
 LaneletMapBin build_minimal_map_bin()
 {
   Lanelet road1 = make_lanelet(0.0, -3.0, AttributeValueString::Road);
@@ -150,8 +150,6 @@ LaneletMapBin build_empty_map_bin()
   bin.header.frame_id = "base_link";
   return bin;
 }
-
-// --- Node construction -------------------------------------------------
 
 // --- Input message builders --------------------------------------------
 
@@ -220,7 +218,7 @@ TrafficLightGroupArray make_signal_array(
 }
 
 // Multi-group variant for tests that publish several ids in one message
-// (e.g. off-map-drop tests that mix an on-map id with kOffMapProbeId).
+// (e.g. off-map-drop tests that mix an on-map id with map_ids::off_map_probe).
 TrafficLightGroupArray make_signal_array(
   const rclcpp::Time & stamp, std::vector<TrafficLightGroup> groups)
 {
@@ -253,11 +251,11 @@ protected:
     }
 
     // Reserve the highest signal id so utils::getId() never returns values
-    // that collide with map_ids::* or kOffMapProbeId. Calling registerId(9999)
+    // that collide with map_ids::* or map_ids::off_map_probe. Calling registerId(9999)
     // advances the global counter to >= 10000, which is safely above every
     // fixed signal id we use. This is process-wide global state, so doing it
     // once per suite is enough.
-    utils::registerId(kOffMapProbeId);
+    utils::registerId(map_ids::off_map_probe);
 
     // map_bin_ is immutable across tests, so build it once for the suite.
     map_bin_ = build_minimal_map_bin();
@@ -565,7 +563,7 @@ TEST_F(ArbiterCharacteristic, signalMatchingOffMapIdDropped)
   // Act
   publish_external(make_signal_array(
     t0_, {make_traffic_light_group(
-            kOffMapProbeId,
+            map_ids::off_map_probe,
             {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)}),
           make_traffic_light_group(
             map_ids::vehicle_signal_a,
@@ -575,7 +573,7 @@ TEST_F(ArbiterCharacteristic, signalMatchingOffMapIdDropped)
     {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)}));
 
   // Assert
-  EXPECT_EQ(find_traffic_light_group(kOffMapProbeId), nullptr);
+  EXPECT_EQ(find_traffic_light_group(map_ids::off_map_probe), nullptr);
   EXPECT_NE(find_traffic_light_group(map_ids::vehicle_signal_a), nullptr);
 }
 
@@ -807,14 +805,14 @@ TEST_F(ArbiterCharacteristic, priorityBasedOffMapIdDropped)
 
   // Act
   publish_external(make_signal_array(
-    t0_, kOffMapProbeId,
+    t0_, map_ids::off_map_probe,
     {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.9f)}));
   publish_perception(make_signal_array(
     t0_, map_ids::vehicle_signal_a,
     {make_traffic_light_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.9f)}));
 
   // Assert
-  EXPECT_EQ(find_traffic_light_group(kOffMapProbeId), nullptr);
+  EXPECT_EQ(find_traffic_light_group(map_ids::off_map_probe), nullptr);
   EXPECT_NE(find_traffic_light_group(map_ids::vehicle_signal_a), nullptr);
 }
 

--- a/perception/autoware_traffic_light_arbiter/test/test_traffic_arbiter_characteristic.cpp
+++ b/perception/autoware_traffic_light_arbiter/test/test_traffic_arbiter_characteristic.cpp
@@ -421,7 +421,7 @@ TEST_F(ArbiterCharacteristic, signalMatchingLongestPath)
 
   // Message from external source like a V2I unit.
   TrafficLightGroupArray external_traffic_signal;
-  external_traffic_signal.stamp = offsetTime(t0, -0.10);
+  external_traffic_signal.stamp = t0;
   external_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
     map_ids::vehicle_signal_a,
     {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE)},
@@ -440,7 +440,7 @@ TEST_F(ArbiterCharacteristic, signalMatchingLongestPath)
 
   // Message from internal source like a perception module.
   TrafficLightGroupArray perception_traffic_signal;
-  perception_traffic_signal.stamp = offsetTime(t0, -0.05);
+  perception_traffic_signal.stamp = t0;
   perception_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
     map_ids::vehicle_signal_a,
     {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE)},
@@ -508,13 +508,13 @@ TEST_F(ArbiterCharacteristic, signalMatchingPedestrianFallbackUsesSourcePriority
   // The confidence contrast (low external vs high perception) makes the
   // priority override explicit: the lower-confidence external wins.
   TrafficLightGroupArray external_traffic_signal;
-  external_traffic_signal.stamp = offsetTime(t0, -0.10);
+  external_traffic_signal.stamp = t0;
   external_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
     map_ids::pedestrian_signal,
     {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.1f)}));
 
   TrafficLightGroupArray perception_traffic_signal;
-  perception_traffic_signal.stamp = offsetTime(t0, -0.05);
+  perception_traffic_signal.stamp = t0;
   perception_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
     map_ids::pedestrian_signal,
     {makeTrafficLightElement(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.9f)}));
@@ -543,7 +543,7 @@ TEST_F(ArbiterCharacteristic, signalMatchingPedestrianPerceptionPriority)
   const auto t0 = arbiter_->now();
 
   TrafficLightGroupArray external_traffic_signal;
-  external_traffic_signal.stamp = offsetTime(t0, -0.10);
+  external_traffic_signal.stamp = t0;
   // The confidence contrast (high external vs low perception) makes the
   // priority override explicit: the lower-confidence perception still wins.
   external_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
@@ -551,7 +551,7 @@ TEST_F(ArbiterCharacteristic, signalMatchingPedestrianPerceptionPriority)
     {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.99f)}));
 
   TrafficLightGroupArray perception_traffic_signal;
-  perception_traffic_signal.stamp = offsetTime(t0, -0.05);
+  perception_traffic_signal.stamp = t0;
   perception_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
     map_ids::pedestrian_signal,
     {makeTrafficLightElement(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.10f)}));
@@ -579,13 +579,13 @@ TEST_F(ArbiterCharacteristic, signalMatchingPedestrianConfidenceMode)
   const auto t0 = arbiter_->now();
 
   TrafficLightGroupArray external_traffic_signal;
-  external_traffic_signal.stamp = offsetTime(t0, -0.10);
+  external_traffic_signal.stamp = t0;
   external_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
     map_ids::pedestrian_signal,
     {makeTrafficLightElement(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.6f)}));
 
   TrafficLightGroupArray perception_traffic_signal;
-  perception_traffic_signal.stamp = offsetTime(t0, -0.05);
+  perception_traffic_signal.stamp = t0;
   perception_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
     map_ids::pedestrian_signal,
     {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.9f)}));
@@ -616,7 +616,7 @@ TEST_F(ArbiterCharacteristic, signalMatchingPedestrianSingleSourcePasses)
   const auto t0 = arbiter_->now();
 
   TrafficLightGroupArray perception_traffic_signal;
-  perception_traffic_signal.stamp = offsetTime(t0, -0.05);
+  perception_traffic_signal.stamp = t0;
   perception_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
     map_ids::pedestrian_signal,
     {makeTrafficLightElement(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE)}));
@@ -651,13 +651,13 @@ TEST_F(ArbiterCharacteristic, signalMatchingSingleSourceNonPedestrianYieldsUnkno
   const auto t0 = arbiter_->now();
 
   TrafficLightGroupArray external_traffic_signal;
-  external_traffic_signal.stamp = offsetTime(t0, -0.10);
+  external_traffic_signal.stamp = t0;
   external_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
     map_ids::vehicle_signal_b,
     {makeTrafficLightElement(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE)}));
 
   TrafficLightGroupArray perception_traffic_signal;
-  perception_traffic_signal.stamp = offsetTime(t0, -0.05);
+  perception_traffic_signal.stamp = t0;
   perception_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
     map_ids::vehicle_signal_a,
     {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE)}));
@@ -697,13 +697,13 @@ TEST_F(ArbiterCharacteristic, signalMatchingIgnoresConfidenceInEquivalence)
   const auto t0 = arbiter_->now();
 
   TrafficLightGroupArray external_traffic_signal;
-  external_traffic_signal.stamp = offsetTime(t0, -0.10);
+  external_traffic_signal.stamp = t0;
   external_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
     map_ids::vehicle_signal_a,
     {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.10f)}));
 
   TrafficLightGroupArray perception_traffic_signal;
-  perception_traffic_signal.stamp = offsetTime(t0, -0.05);
+  perception_traffic_signal.stamp = t0;
   perception_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
     map_ids::vehicle_signal_a,
     {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.90f)}));
@@ -738,7 +738,7 @@ TEST_F(ArbiterCharacteristic, signalMatchingIgnoresConfidenceInEquivalence)
 TEST_F(ArbiterCharacteristic, priorityBasedConfidenceLongestPath)
 {
   // Scenario inputs and expectations:
-  //   - Publish order: external (-0.5s) -> perception (-0.2s).
+  //   - Publish order: external -> perception.
   //
   // vehicle_signal_a:
   //   external:   GREEN/CIRCLE/0.7
@@ -766,7 +766,7 @@ TEST_F(ArbiterCharacteristic, priorityBasedConfidenceLongestPath)
   const auto t0 = arbiter_->now();
 
   TrafficLightGroupArray external_traffic_signal;
-  external_traffic_signal.stamp = offsetTime(t0, -0.5);
+  external_traffic_signal.stamp = t0;
   external_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
     map_ids::vehicle_signal_a,
     {makeTrafficLightElement(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.7f)}));
@@ -779,7 +779,7 @@ TEST_F(ArbiterCharacteristic, priorityBasedConfidenceLongestPath)
     {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.9f)}));
 
   TrafficLightGroupArray perception_traffic_signal;
-  perception_traffic_signal.stamp = offsetTime(t0, -0.2);
+  perception_traffic_signal.stamp = t0;
   perception_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
     map_ids::vehicle_signal_a,
     {makeTrafficLightElement(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.9f)}));
@@ -888,13 +888,13 @@ TEST_F(ArbiterCharacteristic, unknownSourcePriorityFallsBackToConfidence)
   const auto t0 = arbiter_->now();
 
   TrafficLightGroupArray external_traffic_signal;
-  external_traffic_signal.stamp = offsetTime(t0, -0.10);
+  external_traffic_signal.stamp = t0;
   external_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
     map_ids::vehicle_signal_a,
     {makeTrafficLightElement(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.7f)}));
 
   TrafficLightGroupArray perception_traffic_signal;
-  perception_traffic_signal.stamp = offsetTime(t0, -0.05);
+  perception_traffic_signal.stamp = t0;
   perception_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
     map_ids::vehicle_signal_a,
     {makeTrafficLightElement(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.9f)}));
@@ -922,13 +922,13 @@ TEST_F(ArbiterCharacteristic, priorityFlagOverridesHigherConfidence)
   // The confidence contrast (high external vs low perception) makes the
   // priority override explicit: the lower-confidence perception still wins.
   TrafficLightGroupArray external_traffic_signal;
-  external_traffic_signal.stamp = offsetTime(t0, -0.10);
+  external_traffic_signal.stamp = t0;
   external_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
     map_ids::vehicle_signal_a,
     {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.99f)}));
 
   TrafficLightGroupArray perception_traffic_signal;
-  perception_traffic_signal.stamp = offsetTime(t0, -0.05);
+  perception_traffic_signal.stamp = t0;
   perception_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
     map_ids::vehicle_signal_a,
     {makeTrafficLightElement(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.10f)}));
@@ -959,13 +959,13 @@ TEST_F(ArbiterCharacteristic, priorityFlagFromExternalOverridesHigherConfidence)
   // The confidence contrast (low external vs high perception) makes the
   // priority override explicit: the lower-confidence external still wins.
   TrafficLightGroupArray external_traffic_signal;
-  external_traffic_signal.stamp = offsetTime(t0, -0.10);
+  external_traffic_signal.stamp = t0;
   external_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
     map_ids::vehicle_signal_a,
     {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.10f)}));
 
   TrafficLightGroupArray perception_traffic_signal;
-  perception_traffic_signal.stamp = offsetTime(t0, -0.05);
+  perception_traffic_signal.stamp = t0;
   perception_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
     map_ids::vehicle_signal_a,
     {makeTrafficLightElement(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.99f)}));
@@ -994,7 +994,7 @@ TEST_F(ArbiterCharacteristic, multipleExternalSourcesAccumulate)
 
   // Act 1: publish the first external signal (id vehicle_signal_a).
   TrafficLightGroupArray first_external_traffic_signal;
-  first_external_traffic_signal.stamp = offsetTime(t0, -1.0);
+  first_external_traffic_signal.stamp = t0;
   first_external_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
     map_ids::vehicle_signal_a,
     {makeTrafficLightElement(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE)}));
@@ -1008,7 +1008,7 @@ TEST_F(ArbiterCharacteristic, multipleExternalSourcesAccumulate)
 
   // Act 2: publish a second external signal carrying a different id.
   TrafficLightGroupArray second_external_traffic_signal;
-  second_external_traffic_signal.stamp = offsetTime(t0, -0.5);
+  second_external_traffic_signal.stamp = t0;
   second_external_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
     map_ids::vehicle_signal_b,
     {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE)}));
@@ -1070,7 +1070,7 @@ TEST_F(ArbiterCharacteristic, externalTimeToleranceCleanupOnPerception)
   const auto t0 = arbiter_->now();
 
   TrafficLightGroupArray external_traffic_signal;
-  external_traffic_signal.stamp = offsetTime(t0, -0.05);
+  external_traffic_signal.stamp = t0;
   external_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
     map_ids::vehicle_signal_a,
     {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE)}));

--- a/perception/autoware_traffic_light_arbiter/test/test_traffic_arbiter_characteristic.cpp
+++ b/perception/autoware_traffic_light_arbiter/test/test_traffic_arbiter_characteristic.cpp
@@ -404,25 +404,10 @@ protected:
     return group ? group->predictions.size() : SIZE_MAX;
   }
 
-  // Publish-count specs: a handful of contracts cannot be expressed by
-  // observing the published content alone, because they hinge on whether
-  // the arbiter emitted any message at all. For those, we count callbacks
-  // on the output subscription. Tests whose spec can be expressed as
-  // "the next publish contains X (and not the value that would have been
-  // emitted if the spec were violated)" should compare content via
-  // observed_* instead — content checks are stronger because they verify
-  // the user-visible behavior.
-
-  // Spec: the arbiter has not emitted any TrafficLightGroupArray yet.
-  // Content-only checks cannot distinguish "subscriber never received
-  // anything" from "subscriber received a default-constructed payload",
-  // so the count is the only direct test of the early-return contract.
-  void expect_no_publish() { EXPECT_EQ(arbiter_publish_count_, 0u); }
-
-  // Spec: the arbiter has emitted at least one TrafficLightGroupArray.
-  // Used when the published content is expected to be empty so a
-  // content-based check cannot tell "no publish" from "empty publish".
-  void expect_publish_happened() { ASSERT_GE(arbiter_publish_count_, 1u); }
+  // arbiter_publish_count_ (incremented by the output subscription callback)
+  // is read in two specific tests where content alone cannot express the
+  // contract: see perceptionBeforeMapProducesNoOutput and
+  // emptyMapProducesEmptyOutput for the rationale at each call site.
 
   // Wrapped in std::optional because LaneletMapBin (a generated ROS msg)
   // has no usable default constructor that can be invoked at static storage
@@ -818,8 +803,10 @@ TEST_F(ArbiterCharacteristic, perceptionBeforeMapProducesNoOutput)
     t0_, map_ids::vehicle_signal_a,
     {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)}));
 
-  // Assert: arbitrateAndPublish should early-return when no map has been received.
-  expect_no_publish();
+  // Assert: arbitrateAndPublish should early-return when no map has been
+  // received. Content alone cannot prove this (a default-constructed
+  // message looks identical to no publish at all), so we read the counter.
+  EXPECT_EQ(arbiter_publish_count_, 0u);
 }
 
 // A non-null but signal-free map should yield an empty TrafficLightGroupArray
@@ -836,8 +823,10 @@ TEST_F(ArbiterCharacteristic, emptyMapProducesEmptyOutput)
     t0_, map_ids::vehicle_signal_a,
     {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)}));
 
-  // Assert: arbiter publishes, but the output contains no groups.
-  expect_publish_happened();
+  // Assert: arbiter publishes, but the output contains no groups. The
+  // counter read distinguishes "publish happened with zero groups" (the
+  // spec) from "no publish at all" (which would also leave groups empty).
+  ASSERT_GE(arbiter_publish_count_, 1u);
   EXPECT_EQ(latest_arbitrated_traffic_signal_.traffic_light_groups.size(), 0u);
 }
 

--- a/perception/autoware_traffic_light_arbiter/test/test_traffic_arbiter_characteristic.cpp
+++ b/perception/autoware_traffic_light_arbiter/test/test_traffic_arbiter_characteristic.cpp
@@ -69,30 +69,30 @@ constexpr lanelet::Id kOffMapProbeId = 9999;
 
 // --- Map construction --------------------------------------------------
 
-Point3d makePoint(lanelet::Id id, double x, double y, double z = 0.0)
+Point3d make_point(lanelet::Id id, double x, double y, double z = 0.0)
 {
   return Point3d(id, x, y, z);
 }
 
-Lanelet makeLanelet(double y_left, double y_right, const std::string & subtype)
+Lanelet make_lanelet(double y_left, double y_right, const std::string & subtype)
 {
-  LineString3d left(getId(), {makePoint(getId(), 0.0, y_left), makePoint(getId(), 10.0, y_left)});
+  LineString3d left(getId(), {make_point(getId(), 0.0, y_left), make_point(getId(), 10.0, y_left)});
   LineString3d right(
-    getId(), {makePoint(getId(), 0.0, y_right), makePoint(getId(), 10.0, y_right)});
+    getId(), {make_point(getId(), 0.0, y_right), make_point(getId(), 10.0, y_right)});
   Lanelet new_lanelet(getId(), left, right);
   new_lanelet.attributes()[AttributeName::Subtype] = subtype;
   new_lanelet.attributes()[AttributeName::Type] = AttributeValueString::Lanelet;
   return new_lanelet;
 }
 
-LineString3d makeTrafficLightBulb()
+LineString3d make_traffic_light_bulb()
 {
   // The exact position does not affect arbiter logic; we pick the lanelet
   // midpoint (x = 5.0 within the 0..10 span) at z = 5.0 above the ground.
   constexpr double kBulbX = 5.0;
   constexpr double kBulbZ = 5.0;
   LineString3d bulb(
-    getId(), {makePoint(getId(), kBulbX, 0.0, kBulbZ), makePoint(getId(), kBulbX, 1.0, kBulbZ)});
+    getId(), {make_point(getId(), kBulbX, 0.0, kBulbZ), make_point(getId(), kBulbX, 1.0, kBulbZ)});
   bulb.attributes()[AttributeName::Type] = AttributeValueString::TrafficLight;
   return bulb;
 }
@@ -112,25 +112,25 @@ LineString3d makeTrafficLightBulb()
 //         0          -3       road1        1001 (vehicle_signal_a)
 //
 // Probe id intentionally absent from the map: 9999 (kOffMapProbeId)
-LaneletMapBin buildMinimalMapBin()
+LaneletMapBin build_minimal_map_bin()
 {
-  Lanelet road1 = makeLanelet(0.0, -3.0, AttributeValueString::Road);
-  Lanelet road2 = makeLanelet(4.0, 1.0, AttributeValueString::Road);
-  Lanelet road3 = makeLanelet(8.0, 5.0, AttributeValueString::Road);
-  Lanelet crosswalk = makeLanelet(12.0, 11.0, AttributeValueString::Crosswalk);
+  Lanelet road1 = make_lanelet(0.0, -3.0, AttributeValueString::Road);
+  Lanelet road2 = make_lanelet(4.0, 1.0, AttributeValueString::Road);
+  Lanelet road3 = make_lanelet(8.0, 5.0, AttributeValueString::Road);
+  Lanelet crosswalk = make_lanelet(12.0, 11.0, AttributeValueString::Crosswalk);
 
   road1.addRegulatoryElement(
     TrafficLight::make(
-      map_ids::vehicle_signal_a, {}, LineStringsOrPolygons3d{makeTrafficLightBulb()}));
+      map_ids::vehicle_signal_a, {}, LineStringsOrPolygons3d{make_traffic_light_bulb()}));
   road2.addRegulatoryElement(
     TrafficLight::make(
-      map_ids::vehicle_signal_b, {}, LineStringsOrPolygons3d{makeTrafficLightBulb()}));
+      map_ids::vehicle_signal_b, {}, LineStringsOrPolygons3d{make_traffic_light_bulb()}));
   road3.addRegulatoryElement(
     TrafficLight::make(
-      map_ids::vehicle_signal_c, {}, LineStringsOrPolygons3d{makeTrafficLightBulb()}));
+      map_ids::vehicle_signal_c, {}, LineStringsOrPolygons3d{make_traffic_light_bulb()}));
   crosswalk.addRegulatoryElement(
     TrafficLight::make(
-      map_ids::pedestrian_signal, {}, LineStringsOrPolygons3d{makeTrafficLightBulb()}));
+      map_ids::pedestrian_signal, {}, LineStringsOrPolygons3d{make_traffic_light_bulb()}));
 
   const LaneletMapConstPtr map{
     utils::createMap(Lanelets{road1, road2, road3, crosswalk}).release()};
@@ -139,12 +139,12 @@ LaneletMapBin buildMinimalMapBin()
   return bin;
 }
 
-// Variant of buildMinimalMapBin with a single road lanelet but no Traffic
+// Variant of build_minimal_map_bin with a single road lanelet but no Traffic
 // Light regulatory elements. Used to drive the
 // "map_regulatory_elements_set_->empty()" branch in arbitrateAndPublish.
-LaneletMapBin buildEmptyMapBin()
+LaneletMapBin build_empty_map_bin()
 {
-  Lanelet road = makeLanelet(0.0, -3.0, AttributeValueString::Road);
+  Lanelet road = make_lanelet(0.0, -3.0, AttributeValueString::Road);
   const LaneletMapConstPtr map{utils::createMap(Lanelets{road}).release()};
   auto bin = ::autoware::experimental::lanelet2_utils::to_autoware_map_msgs(map);
   bin.header.frame_id = "base_link";
@@ -157,7 +157,7 @@ LaneletMapBin buildEmptyMapBin()
 // re-declare them here instead of reading the YAML so the test is fully
 // self-contained and unaffected by production config changes. Only the
 // two parameters that any test actually toggles are exposed as arguments.
-std::shared_ptr<TrafficLightArbiter> makeArbiter(
+std::shared_ptr<TrafficLightArbiter> make_arbiter(
   bool enable_signal_matching = false, const std::string & source_priority = "confidence")
 {
   rclcpp::NodeOptions options;
@@ -176,7 +176,8 @@ std::shared_ptr<TrafficLightArbiter> makeArbiter(
 // Confidence defaults to 1.0f: most tests don't care about the value (the
 // arbiter only consults it under the CONFIDENCE branch), so omitting the
 // argument signals "this number is irrelevant to the assertion".
-TrafficLightElement makeTrafficLightElement(uint8_t color, uint8_t shape, float confidence = 1.0f)
+TrafficLightElement make_traffic_light_element(
+  uint8_t color, uint8_t shape, float confidence = 1.0f)
 {
   TrafficLightElement element;
   element.color = color;
@@ -186,7 +187,7 @@ TrafficLightElement makeTrafficLightElement(uint8_t color, uint8_t shape, float 
   return element;
 }
 
-PredictedTrafficLightState makeTrafficLightPrediction(
+PredictedTrafficLightState make_traffic_light_prediction(
   const builtin_interfaces::msg::Time & stamp, uint8_t color, uint8_t shape,
   const std::string & source)
 {
@@ -199,13 +200,14 @@ PredictedTrafficLightState makeTrafficLightPrediction(
   PredictedTrafficLightState prediction;
   prediction.predicted_stamp = stamp;
   prediction.predicted_stamp.sec += kPredictionOffsetSec;
-  prediction.simultaneous_elements.push_back(makeTrafficLightElement(color, shape, kFullCertainty));
+  prediction.simultaneous_elements.push_back(
+    make_traffic_light_element(color, shape, kFullCertainty));
   prediction.reliability = kFullCertainty;
   prediction.information_source = source;
   return prediction;
 }
 
-TrafficLightGroup makeTrafficLightGroup(
+TrafficLightGroup make_traffic_light_group(
   lanelet::Id id, std::vector<TrafficLightElement> elements,
   std::vector<PredictedTrafficLightState> predictions = {})
 {
@@ -218,14 +220,15 @@ TrafficLightGroup makeTrafficLightGroup(
 
 // --- Timestamp utility -------------------------------------------------
 
-builtin_interfaces::msg::Time offsetTime(const rclcpp::Time & base, double seconds)
+builtin_interfaces::msg::Time offset_time(const rclcpp::Time & base, double seconds)
 {
   return (base + rclcpp::Duration::from_seconds(seconds));
 }
 
 // --- Output inspection helpers -----------------------------------------
 
-const TrafficLightGroup * findTrafficLightGroup(const TrafficLightGroupArray & msg, lanelet::Id id)
+const TrafficLightGroup * find_traffic_light_group(
+  const TrafficLightGroupArray & msg, lanelet::Id id)
 {
   for (const auto & group : msg.traffic_light_groups) {
     if (group.traffic_light_group_id == id) {
@@ -235,7 +238,8 @@ const TrafficLightGroup * findTrafficLightGroup(const TrafficLightGroupArray & m
   return nullptr;
 }
 
-const TrafficLightElement * findTrafficLightElement(const TrafficLightGroup & group, uint8_t shape)
+const TrafficLightElement * find_traffic_light_element(
+  const TrafficLightGroup & group, uint8_t shape)
 {
   for (const auto & element : group.elements) {
     if (element.shape == shape) {
@@ -264,7 +268,7 @@ protected:
     utils::registerId(kOffMapProbeId);
 
     // map_bin_ is immutable across tests, so build it once for the suite.
-    map_bin_ = buildMinimalMapBin();
+    map_bin_ = build_minimal_map_bin();
   }
   static void TearDownTestSuite()
   {
@@ -305,34 +309,34 @@ protected:
     test_node_.reset();
   }
 
-  void startArbiter(bool enable_signal_matching, const std::string & source_priority)
+  void start_arbiter(bool enable_signal_matching, const std::string & source_priority)
   {
-    arbiter_ = makeArbiter(enable_signal_matching, source_priority);
+    arbiter_ = make_arbiter(enable_signal_matching, source_priority);
     executor_ = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
     executor_->add_node(arbiter_);
     executor_->add_node(test_node_);
-    spinFor();
+    spin_for();
   }
 
-  void publishMap() { publishMap(*map_bin_); }
+  void publish_map() { publish_map(*map_bin_); }
 
-  void publishMap(const LaneletMapBin & bin)
+  void publish_map(const LaneletMapBin & bin)
   {
     map_pub_->publish(bin);
-    spinFor();
+    spin_for();
   }
-  void publishPerception(const TrafficLightGroupArray & msg)
+  void publish_perception(const TrafficLightGroupArray & msg)
   {
     perception_pub_->publish(msg);
-    spinFor();
+    spin_for();
   }
-  void publishExternal(const TrafficLightGroupArray & msg)
+  void publish_external(const TrafficLightGroupArray & msg)
   {
     external_pub_->publish(msg);
-    spinFor();
+    spin_for();
   }
 
-  void spinFor(std::chrono::milliseconds duration = std::chrono::milliseconds(150))
+  void spin_for(std::chrono::milliseconds duration = std::chrono::milliseconds(150))
   {
     const auto deadline = std::chrono::steady_clock::now() + duration;
     while (std::chrono::steady_clock::now() < deadline) {
@@ -345,24 +349,24 @@ protected:
   // the latest arbitrated output. When the id is absent or has no
   // elements, return a sentinel value (UINT8_MAX / -1.0f) that is never
   // valid, so EXPECT_EQ at the call site fails loudly.
-  uint8_t observedColor(lanelet::Id signal_id) const
+  uint8_t observed_color(lanelet::Id signal_id) const
   {
-    const auto * group = findTrafficLightGroup(latest_arbitrated_traffic_signal_, signal_id);
+    const auto * group = find_traffic_light_group(latest_arbitrated_traffic_signal_, signal_id);
     return (group && !group->elements.empty()) ? group->elements[0].color : UINT8_MAX;
   }
-  uint8_t observedShape(lanelet::Id signal_id) const
+  uint8_t observed_shape(lanelet::Id signal_id) const
   {
-    const auto * group = findTrafficLightGroup(latest_arbitrated_traffic_signal_, signal_id);
+    const auto * group = find_traffic_light_group(latest_arbitrated_traffic_signal_, signal_id);
     return (group && !group->elements.empty()) ? group->elements[0].shape : UINT8_MAX;
   }
-  float observedConfidence(lanelet::Id signal_id) const
+  float observed_confidence(lanelet::Id signal_id) const
   {
-    const auto * group = findTrafficLightGroup(latest_arbitrated_traffic_signal_, signal_id);
+    const auto * group = find_traffic_light_group(latest_arbitrated_traffic_signal_, signal_id);
     return (group && !group->elements.empty()) ? group->elements[0].confidence : -1.0f;
   }
-  std::size_t observedPredictionCount(lanelet::Id signal_id) const
+  std::size_t observed_prediction_count(lanelet::Id signal_id) const
   {
-    const auto * group = findTrafficLightGroup(latest_arbitrated_traffic_signal_, signal_id);
+    const auto * group = find_traffic_light_group(latest_arbitrated_traffic_signal_, signal_id);
     return group ? group->predictions.size() : SIZE_MAX;
   }
 
@@ -408,35 +412,35 @@ protected:
 TEST_F(ArbiterCharacteristic, signalMatchingMatchedPassesThrough)
 {
   // Arrange
-  startArbiter(true, "confidence");  // signal matching mode, "confidence" priority
-  publishMap();
+  start_arbiter(true, "confidence");  // signal matching mode, "confidence" priority
+  publish_map();
   const auto t0 = arbiter_->now();
 
   TrafficLightGroupArray external_traffic_signal;
   external_traffic_signal.stamp = t0;
-  external_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
+  external_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
     map_ids::vehicle_signal_a,
-    {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE)},
-    {makeTrafficLightPrediction(
+    {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)},
+    {make_traffic_light_prediction(
       external_traffic_signal.stamp, TrafficLightElement::GREEN, TrafficLightElement::CIRCLE,
       PredictedTrafficLightState::INFORMATION_SOURCE_V2I)}));
 
   TrafficLightGroupArray perception_traffic_signal;
   perception_traffic_signal.stamp = t0;
-  perception_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
+  perception_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
     map_ids::vehicle_signal_a,
-    {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE)},
-    {makeTrafficLightPrediction(
+    {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)},
+    {make_traffic_light_prediction(
       perception_traffic_signal.stamp, TrafficLightElement::RED, TrafficLightElement::CIRCLE,
       PredictedTrafficLightState::INFORMATION_SOURCE_INTERNAL_ESTIMATION)}));
 
   // Act
-  publishExternal(external_traffic_signal);
-  publishPerception(perception_traffic_signal);
+  publish_external(external_traffic_signal);
+  publish_perception(perception_traffic_signal);
 
   // Assert
-  EXPECT_EQ(observedColor(map_ids::vehicle_signal_a), TrafficLightElement::RED);
-  EXPECT_EQ(observedPredictionCount(map_ids::vehicle_signal_a), 2u);
+  EXPECT_EQ(observed_color(map_ids::vehicle_signal_a), TrafficLightElement::RED);
+  EXPECT_EQ(observed_prediction_count(map_ids::vehicle_signal_a), 2u);
 }
 
 // Color mismatch: external GREEN/CIRCLE vs perception RED/CIRCLE.
@@ -444,29 +448,29 @@ TEST_F(ArbiterCharacteristic, signalMatchingMatchedPassesThrough)
 TEST_F(ArbiterCharacteristic, signalMatchingColorMismatchProducesUnknown)
 {
   // Arrange
-  startArbiter(true, "confidence");  // signal matching mode, "confidence" priority
-  publishMap();
+  start_arbiter(true, "confidence");  // signal matching mode, "confidence" priority
+  publish_map();
   const auto t0 = arbiter_->now();
 
   TrafficLightGroupArray external_traffic_signal;
   external_traffic_signal.stamp = t0;
-  external_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
+  external_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
     map_ids::vehicle_signal_b,
-    {makeTrafficLightElement(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE)}));
+    {make_traffic_light_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE)}));
 
   TrafficLightGroupArray perception_traffic_signal;
   perception_traffic_signal.stamp = t0;
-  perception_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
+  perception_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
     map_ids::vehicle_signal_b,
-    {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE)}));
+    {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)}));
 
   // Act
-  publishExternal(external_traffic_signal);
-  publishPerception(perception_traffic_signal);
+  publish_external(external_traffic_signal);
+  publish_perception(perception_traffic_signal);
 
   // Assert
-  EXPECT_EQ(observedColor(map_ids::vehicle_signal_b), TrafficLightElement::UNKNOWN);
-  EXPECT_EQ(observedShape(map_ids::vehicle_signal_b), TrafficLightElement::CIRCLE);
+  EXPECT_EQ(observed_color(map_ids::vehicle_signal_b), TrafficLightElement::UNKNOWN);
+  EXPECT_EQ(observed_shape(map_ids::vehicle_signal_b), TrafficLightElement::CIRCLE);
 }
 
 // Element-count mismatch: external has only CIRCLE while perception has
@@ -474,34 +478,34 @@ TEST_F(ArbiterCharacteristic, signalMatchingColorMismatchProducesUnknown)
 TEST_F(ArbiterCharacteristic, signalMatchingElementCountMismatchProducesUnknown)
 {
   // Arrange
-  startArbiter(true, "confidence");  // signal matching mode, "confidence" priority
-  publishMap();
+  start_arbiter(true, "confidence");  // signal matching mode, "confidence" priority
+  publish_map();
   const auto t0 = arbiter_->now();
 
   TrafficLightGroupArray external_traffic_signal;
   external_traffic_signal.stamp = t0;
-  external_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
+  external_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
     map_ids::vehicle_signal_c,
-    {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE)}));
+    {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)}));
 
   TrafficLightGroupArray perception_traffic_signal;
   perception_traffic_signal.stamp = t0;
-  perception_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
+  perception_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
     map_ids::vehicle_signal_c,
-    {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE),
-     makeTrafficLightElement(TrafficLightElement::GREEN, TrafficLightElement::RIGHT_ARROW)}));
+    {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE),
+     make_traffic_light_element(TrafficLightElement::GREEN, TrafficLightElement::RIGHT_ARROW)}));
 
   // Act
-  publishExternal(external_traffic_signal);
-  publishPerception(perception_traffic_signal);
+  publish_external(external_traffic_signal);
+  publish_perception(perception_traffic_signal);
 
   // Assert
   const auto * group =
-    findTrafficLightGroup(latest_arbitrated_traffic_signal_, map_ids::vehicle_signal_c);
+    find_traffic_light_group(latest_arbitrated_traffic_signal_, map_ids::vehicle_signal_c);
   ASSERT_NE(group, nullptr);
   ASSERT_EQ(group->elements.size(), 2u);
-  EXPECT_NE(findTrafficLightElement(*group, TrafficLightElement::CIRCLE), nullptr);
-  EXPECT_NE(findTrafficLightElement(*group, TrafficLightElement::RIGHT_ARROW), nullptr);
+  EXPECT_NE(find_traffic_light_element(*group, TrafficLightElement::CIRCLE), nullptr);
+  EXPECT_NE(find_traffic_light_element(*group, TrafficLightElement::RIGHT_ARROW), nullptr);
   for (const auto & element : group->elements) {
     EXPECT_EQ(element.color, TrafficLightElement::UNKNOWN);
   }
@@ -513,33 +517,34 @@ TEST_F(ArbiterCharacteristic, signalMatchingElementCountMismatchProducesUnknown)
 TEST_F(ArbiterCharacteristic, signalMatchingOffMapIdDropped)
 {
   // Arrange
-  startArbiter(true, "confidence");  // signal matching mode, "confidence" priority
-  publishMap();
+  start_arbiter(true, "confidence");  // signal matching mode, "confidence" priority
+  publish_map();
   const auto t0 = arbiter_->now();
 
   TrafficLightGroupArray external_traffic_signal;
   external_traffic_signal.stamp = t0;
-  external_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
+  external_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
     kOffMapProbeId,
-    {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE)}));
-  external_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
+    {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)}));
+  external_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
     map_ids::vehicle_signal_a,
-    {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE)}));
+    {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)}));
 
   TrafficLightGroupArray perception_traffic_signal;
   perception_traffic_signal.stamp = t0;
-  perception_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
+  perception_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
     map_ids::vehicle_signal_a,
-    {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE)}));
+    {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)}));
 
   // Act
-  publishExternal(external_traffic_signal);
-  publishPerception(perception_traffic_signal);
+  publish_external(external_traffic_signal);
+  publish_perception(perception_traffic_signal);
 
   // Assert
-  EXPECT_EQ(findTrafficLightGroup(latest_arbitrated_traffic_signal_, kOffMapProbeId), nullptr);
+  EXPECT_EQ(find_traffic_light_group(latest_arbitrated_traffic_signal_, kOffMapProbeId), nullptr);
   EXPECT_NE(
-    findTrafficLightGroup(latest_arbitrated_traffic_signal_, map_ids::vehicle_signal_a), nullptr);
+    find_traffic_light_group(latest_arbitrated_traffic_signal_, map_ids::vehicle_signal_a),
+    nullptr);
 }
 
 // Pedestrian path bypasses element matching; with source_priority=external
@@ -547,30 +552,30 @@ TEST_F(ArbiterCharacteristic, signalMatchingOffMapIdDropped)
 TEST_F(ArbiterCharacteristic, signalMatchingPedestrianFallbackUsesSourcePriority)
 {
   // Arrange
-  startArbiter(true, "external");  // signal matching mode, "external" priority
-  publishMap();
+  start_arbiter(true, "external");  // signal matching mode, "external" priority
+  publish_map();
   const auto t0 = arbiter_->now();
 
   // The confidence contrast (low external vs high perception) makes the
   // priority override explicit: the lower-confidence external wins.
   TrafficLightGroupArray external_traffic_signal;
   external_traffic_signal.stamp = t0;
-  external_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
+  external_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
     map_ids::pedestrian_signal,
-    {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.1f)}));
+    {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.1f)}));
 
   TrafficLightGroupArray perception_traffic_signal;
   perception_traffic_signal.stamp = t0;
-  perception_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
+  perception_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
     map_ids::pedestrian_signal,
-    {makeTrafficLightElement(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.9f)}));
+    {make_traffic_light_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.9f)}));
 
   // Act
-  publishExternal(external_traffic_signal);
-  publishPerception(perception_traffic_signal);
+  publish_external(external_traffic_signal);
+  publish_perception(perception_traffic_signal);
 
   // Assert: external priority wins despite its lower confidence.
-  EXPECT_EQ(observedColor(map_ids::pedestrian_signal), TrafficLightElement::RED);
+  EXPECT_EQ(observed_color(map_ids::pedestrian_signal), TrafficLightElement::RED);
 }
 
 // Symmetric counterpart of the external-priority pedestrian test: with
@@ -580,30 +585,30 @@ TEST_F(ArbiterCharacteristic, signalMatchingPedestrianFallbackUsesSourcePriority
 TEST_F(ArbiterCharacteristic, signalMatchingPedestrianPerceptionPriority)
 {
   // Arrange
-  startArbiter(true, "perception");  // signal matching mode, "perception" priority
-  publishMap();
+  start_arbiter(true, "perception");  // signal matching mode, "perception" priority
+  publish_map();
   const auto t0 = arbiter_->now();
 
   TrafficLightGroupArray external_traffic_signal;
   external_traffic_signal.stamp = t0;
   // The confidence contrast (high external vs low perception) makes the
   // priority override explicit: the lower-confidence perception still wins.
-  external_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
+  external_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
     map_ids::pedestrian_signal,
-    {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.99f)}));
+    {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.99f)}));
 
   TrafficLightGroupArray perception_traffic_signal;
   perception_traffic_signal.stamp = t0;
-  perception_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
+  perception_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
     map_ids::pedestrian_signal,
-    {makeTrafficLightElement(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.10f)}));
+    {make_traffic_light_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.10f)}));
 
   // Act
-  publishExternal(external_traffic_signal);
-  publishPerception(perception_traffic_signal);
+  publish_external(external_traffic_signal);
+  publish_perception(perception_traffic_signal);
 
   // Assert: perception priority wins despite its lower confidence.
-  EXPECT_EQ(observedColor(map_ids::pedestrian_signal), TrafficLightElement::GREEN);
+  EXPECT_EQ(observed_color(map_ids::pedestrian_signal), TrafficLightElement::GREEN);
 }
 
 // Pedestrian + CONFIDENCE: get_highest_confidence_signal walks each shape and
@@ -612,29 +617,29 @@ TEST_F(ArbiterCharacteristic, signalMatchingPedestrianPerceptionPriority)
 TEST_F(ArbiterCharacteristic, signalMatchingPedestrianConfidenceMode)
 {
   // Arrange
-  startArbiter(true, "confidence");  // signal matching mode, "confidence" priority
-  publishMap();
+  start_arbiter(true, "confidence");  // signal matching mode, "confidence" priority
+  publish_map();
   const auto t0 = arbiter_->now();
 
   TrafficLightGroupArray external_traffic_signal;
   external_traffic_signal.stamp = t0;
-  external_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
+  external_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
     map_ids::pedestrian_signal,
-    {makeTrafficLightElement(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.6f)}));
+    {make_traffic_light_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.6f)}));
 
   TrafficLightGroupArray perception_traffic_signal;
   perception_traffic_signal.stamp = t0;
-  perception_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
+  perception_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
     map_ids::pedestrian_signal,
-    {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.9f)}));
+    {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.9f)}));
 
   // Act
-  publishExternal(external_traffic_signal);
-  publishPerception(perception_traffic_signal);
+  publish_external(external_traffic_signal);
+  publish_perception(perception_traffic_signal);
 
   // Assert: CONFIDENCE picks the higher-confidence element (perception 0.9)
-  EXPECT_EQ(observedColor(map_ids::pedestrian_signal), TrafficLightElement::RED);
-  EXPECT_NEAR(observedConfidence(map_ids::pedestrian_signal), 0.9f, kConfidenceEpsilon);
+  EXPECT_EQ(observed_color(map_ids::pedestrian_signal), TrafficLightElement::RED);
+  EXPECT_NEAR(observed_confidence(map_ids::pedestrian_signal), 0.9f, kConfidenceEpsilon);
 }
 
 // Pedestrian id with a single source: get_highest_confidence_signal early-
@@ -645,21 +650,21 @@ TEST_F(ArbiterCharacteristic, signalMatchingPedestrianSingleSourcePasses)
 {
   // Arrange: external_priority is set to demonstrate that absent-side handling
   // happens BEFORE the priority switch is consulted.
-  startArbiter(true, "external");  // signal matching mode, "external" priority
-  publishMap();
+  start_arbiter(true, "external");  // signal matching mode, "external" priority
+  publish_map();
   const auto t0 = arbiter_->now();
 
   TrafficLightGroupArray perception_traffic_signal;
   perception_traffic_signal.stamp = t0;
-  perception_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
+  perception_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
     map_ids::pedestrian_signal,
-    {makeTrafficLightElement(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE)}));
+    {make_traffic_light_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE)}));
 
   // Act (no external publish)
-  publishPerception(perception_traffic_signal);
+  publish_perception(perception_traffic_signal);
 
   // Assert: perception passes through unchanged (no UNKNOWN translation)
-  EXPECT_EQ(observedColor(map_ids::pedestrian_signal), TrafficLightElement::GREEN);
+  EXPECT_EQ(observed_color(map_ids::pedestrian_signal), TrafficLightElement::GREEN);
 }
 
 // In Signal Matching mode, a non-pedestrian id that arrives on only one side
@@ -676,31 +681,31 @@ TEST_F(ArbiterCharacteristic, signalMatchingSingleSourceNonPedestrianYieldsUnkno
   //   vehicle_signal_b  GREEN/CIRCLE  (none)       external-only   -> UNKNOWN/CIRCLE
 
   // Arrange
-  startArbiter(true, "confidence");  // signal matching mode, "confidence" priority
-  publishMap();
+  start_arbiter(true, "confidence");  // signal matching mode, "confidence" priority
+  publish_map();
   const auto t0 = arbiter_->now();
 
   TrafficLightGroupArray external_traffic_signal;
   external_traffic_signal.stamp = t0;
-  external_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
+  external_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
     map_ids::vehicle_signal_b,
-    {makeTrafficLightElement(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE)}));
+    {make_traffic_light_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE)}));
 
   TrafficLightGroupArray perception_traffic_signal;
   perception_traffic_signal.stamp = t0;
-  perception_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
+  perception_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
     map_ids::vehicle_signal_a,
-    {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE)}));
+    {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)}));
 
   // Act
-  publishExternal(external_traffic_signal);
-  publishPerception(perception_traffic_signal);
+  publish_external(external_traffic_signal);
+  publish_perception(perception_traffic_signal);
 
   // Assert
-  EXPECT_EQ(observedColor(map_ids::vehicle_signal_a), TrafficLightElement::UNKNOWN);
-  EXPECT_EQ(observedShape(map_ids::vehicle_signal_a), TrafficLightElement::CIRCLE);
-  EXPECT_EQ(observedColor(map_ids::vehicle_signal_b), TrafficLightElement::UNKNOWN);
-  EXPECT_EQ(observedShape(map_ids::vehicle_signal_b), TrafficLightElement::CIRCLE);
+  EXPECT_EQ(observed_color(map_ids::vehicle_signal_a), TrafficLightElement::UNKNOWN);
+  EXPECT_EQ(observed_shape(map_ids::vehicle_signal_a), TrafficLightElement::CIRCLE);
+  EXPECT_EQ(observed_color(map_ids::vehicle_signal_b), TrafficLightElement::UNKNOWN);
+  EXPECT_EQ(observed_shape(map_ids::vehicle_signal_b), TrafficLightElement::CIRCLE);
 }
 
 // Signal Matching does not consult the confidence field when checking
@@ -710,29 +715,29 @@ TEST_F(ArbiterCharacteristic, signalMatchingSingleSourceNonPedestrianYieldsUnkno
 TEST_F(ArbiterCharacteristic, signalMatchingIgnoresConfidenceInEquivalence)
 {
   // Arrange
-  startArbiter(true, "confidence");  // signal matching mode, "confidence" priority
-  publishMap();
+  start_arbiter(true, "confidence");  // signal matching mode, "confidence" priority
+  publish_map();
   const auto t0 = arbiter_->now();
 
   TrafficLightGroupArray external_traffic_signal;
   external_traffic_signal.stamp = t0;
-  external_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
+  external_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
     map_ids::vehicle_signal_a,
-    {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.10f)}));
+    {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.10f)}));
 
   TrafficLightGroupArray perception_traffic_signal;
   perception_traffic_signal.stamp = t0;
-  perception_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
+  perception_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
     map_ids::vehicle_signal_a,
-    {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.90f)}));
+    {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.90f)}));
 
   // Act
-  publishExternal(external_traffic_signal);
-  publishPerception(perception_traffic_signal);
+  publish_external(external_traffic_signal);
+  publish_perception(perception_traffic_signal);
 
   // Assert
-  EXPECT_EQ(observedColor(map_ids::vehicle_signal_a), TrafficLightElement::RED);
-  EXPECT_NEAR(observedConfidence(map_ids::vehicle_signal_a), 0.90f, kConfidenceEpsilon);
+  EXPECT_EQ(observed_color(map_ids::vehicle_signal_a), TrafficLightElement::RED);
+  EXPECT_NEAR(observed_confidence(map_ids::vehicle_signal_a), 0.90f, kConfidenceEpsilon);
 }
 
 // ---------------------------------------------------------------------------
@@ -744,29 +749,29 @@ TEST_F(ArbiterCharacteristic, signalMatchingIgnoresConfidenceInEquivalence)
 TEST_F(ArbiterCharacteristic, priorityBasedConfidencePicksHigherValue)
 {
   // Arrange
-  startArbiter(false, "confidence");  // priority-based mode, "confidence" priority
-  publishMap();
+  start_arbiter(false, "confidence");  // priority-based mode, "confidence" priority
+  publish_map();
   const auto t0 = arbiter_->now();
 
   TrafficLightGroupArray external_traffic_signal;
   external_traffic_signal.stamp = t0;
-  external_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
+  external_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
     map_ids::vehicle_signal_a,
-    {makeTrafficLightElement(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.7f)}));
+    {make_traffic_light_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.7f)}));
 
   TrafficLightGroupArray perception_traffic_signal;
   perception_traffic_signal.stamp = t0;
-  perception_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
+  perception_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
     map_ids::vehicle_signal_a,
-    {makeTrafficLightElement(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.9f)}));
+    {make_traffic_light_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.9f)}));
 
   // Act
-  publishExternal(external_traffic_signal);
-  publishPerception(perception_traffic_signal);
+  publish_external(external_traffic_signal);
+  publish_perception(perception_traffic_signal);
 
   // Assert
-  EXPECT_EQ(observedColor(map_ids::vehicle_signal_a), TrafficLightElement::GREEN);
-  EXPECT_NEAR(observedConfidence(map_ids::vehicle_signal_a), 0.9f, kConfidenceEpsilon);
+  EXPECT_EQ(observed_color(map_ids::vehicle_signal_a), TrafficLightElement::GREEN);
+  EXPECT_NEAR(observed_confidence(map_ids::vehicle_signal_a), 0.9f, kConfidenceEpsilon);
 }
 
 // Only external contributes an id (perception silent). Both shapes survive
@@ -774,36 +779,37 @@ TEST_F(ArbiterCharacteristic, priorityBasedConfidencePicksHigherValue)
 TEST_F(ArbiterCharacteristic, priorityBasedExternalOnlyPassesThrough)
 {
   // Arrange
-  startArbiter(false, "confidence");  // priority-based mode, "confidence" priority
-  publishMap();
+  start_arbiter(false, "confidence");  // priority-based mode, "confidence" priority
+  publish_map();
   const auto t0 = arbiter_->now();
 
   TrafficLightGroupArray external_traffic_signal;
   external_traffic_signal.stamp = t0;
-  external_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
+  external_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
     map_ids::vehicle_signal_b,
-    {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.5f),
-     makeTrafficLightElement(TrafficLightElement::GREEN, TrafficLightElement::RIGHT_ARROW, 0.3f)}));
+    {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.5f),
+     make_traffic_light_element(
+       TrafficLightElement::GREEN, TrafficLightElement::RIGHT_ARROW, 0.3f)}));
 
   // Send a separate id from perception so the arbiter publishes after both
   // callbacks have settled (the test then inspects vehicle_signal_b output).
   TrafficLightGroupArray perception_traffic_signal;
   perception_traffic_signal.stamp = t0;
-  perception_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
+  perception_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
     map_ids::vehicle_signal_a,
-    {makeTrafficLightElement(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.9f)}));
+    {make_traffic_light_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.9f)}));
 
   // Act
-  publishExternal(external_traffic_signal);
-  publishPerception(perception_traffic_signal);
+  publish_external(external_traffic_signal);
+  publish_perception(perception_traffic_signal);
 
   // Assert
   const auto * group =
-    findTrafficLightGroup(latest_arbitrated_traffic_signal_, map_ids::vehicle_signal_b);
+    find_traffic_light_group(latest_arbitrated_traffic_signal_, map_ids::vehicle_signal_b);
   ASSERT_NE(group, nullptr);
   ASSERT_EQ(group->elements.size(), 2u);
-  EXPECT_NE(findTrafficLightElement(*group, TrafficLightElement::CIRCLE), nullptr);
-  EXPECT_NE(findTrafficLightElement(*group, TrafficLightElement::RIGHT_ARROW), nullptr);
+  EXPECT_NE(find_traffic_light_element(*group, TrafficLightElement::CIRCLE), nullptr);
+  EXPECT_NE(find_traffic_light_element(*group, TrafficLightElement::RIGHT_ARROW), nullptr);
 }
 
 // Only perception contributes an id (external silent). The element flows
@@ -811,31 +817,31 @@ TEST_F(ArbiterCharacteristic, priorityBasedExternalOnlyPassesThrough)
 TEST_F(ArbiterCharacteristic, priorityBasedPerceptionOnlyPassesThrough)
 {
   // Arrange
-  startArbiter(false, "confidence");  // priority-based mode, "confidence" priority
-  publishMap();
+  start_arbiter(false, "confidence");  // priority-based mode, "confidence" priority
+  publish_map();
   const auto t0 = arbiter_->now();
 
   // External must publish something for the arbiter to settle; use a
   // different id so vehicle_signal_c is perception-only.
   TrafficLightGroupArray external_traffic_signal;
   external_traffic_signal.stamp = t0;
-  external_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
+  external_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
     map_ids::vehicle_signal_a,
-    {makeTrafficLightElement(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.7f)}));
+    {make_traffic_light_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.7f)}));
 
   TrafficLightGroupArray perception_traffic_signal;
   perception_traffic_signal.stamp = t0;
-  perception_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
+  perception_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
     map_ids::vehicle_signal_c,
-    {makeTrafficLightElement(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.8f)}));
+    {make_traffic_light_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.8f)}));
 
   // Act
-  publishExternal(external_traffic_signal);
-  publishPerception(perception_traffic_signal);
+  publish_external(external_traffic_signal);
+  publish_perception(perception_traffic_signal);
 
   // Assert
-  EXPECT_EQ(observedColor(map_ids::vehicle_signal_c), TrafficLightElement::GREEN);
-  EXPECT_NEAR(observedConfidence(map_ids::vehicle_signal_c), 0.8f, kConfidenceEpsilon);
+  EXPECT_EQ(observed_color(map_ids::vehicle_signal_c), TrafficLightElement::GREEN);
+  EXPECT_NEAR(observed_confidence(map_ids::vehicle_signal_c), 0.8f, kConfidenceEpsilon);
 }
 
 // An id not in the vector map is silently dropped (WARN log only) by
@@ -843,30 +849,31 @@ TEST_F(ArbiterCharacteristic, priorityBasedPerceptionOnlyPassesThrough)
 TEST_F(ArbiterCharacteristic, priorityBasedOffMapIdDropped)
 {
   // Arrange
-  startArbiter(false, "confidence");  // priority-based mode, "confidence" priority
-  publishMap();
+  start_arbiter(false, "confidence");  // priority-based mode, "confidence" priority
+  publish_map();
   const auto t0 = arbiter_->now();
 
   TrafficLightGroupArray external_traffic_signal;
   external_traffic_signal.stamp = t0;
-  external_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
+  external_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
     kOffMapProbeId,
-    {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.9f)}));
+    {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.9f)}));
 
   TrafficLightGroupArray perception_traffic_signal;
   perception_traffic_signal.stamp = t0;
-  perception_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
+  perception_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
     map_ids::vehicle_signal_a,
-    {makeTrafficLightElement(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.9f)}));
+    {make_traffic_light_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.9f)}));
 
   // Act
-  publishExternal(external_traffic_signal);
-  publishPerception(perception_traffic_signal);
+  publish_external(external_traffic_signal);
+  publish_perception(perception_traffic_signal);
 
   // Assert
-  EXPECT_EQ(findTrafficLightGroup(latest_arbitrated_traffic_signal_, kOffMapProbeId), nullptr);
+  EXPECT_EQ(find_traffic_light_group(latest_arbitrated_traffic_signal_, kOffMapProbeId), nullptr);
   EXPECT_NE(
-    findTrafficLightGroup(latest_arbitrated_traffic_signal_, map_ids::vehicle_signal_a), nullptr);
+    find_traffic_light_group(latest_arbitrated_traffic_signal_, map_ids::vehicle_signal_a),
+    nullptr);
 }
 
 // ---------------------------------------------------------------------------
@@ -876,17 +883,17 @@ TEST_F(ArbiterCharacteristic, priorityBasedOffMapIdDropped)
 
 TEST_F(ArbiterCharacteristic, perceptionBeforeMapProducesNoOutput)
 {
-  // Arrange (intentionally no publishMap())
-  startArbiter(false, "confidence");  // priority-based mode, "confidence" priority
+  // Arrange (intentionally no publish_map())
+  start_arbiter(false, "confidence");  // priority-based mode, "confidence" priority
 
   TrafficLightGroupArray perception_traffic_signal;
   perception_traffic_signal.stamp = arbiter_->now();
-  perception_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
+  perception_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
     map_ids::vehicle_signal_a,
-    {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE)}));
+    {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)}));
 
   // Act
-  publishPerception(perception_traffic_signal);
+  publish_perception(perception_traffic_signal);
 
   // Assert
   EXPECT_EQ(arbiter_publish_count_, 0u)
@@ -899,17 +906,17 @@ TEST_F(ArbiterCharacteristic, perceptionBeforeMapProducesNoOutput)
 TEST_F(ArbiterCharacteristic, emptyMapProducesEmptyOutput)
 {
   // Arrange: replace the default minimal map with a signal-free one.
-  startArbiter(false, "confidence");  // priority-based mode, "confidence" priority
-  publishMap(buildEmptyMapBin());
+  start_arbiter(false, "confidence");  // priority-based mode, "confidence" priority
+  publish_map(build_empty_map_bin());
 
   TrafficLightGroupArray perception_traffic_signal;
   perception_traffic_signal.stamp = arbiter_->now();
-  perception_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
+  perception_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
     map_ids::vehicle_signal_a,
-    {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE)}));
+    {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)}));
 
   // Act
-  publishPerception(perception_traffic_signal);
+  publish_perception(perception_traffic_signal);
 
   // Assert: arbiter publishes, but the output contains no groups.
   // The publish-count check distinguishes "no publish happened" from
@@ -926,58 +933,58 @@ TEST_F(ArbiterCharacteristic, emptyMapProducesEmptyOutput)
 TEST_F(ArbiterCharacteristic, unknownSourcePriorityFallsBackToConfidence)
 {
   // Arrange: pass a value not in {"external", "perception", "confidence"}.
-  startArbiter(false, "invalid_value");  // priority-based mode, "invalid_value" priority
-  publishMap();
+  start_arbiter(false, "invalid_value");  // priority-based mode, "invalid_value" priority
+  publish_map();
   const auto t0 = arbiter_->now();
 
   TrafficLightGroupArray external_traffic_signal;
   external_traffic_signal.stamp = t0;
-  external_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
+  external_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
     map_ids::vehicle_signal_a,
-    {makeTrafficLightElement(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.7f)}));
+    {make_traffic_light_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.7f)}));
 
   TrafficLightGroupArray perception_traffic_signal;
   perception_traffic_signal.stamp = t0;
-  perception_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
+  perception_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
     map_ids::vehicle_signal_a,
-    {makeTrafficLightElement(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.9f)}));
+    {make_traffic_light_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.9f)}));
 
   // Act
-  publishExternal(external_traffic_signal);
-  publishPerception(perception_traffic_signal);
+  publish_external(external_traffic_signal);
+  publish_perception(perception_traffic_signal);
 
   // Assert: CONFIDENCE behavior - the higher-confidence perception wins.
-  EXPECT_EQ(observedColor(map_ids::vehicle_signal_a), TrafficLightElement::GREEN);
-  EXPECT_NEAR(observedConfidence(map_ids::vehicle_signal_a), 0.9f, kConfidenceEpsilon);
+  EXPECT_EQ(observed_color(map_ids::vehicle_signal_a), TrafficLightElement::GREEN);
+  EXPECT_NEAR(observed_confidence(map_ids::vehicle_signal_a), 0.9f, kConfidenceEpsilon);
 }
 
 TEST_F(ArbiterCharacteristic, priorityFlagOverridesHigherConfidence)
 {
   // Arrange
-  startArbiter(false, "perception");  // priority-based mode, "perception" priority
-  publishMap();
+  start_arbiter(false, "perception");  // priority-based mode, "perception" priority
+  publish_map();
   const auto t0 = arbiter_->now();
 
   // The confidence contrast (high external vs low perception) makes the
   // priority override explicit: the lower-confidence perception still wins.
   TrafficLightGroupArray external_traffic_signal;
   external_traffic_signal.stamp = t0;
-  external_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
+  external_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
     map_ids::vehicle_signal_a,
-    {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.99f)}));
+    {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.99f)}));
 
   TrafficLightGroupArray perception_traffic_signal;
   perception_traffic_signal.stamp = t0;
-  perception_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
+  perception_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
     map_ids::vehicle_signal_a,
-    {makeTrafficLightElement(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.10f)}));
+    {make_traffic_light_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.10f)}));
 
   // Act
-  publishExternal(external_traffic_signal);
-  publishPerception(perception_traffic_signal);
+  publish_external(external_traffic_signal);
+  publish_perception(perception_traffic_signal);
 
   // Assert: perception priority wins despite its lower confidence.
-  EXPECT_EQ(observedColor(map_ids::vehicle_signal_a), TrafficLightElement::GREEN);
+  EXPECT_EQ(observed_color(map_ids::vehicle_signal_a), TrafficLightElement::GREEN);
 }
 
 // Symmetric counterpart of priorityFlagOverridesHigherConfidence: with
@@ -987,30 +994,30 @@ TEST_F(ArbiterCharacteristic, priorityFlagOverridesHigherConfidence)
 TEST_F(ArbiterCharacteristic, priorityFlagFromExternalOverridesHigherConfidence)
 {
   // Arrange
-  startArbiter(false, "external");  // priority-based mode, "external" priority
-  publishMap();
+  start_arbiter(false, "external");  // priority-based mode, "external" priority
+  publish_map();
   const auto t0 = arbiter_->now();
 
   // The confidence contrast (low external vs high perception) makes the
   // priority override explicit: the lower-confidence external still wins.
   TrafficLightGroupArray external_traffic_signal;
   external_traffic_signal.stamp = t0;
-  external_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
+  external_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
     map_ids::vehicle_signal_a,
-    {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.10f)}));
+    {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.10f)}));
 
   TrafficLightGroupArray perception_traffic_signal;
   perception_traffic_signal.stamp = t0;
-  perception_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
+  perception_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
     map_ids::vehicle_signal_a,
-    {makeTrafficLightElement(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.99f)}));
+    {make_traffic_light_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.99f)}));
 
   // Act
-  publishExternal(external_traffic_signal);
-  publishPerception(perception_traffic_signal);
+  publish_external(external_traffic_signal);
+  publish_perception(perception_traffic_signal);
 
   // Assert: external priority wins despite its lower confidence.
-  EXPECT_EQ(observedColor(map_ids::vehicle_signal_a), TrafficLightElement::RED);
+  EXPECT_EQ(observed_color(map_ids::vehicle_signal_a), TrafficLightElement::RED);
 }
 
 // Successive external publishes that carry different ids accumulate in the
@@ -1019,17 +1026,17 @@ TEST_F(ArbiterCharacteristic, priorityFlagFromExternalOverridesHigherConfidence)
 TEST_F(ArbiterCharacteristic, multipleExternalSourcesAccumulate)
 {
   // Arrange
-  startArbiter(false, "confidence");  // priority-based mode, "confidence" priority
-  publishMap();
+  start_arbiter(false, "confidence");  // priority-based mode, "confidence" priority
+  publish_map();
   const auto t0 = arbiter_->now();
 
   // Act 1: publish the first external signal (id vehicle_signal_a).
   TrafficLightGroupArray first_external_traffic_signal;
   first_external_traffic_signal.stamp = t0;
-  first_external_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
+  first_external_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
     map_ids::vehicle_signal_a,
-    {makeTrafficLightElement(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE)}));
-  publishExternal(first_external_traffic_signal);
+    {make_traffic_light_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE)}));
+  publish_external(first_external_traffic_signal);
 
   // Assert 1: only vehicle_signal_a is visible after the first publish.
   ASSERT_EQ(latest_arbitrated_traffic_signal_.traffic_light_groups.size(), 1u);
@@ -1040,45 +1047,45 @@ TEST_F(ArbiterCharacteristic, multipleExternalSourcesAccumulate)
   // Act 2: publish a second external signal carrying a different id.
   TrafficLightGroupArray second_external_traffic_signal;
   second_external_traffic_signal.stamp = t0;
-  second_external_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
+  second_external_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
     map_ids::vehicle_signal_b,
-    {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE)}));
-  publishExternal(second_external_traffic_signal);
+    {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)}));
+  publish_external(second_external_traffic_signal);
 
   // Assert 2: both vehicle_signal_a and vehicle_signal_b appear in the output.
   EXPECT_EQ(latest_arbitrated_traffic_signal_.traffic_light_groups.size(), 2u);
-  EXPECT_EQ(observedColor(map_ids::vehicle_signal_a), TrafficLightElement::GREEN);
-  EXPECT_EQ(observedColor(map_ids::vehicle_signal_b), TrafficLightElement::RED);
+  EXPECT_EQ(observed_color(map_ids::vehicle_signal_a), TrafficLightElement::GREEN);
+  EXPECT_EQ(observed_color(map_ids::vehicle_signal_b), TrafficLightElement::RED);
 }
 
 TEST_F(ArbiterCharacteristic, externalDelayToleranceDropsStaleMessage)
 {
   // Arrange: establish a perception baseline so we can detect any extra publish.
-  startArbiter(false, "confidence");  // priority-based mode, "confidence" priority
-  publishMap();
+  start_arbiter(false, "confidence");  // priority-based mode, "confidence" priority
+  publish_map();
 
   TrafficLightGroupArray perception_traffic_signal;
   perception_traffic_signal.stamp = arbiter_->now();
-  perception_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
+  perception_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
     map_ids::vehicle_signal_a,
-    {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE)}));
-  publishPerception(perception_traffic_signal);
+    {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)}));
+  publish_perception(perception_traffic_signal);
   const auto baseline_count = arbiter_publish_count_;
 
   // external_delay_tolerance defaults to 5.0s; 20s in the past is well past it.
   TrafficLightGroupArray stale_external_traffic_signal;
-  stale_external_traffic_signal.stamp = offsetTime(arbiter_->now(), -20.0);
-  stale_external_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
+  stale_external_traffic_signal.stamp = offset_time(arbiter_->now(), -20.0);
+  stale_external_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
     map_ids::vehicle_signal_a,
-    {makeTrafficLightElement(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE)}));
+    {make_traffic_light_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE)}));
 
   // Act
-  publishExternal(stale_external_traffic_signal);
+  publish_external(stale_external_traffic_signal);
 
   // Assert
   EXPECT_EQ(arbiter_publish_count_, baseline_count)
     << "Stale external message must be dropped before arbitrateAndPublish runs";
-  EXPECT_EQ(observedColor(map_ids::vehicle_signal_a), TrafficLightElement::RED)
+  EXPECT_EQ(observed_color(map_ids::vehicle_signal_a), TrafficLightElement::RED)
     << "Last publish must reflect perception";
 }
 
@@ -1086,28 +1093,28 @@ TEST_F(ArbiterCharacteristic, externalTimeToleranceCleanupOnPerception)
 {
   // Arrange: seed an external entry that should be purged by the perception
   // arrival's cleanupExpiredExternalSignals (perception is +6s newer).
-  startArbiter(false, "confidence");  // priority-based mode, "confidence" priority
-  publishMap();
+  start_arbiter(false, "confidence");  // priority-based mode, "confidence" priority
+  publish_map();
   const auto t0 = arbiter_->now();
 
   TrafficLightGroupArray external_traffic_signal;
   external_traffic_signal.stamp = t0;
-  external_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
+  external_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
     map_ids::vehicle_signal_a,
-    {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE)}));
-  publishExternal(external_traffic_signal);
+    {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)}));
+  publish_external(external_traffic_signal);
 
   TrafficLightGroupArray perception_traffic_signal;
-  perception_traffic_signal.stamp = offsetTime(t0, 6.0);
-  perception_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
+  perception_traffic_signal.stamp = offset_time(t0, 6.0);
+  perception_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
     map_ids::vehicle_signal_a,
-    {makeTrafficLightElement(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE)}));
+    {make_traffic_light_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE)}));
 
   // Act
-  publishPerception(perception_traffic_signal);
+  publish_perception(perception_traffic_signal);
 
   // Assert
-  EXPECT_EQ(observedColor(map_ids::vehicle_signal_a), TrafficLightElement::GREEN);
+  EXPECT_EQ(observed_color(map_ids::vehicle_signal_a), TrafficLightElement::GREEN);
 }
 
 // onExternalMsg compares its own stamp to latest_perception_msg_.stamp; if
@@ -1116,56 +1123,56 @@ TEST_F(ArbiterCharacteristic, externalTimeToleranceCleanupOnPerception)
 TEST_F(ArbiterCharacteristic, perceptionTimeToleranceClearsLatestPerception)
 {
   // Arrange
-  startArbiter(false, "confidence");  // priority-based mode, "confidence" priority
-  publishMap();
+  start_arbiter(false, "confidence");  // priority-based mode, "confidence" priority
+  publish_map();
   const auto t0 = arbiter_->now();
 
   // Seed a perception value at t0.
   TrafficLightGroupArray perception_traffic_signal;
   perception_traffic_signal.stamp = t0;
-  perception_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
+  perception_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
     map_ids::vehicle_signal_a,
-    {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE)}));
-  publishPerception(perception_traffic_signal);
+    {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)}));
+  publish_perception(perception_traffic_signal);
 
   // External arrives 2.0s after perception (> perception_time_tolerance=1.0,
   // < external_delay_tolerance=5.0 so it is itself accepted).
   TrafficLightGroupArray external_traffic_signal;
-  external_traffic_signal.stamp = offsetTime(t0, 2.0);
-  external_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
+  external_traffic_signal.stamp = offset_time(t0, 2.0);
+  external_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
     map_ids::vehicle_signal_a,
-    {makeTrafficLightElement(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE)}));
+    {make_traffic_light_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE)}));
 
   // Act
-  publishExternal(external_traffic_signal);
+  publish_external(external_traffic_signal);
 
   // Assert: stale perception was wiped, output reflects only external.
-  EXPECT_EQ(observedColor(map_ids::vehicle_signal_a), TrafficLightElement::GREEN);
+  EXPECT_EQ(observed_color(map_ids::vehicle_signal_a), TrafficLightElement::GREEN);
 }
 
 TEST_F(ArbiterCharacteristic, predictionsFromSingleSidePropagate)
 {
   // Arrange
-  startArbiter(false, "confidence");  // priority-based mode, "confidence" priority
-  publishMap();
+  start_arbiter(false, "confidence");  // priority-based mode, "confidence" priority
+  publish_map();
   const auto t0 = arbiter_->now();
 
   TrafficLightGroupArray perception_traffic_signal;
   perception_traffic_signal.stamp = t0;
-  perception_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
+  perception_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
     map_ids::vehicle_signal_a,
-    {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE)},
-    {makeTrafficLightPrediction(
+    {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)},
+    {make_traffic_light_prediction(
       t0, TrafficLightElement::GREEN, TrafficLightElement::CIRCLE,
       PredictedTrafficLightState::INFORMATION_SOURCE_INTERNAL_ESTIMATION)}));
 
   // Act
-  publishPerception(perception_traffic_signal);
+  publish_perception(perception_traffic_signal);
 
   // Assert
-  ASSERT_EQ(observedPredictionCount(map_ids::vehicle_signal_a), 1u);
+  ASSERT_EQ(observed_prediction_count(map_ids::vehicle_signal_a), 1u);
   const auto * group =
-    findTrafficLightGroup(latest_arbitrated_traffic_signal_, map_ids::vehicle_signal_a);
+    find_traffic_light_group(latest_arbitrated_traffic_signal_, map_ids::vehicle_signal_a);
   EXPECT_EQ(
     group->predictions[0].information_source,
     PredictedTrafficLightState::INFORMATION_SOURCE_INTERNAL_ESTIMATION);

--- a/perception/autoware_traffic_light_arbiter/test/test_traffic_arbiter_characteristic.cpp
+++ b/perception/autoware_traffic_light_arbiter/test/test_traffic_arbiter_characteristic.cpp
@@ -404,6 +404,24 @@ protected:
     return group ? group->predictions.size() : SIZE_MAX;
   }
 
+  // Multi-element variants: pick the element whose shape matches and read
+  // its color. Used by tests that pin a shape-union output (e.g.
+  // element-count mismatch yielding UNKNOWN over CIRCLE+RIGHT_ARROW).
+  std::size_t observed_element_count(lanelet::Id signal_id) const
+  {
+    const auto * group = find_traffic_light_group(signal_id);
+    return group ? group->elements.size() : SIZE_MAX;
+  }
+  uint8_t observed_color_of_shape(lanelet::Id signal_id, uint8_t shape) const
+  {
+    const auto * group = find_traffic_light_group(signal_id);
+    if (!group) {
+      return UINT8_MAX;
+    }
+    const auto * element = find_traffic_light_element(*group, shape);
+    return element ? element->color : UINT8_MAX;
+  }
+
   // arbiter_publish_count_ (incremented by the output subscription callback)
   // is read in two specific tests where content alone cannot express the
   // contract: see perceptionBeforeMapProducesNoOutput and
@@ -514,15 +532,14 @@ TEST_F(ArbiterCharacteristic, signalMatchingElementCountMismatchProducesUnknown)
     {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE),
      make_traffic_light_element(TrafficLightElement::GREEN, TrafficLightElement::RIGHT_ARROW)}));
 
-  // Assert
-  const auto * group = find_traffic_light_group(map_ids::vehicle_signal_c);
-  ASSERT_NE(group, nullptr);
-  ASSERT_EQ(group->elements.size(), 2u);
-  EXPECT_NE(find_traffic_light_element(*group, TrafficLightElement::CIRCLE), nullptr);
-  EXPECT_NE(find_traffic_light_element(*group, TrafficLightElement::RIGHT_ARROW), nullptr);
-  for (const auto & element : group->elements) {
-    EXPECT_EQ(element.color, TrafficLightElement::UNKNOWN);
-  }
+  // Assert: shape union has both CIRCLE and RIGHT_ARROW, both as UNKNOWN.
+  EXPECT_EQ(observed_element_count(map_ids::vehicle_signal_c), 2u);
+  EXPECT_EQ(
+    observed_color_of_shape(map_ids::vehicle_signal_c, TrafficLightElement::CIRCLE),
+    TrafficLightElement::UNKNOWN);
+  EXPECT_EQ(
+    observed_color_of_shape(map_ids::vehicle_signal_c, TrafficLightElement::RIGHT_ARROW),
+    TrafficLightElement::UNKNOWN);
 }
 
 // Off-map id: an id not present in the vector map is silently dropped
@@ -737,12 +754,14 @@ TEST_F(ArbiterCharacteristic, priorityBasedExternalOnlyPassesThrough)
     t0_, map_ids::vehicle_signal_a,
     {make_traffic_light_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.9f)}));
 
-  // Assert
-  const auto * group = find_traffic_light_group(map_ids::vehicle_signal_b);
-  ASSERT_NE(group, nullptr);
-  ASSERT_EQ(group->elements.size(), 2u);
-  EXPECT_NE(find_traffic_light_element(*group, TrafficLightElement::CIRCLE), nullptr);
-  EXPECT_NE(find_traffic_light_element(*group, TrafficLightElement::RIGHT_ARROW), nullptr);
+  // Assert: external-only passes through with both shapes and colors preserved.
+  EXPECT_EQ(observed_element_count(map_ids::vehicle_signal_b), 2u);
+  EXPECT_EQ(
+    observed_color_of_shape(map_ids::vehicle_signal_b, TrafficLightElement::CIRCLE),
+    TrafficLightElement::RED);
+  EXPECT_EQ(
+    observed_color_of_shape(map_ids::vehicle_signal_b, TrafficLightElement::RIGHT_ARROW),
+    TrafficLightElement::GREEN);
 }
 
 // Only perception contributes an id (external silent). The element flows

--- a/perception/autoware_traffic_light_arbiter/test/test_traffic_arbiter_characteristic.cpp
+++ b/perception/autoware_traffic_light_arbiter/test/test_traffic_arbiter_characteristic.cpp
@@ -223,6 +223,31 @@ TrafficLightGroup make_traffic_light_group(
   return group;
 }
 
+// Compose a TrafficLightGroupArray with one group in a single expression.
+// Reduces the per-test boilerplate of declaring an array, setting the
+// stamp, and pushing a group with three calls.
+TrafficLightGroupArray make_signal_array(
+  const rclcpp::Time & stamp, lanelet::Id id, std::vector<TrafficLightElement> elements,
+  std::vector<PredictedTrafficLightState> predictions = {})
+{
+  TrafficLightGroupArray msg;
+  msg.stamp = stamp;
+  msg.traffic_light_groups.push_back(
+    make_traffic_light_group(id, std::move(elements), std::move(predictions)));
+  return msg;
+}
+
+// Multi-group variant for tests that publish several ids in one message
+// (e.g. off-map-drop tests that mix an on-map id with kOffMapProbeId).
+TrafficLightGroupArray make_signal_array(
+  const rclcpp::Time & stamp, std::vector<TrafficLightGroup> groups)
+{
+  TrafficLightGroupArray msg;
+  msg.stamp = stamp;
+  msg.traffic_light_groups = std::move(groups);
+  return msg;
+}
+
 // --- Timestamp utility -------------------------------------------------
 
 builtin_interfaces::msg::Time offset_time(const rclcpp::Time & base, double seconds)
@@ -458,23 +483,15 @@ TEST_F(ArbiterCharacteristic, signalMatchingMatchedPassesThrough)
   start_arbiter(true, "confidence");  // signal matching mode, "confidence" priority
   publish_map();
 
-  TrafficLightGroupArray external_traffic_signal;
-  external_traffic_signal.stamp = t0_;
-  external_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
-    map_ids::vehicle_signal_a,
-    {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)},
-    {make_traffic_light_prediction(external_traffic_signal.stamp)}));
-
-  TrafficLightGroupArray perception_traffic_signal;
-  perception_traffic_signal.stamp = t0_;
-  perception_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
-    map_ids::vehicle_signal_a,
-    {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)},
-    {make_traffic_light_prediction(perception_traffic_signal.stamp)}));
-
   // Act
-  publish_external(external_traffic_signal);
-  publish_perception(perception_traffic_signal);
+  publish_external(make_signal_array(
+    t0_, map_ids::vehicle_signal_a,
+    {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)},
+    {make_traffic_light_prediction(t0_)}));
+  publish_perception(make_signal_array(
+    t0_, map_ids::vehicle_signal_a,
+    {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)},
+    {make_traffic_light_prediction(t0_)}));
 
   // Assert
   EXPECT_EQ(observed_color(map_ids::vehicle_signal_a), TrafficLightElement::RED);
@@ -489,21 +506,13 @@ TEST_F(ArbiterCharacteristic, signalMatchingColorMismatchProducesUnknown)
   start_arbiter(true, "confidence");  // signal matching mode, "confidence" priority
   publish_map();
 
-  TrafficLightGroupArray external_traffic_signal;
-  external_traffic_signal.stamp = t0_;
-  external_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
-    map_ids::vehicle_signal_b,
-    {make_traffic_light_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE)}));
-
-  TrafficLightGroupArray perception_traffic_signal;
-  perception_traffic_signal.stamp = t0_;
-  perception_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
-    map_ids::vehicle_signal_b,
-    {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)}));
-
   // Act
-  publish_external(external_traffic_signal);
-  publish_perception(perception_traffic_signal);
+  publish_external(make_signal_array(
+    t0_, map_ids::vehicle_signal_b,
+    {make_traffic_light_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE)}));
+  publish_perception(make_signal_array(
+    t0_, map_ids::vehicle_signal_b,
+    {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)}));
 
   // Assert
   EXPECT_EQ(observed_color(map_ids::vehicle_signal_b), TrafficLightElement::UNKNOWN);
@@ -518,22 +527,14 @@ TEST_F(ArbiterCharacteristic, signalMatchingElementCountMismatchProducesUnknown)
   start_arbiter(true, "confidence");  // signal matching mode, "confidence" priority
   publish_map();
 
-  TrafficLightGroupArray external_traffic_signal;
-  external_traffic_signal.stamp = t0_;
-  external_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
-    map_ids::vehicle_signal_c,
+  // Act
+  publish_external(make_signal_array(
+    t0_, map_ids::vehicle_signal_c,
     {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)}));
-
-  TrafficLightGroupArray perception_traffic_signal;
-  perception_traffic_signal.stamp = t0_;
-  perception_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
-    map_ids::vehicle_signal_c,
+  publish_perception(make_signal_array(
+    t0_, map_ids::vehicle_signal_c,
     {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE),
      make_traffic_light_element(TrafficLightElement::GREEN, TrafficLightElement::RIGHT_ARROW)}));
-
-  // Act
-  publish_external(external_traffic_signal);
-  publish_perception(perception_traffic_signal);
 
   // Assert
   const auto * group = find_traffic_light_group(map_ids::vehicle_signal_c);
@@ -555,24 +556,17 @@ TEST_F(ArbiterCharacteristic, signalMatchingOffMapIdDropped)
   start_arbiter(true, "confidence");  // signal matching mode, "confidence" priority
   publish_map();
 
-  TrafficLightGroupArray external_traffic_signal;
-  external_traffic_signal.stamp = t0_;
-  external_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
-    kOffMapProbeId,
-    {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)}));
-  external_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
-    map_ids::vehicle_signal_a,
-    {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)}));
-
-  TrafficLightGroupArray perception_traffic_signal;
-  perception_traffic_signal.stamp = t0_;
-  perception_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
-    map_ids::vehicle_signal_a,
-    {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)}));
-
   // Act
-  publish_external(external_traffic_signal);
-  publish_perception(perception_traffic_signal);
+  publish_external(make_signal_array(
+    t0_, {make_traffic_light_group(
+            kOffMapProbeId,
+            {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)}),
+          make_traffic_light_group(
+            map_ids::vehicle_signal_a,
+            {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)})}));
+  publish_perception(make_signal_array(
+    t0_, map_ids::vehicle_signal_a,
+    {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)}));
 
   // Assert
   EXPECT_EQ(find_traffic_light_group(kOffMapProbeId), nullptr);
@@ -587,23 +581,14 @@ TEST_F(ArbiterCharacteristic, signalMatchingPedestrianFallbackUsesSourcePriority
   start_arbiter(true, "external");  // signal matching mode, "external" priority
   publish_map();
 
-  // The confidence contrast (low external vs high perception) makes the
+  // Act: confidence contrast (low external vs high perception) makes the
   // priority override explicit: the lower-confidence external wins.
-  TrafficLightGroupArray external_traffic_signal;
-  external_traffic_signal.stamp = t0_;
-  external_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
-    map_ids::pedestrian_signal,
+  publish_external(make_signal_array(
+    t0_, map_ids::pedestrian_signal,
     {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.1f)}));
-
-  TrafficLightGroupArray perception_traffic_signal;
-  perception_traffic_signal.stamp = t0_;
-  perception_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
-    map_ids::pedestrian_signal,
+  publish_perception(make_signal_array(
+    t0_, map_ids::pedestrian_signal,
     {make_traffic_light_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.9f)}));
-
-  // Act
-  publish_external(external_traffic_signal);
-  publish_perception(perception_traffic_signal);
 
   // Assert: external priority wins despite its lower confidence.
   EXPECT_EQ(observed_color(map_ids::pedestrian_signal), TrafficLightElement::RED);
@@ -619,23 +604,14 @@ TEST_F(ArbiterCharacteristic, signalMatchingPedestrianPerceptionPriority)
   start_arbiter(true, "perception");  // signal matching mode, "perception" priority
   publish_map();
 
-  TrafficLightGroupArray external_traffic_signal;
-  external_traffic_signal.stamp = t0_;
-  // The confidence contrast (high external vs low perception) makes the
+  // Act: confidence contrast (high external vs low perception) makes the
   // priority override explicit: the lower-confidence perception still wins.
-  external_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
-    map_ids::pedestrian_signal,
+  publish_external(make_signal_array(
+    t0_, map_ids::pedestrian_signal,
     {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.99f)}));
-
-  TrafficLightGroupArray perception_traffic_signal;
-  perception_traffic_signal.stamp = t0_;
-  perception_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
-    map_ids::pedestrian_signal,
+  publish_perception(make_signal_array(
+    t0_, map_ids::pedestrian_signal,
     {make_traffic_light_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.10f)}));
-
-  // Act
-  publish_external(external_traffic_signal);
-  publish_perception(perception_traffic_signal);
 
   // Assert: perception priority wins despite its lower confidence.
   EXPECT_EQ(observed_color(map_ids::pedestrian_signal), TrafficLightElement::GREEN);
@@ -650,21 +626,13 @@ TEST_F(ArbiterCharacteristic, signalMatchingPedestrianConfidenceMode)
   start_arbiter(true, "confidence");  // signal matching mode, "confidence" priority
   publish_map();
 
-  TrafficLightGroupArray external_traffic_signal;
-  external_traffic_signal.stamp = t0_;
-  external_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
-    map_ids::pedestrian_signal,
-    {make_traffic_light_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.6f)}));
-
-  TrafficLightGroupArray perception_traffic_signal;
-  perception_traffic_signal.stamp = t0_;
-  perception_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
-    map_ids::pedestrian_signal,
-    {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.9f)}));
-
   // Act
-  publish_external(external_traffic_signal);
-  publish_perception(perception_traffic_signal);
+  publish_external(make_signal_array(
+    t0_, map_ids::pedestrian_signal,
+    {make_traffic_light_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.6f)}));
+  publish_perception(make_signal_array(
+    t0_, map_ids::pedestrian_signal,
+    {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.9f)}));
 
   // Assert: CONFIDENCE picks the higher-confidence element (perception 0.9)
   EXPECT_EQ(observed_color(map_ids::pedestrian_signal), TrafficLightElement::RED);
@@ -682,14 +650,10 @@ TEST_F(ArbiterCharacteristic, signalMatchingPedestrianSingleSourcePasses)
   start_arbiter(true, "external");  // signal matching mode, "external" priority
   publish_map();
 
-  TrafficLightGroupArray perception_traffic_signal;
-  perception_traffic_signal.stamp = t0_;
-  perception_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
-    map_ids::pedestrian_signal,
-    {make_traffic_light_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE)}));
-
   // Act (no external publish)
-  publish_perception(perception_traffic_signal);
+  publish_perception(make_signal_array(
+    t0_, map_ids::pedestrian_signal,
+    {make_traffic_light_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE)}));
 
   // Assert: perception passes through unchanged (no UNKNOWN translation)
   EXPECT_EQ(observed_color(map_ids::pedestrian_signal), TrafficLightElement::GREEN);
@@ -712,21 +676,13 @@ TEST_F(ArbiterCharacteristic, signalMatchingSingleSourceNonPedestrianYieldsUnkno
   start_arbiter(true, "confidence");  // signal matching mode, "confidence" priority
   publish_map();
 
-  TrafficLightGroupArray external_traffic_signal;
-  external_traffic_signal.stamp = t0_;
-  external_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
-    map_ids::vehicle_signal_b,
+  // Act: each side carries a different id, so each id has only one source.
+  publish_external(make_signal_array(
+    t0_, map_ids::vehicle_signal_b,
     {make_traffic_light_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE)}));
-
-  TrafficLightGroupArray perception_traffic_signal;
-  perception_traffic_signal.stamp = t0_;
-  perception_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
-    map_ids::vehicle_signal_a,
+  publish_perception(make_signal_array(
+    t0_, map_ids::vehicle_signal_a,
     {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)}));
-
-  // Act
-  publish_external(external_traffic_signal);
-  publish_perception(perception_traffic_signal);
 
   // Assert
   EXPECT_EQ(observed_color(map_ids::vehicle_signal_a), TrafficLightElement::UNKNOWN);
@@ -745,21 +701,13 @@ TEST_F(ArbiterCharacteristic, signalMatchingIgnoresConfidenceInEquivalence)
   start_arbiter(true, "confidence");  // signal matching mode, "confidence" priority
   publish_map();
 
-  TrafficLightGroupArray external_traffic_signal;
-  external_traffic_signal.stamp = t0_;
-  external_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
-    map_ids::vehicle_signal_a,
-    {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.10f)}));
-
-  TrafficLightGroupArray perception_traffic_signal;
-  perception_traffic_signal.stamp = t0_;
-  perception_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
-    map_ids::vehicle_signal_a,
-    {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.90f)}));
-
   // Act
-  publish_external(external_traffic_signal);
-  publish_perception(perception_traffic_signal);
+  publish_external(make_signal_array(
+    t0_, map_ids::vehicle_signal_a,
+    {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.10f)}));
+  publish_perception(make_signal_array(
+    t0_, map_ids::vehicle_signal_a,
+    {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.90f)}));
 
   // Assert
   EXPECT_EQ(observed_color(map_ids::vehicle_signal_a), TrafficLightElement::RED);
@@ -778,21 +726,13 @@ TEST_F(ArbiterCharacteristic, priorityBasedConfidencePicksHigherValue)
   start_arbiter(false, "confidence");  // priority-based mode, "confidence" priority
   publish_map();
 
-  TrafficLightGroupArray external_traffic_signal;
-  external_traffic_signal.stamp = t0_;
-  external_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
-    map_ids::vehicle_signal_a,
-    {make_traffic_light_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.7f)}));
-
-  TrafficLightGroupArray perception_traffic_signal;
-  perception_traffic_signal.stamp = t0_;
-  perception_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
-    map_ids::vehicle_signal_a,
-    {make_traffic_light_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.9f)}));
-
   // Act
-  publish_external(external_traffic_signal);
-  publish_perception(perception_traffic_signal);
+  publish_external(make_signal_array(
+    t0_, map_ids::vehicle_signal_a,
+    {make_traffic_light_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.7f)}));
+  publish_perception(make_signal_array(
+    t0_, map_ids::vehicle_signal_a,
+    {make_traffic_light_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.9f)}));
 
   // Assert
   EXPECT_EQ(observed_color(map_ids::vehicle_signal_a), TrafficLightElement::GREEN);
@@ -807,25 +747,17 @@ TEST_F(ArbiterCharacteristic, priorityBasedExternalOnlyPassesThrough)
   start_arbiter(false, "confidence");  // priority-based mode, "confidence" priority
   publish_map();
 
-  TrafficLightGroupArray external_traffic_signal;
-  external_traffic_signal.stamp = t0_;
-  external_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
-    map_ids::vehicle_signal_b,
+  // Act
+  publish_external(make_signal_array(
+    t0_, map_ids::vehicle_signal_b,
     {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.5f),
      make_traffic_light_element(
        TrafficLightElement::GREEN, TrafficLightElement::RIGHT_ARROW, 0.3f)}));
-
   // Send a separate id from perception so the arbiter publishes after both
   // callbacks have settled (the test then inspects vehicle_signal_b output).
-  TrafficLightGroupArray perception_traffic_signal;
-  perception_traffic_signal.stamp = t0_;
-  perception_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
-    map_ids::vehicle_signal_a,
+  publish_perception(make_signal_array(
+    t0_, map_ids::vehicle_signal_a,
     {make_traffic_light_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.9f)}));
-
-  // Act
-  publish_external(external_traffic_signal);
-  publish_perception(perception_traffic_signal);
 
   // Assert
   const auto * group = find_traffic_light_group(map_ids::vehicle_signal_b);
@@ -843,23 +775,14 @@ TEST_F(ArbiterCharacteristic, priorityBasedPerceptionOnlyPassesThrough)
   start_arbiter(false, "confidence");  // priority-based mode, "confidence" priority
   publish_map();
 
-  // External must publish something for the arbiter to settle; use a
+  // Act: external must publish something for the arbiter to settle; use a
   // different id so vehicle_signal_c is perception-only.
-  TrafficLightGroupArray external_traffic_signal;
-  external_traffic_signal.stamp = t0_;
-  external_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
-    map_ids::vehicle_signal_a,
+  publish_external(make_signal_array(
+    t0_, map_ids::vehicle_signal_a,
     {make_traffic_light_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.7f)}));
-
-  TrafficLightGroupArray perception_traffic_signal;
-  perception_traffic_signal.stamp = t0_;
-  perception_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
-    map_ids::vehicle_signal_c,
+  publish_perception(make_signal_array(
+    t0_, map_ids::vehicle_signal_c,
     {make_traffic_light_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.8f)}));
-
-  // Act
-  publish_external(external_traffic_signal);
-  publish_perception(perception_traffic_signal);
 
   // Assert
   EXPECT_EQ(observed_color(map_ids::vehicle_signal_c), TrafficLightElement::GREEN);
@@ -874,21 +797,13 @@ TEST_F(ArbiterCharacteristic, priorityBasedOffMapIdDropped)
   start_arbiter(false, "confidence");  // priority-based mode, "confidence" priority
   publish_map();
 
-  TrafficLightGroupArray external_traffic_signal;
-  external_traffic_signal.stamp = t0_;
-  external_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
-    kOffMapProbeId,
-    {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.9f)}));
-
-  TrafficLightGroupArray perception_traffic_signal;
-  perception_traffic_signal.stamp = t0_;
-  perception_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
-    map_ids::vehicle_signal_a,
-    {make_traffic_light_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.9f)}));
-
   // Act
-  publish_external(external_traffic_signal);
-  publish_perception(perception_traffic_signal);
+  publish_external(make_signal_array(
+    t0_, kOffMapProbeId,
+    {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.9f)}));
+  publish_perception(make_signal_array(
+    t0_, map_ids::vehicle_signal_a,
+    {make_traffic_light_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.9f)}));
 
   // Assert
   EXPECT_EQ(find_traffic_light_group(kOffMapProbeId), nullptr);
@@ -905,14 +820,10 @@ TEST_F(ArbiterCharacteristic, perceptionBeforeMapProducesNoOutput)
   // Arrange (intentionally no publish_map())
   start_arbiter(false, "confidence");  // priority-based mode, "confidence" priority
 
-  TrafficLightGroupArray perception_traffic_signal;
-  perception_traffic_signal.stamp = t0_;
-  perception_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
-    map_ids::vehicle_signal_a,
-    {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)}));
-
   // Act
-  publish_perception(perception_traffic_signal);
+  publish_perception(make_signal_array(
+    t0_, map_ids::vehicle_signal_a,
+    {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)}));
 
   // Assert: arbitrateAndPublish should early-return when no map has been received.
   expect_no_publish();
@@ -927,14 +838,10 @@ TEST_F(ArbiterCharacteristic, emptyMapProducesEmptyOutput)
   start_arbiter(false, "confidence");  // priority-based mode, "confidence" priority
   publish_map(build_empty_map_bin());
 
-  TrafficLightGroupArray perception_traffic_signal;
-  perception_traffic_signal.stamp = t0_;
-  perception_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
-    map_ids::vehicle_signal_a,
-    {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)}));
-
   // Act
-  publish_perception(perception_traffic_signal);
+  publish_perception(make_signal_array(
+    t0_, map_ids::vehicle_signal_a,
+    {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)}));
 
   // Assert: arbiter publishes, but the output contains no groups.
   expect_publish_happened();
@@ -952,21 +859,13 @@ TEST_F(ArbiterCharacteristic, unknownSourcePriorityFallsBackToConfidence)
   start_arbiter(false, "invalid_value");  // priority-based mode, "invalid_value" priority
   publish_map();
 
-  TrafficLightGroupArray external_traffic_signal;
-  external_traffic_signal.stamp = t0_;
-  external_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
-    map_ids::vehicle_signal_a,
-    {make_traffic_light_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.7f)}));
-
-  TrafficLightGroupArray perception_traffic_signal;
-  perception_traffic_signal.stamp = t0_;
-  perception_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
-    map_ids::vehicle_signal_a,
-    {make_traffic_light_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.9f)}));
-
   // Act
-  publish_external(external_traffic_signal);
-  publish_perception(perception_traffic_signal);
+  publish_external(make_signal_array(
+    t0_, map_ids::vehicle_signal_a,
+    {make_traffic_light_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.7f)}));
+  publish_perception(make_signal_array(
+    t0_, map_ids::vehicle_signal_a,
+    {make_traffic_light_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.9f)}));
 
   // Assert: CONFIDENCE behavior - the higher-confidence perception wins.
   EXPECT_EQ(observed_color(map_ids::vehicle_signal_a), TrafficLightElement::GREEN);
@@ -979,23 +878,14 @@ TEST_F(ArbiterCharacteristic, priorityFlagOverridesHigherConfidence)
   start_arbiter(false, "perception");  // priority-based mode, "perception" priority
   publish_map();
 
-  // The confidence contrast (high external vs low perception) makes the
+  // Act: confidence contrast (high external vs low perception) makes the
   // priority override explicit: the lower-confidence perception still wins.
-  TrafficLightGroupArray external_traffic_signal;
-  external_traffic_signal.stamp = t0_;
-  external_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
-    map_ids::vehicle_signal_a,
+  publish_external(make_signal_array(
+    t0_, map_ids::vehicle_signal_a,
     {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.99f)}));
-
-  TrafficLightGroupArray perception_traffic_signal;
-  perception_traffic_signal.stamp = t0_;
-  perception_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
-    map_ids::vehicle_signal_a,
+  publish_perception(make_signal_array(
+    t0_, map_ids::vehicle_signal_a,
     {make_traffic_light_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.10f)}));
-
-  // Act
-  publish_external(external_traffic_signal);
-  publish_perception(perception_traffic_signal);
 
   // Assert: perception priority wins despite its lower confidence.
   EXPECT_EQ(observed_color(map_ids::vehicle_signal_a), TrafficLightElement::GREEN);
@@ -1011,23 +901,14 @@ TEST_F(ArbiterCharacteristic, priorityFlagFromExternalOverridesHigherConfidence)
   start_arbiter(false, "external");  // priority-based mode, "external" priority
   publish_map();
 
-  // The confidence contrast (low external vs high perception) makes the
+  // Act: confidence contrast (low external vs high perception) makes the
   // priority override explicit: the lower-confidence external still wins.
-  TrafficLightGroupArray external_traffic_signal;
-  external_traffic_signal.stamp = t0_;
-  external_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
-    map_ids::vehicle_signal_a,
+  publish_external(make_signal_array(
+    t0_, map_ids::vehicle_signal_a,
     {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.10f)}));
-
-  TrafficLightGroupArray perception_traffic_signal;
-  perception_traffic_signal.stamp = t0_;
-  perception_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
-    map_ids::vehicle_signal_a,
+  publish_perception(make_signal_array(
+    t0_, map_ids::vehicle_signal_a,
     {make_traffic_light_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.99f)}));
-
-  // Act
-  publish_external(external_traffic_signal);
-  publish_perception(perception_traffic_signal);
 
   // Assert: external priority wins despite its lower confidence.
   EXPECT_EQ(observed_color(map_ids::vehicle_signal_a), TrafficLightElement::RED);
@@ -1043,12 +924,9 @@ TEST_F(ArbiterCharacteristic, multipleExternalSourcesAccumulate)
   publish_map();
 
   // Act 1: publish the first external signal (id vehicle_signal_a).
-  TrafficLightGroupArray first_external_traffic_signal;
-  first_external_traffic_signal.stamp = t0_;
-  first_external_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
-    map_ids::vehicle_signal_a,
+  publish_external(make_signal_array(
+    t0_, map_ids::vehicle_signal_a,
     {make_traffic_light_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE)}));
-  publish_external(first_external_traffic_signal);
 
   // Assert 1: only vehicle_signal_a is visible after the first publish.
   ASSERT_EQ(latest_arbitrated_traffic_signal_.traffic_light_groups.size(), 1u);
@@ -1057,12 +935,9 @@ TEST_F(ArbiterCharacteristic, multipleExternalSourcesAccumulate)
     map_ids::vehicle_signal_a);
 
   // Act 2: publish a second external signal carrying a different id.
-  TrafficLightGroupArray second_external_traffic_signal;
-  second_external_traffic_signal.stamp = t0_;
-  second_external_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
-    map_ids::vehicle_signal_b,
+  publish_external(make_signal_array(
+    t0_, map_ids::vehicle_signal_b,
     {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)}));
-  publish_external(second_external_traffic_signal);
 
   // Assert 2: both vehicle_signal_a and vehicle_signal_b appear in the output.
   EXPECT_EQ(latest_arbitrated_traffic_signal_.traffic_light_groups.size(), 2u);
@@ -1075,24 +950,15 @@ TEST_F(ArbiterCharacteristic, externalDelayToleranceDropsStaleMessage)
   // Arrange: establish a perception baseline so we can detect any extra publish.
   start_arbiter(false, "confidence");  // priority-based mode, "confidence" priority
   publish_map();
-
-  TrafficLightGroupArray perception_traffic_signal;
-  perception_traffic_signal.stamp = t0_;
-  perception_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
-    map_ids::vehicle_signal_a,
+  publish_perception(make_signal_array(
+    t0_, map_ids::vehicle_signal_a,
     {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)}));
-  publish_perception(perception_traffic_signal);
   const auto baseline = publish_count();
 
-  // external_delay_tolerance defaults to 5.0s; 20s in the past is well past it.
-  TrafficLightGroupArray stale_external_traffic_signal;
-  stale_external_traffic_signal.stamp = offset_time(t0_, -20.0);
-  stale_external_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
-    map_ids::vehicle_signal_a,
+  // Act: external_delay_tolerance defaults to 5.0s; 20s in the past is well past it.
+  publish_external(make_signal_array(
+    offset_time(t0_, -20.0), map_ids::vehicle_signal_a,
     {make_traffic_light_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE)}));
-
-  // Act
-  publish_external(stale_external_traffic_signal);
 
   // Assert: stale external message must be dropped before arbitrateAndPublish runs.
   expect_no_publish_since(baseline);
@@ -1106,22 +972,14 @@ TEST_F(ArbiterCharacteristic, externalTimeToleranceCleanupOnPerception)
   // arrival's cleanupExpiredExternalSignals (perception is +6s newer).
   start_arbiter(false, "confidence");  // priority-based mode, "confidence" priority
   publish_map();
-
-  TrafficLightGroupArray external_traffic_signal;
-  external_traffic_signal.stamp = t0_;
-  external_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
-    map_ids::vehicle_signal_a,
+  publish_external(make_signal_array(
+    t0_, map_ids::vehicle_signal_a,
     {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)}));
-  publish_external(external_traffic_signal);
-
-  TrafficLightGroupArray perception_traffic_signal;
-  perception_traffic_signal.stamp = offset_time(t0_, 6.0);
-  perception_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
-    map_ids::vehicle_signal_a,
-    {make_traffic_light_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE)}));
 
   // Act
-  publish_perception(perception_traffic_signal);
+  publish_perception(make_signal_array(
+    offset_time(t0_, 6.0), map_ids::vehicle_signal_a,
+    {make_traffic_light_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE)}));
 
   // Assert
   EXPECT_EQ(observed_color(map_ids::vehicle_signal_a), TrafficLightElement::GREEN);
@@ -1137,23 +995,15 @@ TEST_F(ArbiterCharacteristic, perceptionTimeToleranceClearsLatestPerception)
   publish_map();
 
   // Seed a perception value at t0_.
-  TrafficLightGroupArray perception_traffic_signal;
-  perception_traffic_signal.stamp = t0_;
-  perception_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
-    map_ids::vehicle_signal_a,
+  publish_perception(make_signal_array(
+    t0_, map_ids::vehicle_signal_a,
     {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)}));
-  publish_perception(perception_traffic_signal);
 
-  // External arrives 2.0s after perception (> perception_time_tolerance=1.0,
+  // Act: external arrives 2.0s after perception (> perception_time_tolerance=1.0,
   // < external_delay_tolerance=5.0 so it is itself accepted).
-  TrafficLightGroupArray external_traffic_signal;
-  external_traffic_signal.stamp = offset_time(t0_, 2.0);
-  external_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
-    map_ids::vehicle_signal_a,
+  publish_external(make_signal_array(
+    offset_time(t0_, 2.0), map_ids::vehicle_signal_a,
     {make_traffic_light_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE)}));
-
-  // Act
-  publish_external(external_traffic_signal);
 
   // Assert: stale perception was wiped, output reflects only external.
   EXPECT_EQ(observed_color(map_ids::vehicle_signal_a), TrafficLightElement::GREEN);
@@ -1165,17 +1015,13 @@ TEST_F(ArbiterCharacteristic, predictionsFromSingleSidePropagate)
   start_arbiter(false, "confidence");  // priority-based mode, "confidence" priority
   publish_map();
 
-  TrafficLightGroupArray perception_traffic_signal;
-  perception_traffic_signal.stamp = t0_;
-  perception_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
-    map_ids::vehicle_signal_a,
+  // Act
+  publish_perception(make_signal_array(
+    t0_, map_ids::vehicle_signal_a,
     {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)},
     {make_traffic_light_prediction(
       t0_, TrafficLightElement::GREEN, TrafficLightElement::CIRCLE,
       PredictedTrafficLightState::INFORMATION_SOURCE_INTERNAL_ESTIMATION)}));
-
-  // Act
-  publish_perception(perception_traffic_signal);
 
   // Assert
   ASSERT_EQ(observed_prediction_count(map_ids::vehicle_signal_a), 1u);

--- a/perception/autoware_traffic_light_arbiter/test/test_traffic_arbiter_characteristic.cpp
+++ b/perception/autoware_traffic_light_arbiter/test/test_traffic_arbiter_characteristic.cpp
@@ -187,9 +187,14 @@ TrafficLightElement make_traffic_light_element(
   return element;
 }
 
+// Build a PredictedTrafficLightState with the given stamp. Color, shape,
+// and source default to placeholder values because most tests only assert
+// presence or count of predictions; tests that pin a specific source
+// (e.g., predictionsFromSingleSidePropagate) pass it explicitly.
 PredictedTrafficLightState make_traffic_light_prediction(
-  const builtin_interfaces::msg::Time & stamp, uint8_t color, uint8_t shape,
-  const std::string & source)
+  const builtin_interfaces::msg::Time & stamp, uint8_t color = TrafficLightElement::UNKNOWN,
+  uint8_t shape = TrafficLightElement::CIRCLE,
+  const std::string & source = PredictedTrafficLightState::INFORMATION_SOURCE_INTERNAL_ESTIMATION)
 {
   // The arbiter passes predictions through without inspecting any field
   // value, so the numbers below only need to form a syntactically complete
@@ -458,18 +463,14 @@ TEST_F(ArbiterCharacteristic, signalMatchingMatchedPassesThrough)
   external_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
     map_ids::vehicle_signal_a,
     {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)},
-    {make_traffic_light_prediction(
-      external_traffic_signal.stamp, TrafficLightElement::GREEN, TrafficLightElement::CIRCLE,
-      PredictedTrafficLightState::INFORMATION_SOURCE_V2I)}));
+    {make_traffic_light_prediction(external_traffic_signal.stamp)}));
 
   TrafficLightGroupArray perception_traffic_signal;
   perception_traffic_signal.stamp = t0_;
   perception_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
     map_ids::vehicle_signal_a,
     {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)},
-    {make_traffic_light_prediction(
-      perception_traffic_signal.stamp, TrafficLightElement::RED, TrafficLightElement::CIRCLE,
-      PredictedTrafficLightState::INFORMATION_SOURCE_INTERNAL_ESTIMATION)}));
+    {make_traffic_light_prediction(perception_traffic_signal.stamp)}));
 
   // Act
   publish_external(external_traffic_signal);

--- a/perception/autoware_traffic_light_arbiter/test/test_traffic_arbiter_characteristic.cpp
+++ b/perception/autoware_traffic_light_arbiter/test/test_traffic_arbiter_characteristic.cpp
@@ -225,29 +225,9 @@ builtin_interfaces::msg::Time offset_time(const rclcpp::Time & base, double seco
   return (base + rclcpp::Duration::from_seconds(seconds));
 }
 
-// --- Output inspection helpers -----------------------------------------
-
-const TrafficLightGroup * find_traffic_light_group(
-  const TrafficLightGroupArray & msg, lanelet::Id id)
-{
-  for (const auto & group : msg.traffic_light_groups) {
-    if (group.traffic_light_group_id == id) {
-      return &group;
-    }
-  }
-  return nullptr;
-}
-
-const TrafficLightElement * find_traffic_light_element(
-  const TrafficLightGroup & group, uint8_t shape)
-{
-  for (const auto & element : group.elements) {
-    if (element.shape == shape) {
-      return &element;
-    }
-  }
-  return nullptr;
-}
+// Output inspection helpers live on the fixture (see find_traffic_light_group
+// and find_traffic_light_element) so they can read latest_arbitrated_traffic_signal_
+// implicitly and share a layer with observed_color/shape/... etc.
 
 // --- Test fixture ------------------------------------------------------
 
@@ -346,28 +326,51 @@ protected:
     }
   }
 
+  // Look up a TrafficLightGroup or TrafficLightElement in the latest
+  // arbitrated output. Returning nullptr signals "not present"; tests
+  // pair this with ASSERT_NE / EXPECT_EQ accordingly.
+  const TrafficLightGroup * find_traffic_light_group(lanelet::Id id) const
+  {
+    for (const auto & group : latest_arbitrated_traffic_signal_.traffic_light_groups) {
+      if (group.traffic_light_group_id == id) {
+        return &group;
+      }
+    }
+    return nullptr;
+  }
+  const TrafficLightElement * find_traffic_light_element(
+    const TrafficLightGroup & group, uint8_t shape) const
+  {
+    for (const auto & element : group.elements) {
+      if (element.shape == shape) {
+        return &element;
+      }
+    }
+    return nullptr;
+  }
+
   // Return the first element's color/shape/confidence for the given id in
   // the latest arbitrated output. When the id is absent or has no
   // elements, return a sentinel value (UINT8_MAX / -1.0f) that is never
   // valid, so EXPECT_EQ at the call site fails loudly.
   uint8_t observed_color(lanelet::Id signal_id) const
   {
-    const auto * group = find_traffic_light_group(latest_arbitrated_traffic_signal_, signal_id);
+    const auto * group = find_traffic_light_group(signal_id);
     return (group && !group->elements.empty()) ? group->elements[0].color : UINT8_MAX;
   }
   uint8_t observed_shape(lanelet::Id signal_id) const
   {
-    const auto * group = find_traffic_light_group(latest_arbitrated_traffic_signal_, signal_id);
+    const auto * group = find_traffic_light_group(signal_id);
     return (group && !group->elements.empty()) ? group->elements[0].shape : UINT8_MAX;
   }
   float observed_confidence(lanelet::Id signal_id) const
   {
-    const auto * group = find_traffic_light_group(latest_arbitrated_traffic_signal_, signal_id);
+    const auto * group = find_traffic_light_group(signal_id);
     return (group && !group->elements.empty()) ? group->elements[0].confidence : -1.0f;
   }
   std::size_t observed_prediction_count(lanelet::Id signal_id) const
   {
-    const auto * group = find_traffic_light_group(latest_arbitrated_traffic_signal_, signal_id);
+    const auto * group = find_traffic_light_group(signal_id);
     return group ? group->predictions.size() : SIZE_MAX;
   }
 
@@ -532,8 +535,7 @@ TEST_F(ArbiterCharacteristic, signalMatchingElementCountMismatchProducesUnknown)
   publish_perception(perception_traffic_signal);
 
   // Assert
-  const auto * group =
-    find_traffic_light_group(latest_arbitrated_traffic_signal_, map_ids::vehicle_signal_c);
+  const auto * group = find_traffic_light_group(map_ids::vehicle_signal_c);
   ASSERT_NE(group, nullptr);
   ASSERT_EQ(group->elements.size(), 2u);
   EXPECT_NE(find_traffic_light_element(*group, TrafficLightElement::CIRCLE), nullptr);
@@ -572,10 +574,8 @@ TEST_F(ArbiterCharacteristic, signalMatchingOffMapIdDropped)
   publish_perception(perception_traffic_signal);
 
   // Assert
-  EXPECT_EQ(find_traffic_light_group(latest_arbitrated_traffic_signal_, kOffMapProbeId), nullptr);
-  EXPECT_NE(
-    find_traffic_light_group(latest_arbitrated_traffic_signal_, map_ids::vehicle_signal_a),
-    nullptr);
+  EXPECT_EQ(find_traffic_light_group(kOffMapProbeId), nullptr);
+  EXPECT_NE(find_traffic_light_group(map_ids::vehicle_signal_a), nullptr);
 }
 
 // Pedestrian path bypasses element matching; with source_priority=external
@@ -827,8 +827,7 @@ TEST_F(ArbiterCharacteristic, priorityBasedExternalOnlyPassesThrough)
   publish_perception(perception_traffic_signal);
 
   // Assert
-  const auto * group =
-    find_traffic_light_group(latest_arbitrated_traffic_signal_, map_ids::vehicle_signal_b);
+  const auto * group = find_traffic_light_group(map_ids::vehicle_signal_b);
   ASSERT_NE(group, nullptr);
   ASSERT_EQ(group->elements.size(), 2u);
   EXPECT_NE(find_traffic_light_element(*group, TrafficLightElement::CIRCLE), nullptr);
@@ -891,10 +890,8 @@ TEST_F(ArbiterCharacteristic, priorityBasedOffMapIdDropped)
   publish_perception(perception_traffic_signal);
 
   // Assert
-  EXPECT_EQ(find_traffic_light_group(latest_arbitrated_traffic_signal_, kOffMapProbeId), nullptr);
-  EXPECT_NE(
-    find_traffic_light_group(latest_arbitrated_traffic_signal_, map_ids::vehicle_signal_a),
-    nullptr);
+  EXPECT_EQ(find_traffic_light_group(kOffMapProbeId), nullptr);
+  EXPECT_NE(find_traffic_light_group(map_ids::vehicle_signal_a), nullptr);
 }
 
 // ---------------------------------------------------------------------------
@@ -1181,8 +1178,7 @@ TEST_F(ArbiterCharacteristic, predictionsFromSingleSidePropagate)
 
   // Assert
   ASSERT_EQ(observed_prediction_count(map_ids::vehicle_signal_a), 1u);
-  const auto * group =
-    find_traffic_light_group(latest_arbitrated_traffic_signal_, map_ids::vehicle_signal_a);
+  const auto * group = find_traffic_light_group(map_ids::vehicle_signal_a);
   EXPECT_EQ(
     group->predictions[0].information_source,
     PredictedTrafficLightState::INFORMATION_SOURCE_INTERNAL_ESTIMATION);

--- a/perception/autoware_traffic_light_arbiter/test/test_traffic_arbiter_characteristic.cpp
+++ b/perception/autoware_traffic_light_arbiter/test/test_traffic_arbiter_characteristic.cpp
@@ -380,14 +380,14 @@ protected:
 // Pins the full Signal Matching behavior spec: the arbiter degrades
 // gracefully as the agreement between sources weakens, falling back to
 // UNKNOWN when the signals disagree and dropping ids that are not on the
-// map. The longest path through SignalMatchValidator (4 ids in a single
-// publish) is traversed in one test:
+// map. All validation outcomes of SignalMatchValidator are exercised in
+// a single publish (4 ids):
 //   - matched (color & shape agree) -> perception passes through
 //   - color mismatch                -> UNKNOWN over the shared shape
 //   - element-count mismatch        -> UNKNOWN over the shape union
 //   - off-map id                    -> dropped (WARN+skip)
 // ---------------------------------------------------------------------------
-TEST_F(ArbiterCharacteristic, signalMatchingLongestPath)
+TEST_F(ArbiterCharacteristic, signalMatchingAllValidationOutcomes)
 {
   // Scenario inputs and expectations (confidence is omitted everywhere
   // because Signal Matching never reads it; the 1.0f default applies):

--- a/perception/autoware_traffic_light_arbiter/test/test_traffic_arbiter_characteristic.cpp
+++ b/perception/autoware_traffic_light_arbiter/test/test_traffic_arbiter_characteristic.cpp
@@ -316,6 +316,7 @@ protected:
     executor_->add_node(arbiter_);
     executor_->add_node(test_node_);
     spin_for();
+    t0_ = arbiter_->now();
   }
 
   void publish_map() { publish_map(*map_bin_); }
@@ -387,6 +388,13 @@ protected:
   TrafficLightGroupArray latest_arbitrated_traffic_signal_;
   std::size_t arbiter_publish_count_ = 0;
 
+  // Reference timestamp captured once in start_arbiter(). Tests use t0_
+  // (and offset_time(t0_, ...)) as a fixed clock so no test body needs
+  // to query the node clock again. t0_ is sampled just before each test
+  // publishes, so its small drift from the arbiter's wall clock stays
+  // well within external_delay_tolerance.
+  rclcpp::Time t0_;
+
 private:
   // Topic names used by the publishers/subscription owned by the fixture.
   static constexpr const char * kMapTopic = "/traffic_light_arbiter/sub/vector_map";
@@ -414,10 +422,9 @@ TEST_F(ArbiterCharacteristic, signalMatchingMatchedPassesThrough)
   // Arrange
   start_arbiter(true, "confidence");  // signal matching mode, "confidence" priority
   publish_map();
-  const auto t0 = arbiter_->now();
 
   TrafficLightGroupArray external_traffic_signal;
-  external_traffic_signal.stamp = t0;
+  external_traffic_signal.stamp = t0_;
   external_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
     map_ids::vehicle_signal_a,
     {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)},
@@ -426,7 +433,7 @@ TEST_F(ArbiterCharacteristic, signalMatchingMatchedPassesThrough)
       PredictedTrafficLightState::INFORMATION_SOURCE_V2I)}));
 
   TrafficLightGroupArray perception_traffic_signal;
-  perception_traffic_signal.stamp = t0;
+  perception_traffic_signal.stamp = t0_;
   perception_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
     map_ids::vehicle_signal_a,
     {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)},
@@ -450,16 +457,15 @@ TEST_F(ArbiterCharacteristic, signalMatchingColorMismatchProducesUnknown)
   // Arrange
   start_arbiter(true, "confidence");  // signal matching mode, "confidence" priority
   publish_map();
-  const auto t0 = arbiter_->now();
 
   TrafficLightGroupArray external_traffic_signal;
-  external_traffic_signal.stamp = t0;
+  external_traffic_signal.stamp = t0_;
   external_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
     map_ids::vehicle_signal_b,
     {make_traffic_light_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE)}));
 
   TrafficLightGroupArray perception_traffic_signal;
-  perception_traffic_signal.stamp = t0;
+  perception_traffic_signal.stamp = t0_;
   perception_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
     map_ids::vehicle_signal_b,
     {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)}));
@@ -480,16 +486,15 @@ TEST_F(ArbiterCharacteristic, signalMatchingElementCountMismatchProducesUnknown)
   // Arrange
   start_arbiter(true, "confidence");  // signal matching mode, "confidence" priority
   publish_map();
-  const auto t0 = arbiter_->now();
 
   TrafficLightGroupArray external_traffic_signal;
-  external_traffic_signal.stamp = t0;
+  external_traffic_signal.stamp = t0_;
   external_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
     map_ids::vehicle_signal_c,
     {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)}));
 
   TrafficLightGroupArray perception_traffic_signal;
-  perception_traffic_signal.stamp = t0;
+  perception_traffic_signal.stamp = t0_;
   perception_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
     map_ids::vehicle_signal_c,
     {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE),
@@ -519,10 +524,9 @@ TEST_F(ArbiterCharacteristic, signalMatchingOffMapIdDropped)
   // Arrange
   start_arbiter(true, "confidence");  // signal matching mode, "confidence" priority
   publish_map();
-  const auto t0 = arbiter_->now();
 
   TrafficLightGroupArray external_traffic_signal;
-  external_traffic_signal.stamp = t0;
+  external_traffic_signal.stamp = t0_;
   external_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
     kOffMapProbeId,
     {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)}));
@@ -531,7 +535,7 @@ TEST_F(ArbiterCharacteristic, signalMatchingOffMapIdDropped)
     {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)}));
 
   TrafficLightGroupArray perception_traffic_signal;
-  perception_traffic_signal.stamp = t0;
+  perception_traffic_signal.stamp = t0_;
   perception_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
     map_ids::vehicle_signal_a,
     {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)}));
@@ -554,18 +558,17 @@ TEST_F(ArbiterCharacteristic, signalMatchingPedestrianFallbackUsesSourcePriority
   // Arrange
   start_arbiter(true, "external");  // signal matching mode, "external" priority
   publish_map();
-  const auto t0 = arbiter_->now();
 
   // The confidence contrast (low external vs high perception) makes the
   // priority override explicit: the lower-confidence external wins.
   TrafficLightGroupArray external_traffic_signal;
-  external_traffic_signal.stamp = t0;
+  external_traffic_signal.stamp = t0_;
   external_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
     map_ids::pedestrian_signal,
     {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.1f)}));
 
   TrafficLightGroupArray perception_traffic_signal;
-  perception_traffic_signal.stamp = t0;
+  perception_traffic_signal.stamp = t0_;
   perception_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
     map_ids::pedestrian_signal,
     {make_traffic_light_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.9f)}));
@@ -587,10 +590,9 @@ TEST_F(ArbiterCharacteristic, signalMatchingPedestrianPerceptionPriority)
   // Arrange
   start_arbiter(true, "perception");  // signal matching mode, "perception" priority
   publish_map();
-  const auto t0 = arbiter_->now();
 
   TrafficLightGroupArray external_traffic_signal;
-  external_traffic_signal.stamp = t0;
+  external_traffic_signal.stamp = t0_;
   // The confidence contrast (high external vs low perception) makes the
   // priority override explicit: the lower-confidence perception still wins.
   external_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
@@ -598,7 +600,7 @@ TEST_F(ArbiterCharacteristic, signalMatchingPedestrianPerceptionPriority)
     {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.99f)}));
 
   TrafficLightGroupArray perception_traffic_signal;
-  perception_traffic_signal.stamp = t0;
+  perception_traffic_signal.stamp = t0_;
   perception_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
     map_ids::pedestrian_signal,
     {make_traffic_light_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.10f)}));
@@ -619,16 +621,15 @@ TEST_F(ArbiterCharacteristic, signalMatchingPedestrianConfidenceMode)
   // Arrange
   start_arbiter(true, "confidence");  // signal matching mode, "confidence" priority
   publish_map();
-  const auto t0 = arbiter_->now();
 
   TrafficLightGroupArray external_traffic_signal;
-  external_traffic_signal.stamp = t0;
+  external_traffic_signal.stamp = t0_;
   external_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
     map_ids::pedestrian_signal,
     {make_traffic_light_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.6f)}));
 
   TrafficLightGroupArray perception_traffic_signal;
-  perception_traffic_signal.stamp = t0;
+  perception_traffic_signal.stamp = t0_;
   perception_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
     map_ids::pedestrian_signal,
     {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.9f)}));
@@ -652,10 +653,9 @@ TEST_F(ArbiterCharacteristic, signalMatchingPedestrianSingleSourcePasses)
   // happens BEFORE the priority switch is consulted.
   start_arbiter(true, "external");  // signal matching mode, "external" priority
   publish_map();
-  const auto t0 = arbiter_->now();
 
   TrafficLightGroupArray perception_traffic_signal;
-  perception_traffic_signal.stamp = t0;
+  perception_traffic_signal.stamp = t0_;
   perception_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
     map_ids::pedestrian_signal,
     {make_traffic_light_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE)}));
@@ -683,16 +683,15 @@ TEST_F(ArbiterCharacteristic, signalMatchingSingleSourceNonPedestrianYieldsUnkno
   // Arrange
   start_arbiter(true, "confidence");  // signal matching mode, "confidence" priority
   publish_map();
-  const auto t0 = arbiter_->now();
 
   TrafficLightGroupArray external_traffic_signal;
-  external_traffic_signal.stamp = t0;
+  external_traffic_signal.stamp = t0_;
   external_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
     map_ids::vehicle_signal_b,
     {make_traffic_light_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE)}));
 
   TrafficLightGroupArray perception_traffic_signal;
-  perception_traffic_signal.stamp = t0;
+  perception_traffic_signal.stamp = t0_;
   perception_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
     map_ids::vehicle_signal_a,
     {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)}));
@@ -717,16 +716,15 @@ TEST_F(ArbiterCharacteristic, signalMatchingIgnoresConfidenceInEquivalence)
   // Arrange
   start_arbiter(true, "confidence");  // signal matching mode, "confidence" priority
   publish_map();
-  const auto t0 = arbiter_->now();
 
   TrafficLightGroupArray external_traffic_signal;
-  external_traffic_signal.stamp = t0;
+  external_traffic_signal.stamp = t0_;
   external_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
     map_ids::vehicle_signal_a,
     {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.10f)}));
 
   TrafficLightGroupArray perception_traffic_signal;
-  perception_traffic_signal.stamp = t0;
+  perception_traffic_signal.stamp = t0_;
   perception_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
     map_ids::vehicle_signal_a,
     {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.90f)}));
@@ -751,16 +749,15 @@ TEST_F(ArbiterCharacteristic, priorityBasedConfidencePicksHigherValue)
   // Arrange
   start_arbiter(false, "confidence");  // priority-based mode, "confidence" priority
   publish_map();
-  const auto t0 = arbiter_->now();
 
   TrafficLightGroupArray external_traffic_signal;
-  external_traffic_signal.stamp = t0;
+  external_traffic_signal.stamp = t0_;
   external_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
     map_ids::vehicle_signal_a,
     {make_traffic_light_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.7f)}));
 
   TrafficLightGroupArray perception_traffic_signal;
-  perception_traffic_signal.stamp = t0;
+  perception_traffic_signal.stamp = t0_;
   perception_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
     map_ids::vehicle_signal_a,
     {make_traffic_light_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.9f)}));
@@ -781,10 +778,9 @@ TEST_F(ArbiterCharacteristic, priorityBasedExternalOnlyPassesThrough)
   // Arrange
   start_arbiter(false, "confidence");  // priority-based mode, "confidence" priority
   publish_map();
-  const auto t0 = arbiter_->now();
 
   TrafficLightGroupArray external_traffic_signal;
-  external_traffic_signal.stamp = t0;
+  external_traffic_signal.stamp = t0_;
   external_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
     map_ids::vehicle_signal_b,
     {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.5f),
@@ -794,7 +790,7 @@ TEST_F(ArbiterCharacteristic, priorityBasedExternalOnlyPassesThrough)
   // Send a separate id from perception so the arbiter publishes after both
   // callbacks have settled (the test then inspects vehicle_signal_b output).
   TrafficLightGroupArray perception_traffic_signal;
-  perception_traffic_signal.stamp = t0;
+  perception_traffic_signal.stamp = t0_;
   perception_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
     map_ids::vehicle_signal_a,
     {make_traffic_light_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.9f)}));
@@ -819,18 +815,17 @@ TEST_F(ArbiterCharacteristic, priorityBasedPerceptionOnlyPassesThrough)
   // Arrange
   start_arbiter(false, "confidence");  // priority-based mode, "confidence" priority
   publish_map();
-  const auto t0 = arbiter_->now();
 
   // External must publish something for the arbiter to settle; use a
   // different id so vehicle_signal_c is perception-only.
   TrafficLightGroupArray external_traffic_signal;
-  external_traffic_signal.stamp = t0;
+  external_traffic_signal.stamp = t0_;
   external_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
     map_ids::vehicle_signal_a,
     {make_traffic_light_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.7f)}));
 
   TrafficLightGroupArray perception_traffic_signal;
-  perception_traffic_signal.stamp = t0;
+  perception_traffic_signal.stamp = t0_;
   perception_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
     map_ids::vehicle_signal_c,
     {make_traffic_light_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.8f)}));
@@ -851,16 +846,15 @@ TEST_F(ArbiterCharacteristic, priorityBasedOffMapIdDropped)
   // Arrange
   start_arbiter(false, "confidence");  // priority-based mode, "confidence" priority
   publish_map();
-  const auto t0 = arbiter_->now();
 
   TrafficLightGroupArray external_traffic_signal;
-  external_traffic_signal.stamp = t0;
+  external_traffic_signal.stamp = t0_;
   external_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
     kOffMapProbeId,
     {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.9f)}));
 
   TrafficLightGroupArray perception_traffic_signal;
-  perception_traffic_signal.stamp = t0;
+  perception_traffic_signal.stamp = t0_;
   perception_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
     map_ids::vehicle_signal_a,
     {make_traffic_light_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.9f)}));
@@ -887,7 +881,7 @@ TEST_F(ArbiterCharacteristic, perceptionBeforeMapProducesNoOutput)
   start_arbiter(false, "confidence");  // priority-based mode, "confidence" priority
 
   TrafficLightGroupArray perception_traffic_signal;
-  perception_traffic_signal.stamp = arbiter_->now();
+  perception_traffic_signal.stamp = t0_;
   perception_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
     map_ids::vehicle_signal_a,
     {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)}));
@@ -910,7 +904,7 @@ TEST_F(ArbiterCharacteristic, emptyMapProducesEmptyOutput)
   publish_map(build_empty_map_bin());
 
   TrafficLightGroupArray perception_traffic_signal;
-  perception_traffic_signal.stamp = arbiter_->now();
+  perception_traffic_signal.stamp = t0_;
   perception_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
     map_ids::vehicle_signal_a,
     {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)}));
@@ -935,16 +929,15 @@ TEST_F(ArbiterCharacteristic, unknownSourcePriorityFallsBackToConfidence)
   // Arrange: pass a value not in {"external", "perception", "confidence"}.
   start_arbiter(false, "invalid_value");  // priority-based mode, "invalid_value" priority
   publish_map();
-  const auto t0 = arbiter_->now();
 
   TrafficLightGroupArray external_traffic_signal;
-  external_traffic_signal.stamp = t0;
+  external_traffic_signal.stamp = t0_;
   external_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
     map_ids::vehicle_signal_a,
     {make_traffic_light_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.7f)}));
 
   TrafficLightGroupArray perception_traffic_signal;
-  perception_traffic_signal.stamp = t0;
+  perception_traffic_signal.stamp = t0_;
   perception_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
     map_ids::vehicle_signal_a,
     {make_traffic_light_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.9f)}));
@@ -963,18 +956,17 @@ TEST_F(ArbiterCharacteristic, priorityFlagOverridesHigherConfidence)
   // Arrange
   start_arbiter(false, "perception");  // priority-based mode, "perception" priority
   publish_map();
-  const auto t0 = arbiter_->now();
 
   // The confidence contrast (high external vs low perception) makes the
   // priority override explicit: the lower-confidence perception still wins.
   TrafficLightGroupArray external_traffic_signal;
-  external_traffic_signal.stamp = t0;
+  external_traffic_signal.stamp = t0_;
   external_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
     map_ids::vehicle_signal_a,
     {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.99f)}));
 
   TrafficLightGroupArray perception_traffic_signal;
-  perception_traffic_signal.stamp = t0;
+  perception_traffic_signal.stamp = t0_;
   perception_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
     map_ids::vehicle_signal_a,
     {make_traffic_light_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.10f)}));
@@ -996,18 +988,17 @@ TEST_F(ArbiterCharacteristic, priorityFlagFromExternalOverridesHigherConfidence)
   // Arrange
   start_arbiter(false, "external");  // priority-based mode, "external" priority
   publish_map();
-  const auto t0 = arbiter_->now();
 
   // The confidence contrast (low external vs high perception) makes the
   // priority override explicit: the lower-confidence external still wins.
   TrafficLightGroupArray external_traffic_signal;
-  external_traffic_signal.stamp = t0;
+  external_traffic_signal.stamp = t0_;
   external_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
     map_ids::vehicle_signal_a,
     {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.10f)}));
 
   TrafficLightGroupArray perception_traffic_signal;
-  perception_traffic_signal.stamp = t0;
+  perception_traffic_signal.stamp = t0_;
   perception_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
     map_ids::vehicle_signal_a,
     {make_traffic_light_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.99f)}));
@@ -1028,11 +1019,10 @@ TEST_F(ArbiterCharacteristic, multipleExternalSourcesAccumulate)
   // Arrange
   start_arbiter(false, "confidence");  // priority-based mode, "confidence" priority
   publish_map();
-  const auto t0 = arbiter_->now();
 
   // Act 1: publish the first external signal (id vehicle_signal_a).
   TrafficLightGroupArray first_external_traffic_signal;
-  first_external_traffic_signal.stamp = t0;
+  first_external_traffic_signal.stamp = t0_;
   first_external_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
     map_ids::vehicle_signal_a,
     {make_traffic_light_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE)}));
@@ -1046,7 +1036,7 @@ TEST_F(ArbiterCharacteristic, multipleExternalSourcesAccumulate)
 
   // Act 2: publish a second external signal carrying a different id.
   TrafficLightGroupArray second_external_traffic_signal;
-  second_external_traffic_signal.stamp = t0;
+  second_external_traffic_signal.stamp = t0_;
   second_external_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
     map_ids::vehicle_signal_b,
     {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)}));
@@ -1065,7 +1055,7 @@ TEST_F(ArbiterCharacteristic, externalDelayToleranceDropsStaleMessage)
   publish_map();
 
   TrafficLightGroupArray perception_traffic_signal;
-  perception_traffic_signal.stamp = arbiter_->now();
+  perception_traffic_signal.stamp = t0_;
   perception_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
     map_ids::vehicle_signal_a,
     {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)}));
@@ -1074,7 +1064,7 @@ TEST_F(ArbiterCharacteristic, externalDelayToleranceDropsStaleMessage)
 
   // external_delay_tolerance defaults to 5.0s; 20s in the past is well past it.
   TrafficLightGroupArray stale_external_traffic_signal;
-  stale_external_traffic_signal.stamp = offset_time(arbiter_->now(), -20.0);
+  stale_external_traffic_signal.stamp = offset_time(t0_, -20.0);
   stale_external_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
     map_ids::vehicle_signal_a,
     {make_traffic_light_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE)}));
@@ -1095,17 +1085,16 @@ TEST_F(ArbiterCharacteristic, externalTimeToleranceCleanupOnPerception)
   // arrival's cleanupExpiredExternalSignals (perception is +6s newer).
   start_arbiter(false, "confidence");  // priority-based mode, "confidence" priority
   publish_map();
-  const auto t0 = arbiter_->now();
 
   TrafficLightGroupArray external_traffic_signal;
-  external_traffic_signal.stamp = t0;
+  external_traffic_signal.stamp = t0_;
   external_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
     map_ids::vehicle_signal_a,
     {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)}));
   publish_external(external_traffic_signal);
 
   TrafficLightGroupArray perception_traffic_signal;
-  perception_traffic_signal.stamp = offset_time(t0, 6.0);
+  perception_traffic_signal.stamp = offset_time(t0_, 6.0);
   perception_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
     map_ids::vehicle_signal_a,
     {make_traffic_light_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE)}));
@@ -1125,11 +1114,10 @@ TEST_F(ArbiterCharacteristic, perceptionTimeToleranceClearsLatestPerception)
   // Arrange
   start_arbiter(false, "confidence");  // priority-based mode, "confidence" priority
   publish_map();
-  const auto t0 = arbiter_->now();
 
-  // Seed a perception value at t0.
+  // Seed a perception value at t0_.
   TrafficLightGroupArray perception_traffic_signal;
-  perception_traffic_signal.stamp = t0;
+  perception_traffic_signal.stamp = t0_;
   perception_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
     map_ids::vehicle_signal_a,
     {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)}));
@@ -1138,7 +1126,7 @@ TEST_F(ArbiterCharacteristic, perceptionTimeToleranceClearsLatestPerception)
   // External arrives 2.0s after perception (> perception_time_tolerance=1.0,
   // < external_delay_tolerance=5.0 so it is itself accepted).
   TrafficLightGroupArray external_traffic_signal;
-  external_traffic_signal.stamp = offset_time(t0, 2.0);
+  external_traffic_signal.stamp = offset_time(t0_, 2.0);
   external_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
     map_ids::vehicle_signal_a,
     {make_traffic_light_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE)}));
@@ -1155,15 +1143,14 @@ TEST_F(ArbiterCharacteristic, predictionsFromSingleSidePropagate)
   // Arrange
   start_arbiter(false, "confidence");  // priority-based mode, "confidence" priority
   publish_map();
-  const auto t0 = arbiter_->now();
 
   TrafficLightGroupArray perception_traffic_signal;
-  perception_traffic_signal.stamp = t0;
+  perception_traffic_signal.stamp = t0_;
   perception_traffic_signal.traffic_light_groups.push_back(make_traffic_light_group(
     map_ids::vehicle_signal_a,
     {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)},
     {make_traffic_light_prediction(
-      t0, TrafficLightElement::GREEN, TrafficLightElement::CIRCLE,
+      t0_, TrafficLightElement::GREEN, TrafficLightElement::CIRCLE,
       PredictedTrafficLightState::INFORMATION_SOURCE_INTERNAL_ESTIMATION)}));
 
   // Act

--- a/perception/autoware_traffic_light_arbiter/test/test_traffic_arbiter_characteristic.cpp
+++ b/perception/autoware_traffic_light_arbiter/test/test_traffic_arbiter_characteristic.cpp
@@ -305,8 +305,7 @@ protected:
     test_node_.reset();
   }
 
-  void startArbiter(
-    bool enable_signal_matching = false, const std::string & source_priority = "confidence")
+  void startArbiter(bool enable_signal_matching, const std::string & source_priority)
   {
     arbiter_ = makeArbiter(enable_signal_matching, source_priority);
     executor_ = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
@@ -415,7 +414,7 @@ TEST_F(ArbiterCharacteristic, signalMatchingLongestPath)
   //   expected:   dropped (WARN+skip)
 
   // Arrange
-  startArbiter(true);
+  startArbiter(true, "confidence");  // signal matching mode, "confidence" priority
   publishMap();
   const auto t0 = arbiter_->now();
 
@@ -501,7 +500,7 @@ TEST_F(ArbiterCharacteristic, signalMatchingLongestPath)
 TEST_F(ArbiterCharacteristic, signalMatchingPedestrianFallbackUsesSourcePriority)
 {
   // Arrange
-  startArbiter(true, "external");
+  startArbiter(true, "external");  // signal matching mode, "external" priority
   publishMap();
   const auto t0 = arbiter_->now();
 
@@ -538,7 +537,7 @@ TEST_F(ArbiterCharacteristic, signalMatchingPedestrianFallbackUsesSourcePriority
 TEST_F(ArbiterCharacteristic, signalMatchingPedestrianPerceptionPriority)
 {
   // Arrange
-  startArbiter(true, "perception");
+  startArbiter(true, "perception");  // signal matching mode, "perception" priority
   publishMap();
   const auto t0 = arbiter_->now();
 
@@ -574,7 +573,7 @@ TEST_F(ArbiterCharacteristic, signalMatchingPedestrianPerceptionPriority)
 TEST_F(ArbiterCharacteristic, signalMatchingPedestrianConfidenceMode)
 {
   // Arrange
-  startArbiter(true, "confidence");
+  startArbiter(true, "confidence");  // signal matching mode, "confidence" priority
   publishMap();
   const auto t0 = arbiter_->now();
 
@@ -611,7 +610,7 @@ TEST_F(ArbiterCharacteristic, signalMatchingPedestrianSingleSourcePasses)
 {
   // Arrange: external_priority is set to demonstrate that absent-side handling
   // happens BEFORE the priority switch is consulted.
-  startArbiter(true, "external");
+  startArbiter(true, "external");  // signal matching mode, "external" priority
   publishMap();
   const auto t0 = arbiter_->now();
 
@@ -646,7 +645,7 @@ TEST_F(ArbiterCharacteristic, signalMatchingSingleSourceNonPedestrianYieldsUnkno
   //   vehicle_signal_b  GREEN/CIRCLE  (none)       external-only   -> UNKNOWN/CIRCLE
 
   // Arrange
-  startArbiter(true);
+  startArbiter(true, "confidence");  // signal matching mode, "confidence" priority
   publishMap();
   const auto t0 = arbiter_->now();
 
@@ -692,7 +691,7 @@ TEST_F(ArbiterCharacteristic, signalMatchingSingleSourceNonPedestrianYieldsUnkno
 TEST_F(ArbiterCharacteristic, signalMatchingIgnoresConfidenceInEquivalence)
 {
   // Arrange
-  startArbiter(true);
+  startArbiter(true, "confidence");  // signal matching mode, "confidence" priority
   publishMap();
   const auto t0 = arbiter_->now();
 
@@ -761,7 +760,7 @@ TEST_F(ArbiterCharacteristic, priorityBasedConfidenceLongestPath)
   //   expected:   dropped (WARN+skip)
 
   // Arrange
-  startArbiter();
+  startArbiter(false, "confidence");  // priority-based mode, "confidence" priority
   publishMap();
   const auto t0 = arbiter_->now();
 
@@ -836,7 +835,7 @@ TEST_F(ArbiterCharacteristic, priorityBasedConfidenceLongestPath)
 TEST_F(ArbiterCharacteristic, perceptionBeforeMapProducesNoOutput)
 {
   // Arrange (intentionally no publishMap())
-  startArbiter();
+  startArbiter(false, "confidence");  // priority-based mode, "confidence" priority
 
   TrafficLightGroupArray perception_traffic_signal;
   perception_traffic_signal.stamp = arbiter_->now();
@@ -858,7 +857,7 @@ TEST_F(ArbiterCharacteristic, perceptionBeforeMapProducesNoOutput)
 TEST_F(ArbiterCharacteristic, emptyMapProducesEmptyOutput)
 {
   // Arrange: replace the default minimal map with a signal-free one.
-  startArbiter();
+  startArbiter(false, "confidence");  // priority-based mode, "confidence" priority
   publishMap(buildEmptyMapBin());
 
   TrafficLightGroupArray perception_traffic_signal;
@@ -883,7 +882,7 @@ TEST_F(ArbiterCharacteristic, emptyMapProducesEmptyOutput)
 TEST_F(ArbiterCharacteristic, unknownSourcePriorityFallsBackToConfidence)
 {
   // Arrange: pass a value not in {"external", "perception", "confidence"}.
-  startArbiter(false, "invalid_value");
+  startArbiter(false, "invalid_value");  // priority-based mode, "invalid_value" priority
   publishMap();
   const auto t0 = arbiter_->now();
 
@@ -915,7 +914,7 @@ TEST_F(ArbiterCharacteristic, unknownSourcePriorityFallsBackToConfidence)
 TEST_F(ArbiterCharacteristic, priorityFlagOverridesHigherConfidence)
 {
   // Arrange
-  startArbiter(false, "perception");
+  startArbiter(false, "perception");  // priority-based mode, "perception" priority
   publishMap();
   const auto t0 = arbiter_->now();
 
@@ -952,7 +951,7 @@ TEST_F(ArbiterCharacteristic, priorityFlagOverridesHigherConfidence)
 TEST_F(ArbiterCharacteristic, priorityFlagFromExternalOverridesHigherConfidence)
 {
   // Arrange
-  startArbiter(false, "external");
+  startArbiter(false, "external");  // priority-based mode, "external" priority
   publishMap();
   const auto t0 = arbiter_->now();
 
@@ -988,7 +987,7 @@ TEST_F(ArbiterCharacteristic, priorityFlagFromExternalOverridesHigherConfidence)
 TEST_F(ArbiterCharacteristic, multipleExternalSourcesAccumulate)
 {
   // Arrange
-  startArbiter();
+  startArbiter(false, "confidence");  // priority-based mode, "confidence" priority
   publishMap();
   const auto t0 = arbiter_->now();
 
@@ -1029,7 +1028,7 @@ TEST_F(ArbiterCharacteristic, multipleExternalSourcesAccumulate)
 TEST_F(ArbiterCharacteristic, externalDelayToleranceDropsStaleMessage)
 {
   // Arrange: establish a perception baseline so we can detect any extra publish.
-  startArbiter();
+  startArbiter(false, "confidence");  // priority-based mode, "confidence" priority
   publishMap();
 
   TrafficLightGroupArray perception_traffic_signal;
@@ -1065,7 +1064,7 @@ TEST_F(ArbiterCharacteristic, externalTimeToleranceCleanupOnPerception)
 {
   // Arrange: seed an external entry that should be purged by the perception
   // arrival's cleanupExpiredExternalSignals (perception is +6s newer).
-  startArbiter();
+  startArbiter(false, "confidence");  // priority-based mode, "confidence" priority
   publishMap();
   const auto t0 = arbiter_->now();
 
@@ -1099,7 +1098,7 @@ TEST_F(ArbiterCharacteristic, externalTimeToleranceCleanupOnPerception)
 TEST_F(ArbiterCharacteristic, perceptionTimeToleranceClearsLatestPerception)
 {
   // Arrange
-  startArbiter();
+  startArbiter(false, "confidence");  // priority-based mode, "confidence" priority
   publishMap();
   const auto t0 = arbiter_->now();
 
@@ -1133,7 +1132,7 @@ TEST_F(ArbiterCharacteristic, perceptionTimeToleranceClearsLatestPerception)
 TEST_F(ArbiterCharacteristic, predictionsFromSingleSidePropagate)
 {
   // Arrange
-  startArbiter();
+  startArbiter(false, "confidence");  // priority-based mode, "confidence" priority
   publishMap();
   const auto t0 = arbiter_->now();
 

--- a/perception/autoware_traffic_light_arbiter/test/test_traffic_arbiter_characteristic.cpp
+++ b/perception/autoware_traffic_light_arbiter/test/test_traffic_arbiter_characteristic.cpp
@@ -173,7 +173,10 @@ std::shared_ptr<TrafficLightArbiter> makeArbiter(
 
 // --- Input message builders --------------------------------------------
 
-TrafficLightElement makeTrafficLightElement(uint8_t color, uint8_t shape, float confidence)
+// Confidence defaults to 1.0f: most tests don't care about the value (the
+// arbiter only consults it under the CONFIDENCE branch), so omitting the
+// argument signals "this number is irrelevant to the assertion".
+TrafficLightElement makeTrafficLightElement(uint8_t color, uint8_t shape, float confidence = 1.0f)
 {
   TrafficLightElement element;
   element.color = color;
@@ -313,9 +316,11 @@ protected:
     spinFor(std::chrono::milliseconds(200));
   }
 
-  void publishMap()
+  void publishMap() { publishMap(*map_bin_); }
+
+  void publishMap(const LaneletMapBin & bin)
   {
-    map_pub_->publish(*map_bin_);
+    map_pub_->publish(bin);
     spinFor(std::chrono::milliseconds(150));
   }
   void publishPerception(const TrafficLightGroupArray & msg)
@@ -337,8 +342,6 @@ protected:
       std::this_thread::sleep_for(std::chrono::milliseconds(5));
     }
   }
-
-  rclcpp::Time arbiterNow() const { return arbiter_->now(); }
 
   // Wrapped in std::optional because LaneletMapBin (a generated ROS msg)
   // has no usable default constructor that can be invoked at static storage
@@ -374,77 +377,83 @@ protected:
 };
 
 // ---------------------------------------------------------------------------
-// A. Longest path - Signal Matching mode (enable_signal_matching=true).
+// A. Signal Matching mode - arbitration rules across source agreement.
 //
-// Exercises every branch of SignalMatchValidator::validateSignals in one run:
-//   - vehicle id with matching color/shape       -> use perception as-is
-//   - vehicle id with mismatching color          -> UNKNOWN for that shape
-//   - vehicle id with mismatching element count  -> UNKNOWN over union of shapes
-//   - vehicle id seen only by external           -> UNKNOWN
-//   - signal id not on the map                   -> dropped (WARN path)
+// Pins the full Signal Matching behavior spec: the arbiter degrades
+// gracefully as the agreement between sources weakens, falling back to
+// UNKNOWN when the signals disagree and dropping ids that are not on the
+// map. The longest path through SignalMatchValidator (4 ids in a single
+// publish) is traversed in one test:
+//   - matched (color & shape agree) -> perception passes through
+//   - color mismatch                -> UNKNOWN over the shared shape
+//   - element-count mismatch        -> UNKNOWN over the shape union
+//   - off-map id                    -> dropped (WARN+skip)
 // ---------------------------------------------------------------------------
 TEST_F(ArbiterCharacteristic, signalMatchingLongestPath)
 {
-  // Scenario inputs and expectations:
+  // Scenario inputs and expectations (confidence is omitted everywhere
+  // because Signal Matching never reads it; the 1.0f default applies):
   //
   // vehicle_signal_a:
-  //   external:   RED/CIRCLE/0.6 + V2I prediction
-  //   perception: RED/CIRCLE/0.7 + INTERNAL prediction
+  //   external:   RED/CIRCLE + V2I prediction
+  //   perception: RED/CIRCLE + INTERNAL prediction
   //   expected:   matched -> perception passes through; both predictions merged (2 total)
   //
   // vehicle_signal_b:
-  //   external:   GREEN/CIRCLE/0.8
-  //   perception: RED/CIRCLE/0.9
+  //   external:   GREEN/CIRCLE
+  //   perception: RED/CIRCLE
   //   expected:   color mismatch -> UNKNOWN
   //
   // vehicle_signal_c:
-  //   external:   RED/CIRCLE/0.8
-  //   perception: RED/CIRCLE/0.8 + GREEN/RIGHT_ARROW/0.6
+  //   external:   RED/CIRCLE
+  //   perception: RED/CIRCLE + GREEN/RIGHT_ARROW
   //   expected:   element-count mismatch -> UNKNOWN over shape union
   //
   // kOffMapProbeId:
-  //   external:   RED/CIRCLE/0.9
+  //   external:   RED/CIRCLE
   //   perception: (none)
   //   expected:   dropped (WARN+skip)
 
   // Arrange
   startArbiter(true);
   publishMap();
-  const auto t0 = arbiterNow();
+  const auto t0 = arbiter_->now();
 
+  // Message from external source like a V2I unit.
   TrafficLightGroupArray external_traffic_signal;
   external_traffic_signal.stamp = offsetTime(t0, -0.10);
   external_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
     map_ids::vehicle_signal_a,
-    {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.6f)},
+    {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE)},
     {makeTrafficLightPrediction(
       external_traffic_signal.stamp, TrafficLightElement::GREEN, TrafficLightElement::CIRCLE,
       PredictedTrafficLightState::INFORMATION_SOURCE_V2I)}));
   external_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
     map_ids::vehicle_signal_b,
-    {makeTrafficLightElement(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.8f)}));
+    {makeTrafficLightElement(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE)}));
   external_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
     map_ids::vehicle_signal_c,
-    {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.8f)}));
+    {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE)}));
   external_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
     kOffMapProbeId,
-    {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.9f)}));
+    {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE)}));
 
+  // Message from internal source like a perception module.
   TrafficLightGroupArray perception_traffic_signal;
   perception_traffic_signal.stamp = offsetTime(t0, -0.05);
   perception_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
     map_ids::vehicle_signal_a,
-    {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.7f)},
+    {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE)},
     {makeTrafficLightPrediction(
       perception_traffic_signal.stamp, TrafficLightElement::RED, TrafficLightElement::CIRCLE,
       PredictedTrafficLightState::INFORMATION_SOURCE_INTERNAL_ESTIMATION)}));
   perception_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
     map_ids::vehicle_signal_b,
-    {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.9f)}));
+    {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE)}));
   perception_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
     map_ids::vehicle_signal_c,
-    {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.8f),
-     makeTrafficLightElement(TrafficLightElement::GREEN, TrafficLightElement::RIGHT_ARROW, 0.6f)}));
+    {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE),
+     makeTrafficLightElement(TrafficLightElement::GREEN, TrafficLightElement::RIGHT_ARROW)}));
 
   // Act
   publishExternal(external_traffic_signal);
@@ -452,39 +461,39 @@ TEST_F(ArbiterCharacteristic, signalMatchingLongestPath)
 
   // Assert
   ASSERT_GE(arbiter_publish_count_, 1u);
-  EXPECT_EQ(findTrafficLightGroup(latest_arbitrated_traffic_signal_, kOffMapProbeId), nullptr);
 
-  // matching id: perception passes through unchanged, predictions merged from both sources.
+  // vehicle_signal_a: matched -> perception passes through, predictions merged.
   {
-    const auto * g =
+    const auto * group =
       findTrafficLightGroup(latest_arbitrated_traffic_signal_, map_ids::vehicle_signal_a);
-    ASSERT_NE(g, nullptr);
-    ASSERT_EQ(g->elements.size(), 1u);
-    EXPECT_EQ(g->elements[0].color, TrafficLightElement::RED);
-    EXPECT_NEAR(g->elements[0].confidence, 0.7f, kConfidenceEpsilon);
-    EXPECT_EQ(g->predictions.size(), 2u);
+    ASSERT_NE(group, nullptr);
+    ASSERT_EQ(group->elements.size(), 1u);
+    EXPECT_EQ(group->elements[0].color, TrafficLightElement::RED);
+    EXPECT_EQ(group->predictions.size(), 2u);
   }
-  // color mismatch -> UNKNOWN over the single shared shape
+  // vehicle_signal_b: color mismatch -> UNKNOWN over the shared shape.
   {
-    const auto * g =
+    const auto * group =
       findTrafficLightGroup(latest_arbitrated_traffic_signal_, map_ids::vehicle_signal_b);
-    ASSERT_NE(g, nullptr);
-    ASSERT_EQ(g->elements.size(), 1u);
-    EXPECT_EQ(g->elements[0].color, TrafficLightElement::UNKNOWN);
-    EXPECT_EQ(g->elements[0].shape, TrafficLightElement::CIRCLE);
+    ASSERT_NE(group, nullptr);
+    ASSERT_EQ(group->elements.size(), 1u);
+    EXPECT_EQ(group->elements[0].color, TrafficLightElement::UNKNOWN);
+    EXPECT_EQ(group->elements[0].shape, TrafficLightElement::CIRCLE);
   }
-  // element-count mismatch -> UNKNOWN over union of shapes
+  // vehicle_signal_c: element-count mismatch -> UNKNOWN over shape union.
   {
-    const auto * g =
+    const auto * group =
       findTrafficLightGroup(latest_arbitrated_traffic_signal_, map_ids::vehicle_signal_c);
-    ASSERT_NE(g, nullptr);
-    ASSERT_EQ(g->elements.size(), 2u);
-    EXPECT_NE(findTrafficLightElement(*g, TrafficLightElement::CIRCLE), nullptr);
-    EXPECT_NE(findTrafficLightElement(*g, TrafficLightElement::RIGHT_ARROW), nullptr);
-    for (const auto & e : g->elements) {
-      EXPECT_EQ(e.color, TrafficLightElement::UNKNOWN);
+    ASSERT_NE(group, nullptr);
+    ASSERT_EQ(group->elements.size(), 2u);
+    EXPECT_NE(findTrafficLightElement(*group, TrafficLightElement::CIRCLE), nullptr);
+    EXPECT_NE(findTrafficLightElement(*group, TrafficLightElement::RIGHT_ARROW), nullptr);
+    for (const auto & element : group->elements) {
+      EXPECT_EQ(element.color, TrafficLightElement::UNKNOWN);
     }
   }
+  // kOffMapProbeId: not on the map -> dropped (WARN+skip).
+  EXPECT_EQ(findTrafficLightGroup(latest_arbitrated_traffic_signal_, kOffMapProbeId), nullptr);
 }
 
 // Pedestrian path bypasses element matching; with source_priority=external
@@ -494,8 +503,10 @@ TEST_F(ArbiterCharacteristic, signalMatchingPedestrianFallbackUsesSourcePriority
   // Arrange
   startArbiter(true, "external");
   publishMap();
-  const auto t0 = arbiterNow();
+  const auto t0 = arbiter_->now();
 
+  // The confidence contrast (low external vs high perception) makes the
+  // priority override explicit: the lower-confidence external wins.
   TrafficLightGroupArray external_traffic_signal;
   external_traffic_signal.stamp = offsetTime(t0, -0.10);
   external_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
@@ -512,13 +523,12 @@ TEST_F(ArbiterCharacteristic, signalMatchingPedestrianFallbackUsesSourcePriority
   publishExternal(external_traffic_signal);
   publishPerception(perception_traffic_signal);
 
-  // Assert
-  const auto * g =
+  // Assert: external priority wins despite its lower confidence.
+  const auto * group =
     findTrafficLightGroup(latest_arbitrated_traffic_signal_, map_ids::pedestrian_signal);
-  ASSERT_NE(g, nullptr);
-  ASSERT_EQ(g->elements.size(), 1u);
-  EXPECT_EQ(g->elements[0].color, TrafficLightElement::RED);
-  EXPECT_NEAR(g->elements[0].confidence, 0.1f, kConfidenceEpsilon);
+  ASSERT_NE(group, nullptr);
+  ASSERT_EQ(group->elements.size(), 1u);
+  EXPECT_EQ(group->elements[0].color, TrafficLightElement::RED);
 }
 
 // Symmetric counterpart of the external-priority pedestrian test: with
@@ -530,10 +540,12 @@ TEST_F(ArbiterCharacteristic, signalMatchingPedestrianPerceptionPriority)
   // Arrange
   startArbiter(true, "perception");
   publishMap();
-  const auto t0 = arbiterNow();
+  const auto t0 = arbiter_->now();
 
   TrafficLightGroupArray external_traffic_signal;
   external_traffic_signal.stamp = offsetTime(t0, -0.10);
+  // The confidence contrast (high external vs low perception) makes the
+  // priority override explicit: the lower-confidence perception still wins.
   external_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
     map_ids::pedestrian_signal,
     {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.99f)}));
@@ -548,13 +560,12 @@ TEST_F(ArbiterCharacteristic, signalMatchingPedestrianPerceptionPriority)
   publishExternal(external_traffic_signal);
   publishPerception(perception_traffic_signal);
 
-  // Assert: perception priority wins despite lower confidence
-  const auto * g =
+  // Assert: perception priority wins despite its lower confidence.
+  const auto * group =
     findTrafficLightGroup(latest_arbitrated_traffic_signal_, map_ids::pedestrian_signal);
-  ASSERT_NE(g, nullptr);
-  ASSERT_EQ(g->elements.size(), 1u);
-  EXPECT_EQ(g->elements[0].color, TrafficLightElement::GREEN);
-  EXPECT_NEAR(g->elements[0].confidence, 0.10f, kConfidenceEpsilon);
+  ASSERT_NE(group, nullptr);
+  ASSERT_EQ(group->elements.size(), 1u);
+  EXPECT_EQ(group->elements[0].color, TrafficLightElement::GREEN);
 }
 
 // Pedestrian + CONFIDENCE: get_highest_confidence_signal walks each shape and
@@ -565,7 +576,7 @@ TEST_F(ArbiterCharacteristic, signalMatchingPedestrianConfidenceMode)
   // Arrange
   startArbiter(true, "confidence");
   publishMap();
-  const auto t0 = arbiterNow();
+  const auto t0 = arbiter_->now();
 
   TrafficLightGroupArray external_traffic_signal;
   external_traffic_signal.stamp = offsetTime(t0, -0.10);
@@ -584,12 +595,12 @@ TEST_F(ArbiterCharacteristic, signalMatchingPedestrianConfidenceMode)
   publishPerception(perception_traffic_signal);
 
   // Assert: CONFIDENCE picks the higher-confidence element (perception 0.9)
-  const auto * g =
+  const auto * group =
     findTrafficLightGroup(latest_arbitrated_traffic_signal_, map_ids::pedestrian_signal);
-  ASSERT_NE(g, nullptr);
-  ASSERT_EQ(g->elements.size(), 1u);
-  EXPECT_EQ(g->elements[0].color, TrafficLightElement::RED);
-  EXPECT_NEAR(g->elements[0].confidence, 0.9f, kConfidenceEpsilon);
+  ASSERT_NE(group, nullptr);
+  ASSERT_EQ(group->elements.size(), 1u);
+  EXPECT_EQ(group->elements[0].color, TrafficLightElement::RED);
+  EXPECT_NEAR(group->elements[0].confidence, 0.9f, kConfidenceEpsilon);
 }
 
 // Pedestrian id with a single source: get_highest_confidence_signal early-
@@ -602,24 +613,23 @@ TEST_F(ArbiterCharacteristic, signalMatchingPedestrianSingleSourcePasses)
   // happens BEFORE the priority switch is consulted.
   startArbiter(true, "external");
   publishMap();
-  const auto t0 = arbiterNow();
+  const auto t0 = arbiter_->now();
 
   TrafficLightGroupArray perception_traffic_signal;
   perception_traffic_signal.stamp = offsetTime(t0, -0.05);
   perception_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
     map_ids::pedestrian_signal,
-    {makeTrafficLightElement(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.7f)}));
+    {makeTrafficLightElement(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE)}));
 
   // Act (no external publish)
   publishPerception(perception_traffic_signal);
 
   // Assert: perception passes through unchanged (no UNKNOWN translation)
-  const auto * g =
+  const auto * group =
     findTrafficLightGroup(latest_arbitrated_traffic_signal_, map_ids::pedestrian_signal);
-  ASSERT_NE(g, nullptr);
-  ASSERT_EQ(g->elements.size(), 1u);
-  EXPECT_EQ(g->elements[0].color, TrafficLightElement::GREEN);
-  EXPECT_NEAR(g->elements[0].confidence, 0.7f, kConfidenceEpsilon);
+  ASSERT_NE(group, nullptr);
+  ASSERT_EQ(group->elements.size(), 1u);
+  EXPECT_EQ(group->elements[0].color, TrafficLightElement::GREEN);
 }
 
 // In Signal Matching mode, a non-pedestrian id that arrives on only one side
@@ -630,27 +640,27 @@ TEST_F(ArbiterCharacteristic, signalMatchingSingleSourceNonPedestrianYieldsUnkno
 {
   // Scenario inputs and expectations:
   //
-  //   id                external           perception        expected outcome
-  //   ----------------  -----------------  ----------------  -----------------------------
-  //   vehicle_signal_a  (none)             RED/CIRCLE/0.7    perception-only -> UNKNOWN/CIRCLE
-  //   vehicle_signal_b  GREEN/CIRCLE/0.8   (none)            external-only   -> UNKNOWN/CIRCLE
+  //   id                external      perception   expected outcome
+  //   ----------------  ------------  -----------  -----------------------------
+  //   vehicle_signal_a  (none)        RED/CIRCLE   perception-only -> UNKNOWN/CIRCLE
+  //   vehicle_signal_b  GREEN/CIRCLE  (none)       external-only   -> UNKNOWN/CIRCLE
 
   // Arrange
   startArbiter(true);
   publishMap();
-  const auto t0 = arbiterNow();
+  const auto t0 = arbiter_->now();
 
   TrafficLightGroupArray external_traffic_signal;
   external_traffic_signal.stamp = offsetTime(t0, -0.10);
   external_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
     map_ids::vehicle_signal_b,
-    {makeTrafficLightElement(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.8f)}));
+    {makeTrafficLightElement(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE)}));
 
   TrafficLightGroupArray perception_traffic_signal;
   perception_traffic_signal.stamp = offsetTime(t0, -0.05);
   perception_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
     map_ids::vehicle_signal_a,
-    {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.7f)}));
+    {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE)}));
 
   // Act
   publishExternal(external_traffic_signal);
@@ -675,261 +685,16 @@ TEST_F(ArbiterCharacteristic, signalMatchingSingleSourceNonPedestrianYieldsUnkno
   }
 }
 
-// ---------------------------------------------------------------------------
-// B. Longest path - Priority-based mode (enable_signal_matching=false).
-// ---------------------------------------------------------------------------
-TEST_F(ArbiterCharacteristic, priorityBasedConfidenceLongestPath)
-{
-  // Scenario inputs and expectations:
-  //   - Publish order: stale external (-4.0s) -> recent external (-0.5s) -> perception (-0.2s).
-  //   - The stale external entry must be cleaned up before arbitration runs.
-  //
-  // vehicle_signal_a:
-  //   recent external: GREEN/CIRCLE/0.7
-  //   perception:      GREEN/CIRCLE/0.9
-  //   expected:        CONFIDENCE picks perception (0.9 > 0.7)
-  //
-  // vehicle_signal_b:
-  //   recent external: RED/CIRCLE/0.5 + GREEN/RIGHT_ARROW
-  //   perception:      (none)
-  //   expected:        external only, both shapes pass through
-  //
-  // vehicle_signal_c:
-  //   recent external: (none)
-  //   perception:      GREEN/CIRCLE/0.8
-  //   expected:        perception only, passes
-  //
-  // kOffMapProbeId:
-  //   recent external: RED/CIRCLE/0.9
-  //   perception:      (none)
-  //   expected:        dropped (WARN+skip)
-
-  // Arrange
-  startArbiter();
-  publishMap();
-  const auto t0 = arbiterNow();
-
-  TrafficLightGroupArray stale_external_traffic_signal;
-  stale_external_traffic_signal.stamp = offsetTime(t0, -4.0);
-  stale_external_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
-    map_ids::vehicle_signal_a,
-    {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.4f)}));
-
-  TrafficLightGroupArray recent_external_traffic_signal;
-  recent_external_traffic_signal.stamp = offsetTime(t0, -0.5);
-  recent_external_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
-    map_ids::vehicle_signal_a,
-    {makeTrafficLightElement(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.7f)}));
-  recent_external_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
-    map_ids::vehicle_signal_b,
-    {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.5f),
-     makeTrafficLightElement(TrafficLightElement::GREEN, TrafficLightElement::RIGHT_ARROW, 0.3f)}));
-  recent_external_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
-    kOffMapProbeId,
-    {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.9f)}));
-
-  TrafficLightGroupArray perception_traffic_signal;
-  perception_traffic_signal.stamp = offsetTime(t0, -0.2);
-  perception_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
-    map_ids::vehicle_signal_a,
-    {makeTrafficLightElement(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.9f)}));
-  perception_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
-    map_ids::vehicle_signal_c,
-    {makeTrafficLightElement(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.8f)}));
-
-  // Act
-  publishExternal(stale_external_traffic_signal);
-  publishExternal(recent_external_traffic_signal);
-  publishPerception(perception_traffic_signal);
-
-  // Assert
-  EXPECT_EQ(findTrafficLightGroup(latest_arbitrated_traffic_signal_, kOffMapProbeId), nullptr);
-  // Both sources agree on shape; CONFIDENCE picks perception (0.9 > 0.7).
-  {
-    const auto * g =
-      findTrafficLightGroup(latest_arbitrated_traffic_signal_, map_ids::vehicle_signal_a);
-    ASSERT_NE(g, nullptr);
-    ASSERT_EQ(g->elements.size(), 1u);
-    EXPECT_EQ(g->elements[0].color, TrafficLightElement::GREEN);
-    EXPECT_NEAR(g->elements[0].confidence, 0.9f, kConfidenceEpsilon);
-  }
-  // External contributes two shapes alone; both survive shape-wise selection.
-  {
-    const auto * g =
-      findTrafficLightGroup(latest_arbitrated_traffic_signal_, map_ids::vehicle_signal_b);
-    ASSERT_NE(g, nullptr);
-    ASSERT_EQ(g->elements.size(), 2u);
-    EXPECT_NE(findTrafficLightElement(*g, TrafficLightElement::CIRCLE), nullptr);
-    EXPECT_NE(findTrafficLightElement(*g, TrafficLightElement::RIGHT_ARROW), nullptr);
-  }
-  // Perception-only id flows through unmodified.
-  {
-    const auto * g =
-      findTrafficLightGroup(latest_arbitrated_traffic_signal_, map_ids::vehicle_signal_c);
-    ASSERT_NE(g, nullptr);
-    ASSERT_EQ(g->elements.size(), 1u);
-    EXPECT_EQ(g->elements[0].color, TrafficLightElement::GREEN);
-    EXPECT_NEAR(g->elements[0].confidence, 0.8f, kConfidenceEpsilon);
-  }
-}
-
-// ---------------------------------------------------------------------------
-// C. Branch coverage that the longest paths cannot reach.
-// ---------------------------------------------------------------------------
-
-TEST_F(ArbiterCharacteristic, perceptionBeforeMapProducesNoOutput)
-{
-  // Arrange (intentionally no publishMap())
-  startArbiter();
-
-  TrafficLightGroupArray perception_traffic_signal;
-  perception_traffic_signal.stamp = arbiterNow();
-  perception_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
-    map_ids::vehicle_signal_a,
-    {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.9f)}));
-
-  // Act
-  publishPerception(perception_traffic_signal);
-
-  // Assert
-  EXPECT_EQ(arbiter_publish_count_, 0u)
-    << "arbitrateAndPublish should early-return when no map has been received";
-}
-
-// A non-null but signal-free map should yield an empty TrafficLightGroupArray
-// (stamp set, no groups). Exercises the
-// "map_regulatory_elements_set_->empty()" branch in arbitrateAndPublish.
-TEST_F(ArbiterCharacteristic, emptyMapProducesEmptyOutput)
-{
-  // Arrange: replace the default minimal map with a signal-free one.
-  startArbiter();
-  const auto empty_map_bin = buildEmptyMapBin();
-  map_pub_->publish(empty_map_bin);
-  spinFor(std::chrono::milliseconds(150));
-
-  TrafficLightGroupArray perception_traffic_signal;
-  perception_traffic_signal.stamp = arbiterNow();
-  perception_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
-    map_ids::vehicle_signal_a,
-    {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.9f)}));
-
-  // Act
-  publishPerception(perception_traffic_signal);
-
-  // Assert: arbiter publishes, but the output contains no groups.
-  ASSERT_GE(arbiter_publish_count_, 1u);
-  EXPECT_EQ(latest_arbitrated_traffic_signal_.traffic_light_groups.size(), 0u);
-}
-
-TEST_F(ArbiterCharacteristic, priorityFlagOverridesHigherConfidence)
-{
-  // Arrange
-  startArbiter(false, "perception");
-  publishMap();
-  const auto t0 = arbiterNow();
-
-  TrafficLightGroupArray external_traffic_signal;
-  external_traffic_signal.stamp = offsetTime(t0, -0.10);
-  external_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
-    map_ids::vehicle_signal_a,
-    {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.99f)}));
-
-  TrafficLightGroupArray perception_traffic_signal;
-  perception_traffic_signal.stamp = offsetTime(t0, -0.05);
-  perception_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
-    map_ids::vehicle_signal_a,
-    {makeTrafficLightElement(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.10f)}));
-
-  // Act
-  publishExternal(external_traffic_signal);
-  publishPerception(perception_traffic_signal);
-
-  // Assert
-  const auto * g =
-    findTrafficLightGroup(latest_arbitrated_traffic_signal_, map_ids::vehicle_signal_a);
-  ASSERT_NE(g, nullptr);
-  ASSERT_EQ(g->elements.size(), 1u);
-  EXPECT_EQ(g->elements[0].color, TrafficLightElement::GREEN);
-  EXPECT_NEAR(g->elements[0].confidence, 0.10f, kConfidenceEpsilon);
-}
-
-// Symmetric counterpart of priorityFlagOverridesHigherConfidence: with
-// source_priority=external, the external value wins over a higher-confidence
-// perception value. This pins the EXTERNAL branch in arbitrateAndPublish
-// ([traffic_light_arbiter.cpp]: source_priority_ == EXTERNAL).
-TEST_F(ArbiterCharacteristic, priorityFlagFromExternalOverridesHigherConfidence)
-{
-  // Arrange
-  startArbiter(false, "external");
-  publishMap();
-  const auto t0 = arbiterNow();
-
-  TrafficLightGroupArray external_traffic_signal;
-  external_traffic_signal.stamp = offsetTime(t0, -0.10);
-  external_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
-    map_ids::vehicle_signal_a,
-    {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.10f)}));
-
-  TrafficLightGroupArray perception_traffic_signal;
-  perception_traffic_signal.stamp = offsetTime(t0, -0.05);
-  perception_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
-    map_ids::vehicle_signal_a,
-    {makeTrafficLightElement(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.99f)}));
-
-  // Act
-  publishExternal(external_traffic_signal);
-  publishPerception(perception_traffic_signal);
-
-  // Assert
-  const auto * g =
-    findTrafficLightGroup(latest_arbitrated_traffic_signal_, map_ids::vehicle_signal_a);
-  ASSERT_NE(g, nullptr);
-  ASSERT_EQ(g->elements.size(), 1u);
-  EXPECT_EQ(g->elements[0].color, TrafficLightElement::RED);
-  EXPECT_NEAR(g->elements[0].confidence, 0.10f, kConfidenceEpsilon);
-}
-
-TEST_F(ArbiterCharacteristic, externalDelayToleranceDropsStaleMessage)
-{
-  // Arrange: establish a perception baseline so we can detect any extra publish.
-  startArbiter();
-  publishMap();
-
-  TrafficLightGroupArray perception_traffic_signal;
-  perception_traffic_signal.stamp = arbiterNow();
-  perception_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
-    map_ids::vehicle_signal_a,
-    {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.8f)}));
-  publishPerception(perception_traffic_signal);
-  const auto baseline_count = arbiter_publish_count_;
-  ASSERT_GE(baseline_count, 1u);
-
-  // external_delay_tolerance defaults to 5.0s; 20s in the past is well past it.
-  TrafficLightGroupArray stale_external_traffic_signal;
-  stale_external_traffic_signal.stamp = offsetTime(arbiterNow(), -20.0);
-  stale_external_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
-    map_ids::vehicle_signal_a,
-    {makeTrafficLightElement(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.9f)}));
-
-  // Act
-  publishExternal(stale_external_traffic_signal);
-
-  // Assert
-  EXPECT_EQ(arbiter_publish_count_, baseline_count)
-    << "Stale external message must be dropped before arbitrateAndPublish runs";
-  const auto * g =
-    findTrafficLightGroup(latest_arbitrated_traffic_signal_, map_ids::vehicle_signal_a);
-  ASSERT_NE(g, nullptr);
-  EXPECT_EQ(g->elements[0].color, TrafficLightElement::RED)
-    << "Last publish must reflect perception";
-}
-
+// Signal Matching does not consult the confidence field when checking
+// equivalence. Two elements with identical color/shape but very different
+// confidence values are treated as a match, and perception's value
+// (confidence included) propagates verbatim.
 TEST_F(ArbiterCharacteristic, signalMatchingIgnoresConfidenceInEquivalence)
 {
   // Arrange
   startArbiter(true);
   publishMap();
-  const auto t0 = arbiterNow();
+  const auto t0 = arbiter_->now();
 
   TrafficLightGroupArray external_traffic_signal;
   external_traffic_signal.stamp = offsetTime(t0, -0.10);
@@ -948,12 +713,352 @@ TEST_F(ArbiterCharacteristic, signalMatchingIgnoresConfidenceInEquivalence)
   publishPerception(perception_traffic_signal);
 
   // Assert
-  const auto * g =
+  const auto * group =
     findTrafficLightGroup(latest_arbitrated_traffic_signal_, map_ids::vehicle_signal_a);
-  ASSERT_NE(g, nullptr);
-  ASSERT_EQ(g->elements.size(), 1u);
-  EXPECT_EQ(g->elements[0].color, TrafficLightElement::RED);
-  EXPECT_NEAR(g->elements[0].confidence, 0.90f, kConfidenceEpsilon);
+  ASSERT_NE(group, nullptr);
+  ASSERT_EQ(group->elements.size(), 1u);
+  EXPECT_EQ(group->elements[0].color, TrafficLightElement::RED);
+  EXPECT_NEAR(group->elements[0].confidence, 0.90f, kConfidenceEpsilon);
+}
+
+// ---------------------------------------------------------------------------
+// B. Priority-based mode - per-shape element selection driven by
+//    source_priority and confidence.
+//
+// Pins the arbitration spec when Signal Matching is off: for each
+// regulatory-element id the arbiter walks every shape independently and
+// resolves the chosen element through a two-stage comparison
+// (priority flag first, confidence tiebreaker second). The longest path
+// combines single-side passthrough and shape-wise CONFIDENCE selection in
+// a single test:
+//   - both sources agree on shape         -> CONFIDENCE picks higher value
+//   - only one source contributes a shape -> passes through unchanged
+//   - off-map id                          -> dropped (WARN+skip)
+// ---------------------------------------------------------------------------
+TEST_F(ArbiterCharacteristic, priorityBasedConfidenceLongestPath)
+{
+  // Scenario inputs and expectations:
+  //   - Publish order: external (-0.5s) -> perception (-0.2s).
+  //
+  // vehicle_signal_a:
+  //   external:   GREEN/CIRCLE/0.7
+  //   perception: GREEN/CIRCLE/0.9
+  //   expected:   CONFIDENCE picks perception (0.9 > 0.7)
+  //
+  // vehicle_signal_b:
+  //   external:   RED/CIRCLE/0.5 + GREEN/RIGHT_ARROW
+  //   perception: (none)
+  //   expected:   external only, both shapes pass through
+  //
+  // vehicle_signal_c:
+  //   external:   (none)
+  //   perception: GREEN/CIRCLE/0.8
+  //   expected:   perception only, passes
+  //
+  // kOffMapProbeId:
+  //   external:   RED/CIRCLE/0.9
+  //   perception: (none)
+  //   expected:   dropped (WARN+skip)
+
+  // Arrange
+  startArbiter();
+  publishMap();
+  const auto t0 = arbiter_->now();
+
+  TrafficLightGroupArray external_traffic_signal;
+  external_traffic_signal.stamp = offsetTime(t0, -0.5);
+  external_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
+    map_ids::vehicle_signal_a,
+    {makeTrafficLightElement(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.7f)}));
+  external_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
+    map_ids::vehicle_signal_b,
+    {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.5f),
+     makeTrafficLightElement(TrafficLightElement::GREEN, TrafficLightElement::RIGHT_ARROW, 0.3f)}));
+  external_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
+    kOffMapProbeId,
+    {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.9f)}));
+
+  TrafficLightGroupArray perception_traffic_signal;
+  perception_traffic_signal.stamp = offsetTime(t0, -0.2);
+  perception_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
+    map_ids::vehicle_signal_a,
+    {makeTrafficLightElement(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.9f)}));
+  perception_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
+    map_ids::vehicle_signal_c,
+    {makeTrafficLightElement(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.8f)}));
+
+  // Act
+  publishExternal(external_traffic_signal);
+  publishPerception(perception_traffic_signal);
+
+  // Assert
+
+  // vehicle_signal_a: both sources agree on shape; CONFIDENCE picks perception (0.9 > 0.7).
+  {
+    const auto * group =
+      findTrafficLightGroup(latest_arbitrated_traffic_signal_, map_ids::vehicle_signal_a);
+    ASSERT_NE(group, nullptr);
+    ASSERT_EQ(group->elements.size(), 1u);
+    EXPECT_EQ(group->elements[0].color, TrafficLightElement::GREEN);
+    EXPECT_NEAR(group->elements[0].confidence, 0.9f, kConfidenceEpsilon);
+  }
+  // vehicle_signal_b: external only with two shapes; both survive shape-wise selection.
+  {
+    const auto * group =
+      findTrafficLightGroup(latest_arbitrated_traffic_signal_, map_ids::vehicle_signal_b);
+    ASSERT_NE(group, nullptr);
+    ASSERT_EQ(group->elements.size(), 2u);
+    EXPECT_NE(findTrafficLightElement(*group, TrafficLightElement::CIRCLE), nullptr);
+    EXPECT_NE(findTrafficLightElement(*group, TrafficLightElement::RIGHT_ARROW), nullptr);
+  }
+  // vehicle_signal_c: perception only, flows through unmodified.
+  {
+    const auto * group =
+      findTrafficLightGroup(latest_arbitrated_traffic_signal_, map_ids::vehicle_signal_c);
+    ASSERT_NE(group, nullptr);
+    ASSERT_EQ(group->elements.size(), 1u);
+    EXPECT_EQ(group->elements[0].color, TrafficLightElement::GREEN);
+    EXPECT_NEAR(group->elements[0].confidence, 0.8f, kConfidenceEpsilon);
+  }
+  // kOffMapProbeId: not on the map -> dropped (WARN+skip).
+  EXPECT_EQ(findTrafficLightGroup(latest_arbitrated_traffic_signal_, kOffMapProbeId), nullptr);
+}
+
+// ---------------------------------------------------------------------------
+// C. Focused specifications - boundary conditions, input validation, and
+//    isolated arbitration rules.
+//
+// Each test pins a single contract that the longest-path tests above do not
+// exercise: map availability, parameter validation, time tolerances,
+// priority overrides, equivalence semantics, and prediction passthrough.
+// ---------------------------------------------------------------------------
+
+TEST_F(ArbiterCharacteristic, perceptionBeforeMapProducesNoOutput)
+{
+  // Arrange (intentionally no publishMap())
+  startArbiter();
+
+  TrafficLightGroupArray perception_traffic_signal;
+  perception_traffic_signal.stamp = arbiter_->now();
+  perception_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
+    map_ids::vehicle_signal_a,
+    {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE)}));
+
+  // Act
+  publishPerception(perception_traffic_signal);
+
+  // Assert
+  EXPECT_EQ(arbiter_publish_count_, 0u)
+    << "arbitrateAndPublish should early-return when no map has been received";
+}
+
+// A non-null but signal-free map should yield an empty TrafficLightGroupArray
+// (stamp set, no groups). Exercises the
+// "map_regulatory_elements_set_->empty()" branch in arbitrateAndPublish.
+TEST_F(ArbiterCharacteristic, emptyMapProducesEmptyOutput)
+{
+  // Arrange: replace the default minimal map with a signal-free one.
+  startArbiter();
+  publishMap(buildEmptyMapBin());
+
+  TrafficLightGroupArray perception_traffic_signal;
+  perception_traffic_signal.stamp = arbiter_->now();
+  perception_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
+    map_ids::vehicle_signal_a,
+    {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE)}));
+
+  // Act
+  publishPerception(perception_traffic_signal);
+
+  // Assert: arbiter publishes, but the output contains no groups.
+  ASSERT_GE(arbiter_publish_count_, 1u);
+  EXPECT_EQ(latest_arbitrated_traffic_signal_.traffic_light_groups.size(), 0u);
+}
+
+// Pins the input-validation contract: an unknown source_priority string
+// must not crash the node and must not silently change behavior; the
+// arbiter must fall back to CONFIDENCE. We verify the fallback by feeding
+// the typical CONFIDENCE scenario (high-confidence perception wins) and
+// confirming perception is selected.
+TEST_F(ArbiterCharacteristic, unknownSourcePriorityFallsBackToConfidence)
+{
+  // Arrange: pass a value not in {"external", "perception", "confidence"}.
+  startArbiter(false, "invalid_value");
+  publishMap();
+  const auto t0 = arbiter_->now();
+
+  TrafficLightGroupArray external_traffic_signal;
+  external_traffic_signal.stamp = offsetTime(t0, -0.10);
+  external_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
+    map_ids::vehicle_signal_a,
+    {makeTrafficLightElement(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.7f)}));
+
+  TrafficLightGroupArray perception_traffic_signal;
+  perception_traffic_signal.stamp = offsetTime(t0, -0.05);
+  perception_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
+    map_ids::vehicle_signal_a,
+    {makeTrafficLightElement(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.9f)}));
+
+  // Act
+  publishExternal(external_traffic_signal);
+  publishPerception(perception_traffic_signal);
+
+  // Assert: CONFIDENCE behavior - the higher-confidence perception wins.
+  const auto * group =
+    findTrafficLightGroup(latest_arbitrated_traffic_signal_, map_ids::vehicle_signal_a);
+  ASSERT_NE(group, nullptr);
+  ASSERT_EQ(group->elements.size(), 1u);
+  EXPECT_EQ(group->elements[0].color, TrafficLightElement::GREEN);
+  EXPECT_NEAR(group->elements[0].confidence, 0.9f, kConfidenceEpsilon);
+}
+
+TEST_F(ArbiterCharacteristic, priorityFlagOverridesHigherConfidence)
+{
+  // Arrange
+  startArbiter(false, "perception");
+  publishMap();
+  const auto t0 = arbiter_->now();
+
+  // The confidence contrast (high external vs low perception) makes the
+  // priority override explicit: the lower-confidence perception still wins.
+  TrafficLightGroupArray external_traffic_signal;
+  external_traffic_signal.stamp = offsetTime(t0, -0.10);
+  external_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
+    map_ids::vehicle_signal_a,
+    {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.99f)}));
+
+  TrafficLightGroupArray perception_traffic_signal;
+  perception_traffic_signal.stamp = offsetTime(t0, -0.05);
+  perception_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
+    map_ids::vehicle_signal_a,
+    {makeTrafficLightElement(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.10f)}));
+
+  // Act
+  publishExternal(external_traffic_signal);
+  publishPerception(perception_traffic_signal);
+
+  // Assert: perception priority wins despite its lower confidence.
+  const auto * group =
+    findTrafficLightGroup(latest_arbitrated_traffic_signal_, map_ids::vehicle_signal_a);
+  ASSERT_NE(group, nullptr);
+  ASSERT_EQ(group->elements.size(), 1u);
+  EXPECT_EQ(group->elements[0].color, TrafficLightElement::GREEN);
+}
+
+// Symmetric counterpart of priorityFlagOverridesHigherConfidence: with
+// source_priority=external, the external value wins over a higher-confidence
+// perception value. This pins the EXTERNAL branch in arbitrateAndPublish
+// ([traffic_light_arbiter.cpp]: source_priority_ == EXTERNAL).
+TEST_F(ArbiterCharacteristic, priorityFlagFromExternalOverridesHigherConfidence)
+{
+  // Arrange
+  startArbiter(false, "external");
+  publishMap();
+  const auto t0 = arbiter_->now();
+
+  // The confidence contrast (low external vs high perception) makes the
+  // priority override explicit: the lower-confidence external still wins.
+  TrafficLightGroupArray external_traffic_signal;
+  external_traffic_signal.stamp = offsetTime(t0, -0.10);
+  external_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
+    map_ids::vehicle_signal_a,
+    {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.10f)}));
+
+  TrafficLightGroupArray perception_traffic_signal;
+  perception_traffic_signal.stamp = offsetTime(t0, -0.05);
+  perception_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
+    map_ids::vehicle_signal_a,
+    {makeTrafficLightElement(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.99f)}));
+
+  // Act
+  publishExternal(external_traffic_signal);
+  publishPerception(perception_traffic_signal);
+
+  // Assert: external priority wins despite its lower confidence.
+  const auto * group =
+    findTrafficLightGroup(latest_arbitrated_traffic_signal_, map_ids::vehicle_signal_a);
+  ASSERT_NE(group, nullptr);
+  ASSERT_EQ(group->elements.size(), 1u);
+  EXPECT_EQ(group->elements[0].color, TrafficLightElement::RED);
+}
+
+// Successive external publishes that carry different ids accumulate in the
+// arbiter's external_traffic_lights_ map; each arrival triggers a new
+// arbitrate run that publishes every currently-stored external signal.
+TEST_F(ArbiterCharacteristic, multipleExternalSourcesAccumulate)
+{
+  // Arrange
+  startArbiter();
+  publishMap();
+  const auto t0 = arbiter_->now();
+
+  // Act 1: publish the first external signal (id vehicle_signal_a).
+  TrafficLightGroupArray first_external_traffic_signal;
+  first_external_traffic_signal.stamp = offsetTime(t0, -1.0);
+  first_external_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
+    map_ids::vehicle_signal_a,
+    {makeTrafficLightElement(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE)}));
+  publishExternal(first_external_traffic_signal);
+
+  // Assert 1: only vehicle_signal_a is visible after the first publish.
+  ASSERT_EQ(latest_arbitrated_traffic_signal_.traffic_light_groups.size(), 1u);
+  EXPECT_EQ(
+    latest_arbitrated_traffic_signal_.traffic_light_groups[0].traffic_light_group_id,
+    map_ids::vehicle_signal_a);
+
+  // Act 2: publish a second external signal carrying a different id.
+  TrafficLightGroupArray second_external_traffic_signal;
+  second_external_traffic_signal.stamp = offsetTime(t0, -0.5);
+  second_external_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
+    map_ids::vehicle_signal_b,
+    {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE)}));
+  publishExternal(second_external_traffic_signal);
+
+  // Assert 2: both vehicle_signal_a and vehicle_signal_b appear in the output.
+  EXPECT_EQ(latest_arbitrated_traffic_signal_.traffic_light_groups.size(), 2u);
+  const auto * group_a =
+    findTrafficLightGroup(latest_arbitrated_traffic_signal_, map_ids::vehicle_signal_a);
+  const auto * group_b =
+    findTrafficLightGroup(latest_arbitrated_traffic_signal_, map_ids::vehicle_signal_b);
+  ASSERT_NE(group_a, nullptr);
+  ASSERT_NE(group_b, nullptr);
+  EXPECT_EQ(group_a->elements[0].color, TrafficLightElement::GREEN);
+  EXPECT_EQ(group_b->elements[0].color, TrafficLightElement::RED);
+}
+
+TEST_F(ArbiterCharacteristic, externalDelayToleranceDropsStaleMessage)
+{
+  // Arrange: establish a perception baseline so we can detect any extra publish.
+  startArbiter();
+  publishMap();
+
+  TrafficLightGroupArray perception_traffic_signal;
+  perception_traffic_signal.stamp = arbiter_->now();
+  perception_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
+    map_ids::vehicle_signal_a,
+    {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE)}));
+  publishPerception(perception_traffic_signal);
+  const auto baseline_count = arbiter_publish_count_;
+  ASSERT_GE(baseline_count, 1u);
+
+  // external_delay_tolerance defaults to 5.0s; 20s in the past is well past it.
+  TrafficLightGroupArray stale_external_traffic_signal;
+  stale_external_traffic_signal.stamp = offsetTime(arbiter_->now(), -20.0);
+  stale_external_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
+    map_ids::vehicle_signal_a,
+    {makeTrafficLightElement(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE)}));
+
+  // Act
+  publishExternal(stale_external_traffic_signal);
+
+  // Assert
+  EXPECT_EQ(arbiter_publish_count_, baseline_count)
+    << "Stale external message must be dropped before arbitrateAndPublish runs";
+  const auto * group =
+    findTrafficLightGroup(latest_arbitrated_traffic_signal_, map_ids::vehicle_signal_a);
+  ASSERT_NE(group, nullptr);
+  EXPECT_EQ(group->elements[0].color, TrafficLightElement::RED)
+    << "Last publish must reflect perception";
 }
 
 TEST_F(ArbiterCharacteristic, externalTimeToleranceCleanupOnPerception)
@@ -962,31 +1067,30 @@ TEST_F(ArbiterCharacteristic, externalTimeToleranceCleanupOnPerception)
   // arrival's cleanupExpiredExternalSignals (perception is +6s newer).
   startArbiter();
   publishMap();
-  const auto t0 = arbiterNow();
+  const auto t0 = arbiter_->now();
 
   TrafficLightGroupArray external_traffic_signal;
   external_traffic_signal.stamp = offsetTime(t0, -0.05);
   external_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
     map_ids::vehicle_signal_a,
-    {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.5f)}));
+    {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE)}));
   publishExternal(external_traffic_signal);
 
   TrafficLightGroupArray perception_traffic_signal;
   perception_traffic_signal.stamp = offsetTime(t0, 6.0);
   perception_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
     map_ids::vehicle_signal_a,
-    {makeTrafficLightElement(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.7f)}));
+    {makeTrafficLightElement(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE)}));
 
   // Act
   publishPerception(perception_traffic_signal);
 
   // Assert
-  const auto * g =
+  const auto * group =
     findTrafficLightGroup(latest_arbitrated_traffic_signal_, map_ids::vehicle_signal_a);
-  ASSERT_NE(g, nullptr);
-  ASSERT_EQ(g->elements.size(), 1u);
-  EXPECT_EQ(g->elements[0].color, TrafficLightElement::GREEN);
-  EXPECT_NEAR(g->elements[0].confidence, 0.7f, kConfidenceEpsilon);
+  ASSERT_NE(group, nullptr);
+  ASSERT_EQ(group->elements.size(), 1u);
+  EXPECT_EQ(group->elements[0].color, TrafficLightElement::GREEN);
 }
 
 // onExternalMsg compares its own stamp to latest_perception_msg_.stamp; if
@@ -997,14 +1101,14 @@ TEST_F(ArbiterCharacteristic, perceptionTimeToleranceClearsLatestPerception)
   // Arrange
   startArbiter();
   publishMap();
-  const auto t0 = arbiterNow();
+  const auto t0 = arbiter_->now();
 
   // Seed a perception value at t0.
   TrafficLightGroupArray perception_traffic_signal;
   perception_traffic_signal.stamp = t0;
   perception_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
     map_ids::vehicle_signal_a,
-    {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.9f)}));
+    {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE)}));
   publishPerception(perception_traffic_signal);
 
   // External arrives 2.0s after perception (> perception_time_tolerance=1.0,
@@ -1013,18 +1117,17 @@ TEST_F(ArbiterCharacteristic, perceptionTimeToleranceClearsLatestPerception)
   external_traffic_signal.stamp = offsetTime(t0, 2.0);
   external_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
     map_ids::vehicle_signal_a,
-    {makeTrafficLightElement(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.5f)}));
+    {makeTrafficLightElement(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE)}));
 
   // Act
   publishExternal(external_traffic_signal);
 
   // Assert: stale perception was wiped, output reflects only external.
-  const auto * g =
+  const auto * group =
     findTrafficLightGroup(latest_arbitrated_traffic_signal_, map_ids::vehicle_signal_a);
-  ASSERT_NE(g, nullptr);
-  ASSERT_EQ(g->elements.size(), 1u);
-  EXPECT_EQ(g->elements[0].color, TrafficLightElement::GREEN);
-  EXPECT_NEAR(g->elements[0].confidence, 0.5f, kConfidenceEpsilon);
+  ASSERT_NE(group, nullptr);
+  ASSERT_EQ(group->elements.size(), 1u);
+  EXPECT_EQ(group->elements[0].color, TrafficLightElement::GREEN);
 }
 
 TEST_F(ArbiterCharacteristic, predictionsFromSingleSidePropagate)
@@ -1032,13 +1135,13 @@ TEST_F(ArbiterCharacteristic, predictionsFromSingleSidePropagate)
   // Arrange
   startArbiter();
   publishMap();
-  const auto t0 = arbiterNow();
+  const auto t0 = arbiter_->now();
 
   TrafficLightGroupArray perception_traffic_signal;
   perception_traffic_signal.stamp = t0;
   perception_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
     map_ids::vehicle_signal_a,
-    {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.8f)},
+    {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE)},
     {makeTrafficLightPrediction(
       t0, TrafficLightElement::GREEN, TrafficLightElement::CIRCLE,
       PredictedTrafficLightState::INFORMATION_SOURCE_INTERNAL_ESTIMATION)}));
@@ -1047,12 +1150,12 @@ TEST_F(ArbiterCharacteristic, predictionsFromSingleSidePropagate)
   publishPerception(perception_traffic_signal);
 
   // Assert
-  const auto * g =
+  const auto * group =
     findTrafficLightGroup(latest_arbitrated_traffic_signal_, map_ids::vehicle_signal_a);
-  ASSERT_NE(g, nullptr);
-  ASSERT_EQ(g->predictions.size(), 1u);
+  ASSERT_NE(group, nullptr);
+  ASSERT_EQ(group->predictions.size(), 1u);
   EXPECT_EQ(
-    g->predictions[0].information_source,
+    group->predictions[0].information_source,
     PredictedTrafficLightState::INFORMATION_SOURCE_INTERNAL_ESTIMATION);
 }
 

--- a/perception/autoware_traffic_light_arbiter/test/test_traffic_arbiter_characteristic.cpp
+++ b/perception/autoware_traffic_light_arbiter/test/test_traffic_arbiter_characteristic.cpp
@@ -235,6 +235,7 @@ builtin_interfaces::msg::Time offset_time(const rclcpp::Time & base, double seco
 class ArbiterCharacteristic : public ::testing::Test
 {
 protected:
+  // --- Lifecycle ---------------------------------------------------------
   static void SetUpTestSuite()
   {
     if (!rclcpp::ok()) {
@@ -290,6 +291,7 @@ protected:
     test_node_.reset();
   }
 
+  // --- Arrange -----------------------------------------------------------
   void start_arbiter(bool enable_signal_matching, const std::string & source_priority)
   {
     rclcpp::NodeOptions options;
@@ -315,6 +317,7 @@ protected:
     map_pub_->publish(bin);
     spin_for();
   }
+  // --- Act ---------------------------------------------------------------
   void publish_perception(const TrafficLightGroupArray & msg)
   {
     perception_pub_->publish(msg);
@@ -335,6 +338,7 @@ protected:
     }
   }
 
+  // --- Assert ------------------------------------------------------------
   // Look up a TrafficLightGroup or TrafficLightElement in the latest
   // arbitrated output. Returns nullptr when not present.
   const TrafficLightGroup * find_traffic_light_group(lanelet::Id id) const

--- a/perception/autoware_traffic_light_arbiter/test/test_traffic_arbiter_characteristic.cpp
+++ b/perception/autoware_traffic_light_arbiter/test/test_traffic_arbiter_characteristic.cpp
@@ -153,24 +153,6 @@ LaneletMapBin build_empty_map_bin()
 
 // --- Node construction -------------------------------------------------
 
-// Default parameters mirror config/traffic_light_arbiter.param.yaml. We
-// re-declare them here instead of reading the YAML so the test is fully
-// self-contained and unaffected by production config changes. Only the
-// two parameters that any test actually toggles are exposed as arguments.
-std::shared_ptr<TrafficLightArbiter> make_arbiter(
-  bool enable_signal_matching = false, const std::string & source_priority = "confidence")
-{
-  rclcpp::NodeOptions options;
-  options.parameter_overrides({
-    rclcpp::Parameter("external_delay_tolerance", 5.0),
-    rclcpp::Parameter("external_time_tolerance", 5.0),
-    rclcpp::Parameter("perception_time_tolerance", 1.0),
-    rclcpp::Parameter("source_priority", source_priority),
-    rclcpp::Parameter("enable_signal_matching", enable_signal_matching),
-  });
-  return std::make_shared<TrafficLightArbiter>(options);
-}
-
 // --- Input message builders --------------------------------------------
 
 // Confidence defaults to 1.0f: most tests don't care about the value (the
@@ -321,7 +303,20 @@ protected:
 
   void start_arbiter(bool enable_signal_matching, const std::string & source_priority)
   {
-    arbiter_ = make_arbiter(enable_signal_matching, source_priority);
+    // Default tolerances mirror config/traffic_light_arbiter.param.yaml.
+    // We re-declare them here so the test is self-contained and unaffected
+    // by production config changes; only the two parameters that any test
+    // actually toggles (enable_signal_matching, source_priority) are
+    // exposed as start_arbiter() arguments.
+    rclcpp::NodeOptions options;
+    options.parameter_overrides({
+      rclcpp::Parameter("external_delay_tolerance", kDefaultExternalDelayTolerance),
+      rclcpp::Parameter("external_time_tolerance", kDefaultExternalTimeTolerance),
+      rclcpp::Parameter("perception_time_tolerance", kDefaultPerceptionTimeTolerance),
+      rclcpp::Parameter("source_priority", source_priority),
+      rclcpp::Parameter("enable_signal_matching", enable_signal_matching),
+    });
+    arbiter_ = std::make_shared<TrafficLightArbiter>(options);
     executor_ = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
     executor_->add_node(arbiter_);
     executor_->add_node(test_node_);
@@ -404,6 +399,14 @@ protected:
     return group ? group->predictions.size() : SIZE_MAX;
   }
 
+  // Whole-output query: how many TrafficLightGroups the arbiter published
+  // in its latest message. Used by tests that pin the cardinality of the
+  // output (empty publish on empty map, accumulation across publishes).
+  std::size_t observed_group_count() const
+  {
+    return latest_arbitrated_traffic_signal_.traffic_light_groups.size();
+  }
+
   // Multi-element variants: pick the element whose shape matches and read
   // its color. Used by tests that pin a shape-union output (e.g.
   // element-count mismatch yielding UNKNOWN over CIRCLE+RIGHT_ARROW).
@@ -465,6 +468,14 @@ protected:
   // EXPECT_NEAR. Kept inside the fixture because it is only meaningful for
   // tests that derive from this class.
   static constexpr float kConfidenceEpsilon = 1e-5f;
+
+  // Default tolerance parameters declared on the arbiter (mirrors
+  // config/traffic_light_arbiter.param.yaml). Time-tolerance tests pick
+  // offsets relative to these so the relationship is explicit at the
+  // call site (e.g., offset_time(t0_, -(kDefaultExternalDelayTolerance + 15.0))).
+  static constexpr double kDefaultExternalDelayTolerance = 5.0;
+  static constexpr double kDefaultExternalTimeTolerance = 5.0;
+  static constexpr double kDefaultPerceptionTimeTolerance = 1.0;
 };
 
 // ---------------------------------------------------------------------------
@@ -846,7 +857,7 @@ TEST_F(ArbiterCharacteristic, emptyMapProducesEmptyOutput)
   // counter read distinguishes "publish happened with zero groups" (the
   // spec) from "no publish at all" (which would also leave groups empty).
   ASSERT_GE(arbiter_publish_count_, 1u);
-  EXPECT_EQ(latest_arbitrated_traffic_signal_.traffic_light_groups.size(), 0u);
+  EXPECT_EQ(observed_group_count(), 0u);
 }
 
 // Pins the input-validation contract: an unknown source_priority string
@@ -930,10 +941,8 @@ TEST_F(ArbiterCharacteristic, multipleExternalSourcesAccumulate)
     {make_traffic_light_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE)}));
 
   // Assert 1: only vehicle_signal_a is visible after the first publish.
-  ASSERT_EQ(latest_arbitrated_traffic_signal_.traffic_light_groups.size(), 1u);
-  EXPECT_EQ(
-    latest_arbitrated_traffic_signal_.traffic_light_groups[0].traffic_light_group_id,
-    map_ids::vehicle_signal_a);
+  ASSERT_EQ(observed_group_count(), 1u);
+  EXPECT_NE(find_traffic_light_group(map_ids::vehicle_signal_a), nullptr);
 
   // Act 2: publish a second external signal carrying a different id.
   publish_external(make_signal_array(
@@ -941,7 +950,7 @@ TEST_F(ArbiterCharacteristic, multipleExternalSourcesAccumulate)
     {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)}));
 
   // Assert 2: both vehicle_signal_a and vehicle_signal_b appear in the output.
-  EXPECT_EQ(latest_arbitrated_traffic_signal_.traffic_light_groups.size(), 2u);
+  EXPECT_EQ(observed_group_count(), 2u);
   EXPECT_EQ(observed_color(map_ids::vehicle_signal_a), TrafficLightElement::GREEN);
   EXPECT_EQ(observed_color(map_ids::vehicle_signal_b), TrafficLightElement::RED);
 }
@@ -957,9 +966,9 @@ TEST_F(ArbiterCharacteristic, externalDelayToleranceDropsStaleMessage)
     t0_, map_ids::vehicle_signal_a,
     {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)}));
 
-  // Act: external_delay_tolerance defaults to 5.0s; 20s in the past is well past it.
+  // Act: stamp is well past external_delay_tolerance in the past.
   publish_external(make_signal_array(
-    offset_time(t0_, -20.0), map_ids::vehicle_signal_a,
+    offset_time(t0_, -(kDefaultExternalDelayTolerance + 15.0)), map_ids::vehicle_signal_a,
     {make_traffic_light_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE)}));
 
   // Assert: the stale GREEN never propagates; the published color stays RED.
@@ -969,7 +978,8 @@ TEST_F(ArbiterCharacteristic, externalDelayToleranceDropsStaleMessage)
 TEST_F(ArbiterCharacteristic, externalTimeToleranceCleanupOnPerception)
 {
   // Arrange: seed an external entry that should be purged by the perception
-  // arrival's cleanupExpiredExternalSignals (perception is +6s newer).
+  // arrival's cleanupExpiredExternalSignals (perception is past
+  // external_time_tolerance newer than the stored external).
   start_arbiter(false, "confidence");  // priority-based mode, "confidence" priority
   publish_map();
   publish_external(make_signal_array(
@@ -978,7 +988,7 @@ TEST_F(ArbiterCharacteristic, externalTimeToleranceCleanupOnPerception)
 
   // Act
   publish_perception(make_signal_array(
-    offset_time(t0_, 6.0), map_ids::vehicle_signal_a,
+    offset_time(t0_, kDefaultExternalTimeTolerance + 1.0), map_ids::vehicle_signal_a,
     {make_traffic_light_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE)}));
 
   // Assert
@@ -986,8 +996,8 @@ TEST_F(ArbiterCharacteristic, externalTimeToleranceCleanupOnPerception)
 }
 
 // onExternalMsg compares its own stamp to latest_perception_msg_.stamp; if
-// the gap exceeds perception_time_tolerance (default 1.0s) it clears the
-// stored perception groups so the upcoming publish reflects only external.
+// the gap exceeds perception_time_tolerance it clears the stored perception
+// groups so the upcoming publish reflects only external.
 TEST_F(ArbiterCharacteristic, perceptionTimeToleranceClearsLatestPerception)
 {
   // Arrange
@@ -999,10 +1009,11 @@ TEST_F(ArbiterCharacteristic, perceptionTimeToleranceClearsLatestPerception)
     t0_, map_ids::vehicle_signal_a,
     {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)}));
 
-  // Act: external arrives 2.0s after perception (> perception_time_tolerance=1.0,
-  // < external_delay_tolerance=5.0 so it is itself accepted).
+  // Act: external arrives past perception_time_tolerance after perception
+  // (so latest perception is cleared) but within external_delay_tolerance
+  // so external itself is accepted.
   publish_external(make_signal_array(
-    offset_time(t0_, 2.0), map_ids::vehicle_signal_a,
+    offset_time(t0_, kDefaultPerceptionTimeTolerance + 1.0), map_ids::vehicle_signal_a,
     {make_traffic_light_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE)}));
 
   // Assert: stale perception was wiped, output reflects only external.

--- a/perception/autoware_traffic_light_arbiter/test/test_traffic_arbiter_characteristic.cpp
+++ b/perception/autoware_traffic_light_arbiter/test/test_traffic_arbiter_characteristic.cpp
@@ -404,10 +404,6 @@ protected:
     return element ? element->color : UINT8_MAX;
   }
 
-  // arbiter_publish_count_ is incremented by the output subscription
-  // callback and read by tests where content alone cannot prove whether
-  // a publish happened.
-
   // Wrapped in std::optional because LaneletMapBin (a generated ROS msg)
   // has no usable default constructor that can be invoked at static storage
   // duration; we initialise it during SetUpTestSuite().

--- a/perception/autoware_traffic_light_arbiter/test/test_traffic_arbiter_characteristic.cpp
+++ b/perception/autoware_traffic_light_arbiter/test/test_traffic_arbiter_characteristic.cpp
@@ -311,7 +311,7 @@ protected:
     executor_ = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
     executor_->add_node(arbiter_);
     executor_->add_node(test_node_);
-    spinFor(std::chrono::milliseconds(150));
+    spinFor();
   }
 
   void publishMap() { publishMap(*map_bin_); }
@@ -319,20 +319,20 @@ protected:
   void publishMap(const LaneletMapBin & bin)
   {
     map_pub_->publish(bin);
-    spinFor(std::chrono::milliseconds(150));
+    spinFor();
   }
   void publishPerception(const TrafficLightGroupArray & msg)
   {
     perception_pub_->publish(msg);
-    spinFor(std::chrono::milliseconds(150));
+    spinFor();
   }
   void publishExternal(const TrafficLightGroupArray & msg)
   {
     external_pub_->publish(msg);
-    spinFor(std::chrono::milliseconds(150));
+    spinFor();
   }
 
-  void spinFor(std::chrono::milliseconds duration)
+  void spinFor(std::chrono::milliseconds duration = std::chrono::milliseconds(150))
   {
     const auto deadline = std::chrono::steady_clock::now() + duration;
     while (std::chrono::steady_clock::now() < deadline) {

--- a/perception/autoware_traffic_light_arbiter/test/test_traffic_arbiter_characteristic.cpp
+++ b/perception/autoware_traffic_light_arbiter/test/test_traffic_arbiter_characteristic.cpp
@@ -925,29 +925,23 @@ TEST_F(ArbiterCharacteristic, priorityFlagFromExternalOverridesHigherConfidence)
 }
 
 // Successive external publishes that carry different ids accumulate in the
-// arbiter's external_traffic_lights_ map; each arrival triggers a new
-// arbitrate run that publishes every currently-stored external signal.
+// arbiter's external_traffic_lights_ map; both end up in the final output
+// with their published values preserved.
 TEST_F(ArbiterCharacteristic, multipleExternalSourcesAccumulate)
 {
   // Arrange
   start_arbiter(false, "confidence");  // priority-based mode, "confidence" priority
   publish_map();
 
-  // Act 1: publish the first external signal (id vehicle_signal_a).
+  // Act: publish two external signals carrying different ids.
   publish_external(make_signal_array(
     t0_, map_ids::vehicle_signal_a,
     {make_traffic_light_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE)}));
-
-  // Assert 1: only vehicle_signal_a is visible after the first publish.
-  ASSERT_EQ(observed_group_count(), 1u);
-  EXPECT_NE(find_traffic_light_group(map_ids::vehicle_signal_a), nullptr);
-
-  // Act 2: publish a second external signal carrying a different id.
   publish_external(make_signal_array(
     t0_, map_ids::vehicle_signal_b,
     {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)}));
 
-  // Assert 2: both vehicle_signal_a and vehicle_signal_b appear in the output.
+  // Assert: both ids accumulated, each id retains its published color.
   EXPECT_EQ(observed_group_count(), 2u);
   EXPECT_EQ(observed_color(map_ids::vehicle_signal_a), TrafficLightElement::GREEN);
   EXPECT_EQ(observed_color(map_ids::vehicle_signal_b), TrafficLightElement::RED);

--- a/perception/autoware_traffic_light_arbiter/test/test_traffic_arbiter_characteristic.cpp
+++ b/perception/autoware_traffic_light_arbiter/test/test_traffic_arbiter_characteristic.cpp
@@ -410,7 +410,6 @@ TEST_F(ArbiterCharacteristic, signalMatchingMatchedPassesThrough)
   publishPerception(perception_traffic_signal);
 
   // Assert
-  ASSERT_GE(arbiter_publish_count_, 1u);
   const auto * group =
     findTrafficLightGroup(latest_arbitrated_traffic_signal_, map_ids::vehicle_signal_a);
   ASSERT_NE(group, nullptr);
@@ -445,7 +444,6 @@ TEST_F(ArbiterCharacteristic, signalMatchingColorMismatchProducesUnknown)
   publishPerception(perception_traffic_signal);
 
   // Assert
-  ASSERT_GE(arbiter_publish_count_, 1u);
   const auto * group =
     findTrafficLightGroup(latest_arbitrated_traffic_signal_, map_ids::vehicle_signal_b);
   ASSERT_NE(group, nullptr);
@@ -481,7 +479,6 @@ TEST_F(ArbiterCharacteristic, signalMatchingElementCountMismatchProducesUnknown)
   publishPerception(perception_traffic_signal);
 
   // Assert
-  ASSERT_GE(arbiter_publish_count_, 1u);
   const auto * group =
     findTrafficLightGroup(latest_arbitrated_traffic_signal_, map_ids::vehicle_signal_c);
   ASSERT_NE(group, nullptr);
@@ -523,7 +520,6 @@ TEST_F(ArbiterCharacteristic, signalMatchingOffMapIdDropped)
   publishPerception(perception_traffic_signal);
 
   // Assert
-  ASSERT_GE(arbiter_publish_count_, 1u);
   EXPECT_EQ(findTrafficLightGroup(latest_arbitrated_traffic_signal_, kOffMapProbeId), nullptr);
   EXPECT_NE(
     findTrafficLightGroup(latest_arbitrated_traffic_signal_, map_ids::vehicle_signal_a), nullptr);
@@ -784,7 +780,6 @@ TEST_F(ArbiterCharacteristic, priorityBasedConfidencePicksHigherValue)
   publishPerception(perception_traffic_signal);
 
   // Assert
-  ASSERT_GE(arbiter_publish_count_, 1u);
   const auto * group =
     findTrafficLightGroup(latest_arbitrated_traffic_signal_, map_ids::vehicle_signal_a);
   ASSERT_NE(group, nullptr);
@@ -822,7 +817,6 @@ TEST_F(ArbiterCharacteristic, priorityBasedExternalOnlyPassesThrough)
   publishPerception(perception_traffic_signal);
 
   // Assert
-  ASSERT_GE(arbiter_publish_count_, 1u);
   const auto * group =
     findTrafficLightGroup(latest_arbitrated_traffic_signal_, map_ids::vehicle_signal_b);
   ASSERT_NE(group, nullptr);
@@ -859,7 +853,6 @@ TEST_F(ArbiterCharacteristic, priorityBasedPerceptionOnlyPassesThrough)
   publishPerception(perception_traffic_signal);
 
   // Assert
-  ASSERT_GE(arbiter_publish_count_, 1u);
   const auto * group =
     findTrafficLightGroup(latest_arbitrated_traffic_signal_, map_ids::vehicle_signal_c);
   ASSERT_NE(group, nullptr);
@@ -894,7 +887,6 @@ TEST_F(ArbiterCharacteristic, priorityBasedOffMapIdDropped)
   publishPerception(perception_traffic_signal);
 
   // Assert
-  ASSERT_GE(arbiter_publish_count_, 1u);
   EXPECT_EQ(findTrafficLightGroup(latest_arbitrated_traffic_signal_, kOffMapProbeId), nullptr);
   EXPECT_NE(
     findTrafficLightGroup(latest_arbitrated_traffic_signal_, map_ids::vehicle_signal_a), nullptr);
@@ -943,6 +935,8 @@ TEST_F(ArbiterCharacteristic, emptyMapProducesEmptyOutput)
   publishPerception(perception_traffic_signal);
 
   // Assert: arbiter publishes, but the output contains no groups.
+  // The publish-count check distinguishes "no publish happened" from
+  // "publish happened with an empty array" — both leave groups empty.
   ASSERT_GE(arbiter_publish_count_, 1u);
   EXPECT_EQ(latest_arbitrated_traffic_signal_.traffic_light_groups.size(), 0u);
 }

--- a/perception/autoware_traffic_light_arbiter/test/test_traffic_arbiter_characteristic.cpp
+++ b/perception/autoware_traffic_light_arbiter/test/test_traffic_arbiter_characteristic.cpp
@@ -371,6 +371,33 @@ protected:
     return group ? group->predictions.size() : SIZE_MAX;
   }
 
+  // Publish-count specs: some contracts hinge on whether the arbiter emits
+  // a message at all, independent of the content. We count callbacks on
+  // the output subscription and expose these helpers so each contract is
+  // named at the call site.
+
+  // Snapshot the running publish count. Capture before an action that
+  // should not trigger a publish, then pair with expect_no_publish_since().
+  std::size_t publish_count() const { return arbiter_publish_count_; }
+
+  // Spec: the arbiter has not emitted any TrafficLightGroupArray yet.
+  // Used when an early-return path is expected (e.g., perception arrived
+  // before the vector_map).
+  void expect_no_publish() { EXPECT_EQ(arbiter_publish_count_, 0u); }
+
+  // Spec: the arbiter has emitted at least one TrafficLightGroupArray.
+  // Used when the published content is expected to be empty so a
+  // content-based check cannot tell "no publish" from "empty publish".
+  void expect_publish_happened() { ASSERT_GE(arbiter_publish_count_, 1u); }
+
+  // Spec: the arbiter has not emitted any new TrafficLightGroupArray
+  // since `baseline`. Used after an action whose contract is "this input
+  // must be dropped before reaching arbitrateAndPublish".
+  void expect_no_publish_since(std::size_t baseline)
+  {
+    EXPECT_EQ(arbiter_publish_count_, baseline);
+  }
+
   // Wrapped in std::optional because LaneletMapBin (a generated ROS msg)
   // has no usable default constructor that can be invoked at static storage
   // duration; we initialise it during SetUpTestSuite().
@@ -889,9 +916,8 @@ TEST_F(ArbiterCharacteristic, perceptionBeforeMapProducesNoOutput)
   // Act
   publish_perception(perception_traffic_signal);
 
-  // Assert
-  EXPECT_EQ(arbiter_publish_count_, 0u)
-    << "arbitrateAndPublish should early-return when no map has been received";
+  // Assert: arbitrateAndPublish should early-return when no map has been received.
+  expect_no_publish();
 }
 
 // A non-null but signal-free map should yield an empty TrafficLightGroupArray
@@ -913,9 +939,7 @@ TEST_F(ArbiterCharacteristic, emptyMapProducesEmptyOutput)
   publish_perception(perception_traffic_signal);
 
   // Assert: arbiter publishes, but the output contains no groups.
-  // The publish-count check distinguishes "no publish happened" from
-  // "publish happened with an empty array" — both leave groups empty.
-  ASSERT_GE(arbiter_publish_count_, 1u);
+  expect_publish_happened();
   EXPECT_EQ(latest_arbitrated_traffic_signal_.traffic_light_groups.size(), 0u);
 }
 
@@ -1060,7 +1084,7 @@ TEST_F(ArbiterCharacteristic, externalDelayToleranceDropsStaleMessage)
     map_ids::vehicle_signal_a,
     {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)}));
   publish_perception(perception_traffic_signal);
-  const auto baseline_count = arbiter_publish_count_;
+  const auto baseline = publish_count();
 
   // external_delay_tolerance defaults to 5.0s; 20s in the past is well past it.
   TrafficLightGroupArray stale_external_traffic_signal;
@@ -1072,11 +1096,10 @@ TEST_F(ArbiterCharacteristic, externalDelayToleranceDropsStaleMessage)
   // Act
   publish_external(stale_external_traffic_signal);
 
-  // Assert
-  EXPECT_EQ(arbiter_publish_count_, baseline_count)
-    << "Stale external message must be dropped before arbitrateAndPublish runs";
-  EXPECT_EQ(observed_color(map_ids::vehicle_signal_a), TrafficLightElement::RED)
-    << "Last publish must reflect perception";
+  // Assert: stale external message must be dropped before arbitrateAndPublish runs.
+  expect_no_publish_since(baseline);
+  // Last publish must still reflect the earlier perception value.
+  EXPECT_EQ(observed_color(map_ids::vehicle_signal_a), TrafficLightElement::RED);
 }
 
 TEST_F(ArbiterCharacteristic, externalTimeToleranceCleanupOnPerception)

--- a/perception/autoware_traffic_light_arbiter/test/test_traffic_arbiter_characteristic.cpp
+++ b/perception/autoware_traffic_light_arbiter/test/test_traffic_arbiter_characteristic.cpp
@@ -153,9 +153,7 @@ LaneletMapBin build_empty_map_bin()
 
 // --- Input message builders --------------------------------------------
 
-// Confidence defaults to 1.0f: most tests don't care about the value (the
-// arbiter only consults it under the CONFIDENCE branch), so omitting the
-// argument signals "this number is irrelevant to the assertion".
+// Confidence defaults to 1.0f because most tests do not assert on it.
 TrafficLightElement make_traffic_light_element(
   uint8_t color, uint8_t shape, float confidence = 1.0f)
 {
@@ -204,8 +202,6 @@ TrafficLightGroup make_traffic_light_group(
 }
 
 // Compose a TrafficLightGroupArray with one group in a single expression.
-// Reduces the per-test boilerplate of declaring an array, setting the
-// stamp, and pushing a group with three calls.
 TrafficLightGroupArray make_signal_array(
   const rclcpp::Time & stamp, lanelet::Id id, std::vector<TrafficLightElement> elements,
   std::vector<PredictedTrafficLightState> predictions = {})
@@ -217,8 +213,7 @@ TrafficLightGroupArray make_signal_array(
   return msg;
 }
 
-// Multi-group variant for tests that publish several ids in one message
-// (e.g. off-map-drop tests that mix an on-map id with map_ids::off_map_probe).
+// Multi-group variant for tests that publish several ids in one message.
 TrafficLightGroupArray make_signal_array(
   const rclcpp::Time & stamp, std::vector<TrafficLightGroup> groups)
 {
@@ -234,10 +229,6 @@ builtin_interfaces::msg::Time offset_time(const rclcpp::Time & base, double seco
 {
   return (base + rclcpp::Duration::from_seconds(seconds));
 }
-
-// Output inspection helpers live on the fixture (see find_traffic_light_group
-// and find_traffic_light_element) so they can read latest_arbitrated_traffic_signal_
-// implicitly and share a layer with observed_color/shape/... etc.
 
 // --- Test fixture ------------------------------------------------------
 
@@ -301,11 +292,6 @@ protected:
 
   void start_arbiter(bool enable_signal_matching, const std::string & source_priority)
   {
-    // Default tolerances mirror config/traffic_light_arbiter.param.yaml.
-    // We re-declare them here so the test is self-contained and unaffected
-    // by production config changes; only the two parameters that any test
-    // actually toggles (enable_signal_matching, source_priority) are
-    // exposed as start_arbiter() arguments.
     rclcpp::NodeOptions options;
     options.parameter_overrides({
       rclcpp::Parameter("external_delay_tolerance", kDefaultExternalDelayTolerance),
@@ -350,8 +336,7 @@ protected:
   }
 
   // Look up a TrafficLightGroup or TrafficLightElement in the latest
-  // arbitrated output. Returning nullptr signals "not present"; tests
-  // pair this with ASSERT_NE / EXPECT_EQ accordingly.
+  // arbitrated output. Returns nullptr when not present.
   const TrafficLightGroup * find_traffic_light_group(lanelet::Id id) const
   {
     for (const auto & group : latest_arbitrated_traffic_signal_.traffic_light_groups) {
@@ -397,17 +382,13 @@ protected:
     return group ? group->predictions.size() : SIZE_MAX;
   }
 
-  // Whole-output query: how many TrafficLightGroups the arbiter published
-  // in its latest message. Used by tests that pin the cardinality of the
-  // output (empty publish on empty map, accumulation across publishes).
+  // Cardinality of the latest published TrafficLightGroupArray.
   std::size_t observed_group_count() const
   {
     return latest_arbitrated_traffic_signal_.traffic_light_groups.size();
   }
 
-  // Multi-element variants: pick the element whose shape matches and read
-  // its color. Used by tests that pin a shape-union output (e.g.
-  // element-count mismatch yielding UNKNOWN over CIRCLE+RIGHT_ARROW).
+  // Multi-element variants: pick the element with the matching shape.
   std::size_t observed_element_count(lanelet::Id signal_id) const
   {
     const auto * group = find_traffic_light_group(signal_id);
@@ -423,10 +404,9 @@ protected:
     return element ? element->color : UINT8_MAX;
   }
 
-  // arbiter_publish_count_ (incremented by the output subscription callback)
-  // is read in two specific tests where content alone cannot express the
-  // contract: see perceptionBeforeMapProducesNoOutput and
-  // emptyMapProducesEmptyOutput for the rationale at each call site.
+  // arbiter_publish_count_ is incremented by the output subscription
+  // callback and read by tests where content alone cannot prove whether
+  // a publish happened.
 
   // Wrapped in std::optional because LaneletMapBin (a generated ROS msg)
   // has no usable default constructor that can be invoked at static storage
@@ -445,11 +425,8 @@ protected:
   TrafficLightGroupArray latest_arbitrated_traffic_signal_;
   std::size_t arbiter_publish_count_ = 0;
 
-  // Reference timestamp captured once in start_arbiter(). Tests use t0_
-  // (and offset_time(t0_, ...)) as a fixed clock so no test body needs
-  // to query the node clock again. t0_ is sampled just before each test
-  // publishes, so its small drift from the arbiter's wall clock stays
-  // well within external_delay_tolerance.
+  // Reference timestamp captured once in start_arbiter(); tests use it
+  // (and offset_time(t0_, ...)) as a fixed clock.
   rclcpp::Time t0_;
 
 private:
@@ -462,9 +439,7 @@ private:
   static constexpr const char * kOutputTopic = "/traffic_light_arbiter/pub/traffic_signals";
 
 protected:
-  // Tolerance used by TEST_F bodies when comparing confidence values via
-  // EXPECT_NEAR. Kept inside the fixture because it is only meaningful for
-  // tests that derive from this class.
+  // Tolerance used by EXPECT_NEAR when comparing confidence values.
   static constexpr float kConfidenceEpsilon = 1e-5f;
 
   // Default tolerance values declared on the arbiter (mirrors
@@ -856,11 +831,9 @@ TEST_F(ArbiterCharacteristic, emptyMapProducesEmptyOutput)
   EXPECT_EQ(observed_group_count(), 0u);
 }
 
-// Pins the input-validation contract: an unknown source_priority string
-// must not crash the node and must not silently change behavior; the
-// arbiter must fall back to CONFIDENCE. We verify the fallback by feeding
-// the typical CONFIDENCE scenario (high-confidence perception wins) and
-// confirming perception is selected.
+// An unknown source_priority string must fall back to CONFIDENCE. Verified
+// by feeding a CONFIDENCE scenario and confirming the higher-confidence
+// perception wins.
 TEST_F(ArbiterCharacteristic, unknownSourcePriorityFallsBackToConfidence)
 {
   // Arrange: pass a value not in {"external", "perception", "confidence"}.
@@ -901,8 +874,7 @@ TEST_F(ArbiterCharacteristic, priorityFlagOverridesHigherConfidence)
 
 // Symmetric counterpart of priorityFlagOverridesHigherConfidence: with
 // source_priority=external, the external value wins over a higher-confidence
-// perception value. This pins the EXTERNAL branch in arbitrateAndPublish
-// ([traffic_light_arbiter.cpp]: source_priority_ == EXTERNAL).
+// perception value.
 TEST_F(ArbiterCharacteristic, priorityFlagFromExternalOverridesHigherConfidence)
 {
   // Arrange

--- a/perception/autoware_traffic_light_arbiter/test/test_traffic_arbiter_characteristic.cpp
+++ b/perception/autoware_traffic_light_arbiter/test/test_traffic_arbiter_characteristic.cpp
@@ -32,6 +32,7 @@
 
 #include <chrono>
 #include <memory>
+#include <optional>
 #include <string>
 #include <thread>
 #include <utility>
@@ -56,6 +57,8 @@ constexpr const char * kOutputTopic = "/traffic_light_arbiter/pub/traffic_signal
 
 constexpr float kConfidenceEpsilon = 1e-5f;
 
+// --- Signal IDs --------------------------------------------------------
+
 // Traffic-light regulatory-element IDs that are installed on the test map.
 // Kept explicit (rather than auto-allocated) so that values appearing in
 // published TrafficLightGroupArray messages and warning logs stay readable.
@@ -70,6 +73,8 @@ constexpr lanelet::Id pedestrian_signal = 2001;
 // Intentionally not installed on the map; used by tests as the "off-map id"
 // probe to exercise the WARN+skip branch in arbitrateAndPublish.
 constexpr lanelet::Id kOffMapProbeId = 9999;
+
+// --- Map construction --------------------------------------------------
 
 Point3d makePoint(lanelet::Id id, double x, double y, double z = 0.0)
 {
@@ -141,6 +146,8 @@ LaneletMapBin buildMinimalMapBin()
   return bin;
 }
 
+// --- Node construction -------------------------------------------------
+
 // Default parameters mirror config/traffic_light_arbiter.param.yaml. We
 // re-declare them here instead of reading the YAML so the test is fully
 // self-contained and unaffected by production config changes. Only the
@@ -158,6 +165,8 @@ std::shared_ptr<TrafficLightArbiter> makeArbiter(
   });
   return std::make_shared<TrafficLightArbiter>(options);
 }
+
+// --- Input message builders --------------------------------------------
 
 TrafficLightElement makeTrafficLightElement(uint8_t color, uint8_t shape, float confidence)
 {
@@ -199,10 +208,14 @@ TrafficLightGroup makeTrafficLightGroup(
   return group;
 }
 
+// --- Timestamp utility -------------------------------------------------
+
 builtin_interfaces::msg::Time offsetTime(const rclcpp::Time & base, double seconds)
 {
   return (base + rclcpp::Duration::from_seconds(seconds));
 }
+
+// --- Output inspection helpers -----------------------------------------
 
 const TrafficLightGroup * findTrafficLightGroup(const TrafficLightGroupArray & msg, lanelet::Id id)
 {
@@ -224,6 +237,8 @@ const TrafficLightElement * findTrafficLightElement(const TrafficLightGroup & gr
   return nullptr;
 }
 
+// --- Test fixture ------------------------------------------------------
+
 class ArbiterCharacteristic : public ::testing::Test
 {
 protected:
@@ -232,6 +247,16 @@ protected:
     if (!rclcpp::ok()) {
       rclcpp::init(0, nullptr);
     }
+
+    // Reserve the highest signal id so utils::getId() never returns values
+    // that collide with map_ids::* or kOffMapProbeId. Calling registerId(9999)
+    // advances the global counter to >= 10000, which is safely above every
+    // fixed signal id we use. This is process-wide global state, so doing it
+    // once per suite is enough.
+    utils::registerId(kOffMapProbeId);
+
+    // map_bin_ is immutable across tests, so build it once for the suite.
+    map_bin_ = buildMinimalMapBin();
   }
   static void TearDownTestSuite()
   {
@@ -242,25 +267,16 @@ protected:
 
   void SetUp() override
   {
-    // Reserve known signal ids so utils::getId() never returns
-    // values that collide with map_ids::* or kOffMapProbeId. Calling
-    // registerId(9999) advances the global counter to >= 10000, which is
-    // safely above every fixed signal id we use.
-    utils::registerId(kOffMapProbeId);
-
-    map_bin_ = buildMinimalMapBin();
-
-    pub_node_ = std::make_shared<rclcpp::Node>("arbiter_characteristic_test_pub");
-    sub_node_ = std::make_shared<rclcpp::Node>("arbiter_characteristic_test_sub");
+    test_node_ = std::make_shared<rclcpp::Node>("arbiter_characteristic_test");
 
     map_pub_ =
-      pub_node_->create_publisher<LaneletMapBin>(kMapTopic, rclcpp::QoS(1).transient_local());
+      test_node_->create_publisher<LaneletMapBin>(kMapTopic, rclcpp::QoS(1).transient_local());
     perception_pub_ =
-      pub_node_->create_publisher<TrafficLightGroupArray>(kPerceptionTopic, rclcpp::QoS(1));
+      test_node_->create_publisher<TrafficLightGroupArray>(kPerceptionTopic, rclcpp::QoS(1));
     external_pub_ =
-      pub_node_->create_publisher<TrafficLightGroupArray>(kExternalTopic, rclcpp::QoS(1));
+      test_node_->create_publisher<TrafficLightGroupArray>(kExternalTopic, rclcpp::QoS(1));
 
-    output_sub_ = sub_node_->create_subscription<TrafficLightGroupArray>(
+    output_sub_ = test_node_->create_subscription<TrafficLightGroupArray>(
       kOutputTopic, rclcpp::QoS(1), [this](const TrafficLightGroupArray::ConstSharedPtr msg) {
         latest_output_ = *msg;
         ++publish_count_;
@@ -278,8 +294,7 @@ protected:
     map_pub_.reset();
     perception_pub_.reset();
     external_pub_.reset();
-    sub_node_.reset();
-    pub_node_.reset();
+    test_node_.reset();
   }
 
   void startArbiter(
@@ -288,16 +303,15 @@ protected:
     arbiter_ = makeArbiter(enable_signal_matching, source_priority);
     executor_ = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
     executor_->add_node(arbiter_);
-    executor_->add_node(pub_node_);
-    executor_->add_node(sub_node_);
+    executor_->add_node(test_node_);
     // Allow discovery to settle before any publish so transient_local replay works.
     spinFor(std::chrono::milliseconds(200));
   }
 
   void publishMap()
   {
-    map_pub_->publish(map_bin_);
-    spinFor(std::chrono::milliseconds(200));
+    map_pub_->publish(*map_bin_);
+    spinFor(std::chrono::milliseconds(150));
   }
   void publishPerception(const TrafficLightGroupArray & msg)
   {
@@ -321,10 +335,12 @@ protected:
 
   rclcpp::Time arbiterNow() const { return arbiter_->now(); }
 
-  LaneletMapBin map_bin_;
+  // Wrapped in std::optional because LaneletMapBin (a generated ROS msg)
+  // has no usable default constructor that can be invoked at static storage
+  // duration; we initialise it during SetUpTestSuite().
+  inline static std::optional<LaneletMapBin> map_bin_;
 
-  rclcpp::Node::SharedPtr pub_node_;
-  rclcpp::Node::SharedPtr sub_node_;
+  rclcpp::Node::SharedPtr test_node_;
   std::shared_ptr<TrafficLightArbiter> arbiter_;
   std::shared_ptr<rclcpp::executors::SingleThreadedExecutor> executor_;
 
@@ -349,6 +365,26 @@ protected:
 // ---------------------------------------------------------------------------
 TEST_F(ArbiterCharacteristic, signalMatchingLongestPath)
 {
+  // Scenario inputs and expectations:
+  //
+  //   id                external                          perception                      expected
+  //   outcome
+  //   ----------------  --------------------------------  ------------------------------
+  //   ---------------------------- vehicle_signal_a  RED/CIRCLE/0.6 + V2I prediction RED/CIRCLE/0.7
+  //   + INTERNAL pred  match -> perception passes,
+  //                                                                                       predictions
+  //                                                                                       merged (2
+  //                                                                                       total)
+  //   vehicle_signal_b  GREEN/CIRCLE/0.8                  RED/CIRCLE/0.9                  color
+  //   mismatch -> UNKNOWN vehicle_signal_c  RED/CIRCLE/0.8                    RED/CIRCLE +
+  //   GREEN/RIGHT_ARROW  element-count mismatch ->
+  //                                                                                       UNKNOWN
+  //                                                                                       over
+  //                                                                                       shape
+  //                                                                                       union
+  //   kOffMapProbeId    RED/CIRCLE/0.9                    (none)                          dropped
+  //   (WARN+skip)
+
   // Arrange
   startArbiter(true);
   publishMap();
@@ -459,11 +495,78 @@ TEST_F(ArbiterCharacteristic, signalMatchingPedestrianFallbackUsesSourcePriority
   EXPECT_NEAR(g->elements[0].confidence, 0.1f, kConfidenceEpsilon);
 }
 
+// In Signal Matching mode, a non-pedestrian id that arrives on only one side
+// must be reported as UNKNOWN: the color/shape data is hidden, only the shape
+// mask of the present side survives. Both directions (perception-only and
+// external-only) exercise distinct branches in SignalMatchValidator.
+TEST_F(ArbiterCharacteristic, signalMatchingSingleSourceNonPedestrianYieldsUnknown)
+{
+  // Scenario inputs and expectations:
+  //
+  //   id                external           perception        expected outcome
+  //   ----------------  -----------------  ----------------  -----------------------------
+  //   vehicle_signal_a  (none)             RED/CIRCLE/0.7    perception-only -> UNKNOWN/CIRCLE
+  //   vehicle_signal_b  GREEN/CIRCLE/0.8   (none)            external-only   -> UNKNOWN/CIRCLE
+
+  // Arrange
+  startArbiter(true);
+  publishMap();
+  const auto t0 = arbiterNow();
+
+  TrafficLightGroupArray external_traffic_signal;
+  external_traffic_signal.stamp = offsetTime(t0, -0.10);
+  external_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
+    map_ids::vehicle_signal_b,
+    {makeTrafficLightElement(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.8f)}));
+
+  TrafficLightGroupArray perception_traffic_signal;
+  perception_traffic_signal.stamp = offsetTime(t0, -0.05);
+  perception_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
+    map_ids::vehicle_signal_a,
+    {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.7f)}));
+
+  // Act
+  publishExternal(external_traffic_signal);
+  publishPerception(perception_traffic_signal);
+
+  // Assert
+  {
+    const auto * group = findTrafficLightGroup(latest_output_, map_ids::vehicle_signal_a);
+    ASSERT_NE(group, nullptr);
+    ASSERT_EQ(group->elements.size(), 1u);
+    EXPECT_EQ(group->elements[0].color, TrafficLightElement::UNKNOWN);
+    EXPECT_EQ(group->elements[0].shape, TrafficLightElement::CIRCLE);
+  }
+  {
+    const auto * group = findTrafficLightGroup(latest_output_, map_ids::vehicle_signal_b);
+    ASSERT_NE(group, nullptr);
+    ASSERT_EQ(group->elements.size(), 1u);
+    EXPECT_EQ(group->elements[0].color, TrafficLightElement::UNKNOWN);
+    EXPECT_EQ(group->elements[0].shape, TrafficLightElement::CIRCLE);
+  }
+}
+
 // ---------------------------------------------------------------------------
 // B. Longest path - Priority-based mode (enable_signal_matching=false).
 // ---------------------------------------------------------------------------
 TEST_F(ArbiterCharacteristic, priorityBasedConfidenceLongestPath)
 {
+  // Scenario inputs and expectations:
+  //   - Publish order: stale external (-4.0s) -> recent external (-0.5s) -> perception (-0.2s).
+  //   - The stale external entry must be cleaned up before arbitration runs.
+  //
+  //   id                recent external                     perception              expected
+  //   outcome
+  //   ----------------  ----------------------------------  ---------------------
+  //   --------------------------- vehicle_signal_a  GREEN/CIRCLE/0.7 GREEN/CIRCLE/0.9 CONFIDENCE
+  //   picks perception
+  //                                                                                 (0.9 > 0.7)
+  //   vehicle_signal_b  RED/CIRCLE/0.5 + GREEN/RIGHT_ARROW  (none)                  external only,
+  //   both shapes
+  //                                                                                 pass through
+  //   vehicle_signal_c  (none)                              GREEN/CIRCLE/0.8        perception
+  //   only, passes kOffMapProbeId    RED/CIRCLE/0.9                      (none) dropped (WARN+skip)
+
   // Arrange
   startArbiter();
   publishMap();
@@ -581,6 +684,41 @@ TEST_F(ArbiterCharacteristic, priorityFlagOverridesHigherConfidence)
   ASSERT_NE(g, nullptr);
   ASSERT_EQ(g->elements.size(), 1u);
   EXPECT_EQ(g->elements[0].color, TrafficLightElement::GREEN);
+  EXPECT_NEAR(g->elements[0].confidence, 0.10f, kConfidenceEpsilon);
+}
+
+// Symmetric counterpart of priorityFlagOverridesHigherConfidence: with
+// source_priority=external, the external value wins over a higher-confidence
+// perception value. This pins the EXTERNAL branch in arbitrateAndPublish
+// ([traffic_light_arbiter.cpp]: source_priority_ == EXTERNAL).
+TEST_F(ArbiterCharacteristic, priorityFlagFromExternalOverridesHigherConfidence)
+{
+  // Arrange
+  startArbiter(false, "external");
+  publishMap();
+  const auto t0 = arbiterNow();
+
+  TrafficLightGroupArray external_traffic_signal;
+  external_traffic_signal.stamp = offsetTime(t0, -0.10);
+  external_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
+    map_ids::vehicle_signal_a,
+    {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.10f)}));
+
+  TrafficLightGroupArray perception_traffic_signal;
+  perception_traffic_signal.stamp = offsetTime(t0, -0.05);
+  perception_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
+    map_ids::vehicle_signal_a,
+    {makeTrafficLightElement(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.99f)}));
+
+  // Act
+  publishExternal(external_traffic_signal);
+  publishPerception(perception_traffic_signal);
+
+  // Assert
+  const auto * g = findTrafficLightGroup(latest_output_, map_ids::vehicle_signal_a);
+  ASSERT_NE(g, nullptr);
+  ASSERT_EQ(g->elements.size(), 1u);
+  EXPECT_EQ(g->elements[0].color, TrafficLightElement::RED);
   EXPECT_NEAR(g->elements[0].confidence, 0.10f, kConfidenceEpsilon);
 }
 

--- a/perception/autoware_traffic_light_arbiter/test/test_traffic_arbiter_characteristic.cpp
+++ b/perception/autoware_traffic_light_arbiter/test/test_traffic_arbiter_characteristic.cpp
@@ -50,13 +50,6 @@ using PredictedTrafficLightState = autoware_perception_msgs::msg::PredictedTraff
 using namespace lanelet;  // NOLINT(build/namespaces)
 using utils::getId;
 
-constexpr const char * kMapTopic = "/traffic_light_arbiter/sub/vector_map";
-constexpr const char * kPerceptionTopic = "/traffic_light_arbiter/sub/perception_traffic_signals";
-constexpr const char * kExternalTopic = "/traffic_light_arbiter/sub/external_traffic_signals";
-constexpr const char * kOutputTopic = "/traffic_light_arbiter/pub/traffic_signals";
-
-constexpr float kConfidenceEpsilon = 1e-5f;
-
 // --- Signal IDs --------------------------------------------------------
 
 // Traffic-light regulatory-element IDs that are installed on the test map.
@@ -141,6 +134,18 @@ LaneletMapBin buildMinimalMapBin()
 
   const LaneletMapConstPtr map{
     utils::createMap(Lanelets{road1, road2, road3, crosswalk}).release()};
+  auto bin = ::autoware::experimental::lanelet2_utils::to_autoware_map_msgs(map);
+  bin.header.frame_id = "base_link";
+  return bin;
+}
+
+// Variant of buildMinimalMapBin with a single road lanelet but no Traffic
+// Light regulatory elements. Used to drive the
+// "map_regulatory_elements_set_->empty()" branch in arbitrateAndPublish.
+LaneletMapBin buildEmptyMapBin()
+{
+  Lanelet road = makeLanelet(0.0, -3.0, AttributeValueString::Road);
+  const LaneletMapConstPtr map{utils::createMap(Lanelets{road}).release()};
   auto bin = ::autoware::experimental::lanelet2_utils::to_autoware_map_msgs(map);
   bin.header.frame_id = "base_link";
   return bin;
@@ -276,10 +281,10 @@ protected:
     external_pub_ =
       test_node_->create_publisher<TrafficLightGroupArray>(kExternalTopic, rclcpp::QoS(1));
 
-    output_sub_ = test_node_->create_subscription<TrafficLightGroupArray>(
+    arbitrated_traffic_signal_sub_ = test_node_->create_subscription<TrafficLightGroupArray>(
       kOutputTopic, rclcpp::QoS(1), [this](const TrafficLightGroupArray::ConstSharedPtr msg) {
-        latest_output_ = *msg;
-        ++publish_count_;
+        latest_arbitrated_traffic_signal_ = *msg;
+        ++arbiter_publish_count_;
       });
   }
 
@@ -290,7 +295,7 @@ protected:
     }
     executor_.reset();
     arbiter_.reset();
-    output_sub_.reset();
+    arbitrated_traffic_signal_sub_.reset();
     map_pub_.reset();
     perception_pub_.reset();
     external_pub_.reset();
@@ -347,10 +352,25 @@ protected:
   rclcpp::Publisher<LaneletMapBin>::SharedPtr map_pub_;
   rclcpp::Publisher<TrafficLightGroupArray>::SharedPtr perception_pub_;
   rclcpp::Publisher<TrafficLightGroupArray>::SharedPtr external_pub_;
-  rclcpp::Subscription<TrafficLightGroupArray>::SharedPtr output_sub_;
+  rclcpp::Subscription<TrafficLightGroupArray>::SharedPtr arbitrated_traffic_signal_sub_;
 
-  TrafficLightGroupArray latest_output_;
-  std::size_t publish_count_ = 0;
+  TrafficLightGroupArray latest_arbitrated_traffic_signal_;
+  std::size_t arbiter_publish_count_ = 0;
+
+private:
+  // Topic names used by the publishers/subscription owned by the fixture.
+  static constexpr const char * kMapTopic = "/traffic_light_arbiter/sub/vector_map";
+  static constexpr const char * kPerceptionTopic =
+    "/traffic_light_arbiter/sub/perception_traffic_signals";
+  static constexpr const char * kExternalTopic =
+    "/traffic_light_arbiter/sub/external_traffic_signals";
+  static constexpr const char * kOutputTopic = "/traffic_light_arbiter/pub/traffic_signals";
+
+protected:
+  // Tolerance used by TEST_F bodies when comparing confidence values via
+  // EXPECT_NEAR. Kept inside the fixture because it is only meaningful for
+  // tests that derive from this class.
+  static constexpr float kConfidenceEpsilon = 1e-5f;
 };
 
 // ---------------------------------------------------------------------------
@@ -367,23 +387,25 @@ TEST_F(ArbiterCharacteristic, signalMatchingLongestPath)
 {
   // Scenario inputs and expectations:
   //
-  //   id                external                          perception                      expected
-  //   outcome
-  //   ----------------  --------------------------------  ------------------------------
-  //   ---------------------------- vehicle_signal_a  RED/CIRCLE/0.6 + V2I prediction RED/CIRCLE/0.7
-  //   + INTERNAL pred  match -> perception passes,
-  //                                                                                       predictions
-  //                                                                                       merged (2
-  //                                                                                       total)
-  //   vehicle_signal_b  GREEN/CIRCLE/0.8                  RED/CIRCLE/0.9                  color
-  //   mismatch -> UNKNOWN vehicle_signal_c  RED/CIRCLE/0.8                    RED/CIRCLE +
-  //   GREEN/RIGHT_ARROW  element-count mismatch ->
-  //                                                                                       UNKNOWN
-  //                                                                                       over
-  //                                                                                       shape
-  //                                                                                       union
-  //   kOffMapProbeId    RED/CIRCLE/0.9                    (none)                          dropped
-  //   (WARN+skip)
+  // vehicle_signal_a:
+  //   external:   RED/CIRCLE/0.6 + V2I prediction
+  //   perception: RED/CIRCLE/0.7 + INTERNAL prediction
+  //   expected:   matched -> perception passes through; both predictions merged (2 total)
+  //
+  // vehicle_signal_b:
+  //   external:   GREEN/CIRCLE/0.8
+  //   perception: RED/CIRCLE/0.9
+  //   expected:   color mismatch -> UNKNOWN
+  //
+  // vehicle_signal_c:
+  //   external:   RED/CIRCLE/0.8
+  //   perception: RED/CIRCLE/0.8 + GREEN/RIGHT_ARROW/0.6
+  //   expected:   element-count mismatch -> UNKNOWN over shape union
+  //
+  // kOffMapProbeId:
+  //   external:   RED/CIRCLE/0.9
+  //   perception: (none)
+  //   expected:   dropped (WARN+skip)
 
   // Arrange
   startArbiter(true);
@@ -429,12 +451,13 @@ TEST_F(ArbiterCharacteristic, signalMatchingLongestPath)
   publishPerception(perception_traffic_signal);
 
   // Assert
-  ASSERT_GE(publish_count_, 1u);
-  EXPECT_EQ(findTrafficLightGroup(latest_output_, kOffMapProbeId), nullptr);
+  ASSERT_GE(arbiter_publish_count_, 1u);
+  EXPECT_EQ(findTrafficLightGroup(latest_arbitrated_traffic_signal_, kOffMapProbeId), nullptr);
 
   // matching id: perception passes through unchanged, predictions merged from both sources.
   {
-    const auto * g = findTrafficLightGroup(latest_output_, map_ids::vehicle_signal_a);
+    const auto * g =
+      findTrafficLightGroup(latest_arbitrated_traffic_signal_, map_ids::vehicle_signal_a);
     ASSERT_NE(g, nullptr);
     ASSERT_EQ(g->elements.size(), 1u);
     EXPECT_EQ(g->elements[0].color, TrafficLightElement::RED);
@@ -443,7 +466,8 @@ TEST_F(ArbiterCharacteristic, signalMatchingLongestPath)
   }
   // color mismatch -> UNKNOWN over the single shared shape
   {
-    const auto * g = findTrafficLightGroup(latest_output_, map_ids::vehicle_signal_b);
+    const auto * g =
+      findTrafficLightGroup(latest_arbitrated_traffic_signal_, map_ids::vehicle_signal_b);
     ASSERT_NE(g, nullptr);
     ASSERT_EQ(g->elements.size(), 1u);
     EXPECT_EQ(g->elements[0].color, TrafficLightElement::UNKNOWN);
@@ -451,7 +475,8 @@ TEST_F(ArbiterCharacteristic, signalMatchingLongestPath)
   }
   // element-count mismatch -> UNKNOWN over union of shapes
   {
-    const auto * g = findTrafficLightGroup(latest_output_, map_ids::vehicle_signal_c);
+    const auto * g =
+      findTrafficLightGroup(latest_arbitrated_traffic_signal_, map_ids::vehicle_signal_c);
     ASSERT_NE(g, nullptr);
     ASSERT_EQ(g->elements.size(), 2u);
     EXPECT_NE(findTrafficLightElement(*g, TrafficLightElement::CIRCLE), nullptr);
@@ -488,11 +513,113 @@ TEST_F(ArbiterCharacteristic, signalMatchingPedestrianFallbackUsesSourcePriority
   publishPerception(perception_traffic_signal);
 
   // Assert
-  const auto * g = findTrafficLightGroup(latest_output_, map_ids::pedestrian_signal);
+  const auto * g =
+    findTrafficLightGroup(latest_arbitrated_traffic_signal_, map_ids::pedestrian_signal);
   ASSERT_NE(g, nullptr);
   ASSERT_EQ(g->elements.size(), 1u);
   EXPECT_EQ(g->elements[0].color, TrafficLightElement::RED);
   EXPECT_NEAR(g->elements[0].confidence, 0.1f, kConfidenceEpsilon);
+}
+
+// Symmetric counterpart of the external-priority pedestrian test: with
+// source_priority=perception, the perception value wins even at lower
+// confidence. Pins the PERCEPTION case of get_highest_confidence_signal
+// inside SignalMatchValidator's pedestrian branch.
+TEST_F(ArbiterCharacteristic, signalMatchingPedestrianPerceptionPriority)
+{
+  // Arrange
+  startArbiter(true, "perception");
+  publishMap();
+  const auto t0 = arbiterNow();
+
+  TrafficLightGroupArray external_traffic_signal;
+  external_traffic_signal.stamp = offsetTime(t0, -0.10);
+  external_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
+    map_ids::pedestrian_signal,
+    {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.99f)}));
+
+  TrafficLightGroupArray perception_traffic_signal;
+  perception_traffic_signal.stamp = offsetTime(t0, -0.05);
+  perception_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
+    map_ids::pedestrian_signal,
+    {makeTrafficLightElement(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.10f)}));
+
+  // Act
+  publishExternal(external_traffic_signal);
+  publishPerception(perception_traffic_signal);
+
+  // Assert: perception priority wins despite lower confidence
+  const auto * g =
+    findTrafficLightGroup(latest_arbitrated_traffic_signal_, map_ids::pedestrian_signal);
+  ASSERT_NE(g, nullptr);
+  ASSERT_EQ(g->elements.size(), 1u);
+  EXPECT_EQ(g->elements[0].color, TrafficLightElement::GREEN);
+  EXPECT_NEAR(g->elements[0].confidence, 0.10f, kConfidenceEpsilon);
+}
+
+// Pedestrian + CONFIDENCE: get_highest_confidence_signal walks each shape and
+// picks the element with higher confidence. Bypasses the
+// color/shape-equivalence check that non-pedestrian ids must pass.
+TEST_F(ArbiterCharacteristic, signalMatchingPedestrianConfidenceMode)
+{
+  // Arrange
+  startArbiter(true, "confidence");
+  publishMap();
+  const auto t0 = arbiterNow();
+
+  TrafficLightGroupArray external_traffic_signal;
+  external_traffic_signal.stamp = offsetTime(t0, -0.10);
+  external_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
+    map_ids::pedestrian_signal,
+    {makeTrafficLightElement(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.6f)}));
+
+  TrafficLightGroupArray perception_traffic_signal;
+  perception_traffic_signal.stamp = offsetTime(t0, -0.05);
+  perception_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
+    map_ids::pedestrian_signal,
+    {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.9f)}));
+
+  // Act
+  publishExternal(external_traffic_signal);
+  publishPerception(perception_traffic_signal);
+
+  // Assert: CONFIDENCE picks the higher-confidence element (perception 0.9)
+  const auto * g =
+    findTrafficLightGroup(latest_arbitrated_traffic_signal_, map_ids::pedestrian_signal);
+  ASSERT_NE(g, nullptr);
+  ASSERT_EQ(g->elements.size(), 1u);
+  EXPECT_EQ(g->elements[0].color, TrafficLightElement::RED);
+  EXPECT_NEAR(g->elements[0].confidence, 0.9f, kConfidenceEpsilon);
+}
+
+// Pedestrian id with a single source: get_highest_confidence_signal early-
+// returns the present side and skips the source_priority switch entirely.
+// In contrast to non-pedestrian ids (which become UNKNOWN), the pedestrian's
+// color/shape passes through unchanged.
+TEST_F(ArbiterCharacteristic, signalMatchingPedestrianSingleSourcePasses)
+{
+  // Arrange: external_priority is set to demonstrate that absent-side handling
+  // happens BEFORE the priority switch is consulted.
+  startArbiter(true, "external");
+  publishMap();
+  const auto t0 = arbiterNow();
+
+  TrafficLightGroupArray perception_traffic_signal;
+  perception_traffic_signal.stamp = offsetTime(t0, -0.05);
+  perception_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
+    map_ids::pedestrian_signal,
+    {makeTrafficLightElement(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.7f)}));
+
+  // Act (no external publish)
+  publishPerception(perception_traffic_signal);
+
+  // Assert: perception passes through unchanged (no UNKNOWN translation)
+  const auto * g =
+    findTrafficLightGroup(latest_arbitrated_traffic_signal_, map_ids::pedestrian_signal);
+  ASSERT_NE(g, nullptr);
+  ASSERT_EQ(g->elements.size(), 1u);
+  EXPECT_EQ(g->elements[0].color, TrafficLightElement::GREEN);
+  EXPECT_NEAR(g->elements[0].confidence, 0.7f, kConfidenceEpsilon);
 }
 
 // In Signal Matching mode, a non-pedestrian id that arrives on only one side
@@ -531,14 +658,16 @@ TEST_F(ArbiterCharacteristic, signalMatchingSingleSourceNonPedestrianYieldsUnkno
 
   // Assert
   {
-    const auto * group = findTrafficLightGroup(latest_output_, map_ids::vehicle_signal_a);
+    const auto * group =
+      findTrafficLightGroup(latest_arbitrated_traffic_signal_, map_ids::vehicle_signal_a);
     ASSERT_NE(group, nullptr);
     ASSERT_EQ(group->elements.size(), 1u);
     EXPECT_EQ(group->elements[0].color, TrafficLightElement::UNKNOWN);
     EXPECT_EQ(group->elements[0].shape, TrafficLightElement::CIRCLE);
   }
   {
-    const auto * group = findTrafficLightGroup(latest_output_, map_ids::vehicle_signal_b);
+    const auto * group =
+      findTrafficLightGroup(latest_arbitrated_traffic_signal_, map_ids::vehicle_signal_b);
     ASSERT_NE(group, nullptr);
     ASSERT_EQ(group->elements.size(), 1u);
     EXPECT_EQ(group->elements[0].color, TrafficLightElement::UNKNOWN);
@@ -555,17 +684,25 @@ TEST_F(ArbiterCharacteristic, priorityBasedConfidenceLongestPath)
   //   - Publish order: stale external (-4.0s) -> recent external (-0.5s) -> perception (-0.2s).
   //   - The stale external entry must be cleaned up before arbitration runs.
   //
-  //   id                recent external                     perception              expected
-  //   outcome
-  //   ----------------  ----------------------------------  ---------------------
-  //   --------------------------- vehicle_signal_a  GREEN/CIRCLE/0.7 GREEN/CIRCLE/0.9 CONFIDENCE
-  //   picks perception
-  //                                                                                 (0.9 > 0.7)
-  //   vehicle_signal_b  RED/CIRCLE/0.5 + GREEN/RIGHT_ARROW  (none)                  external only,
-  //   both shapes
-  //                                                                                 pass through
-  //   vehicle_signal_c  (none)                              GREEN/CIRCLE/0.8        perception
-  //   only, passes kOffMapProbeId    RED/CIRCLE/0.9                      (none) dropped (WARN+skip)
+  // vehicle_signal_a:
+  //   recent external: GREEN/CIRCLE/0.7
+  //   perception:      GREEN/CIRCLE/0.9
+  //   expected:        CONFIDENCE picks perception (0.9 > 0.7)
+  //
+  // vehicle_signal_b:
+  //   recent external: RED/CIRCLE/0.5 + GREEN/RIGHT_ARROW
+  //   perception:      (none)
+  //   expected:        external only, both shapes pass through
+  //
+  // vehicle_signal_c:
+  //   recent external: (none)
+  //   perception:      GREEN/CIRCLE/0.8
+  //   expected:        perception only, passes
+  //
+  // kOffMapProbeId:
+  //   recent external: RED/CIRCLE/0.9
+  //   perception:      (none)
+  //   expected:        dropped (WARN+skip)
 
   // Arrange
   startArbiter();
@@ -606,10 +743,11 @@ TEST_F(ArbiterCharacteristic, priorityBasedConfidenceLongestPath)
   publishPerception(perception_traffic_signal);
 
   // Assert
-  EXPECT_EQ(findTrafficLightGroup(latest_output_, kOffMapProbeId), nullptr);
+  EXPECT_EQ(findTrafficLightGroup(latest_arbitrated_traffic_signal_, kOffMapProbeId), nullptr);
   // Both sources agree on shape; CONFIDENCE picks perception (0.9 > 0.7).
   {
-    const auto * g = findTrafficLightGroup(latest_output_, map_ids::vehicle_signal_a);
+    const auto * g =
+      findTrafficLightGroup(latest_arbitrated_traffic_signal_, map_ids::vehicle_signal_a);
     ASSERT_NE(g, nullptr);
     ASSERT_EQ(g->elements.size(), 1u);
     EXPECT_EQ(g->elements[0].color, TrafficLightElement::GREEN);
@@ -617,7 +755,8 @@ TEST_F(ArbiterCharacteristic, priorityBasedConfidenceLongestPath)
   }
   // External contributes two shapes alone; both survive shape-wise selection.
   {
-    const auto * g = findTrafficLightGroup(latest_output_, map_ids::vehicle_signal_b);
+    const auto * g =
+      findTrafficLightGroup(latest_arbitrated_traffic_signal_, map_ids::vehicle_signal_b);
     ASSERT_NE(g, nullptr);
     ASSERT_EQ(g->elements.size(), 2u);
     EXPECT_NE(findTrafficLightElement(*g, TrafficLightElement::CIRCLE), nullptr);
@@ -625,7 +764,8 @@ TEST_F(ArbiterCharacteristic, priorityBasedConfidenceLongestPath)
   }
   // Perception-only id flows through unmodified.
   {
-    const auto * g = findTrafficLightGroup(latest_output_, map_ids::vehicle_signal_c);
+    const auto * g =
+      findTrafficLightGroup(latest_arbitrated_traffic_signal_, map_ids::vehicle_signal_c);
     ASSERT_NE(g, nullptr);
     ASSERT_EQ(g->elements.size(), 1u);
     EXPECT_EQ(g->elements[0].color, TrafficLightElement::GREEN);
@@ -652,8 +792,33 @@ TEST_F(ArbiterCharacteristic, perceptionBeforeMapProducesNoOutput)
   publishPerception(perception_traffic_signal);
 
   // Assert
-  EXPECT_EQ(publish_count_, 0u)
+  EXPECT_EQ(arbiter_publish_count_, 0u)
     << "arbitrateAndPublish should early-return when no map has been received";
+}
+
+// A non-null but signal-free map should yield an empty TrafficLightGroupArray
+// (stamp set, no groups). Exercises the
+// "map_regulatory_elements_set_->empty()" branch in arbitrateAndPublish.
+TEST_F(ArbiterCharacteristic, emptyMapProducesEmptyOutput)
+{
+  // Arrange: replace the default minimal map with a signal-free one.
+  startArbiter();
+  const auto empty_map_bin = buildEmptyMapBin();
+  map_pub_->publish(empty_map_bin);
+  spinFor(std::chrono::milliseconds(150));
+
+  TrafficLightGroupArray perception_traffic_signal;
+  perception_traffic_signal.stamp = arbiterNow();
+  perception_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
+    map_ids::vehicle_signal_a,
+    {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.9f)}));
+
+  // Act
+  publishPerception(perception_traffic_signal);
+
+  // Assert: arbiter publishes, but the output contains no groups.
+  ASSERT_GE(arbiter_publish_count_, 1u);
+  EXPECT_EQ(latest_arbitrated_traffic_signal_.traffic_light_groups.size(), 0u);
 }
 
 TEST_F(ArbiterCharacteristic, priorityFlagOverridesHigherConfidence)
@@ -680,7 +845,8 @@ TEST_F(ArbiterCharacteristic, priorityFlagOverridesHigherConfidence)
   publishPerception(perception_traffic_signal);
 
   // Assert
-  const auto * g = findTrafficLightGroup(latest_output_, map_ids::vehicle_signal_a);
+  const auto * g =
+    findTrafficLightGroup(latest_arbitrated_traffic_signal_, map_ids::vehicle_signal_a);
   ASSERT_NE(g, nullptr);
   ASSERT_EQ(g->elements.size(), 1u);
   EXPECT_EQ(g->elements[0].color, TrafficLightElement::GREEN);
@@ -715,7 +881,8 @@ TEST_F(ArbiterCharacteristic, priorityFlagFromExternalOverridesHigherConfidence)
   publishPerception(perception_traffic_signal);
 
   // Assert
-  const auto * g = findTrafficLightGroup(latest_output_, map_ids::vehicle_signal_a);
+  const auto * g =
+    findTrafficLightGroup(latest_arbitrated_traffic_signal_, map_ids::vehicle_signal_a);
   ASSERT_NE(g, nullptr);
   ASSERT_EQ(g->elements.size(), 1u);
   EXPECT_EQ(g->elements[0].color, TrafficLightElement::RED);
@@ -734,7 +901,7 @@ TEST_F(ArbiterCharacteristic, externalDelayToleranceDropsStaleMessage)
     map_ids::vehicle_signal_a,
     {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.8f)}));
   publishPerception(perception_traffic_signal);
-  const auto baseline_count = publish_count_;
+  const auto baseline_count = arbiter_publish_count_;
   ASSERT_GE(baseline_count, 1u);
 
   // external_delay_tolerance defaults to 5.0s; 20s in the past is well past it.
@@ -748,9 +915,10 @@ TEST_F(ArbiterCharacteristic, externalDelayToleranceDropsStaleMessage)
   publishExternal(stale_external_traffic_signal);
 
   // Assert
-  EXPECT_EQ(publish_count_, baseline_count)
+  EXPECT_EQ(arbiter_publish_count_, baseline_count)
     << "Stale external message must be dropped before arbitrateAndPublish runs";
-  const auto * g = findTrafficLightGroup(latest_output_, map_ids::vehicle_signal_a);
+  const auto * g =
+    findTrafficLightGroup(latest_arbitrated_traffic_signal_, map_ids::vehicle_signal_a);
   ASSERT_NE(g, nullptr);
   EXPECT_EQ(g->elements[0].color, TrafficLightElement::RED)
     << "Last publish must reflect perception";
@@ -780,7 +948,8 @@ TEST_F(ArbiterCharacteristic, signalMatchingIgnoresConfidenceInEquivalence)
   publishPerception(perception_traffic_signal);
 
   // Assert
-  const auto * g = findTrafficLightGroup(latest_output_, map_ids::vehicle_signal_a);
+  const auto * g =
+    findTrafficLightGroup(latest_arbitrated_traffic_signal_, map_ids::vehicle_signal_a);
   ASSERT_NE(g, nullptr);
   ASSERT_EQ(g->elements.size(), 1u);
   EXPECT_EQ(g->elements[0].color, TrafficLightElement::RED);
@@ -812,11 +981,50 @@ TEST_F(ArbiterCharacteristic, externalTimeToleranceCleanupOnPerception)
   publishPerception(perception_traffic_signal);
 
   // Assert
-  const auto * g = findTrafficLightGroup(latest_output_, map_ids::vehicle_signal_a);
+  const auto * g =
+    findTrafficLightGroup(latest_arbitrated_traffic_signal_, map_ids::vehicle_signal_a);
   ASSERT_NE(g, nullptr);
   ASSERT_EQ(g->elements.size(), 1u);
   EXPECT_EQ(g->elements[0].color, TrafficLightElement::GREEN);
   EXPECT_NEAR(g->elements[0].confidence, 0.7f, kConfidenceEpsilon);
+}
+
+// onExternalMsg compares its own stamp to latest_perception_msg_.stamp; if
+// the gap exceeds perception_time_tolerance (default 1.0s) it clears the
+// stored perception groups so the upcoming publish reflects only external.
+TEST_F(ArbiterCharacteristic, perceptionTimeToleranceClearsLatestPerception)
+{
+  // Arrange
+  startArbiter();
+  publishMap();
+  const auto t0 = arbiterNow();
+
+  // Seed a perception value at t0.
+  TrafficLightGroupArray perception_traffic_signal;
+  perception_traffic_signal.stamp = t0;
+  perception_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
+    map_ids::vehicle_signal_a,
+    {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.9f)}));
+  publishPerception(perception_traffic_signal);
+
+  // External arrives 2.0s after perception (> perception_time_tolerance=1.0,
+  // < external_delay_tolerance=5.0 so it is itself accepted).
+  TrafficLightGroupArray external_traffic_signal;
+  external_traffic_signal.stamp = offsetTime(t0, 2.0);
+  external_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
+    map_ids::vehicle_signal_a,
+    {makeTrafficLightElement(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.5f)}));
+
+  // Act
+  publishExternal(external_traffic_signal);
+
+  // Assert: stale perception was wiped, output reflects only external.
+  const auto * g =
+    findTrafficLightGroup(latest_arbitrated_traffic_signal_, map_ids::vehicle_signal_a);
+  ASSERT_NE(g, nullptr);
+  ASSERT_EQ(g->elements.size(), 1u);
+  EXPECT_EQ(g->elements[0].color, TrafficLightElement::GREEN);
+  EXPECT_NEAR(g->elements[0].confidence, 0.5f, kConfidenceEpsilon);
 }
 
 TEST_F(ArbiterCharacteristic, predictionsFromSingleSidePropagate)
@@ -839,7 +1047,8 @@ TEST_F(ArbiterCharacteristic, predictionsFromSingleSidePropagate)
   publishPerception(perception_traffic_signal);
 
   // Assert
-  const auto * g = findTrafficLightGroup(latest_output_, map_ids::vehicle_signal_a);
+  const auto * g =
+    findTrafficLightGroup(latest_arbitrated_traffic_signal_, map_ids::vehicle_signal_a);
   ASSERT_NE(g, nullptr);
   ASSERT_EQ(g->predictions.size(), 1u);
   EXPECT_EQ(

--- a/perception/autoware_traffic_light_arbiter/test/test_traffic_arbiter_characteristic.cpp
+++ b/perception/autoware_traffic_light_arbiter/test/test_traffic_arbiter_characteristic.cpp
@@ -1,0 +1,712 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/traffic_light_arbiter/traffic_light_arbiter.hpp"
+
+#include <autoware/lanelet2_utils/conversion.hpp>
+#include <rclcpp/executors/single_threaded_executor.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+#include <autoware_map_msgs/msg/lanelet_map_bin.hpp>
+#include <autoware_perception_msgs/msg/traffic_light_group_array.hpp>
+
+#include <gtest/gtest.h>
+#include <lanelet2_core/Attribute.h>
+#include <lanelet2_core/LaneletMap.h>
+#include <lanelet2_core/primitives/BasicRegulatoryElements.h>
+#include <lanelet2_core/primitives/Lanelet.h>
+#include <lanelet2_core/primitives/LineString.h>
+#include <lanelet2_core/primitives/LineStringOrPolygon.h>
+#include <lanelet2_core/primitives/Point.h>
+
+#include <chrono>
+#include <memory>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
+
+namespace
+{
+
+using autoware::traffic_light::TrafficLightArbiter;
+using LaneletMapBin = autoware_map_msgs::msg::LaneletMapBin;
+using TrafficLightGroupArray = autoware_perception_msgs::msg::TrafficLightGroupArray;
+using TrafficLightGroup = autoware_perception_msgs::msg::TrafficLightGroup;
+using TrafficLightElement = autoware_perception_msgs::msg::TrafficLightElement;
+using PredictedTrafficLightState = autoware_perception_msgs::msg::PredictedTrafficLightState;
+using namespace lanelet;  // NOLINT(build/namespaces)
+using utils::getId;
+
+constexpr const char * kMapTopic = "/traffic_light_arbiter/sub/vector_map";
+constexpr const char * kPerceptionTopic = "/traffic_light_arbiter/sub/perception_traffic_signals";
+constexpr const char * kExternalTopic = "/traffic_light_arbiter/sub/external_traffic_signals";
+constexpr const char * kOutputTopic = "/traffic_light_arbiter/pub/traffic_signals";
+
+constexpr float kConfidenceEpsilon = 1e-5f;
+
+// Traffic-light regulatory-element IDs that are installed on the test map.
+// Kept explicit (rather than auto-allocated) so that values appearing in
+// published TrafficLightGroupArray messages and warning logs stay readable.
+namespace map_ids
+{
+constexpr lanelet::Id vehicle_signal_a = 1001;
+constexpr lanelet::Id vehicle_signal_b = 1002;
+constexpr lanelet::Id vehicle_signal_c = 1003;
+constexpr lanelet::Id pedestrian_signal = 2001;
+}  // namespace map_ids
+
+// Intentionally not installed on the map; used by tests as the "off-map id"
+// probe to exercise the WARN+skip branch in arbitrateAndPublish.
+constexpr lanelet::Id kOffMapProbeId = 9999;
+
+Point3d makePoint(lanelet::Id id, double x, double y, double z = 0.0)
+{
+  return Point3d(id, x, y, z);
+}
+
+Lanelet makeLanelet(double y_left, double y_right, const std::string & subtype)
+{
+  LineString3d left(getId(), {makePoint(getId(), 0.0, y_left), makePoint(getId(), 10.0, y_left)});
+  LineString3d right(
+    getId(), {makePoint(getId(), 0.0, y_right), makePoint(getId(), 10.0, y_right)});
+  Lanelet new_lanelet(getId(), left, right);
+  new_lanelet.attributes()[AttributeName::Subtype] = subtype;
+  new_lanelet.attributes()[AttributeName::Type] = AttributeValueString::Lanelet;
+  return new_lanelet;
+}
+
+LineString3d makeTrafficLightBulb()
+{
+  // The exact position does not affect arbiter logic; we pick the lanelet
+  // midpoint (x = 5.0 within the 0..10 span) at z = 5.0 above the ground.
+  constexpr double kBulbX = 5.0;
+  constexpr double kBulbZ = 5.0;
+  LineString3d bulb(
+    getId(), {makePoint(getId(), kBulbX, 0.0, kBulbZ), makePoint(getId(), kBulbX, 1.0, kBulbZ)});
+  bulb.attributes()[AttributeName::Type] = AttributeValueString::TrafficLight;
+  return bulb;
+}
+
+// Builds the minimal map required to drive every code path under test:
+// three road lanelets each carrying one Traffic Light, plus one crosswalk
+// lanelet carrying the pedestrian Traffic Light.
+//
+// Test map summary (top-down view).
+// Each lanelet spans x = 0..10 along the travel direction; +y is the left side.
+//
+//   left bound  right bound   Lanelet      Traffic Light id
+//   ----------  -----------   ----------   --------------------------
+//        12          11       crosswalk    2001 (pedestrian_signal)
+//         8           5       road3        1003 (vehicle_signal_c)
+//         4           1       road2        1002 (vehicle_signal_b)
+//         0          -3       road1        1001 (vehicle_signal_a)
+//
+// Probe id intentionally absent from the map: 9999 (kOffMapProbeId)
+LaneletMapBin buildMinimalMapBin()
+{
+  Lanelet road1 = makeLanelet(0.0, -3.0, AttributeValueString::Road);
+  Lanelet road2 = makeLanelet(4.0, 1.0, AttributeValueString::Road);
+  Lanelet road3 = makeLanelet(8.0, 5.0, AttributeValueString::Road);
+  Lanelet crosswalk = makeLanelet(12.0, 11.0, AttributeValueString::Crosswalk);
+
+  road1.addRegulatoryElement(
+    TrafficLight::make(
+      map_ids::vehicle_signal_a, {}, LineStringsOrPolygons3d{makeTrafficLightBulb()}));
+  road2.addRegulatoryElement(
+    TrafficLight::make(
+      map_ids::vehicle_signal_b, {}, LineStringsOrPolygons3d{makeTrafficLightBulb()}));
+  road3.addRegulatoryElement(
+    TrafficLight::make(
+      map_ids::vehicle_signal_c, {}, LineStringsOrPolygons3d{makeTrafficLightBulb()}));
+  crosswalk.addRegulatoryElement(
+    TrafficLight::make(
+      map_ids::pedestrian_signal, {}, LineStringsOrPolygons3d{makeTrafficLightBulb()}));
+
+  const LaneletMapConstPtr map{
+    utils::createMap(Lanelets{road1, road2, road3, crosswalk}).release()};
+  auto bin = ::autoware::experimental::lanelet2_utils::to_autoware_map_msgs(map);
+  bin.header.frame_id = "base_link";
+  return bin;
+}
+
+// Default parameters mirror config/traffic_light_arbiter.param.yaml. We
+// re-declare them here instead of reading the YAML so the test is fully
+// self-contained and unaffected by production config changes. Only the
+// two parameters that any test actually toggles are exposed as arguments.
+std::shared_ptr<TrafficLightArbiter> makeArbiter(
+  bool enable_signal_matching = false, const std::string & source_priority = "confidence")
+{
+  rclcpp::NodeOptions options;
+  options.parameter_overrides({
+    rclcpp::Parameter("external_delay_tolerance", 5.0),
+    rclcpp::Parameter("external_time_tolerance", 5.0),
+    rclcpp::Parameter("perception_time_tolerance", 1.0),
+    rclcpp::Parameter("source_priority", source_priority),
+    rclcpp::Parameter("enable_signal_matching", enable_signal_matching),
+  });
+  return std::make_shared<TrafficLightArbiter>(options);
+}
+
+TrafficLightElement makeTrafficLightElement(uint8_t color, uint8_t shape, float confidence)
+{
+  TrafficLightElement element;
+  element.color = color;
+  element.shape = shape;
+  element.status = TrafficLightElement::SOLID_ON;
+  element.confidence = confidence;
+  return element;
+}
+
+PredictedTrafficLightState makeTrafficLightPrediction(
+  const builtin_interfaces::msg::Time & stamp, uint8_t color, uint8_t shape,
+  const std::string & source)
+{
+  // The arbiter passes predictions through without inspecting any field
+  // value, so the numbers below only need to form a syntactically complete
+  // PredictedTrafficLightState.
+  constexpr int32_t kPredictionOffsetSec = 10;
+  constexpr float kFullCertainty = 1.0f;
+
+  PredictedTrafficLightState prediction;
+  prediction.predicted_stamp = stamp;
+  prediction.predicted_stamp.sec += kPredictionOffsetSec;
+  prediction.simultaneous_elements.push_back(makeTrafficLightElement(color, shape, kFullCertainty));
+  prediction.reliability = kFullCertainty;
+  prediction.information_source = source;
+  return prediction;
+}
+
+TrafficLightGroup makeTrafficLightGroup(
+  lanelet::Id id, std::vector<TrafficLightElement> elements,
+  std::vector<PredictedTrafficLightState> predictions = {})
+{
+  TrafficLightGroup group;
+  group.traffic_light_group_id = id;
+  group.elements = std::move(elements);
+  group.predictions = std::move(predictions);
+  return group;
+}
+
+builtin_interfaces::msg::Time offsetTime(const rclcpp::Time & base, double seconds)
+{
+  return (base + rclcpp::Duration::from_seconds(seconds));
+}
+
+const TrafficLightGroup * findTrafficLightGroup(const TrafficLightGroupArray & msg, lanelet::Id id)
+{
+  for (const auto & group : msg.traffic_light_groups) {
+    if (group.traffic_light_group_id == id) {
+      return &group;
+    }
+  }
+  return nullptr;
+}
+
+const TrafficLightElement * findTrafficLightElement(const TrafficLightGroup & group, uint8_t shape)
+{
+  for (const auto & element : group.elements) {
+    if (element.shape == shape) {
+      return &element;
+    }
+  }
+  return nullptr;
+}
+
+class ArbiterCharacteristic : public ::testing::Test
+{
+protected:
+  static void SetUpTestSuite()
+  {
+    if (!rclcpp::ok()) {
+      rclcpp::init(0, nullptr);
+    }
+  }
+  static void TearDownTestSuite()
+  {
+    if (rclcpp::ok()) {
+      rclcpp::shutdown();
+    }
+  }
+
+  void SetUp() override
+  {
+    // Reserve known signal ids so utils::getId() never returns
+    // values that collide with map_ids::* or kOffMapProbeId. Calling
+    // registerId(9999) advances the global counter to >= 10000, which is
+    // safely above every fixed signal id we use.
+    utils::registerId(kOffMapProbeId);
+
+    map_bin_ = buildMinimalMapBin();
+
+    pub_node_ = std::make_shared<rclcpp::Node>("arbiter_characteristic_test_pub");
+    sub_node_ = std::make_shared<rclcpp::Node>("arbiter_characteristic_test_sub");
+
+    map_pub_ =
+      pub_node_->create_publisher<LaneletMapBin>(kMapTopic, rclcpp::QoS(1).transient_local());
+    perception_pub_ =
+      pub_node_->create_publisher<TrafficLightGroupArray>(kPerceptionTopic, rclcpp::QoS(1));
+    external_pub_ =
+      pub_node_->create_publisher<TrafficLightGroupArray>(kExternalTopic, rclcpp::QoS(1));
+
+    output_sub_ = sub_node_->create_subscription<TrafficLightGroupArray>(
+      kOutputTopic, rclcpp::QoS(1), [this](const TrafficLightGroupArray::ConstSharedPtr msg) {
+        latest_output_ = *msg;
+        ++publish_count_;
+      });
+  }
+
+  void TearDown() override
+  {
+    if (executor_) {
+      executor_->cancel();
+    }
+    executor_.reset();
+    arbiter_.reset();
+    output_sub_.reset();
+    map_pub_.reset();
+    perception_pub_.reset();
+    external_pub_.reset();
+    sub_node_.reset();
+    pub_node_.reset();
+  }
+
+  void startArbiter(
+    bool enable_signal_matching = false, const std::string & source_priority = "confidence")
+  {
+    arbiter_ = makeArbiter(enable_signal_matching, source_priority);
+    executor_ = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
+    executor_->add_node(arbiter_);
+    executor_->add_node(pub_node_);
+    executor_->add_node(sub_node_);
+    // Allow discovery to settle before any publish so transient_local replay works.
+    spinFor(std::chrono::milliseconds(200));
+  }
+
+  void publishMap()
+  {
+    map_pub_->publish(map_bin_);
+    spinFor(std::chrono::milliseconds(200));
+  }
+  void publishPerception(const TrafficLightGroupArray & msg)
+  {
+    perception_pub_->publish(msg);
+    spinFor(std::chrono::milliseconds(150));
+  }
+  void publishExternal(const TrafficLightGroupArray & msg)
+  {
+    external_pub_->publish(msg);
+    spinFor(std::chrono::milliseconds(150));
+  }
+
+  void spinFor(std::chrono::milliseconds duration)
+  {
+    const auto deadline = std::chrono::steady_clock::now() + duration;
+    while (std::chrono::steady_clock::now() < deadline) {
+      executor_->spin_some();
+      std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+  }
+
+  rclcpp::Time arbiterNow() const { return arbiter_->now(); }
+
+  LaneletMapBin map_bin_;
+
+  rclcpp::Node::SharedPtr pub_node_;
+  rclcpp::Node::SharedPtr sub_node_;
+  std::shared_ptr<TrafficLightArbiter> arbiter_;
+  std::shared_ptr<rclcpp::executors::SingleThreadedExecutor> executor_;
+
+  rclcpp::Publisher<LaneletMapBin>::SharedPtr map_pub_;
+  rclcpp::Publisher<TrafficLightGroupArray>::SharedPtr perception_pub_;
+  rclcpp::Publisher<TrafficLightGroupArray>::SharedPtr external_pub_;
+  rclcpp::Subscription<TrafficLightGroupArray>::SharedPtr output_sub_;
+
+  TrafficLightGroupArray latest_output_;
+  std::size_t publish_count_ = 0;
+};
+
+// ---------------------------------------------------------------------------
+// A. Longest path - Signal Matching mode (enable_signal_matching=true).
+//
+// Exercises every branch of SignalMatchValidator::validateSignals in one run:
+//   - vehicle id with matching color/shape       -> use perception as-is
+//   - vehicle id with mismatching color          -> UNKNOWN for that shape
+//   - vehicle id with mismatching element count  -> UNKNOWN over union of shapes
+//   - vehicle id seen only by external           -> UNKNOWN
+//   - signal id not on the map                   -> dropped (WARN path)
+// ---------------------------------------------------------------------------
+TEST_F(ArbiterCharacteristic, signalMatchingLongestPath)
+{
+  // Arrange
+  startArbiter(true);
+  publishMap();
+  const auto t0 = arbiterNow();
+
+  TrafficLightGroupArray external_traffic_signal;
+  external_traffic_signal.stamp = offsetTime(t0, -0.10);
+  external_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
+    map_ids::vehicle_signal_a,
+    {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.6f)},
+    {makeTrafficLightPrediction(
+      external_traffic_signal.stamp, TrafficLightElement::GREEN, TrafficLightElement::CIRCLE,
+      PredictedTrafficLightState::INFORMATION_SOURCE_V2I)}));
+  external_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
+    map_ids::vehicle_signal_b,
+    {makeTrafficLightElement(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.8f)}));
+  external_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
+    map_ids::vehicle_signal_c,
+    {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.8f)}));
+  external_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
+    kOffMapProbeId,
+    {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.9f)}));
+
+  TrafficLightGroupArray perception_traffic_signal;
+  perception_traffic_signal.stamp = offsetTime(t0, -0.05);
+  perception_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
+    map_ids::vehicle_signal_a,
+    {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.7f)},
+    {makeTrafficLightPrediction(
+      perception_traffic_signal.stamp, TrafficLightElement::RED, TrafficLightElement::CIRCLE,
+      PredictedTrafficLightState::INFORMATION_SOURCE_INTERNAL_ESTIMATION)}));
+  perception_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
+    map_ids::vehicle_signal_b,
+    {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.9f)}));
+  perception_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
+    map_ids::vehicle_signal_c,
+    {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.8f),
+     makeTrafficLightElement(TrafficLightElement::GREEN, TrafficLightElement::RIGHT_ARROW, 0.6f)}));
+
+  // Act
+  publishExternal(external_traffic_signal);
+  publishPerception(perception_traffic_signal);
+
+  // Assert
+  ASSERT_GE(publish_count_, 1u);
+  EXPECT_EQ(findTrafficLightGroup(latest_output_, kOffMapProbeId), nullptr);
+
+  // matching id: perception passes through unchanged, predictions merged from both sources.
+  {
+    const auto * g = findTrafficLightGroup(latest_output_, map_ids::vehicle_signal_a);
+    ASSERT_NE(g, nullptr);
+    ASSERT_EQ(g->elements.size(), 1u);
+    EXPECT_EQ(g->elements[0].color, TrafficLightElement::RED);
+    EXPECT_NEAR(g->elements[0].confidence, 0.7f, kConfidenceEpsilon);
+    EXPECT_EQ(g->predictions.size(), 2u);
+  }
+  // color mismatch -> UNKNOWN over the single shared shape
+  {
+    const auto * g = findTrafficLightGroup(latest_output_, map_ids::vehicle_signal_b);
+    ASSERT_NE(g, nullptr);
+    ASSERT_EQ(g->elements.size(), 1u);
+    EXPECT_EQ(g->elements[0].color, TrafficLightElement::UNKNOWN);
+    EXPECT_EQ(g->elements[0].shape, TrafficLightElement::CIRCLE);
+  }
+  // element-count mismatch -> UNKNOWN over union of shapes
+  {
+    const auto * g = findTrafficLightGroup(latest_output_, map_ids::vehicle_signal_c);
+    ASSERT_NE(g, nullptr);
+    ASSERT_EQ(g->elements.size(), 2u);
+    EXPECT_NE(findTrafficLightElement(*g, TrafficLightElement::CIRCLE), nullptr);
+    EXPECT_NE(findTrafficLightElement(*g, TrafficLightElement::RIGHT_ARROW), nullptr);
+    for (const auto & e : g->elements) {
+      EXPECT_EQ(e.color, TrafficLightElement::UNKNOWN);
+    }
+  }
+}
+
+// Pedestrian path bypasses element matching; with source_priority=external
+// the external value must win even though perception has higher confidence.
+TEST_F(ArbiterCharacteristic, signalMatchingPedestrianFallbackUsesSourcePriority)
+{
+  // Arrange
+  startArbiter(true, "external");
+  publishMap();
+  const auto t0 = arbiterNow();
+
+  TrafficLightGroupArray external_traffic_signal;
+  external_traffic_signal.stamp = offsetTime(t0, -0.10);
+  external_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
+    map_ids::pedestrian_signal,
+    {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.1f)}));
+
+  TrafficLightGroupArray perception_traffic_signal;
+  perception_traffic_signal.stamp = offsetTime(t0, -0.05);
+  perception_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
+    map_ids::pedestrian_signal,
+    {makeTrafficLightElement(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.9f)}));
+
+  // Act
+  publishExternal(external_traffic_signal);
+  publishPerception(perception_traffic_signal);
+
+  // Assert
+  const auto * g = findTrafficLightGroup(latest_output_, map_ids::pedestrian_signal);
+  ASSERT_NE(g, nullptr);
+  ASSERT_EQ(g->elements.size(), 1u);
+  EXPECT_EQ(g->elements[0].color, TrafficLightElement::RED);
+  EXPECT_NEAR(g->elements[0].confidence, 0.1f, kConfidenceEpsilon);
+}
+
+// ---------------------------------------------------------------------------
+// B. Longest path - Priority-based mode (enable_signal_matching=false).
+// ---------------------------------------------------------------------------
+TEST_F(ArbiterCharacteristic, priorityBasedConfidenceLongestPath)
+{
+  // Arrange
+  startArbiter();
+  publishMap();
+  const auto t0 = arbiterNow();
+
+  TrafficLightGroupArray stale_external_traffic_signal;
+  stale_external_traffic_signal.stamp = offsetTime(t0, -4.0);
+  stale_external_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
+    map_ids::vehicle_signal_a,
+    {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.4f)}));
+
+  TrafficLightGroupArray recent_external_traffic_signal;
+  recent_external_traffic_signal.stamp = offsetTime(t0, -0.5);
+  recent_external_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
+    map_ids::vehicle_signal_a,
+    {makeTrafficLightElement(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.7f)}));
+  recent_external_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
+    map_ids::vehicle_signal_b,
+    {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.5f),
+     makeTrafficLightElement(TrafficLightElement::GREEN, TrafficLightElement::RIGHT_ARROW, 0.3f)}));
+  recent_external_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
+    kOffMapProbeId,
+    {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.9f)}));
+
+  TrafficLightGroupArray perception_traffic_signal;
+  perception_traffic_signal.stamp = offsetTime(t0, -0.2);
+  perception_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
+    map_ids::vehicle_signal_a,
+    {makeTrafficLightElement(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.9f)}));
+  perception_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
+    map_ids::vehicle_signal_c,
+    {makeTrafficLightElement(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.8f)}));
+
+  // Act
+  publishExternal(stale_external_traffic_signal);
+  publishExternal(recent_external_traffic_signal);
+  publishPerception(perception_traffic_signal);
+
+  // Assert
+  EXPECT_EQ(findTrafficLightGroup(latest_output_, kOffMapProbeId), nullptr);
+  // Both sources agree on shape; CONFIDENCE picks perception (0.9 > 0.7).
+  {
+    const auto * g = findTrafficLightGroup(latest_output_, map_ids::vehicle_signal_a);
+    ASSERT_NE(g, nullptr);
+    ASSERT_EQ(g->elements.size(), 1u);
+    EXPECT_EQ(g->elements[0].color, TrafficLightElement::GREEN);
+    EXPECT_NEAR(g->elements[0].confidence, 0.9f, kConfidenceEpsilon);
+  }
+  // External contributes two shapes alone; both survive shape-wise selection.
+  {
+    const auto * g = findTrafficLightGroup(latest_output_, map_ids::vehicle_signal_b);
+    ASSERT_NE(g, nullptr);
+    ASSERT_EQ(g->elements.size(), 2u);
+    EXPECT_NE(findTrafficLightElement(*g, TrafficLightElement::CIRCLE), nullptr);
+    EXPECT_NE(findTrafficLightElement(*g, TrafficLightElement::RIGHT_ARROW), nullptr);
+  }
+  // Perception-only id flows through unmodified.
+  {
+    const auto * g = findTrafficLightGroup(latest_output_, map_ids::vehicle_signal_c);
+    ASSERT_NE(g, nullptr);
+    ASSERT_EQ(g->elements.size(), 1u);
+    EXPECT_EQ(g->elements[0].color, TrafficLightElement::GREEN);
+    EXPECT_NEAR(g->elements[0].confidence, 0.8f, kConfidenceEpsilon);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// C. Branch coverage that the longest paths cannot reach.
+// ---------------------------------------------------------------------------
+
+TEST_F(ArbiterCharacteristic, perceptionBeforeMapProducesNoOutput)
+{
+  // Arrange (intentionally no publishMap())
+  startArbiter();
+
+  TrafficLightGroupArray perception_traffic_signal;
+  perception_traffic_signal.stamp = arbiterNow();
+  perception_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
+    map_ids::vehicle_signal_a,
+    {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.9f)}));
+
+  // Act
+  publishPerception(perception_traffic_signal);
+
+  // Assert
+  EXPECT_EQ(publish_count_, 0u)
+    << "arbitrateAndPublish should early-return when no map has been received";
+}
+
+TEST_F(ArbiterCharacteristic, priorityFlagOverridesHigherConfidence)
+{
+  // Arrange
+  startArbiter(false, "perception");
+  publishMap();
+  const auto t0 = arbiterNow();
+
+  TrafficLightGroupArray external_traffic_signal;
+  external_traffic_signal.stamp = offsetTime(t0, -0.10);
+  external_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
+    map_ids::vehicle_signal_a,
+    {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.99f)}));
+
+  TrafficLightGroupArray perception_traffic_signal;
+  perception_traffic_signal.stamp = offsetTime(t0, -0.05);
+  perception_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
+    map_ids::vehicle_signal_a,
+    {makeTrafficLightElement(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.10f)}));
+
+  // Act
+  publishExternal(external_traffic_signal);
+  publishPerception(perception_traffic_signal);
+
+  // Assert
+  const auto * g = findTrafficLightGroup(latest_output_, map_ids::vehicle_signal_a);
+  ASSERT_NE(g, nullptr);
+  ASSERT_EQ(g->elements.size(), 1u);
+  EXPECT_EQ(g->elements[0].color, TrafficLightElement::GREEN);
+  EXPECT_NEAR(g->elements[0].confidence, 0.10f, kConfidenceEpsilon);
+}
+
+TEST_F(ArbiterCharacteristic, externalDelayToleranceDropsStaleMessage)
+{
+  // Arrange: establish a perception baseline so we can detect any extra publish.
+  startArbiter();
+  publishMap();
+
+  TrafficLightGroupArray perception_traffic_signal;
+  perception_traffic_signal.stamp = arbiterNow();
+  perception_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
+    map_ids::vehicle_signal_a,
+    {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.8f)}));
+  publishPerception(perception_traffic_signal);
+  const auto baseline_count = publish_count_;
+  ASSERT_GE(baseline_count, 1u);
+
+  // external_delay_tolerance defaults to 5.0s; 20s in the past is well past it.
+  TrafficLightGroupArray stale_external_traffic_signal;
+  stale_external_traffic_signal.stamp = offsetTime(arbiterNow(), -20.0);
+  stale_external_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
+    map_ids::vehicle_signal_a,
+    {makeTrafficLightElement(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.9f)}));
+
+  // Act
+  publishExternal(stale_external_traffic_signal);
+
+  // Assert
+  EXPECT_EQ(publish_count_, baseline_count)
+    << "Stale external message must be dropped before arbitrateAndPublish runs";
+  const auto * g = findTrafficLightGroup(latest_output_, map_ids::vehicle_signal_a);
+  ASSERT_NE(g, nullptr);
+  EXPECT_EQ(g->elements[0].color, TrafficLightElement::RED)
+    << "Last publish must reflect perception";
+}
+
+TEST_F(ArbiterCharacteristic, signalMatchingIgnoresConfidenceInEquivalence)
+{
+  // Arrange
+  startArbiter(true);
+  publishMap();
+  const auto t0 = arbiterNow();
+
+  TrafficLightGroupArray external_traffic_signal;
+  external_traffic_signal.stamp = offsetTime(t0, -0.10);
+  external_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
+    map_ids::vehicle_signal_a,
+    {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.10f)}));
+
+  TrafficLightGroupArray perception_traffic_signal;
+  perception_traffic_signal.stamp = offsetTime(t0, -0.05);
+  perception_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
+    map_ids::vehicle_signal_a,
+    {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.90f)}));
+
+  // Act
+  publishExternal(external_traffic_signal);
+  publishPerception(perception_traffic_signal);
+
+  // Assert
+  const auto * g = findTrafficLightGroup(latest_output_, map_ids::vehicle_signal_a);
+  ASSERT_NE(g, nullptr);
+  ASSERT_EQ(g->elements.size(), 1u);
+  EXPECT_EQ(g->elements[0].color, TrafficLightElement::RED);
+  EXPECT_NEAR(g->elements[0].confidence, 0.90f, kConfidenceEpsilon);
+}
+
+TEST_F(ArbiterCharacteristic, externalTimeToleranceCleanupOnPerception)
+{
+  // Arrange: seed an external entry that should be purged by the perception
+  // arrival's cleanupExpiredExternalSignals (perception is +6s newer).
+  startArbiter();
+  publishMap();
+  const auto t0 = arbiterNow();
+
+  TrafficLightGroupArray external_traffic_signal;
+  external_traffic_signal.stamp = offsetTime(t0, -0.05);
+  external_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
+    map_ids::vehicle_signal_a,
+    {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.5f)}));
+  publishExternal(external_traffic_signal);
+
+  TrafficLightGroupArray perception_traffic_signal;
+  perception_traffic_signal.stamp = offsetTime(t0, 6.0);
+  perception_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
+    map_ids::vehicle_signal_a,
+    {makeTrafficLightElement(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.7f)}));
+
+  // Act
+  publishPerception(perception_traffic_signal);
+
+  // Assert
+  const auto * g = findTrafficLightGroup(latest_output_, map_ids::vehicle_signal_a);
+  ASSERT_NE(g, nullptr);
+  ASSERT_EQ(g->elements.size(), 1u);
+  EXPECT_EQ(g->elements[0].color, TrafficLightElement::GREEN);
+  EXPECT_NEAR(g->elements[0].confidence, 0.7f, kConfidenceEpsilon);
+}
+
+TEST_F(ArbiterCharacteristic, predictionsFromSingleSidePropagate)
+{
+  // Arrange
+  startArbiter();
+  publishMap();
+  const auto t0 = arbiterNow();
+
+  TrafficLightGroupArray perception_traffic_signal;
+  perception_traffic_signal.stamp = t0;
+  perception_traffic_signal.traffic_light_groups.push_back(makeTrafficLightGroup(
+    map_ids::vehicle_signal_a,
+    {makeTrafficLightElement(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.8f)},
+    {makeTrafficLightPrediction(
+      t0, TrafficLightElement::GREEN, TrafficLightElement::CIRCLE,
+      PredictedTrafficLightState::INFORMATION_SOURCE_INTERNAL_ESTIMATION)}));
+
+  // Act
+  publishPerception(perception_traffic_signal);
+
+  // Assert
+  const auto * g = findTrafficLightGroup(latest_output_, map_ids::vehicle_signal_a);
+  ASSERT_NE(g, nullptr);
+  ASSERT_EQ(g->predictions.size(), 1u);
+  EXPECT_EQ(
+    g->predictions[0].information_source,
+    PredictedTrafficLightState::INFORMATION_SOURCE_INTERNAL_ESTIMATION);
+}
+
+}  // namespace


### PR DESCRIPTION
## Description

Add `test/test_traffic_arbiter_characteristic.cpp` — a self-contained characterization test suite for `autoware_traffic_light_arbiter` that pins the arbiter's full behavior contract before structural refactoring.

### Background

The existing `test/test_node.cpp` provides smoke-level coverage but is not strong enough as a safety net for upcoming refactoring of `autoware_traffic_light_arbiter`:

- It depends on `autoware_test_utils` and a real osm map under that package, so the test cannot run from a build directory without first installing.
- The test bodies use `isEqual` over the whole `TrafficLightGroupArray`, so a single field mismatch surfaces as a generic equality failure with little diagnostic detail.
- It exercises only a subset of arbitration paths: the Signal Matching mode (`enable_signal_matching=true`), pedestrian-specific behavior, map-boundary cases, and time-tolerance paths are not pinned.

This PR adds a second test file (`test_traffic_arbiter_characteristic.cpp`) targeted at characterization — freezing the current behavior so the upcoming refactoring (extracting the arbitrate logic into a ROS-free `ArbiterCore`, splitting `arbitrateAndPublish`, etc.) can proceed with regression visibility.

### Features

- **24 tests** across three sections covering 22+ behavior contracts
- **Programmatically built minimal map** (no `autoware_test_utils` dependency)
- **Direct `rclcpp::Parameter` overrides** instead of YAML reading at test time
- **Per-spec assertions** (color/shape/predictions count) rather than whole-message equality
- **One spec rule per test** — each observable outcome (matched, mismatch, off-map drop, etc.) is exercised by a dedicated test so a failure points directly to the broken rule

### Architecture

The file is organized into three sections that match the spec matrix below:

| Section | Theme | Tests |
| --- | --- | --- |
| A. Signal Matching mode | Arbitration rules across source agreement (matched / mismatch / single-side / pedestrian path / equivalence) | 10 |
| B. Priority-based mode | Per-shape selection driven by `source_priority` and confidence | 4 |
| C. Focused specifications | Boundary conditions, input validation, time tolerances, priority overrides, predictions | 10 |

Supporting helpers are grouped inside the file by role: signal IDs, map construction, input message builders, timestamp utility, and the test fixture (which owns node setup, publish helpers, and output inspection in one place).

## Related links

**Parent Issue:**

- None

**Relevant code:**

- `perception/autoware_traffic_light_arbiter/test/test_node.cpp` — existing integration test, intentionally left untouched per the characterization-test convention.

## How was this PR tested?

```bash
colcon build --packages-select autoware_traffic_light_arbiter \
  --cmake-args -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=ON
colcon test --packages-select autoware_traffic_light_arbiter \
  --event-handlers console_direct+
```

All 24 tests pass (~15 s suite wall-time on the development machine).

Line coverage on a debug build with `--coverage` is **96.7 %** for `src/`; the remaining uncovered lines are dead branches (`__builtin_unreachable`, an `if (!perception && !external) continue;` after a union-of-ids loop) and closing braces.

## Notes for reviewers

### Specification coverage matrix

Each row describes a behavior the arbiter is expected to satisfy and the test that pins it.

#### Signal Matching mode

| Specification | Test |
| --- | --- |
| matched (color & shape agree) → perception passes through | `signalMatchingMatchedPassesThrough` |
| color mismatch → UNKNOWN over shared shape | `signalMatchingColorMismatchProducesUnknown` |
| element-count mismatch → UNKNOWN over shape union | `signalMatchingElementCountMismatchProducesUnknown` |
| single-side non-pedestrian → UNKNOWN | `signalMatchingSingleSourceNonPedestrianYieldsUnknown` |
| confidence does not affect equivalence judgement | `signalMatchingIgnoresConfidenceInEquivalence` |
| pedestrian + external priority → external value wins | `signalMatchingPedestrianFallbackUsesSourcePriority` |
| pedestrian + perception priority → perception value wins | `signalMatchingPedestrianPerceptionPriority` |
| pedestrian + CONFIDENCE → higher confidence per shape wins | `signalMatchingPedestrianConfidenceMode` |
| pedestrian + single-side → the present side passes through | `signalMatchingPedestrianSingleSourcePasses` |

#### Priority-based mode

| Specification | Test |
| --- | --- |
| CONFIDENCE picks the higher confidence per shape | `priorityBasedConfidencePicksHigherValue` |
| only external contributes (per id) → passes through (multi-shape preserved) | `priorityBasedExternalOnlyPassesThrough` |
| only perception contributes (per id) → passes through | `priorityBasedPerceptionOnlyPassesThrough` |
| perception priority overrides higher external confidence | `priorityFlagOverridesHigherConfidence` |
| external priority overrides higher perception confidence | `priorityFlagFromExternalOverridesHigherConfidence` |

#### Map / startup

| Specification | Test |
| --- | --- |
| map not yet received → no publish | `perceptionBeforeMapProducesNoOutput` |
| map carries no traffic lights → empty publish | `emptyMapProducesEmptyOutput` |
| off-map id → dropped (WARN+skip) | `signalMatchingOffMapIdDropped`, `priorityBasedOffMapIdDropped` |

#### Time tolerances

| Specification | Test |
| --- | --- |
| `external_delay_tolerance`: stale external message dropped | `externalDelayToleranceDropsStaleMessage` |
| `external_time_tolerance`: stored external cleaned up on perception arrival | `externalTimeToleranceCleanupOnPerception` |
| `perception_time_tolerance`: latest perception cleared on external arrival | `perceptionTimeToleranceClearsLatestPerception` |

#### External accumulation

| Specification | Test |
| --- | --- |
| successive external publishes with different ids → all accumulated and published | `multipleExternalSourcesAccumulate` |

#### Input validation

| Specification | Test |
| --- | --- |
| unknown `source_priority` → falls back to CONFIDENCE | `unknownSourcePriorityFallsBackToConfidence` |

#### Predictions

| Specification | Test |
| --- | --- |
| predictions from both sources → merged | `signalMatchingMatchedPassesThrough` |
| predictions from a single side → propagated | `predictionsFromSingleSidePropagate` |

### Test list

**Section A — Signal Matching mode**

1. `signalMatchingMatchedPassesThrough`
2. `signalMatchingColorMismatchProducesUnknown`
3. `signalMatchingElementCountMismatchProducesUnknown`
4. `signalMatchingOffMapIdDropped`
5. `signalMatchingPedestrianFallbackUsesSourcePriority`
6. `signalMatchingPedestrianPerceptionPriority`
7. `signalMatchingPedestrianConfidenceMode`
8. `signalMatchingPedestrianSingleSourcePasses`
9. `signalMatchingSingleSourceNonPedestrianYieldsUnknown`
10. `signalMatchingIgnoresConfidenceInEquivalence`

**Section B — Priority-based mode**

11. `priorityBasedConfidencePicksHigherValue`
12. `priorityBasedExternalOnlyPassesThrough`
13. `priorityBasedPerceptionOnlyPassesThrough`
14. `priorityBasedOffMapIdDropped`

**Section C — Focused specifications**

15. `perceptionBeforeMapProducesNoOutput`
16. `emptyMapProducesEmptyOutput`
17. `unknownSourcePriorityFallsBackToConfidence`
18. `priorityFlagOverridesHigherConfidence`
19. `priorityFlagFromExternalOverridesHigherConfidence`
20. `multipleExternalSourcesAccumulate`
21. `externalDelayToleranceDropsStaleMessage`
22. `externalTimeToleranceCleanupOnPerception`
23. `perceptionTimeToleranceClearsLatestPerception`
24. `predictionsFromSingleSidePropagate`

### Coexistence with `test_node.cpp`

`test/test_node.cpp` is intentionally **not** modified or removed:

- Every spec exercised by `test_node.cpp` is now also pinned in the new file with finer-grained assertions (the mapping is included in the matrix above).
- `test_node.cpp` plays the role of a smoke test against the real osm map; the new file plays the role of a programmatic characterization layer.
- A future cleanup, once the planned `ArbiterCore` extraction lands and its unit tests subsume these integration-level checks, may remove `test_node.cpp`. That is intentionally out of scope here.

### Design choices worth flagging

- `make_traffic_light_element(color, shape, confidence = 1.0f)` carries a `1.0f` default so test bodies can omit the confidence argument when the arbiter does not consult it. Only the CONFIDENCE / priority-override / equivalence-ignore tests keep an explicit value, and that value is itself the spec (e.g. "the lower-confidence side still wins").
- Topic-name and tolerance constants live inside the fixture as `private` / `protected static constexpr` because no free helper accesses them.
- Each test fixes one observable outcome (matched / mismatch type / off-map drop / passthrough variant) so a single assertion failure points directly to the broken spec rule. Bundled-scenario tests were intentionally split to avoid coupling unrelated outcomes in one test body.

## Interface changes

### Topic changes

None — this PR only adds test code.

### ROS Parameter Changes

None.

## Effects on system behavior

None. Test-only change.



