### PR TITLE
chore(run-out): add master config fields used in autoware_launch

### DIFF
--- a/planning/motion_velocity_planner/autoware_motion_velocity_run_out_module/config/run_out.param.yaml
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_run_out_module/config/run_out.param.yaml
@@ -79,7 +79,13 @@
           preserved_distance: 2.0 # [m] when cutting a predicted path or ignoring an object, at least this much distance is preserved from the predicted paths
         BICYCLE:
           ignore_collisions:
+            polygon_types: ["NONE"]  # let the intersection module deal with collisions in the intersection
             lanelet_subtypes: ["crosswalk", "walkway"]
+          preserved_duration: 0.0  # [s] when cutting a predicted path or ignoring an object, at least this much duration is preserved from the predicted paths
+        MOTORCYCLE:
+          ignore_collisions:
+            polygon_types: ["NONE"] # let the intersection module deal with collisions in the intersection
+          preserved_duration: 0.0  # [s] when cutting a predicted path or ignoring an object, at least this much duration is preserved from the predicted paths
       debug:
         object_label: "PEDESTRIAN"  # debug markers specific to each object classification labels will only be published for this one
         enabled_markers:  # if true, the corresponding debug markers are published

--- a/planning/motion_velocity_planner/autoware_motion_velocity_run_out_module/schema/run_out.schema.json
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_run_out_module/schema/run_out.schema.json
@@ -234,6 +234,9 @@
             },
             "BICYCLE": {
               "$ref": "#/definitions/object_parameters"
+            },
+            "MOTORCYCLE": {
+              "$ref": "#/definitions/object_parameters"
             }
           },
           "required": ["target_labels", "DEFAULT"]


### PR DESCRIPTION
## Description

Add param fields that is present in autoware_launch side `run_out.param.yaml`  but not here.

https://github.com/autowarefoundation/autoware_launch/blob/main/autoware_launch/config/planning/scenario_planning/lane_driving/motion_planning/motion_velocity_planner/run_out.param.yaml#L79-L87

This is to support [sync-params workflow](https://github.com/autowarefoundation/autoware_launch/pull/1812) to automate autoware_launch compatibility maintenance.

While both `run_out.param.yaml` passes the schema check, sync-params work differently: it directly compares the fields of universe `run_out.param.yaml` as the upstream and launch `run_out.param.yaml` as the downstream, reports for missing or excessive params, and updates the downstream field unless it is explicitly marked as a `# {OVERRIDE}` comment marker.

So in order to correspond both param files, the upstream file should have (at least) all fields the downstream has, and the universe file now acts as a master file for downstream.

In principle it is ideal to explicitly state all default values at once, but as the first step let's start with the fields present in launch side.

## Related links

## How was this PR tested?

Not available (see below).

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None expected. `run_out.param.yaml` here in universe is only for demo, and the param file in autoware_launch will be used.
