### PR TITLE
feat(mrm_comfortable_stop_operator): apply `agnocast_wrapper::Node` to `mrm_comfortable_stop_operator`

### DIFF
--- a/system/autoware_mrm_comfortable_stop_operator/CMakeLists.txt
+++ b/system/autoware_mrm_comfortable_stop_operator/CMakeLists.txt
@@ -8,9 +8,11 @@ ament_auto_add_library(${PROJECT_NAME}_component SHARED
   src/mrm_comfortable_stop_operator/mrm_comfortable_stop_operator_core.cpp
 )
 
-rclcpp_components_register_node(${PROJECT_NAME}_component
+autoware_agnocast_wrapper_register_node(${PROJECT_NAME}_component
   PLUGIN "autoware::mrm_comfortable_stop_operator::MrmComfortableStopOperator"
   EXECUTABLE ${PROJECT_NAME}_node
+  AGNOCAST_EXECUTOR CallbackIsolatedAgnocastExecutor
+  ROS2_EXECUTOR SingleThreadedExecutor
 )
 
 ament_auto_package(INSTALL_TO_SHARE

--- a/system/autoware_mrm_comfortable_stop_operator/CMakeLists.txt
+++ b/system/autoware_mrm_comfortable_stop_operator/CMakeLists.txt
@@ -11,7 +11,7 @@ ament_auto_add_library(${PROJECT_NAME}_component SHARED
 autoware_agnocast_wrapper_register_node(${PROJECT_NAME}_component
   PLUGIN "autoware::mrm_comfortable_stop_operator::MrmComfortableStopOperator"
   EXECUTABLE ${PROJECT_NAME}_node
-  AGNOCAST_EXECUTOR CallbackIsolatedAgnocastExecutor
+  AGNOCAST_EXECUTOR AgnocastOnlyCallbackIsolatedExecutor
   ROS2_EXECUTOR SingleThreadedExecutor
 )
 

--- a/system/autoware_mrm_comfortable_stop_operator/include/autoware/mrm_comfortable_stop_operator/mrm_comfortable_stop_operator_core.hpp
+++ b/system/autoware_mrm_comfortable_stop_operator/include/autoware/mrm_comfortable_stop_operator/mrm_comfortable_stop_operator_core.hpp
@@ -54,8 +54,8 @@ private:
   AUTOWARE_SERVICE_PTR(tier4_system_msgs::srv::OperateMrm) service_operation_;
 
   void operateComfortableStop(
-    const tier4_system_msgs::srv::OperateMrm::Request::SharedPtr request,
-    const tier4_system_msgs::srv::OperateMrm::Response::SharedPtr response);
+    AUTOWARE_SERVICE_REQUEST_CONST_PTR(tier4_system_msgs::srv::OperateMrm) request,
+    AUTOWARE_SERVICE_RESPONSE_PTR(tier4_system_msgs::srv::OperateMrm) response);
 
   rcl_interfaces::msg::SetParametersResult onParameter(
     const std::vector<rclcpp::Parameter> & parameters);

--- a/system/autoware_mrm_comfortable_stop_operator/include/autoware/mrm_comfortable_stop_operator/mrm_comfortable_stop_operator_core.hpp
+++ b/system/autoware_mrm_comfortable_stop_operator/include/autoware/mrm_comfortable_stop_operator/mrm_comfortable_stop_operator_core.hpp
@@ -27,6 +27,7 @@
 #include <tier4_system_msgs/srv/operate_mrm.hpp>
 
 // ROS 2 core
+#include <autoware/agnocast_wrapper/node.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 namespace autoware::mrm_comfortable_stop_operator
@@ -40,7 +41,7 @@ struct Parameters
   double min_jerk;          // [m/s^3]
 };
 
-class MrmComfortableStopOperator : public rclcpp::Node
+class MrmComfortableStopOperator : public autoware::agnocast_wrapper::Node
 {
 public:
   explicit MrmComfortableStopOperator(const rclcpp::NodeOptions & node_options);
@@ -50,7 +51,7 @@ private:
   Parameters params_;
 
   // Server
-  rclcpp::Service<tier4_system_msgs::srv::OperateMrm>::SharedPtr service_operation_;
+  AUTOWARE_SERVICE_PTR(tier4_system_msgs::srv::OperateMrm) service_operation_;
 
   void operateComfortableStop(
     const tier4_system_msgs::srv::OperateMrm::Request::SharedPtr request,
@@ -60,10 +61,9 @@ private:
     const std::vector<rclcpp::Parameter> & parameters);
 
   // Publisher
-  rclcpp::Publisher<tier4_system_msgs::msg::MrmBehaviorStatus>::SharedPtr pub_status_;
-  rclcpp::Publisher<autoware_internal_planning_msgs::msg::VelocityLimit>::SharedPtr
-    pub_velocity_limit_;
-  rclcpp::Publisher<autoware_internal_planning_msgs::msg::VelocityLimitClearCommand>::SharedPtr
+  AUTOWARE_PUBLISHER_PTR(tier4_system_msgs::msg::MrmBehaviorStatus) pub_status_;
+  AUTOWARE_PUBLISHER_PTR(autoware_internal_planning_msgs::msg::VelocityLimit) pub_velocity_limit_;
+  AUTOWARE_PUBLISHER_PTR(autoware_internal_planning_msgs::msg::VelocityLimitClearCommand)
     pub_velocity_limit_clear_command_;
 
   void publishStatus() const;
@@ -71,7 +71,7 @@ private:
   void publishVelocityLimitClearCommand() const;
 
   // Timer
-  rclcpp::TimerBase::SharedPtr timer_;
+  AUTOWARE_TIMER_PTR timer_;
 
   void onTimer() const;
 
@@ -79,7 +79,7 @@ private:
   tier4_system_msgs::msg::MrmBehaviorStatus status_;
 
   // Parameter callback
-  OnSetParametersCallbackHandle::SharedPtr set_param_res_;
+  rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr set_param_res_;
 };
 
 }  // namespace autoware::mrm_comfortable_stop_operator

