### PR TITLE
perf(autoware_cuda_pointcloud_preprocessor): hand node streams to cuda_blackboard

### DIFF
--- a/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_concatenate_data/cuda_combine_cloud_handler.hpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_concatenate_data/cuda_combine_cloud_handler.hpp
@@ -55,10 +55,15 @@ public:
 
   void allocate_pointclouds() override;
 
+<<<<<<< HEAD
   // Per-topic CUDA stream on which that topic's point cloud is consumed during concatenation. It is
   // handed to the topic's CudaBlackboardSubscriber so the blackboard can order the
   // producer/consumer and the buffer free at the stream level instead of synchronizing the whole
   // process.
+=======
+  /// Returns the per-topic CUDA stream used while consuming that topic's cloud.
+  /// Use this stream when constructing the topic's CudaBlackboardSubscriber.
+>>>>>>> 9030ff412f (sensing/cuda_pp: shorten stream docstrings and drop constructor comment)
   cudaStream_t get_stream(const std::string & topic) const
   {
     return cuda_concat_struct_map_.at(topic).stream;

--- a/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_concatenate_data/cuda_combine_cloud_handler.hpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_concatenate_data/cuda_combine_cloud_handler.hpp
@@ -55,15 +55,8 @@ public:
 
   void allocate_pointclouds() override;
 
-<<<<<<< HEAD
-  // Per-topic CUDA stream on which that topic's point cloud is consumed during concatenation. It is
-  // handed to the topic's CudaBlackboardSubscriber so the blackboard can order the
-  // producer/consumer and the buffer free at the stream level instead of synchronizing the whole
-  // process.
-=======
   /// Returns the per-topic CUDA stream used while consuming that topic's cloud.
-  /// Use this stream when constructing the topic's CudaBlackboardSubscriber.
->>>>>>> 9030ff412f (sensing/cuda_pp: shorten stream docstrings and drop constructor comment)
+  /// Enables stream-ordered producer/consumer lifetime handling.
   cudaStream_t get_stream(const std::string & topic) const
   {
     return cuda_concat_struct_map_.at(topic).stream;

--- a/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_concatenate_data/cuda_combine_cloud_handler.hpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_concatenate_data/cuda_combine_cloud_handler.hpp
@@ -57,7 +57,7 @@ public:
 
   /// Returns the per-topic CUDA stream used while consuming that topic's cloud.
   /// Enables stream-ordered producer/consumer lifetime handling.
-  cudaStream_t get_stream(const std::string & topic) const
+  cudaStream_t stream(const std::string & topic) const
   {
     return cuda_concat_struct_map_.at(topic).stream;
   }

--- a/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_concatenate_data/cuda_combine_cloud_handler.hpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_concatenate_data/cuda_combine_cloud_handler.hpp
@@ -54,6 +54,14 @@ public:
     const std::shared_ptr<CollectorInfoBase> & collector_info);
 
   void allocate_pointclouds() override;
+
+  // Per-topic CUDA stream on which that topic's point cloud is consumed during concatenation. It is
+  // handed to the topic's CudaBlackboardSubscriber so the blackboard can order the producer/consumer
+  // and the buffer free at the stream level instead of synchronizing the whole process.
+  cudaStream_t get_stream(const std::string & topic) const
+  {
+    return cuda_concat_struct_map_.at(topic).stream;
+  }
 };
 
 }  // namespace autoware::pointcloud_preprocessor

--- a/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_concatenate_data/cuda_combine_cloud_handler.hpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_concatenate_data/cuda_combine_cloud_handler.hpp
@@ -56,8 +56,9 @@ public:
   void allocate_pointclouds() override;
 
   // Per-topic CUDA stream on which that topic's point cloud is consumed during concatenation. It is
