### PR TITLE
refactor(trajectory_validator): add another severity level for metric and validation reports

### DIFF
--- a/planning/autoware_trajectory_validator/CMakeLists.txt
+++ b/planning/autoware_trajectory_validator/CMakeLists.txt
@@ -41,6 +41,7 @@ unset(PYTHON_EXECUTABLE)
 
 rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/MetricReport.msg"
+  "msg/RiskLevel.msg"
   "msg/ValidationReport.msg"
   "msg/ValidationReportArray.msg"
   DEPENDENCIES

--- a/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/validator_interface.hpp
+++ b/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/validator_interface.hpp
@@ -36,6 +36,7 @@ using autoware_planning_msgs::msg::TrajectoryPoint;
 using TrajectoryPoints = std::vector<TrajectoryPoint>;
 using VehicleInfo = autoware::vehicle_info_utils::VehicleInfo;
 using autoware_trajectory_validator::msg::MetricReport;
+using autoware_trajectory_validator::msg::RiskLevel;
 
 /** @brief Result of a single plugin's feasibility check. */
 struct ValidationResult

--- a/planning/autoware_trajectory_validator/msg/MetricReport.msg
+++ b/planning/autoware_trajectory_validator/msg/MetricReport.msg
@@ -1,11 +1,5 @@
 # This message represents a metric report from a trajectory validator.
 
-# Possible levels for a metric report.
-uint8 SAFE = 0
-uint8 LOW_CAUTION = 1
-uint8 HIGH_CAUTION = 2
-uint8 DANGER = 3
-
 # The name of the validator that generated this report.
 string validator_name
 # The category of the validator that generated this report.
@@ -14,5 +8,5 @@ string validator_category
 string metric_name
 # The value of the metric that was reported.
 float64 metric_value
-# The level of the metric report.
-uint8 level
+# The risk severity of the metric report.
+RiskLevel risk

--- a/planning/autoware_trajectory_validator/msg/RiskLevel.msg
+++ b/planning/autoware_trajectory_validator/msg/RiskLevel.msg
@@ -1,0 +1,9 @@
+# This message represents the possible levels of risk severity.
+
+uint8 SAFE = 0
+uint8 LOW_CAUTION = 1
+uint8 HIGH_CAUTION = 2
+uint8 DANGER = 3
+uint8 FATAL = 4
+
+uint8 level

--- a/planning/autoware_trajectory_validator/msg/ValidationReport.msg
+++ b/planning/autoware_trajectory_validator/msg/ValidationReport.msg
@@ -1,13 +1,7 @@
 # This message represents a validation report for a trajectory.
 
-# Possible levels of validation report severity.
-uint8 SAFE = 0
-uint8 LOW_CAUTION = 1
-uint8 HIGH_CAUTION = 2
-uint8 DANGER = 3
-
 builtin_interfaces/Time trajectory_stamp
 unique_identifier_msgs/UUID generator_id
 string generator_name
-uint8 level
+RiskLevel risk
 MetricReport[] metrics

--- a/planning/autoware_trajectory_validator/src/detail/trajectory_validator.cpp
+++ b/planning/autoware_trajectory_validator/src/detail/trajectory_validator.cpp
@@ -25,6 +25,7 @@
 
 namespace autoware::trajectory_validator
 {
+using autoware_trajectory_validator::msg::RiskLevel;
 using autoware_trajectory_validator::msg::ValidationReport;
 
 TrajectoryValidatorReport TrajectoryValidator::process(
@@ -85,12 +86,14 @@ TrajectoryValidatorReport TrajectoryValidator::process(
       report.num_feasible_trajectories++;
     }
 
+    RiskLevel risk_level;
+    risk_level.level = all_feasible ? RiskLevel::SAFE : RiskLevel::DANGER;
     report.validation_reports.push_back(
       autoware_trajectory_validator::build<ValidationReport>()
         .trajectory_stamp(trajectory.header.stamp)
         .generator_id(trajectory.generator_id)
         .generator_name(uuid_to_name.at(hex_generator_id))
-        .level(all_feasible ? ValidationReport::SAFE : ValidationReport::DANGER)
+        .risk(risk_level)
         .metrics(std::move(combined_metrics)));
   }
 

--- a/planning/autoware_trajectory_validator/src/filters/safety/uncrossable_boundary_departure.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/uncrossable_boundary_departure.cpp
@@ -49,13 +49,14 @@ UncrossableBoundaryDepartureFilter::result_t UncrossableBoundaryDepartureFilter:
       std::back_inserter(debug_markers_.markers));
   }
 
