### PR TITLE
test(autoware_tensorrt_plugins): add SegmentCSR kernel tests

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -15,6 +15,7 @@
     "HPIPM",
     "idxbu",
     "idxsh",
+    "indptr",
     "ineq",
     "lacados",
     "lambdify",

--- a/perception/autoware_tensorrt_plugins/CMakeLists.txt
+++ b/perception/autoware_tensorrt_plugins/CMakeLists.txt
@@ -152,6 +152,7 @@ if(TRT_AVAIL AND CUDA_AVAIL AND SPCONV_AVAIL)
 
     ament_add_gtest(reference_kernels_test
       test/argsort_kernel_test.cpp
+      test/segment_csr_kernel_test.cpp
       test/unique_kernel_test.cpp
     )
     if(TARGET reference_kernels_test)

--- a/perception/autoware_tensorrt_plugins/src/scatter_ops/segment_csr.cu
+++ b/perception/autoware_tensorrt_plugins/src/scatter_ops/segment_csr.cu
@@ -23,6 +23,7 @@
 #include "autoware/scatter_ops/segment_csr.h"
 #include "autoware/scatter_ops/utils.cuh"
 
+#include <algorithm>
 #include <numeric>
 #include <string>
 #include <tuple>
@@ -47,6 +48,19 @@
   SEGMENT_CSR_LAUNCH_INSTANTIATION_TR(T, ReductionType::DIV)  \
   SEGMENT_CSR_LAUNCH_INSTANTIATION_TR(T, ReductionType::MIN)  \
   SEGMENT_CSR_LAUNCH_INSTANTIATION_TR(T, ReductionType::MAX)
