### PR TITLE
chore: bump cuda_blackboard version to 0.4.0

### DIFF
--- a/build_depends_stable.repos
+++ b/build_depends_stable.repos
@@ -23,7 +23,7 @@ repositories:
   universe/external/cuda_blackboard:
     type: git
     url: https://github.com/autowarefoundation/cuda_blackboard.git
-    version: 0.3.0
+    version: 0.4.0
   universe/external/negotiated:
     type: git
     url: https://github.com/osrf/negotiated.git

--- a/perception/autoware_ground_segmentation_cuda/CMakeLists.txt
+++ b/perception/autoware_ground_segmentation_cuda/CMakeLists.txt
@@ -88,6 +88,10 @@ target_link_libraries(cuda_ground_segmentation
   cuda_ground_segmentation_lib
 )
 
+# TODO(mojomex): remove after migrating to the stream-ordered cuda_blackboard API,
+# see autowarefoundation/cuda_blackboard#22 (cf. example migrations #12797, #12798, #12799)
+target_compile_options(cuda_ground_segmentation PRIVATE -Wno-error=deprecated-declarations)
+
 #=========== ScanGround Segmentation filter ========
 rclcpp_components_register_node(cuda_ground_segmentation
   PLUGIN "autoware::cuda_ground_segmentation::CudaScanGroundSegmentationFilterNode"


### PR DESCRIPTION
## Description

Bump `cuda_blackboard` version to gain support for stream-ordered alloc and pub/sub APIs.
This is needed in addition to the `autoware` PR (see below) to make `autoware_universe` CI pass.

### Guard remaining users of the deprecated subscriber constructor

`cuda_blackboard` 0.4.0 deprecates the stream-less `CudaBlackboardSubscriber`
constructor in favor of the stream-ordered one. The packages that take a CUDA
stream are migrated separately (#12797 `autoware_bevfusion`, #12798
`autoware_ptv3`, #12799 `autoware_cuda_pointcloud_preprocessor`).

The remaining nodes still using the deprecated constructor were audited:

| Package | Already silences deprecation? | Change |
| --- | --- | --- |
| `autoware_lidar_centerpoint` | yes — package-wide `-Wno-deprecated-declarations` | none needed |
| `autoware_lidar_frnet` | yes — package-wide `-Wno-deprecated-declarations` | none needed |
| `autoware_lidar_transfusion` | yes — package-wide `-Wno-deprecated-declarations` | none needed |
| `autoware_ground_segmentation_cuda` | no | add `-Wno-error=deprecated-declarations` |

Only `autoware_ground_segmentation_cuda` lacked any deprecation suppression, so
the bump would turn its deprecation warning into a build error under
`-Werror`. A targeted `-Wno-error=deprecated-declarations` is added to the
`cuda_ground_segmentation` target (with a `TODO` to remove it once the node is
migrated to hand its stream to `cuda_blackboard`). The deprecation stays visible
as a warning so it is not forgotten.

The `CudaBlackboardPublisher` constructor is not deprecated in 0.4.0, so
publisher-only users are unaffected.

## Related links

- autowarefoundation/autoware#7172
- autowarefoundation/cuda_blackboard#22 (stream-ordered API)
- #12797, #12798, #12799 (stream migrations of the bevfusion / ptv3 / cuda_pointcloud_preprocessor nodes)
