### PR TITLE
feat(hazard_lights_selector): apply `agnocast_wrapper::Node` to `autoware_hazard_lights_selector`

### DIFF
--- a/planning/autoware_hazard_lights_selector/CMakeLists.txt
+++ b/planning/autoware_hazard_lights_selector/CMakeLists.txt
@@ -8,9 +8,11 @@ ament_auto_add_library(${PROJECT_NAME} SHARED
   src/node.cpp
 )
 
-rclcpp_components_register_node(${PROJECT_NAME}
+autoware_agnocast_wrapper_register_node(${PROJECT_NAME}
   PLUGIN "autoware::hazard_lights_selector::HazardLightsSelector"
   EXECUTABLE ${PROJECT_NAME}_node
+  AGNOCAST_EXECUTOR AgnocastOnlyCallbackIsolatedExecutor
+  ROS2_EXECUTOR SingleThreadedExecutor
 )
 
 ament_auto_package(

--- a/planning/autoware_hazard_lights_selector/launch/hazard_lights_selector.launch.xml
+++ b/planning/autoware_hazard_lights_selector/launch/hazard_lights_selector.launch.xml
@@ -5,8 +5,12 @@
   <arg name="input_hazard_lights_cmd_from_mrm_operator" default="/system/hazard_lights_cmd"/>
   <arg name="output_hazard_lights_cmd" default="/planning/hazard_lights_cmd"/>
 
+  <!-- Builds ld_preload_value (prepends the Agnocast heaphook when ENABLE_AGNOCAST=1). -->
+  <include file="$(find-pkg-share autoware_agnocast_wrapper)/launch/agnocast_env.launch.xml"/>
+
   <node pkg="autoware_hazard_lights_selector" exec="autoware_hazard_lights_selector_node" name="autoware_hazard_lights_selector" output="screen">
     <param from="$(var hazard_lights_selector_param_path)"/>
+    <env name="LD_PRELOAD" value="$(var ld_preload_value)"/>
 
     <remap from="input/planning/hazard_lights_command" to="$(var input_hazard_lights_cmd_from_path_planner)"/>
     <remap from="input/system/hazard_lights_command" to="$(var input_hazard_lights_cmd_from_mrm_operator)"/>

--- a/planning/autoware_hazard_lights_selector/launch/hazard_lights_selector.launch.xml
+++ b/planning/autoware_hazard_lights_selector/launch/hazard_lights_selector.launch.xml
@@ -5,7 +5,6 @@
   <arg name="input_hazard_lights_cmd_from_mrm_operator" default="/system/hazard_lights_cmd"/>
   <arg name="output_hazard_lights_cmd" default="/planning/hazard_lights_cmd"/>
 
-  <!-- Builds ld_preload_value (prepends the Agnocast heaphook when ENABLE_AGNOCAST=1). -->
   <include file="$(find-pkg-share autoware_agnocast_wrapper)/launch/agnocast_env.launch.xml"/>
 
   <node pkg="autoware_hazard_lights_selector" exec="autoware_hazard_lights_selector_node" name="autoware_hazard_lights_selector" output="screen">

--- a/planning/autoware_hazard_lights_selector/package.xml
+++ b/planning/autoware_hazard_lights_selector/package.xml
@@ -13,6 +13,7 @@
   <build_depend>autoware_cmake</build_depend>
 
   <!-- depend -->
+  <depend>autoware_agnocast_wrapper</depend>
   <depend>autoware_vehicle_msgs</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>

--- a/planning/autoware_hazard_lights_selector/src/node.cpp
+++ b/planning/autoware_hazard_lights_selector/src/node.cpp
@@ -41,19 +41,19 @@ HazardLightsSelector::HazardLightsSelector(const rclcpp::NodeOptions & node_opti
       "output/hazard_lights_command", 1);
 
   // Timer
-  timer_ = rclcpp::create_timer(
+  timer_ = autoware::agnocast_wrapper::create_timer(
     this, get_clock(), std::chrono::milliseconds(1000 / params_.update_rate),
     std::bind(&HazardLightsSelector::on_timer, this));
 }
 
 void HazardLightsSelector::on_hazard_lights_command_from_planning(
-  const autoware_vehicle_msgs::msg::HazardLightsCommand::SharedPtr msg)
+  const AUTOWARE_MESSAGE_CONST_SHARED_PTR(autoware_vehicle_msgs::msg::HazardLightsCommand) & msg)
 {
   hazard_lights_command_from_planning_ = msg;
 }
 
 void HazardLightsSelector::on_hazard_lights_command_from_system(
-  const autoware_vehicle_msgs::msg::HazardLightsCommand::SharedPtr msg)
+  const AUTOWARE_MESSAGE_CONST_SHARED_PTR(autoware_vehicle_msgs::msg::HazardLightsCommand) & msg)
 {
   hazard_lights_command_from_system_ = msg;
 }
