### PR TITLE
fix(traffic_light_multi_camera_fusion): use `CallbackIsolatedAgnocastExecutor`

### DIFF
--- a/perception/autoware_traffic_light_multi_camera_fusion/CMakeLists.txt
+++ b/perception/autoware_traffic_light_multi_camera_fusion/CMakeLists.txt
@@ -18,7 +18,7 @@ ament_auto_add_library(${PROJECT_NAME} SHARED
 autoware_agnocast_wrapper_register_node(${PROJECT_NAME}
   PLUGIN "autoware::traffic_light::MultiCameraFusionNode"
   EXECUTABLE traffic_light_multi_camera_fusion_node
-  AGNOCAST_EXECUTOR AgnocastOnlyCallbackIsolatedExecutor
+  AGNOCAST_EXECUTOR CallbackIsolatedAgnocastExecutor
   ROS2_EXECUTOR SingleThreadedExecutor
 )
 

--- a/perception/autoware_traffic_light_multi_camera_fusion/launch/traffic_light_multi_camera_fusion.launch.xml
+++ b/perception/autoware_traffic_light_multi_camera_fusion/launch/traffic_light_multi_camera_fusion.launch.xml
@@ -1,11 +1,14 @@
 <?xml version="1.0"?>
 <launch>
+  <include file="$(find-pkg-share autoware_agnocast_wrapper)/launch/agnocast_env.launch.xml"/>
+
   <arg name="input/vector_map" default="/map/vector_map"/>
   <arg name="param_path" default="$(find-pkg-share autoware_traffic_light_multi_camera_fusion)/config/traffic_light_multi_camera_fusion.param.yaml"/>
   <arg name="output/traffic_signals" default="/perception/traffic_light_recognition/traffic_signals"/>
   <arg name="camera_namespaces" default="[camera6, camera7]"/>
 
   <node pkg="autoware_traffic_light_multi_camera_fusion" exec="traffic_light_multi_camera_fusion_node" name="traffic_light_multi_camera_fusion" output="screen">
+    <env name="LD_PRELOAD" value="$(var ld_preload_value)"/>
     <remap from="~/input/vector_map" to="$(var input/vector_map)"/>
     <remap from="~/output/traffic_signals" to="$(var output/traffic_signals)"/>
     <param from="$(var param_path)"/>


### PR DESCRIPTION
## Description
  
Fix the executor configuration for the `traffic_light_multi_camera_fusion` node and add the missing Agnocast launch setup.

`MultiCameraFusionNode` inherits from rclcpp::Node, but its CMake registration was using `AgnocastOnlyCallbackIsolatedExecutor`, which requires the node to inherit from `autoware::agnocast_wrapper::Node`. This change switches it to the correct executor for an `rclcpp::Node`-based node.

  The launch file was also missing the Agnocast environment setup that other Agnocast-enabled nodes already include.

  Changes

  - `CMakeLists.txt`: Change `AGNOCAST_EXECUTOR` from `AgnocastOnlyCallbackIsolatedExecutor` to `CallbackIsolatedAgnocastExecutor`, matching the rclcpp::Node base class.
  - `launch xml`: Include `agnocast_env.launch.xml` and set `LD_PRELOAD` (ld_preload_value) on the node so the Agnocast heaphook is preloaded when Agnocast is enabled, consistent with other Agnocast-enabled nodes.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
