### PR TITLE
refactor(tensorrt_yolox): unify preprocessing on GPU and remove CPU path

### DIFF
--- a/perception/autoware_tensorrt_yolox/config/yolox_s_plus_opt.param.yaml
+++ b/perception/autoware_tensorrt_yolox/config/yolox_s_plus_opt.param.yaml
@@ -32,6 +32,5 @@
     quantize_last_layer: false # If true, set the operating precision for the last (output) layer to be fp16. This option is valid only when precision==int8.
     profile_per_layer: false # If true, profiler function will be enabled. Since the profile function may affect execution speed, it is recommended to set this flag true only for development purpose.
     clip_value: 6.0 # If positive value is specified, the value of each layer output will be clipped between [0.0, clip_value]. This option is valid only when precision==int8 and used to manually specify the dynamic range instead of using any calibration.
-    preprocess_on_gpu: true # If true, pre-processing is performed on GPU.
     gpu_id: 0 # GPU ID to select CUDA Device
     calibration_image_list_path: "" # Path to a file which contains path to images. Those images will be used for int8 quantization.

--- a/perception/autoware_tensorrt_yolox/config/yolox_tiny.param.yaml
+++ b/perception/autoware_tensorrt_yolox/config/yolox_tiny.param.yaml
@@ -32,6 +32,5 @@
     quantize_last_layer: false # If true, set the operating precision for the last (output) layer to be fp16. This option is valid only when precision==int8.
     profile_per_layer: false # If true, profiler function will be enabled. Since the profile function may affect execution speed, it is recommended to set this flag true only for development purpose.
     clip_value: 0.0 # If positive value is specified, the value of each layer output will be clipped between [0.0, clip_value]. This option is valid only when precision==int8 and used to manually specify the dynamic range instead of using any calibration.
-    preprocess_on_gpu: true # If true, pre-processing is performed on GPU.
     gpu_id: 0 # GPU ID to select CUDA Device
     calibration_image_list_path: "" # Path to a file which contains path to images. Those images will be used for int8 quantization.

--- a/perception/autoware_tensorrt_yolox/config/yolox_traffic_light_detector.param.yaml
+++ b/perception/autoware_tensorrt_yolox/config/yolox_traffic_light_detector.param.yaml
@@ -11,7 +11,6 @@
     quantize_last_layer: false # If true, set the operating precision for the last (output) layer to be fp16. This option is valid only when precision==int8.
     profile_per_layer: false # If true, profiler function will be enabled. Since the profile function may affect execution speed, it is recommended to set this flag true only for development purpose.
     clip_value: 6.0 # If positive value is specified, the value of each layer output will be clipped between [0.0, clip_value]. This option is valid only when precision==int8 and used to manually specify the dynamic range instead of using any calibration.
-    preprocess_on_gpu: true # If true, pre-processing is performed on GPU.
     gpu_id: 0 # GPU ID to select CUDA Device
     calibration_image_list_path: "" # Path to a file which contains path to images. Those images will be used for int8 quantization.
 

--- a/perception/autoware_tensorrt_yolox/include/autoware/tensorrt_yolox/tensorrt_yolox.hpp
+++ b/perception/autoware_tensorrt_yolox/include/autoware/tensorrt_yolox/tensorrt_yolox.hpp
@@ -76,7 +76,6 @@ public:
    * @param[in] num_class classifier-ed num
    * @param[in] score_threshold threshold for detection
    * @param[in] nms_threshold threshold for NMS
-   * @param[in] use_gpu_preprocess whether use cuda gpu for preprocessing
    * @param[in] gpu_id GPU id for inference
    * @param[in] calibration_image_list_path path for calibration files (only require for
    * quantization)
