### PR TITLE
refactor(autoware_tensorrt_plugins): clarify SegmentCSR contract

### DIFF
--- a/perception/autoware_tensorrt_plugins/README.md
+++ b/perception/autoware_tensorrt_plugins/README.md
@@ -25,6 +25,16 @@ We provide a wrapper for the `bev_pool` operation presented in [BEVFusion](https
 
 We provide a wrapper for the `segment_csr` operation presented in [torch_scatter](https://github.com/rusty1s/pytorch_scatter/tree/master). Please refer to the original code for specific details.
 
+The `SegmentCSR` TensorRT plugin supports a 2D source tensor and a 1D CSR row pointer:
+
+- `src`: row-major tensor with shape `[num_rows, num_cols]`
+- `indptr`: int64 tensor with shape `[num_segments + 1]`
+- `output`: tensor with shape `[num_segments, num_cols]`
+
+Each output row reduces the contiguous source rows `src[indptr[s] : indptr[s + 1]]` independently
+for every column. Higher-rank/batched CSR inputs are not part of this plugin contract; callers
+should flatten or reshape inputs before invoking the plugin.
+
 ### Unique
 
 While ONNX supports the unique operation, TensorRT does not provide an implementation. For this reason we implement `Unique` as `CustomUnique` to avoid name classes.

--- a/perception/autoware_tensorrt_plugins/include/autoware/scatter_ops/segment_csr.h
+++ b/perception/autoware_tensorrt_plugins/include/autoware/scatter_ops/segment_csr.h
@@ -25,19 +25,19 @@
 
 #include <cuda_runtime.h>
 
-#include <tuple>
+#include <cstdint>
 #include <vector>
 
 template <typename scalar_t, ReductionType REDUCE>
 int32_t segment_csr_launch(
-  const scalar_t * src, const std::vector<int32_t> & src_size, const int64_t * indptr,
-  const std::vector<int32_t> & indptr_size, const scalar_t * base,
-  std::tuple<scalar_t *, int64_t *> out, cudaStream_t stream);
+  const scalar_t * src_in, const std::vector<int32_t> & src_size_in, const int64_t * indptr_in,
+  const std::vector<int32_t> & indptr_size_in, const scalar_t * base_values_in,
+  scalar_t * reduced_values_out, int64_t * arg_indices_out, cudaStream_t stream_in);
 
 template <typename scalar_t, ReductionType REDUCE>
 int32_t segment_csr_launch(
-  const scalar_t * src, const std::vector<int32_t> & src_size, const int64_t * indptr,
-  const std::vector<int32_t> & indptr_size, std::tuple<scalar_t *, int64_t *> out,
-  cudaStream_t stream);
+  const scalar_t * src_in, const std::vector<int32_t> & src_size_in, const int64_t * indptr_in,
+  const std::vector<int32_t> & indptr_size_in, scalar_t * reduced_values_out,
+  int64_t * arg_indices_out, cudaStream_t stream_in);
 
 #endif  // AUTOWARE__SCATTER_OPS__SEGMENT_CSR_H_

--- a/perception/autoware_tensorrt_plugins/src/scatter_ops/segment_csr.cu
+++ b/perception/autoware_tensorrt_plugins/src/scatter_ops/segment_csr.cu
@@ -26,21 +26,20 @@
 #include <algorithm>
 #include <numeric>
 #include <string>
-#include <tuple>
 #include <vector>
 
 #define THREADS 256
 #define BLOCKS(TB, N) (TB * N + THREADS - 1) / THREADS
 #define FULL_MASK 0xffffffff
