### PR TITLE
perf(autoware_bevfusion): hand node stream to cuda_blackboard

### DIFF
--- a/perception/autoware_bevfusion/include/autoware/bevfusion/bevfusion_trt.hpp
+++ b/perception/autoware_bevfusion/include/autoware/bevfusion/bevfusion_trt.hpp
@@ -97,6 +97,12 @@ public:
     std::vector<sensor_msgs::msg::CameraInfo> & camera_info_vector,
     std::vector<Matrix4fRowM> & lidar2camera_vector);
 
+  // Main CUDA stream on which the input point cloud is consumed (voxelization, pre-/post-process
+  // and inference). It is handed to the CudaBlackboardSubscriber so the blackboard can order the
+  // producer/consumer and the buffer free at the stream level instead of synchronizing the whole
+  // process.
+  cudaStream_t stream() const { return stream_; }
+
 protected:
   void initPtr();
   void initTrt(const TrtBEVFusionConfig & trt_config);

--- a/perception/autoware_bevfusion/include/autoware/bevfusion/bevfusion_trt.hpp
+++ b/perception/autoware_bevfusion/include/autoware/bevfusion/bevfusion_trt.hpp
@@ -98,7 +98,7 @@ public:
     std::vector<Matrix4fRowM> & lidar2camera_vector);
 
   /// CUDA stream used for pointcloud processing and inference.
-  /// Pass this to CudaBlackboardSubscriber for stream-level producer/consumer ordering.
+  /// Enables stream-ordered producer/consumer lifetime handling.
   cudaStream_t stream() const { return stream_; }
 
 protected:

--- a/perception/autoware_bevfusion/include/autoware/bevfusion/bevfusion_trt.hpp
+++ b/perception/autoware_bevfusion/include/autoware/bevfusion/bevfusion_trt.hpp
@@ -97,10 +97,8 @@ public:
     std::vector<sensor_msgs::msg::CameraInfo> & camera_info_vector,
     std::vector<Matrix4fRowM> & lidar2camera_vector);
 
-  // Main CUDA stream on which the input point cloud is consumed (voxelization, pre-/post-process
-  // and inference). It is handed to the CudaBlackboardSubscriber so the blackboard can order the
-  // producer/consumer and the buffer free at the stream level instead of synchronizing the whole
-  // process.
+  /// CUDA stream used for pointcloud processing and inference.
+  /// Pass this to CudaBlackboardSubscriber for stream-level producer/consumer ordering.
   cudaStream_t stream() const { return stream_; }
 
 protected:

--- a/perception/autoware_bevfusion/src/bevfusion_node.cpp
+++ b/perception/autoware_bevfusion/src/bevfusion_node.cpp
@@ -235,7 +235,8 @@ BEVFusionNode::BEVFusionNode(const rclcpp::NodeOptions & options)
   cloud_sub_ =
     std::make_unique<cuda_blackboard::CudaBlackboardSubscriber<cuda_blackboard::CudaPointCloud2>>(
       *this, "~/input/pointcloud",
-      std::bind(&BEVFusionNode::cloudCallback, this, std::placeholders::_1));
+      std::bind(&BEVFusionNode::cloudCallback, this, std::placeholders::_1),
+      detector_ptr_->stream());
 
   objects_pub_ = this->create_publisher<autoware_perception_msgs::msg::DetectedObjects>(
     "~/output/objects", rclcpp::QoS(1));


### PR DESCRIPTION
## Summary
Move to new `cuda_blackboard` stream-ordered API.

## Dependency
- Depends on autowarefoundation/cuda_blackboard#22
