### PR TITLE
refactor(autoware_traffic_light_arbiter): always publish arbitration output, even before a map

### DIFF
--- a/perception/autoware_traffic_light_arbiter/include/autoware/traffic_light_arbiter/traffic_light_arbiter.hpp
+++ b/perception/autoware_traffic_light_arbiter/include/autoware/traffic_light_arbiter/traffic_light_arbiter.hpp
@@ -53,6 +53,11 @@ private:
     const std::vector<TrafficLightArbiterCore::ExpiredExternalSignal> & expired);
 
   std::unique_ptr<TrafficLightArbiterCore> core_;
+
+  // True once on_map() has installed a map into the Core. Drives the
+  // "before a map" warning; the Core emits an empty output regardless, which
+  // the Node publishes either way.
+  bool map_received_{false};
 };
 }  // namespace autoware::traffic_light
 

--- a/perception/autoware_traffic_light_arbiter/include/autoware/traffic_light_arbiter/traffic_light_arbiter_core.hpp
+++ b/perception/autoware_traffic_light_arbiter/include/autoware/traffic_light_arbiter/traffic_light_arbiter_core.hpp
@@ -24,7 +24,6 @@
 #include <lanelet2_core/Forward.h>
 
 #include <memory>
-#include <optional>
 #include <tuple>
 #include <unordered_map>
 #include <unordered_set>
@@ -75,13 +74,12 @@ public:
   ExternalIngestResult ingest_external(
     const TrafficSignalArray & msg, const rclcpp::Time & current_time);
 
-  // Result of one arbitration cycle. `output` holds the arbitrated signals by
-  // value; std::nullopt means no map has arrived yet, so the Node skips the
-  // publish. The Core leaves output unstamped — the Node owns stamp inheritance
-  // and uses latest_input_time for staleness logging.
+  // Result of one arbitration cycle. `output` always holds the arbitrated signals
+  // by value, empty when no map or no traffic-light regulatory element exists. The
+  // Node always publishes it unstamped and uses latest_input_time for staleness logging.
   struct ArbitrationResult
   {
-    std::optional<TrafficSignalArray> output;  // stamp left default; Node fills it in.
+    TrafficSignalArray output;  // stamp left default; Node fills it in.
     std::vector<lanelet::Id> off_map_signal_ids;
     rclcpp::Time latest_input_time{0, 0, RCL_ROS_TIME};
   };

