### PR TITLE
refactor(object_merger): fix to improve readability beside copy

### DIFF
--- a/perception/autoware_object_merger/include/autoware/object_merger/object_fusion_merger_node.hpp
+++ b/perception/autoware_object_merger/include/autoware/object_merger/object_fusion_merger_node.hpp
@@ -56,6 +56,12 @@ private:
     DetectedObjects, DetectedObjects>;
   using Sync = autoware::agnocast_wrapper::message_filters::Synchronizer<SyncPolicy>;
 
+  struct FusionResult
+  {
+    DetectedObjects fused_objects;
+    DetectedObjects other_objects;
+  };
+
   /**
    * @brief Transform synchronized inputs, perform fusion, and publish both outputs.
    *
@@ -71,12 +77,10 @@ private:
    *
    * @param main_objects_msg Main detected objects transformed into the base frame.
    * @param sub_objects_msg Sub detected objects transformed into the base frame.
-   * @param fused_objects Output message populated with the main-based fused objects.
-   * @param other_objects Output message populated with the unmatched sub objects.
+   * @return Fusion result containing the main-based output and unmatched sub objects.
    */
-  void fuse_objects(
-    const DetectedObjects & main_objects_msg, const DetectedObjects & sub_objects_msg,
-    DetectedObjects & fused_objects, DetectedObjects & other_objects);
+  FusionResult fuse_objects(
+    const DetectedObjects & main_objects_msg, const DetectedObjects & sub_objects_msg);
 
   autoware::agnocast_wrapper::Buffer tf_buffer_;
   autoware::agnocast_wrapper::TransformListener tf_listener_;

--- a/perception/autoware_object_merger/src/object_fusion_merger_node.cpp
+++ b/perception/autoware_object_merger/src/object_fusion_merger_node.cpp
@@ -559,16 +559,18 @@ void ObjectFusionMergerNode::callback(
     return;
   }
 
+  const auto result = fuse_objects(transformed_main_objects, transformed_sub_objects);
+
   auto fused_output = ALLOCATE_OUTPUT_MESSAGE_UNIQUE(fused_objects_pub_);
   auto other_output = ALLOCATE_OUTPUT_MESSAGE_UNIQUE(other_objects_pub_);
-  fuse_objects(transformed_main_objects, transformed_sub_objects, *fused_output, *other_output);
-
-  const auto fused_stamp = fused_output->header.stamp;
+  *fused_output = result.fused_objects;
+  *other_output = result.other_objects;
   fused_objects_pub_->publish(std::move(fused_output));
   other_objects_pub_->publish(std::move(other_output));
 
   // Publish debug info
-  published_time_publisher_->publish_if_subscribed(fused_objects_pub_, fused_stamp);
+  published_time_publisher_->publish_if_subscribed(
+    fused_objects_pub_, result.fused_objects.header.stamp);
   processing_time_publisher_->publish<autoware_internal_debug_msgs::msg::Float64Stamped>(
     "debug/cyclic_time_ms", stop_watch_ptr_->toc("cyclic_time", true));
   processing_time_publisher_->publish<autoware_internal_debug_msgs::msg::Float64Stamped>(
@@ -580,12 +582,10 @@ void ObjectFusionMergerNode::callback(
  *
  * @param main_objects_msg Main detected objects already transformed into the base frame.
  * @param sub_objects_msg Sub detected objects already transformed into the base frame.
- * @param fused_objects Output message populated with the main-based fused objects.
- * @param other_objects Output message populated with the unmatched sub objects.
+ * @return Fused main-based objects and unmatched sub objects for separate publication.
  */
-void ObjectFusionMergerNode::fuse_objects(
-  const DetectedObjects & main_objects_msg, const DetectedObjects & sub_objects_msg,
-  DetectedObjects & fused_objects, DetectedObjects & other_objects)
+ObjectFusionMergerNode::FusionResult ObjectFusionMergerNode::fuse_objects(
+  const DetectedObjects & main_objects_msg, const DetectedObjects & sub_objects_msg)
 {
   const auto & main_objects = main_objects_msg.objects;
   const auto & sub_objects = sub_objects_msg.objects;
@@ -598,10 +598,11 @@ void ObjectFusionMergerNode::fuse_objects(
                         .stamp(main_objects_msg.header.stamp)
                         .frame_id(base_link_frame_id_);
 
-  fused_objects.header = header;
-  fused_objects.objects = std::move(fused_main_objects);
-  other_objects.header = header;
-  other_objects.objects = std::move(grouped_inputs.other_objects);
+  return FusionResult{
+    autoware_perception_msgs::build<DetectedObjects>().header(header).objects(
+      std::move(fused_main_objects)),
+    autoware_perception_msgs::build<DetectedObjects>().header(header).objects(
+      std::move(grouped_inputs.other_objects))};
 }
 }  // namespace autoware::object_merger
 


### PR DESCRIPTION
## Description
Revert the `fuse_objects` input/output change introduced in #12704 so that `ObjectFusionMergerNode::fuse_objects()` returns a `FusionResult` again instead of writing into output reference parameters, restoring readability. The agnocast publisher adoption is kept: the node allocates output messages via `ALLOCATE_OUTPUT_MESSAGE_UNIQUE` right before publishing and copies the result into them explicitly, then publishes with the `publish(std::move(...))` overload. The result-building inside `fuse_objects()` now moves objects into the messages instead of copying.

  ## How was this PR tested?

  Built locally with `colcon build --packages-select autoware_object_merger`. Both `ENABLE_AGNOCAST` == 0 and 1.

  ## Notes for reviewers
  One explicit copy remains, at the `ALLOCATE_OUTPUT_MESSAGE_UNIQUE` + assignment step in the callback (the readability/zero-copy trade-off chosen here).

  ## Effects on system behavior
  None.

