### PR TITLE
feat(multi object tracker): tracker export options

### DIFF
--- a/perception/autoware_multi_object_tracker/config/data_association_matrix.param.yaml
+++ b/perception/autoware_multi_object_tracker/config/data_association_matrix.param.yaml
@@ -93,22 +93,4 @@
           hazard:     {max_dist: 2.0, max_area: 2.6, min_area: 0.001, min_iou: 0.0001}
           unknown:    {max_dist: 2.0, max_area: 2.6, min_area: 0.001, min_iou: 0.0001}
 
-    # Per-tracker-type configuration: behavior knobs scoped to a single tracker type.
-    tracker_configs:
-      polygon_tracker:
-        enable_velocity_estimation: true   # estimate velocity for polygon tracks
-        enable_motion_output:              # publish estimated velocity on polygon tracks, per classification
-          unknown:    false
-          car:        true
-          truck:      true
-          bus:        true
-          trailer:    true
-          motorcycle: true
-          bicycle:    true
-          pedestrian: true
-          animal:     true
-          hazard:     false
-      static_tracker:
-        convert_polygon_to_bbox: true      # convert POLYGON shape to BOUNDING_BOX at publish time
-
     unknown_association_giou_threshold: -0.8  # GIoU threshold for unknown-unknown association

--- a/perception/autoware_multi_object_tracker/config/data_association_matrix.param.yaml
+++ b/perception/autoware_multi_object_tracker/config/data_association_matrix.param.yaml
@@ -93,4 +93,12 @@
           hazard:     {max_dist: 2.0, max_area: 2.6,  min_area: 0.001, min_iou: 0.0001}
           unknown:    {max_dist: 2.0, max_area: 2.6,  min_area: 0.001, min_iou: 0.0001}
 
+    # Per-tracker-type configuration: behavior knobs scoped to a single tracker type.
+    tracker_configs:
+      polygon_tracker:
+        enable_velocity_estimation: true   # estimate velocity for polygon tracks
+        enable_motion_output: false        # publish estimated velocity on polygon tracks
+      static_tracker:
+        convert_polygon_to_bbox: true      # convert POLYGON shape to BOUNDING_BOX at publish time
+
     unknown_association_giou_threshold: -0.8  # GIoU threshold for unknown-unknown association

--- a/perception/autoware_multi_object_tracker/config/data_association_matrix.param.yaml
+++ b/perception/autoware_multi_object_tracker/config/data_association_matrix.param.yaml
@@ -46,32 +46,32 @@
     tracker_profiles:
       general_vehicle_tracker:
         bounding_box:
-          unknown:  {max_dist: 4.0, max_area: 60.0,  min_area: 3.6,   min_iou: 0.0001}
-          car:      {max_dist: 5.0, max_area: 12.10, min_area: 3.6,   min_iou: 0.0001}
-          truck:    {max_dist: 5.0, max_area: 36.00, min_area: 6.0,   min_iou: 0.10}
-          bus:      {max_dist: 5.0, max_area: 60.00, min_area: 10.0,  min_iou: 0.10}
-          trailer:  {max_dist: 5.0, max_area: 60.00, min_area: 10.0,  min_iou: 0.10}
+          unknown:  {max_dist: 4.0, max_area: 60.0,  min_area: 3.6,  min_iou: 0.0001}
+          car:      {max_dist: 5.0, max_area: 12.10, min_area: 3.6,  min_iou: 0.0001}
+          truck:    {max_dist: 5.0, max_area: 36.00, min_area: 6.0,  min_iou: 0.10}
+          bus:      {max_dist: 5.0, max_area: 60.00, min_area: 10.0, min_iou: 0.10}
+          trailer:  {max_dist: 5.0, max_area: 60.00, min_area: 10.0, min_iou: 0.10}
         polygon:
-          unknown:  {max_dist: 4.0, max_area: 75.0,  min_area: 0.01,   min_iou: 0.0001}
-          car:      {max_dist: 4.0, max_area: 75.0,  min_area: 0.01,   min_iou: 0.0001}
-          truck:    {max_dist: 4.0, max_area: 75.0,  min_area: 0.01,   min_iou: 0.0001}
-          bus:      {max_dist: 4.0, max_area: 75.0,  min_area: 0.01,   min_iou: 0.0001}
-          trailer:  {max_dist: 4.0, max_area: 75.0,  min_area: 0.01,   min_iou: 0.0001}
+          unknown:  {max_dist: 4.0, max_area: 75.0, min_area: 0.01, min_iou: 0.0001}
+          car:      {max_dist: 4.0, max_area: 75.0, min_area: 0.01, min_iou: 0.0001}
+          truck:    {max_dist: 4.0, max_area: 75.0, min_area: 0.01, min_iou: 0.0001}
+          bus:      {max_dist: 4.0, max_area: 75.0, min_area: 0.01, min_iou: 0.0001}
+          trailer:  {max_dist: 4.0, max_area: 75.0, min_area: 0.01, min_iou: 0.0001}
       pedestrian_and_bicycle_tracker:
         bounding_box:
-          unknown:    {max_dist: 3.0, max_area: 3.5,  min_area: 0.01, min_iou: 0.0001}
-          motorcycle: {max_dist: 3.0, max_area: 3.5, min_area: 0.1,   min_iou: -0.30}
-          bicycle:    {max_dist: 3.0, max_area: 3.5, min_area: 0.1,   min_iou: 0.0001}
-          pedestrian: {max_dist: 2.0, max_area: 3.0, min_area: 0.1,   min_iou: 0.0001}
+          unknown:    {max_dist: 3.0, max_area: 3.5, min_area: 0.01, min_iou: 0.0001}
+          motorcycle: {max_dist: 3.0, max_area: 3.5, min_area: 0.1,  min_iou: -0.30}
+          bicycle:    {max_dist: 3.0, max_area: 3.5, min_area: 0.1,  min_iou: 0.0001}
+          pedestrian: {max_dist: 2.0, max_area: 3.0, min_area: 0.1,  min_iou: 0.0001}
         cylinder:
-          motorcycle: {max_dist: 3.0, max_area: 3.5, min_area: 0.1,   min_iou: -0.30}
-          bicycle:    {max_dist: 3.0, max_area: 3.5, min_area: 0.1,   min_iou: 0.0001}
-          pedestrian: {max_dist: 2.0, max_area: 3.0, min_area: 0.1,   min_iou: 0.0001}
+          motorcycle: {max_dist: 3.0, max_area: 3.5, min_area: 0.1, min_iou: -0.30}
+          bicycle:    {max_dist: 3.0, max_area: 3.5, min_area: 0.1, min_iou: 0.0001}
+          pedestrian: {max_dist: 2.0, max_area: 3.0, min_area: 0.1, min_iou: 0.0001}
         polygon:
-          unknown:    {max_dist: 3.0, max_area: 3.5,  min_area: 0.01, min_iou: 0.0001}
-          motorcycle: {max_dist: 3.0, max_area: 3.5,  min_area: 0.01, min_iou: 0.0001}
-          bicycle:    {max_dist: 3.0, max_area: 3.5,  min_area: 0.01, min_iou: 0.0001}
-          pedestrian: {max_dist: 3.0, max_area: 3.0,  min_area: 0.01, min_iou: 0.0001}
+          unknown:    {max_dist: 3.0, max_area: 3.5, min_area: 0.01, min_iou: 0.0001}
+          motorcycle: {max_dist: 3.0, max_area: 3.5, min_area: 0.01, min_iou: 0.0001}
+          bicycle:    {max_dist: 3.0, max_area: 3.5, min_area: 0.01, min_iou: 0.0001}
+          pedestrian: {max_dist: 3.0, max_area: 3.0, min_area: 0.01, min_iou: 0.0001}
       polygon_tracker:
         polygon:
           unknown:    {max_dist: 4.0, max_area: 100.0, min_area: 0.0, min_iou: 0.0001}
@@ -86,12 +86,12 @@
           hazard:     {max_dist: 3.0, max_area: 3.5,   min_area: 0.0, min_iou: 0.0001}
       static_tracker:
         bounding_box:
-          hazard:     {max_dist: 2.0, max_area: 2.6,  min_area: 0.001, min_iou: 0.0001}
+          hazard:     {max_dist: 2.0, max_area: 2.6, min_area: 0.001, min_iou: 0.0001}
         cylinder:
-          hazard:     {max_dist: 2.0, max_area: 2.6,  min_area: 0.001, min_iou: 0.0001}
+          hazard:     {max_dist: 2.0, max_area: 2.6, min_area: 0.001, min_iou: 0.0001}
         polygon:
