### PR TITLE
refactor(autoware_traffic_light_classifier): extract classification logic from ROS node

### DIFF
--- a/perception/autoware_traffic_light_classifier/CMakeLists.txt
+++ b/perception/autoware_traffic_light_classifier/CMakeLists.txt
@@ -60,6 +60,7 @@ if(TRT_AVAIL AND CUDA_AVAIL)
     src/classifier/color_classifier.cpp
     src/classifier/cnn_classifier.cpp
     src/classifier/cnn_lamp_recognizer.cpp
+    src/traffic_light_classifier.cpp
     src/traffic_light_classifier_node.cpp
     src/traffic_light_classifier_process.cpp
   )
@@ -81,6 +82,7 @@ if(TRT_AVAIL AND CUDA_AVAIL)
     src/classifier/cnn_classifier.cpp
     src/classifier/color_classifier.cpp
     src/classifier/cnn_lamp_recognizer.cpp
+    src/traffic_light_classifier.cpp
     src/traffic_light_classifier_node.cpp
     src/traffic_light_classifier_process.cpp
     src/single_image_debug_inference_node.cpp
@@ -110,6 +112,7 @@ else()
 
   ament_auto_add_library(${PROJECT_NAME} SHARED
     src/classifier/color_classifier.cpp
+    src/traffic_light_classifier.cpp
     src/traffic_light_classifier_node.cpp
     src/traffic_light_classifier_process.cpp
   )

--- a/perception/autoware_traffic_light_classifier/src/traffic_light_classifier.cpp
+++ b/perception/autoware_traffic_light_classifier/src/traffic_light_classifier.cpp
@@ -1,0 +1,109 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "traffic_light_classifier.hpp"
+
+#include "traffic_light_classifier_process.hpp"
+
+#include <autoware/traffic_light_utils/traffic_light_utils.hpp>
+
+#include <sensor_msgs/msg/region_of_interest.hpp>
+#include <tier4_perception_msgs/msg/traffic_light.hpp>
+
+#include <cstddef>
+#include <memory>
+#include <utility>
+#include <vector>
+
+namespace autoware::traffic_light
+{
+TrafficLightClassifier::TrafficLightClassifier(
+  std::shared_ptr<ClassifierInterface> classifier, uint8_t classify_traffic_light_type,
+  double over_exposure_threshold, double under_exposure_threshold)
+: classifier_(std::move(classifier)),
+  classify_traffic_light_type_(classify_traffic_light_type),
+  over_exposure_threshold_(over_exposure_threshold),
+  under_exposure_threshold_(under_exposure_threshold)
+{
+}
+
+std::optional<TrafficLightClassifier::Result> TrafficLightClassifier::classify(
+  const cv::Mat & image, const tier4_perception_msgs::msg::TrafficLightRoiArray & rois) const
+{
+  Result result;
+  result.signals.signals.resize(rois.rois.size());
+
+  std::vector<cv::Mat> images;
+  std::vector<size_t> exposure_out_of_range_indices;
+  size_t idx_valid_roi = 0;
+  for (const auto & input_roi : rois.rois) {
+    // ignore if the roi is not the type to be classified
+    if (input_roi.traffic_light_type != classify_traffic_light_type_) {
+      continue;
+    }
+    // skip if the roi size is zero
+    if (input_roi.roi.height == 0 || input_roi.roi.width == 0) {
+      continue;
+    }
+
+    // set traffic light id and type
+    result.signals.signals[idx_valid_roi].traffic_light_id = input_roi.traffic_light_id;
+    result.signals.signals[idx_valid_roi].traffic_light_type = input_roi.traffic_light_type;
+
+    const sensor_msgs::msg::RegionOfInterest & roi = input_roi.roi;
+    auto roi_img = image(cv::Rect(roi.x_offset, roi.y_offset, roi.width, roi.height));
+    const double brightness = utils::compute_brightness(roi_img);
+    if (brightness >= over_exposure_threshold_) {
+      exposure_out_of_range_indices.emplace_back(idx_valid_roi);
+      result.detected_over_exposure = true;
+    } else if (brightness <= under_exposure_threshold_) {
+      exposure_out_of_range_indices.emplace_back(idx_valid_roi);
+      result.detected_under_exposure = true;
+    }
+    images.emplace_back(roi_img);
+    idx_valid_roi++;
+  }
+
+  // classify the images
+  result.signals.signals.resize(images.size());
+  if (!images.empty()) {
+    if (!classifier_->getTrafficSignals(images, result.signals)) {
+      return std::nullopt;
+    }
+  }
+
+  // append the undetected rois as unknown
+  for (const auto & input_roi : rois.rois) {
+    // if the type is the target type but the roi size is zero, the roi is undetected
+    if (
+      (input_roi.roi.height == 0 || input_roi.roi.width == 0) &&
+      input_roi.traffic_light_type == classify_traffic_light_type_) {
+      tier4_perception_msgs::msg::TrafficLight signal;
+      signal.traffic_light_id = input_roi.traffic_light_id;
+      signal.traffic_light_type = input_roi.traffic_light_type;
+      traffic_light_utils::setSignalUnknown(signal, 0.0);
+      result.signals.signals.push_back(signal);
+    }
+  }
+
+  // overwrite the out-of-range exposure rois with unknown
+  for (const auto & idx : exposure_out_of_range_indices) {
+    auto & signal = result.signals.signals.at(idx);
+    traffic_light_utils::setSignalUnknown(signal, 0.0);
+  }
+
+  return result;
+}
+
+}  // namespace autoware::traffic_light

