### PR TITLE
feat(autoware_universe_designs): add node designs for yabloc image processing nodes

### DIFF
--- a/common/autoware_universe_designs/design/localization/yabloc_image_processing/GraphSegment.node.yaml
+++ b/common/autoware_universe_designs/design/localization/yabloc_image_processing/GraphSegment.node.yaml
@@ -1,0 +1,32 @@
+autoware_system_design_format: 0.3.0
+# node information
+name: GraphSegment.node
+package:
+  name: yabloc_image_processing
+  provider: autoware
+launch:
+  plugin: yabloc::graph_segment::GraphSegment
+  executable: yabloc_graph_segment_node
+# interfaces
+subscribers:
+  - name: image_raw
+    message_type: sensor_msgs/msg/Image
+publishers:
+  - name: mask_image
+    message_type: sensor_msgs/msg/Image
+  - name: segmented_image
+    message_type: sensor_msgs/msg/Image
+    remap_target: ~/debug/segmented_image
+# parameters
+param_files:
+  - name: graph_segment_param
+    default: config/graph_segment.param.yaml
+param_values: []
+# processes
+processes:
+  - name: segment_image
+    trigger_conditions:
+      - on_input: image_raw
+    outcomes:
+      - to_output: mask_image
+      - to_output: segmented_image

--- a/common/autoware_universe_designs/design/localization/yabloc_image_processing/Lanelet2Overlay.node.yaml
+++ b/common/autoware_universe_designs/design/localization/yabloc_image_processing/Lanelet2Overlay.node.yaml
@@ -1,0 +1,43 @@
+autoware_system_design_format: 0.3.0
+# node information
+name: Lanelet2Overlay.node
+package:
+  name: yabloc_image_processing
+  provider: autoware
+launch:
+  plugin: yabloc::lanelet2_overlay::Lanelet2Overlay
+  executable: yabloc_lanelet2_overlay_node
+# interfaces
+subscribers:
+  - name: ground
+    message_type: std_msgs/msg/Float32MultiArray
+  - name: image_raw
+    message_type: sensor_msgs/msg/Image
+  - name: pose
+    message_type: geometry_msgs/msg/PoseStamped
+  - name: projected_line_segments_cloud
+    message_type: sensor_msgs/msg/PointCloud2
+  - name: camera_info
+    message_type: sensor_msgs/msg/CameraInfo
+  - name: ll2_sign_board
+    message_type: sensor_msgs/msg/PointCloud2
+  - name: ll2_road_marking
+    message_type: sensor_msgs/msg/PointCloud2
+publishers:
+  - name: projected_marker
+    message_type: visualization_msgs/msg/Marker
+    remap_target: ~/debug/projected_marker
+  - name: lanelet2_overlay_image
+    message_type: sensor_msgs/msg/Image
+    remap_target: ~/debug/lanelet2_overlay_image
+# parameters
+param_files: []
+param_values: []
+# processes
+processes:
+  - name: overlay_lanelet2
+    trigger_conditions:
+      - on_input: image_raw
+    outcomes:
+      - to_output: projected_marker
+      - to_output: lanelet2_overlay_image

--- a/common/autoware_universe_designs/design/localization/yabloc_image_processing/LineSegmentDetector.node.yaml
+++ b/common/autoware_universe_designs/design/localization/yabloc_image_processing/LineSegmentDetector.node.yaml
@@ -1,0 +1,30 @@
+autoware_system_design_format: 0.3.0
+# node information
+name: LineSegmentDetector.node
+package:
+  name: yabloc_image_processing
+  provider: autoware
+launch:
+  plugin: yabloc::line_segment_detector::LineSegmentDetector
+  executable: yabloc_line_segment_detector_node
+# interfaces
+subscribers:
+  - name: image_raw
+    message_type: sensor_msgs/msg/Image
+publishers:
+  - name: line_segments_cloud
+    message_type: sensor_msgs/msg/PointCloud2
+  - name: image_with_line_segments
+    message_type: sensor_msgs/msg/Image
+    remap_target: ~/debug/image_with_line_segments
+# parameters
+param_files: []
+param_values: []
+# processes
+processes:
+  - name: detect_line_segments
+    trigger_conditions:
+      - on_input: image_raw
+    outcomes:
+      - to_output: line_segments_cloud
+      - to_output: image_with_line_segments

--- a/common/autoware_universe_designs/design/localization/yabloc_image_processing/LineSegmentsOverlay.node.yaml
+++ b/common/autoware_universe_designs/design/localization/yabloc_image_processing/LineSegmentsOverlay.node.yaml
@@ -1,0 +1,29 @@
+autoware_system_design_format: 0.3.0
+# node information
+name: LineSegmentsOverlay.node
+package:
+  name: yabloc_image_processing
+  provider: autoware
+launch:
+  plugin: yabloc::line_segments_overlay::LineSegmentsOverlay
+  executable: yabloc_line_segments_overlay_node
+# interfaces
+subscribers:
+  - name: image_raw
+    message_type: sensor_msgs/msg/Image
+  - name: line_segments
+    message_type: sensor_msgs/msg/PointCloud2
+publishers:
+  - name: image_with_colored_line_segments
+    message_type: sensor_msgs/msg/Image
+    remap_target: ~/debug/image_with_colored_line_segments
+# parameters
+param_files: []
+param_values: []
+# processes
+processes:
+  - name: overlay_line_segments
+    trigger_conditions:
+      - on_input: image_raw
+    outcomes:
+      - to_output: image_with_colored_line_segments

