### PR TITLE
feat(mrm_emergency_stop_operator): apply `agnocast_wrapper::node` to `autoware_mrm_emergency_stop_operator`

### DIFF
--- a/system/autoware_mrm_emergency_stop_operator/CMakeLists.txt
+++ b/system/autoware_mrm_emergency_stop_operator/CMakeLists.txt
@@ -11,7 +11,7 @@ ament_auto_add_library(${PROJECT_NAME}_component SHARED
 autoware_agnocast_wrapper_register_node(${PROJECT_NAME}_component
   PLUGIN "autoware::mrm_emergency_stop_operator::MrmEmergencyStopOperator"
   EXECUTABLE ${PROJECT_NAME}_node
-  AGNOCAST_EXECUTOR CallbackIsolatedAgnocastExecutor
+  AGNOCAST_EXECUTOR AgnocastOnlyCallbackIsolatedExecutor
   ROS2_EXECUTOR SingleThreadedExecutor
 )
 

--- a/system/autoware_mrm_emergency_stop_operator/CMakeLists.txt
+++ b/system/autoware_mrm_emergency_stop_operator/CMakeLists.txt
@@ -8,9 +8,11 @@ ament_auto_add_library(${PROJECT_NAME}_component SHARED
   src/mrm_emergency_stop_operator/mrm_emergency_stop_operator_core.cpp
 )
 
-rclcpp_components_register_node(${PROJECT_NAME}_component
+autoware_agnocast_wrapper_register_node(${PROJECT_NAME}_component
   PLUGIN "autoware::mrm_emergency_stop_operator::MrmEmergencyStopOperator"
   EXECUTABLE ${PROJECT_NAME}_node
+  AGNOCAST_EXECUTOR CallbackIsolatedAgnocastExecutor
+  ROS2_EXECUTOR SingleThreadedExecutor
 )
 
 ament_auto_package(INSTALL_TO_SHARE

--- a/system/autoware_mrm_emergency_stop_operator/include/autoware/mrm_emergency_stop_operator/mrm_emergency_stop_operator_core.hpp
+++ b/system/autoware_mrm_emergency_stop_operator/include/autoware/mrm_emergency_stop_operator/mrm_emergency_stop_operator_core.hpp
@@ -25,6 +25,7 @@
 #include <tier4_system_msgs/srv/operate_mrm.hpp>
 
 // ROS 2 core
+#include <autoware/agnocast_wrapper/node.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include <vector>
@@ -41,7 +42,7 @@ struct Parameters
   double target_jerk;          // [m/s^3]
 };
 
-class MrmEmergencyStopOperator : public rclcpp::Node
+class MrmEmergencyStopOperator : public autoware::agnocast_wrapper::Node
 {
 public:
   explicit MrmEmergencyStopOperator(const rclcpp::NodeOptions & node_options);
@@ -49,31 +50,32 @@ public:
 private:
   // Parameters
   Parameters params_;
-  OnSetParametersCallbackHandle::SharedPtr set_param_res_;
+  rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr set_param_res_;
 
   rcl_interfaces::msg::SetParametersResult onParameter(
     const std::vector<rclcpp::Parameter> & parameters);
 
   // Subscriber
-  rclcpp::Subscription<Control>::SharedPtr sub_control_cmd_;
+  AUTOWARE_SUBSCRIPTION_PTR(Control) sub_control_cmd_;
 
-  void onControlCommand(Control::ConstSharedPtr msg);
+  void onControlCommand(const AUTOWARE_MESSAGE_CONST_SHARED_PTR(Control) & msg);
 
   // Server
-  rclcpp::Service<OperateMrm>::SharedPtr service_operation_;
+  AUTOWARE_SERVICE_PTR(OperateMrm) service_operation_;
 
   void operateEmergencyStop(
-    const OperateMrm::Request::SharedPtr request, const OperateMrm::Response::SharedPtr response);
+    const AUTOWARE_SERVICE_REQUEST_PTR(OperateMrm) request,
+    AUTOWARE_SERVICE_RESPONSE_PTR(OperateMrm) response);
 
   // Publisher
-  rclcpp::Publisher<MrmBehaviorStatus>::SharedPtr pub_status_;
-  rclcpp::Publisher<Control>::SharedPtr pub_control_cmd_;
+  AUTOWARE_PUBLISHER_PTR(MrmBehaviorStatus) pub_status_;
+  AUTOWARE_PUBLISHER_PTR(Control) pub_control_cmd_;
 
   void publishStatus() const;
   void publishControlCommand(const Control & command) const;
 
   // Timer
-  rclcpp::TimerBase::SharedPtr timer_;
+  AUTOWARE_TIMER_PTR timer_;
 
   void onTimer();
 

--- a/system/autoware_mrm_emergency_stop_operator/launch/mrm_emergency_stop_operator.launch.py
+++ b/system/autoware_mrm_emergency_stop_operator/launch/mrm_emergency_stop_operator.launch.py
@@ -14,8 +14,11 @@
 
 import launch
 from launch.actions import DeclareLaunchArgument
+from launch.actions import IncludeLaunchDescription
 from launch.actions import OpaqueFunction
+from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration
+from launch.substitutions import PathJoinSubstitution
 from launch_ros.actions import ComposableNodeContainer
 from launch_ros.descriptions import ComposableNode
 from launch_ros.substitutions import FindPackageShare
@@ -45,11 +48,12 @@ def launch_setup(context, *args, **kwargs):
     container = ComposableNodeContainer(
         name="mrm_emergency_stop_operator_container",
         namespace="mrm_emergency_stop_operator",
-        package="rclcpp_components",
-        executable="component_container",
+        package=LaunchConfiguration("container_package"),
+        executable=LaunchConfiguration("container_executable"),
         composable_node_descriptions=[
             component,
         ],
+        additional_env={"LD_PRELOAD": LaunchConfiguration("ld_preload_value")},
         output="screen",
     )
 
@@ -57,6 +61,18 @@ def launch_setup(context, *args, **kwargs):
 
 
 def generate_launch_description():
+    agnocast_env = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            PathJoinSubstitution(
+                [
+                    FindPackageShare("autoware_agnocast_wrapper"),
+                    "launch",
+                    "agnocast_env.launch.py",
+                ]
+            )
+        ),
+    )
+
     launch_arguments = [
         DeclareLaunchArgument(
             "config_file",
@@ -68,4 +84,6 @@ def generate_launch_description():
         )
     ]
 
