### PR TITLE
feat(radar_objects_adapter): apply agnocast for publisher of `radar_objects_adapter`

### DIFF
--- a/sensing/autoware_radar_objects_adapter/launch/radar_objects_adapter.launch.xml
+++ b/sensing/autoware_radar_objects_adapter/launch/radar_objects_adapter.launch.xml
@@ -1,4 +1,5 @@
 <launch>
+  <include file="$(find-pkg-share autoware_agnocast_wrapper)/launch/agnocast_env.launch.xml"/>
   <arg name="input_radar_objects" default="/radar_objects"/>
   <arg name="input_radar_info" default="/radar_info"/>
   <arg name="output_detections" default="/detections"/>
@@ -7,6 +8,7 @@
   <arg name="param_path" default="$(find-pkg-share autoware_radar_objects_adapter)/config/radar_objects_adapter.param.yaml"/>
 
   <node pkg="autoware_radar_objects_adapter" exec="radar_objects_adapter_node" name="radar_objects_adapter" output="screen">
+    <env name="LD_PRELOAD" value="$(var ld_preload_value)"/>
     <remap from="~/input/objects" to="$(var input_radar_objects)"/>
     <remap from="~/input/radar_info" to="$(var input_radar_info)"/>
     <remap from="~/output/detections" to="$(var output_detections)"/>

--- a/sensing/autoware_radar_objects_adapter/src/radar_objects_adapter.cpp
+++ b/sensing/autoware_radar_objects_adapter/src/radar_objects_adapter.cpp
@@ -56,11 +56,13 @@ RadarObjectsAdapter::RadarObjectsAdapter(const rclcpp::NodeOptions & options)
     "~/input/radar_info", rclcpp::SensorDataQoS(),
     std::bind(&RadarObjectsAdapter::radar_info_callback, this, std::placeholders::_1));
 
-  detections_pub_ = create_publisher<autoware_perception_msgs::msg::DetectedObjects>(
-    "~/output/detections", rclcpp::QoS(10).reliable().transient_local());
+  detections_pub_ = AUTOWARE_CREATE_PUBLISHER2(
+    autoware_perception_msgs::msg::DetectedObjects, "~/output/detections",
+    rclcpp::QoS(10).reliable().transient_local());
 
-  tracks_pub_ = create_publisher<autoware_perception_msgs::msg::TrackedObjects>(
-    "~/output/tracks", rclcpp::QoS(10).reliable().transient_local());
+  tracks_pub_ = AUTOWARE_CREATE_PUBLISHER2(
+    autoware_perception_msgs::msg::TrackedObjects, "~/output/tracks",
+    rclcpp::QoS(10).reliable().transient_local());
 
   default_position_z_ = this->declare_parameter<float>("default_position_z");
   default_velocity_z_ = this->declare_parameter<float>("default_velocity_z");
