### PR TITLE
test(autoware_traffic_light_arbiter): add unit tests for logic

### DIFF
--- a/perception/autoware_traffic_light_arbiter/CMakeLists.txt
+++ b/perception/autoware_traffic_light_arbiter/CMakeLists.txt
@@ -24,6 +24,9 @@ if(BUILD_TESTING)
   ament_auto_add_gtest(${PROJECT_NAME}_characteristic_test
     test/test_traffic_arbiter_characteristic.cpp
   )
+  ament_auto_add_gtest(${PROJECT_NAME}_core_test
+    test/test_traffic_light_arbiter_core.cpp
+  )
 endif()
 
 autoware_ament_auto_package(INSTALL_TO_SHARE launch config)

--- a/perception/autoware_traffic_light_arbiter/test/test_traffic_light_arbiter_core.cpp
+++ b/perception/autoware_traffic_light_arbiter/test/test_traffic_light_arbiter_core.cpp
@@ -1,0 +1,1305 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/traffic_light_arbiter/traffic_light_arbiter_core.hpp"
+
+#include <autoware_lanelet2_extension/utility/query.hpp>
+#include <rclcpp/duration.hpp>
+#include <rclcpp/time.hpp>
+
+#include <autoware_perception_msgs/msg/traffic_light_group_array.hpp>
+
+#include <gtest/gtest.h>
+#include <lanelet2_core/Attribute.h>
+#include <lanelet2_core/LaneletMap.h>
+#include <lanelet2_core/primitives/BasicRegulatoryElements.h>
+#include <lanelet2_core/primitives/Lanelet.h>
+#include <lanelet2_core/primitives/LineString.h>
+#include <lanelet2_core/primitives/LineStringOrPolygon.h>
+#include <lanelet2_core/primitives/Point.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace
+{
+
+using autoware::traffic_light::SourcePriority;
+using autoware::traffic_light::TrafficLightArbiterCore;
+using PredictedTrafficLightState = autoware_perception_msgs::msg::PredictedTrafficLightState;
+using TrafficLightElement = autoware_perception_msgs::msg::TrafficLightElement;
+using TrafficLightGroup = autoware_perception_msgs::msg::TrafficLightGroup;
+using TrafficLightGroupArray = autoware_perception_msgs::msg::TrafficLightGroupArray;
+
+// --- Map construction --------------------------------------------------
+
+lanelet::Point3d make_point(lanelet::Id id, double x, double y, double z = 0.0)
+{
+  return lanelet::Point3d(id, x, y, z);
+}
+
+lanelet::Lanelet make_lanelet(double y_left, double y_right, const std::string & subtype)
+{
+  using namespace lanelet;  // NOLINT(build/namespaces)
+  LineString3d left(
+    utils::getId(),
+    {make_point(utils::getId(), 0.0, y_left), make_point(utils::getId(), 10.0, y_left)});
+  LineString3d right(
+    utils::getId(),
+    {make_point(utils::getId(), 0.0, y_right), make_point(utils::getId(), 10.0, y_right)});
+  Lanelet ll(utils::getId(), left, right);
+  ll.attributes()[AttributeName::Subtype] = subtype;
+  ll.attributes()[AttributeName::Type] = AttributeValueString::Lanelet;
+  return ll;
+}
+
+lanelet::LineString3d make_traffic_light_bulb()
+{
+  // Geometry does not affect arbiter logic; pick lanelet midpoint at z=5.
+  constexpr double kBulbX = 5.0;
+  constexpr double kBulbZ = 5.0;
+  using namespace lanelet;  // NOLINT(build/namespaces)
+  LineString3d bulb(
+    utils::getId(), {make_point(utils::getId(), kBulbX, 0.0, kBulbZ),
+                     make_point(utils::getId(), kBulbX, 1.0, kBulbZ)});
+  bulb.attributes()[AttributeName::Type] = AttributeValueString::TrafficLight;
+  return bulb;
+}
+
+namespace map_ids
+{
+constexpr lanelet::Id vehicle_a = 1001;
+constexpr lanelet::Id vehicle_b = 1002;
+constexpr lanelet::Id pedestrian = 2001;
+constexpr lanelet::Id off_map_probe = 9999;
+}  // namespace map_ids
+
+// Two roads + one crosswalk, each carrying a Traffic Light regulatory
+// element. The crosswalk row is what makes set_map() expose a pedestrian
+// id to the arbiter; without it the pedestrian-specific reconciliation
+// rule is unreachable.
+//
+//   Lanelet      Traffic Light id
+//   ----------   ----------------------
+//   crosswalk    2001 (pedestrian)
+//   road2        1002 (vehicle_b)
+//   road1        1001 (vehicle_a)
+//
+// Id 9999 (off_map_probe) is intentionally absent from the map so the
+// arbiter drops it as off-map.
+lanelet::LaneletMapConstPtr build_minimal_map()
+{
+  using namespace lanelet;  // NOLINT(build/namespaces)
+  Lanelet road1 = make_lanelet(0.0, -3.0, AttributeValueString::Road);
+  Lanelet road2 = make_lanelet(4.0, 1.0, AttributeValueString::Road);
+  Lanelet crosswalk = make_lanelet(8.0, 5.0, AttributeValueString::Crosswalk);
+  road1.addRegulatoryElement(
+    TrafficLight::make(map_ids::vehicle_a, {}, LineStringsOrPolygons3d{make_traffic_light_bulb()}));
+  road2.addRegulatoryElement(
+    TrafficLight::make(map_ids::vehicle_b, {}, LineStringsOrPolygons3d{make_traffic_light_bulb()}));
+  crosswalk.addRegulatoryElement(
+    TrafficLight::make(
+      map_ids::pedestrian, {}, LineStringsOrPolygons3d{make_traffic_light_bulb()}));
+  return LaneletMapConstPtr{utils::createMap(Lanelets{road1, road2, crosswalk}).release()};
+}
+
+// Empty LaneletMap (no lanelets, no regulatory elements). Exercises the
+// "map present but contains no signals" case (engaged but empty output).
+lanelet::LaneletMapConstPtr build_empty_map()
+{
+  using namespace lanelet;  // NOLINT(build/namespaces)
+  return LaneletMapConstPtr{utils::createMap(Lanelets{}).release()};
+}
+
+// --- Input builders ----------------------------------------------------
+
+TrafficLightElement make_element(uint8_t color, uint8_t shape, float confidence = 1.0f)
+{
+  TrafficLightElement element;
+  element.color = color;
+  element.shape = shape;
+  element.status = TrafficLightElement::SOLID_ON;
+  element.confidence = confidence;
+  return element;
+}
+
+TrafficLightGroup make_group(
+  lanelet::Id id, std::vector<TrafficLightElement> elements,
+  std::vector<PredictedTrafficLightState> predictions = {})
+{
+  TrafficLightGroup group;
+  group.traffic_light_group_id = id;
+  group.elements = std::move(elements);
+  group.predictions = std::move(predictions);
+  return group;
+}
+
+// Predictions ride unmodified through arbitrate(), so the body fields
+// chosen here only need to be syntactically valid.
+PredictedTrafficLightState make_prediction(
+  const rclcpp::Time & stamp,
+  const std::string & source = PredictedTrafficLightState::INFORMATION_SOURCE_INTERNAL_ESTIMATION)
+{
+  constexpr int32_t kPredictionOffsetSec = 10;
+  constexpr float kFullCertainty = 1.0f;
+  PredictedTrafficLightState prediction;
+  prediction.predicted_stamp = stamp;
+  prediction.predicted_stamp.sec += kPredictionOffsetSec;
+  prediction.simultaneous_elements.push_back(
+    make_element(TrafficLightElement::UNKNOWN, TrafficLightElement::CIRCLE, kFullCertainty));
+  prediction.reliability = kFullCertainty;
+  prediction.information_source = source;
+  return prediction;
+}
+
+TrafficLightGroupArray make_signals(
+  const rclcpp::Time & stamp, std::vector<TrafficLightGroup> groups)
+{
+  TrafficLightGroupArray signals;
+  signals.traffic_light_groups = std::move(groups);
+  signals.stamp = stamp;
+  return signals;
+}
+
+// --- Assert helpers ----------------------------------------------------
+//
+// The Core's arbitrate() returns an ArbitrationResult whose `output` may be
+// std::nullopt (e.g. when no map was supplied). Helpers take that optional
+// directly so callers don't need a separate ASSERT_TRUE guard before each
+// observation — the helpers fold the nullopt case into their return.
+
+const TrafficLightGroup * find_group(
+  const std::optional<TrafficLightGroupArray> & output, lanelet::Id id)
+{
+  if (!output) {
+    return nullptr;
+  }
+  for (const auto & group : output->traffic_light_groups) {
+    if (group.traffic_light_group_id == id) {
+      return &group;
+    }
+  }
+  return nullptr;
+}
+
+const TrafficLightElement * find_element(const TrafficLightGroup & group, uint8_t shape)
+{
+  for (const auto & element : group.elements) {
+    if (element.shape == shape) {
+      return &element;
+    }
+  }
+  return nullptr;
+}
+
+std::optional<uint8_t> observed_color(
+  const std::optional<TrafficLightGroupArray> & output, lanelet::Id id)
+{
+  const auto * group = find_group(output, id);
+  if (!group || group->elements.empty()) {
+    return std::nullopt;
+  }
+  return group->elements[0].color;
+}
+
+std::optional<float> observed_confidence(
+  const std::optional<TrafficLightGroupArray> & output, lanelet::Id id)
+{
+  const auto * group = find_group(output, id);
+  if (!group || group->elements.empty()) {
+    return std::nullopt;
+  }
+  return group->elements[0].confidence;
+}
+
+std::optional<std::size_t> observed_group_count(
+  const std::optional<TrafficLightGroupArray> & output)
+{
+  if (!output) {
+    return std::nullopt;
+  }
+  return output->traffic_light_groups.size();
+}
+
+std::optional<uint8_t> observed_color_of_shape(
+  const std::optional<TrafficLightGroupArray> & output, lanelet::Id id, uint8_t shape)
+{
+  const auto * group = find_group(output, id);
+  if (!group) {
+    return std::nullopt;
+  }
+  const auto * element = find_element(*group, shape);
+  if (!element) {
+    return std::nullopt;
+  }
+  return element->color;
+}
+
+std::optional<std::string> observed_prediction_source(
+  const std::optional<TrafficLightGroupArray> & output, lanelet::Id id, std::size_t index)
+{
+  const auto * group = find_group(output, id);
+  if (!group || index >= group->predictions.size()) {
+    return std::nullopt;
+  }
+  return group->predictions[index].information_source;
+}
+
+// --- Base fixture ------------------------------------------------------
+
+// Mirror config/traffic_light_arbiter.param.yaml defaults so the numeric
+// envelope these tests assume matches the production parameter set.
+// Hoisted out of CoreFixtureBase so free TEST() blocks can reach the same
+// defaults without subclassing the fixture.
+constexpr double kDefaultExternalDelayTolerance = 5.0;
+constexpr double kDefaultExternalTimeTolerance = 5.0;
+constexpr double kDefaultPerceptionTimeTolerance = 1.0;
+
+// Arbitrary positive seconds used as the suite-wide base time. Far enough
+// from zero that any base_time - duration derived in a test stays positive
+// (largest backward offset is kDefaultExternalDelayTolerance + a few seconds).
+constexpr int32_t kBaseTimeSeconds = 1'000'000'000;
+
+// Builds the suite-wide base time. Used both as the fixture member
+// base_time_ and as the local base_time inside free TEST() blocks; the
+// member-vs-local distinction stays in the call-site variable name (the
+// trailing underscore on member fields).
+rclcpp::Time make_base_time()
+{
+  return rclcpp::Time{kBaseTimeSeconds, 0, RCL_ROS_TIME};
+}
+
+class CoreFixtureBase : public ::testing::Test
+{
+protected:
+  // Reserve off_map_probe so utils::getId() (used by map builders) never
+  // hands out an id that collides with it. Process-global state; one
+  // registration per suite is enough.
+  static void SetUpTestSuite()
+  {
+    lanelet::utils::registerId(map_ids::off_map_probe);
+    shared_map_ = build_minimal_map();
+  }
+
+  // Fixed clock: avoids std::chrono and keeps tests deterministic. Tests
+  // derive other stamps from base_time_ using rclcpp::Duration.
+  rclcpp::Time base_time_{make_base_time()};
+
+  inline static lanelet::LaneletMapConstPtr shared_map_;
+};
+
+// ---------------------------------------------------------------------------
+// Mode A: Signal Matching (enable_signal_matching=true)
+//
+// In Signal Matching mode the arbiter reconciles perception and external
+// signals: agreement passes through, disagreement falls back to UNKNOWN.
+// These tests pin the non-pedestrian behaviour; pedestrian ids follow a
+// different rule (see TrafficLightArbiterCorePedestrianTest).
+// ---------------------------------------------------------------------------
+
+class TrafficLightArbiterCoreSignalMatchingTest : public CoreFixtureBase
+{
+protected:
+  TrafficLightArbiterCoreSignalMatchingTest()
+  : arbiter_(
+      SourcePriority::CONFIDENCE, /*enable_signal_matching=*/true, kDefaultExternalDelayTolerance,
+      kDefaultExternalTimeTolerance, kDefaultPerceptionTimeTolerance)
+  {
+    arbiter_.set_map(shared_map_);
+  }
+
+  TrafficLightArbiterCore arbiter_;
+};
+
+// Matched: when perception and external agree on color and shape, the
+// output carries the same element verbatim.
+TEST_F(TrafficLightArbiterCoreSignalMatchingTest, matchedSignalsPassThrough)
+{
+  arbiter_.ingest_external(
+    make_signals(
+      base_time_, {make_group(
+                    map_ids::vehicle_a,
+                    {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)})}),
+    base_time_);
+  arbiter_.ingest_perception(make_signals(
+    base_time_,
+    {make_group(
+      map_ids::vehicle_a, {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)})}));
+
+  const auto result = arbiter_.arbitrate();
+
+  EXPECT_EQ(observed_color(result.output, map_ids::vehicle_a), TrafficLightElement::RED);
+}
+
+// Agreement is decided by color/shape only — confidence does not factor
+// in. On a match the perception side flows through, so its confidence
+// (0.90) rather than external's (0.10) reaches the output. Seeing 0.90
+// (and not 0.10) on a same-color/shape pair is what proves the differing
+// confidences did not break the match.
+TEST_F(TrafficLightArbiterCoreSignalMatchingTest, differingConfidencesStillMatch)
+{
+  arbiter_.ingest_external(
+    make_signals(
+      base_time_, {make_group(
+                    map_ids::vehicle_a,
+                    {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.10f)})}),
+    base_time_);
+  arbiter_.ingest_perception(make_signals(
+    base_time_, {make_group(
+                  map_ids::vehicle_a,
+                  {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.90f)})}));
+
+  const auto result = arbiter_.arbitrate();
+
+  EXPECT_EQ(observed_color(result.output, map_ids::vehicle_a), TrafficLightElement::RED);
+  EXPECT_NEAR(observed_confidence(result.output, map_ids::vehicle_a).value_or(-1.0f), 0.90f, 1e-5f);
+}
+
+// Color mismatch: when both sides share the shape but disagree on color,
+// the output falls back to UNKNOWN over that shape.
+TEST_F(TrafficLightArbiterCoreSignalMatchingTest, colorMismatchProducesUnknown)
+{
+  arbiter_.ingest_external(
+    make_signals(
+      base_time_, {make_group(
+                    map_ids::vehicle_b,
+                    {make_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE)})}),
+    base_time_);
+  arbiter_.ingest_perception(make_signals(
+    base_time_,
+    {make_group(
+      map_ids::vehicle_b, {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)})}));
+
+  const auto result = arbiter_.arbitrate();
+
+  EXPECT_EQ(observed_color(result.output, map_ids::vehicle_b), TrafficLightElement::UNKNOWN);
+}
+
+// Shape-set mismatch: perception has CIRCLE + RIGHT_ARROW, external has
+// only CIRCLE → the output is UNKNOWN over the shape union.
+TEST_F(TrafficLightArbiterCoreSignalMatchingTest, shapeSetMismatchProducesUnknown)
+{
+  arbiter_.ingest_external(
+    make_signals(
+      base_time_, {make_group(
+                    map_ids::vehicle_b,
+                    {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)})}),
+    base_time_);
+  arbiter_.ingest_perception(make_signals(
+    base_time_, {make_group(
+                  map_ids::vehicle_b,
+                  {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE),
+                   make_element(TrafficLightElement::GREEN, TrafficLightElement::RIGHT_ARROW)})}));
+
+  const auto result = arbiter_.arbitrate();
+
+  EXPECT_EQ(
+    observed_color_of_shape(result.output, map_ids::vehicle_b, TrafficLightElement::CIRCLE),
+    TrafficLightElement::UNKNOWN);
+  EXPECT_EQ(
+    observed_color_of_shape(result.output, map_ids::vehicle_b, TrafficLightElement::RIGHT_ARROW),
+    TrafficLightElement::UNKNOWN);
+}
+
+// Perception-only single source: with no external to agree with, the
+// output for that id becomes UNKNOWN. Pedestrian ids would pass through
+// unchanged instead — see singleSourcePedestrianPassesThrough.
+TEST_F(TrafficLightArbiterCoreSignalMatchingTest, perceptionOnlySingleSourceYieldsUnknown)
+{
+  arbiter_.ingest_perception(make_signals(
+    base_time_,
+    {make_group(
+      map_ids::vehicle_a, {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)})}));
+
+  const auto result = arbiter_.arbitrate();
+
+  EXPECT_EQ(observed_color(result.output, map_ids::vehicle_a), TrafficLightElement::UNKNOWN);
+}
+
+// External-only single source: symmetric counterpart — reconciliation is
+// direction-symmetric, so the output for that id is also UNKNOWN when
+// perception is the missing side.
+TEST_F(TrafficLightArbiterCoreSignalMatchingTest, externalOnlySingleSourceYieldsUnknown)
+{
+  arbiter_.ingest_external(
+    make_signals(
+      base_time_, {make_group(
+                    map_ids::vehicle_a,
+                    {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)})}),
+    base_time_);
+
+  const auto result = arbiter_.arbitrate();
+
+  EXPECT_EQ(observed_color(result.output, map_ids::vehicle_a), TrafficLightElement::UNKNOWN);
+}
+
+// Off-map id is dropped from the output and recorded in off_map_signal_ids.
+TEST_F(TrafficLightArbiterCoreSignalMatchingTest, offMapIdIsDroppedAndReported)
+{
+  arbiter_.ingest_external(
+    make_signals(
+      base_time_, {make_group(
+                    map_ids::off_map_probe,
+                    {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)})}),
+    base_time_);
+
+  const auto result = arbiter_.arbitrate();
+
+  EXPECT_EQ(find_group(result.output, map_ids::off_map_probe), nullptr);
+  EXPECT_EQ(result.off_map_signal_ids, std::vector<lanelet::Id>{map_ids::off_map_probe});
+}
+
+// ---------------------------------------------------------------------------
+// Signal Matching — Pedestrian ids
+//
+// Pedestrian ids reconcile differently from vehicle ids: instead of
+// requiring color/shape agreement between sources, the arbiter picks a
+// winner per the source-priority setting. The fixture parametrizes
+// priority via make_arbiter() so each test pins one priority mode
+// without spawning a fixture per priority.
+// ---------------------------------------------------------------------------
+
+class TrafficLightArbiterCorePedestrianTest : public CoreFixtureBase
+{
+protected:
+  TrafficLightArbiterCore make_arbiter(SourcePriority priority)
+  {
+    TrafficLightArbiterCore arbiter(
+      priority, /*enable_signal_matching=*/true, kDefaultExternalDelayTolerance,
+      kDefaultExternalTimeTolerance, kDefaultPerceptionTimeTolerance);
+    arbiter.set_map(shared_map_);
+    return arbiter;
+  }
+};
+
+// EXTERNAL priority: for pedestrian ids the external side wins even when
+// its confidence is lower than perception's.
+TEST_F(TrafficLightArbiterCorePedestrianTest, externalPriorityWinsForPedestrian)
+{
+  auto arbiter = make_arbiter(SourcePriority::EXTERNAL);
+
+  arbiter.ingest_external(
+    make_signals(
+      base_time_, {make_group(
+                    map_ids::pedestrian,
+                    {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.1f)})}),
+    base_time_);
+  arbiter.ingest_perception(make_signals(
+    base_time_, {make_group(
+                  map_ids::pedestrian,
+                  {make_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.9f)})}));
+
+  const auto result = arbiter.arbitrate();
+
+  EXPECT_EQ(observed_color(result.output, map_ids::pedestrian), TrafficLightElement::RED);
+}
+
+// PERCEPTION priority: symmetric counterpart — for pedestrian ids the
+// perception side wins even when its confidence is lower than external's.
+TEST_F(TrafficLightArbiterCorePedestrianTest, perceptionPriorityWinsForPedestrian)
+{
+  auto arbiter = make_arbiter(SourcePriority::PERCEPTION);
+
+  arbiter.ingest_external(
+    make_signals(
+      base_time_, {make_group(
+                    map_ids::pedestrian,
+                    {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.99f)})}),
+    base_time_);
+  arbiter.ingest_perception(make_signals(
+    base_time_,
+    {make_group(
+      map_ids::pedestrian,
+      {make_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.10f)})}));
+
+  const auto result = arbiter.arbitrate();
+
+  EXPECT_EQ(observed_color(result.output, map_ids::pedestrian), TrafficLightElement::GREEN);
+}
+
+// CONFIDENCE mode: for pedestrian ids the arbiter walks each shape and
+// picks the side with the higher confidence.
+TEST_F(TrafficLightArbiterCorePedestrianTest, confidenceModePicksHigherConfidenceForPedestrian)
+{
+  auto arbiter = make_arbiter(SourcePriority::CONFIDENCE);
+
+  arbiter.ingest_external(
+    make_signals(
+      base_time_,
+      {make_group(
+        map_ids::pedestrian,
+        {make_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.6f)})}),
+    base_time_);
+  arbiter.ingest_perception(make_signals(
+    base_time_, {make_group(
+                  map_ids::pedestrian,
+                  {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.9f)})}));
+
+  const auto result = arbiter.arbitrate();
+
+  EXPECT_EQ(observed_color(result.output, map_ids::pedestrian), TrafficLightElement::RED);
+}
+
+// Single-source pedestrian: contrast with the non-pedestrian behaviour
+// (perceptionOnlySingleSourceYieldsUnknown / externalOnlySingleSourceYieldsUnknown).
+// For pedestrian ids the present side flows through unchanged with no
+// UNKNOWN translation, even when source_priority would otherwise prefer
+// the absent side.
+TEST_F(TrafficLightArbiterCorePedestrianTest, singleSourcePedestrianPassesThrough)
+{
+  auto arbiter = make_arbiter(SourcePriority::EXTERNAL);
+
+  arbiter.ingest_perception(make_signals(
+    base_time_, {make_group(
+                  map_ids::pedestrian,
+                  {make_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE)})}));
+
+  const auto result = arbiter.arbitrate();
+
+  EXPECT_EQ(observed_color(result.output, map_ids::pedestrian), TrafficLightElement::GREEN);
+}
+
+// ---------------------------------------------------------------------------
+// Mode B: Priority-based — CONFIDENCE (enable_signal_matching=false)
+// ---------------------------------------------------------------------------
+
+class TrafficLightArbiterCoreConfidencePriorityTest : public CoreFixtureBase
+{
+protected:
+  TrafficLightArbiterCoreConfidencePriorityTest()
+  : arbiter_(
+      SourcePriority::CONFIDENCE, /*enable_signal_matching=*/false, kDefaultExternalDelayTolerance,
+      kDefaultExternalTimeTolerance, kDefaultPerceptionTimeTolerance)
+  {
+    arbiter_.set_map(shared_map_);
+  }
+
+  TrafficLightArbiterCore arbiter_;
+};
+
+// CONFIDENCE: same shape from both sources → the higher-confidence element
+// wins (here, perception 0.9 over external 0.7).
+TEST_F(TrafficLightArbiterCoreConfidencePriorityTest, picksHigherConfidenceElement)
+{
+  arbiter_.ingest_external(
+    make_signals(
+      base_time_,
+      {make_group(
+        map_ids::vehicle_a,
+        {make_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.7f)})}),
+    base_time_);
+  arbiter_.ingest_perception(make_signals(
+    base_time_, {make_group(
+                  map_ids::vehicle_a,
+                  {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.9f)})}));
+
+  const auto result = arbiter_.arbitrate();
+
+  EXPECT_EQ(observed_color(result.output, map_ids::vehicle_a), TrafficLightElement::RED);
+}
+
+// Per-shape union: when each side contributes a different shape under
+// the same id, the output carries both shapes verbatim. Reconciliation
+// runs independently per shape, so the absence of CIRCLE on the external
+// side does not block external's RIGHT_ARROW and vice versa.
+TEST_F(TrafficLightArbiterCoreConfidencePriorityTest, perShapeUnionFromBothSides)
+{
+  arbiter_.ingest_perception(make_signals(
+    base_time_,
+    {make_group(
+      map_ids::vehicle_a, {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)})}));
+  arbiter_.ingest_external(
+    make_signals(
+      base_time_, {make_group(
+                    map_ids::vehicle_a,
+                    {make_element(TrafficLightElement::GREEN, TrafficLightElement::RIGHT_ARROW)})}),
+    base_time_);
+
+  const auto result = arbiter_.arbitrate();
+
+  EXPECT_EQ(
+    observed_color_of_shape(result.output, map_ids::vehicle_a, TrafficLightElement::CIRCLE),
+    TrafficLightElement::RED);
+  EXPECT_EQ(
+    observed_color_of_shape(result.output, map_ids::vehicle_a, TrafficLightElement::RIGHT_ARROW),
+    TrafficLightElement::GREEN);
+}
+
+// Perception-only: with no external present, the perception element flows
+// through unchanged regardless of priority mode.
+TEST_F(TrafficLightArbiterCoreConfidencePriorityTest, perceptionOnlyPassesThrough)
+{
+  arbiter_.ingest_perception(make_signals(
+    base_time_, {make_group(
+                  map_ids::vehicle_b,
+                  {make_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE)})}));
+
+  const auto result = arbiter_.arbitrate();
+
+  EXPECT_EQ(observed_color(result.output, map_ids::vehicle_b), TrafficLightElement::GREEN);
+}
+
+// Off-map id is dropped before reaching priority selection too. Pins the
+// off-map guard as mode-independent (Signal Matching side has its own
+// counterpart in offMapIdIsDroppedAndReported).
+TEST_F(TrafficLightArbiterCoreConfidencePriorityTest, offMapIdIsDroppedAndReported)
+{
+  arbiter_.ingest_external(
+    make_signals(
+      base_time_, {make_group(
+                    map_ids::off_map_probe,
+                    {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)})}),
+    base_time_);
+
+  const auto result = arbiter_.arbitrate();
+
+  EXPECT_EQ(find_group(result.output, map_ids::off_map_probe), nullptr);
+  EXPECT_EQ(result.off_map_signal_ids, std::vector<lanelet::Id>{map_ids::off_map_probe});
+}
+
+// Successive external publishes carrying different ids accumulate in the
+// cache; both end up in the final output with their published colors.
+TEST_F(TrafficLightArbiterCoreConfidencePriorityTest, multipleExternalSourcesAccumulate)
+{
+  arbiter_.ingest_external(
+    make_signals(
+      base_time_, {make_group(
+                    map_ids::vehicle_a,
+                    {make_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE)})}),
+    base_time_);
+  arbiter_.ingest_external(
+    make_signals(
+      base_time_, {make_group(
+                    map_ids::vehicle_b,
+                    {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)})}),
+    base_time_);
+
+  const auto result = arbiter_.arbitrate();
+
+  EXPECT_EQ(observed_color(result.output, map_ids::vehicle_a), TrafficLightElement::GREEN);
+  EXPECT_EQ(observed_color(result.output, map_ids::vehicle_b), TrafficLightElement::RED);
+}
+
+// Predictions ride alongside elements: when both sides carry one each,
+// the output group holds both, perception-side first. Mode is irrelevant
+// — the merge happens before mode-specific element reconciliation, so
+// Confidence is a fine host for this pin.
+TEST_F(TrafficLightArbiterCoreConfidencePriorityTest, predictionsFromBothSidesAreMerged)
+{
+  arbiter_.ingest_perception(make_signals(
+    base_time_,
+    {make_group(
+      map_ids::vehicle_a, {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)},
+      {make_prediction(
+        base_time_, PredictedTrafficLightState::INFORMATION_SOURCE_INTERNAL_ESTIMATION)})}));
+  arbiter_.ingest_external(
+    make_signals(
+      base_time_,
+      {make_group(
+        map_ids::vehicle_a, {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)},
+        {make_prediction(base_time_, PredictedTrafficLightState::INFORMATION_SOURCE_V2I)})}),
+    base_time_);
+
+  const auto result = arbiter_.arbitrate();
+
+  EXPECT_EQ(
+    observed_prediction_source(result.output, map_ids::vehicle_a, 0),
+    PredictedTrafficLightState::INFORMATION_SOURCE_INTERNAL_ESTIMATION);
+  EXPECT_EQ(
+    observed_prediction_source(result.output, map_ids::vehicle_a, 1),
+    PredictedTrafficLightState::INFORMATION_SOURCE_V2I);
+}
+
+// Perception-only side: when external is silent, the perception side's
+// prediction (with its information_source) still reaches the output.
+TEST_F(TrafficLightArbiterCoreConfidencePriorityTest, perceptionOnlyPredictionPropagates)
+{
+  arbiter_.ingest_perception(make_signals(
+    base_time_,
+    {make_group(
+      map_ids::vehicle_a, {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)},
+      {make_prediction(
+        base_time_, PredictedTrafficLightState::INFORMATION_SOURCE_INTERNAL_ESTIMATION)})}));
+
+  const auto result = arbiter_.arbitrate();
+
+  EXPECT_EQ(
+    observed_prediction_source(result.output, map_ids::vehicle_a, 0),
+    PredictedTrafficLightState::INFORMATION_SOURCE_INTERNAL_ESTIMATION);
+}
+
+// External-only side: symmetric counterpart — when perception is silent,
+// the external side's prediction (with its information_source) reaches
+// the output.
+TEST_F(TrafficLightArbiterCoreConfidencePriorityTest, externalOnlyPredictionPropagates)
+{
+  arbiter_.ingest_external(
+    make_signals(
+      base_time_,
+      {make_group(
+        map_ids::vehicle_a, {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)},
+        {make_prediction(base_time_, PredictedTrafficLightState::INFORMATION_SOURCE_V2I)})}),
+    base_time_);
+
+  const auto result = arbiter_.arbitrate();
+
+  EXPECT_EQ(
+    observed_prediction_source(result.output, map_ids::vehicle_a, 0),
+    PredictedTrafficLightState::INFORMATION_SOURCE_V2I);
+}
+
+// ---------------------------------------------------------------------------
+// Mode C: Priority-based — EXTERNAL
+// ---------------------------------------------------------------------------
+
+class TrafficLightArbiterCoreExternalPriorityTest : public CoreFixtureBase
+{
+protected:
+  TrafficLightArbiterCoreExternalPriorityTest()
+  : arbiter_(
+      SourcePriority::EXTERNAL, /*enable_signal_matching=*/false, kDefaultExternalDelayTolerance,
+      kDefaultExternalTimeTolerance, kDefaultPerceptionTimeTolerance)
+  {
+    arbiter_.set_map(shared_map_);
+  }
+
+  TrafficLightArbiterCore arbiter_;
+};
+
+// External wins despite lower confidence: the EXTERNAL setting forces
+// the external side to win over a higher-confidence perception.
+TEST_F(TrafficLightArbiterCoreExternalPriorityTest, externalPriorityOverridesConfidence)
+{
+  arbiter_.ingest_external(
+    make_signals(
+      base_time_, {make_group(
+                    map_ids::vehicle_a,
+                    {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.10f)})}),
+    base_time_);
+  arbiter_.ingest_perception(make_signals(
+    base_time_,
+    {make_group(
+      map_ids::vehicle_a,
+      {make_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.99f)})}));
+
+  const auto result = arbiter_.arbitrate();
+
+  EXPECT_EQ(observed_color(result.output, map_ids::vehicle_a), TrafficLightElement::RED);
+}
+
+// External-only: the EXTERNAL setting has no effect when only one source
+// is present.
+TEST_F(TrafficLightArbiterCoreExternalPriorityTest, externalOnlyPassesThrough)
+{
+  arbiter_.ingest_external(
+    make_signals(
+      base_time_, {make_group(
+                    map_ids::vehicle_a,
+                    {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)})}),
+    base_time_);
+
+  const auto result = arbiter_.arbitrate();
+
+  EXPECT_EQ(observed_color(result.output, map_ids::vehicle_a), TrafficLightElement::RED);
+}
+
+// Perception-only with EXTERNAL priority: with no external side present,
+// the EXTERNAL setting has nothing to apply to and the perception element
+// reaches the output.
+TEST_F(TrafficLightArbiterCoreExternalPriorityTest, perceptionOnlyPassesThrough)
+{
+  arbiter_.ingest_perception(make_signals(
+    base_time_, {make_group(
+                  map_ids::vehicle_a,
+                  {make_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE)})}));
+
+  const auto result = arbiter_.arbitrate();
+
+  EXPECT_EQ(observed_color(result.output, map_ids::vehicle_a), TrafficLightElement::GREEN);
+}
+
+// ---------------------------------------------------------------------------
+// Mode D: Priority-based — PERCEPTION
+// ---------------------------------------------------------------------------
+
+class TrafficLightArbiterCorePerceptionPriorityTest : public CoreFixtureBase
+{
+protected:
+  TrafficLightArbiterCorePerceptionPriorityTest()
+  : arbiter_(
+      SourcePriority::PERCEPTION, /*enable_signal_matching=*/false, kDefaultExternalDelayTolerance,
+      kDefaultExternalTimeTolerance, kDefaultPerceptionTimeTolerance)
+  {
+    arbiter_.set_map(shared_map_);
+  }
+
+  TrafficLightArbiterCore arbiter_;
+};
+
+// Perception wins despite lower confidence: symmetric counterpart of the
+// EXTERNAL override case.
+TEST_F(TrafficLightArbiterCorePerceptionPriorityTest, perceptionPriorityOverridesConfidence)
+{
+  arbiter_.ingest_external(
+    make_signals(
+      base_time_, {make_group(
+                    map_ids::vehicle_a,
+                    {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.99f)})}),
+    base_time_);
+  arbiter_.ingest_perception(make_signals(
+    base_time_,
+    {make_group(
+      map_ids::vehicle_a,
+      {make_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.10f)})}));
+
+  const auto result = arbiter_.arbitrate();
+
+  EXPECT_EQ(observed_color(result.output, map_ids::vehicle_a), TrafficLightElement::GREEN);
+}
+
+// Perception-only: the PERCEPTION setting has no effect when only one
+// source is present.
+TEST_F(TrafficLightArbiterCorePerceptionPriorityTest, perceptionOnlyPassesThrough)
+{
+  arbiter_.ingest_perception(make_signals(
+    base_time_, {make_group(
+                  map_ids::vehicle_a,
+                  {make_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE)})}));
+
+  const auto result = arbiter_.arbitrate();
+
+  EXPECT_EQ(observed_color(result.output, map_ids::vehicle_a), TrafficLightElement::GREEN);
+}
+
+// External-only with PERCEPTION priority: symmetric counterpart — external
+// is the only source, so it passes through.
+TEST_F(TrafficLightArbiterCorePerceptionPriorityTest, externalOnlyPassesThrough)
+{
+  arbiter_.ingest_external(
+    make_signals(
+      base_time_, {make_group(
+                    map_ids::vehicle_a,
+                    {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)})}),
+    base_time_);
+
+  const auto result = arbiter_.arbitrate();
+
+  EXPECT_EQ(observed_color(result.output, map_ids::vehicle_a), TrafficLightElement::RED);
+}
+
+// ---------------------------------------------------------------------------
+// Boundary: mode-agnostic ground truth. Kept as free TEST() because the
+// scenario does not depend on which mode the Core runs in.
+// ---------------------------------------------------------------------------
+
+// arbitrate() before set_map() yields output=std::nullopt. The Node
+// distinguishes "no output" (skip publish) from "empty output" (publish
+// with zero groups), so the optional must stay disengaged here.
+TEST(TrafficLightArbiterCoreBoundaryTest, arbitrateWithoutMapProducesNoOutput)
+{
+  TrafficLightArbiterCore unconfigured(
+    SourcePriority::CONFIDENCE, /*enable_signal_matching=*/false, kDefaultExternalDelayTolerance,
+    kDefaultExternalTimeTolerance, kDefaultPerceptionTimeTolerance);
+
+  const rclcpp::Time base_time{make_base_time()};
+  unconfigured.ingest_perception(make_signals(
+    base_time,
+    {make_group(
+      map_ids::vehicle_a, {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)})}));
+
+  const auto result = unconfigured.arbitrate();
+
+  EXPECT_FALSE(result.output.has_value());
+}
+
+// A map with no TrafficLight regulatory elements yields an output that is
+// engaged but empty — the counterpart to the no-map case above. The Node
+// publishes a zero-group message here instead of skipping the publish.
+TEST(TrafficLightArbiterCoreBoundaryTest, emptyMapProducesEmptyOutput)
+{
+  TrafficLightArbiterCore arbiter(
+    SourcePriority::CONFIDENCE, /*enable_signal_matching=*/false, kDefaultExternalDelayTolerance,
+    kDefaultExternalTimeTolerance, kDefaultPerceptionTimeTolerance);
+  arbiter.set_map(build_empty_map());
+
+  const rclcpp::Time base_time{make_base_time()};
+  arbiter.ingest_perception(make_signals(
+    base_time,
+    {make_group(
+      map_ids::vehicle_a, {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)})}));
+
+  const auto result = arbiter.arbitrate();
+
+  EXPECT_EQ(observed_group_count(result.output), 0u);
+}
+
+// ---------------------------------------------------------------------------
+// Perception staleness: when perception's stamp lags the freshest external
+// stamp by more than perception_time_tolerance, arbitrate() drops the
+// perception side from the current cycle without modifying what has been
+// ingested. Tests pin the boundary both inside and outside the tolerance,
+// plus the prediction side effect.
+// ---------------------------------------------------------------------------
+
+class TrafficLightArbiterCorePerceptionStalenessTest : public CoreFixtureBase
+{
+protected:
+  TrafficLightArbiterCorePerceptionStalenessTest()
+  : arbiter_(
+      SourcePriority::CONFIDENCE, /*enable_signal_matching=*/false, kDefaultExternalDelayTolerance,
+      kDefaultExternalTimeTolerance, kDefaultPerceptionTimeTolerance)
+  {
+    arbiter_.set_map(shared_map_);
+  }
+
+  TrafficLightArbiterCore arbiter_;
+};
+
+// Outside tolerance (perception is older than tolerance allows): perception
+// is excluded from arbitrate() so external alone reaches the output.
+TEST_F(TrafficLightArbiterCorePerceptionStalenessTest, stalePerceptionIsExcludedFromOutput)
+{
+  const auto t_perception =
+    base_time_ - rclcpp::Duration::from_seconds(kDefaultPerceptionTimeTolerance + 1.0);
+
+  arbiter_.ingest_perception(make_signals(
+    t_perception,
+    {make_group(
+      map_ids::vehicle_a, {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)})}));
+  arbiter_.ingest_external(
+    make_signals(
+      base_time_, {make_group(
+                    map_ids::vehicle_a,
+                    {make_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE)})}),
+    base_time_);
+
+  const auto result = arbiter_.arbitrate();
+
+  EXPECT_EQ(observed_color(result.output, map_ids::vehicle_a), TrafficLightElement::GREEN);
+}
+
+// Inside tolerance (perception is older but only by half the budget):
+// perception remains effective, so CONFIDENCE picks the higher-confidence
+// perception element over the lower-confidence external.
+TEST_F(TrafficLightArbiterCorePerceptionStalenessTest, freshPerceptionRemainsEffective)
+{
+  const auto t_perception =
+    base_time_ - rclcpp::Duration::from_seconds(0.5 * kDefaultPerceptionTimeTolerance);
+
+  arbiter_.ingest_perception(make_signals(
+    t_perception, {make_group(
+                    map_ids::vehicle_a,
+                    {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.9f)})}));
+  arbiter_.ingest_external(
+    make_signals(
+      base_time_,
+      {make_group(
+        map_ids::vehicle_a,
+        {make_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.7f)})}),
+    base_time_);
+
+  const auto result = arbiter_.arbitrate();
+
+  EXPECT_EQ(observed_color(result.output, map_ids::vehicle_a), TrafficLightElement::RED);
+}
+
+// External is silent: with no external stamp to compare against, the
+// staleness check has nothing to evaluate and the perception side
+// reaches the output even when its stamp lags base_time by far more
+// than the tolerance.
+//
+// This asymmetry predates the Core extraction — only the external side
+// has ever had a wall-clock admission guard (added in 3dc9605d9 to the
+// combined Node+logic code; the perception side was not given the same
+// treatment then and has not been since). Whether that is intentional
+// (Core is a pure function; absolute staleness is a Node-layer concern)
+// or a latent gap (a stalled perception node could keep stale signals
+// on the bus indefinitely when no external source is publishing) is an
+// open question. This test pins the current behaviour; it does not
+// endorse it.
+TEST_F(TrafficLightArbiterCorePerceptionStalenessTest, perceptionAloneIsNeverStale)
+{
+  const auto t_perception =
+    base_time_ - rclcpp::Duration::from_seconds(kDefaultPerceptionTimeTolerance + 10.0);
+
+  arbiter_.ingest_perception(make_signals(
+    t_perception,
+    {make_group(
+      map_ids::vehicle_a, {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)})}));
+
+  const auto result = arbiter_.arbitrate();
+
+  EXPECT_EQ(observed_color(result.output, map_ids::vehicle_a), TrafficLightElement::RED);
+}
+
+// Staleness is decided at the message level, not per id: when the
+// perception message is stale, its entire content is excluded — even ids
+// that the external side does not cover. With perception carrying
+// vehicle_a (stale) and external carrying vehicle_b (fresh), vehicle_a
+// must be absent from the output and vehicle_b must remain present.
+TEST_F(TrafficLightArbiterCorePerceptionStalenessTest, stalenessDropsEntirePerceptionMessage)
+{
+  const auto t_perception =
+    base_time_ - rclcpp::Duration::from_seconds(kDefaultPerceptionTimeTolerance + 1.0);
+
+  arbiter_.ingest_perception(make_signals(
+    t_perception,
+    {make_group(
+      map_ids::vehicle_a, {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)})}));
+  arbiter_.ingest_external(
+    make_signals(
+      base_time_, {make_group(
+                    map_ids::vehicle_b,
+                    {make_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE)})}),
+    base_time_);
+
+  const auto result = arbiter_.arbitrate();
+
+  EXPECT_EQ(find_group(result.output, map_ids::vehicle_a), nullptr);
+  EXPECT_NE(find_group(result.output, map_ids::vehicle_b), nullptr);
+}
+
+// Stale perception drops its predictions from the merge too, so only the
+// external-side prediction (V2I) survives in the output group.
+TEST_F(TrafficLightArbiterCorePerceptionStalenessTest, stalePerceptionPredictionsAreSkipped)
+{
+  const auto t_perception =
+    base_time_ - rclcpp::Duration::from_seconds(kDefaultPerceptionTimeTolerance + 1.0);
+
+  arbiter_.ingest_perception(make_signals(
+    t_perception,
+    {make_group(
+      map_ids::vehicle_a, {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)},
+      {make_prediction(
+        t_perception, PredictedTrafficLightState::INFORMATION_SOURCE_INTERNAL_ESTIMATION)})}));
+  arbiter_.ingest_external(
+    make_signals(
+      base_time_,
+      {make_group(
+        map_ids::vehicle_a, {make_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE)},
+        {make_prediction(base_time_, PredictedTrafficLightState::INFORMATION_SOURCE_V2I)})}),
+    base_time_);
+
+  const auto result = arbiter_.arbitrate();
+
+  EXPECT_EQ(
+    observed_prediction_source(result.output, map_ids::vehicle_a, 0),
+    PredictedTrafficLightState::INFORMATION_SOURCE_V2I);
+}
+
+// ---------------------------------------------------------------------------
+// latest_input_time: the Node uses this to decide whether its published
+// output is behind some input that has arrived but not yet driven a
+// publish cycle. The non-trivial piece is selecting the most recent
+// stamp across stored sources, so we pin all directions of that
+// selection.
+// ---------------------------------------------------------------------------
+
+class TrafficLightArbiterCoreLatestInputTimeTest : public CoreFixtureBase
+{
+protected:
+  TrafficLightArbiterCoreLatestInputTimeTest()
+  : arbiter_(
+      SourcePriority::CONFIDENCE, /*enable_signal_matching=*/false, kDefaultExternalDelayTolerance,
+      kDefaultExternalTimeTolerance, kDefaultPerceptionTimeTolerance)
+  {
+    arbiter_.set_map(shared_map_);
+  }
+
+  TrafficLightArbiterCore arbiter_;
+};
+
+TEST_F(TrafficLightArbiterCoreLatestInputTimeTest, takesNewerOfPerceptionAndExternal)
+{
+  const auto t_external_newer = base_time_ + rclcpp::Duration::from_seconds(0.5);
+
+  arbiter_.ingest_perception(make_signals(
+    base_time_,
+    {make_group(
+      map_ids::vehicle_a, {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)})}));
+  arbiter_.ingest_external(
+    make_signals(
+      t_external_newer, {make_group(
+                          map_ids::vehicle_a,
+                          {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)})}),
+    t_external_newer);
+
+  const auto result = arbiter_.arbitrate();
+
+  EXPECT_EQ(result.latest_input_time, t_external_newer);
+}
+
+// Symmetric counterpart: when perception is the newer source, its stamp
+// wins even though external is also stored.
+TEST_F(TrafficLightArbiterCoreLatestInputTimeTest, perceptionWinsWhenNewer)
+{
+  const auto t_perception_newer = base_time_ + rclcpp::Duration::from_seconds(0.3);
+
+  arbiter_.ingest_external(
+    make_signals(
+      base_time_, {make_group(
+                    map_ids::vehicle_a,
+                    {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)})}),
+    base_time_);
+  arbiter_.ingest_perception(make_signals(
+    t_perception_newer,
+    {make_group(
+      map_ids::vehicle_a, {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)})}));
+
+  const auto result = arbiter_.arbitrate();
+
+  EXPECT_EQ(result.latest_input_time, t_perception_newer);
+}
+
+// External is silent: with no external stamps to compare against,
+// latest_input_time falls back to the perception stamp.
+TEST_F(TrafficLightArbiterCoreLatestInputTimeTest, perceptionStampWhenExternalIsSilent)
+{
+  const auto t_perception = base_time_ + rclcpp::Duration::from_seconds(0.5);
+
+  arbiter_.ingest_perception(make_signals(
+    t_perception,
+    {make_group(
+      map_ids::vehicle_a, {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)})}));
+
+  const auto result = arbiter_.arbitrate();
+
+  EXPECT_EQ(result.latest_input_time, t_perception);
+}
+
+// ---------------------------------------------------------------------------
+// Timing utilities: mode-agnostic. Behaviour is observed through
+// ingest_external's admission-control return (accepted/rejected) and
+// ingest_perception's expired-entries return.
+// ---------------------------------------------------------------------------
+
+class TrafficLightArbiterCoreTimingTest : public CoreFixtureBase
+{
+protected:
+  TrafficLightArbiterCoreTimingTest()
+  : arbiter_(
+      SourcePriority::CONFIDENCE, /*enable_signal_matching=*/false, kDefaultExternalDelayTolerance,
+      kDefaultExternalTimeTolerance, kDefaultPerceptionTimeTolerance)
+  {
+    arbiter_.set_map(shared_map_);
+  }
+
+  TrafficLightArbiterCore arbiter_;
+};
+
+// A stamp close enough to current_time (within external_delay_tolerance)
+// is accepted.
+TEST_F(TrafficLightArbiterCoreTimingTest, ingestExternalAcceptsStampsWithinTolerance)
+{
+  const auto t_past_within =
+    base_time_ - rclcpp::Duration::from_seconds(kDefaultExternalDelayTolerance - 1.0);
+
+  const auto result = arbiter_.ingest_external(
+    make_signals(
+      t_past_within, {make_group(
+                       map_ids::vehicle_a,
+                       {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)})}),
+    base_time_);
+
+  EXPECT_TRUE(result.accepted);
+}
+
+// A stamp older than current_time by more than external_delay_tolerance
+// is rejected.
+TEST_F(TrafficLightArbiterCoreTimingTest, ingestExternalRejectsTooOldStamps)
+{
+  const auto t_past_beyond =
+    base_time_ - rclcpp::Duration::from_seconds(kDefaultExternalDelayTolerance + 1.0);
+
+  const auto result = arbiter_.ingest_external(
+    make_signals(
+      t_past_beyond, {make_group(
+                       map_ids::vehicle_a,
+                       {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)})}),
+    base_time_);
+
+  EXPECT_FALSE(result.accepted);
+}
+
+// A stamp ahead of current_time by more than external_delay_tolerance is
+// also rejected — the tolerance is applied symmetrically in both
+// directions.
+TEST_F(TrafficLightArbiterCoreTimingTest, ingestExternalRejectsTooFutureStamps)
+{
+  const auto t_future_beyond =
+    base_time_ + rclcpp::Duration::from_seconds(kDefaultExternalDelayTolerance + 1.0);
+
+  const auto result = arbiter_.ingest_external(
+    make_signals(
+      t_future_beyond, {make_group(
+                         map_ids::vehicle_a,
+                         {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)})}),
+    base_time_);
+
+  EXPECT_FALSE(result.accepted);
+}
+
+// Sweep-on-ingest report: a perception arrival far past
+// external_time_tolerance after a stored external evicts that entry,
+// and ingest_perception's return value carries the eviction details
+// (used by the Node for DEBUG logging).
+TEST_F(TrafficLightArbiterCoreTimingTest, ingestPerceptionReportsExpiredExternalEntry)
+{
+  arbiter_.ingest_external(
+    make_signals(
+      base_time_, {make_group(
+                    map_ids::vehicle_a,
+                    {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)})}),
+    base_time_);
+  const auto t_perception =
+    base_time_ + rclcpp::Duration::from_seconds(kDefaultExternalTimeTolerance + 1.0);
+
+  const auto expired = arbiter_.ingest_perception(make_signals(
+    t_perception, {make_group(
+                    map_ids::vehicle_b,
+                    {make_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE)})}));
+
+  ASSERT_EQ(expired.size(), 1u);
+  EXPECT_EQ(expired.front().id, map_ids::vehicle_a);
+  EXPECT_GT(expired.front().age, kDefaultExternalTimeTolerance);
+}
+
+// Sweep-on-ingest downstream effect: an external entry evicted by the
+// sweep is absent from the next arbitration output, even when the
+// triggering perception covers a different id.
+TEST_F(TrafficLightArbiterCoreTimingTest, evictedExternalEntryAbsentFromOutput)
+{
+  arbiter_.ingest_external(
+    make_signals(
+      base_time_, {make_group(
+                    map_ids::vehicle_a,
+                    {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)})}),
+    base_time_);
+  const auto t_perception =
+    base_time_ + rclcpp::Duration::from_seconds(kDefaultExternalTimeTolerance + 1.0);
+  arbiter_.ingest_perception(make_signals(
+    t_perception, {make_group(
+                    map_ids::vehicle_b,
+                    {make_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE)})}));
+
+  const auto result = arbiter_.arbitrate();
+
+  EXPECT_EQ(find_group(result.output, map_ids::vehicle_a), nullptr);
+}
+
+}  // namespace

