### PR TITLE
fix(goal_planner): use resampled_arc_path

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/pull_over_planner/geometric_pull_over.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/pull_over_planner/geometric_pull_over.cpp
@@ -80,7 +80,8 @@ std::optional<PullOverPath> GeometricPullOver::plan(
   // todo: Implement lane departure detection that does not depend on the footprint
   const auto resampled_arc_path =
     utils::resamplePathWithSpline(arc_path, parameters_.center_line_path_interval / 2);
-  if (boundary_departure_checker_.checkPathWillLeaveLane({departure_check_lane}, arc_path))
+  if (boundary_departure_checker_.checkPathWillLeaveLane(
+        {departure_check_lane}, resampled_arc_path))
     return {};
 
   auto pull_over_path_opt = PullOverPath::create(


### PR DESCRIPTION
## Description

With PR #10058, the path was resampled to increase accuracy. However, it was missed to use resampled path in [geometric_pull_over.cpp](https://github.com/autowarefoundation/autoware_universe/pull/10058/changes#diff-9880c0c55160974729d09776541552eb11d948e553a899d5c782fe2a6efec669)

This PR uses resampled path.

## Related links


**Private Links:**

- [TIER IV ticket](https://tier4.atlassian.net/browse/ISSJP-4241)


## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
