### PR TITLE
feat(trajectory_modifier): improve trajectory modifier obstacle stop

### DIFF
--- a/planning/autoware_trajectory_modifier/CMakeLists.txt
+++ b/planning/autoware_trajectory_modifier/CMakeLists.txt
@@ -37,6 +37,7 @@ autoware_agnocast_wrapper_register_node(${PROJECT_NAME}
 ament_auto_add_library(${PROJECT_NAME}_plugins SHARED
   src/trajectory_modifier_plugins/stop_point_fixer.cpp
   src/trajectory_modifier_plugins/obstacle_stop.cpp
+  src/trajectory_modifier_plugins/velocity_modifier.cpp
 )
 
 target_link_libraries(${PROJECT_NAME}_plugins

--- a/planning/autoware_trajectory_modifier/README.md
+++ b/planning/autoware_trajectory_modifier/README.md
@@ -38,8 +38,11 @@ Both conditions are individually enabled or disabled via parameters, allowing fi
 The Obstacle Stop plugin serves as a deterministic safety shield operating independently of the generative model to:
 
 - **Enforce Longitudinal Safety**: Monitors the gap to dynamic and static obstacles to ensure a safe distance is maintained under all kinematic conditions.
-- **Ensure Definitive Stopping**: Guarantees zero-velocity set-points for stationary objects (e.g., traffic lights, stopped vehicles) to prevent "creeping" or oscillating behavior near obstacles.
-- **Provide Predictable Deceleration**: Standardizes the vehicle’s stopping profile to ensure consistent, comfortable, and physically guaranteed deceleration regardless of the AI's intended path.
+- **Ensure Definitive Stopping For Obstacles**: Guarantees zero-velocity set-points for stationary objects (e.g., traffic lights, stopped vehicles) to prevent "creeping" or oscillating behavior near obstacles.
+
+#### Velocity Modifier
+
+The Velocity Modifier plugins is responsible for ensuring the velocity profile is smooth and feasible, and adjusts the velocity profile if an anomaly is detected while respecting deceleration and jerk constraints.
 
 ## Dependencies
 

--- a/planning/autoware_trajectory_modifier/config/trajectory_modifier.param.yaml
+++ b/planning/autoware_trajectory_modifier/config/trajectory_modifier.param.yaml
@@ -1,10 +1,12 @@
 /**:
   ros__parameters:
     plugin_names:
-      - "autoware::trajectory_modifier::plugin::ObstacleStop"
       - "autoware::trajectory_modifier::plugin::StopPointFixer"
+      - "autoware::trajectory_modifier::plugin::ObstacleStop"
+      - "autoware::trajectory_modifier::plugin::VelocityModifier"
     use_stop_point_fixer: true
     use_obstacle_stop: true
+    use_velocity_modifier: true
     trajectory_time_step: 0.1 # [s]
 
     # Stop Point Fixer Plugin Parameters
@@ -15,6 +17,11 @@
       min_distance_threshold: 1.0 # [m]
       min_stop_duration: 0.5 # [s]
 
+    stopping_constraints:
+      nominal_deceleration: 1.0 # [m/s^2]
+      maximum_deceleration: 4.0 # [m/s^2]
+      jerk_limit: 3.0 # [m/s^3]
+
     # Obstacle Stop Plugin Parameters
     obstacle_stop:
       use_objects: true
@@ -22,9 +29,6 @@
       enable_stop_for_objects: true
       enable_stop_for_pointcloud: false
       stop_margin: 6.0 # [m]
-      nominal_stopping_decel: 1.0 # [m/s^2]
-      maximum_stopping_decel: 4.0 # [m/s^2]
-      stopping_jerk: 3.0 # [m/s^3]
       lateral_margin: 0.0     # lateral margin on top of ego width from trajectory to consider for obstacle stop [m]
       duplicate_check_threshold: 0.5 # threshold to check if the stop point is already in the trajectory [m]
       arrived_distance_threshold: 0.5 # threshold to check if the ego vehicle has arrived at the stop point [m]

--- a/planning/autoware_trajectory_modifier/config/trajectory_modifier.param.yaml
+++ b/planning/autoware_trajectory_modifier/config/trajectory_modifier.param.yaml
@@ -33,12 +33,13 @@
         off_time_buffer: 1.0
         object_distance_th: 1.0 # [m]
         object_yaw_th: 0.1745 # [rad] (10 degrees)
-        pcd_distance_th: 0.5 # [m]
+        pcd_distance_th: 1.0 # [m]
         grace_period: 0.2 # [s]
 
       objects:
         object_types: ["car", "truck", "bus", "trailer", "motorcycle", "bicycle", "pedestrian"] # object types to consider for obstacle stop
-        max_velocity_th: 1.0      # maximum velocity threshold for target object [m/s]
+        max_velocity_th: 5.0      # maximum velocity threshold for target object [m/s]
+        stopped_velocity_th: 0.25 # [m/s]
 
       pointcloud:
         height_buffer: 0.5  # height buffer to add above ego height [m]
@@ -64,6 +65,7 @@
           motorcycle: 3.0
           bicycle: 5.0
           pedestrian: 5.0
+        ego_decel: 4.0 # [m/s^2]
         reaction_time: 0.2 # [s]
         safety_margin: 2.0 # [m]
-        min_vel_th: 0.5 # [m/s] minimum object velocity to consider for rss check
+        lookahead_horizon: 1.5 # [s]

--- a/planning/autoware_trajectory_modifier/config/trajectory_modifier.param.yaml
+++ b/planning/autoware_trajectory_modifier/config/trajectory_modifier.param.yaml
@@ -29,13 +29,13 @@
       enable_stop_for_objects: true
       enable_stop_for_pointcloud: false
       stop_margin: 6.0 # [m]
-      lateral_margin: 0.0     # lateral margin on top of ego width from trajectory to consider for obstacle stop [m]
+      lateral_margin: 0.2     # lateral margin on top of ego width from trajectory to consider for obstacle stop [m]
       duplicate_check_threshold: 0.5 # threshold to check if the stop point is already in the trajectory [m]
       arrived_distance_threshold: 0.5 # threshold to check if the ego vehicle has arrived at the stop point [m]
 
       obstacle_tracking:
         on_time_buffer: 0.5
-        off_time_buffer: 1.0
+        off_time_buffer: 0.7
         object_distance_th: 1.0 # [m]
         object_yaw_th: 0.1745 # [rad] (10 degrees)
         pcd_distance_th: 1.0 # [m]
@@ -43,10 +43,10 @@
 
       objects:
         object_types: ["car", "truck", "bus", "trailer", "motorcycle", "bicycle", "pedestrian"] # object types to consider for obstacle stop
-        max_velocity_th: 5.0      # maximum velocity threshold for target object [m/s]
-        stopped_velocity_th: 0.25 # [m/s]
+        max_velocity_th: 3.0      # maximum velocity threshold for target object [m/s]
+        stopped_velocity_th: 0.3 # [m/s]
         max_lateral_velocity_th: 1.0 # [m/s] max lateral velocity (w.r.t ego traj) to consider for obstacle stop
-        safety_buffer: 0.0 # [m] safety buffer to expand object shape
+        safety_buffer: 0.1 # [m] safety buffer to expand object shape
 
       pointcloud:
         height_buffer: 0.5  # height buffer to add above ego height [m]
@@ -69,10 +69,10 @@
           truck: 1.5
           bus: 1.5
           trailer: 1.5
-          motorcycle: 3.0
-          bicycle: 5.0
+          motorcycle: 2.0
+          bicycle: 3.0
           pedestrian: 5.0
-        ego_decel: 4.0 # [m/s^2]
+        ego_decel: 2.5 # [m/s^2]
         reaction_time: 0.2 # [s]
         safety_margin: 2.0 # [m]
         lookahead_horizon: 1.5 # [s]

--- a/planning/autoware_trajectory_modifier/config/trajectory_modifier.param.yaml
+++ b/planning/autoware_trajectory_modifier/config/trajectory_modifier.param.yaml
@@ -26,6 +26,7 @@
       maximum_stopping_decel: 4.0 # [m/s^2]
       stopping_jerk: 3.0 # [m/s^3]
       lateral_margin: 0.0     # lateral margin on top of ego width from trajectory to consider for obstacle stop [m]
+      duplicate_check_threshold: 0.5 # threshold to check if the stop point is already in the trajectory [m]
       arrived_distance_threshold: 0.5 # threshold to check if the ego vehicle has arrived at the stop point [m]
 
       obstacle_tracking:
@@ -40,6 +41,7 @@
         object_types: ["car", "truck", "bus", "trailer", "motorcycle", "bicycle", "pedestrian"] # object types to consider for obstacle stop
         max_velocity_th: 5.0      # maximum velocity threshold for target object [m/s]
         stopped_velocity_th: 0.25 # [m/s]
+        max_lateral_velocity_th: 1.0 # [m/s] max lateral velocity (w.r.t ego traj) to consider for obstacle stop
 
       pointcloud:
         height_buffer: 0.5  # height buffer to add above ego height [m]

--- a/planning/autoware_trajectory_modifier/config/trajectory_modifier.param.yaml
+++ b/planning/autoware_trajectory_modifier/config/trajectory_modifier.param.yaml
@@ -42,6 +42,7 @@
         max_velocity_th: 5.0      # maximum velocity threshold for target object [m/s]
         stopped_velocity_th: 0.25 # [m/s]
         max_lateral_velocity_th: 1.0 # [m/s] max lateral velocity (w.r.t ego traj) to consider for obstacle stop
+        safety_buffer: 0.0 # [m] safety buffer to expand object shape
 
       pointcloud:
         height_buffer: 0.5  # height buffer to add above ego height [m]

--- a/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier_plugins/obstacle_stop.hpp
+++ b/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier_plugins/obstacle_stop.hpp
@@ -21,6 +21,7 @@
 
 #include <rclcpp/rclcpp.hpp>
 
+#include <autoware_internal_debug_msgs/msg/string_stamped.hpp>
 #include <visualization_msgs/msg/marker_array.hpp>
 
 #include <memory>
@@ -30,6 +31,7 @@
 
 namespace autoware::trajectory_modifier::plugin
 {
+using autoware_internal_debug_msgs::msg::StringStamped;
 using autoware_internal_planning_msgs::msg::SafetyFactor;
 using autoware_internal_planning_msgs::msg::SafetyFactorArray;
 using autoware_perception_msgs::msg::PredictedObjects;
@@ -79,7 +81,9 @@ private:
 
   MarkerArray marker_array_;
   rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr debug_viz_pub_;
+  rclcpp::Publisher<PointCloud2>::SharedPtr pub_filtered_pointcloud_;
   rclcpp::Publisher<PointCloud2>::SharedPtr pub_clustered_pointcloud_;
+  rclcpp::Publisher<StringStamped>::SharedPtr pub_debug_text_;
 
   void check_obstacles(const TrajectoryPoints & traj_points, const InputData & input);
   std::optional<CollisionPoint> check_predicted_objects(
@@ -91,6 +95,8 @@ private:
 
   bool apply_stopping(
     TrajectoryPoints & traj_points, const double target_stop_point_arc_length) const;
+
+  void publish_debug_string(bool is_safe) const;
 };
 
 }  // namespace autoware::trajectory_modifier::plugin

--- a/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier_plugins/obstacle_stop.hpp
+++ b/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier_plugins/obstacle_stop.hpp
@@ -64,6 +64,7 @@ protected:
 
 private:
   TrajectoryModifierParams::ObstacleStop params_;
+  TrajectoryModifierParams::StoppingConstraints stopping_params_;
 
   std::optional<CollisionPoint> nearest_collision_point_;
 

--- a/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier_plugins/velocity_modifier.hpp
+++ b/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier_plugins/velocity_modifier.hpp
@@ -1,0 +1,55 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__TRAJECTORY_MODIFIER__TRAJECTORY_MODIFIER_PLUGINS__VELOCITY_MODIFIER_HPP_
+#define AUTOWARE__TRAJECTORY_MODIFIER__TRAJECTORY_MODIFIER_PLUGINS__VELOCITY_MODIFIER_HPP_
+
+#include "autoware/trajectory_modifier/trajectory_modifier_plugins/trajectory_modifier_plugin_base.hpp"
+#include "autoware/trajectory_modifier/trajectory_modifier_utils/utils.hpp"
+
+#include <rclcpp/rclcpp.hpp>
+
+namespace autoware::trajectory_modifier::plugin
+{
+
+class VelocityModifier : public TrajectoryModifierPluginBase
+{
+public:
+  VelocityModifier() = default;
+
+  bool modify_trajectory(TrajectoryPoints & traj_points, const InputData & input) override;
+
+  [[nodiscard]] bool is_trajectory_modification_required(
+    const TrajectoryPoints & traj_points, [[maybe_unused]] const InputData & input) override;
+
+  void update_params(const TrajectoryModifierParams & params) override
+  {
+    enabled_ = params.use_velocity_modifier;
+    trajectory_time_step_ = params.trajectory_time_step;
+    params_ = params.stopping_constraints;
+  };
+
+protected:
+  void on_initialize(const TrajectoryModifierParams & params) override;
+
+private:
+  TrajectoryModifierParams::StoppingConstraints params_;
+
+  size_t update_velocities(
+    TrajectoryPoints & trajectory, const double jerk, const double decel) const;
+};
+
+}  // namespace autoware::trajectory_modifier::plugin
+
+#endif  // AUTOWARE__TRAJECTORY_MODIFIER__TRAJECTORY_MODIFIER_PLUGINS__VELOCITY_MODIFIER_HPP_

--- a/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier_utils/obstacle_stop_utils.hpp
+++ b/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier_utils/obstacle_stop_utils.hpp
@@ -107,6 +107,13 @@ struct CollisionPoint
   }
 };
 
+struct ObjectState
+{
+  double arc_length;
+  double lon_vel;
+  geometry_msgs::msg::Point nearest_point;
+};
+
 struct TrajectoryShape
 {
   MultiPolygon2d polygon;
@@ -118,7 +125,8 @@ struct TrajectoryShape
 struct DebugData
 {
   PointCloud2::SharedPtr cluster_points;
-  PointCloud2::SharedPtr voxel_points;
+  PointCloud2::SharedPtr filtered_points;
+  PredictedObjects filtered_objects;
   MultiPolygon2d target_polygons;
   TrajectoryShape trajectory_shape;
   std::vector<geometry_msgs::msg::Point> target_pcd_points;
@@ -148,8 +156,8 @@ using ObjectDecelMap = std::unordered_map<ObjectType, double>;
 std::optional<CollisionPoint> get_nearest_object_collision(
   const TrajectoryPoints & trajectory_points, const TrajectoryShape & trajectory_shape,
   const autoware::vehicle_info_utils::VehicleInfo & vehicle_info, const PredictedObjects & objects,
-  const ObjectDecelMap & object_decel_map, const double ego_vel, const double ego_decel,
-  const double reaction_time, const double safety_margin, const double min_vel_th,
+  const ObjectDecelMap & object_decel_map, const double ego_decel, const double reaction_time,
+  const double safety_margin, const double stopped_vel_th, const double lookahead_horizon,
   MultiPolygon2d & target_polygons, PredictedObject & colliding_object);
 
 struct ObjectFilter

--- a/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier_utils/obstacle_stop_utils.hpp
+++ b/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier_utils/obstacle_stop_utils.hpp
@@ -92,11 +92,22 @@ struct CollisionPoint
   rclcpp::Time start_time;
   bool is_active{false};
 
+  /**
+   * @brief Construct a collision sample from a point and its arc length along the reference path.
+   * @param point Collision position in map frame.
+   * @param arc_length Signed arc length from the start of the trajectory to the collision point.
+   */
   CollisionPoint(const geometry_msgs::msg::Point & point, const double arc_length)
   : point(point), arc_length(arc_length)
   {
   }
 
+  /**
+   * @brief Copy a collision point and attach timing / activation state (e.g. for hysteresis).
+   * @param collision_point Source geometry and arc length.
+   * @param start_time Time associated with this collision state.
+   * @param active Whether this collision is currently considered active.
+   */
   CollisionPoint(
     const CollisionPoint & collision_point, const rclcpp::Time & start_time, const bool active)
   : point(collision_point.point),
@@ -135,35 +146,117 @@ struct DebugData
   double ego_z = 0.0;  // cached for marker placement during publish_debug_data
 };
 
+/**
+ * @brief Trim the trajectory after the first zero-velocity point and remove overlapping duplicate
+ * points.
+ * @param[in,out] trajectory_points Trajectory to shorten and deduplicate in place.
+ */
 void trim_trajectory_and_remove_duplicates(TrajectoryPoints & trajectory_points);
 
+/**
+ * @brief Build a 2D swept footprint of the ego vehicle along the portion of the path used for
+ * obstacle detection.
+ * @details The detection length combines stopping-distance logic (speed, deceleration, jerk,
+ * margins) with the path ahead of the ego. The polygon is the union of vehicle footprints
+ * sampled along that segment; the returned bounding box encloses that multi-polygon.
+ * @param trajectory_points Full reference trajectory.
+ * @param ego_pose Current ego pose on the trajectory.
+ * @param vehicle_info Vehicle geometry for the footprint polygon.
+ * @param ego_vel Current longitudinal speed [m/s].
+ * @param ego_accel Current longitudinal acceleration [m/s^2].
+ * @param decel Magnitude of comfortable deceleration used for stopping distance [m/s^2].
+ * @param jerk Longitudinal jerk limit used for stopping distance [m/s^3].
+ * @param stop_margin Extra longitudinal margin added to the detection range [m].
+ * @param lateral_margin Lateral expansion of the footprint [m].
+ * @param longitudinal_margin Longitudinal expansion of the footprint [m].
+ * @return Swept shape, its axis-aligned bounding box, total trajectory length, and forward arc
+ * length from the ego.
+ */
 TrajectoryShape get_trajectory_shape(
   const TrajectoryPoints & trajectory_points, const geometry_msgs::msg::Pose & ego_pose,
   const autoware::vehicle_info_utils::VehicleInfo & vehicle_info, const double ego_vel,
   const double ego_accel, const double decel, const double jerk, const double stop_margin,
   const double lateral_margin = 0.0, const double longitudinal_margin = 0.0);
 
+/**
+ * @brief Find the closest point-cloud obstacle inside the trajectory swept area.
+ * @details Points inside `trajectory_shape.polygon` are considered; the collision is the one with
+ * minimum arc length along `trajectory_points`. All inlier points are appended to
+ * `target_pcd_points` for visualization or debugging.
+ * @param trajectory_points Reference path for arc-length queries.
+ * @param trajectory_shape Swept ego region from get_trajectory_shape().
+ * @param pointcloud Input points in the same frame as the trajectory.
+ * @param[out] target_pcd_points Points that fell inside the trajectory polygon.
+ * @return Nearest collision by arc length, or nullopt if the cloud is empty or none intersect.
+ */
 std::optional<CollisionPoint> get_nearest_pcd_collision(
   const TrajectoryPoints & trajectory_points, const TrajectoryShape & trajectory_shape,
   const PointCloud::Ptr & pointcloud, std::vector<geometry_msgs::msg::Point> & target_pcd_points);
 
+/**
+ * @brief Find the nearest obstacle along the path using each object's footprint polygon at the
+ * current time.
+ * @details For every target object, polygon vertices are projected onto arc length along the
+ * trajectory; the minimum over all vertices and objects defines the collision point.
+ * @param trajectory_points Reference path.
+ * @param target_objects Predicted objects to test (typically already filtered).
+ * @param[out] colliding_object Object that yielded the minimum arc-length collision.
+ * @return Collision point and arc length, or nullopt if inputs are invalid or no objects.
+ */
 std::optional<CollisionPoint> get_nearest_object_collision(
-  const TrajectoryPoints & trajectory_points, const TrajectoryShape & trajectory_shape,
-  const PredictedObjects & objects, MultiPolygon2d & target_polygons,
+  const TrajectoryPoints & trajectory_points, const PredictedObjects & target_objects,
   PredictedObject & colliding_object);
 
 using ObjectDecelMap = std::unordered_map<ObjectType, double>;
-std::optional<CollisionPoint> get_nearest_object_collision(
-  const TrajectoryPoints & trajectory_points, const TrajectoryShape & trajectory_shape,
-  const autoware::vehicle_info_utils::VehicleInfo & vehicle_info, const PredictedObjects & objects,
-  const ObjectDecelMap & object_decel_map, const double ego_decel, const double reaction_time,
-  const double safety_margin, const double stopped_vel_th, const double lookahead_horizon,
-  MultiPolygon2d & target_polygons, PredictedObject & colliding_object);
 
+/**
+ * @brief Find the nearest predicted object that is not longitudinally safe relative to the ego
+ * path within a time horizon.
+ * @details For each trajectory point up to `lookahead_horizon`, an RSS check is applied to the
+ * ego's and the object's predicted states to determine if the object is longitudinally safe
+ * relative to the ego path. If the object is not longitudinally safe, the object is considered to
+ * be a collision candidate. If the object's lon. velocity along ego path is below `stopped_vel_th`,
+ * the object is considered to be a collision candidate. The object with the smallest arc length
+ * along `trajectory_points` is returned as the collision point.
+ * @param trajectory_points Reference path; arc lengths and ego motion are read from these points.
+ * @param vehicle_info Used for the ego front longitudinal offset when comparing gap to safe
+ * distance.
+ * @param target_objects Predicted objects to evaluate (already filtered).
+ * @param object_decel_map Braking magnitude [m/s^2] per object type for the object stopping term in
+ * the safe-distance model.
+ * @param ego_decel Magnitude of ego deceleration [m/s^2] for the ego stopping term.
+ * @param reaction_time system reaction time [s] to respond to detected collision.
+ * @param safety_margin Extra longitudinal buffer [m] added to the computed safe distance.
+ * @param stopped_vel_th Objects with longitudinal speed along the path below this [m/s] are
+ * considered static.
+ * @param lookahead_horizon Maximum `time_from_start` along the trajectory [s] to propagate objects
+ * and ego states.
+ * @param[out] colliding_object Object with the smallest arc-length collision among unsafe cases.
+ * @return Collision geometry and arc length, or nullopt if inputs are invalid or objects are safe
+ */
+std::optional<CollisionPoint> get_nearest_object_collision(
+  const TrajectoryPoints & trajectory_points,
+  const autoware::vehicle_info_utils::VehicleInfo & vehicle_info,
+  const PredictedObjects & target_objects, const ObjectDecelMap & object_decel_map,
+  const double ego_decel, const double reaction_time, const double safety_margin,
+  const double stopped_vel_th, const double lookahead_horizon, PredictedObject & colliding_object);
+
+/// Filters predicted objects by semantic type, speed, and spatial relationship to the trajectory.
 struct ObjectFilter
 {
-  ObjectFilter(const std::vector<std::string> & object_type_strings, const double max_velocity_th)
-  : max_velocity_th_(max_velocity_th)
+  /**
+   * @brief Construct a filter from allowed type names and speed thresholds.
+   * @param object_type_strings Allowed object classes (see string_to_object_type).
+   * @param max_velocity_th Remove objects with longitudinal twist.x above this [m/s].
+   * @param stopped_velocity_th Used when filtering by target area for "moving" vs stopped.
+   * @param max_lateral_velocity_th Lateral speed threshold for the exiting-object heuristic [m/s].
+   */
+  ObjectFilter(
+    const std::vector<std::string> & object_type_strings, const double max_velocity_th,
+    const double stopped_velocity_th, const double max_lateral_velocity_th)
+  : max_velocity_th_(max_velocity_th),
+    stopped_velocity_th_(stopped_velocity_th),
+    max_lateral_velocity_th_(max_lateral_velocity_th)
   {
     for (const auto & object_type_string : object_type_strings) {
       if (string_to_object_type.count(object_type_string) == 0) continue;
@@ -171,6 +264,10 @@ struct ObjectFilter
     }
   }
 
+  /**
+   * @brief Remove objects that are too fast or whose class is not in the configured allow-list.
+   * @param[in,out] objects Predicted objects message updated in place.
+   */
   void filter_objects(PredictedObjects & objects)
   {
     objects.objects.erase(
@@ -187,8 +284,26 @@ struct ObjectFilter
       objects.objects.end());
   }
 
+  /**
+   * @brief Keep only objects that intersect the target region, dropping those leaving laterally.
+   * @details Objects disjoint from `target_area` are removed. Moving objects that are judged to be
+   * exiting the corridor (using lateral velocity and a short prediction horizon) are also removed.
+   * Polygons of retained objects are accumulated in `target_polygons`.
+   * @param[in,out] objects Predicted objects to filter in place.
+   * @param trajectory_points Reference path for time and geometry queries.
+   * @param target_area Multi-polygon region of interest (e.g. expanded path).
+   * @param[out] target_polygons Footprints of objects that remain after filtering.
+   */
+  void filter_by_target_area(
+    PredictedObjects & objects, const TrajectoryPoints & trajectory_points,
+    const MultiPolygon2d & target_area, MultiPolygon2d & target_polygons);
+
+  /**
+   * @brief Update allow-listed types and velocity thresholds without reconstructing the filter.
+   */
   void set_params(
-    const std::vector<std::string> & object_type_strings, const double max_velocity_th)
+    const std::vector<std::string> & object_type_strings, const double max_velocity_th,
+    const double stopped_velocity_th, const double max_lateral_velocity_th)
   {
     object_types_.clear();
     for (const auto & object_type_string : object_type_strings) {
@@ -196,15 +311,23 @@ struct ObjectFilter
       object_types_.emplace(string_to_object_type.at(object_type_string));
     }
     max_velocity_th_ = max_velocity_th;
+    stopped_velocity_th_ = stopped_velocity_th;
+    max_lateral_velocity_th_ = max_lateral_velocity_th;
   }
 
 private:
   std::unordered_set<ObjectType> object_types_;
   double max_velocity_th_;
+  double stopped_velocity_th_;
+  double max_lateral_velocity_th_;
 };
 
