### PR TITLE
feat(autoware_tensorrt_common): enable tensor io type setting

### DIFF
--- a/perception/autoware_tensorrt_common/include/autoware/tensorrt_common/utils.hpp
+++ b/perception/autoware_tensorrt_common/include/autoware/tensorrt_common/utils.hpp
@@ -220,7 +220,6 @@ struct NetworkIO : public TensorInfo
    * @param[in] name Tensor name.
    * @param[in] tensor_dims Tensor dimensions.
    * @param[in] data_type If set, TRT is required to produce this dtype for the tensor.
-   *            Only meaningful for output tensors. Requires kOBEY_PRECISION_CONSTRAINTS.
    */
   NetworkIO(
     std::string name, const nvinfer1::Dims & tensor_dims,

--- a/perception/autoware_tensorrt_common/include/autoware/tensorrt_common/utils.hpp
+++ b/perception/autoware_tensorrt_common/include/autoware/tensorrt_common/utils.hpp
@@ -30,6 +30,7 @@ namespace fs = ::std::experimental::filesystem;
 #include <array>
 #include <cstdint>
 #include <iostream>
+#include <optional>
 #include <sstream>
 #include <string>
 #include <string_view>
@@ -40,6 +41,36 @@ namespace autoware
 namespace tensorrt_common
 {
 constexpr std::array<std::string_view, 3> valid_precisions = {"fp32", "fp16", "int8"};
+
+/**
+ * @brief Return a human-readable name for a TensorRT DataType.
+ *
+ * @param dt TensorRT data type.
+ * @return String literal describing the type.
+ */
+inline const char * dtype_name(nvinfer1::DataType dt)
+{
+  switch (dt) {
+    case nvinfer1::DataType::kFLOAT:
+      return "float32";
+    case nvinfer1::DataType::kHALF:
+      return "float16";
+    case nvinfer1::DataType::kINT8:
+      return "int8";
+    case nvinfer1::DataType::kINT32:
+      return "int32";
+    case nvinfer1::DataType::kBOOL:
+      return "bool";
+    case nvinfer1::DataType::kUINT8:
+      return "uint8";
+    case nvinfer1::DataType::kBF16:
+      return "bfloat16";
+    case nvinfer1::DataType::kINT64:
+      return "int64";
+    default:
+      return "unknown";
+  }
+}
 
 /**
  * @struct TrtCommonConfig
@@ -188,9 +219,13 @@ struct NetworkIO : public TensorInfo
    *
    * @param[in] name Tensor name.
    * @param[in] tensor_dims Tensor dimensions.
+   * @param[in] data_type If set, TRT is required to produce this dtype for the tensor.
+   *            Only meaningful for output tensors. Requires kOBEY_PRECISION_CONSTRAINTS.
    */
-  NetworkIO(std::string name, const nvinfer1::Dims & tensor_dims)
-  : TensorInfo(std::move(name)), dims(tensor_dims)
+  NetworkIO(
+    std::string name, const nvinfer1::Dims & tensor_dims,
+    std::optional<nvinfer1::DataType> data_type = std::nullopt)
+  : TensorInfo(std::move(name)), dims(tensor_dims), dtype(data_type)
   {
   }
 
@@ -214,6 +249,9 @@ struct NetworkIO : public TensorInfo
   {
     std::stringstream ss;
     ss << tensor_name << " {" << TensorInfo::dimsRepr(dims) << "}";
+    if (dtype) {
+      ss << " dtype=" << dtype_name(*dtype);
+    }
     return ss.str();
   }
 
@@ -252,6 +290,9 @@ struct NetworkIO : public TensorInfo
 
   //!< @brief Tensor dimensions.
   nvinfer1::Dims dims;
+
+  //!< @brief If set, forces TRT to use this dtype for the tensor (inputs and outputs).
+  std::optional<nvinfer1::DataType> dtype;
 };
 
 /**

--- a/perception/autoware_tensorrt_common/src/tensorrt_common.cpp
+++ b/perception/autoware_tensorrt_common/src/tensorrt_common.cpp
@@ -109,6 +109,27 @@ bool TrtCommon::setup(ProfileDimsPtr profile_dims, NetworkIOPtr network_io)
     builder_config_->addOptimizationProfile(profile);
   }
 
+  // Apply dtype overrides from NetworkIO to the parsed network inputs and outputs.
+  if (network_io_) {
+    const auto apply_dtype = [&](nvinfer1::ITensor * tensor, const char * io_type) {
+      if (!tensor) return;
+      const auto it = std::find_if(network_io_->begin(), network_io_->end(), [&](const auto & io) {
+        return io.tensor_name == tensor->getName() && io.dtype.has_value();
+      });
+      if (it == network_io_->end()) return;
+      tensor->setType(*it->dtype);
+      logger_->log(
+        nvinfer1::ILogger::Severity::kINFO, "Setting %s tensor '%s' to dtype %s", io_type,
+        tensor->getName(), dtype_name(*it->dtype));
+    };
+    for (int i = 0; i < network_->getNbInputs(); ++i) {
+      apply_dtype(network_->getInput(i), "input");
+    }
+    for (int i = 0; i < network_->getNbOutputs(); ++i) {
+      apply_dtype(network_->getOutput(i), "output");
+    }
+  }
+
   auto build_engine_with_log = [this]() -> bool {
     logger_->log(nvinfer1::ILogger::Severity::kINFO, "Starting to build engine");
     auto log_thread = logger_->log_throttle(
@@ -526,34 +547,6 @@ bool TrtCommon::initialize()
 
   if (trt_config_->profile_per_layer) {
     builder_config_->setProfilingVerbosity(nvinfer1::ProfilingVerbosity::kDETAILED);
-  }
-
-  // Apply dtype overrides from NetworkIO to the parsed network inputs and outputs
-  if (network_io_) {
-    const auto apply_dtype = [&](nvinfer1::ITensor * tensor, const char * io_type) {
-      if (!tensor) return;
-
-      const auto it = std::find_if(network_io_->begin(), network_io_->end(), [&](const auto & io) {
-        return io.tensor_name == tensor->getName() && io.dtype.has_value();
-      });
-
-      if (it != network_io_->end()) {
-        tensor->setType(*it->dtype);
-        logger_->log(
-          nvinfer1::ILogger::Severity::kINFO, "Setting %s tensor '%s' to dtype %s", io_type,
-          tensor->getName(), dtype_name(*it->dtype));
-      }
-    };
-
-    // Configure network inputs
-    for (int i = 0; i < network_->getNbInputs(); ++i) {
-      apply_dtype(network_->getInput(i), "input");
-    }
-
-    // Configure network outputs
-    for (int i = 0; i < network_->getNbOutputs(); ++i) {
-      apply_dtype(network_->getOutput(i), "output");
-    }
   }
 
   return true;

--- a/perception/autoware_tensorrt_common/src/tensorrt_common.cpp
+++ b/perception/autoware_tensorrt_common/src/tensorrt_common.cpp
@@ -22,6 +22,7 @@
 #include <NvInferRuntime.h>
 #include <dlfcn.h>
 
+#include <algorithm>
 #include <cmath>
 #include <fstream>
 #include <iostream>
@@ -527,6 +528,34 @@ bool TrtCommon::initialize()
     builder_config_->setProfilingVerbosity(nvinfer1::ProfilingVerbosity::kDETAILED);
   }
 
+  // Apply dtype overrides from NetworkIO to the parsed network inputs and outputs
+  if (network_io_) {
+    const auto apply_dtype = [&](nvinfer1::ITensor * tensor, const char * io_type) {
+      if (!tensor) return;
+
+      const auto it = std::find_if(network_io_->begin(), network_io_->end(), [&](const auto & io) {
+        return io.tensor_name == tensor->getName() && io.dtype.has_value();
+      });
+
+      if (it != network_io_->end()) {
+        tensor->setType(*it->dtype);
+        logger_->log(
+          nvinfer1::ILogger::Severity::kINFO, "Setting %s tensor '%s' to dtype %s", io_type,
+          tensor->getName(), dtype_name(*it->dtype));
+      }
+    };
+
+    // Configure network inputs
+    for (int i = 0; i < network_->getNbInputs(); ++i) {
+      apply_dtype(network_->getInput(i), "input");
+    }
+
+    // Configure network outputs
+    for (int i = 0; i < network_->getNbOutputs(); ++i) {
+      apply_dtype(network_->getOutput(i), "output");
+    }
+  }
+
   return true;
 }
 
@@ -701,6 +730,17 @@ bool TrtCommon::validateNetworkIO()
         "Invalid tensor. Current configuration: %s. Cached engine: %s", io.toString().c_str(),
         tensor_from_engine.toString().c_str());
       success = false;
+    }
+    if (io.dtype) {
+      const auto actual_dtype = getTensorDataType(io.tensor_name.c_str());
+      if (!actual_dtype || *actual_dtype != *io.dtype) {
+        logger_->log(
+          nvinfer1::ILogger::Severity::kERROR,
+          "Tensor '%s' dtype mismatch. Current configuration: %s. Cached engine: %s",
+          io.tensor_name.c_str(), dtype_name(*io.dtype),
+          actual_dtype ? dtype_name(*actual_dtype) : "unknown");
+        success = false;
+      }
     }
   }
 


### PR DESCRIPTION
## Description

Extends `NetworkIO` with an optional `data_type` field that, when set, instructs TensorRT to produce that exact dtype for the tensor regardless of the network's global precision mode (see [setType()](https://docs.nvidia.com/deeplearning/tensorrt/10.x.x/_static/c-api/classnvinfer1_1_1_i_tensor.html#a7e994c66880bac60a8b469272eb938c3)). When not set, TensorRT decides about the type during optimization. Strongly typed networks are prefered, but it would need bigger refactor.

`autoware_ptv3` runs with `trt_precision: fp16` but its postprocessing kernels read backbone and segmentation head outputs as `float*`. Without this change TensorRT can choose fp16 for engine boundary tensors, causing the kernels to misread prediction buffers silently. `data_type` lets the caller pin those tensors to `kFLOAT` at engine-build time.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