-#define SEGMENT_CSR_LAUNCH_INSTANTIATION_TR(T, R)                                             \
-  template int32_t segment_csr_launch<T, R>(                                                  \
-    const T * src, const std::vector<int32_t> & src_size, const int64_t * indptr,             \
-    const std::vector<int32_t> & indptr_size, std::tuple<T *, int64_t *> out,                 \
-    cudaStream_t stream);                                                                     \
-  template int32_t segment_csr_launch<T, R>(                                                  \
-    const T * src, const std::vector<int32_t> & src_size, const int64_t * indptr,             \
-    const std::vector<int32_t> & indptr_size, const T * base, std::tuple<T *, int64_t *> out, \
-    cudaStream_t stream);
+#define SEGMENT_CSR_LAUNCH_INSTANTIATION_TR(T, R)                                                  \
+  template int32_t segment_csr_launch<T, R>(                                                       \
+    const T * src_in, const std::vector<int32_t> & src_size_in, const int64_t * indptr_in,         \
+    const std::vector<int32_t> & indptr_size_in, T * reduced_values_out,                           \
+    int64_t * arg_indices_out, cudaStream_t stream_in);                                            \
+  template int32_t segment_csr_launch<T, R>(                                                       \
+    const T * src_in, const std::vector<int32_t> & src_size_in, const int64_t * indptr_in,         \
+    const std::vector<int32_t> & indptr_size_in, const T * base_values_in, T * reduced_values_out, \
+    int64_t * arg_indices_out, cudaStream_t stream_in);
 #define SEGMENT_CSR_LAUNCH_INSTANTIATION(T)                   \
   SEGMENT_CSR_LAUNCH_INSTANTIATION_TR(T, ReductionType::SUM)  \
   SEGMENT_CSR_LAUNCH_INSTANTIATION_TR(T, ReductionType::MEAN) \
@@ -138,76 +137,80 @@ __global__ void segment_csr_broadcast_kernel(
 //! \todo expand index
 template <typename scalar_t, ReductionType REDUCE>
 int32_t segment_csr_launch(
-  const scalar_t * src, const std::vector<int32_t> & src_size, const int64_t * indptr,
-  const std::vector<int32_t> & indptr_size, const scalar_t * base,
-  std::tuple<scalar_t *, int64_t *> out, cudaStream_t stream)
+  const scalar_t * src_in, const std::vector<int32_t> & src_size_in, const int64_t * indptr_in,
+  const std::vector<int32_t> & indptr_size_in, const scalar_t * base_values_in,
+  scalar_t * reduced_values_out, int64_t * arg_indices_out, cudaStream_t stream_in)
 {
-  if (indptr_size.empty() || src_size.size() < indptr_size.size()) return -1;
+  if (indptr_size_in.empty() || src_size_in.size() < indptr_size_in.size()) return -1;
 
-  if (!std::equal(indptr_size.begin(), indptr_size.end() - 1, src_size.begin())) return -1;
+  if (!std::equal(indptr_size_in.begin(), indptr_size_in.end() - 1, src_size_in.begin())) return -1;
 
-  auto dim = indptr_size.size() - 1;
+  auto dim = indptr_size_in.size() - 1;
 
   auto _mul = [](int a, int b) { return a * b; };
-  auto src_numel = std::accumulate(src_size.begin(), src_size.end(), 1, _mul);
-  auto indptr_numel = std::accumulate(indptr_size.begin(), indptr_size.end(), 1, _mul);
-  auto out_numel = get_output_numel(src_size, indptr_size, dim);
+  auto src_numel = std::accumulate(src_size_in.begin(), src_size_in.end(), 1, _mul);
+  auto indptr_numel = std::accumulate(indptr_size_in.begin(), indptr_size_in.end(), 1, _mul);
+  auto out_numel = get_output_numel(src_size_in, indptr_size_in, dim);
 
   if (out_numel == 0) return 0;
 
   cudaMemcpyAsync(
-    std::get<0>(out), base, sizeof(scalar_t) * out_numel, cudaMemcpyDeviceToDevice, stream);
+    reduced_values_out, base_values_in, sizeof(scalar_t) * out_numel, cudaMemcpyDeviceToDevice,
+    stream_in);
 
-  if ((REDUCE == ReductionType::MIN || REDUCE == ReductionType::MAX) && std::get<1>(out) != nullptr)
-    fill_kernel<int64_t>
-      <<<BLOCKS(1, out_numel), THREADS, 0, stream>>>(std::get<1>(out), out_numel, src_size[dim]);
+  if ((REDUCE == ReductionType::MIN || REDUCE == ReductionType::MAX) && arg_indices_out != nullptr)
+    fill_kernel<int64_t><<<BLOCKS(1, out_numel), THREADS, 0, stream_in>>>(
+      arg_indices_out, out_numel, src_size_in[dim]);
 
   if (src_numel == 0) return 0;
 
-  auto N = max(indptr_size[dim] - 1, 0) * (indptr_numel / indptr_size[dim]);
+  auto N = max(indptr_size_in[dim] - 1, 0) * (indptr_numel / indptr_size_in[dim]);
   auto K = out_numel / N;
-  auto E = src_size[dim];
+  auto E = src_size_in[dim];
   int64_t * indptr_size_dev;
