### PR TITLE
refactor(cuda_pointcloud_preprocessor): slim ROS node wrapper

### DIFF
--- a/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor.hpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor.hpp
@@ -82,14 +82,8 @@ public:
   using Config = CudaPointcloudPreprocessorConfig;
   using UndistortionType = CudaPointcloudPreprocessorConfig::UndistortionType;
 
-  CudaPointcloudPreprocessor();
   explicit CudaPointcloudPreprocessor(const Config & config);
 
-  void setConfig(const Config & config);
-  void setCropBoxParameters(const std::vector<CropBoxParameters> & crop_box_parameters);
-  void setRingOutlierFilterParameters(const RingOutlierFilterParameters & ring_outlier_parameters);
-  void setRingOutlierFilterActive(const bool enable_filter);
-  void setUndistortionType(const UndistortionType & undistortion_type);
   void addTwist(const geometry_msgs::msg::TwistWithCovarianceStamped & twist_msg);
   void addAngularVelocityInBaseFrame(const geometry_msgs::msg::Vector3Stamped & angular_velocity);
 
@@ -102,6 +96,10 @@ public:
 
 private:
   static cudaStream_t initialize_stream();
+  void setCropBoxParameters(const std::vector<CropBoxParameters> & crop_box_parameters);
+  void setRingOutlierFilterParameters(const RingOutlierFilterParameters & ring_outlier_parameters);
+  void setRingOutlierFilterActive(const bool enable_filter);
+  void setUndistortionType(const UndistortionType & undistortion_type);
   [[nodiscard]] bool validatePointcloudLayout(
     const sensor_msgs::msg::PointCloud2 & input_pointcloud_msg) const;
   std::pair<std::uint64_t, std::uint32_t> getFirstPointTimeInfo(

--- a/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor.hpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor.hpp
@@ -22,6 +22,7 @@
 #include <Eigen/Geometry>
 #include <autoware/cuda_utils/thrust_utils.hpp>
 #include <cuda_blackboard/cuda_pointcloud2.hpp>
+#include <tl_expected/expected.hpp>
 
 #include <geometry_msgs/msg/transform_stamped.hpp>
 #include <geometry_msgs/msg/twist_with_covariance_stamped.hpp>
@@ -33,6 +34,8 @@
 #include <cstdint>
 #include <deque>
 #include <memory>
+#include <string>
+#include <utility>
 #include <vector>
 
 namespace autoware::cuda_pointcloud_preprocessor
@@ -45,30 +48,66 @@ struct ProcessingStats
   int num_nan_points{0};
 };
 