-  // handed to the topic's CudaBlackboardSubscriber so the blackboard can order the producer/consumer
-  // and the buffer free at the stream level instead of synchronizing the whole process.
+  // handed to the topic's CudaBlackboardSubscriber so the blackboard can order the
+  // producer/consumer and the buffer free at the stream level instead of synchronizing the whole
+  // process.
   cudaStream_t get_stream(const std::string & topic) const
   {
     return cuda_concat_struct_map_.at(topic).stream;

--- a/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_downsample_filter/cuda_voxel_grid_downsample_filter.hpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_downsample_filter/cuda_voxel_grid_downsample_filter.hpp
@@ -91,6 +91,11 @@ public:
   std::unique_ptr<cuda_blackboard::CudaPointCloud2> filter(
     const cuda_blackboard::CudaPointCloud2::ConstSharedPtr & input_points);
 
+  // CUDA stream on which the input point cloud is consumed. It is handed to the
+  // CudaBlackboardSubscriber so the blackboard can order the producer/consumer and the buffer free
+  // at the stream level instead of synchronizing the whole process.
+  cudaStream_t stream() const { return stream_; }
+
 private:
   template <typename T>
   T * allocateBufferFromPool(size_t num_elements);

--- a/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_downsample_filter/cuda_voxel_grid_downsample_filter.hpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_downsample_filter/cuda_voxel_grid_downsample_filter.hpp
@@ -92,7 +92,7 @@ public:
     const cuda_blackboard::CudaPointCloud2::ConstSharedPtr & input_points);
 
   /// CUDA stream used by this filter to consume input pointclouds.
-  /// Pass this to CudaBlackboardSubscriber for stream-level producer/consumer ordering.
+  /// Enables stream-ordered producer/consumer lifetime handling.
   cudaStream_t stream() const { return stream_; }
 
 private:

--- a/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_downsample_filter/cuda_voxel_grid_downsample_filter.hpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_downsample_filter/cuda_voxel_grid_downsample_filter.hpp
@@ -91,9 +91,8 @@ public:
   std::unique_ptr<cuda_blackboard::CudaPointCloud2> filter(
     const cuda_blackboard::CudaPointCloud2::ConstSharedPtr & input_points);
 
-  // CUDA stream on which the input point cloud is consumed. It is handed to the
-  // CudaBlackboardSubscriber so the blackboard can order the producer/consumer and the buffer free
-  // at the stream level instead of synchronizing the whole process.
+  /// CUDA stream used by this filter to consume input pointclouds.
+  /// Pass this to CudaBlackboardSubscriber for stream-level producer/consumer ordering.
   cudaStream_t stream() const { return stream_; }
 
 private:

--- a/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_outlier_filter/cuda_polar_voxel_noise_filter.hpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_outlier_filter/cuda_polar_voxel_noise_filter.hpp
@@ -158,6 +158,10 @@ public:
     set_return_types(primary_types, primary_return_type_dev_);
   }
 
+  /// CUDA stream used by this filter to consume input pointclouds.
+  /// Enables stream-ordered producer/consumer lifetime handling.
+  cudaStream_t stream() const { return stream_; }
+
 protected:
   enum class ReductionType : uint8_t { Min, Max, Sum };
 

--- a/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_outlier_filter/cuda_polar_voxel_outlier_filter.hpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_outlier_filter/cuda_polar_voxel_outlier_filter.hpp
@@ -195,6 +195,11 @@ public:
     set_return_types(primary_types, primary_return_type_dev_);
   }
 
+  // CUDA stream on which the input point cloud is consumed. It is handed to the
+  // CudaBlackboardSubscriber so the blackboard can order the producer/consumer and the buffer free
+  // at the stream level instead of synchronizing the whole process.
+  cudaStream_t stream() const { return stream_; }
+
 protected:
   enum class ReductionType : uint8_t { Min, Max, Sum };
 

--- a/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_outlier_filter/cuda_polar_voxel_outlier_filter.hpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_outlier_filter/cuda_polar_voxel_outlier_filter.hpp
@@ -195,9 +195,8 @@ public:
     set_return_types(primary_types, primary_return_type_dev_);
   }
 
