### PR TITLE
fix(autoware_joy_controller): update joy controller manual control topics

### DIFF
--- a/control/autoware_joy_controller/README.md
+++ b/control/autoware_joy_controller/README.md
@@ -36,35 +36,35 @@ ros2 launch autoware_joy_controller joy_controller.launch.xml config_file:=/path
 
 ### Output topics
 
-| Name                           | Type                                                 | Description                                   |
-| ------------------------------ | ---------------------------------------------------- | --------------------------------------------- |
-| `~/output/control_command`     | autoware_control_msgs::msg::Control                  | lateral and longitudinal control command      |
-| `~/output/pedals_command`      | autoware_adapi_v1_msgs::msg::PedalsCommand           | manual pedals command for AD API              |
-| `~/output/steering_command`    | autoware_adapi_v1_msgs::msg::SteeringCommand         | manual steering command for AD API            |
-| `~/output/gear_cmd`            | autoware_vehicle_msgs::msg::GearCommand              | gear command for AD API                       |
-| `~/output/turn_indicators_cmd` | autoware_vehicle_msgs::msg::TurnIndicatorsCommand    | turn indicator command for AD API             |
-| `~/output/hazard_lights_cmd`   | autoware_vehicle_msgs::msg::HazardLightsCommand      | hazard light command for AD API               |
-| `~/output/gate_mode`           | tier4_control_msgs::msg::GateMode                    | gate mode (Auto or External)                  |
-| `~/output/operator_heartbeat`  | autoware_adapi_v1_msgs::msg::ManualOperatorHeartbeat | manual operator heartbeat for AD API          |
-| `~/output/vehicle_engage`      | autoware_vehicle_msgs::msg::Engage                   | vehicle engage                                |
+| Name                           | Type                                                 | Description                              |
+| ------------------------------ | ---------------------------------------------------- | ---------------------------------------- |
+| `~/output/control_command`     | autoware_control_msgs::msg::Control                  | lateral and longitudinal control command |
+| `~/output/pedals_command`      | autoware_adapi_v1_msgs::msg::PedalsCommand           | manual pedals command for AD API         |
+| `~/output/steering_command`    | autoware_adapi_v1_msgs::msg::SteeringCommand         | manual steering command for AD API       |
+| `~/output/gear_cmd`            | autoware_vehicle_msgs::msg::GearCommand              | gear command for AD API                  |
+| `~/output/turn_indicators_cmd` | autoware_vehicle_msgs::msg::TurnIndicatorsCommand    | turn indicator command for AD API        |
+| `~/output/hazard_lights_cmd`   | autoware_vehicle_msgs::msg::HazardLightsCommand      | hazard light command for AD API          |
+| `~/output/gate_mode`           | tier4_control_msgs::msg::GateMode                    | gate mode (Auto or External)             |
+| `~/output/operator_heartbeat`  | autoware_adapi_v1_msgs::msg::ManualOperatorHeartbeat | manual operator heartbeat for AD API     |
+| `~/output/vehicle_engage`      | autoware_vehicle_msgs::msg::Engage                   | vehicle engage                           |
 
 ## Parameters
 
-| Parameter                 | Type   | Description                                                                                                        |
-| ------------------------- | ------ | ------------------------------------------------------------------------------------------------------------------ |
-| `joy_type`                | string | joy controller type (default: DS4)                                                                                 |
-| `update_rate`             | double | update rate to publish control commands                                                                            |
-| `accel_ratio`             | double | ratio to calculate acceleration (commanded acceleration is ratio \* operation)                                     |
-| `brake_ratio`             | double | ratio to calculate deceleration (commanded acceleration is -ratio \* operation)                                    |
-| `steer_ratio`             | double | ratio to calculate deceleration (commanded steer is ratio \* operation)                                            |
-| `steering_angle_velocity` | double | steering angle velocity for operation                                                                              |
-| `accel_sensitivity`       | double | sensitivity to calculate pedal throttle output (commanded acceleration is pow(operation, 1 / sensitivity))         |
-| `brake_sensitivity`       | double | sensitivity to calculate pedal brake output (commanded acceleration is pow(operation, 1 / sensitivity))            |
-| `raw_control`             | bool   | skip input odometry if true                                                                                        |
-| `velocity_gain`           | double | ratio to calculate velocity by acceleration                                                                        |
-| `max_forward_velocity`    | double | absolute max velocity to go forward                                                                                |
-| `max_backward_velocity`   | double | absolute max velocity to go backward                                                                               |
-| `backward_accel_ratio`    | double | ratio to calculate deceleration (commanded acceleration is -ratio \* operation)                                    |
+| Parameter                 | Type   | Description                                                                                                |
+| ------------------------- | ------ | ---------------------------------------------------------------------------------------------------------- |
+| `joy_type`                | string | joy controller type (default: DS4)                                                                         |
+| `update_rate`             | double | update rate to publish control commands                                                                    |
+| `accel_ratio`             | double | ratio to calculate acceleration (commanded acceleration is ratio \* operation)                             |
+| `brake_ratio`             | double | ratio to calculate deceleration (commanded acceleration is -ratio \* operation)                            |
+| `steer_ratio`             | double | ratio to calculate deceleration (commanded steer is ratio \* operation)                                    |
+| `steering_angle_velocity` | double | steering angle velocity for operation                                                                      |
+| `accel_sensitivity`       | double | sensitivity to calculate pedal throttle output (commanded acceleration is pow(operation, 1 / sensitivity)) |
+| `brake_sensitivity`       | double | sensitivity to calculate pedal brake output (commanded acceleration is pow(operation, 1 / sensitivity))    |
+| `raw_control`             | bool   | skip input odometry if true                                                                                |
+| `velocity_gain`           | double | ratio to calculate velocity by acceleration                                                                |
+| `max_forward_velocity`    | double | absolute max velocity to go forward                                                                        |
+| `max_backward_velocity`   | double | absolute max velocity to go backward                                                                       |
+| `backward_accel_ratio`    | double | ratio to calculate deceleration (commanded acceleration is -ratio \* operation)                            |
 
 ## P65 Joystick Key Map
 

--- a/control/autoware_joy_controller/README.md
+++ b/control/autoware_joy_controller/README.md
@@ -34,10 +34,14 @@ ros2 launch autoware_joy_controller joy_controller.launch.xml config_file:=/path
 | ----------------------------------- | --------------------------------------------------- | ---------------------------------------- |
 | `~/output/control_command`          | autoware_control_msgs::msg::Control                 | lateral and longitudinal control command |
 | `~/output/external_control_command` | tier4_external_api_msgs::msg::ControlCommandStamped | lateral and longitudinal control command |
-| `~/output/shift`                    | tier4_external_api_msgs::msg::GearShiftStamped      | gear command                             |
-| `~/output/turn_signal`              | tier4_external_api_msgs::msg::TurnSignalStamped     | turn signal command                      |
+| `~/output/pedals_command`           | autoware_adapi_v1_msgs::msg::PedalsCommand          | manual pedals command for latest Autoware |
+| `~/output/steering_command`         | autoware_adapi_v1_msgs::msg::SteeringCommand        | manual steering command for latest Autoware |
+| `~/output/shift`                    | autoware_vehicle_msgs::msg::GearCommand             | gear command                             |
+| `~/output/turn_signal`              | autoware_vehicle_msgs::msg::TurnIndicatorsCommand   | turn indicator command                   |
+| `~/output/hazard_lights`            | autoware_vehicle_msgs::msg::HazardLightsCommand     | hazard light command                     |
 | `~/output/gate_mode`                | tier4_control_msgs::msg::GateMode                   | gate mode (Auto or External)             |
 | `~/output/heartbeat`                | tier4_external_api_msgs::msg::Heartbeat             | heartbeat                                |
