### PR TITLE
fix(clang-tidy): fix unchecked optional access in yabloc common

### DIFF
--- a/localization/yabloc/yabloc_common/src/camera_info_subscriber.cpp
+++ b/localization/yabloc/yabloc_common/src/camera_info_subscriber.cpp
@@ -37,6 +37,9 @@ bool CameraInfoSubscriber::is_camera_info_nullopt() const
 
 std::string CameraInfoSubscriber::get_frame_id() const
 {
+  if (!opt_info_.has_value()) {
+    throw std::runtime_error("camera_info is not ready but it's accessed");
+  }
   return opt_info_->header.frame_id;
 }
 


### PR DESCRIPTION
## Description

This PR fixes `bugprone-unchecked-optional-access` warnings in `yabloc_common`.

The change adds an explicit camera info readiness check before accessing the optional camera info in `CameraInfoSubscriber::get_frame_id()`.

## Related links

Parent Issue:

- Fix suppressed clang-tidy failures #12450

## How was this PR tested?

```bash
pre-commit run clang-format --files   localization/yabloc/yabloc_common/src/camera_info_subscriber.cpp
```

Result:

```text
clang-format.............................................................Passed
```

```bash
colcon build --packages-up-to yabloc_common   --cmake-args -DCMAKE_EXPORT_COMPILE_COMMANDS=1
```

Result:

```text
Summary: 18 packages finished
```

```bash
timeout 15m run-clang-tidy -p build/   -config="$(cat /tmp/unchecked_optional_only.yaml)"   -j $(nproc)   localization/yabloc/yabloc_common/src/camera_info_subscriber.cpp   > /tmp/clang-tidy-result/unchecked_optional_yabloc_common_after.log 2>&1 || true

grep -n "bugprone-unchecked-optional-access"   /tmp/clang-tidy-result/unchecked_optional_yabloc_common_after.log | grep "error:"   || echo "0 unchecked optional access errors"
```

Result:

```text
0 unchecked optional access errors
```

## Notes for reviewers

This PR only addresses an unchecked optional access warning in `yabloc_common`.

## Interface changes

None.

## Effects on system behavior

No intended behavior change in normal operation. Access to camera info now uses the same readiness guard pattern as other methods in this class.