-  std::vector<MetricReport> metrics{
-    autoware_trajectory_validator::build<MetricReport>()
-      .validator_name(get_name())
-      .validator_category(category())
-      .metric_name("check_critical_departure")
-      .metric_value(is_feasible ? 1.0 : 0.0)
-      .level(!is_feasible ? MetricReport::DANGER : MetricReport::SAFE)};
+  RiskLevel risk_level;
+  risk_level.level = is_feasible ? RiskLevel::SAFE : RiskLevel::DANGER;
+  std::vector<MetricReport> metrics{autoware_trajectory_validator::build<MetricReport>()
+                                      .validator_name(get_name())
+                                      .validator_category(category())
+                                      .metric_name("check_critical_departure")
+                                      .metric_value(is_feasible ? 1.0 : 0.0)
+                                      .risk(risk_level)};
 
   return ValidationResult{is_feasible, std::move(metrics)};
 }

--- a/planning/autoware_trajectory_validator/src/filters/safety/vehicle_constraint_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/vehicle_constraint_filter.cpp
@@ -127,7 +127,7 @@ VehicleConstraintFilter::result_t VehicleConstraintFilter::is_feasible(
   std::vector<MetricReport> metrics;
   for (const auto & checker : checkers_) {
     auto report = (this->*checker)(traj_points);
-    is_feasible &= report.level == MetricReport::SAFE;
+    is_feasible &= report.risk.level == RiskLevel::SAFE;
     metrics.push_back(report);
   }
 
@@ -138,36 +138,42 @@ MetricReport VehicleConstraintFilter::check_speed(const TrajectoryPoints & traj_
 {
   const auto [max_observed, is_ok] = is_speed_ok(traj_points, params_.max_speed);
 
+  RiskLevel risk_level;
+  risk_level.level = is_ok ? RiskLevel::SAFE : RiskLevel::DANGER;
   return autoware_trajectory_validator::build<MetricReport>()
     .validator_name(get_name())
     .validator_category(category())
     .metric_name("check_speed")
     .metric_value(max_observed)
-    .level(is_ok ? MetricReport::SAFE : MetricReport::DANGER);
+    .risk(risk_level);
 }
 
 MetricReport VehicleConstraintFilter::check_acceleration(const TrajectoryPoints & traj_points) const
 {
   const auto [max_observed, is_ok] = is_acceleration_ok(traj_points, params_.max_acceleration);
 
+  RiskLevel risk_level;
+  risk_level.level = is_ok ? RiskLevel::SAFE : RiskLevel::DANGER;
   return autoware_trajectory_validator::build<MetricReport>()
     .validator_name(get_name())
     .validator_category(category())
     .metric_name("check_acceleration")
     .metric_value(max_observed)
-    .level(is_ok ? MetricReport::SAFE : MetricReport::DANGER);
+    .risk(risk_level);
 }
 
 MetricReport VehicleConstraintFilter::check_deceleration(const TrajectoryPoints & traj_points) const
 {
   const auto [max_observed, is_ok] = is_deceleration_ok(traj_points, params_.max_deceleration);
 
+  RiskLevel risk_level;
+  risk_level.level = is_ok ? RiskLevel::SAFE : RiskLevel::DANGER;
   return autoware_trajectory_validator::build<MetricReport>()
     .validator_name(get_name())
     .validator_category(category())
     .metric_name("check_deceleration")
     .metric_value(max_observed)
-    .level(is_ok ? MetricReport::SAFE : MetricReport::DANGER);
+    .risk(risk_level);
 }
 
 MetricReport VehicleConstraintFilter::check_steering_angle(
@@ -176,12 +182,14 @@ MetricReport VehicleConstraintFilter::check_steering_angle(
   const auto [max_observed, is_ok] =
     is_steering_angle_ok(traj_points, *vehicle_info_ptr_, params_.max_steering_angle);
 
+  RiskLevel risk_level;
+  risk_level.level = is_ok ? RiskLevel::SAFE : RiskLevel::DANGER;
   return autoware_trajectory_validator::build<MetricReport>()
     .validator_name(get_name())
     .validator_category(category())
     .metric_name("check_steering_angle")
     .metric_value(max_observed)
-    .level(is_ok ? MetricReport::SAFE : MetricReport::DANGER);
+    .risk(risk_level);
 }
 
 MetricReport VehicleConstraintFilter::check_steering_rate(
@@ -190,12 +198,14 @@ MetricReport VehicleConstraintFilter::check_steering_rate(
   const auto [max_observed, is_ok] =
     is_steering_rate_ok(traj_points, *vehicle_info_ptr_, params_.max_steering_rate);
 
+  RiskLevel risk_level;
+  risk_level.level = is_ok ? RiskLevel::SAFE : RiskLevel::DANGER;
   return autoware_trajectory_validator::build<MetricReport>()
     .validator_name(get_name())
     .validator_category(category())
     .metric_name("check_steering_rate")
     .metric_value(max_observed)
-    .level(is_ok ? MetricReport::SAFE : MetricReport::DANGER);
+    .risk(risk_level);
 }
 
 // --- Helper functions for constraint checks ---

--- a/planning/autoware_trajectory_validator/src/filters/traffic_rule/traffic_light_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/traffic_rule/traffic_light_filter.cpp
@@ -164,13 +164,20 @@ TrafficLightFilter::result_t TrafficLightFilter::is_feasible(
     context.odometry->pose.pose.position.z);
 
   std::vector<MetricReport> metrics;
+
+  auto get_risk_level = [](bool is_crossing) {
+    RiskLevel risk_level;
+    risk_level.level = is_crossing ? RiskLevel::DANGER : RiskLevel::SAFE;
+    return risk_level;
+  };
+
   metrics.push_back(
     autoware_trajectory_validator::build<MetricReport>()
       .validator_name(get_name())
       .validator_category(category())
       .metric_name("check_crossing_red_light")
       .metric_value(0.0)
-      .level(is_crossing_red ? MetricReport::DANGER : MetricReport::SAFE));
+      .risk(get_risk_level(is_crossing_red)));
 
   metrics.push_back(
     autoware_trajectory_validator::build<MetricReport>()
@@ -178,7 +185,7 @@ TrafficLightFilter::result_t TrafficLightFilter::is_feasible(
       .validator_category(category())
       .metric_name("check_crossing_amber_light")
       .metric_value(0.0)
-      .level(is_crossing_amber ? MetricReport::DANGER : MetricReport::SAFE));
+      .risk(get_risk_level(is_crossing_amber)));
 
   const bool is_feasible = !is_crossing_red && !is_crossing_amber;
 


### PR DESCRIPTION
## Description
- create separate msg RiskLevel.msg
- move severity levels from Metric/ValidationReport.msg to RiskLevel.msg
- add new level FATAL

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
`colcon build --packages-select autoware_trajectory_validator --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release`

## Notes for reviewers

None.

## Interface changes

### 1. `ValidationReport.msg`
| Before | After |
| :--- | :--- |
| <pre># Possible levels of validation report severity.<br>uint8 SAFE = 0<br>uint8 LOW_CAUTION = 1<br>uint8 HIGH_CAUTION = 2<br>uint8 DANGER = 3<br><br>builtin_interfaces/Time trajectory_stamp<br>unique_identifier_msgs/UUID generator_id<br>string generator_name<br><b>uint8 level</b><br>MetricReport[] metrics</pre> | <pre>builtin_interfaces/Time trajectory_stamp<br>unique_identifier_msgs/UUID generator_id<br>string generator_name<br><b>RiskLevel risk</b><br>MetricReport[] metrics</pre> |

### 2. `MetricReport.msg`
| Before | After |
| :--- | :--- |
| <pre># Possible levels for a metric report.<br>uint8 SAFE = 0<br>uint8 LOW_CAUTION = 1<br>uint8 HIGH_CAUTION = 2<br>uint8 DANGER = 3<br><br>string validator_name<br>string validator_category<br>string metric_name<br>float64 metric_value<br><b>uint8 level</b></pre> | <pre>string validator_name<br>string validator_category<br>string metric_name<br>float64 metric_value<br><b>RiskLevel risk</b></pre> |

### 3. `RiskLevel.msg` (Newly Added)
```
# This message represents the possible levels of risk severity.

uint8 SAFE = 0
uint8 LOW_CAUTION = 1
uint8 HIGH_CAUTION = 2
uint8 DANGER = 3
uint8 FATAL = 4

uint8 level
```

## Effects on system behavior

None.
