### PR TITLE
feat(autoware_universe_designs): add node designs for yabloc common, particle filter, pose initializer, and monitor nodes

### DIFF
--- a/common/autoware_universe_designs/design/localization/yabloc_common/GroundServer.node.yaml
+++ b/common/autoware_universe_designs/design/localization/yabloc_common/GroundServer.node.yaml
@@ -1,0 +1,45 @@
+autoware_system_design_format: 0.3.0
+# node information
+name: GroundServer.node
+package:
+  name: yabloc_common
+  provider: autoware
+launch:
+  plugin: yabloc::ground_server::GroundServer
+  executable: yabloc_ground_server_node
+# interfaces
+subscribers:
+  - name: vector_map
+    message_type: autoware_map_msgs/msg/LaneletMapBin
+  - name: pose
+    message_type: geometry_msgs/msg/PoseStamped
+publishers:
+  - name: height
+    message_type: std_msgs/msg/Float32
+  - name: ground
+    message_type: std_msgs/msg/Float32MultiArray
+  - name: ground_markers
+    message_type: visualization_msgs/msg/Marker
+    remap_target: ~/debug/ground_markers
+  - name: ground_status
+    message_type: std_msgs/msg/String
+    remap_target: ~/debug/ground_status
+  - name: near_cloud
+    message_type: sensor_msgs/msg/PointCloud2
+    remap_target: ~/debug/near_cloud
+# parameters
+param_files:
+  - name: ground_server_param
+    default: config/ground_server.param.yaml
+param_values: []
+# processes
+processes:
+  - name: estimate_ground
+    trigger_conditions:
+      - on_input: pose
+    outcomes:
+      - to_output: height
+      - to_output: ground
+      - to_output: ground_markers
+      - to_output: ground_status
+      - to_output: near_cloud

--- a/common/autoware_universe_designs/design/localization/yabloc_common/Ll2Decomposer.node.yaml
+++ b/common/autoware_universe_designs/design/localization/yabloc_common/Ll2Decomposer.node.yaml
@@ -1,0 +1,38 @@
+autoware_system_design_format: 0.3.0
+# node information
+name: Ll2Decomposer.node
+package:
+  name: yabloc_common
+  provider: autoware
+launch:
+  plugin: yabloc::ll2_decomposer::Ll2Decomposer
+  executable: yabloc_ll2_decomposer_node
+# interfaces
+subscribers:
+  - name: vector_map
+    message_type: autoware_map_msgs/msg/LaneletMapBin
+publishers:
+  - name: ll2_road_marking
+    message_type: sensor_msgs/msg/PointCloud2
+  - name: ll2_sign_board
+    message_type: sensor_msgs/msg/PointCloud2
+  - name: ll2_bounding_box
+    message_type: sensor_msgs/msg/PointCloud2
+  - name: sign_board_marker
+    message_type: visualization_msgs/msg/MarkerArray
+    remap_target: ~/debug/sign_board_marker
+# parameters
+param_files:
+  - name: ll2_decomposer_param
+    default: config/ll2_decomposer.param.yaml
+param_values: []
+# processes
+processes:
+  - name: decompose_lanelet2
+    trigger_conditions:
+      - on_input: vector_map
+    outcomes:
+      - to_output: ll2_road_marking
+      - to_output: ll2_sign_board
+      - to_output: ll2_bounding_box
+      - to_output: sign_board_marker

--- a/common/autoware_universe_designs/design/localization/yabloc_monitor/YabLocMonitor.node.yaml
+++ b/common/autoware_universe_designs/design/localization/yabloc_monitor/YabLocMonitor.node.yaml
@@ -1,0 +1,29 @@
+autoware_system_design_format: 0.3.0
+# node information
+name: YabLocMonitor.node
+package:
+  name: yabloc_monitor
+  provider: autoware
+launch:
+  plugin: YabLocMonitor
+  executable: yabloc_monitor_node
+# interfaces
+subscribers:
+  - name: yabloc_pose
+    message_type: geometry_msgs/msg/PoseStamped
+publishers:
+  - name: diagnostics
+    message_type: diagnostic_msgs/msg/DiagnosticArray
+    global: /diagnostics
+# parameters
+param_files:
+  - name: yabloc_monitor_param
+    default: config/yabloc_monitor.param.yaml
+param_values: []
+# processes
+processes:
+  - name: monitor_yabloc_availability
+    trigger_conditions:
+      - on_input: yabloc_pose
+    outcomes:
+      - to_output: diagnostics

