### PR TITLE
fix(behavior_velocity_crosswalk_module): ensure strict sort comparator

### DIFF
--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/scene_crosswalk.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/scene_crosswalk.cpp
@@ -141,7 +141,13 @@ void sortCrosswalksByDistance(
     const auto l2_end_points_on_crosswalk =
       getPathEndPointsOnCrosswalk(ego_path, l2.polygon2d().basicPolygon(), ego_pos);
 
-    if (!l1_end_points_on_crosswalk || !l2_end_points_on_crosswalk) {
+    if (!l1_end_points_on_crosswalk && !l2_end_points_on_crosswalk) {
+      return l1.id() < l2.id();
+    }
+    if (!l1_end_points_on_crosswalk) {
+      return false;
+    }
+    if (!l2_end_points_on_crosswalk) {
       return true;
     }
 


### PR DESCRIPTION
## Description

This PR fixes the comparator used by `sortCrosswalksByDistance` in the crosswalk module.

The previous comparator returned `true` whenever either operand did not have a path-intersection endpoint. This could violate the strict weak ordering requirement of `std::sort`, because `compare(a, b)` and `compare(b, a)` could both return `true`.

This change handles the no-endpoint cases explicitly:

- both operands have no endpoint: order by lanelet id
- only the left operand has no endpoint: sort it after endpoint-bearing crosswalks
- only the right operand has no endpoint: sort the left operand before it
- both operands have endpoints: keep the existing arc-length comparison

This preserves the existing distance-based ordering for endpoint-bearing crosswalks while making the comparator strict for all inputs.

## Related links

**Parent Issue:**

- Fixes #12517

## How was this PR tested?

Not run locally. The change is limited to comparator logic and will be validated by CI.

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

No external interface changes are expected. This change makes crosswalk sorting deterministic and compliant with the strict weak ordering requirement of `std::sort` when one or both crosswalks do not have path-intersection endpoints.