### PR TITLE
feat(autoware_control_evaluator): add object_metrics.excluded_labels fpr ignoring unknown objects

### DIFF
--- a/evaluator/autoware_control_evaluator/config/control_evaluator.param.yaml
+++ b/evaluator/autoware_control_evaluator/config/control_evaluator.param.yaml
@@ -21,3 +21,5 @@
           - walkway
     object_metrics:
       distance_filter_thr_m: 30.0 # [m] distance filter threshold for predicted objects
+      excluded_labels: #   unknown, car, truck, bus, trailer, motorcycle, bicycle, pedestrian, animal, hazard, over_drivable, under_drivable
+        - unknown

--- a/evaluator/autoware_control_evaluator/include/autoware/control_evaluator/control_evaluator_node.hpp
+++ b/evaluator/autoware_control_evaluator/include/autoware/control_evaluator/control_evaluator_node.hpp
@@ -131,6 +131,7 @@ private:
   // Parameters
   bool output_metrics_;
   double distance_filter_thr_m_;
+  std::unordered_set<uint8_t> excluded_object_labels_;
 
   // Metric
   const std::vector<Metric> metrics_ = {

--- a/evaluator/autoware_control_evaluator/include/autoware/control_evaluator/metrics/metric.hpp
+++ b/evaluator/autoware_control_evaluator/include/autoware/control_evaluator/metrics/metric.hpp
@@ -175,7 +175,7 @@ static const std::unordered_map<Metric, std::string> metric_descriptions = {
    "Absolute deviation to the stop line when the ego stop by a module[m]"},
   {Metric::closest_object_distance,
    "Distance to the closest object[m], the objects outside of the distance_filter_thr_m (default: "
-   "30m) are ignored"},
+   "30m) or in object_metrics.excluded_labels are ignored"},
   {Metric::longitudinal_velocity_deviation,
    "Longitudinal velocity deviation from the reference trajectory[m], positive value means the "
    "actual velocity is larger than the planned velocity."},

--- a/evaluator/autoware_control_evaluator/package.xml
+++ b/evaluator/autoware_control_evaluator/package.xml
@@ -20,6 +20,7 @@
   <depend>autoware_internal_planning_msgs</depend>
   <depend>autoware_lanelet2_utils</depend>
   <depend>autoware_motion_utils</depend>
+  <depend>autoware_object_recognition_utils</depend>
   <depend>autoware_perception_msgs</depend>
   <depend>autoware_planning_factor_interface</depend>
   <depend>autoware_planning_msgs</depend>

--- a/evaluator/autoware_control_evaluator/schema/autoware_control_evaluator.schema.json
+++ b/evaluator/autoware_control_evaluator/schema/autoware_control_evaluator.schema.json
@@ -70,6 +70,28 @@
               "description": "maximum distance to the predicted objects to be considered",
               "type": "number",
               "default": 30.0
+            },
+            "excluded_labels": {
+              "description": "object classification labels excluded from closest_object_distance metric",
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "unknown",
+                  "car",
+                  "truck",
+                  "bus",
+                  "trailer",
+                  "motorcycle",
+                  "bicycle",
+                  "pedestrian",
+                  "animal",
+                  "hazard",
+                  "over_drivable",
+                  "under_drivable"
+                ]
+              },
+              "default": ["unknown"]
             }
           }
         }

