### PR TITLE
feat(ptv3): add SemanticLabel enum

### DIFF
--- a/perception/autoware_ptv3/CMakeLists.txt
+++ b/perception/autoware_ptv3/CMakeLists.txt
@@ -48,10 +48,15 @@ else()
   set(TRT_AVAIL OFF)
 endif()
 
-if(TRT_AVAIL AND CUDA_AVAIL)
-  find_package(ament_cmake_auto REQUIRED)
-  ament_auto_find_build_dependencies()
+if(BUILD_TESTING)
+  find_package(ament_cmake_gtest REQUIRED)
 
+  ament_add_gtest(semantic_label_test test/semantic_label_test.cpp)
+  target_include_directories(semantic_label_test PRIVATE include)
+  ament_target_dependencies(semantic_label_test autoware_perception_msgs)
+endif()
+
+if(TRT_AVAIL AND CUDA_AVAIL)
   include_directories(
     include
     ${CUDA_INCLUDE_DIRS}
@@ -133,8 +138,6 @@ if(TRT_AVAIL AND CUDA_AVAIL)
   )
 
   if(BUILD_TESTING)
-    find_package(ament_cmake_gtest REQUIRED)
-
     ament_add_gtest(serialized_pooling_metadata_test
       test/serialized_pooling_metadata_test.cpp
     )
@@ -148,16 +151,6 @@ if(TRT_AVAIL AND CUDA_AVAIL)
         ${CUDA_INCLUDE_DIRS}
       )
     endif()
-
-    ament_add_gtest(semantic_label_test
-      test/semantic_label_test.cpp
-    )
-    if(TARGET semantic_label_test)
-      target_include_directories(semantic_label_test PRIVATE
-        include
-      )
-      ament_target_dependencies(semantic_label_test autoware_perception_msgs)
-    endif()
   endif()
 
   ament_auto_package(
@@ -167,9 +160,6 @@ if(TRT_AVAIL AND CUDA_AVAIL)
   )
 
 else()
-  find_package(ament_cmake_auto REQUIRED)
-  ament_auto_find_build_dependencies()
-
   ament_auto_package(
     INSTALL_TO_SHARE
       launch

--- a/perception/autoware_ptv3/CMakeLists.txt
+++ b/perception/autoware_ptv3/CMakeLists.txt
@@ -148,6 +148,16 @@ if(TRT_AVAIL AND CUDA_AVAIL)
         ${CUDA_INCLUDE_DIRS}
       )
     endif()
+
+    ament_add_gtest(semantic_label_test
+      test/semantic_label_test.cpp
+    )
+    if(TARGET semantic_label_test)
+      target_include_directories(semantic_label_test PRIVATE
+        include
+      )
+      ament_target_dependencies(semantic_label_test autoware_perception_msgs)
+    endif()
   endif()
 
   ament_auto_package(

--- a/perception/autoware_ptv3/include/autoware/ptv3/experimental/semantic_label.hpp
+++ b/perception/autoware_ptv3/include/autoware/ptv3/experimental/semantic_label.hpp
@@ -15,17 +15,10 @@
 #ifndef AUTOWARE__PTV3__EXPERIMENTAL__SEMANTIC_LABEL_HPP_
 #define AUTOWARE__PTV3__EXPERIMENTAL__SEMANTIC_LABEL_HPP_
 
-#include <autoware_perception_msgs/msg/object_classification.hpp>
-
 #include <cstdint>
-#include <optional>
-#include <string_view>
 
 namespace autoware::ptv3::experimental
 {
-using autoware_perception_msgs::msg::ObjectClassification;
-using ObjectLabel = ObjectClassification::_label_type;
-
 /// @brief Semantic labels for point cloud segmentation.
 /// @details
 /// Consolidated labels representing different point cloud categories:
@@ -47,117 +40,6 @@ enum class SemanticLabel : std::uint8_t {
   VEGETATION = 8,
   NOISE = 9,
 };
-
-/// @brief Get the string representation of a semantic label.
-/// @param label The semantic label to convert.
-/// @return String view of the label name (e.g., "CAR", "HAZARD", "STRUCTURE").
-constexpr std::string_view to_string(SemanticLabel label) noexcept
-{
-  switch (label) {
-    case SemanticLabel::CAR:
-      return "CAR";
-    case SemanticLabel::TRUCK:
-      return "TRUCK";
-    case SemanticLabel::BUS:
-      return "BUS";
-    case SemanticLabel::BICYCLE:
-      return "BICYCLE";
-    case SemanticLabel::PEDESTRIAN:
-      return "PEDESTRIAN";
-    case SemanticLabel::HAZARD:
-      return "HAZARD";
-    case SemanticLabel::GROUND:
-      return "GROUND";
-    case SemanticLabel::STRUCTURE:
-      return "STRUCTURE";
-    case SemanticLabel::VEGETATION:
-      return "VEGETATION";
-    case SemanticLabel::NOISE:
-      return "NOISE";
-    default:
-      return "UNKNOWN";
-  }
-}
-
-/// @brief Convert a semantic label to ObjectClassification label type where applicable.
-/// @param label The semantic label to convert.
-/// @return The ObjectClassification label value (as uint8_t), or std::nullopt if the label
-///         does not map to an object class (e.g., GROUND, STRUCTURE, VEGETATION, NOISE).
-/// @details
-/// Mapping:
-/// - CAR -> 1 (ObjectClassification::CAR)
-/// - TRUCK -> 2 (ObjectClassification::TRUCK)
-/// - BUS -> 3 (ObjectClassification::BUS)
-/// - BICYCLE -> 6 (ObjectClassification::BICYCLE)
-/// - PEDESTRIAN -> 7 (ObjectClassification::PEDESTRIAN)
-/// - HAZARD -> 9 (ObjectClassification::HAZARD)
-/// - GROUND, STRUCTURE, VEGETATION, NOISE -> std::nullopt (non-object labels)
-constexpr std::optional<ObjectLabel> try_into_object(SemanticLabel label) noexcept
-{
-  switch (label) {
-    case SemanticLabel::CAR:
-      return ObjectClassification::CAR;
-    case SemanticLabel::TRUCK:
-      return ObjectClassification::TRUCK;
-    case SemanticLabel::BUS:
-      return ObjectClassification::BUS;
-    case SemanticLabel::BICYCLE:
-      return ObjectClassification::BICYCLE;
-    case SemanticLabel::PEDESTRIAN:
-      return ObjectClassification::PEDESTRIAN;
-    case SemanticLabel::HAZARD:
-      return ObjectClassification::HAZARD;
-    case SemanticLabel::GROUND:
-    case SemanticLabel::STRUCTURE:
-    case SemanticLabel::VEGETATION:
-    case SemanticLabel::NOISE:
-      return std::nullopt;
-    default:
-      return std::nullopt;
-  }
-}
-
-/// @brief Convert an ObjectClassification label to its most likely semantic label.
-/// @param label The ObjectClassification label value (uint8_t).
-/// @return The corresponding SemanticLabel, or std::nullopt if the object class cannot be mapped.
-/// @details
-/// Reverse mapping (non-unique, maps to most common PTv3 output):
-/// - 1 (CAR) -> CAR
-/// - 2 (TRUCK) -> TRUCK
-/// - 3 (BUS) -> BUS
-/// - 6 (BICYCLE) -> BICYCLE
-/// - 7 (PEDESTRIAN) -> PEDESTRIAN
-/// - 9 (HAZARD) -> HAZARD
-/// - Other ObjectClassification values -> std::nullopt
-constexpr std::optional<SemanticLabel> try_into_semantic(std::uint8_t label) noexcept
-{
-  switch (label) {
-    case ObjectClassification::CAR:
-      return SemanticLabel::CAR;
-    case ObjectClassification::TRUCK:
-      return SemanticLabel::TRUCK;
-    case ObjectClassification::BUS:
-      return SemanticLabel::BUS;
-    case ObjectClassification::BICYCLE:
-      return SemanticLabel::BICYCLE;
-    case ObjectClassification::PEDESTRIAN:
-      return SemanticLabel::PEDESTRIAN;
-    case ObjectClassification::HAZARD:
-      return SemanticLabel::HAZARD;
-    default:
-      return std::nullopt;
-  }
-}
-
-/// @brief Check whether a semantic label is compatible with ObjectClassification.
-/// @param label The semantic label to check.
-/// @return true if the label represents an object class that can be converted to
-/// ObjectClassification,
-///         false for environment/non-object labels (GROUND, STRUCTURE, VEGETATION, NOISE).
-constexpr bool is_object_compatible(SemanticLabel label) noexcept
-{
-  return try_into_object(label).has_value();
-}
 
 }  // namespace autoware::ptv3::experimental
 

--- a/perception/autoware_ptv3/include/autoware/ptv3/experimental/semantic_label.hpp
+++ b/perception/autoware_ptv3/include/autoware/ptv3/experimental/semantic_label.hpp
@@ -31,10 +31,10 @@ enum class SemanticLabel : std::uint8_t {
   PEDESTRIAN = 5,
   ANIMAL = 6,
   HAZARD = 7,
-  GROUND = 8,       ///< Drivable ground surface.
-  STRUCTURE = 9,    ///< Non-drivable structures, such as buildings and walls.
-  VEGETATION = 10,  ///< Vegetation, such as trees and bushes.
-  NOISE = 11,       ///< Noise points and outliers.
+  FLAT_SURFACE = 8,  ///< Flat surfaces that can be filtered out.
+  STRUCTURE = 9,     ///< Non-drivable structures, such as buildings and walls.
+  VEGETATION = 10,   ///< Vegetation, such as trees and bushes.
+  NOISE = 11,        ///< Noise points and outliers.
 };
 
 }  // namespace autoware::ptv3::experimental