--- a/perception/autoware_traffic_light_arbiter/test/test_traffic_light_arbiter_core.cpp
+++ b/perception/autoware_traffic_light_arbiter/test/test_traffic_light_arbiter_core.cpp
@@ -260,88 +260,66 @@ std::optional<std::string> observed_prediction_source(
   return group->predictions[index].information_source;
 }
 
-// --- Base fixture ------------------------------------------------------
+// --- Suite-wide state and factory -------------------------------------
 
 // Mirror config/traffic_light_arbiter.param.yaml defaults so the numeric
 // envelope these tests assume matches the production parameter set.
-// Hoisted out of CoreFixtureBase so free TEST() blocks can reach the same
-// defaults without subclassing the fixture.
 constexpr double kDefaultExternalDelayTolerance = 5.0;
 constexpr double kDefaultExternalTimeTolerance = 5.0;
 constexpr double kDefaultPerceptionTimeTolerance = 1.0;
 
 // Arbitrary positive seconds used as the suite-wide base time. Far enough
-// from zero that any base_time - duration derived in a test stays positive
+// from zero that any kBaseTime - duration derived in a test stays positive
 // (largest backward offset is kDefaultExternalDelayTolerance + a few seconds).
 constexpr int32_t kBaseTimeSeconds = 1'000'000'000;
+const rclcpp::Time kBaseTime{kBaseTimeSeconds, 0, RCL_ROS_TIME};
 
-// Builds the suite-wide base time. Used both as the fixture member
-// base_time_ and as the local base_time inside free TEST() blocks; the
-// member-vs-local distinction stays in the call-site variable name (the
-// trailing underscore on member fields).
-rclcpp::Time make_base_time()
+// Static initializer reserves off_map_probe so utils::getId() (used by map
+// builders) never hands out an id that collides with it, then builds the
+// suite-wide map once. Process-global state; one registration is enough.
+const lanelet::LaneletMapConstPtr kSharedMap = []() {
+  lanelet::utils::registerId(map_ids::off_map_probe);
+  return build_minimal_map();
+}();
+
+// Builds an arbiter with the suite-wide map already loaded. priority and
+// enable_signal_matching select the reconciliation mode under test.
+TrafficLightArbiterCore make_arbiter(SourcePriority priority, bool enable_signal_matching)
 {
-  return rclcpp::Time{kBaseTimeSeconds, 0, RCL_ROS_TIME};
+  TrafficLightArbiterCore arbiter(
+    priority, enable_signal_matching, kDefaultExternalDelayTolerance, kDefaultExternalTimeTolerance,
+    kDefaultPerceptionTimeTolerance);
+  arbiter.set_map(kSharedMap);
+  return arbiter;
 }
-
-class CoreFixtureBase : public ::testing::Test
-{
-protected:
-  // Reserve off_map_probe so utils::getId() (used by map builders) never
-  // hands out an id that collides with it. Process-global state; one
-  // registration per suite is enough.
-  static void SetUpTestSuite()
-  {
-    lanelet::utils::registerId(map_ids::off_map_probe);
-    shared_map_ = build_minimal_map();
-  }
-
-  // Fixed clock: avoids std::chrono and keeps tests deterministic. Tests
-  // derive other stamps from base_time_ using rclcpp::Duration.
-  rclcpp::Time base_time_{make_base_time()};
-
-  inline static lanelet::LaneletMapConstPtr shared_map_;
-};
 
 // ---------------------------------------------------------------------------
 // Mode A: Signal Matching (enable_signal_matching=true)
 //
-// In Signal Matching mode the arbiter reconciles perception and external
-// signals: agreement passes through, disagreement falls back to UNKNOWN.
-// These tests pin the non-pedestrian behaviour; pedestrian ids follow a
-// different rule (see TrafficLightArbiterCorePedestrianTest).
+// The arbiter reconciles perception and external signals: agreement passes
+// through, disagreement falls back to UNKNOWN. These tests pin the non-
+// pedestrian behaviour; pedestrian ids follow a different rule (see the
+// pedestrian section below).
 // ---------------------------------------------------------------------------
-
-class TrafficLightArbiterCoreSignalMatchingTest : public CoreFixtureBase
-{
-protected:
-  TrafficLightArbiterCoreSignalMatchingTest()
-  : arbiter_(
-      SourcePriority::CONFIDENCE, /*enable_signal_matching=*/true, kDefaultExternalDelayTolerance,
-      kDefaultExternalTimeTolerance, kDefaultPerceptionTimeTolerance)
-  {
-    arbiter_.set_map(shared_map_);
-  }
-
-  TrafficLightArbiterCore arbiter_;
-};
 
 // Matched: when perception and external agree on color and shape, the
 // output carries the same element verbatim.
-TEST_F(TrafficLightArbiterCoreSignalMatchingTest, matchedSignalsPassThrough)
+TEST(TrafficLightArbiterCoreSignalMatching, matchedSignalsPassThrough)
 {
-  arbiter_.ingest_external(
+  auto arbiter = make_arbiter(SourcePriority::CONFIDENCE, /*enable_signal_matching=*/true);
+
+  arbiter.ingest_external(
     make_signals(
-      base_time_, {make_group(
-                    map_ids::vehicle_a,
-                    {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)})}),
-    base_time_);
-  arbiter_.ingest_perception(make_signals(
-    base_time_,
+      kBaseTime, {make_group(
+                   map_ids::vehicle_a,
+                   {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)})}),
+    kBaseTime);
+  arbiter.ingest_perception(make_signals(
+    kBaseTime,
     {make_group(
       map_ids::vehicle_a, {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)})}));
 
-  const auto result = arbiter_.arbitrate();
+  const auto result = arbiter.arbitrate();
 
   EXPECT_EQ(observed_color(result.output, map_ids::vehicle_a), TrafficLightElement::RED);
 }
@@ -351,20 +329,22 @@ TEST_F(TrafficLightArbiterCoreSignalMatchingTest, matchedSignalsPassThrough)
 // (0.90) rather than external's (0.10) reaches the output. Seeing 0.90
 // (and not 0.10) on a same-color/shape pair is what proves the differing
 // confidences did not break the match.
-TEST_F(TrafficLightArbiterCoreSignalMatchingTest, differingConfidencesStillMatch)
+TEST(TrafficLightArbiterCoreSignalMatching, differingConfidencesStillMatch)
 {
-  arbiter_.ingest_external(
-    make_signals(
-      base_time_, {make_group(
-                    map_ids::vehicle_a,
-                    {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.10f)})}),
-    base_time_);
-  arbiter_.ingest_perception(make_signals(
-    base_time_, {make_group(
-                  map_ids::vehicle_a,
-                  {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.90f)})}));
+  auto arbiter = make_arbiter(SourcePriority::CONFIDENCE, /*enable_signal_matching=*/true);
 
-  const auto result = arbiter_.arbitrate();
+  arbiter.ingest_external(
+    make_signals(
+      kBaseTime, {make_group(
+                   map_ids::vehicle_a,
+                   {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.10f)})}),
+    kBaseTime);
+  arbiter.ingest_perception(make_signals(
+    kBaseTime, {make_group(
+                 map_ids::vehicle_a,
+                 {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.90f)})}));
+
+  const auto result = arbiter.arbitrate();
 
   EXPECT_EQ(observed_color(result.output, map_ids::vehicle_a), TrafficLightElement::RED);
   EXPECT_NEAR(observed_confidence(result.output, map_ids::vehicle_a).value_or(-1.0f), 0.90f, 1e-5f);
@@ -372,41 +352,45 @@ TEST_F(TrafficLightArbiterCoreSignalMatchingTest, differingConfidencesStillMatch
 
 // Color mismatch: when both sides share the shape but disagree on color,
 // the output falls back to UNKNOWN over that shape.
-TEST_F(TrafficLightArbiterCoreSignalMatchingTest, colorMismatchProducesUnknown)
+TEST(TrafficLightArbiterCoreSignalMatching, colorMismatchProducesUnknown)
 {
-  arbiter_.ingest_external(
+  auto arbiter = make_arbiter(SourcePriority::CONFIDENCE, /*enable_signal_matching=*/true);
+
+  arbiter.ingest_external(
     make_signals(
-      base_time_, {make_group(
-                    map_ids::vehicle_b,
-                    {make_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE)})}),
-    base_time_);
-  arbiter_.ingest_perception(make_signals(
-    base_time_,
+      kBaseTime, {make_group(
+                   map_ids::vehicle_b,
+                   {make_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE)})}),
+    kBaseTime);
+  arbiter.ingest_perception(make_signals(
+    kBaseTime,
     {make_group(
       map_ids::vehicle_b, {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)})}));
 
-  const auto result = arbiter_.arbitrate();
+  const auto result = arbiter.arbitrate();
 
   EXPECT_EQ(observed_color(result.output, map_ids::vehicle_b), TrafficLightElement::UNKNOWN);
 }
 
 // Shape-set mismatch: perception has CIRCLE + RIGHT_ARROW, external has
 // only CIRCLE → the output is UNKNOWN over the shape union.
-TEST_F(TrafficLightArbiterCoreSignalMatchingTest, shapeSetMismatchProducesUnknown)
+TEST(TrafficLightArbiterCoreSignalMatching, shapeSetMismatchProducesUnknown)
 {
-  arbiter_.ingest_external(
-    make_signals(
-      base_time_, {make_group(
-                    map_ids::vehicle_b,
-                    {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)})}),
-    base_time_);
-  arbiter_.ingest_perception(make_signals(
-    base_time_, {make_group(
-                  map_ids::vehicle_b,
-                  {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE),
-                   make_element(TrafficLightElement::GREEN, TrafficLightElement::RIGHT_ARROW)})}));
+  auto arbiter = make_arbiter(SourcePriority::CONFIDENCE, /*enable_signal_matching=*/true);
 