+| `~/output/operator_heartbeat`       | autoware_adapi_v1_msgs::msg::ManualOperatorHeartbeat | manual operator heartbeat for latest Autoware |
 | `~/output/vehicle_engage`           | autoware_vehicle_msgs::msg::Engage                  | vehicle engage                           |
 
 ## Parameters

--- a/control/autoware_joy_controller/README.md
+++ b/control/autoware_joy_controller/README.md
@@ -4,6 +4,12 @@
 
 `autoware_joy_controller` is the package to convert a joy msg to autoware commands (e.g. steering wheel, shift, turn signal, engage) for a vehicle.
 
+This package targets the AD API manual control pipeline:
+
+`joy_controller -> external_cmd_selector -> external_cmd_converter -> vehicle_cmd_gate`
+
+Legacy `tier4_external_api_msgs` manual command topics are not published by this package.
+
 ## Usage
 
 ### ROS 2 launch
@@ -30,19 +36,17 @@ ros2 launch autoware_joy_controller joy_controller.launch.xml config_file:=/path
 
 ### Output topics
 
-| Name                                | Type                                                 | Description                                   |
-| ----------------------------------- | ---------------------------------------------------- | --------------------------------------------- |
-| `~/output/control_command`          | autoware_control_msgs::msg::Control                  | lateral and longitudinal control command      |
-| `~/output/external_control_command` | tier4_external_api_msgs::msg::ControlCommandStamped  | lateral and longitudinal control command      |
-| `~/output/pedals_command`           | autoware_adapi_v1_msgs::msg::PedalsCommand           | manual pedals command for latest Autoware     |
-| `~/output/steering_command`         | autoware_adapi_v1_msgs::msg::SteeringCommand         | manual steering command for latest Autoware   |
-| `~/output/shift`                    | autoware_vehicle_msgs::msg::GearCommand              | gear command                                  |
-| `~/output/turn_signal`              | autoware_vehicle_msgs::msg::TurnIndicatorsCommand    | turn indicator command                        |
-| `~/output/hazard_lights`            | autoware_vehicle_msgs::msg::HazardLightsCommand      | hazard light command                          |
-| `~/output/gate_mode`                | tier4_control_msgs::msg::GateMode                    | gate mode (Auto or External)                  |
-| `~/output/heartbeat`                | tier4_external_api_msgs::msg::Heartbeat              | heartbeat                                     |
-| `~/output/operator_heartbeat`       | autoware_adapi_v1_msgs::msg::ManualOperatorHeartbeat | manual operator heartbeat for latest Autoware |
-| `~/output/vehicle_engage`           | autoware_vehicle_msgs::msg::Engage                   | vehicle engage                                |
+| Name                           | Type                                                 | Description                                   |
+| ------------------------------ | ---------------------------------------------------- | --------------------------------------------- |
+| `~/output/control_command`     | autoware_control_msgs::msg::Control                  | lateral and longitudinal control command      |
+| `~/output/pedals_command`      | autoware_adapi_v1_msgs::msg::PedalsCommand           | manual pedals command for AD API              |
+| `~/output/steering_command`    | autoware_adapi_v1_msgs::msg::SteeringCommand         | manual steering command for AD API            |
+| `~/output/gear_cmd`            | autoware_vehicle_msgs::msg::GearCommand              | gear command for AD API                       |
+| `~/output/turn_indicators_cmd` | autoware_vehicle_msgs::msg::TurnIndicatorsCommand    | turn indicator command for AD API             |
+| `~/output/hazard_lights_cmd`   | autoware_vehicle_msgs::msg::HazardLightsCommand      | hazard light command for AD API               |
+| `~/output/gate_mode`           | tier4_control_msgs::msg::GateMode                    | gate mode (Auto or External)                  |
+| `~/output/operator_heartbeat`  | autoware_adapi_v1_msgs::msg::ManualOperatorHeartbeat | manual operator heartbeat for AD API          |
+| `~/output/vehicle_engage`      | autoware_vehicle_msgs::msg::Engage                   | vehicle engage                                |
 
 ## Parameters
 
@@ -54,8 +58,8 @@ ros2 launch autoware_joy_controller joy_controller.launch.xml config_file:=/path
 | `brake_ratio`             | double | ratio to calculate deceleration (commanded acceleration is -ratio \* operation)                                    |
 | `steer_ratio`             | double | ratio to calculate deceleration (commanded steer is ratio \* operation)                                            |
 | `steering_angle_velocity` | double | steering angle velocity for operation                                                                              |
-| `accel_sensitivity`       | double | sensitivity to calculate acceleration for external API (commanded acceleration is pow(operation, 1 / sensitivity)) |
-| `brake_sensitivity`       | double | sensitivity to calculate deceleration for external API (commanded acceleration is pow(operation, 1 / sensitivity)) |
+| `accel_sensitivity`       | double | sensitivity to calculate pedal throttle output (commanded acceleration is pow(operation, 1 / sensitivity))         |
+| `brake_sensitivity`       | double | sensitivity to calculate pedal brake output (commanded acceleration is pow(operation, 1 / sensitivity))            |
 | `raw_control`             | bool   | skip input odometry if true                                                                                        |
 | `velocity_gain`           | double | ratio to calculate velocity by acceleration                                                                        |
 | `max_forward_velocity`    | double | absolute max velocity to go forward                                                                                |

--- a/control/autoware_joy_controller/README.md
+++ b/control/autoware_joy_controller/README.md
@@ -30,19 +30,19 @@ ros2 launch autoware_joy_controller joy_controller.launch.xml config_file:=/path
 
 ### Output topics
 
-| Name                                | Type                                                | Description                              |
-| ----------------------------------- | --------------------------------------------------- | ---------------------------------------- |
-| `~/output/control_command`          | autoware_control_msgs::msg::Control                 | lateral and longitudinal control command |
-| `~/output/external_control_command` | tier4_external_api_msgs::msg::ControlCommandStamped | lateral and longitudinal control command |
-| `~/output/pedals_command`           | autoware_adapi_v1_msgs::msg::PedalsCommand          | manual pedals command for latest Autoware |
-| `~/output/steering_command`         | autoware_adapi_v1_msgs::msg::SteeringCommand        | manual steering command for latest Autoware |
-| `~/output/shift`                    | autoware_vehicle_msgs::msg::GearCommand             | gear command                             |
-| `~/output/turn_signal`              | autoware_vehicle_msgs::msg::TurnIndicatorsCommand   | turn indicator command                   |
-| `~/output/hazard_lights`            | autoware_vehicle_msgs::msg::HazardLightsCommand     | hazard light command                     |
-| `~/output/gate_mode`                | tier4_control_msgs::msg::GateMode                   | gate mode (Auto or External)             |
-| `~/output/heartbeat`                | tier4_external_api_msgs::msg::Heartbeat             | heartbeat                                |
+| Name                                | Type                                                 | Description                                   |
+| ----------------------------------- | ---------------------------------------------------- | --------------------------------------------- |
+| `~/output/control_command`          | autoware_control_msgs::msg::Control                  | lateral and longitudinal control command      |
+| `~/output/external_control_command` | tier4_external_api_msgs::msg::ControlCommandStamped  | lateral and longitudinal control command      |
+| `~/output/pedals_command`           | autoware_adapi_v1_msgs::msg::PedalsCommand           | manual pedals command for latest Autoware     |
+| `~/output/steering_command`         | autoware_adapi_v1_msgs::msg::SteeringCommand         | manual steering command for latest Autoware   |
+| `~/output/shift`                    | autoware_vehicle_msgs::msg::GearCommand              | gear command                                  |
+| `~/output/turn_signal`              | autoware_vehicle_msgs::msg::TurnIndicatorsCommand    | turn indicator command                        |
+| `~/output/hazard_lights`            | autoware_vehicle_msgs::msg::HazardLightsCommand      | hazard light command                          |
+| `~/output/gate_mode`                | tier4_control_msgs::msg::GateMode                    | gate mode (Auto or External)                  |
+| `~/output/heartbeat`                | tier4_external_api_msgs::msg::Heartbeat              | heartbeat                                     |
 | `~/output/operator_heartbeat`       | autoware_adapi_v1_msgs::msg::ManualOperatorHeartbeat | manual operator heartbeat for latest Autoware |
