### PR TITLE
feat(traffic_light_arbiter): apply autoware_agnocast_wrapper for CIE

### DIFF
--- a/perception/autoware_traffic_light_arbiter/CMakeLists.txt
+++ b/perception/autoware_traffic_light_arbiter/CMakeLists.txt
@@ -10,9 +10,11 @@ ament_auto_add_library(${PROJECT_NAME} SHARED
   src/signal_match_validator.cpp
 )
 
-rclcpp_components_register_node(${PROJECT_NAME}
+autoware_agnocast_wrapper_register_node(${PROJECT_NAME}
   PLUGIN "autoware::traffic_light::TrafficLightArbiter"
   EXECUTABLE traffic_light_arbiter_node
+  AGNOCAST_EXECUTOR CallbackIsolatedAgnocastExecutor
+  ROS2_EXECUTOR SingleThreadedExecutor
 )
 
 if(BUILD_TESTING)

--- a/perception/autoware_traffic_light_arbiter/package.xml
+++ b/perception/autoware_traffic_light_arbiter/package.xml
@@ -13,6 +13,7 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
+  <depend>autoware_agnocast_wrapper</depend>
   <depend>autoware_lanelet2_extension</depend>
   <depend>autoware_lanelet2_utils</depend>
   <depend>autoware_map_msgs</depend>


### PR DESCRIPTION
## Description

Apply `CallbackIsolatedAgnocastExecutor` (CIE) to `traffic_light_arbiter`, as part of the CIE rollout (see parent issue). By going through `autoware_agnocast_wrapper`, CIE activation is controlled by the `ENABLE_AGNOCAST` environment variable — when unset or `0`, the node runs with the standard ROS 2 executor as before; when set to `1`, it switches to `CallbackIsolatedAgnocastExecutor`.

### Changes

- `CMakeLists.txt`: replace `rclcpp_components_register_node(...)` with `autoware_agnocast_wrapper_register_node(...)`. The generated `traffic_light_arbiter_node` executable uses `CallbackIsolatedAgnocastExecutor` when built with `ENABLE_AGNOCAST=1`, and falls back to a `SingleThreadedExecutor` standalone executable (identical to the previous `rclcpp_components` behavior) otherwise.
- `package.xml`: add the `autoware_agnocast_wrapper` dependency.

No source changes. The node uses plain `rclcpp` publishers/subscriptions, so this only swaps the executor.

## Related links

**Related Issue:**

- https://github.com/autowarefoundation/autoware_core/issues/968

## How was this PR tested?

Verification in Lsim (both ENABLE_AGNOCAST=0 and ENABLE_AGNOCAST=1).

## Notes for reviewers

**Please review the following aspect:**

If the node meets **all** of the following conditions, please check for potential race conditions (see [Effects on system behavior](#effects-on-system-behavior) for the reason):
  1. The node was originally running on a `SingleThreadedExecutor`
  2. The node has multiple callback groups (the default is one)
  3. Shared variables are accessed across callback groups without proper mutex protection

  > **Note:** Nodes already running on `MultiThreadedExecutor` (or `component_container_mt`) are not affected, as their callbacks are already executed concurrently.

## Interface changes

None.

## Effects on system behavior

When `ENABLE_AGNOCAST=0` (default), there is no change in behavior at all — the node runs with the standard ROS 2 executor exactly as before.

When `ENABLE_AGNOCAST=1`, the executor switches to `CallbackIsolatedAgnocastExecutor` (CIE). Internally, CIE creates a dedicated `rclcpp::SingleThreadedExecutor` for each callback group, so the fundamental scheduling behavior within each group remains almost identical. The key difference is that, for nodes originally using `SingleThreadedExecutor`, callback groups now run in parallel across separate threads, similar to `MultiThreadedExecutor`.
