### PR TITLE
refactor(image_transport_decompressor): replace anonymous node name with static name using camera_id

### DIFF
--- a/sensing/autoware_image_transport_decompressor/launch/image_transport_decompressor.launch.xml
+++ b/sensing/autoware_image_transport_decompressor/launch/image_transport_decompressor.launch.xml
@@ -1,9 +1,10 @@
 <launch>
+  <arg name="camera_id" default=""/>
   <arg name="input_topic_name" default="/input/compressed_image"/>
   <arg name="output_topic_name" default="/output/raw_image"/>
   <arg name="param_file" default="$(find-pkg-share autoware_image_transport_decompressor)/config/image_transport_decompressor.param.yaml"/>
 
-  <node pkg="autoware_image_transport_decompressor" exec="image_transport_decompressor_node" name="$(anon image_transport_decompressor_node)">
+  <node pkg="autoware_image_transport_decompressor" exec="image_transport_decompressor_node" name="image_transport_decompressor$(var camera_id)">
     <remap from="~/input/compressed_image" to="$(var input_topic_name)"/>
     <remap from="~/output/raw_image" to="$(var output_topic_name)"/>
     <param from="$(var param_file)" allow_substs="true"/>


### PR DESCRIPTION
## Description
In order to apply the proposed CIE ([AutowareDiscussion about adopting CIE](https://github.com/orgs/autowarefoundation/discussions/6813)), all running node names need to be statically defined and predictable.
Previously, image_transport_decompressor.launch.xml used a hardcoded $(anon ...) tag, resulting in randomly generated node names at runtime. This PR removes the anonymous naming and enforces a static node name.

### What was changed

* Removed `name="$(anon image_transport_decompressor_node)"` from the `<node>` definition in `image_transport_decompressor.launch.xml`.
* Changed the attribute to `name="image_transport_decompressor$(var camera_id)"`, utilizing the argument passed from the parent launch file.

**Design Intent & Consistency:**
This modification aligns with the design pattern already used in other files within the project, such as `image_diagnostics.launch.xml`, which uses `camera_id` as a suffix. This approach allows us to generate unique, static node names without needing to modify the parent Python launch files (e.g., `edge_auto_multi_launch_engine.launch.py`). Furthermore, it improves the overall consistency of the launch file design across the project.

## Related links

[Issue(Confluence) internal link](https://tier4.atlassian.net/wiki/spaces/~5ed0b4584824b20c18371c06/pages/3008202199)
[image_diagnostics.launch.xml(x2) internal link](https://github.com/tier4/autoware_launch.x2/blob/tier4/main/edge_auto_jetson_launch/launch/camera_common/image_diagnostics.launch.xml#L24)

## How was this PR tested?

I performed standalone launch tests as shown below and verified that the node names are determined statically as intended, depending on whether the argument is provided or not.

**1. Launch assuming integration into the full system (`camera_id` is specified)**

```bash
$ ros2 launch autoware_image_transport_decompressor image_transport_decompressor.launch.xml camera_id:=0
```

Output of `ros2 node list` (Confirmed that it is fixed to a unique name):

```text
/image_transport_decompressor0
```

**2. Launch assuming a standalone test (No argument provided)**

```bash
$ ros2 launch autoware_image_transport_decompressor image_transport_decompressor.launch.xml
```

Output of `ros2 node list` (Confirmed that `camera_id` is processed as an empty string and the node launches without any errors):

```text
/image_transport_decompressor
```

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
