### PR TITLE
feat(image_projection_based_fusion): apply to CIE

### DIFF
--- a/perception/autoware_image_projection_based_fusion/CMakeLists.txt
+++ b/perception/autoware_image_projection_based_fusion/CMakeLists.txt
@@ -59,9 +59,11 @@ autoware_agnocast_wrapper_register_node(${PROJECT_NAME}
   ROS2_EXECUTOR SingleThreadedExecutor
 )
 
-rclcpp_components_register_node(${PROJECT_NAME}
+autoware_agnocast_wrapper_register_node(${PROJECT_NAME}
   PLUGIN "autoware::image_projection_based_fusion::SegmentPointCloudFusionNode"
   EXECUTABLE segmentation_pointcloud_fusion_node
+  AGNOCAST_EXECUTOR CallbackIsolatedAgnocastExecutor
+  ROS2_EXECUTOR SingleThreadedExecutor
 )
 
 autoware_agnocast_wrapper_register_node(${PROJECT_NAME}


### PR DESCRIPTION
## Description
Use `CallbackIsolatedAgnocastExecutor` (CIE) for `image_projection_based_fusion` node, as part of the effort to achieve middleware-transparent scheduling and optimize end-to-end response time across Autoware. By going through `autoware_agnocast_wrapper`, CIE activation is controlled by the `ENABLE_AGNOCAST` environment variable — when unset or `0`, the node runs with the standard ROS 2 executor as before; when set to `1`, it switches to `CallbackIsolatedAgnocastExecutor`.

### Changes
- **CMakeLists.txt**: Set `SingleThreadedExecutor` explicitly for `ROS_EXECUTOR` and changed to `CallbackIsolatedAgnocastExecutor` for `AGNOCAST_EXECUTOR` option.

## Related links

- Issue: https://github.com/autowarefoundation/autoware_core/issues/1056

- [AutowareDiscussion about adopting CIE](https://github.com/orgs/autowarefoundation/discussions/6813)
- [What is autoware_agnocast_wrapper?](https://github.com/autowarefoundation/autoware_core/blob/main/common/autoware_agnocast_wrapper/README.md)

## How was this PR tested?

- Evaluator passed: https://evaluation.tier4.jp/evaluation/reports/5b248072-d446-5701-8c6a-dd99afe9d50f?project_id=prd_jt
- Verification in Lsim (both ENABLE_AGNOCAST=0 and ENABLE_AGNOCAST=1).

## Notes for reviewers

**Please review the following aspects:**

- Verify that all relevant `CMakeLists.txt` for `image_projection_based_fusion` node have been updated (no missed files).
- If the node meets **all** of the following conditions, please check for potential race conditions (see [Effects on system behavior](##effects-on-system-behavior) for the reason):
  1. The node was originally running on a `rclcpp::executors::SingleThreadedExecutor` or `rclcpp_components::component_container`
  2. The node has multiple callback groups (the default is one)
  3. Shared variables are accessed across callback groups without proper mutex protection

 **Note:** Nodes already running on `MultiThreadedExecutor` (or `component_container_mt`) are not affected, as their callbacks are already executed concurrently.

## Interface changes

None.

## Effects on system behavior

When `ENABLE_AGNOCAST=0` (default), there is no change in behavior at all — the node runs with the standard ROS 2 executor exactly as before.

When `ENABLE_AGNOCAST=1`, the executor switches to `CallbackIsolatedAgnocastExecutor` (CIE). Internally, CIE creates a dedicated `rclcpp::executors::SingleThreadedExecutor` for each callback group, so the fundamental scheduling behavior within each group remains almost identical. The key difference is that, for nodes originally using `rclcpp::executors::SingleThreadedExecutor`, callback groups now run in parallel across separate threads, similar to `MultiThreadedExecutor`.


<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->