+/// PCL-based downsampling, cropping, clustering, and object masking for obstacle point clouds.
 struct PointCloudFilter
 {
+  /**
+   * @brief Configure voxel grid and euclidean clustering parameters used by subsequent filters.
+   */
   PointCloudFilter(
     double voxel_size_x, double voxel_size_y, double voxel_size_z, int voxel_min_size,
     double cluster_tolerance, int cluster_min_size, int cluster_max_size)
@@ -218,6 +341,9 @@ struct PointCloudFilter
     convex_hull_.setDimension(2);
   };
 
+  /**
+   * @brief Update voxel and clustering parameters at runtime.
+   */
   void set_params(
     double voxel_size_x, double voxel_size_y, double voxel_size_z, int voxel_min_size,
     double cluster_tolerance, int cluster_min_size, int cluster_max_size)
@@ -229,11 +355,27 @@ struct PointCloudFilter
     ec_.setMaxClusterSize(cluster_max_size);
   }
 
+  /**
+   * @brief Crop the cloud to an axis-aligned box, then apply voxel grid downsampling.
+   * @param[in,out] pointcloud Cloud updated in place; empty if nothing remains.
+   * @param min_x,max_x,min_y,max_y,min_z,max_z Crop box bounds in the cloud frame.
+   */
   void filter_pointcloud(
     PointCloud::Ptr & pointcloud, const double min_x, const double max_x, const double min_y,
     const double max_y, const double min_z, const double max_z);
+  /**
+   * @brief Cluster the cloud and output 2D convex hull vertices of clusters above a height cutoff.
+   * @param input Downsampled or cropped cloud.
+   * @param[out] output Hull vertices of qualifying clusters (typically for footprint tests).
+   * @param min_height A cluster is kept only if at least one point has z >= this value [m].
+   */
   void cluster_pointcloud(
     const PointCloud::Ptr & input, PointCloud::Ptr & output, const double min_height);
+  /**
+   * @brief Remove points that lie inside predicted object footprints (expanded by a small margin).
+   * @param[in,out] pointcloud Cloud to strip in place.
+   * @param objects Predicted obstacles whose shapes define removal regions.
+   */
   void filter_pointcloud_by_object(PointCloud::Ptr & pointcloud, const PredictedObjects & objects);
 
 private:
@@ -244,8 +386,18 @@ private:
   pcl::ConvexHull<pcl::PointXYZ> convex_hull_;
 };
 
