### PR TITLE
feat(ptv3): add serialized pooling TensorRT path

### DIFF
--- a/perception/autoware_ptv3/CMakeLists.txt
+++ b/perception/autoware_ptv3/CMakeLists.txt
@@ -132,6 +132,24 @@ if(TRT_AVAIL AND CUDA_AVAIL)
     DESTINATION lib
   )
 
+  if(BUILD_TESTING)
+    find_package(ament_cmake_gtest REQUIRED)
+
+    ament_add_gtest(serialized_pooling_metadata_test
+      test/serialized_pooling_metadata_test.cpp
+    )
+    if(TARGET serialized_pooling_metadata_test)
+      target_link_libraries(serialized_pooling_metadata_test
+        CUDA::cudart
+        ${PROJECT_NAME}_cuda_lib
+      )
+      target_include_directories(serialized_pooling_metadata_test PRIVATE
+        include
+        ${CUDA_INCLUDE_DIRS}
+      )
+    endif()
+  endif()
+
   ament_auto_package(
     INSTALL_TO_SHARE
       launch

--- a/perception/autoware_ptv3/config/ml_package_ptv3.param.yaml
+++ b/perception/autoware_ptv3/config/ml_package_ptv3.param.yaml
@@ -59,3 +59,5 @@
     voxels_num: [32000, 192000, 320000] # [min, opt, max]
     point_cloud_range: [-102.4, -102.4, -2.8, 102.4, 102.4, 10.0] # [x_min, y_min, z_min, x_max, y_max, z_max]
     voxel_size: [0.1, 0.1, 0.1] # [x, y, z]
+    serialization_orders: ["z", "z-trans"]
+    pooling_strides: [2, 2, 2, 2]

--- a/perception/autoware_ptv3/include/autoware/ptv3/preprocess/preprocess_kernel.hpp
+++ b/perception/autoware_ptv3/include/autoware/ptv3/preprocess/preprocess_kernel.hpp
@@ -23,9 +23,22 @@
 #include <cuda_runtime_api.h>
 
 #include <cstdint>
+#include <vector>
 
 namespace autoware::ptv3
 {
+
+struct SerializedPoolingDeviceStageView
+{
+  std::int64_t * indices{};
+  std::int64_t * indptr{};
+  std::int64_t * head_indices{};
+  std::int64_t * cluster{};
+  std::int64_t * grid_coord{};
+  std::int64_t * serialized_code{};
+  std::int64_t * serialized_order{};
+  std::int64_t * serialized_inverse{};
+};
 
 class PreprocessCuda
 {
@@ -37,6 +50,10 @@ public:
     float * voxel_features, std::int64_t * voxel_coords, std::int64_t * voxel_hashes,
     void * compact_points, float * reconstruction_features, void * cropped_source_points,
     std::int64_t * inverse_map, std::size_t * num_cropped_points);
+
+  void generateSerializedPoolingMetadata(
+    const std::int64_t * grid_coord, const std::int64_t * serialized_code, std::int64_t num_voxels,
+    const std::vector<SerializedPoolingDeviceStageView> & stages, std::int64_t * stage_counts);
 
   [[nodiscard]] const std::uint32_t * cropMask() const { return crop_mask_d_.get(); }
   [[nodiscard]] const std::uint32_t * cropIndices() const { return crop_indices_d_.get(); }
@@ -67,6 +84,15 @@ private:
 
   autoware::cuda_utils::CudaUniquePtr<std::uint8_t[]> sort_workspace_d_{nullptr};
   std::size_t sort_workspace_size_{0};
+
+  autoware::cuda_utils::CudaUniquePtr<std::int64_t[]> pooling_keys_d_{nullptr};
+  autoware::cuda_utils::CudaUniquePtr<std::int64_t[]> pooling_sorted_keys_d_{nullptr};
+  autoware::cuda_utils::CudaUniquePtr<std::int64_t[]> pooling_indices_d_{nullptr};
+  autoware::cuda_utils::CudaUniquePtr<std::int64_t[]> pooling_sorted_indices_d_{nullptr};
+  autoware::cuda_utils::CudaUniquePtr<std::int64_t[]> pooling_run_flags_d_{nullptr};
+  autoware::cuda_utils::CudaUniquePtr<std::int64_t[]> pooling_run_ids_d_{nullptr};
+  autoware::cuda_utils::CudaUniquePtr<std::uint8_t[]> pooling_workspace_d_{nullptr};
+  std::size_t pooling_workspace_size_{0};
 };
 }  // namespace autoware::ptv3
 

--- a/perception/autoware_ptv3/include/autoware/ptv3/ptv3_config.hpp
+++ b/perception/autoware_ptv3/include/autoware/ptv3/ptv3_config.hpp
@@ -41,9 +41,10 @@ public:
     const std::string & plugins_path, const std::int64_t cloud_capacity,
     const std::vector<std::int64_t> & voxels_num, const std::vector<float> & point_cloud_range,
     const std::vector<float> & voxel_size, const std::vector<std::string> & class_names,
-    const std::vector<std::int64_t> & palette, const float filter_class_probability_threshold,
-    const std::vector<std::string> & filter_classes, const std::string & filter_output_format,
-    const std::string & source_reconstruction)
+    const std::vector<std::string> & serialization_orders,
+    const std::vector<std::int64_t> & pooling_strides, const std::vector<std::int64_t> & palette,
+    const float filter_class_probability_threshold, const std::vector<std::string> & filter_classes,
+    const std::string & filter_output_format, const std::string & source_reconstruction)
   {
     plugins_path_ = plugins_path;
 
@@ -87,6 +88,8 @@ public:
       grid_x_size_ * grid_y_size_ * grid_z_size_ > std::numeric_limits<std::uint32_t>::max();
 
     class_names_ = class_names;
+    serialization_orders_ = validate_serialization_orders(serialization_orders);
+    pooling_strides_ = validate_pooling_strides(pooling_strides);
 
     colors_rgb_ = make_palette(class_names_, palette);
 
@@ -159,6 +162,32 @@ public:
     return colors;
   }
 
+  static std::vector<std::string> validate_serialization_orders(
+    const std::vector<std::string> & serialization_orders)
+  {
+    if (serialization_orders.empty()) {
+      throw std::runtime_error("serialization_orders must not be empty.");
+    }
+    if (
+      serialization_orders.size() != 2 || serialization_orders[0] != "z" ||
+      serialization_orders[1] != "z-trans") {
+      throw std::runtime_error(
+        "The current PTv3 preprocessing path supports serialization_orders: ['z', 'z-trans'].");
+    }
+    return serialization_orders;
+  }
+
+  static std::vector<std::int64_t> validate_pooling_strides(
+    const std::vector<std::int64_t> & pooling_strides)
+  {
+    for (const auto stride : pooling_strides) {
+      if (stride < 1 || (stride & (stride - 1)) != 0) {
+        throw std::runtime_error("Each pooling stride must be a positive power of two.");
+      }
+    }
+    return pooling_strides;
+  }
+
   // CUDA parameters
   const std::uint32_t threads_per_block_{256};  // threads number for a block
 
@@ -173,6 +202,8 @@ public:
 
   // Head parameters
   std::vector<std::string> class_names_;
+  std::vector<std::string> serialization_orders_;
+  std::vector<std::int64_t> pooling_strides_;
   std::vector<float> colors_rgb_;
   float filter_class_probability_threshold_{};
   std::vector<std::uint32_t> filter_class_indices_;

--- a/perception/autoware_ptv3/include/autoware/ptv3/ptv3_trt.hpp
+++ b/perception/autoware_ptv3/include/autoware/ptv3/ptv3_trt.hpp
@@ -62,6 +62,8 @@ protected:
   void initTrt(const tensorrt_common::TrtCommonConfig & trt_config);
   void createPointFields();
   void allocateMessages();
+  void allocateSerializedPoolingBuffers();
+  void precomputeSerializedPoolingMetadata();
   [[nodiscard]] CloudFormat detectCloudFormat(const cuda_blackboard::CudaPointCloud2 & cloud) const;
 
   bool preProcess(const std::shared_ptr<const cuda_blackboard::CudaPointCloud2> & msg_ptr);
@@ -97,6 +99,23 @@ protected:
   std::once_flag init_cloud_;
   CloudFormat input_format_{CloudFormat::UNKNOWN};
   CloudFormat filtered_output_format_{CloudFormat::UNKNOWN};
+
+  struct SerializedPoolingDeviceStage
+  {
+    CudaUniquePtr<std::int64_t[]> indices{nullptr};
+    CudaUniquePtr<std::int64_t[]> indptr{nullptr};
+    CudaUniquePtr<std::int64_t[]> head_indices{nullptr};
+    CudaUniquePtr<std::int64_t[]> cluster{nullptr};
+    CudaUniquePtr<std::int64_t[]> grid_coord{nullptr};
+    CudaUniquePtr<std::int64_t[]> serialized_code{nullptr};
+    CudaUniquePtr<std::int64_t[]> serialized_order{nullptr};
+    CudaUniquePtr<std::int64_t[]> serialized_inverse{nullptr};
+  };
+
+  std::vector<SerializedPoolingDeviceStage> serialized_pooling_stages_d_;
+  CudaUniquePtr<std::int64_t[]> serialized_pooling_num_voxels_d_{nullptr};
+  std::vector<std::int64_t> serialized_pooling_num_voxels_;
+  std::vector<std::int64_t> serialized_pooling_depths_;
 
   // Preprocess outputs
   std::int64_t num_voxels_{0};

--- a/perception/autoware_ptv3/include/autoware/ptv3/ptv3_trt.hpp
+++ b/perception/autoware_ptv3/include/autoware/ptv3/ptv3_trt.hpp
@@ -63,7 +63,9 @@ protected:
   void createPointFields();
   void allocateMessages();
   void allocateSerializedPoolingBuffers();
+  void bindSerializedPoolingAddresses();
   void precomputeSerializedPoolingMetadata();
+  bool setSerializedPoolingInputShapes();
   [[nodiscard]] CloudFormat detectCloudFormat(const cuda_blackboard::CudaPointCloud2 & cloud) const;
 
   bool preProcess(const std::shared_ptr<const cuda_blackboard::CudaPointCloud2> & msg_ptr);

--- a/perception/autoware_ptv3/lib/preprocess/preprocess_kernel.cu
+++ b/perception/autoware_ptv3/lib/preprocess/preprocess_kernel.cu
@@ -458,18 +458,20 @@ void PreprocessCuda::generateSerializedPoolingMetadata(
       static_cast<std::int32_t>(stage_index), pooling_depth, capacity);
     CHECK_CUDA_ERROR(cudaPeekAtLastError());
 
-    CHECK_CUDA_ERROR(cub::DeviceRadixSort::SortPairs(
-      pooling_workspace_d_.get(), pooling_workspace_size_, pooling_keys_d_.get(),
-      pooling_sorted_keys_d_.get(), pooling_indices_d_.get(), pooling_sorted_indices_d_.get(),
-      capacity, 0, 63, stream_));
+    CHECK_CUDA_ERROR(
+      cub::DeviceRadixSort::SortPairs(
+        pooling_workspace_d_.get(), pooling_workspace_size_, pooling_keys_d_.get(),
+        pooling_sorted_keys_d_.get(), pooling_indices_d_.get(), pooling_sorted_indices_d_.get(),
+        capacity, 0, 63, stream_));
 
     markPoolingRunsKernel<<<num_blocks, config_.threads_per_block_, 0, stream_>>>(
       pooling_sorted_keys_d_.get(), pooling_run_flags_d_.get(), capacity);
     CHECK_CUDA_ERROR(cudaPeekAtLastError());
 
