### PR TITLE
test(traffic_light_multi_camera_fusion): shrink node integration test

### DIFF
--- a/perception/autoware_traffic_light_multi_camera_fusion/test/test_traffic_light_multi_camera_fusion_node.cpp
+++ b/perception/autoware_traffic_light_multi_camera_fusion/test/test_traffic_light_multi_camera_fusion_node.cpp
@@ -20,6 +20,7 @@
 
 #include <autoware_map_msgs/msg/lanelet_map_bin.hpp>
 #include <autoware_perception_msgs/msg/traffic_light_group_array.hpp>
+#include <diagnostic_msgs/msg/diagnostic_array.hpp>
 #include <sensor_msgs/msg/camera_info.hpp>
 #include <tier4_perception_msgs/msg/traffic_light_array.hpp>
 #include <tier4_perception_msgs/msg/traffic_light_roi_array.hpp>
@@ -39,6 +40,8 @@
 using autoware::traffic_light::MultiCameraFusionNode;
 using autoware_map_msgs::msg::LaneletMapBin;
 using autoware_perception_msgs::msg::TrafficLightGroupArray;
+using diagnostic_msgs::msg::DiagnosticArray;
+using diagnostic_msgs::msg::DiagnosticStatus;
 using sensor_msgs::msg::CameraInfo;
 using tier4_perception_msgs::msg::TrafficLight;
 using tier4_perception_msgs::msg::TrafficLightArray;
@@ -94,6 +97,12 @@ protected:
         received_message_ = message;
         message_received_ = true;
       });
+
+    diagnostics_subscription_ = test_node_->create_subscription<DiagnosticArray>(
+      "/diagnostics", rclcpp::QoS(10), [this](const DiagnosticArray::SharedPtr message) {
+        received_diagnostics_ = message;
+        diagnostics_received_ = true;
+      });
   }
 
   void initialize_fusion_node(const FusionNodeOptions & options)
@@ -117,6 +126,7 @@ protected:
   {
     executor_.reset();
     output_subscription_.reset();
+    diagnostics_subscription_.reset();
     camera_info_publishers_.clear();
     roi_publishers_.clear();
     signal_publishers_.clear();
@@ -126,11 +136,13 @@ protected:
     rclcpp::shutdown();
   }
 