-| `~/output/vehicle_engage`           | autoware_vehicle_msgs::msg::Engage                  | vehicle engage                           |
+| `~/output/vehicle_engage`           | autoware_vehicle_msgs::msg::Engage                   | vehicle engage                                |
 
 ## Parameters
 
@@ -75,6 +75,7 @@ ros2 launch autoware_joy_controller joy_controller.launch.xml config_file:=/path
 | Shift Reverse        | Cursor Right          |
 | Turn Signal Left     | L1                    |
 | Turn Signal Right    | R1                    |
+| Hazard Lights        | L1 + R1               |
 | Clear Turn Signal    | A                     |
 | Gate Mode            | B                     |
 | Emergency Stop       | Select                |
@@ -97,6 +98,7 @@ ros2 launch autoware_joy_controller joy_controller.launch.xml config_file:=/path
 | Shift Reverse        | Cursor Right               |
 | Turn Signal Left     | L1                         |
 | Turn Signal Right    | R1                         |
+| Hazard Lights        | L1 + R1                    |
 | Clear Turn Signal    | SHARE                      |
 | Gate Mode            | OPTIONS                    |
 | Emergency Stop       | PS                         |
@@ -119,6 +121,7 @@ ros2 launch autoware_joy_controller joy_controller.launch.xml config_file:=/path
 | Shift Reverse        | Cursor Right          |
 | Turn Signal Left     | LB                    |
 | Turn Signal Right    | RB                    |
+| Hazard Lights        | LB + RB               |
 | Clear Turn Signal    | A                     |
 | Gate Mode            | B                     |
 | Emergency Stop       | View                  |

--- a/control/autoware_joy_controller/include/autoware/joy_controller/joy_controller.hpp
+++ b/control/autoware_joy_controller/include/autoware/joy_controller/joy_controller.hpp
@@ -32,8 +32,6 @@
 #include <nav_msgs/msg/odometry.hpp>
 #include <sensor_msgs/msg/joy.hpp>
 #include <tier4_control_msgs/msg/gate_mode.hpp>
-#include <tier4_external_api_msgs/msg/control_command_stamped.hpp>
-#include <tier4_external_api_msgs/msg/heartbeat.hpp>
 #include <tier4_external_api_msgs/srv/engage.hpp>
 #include <tier4_external_api_msgs/srv/set_emergency.hpp>
 
@@ -86,25 +84,22 @@ private:
 
   // Publisher
   rclcpp::Publisher<autoware_control_msgs::msg::Control>::SharedPtr pub_control_command_;
-  rclcpp::Publisher<tier4_external_api_msgs::msg::ControlCommandStamped>::SharedPtr
-    pub_external_control_command_;
   rclcpp::Publisher<autoware_adapi_v1_msgs::msg::PedalsCommand>::SharedPtr pub_pedals_command_;
   rclcpp::Publisher<autoware_adapi_v1_msgs::msg::SteeringCommand>::SharedPtr pub_steering_command_;
-  rclcpp::Publisher<autoware_vehicle_msgs::msg::GearCommand>::SharedPtr pub_shift_;
-  rclcpp::Publisher<autoware_vehicle_msgs::msg::TurnIndicatorsCommand>::SharedPtr pub_turn_signal_;
+  rclcpp::Publisher<autoware_vehicle_msgs::msg::GearCommand>::SharedPtr pub_gear_cmd_;
+  rclcpp::Publisher<autoware_vehicle_msgs::msg::TurnIndicatorsCommand>::SharedPtr
+    pub_turn_indicators_cmd_;
   rclcpp::Publisher<autoware_vehicle_msgs::msg::HazardLightsCommand>::SharedPtr pub_hazard_lights_;
-  rclcpp::Publisher<tier4_external_api_msgs::msg::Heartbeat>::SharedPtr pub_heartbeat_;
   rclcpp::Publisher<autoware_adapi_v1_msgs::msg::ManualOperatorHeartbeat>::SharedPtr
     pub_operator_heartbeat_;
   rclcpp::Publisher<tier4_control_msgs::msg::GateMode>::SharedPtr pub_gate_mode_;
   rclcpp::Publisher<autoware_vehicle_msgs::msg::Engage>::SharedPtr pub_vehicle_engage_;
 
   void publishControlCommand();
-  void publishExternalControlCommand();
   void publishPedalsCommand();
   void publishSteeringCommand();
-  void publishShift();
-  void publishTurnSignal();
+  void publishGearCommand();
+  void publishTurnIndicatorsCommand();
   void publishHazardLights(bool enable);
   void publishGateMode();
   void publishHeartbeat();
@@ -118,7 +113,6 @@ private:
 
   // Previous State
   autoware_control_msgs::msg::Control prev_control_command_;
-  tier4_external_api_msgs::msg::ControlCommand prev_external_control_command_;
   GearCommandType prev_shift_ = autoware_vehicle_msgs::msg::GearCommand::NONE;
   GateModeType prev_gate_mode_ = tier4_control_msgs::msg::GateMode::AUTO;
 

--- a/control/autoware_joy_controller/include/autoware/joy_controller/joy_controller.hpp
+++ b/control/autoware_joy_controller/include/autoware/joy_controller/joy_controller.hpp
@@ -20,10 +20,10 @@
 #include <autoware_utils/ros/polling_subscriber.hpp>
 #include <rclcpp/rclcpp.hpp>
 
-#include <autoware_control_msgs/msg/control.hpp>
 #include <autoware_adapi_v1_msgs/msg/manual_operator_heartbeat.hpp>
 #include <autoware_adapi_v1_msgs/msg/pedals_command.hpp>
 #include <autoware_adapi_v1_msgs/msg/steering_command.hpp>
+#include <autoware_control_msgs/msg/control.hpp>
 #include <autoware_vehicle_msgs/msg/engage.hpp>
 #include <autoware_vehicle_msgs/msg/gear_command.hpp>
 #include <autoware_vehicle_msgs/msg/hazard_lights_command.hpp>
@@ -88,15 +88,11 @@ private:
   rclcpp::Publisher<autoware_control_msgs::msg::Control>::SharedPtr pub_control_command_;
   rclcpp::Publisher<tier4_external_api_msgs::msg::ControlCommandStamped>::SharedPtr
     pub_external_control_command_;
