### PR TITLE
feat(traffic_light_multi_camera_fusion): apply `agnocast_wrapper::Node` to `traffic_light_multi_camera_fusion`

### DIFF
--- a/perception/autoware_traffic_light_multi_camera_fusion/CMakeLists.txt
+++ b/perception/autoware_traffic_light_multi_camera_fusion/CMakeLists.txt
@@ -18,7 +18,7 @@ ament_auto_add_library(${PROJECT_NAME} SHARED
 autoware_agnocast_wrapper_register_node(${PROJECT_NAME}
   PLUGIN "autoware::traffic_light::MultiCameraFusionNode"
   EXECUTABLE traffic_light_multi_camera_fusion_node
-  AGNOCAST_EXECUTOR CallbackIsolatedAgnocastExecutor
+  AGNOCAST_EXECUTOR AgnocastOnlyCallbackIsolatedExecutor
   ROS2_EXECUTOR SingleThreadedExecutor
 )
 

--- a/perception/autoware_traffic_light_multi_camera_fusion/src/traffic_light_multi_camera_fusion_node.cpp
+++ b/perception/autoware_traffic_light_multi_camera_fusion/src/traffic_light_multi_camera_fusion_node.cpp
@@ -27,10 +27,6 @@ namespace autoware::traffic_light
 MultiCameraFusionNode::MultiCameraFusionNode(const rclcpp::NodeOptions & node_options)
 : Node("traffic_light_multi_camera_fusion", node_options)
 {
-  using std::placeholders::_1;
-  using std::placeholders::_2;
-  using std::placeholders::_3;
-
   std::vector<std::string> camera_namespaces =
     this->declare_parameter<std::vector<std::string>>("camera_namespaces");
   const bool is_approximate_sync = this->declare_parameter<bool>("approximate_sync");
@@ -60,31 +56,32 @@ MultiCameraFusionNode::MultiCameraFusionNode(const rclcpp::NodeOptions & node_op
         ExactSyncPolicy(10), *(cam_info_subs_.back()), *(roi_subs_.back()),
         *(signal_subs_.back())));
       exact_sync_subs_.back()->registerCallback(
-        std::bind(&MultiCameraFusionNode::traffic_signal_roi_callback, this, _1, _2, _3));
+        &MultiCameraFusionNode::traffic_signal_roi_callback, this);
     } else {
       approximate_sync_subs_.emplace_back(new ApproximateSync(
         ApproximateSyncPolicy(10), *(cam_info_subs_.back()), *(roi_subs_.back()),
         *(signal_subs_.back())));
       approximate_sync_subs_.back()->registerCallback(
-        std::bind(&MultiCameraFusionNode::traffic_signal_roi_callback, this, _1, _2, _3));
+        &MultiCameraFusionNode::traffic_signal_roi_callback, this);
     }
   }
 
   map_sub_ = create_subscription<autoware_map_msgs::msg::LaneletMapBin>(
     "~/input/vector_map", rclcpp::QoS{1}.transient_local(),
-    [this](const autoware_map_msgs::msg::LaneletMapBin::ConstSharedPtr msg) {
+    [this](const AUTOWARE_MESSAGE_CONST_SHARED_PTR(autoware_map_msgs::msg::LaneletMapBin) & msg) {
       this->map_callback(msg);
     });
-  signal_pub_ =
-    AUTOWARE_CREATE_PUBLISHER2(NewSignalArrayType, "~/output/traffic_signals", rclcpp::QoS{1});
+  signal_pub_ = create_publisher<NewSignalArrayType>("~/output/traffic_signals", rclcpp::QoS{1});
 
   diagnostics_interface_ptr_ =
-    std::make_unique<autoware_utils::DiagnosticsInterface>(this, "traffic light conflict status");
+    std::make_unique<autoware_utils::BasicDiagnosticsInterface<autoware::agnocast_wrapper::Node>>(
+      this, "traffic light conflict status");
 }
 
 void MultiCameraFusionNode::traffic_signal_roi_callback(
-  const CamInfoType::ConstSharedPtr cam_info_msg, const RoiArrayType::ConstSharedPtr roi_msg,
-  const SignalArrayType::ConstSharedPtr signal_msg)
+  const AUTOWARE_MESSAGE_CONST_SHARED_PTR(CamInfoType) & cam_info_msg,
+  const AUTOWARE_MESSAGE_CONST_SHARED_PTR(RoiArrayType) & roi_msg,
+  const AUTOWARE_MESSAGE_CONST_SHARED_PTR(SignalArrayType) & signal_msg)
 {
   rclcpp::Time stamp(roi_msg->header.stamp);
 
@@ -101,7 +98,7 @@ void MultiCameraFusionNode::traffic_signal_roi_callback(
 }
 
 void MultiCameraFusionNode::map_callback(
-  const autoware_map_msgs::msg::LaneletMapBin::ConstSharedPtr input_msg)
+  const AUTOWARE_MESSAGE_CONST_SHARED_PTR(autoware_map_msgs::msg::LaneletMapBin) & input_msg)
 {
   fusion_config_.lanelet_map_ptr = autoware::experimental::lanelet2_utils::remove_const(
     autoware::experimental::lanelet2_utils::from_autoware_map_msgs(*input_msg));

--- a/perception/autoware_traffic_light_multi_camera_fusion/src/traffic_light_multi_camera_fusion_node.hpp
+++ b/perception/autoware_traffic_light_multi_camera_fusion/src/traffic_light_multi_camera_fusion_node.hpp
@@ -18,6 +18,8 @@
 #include "multi_camera_fusion.hpp"
 
 #include <autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp>
+#include <autoware/agnocast_wrapper/message_filters.hpp>
+#include <autoware/agnocast_wrapper/node.hpp>
 #include <autoware_utils/ros/diagnostics_interface.hpp>
 #include <rclcpp/rclcpp.hpp>
 
@@ -30,20 +32,15 @@
 #include <tier4_perception_msgs/msg/traffic_light_roi.hpp>
 #include <tier4_perception_msgs/msg/traffic_light_roi_array.hpp>
 
-#include <message_filters/subscriber.h>
-#include <message_filters/sync_policies/approximate_time.h>
-#include <message_filters/sync_policies/exact_time.h>
-#include <message_filters/synchronizer.h>
-
 #include <memory>
 #include <utility>
 #include <vector>
 
 namespace autoware::traffic_light
 {
-namespace mf = message_filters;
+namespace mf = autoware::agnocast_wrapper::message_filters;
 
-class MultiCameraFusionNode : public rclcpp::Node
+class MultiCameraFusionNode : public autoware::agnocast_wrapper::Node
 {
 public:
   using CamInfoType = sensor_msgs::msg::CameraInfo;
@@ -61,10 +58,12 @@ public:
 
 private:
   void traffic_signal_roi_callback(
-    const CamInfoType::ConstSharedPtr cam_info_msg, const RoiArrayType::ConstSharedPtr roi_msg,
-    const SignalArrayType::ConstSharedPtr signal_msg);
+    const AUTOWARE_MESSAGE_CONST_SHARED_PTR(CamInfoType) & cam_info_msg,
+    const AUTOWARE_MESSAGE_CONST_SHARED_PTR(RoiArrayType) & roi_msg,
+    const AUTOWARE_MESSAGE_CONST_SHARED_PTR(SignalArrayType) & signal_msg);
 
-  void map_callback(const autoware_map_msgs::msg::LaneletMapBin::ConstSharedPtr input_msg);
+  void map_callback(
+    const AUTOWARE_MESSAGE_CONST_SHARED_PTR(autoware_map_msgs::msg::LaneletMapBin) & input_msg);
 
   void publish_diagnostics(
     const std::vector<ConflictInfo> & conflicted_regulatory_element_status, rclcpp::Time stamp);
@@ -80,14 +79,15 @@ private:
   std::vector<std::unique_ptr<mf::Subscriber<CamInfoType>>> cam_info_subs_;
   std::vector<std::unique_ptr<ExactSync>> exact_sync_subs_;
   std::vector<std::unique_ptr<ApproximateSync>> approximate_sync_subs_;
-  rclcpp::Subscription<autoware_map_msgs::msg::LaneletMapBin>::SharedPtr map_sub_;
+  AUTOWARE_SUBSCRIPTION_PTR(autoware_map_msgs::msg::LaneletMapBin) map_sub_;
 
   AUTOWARE_PUBLISHER_PTR(NewSignalArrayType) signal_pub_;
 
   MultiCameraFusionConfig fusion_config_{};
   MultiCameraFusion fusion_{};
 
-  std::unique_ptr<autoware_utils::DiagnosticsInterface> diagnostics_interface_ptr_;
+  std::unique_ptr<autoware_utils::BasicDiagnosticsInterface<autoware::agnocast_wrapper::Node>>
+    diagnostics_interface_ptr_;
 };
 }  // namespace autoware::traffic_light
 #endif  // TRAFFIC_LIGHT_MULTI_CAMERA_FUSION_NODE_HPP_

