### PR TITLE
refactor(euclidean_cluster): replace hardcoded label handling with parameter driven parsing

### DIFF
--- a/perception/autoware_euclidean_cluster/CMakeLists.txt
+++ b/perception/autoware_euclidean_cluster/CMakeLists.txt
@@ -89,6 +89,15 @@ if(BUILD_TESTING)
   ament_auto_add_gtest(test_voxel_grid_based_euclidean_cluster_fusion
     test/test_voxel_grid_based_euclidean_cluster.cpp
   )
+  ament_auto_add_gtest(test_label_based_euclidean_cluster_node
+    test/test_label_based_euclidean_cluster_node.cpp
+  )
+  target_include_directories(test_label_based_euclidean_cluster_node PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/src
+  )
+  target_link_libraries(test_label_based_euclidean_cluster_node
+    ${PROJECT_NAME}_label_based_node_core
+  )
 endif()
 
 autoware_ament_auto_package(INSTALL_TO_SHARE

--- a/perception/autoware_euclidean_cluster/package.xml
+++ b/perception/autoware_euclidean_cluster/package.xml
@@ -14,6 +14,7 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_agnocast_wrapper</depend>
+  <depend>autoware_object_recognition_utils</depend>
   <depend>autoware_perception_msgs</depend>
   <depend>autoware_point_types</depend>
   <depend>autoware_shape_estimation</depend>

--- a/perception/autoware_euclidean_cluster/src/label_based_euclidean_cluster_node.cpp
+++ b/perception/autoware_euclidean_cluster/src/label_based_euclidean_cluster_node.cpp
@@ -17,6 +17,7 @@
 #include "autoware/euclidean_cluster/voxel_grid_based_euclidean_cluster.hpp"
 
 #include <Eigen/Core>
+#include <autoware/object_recognition_utils/object_classification.hpp>
 #include <autoware_utils_rclcpp/parameter.hpp>
 #include <rclcpp/parameter_map.hpp>
 
@@ -32,6 +33,7 @@
 #include <pcl/common/common.h>
 
 #include <algorithm>
+#include <cctype>
 #include <cstdint>
 #include <memory>
 #include <numeric>
@@ -84,6 +86,18 @@ bool is_ignored_mapping(const std::string & mapped_label)
   return mapped_label == "ignore";
 }
 
+/// @brief Normalize configured label names to the uppercase form expected by toLabel().
+/// NOTE: This should be unnecessary once
+/// https://github.com/autowarefoundation/autoware_core/pull/1184 has been merged.
+std::string normalize_object_label_name(const std::string & label_name)
+{
+  std::string normalized = label_name;
+  std::transform(normalized.begin(), normalized.end(), normalized.begin(), [](unsigned char c) {
+    return static_cast<char>(std::toupper(c));
+  });
+  return normalized;
+}
+
 /// @brief Convert an integer parameter into a validated shape policy.
 ShapePolicy to_shape_policy(const std::uint8_t value)
 {
@@ -121,32 +135,32 @@ std::vector<std::pair<std::string, std::string>> extract_class_mappings(
   return class_mappings;
 }
 
-/// @brief Canonical ordered mapping from configured label name to Autoware object classification.
-///        Single source of truth shared by name->label lookup and per-label override parsing.
-const std::vector<std::pair<std::string, std::uint8_t>> & label_name_table()
+/// @brief Extract per-label parameter prefixes from nested overrides.
+///        Example: "label_cluster_params.car.tolerance_m" -> {"car", "label_cluster_params.car."}
+std::unordered_map<std::string, std::string> load_label_cluster_parameter_prefixes(
+  const rclcpp::NodeOptions & options)
 {
-  static const std::vector<std::pair<std::string, std::uint8_t>> table = {
-    {"unknown", ObjectClassification::UNKNOWN},
-    {"car", ObjectClassification::CAR},
-    {"bus", ObjectClassification::BUS},
-    {"truck", ObjectClassification::TRUCK},
-    {"motorcycle", ObjectClassification::MOTORCYCLE},
-    {"bicycle", ObjectClassification::BICYCLE},
-    {"pedestrian", ObjectClassification::PEDESTRIAN},
-    {"animal", ObjectClassification::ANIMAL},
-    {"trailer", ObjectClassification::TRAILER},
-    {"hazard", ObjectClassification::HAZARD},
-  };
-  return table;
-}
+  constexpr std::string_view prefix = "label_cluster_params.";
 
-/// @brief Map a configured label name to an Autoware object classification label.
-std::optional<std::uint8_t> to_object_label(const std::string & mapped_label)
-{
-  const auto & table = label_name_table();
-  const auto it = std::find_if(
-    table.begin(), table.end(), [&](const auto & entry) { return entry.first == mapped_label; });
-  return it != table.end() ? std::optional<std::uint8_t>(it->second) : std::nullopt;
+  // first: label name, second: parameter prefix including the label name and trailing dot
+  std::unordered_map<std::string, std::string> outputs;
+
+  for (const auto & parameter : options.parameter_overrides()) {
+    const auto & name = parameter.get_name();
+
+    if (name.rfind(prefix, 0) != 0) {
+      continue;
+    }
+
+    const std::string rest = name.substr(prefix.size());
+
+    const auto dot_pos = rest.find('.');
+    if (dot_pos != std::string::npos) {
+      outputs.emplace(rest.substr(0, dot_pos), std::string(prefix) + rest.substr(0, dot_pos) + ".");
+    }
+  }
+
+  return outputs;
 }
 
 /// @brief Create fallback shape and pose from the cluster axis-aligned bounding box.
@@ -347,10 +361,8 @@ std::vector<ConfusableLabelGroup> load_confusable_groups(const rclcpp::NodeOptio
     } else if (
       key == "labels" && param.get_type() == rclcpp::ParameterType::PARAMETER_STRING_ARRAY) {
       for (const auto & label_name : param.as_string_array()) {
-        const auto label_id = to_object_label(label_name);
-        if (label_id.has_value()) {
-          group.labels.push_back(label_id.value());
-        }
+        group.labels.push_back(
+          object_recognition_utils::toLabel(normalize_object_label_name(label_name)));
       }
     }
   }
