### PR TITLE
refactor(traffic_light_multi_camera_fusion): improve readability

### DIFF
--- a/perception/autoware_traffic_light_multi_camera_fusion/src/multi_camera_fusion.cpp
+++ b/perception/autoware_traffic_light_multi_camera_fusion/src/multi_camera_fusion.cpp
@@ -20,6 +20,7 @@
 #include <algorithm>
 #include <cmath>
 #include <map>
+#include <set>
 #include <utility>
 #include <vector>
 
@@ -170,6 +171,9 @@ std::vector<MultiCameraFusion::IdType> find_unmapped_traffic_light_ids(
 
 }  // namespace
 
+std::map<MultiCameraFusion::IdType, utils::FusionRecord> multi_camera_fusion(
+  std::multiset<utils::FusionRecordArr> & record_arr_set, double message_lifespan);
+
 MultiCameraFusion::MultiCameraFusion(const MultiCameraFusionConfig & config)
 : config_(config),
   traffic_light_id_to_regulatory_ele_id_(
@@ -187,8 +191,9 @@ MultiCameraFusionResult MultiCameraFusion::fuse(
   record_arr_set_.insert(utils::FusionRecordArr{cam_info.header, cam_info, rois, signals});
 
   MultiCameraFusionResult result;
-  std::map<IdType, utils::FusionRecord> fused_record_map, grouped_record_map;
-  multi_camera_fusion(fused_record_map);
+  std::map<IdType, utils::FusionRecord> grouped_record_map;
+  std::map<IdType, utils::FusionRecord> fused_record_map =
+    multi_camera_fusion(record_arr_set_, config_.message_lifespan);
   result.unmapped_traffic_light_ids =
     find_unmapped_traffic_light_ids(fused_record_map, traffic_light_id_to_regulatory_ele_id_);
   group_fusion(fused_record_map, grouped_record_map, result.conflicted_regulatory_element_status);
@@ -201,30 +206,32 @@ MultiCameraFusionResult MultiCameraFusion::fuse(
   return result;
 }
 
-void MultiCameraFusion::multi_camera_fusion(
-  std::map<IdType, utils::FusionRecord> & fused_record_map)
+std::map<MultiCameraFusion::IdType, utils::FusionRecord> multi_camera_fusion(
+  std::multiset<utils::FusionRecordArr> & record_arr_set, double message_lifespan)
 {
-  fused_record_map.clear();
-  const rclcpp::Time & newest_stamp(record_arr_set_.rbegin()->header.stamp);
-  for (auto it = record_arr_set_.begin(); it != record_arr_set_.end();) {
+  std::map<MultiCameraFusion::IdType, utils::FusionRecord> fused_record_map;
+  const rclcpp::Time & newest_stamp(record_arr_set.rbegin()->header.stamp);
+  for (auto it = record_arr_set.begin(); it != record_arr_set.end();) {
     /*
     remove all old record arrays whose timestamp difference with newest record is larger than
     threshold
     */
     if (
       (newest_stamp - rclcpp::Time(it->header.stamp)) >
-      rclcpp::Duration::from_seconds(config_.message_lifespan)) {
-      it = record_arr_set_.erase(it);
+      rclcpp::Duration::from_seconds(message_lifespan)) {
+      it = record_arr_set.erase(it);
     } else {
       /*
       generate fused record result with the saved records
       */
       const utils::FusionRecordArr & record_arr = *it;
       for (size_t i = 0; i < record_arr.rois.rois.size(); i++) {
-        const RoiType & roi = record_arr.rois.rois[i];
+        const MultiCameraFusion::RoiType & roi = record_arr.rois.rois[i];
         auto signal_it = std::find_if(
           record_arr.signals.signals.begin(), record_arr.signals.signals.end(),
-          [roi](const SignalType & s1) { return roi.traffic_light_id == s1.traffic_light_id; });
+          [roi](const MultiCameraFusion::SignalType & s1) {
+            return roi.traffic_light_id == s1.traffic_light_id;
+          });
         /*
         failed to find corresponding signal. skip it
         */
@@ -245,6 +252,7 @@ void MultiCameraFusion::multi_camera_fusion(
       it++;
     }
   }
+  return fused_record_map;
 }
 
 void MultiCameraFusion::group_fusion(

--- a/perception/autoware_traffic_light_multi_camera_fusion/src/multi_camera_fusion.cpp
+++ b/perception/autoware_traffic_light_multi_camera_fusion/src/multi_camera_fusion.cpp
@@ -171,14 +171,15 @@ MultiCameraFusionResult MultiCameraFusion::fuse(
   MultiCameraFusionResult result;
   std::map<IdType, utils::FusionRecord> fused_record_map, grouped_record_map;
   multi_camera_fusion(fused_record_map);
-  group_fusion(fused_record_map, grouped_record_map, result.unmapped_traffic_light_ids);
+  group_fusion(
+    fused_record_map, grouped_record_map, result.unmapped_traffic_light_ids,
+    result.conflicted_regulatory_element_status);
 
   NewSignalArrayType msg_out;
   convert_output_msg(grouped_record_map, msg_out);
   msg_out.stamp = cam_info.header.stamp;
   result.traffic_light_groups = msg_out;
 
-  result.conflicted_regulatory_element_status = conflicted_regulatory_element_status_;
   return result;
 }
 
@@ -231,7 +232,8 @@ void MultiCameraFusion::multi_camera_fusion(
 void MultiCameraFusion::group_fusion(
   const std::map<IdType, utils::FusionRecord> & fused_record_map,
   std::map<IdType, utils::FusionRecord> & grouped_record_map,
-  std::vector<IdType> & unmapped_traffic_light_ids)
+  std::vector<IdType> & unmapped_traffic_light_ids,
+  std::vector<ConflictInfo> & conflicted_regulatory_element_status)
 {
   grouped_record_map.clear();
 
@@ -240,7 +242,8 @@ void MultiCameraFusion::group_fusion(
     accumulate_group_evidence(fused_record_map, unmapped_traffic_light_ids);
 
   // Stage 2: Determine the best state for each group from the accumulated evidence
-  determine_best_group_state(group_fusion_info_map, grouped_record_map);
+  conflicted_regulatory_element_status =
+    determine_best_group_state(group_fusion_info_map, grouped_record_map);
 }
 
 GroupFusionInfoMap MultiCameraFusion::accumulate_group_evidence(
@@ -321,11 +324,11 @@ void MultiCameraFusion::update_log_odds(
   log_odds_map[state_key] += evidence_log_odds - config_.prior_log_odds;
 }
 
-void MultiCameraFusion::determine_best_group_state(
+std::vector<ConflictInfo> MultiCameraFusion::determine_best_group_state(
   const std::map<IdType, GroupFusionInfo> & group_fusion_info_map,
-  std::map<IdType, utils::FusionRecord> & grouped_record_map)
+  std::map<IdType, utils::FusionRecord> & grouped_record_map) const
 {
-  conflicted_regulatory_element_status_.clear();
+  std::vector<ConflictInfo> conflicted_regulatory_element_status;
 
   for (const auto & pair : group_fusion_info_map) {
     const IdType reg_ele_id = pair.first;
@@ -409,9 +412,11 @@ void MultiCameraFusion::determine_best_group_state(
     // suppress diagnostics for comparisons with unknown
     if (conflict_result.conflict_type != ConflictType::NO_CONFLICT) {
       // record it for diagnostics
-      conflicted_regulatory_element_status_.push_back({reg_ele_id, conflict_result.conflict_type});
+      conflicted_regulatory_element_status.push_back({reg_ele_id, conflict_result.conflict_type});
     }
   }
+
+  return conflicted_regulatory_element_status;
 }
 
 }  // namespace autoware::traffic_light

--- a/perception/autoware_traffic_light_multi_camera_fusion/src/multi_camera_fusion.cpp
+++ b/perception/autoware_traffic_light_multi_camera_fusion/src/multi_camera_fusion.cpp
@@ -174,6 +174,14 @@ std::vector<MultiCameraFusion::IdType> find_unmapped_traffic_light_ids(
 std::map<MultiCameraFusion::IdType, utils::FusionRecord> multi_camera_fusion(
   std::multiset<utils::FusionRecordArr> & record_arr_set, double message_lifespan);
 
+void update_log_odds(
+  std::map<StateKey, double> & log_odds_map, const StateKey & state_key, double confidence,
+  double prior_log_odds);
+
+void update_group_info_for_element(
+  GroupFusionInfoMap & group_fusion_info_map, const MultiCameraFusion::IdType & reg_ele_id,
+  const utils::FusionRecord & record, double prior_log_odds);
+
 MultiCameraFusion::MultiCameraFusion(const MultiCameraFusionConfig & config)
 : config_(config),
   traffic_light_id_to_regulatory_ele_id_(
@@ -305,16 +313,17 @@ void MultiCameraFusion::process_fused_record(
   // Loop over all regulatory IDs associated with this traffic light
   for (const auto & reg_ele_id : reg_ele_id_vec) {
     // Delegate the innermost logic to another helper
-    update_group_info_for_element(group_fusion_info_map, reg_ele_id, record);
+    update_group_info_for_element(
+      group_fusion_info_map, reg_ele_id, record, config_.prior_log_odds);
   }
 }
 
 /**
  * @brief Updates the map for a single (element, regulatory_id) combination.
  */
-void MultiCameraFusion::update_group_info_for_element(
-  GroupFusionInfoMap & group_fusion_info_map, const IdType & reg_ele_id,
-  const utils::FusionRecord & record) const
+void update_group_info_for_element(
+  GroupFusionInfoMap & group_fusion_info_map, const MultiCameraFusion::IdType & reg_ele_id,
+  const utils::FusionRecord & record, double prior_log_odds)
 {
   StateKey state_key;
   for (const auto & element : record.signal.elements) {
@@ -324,7 +333,7 @@ void MultiCameraFusion::update_group_info_for_element(
   auto & group_info = group_fusion_info_map[reg_ele_id];
 
   // Update Log-Odds
-  update_log_odds(group_info.accumulated_log_odds, state_key, confidence);
+  update_log_odds(group_info.accumulated_log_odds, state_key, confidence, prior_log_odds);
 
   // Update Best Record
   update_best_record(group_info.best_record_for_state, state_key, confidence, record);
@@ -333,8 +342,9 @@ void MultiCameraFusion::update_group_info_for_element(
 /**
  * @brief Handles the log-odds accumulation logic.
  */
-void MultiCameraFusion::update_log_odds(
-  std::map<StateKey, double> & log_odds_map, const StateKey & state_key, double confidence) const
+void update_log_odds(
+  std::map<StateKey, double> & log_odds_map, const StateKey & state_key, double confidence,
+  double prior_log_odds)
 {
   // try_emplace ensures we only add the 0.0 prior (from a 0.5 probability) once.
   log_odds_map.try_emplace(state_key, 0.0);
@@ -342,7 +352,7 @@ void MultiCameraFusion::update_log_odds(
   const double evidence_log_odds = probability_to_log_odds(confidence);
 
   // Accumulate evidence
-  log_odds_map[state_key] += evidence_log_odds - config_.prior_log_odds;
+  log_odds_map[state_key] += evidence_log_odds - prior_log_odds;
 }
 
 std::vector<ConflictInfo> MultiCameraFusion::determine_best_group_state(

--- a/perception/autoware_traffic_light_multi_camera_fusion/src/multi_camera_fusion.cpp
+++ b/perception/autoware_traffic_light_multi_camera_fusion/src/multi_camera_fusion.cpp
@@ -150,6 +150,24 @@ void update_best_record(
   }
 }
 
+/**
+ * @brief Collect the traffic light ids that were observed but are not registered in the map.
+ */
+std::vector<MultiCameraFusion::IdType> find_unmapped_traffic_light_ids(
+  const std::map<MultiCameraFusion::IdType, utils::FusionRecord> & fused_record_map,
+  const std::map<lanelet::Id, std::vector<lanelet::Id>> & traffic_light_id_to_regulatory_ele_id)
+{
+  std::vector<MultiCameraFusion::IdType> unmapped_traffic_light_ids;
+  for (const auto & [traffic_light_id, record] : fused_record_map) {
+    if (
+      traffic_light_id_to_regulatory_ele_id.find(traffic_light_id) ==
+      traffic_light_id_to_regulatory_ele_id.end()) {
+      unmapped_traffic_light_ids.emplace_back(traffic_light_id);
+    }
+  }
+  return unmapped_traffic_light_ids;
+}
+
 }  // namespace
 
 MultiCameraFusion::MultiCameraFusion(const MultiCameraFusionConfig & config)
@@ -171,9 +189,9 @@ MultiCameraFusionResult MultiCameraFusion::fuse(
   MultiCameraFusionResult result;
   std::map<IdType, utils::FusionRecord> fused_record_map, grouped_record_map;
   multi_camera_fusion(fused_record_map);
-  group_fusion(
-    fused_record_map, grouped_record_map, result.unmapped_traffic_light_ids,
-    result.conflicted_regulatory_element_status);
+  result.unmapped_traffic_light_ids =
+    find_unmapped_traffic_light_ids(fused_record_map, traffic_light_id_to_regulatory_ele_id_);
+  group_fusion(fused_record_map, grouped_record_map, result.conflicted_regulatory_element_status);
 
   NewSignalArrayType msg_out;
   convert_output_msg(grouped_record_map, msg_out);
@@ -232,14 +250,13 @@ void MultiCameraFusion::multi_camera_fusion(
 void MultiCameraFusion::group_fusion(
   const std::map<IdType, utils::FusionRecord> & fused_record_map,
   std::map<IdType, utils::FusionRecord> & grouped_record_map,
-  std::vector<IdType> & unmapped_traffic_light_ids,
   std::vector<ConflictInfo> & conflicted_regulatory_element_status)
 {
   grouped_record_map.clear();
 
   // Stage 1: Accumulate evidence from all fused records
   const std::map<IdType, GroupFusionInfo> group_fusion_info_map =
-    accumulate_group_evidence(fused_record_map, unmapped_traffic_light_ids);
+    accumulate_group_evidence(fused_record_map);
 
   // Stage 2: Determine the best state for each group from the accumulated evidence
   conflicted_regulatory_element_status =
@@ -247,30 +264,26 @@ void MultiCameraFusion::group_fusion(
 }
 
 GroupFusionInfoMap MultiCameraFusion::accumulate_group_evidence(
-  const std::map<IdType, utils::FusionRecord> & fused_record_map,
-  std::vector<IdType> & unmapped_traffic_light_ids)
+  const std::map<IdType, utils::FusionRecord> & fused_record_map)
 {
   GroupFusionInfoMap group_fusion_info_map;
-  for (const auto & p : fused_record_map) {
-    process_fused_record(group_fusion_info_map, p.second, unmapped_traffic_light_ids);
+  for (const auto & [traffic_light_id, record] : fused_record_map) {
+    process_fused_record(group_fusion_info_map, record);
   }
   return group_fusion_info_map;
 }
 
 /**
  * @brief Processes a single fused record and updates the group_fusion_info_map.
- * (This function contains the logic from the outer loop)
  */
 void MultiCameraFusion::process_fused_record(
-  GroupFusionInfoMap & group_fusion_info_map, const utils::FusionRecord & record,
-  std::vector<IdType> & unmapped_traffic_light_ids)
+  GroupFusionInfoMap & group_fusion_info_map, const utils::FusionRecord & record)
 {
   const IdType roi_id = record.roi.traffic_light_id;
 
   // Guard Clause 1: Check if traffic light ID is in the map
   const auto it = traffic_light_id_to_regulatory_ele_id_.find(roi_id);
   if (it == traffic_light_id_to_regulatory_ele_id_.end()) {
-    unmapped_traffic_light_ids.emplace_back(roi_id);
     return;
   }
 

--- a/perception/autoware_traffic_light_multi_camera_fusion/src/multi_camera_fusion.cpp
+++ b/perception/autoware_traffic_light_multi_camera_fusion/src/multi_camera_fusion.cpp
@@ -199,15 +199,15 @@ MultiCameraFusionResult MultiCameraFusion::fuse(
   record_arr_set_.insert(utils::FusionRecordArr{cam_info.header, cam_info, rois, signals});
 
   MultiCameraFusionResult result;
-  std::map<IdType, utils::FusionRecord> grouped_record_map;
   std::map<IdType, utils::FusionRecord> fused_record_map =
     multi_camera_fusion(record_arr_set_, config_.message_lifespan);
   result.unmapped_traffic_light_ids =
     find_unmapped_traffic_light_ids(fused_record_map, traffic_light_id_to_regulatory_ele_id_);
-  group_fusion(fused_record_map, grouped_record_map, result.conflicted_regulatory_element_status);
+  GroupFusionResult group_result = group_fusion(fused_record_map);
+  result.conflicted_regulatory_element_status = group_result.conflicts;
 
   NewSignalArrayType msg_out;
-  convert_output_msg(grouped_record_map, msg_out);
+  convert_output_msg(group_result.grouped_record_map, msg_out);
   msg_out.stamp = cam_info.header.stamp;
   result.traffic_light_groups = msg_out;
 
@@ -263,20 +263,17 @@ std::map<MultiCameraFusion::IdType, utils::FusionRecord> multi_camera_fusion(
   return fused_record_map;
 }
 
-void MultiCameraFusion::group_fusion(
-  const std::map<IdType, utils::FusionRecord> & fused_record_map,
-  std::map<IdType, utils::FusionRecord> & grouped_record_map,
-  std::vector<ConflictInfo> & conflicted_regulatory_element_status)
+GroupFusionResult MultiCameraFusion::group_fusion(
+  const std::map<IdType, utils::FusionRecord> & fused_record_map)
 {
-  grouped_record_map.clear();
-
   // Stage 1: Accumulate evidence from all fused records
   const std::map<IdType, GroupFusionInfo> group_fusion_info_map =
     accumulate_group_evidence(fused_record_map);
 
   // Stage 2: Determine the best state for each group from the accumulated evidence
-  conflicted_regulatory_element_status =
-    determine_best_group_state(group_fusion_info_map, grouped_record_map);
+  GroupFusionResult result;
+  result.conflicts = determine_best_group_state(group_fusion_info_map, result.grouped_record_map);
+  return result;
 }
 
 GroupFusionInfoMap MultiCameraFusion::accumulate_group_evidence(

--- a/perception/autoware_traffic_light_multi_camera_fusion/src/multi_camera_fusion.hpp
+++ b/perception/autoware_traffic_light_multi_camera_fusion/src/multi_camera_fusion.hpp
@@ -102,7 +102,6 @@ private:
   void group_fusion(
     const std::map<IdType, utils::FusionRecord> & fused_record_map,
     std::map<IdType, utils::FusionRecord> & grouped_record_map,
-    std::vector<IdType> & unmapped_traffic_light_ids,
     std::vector<ConflictInfo> & conflicted_regulatory_element_status);
 
   /**
@@ -110,15 +109,13 @@ private:
    * records.
    */
   GroupFusionInfoMap accumulate_group_evidence(
-    const std::map<IdType, utils::FusionRecord> & fused_record_map,
-    std::vector<IdType> & unmapped_traffic_light_ids);
+    const std::map<IdType, utils::FusionRecord> & fused_record_map);
 
   /**
    * @brief Processes a single fused record and updates the group_fusion_info_map.
    */
   void process_fused_record(
-    GroupFusionInfoMap & group_fusion_info_map, const utils::FusionRecord & record,
-    std::vector<IdType> & unmapped_traffic_light_ids);
+    GroupFusionInfoMap & group_fusion_info_map, const utils::FusionRecord & record);
 
   /**
    * @brief Updates the map for a single (element, regulatory_id) combination.

--- a/perception/autoware_traffic_light_multi_camera_fusion/src/multi_camera_fusion.hpp
+++ b/perception/autoware_traffic_light_multi_camera_fusion/src/multi_camera_fusion.hpp
@@ -51,6 +51,13 @@ struct ConflictInfo
 using GroupFusionInfoMap =
   std::map<tier4_perception_msgs::msg::TrafficLightRoi::_traffic_light_id_type, GroupFusionInfo>;
 
+struct GroupFusionResult
+{
+  std::map<tier4_perception_msgs::msg::TrafficLightRoi::_traffic_light_id_type, utils::FusionRecord>
+    grouped_record_map;
+  std::vector<ConflictInfo> conflicts;
+};
+
 struct MultiCameraFusionConfig
 {
   /*
@@ -97,10 +104,7 @@ public:
     const CamInfoType & cam_info, const RoiArrayType & rois, const SignalArrayType & signals);
 
 private:
-  void group_fusion(
-    const std::map<IdType, utils::FusionRecord> & fused_record_map,
-    std::map<IdType, utils::FusionRecord> & grouped_record_map,
-    std::vector<ConflictInfo> & conflicted_regulatory_element_status);
+  GroupFusionResult group_fusion(const std::map<IdType, utils::FusionRecord> & fused_record_map);
 
   /**
    * @brief Accumulates log-odds evidence for each traffic light group from individual fused

--- a/perception/autoware_traffic_light_multi_camera_fusion/src/multi_camera_fusion.hpp
+++ b/perception/autoware_traffic_light_multi_camera_fusion/src/multi_camera_fusion.hpp
@@ -116,19 +116,6 @@ private:
     GroupFusionInfoMap & group_fusion_info_map, const utils::FusionRecord & record);
 
   /**
-   * @brief Updates the map for a single (element, regulatory_id) combination.
-   */
-  void update_group_info_for_element(
-    GroupFusionInfoMap & group_fusion_info_map, const IdType & reg_ele_id,
-    const utils::FusionRecord & record) const;
-
-  /**
-   * @brief Handles the log-odds accumulation logic.
-   */
-  void update_log_odds(
-    std::map<StateKey, double> & log_odds_map, const StateKey & state_key, double confidence) const;
-
-  /**
    * @brief Determines the best state for each group based on accumulated evidence.
    * @return The conflicts detected during this call. Empty when no conflict is found.
    */

--- a/perception/autoware_traffic_light_multi_camera_fusion/src/multi_camera_fusion.hpp
+++ b/perception/autoware_traffic_light_multi_camera_fusion/src/multi_camera_fusion.hpp
@@ -102,7 +102,8 @@ private:
   void group_fusion(
     const std::map<IdType, utils::FusionRecord> & fused_record_map,
     std::map<IdType, utils::FusionRecord> & grouped_record_map,
-    std::vector<IdType> & unmapped_traffic_light_ids);
+    std::vector<IdType> & unmapped_traffic_light_ids,
+    std::vector<ConflictInfo> & conflicted_regulatory_element_status);
 
   /**
    * @brief Accumulates log-odds evidence for each traffic light group from individual fused
@@ -134,10 +135,11 @@ private:
 
   /**
    * @brief Determines the best state for each group based on accumulated evidence.
+   * @return The conflicts detected during this call. Empty when no conflict is found.
    */
-  void determine_best_group_state(
+  std::vector<ConflictInfo> determine_best_group_state(
     const std::map<IdType, GroupFusionInfo> & group_fusion_info_map,
-    std::map<IdType, utils::FusionRecord> & grouped_record_map);
+    std::map<IdType, utils::FusionRecord> & grouped_record_map) const;
 
   MultiCameraFusionConfig config_{};
   /*
@@ -149,8 +151,6 @@ private:
   Use multiset in case multiple cameras publish images at the exact same time.
   */
   std::multiset<utils::FusionRecordArr> record_arr_set_;
-
-  std::vector<ConflictInfo> conflicted_regulatory_element_status_{};
 };
 
 }  // namespace autoware::traffic_light

--- a/perception/autoware_traffic_light_multi_camera_fusion/src/multi_camera_fusion.hpp
+++ b/perception/autoware_traffic_light_multi_camera_fusion/src/multi_camera_fusion.hpp
@@ -97,8 +97,6 @@ public:
     const CamInfoType & cam_info, const RoiArrayType & rois, const SignalArrayType & signals);
 
 private:
-  void multi_camera_fusion(std::map<IdType, utils::FusionRecord> & fused_record_map);
-
   void group_fusion(
     const std::map<IdType, utils::FusionRecord> & fused_record_map,
     std::map<IdType, utils::FusionRecord> & grouped_record_map,


### PR DESCRIPTION
## Description

Behavior-preserving refactor of the `MultiCameraFusion` class in `autoware_traffic_light_multi_camera_fusion`. It reduces hidden member state and member functions in favor of free functions and value-returning APIs. No ROS interfaces, parameters or topics are changed.

Changes:

1. `determine_best_group_state()` returns conflicts by value; removed the `conflicted_regulatory_element_status_` member.
2. Extracted `find_unmapped_traffic_light_ids()` as a free helper instead of threading unmapped IDs through the accumulation path.
3. Made `multi_camera_fusion()` a free function returning the fused record map.
4. Made `update_log_odds()` / `update_group_info_for_element()` free functions (`prior_log_odds` passed as an argument).
5. `group_fusion()` returns a `GroupFusionResult` struct instead of two output parameters.

## How was this PR tested?

```bash
colcon build --packages-select autoware_traffic_light_multi_camera_fusion
colcon test  --packages-select autoware_traffic_light_multi_camera_fusion --event-handlers console_cohesion+
# 114 tests, 0 failures
```

The existing unit and node-level integration tests pass without modification, confirming the refactor is behavior-preserving.

## Interface changes

None. 

## Effects on system behavior

None.