--- a/perception/autoware_traffic_light_multi_camera_fusion/test/test_traffic_light_multi_camera_fusion_node.cpp
+++ b/perception/autoware_traffic_light_multi_camera_fusion/test/test_traffic_light_multi_camera_fusion_node.cpp
@@ -119,7 +119,7 @@ protected:
       options.publish_partial_matched_signal);
 
     node_ = std::make_shared<MultiCameraFusionNode>(node_options);
-    executor_->add_node(node_);
+    executor_->add_node(node_->get_node_base_interface());
   }
 
   void TearDown() override


### PR DESCRIPTION
## Description

Apply `agnocast_wrapper::Node` to `autoware_traffic_light_multi_camera_fusion`.
Please read https://github.com/autowarefoundation/autoware/issues/7007 for the context and review guidelines of `autoware_agnocast_wrapper` adoption. Also, please refer to https://github.com/autowarefoundation/autoware_core/blob/main/common/autoware_agnocast_wrapper/docs/review_guide.md for the review guide of `autoware_agnocast_wrapper` application PR. FYI: This node takes [Method2](https://github.com/autowarefoundation/autoware_core/blob/main/common/autoware_agnocast_wrapper/docs/review_guide.md#method-2-agnocast_wrappernode-inheritance) of two integration methods.

