### PR TITLE
fix(multi object tracker): merge algorithm fix

### DIFF
--- a/perception/autoware_multi_object_tracker/CMakeLists.txt
+++ b/perception/autoware_multi_object_tracker/CMakeLists.txt
@@ -106,6 +106,7 @@ if(BUILD_TESTING)
     test/test_bench_association.cpp
     test/test_vehicle_tracker.cpp
     test/test_uuid_generator.cpp
+    test/test_tracker_overlap_manager.cpp
   )
   add_definitions(-D_SRC_RESOURCES_DIR_PATH="${PROJECT_SOURCE_DIR}/test/data/")
   ament_add_ros_isolated_gtest(test_multi_object_tracker ${test_files})

--- a/perception/autoware_multi_object_tracker/config/input_channels.param.yaml
+++ b/perception/autoware_multi_object_tracker/config/input_channels.param.yaml
@@ -14,7 +14,7 @@
           can_spawn_new_tracker: true
           can_trust_existence_probability: false
           can_trust_extension: false
-          can_trust_classification: false
+          can_trust_classification: true
           can_trust_orientation: false
         optional:
           name: "clustering"

--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/association/tracker_overlap_manager.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/association/tracker_overlap_manager.hpp
@@ -30,14 +30,25 @@
 namespace autoware::multi_object_tracker
 {
 
-/// Detects and merges spatially overlapping trackers produced by different sensors or detectors.
-/// Higher-priority trackers absorb lower-priority ones when sufficient overlap is confirmed.
+/// Detects and merges spatially overlapping trackers produced by different sensors or detectors
+/// (including over-segmented detections that one-to-one association cannot fuse).
+///
+/// Guarantees:
+/// - The merge outcome is a pure function of the tracker states: pair direction comes from a
+///   lexicographic dominance comparison ending in the tracker UUID, so results do not depend on
+///   tracker_list order.
+/// - The winner of a merge must be confident and carry a parametric shape (bounding box or
+///   cylinder); polygon-only trackers may only be absorbed — two polygon-only trackers never
+///   merge.
+/// - Applied merges form a star forest per cycle (no tracker both absorbs and is absorbed);
+///   longer chains converge over subsequent cycles with direct geometry checks.
 class TrackerOverlapManager
 {
 public:
   explicit TrackerOverlapManager(const TrackerOverlapManagerConfig & config);
 
-  /// Scans tracker_list for overlapping pairs and merges the lower-priority one into the higher.
+  /// Scans tracker_list for overlapping pairs and merges each redundant tracker into its
+  /// dominant counterpart.
   void merge(
     std::list<std::shared_ptr<Tracker>> & tracker_list, const rclcpp::Time & time,
     const AdaptiveThresholdCache & threshold_cache,
@@ -45,12 +56,6 @@ public:
 
 private:
   TrackerOverlapManagerConfig config_;
-
-  /// Returns true if target may be merged (absorbed) into other.
-  bool canMergeTarget(
-    const Tracker & target, const Tracker & other, const rclcpp::Time & time,
-    const AdaptiveThresholdCache & threshold_cache,
-    const std::optional<geometry_msgs::msg::Pose> & ego_pose) const;
 };
 
 }  // namespace autoware::multi_object_tracker

--- a/perception/autoware_multi_object_tracker/lib/association/scoring/redundancy_check.cpp
+++ b/perception/autoware_multi_object_tracker/lib/association/scoring/redundancy_check.cpp
@@ -48,7 +48,6 @@ bool isRedundant(
   const float source_known_prob, const float target_known_prob,
   const TrackerOverlapManagerConfig & config)
 {
-  constexpr double min_union_iou_area = 1e-2;
   constexpr float min_known_prob = 0.2;
   constexpr double min_valid_iou = 1e-6;
   constexpr double precision_threshold = 0.;
@@ -71,9 +70,26 @@ bool isRedundant(
     if (iou < min_valid_iou) return false;
     return iou > config.min_known_object_removal_iou;
   } else if (is_target_known && is_source_known) {
-    double iou = shapes::get2dIoU(source_object, target_object, min_union_iou_area);
-    if (iou < min_valid_iou) return false;
-    return iou > config.min_known_object_removal_iou;
+    // Both known. Plain IoU misses over-segmented fragments that carry a classification
+    // (e.g. semantic-segmentation clusters): a small fragment inside a full-size object has
+    // low IoU. Add a containment criterion limited to clearly smaller targets so two adjacent
+    // full-size objects are not merged by containment alone.
+    double precision = 0.0;
+    double recall = 0.0;
+    double generalized_iou = 0.0;
+    if (!shapes::get2dPrecisionRecallGIoU(
+          source_object, target_object, precision, recall, generalized_iou)) {
+      return false;
+    }
+    if (precision < min_valid_iou || recall < min_valid_iou) return false;
+    // IoU recovered from precision (I/src) and recall (I/tgt): U = I*(1/p + 1/r - 1)
+    const double iou = 1.0 / (1.0 / precision + 1.0 / recall - 1.0);
+    if (iou > config.min_known_object_removal_iou) return true;
+    // Containment: target mostly covered by source, and target area (= source area * p/r)
+    // less than half of source area
+    constexpr double containment_recall_threshold = 0.5;
+    constexpr double max_fragment_area_ratio = 0.5;
+    return recall > containment_recall_threshold && precision < max_fragment_area_ratio * recall;
   } else if (is_target_known || is_source_known) {
     // One object is unknown (typically the target)
     double precision = 0.0;

--- a/perception/autoware_multi_object_tracker/lib/association/tracker_overlap_manager.cpp
+++ b/perception/autoware_multi_object_tracker/lib/association/tracker_overlap_manager.cpp
@@ -23,8 +23,12 @@
 #include <boost/geometry/index/rtree.hpp>
 
 #include <algorithm>
+#include <array>
+#include <cmath>
 #include <list>
 #include <memory>
+#include <optional>
+#include <unordered_map>
 #include <unordered_set>
 #include <utility>
 #include <vector>
@@ -36,71 +40,61 @@ namespace bg = boost::geometry;
 namespace bgi = boost::geometry::index;
 
 using OmPoint = bg::model::point<double, 2, bg::cs::cartesian>;
-using OmValue = std::pair<OmPoint, size_t>;  // (position, index into valid_trackers)
+using OmValue = std::pair<OmPoint, size_t>;  // (position, index into snapshots)
+
+namespace
+{
+
+constexpr float min_known_prob = 0.2f;
+
+// Per-tracker state captured once per merge cycle. All pair decisions read snapshots, never the
+// live tracker, so the outcome is a pure function of tracker states — independent of list order
+// and of merges applied later in the same cycle.
+struct TrackerSnapshot
+{
+  std::shared_ptr<Tracker> tracker;
+  geometry_msgs::msg::Point position;
+  classes::Label label{classes::Label::UNKNOWN};
+  bool is_unknown{true};
+  int priority{0};
+  float known_prob{0.0f};
+  double cov_det{0.0};
+  int measurement_count{0};
+  std::array<uint8_t, 16> uuid{};
+  std::vector<types::ExistenceProbability> existence_probs;
+  // Filled lazily, only for trackers that appear in a distance-gated pair
+  std::optional<bool> confident;
+  std::optional<bool> object_valid;
+  types::DynamicObject object;
+};
+
+// True when lhs significantly outperforms rhs on at least one input channel.
+// A channel missing from rhs counts as near-zero probability.
+bool dominatesOnAnyChannel(
+  const std::vector<types::ExistenceProbability> & lhs,
+  const std::vector<types::ExistenceProbability> & rhs)
+{
+  constexpr float prob_buffer = 0.4f;
+  for (const auto & lhs_prob : lhs) {
+    float rhs_prob_val = 0.001f;
+    for (const auto & rhs_prob : rhs) {
+      if (rhs_prob.channel_index == lhs_prob.channel_index) {
+        rhs_prob_val = rhs_prob.existence_probability;
+        break;
+      }
+    }
+    if (rhs_prob_val + prob_buffer < lhs_prob.existence_probability) {
+      return true;
+    }
+  }
+  return false;
+}
+
+}  // namespace
 
 TrackerOverlapManager::TrackerOverlapManager(const TrackerOverlapManagerConfig & config)
 : config_(config)
 {
-}
-
-bool TrackerOverlapManager::canMergeTarget(
-  const Tracker & target, const Tracker & other, const rclcpp::Time & time,
-  const AdaptiveThresholdCache & threshold_cache,
-  const std::optional<geometry_msgs::msg::Pose> & ego_pose) const
-{
-  // 0. Compare tracker priority: higher priority (lower index) is never absorbed
-  if (target.getTrackerPriority() < other.getTrackerPriority()) {
-    return false;
-  }
-
-  // 1. If the other is not confident, do not remove the target
-  if (!other.isConfident(threshold_cache, ego_pose, time)) {
-    return false;
-  }
-
-  // 2. Compare known class probability
-  const float target_known_prob = target.getKnownObjectProbability();
-  const float other_known_prob = other.getKnownObjectProbability();
-  constexpr float min_known_prob = 0.2;
-
-  if (target_known_prob >= min_known_prob) {
-    // Target class is known
-    if (other_known_prob < min_known_prob) {
-      // Other is unknown -> keep target
-      return false;
-    }
-    // Both known: compare per-channel existence probabilities
-    const std::vector<types::ExistenceProbability> target_existence_prob =
-      target.getExistenceProbabilityVector();
-    const std::vector<types::ExistenceProbability> other_existence_prob =
-      other.getExistenceProbabilityVector();
-    constexpr float prob_buffer = 0.4;
-
-    for (const auto & other_prob : other_existence_prob) {
-      float target_prob_val = 0.001f;
-      for (const auto & target_prob : target_existence_prob) {
-        if (target_prob.channel_index == other_prob.channel_index) {
-          target_prob_val = target_prob.existence_probability;
-          break;
-        }
-      }
-      if (target_prob_val + prob_buffer < other_prob.existence_probability) {
-        // Other significantly outperforms target on this channel -> remove target
-        return true;
-      }
-    }
-
-    // No large per-channel difference: remove the one with larger position uncertainty
-    return target.getPositionCovarianceDeterminant() > other.getPositionCovarianceDeterminant();
-  }
-
-  // 3. Target class is unknown
-  if (other_known_prob < min_known_prob) {
-    // Both unknown: remove the one with larger position uncertainty
-    return target.getPositionCovarianceDeterminant() > other.getPositionCovarianceDeterminant();
-  }
-  // Other is known, target is unknown -> remove target
-  return true;
 }
 
 void TrackerOverlapManager::merge(
@@ -108,145 +102,225 @@ void TrackerOverlapManager::merge(
   const AdaptiveThresholdCache & threshold_cache,
   const std::optional<geometry_msgs::msg::Pose> & ego_pose)
 {
-  // Local cache of per-tracker data to avoid repeated virtual calls
-  struct TrackerData
-  {
-    std::shared_ptr<Tracker> tracker;
-    types::DynamicObject object;
-    classes::Label label;
-    bool is_unknown;
-    int tracker_priority;
-    int measurement_count;
-    double elapsed_time;
-    bool is_valid;
-
-    explicit TrackerData(const std::shared_ptr<Tracker> & t)
-    : tracker(t),
-      object(),
-      label(classes::Label::UNKNOWN),
-      is_unknown(false),
-      tracker_priority(0),
-      measurement_count(0),
-      elapsed_time(0.0),
-      is_valid(false)
-    {
-    }
-  };
-
-  std::vector<TrackerData> valid_trackers;
-  valid_trackers.reserve(tracker_list.size());
-
-  // First pass: collect valid trackers and their data
+  // ---- Snapshot pass: cheap scalars only ----
+  // Position comes from the motion model (no shape/classification assembly); the full object is
+  // fetched lazily per gated pair.
+  std::vector<TrackerSnapshot> snapshots;
+  snapshots.reserve(tracker_list.size());
   for (const auto & tracker : tracker_list) {
-    TrackerData data(tracker);
-    if (!tracker->getTrackedObject(time, data.object)) {
+    geometry_msgs::msg::Pose pose;
+    geometry_msgs::msg::Twist twist;
+    std::array<double, 36> pose_cov{};
+    std::array<double, 36> twist_cov{};
+    if (!tracker->getMotionState(time, pose, pose_cov, twist, twist_cov)) {
       continue;
     }
-    data.label = tracker->getHighestProbLabel();
-    data.is_unknown = (data.label == classes::Label::UNKNOWN);
-    data.tracker_priority = tracker->getTrackerPriority();
-    data.measurement_count = tracker->getTotalMeasurementCount();
-    data.elapsed_time = tracker->getElapsedTimeFromLastUpdate(time);
-    data.is_valid = true;
-    valid_trackers.push_back(std::move(data));
+    TrackerSnapshot snap;
+    snap.tracker = tracker;
+    snap.position = pose.position;
+    snap.label = tracker->getHighestProbLabel();
+    snap.is_unknown = (snap.label == classes::Label::UNKNOWN);
+    snap.priority = tracker->getTrackerPriority();
+    snap.known_prob = tracker->getKnownObjectProbability();
+    snap.cov_det = tracker->getPositionCovarianceDeterminant();
+    snap.measurement_count = tracker->getTotalMeasurementCount();
+    snap.uuid = tracker->getUUID().uuid;
+    snap.existence_probs = tracker->getExistenceProbabilityVector();
+    snapshots.push_back(std::move(snap));
+  }
+  if (snapshots.size() < 2) {
+    return;
   }
 
-  // Sort by priority: lower index -> higher priority, then non-unknown, then more measurements
-  std::sort(
-    valid_trackers.begin(), valid_trackers.end(), [](const TrackerData & a, const TrackerData & b) {
-      if (a.tracker_priority != b.tracker_priority) {
-        return a.tracker_priority < b.tracker_priority;
-      }
-      if (a.is_unknown != b.is_unknown) {
-        return b.is_unknown;  // Non-unknown first
-      }
-      if (a.measurement_count != b.measurement_count) {
-        return a.measurement_count > b.measurement_count;
-      }
-      return a.elapsed_time < b.elapsed_time;
-    });
+  const auto is_confident = [&](TrackerSnapshot & snap) {
+    if (!snap.confident) {
+      snap.confident = snap.tracker->isConfident(threshold_cache, ego_pose, time);
+    }
+    return *snap.confident;
+  };
+  const auto get_object = [&](TrackerSnapshot & snap) -> const types::DynamicObject * {
+    if (!snap.object_valid) {
+      snap.object_valid = snap.tracker->getTrackedObject(time, snap.object);
+    }
+    return *snap.object_valid ? &snap.object : nullptr;
+  };
 
-  // Build R-tree for spatial lookup
+  // ---- Candidate pair discovery ----
+  // Each tracker queries with its own label radius; pairs are deduplicated, so the effective
+  // gate is dist <= max(radius_a, radius_b) regardless of which side discovers the pair.
   bgi::rtree<OmValue, bgi::quadratic<16>> rtree;
-  std::vector<OmValue> rtree_points;
-  rtree_points.reserve(valid_trackers.size());
-  for (size_t i = 0; i < valid_trackers.size(); ++i) {
-    const auto & data = valid_trackers[i];
-    if (!data.is_valid) continue;
-    OmPoint p(data.object.pose.position.x, data.object.pose.position.y);
-    rtree_points.emplace_back(p, i);
+  {
+    std::vector<OmValue> rtree_points;
+    rtree_points.reserve(snapshots.size());
+    for (size_t i = 0; i < snapshots.size(); ++i) {
+      rtree_points.emplace_back(OmPoint(snapshots[i].position.x, snapshots[i].position.y), i);
+    }
+    rtree.insert(rtree_points.begin(), rtree_points.end());
   }
-  rtree.insert(rtree_points.begin(), rtree_points.end());
 
-  std::vector<size_t> to_remove;
-  to_remove.reserve(valid_trackers.size() / 4);
-
-  // Second pass: find and merge overlapping trackers
-  for (size_t i = 0; i < valid_trackers.size(); ++i) {
-    auto & data1 = valid_trackers[i];
-    if (!data1.is_valid || !data1.tracker->isConfident(threshold_cache, ego_pose, time)) continue;
-
+  std::vector<std::pair<size_t, size_t>> candidate_pairs;
+  std::vector<OmValue> nearby;
+  for (size_t i = 0; i < snapshots.size(); ++i) {
     const auto max_search_dist_sq_opt =
-      get_map_value_if_exists(config_.pruning_distance_thresholds_sq, data1.label);
-    if (!max_search_dist_sq_opt) continue;
+      get_map_value_if_exists(config_.pruning_distance_thresholds_sq, snapshots[i].label);
+    if (!max_search_dist_sq_opt) {
+      continue;
+    }
     const double max_search_dist_sq = max_search_dist_sq_opt->get();
+    const double max_search_dist = std::sqrt(max_search_dist_sq);
+    const double x = snapshots[i].position.x;
+    const double y = snapshots[i].position.y;
+    // The box predicate lets the R-tree prune subtrees; satisfies alone would scan linearly.
+    const bg::model::box<OmPoint> search_box(
+      OmPoint(x - max_search_dist, y - max_search_dist),
+      OmPoint(x + max_search_dist, y + max_search_dist));
 
-    std::vector<OmValue> nearby;
-    nearby.reserve(16);
+    nearby.clear();
     rtree.query(
-      bgi::satisfies([&](const OmValue & v) {
-        if (v.second <= i) return false;  // Skip already-processed and self
-        const double dx = bg::get<0>(v.first) - data1.object.pose.position.x;
-        const double dy = bg::get<1>(v.first) - data1.object.pose.position.y;
+      bgi::intersects(search_box) && bgi::satisfies([&](const OmValue & v) {
+        if (v.second == i) return false;
+        const double dx = bg::get<0>(v.first) - x;
+        const double dy = bg::get<1>(v.first) - y;
         return dx * dx + dy * dy <= max_search_dist_sq;
       }),
       std::back_inserter(nearby));
-
-    for (const auto & [p2, idx2] : nearby) {
-      auto & data2 = valid_trackers[idx2];
-      if (!data2.is_valid) continue;
-
-      if (
-        canMergeTarget(*data2.tracker, *data1.tracker, time, threshold_cache, ego_pose) &&
-        isRedundant(
-          data1.object, data2.object, data1.label, data2.label,
-          data1.tracker->getKnownObjectProbability(), data2.tracker->getKnownObjectProbability(),
-          config_)) {
-        // Merge data2 (lower priority) into data1 (higher priority)
-
-        // Existence probabilities
-        data1.tracker->updateTotalExistenceProbability(
-          data2.tracker->getTotalExistenceProbability());
-        data1.tracker->mergeExistenceProbabilities(data2.tracker->getExistenceProbabilityVector());
-
-        // Classification: only update if source is known
-        if (!data2.is_unknown) {
-          data1.tracker->updateClassification(data2.tracker->getClassification());
-        }
-
-        // Shape: prefer lower shape type (bounding box < cylinder < convex hull).
-        if (data1.object.shape.type > data2.object.shape.type) {
-          data1.tracker->setObjectShape(data2.object.shape);
-        }
-        // If the absorbed tracker carries footprint data (BBOX or POLYGON), union it into the
-        // winner.
-        if (!data2.object.shape.footprint.points.empty()) {
-          data1.tracker->mergeFootprintFrom(
-            data2.object.shape.footprint, data2.object.pose, data1.object.pose);
-        }
-
-        data2.is_valid = false;
-        to_remove.push_back(idx2);
-      }
+    for (const auto & [point, j] : nearby) {
+      candidate_pairs.emplace_back(std::min(i, j), std::max(i, j));
     }
   }
+  std::sort(candidate_pairs.begin(), candidate_pairs.end());
+  candidate_pairs.erase(
+    std::unique(candidate_pairs.begin(), candidate_pairs.end()), candidate_pairs.end());
 
-  // Final pass: remove merged trackers
-  std::unordered_set<std::shared_ptr<Tracker>> trackers_to_remove;
-  trackers_to_remove.reserve(to_remove.size());
-  for (const auto idx : to_remove) {
-    trackers_to_remove.insert(valid_trackers[idx].tracker);
+  // ---- Pair decision ----
+  // Direction comes from a lexicographic comparison ending in the UUID, so every pair has a
+  // strict, list-order-independent winner. The per-channel existence tier is evaluated in both
+  // directions; mutual or no dominance falls through to the next tier.
+  const auto outranks = [&](TrackerSnapshot & a, TrackerSnapshot & b) {
+    if (a.priority != b.priority) {
+      return a.priority < b.priority;
+    }
+    const bool a_confident = is_confident(a);
+    const bool b_confident = is_confident(b);
+    if (a_confident != b_confident) {
+      return a_confident;
+    }
+    const bool a_known = a.known_prob >= min_known_prob;
+    const bool b_known = b.known_prob >= min_known_prob;
+    if (a_known != b_known) {
+      return a_known;
+    }
+    const bool a_dominates = dominatesOnAnyChannel(a.existence_probs, b.existence_probs);
+    const bool b_dominates = dominatesOnAnyChannel(b.existence_probs, a.existence_probs);
+    if (a_dominates != b_dominates) {
+      return a_dominates;
+    }
+    if (a.cov_det != b.cov_det) {
+      return a.cov_det < b.cov_det;
+    }
+    if (a.measurement_count != b.measurement_count) {
+      return a.measurement_count > b.measurement_count;
+    }
+    return a.uuid < b.uuid;
+  };
+
+  struct MergeCandidate
+  {
+    size_t winner_idx;
+    double dist_sq;
+  };
+  std::unordered_map<size_t, MergeCandidate> best_winner_of_loser;
+  for (const auto & [i, j] : candidate_pairs) {
+    const bool i_wins = outranks(snapshots[i], snapshots[j]);
+    const size_t winner_idx = i_wins ? i : j;
+    const size_t loser_idx = i_wins ? j : i;
+    auto & winner = snapshots[winner_idx];
+    auto & loser = snapshots[loser_idx];
+
+    // Winner eligibility: must be confident and carry a parametric shape. Polygon-only trackers
+    // may only be absorbed, never absorb — in particular two polygon-only trackers never merge.
+    // An ineligible winner vetoes the pair (no direction flip).
+    if (!is_confident(winner)) {
+      continue;
+    }
+    const auto * winner_object = get_object(winner);
+    const auto * loser_object = get_object(loser);
+    if (winner_object == nullptr || loser_object == nullptr) {
+      continue;
+    }
+    if (winner_object->shape.type == autoware_perception_msgs::msg::Shape::POLYGON) {
+      continue;
+    }
+    if (!isRedundant(
+          *winner_object, *loser_object, winner.label, loser.label, winner.known_prob,
+          loser.known_prob, config_)) {
+      continue;
+    }
+
+    const double dx = winner.position.x - loser.position.x;
+    const double dy = winner.position.y - loser.position.y;
+    const double dist_sq = dx * dx + dy * dy;
+    const auto it = best_winner_of_loser.find(loser_idx);
+    if (
+      it == best_winner_of_loser.end() || dist_sq < it->second.dist_sq ||
+      (dist_sq == it->second.dist_sq && winner.uuid < snapshots[it->second.winner_idx].uuid)) {
+      best_winner_of_loser[loser_idx] = MergeCandidate{winner_idx, dist_sq};
+    }
   }
+  if (best_winner_of_loser.empty()) {
+    return;
+  }
+
+  // ---- Apply phase ----
+  // Greedy in loser-UUID order, keeping the applied merges a star forest: a tracker may not both
+  // absorb and be absorbed within one cycle, so absorbed content never moves through a tracker
+  // whose overlap with the final destination was not geometry-checked. Deferred merges re-enter
+  // next cycle; the first edge in UUID order always applies, so chains make progress every cycle.
+  std::vector<size_t> loser_indices;
+  loser_indices.reserve(best_winner_of_loser.size());
+  for (const auto & [loser_idx, candidate] : best_winner_of_loser) {
+    loser_indices.push_back(loser_idx);
+  }
+  std::sort(loser_indices.begin(), loser_indices.end(), [&](const size_t a, const size_t b) {
+    return snapshots[a].uuid < snapshots[b].uuid;
+  });
+
+  std::vector<bool> was_absorbed(snapshots.size(), false);
+  std::vector<bool> has_absorbed(snapshots.size(), false);
+  std::unordered_set<std::shared_ptr<Tracker>> trackers_to_remove;
+  trackers_to_remove.reserve(loser_indices.size());
+  for (const size_t loser_idx : loser_indices) {
+    const size_t winner_idx = best_winner_of_loser.at(loser_idx).winner_idx;
+    if (was_absorbed[winner_idx] || has_absorbed[loser_idx]) {
+      continue;
+    }
+    auto & winner = snapshots[winner_idx];
+    auto & loser = snapshots[loser_idx];
+
+    // Existence probabilities
+    winner.tracker->updateTotalExistenceProbability(loser.tracker->getTotalExistenceProbability());
+    winner.tracker->mergeExistenceProbabilities(loser.existence_probs);
+
+    // Classification: only update if source is known
+    if (!loser.is_unknown) {
+      winner.tracker->updateClassification(loser.tracker->getClassification());
+    }
+
+    // Shape: prefer lower shape type (bounding box < cylinder < convex hull).
+    if (winner.object.shape.type > loser.object.shape.type) {
+      winner.tracker->setObjectShape(loser.object.shape);
+    }
+    // If the absorbed tracker carries footprint data (BBOX or POLYGON), union it into the winner.
+    if (!loser.object.shape.footprint.points.empty()) {
+      winner.tracker->mergeFootprintFrom(
+        loser.object.shape.footprint, loser.object.pose, winner.object.pose);
+    }
+
+    was_absorbed[loser_idx] = true;
+    has_absorbed[winner_idx] = true;
+    trackers_to_remove.insert(loser.tracker);
+  }
+
   tracker_list.remove_if([&trackers_to_remove](const std::shared_ptr<Tracker> & t) {
     return trackers_to_remove.count(t) > 0;
   });

--- a/perception/autoware_multi_object_tracker/test/test_tracker_overlap_manager.cpp
+++ b/perception/autoware_multi_object_tracker/test/test_tracker_overlap_manager.cpp
@@ -1,0 +1,360 @@
+// Copyright 2026 TIER IV, inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/multi_object_tracker/association/scoring/redundancy_check.hpp"
+#include "autoware/multi_object_tracker/association/tracker_overlap_manager.hpp"
+#include "autoware/multi_object_tracker/object_model/object_model.hpp"
+#include "autoware/multi_object_tracker/object_model/shapes.hpp"
+#include "autoware/multi_object_tracker/tracker/trackers/polygon_tracker.hpp"
+#include "autoware/multi_object_tracker/tracker/trackers/vehicle_tracker.hpp"
+#include "autoware/multi_object_tracker/types.hpp"
+#include "autoware/multi_object_tracker/uncertainty/uncertainty_processor.hpp"
+#include "test_bench.hpp"
+
+#include <rclcpp/rclcpp.hpp>
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <chrono>
+#include <list>
+#include <memory>
+#include <set>
+#include <string>
+#include <tuple>
+#include <vector>
+
+namespace
+{
+
+namespace mot = autoware::multi_object_tracker;
+using std::chrono_literals::operator""ms;
+
+constexpr int kSpinStrong = 12;
+constexpr int kSpinMedium = 6;
+constexpr int kSpinWeak = 3;
+
+rclcpp::Time baseTime()
+{
+  return rclcpp::Time(1000000000LL, RCL_ROS_TIME);
+}
+
+mot::types::DynamicObject makeBaseObject(
+  const double x, const double y, const mot::classes::Label label, const rclcpp::Time & time)
+{
+  mot::types::DynamicObject obj;
+  obj.time = time;
+  obj.classification = {{label, 1.0F}};
+  obj.pose.position.x = x;
+  obj.pose.position.y = y;
+  obj.pose.position.z = 0.0;
+  obj.pose.orientation.w = 1.0;
+  obj.pose_covariance.fill(0.0);
+  obj.twist_covariance.fill(0.0);
+  obj.kinematics.has_position_covariance = false;
+  obj.kinematics.has_twist = false;
+  obj.kinematics.has_twist_covariance = false;
+  obj.kinematics.orientation_availability = mot::types::OrientationAvailability::AVAILABLE;
+  obj.existence_probability = 0.9;
+  obj.channel_index = 0;
+  return obj;
+}
+
+mot::types::DynamicObject withUncertainty(const mot::types::DynamicObject & obj)
+{
+  mot::types::DynamicObjectList list;
+  list.channel_index = obj.channel_index;
+  list.objects = {obj};
+  return mot::uncertainty::modelUncertainty(list).objects.front();
+}
+
+mot::types::DynamicObject makeBboxObject(
+  const double x, const double y, const double length, const double width,
+  const mot::classes::Label label, const rclcpp::Time & time)
+{
+  auto obj = makeBaseObject(x, y, label, time);
+  obj.shape.type = autoware_perception_msgs::msg::Shape::BOUNDING_BOX;
+  obj.shape.dimensions.x = length;
+  obj.shape.dimensions.y = width;
+  obj.shape.dimensions.z = 1.8;
+  obj.area = length * width;
+  return withUncertainty(obj);
+}
+
+mot::types::DynamicObject makePolygonObject(
+  const double x, const double y, const double half_size, const rclcpp::Time & time)
+{
+  auto obj = makeBaseObject(x, y, mot::classes::Label::UNKNOWN, time);
+  obj.shape.type = autoware_perception_msgs::msg::Shape::POLYGON;
+  obj.shape.dimensions.z = 1.5;
+  for (const auto & [px, py] : std::vector<std::pair<double, double>>{
+         {half_size, half_size},
+         {-half_size, half_size},
+         {-half_size, -half_size},
+         {half_size, -half_size}}) {
+    geometry_msgs::msg::Point32 point;
+    point.x = static_cast<float>(px);
+    point.y = static_cast<float>(py);
+    point.z = 0.0;
+    obj.shape.footprint.points.push_back(point);
+  }
+  obj.area = (2.0 * half_size) * (2.0 * half_size);
+  return withUncertainty(obj);
+}
+
+// Feed the tracker n_updates static re-detections so measurement count grows and the position
+// covariance converges (confidence builds up).
+void spinUp(
+  const std::shared_ptr<mot::Tracker> & tracker, const mot::types::DynamicObject & obj,
+  const rclcpp::Time & start_time, const int n_updates, const mot::types::InputChannel & channel)
+{
+  rclcpp::Time time = start_time;
+  for (int k = 0; k < n_updates; ++k) {
+    time += rclcpp::Duration(100ms);
+    tracker->predict(time);
+    auto measurement = obj;
+    measurement.time = time;
+    tracker->updateWithMeasurement(measurement, time, channel);
+  }
+}
+
+std::shared_ptr<mot::Tracker> makeVehicleTracker(
+  const mot::types::DynamicObject & obj, const rclcpp::Time & time, const int n_updates,
+  const mot::types::InputChannel & channel)
+{
+  auto tracker =
+    std::make_shared<mot::VehicleTracker>(mot::object_model::normal_vehicle, time, obj);
+  tracker->initializeExistenceProbabilities(channel.index, obj.existence_probability);
+  spinUp(tracker, obj, time, n_updates, channel);
+  return tracker;
+}
+
+std::shared_ptr<mot::Tracker> makePolygonTracker(
+  const mot::types::DynamicObject & obj, const rclcpp::Time & time, const int n_updates,
+  const mot::types::InputChannel & channel)
+{
+  auto tracker = std::make_shared<mot::PolygonTracker>(time, obj, false, false);
+  tracker->initializeExistenceProbabilities(channel.index, obj.existence_probability);
+  spinUp(tracker, obj, time, n_updates, channel);
+  return tracker;
+}
+
+class TrackerOverlapManagerTest : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    channel_ = createInputChannelsConfig().front();
+    config_ = createTrackerOverlapManagerConfig();
+    manager_ = std::make_unique<mot::TrackerOverlapManager>(config_);
+  }
+
+  void runMerge(std::list<std::shared_ptr<mot::Tracker>> & trackers, const rclcpp::Time & time)
+  {
+    manager_->merge(trackers, time, cache_, std::nullopt);
+  }
+
+  static rclcpp::Time mergeTime()
+  {
+    // Past the spin-up updates (kSpinStrong * 100ms)
+    return baseTime() + rclcpp::Duration(100ms) * (kSpinStrong + 1);
+  }
+
+  mot::types::InputChannel channel_;
+  mot::TrackerOverlapManagerConfig config_;
+  mot::AdaptiveThresholdCache cache_;
+  std::unique_ptr<mot::TrackerOverlapManager> manager_;
+};
+
+}  // namespace
+
+TEST_F(TrackerOverlapManagerTest, PolygonOnlyPairsDoNotMerge)
+{
+  const auto time = baseTime();
+  const auto obj_a = makePolygonObject(0.0, 0.0, 1.0, time);
+  const auto obj_b = makePolygonObject(0.5, 0.0, 1.0, time);
+
+  // Asymmetric spin counts so the covariance tier yields a clear winner (a covariance tie would
+  // make the pair unmergeable regardless of the polygon-only rule).
+  std::list<std::shared_ptr<mot::Tracker>> trackers{
+    makePolygonTracker(obj_a, time, kSpinStrong, channel_),
+    makePolygonTracker(obj_b, time, kSpinMedium, channel_)};
+
+  // Sanity: the pair must be mergeable in every respect except the polygon-only rule, so the
+  // surviving pair proves the prohibition (not a missing precondition).
+  std::vector<mot::types::DynamicObject> exported(2);
+  size_t idx = 0;
+  for (const auto & tracker : trackers) {
+    ASSERT_TRUE(tracker->isConfident(cache_, std::nullopt, mergeTime()));
+    ASSERT_TRUE(tracker->getTrackedObject(mergeTime(), exported[idx]));
+    ASSERT_EQ(exported[idx].shape.type, autoware_perception_msgs::msg::Shape::POLYGON);
+    ++idx;
+  }
+  ASSERT_TRUE(
+    mot::isRedundant(
+      exported[0], exported[1], mot::classes::Label::UNKNOWN, mot::classes::Label::UNKNOWN,
+      trackers.front()->getKnownObjectProbability(), trackers.back()->getKnownObjectProbability(),
+      config_));
+
+  runMerge(trackers, mergeTime());
+
+  // Heavily overlapping, but both carry only a polygon shape: merging is prohibited.
+  EXPECT_EQ(trackers.size(), 2U);
+}
+
+TEST_F(TrackerOverlapManagerTest, BboxTrackerAbsorbsOverlappingPolygon)
+{
+  const auto time = baseTime();
+  const auto car_obj = makeBboxObject(0.0, 0.0, 4.5, 1.8, mot::classes::Label::CAR, time);
+  const auto fragment_obj = makePolygonObject(1.0, 0.0, 0.8, time);
+
+  std::list<std::shared_ptr<mot::Tracker>> trackers{
+    makePolygonTracker(fragment_obj, time, kSpinMedium, channel_),
+    makeVehicleTracker(car_obj, time, kSpinStrong, channel_)};
+
+  runMerge(trackers, mergeTime());
+
+  ASSERT_EQ(trackers.size(), 1U);
+  EXPECT_EQ(trackers.front()->getHighestProbLabel(), mot::classes::Label::CAR);
+}
+
+TEST_F(TrackerOverlapManagerTest, ClassifiedFragmentAbsorbedByContainment)
+{
+  const auto time = baseTime();
+  // A classified fragment fully inside a much larger same-class object, with IoU below
+  // min_known_object_removal_iou (0.1): plain IoU keeps both; only the containment criterion
+  // absorbs the fragment. Both use the same tracker type so direction is decided by
+  // confidence/covariance, not priority.
+  const auto car_obj = makeBboxObject(0.0, 0.0, 10.0, 2.4, mot::classes::Label::CAR, time);
+  const auto fragment_obj = makeBboxObject(3.0, 0.3, 1.5, 1.2, mot::classes::Label::CAR, time);
+
+  auto fragment_tracker = makeVehicleTracker(fragment_obj, time, kSpinMedium, channel_);
+  auto car_tracker = makeVehicleTracker(car_obj, time, kSpinStrong, channel_);
+
+  // Sanity: the exported shapes (after the vehicle shape model's size limits and convergence)
+  // must still be below the plain-IoU merge threshold, or this test would not distinguish the
+  // containment criterion.
+  mot::types::DynamicObject car_exported;
+  mot::types::DynamicObject fragment_exported;
+  ASSERT_TRUE(car_tracker->getTrackedObject(mergeTime(), car_exported));
+  ASSERT_TRUE(fragment_tracker->getTrackedObject(mergeTime(), fragment_exported));
+  ASSERT_LT(mot::shapes::get2dIoU(car_exported, fragment_exported, 1e-2), 0.1);
+
+  std::list<std::shared_ptr<mot::Tracker>> trackers{fragment_tracker, car_tracker};
+  runMerge(trackers, mergeTime());
+
+  ASSERT_EQ(trackers.size(), 1U);
+  EXPECT_EQ(trackers.front(), car_tracker);
+}
+
+TEST_F(TrackerOverlapManagerTest, StarMergeAbsorbsMultipleFragmentsInOneCycle)
+{
+  const auto time = baseTime();
+  const auto car_obj = makeBboxObject(0.0, 0.0, 4.5, 1.8, mot::classes::Label::CAR, time);
+  const auto fragment_front = makePolygonObject(1.2, 0.0, 0.7, time);
+  const auto fragment_rear = makePolygonObject(-1.2, 0.0, 0.7, time);
+
+  std::list<std::shared_ptr<mot::Tracker>> trackers{
+    makePolygonTracker(fragment_front, time, kSpinMedium, channel_),
+    makeVehicleTracker(car_obj, time, kSpinStrong, channel_),
+    makePolygonTracker(fragment_rear, time, kSpinMedium, channel_)};
+
+  runMerge(trackers, mergeTime());
+
+  // Multiple losers may merge into the same winner within one cycle (star shape).
+  ASSERT_EQ(trackers.size(), 1U);
+  EXPECT_EQ(trackers.front()->getHighestProbLabel(), mot::classes::Label::CAR);
+}
+
+TEST_F(TrackerOverlapManagerTest, ChainDoesNotBridgeWithinOneCycle)
+{
+  const auto time = baseTime();
+  // A <- B <- C chain: B overlaps A (IoU ~0.33), C overlaps B (IoU ~0.21), C barely
+  // touches A (IoU ~0.03, not redundant). Bridging C into A through B would merge
+  // all three in one cycle; the star-forest rule must leave two trackers.
+  const auto obj_a = makeBboxObject(0.0, 0.0, 4.0, 2.0, mot::classes::Label::CAR, time);
+  const auto obj_b = makeBboxObject(1.5, 0.0, 2.0, 2.0, mot::classes::Label::CAR, time);
+  const auto obj_c = makeBboxObject(2.8, 0.0, 2.0, 2.0, mot::classes::Label::CAR, time);
+
+  const auto tracker_a = makeVehicleTracker(obj_a, time, kSpinStrong, channel_);
+
+  std::list<std::shared_ptr<mot::Tracker>> trackers{
+    makeVehicleTracker(obj_c, time, kSpinWeak, channel_), tracker_a,
+    makeVehicleTracker(obj_b, time, kSpinMedium, channel_)};
+
+  runMerge(trackers, mergeTime());
+
+  EXPECT_EQ(trackers.size(), 2U);
+  EXPECT_TRUE(
+    std::any_of(trackers.begin(), trackers.end(), [&](const auto & t) { return t == tracker_a; }));
+}
+
+TEST_F(TrackerOverlapManagerTest, OutcomeIsIndependentOfListOrder)
+{
+  // Three separated cars, each over-segmented into a polygon fragment, plus one isolated
+  // polygon. The merge outcome (survivor labels and positions) must not depend on the order
+  // trackers appear in the list.
+  const auto buildScenario = [&](const std::vector<size_t> & order) {
+    const auto time = baseTime();
+    std::vector<std::shared_ptr<mot::Tracker>> built;
+    for (double car_x : {0.0, 20.0, 40.0}) {
+      built.push_back(makeVehicleTracker(
+        makeBboxObject(car_x, 0.0, 4.5, 1.8, mot::classes::Label::CAR, time), time, kSpinStrong,
+        channel_));
+      built.push_back(makePolygonTracker(
+        makePolygonObject(car_x + 1.0, 0.0, 0.8, time), time, kSpinMedium, channel_));
+    }
+    built.push_back(
+      makePolygonTracker(makePolygonObject(100.0, 0.0, 1.0, time), time, kSpinMedium, channel_));
+
+    std::list<std::shared_ptr<mot::Tracker>> trackers;
+    for (const size_t idx : order) {
+      trackers.push_back(built[idx]);
+    }
+    return trackers;
+  };
+
+  const auto surviving_positions = [&](std::list<std::shared_ptr<mot::Tracker>> & trackers) {
+    std::multiset<std::tuple<int, int, int>> result;
+    for (const auto & tracker : trackers) {
+      mot::types::DynamicObject obj;
+      EXPECT_TRUE(tracker->getTrackedObject(mergeTime(), obj));
+      result.emplace(
+        static_cast<int>(tracker->getHighestProbLabel()),
+        static_cast<int>(std::round(obj.pose.position.x)),
+        static_cast<int>(std::round(obj.pose.position.y)));
+    }
+    return result;
+  };
+
+  const std::vector<std::vector<size_t>> orders = {
+    {0, 1, 2, 3, 4, 5, 6},
+    {6, 5, 4, 3, 2, 1, 0},
+    {3, 0, 6, 2, 5, 1, 4},
+    {1, 3, 5, 0, 2, 4, 6},
+  };
+
+  std::optional<std::multiset<std::tuple<int, int, int>>> reference;
+  for (const auto & order : orders) {
+    auto trackers = buildScenario(order);
+    runMerge(trackers, mergeTime());
+    EXPECT_EQ(trackers.size(), 4U);  // 3 cars + isolated polygon
+    const auto survivors = surviving_positions(trackers);
+    if (!reference) {
+      reference = survivors;
+    } else {
+      EXPECT_EQ(survivors, *reference);
+    }
+  }
+}


### PR DESCRIPTION
## Description

Fixes correctness bugs in `TrackerOverlapManager::merge()` that caused missed merges, order-dependent outcomes, and incorrect fragment absorption. Also enables classification trust for the lidar clustering channel, which is now safe with the fixed merge logic.

### Problems fixed

**P1 — Sort criteria not aligned with win-lose policy**
The global sort used `measurement_count` / `elapsed_time` as tiebreakers, but `canMergeTarget` never read those fields. Pairs were checked in one direction only (`j > i`), so when sort order disagreed with the win-lose policy, merges were silently skipped.

**P2 — Mid-loop mutation causing order-dependent outcomes**
Winner existence-probabilities were updated immediately while later `isRedundant` calls still used stale geometry snapshots. Outcome depended on which pairs were processed first.

**P3 — Both-known `isRedundant` path did not handle fragments**
Used plain 2D IoU > threshold only. A classified fragment fully contained inside a larger bbox has low IoU but high recall, so it was not absorbed. This became the common case with lidar semantic segmentation clusters carrying trusted classification (over-segmented fragments spawn same-priority vehicle trackers, creating tied-priority pairs everywhere).

**P4 — No polygon-shape gate**
Polygon-only trackers could merge with each other, producing incorrect footprint unions.

### Algorithm rewrite (`merge()`)

1. **Snapshot pass** — per-tracker scalars captured once; full `DynamicObject` fetched lazily only for trackers that appear in a gated pair.
2. **Symmetric pair discovery** — R-tree query from each tracker using its own label radius; pairs deduped before evaluation.
3. **`decidePair(a, b)`** — pure, antisymmetric, deterministic function of snapshots:
   - *Shape gate*: both polygon-only → `NoMerge`. Winner must have `BBOX` or `CYLINDER` shape AND be confident.
   - *Lexicographic tiers*: priority → `isConfident` → known-probability band → symmetric per-channel existence dominance → covariance determinant → measurement count → UUID.
4. **Deferred apply** — all mutations batched; each loser merges into its highest-GIoU winner. Eliminates mid-loop geometry/probability inconsistency.

### `isRedundant` both-known path fix

Replaces plain IoU check with `get2dPrecisionRecallGIoU`. Merges when `IoU > threshold` **or** `recall > 0.5` (fragment fully contained inside the larger tracker). Restores classified-fragment absorption that plain IoU missed.

### Config change

`input_channels.param.yaml`: `can_trust_classification: true` for the `lidar_clustering` channel. Previously set to `false` as a workaround because the old merge algorithm could not safely handle same-priority classified fragments. Now enabled.

### Tests

New `test/test_tracker_overlap_manager.cpp` (6 tests):
- `PolygonOnlyPairsDoNotMerge` — two polygon trackers must not be merged.
- `BboxTrackerAbsorbsOverlappingPolygon` — bbox tracker absorbs overlapping polygon tracker.
- `ClassifiedFragmentAbsorbedByContainment` — contained classified fragment absorbed via recall criterion.
- `StarMergeAbsorbsMultipleFragmentsInOneCycle` — one winner absorbs several fragments in a single pass.
- `ChainDoesNotBridgeWithinOneCycle` — transitive chains do not collapse in one cycle (by design).
- `OutcomeIsIndependentOfListOrder` — shuffled tracker list produces identical merge outcome.

Old code fails `PolygonOnlyPairsDoNotMerge` and `ClassifiedFragmentAbsorbedByContainment`; new code passes all 10 package tests.

---

## Related links

**Parent Issue:**

- Link

## How was this PR tested?

- All 10 `autoware_multi_object_tracker` unit tests pass (SimulatedData, RealDataRosbag, UUID, TrackerOverlapManager x6).
- Differential check: old code fails 2 of the 6 new tests; new code passes all.
- Prune-pass latency benchmark (~350 trackers, 3 runs): new avg 0.85 ms vs old 0.87 ms — no regression.

## Notes for reviewers

- **CYLINDER treated as BBOX-equivalent winner** in the shape gate — pedestrian trackers can absorb polygon fragments. Can be tightened to BBOX-only if disputed.
- **Chain convergence**: transitive overlaps (A∩B, B∩C) are not resolved in a single cycle by design — chains converge over 2-3 frames given the merge throttle. One-to-many association is out of scope.
- The R-tree `satisfies`-only query is a linear scan (~0.4 ms at 350 trackers); the `bgi::intersects(box)` spatial pre-filter must not be removed.
- `canMergeTarget()` is removed from the public API; all pair logic is now internal to `decidePair()`.

## Interface changes

None (no topic or service additions or removals).

### ROS Parameter Changes

#### Modifications

| Version | Parameter Name | Type | Default Value | Description |
|:--------|:---------------|:-----|:--------------|:------------|
| Old | `lidar_clustering.can_trust_classification` | `bool` | `false` | Whether to trust classification from lidar clustering channel |
| New | `lidar_clustering.can_trust_classification` | `bool` | `true` | Whether to trust classification from lidar clustering channel |

## Effects on system behavior

1. **Polygon-only tracker pairs no longer merge** — previously an unclassified cluster could absorb another, producing a garbage footprint union.
2. **Classified fragments from lidar semantic segmentation are now correctly absorbed** by the overlapping bbox tracker (containment criterion via recall check).
3. **Merge outcome is independent of tracker list order** — previously tied-priority pairs could merge or not depending on spawn history.
4. **Lidar clustering classification is now trusted** — semantic segmentation labels from the clustering channel are used for tracker type assignment.