-  bool wait_for_message(std::chrono::milliseconds timeout = std::chrono::milliseconds(3000))
+  // Spin until both the fused output and the diagnostics message have been received.
+  bool wait_for_messages(std::chrono::milliseconds timeout = std::chrono::milliseconds(3000))
   {
     auto start = std::chrono::steady_clock::now();
     message_received_ = false;
-    while (!message_received_) {
+    diagnostics_received_ = false;
+    while (!message_received_ || !diagnostics_received_) {
       if (std::chrono::steady_clock::now() - start > timeout) {
         return false;
       }
@@ -230,9 +242,12 @@ protected:
   std::vector<rclcpp::Publisher<TrafficLightRoiArray>::SharedPtr> roi_publishers_;
   std::vector<rclcpp::Publisher<TrafficLightArray>::SharedPtr> signal_publishers_;
   rclcpp::Subscription<TrafficLightGroupArray>::SharedPtr output_subscription_;
+  rclcpp::Subscription<DiagnosticArray>::SharedPtr diagnostics_subscription_;
 
   TrafficLightGroupArray::SharedPtr received_message_;
+  DiagnosticArray::SharedPtr received_diagnostics_;
   bool message_received_ = false;
+  bool diagnostics_received_ = false;
 };
 
 /// @brief Create a lanelet map with two traffic-light line strings sharing a single
@@ -293,58 +308,12 @@ LaneletMapBin create_map()
   return map_bin;
 }
 
-// Two cameras observe two distinct traffic lights that belong to the same regulatory element.
-// Per-camera fusion picks the only record per traffic-light id, and group fusion accumulates
-// evidence across the two ids and outputs a single GREEN group.
-TEST_F(MultiCameraFusionIntegrationTest, TwoCamerasOneRegulatoryElementOutputsGreenGroup)
-{
-  // Arrange
-  initialize_fusion_node(FusionNodeOptions{});
-  publish_map(create_map());
-
-  // Act
-  publish_camera_detection(0, LEFT_TRAFFIC_LIGHT_ID, TrafficLightElement::GREEN, 0.9f);
-  publish_camera_detection(1, RIGHT_TRAFFIC_LIGHT_ID, TrafficLightElement::GREEN, 0.9f);
-
-  // Assert
-  ASSERT_TRUE(wait_for_message());
-  ASSERT_EQ(received_message_->traffic_light_groups.size(), 1u);
-  const auto & group = received_message_->traffic_light_groups.front();
-  EXPECT_EQ(group.traffic_light_group_id, REGULATORY_ELEMENT_ID);
-  ASSERT_EQ(group.elements.size(), 1u);
-  EXPECT_EQ(
-    group.elements.front().color, autoware_perception_msgs::msg::TrafficLightElement::GREEN);
-  EXPECT_EQ(
-    group.elements.front().shape, autoware_perception_msgs::msg::TrafficLightElement::CIRCLE);
-}
-
-// Two cameras observe different traffic lights in the same regulatory element with
-// conflicting colors and different confidences. With consistency check disabled,
-// the node selects the color from the higher-confidence observation.
-TEST_F(MultiCameraFusionIntegrationTest, HigherConfidenceColorWinsAmongConflictingObservations)
-{
-  // Arrange
-  initialize_fusion_node(FusionNodeOptions{});
-  publish_map(create_map());
-
-  // Act
-  publish_camera_detection(0, LEFT_TRAFFIC_LIGHT_ID, TrafficLightElement::RED, 0.6f);
-  publish_camera_detection(1, RIGHT_TRAFFIC_LIGHT_ID, TrafficLightElement::GREEN, 0.9f);
-
-  // Assert
-  ASSERT_TRUE(wait_for_message());
-  ASSERT_EQ(received_message_->traffic_light_groups.size(), 1u);
-  const auto & group = received_message_->traffic_light_groups.front();
-  EXPECT_EQ(group.traffic_light_group_id, REGULATORY_ELEMENT_ID);
-  ASSERT_EQ(group.elements.size(), 1u);
-  EXPECT_EQ(
-    group.elements.front().color, autoware_perception_msgs::msg::TrafficLightElement::GREEN);
-}
-
 // Two cameras observe the same regulatory element with conflicting colors (RED vs GREEN).
-// With consistency check enabled and partial-match publishing disabled, the node detects
-// a CONFLICT between the two state keys and emits a fail-safe UNKNOWN group.
-TEST_F(MultiCameraFusionIntegrationTest, TwoCamerasConflictingColorsOutputsFailsafeUnknown)
+// With the consistency check enabled, the node detects the conflict, so it publishes both an
+// output group array and a WARN diagnostics message. This exercises the node's subscribers,
+// map handling, output publisher, and diagnostics publishing path; the fusion logic itself is
+// covered by the unit tests.
+TEST_F(MultiCameraFusionIntegrationTest, ConflictingObservationsPublishOutputAndDiagnostics)
 {
   // Arrange
   FusionNodeOptions options;
@@ -357,15 +326,11 @@ TEST_F(MultiCameraFusionIntegrationTest, TwoCamerasConflictingColorsOutputsFails
   publish_camera_detection(1, RIGHT_TRAFFIC_LIGHT_ID, TrafficLightElement::GREEN, 0.9f);
 
   // Assert
-  ASSERT_TRUE(wait_for_message());
-  ASSERT_EQ(received_message_->traffic_light_groups.size(), 1u);
-  const auto & group = received_message_->traffic_light_groups.front();
-  EXPECT_EQ(group.traffic_light_group_id, REGULATORY_ELEMENT_ID);
-  ASSERT_EQ(group.elements.size(), 1u);
-  EXPECT_EQ(
-    group.elements.front().color, autoware_perception_msgs::msg::TrafficLightElement::UNKNOWN);
-  EXPECT_EQ(
-    group.elements.front().shape, autoware_perception_msgs::msg::TrafficLightElement::UNKNOWN);
+  ASSERT_TRUE(wait_for_messages());
+  EXPECT_EQ(received_message_->traffic_light_groups.size(), 1u);
+
+  ASSERT_FALSE(received_diagnostics_->status.empty());
+  EXPECT_EQ(received_diagnostics_->status.front().level, DiagnosticStatus::WARN);
 }
 
 int main(int argc, char ** argv)

--- a/perception/autoware_traffic_light_multi_camera_fusion/test/test_traffic_light_multi_camera_fusion_node.cpp
+++ b/perception/autoware_traffic_light_multi_camera_fusion/test/test_traffic_light_multi_camera_fusion_node.cpp
@@ -49,12 +49,12 @@ using tier4_perception_msgs::msg::TrafficLightElement;
 using tier4_perception_msgs::msg::TrafficLightRoi;
 using tier4_perception_msgs::msg::TrafficLightRoiArray;
 
-// IDs assigned to map elements. The two traffic-light line strings (*_TRAFFIC_LIGHT_ID) are
-// bound to the same regulatory element (REGULATORY_ELEMENT_ID); the node groups them into a
+// IDs assigned to map elements. The two traffic-light line strings (*_traffic_light_id) are
+// bound to the same regulatory element (regulatory_element_id); the node groups them into a
 // single output.
-constexpr lanelet::Id LEFT_TRAFFIC_LIGHT_ID = 11;
-constexpr lanelet::Id RIGHT_TRAFFIC_LIGHT_ID = 12;
-constexpr lanelet::Id REGULATORY_ELEMENT_ID = 100;
+constexpr lanelet::Id left_traffic_light_id = 11;
+constexpr lanelet::Id right_traffic_light_id = 12;
+constexpr lanelet::Id regulatory_element_id = 100;
 
 struct FusionNodeOptions
 {
@@ -285,19 +285,19 @@ LaneletMapBin create_map()
   Point3d left_traffic_light_left_end(7, 19.5, 0.5, 3.5);
   Point3d left_traffic_light_right_end(8, 19.5, -0.5, 3.5);
   LineString3d left_traffic_light(
-    LEFT_TRAFFIC_LIGHT_ID, {left_traffic_light_left_end, left_traffic_light_right_end});
+    left_traffic_light_id, {left_traffic_light_left_end, left_traffic_light_right_end});
   left_traffic_light.attributes()["subtype"] = "red_yellow_green";
   left_traffic_light.attributes()["height"] = "1.0";
 
   Point3d right_traffic_light_left_end(9, 20.5, 0.5, 3.5);
   Point3d right_traffic_light_right_end(10, 20.5, -0.5, 3.5);
   LineString3d right_traffic_light(
-    RIGHT_TRAFFIC_LIGHT_ID, {right_traffic_light_left_end, right_traffic_light_right_end});
+    right_traffic_light_id, {right_traffic_light_left_end, right_traffic_light_right_end});
   right_traffic_light.attributes()["subtype"] = "red_yellow_green";
   right_traffic_light.attributes()["height"] = "1.0";
 
   auto traffic_light_regulatory_element = lanelet::autoware::AutowareTrafficLight::make(
-    REGULATORY_ELEMENT_ID, lanelet::AttributeMap(), {left_traffic_light, right_traffic_light});
+    regulatory_element_id, lanelet::AttributeMap(), {left_traffic_light, right_traffic_light});
   road_lanelet.addRegulatoryElement(traffic_light_regulatory_element);
 
   auto lanelet_map = std::make_shared<lanelet::LaneletMap>();