-  // CUDA stream on which the input point cloud is consumed. It is handed to the
-  // CudaBlackboardSubscriber so the blackboard can order the producer/consumer and the buffer free
-  // at the stream level instead of synchronizing the whole process.
+  /// CUDA stream used by this filter to consume input pointclouds.
+  /// Pass this to CudaBlackboardSubscriber for stream-level producer/consumer ordering.
   cudaStream_t stream() const { return stream_; }
 
 protected:

--- a/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_outlier_filter/cuda_polar_voxel_outlier_filter.hpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_outlier_filter/cuda_polar_voxel_outlier_filter.hpp
@@ -196,7 +196,7 @@ public:
   }
 
   /// CUDA stream used by this filter to consume input pointclouds.
-  /// Pass this to CudaBlackboardSubscriber for stream-level producer/consumer ordering.
+  /// Enables stream-ordered producer/consumer lifetime handling.
   cudaStream_t stream() const { return stream_; }
 
 protected:

--- a/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_concatenate_data/cuda_concatenate_and_time_sync_node.cpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_concatenate_data/cuda_concatenate_and_time_sync_node.cpp
@@ -55,7 +55,7 @@ void PointCloudConcatenateDataSynchronizerComponentTemplated<
 
     auto pointcloud_sub =
       std::make_shared<cuda_blackboard::CudaBlackboardSubscriber<cuda_blackboard::CudaPointCloud2>>(
-        *this, topic, false, callback);
+        *this, topic, callback, combine_cloud_handler_->get_stream(topic));
     pointcloud_subs_.push_back(pointcloud_sub);
   }
 

--- a/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_concatenate_data/cuda_concatenate_and_time_sync_node.cpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_concatenate_data/cuda_concatenate_and_time_sync_node.cpp
@@ -55,7 +55,7 @@ void PointCloudConcatenateDataSynchronizerComponentTemplated<
 
     auto pointcloud_sub =
       std::make_shared<cuda_blackboard::CudaBlackboardSubscriber<cuda_blackboard::CudaPointCloud2>>(
-        *this, topic, callback, combine_cloud_handler_->get_stream(topic));
+        *this, topic, callback, combine_cloud_handler_->stream(topic));
     pointcloud_subs_.push_back(pointcloud_sub);
   }
 

--- a/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_downsample_filter/cuda_voxel_grid_downsample_filter_node.cpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_downsample_filter/cuda_voxel_grid_downsample_filter_node.cpp
@@ -35,18 +35,20 @@ CudaVoxelGridDownsampleFilterNode::CudaVoxelGridDownsampleFilterNode(
     return;
   }
 
+  // Construct the filter first so its CUDA stream can be handed to the subscriber below.
+  cuda_voxel_grid_downsample_filter_ = std::make_unique<CudaVoxelGridDownsampleFilter>(
+    voxel_size_x, voxel_size_y, voxel_size_z, max_mem_pool_size_in_byte);
+
   sub_ =
     std::make_shared<cuda_blackboard::CudaBlackboardSubscriber<cuda_blackboard::CudaPointCloud2>>(
       *this, "~/input/pointcloud",
       std::bind(
-        &CudaVoxelGridDownsampleFilterNode::cudaPointcloudCallback, this, std::placeholders::_1));
+        &CudaVoxelGridDownsampleFilterNode::cudaPointcloudCallback, this, std::placeholders::_1),
+      cuda_voxel_grid_downsample_filter_->stream());
 
   pub_ =
     std::make_unique<cuda_blackboard::CudaBlackboardPublisher<cuda_blackboard::CudaPointCloud2>>(
       *this, "~/output/pointcloud");