--- a/common/autoware_universe_designs/design/localization/yabloc_particle_filter/CameraParticleCorrector.node.yaml
+++ b/common/autoware_universe_designs/design/localization/yabloc_particle_filter/CameraParticleCorrector.node.yaml
@@ -1,0 +1,58 @@
+autoware_system_design_format: 0.3.0
+# node information
+name: CameraParticleCorrector.node
+package:
+  name: yabloc_particle_filter
+  provider: autoware
+launch:
+  plugin: yabloc::modularized_particle_filter::CameraParticleCorrector
+  executable: yabloc_camera_particle_corrector_node
+# interfaces
+subscribers:
+  - name: predicted_particles
+    message_type: yabloc_particle_filter/msg/ParticleArray
+  - name: line_segments_cloud
+    message_type: sensor_msgs/msg/PointCloud2
+  - name: ll2_road_marking
+    message_type: sensor_msgs/msg/PointCloud2
+  - name: ll2_bounding_box
+    message_type: sensor_msgs/msg/PointCloud2
+  - name: pose
+    message_type: geometry_msgs/msg/PoseStamped
+publishers:
+  - name: weighted_particles
+    message_type: yabloc_particle_filter/msg/ParticleArray
+  - name: match_image
+    message_type: sensor_msgs/msg/Image
+    remap_target: ~/debug/match_image
+  - name: cost_map_image
+    message_type: sensor_msgs/msg/Image
+    remap_target: ~/debug/cost_map_image
+  - name: cost_map_range
+    message_type: visualization_msgs/msg/MarkerArray
+    remap_target: ~/debug/cost_map_range
+  - name: state_string
+    message_type: std_msgs/msg/String
+    remap_target: ~/debug/state_string
+  - name: scored_cloud
+    message_type: sensor_msgs/msg/PointCloud2
+    remap_target: ~/debug/scored_cloud
+  - name: scored_post_cloud
+    message_type: sensor_msgs/msg/PointCloud2
+    remap_target: ~/debug/scored_post_cloud
+servers:
+  - name: switch_srv
+    message_type: std_srvs/srv/SetBool
+    remap_target: ~/service/switch_srv
+# parameters
+param_files:
+  - name: camera_particle_corrector_param
+    default: config/camera_particle_corrector.param.yaml
+param_values: []
+# processes
+processes:
+  - name: correct_with_camera
+    trigger_conditions:
+      - on_input: predicted_particles
+    outcomes:
+      - to_output: weighted_particles

--- a/common/autoware_universe_designs/design/localization/yabloc_particle_filter/GnssParticleCorrector.node.yaml
+++ b/common/autoware_universe_designs/design/localization/yabloc_particle_filter/GnssParticleCorrector.node.yaml
@@ -1,0 +1,35 @@
+autoware_system_design_format: 0.3.0
+# node information
+name: GnssParticleCorrector.node
+package:
+  name: yabloc_particle_filter
+  provider: autoware
+launch:
+  plugin: yabloc::modularized_particle_filter::GnssParticleCorrector
+  executable: yabloc_gnss_particle_corrector_node
+# interfaces
+subscribers:
+  - name: predicted_particles
+    message_type: yabloc_particle_filter/msg/ParticleArray
+  - name: pose_with_covariance
+    message_type: geometry_msgs/msg/PoseWithCovarianceStamped
+  - name: height
+    message_type: std_msgs/msg/Float32
+publishers:
+  - name: weighted_particles
+    message_type: yabloc_particle_filter/msg/ParticleArray
+  - name: gnss_range_marker
+    message_type: visualization_msgs/msg/MarkerArray
+    remap_target: ~/debug/gnss_range_marker
+# parameters
+param_files:
+  - name: gnss_particle_corrector_param
+    default: config/gnss_particle_corrector.param.yaml
+param_values: []
+# processes
+processes:
+  - name: correct_with_gnss
+    trigger_conditions:
+      - on_input: predicted_particles
+    outcomes:
+      - to_output: weighted_particles

--- a/common/autoware_universe_designs/design/localization/yabloc_particle_filter/YablocPredictor.node.yaml
+++ b/common/autoware_universe_designs/design/localization/yabloc_particle_filter/YablocPredictor.node.yaml
@@ -1,0 +1,55 @@
+autoware_system_design_format: 0.3.0
+# node information
+name: YablocPredictor.node
+package:
+  name: yabloc_particle_filter
+  provider: autoware
+launch:
+  plugin: yabloc::modularized_particle_filter::Predictor
+  executable: yabloc_predictor_node
+# interfaces
+subscribers:
+  - name: initialpose
+    message_type: geometry_msgs/msg/PoseWithCovarianceStamped
+  - name: weighted_particles
+    message_type: yabloc_particle_filter/msg/ParticleArray
+  - name: height
+    message_type: std_msgs/msg/Float32
+  - name: twist_with_covariance
+    message_type: geometry_msgs/msg/TwistWithCovarianceStamped
+  - name: ekf_pose
+    message_type: geometry_msgs/msg/PoseWithCovarianceStamped
+publishers:
+  - name: predicted_particles
+    message_type: yabloc_particle_filter/msg/ParticleArray
+  - name: pose
+    message_type: geometry_msgs/msg/PoseStamped
+  - name: pose_with_covariance
+    message_type: geometry_msgs/msg/PoseWithCovarianceStamped
+  - name: init_marker
+    message_type: visualization_msgs/msg/Marker
+    remap_target: ~/debug/init_marker
+  - name: particles_marker_array
+    message_type: visualization_msgs/msg/MarkerArray
+    remap_target: ~/debug/particles_marker_array
+  - name: tf
+    message_type: tf2_msgs/msg/TFMessage
+    global: /tf
+servers:
+  - name: yabloc_trigger_srv
+    message_type: std_srvs/srv/SetBool
+    remap_target: ~/service/yabloc_trigger_srv
+# parameters
+param_files:
+  - name: predictor_param
+    default: config/predictor.param.yaml
+param_values: []
+# processes
+processes:
+  - name: predict_particles
+    trigger_conditions:
+      - on_input: weighted_particles
+    outcomes:
+      - to_output: predicted_particles
+      - to_output: pose
+      - to_output: pose_with_covariance

