### PR TITLE
fix(euclidean_cluster): resolve invalid type error

### DIFF
--- a/perception/autoware_euclidean_cluster/launch/label_based_euclidean_cluster.launch.py
+++ b/perception/autoware_euclidean_cluster/launch/label_based_euclidean_cluster.launch.py
@@ -80,7 +80,7 @@ def generate_launch_description():
             add_launch_arg("output_objects", "objects"),
             add_launch_arg("use_pointcloud_container", "false"),
             add_launch_arg("pointcloud_container_name", "pointcloud_container"),
-            add_launch_arg("shape_policy", 0),
+            add_launch_arg("shape_policy", "0"),
             add_launch_arg(
                 "param_path",
                 [


### PR DESCRIPTION
## Description

This pull request makes a minor change to the `label_based_euclidean_cluster.launch.py` launch file, ensuring consistency in how launch arguments are specified. The main update is changing the `shape_policy` argument's default value from an integer to a string.

* Changed the default value for the `shape_policy` launch argument from integer `0` to string `"0"` in `label_based_euclidean_cluster.launch.py` to maintain type consistency across launch arguments.

## Related links

**Parent Issue:**

- https://github.com/autowarefoundation/autoware_universe/pull/12682#discussion_r3371165518

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