-    return launch.LaunchDescription(launch_arguments + [OpaqueFunction(function=launch_setup)])
+    return launch.LaunchDescription(
+        launch_arguments + [agnocast_env, OpaqueFunction(function=launch_setup)]
+    )

--- a/system/autoware_mrm_emergency_stop_operator/package.xml
+++ b/system/autoware_mrm_emergency_stop_operator/package.xml
@@ -13,6 +13,7 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_adapi_v1_msgs</depend>
+  <depend>autoware_agnocast_wrapper</depend>
   <depend>autoware_control_msgs</depend>
   <depend>autoware_utils</depend>
   <depend>rclcpp</depend>

--- a/system/autoware_mrm_emergency_stop_operator/src/mrm_emergency_stop_operator/mrm_emergency_stop_operator_core.cpp
+++ b/system/autoware_mrm_emergency_stop_operator/src/mrm_emergency_stop_operator/mrm_emergency_stop_operator_core.cpp
@@ -16,13 +16,14 @@
 
 #include <autoware_utils/ros/update_param.hpp>
 
+#include <utility>
 #include <vector>
 
 namespace autoware::mrm_emergency_stop_operator
 {
 
 MrmEmergencyStopOperator::MrmEmergencyStopOperator(const rclcpp::NodeOptions & node_options)
-: Node("mrm_emergency_stop_operator", node_options)
+: autoware::agnocast_wrapper::Node("mrm_emergency_stop_operator", node_options)
 {
   // Parameter
   params_.update_rate = declare_parameter<int>("update_rate");
@@ -46,7 +47,7 @@ MrmEmergencyStopOperator::MrmEmergencyStopOperator(const rclcpp::NodeOptions & n
 
   // Timer
   const auto update_period_ns = rclcpp::Rate(params_.update_rate).period();
-  timer_ = rclcpp::create_timer(
+  timer_ = autoware::agnocast_wrapper::create_timer(
     this, get_clock(), update_period_ns, std::bind(&MrmEmergencyStopOperator::onTimer, this));
 
   // Initialize
@@ -71,7 +72,8 @@ rcl_interfaces::msg::SetParametersResult MrmEmergencyStopOperator::onParameter(
   return result;
 }
 
-void MrmEmergencyStopOperator::onControlCommand(Control::ConstSharedPtr msg)
+void MrmEmergencyStopOperator::onControlCommand(
+  const AUTOWARE_MESSAGE_CONST_SHARED_PTR(Control) & msg)
 {
   if (status_.state != MrmBehaviorStatus::OPERATING) {
     prev_control_cmd_ = *msg;
@@ -80,7 +82,8 @@ void MrmEmergencyStopOperator::onControlCommand(Control::ConstSharedPtr msg)
 }
 
 void MrmEmergencyStopOperator::operateEmergencyStop(
-  const OperateMrm::Request::SharedPtr request, const OperateMrm::Response::SharedPtr response)
+  const AUTOWARE_SERVICE_REQUEST_PTR(OperateMrm) request,
+  AUTOWARE_SERVICE_RESPONSE_PTR(OperateMrm) response)
 {
   if (request->operate == true) {
     status_.state = MrmBehaviorStatus::OPERATING;
@@ -93,14 +96,17 @@ void MrmEmergencyStopOperator::operateEmergencyStop(
 
 void MrmEmergencyStopOperator::publishStatus() const
 {
-  auto status = status_;
-  status.stamp = this->now();
-  pub_status_->publish(status);
+  auto status = ALLOCATE_OUTPUT_MESSAGE_UNIQUE(pub_status_);
+  *status = status_;
+  status->stamp = this->now();
+  pub_status_->publish(std::move(status));
 }
 
 void MrmEmergencyStopOperator::publishControlCommand(const Control & command) const
 {
-  pub_control_cmd_->publish(command);
+  auto control_cmd = ALLOCATE_OUTPUT_MESSAGE_UNIQUE(pub_control_cmd_);
+  *control_cmd = command;
+  pub_control_cmd_->publish(std::move(control_cmd));
 }
 
 void MrmEmergencyStopOperator::onTimer()


### PR DESCRIPTION
## Description

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
