### PR TITLE
fix(autoware_object_merger): disable test when agnocast enabled

### DIFF
--- a/perception/autoware_object_merger/CMakeLists.txt
+++ b/perception/autoware_object_merger/CMakeLists.txt
@@ -48,9 +48,11 @@ if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
 
-  ament_auto_add_gtest(object_fusion_merger_node_tests
-    test/test_object_fusion_merger_node.cpp
-  )
+  if(NOT "$ENV{ENABLE_AGNOCAST}" STREQUAL "1")
+    ament_auto_add_gtest(object_fusion_merger_node_tests
+      test/test_object_fusion_merger_node.cpp
+    )
+  endif()
 endif()
 
 ament_auto_package(INSTALL_TO_SHARE


### PR DESCRIPTION
## Description
  The `object_fusion_merger_node_tests` integration test publishes via plain `rclcpp` and cannot reach the node's subscriptions in the Agnocast build (`ENABLE_AGNOCAST=1`), where `agnocast_wrapper::Node` no longer derives from `rclcpp::Node`. This currently breaks compilation of the Agnocast build.

  This PR gates the test so it is only built in the standard build, matching the existing convention in the other migrated packages (e.g. `autoware_detected_object_validation`, `autoware_traffic_light_arbiter`, `autoware_shape_estimation`).

  ```cmake
  if(NOT "$ENV{ENABLE_AGNOCAST}" STREQUAL "1")
    ament_auto_add_gtest(object_fusion_merger_node_tests ...)
  endif()
  ```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
Tested by building successfully with both `ENABLE_AGNOCAST` = 1 and 0.

## Notes for reviewers

  - The node logic is fully verified by this test in the standard `rclcpp::Node` build; nothing about the node behavior is left untested.
  - There is no plan to adapt the test code for `ENABLE_AGNOCAST=1`. Upcoming Autoware refactoring will move these tests toward exercising the node logic without launching the node, removing the need for this build-time gate.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
