### PR TITLE
feat(autoware_pointcloud_preprocessor): add ROS-runtime-free conversion utils

### DIFF
--- a/sensing/autoware_pointcloud_preprocessor/CMakeLists.txt
+++ b/sensing/autoware_pointcloud_preprocessor/CMakeLists.txt
@@ -320,6 +320,15 @@ if(BUILD_TESTING)
     test/test_utilities.cpp
   )
 
+  ament_add_gtest(test_conversion
+    test/test_conversion.cpp
+  )
+  ament_target_dependencies(test_conversion
+    builtin_interfaces
+    geometry_msgs
+    tf2
+  )
+
   ament_add_gtest(test_distortion_corrector_node
     test/test_distortion_corrector_node.cpp
   )

--- a/sensing/autoware_pointcloud_preprocessor/include/autoware/pointcloud_preprocessor/utility/conversion.hpp
+++ b/sensing/autoware_pointcloud_preprocessor/include/autoware/pointcloud_preprocessor/utility/conversion.hpp
@@ -1,0 +1,70 @@
+// Copyright 2024 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__POINTCLOUD_PREPROCESSOR__UTILITY__CONVERSION_HPP_
+#define AUTOWARE__POINTCLOUD_PREPROCESSOR__UTILITY__CONVERSION_HPP_
+
+#include <Eigen/Core>
+#include <Eigen/Geometry>
+#include <builtin_interfaces/msg/time.hpp>
+#include <tf2/LinearMath/Transform.hpp>
+
+#include <geometry_msgs/msg/transform.hpp>
+
+#include <cstdint>
+
+// ROS-message conversion helpers that depend only on message types and header-only math (no rclcpp,
+// no tf2_ros). They let downstream code keep header stamps and transforms without pulling in the
+// ROS runtime, so the consuming logic can stay ROS-runtime-free and deterministic.
+namespace autoware::pointcloud_preprocessor::utils
+{
+
+/// Convert a header stamp to an absolute time in integer nanoseconds (matches rclcpp::Time).
+inline int64_t to_nanoseconds(const builtin_interfaces::msg::Time & stamp)
+{
+  return static_cast<int64_t>(stamp.sec) * 1'000'000'000LL + stamp.nanosec;
+}
+
+/// Convert a header stamp to an absolute time in seconds (matches rclcpp::Time::seconds()).
+inline double to_seconds(const builtin_interfaces::msg::Time & stamp)
+{
+  return static_cast<double>(to_nanoseconds(stamp)) * 1e-9;
+}
+
+/// Convert a transform message to a tf2 transform (equivalent to tf2::fromMsg).
+inline tf2::Transform to_tf2_transform(const geometry_msgs::msg::Transform & transform)
+{
+  tf2::Transform out;
+  out.setOrigin(
+    tf2::Vector3(transform.translation.x, transform.translation.y, transform.translation.z));
+  out.setRotation(
+    tf2::Quaternion(
+      transform.rotation.x, transform.rotation.y, transform.rotation.z, transform.rotation.w));
+  return out;
+}
+
+/// Convert a transform message to a 4x4 homogeneous matrix (equivalent to tf2::transformToEigen).
+inline Eigen::Matrix4f to_eigen_matrix(const geometry_msgs::msg::Transform & transform)
+{
+  const Eigen::Isometry3d isometry =
+    Eigen::Translation3d(
+      transform.translation.x, transform.translation.y, transform.translation.z) *
+    Eigen::Quaterniond(
+      transform.rotation.w, transform.rotation.x, transform.rotation.y, transform.rotation.z);
+  return isometry.matrix().cast<float>();
+}
+
+}  // namespace autoware::pointcloud_preprocessor::utils
+
+#endif  // AUTOWARE__POINTCLOUD_PREPROCESSOR__UTILITY__CONVERSION_HPP_

--- a/sensing/autoware_pointcloud_preprocessor/include/autoware/pointcloud_preprocessor/utility/conversion.hpp
+++ b/sensing/autoware_pointcloud_preprocessor/include/autoware/pointcloud_preprocessor/utility/conversion.hpp
@@ -26,7 +26,7 @@
 
 // ROS-message conversion helpers that depend only on message types and header-only math (no rclcpp,
 // no tf2_ros). They let downstream code keep header stamps and transforms without pulling in the
