### PR TITLE
fix(clang-tidy): fix unchecked optional access in pointcloud preprocessor

### DIFF
--- a/sensing/autoware_pointcloud_preprocessor/test/test_distortion_corrector_node.cpp
+++ b/sensing/autoware_pointcloud_preprocessor/test/test_distortion_corrector_node.cpp
@@ -1191,10 +1191,12 @@ TEST_F(DistortionCorrectorTest, TestTryComputeAngleConversionOnVelodynePointclou
     generate_pointcloud_msg(true, timestamp, velodyne_points, velodyne_azimuths);
   auto angle_conversion_opt =
     distortion_corrector_2d_->try_compute_angle_conversion(velodyne_pointcloud);
-  EXPECT_TRUE(angle_conversion_opt.has_value());
+  ASSERT_TRUE(angle_conversion_opt.has_value());
+  const auto angle_conversion =
+    angle_conversion_opt.value_or(autoware::pointcloud_preprocessor::AngleConversion{});
 
-  EXPECT_EQ(angle_conversion_opt->sign, -1);
-  EXPECT_NEAR(angle_conversion_opt->offset_rad, 0, standard_tolerance);
+  EXPECT_EQ(angle_conversion.sign, -1);
+  EXPECT_NEAR(angle_conversion.offset_rad, 0, standard_tolerance);
 }
 
 TEST_F(DistortionCorrectorTest, TestTryComputeAngleConversionOnHesaiPointcloud)
@@ -1213,9 +1215,11 @@ TEST_F(DistortionCorrectorTest, TestTryComputeAngleConversionOnHesaiPointcloud)
   auto angle_conversion_opt =
     distortion_corrector_2d_->try_compute_angle_conversion(hesai_pointcloud);
 
-  EXPECT_TRUE(angle_conversion_opt.has_value());
-  EXPECT_EQ(angle_conversion_opt->sign, -1);
-  EXPECT_NEAR(angle_conversion_opt->offset_rad, autoware_utils::pi / 2, standard_tolerance);
+  ASSERT_TRUE(angle_conversion_opt.has_value());
+  const auto angle_conversion =
+    angle_conversion_opt.value_or(autoware::pointcloud_preprocessor::AngleConversion{});
+  EXPECT_EQ(angle_conversion.sign, -1);
+  EXPECT_NEAR(angle_conversion.offset_rad, autoware_utils::pi / 2, standard_tolerance);
 }
 
 TEST_F(DistortionCorrectorTest, TestTryComputeAngleConversionCartesianPointcloud)
@@ -1237,9 +1241,11 @@ TEST_F(DistortionCorrectorTest, TestTryComputeAngleConversionCartesianPointcloud
   auto angle_conversion_opt =
     distortion_corrector_2d_->try_compute_angle_conversion(cartesian_pointcloud);
 
-  EXPECT_TRUE(angle_conversion_opt.has_value());
-  EXPECT_EQ(angle_conversion_opt->sign, 1);
-  EXPECT_NEAR(angle_conversion_opt->offset_rad, 0, standard_tolerance);
+  ASSERT_TRUE(angle_conversion_opt.has_value());
+  const auto angle_conversion =
+    angle_conversion_opt.value_or(autoware::pointcloud_preprocessor::AngleConversion{});
+  EXPECT_EQ(angle_conversion.sign, 1);
+  EXPECT_NEAR(angle_conversion.offset_rad, 0, standard_tolerance);
 }
 
 TEST_F(DistortionCorrectorTest, TestTryComputeAngleConversionOnRandomPointcloud)
@@ -1259,9 +1265,11 @@ TEST_F(DistortionCorrectorTest, TestTryComputeAngleConversionOnRandomPointcloud)
   auto pointcloud = generate_pointcloud_msg(true, timestamp, points, azimuths);
   auto angle_conversion_opt = distortion_corrector_2d_->try_compute_angle_conversion(pointcloud);
 
-  EXPECT_TRUE(angle_conversion_opt.has_value());
-  EXPECT_EQ(angle_conversion_opt->sign, 1);
-  EXPECT_NEAR(angle_conversion_opt->offset_rad, autoware_utils::pi * 3 / 2, standard_tolerance);
+  ASSERT_TRUE(angle_conversion_opt.has_value());
+  const auto angle_conversion =
+    angle_conversion_opt.value_or(autoware::pointcloud_preprocessor::AngleConversion{});
+  EXPECT_EQ(angle_conversion.sign, 1);
+  EXPECT_NEAR(angle_conversion.offset_rad, autoware_utils::pi * 3 / 2, standard_tolerance);
 }
 
 TEST_F(DistortionCorrectorTest, TestTryComputeAngleConversionOnBadAzimuthPointcloud)


### PR DESCRIPTION
## Description

This PR fixes `bugprone-unchecked-optional-access` warnings in `autoware_pointcloud_preprocessor`.

The changes replace unchecked optional accesses in distortion corrector tests with checked local values before use.

Main fixes:

- Replace `EXPECT_TRUE(angle_conversion_opt.has_value())` with `ASSERT_TRUE(...)` before using the optional value.
- Store the checked optional value in a local `angle_conversion` variable.
- Keep the fix limited to `test/test_distortion_corrector_node.cpp`.

## Related links

Parent Issue:

- Fix suppressed clang-tidy failures #12450

## How was this PR tested?

```bash
pre-commit run clang-format --files \
  sensing/autoware_pointcloud_preprocessor/test/test_distortion_corrector_node.cpp
```

Result:

```text
clang-format.............................................................Passed
```

```bash
colcon build --packages-up-to autoware_pointcloud_preprocessor \
  --cmake-args -DCMAKE_EXPORT_COMPILE_COMMANDS=1
```

Result:

```text
Summary: 35 packages finished
```

```bash
timeout 15m run-clang-tidy -p build/ \
  -config="$(cat /tmp/unchecked_optional_only.yaml)" \
  -j $(nproc) \
  autoware_pointcloud_preprocessor \
  > /tmp/clang-tidy-result/unchecked_optional_pointcloud_preprocessor_after.log 2>&1 || true

grep -n "bugprone-unchecked-optional-access" \
  /tmp/clang-tidy-result/unchecked_optional_pointcloud_preprocessor_after.log | grep "error:" \
  || echo "0 unchecked optional access errors"
```

Result:

```text
0 unchecked optional access errors
```

## Notes for reviewers

This PR only addresses unchecked optional access warnings in the pointcloud preprocessor tests.

## Interface changes

None.

## Effects on system behavior

None intended.