### PR TITLE
fix(control_evaluator): boundary_distance was 0 on both the left and right sides

### DIFF
--- a/evaluator/autoware_control_evaluator/src/control_evaluator_node.cpp
+++ b/evaluator/autoware_control_evaluator/src/control_evaluator_node.cpp
@@ -313,30 +313,31 @@ void ControlEvaluatorNode::AddUncrossableBoundaryDistanceMetricMsg(const Pose & 
     const auto current_fp = autoware_utils::transform_vector(local_fp, transformed_pose);
     const auto side = bdc_utils::get_footprint_sides(current_fp, false, false);
 
-    auto is_overlapping{false};
     for (const auto & nearby_ls : nearby_uncrossable_lines) {
       const auto & basic_ls = nearby_ls.basicLineString();
       for (size_t idx = 0; idx + 1 < basic_ls.size(); ++idx) {
         const auto segment = bdc_utils::to_segment_2d(basic_ls[idx], basic_ls[idx + 1]);
 
-        is_overlapping = !boost::geometry::disjoint(current_fp, segment);
-        if (is_overlapping) {
-          nearest_left = 0.0;
-          nearest_right = 0.0;
-          break;
-        }
-
         const auto dist_to_left = boost::geometry::distance(segment, side.left);
         const auto dist_to_right = boost::geometry::distance(segment, side.right);
-        if (dist_to_left < dist_to_right) {
-          nearest_left = std::min(dist_to_left, nearest_left);
-        } else {
-          nearest_right = std::min(dist_to_right, nearest_right);
+
+        // Update the nearest distance to the boundary.
+        bool left_touched = dist_to_left <= 0.0;
+        bool right_touched = dist_to_right <= 0.0;
+        if (left_touched) nearest_left = 0.0;
+        if (right_touched) nearest_right = 0.0;
+
+        if (!left_touched && !right_touched) {
+          if (dist_to_left < dist_to_right) {
+            nearest_left = std::min(dist_to_left, nearest_left);
+          } else {
+            nearest_right = std::min(dist_to_right, nearest_right);
+          }
         }
+
+        if (nearest_left == 0.0 && nearest_right == 0.0) break;
       }
-      if (is_overlapping) {
-        break;
-      }
+      if (nearest_left == 0.0 && nearest_right == 0.0) break;
     }
   }
 


### PR DESCRIPTION
## Description

Fixed a bug where, when the `uncrossable_boundary_distance` for either the left or right side reached 0, both distances would become 0.

### Before (0:11~)

https://github.com/user-attachments/assets/b4bd75c9-c12b-497e-8ba9-ab2f93a0c63a

### After (0:05~)

https://github.com/user-attachments/assets/1a13b78d-81dd-49a3-b3ff-e8807418eaf7

## Related links

[TIER IV Internal link](https://star4.slack.com/archives/C02J99Y9L8G/p1779753048623989?thread_ts=1776847163.924389&cid=C02J99Y9L8G)

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

- Local Test

- [Evaluator Test](https://evaluation.tier4.jp/evaluation/reports/05181e7b-3e49-5e71-b326-1e34e8303b39?project_id=autoware_dev)

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