--- a/common/autoware_universe_designs/design/localization/yabloc_image_processing/SegmentFilter.node.yaml
+++ b/common/autoware_universe_designs/design/localization/yabloc_image_processing/SegmentFilter.node.yaml
@@ -1,0 +1,40 @@
+autoware_system_design_format: 0.3.0
+# node information
+name: SegmentFilter.node
+package:
+  name: yabloc_image_processing
+  provider: autoware
+launch:
+  plugin: yabloc::segment_filter::SegmentFilter
+  executable: yabloc_segment_filter_node
+# interfaces
+subscribers:
+  - name: line_segments_cloud
+    message_type: sensor_msgs/msg/PointCloud2
+  - name: graph_segmented
+    message_type: sensor_msgs/msg/Image
+  - name: camera_info
+    message_type: sensor_msgs/msg/CameraInfo
+publishers:
+  - name: projected_line_segments_cloud
+    message_type: sensor_msgs/msg/PointCloud2
+  - name: debug_line_segments
+    message_type: sensor_msgs/msg/PointCloud2
+    remap_target: ~/debug/debug_line_segments
+  - name: projected_image
+    message_type: sensor_msgs/msg/Image
+    remap_target: ~/debug/projected_image
+# parameters
+param_files:
+  - name: segment_filter_param
+    default: config/segment_filter.param.yaml
+param_values: []
+# processes
+processes:
+  - name: filter_segments
+    trigger_conditions:
+      - on_input: graph_segmented
+    outcomes:
+      - to_output: projected_line_segments_cloud
+      - to_output: debug_line_segments
+      - to_output: projected_image

--- a/common/autoware_universe_designs/design/localization/yabloc_image_processing/UndistortNode.node.yaml
+++ b/common/autoware_universe_designs/design/localization/yabloc_image_processing/UndistortNode.node.yaml
@@ -1,0 +1,36 @@
+autoware_system_design_format: 0.3.0
+# node information
+name: UndistortNode.node
+package:
+  name: yabloc_image_processing
+  provider: autoware
+launch:
+  plugin: yabloc::undistort::UndistortNode
+  executable: yabloc_undistort_node
+# interfaces
+subscribers:
+  - name: image_raw
+    message_type: sensor_msgs/msg/Image
+  - name: image_raw_compressed
+    message_type: sensor_msgs/msg/CompressedImage
+    remap_target: ~/input/image_raw/compressed
+  - name: camera_info
+    message_type: sensor_msgs/msg/CameraInfo
+publishers:
+  - name: resized_info
+    message_type: sensor_msgs/msg/CameraInfo
+  - name: resized_image
+    message_type: sensor_msgs/msg/Image
+# parameters
+param_files:
+  - name: undistort_param
+    default: config/undistort.param.yaml
+param_values: []
+# processes
+processes:
+  - name: undistort_image
+    trigger_conditions:
+      - on_input: image_raw
+    outcomes:
+      - to_output: resized_image
+      - to_output: resized_info


### PR DESCRIPTION
## Description

Adds the missing *.node.yaml design files (Autoware System Design Format 0.3.0) for the 6 yabloc_image_processing nodes under common/autoware_universe_designs/design/localization/yabloc_image_processing/. Part of the yabloc-subsystem batch, following the localization core batch (#12801).

- yabloc_image_processing / GraphSegment
- yabloc_image_processing / Lanelet2Overlay
- yabloc_image_processing / LineSegmentDetector
- yabloc_image_processing / LineSegmentsOverlay
- yabloc_image_processing / SegmentFilter
- yabloc_image_processing / UndistortNode

Interfaces were derived directly from each node's implementation and CMakeLists. The remaining 7 yabloc nodes (yabloc_common, yabloc_particle_filter, yabloc_pose_initializer, yabloc_monitor) follow in a separate PR.

## How was this PR tested?

Following same way on #12801, I made a module that uses these nodes and confirmed the three points (topic types, remap targets, visual).

I built a YablocDebugTools module instantiating all 13 yabloc nodes, added it to AutowareSample.system.yaml as a yabloc_tools component with a parameter_set, deployed, and launched.

**Topic types & remap targets** — ran ros2 node info on each node and checked every port against the source:
- Debug topics resolve to their ~/debug/... names via remap_target (e.g. graph_segment's segmented_image, lanelet2_overlay's projected_marker / lanelet2_overlay_image, segment_filter's debug_line_segments / projected_image).
- The undistort nested input resolves correctly: /yabloc_tools/yabloc_undistort/input/image_raw/compressed (sensor_msgs/msg/CompressedImage).
- Bare ~/output topics (mask_image, line_segments_cloud, projected_line_segments_cloud, resized_image, resized_info) resolve as expected.

**Visual** — the Diagram renders the yabloc_tools component with all nodes.

<img width="2090" height="1408" alt="Screenshot from 2026-06-18 09-47-41" src="https://github.com/user-attachments/assets/0a8589e9-83ba-47f7-88ca-af3453dd5296" />


pre-commit run lint-system-design-format passes on all 6 files.

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None. Documentation-only change.