--- a/perception/autoware_traffic_light_classifier/src/traffic_light_classifier.hpp
+++ b/perception/autoware_traffic_light_classifier/src/traffic_light_classifier.hpp
@@ -1,0 +1,66 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef TRAFFIC_LIGHT_CLASSIFIER_HPP_
+#define TRAFFIC_LIGHT_CLASSIFIER_HPP_
+
+#include "classifier/classifier_interface.hpp"
+
+#include <opencv2/core/core.hpp>
+
+#include <tier4_perception_msgs/msg/traffic_light_array.hpp>
+#include <tier4_perception_msgs/msg/traffic_light_roi_array.hpp>
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+
+namespace autoware::traffic_light
+{
+// ROS-free classification orchestration extracted from TrafficLightClassifierNodelet.
+// Owns the classifier backend and the per-ROI filtering / exposure / UNKNOWN-handling
+// logic; the node remains a thin adapter that handles I/O (params, pub/sub, diagnostics).
+class TrafficLightClassifier
+{
+public:
+  struct Result
+  {
+    // Classification output. The header is intentionally left unset: the node stamps
+    // it from the input image before publishing.
+    tier4_perception_msgs::msg::TrafficLightArray signals;
+    bool detected_over_exposure = false;
+    bool detected_under_exposure = false;
+  };
+
+  TrafficLightClassifier(
+    std::shared_ptr<ClassifierInterface> classifier, uint8_t classify_traffic_light_type,
+    double over_exposure_threshold, double under_exposure_threshold);
+
+  // Pure orchestration over an already-decoded RGB image and its ROIs: filter ROIs by type,
+  // crop and classify the valid ones, append undetected (zero-sized) ROIs as UNKNOWN, and
+  // overwrite over/under-exposed slots with UNKNOWN. Returns std::nullopt when the classifier
+  // backend fails, so the caller can skip publishing.
+  std::optional<Result> classify(
+    const cv::Mat & image, const tier4_perception_msgs::msg::TrafficLightRoiArray & rois) const;
+
+private:
+  std::shared_ptr<ClassifierInterface> classifier_;
+  uint8_t classify_traffic_light_type_;
+  double over_exposure_threshold_;
+  double under_exposure_threshold_;
+};
+
+}  // namespace autoware::traffic_light
+
+#endif  // TRAFFIC_LIGHT_CLASSIFIER_HPP_