@@ -322,8 +322,8 @@ TEST_F(MultiCameraFusionIntegrationTest, ConflictingObservationsPublishOutputAnd
   publish_map(create_map());
 
   // Act
-  publish_camera_detection(0, LEFT_TRAFFIC_LIGHT_ID, TrafficLightElement::RED, 0.9f);
-  publish_camera_detection(1, RIGHT_TRAFFIC_LIGHT_ID, TrafficLightElement::GREEN, 0.9f);
+  publish_camera_detection(0, left_traffic_light_id, TrafficLightElement::RED, 0.9f);
+  publish_camera_detection(1, right_traffic_light_id, TrafficLightElement::GREEN, 0.9f);
 
   // Assert
   ASSERT_TRUE(wait_for_messages());


### PR DESCRIPTION
## Description

This PR shrinks the node-level integration test of `autoware_traffic_light_multi_camera_fusion`
down to a single, focused integration case.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

- `colcon build --packages-select autoware_traffic_light_multi_camera_fusion`
- `colcon test --packages-select autoware_traffic_light_multi_camera_fusion`
  - The `MultiCameraFusionIntegrationTest.ConflictingObservationsPublishOutputAndDiagnostics` case
    passes, along with all linters (clang-format, cpplint, etc.).


## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None. This PR only touches the test file; no production code is changed.
