### PR TITLE
feat(multi object tracker): optimze execution for diffusion planner

### DIFF
--- a/perception/autoware_multi_object_tracker/config/multi_object_tracker_node.param.yaml
+++ b/perception/autoware_multi_object_tracker/config/multi_object_tracker_node.param.yaml
@@ -4,13 +4,18 @@
     publish_rate: 10.0
     world_frame_id: map
     ego_frame_id: base_link
-    consider_odometry_uncertainty: false
 
     # ego pose source: "tf" (look up from TF tree) or "odometry" (interpolate from ~/input/odometry)
-    ego_source: tf
+    # publish-trigger side: false publishes on measurement, true publishes from the periodic timer.
     # object-export side: timestamp the published tracks are predicted to.
-    # "detection" (publish on measurement, no timer) | "now" | "latest_odometry"
+    publish_rate: 10.0
+    publish_on_timer: true
+
+    # "detection" (latest detection/update time) | "now" | "latest_odometry"
+    ego_source: odometry
     delay_compensation: detection
+
+    consider_odometry_uncertainty: false
 
     # Per-tracker-type configuration
     tracker_configs:

--- a/perception/autoware_multi_object_tracker/config/multi_object_tracker_node.param.yaml
+++ b/perception/autoware_multi_object_tracker/config/multi_object_tracker_node.param.yaml
@@ -1,7 +1,6 @@
 /**:
   ros__parameters:
     # default tracker node parameters
-    publish_rate: 10.0
     world_frame_id: map
     ego_frame_id: base_link
 

--- a/perception/autoware_multi_object_tracker/config/multi_object_tracker_node.param.yaml
+++ b/perception/autoware_multi_object_tracker/config/multi_object_tracker_node.param.yaml
@@ -12,7 +12,7 @@
     ego_source: tf
     # delay compensation, least -> most:
     # "none" | "publish_delay" (detection + update->publish delay) | "odometry" (up to latest odometry) | "full" (to now)
-    delay_compensation: publish_delay
+    delay_compensation: none
 
     consider_odometry_uncertainty: false
 

--- a/perception/autoware_multi_object_tracker/config/multi_object_tracker_node.param.yaml
+++ b/perception/autoware_multi_object_tracker/config/multi_object_tracker_node.param.yaml
@@ -4,8 +4,13 @@
     publish_rate: 10.0
     world_frame_id: map
     ego_frame_id: base_link
-    enable_delay_compensation: false
     consider_odometry_uncertainty: false
+
+    # ego pose source: "tf" (look up from TF tree) or "odometry" (interpolate from ~/input/odometry)
+    ego_source: tf
+    # object-export side: timestamp the published tracks are predicted to.
+    # "detection" (publish on measurement, no timer) | "now" | "latest_odometry"
+    delay_compensation: detection
 
     # Per-tracker-type configuration
     tracker_configs:

--- a/perception/autoware_multi_object_tracker/config/multi_object_tracker_node.param.yaml
+++ b/perception/autoware_multi_object_tracker/config/multi_object_tracker_node.param.yaml
@@ -9,10 +9,10 @@
     publish_rate: 10.0
 
     # ego pose source: "tf" (look up from TF tree) or "odometry" (interpolate from ~/input/odometry)
-    ego_source: odometry
+    ego_source: tf
     # delay compensation, least -> most:
     # "none" | "publish_delay" (detection + update->publish delay) | "odometry" (up to latest odometry) | "full" (to now)
-    delay_compensation: none
+    delay_compensation: publish_delay
 
     consider_odometry_uncertainty: false
 

--- a/perception/autoware_multi_object_tracker/config/multi_object_tracker_node.param.yaml
+++ b/perception/autoware_multi_object_tracker/config/multi_object_tracker_node.param.yaml
@@ -11,7 +11,7 @@
     publish_rate: 10.0
     publish_on_timer: true
 
-    # "detection" (latest detection/update time) | "now" | "latest_odometry"
+    # "detection" (no compensation) | "elapsed" (detection + publish delay) | "latest_odometry" | "now"
     ego_source: odometry
     delay_compensation: detection
 

--- a/perception/autoware_multi_object_tracker/config/multi_object_tracker_node.param.yaml
+++ b/perception/autoware_multi_object_tracker/config/multi_object_tracker_node.param.yaml
@@ -5,15 +5,15 @@
     world_frame_id: map
     ego_frame_id: base_link
 
-    # ego pose source: "tf" (look up from TF tree) or "odometry" (interpolate from ~/input/odometry)
-    # publish-trigger side: false publishes on measurement, true publishes from the periodic timer.
-    # object-export side: timestamp the published tracks are predicted to.
+    # publish-trigger
+    publish_on_timer: false
     publish_rate: 10.0
-    publish_on_timer: true
 
-    # "detection" (no compensation) | "elapsed" (detection + publish delay) | "latest_odometry" | "now"
+    # ego pose source: "tf" (look up from TF tree) or "odometry" (interpolate from ~/input/odometry)
     ego_source: odometry
-    delay_compensation: detection
+    # delay compensation, least -> most:
+    # "none" | "publish_delay" (detection + update->publish delay) | "odometry" (up to latest odometry) | "full" (to now)
+    delay_compensation: none
 
     consider_odometry_uncertainty: false
 

--- a/perception/autoware_multi_object_tracker/design/MultiObjectTracker.node.yaml
+++ b/perception/autoware_multi_object_tracker/design/MultiObjectTracker.node.yaml
@@ -106,7 +106,7 @@ param_values:
     default: false
   - name: ego_source
     type: string
-    default: odometry
+    default: tf
 
 # processes
 processes:

--- a/perception/autoware_multi_object_tracker/design/MultiObjectTracker.node.yaml
+++ b/perception/autoware_multi_object_tracker/design/MultiObjectTracker.node.yaml
@@ -40,6 +40,9 @@ subscribers:
     message_type: autoware_perception_msgs/msg/DetectedObjects
   - name: detection12/objects
     message_type: autoware_perception_msgs/msg/DetectedObjects
+  - name: input/odometry
+    message_type: nav_msgs/msg/Odometry
+
 publishers:
   - name: objects
     message_type: autoware_perception_msgs/msg/TrackedObjects
@@ -101,6 +104,9 @@ param_values:
   - name: publish_merged_objects
     type: boolean
     default: false
+  - name: ego_source
+    type: string
+    default: odometry
 
 # processes
 processes:

--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/odometry.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/odometry.hpp
@@ -35,6 +35,23 @@
 namespace autoware::multi_object_tracker
 {
 
+/// Backend used to obtain the time-varying ego pose (world <- ego).
+enum class EgoSource {
+  TF,        ///< look up the ego pose from the TF tree (default, legacy behavior)
+  ODOMETRY,  ///< interpolate the ego pose from a subscribed odometry buffer
+};
+
+/// Reference time the exported objects are predicted/published to (object-export side).
+enum class DelayReference {
+  DETECTION,        ///< the latest measurement/detection stamp (publish on measurement, no timer)
+  NOW,              ///< the current wall-clock time
+  LATEST_ODOMETRY,  ///< the stamp of the newest buffered odometry sample
+};
+
+/// Parse helpers (strict string match; throw std::invalid_argument on mismatch).
+EgoSource toEgoSource(const std::string & name);
+DelayReference toDelayReference(const std::string & name);
+
 class Odometry
 {
 public:
@@ -42,7 +59,13 @@ public:
     rclcpp::Logger logger, rclcpp::Clock::SharedPtr clock,
     std::shared_ptr<autoware::agnocast_wrapper::Buffer> tf_buffer,
     const std::string & world_frame_id, const std::string & ego_frame_id,
-    bool enable_odometry_uncertainty = false);
+    bool enable_odometry_uncertainty = false, EgoSource ego_source = EgoSource::TF);
+
+  /// Feed a new odometry sample (world <- ego) into the interpolation buffer.
+  void updateOdometryBuffer(const nav_msgs::msg::Odometry & odometry);
+
+  /// Stamp of the newest buffered odometry sample (nullopt if the buffer is empty).
+  std::optional<rclcpp::Time> getLatestOdometryTime() const;
 
   std::optional<geometry_msgs::msg::Transform> getTransform(
     const std::string & source_frame_id, const rclcpp::Time & time) const;
@@ -62,6 +85,8 @@ private:
   // tf
   std::shared_ptr<autoware::agnocast_wrapper::Buffer> tf_buffer_;
   autoware::agnocast_wrapper::TransformListener tf_listener_;
+  // ego source
+  EgoSource ego_source_;
 
 public:
   bool enable_odometry_uncertainty_ = false;
@@ -70,8 +95,17 @@ private:
   void updateTfCache(
     const rclcpp::Time & time, const geometry_msgs::msg::Transform & transform) const;
 
-  // cache of tf
+  // --- odometry-source helpers ---
+  /// Interpolate (or bounded-extrapolate) the buffered odometry to `time`.
+  std::optional<nav_msgs::msg::Odometry> interpolateOdometry(const rclcpp::Time & time) const;
+  /// world <- ego transform from the odometry buffer at `time` (nullopt on miss).
+  std::optional<geometry_msgs::msg::Transform> getEgoTransformFromOdometry(
+    const rclcpp::Time & time) const;
+
+  // cache of tf (TF backend)
   mutable std::map<rclcpp::Time, geometry_msgs::msg::Transform> tf_cache_;
+  // buffer of odometry samples (ODOMETRY backend)
+  mutable std::map<rclcpp::Time, nav_msgs::msg::Odometry> odom_buffer_;
 };
 
 }  // namespace autoware::multi_object_tracker

--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/odometry.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/odometry.hpp
@@ -44,8 +44,9 @@ enum class EgoSource {
 /// Reference time the exported objects are predicted/published to (object-export side).
 enum class DelayReference {
   DETECTION,        ///< the latest detection/update stamp (no forward compensation)
-  NOW,              ///< the current wall-clock time
+  ELAPSED,          ///< detection stamp advanced by the wall-clock elapsed since the last update
   LATEST_ODOMETRY,  ///< the stamp of the newest buffered odometry sample
+  NOW,              ///< the current wall-clock time
 };
 
 /// Parse helpers (strict string match; throw std::invalid_argument on mismatch).

--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/odometry.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/odometry.hpp
@@ -43,7 +43,7 @@ enum class EgoSource {
 
 /// Reference time the exported objects are predicted/published to (object-export side).
 enum class DelayReference {
-  DETECTION,        ///< the latest measurement/detection stamp (publish on measurement, no timer)
+  DETECTION,        ///< the latest detection/update stamp (no forward compensation)
   NOW,              ///< the current wall-clock time
   LATEST_ODOMETRY,  ///< the stamp of the newest buffered odometry sample
 };

--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/odometry.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/odometry.hpp
@@ -65,8 +65,7 @@ public:
   /// Feed a new odometry sample (world <- ego) into the interpolation buffer.
   void updateOdometryBuffer(const nav_msgs::msg::Odometry & odometry);
 
-  /// Get the latest odometry time in the buffer (nullopt if empty).
-  std::optional<rclcpp::Time> getLatestOdometryTime() const;
+  std::optional<rclcpp::Time> getLatestEgoPoseTime() const;
 
   std::optional<geometry_msgs::msg::Transform> getTransform(
     const std::string & source_frame_id, const rclcpp::Time & time) const;

--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/odometry.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/odometry.hpp
@@ -43,10 +43,10 @@ enum class EgoSource {
 
 /// Reference time the exported objects are predicted/published to (object-export side).
 enum class DelayReference {
-  DETECTION,        ///< the latest detection/update stamp (no forward compensation)
-  ELAPSED,          ///< detection stamp advanced by the wall-clock elapsed since the last update
-  LATEST_ODOMETRY,  ///< the stamp of the newest buffered odometry sample
-  NOW,              ///< the current wall-clock time
+  NONE,           ///< no compensation: the latest detection/update stamp
+  PUBLISH_DELAY,  ///< detection stamp advanced by the update->publish delay
+  ODOMETRY,       ///< compensate up to the newest buffered odometry stamp
+  FULL,           ///< full compensation to the current wall-clock time
 };
 
 /// Parse helpers (strict string match; throw std::invalid_argument on mismatch).

--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/odometry.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/odometry.hpp
@@ -65,7 +65,7 @@ public:
   /// Feed a new odometry sample (world <- ego) into the interpolation buffer.
   void updateOdometryBuffer(const nav_msgs::msg::Odometry & odometry);
 
-  /// Stamp of the newest buffered odometry sample (nullopt if the buffer is empty).
+  /// Get the latest odometry time in the buffer (nullopt if empty).
   std::optional<rclcpp::Time> getLatestOdometryTime() const;
 
   std::optional<geometry_msgs::msg::Transform> getTransform(

--- a/perception/autoware_multi_object_tracker/launch/multi_object_tracker.launch.xml
+++ b/perception/autoware_multi_object_tracker/launch/multi_object_tracker.launch.xml
@@ -34,7 +34,7 @@
   <arg name="data_association_matrix_path" default="$(find-pkg-share autoware_multi_object_tracker)/config/data_association_matrix.param.yaml"/>
   <arg name="input_channels_path" default="$(find-pkg-share autoware_multi_object_tracker)/config/input_channels.param.yaml"/>
   <arg name="publish_merged_objects" default="false"/>
-  <arg name="ego_source" default="odometry" description="ego pose source: tf (look up from TF tree) or odometry (interpolate from input/odometry)"/>
+  <arg name="ego_source" default="tf" description="ego pose source: tf (look up from TF tree) or odometry (interpolate from input/odometry)"/>
 
   <node pkg="autoware_multi_object_tracker" exec="multi_object_tracker_node" name="multi_object_tracker" output="both">
     <env name="LD_PRELOAD" value="$(var ld_preload_value)"/>

--- a/perception/autoware_multi_object_tracker/launch/multi_object_tracker.launch.xml
+++ b/perception/autoware_multi_object_tracker/launch/multi_object_tracker.launch.xml
@@ -14,6 +14,7 @@
   <arg name="input/detection10/objects" default="input/objects10"/>
   <arg name="input/detection11/objects" default="input/objects11"/>
   <arg name="input/detection12/objects" default="input/objects12"/>
+  <arg name="input/odometry" default="/localization/kinematic_state"/>
   <arg name="output/objects" default="objects"/>
   <arg name="output/merged_objects" default="merged_objects"/>
 
@@ -48,6 +49,7 @@
     <remap from="~/input/detection10/objects" to="$(var input/detection10/objects)"/>
     <remap from="~/input/detection11/objects" to="$(var input/detection11/objects)"/>
     <remap from="~/input/detection12/objects" to="$(var input/detection12/objects)"/>
+    <remap from="~/input/odometry" to="$(var input/odometry)"/>
     <remap from="~/output/objects" to="$(var output/objects)"/>
     <remap from="~/output/merged_objects" to="$(var output/merged_objects)"/>
     <param name="input/detection01/channel" value="$(var input/detection01/channel)"/>

--- a/perception/autoware_multi_object_tracker/launch/multi_object_tracker.launch.xml
+++ b/perception/autoware_multi_object_tracker/launch/multi_object_tracker.launch.xml
@@ -34,6 +34,7 @@
   <arg name="data_association_matrix_path" default="$(find-pkg-share autoware_multi_object_tracker)/config/data_association_matrix.param.yaml"/>
   <arg name="input_channels_path" default="$(find-pkg-share autoware_multi_object_tracker)/config/input_channels.param.yaml"/>
   <arg name="publish_merged_objects" default="false"/>
+  <arg name="ego_source" default="odometry" description="ego pose source: tf (look up from TF tree) or odometry (interpolate from input/odometry)"/>
 
   <node pkg="autoware_multi_object_tracker" exec="multi_object_tracker_node" name="multi_object_tracker" output="both">
     <env name="LD_PRELOAD" value="$(var ld_preload_value)"/>
@@ -68,5 +69,6 @@
     <param from="$(var data_association_matrix_path)"/>
     <param from="$(var input_channels_path)"/>
     <param name="publish_merged_objects" value="$(var publish_merged_objects)"/>
+    <param name="ego_source" value="$(var ego_source)"/>
   </node>
 </launch>

--- a/perception/autoware_multi_object_tracker/lib/odometry.cpp
+++ b/perception/autoware_multi_object_tracker/lib/odometry.cpp
@@ -134,13 +134,13 @@ EgoSource toEgoSource(const std::string & name)
 
 DelayReference toDelayReference(const std::string & name)
 {
-  if (name == "detection") return DelayReference::DETECTION;
-  if (name == "elapsed") return DelayReference::ELAPSED;
-  if (name == "latest_odometry") return DelayReference::LATEST_ODOMETRY;
-  if (name == "now") return DelayReference::NOW;
+  if (name == "none") return DelayReference::NONE;
+  if (name == "publish_delay") return DelayReference::PUBLISH_DELAY;
+  if (name == "odometry") return DelayReference::ODOMETRY;
+  if (name == "full") return DelayReference::FULL;
   throw std::invalid_argument(
     "Invalid delay_compensation: '" + name +
-    "'. Expected 'detection', 'elapsed', 'latest_odometry', or 'now'.");
+    "'. Expected 'none', 'publish_delay', 'odometry', or 'full'.");
 }
 
 Odometry::Odometry(

--- a/perception/autoware_multi_object_tracker/lib/odometry.cpp
+++ b/perception/autoware_multi_object_tracker/lib/odometry.cpp
@@ -160,6 +160,18 @@ Odometry::Odometry(
 
 void Odometry::updateOdometryBuffer(const nav_msgs::msg::Odometry & odometry)
 {
+  // The odometry pose is consumed as the world <- ego transform without re-projection, so the
+  // incoming frames must match the configured ones. Warn (throttled) on mismatch instead of
+  // silently producing wrong poses.
+  if (odometry.header.frame_id != world_frame_id_ || odometry.child_frame_id != ego_frame_id_) {
+    RCLCPP_WARN_THROTTLE(
+      logger_, *clock_, 2000,
+      "Odometry frames ('%s' <- '%s') do not match the configured frames ('%s' <- '%s'); "
+      "ego poses from the odometry backend may be wrong.",
+      odometry.header.frame_id.c_str(), odometry.child_frame_id.c_str(), world_frame_id_.c_str(),
+      ego_frame_id_.c_str());
+  }
+
   const rclcpp::Time stamp(odometry.header.stamp);
   odom_buffer_[stamp] = odometry;
 

--- a/perception/autoware_multi_object_tracker/lib/odometry.cpp
+++ b/perception/autoware_multi_object_tracker/lib/odometry.cpp
@@ -177,10 +177,27 @@ void Odometry::updateOdometryBuffer(const nav_msgs::msg::Odometry & odometry)
 
 std::optional<rclcpp::Time> Odometry::getLatestOdometryTime() const
 {
-  if (odom_buffer_.empty()) {
+  // ODOMETRY backend: newest buffered odometry sample.
+  if (ego_source_ == EgoSource::ODOMETRY) {
+    if (!odom_buffer_.empty()) {
+      return rclcpp::Time(odom_buffer_.rbegin()->first);
+    }
+  }
+
+  // TF backend (and odometry fallback): stamp of the latest available transform.
+  try {
+    std::string errstr;  // suppresses error msg from being printed to the terminal
+    if (!tf_buffer_->canTransform(
+          world_frame_id_, ego_frame_id_, tf2::TimePointZero, tf2::Duration::zero(), &errstr)) {
+      return std::nullopt;
+    }
+    const auto latest =
+      tf_buffer_->lookupTransform(world_frame_id_, ego_frame_id_, tf2::TimePointZero);
+    return rclcpp::Time(latest.header.stamp);
+  } catch (tf2::TransformException & ex) {
+    RCLCPP_WARN_STREAM(logger_, ex.what());
     return std::nullopt;
   }
-  return rclcpp::Time(odom_buffer_.rbegin()->first);
 }
 
 std::optional<nav_msgs::msg::Odometry> Odometry::interpolateOdometry(

--- a/perception/autoware_multi_object_tracker/lib/odometry.cpp
+++ b/perception/autoware_multi_object_tracker/lib/odometry.cpp
@@ -16,9 +16,10 @@
 
 #include "autoware/multi_object_tracker/uncertainty/uncertainty_processor.hpp"
 
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+
 #include <tf2/LinearMath/Quaternion.h>
 #include <tf2/utils.h>
-#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 
 #include <array>
 #include <cmath>
@@ -35,8 +36,8 @@ namespace autoware::multi_object_tracker
 namespace
 {
 // Buffering / interpolation limits for the odometry backend.
-constexpr double kMaxOdomBufferAge = 2.0;     // [s] keep at most this much history
-constexpr double kMaxExtrapolation = 1.0;     // [s] bounded extrapolation beyond buffer edges
+constexpr double kMaxOdomBufferAge = 2.0;  // [s] keep at most this much history
+constexpr double kMaxExtrapolation = 1.0;  // [s] bounded extrapolation beyond buffer edges
 
 double toSeconds(const rclcpp::Duration & d)
 {
@@ -134,11 +135,12 @@ EgoSource toEgoSource(const std::string & name)
 DelayReference toDelayReference(const std::string & name)
 {
   if (name == "detection") return DelayReference::DETECTION;
-  if (name == "now") return DelayReference::NOW;
+  if (name == "elapsed") return DelayReference::ELAPSED;
   if (name == "latest_odometry") return DelayReference::LATEST_ODOMETRY;
+  if (name == "now") return DelayReference::NOW;
   throw std::invalid_argument(
     "Invalid delay_compensation: '" + name +
-    "'. Expected 'detection', 'now', or 'latest_odometry'.");
+    "'. Expected 'detection', 'elapsed', 'latest_odometry', or 'now'.");
 }
 
 Odometry::Odometry(
@@ -181,7 +183,8 @@ std::optional<rclcpp::Time> Odometry::getLatestOdometryTime() const
   return rclcpp::Time(odom_buffer_.rbegin()->first);
 }
 
-std::optional<nav_msgs::msg::Odometry> Odometry::interpolateOdometry(const rclcpp::Time & time) const
+std::optional<nav_msgs::msg::Odometry> Odometry::interpolateOdometry(
+  const rclcpp::Time & time) const
 {
   if (odom_buffer_.empty()) {
     return std::nullopt;
@@ -289,8 +292,8 @@ std::optional<geometry_msgs::msg::Transform> Odometry::getTransform(
         std::string errstr;
         if (tf_buffer_->canTransform(
               ego_frame_id_, source_frame_id, tf2::TimePointZero, tf2::Duration::zero(), &errstr)) {
-          const auto ego_to_source = tf_buffer_->lookupTransform(
-            ego_frame_id_, source_frame_id, tf2::TimePointZero);
+          const auto ego_to_source =
+            tf_buffer_->lookupTransform(ego_frame_id_, source_frame_id, tf2::TimePointZero);
           tf2::Transform tf_world_to_ego;
           tf2::Transform tf_ego_to_source;
           tf2::fromMsg(*world_to_ego, tf_world_to_ego);

--- a/perception/autoware_multi_object_tracker/lib/odometry.cpp
+++ b/perception/autoware_multi_object_tracker/lib/odometry.cpp
@@ -187,7 +187,7 @@ void Odometry::updateOdometryBuffer(const nav_msgs::msg::Odometry & odometry)
   }
 }
 
-std::optional<rclcpp::Time> Odometry::getLatestOdometryTime() const
+std::optional<rclcpp::Time> Odometry::getLatestEgoPoseTime() const
 {
   // ODOMETRY backend: newest buffered odometry sample.
   if (ego_source_ == EgoSource::ODOMETRY) {

--- a/perception/autoware_multi_object_tracker/lib/odometry.cpp
+++ b/perception/autoware_multi_object_tracker/lib/odometry.cpp
@@ -16,26 +16,225 @@
 
 #include "autoware/multi_object_tracker/uncertainty/uncertainty_processor.hpp"
 
+#include <tf2/LinearMath/Quaternion.h>
+#include <tf2/utils.h>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 
+#include <array>
+#include <cmath>
+#include <cstddef>
+#include <iterator>
 #include <memory>
+#include <optional>
+#include <stdexcept>
 #include <string>
 
 namespace autoware::multi_object_tracker
 {
 
+namespace
+{
+// Buffering / interpolation limits for the odometry backend.
+constexpr double kMaxOdomBufferAge = 2.0;     // [s] keep at most this much history
+constexpr double kMaxExtrapolation = 1.0;     // [s] bounded extrapolation beyond buffer edges
+
+double toSeconds(const rclcpp::Duration & d)
+{
+  return static_cast<double>(d.nanoseconds()) * 1e-9;
+}
+
+// Linear interpolation of the 6x6 covariance arrays.
+void lerpCovariance(
+  const std::array<double, 36> & a, const std::array<double, 36> & b, double ratio,
+  std::array<double, 36> & out)
+{
+  for (size_t i = 0; i < 36; ++i) {
+    out[i] = a[i] + (b[i] - a[i]) * ratio;
+  }
+}
+
+// Interpolate between two odometry samples at the given ratio in [0, 1].
+nav_msgs::msg::Odometry lerpOdometry(
+  const nav_msgs::msg::Odometry & a, const nav_msgs::msg::Odometry & b, double ratio,
+  const rclcpp::Time & stamp)
+{
+  nav_msgs::msg::Odometry out = a;
+  out.header.stamp = stamp;
+
+  // position: linear
+  const auto & pa = a.pose.pose.position;
+  const auto & pb = b.pose.pose.position;
+  out.pose.pose.position.x = pa.x + (pb.x - pa.x) * ratio;
+  out.pose.pose.position.y = pa.y + (pb.y - pa.y) * ratio;
+  out.pose.pose.position.z = pa.z + (pb.z - pa.z) * ratio;
+
+  // orientation: SLERP
+  tf2::Quaternion qa;
+  tf2::Quaternion qb;
+  tf2::fromMsg(a.pose.pose.orientation, qa);
+  tf2::fromMsg(b.pose.pose.orientation, qb);
+  tf2::Quaternion q = qa.slerp(qb, ratio);
+  q.normalize();
+  out.pose.pose.orientation = tf2::toMsg(q);
+
+  // twist: linear
+  const auto & la = a.twist.twist.linear;
+  const auto & lb = b.twist.twist.linear;
+  out.twist.twist.linear.x = la.x + (lb.x - la.x) * ratio;
+  out.twist.twist.linear.y = la.y + (lb.y - la.y) * ratio;
+  out.twist.twist.linear.z = la.z + (lb.z - la.z) * ratio;
+  const auto & aa = a.twist.twist.angular;
+  const auto & ab = b.twist.twist.angular;
+  out.twist.twist.angular.x = aa.x + (ab.x - aa.x) * ratio;
+  out.twist.twist.angular.y = aa.y + (ab.y - aa.y) * ratio;
+  out.twist.twist.angular.z = aa.z + (ab.z - aa.z) * ratio;
+
+  // covariance: linear
+  lerpCovariance(a.pose.covariance, b.pose.covariance, ratio, out.pose.covariance);
+  lerpCovariance(a.twist.covariance, b.twist.covariance, ratio, out.twist.covariance);
+
+  return out;
+}
+
+// Constant-twist forward/backward extrapolation of a single odometry sample by dt seconds.
+nav_msgs::msg::Odometry extrapolateOdometry(
+  const nav_msgs::msg::Odometry & base, double dt, const rclcpp::Time & stamp)
+{
+  nav_msgs::msg::Odometry out = base;
+  out.header.stamp = stamp;
+
+  // integrate planar motion in the body frame using the body twist
+  tf2::Quaternion q;
+  tf2::fromMsg(base.pose.pose.orientation, q);
+  const double yaw = tf2::getYaw(q);
+  const double vx = base.twist.twist.linear.x;
+  const double vy = base.twist.twist.linear.y;
+  const double wz = base.twist.twist.angular.z;
+
+  out.pose.pose.position.x += (std::cos(yaw) * vx - std::sin(yaw) * vy) * dt;
+  out.pose.pose.position.y += (std::sin(yaw) * vx + std::cos(yaw) * vy) * dt;
+
+  tf2::Quaternion dq;
+  dq.setRPY(0.0, 0.0, wz * dt);
+  tf2::Quaternion q_new = q * dq;
+  q_new.normalize();
+  out.pose.pose.orientation = tf2::toMsg(q_new);
+
+  return out;
+}
+}  // namespace
+
+EgoSource toEgoSource(const std::string & name)
+{
+  if (name == "tf") return EgoSource::TF;
+  if (name == "odometry") return EgoSource::ODOMETRY;
+  throw std::invalid_argument("Invalid ego_source: '" + name + "'. Expected 'tf' or 'odometry'.");
+}
+
+DelayReference toDelayReference(const std::string & name)
+{
+  if (name == "detection") return DelayReference::DETECTION;
+  if (name == "now") return DelayReference::NOW;
+  if (name == "latest_odometry") return DelayReference::LATEST_ODOMETRY;
+  throw std::invalid_argument(
+    "Invalid delay_compensation: '" + name +
+    "'. Expected 'detection', 'now', or 'latest_odometry'.");
+}
+
 Odometry::Odometry(
   rclcpp::Logger logger, rclcpp::Clock::SharedPtr clock,
   std::shared_ptr<autoware::agnocast_wrapper::Buffer> tf_buffer, const std::string & world_frame_id,
-  const std::string & ego_frame_id, bool enable_odometry_uncertainty)
+  const std::string & ego_frame_id, bool enable_odometry_uncertainty, EgoSource ego_source)
 : logger_(logger),
   clock_(clock),
   ego_frame_id_(ego_frame_id),
   world_frame_id_(world_frame_id),
   tf_buffer_(tf_buffer),
   tf_listener_(*tf_buffer_),
+  ego_source_(ego_source),
   enable_odometry_uncertainty_(enable_odometry_uncertainty)
 {
+}
+
+void Odometry::updateOdometryBuffer(const nav_msgs::msg::Odometry & odometry)
+{
+  const rclcpp::Time stamp(odometry.header.stamp);
+  odom_buffer_[stamp] = odometry;
+
+  // evict samples older than the newest by more than the max age
+  const auto newest = odom_buffer_.rbegin()->first;
+  const auto max_age = rclcpp::Duration::from_seconds(kMaxOdomBufferAge);
+  for (auto it = odom_buffer_.begin(); it != odom_buffer_.end();) {
+    if (newest - it->first > max_age) {
+      it = odom_buffer_.erase(it);
+    } else {
+      ++it;
+    }
+  }
+}
+
+std::optional<rclcpp::Time> Odometry::getLatestOdometryTime() const
+{
+  if (odom_buffer_.empty()) {
+    return std::nullopt;
+  }
+  return rclcpp::Time(odom_buffer_.rbegin()->first);
+}
+
+std::optional<nav_msgs::msg::Odometry> Odometry::interpolateOdometry(const rclcpp::Time & time) const
+{
+  if (odom_buffer_.empty()) {
+    return std::nullopt;
+  }
+
+  // exact / bracketing lookup
+  const auto upper = odom_buffer_.lower_bound(time);  // first sample with stamp >= time
+
+  if (upper == odom_buffer_.end()) {
+    // time is newer than the newest sample: bounded forward extrapolation
+    const auto & last = odom_buffer_.rbegin()->second;
+    const double dt = toSeconds(time - odom_buffer_.rbegin()->first);
+    if (dt > kMaxExtrapolation) {
+      return std::nullopt;
+    }
+    return extrapolateOdometry(last, dt, time);
+  }
+
+  if (rclcpp::Time(upper->first) == time) {
+    return upper->second;  // exact hit
+  }
+
+  if (upper == odom_buffer_.begin()) {
+    // time is older than the oldest sample: bounded backward extrapolation
+    const double dt = toSeconds(time - upper->first);  // negative
+    if (-dt > kMaxExtrapolation) {
+      return std::nullopt;
+    }
+    return extrapolateOdometry(upper->second, dt, time);
+  }
+
+  // interpolate between the bracketing samples
+  const auto lower = std::prev(upper);
+  const rclcpp::Time t0 = lower->first;
+  const rclcpp::Time t1 = upper->first;
+  const double span = toSeconds(t1 - t0);
+  const double ratio = span > 0.0 ? toSeconds(time - t0) / span : 0.0;
+  return lerpOdometry(lower->second, upper->second, ratio, time);
+}
+
+std::optional<geometry_msgs::msg::Transform> Odometry::getEgoTransformFromOdometry(
+  const rclcpp::Time & time) const
+{
+  const auto odometry = interpolateOdometry(time);
+  if (!odometry) {
+    return std::nullopt;
+  }
+  geometry_msgs::msg::Transform transform;
+  transform.translation.x = odometry->pose.pose.position.x;
+  transform.translation.y = odometry->pose.pose.position.y;
+  transform.translation.z = odometry->pose.pose.position.z;
+  transform.rotation = odometry->pose.pose.orientation;
+  return transform;
 }
 
 void Odometry::updateTfCache(
@@ -57,19 +256,58 @@ void Odometry::updateTfCache(
 
 std::optional<geometry_msgs::msg::Transform> Odometry::getTransform(const rclcpp::Time & time) const
 {
-  // check buffer and return if the transform is found
+  // odometry backend: interpolate (or bounded-extrapolate) world <- ego at the addressed time
+  if (ego_source_ == EgoSource::ODOMETRY) {
+    const auto ego_tf = getEgoTransformFromOdometry(time);
+    if (ego_tf) {
+      return ego_tf;
+    }
+    RCLCPP_WARN_THROTTLE(
+      logger_, *clock_, 2000, "Odometry buffer miss at %.9f, falling back to TF.", time.seconds());
+  }
+
+  // TF backend (and fallback): check cache then look up the transform from tf
   for (const auto & tf : tf_cache_) {
     if (tf.first == time) {
       return std::optional<geometry_msgs::msg::Transform>(tf.second);
     }
   }
-  // if not found, get the transform from tf
   return getTransform(ego_frame_id_, time);
 }
 
 std::optional<geometry_msgs::msg::Transform> Odometry::getTransform(
   const std::string & source_frame_id, const rclcpp::Time & time) const
 {
+  // odometry backend: world <- source = world <- ego(t) [odom] * ego <- source [static TF]
+  if (ego_source_ == EgoSource::ODOMETRY) {
+    const auto world_to_ego = getEgoTransformFromOdometry(time);
+    if (world_to_ego) {
+      if (source_frame_id == ego_frame_id_) {
+        return world_to_ego;
+      }
+      try {
+        std::string errstr;
+        if (tf_buffer_->canTransform(
+              ego_frame_id_, source_frame_id, tf2::TimePointZero, tf2::Duration::zero(), &errstr)) {
+          const auto ego_to_source = tf_buffer_->lookupTransform(
+            ego_frame_id_, source_frame_id, tf2::TimePointZero);
+          tf2::Transform tf_world_to_ego;
+          tf2::Transform tf_ego_to_source;
+          tf2::fromMsg(*world_to_ego, tf_world_to_ego);
+          tf2::fromMsg(ego_to_source.transform, tf_ego_to_source);
+          geometry_msgs::msg::Transform composed;
+          tf2::toMsg(tf_world_to_ego * tf_ego_to_source, composed);
+          return composed;
+        }
+      } catch (tf2::TransformException & ex) {
+        RCLCPP_WARN_STREAM(logger_, ex.what());
+      }
+    }
+    RCLCPP_WARN_THROTTLE(
+      logger_, *clock_, 2000, "Odometry-based transform unavailable for '%s', falling back to TF.",
+      source_frame_id.c_str());
+  }
+
   try {
     // Check if the frames are ready
     std::string errstr;  // This argument prevents error msg from being displayed in the terminal.
@@ -97,6 +335,15 @@ std::optional<geometry_msgs::msg::Transform> Odometry::getTransform(
 
 std::optional<nav_msgs::msg::Odometry> Odometry::getOdometryFromTf(const rclcpp::Time & time) const
 {
+  // odometry backend: return the real interpolated odometry (with real twist & covariance)
+  if (ego_source_ == EgoSource::ODOMETRY) {
+    if (const auto odometry = interpolateOdometry(time)) {
+      return odometry;
+    }
+    RCLCPP_WARN_THROTTLE(
+      logger_, *clock_, 2000, "Odometry buffer miss at %.9f, fabricating from TF.", time.seconds());
+  }
+
   const auto self_transform = getTransform(time);
   if (!self_transform) {
     return std::nullopt;

--- a/perception/autoware_multi_object_tracker/schema/multi_object_tracker_node.schema.json
+++ b/perception/autoware_multi_object_tracker/schema/multi_object_tracker_node.schema.json
@@ -162,8 +162,8 @@
         },
         "delay_compensation": {
           "type": "string",
-          "enum": ["detection", "now", "latest_odometry"],
-          "description": "Object-export reference time the published tracks are predicted to (independent of publish_on_timer). 'detection' uses the latest detection/update stamp (no forward compensation); 'now' extrapolates to the current time; 'latest_odometry' extrapolates to the newest buffered odometry stamp.",
+          "enum": ["detection", "elapsed", "latest_odometry", "now"],
+          "description": "Object-export reference time the published tracks are predicted to (independent of publish_on_timer), ordered from least to most forward compensation. 'detection' uses the latest detection/update stamp (no forward compensation); 'elapsed' advances the detection stamp by the wall-clock time elapsed since the last tracker update (compensates publish-side latency without over-extrapolating the sensor pipeline delay); 'latest_odometry' extrapolates to the newest buffered odometry stamp; 'now' extrapolates to the current time.",
           "default": "detection"
         },
         "tracker_configs": {

--- a/perception/autoware_multi_object_tracker/schema/multi_object_tracker_node.schema.json
+++ b/perception/autoware_multi_object_tracker/schema/multi_object_tracker_node.schema.json
@@ -162,9 +162,9 @@
         },
         "delay_compensation": {
           "type": "string",
-          "enum": ["detection", "elapsed", "latest_odometry", "now"],
-          "description": "Object-export reference time the published tracks are predicted to (independent of publish_on_timer), ordered from least to most forward compensation. 'detection' uses the latest detection/update stamp (no forward compensation); 'elapsed' advances the detection stamp by the wall-clock time elapsed since the last tracker update (compensates publish-side latency without over-extrapolating the sensor pipeline delay); 'latest_odometry' extrapolates to the newest buffered odometry stamp; 'now' extrapolates to the current time.",
-          "default": "detection"
+          "enum": ["none", "publish_delay", "odometry", "full"],
+          "description": "Object-export delay compensation applied to the published tracks (independent of publish_on_timer), ordered from least to most. 'none': no compensation, use the latest detection/update stamp; 'publish_delay': advance the detection stamp by the update->publish delay; 'odometry': compensate up to the newest buffered odometry stamp; 'full': full compensation to the current time.",
+          "default": "none"
         },
         "tracker_configs": {
           "$ref": "#/definitions/tracker_configs"

--- a/perception/autoware_multi_object_tracker/schema/multi_object_tracker_node.schema.json
+++ b/perception/autoware_multi_object_tracker/schema/multi_object_tracker_node.schema.json
@@ -155,10 +155,15 @@
           "description": "Backend used to obtain the time-varying ego pose: 'tf' looks it up from the TF tree (legacy), 'odometry' interpolates it from the subscribed ~/input/odometry buffer (TF fallback on miss).",
           "default": "tf"
         },
+        "publish_on_timer": {
+          "type": "boolean",
+          "description": "Publish trigger, independent of delay_compensation. false publishes tracks on measurement; true publishes them from the periodic timer at publish_rate.",
+          "default": false
+        },
         "delay_compensation": {
           "type": "string",
           "enum": ["detection", "now", "latest_odometry"],
-          "description": "Object-export reference time the published tracks are predicted to. 'detection' publishes on measurement with no timer (no compensation); 'now' uses a publish timer to extrapolate to the current time; 'latest_odometry' extrapolates to the newest buffered odometry stamp.",
+          "description": "Object-export reference time the published tracks are predicted to (independent of publish_on_timer). 'detection' uses the latest detection/update stamp (no forward compensation); 'now' extrapolates to the current time; 'latest_odometry' extrapolates to the newest buffered odometry stamp.",
           "default": "detection"
         },
         "tracker_configs": {
@@ -243,6 +248,7 @@
         "ego_frame_id",
         "consider_odometry_uncertainty",
         "ego_source",
+        "publish_on_timer",
         "delay_compensation",
         "tracker_configs",
         "min_known_object_removal_iou",

--- a/perception/autoware_multi_object_tracker/schema/multi_object_tracker_node.schema.json
+++ b/perception/autoware_multi_object_tracker/schema/multi_object_tracker_node.schema.json
@@ -144,15 +144,22 @@
           "description": "Vehicle's ego frame.",
           "default": "base_link"
         },
-        "enable_delay_compensation": {
-          "type": "boolean",
-          "description": "If True, tracker uses timers to schedule publishers and uses prediction step to extrapolate object state at desired timestamp.",
-          "default": false
-        },
         "consider_odometry_uncertainty": {
           "type": "boolean",
           "description": "If True, consider odometry uncertainty in tracking.",
           "default": false
+        },
+        "ego_source": {
+          "type": "string",
+          "enum": ["tf", "odometry"],
+          "description": "Backend used to obtain the time-varying ego pose: 'tf' looks it up from the TF tree (legacy), 'odometry' interpolates it from the subscribed ~/input/odometry buffer (TF fallback on miss).",
+          "default": "tf"
+        },
+        "delay_compensation": {
+          "type": "string",
+          "enum": ["detection", "now", "latest_odometry"],
+          "description": "Object-export reference time the published tracks are predicted to. 'detection' publishes on measurement with no timer (no compensation); 'now' uses a publish timer to extrapolate to the current time; 'latest_odometry' extrapolates to the newest buffered odometry stamp.",
+          "default": "detection"
         },
         "tracker_configs": {
           "$ref": "#/definitions/tracker_configs"
@@ -234,8 +241,9 @@
         "publish_rate",
         "world_frame_id",
         "ego_frame_id",
-        "enable_delay_compensation",
         "consider_odometry_uncertainty",
+        "ego_source",
+        "delay_compensation",
         "tracker_configs",
         "min_known_object_removal_iou",
         "min_unknown_object_removal_iou",

--- a/perception/autoware_multi_object_tracker/src/multi_object_tracker_core.cpp
+++ b/perception/autoware_multi_object_tracker/src/multi_object_tracker_core.cpp
@@ -294,11 +294,20 @@ PublishingData prepare_publishing_data(
     case DelayReference::DETECTION:
       result.object_time = last_tracker_time;
       break;
-    case DelayReference::NOW:
-      result.object_time = current_time;
+    case DelayReference::ELAPSED: {
+      // Advance the detection stamp by the wall-clock time elapsed since the last tracker update.
+      // This compensates for the publish-side latency without over-extrapolating by the
+      // sensor->tracker pipeline delay (as 'now' would).
+      const auto elapsed = current_time - state.last_updated_time;
+      result.object_time =
+        last_tracker_time + (elapsed.seconds() > 0.0 ? elapsed : rclcpp::Duration(0, 0));
       break;
+    }
     case DelayReference::LATEST_ODOMETRY:
       result.object_time = state.odometry->getLatestOdometryTime().value_or(current_time);
+      break;
+    case DelayReference::NOW:
+      result.object_time = current_time;
       break;
   }
 

--- a/perception/autoware_multi_object_tracker/src/multi_object_tracker_core.cpp
+++ b/perception/autoware_multi_object_tracker/src/multi_object_tracker_core.cpp
@@ -305,6 +305,7 @@ PublishingData prepare_publishing_data(
     }
     case DelayReference::ODOMETRY:
       result.object_time = state.odometry->getLatestEgoPoseTime().value_or(current_time);
+      // If no odometry is available, fall back to the current time.
       break;
     case DelayReference::FULL:
       result.object_time = current_time;

--- a/perception/autoware_multi_object_tracker/src/multi_object_tracker_core.cpp
+++ b/perception/autoware_multi_object_tracker/src/multi_object_tracker_core.cpp
@@ -304,7 +304,7 @@ PublishingData prepare_publishing_data(
       break;
     }
     case DelayReference::ODOMETRY:
-      result.object_time = state.odometry->getLatestOdometryTime().value_or(current_time);
+      result.object_time = state.odometry->getLatestEgoPoseTime().value_or(current_time);
       break;
     case DelayReference::FULL:
       result.object_time = current_time;

--- a/perception/autoware_multi_object_tracker/src/multi_object_tracker_core.cpp
+++ b/perception/autoware_multi_object_tracker/src/multi_object_tracker_core.cpp
@@ -291,22 +291,22 @@ PublishingData prepare_publishing_data(
 
   // Calculate object_time based on the export-time reference
   switch (params.delay_compensation) {
-    case DelayReference::DETECTION:
+    case DelayReference::NONE:
       result.object_time = last_tracker_time;
       break;
-    case DelayReference::ELAPSED: {
-      // Advance the detection stamp by the wall-clock time elapsed since the last tracker update.
-      // This compensates for the publish-side latency without over-extrapolating by the
-      // sensor->tracker pipeline delay (as 'now' would).
+    case DelayReference::PUBLISH_DELAY: {
+      // Advance the detection stamp by the update->publish delay (wall-clock elapsed since the last
+      // tracker update). Compensates the publish-side latency without over-extrapolating by the
+      // sensor->tracker pipeline delay (as FULL would).
       const auto elapsed = current_time - state.last_updated_time;
       result.object_time =
         last_tracker_time + (elapsed.seconds() > 0.0 ? elapsed : rclcpp::Duration(0, 0));
       break;
     }
-    case DelayReference::LATEST_ODOMETRY:
+    case DelayReference::ODOMETRY:
       result.object_time = state.odometry->getLatestOdometryTime().value_or(current_time);
       break;
-    case DelayReference::NOW:
+    case DelayReference::FULL:
       result.object_time = current_time;
       break;
   }

--- a/perception/autoware_multi_object_tracker/src/multi_object_tracker_core.cpp
+++ b/perception/autoware_multi_object_tracker/src/multi_object_tracker_core.cpp
@@ -274,8 +274,9 @@ ObjectProcessingResult process_objects_batch(
   // process end - end measurement time after processing
   debugger.endMeasurementTime(current_time);
 
-  // Publish immediately when exporting at the detection time; otherwise the timer drives publishing
-  result.should_publish = (params.delay_compensation == DelayReference::DETECTION);
+  // Publish immediately when the timer is disabled; otherwise the periodic timer drives publishing.
+  // This is independent of delay_compensation, which only selects the export reference time.
+  result.should_publish = !params.publish_on_timer;
 
   return result;
 }

--- a/perception/autoware_multi_object_tracker/src/multi_object_tracker_core.cpp
+++ b/perception/autoware_multi_object_tracker/src/multi_object_tracker_core.cpp
@@ -40,7 +40,7 @@ void MultiObjectTrackerInternalState::init(
   auto tf_buffer = std::make_shared<autoware::agnocast_wrapper::Buffer>(node.get_clock());
   odometry = std::make_shared<Odometry>(
     node.get_logger(), node.get_clock(), tf_buffer, params.world_frame_id, params.ego_frame_id,
-    params.enable_odometry_uncertainty);
+    params.enable_odometry_uncertainty, params.ego_source);
 
   // Initialize input manager
   input_manager = std::make_unique<InputManager>(odometry, node.get_logger(), node.get_clock());
@@ -274,8 +274,8 @@ ObjectProcessingResult process_objects_batch(
   // process end - end measurement time after processing
   debugger.endMeasurementTime(current_time);
 
-  // Publish immediately if delay compensation is disabled
-  result.should_publish = !params.enable_delay_compensation;
+  // Publish immediately when exporting at the detection time; otherwise the timer drives publishing
+  result.should_publish = (params.delay_compensation == DelayReference::DETECTION);
 
   return result;
 }
@@ -288,8 +288,18 @@ PublishingData prepare_publishing_data(
 
   const auto & last_tracker_time = state.last_tracker_time;
 
-  // Calculate object_time based on delay compensation setting
-  result.object_time = params.enable_delay_compensation ? current_time : last_tracker_time;
+  // Calculate object_time based on the export-time reference
+  switch (params.delay_compensation) {
+    case DelayReference::DETECTION:
+      result.object_time = last_tracker_time;
+      break;
+    case DelayReference::NOW:
+      result.object_time = current_time;
+      break;
+    case DelayReference::LATEST_ODOMETRY:
+      result.object_time = state.odometry->getLatestOdometryTime().value_or(current_time);
+      break;
+  }
 
   /// Tracker pruning
   state.processor->prune(last_tracker_time);

--- a/perception/autoware_multi_object_tracker/src/multi_object_tracker_core.hpp
+++ b/perception/autoware_multi_object_tracker/src/multi_object_tracker_core.hpp
@@ -47,10 +47,14 @@ struct MultiObjectTrackerParameters
   double publish_rate;
   std::string world_frame_id;
   std::string ego_frame_id;
-  bool enable_delay_compensation;
   bool enable_odometry_uncertainty;
   bool publish_processing_time_detail;
   bool publish_merged_objects;
+
+  // ego pose sourcing
+  EgoSource ego_source;
+  // object-export side: which timestamp the published tracks are predicted to
+  DelayReference delay_compensation;
 
   std::vector<types::InputChannel> input_channels_config;
 

--- a/perception/autoware_multi_object_tracker/src/multi_object_tracker_core.hpp
+++ b/perception/autoware_multi_object_tracker/src/multi_object_tracker_core.hpp
@@ -53,6 +53,8 @@ struct MultiObjectTrackerParameters
 
   // ego pose sourcing
   EgoSource ego_source;
+  // publish-trigger side: false publishes on measurement, true publishes from the periodic timer
+  bool publish_on_timer;
   // object-export side: which timestamp the published tracks are predicted to
   DelayReference delay_compensation;
 

--- a/perception/autoware_multi_object_tracker/src/multi_object_tracker_node.cpp
+++ b/perception/autoware_multi_object_tracker/src/multi_object_tracker_node.cpp
@@ -61,6 +61,8 @@ MultiObjectTracker::MultiObjectTracker(const rclcpp::NodeOptions & node_options)
   params_.ego_frame_id = declare_parameter<std::string>("ego_frame_id");
   params_.enable_odometry_uncertainty = declare_parameter<bool>("consider_odometry_uncertainty");
   params_.ego_source = toEgoSource(declare_parameter<std::string>("ego_source"));
+  // publish-trigger side: false publishes on measurement, true publishes from the periodic timer
+  params_.publish_on_timer = declare_parameter<bool>("publish_on_timer");
   // object-export side: which timestamp the published tracks are predicted to
   params_.delay_compensation =
     toDelayReference(declare_parameter<std::string>("delay_compensation"));
@@ -295,8 +297,9 @@ MultiObjectTracker::MultiObjectTracker(const rclcpp::NodeOptions & node_options)
   }
 
   ////// callback timer
-  // detection reference publishes on measurement; now / latest_odometry use the publish timer
-  if (params_.delay_compensation != DelayReference::DETECTION) {
+  // The publish timer is an independent trigger: when disabled, tracks are published on measurement;
+  // when enabled, the timer drives publishing. The export reference (delay_compensation) is orthogonal.
+  if (params_.publish_on_timer) {
     constexpr double timer_multiplier = 10.0;  // 10 times frequent for publish timing check
     const auto timer_period = rclcpp::Rate(params_.publish_rate * timer_multiplier).period();
     publish_timer_ = autoware::agnocast_wrapper::create_timer(

--- a/perception/autoware_multi_object_tracker/src/multi_object_tracker_node.cpp
+++ b/perception/autoware_multi_object_tracker/src/multi_object_tracker_node.cpp
@@ -297,8 +297,9 @@ MultiObjectTracker::MultiObjectTracker(const rclcpp::NodeOptions & node_options)
   }
 
   ////// callback timer
-  // The publish timer is an independent trigger: when disabled, tracks are published on measurement;
-  // when enabled, the timer drives publishing. The export reference (delay_compensation) is orthogonal.
+  // The publish timer is an independent trigger: when disabled, tracks are published on
+  // measurement; when enabled, the timer drives publishing. The export reference
+  // (delay_compensation) is orthogonal.
   if (params_.publish_on_timer) {
     constexpr double timer_multiplier = 10.0;  // 10 times frequent for publish timing check
     const auto timer_period = rclcpp::Rate(params_.publish_rate * timer_multiplier).period();

--- a/perception/autoware_multi_object_tracker/src/multi_object_tracker_node.cpp
+++ b/perception/autoware_multi_object_tracker/src/multi_object_tracker_node.cpp
@@ -59,8 +59,11 @@ MultiObjectTracker::MultiObjectTracker(const rclcpp::NodeOptions & node_options)
   params_.publish_rate = declare_parameter<double>("publish_rate");  // [hz]
   params_.world_frame_id = declare_parameter<std::string>("world_frame_id");
   params_.ego_frame_id = declare_parameter<std::string>("ego_frame_id");
-  params_.enable_delay_compensation = declare_parameter<bool>("enable_delay_compensation");
   params_.enable_odometry_uncertainty = declare_parameter<bool>("consider_odometry_uncertainty");
+  params_.ego_source = toEgoSource(declare_parameter<std::string>("ego_source"));
+  // object-export side: which timestamp the published tracks are predicted to
+  params_.delay_compensation =
+    toDelayReference(declare_parameter<std::string>("delay_compensation"));
   params_.publish_processing_time_detail =
     declare_parameter<bool>("publish_processing_time_detail");
   params_.publish_merged_objects = declare_parameter<bool>("publish_merged_objects");
@@ -273,6 +276,15 @@ MultiObjectTracker::MultiObjectTracker(const rclcpp::NodeOptions & node_options)
                   msg) { this->onMeasurement(index, std::move(msg)); });
   }
 
+  // odometry subscription (ego pose source when ego_source == "odometry")
+  if (params_.ego_source == EgoSource::ODOMETRY) {
+    sub_odometry_ = create_subscription<nav_msgs::msg::Odometry>(
+      "~/input/odometry", rclcpp::QoS{10},
+      [this](AUTOWARE_MESSAGE_CONST_SHARED_PTR(nav_msgs::msg::Odometry) msg) {
+        state_.odometry->updateOdometryBuffer(*msg);
+      });
+  }
+
   // publishers
   tracked_objects_pub_ = create_publisher<autoware_perception_msgs::msg::TrackedObjects>(
     "~/output/objects", rclcpp::QoS{1});
@@ -283,7 +295,8 @@ MultiObjectTracker::MultiObjectTracker(const rclcpp::NodeOptions & node_options)
   }
 
   ////// callback timer
-  if (params_.enable_delay_compensation) {
+  // detection reference publishes on measurement; now / latest_odometry use the publish timer
+  if (params_.delay_compensation != DelayReference::DETECTION) {
     constexpr double timer_multiplier = 10.0;  // 10 times frequent for publish timing check
     const auto timer_period = rclcpp::Rate(params_.publish_rate * timer_multiplier).period();
     publish_timer_ = autoware::agnocast_wrapper::create_timer(

--- a/perception/autoware_multi_object_tracker/src/multi_object_tracker_node.hpp
+++ b/perception/autoware_multi_object_tracker/src/multi_object_tracker_node.hpp
@@ -27,6 +27,8 @@
 #include "autoware_perception_msgs/msg/detected_objects.hpp"
 #include "autoware_perception_msgs/msg/tracked_objects.hpp"
 
+#include <nav_msgs/msg/odometry.hpp>
+
 #include <memory>
 #include <vector>
 
@@ -42,6 +44,7 @@ private:
   // ROS interface
   std::vector<AUTOWARE_SUBSCRIPTION_PTR(autoware_perception_msgs::msg::DetectedObjects)>
     sub_objects_array_{};
+  AUTOWARE_SUBSCRIPTION_PTR(nav_msgs::msg::Odometry) sub_odometry_{};
 
   AUTOWARE_PUBLISHER_PTR(autoware_perception_msgs::msg::TrackedObjects) tracked_objects_pub_;
   AUTOWARE_PUBLISHER_PTR(autoware_perception_msgs::msg::DetectedObjects) merged_objects_pub_;

--- a/perception/autoware_multi_object_tracker/src/multi_object_tracker_node.hpp
+++ b/perception/autoware_multi_object_tracker/src/multi_object_tracker_node.hpp
@@ -26,7 +26,6 @@
 
 #include "autoware_perception_msgs/msg/detected_objects.hpp"
 #include "autoware_perception_msgs/msg/tracked_objects.hpp"
-
 #include <nav_msgs/msg/odometry.hpp>
 
 #include <memory>
@@ -44,7 +43,7 @@ private:
   // ROS interface
   std::vector<AUTOWARE_SUBSCRIPTION_PTR(autoware_perception_msgs::msg::DetectedObjects)>
     sub_objects_array_{};
-  AUTOWARE_SUBSCRIPTION_PTR(nav_msgs::msg::Odometry) sub_odometry_{};
+  AUTOWARE_SUBSCRIPTION_PTR(nav_msgs::msg::Odometry) sub_odometry_ {};
 
   AUTOWARE_PUBLISHER_PTR(autoware_perception_msgs::msg::TrackedObjects) tracked_objects_pub_;
   AUTOWARE_PUBLISHER_PTR(autoware_perception_msgs::msg::DetectedObjects) merged_objects_pub_;


### PR DESCRIPTION
## Description

Optimizes the `multi_object_tracker` publishing/execution path so tracked objects can be exported in a form better suited to the diffusion planner (low-latency, ego-consistent output). The change decouples two concerns that were previously fused into the single `enable_delay_compensation` flag and adds an odometry-based ego-pose backend.

**1. Split the publish trigger from the export-time reference**

The old `enable_delay_compensation` bool controlled *both* the publish trigger (timer vs. on-measurement) *and* the export timestamp (extrapolate to now vs. last detection). These are now two orthogonal parameters:

- `publish_on_timer` (bool): publish trigger only. `false` publishes on measurement (default), `true` publishes from the periodic timer at `publish_rate`.
- `delay_compensation` (enum): which timestamp the published tracks are predicted to, ordered least → most aggressive:
  - `none` — latest detection/update stamp (no compensation)
  - `publish_delay` — detection stamp advanced by the update→publish delay (compensates publish-side latency without over-extrapolating the sensor→tracker pipeline delay)
  - `odometry` — compensate up to the newest buffered odometry stamp
  - `full` — full compensation to the current wall-clock time (old `enable_delay_compensation: true` behavior)

**2. Add an odometry-based ego-pose source**

New `ego_source` parameter selects the backend used to obtain the time-varying ego pose (world ← ego):

- `tf` — look it up from the TF tree (legacy behavior)
- `odometry` — interpolate it from a subscribed `~/input/odometry` buffer (default remapped to `/localization/kinematic_state`, the same source the diffusion planner consumes)

The odometry backend (`lib/odometry.cpp`):
- buffers odometry samples (≤ 2 s history, oldest evicted),
- interpolates pose at the requested time (linear position/twist/covariance, SLERP orientation),
- bounded constant-twist extrapolation (≤ 1 s) beyond buffer edges,
- composes `world ← source = world ← ego(t) [odom] * ego ← source [static TF]` for non-ego frames,
- **falls back to TF on any buffer miss** (throttled warning), so behavior degrades gracefully.

Supporting additions: `EgoSource`/`DelayReference` enums, strict `toEgoSource`/`toDelayReference` string parsers (throw on invalid value), `updateOdometryBuffer()` / `getLatestOdometryTime()`, and the `~/input/odometry` subscriber (only created when `ego_source == odometry`).

## Related links

**Parent Issue:**

- Link

## How was this PR tested?

- Built the package locally.
- No unit tests added yet for the odometry interpolation/extrapolation buffer or the parse helpers — to be added.

## Notes for reviewers

- `enable_delay_compensation` is **removed** and replaced by `publish_on_timer` + `delay_compensation`. Any external launch/config setting `enable_delay_compensation` must be migrated (`true` → `publish_on_timer: true` + `delay_compensation: full`).
- Heads-up on default-value consistency across the layers, please confirm intent:
  - `config/multi_object_tracker_node.param.yaml`: `ego_source: tf`, `delay_compensation: publish_delay`
  - `schema/...schema.json`: `ego_source` default `tf`, `delay_compensation` default `none`
  - `launch/multi_object_tracker.launch.xml`: `ego_source` arg default `odometry` (explicit `<param>` overrides the yaml, so the effective launch default is `odometry`)
  - `design/MultiObjectTracker.node.yaml`: `ego_source` default `odometry`

## Interface changes

### Subscribed topics

| Change type | Topic Type | Topic Name | Message Type | Description |
|:--|:--|:--|:--|:--|
| Added | Sub | `~/input/odometry` | `nav_msgs/msg/Odometry` | Ego pose source when `ego_source: odometry`. Default remap `/localization/kinematic_state`. |

### ROS Parameter Changes

#### Additions and removals

| Change type | Parameter Name | Type | Default Value | Description |
|:--|:--|:--|:--|:--|
| Removed | `enable_delay_compensation` | `bool` | `false` | Replaced by `publish_on_timer` + `delay_compensation`. |
| Added | `ego_source` | `string` | `tf` | Ego-pose backend: `tf` or `odometry`. |
| Added | `publish_on_timer` | `bool` | `false` | Publish trigger: measurement vs. periodic timer. |
| Added | `delay_compensation` | `string` | `none` | Export-time reference: `none` / `publish_delay` / `odometry` / `full`. |

## Effects on system behavior

- Default behavior with `delay_compensation: none` / `publish_on_timer: false` publishes on measurement at the detection stamp (no timer, no extrapolation), differing from the previous default which still published on measurement but without the new explicit reference selection.
- With `ego_source: odometry`, the ego pose is interpolated from `/localization/kinematic_state` instead of TF, with automatic TF fallback on buffer miss.