--- a/evaluator/autoware_control_evaluator/src/control_evaluator_node.cpp
+++ b/evaluator/autoware_control_evaluator/src/control_evaluator_node.cpp
@@ -107,9 +107,8 @@ ControlEvaluatorNode::ControlEvaluatorNode(const rclcpp::NodeOptions & node_opti
   // Parameters
   output_metrics_ = declare_parameter<bool>("output_metrics");
   distance_filter_thr_m_ = declare_parameter<double>("object_metrics.distance_filter_thr_m");
-  const std::vector<std::string> excluded_labels =
-    declare_parameter<std::vector<std::string>>(
-      "object_metrics.excluded_labels", std::vector<std::string>{"unknown"});
+  const std::vector<std::string> excluded_labels = declare_parameter<std::vector<std::string>>(
+    "object_metrics.excluded_labels", std::vector<std::string>{"unknown"});
   for (const auto & label_name : excluded_labels) {
     const auto label = label_from_string(label_name);
     if (label) {

--- a/evaluator/autoware_control_evaluator/src/control_evaluator_node.cpp
+++ b/evaluator/autoware_control_evaluator/src/control_evaluator_node.cpp
@@ -627,7 +627,7 @@ void ControlEvaluatorNode::AddObjectMetricMsg(
   for (const auto & object : objects.objects) {
     const auto label =
       autoware::object_recognition_utils::getHighestProbLabel(object.classification);
-    if (excluded_object_labels_.count(label) > 0) {
+    if (excluded_object_labels_.find(label) != excluded_object_labels.end()) {
       continue;
     }
 

--- a/evaluator/autoware_control_evaluator/src/control_evaluator_node.cpp
+++ b/evaluator/autoware_control_evaluator/src/control_evaluator_node.cpp
@@ -626,7 +626,7 @@ void ControlEvaluatorNode::AddObjectMetricMsg(
   for (const auto & object : objects.objects) {
     const auto label =
       autoware::object_recognition_utils::getHighestProbLabel(object.classification);
-    if (excluded_object_labels_.find(label) != excluded_object_labels.end()) {
+    if (excluded_object_labels_.find(label) != excluded_object_labels_.end()) {
       continue;
     }
 

--- a/evaluator/autoware_control_evaluator/src/control_evaluator_node.cpp
+++ b/evaluator/autoware_control_evaluator/src/control_evaluator_node.cpp
@@ -21,7 +21,6 @@
 #include <autoware/lanelet2_utils/geometry.hpp>
 #include <autoware/lanelet2_utils/nn_search.hpp>
 #include <autoware/object_recognition_utils/object_recognition_utils.hpp>
-#include <autoware_lanelet2_extension/utility/utilities.hpp>
 #include <autoware_utils/geometry/boost_polygon_utils.hpp>
 #include <autoware_utils/geometry/geometry.hpp>
 #include <nlohmann/json.hpp>

--- a/evaluator/autoware_control_evaluator/src/control_evaluator_node.cpp
+++ b/evaluator/autoware_control_evaluator/src/control_evaluator_node.cpp
@@ -20,6 +20,8 @@
 #include <autoware/deprecated/boundary_departure_checker/utils.hpp>
 #include <autoware/lanelet2_utils/geometry.hpp>
 #include <autoware/lanelet2_utils/nn_search.hpp>
+#include <autoware/object_recognition_utils/object_recognition_utils.hpp>
+#include <autoware_lanelet2_extension/utility/utilities.hpp>
 #include <autoware_utils/geometry/boost_polygon_utils.hpp>
 #include <autoware_utils/geometry/geometry.hpp>
 #include <nlohmann/json.hpp>
@@ -29,6 +31,7 @@
 #include <algorithm>
 #include <chrono>
 #include <cmath>
+#include <cstdint>
 #include <cstdlib>
 #include <filesystem>
 #include <fstream>
@@ -37,12 +40,42 @@
 #include <limits>
 #include <optional>
 #include <string>
+#include <unordered_map>
 #include <unordered_set>
 #include <vector>
 
 namespace control_diagnostics
 {
 namespace bg = boost::geometry;
+
+namespace
+{
+using autoware_perception_msgs::msg::ObjectClassification;
+
+const std::unordered_map<std::string, uint8_t> kObjectLabelNameToValue = {
+  {"unknown", ObjectClassification::UNKNOWN},
+  {"car", ObjectClassification::CAR},
+  {"truck", ObjectClassification::TRUCK},
+  {"bus", ObjectClassification::BUS},
+  {"trailer", ObjectClassification::TRAILER},
+  {"motorcycle", ObjectClassification::MOTORCYCLE},
+  {"bicycle", ObjectClassification::BICYCLE},
+  {"pedestrian", ObjectClassification::PEDESTRIAN},
+  {"animal", ObjectClassification::ANIMAL},
+  {"hazard", ObjectClassification::HAZARD},
+  {"over_drivable", ObjectClassification::OVER_DRIVABLE},
+  {"under_drivable", ObjectClassification::UNDER_DRIVABLE},
+};
+
+std::optional<uint8_t> label_from_string(const std::string & label_name)
+{
+  const auto it = kObjectLabelNameToValue.find(label_name);
+  if (it == kObjectLabelNameToValue.end()) {
+    return std::nullopt;
+  }
+  return it->second;
+}
+}  // namespace
 
 ControlEvaluatorNode::ControlEvaluatorNode(const rclcpp::NodeOptions & node_options)
 : Node("control_evaluator", node_options),
@@ -75,6 +108,19 @@ ControlEvaluatorNode::ControlEvaluatorNode(const rclcpp::NodeOptions & node_opti
   // Parameters
   output_metrics_ = declare_parameter<bool>("output_metrics");
   distance_filter_thr_m_ = declare_parameter<double>("object_metrics.distance_filter_thr_m");
+  const std::vector<std::string> excluded_labels =
+    declare_parameter<std::vector<std::string>>(
+      "object_metrics.excluded_labels", std::vector<std::string>{"unknown"});
+  for (const auto & label_name : excluded_labels) {
+    const auto label = label_from_string(label_name);
+    if (label) {
+      excluded_object_labels_.insert(*label);
+    } else {
+      RCLCPP_ERROR(
+        get_logger(), "Unknown object label '%s' in object_metrics.excluded_labels",
+        label_name.c_str());
+    }
+  }
 
   // Setting about Output metrics only when the vehicle is moving
   const bool output_metrics_only_moving_enabled =
@@ -580,6 +626,12 @@ void ControlEvaluatorNode::AddObjectMetricMsg(
 
   double minimum_distance = std::numeric_limits<double>::max();
   for (const auto & object : objects.objects) {
+    const auto label =
+      autoware::object_recognition_utils::getHighestProbLabel(object.classification);
+    if (excluded_object_labels_.count(label) > 0) {
+      continue;
+    }
+
     const double center_distance = autoware_utils::calc_distance2d(
       odom.pose.pose.position, object.kinematics.initial_pose_with_covariance.pose.position);
     if (center_distance > distance_filter_thr_m_) {

--- a/evaluator/autoware_control_evaluator/test/test_control_evaluator_node.cpp
+++ b/evaluator/autoware_control_evaluator/test/test_control_evaluator_node.cpp
@@ -24,6 +24,8 @@
 
 #include "autoware_planning_msgs/msg/trajectory.hpp"
 #include "geometry_msgs/msg/transform_stamped.hpp"
+#include <autoware_perception_msgs/msg/object_classification.hpp>
+#include <autoware_perception_msgs/msg/predicted_objects.hpp>
 #include <tier4_metric_msgs/msg/metric_array.hpp>
 
 #include "boost/lexical_cast.hpp"
@@ -43,6 +45,10 @@ using autoware_internal_planning_msgs::msg::SafetyFactorArray;
 using geometry_msgs::msg::AccelWithCovarianceStamped;
 using geometry_msgs::msg::Pose;
 using nav_msgs::msg::Odometry;
+using autoware_perception_msgs::msg::ObjectClassification;
+using autoware_perception_msgs::msg::PredictedObject;
+using autoware_perception_msgs::msg::PredictedObjects;
+using autoware_perception_msgs::msg::Shape;
 
 constexpr double epsilon = 1e-6;
 
@@ -82,6 +88,8 @@ protected:
       rclcpp::create_publisher<Odometry>(dummy_node, "/control_evaluator/input/odometry", 1);
     acc_pub_ = rclcpp::create_publisher<AccelWithCovarianceStamped>(
       dummy_node, "/control_evaluator/input/acceleration", 1);
+    objects_pub_ = rclcpp::create_publisher<PredictedObjects>(
+      dummy_node, "/control_evaluator/input/objects", 1);
     planning_factor_interface_ =
       std::make_unique<autoware::planning_factor_interface::PlanningFactorInterface>(
         dummy_node.get(), "stop_line");
@@ -195,6 +203,37 @@ protected:
     return metric_value_;
   }
 
+  PredictedObject makePredictedObject(
+    const double x, const double y, const uint8_t label, const double size = 1.0)
+  {
+    PredictedObject object;
+    ObjectClassification classification;
+    classification.label = label;
+    classification.probability = 1.0;
+    object.classification = {classification};
+
+    object.kinematics.initial_pose_with_covariance.pose.position.x = x;
+    object.kinematics.initial_pose_with_covariance.pose.position.y = y;
+    object.kinematics.initial_pose_with_covariance.pose.orientation.w = 1.0;
+
+    object.shape.type = Shape::BOUNDING_BOX;
+    object.shape.dimensions.x = size;
+    object.shape.dimensions.y = size;
+    object.shape.dimensions.z = size;
+
+    return object;
+  }
+
+  double publishObjectsAndGetMetric(const PredictedObjects & objects)
+  {
+    metric_updated_ = false;
+    objects_pub_->publish(objects);
+    while (!metric_updated_) {
+      spin_some();
+    }
+    return metric_value_;
+  }
+
   void spin_some()
   {
     rclcpp::spin_some(eval_node);
@@ -212,6 +251,7 @@ protected:
   rclcpp::Publisher<Trajectory>::SharedPtr traj_pub_;
   rclcpp::Publisher<Odometry>::SharedPtr odom_pub_;
   rclcpp::Publisher<AccelWithCovarianceStamped>::SharedPtr acc_pub_;
+  rclcpp::Publisher<PredictedObjects>::SharedPtr objects_pub_;
   std::unique_ptr<autoware::planning_factor_interface::PlanningFactorInterface>
     planning_factor_interface_;
 
@@ -331,4 +371,17 @@ TEST_F(EvalTest, TestStopDeviationABS)
   EXPECT_NEAR(publishPlanningFactorAndGetStopDeviationMetric(-5.0, 4.0, 3.0), 5.0, epsilon);
 
   EXPECT_NEAR(publishPlanningFactorAndGetStopDeviationMetric(5.0, 4.0, 3.0), 5.0, epsilon);
+}
+
+TEST_F(EvalTest, TestClosestObjectDistanceExcludedLabels)
+{
+  setTargetMetric("closest_object_distance");
+  publishEgoPose(0.0, 0.0, 0.0);
+
+  PredictedObjects objects;
+  objects.objects.push_back(makePredictedObject(2.0, 0.0, ObjectClassification::UNKNOWN));
+  objects.objects.push_back(makePredictedObject(10.0, 0.0, ObjectClassification::CAR));
+
+  const double closest_distance = publishObjectsAndGetMetric(objects);
+  EXPECT_GT(closest_distance, 5.0);
 }

--- a/evaluator/autoware_control_evaluator/test/test_control_evaluator_node.cpp
+++ b/evaluator/autoware_control_evaluator/test/test_control_evaluator_node.cpp
@@ -42,13 +42,13 @@ using TrajectoryPoint = autoware_planning_msgs::msg::TrajectoryPoint;
 using MetricArrayMsg = tier4_metric_msgs::msg::MetricArray;
 using autoware_internal_planning_msgs::msg::PlanningFactor;
 using autoware_internal_planning_msgs::msg::SafetyFactorArray;
-using geometry_msgs::msg::AccelWithCovarianceStamped;
-using geometry_msgs::msg::Pose;
-using nav_msgs::msg::Odometry;
 using autoware_perception_msgs::msg::ObjectClassification;
 using autoware_perception_msgs::msg::PredictedObject;
 using autoware_perception_msgs::msg::PredictedObjects;
 using autoware_perception_msgs::msg::Shape;
+using geometry_msgs::msg::AccelWithCovarianceStamped;
+using geometry_msgs::msg::Pose;
+using nav_msgs::msg::Odometry;
 
 constexpr double epsilon = 1e-6;
 
@@ -88,8 +88,8 @@ protected:
       rclcpp::create_publisher<Odometry>(dummy_node, "/control_evaluator/input/odometry", 1);
     acc_pub_ = rclcpp::create_publisher<AccelWithCovarianceStamped>(
       dummy_node, "/control_evaluator/input/acceleration", 1);
-    objects_pub_ = rclcpp::create_publisher<PredictedObjects>(
-      dummy_node, "/control_evaluator/input/objects", 1);
+    objects_pub_ =
+      rclcpp::create_publisher<PredictedObjects>(dummy_node, "/control_evaluator/input/objects", 1);
     planning_factor_interface_ =
       std::make_unique<autoware::planning_factor_interface::PlanningFactorInterface>(
         dummy_node.get(), "stop_line");


### PR DESCRIPTION
## Description

Add `object_metrics.excluded_labels` to ignore unknown objects for object distance calculation.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

Unit tests and local Psim

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |
🔴⬆️ -->

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added | `object_metrics.excluded_labels`   | `list` | `["unknown"]`         | A object classification list to exclueded from object_metrics calculation |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |



## Effects on system behavior

None.
