### PR TITLE
feat(autoware_bevfusion): add diagnostic declaration

### DIFF
--- a/perception/autoware_bevfusion/src/bevfusion_node.cpp
+++ b/perception/autoware_bevfusion/src/bevfusion_node.cpp
@@ -219,6 +219,19 @@ BEVFusionNode::BEVFusionNode(const rclcpp::NodeOptions & options)
   diagnostics_detector_trt_ =
     std::make_unique<autoware_utils_diagnostics::DiagnosticsInterface>(this, "bevfusion_trt");
 
+  // processing time diagnostics
+  max_allowed_processing_time_ms_ =
+    this->declare_parameter<double>("diagnostics.max_allowed_processing_time_ms");
+  max_acceptable_consecutive_delay_ms_ =
+    this->declare_parameter<double>("diagnostics.max_acceptable_consecutive_delay_ms");
+  const double validation_callback_interval_ms =
+    this->declare_parameter<double>("diagnostics.validation_callback_interval_ms");
+
+  diagnostic_processing_time_updater_.setHardwareID("bevfusion");
+  diagnostic_processing_time_updater_.add(
+    "processing_time_status", this, &BEVFusionNode::diagnoseProcessingTime);
+  diagnostic_processing_time_updater_.setPeriod(validation_callback_interval_ms / 1000.0);
+
   cloud_sub_ =
     std::make_unique<cuda_blackboard::CudaBlackboardSubscriber<cuda_blackboard::CudaPointCloud2>>(
       *this, "~/input/pointcloud",

--- a/perception/autoware_bevfusion/src/bevfusion_node_utils.cpp
+++ b/perception/autoware_bevfusion/src/bevfusion_node_utils.cpp
@@ -172,6 +172,7 @@ void BEVFusionNode::publishDebugInfo(
 
   const double cyclic_time_ms = stop_watch_ptr_->toc("cyclic", true);
   const double processing_time_ms = stop_watch_ptr_->toc("processing/total", true);
+  last_processing_time_ms_ = processing_time_ms;
   const double pipeline_latency_ms =
     std::chrono::duration<double, std::milli>(
       std::chrono::nanoseconds((this->get_clock()->now() - header.stamp).nanoseconds()))


### PR DESCRIPTION
## Description

Wire up the BEVFusion processing time diagnostic. The diagnostics.* params, callback (diagnoseProcessingTime), and members already existed but were never connected, so the diagnostic never ran. 

## Related links

https://github.com/search?q=repo%3Aautowarefoundation%2Fautoware_universe+max_allowed_processing_time_ms+path%3A%2F%5Eperception%5C%2Fautoware_bevfusion%5C%2F%2F&type=code

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
Built autoware_bevfusion and confirmed the processing_time_status diagnostic is published.
## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

The processing_time_status diagnostic now functions; no other behavior changes.
