### PR TITLE
feat: add reverse goal support for reverse oriented goal poses

### DIFF
--- a/planning/autoware_mission_planner_universe/src/lanelet2_plugins/default_planner.cpp
+++ b/planning/autoware_mission_planner_universe/src/lanelet2_plugins/default_planner.cpp
@@ -43,6 +43,7 @@
 #include <lanelet2_core/geometry/Lanelet.h>
 
 #include <limits>
+#include <string>
 #include <vector>
 
 namespace autoware::mission_planner_universe::lanelet2
@@ -73,6 +74,17 @@ lanelet::ConstLanelets get_lanelets_to(
     backward ? lanelets.begin() : lanelets.end(), ahead_lanelets.begin(), ahead_lanelets.end());
 
   return lanelets;
+}
+
+/**
+ * @brief Check if a lanelet has the direction_change tag
+ * @param lanelet The lanelet to check
+ * @return true if the lanelet has the direction_change attribute set to "yes"
+ */
+bool hasDirectionChangeAreaTag(const lanelet::ConstLanelet & lanelet)
+{
+  const std::string direction_change_tag = lanelet.attributeOr("direction_change", "none");
+  return direction_change_tag == "yes";
 }
 }  // namespace
 

--- a/planning/autoware_mission_planner_universe/src/lanelet2_plugins/default_planner.cpp
+++ b/planning/autoware_mission_planner_universe/src/lanelet2_plugins/default_planner.cpp
@@ -81,7 +81,7 @@ lanelet::ConstLanelets get_lanelets_to(
  * @param lanelet The lanelet to check
  * @return true if the lanelet has the direction_change attribute set to "yes"
  */
-bool hasDirectionChangeAreaTag(const lanelet::ConstLanelet & lanelet)
+bool hasDirectionChangeTag(const lanelet::ConstLanelet & lanelet)
 {
   const std::string direction_change_tag = lanelet.attributeOr("direction_change", "none");
   return direction_change_tag == "yes";
@@ -295,8 +295,16 @@ bool DefaultPlanner::is_goal_valid(const geometry_msgs::msg::Pose & goal)
     const auto goal_yaw = tf2::getYaw(goal.orientation);
     const auto angle_diff = autoware_utils::normalize_radian(lane_yaw - goal_yaw);
     const double th_angle = autoware_utils::deg2rad(param_.goal_angle_threshold_deg);
+    const bool has_direction_change_tag = hasDirectionChangeTag(closest_shoulder_lanelet);
     if (std::abs(angle_diff) < th_angle) {
       return true;
+    }
+    if (has_direction_change_tag) {
+      const double reversed_angle_diff =
+        std::abs(autoware_utils::normalize_radian(angle_diff - M_PI));
+      if (reversed_angle_diff < th_angle) {
+        return true;
+      }
     }
   }
   const auto road_lanelets_at_goal = route_handler_.getRoadLaneletsAtPose(goal);
@@ -358,8 +366,16 @@ bool DefaultPlanner::is_goal_valid(const geometry_msgs::msg::Pose & goal)
     const auto angle_diff = autoware_utils::normalize_radian(lane_yaw - goal_yaw);
 
     const double th_angle = autoware_utils::deg2rad(param_.goal_angle_threshold_deg);
+    const bool has_direction_change_tag = hasDirectionChangeTag(closest_lanelet_to_goal);
     if (std::abs(angle_diff) < th_angle) {
       return true;
+    }
+    if (has_direction_change_tag) {
+      const double reversed_angle_diff =
+        std::abs(autoware_utils::normalize_radian(angle_diff - M_PI));
+      if (reversed_angle_diff < th_angle) {
+        return true;
+      }
     }
   }
 


### PR DESCRIPTION
## Description

This PR is for reverse-oriented goal validation in the `autoware_mission_planner_universe`. When the goal pose lies in a lanelet tagged with `direction_change` lane, the planner accepts goals whose orientation is opposite to the lane direction (reverse), in addition to forward-aligned goals. This enables routes that end in reverse in designated areas (e.g. after a cusp maneuver).

## Related links

**Parent Issue:**

- [TierIV Internal Link](https://tier4.atlassian.net/browse/T4DEV-2508)

<!-- ⬇️🟢
**Private Links:**

1. Design Document [Tier IV Internal Link](https://tier4.atlassian.net/wiki/spaces/SI/pages/4651221271/Detailed+Design+Document+Mission+Planner+Reverse-Oriented+Goal+in+direction_change_area)
2. 

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

1. Evaluator Links [1](https://evaluation.tier4.jp/evaluation/reports/307fe9bd-f02f-5fbb-85d1-6ce1c5d2fd8f?project_id=autoware_dev), [2](https://evaluation.tier4.jp/evaluation/reports/93955943-b112-537e-bdd5-f31b5e8524cd?project_id=autoware_dev), [3](https://evaluation.tier4.jp/evaluation/reports/fbb1cb46-9223-523d-ba10-9717e74af415?project_id=autoware_dev) 
  - The above links for Evaluator got failed  because `rosdep` cannot locate `rosdep` definition for [`autoware_system_designer`] 

## Notes for reviewers

None.

## Interface changes

None

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior 

1.  the planner accepts goals whose orientation is opposite to the lane direction (reverse), in addition to forward-aligned goals. 