-  const auto result = arbiter_.arbitrate();
+  arbiter.ingest_external(
+    make_signals(
+      kBaseTime, {make_group(
+                   map_ids::vehicle_b,
+                   {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)})}),
+    kBaseTime);
+  arbiter.ingest_perception(make_signals(
+    kBaseTime, {make_group(
+                 map_ids::vehicle_b,
+                 {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE),
+                  make_element(TrafficLightElement::GREEN, TrafficLightElement::RIGHT_ARROW)})}));
+
+  const auto result = arbiter.arbitrate();
 
   EXPECT_EQ(
     observed_color_of_shape(result.output, map_ids::vehicle_b, TrafficLightElement::CIRCLE),
@@ -419,14 +403,16 @@ TEST_F(TrafficLightArbiterCoreSignalMatchingTest, shapeSetMismatchProducesUnknow
 // Perception-only single source: with no external to agree with, the
 // output for that id becomes UNKNOWN. Pedestrian ids would pass through
 // unchanged instead — see singleSourcePedestrianPassesThrough.
-TEST_F(TrafficLightArbiterCoreSignalMatchingTest, perceptionOnlySingleSourceYieldsUnknown)
+TEST(TrafficLightArbiterCoreSignalMatching, perceptionOnlySingleSourceYieldsUnknown)
 {
-  arbiter_.ingest_perception(make_signals(
-    base_time_,
+  auto arbiter = make_arbiter(SourcePriority::CONFIDENCE, /*enable_signal_matching=*/true);
+
+  arbiter.ingest_perception(make_signals(
+    kBaseTime,
     {make_group(
       map_ids::vehicle_a, {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)})}));
 
-  const auto result = arbiter_.arbitrate();
+  const auto result = arbiter.arbitrate();
 
   EXPECT_EQ(observed_color(result.output, map_ids::vehicle_a), TrafficLightElement::UNKNOWN);
 }
@@ -434,31 +420,35 @@ TEST_F(TrafficLightArbiterCoreSignalMatchingTest, perceptionOnlySingleSourceYiel
 // External-only single source: symmetric counterpart — reconciliation is
 // direction-symmetric, so the output for that id is also UNKNOWN when
 // perception is the missing side.
-TEST_F(TrafficLightArbiterCoreSignalMatchingTest, externalOnlySingleSourceYieldsUnknown)
+TEST(TrafficLightArbiterCoreSignalMatching, externalOnlySingleSourceYieldsUnknown)
 {
-  arbiter_.ingest_external(
-    make_signals(
-      base_time_, {make_group(
-                    map_ids::vehicle_a,
-                    {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)})}),
-    base_time_);
+  auto arbiter = make_arbiter(SourcePriority::CONFIDENCE, /*enable_signal_matching=*/true);
 
-  const auto result = arbiter_.arbitrate();
+  arbiter.ingest_external(
+    make_signals(
+      kBaseTime, {make_group(
+                   map_ids::vehicle_a,
+                   {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)})}),
+    kBaseTime);
+
+  const auto result = arbiter.arbitrate();
 
   EXPECT_EQ(observed_color(result.output, map_ids::vehicle_a), TrafficLightElement::UNKNOWN);
 }
 
 // Off-map id is dropped from the output and recorded in off_map_signal_ids.
-TEST_F(TrafficLightArbiterCoreSignalMatchingTest, offMapIdIsDroppedAndReported)
+TEST(TrafficLightArbiterCoreSignalMatching, offMapIdIsDroppedAndReported)
 {
-  arbiter_.ingest_external(
-    make_signals(
-      base_time_, {make_group(
-                    map_ids::off_map_probe,
-                    {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)})}),
-    base_time_);
+  auto arbiter = make_arbiter(SourcePriority::CONFIDENCE, /*enable_signal_matching=*/true);
 
-  const auto result = arbiter_.arbitrate();
+  arbiter.ingest_external(
+    make_signals(
+      kBaseTime, {make_group(
+                   map_ids::off_map_probe,
+                   {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)})}),
+    kBaseTime);
+
+  const auto result = arbiter.arbitrate();
 
   EXPECT_EQ(find_group(result.output, map_ids::off_map_probe), nullptr);
   EXPECT_EQ(result.off_map_signal_ids, std::vector<lanelet::Id>{map_ids::off_map_probe});
@@ -469,40 +459,25 @@ TEST_F(TrafficLightArbiterCoreSignalMatchingTest, offMapIdIsDroppedAndReported)
 //
 // Pedestrian ids reconcile differently from vehicle ids: instead of
 // requiring color/shape agreement between sources, the arbiter picks a
-// winner per the source-priority setting. The fixture parametrizes
-// priority via make_arbiter() so each test pins one priority mode
-// without spawning a fixture per priority.
+// winner per the source-priority setting.
 // ---------------------------------------------------------------------------
-
-class TrafficLightArbiterCorePedestrianTest : public CoreFixtureBase
-{
-protected:
-  TrafficLightArbiterCore make_arbiter(SourcePriority priority)
-  {
-    TrafficLightArbiterCore arbiter(
-      priority, /*enable_signal_matching=*/true, kDefaultExternalDelayTolerance,
-      kDefaultExternalTimeTolerance, kDefaultPerceptionTimeTolerance);
-    arbiter.set_map(shared_map_);
-    return arbiter;
-  }
-};
 
 // EXTERNAL priority: for pedestrian ids the external side wins even when
 // its confidence is lower than perception's.
-TEST_F(TrafficLightArbiterCorePedestrianTest, externalPriorityWinsForPedestrian)
+TEST(TrafficLightArbiterCorePedestrian, externalPriorityWinsForPedestrian)
 {
-  auto arbiter = make_arbiter(SourcePriority::EXTERNAL);
+  auto arbiter = make_arbiter(SourcePriority::EXTERNAL, /*enable_signal_matching=*/true);
 
   arbiter.ingest_external(
     make_signals(
-      base_time_, {make_group(
-                    map_ids::pedestrian,
-                    {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.1f)})}),
-    base_time_);
+      kBaseTime, {make_group(
+                   map_ids::pedestrian,
+                   {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.1f)})}),
+    kBaseTime);
   arbiter.ingest_perception(make_signals(
-    base_time_, {make_group(
-                  map_ids::pedestrian,
-                  {make_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.9f)})}));
+    kBaseTime, {make_group(
+                 map_ids::pedestrian,
+                 {make_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.9f)})}));
 
   const auto result = arbiter.arbitrate();
 
@@ -511,21 +486,20 @@ TEST_F(TrafficLightArbiterCorePedestrianTest, externalPriorityWinsForPedestrian)
 
 // PERCEPTION priority: symmetric counterpart — for pedestrian ids the
 // perception side wins even when its confidence is lower than external's.
-TEST_F(TrafficLightArbiterCorePedestrianTest, perceptionPriorityWinsForPedestrian)
+TEST(TrafficLightArbiterCorePedestrian, perceptionPriorityWinsForPedestrian)
 {
-  auto arbiter = make_arbiter(SourcePriority::PERCEPTION);
+  auto arbiter = make_arbiter(SourcePriority::PERCEPTION, /*enable_signal_matching=*/true);
 
   arbiter.ingest_external(
     make_signals(
-      base_time_, {make_group(
-                    map_ids::pedestrian,
-                    {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.99f)})}),
-    base_time_);
+      kBaseTime, {make_group(
+                   map_ids::pedestrian,
+                   {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.99f)})}),
+    kBaseTime);
   arbiter.ingest_perception(make_signals(
-    base_time_,
-    {make_group(
-      map_ids::pedestrian,
-      {make_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.10f)})}));
+    kBaseTime, {make_group(
+                 map_ids::pedestrian,
+                 {make_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.10f)})}));
 
   const auto result = arbiter.arbitrate();
 
@@ -534,21 +508,20 @@ TEST_F(TrafficLightArbiterCorePedestrianTest, perceptionPriorityWinsForPedestria
 
 // CONFIDENCE mode: for pedestrian ids the arbiter walks each shape and
 // picks the side with the higher confidence.
-TEST_F(TrafficLightArbiterCorePedestrianTest, confidenceModePicksHigherConfidenceForPedestrian)
+TEST(TrafficLightArbiterCorePedestrian, confidenceModePicksHigherConfidenceForPedestrian)
 {
-  auto arbiter = make_arbiter(SourcePriority::CONFIDENCE);
+  auto arbiter = make_arbiter(SourcePriority::CONFIDENCE, /*enable_signal_matching=*/true);
 
   arbiter.ingest_external(
     make_signals(
-      base_time_,
-      {make_group(
-        map_ids::pedestrian,
-        {make_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.6f)})}),
-    base_time_);
+      kBaseTime, {make_group(
+                   map_ids::pedestrian,
+                   {make_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.6f)})}),
+    kBaseTime);
   arbiter.ingest_perception(make_signals(
-    base_time_, {make_group(
-                  map_ids::pedestrian,
-                  {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.9f)})}));
+    kBaseTime, {make_group(
+                 map_ids::pedestrian,
+                 {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.9f)})}));
 
   const auto result = arbiter.arbitrate();
 
@@ -560,14 +533,14 @@ TEST_F(TrafficLightArbiterCorePedestrianTest, confidenceModePicksHigherConfidenc
 // For pedestrian ids the present side flows through unchanged with no
 // UNKNOWN translation, even when source_priority would otherwise prefer
 // the absent side.
-TEST_F(TrafficLightArbiterCorePedestrianTest, singleSourcePedestrianPassesThrough)
+TEST(TrafficLightArbiterCorePedestrian, singleSourcePedestrianPassesThrough)
 {
-  auto arbiter = make_arbiter(SourcePriority::EXTERNAL);
+  auto arbiter = make_arbiter(SourcePriority::EXTERNAL, /*enable_signal_matching=*/true);
 
   arbiter.ingest_perception(make_signals(
-    base_time_, {make_group(
-                  map_ids::pedestrian,
-                  {make_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE)})}));
+    kBaseTime, {make_group(
+                 map_ids::pedestrian,
+                 {make_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE)})}));
 
   const auto result = arbiter.arbitrate();
 
@@ -578,37 +551,24 @@ TEST_F(TrafficLightArbiterCorePedestrianTest, singleSourcePedestrianPassesThroug
 // Mode B: Priority-based — CONFIDENCE (enable_signal_matching=false)
 // ---------------------------------------------------------------------------
 
-class TrafficLightArbiterCoreConfidencePriorityTest : public CoreFixtureBase
-{
-protected:
-  TrafficLightArbiterCoreConfidencePriorityTest()
-  : arbiter_(
-      SourcePriority::CONFIDENCE, /*enable_signal_matching=*/false, kDefaultExternalDelayTolerance,
-      kDefaultExternalTimeTolerance, kDefaultPerceptionTimeTolerance)
-  {
-    arbiter_.set_map(shared_map_);
-  }
-
-  TrafficLightArbiterCore arbiter_;
-};
-
 // CONFIDENCE: same shape from both sources → the higher-confidence element
 // wins (here, perception 0.9 over external 0.7).
-TEST_F(TrafficLightArbiterCoreConfidencePriorityTest, picksHigherConfidenceElement)
+TEST(TrafficLightArbiterCoreConfidencePriority, picksHigherConfidenceElement)
 {
-  arbiter_.ingest_external(
-    make_signals(
-      base_time_,
-      {make_group(
-        map_ids::vehicle_a,
-        {make_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.7f)})}),
-    base_time_);
-  arbiter_.ingest_perception(make_signals(
-    base_time_, {make_group(
-                  map_ids::vehicle_a,
-                  {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.9f)})}));
+  auto arbiter = make_arbiter(SourcePriority::CONFIDENCE, /*enable_signal_matching=*/false);
 
-  const auto result = arbiter_.arbitrate();
+  arbiter.ingest_external(
+    make_signals(
+      kBaseTime, {make_group(
+                   map_ids::vehicle_a,
+                   {make_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.7f)})}),
+    kBaseTime);
+  arbiter.ingest_perception(make_signals(
+    kBaseTime, {make_group(
+                 map_ids::vehicle_a,
+                 {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.9f)})}));
+
+  const auto result = arbiter.arbitrate();
 
   EXPECT_EQ(observed_color(result.output, map_ids::vehicle_a), TrafficLightElement::RED);
 }
@@ -617,20 +577,22 @@ TEST_F(TrafficLightArbiterCoreConfidencePriorityTest, picksHigherConfidenceEleme
 // the same id, the output carries both shapes verbatim. Reconciliation
 // runs independently per shape, so the absence of CIRCLE on the external
 // side does not block external's RIGHT_ARROW and vice versa.
-TEST_F(TrafficLightArbiterCoreConfidencePriorityTest, perShapeUnionFromBothSides)
+TEST(TrafficLightArbiterCoreConfidencePriority, perShapeUnionFromBothSides)
 {
-  arbiter_.ingest_perception(make_signals(
-    base_time_,
+  auto arbiter = make_arbiter(SourcePriority::CONFIDENCE, /*enable_signal_matching=*/false);
+
+  arbiter.ingest_perception(make_signals(
+    kBaseTime,
     {make_group(
       map_ids::vehicle_a, {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)})}));
-  arbiter_.ingest_external(
+  arbiter.ingest_external(
     make_signals(
-      base_time_, {make_group(
-                    map_ids::vehicle_a,
-                    {make_element(TrafficLightElement::GREEN, TrafficLightElement::RIGHT_ARROW)})}),
-    base_time_);
+      kBaseTime, {make_group(
+                   map_ids::vehicle_a,
+                   {make_element(TrafficLightElement::GREEN, TrafficLightElement::RIGHT_ARROW)})}),
+    kBaseTime);
 
-  const auto result = arbiter_.arbitrate();
+  const auto result = arbiter.arbitrate();
 
   EXPECT_EQ(
     observed_color_of_shape(result.output, map_ids::vehicle_a, TrafficLightElement::CIRCLE),
@@ -642,14 +604,16 @@ TEST_F(TrafficLightArbiterCoreConfidencePriorityTest, perShapeUnionFromBothSides
 
 // Perception-only: with no external present, the perception element flows
 // through unchanged regardless of priority mode.
-TEST_F(TrafficLightArbiterCoreConfidencePriorityTest, perceptionOnlyPassesThrough)
+TEST(TrafficLightArbiterCoreConfidencePriority, perceptionOnlyPassesThrough)
 {
-  arbiter_.ingest_perception(make_signals(
-    base_time_, {make_group(
-                  map_ids::vehicle_b,
-                  {make_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE)})}));
+  auto arbiter = make_arbiter(SourcePriority::CONFIDENCE, /*enable_signal_matching=*/false);
 
-  const auto result = arbiter_.arbitrate();
+  arbiter.ingest_perception(make_signals(
+    kBaseTime, {make_group(
+                 map_ids::vehicle_b,
+                 {make_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE)})}));
+
+  const auto result = arbiter.arbitrate();
 
   EXPECT_EQ(observed_color(result.output, map_ids::vehicle_b), TrafficLightElement::GREEN);
 }
@@ -657,16 +621,18 @@ TEST_F(TrafficLightArbiterCoreConfidencePriorityTest, perceptionOnlyPassesThroug
 // Off-map id is dropped before reaching priority selection too. Pins the
 // off-map guard as mode-independent (Signal Matching side has its own
 // counterpart in offMapIdIsDroppedAndReported).
-TEST_F(TrafficLightArbiterCoreConfidencePriorityTest, offMapIdIsDroppedAndReported)
+TEST(TrafficLightArbiterCoreConfidencePriority, offMapIdIsDroppedAndReported)
 {
-  arbiter_.ingest_external(
-    make_signals(
-      base_time_, {make_group(
-                    map_ids::off_map_probe,
-                    {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)})}),
-    base_time_);
+  auto arbiter = make_arbiter(SourcePriority::CONFIDENCE, /*enable_signal_matching=*/false);
 
-  const auto result = arbiter_.arbitrate();
+  arbiter.ingest_external(
+    make_signals(
+      kBaseTime, {make_group(
+                   map_ids::off_map_probe,
+                   {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)})}),
+    kBaseTime);
+
+  const auto result = arbiter.arbitrate();
 
   EXPECT_EQ(find_group(result.output, map_ids::off_map_probe), nullptr);
   EXPECT_EQ(result.off_map_signal_ids, std::vector<lanelet::Id>{map_ids::off_map_probe});
@@ -674,22 +640,24 @@ TEST_F(TrafficLightArbiterCoreConfidencePriorityTest, offMapIdIsDroppedAndReport
 
 // Successive external publishes carrying different ids accumulate in the
 // cache; both end up in the final output with their published colors.
-TEST_F(TrafficLightArbiterCoreConfidencePriorityTest, multipleExternalSourcesAccumulate)
+TEST(TrafficLightArbiterCoreConfidencePriority, multipleExternalSourcesAccumulate)
 {
-  arbiter_.ingest_external(
-    make_signals(
-      base_time_, {make_group(
-                    map_ids::vehicle_a,
-                    {make_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE)})}),
-    base_time_);
-  arbiter_.ingest_external(
-    make_signals(
-      base_time_, {make_group(
-                    map_ids::vehicle_b,
-                    {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)})}),
-    base_time_);
+  auto arbiter = make_arbiter(SourcePriority::CONFIDENCE, /*enable_signal_matching=*/false);
 
-  const auto result = arbiter_.arbitrate();
+  arbiter.ingest_external(
+    make_signals(
+      kBaseTime, {make_group(
+                   map_ids::vehicle_a,
+                   {make_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE)})}),
+    kBaseTime);
+  arbiter.ingest_external(
+    make_signals(
+      kBaseTime, {make_group(
+                   map_ids::vehicle_b,
+                   {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)})}),
+    kBaseTime);
+
+  const auto result = arbiter.arbitrate();
 
   EXPECT_EQ(observed_color(result.output, map_ids::vehicle_a), TrafficLightElement::GREEN);
   EXPECT_EQ(observed_color(result.output, map_ids::vehicle_b), TrafficLightElement::RED);
@@ -699,23 +667,25 @@ TEST_F(TrafficLightArbiterCoreConfidencePriorityTest, multipleExternalSourcesAcc
 // the output group holds both, perception-side first. Mode is irrelevant
 // — the merge happens before mode-specific element reconciliation, so
 // Confidence is a fine host for this pin.
-TEST_F(TrafficLightArbiterCoreConfidencePriorityTest, predictionsFromBothSidesAreMerged)
+TEST(TrafficLightArbiterCoreConfidencePriority, predictionsFromBothSidesAreMerged)
 {
-  arbiter_.ingest_perception(make_signals(
-    base_time_,
+  auto arbiter = make_arbiter(SourcePriority::CONFIDENCE, /*enable_signal_matching=*/false);
+
+  arbiter.ingest_perception(make_signals(
+    kBaseTime,
     {make_group(
       map_ids::vehicle_a, {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)},
       {make_prediction(
-        base_time_, PredictedTrafficLightState::INFORMATION_SOURCE_INTERNAL_ESTIMATION)})}));
-  arbiter_.ingest_external(
+        kBaseTime, PredictedTrafficLightState::INFORMATION_SOURCE_INTERNAL_ESTIMATION)})}));
+  arbiter.ingest_external(
     make_signals(
-      base_time_,
+      kBaseTime,
       {make_group(
         map_ids::vehicle_a, {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)},
-        {make_prediction(base_time_, PredictedTrafficLightState::INFORMATION_SOURCE_V2I)})}),
-    base_time_);
+        {make_prediction(kBaseTime, PredictedTrafficLightState::INFORMATION_SOURCE_V2I)})}),
+    kBaseTime);
 
-  const auto result = arbiter_.arbitrate();
+  const auto result = arbiter.arbitrate();
 
   EXPECT_EQ(
     observed_prediction_source(result.output, map_ids::vehicle_a, 0),
@@ -727,16 +697,18 @@ TEST_F(TrafficLightArbiterCoreConfidencePriorityTest, predictionsFromBothSidesAr
 
 // Perception-only side: when external is silent, the perception side's
 // prediction (with its information_source) still reaches the output.
-TEST_F(TrafficLightArbiterCoreConfidencePriorityTest, perceptionOnlyPredictionPropagates)
+TEST(TrafficLightArbiterCoreConfidencePriority, perceptionOnlyPredictionPropagates)
 {
-  arbiter_.ingest_perception(make_signals(
-    base_time_,
+  auto arbiter = make_arbiter(SourcePriority::CONFIDENCE, /*enable_signal_matching=*/false);
+
+  arbiter.ingest_perception(make_signals(
+    kBaseTime,
     {make_group(
       map_ids::vehicle_a, {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)},
       {make_prediction(
-        base_time_, PredictedTrafficLightState::INFORMATION_SOURCE_INTERNAL_ESTIMATION)})}));
+        kBaseTime, PredictedTrafficLightState::INFORMATION_SOURCE_INTERNAL_ESTIMATION)})}));
 
-  const auto result = arbiter_.arbitrate();
+  const auto result = arbiter.arbitrate();
 
   EXPECT_EQ(
     observed_prediction_source(result.output, map_ids::vehicle_a, 0),
@@ -746,17 +718,19 @@ TEST_F(TrafficLightArbiterCoreConfidencePriorityTest, perceptionOnlyPredictionPr
 // External-only side: symmetric counterpart — when perception is silent,
 // the external side's prediction (with its information_source) reaches
 // the output.
-TEST_F(TrafficLightArbiterCoreConfidencePriorityTest, externalOnlyPredictionPropagates)
+TEST(TrafficLightArbiterCoreConfidencePriority, externalOnlyPredictionPropagates)
 {
-  arbiter_.ingest_external(
+  auto arbiter = make_arbiter(SourcePriority::CONFIDENCE, /*enable_signal_matching=*/false);
+
+  arbiter.ingest_external(
     make_signals(
-      base_time_,
+      kBaseTime,
       {make_group(
         map_ids::vehicle_a, {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)},
-        {make_prediction(base_time_, PredictedTrafficLightState::INFORMATION_SOURCE_V2I)})}),
-    base_time_);
+        {make_prediction(kBaseTime, PredictedTrafficLightState::INFORMATION_SOURCE_V2I)})}),
+    kBaseTime);
 
-  const auto result = arbiter_.arbitrate();
+  const auto result = arbiter.arbitrate();
 
   EXPECT_EQ(
     observed_prediction_source(result.output, map_ids::vehicle_a, 0),
@@ -767,53 +741,42 @@ TEST_F(TrafficLightArbiterCoreConfidencePriorityTest, externalOnlyPredictionProp
 // Mode C: Priority-based — EXTERNAL
 // ---------------------------------------------------------------------------
 
-class TrafficLightArbiterCoreExternalPriorityTest : public CoreFixtureBase
-{
-protected:
-  TrafficLightArbiterCoreExternalPriorityTest()
-  : arbiter_(
-      SourcePriority::EXTERNAL, /*enable_signal_matching=*/false, kDefaultExternalDelayTolerance,
-      kDefaultExternalTimeTolerance, kDefaultPerceptionTimeTolerance)
-  {
-    arbiter_.set_map(shared_map_);
-  }
-
-  TrafficLightArbiterCore arbiter_;
-};
-
 // External wins despite lower confidence: the EXTERNAL setting forces
 // the external side to win over a higher-confidence perception.
-TEST_F(TrafficLightArbiterCoreExternalPriorityTest, externalPriorityOverridesConfidence)
+TEST(TrafficLightArbiterCoreExternalPriority, externalPriorityOverridesConfidence)
 {
-  arbiter_.ingest_external(
-    make_signals(
-      base_time_, {make_group(
-                    map_ids::vehicle_a,
-                    {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.10f)})}),
-    base_time_);
-  arbiter_.ingest_perception(make_signals(
-    base_time_,
-    {make_group(
-      map_ids::vehicle_a,
-      {make_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.99f)})}));
+  auto arbiter = make_arbiter(SourcePriority::EXTERNAL, /*enable_signal_matching=*/false);
 
-  const auto result = arbiter_.arbitrate();
+  arbiter.ingest_external(
+    make_signals(
+      kBaseTime, {make_group(
+                   map_ids::vehicle_a,
+                   {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.10f)})}),
+    kBaseTime);
+  arbiter.ingest_perception(make_signals(
+    kBaseTime, {make_group(
+                 map_ids::vehicle_a,
+                 {make_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.99f)})}));
+
+  const auto result = arbiter.arbitrate();
 
   EXPECT_EQ(observed_color(result.output, map_ids::vehicle_a), TrafficLightElement::RED);
 }
 
 // External-only: the EXTERNAL setting has no effect when only one source
 // is present.
-TEST_F(TrafficLightArbiterCoreExternalPriorityTest, externalOnlyPassesThrough)
+TEST(TrafficLightArbiterCoreExternalPriority, externalOnlyPassesThrough)
 {
-  arbiter_.ingest_external(
-    make_signals(
-      base_time_, {make_group(
-                    map_ids::vehicle_a,
-                    {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)})}),
-    base_time_);
+  auto arbiter = make_arbiter(SourcePriority::EXTERNAL, /*enable_signal_matching=*/false);
 
-  const auto result = arbiter_.arbitrate();
+  arbiter.ingest_external(
+    make_signals(
+      kBaseTime, {make_group(
+                   map_ids::vehicle_a,
+                   {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)})}),
+    kBaseTime);
+
+  const auto result = arbiter.arbitrate();
 
   EXPECT_EQ(observed_color(result.output, map_ids::vehicle_a), TrafficLightElement::RED);
 }
@@ -821,14 +784,16 @@ TEST_F(TrafficLightArbiterCoreExternalPriorityTest, externalOnlyPassesThrough)
 // Perception-only with EXTERNAL priority: with no external side present,
 // the EXTERNAL setting has nothing to apply to and the perception element
 // reaches the output.
-TEST_F(TrafficLightArbiterCoreExternalPriorityTest, perceptionOnlyPassesThrough)
+TEST(TrafficLightArbiterCoreExternalPriority, perceptionOnlyPassesThrough)
 {
-  arbiter_.ingest_perception(make_signals(
-    base_time_, {make_group(
-                  map_ids::vehicle_a,
-                  {make_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE)})}));
+  auto arbiter = make_arbiter(SourcePriority::EXTERNAL, /*enable_signal_matching=*/false);
 
-  const auto result = arbiter_.arbitrate();
+  arbiter.ingest_perception(make_signals(
+    kBaseTime, {make_group(
+                 map_ids::vehicle_a,
+                 {make_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE)})}));
+
+  const auto result = arbiter.arbitrate();
 
   EXPECT_EQ(observed_color(result.output, map_ids::vehicle_a), TrafficLightElement::GREEN);
 }
@@ -837,88 +802,78 @@ TEST_F(TrafficLightArbiterCoreExternalPriorityTest, perceptionOnlyPassesThrough)
 // Mode D: Priority-based — PERCEPTION
 // ---------------------------------------------------------------------------
 
-class TrafficLightArbiterCorePerceptionPriorityTest : public CoreFixtureBase
-{
-protected:
-  TrafficLightArbiterCorePerceptionPriorityTest()
-  : arbiter_(
-      SourcePriority::PERCEPTION, /*enable_signal_matching=*/false, kDefaultExternalDelayTolerance,
-      kDefaultExternalTimeTolerance, kDefaultPerceptionTimeTolerance)
-  {
-    arbiter_.set_map(shared_map_);
-  }
-
-  TrafficLightArbiterCore arbiter_;
-};
-
 // Perception wins despite lower confidence: symmetric counterpart of the
 // EXTERNAL override case.
-TEST_F(TrafficLightArbiterCorePerceptionPriorityTest, perceptionPriorityOverridesConfidence)
+TEST(TrafficLightArbiterCorePerceptionPriority, perceptionPriorityOverridesConfidence)
 {
-  arbiter_.ingest_external(
-    make_signals(
-      base_time_, {make_group(
-                    map_ids::vehicle_a,
-                    {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.99f)})}),
-    base_time_);
-  arbiter_.ingest_perception(make_signals(
-    base_time_,
-    {make_group(
-      map_ids::vehicle_a,
-      {make_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.10f)})}));
+  auto arbiter = make_arbiter(SourcePriority::PERCEPTION, /*enable_signal_matching=*/false);
 
-  const auto result = arbiter_.arbitrate();
+  arbiter.ingest_external(
+    make_signals(
+      kBaseTime, {make_group(
+                   map_ids::vehicle_a,
+                   {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.99f)})}),
+    kBaseTime);
+  arbiter.ingest_perception(make_signals(
+    kBaseTime, {make_group(
+                 map_ids::vehicle_a,
+                 {make_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.10f)})}));
+
+  const auto result = arbiter.arbitrate();
 
   EXPECT_EQ(observed_color(result.output, map_ids::vehicle_a), TrafficLightElement::GREEN);
 }
 
 // Perception-only: the PERCEPTION setting has no effect when only one
 // source is present.
-TEST_F(TrafficLightArbiterCorePerceptionPriorityTest, perceptionOnlyPassesThrough)
+TEST(TrafficLightArbiterCorePerceptionPriority, perceptionOnlyPassesThrough)
 {
-  arbiter_.ingest_perception(make_signals(
-    base_time_, {make_group(
-                  map_ids::vehicle_a,
-                  {make_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE)})}));
+  auto arbiter = make_arbiter(SourcePriority::PERCEPTION, /*enable_signal_matching=*/false);
 
-  const auto result = arbiter_.arbitrate();
+  arbiter.ingest_perception(make_signals(
+    kBaseTime, {make_group(
+                 map_ids::vehicle_a,
+                 {make_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE)})}));
+
+  const auto result = arbiter.arbitrate();
 
   EXPECT_EQ(observed_color(result.output, map_ids::vehicle_a), TrafficLightElement::GREEN);
 }
 
 // External-only with PERCEPTION priority: symmetric counterpart — external
 // is the only source, so it passes through.
-TEST_F(TrafficLightArbiterCorePerceptionPriorityTest, externalOnlyPassesThrough)
+TEST(TrafficLightArbiterCorePerceptionPriority, externalOnlyPassesThrough)
 {
-  arbiter_.ingest_external(
-    make_signals(
-      base_time_, {make_group(
-                    map_ids::vehicle_a,
-                    {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)})}),
-    base_time_);
+  auto arbiter = make_arbiter(SourcePriority::PERCEPTION, /*enable_signal_matching=*/false);
 
-  const auto result = arbiter_.arbitrate();
+  arbiter.ingest_external(
+    make_signals(
+      kBaseTime, {make_group(
+                   map_ids::vehicle_a,
+                   {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)})}),
+    kBaseTime);
+
+  const auto result = arbiter.arbitrate();
 
   EXPECT_EQ(observed_color(result.output, map_ids::vehicle_a), TrafficLightElement::RED);
 }
 
 // ---------------------------------------------------------------------------
