### PR TITLE
feat: single map node

### DIFF
--- a/map/autoware_map_host/CMakeLists.txt
+++ b/map/autoware_map_host/CMakeLists.txt
@@ -1,0 +1,49 @@
+cmake_minimum_required(VERSION 3.14)
+project(autoware_map_host)
+
+find_package(autoware_cmake REQUIRED)
+autoware_package()
+pluginlib_export_plugin_description_file(autoware_map_host plugins.xml)
+
+find_package(autoware_map_loader REQUIRED)
+find_package(OpenSSL REQUIRED)
+find_package(PCL REQUIRED COMPONENTS common io filters)
+
+ament_auto_add_library(autoware_map_loader_host_component SHARED
+  src/map_loader_host/map_loader_host.cpp
+)
+
+rclcpp_components_register_node(autoware_map_loader_host_component
+  PLUGIN "autoware::map_loader::MapLoaderHost"
+  EXECUTABLE autoware_map_loader_host_node
+)
+
+ament_auto_add_library(autoware_map_loader_host_plugins SHARED
+  src/map_loader_host/plugins/map_projection_loader_plugin.cpp
+  src/map_loader_host/plugins/pointcloud_map_loader_plugin.cpp
+  src/map_loader_host/plugins/lanelet2_map_loader_plugin.cpp
+  src/map_loader_host/plugins/lanelet2_visualization_plugin.cpp
+  src/map_loader_host/plugins/vector_map_tf_generator_plugin.cpp
+  src/map_loader_host/plugins/map_hash_generator_plugin.cpp
+)
+
+# Vendored pointcloud module headers (include/) are compile-time only.
+# Implementations are linked from autoware_map_loader libraries.
+target_include_directories(autoware_map_loader_host_plugins PRIVATE
+  ${CMAKE_CURRENT_SOURCE_DIR}/include
+)
+
+target_link_libraries(autoware_map_loader_host_plugins
+  ${autoware_map_loader_LIBRARIES}
+  OpenSSL::Crypto
+)
+ament_target_dependencies(autoware_map_loader_host_plugins
+  autoware_map_loader
+  autoware_utils
+  tier4_external_api_msgs
+)
+
+autoware_ament_auto_package(INSTALL_TO_SHARE
+  launch
+  config
+)