--- a/system/autoware_mrm_comfortable_stop_operator/include/autoware/mrm_comfortable_stop_operator/mrm_comfortable_stop_operator_core.hpp
+++ b/system/autoware_mrm_comfortable_stop_operator/include/autoware/mrm_comfortable_stop_operator/mrm_comfortable_stop_operator_core.hpp
@@ -64,7 +64,7 @@ private:
   AUTOWARE_PUBLISHER_PTR(tier4_system_msgs::msg::MrmBehaviorStatus) pub_status_;
   AUTOWARE_PUBLISHER_PTR(autoware_internal_planning_msgs::msg::VelocityLimit) pub_velocity_limit_;
   AUTOWARE_PUBLISHER_PTR(autoware_internal_planning_msgs::msg::VelocityLimitClearCommand)
-    pub_velocity_limit_clear_command_;
+  pub_velocity_limit_clear_command_;
 
   void publishStatus() const;
   void publishVelocityLimit() const;

--- a/system/autoware_mrm_comfortable_stop_operator/include/autoware/mrm_comfortable_stop_operator/mrm_comfortable_stop_operator_core.hpp
+++ b/system/autoware_mrm_comfortable_stop_operator/include/autoware/mrm_comfortable_stop_operator/mrm_comfortable_stop_operator_core.hpp
@@ -54,8 +54,8 @@ private:
   AUTOWARE_SERVICE_PTR(tier4_system_msgs::srv::OperateMrm) service_operation_;
 
   void operateComfortableStop(
-    AUTOWARE_SERVICE_REQUEST_CONST_PTR(tier4_system_msgs::srv::OperateMrm) request,
-    AUTOWARE_SERVICE_RESPONSE_PTR(tier4_system_msgs::srv::OperateMrm) response);
+    AUTOWARE_SERVER_REQUEST_PTR(tier4_system_msgs::srv::OperateMrm) request,
+    AUTOWARE_SERVER_RESPONSE_PTR(tier4_system_msgs::srv::OperateMrm) response);
 
   rcl_interfaces::msg::SetParametersResult onParameter(
     const std::vector<rclcpp::Parameter> & parameters);