-    CHECK_CUDA_ERROR(cub::DeviceScan::InclusiveSum(
-      pooling_workspace_d_.get(), pooling_workspace_size_, pooling_run_flags_d_.get(),
-      pooling_run_ids_d_.get(), capacity, stream_));
+    CHECK_CUDA_ERROR(
+      cub::DeviceScan::InclusiveSum(
+        pooling_workspace_d_.get(), pooling_workspace_size_, pooling_run_flags_d_.get(),
+        pooling_run_ids_d_.get(), capacity, stream_));
 
     fillPoolingStageKernel<<<num_blocks, config_.threads_per_block_, 0, stream_>>>(
       current_grid_coord, current_serialized_code, pooling_sorted_keys_d_.get(),
@@ -485,10 +487,11 @@ void PreprocessCuda::generateSerializedPoolingMetadata(
         static_cast<std::int32_t>(stage_index + 1), order_index, capacity);
       CHECK_CUDA_ERROR(cudaPeekAtLastError());
 
-      CHECK_CUDA_ERROR(cub::DeviceRadixSort::SortPairs(
-        pooling_workspace_d_.get(), pooling_workspace_size_, pooling_keys_d_.get(),
-        pooling_sorted_keys_d_.get(), pooling_indices_d_.get(), pooling_sorted_indices_d_.get(),
-        capacity, 0, 63, stream_));
+      CHECK_CUDA_ERROR(
+        cub::DeviceRadixSort::SortPairs(
+          pooling_workspace_d_.get(), pooling_workspace_size_, pooling_keys_d_.get(),
+          pooling_sorted_keys_d_.get(), pooling_indices_d_.get(), pooling_sorted_indices_d_.get(),
+          capacity, 0, 63, stream_));
 
       fillOrderAndInverseKernel<<<num_blocks, config_.threads_per_block_, 0, stream_>>>(
         pooling_sorted_keys_d_.get(), pooling_sorted_indices_d_.get(), stage_counts,

--- a/perception/autoware_ptv3/lib/preprocess/preprocess_kernel.cu
+++ b/perception/autoware_ptv3/lib/preprocess/preprocess_kernel.cu
@@ -27,7 +27,9 @@
 #include <thrust/sequence.h>
 #include <thrust/unique.h>
 
+#include <algorithm>
 #include <limits>
+#include <stdexcept>
 
 namespace autoware::ptv3
 {
@@ -83,6 +85,27 @@ PreprocessCuda::PreprocessCuda(const PTv3Config & config, cudaStream_t stream)
     config_.cloud_capacity_, 0, 64, nullptr);
 
   sort_workspace_d_ = autoware::cuda_utils::make_unique<std::uint8_t[]>(sort_workspace_size_);
+
+  pooling_keys_d_ = autoware::cuda_utils::make_unique<std::int64_t[]>(config_.max_num_voxels_);
+  pooling_sorted_keys_d_ =
+    autoware::cuda_utils::make_unique<std::int64_t[]>(config_.max_num_voxels_);
+  pooling_indices_d_ = autoware::cuda_utils::make_unique<std::int64_t[]>(config_.max_num_voxels_);
+  pooling_sorted_indices_d_ =
+    autoware::cuda_utils::make_unique<std::int64_t[]>(config_.max_num_voxels_);
+  pooling_run_flags_d_ = autoware::cuda_utils::make_unique<std::int64_t[]>(config_.max_num_voxels_);
+  pooling_run_ids_d_ = autoware::cuda_utils::make_unique<std::int64_t[]>(config_.max_num_voxels_);
+
+  std::size_t pooling_sort_workspace_size = 0;
+  std::size_t pooling_scan_workspace_size = 0;
+  std::int64_t * int64_nullptr = nullptr;
+  cub::DeviceRadixSort::SortPairs(
+    nullptr, pooling_sort_workspace_size, int64_nullptr, int64_nullptr, int64_nullptr,
+    int64_nullptr, config_.max_num_voxels_, 0, 63, nullptr);
+  cub::DeviceScan::InclusiveSum(
+    nullptr, pooling_scan_workspace_size, int64_nullptr, int64_nullptr, config_.max_num_voxels_,
+    nullptr);
+  pooling_workspace_size_ = std::max(pooling_sort_workspace_size, pooling_scan_workspace_size);
+  pooling_workspace_d_ = autoware::cuda_utils::make_unique<std::uint8_t[]>(pooling_workspace_size_);
 
   CHECK_CUDA_ERROR(cudaStreamSynchronize(stream_));
 }
@@ -273,6 +296,203 @@ __global__ void computeGridCoordsAndSerializationKernel(
 
   hashes[idx] = key1;
   hashes[idx + num_points] = key2;
+}
+
+constexpr std::int64_t kInvalidPoolingKey = std::numeric_limits<std::int64_t>::max();
+
+__global__ void setInitialStageCountKernel(
+  std::int64_t * __restrict__ stage_counts, std::int64_t num_voxels)
+{
+  *stage_counts = num_voxels;
+}
+
+__global__ void preparePoolingSortInputKernel(
+  const std::int64_t * __restrict__ serialized_code, const std::int64_t * __restrict__ stage_counts,
+  std::int64_t * __restrict__ keys, std::int64_t * __restrict__ indices, std::int32_t stage_index,
+  std::int32_t pooling_depth, std::int64_t capacity)
+{
+  const auto idx = static_cast<std::int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (idx >= capacity) {
+    return;
+  }
+
+  const auto input_count = stage_counts[stage_index];
+  keys[idx] = idx < input_count ? serialized_code[idx] >> (pooling_depth * 3) : kInvalidPoolingKey;
+  indices[idx] = idx;
+}
+
+__global__ void markPoolingRunsKernel(
+  const std::int64_t * __restrict__ sorted_keys, std::int64_t * __restrict__ run_flags,
+  std::int64_t capacity)
+{
+  const auto idx = static_cast<std::int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (idx >= capacity) {
+    return;
+  }
+
+  const auto key = sorted_keys[idx];
+  run_flags[idx] = key != kInvalidPoolingKey && (idx == 0 || key != sorted_keys[idx - 1]) ? 1 : 0;
+}
+
+__global__ void fillPoolingStageKernel(
+  const std::int64_t * __restrict__ grid_coord_in,
+  const std::int64_t * __restrict__ serialized_code_in,
+  const std::int64_t * __restrict__ sorted_keys, const std::int64_t * __restrict__ sorted_indices,
+  const std::int64_t * __restrict__ run_flags, const std::int64_t * __restrict__ run_ids,
+  std::int64_t * __restrict__ indices_out, std::int64_t * __restrict__ indptr_out,
+  std::int64_t * __restrict__ head_indices_out, std::int64_t * __restrict__ cluster_out,
+  std::int64_t * __restrict__ grid_coord_out, std::int64_t * __restrict__ serialized_code_out,
+  std::int64_t * __restrict__ stage_counts, std::int32_t stage_index, std::int32_t pooling_depth,
+  std::int32_t num_orders, std::int64_t capacity)
+{
+  const auto idx = static_cast<std::int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (idx >= capacity) {
+    return;
+  }
+
+  const auto next_count = run_ids[capacity - 1];
+  if (idx == 0) {
+    stage_counts[stage_index + 1] = next_count;
+    indptr_out[next_count] = stage_counts[stage_index];
+  }
+
+  if (sorted_keys[idx] == kInvalidPoolingKey) {
+    return;
+  }
+
+  const auto input_index = sorted_indices[idx];
+  const auto segment_index = run_ids[idx] - 1;
+  indices_out[idx] = input_index;
+  cluster_out[input_index] = segment_index;
+
+  if (run_flags[idx] == 0) {
+    return;
+  }
+
+  indptr_out[segment_index] = idx;
+  head_indices_out[segment_index] = input_index;
+  for (std::int32_t coord_index = 0; coord_index < 3; ++coord_index) {
+    grid_coord_out[segment_index * 3 + coord_index] =
+      grid_coord_in[input_index * 3 + coord_index] >> pooling_depth;
+  }
+  for (std::int32_t order_index = 0; order_index < num_orders; ++order_index) {
+    serialized_code_out[order_index * capacity + segment_index] =
+      serialized_code_in[order_index * capacity + input_index] >> (pooling_depth * 3);
+  }
+}
+
+__global__ void prepareOrderSortInputKernel(
+  const std::int64_t * __restrict__ serialized_code, const std::int64_t * __restrict__ stage_counts,
+  std::int64_t * __restrict__ keys, std::int64_t * __restrict__ indices, std::int32_t stage_index,
+  std::int32_t order_index, std::int64_t capacity)
+{
+  const auto idx = static_cast<std::int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (idx >= capacity) {
+    return;
+  }
+
+  const auto input_count = stage_counts[stage_index];
+  keys[idx] =
+    idx < input_count ? serialized_code[order_index * capacity + idx] : kInvalidPoolingKey;
+  indices[idx] = idx;
+}
+
+__global__ void fillOrderAndInverseKernel(
+  const std::int64_t * __restrict__ sorted_keys, const std::int64_t * __restrict__ sorted_indices,
+  const std::int64_t * __restrict__ stage_counts, std::int64_t * __restrict__ order_out,
+  std::int64_t * __restrict__ inverse_out, std::int32_t stage_index, std::int32_t order_index,
+  std::int64_t capacity)
+{
+  const auto rank = static_cast<std::int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (
+    rank >= capacity || rank >= stage_counts[stage_index] ||
+    sorted_keys[rank] == kInvalidPoolingKey) {
+    return;
+  }
+
+  const auto input_index = sorted_indices[rank];
+  order_out[order_index * capacity + rank] = input_index;
+  inverse_out[order_index * capacity + input_index] = rank;
+}
+
+std::int32_t poolingDepth(const std::int64_t stride)
+{
+  std::int32_t depth = 0;
+  for (auto value = stride; value > 1; value >>= 1) {
+    ++depth;
+  }
+  return depth;
+}
+
+void PreprocessCuda::generateSerializedPoolingMetadata(
+  const std::int64_t * grid_coord, const std::int64_t * serialized_code, std::int64_t num_voxels,
+  const std::vector<SerializedPoolingDeviceStageView> & stages, std::int64_t * stage_counts)
+{
+  if (stages.size() != config_.pooling_strides_.size()) {
+    throw std::runtime_error("Serialized pooling stage buffer count does not match config.");
+  }
+
+  const auto capacity = config_.max_num_voxels_;
+  const auto num_orders = static_cast<std::int32_t>(config_.serialization_orders_.size());
+  const auto num_blocks = divup(static_cast<std::size_t>(capacity), config_.threads_per_block_);
+
+  setInitialStageCountKernel<<<1, 1, 0, stream_>>>(stage_counts, num_voxels);
+  CHECK_CUDA_ERROR(cudaPeekAtLastError());
+
+  const std::int64_t * current_grid_coord = grid_coord;
+  const std::int64_t * current_serialized_code = serialized_code;
+
+  for (std::size_t stage_index = 0; stage_index < stages.size(); ++stage_index) {
+    const auto & stage = stages[stage_index];
+    const auto pooling_depth = poolingDepth(config_.pooling_strides_[stage_index]);
+
+    preparePoolingSortInputKernel<<<num_blocks, config_.threads_per_block_, 0, stream_>>>(
+      current_serialized_code, stage_counts, pooling_keys_d_.get(), pooling_indices_d_.get(),
+      static_cast<std::int32_t>(stage_index), pooling_depth, capacity);
+    CHECK_CUDA_ERROR(cudaPeekAtLastError());
+
+    CHECK_CUDA_ERROR(cub::DeviceRadixSort::SortPairs(
+      pooling_workspace_d_.get(), pooling_workspace_size_, pooling_keys_d_.get(),
+      pooling_sorted_keys_d_.get(), pooling_indices_d_.get(), pooling_sorted_indices_d_.get(),
+      capacity, 0, 63, stream_));
+
+    markPoolingRunsKernel<<<num_blocks, config_.threads_per_block_, 0, stream_>>>(
+      pooling_sorted_keys_d_.get(), pooling_run_flags_d_.get(), capacity);
+    CHECK_CUDA_ERROR(cudaPeekAtLastError());
+
+    CHECK_CUDA_ERROR(cub::DeviceScan::InclusiveSum(
+      pooling_workspace_d_.get(), pooling_workspace_size_, pooling_run_flags_d_.get(),
+      pooling_run_ids_d_.get(), capacity, stream_));
+
+    fillPoolingStageKernel<<<num_blocks, config_.threads_per_block_, 0, stream_>>>(
+      current_grid_coord, current_serialized_code, pooling_sorted_keys_d_.get(),
+      pooling_sorted_indices_d_.get(), pooling_run_flags_d_.get(), pooling_run_ids_d_.get(),
+      stage.indices, stage.indptr, stage.head_indices, stage.cluster, stage.grid_coord,
+      stage.serialized_code, stage_counts, static_cast<std::int32_t>(stage_index), pooling_depth,
+      num_orders, capacity);
+    CHECK_CUDA_ERROR(cudaPeekAtLastError());
+
+    for (std::int32_t order_index = 0; order_index < num_orders; ++order_index) {
+      prepareOrderSortInputKernel<<<num_blocks, config_.threads_per_block_, 0, stream_>>>(
+        stage.serialized_code, stage_counts, pooling_keys_d_.get(), pooling_indices_d_.get(),
+        static_cast<std::int32_t>(stage_index + 1), order_index, capacity);
+      CHECK_CUDA_ERROR(cudaPeekAtLastError());
+
+      CHECK_CUDA_ERROR(cub::DeviceRadixSort::SortPairs(
+        pooling_workspace_d_.get(), pooling_workspace_size_, pooling_keys_d_.get(),
+        pooling_sorted_keys_d_.get(), pooling_indices_d_.get(), pooling_sorted_indices_d_.get(),
+        capacity, 0, 63, stream_));
+
+      fillOrderAndInverseKernel<<<num_blocks, config_.threads_per_block_, 0, stream_>>>(
+        pooling_sorted_keys_d_.get(), pooling_sorted_indices_d_.get(), stage_counts,
+        stage.serialized_order, stage.serialized_inverse,
+        static_cast<std::int32_t>(stage_index + 1), order_index, capacity);
+      CHECK_CUDA_ERROR(cudaPeekAtLastError());
+    }
+
+    current_grid_coord = stage.grid_coord;
+    current_serialized_code = stage.serialized_code;
+  }
 }
 
 std::size_t PreprocessCuda::generateFeatures(

--- a/perception/autoware_ptv3/lib/preprocess/preprocess_kernel.cu
+++ b/perception/autoware_ptv3/lib/preprocess/preprocess_kernel.cu
@@ -350,10 +350,16 @@ __global__ void fillPoolingStageKernel(
     return;
   }
 
+  // The order-major (per-serialization-order) tensors are stored densely so they can be bound
+  // directly to the engine inputs of shape [num_orders, count]: the input is strided by the
+  // stage's input count (the original serialized_code is laid out [2, num_voxels]) and the output
+  // by the stage's output count. Using `capacity` as the stride here would both misread the
+  // dense input and produce a non-dense output that TensorRT cannot consume.
+  const auto input_count = stage_counts[stage_index];
   const auto next_count = run_ids[capacity - 1];
   if (idx == 0) {
     stage_counts[stage_index + 1] = next_count;
-    indptr_out[next_count] = stage_counts[stage_index];
+    indptr_out[next_count] = input_count;
   }
 
   if (sorted_keys[idx] == kInvalidPoolingKey) {
@@ -376,8 +382,8 @@ __global__ void fillPoolingStageKernel(
       grid_coord_in[input_index * 3 + coord_index] >> pooling_depth;
   }
   for (std::int32_t order_index = 0; order_index < num_orders; ++order_index) {
-    serialized_code_out[order_index * capacity + segment_index] =
-      serialized_code_in[order_index * capacity + input_index] >> (pooling_depth * 3);
+    serialized_code_out[order_index * next_count + segment_index] =
+      serialized_code_in[order_index * input_count + input_index] >> (pooling_depth * 3);
   }
 }
 
@@ -392,8 +398,9 @@ __global__ void prepareOrderSortInputKernel(
   }
 
   const auto input_count = stage_counts[stage_index];
+  // serialized_code is stored densely as [num_orders, input_count] (see fillPoolingStageKernel).
   keys[idx] =
-    idx < input_count ? serialized_code[order_index * capacity + idx] : kInvalidPoolingKey;
+    idx < input_count ? serialized_code[order_index * input_count + idx] : kInvalidPoolingKey;
   indices[idx] = idx;
 }
 
@@ -403,16 +410,16 @@ __global__ void fillOrderAndInverseKernel(
   std::int64_t * __restrict__ inverse_out, std::int32_t stage_index, std::int32_t order_index,
   std::int64_t capacity)
 {
+  const auto count = stage_counts[stage_index];
   const auto rank = static_cast<std::int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
-  if (
-    rank >= capacity || rank >= stage_counts[stage_index] ||
-    sorted_keys[rank] == kInvalidPoolingKey) {
+  if (rank >= capacity || rank >= count || sorted_keys[rank] == kInvalidPoolingKey) {
     return;
   }
 
+  // order/inverse are stored densely as [num_orders, count] to match the engine input layout.
   const auto input_index = sorted_indices[rank];
-  order_out[order_index * capacity + rank] = input_index;
-  inverse_out[order_index * capacity + input_index] = rank;
+  order_out[order_index * count + rank] = input_index;
+  inverse_out[order_index * count + input_index] = rank;
 }
 
 std::int32_t poolingDepth(const std::int64_t stride)

--- a/perception/autoware_ptv3/lib/ptv3_trt.cpp
+++ b/perception/autoware_ptv3/lib/ptv3_trt.cpp
@@ -35,6 +35,19 @@
 
 namespace autoware::ptv3
 {
+namespace
+{
+
+std::int64_t poolingDepth(const std::int64_t stride)
+{
+  std::int64_t depth = 0;
+  for (auto value = stride; value > 1; value >>= 1) {
+    ++depth;
+  }
+  return depth;
+}
+
+}  // namespace
 
 PTv3TRT::PTv3TRT(const tensorrt_common::TrtCommonConfig & trt_config, const PTv3Config & config)
 : config_(config)
@@ -148,6 +161,39 @@ void PTv3TRT::initPtr()
   post_ptr_ = std::make_unique<PostprocessCuda>(config_, stream_);
 
   allocateMessages();
+  allocateSerializedPoolingBuffers();
+}
+
+void PTv3TRT::allocateSerializedPoolingBuffers()
+{
+  serialized_pooling_stages_d_.clear();
+  serialized_pooling_stages_d_.reserve(config_.pooling_strides_.size());
+  const auto max_num_voxels = static_cast<std::size_t>(config_.max_num_voxels_);
+  const auto num_orders = config_.serialization_orders_.size();
+
+  for (std::size_t stage_index = 0; stage_index < config_.pooling_strides_.size(); ++stage_index) {
+    SerializedPoolingDeviceStage stage;
+    stage.indices = autoware::cuda_utils::make_unique<std::int64_t[]>(max_num_voxels);
+    stage.indptr = autoware::cuda_utils::make_unique<std::int64_t[]>(max_num_voxels + 1);
+    stage.head_indices = autoware::cuda_utils::make_unique<std::int64_t[]>(max_num_voxels);
+    stage.cluster = autoware::cuda_utils::make_unique<std::int64_t[]>(max_num_voxels);
+    stage.grid_coord = autoware::cuda_utils::make_unique<std::int64_t[]>(max_num_voxels * 3);
+    stage.serialized_code =
+      autoware::cuda_utils::make_unique<std::int64_t[]>(max_num_voxels * num_orders);
+    stage.serialized_order =
+      autoware::cuda_utils::make_unique<std::int64_t[]>(max_num_voxels * num_orders);
+    stage.serialized_inverse =
+      autoware::cuda_utils::make_unique<std::int64_t[]>(max_num_voxels * num_orders);
+    serialized_pooling_stages_d_.push_back(std::move(stage));
+  }
+
+  serialized_pooling_num_voxels_d_ =
+    autoware::cuda_utils::make_unique<std::int64_t[]>(config_.pooling_strides_.size() + 1);
+  serialized_pooling_num_voxels_.assign(config_.pooling_strides_.size() + 1, 0);
+  serialized_pooling_depths_.resize(config_.pooling_strides_.size());
+  for (std::size_t stage_index = 0; stage_index < config_.pooling_strides_.size(); ++stage_index) {
+    serialized_pooling_depths_[stage_index] = poolingDepth(config_.pooling_strides_[stage_index]);
+  }
 }
 
 void PTv3TRT::createPointFields()
@@ -230,6 +276,30 @@ void PTv3TRT::initTrt(const tensorrt_common::TrtCommonConfig & trt_config)
   network_trt_ptr_->setTensorAddress("serialized_code", serialized_code_d_.get());
   network_trt_ptr_->setTensorAddress("pred_labels", pred_labels_d_.get());
   network_trt_ptr_->setTensorAddress("pred_probs", pred_probs_d_.get());
+}
+
+void PTv3TRT::precomputeSerializedPoolingMetadata()
+{
+  if (config_.pooling_strides_.empty()) {
+    return;
+  }
+
+  std::vector<SerializedPoolingDeviceStageView> stage_views;
+  stage_views.reserve(serialized_pooling_stages_d_.size());
+  for (auto & stage : serialized_pooling_stages_d_) {
+    stage_views.push_back(SerializedPoolingDeviceStageView{
+      stage.indices.get(), stage.indptr.get(), stage.head_indices.get(), stage.cluster.get(),
+      stage.grid_coord.get(), stage.serialized_code.get(), stage.serialized_order.get(),
+      stage.serialized_inverse.get()});
+  }
+
+  pre_ptr_->generateSerializedPoolingMetadata(
+    grid_coord_d_.get(), serialized_code_d_.get(), num_voxels_, stage_views,
+    serialized_pooling_num_voxels_d_.get());
+  CHECK_CUDA_ERROR(cudaMemcpyAsync(
+    serialized_pooling_num_voxels_.data(), serialized_pooling_num_voxels_d_.get(),
+    serialized_pooling_num_voxels_.size() * sizeof(std::int64_t), cudaMemcpyDeviceToHost, stream_));
+  CHECK_CUDA_ERROR(cudaStreamSynchronize(stream_));
 }
 
 CloudFormat PTv3TRT::detectCloudFormat(const cuda_blackboard::CudaPointCloud2 & cloud) const
@@ -438,6 +508,8 @@ bool PTv3TRT::preProcess(const std::shared_ptr<const cuda_blackboard::CudaPointC
                                     << config_.max_num_voxels_ << "). Clipping to the limit.");
     num_voxels_ = config_.max_num_voxels_;
   }
