### PR TITLE
ci: remove autoware_core dependecy repositories from build_depends repos files

### DIFF
--- a/.github/workflows/build-and-test-differential.yaml
+++ b/.github/workflows/build-and-test-differential.yaml
@@ -113,6 +113,8 @@ jobs:
           build-depends-repos: build_depends.repos
           cache-key-element: ${{ env.BUILD_TYPE_CUDA_STATE }}
           build-pre-command: ${{ inputs.build-pre-command }}
+          # Core dependencies are provided pre-built by the Docker image under /opt/autoware.
+          underlay-workspace: /opt/autoware
       - name: Show ccache stats after build
         run: du -sh ${CCACHE_DIR} && ccache -s
         shell: bash
@@ -125,6 +127,8 @@ jobs:
           rosdistro: ${{ inputs.rosdistro }}
           target-packages: ${{ steps.get-modified-packages.outputs.modified-packages }}
           build-depends-repos: build_depends.repos
+          # Core dependencies are provided pre-built by the Docker image under /opt/autoware.
+          underlay-workspace: /opt/autoware
 
       - name: Upload coverage to CodeCov
         if: ${{ steps.test.outputs.coverage-report-files != '' && contains(inputs.container, '-cuda') && inputs.rosdistro == 'jazzy' }}

--- a/.github/workflows/build-and-test-packages-above-differential.yaml
+++ b/.github/workflows/build-and-test-packages-above-differential.yaml
@@ -109,6 +109,8 @@ jobs:
           packages-above-repos: packages_above.repos
           cache-key-element: ${{ env.BUILD_TYPE_CUDA_STATE }}-above
           build-pre-command: ${{ inputs.build-pre-command }}
+          # Core dependencies are provided pre-built by the Docker image under /opt/autoware.
+          underlay-workspace: /opt/autoware
 
       - name: Show ccache stats after build
         run: du -sh ${CCACHE_DIR} && ccache -s
@@ -123,6 +125,8 @@ jobs:
           target-packages: ${{ steps.get-modified-packages.outputs.modified-packages }}
           build-depends-repos: build_depends.repos
           packages-above-repos: packages_above.repos
+          # Core dependencies are provided pre-built by the Docker image under /opt/autoware.
+          underlay-workspace: /opt/autoware
 
       - name: Show disk space after the tasks
         run: df -h

--- a/.github/workflows/build-and-test-reusable.yaml
+++ b/.github/workflows/build-and-test-reusable.yaml
@@ -138,6 +138,8 @@ jobs:
           build-depends-repos: build_depends.repos
           cache-key-element: ${{ env.BUILD_TYPE_CUDA_STATE }}
           build-pre-command: ${{ inputs.build-pre-command }}
+          # Core dependencies are provided pre-built by the Docker image under /opt/autoware.
+          underlay-workspace: /opt/autoware
 
       - name: Show ccache stats after build
         if: ${{ inputs.pull-ccache || inputs.push-ccache }}
@@ -160,6 +162,8 @@ jobs:
           rosdistro: ${{ inputs.rosdistro }}
           target-packages: ${{ steps.get-self-packages.outputs.self-packages }}
           build-depends-repos: build_depends.repos
+          # Core dependencies are provided pre-built by the Docker image under /opt/autoware.
+          underlay-workspace: /opt/autoware
 
       - name: Upload coverage to CodeCov
         if: ${{ steps.test.outputs.coverage-report-files != '' && inputs.upload-coverage }}
@@ -214,6 +218,8 @@ jobs:
           clang-tidy-ignore-path: .clang-tidy-ignore
           build-depends-repos: build_depends.repos
           cache-key-element: ${{ env.BUILD_TYPE_CUDA_STATE }}
+          # Core dependencies are provided pre-built by the Docker image under /opt/autoware.
+          underlay-workspace: /opt/autoware
           artifact-name: clang-tidy-result-${{ inputs.rosdistro }}${{ contains(inputs.container, '-cuda') && '-cuda' || '' }}
           use-clang-tidy-cache: true
 

--- a/.github/workflows/clang-tidy-differential.yaml
+++ b/.github/workflows/clang-tidy-differential.yaml
@@ -103,6 +103,8 @@ jobs:
           cache-key-element: ${{ env.BUILD_TYPE_CUDA_STATE }}
           artifact-name: clang-tidy-result-${{ inputs.rosdistro }}${{ contains(inputs.container, '-cuda') && '-cuda' || '' }}
           use-clang-tidy-cache: true
+          # Core dependencies are provided pre-built by the Docker image under /opt/autoware.
+          underlay-workspace: /opt/autoware
 
       - name: Show disk space after the tasks
         run: df -h

--- a/.github/workflows/generate-build-cache.yaml
+++ b/.github/workflows/generate-build-cache.yaml
@@ -72,6 +72,8 @@ jobs:
           rosdistro: ${{ env.rosdistro }}
           cache-key-element: ${{ env.BUILD_TYPE_CUDA_STATE }}
           base-paths: dependency_ws
+          # Core dependencies are provided pre-built by the Docker image under /opt/autoware.
+          underlay-workspace: /opt/autoware
 
       - name: Save deps cache
         uses: actions/cache/save@v4