@@ -61,23 +61,23 @@ void HazardLightsSelector::on_hazard_lights_command_from_system(
 void HazardLightsSelector::on_timer()
 {
   using autoware_vehicle_msgs::msg::HazardLightsCommand;
-  auto hazard_lights_command = HazardLightsCommand();
-  hazard_lights_command.stamp = this->now();
-  hazard_lights_command.command = HazardLightsCommand::DISABLE;
+  auto hazard_lights_command = ALLOCATE_OUTPUT_MESSAGE_UNIQUE(pub_hazard_lights_command_);
+  hazard_lights_command->stamp = this->now();
+  hazard_lights_command->command = HazardLightsCommand::DISABLE;
 
   if (hazard_lights_command_from_planning_) {
     if (hazard_lights_command_from_planning_->command == HazardLightsCommand::ENABLE) {
-      hazard_lights_command.command = HazardLightsCommand::ENABLE;
+      hazard_lights_command->command = HazardLightsCommand::ENABLE;
     }
   }
 
   if (hazard_lights_command_from_system_) {
     if (hazard_lights_command_from_system_->command == HazardLightsCommand::ENABLE) {
-      hazard_lights_command.command = HazardLightsCommand::ENABLE;
+      hazard_lights_command->command = HazardLightsCommand::ENABLE;
     }
   }
 
-  pub_hazard_lights_command_->publish(hazard_lights_command);
+  pub_hazard_lights_command_->publish(std::move(hazard_lights_command));
 }
 
 }  // namespace autoware::hazard_lights_selector

--- a/planning/autoware_hazard_lights_selector/src/node.cpp
+++ b/planning/autoware_hazard_lights_selector/src/node.cpp
@@ -14,6 +14,8 @@
 
 #include "node.hpp"
 
+#include <stdexcept>
+#include <string>
 #include <utility>
 
 namespace autoware::hazard_lights_selector
@@ -26,6 +28,11 @@ HazardLightsSelector::HazardLightsSelector(const rclcpp::NodeOptions & node_opti
 
   // Parameter
   params_.update_rate = static_cast<int>(declare_parameter("update_rate", 10));
+  if (params_.update_rate <= 0) {
+    throw std::invalid_argument(
+      "update_rate must be positive, but got " + std::to_string(params_.update_rate));
+  }
+  const auto period_ms = 1000 / params_.update_rate;
 
   // Subscriber
   sub_hazard_lights_command_from_planning_ =
@@ -44,7 +51,7 @@ HazardLightsSelector::HazardLightsSelector(const rclcpp::NodeOptions & node_opti
 
   // Timer
   timer_ = autoware::agnocast_wrapper::create_timer(
-    this, get_clock(), std::chrono::milliseconds(1000 / params_.update_rate),
+    this, get_clock(), std::chrono::milliseconds(period_ms),
     std::bind(&HazardLightsSelector::on_timer, this));
 }
 

--- a/planning/autoware_hazard_lights_selector/src/node.cpp
+++ b/planning/autoware_hazard_lights_selector/src/node.cpp
@@ -14,6 +14,8 @@
 
 #include "node.hpp"
 
+#include <utility>
+
 namespace autoware::hazard_lights_selector
 {
 

--- a/planning/autoware_hazard_lights_selector/src/node.hpp
+++ b/planning/autoware_hazard_lights_selector/src/node.hpp
@@ -16,6 +16,7 @@
 #define NODE_HPP_
 
 // include
+#include <autoware/agnocast_wrapper/node.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include <autoware_vehicle_msgs/msg/hazard_lights_command.hpp>
@@ -28,7 +29,7 @@ struct Parameters
   int update_rate;  // [Hz]
 };
 
-class HazardLightsSelector : public rclcpp::Node
+class HazardLightsSelector : public autoware::agnocast_wrapper::Node
 {
 public:
   explicit HazardLightsSelector(const rclcpp::NodeOptions & node_options);
@@ -38,30 +39,30 @@ private:
   Parameters params_;
 
   // Subscriber
-  rclcpp::Subscription<autoware_vehicle_msgs::msg::HazardLightsCommand>::SharedPtr
-    sub_hazard_lights_command_from_planning_;
-  rclcpp::Subscription<autoware_vehicle_msgs::msg::HazardLightsCommand>::SharedPtr
-    sub_hazard_lights_command_from_system_;
+  AUTOWARE_SUBSCRIPTION_PTR(autoware_vehicle_msgs::msg::HazardLightsCommand)
+  sub_hazard_lights_command_from_planning_;
+  AUTOWARE_SUBSCRIPTION_PTR(autoware_vehicle_msgs::msg::HazardLightsCommand)
+  sub_hazard_lights_command_from_system_;
 
   void on_hazard_lights_command_from_planning(
-    const autoware_vehicle_msgs::msg::HazardLightsCommand::SharedPtr msg);
+    const AUTOWARE_MESSAGE_CONST_SHARED_PTR(autoware_vehicle_msgs::msg::HazardLightsCommand) & msg);
   void on_hazard_lights_command_from_system(
-    const autoware_vehicle_msgs::msg::HazardLightsCommand::SharedPtr msg);
+    const AUTOWARE_MESSAGE_CONST_SHARED_PTR(autoware_vehicle_msgs::msg::HazardLightsCommand) & msg);
 
   // Publisher