+
+  precomputeSerializedPoolingMetadata();
 
   network_trt_ptr_->setInputShape("grid_coord", nvinfer1::Dims{2, {num_voxels_, 3}});
   network_trt_ptr_->setInputShape("feat", nvinfer1::Dims{2, {num_voxels_, 4}});

--- a/perception/autoware_ptv3/lib/ptv3_trt.cpp
+++ b/perception/autoware_ptv3/lib/ptv3_trt.cpp
@@ -258,6 +258,55 @@ void PTv3TRT::initTrt(const tensorrt_common::TrtCommonConfig & trt_config)
     "serialized_code", nvinfer1::Dims{2, {2, config_.voxels_num_[0]}},
     nvinfer1::Dims{2, {2, config_.voxels_num_[1]}}, nvinfer1::Dims{2, {2, config_.voxels_num_[2]}});
 
+  // Serialized pooling metadata inputs are precomputed on device each frame and fed as engine
+  // inputs (see precomputeSerializedPoolingMetadata). Their per-stage extents are data-dependent,
+  // so they are declared dynamic and bounded by the voxel-count optimization profile. A pooled
+  // (output) count is at most its input count, so all pooled dims are conservatively bounded by
+  // [1, opt, max] voxels.
+  const auto add_pooling_io =
+    [&network_io, &profile_dims](
+      const std::string & name, const nvinfer1::Dims & io_dims, const nvinfer1::Dims & min_dims,
+      const nvinfer1::Dims & opt_dims, const nvinfer1::Dims & max_dims) {
+      network_io.emplace_back(name, io_dims);
+      profile_dims.emplace_back(name, min_dims, opt_dims, max_dims);
+    };
+
+  const std::int64_t min_voxels = config_.voxels_num_[0];
+  const std::int64_t opt_voxels = config_.voxels_num_[1];
+  const std::int64_t max_voxels = config_.voxels_num_[2];
+  const std::int64_t num_orders = static_cast<std::int64_t>(config_.serialization_orders_.size());
+
+  for (std::size_t stage = 0; stage < config_.pooling_strides_.size(); ++stage) {
+    const auto prefix = "serialized_pooling_" + std::to_string(stage) + "_";
+    // Input-count-sized tensors. Stage 0 consumes the original voxels and therefore shares their
+    // lower bound; deeper stages consume an already-pooled (smaller) count.
+    const std::int64_t in_min = stage == 0 ? min_voxels : 1;
+    add_pooling_io(
+      prefix + "indices", nvinfer1::Dims{1, {-1}}, nvinfer1::Dims{1, {in_min}},
+      nvinfer1::Dims{1, {opt_voxels}}, nvinfer1::Dims{1, {max_voxels}});
+    add_pooling_io(
+      prefix + "cluster", nvinfer1::Dims{1, {-1}}, nvinfer1::Dims{1, {in_min}},
+      nvinfer1::Dims{1, {opt_voxels}}, nvinfer1::Dims{1, {max_voxels}});
+    // Output-count-sized (pooled) tensors.
+    add_pooling_io(
+      prefix + "indptr", nvinfer1::Dims{1, {-1}}, nvinfer1::Dims{1, {2}},
+      nvinfer1::Dims{1, {opt_voxels + 1}}, nvinfer1::Dims{1, {max_voxels + 1}});
+    add_pooling_io(
+      prefix + "head_indices", nvinfer1::Dims{1, {-1}}, nvinfer1::Dims{1, {1}},
+      nvinfer1::Dims{1, {opt_voxels}}, nvinfer1::Dims{1, {max_voxels}});
+    add_pooling_io(
+      prefix + "grid_coord", nvinfer1::Dims{2, {-1, 3}}, nvinfer1::Dims{2, {1, 3}},
+      nvinfer1::Dims{2, {opt_voxels, 3}}, nvinfer1::Dims{2, {max_voxels, 3}});
+    add_pooling_io(
+      prefix + "serialized_order", nvinfer1::Dims{2, {num_orders, -1}},
+      nvinfer1::Dims{2, {num_orders, 1}}, nvinfer1::Dims{2, {num_orders, opt_voxels}},
+      nvinfer1::Dims{2, {num_orders, max_voxels}});
+    add_pooling_io(
+      prefix + "serialized_inverse", nvinfer1::Dims{2, {num_orders, -1}},
+      nvinfer1::Dims{2, {num_orders, 1}}, nvinfer1::Dims{2, {num_orders, opt_voxels}},
+      nvinfer1::Dims{2, {num_orders, max_voxels}});
+  }
+
   auto network_io_ptr =
     std::make_unique<std::vector<autoware::tensorrt_common::NetworkIO>>(network_io);
   auto profile_dims_ptr =
@@ -276,6 +325,30 @@ void PTv3TRT::initTrt(const tensorrt_common::TrtCommonConfig & trt_config)
   network_trt_ptr_->setTensorAddress("serialized_code", serialized_code_d_.get());
   network_trt_ptr_->setTensorAddress("pred_labels", pred_labels_d_.get());
   network_trt_ptr_->setTensorAddress("pred_probs", pred_probs_d_.get());
+
+  bindSerializedPoolingAddresses();
+}
+
+void PTv3TRT::bindSerializedPoolingAddresses()
+{
+  // Metadata buffers are allocated once in allocateSerializedPoolingBuffers and never reallocated,
+  // so their device addresses are stable and can be bound a single time. The per-stage
+  // serialized_code buffers are only used to chain pooling stages on the host side and are not
+  // engine inputs, so they are intentionally not bound here.
+  for (std::size_t stage = 0; stage < serialized_pooling_stages_d_.size(); ++stage) {
+    const auto prefix = "serialized_pooling_" + std::to_string(stage) + "_";
+    auto & buffers = serialized_pooling_stages_d_[stage];
+    network_trt_ptr_->setTensorAddress((prefix + "indices").c_str(), buffers.indices.get());
+    network_trt_ptr_->setTensorAddress((prefix + "indptr").c_str(), buffers.indptr.get());
+    network_trt_ptr_->setTensorAddress(
+      (prefix + "head_indices").c_str(), buffers.head_indices.get());
+    network_trt_ptr_->setTensorAddress((prefix + "cluster").c_str(), buffers.cluster.get());
+    network_trt_ptr_->setTensorAddress((prefix + "grid_coord").c_str(), buffers.grid_coord.get());
+    network_trt_ptr_->setTensorAddress(
+      (prefix + "serialized_order").c_str(), buffers.serialized_order.get());
+    network_trt_ptr_->setTensorAddress(
+      (prefix + "serialized_inverse").c_str(), buffers.serialized_inverse.get());
+  }
 }
 
 void PTv3TRT::precomputeSerializedPoolingMetadata()
@@ -300,6 +373,36 @@ void PTv3TRT::precomputeSerializedPoolingMetadata()
     serialized_pooling_num_voxels_.data(), serialized_pooling_num_voxels_d_.get(),
     serialized_pooling_num_voxels_.size() * sizeof(std::int64_t), cudaMemcpyDeviceToHost, stream_));
   CHECK_CUDA_ERROR(cudaStreamSynchronize(stream_));
+}
+
+bool PTv3TRT::setSerializedPoolingInputShapes()
+{
+  bool success = true;
+  const auto num_orders = static_cast<std::int64_t>(config_.serialization_orders_.size());
+
+  // serialized_pooling_num_voxels_[s] is the input count of stage s (entry 0 is num_voxels_) and
+  // [s + 1] is its pooled output count, matching the dense buffer layouts written by the kernels.
+  for (std::size_t stage = 0; stage < serialized_pooling_stages_d_.size(); ++stage) {
+    const auto prefix = "serialized_pooling_" + std::to_string(stage) + "_";
+    const auto in_count = serialized_pooling_num_voxels_[stage];
+    const auto out_count = serialized_pooling_num_voxels_[stage + 1];
+    success &= network_trt_ptr_->setInputShape(
+      (prefix + "indices").c_str(), nvinfer1::Dims{1, {in_count}});
+    success &= network_trt_ptr_->setInputShape(
+      (prefix + "cluster").c_str(), nvinfer1::Dims{1, {in_count}});
+    success &= network_trt_ptr_->setInputShape(
+      (prefix + "indptr").c_str(), nvinfer1::Dims{1, {out_count + 1}});
+    success &= network_trt_ptr_->setInputShape(
+      (prefix + "head_indices").c_str(), nvinfer1::Dims{1, {out_count}});
+    success &= network_trt_ptr_->setInputShape(
+      (prefix + "grid_coord").c_str(), nvinfer1::Dims{2, {out_count, 3}});
+    success &= network_trt_ptr_->setInputShape(
+      (prefix + "serialized_order").c_str(), nvinfer1::Dims{2, {num_orders, out_count}});
+    success &= network_trt_ptr_->setInputShape(
+      (prefix + "serialized_inverse").c_str(), nvinfer1::Dims{2, {num_orders, out_count}});
+  }
+
+  return success;
 }
 
 CloudFormat PTv3TRT::detectCloudFormat(const cuda_blackboard::CudaPointCloud2 & cloud) const
@@ -514,6 +617,11 @@ bool PTv3TRT::preProcess(const std::shared_ptr<const cuda_blackboard::CudaPointC
   network_trt_ptr_->setInputShape("grid_coord", nvinfer1::Dims{2, {num_voxels_, 3}});
   network_trt_ptr_->setInputShape("feat", nvinfer1::Dims{2, {num_voxels_, 4}});
   network_trt_ptr_->setInputShape("serialized_code", nvinfer1::Dims{2, {2, num_voxels_}});
+
+  if (!setSerializedPoolingInputShapes()) {
+    RCLCPP_ERROR(rclcpp::get_logger("ptv3"), "Failed to set serialized pooling input shapes.");
+    return false;
+  }
 
   return true;
 }

