### PR TITLE
chore(data_association_matrix.param.yaml): remove OVERRIDE marker from master file

### DIFF
--- a/perception/autoware_tracking_object_merger/config/data_association_matrix.param.yaml
+++ b/perception/autoware_tracking_object_merger/config/data_association_matrix.param.yaml
@@ -67,7 +67,7 @@
         0.1,     0.1,   0.1,   0.1,    0.1,      0.1,       0.1,      0.1,        0.1,     0.1]     #HAZARD
 
     lidar-radar:
-      can_assign_matrix: # {OVERRIDE}
+      can_assign_matrix:
         #UNKNOWN, CAR, TRUCK, BUS, TRAILER, MOTORBIKE, BICYCLE, PEDESTRIAN, ANIMAL, HAZARD
         [1,       1,   1,     1,    1,       1,         1,       1,          1,      1,      #UNKNOWN
         1,       1,   1,     1,    1,       1,         1,       1,          1,      1,      #CAR
@@ -80,7 +80,7 @@
         1,       1,   1,     1,    1,       1,         1,       1,          1,      1,      #ANIMAL
         1,       1,   1,     1,    1,       1,         1,       1,          1,      1]      #HAZARD
 
-      max_dist_matrix: # {OVERRIDE}
+      max_dist_matrix:
         #UNKNOWN, CAR, TRUCK, BUS, TRAILER, MOTORBIKE, BICYCLE, PEDESTRIAN, ANIMAL, HAZARD
         [4.0,     4.0, 5.0,   5.0,  5.0,     3.5,       3.5,      3.5,        4.0,    4.0,    #UNKNOWN
         4.0,     5.5, 6.0,   6.0,  6.0,     3.0,       3.0,      3.0,        4.0,    4.0,    #CAR


### PR DESCRIPTION
## Description

`# {OVERRIDE}` comment marker is only used for [sync-params workflow](https://github.com/autowarefoundation/autoware/issues/7048), which does not belong to the upstream file. Removing the comment.

## Related links

## How was this PR tested?

None. only a comment issue.

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.