@@ -86,9 +85,9 @@ public:
    */
   TrtYoloX(
     TrtCommonConfig & trt_config, const int num_class = 8, const float score_threshold = 0.3,
-    const float nms_threshold = 0.7, const bool use_gpu_preprocess = false,
-    const uint8_t gpu_id = 0, std::string calibration_image_list_path = std::string(),
-    const double norm_factor = 1.0, [[maybe_unused]] const std::string & cache_dir = "",
+    const float nms_threshold = 0.7, const uint8_t gpu_id = 0,
+    std::string calibration_image_list_path = std::string(), const double norm_factor = 1.0,
+    [[maybe_unused]] const std::string & cache_dir = "",
     const CalibrationConfig & calib_config = CalibrationConfig());
   /**
    * @brief Deconstruct TrtYoloX
@@ -151,23 +150,10 @@ public:
 
 private:
   /**
-   * @brief run preprocess including resizing, letterbox, NHWC2NCHW and toFloat on CPU
-   * @param[in] images batching images
-   */
-  void preprocess(const std::vector<cv::Mat> & images);
-
-  /**
    * @brief run preprocess on GPU
    * @param[in] images batching images
    */
   void preprocessGpu(const std::vector<cv::Mat> & images);
-
-  /**
-   * @brief run multi-scale preprocess including resizing, letterbox, NHWC2NCHW and toFloat on CPU
-   * @param[in] images batching images
-   * @param[in] rois region of interest
-   */
-  void multiScalePreprocess(const cv::Mat & image, const std::vector<cv::Rect> & rois);
 
   /**
    * @brief run multi-scale preprocess including resizing, letterbox, NHWC2NCHW and toFloat on GPU
@@ -213,16 +199,6 @@ private:
     const ObjectArray & face_objects, std::vector<int> & picked, float nms_threshold) const;
 
   /**
-   * @brief get a mask image for a segmentation head
-   * @param[out] argmax argmax results
-   * @param[in] prob probability map
-   * @param[in] dims dimension for probability map
-   * @param[in] out_w mask width excluding letterbox
-   * @param[in] out_h mask height excluding letterbox
-   */
-  cv::Mat getMaskImage(float * prob, nvinfer1::Dims dims, int out_w, int out_h);
-
-  /**
    * @brief get a mask image on GPUs for a segmentation head
    * @param[out] mask image
    * @param[in] prob probability map on device
@@ -234,7 +210,6 @@ private:
 
   std::unique_ptr<TrtConvCalib> trt_common_;
 
-  std::vector<float> input_h_;
   CudaUniquePtr<float[]> input_d_;
   CudaUniquePtr<int32_t[]> out_num_detections_d_;
   CudaUniquePtr<float[]> out_boxes_d_;
@@ -257,8 +232,6 @@ private:
   int32_t batch_size_;
   CudaUniquePtrHost<float[]> out_prob_h_;
 
-  // flag whether preprocess are performed on GPU
-  bool use_gpu_preprocess_;
   // GPU id for inference
   const uint8_t gpu_id_;
   // flag for gpu initialization
@@ -284,7 +257,6 @@ private:
   int multitask_;
   // buff size for segmentation heads
   CudaUniquePtr<float[]> segmentation_out_prob_d_;
-  CudaUniquePtrHost<float[]> segmentation_out_prob_h_;
   size_t segmentation_out_elem_num_;
   size_t segmentation_out_elem_num_per_batch_;
   std::vector<cv::Mat> segmentation_masks_;

--- a/perception/autoware_tensorrt_yolox/include/autoware/tensorrt_yolox/tensorrt_yolox_detector.hpp
+++ b/perception/autoware_tensorrt_yolox/include/autoware/tensorrt_yolox/tensorrt_yolox_detector.hpp
@@ -77,7 +77,6 @@ struct TrtYoloXDetectorConfig
   bool quantize_last_layer;
   bool profile_per_layer;
   double clip_value;
-  bool preprocess_on_gpu;
   std::string calibration_image_list_path;
   uint8_t gpu_id;
 

--- a/perception/autoware_tensorrt_yolox/schema/yolox_s_plus_opt.schema.json
+++ b/perception/autoware_tensorrt_yolox/schema/yolox_s_plus_opt.schema.json
@@ -74,11 +74,6 @@
           "description": "Maximum clipping value for layer output. Valid only for int8 precision.",
           "default": 6.0
         },
-        "preprocess_on_gpu": {
-          "type": "boolean",
-          "description": "Enable preprocessing on GPU.",
-          "default": true
-        },
         "gpu_id": {
           "type": "integer",
           "description": "GPU ID for selecting CUDA device.",
@@ -104,7 +99,6 @@
         "quantize_last_layer",
         "profile_per_layer",
         "clip_value",
-        "preprocess_on_gpu",
         "gpu_id",
         "calibration_image_list_path"
       ],

--- a/perception/autoware_tensorrt_yolox/schema/yolox_tiny.schema.json
+++ b/perception/autoware_tensorrt_yolox/schema/yolox_tiny.schema.json
@@ -74,11 +74,6 @@
           "description": "Maximum clipping value for layer outputs. Valid only for int8 precision.",
           "default": 0.0
         },
-        "preprocess_on_gpu": {
-          "type": "boolean",
-          "description": "Enable preprocessing on the GPU.",
-          "default": true
-        },
         "gpu_id": {
           "type": "integer",
           "description": "GPU ID for selecting the CUDA device.",
@@ -104,7 +99,6 @@
         "quantize_last_layer",
         "profile_per_layer",
         "clip_value",
-        "preprocess_on_gpu",
         "gpu_id",
         "calibration_image_list_path"
       ],

--- a/perception/autoware_tensorrt_yolox/schema/yolox_traffic_light_detector.schema.json
+++ b/perception/autoware_tensorrt_yolox/schema/yolox_traffic_light_detector.schema.json
@@ -55,11 +55,6 @@
           "default": 0.0,
           "description": "If positive value is specified, the value of each layer output will be clipped between [0.0, clip_value]. This option is valid only when precision==int8 and used to manually specify the dynamic range instead of using any calibration."
         },
-        "preprocess_on_gpu": {
-          "type": "boolean",
-          "default": true,
-          "description": "If true, pre-processing is performed on GPU."
-        },
         "gpu_id": {
           "type": "integer",
           "default": 0,
@@ -100,7 +95,6 @@
         "quantize_last_layer",
         "profile_per_layer",
         "clip_value",
-        "preprocess_on_gpu",
         "gpu_id",
         "calibration_image_list_path",
         "is_roi_overlap_segmentation",

--- a/perception/autoware_tensorrt_yolox/src/tensorrt_yolox.cpp
+++ b/perception/autoware_tensorrt_yolox/src/tensorrt_yolox.cpp
@@ -22,7 +22,6 @@
 #include <experimental/filesystem>
 
 #include <algorithm>
-#include <fstream>
 #include <functional>
 #include <iostream>
 #include <memory>
@@ -36,9 +35,9 @@ namespace autoware::tensorrt_yolox
 {
 TrtYoloX::TrtYoloX(
   TrtCommonConfig & trt_config, const int num_class, const float score_threshold,
-  const float nms_threshold, const bool use_gpu_preprocess, const uint8_t gpu_id,
-  std::string calibration_image_list_path, const double norm_factor,
-  [[maybe_unused]] const std::string & cache_dir, const CalibrationConfig & calib_config)
+  const float nms_threshold, const uint8_t gpu_id, std::string calibration_image_list_path,
+  const double norm_factor, [[maybe_unused]] const std::string & cache_dir,
+  const CalibrationConfig & calib_config)
 : gpu_id_(gpu_id), is_gpu_initialized_(false)
 {
   if (!setCudaDeviceId(gpu_id_)) {
@@ -209,35 +208,26 @@ TrtYoloX::TrtYoloX(
       static_cast<int>(segmentation_out_elem_num_ / batch_size_);
     segmentation_out_prob_d_ =
       autoware::cuda_utils::make_unique<float[]>(segmentation_out_elem_num_);
-    segmentation_out_prob_h_ = autoware::cuda_utils::make_unique_host<float[]>(
-      segmentation_out_elem_num_, cudaHostAllocPortable);
   }
-  if (use_gpu_preprocess) {
-    use_gpu_preprocess_ = true;
-    image_buf_h_ = nullptr;
-    image_buf_d_ = nullptr;
-    if (multitask_) {
-      argmax_buf_h_ = nullptr;
-      argmax_buf_d_ = nullptr;
-    }
-  } else {
-    use_gpu_preprocess_ = false;
+  image_buf_h_ = nullptr;
+  image_buf_d_ = nullptr;
+  if (multitask_) {
+    argmax_buf_h_ = nullptr;
+    argmax_buf_d_ = nullptr;
   }
 }
 
 TrtYoloX::~TrtYoloX()
 {
   try {
-    if (use_gpu_preprocess_) {
-      if (image_buf_h_) {
-        image_buf_h_.reset();
-      }
-      if (image_buf_d_) {
-        image_buf_d_.reset();
-      }
-      if (argmax_buf_d_) {
-        argmax_buf_d_.reset();
-      }
+    if (image_buf_h_) {
+      image_buf_h_.reset();
+    }
+    if (image_buf_d_) {
+      image_buf_d_.reset();
+    }
+    if (argmax_buf_d_) {
+      argmax_buf_d_.reset();
     }
   } catch (const std::exception & e) {
     std::cerr << "Exception in TrtYoloX destructor: " << e.what() << std::endl;
@@ -272,52 +262,50 @@ void TrtYoloX::initPreprocessBuffer(int width, int height)
   }
   src_width_ = width;
   src_height_ = height;
-  if (use_gpu_preprocess_) {
-    auto input_dims = trt_common_->getTensorShape(0);
-    bool const hasRuntimeDim = std::any_of(
-      input_dims.d, input_dims.d + input_dims.nbDims,
-      [](int32_t input_dim) { return input_dim == -1; });
-    if (hasRuntimeDim) {
-      input_dims.d[0] = batch_size_;
+  auto input_dims = trt_common_->getTensorShape(0);
+  bool const hasRuntimeDim = std::any_of(
+    input_dims.d, input_dims.d + input_dims.nbDims,
+    [](int32_t input_dim) { return input_dim == -1; });
+  if (hasRuntimeDim) {
+    input_dims.d[0] = batch_size_;
+  }
+  if (!image_buf_h_) {
+    if (!trt_common_->setInputShape(0, input_dims)) {
+      return;
     }
-    if (!image_buf_h_) {
-      if (!trt_common_->setInputShape(0, input_dims)) {
-        return;
-      }
-      scales_.clear();
+    scales_.clear();
+  }
+  const float input_height = static_cast<float>(input_dims.d[2]);
+  const float input_width = static_cast<float>(input_dims.d[3]);
+  if (!image_buf_h_) {
+    const float scale = std::min(input_width / width, input_height / height);
+    for (int b = 0; b < batch_size_; b++) {
+      scales_.emplace_back(scale);
     }
-    const float input_height = static_cast<float>(input_dims.d[2]);
-    const float input_width = static_cast<float>(input_dims.d[3]);
-    if (!image_buf_h_) {
-      const float scale = std::min(input_width / width, input_height / height);
-      for (int b = 0; b < batch_size_; b++) {
-        scales_.emplace_back(scale);
-      }
-      image_buf_h_ = autoware::cuda_utils::make_unique_host<unsigned char[]>(
-        width * height * 3 * batch_size_, cudaHostAllocWriteCombined);
-      image_buf_d_ =
-        autoware::cuda_utils::make_unique<unsigned char[]>(width * height * 3 * batch_size_);
+    image_buf_h_ = autoware::cuda_utils::make_unique_host<unsigned char[]>(
+      width * height * 3 * batch_size_, cudaHostAllocWriteCombined);
+    image_buf_d_ =
+      autoware::cuda_utils::make_unique<unsigned char[]>(width * height * 3 * batch_size_);
+  }
+  if (multitask_) {
+    size_t argmax_out_elem_num = 0;
+    for (int m = 0; m < multitask_; m++) {
+      const auto output_dims =
+        trt_common_->getTensorShape(m + 2);  // 0 : input, 1 : output for detections
+      const float scale = std::min(
+        output_dims.d[3] / static_cast<float>(width),
+        output_dims.d[2] / static_cast<float>(height));
+      int out_w = static_cast<int>(width * scale);
+      int out_h = static_cast<int>(height * scale);
+      // size_t out_elem_num = std::accumulate(
+      // output_dims.d + 1, output_dims.d + output_dims.nbDims, 1, std::multiplies<int>());
+      // out_elem_num = out_elem_num * batch_size_;
+      size_t out_elem_num = out_w * out_h * batch_size_;
+      argmax_out_elem_num += out_elem_num;
     }
-    if (multitask_) {
-      size_t argmax_out_elem_num = 0;
-      for (int m = 0; m < multitask_; m++) {
-        const auto output_dims =
-          trt_common_->getTensorShape(m + 2);  // 0 : input, 1 : output for detections
-        const float scale = std::min(
-          output_dims.d[3] / static_cast<float>(width),
-          output_dims.d[2] / static_cast<float>(height));
-        int out_w = static_cast<int>(width * scale);
-        int out_h = static_cast<int>(height * scale);
-        // size_t out_elem_num = std::accumulate(
-        // output_dims.d + 1, output_dims.d + output_dims.nbDims, 1, std::multiplies<int>());
-        // out_elem_num = out_elem_num * batch_size_;
-        size_t out_elem_num = out_w * out_h * batch_size_;
-        argmax_out_elem_num += out_elem_num;
-      }
-      argmax_buf_h_ = autoware::cuda_utils::make_unique_host<unsigned char[]>(
-        argmax_out_elem_num, cudaHostAllocPortable);
-      argmax_buf_d_ = autoware::cuda_utils::make_unique<unsigned char[]>(argmax_out_elem_num);
-    }
+    argmax_buf_h_ = autoware::cuda_utils::make_unique_host<unsigned char[]>(
+      argmax_out_elem_num, cudaHostAllocPortable);
+    argmax_buf_d_ = autoware::cuda_utils::make_unique<unsigned char[]>(argmax_out_elem_num);
   }
 }
 
@@ -417,41 +405,6 @@ void TrtYoloX::preprocessGpu(const std::vector<cv::Mat> & images)
     images[0].rows, 3, batch_size, static_cast<float>(norm_factor_), *stream_);
 }
 
-void TrtYoloX::preprocess(const std::vector<cv::Mat> & images)
-{
-  const auto batch_size = images.size();
-  auto input_dims = trt_common_->getTensorShape(0);
-  input_dims.d[0] = batch_size;
-  if (!trt_common_->setInputShape(0, input_dims)) {
-    return;
-  }
-  const float input_height = static_cast<float>(input_dims.d[2]);
-  const float input_width = static_cast<float>(input_dims.d[3]);
-  std::vector<cv::Mat> dst_images;
-  scales_.clear();
-  for (const auto & image : images) {
-    cv::Mat dst_image;
-    const float scale = std::min(input_width / image.cols, input_height / image.rows);
-    scales_.emplace_back(scale);
-    const auto scale_size = cv::Size(image.cols * scale, image.rows * scale);
-    cv::resize(image, dst_image, scale_size, 0, 0, cv::INTER_CUBIC);
-    const auto bottom = input_height - dst_image.rows;
-    const auto right = input_width - dst_image.cols;
-    copyMakeBorder(dst_image, dst_image, 0, bottom, 0, right, cv::BORDER_CONSTANT, {114, 114, 114});
-    dst_images.emplace_back(dst_image);
-  }
-  const auto chw_images = cv::dnn::blobFromImages(
-    dst_images, norm_factor_, cv::Size(), cv::Scalar(), false, false, CV_32F);
-
-  const auto data_length = chw_images.total();
-  input_h_.reserve(data_length);
-  const auto flat = chw_images.reshape(1, data_length);
-  input_h_ = chw_images.isContinuous() ? flat : flat.clone();
-  CHECK_CUDA_ERROR(cudaMemcpy(
-    input_d_.get(), input_h_.data(), input_h_.size() * sizeof(float), cudaMemcpyHostToDevice));
-  // No Need for Sync
-}
-
 bool TrtYoloX::doInference(
   const std::vector<cv::Mat> & images, ObjectArrays & objects, std::vector<cv::Mat> & masks,
   [[maybe_unused]] std::vector<cv::Mat> & color_masks)
@@ -460,11 +413,7 @@ bool TrtYoloX::doInference(
     return false;
   }
 
-  if (use_gpu_preprocess_) {
-    preprocessGpu(images);
-  } else {
-    preprocess(images);
-  }
+  preprocessGpu(images);
 
   if (needs_output_decode_) {
     return feedforwardAndDecode(images, objects, masks, color_masks);
@@ -545,52 +494,10 @@ void TrtYoloX::multiScalePreprocessGpu(const cv::Mat & image, const std::vector<
     image.rows, 3, batch_size, static_cast<float>(norm_factor_), *stream_);
 }
 
-void TrtYoloX::multiScalePreprocess(const cv::Mat & image, const std::vector<cv::Rect> & rois)
-{
-  const auto batch_size = rois.size();
-  auto input_dims = trt_common_->getTensorShape(0);
-  input_dims.d[0] = batch_size;
-  if (!trt_common_->setInputShape(0, input_dims)) {
-    return;
-  }
-  const float input_height = static_cast<float>(input_dims.d[2]);
-  const float input_width = static_cast<float>(input_dims.d[3]);
-  std::vector<cv::Mat> dst_images;
-  scales_.clear();
-
-  for (const auto & roi : rois) {
-    cv::Mat dst_image;
-    cv::Mat cropped = image(roi);
-    const float scale = std::min(
-      input_width / static_cast<float>(roi.width), input_height / static_cast<float>(roi.height));
-    scales_.emplace_back(scale);
-    const auto scale_size = cv::Size(roi.width * scale, roi.height * scale);
-    cv::resize(cropped, dst_image, scale_size, 0, 0, cv::INTER_CUBIC);
-    const auto bottom = input_height - dst_image.rows;
-    const auto right = input_width - dst_image.cols;
-    copyMakeBorder(dst_image, dst_image, 0, bottom, 0, right, cv::BORDER_CONSTANT, {114, 114, 114});
-    dst_images.emplace_back(dst_image);
-  }
-  const auto chw_images = cv::dnn::blobFromImages(
-    dst_images, norm_factor_, cv::Size(), cv::Scalar(), false, false, CV_32F);
-
-  const auto data_length = chw_images.total();
-  input_h_.reserve(data_length);
-  const auto flat = chw_images.reshape(1, data_length);
-  input_h_ = chw_images.isContinuous() ? flat : flat.clone();
-  CHECK_CUDA_ERROR(cudaMemcpy(
-    input_d_.get(), input_h_.data(), input_h_.size() * sizeof(float), cudaMemcpyHostToDevice));
-  // No Need for Sync
-}
-
 bool TrtYoloX::doMultiScaleInference(
   const cv::Mat & image, ObjectArrays & objects, const std::vector<cv::Rect> & rois)
 {
-  if (use_gpu_preprocess_) {
-    multiScalePreprocessGpu(image, rois);
-  } else {
-    multiScalePreprocess(image, rois);
-  }
+  multiScalePreprocessGpu(image, rois);
   if (needs_output_decode_) {
     return multiScaleFeedforwardAndDecode(image, rois.size(), objects);
   } else {
@@ -672,11 +579,6 @@ bool TrtYoloX::feedforwardAndDecode(
   CHECK_CUDA_ERROR(cudaMemcpyAsync(
     out_prob_h_.get(), out_prob_d_.get(), sizeof(float) * out_elem_num_, cudaMemcpyDeviceToHost,
     *stream_));
-  if (multitask_ && !use_gpu_preprocess_) {
-    CHECK_CUDA_ERROR(cudaMemcpyAsync(
-      segmentation_out_prob_h_.get(), segmentation_out_prob_d_.get(),
-      sizeof(float) * segmentation_out_elem_num_, cudaMemcpyDeviceToHost, *stream_));
-  }
   cudaStreamSynchronize(*stream_);
   objects.clear();
 
@@ -704,16 +606,10 @@ bool TrtYoloX::feedforwardAndDecode(
           output_dims.d[2] / static_cast<float>(image_size.height));
         int out_w = static_cast<int>(image_size.width * scale);
         int out_h = static_cast<int>(image_size.height * scale);
-        cv::Mat mask;
-        if (use_gpu_preprocess_) {
-          float * d_segmentation_results =
-            segmentation_out_prob_d_.get() + (i * segmentation_out_elem_num_per_batch_);
-          mask = getMaskImageGpu(&(d_segmentation_results[counter]), output_dims, out_w, out_h, i);
-        } else {
-          float * segmentation_results =
-            segmentation_out_prob_h_.get() + (i * segmentation_out_elem_num_per_batch_);
-          mask = getMaskImage(&(segmentation_results[counter]), output_dims, out_w, out_h);
-        }
+        float * d_segmentation_results =
+          segmentation_out_prob_d_.get() + (i * segmentation_out_elem_num_per_batch_);
+        cv::Mat mask =
+          getMaskImageGpu(&(d_segmentation_results[counter]), output_dims, out_w, out_h, i);
         segmentation_masks_.emplace_back(std::move(mask));
         counter += out_elem_num;
       }
@@ -1013,32 +909,6 @@ cv::Mat TrtYoloX::getMaskImageGpu(float * d_prob, nvinfer1::Dims dims, int out_w
     cudaMemcpyDeviceToHost, *stream_));
   cudaStreamSynchronize(*stream_);
   std::memcpy(mask.data, argmax_buf_h_.get() + index, sizeof(unsigned char) * 1 * out_w * out_h);
-  return mask;
-}
-
-cv::Mat TrtYoloX::getMaskImage(float * prob, nvinfer1::Dims dims, int out_w, int out_h)
-{
-  // NCHW
-  int classes = dims.d[1];
-  int height = dims.d[2];
-  int width = dims.d[3];
-  cv::Mat mask = cv::Mat::zeros(out_h, out_w, CV_8UC1);
-  // argmax
-  // #pragma omp parallel for
-  for (int y = 0; y < out_h; y++) {
-    for (int x = 0; x < out_w; x++) {
-      float max = 0.0;
-      int index = 0;
-      for (int c = 0; c < classes; c++) {
-        float value = prob[c * height * width + y * width + x];
-        if (max < value) {
-          max = value;
-          index = c;
-        }
-      }
-      mask.at<unsigned char>(y, x) = index;
-    }
-  }
   return mask;
 }
 

--- a/perception/autoware_tensorrt_yolox/src/tensorrt_yolox_detector.cpp
+++ b/perception/autoware_tensorrt_yolox/src/tensorrt_yolox_detector.cpp
@@ -74,8 +74,7 @@ TrtYoloXDetector::TrtYoloXDetector(const TrtYoloXDetectorConfig & config) : conf
 
   trt_yolox_ = std::make_unique<tensorrt_yolox::TrtYoloX>(
     trt_config, roi_class_name_list_.size(), config_.score_threshold, config_.nms_threshold,
-    config_.preprocess_on_gpu, config_.gpu_id, config_.calibration_image_list_path, norm_factor,
-    cache_dir, calib_config);
+    config_.gpu_id, config_.calibration_image_list_path, norm_factor, cache_dir, calib_config);
 }
 
 bool TrtYoloXDetector::isGPUInitialized() const

--- a/perception/autoware_tensorrt_yolox/src/tensorrt_yolox_node.cpp
+++ b/perception/autoware_tensorrt_yolox/src/tensorrt_yolox_node.cpp
@@ -15,7 +15,6 @@
 #include "autoware/tensorrt_yolox/tensorrt_yolox_node.hpp"
 
 #include <memory>
-#include <optional>
 #include <string>
 
 // cspell: ignore semseg
@@ -45,7 +44,6 @@ TrtYoloXNode::TrtYoloXNode(const rclcpp::NodeOptions & node_options)
   config.quantize_last_layer = this->declare_parameter<bool>("quantize_last_layer");
   config.profile_per_layer = this->declare_parameter<bool>("profile_per_layer");
   config.clip_value = this->declare_parameter<double>("clip_value");
-  config.preprocess_on_gpu = this->declare_parameter<bool>("preprocess_on_gpu");
   config.calibration_image_list_path =
     this->declare_parameter<std::string>("calibration_image_list_path");
   config.gpu_id = this->declare_parameter<uint8_t>("gpu_id");

--- a/perception/autoware_tensorrt_yolox/test/test_tensorrt_yolox_node.cpp
+++ b/perception/autoware_tensorrt_yolox/test/test_tensorrt_yolox_node.cpp
@@ -115,7 +115,6 @@ void append_common_overrides(rclcpp::NodeOptions & options)
   options.append_parameter_override("quantize_last_layer", false);
   options.append_parameter_override("profile_per_layer", false);
   options.append_parameter_override("clip_value", 6.0);
-  options.append_parameter_override("preprocess_on_gpu", true);
   options.append_parameter_override("calibration_image_list_path", std::string(""));
   options.append_parameter_override("gpu_id", 0);
 }

--- a/perception/autoware_traffic_light_fine_detector/src/traffic_light_fine_detector_node.cpp
+++ b/perception/autoware_traffic_light_fine_detector/src/traffic_light_fine_detector_node.cpp
@@ -56,7 +56,6 @@ TrafficLightFineDetectorNode::TrafficLightFineDetectorNode(const rclcpp::NodeOpt
     RCLCPP_ERROR(this->get_logger(), "Could not find tlr id");
   }
 
-  const bool cuda_preprocess = true;
   const std::string calib_image_list = "";
   const double scale = 1.0;
   const std::string cache_dir = "";
@@ -64,8 +63,8 @@ TrafficLightFineDetectorNode::TrafficLightFineDetectorNode(const rclcpp::NodeOpt
   auto trt_config = autoware::tensorrt_common::TrtCommonConfig(model_path, precision);
 
   trt_yolox_ = std::make_unique<autoware::tensorrt_yolox::TrtYoloX>(
-    trt_config, num_class, score_thresh_, nms_threshold, cuda_preprocess, gpu_id, calib_image_list,
-    scale, cache_dir);
+    trt_config, num_class, score_thresh_, nms_threshold, gpu_id, calib_image_list, scale,
+    cache_dir);
 
   batch_size_ = trt_yolox_->getBatchSize();
 


### PR DESCRIPTION
## Description

Remove the `use_gpu_preprocess` / `preprocess_on_gpu` option and the entire CPU preprocessing code path from `autoware_tensorrt_yolox`, so that preprocessing is always performed on the GPU.

All shipped configurations already set `preprocess_on_gpu: true`. The CPU path was therefore effectively dead code that doubled the preprocessing implementation and complicated every preprocessing branch. This change unifies on the GPU path and deletes the now-unreachable CPU code.

## Related links

Introducing PR (where the `preprocess_on_gpu` option was originally added): https://github.com/autowarefoundation/autoware_universe/pull/3430

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

Built and tested both affected packages on a machine with an NVIDIA RTX 4060 (CUDA 12.4, TensorRT):

- `colcon build --packages-select autoware_tensorrt_yolox` and `colcon test`: 6/6 tests passed.
- `colcon build --packages-select autoware_traffic_light_fine_detector` and `colcon test`: 5/5 tests passed.

The end-to-end characterization test `test_tensorrt_yolox_node` actually ran (not skipped) on the GPU and passed all three cases.

## Notes for reviewers

None.

## Interface changes

The `preprocess_on_gpu` ROS parameter is removed. It was present in all three parameter sets (`yolox_s_plus_opt`, `yolox_tiny`, `yolox_traffic_light_detector`) and always set to `true`, which is now the unconditional behavior.

### ROS Parameter Changes

#### Additions and removals

| Change type | Parameter Name      | Type   | Default Value | Description                                         |
|:------------|:--------------------|:-------|:--------------|:----------------------------------------------------|
| Removed     | `preprocess_on_gpu` | `bool` | `true`        | Selected GPU vs CPU preprocessing; now fixed to GPU |

## Effects on system behavior

None for default deployments: every shipped configuration already ran preprocessing on the GPU, so the runtime behavior is identical. The only difference is that the CPU preprocessing fallback is no longer selectable.