-          hazard:     {max_dist: 2.0, max_area: 2.6,  min_area: 0.001, min_iou: 0.0001}
-          unknown:    {max_dist: 2.0, max_area: 2.6,  min_area: 0.001, min_iou: 0.0001}
+          hazard:     {max_dist: 2.0, max_area: 2.6, min_area: 0.001, min_iou: 0.0001}
+          unknown:    {max_dist: 2.0, max_area: 2.6, min_area: 0.001, min_iou: 0.0001}
 
     # Per-tracker-type configuration: behavior knobs scoped to a single tracker type.
     tracker_configs:

--- a/perception/autoware_multi_object_tracker/config/data_association_matrix.param.yaml
+++ b/perception/autoware_multi_object_tracker/config/data_association_matrix.param.yaml
@@ -97,7 +97,17 @@
     tracker_configs:
       polygon_tracker:
         enable_velocity_estimation: true   # estimate velocity for polygon tracks
-        enable_motion_output: false        # publish estimated velocity on polygon tracks
+        enable_motion_output:              # publish estimated velocity on polygon tracks, per classification
+          unknown:    false
+          car:        true
+          truck:      true
+          bus:        true
+          trailer:    true
+          motorcycle: true
+          bicycle:    true
+          pedestrian: true
+          animal:     true
+          hazard:     false
       static_tracker:
         convert_polygon_to_bbox: true      # convert POLYGON shape to BOUNDING_BOX at publish time
 

--- a/perception/autoware_multi_object_tracker/config/multi_object_tracker_node.param.yaml
+++ b/perception/autoware_multi_object_tracker/config/multi_object_tracker_node.param.yaml
@@ -23,7 +23,7 @@
           animal:     true
           hazard:     false
       static_tracker:
-        convert_polygon_to_bbox: true # convert POLYGON shape to BOUNDING_BOX at publish time
+        convert_polygon_to_bbox: false # convert POLYGON shape to BOUNDING_BOX at publish time
 
     # pruning parameters
     min_known_object_removal_iou: 0.1  # [ratio]

--- a/perception/autoware_multi_object_tracker/config/multi_object_tracker_node.param.yaml
+++ b/perception/autoware_multi_object_tracker/config/multi_object_tracker_node.param.yaml
@@ -6,8 +6,6 @@
     ego_frame_id: base_link
     enable_delay_compensation: false
     consider_odometry_uncertainty: false
-    enable_unknown_object_velocity_estimation: true
-    enable_unknown_object_motion_output: false
 
     # tracker parameters
     min_known_object_removal_iou: 0.1  # [ratio]

--- a/perception/autoware_multi_object_tracker/config/multi_object_tracker_node.param.yaml
+++ b/perception/autoware_multi_object_tracker/config/multi_object_tracker_node.param.yaml
@@ -7,6 +7,24 @@
     enable_delay_compensation: false
     consider_odometry_uncertainty: false
 
+    # Per-tracker-type configuration
+    tracker_configs:
+      polygon_tracker:
+        enable_velocity_estimation: true
+        enable_motion_output:
+          unknown:    false
+          car:        true
+          truck:      true
+          bus:        true
+          trailer:    true
+          motorcycle: true
+          bicycle:    true
+          pedestrian: true
+          animal:     true
+          hazard:     false
+      static_tracker:
+        convert_polygon_to_bbox: true # convert POLYGON shape to BOUNDING_BOX at publish time
+
     # tracker parameters
     min_known_object_removal_iou: 0.1  # [ratio]
     min_unknown_object_removal_iou: 0.001  # [ratio]
@@ -38,6 +56,8 @@
     pruning_static_object_speed: 1.38  # [m/s]
     pruning_moving_object_speed: 5.5   # [m/s]
     pruning_static_iou_threshold: 0.0  # [ratio]
+
+
 
     # debug parameters
     publish_processing_time: false

--- a/perception/autoware_multi_object_tracker/config/multi_object_tracker_node.param.yaml
+++ b/perception/autoware_multi_object_tracker/config/multi_object_tracker_node.param.yaml
@@ -30,18 +30,8 @@
     min_unknown_object_removal_iou: 0.001  # [ratio]
 
     # pruning parameters
-    # generalized IoU thresholds for tracked classes
-    pruning_generalized_iou_thresholds:
-      unknown: 0.1
-      car: 0.1
-      truck: 0.1
-      bus: 0.1
-      trailer: 0.1
-      motorcycle: 0.1
-      bicycle: 0.1
-      pedestrian: 0.1
-      animal: 0.1
-      hazard: 0.1
+    # generalized IoU threshold applied to all tracked classes
+    pruning_generalized_iou_threshold: 0.1  # [ratio]
     pruning_distance_thresholds:
       unknown: 9.0
       car: 5.0
@@ -53,11 +43,6 @@
       pedestrian: 2.0
       animal: 2.0
       hazard: 2.0
-    pruning_static_object_speed: 1.38  # [m/s]
-    pruning_moving_object_speed: 5.5   # [m/s]
-    pruning_static_iou_threshold: 0.0  # [ratio]
-
-
 
     # debug parameters
     publish_processing_time: false

--- a/perception/autoware_multi_object_tracker/config/multi_object_tracker_node.param.yaml
+++ b/perception/autoware_multi_object_tracker/config/multi_object_tracker_node.param.yaml
@@ -25,12 +25,9 @@
       static_tracker:
         convert_polygon_to_bbox: true # convert POLYGON shape to BOUNDING_BOX at publish time
 
-    # tracker parameters
+    # pruning parameters
     min_known_object_removal_iou: 0.1  # [ratio]
     min_unknown_object_removal_iou: 0.001  # [ratio]
-
-    # pruning parameters
-    # generalized IoU threshold applied to all tracked classes
     pruning_generalized_iou_threshold: 0.1  # [ratio]
     pruning_distance_thresholds:
       unknown: 9.0

--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/association/scoring/redundancy_check.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/association/scoring/redundancy_check.hpp
@@ -21,13 +21,6 @@
 namespace autoware::multi_object_tracker
 {
 
-/// Interpolates the GIoU removal threshold based on the known partner's speed.
-/// Between static_object_speed and moving_object_speed the threshold is linearly interpolated
-/// from static_iou_threshold down to generalized_iou_threshold.
-double calcAdaptiveGIoUThreshold(
-  double object_speed, double generalized_iou_threshold, double static_object_speed,
-  double moving_object_speed, double static_iou_threshold);
-
 /// Returns true when source and target trackers are spatially redundant and should be merged.
 /// Handles four cases: pedestrian/pedestrian, known/known, known/unknown, unknown/unknown.
 bool isRedundant(

--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/configurations.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/configurations.hpp
@@ -79,7 +79,7 @@ struct PolygonTrackerConfig
 
 struct StaticTrackerConfig
 {
-  bool convert_polygon_to_bbox{true};
+  bool convert_polygon_to_bbox{false};
 };
 
 struct TrackerConfigs

--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/configurations.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/configurations.hpp
@@ -47,6 +47,7 @@ struct AssociationProfile
 };
 
 using LabelDoubleMap = std::unordered_map<classes::Label, double, EnumClassHash>;
+using LabelBoolMap = std::unordered_map<classes::Label, bool, EnumClassHash>;
 
 using ShapeLabelKey = std::pair<types::ShapeType, classes::Label>;
 struct ShapeLabelKeyHash
@@ -71,7 +72,15 @@ using ShapeLabelToTrackerTypeMap =
 struct PolygonTrackerConfig
 {
   bool enable_velocity_estimation{true};
-  bool enable_motion_output{false};
+  // Whether to publish estimated velocity, per object classification.
+  // A label absent from the map (or set false) means motion output is suppressed for that label.
+  LabelBoolMap enable_motion_output;
+
+  bool motionOutputEnabled(classes::Label label) const
+  {
+    const auto it = enable_motion_output.find(label);
+    return it != enable_motion_output.end() && it->second;
+  }
 };
 
 struct StaticTrackerConfig

--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/configurations.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/configurations.hpp
@@ -67,12 +67,27 @@ using AssociationMap = std::unordered_map<ShapeLabelKey, AssociationProfileMap, 
 using ShapeLabelToTrackerTypeMap =
   std::unordered_map<ShapeLabelKey, types::TrackerType, ShapeLabelKeyHash>;
 
+//// Per-tracker-type configuration (parallels tracker_profiles: keyed by tracker type)
+struct PolygonTrackerConfig
+{
+  bool enable_velocity_estimation{true};
+  bool enable_motion_output{false};
+};
+
+struct StaticTrackerConfig
+{
+  bool convert_polygon_to_bbox{true};
+};
+
+struct TrackerConfigs
+{
+  PolygonTrackerConfig polygon_tracker;
+  StaticTrackerConfig static_tracker;
+};
+
 //// Tracker creation (spawning, type mapping)
 struct TrackerCreationConfig
 {
-  bool enable_unknown_object_velocity_estimation{false};
-  bool enable_unknown_object_motion_output{false};
-
   ShapeLabelToTrackerTypeMap shape_tracker_map;
   std::unordered_set<ShapeLabelKey, ShapeLabelKeyHash> explicit_null_combos;
 

--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/configurations.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/configurations.hpp
@@ -75,12 +75,6 @@ struct PolygonTrackerConfig
   // Whether to publish estimated velocity, per object classification.
   // A label absent from the map (or set false) means motion output is suppressed for that label.
   LabelBoolMap enable_motion_output;
-
-  bool motionOutputEnabled(classes::Label label) const
-  {
-    const auto it = enable_motion_output.find(label);
-    return it != enable_motion_output.end() && it->second;
-  }
 };
 
 struct StaticTrackerConfig

--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/configurations.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/configurations.hpp
@@ -146,12 +146,9 @@ struct TrackerOverlapManagerConfig
 {
   float min_known_object_removal_iou{0.0f};
   float min_unknown_object_removal_iou{0.0f};
-  LabelDoubleMap pruning_giou_thresholds;
+  double pruning_giou_threshold{0.0};
   LabelDoubleMap pruning_distance_thresholds;
   LabelDoubleMap pruning_distance_thresholds_sq;
-  double pruning_static_object_speed{0.0};
-  double pruning_moving_object_speed{0.0};
-  double pruning_static_iou_threshold{0.0};
 };
 
 //// Utility: safe map lookup

--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/shape_model/static_shape_model.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/shape_model/static_shape_model.hpp
@@ -43,6 +43,9 @@ public:
   // Update ego position for polygon-to-bbox conversion
   void setEgoPose(const std::optional<geometry_msgs::msg::Point> & ego_pos) override;
 
+  // Enable/disable the publish-time POLYGON -> BOUNDING_BOX conversion
+  void setConvertPolygonToBbox(bool enable) { convert_polygon_to_bbox_ = enable; }
+
   // Write shape to output.
   // When to_publish is true and shape is POLYGON, convert to minimum-area BOUNDING_BOX if
   // ego_pos_ is available.
@@ -51,6 +54,7 @@ public:
 private:
   // shape_type_, dimensions, footprint_, area_ live in ShapeModelBase.
   std::optional<geometry_msgs::msg::Point> ego_pos_;
+  bool convert_polygon_to_bbox_{true};
 };
 
 }  // namespace autoware::multi_object_tracker

