### PR TITLE
feat(perception, proximity_hazard_object_checker): enable new module

### DIFF
--- a/perception/autoware_proximity_hazard_object_checker/CMakeLists.txt
+++ b/perception/autoware_proximity_hazard_object_checker/CMakeLists.txt
@@ -1,0 +1,28 @@
+cmake_minimum_required(VERSION 3.14)
+project(autoware_proximity_hazard_object_checker)
+
+find_package(autoware_cmake REQUIRED)
+autoware_package()
+
+generate_parameter_library(${PROJECT_NAME}_param
+  param/parameter_struct.yaml
+)
+
+ament_auto_add_library(${PROJECT_NAME}_component SHARED
+  src/proximity_hazard_object_checker.cpp
+  src/proximity_hazard_object_checker_node.cpp
+)
+
+target_link_libraries(${PROJECT_NAME}_component
+  ${PROJECT_NAME}_param
+)
+
+rclcpp_components_register_node(${PROJECT_NAME}_component
+  PLUGIN "autoware::proximity_hazard_object_checker::ProximityHazardObjectCheckerNode"
+  EXECUTABLE ${PROJECT_NAME}_node
+)
+
+ament_auto_package(INSTALL_TO_SHARE
+  launch
+  config
+)

--- a/perception/autoware_proximity_hazard_object_checker/config/proximity_hazard.yaml
+++ b/perception/autoware_proximity_hazard_object_checker/config/proximity_hazard.yaml
@@ -1,0 +1,19 @@
+/**:
+  ros__parameters:
+    node_hz: 5.0
+
+    max_detection_range_m: 2.0
+
+    include_unknown_objects: true
+
+    sector_range:
+      front: [-10.0, 10.0]
+      front_left: [10.0, 30.0]
+      left: [30.0, 150.0]
+      rear_left: [150.0, 170.0]
+      rear: [170.0, -170.0]
+      rear_right: [-170.0, -150.0]
+      right: [-150.0, -30.0]
+      front_right: [-30.0, -10.0]
+
+    sector_boundary_tolerance_deg: 1.0

--- a/perception/autoware_proximity_hazard_object_checker/include/autoware/proximity_hazard_object_checker/proximity_hazard_object_checker.hpp
+++ b/perception/autoware_proximity_hazard_object_checker/include/autoware/proximity_hazard_object_checker/proximity_hazard_object_checker.hpp
@@ -1,0 +1,77 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// cspell : ignore circumradius
+
+#ifndef AUTOWARE__PROXIMITY_HAZARD_OBJECT_CHECKER__PROXIMITY_HAZARD_OBJECT_CHECKER_HPP_
+#define AUTOWARE__PROXIMITY_HAZARD_OBJECT_CHECKER__PROXIMITY_HAZARD_OBJECT_CHECKER_HPP_
+
+#include <autoware_proximity_hazard_object_checker/autoware_proximity_hazard_object_checker_param.hpp>
+#include <tier4_external_api_msgs/msg/proximity_hazard_objects.hpp>
+#include <autoware_utils_geometry/boost_geometry.hpp>
+
+#include <autoware_perception_msgs/msg/predicted_objects.hpp>
+#include <autoware_perception_msgs/msg/shape.hpp>
+#include <geometry_msgs/msg/transform_stamped.hpp>
+
+#include <cstdint>
+#include <optional>
+
+namespace autoware::proximity_hazard_object_checker
+{
+using autoware_perception_msgs::msg::PredictedObjects;
+using tier4_external_api_msgs::msg::ProximityHazardObjects;
+using autoware_utils_geometry::LinearRing2d;
+using autoware_utils_geometry::Polygon2d;
+
+constexpr int g_num_sectors = 8;
+
+class ProximityHazardObjectChecker
+{
+public:
+  ProximityHazardObjectChecker(
+    proximity_hazard_object::Params params, LinearRing2d vehicle_footprint);
+
+  // Build the per-sector hazard message from a PredictedObjects input and the
+  // transform from the input's frame to base_link.
+  [[nodiscard]] ProximityHazardObjects process(
+    const PredictedObjects & input,
+    const geometry_msgs::msg::TransformStamped & to_base_link) const;
+
+  // Maps a bearing in radians (any range; normalized internally) to a sector index
+  // per the configured per-sector ranges. Returns nullopt if the bearing does not
+  // fall in any configured sector (misconfiguration: gap or under-specified).
+  [[nodiscard]] std::optional<uint8_t> bearing_to_sector(double bearing_rad) const;
+
+  // Bounding-circle pre-filter helper. Returns the radius of the smallest circle
+  // centered at the object-local origin that contains the shape.
+  static double compute_circumradius(const autoware_perception_msgs::msg::Shape & shape);
+
+  // Centroid of the vehicle footprint, used as the reference point for sector
+  // bearing computation. Exposed for debug visualization.
+  [[nodiscard]] const autoware_utils_geometry::Point2d & ego_center() const { return ego_center_; }
+
+private:
+  proximity_hazard_object::Params params_;
+  LinearRing2d vehicle_footprint_;
+  autoware_utils_geometry::Point2d ego_center_;  // Centroid of vehicle_footprint_
+  double vehicle_circumradius_;  // Max distance from base_link origin to any footprint vertex.
+  double max_detection_range_squared_;  // Cached: params_.max_detection_range_m^2.
+  std::array<Polygon2d, g_num_sectors>
+    sector_wedges_;  // Triangular wedge polygons use to clip object polygons per sector.
+};
+
+}  // namespace autoware::proximity_hazard_object_checker
+
+#endif  // AUTOWARE__PROXIMITY_HAZARD_OBJECT_CHECKER__PROXIMITY_HAZARD_OBJECT_CHECKER_HPP_

--- a/perception/autoware_proximity_hazard_object_checker/include/autoware/proximity_hazard_object_checker/proximity_hazard_object_checker_node.hpp
+++ b/perception/autoware_proximity_hazard_object_checker/include/autoware/proximity_hazard_object_checker/proximity_hazard_object_checker_node.hpp
@@ -1,0 +1,68 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__PROXIMITY_HAZARD_OBJECT_CHECKER__PROXIMITY_HAZARD_OBJECT_CHECKER_NODE_HPP_
+#define AUTOWARE__PROXIMITY_HAZARD_OBJECT_CHECKER__PROXIMITY_HAZARD_OBJECT_CHECKER_NODE_HPP_
+
+#include "autoware/proximity_hazard_object_checker/proximity_hazard_object_checker.hpp"
+
+#include <tier4_external_api_msgs/msg/proximity_hazard_objects.hpp>
+#include <autoware_utils_rclcpp/polling_subscriber.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+#include <autoware_perception_msgs/msg/predicted_objects.hpp>
+#include <nav_msgs/msg/odometry.hpp>
+#include <visualization_msgs/msg/marker_array.hpp>
+
+#include <tf2_ros/buffer.h>
+#include <tf2_ros/transform_listener.h>
+
+#include <memory>
+#include <string>
+
+namespace autoware::proximity_hazard_object_checker
+{
+using autoware_perception_msgs::msg::PredictedObjects;
+using tier4_external_api_msgs::msg::ProximityHazardObjects;
+using nav_msgs::msg::Odometry;
+
+class ProximityHazardObjectCheckerNode : public rclcpp::Node
+{
+public:
+  explicit ProximityHazardObjectCheckerNode(const rclcpp::NodeOptions & options);
+
+private:
+  void on_timer();
+  void publish_sector_markers(const std::string & frame_id);
+
+  autoware_utils_rclcpp::InterProcessPollingSubscriber<Odometry> sub_odometry_{
+    this, "~/input/odometry"};
+  autoware_utils_rclcpp::InterProcessPollingSubscriber<PredictedObjects> sub_objects_{
+    this, "~/input/objects"};
+  rclcpp::Publisher<ProximityHazardObjects>::SharedPtr pub_hazards_;
+  rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr pub_debug_markers_;
+  rclcpp::TimerBase::SharedPtr timer_;
+
+  std::unique_ptr<tf2_ros::Buffer> tf_buffer_;
+  std::unique_ptr<tf2_ros::TransformListener> tf_listener_;
+
+  std::shared_ptr<proximity_hazard_object::ParamListener> param_listener_;
+  autoware_utils_geometry::LinearRing2d vehicle_footprint_;
+
+  std::unique_ptr<ProximityHazardObjectChecker> impl_;
+};
+
+}  // namespace autoware::proximity_hazard_object_checker
+
+#endif  // AUTOWARE__PROXIMITY_HAZARD_OBJECT_CHECKER__PROXIMITY_HAZARD_OBJECT_CHECKER_NODE_HPP_

--- a/perception/autoware_proximity_hazard_object_checker/launch/proximity_hazard_object_checker.launch.xml
+++ b/perception/autoware_proximity_hazard_object_checker/launch/proximity_hazard_object_checker.launch.xml
@@ -1,0 +1,13 @@
+<launch>
+  <arg name="input_objects" default="/perception/object_recognition/objects"/>
+  <arg name="input_odometry" default="/localization/kinematic_state"/>
+  <arg name="output_hazards" default="/hmi/proximity_hazards"/>
+  <arg name="param_path" default="$(find-pkg-share autoware_proximity_hazard_object_checker)/config/proximity_hazard.yaml"/>
+
+  <node pkg="autoware_proximity_hazard_object_checker" exec="autoware_proximity_hazard_object_checker_node" name="proximity_hazard_object_checker" output="screen">
+    <remap from="~/input/odometry" to="$(var input_odometry)"/>
+    <remap from="~/input/objects" to="$(var input_objects)"/>
+    <remap from="~/output/proximity_hazards" to="$(var output_hazards)"/>
+    <param from="$(var param_path)"/>
+  </node>
+</launch>

--- a/perception/autoware_proximity_hazard_object_checker/package.xml
+++ b/perception/autoware_proximity_hazard_object_checker/package.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>autoware_proximity_hazard_object_checker</name>
+  <version>0.0.1</version>
+  <description>Publishes per-sector proximity hazards for the L2 HMI alert function.</description>
+  <maintainer email="zulfaqar.azmi@tier4.jp">Zulfaqar Azmi</maintainer>
+
+  <license>Apache License 2.0</license>
+
+  <buildtool_depend>ament_cmake_auto</buildtool_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
+
+  <depend>autoware_perception_msgs</depend>
+  <depend>tier4_external_api_msgs</depend>
+  <depend>autoware_utils_geometry</depend>
+  <depend>autoware_utils_math</depend>
+  <depend>autoware_utils_rclcpp</depend>
+  <depend>autoware_vehicle_info_utils</depend>
+  <depend>builtin_interfaces</depend>
+  <depend>generate_parameter_library</depend>
+  <depend>geometry_msgs</depend>
+  <depend>libboost-dev</depend>
+  <depend>nav_msgs</depend>
+  <depend>rclcpp</depend>
+  <depend>rclcpp_components</depend>
+  <depend>tf2</depend>
+  <depend>tf2_geometry_msgs</depend>
+  <depend>tf2_ros</depend>
+  <depend>tier4_hmi_msgs</depend>
+  <depend>unique_identifier_msgs</depend>
+  <depend>visualization_msgs</depend>
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>autoware_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/perception/autoware_proximity_hazard_object_checker/param/parameter_struct.yaml
+++ b/perception/autoware_proximity_hazard_object_checker/param/parameter_struct.yaml
@@ -1,0 +1,76 @@
+proximity_hazard_object:
+  node_hz:
+    type: double
+    description: Timer frequency in Hz.
+    read_only: true
+    validation:
+      gt<>: [0.0]
+
+  max_detection_range_m:
+    type: double
+    description: Polygon-to-polygon distance threshold in meters between the ego footprint and an object polygon. Objects beyond this are filtered out before sector assignment.
+    read_only: true
+    validation:
+      gt<>: [0.0]
+
+  include_unknown_objects:
+    type: bool
+    description: If false, objects whose classification contains UNKNOWN are dropped before sector assignment.
+    read_only: true
+
+  sector_range:
+    front:
+      type: double_array
+      description: "[from_deg, to_deg] angular extent of the FRONT sector. REP-103 bearing (+x forward, +y left, 0 = ahead). Half-open [from, to). The 8 sectors must tile the full circle without gaps or overlaps."
+      read_only: true
+      validation:
+        fixed_size<>: [2]
+    front_left:
+      type: double_array
+      description: "[from_deg, to_deg] angular extent of the FRONT_LEFT sector. See `front` for bearing convention and tiling requirement."
+      read_only: true
+      validation:
+        fixed_size<>: [2]
+    left:
+      type: double_array
+      description: "[from_deg, to_deg] angular extent of the LEFT sector. See `front` for bearing convention and tiling requirement."
+      read_only: true
+      validation:
+        fixed_size<>: [2]
+    rear_left:
+      type: double_array
+      description: "[from_deg, to_deg] angular extent of the REAR_LEFT sector. See `front` for bearing convention and tiling requirement."
+      read_only: true
+      validation:
+        fixed_size<>: [2]
+    rear:
+      type: double_array
+      description: "[from_deg, to_deg] angular extent of the REAR sector. Set to_deg < from_deg to wrap through +/-180 degrees, as the default does. See `front` for bearing convention and tiling requirement."
+      read_only: true
+      validation:
+        fixed_size<>: [2]
+    rear_right:
+      type: double_array
+      description: "[from_deg, to_deg] angular extent of the REAR_RIGHT sector. See `front` for bearing convention and tiling requirement."
+      read_only: true
+      validation:
+        fixed_size<>: [2]
+    right:
+      type: double_array
+      description: "[from_deg, to_deg] angular extent of the RIGHT sector. See `front` for bearing convention and tiling requirement."
+      read_only: true
+      validation:
+        fixed_size<>: [2]
+    front_right:
+      type: double_array
+      description: "[from_deg, to_deg] angular extent of the FRONT_RIGHT sector. See `front` for bearing convention and tiling requirement."
+      read_only: true
+      validation:
+        fixed_size<>: [2]
+
+  sector_boundary_tolerance_deg:
+    type: double
+    description: "[degree] Angular tolerance applied to each side of every sector wedge boundary."
+    validation:
+      gt_eq<>: [0.0]
+    read_only: true

--- a/perception/autoware_proximity_hazard_object_checker/src/proximity_hazard_object_checker.cpp
+++ b/perception/autoware_proximity_hazard_object_checker/src/proximity_hazard_object_checker.cpp
@@ -1,0 +1,225 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// cspell : ignore circumradius
+
+#include "autoware/proximity_hazard_object_checker/proximity_hazard_object_checker.hpp"
+
+#include <autoware_utils_geometry/boost_polygon_utils.hpp>
+#include <autoware_utils_math/unit_conversion.hpp>
+
+#include <autoware_perception_msgs/msg/object_classification.hpp>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+
+#include <boost/geometry.hpp>
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <limits>
+#include <optional>
+#include <utility>
+
+namespace autoware::proximity_hazard_object_checker
+{
+ProximityHazardObjectChecker::ProximityHazardObjectChecker(
+  proximity_hazard_object::Params params, LinearRing2d vehicle_footprint)
+: params_(std::move(params)),
+  vehicle_footprint_(std::move(vehicle_footprint)),
+  vehicle_circumradius_(0.0),
+  max_detection_range_squared_(0.0)
+{
+  boost::geometry::centroid(vehicle_footprint_, ego_center_);
+
+  max_detection_range_squared_ = params_.max_detection_range_m * params_.max_detection_range_m;
+
+  double max_r2 = 0.0;
+  for (const auto & p : vehicle_footprint_) {
+    max_r2 = std::max(max_r2, p.x() * p.x() + p.y() * p.y());
+  }
+  vehicle_circumradius_ = std::sqrt(max_r2);
+
+  constexpr double wedge_radius_offset = 1e-3;
+  const double wedge_radius =
+    vehicle_circumradius_ + params_.max_detection_range_m + wedge_radius_offset;
+
+  const std::array<std::vector<double>, g_num_sectors> sector_refs_in_enum_order = {{
+    {params_.sector_range.front},
+    {params_.sector_range.front_right},
+    {params_.sector_range.right},
+    {params_.sector_range.rear_right},
+    {params_.sector_range.rear},
+    {params_.sector_range.rear_left},
+    {params_.sector_range.left},
+    {params_.sector_range.front_left},
+  }};
+  for (uint8_t s = 0; s < g_num_sectors; ++s) {
+    const double a_from = autoware_utils_math::deg2rad(
+      sector_refs_in_enum_order[s].front() - params_.sector_boundary_tolerance_deg);
+    const double a_to = autoware_utils_math::deg2rad(
+      sector_refs_in_enum_order[s].back() + params_.sector_boundary_tolerance_deg);
+    boost::geometry::append(
+      sector_wedges_[s], autoware_utils_geometry::Point2d{ego_center_.x(), ego_center_.y()});
+    boost::geometry::append(
+      sector_wedges_[s], autoware_utils_geometry::Point2d{
+                           ego_center_.x() + wedge_radius * std::cos(a_from),
+                           ego_center_.y() + wedge_radius * std::sin(a_from)});
+    boost::geometry::append(
+      sector_wedges_[s], autoware_utils_geometry::Point2d{
+                           ego_center_.x() + wedge_radius * std::cos(a_to),
+                           ego_center_.y() + wedge_radius * std::sin(a_to)});
+    boost::geometry::append(
+      sector_wedges_[s], autoware_utils_geometry::Point2d{ego_center_.x(), ego_center_.y()});
+    boost::geometry::correct(sector_wedges_[s]);
+  }
+}
+
+ProximityHazardObjects ProximityHazardObjectChecker::process(
+  const PredictedObjects & input, const geometry_msgs::msg::TransformStamped & to_base_link) const
+{
+  ProximityHazardObjects out;
+  out.header = input.header;
+
+  std::array<double, g_num_sectors> closest_cd{};
+  closest_cd.fill(std::numeric_limits<double>::infinity());
+
+  for (const auto & object : input.objects) {
+    if (!params_.include_unknown_objects) {
+      const bool is_unknown =
+        std::any_of(object.classification.begin(), object.classification.end(), [](const auto & c) {
+          return c.label == autoware_perception_msgs::msg::ObjectClassification::UNKNOWN;
+        });
+      if (is_unknown) {
+        continue;
+      }
+    }
+
+    geometry_msgs::msg::Pose pose_in_base_link;
+    tf2::doTransform(
+      object.kinematics.initial_pose_with_covariance.pose, pose_in_base_link, to_base_link);
+
+    const double object_radius = compute_circumradius(object.shape);
+    const double center_d2 = pose_in_base_link.position.x * pose_in_base_link.position.x +
+                             pose_in_base_link.position.y * pose_in_base_link.position.y;
+    const double reject_radius =
+      vehicle_circumradius_ + object_radius + params_.max_detection_range_m;
+    if (center_d2 > reject_radius * reject_radius) {
+      continue;
+    }
+
+    // The object polygon is assumed to have a closed topology (i.e., the first and last vertices
+    // are connected, forming a closed loop).
+    const auto object_polygon =
+      autoware_utils_geometry::to_polygon2d(pose_in_base_link, object.shape);
+
+    const double cd = boost::geometry::comparable_distance(vehicle_footprint_, object_polygon);
+    if (cd > max_detection_range_squared_) {
+      continue;
+    }
+
+    for (uint8_t s = 0; s < g_num_sectors; ++s) {
+      boost::geometry::model::multi_polygon<Polygon2d> clipped;
+      boost::geometry::intersection(object_polygon, sector_wedges_[s], clipped);
+      if (clipped.empty()) {
+        continue;
+      }
+
+      double sector_cd = std::numeric_limits<double>::infinity();
+      for (const auto & part : clipped) {
+        sector_cd =
+          std::min(sector_cd, boost::geometry::comparable_distance(part, vehicle_footprint_));
+      }
+      if (sector_cd > max_detection_range_squared_) {
+        continue;
+      }
+
+      if (sector_cd < closest_cd[s]) {
+        closest_cd[s] = sector_cd;
+        auto & slot = out.sectors[s];
+        slot.has_object = true;
+        slot.distance_m = static_cast<float>(std::sqrt(sector_cd));
+        slot.predicted_object = object;
+      }
+    }
+  }
+
+  return out;
+}
+
+std::optional<uint8_t> ProximityHazardObjectChecker::bearing_to_sector(double bearing_rad) const
+{
+  double b = std::fmod(bearing_rad + M_PI, 2.0 * M_PI);
+  if (b < 0.0) {
+    b += 2.0 * M_PI;
+  }
+  b -= M_PI;
+
+  auto sector = [](const auto & range) -> std::pair<double, double> {
+    const auto start = autoware_utils_math::deg2rad(range.front());
+    const auto end = autoware_utils_math::deg2rad(range.back());
+    return std::make_pair(start, end);
+  };
+
+  auto in_range = [b](double start, double end) {
+    return (end > start) ? (b >= start && b < end) : (b >= start || b < end);
+  };
+
+  const auto [front_start, front_end] = sector(params_.sector_range.front);
+  if (in_range(front_start, front_end)) return ProximityHazardObjects::FRONT;
+
+  const auto [front_left_start, front_left_end] = sector(params_.sector_range.front_left);
+  if (in_range(front_left_start, front_left_end)) return ProximityHazardObjects::FRONT_LEFT;
+
+  const auto [left_start, left_end] = sector(params_.sector_range.left);
+  if (in_range(left_start, left_end)) return ProximityHazardObjects::LEFT;
+
+  const auto [rear_left_start, rear_left_end] = sector(params_.sector_range.rear_left);
+  if (in_range(rear_left_start, rear_left_end)) return ProximityHazardObjects::REAR_LEFT;
+
+  const auto [rear_start, rear_end] = sector(params_.sector_range.rear);
+  if (in_range(rear_start, rear_end)) return ProximityHazardObjects::REAR;
+
+  const auto [rear_right_start, rear_right_end] = sector(params_.sector_range.rear_right);
+  if (in_range(rear_right_start, rear_right_end)) return ProximityHazardObjects::REAR_RIGHT;
+
+  const auto [right_start, right_end] = sector(params_.sector_range.right);
+  if (in_range(right_start, right_end)) return ProximityHazardObjects::RIGHT;
+
+  const auto [front_right_start, front_right_end] = sector(params_.sector_range.front_right);
+  if (in_range(front_right_start, front_right_end)) return ProximityHazardObjects::FRONT_RIGHT;
+
+  return std::nullopt;
+}
+
+double ProximityHazardObjectChecker::compute_circumradius(
+  const autoware_perception_msgs::msg::Shape & shape)
+{
+  switch (shape.type) {
+    case autoware_perception_msgs::msg::Shape::BOUNDING_BOX:
+      return 0.5 * std::hypot(shape.dimensions.x, shape.dimensions.y);
+    case autoware_perception_msgs::msg::Shape::CYLINDER:
+      return 0.5 * shape.dimensions.x;
+    case autoware_perception_msgs::msg::Shape::POLYGON: {
+      double max_r2 = 0.0;
+      for (const auto & p : shape.footprint.points) {
+        max_r2 = std::max(max_r2, static_cast<double>(p.x * p.x + p.y * p.y));
+      }
+      return std::sqrt(max_r2);
+    }
+    default:
+      return 0.0;
+  }
+}
+
+}  // namespace autoware::proximity_hazard_object_checker

--- a/perception/autoware_proximity_hazard_object_checker/src/proximity_hazard_object_checker_node.cpp
+++ b/perception/autoware_proximity_hazard_object_checker/src/proximity_hazard_object_checker_node.cpp
@@ -1,0 +1,300 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/proximity_hazard_object_checker/proximity_hazard_object_checker_node.hpp"
+
+#include <autoware_utils_math/unit_conversion.hpp>
+#include <autoware_vehicle_info_utils/vehicle_info_utils.hpp>
+
+#include <visualization_msgs/msg/marker.hpp>
+
+#include <boost/geometry/algorithms/append.hpp>
+#include <boost/geometry/algorithms/buffer.hpp>
+#include <boost/geometry/algorithms/correct.hpp>
+#include <boost/geometry/geometries/multi_polygon.hpp>
+#include <boost/geometry/strategies/buffer.hpp>
+#include <boost/geometry/strategies/strategies.hpp>
+
+#include <array>
+#include <cmath>
+#include <limits>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace autoware::proximity_hazard_object_checker
+{
+ProximityHazardObjectCheckerNode::ProximityHazardObjectCheckerNode(
+  const rclcpp::NodeOptions & options)
+: rclcpp::Node("proximity_hazard_object_checker", options)
+{
+  param_listener_ =
+    std::make_shared<proximity_hazard_object::ParamListener>(get_node_parameters_interface());
+
+  const double node_hz = param_listener_->get_params().node_hz;
+  const double node_period_sec = 1.0 / node_hz;
+  timer_ = rclcpp::create_timer(
+    this, get_clock(), rclcpp::Duration::from_seconds(node_period_sec),
+    std::bind(&ProximityHazardObjectCheckerNode::on_timer, this));
+
+  const auto vehicle_info = autoware::vehicle_info_utils::VehicleInfoUtils(*this).getVehicleInfo();
+  vehicle_footprint_ = vehicle_info.createFootprint();
+
+  impl_ = std::make_unique<ProximityHazardObjectChecker>(
+    param_listener_->get_params(), vehicle_footprint_);
+
+  tf_buffer_ = std::make_unique<tf2_ros::Buffer>(get_clock());
+  tf_listener_ = std::make_unique<tf2_ros::TransformListener>(*tf_buffer_);
+
+  pub_hazards_ = create_publisher<ProximityHazardObjects>(
+    "~/output/proximity_hazards", rclcpp::QoS{1}.reliable());
+  pub_debug_markers_ = create_publisher<visualization_msgs::msg::MarkerArray>(
+    "~/debug/sector_markers", rclcpp::QoS{1});
+}
+
+void ProximityHazardObjectCheckerNode::on_timer()
+{
+  const auto object_ptr = sub_objects_.take_data();
+
+  if (!object_ptr) {
+    RCLCPP_WARN_THROTTLE(get_logger(), *get_clock(), 5000, "Failed to take predicted objects data");
+    return;
+  }
+
+  const auto odometry_ptr = sub_odometry_.take_data();
+  if (!odometry_ptr) {
+    RCLCPP_WARN_THROTTLE(
+      get_logger(), *get_clock(), 5000, "Failed to take predicted odometry data");
+    return;
+  }
+
+  geometry_msgs::msg::TransformStamped to_base_link;
+  try {
+    to_base_link = tf_buffer_->lookupTransform(
+      odometry_ptr->child_frame_id, object_ptr->header.frame_id, object_ptr->header.stamp,
+      rclcpp::Duration::from_seconds(0.1));
+  } catch (const tf2::TransformException & ex) {
+    RCLCPP_WARN_THROTTLE(
+      get_logger(), *get_clock(), 5000, "TF lookup %s -> %s failed: %s",
+      object_ptr->header.frame_id.c_str(), odometry_ptr->child_frame_id.c_str(), ex.what());
+    return;
+  }
+
+  pub_hazards_->publish(impl_->process(*object_ptr, to_base_link));
+  publish_sector_markers(odometry_ptr->child_frame_id);
+}
+
+void ProximityHazardObjectCheckerNode::publish_sector_markers(const std::string & frame_id)
+{
+  using visualization_msgs::msg::Marker;
+  using visualization_msgs::msg::MarkerArray;
+  namespace bg = boost::geometry;
+
+  const auto params = param_listener_->get_params();
+  const double range = params.max_detection_range_m;
+  const auto & ego = impl_->ego_center();
+  const auto stamp = now();
+
+  // Build the detection-zone outline: Minkowski sum of the vehicle footprint
+  // with a disc of radius `range`. This is exactly the set of points within
+  // `range` of the footprint -- i.e. the actual detection zone, not a circle
+  // around ego_center.
+  Polygon2d footprint_polygon;
+  for (const auto & p : vehicle_footprint_) {
+    bg::append(footprint_polygon, p);
+  }
+  bg::correct(footprint_polygon);
+
+  constexpr int k_points_per_circle = 36;
+  const bg::strategy::buffer::distance_symmetric<double> distance_strategy(range);
+  const bg::strategy::buffer::join_round join_strategy(k_points_per_circle);
+  const bg::strategy::buffer::end_round end_strategy(k_points_per_circle);
+  const bg::strategy::buffer::point_circle point_strategy(k_points_per_circle);
+  const bg::strategy::buffer::side_straight side_strategy;
+
+  bg::model::multi_polygon<Polygon2d> buffered_mp;
+  bg::buffer(
+    footprint_polygon, buffered_mp, distance_strategy, side_strategy, join_strategy, end_strategy,
+    point_strategy);
+
+  if (buffered_mp.empty()) {
+    RCLCPP_WARN_THROTTLE(
+      get_logger(), *get_clock(), 5000,
+      "Buffered footprint is empty; skipping debug marker publish.");
+    return;
+  }
+  const auto & outline = buffered_mp.front().outer();
+
+  // Distance from ego along unit direction (dx, dy) to the first outline edge
+  // hit by the ray. ego_center is inside the buffered region (it's inside the
+  // footprint), so the ray exits at exactly one boundary point.
+  auto ray_to_outline = [&](double dx, double dy) -> double {
+    double t_min = std::numeric_limits<double>::infinity();
+    for (std::size_t i = 0; i + 1 < outline.size(); ++i) {
+      const double ax = outline[i].x();
+      const double ay = outline[i].y();
+      const double bx = outline[i + 1].x();
+      const double by = outline[i + 1].y();
+      const double ex = bx - ax;
+      const double ey = by - ay;
+      const double det = dy * ex - dx * ey;
+      if (std::abs(det) < 1e-12) {
+        continue;
+      }
+      const double rx = ax - ego.x();
+      const double ry = ay - ego.y();
+      const double t = (ry * ex - rx * ey) / det;
+      const double s = (dx * ry - dy * rx) / det;
+      if (t > 0.0 && s >= 0.0 && s <= 1.0 && t < t_min) {
+        t_min = t;
+      }
+    }
+    return t_min;
+  };
+
+  // Sectors in the same order as bearing_to_sector (CCW around the vehicle).
+  struct SectorVis
+  {
+    const char * name;
+    const std::vector<double> & range_deg;
+  };
+  const std::array<SectorVis, 8> sectors = {{
+    {"FRONT", params.sector_range.front},
+    {"FRONT_LEFT", params.sector_range.front_left},
+    {"LEFT", params.sector_range.left},
+    {"REAR_LEFT", params.sector_range.rear_left},
+    {"REAR", params.sector_range.rear},
+    {"REAR_RIGHT", params.sector_range.rear_right},
+    {"RIGHT", params.sector_range.right},
+    {"FRONT_RIGHT", params.sector_range.front_right},
+  }};
+
+  std_msgs::msg::ColorRGBA color;
+  color.r = 1.0f;
+  color.g = 1.0f;
+  color.b = 1.0f;
+  color.a = 0.7f;
+
+  MarkerArray out;
+  out.markers.reserve(2 + sectors.size());
+
+  // Detection-zone outline (replaces the circle).
+  {
+    Marker m;
+    m.header.frame_id = frame_id;
+    m.header.stamp = stamp;
+    m.ns = "proximity_hazard_sectors";
+    m.id = 0;
+    m.type = Marker::LINE_STRIP;
+    m.action = Marker::ADD;
+    m.frame_locked = true;
+    m.scale.x = 0.03;
+    m.color = color;
+    m.pose.orientation.w = 1.0;
+    m.points.reserve(outline.size());
+    for (const auto & p : outline) {
+      geometry_msgs::msg::Point pt;
+      pt.x = p.x();
+      pt.y = p.y();
+      pt.z = 0.0;
+      m.points.push_back(pt);
+    }
+    out.markers.push_back(m);
+  }
+
+  // Sector boundary lines: each line starts at ego_center and extends along the
+  // sector's start angle out to the buffered outline, so it actually shows the
+  // detection extent in that direction.
+  {
+    Marker m;
+    m.header.frame_id = frame_id;
+    m.header.stamp = stamp;
+    m.ns = "proximity_hazard_sectors";
+    m.id = 1;
+    m.type = Marker::LINE_LIST;
+    m.action = Marker::ADD;
+    m.frame_locked = true;
+    m.scale.x = 0.03;
+    m.color = color;
+    m.pose.orientation.w = 1.0;
+    m.points.reserve(sectors.size() * 2);
+    for (const auto & s : sectors) {
+      const double a = autoware_utils_math::deg2rad(s.range_deg.front());
+      const double dx = std::cos(a);
+      const double dy = std::sin(a);
+      const double t = ray_to_outline(dx, dy);
+      if (!std::isfinite(t)) {
+        continue;
+      }
+      geometry_msgs::msg::Point p0;
+      p0.x = ego.x();
+      p0.y = ego.y();
+      p0.z = 0.0;
+      geometry_msgs::msg::Point p1;
+      p1.x = ego.x() + t * dx;
+      p1.y = ego.y() + t * dy;
+      p1.z = 0.0;
+      m.points.push_back(p0);
+      m.points.push_back(p1);
+    }
+    out.markers.push_back(m);
+  }
+
+  // Sector labels placed at the sector's angular midpoint, slightly past the
+  // buffered outline so they don't sit on the line.
+  constexpr double k_label_offset_m = 0.5;
+  int label_id = 100;
+  for (const auto & s : sectors) {
+    const double start = s.range_deg.front();
+    const double end = s.range_deg.back();
+    // Wraparound: if end < start, the sector crosses +/-180; midpoint shifts by 180.
+    double mid_deg = (end > start) ? 0.5 * (start + end) : 0.5 * (start + end + 360.0);
+    if (mid_deg >= 180.0) {
+      mid_deg -= 360.0;
+    }
+    const double mid_rad = autoware_utils_math::deg2rad(mid_deg);
+    const double dx = std::cos(mid_rad);
+    const double dy = std::sin(mid_rad);
+    const double t_outline = ray_to_outline(dx, dy);
+    if (!std::isfinite(t_outline)) {
+      continue;
+    }
+    const double t = t_outline + k_label_offset_m;
+
+    Marker m;
+    m.header.frame_id = frame_id;
+    m.header.stamp = stamp;
+    m.ns = "proximity_hazard_sectors";
+    m.id = label_id++;
+    m.type = Marker::TEXT_VIEW_FACING;
+    m.action = Marker::ADD;
+    m.frame_locked = true;
+    m.pose.position.x = ego.x() + t * dx;
+    m.pose.position.y = ego.y() + t * dy;
+    m.pose.position.z = 0.0;
+    m.pose.orientation.w = 1.0;
+    m.scale.z = 0.3;  // text height in meters
+    m.color = color;
+    m.text = s.name;
+    out.markers.push_back(m);
+  }
+
+  pub_debug_markers_->publish(out);
+}
+
+}  // namespace autoware::proximity_hazard_object_checker
+
+#include <rclcpp_components/register_node_macro.hpp>
+RCLCPP_COMPONENTS_REGISTER_NODE(
+  autoware::proximity_hazard_object_checker::ProximityHazardObjectCheckerNode)


### PR DESCRIPTION
## Description
Introduces the `autoware_proximity_hazard_object_checker` package — a new ROS 2 component node that publishes per-sector proximity hazard data for the L2 HMI alert function.

The node runs on a configurable timer (default 5 Hz). On each tick it polls the latest predicted objects and vehicle odometry, transforms all object poses into the base_link frame via TF, and evaluates each object against 8 configurable angular sectors around the vehicle. For each sector it reports whether any hazard is present, the distance to the closest object, and the full `PredictedObject` for that closest detection. Objects classified as UNKNOWN can optionally be suppressed, and a polygon-to-footprint distance threshold discards anything beyond the configured detection range.

Detection range (`max_detection_range_m`) is measured as the minimum polygon-to-ego-footprint distance (via `boost::geometry::comparable_distance`), so the threshold applies to the actual surface of the vehicle, not to a point or bounding circle.

The eight sectors tile the full 360° circle and their angular extents are independently configurable. Default extents are narrow fore/aft wedges (±10°) flanked by narrow shoulder wedges (±10–30°) and wide side wedges (±30–150°), with REAR wrapping through ±180°.

A debug topic publishes a `MarkerArray` showing the detection-zone outline (Minkowski sum of the vehicle footprint with a disc of radius `max_detection_range_m`), sector boundary lines, and sector name labels in the vehicle frame.

## Related links

- https://github.com/tier4/tier4_autoware_msgs/pull/222
- https://github.com/autowarefoundation/autoware_launch/pull/1868

## How was this PR tested?
No automated tests are included in this package. The node can be exercised via the provided launch file:

```
ros2 launch autoware_proximity_hazard_object_checker proximity_hazard_object_checker.launch.xml
```

which remaps inputs from `/perception/object_recognition/objects` and `/localization/kinematic_state` and outputs to `/hmi/proximity_hazards`. The debug marker topic (`~/debug/sector_markers`) can be visualized in RViz to confirm sector geometry and detection-zone extent.

## Notes for reviewers
- The sector wedge polygons are built once at construction time and cached; they are **not** recomputed if parameters change at runtime (all `sector_range.*` params are declared `read_only: true`).
- `sector_boundary_tolerance_deg` expands each wedge slightly on both edges to avoid objects that fall exactly on a sector boundary being missed — this means objects near a boundary can appear in two adjacent sectors simultaneously.
- The circumradius pre-filter is a conservative bounding-circle check applied before the more expensive polygon intersection; it cannot produce false negatives.
- The TF lookup uses the odometry `child_frame_id` as the target frame (typically `base_link`), so the node does not hard-code a frame name.

## Interface changes

### Topic changes
#### Additions and removals
| Change type | Topic Type | Topic Name | Message Type | Description |
|:------------|:-----------|:-----------|:-------------|:------------|
| Added | Sub | `/perception/object_recognition/objects` | `autoware_perception_msgs/PredictedObjects` | Predicted objects from object recognition pipeline (remappable via `input_objects` launch arg) |
| Added | Sub | `/localization/kinematic_state` | `nav_msgs/Odometry` | Vehicle odometry; `child_frame_id` used as the TF target frame (remappable via `input_odometry` launch arg) |
| Added | Pub | `/hmi/proximity_hazards` | `tier4_external_api_msgs/ProximityHazardObjects` | Per-sector proximity hazard output (remappable via `output_hazards` launch arg) |
| Added | Pub | `~/debug/sector_markers` | `visualization_msgs/MarkerArray` | Debug visualization: detection-zone outline, sector boundary lines, sector labels |

### ROS Parameter Changes
#### Additions and removals
| Change type | Parameter Name | Type | Default Value | Description |
|:------------|:---------------|:-----|:--------------|:------------|
| Added | `node_hz` | `double` | `5.0` | Timer frequency in Hz |
| Added | `max_detection_range_m` | `double` | `2.0` | Max polygon-to-ego-footprint distance (m); objects beyond this threshold are discarded |
| Added | `include_unknown_objects` | `bool` | `true` | If `false`, objects whose classification contains `UNKNOWN` are dropped before sector assignment |
| Added | `sector_boundary_tolerance_deg` | `double` | `1.0` | Angular tolerance (°) added to each side of every sector wedge boundary |
| Added | `sector_range.front` | `double_array` | `[-10.0, 10.0]` | FRONT sector `[from_deg, to_deg]` (REP-103: +x forward, +y left, 0° = ahead) |
| Added | `sector_range.front_left` | `double_array` | `[10.0, 30.0]` | FRONT_LEFT sector `[from_deg, to_deg]` |
| Added | `sector_range.left` | `double_array` | `[30.0, 150.0]` | LEFT sector `[from_deg, to_deg]` |
| Added | `sector_range.rear_left` | `double_array` | `[150.0, 170.0]` | REAR_LEFT sector `[from_deg, to_deg]` |
| Added | `sector_range.rear` | `double_array` | `[170.0, -170.0]` | REAR sector; `to_deg < from_deg` wraps through ±180° |
| Added | `sector_range.rear_right` | `double_array` | `[-170.0, -150.0]` | REAR_RIGHT sector `[from_deg, to_deg]` |
| Added | `sector_range.right` | `double_array` | `[-150.0, -30.0]` | RIGHT sector `[from_deg, to_deg]` |
| Added | `sector_range.front_right` | `double_array` | `[-30.0, -10.0]` | FRONT_RIGHT sector `[from_deg, to_deg]` |

## Effects on system behavior
- A new topic `/hmi/proximity_hazards` (`tier4_external_api_msgs/ProximityHazardObjects`) begins publishing at 5 Hz once the node is running. Downstream HMI consumers must subscribe to this topic to receive proximity alert data.
- The node introduces a 5 Hz TF lookup from the input objects frame to base_link. If the TF tree is incomplete or stale, the node emits a throttled warning and skips that cycle without affecting other nodes.
- Polling subscribers for objects and odometry are non-blocking; if either input is unavailable on a given tick, a throttled warning is emitted and the publish is skipped for that cycle.
- No existing nodes or topics are modified.