-// Boundary: mode-agnostic ground truth. Kept as free TEST() because the
-// scenario does not depend on which mode the Core runs in.
+// Boundary: map presence boundaries — built outside make_arbiter() because
+// each test needs a non-default map configuration (no map, or empty map).
 // ---------------------------------------------------------------------------
 
 // arbitrate() before set_map() yields output=std::nullopt. The Node
 // distinguishes "no output" (skip publish) from "empty output" (publish
 // with zero groups), so the optional must stay disengaged here.
-TEST(TrafficLightArbiterCoreBoundaryTest, arbitrateWithoutMapProducesNoOutput)
+TEST(TrafficLightArbiterCoreBoundary, arbitrateWithoutMapProducesNoOutput)
 {
   TrafficLightArbiterCore unconfigured(
     SourcePriority::CONFIDENCE, /*enable_signal_matching=*/false, kDefaultExternalDelayTolerance,
     kDefaultExternalTimeTolerance, kDefaultPerceptionTimeTolerance);
 
-  const rclcpp::Time base_time{make_base_time()};
   unconfigured.ingest_perception(make_signals(
-    base_time,
+    kBaseTime,
     {make_group(
       map_ids::vehicle_a, {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)})}));
 
@@ -930,16 +885,15 @@ TEST(TrafficLightArbiterCoreBoundaryTest, arbitrateWithoutMapProducesNoOutput)
 // A map with no TrafficLight regulatory elements yields an output that is
 // engaged but empty — the counterpart to the no-map case above. The Node
 // publishes a zero-group message here instead of skipping the publish.
-TEST(TrafficLightArbiterCoreBoundaryTest, emptyMapProducesEmptyOutput)
+TEST(TrafficLightArbiterCoreBoundary, emptyMapProducesEmptyOutput)
 {
   TrafficLightArbiterCore arbiter(
     SourcePriority::CONFIDENCE, /*enable_signal_matching=*/false, kDefaultExternalDelayTolerance,
     kDefaultExternalTimeTolerance, kDefaultPerceptionTimeTolerance);
   arbiter.set_map(build_empty_map());
 
-  const rclcpp::Time base_time{make_base_time()};
   arbiter.ingest_perception(make_signals(
-    base_time,
+    kBaseTime,
     {make_group(
       map_ids::vehicle_a, {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)})}));
 
@@ -956,39 +910,27 @@ TEST(TrafficLightArbiterCoreBoundaryTest, emptyMapProducesEmptyOutput)
 // plus the prediction side effect.
 // ---------------------------------------------------------------------------
 
-class TrafficLightArbiterCorePerceptionStalenessTest : public CoreFixtureBase
-{
-protected:
-  TrafficLightArbiterCorePerceptionStalenessTest()
-  : arbiter_(
-      SourcePriority::CONFIDENCE, /*enable_signal_matching=*/false, kDefaultExternalDelayTolerance,
-      kDefaultExternalTimeTolerance, kDefaultPerceptionTimeTolerance)
-  {
-    arbiter_.set_map(shared_map_);
-  }
-
-  TrafficLightArbiterCore arbiter_;
-};
-
 // Outside tolerance (perception is older than tolerance allows): perception
 // is excluded from arbitrate() so external alone reaches the output.
-TEST_F(TrafficLightArbiterCorePerceptionStalenessTest, stalePerceptionIsExcludedFromOutput)
+TEST(TrafficLightArbiterCorePerceptionStaleness, stalePerceptionIsExcludedFromOutput)
 {
-  const auto t_perception =
-    base_time_ - rclcpp::Duration::from_seconds(kDefaultPerceptionTimeTolerance + 1.0);
+  auto arbiter = make_arbiter(SourcePriority::CONFIDENCE, /*enable_signal_matching=*/false);
 
-  arbiter_.ingest_perception(make_signals(
+  const auto t_perception =
+    kBaseTime - rclcpp::Duration::from_seconds(kDefaultPerceptionTimeTolerance + 1.0);
+
+  arbiter.ingest_perception(make_signals(
     t_perception,
     {make_group(
       map_ids::vehicle_a, {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)})}));
-  arbiter_.ingest_external(
+  arbiter.ingest_external(
     make_signals(
-      base_time_, {make_group(
-                    map_ids::vehicle_a,
-                    {make_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE)})}),
-    base_time_);
+      kBaseTime, {make_group(
+                   map_ids::vehicle_a,
+                   {make_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE)})}),
+    kBaseTime);
 
-  const auto result = arbiter_.arbitrate();
+  const auto result = arbiter.arbitrate();
 
   EXPECT_EQ(observed_color(result.output, map_ids::vehicle_a), TrafficLightElement::GREEN);
 }
@@ -996,31 +938,32 @@ TEST_F(TrafficLightArbiterCorePerceptionStalenessTest, stalePerceptionIsExcluded
 // Inside tolerance (perception is older but only by half the budget):
 // perception remains effective, so CONFIDENCE picks the higher-confidence
 // perception element over the lower-confidence external.
-TEST_F(TrafficLightArbiterCorePerceptionStalenessTest, freshPerceptionRemainsEffective)
+TEST(TrafficLightArbiterCorePerceptionStaleness, freshPerceptionRemainsEffective)
 {
-  const auto t_perception =
-    base_time_ - rclcpp::Duration::from_seconds(0.5 * kDefaultPerceptionTimeTolerance);
+  auto arbiter = make_arbiter(SourcePriority::CONFIDENCE, /*enable_signal_matching=*/false);
 
-  arbiter_.ingest_perception(make_signals(
+  const auto t_perception =
+    kBaseTime - rclcpp::Duration::from_seconds(0.5 * kDefaultPerceptionTimeTolerance);
+
+  arbiter.ingest_perception(make_signals(
     t_perception, {make_group(
                     map_ids::vehicle_a,
                     {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.9f)})}));
-  arbiter_.ingest_external(
+  arbiter.ingest_external(
     make_signals(
-      base_time_,
-      {make_group(
-        map_ids::vehicle_a,
-        {make_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.7f)})}),
-    base_time_);
+      kBaseTime, {make_group(
+                   map_ids::vehicle_a,
+                   {make_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.7f)})}),
+    kBaseTime);
 
-  const auto result = arbiter_.arbitrate();
+  const auto result = arbiter.arbitrate();
 
   EXPECT_EQ(observed_color(result.output, map_ids::vehicle_a), TrafficLightElement::RED);
 }
 
 // External is silent: with no external stamp to compare against, the
 // staleness check has nothing to evaluate and the perception side
-// reaches the output even when its stamp lags base_time by far more
+// reaches the output even when its stamp lags kBaseTime by far more
 // than the tolerance.
 //
 // This asymmetry predates the Core extraction — only the external side
@@ -1032,17 +975,19 @@ TEST_F(TrafficLightArbiterCorePerceptionStalenessTest, freshPerceptionRemainsEff
 // on the bus indefinitely when no external source is publishing) is an
 // open question. This test pins the current behaviour; it does not
 // endorse it.
-TEST_F(TrafficLightArbiterCorePerceptionStalenessTest, perceptionAloneIsNeverStale)
+TEST(TrafficLightArbiterCorePerceptionStaleness, perceptionAloneIsNeverStale)
 {
-  const auto t_perception =
-    base_time_ - rclcpp::Duration::from_seconds(kDefaultPerceptionTimeTolerance + 10.0);
+  auto arbiter = make_arbiter(SourcePriority::CONFIDENCE, /*enable_signal_matching=*/false);
 
-  arbiter_.ingest_perception(make_signals(
+  const auto t_perception =
+    kBaseTime - rclcpp::Duration::from_seconds(kDefaultPerceptionTimeTolerance + 10.0);
+
+  arbiter.ingest_perception(make_signals(
     t_perception,
     {make_group(
       map_ids::vehicle_a, {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)})}));
 
-  const auto result = arbiter_.arbitrate();
+  const auto result = arbiter.arbitrate();
 
   EXPECT_EQ(observed_color(result.output, map_ids::vehicle_a), TrafficLightElement::RED);
 }
@@ -1052,23 +997,25 @@ TEST_F(TrafficLightArbiterCorePerceptionStalenessTest, perceptionAloneIsNeverSta
 // that the external side does not cover. With perception carrying
 // vehicle_a (stale) and external carrying vehicle_b (fresh), vehicle_a
 // must be absent from the output and vehicle_b must remain present.
-TEST_F(TrafficLightArbiterCorePerceptionStalenessTest, stalenessDropsEntirePerceptionMessage)
+TEST(TrafficLightArbiterCorePerceptionStaleness, stalenessDropsEntirePerceptionMessage)
 {
-  const auto t_perception =
-    base_time_ - rclcpp::Duration::from_seconds(kDefaultPerceptionTimeTolerance + 1.0);
+  auto arbiter = make_arbiter(SourcePriority::CONFIDENCE, /*enable_signal_matching=*/false);
 
-  arbiter_.ingest_perception(make_signals(
+  const auto t_perception =
+    kBaseTime - rclcpp::Duration::from_seconds(kDefaultPerceptionTimeTolerance + 1.0);
+
+  arbiter.ingest_perception(make_signals(
     t_perception,
     {make_group(
       map_ids::vehicle_a, {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)})}));
-  arbiter_.ingest_external(
+  arbiter.ingest_external(
     make_signals(
-      base_time_, {make_group(
-                    map_ids::vehicle_b,
-                    {make_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE)})}),
-    base_time_);
+      kBaseTime, {make_group(
+                   map_ids::vehicle_b,
+                   {make_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE)})}),
+    kBaseTime);
 
-  const auto result = arbiter_.arbitrate();
+  const auto result = arbiter.arbitrate();
 
   EXPECT_EQ(find_group(result.output, map_ids::vehicle_a), nullptr);
   EXPECT_NE(find_group(result.output, map_ids::vehicle_b), nullptr);
@@ -1076,26 +1023,28 @@ TEST_F(TrafficLightArbiterCorePerceptionStalenessTest, stalenessDropsEntirePerce
 
 // Stale perception drops its predictions from the merge too, so only the
 // external-side prediction (V2I) survives in the output group.
-TEST_F(TrafficLightArbiterCorePerceptionStalenessTest, stalePerceptionPredictionsAreSkipped)
+TEST(TrafficLightArbiterCorePerceptionStaleness, stalePerceptionPredictionsAreSkipped)
 {
-  const auto t_perception =
-    base_time_ - rclcpp::Duration::from_seconds(kDefaultPerceptionTimeTolerance + 1.0);
+  auto arbiter = make_arbiter(SourcePriority::CONFIDENCE, /*enable_signal_matching=*/false);
 
-  arbiter_.ingest_perception(make_signals(
+  const auto t_perception =
+    kBaseTime - rclcpp::Duration::from_seconds(kDefaultPerceptionTimeTolerance + 1.0);
+
+  arbiter.ingest_perception(make_signals(
     t_perception,
     {make_group(
       map_ids::vehicle_a, {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)},
       {make_prediction(
         t_perception, PredictedTrafficLightState::INFORMATION_SOURCE_INTERNAL_ESTIMATION)})}));
-  arbiter_.ingest_external(
+  arbiter.ingest_external(
     make_signals(
-      base_time_,
+      kBaseTime,
       {make_group(
         map_ids::vehicle_a, {make_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE)},
-        {make_prediction(base_time_, PredictedTrafficLightState::INFORMATION_SOURCE_V2I)})}),
-    base_time_);
+        {make_prediction(kBaseTime, PredictedTrafficLightState::INFORMATION_SOURCE_V2I)})}),
+    kBaseTime);
 
-  const auto result = arbiter_.arbitrate();
+  const auto result = arbiter.arbitrate();
 
   EXPECT_EQ(
     observed_prediction_source(result.output, map_ids::vehicle_a, 0),
@@ -1110,74 +1059,66 @@ TEST_F(TrafficLightArbiterCorePerceptionStalenessTest, stalePerceptionPrediction
 // selection.
 // ---------------------------------------------------------------------------
 
-class TrafficLightArbiterCoreLatestInputTimeTest : public CoreFixtureBase
+TEST(TrafficLightArbiterCoreLatestInputTime, takesNewerOfPerceptionAndExternal)
 {
-protected:
-  TrafficLightArbiterCoreLatestInputTimeTest()
-  : arbiter_(
-      SourcePriority::CONFIDENCE, /*enable_signal_matching=*/false, kDefaultExternalDelayTolerance,
-      kDefaultExternalTimeTolerance, kDefaultPerceptionTimeTolerance)
-  {
-    arbiter_.set_map(shared_map_);
-  }
+  auto arbiter = make_arbiter(SourcePriority::CONFIDENCE, /*enable_signal_matching=*/false);
 
-  TrafficLightArbiterCore arbiter_;
-};
+  const auto t_external_newer = kBaseTime + rclcpp::Duration::from_seconds(0.5);
 
-TEST_F(TrafficLightArbiterCoreLatestInputTimeTest, takesNewerOfPerceptionAndExternal)
-{
-  const auto t_external_newer = base_time_ + rclcpp::Duration::from_seconds(0.5);
-
-  arbiter_.ingest_perception(make_signals(
-    base_time_,
+  arbiter.ingest_perception(make_signals(
+    kBaseTime,
     {make_group(
       map_ids::vehicle_a, {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)})}));
-  arbiter_.ingest_external(
+  arbiter.ingest_external(
     make_signals(
       t_external_newer, {make_group(
                           map_ids::vehicle_a,
                           {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)})}),
     t_external_newer);
 
-  const auto result = arbiter_.arbitrate();
+  const auto result = arbiter.arbitrate();
 
   EXPECT_EQ(result.latest_input_time, t_external_newer);
 }
 
 // Symmetric counterpart: when perception is the newer source, its stamp
 // wins even though external is also stored.
-TEST_F(TrafficLightArbiterCoreLatestInputTimeTest, perceptionWinsWhenNewer)
+TEST(TrafficLightArbiterCoreLatestInputTime, perceptionWinsWhenNewer)
 {
-  const auto t_perception_newer = base_time_ + rclcpp::Duration::from_seconds(0.3);
+  auto arbiter = make_arbiter(SourcePriority::CONFIDENCE, /*enable_signal_matching=*/false);
 
-  arbiter_.ingest_external(
+  const auto t_perception_newer = kBaseTime + rclcpp::Duration::from_seconds(0.3);
+
+  arbiter.ingest_external(
     make_signals(
-      base_time_, {make_group(
-                    map_ids::vehicle_a,
-                    {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)})}),
-    base_time_);
-  arbiter_.ingest_perception(make_signals(
+      kBaseTime, {make_group(
+                   map_ids::vehicle_a,
+                   {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)})}),
+    kBaseTime);
+  arbiter.ingest_perception(make_signals(
     t_perception_newer,
     {make_group(
       map_ids::vehicle_a, {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)})}));
 
-  const auto result = arbiter_.arbitrate();
+  const auto result = arbiter.arbitrate();
 
   EXPECT_EQ(result.latest_input_time, t_perception_newer);
 }
 
 // External is silent: with no external stamps to compare against,
 // latest_input_time falls back to the perception stamp.
-TEST_F(TrafficLightArbiterCoreLatestInputTimeTest, perceptionStampWhenExternalIsSilent)
+TEST(TrafficLightArbiterCoreLatestInputTime, perceptionStampWhenExternalIsSilent)
 {
-  const auto t_perception = base_time_ + rclcpp::Duration::from_seconds(0.5);
+  auto arbiter = make_arbiter(SourcePriority::CONFIDENCE, /*enable_signal_matching=*/false);
 
-  arbiter_.ingest_perception(make_signals(
+  const auto t_perception = kBaseTime + rclcpp::Duration::from_seconds(0.5);
+
+  arbiter.ingest_perception(make_signals(
     t_perception,
     {make_group(
       map_ids::vehicle_a, {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)})}));
 
-  const auto result = arbiter_.arbitrate();
+  const auto result = arbiter.arbitrate();
 
   EXPECT_EQ(result.latest_input_time, t_perception);
 }
@@ -1188,50 +1129,40 @@ TEST_F(TrafficLightArbiterCoreLatestInputTimeTest, perceptionStampWhenExternalIs
 // ingest_perception's expired-entries return.
 // ---------------------------------------------------------------------------
 
-class TrafficLightArbiterCoreTimingTest : public CoreFixtureBase
-{
-protected:
-  TrafficLightArbiterCoreTimingTest()
-  : arbiter_(
-      SourcePriority::CONFIDENCE, /*enable_signal_matching=*/false, kDefaultExternalDelayTolerance,
-      kDefaultExternalTimeTolerance, kDefaultPerceptionTimeTolerance)
-  {
-    arbiter_.set_map(shared_map_);
-  }
-
-  TrafficLightArbiterCore arbiter_;
-};
-
 // A stamp close enough to current_time (within external_delay_tolerance)
 // is accepted.
-TEST_F(TrafficLightArbiterCoreTimingTest, ingestExternalAcceptsStampsWithinTolerance)
+TEST(TrafficLightArbiterCoreTiming, ingestExternalAcceptsStampsWithinTolerance)
 {
-  const auto t_past_within =
-    base_time_ - rclcpp::Duration::from_seconds(kDefaultExternalDelayTolerance - 1.0);
+  auto arbiter = make_arbiter(SourcePriority::CONFIDENCE, /*enable_signal_matching=*/false);
 
-  const auto result = arbiter_.ingest_external(
+  const auto t_past_within =
+    kBaseTime - rclcpp::Duration::from_seconds(kDefaultExternalDelayTolerance - 1.0);
+
+  const auto result = arbiter.ingest_external(
     make_signals(
       t_past_within, {make_group(
                        map_ids::vehicle_a,
                        {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)})}),
-    base_time_);
+    kBaseTime);
 
   EXPECT_TRUE(result.accepted);
 }
 
 // A stamp older than current_time by more than external_delay_tolerance
 // is rejected.
-TEST_F(TrafficLightArbiterCoreTimingTest, ingestExternalRejectsTooOldStamps)
+TEST(TrafficLightArbiterCoreTiming, ingestExternalRejectsTooOldStamps)
 {
-  const auto t_past_beyond =
-    base_time_ - rclcpp::Duration::from_seconds(kDefaultExternalDelayTolerance + 1.0);
+  auto arbiter = make_arbiter(SourcePriority::CONFIDENCE, /*enable_signal_matching=*/false);
 
-  const auto result = arbiter_.ingest_external(
+  const auto t_past_beyond =
+    kBaseTime - rclcpp::Duration::from_seconds(kDefaultExternalDelayTolerance + 1.0);
+
+  const auto result = arbiter.ingest_external(
     make_signals(
       t_past_beyond, {make_group(
                        map_ids::vehicle_a,
                        {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)})}),
-    base_time_);
+    kBaseTime);
 
   EXPECT_FALSE(result.accepted);
 }
@@ -1239,17 +1170,19 @@ TEST_F(TrafficLightArbiterCoreTimingTest, ingestExternalRejectsTooOldStamps)
 // A stamp ahead of current_time by more than external_delay_tolerance is
 // also rejected — the tolerance is applied symmetrically in both
 // directions.
-TEST_F(TrafficLightArbiterCoreTimingTest, ingestExternalRejectsTooFutureStamps)
+TEST(TrafficLightArbiterCoreTiming, ingestExternalRejectsTooFutureStamps)
 {
-  const auto t_future_beyond =
-    base_time_ + rclcpp::Duration::from_seconds(kDefaultExternalDelayTolerance + 1.0);
+  auto arbiter = make_arbiter(SourcePriority::CONFIDENCE, /*enable_signal_matching=*/false);
 
-  const auto result = arbiter_.ingest_external(
+  const auto t_future_beyond =
+    kBaseTime + rclcpp::Duration::from_seconds(kDefaultExternalDelayTolerance + 1.0);
+
+  const auto result = arbiter.ingest_external(
     make_signals(
       t_future_beyond, {make_group(
                          map_ids::vehicle_a,
                          {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)})}),
-    base_time_);
+    kBaseTime);
 
   EXPECT_FALSE(result.accepted);
 }
@@ -1258,18 +1191,20 @@ TEST_F(TrafficLightArbiterCoreTimingTest, ingestExternalRejectsTooFutureStamps)
 // external_time_tolerance after a stored external evicts that entry,
 // and ingest_perception's return value carries the eviction details
 // (used by the Node for DEBUG logging).
-TEST_F(TrafficLightArbiterCoreTimingTest, ingestPerceptionReportsExpiredExternalEntry)
+TEST(TrafficLightArbiterCoreTiming, ingestPerceptionReportsExpiredExternalEntry)
 {
-  arbiter_.ingest_external(
-    make_signals(
-      base_time_, {make_group(
-                    map_ids::vehicle_a,
-                    {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)})}),
-    base_time_);
-  const auto t_perception =
-    base_time_ + rclcpp::Duration::from_seconds(kDefaultExternalTimeTolerance + 1.0);
+  auto arbiter = make_arbiter(SourcePriority::CONFIDENCE, /*enable_signal_matching=*/false);
 
-  const auto expired = arbiter_.ingest_perception(make_signals(
+  arbiter.ingest_external(
+    make_signals(
+      kBaseTime, {make_group(
+                   map_ids::vehicle_a,
+                   {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)})}),
+    kBaseTime);
+  const auto t_perception =
+    kBaseTime + rclcpp::Duration::from_seconds(kDefaultExternalTimeTolerance + 1.0);
+
+  const auto expired = arbiter.ingest_perception(make_signals(
     t_perception, {make_group(
                     map_ids::vehicle_b,
                     {make_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE)})}));
@@ -1282,22 +1217,24 @@ TEST_F(TrafficLightArbiterCoreTimingTest, ingestPerceptionReportsExpiredExternal
 // Sweep-on-ingest downstream effect: an external entry evicted by the
 // sweep is absent from the next arbitration output, even when the
 // triggering perception covers a different id.
-TEST_F(TrafficLightArbiterCoreTimingTest, evictedExternalEntryAbsentFromOutput)
+TEST(TrafficLightArbiterCoreTiming, evictedExternalEntryAbsentFromOutput)
 {
-  arbiter_.ingest_external(
+  auto arbiter = make_arbiter(SourcePriority::CONFIDENCE, /*enable_signal_matching=*/false);
+
+  arbiter.ingest_external(
     make_signals(
-      base_time_, {make_group(
-                    map_ids::vehicle_a,
-                    {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)})}),
-    base_time_);
+      kBaseTime, {make_group(
+                   map_ids::vehicle_a,
+                   {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)})}),
+    kBaseTime);
   const auto t_perception =
-    base_time_ + rclcpp::Duration::from_seconds(kDefaultExternalTimeTolerance + 1.0);
-  arbiter_.ingest_perception(make_signals(
+    kBaseTime + rclcpp::Duration::from_seconds(kDefaultExternalTimeTolerance + 1.0);
+  arbiter.ingest_perception(make_signals(
     t_perception, {make_group(
                     map_ids::vehicle_b,
                     {make_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE)})}));
 
-  const auto result = arbiter_.arbitrate();
+  const auto result = arbiter.arbitrate();
 
   EXPECT_EQ(find_group(result.output, map_ids::vehicle_a), nullptr);
 }

--- a/perception/autoware_traffic_light_arbiter/test/test_traffic_light_arbiter_core.cpp
+++ b/perception/autoware_traffic_light_arbiter/test/test_traffic_light_arbiter_core.cpp
@@ -157,17 +157,6 @@ TrafficLightElement make_element(uint8_t color, uint8_t shape, float confidence 
   return element;
 }
 
-TrafficLightGroup make_group(
-  lanelet::Id id, std::vector<TrafficLightElement> elements,
-  std::vector<PredictedTrafficLightState> predictions = {})
-{
-  TrafficLightGroup group;
-  group.traffic_light_group_id = id;
-  group.elements = std::move(elements);
-  group.predictions = std::move(predictions);
-  return group;
-}
-
 // Predictions ride unmodified through arbitrate(), so the body fields
 // chosen here only need to be syntactically valid.
 PredictedTrafficLightState make_prediction(
@@ -184,12 +173,22 @@ PredictedTrafficLightState make_prediction(
   return prediction;
 }
 
-TrafficLightGroupArray make_signals(
-  const rclcpp::Time & stamp, std::vector<TrafficLightGroup> groups)
+// Builds a one-group TrafficLightGroupArray. Each test exercises one id per
+// ingest call, so collapsing the previous make_signals + make_group pair
+// into a single flat helper removes a verbose layer of nested braces at
+// every call site.
+TrafficLightGroupArray make_signal(
+  const rclcpp::Time & stamp, lanelet::Id id, std::vector<TrafficLightElement> elements,
+  std::vector<PredictedTrafficLightState> predictions = {})
 {
+  TrafficLightGroup group;
+  group.traffic_light_group_id = id;
+  group.elements = std::move(elements);
+  group.predictions = std::move(predictions);
+
   TrafficLightGroupArray signals;
-  signals.traffic_light_groups = std::move(groups);
   signals.stamp = stamp;
+  signals.traffic_light_groups = {std::move(group)};
   return signals;
 }
 
@@ -326,10 +325,9 @@ TEST(TrafficLightArbiterCoreSignalMatching, matchedSignalsPassThrough)
   auto arbiter = make_arbiter(CONFIDENCE, /*enable_signal_matching=*/true);
 
   arbiter.ingest_external(
-    make_signals(base_time, {make_group(map_ids::vehicle_a, {make_element(RED, CIRCLE)})}),
-    base_time);
+    make_signal(base_time, map_ids::vehicle_a, {make_element(RED, CIRCLE)}), base_time);
   arbiter.ingest_perception(
-    make_signals(base_time, {make_group(map_ids::vehicle_a, {make_element(RED, CIRCLE)})}));
+    make_signal(base_time, map_ids::vehicle_a, {make_element(RED, CIRCLE)}));
 
   const auto result = arbiter.arbitrate();
 
@@ -346,10 +344,9 @@ TEST(TrafficLightArbiterCoreSignalMatching, differingConfidencesStillMatch)
   auto arbiter = make_arbiter(CONFIDENCE, /*enable_signal_matching=*/true);
 
   arbiter.ingest_external(
-    make_signals(base_time, {make_group(map_ids::vehicle_a, {make_element(RED, CIRCLE, 0.10f)})}),
-    base_time);
+    make_signal(base_time, map_ids::vehicle_a, {make_element(RED, CIRCLE, 0.10f)}), base_time);
   arbiter.ingest_perception(
-    make_signals(base_time, {make_group(map_ids::vehicle_a, {make_element(RED, CIRCLE, 0.90f)})}));
+    make_signal(base_time, map_ids::vehicle_a, {make_element(RED, CIRCLE, 0.90f)}));
 
   const auto result = arbiter.arbitrate();
 
@@ -364,10 +361,9 @@ TEST(TrafficLightArbiterCoreSignalMatching, colorMismatchProducesUnknown)
   auto arbiter = make_arbiter(CONFIDENCE, /*enable_signal_matching=*/true);
 
   arbiter.ingest_external(
-    make_signals(base_time, {make_group(map_ids::vehicle_b, {make_element(GREEN, CIRCLE)})}),
-    base_time);
+    make_signal(base_time, map_ids::vehicle_b, {make_element(GREEN, CIRCLE)}), base_time);
   arbiter.ingest_perception(
-    make_signals(base_time, {make_group(map_ids::vehicle_b, {make_element(RED, CIRCLE)})}));
+    make_signal(base_time, map_ids::vehicle_b, {make_element(RED, CIRCLE)}));
 
   const auto result = arbiter.arbitrate();
 
@@ -381,12 +377,9 @@ TEST(TrafficLightArbiterCoreSignalMatching, shapeSetMismatchProducesUnknown)
   auto arbiter = make_arbiter(CONFIDENCE, /*enable_signal_matching=*/true);
 
   arbiter.ingest_external(
-    make_signals(base_time, {make_group(map_ids::vehicle_b, {make_element(RED, CIRCLE)})}),
-    base_time);
-  arbiter.ingest_perception(make_signals(
-    base_time,
-    {make_group(
-      map_ids::vehicle_b, {make_element(RED, CIRCLE), make_element(GREEN, RIGHT_ARROW)})}));
+    make_signal(base_time, map_ids::vehicle_b, {make_element(RED, CIRCLE)}), base_time);
+  arbiter.ingest_perception(make_signal(
+    base_time, map_ids::vehicle_b, {make_element(RED, CIRCLE), make_element(GREEN, RIGHT_ARROW)}));
 
   const auto result = arbiter.arbitrate();
 
@@ -402,7 +395,7 @@ TEST(TrafficLightArbiterCoreSignalMatching, perceptionOnlySingleSourceYieldsUnkn
   auto arbiter = make_arbiter(CONFIDENCE, /*enable_signal_matching=*/true);
 
   arbiter.ingest_perception(
-    make_signals(base_time, {make_group(map_ids::vehicle_a, {make_element(RED, CIRCLE)})}));
+    make_signal(base_time, map_ids::vehicle_a, {make_element(RED, CIRCLE)}));
 
   const auto result = arbiter.arbitrate();
 
@@ -417,8 +410,7 @@ TEST(TrafficLightArbiterCoreSignalMatching, externalOnlySingleSourceYieldsUnknow
   auto arbiter = make_arbiter(CONFIDENCE, /*enable_signal_matching=*/true);
 
   arbiter.ingest_external(
-    make_signals(base_time, {make_group(map_ids::vehicle_a, {make_element(RED, CIRCLE)})}),
-    base_time);
+    make_signal(base_time, map_ids::vehicle_a, {make_element(RED, CIRCLE)}), base_time);
 
   const auto result = arbiter.arbitrate();
 
@@ -431,8 +423,7 @@ TEST(TrafficLightArbiterCoreSignalMatching, offMapIdIsDroppedAndReported)
   auto arbiter = make_arbiter(CONFIDENCE, /*enable_signal_matching=*/true);
 
   arbiter.ingest_external(
-    make_signals(base_time, {make_group(map_ids::off_map_probe, {make_element(RED, CIRCLE)})}),
-    base_time);
+    make_signal(base_time, map_ids::off_map_probe, {make_element(RED, CIRCLE)}), base_time);
 
   const auto result = arbiter.arbitrate();
 
@@ -455,10 +446,9 @@ TEST(TrafficLightArbiterCorePedestrian, externalPriorityWinsForPedestrian)
   auto arbiter = make_arbiter(EXTERNAL, /*enable_signal_matching=*/true);
 
   arbiter.ingest_external(
-    make_signals(base_time, {make_group(map_ids::pedestrian, {make_element(RED, CIRCLE, 0.1f)})}),
-    base_time);
-  arbiter.ingest_perception(make_signals(
-    base_time, {make_group(map_ids::pedestrian, {make_element(GREEN, CIRCLE, 0.9f)})}));
+    make_signal(base_time, map_ids::pedestrian, {make_element(RED, CIRCLE, 0.1f)}), base_time);
+  arbiter.ingest_perception(
+    make_signal(base_time, map_ids::pedestrian, {make_element(GREEN, CIRCLE, 0.9f)}));
 
   const auto result = arbiter.arbitrate();
 