+
+namespace
+{
+size_t get_output_numel(
+  const std::vector<int32_t> & src_size, const std::vector<int32_t> & indptr_size, size_t dim)
+{
+  size_t out_numel = static_cast<size_t>(std::max<int32_t>(indptr_size[dim] - 1, 0));
+  for (size_t i = 0; i < src_size.size(); ++i) {
+    if (i != dim) out_numel *= static_cast<size_t>(src_size[i]);
+  }
+  return out_numel;
+}
+}  // namespace
 
 template <typename scalar_t, ReductionType REDUCE, int TB>
 __global__ void segment_csr_kernel(
@@ -128,7 +142,7 @@ int32_t segment_csr_launch(
   const std::vector<int32_t> & indptr_size, const scalar_t * base,
   std::tuple<scalar_t *, int64_t *> out, cudaStream_t stream)
 {
-  if (src_size.size() < indptr_size.size()) return -1;
+  if (indptr_size.empty() || src_size.size() < indptr_size.size()) return -1;
 
   if (!std::equal(indptr_size.begin(), indptr_size.end() - 1, src_size.begin())) return -1;
 
@@ -137,7 +151,9 @@ int32_t segment_csr_launch(
   auto _mul = [](int a, int b) { return a * b; };
   auto src_numel = std::accumulate(src_size.begin(), src_size.end(), 1, _mul);
   auto indptr_numel = std::accumulate(indptr_size.begin(), indptr_size.end(), 1, _mul);
-  auto out_numel = src_numel / src_size[dim] * std::max<int32_t>(indptr_size[dim] - 1, 0);
+  auto out_numel = get_output_numel(src_size, indptr_size, dim);
+
+  if (out_numel == 0) return 0;
 
   cudaMemcpyAsync(
     std::get<0>(out), base, sizeof(scalar_t) * out_numel, cudaMemcpyDeviceToDevice, stream);
@@ -175,10 +191,13 @@ int32_t segment_csr_launch(
   const std::vector<int32_t> & indptr_size, std::tuple<scalar_t *, int64_t *> out,
   cudaStream_t stream)
 {
+  if (indptr_size.empty() || src_size.size() < indptr_size.size()) return -1;
+
+  if (!std::equal(indptr_size.begin(), indptr_size.end() - 1, src_size.begin())) return -1;
+
   auto dim = indptr_size.size() - 1;
-  auto src_numel =
-    std::accumulate(src_size.begin(), src_size.end(), 1, [](int a, int b) { return a * b; });
-  auto out_numel = src_numel / src_size[dim] * std::max<int32_t>(indptr_size[dim] - 1, 0);
+  auto out_numel = get_output_numel(src_size, indptr_size, dim);
+  if (out_numel == 0) return 0;
 
   scalar_t * base;
   cudaMallocAsync(&base, sizeof(scalar_t) * out_numel, stream);

--- a/perception/autoware_tensorrt_plugins/test/segment_csr_kernel_test.cpp
+++ b/perception/autoware_tensorrt_plugins/test/segment_csr_kernel_test.cpp
@@ -100,8 +100,7 @@ void expect_float_vectors_equal(
 }
 
 template <ReductionType REDUCE>
-void run_segment_csr_case(
-  const SegmentCsrCase & test_case, const std::vector<float> & reference)
+void run_segment_csr_case(const SegmentCsrCase & test_case, const std::vector<float> & reference)
 {
   SKIP_TEST_IF_CUDA_UNAVAILABLE();
 
@@ -162,25 +161,25 @@ INSTANTIATE_TEST_SUITE_P(
       "NonEmptySegments",
       6U,
       2U,
-      {1.0F, 2.0F, 3.0F, 4.0F,  5.0F,  6.0F, 7.0F, 8.0F, 9.0F, 10.0F, 11.0F, 12.0F},
+      {1.0F, 2.0F, 3.0F, 4.0F, 5.0F, 6.0F, 7.0F, 8.0F, 9.0F, 10.0F, 11.0F, 12.0F},
       {0, 2, 5, 6}},
     SegmentCsrCase{
       "EmptyMiddleSegment",
       6U,
       2U,
-      {1.0F, 2.0F, 3.0F, 4.0F,  5.0F,  6.0F, 7.0F, 8.0F, 9.0F, 10.0F, 11.0F, 12.0F},
+      {1.0F, 2.0F, 3.0F, 4.0F, 5.0F, 6.0F, 7.0F, 8.0F, 9.0F, 10.0F, 11.0F, 12.0F},
       {0, 2, 2, 5, 6}},
     SegmentCsrCase{
       "EmptyBoundarySegments",
       6U,
       2U,
-      {1.0F, 2.0F, 3.0F, 4.0F,  5.0F,  6.0F, 7.0F, 8.0F, 9.0F, 10.0F, 11.0F, 12.0F},
+      {1.0F, 2.0F, 3.0F, 4.0F, 5.0F, 6.0F, 7.0F, 8.0F, 9.0F, 10.0F, 11.0F, 12.0F},
       {0, 0, 3, 6, 6}},
     SegmentCsrCase{
       "NoSegmentsWithRows",
       6U,
       2U,
-      {1.0F, 2.0F, 3.0F, 4.0F,  5.0F,  6.0F, 7.0F, 8.0F, 9.0F, 10.0F, 11.0F, 12.0F},
+      {1.0F, 2.0F, 3.0F, 4.0F, 5.0F, 6.0F, 7.0F, 8.0F, 9.0F, 10.0F, 11.0F, 12.0F},
       {0}},
     SegmentCsrCase{"EmptyInputNoSegments", 0U, 2U, {}, {0}},
     SegmentCsrCase{"EmptyInputEmptySegments", 0U, 2U, {}, {0, 0, 0}},

--- a/perception/autoware_tensorrt_plugins/test/segment_csr_kernel_test.cpp
+++ b/perception/autoware_tensorrt_plugins/test/segment_csr_kernel_test.cpp
@@ -1,0 +1,190 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/scatter_ops/segment_csr.h"
+#include "test_utils.hpp"
+
+#include <autoware/cuda_utils/cuda_gtest_utils.hpp>
+
+#include <cuda_runtime_api.h>
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <string>
+#include <tuple>
+#include <vector>
+
+namespace
+{
+
+using autoware::tensorrt_plugins::test::copy_to_device;
+using autoware::tensorrt_plugins::test::copy_to_host;
+using autoware::tensorrt_plugins::test::CudaStreamGuard;
+using autoware::tensorrt_plugins::test::DeviceBuffer;
+
+struct SegmentCsrCase
+{
+  std::string name;
+  std::size_t rows;
+  std::size_t cols;
+  std::vector<float> src;
+  std::vector<std::int64_t> indptr;
+};
+
+std::vector<float> make_segment_reference_mean(
+  const std::vector<float> & src, const std::size_t rows, const std::size_t cols,
+  const std::vector<std::int64_t> & indptr)
+{
+  std::vector<float> out((indptr.size() - 1U) * cols, 0.0F);
+  for (std::size_t segment = 0; segment + 1U < indptr.size(); ++segment) {
+    const auto start = static_cast<std::size_t>(indptr[segment]);
+    const auto end = static_cast<std::size_t>(indptr[segment + 1U]);
+    const auto count = std::max<std::size_t>(end - start, 1U);
+    for (std::size_t col = 0; col < cols; ++col) {
+      float accum = 0.0F;
+      for (std::size_t row = start; row < end; ++row) {
+        accum += src[row * cols + col];
+      }
+      out[segment * cols + col] = accum / static_cast<float>(count);
+    }
+  }
+  (void)rows;
+  return out;
+}
+
+std::vector<float> make_segment_reference_max(
+  const std::vector<float> & src, const std::size_t rows, const std::size_t cols,
+  const std::vector<std::int64_t> & indptr)
+{
+  std::vector<float> out((indptr.size() - 1U) * cols, 0.0F);
+  for (std::size_t segment = 0; segment + 1U < indptr.size(); ++segment) {
+    const auto start = static_cast<std::size_t>(indptr[segment]);
+    const auto end = static_cast<std::size_t>(indptr[segment + 1U]);
+    for (std::size_t col = 0; col < cols; ++col) {
+      float best = 0.0F;
+      if (start < end) {
+        best = -std::numeric_limits<float>::infinity();
+        for (std::size_t row = start; row < end; ++row) {
+          best = std::max(best, src[row * cols + col]);
+        }
+      }
+      out[segment * cols + col] = best;
+    }
+  }
+  (void)rows;
+  return out;
+}
+
+void expect_float_vectors_equal(
+  const std::vector<float> & actual, const std::vector<float> & expected)
+{
+  ASSERT_EQ(actual.size(), expected.size());
+  for (std::size_t index = 0; index < actual.size(); ++index) {
+    EXPECT_FLOAT_EQ(actual[index], expected[index]) << "index=" << index;
+  }
+}
+
+template <ReductionType REDUCE>
+void run_segment_csr_case(
+  const SegmentCsrCase & test_case, const std::vector<float> & reference)
+{
+  SKIP_TEST_IF_CUDA_UNAVAILABLE();
+
+  CudaStreamGuard stream;
+  DeviceBuffer<float> src_d(std::max<std::size_t>(test_case.src.size(), 1U));
+  DeviceBuffer<std::int64_t> indptr_d(test_case.indptr.size());
+  DeviceBuffer<float> out_d(std::max<std::size_t>(reference.size(), 1U));
+  const std::vector<std::int32_t> src_size{
+    static_cast<std::int32_t>(test_case.rows), static_cast<std::int32_t>(test_case.cols)};
+  const std::vector<std::int32_t> indptr_size{static_cast<std::int32_t>(test_case.indptr.size())};
+
+  if (!test_case.src.empty()) {
+    copy_to_device(src_d.get(), test_case.src);
+  }
+  copy_to_device(indptr_d.get(), test_case.indptr);
+
+  ASSERT_EQ(
+    (segment_csr_launch<float, REDUCE>(
+      src_d.get(), src_size, indptr_d.get(), indptr_size,
+      std::make_tuple(out_d.get(), static_cast<std::int64_t *>(nullptr)), stream.get())),
+    0);
+  ASSERT_EQ(cudaStreamSynchronize(stream.get()), cudaSuccess);
+
+  if (!reference.empty()) {
+    expect_float_vectors_equal(copy_to_host(out_d.get(), reference.size()), reference);
+  }
+}
+
+class SegmentCsrTest : public ::testing::TestWithParam<SegmentCsrCase>
+{
+};
+
+TEST_P(SegmentCsrTest, MeanMatchesCpuReference)
+{
+  const auto & test_case = GetParam();
+  const auto reference =
+    make_segment_reference_mean(test_case.src, test_case.rows, test_case.cols, test_case.indptr);
+  run_segment_csr_case<MEAN>(test_case, reference);
+}
+
+TEST_P(SegmentCsrTest, MaxMatchesCpuReference)
+{
+  const auto & test_case = GetParam();
+  const auto reference =
+    make_segment_reference_max(test_case.src, test_case.rows, test_case.cols, test_case.indptr);
+  run_segment_csr_case<MAX>(test_case, reference);
+}
+
+std::string segment_csr_case_name(const testing::TestParamInfo<SegmentCsrCase> & info)
+{
+  return info.param.name;
+}
+
+INSTANTIATE_TEST_SUITE_P(
+  ReferenceKernelsTest, SegmentCsrTest,
+  testing::Values(
+    SegmentCsrCase{
+      "NonEmptySegments",
+      6U,
+      2U,
+      {1.0F, 2.0F, 3.0F, 4.0F,  5.0F,  6.0F, 7.0F, 8.0F, 9.0F, 10.0F, 11.0F, 12.0F},
+      {0, 2, 5, 6}},
+    SegmentCsrCase{
+      "EmptyMiddleSegment",
+      6U,
+      2U,
+      {1.0F, 2.0F, 3.0F, 4.0F,  5.0F,  6.0F, 7.0F, 8.0F, 9.0F, 10.0F, 11.0F, 12.0F},
+      {0, 2, 2, 5, 6}},
+    SegmentCsrCase{
+      "EmptyBoundarySegments",
+      6U,
+      2U,
+      {1.0F, 2.0F, 3.0F, 4.0F,  5.0F,  6.0F, 7.0F, 8.0F, 9.0F, 10.0F, 11.0F, 12.0F},
+      {0, 0, 3, 6, 6}},
+    SegmentCsrCase{
+      "NoSegmentsWithRows",
+      6U,
+      2U,
+      {1.0F, 2.0F, 3.0F, 4.0F,  5.0F,  6.0F, 7.0F, 8.0F, 9.0F, 10.0F, 11.0F, 12.0F},
+      {0}},
+    SegmentCsrCase{"EmptyInputNoSegments", 0U, 2U, {}, {0}},
+    SegmentCsrCase{"EmptyInputEmptySegments", 0U, 2U, {}, {0, 0, 0}},
+    SegmentCsrCase{"ZeroColumns", 3U, 0U, {}, {0, 1, 3}}),
+  segment_csr_case_name);
+
+}  // namespace


### PR DESCRIPTION
## Summary

First PR in the SegmentCSR split stack.

Adds parameterized reference-kernel coverage for SegmentCSR mean and max reductions using the existing launcher API. The covered cases include normal non-empty segments, empty middle/boundary segments, no-segment output, empty source input, empty-source/empty-segment output, and zero-column output.

This also adds the minimal launcher guard needed for those edge cases: zero-output work now returns before zero-size kernel launches, and output size is computed without dividing by an empty reduction axis.

## Stack

1. This PR: add edge-case unit tests with minimal launcher guard/wiring.
2. Follow-up: document the plugin contract and clean up in/out API names.
3. Follow-up: remove the dead n-dimensional `indptr` path.
4. Follow-up: keep SegmentCSR allocation-free (#12555).
