### PR TITLE
fix(autoware_carla_interface): decouple sensor publishing from the synchronous tick loop

### DIFF
--- a/simulator/autoware_carla_interface/launch/autoware_carla_interface.launch.xml
+++ b/simulator/autoware_carla_interface/launch/autoware_carla_interface.launch.xml
@@ -68,9 +68,24 @@
     <!-- <node pkg="tf2_ros" exec="static_transform_publisher" name="carla_velodyne_top" args="0 0 1 -1.5386 -0.015 0.001 velodyne_top velodyne_top_changed"/> -->
     <!-- <node pkg="tf2_ros" exec="static_transform_publisher" name="carla_imu" args="0 0 1 -3.10519265 -0.015 -3.14059265359 tamagawa/imu_link tamagawa/imu_link_changed"/> -->
 
-    <!-- Relay CAM_FRONT to traffic_light namespace for traffic light recognition -->
-    <node pkg="topic_tools" exec="relay" name="traffic_light_image_relay" args="/sensing/camera/CAM_FRONT/image_raw /sensing/camera/traffic_light/image_raw"/>
-    <node pkg="topic_tools" exec="relay" name="traffic_light_camera_info_relay" args="/sensing/camera/CAM_FRONT/camera_info /sensing/camera/traffic_light/camera_info"/>
+    <!-- Relay CAM_FRONT to traffic_light namespace for traffic light recognition.
+         These relays subscribe the raw image, which forces the interface to
+         convert and publish every CAM_FRONT frame; skip them in light-weight
+         mode like the republish nodes below. -->
+    <node
+      pkg="topic_tools"
+      exec="relay"
+      name="traffic_light_image_relay"
+      args="/sensing/camera/CAM_FRONT/image_raw /sensing/camera/traffic_light/image_raw"
+      unless="$(var use_light_weight_sensor_mapping)"
+    />
+    <node
+      pkg="topic_tools"
+      exec="relay"
+      name="traffic_light_camera_info_relay"
+      args="/sensing/camera/CAM_FRONT/camera_info /sensing/camera/traffic_light/camera_info"
+      unless="$(var use_light_weight_sensor_mapping)"
+    />
 
     <!-- Image transport nodes to create compressed versions for all cameras -->
     <node
@@ -78,6 +93,7 @@
       exec="republish"
       name="cam_front_republish"
       args="raw compressed --ros-args -r in:=/sensing/camera/CAM_FRONT/image_raw -r out/compressed:=/sensing/camera/CAM_FRONT/image_raw/compressed"
+      unless="$(var use_light_weight_sensor_mapping)"
     />
 
     <node

--- a/simulator/autoware_carla_interface/src/autoware_carla_interface/carla_ros.py
+++ b/simulator/autoware_carla_interface/src/autoware_carla_interface/carla_ros.py
@@ -42,6 +42,7 @@ from transforms3d.euler import euler2quat
 # New modular sensor infrastructure
 from .modules import ROSPublisherManager
 from .modules import SensorKitLoader
+from .modules import SensorPublishWorker
 from .modules import SensorRegistry
 from .modules.carla_data_provider import GameTime
 from .modules.carla_utils import carla_location_to_ros_point
@@ -300,6 +301,12 @@ class carla_ros2_interface(object):
         # Thread synchronization (protects: current_control, ego_actor, timestamp, physics_control)
         self._state_lock = threading.Lock()
 
+        # Per-sensor publish workers keyed by sensor ID. Heavy sensor data
+        # (camera, lidar) is converted and published on these threads so the
+        # synchronous tick loop is never blocked by serialization or by
+        # reliable-QoS flow control (see SensorPublishWorker).
+        self._publish_workers = {}
+
         # ROS-related helpers initialized later
         self.ros2_node = None
         self.ros_publisher_manager = None
@@ -336,26 +343,50 @@ class carla_ros2_interface(object):
         should_publish = self.sensor_registry.should_publish(sensor, self.timestamp)
         return not should_publish
 
-    def get_msg_header(self, frame_id):
-        """Obtain and modify ROS message header."""
+    def get_msg_header(self, frame_id, timestamp=None):
+        """Obtain and modify ROS message header.
+
+        timestamp defaults to the latest tick time; publish workers pass the
+        timestamp captured when their frame was enqueued so messages are
+        stamped with the frame's own tick even when published later.
+        """
         header = Header()
         header.frame_id = frame_id
-        seconds = int(self.timestamp)
-        nanoseconds = int((self.timestamp - int(self.timestamp)) * 1000000000.0)
+        if timestamp is None:
+            timestamp = self.timestamp
+        seconds = int(timestamp)
+        nanoseconds = int((timestamp - int(timestamp)) * 1000000000.0)
         header.stamp = Time(sec=seconds, nanosec=nanoseconds)
         return header
 
