### PR TITLE
fix(autoware_tensorrt_yolox): correct std::clamp argument order

### DIFF
--- a/perception/autoware_tensorrt_yolox/src/tensorrt_yolox.cpp
+++ b/perception/autoware_tensorrt_yolox/src/tensorrt_yolox.cpp
@@ -778,8 +778,8 @@ bool TrtYoloX::feedforward(const std::vector<cv::Mat> & images, ObjectArrays & o
       const auto y1 = out_boxes[i * max_detections_ * 4 + j * 4 + 1] / scales_[i];
       const auto x2 = out_boxes[i * max_detections_ * 4 + j * 4 + 2] / scales_[i];
       const auto y2 = out_boxes[i * max_detections_ * 4 + j * 4 + 3] / scales_[i];
-      object.x_offset = std::clamp(0, static_cast<int32_t>(x1), images[i].cols);
-      object.y_offset = std::clamp(0, static_cast<int32_t>(y1), images[i].rows);
+      object.x_offset = std::clamp(static_cast<int32_t>(x1), 0, images[i].cols);
+      object.y_offset = std::clamp(static_cast<int32_t>(y1), 0, images[i].rows);
       object.width = static_cast<int32_t>(std::max(0.0F, x2 - x1));
       object.height = static_cast<int32_t>(std::max(0.0F, y2 - y1));
       object.score = out_scores[i * max_detections_ + j];
@@ -906,8 +906,8 @@ bool TrtYoloX::multiScaleFeedforward(const cv::Mat & image, int batch_size, Obje
       const auto y1 = out_boxes[i * max_detections_ * 4 + j * 4 + 1] / scales_[i];
       const auto x2 = out_boxes[i * max_detections_ * 4 + j * 4 + 2] / scales_[i];
       const auto y2 = out_boxes[i * max_detections_ * 4 + j * 4 + 3] / scales_[i];
-      object.x_offset = std::clamp(0, static_cast<int32_t>(x1), image.cols);
-      object.y_offset = std::clamp(0, static_cast<int32_t>(y1), image.rows);
+      object.x_offset = std::clamp(static_cast<int32_t>(x1), 0, image.cols);
+      object.y_offset = std::clamp(static_cast<int32_t>(y1), 0, image.rows);
       object.width = static_cast<int32_t>(std::max(0.0F, x2 - x1));
       object.height = static_cast<int32_t>(std::max(0.0F, y2 - y1));
       object.score = out_scores[i * max_detections_ + j];


### PR DESCRIPTION
## Description

Fixes an argument-order bug in the `std::clamp` calls that clamp detected bounding-box top-left offsets to the image bounds in `autoware_tensorrt_yolox`.

`std::clamp` has the signature `std::clamp(value, low, high)`, but the code passed the arguments as `std::clamp(0, x1, cols)`.

This bug has existed since the package was first added (commit `03de605b09`, "feat: add tensorrt_yolox package (#2370)", 2022-11-30).

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

- `colcon build --packages-select autoware_tensorrt_yolox` — succeeds (only a pre-existing ament_auto header-install-dir deprecation notice on stderr).
- `colcon test --packages-select autoware_tensorrt_yolox --event-handlers console_cohesion+` — 6/6 tests pass (2 gtest + copyright/cppcheck/lint_cmake/xmllint linters), 0 failed.

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

No change for normal in-image detections. For detections whose top-left corner falls outside the image (right/bottom edge), the published ROI top-left offset is now correctly clamped to the image dimensions instead of being passed through un-clamped, and the previous undefined-behavior path is eliminated.