+/// Temporal association of obstacle detections (objects and points) with hysteresis.
 struct ObstacleTracker
 {
+  /**
+   * @brief Construct with time buffers and association thresholds.
+   * @param on_time_buffer Seconds a track must be seen before it is considered active.
+   * @param off_time_buffer Seconds without observation before an active track may be removed.
+   * @param object_distance_th Max 2D distance to match a new detection to an existing object track.
+   * @param object_yaw_th Max yaw difference to match object detections [rad].
+   * @param pcd_distance_th Max 2D distance to match a point to an existing point track.
+   * @param grace_period Seconds to keep inactive tracks before deletion.
+   */
   ObstacleTracker(
     const double on_time_buffer, const double off_time_buffer, const double object_distance_th,
     const double object_yaw_th, const double pcd_distance_th, const double grace_period)
@@ -258,6 +410,9 @@ struct ObstacleTracker
   {
   }
 
+  /**
+   * @brief Update association and timing parameters.
+   */
   void set_params(
     const double on_time_buffer, const double off_time_buffer, const double object_distance_th,
     const double object_yaw_th, const double pcd_distance_th, const double grace_period)
@@ -276,6 +431,7 @@ struct ObstacleTracker
    * based on the on_time_buffer and off_time_buffer.
    * @param objects Input predicted objects after filtering
    * @param persistent_objects Output persistent objects
+   * @param now Current stamp used for track aging and activation timing
    */
   void update_objects(
     const PredictedObjects & objects, PredictedObjects & persistent_objects,
@@ -287,6 +443,7 @@ struct ObstacleTracker
    * based on the on_time_buffer and off_time_buffer.
    * @param points Input pointcloud
    * @param persistent_points Output persistent points
+   * @param now Current stamp used for track aging and activation timing
    */
   void update_points(
     const PointCloud::Ptr & points, PointCloud::Ptr & persistent_points, const rclcpp::Time & now);

--- a/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier_utils/obstacle_stop_utils.hpp
+++ b/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier_utils/obstacle_stop_utils.hpp
@@ -250,13 +250,16 @@ struct ObjectFilter
    * @param max_velocity_th Remove objects with longitudinal twist.x above this [m/s].
    * @param stopped_velocity_th Used when filtering by target area for "moving" vs stopped.
    * @param max_lateral_velocity_th Lateral speed threshold for the exiting-object heuristic [m/s].
+   * @param safety_buffer Safety buffer to expand object shape [m].
    */
   ObjectFilter(
     const std::vector<std::string> & object_type_strings, const double max_velocity_th,
-    const double stopped_velocity_th, const double max_lateral_velocity_th)
+    const double stopped_velocity_th, const double max_lateral_velocity_th,
+    const double safety_buffer)
   : max_velocity_th_(max_velocity_th),
     stopped_velocity_th_(stopped_velocity_th),
-    max_lateral_velocity_th_(max_lateral_velocity_th)
+    max_lateral_velocity_th_(max_lateral_velocity_th),
+    safety_buffer_(safety_buffer)
   {
     for (const auto & object_type_string : object_type_strings) {
       if (string_to_object_type.count(object_type_string) == 0) continue;
@@ -303,7 +306,8 @@ struct ObjectFilter
    */
   void set_params(
     const std::vector<std::string> & object_type_strings, const double max_velocity_th,
-    const double stopped_velocity_th, const double max_lateral_velocity_th)
+    const double stopped_velocity_th, const double max_lateral_velocity_th,
+    const double safety_buffer)
   {
     object_types_.clear();
     for (const auto & object_type_string : object_type_strings) {
@@ -313,6 +317,7 @@ struct ObjectFilter
     max_velocity_th_ = max_velocity_th;
     stopped_velocity_th_ = stopped_velocity_th;
     max_lateral_velocity_th_ = max_lateral_velocity_th;
+    safety_buffer_ = safety_buffer;
   }
 
 private:
@@ -320,6 +325,7 @@ private:
   double max_velocity_th_;
   double stopped_velocity_th_;
   double max_lateral_velocity_th_;
+  double safety_buffer_;
 };
 
 /// PCL-based downsampling, cropping, clustering, and object masking for obstacle point clouds.

--- a/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier_utils/obstacle_stop_utils.hpp
+++ b/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier_utils/obstacle_stop_utils.hpp
@@ -91,14 +91,17 @@ struct CollisionPoint
   double arc_length;
   rclcpp::Time start_time;
   bool is_active{false};
+  bool is_dynamic{false};
 
   /**
    * @brief Construct a collision sample from a point and its arc length along the reference path.
    * @param point Collision position in map frame.
    * @param arc_length Signed arc length from the start of the trajectory to the collision point.
+   * @param is_dynamic Whether this collision is dynamic.
    */
-  CollisionPoint(const geometry_msgs::msg::Point & point, const double arc_length)
-  : point(point), arc_length(arc_length)
+  CollisionPoint(
+    const geometry_msgs::msg::Point & point, const double arc_length, const bool is_dynamic = false)
+  : point(point), arc_length(arc_length), is_dynamic(is_dynamic)
   {
   }
 
@@ -113,7 +116,8 @@ struct CollisionPoint
   : point(collision_point.point),
     arc_length(collision_point.arc_length),
     start_time(start_time),
-    is_active(active)
+    is_active(active),
+    is_dynamic(collision_point.is_dynamic)
   {
   }
 };
@@ -299,6 +303,7 @@ struct ObjectFilter
    */
   void filter_by_target_area(
     PredictedObjects & objects, const TrajectoryPoints & trajectory_points,
+    const autoware::vehicle_info_utils::VehicleInfo & vehicle_info,
     const MultiPolygon2d & target_area, MultiPolygon2d & target_polygons);
 
   /**

--- a/planning/autoware_trajectory_modifier/launch/trajectory_modifier.launch.xml
+++ b/planning/autoware_trajectory_modifier/launch/trajectory_modifier.launch.xml
@@ -7,7 +7,7 @@
   <arg name="input_pointcloud_topic_name" default="/perception/obstacle_segmentation/pointcloud"/>
   <arg name="output_candidate_trajectories" default="~/output/candidate_trajectories"/>
 
-  <node pkg="autoware_trajectory_modifier" exec="autoware_trajectory_modifier_node" name="trajectory_modifier" output="screen">
+  <node pkg="autoware_trajectory_modifier" exec="autoware_trajectory_modifier_node" name="trajectory_modifier" output="screen" launch-prefix="konsole -e gdb -ex run --args">
     <param from="$(var trajectory_modifier_param_path)"/>
     <remap from="~/input/objects" to="$(var input_objects_topic_name)"/>
     <remap from="~/input/pointcloud" to="$(var input_pointcloud_topic_name)"/>

--- a/planning/autoware_trajectory_modifier/launch/trajectory_modifier.launch.xml
+++ b/planning/autoware_trajectory_modifier/launch/trajectory_modifier.launch.xml
@@ -7,13 +7,17 @@
   <arg name="input_pointcloud_topic_name" default="/perception/obstacle_segmentation/pointcloud"/>
   <arg name="output_candidate_trajectories" default="~/output/candidate_trajectories"/>
 
-  <node pkg="autoware_trajectory_modifier" exec="autoware_trajectory_modifier_node" name="trajectory_modifier" output="screen" launch-prefix="konsole -e gdb -ex run --args">
-    <param from="$(var trajectory_modifier_param_path)"/>
-    <remap from="~/input/objects" to="$(var input_objects_topic_name)"/>
-    <remap from="~/input/pointcloud" to="$(var input_pointcloud_topic_name)"/>
-    <remap from="~/input/candidate_trajectories" to="$(var input_candidate_trajectories)"/>
-    <remap from="~/input/odometry" to="$(var input_odometry)"/>
-    <remap from="~/input/acceleration" to="$(var input_acceleration)"/>
-    <remap from="~/output/candidate_trajectories" to="$(var output_candidate_trajectories)"/>
-  </node>
+  <node_container pkg="rclcpp_components" exec="component_container" name="trajectory_modifier_container" namespace="">
+    <composable_node pkg="autoware_glog_component" plugin="autoware::glog_component::GlogComponent" name="glog_component" namespace=""/>
+    <composable_node pkg="autoware_trajectory_modifier" plugin="autoware::trajectory_modifier::TrajectoryModifier" name="trajectory_modifier" namespace="">
+      <param from="$(var trajectory_modifier_param_path)"/>
+      <remap from="~/input/objects" to="$(var input_objects_topic_name)"/>
+      <remap from="~/input/pointcloud" to="$(var input_pointcloud_topic_name)"/>
+      <remap from="~/input/candidate_trajectories" to="$(var input_candidate_trajectories)"/>
+      <remap from="~/input/odometry" to="$(var input_odometry)"/>
+      <remap from="~/input/acceleration" to="$(var input_acceleration)"/>
+      <remap from="~/output/candidate_trajectories" to="$(var output_candidate_trajectories)"/>
+      <extra_arg name="use_intra_process_comms" value="false"/>
+    </composable_node>
+  </node_container>
 </launch>

--- a/planning/autoware_trajectory_modifier/launch/trajectory_modifier.launch.xml
+++ b/planning/autoware_trajectory_modifier/launch/trajectory_modifier.launch.xml
@@ -3,16 +3,16 @@
   <arg name="input_candidate_trajectories" default="/planning/diffusion_planner/candidate_trajectories"/>
   <arg name="input_odometry" default="/localization/kinematic_state"/>
   <arg name="input_acceleration" default="/localization/acceleration"/>
-  <arg name="input_objects_topic_name" default="/perception/object_recognition/objects"/>
-  <arg name="input_pointcloud_topic_name" default="/perception/obstacle_segmentation/pointcloud"/>
+  <arg name="input_objects" default="/perception/object_recognition/objects"/>
+  <arg name="input_pointcloud" default="/perception/obstacle_segmentation/pointcloud"/>
   <arg name="output_candidate_trajectories" default="~/output/candidate_trajectories"/>
 
   <node_container pkg="rclcpp_components" exec="component_container" name="trajectory_modifier_container" namespace="">
     <composable_node pkg="autoware_glog_component" plugin="autoware::glog_component::GlogComponent" name="glog_component" namespace=""/>
     <composable_node pkg="autoware_trajectory_modifier" plugin="autoware::trajectory_modifier::TrajectoryModifier" name="trajectory_modifier" namespace="">
       <param from="$(var trajectory_modifier_param_path)"/>
-      <remap from="~/input/objects" to="$(var input_objects_topic_name)"/>
-      <remap from="~/input/pointcloud" to="$(var input_pointcloud_topic_name)"/>
+      <remap from="~/input/objects" to="$(var input_objects)"/>
+      <remap from="~/input/pointcloud" to="$(var input_pointcloud)"/>
       <remap from="~/input/candidate_trajectories" to="$(var input_candidate_trajectories)"/>
       <remap from="~/input/odometry" to="$(var input_odometry)"/>
       <remap from="~/input/acceleration" to="$(var input_acceleration)"/>

--- a/planning/autoware_trajectory_modifier/param/trajectory_modifier_parameter_struct.yaml
+++ b/planning/autoware_trajectory_modifier/param/trajectory_modifier_parameter_struct.yaml
@@ -223,13 +223,6 @@ trajectory_modifier_params:
         validation:
           bounds<>: [0.0, 10.0]
         read_only: false
-      detection_range:
-        type: double
-        default_value: 50.0
-        description: Detection range [m]
-        validation:
-          bounds<>: [0.0, 200.0]
-        read_only: false
       voxel_grid_filter:
         x:
           type: double

--- a/planning/autoware_trajectory_modifier/param/trajectory_modifier_parameter_struct.yaml
+++ b/planning/autoware_trajectory_modifier/param/trajectory_modifier_parameter_struct.yaml
@@ -5,6 +5,7 @@ trajectory_modifier_params:
       [
         autoware::trajectory_modifier::plugin::ObstacleStop,
         autoware::trajectory_modifier::plugin::StopPointFixer,
+        autoware::trajectory_modifier::plugin::VelocityModifier,
       ]
     description: List of plugin names to load
     read_only: false
@@ -17,6 +18,11 @@ trajectory_modifier_params:
     type: bool
     default_value: true
     description: Enable the use of obstacle stop
+    read_only: false
+  use_velocity_modifier:
+    type: bool
+    default_value: true
+    description: Enable the use of velocity modifier
     read_only: false
   trajectory_time_step:
     type: double
@@ -59,6 +65,29 @@ trajectory_modifier_params:
       validation:
         bounds<>: [0.0, 10.0]
 
+  stopping_constraints:
+    nominal_deceleration:
+      type: double
+      default_value: 1.0
+      description: Nominal deceleration during stopping [m/s^2]
+      read_only: false
+      validation:
+        bounds<>: [0.0, 10.0]
+    maximum_deceleration:
+      type: double
+      default_value: 4.0
+      description: Maximum deceleration during stopping [m/s^2]
+      read_only: false
+      validation:
+        bounds<>: [0.0, 10.0]
+    jerk_limit:
+      type: double
+      default_value: 3.0
+      description: Jerk limit during stopping [m/s^3]
+      read_only: false
+      validation:
+        bounds<>: [0.0, 10.0]
+
   obstacle_stop:
     use_objects:
       type: bool
@@ -86,27 +115,6 @@ trajectory_modifier_params:
       description: Distance to maintain from an obstacle when stopped [m]
       validation:
         bounds<>: [0.0, 100.0]
-      read_only: false
-    nominal_stopping_decel:
-      type: double
-      default_value: 1.0
-      description: Nominal deceleration during stopping [m/s^2]
-      validation:
-        bounds<>: [0.0, 10.0]
-      read_only: false
-    maximum_stopping_decel:
-      type: double
-      default_value: 4.0
-      description: Maximum deceleration during stopping [m/s^2]
-      validation:
-        bounds<>: [0.0, 10.0]
-      read_only: false
-    stopping_jerk:
-      type: double
-      default_value: 3.0
-      description: Jerk during stopping [m/s^3]
-      validation:
-        bounds<>: [0.0, 10.0]
       read_only: false
     lateral_margin:
       type: double

--- a/planning/autoware_trajectory_modifier/param/trajectory_modifier_parameter_struct.yaml
+++ b/planning/autoware_trajectory_modifier/param/trajectory_modifier_parameter_struct.yaml
@@ -3,8 +3,8 @@ trajectory_modifier_params:
     type: string_array
     default_value:
       [
-        "autoware::trajectory_modifier::plugin::ObstacleStop",
-        "autoware::trajectory_modifier::plugin::StopPointFixer",
+        autoware::trajectory_modifier::plugin::ObstacleStop,
+        autoware::trajectory_modifier::plugin::StopPointFixer,
       ]
     description: List of plugin names to load
     read_only: false
@@ -117,7 +117,7 @@ trajectory_modifier_params:
       read_only: false
     duplicate_check_threshold:
       type: double
-      default_value: 1.0
+      default_value: 0.5
       description: Threshold to check if the stop point is already in the trajectory [m]
       validation:
         bounds<>: [0.0, 10.0]
@@ -191,6 +191,13 @@ trajectory_modifier_params:
         type: double
         default_value: 0.25
         description: Velocity threshold for target object to be considered as stopped [m/s]
+        validation:
+          bounds<>: [0.0, 10.0]
+        read_only: false
+      max_lateral_velocity_th:
+        type: double
+        default_value: 1.0
+        description: Maximum lateral velocity threshold for target object to be considered for obstacle stop [m/s]
         validation:
           bounds<>: [0.0, 10.0]
         read_only: false

--- a/planning/autoware_trajectory_modifier/param/trajectory_modifier_parameter_struct.yaml
+++ b/planning/autoware_trajectory_modifier/param/trajectory_modifier_parameter_struct.yaml
@@ -201,7 +201,13 @@ trajectory_modifier_params:
         validation:
           bounds<>: [0.0, 10.0]
         read_only: false
-
+      safety_buffer:
+        type: double
+        default_value: 0.0
+        description: Safety buffer to expand object shape [m]
+        validation:
+          bounds<>: [0.0, 10.0]
+        read_only: false
     pointcloud:
       height_buffer:
         type: double

--- a/planning/autoware_trajectory_modifier/param/trajectory_modifier_parameter_struct.yaml
+++ b/planning/autoware_trajectory_modifier/param/trajectory_modifier_parameter_struct.yaml
@@ -2,11 +2,9 @@ trajectory_modifier_params:
   plugin_names:
     type: string_array
     default_value:
-      [
-        autoware::trajectory_modifier::plugin::ObstacleStop,
-        autoware::trajectory_modifier::plugin::StopPointFixer,
-        autoware::trajectory_modifier::plugin::VelocityModifier,
-      ]
+      - autoware::trajectory_modifier::plugin::ObstacleStop
+      - autoware::trajectory_modifier::plugin::StopPointFixer
+      - autoware::trajectory_modifier::plugin::VelocityModifier
     description: List of plugin names to load
     read_only: false
   use_stop_point_fixer:

--- a/planning/autoware_trajectory_modifier/param/trajectory_modifier_parameter_struct.yaml
+++ b/planning/autoware_trajectory_modifier/param/trajectory_modifier_parameter_struct.yaml
@@ -3,10 +3,10 @@ trajectory_modifier_params:
     type: string_array
     default_value:
       [
-        autoware::trajectory_modifier::plugin::ObstacleStop,
-        autoware::trajectory_modifier::plugin::StopPointFixer,
+        "autoware::trajectory_modifier::plugin::ObstacleStop",
+        "autoware::trajectory_modifier::plugin::StopPointFixer",
       ]
-    description: List of trajectory modifier plugins to load
+    description: List of plugin names to load
     read_only: false
   use_stop_point_fixer:
     type: bool
@@ -24,7 +24,7 @@ trajectory_modifier_params:
     description: Time step for trajectory modification [s]
     read_only: false
     validation:
-      bounds<>: [0.01, 1.0]
+      bounds<>: [0.05, 1.0]
 
   stop_point_fixer:
     force_stop_long_stopped_trajectories:
@@ -115,6 +115,13 @@ trajectory_modifier_params:
       validation:
         bounds<>: [0.0, 10.0]
       read_only: false
+    duplicate_check_threshold:
+      type: double
+      default_value: 1.0
+      description: Threshold to check if the stop point is already in the trajectory [m]
+      validation:
+        bounds<>: [0.0, 10.0]
+      read_only: false
     arrived_distance_threshold:
       type: double
       default_value: 0.5
@@ -154,7 +161,7 @@ trajectory_modifier_params:
         read_only: false
       pcd_distance_th:
         type: double
-        default_value: 0.5
+        default_value: 1.0
         description: Distance threshold for pointcloud tracking [m]
         validation:
           bounds<>: [0.0, 10.0]
@@ -175,10 +182,17 @@ trajectory_modifier_params:
         read_only: false
       max_velocity_th:
         type: double
-        default_value: 1.0
+        default_value: 5.0
         description: Maximum velocity threshold for target object to be considered for obstacle stop [m/s]
         validation:
           bounds<>: [0.0, 100.0]
+        read_only: false
+      stopped_velocity_th:
+        type: double
+        default_value: 0.25
+        description: Velocity threshold for target object to be considered as stopped [m/s]
+        validation:
+          bounds<>: [0.0, 10.0]
         read_only: false
 
     pointcloud:
@@ -195,6 +209,13 @@ trajectory_modifier_params:
         description: Minimum height of pointcloud [m]
         validation:
           bounds<>: [0.0, 10.0]
+        read_only: false
+      detection_range:
+        type: double
+        default_value: 50.0
+        description: Detection range [m]
+        validation:
+          bounds<>: [0.0, 200.0]
         read_only: false
       voxel_grid_filter:
         x:
@@ -304,6 +325,13 @@ trajectory_modifier_params:
           validation:
             bounds<>: [0.0, 10.0]
           read_only: false
+      ego_decel:
+        type: double
+        default_value: 4.0
+        description: Deceleration for ego vehicle [m/s^2]
+        validation:
+          bounds<>: [0.0, 10.0]
+        read_only: false
       reaction_time:
         type: double
         default_value: 0.2
@@ -318,10 +346,10 @@ trajectory_modifier_params:
         validation:
           bounds<>: [0.0, 10.0]
         read_only: false
-      min_vel_th:
+      lookahead_horizon:
         type: double
-        default_value: 0.5
-        description: Minimum velocity threshold for object to be considered for RSS calculation [m/s]
+        default_value: 1.5
+        description: lookahead horizon for RSS calculation [s]
         validation:
           bounds<>: [0.0, 10.0]
         read_only: false

--- a/planning/autoware_trajectory_modifier/plugins.xml
+++ b/planning/autoware_trajectory_modifier/plugins.xml
@@ -12,4 +12,10 @@
       Modifies the trajectory to avoid obstacles by stopping
     </description>
   </class>
+  <class type="autoware::trajectory_modifier::plugin::VelocityModifier"
+         base_class_type="autoware::trajectory_modifier::plugin::TrajectoryModifierPluginBase">
+    <description>
+      Modifies the velocity of a trajectory to smooth the motion
+    </description>
+  </class>
 </library>

--- a/planning/autoware_trajectory_modifier/schema/trajectory_modifier.schema.json
+++ b/planning/autoware_trajectory_modifier/schema/trajectory_modifier.schema.json
@@ -118,6 +118,12 @@
               "default": 0.5,
               "minimum": 0.0
             },
+            "duplicate_check_threshold": {
+              "type": "number",
+              "description": "Threshold to check if the stop point is already in the trajectory [m]",
+              "default": 0.5,
+              "minimum": 0.0
+            },
             "arrived_distance_threshold": {
               "type": "number",
               "description": "Threshold to check if the ego vehicle has arrived at the stop point [m]",
@@ -197,6 +203,12 @@
                   "type": "number",
                   "description": "Velocity threshold for target object to be considered as stopped [m/s]",
                   "default": 0.25,
+                  "minimum": 0.0
+                },
+                "max_lateral_velocity_th": {
+                  "type": "number",
+                  "description": "Maximum lateral velocity threshold for target object to be considered for obstacle stop [m/s]",
+                  "default": 1.0,
                   "minimum": 0.0
                 }
               },

--- a/planning/autoware_trajectory_modifier/schema/trajectory_modifier.schema.json
+++ b/planning/autoware_trajectory_modifier/schema/trajectory_modifier.schema.json
@@ -154,7 +154,7 @@
                 "pcd_distance_th": {
                   "type": "number",
                   "description": "Distance threshold for pointcloud tracking [m]",
-                  "default": 0.5,
+                  "default": 1.0,
                   "minimum": 0.0
                 },
                 "grace_period": {
@@ -190,7 +190,13 @@
                 "max_velocity_th": {
                   "type": "number",
                   "description": "Maximum velocity threshold for target object [m/s]",
-                  "default": 1.0,
+                  "default": 5.0,
+                  "minimum": 0.0
+                },
+                "stopped_velocity_th": {
+                  "type": "number",
+                  "description": "Velocity threshold for target object to be considered as stopped [m/s]",
+                  "default": 0.25,
                   "minimum": 0.0
                 }
               },
@@ -335,6 +341,12 @@
                   "required": [],
                   "additionalProperties": false
                 },
+                "ego_decel": {
+                  "type": "number",
+                  "description": "Deceleration for ego vehicle [m/s^2]",
+                  "default": 4.0,
+                  "minimum": 0.0
+                },
                 "reaction_time": {
                   "type": "number",
                   "description": "Reaction time to consider for RSS calculation [s]",
@@ -347,10 +359,10 @@
                   "default": 2.0,
                   "minimum": 0.0
                 },
-                "min_vel_th": {
+                "lookahead_horizon": {
                   "type": "number",
-                  "description": "Minimum velocity threshold for object to be considered for RSS safety check [m/s]",
-                  "default": 0.5,
+                  "description": "Lookahead horizon for RSS calculation [s]",
+                  "default": 1.5,
                   "minimum": 0.0
                 }
               },

--- a/planning/autoware_trajectory_modifier/schema/trajectory_modifier.schema.json
+++ b/planning/autoware_trajectory_modifier/schema/trajectory_modifier.schema.json
@@ -210,6 +210,12 @@
                   "description": "Maximum lateral velocity threshold for target object to be considered for obstacle stop [m/s]",
                   "default": 1.0,
                   "minimum": 0.0
+                },
+                "safety_buffer": {
+                  "type": "number",
+                  "description": "Safety buffer to expand object shape [m]",
+                  "default": 0.0,
+                  "minimum": 0.0
                 }
               },
               "required": [],

--- a/planning/autoware_trajectory_modifier/schema/trajectory_modifier.schema.json
+++ b/planning/autoware_trajectory_modifier/schema/trajectory_modifier.schema.json
@@ -11,7 +11,8 @@
           "description": "List of trajectory modifier plugins to load",
           "default": [
             "autoware::trajectory_modifier::plugin::ObstacleStop",
-            "autoware::trajectory_modifier::plugin::StopPointFixer"
+            "autoware::trajectory_modifier::plugin::StopPointFixer",
+            "autoware::trajectory_modifier::plugin::VelocityModifier"
           ],
           "items": {
             "type": "string"
@@ -25,6 +26,11 @@
         "use_obstacle_stop": {
           "type": "boolean",
           "description": "Enable the obstacle stop modifier plugin",
+          "default": true
+        },
+        "use_velocity_modifier": {
+          "type": "boolean",
+          "description": "Enable the velocity modifier plugin",
           "default": true
         },
         "trajectory_time_step": {
@@ -68,6 +74,31 @@
           "required": [],
           "additionalProperties": false
         },
+        "stopping_constraints": {
+          "type": "object",
+          "properties": {
+            "nominal_deceleration": {
+              "type": "number",
+              "description": "Nominal deceleration during stopping [m/s^2]",
+              "default": 1.0,
+              "minimum": 0.0
+            },
+            "maximum_deceleration": {
+              "type": "number",
+              "description": "Maximum deceleration during stopping [m/s^2]",
+              "default": 4.0,
+              "minimum": 0.0
+            },
+            "jerk_limit": {
+              "type": "number",
+              "description": "Jerk limit during stopping [m/s^3]",
+              "default": 3.0,
+              "minimum": 0.0
+            }
+          },
+          "required": [],
+          "additionalProperties": false
+        },
         "obstacle_stop": {
           "type": "object",
           "properties": {
@@ -96,21 +127,6 @@
               "description": "Distance to maintain from an obstacle when stopped [m]",
               "default": 6.0,
               "minimum": 0.0
-            },
-            "nominal_stopping_decel": {
-              "type": "number",
-              "description": "Nominal deceleration during stopping [m/s^2]",
-              "default": 1.0
-            },
-            "maximum_stopping_decel": {
-              "type": "number",
-              "description": "Maximum deceleration during stopping [m/s^2]",
-              "default": 4.0
-            },
-            "stopping_jerk": {
-              "type": "number",
-              "description": "Jerk during stopping [m/s^3]",
-              "default": 3.0
             },
             "lateral_margin": {
               "type": "number",

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/obstacle_stop.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/obstacle_stop.cpp
@@ -19,8 +19,6 @@
 
 #include <autoware/motion_utils/distance/distance.hpp>
 #include <autoware/motion_utils/trajectory/trajectory.hpp>
-#include <autoware/trajectory/interpolator/akima_spline.hpp>
-#include <autoware/trajectory/interpolator/interpolator.hpp>
 #include <autoware/trajectory/trajectory_point.hpp>
 #include <autoware_utils/ros/marker_helper.hpp>
 #include <autoware_utils/transform/transforms.hpp>
@@ -43,10 +41,6 @@ using utils::obstacle_stop::get_trajectory_shape;
 using utils::obstacle_stop::PointCloud;
 using utils::obstacle_stop::PointCloud2;
 
-using autoware::experimental::trajectory::interpolator::AkimaSpline;
-using InterpolationTrajectory =
-  autoware::experimental::trajectory::Trajectory<autoware_planning_msgs::msg::TrajectoryPoint>;
-
 void ObstacleStop::on_initialize(const TrajectoryModifierParams & params)
 {
   const auto node_ptr = get_node_ptr();
@@ -63,13 +57,14 @@ void ObstacleStop::on_initialize(const TrajectoryModifierParams & params)
   pub_debug_text_ = node_ptr->create_publisher<StringStamped>("~/obstacle_stop/debug/text", 1);
 
   params_ = params.obstacle_stop;
+  stopping_params_ = params.stopping_constraints;
   enabled_ = params.use_obstacle_stop;
   trajectory_time_step_ = params.trajectory_time_step;
 
   {
     auto & p = params_.rss_params;
-    p.ego_decel =
-      std::clamp(p.ego_decel, params_.nominal_stopping_decel, params_.maximum_stopping_decel);
+    p.ego_decel = std::clamp(
+      p.ego_decel, stopping_params_.nominal_deceleration, stopping_params_.maximum_deceleration);
   }
 
   {
@@ -110,13 +105,14 @@ void ObstacleStop::on_initialize(const TrajectoryModifierParams & params)
 void ObstacleStop::update_params(const TrajectoryModifierParams & params)
 {
   params_ = params.obstacle_stop;
+  stopping_params_ = params.stopping_constraints;
   enabled_ = params.use_obstacle_stop;
   trajectory_time_step_ = params.trajectory_time_step;
 
   {
     auto & p = params_.rss_params;
-    p.ego_decel =
-      std::clamp(p.ego_decel, params_.nominal_stopping_decel, params_.maximum_stopping_decel);
+    p.ego_decel = std::clamp(
+      p.ego_decel, stopping_params_.nominal_deceleration, stopping_params_.maximum_deceleration);
   }
 
   {
@@ -172,8 +168,8 @@ bool ObstacleStop::is_trajectory_modification_required(
     debug_data_.trajectory_shape = get_trajectory_shape(
       traj_points, input.current_odometry->pose.pose, context_->vehicle_info,
       input.current_odometry->twist.twist.linear.x,
-      input.current_acceleration->accel.accel.linear.x, params_.nominal_stopping_decel,
-      params_.stopping_jerk, params_.stop_margin, params_.lateral_margin);
+      input.current_acceleration->accel.accel.linear.x, stopping_params_.nominal_deceleration,
+      stopping_params_.jerk_limit, params_.stop_margin, params_.lateral_margin);
   }
 
   check_obstacles(traj_points, input);
@@ -215,8 +211,8 @@ bool ObstacleStop::set_stop_point(TrajectoryPoints & traj_points, const InputDat
     const auto stop_margin = params_.stop_margin + context_->vehicle_info.max_longitudinal_offset_m;
     auto min_stopping_distance = motion_utils::calculate_stop_distance(
       input.current_odometry->twist.twist.linear.x,
-      input.current_acceleration->accel.accel.linear.x, params_.maximum_stopping_decel,
-      params_.stopping_jerk, 0.0);
+      input.current_acceleration->accel.accel.linear.x, stopping_params_.maximum_deceleration,
+      stopping_params_.jerk_limit, 0.0);
     if (!min_stopping_distance) min_stopping_distance = 0.0;
     return std::clamp(
       nearest_collision_point_->arc_length - stop_margin, min_stopping_distance.value(),
@@ -271,39 +267,6 @@ bool ObstacleStop::set_stop_point(TrajectoryPoints & traj_points, const InputDat
   return true;
 }
 
-size_t update_velocities(TrajectoryPoints & trajectory, const double jerk, const double decel)
-{
-  if (trajectory.size() < 2) return 0;
-
-  auto get_vel_accel = [&](
-                         const auto & point, const auto & ref_point) -> std::pair<double, double> {
-    const auto v_ref = ref_point.longitudinal_velocity_mps;
-    const auto a_ref = std::abs(ref_point.acceleration_mps2);
-
-    const auto ds =
-      autoware_utils_geometry::calc_distance2d(point.pose.position, ref_point.pose.position);
-    const auto da = jerk * (ds / std::max<double>(v_ref, 0.1));
-    const auto a_curr = std::min(a_ref + da, decel);
-    const auto a_avg = (a_ref + a_curr) / 2.0;
-    const auto v_curr = std::sqrt(std::max(0.0, v_ref * v_ref + 2.0 * a_avg * ds));
-    return {v_curr, -1.0 * a_curr};
-  };
-
-  const auto stop_index = trajectory.size() - 1;
-  auto vel_update_start_index = stop_index;
-  for (int i = static_cast<int>(stop_index) - 1; i > 0; --i) {
-    auto & curr = trajectory.at(i);
-    auto & next = trajectory.at(i + 1);
-    const auto [v_curr, a_curr] = get_vel_accel(curr, next);
-
-    if (v_curr >= curr.longitudinal_velocity_mps) break;
-    curr.longitudinal_velocity_mps = static_cast<float>(v_curr);
-    curr.acceleration_mps2 = static_cast<float>(a_curr);
-    vel_update_start_index = i;
-  }
-  return vel_update_start_index;
-}
-
 size_t insert_stop_point(
   TrajectoryPoints & trajectory, const double target_stop_point_arc_length,
   const double traj_length)
@@ -337,71 +300,12 @@ bool ObstacleStop::apply_stopping(
 {
   if (target_stop_point_arc_length < 1e-3) return false;
 
-  auto trajectory = traj_points;
-
   const auto stop_index = insert_stop_point(
-    trajectory, target_stop_point_arc_length, debug_data_.trajectory_shape.trajectory_length);
+    traj_points, target_stop_point_arc_length, debug_data_.trajectory_shape.trajectory_length);
 
-  trajectory.erase(trajectory.begin() + stop_index + 1, trajectory.end());
-  trajectory.back().longitudinal_velocity_mps = 0.0;
-  trajectory.back().acceleration_mps2 = 0.0;
-
-  constexpr double min_v_ref = 1.0;
-  const auto v_ref = std::max<double>(min_v_ref, trajectory.front().longitudinal_velocity_mps);
-  const auto required_decel = std::abs(v_ref * v_ref / (2.0 * target_stop_point_arc_length));
-  const auto jerk = std::abs(params_.stopping_jerk);
-  const auto decel = std::clamp(
-    required_decel, std::abs(params_.nominal_stopping_decel),
-    std::abs(params_.maximum_stopping_decel));
-
-  const auto vel_update_start_index = update_velocities(trajectory, jerk, decel);
-  const auto interpolate_start_index = vel_update_start_index > 0 ? vel_update_start_index - 1 : 0;
-
-  auto trajectory_interpolation_util =
-    InterpolationTrajectory::Builder{}
-      .set_xy_interpolator<AkimaSpline>()  // Set interpolator for x-y plane
-      .set_longitudinal_velocity_interpolator<AkimaSpline>()
-      .build(trajectory);
-  if (!trajectory_interpolation_util) {
-    RCLCPP_WARN_THROTTLE(
-      get_node_ptr()->get_logger(), *get_clock(), 1000,
-      "[TM ObstacleStop] Failed to build interpolation trajectory");
-    return false;
-  }
-
-  const auto dt = trajectory_time_step_;
-
-  if (dt < 1e-3) {
-    RCLCPP_ERROR_THROTTLE(
-      get_node_ptr()->get_logger(), *get_clock(), 1000,
-      "[TM ObstacleStop] Invalid trajectory time step: %f, unable to interpolate trajectory", dt);
-    traj_points = std::move(trajectory);
-    return true;
-  }
-
-  const auto s_max = trajectory_interpolation_util->length();
-  const auto interpolate_start_arc_length =
-    trajectory_interpolation_util->get_underlying_bases().at(interpolate_start_index);
-  trajectory_interpolation_util->align_orientation_with_trajectory_direction();
-  traj_points.erase(traj_points.begin() + interpolate_start_index + 1, traj_points.end());
-  double s_curr{interpolate_start_arc_length};
-  while (s_curr <= s_max) {
-    const auto v_curr = traj_points.back().longitudinal_velocity_mps;
-    const auto a_curr = traj_points.back().acceleration_mps2;
-    const auto t_curr = rclcpp::Duration(traj_points.back().time_from_start);
-    if (v_curr < 1e-3) break;
-
-    double ds = v_curr * dt + 0.5 * a_curr * dt * dt;
-    if (ds < 1e-3) break;
-
-    s_curr += ds;
-    const auto s_clamped = std::min(s_curr, s_max);
-
-    auto p = trajectory_interpolation_util->compute(s_clamped);
-    p.acceleration_mps2 = (p.longitudinal_velocity_mps - v_curr) / static_cast<float>(dt);
-    p.time_from_start = t_curr + rclcpp::Duration::from_seconds(dt);
-    traj_points.push_back(p);
-  }
+  traj_points.erase(traj_points.begin() + stop_index + 1, traj_points.end());
+  traj_points.back().longitudinal_velocity_mps = 0.0;
+  traj_points.back().acceleration_mps2 = 0.0;
 
   return true;
 }

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/obstacle_stop.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/obstacle_stop.cpp
@@ -231,7 +231,8 @@ bool ObstacleStop::set_stop_point(TrajectoryPoints & traj_points, const InputDat
   for (size_t i = 1; i < traj_points.size(); ++i) {
     const auto & curr = traj_points.at(i);
     const auto & prev = traj_points.at(i - 1);
-    checked_distance += autoware_utils_geometry::calc_distance2d(curr.pose.position, prev.pose.position);
+    checked_distance +=
+      autoware_utils_geometry::calc_distance2d(curr.pose.position, prev.pose.position);
     if (checked_distance > target_stop_point_arc_length + params_.duplicate_check_threshold) break;
     if (curr.longitudinal_velocity_mps < stop_velocity_threshold) {
       return skip("Preceding (or duplicate) stop point exists");

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/obstacle_stop.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/obstacle_stop.cpp
@@ -55,12 +55,21 @@ void ObstacleStop::on_initialize(const TrajectoryModifierParams & params)
 
   pub_clustered_pointcloud_ =
     node_ptr->create_publisher<PointCloud2>("~/obstacle_stop/debug/cluster_points", 1);
+  pub_filtered_pointcloud_ =
+    node_ptr->create_publisher<PointCloud2>("~/obstacle_stop/debug/filtered_points", 1);
   debug_viz_pub_ = node_ptr->create_publisher<visualization_msgs::msg::MarkerArray>(
     "~/obstacle_stop/debug/marker", 1);
+  pub_debug_text_ = node_ptr->create_publisher<StringStamped>("~/obstacle_stop/debug/text", 1);
 
   params_ = params.obstacle_stop;
   enabled_ = params.use_obstacle_stop;
   trajectory_time_step_ = params.trajectory_time_step;
+
+  {
+    auto & p = params_.rss_params;
+    p.ego_decel =
+      std::clamp(p.ego_decel, params_.nominal_stopping_decel, params_.maximum_stopping_decel);
+  }
 
   {
     const auto & p = params_.pointcloud;
@@ -101,6 +110,12 @@ void ObstacleStop::update_params(const TrajectoryModifierParams & params)
   params_ = params.obstacle_stop;
   enabled_ = params.use_obstacle_stop;
   trajectory_time_step_ = params.trajectory_time_step;
+
+  {
+    auto & p = params_.rss_params;
+    p.ego_decel =
+      std::clamp(p.ego_decel, params_.nominal_stopping_decel, params_.maximum_stopping_decel);
+  }
 
   {
     const auto & p = params_.pointcloud;
@@ -163,14 +178,18 @@ bool ObstacleStop::is_trajectory_modification_required(
     nearest_collision_point_ ? nearest_collision_point_->point : geometry_msgs::msg::Point();
   debug_data_.ego_z = input.current_odometry->pose.pose.position.z;
 
-  return nearest_collision_point_ != std::nullopt;
+  const bool is_safe = nearest_collision_point_ == std::nullopt;
+
+  publish_debug_string(is_safe);
+
+  return !is_safe;
 }
 
 bool ObstacleStop::modify_trajectory(TrajectoryPoints & traj_points, const InputData & input)
 {
   autoware_utils_debug::ScopedTimeTrack st("ObstacleStop::modify_trajectory", *get_time_keeper());
 
-  if (!enabled_) return false;
+  if (!enabled_ || traj_points.size() < 2) return false;
 
   auto trajectory = traj_points;
   utils::obstacle_stop::trim_trajectory_and_remove_duplicates(trajectory);
@@ -441,12 +460,13 @@ std::optional<CollisionPoint> ObstacleStop::check_predicted_objects(
     "ObstacleStop::check_predicted_objects", *get_time_keeper());
   if (!params_.use_objects || !input.predicted_objects || input.predicted_objects->objects.empty())
     return std::nullopt;
-  auto predicted_objects = *input.predicted_objects;
+  debug_data_.filtered_objects = *input.predicted_objects;
 
-  object_filter_->filter_objects(predicted_objects);
+  object_filter_->filter_objects(debug_data_.filtered_objects);
 
   PredictedObjects active_objects;
-  obstacle_tracker_->update_objects(predicted_objects, active_objects, get_clock()->now());
+  obstacle_tracker_->update_objects(
+    debug_data_.filtered_objects, active_objects, get_clock()->now());
 
   autoware_perception_msgs::msg::PredictedObject colliding_object;
   auto collision_point = std::invoke([&]() -> std::optional<CollisionPoint> {
@@ -457,10 +477,9 @@ std::optional<CollisionPoint> ObstacleStop::check_predicted_objects(
     }
     return get_nearest_object_collision(
       traj_points, debug_data_.trajectory_shape, context_->vehicle_info, active_objects,
-      object_decel_map_, input.current_odometry->twist.twist.linear.x,
-      params_.nominal_stopping_decel, params_.rss_params.reaction_time,
-      params_.rss_params.safety_margin, params_.rss_params.min_vel_th, debug_data_.target_polygons,
-      colliding_object);
+      object_decel_map_, params_.rss_params.ego_decel, params_.rss_params.reaction_time,
+      params_.rss_params.safety_margin, params_.objects.stopped_velocity_th,
+      params_.rss_params.lookahead_horizon, debug_data_.target_polygons, colliding_object);
   });
 
   if (collision_point) debug_data_.colliding_object = colliding_object;
@@ -521,11 +540,16 @@ std::optional<CollisionPoint> ObstacleStop::check_pointcloud(
   }
 
   {
-    const auto cluster_pointcloud = std::make_shared<sensor_msgs::msg::PointCloud2>();
-    pcl::toROSMsg(*clustered_points, *cluster_pointcloud);
-    cluster_pointcloud->header.stamp = input.obstacle_pointcloud->header.stamp;
-    cluster_pointcloud->header.frame_id = "map";
-    debug_data_.cluster_points = cluster_pointcloud;
+    const auto cluster_pointcloud_msg = std::make_shared<sensor_msgs::msg::PointCloud2>();
+    const auto filtered_pointcloud_msg = std::make_shared<sensor_msgs::msg::PointCloud2>();
+    pcl::toROSMsg(*clustered_points, *cluster_pointcloud_msg);
+    pcl::toROSMsg(*filtered_pointcloud, *filtered_pointcloud_msg);
+    cluster_pointcloud_msg->header.stamp = input.obstacle_pointcloud->header.stamp;
+    cluster_pointcloud_msg->header.frame_id = "map";
+    filtered_pointcloud_msg->header.stamp = input.obstacle_pointcloud->header.stamp;
+    filtered_pointcloud_msg->header.frame_id = "map";
+    debug_data_.cluster_points = cluster_pointcloud_msg;
+    debug_data_.filtered_points = filtered_pointcloud_msg;
   }
 
   if (input.predicted_objects && !input.predicted_objects->objects.empty()) {
@@ -548,8 +572,34 @@ std::optional<CollisionPoint> ObstacleStop::check_pointcloud(
   return collision_point;
 }
 
+void ObstacleStop::publish_debug_string(bool is_safe) const
+{
+  const auto filtered_pcd_size =
+    debug_data_.filtered_points ? debug_data_.filtered_points->data.size() : 0;
+  const auto cluster_pcd_size =
+    debug_data_.cluster_points ? debug_data_.cluster_points->data.size() : 0;
+  std::ostringstream ss;
+  ss << std::fixed << std::setprecision(2) << std::boolalpha;
+  ss << "OBSTACLE STOP MODIFIER: " << "\n";
+  ss << "\t\t" << "SAFE: " << is_safe << "\n";
+  ss << "\t\t" << "OBJECTS: " << debug_data_.filtered_objects.objects.size() << " --> "
+     << debug_data_.target_polygons.size() << "\n";
+  ss << "\t\t" << "POINTCLOUD: " << filtered_pcd_size << " --> " << cluster_pcd_size << " --> "
+     << debug_data_.target_pcd_points.size() << "\n";
+  if (nearest_collision_point_) {
+    ss << "\t\t" << "DISTANCE TO COLLISION: " << nearest_collision_point_->arc_length << " m"
+       << "\n";
+  }
+
+  StringStamped string_stamp;
+  string_stamp.stamp = get_clock()->now();
+  string_stamp.data = ss.str();
+  pub_debug_text_->publish(string_stamp);
+}
+
 void ObstacleStop::publish_debug_data(const std::string & ns) const
 {
+  if (debug_data_.filtered_points) pub_filtered_pointcloud_->publish(*debug_data_.filtered_points);
   if (debug_data_.cluster_points) pub_clustered_pointcloud_->publish(*debug_data_.cluster_points);
 
   MarkerArray marker_array;

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/obstacle_stop.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/obstacle_stop.cpp
@@ -193,7 +193,7 @@ bool ObstacleStop::modify_trajectory(TrajectoryPoints & traj_points, const Input
 
   auto trajectory = traj_points;
   utils::obstacle_stop::trim_trajectory_and_remove_duplicates(trajectory);
-  if (trajectory.empty()) return false;
+  if (trajectory.size() < 2) return false;
 
   if (!is_trajectory_modification_required(trajectory, input)) return false;
 

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/obstacle_stop.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/obstacle_stop.cpp
@@ -81,8 +81,8 @@ void ObstacleStop::on_initialize(const TrajectoryModifierParams & params)
 
   {
     const auto & p = params_.objects;
-    object_filter_ =
-      std::make_unique<utils::obstacle_stop::ObjectFilter>(p.object_types, p.max_velocity_th);
+    object_filter_ = std::make_unique<utils::obstacle_stop::ObjectFilter>(
+      p.object_types, p.max_velocity_th, p.stopped_velocity_th, p.max_lateral_velocity_th);
   }
 
   {
@@ -127,7 +127,8 @@ void ObstacleStop::update_params(const TrajectoryModifierParams & params)
 
   {
     const auto & p = params_.objects;
-    object_filter_->set_params(p.object_types, p.max_velocity_th);
+    object_filter_->set_params(
+      p.object_types, p.max_velocity_th, p.stopped_velocity_th, p.max_lateral_velocity_th);
   }
 
   {
@@ -226,16 +227,15 @@ bool ObstacleStop::set_stop_point(TrajectoryPoints & traj_points, const InputDat
     return false;
   };
 
-  constexpr double zero_velocity_threshold = 0.01;
+  constexpr double stop_velocity_threshold = 0.01;
   auto checked_distance = 0.0;
   for (size_t i = 1; i < traj_points.size(); ++i) {
     const auto & curr = traj_points.at(i);
     const auto & prev = traj_points.at(i - 1);
-    checked_distance +=
-      autoware_utils_geometry::calc_distance2d(curr.pose.position, prev.pose.position);
-    if (curr.longitudinal_velocity_mps > zero_velocity_threshold) continue;
-    if (checked_distance < target_stop_point_arc_length) {
-      return skip("Preceding stop point exists");
+    checked_distance += autoware_utils_geometry::calc_distance2d(curr.pose.position, prev.pose.position);
+    if (checked_distance > target_stop_point_arc_length + params_.duplicate_check_threshold) break;
+    if (curr.longitudinal_velocity_mps < stop_velocity_threshold) {
+      return skip("Preceding (or duplicate) stop point exists");
     }
   }
 
@@ -468,18 +468,19 @@ std::optional<CollisionPoint> ObstacleStop::check_predicted_objects(
   obstacle_tracker_->update_objects(
     debug_data_.filtered_objects, active_objects, get_clock()->now());
 
+  object_filter_->filter_by_target_area(
+    active_objects, traj_points, debug_data_.trajectory_shape.polygon, debug_data_.target_polygons);
+
   autoware_perception_msgs::msg::PredictedObject colliding_object;
   auto collision_point = std::invoke([&]() -> std::optional<CollisionPoint> {
     if (!params_.rss_params.enable) {
-      return get_nearest_object_collision(
-        traj_points, debug_data_.trajectory_shape, active_objects, debug_data_.target_polygons,
-        colliding_object);
+      return get_nearest_object_collision(traj_points, active_objects, colliding_object);
     }
     return get_nearest_object_collision(
-      traj_points, debug_data_.trajectory_shape, context_->vehicle_info, active_objects,
-      object_decel_map_, params_.rss_params.ego_decel, params_.rss_params.reaction_time,
+      traj_points, context_->vehicle_info, active_objects, object_decel_map_,
+      params_.rss_params.ego_decel, params_.rss_params.reaction_time,
       params_.rss_params.safety_margin, params_.objects.stopped_velocity_th,
-      params_.rss_params.lookahead_horizon, debug_data_.target_polygons, colliding_object);
+      params_.rss_params.lookahead_horizon, colliding_object);
   });
 
   if (collision_point) debug_data_.colliding_object = colliding_object;

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/obstacle_stop.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/obstacle_stop.cpp
@@ -379,7 +379,8 @@ std::optional<CollisionPoint> ObstacleStop::check_predicted_objects(
     debug_data_.filtered_objects, active_objects, get_clock()->now());
 
   object_filter_->filter_by_target_area(
-    active_objects, traj_points, debug_data_.trajectory_shape.polygon, debug_data_.target_polygons);
+    active_objects, traj_points, context_->vehicle_info, debug_data_.trajectory_shape.polygon,
+    debug_data_.target_polygons);
 
   autoware_perception_msgs::msg::PredictedObject colliding_object;
   auto collision_point = std::invoke([&]() -> std::optional<CollisionPoint> {
@@ -495,6 +496,9 @@ void ObstacleStop::publish_debug_string(bool is_safe) const
      << debug_data_.target_pcd_points.size() << "\n";
   if (nearest_collision_point_) {
     ss << "\t\t" << "DISTANCE TO COLLISION: " << nearest_collision_point_->arc_length << " m"
+       << "\n";
+    ss << "\t\t"
+       << "OBSTACLE TYPE: " << (nearest_collision_point_->is_dynamic ? "DYNAMIC" : "STATIC")
        << "\n";
   }
 

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/obstacle_stop.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/obstacle_stop.cpp
@@ -367,8 +367,8 @@ std::optional<CollisionPoint> ObstacleStop::check_predicted_objects(
 {
   autoware_utils_debug::ScopedTimeTrack st(
     "ObstacleStop::check_predicted_objects", *get_time_keeper());
-  if (!params_.use_objects || !input.predicted_objects || input.predicted_objects->objects.empty())
-    return std::nullopt;
+  if (!params_.use_objects || !input.predicted_objects) return std::nullopt;
+
   debug_data_.filtered_objects = *input.predicted_objects;
 
   object_filter_->filter_objects(debug_data_.filtered_objects);
@@ -401,11 +401,7 @@ std::optional<CollisionPoint> ObstacleStop::check_pointcloud(
   const TrajectoryPoints & traj_points, const InputData & input)
 {
   autoware_utils_debug::ScopedTimeTrack st("ObstacleStop::check_pointcloud", *get_time_keeper());
-  if (
-    !params_.use_pointcloud || !input.obstacle_pointcloud ||
-    input.obstacle_pointcloud->data.empty()) {
-    return std::nullopt;
-  }
+  if (!params_.use_pointcloud || !input.obstacle_pointcloud) return std::nullopt;
 
   PointCloud::Ptr filtered_pointcloud(new PointCloud);
   pcl::fromROSMsg(*input.obstacle_pointcloud, *filtered_pointcloud);

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/obstacle_stop.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/obstacle_stop.cpp
@@ -82,7 +82,8 @@ void ObstacleStop::on_initialize(const TrajectoryModifierParams & params)
   {
     const auto & p = params_.objects;
     object_filter_ = std::make_unique<utils::obstacle_stop::ObjectFilter>(
-      p.object_types, p.max_velocity_th, p.stopped_velocity_th, p.max_lateral_velocity_th);
+      p.object_types, p.max_velocity_th, p.stopped_velocity_th, p.max_lateral_velocity_th,
+      p.safety_buffer);
   }
 
   {
@@ -128,7 +129,8 @@ void ObstacleStop::update_params(const TrajectoryModifierParams & params)
   {
     const auto & p = params_.objects;
     object_filter_->set_params(
-      p.object_types, p.max_velocity_th, p.stopped_velocity_th, p.max_lateral_velocity_th);
+      p.object_types, p.max_velocity_th, p.stopped_velocity_th, p.max_lateral_velocity_th,
+      p.safety_buffer);
   }
 
   {

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/obstacle_stop.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/obstacle_stop.cpp
@@ -18,6 +18,7 @@
 #include "autoware/trajectory_modifier/trajectory_modifier_utils/utils.hpp"
 
 #include <autoware/motion_utils/distance/distance.hpp>
+#include <autoware/motion_utils/trajectory/trajectory.hpp>
 #include <autoware/trajectory/interpolator/akima_spline.hpp>
 #include <autoware/trajectory/interpolator/interpolator.hpp>
 #include <autoware/trajectory/trajectory_point.hpp>
@@ -259,8 +260,10 @@ bool ObstacleStop::set_stop_point(TrajectoryPoints & traj_points, const InputDat
 
   const auto & stop_pose = traj_points.back().pose;
   const auto & ego_pose = input.current_odometry->pose.pose;
-  planning_factor_interface_->add(
-    traj_points, ego_pose, stop_pose, PlanningFactor::STOP, safety_factors_);
+  auto distance =
+    motion_utils::calcSignedArcLength(traj_points, ego_pose.position, stop_pose.position);
+  if (std::isnan(distance)) distance = 0.0;
+  planning_factor_interface_->add(distance, stop_pose, PlanningFactor::STOP, safety_factors_);
 
   RCLCPP_WARN_THROTTLE(
     get_node_ptr()->get_logger(), *get_clock(), 1000,

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/velocity_modifier.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/velocity_modifier.cpp
@@ -1,0 +1,178 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/trajectory_modifier/trajectory_modifier_plugins/velocity_modifier.hpp"
+
+#include <autoware/trajectory/interpolator/akima_spline.hpp>
+#include <autoware/trajectory/interpolator/interpolator.hpp>
+#include <autoware/trajectory/trajectory_point.hpp>
+
+#include <algorithm>
+#include <utility>
+
+namespace autoware::trajectory_modifier::plugin
+{
+
+using autoware::experimental::trajectory::interpolator::AkimaSpline;
+using InterpolationTrajectory =
+  autoware::experimental::trajectory::Trajectory<autoware_planning_msgs::msg::TrajectoryPoint>;
+
+void VelocityModifier::on_initialize(const TrajectoryModifierParams & params)
+{
+  enabled_ = params.use_velocity_modifier;
+  trajectory_time_step_ = params.trajectory_time_step;
+  params_ = params.stopping_constraints;
+}
+
+bool VelocityModifier::is_trajectory_modification_required(
+  const TrajectoryPoints & traj_points, [[maybe_unused]] const InputData & input)
+{
+  if (traj_points.size() < 2) return false;
+
+  const auto stop_idx = autoware::motion_utils::searchZeroVelocityIndex(traj_points);
+  if (!stop_idx.has_value() || stop_idx.value() == 0) return false;
+
+  const auto & stop_point = traj_points.at(stop_idx.value());
+  const auto & prev_point = traj_points.at(stop_idx.value() - 1);
+
+  const auto ds =
+    autoware_utils_geometry::calc_distance2d(stop_point.pose.position, prev_point.pose.position);
+
+  const auto v_prev = prev_point.longitudinal_velocity_mps;
+
+  static constexpr double epsilon = 1e-3;
+  if (ds < epsilon) return v_prev > epsilon;
+
+  const auto expected_accel = -1.0 * (v_prev * v_prev) / (2.0 * ds);
+  const auto a_prev = prev_point.acceleration_mps2;
+
+  constexpr double tolerance = 0.1;
+  return std::abs(a_prev - expected_accel) > tolerance;
+}
+
+bool VelocityModifier::modify_trajectory(TrajectoryPoints & traj_points, const InputData & input)
+{
+  if (!enabled_ || !is_trajectory_modification_required(traj_points, input)) return false;
+
+  const auto stop_idx = autoware::motion_utils::searchZeroVelocityIndex(traj_points);
+  if (!stop_idx.has_value() || stop_idx.value() == 0) return false;
+
+  auto trajectory = traj_points;
+
+  trajectory.erase(trajectory.begin() + stop_idx.value() + 1, trajectory.end());
+  trajectory.back().longitudinal_velocity_mps = 0.0;
+  trajectory.back().acceleration_mps2 = 0.0;
+
+  const auto traj_length = motion_utils::calcArcLength(trajectory);
+
+  constexpr double min_v_ref = 1.0;
+  const auto v_ref = std::max<double>(min_v_ref, trajectory.front().longitudinal_velocity_mps);
+  const auto required_decel = std::abs(v_ref * v_ref / (2.0 * traj_length));
+  const auto jerk = std::abs(params_.jerk_limit);
+  const auto decel = std::clamp(
+    required_decel, std::abs(params_.nominal_deceleration), std::abs(params_.maximum_deceleration));
+
+  const auto vel_update_start_index = update_velocities(trajectory, jerk, decel);
+  const auto interpolate_start_index = vel_update_start_index > 0 ? vel_update_start_index - 1 : 0;
+
+  auto trajectory_interpolation_util =
+    InterpolationTrajectory::Builder{}
+      .set_xy_interpolator<AkimaSpline>()  // Set interpolator for x-y plane
+      .set_longitudinal_velocity_interpolator<AkimaSpline>()
+      .build(trajectory);
+  if (!trajectory_interpolation_util) {
+    RCLCPP_WARN_THROTTLE(
+      get_node_ptr()->get_logger(), *get_clock(), 1000,
+      "[TM VelocityModifier] Failed to build interpolation trajectory");
+    return false;
+  }
+
+  const auto dt = trajectory_time_step_;
+
+  if (dt < 1e-3) {
+    RCLCPP_ERROR_THROTTLE(
+      get_node_ptr()->get_logger(), *get_clock(), 1000,
+      "[TM VelocityModifier] Invalid trajectory time step: %f, unable to interpolate trajectory",
+      dt);
+    traj_points = std::move(trajectory);
+    return true;
+  }
+
+  const auto s_max = trajectory_interpolation_util->length();
+  const auto interpolate_start_arc_length =
+    trajectory_interpolation_util->get_underlying_bases().at(interpolate_start_index);
+  trajectory_interpolation_util->align_orientation_with_trajectory_direction();
+  traj_points.erase(traj_points.begin() + interpolate_start_index + 1, traj_points.end());
+  double s_curr{interpolate_start_arc_length};
+  while (s_curr <= s_max) {
+    const auto v_curr = traj_points.back().longitudinal_velocity_mps;
+    const auto a_curr = traj_points.back().acceleration_mps2;
+    const auto t_curr = rclcpp::Duration(traj_points.back().time_from_start);
+    if (v_curr < 1e-3) break;
+
+    double ds = v_curr * dt + 0.5 * a_curr * dt * dt;
+    if (ds < 1e-3) break;
+
+    s_curr += ds;
+    const auto s_clamped = std::min(s_curr, s_max);
+
+    auto p = trajectory_interpolation_util->compute(s_clamped);
+    p.acceleration_mps2 = (p.longitudinal_velocity_mps - v_curr) / static_cast<float>(dt);
+    p.time_from_start = t_curr + rclcpp::Duration::from_seconds(dt);
+    traj_points.push_back(p);
+  }
+
+  return true;
+}
+
+size_t VelocityModifier::update_velocities(
+  TrajectoryPoints & trajectory, const double jerk, const double decel) const
+{
+  if (trajectory.size() < 2) return 0;
+
+  auto get_vel_accel = [&](
+                         const auto & point, const auto & ref_point) -> std::pair<double, double> {
+    const auto v_ref = ref_point.longitudinal_velocity_mps;
+    const auto a_ref = std::abs(ref_point.acceleration_mps2);
+
+    const auto ds =
+      autoware_utils_geometry::calc_distance2d(point.pose.position, ref_point.pose.position);
+    const auto da = jerk * (ds / std::max<double>(v_ref, 0.1));
+    const auto a_curr = std::min(a_ref + da, decel);
+    const auto a_avg = (a_ref + a_curr) / 2.0;
+    const auto v_curr = std::sqrt(std::max(0.0, v_ref * v_ref + 2.0 * a_avg * ds));
+    return {v_curr, -1.0 * a_curr};
+  };
+
+  const auto stop_index = trajectory.size() - 1;
+  auto vel_update_start_index = stop_index;
+  for (int i = static_cast<int>(stop_index) - 1; i > 0; --i) {
+    auto & curr = trajectory.at(i);
+    auto & next = trajectory.at(i + 1);
+    const auto [v_curr, a_curr] = get_vel_accel(curr, next);
+
+    if (v_curr >= curr.longitudinal_velocity_mps) break;
+    curr.longitudinal_velocity_mps = static_cast<float>(v_curr);
+    curr.acceleration_mps2 = static_cast<float>(a_curr);
+    vel_update_start_index = i;
+  }
+  return vel_update_start_index;
+}
+
+}  // namespace autoware::trajectory_modifier::plugin
+
+#include <pluginlib/class_list_macros.hpp>
+PLUGINLIB_EXPORT_CLASS(
+  autoware::trajectory_modifier::plugin::VelocityModifier,
+  autoware::trajectory_modifier::plugin::TrajectoryModifierPluginBase)

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/velocity_modifier.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/velocity_modifier.cpp
@@ -129,7 +129,12 @@ bool VelocityModifier::modify_trajectory(TrajectoryPoints & traj_points, const I
     const auto s_clamped = std::min(s_curr, s_max);
 
     auto p = trajectory_interpolation_util->compute(s_clamped);
-    p.acceleration_mps2 = (p.longitudinal_velocity_mps - v_curr) / static_cast<float>(dt);
+    if (s_clamped >= s_max - 1e-6) {
+      p.longitudinal_velocity_mps = 0.0f;
+      p.acceleration_mps2 = 0.0f;
+    } else {
+      p.acceleration_mps2 = (p.longitudinal_velocity_mps - v_curr) / static_cast<float>(dt);
+    }
     p.time_from_start = t_curr + rclcpp::Duration::from_seconds(dt);
     traj_points.push_back(p);
   }

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/velocity_modifier.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/velocity_modifier.cpp
@@ -19,6 +19,7 @@
 #include <autoware/trajectory/trajectory_point.hpp>
 
 #include <algorithm>
+#include <cmath>
 #include <utility>
 
 namespace autoware::trajectory_modifier::plugin

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
@@ -204,7 +204,7 @@ std::optional<CollisionPoint> get_nearest_pcd_collision(
   const TrajectoryPoints & trajectory_points, const TrajectoryShape & trajectory_shape,
   const PointCloud::Ptr & pointcloud, std::vector<geometry_msgs::msg::Point> & target_pcd_points)
 {
-  if (pointcloud->empty()) return std::nullopt;
+  if (pointcloud->empty() || trajectory_points.size() < 2) return std::nullopt;
 
   PointCloud::Ptr pointcloud_in_polygon(new PointCloud);
   for (const auto & point : *pointcloud) {
@@ -237,7 +237,7 @@ std::optional<CollisionPoint> get_nearest_object_collision(
   const PredictedObjects & objects, MultiPolygon2d & target_polygons,
   PredictedObject & colliding_object)
 {
-  if (objects.objects.empty()) return std::nullopt;
+  if (objects.objects.empty() || trajectory_points.size() < 2) return std::nullopt;
 
   auto min_arc_length = std::numeric_limits<double>::max();
   geometry_msgs::msg::Point nearest_collision_point;
@@ -327,7 +327,7 @@ std::optional<CollisionPoint> get_nearest_object_collision(
   const double safety_margin, const double stopped_vel_th, const double lookahead_horizon,
   MultiPolygon2d & target_polygons, PredictedObject & colliding_object)
 {
-  if (objects.objects.empty()) return std::nullopt;
+  if (objects.objects.empty() || trajectory_points.size() < 2) return std::nullopt;
 
   const auto ego_front_offset = vehicle_info.max_longitudinal_offset_m;
 
@@ -351,7 +351,6 @@ std::optional<CollisionPoint> get_nearest_object_collision(
     const auto object_pose = object.kinematics.initial_pose_with_covariance.pose;
     const auto object_polygon = autoware_utils::to_polygon2d(object_pose, object.shape);
     if (boost::geometry::disjoint(object_polygon, trajectory_shape.polygon)) {
-      RCLCPP_INFO(rclcpp::get_logger("ObstacleStop"), "Object is out of trajectory shape");
       continue;
     }
     target_objects.objects.push_back(object);

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
@@ -504,7 +504,8 @@ void ObjectFilter::filter_by_target_area(
       rclcpp::Duration(trajectory_points.at(nearest_seg_idx).time_from_start).seconds();
     const auto lon_offset_dist =
       motion_utils::calcSignedArcLength(trajectory_points, nearest_seg_idx, object_pose.position);
-    const auto nearest_seg_vel = trajectory_points.at(nearest_seg_idx).longitudinal_velocity_mps;
+    const auto nearest_seg_vel =
+      std::max<double>(trajectory_points.at(nearest_seg_idx).longitudinal_velocity_mps, 1e-3);
     const auto ego_front_time_offset = ego_front_offset / nearest_seg_vel;
     const auto t_to_obj =
       t_to_nearest_seg + (lon_offset_dist / nearest_seg_vel) - ego_front_time_offset - time_buffer;

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
@@ -51,9 +51,10 @@ double get_detection_length(
 {
   // add a buffer length to account for the reaction time of the vehicle
   constexpr double buffer_length = 1.0;
+  constexpr double time_delay = 0.3;
   const auto margin = stop_margin + buffer_length;
-  auto nominal_stopping_distance =
-    autoware::motion_utils::calculate_stop_distance(current_vel, current_accel, decel, jerk, 0.0);
+  auto nominal_stopping_distance = autoware::motion_utils::calculate_stop_distance(
+    current_vel, current_accel, decel, jerk, time_delay);
   if (nominal_stopping_distance) {
     return nominal_stopping_distance.value() + margin;
   }
@@ -264,6 +265,46 @@ std::optional<CollisionPoint> get_nearest_object_collision(
   return CollisionPoint(nearest_collision_point, min_arc_length);
 }
 
+ObjectState get_object_state_at_time(
+  const TrajectoryPoints & trajectory_points, const PredictedObject & object, const double t)
+{
+  const auto predicted_obj_pose = std::invoke([&]() -> geometry_msgs::msg::Pose {
+    if (object.kinematics.predicted_paths.empty())
+      return object.kinematics.initial_pose_with_covariance.pose;
+    const auto & pred_path = object.kinematics.predicted_paths.front();
+    size_t pred_pose_index = t / rclcpp::Duration(pred_path.time_step).seconds();
+    pred_pose_index = std::min(pred_pose_index, pred_path.path.size() - 1);
+    return pred_path.path.at(pred_pose_index);
+  });
+
+  const auto nearest_seg =
+    motion_utils::findNearestSegmentIndex(trajectory_points, predicted_obj_pose.position);
+  const auto p1 = trajectory_points.at(nearest_seg).pose.position;
+  const auto p2 = trajectory_points.at(nearest_seg + 1).pose.position;
+  auto lon_vel = std::invoke([&]() -> double {
+    const auto traj_dir = Eigen::Vector2d(p2.x - p1.x, p2.y - p1.y).normalized();
+    const auto obj_yaw = tf2::getYaw(predicted_obj_pose.orientation);
+    const auto obj_dir = Eigen::Vector2d(std::cos(obj_yaw), std::sin(obj_yaw));
+    const auto obj_lon_vel = object.kinematics.initial_twist_with_covariance.twist.linear.x;
+    return std::max(0.0, obj_lon_vel * obj_dir.dot(traj_dir));
+  });
+
+  const auto obj_polygon = autoware_utils::to_polygon2d(predicted_obj_pose, object.shape);
+  auto min_arc_length = std::numeric_limits<double>::max();
+  geometry_msgs::msg::Point nearest_point;
+  for (const auto & point : obj_polygon.outer()) {
+    const geometry_msgs::msg::Point p =
+      geometry_msgs::msg::Point().set__x(point.x()).set__y(point.y());
+    const auto l = motion_utils::calcSignedArcLength(trajectory_points, 0, p);
+    if (l < min_arc_length) {
+      min_arc_length = l;
+      nearest_point = p;
+    }
+  }
+
+  return ObjectState{std::max(0.0, min_arc_length), lon_vel, nearest_point};
+}
+
 double get_safe_distance(
   const double ego_vel, const double object_vel, const double ego_decel, const double object_decel,
   const double reaction_time, const double safety_margin)
@@ -282,82 +323,67 @@ double get_safe_distance(
 std::optional<CollisionPoint> get_nearest_object_collision(
   const TrajectoryPoints & trajectory_points, const TrajectoryShape & trajectory_shape,
   const autoware::vehicle_info_utils::VehicleInfo & vehicle_info, const PredictedObjects & objects,
-  const ObjectDecelMap & object_decel_map, const double ego_vel, const double ego_decel,
-  const double reaction_time, const double safety_margin, const double min_vel_th,
+  const ObjectDecelMap & object_decel_map, const double ego_decel, const double reaction_time,
+  const double safety_margin, const double stopped_vel_th, const double lookahead_horizon,
   MultiPolygon2d & target_polygons, PredictedObject & colliding_object)
 {
   if (objects.objects.empty()) return std::nullopt;
 
-  auto lon_vel = [&](const auto & object) -> std::optional<double> {
-    const auto nearest_seg = motion_utils::findNearestSegmentIndex(
-      trajectory_points, object.kinematics.initial_pose_with_covariance.pose.position);
-    if (!nearest_seg) return std::nullopt;
-    const auto traj_yaw = tf2::getYaw(trajectory_points.at(nearest_seg).pose.orientation);
-    const auto traj_direction = Eigen::Vector2d(std::cos(traj_yaw), std::sin(traj_yaw));
-    const auto obj_vel = object.kinematics.initial_twist_with_covariance.twist.linear;
-    const auto obj_vel_vector = Eigen::Vector2d(obj_vel.x, obj_vel.y);
-    return std::max(0.0, obj_vel_vector.dot(traj_direction));
-  };
+  const auto ego_front_offset = vehicle_info.max_longitudinal_offset_m;
 
-  auto safe_distance = [&](const auto & object) -> std::optional<double> {
-    if (object.classification.empty()) return std::nullopt;
+  auto is_safe = [&](
+                   const auto & object, const double obj_arc_length, const double obj_lon_vel,
+                   const double ego_arc_length, const double ego_vel) -> bool {
+    if (object.classification.empty()) return false;
     const auto obj_type = classification_to_object_type.at(object.classification.front().label);
-    if (!object_decel_map.count(obj_type)) return std::nullopt;
+    if (!object_decel_map.count(obj_type)) return false;
     const auto obj_decel = object_decel_map.at(obj_type);
-    const auto obj_vel = lon_vel(object);
-    if (!obj_vel || obj_vel.value() < min_vel_th) return std::nullopt;
-    return get_safe_distance(
-      ego_vel, obj_vel.value(), ego_decel, obj_decel, reaction_time, safety_margin);
+    if (obj_lon_vel < stopped_vel_th) return false;
+    const auto safe_dist =
+      get_safe_distance(ego_vel, obj_lon_vel, ego_decel, obj_decel, reaction_time, safety_margin);
+    const auto ego_front_arc_length = ego_arc_length + ego_front_offset;
+    const auto relative_arc_length = std::max(0.0, obj_arc_length - ego_front_arc_length);
+    return relative_arc_length - safe_dist > 1e-3;
   };
 
-  const auto ego_front_arc_length =
-    std::max(0.0, trajectory_shape.trajectory_length - trajectory_shape.forward_traj_length) +
-    vehicle_info.max_longitudinal_offset_m;
-
-  auto min_arc_length = std::numeric_limits<double>::max();
-  geometry_msgs::msg::Point nearest_collision_point;
-  bool found_collision = false;
+  PredictedObjects target_objects;
   for (const auto & object : objects.objects) {
     const auto object_pose = object.kinematics.initial_pose_with_covariance.pose;
     const auto object_polygon = autoware_utils::to_polygon2d(object_pose, object.shape);
     if (boost::geometry::disjoint(object_polygon, trajectory_shape.polygon)) {
+      RCLCPP_INFO(rclcpp::get_logger("ObstacleStop"), "Object is out of trajectory shape");
       continue;
     }
-
+    target_objects.objects.push_back(object);
     target_polygons.emplace_back(object_polygon);
+  }
 
-    const auto [obj_arc_length, obj_nearest_p] =
-      std::invoke([&]() -> std::pair<double, geometry_msgs::msg::Point> {
-        double arc_length = std::numeric_limits<double>::max();
-        geometry_msgs::msg::Point nearest_p;
-        for (const auto & point : object_polygon.outer()) {
-          const geometry_msgs::msg::Point p =
-            geometry_msgs::msg::Point().set__x(point.x()).set__y(point.y());
-          const auto l = motion_utils::calcSignedArcLength(trajectory_points, 0, p);
-          if (l < arc_length) {
-            arc_length = l;
-            nearest_p = p;
-          }
-        }
-        return {arc_length, nearest_p};
-      });
-
-    const auto safe_dist = safe_distance(object);
-    const auto relative_arc_length = std::max(0.0, obj_arc_length - ego_front_arc_length);
-    if (safe_dist && relative_arc_length - safe_dist.value() > 1e-3) {
-      continue;
+  auto min_obj_arc_length = std::numeric_limits<double>::max();
+  geometry_msgs::msg::Point nearest_collision_point;
+  bool found_collision = false;
+  auto curr_arc_length = 0.0;
+  auto last_p = trajectory_points.front().pose.position;
+  for (const auto & traj_p : trajectory_points) {
+    const auto t = rclcpp::Duration(traj_p.time_from_start).seconds();
+    if (t > lookahead_horizon) break;
+    curr_arc_length += autoware_utils::calc_distance2d(last_p, traj_p.pose.position);
+    const auto target_ego_vel = traj_p.longitudinal_velocity_mps;
+    for (const auto & object : target_objects.objects) {
+      const auto obj_state = get_object_state_at_time(trajectory_points, object, t);
+      if (is_safe(object, obj_state.arc_length, obj_state.lon_vel, curr_arc_length, target_ego_vel))
+        continue;
+      found_collision = true;
+      if (obj_state.arc_length < min_obj_arc_length) {
+        min_obj_arc_length = obj_state.arc_length;
+        colliding_object = object;
+        nearest_collision_point = obj_state.nearest_point;
+      }
     }
-
-    found_collision = true;
-    if (obj_arc_length < min_arc_length) {
-      min_arc_length = obj_arc_length;
-      nearest_collision_point = obj_nearest_p;
-      colliding_object = object;
-    }
+    last_p = traj_p.pose.position;
   }
 
   if (!found_collision) return std::nullopt;
-  return CollisionPoint(nearest_collision_point, min_arc_length);
+  return CollisionPoint(nearest_collision_point, min_obj_arc_length);
 }
 
 void PointCloudFilter::filter_pointcloud(

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
@@ -19,6 +19,7 @@
 #include <autoware/motion_utils/trajectory/trajectory.hpp>
 #include <autoware_utils/geometry/boost_polygon_utils.hpp>
 #include <autoware_utils/transform/transforms.hpp>
+#include <autoware_utils_geometry/geometry.hpp>
 #include <range/v3/view.hpp>
 
 #include <boost/geometry.hpp>
@@ -265,17 +266,40 @@ std::optional<CollisionPoint> get_nearest_object_collision(
   return CollisionPoint(nearest_collision_point, min_arc_length);
 }
 
+geometry_msgs::msg::Pose extrapolate_object_pose_from_kinematics(
+  const PredictedObject & object, const double t)
+{
+  const auto & initial_pose = object.kinematics.initial_pose_with_covariance.pose;
+  if (t <= 0.0) return initial_pose;
+
+  const auto obj_vel = object.kinematics.initial_twist_with_covariance.twist.linear.x;
+  const auto obj_accel = object.kinematics.initial_acceleration_with_covariance.accel.linear.x;
+  const auto dist = obj_vel * t + 0.5 * obj_accel * t * t;
+  return autoware_utils::calc_offset_pose(initial_pose, dist, 0, 0);
+}
+
 geometry_msgs::msg::Pose get_predicted_obj_pose_at_time(
   const PredictedObject & object, const double t)
 {
-  if (object.kinematics.predicted_paths.empty())
-    return object.kinematics.initial_pose_with_covariance.pose;
+  if (object.kinematics.predicted_paths.empty()) {
+    return extrapolate_object_pose_from_kinematics(object, t);
+  }
+
   const auto & pred_path = object.kinematics.predicted_paths.front();
-  if (pred_path.path.empty()) return object.kinematics.initial_pose_with_covariance.pose;
+  if (pred_path.path.size() < 2) {
+    return extrapolate_object_pose_from_kinematics(object, t);
+  }
+
   const auto dt = std::max(rclcpp::Duration(pred_path.time_step).seconds(), 1e-3);
-  size_t pred_pose_index = (t + 1e-6) / dt;
-  pred_pose_index = std::min(pred_pose_index, pred_path.path.size() - 1);
-  return pred_path.path.at(pred_pose_index);
+  const double max_time = dt * static_cast<double>(pred_path.path.size() - 1);
+  const double clamped_t = std::clamp(t, 0.0, max_time);
+
+  const auto index = static_cast<size_t>(std::floor(clamped_t / dt));
+  const size_t next_index = std::min(index + 1, pred_path.path.size() - 1);
+  const double ratio = (clamped_t - static_cast<double>(index) * dt) / dt;
+
+  return autoware_utils_geometry::calc_interpolated_pose(
+    pred_path.path.at(index), pred_path.path.at(next_index), ratio, false);
 }
 
 ObjectState get_object_state_at_time(
@@ -339,22 +363,23 @@ std::optional<CollisionPoint> get_nearest_object_collision(
 
   auto is_safe = [&](
                    const auto & object, const double obj_arc_length, const double obj_lon_vel,
-                   const double ego_arc_length, const double ego_vel) -> bool {
-    if (object.classification.empty()) return false;
+                   const double ego_arc_length, const double ego_vel) -> std::pair<bool, bool> {
+    if (object.classification.empty()) return {false, false};
     const auto obj_type = classification_to_object_type.at(object.classification.front().label);
-    if (!object_decel_map.count(obj_type)) return false;
+    if (!object_decel_map.count(obj_type)) return {false, false};
     const auto obj_decel = object_decel_map.at(obj_type);
-    if (obj_lon_vel < stopped_vel_th) return false;
+    if (obj_lon_vel < stopped_vel_th) return {false, false};
     const auto safe_dist =
       get_safe_distance(ego_vel, obj_lon_vel, ego_decel, obj_decel, reaction_time, safety_margin);
     const auto ego_front_arc_length = ego_arc_length + ego_front_offset;
     const auto relative_arc_length = std::max(0.0, obj_arc_length - ego_front_arc_length);
-    return relative_arc_length - safe_dist > 1e-3;
+    return {relative_arc_length - safe_dist > 1e-3, true};
   };
 
   auto min_obj_arc_length = std::numeric_limits<double>::max();
   geometry_msgs::msg::Point nearest_collision_point;
   bool found_collision = false;
+  bool is_dynamic_collision = false;
   auto curr_arc_length = 0.0;
   auto last_p = trajectory_points.front().pose.position;
   for (const auto & traj_p : trajectory_points) {
@@ -364,20 +389,22 @@ std::optional<CollisionPoint> get_nearest_object_collision(
     const auto target_ego_vel = traj_p.longitudinal_velocity_mps;
     for (const auto & object : target_objects.objects) {
       const auto obj_state = get_object_state_at_time(trajectory_points, object, t);
-      if (is_safe(object, obj_state.arc_length, obj_state.lon_vel, curr_arc_length, target_ego_vel))
-        continue;
+      const auto [safe, dynamic] =
+        is_safe(object, obj_state.arc_length, obj_state.lon_vel, curr_arc_length, target_ego_vel);
+      if (safe) continue;
       found_collision = true;
       if (obj_state.arc_length < min_obj_arc_length) {
         min_obj_arc_length = obj_state.arc_length;
         colliding_object = object;
         nearest_collision_point = obj_state.nearest_point;
+        is_dynamic_collision = dynamic;
       }
     }
     last_p = traj_p.pose.position;
   }
 
   if (!found_collision) return std::nullopt;
-  return CollisionPoint(nearest_collision_point, min_obj_arc_length);
+  return CollisionPoint(nearest_collision_point, min_obj_arc_length, is_dynamic_collision);
 }
 
 void PointCloudFilter::filter_pointcloud(
@@ -466,19 +493,22 @@ void PointCloudFilter::filter_pointcloud_by_object(
 
 void ObjectFilter::filter_by_target_area(
   PredictedObjects & objects, const TrajectoryPoints & trajectory_points,
+  const autoware::vehicle_info_utils::VehicleInfo & vehicle_info,
   const MultiPolygon2d & target_area, MultiPolygon2d & target_polygons)
 {
-  constexpr double time_buffer = 1.0;
+  const auto ego_front_offset = vehicle_info.max_longitudinal_offset_m;
+  constexpr double time_buffer = 0.5;
   auto time_to_obj_current_pos =
     [&](const auto & object_pose, const size_t nearest_seg_idx) -> double {
     const auto t_to_nearest_seg =
       rclcpp::Duration(trajectory_points.at(nearest_seg_idx).time_from_start).seconds();
-    if (nearest_seg_idx < trajectory_points.size() - 2) return t_to_nearest_seg - time_buffer;
     const auto lon_offset_dist =
       motion_utils::calcSignedArcLength(trajectory_points, nearest_seg_idx, object_pose.position);
     const auto nearest_seg_vel = trajectory_points.at(nearest_seg_idx).longitudinal_velocity_mps;
-    const auto t_to_obj = t_to_nearest_seg + lon_offset_dist / nearest_seg_vel;
-    return t_to_obj - time_buffer;
+    const auto ego_front_time_offset = ego_front_offset / nearest_seg_vel;
+    const auto t_to_obj =
+      t_to_nearest_seg + (lon_offset_dist / nearest_seg_vel) - ego_front_time_offset - time_buffer;
+    return std::max(0.0, t_to_obj);
   };
 
   auto get_object_polygon = [&](const auto & pose, const auto & shape) {
@@ -501,7 +531,6 @@ void ObjectFilter::filter_by_target_area(
     const auto obj_lon_vel = std::abs(obj_vel_vector.dot(traj_dir));
     const auto obj_lat_vel = std::abs(obj_vel_vector.dot(traj_lat_dir));
     if (obj_lat_vel < max_lateral_velocity_th_ && obj_lat_vel < obj_lon_vel) return false;
-    if (object.kinematics.predicted_paths.empty()) return true;
     const auto t_to_obj_current_pos = time_to_obj_current_pos(object_pose, nearest_seg);
     const auto obj_pred_pose = get_predicted_obj_pose_at_time(object, t_to_obj_current_pos);
     const auto obj_pred_polygon = get_object_polygon(obj_pred_pose, object.shape);

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
@@ -38,11 +38,16 @@ void trim_trajectory_and_remove_duplicates(TrajectoryPoints & trajectory_points)
   if (trajectory_points.empty()) return;
   const auto zero_velocity_index =
     autoware::motion_utils::searchZeroVelocityIndex(trajectory_points);
-  if (zero_velocity_index && zero_velocity_index.value() < trajectory_points.size() - 1) {
+  const bool found_zero_vel =
+    zero_velocity_index && zero_velocity_index.value() < trajectory_points.size() - 1;
+  if (found_zero_vel) {
     trajectory_points.erase(
       trajectory_points.begin() + zero_velocity_index.value() + 1, trajectory_points.end());
   }
   trajectory_points = autoware::motion_utils::removeOverlapPoints(trajectory_points);
+  if (found_zero_vel)
+    trajectory_points.back().longitudinal_velocity_mps =
+      0.0;  // set zero velocity at the end of the trajectory
 }
 
 double get_detection_length(
@@ -68,7 +73,7 @@ TrajectoryPoints extend_trajectory(
 
   const auto & last_p = trajectory_points.back();
   const auto yaw_last = tf2::getYaw(last_p.pose.orientation);
-  constexpr double lookback_distance = 1.0;  // [m]
+  constexpr double lookback_distance = 2.0;  // [m]
   const auto lookback_pose = motion_utils::calcLongitudinalOffsetPose(
     trajectory_points, trajectory_points.size() - 1, -1.0 * lookback_distance);
 
@@ -233,21 +238,17 @@ std::optional<CollisionPoint> get_nearest_pcd_collision(
 }
 
 std::optional<CollisionPoint> get_nearest_object_collision(
-  const TrajectoryPoints & trajectory_points, const TrajectoryShape & trajectory_shape,
-  const PredictedObjects & objects, MultiPolygon2d & target_polygons,
+  const TrajectoryPoints & trajectory_points, const PredictedObjects & target_objects,
   PredictedObject & colliding_object)
 {
-  if (objects.objects.empty() || trajectory_points.size() < 2) return std::nullopt;
+  if (target_objects.objects.empty() || trajectory_points.size() < 2) return std::nullopt;
 
   auto min_arc_length = std::numeric_limits<double>::max();
   geometry_msgs::msg::Point nearest_collision_point;
   bool found_collision = false;
-  for (const auto & object : objects.objects) {
+  for (const auto & object : target_objects.objects) {
     const auto object_pose = object.kinematics.initial_pose_with_covariance.pose;
     const auto object_polygon = autoware_utils::to_polygon2d(object_pose, object.shape);
-    if (boost::geometry::disjoint(object_polygon, trajectory_shape.polygon)) {
-      continue;
-    }
     found_collision = true;
     for (const auto & point : object_polygon.outer()) {
       geometry_msgs::msg::Point p = geometry_msgs::msg::Point().set__x(point.x()).set__y(point.y());
@@ -258,24 +259,29 @@ std::optional<CollisionPoint> get_nearest_object_collision(
         colliding_object = object;
       }
     }
-    target_polygons.emplace_back(object_polygon);
   }
 
   if (!found_collision) return std::nullopt;
   return CollisionPoint(nearest_collision_point, min_arc_length);
 }
 
+geometry_msgs::msg::Pose get_predicted_obj_pose_at_time(
+  const PredictedObject & object, const double t)
+{
+  if (object.kinematics.predicted_paths.empty())
+    return object.kinematics.initial_pose_with_covariance.pose;
+  const auto & pred_path = object.kinematics.predicted_paths.front();
+  if (pred_path.path.empty()) return object.kinematics.initial_pose_with_covariance.pose;
+  const auto dt = std::max(rclcpp::Duration(pred_path.time_step).seconds(), 1e-3);
+  size_t pred_pose_index = (t + 1e-6) / dt;
+  pred_pose_index = std::min(pred_pose_index, pred_path.path.size() - 1);
+  return pred_path.path.at(pred_pose_index);
+}
+
 ObjectState get_object_state_at_time(
   const TrajectoryPoints & trajectory_points, const PredictedObject & object, const double t)
 {
-  const auto predicted_obj_pose = std::invoke([&]() -> geometry_msgs::msg::Pose {
-    if (object.kinematics.predicted_paths.empty())
-      return object.kinematics.initial_pose_with_covariance.pose;
-    const auto & pred_path = object.kinematics.predicted_paths.front();
-    size_t pred_pose_index = t / rclcpp::Duration(pred_path.time_step).seconds();
-    pred_pose_index = std::min(pred_pose_index, pred_path.path.size() - 1);
-    return pred_path.path.at(pred_pose_index);
-  });
+  const auto predicted_obj_pose = get_predicted_obj_pose_at_time(object, t);
 
   const auto nearest_seg =
     motion_utils::findNearestSegmentIndex(trajectory_points, predicted_obj_pose.position);
@@ -283,10 +289,10 @@ ObjectState get_object_state_at_time(
   const auto p2 = trajectory_points.at(nearest_seg + 1).pose.position;
   auto lon_vel = std::invoke([&]() -> double {
     const auto traj_dir = Eigen::Vector2d(p2.x - p1.x, p2.y - p1.y).normalized();
-    const auto obj_yaw = tf2::getYaw(predicted_obj_pose.orientation);
-    const auto obj_dir = Eigen::Vector2d(std::cos(obj_yaw), std::sin(obj_yaw));
-    const auto obj_lon_vel = object.kinematics.initial_twist_with_covariance.twist.linear.x;
-    return std::max(0.0, obj_lon_vel * obj_dir.dot(traj_dir));
+    const Eigen::Rotation2Dd obj_rot(tf2::getYaw(predicted_obj_pose.orientation));
+    const auto obj_vel = object.kinematics.initial_twist_with_covariance.twist.linear;
+    const auto obj_vel_vector = obj_rot * Eigen::Vector2d(obj_vel.x, obj_vel.y);
+    return std::max(0.0, obj_vel_vector.dot(traj_dir));
   });
 
   const auto obj_polygon = autoware_utils::to_polygon2d(predicted_obj_pose, object.shape);
@@ -321,13 +327,13 @@ double get_safe_distance(
 }
 
 std::optional<CollisionPoint> get_nearest_object_collision(
-  const TrajectoryPoints & trajectory_points, const TrajectoryShape & trajectory_shape,
-  const autoware::vehicle_info_utils::VehicleInfo & vehicle_info, const PredictedObjects & objects,
-  const ObjectDecelMap & object_decel_map, const double ego_decel, const double reaction_time,
-  const double safety_margin, const double stopped_vel_th, const double lookahead_horizon,
-  MultiPolygon2d & target_polygons, PredictedObject & colliding_object)
+  const TrajectoryPoints & trajectory_points,
+  const autoware::vehicle_info_utils::VehicleInfo & vehicle_info,
+  const PredictedObjects & target_objects, const ObjectDecelMap & object_decel_map,
+  const double ego_decel, const double reaction_time, const double safety_margin,
+  const double stopped_vel_th, const double lookahead_horizon, PredictedObject & colliding_object)
 {
-  if (objects.objects.empty() || trajectory_points.size() < 2) return std::nullopt;
+  if (target_objects.objects.empty() || trajectory_points.size() < 2) return std::nullopt;
 
   const auto ego_front_offset = vehicle_info.max_longitudinal_offset_m;
 
@@ -345,17 +351,6 @@ std::optional<CollisionPoint> get_nearest_object_collision(
     const auto relative_arc_length = std::max(0.0, obj_arc_length - ego_front_arc_length);
     return relative_arc_length - safe_dist > 1e-3;
   };
-
-  PredictedObjects target_objects;
-  for (const auto & object : objects.objects) {
-    const auto object_pose = object.kinematics.initial_pose_with_covariance.pose;
-    const auto object_polygon = autoware_utils::to_polygon2d(object_pose, object.shape);
-    if (boost::geometry::disjoint(object_polygon, trajectory_shape.polygon)) {
-      continue;
-    }
-    target_objects.objects.push_back(object);
-    target_polygons.emplace_back(object_polygon);
-  }
 
   auto min_obj_arc_length = std::numeric_limits<double>::max();
   geometry_msgs::msg::Point nearest_collision_point;
@@ -467,6 +462,59 @@ void PointCloudFilter::filter_pointcloud_by_object(
         }),
       pointcloud->end());
   }
+}
+
+void ObjectFilter::filter_by_target_area(
+  PredictedObjects & objects, const TrajectoryPoints & trajectory_points,
+  const MultiPolygon2d & target_area, MultiPolygon2d & target_polygons)
+{
+  constexpr double time_buffer = 1.0;
+  auto time_to_obj_current_pos =
+    [&](const auto & object_pose, const size_t nearest_seg_idx) -> double {
+    const auto t_to_nearest_seg =
+      rclcpp::Duration(trajectory_points.at(nearest_seg_idx).time_from_start).seconds();
+    if (nearest_seg_idx < trajectory_points.size() - 2) return t_to_nearest_seg - time_buffer;
+    const auto lon_offset_dist =
+      motion_utils::calcSignedArcLength(trajectory_points, nearest_seg_idx, object_pose.position);
+    const auto nearest_seg_vel = trajectory_points.at(nearest_seg_idx).longitudinal_velocity_mps;
+    const auto t_to_obj = t_to_nearest_seg + lon_offset_dist / nearest_seg_vel;
+    return t_to_obj - time_buffer;
+  };
+
+  auto is_exiting = [&](const auto & object) -> bool {
+    const auto & object_pose = object.kinematics.initial_pose_with_covariance.pose;
+    const auto obj_rot = Eigen::Rotation2Dd(tf2::getYaw(object_pose.orientation));
+    const auto obj_vel = object.kinematics.initial_twist_with_covariance.twist.linear;
+    const auto obj_vel_vector = (obj_rot * Eigen::Vector2d(obj_vel.x, obj_vel.y));
+    if (obj_vel_vector.norm() < stopped_velocity_th_) return false;  // object is stopped
+    const auto nearest_seg =
+      motion_utils::findNearestSegmentIndex(trajectory_points, object_pose.position);
+    const auto p1 = trajectory_points.at(nearest_seg).pose.position;
+    const auto p2 = trajectory_points.at(nearest_seg + 1).pose.position;
+    const auto traj_dir = Eigen::Vector2d(p2.x - p1.x, p2.y - p1.y).normalized();
+    const auto traj_lat_dir = Eigen::Vector2d(traj_dir.y(), -traj_dir.x());
+    const auto obj_lon_vel = std::abs(obj_vel_vector.dot(traj_dir));
+    const auto obj_lat_vel = std::abs(obj_vel_vector.dot(traj_lat_dir));
+    if (obj_lat_vel < max_lateral_velocity_th_ && obj_lat_vel < obj_lon_vel) return false;
+    if (object.kinematics.predicted_paths.empty()) return true;
+    const auto t_to_obj_current_pos = time_to_obj_current_pos(object_pose, nearest_seg);
+    const auto obj_pred_pose = get_predicted_obj_pose_at_time(object, t_to_obj_current_pos);
+    const auto obj_pred_polygon = autoware_utils::to_polygon2d(obj_pred_pose, object.shape);
+    return boost::geometry::disjoint(obj_pred_polygon, target_area);
+  };
+
+  objects.objects.erase(
+    std::remove_if(
+      objects.objects.begin(), objects.objects.end(),
+      [&](const auto & object) {
+        const auto object_pose = object.kinematics.initial_pose_with_covariance.pose;
+        const auto object_polygon = autoware_utils::to_polygon2d(object_pose, object.shape);
+        if (boost::geometry::disjoint(object_polygon, target_area)) return true;
+        if (is_exiting(object)) return true;
+        target_polygons.emplace_back(object_polygon);
+        return false;
+      }),
+    objects.objects.end());
 }
 
 void ObstacleTracker::update_objects(

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
@@ -481,6 +481,11 @@ void ObjectFilter::filter_by_target_area(
     return t_to_obj - time_buffer;
   };
 
+  auto get_object_polygon = [&](const auto & pose, const auto & shape) {
+    const auto polygon = autoware_utils::to_polygon2d(pose, shape);
+    return autoware_utils::expand_polygon(polygon, safety_buffer_);
+  };
+
   auto is_exiting = [&](const auto & object) -> bool {
     const auto & object_pose = object.kinematics.initial_pose_with_covariance.pose;
     const auto obj_rot = Eigen::Rotation2Dd(tf2::getYaw(object_pose.orientation));
@@ -499,7 +504,7 @@ void ObjectFilter::filter_by_target_area(
     if (object.kinematics.predicted_paths.empty()) return true;
     const auto t_to_obj_current_pos = time_to_obj_current_pos(object_pose, nearest_seg);
     const auto obj_pred_pose = get_predicted_obj_pose_at_time(object, t_to_obj_current_pos);
-    const auto obj_pred_polygon = autoware_utils::to_polygon2d(obj_pred_pose, object.shape);
+    const auto obj_pred_polygon = get_object_polygon(obj_pred_pose, object.shape);
     return boost::geometry::disjoint(obj_pred_polygon, target_area);
   };
 
@@ -508,7 +513,7 @@ void ObjectFilter::filter_by_target_area(
       objects.objects.begin(), objects.objects.end(),
       [&](const auto & object) {
         const auto object_pose = object.kinematics.initial_pose_with_covariance.pose;
-        const auto object_polygon = autoware_utils::to_polygon2d(object_pose, object.shape);
+        const auto object_polygon = get_object_polygon(object_pose, object.shape);
         if (boost::geometry::disjoint(object_polygon, target_area)) return true;
         if (is_exiting(object)) return true;
         target_polygons.emplace_back(object_polygon);

--- a/planning/autoware_trajectory_modifier/tests/test_obstacle_stop_integration.cpp
+++ b/planning/autoware_trajectory_modifier/tests/test_obstacle_stop_integration.cpp
@@ -30,6 +30,7 @@
 #include <gtest/gtest.h>
 
 #include <chrono>
+#include <limits>
 #include <memory>
 #include <string>
 #include <thread>
@@ -205,10 +206,10 @@ protected:
 
   void TearDown() override
   {
+    rclcpp::shutdown();
     plugin_.reset();
     context_.reset();
     node_.reset();
-    rclcpp::shutdown();
   }
 
   void set_up_default_params()
@@ -217,15 +218,16 @@ protected:
     params_.use_stop_point_fixer = false;
     params_.trajectory_time_step = 0.1;
 
+    params_.stopping_constraints.nominal_deceleration = 1.0;
+    params_.stopping_constraints.maximum_deceleration = 4.0;
+    params_.stopping_constraints.jerk_limit = 3.0;
+
     auto & p = params_.obstacle_stop;
     p.use_objects = true;
     p.use_pointcloud = true;
     p.enable_stop_for_objects = true;
     p.enable_stop_for_pointcloud = true;
     p.stop_margin = 6.0;
-    p.nominal_stopping_decel = 1.0;
-    p.maximum_stopping_decel = 4.0;
-    p.stopping_jerk = 3.0;
     p.lateral_margin = 0.5;
     p.arrived_distance_threshold = 0.5;
 
@@ -356,8 +358,14 @@ TEST_F(ObstacleStopIntegrationTest, StopPointInsertedBeforeObject)
 
   // Assert
   ASSERT_TRUE(modified);
-  EXPECT_NEAR(trajectory.back().longitudinal_velocity_mps, 0.0F, 0.1F);
+  EXPECT_FLOAT_EQ(trajectory.back().longitudinal_velocity_mps, 0.0F);
   EXPECT_LT(trajectory.back().pose.position.x, object_x);
+
+  const auto obj_length = car_blocking_path->objects.at(0).shape.dimensions.x;
+  const auto ego_front_offset = context_->vehicle_info.max_longitudinal_offset_m;
+  const auto expected_stop_margin =
+    params_.obstacle_stop.stop_margin + ego_front_offset + obj_length / 2.0;
+  EXPECT_NEAR(object_x - trajectory.back().pose.position.x, expected_stop_margin, 0.1);
 }
 
 TEST_F(ObstacleStopIntegrationTest, StopPointInsertedForBlockingPointcloudCluster)
@@ -378,6 +386,21 @@ TEST_F(ObstacleStopIntegrationTest, StopPointInsertedForBlockingPointcloudCluste
 
   // Assert
   ASSERT_TRUE(modified);
-  EXPECT_NEAR(trajectory.back().longitudinal_velocity_mps, 0.0F, 0.1F);
+  EXPECT_FLOAT_EQ(trajectory.back().longitudinal_velocity_mps, 0.0F);
   EXPECT_LT(trajectory.back().pose.position.x, cluster_center_x);
+
+  const auto min_pcd_x = [&pointcloud_blocking_path]() {
+    sensor_msgs::PointCloud2ConstIterator<float> iter_x(*pointcloud_blocking_path, "x");
+    auto min_x = std::numeric_limits<float>::max();
+    for (; iter_x != iter_x.end(); ++iter_x) {
+      if (*iter_x < min_x) {
+        min_x = *iter_x;
+      }
+    }
+    return min_x;
+  }();
+
+  const auto ego_front_offset = context_->vehicle_info.max_longitudinal_offset_m;
+  const auto expected_stop_margin = params_.obstacle_stop.stop_margin + ego_front_offset;
+  EXPECT_NEAR(min_pcd_x - trajectory.back().pose.position.x, expected_stop_margin, 0.1);
 }

--- a/planning/autoware_trajectory_modifier/tests/test_obstacle_stop_integration.cpp
+++ b/planning/autoware_trajectory_modifier/tests/test_obstacle_stop_integration.cpp
@@ -254,7 +254,8 @@ protected:
     p.rss_params.object_decel.car = 1.5;
     p.rss_params.reaction_time = 0.2;
     p.rss_params.safety_margin = 2.0;
-    p.rss_params.min_vel_th = 0.5;
+    p.rss_params.ego_decel = 4.0;
+    p.rss_params.lookahead_horizon = 1.5;
   }
 
   std::shared_ptr<rclcpp::Node> node_;

--- a/planning/autoware_trajectory_modifier/tests/test_obstacle_stop_integration.cpp
+++ b/planning/autoware_trajectory_modifier/tests/test_obstacle_stop_integration.cpp
@@ -344,7 +344,7 @@ TEST_F(ObstacleStopIntegrationTest, TrajectoryModifiedWhenObjectBlocksPath)
 TEST_F(ObstacleStopIntegrationTest, StopPointInsertedBeforeObject)
 {
   // Arrange
-  constexpr double object_x = 20.0;
+  constexpr double object_x = 25.0;
   auto trajectory = create_straight_trajectory(30.0, 8.0);
   const auto car_blocking_path = make_blocking_car(object_x, 0.0);
   const auto input =
@@ -368,7 +368,68 @@ TEST_F(ObstacleStopIntegrationTest, StopPointInsertedBeforeObject)
   EXPECT_NEAR(object_x - trajectory.back().pose.position.x, expected_stop_margin, 0.1);
 }
 
+TEST_F(ObstacleStopIntegrationTest, StopPointInsertedBeforeObject_ReachMaxDecel)
+{
+  // Arrange
+  constexpr double object_x = 20.0;
+  auto trajectory = create_straight_trajectory(30.0, 8.0);
+  const auto car_blocking_path = make_blocking_car(object_x, 0.0);
+  const auto input =
+    create_input_data(make_odometry(0.0, 0.0, 8.0), make_acceleration(0.0), car_blocking_path);
+
+  // Act: obstacle tracker requires `on_time_buffer` of continuous observation
+  //      before becoming active
+  plugin_->modify_trajectory(trajectory, input);
+  std::this_thread::sleep_for(std::chrono::milliseconds(50));
+  const bool modified = plugin_->modify_trajectory(trajectory, input);
+
+  // Assert
+  ASSERT_TRUE(modified);
+  EXPECT_FLOAT_EQ(trajectory.back().longitudinal_velocity_mps, 0.0F);
+  EXPECT_LT(trajectory.back().pose.position.x, object_x);
+
+  const auto expected_stop_margin = 6.96;  // Computed based on max_decel limit and jerk limit
+  EXPECT_NEAR(object_x - trajectory.back().pose.position.x, expected_stop_margin, 0.1);
+}
+
 TEST_F(ObstacleStopIntegrationTest, StopPointInsertedForBlockingPointcloudCluster)
+{
+  // Arrange
+  constexpr double cluster_center_x = 25.0;
+  auto trajectory = create_straight_trajectory(30.0, 8.0);
+  const auto pointcloud_blocking_path =
+    make_blocking_pointcloud_cluster(cluster_center_x, 0.0, 0.7);
+  const auto input = create_input_data(
+    make_odometry(0.0, 0.0, 8.0), make_acceleration(0.0), nullptr, pointcloud_blocking_path);
+
+  // Act: obstacle tracker requires `on_time_buffer` of continuous observation
+  //      before becoming active
+  plugin_->modify_trajectory(trajectory, input);
+  std::this_thread::sleep_for(std::chrono::milliseconds(50));
+  const bool modified = plugin_->modify_trajectory(trajectory, input);
+
+  // Assert
+  ASSERT_TRUE(modified);
+  EXPECT_FLOAT_EQ(trajectory.back().longitudinal_velocity_mps, 0.0F);
+  EXPECT_LT(trajectory.back().pose.position.x, cluster_center_x);
+
+  const auto min_pcd_x = [&pointcloud_blocking_path]() {
+    sensor_msgs::PointCloud2ConstIterator<float> iter_x(*pointcloud_blocking_path, "x");
+    auto min_x = std::numeric_limits<float>::max();
+    for (; iter_x != iter_x.end(); ++iter_x) {
+      if (*iter_x < min_x) {
+        min_x = *iter_x;
+      }
+    }
+    return min_x;
+  }();
+
+  const auto ego_front_offset = context_->vehicle_info.max_longitudinal_offset_m;
+  const auto expected_stop_margin = params_.obstacle_stop.stop_margin + ego_front_offset;
+  EXPECT_NEAR(min_pcd_x - trajectory.back().pose.position.x, expected_stop_margin, 0.1);
+}
+
+TEST_F(ObstacleStopIntegrationTest, StopPointInsertedForBlockingPointcloudCluster_ReachMaxDecel)
 {
   // Arrange
   constexpr double cluster_center_x = 15.0;
@@ -400,7 +461,6 @@ TEST_F(ObstacleStopIntegrationTest, StopPointInsertedForBlockingPointcloudCluste
     return min_x;
   }();
 
-  const auto ego_front_offset = context_->vehicle_info.max_longitudinal_offset_m;
-  const auto expected_stop_margin = params_.obstacle_stop.stop_margin + ego_front_offset;
+  const auto expected_stop_margin = 2.01;  // Computed based on max_decel limit and jerk limit
   EXPECT_NEAR(min_pcd_x - trajectory.back().pose.position.x, expected_stop_margin, 0.1);
 }

--- a/planning/autoware_trajectory_modifier/tests/test_velocity_modifier_integration.cpp
+++ b/planning/autoware_trajectory_modifier/tests/test_velocity_modifier_integration.cpp
@@ -25,6 +25,7 @@
 #include <gtest/gtest.h>
 
 #include <chrono>
+#include <cmath>
 #include <memory>
 #include <string>
 #include <thread>
@@ -82,7 +83,7 @@ TrajectoryPoints create_constant_deceleration_trajectory(
   const auto accel = -1.0 * initial_velocity * initial_velocity / (2.0 * length);
   TrajectoryPoints trajectory;
   for (double x = 0.0; x <= length + 1e-6; x += spacing) {
-    auto velocity = sqrt(initial_velocity * initial_velocity + 2.0 * accel * x);
+    auto velocity = std::sqrt(initial_velocity * initial_velocity + 2.0 * accel * x);
     trajectory.push_back(create_trajectory_point(x, 0.0, velocity, accel));
   }
   return trajectory;

--- a/planning/autoware_trajectory_modifier/tests/test_velocity_modifier_integration.cpp
+++ b/planning/autoware_trajectory_modifier/tests/test_velocity_modifier_integration.cpp
@@ -1,0 +1,204 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/trajectory_modifier/trajectory_modifier_plugins/velocity_modifier.hpp"
+
+#include <ament_index_cpp/get_package_share_directory.hpp>
+#include <autoware_test_utils/autoware_test_utils.hpp>
+#include <autoware_trajectory_modifier/trajectory_modifier_param.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+#include <geometry_msgs/msg/accel_with_covariance_stamped.hpp>
+#include <nav_msgs/msg/odometry.hpp>
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <memory>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
+
+namespace
+{
+using autoware::trajectory_modifier::TrajectoryModifierContext;
+using autoware::trajectory_modifier::plugin::InputData;
+using autoware::trajectory_modifier::plugin::TrajectoryPoints;
+using autoware::trajectory_modifier::plugin::VelocityModifier;
+using autoware_planning_msgs::msg::TrajectoryPoint;
+
+TrajectoryPoint create_trajectory_point(
+  double x, double y, double velocity, double acceleration = 0.0)
+{
+  TrajectoryPoint point;
+  point.pose.position.x = x;
+  point.pose.position.y = y;
+  point.pose.position.z = 0.0;
+  point.pose.orientation.x = 0.0;
+  point.pose.orientation.y = 0.0;
+  point.pose.orientation.z = 0.0;
+  point.pose.orientation.w = 1.0;
+  point.longitudinal_velocity_mps = static_cast<float>(velocity);
+  point.acceleration_mps2 = static_cast<float>(acceleration);
+  return point;
+}
+
+TrajectoryPoints create_constant_velocity_trajectory(
+  double length, double velocity, double spacing = 1.0)
+{
+  TrajectoryPoints trajectory;
+  for (double x = 0.0; x <= length + 1e-6; x += spacing) {
+    trajectory.push_back(create_trajectory_point(x, 0.0, velocity));
+  }
+  return trajectory;
+}
+
+TrajectoryPoints create_step_change_zero_velocity_trajectory(
+  double length, double default_velocity, double zero_velocity_length, double spacing = 1.0)
+{
+  TrajectoryPoints trajectory;
+  for (double x = 0.0; x <= length + 1e-6; x += spacing) {
+    auto velocity = x < zero_velocity_length ? default_velocity : 0.0;
+    trajectory.push_back(create_trajectory_point(x, 0.0, velocity, 0.0));
+  }
+  return trajectory;
+}
+
+TrajectoryPoints create_constant_deceleration_trajectory(
+  double length, double initial_velocity, double spacing = 1.0)
+{
+  const auto accel = -1.0 * initial_velocity * initial_velocity / (2.0 * length);
+  TrajectoryPoints trajectory;
+  for (double x = 0.0; x <= length + 1e-6; x += spacing) {
+    auto velocity = sqrt(initial_velocity * initial_velocity + 2.0 * accel * x);
+    trajectory.push_back(create_trajectory_point(x, 0.0, velocity, accel));
+  }
+  return trajectory;
+}
+
+}  // namespace
+
+class VelocityModifierIntegrationTest : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    rclcpp::init(0, nullptr);
+
+    auto node_options = rclcpp::NodeOptions{};
+    const auto autoware_test_utils_dir =
+      ament_index_cpp::get_package_share_directory("autoware_test_utils");
+    autoware::test_utils::updateNodeOptions(
+      node_options, {autoware_test_utils_dir + "/config/test_vehicle_info.param.yaml"});
+
+    node_ = std::make_shared<rclcpp::Node>("test_velocity_modifier_node", node_options);
+    time_keeper_ = std::make_shared<autoware_utils_debug::TimeKeeper>();
+
+    set_up_default_params();
+
+    // Create the context and the plugin once. Tests build per-frame InputData inline,
+    // and inject any required TF directly into context_->tf_buffer.
+    context_ = std::make_shared<TrajectoryModifierContext>(node_.get());
+    plugin_ = std::make_unique<VelocityModifier>();
+    plugin_->initialize("test_velocity_modifier", node_.get(), time_keeper_, context_, params_);
+  }
+
+  void TearDown() override
+  {
+    rclcpp::shutdown();
+    plugin_.reset();
+    context_.reset();
+    node_.reset();
+  }
+
+  void set_up_default_params()
+  {
+    params_.use_velocity_modifier = true;
+    params_.trajectory_time_step = 0.1;
+    params_.stopping_constraints.nominal_deceleration = 1.0;
+    params_.stopping_constraints.maximum_deceleration = 4.0;
+    params_.stopping_constraints.jerk_limit = 3.0;
+  }
+
+  std::shared_ptr<rclcpp::Node> node_;
+  std::shared_ptr<autoware_utils_debug::TimeKeeper> time_keeper_;
+  std::unique_ptr<VelocityModifier> plugin_;
+  trajectory_modifier_params::Params params_;
+  std::shared_ptr<TrajectoryModifierContext> context_;
+};
+
+TEST_F(VelocityModifierIntegrationTest, TrajectoryNotModifiedWhenDisabled)
+{
+  // Arrange
+  params_.use_velocity_modifier = false;
+  plugin_->update_params(params_);
+  TrajectoryPoints trajectory;
+
+  // Act
+  const bool modified = plugin_->modify_trajectory(trajectory, InputData{});
+
+  // Assert
+  EXPECT_FALSE(modified);
+}
+
+TEST_F(VelocityModifierIntegrationTest, TrajectoryNotModifiedForEmptyTrajectory)
+{
+  // Arrange
+  TrajectoryPoints trajectory;
+
+  // Act
+  const bool modified = plugin_->modify_trajectory(trajectory, InputData{});
+
+  // Assert
+  EXPECT_FALSE(modified);
+}
+
+TEST_F(VelocityModifierIntegrationTest, TrajectoryNotModifiedWhenNoStopPoint)
+{
+  // Arrange
+  auto trajectory = create_constant_velocity_trajectory(20.0, 10.0);
+
+  // Act
+  const bool modified = plugin_->modify_trajectory(trajectory, InputData{});
+
+  // Assert
+  EXPECT_FALSE(modified);
+}
+
+TEST_F(VelocityModifierIntegrationTest, TrajectoryNotModifiedForSmoothStoppingTrajectory)
+{
+  // Arrange
+  auto trajectory = create_constant_deceleration_trajectory(20.0, 10.0);
+
+  // Act
+  const bool modified = plugin_->modify_trajectory(trajectory, InputData{});
+
+  // Assert
+  EXPECT_FALSE(modified);
+}
+
+TEST_F(VelocityModifierIntegrationTest, TrajectoryModifiedForStepChangeZeroVelocityTrajectory)
+{
+  // Arrange
+  auto trajectory = create_step_change_zero_velocity_trajectory(20.0, 10.0, 15.0);
+
+  // Act
+  const bool modified = plugin_->modify_trajectory(trajectory, InputData{});
+
+  // Assert
+  EXPECT_TRUE(modified);
+  EXPECT_NEAR(trajectory.back().longitudinal_velocity_mps, 0.0, 0.1);
+  EXPECT_NEAR(trajectory.back().acceleration_mps2, 0.0, 0.1);
+}


### PR DESCRIPTION
## Description
The following improvements are applied to `obstacle_stop` plugin of `trajectory_modifier` node:
- Modify RSS check to evaluate future states within specified time horizon instead of checking only current state
- Improve object processing and filtering to better handle crossing objects
- Add parameterized safety buffer around obstacle footprint
- Always process objects/pointcloud (even when empty) to keep tracker updated

The following refactor is applied to `trajectory_modifier`:
- Move velocity update logic from obstacle_stop to new velocity_modifier plugin
  - When a modifier plugin (such as `obstacle_stop`) inserts a stop point, the velocity_modifier will update the velocity & acceleration profile of the trajectory to enforce kinematic limits, and interpolate trajectory points to insure temporal representation.
- update trajectory_modifier parameters struct
- update trajectory_modifier param yaml and schema
- update trajectory_modifier CMakeLists and plugins.xml

## Related links

- [Launcher PR](https://github.com/autowarefoundation/autoware_launch/pull/1854)

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

### Launch Arguments Changes

#### Modifications (trajectory_modifier.launch.xml)

| Version | Argument Name  |  Default Value  |
|:--------|:----------------|:------------------|
| Old     | `input_objects_topic_name` | `/perception/object_recognition/objects` |
| New    | `input_objects` | `/perception/object_recognition/objects` |
| Old     | `input_pointcloud_topic_name` | `/perception/obstacle_segmentation/pointcloud` |
| New    | `input_pointcloud` | `/perception/obstacle_segmentation/pointcloud` |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added | `use_velocity_modifier`   | `bool` | `true`         | Flag to enable/disable velocity modifier plugin |
| Added | `stopping_constraints.nominal_deceleration`  | `double` | `1.0` | Nominal deceleration value for stopping |
| Added | `stopping_constraints.maximum_deceleration`  | `double` | `4.0` | Maximum deceleration value for stopping |
| Added | `stopping_constraints.jerk_limit`  | `double` | `3.0` | Jerk limit value for stopping |
| Added | `obstacle_stop.duplicate_check_threshold`  | `double` | `0.5` | threshold to check if stop point is already in the trajectory |
| Added | `obstacle_stop.objects.stopped_velocity_th`  | `double` | `0.25` | static object velocity threshold |
| Added | `obstacle_stop.objects.max_lateral_velocity_th`  | `double` | `1.0` | lateral moving object velocity threshold |
| Added | `obstacle_stop.objects.safety_buffer`  | `double` | `0.0` | safety buffer to expand object footprint |
| Added | `obstacle_stop.rss_params.ego_decel`  | `double` | `4.0` | Ego deceleration value used in rss check |
| Added | `obstacle_stop.rss_params.lookahead_horizon`  | `double` | `1.5` | lookahead duration for RSS calculation |
| Removed | `obstacle_stop.nominal_deceleration`  | `double` | `1.0` | Nominal deceleration value for stopping |
| Removed | `obstacle_stop.maximum_deceleration`  | `double` | `4.0` | Maximum deceleration value for stopping |
| Removed | `obstacle_stop.jerk_limit`  | `double` | `3.0` | Jerk limit value for stopping |
| Removed | `obstacle_stop.rss_params.min_vel_th`  | `double` | `0.5` | minimum object velocity to consider for rss check |

## Effects on system behavior

Improved obstacle stop behavior
