### PR TITLE
fix(autoware_map_based_prediction): flip footprint points when object direction is flipped

### DIFF
--- a/perception/autoware_map_based_prediction/lib/predictor_vehicle/object_processing.cpp
+++ b/perception/autoware_map_based_prediction/lib/predictor_vehicle/object_processing.cpp
@@ -195,6 +195,10 @@ void ObjectTracker::updateObjectData(TrackedObject & object)
       autoware_utils::create_quaternion_from_yaw(autoware_utils::pi + original_yaw);
     object.kinematics.twist_with_covariance.twist.linear.x *= -1.0;
     object.kinematics.twist_with_covariance.twist.linear.y *= -1.0;
+    for (auto & point : object.shape.footprint.points) {
+      point.x = -point.x;
+      point.y = -point.y;
+    }
   }
 }
 


### PR DESCRIPTION
## Description

When the input `TrackedObject` carries both a bounding-box and a footprint polygon (introduced in #12728), the predictor's orientation-correction logic in `ObjectTracker::updateObjectData` was leaving the footprint in an inconsistent state.

`updateObjectData` flips the heading by π and negates the longitudinal/lateral velocities whenever a `SIGN_UNKNOWN` object is detected moving backwards. The footprint polygon is defined in the object's local body frame, so a π-rotation of the heading must be accompanied by a π-rotation of every footprint vertex: `(x, y) → (−x, −y)`.

Without this fix, the footprint's front/rear geometry would remain pointing in the pre-flip direction while the bounding-box and velocity already reflected the corrected heading — causing downstream consumers (collision checks, occupancy, visualisation) to see a footprint whose nose points in the wrong direction.

## Related links

**Parent Issue:**

- #12728

## How was this PR tested?

Code review. The change is a one-loop arithmetic operation (`point.x = -point.x; point.y = -point.y`) applied only in the branch that was already flipping yaw and velocities — no new control flow.

## Notes for reviewers

The loop is a no-op when `shape.footprint.points` is empty (e.g. objects that carry only a bounding-box shape), so there is no regression for existing object types.

## Interface changes

None.

## Effects on system behavior

Footprint polygon of `SIGN_UNKNOWN` objects moving backwards is now rotated consistently with the corrected heading. No change for objects with `AVAILABLE` orientation or for objects that do not carry a footprint.