@@ -472,10 +462,9 @@ TEST(TrafficLightArbiterCorePedestrian, perceptionPriorityWinsForPedestrian)
   auto arbiter = make_arbiter(PERCEPTION, /*enable_signal_matching=*/true);
 
   arbiter.ingest_external(
-    make_signals(base_time, {make_group(map_ids::pedestrian, {make_element(RED, CIRCLE, 0.99f)})}),
-    base_time);
-  arbiter.ingest_perception(make_signals(
-    base_time, {make_group(map_ids::pedestrian, {make_element(GREEN, CIRCLE, 0.10f)})}));
+    make_signal(base_time, map_ids::pedestrian, {make_element(RED, CIRCLE, 0.99f)}), base_time);
+  arbiter.ingest_perception(
+    make_signal(base_time, map_ids::pedestrian, {make_element(GREEN, CIRCLE, 0.10f)}));
 
   const auto result = arbiter.arbitrate();
 
@@ -489,10 +478,9 @@ TEST(TrafficLightArbiterCorePedestrian, confidenceModePicksHigherConfidenceForPe
   auto arbiter = make_arbiter(CONFIDENCE, /*enable_signal_matching=*/true);
 
   arbiter.ingest_external(
-    make_signals(base_time, {make_group(map_ids::pedestrian, {make_element(GREEN, CIRCLE, 0.6f)})}),
-    base_time);
+    make_signal(base_time, map_ids::pedestrian, {make_element(GREEN, CIRCLE, 0.6f)}), base_time);
   arbiter.ingest_perception(
-    make_signals(base_time, {make_group(map_ids::pedestrian, {make_element(RED, CIRCLE, 0.9f)})}));
+    make_signal(base_time, map_ids::pedestrian, {make_element(RED, CIRCLE, 0.9f)}));
 
   const auto result = arbiter.arbitrate();
 
@@ -509,7 +497,7 @@ TEST(TrafficLightArbiterCorePedestrian, singleSourcePedestrianPassesThrough)
   auto arbiter = make_arbiter(EXTERNAL, /*enable_signal_matching=*/true);
 
   arbiter.ingest_perception(
-    make_signals(base_time, {make_group(map_ids::pedestrian, {make_element(GREEN, CIRCLE)})}));
+    make_signal(base_time, map_ids::pedestrian, {make_element(GREEN, CIRCLE)}));
 
   const auto result = arbiter.arbitrate();
 
@@ -527,10 +515,9 @@ TEST(TrafficLightArbiterCoreConfidencePriority, picksHigherConfidenceElement)
   auto arbiter = make_arbiter(CONFIDENCE, /*enable_signal_matching=*/false);
 
   arbiter.ingest_external(
-    make_signals(base_time, {make_group(map_ids::vehicle_a, {make_element(GREEN, CIRCLE, 0.7f)})}),
-    base_time);
+    make_signal(base_time, map_ids::vehicle_a, {make_element(GREEN, CIRCLE, 0.7f)}), base_time);
   arbiter.ingest_perception(
-    make_signals(base_time, {make_group(map_ids::vehicle_a, {make_element(RED, CIRCLE, 0.9f)})}));
+    make_signal(base_time, map_ids::vehicle_a, {make_element(RED, CIRCLE, 0.9f)}));
 
   const auto result = arbiter.arbitrate();
 
@@ -546,10 +533,9 @@ TEST(TrafficLightArbiterCoreConfidencePriority, perShapeUnionFromBothSides)
   auto arbiter = make_arbiter(CONFIDENCE, /*enable_signal_matching=*/false);
 
   arbiter.ingest_perception(
-    make_signals(base_time, {make_group(map_ids::vehicle_a, {make_element(RED, CIRCLE)})}));
+    make_signal(base_time, map_ids::vehicle_a, {make_element(RED, CIRCLE)}));
   arbiter.ingest_external(
-    make_signals(base_time, {make_group(map_ids::vehicle_a, {make_element(GREEN, RIGHT_ARROW)})}),
-    base_time);
+    make_signal(base_time, map_ids::vehicle_a, {make_element(GREEN, RIGHT_ARROW)}), base_time);
 
   const auto result = arbiter.arbitrate();
 
@@ -564,7 +550,7 @@ TEST(TrafficLightArbiterCoreConfidencePriority, perceptionOnlyPassesThrough)
   auto arbiter = make_arbiter(CONFIDENCE, /*enable_signal_matching=*/false);
 
   arbiter.ingest_perception(
-    make_signals(base_time, {make_group(map_ids::vehicle_b, {make_element(GREEN, CIRCLE)})}));
+    make_signal(base_time, map_ids::vehicle_b, {make_element(GREEN, CIRCLE)}));
 
   const auto result = arbiter.arbitrate();
 
@@ -579,8 +565,7 @@ TEST(TrafficLightArbiterCoreConfidencePriority, offMapIdIsDroppedAndReported)
   auto arbiter = make_arbiter(CONFIDENCE, /*enable_signal_matching=*/false);
 
   arbiter.ingest_external(
-    make_signals(base_time, {make_group(map_ids::off_map_probe, {make_element(RED, CIRCLE)})}),
-    base_time);
+    make_signal(base_time, map_ids::off_map_probe, {make_element(RED, CIRCLE)}), base_time);
 
   const auto result = arbiter.arbitrate();
 
@@ -595,11 +580,9 @@ TEST(TrafficLightArbiterCoreConfidencePriority, multipleExternalSourcesAccumulat
   auto arbiter = make_arbiter(CONFIDENCE, /*enable_signal_matching=*/false);
 
   arbiter.ingest_external(
-    make_signals(base_time, {make_group(map_ids::vehicle_a, {make_element(GREEN, CIRCLE)})}),
-    base_time);
+    make_signal(base_time, map_ids::vehicle_a, {make_element(GREEN, CIRCLE)}), base_time);
   arbiter.ingest_external(
-    make_signals(base_time, {make_group(map_ids::vehicle_b, {make_element(RED, CIRCLE)})}),
-    base_time);
+    make_signal(base_time, map_ids::vehicle_b, {make_element(RED, CIRCLE)}), base_time);
 
   const auto result = arbiter.arbitrate();
 
@@ -615,15 +598,13 @@ TEST(TrafficLightArbiterCoreConfidencePriority, predictionsFromBothSidesAreMerge
 {
   auto arbiter = make_arbiter(CONFIDENCE, /*enable_signal_matching=*/false);
 
-  arbiter.ingest_perception(make_signals(
-    base_time, {make_group(
-                 map_ids::vehicle_a, {make_element(RED, CIRCLE)},
-                 {make_prediction(base_time, INTERNAL_ESTIMATION)})}));
+  arbiter.ingest_perception(make_signal(
+    base_time, map_ids::vehicle_a, {make_element(RED, CIRCLE)},
+    {make_prediction(base_time, INTERNAL_ESTIMATION)}));
   arbiter.ingest_external(
-    make_signals(
-      base_time,
-      {make_group(
-        map_ids::vehicle_a, {make_element(RED, CIRCLE)}, {make_prediction(base_time, V2I)})}),
+    make_signal(
+      base_time, map_ids::vehicle_a, {make_element(RED, CIRCLE)},
+      {make_prediction(base_time, V2I)}),
     base_time);
 
   const auto result = arbiter.arbitrate();
@@ -638,10 +619,9 @@ TEST(TrafficLightArbiterCoreConfidencePriority, perceptionOnlyPredictionPropagat
 {
   auto arbiter = make_arbiter(CONFIDENCE, /*enable_signal_matching=*/false);
 
-  arbiter.ingest_perception(make_signals(
-    base_time, {make_group(
-                 map_ids::vehicle_a, {make_element(RED, CIRCLE)},
-                 {make_prediction(base_time, INTERNAL_ESTIMATION)})}));
+  arbiter.ingest_perception(make_signal(
+    base_time, map_ids::vehicle_a, {make_element(RED, CIRCLE)},
+    {make_prediction(base_time, INTERNAL_ESTIMATION)}));
 
   const auto result = arbiter.arbitrate();
 
@@ -656,10 +636,9 @@ TEST(TrafficLightArbiterCoreConfidencePriority, externalOnlyPredictionPropagates
   auto arbiter = make_arbiter(CONFIDENCE, /*enable_signal_matching=*/false);
 
   arbiter.ingest_external(
-    make_signals(
-      base_time,
-      {make_group(
-        map_ids::vehicle_a, {make_element(RED, CIRCLE)}, {make_prediction(base_time, V2I)})}),
+    make_signal(
+      base_time, map_ids::vehicle_a, {make_element(RED, CIRCLE)},
+      {make_prediction(base_time, V2I)}),
     base_time);
 
   const auto result = arbiter.arbitrate();
@@ -678,10 +657,9 @@ TEST(TrafficLightArbiterCoreExternalPriority, externalPriorityOverridesConfidenc
   auto arbiter = make_arbiter(EXTERNAL, /*enable_signal_matching=*/false);
 
   arbiter.ingest_external(
-    make_signals(base_time, {make_group(map_ids::vehicle_a, {make_element(RED, CIRCLE, 0.10f)})}),
-    base_time);
-  arbiter.ingest_perception(make_signals(
-    base_time, {make_group(map_ids::vehicle_a, {make_element(GREEN, CIRCLE, 0.99f)})}));
+    make_signal(base_time, map_ids::vehicle_a, {make_element(RED, CIRCLE, 0.10f)}), base_time);
+  arbiter.ingest_perception(
+    make_signal(base_time, map_ids::vehicle_a, {make_element(GREEN, CIRCLE, 0.99f)}));
 
   const auto result = arbiter.arbitrate();
 
@@ -695,8 +673,7 @@ TEST(TrafficLightArbiterCoreExternalPriority, externalOnlyPassesThrough)
   auto arbiter = make_arbiter(EXTERNAL, /*enable_signal_matching=*/false);
 
   arbiter.ingest_external(
-    make_signals(base_time, {make_group(map_ids::vehicle_a, {make_element(RED, CIRCLE)})}),
-    base_time);
+    make_signal(base_time, map_ids::vehicle_a, {make_element(RED, CIRCLE)}), base_time);
 
   const auto result = arbiter.arbitrate();
 
@@ -711,7 +688,7 @@ TEST(TrafficLightArbiterCoreExternalPriority, perceptionOnlyPassesThrough)
   auto arbiter = make_arbiter(EXTERNAL, /*enable_signal_matching=*/false);
 
   arbiter.ingest_perception(
-    make_signals(base_time, {make_group(map_ids::vehicle_a, {make_element(GREEN, CIRCLE)})}));
+    make_signal(base_time, map_ids::vehicle_a, {make_element(GREEN, CIRCLE)}));
 
   const auto result = arbiter.arbitrate();
 
@@ -729,10 +706,9 @@ TEST(TrafficLightArbiterCorePerceptionPriority, perceptionPriorityOverridesConfi
   auto arbiter = make_arbiter(PERCEPTION, /*enable_signal_matching=*/false);
 
   arbiter.ingest_external(
-    make_signals(base_time, {make_group(map_ids::vehicle_a, {make_element(RED, CIRCLE, 0.99f)})}),
-    base_time);
-  arbiter.ingest_perception(make_signals(
-    base_time, {make_group(map_ids::vehicle_a, {make_element(GREEN, CIRCLE, 0.10f)})}));
+    make_signal(base_time, map_ids::vehicle_a, {make_element(RED, CIRCLE, 0.99f)}), base_time);
+  arbiter.ingest_perception(
+    make_signal(base_time, map_ids::vehicle_a, {make_element(GREEN, CIRCLE, 0.10f)}));
 
   const auto result = arbiter.arbitrate();
 
@@ -746,7 +722,7 @@ TEST(TrafficLightArbiterCorePerceptionPriority, perceptionOnlyPassesThrough)
   auto arbiter = make_arbiter(PERCEPTION, /*enable_signal_matching=*/false);
 
   arbiter.ingest_perception(
-    make_signals(base_time, {make_group(map_ids::vehicle_a, {make_element(GREEN, CIRCLE)})}));
+    make_signal(base_time, map_ids::vehicle_a, {make_element(GREEN, CIRCLE)}));
 
   const auto result = arbiter.arbitrate();
 
@@ -760,8 +736,7 @@ TEST(TrafficLightArbiterCorePerceptionPriority, externalOnlyPassesThrough)
   auto arbiter = make_arbiter(PERCEPTION, /*enable_signal_matching=*/false);
 
   arbiter.ingest_external(
-    make_signals(base_time, {make_group(map_ids::vehicle_a, {make_element(RED, CIRCLE)})}),
-    base_time);
+    make_signal(base_time, map_ids::vehicle_a, {make_element(RED, CIRCLE)}), base_time);
 
   const auto result = arbiter.arbitrate();
 
@@ -783,7 +758,7 @@ TEST(TrafficLightArbiterCoreBoundary, arbitrateWithoutMapProducesNoOutput)
     default_external_time_tolerance, default_perception_time_tolerance);
 
   unconfigured.ingest_perception(
-    make_signals(base_time, {make_group(map_ids::vehicle_a, {make_element(RED, CIRCLE)})}));
+    make_signal(base_time, map_ids::vehicle_a, {make_element(RED, CIRCLE)}));
 
   const auto result = unconfigured.arbitrate();
 
@@ -801,7 +776,7 @@ TEST(TrafficLightArbiterCoreBoundary, emptyMapProducesEmptyOutput)
   arbiter.set_map(build_empty_map());
 
   arbiter.ingest_perception(
-    make_signals(base_time, {make_group(map_ids::vehicle_a, {make_element(RED, CIRCLE)})}));
+    make_signal(base_time, map_ids::vehicle_a, {make_element(RED, CIRCLE)}));
 
   const auto result = arbiter.arbitrate();
 
@@ -826,10 +801,9 @@ TEST(TrafficLightArbiterCorePerceptionStaleness, stalePerceptionIsExcludedFromOu
     base_time - rclcpp::Duration::from_seconds(default_perception_time_tolerance + 1.0);
 
   arbiter.ingest_perception(
-    make_signals(t_perception, {make_group(map_ids::vehicle_a, {make_element(RED, CIRCLE)})}));
+    make_signal(t_perception, map_ids::vehicle_a, {make_element(RED, CIRCLE)}));
   arbiter.ingest_external(
-    make_signals(base_time, {make_group(map_ids::vehicle_a, {make_element(GREEN, CIRCLE)})}),
-    base_time);
+    make_signal(base_time, map_ids::vehicle_a, {make_element(GREEN, CIRCLE)}), base_time);
 
   const auto result = arbiter.arbitrate();
 
@@ -846,11 +820,10 @@ TEST(TrafficLightArbiterCorePerceptionStaleness, freshPerceptionRemainsEffective
   const auto t_perception =
     base_time - rclcpp::Duration::from_seconds(0.5 * default_perception_time_tolerance);
 
-  arbiter.ingest_perception(make_signals(
-    t_perception, {make_group(map_ids::vehicle_a, {make_element(RED, CIRCLE, 0.9f)})}));
+  arbiter.ingest_perception(
+    make_signal(t_perception, map_ids::vehicle_a, {make_element(RED, CIRCLE, 0.9f)}));
   arbiter.ingest_external(
-    make_signals(base_time, {make_group(map_ids::vehicle_a, {make_element(GREEN, CIRCLE, 0.7f)})}),
-    base_time);
+    make_signal(base_time, map_ids::vehicle_a, {make_element(GREEN, CIRCLE, 0.7f)}), base_time);
 
   const auto result = arbiter.arbitrate();
 
@@ -879,7 +852,7 @@ TEST(TrafficLightArbiterCorePerceptionStaleness, perceptionAloneIsNeverStale)
     base_time - rclcpp::Duration::from_seconds(default_perception_time_tolerance + 10.0);
 
   arbiter.ingest_perception(
-    make_signals(t_perception, {make_group(map_ids::vehicle_a, {make_element(RED, CIRCLE)})}));
+    make_signal(t_perception, map_ids::vehicle_a, {make_element(RED, CIRCLE)}));
 
   const auto result = arbiter.arbitrate();
 
@@ -899,10 +872,9 @@ TEST(TrafficLightArbiterCorePerceptionStaleness, stalenessDropsEntirePerceptionM
     base_time - rclcpp::Duration::from_seconds(default_perception_time_tolerance + 1.0);
 
   arbiter.ingest_perception(
-    make_signals(t_perception, {make_group(map_ids::vehicle_a, {make_element(RED, CIRCLE)})}));
+    make_signal(t_perception, map_ids::vehicle_a, {make_element(RED, CIRCLE)}));
   arbiter.ingest_external(
-    make_signals(base_time, {make_group(map_ids::vehicle_b, {make_element(GREEN, CIRCLE)})}),
-    base_time);
+    make_signal(base_time, map_ids::vehicle_b, {make_element(GREEN, CIRCLE)}), base_time);
 
   const auto result = arbiter.arbitrate();
 
@@ -919,15 +891,13 @@ TEST(TrafficLightArbiterCorePerceptionStaleness, stalePerceptionPredictionsAreSk
   const auto t_perception =
     base_time - rclcpp::Duration::from_seconds(default_perception_time_tolerance + 1.0);
 
-  arbiter.ingest_perception(make_signals(
-    t_perception, {make_group(
-                    map_ids::vehicle_a, {make_element(RED, CIRCLE)},
-                    {make_prediction(t_perception, INTERNAL_ESTIMATION)})}));
+  arbiter.ingest_perception(make_signal(
+    t_perception, map_ids::vehicle_a, {make_element(RED, CIRCLE)},
+    {make_prediction(t_perception, INTERNAL_ESTIMATION)}));
   arbiter.ingest_external(
-    make_signals(
-      base_time,
-      {make_group(
-        map_ids::vehicle_a, {make_element(GREEN, CIRCLE)}, {make_prediction(base_time, V2I)})}),
+    make_signal(
+      base_time, map_ids::vehicle_a, {make_element(GREEN, CIRCLE)},
+      {make_prediction(base_time, V2I)}),
     base_time);
 
   const auto result = arbiter.arbitrate();
@@ -950,9 +920,9 @@ TEST(TrafficLightArbiterCoreLatestInputTime, takesNewerOfPerceptionAndExternal)
   const auto t_external_newer = base_time + rclcpp::Duration::from_seconds(0.5);
 
   arbiter.ingest_perception(
-    make_signals(base_time, {make_group(map_ids::vehicle_a, {make_element(RED, CIRCLE)})}));
+    make_signal(base_time, map_ids::vehicle_a, {make_element(RED, CIRCLE)}));
   arbiter.ingest_external(
-    make_signals(t_external_newer, {make_group(map_ids::vehicle_a, {make_element(RED, CIRCLE)})}),
+    make_signal(t_external_newer, map_ids::vehicle_a, {make_element(RED, CIRCLE)}),
     t_external_newer);
 
   const auto result = arbiter.arbitrate();
@@ -969,10 +939,9 @@ TEST(TrafficLightArbiterCoreLatestInputTime, perceptionWinsWhenNewer)
   const auto t_perception_newer = base_time + rclcpp::Duration::from_seconds(0.3);
 
   arbiter.ingest_external(
-    make_signals(base_time, {make_group(map_ids::vehicle_a, {make_element(RED, CIRCLE)})}),
-    base_time);
-  arbiter.ingest_perception(make_signals(
-    t_perception_newer, {make_group(map_ids::vehicle_a, {make_element(RED, CIRCLE)})}));
+    make_signal(base_time, map_ids::vehicle_a, {make_element(RED, CIRCLE)}), base_time);
+  arbiter.ingest_perception(
+    make_signal(t_perception_newer, map_ids::vehicle_a, {make_element(RED, CIRCLE)}));
 
   const auto result = arbiter.arbitrate();
 
@@ -988,7 +957,7 @@ TEST(TrafficLightArbiterCoreLatestInputTime, perceptionStampWhenExternalIsSilent
   const auto t_perception = base_time + rclcpp::Duration::from_seconds(0.5);
 
   arbiter.ingest_perception(
-    make_signals(t_perception, {make_group(map_ids::vehicle_a, {make_element(RED, CIRCLE)})}));
+    make_signal(t_perception, map_ids::vehicle_a, {make_element(RED, CIRCLE)}));
 
   const auto result = arbiter.arbitrate();
 
@@ -1011,8 +980,7 @@ TEST(TrafficLightArbiterCoreTiming, ingestExternalAcceptsStampsWithinTolerance)
     base_time - rclcpp::Duration::from_seconds(default_external_delay_tolerance - 1.0);
 
   const auto result = arbiter.ingest_external(
-    make_signals(t_past_within, {make_group(map_ids::vehicle_a, {make_element(RED, CIRCLE)})}),
-    base_time);
+    make_signal(t_past_within, map_ids::vehicle_a, {make_element(RED, CIRCLE)}), base_time);
 
   EXPECT_TRUE(result.accepted);
 }
@@ -1027,8 +995,7 @@ TEST(TrafficLightArbiterCoreTiming, ingestExternalRejectsTooOldStamps)
     base_time - rclcpp::Duration::from_seconds(default_external_delay_tolerance + 1.0);
 
   const auto result = arbiter.ingest_external(
-    make_signals(t_past_beyond, {make_group(map_ids::vehicle_a, {make_element(RED, CIRCLE)})}),
-    base_time);
+    make_signal(t_past_beyond, map_ids::vehicle_a, {make_element(RED, CIRCLE)}), base_time);
 
   EXPECT_FALSE(result.accepted);
 }
@@ -1044,8 +1011,7 @@ TEST(TrafficLightArbiterCoreTiming, ingestExternalRejectsTooFutureStamps)
     base_time + rclcpp::Duration::from_seconds(default_external_delay_tolerance + 1.0);
 
   const auto result = arbiter.ingest_external(
-    make_signals(t_future_beyond, {make_group(map_ids::vehicle_a, {make_element(RED, CIRCLE)})}),
-    base_time);
+    make_signal(t_future_beyond, map_ids::vehicle_a, {make_element(RED, CIRCLE)}), base_time);
 
   EXPECT_FALSE(result.accepted);
 }
@@ -1059,13 +1025,12 @@ TEST(TrafficLightArbiterCoreTiming, ingestPerceptionReportsExpiredExternalEntry)
   auto arbiter = make_arbiter(CONFIDENCE, /*enable_signal_matching=*/false);
 
   arbiter.ingest_external(
-    make_signals(base_time, {make_group(map_ids::vehicle_a, {make_element(RED, CIRCLE)})}),
-    base_time);
+    make_signal(base_time, map_ids::vehicle_a, {make_element(RED, CIRCLE)}), base_time);
   const auto t_perception =
     base_time + rclcpp::Duration::from_seconds(default_external_time_tolerance + 1.0);
 
   const auto expired = arbiter.ingest_perception(
-    make_signals(t_perception, {make_group(map_ids::vehicle_b, {make_element(GREEN, CIRCLE)})}));
+    make_signal(t_perception, map_ids::vehicle_b, {make_element(GREEN, CIRCLE)}));
 
   ASSERT_EQ(expired.size(), 1u);
   EXPECT_EQ(expired.front().id, map_ids::vehicle_a);
@@ -1080,12 +1045,11 @@ TEST(TrafficLightArbiterCoreTiming, evictedExternalEntryAbsentFromOutput)
   auto arbiter = make_arbiter(CONFIDENCE, /*enable_signal_matching=*/false);
 
   arbiter.ingest_external(
-    make_signals(base_time, {make_group(map_ids::vehicle_a, {make_element(RED, CIRCLE)})}),
-    base_time);
+    make_signal(base_time, map_ids::vehicle_a, {make_element(RED, CIRCLE)}), base_time);
   const auto t_perception =
     base_time + rclcpp::Duration::from_seconds(default_external_time_tolerance + 1.0);
   arbiter.ingest_perception(
-    make_signals(t_perception, {make_group(map_ids::vehicle_b, {make_element(GREEN, CIRCLE)})}));
+    make_signal(t_perception, map_ids::vehicle_b, {make_element(GREEN, CIRCLE)}));
 
   const auto result = arbiter.arbitrate();
 

--- a/perception/autoware_traffic_light_arbiter/test/test_traffic_light_arbiter_core.cpp
+++ b/perception/autoware_traffic_light_arbiter/test/test_traffic_light_arbiter_core.cpp
@@ -90,12 +90,12 @@ lanelet::Lanelet make_lanelet(double y_left, double y_right, const std::string &
 lanelet::LineString3d make_traffic_light_bulb()
 {
   // Geometry does not affect arbiter logic; pick lanelet midpoint at z=5.
-  constexpr double kBulbX = 5.0;
-  constexpr double kBulbZ = 5.0;
+  constexpr double bulb_x = 5.0;
+  constexpr double bulb_z = 5.0;
   using namespace lanelet;  // NOLINT(build/namespaces)
   LineString3d bulb(
-    utils::getId(), {make_point(utils::getId(), kBulbX, 0.0, kBulbZ),
-                     make_point(utils::getId(), kBulbX, 1.0, kBulbZ)});
+    utils::getId(), {make_point(utils::getId(), bulb_x, 0.0, bulb_z),
+                     make_point(utils::getId(), bulb_x, 1.0, bulb_z)});
   bulb.attributes()[AttributeName::Type] = AttributeValueString::TrafficLight;
   return bulb;
 }
@@ -173,13 +173,13 @@ TrafficLightGroup make_group(
 PredictedTrafficLightState make_prediction(
   const rclcpp::Time & stamp, const std::string & source = INTERNAL_ESTIMATION)
 {
-  constexpr int32_t kPredictionOffsetSec = 10;
-  constexpr float kFullCertainty = 1.0f;
+  constexpr int32_t prediction_offset_sec = 10;
+  constexpr float full_certainty = 1.0f;
   PredictedTrafficLightState prediction;
   prediction.predicted_stamp = stamp;
-  prediction.predicted_stamp.sec += kPredictionOffsetSec;
-  prediction.simultaneous_elements.push_back(make_element(UNKNOWN, CIRCLE, kFullCertainty));
-  prediction.reliability = kFullCertainty;
+  prediction.predicted_stamp.sec += prediction_offset_sec;
+  prediction.simultaneous_elements.push_back(make_element(UNKNOWN, CIRCLE, full_certainty));
+  prediction.reliability = full_certainty;
   prediction.information_source = source;
   return prediction;
 }
@@ -281,20 +281,20 @@ std::optional<std::string> observed_prediction_source(
 
 // Mirror config/traffic_light_arbiter.param.yaml defaults so the numeric
 // envelope these tests assume matches the production parameter set.
-constexpr double kDefaultExternalDelayTolerance = 5.0;
-constexpr double kDefaultExternalTimeTolerance = 5.0;
-constexpr double kDefaultPerceptionTimeTolerance = 1.0;
+constexpr double default_external_delay_tolerance = 5.0;
+constexpr double default_external_time_tolerance = 5.0;
+constexpr double default_perception_time_tolerance = 1.0;
 
 // Arbitrary positive seconds used as the suite-wide base time. Far enough
-// from zero that any kBaseTime - duration derived in a test stays positive
-// (largest backward offset is kDefaultExternalDelayTolerance + a few seconds).
-constexpr int32_t kBaseTimeSeconds = 1'000'000'000;
-const rclcpp::Time kBaseTime{kBaseTimeSeconds, 0, RCL_ROS_TIME};
+// from zero that any base_time - duration derived in a test stays positive
+// (largest backward offset is default_external_delay_tolerance + a few seconds).
+constexpr int32_t base_time_seconds = 1'000'000'000;
+const rclcpp::Time base_time{base_time_seconds, 0, RCL_ROS_TIME};
 
 // Static initializer reserves off_map_probe so utils::getId() (used by map
 // builders) never hands out an id that collides with it, then builds the
 // suite-wide map once. Process-global state; one registration is enough.
-const lanelet::LaneletMapConstPtr kSharedMap = []() {
+const lanelet::LaneletMapConstPtr shared_map = []() {
   lanelet::utils::registerId(map_ids::off_map_probe);
   return build_minimal_map();
 }();
@@ -304,9 +304,9 @@ const lanelet::LaneletMapConstPtr kSharedMap = []() {
 TrafficLightArbiterCore make_arbiter(SourcePriority priority, bool enable_signal_matching)
 {
   TrafficLightArbiterCore arbiter(
-    priority, enable_signal_matching, kDefaultExternalDelayTolerance, kDefaultExternalTimeTolerance,
-    kDefaultPerceptionTimeTolerance);
-  arbiter.set_map(kSharedMap);
+    priority, enable_signal_matching, default_external_delay_tolerance,
+    default_external_time_tolerance, default_perception_time_tolerance);
+  arbiter.set_map(shared_map);
   return arbiter;
 }
 
@@ -326,10 +326,10 @@ TEST(TrafficLightArbiterCoreSignalMatching, matchedSignalsPassThrough)
   auto arbiter = make_arbiter(CONFIDENCE, /*enable_signal_matching=*/true);
 
   arbiter.ingest_external(
-    make_signals(kBaseTime, {make_group(map_ids::vehicle_a, {make_element(RED, CIRCLE)})}),
-    kBaseTime);
+    make_signals(base_time, {make_group(map_ids::vehicle_a, {make_element(RED, CIRCLE)})}),
+    base_time);
   arbiter.ingest_perception(
-    make_signals(kBaseTime, {make_group(map_ids::vehicle_a, {make_element(RED, CIRCLE)})}));
+    make_signals(base_time, {make_group(map_ids::vehicle_a, {make_element(RED, CIRCLE)})}));
 
   const auto result = arbiter.arbitrate();
 
@@ -346,10 +346,10 @@ TEST(TrafficLightArbiterCoreSignalMatching, differingConfidencesStillMatch)
   auto arbiter = make_arbiter(CONFIDENCE, /*enable_signal_matching=*/true);
 
   arbiter.ingest_external(
-    make_signals(kBaseTime, {make_group(map_ids::vehicle_a, {make_element(RED, CIRCLE, 0.10f)})}),
-    kBaseTime);
+    make_signals(base_time, {make_group(map_ids::vehicle_a, {make_element(RED, CIRCLE, 0.10f)})}),
+    base_time);
   arbiter.ingest_perception(
-    make_signals(kBaseTime, {make_group(map_ids::vehicle_a, {make_element(RED, CIRCLE, 0.90f)})}));
+    make_signals(base_time, {make_group(map_ids::vehicle_a, {make_element(RED, CIRCLE, 0.90f)})}));
 
   const auto result = arbiter.arbitrate();
 