@@ -419,9 +431,10 @@ LabelBasedEuclideanClusterNode::LabelBasedEuclideanClusterNode(const rclcpp::Nod
   // Build per-label cluster overrides from label_cluster_params.<label_name>.* parameters.
   // Any omitted sub-key falls back to the global default above.
   {
-    for (const auto & [label_name, label] : label_name_table()) {
-      const std::string prefix = "label_cluster_params." + label_name + ".";
-      auto has = [&](const std::string & key) { return this->has_parameter(prefix + key); };
+    for (const auto & entry : load_label_cluster_parameter_prefixes(options)) {
+      const auto & label_name = entry.first;
+      const auto & label_prefix = entry.second;
+      auto has = [&](const std::string & key) { return this->has_parameter(label_prefix + key); };
       // Skip labels with no overrides at all
       if (
         !has("tolerance_m") && !has("min_points_per_cluster") && !has("use_height") &&
@@ -432,13 +445,13 @@ LabelBasedEuclideanClusterNode::LabelBasedEuclideanClusterNode(const rclcpp::Nod
       }
 
       auto get_bool = [&](const std::string & key, bool def) -> bool {
-        return has(key) ? this->get_parameter(prefix + key).as_bool() : def;
+        return has(key) ? this->get_parameter(label_prefix + key).as_bool() : def;
       };
       auto get_int = [&](const std::string & key, int def) -> int {
         if (!has(key)) {
           return def;
         }
-        const auto param = this->get_parameter(prefix + key);
+        const auto param = this->get_parameter(label_prefix + key);
         return param.get_type() == rclcpp::ParameterType::PARAMETER_DOUBLE
                  ? static_cast<int>(param.as_double())
                  : static_cast<int>(param.as_int());
@@ -447,12 +460,13 @@ LabelBasedEuclideanClusterNode::LabelBasedEuclideanClusterNode(const rclcpp::Nod
         if (!has(key)) {
           return def;
         }
-        const auto param = this->get_parameter(prefix + key);
+        const auto param = this->get_parameter(label_prefix + key);
         return param.get_type() == rclcpp::ParameterType::PARAMETER_INTEGER
                  ? static_cast<float>(param.as_int())
                  : static_cast<float>(param.as_double());
       };
 
+      const auto label = object_recognition_utils::toLabel(normalize_object_label_name(label_name));
       label_cluster_executers_[label] = std::make_shared<VoxelGridBasedEuclideanCluster>(
         get_bool("use_height", use_height),
         get_int("min_points_per_cluster", min_points_per_cluster),
@@ -525,15 +539,8 @@ bool LabelBasedEuclideanClusterNode::update_target_label_map(
       continue;
     }
 
-    const auto mapped_label = to_object_label(mapped_label_name);
-    if (!mapped_label.has_value()) {
-      RCLCPP_WARN(
-        get_logger(), "Ignoring unsupported mapped label '%s' for class '%s'",
-        mapped_label_name.c_str(), original_class_name.c_str());
-      continue;
-    }
-
-    class_id_to_object_label_[class_id] = mapped_label.value();
+    class_id_to_object_label_[class_id] =
+      object_recognition_utils::toLabel(normalize_object_label_name(mapped_label_name));
   }
 
   return !class_id_to_object_label_.empty();

--- a/perception/autoware_euclidean_cluster/src/label_based_euclidean_cluster_node.cpp
+++ b/perception/autoware_euclidean_cluster/src/label_based_euclidean_cluster_node.cpp
@@ -135,6 +135,29 @@ std::vector<std::pair<std::string, std::string>> extract_class_mappings(
   return class_mappings;
 }
 
+struct NestedOverrideName
+{
+  std::string group_name;
+  std::string key;
+};
+
+/// @brief Parse a nested override name in the form "<prefix><group>.<key>".
+std::optional<NestedOverrideName> parse_nested_override_name(
+  const std::string & parameter_name, const std::string_view prefix)
+{
+  if (parameter_name.rfind(prefix, 0) != 0) {
+    return std::nullopt;
+  }
+
+  const std::string rest = parameter_name.substr(prefix.size());
+  const auto dot_pos = rest.find('.');
+  if (dot_pos == std::string::npos) {
+    return std::nullopt;
+  }
+
+  return NestedOverrideName{rest.substr(0, dot_pos), rest.substr(dot_pos + 1)};
+}
+
 /// @brief Extract per-label parameter prefixes from nested overrides.
 ///        Example: "label_cluster_params.car.tolerance_m" -> {"car", "label_cluster_params.car."}
 std::unordered_map<std::string, std::string> load_label_cluster_parameter_prefixes(
@@ -146,18 +169,12 @@ std::unordered_map<std::string, std::string> load_label_cluster_parameter_prefix
   std::unordered_map<std::string, std::string> outputs;
 
   for (const auto & parameter : options.parameter_overrides()) {
-    const auto & name = parameter.get_name();
-
-    if (name.rfind(prefix, 0) != 0) {
+    const auto nested_name = parse_nested_override_name(parameter.get_name(), prefix);
+    if (!nested_name) {
       continue;
     }
 
-    const std::string rest = name.substr(prefix.size());
-
-    const auto dot_pos = rest.find('.');
-    if (dot_pos != std::string::npos) {
-      outputs.emplace(rest.substr(0, dot_pos), std::string(prefix) + rest.substr(0, dot_pos) + ".");
-    }
+    outputs.emplace(nested_name->group_name, std::string(prefix) + nested_name->group_name + ".");
   }
 
   return outputs;
@@ -334,19 +351,13 @@ std::vector<ConfusableLabelGroup> load_confusable_groups(const rclcpp::NodeOptio
   std::unordered_set<std::string> provided_keys;
 
   for (const auto & param : options.parameter_overrides()) {
-    const auto & name = param.get_name();
-    if (name.rfind(prefix, 0) != 0) {
+    const auto nested_name = parse_nested_override_name(param.get_name(), prefix);
+    if (!nested_name) {
       continue;
     }
 
-    const auto rest = name.substr(prefix.size());
-    const auto dot = rest.find('.');
-    if (dot == std::string::npos) {
-      continue;
-    }
-
-    const auto group_name = rest.substr(0, dot);
-    const auto key = rest.substr(dot + 1);
+    const auto & group_name = nested_name->group_name;
+    const auto & key = nested_name->key;
     auto & group = groups_map[group_name];
 
     if (

--- a/perception/autoware_euclidean_cluster/src/label_based_euclidean_cluster_node.hpp
+++ b/perception/autoware_euclidean_cluster/src/label_based_euclidean_cluster_node.hpp
@@ -51,6 +51,9 @@ public:
   explicit LabelBasedEuclideanClusterNode(const rclcpp::NodeOptions & options);
 
 private:
+  friend class LabelClusterConfigBehavior_AcceptsLowercaseConfiguredLabels_Test;
+  friend class LabelClusterConfigBehavior_CreatesExecuterForDynamicOverrideLabel_Test;
+
   /// @brief Process an input semantic point cloud and publish detected objects.
   /// @param input_msg Input point cloud containing xyz and optionally class_id / probability.
   void on_pointcloud(sensor_msgs::msg::PointCloud2::ConstSharedPtr input_msg);

--- a/perception/autoware_euclidean_cluster/test/test_label_based_euclidean_cluster_node.cpp
+++ b/perception/autoware_euclidean_cluster/test/test_label_based_euclidean_cluster_node.cpp
@@ -1,0 +1,129 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "../src/label_based_euclidean_cluster_node.hpp"
+
+#include <rclcpp/rclcpp.hpp>
+
+#include <autoware_perception_msgs/msg/object_classification.hpp>
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace autoware::euclidean_cluster
+{
+using autoware_perception_msgs::msg::ObjectClassification;
+
+class LabelClusterConfigBehavior : public ::testing::Test
+{
+protected:
+  static void SetUpTestSuite()
+  {
+    if (!rclcpp::ok()) {
+      int argc = 0;
+      char ** argv = nullptr;
+      rclcpp::init(argc, argv);
+    }
+  }
+
+  static void TearDownTestSuite()
+  {
+    if (rclcpp::ok()) {
+      rclcpp::shutdown();
+    }
+  }
+
+  static rclcpp::NodeOptions make_node_options(
+    const std::vector<rclcpp::Parameter> & extra_parameters)
+  {
+    std::vector<rclcpp::Parameter> parameters = {
+      rclcpp::Parameter("min_probability", 0.3),
+      rclcpp::Parameter("shape_policy", static_cast<int64_t>(0)),
+      rclcpp::Parameter("use_height", false),
+      rclcpp::Parameter("tolerance_m", 0.65),
+      rclcpp::Parameter("voxel_leaf_size_m", 0.2),
+      rclcpp::Parameter("min_points_per_voxel", static_cast<int64_t>(3)),
+      rclcpp::Parameter("min_points_per_cluster", static_cast<int64_t>(10)),
+      rclcpp::Parameter("large_cluster_voxel_count_threshold", static_cast<int64_t>(50)),
+      rclcpp::Parameter("large_cluster_max_points_per_voxel", static_cast<int64_t>(100)),
+      rclcpp::Parameter("max_voxels_per_cluster", static_cast<int64_t>(2000)),
+      rclcpp::Parameter("use_shape_estimation_corrector", false),
+      rclcpp::Parameter("use_shape_estimation_filter", false),
+      rclcpp::Parameter("use_boost_bbox_optimizer", false),
+    };
+
+    parameters.insert(parameters.end(), extra_parameters.begin(), extra_parameters.end());
+
+    rclcpp::NodeOptions options;
+    options.parameter_overrides(parameters);
+    return options;
+  }
+};
+
+TEST_F(LabelClusterConfigBehavior, AcceptsLowercaseConfiguredLabels)
+{
+  // Arrange
+  const auto options = make_node_options({
+    rclcpp::Parameter("class_names.car", std::string("car")),
+    rclcpp::Parameter("class_names.truck", std::string("truck")),
+    rclcpp::Parameter("class_names.tractor_unit", std::string("trailer")),
+    rclcpp::Parameter("class_names.pedestrian", std::string("pedestrian")),
+    rclcpp::Parameter("label_cluster_params.pedestrian.tolerance_m", 0.3),
+    rclcpp::Parameter(
+      "confusable_label_groups.truck_trailer.labels", std::vector<std::string>{"truck", "trailer"}),
+    rclcpp::Parameter("confusable_label_groups.truck_trailer.cross_label_tolerance_m", 0.5),
+    rclcpp::Parameter("confusable_label_groups.truck_trailer.max_merged_size_m", 25.0),
+  });
+
+  // Act
+  auto node = std::make_unique<LabelBasedEuclideanClusterNode>(options);
+
+  // Assert
+  ASSERT_EQ(node->class_id_to_object_label_.size(), 4U);
+  EXPECT_EQ(node->class_id_to_object_label_.at(0), ObjectClassification::CAR);
+  EXPECT_EQ(node->class_id_to_object_label_.at(1), ObjectClassification::TRUCK);
+  EXPECT_EQ(node->class_id_to_object_label_.at(2), ObjectClassification::TRAILER);
+  EXPECT_EQ(node->class_id_to_object_label_.at(3), ObjectClassification::PEDESTRIAN);
+  ASSERT_EQ(node->confusable_groups_.size(), 1U);
+  ASSERT_EQ(node->confusable_groups_.front().labels.size(), 2U);
+  EXPECT_EQ(node->confusable_groups_.front().labels.at(0), ObjectClassification::TRUCK);
+  EXPECT_EQ(node->confusable_groups_.front().labels.at(1), ObjectClassification::TRAILER);
+  EXPECT_EQ(node->label_cluster_executers_.count(ObjectClassification::PEDESTRIAN), 1U);
+}
+
+TEST_F(LabelClusterConfigBehavior, CreatesExecuterForDynamicOverrideLabel)
+{
+  // Arrange
+  const auto options = make_node_options({
+    rclcpp::Parameter("class_names.car", std::string("car")),
+    rclcpp::Parameter("class_names.tractor_unit", std::string("trailer")),
+    rclcpp::Parameter("label_cluster_params.trailer.tolerance_m", 0.4),
+    rclcpp::Parameter(
+      "label_cluster_params.trailer.min_points_per_cluster", static_cast<int64_t>(7)),
+  });
+
+  // Act
+  auto node = std::make_unique<LabelBasedEuclideanClusterNode>(options);
+
+  // Assert
+  EXPECT_TRUE(node->has_parameter("label_cluster_params.trailer.tolerance_m"));
+  EXPECT_EQ(node->label_cluster_executers_.count(ObjectClassification::TRAILER), 1U);
+  EXPECT_EQ(node->label_cluster_executers_.count(ObjectClassification::CAR), 0U);
+}
+
+}  // namespace autoware::euclidean_cluster


### PR DESCRIPTION
## Description

This pull request improves the flexibility and robustness of the `label_based_euclidean_cluster_node` in the `autoware_euclidean_cluster` package, particularly in how it handles label names and per-label configuration. The main focus is to allow label names to be specified in a case-insensitive manner and to support dynamic per-label parameter overrides. Additionally, new tests are added to verify these behaviors.

**Label handling and configuration improvements:**

* Added a `normalize_object_label_name` function to ensure label names are normalized to uppercase before being mapped to Autoware object classifications, making label handling case-insensitive. This improves compatibility with various configuration styles. [[1]](diffhunk://#diff-1489cb10f7ea3f8cd0c84ff03c716ca661d538e46e19a59a8fd271bf9a43d760R89-R100) [[2]](diffhunk://#diff-1489cb10f7ea3f8cd0c84ff03c716ca661d538e46e19a59a8fd271bf9a43d760L350-R365) [[3]](diffhunk://#diff-1489cb10f7ea3f8cd0c84ff03c716ca661d538e46e19a59a8fd271bf9a43d760L450-R469) [[4]](diffhunk://#diff-1489cb10f7ea3f8cd0c84ff03c716ca661d538e46e19a59a8fd271bf9a43d760L528-R543)
* Replaced the static label mapping table and `to_object_label` function with logic that dynamically extracts per-label parameter prefixes from node options, allowing for more flexible and dynamic per-label configuration. [[1]](diffhunk://#diff-1489cb10f7ea3f8cd0c84ff03c716ca661d538e46e19a59a8fd271bf9a43d760L124-R163) [[2]](diffhunk://#diff-1489cb10f7ea3f8cd0c84ff03c716ca661d538e46e19a59a8fd271bf9a43d760L422-R437) [[3]](diffhunk://#diff-1489cb10f7ea3f8cd0c84ff03c716ca661d538e46e19a59a8fd271bf9a43d760L435-R454)

**Testing and code quality:**

* Added a new test file `test_label_based_euclidean_cluster_node.cpp` with tests verifying that lowercase label names are accepted and that executors are created for dynamically overridden labels. This ensures the new label handling logic works as intended.
* Updated `CMakeLists.txt` to add and properly configure the new test, including linking and include directories.
* Added test-only friend declarations in the node class to allow test access to private members.

**Dependency updates:**

* Added a dependency on `autoware_object_recognition_utils` in the package manifest to support the new label normalization logic.
* Included the appropriate header for object classification utilities.
* Added missing standard header includes for completeness.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
