### PR TITLE
refactor(tensorrt_yolox): remove hard-coded label mapping

### DIFF
--- a/perception/autoware_tensorrt_yolox/include/autoware/tensorrt_yolox/tensorrt_yolox_node.hpp
+++ b/perception/autoware_tensorrt_yolox/include/autoware/tensorrt_yolox/tensorrt_yolox_node.hpp
@@ -42,6 +42,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -54,24 +55,30 @@ class TrtYoloXNode : public rclcpp::Node
 {
   struct RoiOverlaySemsegLabel
   {
-    bool UNKNOWN;
-    bool CAR;
-    bool TRUCK;
-    bool BUS;
-    bool MOTORCYCLE;
-    bool BICYCLE;
-    bool PEDESTRIAN;
-    bool ANIMAL;
-    bool HAZARD;
+    /// @brief Clear all overlay label settings.
+    void clear() { label_to_overlay_index_map_.clear(); }
 
+    /// @brief Set whether to overlay the segmentation mask for a specific label.
+    /// @param label_id the label ID defined in Autoware object classification (e.g. CAR=1,
+    /// PEDESTRIAN=6)
+    /// @param enabled whether to overlay
+    void setOverlay(const uint8_t label_id, const bool enabled)
+    {
+      label_to_overlay_index_map_[label_id] = enabled;
+    }
+
+    /// @brief Check whether to overlay the segmentation mask for a specific label.
+    /// @param label_id the label ID defined in Autoware object classification (e.g. CAR=1,
+    /// PEDESTRIAN=6)
+    /// @return true if the segmentation mask should be overlayed for the label, false otherwise
     bool isOverlay(const uint8_t label) const
     {
-      return (label == Label::UNKNOWN && UNKNOWN) || (label == Label::CAR && CAR) ||
-             (label == Label::TRUCK && TRUCK) || (label == Label::BUS && BUS) ||
-             (label == Label::ANIMAL && ANIMAL) || (label == Label::MOTORBIKE && MOTORCYCLE) ||
-             (label == Label::BICYCLE && BICYCLE) || (label == Label::PEDESTRIAN && PEDESTRIAN) ||
-             (label == Label::HAZARD && HAZARD);
+      return label_to_overlay_index_map_.count(label) > 0 && label_to_overlay_index_map_.at(label);
     };
+
+  private:
+    /// @brief store the label ID and whether to overlay the segmentation mask for the label
+    std::unordered_map<uint8_t, bool> label_to_overlay_index_map_;
   };  // struct RoiOverlaySemsegLabel
 
 public:
@@ -86,6 +93,7 @@ private:
   void setupLabel(
     const std::string & roi_label_file_path, const std::string & segment_color_map_file_path,
     const std::string & roi_label_remap_file_path, const std::string & roi_segment_remap_path);
+  void loadOverlaySegmentationLabels();
   void getColorizedMask(const cv::Mat & mask, cv::Mat & cmask);
 
   image_transport::Publisher image_pub_;

--- a/perception/autoware_tensorrt_yolox/src/tensorrt_yolox_node.cpp
+++ b/perception/autoware_tensorrt_yolox/src/tensorrt_yolox_node.cpp
@@ -22,6 +22,7 @@
 
 #include <algorithm>
 #include <memory>
+#include <ostream>
 #include <string>
 #include <unordered_map>
 #include <utility>
@@ -72,22 +73,6 @@ TrtYoloXNode::TrtYoloXNode(const rclcpp::NodeOptions & node_options)
   is_roi_overlap_semseg_ = declare_parameter<bool>("is_roi_overlap_segmentation");
   is_publish_color_mask_ = declare_parameter<bool>("is_publish_color_mask");
   overlap_roi_score_threshold_ = declare_parameter<float>("overlap_roi_score_threshold");
-  roi_overlay_semseg_labels_.UNKNOWN =
-    declare_parameter<bool>("roi_overlay_segmentation_label.UNKNOWN");
-  roi_overlay_semseg_labels_.CAR = declare_parameter<bool>("roi_overlay_segmentation_label.CAR");
-  roi_overlay_semseg_labels_.TRUCK =
-    declare_parameter<bool>("roi_overlay_segmentation_label.TRUCK");
-  roi_overlay_semseg_labels_.BUS = declare_parameter<bool>("roi_overlay_segmentation_label.BUS");
-  roi_overlay_semseg_labels_.MOTORCYCLE =
-    declare_parameter<bool>("roi_overlay_segmentation_label.MOTORCYCLE");
-  roi_overlay_semseg_labels_.BICYCLE =
-    declare_parameter<bool>("roi_overlay_segmentation_label.BICYCLE");
-  roi_overlay_semseg_labels_.PEDESTRIAN =
-    declare_parameter<bool>("roi_overlay_segmentation_label.PEDESTRIAN");
-  roi_overlay_semseg_labels_.ANIMAL =
-    declare_parameter<bool>("roi_overlay_segmentation_label.ANIMAL");
-  roi_overlay_semseg_labels_.HAZARD =
-    declare_parameter<bool>("roi_overlay_segmentation_label.HAZARD");
 
   if (is_publish_color_mask_ && semseg_color_map_path.empty()) {
     std::stringstream error_msg;
@@ -105,6 +90,7 @@ TrtYoloXNode::TrtYoloXNode(const rclcpp::NodeOptions & node_options)
 
   // setup the label information and process the remappings
   setupLabel(label_path, semseg_color_map_path, roi_remap_path, roi_to_semseg_remap_path);
+  loadOverlaySegmentationLabels();
 
   TrtCommonConfig trt_config(
     model_path, precision, "", (1ULL << 30U), dla_core_id, profile_per_layer);
@@ -138,6 +124,32 @@ TrtYoloXNode::TrtYoloXNode(const rclcpp::NodeOptions & node_options)
   if (declare_parameter("build_only", false)) {
     RCLCPP_INFO(this->get_logger(), "TensorRT engine file is built and exit.");
     rclcpp::shutdown();
+  }
+}
+
+void TrtYoloXNode::loadOverlaySegmentationLabels()
+{
+  constexpr std::string_view prefix = "roi_overlay_segmentation_label.";
+
+  roi_overlay_semseg_labels_.clear();
+
+  for (const auto & [param_name, param_value] :
+       get_node_parameters_interface()->get_parameter_overrides()) {
+    if (param_name.rfind(prefix, 0) != 0) {
+      continue;
+    }
+
+    if (param_value.get_type() != rclcpp::ParameterType::PARAMETER_BOOL) {
+      std::ostringstream error_msg;
+      error_msg << "Parameter '" << param_name << "' must be a boolean.";
+      throw std::runtime_error{error_msg.str()};
+    }
+
+    const std::string label_name = param_name.substr(prefix.length());
+    const auto label_id = autoware::object_recognition_utils::toLabel(label_name);
+    const bool enabled = param_value.get<bool>();
+
+    roi_overlay_semseg_labels_.setOverlay(label_id, enabled);
   }
 }
 


### PR DESCRIPTION
## Description

This pull request refactors how segmentation mask overlay labels are managed and configured in the `TrtYoloXNode` class. Instead of using hardcoded boolean fields for each label, the code now uses a flexible map-based approach, allowing dynamic configuration of which labels should have overlays via parameters. The most important changes are:

### Refactoring label overlay configuration

* Replaced individual boolean fields for each overlay label in `RoiOverlaySemsegLabel` with an internal `std::unordered_map<uint8_t, bool>`, and added methods to set, clear, and check overlay status for arbitrary label IDs. This change makes the overlay configuration extensible and less error-prone.
* Updated the constructor of `TrtYoloXNode` to remove hardcoded parameter declarations for each label, delegating overlay label setup to a new method.

### Dynamic parameter handling

* Added the `loadOverlaySegmentationLabels()` method, which dynamically loads all overlay label parameters with the prefix `roi_overlay_segmentation_label.`, validates them, and updates the overlay map accordingly. This allows for easier addition or removal of labels through configuration. [[1]](diffhunk://#diff-a46e293f3ec1aa2ddd8253653b9d7cd76cbc1d505d86400fc6de5dcc11ccc21bR96) [[2]](diffhunk://#diff-4519a25e256b218c2807d6f99f5e4b69a3680da45d86c19695909a3897a36526R93) [[3]](diffhunk://#diff-4519a25e256b218c2807d6f99f5e4b69a3680da45d86c19695909a3897a36526R130-R155)

### Code maintenance

* Added necessary includes for `std::unordered_map` and `std::ostream` to support these changes. [[1]](diffhunk://#diff-a46e293f3ec1aa2ddd8253653b9d7cd76cbc1d505d86400fc6de5dcc11ccc21bR45) [[2]](diffhunk://#diff-4519a25e256b218c2807d6f99f5e4b69a3680da45d86c19695909a3897a36526R25)

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