-
-  cuda_voxel_grid_downsample_filter_ = std::make_unique<CudaVoxelGridDownsampleFilter>(
-    voxel_size_x, voxel_size_y, voxel_size_z, max_mem_pool_size_in_byte);
 }
 
 void CudaVoxelGridDownsampleFilterNode::cudaPointcloudCallback(

--- a/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_downsample_filter/cuda_voxel_grid_downsample_filter_node.cpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_downsample_filter/cuda_voxel_grid_downsample_filter_node.cpp
@@ -35,7 +35,6 @@ CudaVoxelGridDownsampleFilterNode::CudaVoxelGridDownsampleFilterNode(
     return;
   }
 
-  // Construct the filter first so its CUDA stream can be handed to the subscriber below.
   cuda_voxel_grid_downsample_filter_ = std::make_unique<CudaVoxelGridDownsampleFilter>(
     voxel_size_x, voxel_size_y, voxel_size_z, max_mem_pool_size_in_byte);
 

--- a/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_outlier_filter/cuda_polar_voxel_noise_filter_node.cpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_outlier_filter/cuda_polar_voxel_noise_filter_node.cpp
@@ -132,7 +132,8 @@ CudaPolarVoxelNoiseFilterNode::CudaPolarVoxelNoiseFilterNode(
   pointcloud_sub_ =
     std::make_shared<cuda_blackboard::CudaBlackboardSubscriber<cuda_blackboard::CudaPointCloud2>>(
       *this, "~/input/pointcloud",
-      std::bind(&CudaPolarVoxelNoiseFilterNode::pointcloud_callback, this, std::placeholders::_1));
+      std::bind(&CudaPolarVoxelNoiseFilterNode::pointcloud_callback, this, std::placeholders::_1),
+      cuda_polar_voxel_noise_filter_->stream());
 
   filtered_cloud_pub_ =
     std::make_unique<cuda_blackboard::CudaBlackboardPublisher<cuda_blackboard::CudaPointCloud2>>(

--- a/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_outlier_filter/cuda_polar_voxel_outlier_filter_node.cpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_outlier_filter/cuda_polar_voxel_outlier_filter_node.cpp
@@ -106,8 +106,7 @@ CudaPolarVoxelOutlierFilterNode::CudaPolarVoxelOutlierFilterNode(
   pointcloud_sub_ =
     std::make_shared<cuda_blackboard::CudaBlackboardSubscriber<cuda_blackboard::CudaPointCloud2>>(
       *this, "~/input/pointcloud",
-      std::bind(
-        &CudaPolarVoxelOutlierFilterNode::pointcloud_callback, this, std::placeholders::_1),
+      std::bind(&CudaPolarVoxelOutlierFilterNode::pointcloud_callback, this, std::placeholders::_1),
       cuda_polar_voxel_outlier_filter_->stream());
 
   filtered_cloud_pub_ =

--- a/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_outlier_filter/cuda_polar_voxel_outlier_filter_node.cpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_outlier_filter/cuda_polar_voxel_outlier_filter_node.cpp
@@ -107,7 +107,8 @@ CudaPolarVoxelOutlierFilterNode::CudaPolarVoxelOutlierFilterNode(
     std::make_shared<cuda_blackboard::CudaBlackboardSubscriber<cuda_blackboard::CudaPointCloud2>>(
       *this, "~/input/pointcloud",
       std::bind(
-        &CudaPolarVoxelOutlierFilterNode::pointcloud_callback, this, std::placeholders::_1));
+        &CudaPolarVoxelOutlierFilterNode::pointcloud_callback, this, std::placeholders::_1),
+      cuda_polar_voxel_outlier_filter_->stream());
 
   filtered_cloud_pub_ =
     std::make_unique<cuda_blackboard::CudaBlackboardPublisher<cuda_blackboard::CudaPointCloud2>>(


### PR DESCRIPTION
## Summary
Move to new `cuda_blackboard` stream-ordered API.

## Dependency
- Depends on autowarefoundation/cuda_blackboard#22