--- a/system/autoware_mrm_comfortable_stop_operator/launch/mrm_comfortable_stop_operator.launch.py
+++ b/system/autoware_mrm_comfortable_stop_operator/launch/mrm_comfortable_stop_operator.launch.py
@@ -14,8 +14,11 @@
 
 import launch
 from launch.actions import DeclareLaunchArgument
+from launch.actions import IncludeLaunchDescription
 from launch.actions import OpaqueFunction
+from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration
+from launch.substitutions import PathJoinSubstitution
 from launch_ros.actions import ComposableNodeContainer
 from launch_ros.descriptions import ComposableNode
 from launch_ros.substitutions import FindPackageShare
@@ -45,11 +48,12 @@ def launch_setup(context, *args, **kwargs):
     container = ComposableNodeContainer(
         name="mrm_comfortable_stop_operator_container",
         namespace="mrm_comfortable_stop_operator",
-        package="rclcpp_components",
-        executable="component_container",
+        package=LaunchConfiguration("container_package"),
+        executable=LaunchConfiguration("container_executable"),
         composable_node_descriptions=[
             component,
         ],
+        additional_env={"LD_PRELOAD": LaunchConfiguration("ld_preload_value")},
         output="screen",
     )
 
@@ -57,6 +61,21 @@ def launch_setup(context, *args, **kwargs):
 
 
 def generate_launch_description():
+    # Resolves the component container (rclcpp_components vs agnocast_components) and the
+    # LD_PRELOAD value based on the ENABLE_AGNOCAST environment variable. Stays backward
+    # compatible when Agnocast is disabled.
+    agnocast_env = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            PathJoinSubstitution(
+                [
+                    FindPackageShare("autoware_agnocast_wrapper"),
+                    "launch",
+                    "agnocast_env.launch.py",
+                ]
+            )
+        ),
+    )
+
     launch_arguments = [
         DeclareLaunchArgument(
             "config_file",
@@ -68,4 +87,6 @@ def generate_launch_description():
         )
     ]
 
-    return launch.LaunchDescription(launch_arguments + [OpaqueFunction(function=launch_setup)])
+    return launch.LaunchDescription(
+        launch_arguments + [agnocast_env, OpaqueFunction(function=launch_setup)]
+    )

--- a/system/autoware_mrm_comfortable_stop_operator/package.xml
+++ b/system/autoware_mrm_comfortable_stop_operator/package.xml
@@ -13,6 +13,7 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_adapi_v1_msgs</depend>
+  <depend>autoware_agnocast_wrapper</depend>
   <depend>autoware_internal_planning_msgs</depend>
   <depend>autoware_utils</depend>
   <depend>rclcpp</depend>