--- a/map/autoware_map_host/README.md
+++ b/map/autoware_map_host/README.md
@@ -1,0 +1,142 @@
+# autoware_map_host
+
+`autoware_map_host` provides a single ROS 2 node that loads and publishes all map-related data used by Autoware. Map loading is implemented as a set of [pluginlib](https://github.com/ros/pluginlib) plugins orchestrated by `MapLoaderHost`.
+
+This package complements `[autoware_map_loader](https://github.com/autowarefoundation/autoware_core/tree/main/map/autoware_map_loader)` in Autoware Core, which provides standalone map loader nodes and shared loader libraries.
+
+## Role in the map stack
+
+| Package                        | Responsibility                                                                                                                             |
+| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| `autoware_map_loader` (Core)   | Standalone `pointcloud_map_loader` / `lanelet2_map_loader` nodes and their shared libraries                                                |
+| `autoware_map_host` (Universe) | Integrated `map_loader` node with plugin-based loading of projection info, pointcloud map, Lanelet2 map, visualization, TF, and map hashes |
+
+Use `autoware_map_host` when you want one node under `/map` that wires everything together (typical Autoware launch configuration). Use the Core nodes when you need individual loaders as separate processes.
+
+## Architecture
+
+```mermaid
+flowchart TB
+  subgraph host ["autoware_map_host"]
+    MLH["MapLoaderHost<br/>(autoware_map_loader_host_node)"]
+    PL["pluginlib loader"]
+    MLH --> PL
+    PL --> P1["MapProjectionLoaderPlugin"]
+    PL --> P2["PointCloudMapLoaderPlugin"]
+    PL --> P3["Lanelet2MapLoaderPlugin"]
+    PL --> P4["Lanelet2VisualizationPlugin"]
+    PL --> P5["VectorMapTfGeneratorPlugin"]
+    PL --> P6["MapHashGeneratorPlugin"]
+  end
+
+  subgraph core ["autoware_map_loader (linked libraries)"]
+    PC["pointcloud_map_loader_node"]
+    LL["lanelet2_map_loader_node"]
+  end
+
+  P2 -.->|uses module API| PC
+  P3 -.->|uses static API| LL
+```
+
+Plugins share state through `MapLoaderData` (for example, map projection info loaded by `MapProjectionLoaderPlugin` is consumed by `Lanelet2MapLoaderPlugin` on startup).
+
+Default plugin load order is defined in `config/map_loader_host.param.yaml`.
+
+## Plugins
+
+| Plugin                        | Description                                                                                                |
+| ----------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| `MapProjectionLoaderPlugin`   | Loads `map_projector_info.yaml` and publishes `/map/map_projector_info`                                    |
+| `PointCloudMapLoaderPlugin`   | Loads PCD map(s), publishes whole/downsampled maps, and exposes partial/differential/selected map services |
+| `Lanelet2MapLoaderPlugin`     | Loads Lanelet2 OSM and publishes `/map/vector_map`                                                         |
+| `Lanelet2VisualizationPlugin` | Publishes Lanelet2 visualization markers                                                                   |
+| `VectorMapTfGeneratorPlugin`  | Broadcasts static TF for the map viewer frame                                                              |
+| `MapHashGeneratorPlugin`      | Publishes map file hashes and exposes lanelet XML via Tier IV external API                                 |
+
+## Dependency on `autoware_map_loader`
+
+`PointCloudMapLoaderPlugin` and `Lanelet2MapLoaderPlugin` reuse implementation code from `autoware_map_loader`:
+
+- **Lanelet2**: uses the public API in `autoware/map_loader/lanelet2_map_loader_node.hpp` and links `lanelet2_map_loader_node`.
+- **Pointcloud**: includes vendored module headers under `include/` (for example `pointcloud_map_loader_module.hpp`) and links `pointcloud_map_loader_node` for the actual implementations.
+
+The vendored headers are compile-time copies of the internal headers in `autoware_map_loader/src/pointcloud_map_loader/`. They must be kept in sync with the Core package version you build against. A future refactor in Core may expose a public pointcloud API and remove the need for these copies.
+
+## How to run
+
+### Launch file
+
+```bash
+ros2 launch autoware_map_host map_loader.launch.xml \
+  pointcloud_map_path:=/path/to/pointcloud_map.pcd \
+  pointcloud_map_metadata_path:=/path/to/pointcloud_map_metadata.yaml \
+  lanelet2_map_path:=/path/to/lanelet2_map.osm \
+  map_projector_info_path:=/path/to/map_projector_info.yaml \
+  pointcloud_map_loader_param_path:=$(ros2 pkg prefix autoware_map_loader)/share/autoware_map_loader/config/pointcloud_map_loader.param.yaml \
+  lanelet2_map_loader_param_path:=$(ros2 pkg prefix autoware_map_loader)/share/autoware_map_loader/config/lanelet2_map_loader.param.yaml \
+  map_tf_generator_param_path:=/path/to/map_tf_generator.param.yaml \
+  map_projection_loader_param_path:=/path/to/map_projection_loader.param.yaml
+```
+
+Parameter files for pointcloud and Lanelet2 loader options are provided by `autoware_map_loader`. Other parameter files depend on your launch setup.
+
+### Standalone node
+
+```bash
+ros2 run autoware_map_host autoware_map_loader_host_node --ros-args \
+  --params-file $(ros2 pkg prefix autoware_map_host)/share/autoware_map_host/config/map_loader_host.param.yaml
+```
+
+## Parameters
+
+### Host
+
+`config/map_loader_host.param.yaml` sets `plugin_names`, the ordered list of plugins to load.
+
+### Per-plugin parameters
+
+Pointcloud and Lanelet2 plugin parameters follow the schemas shared with `autoware_map_loader`:
+
+- Pointcloud: see [autoware_map_loader README — pointcloud_map_loader](https://github.com/autowarefoundation/autoware_core/tree/main/map/autoware_map_loader#pointcloud_map_loader) and `schema/pointcloud_map_loader.schema.json`
+- Lanelet2: see [autoware_map_loader README — lanelet2_map_loader](https://github.com/autowarefoundation/autoware_core/tree/main/map/autoware_map_loader#lanelet2_map_loader) and `schema/lanelet2_map_loader.schema.json`
+
+## Interfaces (under `/map` namespace)
+
+When launched via `map_loader.launch.xml`, the node runs in the `map` namespace. Key interfaces include:
+
+| Interface                           | Type    | Plugin                    |
+| ----------------------------------- | ------- | ------------------------- |
+| `map_projector_info`                | topic   | MapProjectionLoaderPlugin |
+| `pointcloud_map`                    | topic   | PointCloudMapLoaderPlugin |
+| `pointcloud_map_metadata`           | topic   | PointCloudMapLoaderPlugin |
+| `vector_map`                        | topic   | Lanelet2MapLoaderPlugin   |
+| `get_partial_pointcloud_map`        | service | PointCloudMapLoaderPlugin |
+| `get_differential_pointcloud_map`   | service | PointCloudMapLoaderPlugin |
+| `get_selected_pointcloud_map`       | service | PointCloudMapLoaderPlugin |
+| `/api/autoware/get/map/info/hash`   | topic   | MapHashGeneratorPlugin    |
+| `/api/autoware/get/map/lanelet/xml` | service | MapHashGeneratorPlugin    |
+
+See `launch/map_loader.launch.xml` for topic/service remaps.
+
+## Package layout
+
+```text
+autoware_map_host/
+├── config/           # Host plugin list
+├── include/
+│   ├── autoware/map_loader/   # Host and plugin headers
+│   └── *.hpp                  # Vendored pointcloud module headers (sync with Core)
+├── launch/           # Integrated map loader launch
+├── schema/           # Parameter schemas (shared with autoware_map_loader)
+└── src/map_loader_host/
+    ├── map_loader_host.cpp
+    └── plugins/      # Plugin implementations
+```
+
+## Building
+
+```bash
+colcon build --packages-select autoware_map_loader autoware_map_host
+```
+
+Both packages must be present: `autoware_map_host` links against libraries exported by `autoware_map_loader`.

--- a/map/autoware_map_host/config/map_loader_host.param.yaml
+++ b/map/autoware_map_host/config/map_loader_host.param.yaml
@@ -1,0 +1,9 @@
+/**:
+  ros__parameters:
+    plugin_names:
+      - autoware::map_loader::plugin::MapProjectionLoaderPlugin
+      - autoware::map_loader::plugin::PointCloudMapLoaderPlugin
+      - autoware::map_loader::plugin::Lanelet2MapLoaderPlugin
+      - autoware::map_loader::plugin::Lanelet2VisualizationPlugin
+      - autoware::map_loader::plugin::VectorMapTfGeneratorPlugin
+      - autoware::map_loader::plugin::MapHashGeneratorPlugin

--- a/map/autoware_map_host/include/autoware/map_loader/map_loader_data.hpp
+++ b/map/autoware_map_host/include/autoware/map_loader/map_loader_data.hpp
@@ -1,0 +1,37 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__MAP_LOADER__MAP_LOADER_DATA_HPP_
+#define AUTOWARE__MAP_LOADER__MAP_LOADER_DATA_HPP_
+
+#include <autoware_map_msgs/msg/lanelet_map_bin.hpp>
+#include <autoware_map_msgs/msg/map_projector_info.hpp>
+
+#include <lanelet2_core/LaneletMap.h>
+
+#include <optional>
+
+namespace autoware::map_loader
+{
+
+struct MapLoaderData
+{
+  std::optional<autoware_map_msgs::msg::MapProjectorInfo> projector_info;
+  std::optional<autoware_map_msgs::msg::LaneletMapBin> vector_map_msg;
+  lanelet::LaneletMapPtr lanelet_map_ptr;
+};
+
+}  // namespace autoware::map_loader
+
+#endif  // AUTOWARE__MAP_LOADER__MAP_LOADER_DATA_HPP_

--- a/map/autoware_map_host/include/autoware/map_loader/map_loader_host.hpp
+++ b/map/autoware_map_host/include/autoware/map_loader/map_loader_host.hpp
@@ -1,0 +1,48 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__MAP_LOADER__MAP_LOADER_HOST_HPP_
+#define AUTOWARE__MAP_LOADER__MAP_LOADER_HOST_HPP_
+
+#include "autoware/map_loader/map_loader_data.hpp"
+#include "autoware/map_loader/map_loader_plugin_base.hpp"
+
+#include <pluginlib/class_loader.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace autoware::map_loader
+{
+
+class MapLoaderHost : public rclcpp::Node
+{
+public:
+  explicit MapLoaderHost(const rclcpp::NodeOptions & options);
+
+private:
+  void initialize_plugins();
+  void load_plugin(const std::string & plugin_name);
+
+  std::unique_ptr<pluginlib::ClassLoader<plugin::MapLoaderPluginBase>> plugin_loader_;
+  std::vector<std::shared_ptr<plugin::MapLoaderPluginBase>> plugins_;
+  MapLoaderData data_;
+  bool initialized_plugins_{false};
+};
+
+}  // namespace autoware::map_loader
+
+#endif  // AUTOWARE__MAP_LOADER__MAP_LOADER_HOST_HPP_

--- a/map/autoware_map_host/include/autoware/map_loader/map_loader_plugin_base.hpp
+++ b/map/autoware_map_host/include/autoware/map_loader/map_loader_plugin_base.hpp
@@ -1,0 +1,56 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__MAP_LOADER__MAP_LOADER_PLUGIN_BASE_HPP_
+#define AUTOWARE__MAP_LOADER__MAP_LOADER_PLUGIN_BASE_HPP_
+
+#include "autoware/map_loader/map_loader_data.hpp"
+
+#include <rclcpp/rclcpp.hpp>
+
+#include <string>
+
+namespace autoware::map_loader::plugin
+{
+
+class MapLoaderPluginBase
+{
+public:
+  MapLoaderPluginBase() = default;
+  virtual ~MapLoaderPluginBase() = default;
+
+  virtual void initialize(
+    const std::string & name, rclcpp::Node * node_ptr, MapLoaderData & data) = 0;
+
+  virtual void on_startup(MapLoaderData & data) = 0;
+
+  std::string get_name() const { return name_; }
+
+  void bind(const std::string & name, rclcpp::Node * node_ptr)
+  {
+    name_ = name;
+    node_ptr_ = node_ptr;
+  }
+
+protected:
+  rclcpp::Node * get_node_ptr() const { return node_ptr_; }
+
+private:
+  std::string name_{"unnamed_map_loader_plugin"};
+  rclcpp::Node * node_ptr_{nullptr};
+};
+
+}  // namespace autoware::map_loader::plugin
+
+#endif  // AUTOWARE__MAP_LOADER__MAP_LOADER_PLUGIN_BASE_HPP_

--- a/map/autoware_map_host/include/autoware/map_loader/plugins/lanelet2_visualization_plugin.hpp
+++ b/map/autoware_map_host/include/autoware/map_loader/plugins/lanelet2_visualization_plugin.hpp
@@ -1,0 +1,316 @@
+// Copyright 2026 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*
+ * Copyright 2019 Autoware Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Authors: Simon Thompson, Ryohsuke Mitsudome
+ *
+ */
+#ifndef AUTOWARE__MAP_LOADER__PLUGINS__LANELET2_VISUALIZATION_PLUGIN_HPP_
+#define AUTOWARE__MAP_LOADER__PLUGINS__LANELET2_VISUALIZATION_PLUGIN_HPP_
+
+#include <autoware/lanelet2_utils/conversion.hpp>
+#include <autoware_lanelet2_extension/regulatory_elements/autoware_traffic_light.hpp>
+#include <autoware_lanelet2_extension/utility/query.hpp>
+#include <autoware_lanelet2_extension/visualization/visualization.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+#include <autoware_map_msgs/msg/lanelet_map_bin.hpp>
+#include <sensor_msgs/msg/point_cloud2.hpp>
+#include <visualization_msgs/msg/marker_array.hpp>
+
+#include <lanelet2_core/LaneletMap.h>
+#include <lanelet2_projection/UTM.h>
+
+#include <memory>
+#include <vector>
+
+namespace autoware::lanelet2_map_visualizer
+{
+void insert_marker_array(
+  visualization_msgs::msg::MarkerArray * a1, const visualization_msgs::msg::MarkerArray & a2)
+{
+  a1->markers.insert(a1->markers.end(), a2.markers.begin(), a2.markers.end());
+}
+
+void set_color(std_msgs::msg::ColorRGBA * cl, double r, double g, double b, double a)
+{
+  cl->r = static_cast<float>(r);
+  cl->g = static_cast<float>(g);
+  cl->b = static_cast<float>(b);
+  cl->a = static_cast<float>(a);
+}
+
+visualization_msgs::msg::MarkerArray create_vector_map_marker_array(
+  const autoware_map_msgs::msg::LaneletMapBin & map_bin_msg,
+  const bool viz_lanelets_centerline = true)
+{
+  const autoware_map_msgs::msg::LaneletMapBin msg = map_bin_msg;
+  lanelet::LaneletMapPtr viz_lanelet_map = autoware::experimental::lanelet2_utils::remove_const(
+    autoware::experimental::lanelet2_utils::from_autoware_map_msgs(msg));
+
+  // get lanelets etc to visualize
+  lanelet::ConstLanelets all_lanelets = lanelet::utils::query::laneletLayer(viz_lanelet_map);
+  lanelet::ConstLanelets road_lanelets = lanelet::utils::query::roadLanelets(all_lanelets);
+  lanelet::ConstLanelets shoulder_lanelets = lanelet::utils::query::shoulderLanelets(all_lanelets);
+  lanelet::ConstLanelets crosswalk_lanelets =
+    lanelet::utils::query::crosswalkLanelets(all_lanelets);
+  lanelet::ConstLanelets bicycle_lane_lanelets =
+    lanelet::utils::query::bicycleLaneLanelets(all_lanelets);
+  lanelet::ConstLineStrings3d partitions = lanelet::utils::query::getAllPartitions(viz_lanelet_map);
+  lanelet::ConstLineStrings3d road_borders =
+    lanelet::utils::query::getAllLinestringsWithType(viz_lanelet_map, "road_border");
+  lanelet::ConstLineStrings3d pedestrian_polygon_markings =
+    lanelet::utils::query::getAllPedestrianPolygonMarkings(viz_lanelet_map);
+  lanelet::ConstLineStrings3d pedestrian_line_markings =
+    lanelet::utils::query::getAllPedestrianLineMarkings(viz_lanelet_map);
+  lanelet::ConstLanelets walkway_lanelets = lanelet::utils::query::walkwayLanelets(all_lanelets);
+  std::vector<lanelet::ConstLineString3d> stop_lines =
+    lanelet::utils::query::stopLinesLanelets(road_lanelets);
+  std::vector<lanelet::AutowareTrafficLightConstPtr> aw_tl_reg_elems =
+    lanelet::utils::query::autowareTrafficLights(all_lanelets);
+  std::vector<lanelet::DetectionAreaConstPtr> da_reg_elems =
+    lanelet::utils::query::detectionAreas(all_lanelets);
+  std::vector<lanelet::NoStoppingAreaConstPtr> no_reg_elems =
+    lanelet::utils::query::noStoppingAreas(all_lanelets);
+  std::vector<lanelet::SpeedBumpConstPtr> sb_reg_elems =
+    lanelet::utils::query::speedBumps(all_lanelets);
+  std::vector<lanelet::CrosswalkConstPtr> cw_reg_elems =
+    lanelet::utils::query::crosswalks(all_lanelets);
+  lanelet::ConstLineStrings3d parking_spaces =
+    lanelet::utils::query::getAllParkingSpaces(viz_lanelet_map);
+  lanelet::ConstPolygons3d parking_lots = lanelet::utils::query::getAllParkingLots(viz_lanelet_map);
+  lanelet::ConstPolygons3d obstacle_polygons =
+    lanelet::utils::query::getAllObstaclePolygons(viz_lanelet_map);
+  lanelet::ConstPolygons3d no_obstacle_segmentation_area =
+    lanelet::utils::query::getAllPolygonsByType(viz_lanelet_map, "no_obstacle_segmentation_area");
+  lanelet::ConstPolygons3d no_obstacle_segmentation_area_for_run_out =
+    lanelet::utils::query::getAllPolygonsByType(
+      viz_lanelet_map, "no_obstacle_segmentation_area_for_run_out");
+  lanelet::ConstPolygons3d hatched_road_markings_area =
+    lanelet::utils::query::getAllPolygonsByType(viz_lanelet_map, "hatched_road_markings");
+  lanelet::ConstPolygons3d intersection_areas =
+    lanelet::utils::query::getAllPolygonsByType(viz_lanelet_map, "intersection_area");
+  std::vector<lanelet::NoParkingAreaConstPtr> no_parking_reg_elems =
+    lanelet::utils::query::noParkingAreas(all_lanelets);
+  lanelet::ConstLineStrings3d curbstones = lanelet::utils::query::curbstones(viz_lanelet_map);
+  std::vector<lanelet::BusStopAreaConstPtr> bus_stop_reg_elems =
+    lanelet::utils::query::busStopAreas(all_lanelets);
+  lanelet::ConstLineStrings3d waypoints = lanelet::utils::query::getAllWaypoints(viz_lanelet_map);
+
+  std_msgs::msg::ColorRGBA cl_road;
+  std_msgs::msg::ColorRGBA cl_shoulder;
+  std_msgs::msg::ColorRGBA cl_cross;
+  std_msgs::msg::ColorRGBA cl_partitions;
+  std_msgs::msg::ColorRGBA cl_road_borders;
+  std_msgs::msg::ColorRGBA cl_pedestrian_markings;
+  std_msgs::msg::ColorRGBA cl_ll_borders;
+  std_msgs::msg::ColorRGBA cl_shoulder_borders;
+  std_msgs::msg::ColorRGBA cl_stoplines;
+  std_msgs::msg::ColorRGBA cl_trafficlights;
+  std_msgs::msg::ColorRGBA cl_detection_areas;
+  std_msgs::msg::ColorRGBA cl_speed_bumps;
+  std_msgs::msg::ColorRGBA cl_crosswalks;
+  std_msgs::msg::ColorRGBA cl_parking_lots;
+  std_msgs::msg::ColorRGBA cl_parking_spaces;
+  std_msgs::msg::ColorRGBA cl_lanelet_id;
+  std_msgs::msg::ColorRGBA cl_obstacle_polygons;
+  std_msgs::msg::ColorRGBA cl_no_stopping_areas;
+  std_msgs::msg::ColorRGBA cl_no_obstacle_segmentation_area;
+  std_msgs::msg::ColorRGBA cl_no_obstacle_segmentation_area_for_run_out;
+  std_msgs::msg::ColorRGBA cl_hatched_road_markings_area;
+  std_msgs::msg::ColorRGBA cl_hatched_road_markings_line;
+  std_msgs::msg::ColorRGBA cl_no_parking_areas;
+  std_msgs::msg::ColorRGBA cl_curbstones;
+  std_msgs::msg::ColorRGBA cl_intersection_area;
+  std_msgs::msg::ColorRGBA cl_bus_stop_area;
+  std_msgs::msg::ColorRGBA cl_bicycle_lane;
+  std_msgs::msg::ColorRGBA cl_waypoints;
+  set_color(&cl_road, 0.27, 0.27, 0.27, 0.999);
+  set_color(&cl_shoulder, 0.15, 0.15, 0.15, 0.999);
+  set_color(&cl_cross, 0.27, 0.3, 0.27, 0.5);
+  set_color(&cl_partitions, 0.25, 0.25, 0.25, 0.999);
+  set_color(&cl_road_borders, 0.3, 0.25, 0.3, 0.999);
+  set_color(&cl_pedestrian_markings, 0.5, 0.5, 0.5, 0.999);
+  set_color(&cl_ll_borders, 0.5, 0.5, 0.5, 0.999);
+  set_color(&cl_shoulder_borders, 0.2, 0.2, 0.2, 0.999);
+  set_color(&cl_stoplines, 0.5, 0.5, 0.5, 0.999);
+  set_color(&cl_trafficlights, 0.5, 0.5, 0.5, 0.8);
+  set_color(&cl_detection_areas, 0.27, 0.27, 0.37, 0.5);
+  set_color(&cl_no_stopping_areas, 0.37, 0.37, 0.37, 0.5);
+  set_color(&cl_speed_bumps, 0.56, 0.40, 0.27, 0.5);
+  set_color(&cl_crosswalks, 0.80, 0.80, 0.0, 0.5);
+  set_color(&cl_obstacle_polygons, 0.4, 0.27, 0.27, 0.5);
+  set_color(&cl_parking_lots, 1.0, 1.0, 1.0, 0.2);
+  set_color(&cl_parking_spaces, 1.0, 1.0, 1.0, 0.3);
+  set_color(&cl_lanelet_id, 0.5, 0.5, 0.5, 0.999);
+  set_color(&cl_no_obstacle_segmentation_area, 0.37, 0.37, 0.27, 0.5);
+  set_color(&cl_no_obstacle_segmentation_area_for_run_out, 0.37, 0.7, 0.27, 0.5);
+  set_color(&cl_hatched_road_markings_area, 0.3, 0.3, 0.3, 0.5);
+  set_color(&cl_hatched_road_markings_line, 0.5, 0.5, 0.5, 0.999);
+  set_color(&cl_no_parking_areas, 0.42, 0.42, 0.42, 0.5);
+  set_color(&cl_curbstones, 0.1, 0.1, 0.2, 0.999);
+  set_color(&cl_intersection_area, 0.16, 1.0, 0.69, 0.5);
+  set_color(&cl_bus_stop_area, 0.863, 0.863, 0.863, 0.5);
+  set_color(&cl_bicycle_lane, 0.0, 0.3843, 0.6274, 0.5);
+  set_color(&cl_waypoints, 0.6, 0.4, 0.3, 0.999);
+
+  visualization_msgs::msg::MarkerArray map_marker_array;
+
+  insert_marker_array(
+    &map_marker_array,
+    lanelet::visualization::lineStringsAsMarkerArray(stop_lines, "stop_lines", cl_stoplines, 0.5));
+  insert_marker_array(
+    &map_marker_array,
+    lanelet::visualization::lineStringsAsMarkerArray(partitions, "partitions", cl_partitions, 0.1));
+  insert_marker_array(
+    &map_marker_array, lanelet::visualization::lineStringsAsMarkerArray(
+                         road_borders, "road_borders", cl_road_borders, 0.2));
+  insert_marker_array(
+    &map_marker_array,
+    lanelet::visualization::laneletDirectionAsMarkerArray(shoulder_lanelets, "shoulder_"));
+  insert_marker_array(
+    &map_marker_array, lanelet::visualization::laneletDirectionAsMarkerArray(road_lanelets));
+  insert_marker_array(
+    &map_marker_array, lanelet::visualization::laneletsAsTriangleMarkerArray(
+                         "crosswalk_lanelets", crosswalk_lanelets, cl_cross));
+  insert_marker_array(
+    &map_marker_array, lanelet::visualization::pedestrianPolygonMarkingsAsMarkerArray(
+                         pedestrian_polygon_markings, cl_pedestrian_markings));
+
+  insert_marker_array(
+    &map_marker_array, lanelet::visualization::pedestrianLineMarkingsAsMarkerArray(
+                         pedestrian_line_markings, cl_pedestrian_markings));
+  insert_marker_array(
+    &map_marker_array, lanelet::visualization::laneletsAsTriangleMarkerArray(
+                         "walkway_lanelets", walkway_lanelets, cl_cross));
+  insert_marker_array(
+    &map_marker_array,
+    lanelet::visualization::obstaclePolygonsAsMarkerArray(obstacle_polygons, cl_obstacle_polygons));
+  insert_marker_array(
+    &map_marker_array,
+    lanelet::visualization::detectionAreasAsMarkerArray(da_reg_elems, cl_detection_areas));
+  insert_marker_array(
+    &map_marker_array,
+    lanelet::visualization::noStoppingAreasAsMarkerArray(no_reg_elems, cl_no_stopping_areas));
+  insert_marker_array(
+    &map_marker_array,
+    lanelet::visualization::speedBumpsAsMarkerArray(sb_reg_elems, cl_speed_bumps));
+  insert_marker_array(
+    &map_marker_array,
+    lanelet::visualization::crosswalkAreasAsMarkerArray(cw_reg_elems, cl_crosswalks));
+  insert_marker_array(
+    &map_marker_array,
+    lanelet::visualization::parkingLotsAsMarkerArray(parking_lots, cl_parking_lots));
+  insert_marker_array(
+    &map_marker_array,
+    lanelet::visualization::parkingSpacesAsMarkerArray(parking_spaces, cl_parking_spaces));
+  insert_marker_array(
+    &map_marker_array,
+    lanelet::visualization::laneletsBoundaryAsMarkerArray(
+      shoulder_lanelets, cl_shoulder_borders, viz_lanelets_centerline, "shoulder_"));
+  insert_marker_array(
+    &map_marker_array, lanelet::visualization::laneletsBoundaryAsMarkerArray(
+                         road_lanelets, cl_ll_borders, viz_lanelets_centerline));
+  insert_marker_array(
+    &map_marker_array,
+    lanelet::visualization::autowareTrafficLightsAsMarkerArray(aw_tl_reg_elems, cl_trafficlights));
+  insert_marker_array(
+    &map_marker_array, lanelet::visualization::generateTrafficLightRegulatoryElementIdMaker(
+                         road_lanelets, cl_trafficlights));
+  insert_marker_array(
+    &map_marker_array, lanelet::visualization::generateTrafficLightRegulatoryElementIdMaker(
+                         crosswalk_lanelets, cl_trafficlights));
+  insert_marker_array(
+    &map_marker_array,
+    lanelet::visualization::generateTrafficLightIdMaker(aw_tl_reg_elems, cl_trafficlights));
+  insert_marker_array(
+    &map_marker_array,
+    lanelet::visualization::generateLaneletIdMarker(shoulder_lanelets, cl_lanelet_id));
+  insert_marker_array(
+    &map_marker_array,
+    lanelet::visualization::generateLaneletIdMarker(road_lanelets, cl_lanelet_id));
+  insert_marker_array(
+    &map_marker_array, lanelet::visualization::generateLaneletIdMarker(
+                         crosswalk_lanelets, cl_lanelet_id, "crosswalk_lanelet_id"));
+  insert_marker_array(
+    &map_marker_array, lanelet::visualization::laneletsAsTriangleMarkerArray(
+                         "shoulder_road_lanelets", shoulder_lanelets, cl_shoulder));
+  insert_marker_array(
+    &map_marker_array,
+    lanelet::visualization::laneletsAsTriangleMarkerArray("road_lanelets", road_lanelets, cl_road));
+  insert_marker_array(
+    &map_marker_array, lanelet::visualization::noObstacleSegmentationAreaAsMarkerArray(
+                         no_obstacle_segmentation_area, cl_no_obstacle_segmentation_area));
+  insert_marker_array(
+    &map_marker_array,
+    lanelet::visualization::noObstacleSegmentationAreaForRunOutAsMarkerArray(
+      no_obstacle_segmentation_area_for_run_out, cl_no_obstacle_segmentation_area_for_run_out));
+
+  insert_marker_array(
+    &map_marker_array,
+    lanelet::visualization::hatchedRoadMarkingsAreaAsMarkerArray(
+      hatched_road_markings_area, cl_hatched_road_markings_area, cl_hatched_road_markings_line));
+
+  insert_marker_array(
+    &map_marker_array,
+    lanelet::visualization::noParkingAreasAsMarkerArray(no_parking_reg_elems, cl_no_parking_areas));
+
+  insert_marker_array(
+    &map_marker_array,
+    lanelet::visualization::lineStringsAsMarkerArray(curbstones, "curbstone", cl_curbstones, 0.2));
+
+  insert_marker_array(
+    &map_marker_array, lanelet::visualization::intersectionAreaAsMarkerArray(
+                         intersection_areas, cl_intersection_area));
+
+  insert_marker_array(
+    &map_marker_array,
+    lanelet::visualization::busStopAreasAsMarkerArray(bus_stop_reg_elems, cl_bus_stop_area));
+
+  insert_marker_array(
+    &map_marker_array,
+    lanelet::visualization::laneletDirectionAsMarkerArray(bicycle_lane_lanelets, "bicycle_lane_"));
+  insert_marker_array(
+    &map_marker_array, lanelet::visualization::laneletsBoundaryAsMarkerArray(
+                         bicycle_lane_lanelets, cl_ll_borders /* use ll_border color */,
+                         viz_lanelets_centerline, "bicycle_lane_"));
+  insert_marker_array(
+    &map_marker_array, lanelet::visualization::generateLaneletIdMarker(
+                         bicycle_lane_lanelets, cl_lanelet_id /* use lanelet_id color */));
+  insert_marker_array(
+    &map_marker_array, lanelet::visualization::laneletsAsTriangleMarkerArray(
+                         "bicycle_lane_lanelets", bicycle_lane_lanelets, cl_bicycle_lane));
+
+  insert_marker_array(
+    &map_marker_array,
+    lanelet::visualization::lineStringsAsMarkerArray(waypoints, "waypoints", cl_waypoints, 0.02));
+
+  return map_marker_array;
+}
+}  // namespace autoware::lanelet2_map_visualizer
+#endif  // AUTOWARE__MAP_LOADER__PLUGINS__LANELET2_VISUALIZATION_PLUGIN_HPP_

--- a/map/autoware_map_host/include/autoware/map_loader/plugins/map_projection_loader_plugin.hpp
+++ b/map/autoware_map_host/include/autoware/map_loader/plugins/map_projection_loader_plugin.hpp
@@ -1,0 +1,31 @@
+// Copyright 2023 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__MAP_LOADER__PLUGINS__MAP_PROJECTION_LOADER_PLUGIN_HPP_
+#define AUTOWARE__MAP_LOADER__PLUGINS__MAP_PROJECTION_LOADER_PLUGIN_HPP_
+
+#include <autoware/component_interface_specs/map.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+#include <string>
+
+namespace autoware::map_projection_loader
+{
+autoware_map_msgs::msg::MapProjectorInfo load_info_from_yaml(const std::string & filename);
+autoware_map_msgs::msg::MapProjectorInfo load_map_projector_info(
+  const std::string & yaml_filename, const std::string & lanelet2_map_filename);
+autoware_map_msgs::msg::MapProjectorInfo load_info_from_lanelet2_map(const std::string & filename);
+}  // namespace autoware::map_projection_loader
+
+#endif  // AUTOWARE__MAP_LOADER__PLUGINS__MAP_PROJECTION_LOADER_PLUGIN_HPP_

--- a/map/autoware_map_host/include/autoware/map_loader/plugins/vector_map_tf_generator_plugin.hpp
+++ b/map/autoware_map_host/include/autoware/map_loader/plugins/vector_map_tf_generator_plugin.hpp
@@ -1,0 +1,78 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__MAP_LOADER__PLUGINS__VECTOR_MAP_TF_GENERATOR_PLUGIN_HPP_
+#define AUTOWARE__MAP_LOADER__PLUGINS__VECTOR_MAP_TF_GENERATOR_PLUGIN_HPP_
+
+#include <autoware/lanelet2_utils/conversion.hpp>
+#include <rclcpp/time.hpp>
+#include <tf2/LinearMath/Quaternion.hpp>
+
+#include <autoware_map_msgs/msg/lanelet_map_bin.hpp>
+#include <geometry_msgs/msg/transform_stamped.hpp>
+
+#include <lanelet2_core/LaneletMap.h>
+#include <lanelet2_core/geometry/Point.h>
+
+#include <numeric>
+#include <string>
+#include <vector>
+
+namespace autoware::map_tf_generator
+{
+
+geometry_msgs::msg::TransformStamped create_viewer_transform(
+  const autoware_map_msgs::msg::LaneletMapBin & map_bin_msg, const std::string & map_frame,
+  const std::string & viewer_frame, const rclcpp::Time & stamp)
+{
+  const auto lanelet_map_ptr = autoware::experimental::lanelet2_utils::remove_const(
+    autoware::experimental::lanelet2_utils::from_autoware_map_msgs(map_bin_msg));
+
+  std::vector<double> points_x;
+  std::vector<double> points_y;
+  std::vector<double> points_z;
+
+  for (const lanelet::Point3d & point : lanelet_map_ptr->pointLayer) {
+    points_x.push_back(point.x());
+    points_y.push_back(point.y());
+    points_z.push_back(point.z());
+  }
+
+  const double coordinate_x =
+    std::accumulate(points_x.begin(), points_x.end(), 0.0) / static_cast<double>(points_x.size());
+  const double coordinate_y =
+    std::accumulate(points_y.begin(), points_y.end(), 0.0) / static_cast<double>(points_y.size());
+  const double coordinate_z =
+    std::accumulate(points_z.begin(), points_z.end(), 0.0) / static_cast<double>(points_z.size());
+
+  geometry_msgs::msg::TransformStamped static_transform_stamped;
+  static_transform_stamped.header.stamp = stamp;
+  static_transform_stamped.header.frame_id = map_frame;
+  static_transform_stamped.child_frame_id = viewer_frame;
+  static_transform_stamped.transform.translation.x = coordinate_x;
+  static_transform_stamped.transform.translation.y = coordinate_y;
+  static_transform_stamped.transform.translation.z = coordinate_z;
+  tf2::Quaternion quat;
+  quat.setRPY(0, 0, 0);
+  static_transform_stamped.transform.rotation.x = quat.x();
+  static_transform_stamped.transform.rotation.y = quat.y();
+  static_transform_stamped.transform.rotation.z = quat.z();
+  static_transform_stamped.transform.rotation.w = quat.w();
+
+  return static_transform_stamped;
+}
+
+}  // namespace autoware::map_tf_generator
+
+#endif  // AUTOWARE__MAP_LOADER__PLUGINS__VECTOR_MAP_TF_GENERATOR_PLUGIN_HPP_

--- a/map/autoware_map_host/include/differential_map_loader_module.hpp
+++ b/map/autoware_map_host/include/differential_map_loader_module.hpp
@@ -1,0 +1,62 @@
+// Copyright 2022 The Autoware Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DIFFERENTIAL_MAP_LOADER_MODULE_HPP_
+#define DIFFERENTIAL_MAP_LOADER_MODULE_HPP_
+
+#include "utils.hpp"
+
+#include <rclcpp/rclcpp.hpp>
+
+#include "autoware_map_msgs/srv/get_differential_point_cloud_map.hpp"
+
+#include <pcl/common/common.h>
+#include <pcl/filters/voxel_grid.h>
+#include <pcl/io/pcd_io.h>
+#include <pcl/point_cloud.h>
+#include <pcl/point_types.h>
+#include <pcl_conversions/pcl_conversions.h>
+
+#include <map>
+#include <string>
+#include <vector>
+
+namespace autoware::map_loader
+{
+class DifferentialMapLoaderModule
+{
+  using GetDifferentialPointCloudMap = autoware_map_msgs::srv::GetDifferentialPointCloudMap;
+
+public:
+  explicit DifferentialMapLoaderModule(
+    rclcpp::Node * node, std::map<std::string, PCDFileMetadata> pcd_file_metadata_dict);
+
+private:
+  rclcpp::Logger logger_;
+
+  std::map<std::string, PCDFileMetadata> all_pcd_file_metadata_dict_;
+  rclcpp::Service<GetDifferentialPointCloudMap>::SharedPtr get_differential_pcd_maps_service_;
+
+  [[nodiscard]] bool on_service_get_differential_point_cloud_map(
+    GetDifferentialPointCloudMap::Request::SharedPtr req,
+    GetDifferentialPointCloudMap::Response::SharedPtr res) const;
+  void differential_area_load(
+    const autoware_map_msgs::msg::AreaInfo & area_info, const std::vector<std::string> & cached_ids,
+    const GetDifferentialPointCloudMap::Response::SharedPtr & response) const;
+  [[nodiscard]] autoware_map_msgs::msg::PointCloudMapCellWithID load_point_cloud_map_cell_with_id(
+    const std::string & path, const std::string & map_id) const;
+};
+}  // namespace autoware::map_loader
+
+#endif  // DIFFERENTIAL_MAP_LOADER_MODULE_HPP_

--- a/map/autoware_map_host/include/partial_map_loader_module.hpp
+++ b/map/autoware_map_host/include/partial_map_loader_module.hpp
@@ -1,0 +1,62 @@
+// Copyright 2022 The Autoware Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef PARTIAL_MAP_LOADER_MODULE_HPP_
+#define PARTIAL_MAP_LOADER_MODULE_HPP_
+
+#include "utils.hpp"
+
+#include <rclcpp/rclcpp.hpp>
+
+#include <autoware_map_msgs/srv/get_partial_point_cloud_map.hpp>
+
+#include <pcl/common/common.h>
+#include <pcl/filters/voxel_grid.h>
+#include <pcl/io/pcd_io.h>
+#include <pcl/point_cloud.h>
+#include <pcl/point_types.h>
+#include <pcl_conversions/pcl_conversions.h>
+
+#include <map>
+#include <string>
+#include <vector>
+
+namespace autoware::map_loader
+{
+class PartialMapLoaderModule
+{
+  using GetPartialPointCloudMap = autoware_map_msgs::srv::GetPartialPointCloudMap;
+
+public:
+  explicit PartialMapLoaderModule(
+    rclcpp::Node * node, std::map<std::string, PCDFileMetadata> pcd_file_metadata_dict);
+
+private:
+  rclcpp::Logger logger_;
+
+  std::map<std::string, PCDFileMetadata> all_pcd_file_metadata_dict_;
+  rclcpp::Service<GetPartialPointCloudMap>::SharedPtr get_partial_pcd_maps_service_;
+
+  [[nodiscard]] bool on_service_get_partial_point_cloud_map(
+    GetPartialPointCloudMap::Request::SharedPtr req,
+    GetPartialPointCloudMap::Response::SharedPtr res) const;
+  void partial_area_load(
+    const autoware_map_msgs::msg::AreaInfo & area,
+    const GetPartialPointCloudMap::Response::SharedPtr & response) const;
+  [[nodiscard]] autoware_map_msgs::msg::PointCloudMapCellWithID load_point_cloud_map_cell_with_id(
+    const std::string & path, const std::string & map_id) const;
+};
+}  // namespace autoware::map_loader
+
+#endif  // PARTIAL_MAP_LOADER_MODULE_HPP_

--- a/map/autoware_map_host/include/pointcloud_map_loader_module.hpp
+++ b/map/autoware_map_host/include/pointcloud_map_loader_module.hpp
@@ -1,0 +1,49 @@
+// Copyright 2022 The Autoware Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef POINTCLOUD_MAP_LOADER_MODULE_HPP_
+#define POINTCLOUD_MAP_LOADER_MODULE_HPP_
+
+#include <rclcpp/rclcpp.hpp>
+
+#include <sensor_msgs/msg/point_cloud2.hpp>
+
+#include <boost/optional.hpp>
+
+#include <pcl/filters/voxel_grid.h>
+#include <pcl/io/pcd_io.h>
+#include <pcl_conversions/pcl_conversions.h>
+
+#include <string>
+#include <vector>
+
+namespace autoware::map_loader
+{
+class PointcloudMapLoaderModule
+{
+public:
+  explicit PointcloudMapLoaderModule(
+    rclcpp::Node * node, const std::vector<std::string> & pcd_paths,
+    const std::string & publisher_name, const bool use_downsample);
+
+private:
+  rclcpp::Logger logger_;
+  rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr pub_pointcloud_map_;
+
+  [[nodiscard]] sensor_msgs::msg::PointCloud2 load_pcd_files(
+    const std::vector<std::string> & pcd_paths, const boost::optional<float> leaf_size) const;
+};
+}  // namespace autoware::map_loader
+
+#endif  // POINTCLOUD_MAP_LOADER_MODULE_HPP_

--- a/map/autoware_map_host/include/selected_map_loader_module.hpp
+++ b/map/autoware_map_host/include/selected_map_loader_module.hpp
@@ -1,0 +1,62 @@
+// Copyright 2022 The Autoware Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SELECTED_MAP_LOADER_MODULE_HPP_
+#define SELECTED_MAP_LOADER_MODULE_HPP_
+
+#include "utils.hpp"
+
+#include <rclcpp/rclcpp.hpp>
+
+#include <autoware_map_msgs/msg/point_cloud_map_meta_data.hpp>
+#include <autoware_map_msgs/srv/get_selected_point_cloud_map.hpp>
+
+#include <pcl/common/common.h>
+#include <pcl/filters/voxel_grid.h>
+#include <pcl/io/pcd_io.h>
+#include <pcl/point_cloud.h>
+#include <pcl/point_types.h>
+#include <pcl_conversions/pcl_conversions.h>
+
+#include <map>
+#include <string>
+#include <vector>
+
+namespace autoware::map_loader
+{
+class SelectedMapLoaderModule
+{
+  using GetSelectedPointCloudMap = autoware_map_msgs::srv::GetSelectedPointCloudMap;
+
+public:
+  explicit SelectedMapLoaderModule(
+    rclcpp::Node * node, std::map<std::string, PCDFileMetadata> pcd_file_metadata_dict);
+
+private:
+  rclcpp::Logger logger_;
+
+  std::map<std::string, PCDFileMetadata> all_pcd_file_metadata_dict_;
+  rclcpp::Service<GetSelectedPointCloudMap>::SharedPtr get_selected_pcd_maps_service_;
+
+  rclcpp::Publisher<autoware_map_msgs::msg::PointCloudMapMetaData>::SharedPtr pub_metadata_;
+
+  [[nodiscard]] bool on_service_get_selected_point_cloud_map(
+    GetSelectedPointCloudMap::Request::SharedPtr req,
+    GetSelectedPointCloudMap::Response::SharedPtr res) const;
+  [[nodiscard]] autoware_map_msgs::msg::PointCloudMapCellWithID load_point_cloud_map_cell_with_id(
+    const std::string & path, const std::string & map_id) const;
+};
+}  // namespace autoware::map_loader
+
+#endif  // SELECTED_MAP_LOADER_MODULE_HPP_

--- a/map/autoware_map_host/include/utils.hpp
+++ b/map/autoware_map_host/include/utils.hpp
@@ -1,0 +1,55 @@
+// Copyright 2022 The Autoware Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef UTILS_HPP_
+#define UTILS_HPP_
+
+#include <autoware_map_msgs/msg/area_info.hpp>
+#include <geometry_msgs/msg/point.hpp>
+
+#include <pcl/common/common.h>
+#include <yaml-cpp/yaml.h>
+
+#include <map>
+#include <set>
+#include <string>
+#include <vector>
+
+namespace autoware::map_loader
+{
+struct PCDFileMetadata
+{
+  pcl::PointXYZ min;
+  pcl::PointXYZ max;
+  bool operator==(const PCDFileMetadata & other) const
+  {
+    return min.x == other.min.x && min.y == other.min.y && min.z == other.min.z &&
+           max.x == other.max.x && max.y == other.max.y && max.z == other.max.z;
+  }
+};
+
+std::map<std::string, PCDFileMetadata> load_pcd_metadata(const std::string & pcd_metadata_path);
+std::map<std::string, PCDFileMetadata> replace_with_absolute_path(
+  const std::map<std::string, PCDFileMetadata> & pcd_metadata_path,
+  const std::vector<std::string> & pcd_paths, std::set<std::string> & missing_pcd_names);
+
+bool cylinder_and_box_overlap_exists(
+  const double center_x, const double center_y, const double radius,
+  const pcl::PointXYZ box_min_point, const pcl::PointXYZ box_max_point);
+bool is_grid_within_queried_area(
+  const autoware_map_msgs::msg::AreaInfo area, const PCDFileMetadata metadata);
+
+}  // namespace autoware::map_loader
+
+#endif  // UTILS_HPP_

--- a/map/autoware_map_host/launch/map_loader.launch.xml
+++ b/map/autoware_map_host/launch/map_loader.launch.xml
@@ -1,0 +1,35 @@
+<launch>
+  <!-- map files -->
+  <arg name="pointcloud_map_path"/>
+  <arg name="pointcloud_map_metadata_path"/>
+  <arg name="lanelet2_map_path"/>
+  <arg name="map_projector_info_path"/>
+
+  <!-- Parameter files -->
+  <arg name="map_loader_host_param_path" default="$(find-pkg-share autoware_map_host)/config/map_loader_host.param.yaml"/>
+  <arg name="pointcloud_map_loader_param_path"/>
+  <arg name="lanelet2_map_loader_param_path"/>
+  <arg name="map_tf_generator_param_path"/>
+  <arg name="map_projection_loader_param_path"/>
+
+  <group>
+    <push-ros-namespace namespace="map"/>
+
+    <node pkg="autoware_map_host" exec="autoware_map_loader_host_node" name="map_loader" output="both">
+      <param from="$(var map_loader_host_param_path)"/>
+      <param from="$(var pointcloud_map_loader_param_path)"/>
+      <param from="$(var lanelet2_map_loader_param_path)"/>
+      <param from="$(var map_tf_generator_param_path)"/>
+      <param from="$(var map_projection_loader_param_path)" allow_substs="true"/>
+      <param name="pcd_paths_or_directory" value="[$(var pointcloud_map_path)]"/>
+      <param name="pcd_metadata_path" value="$(var pointcloud_map_metadata_path)"/>
+      <param name="lanelet2_map_path" value="$(var lanelet2_map_path)"/>
+      <param name="map_projector_info_path" value="$(var map_projector_info_path)"/>
+      <param name="pointcloud_map_path" value="$(var pointcloud_map_path)"/>
+      <remap from="service/get_partial_pcd_map" to="/map/get_partial_pointcloud_map"/>
+      <remap from="service/get_differential_pcd_map" to="/map/get_differential_pointcloud_map"/>
+      <remap from="service/get_selected_pcd_map" to="/map/get_selected_pointcloud_map"/>
+      <remap from="output/pointcloud_map_metadata" to="pointcloud_map_metadata"/>
+    </node>
+  </group>
+</launch>

--- a/map/autoware_map_host/package.xml
+++ b/map/autoware_map_host/package.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>autoware_map_host</name>
+  <version>1.7.0</version>
+  <description>Plugin-based map loader host that integrates pointcloud, Lanelet2, projection, visualization, and map hash loading in a single node.</description>
+  <maintainer email="yamato.ando@tier4.jp">Yamato Ando</maintainer>
+  <maintainer email="masahiro.sakamoto@tier4.jp">Masahiro Sakamoto</maintainer>
+  <maintainer email="anh.nguyen.2@tier4.jp">NGUYEN Viet Anh</maintainer>
+  <maintainer email="taiki.yamada@tier4.jp">Taiki Yamada</maintainer>
+
+  <license>Apache License 2.0</license>
+  <author email="ryohsuke.mitsudome@tier4.jp">Ryohsuke Mitsudome</author>
+  <author email="koji.minoda@tier4.jp">Koji Minoda</author>
+
+  <buildtool_depend>ament_cmake_auto</buildtool_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
+
+  <depend>autoware_component_interface_specs</depend>
+  <depend>autoware_geography_utils</depend>
+  <depend>autoware_lanelet2_extension</depend>
+  <depend>autoware_lanelet2_utils</depend>
+  <depend>autoware_map_loader</depend>
+  <depend>autoware_map_msgs</depend>
+  <depend>autoware_utils</depend>
+  <depend>fmt</depend>
+  <depend>geometry_msgs</depend>
+  <depend>libpcl-all-dev</depend>
+  <depend>libssl-dev</depend>
+  <depend>pcl_conversions</depend>
+  <depend>pluginlib</depend>
+  <depend>rclcpp</depend>
+  <depend>rclcpp_components</depend>
+  <depend>tf2_ros</depend>
+  <depend>tier4_external_api_msgs</depend>
+  <depend>visualization_msgs</depend>
+  <depend>yaml-cpp</depend>
+
+  <test_depend>ament_cmake_gmock</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>autoware_lint_common</test_depend>
+  <test_depend>launch_testing_ament_cmake</test_depend>
+  <test_depend>ros_testing</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/map/autoware_map_host/plugins.xml
+++ b/map/autoware_map_host/plugins.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<library path="autoware_map_loader_host_plugins">
+  <class type="autoware::map_loader::plugin::MapProjectionLoaderPlugin"
+         base_class_type="autoware::map_loader::plugin::MapLoaderPluginBase">
+    <description>Loads and publishes map projection metadata.</description>
+  </class>
+  <class type="autoware::map_loader::plugin::PointCloudMapLoaderPlugin"
+         base_class_type="autoware::map_loader::plugin::MapLoaderPluginBase">
+    <description>Loads pointcloud map and partial/differential/selected map services.</description>
+  </class>
+  <class type="autoware::map_loader::plugin::Lanelet2MapLoaderPlugin"
+         base_class_type="autoware::map_loader::plugin::MapLoaderPluginBase">
+    <description>Loads Lanelet2 vector map.</description>
+  </class>
+  <class type="autoware::map_loader::plugin::Lanelet2VisualizationPlugin"
+         base_class_type="autoware::map_loader::plugin::MapLoaderPluginBase">
+    <description>Publishes Lanelet2 visualization markers.</description>
+  </class>
+  <class type="autoware::map_loader::plugin::VectorMapTfGeneratorPlugin"
+         base_class_type="autoware::map_loader::plugin::MapLoaderPluginBase">
+    <description>Broadcasts map viewer static TF from vector map.</description>
+  </class>
+  <class type="autoware::map_loader::plugin::MapHashGeneratorPlugin"
+         base_class_type="autoware::map_loader::plugin::MapLoaderPluginBase">
+    <description>Publishes map file hashes and lanelet XML API service.</description>
+  </class>
+</library>

--- a/map/autoware_map_host/src/map_loader_host/map_loader_host.cpp
+++ b/map/autoware_map_host/src/map_loader_host/map_loader_host.cpp
@@ -1,0 +1,81 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/map_loader/map_loader_host.hpp"
+
+#include <rclcpp/logging.hpp>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace autoware::map_loader
+{
+
+MapLoaderHost::MapLoaderHost(const rclcpp::NodeOptions & options)
+: Node("map_loader", options),
+  plugin_loader_(
+    std::make_unique<pluginlib::ClassLoader<plugin::MapLoaderPluginBase>>(
+      "autoware_map_host", "autoware::map_loader::plugin::MapLoaderPluginBase"))
+{
+  declare_parameter<std::vector<std::string>>("plugin_names", std::vector<std::string>{});
+  initialize_plugins();
+}
+
+void MapLoaderHost::initialize_plugins()
+{
+  if (initialized_plugins_) {
+    return;
+  }
+
+  const auto plugin_names = get_parameter("plugin_names").as_string_array();
+  for (const auto & plugin_name : plugin_names) {
+    load_plugin(plugin_name);
+  }
+
+  for (auto & plugin : plugins_) {
+    plugin->on_startup(data_);
+  }
+
+  initialized_plugins_ = true;
+}
+
+void MapLoaderHost::load_plugin(const std::string & plugin_name)
+{
+  try {
+    auto plugin = plugin_loader_->createSharedInstance(plugin_name);
+
+    for (const auto & loaded : plugins_) {
+      if (plugin->get_name() == loaded->get_name()) {
+        RCLCPP_WARN_STREAM(get_logger(), "Plugin '" << plugin_name << "' is already loaded.");
+        return;
+      }
+    }
+
+    plugin->bind(plugin_name, this);
+    plugin->initialize(plugin_name, this, data_);
+    plugins_.push_back(plugin);
+
+    RCLCPP_INFO_STREAM(get_logger(), "Loaded map loader plugin: " << plugin_name);
+  } catch (const pluginlib::CreateClassException & e) {
+    RCLCPP_ERROR_STREAM(
+      get_logger(), "Failed to load plugin '" << plugin_name << "': " << e.what());
+    throw;
+  }
+}
+
+}  // namespace autoware::map_loader
+
+#include <rclcpp_components/register_node_macro.hpp>
+RCLCPP_COMPONENTS_REGISTER_NODE(autoware::map_loader::MapLoaderHost)

--- a/map/autoware_map_host/src/map_loader_host/plugins/lanelet2_map_loader_plugin.cpp
+++ b/map/autoware_map_host/src/map_loader_host/plugins/lanelet2_map_loader_plugin.cpp
@@ -1,0 +1,122 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/map_loader/lanelet2_map_loader_node.hpp"
+#include "autoware/map_loader/map_loader_plugin_base.hpp"
+
+#include <autoware/component_interface_specs/map.hpp>
+#include <autoware_lanelet2_extension/io/autoware_osm_parser.hpp>
+#include <autoware_lanelet2_extension/utility/utilities.hpp>
+#include <autoware_lanelet2_extension/version.hpp>
+#include <autoware_utils/ros/parameter.hpp>
+#include <pluginlib/class_list_macros.hpp>
+
+#include <stdexcept>
+#include <string>
+
+namespace autoware::map_loader::plugin
+{
+
+class Lanelet2MapLoaderPlugin : public MapLoaderPluginBase
+{
+public:
+  void initialize(
+    const std::string & /*name*/, rclcpp::Node * node, MapLoaderData & /*data*/) override
+  {
+    node_ = node;
+    using autoware_utils_rclcpp::get_or_declare_parameter;
+    allow_unsupported_version_ = get_or_declare_parameter<bool>(*node, "allow_unsupported_version");
+    lanelet2_map_path_ = get_or_declare_parameter<std::string>(*node, "lanelet2_map_path");
+    center_line_resolution_ = get_or_declare_parameter<double>(*node, "center_line_resolution");
+    use_waypoints_ = get_or_declare_parameter<bool>(*node, "use_waypoints");
+
+    using VectorMap = autoware::component_interface_specs::map::VectorMap;
+    pub_map_bin_ =
+      node->create_publisher<VectorMap::Message>(VectorMap::name, rclcpp::QoS{1}.transient_local());
+  }
+
+  void on_startup(MapLoaderData & data) override
+  {
+    if (!data.projector_info.has_value()) {
+      throw std::runtime_error("Map projector info is not available for lanelet2 map loader.");
+    }
+
+    const auto & projector_info = data.projector_info.value();
+    const auto map = Lanelet2MapLoaderNode::load_map(lanelet2_map_path_, projector_info);
+    if (!map) {
+      RCLCPP_ERROR(node_->get_logger(), "Failed to load lanelet2_map. Not published.");
+      return;
+    }
+
+    std::string format_version{"null"};
+    std::string map_version{""};
+    lanelet::io_handlers::AutowareOsmParser::parseVersions(
+      lanelet2_map_path_, &format_version, &map_version);
+    if (format_version == "null" || format_version.empty() || !isdigit(format_version[0])) {
+      RCLCPP_WARN(
+        node_->get_logger(),
+        "%s has no format_version(null) or non semver-style format_version(%s) information",
+        lanelet2_map_path_.c_str(), format_version.c_str());
+      if (!allow_unsupported_version_) {
+        throw std::invalid_argument(
+          "allow_unsupported_version is false, so stop loading lanelet map");
+      }
+    } else if (const auto map_major_ver_opt =
+                 lanelet::io_handlers::parseMajorVersion(format_version);
+               map_major_ver_opt.has_value()) {
+      const auto map_major_ver = map_major_ver_opt.value();
+      if (map_major_ver > static_cast<uint64_t>(lanelet::autoware::version)) {
+        RCLCPP_WARN(
+          node_->get_logger(),
+          "format_version(%ld) of the provided map(%s) is larger than the supported version(%ld)",
+          map_major_ver, lanelet2_map_path_.c_str(),
+          static_cast<uint64_t>(lanelet::autoware::version));
+        if (!allow_unsupported_version_) {
+          throw std::invalid_argument(
+            "allow_unsupported_version is false, so stop loading lanelet map");
+        }
+      }
+    }
+    RCLCPP_INFO(node_->get_logger(), "Loaded map format_version: %s", format_version.c_str());
+
+    if (use_waypoints_) {
+      lanelet::utils::overwriteLaneletsCenterlineWithWaypoints(map, center_line_resolution_, false);
+    } else {
+      lanelet::utils::overwriteLaneletsCenterline(map, center_line_resolution_, false);
+    }
+
+    const auto map_bin_msg =
+      Lanelet2MapLoaderNode::create_map_bin_msg(map, lanelet2_map_path_, node_->now());
+    pub_map_bin_->publish(map_bin_msg);
+
+    data.lanelet_map_ptr = map;
+    data.vector_map_msg = map_bin_msg;
+
+    RCLCPP_INFO(node_->get_logger(), "Succeeded to load lanelet2_map. Map is published.");
+  }
+
+private:
+  rclcpp::Node * node_{nullptr};
+  bool allow_unsupported_version_{false};
+  std::string lanelet2_map_path_;
+  double center_line_resolution_{5.0};
+  bool use_waypoints_{true};
+  rclcpp::Publisher<autoware_map_msgs::msg::LaneletMapBin>::SharedPtr pub_map_bin_;
+};
+
+}  // namespace autoware::map_loader::plugin
+
+PLUGINLIB_EXPORT_CLASS(
+  autoware::map_loader::plugin::Lanelet2MapLoaderPlugin,
+  autoware::map_loader::plugin::MapLoaderPluginBase)

--- a/map/autoware_map_host/src/map_loader_host/plugins/lanelet2_visualization_plugin.cpp
+++ b/map/autoware_map_host/src/map_loader_host/plugins/lanelet2_visualization_plugin.cpp
@@ -1,0 +1,60 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/map_loader/plugins/lanelet2_visualization_plugin.hpp"
+
+#include "autoware/map_loader/map_loader_plugin_base.hpp"
+
+// #include <autoware/lanelet2_map_visualizer/lanelet2_map_visualization.hpp>
+
+#include <pluginlib/class_list_macros.hpp>
+
+#include <string>
+
+namespace autoware::map_loader::plugin
+{
+
+class Lanelet2VisualizationPlugin : public MapLoaderPluginBase
+{
+public:
+  void initialize(
+    const std::string & /*name*/, rclcpp::Node * node, MapLoaderData & /*data*/) override
+  {
+    pub_marker_ = node->create_publisher<visualization_msgs::msg::MarkerArray>(
+      "vector_map_marker", rclcpp::QoS{1}.transient_local());
+  }
+
+  void on_startup(MapLoaderData & data) override
+  {
+    if (!data.vector_map_msg.has_value()) {
+      RCLCPP_WARN(
+        get_node_ptr()->get_logger(), "Vector map is not loaded; skipping lanelet2 visualization.");
+      return;
+    }
+
+    const auto markers = autoware::lanelet2_map_visualizer::create_vector_map_marker_array(
+      data.vector_map_msg.value());
+    pub_marker_->publish(markers);
+    RCLCPP_INFO(get_node_ptr()->get_logger(), "Published vector map markers.");
+  }
+
+private:
+  rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr pub_marker_;
+};
+
+}  // namespace autoware::map_loader::plugin
+
+PLUGINLIB_EXPORT_CLASS(
+  autoware::map_loader::plugin::Lanelet2VisualizationPlugin,
+  autoware::map_loader::plugin::MapLoaderPluginBase)

--- a/map/autoware_map_host/src/map_loader_host/plugins/map_hash_generator_plugin.cpp
+++ b/map/autoware_map_host/src/map_loader_host/plugins/map_hash_generator_plugin.cpp
@@ -1,0 +1,193 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/map_loader/map_loader_plugin_base.hpp"
+
+#include <autoware_utils/ros/parameter.hpp>
+#include <pluginlib/class_list_macros.hpp>
+
+#include "tier4_external_api_msgs/msg/map_hash.hpp"
+#include "tier4_external_api_msgs/msg/response_status.hpp"
+#include "tier4_external_api_msgs/srv/get_text_file.hpp"
+
+#include <openssl/evp.h>
+
+#include <algorithm>
+#include <filesystem>
+#include <fstream>
+#include <iomanip>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace autoware::map_loader::plugin
+{
+namespace fs = std::filesystem;
+
+class MapHashGeneratorPlugin : public MapLoaderPluginBase
+{
+public:
+  void initialize(
+    const std::string & /*name*/, rclcpp::Node * node, MapLoaderData & /*data*/) override
+  {
+    node_ = node;
+    using autoware_utils_rclcpp::get_or_declare_parameter;
+    lanelet2_map_path_ = get_or_declare_parameter<std::string>(*node, "lanelet2_map_path");
+    pointcloud_map_path_ = get_or_declare_parameter<std::string>(*node, "pointcloud_map_path");
+
+    lanelet_text_ = load_lanelet_text(lanelet2_map_path_);
+    lanelet_hash_ = generate_lanelet_file_hash(lanelet_text_);
+    pcd_hash_ = generate_pcd_file_hash(pointcloud_map_path_);
+
+    const auto qos = rclcpp::QoS(1).transient_local();
+    hash_pub_ = node->create_publisher<tier4_external_api_msgs::msg::MapHash>(
+      "/api/autoware/get/map/info/hash", qos);
+
+    lanelet_xml_srv_ = node->create_service<tier4_external_api_msgs::srv::GetTextFile>(
+      "/api/autoware/get/map/lanelet/xml", std::bind(
+                                             &MapHashGeneratorPlugin::on_get_lanelet_xml, this,
+                                             std::placeholders::_1, std::placeholders::_2));
+  }
+
+  void on_startup(MapLoaderData & /*data*/) override
+  {
+    tier4_external_api_msgs::msg::MapHash msg;
+    msg.lanelet = lanelet_hash_;
+    msg.pcd = pcd_hash_;
+    hash_pub_->publish(msg);
+    RCLCPP_INFO(node_->get_logger(), "Published map hash.");
+  }
+
+private:
+  rclcpp::Node * node_{nullptr};
+  std::string lanelet2_map_path_;
+  std::string pointcloud_map_path_;
+  std::string lanelet_text_;
+  std::string lanelet_hash_;
+  std::string pcd_hash_;
+  rclcpp::Publisher<tier4_external_api_msgs::msg::MapHash>::SharedPtr hash_pub_;
+  rclcpp::Service<tier4_external_api_msgs::srv::GetTextFile>::SharedPtr lanelet_xml_srv_;
+
+  static std::string load_lanelet_text(const std::string & path)
+  {
+    const fs::path file_path(path);
+    if (!fs::is_regular_file(file_path)) {
+      return "";
+    }
+    std::ifstream ifs(file_path);
+    std::stringstream buffer;
+    buffer << ifs.rdbuf();
+    return buffer.str();
+  }
+
+  static std::string sha256_hex(const std::string & data)
+  {
+    unsigned char hash[EVP_MAX_MD_SIZE];
+    unsigned int hash_len = 0;
+    EVP_MD_CTX * context = EVP_MD_CTX_new();
+    EVP_DigestInit_ex(context, EVP_sha256(), nullptr);
+    EVP_DigestUpdate(context, data.data(), data.size());
+    EVP_DigestFinal_ex(context, hash, &hash_len);
+    EVP_MD_CTX_free(context);
+
+    std::ostringstream oss;
+    for (unsigned int i = 0; i < hash_len; ++i) {
+      oss << std::hex << std::setw(2) << std::setfill('0') << static_cast<int>(hash[i]);
+    }
+    return oss.str();
+  }
+
+  static std::string sha256_file_hex(const std::string & path)
+  {
+    std::ifstream file(path, std::ios::binary);
+    if (!file) {
+      return "";
+    }
+    std::string content((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
+    return sha256_hex(content);
+  }
+
+  static std::string generate_lanelet_file_hash(const std::string & data)
+  {
+    return data.empty() ? "" : sha256_hex(data);
+  }
+
+  std::string generate_pcd_file_hash(const std::string & path) const
+  {
+    const fs::path map_path(path);
+    if (fs::is_regular_file(map_path)) {
+      if (map_path.extension() != ".pcd" && map_path.extension() != ".PCD") {
+        RCLCPP_ERROR(node_->get_logger(), "[%s] is not pcd file", path.c_str());
+        return "";
+      }
+      return sha256_file_hex(path);
+    }
+
+    if (fs::is_directory(map_path)) {
+      EVP_MD_CTX * context = EVP_MD_CTX_new();
+      EVP_DigestInit_ex(context, EVP_sha256(), nullptr);
+      bool has_pcd = false;
+      std::vector<fs::path> pcd_files;
+      for (const auto & entry : fs::directory_iterator(map_path)) {
+        if (entry.path().extension() == ".pcd" || entry.path().extension() == ".PCD") {
+          pcd_files.push_back(entry.path());
+        }
+      }
+      std::sort(pcd_files.begin(), pcd_files.end());
+      for (const auto & pcd_file : pcd_files) {
+        std::ifstream file(pcd_file, std::ios::binary);
+        if (!file) {
+          RCLCPP_ERROR(node_->get_logger(), "Failed to open %s", pcd_file.c_str());
+          EVP_MD_CTX_free(context);
+          return "";
+        }
+        std::string content(
+          (std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
+        EVP_DigestUpdate(context, content.data(), content.size());
+        has_pcd = true;
+      }
+      if (!has_pcd) {
+        RCLCPP_ERROR(node_->get_logger(), "there are no pcd files in [%s]", path.c_str());
+        EVP_MD_CTX_free(context);
+        return "";
+      }
+      unsigned char hash[EVP_MAX_MD_SIZE];
+      unsigned int hash_len = 0;
+      EVP_DigestFinal_ex(context, hash, &hash_len);
+      EVP_MD_CTX_free(context);
+      std::ostringstream oss;
+      for (unsigned int i = 0; i < hash_len; ++i) {
+        oss << std::hex << std::setw(2) << std::setfill('0') << static_cast<int>(hash[i]);
+      }
+      return oss.str();
+    }
+
+    RCLCPP_ERROR(node_->get_logger(), "[%s] is neither file nor directory", path.c_str());
+    return "";
+  }
+
+  void on_get_lanelet_xml(
+    const tier4_external_api_msgs::srv::GetTextFile::Request::SharedPtr /*request*/,
+    const tier4_external_api_msgs::srv::GetTextFile::Response::SharedPtr response) const
+  {
+    response->status.code = tier4_external_api_msgs::msg::ResponseStatus::SUCCESS;
+    response->file.text = lanelet_text_;
+  }
+};
+
+}  // namespace autoware::map_loader::plugin
+
+PLUGINLIB_EXPORT_CLASS(
+  autoware::map_loader::plugin::MapHashGeneratorPlugin,
+  autoware::map_loader::plugin::MapLoaderPluginBase)

--- a/map/autoware_map_host/src/map_loader_host/plugins/map_projection_loader_plugin.cpp
+++ b/map/autoware_map_host/src/map_loader_host/plugins/map_projection_loader_plugin.cpp
@@ -1,0 +1,214 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/map_loader/plugins/map_projection_loader_plugin.hpp"
+
+#include "autoware/map_loader/map_loader_plugin_base.hpp"
+
+#include <autoware/component_interface_specs/map.hpp>
+#include <autoware_lanelet2_extension/io/autoware_osm_parser.hpp>
+#include <autoware_lanelet2_extension/projection/mgrs_projector.hpp>
+#include <autoware_lanelet2_extension/utility/utilities.hpp>
+#include <autoware_utils/ros/parameter.hpp>
+#include <pluginlib/class_list_macros.hpp>
+
+#include <autoware_map_msgs/msg/map_projector_info.hpp>
+
+#include <lanelet2_core/LaneletMap.h>
+#include <lanelet2_core/geometry/LineString.h>
+#include <lanelet2_io/Io.h>
+#include <lanelet2_projection/UTM.h>
+#include <yaml-cpp/yaml.h>
+
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <string>
+
+namespace autoware::map_projection_loader
+{
+autoware_map_msgs::msg::MapProjectorInfo load_info_from_yaml(const std::string & filename)
+{
+  YAML::Node data = YAML::LoadFile(filename);
+
+  autoware_map_msgs::msg::MapProjectorInfo msg;
+  msg.projector_type = data["projector_type"].as<std::string>();
+  if (msg.projector_type == autoware_map_msgs::msg::MapProjectorInfo::MGRS) {
+    msg.vertical_datum = data["vertical_datum"].as<std::string>();
+    msg.mgrs_grid = data["mgrs_grid"].as<std::string>();
+
+  } else if (
+    msg.projector_type == autoware_map_msgs::msg::MapProjectorInfo::LOCAL_CARTESIAN_UTM ||
+    msg.projector_type == autoware_map_msgs::msg::MapProjectorInfo::LOCAL_CARTESIAN ||
+    msg.projector_type == autoware_map_msgs::msg::MapProjectorInfo::TRANSVERSE_MERCATOR) {
+    msg.vertical_datum = data["vertical_datum"].as<std::string>();
+    msg.map_origin.latitude = data["map_origin"]["latitude"].as<double>();
+    msg.map_origin.longitude = data["map_origin"]["longitude"].as<double>();
+    msg.map_origin.altitude = 0.0;
+
+  } else if (msg.projector_type == autoware_map_msgs::msg::MapProjectorInfo::LOCAL) {
+    ;  // do nothing
+
+  } else if (msg.projector_type == "local") {
+    RCLCPP_WARN_STREAM(
+      rclcpp::get_logger("MapProjectionLoader"),
+      "Load " << filename << "\n"
+              << "DEPRECATED WARNING: projector type \"local\" is deprecated."
+                 "Please use \"Local\" instead. For more info, visit "
+                 "https://github.com/autowarefoundation/autoware.universe/blob/main/map/"
+                 "map_projection_loader README.md");
+    msg.projector_type = autoware_map_msgs::msg::MapProjectorInfo::LOCAL;
+  } else {
+    throw std::runtime_error(
+      "Invalid map projector type. Currently supported types: MGRS, LocalCartesian, "
+      "LocalCartesianUTM, "
+      "TransverseMercator, and local");
+  }
+
+  // set scale factor
+  static constexpr float scale_factor_for_utm = 0.9996;
+  static constexpr float scale_factor_for_local = 1.0;
+  if (msg.projector_type == autoware_map_msgs::msg::MapProjectorInfo::TRANSVERSE_MERCATOR) {
+    if (data["scale_factor"]) {
+      msg.scale_factor = data["scale_factor"].as<float>();
+    } else {
+      msg.scale_factor = scale_factor_for_utm;
+    }
+  } else if (
+    msg.projector_type == autoware_map_msgs::msg::MapProjectorInfo::MGRS ||
+    msg.projector_type == autoware_map_msgs::msg::MapProjectorInfo::LOCAL_CARTESIAN_UTM) {
+    msg.scale_factor = scale_factor_for_utm;
+  } else if (
+    msg.projector_type == autoware_map_msgs::msg::MapProjectorInfo::LOCAL ||
+    msg.projector_type == autoware_map_msgs::msg::MapProjectorInfo::LOCAL_CARTESIAN) {
+    msg.scale_factor = scale_factor_for_local;
+  }
+
+  if (msg.scale_factor <= 0.0) {
+    throw std::runtime_error(
+      "Invalid scale factor. The scale factor must be a value greater than 0.");
+  }
+  return msg;
+}
+
+autoware_map_msgs::msg::MapProjectorInfo load_map_projector_info(
+  const std::string & yaml_filename, const std::string & lanelet2_map_filename)
+{
+  autoware_map_msgs::msg::MapProjectorInfo msg;
+
+  if (std::filesystem::exists(yaml_filename)) {
+    std::cout << "Load " << yaml_filename << std::endl;
+    msg = load_info_from_yaml(yaml_filename);
+  } else if (std::filesystem::exists(lanelet2_map_filename)) {
+    std::cout << "Load " << lanelet2_map_filename << std::endl;
+    std::cout
+      << "DEPRECATED WARNING: Loading map projection info from lanelet2 map may soon be deleted. "
+         "Please use map_projector_info.yaml instead. For more info, visit "
+         "https://github.com/autowarefoundation/autoware.universe/blob/main/map/"
+         "map_projection_loader/"
+         "README.md"
+      << std::endl;
+    msg = load_info_from_lanelet2_map(lanelet2_map_filename);
+  } else {
+    throw std::runtime_error(
+      "No map projector info files found. Please provide either "
+      "map_projector_info.yaml or lanelet2_map.osm");
+  }
+  return msg;
+}
+
+autoware_map_msgs::msg::MapProjectorInfo load_info_from_lanelet2_map(const std::string & filename)
+{
+  lanelet::ErrorMessages errors{};
+  lanelet::projection::MGRSProjector projector{};
+  const lanelet::LaneletMapPtr map = lanelet::load(filename, projector, &errors);
+  if (!errors.empty()) {
+    std::stringstream ss;
+    ss << "Error occurred while loading lanelet2 map:\n";
+    for (const auto & err : errors) {
+      ss << "- " << err << "\n";
+    }
+    throw std::runtime_error(ss.str());
+  }
+
+  // If the lat & lon values in all the points of lanelet2 map are all zeros,
+  // it will be interpreted as a local map.
+  // If any single point exists with non-zero lat or lon values, it will be interpreted as MGRS.
+  bool is_local = true;
+  for (const auto & point : map->pointLayer) {
+    const auto gps_point = projector.reverse(point);
+    if (gps_point.lat != 0.0 || gps_point.lon != 0.0) {
+      is_local = false;
+      break;
+    }
+  }
+
+  autoware_map_msgs::msg::MapProjectorInfo msg;
+  if (is_local) {
+    msg.projector_type = autoware_map_msgs::msg::MapProjectorInfo::LOCAL;
+  } else {
+    msg.projector_type = autoware_map_msgs::msg::MapProjectorInfo::MGRS;
+    msg.mgrs_grid = projector.getProjectedMGRSGrid();
+  }
+
+  // We assume that the vertical datum of the map is WGS84 when using lanelet2 map.
+  // However, do note that this is not always true, and may cause problems in the future.
+  // Thus, please consider using the map_projector_info.yaml instead of this deprecated function.
+  msg.vertical_datum = autoware_map_msgs::msg::MapProjectorInfo::WGS84;
+  return msg;
+}
+}  // namespace autoware::map_projection_loader
+
+namespace autoware::map_loader::plugin
+{
+
+class MapProjectionLoaderPlugin : public MapLoaderPluginBase
+{
+public:
+  void initialize(
+    const std::string & /*name*/, rclcpp::Node * node, MapLoaderData & /*data*/) override
+  {
+    using autoware_utils_rclcpp::get_or_declare_parameter;
+    const std::string yaml_filename =
+      get_or_declare_parameter<std::string>(*node, "map_projector_info_path");
+    const std::string lanelet2_map_filename =
+      get_or_declare_parameter<std::string>(*node, "lanelet2_map_path");
+
+    projector_info_ = autoware::map_projection_loader::load_map_projector_info(
+      yaml_filename, lanelet2_map_filename);
+
+    using MapProjectorInfo = autoware::component_interface_specs::map::MapProjectorInfo;
+    publisher_ = node->create_publisher<MapProjectorInfo::Message>(
+      MapProjectorInfo::name, autoware::component_interface_specs::get_qos<MapProjectorInfo>());
+  }
+
+  void on_startup(MapLoaderData & data) override
+  {
+    publisher_->publish(projector_info_);
+    data.projector_info = projector_info_;
+    RCLCPP_INFO(
+      get_node_ptr()->get_logger(), "Published map projector info (type: %s)",
+      projector_info_.projector_type.c_str());
+  }
+
+private:
+  autoware_map_msgs::msg::MapProjectorInfo projector_info_;
+  rclcpp::Publisher<autoware_map_msgs::msg::MapProjectorInfo>::SharedPtr publisher_;
+};
+
+}  // namespace autoware::map_loader::plugin
+
+PLUGINLIB_EXPORT_CLASS(
+  autoware::map_loader::plugin::MapProjectionLoaderPlugin,
+  autoware::map_loader::plugin::MapLoaderPluginBase)

--- a/map/autoware_map_host/src/map_loader_host/plugins/pointcloud_map_loader_plugin.cpp
+++ b/map/autoware_map_host/src/map_loader_host/plugins/pointcloud_map_loader_plugin.cpp
@@ -1,0 +1,166 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/map_loader/map_loader_plugin_base.hpp"
+#include "differential_map_loader_module.hpp"
+#include "partial_map_loader_module.hpp"
+#include "pointcloud_map_loader_module.hpp"
+#include "selected_map_loader_module.hpp"
+#include "utils.hpp"
+
+#include <autoware_utils/ros/parameter.hpp>
+#include <pluginlib/class_list_macros.hpp>
+
+#include <pcl/io/pcd_io.h>
+#include <pcl/point_cloud.h>
+#include <pcl/point_types.h>
+
+#include <filesystem>
+#include <map>
+#include <memory>
+#include <set>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace autoware::map_loader::plugin
+{
+namespace fs = std::filesystem;
+
+class PointCloudMapLoaderPlugin : public MapLoaderPluginBase
+{
+public:
+  void initialize(
+    const std::string & /*name*/, rclcpp::Node * node, MapLoaderData & /*data*/) override
+  {
+    node_ = node;
+    using autoware_utils_rclcpp::get_or_declare_parameter;
+    const auto pcd_paths = get_pcd_paths(
+      get_or_declare_parameter<std::vector<std::string>>(*node, "pcd_paths_or_directory"));
+    const std::string pcd_metadata_path =
+      get_or_declare_parameter<std::string>(*node, "pcd_metadata_path");
+    const bool enable_whole_load = get_or_declare_parameter<bool>(*node, "enable_whole_load");
+    const bool enable_downsample_whole_load =
+      get_or_declare_parameter<bool>(*node, "enable_downsampled_whole_load");
+    const bool enable_partial_load = get_or_declare_parameter<bool>(*node, "enable_partial_load");
+    const bool enable_selected_load = get_or_declare_parameter<bool>(*node, "enable_selected_load");
+
+    if (enable_whole_load) {
+      pcd_map_loader_ =
+        std::make_unique<PointcloudMapLoaderModule>(node, pcd_paths, "pointcloud_map", false);
+    }
+
+    if (enable_downsample_whole_load) {
+      downsampled_pcd_map_loader_ = std::make_unique<PointcloudMapLoaderModule>(
+        node, pcd_paths, "debug/downsampled_pointcloud_map", true);
+    }
+
+    const auto pcd_metadata_dict = get_pcd_metadata(pcd_metadata_path, pcd_paths);
+
+    if (enable_partial_load) {
+      partial_map_loader_ = std::make_unique<PartialMapLoaderModule>(node, pcd_metadata_dict);
+    }
+
+    differential_map_loader_ =
+      std::make_unique<DifferentialMapLoaderModule>(node, pcd_metadata_dict);
+
+    if (enable_selected_load) {
+      selected_map_loader_ = std::make_unique<SelectedMapLoaderModule>(node, pcd_metadata_dict);
+    }
+  }
+
+  void on_startup(MapLoaderData & /*data*/) override
+  {
+    RCLCPP_INFO(node_->get_logger(), "Pointcloud map loader plugin initialized.");
+  }
+
+private:
+  rclcpp::Node * node_{nullptr};
+  std::unique_ptr<PointcloudMapLoaderModule> pcd_map_loader_;
+  std::unique_ptr<PointcloudMapLoaderModule> downsampled_pcd_map_loader_;
+  std::unique_ptr<PartialMapLoaderModule> partial_map_loader_;
+  std::unique_ptr<DifferentialMapLoaderModule> differential_map_loader_;
+  std::unique_ptr<SelectedMapLoaderModule> selected_map_loader_;
+
+  static bool is_pcd_file(const std::string & p)
+  {
+    if (fs::is_directory(p)) {
+      return false;
+    }
+    const std::string ext = fs::path(p).extension();
+    return ext == ".pcd" || ext == ".PCD";
+  }
+
+  static std::vector<std::string> get_pcd_paths(
+    const std::vector<std::string> & pcd_paths_or_directory)
+  {
+    std::vector<std::string> pcd_paths;
+    for (const auto & p : pcd_paths_or_directory) {
+      if (!fs::exists(p)) {
+        RCLCPP_ERROR(rclcpp::get_logger("map_loader"), "invalid path: %s", p.c_str());
+      }
+      if (is_pcd_file(p)) {
+        pcd_paths.push_back(p);
+      }
+      if (fs::is_directory(p)) {
+        for (const auto & file : fs::directory_iterator(p)) {
+          const auto filename = file.path().string();
+          if (is_pcd_file(filename)) {
+            pcd_paths.push_back(filename);
+          }
+        }
+      }
+    }
+    return pcd_paths;
+  }
+
+  static std::map<std::string, PCDFileMetadata> get_pcd_metadata(
+    const std::string & pcd_metadata_path, const std::vector<std::string> & pcd_paths)
+  {
+    if (fs::exists(pcd_metadata_path)) {
+      std::set<std::string> missing_pcd_names;
+      auto pcd_metadata_dict = load_pcd_metadata(pcd_metadata_path);
+      pcd_metadata_dict =
+        replace_with_absolute_path(pcd_metadata_dict, pcd_paths, missing_pcd_names);
+      if (!missing_pcd_names.empty()) {
+        std::ostringstream oss;
+        oss << "The following segment(s) are missing from the input PCDs: ";
+        for (const auto & fname : missing_pcd_names) {
+          oss << std::endl << fname;
+        }
+        RCLCPP_ERROR(rclcpp::get_logger("map_loader"), "%s", oss.str().c_str());
+        throw std::runtime_error("Missing PCD segments. Exiting map loader...");
+      }
+      return pcd_metadata_dict;
+    }
+
+    if (pcd_paths.size() == 1) {
+      pcl::PointCloud<pcl::PointXYZ> single_pcd;
+      const auto & pcd_path = pcd_paths.front();
+      if (pcl::io::loadPCDFile(pcd_path, single_pcd) == -1) {
+        throw std::runtime_error("PCD load failed: " + pcd_path);
+      }
+      PCDFileMetadata metadata = {};
+      pcl::getMinMax3D(single_pcd, metadata.min, metadata.max);
+      return std::map<std::string, PCDFileMetadata>{{pcd_path, metadata}};
+    }
+    throw std::runtime_error("PCD metadata file not found: " + pcd_metadata_path);
+  }
+};
+
+}  // namespace autoware::map_loader::plugin
+
+PLUGINLIB_EXPORT_CLASS(
+  autoware::map_loader::plugin::PointCloudMapLoaderPlugin,
+  autoware::map_loader::plugin::MapLoaderPluginBase)

--- a/map/autoware_map_host/src/map_loader_host/plugins/vector_map_tf_generator_plugin.cpp
+++ b/map/autoware_map_host/src/map_loader_host/plugins/vector_map_tf_generator_plugin.cpp
@@ -1,0 +1,71 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/map_loader/plugins/vector_map_tf_generator_plugin.hpp"
+
+#include "autoware/map_loader/map_loader_plugin_base.hpp"
+
+#include <autoware_utils/ros/parameter.hpp>
+#include <pluginlib/class_list_macros.hpp>
+
+#include <tf2_ros/static_transform_broadcaster.h>
+
+#include <memory>
+#include <string>
+
+namespace autoware::map_loader::plugin
+{
+
+class VectorMapTfGeneratorPlugin : public MapLoaderPluginBase
+{
+public:
+  void initialize(
+    const std::string & /*name*/, rclcpp::Node * node, MapLoaderData & /*data*/) override
+  {
+    node_ = node;
+    using autoware_utils_rclcpp::get_or_declare_parameter;
+    map_frame_ = get_or_declare_parameter<std::string>(*node, "map_frame");
+    viewer_frame_ = get_or_declare_parameter<std::string>(*node, "viewer_frame");
+    static_broadcaster_ = std::make_shared<tf2_ros::StaticTransformBroadcaster>(node);
+  }
+
+  void on_startup(MapLoaderData & data) override
+  {
+    if (!data.vector_map_msg.has_value()) {
+      RCLCPP_WARN(
+        get_node_ptr()->get_logger(), "Vector map is not loaded; skipping TF generation.");
+      return;
+    }
+
+    const auto transform = autoware::map_tf_generator::create_viewer_transform(
+      data.vector_map_msg.value(), map_frame_, viewer_frame_, node_->now());
+    static_broadcaster_->sendTransform(transform);
+
+    RCLCPP_INFO_STREAM(
+      get_node_ptr()->get_logger(),
+      "Broadcast static tf. map_frame:" << map_frame_ << ", viewer_frame:" << viewer_frame_);
+  }
+
+private:
+  rclcpp::Node * node_{nullptr};
+  std::string map_frame_;
+  std::string viewer_frame_;
+  std::shared_ptr<tf2_ros::StaticTransformBroadcaster> static_broadcaster_;
+};
+
+}  // namespace autoware::map_loader::plugin
+
+PLUGINLIB_EXPORT_CLASS(
+  autoware::map_loader::plugin::VectorMapTfGeneratorPlugin,
+  autoware::map_loader::plugin::MapLoaderPluginBase)


### PR DESCRIPTION
## Description

https://github.com/autowarefoundation/autoware_core/pull/1163

Merge all the map loading function into one ros node.

- Based on the [launch file](https://github.com/autowarefoundation/autoware_launch/blob/main/tier4_universe_launch/tier4_map_launch/launch/map.launch.xml), we are launching **six** nodes to launch lanelet2 map, pointcloud map, output visualization, projection, hash, tf trees.
- All these nodes are only reading map once, then output consistent topics after initialization.
   - The pointcloud map loader provides services
- For reducing the number of nodes to reduce pressure on ROS2 DDS, here is a suggestion to simply launch one node, and use plugins to manage the parameters and different features

How the current node constructed:

- **For lanelet2 map loader and pointcloud_map_loader, I synced hpp files and re-use the library in the autoware_map_loader package**.
- For lanelet2 visualization / map_projection_loader / vector_map+tf_generator, I organize these external existing codes into hpp/cpp libraries in this the map_loader_host code base, and keep single ROS node .
- Implemented a C++ version of the python MapHashGenerator

How it affect system performance:
- Firstly, there is no changes  to existing codes, so it is a purely incremental feature implementation. As long as we do not actively launch the map_loader_host node, nothing will change.
- Secondly, I provided a "map_loader.launch.xml", which will just perform everything well similar to the entire map launch file by taking all existing parameters and launch the map_loader_host node.
    - I tested locally the build and also the result that we will only have one ROS2 node now.
    - No clear topic name changes.
- Thirdly, the current implementation (for the starting phase of this PR), I do not try to separate the parameters in namespace (we should do that) and use the original configurations to keep the consistency with existing launch files.

## Related links

**Parent Issue:**

- https://github.com/autowarefoundation/autoware_core/pull/1163
- The core PR failed because of the dependencies on the tier4_external_api_msgs from rewriting map hash generator

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
