### PR TITLE
fix(autoware_image_projection_based_fusion): adding 2 new classes for perception

### DIFF
--- a/perception/autoware_image_projection_based_fusion/config/roi_cluster_fusion.param.yaml
+++ b/perception/autoware_image_projection_based_fusion/config/roi_cluster_fusion.param.yaml
@@ -16,6 +16,8 @@
       MOTORCYCLE : 0.65
       BICYCLE : 0.65
       PEDESTRIAN : 0.2
+      ANIMAL : 0.1
+      HAZARD : 0.1
     remove_unknown: true
 
     # Pedestrian size validation parameters

--- a/perception/autoware_image_projection_based_fusion/config/roi_pointcloud_fusion.param.yaml
+++ b/perception/autoware_image_projection_based_fusion/config/roi_pointcloud_fusion.param.yaml
@@ -15,3 +15,5 @@
       MOTORCYCLE: false
       BICYCLE: true
       PEDESTRIAN: true
+      ANIMAL: true
+      HAZARD: true

--- a/perception/autoware_image_projection_based_fusion/include/autoware/image_projection_based_fusion/utils/utils.hpp
+++ b/perception/autoware_image_projection_based_fusion/include/autoware/image_projection_based_fusion/utils/utils.hpp
@@ -69,6 +69,8 @@ struct ObjClassIoUThresh
   float MOTORCYCLE;
   float BICYCLE;
   float PEDESTRIAN;
+  float ANIMAL;
+  float HAZARD;
   float get_class_iou_thresh(const uint8_t label);
 };
 

--- a/perception/autoware_image_projection_based_fusion/schema/roi_cluster_fusion.schema.json
+++ b/perception/autoware_image_projection_based_fusion/schema/roi_cluster_fusion.schema.json
@@ -106,6 +106,20 @@
               "default": 0.65,
               "minimum": 0.0,
               "maximum": 1.0
+            },
+            "ANIMAL": {
+              "type": "number",
+              "description": "IoU threshold for ANIMAL objects.",
+              "default": 0.1,
+              "minimum": 0.0,
+              "maximum": 1.0
+            },
+            "HAZARD": {
+              "type": "number",
+              "description": "IoU threshold for HAZARD objects.",
+              "default": 0.1,
+              "minimum": 0.0,
+              "maximum": 1.0
             }
           },
           "required": [
@@ -116,7 +130,9 @@
             "TRAILER",
             "MOTORCYCLE",
             "BICYCLE",
-            "PEDESTRIAN"
+            "PEDESTRIAN",
+            "ANIMAL",
+            "HAZARD"
           ]
         },
         "remove_unknown": {

--- a/perception/autoware_image_projection_based_fusion/schema/roi_pointcloud_fusion.schema.json
+++ b/perception/autoware_image_projection_based_fusion/schema/roi_pointcloud_fusion.schema.json
@@ -48,6 +48,16 @@
               "type": "boolean",
               "default": true,
               "description": "Whether to enable fusion for objects with PEDESTRIAN class."
+            },
+            "ANIMAL": {
+              "type": "boolean",
+              "default": true,
+              "description": "Whether to enable fusion for objects with ANIMAL class."
+            },
+            "HAZARD": {
+              "type": "boolean",
+              "default": true,
+              "description": "Whether to enable fusion for objects with HAZARD class."
             }
           },
           "required": [
@@ -58,7 +68,9 @@
             "TRAILER",
             "MOTORCYCLE",
             "BICYCLE",
-            "PEDESTRIAN"
+            "PEDESTRIAN",
+            "ANIMAL",
+            "HAZARD"
           ]
         },
         "override_class_with_unknown": {

--- a/perception/autoware_image_projection_based_fusion/src/roi_cluster_fusion/node.cpp
+++ b/perception/autoware_image_projection_based_fusion/src/roi_cluster_fusion/node.cpp
@@ -53,6 +53,8 @@ RoiClusterFusionNode::RoiClusterFusionNode(const rclcpp::NodeOptions & options)
   iou_threshold_.PEDESTRIAN = declare_parameter<double>("iou_threshold.PEDESTRIAN");
   iou_threshold_.TRUCK = declare_parameter<double>("iou_threshold.TRUCK");
   iou_threshold_.UNKNOWN = declare_parameter<double>("iou_threshold.UNKNOWN");
+  iou_threshold_.ANIMAL = declare_parameter<double>("iou_threshold.ANIMAL");
+  iou_threshold_.HAZARD = declare_parameter<double>("iou_threshold.HAZARD");
 
   remove_unknown_ = declare_parameter<bool>("remove_unknown");
   fusion_distance_ = declare_parameter<double>("fusion_distance");

--- a/perception/autoware_image_projection_based_fusion/src/roi_pointcloud_fusion/node.cpp
+++ b/perception/autoware_image_projection_based_fusion/src/roi_pointcloud_fusion/node.cpp
@@ -39,7 +39,7 @@ using Classification = autoware_perception_msgs::msg::ObjectClassification;
 RoiPointCloudFusionNode::RoiPointCloudFusionNode(const rclcpp::NodeOptions & options)
 : FusionNode<PointCloudMsgType, RoiMsgType, ClusterMsgType>("roi_pointcloud_fusion", options)
 {
-  const std::array<std::pair<std::string, uint8_t>, 8> fusion_class_names = {
+  const std::array<std::pair<std::string, uint8_t>, 10> fusion_class_names = {
     {{"UNKNOWN", Classification::UNKNOWN},
      {"CAR", Classification::CAR},
      {"TRUCK", Classification::TRUCK},
@@ -47,7 +47,9 @@ RoiPointCloudFusionNode::RoiPointCloudFusionNode(const rclcpp::NodeOptions & opt
      {"TRAILER", Classification::TRAILER},
      {"MOTORCYCLE", Classification::MOTORCYCLE},
      {"BICYCLE", Classification::BICYCLE},
-     {"PEDESTRIAN", Classification::PEDESTRIAN}}};
+     {"PEDESTRIAN", Classification::PEDESTRIAN},
+     {"ANIMAL", Classification::ANIMAL},
+     {"HAZARD", Classification::HAZARD}}};
   for (const auto & [class_name, label] : fusion_class_names) {
     fusion_enabled_classes_[label] =
       declare_parameter<bool>("fusion_enabled_classes." + class_name);

--- a/perception/autoware_image_projection_based_fusion/src/utils/utils.cpp
+++ b/perception/autoware_image_projection_based_fusion/src/utils/utils.cpp
@@ -45,6 +45,10 @@ float ObjClassIoUThresh::get_class_iou_thresh(const uint8_t label)
       return BICYCLE;
     case Label::PEDESTRIAN:
       return PEDESTRIAN;
+    case Label::ANIMAL:
+      return ANIMAL;
+    case Label::HAZARD:
+      return HAZARD;
     default:
       return UNKNOWN;
   }


### PR DESCRIPTION
## Description
- For issue: https://github.com/autowarefoundation/autoware/issues/7137
- Need merge after https://github.com/autowarefoundation/autoware_launch/pull/1855
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