--- a/perception/autoware_ptv3/lib/ptv3_trt.cpp
+++ b/perception/autoware_ptv3/lib/ptv3_trt.cpp
@@ -263,13 +263,13 @@ void PTv3TRT::initTrt(const tensorrt_common::TrtCommonConfig & trt_config)
   // so they are declared dynamic and bounded by the voxel-count optimization profile. A pooled
   // (output) count is at most its input count, so all pooled dims are conservatively bounded by
   // [1, opt, max] voxels.
-  const auto add_pooling_io =
-    [&network_io, &profile_dims](
-      const std::string & name, const nvinfer1::Dims & io_dims, const nvinfer1::Dims & min_dims,
-      const nvinfer1::Dims & opt_dims, const nvinfer1::Dims & max_dims) {
-      network_io.emplace_back(name, io_dims);
-      profile_dims.emplace_back(name, min_dims, opt_dims, max_dims);
-    };
+  const auto add_pooling_io = [&network_io, &profile_dims](
+                                const std::string & name, const nvinfer1::Dims & io_dims,
+                                const nvinfer1::Dims & min_dims, const nvinfer1::Dims & opt_dims,
+                                const nvinfer1::Dims & max_dims) {
+    network_io.emplace_back(name, io_dims);
+    profile_dims.emplace_back(name, min_dims, opt_dims, max_dims);
+  };
 
   const std::int64_t min_voxels = config_.voxels_num_[0];
   const std::int64_t opt_voxels = config_.voxels_num_[1];
@@ -360,10 +360,11 @@ void PTv3TRT::precomputeSerializedPoolingMetadata()
   std::vector<SerializedPoolingDeviceStageView> stage_views;
   stage_views.reserve(serialized_pooling_stages_d_.size());
   for (auto & stage : serialized_pooling_stages_d_) {
-    stage_views.push_back(SerializedPoolingDeviceStageView{
-      stage.indices.get(), stage.indptr.get(), stage.head_indices.get(), stage.cluster.get(),
-      stage.grid_coord.get(), stage.serialized_code.get(), stage.serialized_order.get(),
-      stage.serialized_inverse.get()});
+    stage_views.push_back(
+      SerializedPoolingDeviceStageView{
+        stage.indices.get(), stage.indptr.get(), stage.head_indices.get(), stage.cluster.get(),
+        stage.grid_coord.get(), stage.serialized_code.get(), stage.serialized_order.get(),
+        stage.serialized_inverse.get()});
   }
 
   pre_ptr_->generateSerializedPoolingMetadata(
@@ -386,10 +387,10 @@ bool PTv3TRT::setSerializedPoolingInputShapes()
     const auto prefix = "serialized_pooling_" + std::to_string(stage) + "_";
     const auto in_count = serialized_pooling_num_voxels_[stage];
     const auto out_count = serialized_pooling_num_voxels_[stage + 1];
-    success &= network_trt_ptr_->setInputShape(
-      (prefix + "indices").c_str(), nvinfer1::Dims{1, {in_count}});
-    success &= network_trt_ptr_->setInputShape(
-      (prefix + "cluster").c_str(), nvinfer1::Dims{1, {in_count}});
+    success &=
+      network_trt_ptr_->setInputShape((prefix + "indices").c_str(), nvinfer1::Dims{1, {in_count}});
+    success &=
+      network_trt_ptr_->setInputShape((prefix + "cluster").c_str(), nvinfer1::Dims{1, {in_count}});
     success &= network_trt_ptr_->setInputShape(
       (prefix + "indptr").c_str(), nvinfer1::Dims{1, {out_count + 1}});
     success &= network_trt_ptr_->setInputShape(

--- a/perception/autoware_ptv3/package.xml
+++ b/perception/autoware_ptv3/package.xml
@@ -27,6 +27,7 @@
 
   <exec_depend>autoware_tensorrt_plugins</exec_depend>
 
+  <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_cmake_ros</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>

--- a/perception/autoware_ptv3/schema/ml_package_ptv3.schema.json
+++ b/perception/autoware_ptv3/schema/ml_package_ptv3.schema.json
@@ -51,9 +51,37 @@
           "default": [0.3, 0.3, 8.0],
           "minItems": 3,
           "maxItems": 3
+        },
+        "serialization_orders": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": ["z", "z-trans"]
+          },
+          "description": "Space-filling curve serialization orders used by the exported model.",
+          "default": ["z", "z-trans"],
+          "minItems": 2,
+          "maxItems": 2
+        },
+        "pooling_strides": {
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "enum": [2]
+          },
+          "description": "SerializedPooling strides for each encoder downsampling stage.",
+          "default": [2, 2, 2, 2]
         }
       },
-      "required": ["class_names", "palette", "voxels_num", "point_cloud_range", "voxel_size"],
+      "required": [
+        "class_names",
+        "palette",
+        "voxels_num",
+        "point_cloud_range",
+        "voxel_size",
+        "serialization_orders",
+        "pooling_strides"
+      ],
       "additionalProperties": false
     }
   },

--- a/perception/autoware_ptv3/src/ptv3_node.cpp
+++ b/perception/autoware_ptv3/src/ptv3_node.cpp
@@ -49,6 +49,10 @@ PTv3Node::PTv3Node(const rclcpp::NodeOptions & options) : Node("ptv3", options)
     to_float_vector(this->declare_parameter<std::vector<double>>("point_cloud_range", descriptor));
   const auto voxel_size =
     to_float_vector(this->declare_parameter<std::vector<double>>("voxel_size", descriptor));
+  const auto serialization_orders =
+    this->declare_parameter<std::vector<std::string>>("serialization_orders", descriptor);
+  const auto pooling_strides =
+    this->declare_parameter<std::vector<std::int64_t>>("pooling_strides", descriptor);
 
   // Head parameters
   auto class_names = this->declare_parameter<std::vector<std::string>>("class_names", descriptor);
@@ -70,9 +74,9 @@ PTv3Node::PTv3Node(const rclcpp::NodeOptions & options) : Node("ptv3", options)
   }
 
   PTv3Config config(
-    plugins_path, cloud_capacity, voxels_num, point_cloud_range, voxel_size, class_names, palette,
-    filter_class_probability_threshold, filter_classes, filter_output_format,
-    source_reconstruction);
+    plugins_path, cloud_capacity, voxels_num, point_cloud_range, voxel_size, class_names,
+    serialization_orders, pooling_strides, palette, filter_class_probability_threshold,
+    filter_classes, filter_output_format, source_reconstruction);
 
   auto trt_config =
     tensorrt_common::TrtCommonConfig(onnx_path, trt_precision, engine_path, 1ULL << 33U);

--- a/perception/autoware_ptv3/test/serialized_pooling_metadata_test.cpp
+++ b/perception/autoware_ptv3/test/serialized_pooling_metadata_test.cpp
@@ -287,8 +287,8 @@ CpuStage make_stage_reference(
 PTv3Config make_test_config()
 {
   return PTv3Config(
-    "", 64, {1, 16, 32}, {0.0F, 0.0F, 0.0F, 64.0F, 64.0F, 64.0F}, {1.0F, 1.0F, 1.0F},
-    {"class"}, {"z", "z-trans"}, {2, 2}, {0, 0, 0}, 0.0F, {}, "XYZI", "none");
+    "", 64, {1, 16, 32}, {0.0F, 0.0F, 0.0F, 64.0F, 64.0F, 64.0F}, {1.0F, 1.0F, 1.0F}, {"class"},
+    {"z", "z-trans"}, {2, 2}, {0, 0, 0}, 0.0F, {}, "XYZI", "none");
 }
 
 void expect_equal(
@@ -304,9 +304,8 @@ TEST(SerializedPoolingMetadataTest, MatchesCpuReferenceForOnnxFacingInputs)
 
   const auto config = make_test_config();
   constexpr std::size_t kNumOrders = 2;
-  const std::vector<std::int64_t> grid_coord{
-    5, 0, 0, 0, 0, 0, 1, 0, 0, 2, 0, 0, 3, 0, 1,
-    4, 4, 0, 5, 4, 1, 8, 0, 0, 9, 0, 0, 10, 2, 0};
+  const std::vector<std::int64_t> grid_coord{5, 0, 0, 0, 0, 0, 1, 0, 0, 2, 0, 0, 3,  0, 1,
+                                             4, 4, 0, 5, 4, 1, 8, 0, 0, 9, 0, 0, 10, 2, 0};
   const auto serialized_code = make_serialized_code(grid_coord, config.serialization_depth_);
   const auto num_voxels = static_cast<std::int64_t>(grid_coord.size() / 3);
 
@@ -321,10 +320,11 @@ TEST(SerializedPoolingMetadataTest, MatchesCpuReferenceForOnnxFacingInputs)
     device_stages.emplace_back(config.max_num_voxels_, kNumOrders);
   }
   for (auto & stage : device_stages) {
-    stage_views.push_back(SerializedPoolingDeviceStageView{
-      stage.indices.get(), stage.indptr.get(), stage.head_indices.get(), stage.cluster.get(),
-      stage.grid_coord.get(), stage.serialized_code.get(), stage.serialized_order.get(),
-      stage.serialized_inverse.get()});
+    stage_views.push_back(
+      SerializedPoolingDeviceStageView{
+        stage.indices.get(), stage.indptr.get(), stage.head_indices.get(), stage.cluster.get(),
+        stage.grid_coord.get(), stage.serialized_code.get(), stage.serialized_order.get(),
+        stage.serialized_inverse.get()});
   }
 
   copy_to_device(grid_coord_d.get(), grid_coord);
@@ -353,13 +353,15 @@ TEST(SerializedPoolingMetadataTest, MatchesCpuReferenceForOnnxFacingInputs)
     const auto out_count = static_cast<std::size_t>(stage_counts[stage_index + 1]);
     const auto prefix = "stage " + std::to_string(stage_index) + " ";
 
-    expect_equal(copy_to_host(actual.indices.get(), in_count), expected.indices, prefix + "indices");
+    expect_equal(
+      copy_to_host(actual.indices.get(), in_count), expected.indices, prefix + "indices");
     expect_equal(
       copy_to_host(actual.indptr.get(), out_count + 1), expected.indptr, prefix + "indptr");
     expect_equal(
       copy_to_host(actual.head_indices.get(), out_count), expected.head_indices,
       prefix + "head_indices");
-    expect_equal(copy_to_host(actual.cluster.get(), in_count), expected.cluster, prefix + "cluster");
+    expect_equal(
+      copy_to_host(actual.cluster.get(), in_count), expected.cluster, prefix + "cluster");
     expect_equal(
       copy_to_host(actual.grid_coord.get(), out_count * 3), expected.grid_coord,
       prefix + "grid_coord");