--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/trackers/polygon_tracker.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/trackers/polygon_tracker.hpp
@@ -46,6 +46,11 @@ private:
 
   bool updateKinematics(const types::DynamicObject & object);
 
+  // Continuously attenuate the published velocity by its direction-projected uncertainty
+  // (mirrors VehicleTracker): zero when too uncertain, unchanged when large enough, rescaling
+  // the 2D twist so the velocity direction is preserved.
+  void suppressUncertainVelocity(types::DynamicObject & object) const;
+
 public:
   PolygonTracker(
     const rclcpp::Time & time, const types::DynamicObject & object,

--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/trackers/polygon_tracker.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/trackers/polygon_tracker.hpp
@@ -15,6 +15,7 @@
 #ifndef AUTOWARE__MULTI_OBJECT_TRACKER__TRACKER__TRACKERS__POLYGON_TRACKER_HPP_
 #define AUTOWARE__MULTI_OBJECT_TRACKER__TRACKER__TRACKERS__POLYGON_TRACKER_HPP_
 
+#include "autoware/multi_object_tracker/configurations.hpp"
 #include "autoware/multi_object_tracker/object_model/object_model.hpp"
 #include "autoware/multi_object_tracker/tracker/motion_model/cv_motion_model.hpp"
 #include "autoware/multi_object_tracker/tracker/motion_model/static_motion_model.hpp"
@@ -47,7 +48,7 @@ private:
 public:
   PolygonTracker(
     const rclcpp::Time & time, const types::DynamicObject & object,
-    const bool enable_velocity_estimation, const bool enable_motion_output);
+    const PolygonTrackerConfig & config);
 
   bool predict(const rclcpp::Time & time) override;
   bool measure(

--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/trackers/polygon_tracker.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/trackers/polygon_tracker.hpp
@@ -37,7 +37,8 @@ private:
   StaticMotionModel static_motion_model_;
 
   bool enable_velocity_estimation_;
-  bool enable_motion_output_;
+  // Per-label motion-output gate, evaluated at publish time against the track's current label.
+  LabelBoolMap enable_motion_output_;
 
   geometry_msgs::msg::Pose last_pose_;
 

--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/trackers/static_tracker.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/trackers/static_tracker.hpp
@@ -15,6 +15,7 @@
 #ifndef AUTOWARE__MULTI_OBJECT_TRACKER__TRACKER__TRACKERS__STATIC_TRACKER_HPP_
 #define AUTOWARE__MULTI_OBJECT_TRACKER__TRACKER__TRACKERS__STATIC_TRACKER_HPP_
 
+#include "autoware/multi_object_tracker/configurations.hpp"
 #include "autoware/multi_object_tracker/object_model/object_model.hpp"
 #include "autoware/multi_object_tracker/tracker/motion_model/static_motion_model.hpp"
 #include "autoware/multi_object_tracker/tracker/shape_model/static_shape_model.hpp"
@@ -36,7 +37,9 @@ private:
   bool updateKinematics(const types::DynamicObject & object);
 
 public:
-  StaticTracker(const rclcpp::Time & time, const types::DynamicObject & object);
+  StaticTracker(
+    const rclcpp::Time & time, const types::DynamicObject & object,
+    const StaticTrackerConfig & config);
 
   // setEgoPose() is handled by the base via getShapeModel().setEgoPose().
 

--- a/perception/autoware_multi_object_tracker/lib/association/scoring/redundancy_check.cpp
+++ b/perception/autoware_multi_object_tracker/lib/association/scoring/redundancy_check.cpp
@@ -16,31 +16,8 @@
 
 #include "autoware/multi_object_tracker/object_model/shapes.hpp"
 
-#include <cmath>
-
 namespace autoware::multi_object_tracker
 {
-
-double calcAdaptiveGIoUThreshold(
-  const double object_speed, const double generalized_iou_threshold,
-  const double static_object_speed, const double moving_object_speed,
-  const double static_iou_threshold)
-{
-  // If the threshold is already larger than static threshold, just return it
-  if (generalized_iou_threshold > static_iou_threshold) {
-    return generalized_iou_threshold;
-  }
-  if (object_speed >= moving_object_speed) {
-    return generalized_iou_threshold;
-  }
-  if (object_speed > static_object_speed) {
-    // Linear interpolation between static and moving thresholds
-    const double speed_ratio =
-      (object_speed - static_object_speed) / (moving_object_speed - static_object_speed);
-    return static_iou_threshold + speed_ratio * (generalized_iou_threshold - static_iou_threshold);
-  }
-  return static_iou_threshold;
-}
 
 bool isRedundant(
   const types::DynamicObject & source_object, const types::DynamicObject & target_object,
@@ -53,12 +30,7 @@ bool isRedundant(
   constexpr double precision_threshold = 0.;
   constexpr double recall_threshold = 0.5;
 
-  const auto generalized_iou_threshold_opt =
-    get_map_value_if_exists(config.pruning_giou_thresholds, source_label);
-  if (!generalized_iou_threshold_opt) {
-    return false;
-  }
-  const double generalized_iou_threshold = generalized_iou_threshold_opt->get();
+  const double generalized_iou_threshold = config.pruning_giou_threshold;
 
   const bool is_pedestrian =
     (source_label == classes::Label::PEDESTRIAN && target_label == classes::Label::PEDESTRIAN);
@@ -99,16 +71,8 @@ bool isRedundant(
           source_object, target_object, precision, recall, generalized_iou)) {
       return false;
     }
-    // Adjust threshold based on known partner's speed and static/moving status
-    const double known_object_speed =
-      is_target_known ? std::hypot(target_object.twist.linear.x, target_object.twist.linear.y)
-                      : std::hypot(source_object.twist.linear.x, source_object.twist.linear.y);
-    const double adaptive_threshold = calcAdaptiveGIoUThreshold(
-      known_object_speed, generalized_iou_threshold, config.pruning_static_object_speed,
-      config.pruning_moving_object_speed, config.pruning_static_iou_threshold);
-    return (
-      precision > precision_threshold || recall > recall_threshold ||
-      generalized_iou > adaptive_threshold);
+    // Any overlap (precision > 0) or a majority-covered target marks the unknown as redundant.
+    return precision > precision_threshold || recall > recall_threshold;
   } else {
     // Both are unknown: use generalized IoU
     double iou = shapes::get2dGeneralizedIoU(source_object, target_object);

--- a/perception/autoware_multi_object_tracker/lib/tracker/shape_model/static_shape_model.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/shape_model/static_shape_model.cpp
@@ -46,7 +46,9 @@ void StaticShapeModel::exportTo(types::DynamicObject & output, bool to_publish) 
   output.shape = assembleShapeMsg();
   output.area = area_;
 
-  if (to_publish && shape_type_ == autoware_perception_msgs::msg::Shape::POLYGON) {
+  if (
+    to_publish && convert_polygon_to_bbox_ &&
+    shape_type_ == autoware_perception_msgs::msg::Shape::POLYGON) {
     types::DynamicObject converted;
     if (shapes::convertConvexHullToBoundingBox(output, converted, ego_pos_)) {
       output.pose = converted.pose;

--- a/perception/autoware_multi_object_tracker/lib/tracker/trackers/pedestrian_tracker.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/trackers/pedestrian_tracker.cpp
@@ -164,8 +164,9 @@ bool PedestrianTracker::getTrackedObject(
     constexpr double vel_too_low_ignore = 0.35;
     const double vel_long = std::abs(twist.linear.x);
     if (vel_long > vel_too_low_ignore) {
-      const double vel_limit =
-        std::max(std::sqrt(object.twist_covariance[XYZRPY_COV_IDX::X_X]) - vel_cov_buffer, 0.0);
+      const double vel_limit = std::max(
+        std::sqrt(std::max(0.0, object.twist_covariance[XYZRPY_COV_IDX::X_X])) - vel_cov_buffer,
+        0.0);
 
       if (vel_long < vel_limit) {
         twist.linear.x = twist.linear.x > 0 ? vel_too_low_ignore : -vel_too_low_ignore;

--- a/perception/autoware_multi_object_tracker/lib/tracker/trackers/polygon_tracker.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/trackers/polygon_tracker.cpp
@@ -21,6 +21,7 @@
 #include <autoware_utils_math/unit_conversion.hpp>
 #include <tf2/utils.hpp>
 
+#include <algorithm>
 #include <cmath>
 
 namespace autoware::multi_object_tracker
@@ -242,10 +243,46 @@ bool PolygonTracker::getTrackedObject(
     if (!motion_output_enabled) {
       object.twist.linear.x = 0.0;
       object.twist.linear.y = 0.0;
+    } else {
+      suppressUncertainVelocity(object);
     }
   }
 
   return true;
+}
+
+void PolygonTracker::suppressUncertainVelocity(types::DynamicObject & object) const
+{
+  using autoware_utils_geometry::xyzrpy_covariance_index::XYZRPY_COV_IDX;
+  auto & twist = object.twist;
+  constexpr double vel_cov_buffer = 0.7;
+
+  const double vx = twist.linear.x;
+  const double vy = twist.linear.y;
+  const double speed = std::hypot(vx, vy);  // absolute velocity (rotation-invariant)
+  if (speed <= 0.0) {
+    return;
+  }
+
+  // Velocity uncertainty (std-dev) projected onto the velocity direction. Reduces to the
+  // longitudinal std-dev used by VehicleTracker when the lateral component is zero.
+  const double sxx = object.twist_covariance[XYZRPY_COV_IDX::X_X];
+  const double syy = object.twist_covariance[XYZRPY_COV_IDX::Y_Y];
+  const double sxy = object.twist_covariance[XYZRPY_COV_IDX::X_Y];
+  const double dir_stddev =
+    std::sqrt((vx * vx * sxx + 2.0 * vx * vy * sxy + vy * vy * syy) / (speed * speed));
+
+  const double vel_limit = dir_stddev - vel_cov_buffer;
+  if (vel_limit <= 0.0) {
+    return;  // uncertainty within the buffer -> velocity is trustworthy, export as is
+  }
+
+  // Continuous gain in [0, 1]: 0 when speed <= vel_limit (too uncertain -> zero), ramps linearly,
+  // and reaches 1 when speed >= 2 * vel_limit (large enough -> export as is). Applying the same
+  // gain to both components rescales the magnitude while preserving the velocity direction.
+  const double gain = std::clamp((speed - vel_limit) / vel_limit, 0.0, 1.0);
+  twist.linear.x = vx * gain;
+  twist.linear.y = vy * gain;
 }
 
 }  // namespace autoware::multi_object_tracker

--- a/perception/autoware_multi_object_tracker/lib/tracker/trackers/polygon_tracker.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/trackers/polygon_tracker.cpp
@@ -255,7 +255,7 @@ void PolygonTracker::suppressUncertainVelocity(types::DynamicObject & object) co
 {
   using autoware_utils_geometry::xyzrpy_covariance_index::XYZRPY_COV_IDX;
   auto & twist = object.twist;
-  constexpr double vel_cov_buffer = 0.7;
+  constexpr double vel_cov_buffer = 0.3;
 
   const double vx = twist.linear.x;
   const double vy = twist.linear.y;

--- a/perception/autoware_multi_object_tracker/lib/tracker/trackers/polygon_tracker.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/trackers/polygon_tracker.cpp
@@ -234,7 +234,12 @@ bool PolygonTracker::getTrackedObject(
 
   if (to_publish) {
     object.pose = last_pose_;
-    if (!enable_motion_output_) {
+    // Gate motion output on the track's current classification (object.classification was
+    // populated above by populateKinematicObject). Absent/false label => suppress velocity.
+    const auto label = classes::getHighestProbLabel(object.classification);
+    const auto it = enable_motion_output_.find(label);
+    const bool motion_output_enabled = it != enable_motion_output_.end() && it->second;
+    if (!motion_output_enabled) {
       object.twist.linear.x = 0.0;
       object.twist.linear.y = 0.0;
     }

--- a/perception/autoware_multi_object_tracker/lib/tracker/trackers/polygon_tracker.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/trackers/polygon_tracker.cpp
@@ -28,11 +28,11 @@ namespace autoware::multi_object_tracker
 
 PolygonTracker::PolygonTracker(
   const rclcpp::Time & time, const types::DynamicObject & object,
-  const bool enable_velocity_estimation, const bool enable_motion_output)
+  const PolygonTrackerConfig & config)
 : Tracker(time, object),
   logger_(rclcpp::get_logger("PolygonTracker")),
-  enable_velocity_estimation_(enable_velocity_estimation),
-  enable_motion_output_(enable_motion_output)
+  enable_velocity_estimation_(config.enable_velocity_estimation),
+  enable_motion_output_(config.enable_motion_output)
 {
   tracker_type_ = TrackerType::POLYGON;
   shape_model_.init(object);

--- a/perception/autoware_multi_object_tracker/lib/tracker/trackers/polygon_tracker.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/trackers/polygon_tracker.cpp
@@ -269,8 +269,8 @@ void PolygonTracker::suppressUncertainVelocity(types::DynamicObject & object) co
   const double sxx = object.twist_covariance[XYZRPY_COV_IDX::X_X];
   const double syy = object.twist_covariance[XYZRPY_COV_IDX::Y_Y];
   const double sxy = object.twist_covariance[XYZRPY_COV_IDX::X_Y];
-  const double dir_stddev =
-    std::sqrt((vx * vx * sxx + 2.0 * vx * vy * sxy + vy * vy * syy) / (speed * speed));
+  const double dir_var = (vx * vx * sxx + 2.0 * vx * vy * sxy + vy * vy * syy) / (speed * speed);
+  const double dir_stddev = std::sqrt(std::max(0.0, dir_var));
 
   const double vel_limit = dir_stddev - vel_cov_buffer;
   if (vel_limit <= 0.0) {

--- a/perception/autoware_multi_object_tracker/lib/tracker/trackers/static_tracker.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/trackers/static_tracker.cpp
@@ -21,10 +21,13 @@
 namespace autoware::multi_object_tracker
 {
 
-StaticTracker::StaticTracker(const rclcpp::Time & time, const types::DynamicObject & object)
+StaticTracker::StaticTracker(
+  const rclcpp::Time & time, const types::DynamicObject & object,
+  const StaticTrackerConfig & config)
 : Tracker(time, object), logger_(rclcpp::get_logger("StaticTracker"))
 {
   tracker_type_ = TrackerType::STATIC;
+  shape_model_.setConvertPolygonToBbox(config.convert_polygon_to_bbox);
   shape_model_.init(object);
 
   // Set motion model parameters

--- a/perception/autoware_multi_object_tracker/lib/tracker/trackers/vehicle_tracker.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/trackers/vehicle_tracker.cpp
@@ -281,13 +281,13 @@ bool VehicleTracker::getTrackedObject(
 
   if (to_publish) {
     using autoware_utils_geometry::xyzrpy_covariance_index::XYZRPY_COV_IDX;
-    auto & twist = object.twist;
     constexpr double vel_cov_buffer = 0.7;
     const double vel_limit =
       std::sqrt(object.twist_covariance[XYZRPY_COV_IDX::X_X]) - vel_cov_buffer;
     if (vel_limit > 0.0) {
       // Continuous gain in [0, 1]: 0 when |v| <= vel_limit (too uncertain -> zero), ramps
       // linearly, and reaches 1 when |v| >= 2 * vel_limit (large enough -> export as is).
+      auto & twist = object.twist;
       const double gain = std::clamp((std::abs(twist.linear.x) - vel_limit) / vel_limit, 0.0, 1.0);
       twist.linear.x *= gain;
     }

--- a/perception/autoware_multi_object_tracker/lib/tracker/trackers/vehicle_tracker.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/trackers/vehicle_tracker.cpp
@@ -283,20 +283,15 @@ bool VehicleTracker::getTrackedObject(
     using autoware_utils_geometry::xyzrpy_covariance_index::XYZRPY_COV_IDX;
     auto & twist = object.twist;
     constexpr double vel_cov_buffer = 0.7;
-    constexpr double vel_too_low_ignore = 0.25;
-    const double vel_long = std::abs(twist.linear.x);
-    if (vel_long > vel_too_low_ignore) {
-      const double vel_limit =
-        std::max(std::sqrt(object.twist_covariance[XYZRPY_COV_IDX::X_X]) - vel_cov_buffer, 0.0);
-
-      if (vel_long < vel_limit) {
-        twist.linear.x = twist.linear.x > 0 ? vel_too_low_ignore : -vel_too_low_ignore;
-      } else {
-        double vel_suppressed = vel_long - vel_limit;
-        vel_suppressed = std::max(vel_suppressed, vel_too_low_ignore);
-        twist.linear.x = twist.linear.x > 0 ? vel_suppressed : -vel_suppressed;
-      }
+    const double vel_limit =
+      std::sqrt(object.twist_covariance[XYZRPY_COV_IDX::X_X]) - vel_cov_buffer;
+    if (vel_limit > 0.0) {
+      // Continuous gain in [0, 1]: 0 when |v| <= vel_limit (too uncertain -> zero), ramps
+      // linearly, and reaches 1 when |v| >= 2 * vel_limit (large enough -> export as is).
+      const double gain = std::clamp((std::abs(twist.linear.x) - vel_limit) / vel_limit, 0.0, 1.0);
+      twist.linear.x *= gain;
     }
+    // vel_limit <= 0: uncertainty within the buffer -> velocity is trustworthy, export as is.
   }
 
   return true;

--- a/perception/autoware_multi_object_tracker/lib/tracker/trackers/vehicle_tracker.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/trackers/vehicle_tracker.cpp
@@ -283,7 +283,7 @@ bool VehicleTracker::getTrackedObject(
     using autoware_utils_geometry::xyzrpy_covariance_index::XYZRPY_COV_IDX;
     constexpr double vel_cov_buffer = 0.7;
     const double vel_limit =
-      std::sqrt(object.twist_covariance[XYZRPY_COV_IDX::X_X]) - vel_cov_buffer;
+      std::sqrt(std::max(0.0, object.twist_covariance[XYZRPY_COV_IDX::X_X])) - vel_cov_buffer;
     if (vel_limit > 0.0) {
       // Continuous gain in [0, 1]: 0 when |v| <= vel_limit (too uncertain -> zero), ramps
       // linearly, and reaches 1 when |v| >= 2 * vel_limit (large enough -> export as is).

--- a/perception/autoware_multi_object_tracker/schema/multi_object_tracker_node.schema.json
+++ b/perception/autoware_multi_object_tracker/schema/multi_object_tracker_node.schema.json
@@ -159,16 +159,6 @@
           "description": "If True, consider odometry uncertainty in tracking.",
           "default": false
         },
-        "enable_unknown_object_velocity_estimation": {
-          "type": "boolean",
-          "description": "If True, enable velocity estimation for unknown objects.",
-          "default": true
-        },
-        "enable_unknown_object_motion_output": {
-          "type": "boolean",
-          "description": "If True, export unknown object velocity.",
-          "default": false
-        },
         "min_known_object_removal_iou": {
           "type": "number",
           "description": "Minimum IOU between associated objects with known label to remove younger tracker.",
@@ -271,8 +261,6 @@
         "ego_frame_id",
         "enable_delay_compensation",
         "consider_odometry_uncertainty",
-        "enable_unknown_object_velocity_estimation",
-        "enable_unknown_object_motion_output",
         "min_known_object_removal_iou",
         "min_unknown_object_removal_iou",
         "pruning_generalized_iou_thresholds",

--- a/perception/autoware_multi_object_tracker/schema/multi_object_tracker_node.schema.json
+++ b/perception/autoware_multi_object_tracker/schema/multi_object_tracker_node.schema.json
@@ -118,7 +118,7 @@
             "convert_polygon_to_bbox": {
               "type": "boolean",
               "description": "Convert POLYGON shape to BOUNDING_BOX at publish time.",
-              "default": true
+              "default": false
             }
           },
           "required": ["convert_polygon_to_bbox"]

--- a/perception/autoware_multi_object_tracker/schema/multi_object_tracker_node.schema.json
+++ b/perception/autoware_multi_object_tracker/schema/multi_object_tracker_node.schema.json
@@ -3,75 +3,6 @@
   "title": "Parameters for Multi Object Tracker Node",
   "type": "object",
   "definitions": {
-    "pruning_generalized_iou_thresholds": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "unknown": {
-          "type": "number",
-          "minimum": -1.0,
-          "maximum": 1.0
-        },
-        "car": {
-          "type": "number",
-          "minimum": -1.0,
-          "maximum": 1.0
-        },
-        "truck": {
-          "type": "number",
-          "minimum": -1.0,
-          "maximum": 1.0
-        },
-        "bus": {
-          "type": "number",
-          "minimum": -1.0,
-          "maximum": 1.0
-        },
-        "trailer": {
-          "type": "number",
-          "minimum": -1.0,
-          "maximum": 1.0
-        },
-        "motorcycle": {
-          "type": "number",
-          "minimum": -1.0,
-          "maximum": 1.0
-        },
-        "bicycle": {
-          "type": "number",
-          "minimum": -1.0,
-          "maximum": 1.0
-        },
-        "pedestrian": {
-          "type": "number",
-          "minimum": -1.0,
-          "maximum": 1.0
-        },
-        "animal": {
-          "type": "number",
-          "minimum": -1.0,
-          "maximum": 1.0
-        },
-        "hazard": {
-          "type": "number",
-          "minimum": -1.0,
-          "maximum": 1.0
-        }
-      },
-      "required": [
-        "unknown",
-        "car",
-        "truck",
-        "bus",
-        "trailer",
-        "motorcycle",
-        "bicycle",
-        "pedestrian",
-        "animal",
-        "hazard"
-      ],
-      "description": "Generalized IoU threshold for each tracked class."
-    },
     "pruning_distance_thresholds": {
       "type": "object",
       "additionalProperties": false,
@@ -236,20 +167,12 @@
           "description": "Minimum IOU between associated objects with unknown label to remove unknown tracker.",
           "default": 0.001
         },
-        "pruning_generalized_iou_thresholds": {
-          "$ref": "#/definitions/pruning_generalized_iou_thresholds",
-          "default": {
-            "unknown": 0.1,
-            "car": 0.1,
-            "truck": 0.1,
-            "bus": 0.1,
-            "trailer": 0.1,
-            "motorcycle": 0.1,
-            "bicycle": 0.1,
-            "pedestrian": 0.1,
-            "animal": 0.1,
-            "hazard": 0.1
-          }
+        "pruning_generalized_iou_threshold": {
+          "type": "number",
+          "minimum": -1.0,
+          "maximum": 1.0,
+          "description": "Generalized IoU threshold applied to all tracked classes.",
+          "default": 0.1
         },
         "pruning_distance_thresholds": {
           "$ref": "#/definitions/pruning_distance_thresholds",
@@ -265,21 +188,6 @@
             "animal": 2.0,
             "hazard": 2.0
           }
-        },
-        "pruning_static_object_speed": {
-          "type": "number",
-          "description": "Speed threshold to consider an object as static. Below this speed, nearby unknown objects should always be detected.",
-          "default": 1.38
-        },
-        "pruning_moving_object_speed": {
-          "type": "number",
-          "description": "Speed threshold to consider an object as moving. Above this speed, nearby unknown objects should always be merged to avoid false unknown detections.",
-          "default": 5.5
-        },
-        "pruning_static_iou_threshold": {
-          "type": "number",
-          "description": "Generalized IoU threshold for a static object.",
-          "default": 0.0
         },
         "publish_processing_time": {
           "type": "boolean",
@@ -331,11 +239,8 @@
         "tracker_configs",
         "min_known_object_removal_iou",
         "min_unknown_object_removal_iou",
-        "pruning_generalized_iou_thresholds",
+        "pruning_generalized_iou_threshold",
         "pruning_distance_thresholds",
-        "pruning_static_object_speed",
-        "pruning_moving_object_speed",
-        "pruning_static_iou_threshold",
         "publish_processing_time",
         "publish_processing_time_detail",
         "publish_tentative_objects",

--- a/perception/autoware_multi_object_tracker/schema/multi_object_tracker_node.schema.json
+++ b/perception/autoware_multi_object_tracker/schema/multi_object_tracker_node.schema.json
@@ -131,6 +131,70 @@
       ],
       "description": "Overlap distance threshold for each tracked class."
     },
+    "enable_motion_output": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "unknown": { "type": "boolean" },
+        "car": { "type": "boolean" },
+        "truck": { "type": "boolean" },
+        "bus": { "type": "boolean" },
+        "trailer": { "type": "boolean" },
+        "motorcycle": { "type": "boolean" },
+        "bicycle": { "type": "boolean" },
+        "pedestrian": { "type": "boolean" },
+        "animal": { "type": "boolean" },
+        "hazard": { "type": "boolean" }
+      },
+      "required": [
+        "unknown",
+        "car",
+        "truck",
+        "bus",
+        "trailer",
+        "motorcycle",
+        "bicycle",
+        "pedestrian",
+        "animal",
+        "hazard"
+      ],
+      "description": "Whether to publish estimated velocity on polygon tracks, per classification."
+    },
+    "tracker_configs": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Per-tracker-type configuration: behavior knobs scoped to a single tracker type.",
+      "properties": {
+        "polygon_tracker": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enable_velocity_estimation": {
+              "type": "boolean",
+              "description": "Estimate velocity for polygon tracks.",
+              "default": true
+            },
+            "enable_motion_output": {
+              "$ref": "#/definitions/enable_motion_output"
+            }
+          },
+          "required": ["enable_velocity_estimation", "enable_motion_output"]
+        },
+        "static_tracker": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "convert_polygon_to_bbox": {
+              "type": "boolean",
+              "description": "Convert POLYGON shape to BOUNDING_BOX at publish time.",
+              "default": true
+            }
+          },
+          "required": ["convert_polygon_to_bbox"]
+        }
+      },
+      "required": ["polygon_tracker", "static_tracker"]
+    },
     "multi_object_tracker_node": {
       "type": "object",
       "properties": {
@@ -158,6 +222,9 @@
           "type": "boolean",
           "description": "If True, consider odometry uncertainty in tracking.",
           "default": false
+        },
+        "tracker_configs": {
+          "$ref": "#/definitions/tracker_configs"
         },
         "min_known_object_removal_iou": {
           "type": "number",
@@ -261,6 +328,7 @@
         "ego_frame_id",
         "enable_delay_compensation",
         "consider_odometry_uncertainty",
+        "tracker_configs",
         "min_known_object_removal_iou",
         "min_unknown_object_removal_iou",
         "pruning_generalized_iou_thresholds",

--- a/perception/autoware_multi_object_tracker/src/multi_object_tracker_core.cpp
+++ b/perception/autoware_multi_object_tracker/src/multi_object_tracker_core.cpp
@@ -49,8 +49,9 @@ void MultiObjectTrackerInternalState::init(
 
   // Initialize processor
   processor = std::make_unique<TrackerProcessor>(
-    params.creation_config, params.association_config, params.tracker_overlap_manager_config,
-    params.input_channels_config, node.get_logger(), node.get_clock());
+    params.tracker_configs, params.creation_config, params.association_config,
+    params.tracker_overlap_manager_config, params.input_channels_config, node.get_logger(),
+    node.get_clock());
 
   last_publish_time = node.now();
   last_updated_time = node.now();

--- a/perception/autoware_multi_object_tracker/src/multi_object_tracker_core.hpp
+++ b/perception/autoware_multi_object_tracker/src/multi_object_tracker_core.hpp
@@ -55,6 +55,7 @@ struct MultiObjectTrackerParameters
   std::vector<types::InputChannel> input_channels_config;
 
   // Induced parameters
+  TrackerConfigs tracker_configs;
   TrackerCreationConfig creation_config;
   TrackerAssociationConfig association_config;
   TrackerOverlapManagerConfig tracker_overlap_manager_config;

--- a/perception/autoware_multi_object_tracker/src/multi_object_tracker_node.cpp
+++ b/perception/autoware_multi_object_tracker/src/multi_object_tracker_node.cpp
@@ -223,14 +223,8 @@ MultiObjectTracker::MultiObjectTracker(const rclcpp::NodeOptions & node_options)
   };
 
   // pruning parameters
-  params_.tracker_overlap_manager_config.pruning_giou_thresholds =
-    parse_label_double_map("pruning_generalized_iou_thresholds");
-  params_.tracker_overlap_manager_config.pruning_static_object_speed =
-    declare_parameter<double>("pruning_static_object_speed");
-  params_.tracker_overlap_manager_config.pruning_moving_object_speed =
-    declare_parameter<double>("pruning_moving_object_speed");
-  params_.tracker_overlap_manager_config.pruning_static_iou_threshold =
-    declare_parameter<double>("pruning_static_iou_threshold");
+  params_.tracker_overlap_manager_config.pruning_giou_threshold =
+    declare_parameter<double>("pruning_generalized_iou_threshold");
 
   params_.tracker_overlap_manager_config.pruning_distance_thresholds =
     parse_label_double_map("pruning_distance_thresholds");

--- a/perception/autoware_multi_object_tracker/src/multi_object_tracker_node.cpp
+++ b/perception/autoware_multi_object_tracker/src/multi_object_tracker_node.cpp
@@ -238,10 +238,13 @@ MultiObjectTracker::MultiObjectTracker(const rclcpp::NodeOptions & node_options)
        params_.tracker_overlap_manager_config.pruning_distance_thresholds) {
     params_.tracker_overlap_manager_config.pruning_distance_thresholds_sq[label] = dist * dist;
   }
-  params_.creation_config.enable_unknown_object_velocity_estimation =
-    declare_parameter<bool>("enable_unknown_object_velocity_estimation");
-  params_.creation_config.enable_unknown_object_motion_output =
-    declare_parameter<bool>("enable_unknown_object_motion_output");
+  // Per-tracker-type configuration (tracker_configs.<tracker>.<member>)
+  params_.tracker_configs.polygon_tracker.enable_velocity_estimation =
+    declare_parameter<bool>("tracker_configs.polygon_tracker.enable_velocity_estimation");
+  params_.tracker_configs.polygon_tracker.enable_motion_output =
+    declare_parameter<bool>("tracker_configs.polygon_tracker.enable_motion_output");
+  params_.tracker_configs.static_tracker.convert_polygon_to_bbox =
+    declare_parameter<bool>("tracker_configs.static_tracker.convert_polygon_to_bbox");
 
   // Set the unknown-unknown association GIoU threshold
   params_.association_config.unknown_association_giou_threshold =

--- a/perception/autoware_multi_object_tracker/src/multi_object_tracker_node.cpp
+++ b/perception/autoware_multi_object_tracker/src/multi_object_tracker_node.cpp
@@ -241,8 +241,10 @@ MultiObjectTracker::MultiObjectTracker(const rclcpp::NodeOptions & node_options)
   // Per-tracker-type configuration (tracker_configs.<tracker>.<member>)
   params_.tracker_configs.polygon_tracker.enable_velocity_estimation =
     declare_parameter<bool>("tracker_configs.polygon_tracker.enable_velocity_estimation");
-  params_.tracker_configs.polygon_tracker.enable_motion_output =
-    declare_parameter<bool>("tracker_configs.polygon_tracker.enable_motion_output");
+  for (const auto label : classes::trackedLabels()) {
+    params_.tracker_configs.polygon_tracker.enable_motion_output[label] = declare_parameter<bool>(
+      "tracker_configs.polygon_tracker.enable_motion_output." + classes::toString(label));
+  }
   params_.tracker_configs.static_tracker.convert_polygon_to_bbox =
     declare_parameter<bool>("tracker_configs.static_tracker.convert_polygon_to_bbox");
 

--- a/perception/autoware_multi_object_tracker/src/processor/processor.cpp
+++ b/perception/autoware_multi_object_tracker/src/processor/processor.cpp
@@ -41,12 +41,13 @@ namespace autoware::multi_object_tracker
 using autoware_utils_debug::ScopedTimeTrack;
 
 TrackerProcessor::TrackerProcessor(
-  const TrackerCreationConfig & creation_config,
+  const TrackerConfigs & tracker_configs, const TrackerCreationConfig & creation_config,
   const TrackerAssociationConfig & association_config,
   const TrackerOverlapManagerConfig & tracker_overlap_manager_config,
   const std::vector<types::InputChannel> & channels_config, const rclcpp::Logger & logger,
   rclcpp::Clock::SharedPtr clock)
-: creation_config_(creation_config),
+: tracker_configs_(tracker_configs),
+  creation_config_(creation_config),
   channels_config_(channels_config),
   logger_(logger),
   clock_(std::move(clock))
@@ -186,15 +187,11 @@ std::shared_ptr<Tracker> TrackerProcessor::createNewTracker(
       case types::TrackerType::BIG_VEHICLE:
         return std::make_shared<VehicleTracker>(object_model::big_vehicle, time, object);
       case types::TrackerType::STATIC:
-        return std::make_shared<StaticTracker>(time, object);
+        return std::make_shared<StaticTracker>(time, object, tracker_configs_.static_tracker);
       case types::TrackerType::POLYGON:
-        return std::make_shared<PolygonTracker>(
-          time, object, creation_config_.enable_unknown_object_velocity_estimation,
-          creation_config_.enable_unknown_object_motion_output);
+        return std::make_shared<PolygonTracker>(time, object, tracker_configs_.polygon_tracker);
       default:
-        return std::make_shared<PolygonTracker>(
-          time, object, creation_config_.enable_unknown_object_velocity_estimation,
-          creation_config_.enable_unknown_object_motion_output);
+        return std::make_shared<PolygonTracker>(time, object, tracker_configs_.polygon_tracker);
     }
   }
 

--- a/perception/autoware_multi_object_tracker/src/processor/processor.hpp
+++ b/perception/autoware_multi_object_tracker/src/processor/processor.hpp
@@ -40,7 +40,7 @@ class TrackerProcessor
 {
 public:
   TrackerProcessor(
-    const TrackerCreationConfig & creation_config,
+    const TrackerConfigs & tracker_configs, const TrackerCreationConfig & creation_config,
     const TrackerAssociationConfig & association_config,
     const TrackerOverlapManagerConfig & tracker_overlap_manager_config,
     const std::vector<types::InputChannel> & channels_config, const rclcpp::Logger & logger,
@@ -70,6 +70,7 @@ public:
   void setTimeKeeper(std::shared_ptr<autoware_utils_debug::TimeKeeper> time_keeper_ptr);
 
 private:
+  const TrackerConfigs tracker_configs_;
   const TrackerCreationConfig creation_config_;
   const std::vector<types::InputChannel> & channels_config_;
 

--- a/perception/autoware_multi_object_tracker/test/test_bench.cpp
+++ b/perception/autoware_multi_object_tracker/test/test_bench.cpp
@@ -27,6 +27,14 @@
 #include <vector>
 
 // Configuration creation functions
+autoware::multi_object_tracker::TrackerConfigs createTrackerConfigs()
+{
+  autoware::multi_object_tracker::TrackerConfigs config;
+  config.polygon_tracker.enable_velocity_estimation = false;
+  config.polygon_tracker.enable_motion_output = false;
+  return config;
+}
+
 autoware::multi_object_tracker::TrackerCreationConfig createTrackerCreationConfig()
 {
   autoware::multi_object_tracker::TrackerCreationConfig config;
@@ -43,9 +51,6 @@ autoware::multi_object_tracker::TrackerCreationConfig createTrackerCreationConfi
     config.setCreation(shape_type, Label::BICYCLE, TrackerType::PEDESTRIAN_AND_BICYCLE);
     config.setCreation(shape_type, Label::MOTORCYCLE, TrackerType::PEDESTRIAN_AND_BICYCLE);
   }
-
-  config.enable_unknown_object_velocity_estimation = false;
-  config.enable_unknown_object_motion_output = false;
 
   return config;
 }

--- a/perception/autoware_multi_object_tracker/test/test_bench.cpp
+++ b/perception/autoware_multi_object_tracker/test/test_bench.cpp
@@ -31,7 +31,7 @@ autoware::multi_object_tracker::TrackerConfigs createTrackerConfigs()
 {
   autoware::multi_object_tracker::TrackerConfigs config;
   config.polygon_tracker.enable_velocity_estimation = false;
-  config.polygon_tracker.enable_motion_output = false;
+  // enable_motion_output left empty => motion output disabled for all labels
   return config;
 }
 

--- a/perception/autoware_multi_object_tracker/test/test_bench.cpp
+++ b/perception/autoware_multi_object_tracker/test/test_bench.cpp
@@ -173,14 +173,7 @@ autoware::multi_object_tracker::TrackerOverlapManagerConfig createTrackerOverlap
   config.min_known_object_removal_iou = 0.1;      // [ratio]
   config.min_unknown_object_removal_iou = 0.001;  // [ratio]
 
-  config.pruning_giou_thresholds = {{Label::UNKNOWN, -0.3}, {Label::CAR, -0.4},
-                                    {Label::TRUCK, -0.6},   {Label::BUS, -0.6},
-                                    {Label::TRAILER, -0.6}, {Label::MOTORCYCLE, -0.1},
-                                    {Label::BICYCLE, -0.1}, {Label::PEDESTRIAN, -0.1}};
-
-  config.pruning_moving_object_speed = 5.5;   // [m/s]
-  config.pruning_static_object_speed = 1.38;  // [m/s]
-  config.pruning_static_iou_threshold = 0.0;  // [ratio]
+  config.pruning_giou_threshold = -0.3;  // [ratio]
 
   config.pruning_distance_thresholds = {{Label::UNKNOWN, 9.0}, {Label::CAR, 5.0},
                                         {Label::TRUCK, 9.0},   {Label::BUS, 9.0},

--- a/perception/autoware_multi_object_tracker/test/test_bench.hpp
+++ b/perception/autoware_multi_object_tracker/test/test_bench.hpp
@@ -133,6 +133,7 @@ struct ScenarioParams
 };
 
 // Configuration creation functions
+autoware::multi_object_tracker::TrackerConfigs createTrackerConfigs();
 autoware::multi_object_tracker::TrackerCreationConfig createTrackerCreationConfig();
 autoware::multi_object_tracker::TrackerAssociationConfig createTrackerAssociationConfig();
 autoware::multi_object_tracker::TrackerOverlapManagerConfig createTrackerOverlapManagerConfig();

--- a/perception/autoware_multi_object_tracker/test/test_multi_object_tracker.cpp
+++ b/perception/autoware_multi_object_tracker/test/test_multi_object_tracker.cpp
@@ -63,13 +63,14 @@ FunctionTimings runIterationsAssociation(
 {
   RosbagWriterHelper writer(write_bag);
 
+  const auto tracker_configs = createTrackerConfigs();
   const auto creation_config = createTrackerCreationConfig();
   const auto association_config = createTrackerAssociationConfig();
   const auto overlap_config = createTrackerOverlapManagerConfig();
   const auto input_channels_config = createInputChannelsConfig();
 
   auto processor = std::make_unique<autoware::multi_object_tracker::TrackerProcessor>(
-    creation_config, association_config, overlap_config, input_channels_config,
+    tracker_configs, creation_config, association_config, overlap_config, input_channels_config,
     rclcpp::get_logger("test_multi_object_tracker"),
     std::make_shared<rclcpp::Clock>(RCL_STEADY_TIME));
   // TestBenchAssociation by default.
@@ -156,13 +157,14 @@ FunctionTimings runIterations(
 {
   RosbagWriterHelper writer(write_bag);
 
+  const auto tracker_configs = createTrackerConfigs();
   const auto creation_config = createTrackerCreationConfig();
   const auto association_config = createTrackerAssociationConfig();
   const auto overlap_config = createTrackerOverlapManagerConfig();
   const auto input_channels_config = createInputChannelsConfig();
 
   auto processor = std::make_unique<autoware::multi_object_tracker::TrackerProcessor>(
-    creation_config, association_config, overlap_config, input_channels_config,
+    tracker_configs, creation_config, association_config, overlap_config, input_channels_config,
     rclcpp::get_logger("test_multi_object_tracker"),
     std::make_shared<rclcpp::Clock>(RCL_STEADY_TIME));
   TestBench simulator(config);
@@ -275,13 +277,14 @@ void runPerformanceTestWithRosbag(const std::string & rosbag_path, bool write_ba
   const auto odometry = std::make_shared<autoware::multi_object_tracker::Odometry>(
     node->get_logger(), node->get_clock(), tf_buffer, world_frame_id, ego_frame_id, true);
 
+  const auto tracker_configs = createTrackerConfigs();
   const auto creation_config = createTrackerCreationConfig();
   const auto association_config = createTrackerAssociationConfig();
   const auto overlap_config = createTrackerOverlapManagerConfig();
   const auto input_channels_config = createInputChannelsConfig();
 
   auto processor = std::make_unique<autoware::multi_object_tracker::TrackerProcessor>(
-    creation_config, association_config, overlap_config, input_channels_config,
+    tracker_configs, creation_config, association_config, overlap_config, input_channels_config,
     rclcpp::get_logger("test_multi_object_tracker"),
     std::make_shared<rclcpp::Clock>(RCL_STEADY_TIME));
 

--- a/perception/autoware_multi_object_tracker/test/test_tracker_overlap_manager.cpp
+++ b/perception/autoware_multi_object_tracker/test/test_tracker_overlap_manager.cpp
@@ -144,7 +144,10 @@ std::shared_ptr<mot::Tracker> makePolygonTracker(
   const mot::types::DynamicObject & obj, const rclcpp::Time & time, const int n_updates,
   const mot::types::InputChannel & channel)
 {
-  auto tracker = std::make_shared<mot::PolygonTracker>(time, obj, false, false);
+  mot::PolygonTrackerConfig polygon_config;
+  polygon_config.enable_velocity_estimation = false;
+  polygon_config.enable_motion_output = false;
+  auto tracker = std::make_shared<mot::PolygonTracker>(time, obj, polygon_config);
   tracker->initializeExistenceProbabilities(channel.index, obj.existence_probability);
   spinUp(tracker, obj, time, n_updates, channel);
   return tracker;

--- a/perception/autoware_multi_object_tracker/test/test_tracker_overlap_manager.cpp
+++ b/perception/autoware_multi_object_tracker/test/test_tracker_overlap_manager.cpp
@@ -146,7 +146,7 @@ std::shared_ptr<mot::Tracker> makePolygonTracker(
 {
   mot::PolygonTrackerConfig polygon_config;
   polygon_config.enable_velocity_estimation = false;
-  polygon_config.enable_motion_output = false;
+  // enable_motion_output left empty => motion output disabled for all labels
   auto tracker = std::make_shared<mot::PolygonTracker>(time, obj, polygon_config);
   tracker->initializeExistenceProbabilities(channel.index, obj.existence_probability);
   spinUp(tracker, obj, time, n_updates, channel);


### PR DESCRIPTION
## Description

This PR adds tracker export options and configurability per tracker type, and simplifies unknown-object pruning. Key updates, in order of importance:

### 1. `convert_polygon_to_bbox` — toggles the static tracker's output shape type
- New `tracker_configs.static_tracker.convert_polygon_to_bbox` flag (default `false`) gates the publish-time POLYGON → minimum-area BOUNDING_BOX conversion in `StaticShapeModel`.
- When disabled, the static tracker now exports the POLYGON shape as-is instead of always converting to a bounding box.

### 2. `tracker_configs` — per-tracker-type configuration, with renamed/per-class flags
- New `TrackerConfigs` struct (`PolygonTrackerConfig`, `StaticTrackerConfig`) that parallels `tracker_profiles`, keyed by tracker type. Config is namespaced as `tracker_configs.<tracker>.<member>`, and constructors take the config struct instead of loose flags.
- Renamed parameters:
  - `enable_unknown_object_velocity_estimation` → `tracker_configs.polygon_tracker.enable_velocity_estimation`
  - `enable_unknown_object_motion_output` → `tracker_configs.polygon_tracker.enable_motion_output`
- `enable_motion_output` is now **per object class** (a `LabelBoolMap`) instead of a single bool. It is evaluated at publish time against the track's current classification; a label that is absent or set `false` has its velocity suppressed. Default: published for `car/truck/bus/trailer/motorcycle/bicycle/pedestrian/animal`, suppressed for `unknown` and `hazard`.

### 3. Simplified pruning — removed [`calcAdaptiveGIoUThreshold` and speed-adaptive parameters](https://github.com/autowarefoundation/autoware_universe/pull/11237)
- `pruning_generalized_iou_thresholds` (per-label map) is consolidated into a single scalar `pruning_generalized_iou_threshold`, set to `0.1`.
- This GIoU threshold was kept very low because cluster association was poor. With the polar associator and shape-management improvements, this parameter can be increased, and the speed-adaptive `calcAdaptiveGIoUThreshold` is no longer necessary.
- Removed `calcAdaptiveGIoUThreshold()` and its parameters: `pruning_static_object_speed`, `pruning_moving_object_speed`, `pruning_static_iou_threshold`. Known/unknown redundancy now reduces to: any overlap (`precision > 0`) or a majority-covered target (`recall > 0.5`).

### 4. `suppressUncertainVelocity` — continuous velocity suppression for polygon + vehicle trackers
- Applied to `PolygonTracker` (new `suppressUncertainVelocity()`) and the existing `VehicleTracker` function is revised.
- Uncertain velocity is **suppressed in magnitude** (not hard-gated): a continuous gain in `[0,1]` that is 0 when speed is below the uncertainty limit, ramps linearly, and reaches 1 at twice the limit — rescaling the twist while preserving direction. This replaces the old discontinuous `vel_too_low_ignore` step logic in `VehicleTracker`. For the polygon tracker the uncertainty is projected onto the velocity direction (rotation-invariant) so the 2D twist is scaled consistently.

## Related links

**Parent Issue:**

- Link

## How was this PR tested?

- Unit tests updated (`test_bench`, `test_multi_object_tracker`, `test_tracker_overlap_manager`) to use the new config structures.
- Build + existing test suite green.

sample rosbag (with ptv3 pipeline)

<img width="2173" height="1421" alt="Screenshot from 2026-06-16 19-43-56" src="https://github.com/user-attachments/assets/c6be65b9-0183-4bf7-a1c4-ddef7fd591db" />


## Notes for reviewers

The `data_association_matrix.param.yaml` change is whitespace-only (column re-alignment).

## Interface changes

### ROS Parameter Changes

#### Additions and removals

| Change type | Parameter Name | Type | Default Value | Description |
|:--|:--|:--|:--|:--|
| Added | `tracker_configs.static_tracker.convert_polygon_to_bbox` | `bool` | `false` | Convert POLYGON shape to BOUNDING_BOX at publish time |
| Added | `tracker_configs.polygon_tracker.enable_velocity_estimation` | `bool` | `true` | Enable velocity estimation for polygon trackers (renamed from `enable_unknown_object_velocity_estimation`) |
| Added | `tracker_configs.polygon_tracker.enable_motion_output.<label>` | `bool` | per-label | Publish estimated velocity per object class (renamed + per-class from `enable_unknown_object_motion_output`) |
| Added | `pruning_generalized_iou_threshold` | `double` | `0.1` | Scalar GIoU threshold for pruning |
| Removed | `enable_unknown_object_velocity_estimation` | `bool` | `true` | Replaced by `tracker_configs.polygon_tracker.enable_velocity_estimation` |
| Removed | `enable_unknown_object_motion_output` | `bool` | `false` | Replaced by per-label `tracker_configs.polygon_tracker.enable_motion_output` |
| Removed | `pruning_generalized_iou_thresholds` | `map` | — | Replaced by scalar `pruning_generalized_iou_threshold` |
| Removed | `pruning_static_object_speed` | `double` | `1.38` | Speed-adaptive pruning removed |
| Removed | `pruning_moving_object_speed` | `double` | `5.5` | Speed-adaptive pruning removed |
| Removed | `pruning_static_iou_threshold` | `double` | `0.0` | Speed-adaptive pruning removed |

## Effects on system behavior

- Static-tracker polygon→bbox conversion is now disabled by default; the static tracker exports POLYGON shapes as-is.
- Polygon-tracker velocity is now published per object class (previously a single unknown-object flag), and is continuously attenuated by velocity uncertainty rather than being hard-gated.
- Vehicle-tracker velocity suppression is now continuous instead of stepped.
- Unknown-object pruning no longer adapts the GIoU threshold to object speed; a single low scalar threshold is used.
