### PR TITLE
fix(behavior_velocity_no_stopping_area): declare predicted_objects subscription and guard null deref

### DIFF
--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_no_stopping_area_module/src/experimental/manager.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_no_stopping_area_module/src/experimental/manager.hpp
@@ -33,7 +33,9 @@ public:
 
   RequiredSubscriptionInfo getRequiredSubscriptions() const override
   {
-    return RequiredSubscriptionInfo{};
+    RequiredSubscriptionInfo required_subscription_info;
+    required_subscription_info.predicted_objects = true;
+    return required_subscription_info;
   }
 
 private:

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_no_stopping_area_module/src/experimental/scene_no_stopping_area.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_no_stopping_area_module/src/experimental/scene_no_stopping_area.cpp
@@ -151,6 +151,11 @@ bool NoStoppingAreaModule::modifyPathVelocity(
   const auto & predicted_obj_arr_ptr = planner_data.predicted_objects;
   const auto & current_pose = planner_data.current_odometry->pose;
 
+  if (!predicted_obj_arr_ptr) {
+    setSafe(true);
+    return true;
+  }
+
   // Reset data
   debug_data_ = no_stopping_area::DebugData();
   debug_data_.base_link2front = planner_data.vehicle_info_.max_longitudinal_offset_m;

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_no_stopping_area_module/src/manager.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_no_stopping_area_module/src/manager.hpp
@@ -38,7 +38,9 @@ public:
 
   RequiredSubscriptionInfo getRequiredSubscriptions() const override
   {
-    return RequiredSubscriptionInfo{};
+    RequiredSubscriptionInfo required_subscription_info;
+    required_subscription_info.predicted_objects = true;
+    return required_subscription_info;
   }
 
 private:

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_no_stopping_area_module/src/scene_no_stopping_area.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_no_stopping_area_module/src/scene_no_stopping_area.cpp
@@ -64,6 +64,9 @@ bool NoStoppingAreaModule::modifyPathVelocity(PathWithLaneId * path)
   if (path->points.size() <= 2) {
     return true;
   }
+  if (!predicted_obj_arr_ptr) {
+    return true;
+  }
   // Reset data
   debug_data_ = no_stopping_area::DebugData();
   debug_data_.base_link2front = planner_data_->vehicle_info_.max_longitudinal_offset_m;


### PR DESCRIPTION
## Description

The `no_stopping_area` module reads `planner_data.predicted_objects` to detect stuck/stopped vehicles inside the no-stopping area (`check_stuck_vehicles_in_no_stopping_area` dereferences `predicted_obj_arr_ptr->objects`), but its `getRequiredSubscriptions()` returned an empty `RequiredSubscriptionInfo{}`.

In `behavior_velocity_planner`, the node only fetches a topic when at least one loaded module declares it as required (`getData()` skips `take_data()` otherwise). As a result, if `no_stopping_area` runs without any other predicted-objects-consuming module (e.g. crosswalk / intersection / blind_spot) loaded alongside it, `planner_data.predicted_objects` stays null and the module dereferences a null pointer.

This affects **both** the stable and the experimental variants (both declared the empty requirement).

### Changes

- **Declare the dependency (root-cause fix):** `getRequiredSubscriptions()` now sets `predicted_objects = true` in both `manager.hpp` and `experimental/manager.hpp`, so the planner subscribes to and populates `dynamic_objects` for this module — consistent with how the crosswalk/intersection/blind_spot modules declare it.
- **Defensive null guard:** `modifyPathVelocity()` now returns early (no stop imposed by this module) when `predicted_objects` is not yet available, in both `scene_no_stopping_area.cpp` and `experimental/scene_no_stopping_area.cpp`.

## Related links

**Parent Issue:**

- None

## How was this PR tested?

- Built locally:
  `colcon build --packages-select autoware_behavior_velocity_no_stopping_area_module` — succeeds.
- Reviewed the data-flow path in `autoware_behavior_velocity_planner` (`processData()` / `getData()`) confirming a non-required topic is never fetched and the field remains null.

## Notes for reviewers

The defensive guard is intentionally redundant with the requirement declaration: once the dependency is declared, the node will not call `modifyPathVelocity` until the data is available, but the guard keeps the module from crashing if it is ever invoked before data is ready.

## Interface changes

The module now declares `predicted_objects` as a required subscription. No new ROS topics are added — `~/input/dynamic_objects` is already a node-level subscription; this only ensures it is actually fetched when the no-stopping-area module is enabled.

## Effects on system behavior

When the `no_stopping_area` module is enabled, the behavior_velocity_planner will now wait for `dynamic_objects` before planning (as it already does for the other object-consuming modules). Stuck-vehicle detection in the no-stopping area now functions reliably regardless of which other modules are loaded; previously it could crash on a null pointer.