--- a/perception/autoware_ptv3/test/serialized_pooling_metadata_test.cpp
+++ b/perception/autoware_ptv3/test/serialized_pooling_metadata_test.cpp
@@ -1,0 +1,378 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/ptv3/preprocess/preprocess_kernel.hpp"
+#include "autoware/ptv3/ptv3_config.hpp"
+
+#include <autoware/cuda_utils/cuda_gtest_utils.hpp>
+
+#include <cuda_runtime_api.h>
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <map>
+#include <numeric>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace
+{
+
+using autoware::ptv3::PreprocessCuda;
+using autoware::ptv3::PTv3Config;
+using autoware::ptv3::SerializedPoolingDeviceStageView;
+
+class CudaStreamGuard
+{
+public:
+  CudaStreamGuard()
+  {
+    const auto status = cudaStreamCreate(&stream_);
+    if (status != cudaSuccess) {
+      throw std::runtime_error(cudaGetErrorString(status));
+    }
+  }
+
+  ~CudaStreamGuard()
+  {
+    if (stream_ != nullptr) {
+      cudaStreamDestroy(stream_);
+    }
+  }
+
+  CudaStreamGuard(const CudaStreamGuard &) = delete;
+  CudaStreamGuard & operator=(const CudaStreamGuard &) = delete;
+
+  [[nodiscard]] cudaStream_t get() const { return stream_; }
+
+private:
+  cudaStream_t stream_{nullptr};
+};
+
+template <typename T>
+class DeviceBuffer
+{
+public:
+  explicit DeviceBuffer(const std::size_t element_count)
+  {
+    const auto status = cudaMalloc(&data_, sizeof(T) * element_count);
+    if (status != cudaSuccess) {
+      throw std::runtime_error(cudaGetErrorString(status));
+    }
+  }
+
+  ~DeviceBuffer()
+  {
+    if (data_ != nullptr) {
+      cudaFree(data_);
+    }
+  }
+
+  DeviceBuffer(const DeviceBuffer &) = delete;
+  DeviceBuffer & operator=(const DeviceBuffer &) = delete;
+  DeviceBuffer(DeviceBuffer && other) noexcept : data_(other.data_) { other.data_ = nullptr; }
+  DeviceBuffer & operator=(DeviceBuffer && other) noexcept
+  {
+    if (this != &other) {
+      if (data_ != nullptr) {
+        cudaFree(data_);
+      }
+      data_ = other.data_;
+      other.data_ = nullptr;
+    }
+    return *this;
+  }
+
+  [[nodiscard]] T * get() const { return static_cast<T *>(data_); }
+
+private:
+  void * data_{nullptr};
+};
+
+template <typename T>
+void copy_to_device(T * device_ptr, const std::vector<T> & values)
+{
+  const auto status =
+    cudaMemcpy(device_ptr, values.data(), sizeof(T) * values.size(), cudaMemcpyHostToDevice);
+  if (status != cudaSuccess) {
+    throw std::runtime_error(cudaGetErrorString(status));
+  }
+}
+
+template <typename T>
+std::vector<T> copy_to_host(const T * device_ptr, const std::size_t count)
+{
+  std::vector<T> values(count);
+  const auto status =
+    cudaMemcpy(values.data(), device_ptr, sizeof(T) * count, cudaMemcpyDeviceToHost);
+  if (status != cudaSuccess) {
+    throw std::runtime_error(cudaGetErrorString(status));
+  }
+  return values;
+}
+
+struct DeviceStage
+{
+  explicit DeviceStage(const std::size_t capacity, const std::size_t num_orders)
+  : indices(capacity),
+    indptr(capacity + 1),
+    head_indices(capacity),
+    cluster(capacity),
+    grid_coord(capacity * 3),
+    serialized_code(capacity * num_orders),
+    serialized_order(capacity * num_orders),
+    serialized_inverse(capacity * num_orders)
+  {
+  }
+
+  DeviceBuffer<std::int64_t> indices;
+  DeviceBuffer<std::int64_t> indptr;
+  DeviceBuffer<std::int64_t> head_indices;
+  DeviceBuffer<std::int64_t> cluster;
+  DeviceBuffer<std::int64_t> grid_coord;
+  DeviceBuffer<std::int64_t> serialized_code;
+  DeviceBuffer<std::int64_t> serialized_order;
+  DeviceBuffer<std::int64_t> serialized_inverse;
+};
+
+struct CpuStage
+{
+  std::vector<std::int64_t> indices;
+  std::vector<std::int64_t> indptr;
+  std::vector<std::int64_t> head_indices;
+  std::vector<std::int64_t> cluster;
+  std::vector<std::int64_t> grid_coord;
+  std::vector<std::int64_t> serialized_code;
+  std::vector<std::int64_t> serialized_order;
+  std::vector<std::int64_t> serialized_inverse;
+};
+
+std::int32_t pooling_depth(const std::int64_t stride)
+{
+  std::int32_t depth = 0;
+  for (auto value = stride; value > 1; value >>= 1) {
+    ++depth;
+  }
+  return depth;
+}
+
+std::int64_t serialize_coord(
+  const std::int64_t x, const std::int64_t y, const std::int64_t z, const std::int32_t depth,
+  const bool transposed)
+{
+  std::int64_t code = 0;
+  for (std::int32_t bit = 0; bit < depth; ++bit) {
+    const std::int64_t mask = 1LL << bit;
+    if (transposed) {
+      code |= ((y & mask) << (2 * bit + 2));
+      code |= ((x & mask) << (2 * bit + 1));
+    } else {
+      code |= ((x & mask) << (2 * bit + 2));
+      code |= ((y & mask) << (2 * bit + 1));
+    }
+    code |= ((z & mask) << (2 * bit));
+  }
+  return code;
+}
+
+std::vector<std::int64_t> make_serialized_code(
+  const std::vector<std::int64_t> & grid_coord, const std::int32_t depth)
+{
+  const auto count = grid_coord.size() / 3;
+  std::vector<std::int64_t> code(2 * count);
+  for (std::size_t index = 0; index < count; ++index) {
+    const auto x = grid_coord[index * 3 + 0];
+    const auto y = grid_coord[index * 3 + 1];
+    const auto z = grid_coord[index * 3 + 2];
+    code[index] = serialize_coord(x, y, z, depth, false);
+    code[count + index] = serialize_coord(x, y, z, depth, true);
+  }
+  return code;
+}
+
+std::vector<std::int64_t> stable_argsort(const std::vector<std::int64_t> & values)
+{
+  std::vector<std::int64_t> order(values.size());
+  std::iota(order.begin(), order.end(), 0);
+  std::stable_sort(order.begin(), order.end(), [&values](const auto lhs, const auto rhs) {
+    return values[static_cast<std::size_t>(lhs)] < values[static_cast<std::size_t>(rhs)];
+  });
+  return order;
+}
+
+CpuStage make_stage_reference(
+  const std::vector<std::int64_t> & grid_coord_in,
+  const std::vector<std::int64_t> & serialized_code_in, const std::size_t num_orders,
+  const std::int64_t stride)
+{
+  const auto input_count = grid_coord_in.size() / 3;
+  const auto depth = pooling_depth(stride);
+  std::vector<std::int64_t> pooled_keys(input_count);
+  for (std::size_t index = 0; index < input_count; ++index) {
+    pooled_keys[index] = serialized_code_in[index] >> (depth * 3);
+  }
+
+  std::vector<std::int64_t> unique_keys = pooled_keys;
+  std::sort(unique_keys.begin(), unique_keys.end());
+  unique_keys.erase(std::unique(unique_keys.begin(), unique_keys.end()), unique_keys.end());
+
+  std::map<std::int64_t, std::int64_t> key_to_cluster;
+  for (std::size_t index = 0; index < unique_keys.size(); ++index) {
+    key_to_cluster.emplace(unique_keys[index], static_cast<std::int64_t>(index));
+  }
+
+  CpuStage stage;
+  stage.cluster.resize(input_count);
+  stage.indptr.assign(unique_keys.size() + 1, 0);
+  for (std::size_t index = 0; index < input_count; ++index) {
+    const auto cluster = key_to_cluster.at(pooled_keys[index]);
+    stage.cluster[index] = cluster;
+    ++stage.indptr[static_cast<std::size_t>(cluster + 1)];
+  }
+  for (std::size_t index = 1; index < stage.indptr.size(); ++index) {
+    stage.indptr[index] += stage.indptr[index - 1];
+  }
+
+  stage.indices = stable_argsort(stage.cluster);
+  stage.head_indices.resize(unique_keys.size());
+  for (std::size_t segment = 0; segment < unique_keys.size(); ++segment) {
+    stage.head_indices[segment] = stage.indices[static_cast<std::size_t>(stage.indptr[segment])];
+  }
+
+  stage.grid_coord.resize(unique_keys.size() * 3);
+  stage.serialized_code.resize(num_orders * unique_keys.size());
+  for (std::size_t segment = 0; segment < unique_keys.size(); ++segment) {
+    const auto source = static_cast<std::size_t>(stage.head_indices[segment]);
+    for (std::size_t coord = 0; coord < 3; ++coord) {
+      stage.grid_coord[segment * 3 + coord] = grid_coord_in[source * 3 + coord] >> depth;
+    }
+    for (std::size_t order = 0; order < num_orders; ++order) {
+      stage.serialized_code[order * unique_keys.size() + segment] =
+        serialized_code_in[order * input_count + source] >> (depth * 3);
+    }
+  }
+
+  stage.serialized_order.resize(num_orders * unique_keys.size());
+  stage.serialized_inverse.resize(num_orders * unique_keys.size());
+  for (std::size_t order = 0; order < num_orders; ++order) {
+    std::vector<std::int64_t> order_codes(unique_keys.size());
+    for (std::size_t index = 0; index < unique_keys.size(); ++index) {
+      order_codes[index] = stage.serialized_code[order * unique_keys.size() + index];
+    }
+    const auto sorted_order = stable_argsort(order_codes);
+    for (std::size_t rank = 0; rank < sorted_order.size(); ++rank) {
+      const auto input_index = sorted_order[rank];
+      stage.serialized_order[order * unique_keys.size() + rank] = input_index;
+      stage.serialized_inverse[order * unique_keys.size() + static_cast<std::size_t>(input_index)] =
+        static_cast<std::int64_t>(rank);
+    }
+  }
+  return stage;
+}
+
+PTv3Config make_test_config()
+{
+  return PTv3Config(
+    "", 64, {1, 16, 32}, {0.0F, 0.0F, 0.0F, 64.0F, 64.0F, 64.0F}, {1.0F, 1.0F, 1.0F},
+    {"class"}, {"z", "z-trans"}, {2, 2}, {0, 0, 0}, 0.0F, {}, "XYZI", "none");
+}
+
+void expect_equal(
+  const std::vector<std::int64_t> & actual, const std::vector<std::int64_t> & expected,
+  const std::string & name)
+{
+  EXPECT_EQ(actual, expected) << name;
+}
+
+TEST(SerializedPoolingMetadataTest, MatchesCpuReferenceForOnnxFacingInputs)
+{
+  SKIP_TEST_IF_CUDA_UNAVAILABLE();
+
+  const auto config = make_test_config();
+  constexpr std::size_t kNumOrders = 2;
+  const std::vector<std::int64_t> grid_coord{
+    5, 0, 0, 0, 0, 0, 1, 0, 0, 2, 0, 0, 3, 0, 1,
+    4, 4, 0, 5, 4, 1, 8, 0, 0, 9, 0, 0, 10, 2, 0};
+  const auto serialized_code = make_serialized_code(grid_coord, config.serialization_depth_);
+  const auto num_voxels = static_cast<std::int64_t>(grid_coord.size() / 3);
+
+  CudaStreamGuard stream;
+  PreprocessCuda preprocess(config, stream.get());
+  DeviceBuffer<std::int64_t> grid_coord_d(grid_coord.size());
+  DeviceBuffer<std::int64_t> serialized_code_d(serialized_code.size());
+  DeviceBuffer<std::int64_t> stage_counts_d(config.pooling_strides_.size() + 1);
+  std::vector<DeviceStage> device_stages;
+  std::vector<SerializedPoolingDeviceStageView> stage_views;
+  for (std::size_t stage = 0; stage < config.pooling_strides_.size(); ++stage) {
+    device_stages.emplace_back(config.max_num_voxels_, kNumOrders);
+  }
+  for (auto & stage : device_stages) {
+    stage_views.push_back(SerializedPoolingDeviceStageView{
+      stage.indices.get(), stage.indptr.get(), stage.head_indices.get(), stage.cluster.get(),
+      stage.grid_coord.get(), stage.serialized_code.get(), stage.serialized_order.get(),
+      stage.serialized_inverse.get()});
+  }
+
+  copy_to_device(grid_coord_d.get(), grid_coord);
+  copy_to_device(serialized_code_d.get(), serialized_code);
+
+  preprocess.generateSerializedPoolingMetadata(
+    grid_coord_d.get(), serialized_code_d.get(), num_voxels, stage_views, stage_counts_d.get());
+  ASSERT_EQ(cudaStreamSynchronize(stream.get()), cudaSuccess);
+
+  std::vector<CpuStage> references;
+  references.push_back(
+    make_stage_reference(grid_coord, serialized_code, kNumOrders, config.pooling_strides_[0]));
+  references.push_back(make_stage_reference(
+    references[0].grid_coord, references[0].serialized_code, kNumOrders,
+    config.pooling_strides_[1]));
+
+  const auto stage_counts = copy_to_host(stage_counts_d.get(), config.pooling_strides_.size() + 1);
+  ASSERT_EQ(stage_counts[0], num_voxels);
+  ASSERT_EQ(stage_counts[1], static_cast<std::int64_t>(references[0].head_indices.size()));
+  ASSERT_EQ(stage_counts[2], static_cast<std::int64_t>(references[1].head_indices.size()));
+
+  for (std::size_t stage_index = 0; stage_index < references.size(); ++stage_index) {
+    const auto & expected = references[stage_index];
+    const auto & actual = device_stages[stage_index];
+    const auto in_count = static_cast<std::size_t>(stage_counts[stage_index]);
+    const auto out_count = static_cast<std::size_t>(stage_counts[stage_index + 1]);
+    const auto prefix = "stage " + std::to_string(stage_index) + " ";
+
+    expect_equal(copy_to_host(actual.indices.get(), in_count), expected.indices, prefix + "indices");
+    expect_equal(
+      copy_to_host(actual.indptr.get(), out_count + 1), expected.indptr, prefix + "indptr");
+    expect_equal(
+      copy_to_host(actual.head_indices.get(), out_count), expected.head_indices,
+      prefix + "head_indices");
+    expect_equal(copy_to_host(actual.cluster.get(), in_count), expected.cluster, prefix + "cluster");
+    expect_equal(
+      copy_to_host(actual.grid_coord.get(), out_count * 3), expected.grid_coord,
+      prefix + "grid_coord");
+    expect_equal(
+      copy_to_host(actual.serialized_code.get(), out_count * kNumOrders), expected.serialized_code,
+      prefix + "serialized_code");
+    expect_equal(
+      copy_to_host(actual.serialized_order.get(), out_count * kNumOrders),
+      expected.serialized_order, prefix + "serialized_order");
+    expect_equal(
+      copy_to_host(actual.serialized_inverse.get(), out_count * kNumOrders),
+      expected.serialized_inverse, prefix + "serialized_inverse");
+  }
+}
+
+}  // namespace

--- a/perception/autoware_tensorrt_plugins/CMakeLists.txt
+++ b/perception/autoware_tensorrt_plugins/CMakeLists.txt
@@ -106,6 +106,7 @@ if(TRT_AVAIL AND CUDA_AVAIL AND SPCONV_AVAIL)
     src/bev_ops/bev_pool_cuda.cu
     src/scatter_ops/segment_csr.cu
     src/unique_ops/unique.cu
+    src/ptv3_ops/serialized_pooling.cu
     src/multi_scale_deform_attn_ops/ms_deform_attn_kernel.cu
     src/rotate_ops/rotate_kernel.cu
     src/select_and_pad_ops/select_and_pad_kernel.cu
@@ -130,6 +131,8 @@ if(TRT_AVAIL AND CUDA_AVAIL AND SPCONV_AVAIL)
     src/rotate_plugin_creator.cpp
     src/segment_csr_plugin_creator.cpp
     src/segment_csr_plugin.cpp
+    src/serialized_pooling_plugin.cpp
+    src/serialized_pooling_plugin_creator.cpp
     src/select_and_pad_plugin.cpp
     src/select_and_pad_plugin_creator.cpp
     src/unique_plugin.cpp

--- a/perception/autoware_tensorrt_plugins/CMakeLists.txt
+++ b/perception/autoware_tensorrt_plugins/CMakeLists.txt
@@ -155,6 +155,7 @@ if(TRT_AVAIL AND CUDA_AVAIL AND SPCONV_AVAIL)
 
     ament_add_gtest(reference_kernels_test
       test/argsort_kernel_test.cpp
+      test/serialized_pooling_kernel_test.cpp
       test/unique_kernel_test.cpp
     )
     if(TARGET reference_kernels_test)

--- a/perception/autoware_tensorrt_plugins/include/autoware/ptv3_ops/serialized_pooling.hpp
+++ b/perception/autoware_tensorrt_plugins/include/autoware/ptv3_ops/serialized_pooling.hpp
@@ -1,0 +1,47 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__PTV3_OPS__SERIALIZED_POOLING_HPP_
+#define AUTOWARE__PTV3_OPS__SERIALIZED_POOLING_HPP_
+
+#include <cuda_fp16.h>
+#include <cuda_runtime_api.h>
+
+#include <cstdint>
+
+namespace autoware::ptv3
+{
+
+enum class SerializedPoolingReduce : std::int32_t {
+  kSum = 0,
+  kMean = 1,
+  kMin = 2,
+  kMax = 3,
+};
+
+cudaError_t serialized_pooling_float(
+  const float * feature_in, const float * coord_in, const std::int64_t * indices_in,
+  const std::int64_t * indptr_in, float * feature_out, float * coord_out,
+  std::int32_t num_segments_in, std::int32_t num_channels_in,
+  SerializedPoolingReduce feature_reduce_in, cudaStream_t stream_in);
+
+cudaError_t serialized_pooling_half(
+  const half * feature_in, const float * coord_in, const std::int64_t * indices_in,
+  const std::int64_t * indptr_in, half * feature_out, float * coord_out,
+  std::int32_t num_segments_in, std::int32_t num_channels_in,
+  SerializedPoolingReduce feature_reduce_in, cudaStream_t stream_in);
+
+}  // namespace autoware::ptv3
+
+#endif  // AUTOWARE__PTV3_OPS__SERIALIZED_POOLING_HPP_