--- a/perception/autoware_ptv3/include/autoware/ptv3/experimental/semantic_label.hpp
+++ b/perception/autoware_ptv3/include/autoware/ptv3/experimental/semantic_label.hpp
@@ -21,13 +21,6 @@ namespace autoware::ptv3::experimental
 {
 /**
  * @brief Semantic labels for point cloud segmentation.
- * @details
- * Consolidated labels representing different point cloud categories:
- * - CAR, TRUCK, BUS, MOTORCYCLE, BICYCLE, PEDESTRIAN, ANIMAL, HAZARD: Object classes
- * - GROUND: Drivable ground surface
- * - STRUCTURE: Non-drivable structures (e.g., buildings, walls)
- * - VEGETATION: Vegetation (trees, bushes)
- * - NOISE: Noise points and outliers
  */
 enum class SemanticLabel : std::uint8_t {
   CAR = 0,
@@ -38,10 +31,10 @@ enum class SemanticLabel : std::uint8_t {
   PEDESTRIAN = 5,
   ANIMAL = 6,
   HAZARD = 7,
-  GROUND = 8,
-  STRUCTURE = 9,
-  VEGETATION = 10,
-  NOISE = 11,
+  GROUND = 8,       ///< Drivable ground surface.
+  STRUCTURE = 9,    ///< Non-drivable structures, such as buildings and walls.
+  VEGETATION = 10,  ///< Vegetation, such as trees and bushes.
+  NOISE = 11,       ///< Noise points and outliers.
 };
 
 }  // namespace autoware::ptv3::experimental

--- a/perception/autoware_ptv3/include/autoware/ptv3/experimental/semantic_label.hpp
+++ b/perception/autoware_ptv3/include/autoware/ptv3/experimental/semantic_label.hpp
@@ -1,0 +1,164 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__PTV3__EXPERIMENTAL__SEMANTIC_LABEL_HPP_
+#define AUTOWARE__PTV3__EXPERIMENTAL__SEMANTIC_LABEL_HPP_
+
+#include <autoware_perception_msgs/msg/object_classification.hpp>
+
+#include <cstdint>
+#include <optional>
+#include <string_view>
+
+namespace autoware::ptv3::experimental
+{
+using autoware_perception_msgs::msg::ObjectClassification;
+using ObjectLabel = ObjectClassification::_label_type;
+
+/// @brief Semantic labels for point cloud segmentation.
+/// @details
+/// Consolidated labels representing different point cloud categories:
+/// - CAR, TRUCK, BUS, BICYCLE, PEDESTRIAN: Object classes
+/// - HAZARD: Small hazardous objects (e.g., debris, barriers)
+/// - GROUND: Drivable ground surface
+/// - STRUCTURE: Non-drivable structures (e.g., buildings, walls)
+/// - VEGETATION: Vegetation (trees, bushes)
+/// - NOISE: Noise points and outliers
+enum class SemanticLabel : std::uint8_t {
+  CAR = 0,
+  TRUCK = 1,
+  BUS = 2,
+  BICYCLE = 3,
+  PEDESTRIAN = 4,
+  HAZARD = 5,
+  GROUND = 6,
+  STRUCTURE = 7,
+  VEGETATION = 8,
+  NOISE = 9,
+};
+
+/// @brief Get the string representation of a semantic label.
+/// @param label The semantic label to convert.
+/// @return String view of the label name (e.g., "CAR", "HAZARD", "STRUCTURE").
+constexpr std::string_view to_string(SemanticLabel label) noexcept
+{
+  switch (label) {
+    case SemanticLabel::CAR:
+      return "CAR";
+    case SemanticLabel::TRUCK:
+      return "TRUCK";
+    case SemanticLabel::BUS:
+      return "BUS";
+    case SemanticLabel::BICYCLE:
+      return "BICYCLE";
+    case SemanticLabel::PEDESTRIAN:
+      return "PEDESTRIAN";
+    case SemanticLabel::HAZARD:
+      return "HAZARD";
+    case SemanticLabel::GROUND:
+      return "GROUND";
+    case SemanticLabel::STRUCTURE:
+      return "STRUCTURE";
+    case SemanticLabel::VEGETATION:
+      return "VEGETATION";
+    case SemanticLabel::NOISE:
+      return "NOISE";
+    default:
+      return "UNKNOWN";
+  }
+}
+
+/// @brief Convert a semantic label to ObjectClassification label type where applicable.
+/// @param label The semantic label to convert.
+/// @return The ObjectClassification label value (as uint8_t), or std::nullopt if the label
+///         does not map to an object class (e.g., GROUND, STRUCTURE, VEGETATION, NOISE).
+/// @details
+/// Mapping:
+/// - CAR -> 1 (ObjectClassification::CAR)
+/// - TRUCK -> 2 (ObjectClassification::TRUCK)
+/// - BUS -> 3 (ObjectClassification::BUS)
+/// - BICYCLE -> 6 (ObjectClassification::BICYCLE)
+/// - PEDESTRIAN -> 7 (ObjectClassification::PEDESTRIAN)
+/// - HAZARD -> 9 (ObjectClassification::HAZARD)
+/// - GROUND, STRUCTURE, VEGETATION, NOISE -> std::nullopt (non-object labels)
+constexpr std::optional<ObjectLabel> try_into_object(SemanticLabel label) noexcept
+{
+  switch (label) {
+    case SemanticLabel::CAR:
+      return ObjectClassification::CAR;
+    case SemanticLabel::TRUCK:
+      return ObjectClassification::TRUCK;
+    case SemanticLabel::BUS:
+      return ObjectClassification::BUS;
+    case SemanticLabel::BICYCLE:
+      return ObjectClassification::BICYCLE;
+    case SemanticLabel::PEDESTRIAN:
+      return ObjectClassification::PEDESTRIAN;
+    case SemanticLabel::HAZARD:
+      return ObjectClassification::HAZARD;
+    case SemanticLabel::GROUND:
+    case SemanticLabel::STRUCTURE:
+    case SemanticLabel::VEGETATION:
+    case SemanticLabel::NOISE:
+      return std::nullopt;
+    default:
+      return std::nullopt;
+  }
+}
+
+/// @brief Convert an ObjectClassification label to its most likely semantic label.
+/// @param label The ObjectClassification label value (uint8_t).
+/// @return The corresponding SemanticLabel, or std::nullopt if the object class cannot be mapped.
+/// @details
+/// Reverse mapping (non-unique, maps to most common PTv3 output):
+/// - 1 (CAR) -> CAR
+/// - 2 (TRUCK) -> TRUCK
+/// - 3 (BUS) -> BUS
+/// - 6 (BICYCLE) -> BICYCLE
+/// - 7 (PEDESTRIAN) -> PEDESTRIAN
+/// - 9 (HAZARD) -> HAZARD
+/// - Other ObjectClassification values -> std::nullopt
+constexpr std::optional<SemanticLabel> try_into_semantic(std::uint8_t label) noexcept
+{
+  switch (label) {
+    case ObjectClassification::CAR:
+      return SemanticLabel::CAR;
+    case ObjectClassification::TRUCK:
+      return SemanticLabel::TRUCK;
+    case ObjectClassification::BUS:
+      return SemanticLabel::BUS;
+    case ObjectClassification::BICYCLE:
+      return SemanticLabel::BICYCLE;
+    case ObjectClassification::PEDESTRIAN:
+      return SemanticLabel::PEDESTRIAN;
+    case ObjectClassification::HAZARD:
+      return SemanticLabel::HAZARD;
+    default:
+      return std::nullopt;
+  }
+}
+
+/// @brief Check whether a semantic label is compatible with ObjectClassification.
+/// @param label The semantic label to check.
+/// @return true if the label represents an object class that can be converted to
+/// ObjectClassification,
+///         false for environment/non-object labels (GROUND, STRUCTURE, VEGETATION, NOISE).
+constexpr bool is_object_compatible(SemanticLabel label) noexcept
+{
+  return try_into_object(label).has_value();
+}
+
+}  // namespace autoware::ptv3::experimental
+
+#endif  // AUTOWARE__PTV3__EXPERIMENTAL__SEMANTIC_LABEL_HPP_

--- a/perception/autoware_ptv3/include/autoware/ptv3/experimental/semantic_label.hpp
+++ b/perception/autoware_ptv3/include/autoware/ptv3/experimental/semantic_label.hpp
@@ -19,14 +19,16 @@
 
 namespace autoware::ptv3::experimental
 {
-/// @brief Semantic labels for point cloud segmentation.
-/// @details
-/// Consolidated labels representing different point cloud categories:
-/// - CAR, TRUCK, BUS, MOTORCYCLE, BICYCLE, PEDESTRIAN, ANIMAL, HAZARD: Object classes
-/// - GROUND: Drivable ground surface
-/// - STRUCTURE: Non-drivable structures (e.g., buildings, walls)
-/// - VEGETATION: Vegetation (trees, bushes)
-/// - NOISE: Noise points and outliers
+/**
+ * @brief Semantic labels for point cloud segmentation.
+ * @details
+ * Consolidated labels representing different point cloud categories:
+ * - CAR, TRUCK, BUS, MOTORCYCLE, BICYCLE, PEDESTRIAN, ANIMAL, HAZARD: Object classes
+ * - GROUND: Drivable ground surface
+ * - STRUCTURE: Non-drivable structures (e.g., buildings, walls)
+ * - VEGETATION: Vegetation (trees, bushes)
+ * - NOISE: Noise points and outliers
+ */
 enum class SemanticLabel : std::uint8_t {
   CAR = 0,
   TRUCK = 1,

--- a/perception/autoware_ptv3/include/autoware/ptv3/experimental/semantic_label.hpp
+++ b/perception/autoware_ptv3/include/autoware/ptv3/experimental/semantic_label.hpp
@@ -22,8 +22,7 @@ namespace autoware::ptv3::experimental
 /// @brief Semantic labels for point cloud segmentation.
 /// @details
 /// Consolidated labels representing different point cloud categories:
-/// - CAR, TRUCK, BUS, BICYCLE, PEDESTRIAN: Object classes
-/// - HAZARD: Small hazardous objects (e.g., debris, barriers)
+/// - CAR, TRUCK, BUS, MOTORCYCLE, BICYCLE, PEDESTRIAN, ANIMAL, HAZARD: Object classes
 /// - GROUND: Drivable ground surface
 /// - STRUCTURE: Non-drivable structures (e.g., buildings, walls)
 /// - VEGETATION: Vegetation (trees, bushes)
@@ -32,13 +31,15 @@ enum class SemanticLabel : std::uint8_t {
   CAR = 0,
   TRUCK = 1,
   BUS = 2,
-  BICYCLE = 3,
-  PEDESTRIAN = 4,
-  HAZARD = 5,
-  GROUND = 6,
-  STRUCTURE = 7,
-  VEGETATION = 8,
-  NOISE = 9,
+  MOTORCYCLE = 3,
+  BICYCLE = 4,
+  PEDESTRIAN = 5,
+  ANIMAL = 6,
+  HAZARD = 7,
+  GROUND = 8,
+  STRUCTURE = 9,
+  VEGETATION = 10,
+  NOISE = 11,
 };
 
 }  // namespace autoware::ptv3::experimental

--- a/perception/autoware_ptv3/include/autoware/ptv3/experimental/semantic_label_helper.hpp
+++ b/perception/autoware_ptv3/include/autoware/ptv3/experimental/semantic_label_helper.hpp
@@ -27,9 +27,11 @@ namespace autoware::ptv3::experimental
 using autoware_perception_msgs::msg::ObjectClassification;
 using ObjectLabel = ObjectClassification::_label_type;
 
-/// @brief Get the string representation of a semantic label.
-/// @param label The semantic label to convert.
-/// @return String view of the label name (e.g., "CAR", "HAZARD", "STRUCTURE").
+/**
+ * @brief Get the string representation of a semantic label.
+ * @param label The semantic label to convert.
+ * @return String view of the label name (e.g., "CAR", "HAZARD", "STRUCTURE").
+ */
 constexpr std::string_view to_string(SemanticLabel label) noexcept
 {
   switch (label) {
@@ -62,9 +64,11 @@ constexpr std::string_view to_string(SemanticLabel label) noexcept
   }
 }
 
-/// @brief Convert a semantic label to ObjectClassification label type where applicable.
-/// @param label The semantic label to convert.
-/// @return The ObjectClassification label value, or std::nullopt for non-object labels.
+/**
+ * @brief Convert a semantic label to ObjectClassification label type where applicable.
+ * @param label The semantic label to convert.
+ * @return The ObjectClassification label value, or std::nullopt for non-object labels.
+ */
 inline std::optional<ObjectLabel> try_into_object(SemanticLabel label) noexcept
 {
   switch (label) {
@@ -94,9 +98,11 @@ inline std::optional<ObjectLabel> try_into_object(SemanticLabel label) noexcept
   }
 }
 
-/// @brief Convert an ObjectClassification label to its semantic label.
-/// @param label The ObjectClassification label value.
-/// @return The corresponding SemanticLabel, or std::nullopt if not mapped.
+/**
+ * @brief Convert an ObjectClassification label to its semantic label.
+ * @param label The ObjectClassification label value.
+ * @return The corresponding SemanticLabel, or std::nullopt if not mapped.
+ */
 inline std::optional<SemanticLabel> try_into_semantic(ObjectLabel label) noexcept
 {
   switch (label) {
@@ -123,10 +129,12 @@ inline std::optional<SemanticLabel> try_into_semantic(ObjectLabel label) noexcep
   }
 }
 
-/// @brief Check whether a semantic label is object-compatible.
-/// @param label The semantic label to check.
-/// @return true if the label is an object class, false for environment/non-object labels
-///         (GROUND, STRUCTURE, VEGETATION, NOISE).
+/**
+ * @brief Check whether a semantic label is object-compatible.
+ * @param label The semantic label to check.
+ * @return true if the label is an object class, false for environment/non-object labels
+ *         (GROUND, STRUCTURE, VEGETATION, NOISE).
+ */
 inline bool is_object_compatible(SemanticLabel label) noexcept
 {
   return try_into_object(label).has_value();

--- a/perception/autoware_ptv3/include/autoware/ptv3/experimental/semantic_label_helper.hpp
+++ b/perception/autoware_ptv3/include/autoware/ptv3/experimental/semantic_label_helper.hpp
@@ -1,0 +1,124 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__PTV3__EXPERIMENTAL__SEMANTIC_LABEL_HELPER_HPP_
+#define AUTOWARE__PTV3__EXPERIMENTAL__SEMANTIC_LABEL_HELPER_HPP_
+
+#include "autoware/ptv3/experimental/semantic_label.hpp"
+
+#include <autoware_perception_msgs/msg/object_classification.hpp>
+
+#include <cstdint>
+#include <optional>
+#include <string_view>
+
+namespace autoware::ptv3::experimental
+{
+using autoware_perception_msgs::msg::ObjectClassification;
+using ObjectLabel = ObjectClassification::_label_type;
+
+/// @brief Get the string representation of a semantic label.
+/// @param label The semantic label to convert.
+/// @return String view of the label name (e.g., "CAR", "HAZARD", "STRUCTURE").
+constexpr std::string_view to_string(SemanticLabel label) noexcept
+{
+  switch (label) {
+    case SemanticLabel::CAR:
+      return "CAR";
+    case SemanticLabel::TRUCK:
+      return "TRUCK";
+    case SemanticLabel::BUS:
+      return "BUS";
+    case SemanticLabel::BICYCLE:
+      return "BICYCLE";
+    case SemanticLabel::PEDESTRIAN:
+      return "PEDESTRIAN";
+    case SemanticLabel::HAZARD:
+      return "HAZARD";
+    case SemanticLabel::GROUND:
+      return "GROUND";
+    case SemanticLabel::STRUCTURE:
+      return "STRUCTURE";
+    case SemanticLabel::VEGETATION:
+      return "VEGETATION";
+    case SemanticLabel::NOISE:
+      return "NOISE";
+    default:
+      return "UNKNOWN";
+  }
+}
+
+/// @brief Convert a semantic label to ObjectClassification label type where applicable.
+/// @param label The semantic label to convert.
+/// @return The ObjectClassification label value, or std::nullopt for non-object labels.
+constexpr std::optional<ObjectLabel> try_into_object(SemanticLabel label) noexcept
+{
+  switch (label) {
+    case SemanticLabel::CAR:
+      return ObjectClassification::CAR;
+    case SemanticLabel::TRUCK:
+      return ObjectClassification::TRUCK;
+    case SemanticLabel::BUS:
+      return ObjectClassification::BUS;
+    case SemanticLabel::BICYCLE:
+      return ObjectClassification::BICYCLE;
+    case SemanticLabel::PEDESTRIAN:
+      return ObjectClassification::PEDESTRIAN;
+    case SemanticLabel::HAZARD:
+      return ObjectClassification::HAZARD;
+    case SemanticLabel::GROUND:
+    case SemanticLabel::STRUCTURE:
+    case SemanticLabel::VEGETATION:
+    case SemanticLabel::NOISE:
+      return std::nullopt;
+    default:
+      return std::nullopt;
+  }
+}
+
+/// @brief Convert an ObjectClassification label to its semantic label.
+/// @param label The ObjectClassification label value.
+/// @return The corresponding SemanticLabel, or std::nullopt if not mapped.
+constexpr std::optional<SemanticLabel> try_into_semantic(std::uint8_t label) noexcept
+{
+  switch (label) {
+    case ObjectClassification::CAR:
+      return SemanticLabel::CAR;
+    case ObjectClassification::TRUCK:
+      return SemanticLabel::TRUCK;
+    case ObjectClassification::BUS:
+      return SemanticLabel::BUS;
+    case ObjectClassification::BICYCLE:
+      return SemanticLabel::BICYCLE;
+    case ObjectClassification::PEDESTRIAN:
+      return SemanticLabel::PEDESTRIAN;
+    case ObjectClassification::HAZARD:
+      return SemanticLabel::HAZARD;
+    default:
+      return std::nullopt;
+  }
+}
+
+/// @brief Check whether a semantic label is object-compatible.
+/// @param label The semantic label to check.
+/// @return true if the label is an object class, false for environment/non-object labels
+///         (GROUND, STRUCTURE, VEGETATION, NOISE).
+constexpr bool is_object_compatible(SemanticLabel label) noexcept
+{
+  return try_into_object(label).has_value();
+}
+
+}  // namespace autoware::ptv3::experimental
+
+#endif  // AUTOWARE__PTV3__EXPERIMENTAL__SEMANTIC_LABEL_HELPER_HPP_

--- a/perception/autoware_ptv3/include/autoware/ptv3/experimental/semantic_label_helper.hpp
+++ b/perception/autoware_ptv3/include/autoware/ptv3/experimental/semantic_label_helper.hpp
@@ -62,7 +62,7 @@ constexpr std::string_view to_string(SemanticLabel label) noexcept
 /// @brief Convert a semantic label to ObjectClassification label type where applicable.
 /// @param label The semantic label to convert.
 /// @return The ObjectClassification label value, or std::nullopt for non-object labels.
-constexpr std::optional<ObjectLabel> try_into_object(SemanticLabel label) noexcept
+inline std::optional<ObjectLabel> try_into_object(SemanticLabel label) noexcept
 {
   switch (label) {
     case SemanticLabel::CAR:
@@ -90,7 +90,7 @@ constexpr std::optional<ObjectLabel> try_into_object(SemanticLabel label) noexce
 /// @brief Convert an ObjectClassification label to its semantic label.
 /// @param label The ObjectClassification label value.
 /// @return The corresponding SemanticLabel, or std::nullopt if not mapped.
-constexpr std::optional<SemanticLabel> try_into_semantic(std::uint8_t label) noexcept
+inline std::optional<SemanticLabel> try_into_semantic(ObjectLabel label) noexcept
 {
   switch (label) {
     case ObjectClassification::CAR:
@@ -114,7 +114,7 @@ constexpr std::optional<SemanticLabel> try_into_semantic(std::uint8_t label) noe
 /// @param label The semantic label to check.
 /// @return true if the label is an object class, false for environment/non-object labels
 ///         (GROUND, STRUCTURE, VEGETATION, NOISE).
-constexpr bool is_object_compatible(SemanticLabel label) noexcept
+inline bool is_object_compatible(SemanticLabel label) noexcept
 {
   return try_into_object(label).has_value();
 }

--- a/perception/autoware_ptv3/include/autoware/ptv3/experimental/semantic_label_helper.hpp
+++ b/perception/autoware_ptv3/include/autoware/ptv3/experimental/semantic_label_helper.hpp
@@ -51,8 +51,8 @@ constexpr std::string_view to_string(SemanticLabel label) noexcept
       return "ANIMAL";
     case SemanticLabel::HAZARD:
       return "HAZARD";
-    case SemanticLabel::GROUND:
-      return "GROUND";
+    case SemanticLabel::FLAT_SURFACE:
+      return "FLAT_SURFACE";
     case SemanticLabel::STRUCTURE:
       return "STRUCTURE";
     case SemanticLabel::VEGETATION:
@@ -88,7 +88,7 @@ inline std::optional<ObjectLabel> try_into_object(SemanticLabel label) noexcept
       return ObjectClassification::ANIMAL;
     case SemanticLabel::HAZARD:
       return ObjectClassification::HAZARD;
-    case SemanticLabel::GROUND:
+    case SemanticLabel::FLAT_SURFACE:
     case SemanticLabel::STRUCTURE:
     case SemanticLabel::VEGETATION:
     case SemanticLabel::NOISE:
@@ -133,7 +133,7 @@ inline std::optional<SemanticLabel> try_into_semantic(ObjectLabel label) noexcep
  * @brief Check whether a semantic label is object-compatible.
  * @param label The semantic label to check.
  * @return true if the label is an object class, false for environment/non-object labels
- *         (GROUND, STRUCTURE, VEGETATION, NOISE).
+ *         (FLAT_SURFACE, STRUCTURE, VEGETATION, NOISE).
  */
 inline bool is_object_compatible(SemanticLabel label) noexcept
 {

--- a/perception/autoware_ptv3/include/autoware/ptv3/experimental/semantic_label_helper.hpp
+++ b/perception/autoware_ptv3/include/autoware/ptv3/experimental/semantic_label_helper.hpp
@@ -19,7 +19,6 @@
 
 #include <autoware_perception_msgs/msg/object_classification.hpp>
 
-#include <cstdint>
 #include <optional>
 #include <string_view>
 
@@ -40,10 +39,14 @@ constexpr std::string_view to_string(SemanticLabel label) noexcept
       return "TRUCK";
     case SemanticLabel::BUS:
       return "BUS";
+    case SemanticLabel::MOTORCYCLE:
+      return "MOTORCYCLE";
     case SemanticLabel::BICYCLE:
       return "BICYCLE";
     case SemanticLabel::PEDESTRIAN:
       return "PEDESTRIAN";
+    case SemanticLabel::ANIMAL:
+      return "ANIMAL";
     case SemanticLabel::HAZARD:
       return "HAZARD";
     case SemanticLabel::GROUND:
@@ -71,10 +74,14 @@ inline std::optional<ObjectLabel> try_into_object(SemanticLabel label) noexcept
       return ObjectClassification::TRUCK;
     case SemanticLabel::BUS:
       return ObjectClassification::BUS;
+    case SemanticLabel::MOTORCYCLE:
+      return ObjectClassification::MOTORCYCLE;
     case SemanticLabel::BICYCLE:
       return ObjectClassification::BICYCLE;
     case SemanticLabel::PEDESTRIAN:
       return ObjectClassification::PEDESTRIAN;
+    case SemanticLabel::ANIMAL:
+      return ObjectClassification::ANIMAL;
     case SemanticLabel::HAZARD:
       return ObjectClassification::HAZARD;
     case SemanticLabel::GROUND:
@@ -99,10 +106,16 @@ inline std::optional<SemanticLabel> try_into_semantic(ObjectLabel label) noexcep
       return SemanticLabel::TRUCK;
     case ObjectClassification::BUS:
       return SemanticLabel::BUS;
+    case ObjectClassification::TRAILER:
+      return SemanticLabel::TRUCK;
+    case ObjectClassification::MOTORCYCLE:
+      return SemanticLabel::MOTORCYCLE;
     case ObjectClassification::BICYCLE:
       return SemanticLabel::BICYCLE;
     case ObjectClassification::PEDESTRIAN:
       return SemanticLabel::PEDESTRIAN;
+    case ObjectClassification::ANIMAL:
+      return SemanticLabel::ANIMAL;
     case ObjectClassification::HAZARD:
       return SemanticLabel::HAZARD;
     default:

--- a/perception/autoware_ptv3/test/semantic_label_test.cpp
+++ b/perception/autoware_ptv3/test/semantic_label_test.cpp
@@ -14,6 +14,8 @@
 
 #include "autoware/ptv3/experimental/semantic_label.hpp"
 
+#include "autoware/ptv3/experimental/semantic_label_helper.hpp"
+
 #include <gtest/gtest.h>
 
 #include <cstdint>

--- a/perception/autoware_ptv3/test/semantic_label_test.cpp
+++ b/perception/autoware_ptv3/test/semantic_label_test.cpp
@@ -41,7 +41,7 @@ TEST_F(SemanticLabelTest, EnumValuesCorrect)
   EXPECT_EQ(static_cast<std::uint8_t>(SemanticLabel::PEDESTRIAN), 5U);
   EXPECT_EQ(static_cast<std::uint8_t>(SemanticLabel::ANIMAL), 6U);
   EXPECT_EQ(static_cast<std::uint8_t>(SemanticLabel::HAZARD), 7U);
-  EXPECT_EQ(static_cast<std::uint8_t>(SemanticLabel::GROUND), 8U);
+  EXPECT_EQ(static_cast<std::uint8_t>(SemanticLabel::FLAT_SURFACE), 8U);
   EXPECT_EQ(static_cast<std::uint8_t>(SemanticLabel::STRUCTURE), 9U);
   EXPECT_EQ(static_cast<std::uint8_t>(SemanticLabel::VEGETATION), 10U);
   EXPECT_EQ(static_cast<std::uint8_t>(SemanticLabel::NOISE), 11U);
@@ -61,7 +61,7 @@ TEST_F(SemanticLabelTest, ToStringConversion)
   EXPECT_EQ(to_string(SemanticLabel::PEDESTRIAN), "PEDESTRIAN");
   EXPECT_EQ(to_string(SemanticLabel::ANIMAL), "ANIMAL");
   EXPECT_EQ(to_string(SemanticLabel::HAZARD), "HAZARD");
-  EXPECT_EQ(to_string(SemanticLabel::GROUND), "GROUND");
+  EXPECT_EQ(to_string(SemanticLabel::FLAT_SURFACE), "FLAT_SURFACE");
   EXPECT_EQ(to_string(SemanticLabel::STRUCTURE), "STRUCTURE");
   EXPECT_EQ(to_string(SemanticLabel::VEGETATION), "VEGETATION");
   EXPECT_EQ(to_string(SemanticLabel::NOISE), "NOISE");
@@ -110,7 +110,7 @@ TEST_F(SemanticLabelTest, TryIntoObjectValidObjectLabels)
 TEST_F(SemanticLabelTest, TryIntoObjectNonObjectLabels)
 {
   // Non-object labels should return nullopt
-  EXPECT_FALSE(try_into_object(SemanticLabel::GROUND).has_value());
+  EXPECT_FALSE(try_into_object(SemanticLabel::FLAT_SURFACE).has_value());
   EXPECT_FALSE(try_into_object(SemanticLabel::STRUCTURE).has_value());
   EXPECT_FALSE(try_into_object(SemanticLabel::VEGETATION).has_value());
   EXPECT_FALSE(try_into_object(SemanticLabel::NOISE).has_value());
@@ -190,7 +190,7 @@ TEST_F(SemanticLabelTest, IsObjectCompatibleObjectLabels)
 TEST_F(SemanticLabelTest, IsObjectCompatibleNonObjectLabels)
 {
   // Non-object labels
-  EXPECT_FALSE(is_object_compatible(SemanticLabel::GROUND));
+  EXPECT_FALSE(is_object_compatible(SemanticLabel::FLAT_SURFACE));
   EXPECT_FALSE(is_object_compatible(SemanticLabel::STRUCTURE));
   EXPECT_FALSE(is_object_compatible(SemanticLabel::VEGETATION));
   EXPECT_FALSE(is_object_compatible(SemanticLabel::NOISE));

--- a/perception/autoware_ptv3/test/semantic_label_test.cpp
+++ b/perception/autoware_ptv3/test/semantic_label_test.cpp
@@ -202,15 +202,15 @@ TEST_F(SemanticLabelTest, ConstexprEvaluation)
   constexpr auto str = to_string(SemanticLabel::CAR);
   EXPECT_EQ(str, "CAR");
 
-  constexpr auto obj = try_into_object(SemanticLabel::CAR);
+  auto obj = try_into_object(SemanticLabel::CAR);
   EXPECT_TRUE(obj.has_value());
   EXPECT_EQ(obj.value(), 1U);
 
-  constexpr auto sem = try_into_semantic(1U);
+  auto sem = try_into_semantic(1U);
   EXPECT_TRUE(sem.has_value());
   EXPECT_EQ(sem.value(), SemanticLabel::CAR);
 
-  constexpr auto compat = is_object_compatible(SemanticLabel::CAR);
+  const auto compat = is_object_compatible(SemanticLabel::CAR);
   EXPECT_TRUE(compat);
 }
 

--- a/perception/autoware_ptv3/test/semantic_label_test.cpp
+++ b/perception/autoware_ptv3/test/semantic_label_test.cpp
@@ -19,7 +19,6 @@
 #include <gtest/gtest.h>
 
 #include <cstdint>
-#include <string_view>
 
 namespace autoware::ptv3::experimental
 {
@@ -37,13 +36,15 @@ TEST_F(SemanticLabelTest, EnumValuesCorrect)
   EXPECT_EQ(static_cast<std::uint8_t>(SemanticLabel::CAR), 0U);
   EXPECT_EQ(static_cast<std::uint8_t>(SemanticLabel::TRUCK), 1U);
   EXPECT_EQ(static_cast<std::uint8_t>(SemanticLabel::BUS), 2U);
-  EXPECT_EQ(static_cast<std::uint8_t>(SemanticLabel::BICYCLE), 3U);
-  EXPECT_EQ(static_cast<std::uint8_t>(SemanticLabel::PEDESTRIAN), 4U);
-  EXPECT_EQ(static_cast<std::uint8_t>(SemanticLabel::HAZARD), 5U);
-  EXPECT_EQ(static_cast<std::uint8_t>(SemanticLabel::GROUND), 6U);
-  EXPECT_EQ(static_cast<std::uint8_t>(SemanticLabel::STRUCTURE), 7U);
-  EXPECT_EQ(static_cast<std::uint8_t>(SemanticLabel::VEGETATION), 8U);
-  EXPECT_EQ(static_cast<std::uint8_t>(SemanticLabel::NOISE), 9U);
+  EXPECT_EQ(static_cast<std::uint8_t>(SemanticLabel::MOTORCYCLE), 3U);
+  EXPECT_EQ(static_cast<std::uint8_t>(SemanticLabel::BICYCLE), 4U);
+  EXPECT_EQ(static_cast<std::uint8_t>(SemanticLabel::PEDESTRIAN), 5U);
+  EXPECT_EQ(static_cast<std::uint8_t>(SemanticLabel::ANIMAL), 6U);
+  EXPECT_EQ(static_cast<std::uint8_t>(SemanticLabel::HAZARD), 7U);
+  EXPECT_EQ(static_cast<std::uint8_t>(SemanticLabel::GROUND), 8U);
+  EXPECT_EQ(static_cast<std::uint8_t>(SemanticLabel::STRUCTURE), 9U);
+  EXPECT_EQ(static_cast<std::uint8_t>(SemanticLabel::VEGETATION), 10U);
+  EXPECT_EQ(static_cast<std::uint8_t>(SemanticLabel::NOISE), 11U);
 }
 
 // ============================================================================
@@ -55,8 +56,10 @@ TEST_F(SemanticLabelTest, ToStringConversion)
   EXPECT_EQ(to_string(SemanticLabel::CAR), "CAR");
   EXPECT_EQ(to_string(SemanticLabel::TRUCK), "TRUCK");
   EXPECT_EQ(to_string(SemanticLabel::BUS), "BUS");
+  EXPECT_EQ(to_string(SemanticLabel::MOTORCYCLE), "MOTORCYCLE");
   EXPECT_EQ(to_string(SemanticLabel::BICYCLE), "BICYCLE");
   EXPECT_EQ(to_string(SemanticLabel::PEDESTRIAN), "PEDESTRIAN");
+  EXPECT_EQ(to_string(SemanticLabel::ANIMAL), "ANIMAL");
   EXPECT_EQ(to_string(SemanticLabel::HAZARD), "HAZARD");
   EXPECT_EQ(to_string(SemanticLabel::GROUND), "GROUND");
   EXPECT_EQ(to_string(SemanticLabel::STRUCTURE), "STRUCTURE");
@@ -73,27 +76,35 @@ TEST_F(SemanticLabelTest, TryIntoObjectValidObjectLabels)
   // Object-compatible labels should return non-nullopt values
   auto car = try_into_object(SemanticLabel::CAR);
   EXPECT_TRUE(car.has_value());
-  EXPECT_EQ(car.value(), 1U);  // ObjectClassification::CAR
+  EXPECT_EQ(car.value(), ObjectClassification::CAR);
 
   auto truck = try_into_object(SemanticLabel::TRUCK);
   EXPECT_TRUE(truck.has_value());
-  EXPECT_EQ(truck.value(), 2U);  // ObjectClassification::TRUCK
+  EXPECT_EQ(truck.value(), ObjectClassification::TRUCK);
 
   auto bus = try_into_object(SemanticLabel::BUS);
   EXPECT_TRUE(bus.has_value());
-  EXPECT_EQ(bus.value(), 3U);  // ObjectClassification::BUS
+  EXPECT_EQ(bus.value(), ObjectClassification::BUS);
+
+  auto motorcycle = try_into_object(SemanticLabel::MOTORCYCLE);
+  EXPECT_TRUE(motorcycle.has_value());
+  EXPECT_EQ(motorcycle.value(), ObjectClassification::MOTORCYCLE);
 
   auto bicycle = try_into_object(SemanticLabel::BICYCLE);
   EXPECT_TRUE(bicycle.has_value());
-  EXPECT_EQ(bicycle.value(), 6U);  // ObjectClassification::BICYCLE
+  EXPECT_EQ(bicycle.value(), ObjectClassification::BICYCLE);
 
   auto pedestrian = try_into_object(SemanticLabel::PEDESTRIAN);
   EXPECT_TRUE(pedestrian.has_value());
-  EXPECT_EQ(pedestrian.value(), 7U);  // ObjectClassification::PEDESTRIAN
+  EXPECT_EQ(pedestrian.value(), ObjectClassification::PEDESTRIAN);
+
+  auto animal = try_into_object(SemanticLabel::ANIMAL);
+  EXPECT_TRUE(animal.has_value());
+  EXPECT_EQ(animal.value(), ObjectClassification::ANIMAL);
 
   auto hazard = try_into_object(SemanticLabel::HAZARD);
   EXPECT_TRUE(hazard.has_value());
-  EXPECT_EQ(hazard.value(), 9U);  // ObjectClassification::HAZARD
+  EXPECT_EQ(hazard.value(), ObjectClassification::HAZARD);
 }
 
 TEST_F(SemanticLabelTest, TryIntoObjectNonObjectLabels)
@@ -112,27 +123,39 @@ TEST_F(SemanticLabelTest, TryIntoObjectNonObjectLabels)
 TEST_F(SemanticLabelTest, TryIntoSemanticValidLabels)
 {
   // Valid ObjectClassification labels should map back to SemanticLabel
-  auto car = try_into_semantic(1U);  // ObjectClassification::CAR
+  auto car = try_into_semantic(ObjectClassification::CAR);
   EXPECT_TRUE(car.has_value());
   EXPECT_EQ(car.value(), SemanticLabel::CAR);
 
-  auto truck = try_into_semantic(2U);  // ObjectClassification::TRUCK
+  auto truck = try_into_semantic(ObjectClassification::TRUCK);
   EXPECT_TRUE(truck.has_value());
   EXPECT_EQ(truck.value(), SemanticLabel::TRUCK);
 
-  auto bus = try_into_semantic(3U);  // ObjectClassification::BUS
+  auto bus = try_into_semantic(ObjectClassification::BUS);
   EXPECT_TRUE(bus.has_value());
   EXPECT_EQ(bus.value(), SemanticLabel::BUS);
 
-  auto bicycle = try_into_semantic(6U);  // ObjectClassification::BICYCLE
+  auto trailer = try_into_semantic(ObjectClassification::TRAILER);
+  EXPECT_TRUE(trailer.has_value());
+  EXPECT_EQ(trailer.value(), SemanticLabel::TRUCK);
+
+  auto motorcycle = try_into_semantic(ObjectClassification::MOTORCYCLE);
+  EXPECT_TRUE(motorcycle.has_value());
+  EXPECT_EQ(motorcycle.value(), SemanticLabel::MOTORCYCLE);
+
+  auto bicycle = try_into_semantic(ObjectClassification::BICYCLE);
   EXPECT_TRUE(bicycle.has_value());
   EXPECT_EQ(bicycle.value(), SemanticLabel::BICYCLE);
 
-  auto pedestrian = try_into_semantic(7U);  // ObjectClassification::PEDESTRIAN
+  auto pedestrian = try_into_semantic(ObjectClassification::PEDESTRIAN);
   EXPECT_TRUE(pedestrian.has_value());
   EXPECT_EQ(pedestrian.value(), SemanticLabel::PEDESTRIAN);
 
-  auto hazard = try_into_semantic(9U);  // ObjectClassification::HAZARD
+  auto animal = try_into_semantic(ObjectClassification::ANIMAL);
+  EXPECT_TRUE(animal.has_value());
+  EXPECT_EQ(animal.value(), SemanticLabel::ANIMAL);
+
+  auto hazard = try_into_semantic(ObjectClassification::HAZARD);
   EXPECT_TRUE(hazard.has_value());
   EXPECT_EQ(hazard.value(), SemanticLabel::HAZARD);
 }
@@ -140,13 +163,11 @@ TEST_F(SemanticLabelTest, TryIntoSemanticValidLabels)
 TEST_F(SemanticLabelTest, TryIntoSemanticInvalidLabels)
 {
   // Invalid ObjectClassification labels should return nullopt
-  EXPECT_FALSE(try_into_semantic(0U).has_value());   // UNKNOWN
-  EXPECT_FALSE(try_into_semantic(4U).has_value());   // TRAILER (not in semantic mapping)
-  EXPECT_FALSE(try_into_semantic(5U).has_value());   // MOTORCYCLE (not in semantic mapping)
-  EXPECT_FALSE(try_into_semantic(8U).has_value());   // ANIMAL (not in semantic mapping)
-  EXPECT_FALSE(try_into_semantic(10U).has_value());  // OVER_DRIVABLE (not in semantic mapping)
-  EXPECT_FALSE(try_into_semantic(11U).has_value());  // UNDER_DRIVABLE (not in semantic mapping)
-  EXPECT_FALSE(try_into_semantic(255U).has_value());
+  EXPECT_FALSE(try_into_semantic(ObjectClassification::UNKNOWN).has_value());  // UNKNOWN
+  EXPECT_FALSE(try_into_semantic(ObjectClassification::OVER_DRIVABLE)
+                 .has_value());  // OVER_DRIVABLE (not in semantic mapping)
+  EXPECT_FALSE(try_into_semantic(ObjectClassification::UNDER_DRIVABLE)
+                 .has_value());  // UNDER_DRIVABLE (not in semantic mapping)
 }
 
 // ============================================================================
@@ -159,8 +180,10 @@ TEST_F(SemanticLabelTest, IsObjectCompatibleObjectLabels)
   EXPECT_TRUE(is_object_compatible(SemanticLabel::CAR));
   EXPECT_TRUE(is_object_compatible(SemanticLabel::TRUCK));
   EXPECT_TRUE(is_object_compatible(SemanticLabel::BUS));
+  EXPECT_TRUE(is_object_compatible(SemanticLabel::MOTORCYCLE));
   EXPECT_TRUE(is_object_compatible(SemanticLabel::BICYCLE));
   EXPECT_TRUE(is_object_compatible(SemanticLabel::PEDESTRIAN));
+  EXPECT_TRUE(is_object_compatible(SemanticLabel::ANIMAL));
   EXPECT_TRUE(is_object_compatible(SemanticLabel::HAZARD));
 }
 
@@ -179,16 +202,31 @@ TEST_F(SemanticLabelTest, IsObjectCompatibleNonObjectLabels)
 
 TEST_F(SemanticLabelTest, RoundtripObjectLabelToSemanticAndBack)
 {
-  // Test roundtrip for object-compatible labels
-  constexpr std::uint8_t object_labels[] = {1U, 2U, 3U, 6U, 7U, 9U};
+  // TRAILER is intentionally normalized to TRUCK and does not roundtrip to TRAILER.
+  struct RoundtripExpectation
+  {
+    ObjectLabel input;
+    ObjectLabel expected_output;
+  };
 
-  for (auto obj_label : object_labels) {
-    auto semantic = try_into_semantic(obj_label);
+  constexpr RoundtripExpectation object_labels[] = {
+    {ObjectClassification::CAR, ObjectClassification::CAR},
+    {ObjectClassification::TRUCK, ObjectClassification::TRUCK},
+    {ObjectClassification::BUS, ObjectClassification::BUS},
+    {ObjectClassification::TRAILER, ObjectClassification::TRUCK},
+    {ObjectClassification::MOTORCYCLE, ObjectClassification::MOTORCYCLE},
+    {ObjectClassification::BICYCLE, ObjectClassification::BICYCLE},
+    {ObjectClassification::PEDESTRIAN, ObjectClassification::PEDESTRIAN},
+    {ObjectClassification::ANIMAL, ObjectClassification::ANIMAL},
+    {ObjectClassification::HAZARD, ObjectClassification::HAZARD}};
+
+  for (const auto & expectation : object_labels) {
+    auto semantic = try_into_semantic(expectation.input);
     EXPECT_TRUE(semantic.has_value());
 
     auto back_to_object = try_into_object(semantic.value());
     EXPECT_TRUE(back_to_object.has_value());
-    EXPECT_EQ(back_to_object.value(), obj_label);
+    EXPECT_EQ(back_to_object.value(), expectation.expected_output);
   }
 }
 
@@ -204,9 +242,9 @@ TEST_F(SemanticLabelTest, ConstexprEvaluation)
 
   auto obj = try_into_object(SemanticLabel::CAR);
   EXPECT_TRUE(obj.has_value());
-  EXPECT_EQ(obj.value(), 1U);
+  EXPECT_EQ(obj.value(), ObjectClassification::CAR);
 
-  auto sem = try_into_semantic(1U);
+  auto sem = try_into_semantic(ObjectClassification::CAR);
   EXPECT_TRUE(sem.has_value());
   EXPECT_EQ(sem.value(), SemanticLabel::CAR);
 

--- a/perception/autoware_ptv3/test/semantic_label_test.cpp
+++ b/perception/autoware_ptv3/test/semantic_label_test.cpp
@@ -1,0 +1,215 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/ptv3/experimental/semantic_label.hpp"
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <string_view>
+
+namespace autoware::ptv3::experimental
+{
+
+class SemanticLabelTest : public ::testing::Test
+{
+};
+
+// ============================================================================
+// Enum Value Tests
+// ============================================================================
+
+TEST_F(SemanticLabelTest, EnumValuesCorrect)
+{
+  EXPECT_EQ(static_cast<std::uint8_t>(SemanticLabel::CAR), 0U);
+  EXPECT_EQ(static_cast<std::uint8_t>(SemanticLabel::TRUCK), 1U);
+  EXPECT_EQ(static_cast<std::uint8_t>(SemanticLabel::BUS), 2U);
+  EXPECT_EQ(static_cast<std::uint8_t>(SemanticLabel::BICYCLE), 3U);
+  EXPECT_EQ(static_cast<std::uint8_t>(SemanticLabel::PEDESTRIAN), 4U);
+  EXPECT_EQ(static_cast<std::uint8_t>(SemanticLabel::HAZARD), 5U);
+  EXPECT_EQ(static_cast<std::uint8_t>(SemanticLabel::GROUND), 6U);
+  EXPECT_EQ(static_cast<std::uint8_t>(SemanticLabel::STRUCTURE), 7U);
+  EXPECT_EQ(static_cast<std::uint8_t>(SemanticLabel::VEGETATION), 8U);
+  EXPECT_EQ(static_cast<std::uint8_t>(SemanticLabel::NOISE), 9U);
+}
+
+// ============================================================================
+// String Conversion Tests
+// ============================================================================
+
+TEST_F(SemanticLabelTest, ToStringConversion)
+{
+  EXPECT_EQ(to_string(SemanticLabel::CAR), "CAR");
+  EXPECT_EQ(to_string(SemanticLabel::TRUCK), "TRUCK");
+  EXPECT_EQ(to_string(SemanticLabel::BUS), "BUS");
+  EXPECT_EQ(to_string(SemanticLabel::BICYCLE), "BICYCLE");
+  EXPECT_EQ(to_string(SemanticLabel::PEDESTRIAN), "PEDESTRIAN");
+  EXPECT_EQ(to_string(SemanticLabel::HAZARD), "HAZARD");
+  EXPECT_EQ(to_string(SemanticLabel::GROUND), "GROUND");
+  EXPECT_EQ(to_string(SemanticLabel::STRUCTURE), "STRUCTURE");
+  EXPECT_EQ(to_string(SemanticLabel::VEGETATION), "VEGETATION");
+  EXPECT_EQ(to_string(SemanticLabel::NOISE), "NOISE");
+}
+
+// ============================================================================
+// try_into_object Tests
+// ============================================================================
+
+TEST_F(SemanticLabelTest, TryIntoObjectValidObjectLabels)
+{
+  // Object-compatible labels should return non-nullopt values
+  auto car = try_into_object(SemanticLabel::CAR);
+  EXPECT_TRUE(car.has_value());
+  EXPECT_EQ(car.value(), 1U);  // ObjectClassification::CAR
+
+  auto truck = try_into_object(SemanticLabel::TRUCK);
+  EXPECT_TRUE(truck.has_value());
+  EXPECT_EQ(truck.value(), 2U);  // ObjectClassification::TRUCK
+
+  auto bus = try_into_object(SemanticLabel::BUS);
+  EXPECT_TRUE(bus.has_value());
+  EXPECT_EQ(bus.value(), 3U);  // ObjectClassification::BUS
+
+  auto bicycle = try_into_object(SemanticLabel::BICYCLE);
+  EXPECT_TRUE(bicycle.has_value());
+  EXPECT_EQ(bicycle.value(), 6U);  // ObjectClassification::BICYCLE
+
+  auto pedestrian = try_into_object(SemanticLabel::PEDESTRIAN);
+  EXPECT_TRUE(pedestrian.has_value());
+  EXPECT_EQ(pedestrian.value(), 7U);  // ObjectClassification::PEDESTRIAN
+
+  auto hazard = try_into_object(SemanticLabel::HAZARD);
+  EXPECT_TRUE(hazard.has_value());
+  EXPECT_EQ(hazard.value(), 9U);  // ObjectClassification::HAZARD
+}
+
+TEST_F(SemanticLabelTest, TryIntoObjectNonObjectLabels)
+{
+  // Non-object labels should return nullopt
+  EXPECT_FALSE(try_into_object(SemanticLabel::GROUND).has_value());
+  EXPECT_FALSE(try_into_object(SemanticLabel::STRUCTURE).has_value());
+  EXPECT_FALSE(try_into_object(SemanticLabel::VEGETATION).has_value());
+  EXPECT_FALSE(try_into_object(SemanticLabel::NOISE).has_value());
+}
+
+// ============================================================================
+// try_into_semantic Tests
+// ============================================================================
+
+TEST_F(SemanticLabelTest, TryIntoSemanticValidLabels)
+{
+  // Valid ObjectClassification labels should map back to SemanticLabel
+  auto car = try_into_semantic(1U);  // ObjectClassification::CAR
+  EXPECT_TRUE(car.has_value());
+  EXPECT_EQ(car.value(), SemanticLabel::CAR);
+
+  auto truck = try_into_semantic(2U);  // ObjectClassification::TRUCK
+  EXPECT_TRUE(truck.has_value());
+  EXPECT_EQ(truck.value(), SemanticLabel::TRUCK);
+
+  auto bus = try_into_semantic(3U);  // ObjectClassification::BUS
+  EXPECT_TRUE(bus.has_value());
+  EXPECT_EQ(bus.value(), SemanticLabel::BUS);
+
+  auto bicycle = try_into_semantic(6U);  // ObjectClassification::BICYCLE
+  EXPECT_TRUE(bicycle.has_value());
+  EXPECT_EQ(bicycle.value(), SemanticLabel::BICYCLE);
+
+  auto pedestrian = try_into_semantic(7U);  // ObjectClassification::PEDESTRIAN
+  EXPECT_TRUE(pedestrian.has_value());
+  EXPECT_EQ(pedestrian.value(), SemanticLabel::PEDESTRIAN);
+
+  auto hazard = try_into_semantic(9U);  // ObjectClassification::HAZARD
+  EXPECT_TRUE(hazard.has_value());
+  EXPECT_EQ(hazard.value(), SemanticLabel::HAZARD);
+}
+
+TEST_F(SemanticLabelTest, TryIntoSemanticInvalidLabels)
+{
+  // Invalid ObjectClassification labels should return nullopt
+  EXPECT_FALSE(try_into_semantic(0U).has_value());   // UNKNOWN
+  EXPECT_FALSE(try_into_semantic(4U).has_value());   // TRAILER (not in semantic mapping)
+  EXPECT_FALSE(try_into_semantic(5U).has_value());   // MOTORCYCLE (not in semantic mapping)
+  EXPECT_FALSE(try_into_semantic(8U).has_value());   // ANIMAL (not in semantic mapping)
+  EXPECT_FALSE(try_into_semantic(10U).has_value());  // OVER_DRIVABLE (not in semantic mapping)
+  EXPECT_FALSE(try_into_semantic(11U).has_value());  // UNDER_DRIVABLE (not in semantic mapping)
+  EXPECT_FALSE(try_into_semantic(255U).has_value());
+}
+
+// ============================================================================
+// is_object_compatible Tests
+// ============================================================================
+
+TEST_F(SemanticLabelTest, IsObjectCompatibleObjectLabels)
+{
+  // Object-compatible labels
+  EXPECT_TRUE(is_object_compatible(SemanticLabel::CAR));
+  EXPECT_TRUE(is_object_compatible(SemanticLabel::TRUCK));
+  EXPECT_TRUE(is_object_compatible(SemanticLabel::BUS));
+  EXPECT_TRUE(is_object_compatible(SemanticLabel::BICYCLE));
+  EXPECT_TRUE(is_object_compatible(SemanticLabel::PEDESTRIAN));
+  EXPECT_TRUE(is_object_compatible(SemanticLabel::HAZARD));
+}
+
+TEST_F(SemanticLabelTest, IsObjectCompatibleNonObjectLabels)
+{
+  // Non-object labels
+  EXPECT_FALSE(is_object_compatible(SemanticLabel::GROUND));
+  EXPECT_FALSE(is_object_compatible(SemanticLabel::STRUCTURE));
+  EXPECT_FALSE(is_object_compatible(SemanticLabel::VEGETATION));
+  EXPECT_FALSE(is_object_compatible(SemanticLabel::NOISE));
+}
+
+// ============================================================================
+// Roundtrip Conversion Tests
+// ============================================================================
+
+TEST_F(SemanticLabelTest, RoundtripObjectLabelToSemanticAndBack)
+{
+  // Test roundtrip for object-compatible labels
+  constexpr std::uint8_t object_labels[] = {1U, 2U, 3U, 6U, 7U, 9U};
+
+  for (auto obj_label : object_labels) {
+    auto semantic = try_into_semantic(obj_label);
+    EXPECT_TRUE(semantic.has_value());
+
+    auto back_to_object = try_into_object(semantic.value());
+    EXPECT_TRUE(back_to_object.has_value());
+    EXPECT_EQ(back_to_object.value(), obj_label);
+  }
+}
+
+// ============================================================================
+// Constexpr Verification Tests
+// ============================================================================
+
+TEST_F(SemanticLabelTest, ConstexprEvaluation)
+{
+  // Verify that functions can be evaluated at compile time
+  constexpr auto str = to_string(SemanticLabel::CAR);
+  EXPECT_EQ(str, "CAR");
+
+  constexpr auto obj = try_into_object(SemanticLabel::CAR);
+  EXPECT_TRUE(obj.has_value());
+  EXPECT_EQ(obj.value(), 1U);
+
+  constexpr auto sem = try_into_semantic(1U);
+  EXPECT_TRUE(sem.has_value());
+  EXPECT_EQ(sem.value(), SemanticLabel::CAR);
+
+  constexpr auto compat = is_object_compatible(SemanticLabel::CAR);
+  EXPECT_TRUE(compat);
+}
+
+}  // namespace autoware::ptv3::experimental


### PR DESCRIPTION
## Description

This pull request introduces a new semantic labeling system for point cloud segmentation in the `autoware_ptv3` package. It adds a `SemanticLabel` enum to categorize different types of points, provides helper functions for conversions and compatibility checks, and includes comprehensive unit tests to ensure correctness. Additionally, it updates the CMake configuration to build the new tests.

**NOTE**
This feature is experimental and we will place them in the other proper packages.

**Core functionality:**

* Added a new `SemanticLabel` enum in `semantic_label.hpp` to represent consolidated semantic categories for point cloud segmentation, including object and environment classes.
* Introduced `semantic_label_helper.hpp` with constexpr helper functions for:
  * Converting semantic labels to string representations.
  * Checking if a label is object-compatible.
  * Converting between `SemanticLabel` and `ObjectClassification` labels (and vice versa).

**Testing:**

* Added `semantic_label_test.cpp` with extensive unit tests covering enum values, conversion functions, object compatibility checks, roundtrip conversions, and constexpr evaluation.
* Updated `CMakeLists.txt` to add the new GTest target for semantic label tests and set up dependencies and include directories.

## Related links

**Parent Issue:**

- [TIER IV INTERNAL LINK](https://tier4.atlassian.net/wiki/spaces/CB/pages/5309464582/PDD+Segmented+Point+Cloud+Interface+Design+Proposal)
- Successor PR: https://github.com/autowarefoundation/autoware_universe/pull/12820

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
