### PR TITLE
feat(map_tf_generator): apply `agnocast_wrapper::Node` to `map_tf_generator`

### DIFF
--- a/map/autoware_map_tf_generator/CMakeLists.txt
+++ b/map/autoware_map_tf_generator/CMakeLists.txt
@@ -26,9 +26,11 @@ ament_auto_add_library(vector_map_tf_generator_node SHARED
   src/vector_map_tf_generator_node.cpp
 )
 
-rclcpp_components_register_node(vector_map_tf_generator_node
+autoware_agnocast_wrapper_register_node(vector_map_tf_generator_node
   PLUGIN "autoware::map_tf_generator::VectorMapTFGeneratorNode"
   EXECUTABLE autoware_vector_map_tf_generator
+  AGNOCAST_EXECUTOR AgnocastOnlyCallbackIsolatedExecutor
+  ROS2_EXECUTOR SingleThreadedExecutor
 )
 
 if(BUILD_TESTING)

--- a/map/autoware_map_tf_generator/launch/map_tf_generator.launch.xml
+++ b/map/autoware_map_tf_generator/launch/map_tf_generator.launch.xml
@@ -1,9 +1,11 @@
 <launch>
+  <include file="$(find-pkg-share autoware_agnocast_wrapper)/launch/agnocast_env.launch.xml"/>
   <arg name="param_file" default="$(find-pkg-share autoware_map_tf_generator)/config/map_tf_generator.param.yaml"/>
 
   <arg name="input_vector_map_topic" default="/map/vector_map"/>
 
   <node pkg="autoware_map_tf_generator" exec="autoware_vector_map_tf_generator" name="vector_map_tf_generator" output="both">
+    <env name="LD_PRELOAD" value="$(var ld_preload_value)"/>
     <remap from="vector_map" to="$(var input_vector_map_topic)"/>
 
     <param from="$(var param_file)"/>

--- a/map/autoware_map_tf_generator/package.xml
+++ b/map/autoware_map_tf_generator/package.xml
@@ -13,6 +13,7 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
+  <depend>autoware_agnocast_wrapper</depend>
   <depend>autoware_lanelet2_utils</depend>
   <depend>libpcl-all-dev</depend>
   <depend>pcl_conversions</depend>

--- a/map/autoware_map_tf_generator/src/vector_map_tf_generator_node.cpp
+++ b/map/autoware_map_tf_generator/src/vector_map_tf_generator_node.cpp
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <autoware/agnocast_wrapper/node.hpp>
+#include <autoware/agnocast_wrapper/tf2.hpp>
 #include <autoware/lanelet2_utils/conversion.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <tf2/LinearMath/Quaternion.hpp>
@@ -20,7 +22,6 @@
 
 #include <lanelet2_core/LaneletMap.h>
 #include <lanelet2_core/geometry/Point.h>
-#include <tf2_ros/static_transform_broadcaster.h>
 
 #include <memory>
 #include <string>
@@ -28,7 +29,7 @@
 
 namespace autoware::map_tf_generator
 {
-class VectorMapTFGeneratorNode : public rclcpp::Node
+class VectorMapTFGeneratorNode : public autoware::agnocast_wrapper::Node
 {
 public:
   explicit VectorMapTFGeneratorNode(const rclcpp::NodeOptions & options)
@@ -40,18 +41,20 @@ public:
       "vector_map", rclcpp::QoS{1}.transient_local(),
       std::bind(&VectorMapTFGeneratorNode::on_vector_map, this, std::placeholders::_1));
 
-    static_broadcaster_ = std::make_shared<tf2_ros::StaticTransformBroadcaster>(this);
+    static_broadcaster_ =
+      std::make_shared<autoware::agnocast_wrapper::StaticTransformBroadcaster>(*this);
   }
 
 private:
   std::string map_frame_;
   std::string viewer_frame_;
-  rclcpp::Subscription<autoware_map_msgs::msg::LaneletMapBin>::SharedPtr sub_;
+  AUTOWARE_SUBSCRIPTION_PTR(autoware_map_msgs::msg::LaneletMapBin) sub_;
 
-  std::shared_ptr<tf2_ros::StaticTransformBroadcaster> static_broadcaster_;
+  std::shared_ptr<autoware::agnocast_wrapper::StaticTransformBroadcaster> static_broadcaster_;
   std::shared_ptr<lanelet::LaneletMap> lanelet_map_ptr_;
 
-  void on_vector_map(const autoware_map_msgs::msg::LaneletMapBin::ConstSharedPtr msg)
+  void on_vector_map(
+    const AUTOWARE_MESSAGE_CONST_SHARED_PTR(autoware_map_msgs::msg::LaneletMapBin) & msg)
   {
     lanelet_map_ptr_ = autoware::experimental::lanelet2_utils::remove_const(
       autoware::experimental::lanelet2_utils::from_autoware_map_msgs(*msg));


### PR DESCRIPTION
## Description
Apply `agnocast_wrapper::Node` to `autoware_map_tf_generator`.
Please read https://github.com/autowarefoundation/autoware/issues/7007 for the context and review guidelines of `autoware_agnocast_wrapper` adoption. 
Also, please refer to https://github.com/autowarefoundation/autoware_core/blob/main/common/autoware_agnocast_wrapper/docs/review_guide.md for the review guide of `autoware_agnocast_wrapper` application PR. FYI: This node take [Method2](https://github.com/autowarefoundation/autoware_core/blob/main/common/autoware_agnocast_wrapper/docs/review_guide.md#method-2-agnocast_wrappernode-inheritance) of two integrations methods.

**AgnocastOnlyCallbackIsolatedExecutor:**
When built and run with `ENABLE_AGNOCAST=1`, the node runs on a `AgnocastOnlyCallbackIsolatedExecutor` (CIE), the standard executor for `agnocast_wrapper::Node`. Please check for potential race conditions only if the node meets **all** of the following:

1. It was originally running on a `SingleThreadedExecutor`.
2. It has multiple callback groups (the default is one).
3. Shared variables are accessed across those callback groups without mutex protection.

**Nodes already running on `MultiThreadedExecutor` are unaffected**, since their callbacks already run concurrently.

## Related Links

  - https://github.com/autowarefoundation/autoware/issues/7007
  - https://github.com/orgs/autowarefoundation/discussions/6804

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
  - `colcon build` succeeds with both `ENABLE_AGNOCAST=1` and `ENABLE_AGNOCAST=0`.
  - Ran Autoware based product with this change applied and confirmed it operates without any regression.

## Notes for reviewers
This PR depends to https://github.com/autowarefoundation/autoware_launch/pull/1898. Please wait for this PR to be merged before this PR.


## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None when ENABLE_AGNOCAST is not set or set to 0 on runtime. When ENABLE_AGNOCAST=1, CPU Time used in this node for message serialization/deserialization will be reduced.