--- a/perception/autoware_tensorrt_plugins/include/autoware/ptv3_ops/serialized_pooling.hpp
+++ b/perception/autoware_tensorrt_plugins/include/autoware/ptv3_ops/serialized_pooling.hpp
@@ -30,6 +30,21 @@ enum class SerializedPoolingReduce : std::int32_t {
   kMax = 3,
 };
 
+/// \brief Run PTv3 serialized pooling over CSR-encoded voxel groups.
+///
+/// Inputs:
+/// - `feature_in`: dense `[num_input_voxels, num_channels]` feature tensor. This must be the
+///   ungathered projected feature tensor; the kernel applies `indices_in` internally.
+/// - `coord_in`: dense `[num_input_voxels, 3]` float coordinate tensor.
+/// - `indices_in`: concatenated source voxel indices sorted by output segment.
+/// - `indptr_in`: CSR pointer tensor of shape `[num_segments + 1]`.
+///
+/// Outputs:
+/// - `feature_out`: dense `[num_segments, num_channels]` reduced features.
+/// - `coord_out`: dense `[num_segments, 3]` mean-reduced coordinates.
+///
+/// The output shape is fully determined by `indptr_in.shape[0] - 1`, so TensorRT sees the plugin
+/// as a non-data-dependent-shape operation when `indptr_in` is provided as an engine input.
 cudaError_t serialized_pooling_float(
   const float * feature_in, const float * coord_in, const std::int64_t * indices_in,
   const std::int64_t * indptr_in, float * feature_out, float * coord_out,

--- a/perception/autoware_tensorrt_plugins/include/autoware/tensorrt_plugins/serialized_pooling_plugin.hpp
+++ b/perception/autoware_tensorrt_plugins/include/autoware/tensorrt_plugins/serialized_pooling_plugin.hpp
@@ -28,7 +28,9 @@
 
 constexpr char const * const kSERIALIZED_POOLING_PLUGIN_NAME{"SerializedPooling"};
 constexpr char const * const kSERIALIZED_POOLING_PLUGIN_VERSION{"1"};
-constexpr char const * const kSERIALIZED_POOLING_PLUGIN_NAMESPACE{"autoware::ptv3"};
+// Empty namespace to match every other plugin in this package: the ONNX-parser fallback importer
+// resolves custom ops (domain "autoware") against the default/empty plugin namespace.
+constexpr char const * const kSERIALIZED_POOLING_PLUGIN_NAMESPACE{""};
 
 namespace autoware::ptv3
 {

--- a/perception/autoware_tensorrt_plugins/include/autoware/tensorrt_plugins/serialized_pooling_plugin.hpp
+++ b/perception/autoware_tensorrt_plugins/include/autoware/tensorrt_plugins/serialized_pooling_plugin.hpp
@@ -1,0 +1,117 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__TENSORRT_PLUGINS__SERIALIZED_POOLING_PLUGIN_HPP_
+#define AUTOWARE__TENSORRT_PLUGINS__SERIALIZED_POOLING_PLUGIN_HPP_
+
+#include "autoware/ptv3_ops/serialized_pooling.hpp"
+
+#include <NvInferRuntime.h>
+#include <NvInferRuntimePlugin.h>
+#include <cuda_runtime.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+constexpr char const * const kSERIALIZED_POOLING_PLUGIN_NAME{"SerializedPooling"};
+constexpr char const * const kSERIALIZED_POOLING_PLUGIN_VERSION{"1"};
+constexpr char const * const kSERIALIZED_POOLING_PLUGIN_NAMESPACE{"autoware::ptv3"};
+
+namespace autoware::ptv3
+{
+
+class SerializedPoolingPlugin : public nvinfer1::IPluginV3,
+                                public nvinfer1::IPluginV3OneCore,
+                                public nvinfer1::IPluginV3OneBuild,
+                                public nvinfer1::IPluginV3OneRuntime
+{
+public:
+  SerializedPoolingPlugin(const std::string & name, const std::string & reduce);
+
+  ~SerializedPoolingPlugin() override = default;
+
+  nvinfer1::IPluginCapability * getCapabilityInterface(
+    nvinfer1::PluginCapabilityType type) noexcept override;
+
+  nvinfer1::IPluginV3 * clone() noexcept override;
+
+  char const * getPluginName() const noexcept override;
+
+  char const * getPluginVersion() const noexcept override;
+
+  char const * getPluginNamespace() const noexcept override;
+
+  std::int32_t getNbOutputs() const noexcept override;
+
+  std::int32_t configurePlugin(
+    nvinfer1::DynamicPluginTensorDesc const * in, std::int32_t num_inputs,
+    nvinfer1::DynamicPluginTensorDesc const * out, std::int32_t num_outputs) noexcept override;
+
+  bool supportsFormatCombination(
+    std::int32_t pos, nvinfer1::DynamicPluginTensorDesc const * in_out, std::int32_t num_inputs,
+    std::int32_t num_outputs) noexcept override;
+
+  std::int32_t getOutputDataTypes(
+    nvinfer1::DataType * output_types, std::int32_t num_outputs,
+    nvinfer1::DataType const * input_types, std::int32_t num_inputs) const noexcept override;
+
+  std::int32_t getOutputShapes(
+    nvinfer1::DimsExprs const * inputs, std::int32_t num_inputs,
+    nvinfer1::DimsExprs const * shape_inputs, std::int32_t num_shape_inputs,
+    nvinfer1::DimsExprs * outputs, std::int32_t num_outputs,
+    nvinfer1::IExprBuilder & expr_builder) noexcept override;
+
+  std::int32_t enqueue(
+    nvinfer1::PluginTensorDesc const * input_desc, nvinfer1::PluginTensorDesc const * output_desc,
+    void const * const * inputs, void * const * outputs, void * workspace,
+    cudaStream_t stream) noexcept override;
+
+  std::int32_t onShapeChange(
+    nvinfer1::PluginTensorDesc const * in, std::int32_t num_inputs,
+    nvinfer1::PluginTensorDesc const * out, std::int32_t num_outputs) noexcept override;
+
+  nvinfer1::IPluginV3 * attachToContext(
+    nvinfer1::IPluginResourceContext * context) noexcept override;
+
+  nvinfer1::PluginFieldCollection const * getFieldsToSerialize() noexcept override;
+
+  std::size_t getWorkspaceSize(
+    nvinfer1::DynamicPluginTensorDesc const * inputs, std::int32_t num_inputs,
+    nvinfer1::DynamicPluginTensorDesc const * outputs,
+    std::int32_t num_outputs) const noexcept override;
+
+private:
+  static constexpr std::int32_t kFeatureInput = 0;
+  static constexpr std::int32_t kCoordInput = 1;
+  static constexpr std::int32_t kIndicesInput = 2;
+  static constexpr std::int32_t kIndptrInput = 3;
+  static constexpr std::int32_t kFeatureOutput = 4;
+  static constexpr std::int32_t kCoordOutput = 5;
+
+  void initFieldsToSerialize();
+
+  std::string layer_name_;
+  std::string reduce_;
+  SerializedPoolingReduce reduce_type_;
+  std::vector<nvinfer1::PluginField> data_to_serialize_;
+  nvinfer1::PluginFieldCollection fc_to_serialize_{};
+};
+
+SerializedPoolingReduce parseSerializedPoolingReduce(const std::string & reduce);
+
+}  // namespace autoware::ptv3
+
+#endif  // AUTOWARE__TENSORRT_PLUGINS__SERIALIZED_POOLING_PLUGIN_HPP_

--- a/perception/autoware_tensorrt_plugins/include/autoware/tensorrt_plugins/serialized_pooling_plugin_creator.hpp
+++ b/perception/autoware_tensorrt_plugins/include/autoware/tensorrt_plugins/serialized_pooling_plugin_creator.hpp
@@ -1,0 +1,59 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__TENSORRT_PLUGINS__SERIALIZED_POOLING_PLUGIN_CREATOR_HPP_
+#define AUTOWARE__TENSORRT_PLUGINS__SERIALIZED_POOLING_PLUGIN_CREATOR_HPP_
+
+#include "autoware/tensorrt_plugins/serialized_pooling_plugin.hpp"
+
+#include <NvInferRuntime.h>
+
+#include <vector>
+
+namespace autoware::ptv3
+{
+
+class SerializedPoolingPluginCreator : public nvinfer1::IPluginCreatorV3One
+{
+public:
+  SerializedPoolingPluginCreator();
+
+  ~SerializedPoolingPluginCreator() override = default;
+
+  char const * getPluginNamespace() const noexcept override
+  {
+    return kSERIALIZED_POOLING_PLUGIN_NAMESPACE;
+  }
+
+  char const * getPluginName() const noexcept override { return kSERIALIZED_POOLING_PLUGIN_NAME; }
+
+  char const * getPluginVersion() const noexcept override
+  {
+    return kSERIALIZED_POOLING_PLUGIN_VERSION;
+  }
+
+  nvinfer1::PluginFieldCollection const * getFieldNames() noexcept override;
+
+  nvinfer1::IPluginV3 * createPlugin(
+    char const * name, nvinfer1::PluginFieldCollection const * fc,
+    nvinfer1::TensorRTPhase phase) noexcept override;
+
+private:
+  nvinfer1::PluginFieldCollection fc_{};
+  std::vector<nvinfer1::PluginField> plugin_attributes_;
+};
+
+}  // namespace autoware::ptv3
+
+#endif  // AUTOWARE__TENSORRT_PLUGINS__SERIALIZED_POOLING_PLUGIN_CREATOR_HPP_

--- a/perception/autoware_tensorrt_plugins/src/plugin_registration.cpp
+++ b/perception/autoware_tensorrt_plugins/src/plugin_registration.cpp
@@ -22,6 +22,7 @@
 #include "autoware/tensorrt_plugins/rotate_plugin_creator.hpp"
 #include "autoware/tensorrt_plugins/segment_csr_plugin_creator.hpp"
 #include "autoware/tensorrt_plugins/select_and_pad_plugin_creator.hpp"
+#include "autoware/tensorrt_plugins/serialized_pooling_plugin_creator.hpp"
 #include "autoware/tensorrt_plugins/unique_plugin_creator.hpp"
 
 #include <NvInferRuntime.h>
@@ -67,7 +68,7 @@ extern "C" void setLoggerFinder(nvinfer1::ILoggerFinder * finder)
 
 extern "C" nvinfer1::IPluginCreatorInterface * const * getCreators(std::int32_t & num_creators)
 {
-  num_creators = 11;
+  num_creators = 12;
   static nvinfer1::plugin::ArgsortPluginCreator argsort_plugin_creator{};
   static nvinfer1::plugin::QuickCumsumCudaPluginCreator quick_cumsum_cuda_plugin_creator{};
   static nvinfer1::plugin::GetIndicesPairsImplicitGemmPluginCreator
@@ -80,6 +81,7 @@ extern "C" nvinfer1::IPluginCreatorInterface * const * getCreators(std::int32_t 
     multi_scale_deformable_attention_plugin_creator{};
   static autoware::tensorrt_plugins::RotatePluginCreator rotate_plugin_creator{};
   static nvinfer1::plugin::SegmentCSRPluginCreator segment_csr_plugin_creator{};
+  static autoware::ptv3::SerializedPoolingPluginCreator serialized_pooling_plugin_creator{};
   static autoware::tensorrt_plugins::SelectAndPadPluginCreator select_and_pad_plugin_creator{};
   static nvinfer1::plugin::UniquePluginCreator unique_plugin_creator{};
 
@@ -93,6 +95,7 @@ extern "C" nvinfer1::IPluginCreatorInterface * const * getCreators(std::int32_t 
     &multi_scale_deformable_attention_plugin_creator,
     &rotate_plugin_creator,
     &segment_csr_plugin_creator,
+    &serialized_pooling_plugin_creator,
     &select_and_pad_plugin_creator,
     &unique_plugin_creator};
   return plugin_creator_list;

--- a/perception/autoware_tensorrt_plugins/src/ptv3_ops/serialized_pooling.cu
+++ b/perception/autoware_tensorrt_plugins/src/ptv3_ops/serialized_pooling.cu
@@ -1,0 +1,194 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/ptv3_ops/serialized_pooling.hpp"
+
+#include <cuda_fp16.h>
+#include <cuda_runtime_api.h>
+
+#include <cstdint>
+
+namespace autoware::ptv3
+{
+namespace
+{
+
+constexpr int kThreadsPerBlock = 256;
+constexpr int kCoordChannels = 3;
+constexpr float kFloatMax = 3.402823466e+38F;
+
+template <typename Scalar>
+struct FeatureCast
+{
+  __device__ static float toFloat(Scalar value_in) { return static_cast<float>(value_in); }
+
+  __device__ static Scalar fromFloat(float value_in) { return static_cast<Scalar>(value_in); }
+};
+
+template <>
+struct FeatureCast<half>
+{
+  __device__ static float toFloat(half value_in) { return __half2float(value_in); }
+
+  __device__ static half fromFloat(float value_in) { return __float2half(value_in); }
+};
+
+__device__ float initial_value(SerializedPoolingReduce reduce_in)
+{
+  if (reduce_in == SerializedPoolingReduce::kMin) {
+    return kFloatMax;
+  }
+  if (reduce_in == SerializedPoolingReduce::kMax) {
+    return -kFloatMax;
+  }
+  return 0.0F;
+}
+
+__device__ float update_value(float current_in, float next_in, SerializedPoolingReduce reduce_in)
+{
+  if (reduce_in == SerializedPoolingReduce::kMin) {
+    return fminf(current_in, next_in);
+  }
+  if (reduce_in == SerializedPoolingReduce::kMax) {
+    return fmaxf(current_in, next_in);
+  }
+  return current_in + next_in;
+}
+
+template <typename Scalar>
+__global__ void reduce_features_kernel(
+  const Scalar * feature_in, const std::int64_t * indices_in, const std::int64_t * indptr_in,
+  Scalar * feature_out, std::int32_t num_segments_in, std::int32_t num_channels_in,
+  SerializedPoolingReduce reduce_in)
+{
+  const auto linear_index = static_cast<std::int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  const auto output_size =
+    static_cast<std::int64_t>(num_segments_in) * static_cast<std::int64_t>(num_channels_in);
+  if (linear_index >= output_size) {
+    return;
+  }
+
+  const auto segment_index = static_cast<std::int32_t>(linear_index / num_channels_in);
+  const auto channel_index = static_cast<std::int32_t>(linear_index % num_channels_in);
+  const auto begin = indptr_in[segment_index];
+  const auto end = indptr_in[segment_index + 1];
+  const auto count = end - begin;
+
+  float value = initial_value(reduce_in);
+  for (std::int64_t cursor = begin; cursor < end; ++cursor) {
+    const auto source_index = indices_in[cursor];
+    const auto input_offset =
+      source_index * static_cast<std::int64_t>(num_channels_in) + channel_index;
+    value = update_value(value, FeatureCast<Scalar>::toFloat(feature_in[input_offset]), reduce_in);
+  }
+
+  if (count == 0) {
+    value = 0.0F;
+  } else if (reduce_in == SerializedPoolingReduce::kMean) {
+    value /= static_cast<float>(count);
+  }
+
+  feature_out[linear_index] = FeatureCast<Scalar>::fromFloat(value);
+}
+
+__global__ void reduce_coords_mean_kernel(
+  const float * coord_in, const std::int64_t * indices_in, const std::int64_t * indptr_in,
+  float * coord_out, std::int32_t num_segments_in)
+{
+  const auto linear_index = static_cast<std::int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  const auto output_size =
+    static_cast<std::int64_t>(num_segments_in) * static_cast<std::int64_t>(kCoordChannels);
+  if (linear_index >= output_size) {
+    return;
+  }
+
+  const auto segment_index = static_cast<std::int32_t>(linear_index / kCoordChannels);
+  const auto channel_index = static_cast<std::int32_t>(linear_index % kCoordChannels);
+  const auto begin = indptr_in[segment_index];
+  const auto end = indptr_in[segment_index + 1];
+  const auto count = end - begin;
+
+  float value = 0.0F;
+  for (std::int64_t cursor = begin; cursor < end; ++cursor) {
+    const auto source_index = indices_in[cursor];
+    value += coord_in[source_index * kCoordChannels + channel_index];
+  }
+
+  coord_out[linear_index] = count == 0 ? 0.0F : value / static_cast<float>(count);
+}
+
+template <typename Scalar>
+cudaError_t serialized_pooling(
+  const Scalar * feature_in, const float * coord_in, const std::int64_t * indices_in,
+  const std::int64_t * indptr_in, Scalar * feature_out, float * coord_out,
+  std::int32_t num_segments_in, std::int32_t num_channels_in,
+  SerializedPoolingReduce feature_reduce_in, cudaStream_t stream_in)
+{
+  if (num_segments_in < 0 || num_channels_in <= 0) {
+    return cudaErrorInvalidValue;
+  }
+
+  const auto feature_output_size =
+    static_cast<std::int64_t>(num_segments_in) * static_cast<std::int64_t>(num_channels_in);
+  const auto feature_blocks =
+    static_cast<unsigned int>((feature_output_size + kThreadsPerBlock - 1) / kThreadsPerBlock);
+  if (feature_blocks > 0U) {
+    reduce_features_kernel<<<feature_blocks, kThreadsPerBlock, 0, stream_in>>>(
+      feature_in, indices_in, indptr_in, feature_out, num_segments_in, num_channels_in,
+      feature_reduce_in);
+    if (const auto status = cudaPeekAtLastError(); status != cudaSuccess) {
+      return status;
+    }
+  }
+
+  const auto coord_output_size =
+    static_cast<std::int64_t>(num_segments_in) * static_cast<std::int64_t>(kCoordChannels);
+  const auto coord_blocks =
+    static_cast<unsigned int>((coord_output_size + kThreadsPerBlock - 1) / kThreadsPerBlock);
+  if (coord_blocks > 0U) {
+    reduce_coords_mean_kernel<<<coord_blocks, kThreadsPerBlock, 0, stream_in>>>(
+      coord_in, indices_in, indptr_in, coord_out, num_segments_in);
+    if (const auto status = cudaPeekAtLastError(); status != cudaSuccess) {
+      return status;
+    }
+  }
+
+  return cudaSuccess;
+}
+
+}  // namespace
+
+cudaError_t serialized_pooling_float(
+  const float * feature_in, const float * coord_in, const std::int64_t * indices_in,
+  const std::int64_t * indptr_in, float * feature_out, float * coord_out,
+  std::int32_t num_segments_in, std::int32_t num_channels_in,
+  SerializedPoolingReduce feature_reduce_in, cudaStream_t stream_in)
+{
+  return serialized_pooling(
+    feature_in, coord_in, indices_in, indptr_in, feature_out, coord_out, num_segments_in,
+    num_channels_in, feature_reduce_in, stream_in);
+}
+
+cudaError_t serialized_pooling_half(
+  const half * feature_in, const float * coord_in, const std::int64_t * indices_in,
+  const std::int64_t * indptr_in, half * feature_out, float * coord_out,
+  std::int32_t num_segments_in, std::int32_t num_channels_in,
+  SerializedPoolingReduce feature_reduce_in, cudaStream_t stream_in)
+{
+  return serialized_pooling(
+    feature_in, coord_in, indices_in, indptr_in, feature_out, coord_out, num_segments_in,
+    num_channels_in, feature_reduce_in, stream_in);
+}
+
+}  // namespace autoware::ptv3

--- a/perception/autoware_tensorrt_plugins/src/serialized_pooling_plugin.cpp
+++ b/perception/autoware_tensorrt_plugins/src/serialized_pooling_plugin.cpp
@@ -1,0 +1,272 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/tensorrt_plugins/serialized_pooling_plugin.hpp"
+
+#include "autoware/ptv3_ops/serialized_pooling.hpp"
+#include "autoware/tensorrt_plugins/plugin_utils.hpp"
+
+#include <NvInferRuntime.h>
+#include <NvInferRuntimePlugin.h>
+#include <cuda_fp16.h>
+#include <cuda_runtime_api.h>
+
+#include <cstdint>
+#include <exception>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace autoware::ptv3
+{
+namespace
+{
+
+bool isFeatureType(nvinfer1::DataType type_in)
+{
+  return type_in == nvinfer1::DataType::kFLOAT || type_in == nvinfer1::DataType::kHALF;
+}
+
+}  // namespace
+
+SerializedPoolingReduce parseSerializedPoolingReduce(const std::string & reduce)
+{
+  if (reduce == "sum") {
+    return SerializedPoolingReduce::kSum;
+  }
+  if (reduce == "mean") {
+    return SerializedPoolingReduce::kMean;
+  }
+  if (reduce == "min") {
+    return SerializedPoolingReduce::kMin;
+  }
+  if (reduce == "max") {
+    return SerializedPoolingReduce::kMax;
+  }
+  throw std::invalid_argument("Unsupported SerializedPooling reduce mode: " + reduce);
+}
+
+SerializedPoolingPlugin::SerializedPoolingPlugin(
+  const std::string & name, const std::string & reduce)
+: layer_name_{name}, reduce_{reduce}, reduce_type_{parseSerializedPoolingReduce(reduce)}
+{
+  initFieldsToSerialize();
+}
+
+void SerializedPoolingPlugin::initFieldsToSerialize()
+{
+  data_to_serialize_.clear();
+  data_to_serialize_.emplace_back(
+    "reduce", reduce_.c_str(), nvinfer1::PluginFieldType::kCHAR, reduce_.size());
+
+  fc_to_serialize_.nbFields = data_to_serialize_.size();
+  fc_to_serialize_.fields = data_to_serialize_.data();
+}
+
+nvinfer1::IPluginCapability * SerializedPoolingPlugin::getCapabilityInterface(
+  nvinfer1::PluginCapabilityType type) noexcept
+{
+  try {
+    if (type == nvinfer1::PluginCapabilityType::kBUILD) {
+      return static_cast<nvinfer1::IPluginV3OneBuild *>(this);
+    }
+    if (type == nvinfer1::PluginCapabilityType::kRUNTIME) {
+      return static_cast<nvinfer1::IPluginV3OneRuntime *>(this);
+    }
+    PLUGIN_ASSERT(type == nvinfer1::PluginCapabilityType::kCORE);
+    return static_cast<nvinfer1::IPluginV3OneCore *>(this);
+  } catch (std::exception const & e) {
+    caughtError(e);
+  }
+  return nullptr;
+}
+
+nvinfer1::IPluginV3 * SerializedPoolingPlugin::clone() noexcept
+{
+  try {
+    return new SerializedPoolingPlugin{layer_name_, reduce_};
+  } catch (std::exception const & e) {
+    caughtError(e);
+  }
+  return nullptr;
+}
+
+char const * SerializedPoolingPlugin::getPluginName() const noexcept
+{
+  return kSERIALIZED_POOLING_PLUGIN_NAME;
+}
+
+char const * SerializedPoolingPlugin::getPluginVersion() const noexcept
+{
+  return kSERIALIZED_POOLING_PLUGIN_VERSION;
+}
+
+char const * SerializedPoolingPlugin::getPluginNamespace() const noexcept
+{
+  return kSERIALIZED_POOLING_PLUGIN_NAMESPACE;
+}
+
+std::int32_t SerializedPoolingPlugin::getNbOutputs() const noexcept
+{
+  return 2;
+}
+
+std::int32_t SerializedPoolingPlugin::configurePlugin(
+  nvinfer1::DynamicPluginTensorDesc const * in, std::int32_t num_inputs,
+  nvinfer1::DynamicPluginTensorDesc const * out, std::int32_t num_outputs) noexcept
+{
+  PLUGIN_ASSERT(num_inputs == 4);
+  PLUGIN_ASSERT(num_outputs == 2);
+
+  PLUGIN_ASSERT(in[kFeatureInput].desc.dims.nbDims == 2);
+  PLUGIN_ASSERT(in[kCoordInput].desc.dims.nbDims == 2);
+  PLUGIN_ASSERT(in[kIndicesInput].desc.dims.nbDims == 1);
+  PLUGIN_ASSERT(in[kIndptrInput].desc.dims.nbDims == 1);
+
+  PLUGIN_ASSERT(out[0].desc.dims.nbDims == 2);
+  PLUGIN_ASSERT(out[1].desc.dims.nbDims == 2);
+  PLUGIN_ASSERT(out[0].desc.type == in[kFeatureInput].desc.type);
+  PLUGIN_ASSERT(out[1].desc.type == nvinfer1::DataType::kFLOAT);
+
+  return 0;
+}
+
+bool SerializedPoolingPlugin::supportsFormatCombination(
+  std::int32_t pos, nvinfer1::DynamicPluginTensorDesc const * in_out, std::int32_t num_inputs,
+  std::int32_t num_outputs) noexcept
+{
+  PLUGIN_ASSERT(num_inputs == 4);
+  PLUGIN_ASSERT(num_outputs == 2);
+
+  bool supported = in_out[pos].desc.format == nvinfer1::TensorFormat::kLINEAR;
+  switch (pos) {
+    case kFeatureInput:
+      supported &= isFeatureType(in_out[pos].desc.type);
+      break;
+    case kCoordInput:
+      supported &= in_out[pos].desc.type == nvinfer1::DataType::kFLOAT;
+      break;
+    case kIndicesInput:
+    case kIndptrInput:
+      supported &= in_out[pos].desc.type == nvinfer1::DataType::kINT64;
+      break;
+    case kFeatureOutput:
+      supported &= in_out[pos].desc.type == in_out[kFeatureInput].desc.type;
+      break;
+    case kCoordOutput:
+      supported &= in_out[pos].desc.type == nvinfer1::DataType::kFLOAT;
+      break;
+    default:
+      supported = false;
+      break;
+  }
+
+  return supported;
+}
+
+std::int32_t SerializedPoolingPlugin::getOutputDataTypes(
+  nvinfer1::DataType * output_types, std::int32_t num_outputs,
+  nvinfer1::DataType const * input_types, std::int32_t num_inputs) const noexcept
+{
+  PLUGIN_ASSERT(num_inputs == 4);
+  PLUGIN_ASSERT(num_outputs == 2);
+
+  output_types[0] = input_types[kFeatureInput];
+  output_types[1] = nvinfer1::DataType::kFLOAT;
+
+  return 0;
+}
+
+std::int32_t SerializedPoolingPlugin::getOutputShapes(
+  nvinfer1::DimsExprs const * inputs, std::int32_t num_inputs,
+  [[maybe_unused]] nvinfer1::DimsExprs const * shape_inputs,
+  [[maybe_unused]] std::int32_t num_shape_inputs, nvinfer1::DimsExprs * outputs,
+  std::int32_t num_outputs, nvinfer1::IExprBuilder & expr_builder) noexcept
+{
+  PLUGIN_ASSERT(num_inputs == 4);
+  PLUGIN_ASSERT(num_outputs == 2);
+  PLUGIN_ASSERT(inputs[kFeatureInput].nbDims == 2);
+  PLUGIN_ASSERT(inputs[kCoordInput].nbDims == 2);
+  PLUGIN_ASSERT(inputs[kIndptrInput].nbDims == 1);
+
+  auto * num_segments = expr_builder.operation(
+    nvinfer1::DimensionOperation::kSUB, *inputs[kIndptrInput].d[0], *expr_builder.constant(1));
+
+  outputs[0].nbDims = 2;
+  outputs[0].d[0] = num_segments;
+  outputs[0].d[1] = inputs[kFeatureInput].d[1];
+
+  outputs[1].nbDims = 2;
+  outputs[1].d[0] = num_segments;
+  outputs[1].d[1] = inputs[kCoordInput].d[1];
+
+  return 0;
+}
+
+std::int32_t SerializedPoolingPlugin::enqueue(
+  nvinfer1::PluginTensorDesc const * input_desc,
+  [[maybe_unused]] nvinfer1::PluginTensorDesc const * output_desc, void const * const * inputs,
+  void * const * outputs, [[maybe_unused]] void * workspace, cudaStream_t stream) noexcept
+{
+  const auto num_segments = static_cast<std::int32_t>(input_desc[kIndptrInput].dims.d[0] - 1);
+  const auto num_channels = static_cast<std::int32_t>(input_desc[kFeatureInput].dims.d[1]);
+  const auto * coord_in = static_cast<const float *>(inputs[kCoordInput]);
+  const auto * indices_in = static_cast<const std::int64_t *>(inputs[kIndicesInput]);
+  const auto * indptr_in = static_cast<const std::int64_t *>(inputs[kIndptrInput]);
+  auto * coord_out = static_cast<float *>(outputs[1]);
+
+  cudaError_t status = cudaErrorInvalidValue;
+  if (input_desc[kFeatureInput].type == nvinfer1::DataType::kFLOAT) {
+    status = serialized_pooling_float(
+      static_cast<const float *>(inputs[kFeatureInput]), coord_in, indices_in, indptr_in,
+      static_cast<float *>(outputs[0]), coord_out, num_segments, num_channels, reduce_type_,
+      stream);
+  } else if (input_desc[kFeatureInput].type == nvinfer1::DataType::kHALF) {
+    status = serialized_pooling_half(
+      static_cast<const half *>(inputs[kFeatureInput]), coord_in, indices_in, indptr_in,
+      static_cast<half *>(outputs[0]), coord_out, num_segments, num_channels, reduce_type_, stream);
+  }
+
+  return status == cudaSuccess ? 0 : -1;
+}
+
+std::int32_t SerializedPoolingPlugin::onShapeChange(
+  [[maybe_unused]] nvinfer1::PluginTensorDesc const * in, [[maybe_unused]] std::int32_t num_inputs,
+  [[maybe_unused]] nvinfer1::PluginTensorDesc const * out,
+  [[maybe_unused]] std::int32_t num_outputs) noexcept
+{
+  return 0;
+}
+
+nvinfer1::IPluginV3 * SerializedPoolingPlugin::attachToContext(
+  [[maybe_unused]] nvinfer1::IPluginResourceContext * context) noexcept
+{
+  return clone();
+}
+
+nvinfer1::PluginFieldCollection const * SerializedPoolingPlugin::getFieldsToSerialize() noexcept
+{
+  return &fc_to_serialize_;
+}
+
+std::size_t SerializedPoolingPlugin::getWorkspaceSize(
+  [[maybe_unused]] nvinfer1::DynamicPluginTensorDesc const * inputs,
+  [[maybe_unused]] std::int32_t num_inputs,
+  [[maybe_unused]] nvinfer1::DynamicPluginTensorDesc const * outputs,
+  [[maybe_unused]] std::int32_t num_outputs) const noexcept
+{
+  return 0;
+}
+
+}  // namespace autoware::ptv3

--- a/perception/autoware_tensorrt_plugins/src/serialized_pooling_plugin_creator.cpp
+++ b/perception/autoware_tensorrt_plugins/src/serialized_pooling_plugin_creator.cpp
@@ -1,0 +1,67 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/tensorrt_plugins/serialized_pooling_plugin_creator.hpp"
+
+#include "autoware/tensorrt_plugins/plugin_utils.hpp"
+#include "autoware/tensorrt_plugins/serialized_pooling_plugin.hpp"
+
+#include <NvInferRuntimePlugin.h>
+
+#include <exception>
+#include <string>
+
+namespace autoware::ptv3
+{
+
+REGISTER_TENSORRT_PLUGIN(SerializedPoolingPluginCreator);
+
+SerializedPoolingPluginCreator::SerializedPoolingPluginCreator()
+{
+  plugin_attributes_.clear();
+  plugin_attributes_.emplace_back("reduce", nullptr, nvinfer1::PluginFieldType::kCHAR, 1);
+
+  fc_.nbFields = plugin_attributes_.size();
+  fc_.fields = plugin_attributes_.data();
+}
+
+nvinfer1::PluginFieldCollection const * SerializedPoolingPluginCreator::getFieldNames() noexcept
+{
+  return &fc_;
+}
+
+nvinfer1::IPluginV3 * SerializedPoolingPluginCreator::createPlugin(
+  char const * name, nvinfer1::PluginFieldCollection const * fc,
+  [[maybe_unused]] nvinfer1::TensorRTPhase phase) noexcept
+{
+  try {
+    PLUGIN_VALIDATE(fc != nullptr);
+    PLUGIN_VALIDATE(fc->nbFields == 1);
+    PLUGIN_VALIDATE(std::string(fc->fields[0].name) == "reduce");
+
+    std::string reduce(static_cast<char const *>(fc->fields[0].data), fc->fields[0].length);
+    const auto null_pos = reduce.find('\0');
+    if (null_pos != std::string::npos) {
+      reduce.resize(null_pos);
+    }
+    parseSerializedPoolingReduce(reduce);
+
+    return new SerializedPoolingPlugin{std::string(name), reduce};
+  } catch (std::exception const & e) {
+    caughtError(e);
+  }
+  return nullptr;
+}
+
+}  // namespace autoware::ptv3

--- a/perception/autoware_tensorrt_plugins/test/serialized_pooling_kernel_test.cpp
+++ b/perception/autoware_tensorrt_plugins/test/serialized_pooling_kernel_test.cpp
@@ -134,12 +134,10 @@ TEST_P(SerializedPoolingKernelTest, MatchesCpuCsrReference)
   constexpr std::int32_t kNumChannels = 3;
   const auto reduce = GetParam().second;
 
-  const std::vector<float> features{
-    1.0F, 10.0F, -1.0F, 2.0F, 20.0F, -2.0F, 3.0F, 30.0F, -3.0F,
-    4.0F, 40.0F, -4.0F, 5.0F, 50.0F, -5.0F, 6.0F, 60.0F, -6.0F};
-  const std::vector<float> coords{
-    0.0F, 0.0F, 0.0F, 1.0F, 2.0F, 3.0F, 2.0F, 4.0F, 6.0F,
-    3.0F, 6.0F, 9.0F, 4.0F, 8.0F, 12.0F, 5.0F, 10.0F, 15.0F};
+  const std::vector<float> features{1.0F, 10.0F, -1.0F, 2.0F, 20.0F, -2.0F, 3.0F, 30.0F, -3.0F,
+                                    4.0F, 40.0F, -4.0F, 5.0F, 50.0F, -5.0F, 6.0F, 60.0F, -6.0F};
+  const std::vector<float> coords{0.0F, 0.0F, 0.0F, 1.0F, 2.0F, 3.0F,  2.0F, 4.0F,  6.0F,
+                                  3.0F, 6.0F, 9.0F, 4.0F, 8.0F, 12.0F, 5.0F, 10.0F, 15.0F};
 
   // Non-identity ordering is essential: it catches accidental pre-gathered plugin inputs.
   const std::vector<std::int64_t> indices{4, 1, 5, 0, 3, 2};
@@ -170,8 +168,10 @@ TEST_P(SerializedPoolingKernelTest, MatchesCpuCsrReference)
     cudaSuccess);
   ASSERT_EQ(cudaStreamSynchronize(stream.get()), cudaSuccess);
 
-  expect_near_vector(copy_to_host(feature_out_d.get(), expected_features.size()), expected_features, 1.0e-5F);
-  expect_near_vector(copy_to_host(coord_out_d.get(), expected_coords.size()), expected_coords, 1.0e-5F);
+  expect_near_vector(
+    copy_to_host(feature_out_d.get(), expected_features.size()), expected_features, 1.0e-5F);
+  expect_near_vector(
+    copy_to_host(coord_out_d.get(), expected_coords.size()), expected_coords, 1.0e-5F);
 
   (void)kNumInputs;
 }

--- a/perception/autoware_tensorrt_plugins/test/serialized_pooling_kernel_test.cpp
+++ b/perception/autoware_tensorrt_plugins/test/serialized_pooling_kernel_test.cpp
@@ -1,0 +1,187 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/ptv3_ops/serialized_pooling.hpp"
+#include "test_utils.hpp"
+
+#include <autoware/cuda_utils/cuda_gtest_utils.hpp>
+
+#include <cuda_runtime_api.h>
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <string>
+#include <vector>
+
+namespace
+{
+
+using autoware::ptv3::serialized_pooling_float;
+using autoware::ptv3::SerializedPoolingReduce;
+using autoware::tensorrt_plugins::test::copy_to_device;
+using autoware::tensorrt_plugins::test::copy_to_host;
+using autoware::tensorrt_plugins::test::CudaStreamGuard;
+using autoware::tensorrt_plugins::test::DeviceBuffer;
+
+float initial_value(const SerializedPoolingReduce reduce)
+{
+  if (reduce == SerializedPoolingReduce::kMin) {
+    return std::numeric_limits<float>::max();
+  }
+  if (reduce == SerializedPoolingReduce::kMax) {
+    return -std::numeric_limits<float>::max();
+  }
+  return 0.0F;
+}
+
+float update_value(const float current, const float next, const SerializedPoolingReduce reduce)
+{
+  if (reduce == SerializedPoolingReduce::kMin) {
+    return std::min(current, next);
+  }
+  if (reduce == SerializedPoolingReduce::kMax) {
+    return std::max(current, next);
+  }
+  return current + next;
+}
+
+std::vector<float> make_feature_reference(
+  const std::vector<float> & features, const std::vector<std::int64_t> & indices,
+  const std::vector<std::int64_t> & indptr, const std::int32_t num_channels,
+  const SerializedPoolingReduce reduce)
+{
+  const auto num_segments = static_cast<std::int32_t>(indptr.size() - 1);
+  std::vector<float> output(static_cast<std::size_t>(num_segments * num_channels), 0.0F);
+  for (std::int32_t segment = 0; segment < num_segments; ++segment) {
+    const auto begin = indptr[segment];
+    const auto end = indptr[segment + 1];
+    const auto count = end - begin;
+    for (std::int32_t channel = 0; channel < num_channels; ++channel) {
+      float value = initial_value(reduce);
+      for (auto cursor = begin; cursor < end; ++cursor) {
+        const auto source = indices[static_cast<std::size_t>(cursor)];
+        value = update_value(
+          value, features[static_cast<std::size_t>(source * num_channels + channel)], reduce);
+      }
+      if (count == 0) {
+        value = 0.0F;
+      } else if (reduce == SerializedPoolingReduce::kMean) {
+        value /= static_cast<float>(count);
+      }
+      output[static_cast<std::size_t>(segment * num_channels + channel)] = value;
+    }
+  }
+  return output;
+}
+
+std::vector<float> make_coord_reference(
+  const std::vector<float> & coords, const std::vector<std::int64_t> & indices,
+  const std::vector<std::int64_t> & indptr)
+{
+  constexpr std::int32_t kCoordChannels = 3;
+  const auto num_segments = static_cast<std::int32_t>(indptr.size() - 1);
+  std::vector<float> output(static_cast<std::size_t>(num_segments * kCoordChannels), 0.0F);
+  for (std::int32_t segment = 0; segment < num_segments; ++segment) {
+    const auto begin = indptr[segment];
+    const auto end = indptr[segment + 1];
+    const auto count = end - begin;
+    for (std::int32_t channel = 0; channel < kCoordChannels; ++channel) {
+      float value = 0.0F;
+      for (auto cursor = begin; cursor < end; ++cursor) {
+        const auto source = indices[static_cast<std::size_t>(cursor)];
+        value += coords[static_cast<std::size_t>(source * kCoordChannels + channel)];
+      }
+      output[static_cast<std::size_t>(segment * kCoordChannels + channel)] =
+        count == 0 ? 0.0F : value / static_cast<float>(count);
+    }
+  }
+  return output;
+}
+
+void expect_near_vector(
+  const std::vector<float> & actual, const std::vector<float> & expected, const float tolerance)
+{
+  ASSERT_EQ(actual.size(), expected.size());
+  for (std::size_t index = 0; index < actual.size(); ++index) {
+    EXPECT_NEAR(actual[index], expected[index], tolerance) << "index=" << index;
+  }
+}
+
+class SerializedPoolingKernelTest
+: public ::testing::TestWithParam<std::pair<std::string, SerializedPoolingReduce>>
+{
+};
+
+TEST_P(SerializedPoolingKernelTest, MatchesCpuCsrReference)
+{
+  SKIP_TEST_IF_CUDA_UNAVAILABLE();
+
+  constexpr std::int32_t kNumInputs = 6;
+  constexpr std::int32_t kNumChannels = 3;
+  const auto reduce = GetParam().second;
+
+  const std::vector<float> features{
+    1.0F, 10.0F, -1.0F, 2.0F, 20.0F, -2.0F, 3.0F, 30.0F, -3.0F,
+    4.0F, 40.0F, -4.0F, 5.0F, 50.0F, -5.0F, 6.0F, 60.0F, -6.0F};
+  const std::vector<float> coords{
+    0.0F, 0.0F, 0.0F, 1.0F, 2.0F, 3.0F, 2.0F, 4.0F, 6.0F,
+    3.0F, 6.0F, 9.0F, 4.0F, 8.0F, 12.0F, 5.0F, 10.0F, 15.0F};
+
+  // Non-identity ordering is essential: it catches accidental pre-gathered plugin inputs.
+  const std::vector<std::int64_t> indices{4, 1, 5, 0, 3, 2};
+  const std::vector<std::int64_t> indptr{0, 2, 3, 6};
+  const std::int32_t num_segments = static_cast<std::int32_t>(indptr.size() - 1);
+
+  const auto expected_features =
+    make_feature_reference(features, indices, indptr, kNumChannels, reduce);
+  const auto expected_coords = make_coord_reference(coords, indices, indptr);
+
+  CudaStreamGuard stream;
+  DeviceBuffer<float> features_d(features.size());
+  DeviceBuffer<float> coords_d(coords.size());
+  DeviceBuffer<std::int64_t> indices_d(indices.size());
+  DeviceBuffer<std::int64_t> indptr_d(indptr.size());
+  DeviceBuffer<float> feature_out_d(expected_features.size());
+  DeviceBuffer<float> coord_out_d(expected_coords.size());
+
+  copy_to_device(features_d.get(), features);
+  copy_to_device(coords_d.get(), coords);
+  copy_to_device(indices_d.get(), indices);
+  copy_to_device(indptr_d.get(), indptr);
+
+  ASSERT_EQ(
+    serialized_pooling_float(
+      features_d.get(), coords_d.get(), indices_d.get(), indptr_d.get(), feature_out_d.get(),
+      coord_out_d.get(), num_segments, kNumChannels, reduce, stream.get()),
+    cudaSuccess);
+  ASSERT_EQ(cudaStreamSynchronize(stream.get()), cudaSuccess);
+
+  expect_near_vector(copy_to_host(feature_out_d.get(), expected_features.size()), expected_features, 1.0e-5F);
+  expect_near_vector(copy_to_host(coord_out_d.get(), expected_coords.size()), expected_coords, 1.0e-5F);
+
+  (void)kNumInputs;
+}
+
+INSTANTIATE_TEST_SUITE_P(
+  ReduceModes, SerializedPoolingKernelTest,
+  ::testing::Values(
+    std::make_pair("sum", SerializedPoolingReduce::kSum),
+    std::make_pair("mean", SerializedPoolingReduce::kMean),
+    std::make_pair("min", SerializedPoolingReduce::kMin),
+    std::make_pair("max", SerializedPoolingReduce::kMax)));
+
+}  // namespace


### PR DESCRIPTION
## Summary
- add PTv3 SerializedPooling TensorRT plugin
- precompute serialized pooling metadata in PTv3 preprocessing
- bind fixed-shape pooling metadata inputs for doctored PTv3 ONNX models
- add plugin and metadata unit tests

## Verification
- colcon build --packages-up-to autoware_tensorrt_plugins autoware_ptv3 --cmake-args -DBUILD_TESTING=ON
- colcon test --packages-select autoware_tensorrt_plugins autoware_ptv3 --event-handlers console_direct+
- sensing-bench ptv3 serialized-pooling benchmark series and profile