--- a/system/autoware_mrm_comfortable_stop_operator/src/mrm_comfortable_stop_operator/mrm_comfortable_stop_operator_core.cpp
+++ b/system/autoware_mrm_comfortable_stop_operator/src/mrm_comfortable_stop_operator/mrm_comfortable_stop_operator_core.cpp
@@ -22,7 +22,7 @@ namespace autoware::mrm_comfortable_stop_operator
 {
 
 MrmComfortableStopOperator::MrmComfortableStopOperator(const rclcpp::NodeOptions & node_options)
-: Node("mrm_comfortable_stop_operator", node_options)
+: autoware::agnocast_wrapper::Node("mrm_comfortable_stop_operator", node_options)
 {
   // Parameter
   params_.update_rate = static_cast<int>(declare_parameter<int>("update_rate"));
@@ -47,7 +47,7 @@ MrmComfortableStopOperator::MrmComfortableStopOperator(const rclcpp::NodeOptions
 
   // Timer
   const auto update_period_ns = rclcpp::Rate(params_.update_rate).period();
-  timer_ = rclcpp::create_timer(
+  timer_ = autoware::agnocast_wrapper::create_timer(
     this, get_clock(), update_period_ns, std::bind(&MrmComfortableStopOperator::onTimer, this));
 
   // Initialize
@@ -89,34 +89,35 @@ rcl_interfaces::msg::SetParametersResult MrmComfortableStopOperator::onParameter
 
 void MrmComfortableStopOperator::publishStatus() const
 {
-  auto status = status_;
-  status.stamp = this->now();
-  pub_status_->publish(status);
+  auto status = ALLOCATE_OUTPUT_MESSAGE_UNIQUE(pub_status_);
+  *status = status_;
+  status->stamp = this->now();
+  pub_status_->publish(std::move(status));
 }
 
 void MrmComfortableStopOperator::publishVelocityLimit() const
 {
-  auto velocity_limit = autoware_internal_planning_msgs::msg::VelocityLimit();
-  velocity_limit.stamp = this->now();
-  velocity_limit.max_velocity = 0;
-  velocity_limit.use_constraints = true;
-  velocity_limit.constraints.min_acceleration = static_cast<float>(params_.min_acceleration);
-  velocity_limit.constraints.max_jerk = static_cast<float>(params_.max_jerk);
-  velocity_limit.constraints.min_jerk = static_cast<float>(params_.min_jerk);
-  velocity_limit.sender = "mrm_comfortable_stop_operator";
+  auto velocity_limit = ALLOCATE_OUTPUT_MESSAGE_UNIQUE(pub_velocity_limit_);
+  velocity_limit->stamp = this->now();
+  velocity_limit->max_velocity = 0;
+  velocity_limit->use_constraints = true;
+  velocity_limit->constraints.min_acceleration = static_cast<float>(params_.min_acceleration);
+  velocity_limit->constraints.max_jerk = static_cast<float>(params_.max_jerk);
+  velocity_limit->constraints.min_jerk = static_cast<float>(params_.min_jerk);
+  velocity_limit->sender = "mrm_comfortable_stop_operator";
 
-  pub_velocity_limit_->publish(velocity_limit);
+  pub_velocity_limit_->publish(std::move(velocity_limit));
 }
 
 void MrmComfortableStopOperator::publishVelocityLimitClearCommand() const
 {
   auto velocity_limit_clear_command =
-    autoware_internal_planning_msgs::msg::VelocityLimitClearCommand();
-  velocity_limit_clear_command.stamp = this->now();
-  velocity_limit_clear_command.command = true;
-  velocity_limit_clear_command.sender = "mrm_comfortable_stop_operator";
+    ALLOCATE_OUTPUT_MESSAGE_UNIQUE(pub_velocity_limit_clear_command_);
+  velocity_limit_clear_command->stamp = this->now();
+  velocity_limit_clear_command->command = true;
+  velocity_limit_clear_command->sender = "mrm_comfortable_stop_operator";
 
-  pub_velocity_limit_clear_command_->publish(velocity_limit_clear_command);
+  pub_velocity_limit_clear_command_->publish(std::move(velocity_limit_clear_command));
 }
 
 void MrmComfortableStopOperator::onTimer() const

--- a/system/autoware_mrm_comfortable_stop_operator/src/mrm_comfortable_stop_operator/mrm_comfortable_stop_operator_core.cpp
+++ b/system/autoware_mrm_comfortable_stop_operator/src/mrm_comfortable_stop_operator/mrm_comfortable_stop_operator_core.cpp
@@ -59,8 +59,8 @@ MrmComfortableStopOperator::MrmComfortableStopOperator(const rclcpp::NodeOptions
 }
 
 void MrmComfortableStopOperator::operateComfortableStop(
-  AUTOWARE_SERVICE_REQUEST_CONST_PTR(tier4_system_msgs::srv::OperateMrm) request,
-  AUTOWARE_SERVICE_RESPONSE_PTR(tier4_system_msgs::srv::OperateMrm) response)
+  AUTOWARE_SERVER_REQUEST_PTR(tier4_system_msgs::srv::OperateMrm) request,
+  AUTOWARE_SERVER_RESPONSE_PTR(tier4_system_msgs::srv::OperateMrm) response)
 {
   if (request->operate == true) {
     publishVelocityLimit();

--- a/system/autoware_mrm_comfortable_stop_operator/src/mrm_comfortable_stop_operator/mrm_comfortable_stop_operator_core.cpp
+++ b/system/autoware_mrm_comfortable_stop_operator/src/mrm_comfortable_stop_operator/mrm_comfortable_stop_operator_core.cpp
@@ -59,8 +59,8 @@ MrmComfortableStopOperator::MrmComfortableStopOperator(const rclcpp::NodeOptions
 }
 
 void MrmComfortableStopOperator::operateComfortableStop(
-  const tier4_system_msgs::srv::OperateMrm::Request::SharedPtr request,
-  const tier4_system_msgs::srv::OperateMrm::Response::SharedPtr response)
+  AUTOWARE_SERVICE_REQUEST_CONST_PTR(tier4_system_msgs::srv::OperateMrm) request,
+  AUTOWARE_SERVICE_RESPONSE_PTR(tier4_system_msgs::srv::OperateMrm) response)
 {
   if (request->operate == true) {
     publishVelocityLimit();


### PR DESCRIPTION
## Description
Apply `agnocast_wrapper::Node` to `autoware_mrm_comfortable_stop_operator`.
Please read https://github.com/autowarefoundation/autoware/issues/7007 for the context and review guidelines of `autoware_agnocast_wrapper` adoption.  Also, please refer to https://github.com/autowarefoundation/autoware_core/blob/main/common/autoware_agnocast_wrapper/docs/review_guide.md for the review guide of `autoware_agnocast_wrapper` application PR. FYI: This node take [Method2](https://github.com/autowarefoundation/autoware_core/blob/main/common/autoware_agnocast_wrapper/docs/review_guide.md#method-2-agnocast_wrappernode-inheritance) of two integrations methods.

**AgnocastOnlyCallbackIsolatedExecutor:**
When built and run with `ENABLE_AGNOCAST=1`, the node runs on a `AgnocastOnlyCallbackIsolatedExecutor` (CIE), the standard executor for `agnocast_wrapper::Node`. Please check for potential race conditions only if the node meets **all** of the following:

1. It was originally running on a `SingleThreadedExecutor`.
2. It has multiple callback groups (the default is one).
3. Shared variables are accessed across those callback groups without mutex protection.

**Nodes already running on `MultiThreadedExecutor` are unaffected**, since their callbacks already run concurrently.

## Related Links

`agnocast_wrapper::Node`

- https://github.com/autowarefoundation/autoware/issues/7007
- https://github.com/orgs/autowarefoundation/discussions/6804

`AgnocastOnlyCallbackIsolatedExecutor`

- https://github.com/orgs/autowarefoundation/discussions/6813

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
  - `colcon build` succeeds with both `ENABLE_AGNOCAST=1` and `ENABLE_AGNOCAST=0`.
  - Ran LSim with sample rosbag
    - build with `ENABLE_AGNOCAST=0` 
    - build with `ENABLE_AGNOCAST=1` , ran with `ENABLE_AGNOCAST = 0`
    - build with `ENABLE_AGNOCAST=1` , ran with `ENABLE_AGNOCAST = 1`


## Notes for reviewers

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None when `ENABLE_AGNOCAST` is unset or `0` at runtime.

When `ENABLE_AGNOCAST=1`, CPU time spent on message serialization/deserialization in this node is reduced (Agnocast zero-copy IPC). The executor also switches to CIE, but since CIE is almost equivalent to `MultiThreadedExecutor`, there is effectively no change in scheduling behavior.