### PR TITLE
feat(multi object tracker): ekf wheel-anchor updater, lateral anchor correction

### DIFF
--- a/perception/autoware_multi_object_tracker/CMakeLists.txt
+++ b/perception/autoware_multi_object_tracker/CMakeLists.txt
@@ -50,7 +50,8 @@ set(${PROJECT_NAME}_lib
   lib/association/mu_successive_shortest_path/mu_ssp.cpp
   lib/types.cpp
   lib/object_model/uuid.cpp
-  lib/object_model/shapes.cpp
+  lib/object_model/shapes_iou.cpp
+  lib/object_model/shapes_transform.cpp
   lib/tracker/motion_model/bicycle_motion_model.cpp
   # cspell: ignore ctrv
   lib/tracker/motion_model/ctrv_motion_model.cpp

--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/object_model/object_model.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/object_model/object_model.hpp
@@ -144,7 +144,7 @@ public:
 
         process_noise.acc_long = const_g * 0.35;
         process_noise.acc_lat = const_g * 0.15;
-        process_noise.yaw_rate_min = deg2rad(1.5);
+        process_noise.yaw_rate_min = deg2rad(0.5);
         process_noise.yaw_rate_max = deg2rad(18.0);
 
         process_limit.acc_long_max = const_g;
@@ -190,7 +190,7 @@ public:
 
         process_noise.acc_long = const_g * 0.35;
         process_noise.acc_lat = const_g * 0.15;
-        process_noise.yaw_rate_min = deg2rad(1.5);
+        process_noise.yaw_rate_min = deg2rad(0.5);
         process_noise.yaw_rate_max = deg2rad(18.0);
 
         process_limit.acc_long_max = const_g;
@@ -236,7 +236,7 @@ public:
 
         process_noise.acc_long = const_g * 0.35;
         process_noise.acc_lat = const_g * 0.15;
-        process_noise.yaw_rate_min = deg2rad(1.5);
+        process_noise.yaw_rate_min = deg2rad(0.5);
         process_noise.yaw_rate_max = deg2rad(18.0);
 
         process_limit.acc_long_max = const_g;

--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/object_model/shapes_iou.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/object_model/shapes_iou.hpp
@@ -1,4 +1,4 @@
-// Copyright 2024 TIER IV, Inc.
+// Copyright 2026 TIER IV, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/object_model/shapes_iou.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/object_model/shapes_iou.hpp
@@ -1,0 +1,49 @@
+// Copyright 2024 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__MULTI_OBJECT_TRACKER__OBJECT_MODEL__SHAPES_IOU_HPP_
+#define AUTOWARE__MULTI_OBJECT_TRACKER__OBJECT_MODEL__SHAPES_IOU_HPP_
+
+#include "autoware/multi_object_tracker/types.hpp"
+
+#include <utility>
+
+namespace autoware::multi_object_tracker
+{
+namespace shapes
+{
+
+double get1dIoU(
+  const types::DynamicObject & source_object, const types::DynamicObject & target_object);
+
+double get2dIoU(
+  const types::DynamicObject & source_object, const types::DynamicObject & target_object,
+  const double min_union_area = 0.01);
+
+double get2dGeneralizedIoU(
+  const types::DynamicObject & source_object, const types::DynamicObject & target_object);
+
+bool get2dPrecisionRecallGIoU(
+  const types::DynamicObject & source_object, const types::DynamicObject & target_object,
+  double & precision, double & recall, double & generalized_iou);
+
+std::pair<double, double> getObjectZRange(const types::DynamicObject & object);
+
+double get3dGeneralizedIoU(
+  const types::DynamicObject & source_object, const types::DynamicObject & target_object);
+
+}  // namespace shapes
+}  // namespace autoware::multi_object_tracker
+
+#endif  // AUTOWARE__MULTI_OBJECT_TRACKER__OBJECT_MODEL__SHAPES_IOU_HPP_

--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/object_model/shapes_transform.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/object_model/shapes_transform.hpp
@@ -1,4 +1,4 @@
-// Copyright 2024 TIER IV, Inc.
+// Copyright 2026 TIER IV, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/object_model/shapes_transform.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/object_model/shapes_transform.hpp
@@ -12,34 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef AUTOWARE__MULTI_OBJECT_TRACKER__OBJECT_MODEL__SHAPES_HPP_
-#define AUTOWARE__MULTI_OBJECT_TRACKER__OBJECT_MODEL__SHAPES_HPP_
+#ifndef AUTOWARE__MULTI_OBJECT_TRACKER__OBJECT_MODEL__SHAPES_TRANSFORM_HPP_
+#define AUTOWARE__MULTI_OBJECT_TRACKER__OBJECT_MODEL__SHAPES_TRANSFORM_HPP_
 
 #include "autoware/multi_object_tracker/types.hpp"
 
 #include <geometry_msgs/msg/point.hpp>
 
 #include <optional>
-#include <utility>
 
 namespace autoware::multi_object_tracker
 {
 namespace shapes
 {
-
-double get1dIoU(
-  const types::DynamicObject & source_object, const types::DynamicObject & target_object);
-
-double get2dIoU(
-  const types::DynamicObject & source_object, const types::DynamicObject & target_object,
-  const double min_union_area = 0.01);
-
-double get2dGeneralizedIoU(
-  const types::DynamicObject & source_object, const types::DynamicObject & target_object);
-
-bool get2dPrecisionRecallGIoU(
-  const types::DynamicObject & source_object, const types::DynamicObject & target_object,
-  double & precision, double & recall, double & generalized_iou);
 
 bool convertConvexHullToBoundingBox(
   const types::DynamicObject & input_object, types::DynamicObject & output_object,
@@ -47,11 +32,6 @@ bool convertConvexHullToBoundingBox(
 
 std::optional<types::DynamicObject> alignClusterToOrientation(
   const types::DynamicObject & cluster, double target_yaw);
-
-std::pair<double, double> getObjectZRange(const types::DynamicObject & object);
-
-double get3dGeneralizedIoU(
-  const types::DynamicObject & source_object, const types::DynamicObject & target_object);
 
 // Transform polygon footprint points from src_pose's local frame into dst_pose's local frame.
 // Equivalent to: p_dst = R_dst^T * (R_src * p_src + t_src - t_dst)
@@ -68,4 +48,4 @@ geometry_msgs::msg::Polygon unionFootprints(
 }  // namespace shapes
 }  // namespace autoware::multi_object_tracker
 
-#endif  // AUTOWARE__MULTI_OBJECT_TRACKER__OBJECT_MODEL__SHAPES_HPP_
+#endif  // AUTOWARE__MULTI_OBJECT_TRACKER__OBJECT_MODEL__SHAPES_TRANSFORM_HPP_

--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/motion_model/bicycle_motion_model.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/motion_model/bicycle_motion_model.hpp
@@ -106,6 +106,10 @@ public:
     const double & vel_long, const double & vel_lat, const std::array<double, 36> & twist_cov,
     const double & length);
 
+  // Rear/front wheel-anchor update. Only the observed axle is measured (the edge face center is
+  // mapped to that axle along the current heading); the opposite axle is NOT measured and is left
+  // to the EKF prior, responding through the state cross-covariance. This lets the body rotate in
+  // response to the observed end instead of being rigidly translated (which froze yaw).
   bool updateStatePoseRear(
     const double & xr, const double & yr, const std::array<double, 36> & pose_cov);
 

--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/motion_model/bicycle_motion_model.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/motion_model/bicycle_motion_model.hpp
@@ -106,13 +106,10 @@ public:
     const double & vel_long, const double & vel_lat, const std::array<double, 36> & twist_cov,
     const double & length);
 
-  // Front/rear wheel-anchor update. The observed edge FACE center (x, y) is measured directly as an
-  // exact linear function of the two-point state (face = (1 + gamma) * p_near - gamma * p_far,
-  // since the body-axis offset gamma * L * u_hat equals gamma * (p2 - p1)). The measurement
-  // constrains a blend of both endpoints, so the gain splits the correction between translation and
-  // rotation via the prior covariance, letting the body rotate about the observed end instead of
-  // being rigidly translated (which froze yaw). measure_front == true anchors on the front endpoint
-  // p2 (gamma_front); false anchors on the rear endpoint p1 (gamma_rear).
+  // Front/rear wheel-anchor update from the observed edge face center (x, y). Because the
+  // measurement constrains a blend of both endpoints, the gain lets the body rotate about the
+  // observed end rather than translating rigidly (which froze yaw). measure_front selects the
+  // front endpoint p2 (gamma_front) vs the rear endpoint p1 (gamma_rear).
   bool updateStatePoseWheel(
     const double & x, const double & y, const std::array<double, 36> & pose_cov,
     const bool measure_front);

--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/motion_model/bicycle_motion_model.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/motion_model/bicycle_motion_model.hpp
@@ -106,17 +106,16 @@ public:
     const double & vel_long, const double & vel_lat, const std::array<double, 36> & twist_cov,
     const double & length);
 
-  // Rear/front wheel-anchor update. The observed edge FACE center is measured directly as an exact
-  // linear function of the two-point state (face = (1 +/- gamma) * p_near -/+ gamma * p_far, since
-  // the body-axis offset gamma * L * u_hat equals gamma * (p2 - p1)). The measurement constrains a
-  // blend of both endpoints, so the gain splits the correction between translation and rotation via
-  // the prior covariance, letting the body rotate about the observed end instead of being rigidly
-  // translated (which froze yaw).
-  bool updateStatePoseRear(
-    const double & xr, const double & yr, const std::array<double, 36> & pose_cov);
-
-  bool updateStatePoseFront(
-    const double & xf, const double & yf, const std::array<double, 36> & pose_cov);
+  // Front/rear wheel-anchor update. The observed edge FACE center (x, y) is measured directly as an
+  // exact linear function of the two-point state (face = (1 + gamma) * p_near - gamma * p_far,
+  // since the body-axis offset gamma * L * u_hat equals gamma * (p2 - p1)). The measurement
+  // constrains a blend of both endpoints, so the gain splits the correction between translation and
+  // rotation via the prior covariance, letting the body rotate about the observed end instead of
+  // being rigidly translated (which froze yaw). measure_front == true anchors on the front endpoint
+  // p2 (gamma_front); false anchors on the rear endpoint p1 (gamma_rear).
+  bool updateStatePoseWheel(
+    const double & x, const double & y, const std::array<double, 36> & pose_cov,
+    const bool measure_front);
 
   enum class LengthUpdateAnchor { CENTER, FRONT, REAR };
   bool updateStateLength(

--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/motion_model/bicycle_motion_model.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/motion_model/bicycle_motion_model.hpp
@@ -40,7 +40,7 @@ private:
     double q_stddev_acc_lat = 1.47;          // [m/s^2] uncertain longitudinal acceleration, 0.15G
     double q_cov_acc_long = 11.8;            // [m/s^2] uncertain longitudinal acceleration, 0.35G
     double q_cov_acc_lat = 2.16;             // [m/s^2] uncertain lateral acceleration, 0.15G
-    double q_stddev_yaw_rate_min = 0.02618;  // [rad/s] uncertain yaw change rate, 1.5deg/s
+    double q_stddev_yaw_rate_min = 0.00873;  // [rad/s] uncertain yaw change rate, 0.5deg/s
     double q_stddev_yaw_rate_max = 0.2618;   // [rad/s] uncertain yaw change rate, 15deg/s
     double q_cov_slip_rate_min =
       2.7416e-5;  // [rad^2/s^2] uncertain slip angle change rate, 0.3 deg/s

--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/motion_model/bicycle_motion_model.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/motion_model/bicycle_motion_model.hpp
@@ -106,10 +106,12 @@ public:
     const double & vel_long, const double & vel_lat, const std::array<double, 36> & twist_cov,
     const double & length);
 
-  // Rear/front wheel-anchor update. Only the observed axle is measured (the edge face center is
-  // mapped to that axle along the current heading); the opposite axle is NOT measured and is left
-  // to the EKF prior, responding through the state cross-covariance. This lets the body rotate in
-  // response to the observed end instead of being rigidly translated (which froze yaw).
+  // Rear/front wheel-anchor update. The observed edge FACE center is measured directly as an exact
+  // linear function of the two-point state (face = (1 +/- gamma) * p_near -/+ gamma * p_far, since
+  // the body-axis offset gamma * L * u_hat equals gamma * (p2 - p1)). The measurement constrains a
+  // blend of both endpoints, so the gain splits the correction between translation and rotation via
+  // the prior covariance, letting the body rotate about the observed end instead of being rigidly
+  // translated (which froze yaw).
   bool updateStatePoseRear(
     const double & xr, const double & yr, const std::array<double, 36> & pose_cov);
 

--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/shape_model/shape_model_base.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/shape_model/shape_model_base.hpp
@@ -53,6 +53,7 @@ public:
 
   // --- read accessors (base fields) ---
   bool isFootprintValid() const { return footprint_valid_; }
+  double getWidth() const { return width_; }
 
   // --- write interface (sensible defaults; each model overrides what it needs) ---
 

--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/shape_model/shape_model_base.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/shape_model/shape_model_base.hpp
@@ -53,7 +53,6 @@ public:
 
   // --- read accessors (base fields) ---
   bool isFootprintValid() const { return footprint_valid_; }
-  double getWidth() const { return width_; }
 
   // --- write interface (sensible defaults; each model overrides what it needs) ---
 

--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/trackers/multiple_vehicle_tracker.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/trackers/multiple_vehicle_tracker.hpp
@@ -66,7 +66,6 @@ public:
     const types::InputChannel & channel_info) override;
   bool conditionedUpdate(
     const types::DynamicObject & measurement, const types::DynamicObject & prediction,
-    const autoware_perception_msgs::msg::Shape & tracker_shape,
     const rclcpp::Time & measurement_time, const types::InputChannel & channel_info) override;
   void setObjectShape(const autoware_perception_msgs::msg::Shape & shape) override;
   void mergeFootprintFrom(

--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/trackers/tracker_base.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/trackers/tracker_base.hpp
@@ -246,7 +246,6 @@ protected:
 
   virtual bool conditionedUpdate(
     const types::DynamicObject & measurement, const types::DynamicObject & prediction,
-    const autoware_perception_msgs::msg::Shape & tracker_shape,
     const rclcpp::Time & measurement_time, const types::InputChannel & channel_info);
 
   // Selects the update path for a given measurement.

--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/trackers/vehicle_tracker.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/trackers/vehicle_tracker.hpp
@@ -65,7 +65,6 @@ public:
 
   bool conditionedUpdate(
     const types::DynamicObject & measurement, const types::DynamicObject & prediction,
-    const autoware_perception_msgs::msg::Shape & tracker_shape,
     const rclcpp::Time & measurement_time, const types::InputChannel & channel_info) override;
 
   bool getTrackedObject(

--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/trackers/vehicle_tracker.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/trackers/vehicle_tracker.hpp
@@ -47,9 +47,11 @@ private:
   bool updateKinematics(
     const types::DynamicObject & object, const types::InputChannel & channel_info);
   // Wheel-anchor EKF update (front or rear) plus z/height updates.
-  // Also records the anchor in shape_update_anchor_.
+  // Also records the anchor in shape_update_anchor_. `prediction` supplies the tracked body center
+  // used by the lateral (over-/under-wide polygon) anchor correction.
   bool updateWheelKinematics(
-    const UpdateStrategy & strategy, const types::DynamicObject & measurement);
+    const UpdateStrategy & strategy, const types::DynamicObject & measurement,
+    const types::DynamicObject & prediction);
 
 public:
   VehicleTracker(

--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/update/vehicle_update_strategy.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/update/vehicle_update_strategy.hpp
@@ -44,12 +44,12 @@ types::DynamicObject createPseudoMeasurement(
 
 // Scalar lateral correction of the wheel-anchor from the tracker and polygon left/right edges.
 // tracker_left/right and polygon_left/right are signed body-frame lateral coordinates (positive =
-// left). The
-// per-side overhangs of the polygon beyond the tracker box give the slack (half the width excess)
-// and the edge-center offset that drive a soft dead-zone ("back-lash") correction: the anchor is
-// held near the tracker while contained in the polygon and follows an exposed corner once it
-// protrudes. Returns the lateral move and, via `var_lat`, the extra lateral variance from the
-// uncorrected residual.
+// left). Aligning the fixed-width tracker box to each polygon edge yields two candidate vehicle
+// centers; their segment is the lateral "dead-zone" (width |polygon_width - tracker_width|). The
+// corrected anchor is the tracker center projected into that dead-zone: held when inside (polygon
+// straddles or is straddled by the tracker), or snapped to the nearest edge-aligned center when a
+// polygon edge protrudes/recedes. Returns the lateral move and, via `var_lat`, the extra lateral
+// variance, which grows with the dead-zone size (std = half the dead-zone width).
 double correctWheelAnchorLateral(
   const double tracker_left, const double tracker_right, const double polygon_left,
   const double polygon_right, double & var_lat);

--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/update/vehicle_update_strategy.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/update/vehicle_update_strategy.hpp
@@ -42,13 +42,17 @@ types::DynamicObject createPseudoMeasurement(
   const types::DynamicObject & meas, const types::DynamicObject & prediction,
   const bool enlarge_covariance = false);
 
-// Scalar lateral correction of the wheel-anchor given explicit body-frame lateral edge positions.
-// tracker_L/R and polygon_L/R are signed lateral coordinates (positive = left).
-// Returns the lateral move and, via `var_lat`, the extra lateral variance from uncorrected
-// residuals.
+// Scalar lateral correction of the wheel-anchor from the tracker and polygon left/right edges.
+// tracker_left/right and polygon_left/right are signed body-frame lateral coordinates (positive =
+// left). The
+// per-side overhangs of the polygon beyond the tracker box give the slack (half the width excess)
+// and the edge-center offset that drive a soft dead-zone ("back-lash") correction: the anchor is
+// held near the tracker while contained in the polygon and follows an exposed corner once it
+// protrudes. Returns the lateral move and, via `var_lat`, the extra lateral variance from the
+// uncorrected residual.
 double correctWheelAnchorLateral(
-  const double tracker_L, const double tracker_R, const double polygon_L, const double polygon_R,
-  double & var_lat);
+  const double tracker_left, const double tracker_right, const double polygon_left,
+  const double polygon_right, double & var_lat);
 
 // Laterally corrects the anchor against `prediction` and folds the extra variance into `pose_cov`.
 geometry_msgs::msg::Point correctWheelAnchor(

--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/update/vehicle_update_strategy.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/update/vehicle_update_strategy.hpp
@@ -42,10 +42,11 @@ types::DynamicObject createPseudoMeasurement(
   const types::DynamicObject & meas, const types::DynamicObject & prediction,
   const bool enlarge_covariance = false);
 
-// Scalar lateral correction of the wheel-anchor. Returns the lateral move and, via `var_lat`, the
-// extra lateral variance to add when the polygon and tracked widths disagree.
+// Scalar lateral correction of the wheel-anchor given explicit body-frame lateral edge positions.
+// tracker_L/R and polygon_L/R are signed lateral coordinates (positive = left).
+// Returns the lateral move and, via `var_lat`, the extra lateral variance from uncorrected residuals.
 double correctWheelAnchorLateral(
-  const double lateral_offset, const double tracker_width, const double polygon_width,
+  const double tracker_L, const double tracker_R, const double polygon_L, const double polygon_R,
   double & var_lat);
 
 // Laterally corrects the anchor against `prediction` and folds the extra variance into `pose_cov`.

--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/update/vehicle_update_strategy.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/update/vehicle_update_strategy.hpp
@@ -17,6 +17,8 @@
 
 #include "autoware/multi_object_tracker/types.hpp"
 
+#include <array>
+
 namespace autoware::multi_object_tracker
 {
 
@@ -33,11 +35,11 @@ struct UpdateStrategy
 UpdateStrategy determineUpdateStrategy(
   const types::DynamicObject & measurement, const types::DynamicObject & prediction);
 
-// Blends measurement position/orientation into pred using a distance-weighted scheme.
-// When enlarge_covariance=true, inflates pose/velocity covariances for the weak-update path.
-void createPseudoMeasurement(
-  const types::DynamicObject & meas, types::DynamicObject & pred,
-  const autoware_perception_msgs::msg::Shape & tracker_shape,
+// Blends measurement position/orientation into a copy of prediction using a distance-weighted
+// scheme and returns it. When enlarge_covariance=true, inflates pose/velocity covariances for the
+// weak-update path.
+types::DynamicObject createPseudoMeasurement(
+  const types::DynamicObject & meas, const types::DynamicObject & prediction,
   const bool enlarge_covariance = false);
 
 // Result of the wheel-anchor lateral correction.
@@ -47,25 +49,20 @@ struct WheelAnchorLateral
   double var_lat;                    // extra variance to add along the body lateral axis [m^2]
 };
 
-// Corrects the wheel-anchor lateral position and reports extra lateral variance, accounting for the
-// mismatch between the observed polygon width and the tracked width. The wheel update measures the
-// observed front/rear edge CENTER, which is a biased lateral measurement when the widths differ:
-//   - polygon NARROWER (partial view): the center may sit anywhere within (w_t - w_p)/2 of the true
-//     center. The anchor is kept and the worst-case lateral offset is added as variance.
-//   - polygon WIDER (merged / over-segmented cluster): the edge center is pulled off the true body.
-//     A soft dead-zone ("back-lash") of half-width s = (w_p - w_t)/2 is applied to the lateral
-//     offset d between the observed edge center and the tracker center: the anchor is held near the
-//     tracker (slope `balance_alpha`) while the tracker stays contained (|d| <= s) and follows the
-//     exposed corner (unit slope) once |d| > s. The added lateral std scales continuously from s
-//     (centered, true position unknown across the slack) down to `corner_residual_beta` * s once
-//     the corner is matched.
-// `tracker_center` is the tracked body center (e.g. the prediction pose); `anchor` is the observed
-// edge center. The correction only moves the lateral component, leaving the longitudinal anchor
-// (and hence the length estimate) untouched.
+// Laterally corrects the wheel-anchor and reports extra lateral variance to handle the bias that
+// arises when the observed front/rear edge center is used as a lateral measurement but the polygon
+// and tracked widths disagree. Only the lateral component is affected.
 WheelAnchorLateral correctWheelAnchorLateral(
   double yaw, double tracker_width, const geometry_msgs::msg::Point & tracker_center,
   double polygon_width, const geometry_msgs::msg::Point & anchor, double balance_alpha,
   double corner_residual_beta);
+
+// Applies the wheel-anchor lateral correction (see correctWheelAnchorLateral) and folds the
+// resulting extra lateral variance into the x/y block of `pose_cov`. Returns the corrected anchor.
+geometry_msgs::msg::Point correctWheelAnchor(
+  double yaw, double tracker_width, const geometry_msgs::msg::Point & tracker_center,
+  double polygon_width, const geometry_msgs::msg::Point & anchor,
+  std::array<double, 36> & pose_cov);
 
 }  // namespace autoware::multi_object_tracker
 

--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/update/vehicle_update_strategy.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/update/vehicle_update_strategy.hpp
@@ -40,6 +40,33 @@ void createPseudoMeasurement(
   const autoware_perception_msgs::msg::Shape & tracker_shape,
   const bool enlarge_covariance = false);
 
+// Result of the wheel-anchor lateral correction.
+struct WheelAnchorLateral
+{
+  geometry_msgs::msg::Point anchor;  // laterally corrected anchor point
+  double var_lat;                    // extra variance to add along the body lateral axis [m^2]
+};
+
+// Corrects the wheel-anchor lateral position and reports extra lateral variance, accounting for the
+// mismatch between the observed polygon width and the tracked width. The wheel update measures the
+// observed front/rear edge CENTER, which is a biased lateral measurement when the widths differ:
+//   - polygon NARROWER (partial view): the center may sit anywhere within (w_t - w_p)/2 of the true
+//     center. The anchor is kept and the worst-case lateral offset is added as variance.
+//   - polygon WIDER (merged / over-segmented cluster): the edge center is pulled off the true body.
+//     A soft dead-zone ("back-lash") of half-width s = (w_p - w_t)/2 is applied to the lateral
+//     offset d between the observed edge center and the tracker center: the anchor is held near the
+//     tracker (slope `balance_alpha`) while the tracker stays contained (|d| <= s) and follows the
+//     exposed corner (unit slope) once |d| > s. The added lateral std scales continuously from s
+//     (centered, true position unknown across the slack) down to `corner_residual_beta` * s once
+//     the corner is matched.
+// `tracker_center` is the tracked body center (e.g. the prediction pose); `anchor` is the observed
+// edge center. The correction only moves the lateral component, leaving the longitudinal anchor
+// (and hence the length estimate) untouched.
+WheelAnchorLateral correctWheelAnchorLateral(
+  double yaw, double tracker_width, const geometry_msgs::msg::Point & tracker_center,
+  double polygon_width, const geometry_msgs::msg::Point & anchor, double balance_alpha,
+  double corner_residual_beta);
+
 }  // namespace autoware::multi_object_tracker
 
 #endif  // AUTOWARE__MULTI_OBJECT_TRACKER__TRACKER__UPDATE__VEHICLE_UPDATE_STRATEGY_HPP_

--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/update/vehicle_update_strategy.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/update/vehicle_update_strategy.hpp
@@ -44,7 +44,8 @@ types::DynamicObject createPseudoMeasurement(
 
 // Scalar lateral correction of the wheel-anchor given explicit body-frame lateral edge positions.
 // tracker_L/R and polygon_L/R are signed lateral coordinates (positive = left).
-// Returns the lateral move and, via `var_lat`, the extra lateral variance from uncorrected residuals.
+// Returns the lateral move and, via `var_lat`, the extra lateral variance from uncorrected
+// residuals.
 double correctWheelAnchorLateral(
   const double tracker_L, const double tracker_R, const double polygon_L, const double polygon_R,
   double & var_lat);

--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/update/vehicle_update_strategy.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/update/vehicle_update_strategy.hpp
@@ -42,27 +42,16 @@ types::DynamicObject createPseudoMeasurement(
   const types::DynamicObject & meas, const types::DynamicObject & prediction,
   const bool enlarge_covariance = false);
 
-// Result of the wheel-anchor lateral correction.
-struct WheelAnchorLateral
-{
-  geometry_msgs::msg::Point anchor;  // laterally corrected anchor point
-  double var_lat;                    // extra variance to add along the body lateral axis [m^2]
-};
+// Scalar lateral correction of the wheel-anchor. Returns the lateral move and, via `var_lat`, the
+// extra lateral variance to add when the polygon and tracked widths disagree.
+double correctWheelAnchorLateral(
+  const double lateral_offset, const double tracker_width, const double polygon_width,
+  double & var_lat);
 
-// Laterally corrects the wheel-anchor and reports extra lateral variance to handle the bias that
-// arises when the observed front/rear edge center is used as a lateral measurement but the polygon
-// and tracked widths disagree. Only the lateral component is affected.
-WheelAnchorLateral correctWheelAnchorLateral(
-  double yaw, double tracker_width, const geometry_msgs::msg::Point & tracker_center,
-  double polygon_width, const geometry_msgs::msg::Point & anchor, double balance_alpha,
-  double corner_residual_beta);
-
-// Applies the wheel-anchor lateral correction (see correctWheelAnchorLateral) and folds the
-// resulting extra lateral variance into the x/y block of `pose_cov`. Returns the corrected anchor.
+// Laterally corrects the anchor against `prediction` and folds the extra variance into `pose_cov`.
 geometry_msgs::msg::Point correctWheelAnchor(
-  double yaw, double tracker_width, const geometry_msgs::msg::Point & tracker_center,
-  double polygon_width, const geometry_msgs::msg::Point & anchor,
-  std::array<double, 36> & pose_cov);
+  const types::DynamicObject & prediction, const double polygon_width,
+  const geometry_msgs::msg::Point & anchor, std::array<double, 36> & pose_cov);
 
 }  // namespace autoware::multi_object_tracker
 

--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/update/vehicle_update_strategy.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/update/vehicle_update_strategy.hpp
@@ -42,17 +42,12 @@ types::DynamicObject createPseudoMeasurement(
   const types::DynamicObject & meas, const types::DynamicObject & prediction,
   const bool enlarge_covariance = false);
 
-// Scalar lateral correction of the wheel-anchor from the tracker and polygon left/right edges.
-// tracker_left/right and polygon_left/right are signed body-frame lateral coordinates (positive =
-// left). Aligning the fixed-width tracker box to each polygon edge yields two candidate vehicle
-// centers; their segment is the lateral "dead-zone" (width |polygon_width - tracker_width|). The
-// corrected anchor is the tracker center projected into that dead-zone: held when inside (polygon
-// straddles or is straddled by the tracker), or snapped to the nearest edge-aligned center when a
-// polygon edge protrudes/recedes. Returns the lateral move and, via `var_lat`, the extra lateral
-// variance, which grows with the dead-zone size (std = half the dead-zone width).
+// Computes the lateral correction of the wheel-anchor, accounting for the width mismatch between
+// the measurement polygon and the fixed-width tracker box. Returns the lateral move and, via
+// `var_lat`, the extra lateral variance.
 double correctWheelAnchorLateral(
-  const double tracker_left, const double tracker_right, const double polygon_left,
-  const double polygon_right, double & var_lat);
+  const double anchor_lateral, const double tracker_half, const double polygon_half,
+  double & var_lat);
 
 // Laterally corrects the anchor against `prediction` and folds the extra variance into `pose_cov`.
 geometry_msgs::msg::Point correctWheelAnchor(

--- a/perception/autoware_multi_object_tracker/lib/association/scoring/bev_assignment_scoring.cpp
+++ b/perception/autoware_multi_object_tracker/lib/association/scoring/bev_assignment_scoring.cpp
@@ -14,7 +14,7 @@
 
 #include "autoware/multi_object_tracker/association/scoring/bev_assignment_scoring.hpp"
 
-#include "autoware/multi_object_tracker/object_model/shapes.hpp"
+#include "autoware/multi_object_tracker/object_model/shapes_iou.hpp"
 
 #include <algorithm>
 #include <cmath>

--- a/perception/autoware_multi_object_tracker/lib/association/scoring/polar_assignment_scoring.cpp
+++ b/perception/autoware_multi_object_tracker/lib/association/scoring/polar_assignment_scoring.cpp
@@ -14,7 +14,7 @@
 
 #include "autoware/multi_object_tracker/association/scoring/polar_assignment_scoring.hpp"
 
-#include "autoware/multi_object_tracker/object_model/shapes.hpp"
+#include "autoware/multi_object_tracker/object_model/shapes_iou.hpp"
 
 #include <autoware_utils_geometry/boost_geometry.hpp>
 #include <autoware_utils_geometry/boost_polygon_utils.hpp>

--- a/perception/autoware_multi_object_tracker/lib/association/scoring/redundancy_check.cpp
+++ b/perception/autoware_multi_object_tracker/lib/association/scoring/redundancy_check.cpp
@@ -14,7 +14,7 @@
 
 #include "autoware/multi_object_tracker/association/scoring/redundancy_check.hpp"
 
-#include "autoware/multi_object_tracker/object_model/shapes.hpp"
+#include "autoware/multi_object_tracker/object_model/shapes_iou.hpp"
 
 namespace autoware::multi_object_tracker
 {

--- a/perception/autoware_multi_object_tracker/lib/object_model/shapes.cpp
+++ b/perception/autoware_multi_object_tracker/lib/object_model/shapes.cpp
@@ -339,6 +339,12 @@ std::optional<types::DynamicObject> alignClusterToOrientation(
   const double cos_tr = std::cos(target_yaw), sin_tr = std::sin(target_yaw);
 
   types::DynamicObject aligned = cluster;
+
+  // Convert aligned object to bounding box
+  aligned.shape.type = autoware_perception_msgs::msg::Shape::BOUNDING_BOX;
+  aligned.shape.footprint.points.clear();
+
+  // Update position, orientation, and dimensions
   aligned.pose.position.x = cluster.pose.position.x + long_center * cos_tr - lat_center * sin_tr;
   aligned.pose.position.y = cluster.pose.position.y + long_center * sin_tr + lat_center * cos_tr;
 

--- a/perception/autoware_multi_object_tracker/lib/object_model/shapes_iou.cpp
+++ b/perception/autoware_multi_object_tracker/lib/object_model/shapes_iou.cpp
@@ -1,0 +1,217 @@
+// Copyright 2024 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/multi_object_tracker/object_model/shapes_iou.hpp"
+
+#include <autoware_utils_geometry/boost_geometry.hpp>
+#include <autoware_utils_geometry/boost_polygon_utils.hpp>
+
+#include <boost/geometry.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <numeric>
+#include <utility>
+#include <vector>
+
+namespace
+{
+constexpr double MIN_AREA = 1e-6;
+constexpr double INVALID_SCORE = -1.0;
+
+double getSumArea(const std::vector<autoware_utils_geometry::Polygon2d> & polygons)
+{
+  return std::accumulate(
+    polygons.begin(), polygons.end(), 0.0, [](double acc, autoware_utils_geometry::Polygon2d p) {
+      return acc + boost::geometry::area(p);
+    });
+}
+
+double getIntersectionArea(
+  const autoware_utils_geometry::Polygon2d & source_polygon,
+  const autoware_utils_geometry::Polygon2d & target_polygon)
+{
+  std::vector<autoware_utils_geometry::Polygon2d> intersection_polygons;
+  boost::geometry::intersection(source_polygon, target_polygon, intersection_polygons);
+  return getSumArea(intersection_polygons);
+}
+
+double getUnionArea(
+  const autoware_utils_geometry::Polygon2d & source_polygon,
+  const autoware_utils_geometry::Polygon2d & target_polygon)
+{
+  std::vector<autoware_utils_geometry::Polygon2d> union_polygons;
+  boost::geometry::union_(source_polygon, target_polygon, union_polygons);
+  return getSumArea(union_polygons);
+}
+
+double getConvexShapeArea(
+  const autoware_utils_geometry::Polygon2d & source_polygon,
+  const autoware_utils_geometry::Polygon2d & target_polygon)
+{
+  boost::geometry::model::multi_polygon<autoware_utils_geometry::Polygon2d> union_polygons;
+  boost::geometry::union_(source_polygon, target_polygon, union_polygons);
+
+  autoware_utils_geometry::Polygon2d hull;
+  boost::geometry::convex_hull(union_polygons, hull);
+  return boost::geometry::area(hull);
+}
+}  // namespace
+
+namespace autoware::multi_object_tracker
+{
+namespace shapes
+{
+
+double get1dIoU(
+  const types::DynamicObject & source_object, const types::DynamicObject & target_object)
+{
+  constexpr double min_union_length = 0.1;  // As 0.01 used in 2dIoU, use 0.1 here
+  constexpr double min_length = 1e-3;       // As 1e-6 used in 2dIoU, use 1e-3 here
+  // Compute radii from dimensions (use max of x and y as diameter)
+  const double r_src =
+    std::max(source_object.shape.dimensions.x, source_object.shape.dimensions.y) * 0.5;
+  const double r_tgt =
+    std::max(target_object.shape.dimensions.x, target_object.shape.dimensions.y) * 0.5;
+  // if radius is smaller than the minimum length, return 0.0
+  if (r_src < min_length || r_tgt < min_length) return 0.0;
+  // Ensure r1 is the larger radius
+  const double r1 = std::max(r_tgt, r_src);
+  const double r2 = std::min(r_tgt, r_src);
+  const auto dx = source_object.pose.position.x - target_object.pose.position.x;
+  const auto dy = source_object.pose.position.y - target_object.pose.position.y;
+  // distance between centers
+  const auto dist = std::sqrt(dx * dx + dy * dy);
+  // if distance is larger than the sum of radius, return 0.0
+  if (dist > r1 + r2 - min_length) return 0.0;
+  // if distance is smaller than the difference of radius, return the ratio of the smaller radius to
+  // the larger radius
+  // Square used to mimic area ratio behavior as a rough 2D approximation
+  if (dist < r1 - r2) return (r2 * r2) / (r1 * r1);
+  // if distance is between the difference and the sum of radii, return the ratio of the
+  // intersection length to the union length
+  if (r1 + r2 + dist < min_union_length) return 0.0;
+  const double intersection_length = r1 + r2 - dist;
+  const double iou = intersection_length * r2 / (r1 * r1) * 0.5;
+  return iou;
+}
+
+double get2dIoU(
+  const types::DynamicObject & source_object, const types::DynamicObject & target_object,
+  const double min_union_area)
+{
+  const auto source_polygon =
+    autoware_utils_geometry::to_polygon2d(source_object.pose, source_object.shape);
+  if (boost::geometry::area(source_polygon) < MIN_AREA) return 0.0;
+  const auto target_polygon =
+    autoware_utils_geometry::to_polygon2d(target_object.pose, target_object.shape);
+  if (boost::geometry::area(target_polygon) < MIN_AREA) return 0.0;
+
+  const double intersection_area = getIntersectionArea(source_polygon, target_polygon);
+  if (intersection_area < MIN_AREA) return 0.0;
+  const double union_area = getUnionArea(source_polygon, target_polygon);
+
+  const double iou =
+    union_area < min_union_area ? 0.0 : std::min(1.0, intersection_area / union_area);
+  return iou;
+}
+
+double get2dGeneralizedIoU(
+  const types::DynamicObject & source_object, const types::DynamicObject & target_object)
+{
+  const auto source_polygon =
+    autoware_utils_geometry::to_polygon2d(source_object.pose, source_object.shape);
+  const double source_area = boost::geometry::area(source_polygon);
+  const auto target_polygon =
+    autoware_utils_geometry::to_polygon2d(target_object.pose, target_object.shape);
+  const double target_area = boost::geometry::area(target_polygon);
+  if (source_area < MIN_AREA && target_area < MIN_AREA) return -1.0;
+
+  const double intersection_area = getIntersectionArea(source_polygon, target_polygon);
+  const double union_area = getUnionArea(source_polygon, target_polygon);
+  const double iou = union_area < 0.01 ? 0.0 : std::min(1.0, intersection_area / union_area);
+  const double convex_shape_area = getConvexShapeArea(source_polygon, target_polygon);
+
+  return iou - (convex_shape_area - union_area) / convex_shape_area;
+}
+
+bool get2dPrecisionRecallGIoU(
+  const types::DynamicObject & source_object, const types::DynamicObject & target_object,
+  double & precision, double & recall, double & generalized_iou)
+{
+  const auto source_polygon =
+    autoware_utils_geometry::to_polygon2d(source_object.pose, source_object.shape);
+  const double source_area = boost::geometry::area(source_polygon);
+  if (source_area < MIN_AREA) return false;
+  const auto target_polygon =
+    autoware_utils_geometry::to_polygon2d(target_object.pose, target_object.shape);
+  const double target_area = boost::geometry::area(target_polygon);
+  if (target_area < MIN_AREA) return false;
+
+  const double intersection_area = getIntersectionArea(source_polygon, target_polygon);
+  const double union_area = getUnionArea(source_polygon, target_polygon);
+  const double convex_shape_area = getConvexShapeArea(source_polygon, target_polygon);
+  const double iou = union_area < 0.01 ? 0.0 : std::min(1.0, intersection_area / union_area);
+
+  precision = source_area < MIN_AREA ? 0.0 : std::min(1.0, intersection_area / source_area);
+  recall = source_area < MIN_AREA ? 0.0 : std::min(1.0, intersection_area / target_area);
+  generalized_iou = iou - (convex_shape_area - union_area) / convex_shape_area;
+
+  return true;
+}
+
+std::pair<double, double> getObjectZRange(const types::DynamicObject & object)
+{
+  const double center_z = object.pose.position.z;
+  const double height = object.shape.dimensions.z;
+  const double min_z = center_z - height / 2.0;
+  const double max_z = center_z + height / 2.0;
+  return {min_z, max_z};
+}
+
+double get3dGeneralizedIoU(
+  const types::DynamicObject & source_object, const types::DynamicObject & target_object)
+{
+  const auto source_polygon =
+    autoware_utils_geometry::to_polygon2d(source_object.pose, source_object.shape);
+  if (boost::geometry::area(source_polygon) < MIN_AREA) return INVALID_SCORE;
+  const auto target_polygon =
+    autoware_utils_geometry::to_polygon2d(target_object.pose, target_object.shape);
+  if (boost::geometry::area(target_polygon) < MIN_AREA) return INVALID_SCORE;
+
+  const double union_area = getUnionArea(source_polygon, target_polygon);
+  if (union_area < MIN_AREA) return INVALID_SCORE;
+
+  const double intersection_area = getIntersectionArea(source_polygon, target_polygon);
+  const double convex_area = getConvexShapeArea(source_polygon, target_polygon);
+
+  const auto [z_min_src, z_max_src] = getObjectZRange(source_object);
+  const auto [z_min_tgt, z_max_tgt] = getObjectZRange(target_object);
+
+  const double height_overlap =
+    std::max(0.0, std::min(z_max_src, z_max_tgt) - std::max(z_min_src, z_min_tgt));
+
+  if (height_overlap <= 0.0) return INVALID_SCORE;
+
+  const double total_height = std::max(z_max_src, z_max_tgt) - std::min(z_min_src, z_min_tgt);
+
+  const double iou =
+    std::clamp((intersection_area * height_overlap) / (union_area * total_height), 0.0, 1.0);
+
+  return iou - (convex_area - union_area) / convex_area;
+}
+
+}  // namespace shapes
+
+}  // namespace autoware::multi_object_tracker

--- a/perception/autoware_multi_object_tracker/lib/object_model/shapes_iou.cpp
+++ b/perception/autoware_multi_object_tracker/lib/object_model/shapes_iou.cpp
@@ -33,7 +33,8 @@ constexpr double INVALID_SCORE = -1.0;
 double getSumArea(const std::vector<autoware_utils_geometry::Polygon2d> & polygons)
 {
   return std::accumulate(
-    polygons.begin(), polygons.end(), 0.0, [](double acc, autoware_utils_geometry::Polygon2d p) {
+    polygons.begin(), polygons.end(), 0.0,
+    [](double acc, const autoware_utils_geometry::Polygon2d & p) {
       return acc + boost::geometry::area(p);
     });
 }

--- a/perception/autoware_multi_object_tracker/lib/object_model/shapes_transform.cpp
+++ b/perception/autoware_multi_object_tracker/lib/object_model/shapes_transform.cpp
@@ -12,9 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "autoware/multi_object_tracker/object_model/shapes.hpp"
+#include "autoware/multi_object_tracker/object_model/shapes_transform.hpp"
 
-#include <Eigen/Geometry>
 #include <autoware_utils_geometry/boost_geometry.hpp>
 #include <autoware_utils_geometry/boost_polygon_utils.hpp>
 #include <tf2/utils.hpp>
@@ -24,18 +23,13 @@
 
 #include <boost/geometry.hpp>
 
-#include <algorithm>
 #include <cmath>
 #include <limits>
-#include <string>
-#include <utility>
+#include <optional>
 #include <vector>
 
 namespace
 {
-constexpr double MIN_AREA = 1e-6;
-constexpr double INVALID_SCORE = -1.0;
-
 struct OrientedExtent
 {
   double min_along, max_along, min_lat, max_lat;
@@ -59,146 +53,12 @@ inline OrientedExtent computeOrientedExtent(
   }
   return ext;
 }
-double getSumArea(const std::vector<autoware_utils_geometry::Polygon2d> & polygons)
-{
-  return std::accumulate(
-    polygons.begin(), polygons.end(), 0.0, [](double acc, autoware_utils_geometry::Polygon2d p) {
-      return acc + boost::geometry::area(p);
-    });
-}
-
-double getIntersectionArea(
-  const autoware_utils_geometry::Polygon2d & source_polygon,
-  const autoware_utils_geometry::Polygon2d & target_polygon)
-{
-  std::vector<autoware_utils_geometry::Polygon2d> intersection_polygons;
-  boost::geometry::intersection(source_polygon, target_polygon, intersection_polygons);
-  return getSumArea(intersection_polygons);
-}
-
-double getUnionArea(
-  const autoware_utils_geometry::Polygon2d & source_polygon,
-  const autoware_utils_geometry::Polygon2d & target_polygon)
-{
-  std::vector<autoware_utils_geometry::Polygon2d> union_polygons;
-  boost::geometry::union_(source_polygon, target_polygon, union_polygons);
-  return getSumArea(union_polygons);
-}
-
-double getConvexShapeArea(
-  const autoware_utils_geometry::Polygon2d & source_polygon,
-  const autoware_utils_geometry::Polygon2d & target_polygon)
-{
-  boost::geometry::model::multi_polygon<autoware_utils_geometry::Polygon2d> union_polygons;
-  boost::geometry::union_(source_polygon, target_polygon, union_polygons);
-
-  autoware_utils_geometry::Polygon2d hull;
-  boost::geometry::convex_hull(union_polygons, hull);
-  return boost::geometry::area(hull);
-}
 }  // namespace
 
 namespace autoware::multi_object_tracker
 {
 namespace shapes
 {
-
-double get1dIoU(
-  const types::DynamicObject & source_object, const types::DynamicObject & target_object)
-{
-  constexpr double min_union_length = 0.1;  // As 0.01 used in 2dIoU, use 0.1 here
-  constexpr double min_length = 1e-3;       // As 1e-6 used in 2dIoU, use 1e-3 here
-  // Compute radii from dimensions (use max of x and y as diameter)
-  const double r_src =
-    std::max(source_object.shape.dimensions.x, source_object.shape.dimensions.y) * 0.5;
-  const double r_tgt =
-    std::max(target_object.shape.dimensions.x, target_object.shape.dimensions.y) * 0.5;
-  // if radius is smaller than the minimum length, return 0.0
-  if (r_src < min_length || r_tgt < min_length) return 0.0;
-  // Ensure r1 is the larger radius
-  const double r1 = std::max(r_tgt, r_src);
-  const double r2 = std::min(r_tgt, r_src);
-  const auto dx = source_object.pose.position.x - target_object.pose.position.x;
-  const auto dy = source_object.pose.position.y - target_object.pose.position.y;
-  // distance between centers
-  const auto dist = std::sqrt(dx * dx + dy * dy);
-  // if distance is larger than the sum of radius, return 0.0
-  if (dist > r1 + r2 - min_length) return 0.0;
-  // if distance is smaller than the difference of radius, return the ratio of the smaller radius to
-  // the larger radius
-  // Square used to mimic area ratio behavior as a rough 2D approximation
-  if (dist < r1 - r2) return (r2 * r2) / (r1 * r1);
-  // if distance is between the difference and the sum of radii, return the ratio of the
-  // intersection length to the union length
-  if (r1 + r2 + dist < min_union_length) return 0.0;
-  const double intersection_length = r1 + r2 - dist;
-  const double iou = intersection_length * r2 / (r1 * r1) * 0.5;
-  return iou;
-}
-
-double get2dIoU(
-  const types::DynamicObject & source_object, const types::DynamicObject & target_object,
-  const double min_union_area)
-{
-  const auto source_polygon =
-    autoware_utils_geometry::to_polygon2d(source_object.pose, source_object.shape);
-  if (boost::geometry::area(source_polygon) < MIN_AREA) return 0.0;
-  const auto target_polygon =
-    autoware_utils_geometry::to_polygon2d(target_object.pose, target_object.shape);
-  if (boost::geometry::area(target_polygon) < MIN_AREA) return 0.0;
-
-  const double intersection_area = getIntersectionArea(source_polygon, target_polygon);
-  if (intersection_area < MIN_AREA) return 0.0;
-  const double union_area = getUnionArea(source_polygon, target_polygon);
-
-  const double iou =
-    union_area < min_union_area ? 0.0 : std::min(1.0, intersection_area / union_area);
-  return iou;
-}
-
-double get2dGeneralizedIoU(
-  const types::DynamicObject & source_object, const types::DynamicObject & target_object)
-{
-  const auto source_polygon =
-    autoware_utils_geometry::to_polygon2d(source_object.pose, source_object.shape);
-  const double source_area = boost::geometry::area(source_polygon);
-  const auto target_polygon =
-    autoware_utils_geometry::to_polygon2d(target_object.pose, target_object.shape);
-  const double target_area = boost::geometry::area(target_polygon);
-  if (source_area < MIN_AREA && target_area < MIN_AREA) return -1.0;
-
-  const double intersection_area = getIntersectionArea(source_polygon, target_polygon);
-  const double union_area = getUnionArea(source_polygon, target_polygon);
-  const double iou = union_area < 0.01 ? 0.0 : std::min(1.0, intersection_area / union_area);
-  const double convex_shape_area = getConvexShapeArea(source_polygon, target_polygon);
-
-  return iou - (convex_shape_area - union_area) / convex_shape_area;
-}
-
-bool get2dPrecisionRecallGIoU(
-  const types::DynamicObject & source_object, const types::DynamicObject & target_object,
-  double & precision, double & recall, double & generalized_iou)
-{
-  const auto source_polygon =
-    autoware_utils_geometry::to_polygon2d(source_object.pose, source_object.shape);
-  const double source_area = boost::geometry::area(source_polygon);
-  if (source_area < MIN_AREA) return false;
-  const auto target_polygon =
-    autoware_utils_geometry::to_polygon2d(target_object.pose, target_object.shape);
-  const double target_area = boost::geometry::area(target_polygon);
-  if (target_area < MIN_AREA) return false;
-
-  const double intersection_area = getIntersectionArea(source_polygon, target_polygon);
-  const double union_area = getUnionArea(source_polygon, target_polygon);
-  const double convex_shape_area = getConvexShapeArea(source_polygon, target_polygon);
-  const double iou = union_area < 0.01 ? 0.0 : std::min(1.0, intersection_area / union_area);
-
-  precision = source_area < MIN_AREA ? 0.0 : std::min(1.0, intersection_area / source_area);
-  recall = source_area < MIN_AREA ? 0.0 : std::min(1.0, intersection_area / target_area);
-  generalized_iou = iou - (convex_shape_area - union_area) / convex_shape_area;
-
-  return true;
-}
 
 bool convertConvexHullToBoundingBox(
   const types::DynamicObject & input_object, types::DynamicObject & output_object,
@@ -356,47 +216,6 @@ std::optional<types::DynamicObject> alignClusterToOrientation(
   aligned.shape.dimensions.y = ext.max_lat - ext.min_lat;
 
   return aligned;
-}
-
-std::pair<double, double> getObjectZRange(const types::DynamicObject & object)
-{
-  const double center_z = object.pose.position.z;
-  const double height = object.shape.dimensions.z;
-  const double min_z = center_z - height / 2.0;
-  const double max_z = center_z + height / 2.0;
-  return {min_z, max_z};
-}
-
-double get3dGeneralizedIoU(
-  const types::DynamicObject & source_object, const types::DynamicObject & target_object)
-{
-  const auto source_polygon =
-    autoware_utils_geometry::to_polygon2d(source_object.pose, source_object.shape);
-  if (boost::geometry::area(source_polygon) < MIN_AREA) return INVALID_SCORE;
-  const auto target_polygon =
-    autoware_utils_geometry::to_polygon2d(target_object.pose, target_object.shape);
-  if (boost::geometry::area(target_polygon) < MIN_AREA) return INVALID_SCORE;
-
-  const double union_area = getUnionArea(source_polygon, target_polygon);
-  if (union_area < MIN_AREA) return INVALID_SCORE;
-
-  const double intersection_area = getIntersectionArea(source_polygon, target_polygon);
-  const double convex_area = getConvexShapeArea(source_polygon, target_polygon);
-
-  const auto [z_min_src, z_max_src] = getObjectZRange(source_object);
-  const auto [z_min_tgt, z_max_tgt] = getObjectZRange(target_object);
-
-  const double height_overlap =
-    std::max(0.0, std::min(z_max_src, z_max_tgt) - std::max(z_min_src, z_min_tgt));
-
-  if (height_overlap <= 0.0) return INVALID_SCORE;
-
-  const double total_height = std::max(z_max_src, z_max_tgt) - std::min(z_min_src, z_min_tgt);
-
-  const double iou =
-    std::clamp((intersection_area * height_overlap) / (union_area * total_height), 0.0, 1.0);
-
-  return iou - (convex_area - union_area) / convex_area;
 }
 
 geometry_msgs::msg::Polygon unionFootprints(

--- a/perception/autoware_multi_object_tracker/lib/tracker/motion_model/bicycle_motion_model.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/motion_model/bicycle_motion_model.cpp
@@ -252,25 +252,25 @@ bool BicycleMotionModel::updateStatePoseRear(
   // check if the state is initialized
   if (!checkInitialized()) return false;
 
-  StateVec X_t;
-  ekf_.getX(X_t);
-
-  // The heading is used only to map the rear face center to the rear axle position.
-  const double yaw = getYawState();
-  const double wheel_base = std::hypot(X_t(IDX::X2) - X_t(IDX::X1), X_t(IDX::Y2) - X_t(IDX::Y1));
-  const double x1 = xr + wheel_base * motion_params_.wheel_gamma_rear * std::cos(yaw);
-  const double y1 = yr + wheel_base * motion_params_.wheel_gamma_rear * std::sin(yaw);
-
-  // Measure ONLY the observed (rear) axle. The front axle is not measured; it follows through the
-  // EKF cross-covariance, so the body may rotate about the observed end instead of being rigidly
-  // translated (the old 4-row form copied the rear shift onto the front, freezing yaw).
+  // Measure the observed rear FACE center directly. The face center lies on the body axis at a
+  // distance gamma_rear * wheel_base behind the rear axle. Because that offset is gamma_rear * L *
+  // u_hat and L * u_hat == (p2 - p1) by definition of the two-point state, the wheelbase and yaw
+  // cancel and the measurement is an EXACT linear function of the endpoints (true KF, no EKF
+  // approximation):
+  //   face_rear = p1 - gamma_rear * (p2 - p1) = (1 + gamma_rear) * p1 - gamma_rear * p2
+  // The innovation equals the old single-axle form, but C now constrains a linear blend of both
+  // endpoints, so the gain splits the correction between translation and rotation per the prior
+  // covariance instead of dumping it on the rear axle (which rotated the body as a side effect).
+  const double g = motion_params_.wheel_gamma_rear;
   constexpr int DIM_Y = 2;
   Eigen::Matrix<double, DIM_Y, 1> Y;
-  Y << x1, y1;
+  Y << xr, yr;
 
   Eigen::Matrix<double, DIM_Y, DIM> C = Eigen::Matrix<double, DIM_Y, DIM>::Zero();
-  C(0, IDX::X1) = 1.0;
-  C(1, IDX::Y1) = 1.0;
+  C(0, IDX::X1) = 1.0 + g;
+  C(0, IDX::X2) = -g;
+  C(1, IDX::Y1) = 1.0 + g;
+  C(1, IDX::Y2) = -g;
 
   Eigen::Matrix<double, DIM_Y, DIM_Y> R = Eigen::Matrix<double, DIM_Y, DIM_Y>::Zero();
   R(0, 0) = pose_cov[XYZRPY_COV_IDX::X_X];
@@ -287,23 +287,19 @@ bool BicycleMotionModel::updateStatePoseFront(
   // check if the state is initialized
   if (!checkInitialized()) return false;
 
-  StateVec X_t;
-  ekf_.getX(X_t);
-
-  // The heading is used only to map the front face center to the front axle position.
-  const double yaw = getYawState();
-  const double wheel_base = std::hypot(X_t(IDX::X2) - X_t(IDX::X1), X_t(IDX::Y2) - X_t(IDX::Y1));
-  const double x2 = xf - wheel_base * motion_params_.wheel_gamma_front * std::cos(yaw);
-  const double y2 = yf - wheel_base * motion_params_.wheel_gamma_front * std::sin(yaw);
-
-  // Measure ONLY the observed (front) axle; the rear axle follows through the cross-covariance.
+  // Measure the observed front FACE center directly. Same exact-linear reasoning as the rear case:
+  //   face_front = p2 + gamma_front * (p2 - p1) = (1 + gamma_front) * p2 - gamma_front * p1
+  // The wheelbase and yaw cancel because L * u_hat == (p2 - p1), so C is a constant linear map.
+  const double g = motion_params_.wheel_gamma_front;
   constexpr int DIM_Y = 2;
   Eigen::Matrix<double, DIM_Y, 1> Y;
-  Y << x2, y2;
+  Y << xf, yf;
 
   Eigen::Matrix<double, DIM_Y, DIM> C = Eigen::Matrix<double, DIM_Y, DIM>::Zero();
-  C(0, IDX::X2) = 1.0;
-  C(1, IDX::Y2) = 1.0;
+  C(0, IDX::X2) = 1.0 + g;
+  C(0, IDX::X1) = -g;
+  C(1, IDX::Y2) = 1.0 + g;
+  C(1, IDX::Y1) = -g;
 
   Eigen::Matrix<double, DIM_Y, DIM_Y> R = Eigen::Matrix<double, DIM_Y, DIM_Y>::Zero();
   R(0, 0) = pose_cov[XYZRPY_COV_IDX::X_X];

--- a/perception/autoware_multi_object_tracker/lib/tracker/motion_model/bicycle_motion_model.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/motion_model/bicycle_motion_model.cpp
@@ -534,27 +534,19 @@ bool BicycleMotionModel::predictStateStep(const double dt, KalmanFilter & ekf) c
   A(IDX::V, IDX::V) = decay_rate;
 
   // Process noise covariance Q
-  //
   // Nonholonomic constraint: heading cannot change without translating, so yaw-rate uncertainty
-  // must vanish at standstill. A constant floor there inflates the front-point lateral variance
-  // (heading noise feeds Q on X2/Y2 only), which a partial update cannot pull back -> yaw jitter.
+  // must vanish at standstill.
   const double vel_long_abs = std::abs(vel_long);
   constexpr double vel_long_eps = 1e-3;  // [m/s] guard against division by zero
-  /* physical yaw-rate bound, limited by the tighter of the two:
-   *  - centripetal acceleration a_lat : w = a_lat / vel_long
-   *  - or maximum slip angle slip_max : w = vel_long * sin(slip_max) / wheel_base  (-> 0 at v -> 0)
-   */
+  // physical yaw-rate bound, limited by the tighter of the two:
+  //  - centripetal acceleration a_lat : w = a_lat / vel_long
+  //  - or maximum slip angle slip_max : w = vel_long * sin(slip_max) / wheel_base  (-> 0 at v -> 0)
   const double q_stddev_yaw_rate_phys = std::min(
     motion_params_.q_stddev_acc_lat / std::max(vel_long_abs, vel_long_eps),
     vel_long_abs * std::sin(motion_params_.q_max_slip_angle) / wheel_base);  // [rad/s]
-  // Ramp the configured floor in linearly with speed (0 at standstill, full at vel_ref) instead of
-  // applying it unconditionally. NOTE: below vel_ref the floor is lower than the original code,
-  // which applied the full floor for any vel_long > 0.01.
-  constexpr double vel_ref = 1.0;  // [m/s] speed at which the yaw-rate floor reaches full value
-  const double yaw_rate_floor =
-    motion_params_.q_stddev_yaw_rate_min * std::clamp(vel_long_abs / vel_ref, 0.0, 1.0);
-  const double q_stddev_yaw_rate =
-    std::clamp(q_stddev_yaw_rate_phys, yaw_rate_floor, motion_params_.q_stddev_yaw_rate_max);
+  const double q_stddev_yaw_rate = std::clamp(
+    q_stddev_yaw_rate_phys, motion_params_.q_stddev_yaw_rate_min,
+    motion_params_.q_stddev_yaw_rate_max);
   const double q_stddev_head = q_stddev_yaw_rate * wheel_base * dt;  // yaw uncertainty
 
   const double dt2 = dt * dt;

--- a/perception/autoware_multi_object_tracker/lib/tracker/motion_model/bicycle_motion_model.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/motion_model/bicycle_motion_model.cpp
@@ -534,16 +534,16 @@ bool BicycleMotionModel::predictStateStep(const double dt, KalmanFilter & ekf) c
   A(IDX::V, IDX::V) = decay_rate;
 
   // Process noise covariance Q
-  // Nonholonomic constraint: heading cannot change without translating, so yaw-rate uncertainty
-  // must vanish at standstill.
   const double vel_long_abs = std::abs(vel_long);
   constexpr double vel_long_eps = 1e-3;  // [m/s] guard against division by zero
   // physical yaw-rate bound, limited by the tighter of the two:
-  //  - centripetal acceleration a_lat : w = a_lat / vel_long
-  //  - or maximum slip angle slip_max : w = vel_long * sin(slip_max) / wheel_base  (-> 0 at v -> 0)
-  const double q_stddev_yaw_rate_phys = std::min(
-    motion_params_.q_stddev_acc_lat / std::max(vel_long_abs, vel_long_eps),
-    vel_long_abs * std::sin(motion_params_.q_max_slip_angle) / wheel_base);  // [rad/s]
+  //  - Centripetal acceleration a_lat : w = a_lat / vel_long
+  //  - Nonholonomic constraint : w = vel_long * sin(slip_max) / wheel_base  (-> 0 at v -> 0)
+  const double q_stddev_centripetal =
+    motion_params_.q_stddev_acc_lat / std::max(vel_long_abs, vel_long_eps);
+  const double q_stddev_slip =
+    vel_long_abs * std::sin(motion_params_.q_max_slip_angle) / wheel_base;
+  const double q_stddev_yaw_rate_phys = std::min(q_stddev_centripetal, q_stddev_slip);  // [rad/s]
   const double q_stddev_yaw_rate = std::clamp(
     q_stddev_yaw_rate_phys, motion_params_.q_stddev_yaw_rate_min,
     motion_params_.q_stddev_yaw_rate_max);

--- a/perception/autoware_multi_object_tracker/lib/tracker/motion_model/bicycle_motion_model.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/motion_model/bicycle_motion_model.cpp
@@ -246,60 +246,35 @@ bool BicycleMotionModel::updateStatePoseHeadVel(
   return ekf_.update(Y, C, R);
 }
 
-bool BicycleMotionModel::updateStatePoseRear(
-  const double & xr, const double & yr, const std::array<double, 36> & pose_cov)
+bool BicycleMotionModel::updateStatePoseWheel(
+  const double & x, const double & y, const std::array<double, 36> & pose_cov,
+  const bool measure_front)
 {
   // check if the state is initialized
   if (!checkInitialized()) return false;
 
-  // Measure the observed rear FACE center directly. The face center lies on the body axis at a
-  // distance gamma_rear * wheel_base behind the rear axle. Because that offset is gamma_rear * L *
-  // u_hat and L * u_hat == (p2 - p1) by definition of the two-point state, the wheelbase and yaw
-  // cancel and the measurement is an EXACT linear function of the endpoints (true KF, no EKF
-  // approximation):
-  //   face_rear = p1 - gamma_rear * (p2 - p1) = (1 + gamma_rear) * p1 - gamma_rear * p2
-  // The innovation equals the old single-axle form, but C now constrains a linear blend of both
-  // endpoints, so the gain splits the correction between translation and rotation per the prior
-  // covariance instead of dumping it on the rear axle (which rotated the body as a side effect).
-  const double g = motion_params_.wheel_gamma_rear;
   constexpr int DIM_Y = 2;
   Eigen::Matrix<double, DIM_Y, 1> Y;
-  Y << xr, yr;
+  Y << x, y;
 
+  // Measure the edge FACE center as an exact linear blend of the two endpoints (true KF):
+  // face = (1 + gamma) * p_near - gamma * p_far
   Eigen::Matrix<double, DIM_Y, DIM> C = Eigen::Matrix<double, DIM_Y, DIM>::Zero();
-  C(0, IDX::X1) = 1.0 + g;
-  C(0, IDX::X2) = -g;
-  C(1, IDX::Y1) = 1.0 + g;
-  C(1, IDX::Y2) = -g;
-
-  Eigen::Matrix<double, DIM_Y, DIM_Y> R = Eigen::Matrix<double, DIM_Y, DIM_Y>::Zero();
-  R(0, 0) = pose_cov[XYZRPY_COV_IDX::X_X];
-  R(0, 1) = pose_cov[XYZRPY_COV_IDX::X_Y];
-  R(1, 0) = pose_cov[XYZRPY_COV_IDX::Y_X];
-  R(1, 1) = pose_cov[XYZRPY_COV_IDX::Y_Y];
-
-  return ekf_.update(Y, C, R);
-}
-
-bool BicycleMotionModel::updateStatePoseFront(
-  const double & xf, const double & yf, const std::array<double, 36> & pose_cov)
-{
-  // check if the state is initialized
-  if (!checkInitialized()) return false;
-
-  // Measure the observed front FACE center directly. Same exact-linear reasoning as the rear case:
-  //   face_front = p2 + gamma_front * (p2 - p1) = (1 + gamma_front) * p2 - gamma_front * p1
-  // The wheelbase and yaw cancel because L * u_hat == (p2 - p1), so C is a constant linear map.
-  const double g = motion_params_.wheel_gamma_front;
-  constexpr int DIM_Y = 2;
-  Eigen::Matrix<double, DIM_Y, 1> Y;
-  Y << xf, yf;
-
-  Eigen::Matrix<double, DIM_Y, DIM> C = Eigen::Matrix<double, DIM_Y, DIM>::Zero();
-  C(0, IDX::X2) = 1.0 + g;
-  C(0, IDX::X1) = -g;
-  C(1, IDX::Y2) = 1.0 + g;
-  C(1, IDX::Y1) = -g;
+  if (measure_front) {
+    // The front face anchors on p2 = (X2, Y2) with gamma_front
+    const double gamma = motion_params_.wheel_gamma_front;
+    C(0, IDX::X1) = -gamma;
+    C(0, IDX::X2) = 1.0 + gamma;
+    C(1, IDX::Y1) = -gamma;
+    C(1, IDX::Y2) = 1.0 + gamma;
+  } else {
+    // The rear face anchors on p1 = (X1, Y1) with gamma_rear
+    const double gamma = motion_params_.wheel_gamma_rear;
+    C(0, IDX::X1) = 1.0 + gamma;
+    C(0, IDX::X2) = -gamma;
+    C(1, IDX::Y1) = 1.0 + gamma;
+    C(1, IDX::Y2) = -gamma;
+  }
 
   Eigen::Matrix<double, DIM_Y, DIM_Y> R = Eigen::Matrix<double, DIM_Y, DIM_Y>::Zero();
   R(0, 0) = pose_cov[XYZRPY_COV_IDX::X_X];

--- a/perception/autoware_multi_object_tracker/lib/tracker/motion_model/bicycle_motion_model.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/motion_model/bicycle_motion_model.cpp
@@ -576,13 +576,14 @@ bool BicycleMotionModel::predictStateStep(const double dt, KalmanFilter & ekf) c
     motion_params_.q_stddev_acc_lat / std::max(vel_long_abs, vel_long_eps),
     vel_long_abs * std::sin(motion_params_.q_max_slip_angle) / wheel_base);  // [rad/s]
   // Ramp the configured floor in with speed instead of applying it unconditionally, so the floor
-  // -> 0 at standstill (no heading information exists to be tracked) and only reaches its full value
-  // once the vehicle is clearly moving. Above vel_ref this reproduces the original clamp behavior.
+  // -> 0 at standstill (no heading information exists to be tracked) and only reaches its full
+  // value once the vehicle is clearly moving. Above vel_ref this reproduces the original clamp
+  // behavior.
   constexpr double vel_ref = 1.0;  // [m/s] speed at which the yaw-rate floor reaches full value
   const double yaw_rate_floor =
     motion_params_.q_stddev_yaw_rate_min * std::clamp(vel_long_abs / vel_ref, 0.0, 1.0);
-  const double q_stddev_yaw_rate = std::clamp(
-    q_stddev_yaw_rate_phys, yaw_rate_floor, motion_params_.q_stddev_yaw_rate_max);
+  const double q_stddev_yaw_rate =
+    std::clamp(q_stddev_yaw_rate_phys, yaw_rate_floor, motion_params_.q_stddev_yaw_rate_max);
   const double q_stddev_head = q_stddev_yaw_rate * wheel_base * dt;  // yaw uncertainty
 
   const double dt2 = dt * dt;

--- a/perception/autoware_multi_object_tracker/lib/tracker/motion_model/bicycle_motion_model.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/motion_model/bicycle_motion_model.cpp
@@ -257,7 +257,7 @@ bool BicycleMotionModel::updateStatePoseWheel(
   Eigen::Matrix<double, DIM_Y, 1> Y;
   Y << x, y;
 
-  // Measure the edge FACE center as an exact linear blend of the two endpoints (true KF):
+  // Measure the edge face center as an exact linear blend of the two endpoints:
   // face = (1 + gamma) * p_near - gamma * p_far
   Eigen::Matrix<double, DIM_Y, DIM> C = Eigen::Matrix<double, DIM_Y, DIM>::Zero();
   if (measure_front) {
@@ -535,12 +535,9 @@ bool BicycleMotionModel::predictStateStep(const double dt, KalmanFilter & ekf) c
 
   // Process noise covariance Q
   //
-  // Yaw-rate (heading) process noise obeys the nonholonomic constraint: a vehicle cannot change
-  // heading without translating (w = vel_long * tan(steer) / wheel_base), so the yaw-rate
-  // uncertainty must vanish as vel_long -> 0. A stationary vehicle is physically incapable of
-  // turning, hence NO heading noise may be injected at standstill. Injecting a constant floor there
-  // ratchets up the front-point lateral variance (the heading noise feeds q_cov_lat2 -> Q on
-  // X2/Y2 only), which a rear/front partial update cannot pull back -> standstill yaw jitter.
+  // Nonholonomic constraint: heading cannot change without translating, so yaw-rate uncertainty
+  // must vanish at standstill. A constant floor there inflates the front-point lateral variance
+  // (heading noise feeds Q on X2/Y2 only), which a partial update cannot pull back -> yaw jitter.
   const double vel_long_abs = std::abs(vel_long);
   constexpr double vel_long_eps = 1e-3;  // [m/s] guard against division by zero
   /* physical yaw-rate bound, limited by the tighter of the two:
@@ -550,10 +547,9 @@ bool BicycleMotionModel::predictStateStep(const double dt, KalmanFilter & ekf) c
   const double q_stddev_yaw_rate_phys = std::min(
     motion_params_.q_stddev_acc_lat / std::max(vel_long_abs, vel_long_eps),
     vel_long_abs * std::sin(motion_params_.q_max_slip_angle) / wheel_base);  // [rad/s]
-  // Ramp the configured floor in with speed instead of applying it unconditionally, so the floor
-  // -> 0 at standstill (no heading information exists to be tracked) and only reaches its full
-  // value once the vehicle is clearly moving. Above vel_ref this reproduces the original clamp
-  // behavior.
+  // Ramp the configured floor in linearly with speed (0 at standstill, full at vel_ref) instead of
+  // applying it unconditionally. NOTE: below vel_ref the floor is lower than the original code,
+  // which applied the full floor for any vel_long > 0.01.
   constexpr double vel_ref = 1.0;  // [m/s] speed at which the yaw-rate floor reaches full value
   const double yaw_rate_floor =
     motion_params_.q_stddev_yaw_rate_min * std::clamp(vel_long_abs / vel_ref, 0.0, 1.0);

--- a/perception/autoware_multi_object_tracker/lib/tracker/motion_model/bicycle_motion_model.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/motion_model/bicycle_motion_model.cpp
@@ -252,40 +252,31 @@ bool BicycleMotionModel::updateStatePoseRear(
   // check if the state is initialized
   if (!checkInitialized()) return false;
 
-  // get the current state to extract renovate deviation
   StateVec X_t;
-  StateMat P_t;
   ekf_.getX(X_t);
-  ekf_.getP(P_t);
 
+  // The heading is used only to map the rear face center to the rear axle position.
   const double yaw = getYawState();
   const double wheel_base = std::hypot(X_t(IDX::X2) - X_t(IDX::X1), X_t(IDX::Y2) - X_t(IDX::Y1));
   const double x1 = xr + wheel_base * motion_params_.wheel_gamma_rear * std::cos(yaw);
   const double y1 = yr + wheel_base * motion_params_.wheel_gamma_rear * std::sin(yaw);
-  const double delta_x = x1 - X_t(IDX::X1);
-  const double delta_y = y1 - X_t(IDX::Y1);
 
-  // update state
-  constexpr int DIM_Y = 4;
+  // Measure ONLY the observed (rear) axle. The front axle is not measured; it follows through the
+  // EKF cross-covariance, so the body may rotate about the observed end instead of being rigidly
+  // translated (the old 4-row form copied the rear shift onto the front, freezing yaw).
+  constexpr int DIM_Y = 2;
   Eigen::Matrix<double, DIM_Y, 1> Y;
-  Y << x1, y1, X_t(IDX::X2) + delta_x, X_t(IDX::Y2) + delta_y;
+  Y << x1, y1;
 
   Eigen::Matrix<double, DIM_Y, DIM> C = Eigen::Matrix<double, DIM_Y, DIM>::Zero();
   C(0, IDX::X1) = 1.0;
   C(1, IDX::Y1) = 1.0;
-  C(2, IDX::X2) = 1.0;
-  C(3, IDX::Y2) = 1.0;
 
-  constexpr double uncertainty_multiplier = 9.0;  // additional uncertainty for unmeasured position
   Eigen::Matrix<double, DIM_Y, DIM_Y> R = Eigen::Matrix<double, DIM_Y, DIM_Y>::Zero();
   R(0, 0) = pose_cov[XYZRPY_COV_IDX::X_X];
   R(0, 1) = pose_cov[XYZRPY_COV_IDX::X_Y];
   R(1, 0) = pose_cov[XYZRPY_COV_IDX::Y_X];
   R(1, 1) = pose_cov[XYZRPY_COV_IDX::Y_Y];
-  R(2, 2) = pose_cov[XYZRPY_COV_IDX::X_X] * uncertainty_multiplier;
-  R(2, 3) = pose_cov[XYZRPY_COV_IDX::X_Y] * uncertainty_multiplier;
-  R(3, 2) = pose_cov[XYZRPY_COV_IDX::Y_X] * uncertainty_multiplier;
-  R(3, 3) = pose_cov[XYZRPY_COV_IDX::Y_Y] * uncertainty_multiplier;
 
   return ekf_.update(Y, C, R);
 }
@@ -296,40 +287,29 @@ bool BicycleMotionModel::updateStatePoseFront(
   // check if the state is initialized
   if (!checkInitialized()) return false;
 
-  // get the current state to extract renovate deviation
   StateVec X_t;
-  StateMat P_t;
   ekf_.getX(X_t);
-  ekf_.getP(P_t);
 
+  // The heading is used only to map the front face center to the front axle position.
   const double yaw = getYawState();
   const double wheel_base = std::hypot(X_t(IDX::X2) - X_t(IDX::X1), X_t(IDX::Y2) - X_t(IDX::Y1));
   const double x2 = xf - wheel_base * motion_params_.wheel_gamma_front * std::cos(yaw);
   const double y2 = yf - wheel_base * motion_params_.wheel_gamma_front * std::sin(yaw);
-  const double delta_x = x2 - X_t(IDX::X2);
-  const double delta_y = y2 - X_t(IDX::Y2);
 
-  // update state
-  constexpr int DIM_Y = 4;
+  // Measure ONLY the observed (front) axle; the rear axle follows through the cross-covariance.
+  constexpr int DIM_Y = 2;
   Eigen::Matrix<double, DIM_Y, 1> Y;
-  Y << X_t(IDX::X1) + delta_x, X_t(IDX::Y1) + delta_y, x2, y2;
+  Y << x2, y2;
 
   Eigen::Matrix<double, DIM_Y, DIM> C = Eigen::Matrix<double, DIM_Y, DIM>::Zero();
-  C(0, IDX::X1) = 1.0;
-  C(1, IDX::Y1) = 1.0;
-  C(2, IDX::X2) = 1.0;
-  C(3, IDX::Y2) = 1.0;
+  C(0, IDX::X2) = 1.0;
+  C(1, IDX::Y2) = 1.0;
 
-  constexpr double uncertainty_multiplier = 9.0;  // additional uncertainty for unmeasured position
   Eigen::Matrix<double, DIM_Y, DIM_Y> R = Eigen::Matrix<double, DIM_Y, DIM_Y>::Zero();
-  R(0, 0) = pose_cov[XYZRPY_COV_IDX::X_X] * uncertainty_multiplier;
-  R(0, 1) = pose_cov[XYZRPY_COV_IDX::X_Y] * uncertainty_multiplier;
-  R(1, 0) = pose_cov[XYZRPY_COV_IDX::Y_X] * uncertainty_multiplier;
-  R(1, 1) = pose_cov[XYZRPY_COV_IDX::Y_Y] * uncertainty_multiplier;
-  R(2, 2) = pose_cov[XYZRPY_COV_IDX::X_X];
-  R(2, 3) = pose_cov[XYZRPY_COV_IDX::X_Y];
-  R(3, 2) = pose_cov[XYZRPY_COV_IDX::Y_X];
-  R(3, 3) = pose_cov[XYZRPY_COV_IDX::Y_Y];
+  R(0, 0) = pose_cov[XYZRPY_COV_IDX::X_X];
+  R(0, 1) = pose_cov[XYZRPY_COV_IDX::X_Y];
+  R(1, 0) = pose_cov[XYZRPY_COV_IDX::Y_X];
+  R(1, 1) = pose_cov[XYZRPY_COV_IDX::Y_Y];
 
   return ekf_.update(Y, C, R);
 }

--- a/perception/autoware_multi_object_tracker/lib/tracker/motion_model/bicycle_motion_model.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/motion_model/bicycle_motion_model.cpp
@@ -28,7 +28,7 @@
 namespace autoware::multi_object_tracker
 {
 
-// cspell: ignore CTRV
+// cspell: ignore CTRV nonholonomic
 // Bicycle CTRV motion model
 // CTRV : Constant Turn Rate and constant Velocity
 using autoware_utils_geometry::xyzrpy_covariance_index::XYZRPY_COV_IDX;
@@ -559,19 +559,30 @@ bool BicycleMotionModel::predictStateStep(const double dt, KalmanFilter & ekf) c
   A(IDX::V, IDX::V) = decay_rate;
 
   // Process noise covariance Q
-  double q_stddev_yaw_rate = motion_params_.q_stddev_yaw_rate_min;
-  if (vel_long > 0.01) {
-    /* uncertainty of the yaw rate is limited by the following:
-     *  - centripetal acceleration a_lat : d(yaw)/dt = w = a_lat/vel_long
-     *  - or maximum slip angle slip_max : w = vel_long*sin(slip_max)/wheel_base
-     */
-    q_stddev_yaw_rate = std::min(
-      motion_params_.q_stddev_acc_lat / vel_long,
-      vel_long * std::sin(motion_params_.q_max_slip_angle) / wheel_base);  // [rad/s]
-    q_stddev_yaw_rate = std::clamp(
-      q_stddev_yaw_rate, motion_params_.q_stddev_yaw_rate_min,
-      motion_params_.q_stddev_yaw_rate_max);
-  }
+  //
+  // Yaw-rate (heading) process noise obeys the nonholonomic constraint: a vehicle cannot change
+  // heading without translating (w = vel_long * tan(steer) / wheel_base), so the yaw-rate
+  // uncertainty must vanish as vel_long -> 0. A stationary vehicle is physically incapable of
+  // turning, hence NO heading noise may be injected at standstill. Injecting a constant floor there
+  // ratchets up the front-point lateral variance (the heading noise feeds q_cov_lat2 -> Q on
+  // X2/Y2 only), which a rear/front partial update cannot pull back -> standstill yaw jitter.
+  const double vel_long_abs = std::abs(vel_long);
+  constexpr double vel_long_eps = 1e-3;  // [m/s] guard against division by zero
+  /* physical yaw-rate bound, limited by the tighter of the two:
+   *  - centripetal acceleration a_lat : w = a_lat / vel_long
+   *  - or maximum slip angle slip_max : w = vel_long * sin(slip_max) / wheel_base  (-> 0 at v -> 0)
+   */
+  const double q_stddev_yaw_rate_phys = std::min(
+    motion_params_.q_stddev_acc_lat / std::max(vel_long_abs, vel_long_eps),
+    vel_long_abs * std::sin(motion_params_.q_max_slip_angle) / wheel_base);  // [rad/s]
+  // Ramp the configured floor in with speed instead of applying it unconditionally, so the floor
+  // -> 0 at standstill (no heading information exists to be tracked) and only reaches its full value
+  // once the vehicle is clearly moving. Above vel_ref this reproduces the original clamp behavior.
+  constexpr double vel_ref = 1.0;  // [m/s] speed at which the yaw-rate floor reaches full value
+  const double yaw_rate_floor =
+    motion_params_.q_stddev_yaw_rate_min * std::clamp(vel_long_abs / vel_ref, 0.0, 1.0);
+  const double q_stddev_yaw_rate = std::clamp(
+    q_stddev_yaw_rate_phys, yaw_rate_floor, motion_params_.q_stddev_yaw_rate_max);
   const double q_stddev_head = q_stddev_yaw_rate * wheel_base * dt;  // yaw uncertainty
 
   const double dt2 = dt * dt;

--- a/perception/autoware_multi_object_tracker/lib/tracker/shape_model/pedestrian_shape_model.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/shape_model/pedestrian_shape_model.cpp
@@ -14,7 +14,7 @@
 
 #include "autoware/multi_object_tracker/tracker/shape_model/pedestrian_shape_model.hpp"
 
-#include "autoware/multi_object_tracker/object_model/shapes.hpp"
+#include "autoware/multi_object_tracker/object_model/shapes_transform.hpp"
 
 #include <algorithm>
 #include <cmath>

--- a/perception/autoware_multi_object_tracker/lib/tracker/shape_model/static_shape_model.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/shape_model/static_shape_model.cpp
@@ -14,7 +14,7 @@
 
 #include "autoware/multi_object_tracker/tracker/shape_model/static_shape_model.hpp"
 
-#include "autoware/multi_object_tracker/object_model/shapes.hpp"
+#include "autoware/multi_object_tracker/object_model/shapes_transform.hpp"
 
 namespace autoware::multi_object_tracker
 {

--- a/perception/autoware_multi_object_tracker/lib/tracker/shape_model/unstable_shape_filter.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/shape_model/unstable_shape_filter.cpp
@@ -14,8 +14,6 @@
 
 #include "autoware/multi_object_tracker/tracker/shape_model/unstable_shape_filter.hpp"
 
-#include "autoware/multi_object_tracker/object_model/shapes.hpp"
-
 #include <cmath>
 
 namespace autoware::multi_object_tracker

--- a/perception/autoware_multi_object_tracker/lib/tracker/shape_model/vehicle_shape_model.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/shape_model/vehicle_shape_model.cpp
@@ -14,7 +14,7 @@
 
 #include "autoware/multi_object_tracker/tracker/shape_model/vehicle_shape_model.hpp"
 
-#include "autoware/multi_object_tracker/object_model/shapes.hpp"
+#include "autoware/multi_object_tracker/object_model/shapes_transform.hpp"
 
 #include <algorithm>
 

--- a/perception/autoware_multi_object_tracker/lib/tracker/trackers/multiple_vehicle_tracker.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/trackers/multiple_vehicle_tracker.cpp
@@ -48,13 +48,11 @@ bool MultipleVehicleTracker::measure(
 
 bool MultipleVehicleTracker::conditionedUpdate(
   const types::DynamicObject & measurement, const types::DynamicObject & prediction,
-  const autoware_perception_msgs::msg::Shape & tracker_shape, const rclcpp::Time & measurement_time,
-  const types::InputChannel & channel_info)
+  const rclcpp::Time & measurement_time, const types::InputChannel & channel_info)
 {
-  big_vehicle_tracker_.conditionedUpdate(
-    measurement, prediction, tracker_shape, measurement_time, channel_info);
+  big_vehicle_tracker_.conditionedUpdate(measurement, prediction, measurement_time, channel_info);
   normal_vehicle_tracker_.conditionedUpdate(
-    measurement, prediction, tracker_shape, measurement_time, channel_info);
+    measurement, prediction, measurement_time, channel_info);
   big_vehicle_tracker_.setLatestMeasurementTime(measurement_time);
   normal_vehicle_tracker_.setLatestMeasurementTime(measurement_time);
 

--- a/perception/autoware_multi_object_tracker/lib/tracker/trackers/tracker_base.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/trackers/tracker_base.cpp
@@ -226,15 +226,13 @@ bool Tracker::updateWithMeasurement(
       // The current (assembled) shape serves as the conditioned-update reference shape.
       types::DynamicObject predicted_object;
       getTrackedObject(measurement_time, predicted_object);
-      conditionedUpdate(
-        object, predicted_object, predicted_object.shape, measurement_time, channel_info);
+      conditionedUpdate(object, predicted_object, measurement_time, channel_info);
     }
 
   } else {  // UpdatePath::CONDITIONED
     types::DynamicObject predicted_object;
     getTrackedObject(measurement_time, predicted_object);
-    conditionedUpdate(
-      object, predicted_object, predicted_object.shape, measurement_time, channel_info);
+    conditionedUpdate(object, predicted_object, measurement_time, channel_info);
   }
 
   return true;
@@ -599,12 +597,10 @@ double Tracker::getPositionCovarianceDeterminant() const
 
 bool Tracker::conditionedUpdate(
   const types::DynamicObject & measurement, const types::DynamicObject & prediction,
-  const autoware_perception_msgs::msg::Shape & tracker_shape, const rclcpp::Time & measurement_time,
-  const types::InputChannel & channel_info)
+  const rclcpp::Time & measurement_time, const types::InputChannel & channel_info)
 {
   (void)measurement;
   (void)prediction;
-  (void)tracker_shape;
   (void)measurement_time;
   (void)channel_info;
   RCLCPP_ERROR(

--- a/perception/autoware_multi_object_tracker/lib/tracker/trackers/vehicle_tracker.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/trackers/vehicle_tracker.cpp
@@ -209,32 +209,12 @@ bool VehicleTracker::updateWheelKinematics(
 {
   std::array<double, 36> pose_cov = measurement.pose_covariance;
 
-  // Lateral correction for the observed edge center when the polygon width disagrees with the
-  // tracked width (partial view -> narrower, merged/over-segmented cluster -> wider). The wheel
-  // update measures the front/rear edge center; a biased lateral center is amplified into yaw
-  // through the wheel-base lever. correctWheelAnchorLateral() nudges the anchor (over-wide
-  // "back-lash" dead-zone) and reports the extra lateral variance to add. See its documentation.
-  geometry_msgs::msg::Point anchor_point = strategy.anchor_point;
-  {
-    using autoware_utils_geometry::xyzrpy_covariance_index::XYZRPY_COV_IDX;
-    constexpr double balance_alpha = 0.2;  // hold-tracker slope inside the dead-zone
-    constexpr double corner_residual_beta =
-      0.3;  // residual std fraction once the corner is matched
-    const double yaw = motion_model_.getYawState();
-    const auto corr = correctWheelAnchorLateral(
-      yaw, shape_model_.getWidth(), prediction.pose.position, measurement.shape.dimensions.y,
-      strategy.anchor_point, balance_alpha, corner_residual_beta);
-    anchor_point = corr.anchor;
-
-    const double var_lat = corr.var_lat;
-    const double s = std::sin(yaw);
-    const double c = std::cos(yaw);
-    // lateral unit vector n = (-sin(yaw), cos(yaw)); add var_lat * n * n^T to the x/y block
-    pose_cov[XYZRPY_COV_IDX::X_X] += var_lat * s * s;
-    pose_cov[XYZRPY_COV_IDX::X_Y] += -var_lat * s * c;
-    pose_cov[XYZRPY_COV_IDX::Y_X] += -var_lat * s * c;
-    pose_cov[XYZRPY_COV_IDX::Y_Y] += var_lat * c * c;
-  }
+  // When polygon and tracked widths disagree, the observed edge center is a biased lateral
+  // measurement that the wheel-base lever amplifies into yaw. correctWheelAnchor() nudges the
+  // anchor and folds the extra lateral variance into pose_cov.
+  const geometry_msgs::msg::Point anchor_point = correctWheelAnchor(
+    motion_model_.getYawState(), prediction.shape.dimensions.y, prediction.pose.position,
+    measurement.shape.dimensions.y, strategy.anchor_point, pose_cov);
 
   const bool measure_front = strategy.type == UpdateStrategyType::FRONT_WHEEL_UPDATE;
   shape_update_anchor_ = measure_front ? BicycleMotionModel::LengthUpdateAnchor::FRONT
@@ -323,8 +303,7 @@ bool VehicleTracker::getTrackedObject(
 
 bool VehicleTracker::conditionedUpdate(
   const types::DynamicObject & measurement, const types::DynamicObject & prediction,
-  const autoware_perception_msgs::msg::Shape & tracker_shape, const rclcpp::Time & measurement_time,
-  const types::InputChannel & channel_info)
+  const rclcpp::Time & measurement_time, const types::InputChannel & channel_info)
 {
   const auto aligned = shapes::alignClusterToOrientation(measurement, motion_model_.getYawState());
   const types::DynamicObject & meas = aligned ? *aligned : measurement;
@@ -332,8 +311,8 @@ bool VehicleTracker::conditionedUpdate(
   UpdateStrategy strategy = determineUpdateStrategy(meas, prediction);
 
   if (strategy.type == UpdateStrategyType::WEAK_UPDATE) {
-    types::DynamicObject pseudo_measurement = prediction;
-    createPseudoMeasurement(measurement, pseudo_measurement, tracker_shape, true);
+    const types::DynamicObject pseudo_measurement =
+      createPseudoMeasurement(measurement, prediction, true);
 
     const types::DynamicObject pseudo_corrected =
       normalizeYaw(pseudo_measurement, motion_model_.getYawState());

--- a/perception/autoware_multi_object_tracker/lib/tracker/trackers/vehicle_tracker.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/trackers/vehicle_tracker.cpp
@@ -17,7 +17,7 @@
 #include "autoware/multi_object_tracker/tracker/trackers/vehicle_tracker.hpp"
 
 #include "autoware/multi_object_tracker/object_model/object_model.hpp"
-#include "autoware/multi_object_tracker/object_model/shapes.hpp"
+#include "autoware/multi_object_tracker/object_model/shapes_transform.hpp"
 
 #include <autoware_utils_math/normalization.hpp>
 #include <autoware_utils_math/unit_conversion.hpp>

--- a/perception/autoware_multi_object_tracker/lib/tracker/trackers/vehicle_tracker.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/trackers/vehicle_tracker.cpp
@@ -207,14 +207,12 @@ bool VehicleTracker::updateWheelKinematics(
   const UpdateStrategy & strategy, const types::DynamicObject & measurement,
   const types::DynamicObject & prediction)
 {
-  std::array<double, 36> pose_cov = measurement.pose_covariance;
-
   // When polygon and tracked widths disagree, the observed edge center is a biased lateral
   // measurement that the wheel-base lever amplifies into yaw. correctWheelAnchor() nudges the
   // anchor and folds the extra lateral variance into pose_cov.
-  const geometry_msgs::msg::Point anchor_point = correctWheelAnchor(
-    motion_model_.getYawState(), prediction.shape.dimensions.y, prediction.pose.position,
-    measurement.shape.dimensions.y, strategy.anchor_point, pose_cov);
+  std::array<double, 36> pose_cov = measurement.pose_covariance;
+  const geometry_msgs::msg::Point anchor_point =
+    correctWheelAnchor(prediction, measurement.shape.dimensions.y, strategy.anchor_point, pose_cov);
 
   const bool measure_front = strategy.type == UpdateStrategyType::FRONT_WHEEL_UPDATE;
   shape_update_anchor_ = measure_front ? BicycleMotionModel::LengthUpdateAnchor::FRONT

--- a/perception/autoware_multi_object_tracker/lib/tracker/trackers/vehicle_tracker.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/trackers/vehicle_tracker.cpp
@@ -236,14 +236,11 @@ bool VehicleTracker::updateWheelKinematics(
     pose_cov[XYZRPY_COV_IDX::Y_Y] += var_lat * c * c;
   }
 
-  bool is_updated = false;
-  if (strategy.type == UpdateStrategyType::FRONT_WHEEL_UPDATE) {
-    shape_update_anchor_ = BicycleMotionModel::LengthUpdateAnchor::FRONT;
-    is_updated = motion_model_.updateStatePoseFront(anchor_point.x, anchor_point.y, pose_cov);
-  } else {
-    shape_update_anchor_ = BicycleMotionModel::LengthUpdateAnchor::REAR;
-    is_updated = motion_model_.updateStatePoseRear(anchor_point.x, anchor_point.y, pose_cov);
-  }
+  const bool measure_front = strategy.type == UpdateStrategyType::FRONT_WHEEL_UPDATE;
+  shape_update_anchor_ = measure_front ? BicycleMotionModel::LengthUpdateAnchor::FRONT
+                                       : BicycleMotionModel::LengthUpdateAnchor::REAR;
+  const bool is_updated =
+    motion_model_.updateStatePoseWheel(anchor_point.x, anchor_point.y, pose_cov, measure_front);
   // Wheel-anchor EKF only updates x/y; z position and height are applied here.
   constexpr double z_gain = 0.4;
   motion_model_.updateZ(measurement.pose.position.z, z_gain);

--- a/perception/autoware_multi_object_tracker/lib/tracker/trackers/vehicle_tracker.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/trackers/vehicle_tracker.cpp
@@ -207,6 +207,33 @@ bool VehicleTracker::updateWheelKinematics(
   const UpdateStrategy & strategy, const types::DynamicObject & measurement)
 {
   std::array<double, 36> pose_cov = measurement.pose_covariance;
+
+  // Partial-edge lateral uncertainty.
+  // The wheel-anchor update measures the center of the observed front/rear edge. When the polygon
+  // is only partially visible, its width is narrower than the tracked object and the observed edge
+  // center is shifted laterally from the true center by an unknown amount of up to
+  // (object_width - polygon_width)/2. That lateral error is amplified into yaw through the
+  // wheel-base lever, so add the worst-case lateral offset as extra variance along the body lateral
+  // axis (perpendicular to heading) to the measurement covariance.
+  {
+    using autoware_utils_geometry::xyzrpy_covariance_index::XYZRPY_COV_IDX;
+    const double object_width = shape_model_.getWidth();
+    const double polygon_width = measurement.shape.dimensions.y;
+    const double width_gap = std::max(0.0, object_width - polygon_width);
+    if (width_gap > 0.0) {
+      const double half_gap = 0.5 * width_gap;
+      const double var_lat = half_gap * half_gap;  // conservative: std = worst-case lateral offset
+      const double yaw = motion_model_.getYawState();
+      const double s = std::sin(yaw);
+      const double c = std::cos(yaw);
+      // lateral unit vector n = (-sin(yaw), cos(yaw)); add var_lat * n * n^T to the x/y block
+      pose_cov[XYZRPY_COV_IDX::X_X] += var_lat * s * s;
+      pose_cov[XYZRPY_COV_IDX::X_Y] += -var_lat * s * c;
+      pose_cov[XYZRPY_COV_IDX::Y_X] += -var_lat * s * c;
+      pose_cov[XYZRPY_COV_IDX::Y_Y] += var_lat * c * c;
+    }
+  }
+
   bool is_updated = false;
   if (strategy.type == UpdateStrategyType::FRONT_WHEEL_UPDATE) {
     shape_update_anchor_ = BicycleMotionModel::LengthUpdateAnchor::FRONT;

--- a/perception/autoware_multi_object_tracker/lib/tracker/trackers/vehicle_tracker.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/trackers/vehicle_tracker.cpp
@@ -204,45 +204,45 @@ bool VehicleTracker::updateKinematics(
 }
 
 bool VehicleTracker::updateWheelKinematics(
-  const UpdateStrategy & strategy, const types::DynamicObject & measurement)
+  const UpdateStrategy & strategy, const types::DynamicObject & measurement,
+  const types::DynamicObject & prediction)
 {
   std::array<double, 36> pose_cov = measurement.pose_covariance;
 
-  // Partial-edge lateral uncertainty.
-  // The wheel-anchor update measures the center of the observed front/rear edge. When the polygon
-  // is only partially visible, its width is narrower than the tracked object and the observed edge
-  // center is shifted laterally from the true center by an unknown amount of up to
-  // (object_width - polygon_width)/2. That lateral error is amplified into yaw through the
-  // wheel-base lever, so add the worst-case lateral offset as extra variance along the body lateral
-  // axis (perpendicular to heading) to the measurement covariance.
+  // Lateral correction for the observed edge center when the polygon width disagrees with the
+  // tracked width (partial view -> narrower, merged/over-segmented cluster -> wider). The wheel
+  // update measures the front/rear edge center; a biased lateral center is amplified into yaw
+  // through the wheel-base lever. correctWheelAnchorLateral() nudges the anchor (over-wide
+  // "back-lash" dead-zone) and reports the extra lateral variance to add. See its documentation.
+  geometry_msgs::msg::Point anchor_point = strategy.anchor_point;
   {
     using autoware_utils_geometry::xyzrpy_covariance_index::XYZRPY_COV_IDX;
-    const double object_width = shape_model_.getWidth();
-    const double polygon_width = measurement.shape.dimensions.y;
-    const double width_gap = std::max(0.0, object_width - polygon_width);
-    if (width_gap > 0.0) {
-      const double half_gap = 0.5 * width_gap;
-      const double var_lat = half_gap * half_gap;  // conservative: std = worst-case lateral offset
-      const double yaw = motion_model_.getYawState();
-      const double s = std::sin(yaw);
-      const double c = std::cos(yaw);
-      // lateral unit vector n = (-sin(yaw), cos(yaw)); add var_lat * n * n^T to the x/y block
-      pose_cov[XYZRPY_COV_IDX::X_X] += var_lat * s * s;
-      pose_cov[XYZRPY_COV_IDX::X_Y] += -var_lat * s * c;
-      pose_cov[XYZRPY_COV_IDX::Y_X] += -var_lat * s * c;
-      pose_cov[XYZRPY_COV_IDX::Y_Y] += var_lat * c * c;
-    }
+    constexpr double balance_alpha = 0.2;  // hold-tracker slope inside the dead-zone
+    constexpr double corner_residual_beta =
+      0.3;  // residual std fraction once the corner is matched
+    const double yaw = motion_model_.getYawState();
+    const auto corr = correctWheelAnchorLateral(
+      yaw, shape_model_.getWidth(), prediction.pose.position, measurement.shape.dimensions.y,
+      strategy.anchor_point, balance_alpha, corner_residual_beta);
+    anchor_point = corr.anchor;
+
+    const double var_lat = corr.var_lat;
+    const double s = std::sin(yaw);
+    const double c = std::cos(yaw);
+    // lateral unit vector n = (-sin(yaw), cos(yaw)); add var_lat * n * n^T to the x/y block
+    pose_cov[XYZRPY_COV_IDX::X_X] += var_lat * s * s;
+    pose_cov[XYZRPY_COV_IDX::X_Y] += -var_lat * s * c;
+    pose_cov[XYZRPY_COV_IDX::Y_X] += -var_lat * s * c;
+    pose_cov[XYZRPY_COV_IDX::Y_Y] += var_lat * c * c;
   }
 
   bool is_updated = false;
   if (strategy.type == UpdateStrategyType::FRONT_WHEEL_UPDATE) {
     shape_update_anchor_ = BicycleMotionModel::LengthUpdateAnchor::FRONT;
-    is_updated = motion_model_.updateStatePoseFront(
-      strategy.anchor_point.x, strategy.anchor_point.y, pose_cov);
+    is_updated = motion_model_.updateStatePoseFront(anchor_point.x, anchor_point.y, pose_cov);
   } else {
     shape_update_anchor_ = BicycleMotionModel::LengthUpdateAnchor::REAR;
-    is_updated =
-      motion_model_.updateStatePoseRear(strategy.anchor_point.x, strategy.anchor_point.y, pose_cov);
+    is_updated = motion_model_.updateStatePoseRear(anchor_point.x, anchor_point.y, pose_cov);
   }
   // Wheel-anchor EKF only updates x/y; z position and height are applied here.
   constexpr double z_gain = 0.4;
@@ -359,7 +359,9 @@ bool VehicleTracker::conditionedUpdate(
     return true;
   }
 
-  const bool is_updated = updateWheelKinematics(strategy, measurement);
+  // Use the aligned measurement so the polygon width/anchor are expressed in the tracker frame
+  // (raw cluster dimensions.y is in the cluster's own local frame).
+  const bool is_updated = updateWheelKinematics(strategy, meas, prediction);
 
   geometry_msgs::msg::Pose tracker_pose;
   std::array<double, 36> dummy_cov{};

--- a/perception/autoware_multi_object_tracker/lib/tracker/update/vehicle_update_strategy.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/update/vehicle_update_strategy.cpp
@@ -220,39 +220,30 @@ double correctWheelAnchorLateral(
   const double tracker_left, const double tracker_right, const double polygon_left,
   const double polygon_right, double & var_lat)
 {
-  constexpr double balance_alpha = 0.2;         // hold-tracker slope inside the dead-zone
-  constexpr double corner_residual_beta = 0.3;  // residual std fraction once the corner is matched
+  const double tracker_center = 0.5 * (tracker_left + tracker_right);
+  const double polygon_center = 0.5 * (polygon_left + polygon_right);
 
-  // Per-side overhang of the polygon beyond the tracker box (positive = the polygon edge sticks out
-  // past the tracker boundary on that side). The two overhangs fully describe the lateral geometry:
-  //   slack          = half the total overhang     = how far the tracker can slide inside the polygon
-  //   lateral_offset = half the overhang asymmetry  = edge-center bias from the tracker center
-  const double overhang_left = polygon_left - tracker_left;
-  const double overhang_right = tracker_right - polygon_right;
-  const double slack = 0.5 * (overhang_left + overhang_right);
-  const double lateral_offset = 0.5 * (overhang_left - overhang_right);
+  // Two candidate vehicle centers, one per side, obtained by aligning the tracker box (kept at its
+  // own width) to each polygon edge. The true center must lie on the segment between them; that
+  // segment is the lateral "dead-zone" whose width equals |polygon_width - tracker_width|.
+  const double center_from_left = polygon_left - tracker_left;
+  const double center_from_right = polygon_right - tracker_right;
+  const double low = std::min(center_from_left, center_from_right);
+  const double high = std::max(center_from_left, center_from_right);
 
-  if (slack <= 0.0) {
-    // Polygon narrower than (or equal to) the tracker: partial view. Keep the anchor (no move) and
-    // add the worst-case lateral offset (half the missing width) as variance.
-    const double half_gap = -slack;  // = 0.5 * (tracker_width - polygon_width) >= 0
-    var_lat = half_gap * half_gap;
-    return 0.0;
-  }
+  // Project the tracker center into the dead-zone:
+  //  - inside  -> hold it (polygon straddles, or is straddled by, the tracker on both sides)
+  //  - outside -> snap to the nearest edge-aligned center; the closer polygon edge is taken as a
+  //               real vehicle edge and the box slides by that overhang (tracker_center +
+  //               overhang).
+  const double target = std::clamp(tracker_center, low, high);
 
-  // Polygon wider than the tracker: soft dead-zone ("back-lash") lateral correction. The tracker box
-  // can slide within the polygon by up to `slack` on either side before a corner is exposed
-  // Clamping `lateral_offset` to [-slack, slack] expresses both regimes in one line.
-  const double clamped_offset = std::clamp(lateral_offset, -slack, slack);
-  const double lateral_move = -(1.0 - balance_alpha) * clamped_offset;
+  // Lateral position is unknown across the dead-zone, so its variance grows with the dead-zone
+  // size: std = half the dead-zone width = 0.5 * |polygon_width - tracker_width|.
+  const double half_dead_zone = 0.5 * (high - low);
+  var_lat = half_dead_zone * half_dead_zone;
 
-  // Added lateral std: `slack` when centered (true position unknown across the slack), shrinking to
-  // `corner_residual_beta` * slack once the corner is matched. `|clamped_offset| / slack` runs 0 -> 1
-  // as the bias grows from centered to a fully exposed corner.
-  const double t = std::abs(clamped_offset) / slack;
-  const double std_lat = slack * (1.0 - (1.0 - corner_residual_beta) * t);
-  var_lat = std_lat * std_lat;
-  return lateral_move;
+  return target - polygon_center;
 }
 
 geometry_msgs::msg::Point correctWheelAnchor(

--- a/perception/autoware_multi_object_tracker/lib/tracker/update/vehicle_update_strategy.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/update/vehicle_update_strategy.cpp
@@ -229,7 +229,8 @@ double correctWheelAnchorLateral(
   // Project the tracker center (0) into the dead-zone.
   const double target = std::clamp(0.0, low, high);
 
-  // Variance = (dead-zone half-width)^2: the std equals the half-width by which the center may move.
+  // Variance = (dead-zone half-width)^2: the std equals the half-width by which the center may
+  // move.
   var_lat = half_dead_zone * half_dead_zone;
 
   return target - anchor_lateral;

--- a/perception/autoware_multi_object_tracker/lib/tracker/update/vehicle_update_strategy.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/update/vehicle_update_strategy.cpp
@@ -153,10 +153,12 @@ UpdateStrategy determineUpdateStrategy(
   return strategy;
 }
 
-void createPseudoMeasurement(
-  const types::DynamicObject & meas, types::DynamicObject & pred,
-  const autoware_perception_msgs::msg::Shape & tracker_shape, const bool enlarge_covariance)
+types::DynamicObject createPseudoMeasurement(
+  const types::DynamicObject & meas, const types::DynamicObject & prediction,
+  const bool enlarge_covariance)
 {
+  types::DynamicObject pred = prediction;
+
   // Apply linear fall‑off weight on dist square
   const double dx = meas.pose.position.x - pred.pose.position.x;
   const double dy = meas.pose.position.y - pred.pose.position.y;
@@ -170,9 +172,8 @@ void createPseudoMeasurement(
   pred.pose.position.y = pred.pose.position.y * (1 - w_pose) + meas.pose.position.y * w_pose;
   pred.pose.position.z = pred.pose.position.z * (1 - w_pose) + meas.pose.position.z * w_pose;
 
-  // Use smoothed shape and its area
-  pred.shape = tracker_shape;
-  pred.area = types::getArea(tracker_shape);
+  // Refresh the area from pred's (tracker) shape
+  pred.area = types::getArea(pred.shape);
 
   // Blend orientation
   if (meas.kinematics.orientation_availability != types::OrientationAvailability::UNAVAILABLE) {
@@ -211,6 +212,8 @@ void createPseudoMeasurement(
       pred.twist_covariance[XYZRPY_COV_IDX::Y_Y] += additional_velocity_cov;
     }
   }
+
+  return pred;
 }
 
 WheelAnchorLateral correctWheelAnchorLateral(
@@ -252,6 +255,29 @@ WheelAnchorLateral correctWheelAnchorLateral(
   const double std_lat = slack * (1.0 - (1.0 - corner_residual_beta) * t);
   result.var_lat = std_lat * std_lat;
   return result;
+}
+
+geometry_msgs::msg::Point correctWheelAnchor(
+  double yaw, double tracker_width, const geometry_msgs::msg::Point & tracker_center,
+  double polygon_width, const geometry_msgs::msg::Point & anchor, std::array<double, 36> & pose_cov)
+{
+  using autoware_utils_geometry::xyzrpy_covariance_index::XYZRPY_COV_IDX;
+  constexpr double balance_alpha = 0.2;         // hold-tracker slope inside the dead-zone
+  constexpr double corner_residual_beta = 0.3;  // residual std fraction once the corner is matched
+
+  const auto corr = correctWheelAnchorLateral(
+    yaw, tracker_width, tracker_center, polygon_width, anchor, balance_alpha, corner_residual_beta);
+
+  const double var_lat = corr.var_lat;
+  const double sin_yaw = std::sin(yaw);
+  const double cos_yaw = std::cos(yaw);
+  // lateral unit vector n = (-sin(yaw), cos(yaw)); add var_lat * n * n^T to the x/y block
+  pose_cov[XYZRPY_COV_IDX::X_X] += var_lat * sin_yaw * sin_yaw;
+  pose_cov[XYZRPY_COV_IDX::X_Y] += -var_lat * sin_yaw * cos_yaw;
+  pose_cov[XYZRPY_COV_IDX::Y_X] += -var_lat * sin_yaw * cos_yaw;
+  pose_cov[XYZRPY_COV_IDX::Y_Y] += var_lat * cos_yaw * cos_yaw;
+
+  return corr.anchor;
 }
 
 }  // namespace autoware::multi_object_tracker

--- a/perception/autoware_multi_object_tracker/lib/tracker/update/vehicle_update_strategy.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/update/vehicle_update_strategy.cpp
@@ -213,4 +213,45 @@ void createPseudoMeasurement(
   }
 }
 
+WheelAnchorLateral correctWheelAnchorLateral(
+  double yaw, double tracker_width, const geometry_msgs::msg::Point & tracker_center,
+  double polygon_width, const geometry_msgs::msg::Point & anchor, double balance_alpha,
+  double corner_residual_beta)
+{
+  WheelAnchorLateral result{anchor, 0.0};
+
+  const double slack = 0.5 * (polygon_width - tracker_width);
+  if (slack <= 0.0) {
+    // Polygon narrower than (or equal to) the tracker: partial view. Keep the anchor and add the
+    // worst-case lateral offset (half the missing width) as variance.
+    const double half_gap = -slack;  // = 0.5 * (tracker_width - polygon_width) >= 0
+    result.var_lat = half_gap * half_gap;
+    return result;
+  }
+
+  // Polygon wider than the tracker: soft dead-zone ("back-lash") lateral correction.
+  const double sin_yaw = std::sin(yaw);
+  const double cos_yaw = std::cos(yaw);
+  // Signed lateral offset of the observed edge center from the tracker center, along the body
+  // lateral axis n = (-sin yaw, cos yaw). The longitudinal component is orthogonal to n and drops.
+  const double d =
+    -(anchor.x - tracker_center.x) * sin_yaw + (anchor.y - tracker_center.y) * cos_yaw;
+  const double ad = std::abs(d);
+  const double sgn = (d >= 0.0) ? 1.0 : -1.0;
+
+  // Soft dead-zone: slope `balance_alpha` while contained (|d| <= slack), unit slope once the
+  // corner is exposed. Continuous at |d| = slack.
+  const double shift = (ad <= slack) ? balance_alpha * ad : (ad - slack) + balance_alpha * slack;
+  const double lateral_move = sgn * shift - d;  // (corrected - observed) lateral offset, along n
+  result.anchor.x = anchor.x - lateral_move * sin_yaw;
+  result.anchor.y = anchor.y + lateral_move * cos_yaw;
+
+  // Added lateral std: `slack` when centered (true position unknown across the slack), shrinking to
+  // `corner_residual_beta` * slack once the corner is matched. Continuous in |d|.
+  const double t = std::clamp(ad / slack, 0.0, 1.0);
+  const double std_lat = slack * (1.0 - (1.0 - corner_residual_beta) * t);
+  result.var_lat = std_lat * std_lat;
+  return result;
+}
+
 }  // namespace autoware::multi_object_tracker

--- a/perception/autoware_multi_object_tracker/lib/tracker/update/vehicle_update_strategy.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/update/vehicle_update_strategy.cpp
@@ -240,20 +240,16 @@ double correctWheelAnchorLateral(
     return 0.0;
   }
 
-  // Polygon wider than the tracker: soft dead-zone ("back-lash") lateral correction.
-  const double abs_offset = std::abs(lateral_offset);
-  const double sgn = (lateral_offset >= 0.0) ? 1.0 : -1.0;
-
-  // Soft dead-zone: slope `balance_alpha` while the tracker is contained (|offset| <= slack), unit
-  // slope once a corner is exposed. Continuous at |offset| = slack.
-  const double shift = (abs_offset <= slack) ? balance_alpha * abs_offset
-                                             : (abs_offset - slack) + balance_alpha * slack;
-  const double lateral_move =
-    sgn * shift - lateral_offset;  // (corrected - observed) lateral offset
+  // Polygon wider than the tracker: soft dead-zone ("back-lash") lateral correction. The tracker box
+  // can slide within the polygon by up to `slack` on either side before a corner is exposed
+  // Clamping `lateral_offset` to [-slack, slack] expresses both regimes in one line.
+  const double clamped_offset = std::clamp(lateral_offset, -slack, slack);
+  const double lateral_move = -(1.0 - balance_alpha) * clamped_offset;
 
   // Added lateral std: `slack` when centered (true position unknown across the slack), shrinking to
-  // `corner_residual_beta` * slack once the corner is matched. Continuous in |offset|.
-  const double t = std::clamp(abs_offset / slack, 0.0, 1.0);
+  // `corner_residual_beta` * slack once the corner is matched. `|clamped_offset| / slack` runs 0 -> 1
+  // as the bias grows from centered to a fully exposed corner.
+  const double t = std::abs(clamped_offset) / slack;
   const double std_lat = slack * (1.0 - (1.0 - corner_residual_beta) * t);
   var_lat = std_lat * std_lat;
   return lateral_move;

--- a/perception/autoware_multi_object_tracker/lib/tracker/update/vehicle_update_strategy.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/update/vehicle_update_strategy.cpp
@@ -222,15 +222,16 @@ double correctWheelAnchorLateral(
 {
   // Zone boundaries as fractions of tracker half-width H:
   //   dead zone: half-width-miss or per-side excess ≤ 0.20·H → no correction
-  //   inner (zone 2): polygon_width < 0.80·tracker_width → weight based on half-width-miss only
-  //     full match at polygon_width = 0.50·tracker_width (half-width-miss = 0.50·H)
+  //   inner (zone 2): polygon_width ≤ tracker_width → center-pull by half-width-miss weight,
+  //     suppressed when a close side (gap < 0.20·H) is visible; close-side correction then
+  //     aligns that edge with the tracker boundary (full alignment at gap = 0)
   //   outer (zone 3): per-side excess > 0.20·H → full match at excess = 0.40·H (140% of H)
-  constexpr double DEAD_ZONE_FRAC  = 0.20;
+  constexpr double DEAD_ZONE_FRAC = 0.20;
   constexpr double FULL_INNER_FRAC = 0.50;
   constexpr double FULL_OUTER_FRAC = 0.40;
 
-  const double H         = (tracker_L - tracker_R) * 0.5;
-  const double dead_lat  = DEAD_ZONE_FRAC * H;
+  const double H = (tracker_L - tracker_R) * 0.5;
+  const double dead_lat = DEAD_ZONE_FRAC * H;
   const double inner_lat = FULL_INNER_FRAC * H;
   const double outer_lat = FULL_OUTER_FRAC * H;
 
@@ -239,20 +240,37 @@ double correctWheelAnchorLateral(
 
   if (polygon_width <= tracker_width) {
     // Inner zone: polygon narrower than tracker.
-    // Weight is based on the symmetric half-width-miss so it does not depend on lateral_offset,
-    // avoiding the oscillation that per-side excess weights produce when a narrow polygon shifts.
     const double half_width_miss = (tracker_width - polygon_width) * 0.5;
-    const double t_inner = (half_width_miss > dead_lat)
-                             ? std::clamp(
-                                 (half_width_miss - dead_lat) / (inner_lat - dead_lat), 0.0, 1.0)
-                             : 0.0;
-    // Correction: pull the anchor toward the tracker center proportional to its lateral offset.
-    // lateral_offset = (polygon_L + polygon_R) / 2; at t=1 the anchor snaps to center.
+    const double t_inner =
+      (half_width_miss > dead_lat)
+        ? std::clamp((half_width_miss - dead_lat) / (inner_lat - dead_lat), 0.0, 1.0)
+        : 0.0;
+
+    // Per-side gap: signed distance from each polygon edge to the corresponding tracker boundary.
+    // Positive = polygon edge is inside the tracker; negative = polygon edge protrudes beyond.
+    const double gap_L = tracker_L - polygon_L;
+    const double gap_R = polygon_R - tracker_R;
+
+    // Close-side weight: 1 when the polygon edge is AT the tracker boundary (gap = 0, or
+    // protrudes), decreasing to 0 as the gap grows to dead_lat (boundary no longer visible).
+    const double t_close_L =
+      (gap_L < dead_lat) ? std::clamp((dead_lat - gap_L) / dead_lat, 0.0, 1.0) : 0.0;
+    const double t_close_R =
+      (gap_R < dead_lat) ? std::clamp((dead_lat - gap_R) / dead_lat, 0.0, 1.0) : 0.0;
+    const double t_close = std::max(t_close_L, t_close_R);
+
+    // Center-pull suppressed proportionally to the close-side confidence: when one boundary
+    // is directly observable, pulling to center would introduce error.
+    const double effective_t_inner = t_inner * (1.0 - t_close);
     const double lateral_offset = (polygon_L + polygon_R) * 0.5;
-    // Uncorrected residual is also width-based to stay consistent.
-    const double resid = half_width_miss * (1.0 - t_inner);
+
+    // Close-side correction: pull the anchor to align each near edge with its tracker boundary.
+    // gap_L * t_close_L shifts left; gap_R * t_close_R shifts right (subtracted).
+    const double close_correction = gap_L * t_close_L - gap_R * t_close_R;
+
+    const double resid = half_width_miss * (1.0 - effective_t_inner);
     var_lat = 2.0 * resid * resid;
-    return -lateral_offset * t_inner;
+    return -lateral_offset * effective_t_inner + close_correction;
   }
 
   // Outer zone: polygon wider than tracker.
@@ -261,9 +279,8 @@ double correctWheelAnchorLateral(
   const double excess_R = tracker_R - polygon_R;
 
   const auto outer_weight = [&](const double excess) -> double {
-    return (excess > dead_lat)
-             ? std::clamp((excess - dead_lat) / (outer_lat - dead_lat), 0.0, 1.0)
-             : 0.0;
+    return (excess > dead_lat) ? std::clamp((excess - dead_lat) / (outer_lat - dead_lat), 0.0, 1.0)
+                               : 0.0;
   };
   const double t_L = outer_weight(excess_L);
   const double t_R = outer_weight(excess_R);

--- a/perception/autoware_multi_object_tracker/lib/tracker/update/vehicle_update_strategy.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/update/vehicle_update_strategy.cpp
@@ -216,68 +216,74 @@ types::DynamicObject createPseudoMeasurement(
   return pred;
 }
 
-WheelAnchorLateral correctWheelAnchorLateral(
-  double yaw, double tracker_width, const geometry_msgs::msg::Point & tracker_center,
-  double polygon_width, const geometry_msgs::msg::Point & anchor, double balance_alpha,
-  double corner_residual_beta)
+double correctWheelAnchorLateral(
+  const double lateral_offset, const double tracker_width, const double polygon_width,
+  double & var_lat)
 {
-  WheelAnchorLateral result{anchor, 0.0};
-
-  const double slack = 0.5 * (polygon_width - tracker_width);
-  if (slack <= 0.0) {
-    // Polygon narrower than (or equal to) the tracker: partial view. Keep the anchor and add the
-    // worst-case lateral offset (half the missing width) as variance.
-    const double half_gap = -slack;  // = 0.5 * (tracker_width - polygon_width) >= 0
-    result.var_lat = half_gap * half_gap;
-    return result;
-  }
-
-  // Polygon wider than the tracker: soft dead-zone ("back-lash") lateral correction.
-  const double sin_yaw = std::sin(yaw);
-  const double cos_yaw = std::cos(yaw);
-  // Signed lateral offset of the observed edge center from the tracker center, along the body
-  // lateral axis n = (-sin yaw, cos yaw). The longitudinal component is orthogonal to n and drops.
-  const double d =
-    -(anchor.x - tracker_center.x) * sin_yaw + (anchor.y - tracker_center.y) * cos_yaw;
-  const double ad = std::abs(d);
-  const double sgn = (d >= 0.0) ? 1.0 : -1.0;
-
-  // Soft dead-zone: slope `balance_alpha` while contained (|d| <= slack), unit slope once the
-  // corner is exposed. Continuous at |d| = slack.
-  const double shift = (ad <= slack) ? balance_alpha * ad : (ad - slack) + balance_alpha * slack;
-  const double lateral_move = sgn * shift - d;  // (corrected - observed) lateral offset, along n
-  result.anchor.x = anchor.x - lateral_move * sin_yaw;
-  result.anchor.y = anchor.y + lateral_move * cos_yaw;
-
-  // Added lateral std: `slack` when centered (true position unknown across the slack), shrinking to
-  // `corner_residual_beta` * slack once the corner is matched. Continuous in |d|.
-  const double t = std::clamp(ad / slack, 0.0, 1.0);
-  const double std_lat = slack * (1.0 - (1.0 - corner_residual_beta) * t);
-  result.var_lat = std_lat * std_lat;
-  return result;
-}
-
-geometry_msgs::msg::Point correctWheelAnchor(
-  double yaw, double tracker_width, const geometry_msgs::msg::Point & tracker_center,
-  double polygon_width, const geometry_msgs::msg::Point & anchor, std::array<double, 36> & pose_cov)
-{
-  using autoware_utils_geometry::xyzrpy_covariance_index::XYZRPY_COV_IDX;
   constexpr double balance_alpha = 0.2;         // hold-tracker slope inside the dead-zone
   constexpr double corner_residual_beta = 0.3;  // residual std fraction once the corner is matched
 
-  const auto corr = correctWheelAnchorLateral(
-    yaw, tracker_width, tracker_center, polygon_width, anchor, balance_alpha, corner_residual_beta);
+  const double slack = 0.5 * (polygon_width - tracker_width);
+  if (slack <= 0.0) {
+    // Polygon narrower than (or equal to) the tracker: partial view. Keep the anchor (no move) and
+    // add the worst-case lateral offset (half the missing width) as variance.
+    const double half_gap = -slack;  // = 0.5 * (tracker_width - polygon_width) >= 0
+    var_lat = half_gap * half_gap;
+    return 0.0;
+  }
 
-  const double var_lat = corr.var_lat;
+  // Polygon wider than the tracker: soft dead-zone ("back-lash") lateral correction.
+  const double abs_offset = std::abs(lateral_offset);
+  const double sgn = (lateral_offset >= 0.0) ? 1.0 : -1.0;
+
+  // Soft dead-zone: slope `balance_alpha` while contained (|offset| <= slack), unit slope once the
+  // corner is exposed. Continuous at |offset| = slack.
+  const double shift = (abs_offset <= slack) ? balance_alpha * abs_offset
+                                             : (abs_offset - slack) + balance_alpha * slack;
+  const double lateral_move =
+    sgn * shift - lateral_offset;  // (corrected - observed) lateral offset
+
+  // Added lateral std: `slack` when centered (true position unknown across the slack), shrinking to
+  // `corner_residual_beta` * slack once the corner is matched. Continuous in |offset|.
+  const double t = std::clamp(abs_offset / slack, 0.0, 1.0);
+  const double std_lat = slack * (1.0 - (1.0 - corner_residual_beta) * t);
+  var_lat = std_lat * std_lat;
+  return lateral_move;
+}
+
+geometry_msgs::msg::Point correctWheelAnchor(
+  const types::DynamicObject & prediction, const double polygon_width,
+  const geometry_msgs::msg::Point & anchor, std::array<double, 36> & pose_cov)
+{
+  using autoware_utils_geometry::xyzrpy_covariance_index::XYZRPY_COV_IDX;
+
+  const double yaw = tf2::getYaw(prediction.pose.orientation);
+  const double tracker_width = prediction.shape.dimensions.y;
+  const geometry_msgs::msg::Point & tracker_center = prediction.pose.position;
+
   const double sin_yaw = std::sin(yaw);
   const double cos_yaw = std::cos(yaw);
-  // lateral unit vector n = (-sin(yaw), cos(yaw)); add var_lat * n * n^T to the x/y block
+  // Project the observed anchor offset from the tracker center onto the body lateral axis
+  // n = (-sin yaw, cos yaw). The longitudinal component is orthogonal to n and drops.
+  const double lateral_offset =
+    -(anchor.x - tracker_center.x) * sin_yaw + (anchor.y - tracker_center.y) * cos_yaw;
+
+  double var_lat = 0.0;
+  const double lateral_move =
+    correctWheelAnchorLateral(lateral_offset, tracker_width, polygon_width, var_lat);
+
+  // Apply the scalar lateral move back along n to get the corrected anchor point.
+  geometry_msgs::msg::Point corrected = anchor;
+  corrected.x = anchor.x - lateral_move * sin_yaw;
+  corrected.y = anchor.y + lateral_move * cos_yaw;
+
+  // add var_lat * n * n^T to the x/y block
   pose_cov[XYZRPY_COV_IDX::X_X] += var_lat * sin_yaw * sin_yaw;
   pose_cov[XYZRPY_COV_IDX::X_Y] += -var_lat * sin_yaw * cos_yaw;
   pose_cov[XYZRPY_COV_IDX::Y_X] += -var_lat * sin_yaw * cos_yaw;
   pose_cov[XYZRPY_COV_IDX::Y_Y] += var_lat * cos_yaw * cos_yaw;
 
-  return corr.anchor;
+  return corrected;
 }
 
 }  // namespace autoware::multi_object_tracker

--- a/perception/autoware_multi_object_tracker/lib/tracker/update/vehicle_update_strategy.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/update/vehicle_update_strategy.cpp
@@ -229,7 +229,7 @@ double correctWheelAnchorLateral(
   // Project the tracker center (0) into the dead-zone.
   const double target = std::clamp(0.0, low, high);
 
-  // std = half the dead-zone width.
+  // Variance = (dead-zone half-width)^2: the std equals the half-width by which the center may move.
   var_lat = half_dead_zone * half_dead_zone;
 
   return target - anchor_lateral;

--- a/perception/autoware_multi_object_tracker/lib/tracker/update/vehicle_update_strategy.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/update/vehicle_update_strategy.cpp
@@ -217,38 +217,60 @@ types::DynamicObject createPseudoMeasurement(
 }
 
 double correctWheelAnchorLateral(
-  const double lateral_offset, const double tracker_width, const double polygon_width,
+  const double tracker_L, const double tracker_R, const double polygon_L, const double polygon_R,
   double & var_lat)
 {
-  constexpr double balance_alpha = 0.2;         // hold-tracker slope inside the dead-zone
-  constexpr double corner_residual_beta = 0.3;  // residual std fraction once the corner is matched
+  // Zone boundaries as fractions of tracker half-width H:
+  //   dead zone: half-width-miss or per-side excess ≤ 0.20·H → no correction
+  //   inner (zone 2): polygon_width < 0.80·tracker_width → weight based on half-width-miss only
+  //     full match at polygon_width = 0.50·tracker_width (half-width-miss = 0.50·H)
+  //   outer (zone 3): per-side excess > 0.20·H → full match at excess = 0.40·H (140% of H)
+  constexpr double DEAD_ZONE_FRAC  = 0.20;
+  constexpr double FULL_INNER_FRAC = 0.50;
+  constexpr double FULL_OUTER_FRAC = 0.40;
 
-  const double slack = 0.5 * (polygon_width - tracker_width);
-  if (slack <= 0.0) {
-    // Polygon narrower than (or equal to) the tracker: partial view. Keep the anchor (no move) and
-    // add the worst-case lateral offset (half the missing width) as variance.
-    const double half_gap = -slack;  // = 0.5 * (tracker_width - polygon_width) >= 0
-    var_lat = half_gap * half_gap;
-    return 0.0;
+  const double H         = (tracker_L - tracker_R) * 0.5;
+  const double dead_lat  = DEAD_ZONE_FRAC * H;
+  const double inner_lat = FULL_INNER_FRAC * H;
+  const double outer_lat = FULL_OUTER_FRAC * H;
+
+  const double polygon_width = polygon_L - polygon_R;
+  const double tracker_width = 2.0 * H;
+
+  if (polygon_width <= tracker_width) {
+    // Inner zone: polygon narrower than tracker.
+    // Weight is based on the symmetric half-width-miss so it does not depend on lateral_offset,
+    // avoiding the oscillation that per-side excess weights produce when a narrow polygon shifts.
+    const double half_width_miss = (tracker_width - polygon_width) * 0.5;
+    const double t_inner = (half_width_miss > dead_lat)
+                             ? std::clamp(
+                                 (half_width_miss - dead_lat) / (inner_lat - dead_lat), 0.0, 1.0)
+                             : 0.0;
+    // Correction: pull the anchor toward the tracker center proportional to its lateral offset.
+    // lateral_offset = (polygon_L + polygon_R) / 2; at t=1 the anchor snaps to center.
+    const double lateral_offset = (polygon_L + polygon_R) * 0.5;
+    // Uncorrected residual is also width-based to stay consistent.
+    const double resid = half_width_miss * (1.0 - t_inner);
+    var_lat = 2.0 * resid * resid;
+    return -lateral_offset * t_inner;
   }
 
-  // Polygon wider than the tracker: soft dead-zone ("back-lash") lateral correction.
-  const double abs_offset = std::abs(lateral_offset);
-  const double sgn = (lateral_offset >= 0.0) ? 1.0 : -1.0;
+  // Outer zone: polygon wider than tracker.
+  // Per-side excess weights give accurate boundary-level correction.
+  const double excess_L = polygon_L - tracker_L;
+  const double excess_R = tracker_R - polygon_R;
 
-  // Soft dead-zone: slope `balance_alpha` while contained (|offset| <= slack), unit slope once the
-  // corner is exposed. Continuous at |offset| = slack.
-  const double shift = (abs_offset <= slack) ? balance_alpha * abs_offset
-                                             : (abs_offset - slack) + balance_alpha * slack;
-  const double lateral_move =
-    sgn * shift - lateral_offset;  // (corrected - observed) lateral offset
-
-  // Added lateral std: `slack` when centered (true position unknown across the slack), shrinking to
-  // `corner_residual_beta` * slack once the corner is matched. Continuous in |offset|.
-  const double t = std::clamp(abs_offset / slack, 0.0, 1.0);
-  const double std_lat = slack * (1.0 - (1.0 - corner_residual_beta) * t);
-  var_lat = std_lat * std_lat;
-  return lateral_move;
+  const auto outer_weight = [&](const double excess) -> double {
+    return (excess > dead_lat)
+             ? std::clamp((excess - dead_lat) / (outer_lat - dead_lat), 0.0, 1.0)
+             : 0.0;
+  };
+  const double t_L = outer_weight(excess_L);
+  const double t_R = outer_weight(excess_R);
+  const double resid_L = excess_L * (1.0 - t_L);
+  const double resid_R = excess_R * (1.0 - t_R);
+  var_lat = resid_L * resid_L + resid_R * resid_R;
+  return -excess_L * t_L + excess_R * t_R;
 }
 
 geometry_msgs::msg::Point correctWheelAnchor(
@@ -268,9 +290,12 @@ geometry_msgs::msg::Point correctWheelAnchor(
   const double lateral_offset =
     -(anchor.x - tracker_center.x) * sin_yaw + (anchor.y - tracker_center.y) * cos_yaw;
 
+  const double tracker_half = tracker_width * 0.5;
+  const double polygon_half = polygon_width * 0.5;
   double var_lat = 0.0;
-  const double lateral_move =
-    correctWheelAnchorLateral(lateral_offset, tracker_width, polygon_width, var_lat);
+  const double lateral_move = correctWheelAnchorLateral(
+    +tracker_half, -tracker_half, lateral_offset + polygon_half, lateral_offset - polygon_half,
+    var_lat);
 
   // Apply the scalar lateral move back along n to get the corrected anchor point.
   geometry_msgs::msg::Point corrected = anchor;

--- a/perception/autoware_multi_object_tracker/lib/tracker/update/vehicle_update_strategy.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/update/vehicle_update_strategy.cpp
@@ -217,77 +217,46 @@ types::DynamicObject createPseudoMeasurement(
 }
 
 double correctWheelAnchorLateral(
-  const double tracker_L, const double tracker_R, const double polygon_L, const double polygon_R,
-  double & var_lat)
+  const double tracker_left, const double tracker_right, const double polygon_left,
+  const double polygon_right, double & var_lat)
 {
-  // Zone boundaries as fractions of tracker half-width H:
-  //   dead zone: half-width-miss or per-side excess ≤ 0.20·H → no correction
-  //   inner (zone 2): polygon_width ≤ tracker_width → center-pull by half-width-miss weight,
-  //     suppressed when a close side (gap < 0.20·H) is visible; close-side correction then
-  //     aligns that edge with the tracker boundary (full alignment at gap = 0)
-  //   outer (zone 3): per-side excess > 0.20·H → full match at excess = 0.40·H (140% of H)
-  constexpr double DEAD_ZONE_FRAC = 0.20;
-  constexpr double FULL_INNER_FRAC = 0.50;
-  constexpr double FULL_OUTER_FRAC = 0.40;
+  constexpr double balance_alpha = 0.2;         // hold-tracker slope inside the dead-zone
+  constexpr double corner_residual_beta = 0.3;  // residual std fraction once the corner is matched
 
-  const double H = (tracker_L - tracker_R) * 0.5;
-  const double dead_lat = DEAD_ZONE_FRAC * H;
-  const double inner_lat = FULL_INNER_FRAC * H;
-  const double outer_lat = FULL_OUTER_FRAC * H;
+  // Per-side overhang of the polygon beyond the tracker box (positive = the polygon edge sticks out
+  // past the tracker boundary on that side). The two overhangs fully describe the lateral geometry:
+  //   slack          = half the total overhang     = how far the tracker can slide inside the polygon
+  //   lateral_offset = half the overhang asymmetry  = edge-center bias from the tracker center
+  const double overhang_left = polygon_left - tracker_left;
+  const double overhang_right = tracker_right - polygon_right;
+  const double slack = 0.5 * (overhang_left + overhang_right);
+  const double lateral_offset = 0.5 * (overhang_left - overhang_right);
 
-  const double polygon_width = polygon_L - polygon_R;
-  const double tracker_width = 2.0 * H;
-
-  if (polygon_width <= tracker_width) {
-    // Inner zone: polygon narrower than tracker.
-    const double half_width_miss = (tracker_width - polygon_width) * 0.5;
-    const double t_inner =
-      (half_width_miss > dead_lat)
-        ? std::clamp((half_width_miss - dead_lat) / (inner_lat - dead_lat), 0.0, 1.0)
-        : 0.0;
-
-    // Per-side gap: signed distance from each polygon edge to the corresponding tracker boundary.
-    // Positive = polygon edge is inside the tracker; negative = polygon edge protrudes beyond.
-    const double gap_L = tracker_L - polygon_L;
-    const double gap_R = polygon_R - tracker_R;
-
-    // Close-side weight: 1 when the polygon edge is AT the tracker boundary (gap = 0, or
-    // protrudes), decreasing to 0 as the gap grows to dead_lat (boundary no longer visible).
-    const double t_close_L =
-      (gap_L < dead_lat) ? std::clamp((dead_lat - gap_L) / dead_lat, 0.0, 1.0) : 0.0;
-    const double t_close_R =
-      (gap_R < dead_lat) ? std::clamp((dead_lat - gap_R) / dead_lat, 0.0, 1.0) : 0.0;
-    const double t_close = std::max(t_close_L, t_close_R);
-
-    // Center-pull suppressed proportionally to the close-side confidence: when one boundary
-    // is directly observable, pulling to center would introduce error.
-    const double effective_t_inner = t_inner * (1.0 - t_close);
-    const double lateral_offset = (polygon_L + polygon_R) * 0.5;
-
-    // Close-side correction: pull the anchor to align each near edge with its tracker boundary.
-    // gap_L * t_close_L shifts left; gap_R * t_close_R shifts right (subtracted).
-    const double close_correction = gap_L * t_close_L - gap_R * t_close_R;
-
-    const double resid = half_width_miss * (1.0 - effective_t_inner);
-    var_lat = 2.0 * resid * resid;
-    return -lateral_offset * effective_t_inner + close_correction;
+  if (slack <= 0.0) {
+    // Polygon narrower than (or equal to) the tracker: partial view. Keep the anchor (no move) and
+    // add the worst-case lateral offset (half the missing width) as variance.
+    const double half_gap = -slack;  // = 0.5 * (tracker_width - polygon_width) >= 0
+    var_lat = half_gap * half_gap;
+    return 0.0;
   }
 
-  // Outer zone: polygon wider than tracker.
-  // Per-side excess weights give accurate boundary-level correction.
-  const double excess_L = polygon_L - tracker_L;
-  const double excess_R = tracker_R - polygon_R;
+  // Polygon wider than the tracker: soft dead-zone ("back-lash") lateral correction.
+  const double abs_offset = std::abs(lateral_offset);
+  const double sgn = (lateral_offset >= 0.0) ? 1.0 : -1.0;
 
-  const auto outer_weight = [&](const double excess) -> double {
-    return (excess > dead_lat) ? std::clamp((excess - dead_lat) / (outer_lat - dead_lat), 0.0, 1.0)
-                               : 0.0;
-  };
-  const double t_L = outer_weight(excess_L);
-  const double t_R = outer_weight(excess_R);
-  const double resid_L = excess_L * (1.0 - t_L);
-  const double resid_R = excess_R * (1.0 - t_R);
-  var_lat = resid_L * resid_L + resid_R * resid_R;
-  return -excess_L * t_L + excess_R * t_R;
+  // Soft dead-zone: slope `balance_alpha` while the tracker is contained (|offset| <= slack), unit
+  // slope once a corner is exposed. Continuous at |offset| = slack.
+  const double shift = (abs_offset <= slack) ? balance_alpha * abs_offset
+                                             : (abs_offset - slack) + balance_alpha * slack;
+  const double lateral_move =
+    sgn * shift - lateral_offset;  // (corrected - observed) lateral offset
+
+  // Added lateral std: `slack` when centered (true position unknown across the slack), shrinking to
+  // `corner_residual_beta` * slack once the corner is matched. Continuous in |offset|.
+  const double t = std::clamp(abs_offset / slack, 0.0, 1.0);
+  const double std_lat = slack * (1.0 - (1.0 - corner_residual_beta) * t);
+  var_lat = std_lat * std_lat;
+  return lateral_move;
 }
 
 geometry_msgs::msg::Point correctWheelAnchor(

--- a/perception/autoware_multi_object_tracker/lib/tracker/update/vehicle_update_strategy.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/update/vehicle_update_strategy.cpp
@@ -217,33 +217,22 @@ types::DynamicObject createPseudoMeasurement(
 }
 
 double correctWheelAnchorLateral(
-  const double tracker_left, const double tracker_right, const double polygon_left,
-  const double polygon_right, double & var_lat)
+  const double anchor_lateral, const double tracker_half, const double polygon_half,
+  double & var_lat)
 {
-  const double tracker_center = 0.5 * (tracker_left + tracker_right);
-  const double polygon_center = 0.5 * (polygon_left + polygon_right);
+  // The true center lies within +/-half_dead_zone of the anchor; outside it, the closer polygon
+  // edge is taken as a real vehicle edge.
+  const double half_dead_zone = std::abs(polygon_half - tracker_half);
+  const double low = anchor_lateral - half_dead_zone;
+  const double high = anchor_lateral + half_dead_zone;
 
-  // Two candidate vehicle centers, one per side, obtained by aligning the tracker box (kept at its
-  // own width) to each polygon edge. The true center must lie on the segment between them; that
-  // segment is the lateral "dead-zone" whose width equals |polygon_width - tracker_width|.
-  const double center_from_left = polygon_left - tracker_left;
-  const double center_from_right = polygon_right - tracker_right;
-  const double low = std::min(center_from_left, center_from_right);
-  const double high = std::max(center_from_left, center_from_right);
+  // Project the tracker center (0) into the dead-zone.
+  const double target = std::clamp(0.0, low, high);
 
-  // Project the tracker center into the dead-zone:
-  //  - inside  -> hold it (polygon straddles, or is straddled by, the tracker on both sides)
-  //  - outside -> snap to the nearest edge-aligned center; the closer polygon edge is taken as a
-  //               real vehicle edge and the box slides by that overhang (tracker_center +
-  //               overhang).
-  const double target = std::clamp(tracker_center, low, high);
-
-  // Lateral position is unknown across the dead-zone, so its variance grows with the dead-zone
-  // size: std = half the dead-zone width = 0.5 * |polygon_width - tracker_width|.
-  const double half_dead_zone = 0.5 * (high - low);
+  // std = half the dead-zone width.
   var_lat = half_dead_zone * half_dead_zone;
 
-  return target - polygon_center;
+  return target - anchor_lateral;
 }
 
 geometry_msgs::msg::Point correctWheelAnchor(
@@ -266,9 +255,8 @@ geometry_msgs::msg::Point correctWheelAnchor(
   const double tracker_half = tracker_width * 0.5;
   const double polygon_half = polygon_width * 0.5;
   double var_lat = 0.0;
-  const double lateral_move = correctWheelAnchorLateral(
-    +tracker_half, -tracker_half, lateral_offset + polygon_half, lateral_offset - polygon_half,
-    var_lat);
+  const double lateral_move =
+    correctWheelAnchorLateral(lateral_offset, tracker_half, polygon_half, var_lat);
 
   // Apply the scalar lateral move back along n to get the corrected anchor point.
   geometry_msgs::msg::Point corrected = anchor;

--- a/perception/autoware_multi_object_tracker/lib/types.cpp
+++ b/perception/autoware_multi_object_tracker/lib/types.cpp
@@ -14,7 +14,6 @@
 
 #include "autoware/multi_object_tracker/types.hpp"
 
-#include "autoware/multi_object_tracker/object_model/shapes.hpp"
 #include "autoware/multi_object_tracker/object_model/uuid.hpp"
 
 #include <cmath>

--- a/perception/autoware_multi_object_tracker/src/multi_object_tracker_node.cpp
+++ b/perception/autoware_multi_object_tracker/src/multi_object_tracker_node.cpp
@@ -16,7 +16,6 @@
 
 #include "multi_object_tracker_node.hpp"
 
-#include "autoware/multi_object_tracker/object_model/shapes.hpp"
 #include "autoware/multi_object_tracker/types.hpp"
 #include "autoware/multi_object_tracker/uncertainty/uncertainty_processor.hpp"
 

--- a/perception/autoware_multi_object_tracker/src/processor/input_manager.cpp
+++ b/perception/autoware_multi_object_tracker/src/processor/input_manager.cpp
@@ -15,7 +15,6 @@
 #include "input_manager.hpp"
 
 #include "autoware/multi_object_tracker/object_model/classes.hpp"
-#include "autoware/multi_object_tracker/object_model/shapes.hpp"
 #include "autoware/multi_object_tracker/types.hpp"
 #include "autoware/multi_object_tracker/uncertainty/uncertainty_processor.hpp"
 

--- a/perception/autoware_multi_object_tracker/src/processor/processor.cpp
+++ b/perception/autoware_multi_object_tracker/src/processor/processor.cpp
@@ -15,7 +15,6 @@
 #include "processor.hpp"
 
 #include "autoware/multi_object_tracker/object_model/object_model.hpp"
-#include "autoware/multi_object_tracker/object_model/shapes.hpp"
 #include "autoware/multi_object_tracker/tracker/tracker.hpp"
 #include "autoware/multi_object_tracker/tracker/trackers/static_tracker.hpp"
 #include "autoware/multi_object_tracker/types.hpp"

--- a/perception/autoware_multi_object_tracker/test/test_bench.hpp
+++ b/perception/autoware_multi_object_tracker/test/test_bench.hpp
@@ -14,7 +14,6 @@
 #ifndef TEST_BENCH_HPP_
 #define TEST_BENCH_HPP_
 #include "../src/multi_object_tracker_node.hpp"
-#include "autoware/multi_object_tracker/object_model/shapes.hpp"
 #include "autoware/multi_object_tracker/tracker/trackers/tracker_base.hpp"
 #include "autoware/multi_object_tracker/types.hpp"
 #include "autoware/multi_object_tracker/uncertainty/uncertainty_processor.hpp"

--- a/perception/autoware_multi_object_tracker/test/test_multi_object_tracker.cpp
+++ b/perception/autoware_multi_object_tracker/test/test_multi_object_tracker.cpp
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 #include "../src/multi_object_tracker_node.hpp"
-#include "autoware/multi_object_tracker/object_model/shapes.hpp"
 #include "autoware/multi_object_tracker/odometry.hpp"
 #include "autoware/multi_object_tracker/types.hpp"
 #include "autoware/multi_object_tracker/uncertainty/uncertainty_processor.hpp"

--- a/perception/autoware_multi_object_tracker/test/test_tracker_overlap_manager.cpp
+++ b/perception/autoware_multi_object_tracker/test/test_tracker_overlap_manager.cpp
@@ -15,7 +15,7 @@
 #include "autoware/multi_object_tracker/association/scoring/redundancy_check.hpp"
 #include "autoware/multi_object_tracker/association/tracker_overlap_manager.hpp"
 #include "autoware/multi_object_tracker/object_model/object_model.hpp"
-#include "autoware/multi_object_tracker/object_model/shapes.hpp"
+#include "autoware/multi_object_tracker/object_model/shapes_iou.hpp"
 #include "autoware/multi_object_tracker/tracker/trackers/polygon_tracker.hpp"
 #include "autoware/multi_object_tracker/tracker/trackers/vehicle_tracker.hpp"
 #include "autoware/multi_object_tracker/types.hpp"

--- a/perception/autoware_multi_object_tracker/test/test_vehicle_tracker.cpp
+++ b/perception/autoware_multi_object_tracker/test/test_vehicle_tracker.cpp
@@ -22,26 +22,25 @@ namespace autoware::multi_object_tracker
 {
 namespace
 {
-// Matches the values wired into VehicleTracker::updateWheelKinematics.
+// Matches the constants defined inside correctWheelAnchorLateral.
 constexpr double kAlpha = 0.2;  // balance_alpha
 constexpr double kBeta = 0.3;   // corner_residual_beta
 
-geometry_msgs::msg::Point makePoint(double x, double y)
+// correctWheelAnchorLateral is pure scalar math: given the signed lateral offset of the observed
+// edge center from the tracker center, it returns the lateral move and added variance. The
+// corrected lateral coordinate is `lateral_offset + lateral_move`.
+struct LateralResult
 {
-  geometry_msgs::msg::Point p;
-  p.x = x;
-  p.y = y;
-  p.z = 0.0;
-  return p;
-}
+  double lateral;  // corrected lateral coordinate (= lateral_offset + lateral_move)
+  double var_lat;
+};
 
-// With yaw = 0 the body lateral axis is +y, so the lateral offset d equals (anchor.y - center.y)
-// and the corrected anchor keeps x and moves only y. tracker_center is the origin throughout.
-WheelAnchorLateral run(double tracker_width, double polygon_width, double anchor_y)
+LateralResult run(double tracker_width, double polygon_width, double lateral_offset)
 {
-  return correctWheelAnchorLateral(
-    0.0, tracker_width, makePoint(0.0, 0.0), polygon_width, makePoint(5.0, anchor_y), kAlpha,
-    kBeta);
+  double var_lat = 0.0;
+  const double lateral_move =
+    correctWheelAnchorLateral(lateral_offset, tracker_width, polygon_width, var_lat);
+  return {lateral_offset + lateral_move, var_lat};
 }
 }  // namespace
 
@@ -49,8 +48,7 @@ WheelAnchorLateral run(double tracker_width, double polygon_width, double anchor
 TEST(CorrectWheelAnchorLateral, EqualWidthIsNoOp)
 {
   const auto r = run(2.0, 2.0, 0.5);
-  EXPECT_DOUBLE_EQ(r.anchor.x, 5.0);
-  EXPECT_DOUBLE_EQ(r.anchor.y, 0.5);
+  EXPECT_DOUBLE_EQ(r.lateral, 0.5);  // anchor unchanged
   EXPECT_DOUBLE_EQ(r.var_lat, 0.0);
 }
 
@@ -59,8 +57,7 @@ TEST(CorrectWheelAnchorLateral, EqualWidthIsNoOp)
 TEST(CorrectWheelAnchorLateral, NarrowPolygonAddsVarianceOnly)
 {
   const auto r = run(2.0, 1.0, 0.5);
-  EXPECT_DOUBLE_EQ(r.anchor.x, 5.0);
-  EXPECT_DOUBLE_EQ(r.anchor.y, 0.5);  // anchor unchanged
+  EXPECT_DOUBLE_EQ(r.lateral, 0.5);   // anchor unchanged
   EXPECT_DOUBLE_EQ(r.var_lat, 0.25);  // (0.5)^2
 }
 
@@ -69,7 +66,7 @@ TEST(CorrectWheelAnchorLateral, WideCenteredHoldsAnchorMaxVariance)
 {
   const double slack = 1.0;  // (4 - 2) / 2
   const auto r = run(2.0, 4.0, 0.0);
-  EXPECT_DOUBLE_EQ(r.anchor.y, 0.0);
+  EXPECT_DOUBLE_EQ(r.lateral, 0.0);
   EXPECT_DOUBLE_EQ(r.var_lat, slack * slack);  // std = slack
 }
 
@@ -80,7 +77,7 @@ TEST(CorrectWheelAnchorLateral, WideContainedPullsTowardTracker)
   const double slack = 1.0;
   const double d = 0.5;  // < slack -> contained
   const auto r = run(2.0, 4.0, d);
-  EXPECT_DOUBLE_EQ(r.anchor.y, kAlpha * d);  // 0.1, pulled in from 0.5
+  EXPECT_DOUBLE_EQ(r.lateral, kAlpha * d);  // 0.1, pulled in from 0.5
   const double t = d / slack;
   const double std_lat = slack * (1.0 - (1.0 - kBeta) * t);
   EXPECT_DOUBLE_EQ(r.var_lat, std_lat * std_lat);
@@ -93,7 +90,7 @@ TEST(CorrectWheelAnchorLateral, WideUncontainedFollowsCorner)
   const double slack = 1.0;
   const double d = 2.0;  // > slack -> corner exposed
   const auto r = run(2.0, 4.0, d);
-  EXPECT_DOUBLE_EQ(r.anchor.y, (d - slack) + kAlpha * slack);      // 1.2
+  EXPECT_DOUBLE_EQ(r.lateral, (d - slack) + kAlpha * slack);       // 1.2
   EXPECT_DOUBLE_EQ(r.var_lat, (kBeta * slack) * (kBeta * slack));  // std = beta * slack
 }
 
@@ -104,7 +101,7 @@ TEST(CorrectWheelAnchorLateral, ContinuousAtBoundary)
   const double eps = 1e-6;
   const auto inside = run(2.0, 4.0, slack - eps);
   const auto outside = run(2.0, 4.0, slack + eps);
-  EXPECT_NEAR(inside.anchor.y, outside.anchor.y, 1e-4);
+  EXPECT_NEAR(inside.lateral, outside.lateral, 1e-4);
   EXPECT_NEAR(inside.var_lat, outside.var_lat, 1e-4);
 }
 
@@ -113,7 +110,7 @@ TEST(CorrectWheelAnchorLateral, SignSymmetry)
 {
   const auto pos = run(2.0, 4.0, 1.5);
   const auto neg = run(2.0, 4.0, -1.5);
-  EXPECT_DOUBLE_EQ(pos.anchor.y, -neg.anchor.y);
+  EXPECT_DOUBLE_EQ(pos.lateral, -neg.lateral);
   EXPECT_DOUBLE_EQ(pos.var_lat, neg.var_lat);
 }
 

--- a/perception/autoware_multi_object_tracker/test/test_vehicle_tracker.cpp
+++ b/perception/autoware_multi_object_tracker/test/test_vehicle_tracker.cpp
@@ -1,0 +1,120 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/multi_object_tracker/tracker/update/vehicle_update_strategy.hpp"
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+
+namespace autoware::multi_object_tracker
+{
+namespace
+{
+// Matches the values wired into VehicleTracker::updateWheelKinematics.
+constexpr double kAlpha = 0.2;  // balance_alpha
+constexpr double kBeta = 0.3;   // corner_residual_beta
+
+geometry_msgs::msg::Point makePoint(double x, double y)
+{
+  geometry_msgs::msg::Point p;
+  p.x = x;
+  p.y = y;
+  p.z = 0.0;
+  return p;
+}
+
+// With yaw = 0 the body lateral axis is +y, so the lateral offset d equals (anchor.y - center.y)
+// and the corrected anchor keeps x and moves only y. tracker_center is the origin throughout.
+WheelAnchorLateral run(double tracker_width, double polygon_width, double anchor_y)
+{
+  return correctWheelAnchorLateral(
+    0.0, tracker_width, makePoint(0.0, 0.0), polygon_width, makePoint(5.0, anchor_y), kAlpha,
+    kBeta);
+}
+}  // namespace
+
+// Equal widths: no slack, no gap -> anchor untouched, no added variance.
+TEST(CorrectWheelAnchorLateral, EqualWidthIsNoOp)
+{
+  const auto r = run(2.0, 2.0, 0.5);
+  EXPECT_DOUBLE_EQ(r.anchor.x, 5.0);
+  EXPECT_DOUBLE_EQ(r.anchor.y, 0.5);
+  EXPECT_DOUBLE_EQ(r.var_lat, 0.0);
+}
+
+// Polygon narrower than the tracker (partial view): anchor kept, worst-case lateral offset added
+// as variance, var = ((w_t - w_p) / 2)^2.
+TEST(CorrectWheelAnchorLateral, NarrowPolygonAddsVarianceOnly)
+{
+  const auto r = run(2.0, 1.0, 0.5);
+  EXPECT_DOUBLE_EQ(r.anchor.x, 5.0);
+  EXPECT_DOUBLE_EQ(r.anchor.y, 0.5);  // anchor unchanged
+  EXPECT_DOUBLE_EQ(r.var_lat, 0.25);  // (0.5)^2
+}
+
+// Wide polygon, observed center on the body axis: nothing to pull, full slack uncertainty.
+TEST(CorrectWheelAnchorLateral, WideCenteredHoldsAnchorMaxVariance)
+{
+  const double slack = 1.0;  // (4 - 2) / 2
+  const auto r = run(2.0, 4.0, 0.0);
+  EXPECT_DOUBLE_EQ(r.anchor.y, 0.0);
+  EXPECT_DOUBLE_EQ(r.var_lat, slack * slack);  // std = slack
+}
+
+// Wide polygon, observed center inside the slack: anchor held near the tracker (slope alpha), so it
+// is pulled back toward the body axis rather than snapped to the observed center.
+TEST(CorrectWheelAnchorLateral, WideContainedPullsTowardTracker)
+{
+  const double slack = 1.0;
+  const double d = 0.5;  // < slack -> contained
+  const auto r = run(2.0, 4.0, d);
+  EXPECT_DOUBLE_EQ(r.anchor.y, kAlpha * d);  // 0.1, pulled in from 0.5
+  const double t = d / slack;
+  const double std_lat = slack * (1.0 - (1.0 - kBeta) * t);
+  EXPECT_DOUBLE_EQ(r.var_lat, std_lat * std_lat);
+}
+
+// Wide polygon, observed center beyond the slack: a corner is exposed, anchor follows it (unit
+// slope) and the added variance shrinks toward beta * slack.
+TEST(CorrectWheelAnchorLateral, WideUncontainedFollowsCorner)
+{
+  const double slack = 1.0;
+  const double d = 2.0;  // > slack -> corner exposed
+  const auto r = run(2.0, 4.0, d);
+  EXPECT_DOUBLE_EQ(r.anchor.y, (d - slack) + kAlpha * slack);      // 1.2
+  EXPECT_DOUBLE_EQ(r.var_lat, (kBeta * slack) * (kBeta * slack));  // std = beta * slack
+}
+
+// The dead-zone is continuous at |d| = slack: both branches agree on anchor and variance.
+TEST(CorrectWheelAnchorLateral, ContinuousAtBoundary)
+{
+  const double slack = 1.0;
+  const double eps = 1e-6;
+  const auto inside = run(2.0, 4.0, slack - eps);
+  const auto outside = run(2.0, 4.0, slack + eps);
+  EXPECT_NEAR(inside.anchor.y, outside.anchor.y, 1e-4);
+  EXPECT_NEAR(inside.var_lat, outside.var_lat, 1e-4);
+}
+
+// Sign symmetry: a negative lateral offset mirrors the positive case.
+TEST(CorrectWheelAnchorLateral, SignSymmetry)
+{
+  const auto pos = run(2.0, 4.0, 1.5);
+  const auto neg = run(2.0, 4.0, -1.5);
+  EXPECT_DOUBLE_EQ(pos.anchor.y, -neg.anchor.y);
+  EXPECT_DOUBLE_EQ(pos.var_lat, neg.var_lat);
+}
+
+}  // namespace autoware::multi_object_tracker

--- a/perception/autoware_multi_object_tracker/test/test_vehicle_tracker.cpp
+++ b/perception/autoware_multi_object_tracker/test/test_vehicle_tracker.cpp
@@ -22,11 +22,14 @@ namespace autoware::multi_object_tracker
 {
 namespace
 {
-// Mirrors the zone constants defined inside correctWheelAnchorLateral.
-constexpr double kDeadFrac = 0.20;
-constexpr double kInnerFrac = 0.50;
-constexpr double kOuterFrac = 0.40;
+// Matches the constants defined inside correctWheelAnchorLateral.
+constexpr double kAlpha = 0.2;  // balance_alpha
+constexpr double kBeta = 0.3;   // corner_residual_beta
 
+// correctWheelAnchorLateral is pure scalar math over the four lateral edge coordinates. The
+// measurement polygon is centered on the observed edge-center anchor (lateral_offset), so its edges
+// sit at lateral_offset +/- polygon_half; the tracker is centered, with edges at +/- tracker_half.
+// The corrected lateral coordinate is `lateral_offset + lateral_move`.
 struct LateralResult
 {
   double lateral;  // corrected lateral coordinate (= lateral_offset + lateral_move)
@@ -45,174 +48,74 @@ LateralResult run(double tracker_width, double polygon_width, double lateral_off
 }
 }  // namespace
 
-// Equal widths, centered: all excesses are zero -> zone 1, no correction, no variance.
-TEST(CorrectWheelAnchorLateral, EqualWidthCenteredIsNoOp)
+// Equal widths: no slack, no overhang -> anchor untouched, no added variance.
+TEST(CorrectWheelAnchorLateral, EqualWidthIsNoOp)
 {
-  const auto r = run(2.0, 2.0, 0.0);
-  EXPECT_DOUBLE_EQ(r.lateral, 0.0);
+  const auto r = run(2.0, 2.0, 0.5);
+  EXPECT_DOUBLE_EQ(r.lateral, 0.5);  // anchor unchanged
   EXPECT_DOUBLE_EQ(r.var_lat, 0.0);
 }
 
-// Zone 1: polygon slightly wider than tracker (excess < dead), centered.
-// No correction; uncorrected residuals (0.1 each side) contribute to var.
-TEST(CorrectWheelAnchorLateral, Zone1DeadZoneNoCorrection)
+// Polygon narrower than the tracker (partial view): anchor kept, worst-case lateral offset added
+// as variance, var = ((w_t - w_p) / 2)^2.
+TEST(CorrectWheelAnchorLateral, NarrowPolygonAddsVarianceOnly)
 {
-  // tracker_width=2 -> H=1, dead=0.2. polygon_width=2.2 -> excess=0.1 on both sides.
-  const double exc = 0.1;  // < dead (=0.2*H=0.2)
-  const auto r = run(2.0, 2.2, 0.0);
-  EXPECT_DOUBLE_EQ(r.lateral, 0.0);
-  EXPECT_NEAR(r.var_lat, exc * exc + exc * exc, 1e-9);
-}
-
-// Zone 2 symmetric: polygon much narrower, centered -> corrections cancel, no net move.
-TEST(CorrectWheelAnchorLateral, Zone2SymmetricNoMove)
-{
-  // excess_L = excess_R = 0.25 - 1.0 = -0.75 -> both fully matched (t=1)
-  const auto r = run(2.0, 0.5, 0.0);
-  EXPECT_DOUBLE_EQ(r.lateral, 0.0);
-  EXPECT_DOUBLE_EQ(r.var_lat, 0.0);  // t=1 -> residual = 0
-}
-
-// Zone 2 asymmetric with protrusion: polygon=1.4 offset=0.4 → left edge protrudes (gap_L=-0.1).
-// Close-side fully active (t_close_L=1): center-pull suppressed, close_correction = -0.1 (aligns
-// left edge to tracker boundary). Expected lateral = 0.4 - 0.1 = 0.3.
-TEST(CorrectWheelAnchorLateral, Zone2LeftProtrusionCloseSideDominates)
-{
-  // gap_L = 1.0 - (0.4+0.7) = -0.1 → t_close_L=1, t_close_R=0 (gap_R=0.7), effective_t_inner=0
-  // close_correction = (-0.1)*1.0 - 0 = -0.1 ; resid = 0.3*1.0 → var_lat = 2*0.09 = 0.18
-  const auto r = run(2.0, 1.4, 0.4);
-  EXPECT_NEAR(r.lateral, 0.3, 1e-9);
-  EXPECT_NEAR(r.var_lat, 0.18, 1e-9);
-}
-
-// Zone 2 pure center-pull: polygon well inside tracker on both sides (gaps > dead_lat).
-// No close-side → effective_t_inner = t_inner; anchor pulled toward center.
-TEST(CorrectWheelAnchorLateral, Zone2PureCenterPull)
-{
-  // tracker=2 (H=1), polygon=1.0 (half=0.5), offset=0.1
-  // polygon_L=0.6, polygon_R=-0.4 → gap_L=0.4, gap_R=0.6; both > dead=0.2 → t_close=0
-  // half_wm=0.5, t_inner=clamp((0.5-0.2)/0.3,0,1)=1.0, effective_t_inner=1.0
-  // lateral_move = -0.1*1.0 = -0.1 ; corrected = 0.0 ; resid=0 → var_lat=0
-  const auto r = run(2.0, 1.0, 0.1);
-  EXPECT_NEAR(r.lateral, 0.0, 1e-9);
-  EXPECT_NEAR(r.var_lat, 0.0, 1e-9);
-}
-
-// Zone 2 close-side partial: polygon inside tracker, left edge near left boundary (gap_L<dead).
-// Close-side partially suppresses center-pull and adds leftward correction.
-TEST(CorrectWheelAnchorLateral, Zone2CloseSidePartialCorrection)
-{
-  // tracker=2 (H=1), polygon=1.0 (half=0.5), offset=0.4
-  // polygon_L=0.9, polygon_R=-0.1 → gap_L=0.1, gap_R=0.9
-  // t_close_L=(0.2-0.1)/0.2=0.5, t_close_R=0, t_close=0.5
-  // half_wm=0.5, t_inner=1.0, effective_t_inner=0.5
-  // close_correction = 0.1*0.5 - 0 = 0.05
-  // lateral_move = -0.4*0.5 + 0.05 = -0.15 ; corrected = 0.25
-  // resid = 0.5*(1-0.5)=0.25 → var_lat = 2*0.0625 = 0.125
-  const double H = 1.0;
-  const double dead = kDeadFrac * H;
-  const double lat_off = 0.4;
-  const double gap_L = 0.1;
-  const double t_cL = (dead - gap_L) / dead;
-  const double t_inner = 1.0;
-  const double eff_ti = t_inner * (1.0 - t_cL);
-  const double close_c = gap_L * t_cL;
-  const double exp_lat = lat_off + (-lat_off * eff_ti + close_c);
-  const double resid = 0.5 * (1.0 - eff_ti);
-  const double exp_var = 2.0 * resid * resid;
-  const auto r = run(2.0, 1.0, lat_off);
-  EXPECT_NEAR(r.lateral, exp_lat, 1e-9);
-  EXPECT_NEAR(r.var_lat, exp_var, 1e-9);
-}
-
-// Zone 2 close-side full: left edge exactly at tracker boundary (gap_L=0) → no correction,
-// center-pull fully suppressed. Anchor stays at its observed position.
-TEST(CorrectWheelAnchorLateral, Zone2CloseSideFullSuppression)
-{
-  // tracker=2 (H=1), polygon=1.0 (half=0.5), offset=0.5
-  // polygon_L=1.0=tracker_L → gap_L=0 → t_close_L=1.0, t_close_R=0 (gap_R=1.0)
-  // effective_t_inner=0, close_correction=0 → lateral_move=0 ; corrected=0.5
-  // resid=0.5*1.0=0.5 → var_lat=0.5
   const auto r = run(2.0, 1.0, 0.5);
-  EXPECT_NEAR(r.lateral, 0.5, 1e-9);
-  EXPECT_NEAR(r.var_lat, 0.5, 1e-9);
+  EXPECT_DOUBLE_EQ(r.lateral, 0.5);   // anchor unchanged
+  EXPECT_DOUBLE_EQ(r.var_lat, 0.25);  // (0.5)^2
 }
 
-// Zone 3 symmetric: wide polygon centered -> both sides cancel, no net move, no residual.
-TEST(CorrectWheelAnchorLateral, Zone3SymmetricNoMove)
+// Wide polygon, observed center on the body axis: nothing to pull, full slack uncertainty.
+TEST(CorrectWheelAnchorLateral, WideCenteredHoldsAnchorMaxVariance)
 {
-  // tracker=2 H=1, polygon=3.6 -> excess = 0.8 on both sides (>> outer=0.4), t=1
-  const auto r = run(2.0, 3.6, 0.0);
+  const double slack = 1.0;  // (4 - 2) / 2
+  const auto r = run(2.0, 4.0, 0.0);
   EXPECT_DOUBLE_EQ(r.lateral, 0.0);
-  EXPECT_DOUBLE_EQ(r.var_lat, 0.0);
+  EXPECT_DOUBLE_EQ(r.var_lat, slack * slack);  // std = slack
 }
 
-// Zone 3 asymmetric: wide polygon, anchor offset left -> net move right (toward tracker center).
-TEST(CorrectWheelAnchorLateral, Zone3AsymmetricPullsTowardCenter)
+// Wide polygon, observed center inside the slack: anchor held near the tracker (slope alpha), so it
+// is pulled back toward the body axis rather than snapped to the observed center.
+TEST(CorrectWheelAnchorLateral, WideContainedPullsTowardTracker)
 {
-  // tracker=2 H=1, polygon=3.6, offset=0.3
-  // excess_L = 0.3+1.8-1 = 1.1 -> t_L=1.0, excess_R = -1-(0.3-1.8) = 0.5 -> t_R=1.0
-  const auto r = run(2.0, 3.6, 0.3);
-  EXPECT_NEAR(r.lateral, 0.3 + (-1.1 * 1.0 + 0.5 * 1.0), 1e-9);  // = -0.3
-  EXPECT_DOUBLE_EQ(r.var_lat, 0.0);
+  const double slack = 1.0;
+  const double d = 0.5;  // < slack -> contained
+  const auto r = run(2.0, 4.0, d);
+  EXPECT_DOUBLE_EQ(r.lateral, kAlpha * d);  // 0.1, pulled in from 0.5
+  const double t = d / slack;
+  const double std_lat = slack * (1.0 - (1.0 - kBeta) * t);
+  EXPECT_DOUBLE_EQ(r.var_lat, std_lat * std_lat);
 }
 
-// Zone 3 partial: one side in zone 3 (partially), other in zone 1.
-TEST(CorrectWheelAnchorLateral, Zone3PartialOneSideCorrected)
+// Wide polygon, observed center beyond the slack: a corner is exposed, anchor follows it (unit
+// slope) and the added variance shrinks toward beta * slack.
+TEST(CorrectWheelAnchorLateral, WideUncontainedFollowsCorner)
 {
-  // tracker=2 H=1, polygon=2.6 (half=1.3), offset=0.3
-  // excess_L = 0.3+1.3-1 = 0.6 -> zone 3, t_L = clamp((0.6-0.2)/0.2, 0,1) = 1.0
-  // excess_R = -1-(0.3-1.3) = 0.0 -> zone 1, t_R = 0
-  const double H = 1.0;
-  const double dead = kDeadFrac * H;
-  const double outer = kOuterFrac * H;
-  const double exc_L = 0.6;
-  const double exc_R = 0.0;
-  const double t_L = std::clamp((exc_L - dead) / (outer - dead), 0.0, 1.0);
-  const double t_R = 0.0;
-  const double exp_move = -exc_L * t_L + exc_R * t_R;
-  const auto r = run(2.0, 2.6, 0.3);
-  EXPECT_NEAR(r.lateral, 0.3 + exp_move, 1e-9);
-  EXPECT_NEAR(r.var_lat, 0.0, 1e-9);  // both residuals are 0
+  const double slack = 1.0;
+  const double d = 2.0;  // > slack -> corner exposed
+  const auto r = run(2.0, 4.0, d);
+  EXPECT_DOUBLE_EQ(r.lateral, (d - slack) + kAlpha * slack);       // 1.2
+  EXPECT_DOUBLE_EQ(r.var_lat, (kBeta * slack) * (kBeta * slack));  // std = beta * slack
 }
 
-// Continuity at zone 1/2 boundary: just inside vs just outside dead zone -> nearly identical.
-TEST(CorrectWheelAnchorLateral, ContinuousAtZone1Zone2Boundary)
+// The dead-zone is continuous at |d| = slack: both branches agree on anchor and variance.
+TEST(CorrectWheelAnchorLateral, ContinuousAtBoundary)
 {
-  constexpr double eps = 1e-6;
-  // tracker=2 H=1, polygon_width chosen so excess_L = -(dead ± eps), offset=0 keeps both sides
-  // equal dead = 0.2, excess = polygon_half - 1 => polygon_half = 1 + excess => polygon_width =
-  // 2*(1+excess)
-  const double dead = kDeadFrac * 1.0;
-  const double w_in = 2.0 * (1.0 - dead + eps);   // excess just inside dead zone
-  const double w_out = 2.0 * (1.0 - dead - eps);  // excess just below dead zone (zone 2)
-  const auto inside = run(2.0, w_in, 0.0);
-  const auto outside = run(2.0, w_out, 0.0);
+  const double slack = 1.0;
+  const double eps = 1e-6;
+  const auto inside = run(2.0, 4.0, slack - eps);
+  const auto outside = run(2.0, 4.0, slack + eps);
   EXPECT_NEAR(inside.lateral, outside.lateral, 1e-4);
   EXPECT_NEAR(inside.var_lat, outside.var_lat, 1e-4);
 }
 
-// Continuity at zone 1/3 boundary: just inside vs just outside dead zone (wide side).
-TEST(CorrectWheelAnchorLateral, ContinuousAtZone1Zone3Boundary)
-{
-  constexpr double eps = 1e-6;
-  const double dead = kDeadFrac * 1.0;
-  const double w_in = 2.0 * (1.0 + dead - eps);   // excess just below dead (zone 1)
-  const double w_out = 2.0 * (1.0 + dead + eps);  // excess just above dead (zone 3)
-  const auto inside = run(2.0, w_in, 0.0);
-  const auto outside = run(2.0, w_out, 0.0);
-  EXPECT_NEAR(inside.lateral, outside.lateral, 1e-4);
-  EXPECT_NEAR(inside.var_lat, outside.var_lat, 1e-4);
-}
-
-// Sign symmetry: flipping lateral_offset mirrors corrected lateral and preserves variance.
+// Sign symmetry: a negative lateral offset mirrors the positive case.
 TEST(CorrectWheelAnchorLateral, SignSymmetry)
 {
-  const double d = 0.3;
-  const auto pos = run(2.0, 3.6, +d);
-  const auto neg = run(2.0, 3.6, -d);
-  EXPECT_NEAR(pos.lateral, -neg.lateral, 1e-9);
-  EXPECT_NEAR(pos.var_lat, neg.var_lat, 1e-9);
+  const auto pos = run(2.0, 4.0, 1.5);
+  const auto neg = run(2.0, 4.0, -1.5);
+  EXPECT_DOUBLE_EQ(pos.lateral, -neg.lateral);
+  EXPECT_DOUBLE_EQ(pos.var_lat, neg.var_lat);
 }
 
 }  // namespace autoware::multi_object_tracker

--- a/perception/autoware_multi_object_tracker/test/test_vehicle_tracker.cpp
+++ b/perception/autoware_multi_object_tracker/test/test_vehicle_tracker.cpp
@@ -23,7 +23,7 @@ namespace autoware::multi_object_tracker
 namespace
 {
 // Mirrors the zone constants defined inside correctWheelAnchorLateral.
-constexpr double kDeadFrac  = 0.20;
+constexpr double kDeadFrac = 0.20;
 constexpr double kInnerFrac = 0.50;
 constexpr double kOuterFrac = 0.40;
 
@@ -39,8 +39,7 @@ LateralResult run(double tracker_width, double polygon_width, double lateral_off
   const double polygon_half = polygon_width * 0.5;
   double var_lat = 0.0;
   const double lateral_move = correctWheelAnchorLateral(
-    +tracker_half, -tracker_half,
-    lateral_offset + polygon_half, lateral_offset - polygon_half,
+    +tracker_half, -tracker_half, lateral_offset + polygon_half, lateral_offset - polygon_half,
     var_lat);
   return {lateral_offset + lateral_move, var_lat};
 }
@@ -74,25 +73,69 @@ TEST(CorrectWheelAnchorLateral, Zone2SymmetricNoMove)
   EXPECT_DOUBLE_EQ(r.var_lat, 0.0);  // t=1 -> residual = 0
 }
 
-// Zone 2 asymmetric: narrow polygon offset left, width-based weight pulls anchor toward center.
-TEST(CorrectWheelAnchorLateral, Zone2WidthBasedPullsTowardCenter)
+// Zone 2 asymmetric with protrusion: polygon=1.4 offset=0.4 → left edge protrudes (gap_L=-0.1).
+// Close-side fully active (t_close_L=1): center-pull suppressed, close_correction = -0.1 (aligns
+// left edge to tracker boundary). Expected lateral = 0.4 - 0.1 = 0.3.
+TEST(CorrectWheelAnchorLateral, Zone2LeftProtrusionCloseSideDominates)
 {
-  // tracker=2 (H=1), polygon=1.4 (half=0.7), offset=0.4
-  // half_width_miss = (2-1.4)/2 = 0.3; dead=0.2, inner=0.5
-  // t_inner = clamp((0.3-0.2)/(0.5-0.2), 0,1) = 1/3
-  // lateral_move = -0.4 * (1/3) = -2/15
-  // resid = 0.3 * (2/3) = 0.2 -> var_lat = 2*0.04 = 0.08
-  const double dead         = kDeadFrac * 1.0;
-  const double inner        = kInnerFrac * 1.0;
-  const double half_wm      = 0.3;
-  const double lat_off      = 0.4;
-  const double t_inner      = std::clamp((half_wm - dead) / (inner - dead), 0.0, 1.0);
-  const double exp_move     = -lat_off * t_inner;
-  const double resid        = half_wm * (1.0 - t_inner);
-  const double exp_var      = 2.0 * resid * resid;
-  const auto r = run(2.0, 1.4, lat_off);
-  EXPECT_NEAR(r.lateral, lat_off + exp_move, 1e-9);
+  // gap_L = 1.0 - (0.4+0.7) = -0.1 → t_close_L=1, t_close_R=0 (gap_R=0.7), effective_t_inner=0
+  // close_correction = (-0.1)*1.0 - 0 = -0.1 ; resid = 0.3*1.0 → var_lat = 2*0.09 = 0.18
+  const auto r = run(2.0, 1.4, 0.4);
+  EXPECT_NEAR(r.lateral, 0.3, 1e-9);
+  EXPECT_NEAR(r.var_lat, 0.18, 1e-9);
+}
+
+// Zone 2 pure center-pull: polygon well inside tracker on both sides (gaps > dead_lat).
+// No close-side → effective_t_inner = t_inner; anchor pulled toward center.
+TEST(CorrectWheelAnchorLateral, Zone2PureCenterPull)
+{
+  // tracker=2 (H=1), polygon=1.0 (half=0.5), offset=0.1
+  // polygon_L=0.6, polygon_R=-0.4 → gap_L=0.4, gap_R=0.6; both > dead=0.2 → t_close=0
+  // half_wm=0.5, t_inner=clamp((0.5-0.2)/0.3,0,1)=1.0, effective_t_inner=1.0
+  // lateral_move = -0.1*1.0 = -0.1 ; corrected = 0.0 ; resid=0 → var_lat=0
+  const auto r = run(2.0, 1.0, 0.1);
+  EXPECT_NEAR(r.lateral, 0.0, 1e-9);
+  EXPECT_NEAR(r.var_lat, 0.0, 1e-9);
+}
+
+// Zone 2 close-side partial: polygon inside tracker, left edge near left boundary (gap_L<dead).
+// Close-side partially suppresses center-pull and adds leftward correction.
+TEST(CorrectWheelAnchorLateral, Zone2CloseSidePartialCorrection)
+{
+  // tracker=2 (H=1), polygon=1.0 (half=0.5), offset=0.4
+  // polygon_L=0.9, polygon_R=-0.1 → gap_L=0.1, gap_R=0.9
+  // t_close_L=(0.2-0.1)/0.2=0.5, t_close_R=0, t_close=0.5
+  // half_wm=0.5, t_inner=1.0, effective_t_inner=0.5
+  // close_correction = 0.1*0.5 - 0 = 0.05
+  // lateral_move = -0.4*0.5 + 0.05 = -0.15 ; corrected = 0.25
+  // resid = 0.5*(1-0.5)=0.25 → var_lat = 2*0.0625 = 0.125
+  const double H = 1.0;
+  const double dead = kDeadFrac * H;
+  const double lat_off = 0.4;
+  const double gap_L = 0.1;
+  const double t_cL = (dead - gap_L) / dead;
+  const double t_inner = 1.0;
+  const double eff_ti = t_inner * (1.0 - t_cL);
+  const double close_c = gap_L * t_cL;
+  const double exp_lat = lat_off + (-lat_off * eff_ti + close_c);
+  const double resid = 0.5 * (1.0 - eff_ti);
+  const double exp_var = 2.0 * resid * resid;
+  const auto r = run(2.0, 1.0, lat_off);
+  EXPECT_NEAR(r.lateral, exp_lat, 1e-9);
   EXPECT_NEAR(r.var_lat, exp_var, 1e-9);
+}
+
+// Zone 2 close-side full: left edge exactly at tracker boundary (gap_L=0) → no correction,
+// center-pull fully suppressed. Anchor stays at its observed position.
+TEST(CorrectWheelAnchorLateral, Zone2CloseSideFullSuppression)
+{
+  // tracker=2 (H=1), polygon=1.0 (half=0.5), offset=0.5
+  // polygon_L=1.0=tracker_L → gap_L=0 → t_close_L=1.0, t_close_R=0 (gap_R=1.0)
+  // effective_t_inner=0, close_correction=0 → lateral_move=0 ; corrected=0.5
+  // resid=0.5*1.0=0.5 → var_lat=0.5
+  const auto r = run(2.0, 1.0, 0.5);
+  EXPECT_NEAR(r.lateral, 0.5, 1e-9);
+  EXPECT_NEAR(r.var_lat, 0.5, 1e-9);
 }
 
 // Zone 3 symmetric: wide polygon centered -> both sides cancel, no net move, no residual.
@@ -120,13 +163,13 @@ TEST(CorrectWheelAnchorLateral, Zone3PartialOneSideCorrected)
   // tracker=2 H=1, polygon=2.6 (half=1.3), offset=0.3
   // excess_L = 0.3+1.3-1 = 0.6 -> zone 3, t_L = clamp((0.6-0.2)/0.2, 0,1) = 1.0
   // excess_R = -1-(0.3-1.3) = 0.0 -> zone 1, t_R = 0
-  const double H       = 1.0;
-  const double dead    = kDeadFrac * H;
-  const double outer   = kOuterFrac * H;
-  const double exc_L   = 0.6;
-  const double exc_R   = 0.0;
-  const double t_L     = std::clamp((exc_L - dead) / (outer - dead), 0.0, 1.0);
-  const double t_R     = 0.0;
+  const double H = 1.0;
+  const double dead = kDeadFrac * H;
+  const double outer = kOuterFrac * H;
+  const double exc_L = 0.6;
+  const double exc_R = 0.0;
+  const double t_L = std::clamp((exc_L - dead) / (outer - dead), 0.0, 1.0);
+  const double t_R = 0.0;
   const double exp_move = -exc_L * t_L + exc_R * t_R;
   const auto r = run(2.0, 2.6, 0.3);
   EXPECT_NEAR(r.lateral, 0.3 + exp_move, 1e-9);
@@ -137,28 +180,29 @@ TEST(CorrectWheelAnchorLateral, Zone3PartialOneSideCorrected)
 TEST(CorrectWheelAnchorLateral, ContinuousAtZone1Zone2Boundary)
 {
   constexpr double eps = 1e-6;
-  // tracker=2 H=1, polygon_width chosen so excess_L = -(dead ± eps), offset=0 keeps both sides equal
-  // dead = 0.2, excess = polygon_half - 1 => polygon_half = 1 + excess => polygon_width = 2*(1+excess)
+  // tracker=2 H=1, polygon_width chosen so excess_L = -(dead ± eps), offset=0 keeps both sides
+  // equal dead = 0.2, excess = polygon_half - 1 => polygon_half = 1 + excess => polygon_width =
+  // 2*(1+excess)
   const double dead = kDeadFrac * 1.0;
-  const double w_in  = 2.0 * (1.0 - dead + eps);  // excess just inside dead zone
+  const double w_in = 2.0 * (1.0 - dead + eps);   // excess just inside dead zone
   const double w_out = 2.0 * (1.0 - dead - eps);  // excess just below dead zone (zone 2)
-  const auto inside  = run(2.0, w_in,  0.0);
+  const auto inside = run(2.0, w_in, 0.0);
   const auto outside = run(2.0, w_out, 0.0);
-  EXPECT_NEAR(inside.lateral,  outside.lateral,  1e-4);
-  EXPECT_NEAR(inside.var_lat,  outside.var_lat,  1e-4);
+  EXPECT_NEAR(inside.lateral, outside.lateral, 1e-4);
+  EXPECT_NEAR(inside.var_lat, outside.var_lat, 1e-4);
 }
 
 // Continuity at zone 1/3 boundary: just inside vs just outside dead zone (wide side).
 TEST(CorrectWheelAnchorLateral, ContinuousAtZone1Zone3Boundary)
 {
   constexpr double eps = 1e-6;
-  const double dead  = kDeadFrac * 1.0;
-  const double w_in  = 2.0 * (1.0 + dead - eps);  // excess just below dead (zone 1)
+  const double dead = kDeadFrac * 1.0;
+  const double w_in = 2.0 * (1.0 + dead - eps);   // excess just below dead (zone 1)
   const double w_out = 2.0 * (1.0 + dead + eps);  // excess just above dead (zone 3)
-  const auto inside  = run(2.0, w_in,  0.0);
+  const auto inside = run(2.0, w_in, 0.0);
   const auto outside = run(2.0, w_out, 0.0);
-  EXPECT_NEAR(inside.lateral,  outside.lateral,  1e-4);
-  EXPECT_NEAR(inside.var_lat,  outside.var_lat,  1e-4);
+  EXPECT_NEAR(inside.lateral, outside.lateral, 1e-4);
+  EXPECT_NEAR(inside.var_lat, outside.var_lat, 1e-4);
 }
 
 // Sign symmetry: flipping lateral_offset mirrors corrected lateral and preserves variance.
@@ -168,7 +212,7 @@ TEST(CorrectWheelAnchorLateral, SignSymmetry)
   const auto pos = run(2.0, 3.6, +d);
   const auto neg = run(2.0, 3.6, -d);
   EXPECT_NEAR(pos.lateral, -neg.lateral, 1e-9);
-  EXPECT_NEAR(pos.var_lat,  neg.var_lat, 1e-9);
+  EXPECT_NEAR(pos.var_lat, neg.var_lat, 1e-9);
 }
 
 }  // namespace autoware::multi_object_tracker

--- a/perception/autoware_multi_object_tracker/test/test_vehicle_tracker.cpp
+++ b/perception/autoware_multi_object_tracker/test/test_vehicle_tracker.cpp
@@ -22,13 +22,11 @@ namespace autoware::multi_object_tracker
 {
 namespace
 {
-// Matches the constants defined inside correctWheelAnchorLateral.
-constexpr double kAlpha = 0.2;  // balance_alpha
-constexpr double kBeta = 0.3;   // corner_residual_beta
+// Mirrors the zone constants defined inside correctWheelAnchorLateral.
+constexpr double kDeadFrac  = 0.20;
+constexpr double kInnerFrac = 0.50;
+constexpr double kOuterFrac = 0.40;
 
-// correctWheelAnchorLateral is pure scalar math: given the signed lateral offset of the observed
-// edge center from the tracker center, it returns the lateral move and added variance. The
-// corrected lateral coordinate is `lateral_offset + lateral_move`.
 struct LateralResult
 {
   double lateral;  // corrected lateral coordinate (= lateral_offset + lateral_move)
@@ -37,81 +35,140 @@ struct LateralResult
 
 LateralResult run(double tracker_width, double polygon_width, double lateral_offset)
 {
+  const double tracker_half = tracker_width * 0.5;
+  const double polygon_half = polygon_width * 0.5;
   double var_lat = 0.0;
-  const double lateral_move =
-    correctWheelAnchorLateral(lateral_offset, tracker_width, polygon_width, var_lat);
+  const double lateral_move = correctWheelAnchorLateral(
+    +tracker_half, -tracker_half,
+    lateral_offset + polygon_half, lateral_offset - polygon_half,
+    var_lat);
   return {lateral_offset + lateral_move, var_lat};
 }
 }  // namespace
 
-// Equal widths: no slack, no gap -> anchor untouched, no added variance.
-TEST(CorrectWheelAnchorLateral, EqualWidthIsNoOp)
+// Equal widths, centered: all excesses are zero -> zone 1, no correction, no variance.
+TEST(CorrectWheelAnchorLateral, EqualWidthCenteredIsNoOp)
 {
-  const auto r = run(2.0, 2.0, 0.5);
-  EXPECT_DOUBLE_EQ(r.lateral, 0.5);  // anchor unchanged
+  const auto r = run(2.0, 2.0, 0.0);
+  EXPECT_DOUBLE_EQ(r.lateral, 0.0);
   EXPECT_DOUBLE_EQ(r.var_lat, 0.0);
 }
 
-// Polygon narrower than the tracker (partial view): anchor kept, worst-case lateral offset added
-// as variance, var = ((w_t - w_p) / 2)^2.
-TEST(CorrectWheelAnchorLateral, NarrowPolygonAddsVarianceOnly)
+// Zone 1: polygon slightly wider than tracker (excess < dead), centered.
+// No correction; uncorrected residuals (0.1 each side) contribute to var.
+TEST(CorrectWheelAnchorLateral, Zone1DeadZoneNoCorrection)
 {
-  const auto r = run(2.0, 1.0, 0.5);
-  EXPECT_DOUBLE_EQ(r.lateral, 0.5);   // anchor unchanged
-  EXPECT_DOUBLE_EQ(r.var_lat, 0.25);  // (0.5)^2
-}
-
-// Wide polygon, observed center on the body axis: nothing to pull, full slack uncertainty.
-TEST(CorrectWheelAnchorLateral, WideCenteredHoldsAnchorMaxVariance)
-{
-  const double slack = 1.0;  // (4 - 2) / 2
-  const auto r = run(2.0, 4.0, 0.0);
+  // tracker_width=2 -> H=1, dead=0.2. polygon_width=2.2 -> excess=0.1 on both sides.
+  const double exc = 0.1;  // < dead (=0.2*H=0.2)
+  const auto r = run(2.0, 2.2, 0.0);
   EXPECT_DOUBLE_EQ(r.lateral, 0.0);
-  EXPECT_DOUBLE_EQ(r.var_lat, slack * slack);  // std = slack
+  EXPECT_NEAR(r.var_lat, exc * exc + exc * exc, 1e-9);
 }
 
-// Wide polygon, observed center inside the slack: anchor held near the tracker (slope alpha), so it
-// is pulled back toward the body axis rather than snapped to the observed center.
-TEST(CorrectWheelAnchorLateral, WideContainedPullsTowardTracker)
+// Zone 2 symmetric: polygon much narrower, centered -> corrections cancel, no net move.
+TEST(CorrectWheelAnchorLateral, Zone2SymmetricNoMove)
 {
-  const double slack = 1.0;
-  const double d = 0.5;  // < slack -> contained
-  const auto r = run(2.0, 4.0, d);
-  EXPECT_DOUBLE_EQ(r.lateral, kAlpha * d);  // 0.1, pulled in from 0.5
-  const double t = d / slack;
-  const double std_lat = slack * (1.0 - (1.0 - kBeta) * t);
-  EXPECT_DOUBLE_EQ(r.var_lat, std_lat * std_lat);
+  // excess_L = excess_R = 0.25 - 1.0 = -0.75 -> both fully matched (t=1)
+  const auto r = run(2.0, 0.5, 0.0);
+  EXPECT_DOUBLE_EQ(r.lateral, 0.0);
+  EXPECT_DOUBLE_EQ(r.var_lat, 0.0);  // t=1 -> residual = 0
 }
 
-// Wide polygon, observed center beyond the slack: a corner is exposed, anchor follows it (unit
-// slope) and the added variance shrinks toward beta * slack.
-TEST(CorrectWheelAnchorLateral, WideUncontainedFollowsCorner)
+// Zone 2 asymmetric: narrow polygon offset left, width-based weight pulls anchor toward center.
+TEST(CorrectWheelAnchorLateral, Zone2WidthBasedPullsTowardCenter)
 {
-  const double slack = 1.0;
-  const double d = 2.0;  // > slack -> corner exposed
-  const auto r = run(2.0, 4.0, d);
-  EXPECT_DOUBLE_EQ(r.lateral, (d - slack) + kAlpha * slack);       // 1.2
-  EXPECT_DOUBLE_EQ(r.var_lat, (kBeta * slack) * (kBeta * slack));  // std = beta * slack
+  // tracker=2 (H=1), polygon=1.4 (half=0.7), offset=0.4
+  // half_width_miss = (2-1.4)/2 = 0.3; dead=0.2, inner=0.5
+  // t_inner = clamp((0.3-0.2)/(0.5-0.2), 0,1) = 1/3
+  // lateral_move = -0.4 * (1/3) = -2/15
+  // resid = 0.3 * (2/3) = 0.2 -> var_lat = 2*0.04 = 0.08
+  const double dead         = kDeadFrac * 1.0;
+  const double inner        = kInnerFrac * 1.0;
+  const double half_wm      = 0.3;
+  const double lat_off      = 0.4;
+  const double t_inner      = std::clamp((half_wm - dead) / (inner - dead), 0.0, 1.0);
+  const double exp_move     = -lat_off * t_inner;
+  const double resid        = half_wm * (1.0 - t_inner);
+  const double exp_var      = 2.0 * resid * resid;
+  const auto r = run(2.0, 1.4, lat_off);
+  EXPECT_NEAR(r.lateral, lat_off + exp_move, 1e-9);
+  EXPECT_NEAR(r.var_lat, exp_var, 1e-9);
 }
 
-// The dead-zone is continuous at |d| = slack: both branches agree on anchor and variance.
-TEST(CorrectWheelAnchorLateral, ContinuousAtBoundary)
+// Zone 3 symmetric: wide polygon centered -> both sides cancel, no net move, no residual.
+TEST(CorrectWheelAnchorLateral, Zone3SymmetricNoMove)
 {
-  const double slack = 1.0;
-  const double eps = 1e-6;
-  const auto inside = run(2.0, 4.0, slack - eps);
-  const auto outside = run(2.0, 4.0, slack + eps);
-  EXPECT_NEAR(inside.lateral, outside.lateral, 1e-4);
-  EXPECT_NEAR(inside.var_lat, outside.var_lat, 1e-4);
+  // tracker=2 H=1, polygon=3.6 -> excess = 0.8 on both sides (>> outer=0.4), t=1
+  const auto r = run(2.0, 3.6, 0.0);
+  EXPECT_DOUBLE_EQ(r.lateral, 0.0);
+  EXPECT_DOUBLE_EQ(r.var_lat, 0.0);
 }
 
-// Sign symmetry: a negative lateral offset mirrors the positive case.
+// Zone 3 asymmetric: wide polygon, anchor offset left -> net move right (toward tracker center).
+TEST(CorrectWheelAnchorLateral, Zone3AsymmetricPullsTowardCenter)
+{
+  // tracker=2 H=1, polygon=3.6, offset=0.3
+  // excess_L = 0.3+1.8-1 = 1.1 -> t_L=1.0, excess_R = -1-(0.3-1.8) = 0.5 -> t_R=1.0
+  const auto r = run(2.0, 3.6, 0.3);
+  EXPECT_NEAR(r.lateral, 0.3 + (-1.1 * 1.0 + 0.5 * 1.0), 1e-9);  // = -0.3
+  EXPECT_DOUBLE_EQ(r.var_lat, 0.0);
+}
+
+// Zone 3 partial: one side in zone 3 (partially), other in zone 1.
+TEST(CorrectWheelAnchorLateral, Zone3PartialOneSideCorrected)
+{
+  // tracker=2 H=1, polygon=2.6 (half=1.3), offset=0.3
+  // excess_L = 0.3+1.3-1 = 0.6 -> zone 3, t_L = clamp((0.6-0.2)/0.2, 0,1) = 1.0
+  // excess_R = -1-(0.3-1.3) = 0.0 -> zone 1, t_R = 0
+  const double H       = 1.0;
+  const double dead    = kDeadFrac * H;
+  const double outer   = kOuterFrac * H;
+  const double exc_L   = 0.6;
+  const double exc_R   = 0.0;
+  const double t_L     = std::clamp((exc_L - dead) / (outer - dead), 0.0, 1.0);
+  const double t_R     = 0.0;
+  const double exp_move = -exc_L * t_L + exc_R * t_R;
+  const auto r = run(2.0, 2.6, 0.3);
+  EXPECT_NEAR(r.lateral, 0.3 + exp_move, 1e-9);
+  EXPECT_NEAR(r.var_lat, 0.0, 1e-9);  // both residuals are 0
+}
+
+// Continuity at zone 1/2 boundary: just inside vs just outside dead zone -> nearly identical.
+TEST(CorrectWheelAnchorLateral, ContinuousAtZone1Zone2Boundary)
+{
+  constexpr double eps = 1e-6;
+  // tracker=2 H=1, polygon_width chosen so excess_L = -(dead ± eps), offset=0 keeps both sides equal
+  // dead = 0.2, excess = polygon_half - 1 => polygon_half = 1 + excess => polygon_width = 2*(1+excess)
+  const double dead = kDeadFrac * 1.0;
+  const double w_in  = 2.0 * (1.0 - dead + eps);  // excess just inside dead zone
+  const double w_out = 2.0 * (1.0 - dead - eps);  // excess just below dead zone (zone 2)
+  const auto inside  = run(2.0, w_in,  0.0);
+  const auto outside = run(2.0, w_out, 0.0);
+  EXPECT_NEAR(inside.lateral,  outside.lateral,  1e-4);
+  EXPECT_NEAR(inside.var_lat,  outside.var_lat,  1e-4);
+}
+
+// Continuity at zone 1/3 boundary: just inside vs just outside dead zone (wide side).
+TEST(CorrectWheelAnchorLateral, ContinuousAtZone1Zone3Boundary)
+{
+  constexpr double eps = 1e-6;
+  const double dead  = kDeadFrac * 1.0;
+  const double w_in  = 2.0 * (1.0 + dead - eps);  // excess just below dead (zone 1)
+  const double w_out = 2.0 * (1.0 + dead + eps);  // excess just above dead (zone 3)
+  const auto inside  = run(2.0, w_in,  0.0);
+  const auto outside = run(2.0, w_out, 0.0);
+  EXPECT_NEAR(inside.lateral,  outside.lateral,  1e-4);
+  EXPECT_NEAR(inside.var_lat,  outside.var_lat,  1e-4);
+}
+
+// Sign symmetry: flipping lateral_offset mirrors corrected lateral and preserves variance.
 TEST(CorrectWheelAnchorLateral, SignSymmetry)
 {
-  const auto pos = run(2.0, 4.0, 1.5);
-  const auto neg = run(2.0, 4.0, -1.5);
-  EXPECT_DOUBLE_EQ(pos.lateral, -neg.lateral);
-  EXPECT_DOUBLE_EQ(pos.var_lat, neg.var_lat);
+  const double d = 0.3;
+  const auto pos = run(2.0, 3.6, +d);
+  const auto neg = run(2.0, 3.6, -d);
+  EXPECT_NEAR(pos.lateral, -neg.lateral, 1e-9);
+  EXPECT_NEAR(pos.var_lat,  neg.var_lat, 1e-9);
 }
 
 }  // namespace autoware::multi_object_tracker

--- a/perception/autoware_multi_object_tracker/test/test_vehicle_tracker.cpp
+++ b/perception/autoware_multi_object_tracker/test/test_vehicle_tracker.cpp
@@ -22,14 +22,14 @@ namespace autoware::multi_object_tracker
 {
 namespace
 {
-// Matches the constants defined inside correctWheelAnchorLateral.
-constexpr double kAlpha = 0.2;  // balance_alpha
-constexpr double kBeta = 0.3;   // corner_residual_beta
-
 // correctWheelAnchorLateral is pure scalar math over the four lateral edge coordinates. The
 // measurement polygon is centered on the observed edge-center anchor (lateral_offset), so its edges
 // sit at lateral_offset +/- polygon_half; the tracker is centered, with edges at +/- tracker_half.
-// The corrected lateral coordinate is `lateral_offset + lateral_move`.
+//
+// Aligning the fixed-width tracker box to each polygon edge gives two candidate vehicle centers;
+// their segment is the lateral "dead-zone" (width |polygon_width - tracker_width|). The corrected
+// lateral coordinate is the tracker center (0) projected into that dead-zone, and the added lateral
+// variance is the dead-zone half-width squared.
 struct LateralResult
 {
   double lateral;  // corrected lateral coordinate (= lateral_offset + lateral_move)
@@ -46,9 +46,17 @@ LateralResult run(double tracker_width, double polygon_width, double lateral_off
     var_lat);
   return {lateral_offset + lateral_move, var_lat};
 }
+
+// Variance is the dead-zone half-width squared, independent of the offset.
+double expectedVar(double tracker_width, double polygon_width)
+{
+  const double half_dead_zone = 0.5 * std::abs(polygon_width - tracker_width);
+  return half_dead_zone * half_dead_zone;
+}
 }  // namespace
 
-// Equal widths: no slack, no overhang -> anchor untouched, no added variance.
+// Equal widths: zero dead-zone, the two candidate centers coincide -> anchor untouched, no
+// variance.
 TEST(CorrectWheelAnchorLateral, EqualWidthIsNoOp)
 {
   const auto r = run(2.0, 2.0, 0.5);
@@ -56,55 +64,48 @@ TEST(CorrectWheelAnchorLateral, EqualWidthIsNoOp)
   EXPECT_DOUBLE_EQ(r.var_lat, 0.0);
 }
 
-// Polygon narrower than the tracker (partial view): anchor kept, worst-case lateral offset added
-// as variance, var = ((w_t - w_p) / 2)^2.
-TEST(CorrectWheelAnchorLateral, NarrowPolygonAddsVarianceOnly)
+// Row 1 - polygon smaller than the tracker and fully inside it (both overhangs negative): the
+// tracker center sits inside the dead-zone, so the anchor snaps to the tracker lateral center.
+TEST(CorrectWheelAnchorLateral, SmallPolygonWithinSnapsToCenter)
 {
-  const auto r = run(2.0, 1.0, 0.5);
-  EXPECT_DOUBLE_EQ(r.lateral, 0.5);   // anchor unchanged
-  EXPECT_DOUBLE_EQ(r.var_lat, 0.25);  // (0.5)^2
-}
-
-// Wide polygon, observed center on the body axis: nothing to pull, full slack uncertainty.
-TEST(CorrectWheelAnchorLateral, WideCenteredHoldsAnchorMaxVariance)
-{
-  const double slack = 1.0;  // (4 - 2) / 2
-  const auto r = run(2.0, 4.0, 0.0);
+  const auto r = run(2.0, 1.0, 0.3);  // polygon [-0.2, 0.8] inside tracker [-1, 1]
   EXPECT_DOUBLE_EQ(r.lateral, 0.0);
-  EXPECT_DOUBLE_EQ(r.var_lat, slack * slack);  // std = slack
+  EXPECT_DOUBLE_EQ(r.var_lat, expectedVar(2.0, 1.0));  // 0.25
 }
 
-// Wide polygon, observed center inside the slack: anchor held near the tracker (slope alpha), so it
-// is pulled back toward the body axis rather than snapped to the observed center.
-TEST(CorrectWheelAnchorLateral, WideContainedPullsTowardTracker)
+// Row 2 - polygon smaller than the tracker but one edge protrudes (one overhang positive): the
+// protruding polygon edge is taken as a real vehicle edge and the box slides by that overhang.
+TEST(CorrectWheelAnchorLateral, SmallPolygonProtrudingFollowsEdge)
 {
-  const double slack = 1.0;
-  const double d = 0.5;  // < slack -> contained
-  const auto r = run(2.0, 4.0, d);
-  EXPECT_DOUBLE_EQ(r.lateral, kAlpha * d);  // 0.1, pulled in from 0.5
-  const double t = d / slack;
-  const double std_lat = slack * (1.0 - (1.0 - kBeta) * t);
-  EXPECT_DOUBLE_EQ(r.var_lat, std_lat * std_lat);
+  const auto r = run(2.0, 1.0, 0.8);  // polygon [0.3, 1.3], left edge protrudes past tracker 1.0
+  EXPECT_DOUBLE_EQ(r.lateral, 0.3);   // tracker_center + overhang_left (1.3 - 1.0)
+  EXPECT_DOUBLE_EQ(r.var_lat, expectedVar(2.0, 1.0));  // 0.25
 }
 
-// Wide polygon, observed center beyond the slack: a corner is exposed, anchor follows it (unit
-// slope) and the added variance shrinks toward beta * slack.
-TEST(CorrectWheelAnchorLateral, WideUncontainedFollowsCorner)
+// Row 3 - polygon larger than the tracker, tracker fully inside it (both overhangs positive): the
+// tracker center is inside the dead-zone, so the anchor is held at the tracker center.
+TEST(CorrectWheelAnchorLateral, WidePolygonStraddlingHoldsCenter)
 {
-  const double slack = 1.0;
-  const double d = 2.0;  // > slack -> corner exposed
-  const auto r = run(2.0, 4.0, d);
-  EXPECT_DOUBLE_EQ(r.lateral, (d - slack) + kAlpha * slack);       // 1.2
-  EXPECT_DOUBLE_EQ(r.var_lat, (kBeta * slack) * (kBeta * slack));  // std = beta * slack
+  const auto r = run(2.0, 4.0, 0.5);  // polygon [-1.5, 2.5] straddles tracker [-1, 1]
+  EXPECT_DOUBLE_EQ(r.lateral, 0.0);
+  EXPECT_DOUBLE_EQ(r.var_lat, expectedVar(2.0, 4.0));  // 1.0
 }
 
-// The dead-zone is continuous at |d| = slack: both branches agree on anchor and variance.
+// Row 4 - polygon larger than the tracker but one edge recedes inside it (one overhang negative):
+// the recessed polygon edge is the real vehicle edge; the anchor snaps to that edge-aligned center.
+TEST(CorrectWheelAnchorLateral, WidePolygonRecedingFollowsEdge)
+{
+  const auto r = run(2.0, 4.0, 2.0);  // polygon [0, 4], right edge 0 recedes inside tracker
+  EXPECT_DOUBLE_EQ(r.lateral, 1.0);   // tracker right edge aligned to polygon_right (0 + 1)
+  EXPECT_DOUBLE_EQ(r.var_lat, expectedVar(2.0, 4.0));  // 1.0
+}
+
+// The projection is continuous as the tracker center crosses the dead-zone boundary.
 TEST(CorrectWheelAnchorLateral, ContinuousAtBoundary)
 {
-  const double slack = 1.0;
   const double eps = 1e-6;
-  const auto inside = run(2.0, 4.0, slack - eps);
-  const auto outside = run(2.0, 4.0, slack + eps);
+  const auto inside = run(2.0, 4.0, 1.0 - eps);
+  const auto outside = run(2.0, 4.0, 1.0 + eps);
   EXPECT_NEAR(inside.lateral, outside.lateral, 1e-4);
   EXPECT_NEAR(inside.var_lat, outside.var_lat, 1e-4);
 }
@@ -112,8 +113,8 @@ TEST(CorrectWheelAnchorLateral, ContinuousAtBoundary)
 // Sign symmetry: a negative lateral offset mirrors the positive case.
 TEST(CorrectWheelAnchorLateral, SignSymmetry)
 {
-  const auto pos = run(2.0, 4.0, 1.5);
-  const auto neg = run(2.0, 4.0, -1.5);
+  const auto pos = run(2.0, 4.0, 2.0);
+  const auto neg = run(2.0, 4.0, -2.0);
   EXPECT_DOUBLE_EQ(pos.lateral, -neg.lateral);
   EXPECT_DOUBLE_EQ(pos.var_lat, neg.var_lat);
 }

--- a/perception/autoware_multi_object_tracker/test/test_vehicle_tracker.cpp
+++ b/perception/autoware_multi_object_tracker/test/test_vehicle_tracker.cpp
@@ -22,9 +22,9 @@ namespace autoware::multi_object_tracker
 {
 namespace
 {
-// correctWheelAnchorLateral is pure scalar math over the four lateral edge coordinates. The
-// measurement polygon is centered on the observed edge-center anchor (lateral_offset), so its edges
-// sit at lateral_offset +/- polygon_half; the tracker is centered, with edges at +/- tracker_half.
+// correctWheelAnchorLateral is pure scalar math. The measurement polygon is centered on the
+// observed edge-center anchor (lateral_offset) with half-width polygon_half; the tracker is
+// centered at 0 with half-width tracker_half.
 //
 // Aligning the fixed-width tracker box to each polygon edge gives two candidate vehicle centers;
 // their segment is the lateral "dead-zone" (width |polygon_width - tracker_width|). The corrected
@@ -41,9 +41,8 @@ LateralResult run(double tracker_width, double polygon_width, double lateral_off
   const double tracker_half = tracker_width * 0.5;
   const double polygon_half = polygon_width * 0.5;
   double var_lat = 0.0;
-  const double lateral_move = correctWheelAnchorLateral(
-    +tracker_half, -tracker_half, lateral_offset + polygon_half, lateral_offset - polygon_half,
-    var_lat);
+  const double lateral_move =
+    correctWheelAnchorLateral(lateral_offset, tracker_half, polygon_half, var_lat);
   return {lateral_offset + lateral_move, var_lat};
 }
 


### PR DESCRIPTION
## Description

This PR reworks the vehicle wheel-anchor update so that observing one face (front or rear edge) of a vehicle cluster corrects the body **pose without freezing or corrupting yaw**, and makes the yaw-rate process noise physically consistent with the nonholonomic vehicle model.

### Motivation

When only one end of a vehicle is observed (typical for partially-occluded clusters), the previous wheel-anchor update translated both bicycle-model endpoints rigidly. This effectively froze the yaw observation and, when the cluster polygon width disagreed with the tracked box width, the laterally-biased edge center was amplified by the wheel-base lever into spurious yaw. The result was unstable headings on partially-observed vehicles.

### Key changes

**1. Face-center wheel-anchor measurement (`bicycle_motion_model`)**
- Replaced `updateStatePoseRear` / `updateStatePoseFront` with a single `updateStatePoseWheel(x, y, pose_cov, measure_front)`.
- The observed edge face center is now modeled as an exact linear blend of the two endpoints: `face = (1 + gamma) * p_near - gamma * p_far` (2-row measurement instead of the old 4-row rigid-translation form). This lets the body **rotate about the observed end** rather than translating rigidly, restoring the weak-heading observation that the old update discarded.

**2. Lateral wheel-anchor correction (`vehicle_update_strategy`)**
- New `correctWheelAnchorLateral` / `correctWheelAnchor` helpers.
- When the measurement polygon width disagrees with the fixed-width tracker box, the anchor is snapped into a dead-zone of `±|polygon_half − tracker_half|` and the extra lateral uncertainty is folded into `pose_cov` (added as `var_lat · n·nᵀ` on the x/y block). This removes the lateral bias before it can be levered into yaw.
- The aligned measurement (cluster expressed in the tracker frame) is used so the polygon width/anchor are in the correct frame.

**3. Nonholonomic yaw-rate process noise (`bicycle_motion_model`)**
- Yaw-rate uncertainty now scales with speed and **vanishes at standstill** (a stationary vehicle cannot change heading without translating).
- Reduced `q_stddev_yaw_rate_min` from `0.02618` (1.5 deg/s) to `0.00873` (0.5 deg/s) for steadier headings.

**4. Cleanup / refactor**
- `createPseudoMeasurement` now returns a `DynamicObject` copy instead of mutating in place, and no longer takes a redundant `tracker_shape` argument (it uses the prediction's own shape).
- Dropped the `tracker_shape` parameter from `conditionedUpdate` across `Tracker`, `MultipleVehicleTracker`, and `VehicleTracker`.
- Split `shapes.{hpp,cpp}` into `shapes_transform.{hpp,cpp}` (shape transforms, cluster-to-orientation alignment, convert-to-bbox) and `shapes_iou.{hpp,cpp}` (1D/2D/3D IoU & GIoU scoring); updated the shape-model and assignment-scoring call sites accordingly.


## Related links

**Parent Issue:**

- Link

## How was this PR tested?

- Added `test/test_vehicle_tracker.cpp` with unit tests for `correctWheelAnchorLateral` covering: equal-width no-op, small polygon snapping to center / following a protruding edge, wide polygon straddling / receding, boundary continuity, and sign symmetry.
- Existing `multi_object_tracker` unit tests pass.
- Validated on recorded scenes (see Before/After).
    * Simulated by logging-simulation, sample ros bag.
    * Intentionally dropped Lidar ML detection(centerpoint_tiny) rate by raising `min_confidence_scores` to 0.62
    * Lidar clustering done by PTv3 pipeline (`use_semantic_segmentation_ptv3:=true`)

### Before

https://github.com/user-attachments/assets/54871886-256d-49ab-ab3e-a7d0c53252fc

### After

https://github.com/user-attachments/assets/7707ab3e-f104-4cbe-8ab1-d34475d14a8e
## Notes for reviewers

None.

## Interface changes

None. (Internal `conditionedUpdate` / wheel-anchor APIs changed; no ROS topic or parameter interface changes.)

## Effects on system behavior

Improves yaw stability of partially-observed vehicle tracks (single-face observations) and prevents polygon/box width mismatch from being levered into spurious heading changes.