### PR TITLE
refactor(traffic_light_multi_camera_fusion): improve readability and maintainability

### DIFF
--- a/perception/autoware_traffic_light_multi_camera_fusion/src/multi_camera_fusion.cpp
+++ b/perception/autoware_traffic_light_multi_camera_fusion/src/multi_camera_fusion.cpp
@@ -20,7 +20,6 @@
 #include <algorithm>
 #include <cmath>
 #include <map>
-#include <memory>
 #include <utility>
 #include <vector>
 
@@ -95,9 +94,6 @@ MultiCameraFusion::MultiCameraFusion(const MultiCameraFusionConfig & config)
   traffic_light_id_to_regulatory_ele_id_(
     build_traffic_light_id_to_regulatory_ele_id(config.lanelet_map_ptr))
 {
-  if (config_.use_signal_consistency_check) {
-    signal_validator_ = std::make_unique<SignalValidator>();
-  }
 }
 
 MultiCameraFusionResult MultiCameraFusion::fuse(
@@ -336,7 +332,7 @@ void MultiCameraFusion::determine_best_group_state(
     // check if conflicts exist among the signals within the same regulatory element id
     for (++log_odds_it; log_odds_it != group_info.accumulated_log_odds.end(); ++log_odds_it) {
       const StateKey & competitor_state = (*log_odds_it).first;
-      conflict_result = signal_validator_->check_conflict(running_state, competitor_state);
+      conflict_result = signal_validator::check_conflict(running_state, competitor_state);
       running_state = conflict_result.common_state_key;
 
       if (conflict_result.conflict_type == ConflictType::CONFLICT) {

--- a/perception/autoware_traffic_light_multi_camera_fusion/src/multi_camera_fusion.cpp
+++ b/perception/autoware_traffic_light_multi_camera_fusion/src/multi_camera_fusion.cpp
@@ -52,6 +52,29 @@ double probability_to_log_odds(double prob)
   return std::log(prob / (1.0 - prob));
 }
 
+bool is_unknown(const StateKey & state_key)
+{
+  return state_key.size() == 1 &&
+         state_key[0].first == tier4_perception_msgs::msg::TrafficLightElement::UNKNOWN;
+}
+
+bool compare_state_key_log_odds(
+  const std::pair<StateKey, double> & key1, const std::pair<StateKey, double> & key2)
+{
+  // Ordering rule:
+  // 1. Unknown StateKey is always lower priority
+  // 2. Otherwise, smaller log-odds comes first
+  const bool key1_is_unknown = is_unknown(key1.first);
+  const bool key2_is_unknown = is_unknown(key2.first);
+  if (key1_is_unknown && !key2_is_unknown) {
+    return true;
+  }
+  if (!key1_is_unknown && key2_is_unknown) {
+    return false;
+  }
+  return key1.second < key2.second;
+}
+
 /**
  * @brief get the state key that has best log-odds.
  */
@@ -87,6 +110,46 @@ std::map<lanelet::Id, std::vector<lanelet::Id>> build_traffic_light_id_to_regula
   return traffic_light_id_to_regulatory_ele_id;
 }
 
+void convert_output_msg(
+  const std::map<MultiCameraFusion::IdType, utils::FusionRecord> & grouped_record_map,
+  autoware_perception_msgs::msg::TrafficLightGroupArray & msg_out)
+{
+  msg_out.traffic_light_groups.clear();
+  for (const auto & [regulatory_element_id, record] : grouped_record_map) {
+    autoware_perception_msgs::msg::TrafficLightGroup signal_out;
+    signal_out.traffic_light_group_id = regulatory_element_id;
+    for (const auto & element : record.signal.elements) {
+      signal_out.elements.push_back(utils::convert_t4_to_autoware(element));
+    }
+    msg_out.traffic_light_groups.push_back(signal_out);
+  }
+}
+
+/**
+ * @brief Handles the logic for tracking the best record for a given state.
+ */
+void update_best_record(
+  std::map<StateKey, utils::FusionRecord> & best_record_map, const StateKey & state_key,
+  double confidence, const utils::FusionRecord & record)
+{
+  const auto it = best_record_map.find(state_key);
+
+  if (it == best_record_map.end()) {
+    best_record_map[state_key] = record;
+    return;
+  }
+
+  auto & existing_record = it->second;
+
+  if (existing_record.signal.elements.empty()) {
+    return;
+  }
+
+  if (confidence > utils::get_min_confidence(existing_record.signal)) {
+    best_record_map[state_key] = record;
+  }
+}
+
 }  // namespace
 
 MultiCameraFusion::MultiCameraFusion(const MultiCameraFusionConfig & config)
@@ -117,22 +180,6 @@ MultiCameraFusionResult MultiCameraFusion::fuse(
 
   result.conflicted_regulatory_element_status = conflicted_regulatory_element_status_;
   return result;
-}
-
-void MultiCameraFusion::convert_output_msg(
-  const std::map<IdType, utils::FusionRecord> & grouped_record_map, NewSignalArrayType & msg_out)
-{
-  msg_out.traffic_light_groups.clear();
-  for (const auto & p : grouped_record_map) {
-    IdType reg_ele_id = p.first;
-    const SignalType & signal = p.second.signal;
-    NewSignalType signal_out;
-    signal_out.traffic_light_group_id = reg_ele_id;
-    for (const auto & ele : signal.elements) {
-      signal_out.elements.push_back(utils::convert_t4_to_autoware(ele));
-    }
-    msg_out.traffic_light_groups.push_back(signal_out);
-  }
 }
 
 void MultiCameraFusion::multi_camera_fusion(
@@ -272,31 +319,6 @@ void MultiCameraFusion::update_log_odds(
 
   // Accumulate evidence
   log_odds_map[state_key] += evidence_log_odds - config_.prior_log_odds;
-}
-
-/**
- * @brief Handles the logic for tracking the best record for a given state.
- */
-void MultiCameraFusion::update_best_record(
-  std::map<StateKey, utils::FusionRecord> & best_record_map, const StateKey & state_key,
-  double confidence, const utils::FusionRecord & record)
-{
-  const auto it = best_record_map.find(state_key);
-
-  if (it == best_record_map.end()) {
-    best_record_map[state_key] = record;
-    return;
-  }
-
-  auto & existing_record = it->second;
-
-  if (existing_record.signal.elements.empty()) {
-    return;
-  }
-
-  if (confidence > utils::get_min_confidence(existing_record.signal)) {
-    best_record_map[state_key] = record;
-  }
 }
 
 void MultiCameraFusion::determine_best_group_state(

--- a/perception/autoware_traffic_light_multi_camera_fusion/src/multi_camera_fusion.cpp
+++ b/perception/autoware_traffic_light_multi_camera_fusion/src/multi_camera_fusion.cpp
@@ -52,7 +52,7 @@ double probability_to_log_odds(double prob)
   return std::log(prob / (1.0 - prob));
 }
 
-bool is_unknown(const StateKey & state_key)
+bool is_state_key_unknown(const StateKey & state_key)
 {
   return state_key.size() == 1 &&
          state_key[0].first == tier4_perception_msgs::msg::TrafficLightElement::UNKNOWN;
@@ -64,8 +64,8 @@ bool compare_state_key_log_odds(
   // Ordering rule:
   // 1. Unknown StateKey is always lower priority
   // 2. Otherwise, smaller log-odds comes first
-  const bool key1_is_unknown = is_unknown(key1.first);
-  const bool key2_is_unknown = is_unknown(key2.first);
+  const bool key1_is_unknown = is_state_key_unknown(key1.first);
+  const bool key2_is_unknown = is_state_key_unknown(key2.first);
   if (key1_is_unknown && !key2_is_unknown) {
     return true;
   }

--- a/perception/autoware_traffic_light_multi_camera_fusion/src/multi_camera_fusion.cpp
+++ b/perception/autoware_traffic_light_multi_camera_fusion/src/multi_camera_fusion.cpp
@@ -219,7 +219,7 @@ void MultiCameraFusion::multi_camera_fusion(
         */
         if (
           fused_record_map.find(roi.traffic_light_id) == fused_record_map.end() ||
-          utils::compare_record(record, fused_record_map[roi.traffic_light_id]) >= 0) {
+          utils::has_higher_or_equal_priority(record, fused_record_map[roi.traffic_light_id])) {
           fused_record_map[roi.traffic_light_id] = record;
         }
       }

--- a/perception/autoware_traffic_light_multi_camera_fusion/src/multi_camera_fusion.hpp
+++ b/perception/autoware_traffic_light_multi_camera_fusion/src/multi_camera_fusion.hpp
@@ -30,7 +30,6 @@
 #include <lanelet2_core/Forward.h>
 
 #include <map>
-#include <memory>
 #include <set>
 #include <utility>
 #include <vector>
@@ -185,7 +184,6 @@ private:
   */
   std::multiset<utils::FusionRecordArr> record_arr_set_;
 
-  std::unique_ptr<SignalValidator> signal_validator_;
   std::vector<ConflictInfo> conflicted_regulatory_element_status_{};
 };
 

--- a/perception/autoware_traffic_light_multi_camera_fusion/src/multi_camera_fusion.hpp
+++ b/perception/autoware_traffic_light_multi_camera_fusion/src/multi_camera_fusion.hpp
@@ -37,29 +37,6 @@
 namespace autoware::traffic_light
 {
 
-inline bool is_unknown(const StateKey & state_key)
-{
-  return state_key.size() == 1 &&
-         state_key[0].first == tier4_perception_msgs::msg::TrafficLightElement::UNKNOWN;
-}
-
-inline bool compare_state_key_log_odds(
-  const std::pair<StateKey, double> & key1, const std::pair<StateKey, double> & key2)
-{
-  // Ordering rule:
-  // 1. Unknown StateKey is always lower priority
-  // 2. Otherwise, smaller log-odds comes first
-  const bool key1_is_unknown = is_unknown(key1.first);
-  const bool key2_is_unknown = is_unknown(key2.first);
-  if (key1_is_unknown && !key2_is_unknown) {
-    return true;
-  }
-  if (!key1_is_unknown && key2_is_unknown) {
-    return false;
-  }
-  return key1.second < key2.second;
-}
-
 struct GroupFusionInfo
 {
   std::map<StateKey, double> accumulated_log_odds;
@@ -123,9 +100,6 @@ public:
 private:
   void multi_camera_fusion(std::map<IdType, utils::FusionRecord> & fused_record_map);
 
-  static void convert_output_msg(
-    const std::map<IdType, utils::FusionRecord> & grouped_record_map, NewSignalArrayType & msg_out);
-
   void group_fusion(
     const std::map<IdType, utils::FusionRecord> & fused_record_map,
     std::map<IdType, utils::FusionRecord> & grouped_record_map,
@@ -158,13 +132,6 @@ private:
    */
   void update_log_odds(
     std::map<StateKey, double> & log_odds_map, const StateKey & state_key, double confidence) const;
-
-  /**
-   * @brief Handles the logic for tracking the best record for a given state.
-   */
-  static void update_best_record(
-    std::map<StateKey, utils::FusionRecord> & best_record_map, const StateKey & state_key,
-    double confidence, const utils::FusionRecord & record);
 
   /**
    * @brief Determines the best state for each group based on accumulated evidence.

--- a/perception/autoware_traffic_light_multi_camera_fusion/src/multi_camera_fusion.hpp
+++ b/perception/autoware_traffic_light_multi_camera_fusion/src/multi_camera_fusion.hpp
@@ -31,7 +31,6 @@
 
 #include <map>
 #include <set>
-#include <utility>
 #include <vector>
 
 namespace autoware::traffic_light

--- a/perception/autoware_traffic_light_multi_camera_fusion/src/signal_validator.cpp
+++ b/perception/autoware_traffic_light_multi_camera_fusion/src/signal_validator.cpp
@@ -16,6 +16,8 @@
 
 #include "types.hpp"
 
+#include <tier4_perception_msgs/msg/traffic_light_element.hpp>
+
 #include <utility>
 
 namespace autoware::traffic_light

--- a/perception/autoware_traffic_light_multi_camera_fusion/src/signal_validator.cpp
+++ b/perception/autoware_traffic_light_multi_camera_fusion/src/signal_validator.cpp
@@ -71,8 +71,12 @@ inline SignalLUT extract_common_signals(const SignalLUT & lut_a, const SignalLUT
  * @param state_b Second StateKey.
  * @return Conflict status and common signals (StateKey).
  */
-ConflictStatus SignalValidator::check_conflict(const StateKey & state_a, const StateKey & state_b)
+namespace signal_validator
 {
+ConflictStatus check_conflict(const StateKey & state_a, const StateKey & state_b)
+{
+  using TrafficLightElement = tier4_perception_msgs::msg::TrafficLightElement;
+
   // check if states match across signals.
   //
   // NOTE: Currently, identical shape/color pairs (e.g., duplicate entries)
@@ -119,5 +123,6 @@ ConflictStatus SignalValidator::check_conflict(const StateKey & state_a, const S
     }
   }
 }
+}  // namespace signal_validator
 
 }  // namespace autoware::traffic_light

--- a/perception/autoware_traffic_light_multi_camera_fusion/src/signal_validator.hpp
+++ b/perception/autoware_traffic_light_multi_camera_fusion/src/signal_validator.hpp
@@ -48,15 +48,10 @@ struct ConflictStatus
   StateKey common_state_key;
 };
 
-class SignalValidator
+namespace signal_validator
 {
-public:
-  using TrafficLightElement = tier4_perception_msgs::msg::TrafficLightElement;
-
-  static ConflictStatus check_conflict(const StateKey & state_a, const StateKey & state_b);
-
-  StateKey merge_partial_match(const StateKey & state_a, const StateKey & state_b);
-};
+ConflictStatus check_conflict(const StateKey & state_a, const StateKey & state_b);
+}  // namespace signal_validator
 
 }  // namespace autoware::traffic_light
 

--- a/perception/autoware_traffic_light_multi_camera_fusion/src/signal_validator.hpp
+++ b/perception/autoware_traffic_light_multi_camera_fusion/src/signal_validator.hpp
@@ -17,8 +17,6 @@
 
 #include "types.hpp"
 
-#include <tier4_perception_msgs/msg/traffic_light.hpp>
-
 #include <unordered_set>
 #include <utility>
 

--- a/perception/autoware_traffic_light_multi_camera_fusion/src/traffic_light_multi_camera_fusion_process.cpp
+++ b/perception/autoware_traffic_light_multi_camera_fusion/src/traffic_light_multi_camera_fusion_process.cpp
@@ -15,7 +15,7 @@
 #include "traffic_light_multi_camera_fusion_process.hpp"
 
 #include <autoware/traffic_light_utils/traffic_light_utils.hpp>
-#include <rclcpp/rclcpp.hpp>
+#include <rclcpp/time.hpp>
 
 #include <unordered_map>
 

--- a/perception/autoware_traffic_light_multi_camera_fusion/src/traffic_light_multi_camera_fusion_process.cpp
+++ b/perception/autoware_traffic_light_multi_camera_fusion/src/traffic_light_multi_camera_fusion_process.cpp
@@ -100,8 +100,8 @@ int compare_record(const FusionRecord & r1, const FusionRecord & r2)
   if (r1.header.frame_id == r2.header.frame_id && std::abs(t1 - t2) >= dt_thres) {
     return t1 < t2 ? -1 : 1;
   }
-  bool r1_is_unknown = is_unknown(r1.signal);
-  bool r2_is_unknown = is_unknown(r2.signal);
+  bool r1_is_unknown = is_signal_unknown(r1.signal);
+  bool r2_is_unknown = is_signal_unknown(r2.signal);
   /*
   if both are unknown, they are of the same priority
   */

--- a/perception/autoware_traffic_light_multi_camera_fusion/src/traffic_light_multi_camera_fusion_process.cpp
+++ b/perception/autoware_traffic_light_multi_camera_fusion/src/traffic_light_multi_camera_fusion_process.cpp
@@ -114,10 +114,10 @@ bool has_higher_or_equal_priority(const FusionRecord & candidate, const FusionRe
   }
 
   // 3. a fully visible signal outranks a truncated one
-  const int candidate_visible_score = cal_visible_score(candidate);
-  const int existing_visible_score = cal_visible_score(existing);
-  if (candidate_visible_score != existing_visible_score) {
-    return candidate_visible_score > existing_visible_score;
+  const bool candidate_is_visible = is_fully_visible(candidate);
+  const bool existing_is_visible = is_fully_visible(existing);
+  if (candidate_is_visible != existing_is_visible) {
+    return candidate_is_visible;
   }
 
   // 4. otherwise the higher confidence wins
@@ -140,20 +140,16 @@ autoware_perception_msgs::msg::TrafficLightElement convert_t4_to_autoware(
   return output;
 }
 
-int cal_visible_score(const FusionRecord & record)
+bool is_fully_visible(const FusionRecord & record)
 {
   const uint32_t boundary = 5;
-  uint32_t x1 = record.roi.roi.x_offset;
-  uint32_t x2 = record.roi.roi.x_offset + record.roi.roi.width;
-  uint32_t y1 = record.roi.roi.y_offset;
-  uint32_t y2 = record.roi.roi.y_offset + record.roi.roi.height;
-  if (
-    x1 <= boundary || (record.cam_info.width - x2) <= boundary || y1 <= boundary ||
-    (record.cam_info.height - y2) <= boundary) {
-    return 0;
-  } else {
-    return 1;
-  }
+  const uint32_t x1 = record.roi.roi.x_offset;
+  const uint32_t x2 = record.roi.roi.x_offset + record.roi.roi.width;
+  const uint32_t y1 = record.roi.roi.y_offset;
+  const uint32_t y2 = record.roi.roi.y_offset + record.roi.roi.height;
+  const bool is_truncated = x1 <= boundary || (record.cam_info.width - x2) <= boundary ||
+                            y1 <= boundary || (record.cam_info.height - y2) <= boundary;
+  return !is_truncated;
 }
 
 FusionRecord generate_failsafe_record(FusionRecord base_record)

--- a/perception/autoware_traffic_light_multi_camera_fusion/src/traffic_light_multi_camera_fusion_process.cpp
+++ b/perception/autoware_traffic_light_multi_camera_fusion/src/traffic_light_multi_camera_fusion_process.cpp
@@ -83,45 +83,45 @@ double get_min_confidence(const tier4_perception_msgs::msg::TrafficLight & signa
     ->confidence;
 }
 
-int compare_record(const FusionRecord & r1, const FusionRecord & r2)
+bool has_higher_or_equal_priority(const FusionRecord & candidate, const FusionRecord & existing)
 {
   /*
-  r1 will be checked
-  return 1 if r1 is better than r2
-  return -1 if r1 is worse than r2
-  return 0 if r1 is equal to r2
+  Records are ranked by a fixed priority order. Ties favor the candidate so that a
+  newly arrived record wins over an equally-ranked existing one.
   */
-  /*
-  if both records are from the same sensor but different stamp, trust the latest one
-  */
-  double t1 = rclcpp::Time(r1.header.stamp).seconds();
-  double t2 = rclcpp::Time(r2.header.stamp).seconds();
+
+  // 1. records from the same camera are ranked by timestamp; trust the latest one
+  const double candidate_time = rclcpp::Time(candidate.header.stamp).seconds();
+  const double existing_time = rclcpp::Time(existing.header.stamp).seconds();
   const double dt_thres = 1e-3;
-  if (r1.header.frame_id == r2.header.frame_id && std::abs(t1 - t2) >= dt_thres) {
-    return t1 < t2 ? -1 : 1;
+  if (
+    candidate.header.frame_id == existing.header.frame_id &&
+    std::abs(candidate_time - existing_time) >= dt_thres) {
+    return candidate_time >= existing_time;
   }
-  bool r1_is_unknown = is_signal_unknown(r1.signal);
-  bool r2_is_unknown = is_signal_unknown(r2.signal);
-  /*
-  if both are unknown, they are of the same priority
-  */
-  if (r1_is_unknown && r2_is_unknown) {
-    return 0;
-  } else if (r1_is_unknown ^ r2_is_unknown) {
-    /*
-    if either is unknown, the unknown is of lower priority
-    */
-    return r1_is_unknown ? -1 : 1;
+
+  // 2. a recognized signal outranks an unknown one
+  const bool candidate_is_unknown = is_signal_unknown(candidate.signal);
+  const bool existing_is_unknown = is_signal_unknown(existing.signal);
+  if (candidate_is_unknown && existing_is_unknown) {
+    return true;  // both unknown -> equal priority (favor the candidate)
   }
-  int visible_score_1 = cal_visible_score(r1);
-  int visible_score_2 = cal_visible_score(r2);
-  if (visible_score_1 == visible_score_2) {
-    double confidence_1 = get_min_confidence(r1.signal);
-    double confidence_2 = get_min_confidence(r2.signal);
-    return confidence_1 < confidence_2 ? -1 : 1;
-  } else {
-    return visible_score_1 < visible_score_2 ? -1 : 1;
+  if (candidate_is_unknown) {
+    return false;  // only the candidate is unknown -> it loses
   }
+  if (existing_is_unknown) {
+    return true;  // only the existing record is unknown -> the candidate wins
+  }
+
+  // 3. a fully visible signal outranks a truncated one
+  const int candidate_visible_score = cal_visible_score(candidate);
+  const int existing_visible_score = cal_visible_score(existing);
+  if (candidate_visible_score != existing_visible_score) {
+    return candidate_visible_score > existing_visible_score;
+  }
+
+  // 4. otherwise the higher confidence wins
+  return get_min_confidence(candidate.signal) >= get_min_confidence(existing.signal);
 }
 
 autoware_perception_msgs::msg::TrafficLightElement convert_t4_to_autoware(

--- a/perception/autoware_traffic_light_multi_camera_fusion/src/traffic_light_multi_camera_fusion_process.hpp
+++ b/perception/autoware_traffic_light_multi_camera_fusion/src/traffic_light_multi_camera_fusion_process.hpp
@@ -85,13 +85,14 @@ autoware_perception_msgs::msg::TrafficLightElement convert_t4_to_autoware(
   const tier4_perception_msgs::msg::TrafficLightElement & input);
 
 /**
- * @brief Currently the visible score only considers the truncation.
- * If the detection roi is very close to the image boundary, it would be considered as truncated.
+ * @brief Check whether the detection roi is fully visible, i.e. not truncated by the image
+ * boundary. If the detection roi is very close to the image boundary, it is considered as
+ * truncated.
  *
  * @param record    fusion record
- * @return 0 if traffic light is truncated, otherwise 1
+ * @return true if the traffic light is fully visible, false if truncated
  */
-int cal_visible_score(const FusionRecord & record);
+bool is_fully_visible(const FusionRecord & record);
 FusionRecord generate_failsafe_record(FusionRecord base_record);
 
 }  // namespace utils

--- a/perception/autoware_traffic_light_multi_camera_fusion/src/traffic_light_multi_camera_fusion_process.hpp
+++ b/perception/autoware_traffic_light_multi_camera_fusion/src/traffic_light_multi_camera_fusion_process.hpp
@@ -67,7 +67,19 @@ V at_or(const std::unordered_map<K, V> & map, const K & key, const V & value)
 }
 
 double get_min_confidence(const tier4_perception_msgs::msg::TrafficLight & signal);
-int compare_record(const FusionRecord & r1, const FusionRecord & r2);
+
+/**
+ * @brief Decide whether `candidate` should replace `existing` as the fused result.
+ *
+ * Records are ranked by a fixed priority order (timestamp for the same camera, then
+ * recognized-over-unknown, then visibility, then confidence). Ties favor the candidate
+ * so that a newly arrived record wins over an equally-ranked existing one.
+ *
+ * @param candidate   newly arrived record
+ * @param existing    record currently held as the best for this traffic light
+ * @return true if the candidate has a higher or equal priority than the existing record
+ */
+bool has_higher_or_equal_priority(const FusionRecord & candidate, const FusionRecord & existing);
 
 autoware_perception_msgs::msg::TrafficLightElement convert_t4_to_autoware(
   const tier4_perception_msgs::msg::TrafficLightElement & input);

--- a/perception/autoware_traffic_light_multi_camera_fusion/src/traffic_light_multi_camera_fusion_process.hpp
+++ b/perception/autoware_traffic_light_multi_camera_fusion/src/traffic_light_multi_camera_fusion_process.hpp
@@ -53,7 +53,7 @@ struct FusionRecordArr
   }
 };
 
-inline bool is_unknown(const tier4_perception_msgs::msg::TrafficLight & signal)
+inline bool is_signal_unknown(const tier4_perception_msgs::msg::TrafficLight & signal)
 {
   return signal.elements.size() == 1 &&
          signal.elements[0].color == tier4_perception_msgs::msg::TrafficLightElement::UNKNOWN &&

--- a/perception/autoware_traffic_light_multi_camera_fusion/test/test_multi_camera_fusion.cpp
+++ b/perception/autoware_traffic_light_multi_camera_fusion/test/test_multi_camera_fusion.cpp
@@ -454,8 +454,8 @@ TEST(MultiCameraFusionFuse, TruncatedRoiHasLowerPriorityThanCenteredRoi)
   // Arrange
   // Two cameras observe the same traffic_light_id. camera0 reports a truncated ROI
   // (visible_score=0) with the higher confidence; camera1 reports a centered ROI
-  // (visible_score=1) with the lower confidence. compare_record's visibility check ranks above the
-  // confidence check, so camera1's record is selected and the fused output is RED.
+  // (visible_score=1) with the lower confidence. has_higher_or_equal_priority's visibility check
+  // ranks above the confidence check, so camera1's record is selected and the fused output is RED.
   MultiCameraFusion fusion(make_default_config());
   const rclcpp::Time stamp(100, 0);
   const auto truncated_camera_info = make_camera_info(stamp, "camera0");
@@ -478,8 +478,8 @@ TEST(MultiCameraFusionFuse, UnknownSignalLosesToValidSignalForSameTrafficLightId
 {
   // Arrange
   // Two cameras observe the same traffic_light_id. camera0 reports an UNKNOWN signal;
-  // camera1 reports GREEN. compare_record's unknown check drops the unknown record, so the
-  // fused output reflects camera1.
+  // camera1 reports GREEN. has_higher_or_equal_priority's unknown check drops the unknown record,
+  // so the fused output reflects camera1.
   MultiCameraFusion fusion(make_default_config());
   const auto unknown_input =
     make_fusion_input("camera0", make_unknown_signal(LEFT_TRAFFIC_LIGHT_ID));
@@ -499,8 +499,9 @@ TEST(MultiCameraFusionFuse, NewerTimestampWinsForSameFrameIdAndTrafficLightId)
 {
   // Arrange
   // The same camera publishes two observations of the same traffic_light_id within the lifespan.
-  // compare_record's first priority (same frame_id with timestamps differing by >= 1 ms) prefers
-  // the newer record regardless of confidence, so the later RED supersedes the earlier GREEN.
+  // has_higher_or_equal_priority's first priority (same frame_id with timestamps differing by >= 1
+  // ms) prefers the newer record regardless of confidence, so the later RED supersedes the earlier
+  // GREEN.
   MultiCameraFusion fusion(make_default_config());
   const std::string frame_id = "camera0";
   const auto earlier_input = make_fusion_input(
@@ -522,8 +523,8 @@ TEST(MultiCameraFusionFuse, HigherConfidenceWinsWhenVisibleScoreTiesForSameTraff
 {
   // Arrange
   // Two cameras observe the same traffic_light_id with centered ROIs (visible_score=1 each).
-  // compare_record falls through to its last priority — the confidence comparison — and selects
-  // the higher-confidence RED over the lower-confidence GREEN.
+  // has_higher_or_equal_priority falls through to its last priority — the confidence
+  // comparison — and selects the higher-confidence RED over the lower-confidence GREEN.
   MultiCameraFusion fusion(make_default_config());
   const auto low_confidence_input =
     make_fusion_input("camera0", make_signal(LEFT_TRAFFIC_LIGHT_ID, T4Element::GREEN, 0.5f));
@@ -576,9 +577,10 @@ TEST(MultiCameraFusionFuse, MinElementConfidenceDeterminesWinnerForMultiElementS
   // Each signal has CIRCLE + LEFT_ARROW with differing per-element confidences:
   //   camera0: {CIRCLE 0.8, LEFT_ARROW 0.8}  -> min = 0.8
   //   camera1: {CIRCLE 0.9, LEFT_ARROW 0.3}  -> min = 0.3
-  // compare_record falls through to the confidence check, which uses utils::get_min_confidence.
-  // With min-aggregation, camera0 wins (0.8 > 0.3); with max-aggregation, camera1 would win
-  // (0.9 > 0.8). The output's preserved per-element confidences distinguish the two cases.
+  // has_higher_or_equal_priority falls through to the confidence check, which uses
+  // utils::get_min_confidence. With min-aggregation, camera0 wins (0.8 > 0.3); with
+  // max-aggregation, camera1 would win (0.9 > 0.8). The output's preserved per-element confidences
+  // distinguish the two cases.
   MultiCameraFusion fusion(make_default_config());
   const auto input0 = make_fusion_input(
     "camera0", make_signal_with_left_arrow(LEFT_TRAFFIC_LIGHT_ID, T4Element::GREEN, 0.8f, 0.8f));

--- a/perception/autoware_traffic_light_multi_camera_fusion/test/test_multi_camera_fusion.cpp
+++ b/perception/autoware_traffic_light_multi_camera_fusion/test/test_multi_camera_fusion.cpp
@@ -174,7 +174,7 @@ TrafficLight make_signal(lanelet::Id traffic_light_id, uint8_t color, float conf
   return signal;
 }
 
-// Matches utils::is_unknown: a single element whose color and shape are both UNKNOWN.
+// Matches utils::is_signal_unknown: a single element whose color and shape are both UNKNOWN.
 TrafficLight make_unknown_signal(lanelet::Id traffic_light_id)
 {
   T4Element element;

--- a/perception/autoware_traffic_light_multi_camera_fusion/test/test_multi_camera_fusion.cpp
+++ b/perception/autoware_traffic_light_multi_camera_fusion/test/test_multi_camera_fusion.cpp
@@ -142,7 +142,7 @@ TrafficLightRoiArray make_roi_array(
   return roi_array;
 }
 
-// ROI placed against the top-left image boundary so cal_visible_score returns 0.
+// ROI placed against the top-left image boundary so is_fully_visible returns false.
 TrafficLightRoiArray make_truncated_roi_array(
   const rclcpp::Time & stamp, const std::string & frame_id, lanelet::Id traffic_light_id)
 {
@@ -453,8 +453,8 @@ TEST(MultiCameraFusionFuse, TruncatedRoiHasLowerPriorityThanCenteredRoi)
 {
   // Arrange
   // Two cameras observe the same traffic_light_id. camera0 reports a truncated ROI
-  // (visible_score=0) with the higher confidence; camera1 reports a centered ROI
-  // (visible_score=1) with the lower confidence. has_higher_or_equal_priority's visibility check
+  // (truncated) with the higher confidence; camera1 reports a centered ROI
+  // (fully visible) with the lower confidence. has_higher_or_equal_priority's visibility check
   // ranks above the confidence check, so camera1's record is selected and the fused output is RED.
   MultiCameraFusion fusion(make_default_config());
   const rclcpp::Time stamp(100, 0);
@@ -519,10 +519,10 @@ TEST(MultiCameraFusionFuse, NewerTimestampWinsForSameFrameIdAndTrafficLightId)
   expect_single_fused_color(result, TrafficLightElement::RED);
 }
 
-TEST(MultiCameraFusionFuse, HigherConfidenceWinsWhenVisibleScoreTiesForSameTrafficLightId)
+TEST(MultiCameraFusionFuse, HigherConfidenceWinsWhenBothFullyVisibleForSameTrafficLightId)
 {
   // Arrange
-  // Two cameras observe the same traffic_light_id with centered ROIs (visible_score=1 each).
+  // Two cameras observe the same traffic_light_id with centered ROIs (fully visible each).
   // has_higher_or_equal_priority falls through to its last priority — the confidence
   // comparison — and selects the higher-confidence RED over the lower-confidence GREEN.
   MultiCameraFusion fusion(make_default_config());
@@ -573,7 +573,7 @@ TEST(MultiCameraFusionFuse, PartialConflictWithPartialMatchEnabledPublishesCommo
 TEST(MultiCameraFusionFuse, MinElementConfidenceDeterminesWinnerForMultiElementSignals)
 {
   // Arrange
-  // Two cameras observe the same traffic_light_id with centered ROIs (visible_score tied at 1).
+  // Two cameras observe the same traffic_light_id with centered ROIs (both fully visible).
   // Each signal has CIRCLE + LEFT_ARROW with differing per-element confidences:
   //   camera0: {CIRCLE 0.8, LEFT_ARROW 0.8}  -> min = 0.8
   //   camera1: {CIRCLE 0.9, LEFT_ARROW 0.3}  -> min = 0.3

--- a/perception/autoware_traffic_light_multi_camera_fusion/test/test_signal_validator.cpp
+++ b/perception/autoware_traffic_light_multi_camera_fusion/test/test_signal_validator.cpp
@@ -21,27 +21,21 @@
 
 using autoware::traffic_light::ConflictStatus;
 using autoware::traffic_light::ConflictType;
-using autoware::traffic_light::SignalValidator;
 using autoware::traffic_light::StateKey;
+using autoware::traffic_light::signal_validator::check_conflict;
 using tier4_perception_msgs::msg::TrafficLightElement;
-
-class SignalValidatorCheckConflict : public ::testing::Test
-{
-protected:
-  SignalValidator validator;
-};
 
 // ----------------------------------------------------------------------------
 // test checkMismatchLogic
 //  basic rules
 
 // same color and shape: no conflict
-TEST_F(SignalValidatorCheckConflict, RedCircle_RedCircle)
+TEST(CheckConflict, RedCircle_RedCircle)
 {
   StateKey input_a = {{TrafficLightElement::RED, TrafficLightElement::CIRCLE}};
   StateKey input_b = {{TrafficLightElement::RED, TrafficLightElement::CIRCLE}};
 
-  ConflictStatus result = validator.check_conflict(input_a, input_b);
+  ConflictStatus result = check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::NO_CONFLICT;
@@ -53,12 +47,12 @@ TEST_F(SignalValidatorCheckConflict, RedCircle_RedCircle)
 
 // different color and same shape
 // -> critical conflict
-TEST_F(SignalValidatorCheckConflict, RedCircle_GreenCircle)
+TEST(CheckConflict, RedCircle_GreenCircle)
 {
   StateKey input_a = {{TrafficLightElement::RED, TrafficLightElement::CIRCLE}};
   StateKey input_b = {{TrafficLightElement::GREEN, TrafficLightElement::CIRCLE}};
 
-  ConflictStatus result = validator.check_conflict(input_a, input_b);
+  ConflictStatus result = check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::CONFLICT;
@@ -71,12 +65,12 @@ TEST_F(SignalValidatorCheckConflict, RedCircle_GreenCircle)
 // check swapped input
 // different colors and same shape
 // -> critical conflict
-TEST_F(SignalValidatorCheckConflict, GreenCircle_RedCircle)
+TEST(CheckConflict, GreenCircle_RedCircle)
 {
   StateKey input_a = {{TrafficLightElement::GREEN, TrafficLightElement::CIRCLE}};
   StateKey input_b = {{TrafficLightElement::RED, TrafficLightElement::CIRCLE}};
 
-  ConflictStatus result = validator.check_conflict(input_a, input_b);
+  ConflictStatus result = check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::CONFLICT;
@@ -88,7 +82,7 @@ TEST_F(SignalValidatorCheckConflict, GreenCircle_RedCircle)
 
 // same colors and shapes with circles and arrows
 // -> no conflict
-TEST_F(SignalValidatorCheckConflict, RedCircleGreenLeftarrow_RedCircleGreenLeftarrow)
+TEST(CheckConflict, RedCircleGreenLeftarrow_RedCircleGreenLeftarrow)
 {
   StateKey input_a = {
     {TrafficLightElement::RED, TrafficLightElement::CIRCLE},
@@ -97,7 +91,7 @@ TEST_F(SignalValidatorCheckConflict, RedCircleGreenLeftarrow_RedCircleGreenLefta
     {TrafficLightElement::RED, TrafficLightElement::CIRCLE},
     {TrafficLightElement::GREEN, TrafficLightElement::LEFT_ARROW}};
 
-  ConflictStatus result = validator.check_conflict(input_a, input_b);
+  ConflictStatus result = check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::NO_CONFLICT;
@@ -111,7 +105,7 @@ TEST_F(SignalValidatorCheckConflict, RedCircleGreenLeftarrow_RedCircleGreenLefta
 
 // same color for circles, and multiple matched arrows
 // -> no conflict
-TEST_F(SignalValidatorCheckConflict, RedCircleMultipleMatchedArrows_RedCircleMultipleMatchedArrows)
+TEST(CheckConflict, RedCircleMultipleMatchedArrows_RedCircleMultipleMatchedArrows)
 {
   StateKey input_a = {
     {TrafficLightElement::RED, TrafficLightElement::CIRCLE},
@@ -126,7 +120,7 @@ TEST_F(SignalValidatorCheckConflict, RedCircleMultipleMatchedArrows_RedCircleMul
     {TrafficLightElement::GREEN, TrafficLightElement::RIGHT_ARROW},
     {TrafficLightElement::GREEN, TrafficLightElement::DOWN_LEFT_ARROW}};
 
-  ConflictStatus result = validator.check_conflict(input_a, input_b);
+  ConflictStatus result = check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::NO_CONFLICT;
@@ -143,7 +137,7 @@ TEST_F(SignalValidatorCheckConflict, RedCircleMultipleMatchedArrows_RedCircleMul
 
 // different colors for circles, same color for arrows
 // -> partial conflict
-TEST_F(SignalValidatorCheckConflict, RedCircleGreenLeftarrow_GreenCircleGreenLeftarrow)
+TEST(CheckConflict, RedCircleGreenLeftarrow_GreenCircleGreenLeftarrow)
 {
   StateKey input_a = {
     {TrafficLightElement::RED, TrafficLightElement::CIRCLE},
@@ -154,7 +148,7 @@ TEST_F(SignalValidatorCheckConflict, RedCircleGreenLeftarrow_GreenCircleGreenLef
     {TrafficLightElement::GREEN, TrafficLightElement::LEFT_ARROW},
   };
 
-  ConflictStatus result = validator.check_conflict(input_a, input_b);
+  ConflictStatus result = check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::PARTIAL_CONFLICT;
@@ -167,7 +161,7 @@ TEST_F(SignalValidatorCheckConflict, RedCircleGreenLeftarrow_GreenCircleGreenLef
 
 // same color for circles, different colors for arrows
 // -> partial conflict
-TEST_F(SignalValidatorCheckConflict, RedCircleGreenLeftarrow_RedCircleRedLeftarrow)
+TEST(CheckConflict, RedCircleGreenLeftarrow_RedCircleRedLeftarrow)
 {
   StateKey input_a = {
     {TrafficLightElement::RED, TrafficLightElement::CIRCLE},
@@ -178,7 +172,7 @@ TEST_F(SignalValidatorCheckConflict, RedCircleGreenLeftarrow_RedCircleRedLeftarr
     {TrafficLightElement::RED, TrafficLightElement::LEFT_ARROW},
   };
 
-  ConflictStatus result = validator.check_conflict(input_a, input_b);
+  ConflictStatus result = check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::PARTIAL_CONFLICT;
@@ -190,7 +184,7 @@ TEST_F(SignalValidatorCheckConflict, RedCircleGreenLeftarrow_RedCircleRedLeftarr
 
 // same color for circles, different colors for arrows
 // -> partial conflict
-TEST_F(SignalValidatorCheckConflict, GreenLeftarrowRedCircle_RedCircle)
+TEST(CheckConflict, GreenLeftarrowRedCircle_RedCircle)
 {
   StateKey input_a = {
     {TrafficLightElement::GREEN, TrafficLightElement::LEFT_ARROW},
@@ -199,7 +193,7 @@ TEST_F(SignalValidatorCheckConflict, GreenLeftarrowRedCircle_RedCircle)
     {TrafficLightElement::RED, TrafficLightElement::CIRCLE},
   };
 
-  ConflictStatus result = validator.check_conflict(input_a, input_b);
+  ConflictStatus result = check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::PARTIAL_CONFLICT;
@@ -211,7 +205,7 @@ TEST_F(SignalValidatorCheckConflict, GreenLeftarrowRedCircle_RedCircle)
 
 // same color for circles, different colors for arrows (swapped input)
 // -> partial conflict
-TEST_F(SignalValidatorCheckConflict, RedCircle_GreenLeftarrowRedCircle)
+TEST(CheckConflict, RedCircle_GreenLeftarrowRedCircle)
 {
   StateKey input_a = {
     {TrafficLightElement::RED, TrafficLightElement::CIRCLE},
@@ -220,7 +214,7 @@ TEST_F(SignalValidatorCheckConflict, RedCircle_GreenLeftarrowRedCircle)
     {TrafficLightElement::GREEN, TrafficLightElement::LEFT_ARROW},
     {TrafficLightElement::RED, TrafficLightElement::CIRCLE}};
 
-  ConflictStatus result = validator.check_conflict(input_a, input_b);
+  ConflictStatus result = check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::PARTIAL_CONFLICT;
@@ -232,7 +226,7 @@ TEST_F(SignalValidatorCheckConflict, RedCircle_GreenLeftarrowRedCircle)
 
 // same color for circles, and multiple matched arrows and single mismatched arrow
 // -> partial conflict
-TEST_F(SignalValidatorCheckConflict, RedCircleMultipleArrows_RedCircleMultipleArrows_ArrowMismatch)
+TEST(CheckConflict, RedCircleMultipleArrows_RedCircleMultipleArrows_ArrowMismatch)
 {
   StateKey input_a = {
     {TrafficLightElement::RED, TrafficLightElement::CIRCLE},
@@ -247,7 +241,7 @@ TEST_F(SignalValidatorCheckConflict, RedCircleMultipleArrows_RedCircleMultipleAr
     {TrafficLightElement::GREEN, TrafficLightElement::RIGHT_ARROW},
     {TrafficLightElement::GREEN, TrafficLightElement::DOWN_ARROW}};
 
-  ConflictStatus result = validator.check_conflict(input_a, input_b);
+  ConflictStatus result = check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::PARTIAL_CONFLICT;
@@ -264,14 +258,14 @@ TEST_F(SignalValidatorCheckConflict, RedCircleMultipleArrows_RedCircleMultipleAr
 // ------------------------------------------
 // test circle with arrow and only arrow
 // -> critical conflict
-TEST_F(SignalValidatorCheckConflict, RedCircleGreendownarrow_GreenUparrow)
+TEST(CheckConflict, RedCircleGreendownarrow_GreenUparrow)
 {
   StateKey input_a = {
     {TrafficLightElement::RED, TrafficLightElement::CIRCLE},
     {TrafficLightElement::GREEN, TrafficLightElement::DOWN_ARROW}};
   StateKey input_b = {{TrafficLightElement::GREEN, TrafficLightElement::UP_ARROW}};
 
-  ConflictStatus result = validator.check_conflict(input_a, input_b);
+  ConflictStatus result = check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::CONFLICT;
@@ -286,12 +280,12 @@ TEST_F(SignalValidatorCheckConflict, RedCircleGreendownarrow_GreenUparrow)
 
 // same signal
 // -> no conflict
-TEST_F(SignalValidatorCheckConflict, WhiteCross_WhiteCross)
+TEST(CheckConflict, WhiteCross_WhiteCross)
 {
   StateKey input_a = {{TrafficLightElement::WHITE, TrafficLightElement::CROSS}};
   StateKey input_b = {{TrafficLightElement::WHITE, TrafficLightElement::CROSS}};
 
-  ConflictStatus result = validator.check_conflict(input_a, input_b);
+  ConflictStatus result = check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::NO_CONFLICT;
@@ -303,12 +297,12 @@ TEST_F(SignalValidatorCheckConflict, WhiteCross_WhiteCross)
 
 // different signal
 // -> critical conflict
-TEST_F(SignalValidatorCheckConflict, WhiteCross_WhiteCIRCLE)
+TEST(CheckConflict, WhiteCross_WhiteCIRCLE)
 {
   StateKey input_a = {{TrafficLightElement::WHITE, TrafficLightElement::CROSS}};
   StateKey input_b = {{TrafficLightElement::WHITE, TrafficLightElement::CIRCLE}};
 
-  ConflictStatus result = validator.check_conflict(input_a, input_b);
+  ConflictStatus result = check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::CONFLICT;
@@ -320,14 +314,14 @@ TEST_F(SignalValidatorCheckConflict, WhiteCross_WhiteCIRCLE)
 
 // same cross signal and different arrow signal
 // -> critical conflict
-TEST_F(SignalValidatorCheckConflict, AmberCross_AmberCrossGreenUparrow)
+TEST(CheckConflict, AmberCross_AmberCrossGreenUparrow)
 {
   StateKey input_a = {{TrafficLightElement::AMBER, TrafficLightElement::CROSS}};
   StateKey input_b = {
     {TrafficLightElement::AMBER, TrafficLightElement::CROSS},
     {TrafficLightElement::GREEN, TrafficLightElement::UP_ARROW}};
 
-  ConflictStatus result = validator.check_conflict(input_a, input_b);
+  ConflictStatus result = check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::PARTIAL_CONFLICT;
@@ -338,7 +332,7 @@ TEST_F(SignalValidatorCheckConflict, AmberCross_AmberCrossGreenUparrow)
 }
 
 // inputs totally mismatch
-TEST_F(SignalValidatorCheckConflict, AllMismatch)
+TEST(CheckConflict, AllMismatch)
 {
   StateKey input_a = {
     {TrafficLightElement::RED, TrafficLightElement::CIRCLE},
@@ -348,7 +342,7 @@ TEST_F(SignalValidatorCheckConflict, AllMismatch)
     {TrafficLightElement::GREEN, TrafficLightElement::LEFT_ARROW},
   };
 
-  ConflictStatus result = validator.check_conflict(input_a, input_b);
+  ConflictStatus result = check_conflict(input_a, input_b);
 
   StateKey expected_common_state_key = {};
 
@@ -361,12 +355,12 @@ TEST_F(SignalValidatorCheckConflict, AllMismatch)
 
 // same color and shape for arrows
 // -> no conflict
-TEST_F(SignalValidatorCheckConflict, GreenUparrow_GreenUparrow)
+TEST(CheckConflict, GreenUparrow_GreenUparrow)
 {
   StateKey input_a = {{TrafficLightElement::GREEN, TrafficLightElement::UP_ARROW}};
   StateKey input_b = {{TrafficLightElement::GREEN, TrafficLightElement::UP_ARROW}};
 
-  ConflictStatus result = validator.check_conflict(input_a, input_b);
+  ConflictStatus result = check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::NO_CONFLICT;
@@ -379,7 +373,7 @@ TEST_F(SignalValidatorCheckConflict, GreenUparrow_GreenUparrow)
 
 // same colors and shapes for arrows
 // -> no conflict
-TEST_F(SignalValidatorCheckConflict, GreenUparrowGreenRightarrow_GreenUparrowGreenRightarrow)
+TEST(CheckConflict, GreenUparrowGreenRightarrow_GreenUparrowGreenRightarrow)
 {
   StateKey input_a = {
     {TrafficLightElement::GREEN, TrafficLightElement::UP_ARROW},
@@ -388,7 +382,7 @@ TEST_F(SignalValidatorCheckConflict, GreenUparrowGreenRightarrow_GreenUparrowGre
     {TrafficLightElement::GREEN, TrafficLightElement::UP_ARROW},
     {TrafficLightElement::GREEN, TrafficLightElement::RIGHT_ARROW}};
 
-  ConflictStatus result = validator.check_conflict(input_a, input_b);
+  ConflictStatus result = check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::NO_CONFLICT;
@@ -402,12 +396,12 @@ TEST_F(SignalValidatorCheckConflict, GreenUparrowGreenRightarrow_GreenUparrowGre
 
 // different colors and same shape for arrows
 // -> critical conflict
-TEST_F(SignalValidatorCheckConflict, RedUparrow_GreenUparrow)
+TEST(CheckConflict, RedUparrow_GreenUparrow)
 {
   StateKey input_a = {{TrafficLightElement::RED, TrafficLightElement::UP_ARROW}};
   StateKey input_b = {{TrafficLightElement::GREEN, TrafficLightElement::UP_ARROW}};
 
-  ConflictStatus result = validator.check_conflict(input_a, input_b);
+  ConflictStatus result = check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::CONFLICT;
@@ -419,12 +413,12 @@ TEST_F(SignalValidatorCheckConflict, RedUparrow_GreenUparrow)
 
 // same color and different shapes for arrows
 // -> critical conflict
-TEST_F(SignalValidatorCheckConflict, RedUparrow_RedDownleftarrow)
+TEST(CheckConflict, RedUparrow_RedDownleftarrow)
 {
   StateKey input_a = {{TrafficLightElement::RED, TrafficLightElement::UP_ARROW}};
   StateKey input_b = {{TrafficLightElement::RED, TrafficLightElement::DOWN_LEFT_ARROW}};
 
-  ConflictStatus result = validator.check_conflict(input_a, input_b);
+  ConflictStatus result = check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::CONFLICT;
@@ -436,14 +430,14 @@ TEST_F(SignalValidatorCheckConflict, RedUparrow_RedDownleftarrow)
 
 // same color and different shapes for arrows
 // -> critical conflict
-TEST_F(SignalValidatorCheckConflict, RedUparrowRedDownleftarrow_RedDownleftarrow)
+TEST(CheckConflict, RedUparrowRedDownleftarrow_RedDownleftarrow)
 {
   StateKey input_a = {
     {TrafficLightElement::RED, TrafficLightElement::UP_ARROW},
     {TrafficLightElement::RED, TrafficLightElement::DOWN_LEFT_ARROW}};
   StateKey input_b = {{TrafficLightElement::RED, TrafficLightElement::DOWN_LEFT_ARROW}};
 
-  ConflictStatus result = validator.check_conflict(input_a, input_b);
+  ConflictStatus result = check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::PARTIAL_CONFLICT;
@@ -456,14 +450,14 @@ TEST_F(SignalValidatorCheckConflict, RedUparrowRedDownleftarrow_RedDownleftarrow
 
 // same color and different shapes for arrows (swapped input)
 // -> critical conflict
-TEST_F(SignalValidatorCheckConflict, RedDownleftarrow_RedUparrowRedDownleftarrow)
+TEST(CheckConflict, RedDownleftarrow_RedUparrowRedDownleftarrow)
 {
   StateKey input_a = {{TrafficLightElement::RED, TrafficLightElement::DOWN_LEFT_ARROW}};
   StateKey input_b = {
     {TrafficLightElement::RED, TrafficLightElement::UP_ARROW},
     {TrafficLightElement::RED, TrafficLightElement::DOWN_LEFT_ARROW}};
 
-  ConflictStatus result = validator.check_conflict(input_a, input_b);
+  ConflictStatus result = check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::PARTIAL_CONFLICT;
@@ -479,12 +473,12 @@ TEST_F(SignalValidatorCheckConflict, RedDownleftarrow_RedUparrowRedDownleftarrow
 
 // unknown input
 // -> no conflict (unknown should be treated as invalid detection)
-TEST_F(SignalValidatorCheckConflict, RedCircle_Unknown)
+TEST(CheckConflict, RedCircle_Unknown)
 {
   StateKey input_a = {{TrafficLightElement::RED, TrafficLightElement::CIRCLE}};
   StateKey input_b = {{TrafficLightElement::UNKNOWN, TrafficLightElement::UNKNOWN}};
 
-  ConflictStatus result = validator.check_conflict(input_a, input_b);
+  ConflictStatus result = check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::NO_CONFLICT;
@@ -496,12 +490,12 @@ TEST_F(SignalValidatorCheckConflict, RedCircle_Unknown)
 
 // unknown input
 // -> no conflict (unknown should be treated as invalid detection)
-TEST_F(SignalValidatorCheckConflict, RedUparrow_Unknown)
+TEST(CheckConflict, RedUparrow_Unknown)
 {
   StateKey input_a = {{TrafficLightElement::RED, TrafficLightElement::UP_ARROW}};
   StateKey input_b = {{TrafficLightElement::UNKNOWN, TrafficLightElement::UNKNOWN}};
 
-  ConflictStatus result = validator.check_conflict(input_a, input_b);
+  ConflictStatus result = check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::NO_CONFLICT;
@@ -513,12 +507,12 @@ TEST_F(SignalValidatorCheckConflict, RedUparrow_Unknown)
 
 // both unknown inputs
 // -> no conflict (unknown should be treated as invalid detection)
-TEST_F(SignalValidatorCheckConflict, Unknown_Unknown)
+TEST(CheckConflict, Unknown_Unknown)
 {
   StateKey input_a = {{TrafficLightElement::UNKNOWN, TrafficLightElement::UNKNOWN}};
   StateKey input_b = {{TrafficLightElement::UNKNOWN, TrafficLightElement::UNKNOWN}};
 
-  ConflictStatus result = validator.check_conflict(input_a, input_b);
+  ConflictStatus result = check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::NO_CONFLICT;
@@ -531,12 +525,12 @@ TEST_F(SignalValidatorCheckConflict, Unknown_Unknown)
 
 // missing input
 // -> no conflict
-TEST_F(SignalValidatorCheckConflict, RedCircle_NoDetection)
+TEST(CheckConflict, RedCircle_NoDetection)
 {
   StateKey input_a = {{TrafficLightElement::RED, TrafficLightElement::CIRCLE}};
   StateKey input_b = {};
 
-  ConflictStatus result = validator.check_conflict(input_a, input_b);
+  ConflictStatus result = check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::NO_CONFLICT;
@@ -548,12 +542,12 @@ TEST_F(SignalValidatorCheckConflict, RedCircle_NoDetection)
 
 // missing input (swapped input)
 // -> no conflict
-TEST_F(SignalValidatorCheckConflict, NoDetection_RedCircle)
+TEST(CheckConflict, NoDetection_RedCircle)
 {
   StateKey input_a = {};
   StateKey input_b = {{TrafficLightElement::RED, TrafficLightElement::CIRCLE}};
 
-  ConflictStatus result = validator.check_conflict(input_a, input_b);
+  ConflictStatus result = check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::NO_CONFLICT;
@@ -565,12 +559,12 @@ TEST_F(SignalValidatorCheckConflict, NoDetection_RedCircle)
 
 // missing input with arrow
 // -> no conflict
-TEST_F(SignalValidatorCheckConflict, RedUparrow_NoDetection)
+TEST(CheckConflict, RedUparrow_NoDetection)
 {
   StateKey input_a = {{TrafficLightElement::RED, TrafficLightElement::UP_ARROW}};
   StateKey input_b = {};
 
-  ConflictStatus result = validator.check_conflict(input_a, input_b);
+  ConflictStatus result = check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::NO_CONFLICT;
@@ -582,14 +576,14 @@ TEST_F(SignalValidatorCheckConflict, RedUparrow_NoDetection)
 
 // inputs with unknown and missing
 // -> no conflict
-TEST_F(SignalValidatorCheckConflict, Unknown_NoDetection)
+TEST(CheckConflict, Unknown_NoDetection)
 {
   StateKey input_a = {{TrafficLightElement::UNKNOWN, TrafficLightElement::UNKNOWN}};
   StateKey input_b = {};
 
   // unknown and missing inputs will be treated as same,
   // but the returned state key depend on the input order
-  ConflictStatus result = validator.check_conflict(input_a, input_b);
+  ConflictStatus result = check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::NO_CONFLICT;
@@ -602,14 +596,14 @@ TEST_F(SignalValidatorCheckConflict, Unknown_NoDetection)
 
 // inputs with unknown and missing (swapped input)
 // -> no conflict
-TEST_F(SignalValidatorCheckConflict, NoDetection_Unknown)
+TEST(CheckConflict, NoDetection_Unknown)
 {
   StateKey input_a = {};
   StateKey input_b = {{TrafficLightElement::UNKNOWN, TrafficLightElement::UNKNOWN}};
 
   // unknown and missing inputs will be treated as same,
   // but the returned state key depend on the input order
-  ConflictStatus result = validator.check_conflict(input_a, input_b);
+  ConflictStatus result = check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::NO_CONFLICT;
@@ -624,14 +618,14 @@ TEST_F(SignalValidatorCheckConflict, NoDetection_Unknown)
 
 // duplicated circle signal input
 // -> partial conflict
-TEST_F(SignalValidatorCheckConflict, RedCircleRedCircle_RedCircle)
+TEST(CheckConflict, RedCircleRedCircle_RedCircle)
 {
   StateKey input_a = {
     {TrafficLightElement::RED, TrafficLightElement::CIRCLE},
     {TrafficLightElement::RED, TrafficLightElement::CIRCLE}};
   StateKey input_b = {{TrafficLightElement::RED, TrafficLightElement::CIRCLE}};
 
-  ConflictStatus result = validator.check_conflict(input_a, input_b);
+  ConflictStatus result = check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::PARTIAL_CONFLICT;
@@ -643,14 +637,14 @@ TEST_F(SignalValidatorCheckConflict, RedCircleRedCircle_RedCircle)
 
 // mutiple same shape signal input
 // -> partial conflict
-TEST_F(SignalValidatorCheckConflict, RedCircleGreenCircle_RedCircle)
+TEST(CheckConflict, RedCircleGreenCircle_RedCircle)
 {
   StateKey input_a = {
     {TrafficLightElement::RED, TrafficLightElement::CIRCLE},
     {TrafficLightElement::GREEN, TrafficLightElement::CIRCLE}};
   StateKey input_b = {{TrafficLightElement::RED, TrafficLightElement::CIRCLE}};
 
-  ConflictStatus result = validator.check_conflict(input_a, input_b);
+  ConflictStatus result = check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::PARTIAL_CONFLICT;
@@ -662,9 +656,7 @@ TEST_F(SignalValidatorCheckConflict, RedCircleGreenCircle_RedCircle)
 
 // duplicated arrow signal input
 // -> no conflict
-TEST_F(
-  SignalValidatorCheckConflict,
-  RedCircleGreenDownrightarrow_RedCircleGreenDownrightarrowGreenDownrightarrow)
+TEST(CheckConflict, RedCircleGreenDownrightarrow_RedCircleGreenDownrightarrowGreenDownrightarrow)
 {
   StateKey input_a = {
     {TrafficLightElement::RED, TrafficLightElement::CIRCLE},
@@ -674,7 +666,7 @@ TEST_F(
     {TrafficLightElement::GREEN, TrafficLightElement::DOWN_RIGHT_ARROW},
     {TrafficLightElement::GREEN, TrafficLightElement::DOWN_RIGHT_ARROW}};
 
-  ConflictStatus result = validator.check_conflict(input_a, input_b);
+  ConflictStatus result = check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::PARTIAL_CONFLICT;
@@ -691,12 +683,12 @@ TEST_F(
 
 // input_b is empty
 // empty input will treated as unknown prediction
-TEST_F(SignalValidatorCheckConflict, EmptyInputs_1)
+TEST(CheckConflict, EmptyInputs_1)
 {
   StateKey input_a = {{TrafficLightElement::RED, TrafficLightElement::CIRCLE}};
   StateKey input_b = {};
 
-  ConflictStatus result = validator.check_conflict(input_a, input_b);
+  ConflictStatus result = check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::NO_CONFLICT;
@@ -708,12 +700,12 @@ TEST_F(SignalValidatorCheckConflict, EmptyInputs_1)
 
 // input_a is empty
 // empty input will treated as unknown prediction
-TEST_F(SignalValidatorCheckConflict, EmptyInputs_2)
+TEST(CheckConflict, EmptyInputs_2)
 {
   StateKey input_a = {};
   StateKey input_b = {{TrafficLightElement::RED, TrafficLightElement::CIRCLE}};
 
-  ConflictStatus result = validator.check_conflict(input_a, input_b);
+  ConflictStatus result = check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::NO_CONFLICT;
@@ -724,12 +716,12 @@ TEST_F(SignalValidatorCheckConflict, EmptyInputs_2)
 }
 
 // both are empty
-TEST_F(SignalValidatorCheckConflict, EmptyInputs_3)
+TEST(CheckConflict, EmptyInputs_3)
 {
   StateKey input_a = {};
   StateKey input_b = {};
 
-  ConflictStatus result = validator.check_conflict(input_a, input_b);
+  ConflictStatus result = check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::NO_CONFLICT;

--- a/perception/autoware_traffic_light_multi_camera_fusion/test/test_utils.cpp
+++ b/perception/autoware_traffic_light_multi_camera_fusion/test/test_utils.cpp
@@ -33,13 +33,6 @@ constexpr uint8_t circle = TrafficLightElement::CIRCLE;
 // unknown is shared between the color and shape fields
 constexpr uint8_t unknown = TrafficLightElement::UNKNOWN;
 
-// compare_record return values
-enum CompareResult : int {
-  R1_IS_WORSE = -1,
-  BOTH_RECORDS_EQUAL = 0,
-  R1_IS_BETTER = 1,
-};
-
 // cal_visible_score return values
 enum VisibleScore : int {
   TRUNCATED = 0,
@@ -128,129 +121,137 @@ TEST(AtOr, ReturnsDefaultValueWhenKeyMissing)
 }
 
 // first condition: records from the same camera are ranked by timestamp
-TEST(CompareRecordSameCamera, NewerRecordWinsOverOlderRecord)
+TEST(HasHigherOrEqualPrioritySameCamera, NewerRecordWinsOverOlderRecord)
 {
   const auto newer_record = make_record(red, circle, 0.9, "camera0", 200);
   const auto older_record = make_record(green, circle, 0.8, "camera0", 100);
-  EXPECT_EQ(utils::compare_record(newer_record, older_record), R1_IS_BETTER);
+  EXPECT_TRUE(utils::has_higher_or_equal_priority(newer_record, older_record));
 }
 
-TEST(CompareRecordSameCamera, OlderRecordLosesToNewerRecord)
+TEST(HasHigherOrEqualPrioritySameCamera, OlderRecordLosesToNewerRecord)
 {
   const auto older_record = make_record(red, circle, 0.9, "camera0", 100);
   const auto newer_record = make_record(green, circle, 0.8, "camera0", 200);
-  EXPECT_EQ(utils::compare_record(older_record, newer_record), R1_IS_WORSE);
+  EXPECT_FALSE(utils::has_higher_or_equal_priority(older_record, newer_record));
 }
 
 // second condition: an unknown signal loses to a recognized one
-TEST(CompareRecordSameCamera, UnknownRecordLosesToKnownRecord)
+TEST(HasHigherOrEqualPrioritySameCamera, UnknownRecordLosesToKnownRecord)
 {
   const auto unknown_record = make_record(unknown, unknown, 0.0);
   const auto known_record = make_record(green, circle, 0.8);
-  EXPECT_EQ(utils::compare_record(unknown_record, known_record), R1_IS_WORSE);
+  EXPECT_FALSE(utils::has_higher_or_equal_priority(unknown_record, known_record));
 }
 
-TEST(CompareRecordSameCamera, KnownRecordWinsOverUnknownRecord)
+TEST(HasHigherOrEqualPrioritySameCamera, KnownRecordWinsOverUnknownRecord)
 {
   const auto known_record = make_record(red, circle, 0.9);
   const auto unknown_record = make_record(unknown, unknown, 0.0);
-  EXPECT_EQ(utils::compare_record(known_record, unknown_record), R1_IS_BETTER);
+  EXPECT_TRUE(utils::has_higher_or_equal_priority(known_record, unknown_record));
 }
 
-TEST(CompareRecordSameCamera, BothUnknownRecordsAreEqual)
+TEST(HasHigherOrEqualPrioritySameCamera, BothUnknownRecordsHaveEqualPriority)
 {
   const auto unknown_record_1 = make_record(unknown, unknown, 0.0);
   const auto unknown_record_2 = make_record(unknown, unknown, 0.0);
-  EXPECT_EQ(utils::compare_record(unknown_record_1, unknown_record_2), BOTH_RECORDS_EQUAL);
+  // equal priority: each record has a higher-or-equal priority than the other
+  EXPECT_TRUE(utils::has_higher_or_equal_priority(unknown_record_1, unknown_record_2));
+  EXPECT_TRUE(utils::has_higher_or_equal_priority(unknown_record_2, unknown_record_1));
 }
 
 // third condition: a fully visible signal wins over a truncated one
-TEST(CompareRecordSameCamera, VisibleRecordWinsOverTruncatedRecord)
+TEST(HasHigherOrEqualPrioritySameCamera, VisibleRecordWinsOverTruncatedRecord)
 {
   const auto visible_record = make_record_with_roi(visible_offset, visible_offset);
   const auto truncated_record =
     make_record_with_roi(left_top_boundary_offset, left_top_boundary_offset);
-  EXPECT_EQ(utils::compare_record(visible_record, truncated_record), R1_IS_BETTER);
+  EXPECT_TRUE(utils::has_higher_or_equal_priority(visible_record, truncated_record));
 }
 
-TEST(CompareRecordSameCamera, TruncatedRecordLosesToVisibleRecord)
+TEST(HasHigherOrEqualPrioritySameCamera, TruncatedRecordLosesToVisibleRecord)
 {
   const auto truncated_record =
     make_record_with_roi(left_top_boundary_offset, left_top_boundary_offset);
   const auto visible_record = make_record_with_roi(visible_offset, visible_offset);
-  EXPECT_EQ(utils::compare_record(truncated_record, visible_record), R1_IS_WORSE);
+  EXPECT_FALSE(utils::has_higher_or_equal_priority(truncated_record, visible_record));
 }
 
 // fourth condition: a higher confidence signal wins
-TEST(CompareRecordSameCamera, HigherConfidenceRecordWins)
+TEST(HasHigherOrEqualPrioritySameCamera, HigherConfidenceRecordWins)
 {
   const auto higher_confidence_record = make_record(red, circle, 0.9);
   const auto lower_confidence_record = make_record(green, circle, 0.8);
-  EXPECT_EQ(utils::compare_record(higher_confidence_record, lower_confidence_record), R1_IS_BETTER);
+  EXPECT_TRUE(
+    utils::has_higher_or_equal_priority(higher_confidence_record, lower_confidence_record));
 }
 
-TEST(CompareRecordSameCamera, LowerConfidenceRecordLoses)
+TEST(HasHigherOrEqualPrioritySameCamera, LowerConfidenceRecordLoses)
 {
   const auto lower_confidence_record = make_record(red, circle, 0.9);
   const auto higher_confidence_record = make_record(green, circle, 0.95);
-  EXPECT_EQ(utils::compare_record(lower_confidence_record, higher_confidence_record), R1_IS_WORSE);
+  EXPECT_FALSE(
+    utils::has_higher_or_equal_priority(lower_confidence_record, higher_confidence_record));
 }
 
 // the timestamp condition does not apply across different cameras, so the
 // remaining conditions are exercised with different frame_ids below
 
 // second condition
-TEST(CompareRecordDifferentCamera, UnknownRecordLosesToKnownRecord)
+TEST(HasHigherOrEqualPriorityDifferentCamera, UnknownRecordLosesToKnownRecord)
 {
   const auto unknown_record = make_record(unknown, unknown, 0.0, "camera0");
   const auto known_record = make_record(green, circle, 0.8, "camera1");
-  EXPECT_EQ(utils::compare_record(unknown_record, known_record), R1_IS_WORSE);
+  EXPECT_FALSE(utils::has_higher_or_equal_priority(unknown_record, known_record));
 }
 
-TEST(CompareRecordDifferentCamera, KnownRecordWinsOverUnknownRecord)
+TEST(HasHigherOrEqualPriorityDifferentCamera, KnownRecordWinsOverUnknownRecord)
 {
   const auto known_record = make_record(red, circle, 0.9, "camera0");
   const auto unknown_record = make_record(unknown, unknown, 0.0, "camera1");
-  EXPECT_EQ(utils::compare_record(known_record, unknown_record), R1_IS_BETTER);
+  EXPECT_TRUE(utils::has_higher_or_equal_priority(known_record, unknown_record));
 }
 
-TEST(CompareRecordDifferentCamera, BothUnknownRecordsAreEqual)
+TEST(HasHigherOrEqualPriorityDifferentCamera, BothUnknownRecordsHaveEqualPriority)
 {
   const auto unknown_record_1 = make_record(unknown, unknown, 0.0, "camera0");
   const auto unknown_record_2 = make_record(unknown, unknown, 0.0, "camera1");
-  EXPECT_EQ(utils::compare_record(unknown_record_1, unknown_record_2), BOTH_RECORDS_EQUAL);
+  // equal priority: each record has a higher-or-equal priority than the other
+  EXPECT_TRUE(utils::has_higher_or_equal_priority(unknown_record_1, unknown_record_2));
+  EXPECT_TRUE(utils::has_higher_or_equal_priority(unknown_record_2, unknown_record_1));
 }
 
 // third condition
-TEST(CompareRecordDifferentCamera, VisibleRecordWinsOverTruncatedRecord)
+TEST(HasHigherOrEqualPriorityDifferentCamera, VisibleRecordWinsOverTruncatedRecord)
 {
   const auto visible_record = make_record_with_roi(visible_offset, visible_offset, "camera0");
   const auto truncated_record =
     make_record_with_roi(left_top_boundary_offset, left_top_boundary_offset, "camera1");
-  EXPECT_EQ(utils::compare_record(visible_record, truncated_record), R1_IS_BETTER);
+  EXPECT_TRUE(utils::has_higher_or_equal_priority(visible_record, truncated_record));
 }
 
-TEST(CompareRecordDifferentCamera, TruncatedRecordLosesToVisibleRecord)
+TEST(HasHigherOrEqualPriorityDifferentCamera, TruncatedRecordLosesToVisibleRecord)
 {
   const auto truncated_record =
     make_record_with_roi(left_top_boundary_offset, left_top_boundary_offset, "camera0");
   const auto visible_record = make_record_with_roi(visible_offset, visible_offset, "camera1");
-  EXPECT_EQ(utils::compare_record(truncated_record, visible_record), R1_IS_WORSE);
+  EXPECT_FALSE(utils::has_higher_or_equal_priority(truncated_record, visible_record));
 }
 
 // fourth condition
-TEST(CompareRecordDifferentCamera, HigherConfidenceRecordWins)
+TEST(HasHigherOrEqualPriorityDifferentCamera, HigherConfidenceRecordWins)
 {
   const auto higher_confidence_record = make_record(red, circle, 0.9, "camera0");
   const auto lower_confidence_record = make_record(green, circle, 0.8, "camera1");
-  EXPECT_EQ(utils::compare_record(higher_confidence_record, lower_confidence_record), R1_IS_BETTER);
+  EXPECT_TRUE(
+    utils::has_higher_or_equal_priority(higher_confidence_record, lower_confidence_record));
 }
 
-TEST(CompareRecordDifferentCamera, LowerConfidenceRecordLoses)
+TEST(HasHigherOrEqualPriorityDifferentCamera, LowerConfidenceRecordLoses)
 {
   const auto lower_confidence_record = make_record(red, circle, 0.9, "camera0");
   const auto higher_confidence_record = make_record(green, circle, 0.95, "camera1");
-  EXPECT_EQ(utils::compare_record(lower_confidence_record, higher_confidence_record), R1_IS_WORSE);
+  EXPECT_FALSE(
+    utils::has_higher_or_equal_priority(lower_confidence_record, higher_confidence_record));
 }
 
 TEST(CalVisibleScore, FullyVisibleRoiScoresOne)

--- a/perception/autoware_traffic_light_multi_camera_fusion/test/test_utils.cpp
+++ b/perception/autoware_traffic_light_multi_camera_fusion/test/test_utils.cpp
@@ -29,7 +29,7 @@ TEST(IsUnknown, Normal)
     element.shape = tier4_perception_msgs::msg::TrafficLightElement::UNKNOWN;
     signal.elements.push_back(element);
   }
-  EXPECT_TRUE(autoware::traffic_light::utils::is_unknown(signal));
+  EXPECT_TRUE(autoware::traffic_light::utils::is_signal_unknown(signal));
 
   {
     signal.elements.clear();
@@ -37,7 +37,7 @@ TEST(IsUnknown, Normal)
     element.shape = tier4_perception_msgs::msg::TrafficLightElement::CIRCLE;
     signal.elements.push_back(element);
   }
-  EXPECT_FALSE(autoware::traffic_light::utils::is_unknown(signal));
+  EXPECT_FALSE(autoware::traffic_light::utils::is_signal_unknown(signal));
 }
 
 TEST(AtOr, Normal)

--- a/perception/autoware_traffic_light_multi_camera_fusion/test/test_utils.cpp
+++ b/perception/autoware_traffic_light_multi_camera_fusion/test/test_utils.cpp
@@ -33,20 +33,14 @@ constexpr uint8_t circle = TrafficLightElement::CIRCLE;
 // unknown is shared between the color and shape fields
 constexpr uint8_t unknown = TrafficLightElement::UNKNOWN;
 
-// cal_visible_score return values
-enum VisibleScore : int {
-  TRUNCATED = 0,
-  VISIBLE = 1,
-};
-
 // image / roi geometry
 constexpr uint32_t image_width = 1440;
 constexpr uint32_t image_height = 1080;
 constexpr uint32_t roi_size = 100;
 constexpr uint32_t boundary_threshold = 5;
-// roi offset that keeps the traffic light fully inside the image (visible score == 1)
+// roi offset that keeps the traffic light fully inside the image (fully visible)
 constexpr uint32_t visible_offset = 100;
-// roi offsets that push the traffic light against each image boundary (visible score == 0)
+// roi offsets that push the traffic light against each image boundary (truncated)
 constexpr uint32_t left_top_boundary_offset = boundary_threshold;
 constexpr uint32_t right_boundary_offset = image_width - (roi_size + boundary_threshold);
 constexpr uint32_t bottom_boundary_offset = image_height - (roi_size + boundary_threshold);
@@ -254,34 +248,34 @@ TEST(HasHigherOrEqualPriorityDifferentCamera, LowerConfidenceRecordLoses)
     utils::has_higher_or_equal_priority(lower_confidence_record, higher_confidence_record));
 }
 
-TEST(CalVisibleScore, FullyVisibleRoiScoresOne)
+TEST(IsFullyVisible, ReturnsTrueWhenRoiIsCentered)
 {
   const auto record = make_record_with_roi(visible_offset, visible_offset);
-  EXPECT_EQ(utils::cal_visible_score(record), VISIBLE);
+  EXPECT_TRUE(utils::is_fully_visible(record));
 }
 
-TEST(CalVisibleScore, RoiNearLeftBoundaryScoresZero)
+TEST(IsFullyVisible, ReturnsFalseWhenRoiNearLeftBoundary)
 {
   const auto record = make_record_with_roi(left_top_boundary_offset, visible_offset);
-  EXPECT_EQ(utils::cal_visible_score(record), TRUNCATED);
+  EXPECT_FALSE(utils::is_fully_visible(record));
 }
 
-TEST(CalVisibleScore, RoiNearRightBoundaryScoresZero)
+TEST(IsFullyVisible, ReturnsFalseWhenRoiNearRightBoundary)
 {
   const auto record = make_record_with_roi(right_boundary_offset, visible_offset);
-  EXPECT_EQ(utils::cal_visible_score(record), TRUNCATED);
+  EXPECT_FALSE(utils::is_fully_visible(record));
 }
 
-TEST(CalVisibleScore, RoiNearTopBoundaryScoresZero)
+TEST(IsFullyVisible, ReturnsFalseWhenRoiNearTopBoundary)
 {
   const auto record = make_record_with_roi(visible_offset, left_top_boundary_offset);
-  EXPECT_EQ(utils::cal_visible_score(record), TRUNCATED);
+  EXPECT_FALSE(utils::is_fully_visible(record));
 }
 
-TEST(CalVisibleScore, RoiNearBottomBoundaryScoresZero)
+TEST(IsFullyVisible, ReturnsFalseWhenRoiNearBottomBoundary)
 {
   const auto record = make_record_with_roi(visible_offset, bottom_boundary_offset);
-  EXPECT_EQ(utils::cal_visible_score(record), TRUNCATED);
+  EXPECT_FALSE(utils::is_fully_visible(record));
 }
 
 int main(int argc, char ** argv)

--- a/perception/autoware_traffic_light_multi_camera_fusion/test/test_utils.cpp
+++ b/perception/autoware_traffic_light_multi_camera_fusion/test/test_utils.cpp
@@ -14,7 +14,7 @@
 
 #include "../src/traffic_light_multi_camera_fusion_process.hpp"
 
-#include <rclcpp/rclcpp.hpp>
+#include <rclcpp/time.hpp>
 
 #include <gtest/gtest.h>
 

--- a/perception/autoware_traffic_light_multi_camera_fusion/test/test_utils.cpp
+++ b/perception/autoware_traffic_light_multi_camera_fusion/test/test_utils.cpp
@@ -18,1218 +18,269 @@
 
 #include <gtest/gtest.h>
 
+#include <string>
 #include <unordered_map>
 
-TEST(IsUnknown, Normal)
+namespace
 {
+namespace utils = autoware::traffic_light::utils;
+using TrafficLightElement = tier4_perception_msgs::msg::TrafficLightElement;
+
+// colors / shapes used by the tests
+constexpr uint8_t red = TrafficLightElement::RED;
+constexpr uint8_t green = TrafficLightElement::GREEN;
+constexpr uint8_t circle = TrafficLightElement::CIRCLE;
+// unknown is shared between the color and shape fields
+constexpr uint8_t unknown = TrafficLightElement::UNKNOWN;
+
+// compare_record return values
+enum CompareResult : int {
+  R1_IS_WORSE = -1,
+  BOTH_RECORDS_EQUAL = 0,
+  R1_IS_BETTER = 1,
+};
+
+// cal_visible_score return values
+enum VisibleScore : int {
+  TRUNCATED = 0,
+  VISIBLE = 1,
+};
+
+// image / roi geometry
+constexpr uint32_t image_width = 1440;
+constexpr uint32_t image_height = 1080;
+constexpr uint32_t roi_size = 100;
+constexpr uint32_t boundary_threshold = 5;
+// roi offset that keeps the traffic light fully inside the image (visible score == 1)
+constexpr uint32_t visible_offset = 100;
+// roi offsets that push the traffic light against each image boundary (visible score == 0)
+constexpr uint32_t left_top_boundary_offset = boundary_threshold;
+constexpr uint32_t right_boundary_offset = image_width - (roi_size + boundary_threshold);
+constexpr uint32_t bottom_boundary_offset = image_height - (roi_size + boundary_threshold);
+
+constexpr int32_t default_stamp_sec = 100;
+
+tier4_perception_msgs::msg::TrafficLight make_signal(
+  uint8_t color, uint8_t shape, double confidence)
+{
+  TrafficLightElement element;
+  element.color = color;
+  element.shape = shape;
+  element.confidence = confidence;
+
   tier4_perception_msgs::msg::TrafficLight signal;
-  tier4_perception_msgs::msg::TrafficLightElement element;
-  {
-    element.color = tier4_perception_msgs::msg::TrafficLightElement::UNKNOWN;
-    element.shape = tier4_perception_msgs::msg::TrafficLightElement::UNKNOWN;
-    signal.elements.push_back(element);
-  }
-  EXPECT_TRUE(autoware::traffic_light::utils::is_signal_unknown(signal));
-
-  {
-    signal.elements.clear();
-    element.color = tier4_perception_msgs::msg::TrafficLightElement::RED;
-    element.shape = tier4_perception_msgs::msg::TrafficLightElement::CIRCLE;
-    signal.elements.push_back(element);
-  }
-  EXPECT_FALSE(autoware::traffic_light::utils::is_signal_unknown(signal));
+  signal.elements.push_back(element);
+  return signal;
 }
 
-TEST(AtOr, Normal)
+utils::FusionRecord make_record(
+  uint8_t color, uint8_t shape, double confidence, const std::string & frame_id = "camera0",
+  int32_t stamp_sec = default_stamp_sec, uint32_t roi_x_offset = visible_offset,
+  uint32_t roi_y_offset = visible_offset)
 {
-  std::unordered_map<int, int> map;
-  map[1] = 2;
-  map[3] = 4;
-  EXPECT_EQ(autoware::traffic_light::utils::at_or(map, 1, -1), 2);
-  EXPECT_EQ(autoware::traffic_light::utils::at_or(map, 2, -1), -1);
-  EXPECT_EQ(autoware::traffic_light::utils::at_or(map, 3, -1), 4);
+  std_msgs::msg::Header header;
+  header.stamp = rclcpp::Time(stamp_sec, 10);
+  header.frame_id = frame_id;
+
+  utils::FusionRecord record;
+  record.header = header;
+  record.cam_info.header = header;
+  record.cam_info.width = image_width;
+  record.cam_info.height = image_height;
+  record.roi.roi.x_offset = roi_x_offset;
+  record.roi.roi.y_offset = roi_y_offset;
+  record.roi.roi.width = roi_size;
+  record.roi.roi.height = roi_size;
+  record.signal = make_signal(color, shape, confidence);
+  return record;
 }
 
-namespace same_camera
+// only the roi position affects the visible score, so the signal content is fixed here
+utils::FusionRecord make_record_with_roi(
+  uint32_t roi_x_offset, uint32_t roi_y_offset, const std::string & frame_id = "camera0")
 {
-
-// first condition
-TEST(CompareRecord, TimestampCheck)
-{
-  // r1 is newer
-  autoware::traffic_light::utils::FusionRecord r1;
-  {
-    std_msgs::msg::Header header;
-    header.stamp = rclcpp::Time(200, 10);
-    header.frame_id = "camera0";
-    // header
-    r1.header = header;
-    // cam_info
-    r1.cam_info.header = header;
-    r1.cam_info.width = 1440;
-    r1.cam_info.height = 1080;
-    // roi
-    r1.roi.roi.x_offset = 100;
-    r1.roi.roi.y_offset = 100;
-    r1.roi.roi.width = 100;
-    r1.roi.roi.height = 100;
-    // signal
-    r1.signal.elements.clear();
-    tier4_perception_msgs::msg::TrafficLightElement element;
-    element.color = tier4_perception_msgs::msg::TrafficLightElement::RED;
-    element.shape = tier4_perception_msgs::msg::TrafficLightElement::CIRCLE;
-    element.confidence = 0.9;
-    r1.signal.elements.push_back(element);
-  }
-  autoware::traffic_light::utils::FusionRecord r2;
-  {
-    std_msgs::msg::Header header;
-    header.stamp = rclcpp::Time(100, 10);
-    header.frame_id = "camera0";
-    // header
-    r2.header = header;
-    // cam_info
-    r2.cam_info.header = header;
-    r2.cam_info.width = 1440;
-    r2.cam_info.height = 1080;
-    // roi
-    r2.roi.roi.x_offset = 100;
-    r2.roi.roi.y_offset = 100;
-    r2.roi.roi.width = 100;
-    r2.roi.roi.height = 100;
-    // signal
-    r2.signal.elements.clear();
-    tier4_perception_msgs::msg::TrafficLightElement element;
-    element.color = tier4_perception_msgs::msg::TrafficLightElement::GREEN;
-    element.shape = tier4_perception_msgs::msg::TrafficLightElement::CIRCLE;
-    element.confidence = 0.8;
-    r2.signal.elements.push_back(element);
-  }
-  EXPECT_EQ(autoware::traffic_light::utils::compare_record(r1, r2), 1);
-
-  // r2 is newer
-  {
-    std_msgs::msg::Header header;
-    header.stamp = rclcpp::Time(100, 10);
-    header.frame_id = "camera0";
-    // header
-    r1.header = header;
-    // cam_info
-    r1.cam_info.header = header;
-    r1.cam_info.width = 1440;
-    r1.cam_info.height = 1080;
-    // roi
-    r1.roi.roi.x_offset = 100;
-    r1.roi.roi.y_offset = 100;
-    r1.roi.roi.width = 100;
-    r1.roi.roi.height = 100;
-    // signal
-    r1.signal.elements.clear();
-    tier4_perception_msgs::msg::TrafficLightElement element;
-    element.color = tier4_perception_msgs::msg::TrafficLightElement::RED;
-    element.shape = tier4_perception_msgs::msg::TrafficLightElement::CIRCLE;
-    element.confidence = 0.9;
-    r1.signal.elements.push_back(element);
-  }
-  {
-    std_msgs::msg::Header header;
-    header.stamp = rclcpp::Time(200, 10);
-    header.frame_id = "camera0";
-    // header
-    r2.header = header;
-    // cam_info
-    r2.cam_info.header = header;
-    r2.cam_info.width = 1440;
-    r2.cam_info.height = 1080;
-    // roi
-    r2.roi.roi.x_offset = 100;
-    r2.roi.roi.y_offset = 100;
-    r2.roi.roi.width = 100;
-    r2.roi.roi.height = 100;
-    // signal
-    r2.signal.elements.clear();
-    tier4_perception_msgs::msg::TrafficLightElement element;
-    element.color = tier4_perception_msgs::msg::TrafficLightElement::GREEN;
-    element.shape = tier4_perception_msgs::msg::TrafficLightElement::CIRCLE;
-    element.confidence = 0.8;
-    r2.signal.elements.push_back(element);
-  }
-  EXPECT_EQ(autoware::traffic_light::utils::compare_record(r1, r2), -1);
+  return make_record(red, circle, 0.9, frame_id, default_stamp_sec, roi_x_offset, roi_y_offset);
 }
+}  // namespace
+
+TEST(IsSignalUnknown, ReturnsTrueForUnknownSignal)
+{
+  const auto signal = make_signal(unknown, unknown, 0.0);
+  EXPECT_TRUE(utils::is_signal_unknown(signal));
+}
+
+TEST(IsSignalUnknown, ReturnsFalseForColoredSignal)
+{
+  const auto signal = make_signal(red, circle, 0.9);
+  EXPECT_FALSE(utils::is_signal_unknown(signal));
+}
+
+TEST(AtOr, ReturnsMappedValueWhenKeyExists)
+{
+  const std::unordered_map<int, int> map = {{1, 2}, {3, 4}};
+  EXPECT_EQ(utils::at_or(map, 1, -1), 2);
+}
+
+TEST(AtOr, ReturnsDefaultValueWhenKeyMissing)
+{
+  const std::unordered_map<int, int> map = {{1, 2}, {3, 4}};
+  EXPECT_EQ(utils::at_or(map, 2, -1), -1);
+}
+
+// first condition: records from the same camera are ranked by timestamp
+TEST(CompareRecordSameCamera, NewerRecordWinsOverOlderRecord)
+{
+  const auto newer_record = make_record(red, circle, 0.9, "camera0", 200);
+  const auto older_record = make_record(green, circle, 0.8, "camera0", 100);
+  EXPECT_EQ(utils::compare_record(newer_record, older_record), R1_IS_BETTER);
+}
+
+TEST(CompareRecordSameCamera, OlderRecordLosesToNewerRecord)
+{
+  const auto older_record = make_record(red, circle, 0.9, "camera0", 100);
+  const auto newer_record = make_record(green, circle, 0.8, "camera0", 200);
+  EXPECT_EQ(utils::compare_record(older_record, newer_record), R1_IS_WORSE);
+}
+
+// second condition: an unknown signal loses to a recognized one
+TEST(CompareRecordSameCamera, UnknownRecordLosesToKnownRecord)
+{
+  const auto unknown_record = make_record(unknown, unknown, 0.0);
+  const auto known_record = make_record(green, circle, 0.8);
+  EXPECT_EQ(utils::compare_record(unknown_record, known_record), R1_IS_WORSE);
+}
+
+TEST(CompareRecordSameCamera, KnownRecordWinsOverUnknownRecord)
+{
+  const auto known_record = make_record(red, circle, 0.9);
+  const auto unknown_record = make_record(unknown, unknown, 0.0);
+  EXPECT_EQ(utils::compare_record(known_record, unknown_record), R1_IS_BETTER);
+}
+
+TEST(CompareRecordSameCamera, BothUnknownRecordsAreEqual)
+{
+  const auto unknown_record_1 = make_record(unknown, unknown, 0.0);
+  const auto unknown_record_2 = make_record(unknown, unknown, 0.0);
+  EXPECT_EQ(utils::compare_record(unknown_record_1, unknown_record_2), BOTH_RECORDS_EQUAL);
+}
+
+// third condition: a fully visible signal wins over a truncated one
+TEST(CompareRecordSameCamera, VisibleRecordWinsOverTruncatedRecord)
+{
+  const auto visible_record = make_record_with_roi(visible_offset, visible_offset);
+  const auto truncated_record =
+    make_record_with_roi(left_top_boundary_offset, left_top_boundary_offset);
+  EXPECT_EQ(utils::compare_record(visible_record, truncated_record), R1_IS_BETTER);
+}
+
+TEST(CompareRecordSameCamera, TruncatedRecordLosesToVisibleRecord)
+{
+  const auto truncated_record =
+    make_record_with_roi(left_top_boundary_offset, left_top_boundary_offset);
+  const auto visible_record = make_record_with_roi(visible_offset, visible_offset);
+  EXPECT_EQ(utils::compare_record(truncated_record, visible_record), R1_IS_WORSE);
+}
+
+// fourth condition: a higher confidence signal wins
+TEST(CompareRecordSameCamera, HigherConfidenceRecordWins)
+{
+  const auto higher_confidence_record = make_record(red, circle, 0.9);
+  const auto lower_confidence_record = make_record(green, circle, 0.8);
+  EXPECT_EQ(utils::compare_record(higher_confidence_record, lower_confidence_record), R1_IS_BETTER);
+}
+
+TEST(CompareRecordSameCamera, LowerConfidenceRecordLoses)
+{
+  const auto lower_confidence_record = make_record(red, circle, 0.9);
+  const auto higher_confidence_record = make_record(green, circle, 0.95);
+  EXPECT_EQ(utils::compare_record(lower_confidence_record, higher_confidence_record), R1_IS_WORSE);
+}
+
+// the timestamp condition does not apply across different cameras, so the
+// remaining conditions are exercised with different frame_ids below
 
 // second condition
-TEST(CompareRecord, UnknownCheck)
+TEST(CompareRecordDifferentCamera, UnknownRecordLosesToKnownRecord)
 {
-  // r1 is unknown
-  autoware::traffic_light::utils::FusionRecord r1;
-  {
-    std_msgs::msg::Header header;
-    header.stamp = rclcpp::Time(100, 10);
-    header.frame_id = "camera0";
-    // header
-    r1.header = header;
-    // cam_info
-    r1.cam_info.header = header;
-    r1.cam_info.width = 1440;
-    r1.cam_info.height = 1080;
-    // roi
-    r1.roi.roi.x_offset = 100;
-    r1.roi.roi.y_offset = 100;
-    r1.roi.roi.width = 100;
-    r1.roi.roi.height = 100;
-    // signal
-    r1.signal.elements.clear();
-    tier4_perception_msgs::msg::TrafficLightElement element;
-    element.color = tier4_perception_msgs::msg::TrafficLightElement::UNKNOWN;
-    element.shape = tier4_perception_msgs::msg::TrafficLightElement::UNKNOWN;
-    element.confidence = 0.0;
-    r1.signal.elements.push_back(element);
-  }
-  autoware::traffic_light::utils::FusionRecord r2;
-  {
-    std_msgs::msg::Header header;
-    header.stamp = rclcpp::Time(100, 10);
-    header.frame_id = "camera0";
-    // header
-    r2.header = header;
-    // cam_info
-    r2.cam_info.header = header;
-    r2.cam_info.width = 1440;
-    r2.cam_info.height = 1080;
-    // roi
-    r2.roi.roi.x_offset = 100;
-    r2.roi.roi.y_offset = 100;
-    r2.roi.roi.width = 100;
-    r2.roi.roi.height = 100;
-    // signal
-    r2.signal.elements.clear();
-    tier4_perception_msgs::msg::TrafficLightElement element;
-    element.color = tier4_perception_msgs::msg::TrafficLightElement::GREEN;
-    element.shape = tier4_perception_msgs::msg::TrafficLightElement::CIRCLE;
-    element.confidence = 0.8;
-    r2.signal.elements.push_back(element);
-  }
-  EXPECT_EQ(autoware::traffic_light::utils::compare_record(r1, r2), -1);
+  const auto unknown_record = make_record(unknown, unknown, 0.0, "camera0");
+  const auto known_record = make_record(green, circle, 0.8, "camera1");
+  EXPECT_EQ(utils::compare_record(unknown_record, known_record), R1_IS_WORSE);
+}
 
-  // r2 is unknown
-  {
-    std_msgs::msg::Header header;
-    header.stamp = rclcpp::Time(100, 10);
-    header.frame_id = "camera0";
-    // header
-    r1.header = header;
-    // cam_info
-    r1.cam_info.header = header;
-    r1.cam_info.width = 1440;
-    r1.cam_info.height = 1080;
-    // roi
-    r1.roi.roi.x_offset = 100;
-    r1.roi.roi.y_offset = 100;
-    r1.roi.roi.width = 100;
-    r1.roi.roi.height = 100;
-    // signal
-    r1.signal.elements.clear();
-    tier4_perception_msgs::msg::TrafficLightElement element;
-    element.color = tier4_perception_msgs::msg::TrafficLightElement::RED;
-    element.shape = tier4_perception_msgs::msg::TrafficLightElement::CIRCLE;
-    element.confidence = 0.9;
-    r1.signal.elements.push_back(element);
-  }
-  {
-    std_msgs::msg::Header header;
-    header.stamp = rclcpp::Time(100, 10);
-    header.frame_id = "camera0";
-    // header
-    r2.header = header;
-    // cam_info
-    r2.cam_info.header = header;
-    r2.cam_info.width = 1440;
-    r2.cam_info.height = 1080;
-    // roi
-    r2.roi.roi.x_offset = 100;
-    r2.roi.roi.y_offset = 100;
-    r2.roi.roi.width = 100;
-    r2.roi.roi.height = 100;
-    // signal
-    r2.signal.elements.clear();
-    tier4_perception_msgs::msg::TrafficLightElement element;
-    element.color = tier4_perception_msgs::msg::TrafficLightElement::UNKNOWN;
-    element.shape = tier4_perception_msgs::msg::TrafficLightElement::UNKNOWN;
-    element.confidence = 0.0;
-    r2.signal.elements.push_back(element);
-  }
-  EXPECT_EQ(autoware::traffic_light::utils::compare_record(r1, r2), 1);
+TEST(CompareRecordDifferentCamera, KnownRecordWinsOverUnknownRecord)
+{
+  const auto known_record = make_record(red, circle, 0.9, "camera0");
+  const auto unknown_record = make_record(unknown, unknown, 0.0, "camera1");
+  EXPECT_EQ(utils::compare_record(known_record, unknown_record), R1_IS_BETTER);
+}
 
-  // both of r1 and r2 is unknown
-  {
-    std_msgs::msg::Header header;
-    header.stamp = rclcpp::Time(100, 10);
-    header.frame_id = "camera0";
-    // header
-    r1.header = header;
-    // cam_info
-    r1.cam_info.header = header;
-    r1.cam_info.width = 1440;
-    r1.cam_info.height = 1080;
-    // roi
-    r1.roi.roi.x_offset = 100;
-    r1.roi.roi.y_offset = 100;
-    r1.roi.roi.width = 100;
-    r1.roi.roi.height = 100;
-    // signal
-    r1.signal.elements.clear();
-    tier4_perception_msgs::msg::TrafficLightElement element;
-    element.color = tier4_perception_msgs::msg::TrafficLightElement::UNKNOWN;
-    element.shape = tier4_perception_msgs::msg::TrafficLightElement::UNKNOWN;
-    element.confidence = 0.0;
-    r1.signal.elements.push_back(element);
-  }
-  {
-    std_msgs::msg::Header header;
-    header.stamp = rclcpp::Time(100, 10);
-    header.frame_id = "camera0";
-    // header
-    r2.header = header;
-    // cam_info
-    r2.cam_info.header = header;
-    r2.cam_info.width = 1440;
-    r2.cam_info.height = 1080;
-    // roi
-    r2.roi.roi.x_offset = 100;
-    r2.roi.roi.y_offset = 100;
-    r2.roi.roi.width = 100;
-    r2.roi.roi.height = 100;
-    // signal
-    r2.signal.elements.clear();
-    tier4_perception_msgs::msg::TrafficLightElement element;
-    element.color = tier4_perception_msgs::msg::TrafficLightElement::UNKNOWN;
-    element.shape = tier4_perception_msgs::msg::TrafficLightElement::UNKNOWN;
-    element.confidence = 0.0;
-    r2.signal.elements.push_back(element);
-  }
-  EXPECT_EQ(autoware::traffic_light::utils::compare_record(r1, r2), 0);
+TEST(CompareRecordDifferentCamera, BothUnknownRecordsAreEqual)
+{
+  const auto unknown_record_1 = make_record(unknown, unknown, 0.0, "camera0");
+  const auto unknown_record_2 = make_record(unknown, unknown, 0.0, "camera1");
+  EXPECT_EQ(utils::compare_record(unknown_record_1, unknown_record_2), BOTH_RECORDS_EQUAL);
 }
 
 // third condition
-TEST(CompareRecord, VisibleCheck)
+TEST(CompareRecordDifferentCamera, VisibleRecordWinsOverTruncatedRecord)
 {
-  // r1 is better visible on top left
-  autoware::traffic_light::utils::FusionRecord r1;
-  {
-    std_msgs::msg::Header header;
-    header.stamp = rclcpp::Time(100, 10);
-    header.frame_id = "camera0";
-    // header
-    r1.header = header;
-    // cam_info
-    r1.cam_info.header = header;
-    r1.cam_info.width = 1440;
-    r1.cam_info.height = 1080;
-    // roi
-    r1.roi.roi.x_offset = 100;
-    r1.roi.roi.y_offset = 100;
-    r1.roi.roi.width = 100;
-    r1.roi.roi.height = 100;
-    // signal
-    r1.signal.elements.clear();
-    tier4_perception_msgs::msg::TrafficLightElement element;
-    element.color = tier4_perception_msgs::msg::TrafficLightElement::RED;
-    element.shape = tier4_perception_msgs::msg::TrafficLightElement::CIRCLE;
-    element.confidence = 0.9;
-    r1.signal.elements.push_back(element);
-  }
-  autoware::traffic_light::utils::FusionRecord r2;
-  {
-    const uint32_t boundary_thres = 5;
-    std_msgs::msg::Header header;
-    header.stamp = rclcpp::Time(100, 10);
-    header.frame_id = "camera0";
-    // header
-    r2.header = header;
-    // cam_info
-    r2.cam_info.header = header;
-    r2.cam_info.width = 1440;
-    r2.cam_info.height = 1080;
-    // roi
-    r2.roi.roi.x_offset = boundary_thres;
-    r2.roi.roi.y_offset = boundary_thres;
-    r2.roi.roi.width = 100;
-    r2.roi.roi.height = 100;
-    // signal
-    r2.signal.elements.clear();
-    tier4_perception_msgs::msg::TrafficLightElement element;
-    element.color = tier4_perception_msgs::msg::TrafficLightElement::GREEN;
-    element.shape = tier4_perception_msgs::msg::TrafficLightElement::CIRCLE;
-    element.confidence = 0.8;
-    r2.signal.elements.push_back(element);
-  }
-  EXPECT_EQ(autoware::traffic_light::utils::compare_record(r1, r2), 1);
+  const auto visible_record = make_record_with_roi(visible_offset, visible_offset, "camera0");
+  const auto truncated_record =
+    make_record_with_roi(left_top_boundary_offset, left_top_boundary_offset, "camera1");
+  EXPECT_EQ(utils::compare_record(visible_record, truncated_record), R1_IS_BETTER);
+}
 
-  // r1 is better visible on bottom left
-  {
-    std_msgs::msg::Header header;
-    header.stamp = rclcpp::Time(100, 10);
-    header.frame_id = "camera0";
-    // header
-    r1.header = header;
-    // cam_info
-    r1.cam_info.header = header;
-    r1.cam_info.width = 1440;
-    r1.cam_info.height = 1080;
-    // roi
-    r1.roi.roi.x_offset = 100;
-    r1.roi.roi.y_offset = 100;
-    r1.roi.roi.width = 100;
-    r1.roi.roi.height = 100;
-    // signal
-    r1.signal.elements.clear();
-    tier4_perception_msgs::msg::TrafficLightElement element;
-    element.color = tier4_perception_msgs::msg::TrafficLightElement::RED;
-    element.shape = tier4_perception_msgs::msg::TrafficLightElement::CIRCLE;
-    element.confidence = 0.9;
-    r1.signal.elements.push_back(element);
-  }
-  {
-    const uint32_t boundary_thres = 5;
-    std_msgs::msg::Header header;
-    header.stamp = rclcpp::Time(100, 10);
-    header.frame_id = "camera0";
-    // header
-    r2.header = header;
-    // cam_info
-    r2.cam_info.header = header;
-    r2.cam_info.width = 1440;
-    r2.cam_info.height = 1080;
-    // roi
-    r2.roi.roi.x_offset = 1440 - (100 + boundary_thres);
-    r2.roi.roi.y_offset = 1080 - (100 + boundary_thres);
-    r2.roi.roi.width = 100;
-    r2.roi.roi.height = 100;
-    // signal
-    r2.signal.elements.clear();
-    tier4_perception_msgs::msg::TrafficLightElement element;
-    element.color = tier4_perception_msgs::msg::TrafficLightElement::GREEN;
-    element.shape = tier4_perception_msgs::msg::TrafficLightElement::CIRCLE;
-    element.confidence = 0.8;
-    r2.signal.elements.push_back(element);
-  }
-  EXPECT_EQ(autoware::traffic_light::utils::compare_record(r1, r2), 1);
-
-  // r2 is better visible on top left
-  {
-    const uint32_t boundary_thres = 5;
-    std_msgs::msg::Header header;
-    header.stamp = rclcpp::Time(100, 10);
-    header.frame_id = "camera0";
-    // header
-    r1.header = header;
-    // cam_info
-    r1.cam_info.header = header;
-    r1.cam_info.width = 1440;
-    r1.cam_info.height = 1080;
-    // roi
-    r1.roi.roi.x_offset = boundary_thres;
-    r1.roi.roi.y_offset = boundary_thres;
-    r1.roi.roi.width = 100;
-    r1.roi.roi.height = 100;
-    // signal
-    r1.signal.elements.clear();
-    tier4_perception_msgs::msg::TrafficLightElement element;
-    element.color = tier4_perception_msgs::msg::TrafficLightElement::RED;
-    element.shape = tier4_perception_msgs::msg::TrafficLightElement::CIRCLE;
-    element.confidence = 0.9;
-    r1.signal.elements.push_back(element);
-  }
-  {
-    std_msgs::msg::Header header;
-    header.stamp = rclcpp::Time(100, 10);
-    header.frame_id = "camera0";
-    // header
-    r2.header = header;
-    // cam_info
-    r2.cam_info.header = header;
-    r2.cam_info.width = 1440;
-    r2.cam_info.height = 1080;
-    // roi
-    r2.roi.roi.x_offset = 100;
-    r2.roi.roi.y_offset = 100;
-    r2.roi.roi.width = 100;
-    r2.roi.roi.height = 100;
-    // signal
-    r2.signal.elements.clear();
-    tier4_perception_msgs::msg::TrafficLightElement element;
-    element.color = tier4_perception_msgs::msg::TrafficLightElement::GREEN;
-    element.shape = tier4_perception_msgs::msg::TrafficLightElement::CIRCLE;
-    element.confidence = 0.8;
-    r2.signal.elements.push_back(element);
-  }
-  EXPECT_EQ(autoware::traffic_light::utils::compare_record(r1, r2), -1);
-
-  // r2 is better visible on bottom left
-  {
-    const uint32_t boundary_thres = 5;
-    std_msgs::msg::Header header;
-    header.stamp = rclcpp::Time(100, 10);
-    header.frame_id = "camera0";
-    // header
-    r1.header = header;
-    // cam_info
-    r1.cam_info.header = header;
-    r1.cam_info.width = 1440;
-    r1.cam_info.height = 1080;
-    // roi
-    r1.roi.roi.x_offset = 1440 - (100 + boundary_thres);
-    ;
-    r1.roi.roi.y_offset = 1080 - (100 + boundary_thres);
-    r1.roi.roi.width = 100;
-    r1.roi.roi.height = 100;
-    // signal
-    r1.signal.elements.clear();
-    tier4_perception_msgs::msg::TrafficLightElement element;
-    element.color = tier4_perception_msgs::msg::TrafficLightElement::RED;
-    element.shape = tier4_perception_msgs::msg::TrafficLightElement::CIRCLE;
-    element.confidence = 0.9;
-    r1.signal.elements.push_back(element);
-  }
-  {
-    std_msgs::msg::Header header;
-    header.stamp = rclcpp::Time(100, 10);
-    header.frame_id = "camera0";
-    // header
-    r2.header = header;
-    // cam_info
-    r2.cam_info.header = header;
-    r2.cam_info.width = 1440;
-    r2.cam_info.height = 1080;
-    // roi
-    r2.roi.roi.x_offset = 100;
-    r2.roi.roi.y_offset = 100;
-    r2.roi.roi.width = 100;
-    r2.roi.roi.height = 100;
-    // signal
-    r2.signal.elements.clear();
-    tier4_perception_msgs::msg::TrafficLightElement element;
-    element.color = tier4_perception_msgs::msg::TrafficLightElement::GREEN;
-    element.shape = tier4_perception_msgs::msg::TrafficLightElement::CIRCLE;
-    element.confidence = 0.8;
-    r2.signal.elements.push_back(element);
-  }
-  EXPECT_EQ(autoware::traffic_light::utils::compare_record(r1, r2), -1);
+TEST(CompareRecordDifferentCamera, TruncatedRecordLosesToVisibleRecord)
+{
+  const auto truncated_record =
+    make_record_with_roi(left_top_boundary_offset, left_top_boundary_offset, "camera0");
+  const auto visible_record = make_record_with_roi(visible_offset, visible_offset, "camera1");
+  EXPECT_EQ(utils::compare_record(truncated_record, visible_record), R1_IS_WORSE);
 }
 
 // fourth condition
-TEST(CompareRecord, ConfidenceCheck)
+TEST(CompareRecordDifferentCamera, HigherConfidenceRecordWins)
 {
-  // r1 is higher confidence
-  autoware::traffic_light::utils::FusionRecord r1;
-  {
-    std_msgs::msg::Header header;
-    header.stamp = rclcpp::Time(100, 10);
-    header.frame_id = "camera0";
-    // header
-    r1.header = header;
-    // cam_info
-    r1.cam_info.header = header;
-    r1.cam_info.width = 1440;
-    r1.cam_info.height = 1080;
-    // roi
-    r1.roi.roi.x_offset = 100;
-    r1.roi.roi.y_offset = 100;
-    r1.roi.roi.width = 100;
-    r1.roi.roi.height = 100;
-    // signal
-    r1.signal.elements.clear();
-    tier4_perception_msgs::msg::TrafficLightElement element;
-    element.color = tier4_perception_msgs::msg::TrafficLightElement::RED;
-    element.shape = tier4_perception_msgs::msg::TrafficLightElement::CIRCLE;
-    element.confidence = 0.9;
-    r1.signal.elements.push_back(element);
-  }
-  autoware::traffic_light::utils::FusionRecord r2;
-  {
-    std_msgs::msg::Header header;
-    header.stamp = rclcpp::Time(100, 10);
-    header.frame_id = "camera0";
-    // header
-    r2.header = header;
-    // cam_info
-    r2.cam_info.header = header;
-    r2.cam_info.width = 1440;
-    r2.cam_info.height = 1080;
-    // roi
-    r2.roi.roi.x_offset = 100;
-    r2.roi.roi.y_offset = 100;
-    r2.roi.roi.width = 100;
-    r2.roi.roi.height = 100;
-    // signal
-    r2.signal.elements.clear();
-    tier4_perception_msgs::msg::TrafficLightElement element;
-    element.color = tier4_perception_msgs::msg::TrafficLightElement::GREEN;
-    element.shape = tier4_perception_msgs::msg::TrafficLightElement::CIRCLE;
-    element.confidence = 0.8;
-    r2.signal.elements.push_back(element);
-  }
-  EXPECT_EQ(autoware::traffic_light::utils::compare_record(r1, r2), 1);
-
-  // r2 is higher confidence
-  {
-    std_msgs::msg::Header header;
-    header.stamp = rclcpp::Time(100, 10);
-    header.frame_id = "camera0";
-    // header
-    r1.header = header;
-    // cam_info
-    r1.cam_info.header = header;
-    r1.cam_info.width = 1440;
-    r1.cam_info.height = 1080;
-    // roi
-    r1.roi.roi.x_offset = 100;
-    r1.roi.roi.y_offset = 100;
-    r1.roi.roi.width = 100;
-    r1.roi.roi.height = 100;
-    // signal
-    r1.signal.elements.clear();
-    tier4_perception_msgs::msg::TrafficLightElement element;
-    element.color = tier4_perception_msgs::msg::TrafficLightElement::RED;
-    element.shape = tier4_perception_msgs::msg::TrafficLightElement::CIRCLE;
-    element.confidence = 0.9;
-    r1.signal.elements.push_back(element);
-  }
-  {
-    std_msgs::msg::Header header;
-    header.stamp = rclcpp::Time(100, 10);
-    header.frame_id = "camera0";
-    // header
-    r2.header = header;
-    // cam_info
-    r2.cam_info.header = header;
-    r2.cam_info.width = 1440;
-    r2.cam_info.height = 1080;
-    // roi
-    r2.roi.roi.x_offset = 100;
-    r2.roi.roi.y_offset = 100;
-    r2.roi.roi.width = 100;
-    r2.roi.roi.height = 100;
-    // signal
-    r2.signal.elements.clear();
-    tier4_perception_msgs::msg::TrafficLightElement element;
-    element.color = tier4_perception_msgs::msg::TrafficLightElement::GREEN;
-    element.shape = tier4_perception_msgs::msg::TrafficLightElement::CIRCLE;
-    element.confidence = 0.95;
-    r2.signal.elements.push_back(element);
-  }
-  EXPECT_EQ(autoware::traffic_light::utils::compare_record(r1, r2), -1);
+  const auto higher_confidence_record = make_record(red, circle, 0.9, "camera0");
+  const auto lower_confidence_record = make_record(green, circle, 0.8, "camera1");
+  EXPECT_EQ(utils::compare_record(higher_confidence_record, lower_confidence_record), R1_IS_BETTER);
 }
 
-}  // namespace same_camera
-
-namespace different_camera
+TEST(CompareRecordDifferentCamera, LowerConfidenceRecordLoses)
 {
-
-// first condition is nothing in different camera
-
-// second condition
-TEST(CompareRecord, UnknownCheck)
-{
-  // r1 is unknown
-  autoware::traffic_light::utils::FusionRecord r1;
-  {
-    std_msgs::msg::Header header;
-    header.stamp = rclcpp::Time(100, 10);
-    header.frame_id = "camera0";
-    // header
-    r1.header = header;
-    // cam_info
-    r1.cam_info.header = header;
-    r1.cam_info.width = 1440;
-    r1.cam_info.height = 1080;
-    // roi
-    r1.roi.roi.x_offset = 100;
-    r1.roi.roi.y_offset = 100;
-    r1.roi.roi.width = 100;
-    r1.roi.roi.height = 100;
-    // signal
-    r1.signal.elements.clear();
-    tier4_perception_msgs::msg::TrafficLightElement element;
-    element.color = tier4_perception_msgs::msg::TrafficLightElement::UNKNOWN;
-    element.shape = tier4_perception_msgs::msg::TrafficLightElement::UNKNOWN;
-    element.confidence = 0.0;
-    r1.signal.elements.push_back(element);
-  }
-  autoware::traffic_light::utils::FusionRecord r2;
-  {
-    std_msgs::msg::Header header;
-    header.stamp = rclcpp::Time(100, 10);
-    header.frame_id = "camera1";
-    // header
-    r2.header = header;
-    // cam_info
-    r2.cam_info.header = header;
-    r2.cam_info.width = 1440;
-    r2.cam_info.height = 1080;
-    // roi
-    r2.roi.roi.x_offset = 100;
-    r2.roi.roi.y_offset = 100;
-    r2.roi.roi.width = 100;
-    r2.roi.roi.height = 100;
-    // signal
-    r2.signal.elements.clear();
-    tier4_perception_msgs::msg::TrafficLightElement element;
-    element.color = tier4_perception_msgs::msg::TrafficLightElement::GREEN;
-    element.shape = tier4_perception_msgs::msg::TrafficLightElement::CIRCLE;
-    element.confidence = 0.8;
-    r2.signal.elements.push_back(element);
-  }
-  EXPECT_EQ(autoware::traffic_light::utils::compare_record(r1, r2), -1);
-
-  // r2 is unknown
-  {
-    std_msgs::msg::Header header;
-    header.stamp = rclcpp::Time(100, 10);
-    header.frame_id = "camera0";
-    // header
-    r1.header = header;
-    // cam_info
-    r1.cam_info.header = header;
-    r1.cam_info.width = 1440;
-    r1.cam_info.height = 1080;
-    // roi
-    r1.roi.roi.x_offset = 100;
-    r1.roi.roi.y_offset = 100;
-    r1.roi.roi.width = 100;
-    r1.roi.roi.height = 100;
-    // signal
-    r1.signal.elements.clear();
-    tier4_perception_msgs::msg::TrafficLightElement element;
-    element.color = tier4_perception_msgs::msg::TrafficLightElement::RED;
-    element.shape = tier4_perception_msgs::msg::TrafficLightElement::CIRCLE;
-    element.confidence = 0.9;
-    r1.signal.elements.push_back(element);
-  }
-  {
-    std_msgs::msg::Header header;
-    header.stamp = rclcpp::Time(100, 10);
-    header.frame_id = "camera1";
-    // header
-    r2.header = header;
-    // cam_info
-    r2.cam_info.header = header;
-    r2.cam_info.width = 1440;
-    r2.cam_info.height = 1080;
-    // roi
-    r2.roi.roi.x_offset = 100;
-    r2.roi.roi.y_offset = 100;
-    r2.roi.roi.width = 100;
-    r2.roi.roi.height = 100;
-    // signal
-    r2.signal.elements.clear();
-    tier4_perception_msgs::msg::TrafficLightElement element;
-    element.color = tier4_perception_msgs::msg::TrafficLightElement::UNKNOWN;
-    element.shape = tier4_perception_msgs::msg::TrafficLightElement::UNKNOWN;
-    element.confidence = 0.0;
-    r2.signal.elements.push_back(element);
-  }
-  EXPECT_EQ(autoware::traffic_light::utils::compare_record(r1, r2), 1);
-
-  // both of r1 and r2 is unknown
-  {
-    std_msgs::msg::Header header;
-    header.stamp = rclcpp::Time(100, 10);
-    header.frame_id = "camera0";
-    // header
-    r1.header = header;
-    // cam_info
-    r1.cam_info.header = header;
-    r1.cam_info.width = 1440;
-    r1.cam_info.height = 1080;
-    // roi
-    r1.roi.roi.x_offset = 100;
-    r1.roi.roi.y_offset = 100;
-    r1.roi.roi.width = 100;
-    r1.roi.roi.height = 100;
-    // signal
-    r1.signal.elements.clear();
-    tier4_perception_msgs::msg::TrafficLightElement element;
-    element.color = tier4_perception_msgs::msg::TrafficLightElement::UNKNOWN;
-    element.shape = tier4_perception_msgs::msg::TrafficLightElement::UNKNOWN;
-    element.confidence = 0.0;
-    r1.signal.elements.push_back(element);
-  }
-  {
-    std_msgs::msg::Header header;
-    header.stamp = rclcpp::Time(100, 10);
-    header.frame_id = "camera1";
-    // header
-    r2.header = header;
-    // cam_info
-    r2.cam_info.header = header;
-    r2.cam_info.width = 1440;
-    r2.cam_info.height = 1080;
-    // roi
-    r2.roi.roi.x_offset = 100;
-    r2.roi.roi.y_offset = 100;
-    r2.roi.roi.width = 100;
-    r2.roi.roi.height = 100;
-    // signal
-    r2.signal.elements.clear();
-    tier4_perception_msgs::msg::TrafficLightElement element;
-    element.color = tier4_perception_msgs::msg::TrafficLightElement::UNKNOWN;
-    element.shape = tier4_perception_msgs::msg::TrafficLightElement::UNKNOWN;
-    element.confidence = 0.0;
-    r2.signal.elements.push_back(element);
-  }
-  EXPECT_EQ(autoware::traffic_light::utils::compare_record(r1, r2), 0);
+  const auto lower_confidence_record = make_record(red, circle, 0.9, "camera0");
+  const auto higher_confidence_record = make_record(green, circle, 0.95, "camera1");
+  EXPECT_EQ(utils::compare_record(lower_confidence_record, higher_confidence_record), R1_IS_WORSE);
 }
 
-// third condition
-TEST(CompareRecord, VisibleCheck)
+TEST(CalVisibleScore, FullyVisibleRoiScoresOne)
 {
-  // r1 is better visible on top left
-  autoware::traffic_light::utils::FusionRecord r1;
-  {
-    std_msgs::msg::Header header;
-    header.stamp = rclcpp::Time(100, 10);
-    header.frame_id = "camera0";
-    // header
-    r1.header = header;
-    // cam_info
-    r1.cam_info.header = header;
-    r1.cam_info.width = 1440;
-    r1.cam_info.height = 1080;
-    // roi
-    r1.roi.roi.x_offset = 100;
-    r1.roi.roi.y_offset = 100;
-    r1.roi.roi.width = 100;
-    r1.roi.roi.height = 100;
-    // signal
-    r1.signal.elements.clear();
-    tier4_perception_msgs::msg::TrafficLightElement element;
-    element.color = tier4_perception_msgs::msg::TrafficLightElement::RED;
-    element.shape = tier4_perception_msgs::msg::TrafficLightElement::CIRCLE;
-    element.confidence = 0.9;
-    r1.signal.elements.push_back(element);
-  }
-  autoware::traffic_light::utils::FusionRecord r2;
-  {
-    const uint32_t boundary_thres = 5;
-    std_msgs::msg::Header header;
-    header.stamp = rclcpp::Time(100, 10);
-    header.frame_id = "camera1";
-    // header
-    r2.header = header;
-    // cam_info
-    r2.cam_info.header = header;
-    r2.cam_info.width = 1440;
-    r2.cam_info.height = 1080;
-    // roi
-    r2.roi.roi.x_offset = boundary_thres;
-    r2.roi.roi.y_offset = boundary_thres;
-    r2.roi.roi.width = 100;
-    r2.roi.roi.height = 100;
-    // signal
-    r2.signal.elements.clear();
-    tier4_perception_msgs::msg::TrafficLightElement element;
-    element.color = tier4_perception_msgs::msg::TrafficLightElement::GREEN;
-    element.shape = tier4_perception_msgs::msg::TrafficLightElement::CIRCLE;
-    element.confidence = 0.8;
-    r2.signal.elements.push_back(element);
-  }
-  EXPECT_EQ(autoware::traffic_light::utils::compare_record(r1, r2), 1);
-
-  // r1 is better visible on bottom left
-  {
-    std_msgs::msg::Header header;
-    header.stamp = rclcpp::Time(100, 10);
-    header.frame_id = "camera0";
-    // header
-    r1.header = header;
-    // cam_info
-    r1.cam_info.header = header;
-    r1.cam_info.width = 1440;
-    r1.cam_info.height = 1080;
-    // roi
-    r1.roi.roi.x_offset = 100;
-    r1.roi.roi.y_offset = 100;
-    r1.roi.roi.width = 100;
-    r1.roi.roi.height = 100;
-    // signal
-    r1.signal.elements.clear();
-    tier4_perception_msgs::msg::TrafficLightElement element;
-    element.color = tier4_perception_msgs::msg::TrafficLightElement::RED;
-    element.shape = tier4_perception_msgs::msg::TrafficLightElement::CIRCLE;
-    element.confidence = 0.9;
-    r1.signal.elements.push_back(element);
-  }
-  {
-    const uint32_t boundary_thres = 5;
-    std_msgs::msg::Header header;
-    header.stamp = rclcpp::Time(100, 10);
-    header.frame_id = "camera1";
-    // header
-    r2.header = header;
-    // cam_info
-    r2.cam_info.header = header;
-    r2.cam_info.width = 1440;
-    r2.cam_info.height = 1080;
-    // roi
-    r2.roi.roi.x_offset = 1440 - (100 + boundary_thres);
-    r2.roi.roi.y_offset = 1080 - (100 + boundary_thres);
-    r2.roi.roi.width = 100;
-    r2.roi.roi.height = 100;
-    // signal
-    r2.signal.elements.clear();
-    tier4_perception_msgs::msg::TrafficLightElement element;
-    element.color = tier4_perception_msgs::msg::TrafficLightElement::GREEN;
-    element.shape = tier4_perception_msgs::msg::TrafficLightElement::CIRCLE;
-    element.confidence = 0.8;
-    r2.signal.elements.push_back(element);
-  }
-  EXPECT_EQ(autoware::traffic_light::utils::compare_record(r1, r2), 1);
-
-  // r2 is better visible on top left
-  {
-    const uint32_t boundary_thres = 5;
-    std_msgs::msg::Header header;
-    header.stamp = rclcpp::Time(100, 10);
-    header.frame_id = "camera0";
-    // header
-    r1.header = header;
-    // cam_info
-    r1.cam_info.header = header;
-    r1.cam_info.width = 1440;
-    r1.cam_info.height = 1080;
-    // roi
-    r1.roi.roi.x_offset = boundary_thres;
-    r1.roi.roi.y_offset = boundary_thres;
-    r1.roi.roi.width = 100;
-    r1.roi.roi.height = 100;
-    // signal
-    r1.signal.elements.clear();
-    tier4_perception_msgs::msg::TrafficLightElement element;
-    element.color = tier4_perception_msgs::msg::TrafficLightElement::RED;
-    element.shape = tier4_perception_msgs::msg::TrafficLightElement::CIRCLE;
-    element.confidence = 0.9;
-    r1.signal.elements.push_back(element);
-  }
-  {
-    std_msgs::msg::Header header;
-    header.stamp = rclcpp::Time(100, 10);
-    header.frame_id = "camera1";
-    // header
-    r2.header = header;
-    // cam_info
-    r2.cam_info.header = header;
-    r2.cam_info.width = 1440;
-    r2.cam_info.height = 1080;
-    // roi
-    r2.roi.roi.x_offset = 100;
-    r2.roi.roi.y_offset = 100;
-    r2.roi.roi.width = 100;
-    r2.roi.roi.height = 100;
-    // signal
-    r2.signal.elements.clear();
-    tier4_perception_msgs::msg::TrafficLightElement element;
-    element.color = tier4_perception_msgs::msg::TrafficLightElement::GREEN;
-    element.shape = tier4_perception_msgs::msg::TrafficLightElement::CIRCLE;
-    element.confidence = 0.8;
-    r2.signal.elements.push_back(element);
-  }
-  EXPECT_EQ(autoware::traffic_light::utils::compare_record(r1, r2), -1);
-
-  // r2 is better visible on bottom left
-  {
-    const uint32_t boundary_thres = 5;
-    std_msgs::msg::Header header;
-    header.stamp = rclcpp::Time(100, 10);
-    header.frame_id = "camera0";
-    // header
-    r1.header = header;
-    // cam_info
-    r1.cam_info.header = header;
-    r1.cam_info.width = 1440;
-    r1.cam_info.height = 1080;
-    // roi
-    r1.roi.roi.x_offset = 1440 - (100 + boundary_thres);
-    ;
-    r1.roi.roi.y_offset = 1080 - (100 + boundary_thres);
-    r1.roi.roi.width = 100;
-    r1.roi.roi.height = 100;
-    // signal
-    r1.signal.elements.clear();
-    tier4_perception_msgs::msg::TrafficLightElement element;
-    element.color = tier4_perception_msgs::msg::TrafficLightElement::RED;
-    element.shape = tier4_perception_msgs::msg::TrafficLightElement::CIRCLE;
-    element.confidence = 0.9;
-    r1.signal.elements.push_back(element);
-  }
-  {
-    std_msgs::msg::Header header;
-    header.stamp = rclcpp::Time(100, 10);
-    header.frame_id = "camera1";
-    // header
-    r2.header = header;
-    // cam_info
-    r2.cam_info.header = header;
-    r2.cam_info.width = 1440;
-    r2.cam_info.height = 1080;
-    // roi
-    r2.roi.roi.x_offset = 100;
-    r2.roi.roi.y_offset = 100;
-    r2.roi.roi.width = 100;
-    r2.roi.roi.height = 100;
-    // signal
-    r2.signal.elements.clear();
-    tier4_perception_msgs::msg::TrafficLightElement element;
-    element.color = tier4_perception_msgs::msg::TrafficLightElement::GREEN;
-    element.shape = tier4_perception_msgs::msg::TrafficLightElement::CIRCLE;
-    element.confidence = 0.8;
-    r2.signal.elements.push_back(element);
-  }
-  EXPECT_EQ(autoware::traffic_light::utils::compare_record(r1, r2), -1);
+  const auto record = make_record_with_roi(visible_offset, visible_offset);
+  EXPECT_EQ(utils::cal_visible_score(record), VISIBLE);
 }
 
-// fourth condition
-TEST(CompareRecord, ConfidenceCheck)
+TEST(CalVisibleScore, RoiNearLeftBoundaryScoresZero)
 {
-  // r1 is higher confidence
-  autoware::traffic_light::utils::FusionRecord r1;
-  {
-    std_msgs::msg::Header header;
-    header.stamp = rclcpp::Time(100, 10);
-    header.frame_id = "camera0";
-    // header
-    r1.header = header;
-    // cam_info
-    r1.cam_info.header = header;
-    r1.cam_info.width = 1440;
-    r1.cam_info.height = 1080;
-    // roi
-    r1.roi.roi.x_offset = 100;
-    r1.roi.roi.y_offset = 100;
-    r1.roi.roi.width = 100;
-    r1.roi.roi.height = 100;
-    // signal
-    r1.signal.elements.clear();
-    tier4_perception_msgs::msg::TrafficLightElement element;
-    element.color = tier4_perception_msgs::msg::TrafficLightElement::RED;
-    element.shape = tier4_perception_msgs::msg::TrafficLightElement::CIRCLE;
-    element.confidence = 0.9;
-    r1.signal.elements.push_back(element);
-  }
-  autoware::traffic_light::utils::FusionRecord r2;
-  {
-    std_msgs::msg::Header header;
-    header.stamp = rclcpp::Time(100, 10);
-    header.frame_id = "camera1";
-    // header
-    r2.header = header;
-    // cam_info
-    r2.cam_info.header = header;
-    r2.cam_info.width = 1440;
-    r2.cam_info.height = 1080;
-    // roi
-    r2.roi.roi.x_offset = 100;
-    r2.roi.roi.y_offset = 100;
-    r2.roi.roi.width = 100;
-    r2.roi.roi.height = 100;
-    // signal
-    r2.signal.elements.clear();
-    tier4_perception_msgs::msg::TrafficLightElement element;
-    element.color = tier4_perception_msgs::msg::TrafficLightElement::GREEN;
-    element.shape = tier4_perception_msgs::msg::TrafficLightElement::CIRCLE;
-    element.confidence = 0.8;
-    r2.signal.elements.push_back(element);
-  }
-  EXPECT_EQ(autoware::traffic_light::utils::compare_record(r1, r2), 1);
-
-  // r2 is higher confidence
-  {
-    std_msgs::msg::Header header;
-    header.stamp = rclcpp::Time(100, 10);
-    header.frame_id = "camera0";
-    // header
-    r1.header = header;
-    // cam_info
-    r1.cam_info.header = header;
-    r1.cam_info.width = 1440;
-    r1.cam_info.height = 1080;
-    // roi
-    r1.roi.roi.x_offset = 100;
-    r1.roi.roi.y_offset = 100;
-    r1.roi.roi.width = 100;
-    r1.roi.roi.height = 100;
-    // signal
-    r1.signal.elements.clear();
-    tier4_perception_msgs::msg::TrafficLightElement element;
-    element.color = tier4_perception_msgs::msg::TrafficLightElement::RED;
-    element.shape = tier4_perception_msgs::msg::TrafficLightElement::CIRCLE;
-    element.confidence = 0.9;
-    r1.signal.elements.push_back(element);
-  }
-  {
-    std_msgs::msg::Header header;
-    header.stamp = rclcpp::Time(100, 10);
-    header.frame_id = "camera1";
-    // header
-    r2.header = header;
-    // cam_info
-    r2.cam_info.header = header;
-    r2.cam_info.width = 1440;
-    r2.cam_info.height = 1080;
-    // roi
-    r2.roi.roi.x_offset = 100;
-    r2.roi.roi.y_offset = 100;
-    r2.roi.roi.width = 100;
-    r2.roi.roi.height = 100;
-    // signal
-    r2.signal.elements.clear();
-    tier4_perception_msgs::msg::TrafficLightElement element;
-    element.color = tier4_perception_msgs::msg::TrafficLightElement::GREEN;
-    element.shape = tier4_perception_msgs::msg::TrafficLightElement::CIRCLE;
-    element.confidence = 0.95;
-    r2.signal.elements.push_back(element);
-  }
-  EXPECT_EQ(autoware::traffic_light::utils::compare_record(r1, r2), -1);
+  const auto record = make_record_with_roi(left_top_boundary_offset, visible_offset);
+  EXPECT_EQ(utils::cal_visible_score(record), TRUNCATED);
 }
 
-}  // namespace different_camera
-
-TEST(CalVisibleScore, Normal)
+TEST(CalVisibleScore, RoiNearRightBoundaryScoresZero)
 {
-  // visible
-  autoware::traffic_light::utils::FusionRecord r1;
-  {
-    std_msgs::msg::Header header;
-    header.stamp = rclcpp::Time(100, 10);
-    header.frame_id = "camera0";
-    // header
-    r1.header = header;
-    // cam_info
-    r1.cam_info.header = header;
-    r1.cam_info.width = 1440;
-    r1.cam_info.height = 1080;
-    // roi
-    r1.roi.roi.x_offset = 100;
-    r1.roi.roi.y_offset = 100;
-    r1.roi.roi.width = 100;
-    r1.roi.roi.height = 100;
-    // signal
-    r1.signal.elements.clear();
-    tier4_perception_msgs::msg::TrafficLightElement element;
-    element.color = tier4_perception_msgs::msg::TrafficLightElement::RED;
-    element.shape = tier4_perception_msgs::msg::TrafficLightElement::CIRCLE;
-    element.confidence = 0.9;
-    r1.signal.elements.push_back(element);
-  }
-  EXPECT_EQ(autoware::traffic_light::utils::cal_visible_score(r1), 1);
+  const auto record = make_record_with_roi(right_boundary_offset, visible_offset);
+  EXPECT_EQ(utils::cal_visible_score(record), TRUNCATED);
+}
 
-  // invisible by left top
-  {
-    const uint32_t boundary_thres = 5;
-    std_msgs::msg::Header header;
-    header.stamp = rclcpp::Time(100, 10);
-    header.frame_id = "camera0";
-    // header
-    r1.header = header;
-    // cam_info
-    r1.cam_info.header = header;
-    r1.cam_info.width = 1440;
-    r1.cam_info.height = 1080;
-    // roi
-    r1.roi.roi.x_offset = boundary_thres;
-    r1.roi.roi.y_offset = boundary_thres;
-    r1.roi.roi.width = 100;
-    r1.roi.roi.height = 100;
-    // signal
-    r1.signal.elements.clear();
-    tier4_perception_msgs::msg::TrafficLightElement element;
-    element.color = tier4_perception_msgs::msg::TrafficLightElement::RED;
-    element.shape = tier4_perception_msgs::msg::TrafficLightElement::CIRCLE;
-    element.confidence = 0.9;
-    r1.signal.elements.push_back(element);
-  }
-  EXPECT_EQ(autoware::traffic_light::utils::cal_visible_score(r1), 0);
+TEST(CalVisibleScore, RoiNearTopBoundaryScoresZero)
+{
+  const auto record = make_record_with_roi(visible_offset, left_top_boundary_offset);
+  EXPECT_EQ(utils::cal_visible_score(record), TRUNCATED);
+}
 
-  // invisible by right top
-  {
-    const uint32_t boundary_thres = 5;
-    std_msgs::msg::Header header;
-    header.stamp = rclcpp::Time(100, 10);
-    header.frame_id = "camera0";
-    // header
-    r1.header = header;
-    // cam_info
-    r1.cam_info.header = header;
-    r1.cam_info.width = 1440;
-    r1.cam_info.height = 1080;
-    // roi
-    r1.roi.roi.x_offset = 1080 - (100 + boundary_thres);
-    r1.roi.roi.y_offset = boundary_thres;
-    r1.roi.roi.width = 100;
-    r1.roi.roi.height = 100;
-    // signal
-    r1.signal.elements.clear();
-    tier4_perception_msgs::msg::TrafficLightElement element;
-    element.color = tier4_perception_msgs::msg::TrafficLightElement::RED;
-    element.shape = tier4_perception_msgs::msg::TrafficLightElement::CIRCLE;
-    element.confidence = 0.9;
-    r1.signal.elements.push_back(element);
-  }
-  EXPECT_EQ(autoware::traffic_light::utils::cal_visible_score(r1), 0);
-
-  // invisible by left bottom
-  {
-    const uint32_t boundary_thres = 5;
-    std_msgs::msg::Header header;
-    header.stamp = rclcpp::Time(100, 10);
-    header.frame_id = "camera0";
-    // header
-    r1.header = header;
-    // cam_info
-    r1.cam_info.header = header;
-    r1.cam_info.width = 1440;
-    r1.cam_info.height = 1080;
-    // roi
-    r1.roi.roi.x_offset = boundary_thres;
-    r1.roi.roi.y_offset = 1080 - (100 + boundary_thres);
-    r1.roi.roi.width = 100;
-    r1.roi.roi.height = 100;
-    // signal
-    r1.signal.elements.clear();
-    tier4_perception_msgs::msg::TrafficLightElement element;
-    element.color = tier4_perception_msgs::msg::TrafficLightElement::RED;
-    element.shape = tier4_perception_msgs::msg::TrafficLightElement::CIRCLE;
-    element.confidence = 0.9;
-    r1.signal.elements.push_back(element);
-  }
-  EXPECT_EQ(autoware::traffic_light::utils::cal_visible_score(r1), 0);
-
-  // invisible by right bottom
-  {
-    const uint32_t boundary_thres = 5;
-    std_msgs::msg::Header header;
-    header.stamp = rclcpp::Time(100, 10);
-    header.frame_id = "camera0";
-    // header
-    r1.header = header;
-    // cam_info
-    r1.cam_info.header = header;
-    r1.cam_info.width = 1440;
-    r1.cam_info.height = 1080;
-    // roi
-    r1.roi.roi.x_offset = 1440 - (100 + boundary_thres);
-    r1.roi.roi.y_offset = 1080 - (100 + boundary_thres);
-    r1.roi.roi.width = 100;
-    r1.roi.roi.height = 100;
-    // signal
-    r1.signal.elements.clear();
-    tier4_perception_msgs::msg::TrafficLightElement element;
-    element.color = tier4_perception_msgs::msg::TrafficLightElement::RED;
-    element.shape = tier4_perception_msgs::msg::TrafficLightElement::CIRCLE;
-    element.confidence = 0.9;
-    r1.signal.elements.push_back(element);
-  }
-  EXPECT_EQ(autoware::traffic_light::utils::cal_visible_score(r1), 0);
+TEST(CalVisibleScore, RoiNearBottomBoundaryScoresZero)
+{
+  const auto record = make_record_with_roi(visible_offset, bottom_boundary_offset);
+  EXPECT_EQ(utils::cal_visible_score(record), TRUNCATED);
 }
 
 int main(int argc, char ** argv)


### PR DESCRIPTION
## Description

Follow-up refactoring of `autoware_traffic_light_multi_camera_fusion` after the core logic was extracted and unit tests were added (#12630). No ROS interfaces, parameters or topics are changed.

The work is split into focused commits:

### 1. Replace the `SignalValidator` class with a free function
`SignalValidator` held only a static `check_conflict` and an unimplemented `merge_partial_match` (dead code).
- Demoted `check_conflict` to a free function in `namespace signal_validator`.
- Dropped the dead `merge_partial_match` declaration.
- Removed the conditionally-created `signal_validator_` `unique_ptr` member, which left a hidden segfault precondition when the consistency check was disabled.

### 2. Move file-local helpers out of the public header
`is_unknown(StateKey)` and `compare_state_key_log_odds` were inline functions in the header but are only used inside the `.cpp`. `convert_output_msg` and `update_best_record` were `static` member functions that touch no member state. All four were demoted into the existing anonymous namespace in the `.cpp`, so the public header now exposes only the types and the class API.

### 3. Rename ambiguous `is_unknown` overloads
Two same-named `is_unknown` functions checked different things (a `StateKey` vs. a `TrafficLight` signal). Renamed to `is_state_key_unknown` and `is_signal_unknown` so the check target is clear from the name alone.

### 4. Replace the three-valued `compare_record` with a boolean predicate
`compare_record` returned `-1 / 0 / 1`, but its only caller used just the sign via `>= 0`. Redesigned into `has_higher_or_equal_priority(candidate, existing)`, which directly answers whether a candidate record should replace the current best one. The fixed priority order (timestamp → recognized-over-unknown → visibility → confidence) and tie handling are preserved.

### 5. Replace `cal_visible_score` (int 0/1) with `is_fully_visible` (bool)
`cal_visible_score` returned `int` `0/1`, which is effectively a boolean. Replaced with the predicate `is_fully_visible(record)` (`true` = not truncated by the image boundary) and simplified the visibility check in `has_higher_or_equal_priority`.

### 6. Refactor the unit tests for readability
- Extracted `make_signal` / `make_record` builder helpers to remove ~20 lines of `FusionRecord` setup duplicated in every test.
- Split multi-assertion tests into single-scenario test cases with intention-revealing names.
- Replaced magic numbers with named constants and the expected results with named values.

## Related links

**Parent Issue:**

- Link

## How was this PR tested?

Built and tested with `colcon` on the target package; all tests pass.

```bash
colcon build --packages-select autoware_traffic_light_multi_camera_fusion
colcon test  --packages-select autoware_traffic_light_multi_camera_fusion --event-handlers console_cohesion+
# 100% tests passed, 0 tests failed out of 6 (gtest unit + node tests, copyright, cppcheck, lint_cmake, xmllint)
```

The existing unit tests (`test_utils`, `test_signal_validator`) and the node-level integration tests (`test_multi_camera_fusion`) were updated to follow the renamed/boolean APIs and continue to pass, confirming the refactor is behavior-preserving.

## Notes for reviewers

- This is an internal (non-ROS-interface) refactor. The only API changes are to package-internal helpers declared under `src/` (not installed headers):
  - `compare_record` → `has_higher_or_equal_priority`
  - `cal_visible_score` → `is_fully_visible`
  - `is_unknown` (×2) → `is_state_key_unknown` / `is_signal_unknown`
  - `SignalValidator::check_conflict` → `signal_validator::check_conflict` (free function)
- The large diff in `test/test_utils.cpp` is almost entirely deletion of duplicated setup code.

## Interface changes

None.

## Effects on system behavior

The refactor itself preserves the existing fusion behavior (priority ordering, conflict detection, visibility/truncation handling). The only behavioral change is the bug fix in item 8: an roi that extends past the right or bottom image edge is now correctly classified as truncated (previously it was mis-classified as fully visible due to unsigned underflow), so such a detection is now correctly deprioritized during fusion.