-  cudaMallocAsync(&indptr_size_dev, sizeof(int64_t) * indptr_size.size(), stream);
+  cudaMallocAsync(&indptr_size_dev, sizeof(int64_t) * indptr_size_in.size(), stream_in);
   cudaMemcpyAsync(
-    indptr_size_dev, indptr_size.data(), sizeof(int64_t) * indptr_size.size(),
-    cudaMemcpyHostToDevice, stream);
+    indptr_size_dev, indptr_size_in.data(), sizeof(int64_t) * indptr_size_in.size(),
+    cudaMemcpyHostToDevice, stream_in);
 
   if (K == 1)
-    segment_csr_kernel<scalar_t, REDUCE, 1><<<BLOCKS(32, N), THREADS, 0, stream>>>(
-      src, indptr, indptr_size_dev, indptr_size.size(), std::get<0>(out), std::get<1>(out), N, E);
+    segment_csr_kernel<scalar_t, REDUCE, 1><<<BLOCKS(32, N), THREADS, 0, stream_in>>>(
+      src_in, indptr_in, indptr_size_dev, indptr_size_in.size(), reduced_values_out,
+      arg_indices_out, N, E);
   else
-    segment_csr_broadcast_kernel<scalar_t, REDUCE><<<BLOCKS(1, N * K), THREADS, 0, stream>>>(
-      src, indptr, indptr_size_dev, indptr_size.size(), std::get<0>(out), std::get<1>(out), N, K,
-      E);
+    segment_csr_broadcast_kernel<scalar_t, REDUCE><<<BLOCKS(1, N * K), THREADS, 0, stream_in>>>(
+      src_in, indptr_in, indptr_size_dev, indptr_size_in.size(), reduced_values_out,
+      arg_indices_out, N, K, E);
 
-  cudaFreeAsync(indptr_size_dev, stream);
+  cudaFreeAsync(indptr_size_dev, stream_in);
   return 0;
 }
 
 template <typename scalar_t, ReductionType REDUCE>
 int32_t segment_csr_launch(
-  const scalar_t * src, const std::vector<int32_t> & src_size, const int64_t * indptr,
-  const std::vector<int32_t> & indptr_size, std::tuple<scalar_t *, int64_t *> out,
-  cudaStream_t stream)
+  const scalar_t * src_in, const std::vector<int32_t> & src_size_in, const int64_t * indptr_in,
+  const std::vector<int32_t> & indptr_size_in, scalar_t * reduced_values_out,
+  int64_t * arg_indices_out, cudaStream_t stream_in)
 {
-  if (indptr_size.empty() || src_size.size() < indptr_size.size()) return -1;
+  if (indptr_size_in.empty() || src_size_in.size() < indptr_size_in.size()) return -1;
 
-  if (!std::equal(indptr_size.begin(), indptr_size.end() - 1, src_size.begin())) return -1;
+  if (!std::equal(indptr_size_in.begin(), indptr_size_in.end() - 1, src_size_in.begin())) return -1;
 
-  auto dim = indptr_size.size() - 1;
-  auto out_numel = get_output_numel(src_size, indptr_size, dim);
+  auto dim = indptr_size_in.size() - 1;
+  auto out_numel = get_output_numel(src_size_in, indptr_size_in, dim);
   if (out_numel == 0) return 0;
 
-  scalar_t * base;
-  cudaMallocAsync(&base, sizeof(scalar_t) * out_numel, stream);
-  fill_kernel<scalar_t><<<BLOCKS(1, out_numel), THREADS, 0, stream>>>(base, out_numel, (scalar_t)0);
+  scalar_t * base_values;
+  cudaMallocAsync(&base_values, sizeof(scalar_t) * out_numel, stream_in);
+  fill_kernel<scalar_t><<<BLOCKS(1, out_numel), THREADS, 0, stream_in>>>(
+    base_values, out_numel, static_cast<scalar_t>(0));
 
-  auto status =
-    segment_csr_launch<scalar_t, REDUCE>(src, src_size, indptr, indptr_size, base, out, stream);
+  auto status = segment_csr_launch<scalar_t, REDUCE>(
+    src_in, src_size_in, indptr_in, indptr_size_in, base_values, reduced_values_out,
+    arg_indices_out, stream_in);
   if (status != 0) return status;
 
-  cudaFreeAsync(base, stream);
+  cudaFreeAsync(base_values, stream_in);
   return 0;
 }
 