**AgnocastOnlyCallbackIsolatedExecutor:**
When built and run with `ENABLE_AGNOCAST=1`, the node runs on an `AgnocastOnlyCallbackIsolatedExecutor` (CIE), the standard executor for `agnocast_wrapper::Node`. Please check for potential race conditions only if the node meets **all** of the following:

1. It was originally running on a `SingleThreadedExecutor`.
2. It has multiple callback groups (the default is one).
3. Shared variables are accessed across those callback groups without mutex protection.

Main changes:

- `MultiCameraFusionNode` now derives from `agnocast_wrapper::Node`; the map
  subscription uses `AUTOWARE_SUBSCRIPTION_PTR`, and the synchronizer callback
  takes Agnocast message pointers.
- The `message_filters` alias is switched from `message_filters` to
  `autoware::agnocast_wrapper::message_filters`, so the per-camera
  `ExactTime` / `ApproximateTime` synchronizers (`CameraInfo`, `TrafficLightRoiArray`,
  `TrafficLightGroupArray`) run through the Agnocast-aware, variadic
  `message_filters` wrapper.
- The diagnostics helper uses the node-templated `BasicDiagnosticsInterface<...>`.
- `AGNOCAST_EXECUTOR` is set to `AgnocastOnlyCallbackIsolatedExecutor`, which is
  required for Method-2 (`agnocast_wrapper::Node`) nodes.
- The node is launched as a standalone node (not inside a component container).

## Related links

## How was this PR tested?

- **Build**: Confirmed the node builds successfully with both `ENABLE_AGNOCAST=0`
  and `ENABLE_AGNOCAST=1`.
- **Unit tests**: Confirmed the package tests pass.
- **Runtime (synthetic injection)**: On an autoware-based product, confirmed by
  launching the node standalone under `ENABLE_AGNOCAST=1` and injecting synthetic
  inputs for one camera (`camera_info`, `rois`, and `traffic_signals`) with a
  shared timestamp at 10 Hz. The 3-input `ExactTime` synchronizer callback fires
  and the fused traffic signals are published at ~10 Hz.

## Notes for reviewers

- **message_filters wrapper**: The synchronizers now use the variadic
  `autoware::agnocast_wrapper::message_filters` (three-input `ExactTime` /
  `ApproximateTime`). This is available in the Agnocast wrapper and is
  source-compatible for this node.
- **Publish pattern**: The fused signals are published with `publish(const &)`, so
  the message stays in the loaned shared-memory buffer for correct serialization by
  the Agnocast→ROS 2 bridge.

## Interface changes

None.

## Effects on system behavior

None.