### PR TITLE
refactor(traffic_light_multi_camera_fusion): restore fuse() return-based output

### DIFF
--- a/perception/autoware_traffic_light_multi_camera_fusion/src/multi_camera_fusion.cpp
+++ b/perception/autoware_traffic_light_multi_camera_fusion/src/multi_camera_fusion.cpp
@@ -177,8 +177,7 @@ MultiCameraFusion::MultiCameraFusion(const MultiCameraFusionConfig & config)
 }
 
 MultiCameraFusionResult MultiCameraFusion::fuse(
-  const CamInfoType & cam_info, const RoiArrayType & rois, const SignalArrayType & signals,
-  NewSignalArrayType & output_groups)
+  const CamInfoType & cam_info, const RoiArrayType & rois, const SignalArrayType & signals)
 {
   /*
   Insert the received record array to the table.
@@ -194,8 +193,10 @@ MultiCameraFusionResult MultiCameraFusion::fuse(
   GroupFusionResult group_result = group_fusion(fused_record_map);
   result.conflicted_regulatory_element_status = group_result.conflicts;
 
-  convert_output_msg(group_result.grouped_record_map, output_groups);
-  output_groups.stamp = cam_info.header.stamp;
+  NewSignalArrayType msg_out;
+  convert_output_msg(group_result.grouped_record_map, msg_out);
+  msg_out.stamp = cam_info.header.stamp;
+  result.traffic_light_groups = msg_out;
 
   return result;
 }

--- a/perception/autoware_traffic_light_multi_camera_fusion/src/multi_camera_fusion.hpp
+++ b/perception/autoware_traffic_light_multi_camera_fusion/src/multi_camera_fusion.hpp
@@ -77,6 +77,7 @@ struct MultiCameraFusionConfig
 
 struct MultiCameraFusionResult
 {
+  autoware_perception_msgs::msg::TrafficLightGroupArray traffic_light_groups;
   std::vector<ConflictInfo> conflicted_regulatory_element_status;
   // Traffic light IDs that were observed by a camera but are not registered in the loaded map.
   // The Node logs a warning for each entry.
@@ -100,8 +101,7 @@ public:
   MultiCameraFusion() = default;
 
   MultiCameraFusionResult fuse(
-    const CamInfoType & cam_info, const RoiArrayType & rois, const SignalArrayType & signals,
-    NewSignalArrayType & output_groups);
+    const CamInfoType & cam_info, const RoiArrayType & rois, const SignalArrayType & signals);
 
 private:
   GroupFusionResult group_fusion(const std::map<IdType, utils::FusionRecord> & fused_record_map);

--- a/perception/autoware_traffic_light_multi_camera_fusion/src/traffic_light_multi_camera_fusion_node.cpp
+++ b/perception/autoware_traffic_light_multi_camera_fusion/src/traffic_light_multi_camera_fusion_node.cpp
@@ -19,7 +19,6 @@
 #include <functional>
 #include <memory>
 #include <string>
-#include <utility>
 #include <vector>
 
 namespace autoware::traffic_light
@@ -89,14 +88,12 @@ void MultiCameraFusionNode::traffic_signal_roi_callback(
 {
   rclcpp::Time stamp(roi_msg->header.stamp);
 
-  auto msg_out = ALLOCATE_OUTPUT_MESSAGE_UNIQUE(signal_pub_);
-  const MultiCameraFusionResult result =
-    fusion_.fuse(*cam_info_msg, *roi_msg, *signal_msg, *msg_out);
+  const MultiCameraFusionResult result = fusion_.fuse(*cam_info_msg, *roi_msg, *signal_msg);
   for (const auto & unmapped_id : result.unmapped_traffic_light_ids) {
     RCLCPP_WARN_STREAM(
       get_logger(), "Found Traffic Light Id = " << unmapped_id << " which is not defined in Map");
   }
-  signal_pub_->publish(std::move(msg_out));
+  signal_pub_->publish(result.traffic_light_groups);
 
   if (result.conflicted_regulatory_element_status.size() > 0) {
     publish_diagnostics(result.conflicted_regulatory_element_status, stamp);

--- a/perception/autoware_traffic_light_multi_camera_fusion/test/test_multi_camera_fusion.cpp
+++ b/perception/autoware_traffic_light_multi_camera_fusion/test/test_multi_camera_fusion.cpp
@@ -33,7 +33,6 @@
 
 #include <memory>
 #include <string>
-#include <vector>
 
 namespace
 {
@@ -42,7 +41,6 @@ using autoware::traffic_light::MultiCameraFusion;
 using autoware::traffic_light::MultiCameraFusionConfig;
 using autoware::traffic_light::MultiCameraFusionResult;
 using autoware_perception_msgs::msg::TrafficLightElement;
-using autoware_perception_msgs::msg::TrafficLightGroupArray;
 using sensor_msgs::msg::CameraInfo;
 using tier4_perception_msgs::msg::TrafficLight;
 using tier4_perception_msgs::msg::TrafficLightArray;
@@ -230,19 +228,19 @@ FusionInput make_fusion_input(
     make_signal_array(stamp, frame_id, signal)};
 }
 
-void expect_single_fused_color(const TrafficLightGroupArray & groups, uint8_t expected_color)
+void expect_single_fused_color(const MultiCameraFusionResult & result, uint8_t expected_color)
 {
-  ASSERT_EQ(groups.traffic_light_groups.size(), 1u);
-  const auto & group = groups.traffic_light_groups.front();
+  ASSERT_EQ(result.traffic_light_groups.traffic_light_groups.size(), 1u);
+  const auto & group = result.traffic_light_groups.traffic_light_groups.front();
   ASSERT_EQ(group.elements.size(), 1u);
   EXPECT_EQ(group.elements.front().color, expected_color);
 }
 
 void expect_single_fused_color_and_shape(
-  const TrafficLightGroupArray & groups, uint8_t expected_color, uint8_t expected_shape)
+  const MultiCameraFusionResult & result, uint8_t expected_color, uint8_t expected_shape)
 {
-  ASSERT_EQ(groups.traffic_light_groups.size(), 1u);
-  const auto & group = groups.traffic_light_groups.front();
+  ASSERT_EQ(result.traffic_light_groups.traffic_light_groups.size(), 1u);
+  const auto & group = result.traffic_light_groups.traffic_light_groups.front();
   ASSERT_EQ(group.elements.size(), 1u);
   EXPECT_EQ(group.elements.front().color, expected_color);
   EXPECT_EQ(group.elements.front().shape, expected_shape);
@@ -257,10 +255,10 @@ void expect_single_conflict_status(
 }
 
 void expect_element_confidence(
-  const TrafficLightGroupArray & groups, size_t element_index, float expected_confidence)
+  const MultiCameraFusionResult & result, size_t element_index, float expected_confidence)
 {
-  ASSERT_EQ(groups.traffic_light_groups.size(), 1u);
-  const auto & group = groups.traffic_light_groups.front();
+  ASSERT_EQ(result.traffic_light_groups.traffic_light_groups.size(), 1u);
+  const auto & group = result.traffic_light_groups.traffic_light_groups.front();
   ASSERT_LT(element_index, group.elements.size());
   EXPECT_FLOAT_EQ(group.elements[element_index].confidence, expected_confidence);
 }
@@ -275,12 +273,11 @@ TEST(MultiCameraFusionFuse, SingleCameraSingleLightOutputsGroupWithMappedRegulat
     make_fusion_input("camera0", make_signal(LEFT_TRAFFIC_LIGHT_ID, T4Element::GREEN, 0.9f));
 
   // Act
-  TrafficLightGroupArray groups;
-  const auto result = fusion.fuse(input.camera_info, input.roi_array, input.signal_array, groups);
+  const auto result = fusion.fuse(input.camera_info, input.roi_array, input.signal_array);
 
   // Assert
-  ASSERT_EQ(groups.traffic_light_groups.size(), 1u);
-  const auto & group = groups.traffic_light_groups.front();
+  ASSERT_EQ(result.traffic_light_groups.traffic_light_groups.size(), 1u);
+  const auto & group = result.traffic_light_groups.traffic_light_groups.front();
   EXPECT_EQ(group.traffic_light_group_id, REGULATORY_ELEMENT_ID);
   ASSERT_EQ(group.elements.size(), 1u);
   EXPECT_EQ(group.elements.front().color, TrafficLightElement::GREEN);
@@ -302,12 +299,10 @@ TEST(MultiCameraFusionFuse, EmptyRoiArrayProducesEmptyTrafficLightGroups)
   empty_signals.header.frame_id = frame_id;
 
   // Act
-  TrafficLightGroupArray groups;
-  const auto result =
-    fusion.fuse(make_camera_info(stamp, frame_id), empty_rois, empty_signals, groups);
+  const auto result = fusion.fuse(make_camera_info(stamp, frame_id), empty_rois, empty_signals);
 
   // Assert
-  EXPECT_TRUE(groups.traffic_light_groups.empty());
+  EXPECT_TRUE(result.traffic_light_groups.traffic_light_groups.empty());
   EXPECT_TRUE(result.unmapped_traffic_light_ids.empty());
 }
 
@@ -319,11 +314,10 @@ TEST(MultiCameraFusionFuse, UnknownTrafficLightIdIsRecordedAsUnmapped)
     make_fusion_input("camera0", make_signal(UNMAPPED_TRAFFIC_LIGHT_ID, T4Element::GREEN, 0.9f));
 
   // Act
-  TrafficLightGroupArray groups;
-  const auto result = fusion.fuse(input.camera_info, input.roi_array, input.signal_array, groups);
+  const auto result = fusion.fuse(input.camera_info, input.roi_array, input.signal_array);
 
   // Assert
-  EXPECT_TRUE(groups.traffic_light_groups.empty());
+  EXPECT_TRUE(result.traffic_light_groups.traffic_light_groups.empty());
   ASSERT_EQ(result.unmapped_traffic_light_ids.size(), 1u);
   EXPECT_EQ(result.unmapped_traffic_light_ids.front(), UNMAPPED_TRAFFIC_LIGHT_ID);
 }
@@ -340,13 +334,12 @@ TEST(MultiCameraFusionFuse, RoiWithoutMatchingSignalIsIgnored)
     make_signal_array(stamp, frame_id, make_signal(RIGHT_TRAFFIC_LIGHT_ID, T4Element::GREEN, 0.9f));
 
   // Act
-  TrafficLightGroupArray groups;
-  fusion.fuse(
+  const auto result = fusion.fuse(
     make_camera_info(stamp, frame_id), make_roi_array(stamp, frame_id, LEFT_TRAFFIC_LIGHT_ID),
-    mismatched_signals, groups);
+    mismatched_signals);
 
   // Assert
-  EXPECT_TRUE(groups.traffic_light_groups.empty());
+  EXPECT_TRUE(result.traffic_light_groups.traffic_light_groups.empty());
 }
 
 TEST(MultiCameraFusionFuse, HigherConfidenceColorIsSelectedAcrossTwoLights)
@@ -361,12 +354,11 @@ TEST(MultiCameraFusionFuse, HigherConfidenceColorIsSelectedAcrossTwoLights)
     make_fusion_input("camera1", make_signal(RIGHT_TRAFFIC_LIGHT_ID, T4Element::GREEN, 0.9f));
 
   // Act
-  TrafficLightGroupArray groups;
-  fusion.fuse(input0.camera_info, input0.roi_array, input0.signal_array, groups);
-  fusion.fuse(input1.camera_info, input1.roi_array, input1.signal_array, groups);
+  fusion.fuse(input0.camera_info, input0.roi_array, input0.signal_array);
+  const auto result = fusion.fuse(input1.camera_info, input1.roi_array, input1.signal_array);
 
   // Assert
-  expect_single_fused_color(groups, TrafficLightElement::GREEN);
+  expect_single_fused_color(result, TrafficLightElement::GREEN);
 }
 
 TEST(MultiCameraFusionFuse, RecordOlderThanMessageLifespanIsDiscarded)
@@ -383,13 +375,12 @@ TEST(MultiCameraFusionFuse, RecordOlderThanMessageLifespanIsDiscarded)
     "camera1", make_signal(RIGHT_TRAFFIC_LIGHT_ID, T4Element::RED, 0.6f), rclcpp::Time(102, 0));
 
   // Act
-  TrafficLightGroupArray groups;
-  fusion.fuse(input0.camera_info, input0.roi_array, input0.signal_array, groups);
-  fusion.fuse(input1.camera_info, input1.roi_array, input1.signal_array, groups);
+  fusion.fuse(input0.camera_info, input0.roi_array, input0.signal_array);
+  const auto result = fusion.fuse(input1.camera_info, input1.roi_array, input1.signal_array);
 
   // Assert
   // Only the second record contributes -> single light, RED color.
-  expect_single_fused_color(groups, TrafficLightElement::RED);
+  expect_single_fused_color(result, TrafficLightElement::RED);
 }
 
 TEST(MultiCameraFusionFuse, RecordWithinMessageLifespanIsKeptAndAccumulated)
@@ -405,13 +396,12 @@ TEST(MultiCameraFusionFuse, RecordWithinMessageLifespanIsKeptAndAccumulated)
     "camera1", make_signal(RIGHT_TRAFFIC_LIGHT_ID, T4Element::GREEN, 0.7f), rclcpp::Time(101, 0));
 
   // Act
-  TrafficLightGroupArray groups;
-  fusion.fuse(input0.camera_info, input0.roi_array, input0.signal_array, groups);
-  fusion.fuse(input1.camera_info, input1.roi_array, input1.signal_array, groups);
+  fusion.fuse(input0.camera_info, input0.roi_array, input0.signal_array);
+  const auto result = fusion.fuse(input1.camera_info, input1.roi_array, input1.signal_array);
 
   // Assert
   // Both records aggregate into a single group (same regulatory element) with color GREEN.
-  expect_single_fused_color(groups, TrafficLightElement::GREEN);
+  expect_single_fused_color(result, TrafficLightElement::GREEN);
 }
 
 TEST(MultiCameraFusionFuse, ConsistencyCheckWithSameColorOutputsNoConflict)
@@ -426,13 +416,11 @@ TEST(MultiCameraFusionFuse, ConsistencyCheckWithSameColorOutputsNoConflict)
     make_fusion_input("camera1", make_signal(RIGHT_TRAFFIC_LIGHT_ID, T4Element::GREEN, 0.9f));
 
   // Act
-  TrafficLightGroupArray groups;
-  fusion.fuse(input0.camera_info, input0.roi_array, input0.signal_array, groups);
-  const auto result =
-    fusion.fuse(input1.camera_info, input1.roi_array, input1.signal_array, groups);
+  fusion.fuse(input0.camera_info, input0.roi_array, input0.signal_array);
+  const auto result = fusion.fuse(input1.camera_info, input1.roi_array, input1.signal_array);
 
   // Assert
-  expect_single_fused_color(groups, TrafficLightElement::GREEN);
+  expect_single_fused_color(result, TrafficLightElement::GREEN);
   EXPECT_TRUE(result.conflicted_regulatory_element_status.empty());
 }
 
@@ -452,14 +440,12 @@ TEST(MultiCameraFusionFuse, ConsistencyCheckWithConflictingColorsOutputsUnknownF
     make_fusion_input("camera1", make_signal(RIGHT_TRAFFIC_LIGHT_ID, T4Element::GREEN, 0.9f));
 
   // Act
-  TrafficLightGroupArray groups;
-  fusion.fuse(input0.camera_info, input0.roi_array, input0.signal_array, groups);
-  const auto result =
-    fusion.fuse(input1.camera_info, input1.roi_array, input1.signal_array, groups);
+  fusion.fuse(input0.camera_info, input0.roi_array, input0.signal_array);
+  const auto result = fusion.fuse(input1.camera_info, input1.roi_array, input1.signal_array);
 
   // Assert
   expect_single_fused_color_and_shape(
-    groups, TrafficLightElement::UNKNOWN, TrafficLightElement::UNKNOWN);
+    result, TrafficLightElement::UNKNOWN, TrafficLightElement::UNKNOWN);
   expect_single_conflict_status(result, ConflictType::CONFLICT);
 }
 
@@ -480,13 +466,12 @@ TEST(MultiCameraFusionFuse, TruncatedRoiHasLowerPriorityThanCenteredRoi)
     make_fusion_input("camera1", make_signal(LEFT_TRAFFIC_LIGHT_ID, T4Element::RED, 0.6f), stamp);
 
   // Act
-  TrafficLightGroupArray groups;
-  fusion.fuse(truncated_camera_info, truncated_rois, truncated_signals, groups);
-  fusion.fuse(
-    centered_input.camera_info, centered_input.roi_array, centered_input.signal_array, groups);
+  fusion.fuse(truncated_camera_info, truncated_rois, truncated_signals);
+  const auto result =
+    fusion.fuse(centered_input.camera_info, centered_input.roi_array, centered_input.signal_array);
 
   // Assert
-  expect_single_fused_color(groups, TrafficLightElement::RED);
+  expect_single_fused_color(result, TrafficLightElement::RED);
 }
 
 TEST(MultiCameraFusionFuse, UnknownSignalLosesToValidSignalForSameTrafficLightId)
@@ -502,13 +487,12 @@ TEST(MultiCameraFusionFuse, UnknownSignalLosesToValidSignalForSameTrafficLightId
     make_fusion_input("camera1", make_signal(LEFT_TRAFFIC_LIGHT_ID, T4Element::GREEN, 0.8f));
 
   // Act
-  TrafficLightGroupArray groups;
-  fusion.fuse(
-    unknown_input.camera_info, unknown_input.roi_array, unknown_input.signal_array, groups);
-  fusion.fuse(valid_input.camera_info, valid_input.roi_array, valid_input.signal_array, groups);
+  fusion.fuse(unknown_input.camera_info, unknown_input.roi_array, unknown_input.signal_array);
+  const auto result =
+    fusion.fuse(valid_input.camera_info, valid_input.roi_array, valid_input.signal_array);
 
   // Assert
-  expect_single_fused_color(groups, TrafficLightElement::GREEN);
+  expect_single_fused_color(result, TrafficLightElement::GREEN);
 }
 
 TEST(MultiCameraFusionFuse, NewerTimestampWinsForSameFrameIdAndTrafficLightId)
@@ -527,13 +511,12 @@ TEST(MultiCameraFusionFuse, NewerTimestampWinsForSameFrameIdAndTrafficLightId)
     rclcpp::Time(100, 500000000));
 
   // Act
-  TrafficLightGroupArray groups;
-  fusion.fuse(
-    earlier_input.camera_info, earlier_input.roi_array, earlier_input.signal_array, groups);
-  fusion.fuse(later_input.camera_info, later_input.roi_array, later_input.signal_array, groups);
+  fusion.fuse(earlier_input.camera_info, earlier_input.roi_array, earlier_input.signal_array);
+  const auto result =
+    fusion.fuse(later_input.camera_info, later_input.roi_array, later_input.signal_array);
 
   // Assert
-  expect_single_fused_color(groups, TrafficLightElement::RED);
+  expect_single_fused_color(result, TrafficLightElement::RED);
 }
 
 TEST(MultiCameraFusionFuse, HigherConfidenceWinsWhenBothFullyVisibleForSameTrafficLightId)
@@ -549,16 +532,15 @@ TEST(MultiCameraFusionFuse, HigherConfidenceWinsWhenBothFullyVisibleForSameTraff
     make_fusion_input("camera1", make_signal(LEFT_TRAFFIC_LIGHT_ID, T4Element::RED, 0.9f));
 
   // Act
-  TrafficLightGroupArray groups;
   fusion.fuse(
     low_confidence_input.camera_info, low_confidence_input.roi_array,
-    low_confidence_input.signal_array, groups);
-  fusion.fuse(
+    low_confidence_input.signal_array);
+  const auto result = fusion.fuse(
     high_confidence_input.camera_info, high_confidence_input.roi_array,
-    high_confidence_input.signal_array, groups);
+    high_confidence_input.signal_array);
 
   // Assert
-  expect_single_fused_color(groups, TrafficLightElement::RED);
+  expect_single_fused_color(result, TrafficLightElement::RED);
 }
 
 TEST(MultiCameraFusionFuse, PartialConflictWithPartialMatchEnabledPublishesCommonState)
@@ -579,14 +561,12 @@ TEST(MultiCameraFusionFuse, PartialConflictWithPartialMatchEnabledPublishesCommo
     "camera1", make_signal_with_left_arrow(RIGHT_TRAFFIC_LIGHT_ID, T4Element::RED, 0.9f, 0.9f));
 
   // Act
-  TrafficLightGroupArray groups;
-  fusion.fuse(input0.camera_info, input0.roi_array, input0.signal_array, groups);
-  const auto result =
-    fusion.fuse(input1.camera_info, input1.roi_array, input1.signal_array, groups);
+  fusion.fuse(input0.camera_info, input0.roi_array, input0.signal_array);
+  const auto result = fusion.fuse(input1.camera_info, input1.roi_array, input1.signal_array);
 
   // Assert
   expect_single_fused_color_and_shape(
-    groups, TrafficLightElement::RED, TrafficLightElement::CIRCLE);
+    result, TrafficLightElement::RED, TrafficLightElement::CIRCLE);
   expect_single_conflict_status(result, ConflictType::PARTIAL_CONFLICT);
 }
 
@@ -608,14 +588,13 @@ TEST(MultiCameraFusionFuse, MinElementConfidenceDeterminesWinnerForMultiElementS
     "camera1", make_signal_with_left_arrow(LEFT_TRAFFIC_LIGHT_ID, T4Element::GREEN, 0.9f, 0.3f));
 
   // Act
-  TrafficLightGroupArray groups;
-  fusion.fuse(input0.camera_info, input0.roi_array, input0.signal_array, groups);
-  fusion.fuse(input1.camera_info, input1.roi_array, input1.signal_array, groups);
+  fusion.fuse(input0.camera_info, input0.roi_array, input0.signal_array);
+  const auto result = fusion.fuse(input1.camera_info, input1.roi_array, input1.signal_array);
 
   // Assert
   // camera0 wins -> output preserves camera0's per-element confidences (0.8 each).
-  expect_element_confidence(groups, 0, 0.8f);
-  expect_element_confidence(groups, 1, 0.8f);
+  expect_element_confidence(result, 0, 0.8f);
+  expect_element_confidence(result, 1, 0.8f);
 }
 
 TEST(MultiCameraFusionFuse, PartialConflictWithPartialMatchDisabledPublishesFailsafe)
@@ -634,13 +613,11 @@ TEST(MultiCameraFusionFuse, PartialConflictWithPartialMatchDisabledPublishesFail
     "camera1", make_signal_with_left_arrow(RIGHT_TRAFFIC_LIGHT_ID, T4Element::RED, 0.9f, 0.9f));
 
   // Act
-  TrafficLightGroupArray groups;
-  fusion.fuse(input0.camera_info, input0.roi_array, input0.signal_array, groups);
-  const auto result =
-    fusion.fuse(input1.camera_info, input1.roi_array, input1.signal_array, groups);
+  fusion.fuse(input0.camera_info, input0.roi_array, input0.signal_array);
+  const auto result = fusion.fuse(input1.camera_info, input1.roi_array, input1.signal_array);
 
   // Assert
   expect_single_fused_color_and_shape(
-    groups, TrafficLightElement::UNKNOWN, TrafficLightElement::UNKNOWN);
+    result, TrafficLightElement::UNKNOWN, TrafficLightElement::UNKNOWN);
   expect_single_conflict_status(result, ConflictType::PARTIAL_CONFLICT);
 }


### PR DESCRIPTION
## Description

This PR restores the original input/output of `MultiCameraFusion::fuse()` that was changed in #12710, while **keeping** the `autoware_agnocast_wrapper` adoption on the node side.

Returning the result by value reads better than the output-parameter form.

Memory copy is negligible because `TrafficLightGroupArray` is a small message (well under 1 KB for a typical intersection) published at ~10 Hz, so the copy is far smaller than the fusion computation itself.

## Related links

**Parent Issue:**

- https://github.com/autowarefoundation/autoware/issues/7007 (agnocast wrapper adoption)
- #12710 (the PR whose `fuse()` interface change this reverts)

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

```bash
PACKAGE_NAME=autoware_traffic_light_multi_camera_fusion
colcon build --packages-select $PACKAGE_NAME
colcon test --packages-select $PACKAGE_NAME --event-handlers console_cohesion+
```

- Build succeeds.
- All tests pass (6/6: 2 gtest + 4 linters).

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
