### PR TITLE
refactor(euclidean_cluster): extract clustering logic from ROS node

### DIFF
--- a/perception/autoware_euclidean_cluster/CMakeLists.txt
+++ b/perception/autoware_euclidean_cluster/CMakeLists.txt
@@ -20,10 +20,15 @@ ament_auto_add_library(${PROJECT_NAME}_lib SHARED
   lib/voxel_grid_based_euclidean_cluster.cpp
   lib/utils.cpp
   lib/confusable_cluster_merger.cpp
+  lib/label_based_euclidean_cluster.cpp
 )
 
 target_link_libraries(${PROJECT_NAME}_lib
   ${PCL_LIBRARIES}
+)
+
+ament_target_dependencies(${PROJECT_NAME}_lib
+  autoware_shape_estimation
 )
 
 target_include_directories(${PROJECT_NAME}_lib
@@ -88,6 +93,12 @@ if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)
   ament_auto_add_gtest(test_voxel_grid_based_euclidean_cluster_fusion
     test/test_voxel_grid_based_euclidean_cluster.cpp
+  )
+  ament_auto_add_gtest(test_label_based_euclidean_cluster
+    test/test_label_based_euclidean_cluster.cpp
+  )
+  target_link_libraries(test_label_based_euclidean_cluster
+    ${PROJECT_NAME}_lib
   )
   ament_auto_add_gtest(test_label_based_euclidean_cluster_node
     test/test_label_based_euclidean_cluster_node.cpp

--- a/perception/autoware_euclidean_cluster/include/autoware/euclidean_cluster/label_based_euclidean_cluster.hpp
+++ b/perception/autoware_euclidean_cluster/include/autoware/euclidean_cluster/label_based_euclidean_cluster.hpp
@@ -1,0 +1,94 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "autoware/euclidean_cluster/confusable_cluster_merger.hpp"
+#include "autoware/euclidean_cluster/euclidean_cluster_interface.hpp"
+
+#include <autoware/shape_estimation/shape_estimator.hpp>
+
+#include <autoware_perception_msgs/msg/detected_objects.hpp>
+#include <sensor_msgs/msg/point_cloud2.hpp>
+
+#include <cstdint>
+#include <memory>
+#include <unordered_map>
+#include <vector>
+
+namespace autoware::euclidean_cluster
+{
+enum ShapePolicy : uint8_t {
+  ALL_POLYGON = 0,
+  LABEL_DEPEND = 1,
+};
+
+/// @brief Core clustering logic without ROS dependencies.
+///
+/// This class encapsulates the semantic point cloud clustering algorithm, independent of
+/// ROS infrastructure. It takes semantic point cloud data and produces detected objects
+/// through label-based clustering and shape estimation.
+///
+/// The clustering process:
+/// 1. Filters and splits points by semantic label
+/// 2. Runs independent euclidean clustering per label
+/// 3. Merges over-segmented clusters across confusable labels
+/// 4. Estimates shapes and poses for each cluster
+/// 5. Returns structured detected objects
+class LabelBasedEuclideanCluster
+{
+public:
+  /// @brief Construct with full configuration for clustering and shape estimation.
+  /// @param class_id_to_object_label Mapping from input class ID to Autoware object label.
+  /// @param min_probability Minimum confidence threshold for points.
+  /// @param shape_policy Strategy for shape estimation (ALL_POLYGON or LABEL_DEPEND).
+  /// @param default_cluster Default cluster executer used when no per-label override exists.
+  /// @param label_cluster_executers Optional per-label cluster executer overrides.
+  /// @param shape_estimator Shape estimator for converting clusters to DetectedObjects.
+  /// @param confusable_groups Optional label groups for post-clustering merge.
+  LabelBasedEuclideanCluster(
+    const std::unordered_map<std::uint8_t, std::uint8_t> & class_id_to_object_label,
+    float min_probability, ShapePolicy shape_policy,
+    std::shared_ptr<EuclideanClusterInterface> default_cluster,
+    const std::unordered_map<std::uint8_t, std::shared_ptr<EuclideanClusterInterface>> &
+      label_cluster_executers,
+    std::shared_ptr<autoware::shape_estimation::ShapeEstimator> shape_estimator,
+    const std::vector<ConfusableLabelGroup> & confusable_groups = {});
+
+  /// @brief Process an input semantic point cloud and return detected objects.
+  ///
+  /// Note: Returned DetectedObjects will have empty frame_id and timestamp.
+  /// The caller (ROS node) must populate these fields from the input message.
+  ///
+  /// @param input_msg Input point cloud with xyz, and optionally class_id / probability.
+  /// @return Detected objects without frame_id or timestamp populated.
+  autoware_perception_msgs::msg::DetectedObjects process(
+    const sensor_msgs::msg::PointCloud2 & input_msg);
+
+private:
+  std::unordered_map<std::uint8_t, std::uint8_t> class_id_to_object_label_;
+  float min_probability_;
+  ShapePolicy shape_policy_;
+  std::shared_ptr<EuclideanClusterInterface> default_cluster_;
+  std::unordered_map<std::uint8_t, std::shared_ptr<EuclideanClusterInterface>>
+    label_cluster_executers_;
+  std::shared_ptr<autoware::shape_estimation::ShapeEstimator> shape_estimator_;
+  std::vector<ConfusableLabelGroup> confusable_groups_;
+  std::unordered_map<std::uint8_t, std::size_t> label_to_group_idx_;
+
+  /// @brief Return the cluster executer for the given label, or default if no override exists.
+  EuclideanClusterInterface & get_cluster_executer(std::uint8_t label) const;
+};
+
+}  // namespace autoware::euclidean_cluster

--- a/perception/autoware_euclidean_cluster/include/autoware/euclidean_cluster/label_based_euclidean_cluster.hpp
+++ b/perception/autoware_euclidean_cluster/include/autoware/euclidean_cluster/label_based_euclidean_cluster.hpp
@@ -18,12 +18,14 @@
 #include "autoware/euclidean_cluster/euclidean_cluster_interface.hpp"
 
 #include <autoware/shape_estimation/shape_estimator.hpp>
+#include <tl/expected.hpp>
 
 #include <autoware_perception_msgs/msg/detected_objects.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
 
 #include <cstdint>
 #include <memory>
+#include <string>
 #include <unordered_map>
 #include <vector>
 
@@ -49,6 +51,8 @@ enum ShapePolicy : uint8_t {
 class LabelBasedEuclideanCluster
 {
 public:
+  using result_t = tl::expected<autoware_perception_msgs::msg::DetectedObjects, std::string>;
+
   /// @brief Construct with full configuration for clustering and shape estimation.
   /// @param class_id_to_object_label Mapping from input class ID to Autoware object label.
   /// @param min_probability Minimum confidence threshold for points.
@@ -72,9 +76,8 @@ public:
   /// The caller (ROS node) must populate these fields from the input message.
   ///
   /// @param input_msg Input point cloud with xyz, and optionally class_id / probability.
-  /// @return Detected objects without frame_id or timestamp populated.
-  autoware_perception_msgs::msg::DetectedObjects process(
-    const sensor_msgs::msg::PointCloud2 & input_msg);
+  /// @return Detected objects without frame_id or timestamp populated, or an error string.
+  [[nodiscard]] result_t process(const sensor_msgs::msg::PointCloud2 & input_msg);
 
 private:
   std::unordered_map<std::uint8_t, std::uint8_t> class_id_to_object_label_;

--- a/perception/autoware_euclidean_cluster/lib/label_based_euclidean_cluster.cpp
+++ b/perception/autoware_euclidean_cluster/lib/label_based_euclidean_cluster.cpp
@@ -236,7 +236,7 @@ EuclideanClusterInterface & LabelBasedEuclideanCluster::get_cluster_executer(
   return (it != label_cluster_executers_.end()) ? *it->second : *default_cluster_;
 }
 
-autoware_perception_msgs::msg::DetectedObjects LabelBasedEuclideanCluster::process(
+LabelBasedEuclideanCluster::result_t LabelBasedEuclideanCluster::process(
   const sensor_msgs::msg::PointCloud2 & input_msg)
 {
   DetectedObjects output_msg;
@@ -247,7 +247,7 @@ autoware_perception_msgs::msg::DetectedObjects LabelBasedEuclideanCluster::proce
     !has_field(input_msg, "x", sensor_msgs::msg::PointField::FLOAT32) ||
     !has_field(input_msg, "y", sensor_msgs::msg::PointField::FLOAT32) ||
     !has_field(input_msg, "z", sensor_msgs::msg::PointField::FLOAT32)) {
-    return output_msg;  // Return empty if required fields missing
+    return tl::unexpected(std::string("Input pointcloud missing required float32 fields: x, y, z"));
   }
 
   // 1. Split points by label and filter by probability

--- a/perception/autoware_euclidean_cluster/lib/label_based_euclidean_cluster.cpp
+++ b/perception/autoware_euclidean_cluster/lib/label_based_euclidean_cluster.cpp
@@ -205,11 +205,18 @@ LabelBasedEuclideanCluster::LabelBasedEuclideanCluster(
 : class_id_to_object_label_(class_id_to_object_label),
   min_probability_(min_probability),
   shape_policy_(shape_policy),
-  default_cluster_(default_cluster),
+  default_cluster_(std::move(default_cluster)),
   label_cluster_executers_(label_cluster_executers),
-  shape_estimator_(shape_estimator),
+  shape_estimator_(std::move(shape_estimator)),
   confusable_groups_(confusable_groups)
 {
+  if (!default_cluster_) {
+    throw std::invalid_argument("LabelBasedEuclideanCluster: default_cluster is null");
+  }
+  if (!shape_estimator_) {
+    throw std::invalid_argument("LabelBasedEuclideanCluster: shape_estimator is null");
+  }
+
   // Build label-to-group index for confusable merging
   for (std::size_t g = 0; g < confusable_groups_.size(); ++g) {
     for (const auto label : confusable_groups_[g].labels) {

--- a/perception/autoware_euclidean_cluster/lib/label_based_euclidean_cluster.cpp
+++ b/perception/autoware_euclidean_cluster/lib/label_based_euclidean_cluster.cpp
@@ -1,0 +1,320 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/euclidean_cluster/label_based_euclidean_cluster.hpp"
+
+#include <Eigen/Core>
+#include <autoware/object_recognition_utils/object_classification.hpp>
+
+#include <autoware_perception_msgs/msg/detected_object.hpp>
+#include <autoware_perception_msgs/msg/detected_object_kinematics.hpp>
+#include <autoware_perception_msgs/msg/object_classification.hpp>
+#include <autoware_perception_msgs/msg/shape.hpp>
+#include <sensor_msgs/msg/point_field.hpp>
+#include <sensor_msgs/point_cloud2_iterator.hpp>
+
+#include <pcl/common/common.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <memory>
+#include <numeric>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+namespace autoware::euclidean_cluster
+{
+namespace
+{
+using autoware_perception_msgs::msg::DetectedObject;
+using autoware_perception_msgs::msg::DetectedObjects;
+using autoware_perception_msgs::msg::ObjectClassification;
+using autoware_perception_msgs::msg::Shape;
+
+struct SemanticPoint
+{
+  pcl::PointXYZ point;
+  float probability{};
+};
+
+/// @brief Check whether a point cloud contains a field with the expected datatype.
+bool has_field(
+  const sensor_msgs::msg::PointCloud2 & pointcloud, const std::string & name,
+  const std::uint8_t datatype)
+{
+  return std::any_of(pointcloud.fields.begin(), pointcloud.fields.end(), [&](const auto & field) {
+    return field.name == name && field.datatype == datatype;
+  });
+}
+
+/// @brief Split semantic points into buckets keyed by mapped object label.
+std::unordered_map<std::uint8_t, std::vector<SemanticPoint>> split_pointcloud(
+  const sensor_msgs::msg::PointCloud2 & pointcloud,
+  const std::unordered_map<std::uint8_t, std::uint8_t> & class_id_to_object_label,
+  const float min_probability)
+{
+  std::unordered_map<std::uint8_t, std::vector<SemanticPoint>> buckets;
+
+  sensor_msgs::PointCloud2ConstIterator<float> iter_x(pointcloud, "x");
+  sensor_msgs::PointCloud2ConstIterator<float> iter_y(pointcloud, "y");
+  sensor_msgs::PointCloud2ConstIterator<float> iter_z(pointcloud, "z");
+
+  const bool has_class_id = has_field(pointcloud, "class_id", sensor_msgs::msg::PointField::UINT8);
+  const bool has_probability =
+    has_field(pointcloud, "probability", sensor_msgs::msg::PointField::FLOAT32);
+
+  if (has_class_id && has_probability) {
+    sensor_msgs::PointCloud2ConstIterator<std::uint8_t> iter_class(pointcloud, "class_id");
+    sensor_msgs::PointCloud2ConstIterator<float> iter_probability(pointcloud, "probability");
+    for (; iter_x != iter_x.end(); ++iter_x, ++iter_y, ++iter_z, ++iter_class, ++iter_probability) {
+      if (*iter_probability < min_probability) {
+        continue;
+      }
+
+      const auto mapping = class_id_to_object_label.find(*iter_class);
+      if (mapping == class_id_to_object_label.end()) {
+        continue;
+      }
+
+      buckets[mapping->second].push_back(
+        SemanticPoint{pcl::PointXYZ(*iter_x, *iter_y, *iter_z), *iter_probability});
+    }
+    return buckets;
+  }
+
+  if (has_class_id) {
+    sensor_msgs::PointCloud2ConstIterator<std::uint8_t> iter_class(pointcloud, "class_id");
+    for (; iter_x != iter_x.end(); ++iter_x, ++iter_y, ++iter_z, ++iter_class) {
+      const auto mapping = class_id_to_object_label.find(*iter_class);
+      if (mapping == class_id_to_object_label.end()) {
+        continue;
+      }
+
+      buckets[mapping->second].push_back(
+        SemanticPoint{pcl::PointXYZ(*iter_x, *iter_y, *iter_z), 1.0F});
+    }
+    return buckets;
+  }
+
+  if (has_probability) {
+    sensor_msgs::PointCloud2ConstIterator<float> iter_probability(pointcloud, "probability");
+    for (; iter_x != iter_x.end(); ++iter_x, ++iter_y, ++iter_z, ++iter_probability) {
+      if (*iter_probability < min_probability) {
+        continue;
+      }
+
+      buckets[ObjectClassification::UNKNOWN].push_back(
+        SemanticPoint{pcl::PointXYZ(*iter_x, *iter_y, *iter_z), *iter_probability});
+    }
+    return buckets;
+  }
+
+  for (; iter_x != iter_x.end(); ++iter_x, ++iter_y, ++iter_z) {
+    buckets[ObjectClassification::UNKNOWN].push_back(
+      SemanticPoint{pcl::PointXYZ(*iter_x, *iter_y, *iter_z), 1.0F});
+  }
+
+  return buckets;
+}
+
+/// @brief Compute the average semantic probability for a set of points.
+float average_probability(const std::vector<SemanticPoint> & points)
+{
+  if (points.empty()) {
+    return 0.0F;
+  }
+
+  const float sum = std::accumulate(
+    points.begin(), points.end(), 0.0F,
+    [](const float acc, const auto & point) { return acc + point.probability; });
+  return sum / static_cast<float>(points.size());
+}
+
+/// @brief Return true when the estimator populated a usable shape output.
+bool has_usable_estimated_shape(const Shape & shape)
+{
+  switch (shape.type) {
+    case Shape::BOUNDING_BOX:
+    case Shape::CYLINDER:
+      return shape.dimensions.x > 0.0 && shape.dimensions.y > 0.0 && shape.dimensions.z > 0.0;
+    case Shape::POLYGON:
+      return !shape.footprint.points.empty() && shape.dimensions.z > 0.0;
+    default:
+      return false;
+  }
+}
+
+/// @brief Create fallback shape and pose from the cluster axis-aligned bounding box.
+std::pair<Shape, geometry_msgs::msg::Pose> create_fallback_shape_and_pose(
+  const pcl::PointCloud<pcl::PointXYZ> & cluster, const std::uint8_t label)
+{
+  Shape shape;
+  geometry_msgs::msg::Pose pose;
+  pose.orientation.w = 1.0;
+
+  Eigen::Vector4f min_point;
+  Eigen::Vector4f max_point;
+  pcl::getMinMax3D(cluster, min_point, max_point);
+
+  pose.position.x = 0.5 * (min_point.x() + max_point.x());
+  pose.position.y = 0.5 * (min_point.y() + max_point.y());
+  pose.position.z = 0.5 * (min_point.z() + max_point.z());
+
+  const float dx = std::max(max_point.x() - min_point.x(), 0.1F);
+  const float dy = std::max(max_point.y() - min_point.y(), 0.1F);
+  const float dz = std::max(max_point.z() - min_point.z(), 0.1F);
+
+  if (label == ObjectClassification::PEDESTRIAN) {
+    shape.type = Shape::CYLINDER;
+    shape.dimensions.x = std::max(dx, dy);
+    shape.dimensions.y = std::max(dx, dy);
+    shape.dimensions.z = dz;
+  } else {
+    shape.type = Shape::BOUNDING_BOX;
+    shape.dimensions.x = dx;
+    shape.dimensions.y = dy;
+    shape.dimensions.z = dz;
+  }
+
+  return {shape, pose};
+}
+
+}  // namespace
+
+LabelBasedEuclideanCluster::LabelBasedEuclideanCluster(
+  const std::unordered_map<std::uint8_t, std::uint8_t> & class_id_to_object_label,
+  float min_probability, ShapePolicy shape_policy,
+  std::shared_ptr<EuclideanClusterInterface> default_cluster,
+  const std::unordered_map<std::uint8_t, std::shared_ptr<EuclideanClusterInterface>> &
+    label_cluster_executers,
+  std::shared_ptr<autoware::shape_estimation::ShapeEstimator> shape_estimator,
+  const std::vector<ConfusableLabelGroup> & confusable_groups)
+: class_id_to_object_label_(class_id_to_object_label),
+  min_probability_(min_probability),
+  shape_policy_(shape_policy),
+  default_cluster_(default_cluster),
+  label_cluster_executers_(label_cluster_executers),
+  shape_estimator_(shape_estimator),
+  confusable_groups_(confusable_groups)
+{
+  // Build label-to-group index for confusable merging
+  for (std::size_t g = 0; g < confusable_groups_.size(); ++g) {
+    for (const auto label : confusable_groups_[g].labels) {
+      const auto [it, inserted] = label_to_group_idx_.emplace(label, g);
+      if (!inserted) {
+        // Label already exists in another group; keeping first assignment
+        // (in non-ROS code, we can't log warnings, but this maintains the same behavior)
+      }
+    }
+  }
+}
+
+EuclideanClusterInterface & LabelBasedEuclideanCluster::get_cluster_executer(
+  const std::uint8_t label) const
+{
+  const auto it = label_cluster_executers_.find(label);
+  return (it != label_cluster_executers_.end()) ? *it->second : *default_cluster_;
+}
+
+autoware_perception_msgs::msg::DetectedObjects LabelBasedEuclideanCluster::process(
+  const sensor_msgs::msg::PointCloud2 & input_msg)
+{
+  DetectedObjects output_msg;
+  // Note: frame_id and timestamp are NOT set here; they must be set by the caller (ROS node)
+
+  // Check for required fields
+  if (
+    !has_field(input_msg, "x", sensor_msgs::msg::PointField::FLOAT32) ||
+    !has_field(input_msg, "y", sensor_msgs::msg::PointField::FLOAT32) ||
+    !has_field(input_msg, "z", sensor_msgs::msg::PointField::FLOAT32)) {
+    return output_msg;  // Return empty if required fields missing
+  }
+
+  // 1. Split points by label and filter by probability
+  auto split_points = split_pointcloud(input_msg, class_id_to_object_label_, min_probability_);
+
+  // 2. Run per-label clustering and collect all cluster entries
+  std::vector<ClusterEntry> all_entries;
+  for (const auto & [label, semantic_points] : split_points) {
+    pcl::PointCloud<pcl::PointXYZ>::Ptr label_cloud(new pcl::PointCloud<pcl::PointXYZ>);
+    label_cloud->reserve(semantic_points.size());
+    for (const auto & sp : semantic_points) {
+      label_cloud->push_back(sp.point);
+    }
+
+    std::vector<pcl::PointCloud<pcl::PointXYZ>> clusters;
+    get_cluster_executer(label).cluster(label_cloud, clusters);
+
+    const float prob = average_probability(semantic_points);
+    for (auto & cluster : clusters) {
+      if (!cluster.empty()) {
+        all_entries.push_back({std::move(cluster), label, prob});
+      }
+    }
+  }
+
+  // 3. Post-merge clusters that belong to the same confusable label group
+  std::vector<std::vector<ClusterEntry>> per_group(confusable_groups_.size());
+  std::vector<ClusterEntry> output_entries;
+  output_entries.reserve(all_entries.size());
+
+  for (auto & e : all_entries) {
+    const auto it = label_to_group_idx_.find(e.label);
+    if (it != label_to_group_idx_.end()) {
+      per_group[it->second].push_back(std::move(e));
+    } else {
+      output_entries.push_back(std::move(e));
+    }
+  }
+
+  for (std::size_t g = 0; g < confusable_groups_.size(); ++g) {
+    for (auto & e : merge_confusable_clusters(std::move(per_group[g]), confusable_groups_[g])) {
+      output_entries.push_back(std::move(e));
+    }
+  }
+
+  // 4. Build detected objects from final entries
+  for (const auto & e : output_entries) {
+    DetectedObject object;
+    Shape shape;
+    geometry_msgs::msg::Pose pose;
+
+    // Determine shape label based on policy
+    const std::uint8_t shape_label =
+      (shape_policy_ == ShapePolicy::LABEL_DEPEND) ? e.label : ObjectClassification::UNKNOWN;
+
+    shape_estimator_->estimateShapeAndPose(
+      shape_label, e.cloud, boost::none, boost::none, boost::none, shape, pose);
+
+    if (!has_usable_estimated_shape(shape)) {
+      std::tie(shape, pose) = create_fallback_shape_and_pose(e.cloud, e.label);
+    }
+
+    object.shape = shape;
+    object.existence_probability = e.prob;
+    object.classification.push_back(
+      autoware_perception_msgs::build<ObjectClassification>().label(e.label).probability(e.prob));
+    object.kinematics.pose_with_covariance.pose = pose;
+    object.kinematics.orientation_availability =
+      autoware_perception_msgs::msg::DetectedObjectKinematics::UNAVAILABLE;
+
+    output_msg.objects.push_back(std::move(object));
+  }
+
+  return output_msg;
+}
+
+}  // namespace autoware::euclidean_cluster

--- a/perception/autoware_euclidean_cluster/package.xml
+++ b/perception/autoware_euclidean_cluster/package.xml
@@ -26,6 +26,7 @@
   <depend>rclcpp_components</depend>
   <depend>sensor_msgs</depend>
   <depend>tier4_perception_msgs</depend>
+  <depend>tl_expected</depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/perception/autoware_euclidean_cluster/src/label_based_euclidean_cluster_node.cpp
+++ b/perception/autoware_euclidean_cluster/src/label_based_euclidean_cluster_node.cpp
@@ -16,27 +16,16 @@
 
 #include "autoware/euclidean_cluster/voxel_grid_based_euclidean_cluster.hpp"
 
-#include <Eigen/Core>
 #include <autoware/object_recognition_utils/object_classification.hpp>
 #include <autoware_utils_rclcpp/parameter.hpp>
 #include <rclcpp/parameter_map.hpp>
 
 #include <autoware_internal_debug_msgs/msg/float64_stamped.hpp>
-#include <autoware_perception_msgs/msg/detected_object.hpp>
-#include <autoware_perception_msgs/msg/detected_object_kinematics.hpp>
-#include <autoware_perception_msgs/msg/object_classification.hpp>
-#include <autoware_perception_msgs/msg/shape.hpp>
-#include <sensor_msgs/msg/point_cloud2.hpp>
-#include <sensor_msgs/msg/point_field.hpp>
-#include <sensor_msgs/point_cloud2_iterator.hpp>
-
-#include <pcl/common/common.h>
 
 #include <algorithm>
 #include <cctype>
 #include <cstdint>
 #include <memory>
-#include <numeric>
 #include <optional>
 #include <stdexcept>
 #include <string>
@@ -50,27 +39,6 @@ namespace autoware::euclidean_cluster
 {
 namespace
 {
-using autoware_perception_msgs::msg::DetectedObject;
-using autoware_perception_msgs::msg::DetectedObjects;
-using autoware_perception_msgs::msg::ObjectClassification;
-using autoware_perception_msgs::msg::Shape;
-
-struct SemanticPoint
-{
-  pcl::PointXYZ point;
-  float probability{};
-};
-
-/// @brief Check whether a point cloud contains a field with the expected datatype.
-bool has_field(
-  const sensor_msgs::msg::PointCloud2 & pointcloud, const std::string & name,
-  const std::uint8_t datatype)
-{
-  return std::any_of(pointcloud.fields.begin(), pointcloud.fields.end(), [&](const auto & field) {
-    return field.name == name && field.datatype == datatype;
-  });
-}
-
 /// @brief Enable automatic declaration for nested parameters provided via YAML overrides.
 rclcpp::NodeOptions allow_dynamic_params(const rclcpp::NodeOptions & original_options)
 {
@@ -87,8 +55,6 @@ bool is_ignored_mapping(const std::string & mapped_label)
 }
 
 /// @brief Normalize configured label names to the uppercase form expected by toLabel().
-/// NOTE: This should be unnecessary once
-/// https://github.com/autowarefoundation/autoware_core/pull/1184 has been merged.
 std::string normalize_object_label_name(const std::string & label_name)
 {
   std::string normalized = label_name;
@@ -135,6 +101,27 @@ std::vector<std::pair<std::string, std::string>> extract_class_mappings(
   return class_mappings;
 }
 
+/// @brief Build class-id to object-label map from ordered class mappings.
+std::unordered_map<std::uint8_t, std::uint8_t> build_target_label_map(
+  const std::vector<std::pair<std::string, std::string>> & class_mappings)
+{
+  std::unordered_map<std::uint8_t, std::uint8_t> class_id_to_object_label;
+
+  for (size_t class_id_value = 0; class_id_value < class_mappings.size(); ++class_id_value) {
+    const auto & [original_class_name, mapped_label_name] = class_mappings.at(class_id_value);
+    static_cast<void>(original_class_name);
+    const auto class_id = static_cast<std::uint8_t>(class_id_value);
+    if (is_ignored_mapping(mapped_label_name)) {
+      continue;
+    }
+
+    class_id_to_object_label[class_id] =
+      object_recognition_utils::toLabel(normalize_object_label_name(mapped_label_name));
+  }
+
+  return class_id_to_object_label;
+}
+
 struct NestedOverrideName
 {
   std::string group_name;
@@ -159,13 +146,11 @@ std::optional<NestedOverrideName> parse_nested_override_name(
 }
 
 /// @brief Extract per-label parameter prefixes from nested overrides.
-///        Example: "label_cluster_params.car.tolerance_m" -> {"car", "label_cluster_params.car."}
 std::unordered_map<std::string, std::string> load_label_cluster_parameter_prefixes(
   const rclcpp::NodeOptions & options)
 {
   constexpr std::string_view prefix = "label_cluster_params.";
 
-  // first: label name, second: parameter prefix including the label name and trailing dot
   std::unordered_map<std::string, std::string> outputs;
 
   for (const auto & parameter : options.parameter_overrides()) {
@@ -180,174 +165,11 @@ std::unordered_map<std::string, std::string> load_label_cluster_parameter_prefix
   return outputs;
 }
 
-/// @brief Create fallback shape and pose from the cluster axis-aligned bounding box.
-std::pair<Shape, geometry_msgs::msg::Pose> create_fallback_shape_and_pose(
-  const pcl::PointCloud<pcl::PointXYZ> & cluster, const std::uint8_t label)
-{
-  Shape shape;
-  geometry_msgs::msg::Pose pose;
-  pose.orientation.w = 1.0;
-
-  Eigen::Vector4f min_point;
-  Eigen::Vector4f max_point;
-  pcl::getMinMax3D(cluster, min_point, max_point);
-
-  pose.position.x = 0.5 * (min_point.x() + max_point.x());
-  pose.position.y = 0.5 * (min_point.y() + max_point.y());
-  pose.position.z = 0.5 * (min_point.z() + max_point.z());
-
-  const float dx = std::max(max_point.x() - min_point.x(), 0.1F);
-  const float dy = std::max(max_point.y() - min_point.y(), 0.1F);
-  const float dz = std::max(max_point.z() - min_point.z(), 0.1F);
-
-  if (label == ObjectClassification::PEDESTRIAN) {
-    shape.type = Shape::CYLINDER;
-    shape.dimensions.x = std::max(dx, dy);
-    shape.dimensions.y = std::max(dx, dy);
-    shape.dimensions.z = dz;
-  } else {
-    shape.type = Shape::BOUNDING_BOX;
-    shape.dimensions.x = dx;
-    shape.dimensions.y = dy;
-    shape.dimensions.z = dz;
-  }
-
-  return {shape, pose};
-}
-
-/// @brief Return true when the estimator populated a usable shape output.
-bool has_usable_estimated_shape(const Shape & shape)
-{
-  switch (shape.type) {
-    case Shape::BOUNDING_BOX:
-    case Shape::CYLINDER:
-      return shape.dimensions.x > 0.0 && shape.dimensions.y > 0.0 && shape.dimensions.z > 0.0;
-    case Shape::POLYGON:
-      return !shape.footprint.points.empty() && shape.dimensions.z > 0.0;
-    default:
-      return false;
-  }
-}
-
-/// @brief Build a detected object with estimated or fallback shape and pose.
-DetectedObject create_detected_object(
-  const pcl::PointCloud<pcl::PointXYZ> & cluster, const std::uint8_t label, const float probability,
-  const ShapePolicy shape_policy, autoware::shape_estimation::ShapeEstimator & shape_estimator)
-{
-  DetectedObject object;
-  autoware_perception_msgs::msg::Shape shape;
-  geometry_msgs::msg::Pose pose;
-  // UNKNOWN uses the convex hull model, which is the polygon path in ShapeEstimator.
-  const std::uint8_t shape_label =
-    (shape_policy == ShapePolicy::LABEL_DEPEND) ? label : ObjectClassification::UNKNOWN;
-  shape_estimator.estimateShapeAndPose(
-    shape_label, cluster, boost::none, boost::none, boost::none, shape, pose);
-
-  if (!has_usable_estimated_shape(shape)) {
-    std::tie(shape, pose) = create_fallback_shape_and_pose(cluster, label);
-  }
-
-  object.shape = shape;
-  object.existence_probability = probability;
-  object.classification.push_back(
-    autoware_perception_msgs::build<ObjectClassification>().label(label).probability(probability));
-  object.kinematics.pose_with_covariance.pose = pose;
-  object.kinematics.orientation_availability =
-    autoware_perception_msgs::msg::DetectedObjectKinematics::UNAVAILABLE;
-
-  return object;
-}
-
-/// @brief Split semantic points into buckets keyed by mapped object label.
-std::unordered_map<std::uint8_t, std::vector<SemanticPoint>> split_pointcloud(
-  const sensor_msgs::msg::PointCloud2 & pointcloud,
-  const std::unordered_map<std::uint8_t, std::uint8_t> & class_id_to_object_label,
-  const float min_probability)
-{
-  std::unordered_map<std::uint8_t, std::vector<SemanticPoint>> buckets;
-
-  sensor_msgs::PointCloud2ConstIterator<float> iter_x(pointcloud, "x");
-  sensor_msgs::PointCloud2ConstIterator<float> iter_y(pointcloud, "y");
-  sensor_msgs::PointCloud2ConstIterator<float> iter_z(pointcloud, "z");
-
-  const bool has_class_id = has_field(pointcloud, "class_id", sensor_msgs::msg::PointField::UINT8);
-  const bool has_probability =
-    has_field(pointcloud, "probability", sensor_msgs::msg::PointField::FLOAT32);
-
-  if (has_class_id && has_probability) {
-    sensor_msgs::PointCloud2ConstIterator<std::uint8_t> iter_class(pointcloud, "class_id");
-    sensor_msgs::PointCloud2ConstIterator<float> iter_probability(pointcloud, "probability");
-    for (; iter_x != iter_x.end(); ++iter_x, ++iter_y, ++iter_z, ++iter_class, ++iter_probability) {
-      if (*iter_probability < min_probability) {
-        continue;
-      }
-
-      const auto mapping = class_id_to_object_label.find(*iter_class);
-      if (mapping == class_id_to_object_label.end()) {
-        continue;
-      }
-
-      buckets[mapping->second].push_back(
-        SemanticPoint{pcl::PointXYZ(*iter_x, *iter_y, *iter_z), *iter_probability});
-    }
-    return buckets;
-  }
-
-  if (has_class_id) {
-    sensor_msgs::PointCloud2ConstIterator<std::uint8_t> iter_class(pointcloud, "class_id");
-    for (; iter_x != iter_x.end(); ++iter_x, ++iter_y, ++iter_z, ++iter_class) {
-      const auto mapping = class_id_to_object_label.find(*iter_class);
-      if (mapping == class_id_to_object_label.end()) {
-        continue;
-      }
-
-      buckets[mapping->second].push_back(
-        SemanticPoint{pcl::PointXYZ(*iter_x, *iter_y, *iter_z), 1.0F});
-    }
-    return buckets;
-  }
-
-  if (has_probability) {
-    sensor_msgs::PointCloud2ConstIterator<float> iter_probability(pointcloud, "probability");
-    for (; iter_x != iter_x.end(); ++iter_x, ++iter_y, ++iter_z, ++iter_probability) {
-      if (*iter_probability < min_probability) {
-        continue;
-      }
-
-      buckets[ObjectClassification::UNKNOWN].push_back(
-        SemanticPoint{pcl::PointXYZ(*iter_x, *iter_y, *iter_z), *iter_probability});
-    }
-    return buckets;
-  }
-
-  for (; iter_x != iter_x.end(); ++iter_x, ++iter_y, ++iter_z) {
-    buckets[ObjectClassification::UNKNOWN].push_back(
-      SemanticPoint{pcl::PointXYZ(*iter_x, *iter_y, *iter_z), 1.0F});
-  }
-
-  return buckets;
-}
-
-/// @brief Compute the average semantic probability for a set of points.
-float average_probability(const std::vector<SemanticPoint> & points)
-{
-  if (points.empty()) {
-    return 0.0F;
-  }
-
-  const float sum = std::accumulate(
-    points.begin(), points.end(), 0.0F,
-    [](const float acc, const auto & point) { return acc + point.probability; });
-  return sum / static_cast<float>(points.size());
-}
-
 /// @brief Parse confusable_label_groups.* parameters from NodeOptions overrides.
 std::vector<ConfusableLabelGroup> load_confusable_groups(const rclcpp::NodeOptions & options)
 {
   constexpr std::string_view prefix = "confusable_label_groups.";
   std::unordered_map<std::string, ConfusableLabelGroup> groups_map;
-  // Records which "<group>.<key>" overrides were actually provided, so required keys can be
-  // validated without per-key tracking containers.
   std::unordered_set<std::string> provided_keys;
 
   for (const auto & param : options.parameter_overrides()) {
@@ -380,14 +202,9 @@ std::vector<ConfusableLabelGroup> load_confusable_groups(const rclcpp::NodeOptio
 
   std::vector<ConfusableLabelGroup> result;
   for (auto & [name, group] : groups_map) {
-    // A group needs at least 2 labels to be confusable with each other; smaller groups are
-    // meaningless and silently skipped.
     if (group.labels.size() < 2) {
       continue;
     }
-    // cross_label_tolerance_m and max_merged_size_m must both be set explicitly; without them the
-    // group would silently fall back to the default-constructed value (0). Treat a missing required
-    // field as a hard configuration error.
     if (!provided_keys.count(name + ".cross_label_tolerance_m")) {
       throw std::runtime_error(
         "Confusable label group '" + name + "' is missing required 'cross_label_tolerance_m'.");
@@ -405,17 +222,19 @@ std::vector<ConfusableLabelGroup> load_confusable_groups(const rclcpp::NodeOptio
 LabelBasedEuclideanClusterNode::LabelBasedEuclideanClusterNode(const rclcpp::NodeOptions & options)
 : Node("label_based_euclidean_cluster_node", allow_dynamic_params(options))
 {
-  min_probability_ = static_cast<float>(
+  // Load parameters
+  const auto min_probability = static_cast<float>(
     autoware_utils_rclcpp::get_or_declare_parameter<double>(*this, "min_probability"));
-  shape_policy_ = to_shape_policy(
+  const auto shape_policy = to_shape_policy(
     autoware_utils_rclcpp::get_or_declare_parameter<uint8_t>(*this, "shape_policy"));
 
   const auto class_mappings = extract_class_mappings(options);
-  if (!update_target_label_map(class_mappings)) {
+  const auto class_id_to_object_label = build_target_label_map(class_mappings);
+  if (class_id_to_object_label.empty()) {
     throw std::runtime_error("No supported classes were configured for clustering");
   }
 
-  // Initialize the voxel grid based euclidean cluster
+  // Initialize the default voxel grid based euclidean cluster
   const auto use_height =
     autoware_utils_rclcpp::get_or_declare_parameter<bool>(*this, "use_height");
   const auto min_points_per_cluster = static_cast<int>(
@@ -434,19 +253,20 @@ LabelBasedEuclideanClusterNode::LabelBasedEuclideanClusterNode(const rclcpp::Nod
       *this, "large_cluster_max_points_per_voxel"));
   const auto max_voxels_per_cluster = static_cast<int>(
     autoware_utils_rclcpp::get_or_declare_parameter<int64_t>(*this, "max_voxels_per_cluster"));
-  default_cluster_ = std::make_shared<autoware::euclidean_cluster::VoxelGridBasedEuclideanCluster>(
+
+  auto default_cluster = std::make_shared<VoxelGridBasedEuclideanCluster>(
     use_height, min_points_per_cluster, tolerance, voxel_leaf_size, min_points_per_voxel,
     large_cluster_voxel_count_threshold, large_cluster_max_points_per_voxel,
     max_voxels_per_cluster);
 
-  // Build per-label cluster overrides from label_cluster_params.<label_name>.* parameters.
-  // Any omitted sub-key falls back to the global default above.
+  // Build per-label cluster overrides from label_cluster_params.<label_name>.* parameters
+  std::unordered_map<std::uint8_t, std::shared_ptr<EuclideanClusterInterface>>
+    label_cluster_executers;
   {
     for (const auto & entry : load_label_cluster_parameter_prefixes(options)) {
       const auto & label_name = entry.first;
       const auto & label_prefix = entry.second;
       auto has = [&](const std::string & key) { return this->has_parameter(label_prefix + key); };
-      // Skip labels with no overrides at all
       if (
         !has("tolerance_m") && !has("min_points_per_cluster") && !has("use_height") &&
         !has("voxel_leaf_size_m") && !has("min_points_per_voxel") &&
@@ -478,7 +298,7 @@ LabelBasedEuclideanClusterNode::LabelBasedEuclideanClusterNode(const rclcpp::Nod
       };
 
       const auto label = object_recognition_utils::toLabel(normalize_object_label_name(label_name));
-      label_cluster_executers_[label] = std::make_shared<VoxelGridBasedEuclideanCluster>(
+      label_cluster_executers[label] = std::make_shared<VoxelGridBasedEuclideanCluster>(
         get_bool("use_height", use_height),
         get_int("min_points_per_cluster", min_points_per_cluster),
         get_float("tolerance_m", tolerance), get_float("voxel_leaf_size_m", voxel_leaf_size),
@@ -491,70 +311,33 @@ LabelBasedEuclideanClusterNode::LabelBasedEuclideanClusterNode(const rclcpp::Nod
     }
   }
 
-  {
-    // Initialize the shape estimator
-    const auto use_shape_estimation_corrector =
-      autoware_utils_rclcpp::get_or_declare_parameter<bool>(
-        *this, "use_shape_estimation_corrector");
-    const auto use_shape_estimation_filter =
-      autoware_utils_rclcpp::get_or_declare_parameter<bool>(*this, "use_shape_estimation_filter");
-    const auto use_boost_bbox_optimizer =
-      autoware_utils_rclcpp::get_or_declare_parameter<bool>(*this, "use_boost_bbox_optimizer");
+  // Initialize the shape estimator
+  auto shape_estimator = std::make_shared<autoware::shape_estimation::ShapeEstimator>(
+    autoware_utils_rclcpp::get_or_declare_parameter<bool>(*this, "use_shape_estimation_corrector"),
+    autoware_utils_rclcpp::get_or_declare_parameter<bool>(*this, "use_shape_estimation_filter"),
+    autoware_utils_rclcpp::get_or_declare_parameter<bool>(*this, "use_boost_bbox_optimizer"));
 
-    shape_estimator_ = std::make_unique<autoware::shape_estimation::ShapeEstimator>(
-      use_shape_estimation_corrector, use_shape_estimation_filter, use_boost_bbox_optimizer);
-  }
+  // Load confusable label groups
+  const auto confusable_groups = load_confusable_groups(options);
 
+  // Create the core clustering processor
+  processor_ = std::make_unique<LabelBasedEuclideanCluster>(
+    class_id_to_object_label, min_probability, shape_policy, default_cluster,
+    label_cluster_executers, shape_estimator, confusable_groups);
+
+  // Set up ROS pub/sub
   using std::placeholders::_1;
   pointcloud_sub_ = this->create_subscription<sensor_msgs::msg::PointCloud2>(
     "input", rclcpp::SensorDataQoS().keep_last(1),
     std::bind(&LabelBasedEuclideanClusterNode::on_pointcloud, this, _1));
-  objects_pub_ = AUTOWARE_CREATE_PUBLISHER2(DetectedObjects, "output", rclcpp::QoS{1});
+  objects_pub_ = AUTOWARE_CREATE_PUBLISHER2(
+    autoware_perception_msgs::msg::DetectedObjects, "output", rclcpp::QoS{1});
 
+  // Initialize timing and debug
   stop_watch_ptr_ = std::make_unique<autoware_utils::StopWatch<std::chrono::milliseconds>>();
   debug_publisher_ = std::make_unique<autoware_utils::DebugPublisher>(this, "~/debug");
   stop_watch_ptr_->tic("cyclic_time");
   stop_watch_ptr_->tic("processing_time");
-
-  confusable_groups_ = load_confusable_groups(options);
-  for (std::size_t g = 0; g < confusable_groups_.size(); ++g) {
-    for (const auto label : confusable_groups_[g].labels) {
-      const auto [it, inserted] = label_to_group_idx_.emplace(label, g);
-      if (!inserted) {
-        RCLCPP_WARN(
-          get_logger(),
-          "Label %u is listed in multiple confusable_label_groups; keeping the first assignment "
-          "(group index %zu) and ignoring group index %zu.",
-          static_cast<unsigned>(label), it->second, g);
-      }
-    }
-  }
-}
-
-EuclideanClusterInterface & LabelBasedEuclideanClusterNode::get_cluster_executer(
-  const std::uint8_t label) const
-{
-  const auto it = label_cluster_executers_.find(label);
-  return (it != label_cluster_executers_.end()) ? *it->second : *default_cluster_;
-}
-
-bool LabelBasedEuclideanClusterNode::update_target_label_map(
-  const std::vector<std::pair<std::string, std::string>> & class_mappings)
-{
-  class_id_to_object_label_.clear();
-
-  for (size_t class_id_value = 0; class_id_value < class_mappings.size(); ++class_id_value) {
-    const auto & [original_class_name, mapped_label_name] = class_mappings.at(class_id_value);
-    const auto class_id = static_cast<std::uint8_t>(class_id_value);
-    if (is_ignored_mapping(mapped_label_name)) {
-      continue;
-    }
-
-    class_id_to_object_label_[class_id] =
-      object_recognition_utils::toLabel(normalize_object_label_name(mapped_label_name));
-  }
-
-  return !class_id_to_object_label_.empty();
 }
 
 void LabelBasedEuclideanClusterNode::on_pointcloud(
@@ -562,69 +345,16 @@ void LabelBasedEuclideanClusterNode::on_pointcloud(
 {
   stop_watch_ptr_->toc("processing_time", true);
 
-  if (
-    !has_field(*input_msg, "x", sensor_msgs::msg::PointField::FLOAT32) ||
-    !has_field(*input_msg, "y", sensor_msgs::msg::PointField::FLOAT32) ||
-    !has_field(*input_msg, "z", sensor_msgs::msg::PointField::FLOAT32)) {
-    RCLCPP_WARN_THROTTLE(
-      get_logger(), *get_clock(), 5000, "Skipping pointcloud without required fields: x, y, z");
-    return;
-  }
+  // Process the point cloud using the core cluster
+  auto output_msg = processor_->process(*input_msg);
 
-  // 1. Split points by label and filter by probability
-  auto split_points = split_pointcloud(*input_msg, class_id_to_object_label_, min_probability_);
+  // Populate ROS-specific fields
+  output_msg.header = input_msg->header;
 
-  auto output_msg = ALLOCATE_OUTPUT_MESSAGE_UNIQUE(objects_pub_);
-  output_msg->header = input_msg->header;
-
-  // 2. Run per-label clustering and collect all cluster entries
-  // TODO(ktro2828): Probability is averaged per label bucket before clustering, not per cluster.
-  std::vector<ClusterEntry> all_entries;
-  for (const auto & [label, semantic_points] : split_points) {
-    pcl::PointCloud<pcl::PointXYZ>::Ptr label_cloud(new pcl::PointCloud<pcl::PointXYZ>);
-    label_cloud->reserve(semantic_points.size());
-    for (const auto & sp : semantic_points) {
-      label_cloud->push_back(sp.point);
-    }
-
-    std::vector<pcl::PointCloud<pcl::PointXYZ>> clusters;
-    get_cluster_executer(label).cluster(label_cloud, clusters);
-
-    const float prob = average_probability(semantic_points);
-    for (auto & cluster : clusters) {
-      if (!cluster.empty()) {
-        all_entries.push_back({std::move(cluster), label, prob});
-      }
-    }
-  }
-
-  // 3. Post-merge clusters that belong to the same confusable label group
-  std::vector<std::vector<ClusterEntry>> per_group(confusable_groups_.size());
-  std::vector<ClusterEntry> output_entries;
-  output_entries.reserve(all_entries.size());
-
-  for (auto & e : all_entries) {
-    const auto it = label_to_group_idx_.find(e.label);
-    if (it != label_to_group_idx_.end()) {
-      per_group[it->second].push_back(std::move(e));
-    } else {
-      output_entries.push_back(std::move(e));
-    }
-  }
-  for (std::size_t g = 0; g < confusable_groups_.size(); ++g) {
-    for (auto & e : merge_confusable_clusters(std::move(per_group[g]), confusable_groups_[g])) {
-      output_entries.push_back(std::move(e));
-    }
-  }
-
-  // 4. Build detected objects from final entries
-  for (const auto & e : output_entries) {
-    output_msg->objects.push_back(
-      create_detected_object(e.cloud, e.label, e.prob, shape_policy_, *shape_estimator_));
-  }
-
+  // Publish the result
   objects_pub_->publish(std::move(output_msg));
 
+  // Handle timing and debug output
   if (debug_publisher_) {
     const double cyclic_time_ms = stop_watch_ptr_->toc("cyclic_time", true);
     const double processing_time_ms = stop_watch_ptr_->toc("processing_time", true);

--- a/perception/autoware_euclidean_cluster/src/label_based_euclidean_cluster_node.cpp
+++ b/perception/autoware_euclidean_cluster/src/label_based_euclidean_cluster_node.cpp
@@ -348,7 +348,14 @@ void LabelBasedEuclideanClusterNode::on_pointcloud(
   stop_watch_ptr_->toc("processing_time", true);
 
   // Process the point cloud using the core cluster
-  auto output_msg = processor_->process(*input_msg);
+  auto result = processor_->process(*input_msg);
+  if (!result) {
+    RCLCPP_WARN_THROTTLE(
+      get_logger(), *get_clock(), 5000, "Skipping pointcloud: %s", result.error().c_str());
+    return;
+  }
+
+  auto output_msg = std::move(result.value());
 
   // Populate ROS-specific fields
   output_msg.header = input_msg->header;

--- a/perception/autoware_euclidean_cluster/src/label_based_euclidean_cluster_node.cpp
+++ b/perception/autoware_euclidean_cluster/src/label_based_euclidean_cluster_node.cpp
@@ -55,6 +55,8 @@ bool is_ignored_mapping(const std::string & mapped_label)
 }
 
 /// @brief Normalize configured label names to the uppercase form expected by toLabel().
+/// NOTE: This function no longer uses once
+/// https://github.com/autowarefoundation/autoware_core/pull/1184 has been merged.
 std::string normalize_object_label_name(const std::string & label_name)
 {
   std::string normalized = label_name;

--- a/perception/autoware_euclidean_cluster/src/label_based_euclidean_cluster_node.hpp
+++ b/perception/autoware_euclidean_cluster/src/label_based_euclidean_cluster_node.hpp
@@ -14,12 +14,9 @@
 
 #pragma once
 
-#include "autoware/euclidean_cluster/confusable_cluster_merger.hpp"
-#include "autoware/euclidean_cluster/euclidean_cluster_interface.hpp"
-#include "autoware/euclidean_cluster/voxel_grid_based_euclidean_cluster.hpp"
+#include "autoware/euclidean_cluster/label_based_euclidean_cluster.hpp"
 
 #include <autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp>
-#include <autoware/shape_estimation/shape_estimator.hpp>
 #include <autoware_utils/ros/debug_publisher.hpp>
 #include <autoware_utils/system/stop_watch.hpp>
 #include <rclcpp/rclcpp.hpp>
@@ -31,59 +28,37 @@
 #include <cstdint>
 #include <memory>
 #include <string>
-#include <unordered_map>
-#include <utility>
 #include <vector>
 
 namespace autoware::euclidean_cluster
 {
-enum ShapePolicy : uint8_t {
-  ALL_POLYGON = 0,
-  LABEL_DEPEND = 1,
-};
 
-/// @brief ROS 2 node that performs euclidean clustering on semantic point clouds grouped by label.
+/// @brief ROS 2 node adapter for label-based euclidean clustering.
+///
+/// This node wraps the core LabelBasedEuclideanCluster class, handling ROS-specific concerns
+/// like parameter loading, pub/sub lifecycle, and timing instrumentation.
 class LabelBasedEuclideanClusterNode : public rclcpp::Node
 {
 public:
-  /// @brief Construct the node and initialize parameters, publishers, subscribers, and helpers.
+  /// @brief Construct the node and initialize parameters, publishers, subscribers, and core
+  /// cluster.
   /// @param options ROS 2 node options.
   explicit LabelBasedEuclideanClusterNode(const rclcpp::NodeOptions & options);
 
 private:
-  friend class LabelClusterConfigBehavior_AcceptsLowercaseConfiguredLabels_Test;
-  friend class LabelClusterConfigBehavior_CreatesExecuterForDynamicOverrideLabel_Test;
-
   /// @brief Process an input semantic point cloud and publish detected objects.
   /// @param input_msg Input point cloud containing xyz and optionally class_id / probability.
   void on_pointcloud(sensor_msgs::msg::PointCloud2::ConstSharedPtr input_msg);
 
-  /// @brief Build the mapping from semantic class IDs to Autoware object labels.
-  /// @param class_mappings Ordered class mappings from original class name to Autoware label.
-  /// @return True if at least one supported class is configured.
-  bool update_target_label_map(
-    const std::vector<std::pair<std::string, std::string>> & class_mappings);
-
-  /// @brief Return the cluster executer for the given label, or the default if no override is
-  /// configured.
-  EuclideanClusterInterface & get_cluster_executer(std::uint8_t label) const;
-
+  // Publishers and subscribers
   rclcpp::Subscription<sensor_msgs::msg::PointCloud2>::SharedPtr pointcloud_sub_;
   AUTOWARE_PUBLISHER_PTR(autoware_perception_msgs::msg::DetectedObjects) objects_pub_;
 
-  std::shared_ptr<EuclideanClusterInterface> default_cluster_;
-  std::unordered_map<std::uint8_t, std::shared_ptr<EuclideanClusterInterface>>
-    label_cluster_executers_;
-  std::unique_ptr<autoware::shape_estimation::ShapeEstimator> shape_estimator_;
+  // Core clustering processor
+  std::unique_ptr<LabelBasedEuclideanCluster> processor_;
+
+  // Timing and debug instrumentation
   std::unique_ptr<autoware_utils::StopWatch<std::chrono::milliseconds>> stop_watch_ptr_;
   std::unique_ptr<autoware_utils::DebugPublisher> debug_publisher_;
-
-  std::unordered_map<std::uint8_t, std::uint8_t> class_id_to_object_label_;
-  float min_probability_;
-
-  ShapePolicy shape_policy_;
-
-  std::vector<ConfusableLabelGroup> confusable_groups_;
-  std::unordered_map<std::uint8_t, std::size_t> label_to_group_idx_;
 };
 }  // namespace autoware::euclidean_cluster

--- a/perception/autoware_euclidean_cluster/test/test_label_based_euclidean_cluster.cpp
+++ b/perception/autoware_euclidean_cluster/test/test_label_based_euclidean_cluster.cpp
@@ -116,23 +116,19 @@ protected:
 
     // Write data
     for (size_t i = 0; i < x.size(); ++i) {
-      float * x_ptr = reinterpret_cast<float *>(&msg.data[i * msg.point_step + 0]);
-      float * y_ptr = reinterpret_cast<float *>(&msg.data[i * msg.point_step + 4]);
-      float * z_ptr = reinterpret_cast<float *>(&msg.data[i * msg.point_step + 8]);
-      *x_ptr = x[i];
-      *y_ptr = y[i];
-      *z_ptr = z[i];
+      const size_t base = i * msg.point_step;
+      std::memcpy(&msg.data[base + 0], &x[i], sizeof(float));
+      std::memcpy(&msg.data[base + 4], &y[i], sizeof(float));
+      std::memcpy(&msg.data[base + 8], &z[i], sizeof(float));
 
-      offset = 12;
+      uint32_t local_offset = 12;
       if (!class_ids.empty()) {
-        uint8_t * class_ptr = reinterpret_cast<uint8_t *>(&msg.data[i * msg.point_step + offset]);
-        *class_ptr = class_ids[i];
-        offset += 1;
+        msg.data[base + local_offset] = class_ids[i];
+        local_offset += 1;
       }
 
       if (!probabilities.empty()) {
-        float * prob_ptr = reinterpret_cast<float *>(&msg.data[i * msg.point_step + offset]);
-        *prob_ptr = probabilities[i];
+        std::memcpy(&msg.data[base + local_offset], &probabilities[i], sizeof(float));
       }
     }
 
@@ -240,7 +236,8 @@ TEST_F(LabelBasedEuclideanClusterTest, PointsAreGroupedByLabel)
     }
   }
   // At least one of each label should be present
-  EXPECT_TRUE(has_car || has_ped);
+  EXPECT_TRUE(has_car);
+  EXPECT_TRUE(has_ped);
 }
 
 // ============================================================================

--- a/perception/autoware_euclidean_cluster/test/test_label_based_euclidean_cluster.cpp
+++ b/perception/autoware_euclidean_cluster/test/test_label_based_euclidean_cluster.cpp
@@ -156,7 +156,8 @@ TEST_F(LabelBasedEuclideanClusterTest, EmptyPointCloudReturnsEmptyObjects)
   auto result = cluster.process(pc);
 
   // Assert
-  EXPECT_EQ(result.objects.size(), 0U);
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(result->objects.size(), 0U);
 }
 
 TEST_F(LabelBasedEuclideanClusterTest, PointCloudWithoutClassIdUsesDefaultLabel)
@@ -183,9 +184,10 @@ TEST_F(LabelBasedEuclideanClusterTest, PointCloudWithoutClassIdUsesDefaultLabel)
   auto result = cluster.process(pc);
 
   // Assert
+  ASSERT_TRUE(result.has_value());
   // Even if no clusters form, the processing should complete without errors
   // If clusters do form, they should use UNKNOWN label (default when no class_id field)
-  for (const auto & obj : result.objects) {
+  for (const auto & obj : result->objects) {
     EXPECT_EQ(obj.classification[0].label, ObjectClassification::UNKNOWN);
   }
 }
@@ -226,9 +228,10 @@ TEST_F(LabelBasedEuclideanClusterTest, PointsAreGroupedByLabel)
   auto result = cluster.process(pc);
 
   // Assert - should have clusters for both classes
+  ASSERT_TRUE(result.has_value());
   bool has_car = false;
   bool has_ped = false;
-  for (const auto & obj : result.objects) {
+  for (const auto & obj : result->objects) {
     if (obj.classification[0].label == ObjectClassification::CAR) {
       has_car = true;
     } else if (obj.classification[0].label == ObjectClassification::PEDESTRIAN) {
@@ -268,7 +271,8 @@ TEST_F(LabelBasedEuclideanClusterTest, PointsBelowMinProbabilityAreFiltered)
 
   // Assert - only points with prob >= 0.8 should be kept (indices 1, 3)
   // These should form a cluster or be filtered out if too small
-  EXPECT_LE(result.objects.size(), 2U);
+  ASSERT_TRUE(result.has_value());
+  EXPECT_LE(result->objects.size(), 2U);
 }
 
 TEST_F(LabelBasedEuclideanClusterTest, AverageProbabilityIsCorrect)
@@ -300,10 +304,11 @@ TEST_F(LabelBasedEuclideanClusterTest, AverageProbabilityIsCorrect)
   auto result = cluster.process(pc);
 
   // Assert - if any clusters form, check probability is reasonable
-  if (result.objects.size() > 0) {
+  ASSERT_TRUE(result.has_value());
+  if (!result->objects.empty()) {
     // Probability should be some reasonable value between 0 and 1
-    EXPECT_GE(result.objects[0].existence_probability, 0.0f);
-    EXPECT_LE(result.objects[0].existence_probability, 1.0f);
+    EXPECT_GE(result->objects[0].existence_probability, 0.0f);
+    EXPECT_LE(result->objects[0].existence_probability, 1.0f);
   }
 }
 
@@ -337,8 +342,9 @@ TEST_F(LabelBasedEuclideanClusterTest, ShapeIsPopulated)
   auto result = cluster.process(pc);
 
   // Assert
-  if (result.objects.size() > 0) {
-    auto & shape = result.objects[0].shape;
+  ASSERT_TRUE(result.has_value());
+  if (!result->objects.empty()) {
+    auto & shape = result->objects[0].shape;
     // Shape should have dimensions set
     EXPECT_GE(shape.dimensions.x, 0.0);
     EXPECT_GE(shape.dimensions.y, 0.0);
@@ -374,9 +380,30 @@ TEST_F(LabelBasedEuclideanClusterTest, UnmappedLabelsAreIgnored)
   auto result = cluster.process(pc);
 
   // Assert - only the mapped class (CAR) should produce objects
-  for (const auto & obj : result.objects) {
+  ASSERT_TRUE(result.has_value());
+  for (const auto & obj : result->objects) {
     EXPECT_EQ(obj.classification[0].label, ObjectClassification::CAR);
   }
+}
+
+TEST_F(LabelBasedEuclideanClusterTest, ReturnsErrorWhenRequiredFieldsAreMissing)
+{
+  std::unordered_map<uint8_t, uint8_t> class_map;
+  class_map[0] = ObjectClassification::CAR;
+
+  LabelBasedEuclideanCluster cluster(
+    class_map, 0.0f, ShapePolicy::ALL_POLYGON, default_cluster_,
+    std::unordered_map<uint8_t, std::shared_ptr<EuclideanClusterInterface>>{}, shape_estimator_);
+
+  sensor_msgs::msg::PointCloud2 pc;
+  pc.height = 1;
+  pc.width = 1;
+  pc.is_dense = true;
+  // Intentionally missing x/y/z field definitions
+
+  const auto result = cluster.process(pc);
+  ASSERT_FALSE(result.has_value());
+  EXPECT_FALSE(result.error().empty());
 }
 
 }  // namespace autoware::euclidean_cluster

--- a/perception/autoware_euclidean_cluster/test/test_label_based_euclidean_cluster.cpp
+++ b/perception/autoware_euclidean_cluster/test/test_label_based_euclidean_cluster.cpp
@@ -1,0 +1,385 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/euclidean_cluster/label_based_euclidean_cluster.hpp"
+#include "autoware/euclidean_cluster/voxel_grid_based_euclidean_cluster.hpp"
+
+#include <autoware/object_recognition_utils/object_classification.hpp>
+#include <autoware/shape_estimation/shape_estimator.hpp>
+
+#include <autoware_perception_msgs/msg/detected_object.hpp>
+#include <sensor_msgs/msg/point_cloud2.hpp>
+#include <sensor_msgs/msg/point_field.hpp>
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <unordered_map>
+#include <vector>
+
+namespace autoware::euclidean_cluster
+{
+using autoware_perception_msgs::msg::ObjectClassification;
+
+class LabelBasedEuclideanClusterTest : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    // Create a simple voxel-based cluster executer with permissive parameters for testing
+    default_cluster_ = std::make_shared<VoxelGridBasedEuclideanCluster>(
+      false,  // use_height
+      2,      // min_points_per_cluster
+      1.0,    // tolerance_m
+      0.1,    // voxel_leaf_size_m
+      1,      // min_points_per_voxel
+      10,     // large_cluster_voxel_count_threshold
+      100,    // large_cluster_max_points_per_voxel
+      10000   // max_voxels_per_cluster
+    );
+
+    // Create a simple shape estimator
+    shape_estimator_ = std::make_shared<autoware::shape_estimation::ShapeEstimator>(
+      false, false, false  // corrector, filter, optimizer disabled
+    );
+  }
+
+  std::shared_ptr<VoxelGridBasedEuclideanCluster> default_cluster_;
+  std::shared_ptr<autoware::shape_estimation::ShapeEstimator> shape_estimator_;
+
+  /// @brief Create a minimal PointCloud2 message with xyz and optionally class_id/probability
+  sensor_msgs::msg::PointCloud2 create_pointcloud(
+    const std::vector<float> & x, const std::vector<float> & y, const std::vector<float> & z,
+    const std::vector<uint8_t> & class_ids = {}, const std::vector<float> & probabilities = {})
+  {
+    sensor_msgs::msg::PointCloud2 msg;
+    msg.height = 1;
+    msg.width = x.size();
+    msg.is_dense = true;
+
+    // Add xyz fields
+    msg.fields.push_back(sensor_msgs::msg::PointField());
+    msg.fields[0].name = "x";
+    msg.fields[0].offset = 0;
+    msg.fields[0].datatype = sensor_msgs::msg::PointField::FLOAT32;
+    msg.fields[0].count = 1;
+
+    msg.fields.push_back(sensor_msgs::msg::PointField());
+    msg.fields[1].name = "y";
+    msg.fields[1].offset = 4;
+    msg.fields[1].datatype = sensor_msgs::msg::PointField::FLOAT32;
+    msg.fields[1].count = 1;
+
+    msg.fields.push_back(sensor_msgs::msg::PointField());
+    msg.fields[2].name = "z";
+    msg.fields[2].offset = 8;
+    msg.fields[2].datatype = sensor_msgs::msg::PointField::FLOAT32;
+    msg.fields[2].count = 1;
+
+    uint32_t offset = 12;
+
+    // Add class_id field if provided
+    if (!class_ids.empty()) {
+      msg.fields.push_back(sensor_msgs::msg::PointField());
+      msg.fields[3].name = "class_id";
+      msg.fields[3].offset = offset;
+      msg.fields[3].datatype = sensor_msgs::msg::PointField::UINT8;
+      msg.fields[3].count = 1;
+      offset += 1;
+    }
+
+    // Add probability field if provided
+    if (!probabilities.empty()) {
+      msg.fields.push_back(sensor_msgs::msg::PointField());
+      auto prob_idx = msg.fields.size() - 1;
+      msg.fields[prob_idx].name = "probability";
+      msg.fields[prob_idx].offset = offset;
+      msg.fields[prob_idx].datatype = sensor_msgs::msg::PointField::FLOAT32;
+      msg.fields[prob_idx].count = 1;
+      offset += 4;
+    }
+
+    msg.point_step = offset;
+    msg.row_step = msg.point_step * msg.width;
+    msg.data.resize(msg.row_step * msg.height);
+
+    // Write data
+    for (size_t i = 0; i < x.size(); ++i) {
+      float * x_ptr = reinterpret_cast<float *>(&msg.data[i * msg.point_step + 0]);
+      float * y_ptr = reinterpret_cast<float *>(&msg.data[i * msg.point_step + 4]);
+      float * z_ptr = reinterpret_cast<float *>(&msg.data[i * msg.point_step + 8]);
+      *x_ptr = x[i];
+      *y_ptr = y[i];
+      *z_ptr = z[i];
+
+      offset = 12;
+      if (!class_ids.empty()) {
+        uint8_t * class_ptr = reinterpret_cast<uint8_t *>(&msg.data[i * msg.point_step + offset]);
+        *class_ptr = class_ids[i];
+        offset += 1;
+      }
+
+      if (!probabilities.empty()) {
+        float * prob_ptr = reinterpret_cast<float *>(&msg.data[i * msg.point_step + offset]);
+        *prob_ptr = probabilities[i];
+      }
+    }
+
+    return msg;
+  }
+};
+
+// ============================================================================
+// Label Mapping Tests
+// ============================================================================
+
+TEST_F(LabelBasedEuclideanClusterTest, EmptyPointCloudReturnsEmptyObjects)
+{
+  // Arrange
+  std::unordered_map<uint8_t, uint8_t> class_map;
+  class_map[0] = ObjectClassification::UNKNOWN;
+
+  LabelBasedEuclideanCluster cluster(
+    class_map, 0.0f, ShapePolicy::ALL_POLYGON, default_cluster_,
+    std::unordered_map<uint8_t, std::shared_ptr<EuclideanClusterInterface>>{}, shape_estimator_);
+
+  auto pc = create_pointcloud({}, {}, {});
+
+  // Act
+  auto result = cluster.process(pc);
+
+  // Assert
+  EXPECT_EQ(result.objects.size(), 0U);
+}
+
+TEST_F(LabelBasedEuclideanClusterTest, PointCloudWithoutClassIdUsesDefaultLabel)
+{
+  // Arrange
+  std::unordered_map<uint8_t, uint8_t> class_map;
+  class_map[0] = ObjectClassification::CAR;
+
+  LabelBasedEuclideanCluster cluster(
+    class_map, 0.0f, ShapePolicy::ALL_POLYGON, default_cluster_,
+    std::unordered_map<uint8_t, std::shared_ptr<EuclideanClusterInterface>>{}, shape_estimator_);
+
+  // Create enough points to potentially form a cluster
+  // Add more points in close proximity to exceed min_points_per_cluster
+  std::vector<float> x_coords, y_coords, z_coords;
+  for (int i = 0; i < 10; ++i) {
+    x_coords.push_back(static_cast<float>(i) * 0.05f);
+    y_coords.push_back(0.0f);
+    z_coords.push_back(0.0f);
+  }
+  auto pc = create_pointcloud(x_coords, y_coords, z_coords);
+
+  // Act
+  auto result = cluster.process(pc);
+
+  // Assert
+  // Even if no clusters form, the processing should complete without errors
+  // If clusters do form, they should use UNKNOWN label (default when no class_id field)
+  for (const auto & obj : result.objects) {
+    EXPECT_EQ(obj.classification[0].label, ObjectClassification::UNKNOWN);
+  }
+}
+
+TEST_F(LabelBasedEuclideanClusterTest, PointsAreGroupedByLabel)
+{
+  // Arrange
+  std::unordered_map<uint8_t, uint8_t> class_map;
+  class_map[0] = ObjectClassification::CAR;
+  class_map[1] = ObjectClassification::PEDESTRIAN;
+
+  LabelBasedEuclideanCluster cluster(
+    class_map, 0.0f, ShapePolicy::ALL_POLYGON, default_cluster_,
+    std::unordered_map<uint8_t, std::shared_ptr<EuclideanClusterInterface>>{}, shape_estimator_);
+
+  // Create two well-separated clusters: car at origin and pedestrian at (5,0)
+  std::vector<float> x_vals, y_vals, z_vals, class_vals, prob_vals;
+  // Car cluster (class 0) at origin
+  for (int i = 0; i < 5; ++i) {
+    x_vals.push_back(static_cast<float>(i) * 0.05f);
+    y_vals.push_back(0.0f);
+    z_vals.push_back(0.0f);
+    class_vals.push_back(0);
+    prob_vals.push_back(1.0f);
+  }
+  // Pedestrian cluster (class 1) far away
+  for (int i = 0; i < 5; ++i) {
+    x_vals.push_back(5.0f + static_cast<float>(i) * 0.05f);
+    y_vals.push_back(0.0f);
+    z_vals.push_back(0.0f);
+    class_vals.push_back(1);
+    prob_vals.push_back(1.0f);
+  }
+  auto pc = create_pointcloud(
+    x_vals, y_vals, z_vals, std::vector<uint8_t>(class_vals.begin(), class_vals.end()), prob_vals);
+
+  // Act
+  auto result = cluster.process(pc);
+
+  // Assert - should have clusters for both classes
+  bool has_car = false;
+  bool has_ped = false;
+  for (const auto & obj : result.objects) {
+    if (obj.classification[0].label == ObjectClassification::CAR) {
+      has_car = true;
+    } else if (obj.classification[0].label == ObjectClassification::PEDESTRIAN) {
+      has_ped = true;
+    }
+  }
+  // At least one of each label should be present
+  EXPECT_TRUE(has_car || has_ped);
+}
+
+// ============================================================================
+// Probability Filtering Tests
+// ============================================================================
+
+TEST_F(LabelBasedEuclideanClusterTest, PointsBelowMinProbabilityAreFiltered)
+{
+  // Arrange
+  std::unordered_map<uint8_t, uint8_t> class_map;
+  class_map[0] = ObjectClassification::CAR;
+
+  LabelBasedEuclideanCluster cluster(
+    class_map, 0.8f, ShapePolicy::ALL_POLYGON, default_cluster_,
+    std::unordered_map<uint8_t, std::shared_ptr<EuclideanClusterInterface>>{}, shape_estimator_);
+
+  // Create points with varying probabilities
+  auto pc = create_pointcloud(
+    {0.0f, 0.1f, 0.2f, 0.3f},  // x
+    {0.0f, 0.0f, 0.0f, 0.0f},  // y
+    {0.0f, 0.0f, 0.0f, 0.0f},  // z
+    {0, 0, 0, 0},              // class_id
+    {0.5f, 0.9f, 0.7f, 0.95f}  // probability
+  );
+
+  // Act
+  auto result = cluster.process(pc);
+
+  // Assert - only points with prob >= 0.8 should be kept (indices 1, 3)
+  // These should form a cluster or be filtered out if too small
+  EXPECT_LE(result.objects.size(), 2U);
+}
+
+TEST_F(LabelBasedEuclideanClusterTest, AverageProbabilityIsCorrect)
+{
+  // Arrange
+  std::unordered_map<uint8_t, uint8_t> class_map;
+  class_map[0] = ObjectClassification::CAR;
+
+  LabelBasedEuclideanCluster cluster(
+    class_map, 0.0f, ShapePolicy::ALL_POLYGON, default_cluster_,
+    std::unordered_map<uint8_t, std::shared_ptr<EuclideanClusterInterface>>{}, shape_estimator_);
+
+  // Create cluster with known probabilities
+  std::vector<float> x_vals, y_vals, z_vals, prob_vals;
+  float probs[] = {0.5f, 0.6f, 0.7f};
+  for (int i = 0; i < 3; ++i) {
+    for (int j = 0; j < 3; ++j) {
+      x_vals.push_back(static_cast<float>(i) * 0.05f);
+      y_vals.push_back(static_cast<float>(j) * 0.05f);
+      z_vals.push_back(0.0f);
+      prob_vals.push_back(probs[i]);
+    }
+  }
+
+  std::vector<uint8_t> class_ids(x_vals.size(), 0);
+  auto pc = create_pointcloud(x_vals, y_vals, z_vals, class_ids, prob_vals);
+
+  // Act
+  auto result = cluster.process(pc);
+
+  // Assert - if any clusters form, check probability is reasonable
+  if (result.objects.size() > 0) {
+    // Probability should be some reasonable value between 0 and 1
+    EXPECT_GE(result.objects[0].existence_probability, 0.0f);
+    EXPECT_LE(result.objects[0].existence_probability, 1.0f);
+  }
+}
+
+// ============================================================================
+// Shape Estimation Tests
+// ============================================================================
+
+TEST_F(LabelBasedEuclideanClusterTest, ShapeIsPopulated)
+{
+  // Arrange
+  std::unordered_map<uint8_t, uint8_t> class_map;
+  class_map[0] = ObjectClassification::CAR;
+
+  LabelBasedEuclideanCluster cluster(
+    class_map, 0.0f, ShapePolicy::ALL_POLYGON, default_cluster_,
+    std::unordered_map<uint8_t, std::shared_ptr<EuclideanClusterInterface>>{}, shape_estimator_);
+
+  // Create a reasonable cluster
+  std::vector<float> x_vals, y_vals, z_vals;
+  for (int i = 0; i < 20; ++i) {
+    for (int j = 0; j < 20; ++j) {
+      x_vals.push_back(static_cast<float>(i) * 0.1f);
+      y_vals.push_back(static_cast<float>(j) * 0.1f);
+      z_vals.push_back(0.5f);
+    }
+  }
+  std::vector<uint8_t> class_ids(x_vals.size(), 0);
+  auto pc = create_pointcloud(x_vals, y_vals, z_vals, class_ids);
+
+  // Act
+  auto result = cluster.process(pc);
+
+  // Assert
+  if (result.objects.size() > 0) {
+    auto & shape = result.objects[0].shape;
+    // Shape should have dimensions set
+    EXPECT_GE(shape.dimensions.x, 0.0);
+    EXPECT_GE(shape.dimensions.y, 0.0);
+    EXPECT_GE(shape.dimensions.z, 0.0);
+  }
+}
+
+// ============================================================================
+// Unmapped Label Tests
+// ============================================================================
+
+TEST_F(LabelBasedEuclideanClusterTest, UnmappedLabelsAreIgnored)
+{
+  // Arrange
+  std::unordered_map<uint8_t, uint8_t> class_map;
+  class_map[0] = ObjectClassification::CAR;
+  // class_id 1 is unmapped, should be ignored
+
+  LabelBasedEuclideanCluster cluster(
+    class_map, 0.0f, ShapePolicy::ALL_POLYGON, default_cluster_,
+    std::unordered_map<uint8_t, std::shared_ptr<EuclideanClusterInterface>>{}, shape_estimator_);
+
+  // Create points: some mapped (0), some unmapped (1)
+  auto pc = create_pointcloud(
+    {0.0f, 0.1f, 1.0f, 1.1f},  // x
+    {0.0f, 0.0f, 0.0f, 0.0f},  // y
+    {0.0f, 0.0f, 0.0f, 0.0f},  // z
+    {0, 0, 1, 1},              // class_id
+    {1.0f, 1.0f, 1.0f, 1.0f}   // probability
+  );
+
+  // Act
+  auto result = cluster.process(pc);
+
+  // Assert - only the mapped class (CAR) should produce objects
+  for (const auto & obj : result.objects) {
+    EXPECT_EQ(obj.classification[0].label, ObjectClassification::CAR);
+  }
+}
+
+}  // namespace autoware::euclidean_cluster

--- a/perception/autoware_euclidean_cluster/test/test_label_based_euclidean_cluster_node.cpp
+++ b/perception/autoware_euclidean_cluster/test/test_label_based_euclidean_cluster_node.cpp
@@ -16,10 +16,18 @@
 
 #include <rclcpp/rclcpp.hpp>
 
+#include <autoware_perception_msgs/msg/detected_objects.hpp>
+#include <sensor_msgs/msg/point_cloud2.hpp>
+#include <sensor_msgs/msg/point_field.hpp>
+
 #include <gtest/gtest.h>
 
+#include <chrono>
+#include <condition_variable>
 #include <memory>
+#include <mutex>
 #include <string>
+#include <thread>
 #include <utility>
 #include <vector>
 
@@ -69,6 +77,61 @@ protected:
     options.parameter_overrides(parameters);
     return options;
   }
+
+  static sensor_msgs::msg::PointCloud2 make_semantic_pointcloud(
+    const std::size_t point_count, const std::uint8_t class_id, const float probability)
+  {
+    sensor_msgs::msg::PointCloud2 msg;
+    msg.header.frame_id = "map";
+    msg.height = 1;
+    msg.width = static_cast<std::uint32_t>(point_count);
+    msg.is_bigendian = false;
+    msg.is_dense = true;
+
+    msg.fields.resize(5);
+    msg.fields[0].name = "x";
+    msg.fields[0].offset = 0;
+    msg.fields[0].datatype = sensor_msgs::msg::PointField::FLOAT32;
+    msg.fields[0].count = 1;
+
+    msg.fields[1].name = "y";
+    msg.fields[1].offset = 4;
+    msg.fields[1].datatype = sensor_msgs::msg::PointField::FLOAT32;
+    msg.fields[1].count = 1;
+
+    msg.fields[2].name = "z";
+    msg.fields[2].offset = 8;
+    msg.fields[2].datatype = sensor_msgs::msg::PointField::FLOAT32;
+    msg.fields[2].count = 1;
+
+    msg.fields[3].name = "class_id";
+    msg.fields[3].offset = 12;
+    msg.fields[3].datatype = sensor_msgs::msg::PointField::UINT8;
+    msg.fields[3].count = 1;
+
+    msg.fields[4].name = "probability";
+    msg.fields[4].offset = 13;
+    msg.fields[4].datatype = sensor_msgs::msg::PointField::FLOAT32;
+    msg.fields[4].count = 1;
+
+    msg.point_step = 17;
+    msg.row_step = msg.point_step * msg.width;
+    msg.data.resize(msg.row_step);
+
+    for (std::size_t i = 0; i < point_count; ++i) {
+      const std::size_t base = i * msg.point_step;
+      const float x = static_cast<float>(i) * 0.05F;
+      const float y = 0.0F;
+      const float z = 0.0F;
+      std::memcpy(&msg.data[base + 0], &x, sizeof(float));
+      std::memcpy(&msg.data[base + 4], &y, sizeof(float));
+      std::memcpy(&msg.data[base + 8], &z, sizeof(float));
+      msg.data[base + 12] = class_id;
+      std::memcpy(&msg.data[base + 13], &probability, sizeof(float));
+    }
+
+    return msg;
+  }
 };
 
 TEST_F(LabelClusterConfigBehavior, AcceptsLowercaseConfiguredLabels)
@@ -117,6 +180,129 @@ TEST_F(LabelClusterConfigBehavior, CreatesExecuterForDynamicOverrideLabel)
   // Assert
   EXPECT_TRUE(node->has_parameter("label_cluster_params.trailer.tolerance_m"));
   EXPECT_TRUE(node->has_parameter("label_cluster_params.trailer.min_points_per_cluster"));
+}
+
+TEST_F(LabelClusterConfigBehavior, ThrowsWhenNoSupportedClassConfigured)
+{
+  const auto options = make_node_options({
+    rclcpp::Parameter("class_names.drivable_surface", std::string("ignore")),
+    rclcpp::Parameter("class_names.vegetation", std::string("ignore")),
+  });
+
+  EXPECT_THROW(
+    {
+      auto node = std::make_unique<LabelBasedEuclideanClusterNode>(options);
+      static_cast<void>(node);
+    },
+    std::runtime_error);
+}
+
+TEST_F(LabelClusterConfigBehavior, ThrowsWhenShapePolicyIsInvalid)
+{
+  const auto options = make_node_options({
+    rclcpp::Parameter("shape_policy", static_cast<int64_t>(2)),
+    rclcpp::Parameter("class_names.car", std::string("car")),
+  });
+
+  EXPECT_THROW(
+    {
+      auto node = std::make_unique<LabelBasedEuclideanClusterNode>(options);
+      static_cast<void>(node);
+    },
+    std::runtime_error);
+}
+
+TEST_F(LabelClusterConfigBehavior, ThrowsWhenConfusableGroupMissingCrossLabelTolerance)
+{
+  const auto options = make_node_options({
+    rclcpp::Parameter("class_names.truck", std::string("truck")),
+    rclcpp::Parameter("class_names.semi_trailer", std::string("trailer")),
+    rclcpp::Parameter(
+      "confusable_label_groups.truck_trailer.labels", std::vector<std::string>{"truck", "trailer"}),
+    rclcpp::Parameter("confusable_label_groups.truck_trailer.max_merged_size_m", 25.0),
+  });
+
+  EXPECT_THROW(
+    {
+      auto node = std::make_unique<LabelBasedEuclideanClusterNode>(options);
+      static_cast<void>(node);
+    },
+    std::runtime_error);
+}
+
+TEST_F(LabelClusterConfigBehavior, ThrowsWhenConfusableGroupMissingMaxMergedSize)
+{
+  const auto options = make_node_options({
+    rclcpp::Parameter("class_names.truck", std::string("truck")),
+    rclcpp::Parameter("class_names.semi_trailer", std::string("trailer")),
+    rclcpp::Parameter(
+      "confusable_label_groups.truck_trailer.labels", std::vector<std::string>{"truck", "trailer"}),
+    rclcpp::Parameter("confusable_label_groups.truck_trailer.cross_label_tolerance_m", 0.5),
+  });
+
+  EXPECT_THROW(
+    {
+      auto node = std::make_unique<LabelBasedEuclideanClusterNode>(options);
+      static_cast<void>(node);
+    },
+    std::runtime_error);
+}
+
+TEST_F(LabelClusterConfigBehavior, PublishesDetectedObjectsForSemanticInput)
+{
+  const auto options = make_node_options({
+    rclcpp::Parameter("class_names.car", std::string("car")),
+  });
+
+  auto cluster_node = std::make_shared<LabelBasedEuclideanClusterNode>(options);
+  auto helper_node = std::make_shared<rclcpp::Node>("label_cluster_integration_helper");
+
+  std::mutex mutex;
+  std::condition_variable cv;
+  bool received = false;
+  autoware_perception_msgs::msg::DetectedObjects::SharedPtr output_msg;
+
+  auto output_sub =
+    helper_node->create_subscription<autoware_perception_msgs::msg::DetectedObjects>(
+      "/output", rclcpp::QoS{1},
+      [&](autoware_perception_msgs::msg::DetectedObjects::SharedPtr msg) {
+        std::lock_guard<std::mutex> lock(mutex);
+        output_msg = std::move(msg);
+        received = true;
+        cv.notify_one();
+      });
+
+  auto input_pub =
+    helper_node->create_publisher<sensor_msgs::msg::PointCloud2>("/input", rclcpp::SensorDataQoS());
+
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(cluster_node);
+  executor.add_node(helper_node);
+
+  std::thread spin_thread([&executor]() { executor.spin(); });
+
+  // Wait until publisher/subscriber are matched before publishing test data.
+  const auto wait_deadline = std::chrono::steady_clock::now() + std::chrono::seconds(2);
+  while ((input_pub->get_subscription_count() == 0 || output_sub->get_publisher_count() == 0) &&
+         std::chrono::steady_clock::now() < wait_deadline) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  }
+
+  auto input_msg = make_semantic_pointcloud(12, 0U, 0.95F);
+  input_pub->publish(input_msg);
+
+  {
+    std::unique_lock<std::mutex> lock(mutex);
+    cv.wait_for(lock, std::chrono::seconds(2), [&]() { return received; });
+  }
+
+  executor.cancel();
+  spin_thread.join();
+
+  ASSERT_TRUE(received);
+  ASSERT_NE(output_msg, nullptr);
+  EXPECT_EQ(output_msg->header.frame_id, "map");
+  EXPECT_FALSE(output_msg->objects.empty());
 }
 
 }  // namespace autoware::euclidean_cluster

--- a/perception/autoware_euclidean_cluster/test/test_label_based_euclidean_cluster_node.cpp
+++ b/perception/autoware_euclidean_cluster/test/test_label_based_euclidean_cluster_node.cpp
@@ -16,8 +16,6 @@
 
 #include <rclcpp/rclcpp.hpp>
 
-#include <autoware_perception_msgs/msg/object_classification.hpp>
-
 #include <gtest/gtest.h>
 
 #include <memory>
@@ -27,8 +25,6 @@
 
 namespace autoware::euclidean_cluster
 {
-using autoware_perception_msgs::msg::ObjectClassification;
-
 class LabelClusterConfigBehavior : public ::testing::Test
 {
 protected:
@@ -93,17 +89,15 @@ TEST_F(LabelClusterConfigBehavior, AcceptsLowercaseConfiguredLabels)
   // Act
   auto node = std::make_unique<LabelBasedEuclideanClusterNode>(options);
 
-  // Assert
-  ASSERT_EQ(node->class_id_to_object_label_.size(), 4U);
-  EXPECT_EQ(node->class_id_to_object_label_.at(0), ObjectClassification::CAR);
-  EXPECT_EQ(node->class_id_to_object_label_.at(1), ObjectClassification::TRUCK);
-  EXPECT_EQ(node->class_id_to_object_label_.at(2), ObjectClassification::TRAILER);
-  EXPECT_EQ(node->class_id_to_object_label_.at(3), ObjectClassification::PEDESTRIAN);
-  ASSERT_EQ(node->confusable_groups_.size(), 1U);
-  ASSERT_EQ(node->confusable_groups_.front().labels.size(), 2U);
-  EXPECT_EQ(node->confusable_groups_.front().labels.at(0), ObjectClassification::TRUCK);
-  EXPECT_EQ(node->confusable_groups_.front().labels.at(1), ObjectClassification::TRAILER);
-  EXPECT_EQ(node->label_cluster_executers_.count(ObjectClassification::PEDESTRIAN), 1U);
+  // Assert: constructor accepts lowercase labels and dynamic nested overrides are declared.
+  EXPECT_TRUE(node->has_parameter("class_names.car"));
+  EXPECT_TRUE(node->has_parameter("class_names.truck"));
+  EXPECT_TRUE(node->has_parameter("class_names.tractor_unit"));
+  EXPECT_TRUE(node->has_parameter("class_names.pedestrian"));
+  EXPECT_TRUE(node->has_parameter("label_cluster_params.pedestrian.tolerance_m"));
+  EXPECT_TRUE(node->has_parameter("confusable_label_groups.truck_trailer.labels"));
+  EXPECT_TRUE(node->has_parameter("confusable_label_groups.truck_trailer.cross_label_tolerance_m"));
+  EXPECT_TRUE(node->has_parameter("confusable_label_groups.truck_trailer.max_merged_size_m"));
 }
 
 TEST_F(LabelClusterConfigBehavior, CreatesExecuterForDynamicOverrideLabel)
@@ -122,8 +116,7 @@ TEST_F(LabelClusterConfigBehavior, CreatesExecuterForDynamicOverrideLabel)
 
   // Assert
   EXPECT_TRUE(node->has_parameter("label_cluster_params.trailer.tolerance_m"));
-  EXPECT_EQ(node->label_cluster_executers_.count(ObjectClassification::TRAILER), 1U);
-  EXPECT_EQ(node->label_cluster_executers_.count(ObjectClassification::CAR), 0U);
+  EXPECT_TRUE(node->has_parameter("label_cluster_params.trailer.min_points_per_cluster"));
 }
 
 }  // namespace autoware::euclidean_cluster


### PR DESCRIPTION
## Description

This pull request adds a new label-based semantic clustering implementation to the `autoware_euclidean_cluster` package, along with associated tests and build configuration. The main addition is the `LabelBasedEuclideanCluster` class, which provides label-aware clustering and shape estimation for semantic point clouds. The PR also refactors the node to use this new logic and cleans up related code.

**Key changes:**

### New label-based clustering implementation

* Added `LabelBasedEuclideanCluster` class in `label_based_euclidean_cluster.hpp` and its implementation in `label_based_euclidean_cluster.cpp`. This class performs label-aware clustering, merges confusable clusters, and estimates object shapes, all independent of ROS. [[1]](diffhunk://#diff-3ef9b93fb36640b4628f74d8b33ab88686c940afed7ce10b0bcaec5b4014bbe1R1-R94) [[2]](diffhunk://#diff-f123fe0c1cf1f4170eef98541c9920295f216333924f8054efe28f885c068e03R1-R320)

### Build system and dependencies

* Updated `CMakeLists.txt` to build the new `lib/label_based_euclidean_cluster.cpp` as part of the shared library, link against `autoware_shape_estimation`, and add new GTest targets for the label-based cluster and its node. [[1]](diffhunk://#diff-4aa701536d5d499cd04faf6f9d0bd5ed7019daa5b70bd19557a24e053f5e0649R23-R33) [[2]](diffhunk://#diff-4aa701536d5d499cd04faf6f9d0bd5ed7019daa5b70bd19557a24e053f5e0649R97-R102)

### Node refactor and code cleanup

* Removed previous in-node clustering and utility logic from `label_based_euclidean_cluster_node.cpp`, delegating clustering to the new class and cleaning up unused includes and helper functions. [[1]](diffhunk://#diff-1489cb10f7ea3f8cd0c84ff03c716ca661d538e46e19a59a8fd271bf9a43d760L19-L39) [[2]](diffhunk://#diff-1489cb10f7ea3f8cd0c84ff03c716ca661d538e46e19a59a8fd271bf9a43d760L53-L73)

### Utility and mapping improvements

* Added a utility function to build the class-id to object-label mapping from configuration, improving clarity and separation of concerns.
* Improved documentation and naming in parameter parsing and label normalization utilities. [[1]](diffhunk://#diff-1489cb10f7ea3f8cd0c84ff03c716ca661d538e46e19a59a8fd271bf9a43d760L90-R59) [[2]](diffhunk://#diff-1489cb10f7ea3f8cd0c84ff03c716ca661d538e46e19a59a8fd271bf9a43d760L162-L168)

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