--- a/build_depends_nightly.repos
+++ b/build_depends_nightly.repos
@@ -1,30 +1,15 @@
 # Expected usage: first import build_depends_stable.repos, then import this.
-
+#
+# Do not add core (core/*) dependency repositories here.
+# Core packages are provided pre-built by the CI Docker image, and their versions
+# are defined by the image tag. Adding them here would cause redundant rebuilds.
+# The only exception is core/autoware_core below, which is frequently co-developed
+# with Universe and pinned to main so unreleased changes can be tested.
 repositories:
   # core
-  core/autoware_utils:
-    type: git
-    url: https://github.com/autowarefoundation/autoware_utils.git
-    version: main
   core/autoware_core:
     type: git
     url: https://github.com/autowarefoundation/autoware_core.git
-    version: main
-  core/autoware_cmake:
-    type: git
-    url: https://github.com/autowarefoundation/autoware_cmake.git
-    version: main
-  core/autoware_adapi_msgs:
-    type: git
-    url: https://github.com/autowarefoundation/autoware_adapi_msgs.git
-    version: main
-  core/autoware_internal_msgs:
-    type: git
-    url: https://github.com/autowarefoundation/autoware_internal_msgs.git
-    version: main
-  core/autoware_system_designer:
-    type: git
-    url: https://github.com/autowarefoundation/autoware_system_designer.git
     version: main
   # universe
   universe/external/tier4_autoware_msgs:

--- a/build_depends_stable.repos
+++ b/build_depends_stable.repos
@@ -1,38 +1,7 @@
+# Do not add core (core/*) dependency repositories here.
+# Core packages are provided pre-built by the CI Docker image, and their versions
+# are defined by the image tag. Adding them here would cause redundant rebuilds.
 repositories:
-  # core
-  core/autoware_msgs:
-    type: git
-    url: https://github.com/autowarefoundation/autoware_msgs.git
-    version: 1.13.0
-  # TODO (isamu-takagi): Use a released version when autoware_universe uses a released version.
-  core/autoware_adapi_msgs:
-    type: git
-    url: https://github.com/autowarefoundation/autoware_adapi_msgs.git
-    version: 1.9.1
-  core/autoware_internal_msgs:
-    type: git
-    url: https://github.com/autowarefoundation/autoware_internal_msgs.git
-    version: 1.12.1
-  core/autoware_cmake:
-    type: git
-    url: https://github.com/autowarefoundation/autoware_cmake.git
-    version: 1.2.0
-  core/autoware_utils:
-    type: git
-    url: https://github.com/autowarefoundation/autoware_utils.git
-    version: 1.7.1
-  core/autoware_lanelet2_extension:
-    type: git
-    url: https://github.com/autowarefoundation/autoware_lanelet2_extension.git
-    version: 1.1.0
-  core/autoware_core:
-    type: git
-    url: https://github.com/autowarefoundation/autoware_core.git
-    version: 1.8.0
-  core/autoware_system_designer:
-    type: git
-    url: https://github.com/autowarefoundation/autoware_system_designer.git
-    version: v0.3.2
   # universe
   universe/external/tier4_autoware_msgs:
     type: git


### PR DESCRIPTION
## Description

Implements the proposal in [autowarefoundation/autoware discussion #7096](https://github.com/orgs/autowarefoundation/discussions/7096) to stop redundantly importing and rebuilding `core/*` packages that are already provided pre-built in the CI Docker image.

- **`build_depends_stable.repos`**: removed all `core/*` entries (`autoware_msgs`, `autoware_adapi_msgs`, `autoware_internal_msgs`, `autoware_cmake`, `autoware_utils`, `autoware_lanelet2_extension`, `autoware_core`, `autoware_system_designer`). All `universe/external/*` and `middleware/external/*` blocks are retained.
- **`build_depends_nightly.repos`**: removed all `core/*` entries except `core/autoware_core` (kept, pinned to `main`), since it is frequently co-developed with Universe and needs to be testable against unreleased changes.
- Added header comments to both `.repos` files stating that core dependencies must not be added there, because core package versions are defined by the Docker image tag.
- **`build-and-test-reusable.yaml`**: since core packages are no longer built from source, the `colcon-build`, `colcon-test`, and `clang-tidy` steps now set `underlay-workspace: /opt/autoware` so they source the pre-built core packages from the image's underlay (`/opt/autoware/setup.sh`).

Core package versions are now single-sourced from the Docker image tag, and CI skips the redundant import / dependency-resolution / rebuild of core packages, reducing build time, workspace size, and disk pressure.

## Related links

**Parent Issue:**

- https://github.com/orgs/autowarefoundation/discussions/7096

## How was this PR tested?

- [x] Verify the `build-and-test` workflow passes with the updated ci: https://github.com/autowarefoundation/autoware_universe/actions/runs/27219153749
- [x] Confirm `check-build-depends` passes on the modified `.repos` files.
- [x] Confirm the install path `/opt/autoware/setup.sh` exists in the CI image (verified against `core.Dockerfile`/`universe.Dockerfile`, which install core with `--install-base /opt/autoware`).


## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