-  rclcpp::Publisher<autoware_adapi_v1_msgs::msg::PedalsCommand>::SharedPtr
-    pub_pedals_command_;
-  rclcpp::Publisher<autoware_adapi_v1_msgs::msg::SteeringCommand>::SharedPtr
-    pub_steering_command_;
+  rclcpp::Publisher<autoware_adapi_v1_msgs::msg::PedalsCommand>::SharedPtr pub_pedals_command_;
+  rclcpp::Publisher<autoware_adapi_v1_msgs::msg::SteeringCommand>::SharedPtr pub_steering_command_;
   rclcpp::Publisher<autoware_vehicle_msgs::msg::GearCommand>::SharedPtr pub_shift_;
-  rclcpp::Publisher<autoware_vehicle_msgs::msg::TurnIndicatorsCommand>::SharedPtr
-    pub_turn_signal_;
-  rclcpp::Publisher<autoware_vehicle_msgs::msg::HazardLightsCommand>::SharedPtr
-    pub_hazard_lights_;
+  rclcpp::Publisher<autoware_vehicle_msgs::msg::TurnIndicatorsCommand>::SharedPtr pub_turn_signal_;
+  rclcpp::Publisher<autoware_vehicle_msgs::msg::HazardLightsCommand>::SharedPtr pub_hazard_lights_;
   rclcpp::Publisher<tier4_external_api_msgs::msg::Heartbeat>::SharedPtr pub_heartbeat_;
   rclcpp::Publisher<autoware_adapi_v1_msgs::msg::ManualOperatorHeartbeat>::SharedPtr
     pub_operator_heartbeat_;

--- a/control/autoware_joy_controller/include/autoware/joy_controller/joy_controller.hpp
+++ b/control/autoware_joy_controller/include/autoware/joy_controller/joy_controller.hpp
@@ -21,15 +21,19 @@
 #include <rclcpp/rclcpp.hpp>
 
 #include <autoware_control_msgs/msg/control.hpp>
+#include <autoware_adapi_v1_msgs/msg/manual_operator_heartbeat.hpp>
+#include <autoware_adapi_v1_msgs/msg/pedals_command.hpp>
+#include <autoware_adapi_v1_msgs/msg/steering_command.hpp>
 #include <autoware_vehicle_msgs/msg/engage.hpp>
+#include <autoware_vehicle_msgs/msg/gear_command.hpp>
+#include <autoware_vehicle_msgs/msg/hazard_lights_command.hpp>
+#include <autoware_vehicle_msgs/msg/turn_indicators_command.hpp>
 #include <geometry_msgs/msg/twist_stamped.hpp>
 #include <nav_msgs/msg/odometry.hpp>
 #include <sensor_msgs/msg/joy.hpp>
 #include <tier4_control_msgs/msg/gate_mode.hpp>
 #include <tier4_external_api_msgs/msg/control_command_stamped.hpp>
-#include <tier4_external_api_msgs/msg/gear_shift_stamped.hpp>
 #include <tier4_external_api_msgs/msg/heartbeat.hpp>
-#include <tier4_external_api_msgs/msg/turn_signal_stamped.hpp>
 #include <tier4_external_api_msgs/srv/engage.hpp>
 #include <tier4_external_api_msgs/srv/set_emergency.hpp>
 