--- a/perception/autoware_tensorrt_plugins/src/scatter_ops/segment_csr.cu
+++ b/perception/autoware_tensorrt_plugins/src/scatter_ops/segment_csr.cu
@@ -208,7 +208,10 @@ int32_t segment_csr_launch(
   auto status = segment_csr_launch<scalar_t, REDUCE>(
     src_in, src_size_in, indptr_in, indptr_size_in, base_values, reduced_values_out,
     arg_indices_out, stream_in);
-  if (status != 0) return status;
+  if (status != 0) {
+    cudaFreeAsync(base_values, stream_in);
+    return status;
+  }
 
   cudaFreeAsync(base_values, stream_in);
   return 0;

--- a/perception/autoware_tensorrt_plugins/src/segment_csr_plugin.cpp
+++ b/perception/autoware_tensorrt_plugins/src/segment_csr_plugin.cpp
@@ -26,7 +26,6 @@
 #include <cstdint>
 #include <exception>
 #include <string>
-#include <tuple>
 #include <vector>
 namespace nvinfer1::plugin
 {
@@ -187,24 +186,20 @@ std::int32_t SegmentCSRPlugin::enqueue(
   if (input_desc[0].type == nvinfer1::DataType::kFLOAT) {
     const float * src_ptr = reinterpret_cast<const float *>(inputs[0]);
     const std::int64_t * indptr_ptr = reinterpret_cast<const std::int64_t *>(inputs[1]);
-
-    std::tuple<float *, std::int64_t *> out =
-      std::make_tuple(static_cast<float *>(outputs[0]), nullptr);
+    float * out_ptr = static_cast<float *>(outputs[0]);
 
     AT_DISPATCH_REDUCTION_TYPES(reduce_, [&] {
-      result =
-        segment_csr_launch<float, REDUCE>(src_ptr, src_size, indptr_ptr, indptr_size, out, stream);
+      result = segment_csr_launch<float, REDUCE>(
+        src_ptr, src_size, indptr_ptr, indptr_size, out_ptr, nullptr, stream);
     });
   } else if (input_desc[0].type == nvinfer1::DataType::kHALF) {
     const half * src_ptr = reinterpret_cast<const half *>(inputs[0]);
     const std::int64_t * indptr_ptr = reinterpret_cast<const std::int64_t *>(inputs[1]);
-
-    std::tuple<half *, std::int64_t *> out =
-      std::make_tuple(static_cast<half *>(outputs[0]), nullptr);
+    half * out_ptr = static_cast<half *>(outputs[0]);
 
     AT_DISPATCH_REDUCTION_TYPES(reduce_, [&] {
-      result =
-        segment_csr_launch<half, REDUCE>(src_ptr, src_size, indptr_ptr, indptr_size, out, stream);
+      result = segment_csr_launch<half, REDUCE>(
+        src_ptr, src_size, indptr_ptr, indptr_size, out_ptr, nullptr, stream);
     });
   }
 

--- a/perception/autoware_tensorrt_plugins/test/segment_csr_kernel_test.cpp
+++ b/perception/autoware_tensorrt_plugins/test/segment_csr_kernel_test.cpp
@@ -26,7 +26,6 @@
 #include <cstdint>
 #include <limits>
 #include <string>
-#include <tuple>
 #include <vector>
 
 namespace
@@ -119,8 +118,8 @@ void run_segment_csr_case(const SegmentCsrCase & test_case, const std::vector<fl
 
   ASSERT_EQ(
     (segment_csr_launch<float, REDUCE>(
-      src_d.get(), src_size, indptr_d.get(), indptr_size,
-      std::make_tuple(out_d.get(), static_cast<std::int64_t *>(nullptr)), stream.get())),
+      src_d.get(), src_size, indptr_d.get(), indptr_size, out_d.get(),
+      static_cast<std::int64_t *>(nullptr), stream.get())),
     0);
   ASSERT_EQ(cudaStreamSynchronize(stream.get()), cudaSuccess);
 


### PR DESCRIPTION
## Summary

Second PR in the SegmentCSR split stack.

This PR 
* documents the TensorRT plugin's existing 2D source + 1D `indptr` contract
* replaces the SegmentCSR launcher's output tuple with named output pointers
* makes naming and input/output roles clearer

**No behavior changes!**

## Stack

1. Add SegmentCSR kernel tests.
2. This PR: document/clarify the contract and clean up in/out API names.
3. Follow-up: remove the dead n-dimensional `indptr` path.
4. Follow-up: keep SegmentCSR allocation-free (#12555).