-    def lidar(self, carla_lidar_measurement, id_):
-        """Transform the received lidar measurement into a ROS point cloud message."""
-        if self.checkFrequency(id_):
-            return
+    def _submit_to_publish_worker(self, key, fn, *args):
+        """Run a publish call on the sensor's worker thread (created lazily)."""
+        worker = self._publish_workers.get(key)
+        if worker is None:
+            worker = SensorPublishWorker(key, self.logger)
+            self._publish_workers[key] = worker
+        worker.submit(fn, args)
 
+    def lidar(self, carla_lidar_measurement, id_, timestamp=None):
+        """Transform the received lidar measurement into a ROS point cloud message.
+
+        Runs on the sensor's publish worker thread; frequency gating and
+        registry bookkeeping happen at the dispatch site in run_step.
+        """
         config = self.sensor_registry.get_sensor(id_)
         if not config:
             self.logger.warning(f"No registry entry for LiDAR sensor '{id_}'")
             return
 
-        header = self.get_msg_header(frame_id=config.frame_id or "base_link")
+        publisher = self.pub_lidar.get(id_)
+        if publisher is None:
+            self.logger.warning(f"LiDAR publisher missing for '{id_}'")
+            return
+        # Skip the conversion work when nothing consumes this point cloud.
+        if publisher.get_subscription_count() == 0:
+            return
+
+        header = self.get_msg_header(frame_id=config.frame_id or "base_link", timestamp=timestamp)
         fields = [
             PointField(name="x", offset=0, datatype=PointField.FLOAT32, count=1),
             PointField(name="y", offset=4, datatype=PointField.FLOAT32, count=1),
@@ -407,13 +438,7 @@ class carla_ros2_interface(object):
         structured_lidar_data["channel"] = lidar_data[:, 5].astype(numpy.uint16)
 
         point_cloud_msg = create_cloud(header, fields, structured_lidar_data)
-        publisher = self.pub_lidar.get(id_)
-        if publisher is None:
-            self.logger.warning(f"LiDAR publisher missing for '{id_}'")
-            return
-
         publisher.publish(point_cloud_msg)
-        self.sensor_registry.update_sensor_timestamp(id_, self.timestamp)
 
     def initialpose_callback(self, data):
         """Transform RVIZ initial pose to CARLA (thread-safe)."""
@@ -529,42 +554,51 @@ class carla_ros2_interface(object):
 
         return camera_info
 
-    def camera(self, carla_camera_data, cam_id):
-        """Handle multiple cameras with dynamic routing by sensor ID."""
+    def camera(self, carla_camera_data, cam_id, timestamp=None):
+        """Handle multiple cameras with dynamic routing by sensor ID.
+
+        Runs on the sensor's publish worker thread; frequency gating and
+        registry bookkeeping happen at the dispatch site in run_step.
+        """
         config = self.sensor_registry.get_sensor(cam_id)
         if not config:
             self.logger.warning(f"No registry entry for camera '{cam_id}'")
             return
 
+        # Converting and publishing a multi-megabyte image is expensive even
+        # off the tick thread (GIL pressure from several workers starves it).
+        # Skip the work entirely when nothing consumes this camera; checked
+        # per frame so late subscribers start receiving immediately.
+        img_pub = self.pub_camera.get(cam_id)
+        info_pub = self.pub_camera_info.get(cam_id)
+        has_image_subs = img_pub is not None and img_pub.get_subscription_count() > 0
+        has_info_subs = info_pub is not None and info_pub.get_subscription_count() > 0
+        if not has_image_subs and not has_info_subs:
+            return
+
         if cam_id not in self.camera_info_cache:
             self.camera_info_cache[cam_id] = self._build_camera_info(carla_camera_data)
 
-        if self.checkFrequency(cam_id):
-            return
-
-        # Create image message
-        image_array = numpy.ndarray(
-            shape=(carla_camera_data.height, carla_camera_data.width, 4),
-            dtype=numpy.uint8,
-            buffer=carla_camera_data.raw_data,
-        )
-        img_msg = self.cv_bridge.cv2_to_imgmsg(image_array, encoding="bgra8")
-        img_msg.header = self.get_msg_header(
-            frame_id=config.frame_id or f"{cam_id}/camera_optical_link"
+        header = self.get_msg_header(
+            frame_id=config.frame_id or f"{cam_id}/camera_optical_link", timestamp=timestamp
         )
 
         # Publish camera info
-        cam_info = self.camera_info_cache[cam_id]
-        cam_info.header = img_msg.header
-        info_pub = self.pub_camera_info.get(cam_id)
-        if info_pub:
+        if has_info_subs:
+            cam_info = self.camera_info_cache[cam_id]
+            cam_info.header = header
             info_pub.publish(cam_info)
 
         # Publish image
-        img_pub = self.pub_camera.get(cam_id)
-        if img_pub:
+        if has_image_subs:
+            image_array = numpy.ndarray(
+                shape=(carla_camera_data.height, carla_camera_data.width, 4),
+                dtype=numpy.uint8,
+                buffer=carla_camera_data.raw_data,
+            )
+            img_msg = self.cv_bridge.cv2_to_imgmsg(image_array, encoding="bgra8")
+            img_msg.header = header
             img_pub.publish(img_msg)
-            self.sensor_registry.update_sensor_timestamp(cam_id, self.timestamp)
 
     def imu(self, carla_imu_measurement):
         """Transform and publish IMU measurement to ROS."""
@@ -829,12 +863,22 @@ class carla_ros2_interface(object):
                 )
                 continue
 
+            # Camera and lidar conversion/publishing run on per-sensor worker
+            # threads: publishing multi-megabyte messages inline (reliable-QoS
+            # camera images in particular block on DDS flow control) would
+            # stall this loop and slow simulation time itself. Frequency
+            # gating and registry bookkeeping stay on this thread so the
+            # registry is never accessed concurrently.
             if sensor_type == "sensor.camera.rgb":
-                self.camera(data[1], key)  # Pass sensor ID for multi-camera support
+                if not self.checkFrequency(key):
+                    self.sensor_registry.update_sensor_timestamp(key, self.timestamp)
+                    self._submit_to_publish_worker(key, self.camera, data[1], key, self.timestamp)
             elif sensor_type == "sensor.other.gnss":
                 self.pose()
             elif sensor_type == "sensor.lidar.ray_cast":
-                self.lidar(data[1], key)
+                if not self.checkFrequency(key):
+                    self.sensor_registry.update_sensor_timestamp(key, self.timestamp)
+                    self._submit_to_publish_worker(key, self.lidar, data[1], key, self.timestamp)
             elif sensor_type == "sensor.other.imu":
                 self.imu(data[1])
             else:
@@ -858,6 +902,11 @@ class carla_ros2_interface(object):
         process hanging and publisher leaks.
 
         """
+        # Stop publish workers before destroying the publishers they use
+        for worker in self._publish_workers.values():
+            worker.stop()
+        self._publish_workers.clear()
+
         # Destroy publishers first
         if self.ros_publisher_manager:
             self.ros_publisher_manager.destroy_all_publishers()

--- a/simulator/autoware_carla_interface/src/autoware_carla_interface/modules/__init__.py
+++ b/simulator/autoware_carla_interface/src/autoware_carla_interface/modules/__init__.py
@@ -20,11 +20,13 @@ from .ros_publisher_manager import ROSPublisherManager
 from .sensor_kit_loader import SensorKitLoader
 from .sensor_manager import SensorConfig
 from .sensor_manager import SensorRegistry
+from .sensor_publish_worker import SensorPublishWorker
 
 __all__ = [
     "SensorConfig",
     "SensorRegistry",
     "SensorKitLoader",
+    "SensorPublishWorker",
     "ROSPublisherManager",
     "CoordinateTransformer",
 ]

--- a/simulator/autoware_carla_interface/src/autoware_carla_interface/modules/sensor_publish_worker.py
+++ b/simulator/autoware_carla_interface/src/autoware_carla_interface/modules/sensor_publish_worker.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+
+# Copyright 2026 Tier IV, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import queue
+import threading
+
+_SENTINEL = object()
+
+
+class SensorPublishWorker:
+    """Convert and publish one sensor's data off the simulation tick thread.
+
+    The bridge drives the simulation clock from a single synchronous loop:
+    every tick waits for sensor processing to finish before the next
+    world.tick(). Converting and publishing large messages inline (for
+    example multi-megabyte camera images with reliable QoS, whose publish
+    call blocks on DDS flow control) stalls that loop and slows simulation
+    time itself, which destabilizes every downstream consumer.
+
+    Each worker owns one daemon thread and a bounded latest-wins queue:
+    when the publish side cannot keep up, stale frames are dropped instead
+    of blocking the tick loop. Sensor frames are perishable, so dropping
+    the oldest frame is the correct degradation.
+    """
+
+    def __init__(self, name, logger, queue_size=1):
+        self._name = name
+        self._logger = logger
+        self._queue = queue.Queue(maxsize=queue_size)
+        self._dropped = 0
+        self._thread = threading.Thread(
+            target=self._run, name=f"sensor_publish_{name}", daemon=True
+        )
+        self._thread.start()
+
+    def submit(self, fn, args):
+        """Enqueue a publish call without blocking; drop the stale frame when full."""
+        item = (fn, args)
+        while True:
+            try:
+                self._queue.put_nowait(item)
+                return
+            except queue.Full:
+                try:
+                    self._queue.get_nowait()
+                    self._dropped += 1
+                    if self._dropped % 100 == 1:
+                        self._logger.debug(
+                            f"Publish worker '{self._name}' dropped {self._dropped} stale frames"
+                        )
+                except queue.Empty:
+                    pass
+
+    def _run(self):
+        while True:
+            item = self._queue.get()
+            if item is _SENTINEL:
+                return
+            fn, args = item
+            try:
+                fn(*args)
+            except Exception as e:  # noqa: B902 - keep the worker alive on publish errors
+                self._logger.error(f"Publish worker '{self._name}' failed: {e}")
+
+    def stop(self, timeout=2.0):
+        """Stop the worker after letting queued work drain."""
+        try:
+            self._queue.put(_SENTINEL, timeout=timeout)
+        except queue.Full:
+            # Worker is wedged inside a publish call; it is a daemon thread,
+            # so it will not block process exit.
+            return
+        self._thread.join(timeout=timeout)


### PR DESCRIPTION
## Description

The interface converts and publishes all sensor data inline in the same thread that paces `world.tick()`. A publish call can block on DDS flow control — a 1600x900 BGRA image with `reliable` QoS is ~5.8 MB per frame, far above typical writer watermarks — so transport conditions stall the simulation clock itself. Once the simulation slows, every downstream consumer receives stale data and Autoware's data-freshness gates reject or drop autonomous engagement.

Measured on a cloud VM (28 vCPU EPYC @ 2.45 GHz, NVIDIA L40, CARLA 0.9.16 Town01, OpenADKit e2e demo, CycloneDDS): with a single subscribed camera, tick-loop iterations inflate from 7 ms (no cameras) to ~200 ms, dragging the simulation from 20 fps to ~7 fps. A QoS A/B test isolated the dominant cost to the blocking reliable publish (switching the camera to `best_effort` dropped the loop to 21–67 ms with no other change).

This PR makes camera/lidar handling unable to stall the simulation clock:

- **`SensorPublishWorker`** (new): one daemon thread per heavy sensor with a bounded latest-wins queue. Camera and lidar conversion/publishing run on these workers; the tick thread never blocks on serialization or DDS flow control. When a consumer cannot keep up, stale frames are dropped instead of slowing the simulation (sensor frames are perishable, and the drop count is logged at debug level).
- **Zero-subscriber skip**: conversion and publishing are skipped entirely when a camera/lidar topic has no subscribers, checked per frame so late subscribers start receiving immediately. Spawned-but-unconsumed sensors now cost nothing on the ROS side.
- **Launch consistency**: the always-on CAM_FRONT traffic-light relays and `cam_front_republish` now respect `use_light_weight_sensor_mapping`, like the other republish nodes added in #12525. These nodes subscribe the raw image and force full-rate conversion/publishing of CAM_FRONT even in deployments that disable traffic-light recognition.

Design notes:

- Frequency gating (`checkFrequency`) and registry bookkeeping stay on the tick thread, so the sensor registry is never accessed concurrently.
- Messages are stamped with the timestamp captured when their frame was enqueued, not the publish-time `self.timestamp`.
- Each ROS publisher is used by exactly one worker thread; workers are stopped before publishers are destroyed in `shutdown()`.

## Related links

- Builds on the intent of #12525 (light-weight sensor configuration).
- Found while validating autowarefoundation/openadkit#73 (CARLA e2e sample) on cloud GPU VMs.

## How was this PR tested?

Manually, on the cloud VM described above, running the full OpenADKit modular Autoware stack end to end against CARLA 0.9.16:

| Scenario | Before | After |
|---|---|---|
| 1 camera 1600x900 reliable, 2 subscribers | tick-loop iter ~200 ms, sim ~6.7 fps | **12–28 ms**, sim ~2x faster |
| 6 cameras spawned, no subscribers | n/a (always consumed) | zero ROS-side cost (skip path) |
| Cameras off (regression) | lidar 10 Hz / odom 20 Hz, drives | **identical: 9.7 / 19.4 Hz, autonomous drive verified (3.0 m)** |

## Notes for reviewers

With cameras spawned, CARLA's own per-tick render/stream cost remains the next bottleneck on server-class GPUs (we measured the simulation at ~8–10 fps with HD cameras spawned even with zero ROS-side work). That layer is outside this interface; on such hosts the light-weight sensor mapping remains the right tool. This change removes the interface's own contribution to the stall and makes partial camera consumption (e.g. RViz viewing one stream) safe.

## Interface changes

When `use_light_weight_sensor_mapping:=true`, the traffic-light relay nodes and `cam_front_republish` are no longer launched (previously they always ran). Default behavior (`false`) is unchanged.

## Effects on system behavior

Under camera load the simulation clock stays near real time instead of collapsing; camera frames may be dropped under sustained overload (latest-wins), which replaces the previous behavior of slowing the whole simulation.