@@ -364,10 +364,10 @@ TEST(TrafficLightArbiterCoreSignalMatching, colorMismatchProducesUnknown)
   auto arbiter = make_arbiter(CONFIDENCE, /*enable_signal_matching=*/true);
 
   arbiter.ingest_external(
-    make_signals(kBaseTime, {make_group(map_ids::vehicle_b, {make_element(GREEN, CIRCLE)})}),
-    kBaseTime);
+    make_signals(base_time, {make_group(map_ids::vehicle_b, {make_element(GREEN, CIRCLE)})}),
+    base_time);
   arbiter.ingest_perception(
-    make_signals(kBaseTime, {make_group(map_ids::vehicle_b, {make_element(RED, CIRCLE)})}));
+    make_signals(base_time, {make_group(map_ids::vehicle_b, {make_element(RED, CIRCLE)})}));
 
   const auto result = arbiter.arbitrate();
 
@@ -381,10 +381,10 @@ TEST(TrafficLightArbiterCoreSignalMatching, shapeSetMismatchProducesUnknown)
   auto arbiter = make_arbiter(CONFIDENCE, /*enable_signal_matching=*/true);
 
   arbiter.ingest_external(
-    make_signals(kBaseTime, {make_group(map_ids::vehicle_b, {make_element(RED, CIRCLE)})}),
-    kBaseTime);
+    make_signals(base_time, {make_group(map_ids::vehicle_b, {make_element(RED, CIRCLE)})}),
+    base_time);
   arbiter.ingest_perception(make_signals(
-    kBaseTime,
+    base_time,
     {make_group(
       map_ids::vehicle_b, {make_element(RED, CIRCLE), make_element(GREEN, RIGHT_ARROW)})}));
 
@@ -402,7 +402,7 @@ TEST(TrafficLightArbiterCoreSignalMatching, perceptionOnlySingleSourceYieldsUnkn
   auto arbiter = make_arbiter(CONFIDENCE, /*enable_signal_matching=*/true);
 
   arbiter.ingest_perception(
-    make_signals(kBaseTime, {make_group(map_ids::vehicle_a, {make_element(RED, CIRCLE)})}));
+    make_signals(base_time, {make_group(map_ids::vehicle_a, {make_element(RED, CIRCLE)})}));
 
   const auto result = arbiter.arbitrate();
 
@@ -417,8 +417,8 @@ TEST(TrafficLightArbiterCoreSignalMatching, externalOnlySingleSourceYieldsUnknow
   auto arbiter = make_arbiter(CONFIDENCE, /*enable_signal_matching=*/true);
 
   arbiter.ingest_external(
-    make_signals(kBaseTime, {make_group(map_ids::vehicle_a, {make_element(RED, CIRCLE)})}),
-    kBaseTime);
+    make_signals(base_time, {make_group(map_ids::vehicle_a, {make_element(RED, CIRCLE)})}),
+    base_time);
 
   const auto result = arbiter.arbitrate();
 
@@ -431,8 +431,8 @@ TEST(TrafficLightArbiterCoreSignalMatching, offMapIdIsDroppedAndReported)
   auto arbiter = make_arbiter(CONFIDENCE, /*enable_signal_matching=*/true);
 
   arbiter.ingest_external(
-    make_signals(kBaseTime, {make_group(map_ids::off_map_probe, {make_element(RED, CIRCLE)})}),
-    kBaseTime);
+    make_signals(base_time, {make_group(map_ids::off_map_probe, {make_element(RED, CIRCLE)})}),
+    base_time);
 
   const auto result = arbiter.arbitrate();
 
@@ -455,10 +455,10 @@ TEST(TrafficLightArbiterCorePedestrian, externalPriorityWinsForPedestrian)
   auto arbiter = make_arbiter(EXTERNAL, /*enable_signal_matching=*/true);
 
   arbiter.ingest_external(
-    make_signals(kBaseTime, {make_group(map_ids::pedestrian, {make_element(RED, CIRCLE, 0.1f)})}),
-    kBaseTime);
+    make_signals(base_time, {make_group(map_ids::pedestrian, {make_element(RED, CIRCLE, 0.1f)})}),
+    base_time);
   arbiter.ingest_perception(make_signals(
-    kBaseTime, {make_group(map_ids::pedestrian, {make_element(GREEN, CIRCLE, 0.9f)})}));
+    base_time, {make_group(map_ids::pedestrian, {make_element(GREEN, CIRCLE, 0.9f)})}));
 
   const auto result = arbiter.arbitrate();
 
@@ -472,10 +472,10 @@ TEST(TrafficLightArbiterCorePedestrian, perceptionPriorityWinsForPedestrian)
   auto arbiter = make_arbiter(PERCEPTION, /*enable_signal_matching=*/true);
 
   arbiter.ingest_external(
-    make_signals(kBaseTime, {make_group(map_ids::pedestrian, {make_element(RED, CIRCLE, 0.99f)})}),
-    kBaseTime);
+    make_signals(base_time, {make_group(map_ids::pedestrian, {make_element(RED, CIRCLE, 0.99f)})}),
+    base_time);
   arbiter.ingest_perception(make_signals(
-    kBaseTime, {make_group(map_ids::pedestrian, {make_element(GREEN, CIRCLE, 0.10f)})}));
+    base_time, {make_group(map_ids::pedestrian, {make_element(GREEN, CIRCLE, 0.10f)})}));
 
   const auto result = arbiter.arbitrate();
 
@@ -489,10 +489,10 @@ TEST(TrafficLightArbiterCorePedestrian, confidenceModePicksHigherConfidenceForPe
   auto arbiter = make_arbiter(CONFIDENCE, /*enable_signal_matching=*/true);
 
   arbiter.ingest_external(
-    make_signals(kBaseTime, {make_group(map_ids::pedestrian, {make_element(GREEN, CIRCLE, 0.6f)})}),
-    kBaseTime);
+    make_signals(base_time, {make_group(map_ids::pedestrian, {make_element(GREEN, CIRCLE, 0.6f)})}),
+    base_time);
   arbiter.ingest_perception(
-    make_signals(kBaseTime, {make_group(map_ids::pedestrian, {make_element(RED, CIRCLE, 0.9f)})}));
+    make_signals(base_time, {make_group(map_ids::pedestrian, {make_element(RED, CIRCLE, 0.9f)})}));
 
   const auto result = arbiter.arbitrate();
 
@@ -509,7 +509,7 @@ TEST(TrafficLightArbiterCorePedestrian, singleSourcePedestrianPassesThrough)
   auto arbiter = make_arbiter(EXTERNAL, /*enable_signal_matching=*/true);
 
   arbiter.ingest_perception(
-    make_signals(kBaseTime, {make_group(map_ids::pedestrian, {make_element(GREEN, CIRCLE)})}));
+    make_signals(base_time, {make_group(map_ids::pedestrian, {make_element(GREEN, CIRCLE)})}));
 
   const auto result = arbiter.arbitrate();
 
@@ -527,10 +527,10 @@ TEST(TrafficLightArbiterCoreConfidencePriority, picksHigherConfidenceElement)
   auto arbiter = make_arbiter(CONFIDENCE, /*enable_signal_matching=*/false);
 
   arbiter.ingest_external(
-    make_signals(kBaseTime, {make_group(map_ids::vehicle_a, {make_element(GREEN, CIRCLE, 0.7f)})}),
-    kBaseTime);
+    make_signals(base_time, {make_group(map_ids::vehicle_a, {make_element(GREEN, CIRCLE, 0.7f)})}),
+    base_time);
   arbiter.ingest_perception(
-    make_signals(kBaseTime, {make_group(map_ids::vehicle_a, {make_element(RED, CIRCLE, 0.9f)})}));
+    make_signals(base_time, {make_group(map_ids::vehicle_a, {make_element(RED, CIRCLE, 0.9f)})}));
 
   const auto result = arbiter.arbitrate();
 
@@ -546,10 +546,10 @@ TEST(TrafficLightArbiterCoreConfidencePriority, perShapeUnionFromBothSides)
   auto arbiter = make_arbiter(CONFIDENCE, /*enable_signal_matching=*/false);
 
   arbiter.ingest_perception(
-    make_signals(kBaseTime, {make_group(map_ids::vehicle_a, {make_element(RED, CIRCLE)})}));
+    make_signals(base_time, {make_group(map_ids::vehicle_a, {make_element(RED, CIRCLE)})}));
   arbiter.ingest_external(
-    make_signals(kBaseTime, {make_group(map_ids::vehicle_a, {make_element(GREEN, RIGHT_ARROW)})}),
-    kBaseTime);
+    make_signals(base_time, {make_group(map_ids::vehicle_a, {make_element(GREEN, RIGHT_ARROW)})}),
+    base_time);
 
   const auto result = arbiter.arbitrate();
 
@@ -564,7 +564,7 @@ TEST(TrafficLightArbiterCoreConfidencePriority, perceptionOnlyPassesThrough)
   auto arbiter = make_arbiter(CONFIDENCE, /*enable_signal_matching=*/false);
 
   arbiter.ingest_perception(
-    make_signals(kBaseTime, {make_group(map_ids::vehicle_b, {make_element(GREEN, CIRCLE)})}));
+    make_signals(base_time, {make_group(map_ids::vehicle_b, {make_element(GREEN, CIRCLE)})}));
 
   const auto result = arbiter.arbitrate();
 
@@ -579,8 +579,8 @@ TEST(TrafficLightArbiterCoreConfidencePriority, offMapIdIsDroppedAndReported)
   auto arbiter = make_arbiter(CONFIDENCE, /*enable_signal_matching=*/false);
 
   arbiter.ingest_external(
-    make_signals(kBaseTime, {make_group(map_ids::off_map_probe, {make_element(RED, CIRCLE)})}),
-    kBaseTime);
+    make_signals(base_time, {make_group(map_ids::off_map_probe, {make_element(RED, CIRCLE)})}),
+    base_time);
 
   const auto result = arbiter.arbitrate();
 
@@ -595,11 +595,11 @@ TEST(TrafficLightArbiterCoreConfidencePriority, multipleExternalSourcesAccumulat
   auto arbiter = make_arbiter(CONFIDENCE, /*enable_signal_matching=*/false);
 
   arbiter.ingest_external(
-    make_signals(kBaseTime, {make_group(map_ids::vehicle_a, {make_element(GREEN, CIRCLE)})}),
-    kBaseTime);
+    make_signals(base_time, {make_group(map_ids::vehicle_a, {make_element(GREEN, CIRCLE)})}),
+    base_time);
   arbiter.ingest_external(
-    make_signals(kBaseTime, {make_group(map_ids::vehicle_b, {make_element(RED, CIRCLE)})}),
-    kBaseTime);
+    make_signals(base_time, {make_group(map_ids::vehicle_b, {make_element(RED, CIRCLE)})}),
+    base_time);
 
   const auto result = arbiter.arbitrate();
 
@@ -616,15 +616,15 @@ TEST(TrafficLightArbiterCoreConfidencePriority, predictionsFromBothSidesAreMerge
   auto arbiter = make_arbiter(CONFIDENCE, /*enable_signal_matching=*/false);
 
   arbiter.ingest_perception(make_signals(
-    kBaseTime, {make_group(
+    base_time, {make_group(
                  map_ids::vehicle_a, {make_element(RED, CIRCLE)},
-                 {make_prediction(kBaseTime, INTERNAL_ESTIMATION)})}));
+                 {make_prediction(base_time, INTERNAL_ESTIMATION)})}));
   arbiter.ingest_external(
     make_signals(
-      kBaseTime,
+      base_time,
       {make_group(
-        map_ids::vehicle_a, {make_element(RED, CIRCLE)}, {make_prediction(kBaseTime, V2I)})}),
-    kBaseTime);
+        map_ids::vehicle_a, {make_element(RED, CIRCLE)}, {make_prediction(base_time, V2I)})}),
+    base_time);
 
   const auto result = arbiter.arbitrate();
 
@@ -639,9 +639,9 @@ TEST(TrafficLightArbiterCoreConfidencePriority, perceptionOnlyPredictionPropagat
   auto arbiter = make_arbiter(CONFIDENCE, /*enable_signal_matching=*/false);
 
   arbiter.ingest_perception(make_signals(
-    kBaseTime, {make_group(
+    base_time, {make_group(
                  map_ids::vehicle_a, {make_element(RED, CIRCLE)},
-                 {make_prediction(kBaseTime, INTERNAL_ESTIMATION)})}));
+                 {make_prediction(base_time, INTERNAL_ESTIMATION)})}));
 
   const auto result = arbiter.arbitrate();
 
@@ -657,10 +657,10 @@ TEST(TrafficLightArbiterCoreConfidencePriority, externalOnlyPredictionPropagates
 
   arbiter.ingest_external(
     make_signals(
-      kBaseTime,
+      base_time,
       {make_group(
-        map_ids::vehicle_a, {make_element(RED, CIRCLE)}, {make_prediction(kBaseTime, V2I)})}),
-    kBaseTime);
+        map_ids::vehicle_a, {make_element(RED, CIRCLE)}, {make_prediction(base_time, V2I)})}),
+    base_time);
 
   const auto result = arbiter.arbitrate();
 
@@ -678,10 +678,10 @@ TEST(TrafficLightArbiterCoreExternalPriority, externalPriorityOverridesConfidenc
   auto arbiter = make_arbiter(EXTERNAL, /*enable_signal_matching=*/false);
 
   arbiter.ingest_external(
-    make_signals(kBaseTime, {make_group(map_ids::vehicle_a, {make_element(RED, CIRCLE, 0.10f)})}),
-    kBaseTime);
+    make_signals(base_time, {make_group(map_ids::vehicle_a, {make_element(RED, CIRCLE, 0.10f)})}),
+    base_time);
   arbiter.ingest_perception(make_signals(
-    kBaseTime, {make_group(map_ids::vehicle_a, {make_element(GREEN, CIRCLE, 0.99f)})}));
+    base_time, {make_group(map_ids::vehicle_a, {make_element(GREEN, CIRCLE, 0.99f)})}));
 
   const auto result = arbiter.arbitrate();
 
@@ -695,8 +695,8 @@ TEST(TrafficLightArbiterCoreExternalPriority, externalOnlyPassesThrough)
   auto arbiter = make_arbiter(EXTERNAL, /*enable_signal_matching=*/false);
 
   arbiter.ingest_external(
-    make_signals(kBaseTime, {make_group(map_ids::vehicle_a, {make_element(RED, CIRCLE)})}),
-    kBaseTime);
+    make_signals(base_time, {make_group(map_ids::vehicle_a, {make_element(RED, CIRCLE)})}),
+    base_time);
 
   const auto result = arbiter.arbitrate();
 
@@ -711,7 +711,7 @@ TEST(TrafficLightArbiterCoreExternalPriority, perceptionOnlyPassesThrough)
   auto arbiter = make_arbiter(EXTERNAL, /*enable_signal_matching=*/false);
 
   arbiter.ingest_perception(
-    make_signals(kBaseTime, {make_group(map_ids::vehicle_a, {make_element(GREEN, CIRCLE)})}));
+    make_signals(base_time, {make_group(map_ids::vehicle_a, {make_element(GREEN, CIRCLE)})}));
 
   const auto result = arbiter.arbitrate();
 
@@ -729,10 +729,10 @@ TEST(TrafficLightArbiterCorePerceptionPriority, perceptionPriorityOverridesConfi
   auto arbiter = make_arbiter(PERCEPTION, /*enable_signal_matching=*/false);
 
   arbiter.ingest_external(
-    make_signals(kBaseTime, {make_group(map_ids::vehicle_a, {make_element(RED, CIRCLE, 0.99f)})}),
-    kBaseTime);
+    make_signals(base_time, {make_group(map_ids::vehicle_a, {make_element(RED, CIRCLE, 0.99f)})}),
+    base_time);
   arbiter.ingest_perception(make_signals(
-    kBaseTime, {make_group(map_ids::vehicle_a, {make_element(GREEN, CIRCLE, 0.10f)})}));
+    base_time, {make_group(map_ids::vehicle_a, {make_element(GREEN, CIRCLE, 0.10f)})}));
 
   const auto result = arbiter.arbitrate();
 
@@ -746,7 +746,7 @@ TEST(TrafficLightArbiterCorePerceptionPriority, perceptionOnlyPassesThrough)
   auto arbiter = make_arbiter(PERCEPTION, /*enable_signal_matching=*/false);
 
   arbiter.ingest_perception(
-    make_signals(kBaseTime, {make_group(map_ids::vehicle_a, {make_element(GREEN, CIRCLE)})}));
+    make_signals(base_time, {make_group(map_ids::vehicle_a, {make_element(GREEN, CIRCLE)})}));
 
   const auto result = arbiter.arbitrate();
 
@@ -760,8 +760,8 @@ TEST(TrafficLightArbiterCorePerceptionPriority, externalOnlyPassesThrough)
   auto arbiter = make_arbiter(PERCEPTION, /*enable_signal_matching=*/false);
 
   arbiter.ingest_external(
-    make_signals(kBaseTime, {make_group(map_ids::vehicle_a, {make_element(RED, CIRCLE)})}),
-    kBaseTime);
+    make_signals(base_time, {make_group(map_ids::vehicle_a, {make_element(RED, CIRCLE)})}),
+    base_time);
 
   const auto result = arbiter.arbitrate();
 
@@ -779,11 +779,11 @@ TEST(TrafficLightArbiterCorePerceptionPriority, externalOnlyPassesThrough)
 TEST(TrafficLightArbiterCoreBoundary, arbitrateWithoutMapProducesNoOutput)
 {
   TrafficLightArbiterCore unconfigured(
-    CONFIDENCE, /*enable_signal_matching=*/false, kDefaultExternalDelayTolerance,
-    kDefaultExternalTimeTolerance, kDefaultPerceptionTimeTolerance);
+    CONFIDENCE, /*enable_signal_matching=*/false, default_external_delay_tolerance,
+    default_external_time_tolerance, default_perception_time_tolerance);
 
   unconfigured.ingest_perception(
-    make_signals(kBaseTime, {make_group(map_ids::vehicle_a, {make_element(RED, CIRCLE)})}));
+    make_signals(base_time, {make_group(map_ids::vehicle_a, {make_element(RED, CIRCLE)})}));
 
   const auto result = unconfigured.arbitrate();
 
@@ -796,12 +796,12 @@ TEST(TrafficLightArbiterCoreBoundary, arbitrateWithoutMapProducesNoOutput)
 TEST(TrafficLightArbiterCoreBoundary, emptyMapProducesEmptyOutput)
 {
   TrafficLightArbiterCore arbiter(
-    CONFIDENCE, /*enable_signal_matching=*/false, kDefaultExternalDelayTolerance,
-    kDefaultExternalTimeTolerance, kDefaultPerceptionTimeTolerance);
+    CONFIDENCE, /*enable_signal_matching=*/false, default_external_delay_tolerance,
+    default_external_time_tolerance, default_perception_time_tolerance);
   arbiter.set_map(build_empty_map());
 
   arbiter.ingest_perception(
-    make_signals(kBaseTime, {make_group(map_ids::vehicle_a, {make_element(RED, CIRCLE)})}));
+    make_signals(base_time, {make_group(map_ids::vehicle_a, {make_element(RED, CIRCLE)})}));
 
   const auto result = arbiter.arbitrate();
 
@@ -823,13 +823,13 @@ TEST(TrafficLightArbiterCorePerceptionStaleness, stalePerceptionIsExcludedFromOu
   auto arbiter = make_arbiter(CONFIDENCE, /*enable_signal_matching=*/false);
 
   const auto t_perception =
-    kBaseTime - rclcpp::Duration::from_seconds(kDefaultPerceptionTimeTolerance + 1.0);
+    base_time - rclcpp::Duration::from_seconds(default_perception_time_tolerance + 1.0);
 
   arbiter.ingest_perception(
     make_signals(t_perception, {make_group(map_ids::vehicle_a, {make_element(RED, CIRCLE)})}));
   arbiter.ingest_external(
-    make_signals(kBaseTime, {make_group(map_ids::vehicle_a, {make_element(GREEN, CIRCLE)})}),
-    kBaseTime);
+    make_signals(base_time, {make_group(map_ids::vehicle_a, {make_element(GREEN, CIRCLE)})}),
+    base_time);
 
   const auto result = arbiter.arbitrate();
 
@@ -844,13 +844,13 @@ TEST(TrafficLightArbiterCorePerceptionStaleness, freshPerceptionRemainsEffective
   auto arbiter = make_arbiter(CONFIDENCE, /*enable_signal_matching=*/false);
 
   const auto t_perception =
-    kBaseTime - rclcpp::Duration::from_seconds(0.5 * kDefaultPerceptionTimeTolerance);
+    base_time - rclcpp::Duration::from_seconds(0.5 * default_perception_time_tolerance);
 
   arbiter.ingest_perception(make_signals(
     t_perception, {make_group(map_ids::vehicle_a, {make_element(RED, CIRCLE, 0.9f)})}));
   arbiter.ingest_external(
-    make_signals(kBaseTime, {make_group(map_ids::vehicle_a, {make_element(GREEN, CIRCLE, 0.7f)})}),
-    kBaseTime);
+    make_signals(base_time, {make_group(map_ids::vehicle_a, {make_element(GREEN, CIRCLE, 0.7f)})}),
+    base_time);
 
   const auto result = arbiter.arbitrate();
 
@@ -859,7 +859,7 @@ TEST(TrafficLightArbiterCorePerceptionStaleness, freshPerceptionRemainsEffective
 
 // External is silent: with no external stamp to compare against, the
 // staleness check has nothing to evaluate and the perception side
-// reaches the output even when its stamp lags kBaseTime by far more
+// reaches the output even when its stamp lags base_time by far more
 // than the tolerance.
 //
 // This asymmetry predates the Core extraction — only the external side
@@ -876,7 +876,7 @@ TEST(TrafficLightArbiterCorePerceptionStaleness, perceptionAloneIsNeverStale)
   auto arbiter = make_arbiter(CONFIDENCE, /*enable_signal_matching=*/false);
 
   const auto t_perception =
-    kBaseTime - rclcpp::Duration::from_seconds(kDefaultPerceptionTimeTolerance + 10.0);
+    base_time - rclcpp::Duration::from_seconds(default_perception_time_tolerance + 10.0);
 
   arbiter.ingest_perception(
     make_signals(t_perception, {make_group(map_ids::vehicle_a, {make_element(RED, CIRCLE)})}));
@@ -896,13 +896,13 @@ TEST(TrafficLightArbiterCorePerceptionStaleness, stalenessDropsEntirePerceptionM
   auto arbiter = make_arbiter(CONFIDENCE, /*enable_signal_matching=*/false);
 
   const auto t_perception =
-    kBaseTime - rclcpp::Duration::from_seconds(kDefaultPerceptionTimeTolerance + 1.0);
+    base_time - rclcpp::Duration::from_seconds(default_perception_time_tolerance + 1.0);
 
   arbiter.ingest_perception(
     make_signals(t_perception, {make_group(map_ids::vehicle_a, {make_element(RED, CIRCLE)})}));
   arbiter.ingest_external(
-    make_signals(kBaseTime, {make_group(map_ids::vehicle_b, {make_element(GREEN, CIRCLE)})}),
-    kBaseTime);
+    make_signals(base_time, {make_group(map_ids::vehicle_b, {make_element(GREEN, CIRCLE)})}),
+    base_time);
 
   const auto result = arbiter.arbitrate();
 
@@ -917,7 +917,7 @@ TEST(TrafficLightArbiterCorePerceptionStaleness, stalePerceptionPredictionsAreSk
   auto arbiter = make_arbiter(CONFIDENCE, /*enable_signal_matching=*/false);
 
   const auto t_perception =
-    kBaseTime - rclcpp::Duration::from_seconds(kDefaultPerceptionTimeTolerance + 1.0);
+    base_time - rclcpp::Duration::from_seconds(default_perception_time_tolerance + 1.0);
 
   arbiter.ingest_perception(make_signals(
     t_perception, {make_group(
@@ -925,10 +925,10 @@ TEST(TrafficLightArbiterCorePerceptionStaleness, stalePerceptionPredictionsAreSk
                     {make_prediction(t_perception, INTERNAL_ESTIMATION)})}));
   arbiter.ingest_external(
     make_signals(
-      kBaseTime,
+      base_time,
       {make_group(
-        map_ids::vehicle_a, {make_element(GREEN, CIRCLE)}, {make_prediction(kBaseTime, V2I)})}),
-    kBaseTime);
+        map_ids::vehicle_a, {make_element(GREEN, CIRCLE)}, {make_prediction(base_time, V2I)})}),
+    base_time);
 
   const auto result = arbiter.arbitrate();
 
@@ -947,10 +947,10 @@ TEST(TrafficLightArbiterCoreLatestInputTime, takesNewerOfPerceptionAndExternal)
 {
   auto arbiter = make_arbiter(CONFIDENCE, /*enable_signal_matching=*/false);
 
-  const auto t_external_newer = kBaseTime + rclcpp::Duration::from_seconds(0.5);
+  const auto t_external_newer = base_time + rclcpp::Duration::from_seconds(0.5);
 
   arbiter.ingest_perception(
-    make_signals(kBaseTime, {make_group(map_ids::vehicle_a, {make_element(RED, CIRCLE)})}));
+    make_signals(base_time, {make_group(map_ids::vehicle_a, {make_element(RED, CIRCLE)})}));
   arbiter.ingest_external(
     make_signals(t_external_newer, {make_group(map_ids::vehicle_a, {make_element(RED, CIRCLE)})}),
     t_external_newer);
@@ -966,11 +966,11 @@ TEST(TrafficLightArbiterCoreLatestInputTime, perceptionWinsWhenNewer)
 {
   auto arbiter = make_arbiter(CONFIDENCE, /*enable_signal_matching=*/false);
 
-  const auto t_perception_newer = kBaseTime + rclcpp::Duration::from_seconds(0.3);
+  const auto t_perception_newer = base_time + rclcpp::Duration::from_seconds(0.3);
 
   arbiter.ingest_external(
-    make_signals(kBaseTime, {make_group(map_ids::vehicle_a, {make_element(RED, CIRCLE)})}),
-    kBaseTime);
+    make_signals(base_time, {make_group(map_ids::vehicle_a, {make_element(RED, CIRCLE)})}),
+    base_time);
   arbiter.ingest_perception(make_signals(
     t_perception_newer, {make_group(map_ids::vehicle_a, {make_element(RED, CIRCLE)})}));
 
@@ -985,7 +985,7 @@ TEST(TrafficLightArbiterCoreLatestInputTime, perceptionStampWhenExternalIsSilent
 {
   auto arbiter = make_arbiter(CONFIDENCE, /*enable_signal_matching=*/false);
 
-  const auto t_perception = kBaseTime + rclcpp::Duration::from_seconds(0.5);
+  const auto t_perception = base_time + rclcpp::Duration::from_seconds(0.5);
 
   arbiter.ingest_perception(
     make_signals(t_perception, {make_group(map_ids::vehicle_a, {make_element(RED, CIRCLE)})}));
@@ -1008,11 +1008,11 @@ TEST(TrafficLightArbiterCoreTiming, ingestExternalAcceptsStampsWithinTolerance)
   auto arbiter = make_arbiter(CONFIDENCE, /*enable_signal_matching=*/false);
 
   const auto t_past_within =
-    kBaseTime - rclcpp::Duration::from_seconds(kDefaultExternalDelayTolerance - 1.0);
+    base_time - rclcpp::Duration::from_seconds(default_external_delay_tolerance - 1.0);
 
   const auto result = arbiter.ingest_external(
     make_signals(t_past_within, {make_group(map_ids::vehicle_a, {make_element(RED, CIRCLE)})}),
-    kBaseTime);
+    base_time);
 
   EXPECT_TRUE(result.accepted);
 }
@@ -1024,11 +1024,11 @@ TEST(TrafficLightArbiterCoreTiming, ingestExternalRejectsTooOldStamps)
   auto arbiter = make_arbiter(CONFIDENCE, /*enable_signal_matching=*/false);
 
   const auto t_past_beyond =
-    kBaseTime - rclcpp::Duration::from_seconds(kDefaultExternalDelayTolerance + 1.0);
+    base_time - rclcpp::Duration::from_seconds(default_external_delay_tolerance + 1.0);
 
   const auto result = arbiter.ingest_external(
     make_signals(t_past_beyond, {make_group(map_ids::vehicle_a, {make_element(RED, CIRCLE)})}),
-    kBaseTime);
+    base_time);
 
   EXPECT_FALSE(result.accepted);
 }
@@ -1041,11 +1041,11 @@ TEST(TrafficLightArbiterCoreTiming, ingestExternalRejectsTooFutureStamps)
   auto arbiter = make_arbiter(CONFIDENCE, /*enable_signal_matching=*/false);
 
   const auto t_future_beyond =
-    kBaseTime + rclcpp::Duration::from_seconds(kDefaultExternalDelayTolerance + 1.0);
+    base_time + rclcpp::Duration::from_seconds(default_external_delay_tolerance + 1.0);
 
   const auto result = arbiter.ingest_external(
     make_signals(t_future_beyond, {make_group(map_ids::vehicle_a, {make_element(RED, CIRCLE)})}),
-    kBaseTime);
+    base_time);
 
   EXPECT_FALSE(result.accepted);
 }
@@ -1059,17 +1059,17 @@ TEST(TrafficLightArbiterCoreTiming, ingestPerceptionReportsExpiredExternalEntry)
   auto arbiter = make_arbiter(CONFIDENCE, /*enable_signal_matching=*/false);
 
   arbiter.ingest_external(
-    make_signals(kBaseTime, {make_group(map_ids::vehicle_a, {make_element(RED, CIRCLE)})}),
-    kBaseTime);
+    make_signals(base_time, {make_group(map_ids::vehicle_a, {make_element(RED, CIRCLE)})}),
+    base_time);
   const auto t_perception =
-    kBaseTime + rclcpp::Duration::from_seconds(kDefaultExternalTimeTolerance + 1.0);
+    base_time + rclcpp::Duration::from_seconds(default_external_time_tolerance + 1.0);
 
   const auto expired = arbiter.ingest_perception(
     make_signals(t_perception, {make_group(map_ids::vehicle_b, {make_element(GREEN, CIRCLE)})}));
 
   ASSERT_EQ(expired.size(), 1u);
   EXPECT_EQ(expired.front().id, map_ids::vehicle_a);
-  EXPECT_GT(expired.front().age, kDefaultExternalTimeTolerance);
+  EXPECT_GT(expired.front().age, default_external_time_tolerance);
 }
 
 // Sweep-on-ingest downstream effect: an external entry evicted by the
@@ -1080,10 +1080,10 @@ TEST(TrafficLightArbiterCoreTiming, evictedExternalEntryAbsentFromOutput)
   auto arbiter = make_arbiter(CONFIDENCE, /*enable_signal_matching=*/false);
 
   arbiter.ingest_external(
-    make_signals(kBaseTime, {make_group(map_ids::vehicle_a, {make_element(RED, CIRCLE)})}),
-    kBaseTime);
+    make_signals(base_time, {make_group(map_ids::vehicle_a, {make_element(RED, CIRCLE)})}),
+    base_time);
   const auto t_perception =