@@ -38,8 +42,8 @@
 
 namespace autoware::joy_controller
 {
-using GearShiftType = tier4_external_api_msgs::msg::GearShift::_data_type;
-using TurnSignalType = tier4_external_api_msgs::msg::TurnSignal::_data_type;
+using GearCommandType = autoware_vehicle_msgs::msg::GearCommand::_command_type;
+using TurnIndicatorsCommandType = autoware_vehicle_msgs::msg::TurnIndicatorsCommand::_command_type;
 using GateModeType = tier4_control_msgs::msg::GateMode::_data_type;
 
 class AutowareJoyControllerNode : public rclcpp::Node
@@ -84,16 +88,28 @@ private:
   rclcpp::Publisher<autoware_control_msgs::msg::Control>::SharedPtr pub_control_command_;
   rclcpp::Publisher<tier4_external_api_msgs::msg::ControlCommandStamped>::SharedPtr
     pub_external_control_command_;
-  rclcpp::Publisher<tier4_external_api_msgs::msg::GearShiftStamped>::SharedPtr pub_shift_;
-  rclcpp::Publisher<tier4_external_api_msgs::msg::TurnSignalStamped>::SharedPtr pub_turn_signal_;
+  rclcpp::Publisher<autoware_adapi_v1_msgs::msg::PedalsCommand>::SharedPtr
+    pub_pedals_command_;
+  rclcpp::Publisher<autoware_adapi_v1_msgs::msg::SteeringCommand>::SharedPtr
+    pub_steering_command_;
+  rclcpp::Publisher<autoware_vehicle_msgs::msg::GearCommand>::SharedPtr pub_shift_;
+  rclcpp::Publisher<autoware_vehicle_msgs::msg::TurnIndicatorsCommand>::SharedPtr
+    pub_turn_signal_;
+  rclcpp::Publisher<autoware_vehicle_msgs::msg::HazardLightsCommand>::SharedPtr
+    pub_hazard_lights_;
   rclcpp::Publisher<tier4_external_api_msgs::msg::Heartbeat>::SharedPtr pub_heartbeat_;
+  rclcpp::Publisher<autoware_adapi_v1_msgs::msg::ManualOperatorHeartbeat>::SharedPtr
+    pub_operator_heartbeat_;
   rclcpp::Publisher<tier4_control_msgs::msg::GateMode>::SharedPtr pub_gate_mode_;
   rclcpp::Publisher<autoware_vehicle_msgs::msg::Engage>::SharedPtr pub_vehicle_engage_;
 
   void publishControlCommand();
   void publishExternalControlCommand();
+  void publishPedalsCommand();
+  void publishSteeringCommand();
   void publishShift();
   void publishTurnSignal();
+  void publishHazardLights(bool enable);
   void publishGateMode();
   void publishHeartbeat();
   void publishAutowareEngage();
@@ -107,7 +123,7 @@ private:
   // Previous State
   autoware_control_msgs::msg::Control prev_control_command_;
   tier4_external_api_msgs::msg::ControlCommand prev_external_control_command_;
-  GearShiftType prev_shift_ = tier4_external_api_msgs::msg::GearShift::NONE;
+  GearCommandType prev_shift_ = autoware_vehicle_msgs::msg::GearCommand::NONE;
   GateModeType prev_gate_mode_ = tier4_control_msgs::msg::GateMode::AUTO;
 
   // Timer

--- a/control/autoware_joy_controller/launch/joy_controller.launch.xml
+++ b/control/autoware_joy_controller/launch/joy_controller.launch.xml
@@ -6,9 +6,13 @@
 
   <arg name="output_control_command" default="/external/$(var external_cmd_source)/joy/control_cmd"/>
   <arg name="output_external_control_command" default="/api/external/set/command/$(var external_cmd_source)/control"/>
-  <arg name="output_shift" default="/api/external/set/command/$(var external_cmd_source)/shift"/>
-  <arg name="output_turn_signal" default="/api/external/set/command/$(var external_cmd_source)/turn_signal"/>
+  <arg name="output_pedals_command" default="/external/$(var external_cmd_source)/pedals_cmd"/>
+  <arg name="output_steering_command" default="/external/$(var external_cmd_source)/steering_cmd"/>
+  <arg name="output_shift" default="/external/$(var external_cmd_source)/gear_cmd"/>
+  <arg name="output_turn_signal" default="/external/$(var external_cmd_source)/turn_indicators_cmd"/>
+  <arg name="output_hazard_lights" default="/external/$(var external_cmd_source)/hazard_lights_cmd"/>
   <arg name="output_heartbeat" default="/api/external/set/command/$(var external_cmd_source)/heartbeat"/>
+  <arg name="output_operator_heartbeat" default="/external/$(var external_cmd_source)/heartbeat"/>
   <arg name="output_gate_mode" default="/control/gate_mode_cmd"/>
   <arg name="output_vehicle_engage" default="/vehicle/engage"/>
 
@@ -20,10 +24,14 @@
 
     <remap from="output/control_command" to="$(var output_control_command)"/>
     <remap from="output/external_control_command" to="$(var output_external_control_command)"/>
+    <remap from="output/pedals_command" to="$(var output_pedals_command)"/>
+    <remap from="output/steering_command" to="$(var output_steering_command)"/>
     <remap from="output/shift" to="$(var output_shift)"/>
     <remap from="output/turn_signal" to="$(var output_turn_signal)"/>
+    <remap from="output/hazard_lights" to="$(var output_hazard_lights)"/>
     <remap from="output/gate_mode" to="$(var output_gate_mode)"/>
     <remap from="output/heartbeat" to="$(var output_heartbeat)"/>
+    <remap from="output/operator_heartbeat" to="$(var output_operator_heartbeat)"/>
     <remap from="output/vehicle_engage" to="$(var output_vehicle_engage)"/>
 
     <remap from="service/emergency_stop" to="/api/autoware/set/emergency"/>

--- a/control/autoware_joy_controller/launch/joy_controller.launch.xml
+++ b/control/autoware_joy_controller/launch/joy_controller.launch.xml
@@ -5,13 +5,11 @@
   <arg name="input_odometry" default="/localization/kinematic_state"/>
 
   <arg name="output_control_command" default="/external/$(var external_cmd_source)/joy/control_cmd"/>
-  <arg name="output_external_control_command" default="/api/external/set/command/$(var external_cmd_source)/control"/>
   <arg name="output_pedals_command" default="/external/$(var external_cmd_source)/pedals_cmd"/>
   <arg name="output_steering_command" default="/external/$(var external_cmd_source)/steering_cmd"/>
-  <arg name="output_shift" default="/external/$(var external_cmd_source)/gear_cmd"/>
-  <arg name="output_turn_signal" default="/external/$(var external_cmd_source)/turn_indicators_cmd"/>
-  <arg name="output_hazard_lights" default="/external/$(var external_cmd_source)/hazard_lights_cmd"/>
-  <arg name="output_heartbeat" default="/api/external/set/command/$(var external_cmd_source)/heartbeat"/>
+  <arg name="output_gear_cmd" default="/external/$(var external_cmd_source)/gear_cmd"/>
+  <arg name="output_turn_indicators_cmd" default="/external/$(var external_cmd_source)/turn_indicators_cmd"/>
+  <arg name="output_hazard_lights_cmd" default="/external/$(var external_cmd_source)/hazard_lights_cmd"/>
   <arg name="output_operator_heartbeat" default="/external/$(var external_cmd_source)/heartbeat"/>
   <arg name="output_gate_mode" default="/control/gate_mode_cmd"/>
   <arg name="output_vehicle_engage" default="/vehicle/engage"/>
@@ -23,14 +21,12 @@
     <remap from="input/odometry" to="$(var input_odometry)"/>
 
     <remap from="output/control_command" to="$(var output_control_command)"/>
-    <remap from="output/external_control_command" to="$(var output_external_control_command)"/>
     <remap from="output/pedals_command" to="$(var output_pedals_command)"/>
     <remap from="output/steering_command" to="$(var output_steering_command)"/>
-    <remap from="output/shift" to="$(var output_shift)"/>
-    <remap from="output/turn_signal" to="$(var output_turn_signal)"/>
-    <remap from="output/hazard_lights" to="$(var output_hazard_lights)"/>
+    <remap from="output/gear_cmd" to="$(var output_gear_cmd)"/>
+    <remap from="output/turn_indicators_cmd" to="$(var output_turn_indicators_cmd)"/>
+    <remap from="output/hazard_lights_cmd" to="$(var output_hazard_lights_cmd)"/>
     <remap from="output/gate_mode" to="$(var output_gate_mode)"/>
-    <remap from="output/heartbeat" to="$(var output_heartbeat)"/>
     <remap from="output/operator_heartbeat" to="$(var output_operator_heartbeat)"/>
     <remap from="output/vehicle_engage" to="$(var output_vehicle_engage)"/>
 

--- a/control/autoware_joy_controller/package.xml
+++ b/control/autoware_joy_controller/package.xml
@@ -16,6 +16,7 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
+  <depend>autoware_adapi_v1_msgs</depend>
   <depend>autoware_control_msgs</depend>
   <depend>autoware_qos_utils</depend>
   <depend>autoware_utils</depend>

--- a/control/autoware_joy_controller/src/joy_controller_node.cpp
+++ b/control/autoware_joy_controller/src/joy_controller_node.cpp
@@ -28,97 +28,98 @@
 namespace
 {
 using autoware::joy_controller::GateModeType;
-using autoware::joy_controller::GearShiftType;
-using autoware::joy_controller::TurnSignalType;
-using GearShift = tier4_external_api_msgs::msg::GearShift;
-using TurnSignal = tier4_external_api_msgs::msg::TurnSignal;
+using autoware::joy_controller::GearCommandType;
+using autoware::joy_controller::TurnIndicatorsCommandType;
 using GateMode = tier4_control_msgs::msg::GateMode;
+using GearCommand = autoware_vehicle_msgs::msg::GearCommand;
+using HazardLightsCommand = autoware_vehicle_msgs::msg::HazardLightsCommand;
+using TurnIndicatorsCommand = autoware_vehicle_msgs::msg::TurnIndicatorsCommand;
 
-GearShiftType getUpperShift(const GearShiftType & shift)
+GearCommandType getUpperShift(const GearCommandType & shift)
 {
-  if (shift == GearShift::NONE) {
-    return GearShift::PARKING;
+  if (shift == GearCommand::NONE) {
+    return GearCommand::PARK;
   }
-  if (shift == GearShift::PARKING) {
-    return GearShift::REVERSE;
+  if (shift == GearCommand::PARK) {
+    return GearCommand::REVERSE;
   }
-  if (shift == GearShift::REVERSE) {
-    return GearShift::NEUTRAL;
+  if (shift == GearCommand::REVERSE) {
+    return GearCommand::NEUTRAL;
   }
-  if (shift == GearShift::NEUTRAL) {
-    return GearShift::DRIVE;
+  if (shift == GearCommand::NEUTRAL) {
+    return GearCommand::DRIVE;
   }
-  if (shift == GearShift::DRIVE) {
-    return GearShift::LOW;
+  if (shift == GearCommand::DRIVE) {
+    return GearCommand::LOW;
   }
-  if (shift == GearShift::LOW) {
-    return GearShift::LOW;
+  if (shift == GearCommand::LOW) {
+    return GearCommand::LOW;
   }
 
-  return GearShift::NONE;
+  return GearCommand::NONE;
 }
 
-GearShiftType getLowerShift(const GearShiftType & shift)
+GearCommandType getLowerShift(const GearCommandType & shift)
 {
-  if (shift == GearShift::NONE) {
-    return GearShift::PARKING;
+  if (shift == GearCommand::NONE) {
+    return GearCommand::PARK;
   }
-  if (shift == GearShift::PARKING) {
-    return GearShift::PARKING;
+  if (shift == GearCommand::PARK) {
+    return GearCommand::PARK;
   }
-  if (shift == GearShift::REVERSE) {
-    return GearShift::PARKING;
+  if (shift == GearCommand::REVERSE) {
+    return GearCommand::PARK;
   }
-  if (shift == GearShift::NEUTRAL) {
-    return GearShift::REVERSE;
+  if (shift == GearCommand::NEUTRAL) {
+    return GearCommand::REVERSE;
   }
-  if (shift == GearShift::DRIVE) {
-    return GearShift::NEUTRAL;
+  if (shift == GearCommand::DRIVE) {
+    return GearCommand::NEUTRAL;
   }
-  if (shift == GearShift::LOW) {
-    return GearShift::DRIVE;
+  if (shift == GearCommand::LOW) {
+    return GearCommand::DRIVE;
   }
 
-  return GearShift::NONE;
+  return GearCommand::NONE;
 }
 
-const char * getShiftName(const GearShiftType & shift)
+const char * getShiftName(const GearCommandType & shift)
 {
-  if (shift == GearShift::NONE) {
+  if (shift == GearCommand::NONE) {
     return "NONE";
   }
-  if (shift == GearShift::PARKING) {
-    return "PARKING";
+  if (shift == GearCommand::PARK) {
+    return "PARK";
   }
-  if (shift == GearShift::REVERSE) {
+  if (shift == GearCommand::REVERSE) {
     return "REVERSE";
   }
-  if (shift == GearShift::NEUTRAL) {
+  if (shift == GearCommand::NEUTRAL) {
     return "NEUTRAL";
   }
-  if (shift == GearShift::DRIVE) {
+  if (shift == GearCommand::DRIVE) {
     return "DRIVE";
   }
-  if (shift == GearShift::LOW) {
+  if (shift == GearCommand::LOW) {
     return "LOW";
   }
 
   return "NOT_SUPPORTED";
 }
 
-const char * getTurnSignalName(const TurnSignalType & turn_signal)
+const char * getTurnSignalName(const TurnIndicatorsCommandType & turn_signal)
 {
-  if (turn_signal == TurnSignal::NONE) {
-    return "NONE";
+  if (turn_signal == TurnIndicatorsCommand::NO_COMMAND) {
+    return "NO_COMMAND";
   }
-  if (turn_signal == TurnSignal::LEFT) {
-    return "LEFT";
+  if (turn_signal == TurnIndicatorsCommand::DISABLE) {
+    return "DISABLE";
   }
-  if (turn_signal == TurnSignal::RIGHT) {
-    return "RIGHT";
+  if (turn_signal == TurnIndicatorsCommand::ENABLE_LEFT) {
+    return "ENABLE_LEFT";
   }
-  if (turn_signal == TurnSignal::HAZARD) {
-    return "HAZARD";
+  if (turn_signal == TurnIndicatorsCommand::ENABLE_RIGHT) {
+    return "ENABLE_RIGHT";
   }
 
   return "NOT_SUPPORTED";
@@ -266,6 +267,8 @@ void AutowareJoyControllerNode::onTimer()
 
   publishControlCommand();
   publishExternalControlCommand();
+  publishPedalsCommand();
+  publishSteeringCommand();
   publishHeartbeat();
 }
 
@@ -322,53 +325,84 @@ void AutowareJoyControllerNode::publishExternalControlCommand()
   prev_external_control_command_ = cmd_stamped.control;
 }
 
+void AutowareJoyControllerNode::publishPedalsCommand()
+{
+  autoware_adapi_v1_msgs::msg::PedalsCommand cmd;
+  cmd.stamp = this->now();
+  cmd.throttle =
+    accel_ratio_ * calcMapping(static_cast<double>(joy_->accel()), accel_sensitivity_);
+  cmd.brake = brake_ratio_ * calcMapping(static_cast<double>(joy_->brake()), brake_sensitivity_);
+  pub_pedals_command_->publish(cmd);
+}
+
+void AutowareJoyControllerNode::publishSteeringCommand()
+{
+  autoware_adapi_v1_msgs::msg::SteeringCommand cmd;
+  cmd.stamp = this->now();
+  cmd.steering_tire_angle = steer_ratio_ * joy_->steer();
+  cmd.steering_tire_velocity = steering_angle_velocity_;
+  pub_steering_command_->publish(cmd);
+}
+
 void AutowareJoyControllerNode::publishShift()
 {
-  tier4_external_api_msgs::msg::GearShiftStamped gear_shift;
+  autoware_vehicle_msgs::msg::GearCommand gear_shift;
   gear_shift.stamp = this->now();
 
   if (joy_->shift_up()) {
-    gear_shift.gear_shift.data = getUpperShift(prev_shift_);
+    gear_shift.command = getUpperShift(prev_shift_);
   }
 
   if (joy_->shift_down()) {
-    gear_shift.gear_shift.data = getLowerShift(prev_shift_);
+    gear_shift.command = getLowerShift(prev_shift_);
   }
 
   if (joy_->shift_drive()) {
-    gear_shift.gear_shift.data = GearShift::DRIVE;
+    gear_shift.command = GearCommand::DRIVE;
   }
 
   if (joy_->shift_reverse()) {
-    gear_shift.gear_shift.data = GearShift::REVERSE;
+    gear_shift.command = GearCommand::REVERSE;
   }
 
-  RCLCPP_INFO(get_logger(), "GearShift::%s", getShiftName(gear_shift.gear_shift.data));
+  RCLCPP_INFO(get_logger(), "GearCommand::%s", getShiftName(gear_shift.command));
 
   pub_shift_->publish(gear_shift);
-  prev_shift_ = gear_shift.gear_shift.data;
+  prev_shift_ = gear_shift.command;
 }
 
 void AutowareJoyControllerNode::publishTurnSignal()
 {
-  tier4_external_api_msgs::msg::TurnSignalStamped turn_signal;
+  autoware_vehicle_msgs::msg::TurnIndicatorsCommand turn_signal;
   turn_signal.stamp = this->now();
+  turn_signal.command = TurnIndicatorsCommand::DISABLE;
 
   if (joy_->turn_signal_left() && joy_->turn_signal_right()) {
-    turn_signal.turn_signal.data = TurnSignal::HAZARD;
+    publishHazardLights(true);
   } else if (joy_->turn_signal_left()) {
-    turn_signal.turn_signal.data = TurnSignal::LEFT;
+    turn_signal.command = TurnIndicatorsCommand::ENABLE_LEFT;
+    publishHazardLights(false);
   } else if (joy_->turn_signal_right()) {
-    turn_signal.turn_signal.data = TurnSignal::RIGHT;
+    turn_signal.command = TurnIndicatorsCommand::ENABLE_RIGHT;
+    publishHazardLights(false);
   }
 
   if (joy_->clear_turn_signal()) {
-    turn_signal.turn_signal.data = TurnSignal::NONE;
+    turn_signal.command = TurnIndicatorsCommand::DISABLE;
+    publishHazardLights(false);
   }
 
-  RCLCPP_INFO(get_logger(), "TurnSignal::%s", getTurnSignalName(turn_signal.turn_signal.data));
+  RCLCPP_INFO(get_logger(), "TurnIndicatorsCommand::%s", getTurnSignalName(turn_signal.command));
 
   pub_turn_signal_->publish(turn_signal);
+}
+
+void AutowareJoyControllerNode::publishHazardLights(const bool enable)
+{
+  autoware_vehicle_msgs::msg::HazardLightsCommand hazard_lights;
+  hazard_lights.stamp = this->now();
+  hazard_lights.command = enable ? HazardLightsCommand::ENABLE : HazardLightsCommand::DISABLE;
+  pub_hazard_lights_->publish(hazard_lights);
 }
 
 void AutowareJoyControllerNode::publishGateMode()
@@ -394,6 +428,11 @@ void AutowareJoyControllerNode::publishHeartbeat()
   tier4_external_api_msgs::msg::Heartbeat heartbeat;
   heartbeat.stamp = this->now();
   pub_heartbeat_->publish(heartbeat);
+
+  autoware_adapi_v1_msgs::msg::ManualOperatorHeartbeat operator_heartbeat;
+  operator_heartbeat.stamp = heartbeat.stamp;
+  operator_heartbeat.ready = true;
+  pub_operator_heartbeat_->publish(operator_heartbeat);
 }
 
 void AutowareJoyControllerNode::sendEmergencyRequest(bool emergency)
@@ -501,13 +540,26 @@ AutowareJoyControllerNode::AutowareJoyControllerNode(const rclcpp::NodeOptions &
   pub_external_control_command_ =
     this->create_publisher<tier4_external_api_msgs::msg::ControlCommandStamped>(
       "output/external_control_command", 1);
+  pub_pedals_command_ =
+    this->create_publisher<autoware_adapi_v1_msgs::msg::PedalsCommand>(
+      "output/pedals_command", 1);
+  pub_steering_command_ =
+    this->create_publisher<autoware_adapi_v1_msgs::msg::SteeringCommand>(
+      "output/steering_command", 1);
   pub_shift_ =
-    this->create_publisher<tier4_external_api_msgs::msg::GearShiftStamped>("output/shift", 1);
-  pub_turn_signal_ = this->create_publisher<tier4_external_api_msgs::msg::TurnSignalStamped>(
-    "output/turn_signal", 1);
+    this->create_publisher<autoware_vehicle_msgs::msg::GearCommand>("output/shift", 1);
+  pub_turn_signal_ =
+    this->create_publisher<autoware_vehicle_msgs::msg::TurnIndicatorsCommand>(
+      "output/turn_signal", 1);
+  pub_hazard_lights_ =
+    this->create_publisher<autoware_vehicle_msgs::msg::HazardLightsCommand>(
+      "output/hazard_lights", 1);
   pub_gate_mode_ = this->create_publisher<tier4_control_msgs::msg::GateMode>("output/gate_mode", 1);
   pub_heartbeat_ =
     this->create_publisher<tier4_external_api_msgs::msg::Heartbeat>("output/heartbeat", 1);
+  pub_operator_heartbeat_ =
+    this->create_publisher<autoware_adapi_v1_msgs::msg::ManualOperatorHeartbeat>(
+      "output/operator_heartbeat", 1);
   pub_vehicle_engage_ =
     this->create_publisher<autoware_vehicle_msgs::msg::Engage>("output/vehicle_engage", 1);
 

--- a/control/autoware_joy_controller/src/joy_controller_node.cpp
+++ b/control/autoware_joy_controller/src/joy_controller_node.cpp
@@ -329,8 +329,7 @@ void AutowareJoyControllerNode::publishPedalsCommand()
 {
   autoware_adapi_v1_msgs::msg::PedalsCommand cmd;
   cmd.stamp = this->now();
-  cmd.throttle =
-    accel_ratio_ * calcMapping(static_cast<double>(joy_->accel()), accel_sensitivity_);
+  cmd.throttle = accel_ratio_ * calcMapping(static_cast<double>(joy_->accel()), accel_sensitivity_);
   cmd.brake = brake_ratio_ * calcMapping(static_cast<double>(joy_->brake()), brake_sensitivity_);
   pub_pedals_command_->publish(cmd);
 }
@@ -541,19 +540,14 @@ AutowareJoyControllerNode::AutowareJoyControllerNode(const rclcpp::NodeOptions &
     this->create_publisher<tier4_external_api_msgs::msg::ControlCommandStamped>(
       "output/external_control_command", 1);
   pub_pedals_command_ =
-    this->create_publisher<autoware_adapi_v1_msgs::msg::PedalsCommand>(
-      "output/pedals_command", 1);
-  pub_steering_command_ =
-    this->create_publisher<autoware_adapi_v1_msgs::msg::SteeringCommand>(
-      "output/steering_command", 1);
-  pub_shift_ =
-    this->create_publisher<autoware_vehicle_msgs::msg::GearCommand>("output/shift", 1);
-  pub_turn_signal_ =
-    this->create_publisher<autoware_vehicle_msgs::msg::TurnIndicatorsCommand>(
-      "output/turn_signal", 1);
-  pub_hazard_lights_ =
-    this->create_publisher<autoware_vehicle_msgs::msg::HazardLightsCommand>(
-      "output/hazard_lights", 1);
+    this->create_publisher<autoware_adapi_v1_msgs::msg::PedalsCommand>("output/pedals_command", 1);
+  pub_steering_command_ = this->create_publisher<autoware_adapi_v1_msgs::msg::SteeringCommand>(
+    "output/steering_command", 1);
+  pub_shift_ = this->create_publisher<autoware_vehicle_msgs::msg::GearCommand>("output/shift", 1);
+  pub_turn_signal_ = this->create_publisher<autoware_vehicle_msgs::msg::TurnIndicatorsCommand>(
+    "output/turn_signal", 1);
+  pub_hazard_lights_ = this->create_publisher<autoware_vehicle_msgs::msg::HazardLightsCommand>(
+    "output/hazard_lights", 1);
   pub_gate_mode_ = this->create_publisher<tier4_control_msgs::msg::GateMode>("output/gate_mode", 1);
   pub_heartbeat_ =
     this->create_publisher<tier4_external_api_msgs::msg::Heartbeat>("output/heartbeat", 1);

--- a/control/autoware_joy_controller/src/joy_controller_node.cpp
+++ b/control/autoware_joy_controller/src/joy_controller_node.cpp
@@ -168,11 +168,11 @@ void AutowareJoyControllerNode::onJoy()
   }
 
   if (joy_->shift_up() || joy_->shift_down() || joy_->shift_drive() || joy_->shift_reverse()) {
-    publishShift();
+    publishGearCommand();
   }
 
   if (joy_->turn_signal_left() || joy_->turn_signal_right() || joy_->clear_turn_signal()) {
-    publishTurnSignal();
+    publishTurnIndicatorsCommand();
   }
 
   if (joy_->gate_mode()) {
@@ -266,7 +266,6 @@ void AutowareJoyControllerNode::onTimer()
   }
 
   publishControlCommand();
-  publishExternalControlCommand();
   publishPedalsCommand();
   publishSteeringCommand();
   publishHeartbeat();
@@ -307,24 +306,6 @@ void AutowareJoyControllerNode::publishControlCommand()
   prev_control_command_ = cmd;
 }
 
-void AutowareJoyControllerNode::publishExternalControlCommand()
-{
-  tier4_external_api_msgs::msg::ControlCommandStamped cmd_stamped;
-  cmd_stamped.stamp = this->now();
-  {
-    auto & cmd = cmd_stamped.control;
-
-    cmd.steering_angle = steer_ratio_ * joy_->steer();
-    cmd.steering_angle_velocity = steering_angle_velocity_;
-    cmd.throttle =
-      accel_ratio_ * calcMapping(static_cast<double>(joy_->accel()), accel_sensitivity_);
-    cmd.brake = brake_ratio_ * calcMapping(static_cast<double>(joy_->brake()), brake_sensitivity_);
-  }
-
-  pub_external_control_command_->publish(cmd_stamped);
-  prev_external_control_command_ = cmd_stamped.control;
-}
-
 void AutowareJoyControllerNode::publishPedalsCommand()
 {
   autoware_adapi_v1_msgs::msg::PedalsCommand cmd;
@@ -343,7 +324,7 @@ void AutowareJoyControllerNode::publishSteeringCommand()
   pub_steering_command_->publish(cmd);
 }
 
-void AutowareJoyControllerNode::publishShift()
+void AutowareJoyControllerNode::publishGearCommand()
 {
   autoware_vehicle_msgs::msg::GearCommand gear_shift;
   gear_shift.stamp = this->now();
@@ -366,11 +347,11 @@ void AutowareJoyControllerNode::publishShift()
 
   RCLCPP_INFO(get_logger(), "GearCommand::%s", getShiftName(gear_shift.command));
 
-  pub_shift_->publish(gear_shift);
+  pub_gear_cmd_->publish(gear_shift);
   prev_shift_ = gear_shift.command;
 }
 
-void AutowareJoyControllerNode::publishTurnSignal()
+void AutowareJoyControllerNode::publishTurnIndicatorsCommand()
 {
   autoware_vehicle_msgs::msg::TurnIndicatorsCommand turn_signal;
   turn_signal.stamp = this->now();
@@ -393,7 +374,7 @@ void AutowareJoyControllerNode::publishTurnSignal()
 
   RCLCPP_INFO(get_logger(), "TurnIndicatorsCommand::%s", getTurnSignalName(turn_signal.command));
 
-  pub_turn_signal_->publish(turn_signal);
+  pub_turn_indicators_cmd_->publish(turn_signal);
 }
 
 void AutowareJoyControllerNode::publishHazardLights(const bool enable)
@@ -424,12 +405,8 @@ void AutowareJoyControllerNode::publishGateMode()
 
 void AutowareJoyControllerNode::publishHeartbeat()
 {
-  tier4_external_api_msgs::msg::Heartbeat heartbeat;
-  heartbeat.stamp = this->now();
-  pub_heartbeat_->publish(heartbeat);
-
   autoware_adapi_v1_msgs::msg::ManualOperatorHeartbeat operator_heartbeat;
-  operator_heartbeat.stamp = heartbeat.stamp;
+  operator_heartbeat.stamp = this->now();
   operator_heartbeat.ready = true;
   pub_operator_heartbeat_->publish(operator_heartbeat);
 }
@@ -536,21 +513,18 @@ AutowareJoyControllerNode::AutowareJoyControllerNode(const rclcpp::NodeOptions &
   // Publisher
   pub_control_command_ =
     this->create_publisher<autoware_control_msgs::msg::Control>("output/control_command", 1);
-  pub_external_control_command_ =
-    this->create_publisher<tier4_external_api_msgs::msg::ControlCommandStamped>(
-      "output/external_control_command", 1);
   pub_pedals_command_ =
     this->create_publisher<autoware_adapi_v1_msgs::msg::PedalsCommand>("output/pedals_command", 1);
   pub_steering_command_ = this->create_publisher<autoware_adapi_v1_msgs::msg::SteeringCommand>(
     "output/steering_command", 1);
-  pub_shift_ = this->create_publisher<autoware_vehicle_msgs::msg::GearCommand>("output/shift", 1);
-  pub_turn_signal_ = this->create_publisher<autoware_vehicle_msgs::msg::TurnIndicatorsCommand>(
-    "output/turn_signal", 1);
+  pub_gear_cmd_ =
+    this->create_publisher<autoware_vehicle_msgs::msg::GearCommand>("output/gear_cmd", 1);
+  pub_turn_indicators_cmd_ =
+    this->create_publisher<autoware_vehicle_msgs::msg::TurnIndicatorsCommand>(
+      "output/turn_indicators_cmd", 1);
   pub_hazard_lights_ = this->create_publisher<autoware_vehicle_msgs::msg::HazardLightsCommand>(
-    "output/hazard_lights", 1);
+    "output/hazard_lights_cmd", 1);
   pub_gate_mode_ = this->create_publisher<tier4_control_msgs::msg::GateMode>("output/gate_mode", 1);
-  pub_heartbeat_ =
-    this->create_publisher<tier4_external_api_msgs::msg::Heartbeat>("output/heartbeat", 1);
   pub_operator_heartbeat_ =
     this->create_publisher<autoware_adapi_v1_msgs::msg::ManualOperatorHeartbeat>(
       "output/operator_heartbeat", 1);


### PR DESCRIPTION
## Description

Update `autoware_joy_controller` to publish the manual control topics expected by the current Autoware external command pipeline.

Previously, joystick longitudinal and lateral inputs were aggregated in `~/output/external_control_command`, hazard signaling was represented through `~/output/turn_signal`, and manual heartbeat was published through `~/output/heartbeat`.

This PR migrates those legacy outputs to the current manual control interfaces by:
- splitting `~/output/external_control_command` into `~/output/pedals_command` and `~/output/steering_command`
- migrating `~/output/shift` from `tier4_external_api_msgs/GearShiftStamped` to `autoware_vehicle_msgs/GearCommand`
- migrating `~/output/turn_signal` from `tier4_external_api_msgs/TurnSignalStamped` to `autoware_vehicle_msgs/TurnIndicatorsCommand`
- separating the hazard state previously represented in `~/output/turn_signal` into `~/output/hazard_lights`
- migrating the legacy heartbeat output to `~/output/operator_heartbeat`

The goal is to make `autoware_joy_controller` work with the current manual control path:
`joy_controller -> external_cmd_selector -> external_cmd_converter -> vehicle_cmd_gate`.
## Related links

None.

## How was this PR tested?

- Verified with `planning_simulator.launch.xml`
  - Confirmed joy input was converted and propagated through the current external/manual control pipeline
  - Confirmed expected behavior for steering, pedals, gear, turn indicators, and hazard lights

## Notes for reviewers

None.

## Interface changes

### Topic changes

#### Additions and removals

| Change type | Topic Type | Topic Name | Message Type | Description |
|:--|:--|:--|:--|:--|
| Added | Pub | `~/output/pedals_command` | `autoware_adapi_v1_msgs/msg/PedalsCommand` | Manual pedals command |
| Added | Pub | `~/output/steering_command` | `autoware_adapi_v1_msgs/msg/SteeringCommand` | Manual steering command |
| Added | Pub | `~/output/hazard_lights` | `autoware_vehicle_msgs/msg/HazardLightsCommand` | Hazard light command |
| Added | Pub | `~/output/operator_heartbeat` | `autoware_adapi_v1_msgs/msg/ManualOperatorHeartbeat` | Manual operator heartbeat |

#### Modifications

| Version | Topic Type | Topic Name | Message Type | Description |
|:--|:--|:--|:--|:--|
| Old | Pub | `~/output/shift` | `tier4_external_api_msgs/msg/GearShiftStamped` | Gear command output |
| New | Pub | `~/output/shift` | `autoware_vehicle_msgs/msg/GearCommand` | Gear command output |
| Old | Pub | `~/output/turn_signal` | `tier4_external_api_msgs/msg/TurnSignalStamped` | Turn signal output |
| New | Pub | `~/output/turn_signal` | `autoware_vehicle_msgs/msg/TurnIndicatorsCommand` | Turn indicator output |

## Effects on system behavior

Updates `autoware_joy_controller` to match the current Autoware manual control interfaces without changing the existing joystick mappings for steering, throttle, brake, gear, engage, or gate mode. Hazard light behavior is now explicitly published via `HazardLightsCommand` when left and right turn inputs are pressed together.