### PR TITLE
refactor(autoware_traffic_light_arbiter): extract TrafficLightArbiterCore from Node

### DIFF
--- a/perception/autoware_traffic_light_arbiter/CMakeLists.txt
+++ b/perception/autoware_traffic_light_arbiter/CMakeLists.txt
@@ -6,6 +6,7 @@ autoware_package()
 
 ament_auto_add_library(${PROJECT_NAME} SHARED
   src/traffic_light_arbiter.cpp
+  src/traffic_light_arbiter_core.cpp
   src/signal_match_validator.cpp
 )
 

--- a/perception/autoware_traffic_light_arbiter/include/autoware/traffic_light_arbiter/signal_match_validator.hpp
+++ b/perception/autoware_traffic_light_arbiter/include/autoware/traffic_light_arbiter/signal_match_validator.hpp
@@ -82,7 +82,7 @@ public:
    *
    * @param ids Set of regulatory-element IDs classified as pedestrian signals.
    */
-  void set_pedestrian_signal_ids(std::unordered_set<lanelet::Id> ids);
+  void set_pedestrian_traffic_light_ids(std::unordered_set<lanelet::Id> ids);
 
   /**
    * @brief Sets the source priority for signal selection.
@@ -97,7 +97,7 @@ public:
 
 private:
   SourcePriority source_priority_;
-  std::unordered_set<lanelet::Id> map_pedestrian_signal_regulatory_elements_set_;
+  std::unordered_set<lanelet::Id> pedestrian_traffic_light_ids_;
 
   /**
    * @brief Checks if a given signal ID corresponds to a pedestrian signal.
@@ -108,7 +108,7 @@ private:
    * @param signal_id The ID of the signal to check.
    * @return True if the signal is a pedestrian signal, false otherwise.
    */
-  bool is_pedestrian_signal(const lanelet::Id & signal_id);
+  bool is_pedestrian_traffic_light(const lanelet::Id & signal_id);
 };
 
 }  // namespace autoware::traffic_light

--- a/perception/autoware_traffic_light_arbiter/include/autoware/traffic_light_arbiter/signal_match_validator.hpp
+++ b/perception/autoware_traffic_light_arbiter/include/autoware/traffic_light_arbiter/signal_match_validator.hpp
@@ -69,20 +69,20 @@ public:
    * @param external_signals Traffic signal data from external source.
    * @return A validated TrafficSignalArray.
    */
-  TrafficSignalArray validateSignals(
+  TrafficSignalArray validate_signals(
     const TrafficSignalArray & perception_signals, const TrafficSignalArray & external_signals);
 
   /**
    * @brief Sets the pedestrian signal IDs to be considered during validation.
    *
    * Pedestrian-classified signals receive distinct reconciliation handling in
-   * validateSignals(). The caller supplies the set of regulatory-element IDs
+   * validate_signals(). The caller supplies the set of regulatory-element IDs
    * (typically derived from crosswalk lanelets); only the IDs are needed for
    * the routing decision.
    *
    * @param ids Set of regulatory-element IDs classified as pedestrian signals.
    */
-  void setPedestrianSignalIds(std::unordered_set<lanelet::Id> ids);
+  void set_pedestrian_signal_ids(std::unordered_set<lanelet::Id> ids);
 
   /**
    * @brief Sets the source priority for signal selection.
@@ -93,7 +93,7 @@ public:
    *
    * @param source_priority The priority mode for signal selection.
    */
-  void setSourcePriority(const SourcePriority source_priority);
+  void set_source_priority(const SourcePriority source_priority);
 
 private:
   SourcePriority source_priority_;
@@ -108,7 +108,7 @@ private:
    * @param signal_id The ID of the signal to check.
    * @return True if the signal is a pedestrian signal, false otherwise.
    */
-  bool isPedestrianSignal(const lanelet::Id & signal_id);
+  bool is_pedestrian_signal(const lanelet::Id & signal_id);
 };
 
 }  // namespace autoware::traffic_light

--- a/perception/autoware_traffic_light_arbiter/include/autoware/traffic_light_arbiter/signal_match_validator.hpp
+++ b/perception/autoware_traffic_light_arbiter/include/autoware/traffic_light_arbiter/signal_match_validator.hpp
@@ -53,9 +53,16 @@ public:
   using TrafficLightConstPtr = lanelet::TrafficLightConstPtr;
 
   /**
-   * @brief Default constructor for SignalMatchValidator.
+   * @brief Construct a validator with the source-priority mode fixed at
+   *        construction. The mode is immutable for the validator's lifetime.
+   *
+   * @param source_priority CONFIDENCE (confidence-based selection),
+   *                        EXTERNAL (prioritize external), or
+   *                        PERCEPTION (prioritize perception).
    */
-  SignalMatchValidator() = default;
+  explicit SignalMatchValidator(SourcePriority source_priority) : source_priority_(source_priority)
+  {
+  }
 
   /**
    * @brief Validates and compares traffic signal data from perception and external sources.
@@ -83,17 +90,6 @@ public:
    * @param ids Set of regulatory-element IDs classified as pedestrian signals.
    */
   void set_pedestrian_traffic_light_ids(std::unordered_set<lanelet::Id> ids);
-
-  /**
-   * @brief Sets the source priority for signal selection.
-   *
-   * This method sets the priority mode for selecting between perception and external signals.
-   * Options are CONFIDENCE (use confidence-based selection), EXTERNAL (prioritize external),
-   * or PERCEPTION (prioritize perception signals).
-   *
-   * @param source_priority The priority mode for signal selection.
-   */
-  void set_source_priority(const SourcePriority source_priority);
 
 private:
   SourcePriority source_priority_;

--- a/perception/autoware_traffic_light_arbiter/include/autoware/traffic_light_arbiter/signal_match_validator.hpp
+++ b/perception/autoware_traffic_light_arbiter/include/autoware/traffic_light_arbiter/signal_match_validator.hpp
@@ -73,15 +73,16 @@ public:
     const TrafficSignalArray & perception_signals, const TrafficSignalArray & external_signals);
 
   /**
-   * @brief Sets the pedestrian signals to be considered during validation.
+   * @brief Sets the pedestrian signal IDs to be considered during validation.
    *
-   * This method allows the specification of pedestrian signals, which are then
-   * used to adjust the validation logic, acknowledging their unique characteristics
-   * in traffic signal datasets.
+   * Pedestrian-classified signals receive distinct reconciliation handling in
+   * validateSignals(). The caller supplies the set of regulatory-element IDs
+   * (typically derived from crosswalk lanelets); only the IDs are needed for
+   * the routing decision.
    *
-   * @param pedestrian_signals A vector of pedestrian signal pointers.
+   * @param ids Set of regulatory-element IDs classified as pedestrian signals.
    */