-    kBaseTime + rclcpp::Duration::from_seconds(kDefaultExternalTimeTolerance + 1.0);
+    base_time + rclcpp::Duration::from_seconds(default_external_time_tolerance + 1.0);
   arbiter.ingest_perception(
     make_signals(t_perception, {make_group(map_ids::vehicle_b, {make_element(GREEN, CIRCLE)})}));
 

--- a/perception/autoware_traffic_light_arbiter/test/test_traffic_light_arbiter_core.cpp
+++ b/perception/autoware_traffic_light_arbiter/test/test_traffic_light_arbiter_core.cpp
@@ -46,6 +46,25 @@ using TrafficLightElement = autoware_perception_msgs::msg::TrafficLightElement;
 using TrafficLightGroup = autoware_perception_msgs::msg::TrafficLightGroup;
 using TrafficLightGroupArray = autoware_perception_msgs::msg::TrafficLightGroupArray;
 
+// --- Short aliases for enum values used throughout the tests ----------
+//
+// Anonymous-namespace scoped so they don't leak; keeps each test's reading
+// flow on color/shape/priority rather than on the enum-qualifying prefix.
+
+constexpr auto CONFIDENCE = SourcePriority::CONFIDENCE;
+constexpr auto EXTERNAL = SourcePriority::EXTERNAL;
+constexpr auto PERCEPTION = SourcePriority::PERCEPTION;
+
+constexpr uint8_t RED = TrafficLightElement::RED;
+constexpr uint8_t GREEN = TrafficLightElement::GREEN;
+constexpr uint8_t UNKNOWN = TrafficLightElement::UNKNOWN;
+constexpr uint8_t CIRCLE = TrafficLightElement::CIRCLE;
+constexpr uint8_t RIGHT_ARROW = TrafficLightElement::RIGHT_ARROW;
+
+const std::string & INTERNAL_ESTIMATION =
+  PredictedTrafficLightState::INFORMATION_SOURCE_INTERNAL_ESTIMATION;
+const std::string & V2I = PredictedTrafficLightState::INFORMATION_SOURCE_V2I;
+
 // --- Map construction --------------------------------------------------
 
 lanelet::Point3d make_point(lanelet::Id id, double x, double y, double z = 0.0)
@@ -152,16 +171,14 @@ TrafficLightGroup make_group(
 // Predictions ride unmodified through arbitrate(), so the body fields
 // chosen here only need to be syntactically valid.
 PredictedTrafficLightState make_prediction(
-  const rclcpp::Time & stamp,
-  const std::string & source = PredictedTrafficLightState::INFORMATION_SOURCE_INTERNAL_ESTIMATION)
+  const rclcpp::Time & stamp, const std::string & source = INTERNAL_ESTIMATION)
 {
   constexpr int32_t kPredictionOffsetSec = 10;
   constexpr float kFullCertainty = 1.0f;
   PredictedTrafficLightState prediction;
   prediction.predicted_stamp = stamp;
   prediction.predicted_stamp.sec += kPredictionOffsetSec;
-  prediction.simultaneous_elements.push_back(
-    make_element(TrafficLightElement::UNKNOWN, TrafficLightElement::CIRCLE, kFullCertainty));
+  prediction.simultaneous_elements.push_back(make_element(UNKNOWN, CIRCLE, kFullCertainty));
   prediction.reliability = kFullCertainty;
   prediction.information_source = source;
   return prediction;
@@ -306,22 +323,17 @@ TrafficLightArbiterCore make_arbiter(SourcePriority priority, bool enable_signal
 // output carries the same element verbatim.
 TEST(TrafficLightArbiterCoreSignalMatching, matchedSignalsPassThrough)
 {
-  auto arbiter = make_arbiter(SourcePriority::CONFIDENCE, /*enable_signal_matching=*/true);
+  auto arbiter = make_arbiter(CONFIDENCE, /*enable_signal_matching=*/true);
 
   arbiter.ingest_external(
-    make_signals(
-      kBaseTime, {make_group(
-                   map_ids::vehicle_a,
-                   {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)})}),
+    make_signals(kBaseTime, {make_group(map_ids::vehicle_a, {make_element(RED, CIRCLE)})}),
     kBaseTime);
-  arbiter.ingest_perception(make_signals(
-    kBaseTime,
-    {make_group(
-      map_ids::vehicle_a, {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)})}));
+  arbiter.ingest_perception(
+    make_signals(kBaseTime, {make_group(map_ids::vehicle_a, {make_element(RED, CIRCLE)})}));
 
   const auto result = arbiter.arbitrate();
 
-  EXPECT_EQ(observed_color(result.output, map_ids::vehicle_a), TrafficLightElement::RED);
+  EXPECT_EQ(observed_color(result.output, map_ids::vehicle_a), RED);
 }
 
 // Agreement is decided by color/shape only — confidence does not factor
@@ -331,22 +343,17 @@ TEST(TrafficLightArbiterCoreSignalMatching, matchedSignalsPassThrough)
 // confidences did not break the match.
 TEST(TrafficLightArbiterCoreSignalMatching, differingConfidencesStillMatch)
 {
-  auto arbiter = make_arbiter(SourcePriority::CONFIDENCE, /*enable_signal_matching=*/true);
+  auto arbiter = make_arbiter(CONFIDENCE, /*enable_signal_matching=*/true);
 
   arbiter.ingest_external(
-    make_signals(
-      kBaseTime, {make_group(
-                   map_ids::vehicle_a,
-                   {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.10f)})}),
+    make_signals(kBaseTime, {make_group(map_ids::vehicle_a, {make_element(RED, CIRCLE, 0.10f)})}),
     kBaseTime);
-  arbiter.ingest_perception(make_signals(
-    kBaseTime, {make_group(
-                 map_ids::vehicle_a,
-                 {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.90f)})}));
+  arbiter.ingest_perception(
+    make_signals(kBaseTime, {make_group(map_ids::vehicle_a, {make_element(RED, CIRCLE, 0.90f)})}));
 
   const auto result = arbiter.arbitrate();
 
-  EXPECT_EQ(observed_color(result.output, map_ids::vehicle_a), TrafficLightElement::RED);
+  EXPECT_EQ(observed_color(result.output, map_ids::vehicle_a), RED);
   EXPECT_NEAR(observed_confidence(result.output, map_ids::vehicle_a).value_or(-1.0f), 0.90f, 1e-5f);
 }
 
@@ -354,50 +361,37 @@ TEST(TrafficLightArbiterCoreSignalMatching, differingConfidencesStillMatch)
 // the output falls back to UNKNOWN over that shape.
 TEST(TrafficLightArbiterCoreSignalMatching, colorMismatchProducesUnknown)
 {
-  auto arbiter = make_arbiter(SourcePriority::CONFIDENCE, /*enable_signal_matching=*/true);
+  auto arbiter = make_arbiter(CONFIDENCE, /*enable_signal_matching=*/true);
 
   arbiter.ingest_external(
-    make_signals(
-      kBaseTime, {make_group(
-                   map_ids::vehicle_b,
-                   {make_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE)})}),
+    make_signals(kBaseTime, {make_group(map_ids::vehicle_b, {make_element(GREEN, CIRCLE)})}),
     kBaseTime);
-  arbiter.ingest_perception(make_signals(
-    kBaseTime,
-    {make_group(
-      map_ids::vehicle_b, {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)})}));
+  arbiter.ingest_perception(
+    make_signals(kBaseTime, {make_group(map_ids::vehicle_b, {make_element(RED, CIRCLE)})}));
 
   const auto result = arbiter.arbitrate();
 
-  EXPECT_EQ(observed_color(result.output, map_ids::vehicle_b), TrafficLightElement::UNKNOWN);
+  EXPECT_EQ(observed_color(result.output, map_ids::vehicle_b), UNKNOWN);
 }
 
 // Shape-set mismatch: perception has CIRCLE + RIGHT_ARROW, external has
 // only CIRCLE → the output is UNKNOWN over the shape union.
 TEST(TrafficLightArbiterCoreSignalMatching, shapeSetMismatchProducesUnknown)
 {
-  auto arbiter = make_arbiter(SourcePriority::CONFIDENCE, /*enable_signal_matching=*/true);
+  auto arbiter = make_arbiter(CONFIDENCE, /*enable_signal_matching=*/true);
 
   arbiter.ingest_external(
-    make_signals(
-      kBaseTime, {make_group(
-                   map_ids::vehicle_b,
-                   {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)})}),
+    make_signals(kBaseTime, {make_group(map_ids::vehicle_b, {make_element(RED, CIRCLE)})}),
     kBaseTime);
   arbiter.ingest_perception(make_signals(
-    kBaseTime, {make_group(
-                 map_ids::vehicle_b,
-                 {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE),
-                  make_element(TrafficLightElement::GREEN, TrafficLightElement::RIGHT_ARROW)})}));
+    kBaseTime,
+    {make_group(
+      map_ids::vehicle_b, {make_element(RED, CIRCLE), make_element(GREEN, RIGHT_ARROW)})}));
 
   const auto result = arbiter.arbitrate();
 
-  EXPECT_EQ(
-    observed_color_of_shape(result.output, map_ids::vehicle_b, TrafficLightElement::CIRCLE),
-    TrafficLightElement::UNKNOWN);
-  EXPECT_EQ(
-    observed_color_of_shape(result.output, map_ids::vehicle_b, TrafficLightElement::RIGHT_ARROW),
-    TrafficLightElement::UNKNOWN);
+  EXPECT_EQ(observed_color_of_shape(result.output, map_ids::vehicle_b, CIRCLE), UNKNOWN);
+  EXPECT_EQ(observed_color_of_shape(result.output, map_ids::vehicle_b, RIGHT_ARROW), UNKNOWN);
 }
 
 // Perception-only single source: with no external to agree with, the
@@ -405,16 +399,14 @@ TEST(TrafficLightArbiterCoreSignalMatching, shapeSetMismatchProducesUnknown)
 // unchanged instead — see singleSourcePedestrianPassesThrough.
 TEST(TrafficLightArbiterCoreSignalMatching, perceptionOnlySingleSourceYieldsUnknown)
 {
-  auto arbiter = make_arbiter(SourcePriority::CONFIDENCE, /*enable_signal_matching=*/true);
+  auto arbiter = make_arbiter(CONFIDENCE, /*enable_signal_matching=*/true);
 
-  arbiter.ingest_perception(make_signals(
-    kBaseTime,
-    {make_group(
-      map_ids::vehicle_a, {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)})}));
+  arbiter.ingest_perception(
+    make_signals(kBaseTime, {make_group(map_ids::vehicle_a, {make_element(RED, CIRCLE)})}));
 
   const auto result = arbiter.arbitrate();
 
-  EXPECT_EQ(observed_color(result.output, map_ids::vehicle_a), TrafficLightElement::UNKNOWN);
+  EXPECT_EQ(observed_color(result.output, map_ids::vehicle_a), UNKNOWN);
 }
 
 // External-only single source: symmetric counterpart — reconciliation is
@@ -422,30 +414,24 @@ TEST(TrafficLightArbiterCoreSignalMatching, perceptionOnlySingleSourceYieldsUnkn
 // perception is the missing side.
 TEST(TrafficLightArbiterCoreSignalMatching, externalOnlySingleSourceYieldsUnknown)
 {
-  auto arbiter = make_arbiter(SourcePriority::CONFIDENCE, /*enable_signal_matching=*/true);
+  auto arbiter = make_arbiter(CONFIDENCE, /*enable_signal_matching=*/true);
 
   arbiter.ingest_external(
-    make_signals(
-      kBaseTime, {make_group(
-                   map_ids::vehicle_a,
-                   {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)})}),
+    make_signals(kBaseTime, {make_group(map_ids::vehicle_a, {make_element(RED, CIRCLE)})}),
     kBaseTime);
 
   const auto result = arbiter.arbitrate();
 
-  EXPECT_EQ(observed_color(result.output, map_ids::vehicle_a), TrafficLightElement::UNKNOWN);
+  EXPECT_EQ(observed_color(result.output, map_ids::vehicle_a), UNKNOWN);
 }
 
 // Off-map id is dropped from the output and recorded in off_map_signal_ids.
 TEST(TrafficLightArbiterCoreSignalMatching, offMapIdIsDroppedAndReported)
 {
-  auto arbiter = make_arbiter(SourcePriority::CONFIDENCE, /*enable_signal_matching=*/true);
+  auto arbiter = make_arbiter(CONFIDENCE, /*enable_signal_matching=*/true);
 
   arbiter.ingest_external(
-    make_signals(
-      kBaseTime, {make_group(
-                   map_ids::off_map_probe,
-                   {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)})}),
+    make_signals(kBaseTime, {make_group(map_ids::off_map_probe, {make_element(RED, CIRCLE)})}),
     kBaseTime);
 
   const auto result = arbiter.arbitrate();
@@ -466,66 +452,51 @@ TEST(TrafficLightArbiterCoreSignalMatching, offMapIdIsDroppedAndReported)
 // its confidence is lower than perception's.
 TEST(TrafficLightArbiterCorePedestrian, externalPriorityWinsForPedestrian)
 {
-  auto arbiter = make_arbiter(SourcePriority::EXTERNAL, /*enable_signal_matching=*/true);
+  auto arbiter = make_arbiter(EXTERNAL, /*enable_signal_matching=*/true);
 
   arbiter.ingest_external(
-    make_signals(
-      kBaseTime, {make_group(
-                   map_ids::pedestrian,
-                   {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.1f)})}),
+    make_signals(kBaseTime, {make_group(map_ids::pedestrian, {make_element(RED, CIRCLE, 0.1f)})}),
     kBaseTime);
   arbiter.ingest_perception(make_signals(
-    kBaseTime, {make_group(
-                 map_ids::pedestrian,
-                 {make_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.9f)})}));
+    kBaseTime, {make_group(map_ids::pedestrian, {make_element(GREEN, CIRCLE, 0.9f)})}));
 
   const auto result = arbiter.arbitrate();
 
-  EXPECT_EQ(observed_color(result.output, map_ids::pedestrian), TrafficLightElement::RED);
+  EXPECT_EQ(observed_color(result.output, map_ids::pedestrian), RED);
 }
 
 // PERCEPTION priority: symmetric counterpart — for pedestrian ids the
 // perception side wins even when its confidence is lower than external's.
 TEST(TrafficLightArbiterCorePedestrian, perceptionPriorityWinsForPedestrian)
 {
-  auto arbiter = make_arbiter(SourcePriority::PERCEPTION, /*enable_signal_matching=*/true);
+  auto arbiter = make_arbiter(PERCEPTION, /*enable_signal_matching=*/true);
 
   arbiter.ingest_external(
-    make_signals(
-      kBaseTime, {make_group(
-                   map_ids::pedestrian,
-                   {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.99f)})}),
+    make_signals(kBaseTime, {make_group(map_ids::pedestrian, {make_element(RED, CIRCLE, 0.99f)})}),
     kBaseTime);
   arbiter.ingest_perception(make_signals(
-    kBaseTime, {make_group(
-                 map_ids::pedestrian,
-                 {make_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.10f)})}));
+    kBaseTime, {make_group(map_ids::pedestrian, {make_element(GREEN, CIRCLE, 0.10f)})}));
 
   const auto result = arbiter.arbitrate();
 
-  EXPECT_EQ(observed_color(result.output, map_ids::pedestrian), TrafficLightElement::GREEN);
+  EXPECT_EQ(observed_color(result.output, map_ids::pedestrian), GREEN);
 }
 
 // CONFIDENCE mode: for pedestrian ids the arbiter walks each shape and
 // picks the side with the higher confidence.
 TEST(TrafficLightArbiterCorePedestrian, confidenceModePicksHigherConfidenceForPedestrian)
 {
-  auto arbiter = make_arbiter(SourcePriority::CONFIDENCE, /*enable_signal_matching=*/true);
+  auto arbiter = make_arbiter(CONFIDENCE, /*enable_signal_matching=*/true);
 
   arbiter.ingest_external(
-    make_signals(
-      kBaseTime, {make_group(
-                   map_ids::pedestrian,
-                   {make_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.6f)})}),
+    make_signals(kBaseTime, {make_group(map_ids::pedestrian, {make_element(GREEN, CIRCLE, 0.6f)})}),
     kBaseTime);
-  arbiter.ingest_perception(make_signals(
-    kBaseTime, {make_group(
-                 map_ids::pedestrian,
-                 {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.9f)})}));
+  arbiter.ingest_perception(
+    make_signals(kBaseTime, {make_group(map_ids::pedestrian, {make_element(RED, CIRCLE, 0.9f)})}));
 
   const auto result = arbiter.arbitrate();
 
-  EXPECT_EQ(observed_color(result.output, map_ids::pedestrian), TrafficLightElement::RED);
+  EXPECT_EQ(observed_color(result.output, map_ids::pedestrian), RED);
 }
 
 // Single-source pedestrian: contrast with the non-pedestrian behaviour
@@ -535,16 +506,14 @@ TEST(TrafficLightArbiterCorePedestrian, confidenceModePicksHigherConfidenceForPe
 // the absent side.
 TEST(TrafficLightArbiterCorePedestrian, singleSourcePedestrianPassesThrough)
 {
-  auto arbiter = make_arbiter(SourcePriority::EXTERNAL, /*enable_signal_matching=*/true);
+  auto arbiter = make_arbiter(EXTERNAL, /*enable_signal_matching=*/true);
 
-  arbiter.ingest_perception(make_signals(
-    kBaseTime, {make_group(
-                 map_ids::pedestrian,
-                 {make_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE)})}));
+  arbiter.ingest_perception(
+    make_signals(kBaseTime, {make_group(map_ids::pedestrian, {make_element(GREEN, CIRCLE)})}));
 
   const auto result = arbiter.arbitrate();
 
-  EXPECT_EQ(observed_color(result.output, map_ids::pedestrian), TrafficLightElement::GREEN);
+  EXPECT_EQ(observed_color(result.output, map_ids::pedestrian), GREEN);
 }
 
 // ---------------------------------------------------------------------------
@@ -555,22 +524,17 @@ TEST(TrafficLightArbiterCorePedestrian, singleSourcePedestrianPassesThrough)
 // wins (here, perception 0.9 over external 0.7).
 TEST(TrafficLightArbiterCoreConfidencePriority, picksHigherConfidenceElement)
 {
-  auto arbiter = make_arbiter(SourcePriority::CONFIDENCE, /*enable_signal_matching=*/false);
+  auto arbiter = make_arbiter(CONFIDENCE, /*enable_signal_matching=*/false);
 
   arbiter.ingest_external(
-    make_signals(
-      kBaseTime, {make_group(
-                   map_ids::vehicle_a,
-                   {make_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.7f)})}),
+    make_signals(kBaseTime, {make_group(map_ids::vehicle_a, {make_element(GREEN, CIRCLE, 0.7f)})}),
     kBaseTime);
-  arbiter.ingest_perception(make_signals(
-    kBaseTime, {make_group(
-                 map_ids::vehicle_a,
-                 {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.9f)})}));
+  arbiter.ingest_perception(
+    make_signals(kBaseTime, {make_group(map_ids::vehicle_a, {make_element(RED, CIRCLE, 0.9f)})}));
 
   const auto result = arbiter.arbitrate();
 
-  EXPECT_EQ(observed_color(result.output, map_ids::vehicle_a), TrafficLightElement::RED);
+  EXPECT_EQ(observed_color(result.output, map_ids::vehicle_a), RED);
 }
 
 // Per-shape union: when each side contributes a different shape under
@@ -579,43 +543,32 @@ TEST(TrafficLightArbiterCoreConfidencePriority, picksHigherConfidenceElement)
 // side does not block external's RIGHT_ARROW and vice versa.
 TEST(TrafficLightArbiterCoreConfidencePriority, perShapeUnionFromBothSides)
 {
-  auto arbiter = make_arbiter(SourcePriority::CONFIDENCE, /*enable_signal_matching=*/false);
+  auto arbiter = make_arbiter(CONFIDENCE, /*enable_signal_matching=*/false);
 
-  arbiter.ingest_perception(make_signals(
-    kBaseTime,
-    {make_group(
-      map_ids::vehicle_a, {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)})}));
+  arbiter.ingest_perception(
+    make_signals(kBaseTime, {make_group(map_ids::vehicle_a, {make_element(RED, CIRCLE)})}));
   arbiter.ingest_external(
-    make_signals(
-      kBaseTime, {make_group(
-                   map_ids::vehicle_a,
-                   {make_element(TrafficLightElement::GREEN, TrafficLightElement::RIGHT_ARROW)})}),
+    make_signals(kBaseTime, {make_group(map_ids::vehicle_a, {make_element(GREEN, RIGHT_ARROW)})}),
     kBaseTime);
 
   const auto result = arbiter.arbitrate();
 
-  EXPECT_EQ(
-    observed_color_of_shape(result.output, map_ids::vehicle_a, TrafficLightElement::CIRCLE),
-    TrafficLightElement::RED);
-  EXPECT_EQ(
-    observed_color_of_shape(result.output, map_ids::vehicle_a, TrafficLightElement::RIGHT_ARROW),
-    TrafficLightElement::GREEN);
+  EXPECT_EQ(observed_color_of_shape(result.output, map_ids::vehicle_a, CIRCLE), RED);
+  EXPECT_EQ(observed_color_of_shape(result.output, map_ids::vehicle_a, RIGHT_ARROW), GREEN);
 }
 
 // Perception-only: with no external present, the perception element flows
 // through unchanged regardless of priority mode.
 TEST(TrafficLightArbiterCoreConfidencePriority, perceptionOnlyPassesThrough)
 {
-  auto arbiter = make_arbiter(SourcePriority::CONFIDENCE, /*enable_signal_matching=*/false);
+  auto arbiter = make_arbiter(CONFIDENCE, /*enable_signal_matching=*/false);
 
-  arbiter.ingest_perception(make_signals(
-    kBaseTime, {make_group(
-                 map_ids::vehicle_b,
-                 {make_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE)})}));
+  arbiter.ingest_perception(
+    make_signals(kBaseTime, {make_group(map_ids::vehicle_b, {make_element(GREEN, CIRCLE)})}));
 
   const auto result = arbiter.arbitrate();
 
-  EXPECT_EQ(observed_color(result.output, map_ids::vehicle_b), TrafficLightElement::GREEN);
+  EXPECT_EQ(observed_color(result.output, map_ids::vehicle_b), GREEN);
 }
 
 // Off-map id is dropped before reaching priority selection too. Pins the
@@ -623,13 +576,10 @@ TEST(TrafficLightArbiterCoreConfidencePriority, perceptionOnlyPassesThrough)
 // counterpart in offMapIdIsDroppedAndReported).
 TEST(TrafficLightArbiterCoreConfidencePriority, offMapIdIsDroppedAndReported)
 {
-  auto arbiter = make_arbiter(SourcePriority::CONFIDENCE, /*enable_signal_matching=*/false);
+  auto arbiter = make_arbiter(CONFIDENCE, /*enable_signal_matching=*/false);
 
   arbiter.ingest_external(
-    make_signals(
-      kBaseTime, {make_group(
-                   map_ids::off_map_probe,
-                   {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)})}),
+    make_signals(kBaseTime, {make_group(map_ids::off_map_probe, {make_element(RED, CIRCLE)})}),
     kBaseTime);
 
   const auto result = arbiter.arbitrate();
@@ -642,25 +592,19 @@ TEST(TrafficLightArbiterCoreConfidencePriority, offMapIdIsDroppedAndReported)
 // cache; both end up in the final output with their published colors.
 TEST(TrafficLightArbiterCoreConfidencePriority, multipleExternalSourcesAccumulate)
 {
-  auto arbiter = make_arbiter(SourcePriority::CONFIDENCE, /*enable_signal_matching=*/false);
+  auto arbiter = make_arbiter(CONFIDENCE, /*enable_signal_matching=*/false);
 
   arbiter.ingest_external(
-    make_signals(
-      kBaseTime, {make_group(
-                   map_ids::vehicle_a,
-                   {make_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE)})}),
+    make_signals(kBaseTime, {make_group(map_ids::vehicle_a, {make_element(GREEN, CIRCLE)})}),
     kBaseTime);
   arbiter.ingest_external(
-    make_signals(
-      kBaseTime, {make_group(
-                   map_ids::vehicle_b,
-                   {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)})}),
+    make_signals(kBaseTime, {make_group(map_ids::vehicle_b, {make_element(RED, CIRCLE)})}),
     kBaseTime);
 
   const auto result = arbiter.arbitrate();
 
-  EXPECT_EQ(observed_color(result.output, map_ids::vehicle_a), TrafficLightElement::GREEN);
-  EXPECT_EQ(observed_color(result.output, map_ids::vehicle_b), TrafficLightElement::RED);
+  EXPECT_EQ(observed_color(result.output, map_ids::vehicle_a), GREEN);
+  EXPECT_EQ(observed_color(result.output, map_ids::vehicle_b), RED);
 }
 
 // Predictions ride alongside elements: when both sides carry one each,
@@ -669,50 +613,39 @@ TEST(TrafficLightArbiterCoreConfidencePriority, multipleExternalSourcesAccumulat
 // Confidence is a fine host for this pin.
 TEST(TrafficLightArbiterCoreConfidencePriority, predictionsFromBothSidesAreMerged)
 {
-  auto arbiter = make_arbiter(SourcePriority::CONFIDENCE, /*enable_signal_matching=*/false);
+  auto arbiter = make_arbiter(CONFIDENCE, /*enable_signal_matching=*/false);
 
   arbiter.ingest_perception(make_signals(
-    kBaseTime,
-    {make_group(
-      map_ids::vehicle_a, {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)},
-      {make_prediction(
-        kBaseTime, PredictedTrafficLightState::INFORMATION_SOURCE_INTERNAL_ESTIMATION)})}));
+    kBaseTime, {make_group(
+                 map_ids::vehicle_a, {make_element(RED, CIRCLE)},
+                 {make_prediction(kBaseTime, INTERNAL_ESTIMATION)})}));
   arbiter.ingest_external(
     make_signals(
       kBaseTime,
       {make_group(
-        map_ids::vehicle_a, {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)},
-        {make_prediction(kBaseTime, PredictedTrafficLightState::INFORMATION_SOURCE_V2I)})}),
+        map_ids::vehicle_a, {make_element(RED, CIRCLE)}, {make_prediction(kBaseTime, V2I)})}),
     kBaseTime);
 
   const auto result = arbiter.arbitrate();
 
-  EXPECT_EQ(
-    observed_prediction_source(result.output, map_ids::vehicle_a, 0),
-    PredictedTrafficLightState::INFORMATION_SOURCE_INTERNAL_ESTIMATION);
-  EXPECT_EQ(
-    observed_prediction_source(result.output, map_ids::vehicle_a, 1),
-    PredictedTrafficLightState::INFORMATION_SOURCE_V2I);
+  EXPECT_EQ(observed_prediction_source(result.output, map_ids::vehicle_a, 0), INTERNAL_ESTIMATION);
+  EXPECT_EQ(observed_prediction_source(result.output, map_ids::vehicle_a, 1), V2I);
 }
 
 // Perception-only side: when external is silent, the perception side's
 // prediction (with its information_source) still reaches the output.
 TEST(TrafficLightArbiterCoreConfidencePriority, perceptionOnlyPredictionPropagates)
 {
-  auto arbiter = make_arbiter(SourcePriority::CONFIDENCE, /*enable_signal_matching=*/false);
+  auto arbiter = make_arbiter(CONFIDENCE, /*enable_signal_matching=*/false);
 
   arbiter.ingest_perception(make_signals(
-    kBaseTime,
-    {make_group(
-      map_ids::vehicle_a, {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)},
-      {make_prediction(
-        kBaseTime, PredictedTrafficLightState::INFORMATION_SOURCE_INTERNAL_ESTIMATION)})}));
+    kBaseTime, {make_group(
+                 map_ids::vehicle_a, {make_element(RED, CIRCLE)},
+                 {make_prediction(kBaseTime, INTERNAL_ESTIMATION)})}));
 
   const auto result = arbiter.arbitrate();
 
-  EXPECT_EQ(
-    observed_prediction_source(result.output, map_ids::vehicle_a, 0),
-    PredictedTrafficLightState::INFORMATION_SOURCE_INTERNAL_ESTIMATION);
+  EXPECT_EQ(observed_prediction_source(result.output, map_ids::vehicle_a, 0), INTERNAL_ESTIMATION);
 }
 
 // External-only side: symmetric counterpart — when perception is silent,
@@ -720,21 +653,18 @@ TEST(TrafficLightArbiterCoreConfidencePriority, perceptionOnlyPredictionPropagat
 // the output.
 TEST(TrafficLightArbiterCoreConfidencePriority, externalOnlyPredictionPropagates)
 {
-  auto arbiter = make_arbiter(SourcePriority::CONFIDENCE, /*enable_signal_matching=*/false);
+  auto arbiter = make_arbiter(CONFIDENCE, /*enable_signal_matching=*/false);
 
   arbiter.ingest_external(
     make_signals(
       kBaseTime,
       {make_group(
-        map_ids::vehicle_a, {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)},
-        {make_prediction(kBaseTime, PredictedTrafficLightState::INFORMATION_SOURCE_V2I)})}),
+        map_ids::vehicle_a, {make_element(RED, CIRCLE)}, {make_prediction(kBaseTime, V2I)})}),
     kBaseTime);
 
   const auto result = arbiter.arbitrate();
 
-  EXPECT_EQ(
-    observed_prediction_source(result.output, map_ids::vehicle_a, 0),
-    PredictedTrafficLightState::INFORMATION_SOURCE_V2I);
+  EXPECT_EQ(observed_prediction_source(result.output, map_ids::vehicle_a, 0), V2I);
 }
 
 // ---------------------------------------------------------------------------
@@ -745,40 +675,32 @@ TEST(TrafficLightArbiterCoreConfidencePriority, externalOnlyPredictionPropagates
 // the external side to win over a higher-confidence perception.
 TEST(TrafficLightArbiterCoreExternalPriority, externalPriorityOverridesConfidence)
 {
-  auto arbiter = make_arbiter(SourcePriority::EXTERNAL, /*enable_signal_matching=*/false);
+  auto arbiter = make_arbiter(EXTERNAL, /*enable_signal_matching=*/false);
 
   arbiter.ingest_external(
-    make_signals(
-      kBaseTime, {make_group(
-                   map_ids::vehicle_a,
-                   {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.10f)})}),
+    make_signals(kBaseTime, {make_group(map_ids::vehicle_a, {make_element(RED, CIRCLE, 0.10f)})}),
     kBaseTime);
   arbiter.ingest_perception(make_signals(
-    kBaseTime, {make_group(
-                 map_ids::vehicle_a,
-                 {make_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.99f)})}));
+    kBaseTime, {make_group(map_ids::vehicle_a, {make_element(GREEN, CIRCLE, 0.99f)})}));
 
   const auto result = arbiter.arbitrate();
 