--- a/perception/autoware_traffic_light_arbiter/src/traffic_light_arbiter.cpp
+++ b/perception/autoware_traffic_light_arbiter/src/traffic_light_arbiter.cpp
@@ -70,6 +70,7 @@ TrafficLightArbiter::TrafficLightArbiter(const rclcpp::NodeOptions & options)
 void TrafficLightArbiter::on_map(const AUTOWARE_MESSAGE_CONST_SHARED_PTR(LaneletMapBin) & msg)
 {
   core_->set_map(autoware::experimental::lanelet2_utils::from_autoware_map_msgs(*msg));
+  map_received_ = true;
 }
 
 void TrafficLightArbiter::on_perception_msg(
@@ -106,10 +107,12 @@ void TrafficLightArbiter::arbitrate_and_publish(const builtin_interfaces::msg::T
 {
   auto result = core_->arbitrate();
 
-  if (!result.output) {
+  // Before a map arrives the Core hands back an empty output; we still publish
+  // it so downstream sees a live, zero-group stream instead of silence, and
+  // warn here because the empty-on-the-wire result alone cannot convey it.
+  if (!map_received_) {
     RCLCPP_WARN_THROTTLE(
       get_logger(), *get_clock(), 5000, "Received traffic signal messages before a map");
-    return;
   }
 
   for (const auto & id : result.off_map_signal_ids) {
@@ -120,14 +123,14 @@ void TrafficLightArbiter::arbitrate_and_publish(const builtin_interfaces::msg::T
 
   // Stamp inheritance is the Node's I/O contract with downstream consumers:
   // the published output carries the trigger msg's stamp for time alignment.
-  result.output->stamp = stamp;
+  result.output.stamp = stamp;
 
   // Publish by const-ref so the wrapper copies into a freshly borrowed message:
   // agnocast's heaphook only routes allocations into the shared-memory pool
   // while a publisher message is borrowed. The Core builds its output on the
   // regular heap, so moving that buffer into a loaned message would leave the
   // payload outside the segment subscribers map. The copy keeps it in shmem.
-  pub_->publish(*result.output);
+  pub_->publish(result.output);
 
   if (rclcpp::Time(stamp) < result.latest_input_time) {
     RCLCPP_WARN_THROTTLE(

--- a/perception/autoware_traffic_light_arbiter/src/traffic_light_arbiter_core.cpp
+++ b/perception/autoware_traffic_light_arbiter/src/traffic_light_arbiter_core.cpp
@@ -254,15 +254,10 @@ TrafficLightArbiterCore::ArbitrationResult TrafficLightArbiterCore::arbitrate() 
   append_predictions(predictions_map, effective_perception.traffic_light_groups);
   append_predictions(predictions_map, valid_external_signals.traffic_light_groups);
 
-  if (map_regulatory_elements_set_ == nullptr) {
-    return result;
-  }
-
-  TrafficSignalArray output_signals_msg;
-  // stamp deliberately left default — the Node owns stamp inheritance.
-
-  if (map_regulatory_elements_set_->empty()) {
-    result.output = std::move(output_signals_msg);
+  // No map yet, or a map without traffic-light regulatory elements: leave the
+  // default-constructed empty output. The Node publishes it regardless and owns
+  // the "before a map" warning via its own map-subscription state.
+  if (map_regulatory_elements_set_ == nullptr || map_regulatory_elements_set_->empty()) {
     return result;
   }
 
@@ -289,6 +284,8 @@ TrafficLightArbiterCore::ArbitrationResult TrafficLightArbiterCore::arbitrate() 
     }
   }
 
+  TrafficSignalArray output_signals_msg;
+  // stamp deliberately left default — the Node owns stamp inheritance.
   output_signals_msg.traffic_light_groups.reserve(regulatory_element_signals_map.size());
 
   for (const auto & [regulatory_element_id, elements] : regulatory_element_signals_map) {

--- a/perception/autoware_traffic_light_arbiter/test/test_traffic_arbiter_characteristic.cpp
+++ b/perception/autoware_traffic_light_arbiter/test/test_traffic_arbiter_characteristic.cpp
@@ -782,9 +782,10 @@ TEST_F(ArbiterCharacteristic, priorityBasedOffMapIdDropped)
 //    input validation, priority overrides, predictions.
 // ---------------------------------------------------------------------------
 
-// Before the vector_map arrives, arbitrate_and_publish early-returns and no
-// TrafficLightGroupArray is emitted.
-TEST_F(ArbiterCharacteristic, perceptionBeforeMapProducesNoOutput)
+// Before the vector_map arrives, arbitrate_and_publish still publishes — an
+// empty (zero-group) TrafficLightGroupArray — rather than staying silent. The
+// throttled "before a map" warning is the Node's only no-map signal now.
+TEST_F(ArbiterCharacteristic, perceptionBeforeMapPublishesEmptyOutput)
 {
   // Arrange (intentionally no publish_map())
   start_arbiter(false, "confidence");  // priority-based mode, "confidence" priority
@@ -794,10 +795,11 @@ TEST_F(ArbiterCharacteristic, perceptionBeforeMapProducesNoOutput)
     t0_, map_ids::vehicle_signal_a,
     {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)}));
 
-  // Assert: arbitrate_and_publish should early-return when no map has been
-  // received. Content alone cannot prove this (a default-constructed
-  // message looks identical to no publish at all), so we read the counter.
-  EXPECT_EQ(arbiter_publish_count_, 0u);
+  // Assert: a publish happened, and it carried no groups. The counter read
+  // distinguishes "publish happened with zero groups" (the spec) from "no
+  // publish at all", which would also leave groups empty.
+  ASSERT_GE(arbiter_publish_count_, 1u);
+  EXPECT_EQ(observed_group_count(), 0u);
 }
 
 // A non-null but signal-free map should yield an empty TrafficLightGroupArray

--- a/perception/autoware_traffic_light_arbiter/test/test_traffic_light_arbiter_core.cpp
+++ b/perception/autoware_traffic_light_arbiter/test/test_traffic_light_arbiter_core.cpp
@@ -195,18 +195,14 @@ TrafficLightGroupArray make_signal(
 
 // --- Assert helpers ----------------------------------------------------
 //
-// The Core's arbitrate() returns an ArbitrationResult whose `output` may be
-// std::nullopt (e.g. when no map was supplied). Helpers take that optional
-// directly so callers don't need a separate ASSERT_TRUE guard before each
-// observation — the helpers fold the nullopt case into their return.
+// The Core's arbitrate() returns an ArbitrationResult whose `output` is always
+// a TrafficLightGroupArray (empty when no map was supplied). Helpers take it by
+// const-ref and return std::nullopt only when the queried group or element is
+// absent, so callers can observe directly without a separate guard.
 
-const TrafficLightGroup * find_group(
-  const std::optional<TrafficLightGroupArray> & output, lanelet::Id id)
+const TrafficLightGroup * find_group(const TrafficLightGroupArray & output, lanelet::Id id)
 {
-  if (!output) {
-    return nullptr;
-  }
-  for (const auto & group : output->traffic_light_groups) {
+  for (const auto & group : output.traffic_light_groups) {
     if (group.traffic_light_group_id == id) {
       return &group;
     }
@@ -224,8 +220,7 @@ const TrafficLightElement * find_element(const TrafficLightGroup & group, uint8_
   return nullptr;
 }
 
-std::optional<uint8_t> observed_color(
-  const std::optional<TrafficLightGroupArray> & output, lanelet::Id id)
+std::optional<uint8_t> observed_color(const TrafficLightGroupArray & output, lanelet::Id id)
 {
   const auto * group = find_group(output, id);
   if (!group || group->elements.empty()) {
@@ -234,8 +229,7 @@ std::optional<uint8_t> observed_color(
   return group->elements[0].color;
 }
 
-std::optional<float> observed_confidence(
-  const std::optional<TrafficLightGroupArray> & output, lanelet::Id id)
+std::optional<float> observed_confidence(const TrafficLightGroupArray & output, lanelet::Id id)
 {
   const auto * group = find_group(output, id);
   if (!group || group->elements.empty()) {
@@ -244,17 +238,13 @@ std::optional<float> observed_confidence(
   return group->elements[0].confidence;
 }
 
-std::optional<std::size_t> observed_group_count(
-  const std::optional<TrafficLightGroupArray> & output)
+std::size_t observed_group_count(const TrafficLightGroupArray & output)
 {
-  if (!output) {
-    return std::nullopt;
-  }
-  return output->traffic_light_groups.size();
+  return output.traffic_light_groups.size();
 }
 
 std::optional<uint8_t> observed_color_of_shape(
-  const std::optional<TrafficLightGroupArray> & output, lanelet::Id id, uint8_t shape)
+  const TrafficLightGroupArray & output, lanelet::Id id, uint8_t shape)
 {
   const auto * group = find_group(output, id);
   if (!group) {
@@ -268,7 +258,7 @@ std::optional<uint8_t> observed_color_of_shape(
 }
 
 std::optional<std::string> observed_prediction_source(
-  const std::optional<TrafficLightGroupArray> & output, lanelet::Id id, std::size_t index)
+  const TrafficLightGroupArray & output, lanelet::Id id, std::size_t index)
 {
   const auto * group = find_group(output, id);
   if (!group || index >= group->predictions.size()) {
@@ -749,10 +739,10 @@ TEST(TrafficLightArbiterCorePerceptionPriority, externalOnlyPassesThrough)
 // each test needs a non-default map configuration (no map, or empty map).
 // ---------------------------------------------------------------------------
 
-// arbitrate() before set_map() yields output=std::nullopt. The Node
-// distinguishes "no output" (skip publish) from "empty output" (publish
-// with zero groups), so the optional must stay disengaged here.
-TEST(TrafficLightArbiterCoreBoundary, arbitrateWithoutMapProducesNoOutput)
+// arbitrate() before set_map() yields an engaged but empty output: the Core
+// emits zero groups rather than withholding a result, and the Node publishes it
+// regardless. The "before a map" diagnostic lives in the Node, not this return.
+TEST(TrafficLightArbiterCoreBoundary, arbitrateWithoutMapProducesEmptyOutput)
 {
   TrafficLightArbiterCore unconfigured(
     CONFIDENCE, /*enable_signal_matching=*/false, default_external_delay_tolerance,
@@ -763,12 +753,12 @@ TEST(TrafficLightArbiterCoreBoundary, arbitrateWithoutMapProducesNoOutput)
 
   const auto result = unconfigured.arbitrate();
 
-  EXPECT_FALSE(result.output.has_value());
+  EXPECT_EQ(observed_group_count(result.output), 0u);
 }
 
-// A map with no TrafficLight regulatory elements yields an output that is
-// engaged but empty — the counterpart to the no-map case above. The Node
-// publishes a zero-group message here instead of skipping the publish.
+// A map with no TrafficLight regulatory elements yields an empty output too:
+// both this path and the no-map case above converge on a zero-group result
+// that the Node publishes.
 TEST(TrafficLightArbiterCoreBoundary, emptyMapProducesEmptyOutput)
 {
   TrafficLightArbiterCore arbiter(


### PR DESCRIPTION
## Description

Unifies the no-map and empty-map cases in `TrafficLightArbiterCore::arbitrate()`. Previously, before a vector_map arrived the Core returned `output = std::nullopt` and the Node skipped publishing (warning "before a map"); once a map with no traffic-light regulatory elements arrived it instead published an empty array. These two "no map-linked signal" states behaved differently on the wire.

Now `arbitrate()` always returns an engaged `output` — empty (zero groups) when no map has arrived or the map carries no traffic-light regulatory elements — and the Node publishes it unconditionally. Downstream consumers see a live, zero-group stream instead of silence during the pre-map window.

### Changes
- `ArbitrationResult::output`: `std::optional<TrafficLightGroupArray>` → plain `TrafficLightGroupArray` (always engaged).
- The "before a map" warning moves into the Node, driven by its own `map_received_` flag (set in `on_map`), decoupling the diagnostic from the publish decision.
- Core boundary test renamed `arbitrateWithoutMapProducesNoOutput` → `arbitrateWithoutMapProducesEmptyOutput`; node characteristic test now asserts a zero-group publish instead of no publish.

## Related links

None.

## How was this PR tested?

`colcon build` + unit tests for `autoware_traffic_light_arbiter` (Release):
- core: 40/40
- characteristic: 24/24
- node: 7/7

## Notes for reviewers

This is a wire-behavior change: an empty `TrafficLightGroupArray` is now published before a map arrives, where previously nothing was published. The only *new* wire output is that empty message during the pre-map window.

No regression results: the only new wire output is the empty message emitted during the pre-map window, and that window always precedes any real-signal publish — the arbiter sets its map once and latches it (it never re-enters the no-map branch afterward), and the empty-map case already published empty before this PR. So downstream consumers hold no accumulated traffic-signal state when these empty messages arrive; there is nothing for an empty message to clear or to misread as an authoritative "no signals".

## Interface changes

None. The published topic (`~/pub/traffic_signals`) and message type are unchanged; only the presence of an empty message during the pre-map window differs.

## Effects on system behavior

Before a vector_map is received, `~/pub/traffic_signals` now emits an empty (zero-group) `TrafficLightGroupArray` on each trigger instead of staying silent. Once a map is present, output is unchanged.