-// ROS runtime, so the consuming logic can stay ROS-runtime-free and deterministic.
+// ROS runtime.
 namespace autoware::pointcloud_preprocessor::utils
 {
 

--- a/sensing/autoware_pointcloud_preprocessor/include/autoware/pointcloud_preprocessor/utility/conversion.hpp
+++ b/sensing/autoware_pointcloud_preprocessor/include/autoware/pointcloud_preprocessor/utility/conversion.hpp
@@ -1,4 +1,4 @@
-// Copyright 2024 TIER IV, Inc.
+// Copyright 2026 TIER IV, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -45,23 +45,25 @@ inline double to_seconds(const builtin_interfaces::msg::Time & stamp)
 /// Convert a transform message to a tf2 transform (equivalent to tf2::fromMsg).
 inline tf2::Transform to_tf2_transform(const geometry_msgs::msg::Transform & transform)
 {
+  const tf2::Vector3 origin(
+    transform.translation.x, transform.translation.y, transform.translation.z);
+  const tf2::Quaternion rotation(
+    transform.rotation.x, transform.rotation.y, transform.rotation.z, transform.rotation.w);
+
   tf2::Transform out;
-  out.setOrigin(
-    tf2::Vector3(transform.translation.x, transform.translation.y, transform.translation.z));
-  out.setRotation(
-    tf2::Quaternion(
-      transform.rotation.x, transform.rotation.y, transform.rotation.z, transform.rotation.w));
+  out.setOrigin(origin);
+  out.setRotation(rotation);
   return out;
 }
 
 /// Convert a transform message to a 4x4 homogeneous matrix (equivalent to tf2::transformToEigen).
 inline Eigen::Matrix4f to_eigen_matrix(const geometry_msgs::msg::Transform & transform)
 {
-  const Eigen::Isometry3d isometry =
-    Eigen::Translation3d(
-      transform.translation.x, transform.translation.y, transform.translation.z) *
-    Eigen::Quaterniond(
-      transform.rotation.w, transform.rotation.x, transform.rotation.y, transform.rotation.z);
+  const Eigen::Translation3d translation(
+    transform.translation.x, transform.translation.y, transform.translation.z);
+  const Eigen::Quaterniond rotation(
+    transform.rotation.w, transform.rotation.x, transform.rotation.y, transform.rotation.z);
+  const Eigen::Isometry3d isometry = translation * rotation;
   return isometry.matrix().cast<float>();
 }
 

--- a/sensing/autoware_pointcloud_preprocessor/package.xml
+++ b/sensing/autoware_pointcloud_preprocessor/package.xml
@@ -36,9 +36,11 @@
   <depend>autoware_sensing_msgs</depend>
   <depend>autoware_utils</depend>
   <depend>autoware_vehicle_msgs</depend>
+  <depend>builtin_interfaces</depend>
   <depend>cgal</depend>
   <depend>cv_bridge</depend>
   <depend>diagnostic_updater</depend>
+  <depend>geometry_msgs</depend>
   <depend>image_transport</depend>
   <depend>libopencv-dev</depend>
   <depend>libpcl-all-dev</depend>

--- a/sensing/autoware_pointcloud_preprocessor/test/test_conversion.cpp
+++ b/sensing/autoware_pointcloud_preprocessor/test/test_conversion.cpp
@@ -1,4 +1,4 @@
-// Copyright 2024 TIER IV, Inc.
+// Copyright 2026 TIER IV, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/sensing/autoware_pointcloud_preprocessor/test/test_conversion.cpp
+++ b/sensing/autoware_pointcloud_preprocessor/test/test_conversion.cpp
@@ -1,0 +1,94 @@
+// Copyright 2024 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/pointcloud_preprocessor/utility/conversion.hpp"
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+
+namespace
+{
+using autoware::pointcloud_preprocessor::utils::to_eigen_matrix;
+using autoware::pointcloud_preprocessor::utils::to_nanoseconds;
+using autoware::pointcloud_preprocessor::utils::to_seconds;
+using autoware::pointcloud_preprocessor::utils::to_tf2_transform;
+
+geometry_msgs::msg::Transform make_transform(
+  double tx, double ty, double tz, double qx, double qy, double qz, double qw)
+{
+  geometry_msgs::msg::Transform transform;
+  transform.translation.x = tx;
+  transform.translation.y = ty;
+  transform.translation.z = tz;
+  transform.rotation.x = qx;
+  transform.rotation.y = qy;
+  transform.rotation.z = qz;
+  transform.rotation.w = qw;
+  return transform;
+}
+}  // namespace
+
+TEST(ConversionTest, ToNanoseconds)
+{
+  builtin_interfaces::msg::Time stamp;
+  stamp.sec = 10;
+  stamp.nanosec = 100000000;
+  EXPECT_EQ(to_nanoseconds(stamp), 10'100'000'000LL);
+
+  builtin_interfaces::msg::Time zero;
+  EXPECT_EQ(to_nanoseconds(zero), 0);
+}
+
+TEST(ConversionTest, ToSeconds)
+{
+  builtin_interfaces::msg::Time stamp;
+  stamp.sec = 10;
+  stamp.nanosec = 100000000;
+  EXPECT_NEAR(to_seconds(stamp), 10.1, 1e-9);
+}
+
+TEST(ConversionTest, ToTf2Transform)
+{
+  // Translation (1, 2, 3) and a +90 deg rotation about the z-axis.
+  const double s = std::sqrt(0.5);
+  const tf2::Transform tf = to_tf2_transform(make_transform(1.0, 2.0, 3.0, 0.0, 0.0, s, s));
+
+  EXPECT_NEAR(tf.getOrigin().x(), 1.0, 1e-9);
+  EXPECT_NEAR(tf.getOrigin().y(), 2.0, 1e-9);
+  EXPECT_NEAR(tf.getOrigin().z(), 3.0, 1e-9);
+
+  // The rotation alone maps the x-axis onto the y-axis.
+  const tf2::Vector3 rotated = tf.getBasis() * tf2::Vector3(1.0, 0.0, 0.0);
+  EXPECT_NEAR(rotated.x(), 0.0, 1e-6);
+  EXPECT_NEAR(rotated.y(), 1.0, 1e-6);
+  EXPECT_NEAR(rotated.z(), 0.0, 1e-6);
+}
+
+TEST(ConversionTest, ToEigenMatrix)
+{
+  // Translation (1, 2, 3) and a +90 deg rotation about the z-axis.
+  const double s = std::sqrt(0.5);
+  const Eigen::Matrix4f matrix = to_eigen_matrix(make_transform(1.0, 2.0, 3.0, 0.0, 0.0, s, s));
+
+  EXPECT_NEAR(matrix(0, 3), 1.0f, 1e-6f);
+  EXPECT_NEAR(matrix(1, 3), 2.0f, 1e-6f);
+  EXPECT_NEAR(matrix(2, 3), 3.0f, 1e-6f);
+
+  // (1, 0, 0) rotated by +90 deg about z is (0, 1, 0), then translated by (1, 2, 3) -> (1, 3, 3).
+  const Eigen::Vector4f transformed = matrix * Eigen::Vector4f(1.0f, 0.0f, 0.0f, 1.0f);
+  EXPECT_NEAR(transformed.x(), 1.0f, 1e-6f);
+  EXPECT_NEAR(transformed.y(), 3.0f, 1e-6f);
+  EXPECT_NEAR(transformed.z(), 3.0f, 1e-6f);
+}


### PR DESCRIPTION
## Description

Adds a small set of **ROS-runtime-free** conversion helpers (`utility/conversion.hpp`) that convert ROS message types to plain numeric / math representations **without depending on the ROS runtime** (no `rclcpp`, no `tf2_ros`):

- `to_nanoseconds` / `to_seconds` — header stamp (`builtin_interfaces/Time`) → absolute time. Integer-nanosecond form matches `rclcpp::Time`.
- `to_tf2_transform` — `geometry_msgs/Transform` → `tf2::Transform` (equivalent to `tf2::fromMsg`).
- `to_eigen_matrix` — `geometry_msgs/Transform` → 4×4 homogeneous matrix (equivalent to `tf2::transformToEigen`).

These exist because, in ROS 2 Humble, `tf2_geometry_msgs` / `tf2_eigen` (and `rclcpp::Time`) transitively pull in `rclcpp`. Reproducing the few conversions here on top of header-only `tf2::LinearMath` + `Eigen` lets downstream logic keep header stamps and transforms while staying ROS-runtime-free and deterministic — useful for offline/library use.

This PR serves as the **base of a stack**: the distortion-corrector librarification (#12795) builds on top of it and consumes these helpers.

## How was this PR tested?

New gtest `test/test_conversion.cpp` (4 cases) covers all four helpers against known values (stamp arithmetic, a translation + 90° rotation mapped through both the tf2 and Eigen paths). Built and run locally — all pass. pre-commit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