-  EXPECT_EQ(observed_color(result.output, map_ids::vehicle_a), TrafficLightElement::RED);
+  EXPECT_EQ(observed_color(result.output, map_ids::vehicle_a), RED);
 }
 
 // External-only: the EXTERNAL setting has no effect when only one source
 // is present.
 TEST(TrafficLightArbiterCoreExternalPriority, externalOnlyPassesThrough)
 {
-  auto arbiter = make_arbiter(SourcePriority::EXTERNAL, /*enable_signal_matching=*/false);
+  auto arbiter = make_arbiter(EXTERNAL, /*enable_signal_matching=*/false);
 
   arbiter.ingest_external(
-    make_signals(
-      kBaseTime, {make_group(
-                   map_ids::vehicle_a,
-                   {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)})}),
+    make_signals(kBaseTime, {make_group(map_ids::vehicle_a, {make_element(RED, CIRCLE)})}),
     kBaseTime);
 
   const auto result = arbiter.arbitrate();
 
-  EXPECT_EQ(observed_color(result.output, map_ids::vehicle_a), TrafficLightElement::RED);
+  EXPECT_EQ(observed_color(result.output, map_ids::vehicle_a), RED);
 }
 
 // Perception-only with EXTERNAL priority: with no external side present,
@@ -786,16 +708,14 @@ TEST(TrafficLightArbiterCoreExternalPriority, externalOnlyPassesThrough)
 // reaches the output.
 TEST(TrafficLightArbiterCoreExternalPriority, perceptionOnlyPassesThrough)
 {
-  auto arbiter = make_arbiter(SourcePriority::EXTERNAL, /*enable_signal_matching=*/false);
+  auto arbiter = make_arbiter(EXTERNAL, /*enable_signal_matching=*/false);
 
-  arbiter.ingest_perception(make_signals(
-    kBaseTime, {make_group(
-                 map_ids::vehicle_a,
-                 {make_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE)})}));
+  arbiter.ingest_perception(
+    make_signals(kBaseTime, {make_group(map_ids::vehicle_a, {make_element(GREEN, CIRCLE)})}));
 
   const auto result = arbiter.arbitrate();
 
-  EXPECT_EQ(observed_color(result.output, map_ids::vehicle_a), TrafficLightElement::GREEN);
+  EXPECT_EQ(observed_color(result.output, map_ids::vehicle_a), GREEN);
 }
 
 // ---------------------------------------------------------------------------
@@ -806,56 +726,46 @@ TEST(TrafficLightArbiterCoreExternalPriority, perceptionOnlyPassesThrough)
 // EXTERNAL override case.
 TEST(TrafficLightArbiterCorePerceptionPriority, perceptionPriorityOverridesConfidence)
 {
-  auto arbiter = make_arbiter(SourcePriority::PERCEPTION, /*enable_signal_matching=*/false);
+  auto arbiter = make_arbiter(PERCEPTION, /*enable_signal_matching=*/false);
 
   arbiter.ingest_external(
-    make_signals(
-      kBaseTime, {make_group(
-                   map_ids::vehicle_a,
-                   {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.99f)})}),
+    make_signals(kBaseTime, {make_group(map_ids::vehicle_a, {make_element(RED, CIRCLE, 0.99f)})}),
     kBaseTime);
   arbiter.ingest_perception(make_signals(
-    kBaseTime, {make_group(
-                 map_ids::vehicle_a,
-                 {make_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.10f)})}));
+    kBaseTime, {make_group(map_ids::vehicle_a, {make_element(GREEN, CIRCLE, 0.10f)})}));
 
   const auto result = arbiter.arbitrate();
 
-  EXPECT_EQ(observed_color(result.output, map_ids::vehicle_a), TrafficLightElement::GREEN);
+  EXPECT_EQ(observed_color(result.output, map_ids::vehicle_a), GREEN);
 }
 
 // Perception-only: the PERCEPTION setting has no effect when only one
 // source is present.
 TEST(TrafficLightArbiterCorePerceptionPriority, perceptionOnlyPassesThrough)
 {
-  auto arbiter = make_arbiter(SourcePriority::PERCEPTION, /*enable_signal_matching=*/false);
+  auto arbiter = make_arbiter(PERCEPTION, /*enable_signal_matching=*/false);
 
-  arbiter.ingest_perception(make_signals(
-    kBaseTime, {make_group(
-                 map_ids::vehicle_a,
-                 {make_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE)})}));
+  arbiter.ingest_perception(
+    make_signals(kBaseTime, {make_group(map_ids::vehicle_a, {make_element(GREEN, CIRCLE)})}));
 
   const auto result = arbiter.arbitrate();
 
-  EXPECT_EQ(observed_color(result.output, map_ids::vehicle_a), TrafficLightElement::GREEN);
+  EXPECT_EQ(observed_color(result.output, map_ids::vehicle_a), GREEN);
 }
 
 // External-only with PERCEPTION priority: symmetric counterpart — external
 // is the only source, so it passes through.
 TEST(TrafficLightArbiterCorePerceptionPriority, externalOnlyPassesThrough)
 {
-  auto arbiter = make_arbiter(SourcePriority::PERCEPTION, /*enable_signal_matching=*/false);
+  auto arbiter = make_arbiter(PERCEPTION, /*enable_signal_matching=*/false);
 
   arbiter.ingest_external(
-    make_signals(
-      kBaseTime, {make_group(
-                   map_ids::vehicle_a,
-                   {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)})}),
+    make_signals(kBaseTime, {make_group(map_ids::vehicle_a, {make_element(RED, CIRCLE)})}),
     kBaseTime);
 
   const auto result = arbiter.arbitrate();
 
-  EXPECT_EQ(observed_color(result.output, map_ids::vehicle_a), TrafficLightElement::RED);
+  EXPECT_EQ(observed_color(result.output, map_ids::vehicle_a), RED);
 }
 
 // ---------------------------------------------------------------------------
@@ -869,13 +779,11 @@ TEST(TrafficLightArbiterCorePerceptionPriority, externalOnlyPassesThrough)
 TEST(TrafficLightArbiterCoreBoundary, arbitrateWithoutMapProducesNoOutput)
 {
   TrafficLightArbiterCore unconfigured(
-    SourcePriority::CONFIDENCE, /*enable_signal_matching=*/false, kDefaultExternalDelayTolerance,
+    CONFIDENCE, /*enable_signal_matching=*/false, kDefaultExternalDelayTolerance,
     kDefaultExternalTimeTolerance, kDefaultPerceptionTimeTolerance);
 
-  unconfigured.ingest_perception(make_signals(
-    kBaseTime,
-    {make_group(
-      map_ids::vehicle_a, {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)})}));
+  unconfigured.ingest_perception(
+    make_signals(kBaseTime, {make_group(map_ids::vehicle_a, {make_element(RED, CIRCLE)})}));
 
   const auto result = unconfigured.arbitrate();
 
@@ -888,14 +796,12 @@ TEST(TrafficLightArbiterCoreBoundary, arbitrateWithoutMapProducesNoOutput)
 TEST(TrafficLightArbiterCoreBoundary, emptyMapProducesEmptyOutput)
 {
   TrafficLightArbiterCore arbiter(
-    SourcePriority::CONFIDENCE, /*enable_signal_matching=*/false, kDefaultExternalDelayTolerance,
+    CONFIDENCE, /*enable_signal_matching=*/false, kDefaultExternalDelayTolerance,
     kDefaultExternalTimeTolerance, kDefaultPerceptionTimeTolerance);
   arbiter.set_map(build_empty_map());
 
-  arbiter.ingest_perception(make_signals(
-    kBaseTime,
-    {make_group(
-      map_ids::vehicle_a, {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)})}));
+  arbiter.ingest_perception(
+    make_signals(kBaseTime, {make_group(map_ids::vehicle_a, {make_element(RED, CIRCLE)})}));
 
   const auto result = arbiter.arbitrate();
 
@@ -914,25 +820,20 @@ TEST(TrafficLightArbiterCoreBoundary, emptyMapProducesEmptyOutput)
 // is excluded from arbitrate() so external alone reaches the output.
 TEST(TrafficLightArbiterCorePerceptionStaleness, stalePerceptionIsExcludedFromOutput)
 {
-  auto arbiter = make_arbiter(SourcePriority::CONFIDENCE, /*enable_signal_matching=*/false);
+  auto arbiter = make_arbiter(CONFIDENCE, /*enable_signal_matching=*/false);
 
   const auto t_perception =
     kBaseTime - rclcpp::Duration::from_seconds(kDefaultPerceptionTimeTolerance + 1.0);
 
-  arbiter.ingest_perception(make_signals(
-    t_perception,
-    {make_group(
-      map_ids::vehicle_a, {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)})}));
+  arbiter.ingest_perception(
+    make_signals(t_perception, {make_group(map_ids::vehicle_a, {make_element(RED, CIRCLE)})}));
   arbiter.ingest_external(
-    make_signals(
-      kBaseTime, {make_group(
-                   map_ids::vehicle_a,
-                   {make_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE)})}),
+    make_signals(kBaseTime, {make_group(map_ids::vehicle_a, {make_element(GREEN, CIRCLE)})}),
     kBaseTime);
 
   const auto result = arbiter.arbitrate();
 
-  EXPECT_EQ(observed_color(result.output, map_ids::vehicle_a), TrafficLightElement::GREEN);
+  EXPECT_EQ(observed_color(result.output, map_ids::vehicle_a), GREEN);
 }
 
 // Inside tolerance (perception is older but only by half the budget):
@@ -940,25 +841,20 @@ TEST(TrafficLightArbiterCorePerceptionStaleness, stalePerceptionIsExcludedFromOu
 // perception element over the lower-confidence external.
 TEST(TrafficLightArbiterCorePerceptionStaleness, freshPerceptionRemainsEffective)
 {
-  auto arbiter = make_arbiter(SourcePriority::CONFIDENCE, /*enable_signal_matching=*/false);
+  auto arbiter = make_arbiter(CONFIDENCE, /*enable_signal_matching=*/false);
 
   const auto t_perception =
     kBaseTime - rclcpp::Duration::from_seconds(0.5 * kDefaultPerceptionTimeTolerance);
 
   arbiter.ingest_perception(make_signals(
-    t_perception, {make_group(
-                    map_ids::vehicle_a,
-                    {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.9f)})}));
+    t_perception, {make_group(map_ids::vehicle_a, {make_element(RED, CIRCLE, 0.9f)})}));
   arbiter.ingest_external(
-    make_signals(
-      kBaseTime, {make_group(
-                   map_ids::vehicle_a,
-                   {make_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.7f)})}),
+    make_signals(kBaseTime, {make_group(map_ids::vehicle_a, {make_element(GREEN, CIRCLE, 0.7f)})}),
     kBaseTime);
 
   const auto result = arbiter.arbitrate();
 
-  EXPECT_EQ(observed_color(result.output, map_ids::vehicle_a), TrafficLightElement::RED);
+  EXPECT_EQ(observed_color(result.output, map_ids::vehicle_a), RED);
 }
 
 // External is silent: with no external stamp to compare against, the
@@ -977,19 +873,17 @@ TEST(TrafficLightArbiterCorePerceptionStaleness, freshPerceptionRemainsEffective
 // endorse it.
 TEST(TrafficLightArbiterCorePerceptionStaleness, perceptionAloneIsNeverStale)
 {
-  auto arbiter = make_arbiter(SourcePriority::CONFIDENCE, /*enable_signal_matching=*/false);
+  auto arbiter = make_arbiter(CONFIDENCE, /*enable_signal_matching=*/false);
 
   const auto t_perception =
     kBaseTime - rclcpp::Duration::from_seconds(kDefaultPerceptionTimeTolerance + 10.0);
 
-  arbiter.ingest_perception(make_signals(
-    t_perception,
-    {make_group(
-      map_ids::vehicle_a, {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)})}));
+  arbiter.ingest_perception(
+    make_signals(t_perception, {make_group(map_ids::vehicle_a, {make_element(RED, CIRCLE)})}));
 
   const auto result = arbiter.arbitrate();
 
-  EXPECT_EQ(observed_color(result.output, map_ids::vehicle_a), TrafficLightElement::RED);
+  EXPECT_EQ(observed_color(result.output, map_ids::vehicle_a), RED);
 }
 
 // Staleness is decided at the message level, not per id: when the
@@ -999,20 +893,15 @@ TEST(TrafficLightArbiterCorePerceptionStaleness, perceptionAloneIsNeverStale)
 // must be absent from the output and vehicle_b must remain present.
 TEST(TrafficLightArbiterCorePerceptionStaleness, stalenessDropsEntirePerceptionMessage)
 {
-  auto arbiter = make_arbiter(SourcePriority::CONFIDENCE, /*enable_signal_matching=*/false);
+  auto arbiter = make_arbiter(CONFIDENCE, /*enable_signal_matching=*/false);
 
   const auto t_perception =
     kBaseTime - rclcpp::Duration::from_seconds(kDefaultPerceptionTimeTolerance + 1.0);
 
-  arbiter.ingest_perception(make_signals(
-    t_perception,
-    {make_group(
-      map_ids::vehicle_a, {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)})}));
+  arbiter.ingest_perception(
+    make_signals(t_perception, {make_group(map_ids::vehicle_a, {make_element(RED, CIRCLE)})}));
   arbiter.ingest_external(
-    make_signals(
-      kBaseTime, {make_group(
-                   map_ids::vehicle_b,
-                   {make_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE)})}),
+    make_signals(kBaseTime, {make_group(map_ids::vehicle_b, {make_element(GREEN, CIRCLE)})}),
     kBaseTime);
 
   const auto result = arbiter.arbitrate();
@@ -1025,30 +914,25 @@ TEST(TrafficLightArbiterCorePerceptionStaleness, stalenessDropsEntirePerceptionM
 // external-side prediction (V2I) survives in the output group.
 TEST(TrafficLightArbiterCorePerceptionStaleness, stalePerceptionPredictionsAreSkipped)
 {
-  auto arbiter = make_arbiter(SourcePriority::CONFIDENCE, /*enable_signal_matching=*/false);
+  auto arbiter = make_arbiter(CONFIDENCE, /*enable_signal_matching=*/false);
 
   const auto t_perception =
     kBaseTime - rclcpp::Duration::from_seconds(kDefaultPerceptionTimeTolerance + 1.0);
 
   arbiter.ingest_perception(make_signals(
-    t_perception,
-    {make_group(
-      map_ids::vehicle_a, {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)},
-      {make_prediction(
-        t_perception, PredictedTrafficLightState::INFORMATION_SOURCE_INTERNAL_ESTIMATION)})}));
+    t_perception, {make_group(
+                    map_ids::vehicle_a, {make_element(RED, CIRCLE)},
+                    {make_prediction(t_perception, INTERNAL_ESTIMATION)})}));
   arbiter.ingest_external(
     make_signals(
       kBaseTime,
       {make_group(
-        map_ids::vehicle_a, {make_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE)},
-        {make_prediction(kBaseTime, PredictedTrafficLightState::INFORMATION_SOURCE_V2I)})}),
+        map_ids::vehicle_a, {make_element(GREEN, CIRCLE)}, {make_prediction(kBaseTime, V2I)})}),
     kBaseTime);
 
   const auto result = arbiter.arbitrate();
 
-  EXPECT_EQ(
-    observed_prediction_source(result.output, map_ids::vehicle_a, 0),
-    PredictedTrafficLightState::INFORMATION_SOURCE_V2I);
+  EXPECT_EQ(observed_prediction_source(result.output, map_ids::vehicle_a, 0), V2I);
 }
 
 // ---------------------------------------------------------------------------
@@ -1061,19 +945,14 @@ TEST(TrafficLightArbiterCorePerceptionStaleness, stalePerceptionPredictionsAreSk
 
 TEST(TrafficLightArbiterCoreLatestInputTime, takesNewerOfPerceptionAndExternal)
 {
-  auto arbiter = make_arbiter(SourcePriority::CONFIDENCE, /*enable_signal_matching=*/false);
+  auto arbiter = make_arbiter(CONFIDENCE, /*enable_signal_matching=*/false);
 
   const auto t_external_newer = kBaseTime + rclcpp::Duration::from_seconds(0.5);
 
-  arbiter.ingest_perception(make_signals(
-    kBaseTime,
-    {make_group(
-      map_ids::vehicle_a, {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)})}));
+  arbiter.ingest_perception(
+    make_signals(kBaseTime, {make_group(map_ids::vehicle_a, {make_element(RED, CIRCLE)})}));
   arbiter.ingest_external(
-    make_signals(
-      t_external_newer, {make_group(
-                          map_ids::vehicle_a,
-                          {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)})}),
+    make_signals(t_external_newer, {make_group(map_ids::vehicle_a, {make_element(RED, CIRCLE)})}),
     t_external_newer);
 
   const auto result = arbiter.arbitrate();
@@ -1085,20 +964,15 @@ TEST(TrafficLightArbiterCoreLatestInputTime, takesNewerOfPerceptionAndExternal)
 // wins even though external is also stored.
 TEST(TrafficLightArbiterCoreLatestInputTime, perceptionWinsWhenNewer)
 {
-  auto arbiter = make_arbiter(SourcePriority::CONFIDENCE, /*enable_signal_matching=*/false);
+  auto arbiter = make_arbiter(CONFIDENCE, /*enable_signal_matching=*/false);
 
   const auto t_perception_newer = kBaseTime + rclcpp::Duration::from_seconds(0.3);
 
   arbiter.ingest_external(
-    make_signals(
-      kBaseTime, {make_group(
-                   map_ids::vehicle_a,
-                   {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)})}),
+    make_signals(kBaseTime, {make_group(map_ids::vehicle_a, {make_element(RED, CIRCLE)})}),
     kBaseTime);
   arbiter.ingest_perception(make_signals(
-    t_perception_newer,
-    {make_group(
-      map_ids::vehicle_a, {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)})}));
+    t_perception_newer, {make_group(map_ids::vehicle_a, {make_element(RED, CIRCLE)})}));
 
   const auto result = arbiter.arbitrate();
 
@@ -1109,14 +983,12 @@ TEST(TrafficLightArbiterCoreLatestInputTime, perceptionWinsWhenNewer)
 // latest_input_time falls back to the perception stamp.
 TEST(TrafficLightArbiterCoreLatestInputTime, perceptionStampWhenExternalIsSilent)
 {
-  auto arbiter = make_arbiter(SourcePriority::CONFIDENCE, /*enable_signal_matching=*/false);
+  auto arbiter = make_arbiter(CONFIDENCE, /*enable_signal_matching=*/false);
 
   const auto t_perception = kBaseTime + rclcpp::Duration::from_seconds(0.5);
 
-  arbiter.ingest_perception(make_signals(
-    t_perception,
-    {make_group(
-      map_ids::vehicle_a, {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)})}));
+  arbiter.ingest_perception(
+    make_signals(t_perception, {make_group(map_ids::vehicle_a, {make_element(RED, CIRCLE)})}));
 
   const auto result = arbiter.arbitrate();
 
@@ -1133,16 +1005,13 @@ TEST(TrafficLightArbiterCoreLatestInputTime, perceptionStampWhenExternalIsSilent
 // is accepted.
 TEST(TrafficLightArbiterCoreTiming, ingestExternalAcceptsStampsWithinTolerance)
 {
-  auto arbiter = make_arbiter(SourcePriority::CONFIDENCE, /*enable_signal_matching=*/false);
+  auto arbiter = make_arbiter(CONFIDENCE, /*enable_signal_matching=*/false);
 
   const auto t_past_within =
     kBaseTime - rclcpp::Duration::from_seconds(kDefaultExternalDelayTolerance - 1.0);
 
   const auto result = arbiter.ingest_external(
-    make_signals(
-      t_past_within, {make_group(
-                       map_ids::vehicle_a,
-                       {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)})}),
+    make_signals(t_past_within, {make_group(map_ids::vehicle_a, {make_element(RED, CIRCLE)})}),
     kBaseTime);
 
   EXPECT_TRUE(result.accepted);
@@ -1152,16 +1021,13 @@ TEST(TrafficLightArbiterCoreTiming, ingestExternalAcceptsStampsWithinTolerance)
 // is rejected.
 TEST(TrafficLightArbiterCoreTiming, ingestExternalRejectsTooOldStamps)
 {
-  auto arbiter = make_arbiter(SourcePriority::CONFIDENCE, /*enable_signal_matching=*/false);
+  auto arbiter = make_arbiter(CONFIDENCE, /*enable_signal_matching=*/false);
 
   const auto t_past_beyond =
     kBaseTime - rclcpp::Duration::from_seconds(kDefaultExternalDelayTolerance + 1.0);
 
   const auto result = arbiter.ingest_external(
-    make_signals(
-      t_past_beyond, {make_group(
-                       map_ids::vehicle_a,
-                       {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)})}),
+    make_signals(t_past_beyond, {make_group(map_ids::vehicle_a, {make_element(RED, CIRCLE)})}),
     kBaseTime);
 
   EXPECT_FALSE(result.accepted);
@@ -1172,16 +1038,13 @@ TEST(TrafficLightArbiterCoreTiming, ingestExternalRejectsTooOldStamps)
 // directions.
 TEST(TrafficLightArbiterCoreTiming, ingestExternalRejectsTooFutureStamps)
 {
-  auto arbiter = make_arbiter(SourcePriority::CONFIDENCE, /*enable_signal_matching=*/false);
+  auto arbiter = make_arbiter(CONFIDENCE, /*enable_signal_matching=*/false);
 
   const auto t_future_beyond =
     kBaseTime + rclcpp::Duration::from_seconds(kDefaultExternalDelayTolerance + 1.0);
 
   const auto result = arbiter.ingest_external(
-    make_signals(
-      t_future_beyond, {make_group(
-                         map_ids::vehicle_a,
-                         {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)})}),
+    make_signals(t_future_beyond, {make_group(map_ids::vehicle_a, {make_element(RED, CIRCLE)})}),
     kBaseTime);
 
   EXPECT_FALSE(result.accepted);
@@ -1193,21 +1056,16 @@ TEST(TrafficLightArbiterCoreTiming, ingestExternalRejectsTooFutureStamps)
 // (used by the Node for DEBUG logging).
 TEST(TrafficLightArbiterCoreTiming, ingestPerceptionReportsExpiredExternalEntry)
 {
-  auto arbiter = make_arbiter(SourcePriority::CONFIDENCE, /*enable_signal_matching=*/false);
+  auto arbiter = make_arbiter(CONFIDENCE, /*enable_signal_matching=*/false);
 
   arbiter.ingest_external(
-    make_signals(
-      kBaseTime, {make_group(
-                   map_ids::vehicle_a,
-                   {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)})}),
+    make_signals(kBaseTime, {make_group(map_ids::vehicle_a, {make_element(RED, CIRCLE)})}),
     kBaseTime);
   const auto t_perception =
     kBaseTime + rclcpp::Duration::from_seconds(kDefaultExternalTimeTolerance + 1.0);
 
-  const auto expired = arbiter.ingest_perception(make_signals(
-    t_perception, {make_group(
-                    map_ids::vehicle_b,
-                    {make_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE)})}));
+  const auto expired = arbiter.ingest_perception(
+    make_signals(t_perception, {make_group(map_ids::vehicle_b, {make_element(GREEN, CIRCLE)})}));
 
   ASSERT_EQ(expired.size(), 1u);
   EXPECT_EQ(expired.front().id, map_ids::vehicle_a);
@@ -1219,20 +1077,15 @@ TEST(TrafficLightArbiterCoreTiming, ingestPerceptionReportsExpiredExternalEntry)
 // triggering perception covers a different id.
 TEST(TrafficLightArbiterCoreTiming, evictedExternalEntryAbsentFromOutput)
 {
-  auto arbiter = make_arbiter(SourcePriority::CONFIDENCE, /*enable_signal_matching=*/false);
+  auto arbiter = make_arbiter(CONFIDENCE, /*enable_signal_matching=*/false);
 
   arbiter.ingest_external(
-    make_signals(
-      kBaseTime, {make_group(
-                   map_ids::vehicle_a,
-                   {make_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)})}),
+    make_signals(kBaseTime, {make_group(map_ids::vehicle_a, {make_element(RED, CIRCLE)})}),
     kBaseTime);
   const auto t_perception =
     kBaseTime + rclcpp::Duration::from_seconds(kDefaultExternalTimeTolerance + 1.0);
-  arbiter.ingest_perception(make_signals(
-    t_perception, {make_group(
-                    map_ids::vehicle_b,
-                    {make_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE)})}));
+  arbiter.ingest_perception(
+    make_signals(t_perception, {make_group(map_ids::vehicle_b, {make_element(GREEN, CIRCLE)})}));
 
   const auto result = arbiter.arbitrate();
 


### PR DESCRIPTION
## Description

Adds 40 unit tests for `TrafficLightArbiterCore`, the ROS-free core extracted in #12660. The new test file `test_traffic_light_arbiter_core.cpp` instantiates `TrafficLightArbiterCore` directly (no Node, no executor, no ROS pub/sub), pins one observable behaviour per test at the public-contract level, and is organised by `(mode × concern)` fixtures. Production code is untouched; the characterization suite (`test_traffic_arbiter_characteristic.cpp`) and the existing node test (`test_node.cpp`) are unchanged.

### Features

- **New file `test_traffic_light_arbiter_core.cpp`** — 40 tests across 9 fixtures, exercising `TrafficLightArbiterCore` directly without the Node layer.
- **Fixtures organised by `(mode × concern)`** — mode/priority is the primary axis; mode-agnostic concerns (boundary / staleness / latest_input_time / timing) get their own fixtures.
- **Assertions touch only the public API** — `result.output`, `result.latest_input_time`, `result.off_map_signal_ids`, the `accepted` and `expired` fields returned by `ingest_external`, and the `expired` returned by `ingest_perception`.
- **Comments at specification level** — internal identifiers (`validator`, `branch`, `path`, private member names, etc.) do not appear in any comment, so the tests survive future Core-side refactoring.
- **Helpers built on `std::optional<T>`** — `observed_color`, `observed_color_of_shape`, `observed_prediction_source`, `observed_group_count`, and `find_group` absorb the nullopt case internally, so call sites need no `ASSERT_TRUE` guard before observing the result.


### Test structure

| Fixture | Mode | Tests | Pinned behaviour |
| --- | --- | --- | --- |
| `SignalMatchingTest` | matching=true, CONFIDENCE | 7 | matched / color mismatch / shape-set mismatch / single-source (both directions) / off-map / equivalence ignores confidence |
| `PedestrianTest` | matching=true, parametrized | 4 | pedestrian path × 3 priorities + single-source pass-through |
| `ConfidencePriorityTest` | priority, CONFIDENCE | 8 | higher confidence wins / per-shape union / perception-only / off-map / multiple external accumulation / predictions (both / perception-only / external-only) |
| `ExternalPriorityTest` | priority, EXTERNAL | 3 | EXTERNAL setting overrides confidence + single-source fallback (both sides) |
| `PerceptionPriorityTest` | priority, PERCEPTION | 3 | symmetric counterpart of ExternalPriority |
| `BoundaryTest` | (free `TEST()`) | 2 | arbitrate without map (no output) / empty map (engaged empty output) |
| `PerceptionStalenessTest` | priority, CONFIDENCE | 5 | staleness three branches (external presence × tolerance) + message-level scope + prediction merge effect |
| `LatestInputTimeTest` | priority, CONFIDENCE | 3 | most-recent stamp selection in three branches (external wins / perception wins / external-absent fallback) |
| `TimingTest` | priority, CONFIDENCE | 5 | admission three boundaries (within / too old / too far future) + sweep report + sweep's effect on the next arbitrate |

## Related links

**Parent Issue:**

- None

**Built on:**

- #12660 (`refactor(autoware_traffic_light_arbiter): extract TrafficLightArbiterCore from Node`) — extracted the Core class this PR targets directly; this PR is the unit-test sibling.

## How was this PR tested?

`colcon build` + `colcon test` against the package. The new `_core_test` gtest binary runs **40 cases, all pass**. Existing `_test` (7/7) and `_characteristic_test` (24/24) plus the four lint targets remain green. No production code is changed.

```bash
colcon build --packages-select autoware_traffic_light_arbiter
colcon test --packages-select autoware_traffic_light_arbiter
colcon test-result --test-result-base build/autoware_traffic_light_arbiter --verbose
```

## Notes for reviewers

### Specification ambiguities surfaced while writing the tests

#### (1) Perception side has no absolute staleness guard (Node + Core both)

- `arbitrate()`'s staleness check is `has_externals && (max_external_stamp - perception_stamp).seconds() > perception_time_tolerance_`, which **short-circuits when no external stamp is stored**. The Node side likewise has no `now() - msg.stamp` guard on `on_perception_msg`; the message is forwarded straight to `core_->ingest_perception(*msg)`. Only `on_external_msg` goes through wall-clock admission control (via `ingest_external(*msg, this->now())`).
- **This asymmetry predates the Core extraction.** Commit `3dc9605d9 (feat(autoware_traffic_light_arbiter): add current time validation, #9747)` introduced the wall-clock admission for external only; the perception side was never given the same treatment. The Core extraction preserved this exactly.
- Two readings are possible:
  - **Intentional**: the Core is kept as a pure function, and absolute staleness is treated as a Node-layer concern.
  - **Latent production-safety gap**: if the perception node stalls or its publisher disconnects while no external source is publishing, an arbitrarily old perception signal can keep reaching the published output.
- The corresponding test (`perceptionAloneIsNeverStale`) pins the current behaviour, and its in-file comment explicitly says "this test pins it; it does not endorse it." If the reviewer reads this as a gap, a follow-up PR would address it either by:
  - Adding admission to the Node layer (cheapest — Core API unchanged), or
  - Reshaping `arbitrate()` to take `current_time` (loses Core's pure-function property).

#### (2) `ingest_perception`'s `vector<ExpiredExternalSignal>` return value is logging-only

- The only consumer of the return value is `TrafficLightArbiter::log_expired_external_signals`, which `RCLCPP_DEBUG`s each entry.
- If DEBUG logging of expired entries is not required in production, the API can simplify to `void ingest_perception(msg)`. Three of the four assertions in `ingestPerceptionReportsExpiredExternalEntry` (size / id / age) would be dropped along with the API change. The behavioural test (`evictedExternalEntryAbsentFromOutput`) does not depend on the return value and would remain.
- The reviewer can either:
  - Keep the current API (DEBUG logging is considered useful) — no change, both tests stay.
  - Simplify (`void` return) in a follow-up PR — drop `ingestPerceptionReportsExpiredExternalEntry` together with the API change.

## Interface changes

None. No production code is touched. `CMakeLists.txt` only adds a new gtest target (`autoware_traffic_light_arbiter_core_test`); the library, the executable, the component registration, and the parameters are all unchanged.

## Effects on system behavior

**Downstream-observable**: None. Pure test addition.

**Internal-observable (not affecting downstream)**: None.