+struct CudaPointcloudPreprocessorConfig
+{
+  std::vector<CropBoxParameters> crop_box_parameters;
+  RingOutlierFilterParameters ring_outlier_filter_parameters;
+  bool enable_ring_outlier_filter{true};
+  enum class UndistortionType {
+    Invalid,
+    Undistortion2D,
+    Undistortion3D
+  } undistortion_type{UndistortionType::Invalid};
+};
+
+struct ProcessResult
+{
+  std::unique_ptr<cuda_blackboard::CudaPointCloud2> output;
+  ProcessingStats stats;
+};
+
+struct ProcessError
+{
+  enum class Code {
+    IncompatiblePointcloudLayout,
+  };
+
+  Code code;
+  std::string message;
+};
+
 class CudaPointcloudPreprocessor
 {
 public:
-  enum class UndistortionType { Invalid, Undistortion2D, Undistortion3D };
+  using Config = CudaPointcloudPreprocessorConfig;
+  using UndistortionType = CudaPointcloudPreprocessorConfig::UndistortionType;
 
   CudaPointcloudPreprocessor();
+  explicit CudaPointcloudPreprocessor(const Config & config);
 
+  void setConfig(const Config & config);
   void setCropBoxParameters(const std::vector<CropBoxParameters> & crop_box_parameters);
   void setRingOutlierFilterParameters(const RingOutlierFilterParameters & ring_outlier_parameters);
   void setRingOutlierFilterActive(const bool enable_filter);
   void setUndistortionType(const UndistortionType & undistortion_type);
+  void addTwist(const geometry_msgs::msg::TwistWithCovarianceStamped & twist_msg);
+  void addAngularVelocityInBaseFrame(const geometry_msgs::msg::Vector3Stamped & angular_velocity);
 
   void preallocateOutput();
   [[nodiscard]] ProcessingStats getProcessingStats() const { return stats_; }
 
-  std::unique_ptr<cuda_blackboard::CudaPointCloud2> process(
+  tl::expected<ProcessResult, ProcessError> process(
     const sensor_msgs::msg::PointCloud2 & input_pointcloud_msg,
-    const geometry_msgs::msg::TransformStamped & transform_msg,
-    const std::deque<geometry_msgs::msg::TwistWithCovarianceStamped> & twist_queue,
-    const std::deque<geometry_msgs::msg::Vector3Stamped> & angular_velocity_queue,
-    const std::uint32_t first_point_rel_stamp_nsec);
+    const geometry_msgs::msg::TransformStamped & transform_msg);
 
 private:
   static cudaStream_t initialize_stream();
+  [[nodiscard]] bool validatePointcloudLayout(
+    const sensor_msgs::msg::PointCloud2 & input_pointcloud_msg) const;
+  std::pair<std::uint64_t, std::uint32_t> getFirstPointTimeInfo(
+    const sensor_msgs::msg::PointCloud2 & input_pointcloud_msg) const;
+  void trimTwistQueue(std::uint64_t first_point_stamp);
+  void trimAngularVelocityQueue(std::uint64_t first_point_stamp);
 
   void organizePointcloud();
 
@@ -92,6 +131,9 @@ private:
   cudaMemPool_t device_memory_pool_{};
 
   ProcessingStats stats_;
+
+  std::deque<geometry_msgs::msg::TwistWithCovarianceStamped> twist_queue_;
+  std::deque<geometry_msgs::msg::Vector3Stamped> angular_velocity_queue_;
 
   // Organizing buffers
   thrust::device_vector<InputPointType> device_input_points_;

--- a/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor_node.hpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor_node.hpp
@@ -41,6 +41,7 @@
 
 #include <deque>
 #include <memory>
+#include <optional>
 #include <string>
 #include <utility>
 
@@ -86,23 +87,15 @@ private:
   // Callback
   void pointcloudCallback(AUTOWARE_MESSAGE_UNIQUE_PTR(sensor_msgs::msg::PointCloud2)
                             input_pointcloud_msg_ptr);
-  void twistCallback(const geometry_msgs::msg::TwistWithCovarianceStamped & twist_msg);
-  void imuCallback(const sensor_msgs::msg::Imu & imu_msg);
+  void updateTwistQueue();
+  void updateImuQueue();
 
   // Helper Functions
-  [[nodiscard]] bool validatePointcloudLayout(
-    const sensor_msgs::msg::PointCloud2 & input_pointcloud_msg) const;
-  std::pair<std::uint64_t, std::uint32_t> getFirstPointTimeInfo(
-    const sensor_msgs::msg::PointCloud2 & input_pointcloud_msg);
-
-  void updateTwistQueue(std::uint64_t first_point_stamp);
-  void updateImuQueue(std::uint64_t first_point_stamp);
   std::optional<geometry_msgs::msg::TransformStamped> lookupTransformToBase(
     const std::string & source_frame);
-  std::unique_ptr<cuda_blackboard::CudaPointCloud2> processPointcloud(
+  tl::expected<ProcessResult, ProcessError> processPointcloud(
     const sensor_msgs::msg::PointCloud2 & input_pointcloud_msg,
-    const geometry_msgs::msg::TransformStamped & transform_msg,
-    const std::uint32_t first_point_rel_stamp);
+    const geometry_msgs::msg::TransformStamped & transform_msg);
 
   void publishDiagnostics(
     const sensor_msgs::msg::PointCloud2 & input_pointcloud_msg,
@@ -119,9 +112,6 @@ private:
   bool use_imu_;
   double processing_time_threshold_sec_;
   double timestamp_mismatch_fraction_threshold_;
-
-  std::deque<geometry_msgs::msg::TwistWithCovarianceStamped> twist_queue_;
-  std::deque<geometry_msgs::msg::Vector3Stamped> angular_velocity_queue_;
 
   // Subscribers
   autoware_utils::InterProcessPollingSubscriber<

--- a/sensing/autoware_cuda_pointcloud_preprocessor/package.xml
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/package.xml
@@ -31,6 +31,7 @@
   <depend>tf2</depend>
   <depend>tf2_msgs</depend>
   <depend>tier4_debug_msgs</depend>
+  <depend>tl_expected</depend>
 
   <test_depend>ament_clang_format</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor.cu
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor.cu
@@ -14,6 +14,7 @@
 
 #include "autoware/cuda_pointcloud_preprocessor/common_kernels.hpp"
 #include "autoware/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor.hpp"
+#include "autoware/cuda_pointcloud_preprocessor/memory.hpp"
 #include "autoware/cuda_pointcloud_preprocessor/organize_kernels.hpp"
 #include "autoware/cuda_pointcloud_preprocessor/outlier_kernels.hpp"
 #include "autoware/cuda_pointcloud_preprocessor/point_types.hpp"
@@ -26,8 +27,11 @@
 #include <autoware/cuda_utils/cuda_check_error.hpp>
 #include <autoware/cuda_utils/thrust_utils.hpp>
 #include <cub/cub.cuh>
+#include <rclcpp/duration.hpp>
+#include <rclcpp/time.hpp>
 
 #include <sensor_msgs/msg/point_field.hpp>
+#include <sensor_msgs/point_cloud2_iterator.hpp>
 
 #include <cuda_runtime.h>
 #include <tf2/utils.h>
@@ -36,7 +40,9 @@
 #include <thrust/reduce.h>
 #include <thrust/scan.h>
 
+#include <algorithm>
 #include <cstdint>
+#include <utility>
 
 namespace autoware::cuda_pointcloud_preprocessor
 {
@@ -109,11 +115,25 @@ CudaPointcloudPreprocessor::CudaPointcloudPreprocessor() : stream_(initialize_st
   preallocateOutput();
 }
 
+CudaPointcloudPreprocessor::CudaPointcloudPreprocessor(const Config & config)
+: CudaPointcloudPreprocessor()
+{
+  setConfig(config);
+}
+
 cudaStream_t CudaPointcloudPreprocessor::initialize_stream()
 {
   cudaStream_t stream{};
   CHECK_CUDA_ERROR(cudaStreamCreate(&stream));
   return stream;
+}
+
+void CudaPointcloudPreprocessor::setConfig(const Config & config)
+{
+  setCropBoxParameters(config.crop_box_parameters);
+  setRingOutlierFilterParameters(config.ring_outlier_filter_parameters);
+  setRingOutlierFilterActive(config.enable_ring_outlier_filter);
+  setUndistortionType(config.undistortion_type);
 }
 
 void CudaPointcloudPreprocessor::setCropBoxParameters(
@@ -142,11 +162,107 @@ void CudaPointcloudPreprocessor::setUndistortionType(const UndistortionType & un
   undistortion_type_ = undistortion_type;
 }
 
+void CudaPointcloudPreprocessor::addTwist(
+  const geometry_msgs::msg::TwistWithCovarianceStamped & twist_msg)
+{
+  while (!twist_queue_.empty()) {
+    const bool backwards_time_jump_detected =
+      rclcpp::Time(twist_queue_.front().header.stamp) > rclcpp::Time(twist_msg.header.stamp);
+    const bool is_queue_longer_than_1s =
+      rclcpp::Time(twist_queue_.front().header.stamp) <
+      rclcpp::Time(twist_msg.header.stamp) - rclcpp::Duration::from_seconds(1.0);
+
+    if (backwards_time_jump_detected) {
+      twist_queue_.clear();
+    } else if (is_queue_longer_than_1s) {
+      twist_queue_.pop_front();
+    } else {
+      break;
+    }
+  }
+
+  auto it = std::lower_bound(
+    twist_queue_.begin(), twist_queue_.end(), twist_msg.header.stamp,
+    [](const auto & twist, const auto & stamp) {
+      return rclcpp::Time(twist.header.stamp) < stamp;
+    });
+  twist_queue_.insert(it, twist_msg);
+}
+
+void CudaPointcloudPreprocessor::addAngularVelocityInBaseFrame(
+  const geometry_msgs::msg::Vector3Stamped & angular_velocity)
+{
+  while (!angular_velocity_queue_.empty()) {
+    const bool backwards_time_jump_detected =
+      rclcpp::Time(angular_velocity_queue_.front().header.stamp) >
+      rclcpp::Time(angular_velocity.header.stamp);
+    const bool is_queue_longer_than_1s =
+      rclcpp::Time(angular_velocity_queue_.front().header.stamp) <
+      rclcpp::Time(angular_velocity.header.stamp) - rclcpp::Duration::from_seconds(1.0);
+
+    if (backwards_time_jump_detected) {
+      angular_velocity_queue_.clear();
+    } else if (is_queue_longer_than_1s) {
+      angular_velocity_queue_.pop_front();
+    } else {
+      break;
+    }
+  }
+
+  auto it = std::lower_bound(
+    angular_velocity_queue_.begin(), angular_velocity_queue_.end(), angular_velocity.header.stamp,
+    [](const auto & queued_angular_velocity, const auto & stamp) {
+      return rclcpp::Time(queued_angular_velocity.header.stamp) < stamp;
+    });
+  angular_velocity_queue_.insert(it, angular_velocity);
+}
+
 void CudaPointcloudPreprocessor::preallocateOutput()
 {
   output_pointcloud_ptr_ = std::make_unique<cuda_blackboard::CudaPointCloud2>();
   output_pointcloud_ptr_->data = cuda_blackboard::make_unique<std::uint8_t[]>(
     num_rings_ * max_points_per_ring_ * sizeof(OutputPointType));
+}
+
+[[nodiscard]] bool CudaPointcloudPreprocessor::validatePointcloudLayout(
+  const sensor_msgs::msg::PointCloud2 & input_pointcloud_msg) const
+{
+  return is_data_layout_compatible_with_point_xyzircaedt(input_pointcloud_msg.fields);
+}
+
+std::pair<std::uint64_t, std::uint32_t> CudaPointcloudPreprocessor::getFirstPointTimeInfo(
+  const sensor_msgs::msg::PointCloud2 & input_pointcloud_msg) const
+{
+  sensor_msgs::PointCloud2ConstIterator<std::uint32_t> iter_stamp(
+    input_pointcloud_msg, "time_stamp");
+  const auto num_points = input_pointcloud_msg.width * input_pointcloud_msg.height;
+  const std::uint32_t first_point_rel_stamp = num_points > 0 ? *iter_stamp : 0;
+  const std::uint64_t first_point_stamp =
+    input_pointcloud_msg.header.stamp.sec * static_cast<std::uint64_t>(1'000'000'000) +
+    input_pointcloud_msg.header.stamp.nanosec + first_point_rel_stamp;
+  return {first_point_stamp, first_point_rel_stamp};
+}
+
+void CudaPointcloudPreprocessor::trimTwistQueue(std::uint64_t first_point_stamp)
+{
+  auto it = std::lower_bound(
+    twist_queue_.begin(), twist_queue_.end(), first_point_stamp,
+    [](const auto & twist, const std::uint64_t stamp) {
+      return rclcpp::Time(twist.header.stamp).nanoseconds() < stamp;
+    });
+
+  twist_queue_.erase(twist_queue_.begin(), it);
+}
+
+void CudaPointcloudPreprocessor::trimAngularVelocityQueue(std::uint64_t first_point_stamp)
+{
+  auto it = std::lower_bound(
+    angular_velocity_queue_.begin(), angular_velocity_queue_.end(), first_point_stamp,
+    [](const auto & angular_velocity, const std::uint64_t stamp) {
+      return rclcpp::Time(angular_velocity.header.stamp).nanoseconds() < stamp;
+    });
+
+  angular_velocity_queue_.erase(angular_velocity_queue_.begin(), it);
 }
 
 void CudaPointcloudPreprocessor::organizePointcloud()
@@ -273,14 +389,22 @@ void CudaPointcloudPreprocessor::organizePointcloud()
     organized_points_blocks_per_grid, stream_);
 }
 
-std::unique_ptr<cuda_blackboard::CudaPointCloud2> CudaPointcloudPreprocessor::process(
+tl::expected<ProcessResult, ProcessError> CudaPointcloudPreprocessor::process(
   const sensor_msgs::msg::PointCloud2 & input_pointcloud_msg,
-  const geometry_msgs::msg::TransformStamped & transform_msg,
-  const std::deque<geometry_msgs::msg::TwistWithCovarianceStamped> & twist_queue,
-  const std::deque<geometry_msgs::msg::Vector3Stamped> & angular_velocity_queue,
-  const std::uint32_t first_point_rel_stamp_nsec)
+  const geometry_msgs::msg::TransformStamped & transform_msg)
 {
-  auto frame_id = input_pointcloud_msg.header.frame_id;
+  if (!validatePointcloudLayout(input_pointcloud_msg)) {
+    return tl::make_unexpected(
+      ProcessError{
+        ProcessError::Code::IncompatiblePointcloudLayout,
+        "Input pointcloud data layout is not compatible with PointXYZIRCAEDT"});
+  }
+
+  const auto [first_point_stamp, first_point_rel_stamp_nsec] =
+    getFirstPointTimeInfo(input_pointcloud_msg);
+  trimTwistQueue(first_point_stamp);
+  trimAngularVelocityQueue(first_point_stamp);
+
   num_raw_points_ = static_cast<int>(input_pointcloud_msg.width * input_pointcloud_msg.height);
   num_organized_points_ = num_rings_ * max_points_per_ring_;
 
@@ -295,7 +419,7 @@ std::unique_ptr<cuda_blackboard::CudaPointCloud2> CudaPointcloudPreprocessor::pr
     output_pointcloud_ptr_->point_step = sizeof(OutputPointType);
     output_pointcloud_ptr_->header.stamp = input_pointcloud_msg.header.stamp;
 
-    return std::move(output_pointcloud_ptr_);
+    return ProcessResult{std::move(output_pointcloud_ptr_), stats_};
   }
 
   if (num_raw_points_ > device_input_points_.size()) {
@@ -349,11 +473,11 @@ std::unique_ptr<cuda_blackboard::CudaPointCloud2> CudaPointcloudPreprocessor::pr
 
   if (undistortion_type_ == UndistortionType::Undistortion3D) {
     setupTwist3DStructs(
-      twist_queue, angular_velocity_queue, pointcloud_stamp_nsec, first_point_rel_stamp_nsec,
+      twist_queue_, angular_velocity_queue_, pointcloud_stamp_nsec, first_point_rel_stamp_nsec,
       device_twist_3d_structs_, stream_);
   } else if (undistortion_type_ == UndistortionType::Undistortion2D) {
     setupTwist2DStructs(
-      twist_queue, angular_velocity_queue, pointcloud_stamp_nsec, first_point_rel_stamp_nsec,
+      twist_queue_, angular_velocity_queue_, pointcloud_stamp_nsec, first_point_rel_stamp_nsec,
       device_twist_2d_structs_, stream_);
   } else {
     throw std::runtime_error("Invalid undistortion type");
@@ -470,7 +594,7 @@ std::unique_ptr<cuda_blackboard::CudaPointCloud2> CudaPointcloudPreprocessor::pr
   output_pointcloud_ptr_->point_step = sizeof(OutputPointType);
   output_pointcloud_ptr_->header.stamp = input_pointcloud_msg.header.stamp;
 
-  return std::move(output_pointcloud_ptr_);
+  return ProcessResult{std::move(output_pointcloud_ptr_), stats_};
 }
 
 }  // namespace autoware::cuda_pointcloud_preprocessor

--- a/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor.cu
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor.cu
@@ -49,7 +49,8 @@ namespace autoware::cuda_pointcloud_preprocessor
 
 namespace thrust_stream = cuda_utils::thrust_stream;
 
-CudaPointcloudPreprocessor::CudaPointcloudPreprocessor() : stream_(initialize_stream())
+CudaPointcloudPreprocessor::CudaPointcloudPreprocessor(const Config & config)
+: stream_(initialize_stream())
 {
   using sensor_msgs::msg::PointField;
 
@@ -113,12 +114,11 @@ CudaPointcloudPreprocessor::CudaPointcloudPreprocessor() : stream_(initialize_st
   device_indices_.resize(num_organized_points_);
 
   preallocateOutput();
-}
 
-CudaPointcloudPreprocessor::CudaPointcloudPreprocessor(const Config & config)
-: CudaPointcloudPreprocessor()
-{
-  setConfig(config);
+  setCropBoxParameters(config.crop_box_parameters);
+  setRingOutlierFilterParameters(config.ring_outlier_filter_parameters);
+  setRingOutlierFilterActive(config.enable_ring_outlier_filter);
+  setUndistortionType(config.undistortion_type);
 }
 
 cudaStream_t CudaPointcloudPreprocessor::initialize_stream()
@@ -126,14 +126,6 @@ cudaStream_t CudaPointcloudPreprocessor::initialize_stream()
   cudaStream_t stream{};
   CHECK_CUDA_ERROR(cudaStreamCreate(&stream));
   return stream;
-}
-
-void CudaPointcloudPreprocessor::setConfig(const Config & config)
-{
-  setCropBoxParameters(config.crop_box_parameters);
-  setRingOutlierFilterParameters(config.ring_outlier_filter_parameters);
-  setRingOutlierFilterActive(config.enable_ring_outlier_filter);
-  setUndistortionType(config.undistortion_type);
 }
 
 void CudaPointcloudPreprocessor::setCropBoxParameters(

--- a/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor_node.cpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor_node.cpp
@@ -147,15 +147,15 @@ CudaPointcloudPreprocessorNode::CudaPointcloudPreprocessorNode(
       create_subscription(this, "~/input/imu", rclcpp::QoS(TWIST_QUEUE_SIZE));
   }
 
-  CudaPointcloudPreprocessor::UndistortionType undistortion_type =
+  CudaPointcloudPreprocessorConfig preprocessor_config;
+  preprocessor_config.crop_box_parameters = crop_box_parameters;
+  preprocessor_config.ring_outlier_filter_parameters = ring_outlier_filter_parameters;
+  preprocessor_config.enable_ring_outlier_filter = enable_ring_outlier_filter;
+  preprocessor_config.undistortion_type =
     use_3d_undistortion_ ? CudaPointcloudPreprocessor::UndistortionType::Undistortion3D
                          : CudaPointcloudPreprocessor::UndistortionType::Undistortion2D;
 
-  cuda_pointcloud_preprocessor_ = std::make_unique<CudaPointcloudPreprocessor>();
-  cuda_pointcloud_preprocessor_->setRingOutlierFilterParameters(ring_outlier_filter_parameters);
-  cuda_pointcloud_preprocessor_->setRingOutlierFilterActive(enable_ring_outlier_filter);
-  cuda_pointcloud_preprocessor_->setCropBoxParameters(crop_box_parameters);
-  cuda_pointcloud_preprocessor_->setUndistortionType(undistortion_type);
+  cuda_pointcloud_preprocessor_ = std::make_unique<CudaPointcloudPreprocessor>(preprocessor_config);
 
   // initialize debug tool
   {
@@ -194,72 +194,37 @@ bool CudaPointcloudPreprocessorNode::getTransform(
   return true;
 }
 
-void CudaPointcloudPreprocessorNode::twistCallback(
-  const geometry_msgs::msg::TwistWithCovarianceStamped & twist_msg)
+void CudaPointcloudPreprocessorNode::updateTwistQueue()
 {
-  while (!twist_queue_.empty()) {
-    // for replay rosbag
-    bool backwards_time_jump_detected =
-      rclcpp::Time(twist_queue_.front().header.stamp) > rclcpp::Time(twist_msg.header.stamp);
-    bool is_queue_longer_than_1s =
-      rclcpp::Time(twist_queue_.front().header.stamp) <
-      rclcpp::Time(twist_msg.header.stamp) - rclcpp::Duration::from_seconds(1.0);
-
-    if (backwards_time_jump_detected) {
-      twist_queue_.clear();
-    } else if (is_queue_longer_than_1s) {
-      twist_queue_.pop_front();
-    } else {
-      break;
-    }
+  const std::vector<geometry_msgs::msg::TwistWithCovarianceStamped::ConstSharedPtr> twist_msgs =
+    twist_sub_->take_data();
+  for (const auto & msg : twist_msgs) {
+    cuda_pointcloud_preprocessor_->addTwist(*msg);
   }
-
-  auto it = std::lower_bound(
-    twist_queue_.begin(), twist_queue_.end(), twist_msg.header.stamp,
-    [](const auto & twist, const auto & stamp) {
-      return rclcpp::Time(twist.header.stamp) < stamp;
-    });
-  twist_queue_.insert(it, twist_msg);
 }
 
-void CudaPointcloudPreprocessorNode::imuCallback(const sensor_msgs::msg::Imu & imu_msg)
+void CudaPointcloudPreprocessorNode::updateImuQueue()
 {
-  while (!angular_velocity_queue_.empty()) {
-    // for rosbag replay
-    bool backwards_time_jump_detected = rclcpp::Time(angular_velocity_queue_.front().header.stamp) >
-                                        rclcpp::Time(imu_msg.header.stamp);
+  if (!imu_sub_) return;
 
-    bool is_queue_longer_than_1s =
-      rclcpp::Time(angular_velocity_queue_.front().header.stamp) <
-      rclcpp::Time(imu_msg.header.stamp) - rclcpp::Duration::from_seconds(1.0);
+  const std::vector<sensor_msgs::msg::Imu::ConstSharedPtr> imu_msgs = imu_sub_->take_data();
+  for (const auto & msg : imu_msgs) {
+    const auto & imu_msg = *msg;
 
-    if (backwards_time_jump_detected) {
-      angular_velocity_queue_.clear();
-    } else if (is_queue_longer_than_1s) {
-      angular_velocity_queue_.pop_front();
-    } else {
-      break;
-    }
+    tf2::Transform imu_to_base_tf2{};
+    getTransform(base_frame_, imu_msg.header.frame_id, &imu_to_base_tf2);
+    geometry_msgs::msg::TransformStamped imu_to_base_msg;
+    imu_to_base_msg.transform.rotation = tf2::toMsg(imu_to_base_tf2.getRotation());
+
+    geometry_msgs::msg::Vector3Stamped angular_velocity;
+    angular_velocity.vector = imu_msg.angular_velocity;
+
+    geometry_msgs::msg::Vector3Stamped transformed_angular_velocity;
+    tf2::doTransform(angular_velocity, transformed_angular_velocity, imu_to_base_msg);
+    transformed_angular_velocity.header = imu_msg.header;
+
+    cuda_pointcloud_preprocessor_->addAngularVelocityInBaseFrame(transformed_angular_velocity);
   }
-
-  tf2::Transform imu_to_base_tf2{};
-  getTransform(base_frame_, imu_msg.header.frame_id, &imu_to_base_tf2);
-  geometry_msgs::msg::TransformStamped imu_to_base_msg;
-  imu_to_base_msg.transform.rotation = tf2::toMsg(imu_to_base_tf2.getRotation());
-
-  geometry_msgs::msg::Vector3Stamped angular_velocity;
-  angular_velocity.vector = imu_msg.angular_velocity;
-
-  geometry_msgs::msg::Vector3Stamped transformed_angular_velocity;
-  tf2::doTransform(angular_velocity, transformed_angular_velocity, imu_to_base_msg);
-  transformed_angular_velocity.header = imu_msg.header;
-
-  auto it = std::lower_bound(
-    angular_velocity_queue_.begin(), angular_velocity_queue_.end(), imu_msg.header.stamp,
-    [](const auto & angular_velocity, const auto & stamp) {
-      return rclcpp::Time(angular_velocity.header.stamp) < stamp;
-    });
-  angular_velocity_queue_.insert(it, transformed_angular_velocity);
 }
 
 void CudaPointcloudPreprocessorNode::pointcloudCallback(
@@ -268,22 +233,21 @@ void CudaPointcloudPreprocessorNode::pointcloudCallback(
 {
   const auto & input_pointcloud_msg = *input_pointcloud_msg_ptr;
 
-  if (!validatePointcloudLayout(input_pointcloud_msg)) {
-    return;
-  }
-
   stop_watch_ptr_->toc("processing_time", true);
 
-  const auto [first_point_stamp, first_point_rel_stamp] =
-    getFirstPointTimeInfo(input_pointcloud_msg);
-  updateTwistQueue(first_point_stamp);
-  updateImuQueue(first_point_stamp);
+  updateTwistQueue();
+  updateImuQueue();
 
   const auto transform_msg_opt = lookupTransformToBase(input_pointcloud_msg.header.frame_id);
   if (!transform_msg_opt.has_value()) return;
 
-  auto output_pointcloud_ptr =
-    processPointcloud(input_pointcloud_msg, *transform_msg_opt, first_point_rel_stamp);
+  auto process_result = processPointcloud(input_pointcloud_msg, *transform_msg_opt);
+  if (!process_result) {
+    RCLCPP_ERROR(get_logger(), "%s", process_result.error().message.c_str());
+    return;
+  }
+
+  auto output_pointcloud_ptr = std::move(process_result->output);
   output_pointcloud_ptr->header.frame_id = base_frame_;
 
   publishDiagnostics(input_pointcloud_msg, output_pointcloud_ptr);
@@ -292,87 +256,6 @@ void CudaPointcloudPreprocessorNode::pointcloudCallback(
   // Preallocate buffer for the next run.
   // This is intentionally done after publish() to avoid adding latency to the current cycle.
   cuda_pointcloud_preprocessor_->preallocateOutput();
-}
-
-[[nodiscard]] bool CudaPointcloudPreprocessorNode::validatePointcloudLayout(
-  const sensor_msgs::msg::PointCloud2 & input_pointcloud_msg) const
-{
-  static_assert(
-    sizeof(InputPointType) == sizeof(autoware::point_types::PointXYZIRCAEDT),
-    "PointStruct and PointXYZIRCAEDT must have the same size");
-
-  if (is_data_layout_compatible_with_point_xyzircaedt(input_pointcloud_msg.fields)) {
-    return true;
-  }
-
-  RCLCPP_ERROR(get_logger(), "Input pointcloud data layout is not compatible with PointXYZIRCAEDT");
-  return false;
-}
-
-/**
- * @brief Get the first point's timestamp information from a PointCloud2 message.
- *
- * This function extracts the relative timestamp (`time_stamp` field) of the first point in the
- * point cloud and calculates its absolute timestamp by adding it to the message's header timestamp.
- *
- * @param input_pointcloud_msg The input PointCloud2 message, which must include a "time_stamp"
- * field.
- * @return std::pair<std::uint64_t, std::uint32_t>
- *   - first: The absolute timestamp of the first point (in nanoseconds).
- *   - second: The relative timestamp of the first point (in nanoseconds).
- */
-std::pair<std::uint64_t, std::uint32_t> CudaPointcloudPreprocessorNode::getFirstPointTimeInfo(
-  const sensor_msgs::msg::PointCloud2 & input_pointcloud_msg)
-{
-  sensor_msgs::PointCloud2ConstIterator<std::uint32_t> iter_stamp(
-    input_pointcloud_msg, "time_stamp");
-  auto num_points = input_pointcloud_msg.width * input_pointcloud_msg.height;
-  std::uint32_t first_point_rel_stamp = num_points > 0 ? *iter_stamp : 0;
-  std::uint64_t first_point_stamp = input_pointcloud_msg.header.stamp.sec * 1e9 +
-                                    input_pointcloud_msg.header.stamp.nanosec +
-                                    first_point_rel_stamp;
-  return {first_point_stamp, first_point_rel_stamp};
-}
-
-void CudaPointcloudPreprocessorNode::updateTwistQueue(std::uint64_t first_point_stamp)
-{
-  std::vector<geometry_msgs::msg::TwistWithCovarianceStamped::ConstSharedPtr> twist_msgs =
-    twist_sub_->take_data();
-  for (const auto & msg : twist_msgs) {
-    twistCallback(*msg);
-  }
-
-  // Find the last twist message that is before the first point's timestamp
-  // and remove all older messages.
-  auto it = std::lower_bound(
-    twist_queue_.begin(), twist_queue_.end(), first_point_stamp,
-    [](const auto & twist, const std::uint64_t stamp) {
-      // To prevent potential precision loss, use nanoseconds
-      return rclcpp::Time(twist.header.stamp).nanoseconds() < stamp;
-    });
-
-  twist_queue_.erase(twist_queue_.begin(), it);
-}
-
-void CudaPointcloudPreprocessorNode::updateImuQueue(std::uint64_t first_point_stamp)
-{
-  if (!imu_sub_) return;
-
-  std::vector<sensor_msgs::msg::Imu::ConstSharedPtr> imu_msgs = imu_sub_->take_data();
-  for (const auto & msg : imu_msgs) {
-    imuCallback(*msg);
-  }
-
-  // Find the last angular velocity message that is before the first point's timestamp
-  // and remove all older messages.
-  auto it = std::lower_bound(
-    angular_velocity_queue_.begin(), angular_velocity_queue_.end(), first_point_stamp,
-    [](const auto & angular_velocity, const std::uint64_t stamp) {
-      //  To prevent potential precision loss, use nanoseconds
-      return rclcpp::Time(angular_velocity.header.stamp).nanoseconds() < stamp;
-    });
-
-  angular_velocity_queue_.erase(angular_velocity_queue_.begin(), it);
 }
 
 std::optional<geometry_msgs::msg::TransformStamped>
@@ -386,14 +269,11 @@ CudaPointcloudPreprocessorNode::lookupTransformToBase(const std::string & source
   }
 }
 
-std::unique_ptr<cuda_blackboard::CudaPointCloud2> CudaPointcloudPreprocessorNode::processPointcloud(
+tl::expected<ProcessResult, ProcessError> CudaPointcloudPreprocessorNode::processPointcloud(
   const sensor_msgs::msg::PointCloud2 & input_pointcloud_msg,
-  const geometry_msgs::msg::TransformStamped & transform_msg,
-  const std::uint32_t first_point_rel_stamp)
+  const geometry_msgs::msg::TransformStamped & transform_msg)
 {
-  return cuda_pointcloud_preprocessor_->process(
-    input_pointcloud_msg, transform_msg, twist_queue_, angular_velocity_queue_,
-    first_point_rel_stamp);
+  return cuda_pointcloud_preprocessor_->process(input_pointcloud_msg, transform_msg);
 }
 
 void CudaPointcloudPreprocessorNode::publishDiagnostics(


### PR DESCRIPTION
## Description

Refactor `cuda_pointcloud_preprocessor_node` so the reusable CUDA preprocessor library owns the preprocessing state and returns structured success/error results.

Changes include:

- Add `CudaPointcloudPreprocessorConfig`, `ProcessResult`, and `ProcessError`.
- Change `CudaPointcloudPreprocessor::process()` to return `tl::expected<ProcessResult, ProcessError>`.
- Move twist and base-frame angular velocity queues from the ROS node into `CudaPointcloudPreprocessor`.
- Keep ROS-only responsibilities in the node: parameter declaration, polling subscribers, TF lookup, IMU angular velocity transform, diagnostics, and publishing.
- Add the `tl_expected` dependency.

Example library usage:

```cpp
using autoware::cuda_pointcloud_preprocessor::CudaPointcloudPreprocessor;
using autoware::cuda_pointcloud_preprocessor::CudaPointcloudPreprocessorConfig;

CudaPointcloudPreprocessorConfig config;
config.crop_box_parameters = crop_boxes;
config.ring_outlier_filter_parameters = ring_outlier_params;
config.enable_ring_outlier_filter = true;
config.undistortion_type = CudaPointcloudPreprocessor::UndistortionType::Undistortion3D;

CudaPointcloudPreprocessor preprocessor{config};

for (const auto & twist : twist_msgs) {
  preprocessor.addTwist(twist);
}
for (const auto & angular_velocity : angular_velocities_in_base_frame) {
  preprocessor.addAngularVelocityInBaseFrame(angular_velocity);
}

const auto result = preprocessor.process(input_pointcloud, input_to_base_transform);
if (!result) {
  // Caller decides how to log, report, or drop the input.
  throw std::runtime_error(result.error().message);
}

auto output_pointcloud = std::move(result->output);
const auto stats = result->stats;

// Optional latency optimization for the next cycle.
preprocessor.preallocateOutput();
```

## Related links

**Parent Issue:**

- Link

## How was this PR tested?

- `git diff --check`
- `source /opt/ros/humble/setup.bash && colcon build --packages-up-to autoware_cuda_pointcloud_preprocessor`

The local build completed, but CUDA is not available/discoverable in this environment, so `autoware_cuda_pointcloud_preprocessor` configured itself without building CUDA targets.

## Notes for reviewers

This preserves the existing ROS topic/parameter surface while moving algorithmic state out of the node wrapper. The library still uses ROS message types intentionally, but no longer requires the node to manage motion queues or pointcloud validation/timestamp extraction.

## Interface changes

None for ROS topics or parameters.

The C++ library interface changes: `process()` now returns `tl::expected<ProcessResult, ProcessError>` and motion data is supplied through `addTwist()` / `addAngularVelocityInBaseFrame()`.

## Effects on system behavior

None intended.