@@ -290,7 +292,7 @@ void RadarObjectsAdapter::populate_classifications(
 void RadarObjectsAdapter::parse_as_detections(
   const autoware_sensing_msgs::msg::RadarObjects & input_msg)
 {
-  auto output_msg_ptr = std::make_unique<autoware_perception_msgs::msg::DetectedObjects>();
+  auto output_msg_ptr = ALLOCATE_OUTPUT_MESSAGE_UNIQUE(detections_pub_);
   auto & output_msg = *output_msg_ptr;
 
   output_msg.header = input_msg.header;
@@ -322,7 +324,7 @@ void RadarObjectsAdapter::parse_as_detections(
 void RadarObjectsAdapter::parse_as_tracks(
   const autoware_sensing_msgs::msg::RadarObjects & input_msg)
 {
-  auto output_msg_ptr = std::make_unique<autoware_perception_msgs::msg::TrackedObjects>();
+  auto output_msg_ptr = ALLOCATE_OUTPUT_MESSAGE_UNIQUE(tracks_pub_);
   auto & output_msg = *output_msg_ptr;
 
   output_msg.header = input_msg.header;

--- a/sensing/autoware_radar_objects_adapter/src/radar_objects_adapter.hpp
+++ b/sensing/autoware_radar_objects_adapter/src/radar_objects_adapter.hpp
@@ -15,6 +15,7 @@
 #ifndef RADAR_OBJECTS_ADAPTER_HPP_
 #define RADAR_OBJECTS_ADAPTER_HPP_
 
+#include <autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include <autoware_perception_msgs/msg/detected_objects.hpp>
@@ -66,8 +67,8 @@ private:
 
   rclcpp::Subscription<autoware_sensing_msgs::msg::RadarObjects>::SharedPtr radar_objects_sub_;
   rclcpp::Subscription<autoware_sensing_msgs::msg::RadarInfo>::SharedPtr radar_info_sub_;
-  rclcpp::Publisher<autoware_perception_msgs::msg::DetectedObjects>::SharedPtr detections_pub_;
-  rclcpp::Publisher<autoware_perception_msgs::msg::TrackedObjects>::SharedPtr tracks_pub_;
+  AUTOWARE_PUBLISHER_PTR(autoware_perception_msgs::msg::DetectedObjects) detections_pub_;
+  AUTOWARE_PUBLISHER_PTR(autoware_perception_msgs::msg::TrackedObjects) tracks_pub_;
 
   std::unordered_map<std::string, autoware_sensing_msgs::msg::RadarFieldInfo> field_info_map_;
 


### PR DESCRIPTION
  ## Description
  Apply `agnocast_wrapper` to the publishers of `autoware_radar_objects_adapter` to enable zero-copy message publishing via Agnocast.
  Also, please refer to https://github.com/autowarefoundation/autoware_core/blob/main/common/autoware_agnocast_wrapper/docs/review_guide.md for the review guide of `autoware_agnocast_wrapper` application PR. FYI: This node takes [Method1](https://github.com/autowarefoundation/autoware_core/blob/main/common/autoware_agnocast_wrapper/docs/review_guide.md#method-1-macro--free-function-api) of two integration methods,
  i.e. the node stays an `rclcpp::Node` and only its publishers are converted.
  
### Changes
- Publishers: convert both the `DetectedObjects` publisher (`~/output/detections`) and the `TrackedObjects` publisher (`~/output/tracks`) to the agnocast macros — `AUTOWARE_PUBLISHER_PTR` / `AUTOWARE_CREATE_PUBLISHER2`, and publish via `ALLOCATE_OUTPUT_MESSAGE_UNIQUE` + `std::move`.
- Subscriptions are left unchanged (plain `rclcpp`); only the publishers are migrated.
- No changes to `CMakeLists.txt` / `package.xml` were needed — the node is already registered via `autoware_agnocast_wrapper_register_node` (`CallbackIsolatedAgnocastExecutor`) and already depends on `autoware_agnocast_wrapper`.

## Related links
https://github.com/autowarefoundation/autoware/issues/7007
https://github.com/orgs/autowarefoundation/discussions/6804

  **Parent Issue:**   

  - Link

  <!-- ⬇️ 🟢
  **Private Links:**

  - [CompanyName internal link]()
  ⬆️ 🟢 -->

  ## How was this PR tested?
  - colcon build succeeds with both ENABLE_AGNOCAST=1 and ENABLE_AGNOCAST=0.
  - Ran an Autoware-based product with this change applied and confirmed it operates without any regression.

  ## Notes for reviewers

  None.

  ## Interface changes

  None.

  <!-- ⬇️ 🔴

  ### Topic changes

  #### Additions and removals

  | Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
  |:--------------|:----------------|:--------------|:--------------------|:------------------|
  | Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |
  
  #### Modifications

  | Version | Topic Type      | Topic Name        | Message Type        | Description       |
  |:--------|:----------------|:------------------|:--------------------|:------------------|
  | Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
  | New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

  ### ROS Parameter Changes

  #### Additions and removals

  | Change type   | Parameter Name | Type     | Default Value | Description       |
  |:--------------|:---------------|:---------|:--------------|:------------------|
  | Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

  #### Modifications

  | Version | Parameter Name   | Type     | Default Value | Description       |
  |:--------|:-----------------|:---------|:--------------|:------------------|
  | Old     | `old_param_name` | `double` | `1.0`         | Param description |
  | New     | `new_param_name` | `double` | `1.0`         | Param description |

  🔴⬆️  -->
  
  ## Effects on system behavior
  None when ENABLE_AGNOCAST is not set or set to 0 on runtime. When ENABLE_AGNOCAST=1, CPU Time used in this node for message serialization/deserialization will be reduced.