-  rclcpp::Publisher<autoware_vehicle_msgs::msg::HazardLightsCommand>::SharedPtr
-    pub_hazard_lights_command_;
+  AUTOWARE_PUBLISHER_PTR(autoware_vehicle_msgs::msg::HazardLightsCommand)
+  pub_hazard_lights_command_;
 
   // Timer
-  rclcpp::TimerBase::SharedPtr timer_;
+  AUTOWARE_TIMER_PTR timer_;
 
   void on_timer();
 
   // State
-  autoware_vehicle_msgs::msg::HazardLightsCommand::ConstSharedPtr
-    hazard_lights_command_from_planning_;
-  autoware_vehicle_msgs::msg::HazardLightsCommand::ConstSharedPtr
-    hazard_lights_command_from_system_;
+  AUTOWARE_MESSAGE_CONST_SHARED_PTR(autoware_vehicle_msgs::msg::HazardLightsCommand)
+  hazard_lights_command_from_planning_;
+  AUTOWARE_MESSAGE_CONST_SHARED_PTR(autoware_vehicle_msgs::msg::HazardLightsCommand)
+  hazard_lights_command_from_system_;
 };
 }  // namespace autoware::hazard_lights_selector
 


### PR DESCRIPTION
## Description
Apply `agnocast_wrapper::Node` to `autoware_hazard_lights_selector`.
Please read https://github.com/autowarefoundation/autoware/issues/7007 for the context and review guidelines of `autoware_agnocast_wrapper` adoption.  Also, please refer to https://github.com/autowarefoundation/autoware_core/blob/main/common/autoware_agnocast_wrapper/docs/review_guide.md for the review guide of `autoware_agnocast_wrapper` application PR. FYI: This node take [Method2](https://github.com/autowarefoundation/autoware_core/blob/main/common/autoware_agnocast_wrapper/docs/review_guide.md#method-2-agnocast_wrappernode-inheritance) of two integrations methods.

**AgnocastOnlyCallbackIsolatedExecutor:**
When built and run with `ENABLE_AGNOCAST=1`, the node runs on a `AgnocastOnlyCallbackIsolatedExecutor` (CIE), the standard executor for `agnocast_wrapper::Node`. Please check for potential race conditions only if the node meets **all** of the following:

1. It was originally running on a `SingleThreadedExecutor`.
2. It has multiple callback groups (the default is one).
3. Shared variables are accessed across those callback groups without mutex protection.

**Nodes already running on `MultiThreadedExecutor` are unaffected**, since their callbacks already run concurrently.

## Related Links

`agnocast_wrapper::Node`

- https://github.com/autowarefoundation/autoware/issues/7007
- https://github.com/orgs/autowarefoundation/discussions/6804

`AgnocastOnlyCallbackIsolatedExecutor`

- https://github.com/orgs/autowarefoundation/discussions/6813

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
  - `colcon build` succeeds with both `ENABLE_AGNOCAST=1` and `ENABLE_AGNOCAST=0`.
  - Ran LSim with sample rosbag
    - build with `ENABLE_AGNOCAST=0` 
    - build with `ENABLE_AGNOCAST=1` , ran with `ENABLE_AGNOCAST = 0`
    - build with `ENABLE_AGNOCAST=1` , ran with `ENABLE_AGNOCAST = 1`


## Notes for reviewers
 I've also fixed a bug pointed out by Copilot: validate `update_rate` at startup — throw `std::invalid_argument` if it is not positive, preventing a divide-by-zero / negative timer period in `1000 / update_rate`.
https://github.com/autowarefoundation/autoware_universe/pull/12850#discussion_r3456933705

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None when `ENABLE_AGNOCAST` is unset or `0` at runtime.

When `ENABLE_AGNOCAST=1`, CPU time spent on message serialization/deserialization in this node is reduced (Agnocast zero-copy IPC). The executor also switches to CIE, but since CIE is almost equivalent to `MultiThreadedExecutor`, there is effectively no change in scheduling behavior.