### PR TITLE
perf(autoware_ptv3): hand node stream to cuda_blackboard

### DIFF
--- a/perception/autoware_ptv3/config/ptv3.param.yaml
+++ b/perception/autoware_ptv3/config/ptv3.param.yaml
@@ -15,7 +15,7 @@
       source_reconstruction: "full"
       filter:
         class_probability_threshold: 0.05
-        classes: ["drivable_surface"]
+        classes: ["drivable_flat"]
         output_format: ""
     detection3d:
       use_head: $(var use_det3d_head)

--- a/perception/autoware_ptv3/config/ptv3.param.yaml
+++ b/perception/autoware_ptv3/config/ptv3.param.yaml
@@ -15,7 +15,7 @@
       source_reconstruction: "full"
       filter:
         class_probability_threshold: 0.05
-        classes: ["drivable_flat"]
+        classes: ["drivable_surface"]
         output_format: ""
     detection3d:
       use_head: $(var use_det3d_head)

--- a/perception/autoware_ptv3/include/autoware/ptv3/ptv3_trt.hpp
+++ b/perception/autoware_ptv3/include/autoware/ptv3/ptv3_trt.hpp
@@ -65,7 +65,7 @@ public:
     std::function<void(std::unique_ptr<const cuda_blackboard::CudaPointCloud2>)> func);
 
   /// CUDA stream used for pointcloud processing and inference.
-  /// Pass this to CudaBlackboardSubscriber for stream-level producer/consumer ordering.
+  /// Enables stream-ordered producer/consumer lifetime handling.
   cudaStream_t stream() const { return stream_; }
 
 protected:

--- a/perception/autoware_ptv3/include/autoware/ptv3/ptv3_trt.hpp
+++ b/perception/autoware_ptv3/include/autoware/ptv3/ptv3_trt.hpp
@@ -64,9 +64,8 @@ public:
   void setPublishFilteredPointcloud(
     std::function<void(std::unique_ptr<const cuda_blackboard::CudaPointCloud2>)> func);
 
-  // CUDA stream on which the input point cloud is consumed (pre-/post-process and inference). It is
-  // handed to the CudaBlackboardSubscriber so the blackboard can order the producer/consumer and
-  // the buffer free at the stream level instead of synchronizing the whole process.
+  /// CUDA stream used for pointcloud processing and inference.
+  /// Pass this to CudaBlackboardSubscriber for stream-level producer/consumer ordering.
   cudaStream_t stream() const { return stream_; }
 
 protected:

--- a/perception/autoware_ptv3/include/autoware/ptv3/ptv3_trt.hpp
+++ b/perception/autoware_ptv3/include/autoware/ptv3/ptv3_trt.hpp
@@ -64,6 +64,11 @@ public:
   void setPublishFilteredPointcloud(
     std::function<void(std::unique_ptr<const cuda_blackboard::CudaPointCloud2>)> func);
 
+  // CUDA stream on which the input point cloud is consumed (pre-/post-process and inference). It is
+  // handed to the CudaBlackboardSubscriber so the blackboard can order the producer/consumer and
+  // the buffer free at the stream level instead of synchronizing the whole process.
+  cudaStream_t stream() const { return stream_; }
+
 protected:
   void initPtr();
   void initBackboneTrt(const tensorrt_common::TrtCommonConfig & trt_config);

--- a/perception/autoware_ptv3/src/ptv3_node.cpp
+++ b/perception/autoware_ptv3/src/ptv3_node.cpp
@@ -188,7 +188,7 @@ PTv3Node::PTv3Node(const rclcpp::NodeOptions & options) : Node("ptv3", options)
   pointcloud_sub_ =
     std::make_unique<cuda_blackboard::CudaBlackboardSubscriber<cuda_blackboard::CudaPointCloud2>>(
       *this, "~/input/pointcloud",
-      std::bind(&PTv3Node::cloudCallback, this, std::placeholders::_1));
+      std::bind(&PTv3Node::cloudCallback, this, std::placeholders::_1), model_ptr_->stream());
 
   if (use_seg3d_head) {
     segmented_pointcloud_pub_ =

--- a/perception/autoware_ptv3/src/ptv3_node.cpp
+++ b/perception/autoware_ptv3/src/ptv3_node.cpp
@@ -187,8 +187,8 @@ PTv3Node::PTv3Node(const rclcpp::NodeOptions & options) : Node("ptv3", options)
 
   pointcloud_sub_ =
     std::make_unique<cuda_blackboard::CudaBlackboardSubscriber<cuda_blackboard::CudaPointCloud2>>(
-      *this, "~/input/pointcloud",
-      std::bind(&PTv3Node::cloudCallback, this, std::placeholders::_1), model_ptr_->stream());
+      *this, "~/input/pointcloud", std::bind(&PTv3Node::cloudCallback, this, std::placeholders::_1),
+      model_ptr_->stream());
 
   if (use_seg3d_head) {
     segmented_pointcloud_pub_ =


### PR DESCRIPTION
## Summary
Move to new `cuda_blackboard` stream-ordered API.

## Dependency
- Depends on autowarefoundation/cuda_blackboard#22