--- a/common/autoware_universe_designs/design/localization/yabloc_pose_initializer/CameraPoseInitializer.node.yaml
+++ b/common/autoware_universe_designs/design/localization/yabloc_pose_initializer/CameraPoseInitializer.node.yaml
@@ -1,0 +1,35 @@
+autoware_system_design_format: 0.3.0
+# node information
+name: CameraPoseInitializer.node
+package:
+  name: yabloc_pose_initializer
+  provider: autoware
+launch:
+  plugin: yabloc::CameraPoseInitializer
+  executable: yabloc_pose_initializer_node
+# interfaces
+subscribers:
+  - name: vector_map
+    message_type: autoware_map_msgs/msg/LaneletMapBin
+  - name: image_raw
+    message_type: sensor_msgs/msg/Image
+publishers:
+  - name: init_candidates
+    message_type: visualization_msgs/msg/MarkerArray
+    remap_target: ~/debug/init_candidates
+servers:
+  - name: yabloc_align_srv
+    message_type: autoware_internal_localization_msgs/srv/PoseWithCovarianceStamped
+    remap_target: ~/service/yabloc_align_srv
+# parameters
+param_files:
+  - name: camera_pose_initializer_param
+    default: config/camera_pose_initializer.param.yaml
+param_values: []
+# processes
+processes:
+  - name: initialize_pose_from_camera
+    trigger_conditions:
+      - on_input: image_raw
+    outcomes:
+      - to_output: init_candidates


### PR DESCRIPTION
## Description

Adds the missing *.node.yaml design files (Autoware System Design Format 0.3.0) for the remaining 7 yabloc-subsystem nodes, under common/autoware_universe_designs/design/localization/. This completes the yabloc batch, following the image_processing PR (#12824) and the localization core batch (#12801).

- yabloc_common / GroundServer
- yabloc_common / Ll2Decomposer
- yabloc_particle_filter / CameraParticleCorrector
- yabloc_particle_filter / GnssParticleCorrector
- yabloc_particle_filter / Predictor
- yabloc_pose_initializer / CameraPoseInitializer
- yabloc_monitor / YabLocMonitor

Interfaces were derived directly from each node's implementation and CMakeLists.

## How was this PR tested?

Following the same approach as #12801, I made a module that uses these nodes and confirmed the three points (topic types, remap targets, visual). The launch test covered all 13 yabloc nodes together (this batch plus #12824) via a single YablocDebugTools module added to AutowareSample.system.yaml as a yabloc_tools component, deployed and launched.

Topic types & remap targets — ran ros2 node info on each node and checked every port against the source:
- Debug topics resolve to their ~/debug/... names via remap_target (e.g. ground_server's ground_markers / ground_status / near_cloud, camera_particle_corrector's 6 debug topics, predictor's init_marker / particles_marker_array).
- Service servers resolve via remap_target ~/service/...: camera_particle_corrector's switch_srv, predictor's yabloc_trigger_srv, pose_initializer's yabloc_align_srv (all std_srvs/srv/SetBool except yabloc_align_srv).
- Global publishers bind to absolute topics: monitor's /diagnostics, predictor's /tf (TransformBroadcaster).
- Custom message type yabloc_particle_filter/msg/ParticleArray resolves correctly on the predicted_particles / weighted_particles ports of the predictor and both correctors.
- Bare ~/output topics (height, ground, ll2_road_marking / ll2_sign_board / ll2_bounding_box, predicted_particles, pose, pose_with_covariance, resized_*) resolve as expected.

Visual — the Diagram renders the yabloc_tools component with all 13 nodes.
<img width="1557" height="1049" alt="Screenshot from 2026-06-19 09-18-24" src="https://github.com/user-attachments/assets/b49f0f2f-0f8b-4185-a633-e9bbcf199512" />


pre-commit run lint-system-design-format passes on all 7 files.

## Notes for reviewers

CameraPoseInitializer's yabloc_align_srv: the source aliases the service type as autoware_internal_localization_msgs/srv/PoseWithCovarianceStamped, which is what the design file uses. (At runtime in my older test install it resolved to the predecessor tier4_localization_msgs/srv/PoseWithCovarianceStamped; the design follows current source.)

Predictor broadcasts TF (/tf) and publishes particles_marker_array (debug), both confirmed via ros2 node info and added to the design.

## Interface changes

None.

## Effects on system behavior

None. Documentation-only change.