-  void setPedestrianSignals(const std::vector<TrafficLightConstPtr> & pedestrian_signals);
+  void setPedestrianSignalIds(std::unordered_set<lanelet::Id> ids);
 
   /**
    * @brief Sets the source priority for signal selection.

--- a/perception/autoware_traffic_light_arbiter/include/autoware/traffic_light_arbiter/traffic_light_arbiter.hpp
+++ b/perception/autoware_traffic_light_arbiter/include/autoware/traffic_light_arbiter/traffic_light_arbiter.hpp
@@ -40,11 +40,11 @@ private:
   rclcpp::Subscription<TrafficSignalArray>::SharedPtr external_tlr_sub_;
   rclcpp::Publisher<TrafficSignalArray>::SharedPtr pub_;
 
-  void onMap(const LaneletMapBin::ConstSharedPtr msg);
-  void onPerceptionMsg(const TrafficSignalArray::ConstSharedPtr msg);
-  void onExternalMsg(const TrafficSignalArray::ConstSharedPtr msg);
-  void arbitrateAndPublish(const builtin_interfaces::msg::Time & stamp);
-  void cleanupExpiredExternalSignals(const rclcpp::Time & current_time, double tolerance);
+  void on_map(const LaneletMapBin::ConstSharedPtr msg);
+  void on_perception_msg(const TrafficSignalArray::ConstSharedPtr msg);
+  void on_external_msg(const TrafficSignalArray::ConstSharedPtr msg);
+  void arbitrate_and_publish(const builtin_interfaces::msg::Time & stamp);
+  void cleanup_expired_external_signals(const rclcpp::Time & current_time, double tolerance);
 
   double external_delay_tolerance_;
   double external_time_tolerance_;

--- a/perception/autoware_traffic_light_arbiter/include/autoware/traffic_light_arbiter/traffic_light_arbiter.hpp
+++ b/perception/autoware_traffic_light_arbiter/include/autoware/traffic_light_arbiter/traffic_light_arbiter.hpp
@@ -15,18 +15,13 @@
 #ifndef AUTOWARE__TRAFFIC_LIGHT_ARBITER__TRAFFIC_LIGHT_ARBITER_HPP_
 #define AUTOWARE__TRAFFIC_LIGHT_ARBITER__TRAFFIC_LIGHT_ARBITER_HPP_
 
-#include <autoware/traffic_light_arbiter/signal_match_validator.hpp>
+#include <autoware/traffic_light_arbiter/traffic_light_arbiter_core.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include <autoware_map_msgs/msg/lanelet_map_bin.hpp>
 #include <autoware_perception_msgs/msg/traffic_light_group_array.hpp>
 
-#include <lanelet2_core/Forward.h>
-
 #include <memory>
-#include <unordered_map>
-#include <unordered_set>
-#include <utility>
 
 namespace autoware::traffic_light
 {
@@ -37,11 +32,8 @@ public:
   explicit TrafficLightArbiter(const rclcpp::NodeOptions & options);
 
 private:
-  using Element = autoware_perception_msgs::msg::TrafficLightElement;
-  using PredictedTrafficLightState = autoware_perception_msgs::msg::PredictedTrafficLightState;
   using LaneletMapBin = autoware_map_msgs::msg::LaneletMapBin;
   using TrafficSignalArray = autoware_perception_msgs::msg::TrafficLightGroupArray;
-  using TrafficSignal = autoware_perception_msgs::msg::TrafficLightGroup;
 
   rclcpp::Subscription<LaneletMapBin>::SharedPtr map_sub_;
   rclcpp::Subscription<TrafficSignalArray>::SharedPtr perception_tlr_sub_;
@@ -54,17 +46,11 @@ private:
   void arbitrateAndPublish(const builtin_interfaces::msg::Time & stamp);
   void cleanupExpiredExternalSignals(const rclcpp::Time & current_time, double tolerance);
 
-  std::unique_ptr<std::unordered_set<lanelet::Id>> map_regulatory_elements_set_;
-
   double external_delay_tolerance_;
   double external_time_tolerance_;
   double perception_time_tolerance_;
-  SourcePriority source_priority_;
-  bool enable_signal_matching_;
 
-  TrafficSignalArray latest_perception_msg_;
-  std::unordered_map<lanelet::Id, std::pair<rclcpp::Time, TrafficSignal>> external_traffic_lights_;
-  std::unique_ptr<SignalMatchValidator> signal_match_validator_;
+  std::unique_ptr<TrafficLightArbiterCore> core_;
 };
 }  // namespace autoware::traffic_light
 

--- a/perception/autoware_traffic_light_arbiter/include/autoware/traffic_light_arbiter/traffic_light_arbiter.hpp
+++ b/perception/autoware_traffic_light_arbiter/include/autoware/traffic_light_arbiter/traffic_light_arbiter.hpp
@@ -46,10 +46,10 @@ private:
   void on_external_msg(const TrafficSignalArray::ConstSharedPtr msg);
   void arbitrate_and_publish(const builtin_interfaces::msg::Time & stamp);
 
-  // Emits one DEBUG line per dropped entry; called from the on_*_msg
+  // Emits one DEBUG line per expired entry; called from the on_*_msg
   // handlers with the result of the corresponding ingest_*().
-  void log_dropped_external_signals(
-    const std::vector<TrafficLightArbiterCore::DroppedExternalSignal> & dropped);
+  void log_expired_external_signals(
+    const std::vector<TrafficLightArbiterCore::ExpiredExternalSignal> & expired);
 
   std::unique_ptr<TrafficLightArbiterCore> core_;
 };

--- a/perception/autoware_traffic_light_arbiter/include/autoware/traffic_light_arbiter/traffic_light_arbiter.hpp
+++ b/perception/autoware_traffic_light_arbiter/include/autoware/traffic_light_arbiter/traffic_light_arbiter.hpp
@@ -22,6 +22,7 @@
 #include <autoware_perception_msgs/msg/traffic_light_group_array.hpp>
 
 #include <memory>
+#include <vector>
 
 namespace autoware::traffic_light
 {
@@ -44,11 +45,11 @@ private:
   void on_perception_msg(const TrafficSignalArray::ConstSharedPtr msg);
   void on_external_msg(const TrafficSignalArray::ConstSharedPtr msg);
   void arbitrate_and_publish(const builtin_interfaces::msg::Time & stamp);
-  void cleanup_expired_external_signals(const rclcpp::Time & current_time, double tolerance);
 
-  double external_delay_tolerance_;
-  double external_time_tolerance_;
-  double perception_time_tolerance_;
+  // Emits one DEBUG line per dropped entry; called from the on_*_msg
+  // handlers with the result of the corresponding ingest_*().
+  void log_dropped_external_signals(
+    const std::vector<TrafficLightArbiterCore::DroppedExternalSignal> & dropped);
 
   std::unique_ptr<TrafficLightArbiterCore> core_;
 };

--- a/perception/autoware_traffic_light_arbiter/include/autoware/traffic_light_arbiter/traffic_light_arbiter_core.hpp
+++ b/perception/autoware_traffic_light_arbiter/include/autoware/traffic_light_arbiter/traffic_light_arbiter_core.hpp
@@ -49,7 +49,7 @@ public:
 
   void set_traffic_light_ids(std::unordered_set<lanelet::Id> ids);
 
-  void set_pedestrian_signal_ids(std::unordered_set<lanelet::Id> ids);
+  void set_pedestrian_traffic_light_ids(std::unordered_set<lanelet::Id> ids);
 
   bool is_external_outdated(
     const rclcpp::Time & current_time, const rclcpp::Time & msg_stamp) const;

--- a/perception/autoware_traffic_light_arbiter/include/autoware/traffic_light_arbiter/traffic_light_arbiter_core.hpp
+++ b/perception/autoware_traffic_light_arbiter/include/autoware/traffic_light_arbiter/traffic_light_arbiter_core.hpp
@@ -51,24 +51,24 @@ public:
 
   void set_pedestrian_traffic_light_ids(std::unordered_set<lanelet::Id> ids);
 
-  struct DroppedExternalSignal
+  struct ExpiredExternalSignal
   {
     lanelet::Id id;
     double age;
   };
 
   // Update perception buffer, then sweep external cache against msg.stamp
-  // using external_time_tolerance_. Returns dropped entries for caller logging.
-  std::vector<DroppedExternalSignal> ingest_perception(const TrafficSignalArray & msg);
+  // using external_time_tolerance_. Returns expired entries for caller logging.
+  std::vector<ExpiredExternalSignal> ingest_perception(const TrafficSignalArray & msg);
 
   // Outcome of an external-msg ingest. `accepted == false` means the msg's
   // stamp differed from current_time by more than external_delay_tolerance_
   // and was rejected without touching internal state. When accepted,
-  // `dropped` carries any cache entries that the bundled sweep evicted.
+  // `expired` carries any cache entries that the bundled sweep evicted.
   struct ExternalIngestResult
   {
     bool accepted;
-    std::vector<DroppedExternalSignal> dropped;
+    std::vector<ExpiredExternalSignal> expired;
   };
 
   // Admission-control + update + sweep for an external msg:
@@ -76,7 +76,7 @@ public:
   //      current_time, using external_delay_tolerance_.
   //   2. Otherwise update external cache entries with msg.stamp, sweep
   //      external cache against current_time using external_delay_tolerance_,
-  //      and return dropped entries.
+  //      and return expired entries.
   // Perception staleness is evaluated non-destructively inside arbitrate()
   // using perception_time_tolerance_; ingest_external no longer touches
   // latest_perception_msg_.
@@ -108,7 +108,7 @@ private:
 
   // Sweeps external cache: removes every stored entry whose stamp deviates
   // from `reference_time` beyond `tolerance`, returning the removed entries.
-  std::vector<DroppedExternalSignal> sweep_expired_external_signals(
+  std::vector<ExpiredExternalSignal> sweep_expired_external_signals(
     const rclcpp::Time & reference_time, double tolerance);
 
   SourcePriority source_priority_;

--- a/perception/autoware_traffic_light_arbiter/include/autoware/traffic_light_arbiter/traffic_light_arbiter_core.hpp
+++ b/perception/autoware_traffic_light_arbiter/include/autoware/traffic_light_arbiter/traffic_light_arbiter_core.hpp
@@ -65,13 +65,22 @@ public:
 
   void ingestExternal(const TrafficSignalArray & msg);
 
+  // Result of one arbitration cycle. The arbiter intentionally does not stamp
+  // the output: stamp inheritance is an I/O concern owned by the Node (e.g.
+  // "publish carries the trigger msg's stamp"). The Node assigns
+  // `output->stamp` before publishing and compares its trigger stamp against
+  // `latest_input_time` for staleness logging.
+  //
+  // latest_input_time defaults to epoch on RCL_ROS_TIME so the Node can compare
+  // it against rclcpp::Time(msg->stamp) (also RCL_ROS_TIME) regardless of which
+  // arbitrate() branch was taken.
   struct ArbitrationResult
   {
-    std::optional<TrafficSignalArray> output;
+    std::optional<TrafficSignalArray> output;  // stamp left default; Node fills it in.
     std::vector<lanelet::Id> off_map_signal_ids;
-    bool output_not_latest = false;
+    rclcpp::Time latest_input_time{0, 0, RCL_ROS_TIME};
   };
-  ArbitrationResult arbitrate(const builtin_interfaces::msg::Time & stamp);
+  ArbitrationResult arbitrate();
 
 private:
   SourcePriority source_priority_;

--- a/perception/autoware_traffic_light_arbiter/include/autoware/traffic_light_arbiter/traffic_light_arbiter_core.hpp
+++ b/perception/autoware_traffic_light_arbiter/include/autoware/traffic_light_arbiter/traffic_light_arbiter_core.hpp
@@ -49,7 +49,7 @@ public:
 
   void setTrafficLightIds(std::unordered_set<lanelet::Id> ids);
 
-  void setPedestrianSignals(const std::vector<TrafficLightConstPtr> & pedestrian_signals);
+  void setPedestrianSignalIds(std::unordered_set<lanelet::Id> ids);
 
   bool isExternalOutdated(const rclcpp::Time & current_time, const rclcpp::Time & msg_stamp) const;
 

--- a/perception/autoware_traffic_light_arbiter/include/autoware/traffic_light_arbiter/traffic_light_arbiter_core.hpp
+++ b/perception/autoware_traffic_light_arbiter/include/autoware/traffic_light_arbiter/traffic_light_arbiter_core.hpp
@@ -47,23 +47,24 @@ public:
     SourcePriority source_priority, bool enable_signal_matching, double external_delay_tolerance,
     double external_time_tolerance, double perception_time_tolerance);
 
-  void setTrafficLightIds(std::unordered_set<lanelet::Id> ids);
+  void set_traffic_light_ids(std::unordered_set<lanelet::Id> ids);
 
-  void setPedestrianSignalIds(std::unordered_set<lanelet::Id> ids);
+  void set_pedestrian_signal_ids(std::unordered_set<lanelet::Id> ids);
 
-  bool isExternalOutdated(const rclcpp::Time & current_time, const rclcpp::Time & msg_stamp) const;
+  bool is_external_outdated(
+    const rclcpp::Time & current_time, const rclcpp::Time & msg_stamp) const;
 
   struct DroppedExternalSignal
   {
     lanelet::Id id;
     double age;
   };
-  std::vector<DroppedExternalSignal> cleanupExpiredExternalSignals(
+  std::vector<DroppedExternalSignal> cleanup_expired_external_signals(
     const rclcpp::Time & reference_time, double tolerance);
 
-  void ingestPerception(const TrafficSignalArray & msg);
+  void ingest_perception(const TrafficSignalArray & msg);
 
-  void ingestExternal(const TrafficSignalArray & msg);
+  void ingest_external(const TrafficSignalArray & msg);
 
   // Result of one arbitration cycle. The arbiter intentionally does not stamp
   // the output: stamp inheritance is an I/O concern owned by the Node (e.g.

--- a/perception/autoware_traffic_light_arbiter/include/autoware/traffic_light_arbiter/traffic_light_arbiter_core.hpp
+++ b/perception/autoware_traffic_light_arbiter/include/autoware/traffic_light_arbiter/traffic_light_arbiter_core.hpp
@@ -51,9 +51,6 @@ public:
 
   void set_pedestrian_traffic_light_ids(std::unordered_set<lanelet::Id> ids);
 
-  bool is_external_outdated(
-    const rclcpp::Time & current_time, const rclcpp::Time & msg_stamp) const;
-
   struct DroppedExternalSignal
   {
     lanelet::Id id;
@@ -64,11 +61,24 @@ public:
   // using external_time_tolerance_. Returns dropped entries for caller logging.
   std::vector<DroppedExternalSignal> ingest_perception(const TrafficSignalArray & msg);
 
-  // Update external cache, clear perception if its stamp falls outside
-  // perception_time_tolerance_ of msg.stamp, then sweep external cache
-  // against current_time using external_delay_tolerance_. Returns dropped
-  // entries for caller logging.
-  std::vector<DroppedExternalSignal> ingest_external(
+  // Outcome of an external-msg ingest. `accepted == false` means the msg's
+  // stamp differed from current_time by more than external_delay_tolerance_
+  // and was rejected without touching internal state. When accepted,
+  // `dropped` carries any cache entries that the bundled sweep evicted.
+  struct ExternalIngestResult
+  {
+    bool accepted;
+    std::vector<DroppedExternalSignal> dropped;
+  };
+
+  // Admission-control + update + sweep for an external msg:
+  //   1. Reject (return {false, {}}) when the msg arrival is too far from
+  //      current_time, using external_delay_tolerance_.
+  //   2. Otherwise update external cache entries with msg.stamp, clear
+  //      perception when its stamp falls outside perception_time_tolerance_
+  //      of msg.stamp, sweep external cache against current_time using
+  //      external_delay_tolerance_, and return dropped entries.
+  ExternalIngestResult ingest_external(
     const TrafficSignalArray & msg, const rclcpp::Time & current_time);
 
   // Result of one arbitration cycle. The arbiter intentionally does not stamp
@@ -89,6 +99,11 @@ public:
   ArbitrationResult arbitrate();
 
 private:
+  // True when |current_time - msg_stamp| exceeds external_delay_tolerance_.
+  // Used by ingest_external for admission control.
+  bool is_external_outdated(
+    const rclcpp::Time & current_time, const rclcpp::Time & msg_stamp) const;
+
   // Sweeps external cache: removes every stored entry whose stamp deviates
   // from `reference_time` beyond `tolerance`, returning the removed entries.
   std::vector<DroppedExternalSignal> sweep_expired_external_signals(

--- a/perception/autoware_traffic_light_arbiter/include/autoware/traffic_light_arbiter/traffic_light_arbiter_core.hpp
+++ b/perception/autoware_traffic_light_arbiter/include/autoware/traffic_light_arbiter/traffic_light_arbiter_core.hpp
@@ -1,0 +1,92 @@
+// Copyright 2026 The Autoware Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__TRAFFIC_LIGHT_ARBITER__TRAFFIC_LIGHT_ARBITER_CORE_HPP_
+#define AUTOWARE__TRAFFIC_LIGHT_ARBITER__TRAFFIC_LIGHT_ARBITER_CORE_HPP_
+
+#include <autoware/traffic_light_arbiter/signal_match_validator.hpp>
+#include <builtin_interfaces/msg/time.hpp>
+#include <rclcpp/time.hpp>
+
+#include <autoware_perception_msgs/msg/traffic_light_group_array.hpp>
+
+#include <lanelet2_core/Forward.h>
+
+#include <memory>
+#include <optional>
+#include <tuple>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+namespace autoware::traffic_light
+{
+
+class TrafficLightArbiterCore
+{
+public:
+  using Element = autoware_perception_msgs::msg::TrafficLightElement;
+  using PredictedTrafficLightState = autoware_perception_msgs::msg::PredictedTrafficLightState;
+  using TrafficSignalArray = autoware_perception_msgs::msg::TrafficLightGroupArray;
+  using TrafficSignal = autoware_perception_msgs::msg::TrafficLightGroup;
+  using TrafficLightConstPtr = lanelet::TrafficLightConstPtr;
+
+  TrafficLightArbiterCore(
+    SourcePriority source_priority, bool enable_signal_matching, double external_delay_tolerance,
+    double external_time_tolerance, double perception_time_tolerance);
+
+  void setTrafficLightIds(std::unordered_set<lanelet::Id> ids);
+
+  void setPedestrianSignals(const std::vector<TrafficLightConstPtr> & pedestrian_signals);
+
+  bool isExternalOutdated(const rclcpp::Time & current_time, const rclcpp::Time & msg_stamp) const;
+
+  struct DroppedExternalSignal
+  {
+    lanelet::Id id;
+    double age;
+  };
+  std::vector<DroppedExternalSignal> cleanupExpiredExternalSignals(
+    const rclcpp::Time & reference_time, double tolerance);
+
+  void ingestPerception(const TrafficSignalArray & msg);
+
+  void ingestExternal(const TrafficSignalArray & msg);
+
+  struct ArbitrationResult
+  {
+    std::optional<TrafficSignalArray> output;
+    std::vector<lanelet::Id> off_map_signal_ids;
+    bool output_not_latest = false;
+  };
+  ArbitrationResult arbitrate(const builtin_interfaces::msg::Time & stamp);
+
+private:
+  SourcePriority source_priority_;
+  bool enable_signal_matching_;
+  double external_delay_tolerance_;
+  double external_time_tolerance_;
+  double perception_time_tolerance_;
+
+  std::unique_ptr<std::unordered_set<lanelet::Id>> map_regulatory_elements_set_;
+  std::unique_ptr<SignalMatchValidator> signal_match_validator_;
+
+  TrafficSignalArray latest_perception_msg_;
+  std::unordered_map<lanelet::Id, std::pair<rclcpp::Time, TrafficSignal>> external_traffic_lights_;
+};
+
+}  // namespace autoware::traffic_light
+
+#endif  // AUTOWARE__TRAFFIC_LIGHT_ARBITER__TRAFFIC_LIGHT_ARBITER_CORE_HPP_

--- a/perception/autoware_traffic_light_arbiter/include/autoware/traffic_light_arbiter/traffic_light_arbiter_core.hpp
+++ b/perception/autoware_traffic_light_arbiter/include/autoware/traffic_light_arbiter/traffic_light_arbiter_core.hpp
@@ -74,10 +74,12 @@ public:
   // Admission-control + update + sweep for an external msg:
   //   1. Reject (return {false, {}}) when the msg arrival is too far from
   //      current_time, using external_delay_tolerance_.
-  //   2. Otherwise update external cache entries with msg.stamp, clear
-  //      perception when its stamp falls outside perception_time_tolerance_
-  //      of msg.stamp, sweep external cache against current_time using
-  //      external_delay_tolerance_, and return dropped entries.
+  //   2. Otherwise update external cache entries with msg.stamp, sweep
+  //      external cache against current_time using external_delay_tolerance_,
+  //      and return dropped entries.
+  // Perception staleness is evaluated non-destructively inside arbitrate()
+  // using perception_time_tolerance_; ingest_external no longer touches
+  // latest_perception_msg_.
   ExternalIngestResult ingest_external(
     const TrafficSignalArray & msg, const rclcpp::Time & current_time);
 

--- a/perception/autoware_traffic_light_arbiter/include/autoware/traffic_light_arbiter/traffic_light_arbiter_core.hpp
+++ b/perception/autoware_traffic_light_arbiter/include/autoware/traffic_light_arbiter/traffic_light_arbiter_core.hpp
@@ -59,12 +59,17 @@ public:
     lanelet::Id id;
     double age;
   };
-  std::vector<DroppedExternalSignal> cleanup_expired_external_signals(
-    const rclcpp::Time & reference_time, double tolerance);
 
-  void ingest_perception(const TrafficSignalArray & msg);
+  // Update perception buffer, then sweep external cache against msg.stamp
+  // using external_time_tolerance_. Returns dropped entries for caller logging.
+  std::vector<DroppedExternalSignal> ingest_perception(const TrafficSignalArray & msg);
 
-  void ingest_external(const TrafficSignalArray & msg);
+  // Update external cache, clear perception if its stamp falls outside
+  // perception_time_tolerance_ of msg.stamp, then sweep external cache
+  // against current_time using external_delay_tolerance_. Returns dropped
+  // entries for caller logging.
+  std::vector<DroppedExternalSignal> ingest_external(
+    const TrafficSignalArray & msg, const rclcpp::Time & current_time);
 
   // Result of one arbitration cycle. The arbiter intentionally does not stamp
   // the output: stamp inheritance is an I/O concern owned by the Node (e.g.
@@ -84,6 +89,11 @@ public:
   ArbitrationResult arbitrate();
 
 private:
+  // Sweeps external cache: removes every stored entry whose stamp deviates
+  // from `reference_time` beyond `tolerance`, returning the removed entries.
+  std::vector<DroppedExternalSignal> sweep_expired_external_signals(
+    const rclcpp::Time & reference_time, double tolerance);
+
   SourcePriority source_priority_;
   bool enable_signal_matching_;
   double external_delay_tolerance_;

--- a/perception/autoware_traffic_light_arbiter/include/autoware/traffic_light_arbiter/traffic_light_arbiter_core.hpp
+++ b/perception/autoware_traffic_light_arbiter/include/autoware/traffic_light_arbiter/traffic_light_arbiter_core.hpp
@@ -47,9 +47,11 @@ public:
     SourcePriority source_priority, bool enable_signal_matching, double external_delay_tolerance,
     double external_time_tolerance, double perception_time_tolerance);
 
-  void set_traffic_light_ids(std::unordered_set<lanelet::Id> ids);
-
-  void set_pedestrian_traffic_light_ids(std::unordered_set<lanelet::Id> ids);
+  // Load map-derived state from a parsed LaneletMap. Core extracts the
+  // regulatory-element IDs it needs (vehicle traffic lights and, when
+  // signal matching is enabled, pedestrian traffic lights) internally so
+  // callers don't have to know which subsets matter.
+  void set_map(const lanelet::LaneletMapConstPtr & map);
 
   struct ExpiredExternalSignal
   {

--- a/perception/autoware_traffic_light_arbiter/src/signal_match_validator.cpp
+++ b/perception/autoware_traffic_light_arbiter/src/signal_match_validator.cpp
@@ -247,7 +247,7 @@ autoware_perception_msgs::msg::TrafficLightGroupArray SignalMatchValidator::vali
 
     // We don't validate the pedestrian signals
     // TODO(TomohitoAndo): Validate pedestrian signals
-    if (is_pedestrian_signal(signal_id)) {
+    if (is_pedestrian_traffic_light(signal_id)) {
       validated_signals.traffic_light_groups.emplace_back(
         util::get_highest_confidence_signal(perception_result, external_result, source_priority_));
 
@@ -281,9 +281,9 @@ autoware_perception_msgs::msg::TrafficLightGroupArray SignalMatchValidator::vali
   return validated_signals;
 }
 
-void SignalMatchValidator::set_pedestrian_signal_ids(std::unordered_set<lanelet::Id> ids)
+void SignalMatchValidator::set_pedestrian_traffic_light_ids(std::unordered_set<lanelet::Id> ids)
 {
-  map_pedestrian_signal_regulatory_elements_set_ = std::move(ids);
+  pedestrian_traffic_light_ids_ = std::move(ids);
 }
 
 void SignalMatchValidator::set_source_priority(const SourcePriority source_priority)
@@ -291,10 +291,9 @@ void SignalMatchValidator::set_source_priority(const SourcePriority source_prior
   source_priority_ = source_priority;
 }
 
-bool SignalMatchValidator::is_pedestrian_signal(const lanelet::Id & signal_id)
+bool SignalMatchValidator::is_pedestrian_traffic_light(const lanelet::Id & signal_id)
 {
-  return map_pedestrian_signal_regulatory_elements_set_.find(signal_id) !=
-         map_pedestrian_signal_regulatory_elements_set_.end();
+  return pedestrian_traffic_light_ids_.find(signal_id) != pedestrian_traffic_light_ids_.end();
 }
 
 }  // namespace autoware::traffic_light

--- a/perception/autoware_traffic_light_arbiter/src/signal_match_validator.cpp
+++ b/perception/autoware_traffic_light_arbiter/src/signal_match_validator.cpp
@@ -220,7 +220,7 @@ Time get_newer_stamp(const Time & stamp1, const Time & stamp2)
 namespace autoware::traffic_light
 {
 
-autoware_perception_msgs::msg::TrafficLightGroupArray SignalMatchValidator::validateSignals(
+autoware_perception_msgs::msg::TrafficLightGroupArray SignalMatchValidator::validate_signals(
   const TrafficSignalArray & perception_signals, const TrafficSignalArray & external_signals)
 {
   TrafficSignalArray validated_signals;
@@ -247,7 +247,7 @@ autoware_perception_msgs::msg::TrafficLightGroupArray SignalMatchValidator::vali
 
     // We don't validate the pedestrian signals
     // TODO(TomohitoAndo): Validate pedestrian signals
-    if (isPedestrianSignal(signal_id)) {
+    if (is_pedestrian_signal(signal_id)) {
       validated_signals.traffic_light_groups.emplace_back(
         util::get_highest_confidence_signal(perception_result, external_result, source_priority_));
 
@@ -281,17 +281,17 @@ autoware_perception_msgs::msg::TrafficLightGroupArray SignalMatchValidator::vali
   return validated_signals;
 }
 
-void SignalMatchValidator::setPedestrianSignalIds(std::unordered_set<lanelet::Id> ids)
+void SignalMatchValidator::set_pedestrian_signal_ids(std::unordered_set<lanelet::Id> ids)
 {
   map_pedestrian_signal_regulatory_elements_set_ = std::move(ids);
 }
 
-void SignalMatchValidator::setSourcePriority(const SourcePriority source_priority)
+void SignalMatchValidator::set_source_priority(const SourcePriority source_priority)
 {
   source_priority_ = source_priority;
 }
 
-bool SignalMatchValidator::isPedestrianSignal(const lanelet::Id & signal_id)
+bool SignalMatchValidator::is_pedestrian_signal(const lanelet::Id & signal_id)
 {
   return map_pedestrian_signal_regulatory_elements_set_.find(signal_id) !=
          map_pedestrian_signal_regulatory_elements_set_.end();

--- a/perception/autoware_traffic_light_arbiter/src/signal_match_validator.cpp
+++ b/perception/autoware_traffic_light_arbiter/src/signal_match_validator.cpp
@@ -18,6 +18,7 @@
 #include <map>
 #include <unordered_map>
 #include <unordered_set>
+#include <utility>
 #include <vector>
 
 namespace util
@@ -280,12 +281,9 @@ autoware_perception_msgs::msg::TrafficLightGroupArray SignalMatchValidator::vali
   return validated_signals;
 }
 
-void SignalMatchValidator::setPedestrianSignals(
-  const std::vector<TrafficLightConstPtr> & pedestrian_signals)
+void SignalMatchValidator::setPedestrianSignalIds(std::unordered_set<lanelet::Id> ids)
 {
-  for (const auto & pedestrian_signal : pedestrian_signals) {
-    map_pedestrian_signal_regulatory_elements_set_.emplace(pedestrian_signal->id());
-  }
+  map_pedestrian_signal_regulatory_elements_set_ = std::move(ids);
 }
 
 void SignalMatchValidator::setSourcePriority(const SourcePriority source_priority)

--- a/perception/autoware_traffic_light_arbiter/src/signal_match_validator.cpp
+++ b/perception/autoware_traffic_light_arbiter/src/signal_match_validator.cpp
@@ -286,11 +286,6 @@ void SignalMatchValidator::set_pedestrian_traffic_light_ids(std::unordered_set<l
   pedestrian_traffic_light_ids_ = std::move(ids);
 }
 
-void SignalMatchValidator::set_source_priority(const SourcePriority source_priority)
-{
-  source_priority_ = source_priority;
-}
-
 bool SignalMatchValidator::is_pedestrian_traffic_light(const lanelet::Id & signal_id)
 {
   return pedestrian_traffic_light_ids_.find(signal_id) != pedestrian_traffic_light_ids_.end();

--- a/perception/autoware_traffic_light_arbiter/src/traffic_light_arbiter.cpp
+++ b/perception/autoware_traffic_light_arbiter/src/traffic_light_arbiter.cpp
@@ -98,20 +98,20 @@ TrafficLightArbiter::TrafficLightArbiter(const rclcpp::NodeOptions & options)
 
   map_sub_ = create_subscription<LaneletMapBin>(
     "~/sub/vector_map", rclcpp::QoS(1).transient_local(),
-    std::bind(&TrafficLightArbiter::onMap, this, std::placeholders::_1));
+    std::bind(&TrafficLightArbiter::on_map, this, std::placeholders::_1));
 
   perception_tlr_sub_ = create_subscription<TrafficSignalArray>(
     "~/sub/perception_traffic_signals", rclcpp::QoS(1),
-    std::bind(&TrafficLightArbiter::onPerceptionMsg, this, std::placeholders::_1));
+    std::bind(&TrafficLightArbiter::on_perception_msg, this, std::placeholders::_1));
 
   external_tlr_sub_ = create_subscription<TrafficSignalArray>(
     "~/sub/external_traffic_signals", rclcpp::QoS(1),
-    std::bind(&TrafficLightArbiter::onExternalMsg, this, std::placeholders::_1));
+    std::bind(&TrafficLightArbiter::on_external_msg, this, std::placeholders::_1));
 
   pub_ = create_publisher<TrafficSignalArray>("~/pub/traffic_signals", rclcpp::QoS(1));
 }
 
-void TrafficLightArbiter::onMap(const LaneletMapBin::ConstSharedPtr msg)
+void TrafficLightArbiter::on_map(const LaneletMapBin::ConstSharedPtr msg)
 {
   const auto map = autoware::experimental::lanelet2_utils::from_autoware_map_msgs(*msg);
 
@@ -120,7 +120,7 @@ void TrafficLightArbiter::onMap(const LaneletMapBin::ConstSharedPtr msg)
   for (const auto & signal : signals) {
     traffic_light_ids.emplace(signal->id());
   }
-  core_->setTrafficLightIds(std::move(traffic_light_ids));
+  core_->set_traffic_light_ids(std::move(traffic_light_ids));
 
   // Filter only pedestrian signals to distinguish them in signal matching
   const auto pedestrian_signals = lanelet::filter_pedestrian_signals(map);
@@ -128,42 +128,42 @@ void TrafficLightArbiter::onMap(const LaneletMapBin::ConstSharedPtr msg)
   for (const auto & signal : pedestrian_signals) {
     pedestrian_signal_ids.emplace(signal->id());
   }
-  core_->setPedestrianSignalIds(std::move(pedestrian_signal_ids));
+  core_->set_pedestrian_signal_ids(std::move(pedestrian_signal_ids));
 }
 
-void TrafficLightArbiter::onPerceptionMsg(const TrafficSignalArray::ConstSharedPtr msg)
+void TrafficLightArbiter::on_perception_msg(const TrafficSignalArray::ConstSharedPtr msg)
 {
-  core_->ingestPerception(*msg);
+  core_->ingest_perception(*msg);
 
   // Clean up external signals that are too old relative to perception message
-  cleanupExpiredExternalSignals(rclcpp::Time(msg->stamp), external_time_tolerance_);
+  cleanup_expired_external_signals(rclcpp::Time(msg->stamp), external_time_tolerance_);
 
-  arbitrateAndPublish(msg->stamp);
+  arbitrate_and_publish(msg->stamp);
 }
 
-void TrafficLightArbiter::onExternalMsg(const TrafficSignalArray::ConstSharedPtr msg)
+void TrafficLightArbiter::on_external_msg(const TrafficSignalArray::ConstSharedPtr msg)
 {
   const auto current_time = this->now();
   const auto msg_time = rclcpp::Time(msg->stamp);
 
-  if (core_->isExternalOutdated(current_time, msg_time)) {
+  if (core_->is_external_outdated(current_time, msg_time)) {
     RCLCPP_WARN_THROTTLE(
       get_logger(), *get_clock(), 5000, "Received outdated V2X traffic signal messages");
     return;
   }
 
-  core_->ingestExternal(*msg);
+  core_->ingest_external(*msg);
 
   // Clean up expired signals against current time using the receive-delay tolerance
-  cleanupExpiredExternalSignals(current_time, external_delay_tolerance_);
+  cleanup_expired_external_signals(current_time, external_delay_tolerance_);
 
-  arbitrateAndPublish(msg->stamp);
+  arbitrate_and_publish(msg->stamp);
 }
 
-void TrafficLightArbiter::cleanupExpiredExternalSignals(
+void TrafficLightArbiter::cleanup_expired_external_signals(
   const rclcpp::Time & current_time, double tolerance)
 {
-  const auto dropped = core_->cleanupExpiredExternalSignals(current_time, tolerance);
+  const auto dropped = core_->cleanup_expired_external_signals(current_time, tolerance);
   for (const auto & entry : dropped) {
     RCLCPP_DEBUG(
       get_logger(), "Removing expired external traffic light signal (ID: %lu, age: %.2f s)",
@@ -171,7 +171,7 @@ void TrafficLightArbiter::cleanupExpiredExternalSignals(
   }
 }
 
-void TrafficLightArbiter::arbitrateAndPublish(const builtin_interfaces::msg::Time & stamp)
+void TrafficLightArbiter::arbitrate_and_publish(const builtin_interfaces::msg::Time & stamp)
 {
   auto result = core_->arbitrate();
 

--- a/perception/autoware_traffic_light_arbiter/src/traffic_light_arbiter.cpp
+++ b/perception/autoware_traffic_light_arbiter/src/traffic_light_arbiter.cpp
@@ -21,11 +21,9 @@
 #include <lanelet2_core/primitives/BasicRegulatoryElements.h>
 
 #include <algorithm>
-#include <map>
 #include <memory>
 #include <string>
-#include <tuple>
-#include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -77,26 +75,26 @@ TrafficLightArbiter::TrafficLightArbiter(const rclcpp::NodeOptions & options)
   perception_time_tolerance_ = this->declare_parameter<double>("perception_time_tolerance");
 
   // Parse source priority parameter
+  SourcePriority source_priority;
   const std::string priority_str = this->declare_parameter<std::string>("source_priority");
   if (priority_str == "external") {
-    source_priority_ = SourcePriority::EXTERNAL;
+    source_priority = SourcePriority::EXTERNAL;
   } else if (priority_str == "perception") {
-    source_priority_ = SourcePriority::PERCEPTION;
+    source_priority = SourcePriority::PERCEPTION;
   } else if (priority_str == "confidence") {
-    source_priority_ = SourcePriority::CONFIDENCE;
+    source_priority = SourcePriority::CONFIDENCE;
   } else {
     RCLCPP_WARN(
       get_logger(), "Unknown source_priority '%s', defaulting to 'confidence'",
       priority_str.c_str());
-    source_priority_ = SourcePriority::CONFIDENCE;
+    source_priority = SourcePriority::CONFIDENCE;
   }
 
-  enable_signal_matching_ = this->declare_parameter<bool>("enable_signal_matching");
+  const bool enable_signal_matching = this->declare_parameter<bool>("enable_signal_matching");
 
-  if (enable_signal_matching_) {
-    signal_match_validator_ = std::make_unique<SignalMatchValidator>();
-    signal_match_validator_->setSourcePriority(source_priority_);
-  }
+  core_ = std::make_unique<TrafficLightArbiterCore>(
+    source_priority, enable_signal_matching, external_delay_tolerance_, external_time_tolerance_,
+    perception_time_tolerance_);
 
   map_sub_ = create_subscription<LaneletMapBin>(
     "~/sub/vector_map", rclcpp::QoS(1).transient_local(),
@@ -118,26 +116,23 @@ void TrafficLightArbiter::onMap(const LaneletMapBin::ConstSharedPtr msg)
   const auto map = autoware::experimental::lanelet2_utils::from_autoware_map_msgs(*msg);
 
   const auto signals = lanelet::filter_traffic_signals(map);
-  map_regulatory_elements_set_ = std::make_unique<std::unordered_set<lanelet::Id>>();
-
+  std::unordered_set<lanelet::Id> traffic_light_ids;
   for (const auto & signal : signals) {
-    map_regulatory_elements_set_->emplace(signal->id());
+    traffic_light_ids.emplace(signal->id());
   }
+  core_->setTrafficLightIds(std::move(traffic_light_ids));
 
-  if (enable_signal_matching_) {
-    // Filter only pedestrian signals to distinguish them in signal matching
-    const auto pedestrian_signals = lanelet::filter_pedestrian_signals(map);
-    signal_match_validator_->setPedestrianSignals(pedestrian_signals);
-  }
+  // Filter only pedestrian signals to distinguish them in signal matching
+  const auto pedestrian_signals = lanelet::filter_pedestrian_signals(map);
+  core_->setPedestrianSignals(pedestrian_signals);
 }
 
 void TrafficLightArbiter::onPerceptionMsg(const TrafficSignalArray::ConstSharedPtr msg)
 {
-  latest_perception_msg_ = *msg;
+  core_->ingestPerception(*msg);
 
   // Clean up external signals that are too old relative to perception message
-  const auto msg_time = rclcpp::Time(msg->stamp);
-  cleanupExpiredExternalSignals(msg_time, external_time_tolerance_);
+  cleanupExpiredExternalSignals(rclcpp::Time(msg->stamp), external_time_tolerance_);
 
   arbitrateAndPublish(msg->stamp);
 }
@@ -147,27 +142,16 @@ void TrafficLightArbiter::onExternalMsg(const TrafficSignalArray::ConstSharedPtr
   const auto current_time = this->now();
   const auto msg_time = rclcpp::Time(msg->stamp);
 
-  if (std::abs((current_time - msg_time).seconds()) > external_delay_tolerance_) {
+  if (core_->isExternalOutdated(current_time, msg_time)) {
     RCLCPP_WARN_THROTTLE(
       get_logger(), *get_clock(), 5000, "Received outdated V2X traffic signal messages");
     return;
   }
 
-  // Update external traffic lights map with new information
-  for (const auto & signal : msg->traffic_light_groups) {
-    external_traffic_lights_[signal.traffic_light_group_id] =
-      std::make_pair(rclcpp::Time(msg->stamp), signal);
-  }
+  core_->ingestExternal(*msg);
 
-  // Clean up expired signals
+  // Clean up expired signals against current time using the receive-delay tolerance
   cleanupExpiredExternalSignals(current_time, external_delay_tolerance_);
-
-  // Clear perception data if too old relative to any external signal
-  if (
-    std::abs((msg_time - rclcpp::Time(latest_perception_msg_.stamp)).seconds()) >
-    perception_time_tolerance_) {
-    latest_perception_msg_.traffic_light_groups.clear();
-  }
 
   arbitrateAndPublish(msg->stamp);
 }
@@ -175,140 +159,33 @@ void TrafficLightArbiter::onExternalMsg(const TrafficSignalArray::ConstSharedPtr
 void TrafficLightArbiter::cleanupExpiredExternalSignals(
   const rclcpp::Time & current_time, double tolerance)
 {
-  auto it = external_traffic_lights_.begin();
-  while (it != external_traffic_lights_.end()) {
-    const auto & msg_stamp = it->second.first;
-    const auto age = (current_time - msg_stamp).seconds();
-    if (std::abs(age) > tolerance) {
-      RCLCPP_DEBUG(
-        get_logger(), "Removing expired external traffic light signal (ID: %lu, age: %.2f s)",
-        it->first, age);
-      it = external_traffic_lights_.erase(it);
-    } else {
-      ++it;
-    }
+  const auto dropped = core_->cleanupExpiredExternalSignals(current_time, tolerance);
+  for (const auto & entry : dropped) {
+    RCLCPP_DEBUG(
+      get_logger(), "Removing expired external traffic light signal (ID: %lu, age: %.2f s)",
+      entry.id, entry.age);
   }
 }
 
 void TrafficLightArbiter::arbitrateAndPublish(const builtin_interfaces::msg::Time & stamp)
 {
-  using ElementAndPriority = std::pair<Element, bool>;
-  std::unordered_map<lanelet::Id, std::vector<ElementAndPriority>> regulatory_element_signals_map;
+  auto result = core_->arbitrate(stamp);
 
-  // Create external signals array from stored valid signals
-  TrafficSignalArray valid_external_signals;
-  for (const auto & [id, info] : external_traffic_lights_) {
-    valid_external_signals.traffic_light_groups.emplace_back(info.second);
-  }
-
-  auto append_predictions = [](auto & map, const auto & groups) {
-    for (const auto & group : groups) {
-      auto & predictions = map[group.traffic_light_group_id];
-      predictions.insert(predictions.end(), group.predictions.begin(), group.predictions.end());
-    }
-  };
-  std::unordered_map<lanelet::Id, std::vector<PredictedTrafficLightState>> predictions_map;
-  // add in order from perception msg
-  append_predictions(predictions_map, latest_perception_msg_.traffic_light_groups);
-  append_predictions(predictions_map, valid_external_signals.traffic_light_groups);
-
-  if (map_regulatory_elements_set_ == nullptr) {
+  if (!result.output.has_value()) {
     RCLCPP_WARN_THROTTLE(
       get_logger(), *get_clock(), 5000, "Received traffic signal messages before a map");
     return;
   }
 
-  TrafficSignalArray output_signals_msg;
-  output_signals_msg.stamp = stamp;
-
-  if (map_regulatory_elements_set_->empty()) {
-    pub_->publish(output_signals_msg);
-    return;
+  for (const auto & id : result.off_map_signal_ids) {
+    RCLCPP_WARN_THROTTLE(
+      get_logger(), *get_clock(), 5000,
+      "Received a traffic signal not present in the current map (%lu)", id);
   }
 
-  auto add_signal_function = [&](const auto & signal, bool priority) {
-    const auto id = signal.traffic_light_group_id;
-    if (!map_regulatory_elements_set_->count(id)) {
-      RCLCPP_WARN_THROTTLE(
-        get_logger(), *get_clock(), 5000,
-        "Received a traffic signal not present in the current map (%lu)", id);
-      return;
-    }
+  pub_->publish(*result.output);
 
-    auto & elements_and_priority = regulatory_element_signals_map[id];
-    for (const auto & element : signal.elements) {
-      elements_and_priority.emplace_back(element, priority);
-    }
-  };
-
-  if (enable_signal_matching_) {
-    const auto validated_signals =
-      signal_match_validator_->validateSignals(latest_perception_msg_, valid_external_signals);
-    for (const auto & signal : validated_signals.traffic_light_groups) {
-      add_signal_function(signal, false);
-    }
-  } else {
-    for (const auto & signal : latest_perception_msg_.traffic_light_groups) {
-      add_signal_function(signal, source_priority_ == SourcePriority::PERCEPTION);
-    }
-
-    for (const auto & signal : valid_external_signals.traffic_light_groups) {
-      add_signal_function(signal, source_priority_ == SourcePriority::EXTERNAL);
-    }
-  }
-
-  const auto get_highest_confidence_elements =
-    [](const std::vector<ElementAndPriority> & elements_and_priority_vector) {
-      using Key = Element::_shape_type;
-      std::map<Key, ElementAndPriority> highest_score_element_and_priority_map;
-      std::vector<Element> highest_score_elements_vector;
-
-      for (const auto & elements_and_priority : elements_and_priority_vector) {
-        const auto & element = elements_and_priority.first;
-        const auto & element_priority = elements_and_priority.second;
-        const auto key = element.shape;
-        auto [iter, success] =
-          highest_score_element_and_priority_map.try_emplace(key, elements_and_priority);
-        const auto & iter_element = iter->second.first;
-        const auto & iter_priority = iter->second.second;
-
-        if (
-          !success &&
-          (element_priority > iter_priority ||
-           (element_priority == iter_priority && element.confidence > iter_element.confidence))) {
-          iter->second = elements_and_priority;
-        }
-      }
-
-      for (const auto & [k, v] : highest_score_element_and_priority_map) {
-        highest_score_elements_vector.emplace_back(v.first);
-      }
-
-      return highest_score_elements_vector;
-    };
-
-  output_signals_msg.traffic_light_groups.reserve(regulatory_element_signals_map.size());
-
-  for (const auto & [regulatory_element_id, elements] : regulatory_element_signals_map) {
-    TrafficSignal signal_msg;
-    signal_msg.traffic_light_group_id = regulatory_element_id;
-    signal_msg.elements = get_highest_confidence_elements(elements);
-    signal_msg.predictions = predictions_map[regulatory_element_id];
-    output_signals_msg.traffic_light_groups.emplace_back(signal_msg);
-  }
-
-  pub_->publish(output_signals_msg);
-
-  // Calculate latest time from available sources
-  rclcpp::Time latest_time = rclcpp::Time(latest_perception_msg_.stamp);
-  for (const auto & [id, info] : external_traffic_lights_) {
-    const auto & external_time = info.first;
-    if (external_time > latest_time) {
-      latest_time = external_time;
-    }
-  }
-
-  if (rclcpp::Time(output_signals_msg.stamp) < latest_time) {
+  if (result.output_not_latest) {
     RCLCPP_WARN_THROTTLE(
       get_logger(), *get_clock(), 5000, "Published traffic signal messages are not latest");
   }

--- a/perception/autoware_traffic_light_arbiter/src/traffic_light_arbiter.cpp
+++ b/perception/autoware_traffic_light_arbiter/src/traffic_light_arbiter.cpp
@@ -121,7 +121,7 @@ void TrafficLightArbiter::on_map(const LaneletMapBin::ConstSharedPtr msg)
 
 void TrafficLightArbiter::on_perception_msg(const TrafficSignalArray::ConstSharedPtr msg)
 {
-  log_dropped_external_signals(core_->ingest_perception(*msg));
+  log_expired_external_signals(core_->ingest_perception(*msg));
   arbitrate_and_publish(msg->stamp);
 }
 
@@ -133,14 +133,14 @@ void TrafficLightArbiter::on_external_msg(const TrafficSignalArray::ConstSharedP
       get_logger(), *get_clock(), 5000, "Received outdated external traffic signal messages");
     return;
   }
-  log_dropped_external_signals(result.dropped);
+  log_expired_external_signals(result.expired);
   arbitrate_and_publish(msg->stamp);
 }
 
-void TrafficLightArbiter::log_dropped_external_signals(
-  const std::vector<TrafficLightArbiterCore::DroppedExternalSignal> & dropped)
+void TrafficLightArbiter::log_expired_external_signals(
+  const std::vector<TrafficLightArbiterCore::ExpiredExternalSignal> & expired)
 {
-  for (const auto & entry : dropped) {
+  for (const auto & entry : expired) {
     RCLCPP_DEBUG(
       get_logger(), "Removing expired external traffic light signal (ID: %lu, age: %.2f s)",
       entry.id, entry.age);

--- a/perception/autoware_traffic_light_arbiter/src/traffic_light_arbiter.cpp
+++ b/perception/autoware_traffic_light_arbiter/src/traffic_light_arbiter.cpp
@@ -124,7 +124,11 @@ void TrafficLightArbiter::onMap(const LaneletMapBin::ConstSharedPtr msg)
 
   // Filter only pedestrian signals to distinguish them in signal matching
   const auto pedestrian_signals = lanelet::filter_pedestrian_signals(map);
-  core_->setPedestrianSignals(pedestrian_signals);
+  std::unordered_set<lanelet::Id> pedestrian_signal_ids;
+  for (const auto & signal : pedestrian_signals) {
+    pedestrian_signal_ids.emplace(signal->id());
+  }
+  core_->setPedestrianSignalIds(std::move(pedestrian_signal_ids));
 }
 
 void TrafficLightArbiter::onPerceptionMsg(const TrafficSignalArray::ConstSharedPtr msg)

--- a/perception/autoware_traffic_light_arbiter/src/traffic_light_arbiter.cpp
+++ b/perception/autoware_traffic_light_arbiter/src/traffic_light_arbiter.cpp
@@ -70,9 +70,10 @@ namespace autoware::traffic_light
 TrafficLightArbiter::TrafficLightArbiter(const rclcpp::NodeOptions & options)
 : Node("traffic_light_arbiter", options)
 {
-  external_delay_tolerance_ = this->declare_parameter<double>("external_delay_tolerance");
-  external_time_tolerance_ = this->declare_parameter<double>("external_time_tolerance");
-  perception_time_tolerance_ = this->declare_parameter<double>("perception_time_tolerance");
+  const auto external_delay_tolerance = this->declare_parameter<double>("external_delay_tolerance");
+  const auto external_time_tolerance = this->declare_parameter<double>("external_time_tolerance");
+  const auto perception_time_tolerance =
+    this->declare_parameter<double>("perception_time_tolerance");
 
   // Parse source priority parameter
   SourcePriority source_priority;
@@ -93,8 +94,8 @@ TrafficLightArbiter::TrafficLightArbiter(const rclcpp::NodeOptions & options)
   const bool enable_signal_matching = this->declare_parameter<bool>("enable_signal_matching");
 
   core_ = std::make_unique<TrafficLightArbiterCore>(
-    source_priority, enable_signal_matching, external_delay_tolerance_, external_time_tolerance_,
-    perception_time_tolerance_);
+    source_priority, enable_signal_matching, external_delay_tolerance, external_time_tolerance,
+    perception_time_tolerance);
 
   map_sub_ = create_subscription<LaneletMapBin>(
     "~/sub/vector_map", rclcpp::QoS(1).transient_local(),
@@ -120,11 +121,7 @@ void TrafficLightArbiter::on_map(const LaneletMapBin::ConstSharedPtr msg)
 
 void TrafficLightArbiter::on_perception_msg(const TrafficSignalArray::ConstSharedPtr msg)
 {
-  core_->ingest_perception(*msg);
-
-  // Clean up external signals that are too old relative to perception message
-  cleanup_expired_external_signals(rclcpp::Time(msg->stamp), external_time_tolerance_);
-
+  log_dropped_external_signals(core_->ingest_perception(*msg));
   arbitrate_and_publish(msg->stamp);
 }
 
@@ -139,18 +136,13 @@ void TrafficLightArbiter::on_external_msg(const TrafficSignalArray::ConstSharedP
     return;
   }
 
-  core_->ingest_external(*msg);
-
-  // Clean up expired signals against current time using the receive-delay tolerance
-  cleanup_expired_external_signals(current_time, external_delay_tolerance_);
-
+  log_dropped_external_signals(core_->ingest_external(*msg, current_time));
   arbitrate_and_publish(msg->stamp);
 }
 
-void TrafficLightArbiter::cleanup_expired_external_signals(
-  const rclcpp::Time & current_time, double tolerance)
+void TrafficLightArbiter::log_dropped_external_signals(
+  const std::vector<TrafficLightArbiterCore::DroppedExternalSignal> & dropped)
 {
-  const auto dropped = core_->cleanup_expired_external_signals(current_time, tolerance);
   for (const auto & entry : dropped) {
     RCLCPP_DEBUG(
       get_logger(), "Removing expired external traffic light signal (ID: %lu, age: %.2f s)",

--- a/perception/autoware_traffic_light_arbiter/src/traffic_light_arbiter.cpp
+++ b/perception/autoware_traffic_light_arbiter/src/traffic_light_arbiter.cpp
@@ -32,11 +32,15 @@ namespace lanelet
 
 std::unordered_set<lanelet::Id> extract_traffic_light_ids(const LaneletMapConstPtr map)
 {
+  namespace query = lanelet::utils::query;
+
+  const auto all_lanelets = query::laneletLayer(map);
+
   std::unordered_set<lanelet::Id> traffic_light_ids;
-  for (const auto & element : map->regulatoryElementLayer) {
-    const auto signal = std::dynamic_pointer_cast<const TrafficLight>(element);
-    if (signal) {
-      traffic_light_ids.emplace(signal->id());
+  for (const auto & lanelet : all_lanelets) {
+    const auto traffic_lights = lanelet.regulatoryElementsAs<const lanelet::TrafficLight>();
+    for (const auto & traffic_light : traffic_lights) {
+      traffic_light_ids.emplace(traffic_light->id());
     }
   }
   return traffic_light_ids;
@@ -51,10 +55,9 @@ std::unordered_set<lanelet::Id> extract_pedestrian_traffic_light_ids(const Lanel
 
   std::unordered_set<lanelet::Id> pedestrian_traffic_light_ids;
   for (const auto & crosswalk : crosswalks) {
-    const auto traffic_light_reg_elems =
-      crosswalk.regulatoryElementsAs<const lanelet::TrafficLight>();
-    for (const auto & reg_elem : traffic_light_reg_elems) {
-      pedestrian_traffic_light_ids.emplace(reg_elem->id());
+    const auto traffic_lights = crosswalk.regulatoryElementsAs<const lanelet::TrafficLight>();
+    for (const auto & traffic_light : traffic_lights) {
+      pedestrian_traffic_light_ids.emplace(traffic_light->id());
     }
   }
   return pedestrian_traffic_light_ids;

--- a/perception/autoware_traffic_light_arbiter/src/traffic_light_arbiter.cpp
+++ b/perception/autoware_traffic_light_arbiter/src/traffic_light_arbiter.cpp
@@ -30,37 +30,34 @@
 namespace lanelet
 {
 
-using TrafficLightConstPtr = std::shared_ptr<const TrafficLight>;
-
-std::vector<TrafficLightConstPtr> filter_traffic_signals(const LaneletMapConstPtr map)
+std::unordered_set<lanelet::Id> extract_traffic_light_ids(const LaneletMapConstPtr map)
 {
-  std::vector<TrafficLightConstPtr> signals;
+  std::unordered_set<lanelet::Id> traffic_light_ids;
   for (const auto & element : map->regulatoryElementLayer) {
     const auto signal = std::dynamic_pointer_cast<const TrafficLight>(element);
     if (signal) {
-      signals.push_back(signal);
+      traffic_light_ids.emplace(signal->id());
     }
   }
-
-  return signals;
+  return traffic_light_ids;
 }
 
-std::vector<TrafficLightConstPtr> filter_pedestrian_signals(const LaneletMapConstPtr map)
+std::unordered_set<lanelet::Id> extract_pedestrian_traffic_light_ids(const LaneletMapConstPtr map)
 {
   namespace query = lanelet::utils::query;
 
   const auto all_lanelets = query::laneletLayer(map);
   const auto crosswalks = query::crosswalkLanelets(all_lanelets);
-  std::vector<TrafficLightConstPtr> signals;
 
+  std::unordered_set<lanelet::Id> pedestrian_traffic_light_ids;
   for (const auto & crosswalk : crosswalks) {
     const auto traffic_light_reg_elems =
       crosswalk.regulatoryElementsAs<const lanelet::TrafficLight>();
-    std::copy(
-      traffic_light_reg_elems.begin(), traffic_light_reg_elems.end(), std::back_inserter(signals));
+    for (const auto & reg_elem : traffic_light_reg_elems) {
+      pedestrian_traffic_light_ids.emplace(reg_elem->id());
+    }
   }
-
-  return signals;
+  return pedestrian_traffic_light_ids;
 }
 
 }  // namespace lanelet
@@ -114,21 +111,8 @@ TrafficLightArbiter::TrafficLightArbiter(const rclcpp::NodeOptions & options)
 void TrafficLightArbiter::on_map(const LaneletMapBin::ConstSharedPtr msg)
 {
   const auto map = autoware::experimental::lanelet2_utils::from_autoware_map_msgs(*msg);
-
-  const auto signals = lanelet::filter_traffic_signals(map);
-  std::unordered_set<lanelet::Id> traffic_light_ids;
-  for (const auto & signal : signals) {
-    traffic_light_ids.emplace(signal->id());
-  }
-  core_->set_traffic_light_ids(std::move(traffic_light_ids));
-
-  // Filter only pedestrian signals to distinguish them in signal matching
-  const auto pedestrian_signals = lanelet::filter_pedestrian_signals(map);
-  std::unordered_set<lanelet::Id> pedestrian_signal_ids;
-  for (const auto & signal : pedestrian_signals) {
-    pedestrian_signal_ids.emplace(signal->id());
-  }
-  core_->set_pedestrian_signal_ids(std::move(pedestrian_signal_ids));
+  core_->set_traffic_light_ids(lanelet::extract_traffic_light_ids(map));
+  core_->set_pedestrian_traffic_light_ids(lanelet::extract_pedestrian_traffic_light_ids(map));
 }
 
 void TrafficLightArbiter::on_perception_msg(const TrafficSignalArray::ConstSharedPtr msg)

--- a/perception/autoware_traffic_light_arbiter/src/traffic_light_arbiter.cpp
+++ b/perception/autoware_traffic_light_arbiter/src/traffic_light_arbiter.cpp
@@ -14,56 +14,11 @@
 
 #include <autoware/lanelet2_utils/conversion.hpp>
 #include <autoware/traffic_light_arbiter/traffic_light_arbiter.hpp>
-#include <autoware_lanelet2_extension/utility/query.hpp>
 #include <rclcpp/time.hpp>
 
-#include <lanelet2_core/LaneletMap.h>
-#include <lanelet2_core/primitives/BasicRegulatoryElements.h>
-
-#include <algorithm>
 #include <memory>
 #include <string>
-#include <unordered_set>
-#include <utility>
 #include <vector>
-
-namespace lanelet
-{
-
-std::unordered_set<lanelet::Id> extract_traffic_light_ids(const LaneletMapConstPtr map)
-{
-  namespace query = lanelet::utils::query;
-
-  const auto all_lanelets = query::laneletLayer(map);
-
-  std::unordered_set<lanelet::Id> traffic_light_ids;
-  for (const auto & lanelet : all_lanelets) {
-    const auto traffic_lights = lanelet.regulatoryElementsAs<const lanelet::TrafficLight>();
-    for (const auto & traffic_light : traffic_lights) {
-      traffic_light_ids.emplace(traffic_light->id());
-    }
-  }
-  return traffic_light_ids;
-}
-
-std::unordered_set<lanelet::Id> extract_pedestrian_traffic_light_ids(const LaneletMapConstPtr map)
-{
-  namespace query = lanelet::utils::query;
-
-  const auto all_lanelets = query::laneletLayer(map);
-  const auto crosswalks = query::crosswalkLanelets(all_lanelets);
-
-  std::unordered_set<lanelet::Id> pedestrian_traffic_light_ids;
-  for (const auto & crosswalk : crosswalks) {
-    const auto traffic_lights = crosswalk.regulatoryElementsAs<const lanelet::TrafficLight>();
-    for (const auto & traffic_light : traffic_lights) {
-      pedestrian_traffic_light_ids.emplace(traffic_light->id());
-    }
-  }
-  return pedestrian_traffic_light_ids;
-}
-
-}  // namespace lanelet
 
 namespace autoware::traffic_light
 {
@@ -114,9 +69,7 @@ TrafficLightArbiter::TrafficLightArbiter(const rclcpp::NodeOptions & options)
 
 void TrafficLightArbiter::on_map(const LaneletMapBin::ConstSharedPtr msg)
 {
-  const auto map = autoware::experimental::lanelet2_utils::from_autoware_map_msgs(*msg);
-  core_->set_traffic_light_ids(lanelet::extract_traffic_light_ids(map));
-  core_->set_pedestrian_traffic_light_ids(lanelet::extract_pedestrian_traffic_light_ids(map));
+  core_->set_map(autoware::experimental::lanelet2_utils::from_autoware_map_msgs(*msg));
 }
 
 void TrafficLightArbiter::on_perception_msg(const TrafficSignalArray::ConstSharedPtr msg)

--- a/perception/autoware_traffic_light_arbiter/src/traffic_light_arbiter.cpp
+++ b/perception/autoware_traffic_light_arbiter/src/traffic_light_arbiter.cpp
@@ -169,7 +169,7 @@ void TrafficLightArbiter::cleanupExpiredExternalSignals(
 
 void TrafficLightArbiter::arbitrateAndPublish(const builtin_interfaces::msg::Time & stamp)
 {
-  auto result = core_->arbitrate(stamp);
+  auto result = core_->arbitrate();
 
   if (!result.output.has_value()) {
     RCLCPP_WARN_THROTTLE(
@@ -183,9 +183,12 @@ void TrafficLightArbiter::arbitrateAndPublish(const builtin_interfaces::msg::Tim
       "Received a traffic signal not present in the current map (%lu)", id);
   }
 
+  // Stamp inheritance is the Node's I/O contract with downstream consumers:
+  // the published output carries the trigger msg's stamp for time alignment.
+  result.output->stamp = stamp;
   pub_->publish(*result.output);
 
-  if (result.output_not_latest) {
+  if (rclcpp::Time(stamp) < result.latest_input_time) {
     RCLCPP_WARN_THROTTLE(
       get_logger(), *get_clock(), 5000, "Published traffic signal messages are not latest");
   }

--- a/perception/autoware_traffic_light_arbiter/src/traffic_light_arbiter.cpp
+++ b/perception/autoware_traffic_light_arbiter/src/traffic_light_arbiter.cpp
@@ -127,16 +127,13 @@ void TrafficLightArbiter::on_perception_msg(const TrafficSignalArray::ConstShare
 
 void TrafficLightArbiter::on_external_msg(const TrafficSignalArray::ConstSharedPtr msg)
 {
-  const auto current_time = this->now();
-  const auto msg_time = rclcpp::Time(msg->stamp);
-
-  if (core_->is_external_outdated(current_time, msg_time)) {
+  const auto result = core_->ingest_external(*msg, this->now());
+  if (!result.accepted) {
     RCLCPP_WARN_THROTTLE(
-      get_logger(), *get_clock(), 5000, "Received outdated V2X traffic signal messages");
+      get_logger(), *get_clock(), 5000, "Received outdated external traffic signal messages");
     return;
   }
-
-  log_dropped_external_signals(core_->ingest_external(*msg, current_time));
+  log_dropped_external_signals(result.dropped);
   arbitrate_and_publish(msg->stamp);
 }
 

--- a/perception/autoware_traffic_light_arbiter/src/traffic_light_arbiter_core.cpp
+++ b/perception/autoware_traffic_light_arbiter/src/traffic_light_arbiter_core.cpp
@@ -55,7 +55,7 @@ void TrafficLightArbiterCore::set_pedestrian_traffic_light_ids(std::unordered_se
 bool TrafficLightArbiterCore::is_external_outdated(
   const rclcpp::Time & current_time, const rclcpp::Time & msg_stamp) const
 {
-  return std::abs((current_time - msg_stamp).seconds()) > external_delay_tolerance_;
+  return (current_time - msg_stamp).seconds() > external_delay_tolerance_;
 }
 
 std::vector<TrafficLightArbiterCore::ExpiredExternalSignal>
@@ -67,7 +67,7 @@ TrafficLightArbiterCore::sweep_expired_external_signals(
   while (it != external_traffic_lights_.end()) {
     const auto & msg_stamp = it->second.first;
     const auto age = (reference_time - msg_stamp).seconds();
-    if (std::abs(age) > tolerance) {
+    if (age > tolerance) {
       expired.push_back({it->first, age});
       it = external_traffic_lights_.erase(it);
     } else {

--- a/perception/autoware_traffic_light_arbiter/src/traffic_light_arbiter_core.cpp
+++ b/perception/autoware_traffic_light_arbiter/src/traffic_light_arbiter_core.cpp
@@ -84,25 +84,27 @@ TrafficLightArbiterCore::ingest_perception(const TrafficSignalArray & msg)
   return sweep_expired_external_signals(rclcpp::Time(msg.stamp), external_time_tolerance_);
 }
 
-std::vector<TrafficLightArbiterCore::DroppedExternalSignal>
-TrafficLightArbiterCore::ingest_external(
+TrafficLightArbiterCore::ExternalIngestResult TrafficLightArbiterCore::ingest_external(
   const TrafficSignalArray & msg, const rclcpp::Time & current_time)
 {
+  const auto msg_time = rclcpp::Time(msg.stamp);
+  if (is_external_outdated(current_time, msg_time)) {
+    return {false, {}};
+  }
+
   // Update external traffic lights map with new information
   for (const auto & signal : msg.traffic_light_groups) {
-    external_traffic_lights_[signal.traffic_light_group_id] =
-      std::make_pair(rclcpp::Time(msg.stamp), signal);
+    external_traffic_lights_[signal.traffic_light_group_id] = std::make_pair(msg_time, signal);
   }
 
   // Clear perception data if too old relative to this external signal
-  const auto msg_time = rclcpp::Time(msg.stamp);
   if (
     std::abs((msg_time - rclcpp::Time(latest_perception_msg_.stamp)).seconds()) >
     perception_time_tolerance_) {
     latest_perception_msg_.traffic_light_groups.clear();
   }
 
-  return sweep_expired_external_signals(current_time, external_delay_tolerance_);
+  return {true, sweep_expired_external_signals(current_time, external_delay_tolerance_)};
 }
 
 TrafficLightArbiterCore::ArbitrationResult TrafficLightArbiterCore::arbitrate()

--- a/perception/autoware_traffic_light_arbiter/src/traffic_light_arbiter_core.cpp
+++ b/perception/autoware_traffic_light_arbiter/src/traffic_light_arbiter_core.cpp
@@ -35,8 +35,7 @@ TrafficLightArbiterCore::TrafficLightArbiterCore(
   perception_time_tolerance_(perception_time_tolerance)
 {
   if (enable_signal_matching_) {
-    signal_match_validator_ = std::make_unique<SignalMatchValidator>();
-    signal_match_validator_->set_source_priority(source_priority_);
+    signal_match_validator_ = std::make_unique<SignalMatchValidator>(source_priority_);
   }
 }
 

--- a/perception/autoware_traffic_light_arbiter/src/traffic_light_arbiter_core.cpp
+++ b/perception/autoware_traffic_light_arbiter/src/traffic_light_arbiter_core.cpp
@@ -35,14 +35,10 @@ namespace
 
 std::unordered_set<lanelet::Id> extract_traffic_light_ids(const lanelet::LaneletMapConstPtr & map)
 {
-  namespace query = lanelet::utils::query;
-
-  const auto all_lanelets = query::laneletLayer(map);
-
   std::unordered_set<lanelet::Id> traffic_light_ids;
-  for (const auto & lanelet : all_lanelets) {
-    const auto traffic_lights = lanelet.regulatoryElementsAs<const lanelet::TrafficLight>();
-    for (const auto & traffic_light : traffic_lights) {
+  for (const auto & element : map->regulatoryElementLayer) {
+    const auto traffic_light = std::dynamic_pointer_cast<const lanelet::TrafficLight>(element);
+    if (traffic_light) {
       traffic_light_ids.emplace(traffic_light->id());
     }
   }

--- a/perception/autoware_traffic_light_arbiter/src/traffic_light_arbiter_core.cpp
+++ b/perception/autoware_traffic_light_arbiter/src/traffic_light_arbiter_core.cpp
@@ -36,30 +36,30 @@ TrafficLightArbiterCore::TrafficLightArbiterCore(
 {
   if (enable_signal_matching_) {
     signal_match_validator_ = std::make_unique<SignalMatchValidator>();
-    signal_match_validator_->setSourcePriority(source_priority_);
+    signal_match_validator_->set_source_priority(source_priority_);
   }
 }
 
-void TrafficLightArbiterCore::setTrafficLightIds(std::unordered_set<lanelet::Id> ids)
+void TrafficLightArbiterCore::set_traffic_light_ids(std::unordered_set<lanelet::Id> ids)
 {
   map_regulatory_elements_set_ = std::make_unique<std::unordered_set<lanelet::Id>>(std::move(ids));
 }
 
-void TrafficLightArbiterCore::setPedestrianSignalIds(std::unordered_set<lanelet::Id> ids)
+void TrafficLightArbiterCore::set_pedestrian_signal_ids(std::unordered_set<lanelet::Id> ids)
 {
   if (enable_signal_matching_) {
-    signal_match_validator_->setPedestrianSignalIds(std::move(ids));
+    signal_match_validator_->set_pedestrian_signal_ids(std::move(ids));
   }
 }
 
-bool TrafficLightArbiterCore::isExternalOutdated(
+bool TrafficLightArbiterCore::is_external_outdated(
   const rclcpp::Time & current_time, const rclcpp::Time & msg_stamp) const
 {
   return std::abs((current_time - msg_stamp).seconds()) > external_delay_tolerance_;
 }
 
 std::vector<TrafficLightArbiterCore::DroppedExternalSignal>
-TrafficLightArbiterCore::cleanupExpiredExternalSignals(
+TrafficLightArbiterCore::cleanup_expired_external_signals(
   const rclcpp::Time & reference_time, double tolerance)
 {
   std::vector<DroppedExternalSignal> dropped;
@@ -77,12 +77,12 @@ TrafficLightArbiterCore::cleanupExpiredExternalSignals(
   return dropped;
 }
 
-void TrafficLightArbiterCore::ingestPerception(const TrafficSignalArray & msg)
+void TrafficLightArbiterCore::ingest_perception(const TrafficSignalArray & msg)
 {
   latest_perception_msg_ = msg;
 }
 
-void TrafficLightArbiterCore::ingestExternal(const TrafficSignalArray & msg)
+void TrafficLightArbiterCore::ingest_external(const TrafficSignalArray & msg)
 {
   // Update external traffic lights map with new information
   for (const auto & signal : msg.traffic_light_groups) {
@@ -150,7 +150,7 @@ TrafficLightArbiterCore::ArbitrationResult TrafficLightArbiterCore::arbitrate()
 
   if (enable_signal_matching_) {
     const auto validated_signals =
-      signal_match_validator_->validateSignals(latest_perception_msg_, valid_external_signals);
+      signal_match_validator_->validate_signals(latest_perception_msg_, valid_external_signals);
     for (const auto & signal : validated_signals.traffic_light_groups) {
       add_signal_function(signal, false);
     }

--- a/perception/autoware_traffic_light_arbiter/src/traffic_light_arbiter_core.cpp
+++ b/perception/autoware_traffic_light_arbiter/src/traffic_light_arbiter_core.cpp
@@ -1,0 +1,226 @@
+// Copyright 2026 The Autoware Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <autoware/traffic_light_arbiter/traffic_light_arbiter_core.hpp>
+
+#include <algorithm>
+#include <map>
+#include <memory>
+#include <tuple>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+namespace autoware::traffic_light
+{
+
+TrafficLightArbiterCore::TrafficLightArbiterCore(
+  SourcePriority source_priority, bool enable_signal_matching, double external_delay_tolerance,
+  double external_time_tolerance, double perception_time_tolerance)
+: source_priority_(source_priority),
+  enable_signal_matching_(enable_signal_matching),
+  external_delay_tolerance_(external_delay_tolerance),
+  external_time_tolerance_(external_time_tolerance),
+  perception_time_tolerance_(perception_time_tolerance)
+{
+  if (enable_signal_matching_) {
+    signal_match_validator_ = std::make_unique<SignalMatchValidator>();
+    signal_match_validator_->setSourcePriority(source_priority_);
+  }
+}
+
+void TrafficLightArbiterCore::setTrafficLightIds(std::unordered_set<lanelet::Id> ids)
+{
+  map_regulatory_elements_set_ = std::make_unique<std::unordered_set<lanelet::Id>>(std::move(ids));
+}
+
+void TrafficLightArbiterCore::setPedestrianSignals(
+  const std::vector<TrafficLightConstPtr> & pedestrian_signals)
+{
+  if (enable_signal_matching_) {
+    signal_match_validator_->setPedestrianSignals(pedestrian_signals);
+  }
+}
+
+bool TrafficLightArbiterCore::isExternalOutdated(
+  const rclcpp::Time & current_time, const rclcpp::Time & msg_stamp) const
+{
+  return std::abs((current_time - msg_stamp).seconds()) > external_delay_tolerance_;
+}
+
+std::vector<TrafficLightArbiterCore::DroppedExternalSignal>
+TrafficLightArbiterCore::cleanupExpiredExternalSignals(
+  const rclcpp::Time & reference_time, double tolerance)
+{
+  std::vector<DroppedExternalSignal> dropped;
+  auto it = external_traffic_lights_.begin();
+  while (it != external_traffic_lights_.end()) {
+    const auto & msg_stamp = it->second.first;
+    const auto age = (reference_time - msg_stamp).seconds();
+    if (std::abs(age) > tolerance) {
+      dropped.push_back({it->first, age});
+      it = external_traffic_lights_.erase(it);
+    } else {
+      ++it;
+    }
+  }
+  return dropped;
+}
+
+void TrafficLightArbiterCore::ingestPerception(const TrafficSignalArray & msg)
+{
+  latest_perception_msg_ = msg;
+}
+
+void TrafficLightArbiterCore::ingestExternal(const TrafficSignalArray & msg)
+{
+  // Update external traffic lights map with new information
+  for (const auto & signal : msg.traffic_light_groups) {
+    external_traffic_lights_[signal.traffic_light_group_id] =
+      std::make_pair(rclcpp::Time(msg.stamp), signal);
+  }
+
+  // Clear perception data if too old relative to this external signal
+  const auto msg_time = rclcpp::Time(msg.stamp);
+  if (
+    std::abs((msg_time - rclcpp::Time(latest_perception_msg_.stamp)).seconds()) >
+    perception_time_tolerance_) {
+    latest_perception_msg_.traffic_light_groups.clear();
+  }
+}
+
+TrafficLightArbiterCore::ArbitrationResult TrafficLightArbiterCore::arbitrate(
+  const builtin_interfaces::msg::Time & stamp)
+{
+  ArbitrationResult result;
+
+  using ElementAndPriority = std::pair<Element, bool>;
+  std::unordered_map<lanelet::Id, std::vector<ElementAndPriority>> regulatory_element_signals_map;
+
+  // Create external signals array from stored valid signals
+  TrafficSignalArray valid_external_signals;
+  for (const auto & [id, info] : external_traffic_lights_) {
+    valid_external_signals.traffic_light_groups.emplace_back(info.second);
+  }
+
+  auto append_predictions = [](auto & map, const auto & groups) {
+    for (const auto & group : groups) {
+      auto & predictions = map[group.traffic_light_group_id];
+      predictions.insert(predictions.end(), group.predictions.begin(), group.predictions.end());
+    }
+  };
+  std::unordered_map<lanelet::Id, std::vector<PredictedTrafficLightState>> predictions_map;
+  // add in order from perception msg
+  append_predictions(predictions_map, latest_perception_msg_.traffic_light_groups);
+  append_predictions(predictions_map, valid_external_signals.traffic_light_groups);
+
+  if (map_regulatory_elements_set_ == nullptr) {
+    return result;
+  }
+
+  TrafficSignalArray output_signals_msg;
+  output_signals_msg.stamp = stamp;
+
+  if (map_regulatory_elements_set_->empty()) {
+    result.output = std::move(output_signals_msg);
+    return result;
+  }
+
+  auto add_signal_function = [&](const auto & signal, bool priority) {
+    const auto id = signal.traffic_light_group_id;
+    if (!map_regulatory_elements_set_->count(id)) {
+      result.off_map_signal_ids.push_back(id);
+      return;
+    }
+
+    auto & elements_and_priority = regulatory_element_signals_map[id];
+    for (const auto & element : signal.elements) {
+      elements_and_priority.emplace_back(element, priority);
+    }
+  };
+
+  if (enable_signal_matching_) {
+    const auto validated_signals =
+      signal_match_validator_->validateSignals(latest_perception_msg_, valid_external_signals);
+    for (const auto & signal : validated_signals.traffic_light_groups) {
+      add_signal_function(signal, false);
+    }
+  } else {
+    for (const auto & signal : latest_perception_msg_.traffic_light_groups) {
+      add_signal_function(signal, source_priority_ == SourcePriority::PERCEPTION);
+    }
+
+    for (const auto & signal : valid_external_signals.traffic_light_groups) {
+      add_signal_function(signal, source_priority_ == SourcePriority::EXTERNAL);
+    }
+  }
+
+  const auto get_highest_confidence_elements =
+    [](const std::vector<ElementAndPriority> & elements_and_priority_vector) {
+      using Key = Element::_shape_type;
+      std::map<Key, ElementAndPriority> highest_score_element_and_priority_map;
+      std::vector<Element> highest_score_elements_vector;
+
+      for (const auto & elements_and_priority : elements_and_priority_vector) {
+        const auto & element = elements_and_priority.first;
+        const auto & element_priority = elements_and_priority.second;
+        const auto key = element.shape;
+        auto [iter, success] =
+          highest_score_element_and_priority_map.try_emplace(key, elements_and_priority);
+        const auto & iter_element = iter->second.first;
+        const auto & iter_priority = iter->second.second;
+
+        if (
+          !success &&
+          (element_priority > iter_priority ||
+           (element_priority == iter_priority && element.confidence > iter_element.confidence))) {
+          iter->second = elements_and_priority;
+        }
+      }
+
+      for (const auto & [k, v] : highest_score_element_and_priority_map) {
+        highest_score_elements_vector.emplace_back(v.first);
+      }
+
+      return highest_score_elements_vector;
+    };
+
+  output_signals_msg.traffic_light_groups.reserve(regulatory_element_signals_map.size());
+
+  for (const auto & [regulatory_element_id, elements] : regulatory_element_signals_map) {
+    TrafficSignal signal_msg;
+    signal_msg.traffic_light_group_id = regulatory_element_id;
+    signal_msg.elements = get_highest_confidence_elements(elements);
+    signal_msg.predictions = predictions_map[regulatory_element_id];
+    output_signals_msg.traffic_light_groups.emplace_back(signal_msg);
+  }
+
+  // Calculate latest time from available sources
+  rclcpp::Time latest_time = rclcpp::Time(latest_perception_msg_.stamp);
+  for (const auto & [id, info] : external_traffic_lights_) {
+    const auto & external_time = info.first;
+    if (external_time > latest_time) {
+      latest_time = external_time;
+    }
+  }
+
+  if (rclcpp::Time(output_signals_msg.stamp) < latest_time) {
+    result.output_not_latest = true;
+  }
+
+  result.output = std::move(output_signals_msg);
+  return result;
+}
+
+}  // namespace autoware::traffic_light

--- a/perception/autoware_traffic_light_arbiter/src/traffic_light_arbiter_core.cpp
+++ b/perception/autoware_traffic_light_arbiter/src/traffic_light_arbiter_core.cpp
@@ -92,7 +92,7 @@ void TrafficLightArbiterCore::set_map(const lanelet::LaneletMapConstPtr & map)
 bool TrafficLightArbiterCore::is_external_outdated(
   const rclcpp::Time & current_time, const rclcpp::Time & msg_stamp) const
 {
-  return (current_time - msg_stamp).seconds() > external_delay_tolerance_;
+  return std::abs((current_time - msg_stamp).seconds()) > external_delay_tolerance_;
 }
 
 std::vector<TrafficLightArbiterCore::ExpiredExternalSignal>
@@ -104,7 +104,7 @@ TrafficLightArbiterCore::sweep_expired_external_signals(
   while (it != external_traffic_lights_.end()) {
     const auto & msg_stamp = it->second.first;
     const auto age = (reference_time - msg_stamp).seconds();
-    if (age > tolerance) {
+    if (std::abs(age) > tolerance) {
       expired.push_back({it->first, age});
       it = external_traffic_lights_.erase(it);
     } else {

--- a/perception/autoware_traffic_light_arbiter/src/traffic_light_arbiter_core.cpp
+++ b/perception/autoware_traffic_light_arbiter/src/traffic_light_arbiter_core.cpp
@@ -97,13 +97,6 @@ TrafficLightArbiterCore::ExternalIngestResult TrafficLightArbiterCore::ingest_ex
     external_traffic_lights_[signal.traffic_light_group_id] = std::make_pair(msg_time, signal);
   }
 
-  // Clear perception data if too old relative to this external signal
-  if (
-    std::abs((msg_time - rclcpp::Time(latest_perception_msg_.stamp)).seconds()) >
-    perception_time_tolerance_) {
-    latest_perception_msg_.traffic_light_groups.clear();
-  }
-
   return {true, sweep_expired_external_signals(current_time, external_delay_tolerance_)};
 }
 
@@ -114,11 +107,29 @@ TrafficLightArbiterCore::ArbitrationResult TrafficLightArbiterCore::arbitrate()
   using ElementAndPriority = std::pair<Element, bool>;
   std::unordered_map<lanelet::Id, std::vector<ElementAndPriority>> regulatory_element_signals_map;
 
-  // Create external signals array from stored valid signals
+  // Create external signals array from stored valid signals, tracking the
+  // freshest external stamp for the perception-staleness check below.
   TrafficSignalArray valid_external_signals;
+  rclcpp::Time max_external_stamp{0, 0, RCL_ROS_TIME};
+  bool has_externals = false;
   for (const auto & [id, info] : external_traffic_lights_) {
     valid_external_signals.traffic_light_groups.emplace_back(info.second);
+    if (!has_externals || info.first > max_external_stamp) {
+      max_external_stamp = info.first;
+      has_externals = true;
+    }
   }
+
+  // Ignore perception for this cycle when it lags the freshest external by
+  // more than perception_time_tolerance_. Done as a non-destructive view so
+  // ingest_perception() remains the sole writer of latest_perception_msg_.
+  const auto perception_stamp = rclcpp::Time(latest_perception_msg_.stamp);
+  const bool perception_is_stale =
+    has_externals && (max_external_stamp - perception_stamp).seconds() > perception_time_tolerance_;
+  TrafficSignalArray empty_perception;
+  empty_perception.stamp = latest_perception_msg_.stamp;
+  const auto & effective_perception =
+    perception_is_stale ? empty_perception : latest_perception_msg_;
 
   auto append_predictions = [](auto & map, const auto & groups) {
     for (const auto & group : groups) {
@@ -128,7 +139,7 @@ TrafficLightArbiterCore::ArbitrationResult TrafficLightArbiterCore::arbitrate()
   };
   std::unordered_map<lanelet::Id, std::vector<PredictedTrafficLightState>> predictions_map;
   // add in order from perception msg
-  append_predictions(predictions_map, latest_perception_msg_.traffic_light_groups);
+  append_predictions(predictions_map, effective_perception.traffic_light_groups);
   append_predictions(predictions_map, valid_external_signals.traffic_light_groups);
 
   if (map_regulatory_elements_set_ == nullptr) {
@@ -158,12 +169,12 @@ TrafficLightArbiterCore::ArbitrationResult TrafficLightArbiterCore::arbitrate()
 
   if (enable_signal_matching_) {
     const auto validated_signals =
-      signal_match_validator_->validate_signals(latest_perception_msg_, valid_external_signals);
+      signal_match_validator_->validate_signals(effective_perception, valid_external_signals);
     for (const auto & signal : validated_signals.traffic_light_groups) {
       add_signal_function(signal, false);
     }
   } else {
-    for (const auto & signal : latest_perception_msg_.traffic_light_groups) {
+    for (const auto & signal : effective_perception.traffic_light_groups) {
       add_signal_function(signal, source_priority_ == SourcePriority::PERCEPTION);
     }
 
@@ -212,17 +223,12 @@ TrafficLightArbiterCore::ArbitrationResult TrafficLightArbiterCore::arbitrate()
     output_signals_msg.traffic_light_groups.emplace_back(signal_msg);
   }
 
-  // Compute latest input time across stored sources. The Node compares this
-  // against its trigger stamp to decide whether the published output is
-  // behind some input that has arrived but hasn't yet driven a publish cycle.
-  rclcpp::Time latest_time = rclcpp::Time(latest_perception_msg_.stamp);
-  for (const auto & [id, info] : external_traffic_lights_) {
-    const auto & external_time = info.first;
-    if (external_time > latest_time) {
-      latest_time = external_time;
-    }
-  }
-  result.latest_input_time = latest_time;
+  // Latest input stamp across stored sources. The Node compares this against
+  // its trigger stamp to decide whether the published output is behind some
+  // input that has arrived but hasn't yet driven a publish cycle.
+  result.latest_input_time = (has_externals && max_external_stamp > perception_stamp)
+                               ? max_external_stamp
+                               : perception_stamp;
 
   result.output = std::move(output_signals_msg);
   return result;

--- a/perception/autoware_traffic_light_arbiter/src/traffic_light_arbiter_core.cpp
+++ b/perception/autoware_traffic_light_arbiter/src/traffic_light_arbiter_core.cpp
@@ -45,11 +45,10 @@ void TrafficLightArbiterCore::setTrafficLightIds(std::unordered_set<lanelet::Id>
   map_regulatory_elements_set_ = std::make_unique<std::unordered_set<lanelet::Id>>(std::move(ids));
 }
 
-void TrafficLightArbiterCore::setPedestrianSignals(
-  const std::vector<TrafficLightConstPtr> & pedestrian_signals)
+void TrafficLightArbiterCore::setPedestrianSignalIds(std::unordered_set<lanelet::Id> ids)
 {
   if (enable_signal_matching_) {
-    signal_match_validator_->setPedestrianSignals(pedestrian_signals);
+    signal_match_validator_->setPedestrianSignalIds(std::move(ids));
   }
 }
 

--- a/perception/autoware_traffic_light_arbiter/src/traffic_light_arbiter_core.cpp
+++ b/perception/autoware_traffic_light_arbiter/src/traffic_light_arbiter_core.cpp
@@ -59,7 +59,7 @@ bool TrafficLightArbiterCore::is_external_outdated(
 }
 
 std::vector<TrafficLightArbiterCore::DroppedExternalSignal>
-TrafficLightArbiterCore::cleanup_expired_external_signals(
+TrafficLightArbiterCore::sweep_expired_external_signals(
   const rclcpp::Time & reference_time, double tolerance)
 {
   std::vector<DroppedExternalSignal> dropped;
@@ -77,12 +77,16 @@ TrafficLightArbiterCore::cleanup_expired_external_signals(
   return dropped;
 }
 
-void TrafficLightArbiterCore::ingest_perception(const TrafficSignalArray & msg)
+std::vector<TrafficLightArbiterCore::DroppedExternalSignal>
+TrafficLightArbiterCore::ingest_perception(const TrafficSignalArray & msg)
 {
   latest_perception_msg_ = msg;
+  return sweep_expired_external_signals(rclcpp::Time(msg.stamp), external_time_tolerance_);
 }
 
-void TrafficLightArbiterCore::ingest_external(const TrafficSignalArray & msg)
+std::vector<TrafficLightArbiterCore::DroppedExternalSignal>
+TrafficLightArbiterCore::ingest_external(
+  const TrafficSignalArray & msg, const rclcpp::Time & current_time)
 {
   // Update external traffic lights map with new information
   for (const auto & signal : msg.traffic_light_groups) {
@@ -97,6 +101,8 @@ void TrafficLightArbiterCore::ingest_external(const TrafficSignalArray & msg)
     perception_time_tolerance_) {
     latest_perception_msg_.traffic_light_groups.clear();
   }
+
+  return sweep_expired_external_signals(current_time, external_delay_tolerance_);
 }
 
 TrafficLightArbiterCore::ArbitrationResult TrafficLightArbiterCore::arbitrate()

--- a/perception/autoware_traffic_light_arbiter/src/traffic_light_arbiter_core.cpp
+++ b/perception/autoware_traffic_light_arbiter/src/traffic_light_arbiter_core.cpp
@@ -100,8 +100,7 @@ void TrafficLightArbiterCore::ingestExternal(const TrafficSignalArray & msg)
   }
 }
 
-TrafficLightArbiterCore::ArbitrationResult TrafficLightArbiterCore::arbitrate(
-  const builtin_interfaces::msg::Time & stamp)
+TrafficLightArbiterCore::ArbitrationResult TrafficLightArbiterCore::arbitrate()
 {
   ArbitrationResult result;
 
@@ -130,7 +129,7 @@ TrafficLightArbiterCore::ArbitrationResult TrafficLightArbiterCore::arbitrate(
   }
 
   TrafficSignalArray output_signals_msg;
-  output_signals_msg.stamp = stamp;
+  // stamp deliberately left default — the Node owns stamp inheritance.
 
   if (map_regulatory_elements_set_->empty()) {
     result.output = std::move(output_signals_msg);
@@ -206,7 +205,9 @@ TrafficLightArbiterCore::ArbitrationResult TrafficLightArbiterCore::arbitrate(
     output_signals_msg.traffic_light_groups.emplace_back(signal_msg);
   }
 
-  // Calculate latest time from available sources
+  // Compute latest input time across stored sources. The Node compares this
+  // against its trigger stamp to decide whether the published output is
+  // behind some input that has arrived but hasn't yet driven a publish cycle.
   rclcpp::Time latest_time = rclcpp::Time(latest_perception_msg_.stamp);
   for (const auto & [id, info] : external_traffic_lights_) {
     const auto & external_time = info.first;
@@ -214,10 +215,7 @@ TrafficLightArbiterCore::ArbitrationResult TrafficLightArbiterCore::arbitrate(
       latest_time = external_time;
     }
   }
-
-  if (rclcpp::Time(output_signals_msg.stamp) < latest_time) {
-    result.output_not_latest = true;
-  }
+  result.latest_input_time = latest_time;
 
   result.output = std::move(output_signals_msg);
   return result;

--- a/perception/autoware_traffic_light_arbiter/src/traffic_light_arbiter_core.cpp
+++ b/perception/autoware_traffic_light_arbiter/src/traffic_light_arbiter_core.cpp
@@ -45,10 +45,10 @@ void TrafficLightArbiterCore::set_traffic_light_ids(std::unordered_set<lanelet::
   map_regulatory_elements_set_ = std::make_unique<std::unordered_set<lanelet::Id>>(std::move(ids));
 }
 
-void TrafficLightArbiterCore::set_pedestrian_signal_ids(std::unordered_set<lanelet::Id> ids)
+void TrafficLightArbiterCore::set_pedestrian_traffic_light_ids(std::unordered_set<lanelet::Id> ids)
 {
   if (enable_signal_matching_) {
-    signal_match_validator_->set_pedestrian_signal_ids(std::move(ids));
+    signal_match_validator_->set_pedestrian_traffic_light_ids(std::move(ids));
   }
 }
 

--- a/perception/autoware_traffic_light_arbiter/src/traffic_light_arbiter_core.cpp
+++ b/perception/autoware_traffic_light_arbiter/src/traffic_light_arbiter_core.cpp
@@ -58,26 +58,26 @@ bool TrafficLightArbiterCore::is_external_outdated(
   return std::abs((current_time - msg_stamp).seconds()) > external_delay_tolerance_;
 }
 
-std::vector<TrafficLightArbiterCore::DroppedExternalSignal>
+std::vector<TrafficLightArbiterCore::ExpiredExternalSignal>
 TrafficLightArbiterCore::sweep_expired_external_signals(
   const rclcpp::Time & reference_time, double tolerance)
 {
-  std::vector<DroppedExternalSignal> dropped;
+  std::vector<ExpiredExternalSignal> expired;
   auto it = external_traffic_lights_.begin();
   while (it != external_traffic_lights_.end()) {
     const auto & msg_stamp = it->second.first;
     const auto age = (reference_time - msg_stamp).seconds();
     if (std::abs(age) > tolerance) {
-      dropped.push_back({it->first, age});
+      expired.push_back({it->first, age});
       it = external_traffic_lights_.erase(it);
     } else {
       ++it;
     }
   }
-  return dropped;
+  return expired;
 }
 
-std::vector<TrafficLightArbiterCore::DroppedExternalSignal>
+std::vector<TrafficLightArbiterCore::ExpiredExternalSignal>
 TrafficLightArbiterCore::ingest_perception(const TrafficSignalArray & msg)
 {
   latest_perception_msg_ = msg;

--- a/perception/autoware_traffic_light_arbiter/src/traffic_light_arbiter_core.cpp
+++ b/perception/autoware_traffic_light_arbiter/src/traffic_light_arbiter_core.cpp
@@ -13,17 +13,61 @@
 // limitations under the License.
 
 #include <autoware/traffic_light_arbiter/traffic_light_arbiter_core.hpp>
+#include <autoware_lanelet2_extension/utility/query.hpp>
+
+#include <lanelet2_core/LaneletMap.h>
+#include <lanelet2_core/primitives/BasicRegulatoryElements.h>
 
 #include <algorithm>
 #include <map>
 #include <memory>
 #include <tuple>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
 namespace autoware::traffic_light
 {
+
+namespace
+{
+
+std::unordered_set<lanelet::Id> extract_traffic_light_ids(const lanelet::LaneletMapConstPtr & map)
+{
+  namespace query = lanelet::utils::query;
+
+  const auto all_lanelets = query::laneletLayer(map);
+
+  std::unordered_set<lanelet::Id> traffic_light_ids;
+  for (const auto & lanelet : all_lanelets) {
+    const auto traffic_lights = lanelet.regulatoryElementsAs<const lanelet::TrafficLight>();
+    for (const auto & traffic_light : traffic_lights) {
+      traffic_light_ids.emplace(traffic_light->id());
+    }
+  }
+  return traffic_light_ids;
+}
+
+std::unordered_set<lanelet::Id> extract_pedestrian_traffic_light_ids(
+  const lanelet::LaneletMapConstPtr & map)
+{
+  namespace query = lanelet::utils::query;
+
+  const auto all_lanelets = query::laneletLayer(map);
+  const auto crosswalks = query::crosswalkLanelets(all_lanelets);
+
+  std::unordered_set<lanelet::Id> pedestrian_traffic_light_ids;
+  for (const auto & crosswalk : crosswalks) {
+    const auto traffic_lights = crosswalk.regulatoryElementsAs<const lanelet::TrafficLight>();
+    for (const auto & traffic_light : traffic_lights) {
+      pedestrian_traffic_light_ids.emplace(traffic_light->id());
+    }
+  }
+  return pedestrian_traffic_light_ids;
+}
+
+}  // namespace
 
 TrafficLightArbiterCore::TrafficLightArbiterCore(
   SourcePriority source_priority, bool enable_signal_matching, double external_delay_tolerance,
@@ -39,15 +83,13 @@ TrafficLightArbiterCore::TrafficLightArbiterCore(
   }
 }
 
-void TrafficLightArbiterCore::set_traffic_light_ids(std::unordered_set<lanelet::Id> ids)
+void TrafficLightArbiterCore::set_map(const lanelet::LaneletMapConstPtr & map)
 {
-  map_regulatory_elements_set_ = std::make_unique<std::unordered_set<lanelet::Id>>(std::move(ids));
-}
-
-void TrafficLightArbiterCore::set_pedestrian_traffic_light_ids(std::unordered_set<lanelet::Id> ids)
-{
+  map_regulatory_elements_set_ =
+    std::make_unique<std::unordered_set<lanelet::Id>>(extract_traffic_light_ids(map));
   if (enable_signal_matching_) {
-    signal_match_validator_->set_pedestrian_traffic_light_ids(std::move(ids));
+    signal_match_validator_->set_pedestrian_traffic_light_ids(
+      extract_pedestrian_traffic_light_ids(map));
   }
 }
 

--- a/perception/autoware_traffic_light_arbiter/test/test_traffic_arbiter_characteristic.cpp
+++ b/perception/autoware_traffic_light_arbiter/test/test_traffic_arbiter_characteristic.cpp
@@ -62,7 +62,7 @@ constexpr lanelet::Id vehicle_signal_b = 1002;
 constexpr lanelet::Id pedestrian_signal = 2001;
 
 // Intentionally not installed on the map; used by tests as the "off-map id"
-// probe to exercise the WARN+skip branch in arbitrateAndPublish.
+// probe to exercise the WARN+skip branch in arbitrate_and_publish.
 constexpr lanelet::Id off_map_probe = 9999;
 }  // namespace map_ids
 
@@ -134,7 +134,7 @@ LaneletMapBin build_minimal_map_bin()
 
 // Variant of build_minimal_map_bin with a single road lanelet but no Traffic
 // Light regulatory elements. Used to drive the
-// "map_regulatory_elements_set_->empty()" branch in arbitrateAndPublish.
+// "map_regulatory_elements_set_->empty()" branch in arbitrate_and_publish.
 LaneletMapBin build_empty_map_bin()
 {
   Lanelet road = make_lanelet(0.0, -3.0, AttributeValueString::Road);
@@ -782,7 +782,7 @@ TEST_F(ArbiterCharacteristic, priorityBasedOffMapIdDropped)
 //    input validation, priority overrides, predictions.
 // ---------------------------------------------------------------------------
 
-// Before the vector_map arrives, arbitrateAndPublish early-returns and no
+// Before the vector_map arrives, arbitrate_and_publish early-returns and no
 // TrafficLightGroupArray is emitted.
 TEST_F(ArbiterCharacteristic, perceptionBeforeMapProducesNoOutput)
 {
@@ -794,7 +794,7 @@ TEST_F(ArbiterCharacteristic, perceptionBeforeMapProducesNoOutput)
     t0_, map_ids::vehicle_signal_a,
     {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)}));
 
-  // Assert: arbitrateAndPublish should early-return when no map has been
+  // Assert: arbitrate_and_publish should early-return when no map has been
   // received. Content alone cannot prove this (a default-constructed
   // message looks identical to no publish at all), so we read the counter.
   EXPECT_EQ(arbiter_publish_count_, 0u);
@@ -802,7 +802,7 @@ TEST_F(ArbiterCharacteristic, perceptionBeforeMapProducesNoOutput)
 
 // A non-null but signal-free map should yield an empty TrafficLightGroupArray
 // (stamp set, no groups). Exercises the
-// "map_regulatory_elements_set_->empty()" branch in arbitrateAndPublish.
+// "map_regulatory_elements_set_->empty()" branch in arbitrate_and_publish.
 TEST_F(ArbiterCharacteristic, emptyMapProducesEmptyOutput)
 {
   // Arrange: replace the default minimal map with a signal-free one.
@@ -845,7 +845,7 @@ TEST_F(ArbiterCharacteristic, unknownSourcePriorityFallsBackToConfidence)
 
 // With source_priority=perception, the perception value wins even when its
 // confidence is much lower than external's. Pins the PERCEPTION priority
-// branch in arbitrateAndPublish.
+// branch in arbitrate_and_publish.
 TEST_F(ArbiterCharacteristic, priorityFlagOverridesHigherConfidence)
 {
   // Arrange
@@ -911,7 +911,7 @@ TEST_F(ArbiterCharacteristic, multipleExternalSourcesAccumulate)
 }
 
 // An external message whose stamp is older than external_delay_tolerance
-// is dropped before reaching arbitrateAndPublish, so the last published
+// is dropped before reaching arbitrate_and_publish, so the last published
 // content stays as the earlier perception value.
 TEST_F(ArbiterCharacteristic, externalDelayToleranceDropsStaleMessage)
 {
@@ -934,12 +934,12 @@ TEST_F(ArbiterCharacteristic, externalDelayToleranceDropsStaleMessage)
 }
 
 // When perception arrives past external_time_tolerance after a stored
-// external entry, cleanupExpiredExternalSignals purges that entry so the
+// external entry, cleanup_expired_external_signals purges that entry so the
 // upcoming publish reflects only perception.
 TEST_F(ArbiterCharacteristic, externalTimeToleranceCleanupOnPerception)
 {
   // Arrange: seed an external entry that should be purged by the perception
-  // arrival's cleanupExpiredExternalSignals (perception is past
+  // arrival's cleanup_expired_external_signals (perception is past
   // external_time_tolerance newer than the stored external).
   start_arbiter(false, "confidence");  // priority-based mode, "confidence" priority
   publish_map();
@@ -956,7 +956,7 @@ TEST_F(ArbiterCharacteristic, externalTimeToleranceCleanupOnPerception)
   EXPECT_EQ(observed_color(map_ids::vehicle_signal_a), TrafficLightElement::GREEN);
 }
 
-// onExternalMsg compares its own stamp to latest_perception_msg_.stamp; if
+// on_external_msg compares its own stamp to latest_perception_msg_.stamp; if
 // the gap exceeds perception_time_tolerance it clears the stored perception
 // groups so the upcoming publish reflects only external.
 TEST_F(ArbiterCharacteristic, perceptionTimeToleranceClearsLatestPerception)


### PR DESCRIPTION
## Description

Separate arbitration logic from the ROS node in `autoware_traffic_light_arbiter`. The new `TrafficLightArbiterCore` class owns all arbitration state and decisions and has no `rclcpp` dependency in its function bodies. `TrafficLightArbiter` (the ROS node) becomes a thin adapter: parameter loading, sub/pub wiring, msg ↔ pure-data conversion, publish, and logging. Observable behavior is preserved — all existing tests (`test_node.cpp` + `test_traffic_arbiter_characteristic.cpp`, 31 cases total) pass unchanged.

### Features

- **`TrafficLightArbiterCore` class** — ROS-free in body. Owns arbitration state (map ids, pedestrian validator, perception buffer, external signal cache) and exposes `set_map`, `ingest_perception`, `ingest_external`, `arbitrate`
- **`TrafficLightArbiter` (the Node) reduced to a thin adapter** — covers only param loading, sub/pub wiring, message conversion, publish, and logging
- **Diagnostics flow as return-then-log** — Core returns `ArbitrationResult` (with `output`, `off_map_signal_ids`, `latest_input_time`) and `vector<ExpiredExternalSignal>` (from `ingest_perception` / `ingest_external`); the Node consumes these and emits the corresponding `RCLCPP_WARN_*` / `RCLCPP_DEBUG`
- **`arbitrate()` no longer takes a `stamp` argument** — output stamping (an I/O convention) and staleness detection (a monitoring concern) are both moved to the Node, where they belong. Core's `latest_input_time` field supplies the raw datum the Node needs for the staleness comparison
- **`set_map(const lanelet::LaneletMapConstPtr &)`** — Core takes the parsed LaneletMap and extracts the regulatory-element ID subsets it consumes (vehicle traffic lights, plus pedestrian traffic lights when signal matching is enabled) internally. The Node only parses the `LaneletMapBin` msg and forwards the resulting map; it doesn't need to know which subsets the arbiter cares about.

### Architecture

The Node ↔ Core split:

| Concern | Where |
| --- | --- |
| Param load / sub-pub wiring / `LaneletMapBin` → `LaneletMap` parsing / stamp inheritance / logging | `TrafficLightArbiter` (Node) |
| Arbitration state (map id set extracted from the parsed `LaneletMap`, validator, perception buffer, external cache) | `TrafficLightArbiterCore` |
| `ingest_perception` / `ingest_external` / `arbitrate` | `TrafficLightArbiterCore` |
| Matching / priority routing + per-shape highest-confidence selection | `TrafficLightArbiterCore::arbitrate` |

## Related links

**Parent Issue:**

- None

**Built on:**

- #12632 (`test(autoware_traffic_light_arbiter): add characterization test suite`) — its 24 characterization tests serve as the safety net for this refactor; already merged.

## How was this PR tested?

`colcon build` + `colcon test` against the package. All 31 tests pass without test-side changes: `_test` (7/7) + `_characteristic_test` (24/24), plus 4 lint checks. `RCLCPP_COMPONENTS_REGISTER_NODE` is preserved so the node still loads as a composable component.

## Notes for reviewers

### Design choices worth flagging

- `ArbitrationResult.output` is `std::optional<TrafficSignalArray>` so "no map received yet" (`nullopt`) and "map received, no traffic lights" (empty `traffic_light_groups`) can be distinguished. The Node uses this: nullopt → suppress publish + WARN; empty value → publish empty msg silently.
- Core methods that mutate state (`ingest_*`, `set_*`) are non-const; `arbitrate()` is currently non-const because it calls `signal_match_validator_->validate_signals(...)` which is non-const. Marking validator const is queued as a follow-up.

## Interface changes

None. Topics and all five parameters (`external_delay_tolerance`, `external_time_tolerance`, `perception_time_tolerance`, `source_priority`, `enable_signal_matching`) are unchanged in name, type, default, and effect.

## Effects on system behavior

**Downstream-observable**: None. Publish content, timing, and emit count are preserved; parameter handling and log message contents are identical.

**Internal-observable (not affecting downstream)**:

- `RCLCPP_WARN_THROTTLE` macro call sites have moved (editor line numbers change), but startup warning behavior is unchanged.
- DEBUG cleanup log lines flush from a Node-side loop after Core's `ingest_perception` / `ingest_external` return; lag is sub-tick.
