### PR TITLE
fix(autoware_mpc_lateral_controller): disable Eigen OpenMP parallelism to prevent callback starvation

### DIFF
--- a/control/autoware_mpc_lateral_controller/CMakeLists.txt
+++ b/control/autoware_mpc_lateral_controller/CMakeLists.txt
@@ -4,6 +4,8 @@ project(autoware_mpc_lateral_controller)
 find_package(autoware_cmake REQUIRED)
 autoware_package()
 
+add_compile_options(-DEIGEN_DONT_PARALLELIZE)
+
 find_package(fmt REQUIRED)
 
 set(MPC_LAT_CON_LIB ${PROJECT_NAME}_lib)

--- a/control/autoware_mpc_lateral_controller/CMakeLists.txt
+++ b/control/autoware_mpc_lateral_controller/CMakeLists.txt
@@ -4,6 +4,7 @@ project(autoware_mpc_lateral_controller)
 find_package(autoware_cmake REQUIRED)
 autoware_package()
 
+# cspell:ignore DEIGEN DONT
 add_compile_options(-DEIGEN_DONT_PARALLELIZE)
 
 find_package(fmt REQUIRED)


### PR DESCRIPTION
## Description

PCL 1.14 used in Jazzy propagates `-fopenmp` to all downstream packages via its FindOpenMP.cmake ([PR](https://github.com/PointCloudLibrary/pcl/pull/5744)). This causes Eigen to parallelize matrix multiplications using OpenMP worker threads. After each parallel region, those threads spin-wait consuming CPU, which starves other threads sharing the same process.

This was observed in `autoware_mpc_lateral_controller`: the 30ms timer callback processing time increased from ~2ms (PCL 1.12) to ~50ms (PCL 1.14) due to OpenMP worker threads competing for CPU cores.

This PR sets `EIGEN_DONT_PARALLELIZE` to restore the same behavior as Humble, where PCL 1.12 did not propagate -fopenmp and Eigen's internal OpenMP parallelism was disabled.

## Related links

**Parent Issue:**

- Link

**Private Links:**

- [TIER IV internal link](https://star4.slack.com/archives/CRUE57C30/p1780882292292139?thread_ts=1779929948.087319&cid=CRUE57C30)
- [TIER IV internal link](https://star4.slack.com/archives/CRUE57C30/p1780892744546649?thread_ts=1780482942.701449&cid=CRUE57C30)

## How was this PR tested?

Verified that autoware_mpc_lateral_controller's lateral processing time returned from ~50ms to ~2ms after applying `EIGEN_DONT_PARALLELIZE`.

- `/control/trajectory_follower/controller_node_exe/lateral/debug/processing_time_ms` on Humble
  - [TIER IV internal link. Evaluator](https://evaluation.tier4.jp/evaluation/reports/fc3a0b71-92c8-5dcb-8f13-1887f23bef1a/tests/e55d7b02-0f3f-525a-8cf2-531461659b59/bc549b79-305c-5ea8-919a-7e685a7f6a77/ddf79d1e-c235-5fa7-9a9c-69eb1b497564?project_id=x2_dev)
  - <img width="1337" height="835" alt="image" src="https://github.com/user-attachments/assets/2cf48bc1-28cc-418f-ab43-f2320c36a813" />
- `/control/trajectory_follower/controller_node_exe/lateral/debug/processing_time_ms` on Jazzy
  - [TIER IV internal link. Evaluator](https://evaluation.tier4.jp/evaluation/reports/80eac846-4780-528c-bd03-01c8bdcef182/tests/5b6a8e22-cadb-538b-bb57-3f1d091d50b8/3060628e-e2f8-5d85-8f9f-5053f2809b61/2395734d-2444-5899-a42f-24370d33c95b?project_id=x2_dev)
  - <img width="1335" height="837" alt="image" src="https://github.com/user-attachments/assets/c7900ccb-2150-42a9-af5f-422fb07502f2" />
- `/control/trajectory_follower/controller_node_exe/lateral/debug/processing_time_ms` on Jazzy + this PR
  - [TIER IV internal link. Evaluator](https://evaluation.tier4.jp/evaluation/reports/48703f70-4076-51c5-ad6b-627ab3c4620a/tests/055199bc-c898-5292-90d7-566540604412/2ed1a342-0b92-55bd-97eb-ae47ebd07cc0/f608ed1d-e0d5-5ccd-b072-998705a9477f?project_id=x2_dev)
  - <img width="1307" height="831" alt="image" src="https://github.com/user-attachments/assets/03b90112-47f2-4239-a9f2-53d705d7275b" />

(Note: The spikes at the beginning and end of the graph are due to the measurement environment and can be ignored.)

## Notes for reviewers

- `DEIGEN` and `DONT` are not general words (they are artifacts of the CMake -D prefix and a CMake macro name), so added a cspell inline ignore instead of registering them in the dictionary.
- This issue is specific to PCL 1.14+, which is shipped on ROS Humble's successor distributions (Jazzy and later). PCL 1.12.x (used on Humble) does not have this problem.
  - The propagation of -fopenmp downstream was introduced in PCL https://github.com/PointCloudLibrary/pcl/pull/5744 (merged 2023-06-12, included in PCL 1.14.0).

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None. 