--- a/perception/autoware_traffic_light_classifier/src/traffic_light_classifier_node.cpp
+++ b/perception/autoware_traffic_light_classifier/src/traffic_light_classifier_node.cpp
@@ -13,26 +13,25 @@
 // limitations under the License.
 #include "traffic_light_classifier_node.hpp"
 
-#include <autoware/traffic_light_utils/traffic_light_utils.hpp>
-
 #include <diagnostic_msgs/msg/diagnostic_status.hpp>
 #include <tier4_perception_msgs/msg/traffic_light_element.hpp>
 
 #include <memory>
-#include <vector>
+#include <utility>
 
 namespace autoware::traffic_light
 {
 TrafficLightClassifierNodelet::TrafficLightClassifierNodelet(const rclcpp::NodeOptions & options)
 : Node("traffic_light_classifier_node", options)
 {
-  classify_traffic_light_type_ = this->declare_parameter<int>("traffic_light_type");
+  const auto classify_traffic_light_type =
+    static_cast<uint8_t>(this->declare_parameter<int>("traffic_light_type"));
 
   using std::placeholders::_1;
   using std::placeholders::_2;
   is_approximate_sync_ = this->declare_parameter<bool>("approximate_sync");
-  over_exposure_threshold_ = this->declare_parameter<double>("over_exposure_threshold");
-  under_exposure_threshold_ = this->declare_parameter<double>("under_exposure_threshold");
+  const auto over_exposure_threshold = this->declare_parameter<double>("over_exposure_threshold");
+  const auto under_exposure_threshold = this->declare_parameter<double>("under_exposure_threshold");
 
   if (is_approximate_sync_) {
     approximate_sync_.reset(new ApproximateSync(ApproximateSyncPolicy(10), image_sub_, roi_sub_));
@@ -52,21 +51,28 @@ TrafficLightClassifierNodelet::TrafficLightClassifierNodelet(const rclcpp::NodeO
     this, get_clock(), 100ms, std::bind(&TrafficLightClassifierNodelet::connectCb, this));
 
   int classifier_type = this->declare_parameter<int>("classifier_type");
+  std::shared_ptr<ClassifierInterface> classifier_ptr;
   if (classifier_type == TrafficLightClassifierNodelet::ClassifierType::HSVFilter) {
-    classifier_ptr_ = std::make_shared<ColorClassifier>(this);
+    classifier_ptr = std::make_shared<ColorClassifier>(this);
   } else if (classifier_type == TrafficLightClassifierNodelet::ClassifierType::CNN) {
 #if ENABLE_GPU
-    classifier_ptr_ = std::make_shared<CNNClassifier>(this);
+    classifier_ptr = std::make_shared<CNNClassifier>(this);
 #else
     RCLCPP_ERROR(this->get_logger(), "please install CUDA, and TensorRT to use cnn classifier");
 #endif
   } else if (classifier_type == TrafficLightClassifierNodelet::ClassifierType::LampRecognizer) {
 #if ENABLE_GPU
-    classifier_ptr_ = std::make_shared<CnnLampRecognizer>(this);
+    classifier_ptr = std::make_shared<CnnLampRecognizer>(this);
 #else
     RCLCPP_ERROR(
       this->get_logger(), "please install CUDA, CUDNN and TensorRT to use LampRecognizer");
 #endif
+  }
+
+  if (classifier_ptr) {
+    classifier_ = std::make_unique<TrafficLightClassifier>(
+      classifier_ptr, classify_traffic_light_type, over_exposure_threshold,
+      under_exposure_threshold);
   }
 
   diagnostics_interface_ptr_ =
@@ -96,7 +102,7 @@ void TrafficLightClassifierNodelet::imageRoiCallback(
   const sensor_msgs::msg::Image::ConstSharedPtr & input_image_msg,
   const tier4_perception_msgs::msg::TrafficLightRoiArray::ConstSharedPtr & input_rois_msg)
 {
-  if (classifier_ptr_.use_count() == 0) {
+  if (!classifier_) {
     return;
   }
   tier4_perception_msgs::msg::TrafficLightArray output_msg;
@@ -115,82 +121,24 @@ void TrafficLightClassifierNodelet::imageRoiCallback(
       input_image_msg->encoding.c_str());
   }
 
-  output_msg.signals.resize(input_rois_msg->rois.size());
-
-  bool detect_over_exposure = false;
-  bool detect_under_exposure = false;
-
-  std::vector<cv::Mat> images;
-  std::vector<size_t> exposure_out_of_range_indices;
-  size_t idx_valid_roi = 0;
-  for (const auto & input_roi : input_rois_msg->rois) {
-    // ignore if the roi is not the type to be classified
-    if (input_roi.traffic_light_type != classify_traffic_light_type_) {
-      continue;
-    }
-    // skip if the roi size is zero
-    if (input_roi.roi.height == 0 || input_roi.roi.width == 0) {
-      continue;
-    }
-
-    // set traffic light id and type
-    output_msg.signals[idx_valid_roi].traffic_light_id = input_roi.traffic_light_id;
-    output_msg.signals[idx_valid_roi].traffic_light_type = input_roi.traffic_light_type;
-
-    const sensor_msgs::msg::RegionOfInterest & roi = input_roi.roi;
-    auto roi_img = cv_ptr->image(cv::Rect(roi.x_offset, roi.y_offset, roi.width, roi.height));
-    const double brightness = utils::compute_brightness(roi_img);
-    if (brightness >= over_exposure_threshold_) {
-      exposure_out_of_range_indices.emplace_back(idx_valid_roi);
-      detect_over_exposure = true;
-    } else if (brightness <= under_exposure_threshold_) {
-      exposure_out_of_range_indices.emplace_back(idx_valid_roi);
-      detect_under_exposure = true;
-    }
-    images.emplace_back(roi_img);
-    idx_valid_roi++;
+  auto result = classifier_->classify(cv_ptr->image, *input_rois_msg);
+  if (!result) {
+    RCLCPP_ERROR(this->get_logger(), "failed classify image, abort callback");
+    return;
   }
 
-  // classify the images
-  output_msg.signals.resize(images.size());
-  if (!images.empty()) {
-    if (!classifier_ptr_->getTrafficSignals(images, output_msg)) {
-      RCLCPP_ERROR(this->get_logger(), "failed classify image, abort callback");
-      return;
-    }
-  }
-
-  // append the undetected rois as unknown
-  for (const auto & input_roi : input_rois_msg->rois) {
-    // if the type is the target type but the roi size is zero, the roi is undetected
-    if (
-      (input_roi.roi.height == 0 || input_roi.roi.width == 0) &&
-      input_roi.traffic_light_type == classify_traffic_light_type_) {
-      tier4_perception_msgs::msg::TrafficLight signal;
-      signal.traffic_light_id = input_roi.traffic_light_id;
-      signal.traffic_light_type = input_roi.traffic_light_type;
-      traffic_light_utils::setSignalUnknown(signal, 0.0);
-      output_msg.signals.push_back(signal);
-    }
-  }
-
-  // overwrite the out-of-range exposure rois with unknown
-  for (const auto & idx : exposure_out_of_range_indices) {
-    auto & signal = output_msg.signals.at(idx);
-    traffic_light_utils::setSignalUnknown(signal, 0.0);
-  }
-
+  output_msg = std::move(result->signals);
   output_msg.header = input_image_msg->header;
   traffic_signal_array_pub_->publish(output_msg);
 
   // publish diagnostics
   diagnostics_interface_ptr_->clear();
   diagnostics_interface_ptr_->add_key_value(
-    "detect_traffic_light_over_exposure", detect_over_exposure);
+    "detect_traffic_light_over_exposure", result->detected_over_exposure);
   diagnostics_interface_ptr_->add_key_value(
-    "detect_traffic_light_under_exposure", detect_under_exposure);
+    "detect_traffic_light_under_exposure", result->detected_under_exposure);
 
-  if (detect_over_exposure || detect_under_exposure) {
+  if (result->detected_over_exposure || result->detected_under_exposure) {
     diagnostics_interface_ptr_->update_level_and_message(
       diagnostic_msgs::msg::DiagnosticStatus::WARN,
       "Detected out-of-range exposure in ROI. Corresponding ROI was overwritten with UNKNOWN.");

--- a/perception/autoware_traffic_light_classifier/src/traffic_light_classifier_node.hpp
+++ b/perception/autoware_traffic_light_classifier/src/traffic_light_classifier_node.hpp
@@ -16,7 +16,7 @@
 #define TRAFFIC_LIGHT_CLASSIFIER_NODE_HPP_
 
 #include "classifier/classifier_interface.hpp"
-#include "traffic_light_classifier_process.hpp"
+#include "traffic_light_classifier.hpp"
 
 #include <image_transport/image_transport.hpp>
 #include <image_transport/subscriber_filter.hpp>
@@ -72,8 +72,6 @@ public:
     LampRecognizer = 2,  // Per-lamp recognizer based classifier: bbox + color + type + angle
   };
 
-  uint8_t classify_traffic_light_type_;
-
 private:
   void connectCb();
 
@@ -93,13 +91,10 @@ private:
   bool is_approximate_sync_;
   rclcpp::Publisher<tier4_perception_msgs::msg::TrafficLightArray>::SharedPtr
     traffic_signal_array_pub_;
-  std::shared_ptr<ClassifierInterface> classifier_ptr_;
+  std::unique_ptr<TrafficLightClassifier> classifier_;
 
   std::unique_ptr<autoware_utils::DiagnosticsInterface>
     diagnostics_interface_ptr_;  //!< Diagnostic handler.
-
-  double over_exposure_threshold_;
-  double under_exposure_threshold_;
 };
 
 }  // namespace autoware::traffic_light


### PR DESCRIPTION
## Description

Extract the classification orchestration out of the ROS node into a ROS-free class.

`TrafficLightClassifierNodelet::imageRoiCallback` previously contained the whole per-ROI pipeline (filter by traffic-light type, exposure detection, crop & classify, append undetected zero-sized ROIs as `UNKNOWN`, overwrite out-of-range exposure slots with `UNKNOWN`). This logic is moved verbatim into a new `TrafficLightClassifier` class (`traffic_light_classifier.{hpp,cpp}`) that owns the classifier backend and the parameters, and exposes a single `classify(image, rois) -> std::optional<Result>`.

The node is now a thin adapter responsible only for I/O: parameter declaration, pub/sub & time-sync, `cv_bridge` conversion, header stamping, and diagnostics.

This is a pure, behavior-preserving extraction — no functional change.

## Related links

**Parent Issue:**

- Follow-up to #12840 (characterization test that decouples the node and the logic).

## How was this PR tested?

- `colcon build --packages-select autoware_traffic_light_classifier` (color-classifier / non-GPU path) — succeeds.
- `colcon test --packages-select autoware_traffic_light_classifier` — green:
  - `test_traffic_light_classifier_characteristics`: 11/11 passed (the safety net from #12840, unchanged).
  - `test_utils`: 13/13 passed.

The characterization test drives the node end-to-end and pins the observable behavior (filtering, ordering, UNKNOWN handling, exposure overwrite, id/type propagation, diagnostics), so a green run demonstrates the extraction preserved behavior.

## Notes for reviewers

- Behavior-preserving refactor only; the diff is intentionally limited to the extraction.
- The now-unused `traffic_light_classifier_process.hpp` include was dropped from the node header (the node no longer touches `utils::compute_brightness`).
- **Node-free unit tests for `TrafficLightClassifier::classify()` are planned as a separate follow-up PR**, to keep this one focused and reduce review cost. The new class is ROS-free and returns a value, so it can be tested directly without the rclcpp executor harness.
- A pre-existing latent issue (a failed `cv_bridge` conversion does not early-return, leading to a null deref) is intentionally left unchanged here — it is out of scope for a behavior-preserving extraction.

## Interface changes

None.

## Effects on system behavior

None.
