### PR TITLE
test(autoware_tensorrt_yolox): set HAZARD overlay parameter in node characterization test

### DIFF
--- a/perception/autoware_tensorrt_yolox/test/test_tensorrt_yolox_node.cpp
+++ b/perception/autoware_tensorrt_yolox/test/test_tensorrt_yolox_node.cpp
@@ -144,6 +144,7 @@ rclcpp::NodeOptions make_traffic_light_detector_options(
   options.append_parameter_override("roi_overlay_segmentation_label.BICYCLE", false);
   options.append_parameter_override("roi_overlay_segmentation_label.PEDESTRIAN", false);
   options.append_parameter_override("roi_overlay_segmentation_label.ANIMAL", false);
+  options.append_parameter_override("roi_overlay_segmentation_label.HAZARD", false);
   append_common_overrides(options);
   return options;
 }
@@ -177,6 +178,7 @@ rclcpp::NodeOptions make_segmentation_options(
   options.append_parameter_override("roi_overlay_segmentation_label.BICYCLE", true);
   options.append_parameter_override("roi_overlay_segmentation_label.PEDESTRIAN", true);
   options.append_parameter_override("roi_overlay_segmentation_label.ANIMAL", true);
+  options.append_parameter_override("roi_overlay_segmentation_label.HAZARD", true);
   append_common_overrides(options);
   return options;
 }


### PR DESCRIPTION
## Description

Fix the `autoware_tensorrt_yolox` node characterization test (`test_tensorrt_yolox_node`) that fails to construct the node after #12730.

#12730 added a new segmentation-overlay label `HAZARD` and made the node declare the statically-typed parameter `roi_overlay_segmentation_label.HAZARD` **without a default value**. The integration test builds its `NodeOptions` from inline `append_parameter_override(...)` calls, but those override lists were not updated for the new label. As a result, node construction throws:

```
Statically typed parameter 'roi_overlay_segmentation_label.HAZARD' must be initialized.
```

and all three test cases fail in environments where the GPU-gated test actually runs.

This PR adds the missing `roi_overlay_segmentation_label.HAZARD` override to both option builders in the test, mirroring the values in the corresponding `*.param.yaml`:

- `make_traffic_light_detector_options` → `false` (matches `config/yolox_traffic_light_detector.param.yaml`)
- `make_segmentation_options` → `true` (matches `config/yolox_s_plus_opt.param.yaml`)

This is a test-only change; no production code is modified.

## Related links

**Parent Issue:**

- Link

Follow-up to #12730 (which introduced the `HAZARD` label and the required parameter).

## How was this PR tested?

- `colcon build --packages-select autoware_tensorrt_yolox` succeeds.
- `colcon test --packages-select autoware_tensorrt_yolox` passes 6/6 (copyright, cppcheck, lint_cmake, cpplint/uncrustify linters, xmllint, gtest). With the GPU and TensorRT available locally, `test_tensorrt_yolox_node` now constructs the node successfully and exercises its pub/sub path instead of throwing during construction.

## Notes for reviewers

None

## Interface changes

None.

## Effects on system behavior

None. This change is limited to test code and does not affect any runtime behavior.
