### PR TITLE
feat(autoware_pointcloud_preprocessor): concat_conversion_to_ros_time

### DIFF
--- a/sensing/autoware_pointcloud_preprocessor/CMakeLists.txt
+++ b/sensing/autoware_pointcloud_preprocessor/CMakeLists.txt
@@ -305,6 +305,68 @@ install(
 
 ament_export_targets(export_${PROJECT_NAME})
 
+# ========== Python bindings (distortion corrector) ==========
+# The distortion corrector core is built as a standalone shared library that the pybind module
+# links. It is ROS-runtime-free: it links only ROS message types and math libraries (no rclcpp, no
+# tf). It uses tf2's header-only LinearMath types, which are included but never linked. Dependencies
+# are linked via target_link_libraries with the dependencies' exported CMake targets (modern targets
+# propagate their transitive include dirs) instead of ament_target_dependencies, which would
+# over-declare the full package closure and clashes with pybind11's keyword target_link_libraries
+# usage. Only the pybind module (the binding layer, not the core) links rclcpp, for message
+# (de)serialization.
+find_package(ament_cmake_python REQUIRED)
+find_package(python_cmake_module REQUIRED)
+find_package(Python3 REQUIRED COMPONENTS Interpreter Development)
+find_package(pybind11_vendor REQUIRED)
+find_package(pybind11 REQUIRED)
+find_package(autoware_utils_math REQUIRED)
+
+add_library(distortion_corrector_core SHARED
+  src/distortion_corrector/distortion_corrector.cpp
+  src/utility/memory.cpp
+)
+target_include_directories(distortion_corrector_core PUBLIC
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>"
+)
+# Header-only includes (tf2 is used for its LinearMath types only; the autoware_utils meta include
+# provides the autoware_utils/math/* headers). Message includes propagate via the linked targets.
+target_include_directories(distortion_corrector_core SYSTEM PUBLIC
+  ${autoware_utils_INCLUDE_DIRS}
+  ${autoware_point_types_INCLUDE_DIRS}
+  ${tf2_INCLUDE_DIRS}
+)
+target_link_libraries(distortion_corrector_core PUBLIC
+  ${sensor_msgs_TARGETS}
+  ${geometry_msgs_TARGETS}
+  ${autoware_utils_math_LIBRARIES}
+)
+
+pybind11_add_module(_distortion_corrector_pybind
+  src/distortion_corrector/distortion_corrector_pybind.cpp
+)
+target_include_directories(_distortion_corrector_pybind PRIVATE ${rclcpp_INCLUDE_DIRS})
+target_link_libraries(_distortion_corrector_pybind PRIVATE
+  distortion_corrector_core
+  ${rclcpp_LIBRARIES}
+)
+
+install(TARGETS distortion_corrector_core
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+)
+# Install the extension next to the Python package. Use ament_get_python_install_dir() rather than
+# the raw PYTHON_INSTALL_DIR variable: the latter is only populated later (by
+# ament_python_install_package / ament_package), so on a clean configure it is empty and the
+# DESTINATION would resolve to an absolute "/<project>" path.
+ament_get_python_install_dir(python_install_dir)
+install(TARGETS _distortion_corrector_pybind
+  DESTINATION "${python_install_dir}/${PROJECT_NAME}")
+
+ament_python_install_package(${PROJECT_NAME}
+  PACKAGE_DIR python/${PROJECT_NAME})
+
 ament_auto_package(INSTALL_TO_SHARE
   launch
   config
@@ -318,6 +380,15 @@ if(BUILD_TESTING)
 
   ament_add_gtest(test_utilities
     test/test_utilities.cpp
+  )
+
+  ament_add_gtest(test_conversion
+    test/test_conversion.cpp
+  )
+  ament_target_dependencies(test_conversion
+    builtin_interfaces
+    geometry_msgs
+    tf2
   )
 
   ament_add_gtest(test_distortion_corrector_node
@@ -385,6 +456,11 @@ if(BUILD_TESTING)
   add_ros_test(
     test/test_concatenate_node_component.py
     TIMEOUT "50"
+  )
+
+  find_package(ament_cmake_pytest REQUIRED)
+  ament_add_pytest_test(test_distortion_corrector_py
+    test/test_distortion_corrector_py.py
   )
 
 endif()

--- a/sensing/autoware_pointcloud_preprocessor/include/autoware/pointcloud_preprocessor/distortion_corrector/distortion_corrector.hpp
+++ b/sensing/autoware_pointcloud_preprocessor/include/autoware/pointcloud_preprocessor/distortion_corrector/distortion_corrector.hpp
@@ -16,22 +16,20 @@
 #define AUTOWARE__POINTCLOUD_PREPROCESSOR__DISTORTION_CORRECTOR__DISTORTION_CORRECTOR_HPP_
 
 #include <Eigen/Core>
-#include <managed_transform_buffer/managed_transform_buffer.hpp>
-#include <rclcpp/rclcpp.hpp>
 #include <sophus/se3.hpp>
 #include <tf2/LinearMath/Transform.hpp>
-#include <tf2/convert.hpp>
-#include <tf2/transform_datatypes.hpp>
 
+#include <geometry_msgs/msg/transform_stamped.hpp>
 #include <geometry_msgs/msg/twist_stamped.hpp>
 #include <geometry_msgs/msg/twist_with_covariance_stamped.hpp>
+#include <geometry_msgs/msg/vector3_stamped.hpp>
 #include <sensor_msgs/msg/imu.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
 #include <sensor_msgs/point_cloud2_iterator.hpp>
-#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 
 #include <deque>
 #include <memory>
+#include <optional>
 #include <string>
 
 namespace autoware::pointcloud_preprocessor
@@ -49,14 +47,31 @@ struct AngleConversion
   static constexpr float sign_threshold{0.1f};
 };
 
+// Reason why an input pointcloud was rejected. Reported to the caller instead of being logged, so
+// that the core stays free of ROS logging.
+enum class PointcloudValidity {
+  kValid,
+  kEmpty,
+  kMissingTimeStampField,
+  kIncompatibleLayout,
+};
+
+// Outcome of undistort_pointcloud(). Conditions that the node used to log directly are surfaced
+// here so the (ROS-free) core can report them to its caller.
+struct UndistortionResult
+{
+  PointcloudValidity validity{PointcloudValidity::kValid};
+  bool twist_queue_empty{false};
+  bool twist_timestamp_too_late{false};
+  bool imu_timestamp_too_late{false};
+};
+
 class DistortionCorrectorBase
 {
 protected:
   geometry_msgs::msg::TransformStamped::SharedPtr geometry_imu_to_base_link_ptr_;
   bool pointcloud_transform_needed_{false};
   bool pointcloud_transform_exists_{false};
-  bool imu_transform_exists_{false};
-  std::unique_ptr<managed_transform_buffer::ManagedTransformBuffer> managed_tf_buffer_{nullptr};
 
   std::deque<geometry_msgs::msg::TwistStamped> twist_queue_;
   std::deque<geometry_msgs::msg::Vector3Stamped> angular_velocity_queue_;
@@ -64,24 +79,14 @@ protected:
   int timestamp_mismatch_count_{0};
   double timestamp_mismatch_fraction_{0.0};
 
-  rclcpp::Node & node_;
-
-  void get_imu_transformation(const std::string & base_frame, const std::string & imu_frame);
   void enqueue_imu(const sensor_msgs::msg::Imu::ConstSharedPtr imu_msg);
   void get_twist_and_imu_iterator(
     bool use_imu, double first_point_time_stamp_sec,
     std::deque<geometry_msgs::msg::TwistStamped>::iterator & it_twist,
     std::deque<geometry_msgs::msg::Vector3Stamped>::iterator & it_imu);
-  void warn_if_timestamp_is_too_late(
-    bool is_twist_time_stamp_too_late, bool is_imu_time_stamp_too_late);
-  static tf2::Transform convert_matrix_to_transform(const Eigen::Matrix4f & matrix);
 
 public:
-  explicit DistortionCorrectorBase(rclcpp::Node & node) : node_(node)
-  {
-    managed_tf_buffer_ = std::make_unique<managed_transform_buffer::ManagedTransformBuffer>();
-  }
-
+  DistortionCorrectorBase() = default;
   virtual ~DistortionCorrectorBase() = default;
 
   [[nodiscard]] bool pointcloud_transform_exists() const;
@@ -91,13 +96,16 @@ public:
   void process_twist_message(
     const geometry_msgs::msg::TwistWithCovarianceStamped::ConstSharedPtr twist_msg);
 
-  void process_imu_message(
-    const std::string & base_frame, const sensor_msgs::msg::Imu::ConstSharedPtr imu_msg);
+  // The IMU-to-base-frame transform must be provided (via set_imu_transform) before processing IMU
+  // messages, so that angular velocities can be rotated into the base frame.
+  void set_imu_transform(const geometry_msgs::msg::TransformStamped & imu_to_base_link);
+
+  void process_imu_message(const sensor_msgs::msg::Imu::ConstSharedPtr imu_msg);
 
   std::optional<AngleConversion> try_compute_angle_conversion(
     sensor_msgs::msg::PointCloud2 & pointcloud);
 
-  bool is_pointcloud_valid(sensor_msgs::msg::PointCloud2 & pointcloud);
+  PointcloudValidity check_pointcloud_validity(sensor_msgs::msg::PointCloud2 & pointcloud);
 
   [[nodiscard]] int get_timestamp_mismatch_count() const { return timestamp_mismatch_count_; }
   [[nodiscard]] double get_timestamp_mismatch_fraction() const
@@ -105,10 +113,12 @@ public:
     return timestamp_mismatch_fraction_;
   }
 
+  // The lidar-to-base-frame transform (header.frame_id = base frame, child_frame_id = lidar frame)
+  // must be provided before undistorting a pointcloud expressed in the lidar frame.
   virtual void set_pointcloud_transform(
-    const std::string & base_frame, const std::string & lidar_frame) = 0;
+    const geometry_msgs::msg::TransformStamped & lidar_to_base_link) = 0;
   virtual void initialize() = 0;
-  virtual void undistort_pointcloud(
+  virtual UndistortionResult undistort_pointcloud(
     bool use_imu, std::optional<AngleConversion> angle_conversion_opt,
     sensor_msgs::msg::PointCloud2 & pointcloud) = 0;
 };
@@ -117,9 +127,7 @@ template <class T>
 class DistortionCorrector : public DistortionCorrectorBase
 {
 public:
-  explicit DistortionCorrector(rclcpp::Node & node) : DistortionCorrectorBase(node) {}
-
-  void undistort_pointcloud(
+  UndistortionResult undistort_pointcloud(
     bool use_imu, std::optional<AngleConversion> angle_conversion_opt,
     sensor_msgs::msg::PointCloud2 & pointcloud) override;
 
@@ -152,10 +160,9 @@ private:
   tf2::Transform tf2_base_link_to_lidar_;
 
 public:
-  explicit DistortionCorrector2D(rclcpp::Node & node) : DistortionCorrector(node) {}
   void initialize() override;
   void set_pointcloud_transform(
-    const std::string & base_frame, const std::string & lidar_frame) override;
+    const geometry_msgs::msg::TransformStamped & lidar_to_base_link) override;
   void undistort_point_implementation(
     sensor_msgs::PointCloud2Iterator<float> & it_x, sensor_msgs::PointCloud2Iterator<float> & it_y,
     sensor_msgs::PointCloud2Iterator<float> & it_z,
@@ -178,10 +185,9 @@ private:
   Eigen::Matrix4f eigen_base_link_to_lidar_;
 
 public:
-  explicit DistortionCorrector3D(rclcpp::Node & node) : DistortionCorrector(node) {}
   void initialize() override;
   void set_pointcloud_transform(
-    const std::string & base_frame, const std::string & lidar_frame) override;
+    const geometry_msgs::msg::TransformStamped & lidar_to_base_link) override;
   void undistort_point_implementation(
     sensor_msgs::PointCloud2Iterator<float> & it_x, sensor_msgs::PointCloud2Iterator<float> & it_y,
     sensor_msgs::PointCloud2Iterator<float> & it_z,

--- a/sensing/autoware_pointcloud_preprocessor/include/autoware/pointcloud_preprocessor/distortion_corrector/distortion_corrector_node.hpp
+++ b/sensing/autoware_pointcloud_preprocessor/include/autoware/pointcloud_preprocessor/distortion_corrector/distortion_corrector_node.hpp
@@ -22,6 +22,7 @@
 #include <autoware_utils/ros/diagnostics_interface.hpp>
 #include <autoware_utils/ros/polling_subscriber.hpp>
 #include <autoware_utils/system/stop_watch.hpp>
+#include <managed_transform_buffer/managed_transform_buffer.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include <geometry_msgs/msg/twist_stamped.hpp>
@@ -68,11 +69,13 @@ private:
   std::optional<AngleConversion> angle_conversion_opt_;
 
   std::unique_ptr<DistortionCorrectorBase> distortion_corrector_;
+  std::unique_ptr<managed_transform_buffer::ManagedTransformBuffer> managed_tf_buffer_;
 
   // Diagnostic
   std::unique_ptr<autoware_utils::DiagnosticsInterface> diagnostics_interface_;
 
   void pointcloud_callback(PointCloud2::UniquePtr pointcloud_msg);
+  void log_undistortion_result(const UndistortionResult & result, const PointCloud2 & pointcloud);
   void publish_diagnostics(const std::vector<std::shared_ptr<const DiagnosticsBase>> & diagnostics);
 };
 

--- a/sensing/autoware_pointcloud_preprocessor/include/autoware/pointcloud_preprocessor/utility/conversion.hpp
+++ b/sensing/autoware_pointcloud_preprocessor/include/autoware/pointcloud_preprocessor/utility/conversion.hpp
@@ -42,6 +42,16 @@ inline double to_seconds(const builtin_interfaces::msg::Time & stamp)
   return static_cast<double>(to_nanoseconds(stamp)) * 1e-9;
 }
 
+/// Convert an absolute time in integer nanoseconds back to a header stamp (inverse of
+/// to_nanoseconds, for non-negative times).
+inline builtin_interfaces::msg::Time to_ros_time(int64_t nanoseconds)
+{
+  builtin_interfaces::msg::Time stamp;
+  stamp.sec = static_cast<int32_t>(nanoseconds / 1'000'000'000LL);
+  stamp.nanosec = static_cast<uint32_t>(nanoseconds % 1'000'000'000LL);
+  return stamp;
+}
+
 /// Convert a transform message to a tf2 transform (equivalent to tf2::fromMsg).
 inline tf2::Transform to_tf2_transform(const geometry_msgs::msg::Transform & transform)
 {

--- a/sensing/autoware_pointcloud_preprocessor/include/autoware/pointcloud_preprocessor/utility/conversion.hpp
+++ b/sensing/autoware_pointcloud_preprocessor/include/autoware/pointcloud_preprocessor/utility/conversion.hpp
@@ -1,0 +1,70 @@
+// Copyright 2024 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__POINTCLOUD_PREPROCESSOR__UTILITY__CONVERSION_HPP_
+#define AUTOWARE__POINTCLOUD_PREPROCESSOR__UTILITY__CONVERSION_HPP_
+
+#include <Eigen/Core>
+#include <Eigen/Geometry>
+#include <builtin_interfaces/msg/time.hpp>
+#include <tf2/LinearMath/Transform.hpp>
+
+#include <geometry_msgs/msg/transform.hpp>
+
+#include <cstdint>
+
+// ROS-message conversion helpers that depend only on message types and header-only math (no rclcpp,
+// no tf2_ros). They let downstream code keep header stamps and transforms without pulling in the
+// ROS runtime, so the consuming logic can stay ROS-runtime-free and deterministic.
+namespace autoware::pointcloud_preprocessor::utils
+{
+
+/// Convert a header stamp to an absolute time in integer nanoseconds (matches rclcpp::Time).
+inline int64_t to_nanoseconds(const builtin_interfaces::msg::Time & stamp)
+{
+  return static_cast<int64_t>(stamp.sec) * 1'000'000'000LL + stamp.nanosec;
+}
+
+/// Convert a header stamp to an absolute time in seconds (matches rclcpp::Time::seconds()).
+inline double to_seconds(const builtin_interfaces::msg::Time & stamp)
+{
+  return static_cast<double>(to_nanoseconds(stamp)) * 1e-9;
+}
+
+/// Convert a transform message to a tf2 transform (equivalent to tf2::fromMsg).
+inline tf2::Transform to_tf2_transform(const geometry_msgs::msg::Transform & transform)
+{
+  tf2::Transform out;
+  out.setOrigin(
+    tf2::Vector3(transform.translation.x, transform.translation.y, transform.translation.z));
+  out.setRotation(
+    tf2::Quaternion(
+      transform.rotation.x, transform.rotation.y, transform.rotation.z, transform.rotation.w));
+  return out;
+}
+
+/// Convert a transform message to a 4x4 homogeneous matrix (equivalent to tf2::transformToEigen).
+inline Eigen::Matrix4f to_eigen_matrix(const geometry_msgs::msg::Transform & transform)
+{
+  const Eigen::Isometry3d isometry =
+    Eigen::Translation3d(
+      transform.translation.x, transform.translation.y, transform.translation.z) *
+    Eigen::Quaterniond(
+      transform.rotation.w, transform.rotation.x, transform.rotation.y, transform.rotation.z);
+  return isometry.matrix().cast<float>();
+}
+
+}  // namespace autoware::pointcloud_preprocessor::utils
+
+#endif  // AUTOWARE__POINTCLOUD_PREPROCESSOR__UTILITY__CONVERSION_HPP_

--- a/sensing/autoware_pointcloud_preprocessor/package.xml
+++ b/sensing/autoware_pointcloud_preprocessor/package.xml
@@ -25,7 +25,9 @@
   <author email="william@osrfoundation.org">William Woodall</author>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
+  <buildtool_depend>ament_cmake_python</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
+  <buildtool_depend>python_cmake_module</buildtool_depend>
 
   <depend>autoware_agnocast_wrapper</depend>
   <depend>autoware_internal_debug_msgs</depend>
@@ -35,10 +37,13 @@
   <depend>autoware_point_types</depend>
   <depend>autoware_sensing_msgs</depend>
   <depend>autoware_utils</depend>
+  <depend>autoware_utils_math</depend>
   <depend>autoware_vehicle_msgs</depend>
+  <depend>builtin_interfaces</depend>
   <depend>cgal</depend>
   <depend>cv_bridge</depend>
   <depend>diagnostic_updater</depend>
+  <depend>geometry_msgs</depend>
   <depend>image_transport</depend>
   <depend>libopencv-dev</depend>
   <depend>libpcl-all-dev</depend>
@@ -49,6 +54,8 @@
   <depend>pcl_msgs</depend>
   <depend>pcl_ros</depend>
   <depend>point_cloud_msg_wrapper</depend>
+  <depend>pybind11_vendor</depend>
+  <depend>python3-dev</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>sensor_msgs</depend>
@@ -59,9 +66,12 @@
   <depend>tf2_geometry_msgs</depend>
   <depend>tf2_ros</depend>
   <depend>tf2_sensor_msgs</depend>
+  <exec_depend>rclpy</exec_depend>
 
+  <test_depend>ament_cmake_pytest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>
+  <test_depend>python3-pytest</test_depend>
   <test_depend>ros_testing</test_depend>
 
   <export>

--- a/sensing/autoware_pointcloud_preprocessor/python/autoware_pointcloud_preprocessor/__init__.py
+++ b/sensing/autoware_pointcloud_preprocessor/python/autoware_pointcloud_preprocessor/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2024 TIER IV, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Python interface to autoware_pointcloud_preprocessor (offline processing)."""

--- a/sensing/autoware_pointcloud_preprocessor/python/autoware_pointcloud_preprocessor/distortion_corrector.py
+++ b/sensing/autoware_pointcloud_preprocessor/python/autoware_pointcloud_preprocessor/distortion_corrector.py
@@ -1,0 +1,98 @@
+# Copyright 2024 TIER IV, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Deterministic, offline Python interface to the distortion corrector core.
+
+ROS messages are passed as their rclpy message objects; under the hood they are CDR-serialized and
+handed to the C++ core (no wall clock is used, so results are reproducible). ``undistort_pointcloud``
+returns a *new* point cloud and a status object rather than mutating its input.
+"""
+
+from typing import NamedTuple
+from typing import Tuple
+
+from geometry_msgs.msg import TransformStamped
+from geometry_msgs.msg import TwistWithCovarianceStamped
+from rclpy.serialization import deserialize_message
+from rclpy.serialization import serialize_message
+from sensor_msgs.msg import Imu
+from sensor_msgs.msg import PointCloud2
+
+from . import _distortion_corrector_pybind as _ext
+
+# Re-export the bound enum so callers don't need to import the extension module directly.
+PointcloudValidity = _ext.PointcloudValidity
+
+__all__ = ["DistortionCorrector", "PointcloudValidity", "UndistortionStatus"]
+
+
+class UndistortionStatus(NamedTuple):
+    """Outcome of :meth:`DistortionCorrector.undistort_pointcloud`."""
+
+    validity: "PointcloudValidity"
+    twist_queue_empty: bool
+    twist_timestamp_too_late: bool
+    imu_timestamp_too_late: bool
+    timestamp_mismatch_count: int
+    timestamp_mismatch_fraction: float
+
+
+class DistortionCorrector:
+    """Corrects motion distortion of a ``PointCloud2`` using twist and (optionally) IMU data.
+
+    Feed twist/IMU messages in timestamp order; the internal queues keep ~1 s of history keyed by
+    the message stamps (no wall clock). Provide the extrinsics once via the ``set_*_transform``
+    methods (``header.frame_id`` = base frame, ``child_frame_id`` = sensor/IMU frame; rotations must
+    be unit quaternions, as TF provides).
+    """
+
+    def __init__(self, use_3d_distortion_correction: bool = False) -> None:
+        self._impl = _ext.DistortionCorrector(use_3d_distortion_correction)
+
+    def set_pointcloud_transform(self, lidar_to_base_link: TransformStamped) -> None:
+        self._impl.set_pointcloud_transform(serialize_message(lidar_to_base_link))
+
+    def set_imu_transform(self, imu_to_base_link: TransformStamped) -> None:
+        self._impl.set_imu_transform(serialize_message(imu_to_base_link))
+
+    def process_twist_message(self, twist: TwistWithCovarianceStamped) -> None:
+        self._impl.process_twist_message(serialize_message(twist))
+
+    def process_imu_message(self, imu: Imu) -> None:
+        self._impl.process_imu_message(serialize_message(imu))
+
+    def undistort_pointcloud(
+        self,
+        pointcloud: PointCloud2,
+        use_imu: bool = True,
+        update_azimuth_and_distance: bool = False,
+    ) -> Tuple[PointCloud2, UndistortionStatus]:
+        """Undistort ``pointcloud`` and return ``(undistorted_pointcloud, status)``.
+
+        The input is not modified. ``update_azimuth_and_distance`` recomputes the azimuth/distance
+        fields for sensor-frame clouds (the Cartesian-to-azimuth conversion is computed once and
+        cached).
+        """
+        out_bytes, result = self._impl.undistort_pointcloud(
+            serialize_message(pointcloud), use_imu, update_azimuth_and_distance
+        )
+        status = UndistortionStatus(
+            validity=result.validity,
+            twist_queue_empty=result.twist_queue_empty,
+            twist_timestamp_too_late=result.twist_timestamp_too_late,
+            imu_timestamp_too_late=result.imu_timestamp_too_late,
+            timestamp_mismatch_count=self._impl.timestamp_mismatch_count,
+            timestamp_mismatch_fraction=self._impl.timestamp_mismatch_fraction,
+        )
+        return deserialize_message(out_bytes, PointCloud2), status

--- a/sensing/autoware_pointcloud_preprocessor/src/distortion_corrector/distortion_corrector.cpp
+++ b/sensing/autoware_pointcloud_preprocessor/src/distortion_corrector/distortion_corrector.cpp
@@ -14,12 +14,14 @@
 
 #include "autoware/pointcloud_preprocessor/distortion_corrector/distortion_corrector.hpp"
 
+#include "autoware/pointcloud_preprocessor/utility/conversion.hpp"
 #include "autoware/pointcloud_preprocessor/utility/memory.hpp"
 #include "autoware_utils/math/constants.hpp"
 
 #include <autoware_utils/math/trigonometry.hpp>
-#include <tf2_eigen/tf2_eigen.hpp>
+#include <tf2/LinearMath/Quaternion.hpp>
 
+#include <cstdint>
 #include <deque>
 #include <memory>
 #include <string>
@@ -56,16 +58,18 @@ void DistortionCorrectorBase::process_twist_message(
 
   // If time jumps backwards (e.g. when a rosbag restarts), clear buffer
   if (!twist_queue_.empty()) {
-    if (rclcpp::Time(twist_queue_.front().header.stamp) > rclcpp::Time(msg.header.stamp)) {
+    if (
+      utils::to_nanoseconds(twist_queue_.front().header.stamp) >
+      utils::to_nanoseconds(msg.header.stamp)) {
       twist_queue_.clear();
     }
   }
 
   // Twist data in the queue that is older than the current twist by 1 second will be cleared.
-  auto cutoff_time = rclcpp::Time(msg.header.stamp) - rclcpp::Duration::from_seconds(1.0);
+  const int64_t cutoff_nanoseconds = utils::to_nanoseconds(msg.header.stamp) - 1'000'000'000LL;
 
   while (!twist_queue_.empty()) {
-    if (rclcpp::Time(twist_queue_.front().header.stamp) > cutoff_time) {
+    if (utils::to_nanoseconds(twist_queue_.front().header.stamp) > cutoff_nanoseconds) {
       break;
     }
     twist_queue_.pop_front();
@@ -74,57 +78,54 @@ void DistortionCorrectorBase::process_twist_message(
   twist_queue_.push_back(msg);
 }
 
-void DistortionCorrectorBase::process_imu_message(
-  const std::string & base_frame, const sensor_msgs::msg::Imu::ConstSharedPtr imu_msg)
+void DistortionCorrectorBase::set_imu_transform(
+  const geometry_msgs::msg::TransformStamped & imu_to_base_link)
 {
-  get_imu_transformation(base_frame, imu_msg->header.frame_id);
-  enqueue_imu(imu_msg);
+  // Only the rotation is needed to rotate angular velocities into the base frame.
+  geometry_imu_to_base_link_ptr_ = std::make_shared<geometry_msgs::msg::TransformStamped>();
+  geometry_imu_to_base_link_ptr_->transform.rotation = imu_to_base_link.transform.rotation;
 }
 
-void DistortionCorrectorBase::get_imu_transformation(
-  const std::string & base_frame, const std::string & imu_frame)
+void DistortionCorrectorBase::process_imu_message(
+  const sensor_msgs::msg::Imu::ConstSharedPtr imu_msg)
 {
-  if (imu_transform_exists_) {
-    return;
+  if (!geometry_imu_to_base_link_ptr_) {
+    return;  // set_imu_transform() must be called before processing IMU messages.
   }
-
-  Eigen::Matrix4f eigen_imu_to_base_link;
-  auto eigen_transform_opt = managed_tf_buffer_->getTransform<Eigen::Matrix4f>(
-    base_frame, imu_frame, node_.now(), rclcpp::Duration::from_seconds(1.0), node_.get_logger());
-  imu_transform_exists_ = eigen_transform_opt.has_value();
-  if (imu_transform_exists_) {
-    eigen_imu_to_base_link = *eigen_transform_opt;
-  }
-  tf2::Transform tf2_imu_to_base_link = convert_matrix_to_transform(eigen_imu_to_base_link);
-
-  geometry_imu_to_base_link_ptr_ = std::make_shared<geometry_msgs::msg::TransformStamped>();
-  geometry_imu_to_base_link_ptr_->transform.rotation =
-    tf2::toMsg(tf2_imu_to_base_link.getRotation());
+  enqueue_imu(imu_msg);
 }
 
 void DistortionCorrectorBase::enqueue_imu(const sensor_msgs::msg::Imu::ConstSharedPtr imu_msg)
 {
-  geometry_msgs::msg::Vector3Stamped angular_velocity;
-  angular_velocity.vector = imu_msg->angular_velocity;
+  // Rotate the angular velocity into the base frame (rotation only; the stored transform carries no
+  // translation). Equivalent to tf2::doTransform on a Vector3, without depending on
+  // tf2_geometry_msgs.
+  const auto & rotation = geometry_imu_to_base_link_ptr_->transform.rotation;
+  const tf2::Vector3 rotated_angular_velocity = tf2::quatRotate(
+    tf2::Quaternion(rotation.x, rotation.y, rotation.z, rotation.w),
+    tf2::Vector3(
+      imu_msg->angular_velocity.x, imu_msg->angular_velocity.y, imu_msg->angular_velocity.z));
 
   geometry_msgs::msg::Vector3Stamped transformed_angular_velocity;
-  tf2::doTransform(angular_velocity, transformed_angular_velocity, *geometry_imu_to_base_link_ptr_);
+  transformed_angular_velocity.vector.x = rotated_angular_velocity.x();
+  transformed_angular_velocity.vector.y = rotated_angular_velocity.y();
+  transformed_angular_velocity.vector.z = rotated_angular_velocity.z();
   transformed_angular_velocity.header = imu_msg->header;
 
   // If time jumps backwards (e.g. when a rosbag restarts), clear buffer
   if (!angular_velocity_queue_.empty()) {
     if (
-      rclcpp::Time(angular_velocity_queue_.front().header.stamp) >
-      rclcpp::Time(imu_msg->header.stamp)) {
+      utils::to_nanoseconds(angular_velocity_queue_.front().header.stamp) >
+      utils::to_nanoseconds(imu_msg->header.stamp)) {
       angular_velocity_queue_.clear();
     }
   }
 
   // IMU data in the queue that is older than the current imu msg by 1 second will be cleared.
-  auto cutoff_time = rclcpp::Time(imu_msg->header.stamp) - rclcpp::Duration::from_seconds(1.0);
+  const int64_t cutoff_nanoseconds = utils::to_nanoseconds(imu_msg->header.stamp) - 1'000'000'000LL;
 
   while (!angular_velocity_queue_.empty()) {
-    if (rclcpp::Time(angular_velocity_queue_.front().header.stamp) > cutoff_time) {
+    if (utils::to_nanoseconds(angular_velocity_queue_.front().header.stamp) > cutoff_nanoseconds) {
       break;
     }
     angular_velocity_queue_.pop_front();
@@ -141,7 +142,7 @@ void DistortionCorrectorBase::get_twist_and_imu_iterator(
   it_twist = std::lower_bound(
     std::begin(twist_queue_), std::end(twist_queue_), first_point_time_stamp_sec,
     [](const geometry_msgs::msg::TwistStamped & x, const double t) {
-      return rclcpp::Time(x.header.stamp).seconds() < t;
+      return utils::to_seconds(x.header.stamp) < t;
     });
   it_twist = it_twist == std::end(twist_queue_) ? std::end(twist_queue_) - 1 : it_twist;
 
@@ -149,46 +150,32 @@ void DistortionCorrectorBase::get_twist_and_imu_iterator(
     it_imu = std::lower_bound(
       std::begin(angular_velocity_queue_), std::end(angular_velocity_queue_),
       first_point_time_stamp_sec, [](const geometry_msgs::msg::Vector3Stamped & x, const double t) {
-        return rclcpp::Time(x.header.stamp).seconds() < t;
+        return utils::to_seconds(x.header.stamp) < t;
       });
     it_imu =
       it_imu == std::end(angular_velocity_queue_) ? std::end(angular_velocity_queue_) - 1 : it_imu;
   }
 }
 
-bool DistortionCorrectorBase::is_pointcloud_valid(sensor_msgs::msg::PointCloud2 & pointcloud)
+PointcloudValidity DistortionCorrectorBase::check_pointcloud_validity(
+  sensor_msgs::msg::PointCloud2 & pointcloud)
 {
   if (pointcloud.data.empty()) {
-    RCLCPP_WARN_STREAM_THROTTLE(
-      node_.get_logger(), *node_.get_clock(), 10000 /* ms */, "Input pointcloud is empty.");
-    return false;
+    return PointcloudValidity::kEmpty;
   }
 
   auto time_stamp_field_it = std::find_if(
     std::cbegin(pointcloud.fields), std::cend(pointcloud.fields),
     [](const sensor_msgs::msg::PointField & field) { return field.name == "time_stamp"; });
   if (time_stamp_field_it == pointcloud.fields.cend()) {
-    RCLCPP_WARN_STREAM_THROTTLE(
-      node_.get_logger(), *node_.get_clock(), 10000 /* ms */,
-      "Required field time stamp doesn't exist in the point cloud.");
-    return false;
+    return PointcloudValidity::kMissingTimeStampField;
   }
 
   if (!utils::is_data_layout_compatible_with_point_xyzircaedt(pointcloud)) {
-    RCLCPP_ERROR(
-      node_.get_logger(), "The pointcloud layout is not compatible with PointXYZIRCAEDT. Aborting");
-
-    if (utils::is_data_layout_compatible_with_point_xyziradrt(pointcloud)) {
-      RCLCPP_ERROR(
-        node_.get_logger(),
-        "The pointcloud layout is compatible with PointXYZIRADRT. You may be using legacy "
-        "code/data");
-    }
-
-    return false;
+    return PointcloudValidity::kIncompatibleLayout;
   }
 
-  return true;
+  return PointcloudValidity::kValid;
 }
 
 std::optional<AngleConversion> DistortionCorrectorBase::try_compute_angle_conversion(
@@ -197,7 +184,7 @@ std::optional<AngleConversion> DistortionCorrectorBase::try_compute_angle_conver
   // This function tries to compute the angle conversion from Cartesian coordinates to LiDAR azimuth
   // coordinates system
 
-  if (!is_pointcloud_valid(pointcloud)) return std::nullopt;
+  if (check_pointcloud_validity(pointcloud) != PointcloudValidity::kValid) return std::nullopt;
 
   AngleConversion angle_conversion;
 
@@ -214,9 +201,7 @@ std::optional<AngleConversion> DistortionCorrectorBase::try_compute_angle_conver
     next_it_y = it_y + 1;
     next_it_azimuth = it_azimuth + 1;
   } else {
-    RCLCPP_WARN_STREAM_THROTTLE(
-      node_.get_logger(), *node_.get_clock(), 10000 /* ms */,
-      "Current point cloud only has a single point. Could not calculate the angle conversion.");
+    // Current point cloud only has a single point; cannot calculate the angle conversion.
     return std::nullopt;
   }
 
@@ -230,9 +215,7 @@ std::optional<AngleConversion> DistortionCorrectorBase::try_compute_angle_conver
     if (
       std::abs(*next_it_azimuth - *it_azimuth) == 0 ||
       std::abs(next_cartesian_rad - current_cartesian_rad) == 0) {
-      RCLCPP_DEBUG_STREAM_THROTTLE(
-        node_.get_logger(), *node_.get_clock(), 10000 /* ms */,
-        "Angle between two points is 0 degrees. Iterate to next point ...");
+      // Angle between two points is 0 degrees. Iterate to next point.
       continue;
     }
 
@@ -253,9 +236,7 @@ std::optional<AngleConversion> DistortionCorrectorBase::try_compute_angle_conver
     } else if (std::abs(sign + 1.0f) <= angle_conversion.sign_threshold) {
       angle_conversion.sign = -1.0f;
     } else {
-      RCLCPP_DEBUG_STREAM_THROTTLE(
-        node_.get_logger(), *node_.get_clock(), 10000 /* ms */,
-        "Value of sign is not close to 1 or -1. Iterate to next point ...");
+      // Value of sign is not close to 1 or -1. Iterate to next point.
       continue;
     }
 
@@ -265,10 +246,7 @@ std::optional<AngleConversion> DistortionCorrectorBase::try_compute_angle_conver
     if (
       std::abs(offset_rad - multiple_of_90_degrees * (autoware_utils::pi / 2)) >
       angle_conversion.offset_rad_threshold) {
-      RCLCPP_DEBUG_STREAM_THROTTLE(
-        node_.get_logger(), *node_.get_clock(), 10000 /* ms */,
-        "Value of offset_rad is not close to multiplication of 90 degrees. Iterate to next point "
-        "...");
+      // Value of offset_rad is not close to a multiple of 90 degrees. Iterate to next point.
       continue;
     }
 
@@ -282,46 +260,24 @@ std::optional<AngleConversion> DistortionCorrectorBase::try_compute_angle_conver
   return std::nullopt;
 }
 
-void DistortionCorrectorBase::warn_if_timestamp_is_too_late(
-  bool is_twist_time_stamp_too_late, bool is_imu_time_stamp_too_late)
-{
-  if (is_twist_time_stamp_too_late) {
-    RCLCPP_WARN_STREAM_THROTTLE(
-      node_.get_logger(), *node_.get_clock(), 10000 /* ms */,
-      "Twist time_stamp is too late. Could not interpolate.");
-  }
-
-  if (is_imu_time_stamp_too_late) {
-    RCLCPP_WARN_STREAM_THROTTLE(
-      node_.get_logger(), *node_.get_clock(), 10000 /* ms */,
-      "IMU time_stamp is too late. Could not interpolate.");
-  }
-}
-
-tf2::Transform DistortionCorrectorBase::convert_matrix_to_transform(const Eigen::Matrix4f & matrix)
-{
-  tf2::Transform transform;
-  transform.setOrigin(tf2::Vector3(matrix(0, 3), matrix(1, 3), matrix(2, 3)));
-  transform.setBasis(
-    tf2::Matrix3x3(
-      matrix(0, 0), matrix(0, 1), matrix(0, 2), matrix(1, 0), matrix(1, 1), matrix(1, 2),
-      matrix(2, 0), matrix(2, 1), matrix(2, 2)));
-  return transform;
-}
-
 template <class T>
-void DistortionCorrector<T>::undistort_pointcloud(
+UndistortionResult DistortionCorrector<T>::undistort_pointcloud(
   bool use_imu, std::optional<AngleConversion> angle_conversion_opt,
   sensor_msgs::msg::PointCloud2 & pointcloud)
 {
+  UndistortionResult result;
+
   timestamp_mismatch_count_ = 0;
   timestamp_mismatch_fraction_ = 0.0;
 
-  if (!is_pointcloud_valid(pointcloud)) return;
+  // Reset the per-cloud undistortion state so callers don't need to call initialize() themselves.
+  static_cast<T *>(this)->initialize();
+
+  result.validity = check_pointcloud_validity(pointcloud);
+  if (result.validity != PointcloudValidity::kValid) return result;
   if (twist_queue_.empty()) {
-    RCLCPP_WARN_STREAM_THROTTLE(
-      node_.get_logger(), *node_.get_clock(), 10000 /* ms */, "Twist queue is empty.");
-    return;
+    result.twist_queue_empty = true;
+    return result;
   }
 
   sensor_msgs::PointCloud2Iterator<float> it_x(pointcloud, "x");
@@ -340,11 +296,11 @@ void DistortionCorrector<T>::undistort_pointcloud(
   std::deque<geometry_msgs::msg::Vector3Stamped>::iterator it_imu;
   get_twist_and_imu_iterator(use_imu, first_point_time_stamp_sec, it_twist, it_imu);
 
-  // For performance, do not instantiate `rclcpp::Time` inside of the for-loop
-  double twist_stamp = rclcpp::Time(it_twist->header.stamp).seconds();
+  // For performance, do not recompute the stamp seconds inside of the for-loop
+  double twist_stamp = utils::to_seconds(it_twist->header.stamp);
   double imu_stamp{0.0};
   if (use_imu && !angular_velocity_queue_.empty()) {
-    imu_stamp = rclcpp::Time(it_imu->header.stamp).seconds();
+    imu_stamp = utils::to_seconds(it_imu->header.stamp);
   }
 
   // If there is a point in a pointcloud that cannot be associated, record it to issue a warning
@@ -362,7 +318,7 @@ void DistortionCorrector<T>::undistort_pointcloud(
     // Get closest twist information
     while (it_twist != std::end(twist_queue_) - 1 && current_point_stamp > twist_stamp) {
       ++it_twist;
-      twist_stamp = rclcpp::Time(it_twist->header.stamp).seconds();
+      twist_stamp = utils::to_seconds(it_twist->header.stamp);
     }
     if (std::abs(current_point_stamp - twist_stamp) > time_diff) {
       is_twist_time_stamp_too_late = true;
@@ -373,7 +329,7 @@ void DistortionCorrector<T>::undistort_pointcloud(
     if (use_imu && !angular_velocity_queue_.empty()) {
       while (it_imu != std::end(angular_velocity_queue_) - 1 && current_point_stamp > imu_stamp) {
         ++it_imu;
-        imu_stamp = rclcpp::Time(it_imu->header.stamp).seconds();
+        imu_stamp = utils::to_seconds(it_imu->header.stamp);
       }
 
       if (std::abs(current_point_stamp - imu_stamp) > time_diff) {
@@ -422,7 +378,9 @@ void DistortionCorrector<T>::undistort_pointcloud(
                                                       static_cast<float>(total_points)
                                                   : 0.0f;
 
-  warn_if_timestamp_is_too_late(is_twist_time_stamp_too_late, is_imu_time_stamp_too_late);
+  result.twist_timestamp_too_late = is_twist_time_stamp_too_late;
+  result.imu_timestamp_too_late = is_imu_time_stamp_too_late;
+  return result;
 }
 
 ///////////////////////// Functions for different undistortion strategies /////////////////////////
@@ -440,39 +398,23 @@ void DistortionCorrector3D::initialize()
 }
 
 void DistortionCorrector2D::set_pointcloud_transform(
-  const std::string & base_frame, const std::string & lidar_frame)
+  const geometry_msgs::msg::TransformStamped & lidar_to_base_link)
 {
-  if (pointcloud_transform_exists_) {
-    return;
-  }
-
-  Eigen::Matrix4f eigen_lidar_to_base_link;
-  auto eigen_transform_opt = managed_tf_buffer_->getTransform<Eigen::Matrix4f>(
-    base_frame, lidar_frame, node_.now(), rclcpp::Duration::from_seconds(1.0), node_.get_logger());
-  pointcloud_transform_exists_ = eigen_transform_opt.has_value();
-  if (pointcloud_transform_exists_) {
-    eigen_lidar_to_base_link = *eigen_transform_opt;
-  }
-  tf2_lidar_to_base_link_ = convert_matrix_to_transform(eigen_lidar_to_base_link);
+  tf2_lidar_to_base_link_ = utils::to_tf2_transform(lidar_to_base_link.transform);
   tf2_base_link_to_lidar_ = tf2_lidar_to_base_link_.inverse();
-  pointcloud_transform_needed_ = base_frame != lidar_frame && pointcloud_transform_exists_;
+  pointcloud_transform_exists_ = true;
+  pointcloud_transform_needed_ =
+    lidar_to_base_link.header.frame_id != lidar_to_base_link.child_frame_id;
 }
 
 void DistortionCorrector3D::set_pointcloud_transform(
-  const std::string & base_frame, const std::string & lidar_frame)
+  const geometry_msgs::msg::TransformStamped & lidar_to_base_link)
 {
-  if (pointcloud_transform_exists_) {
-    return;
-  }
-
-  auto eigen_transform_opt = managed_tf_buffer_->getTransform<Eigen::Matrix4f>(
-    base_frame, lidar_frame, node_.now(), rclcpp::Duration::from_seconds(1.0), node_.get_logger());
-  pointcloud_transform_exists_ = eigen_transform_opt.has_value();
-  if (pointcloud_transform_exists_) {
-    eigen_lidar_to_base_link_ = *eigen_transform_opt;
-  }
+  eigen_lidar_to_base_link_ = utils::to_eigen_matrix(lidar_to_base_link.transform);
   eigen_base_link_to_lidar_ = eigen_lidar_to_base_link_.inverse();
-  pointcloud_transform_needed_ = base_frame != lidar_frame && pointcloud_transform_exists_;
+  pointcloud_transform_exists_ = true;
+  pointcloud_transform_needed_ =
+    lidar_to_base_link.header.frame_id != lidar_to_base_link.child_frame_id;
 }
 
 inline void DistortionCorrector2D::undistort_point_implementation(

--- a/sensing/autoware_pointcloud_preprocessor/src/distortion_corrector/distortion_corrector_node.cpp
+++ b/sensing/autoware_pointcloud_preprocessor/src/distortion_corrector/distortion_corrector_node.cpp
@@ -17,6 +17,7 @@
 #include "autoware/pointcloud_preprocessor/diagnostics/distortion_corrector_diagnostics.hpp"
 #include "autoware/pointcloud_preprocessor/diagnostics/latency_diagnostics.hpp"
 #include "autoware/pointcloud_preprocessor/distortion_corrector/distortion_corrector.hpp"
+#include "autoware/pointcloud_preprocessor/utility/memory.hpp"
 
 #include <algorithm>
 #include <memory>
@@ -76,10 +77,13 @@ DistortionCorrectorComponent::DistortionCorrectorComponent(const rclcpp::NodeOpt
   // Setup the distortion corrector
 
   if (use_3d_distortion_correction_) {
-    distortion_corrector_ = std::make_unique<DistortionCorrector3D>(*this);
+    distortion_corrector_ = std::make_unique<DistortionCorrector3D>();
   } else {
-    distortion_corrector_ = std::make_unique<DistortionCorrector2D>(*this);
+    distortion_corrector_ = std::make_unique<DistortionCorrector2D>();
   }
+
+  // Transform buffer used to look up the sensor/IMU extrinsics injected into the corrector.
+  managed_tf_buffer_ = std::make_unique<managed_transform_buffer::ManagedTransformBuffer>();
 
   // Diagnostic
   diagnostics_interface_ =
@@ -105,12 +109,25 @@ void DistortionCorrectorComponent::pointcloud_callback(PointCloud2::UniquePtr po
   if (use_imu_) {
     std::vector<sensor_msgs::msg::Imu::ConstSharedPtr> imu_msgs = imu_sub_->take_data();
     for (const auto & msg : imu_msgs) {
-      distortion_corrector_->process_imu_message(base_frame_, msg);
+      const auto imu_to_base_link =
+        managed_tf_buffer_->getTransform<geometry_msgs::msg::TransformStamped>(
+          base_frame_, msg->header.frame_id, this->now(), rclcpp::Duration::from_seconds(1.0),
+          this->get_logger());
+      if (!imu_to_base_link.has_value()) {
+        continue;
+      }
+      distortion_corrector_->set_imu_transform(*imu_to_base_link);
+      distortion_corrector_->process_imu_message(msg);
     }
   }
 
-  distortion_corrector_->set_pointcloud_transform(base_frame_, pointcloud_msg->header.frame_id);
-  distortion_corrector_->initialize();
+  const auto lidar_to_base_link =
+    managed_tf_buffer_->getTransform<geometry_msgs::msg::TransformStamped>(
+      base_frame_, pointcloud_msg->header.frame_id, this->now(),
+      rclcpp::Duration::from_seconds(1.0), this->get_logger());
+  if (lidar_to_base_link.has_value()) {
+    distortion_corrector_->set_pointcloud_transform(*lidar_to_base_link);
+  }
 
   if (update_azimuth_and_distance_ && !angle_conversion_opt_.has_value()) {
     angle_conversion_opt_ = distortion_corrector_->try_compute_angle_conversion(*pointcloud_msg);
@@ -127,7 +144,9 @@ void DistortionCorrectorComponent::pointcloud_callback(PointCloud2::UniquePtr po
     }
   }
 
-  distortion_corrector_->undistort_pointcloud(use_imu_, angle_conversion_opt_, *pointcloud_msg);
+  const auto undistortion_result =
+    distortion_corrector_->undistort_pointcloud(use_imu_, angle_conversion_opt_, *pointcloud_msg);
+  log_undistortion_result(undistortion_result, *pointcloud_msg);
 
   const rclcpp::Time stamp(pointcloud_msg->header.stamp);
 
@@ -156,6 +175,49 @@ void DistortionCorrectorComponent::pointcloud_callback(PointCloud2::UniquePtr po
     update_azimuth_and_distance_, timestamp_mismatch_fraction_threshold_);
 
   publish_diagnostics({latency_diagnostics, distortion_corrector_diagnostics});
+}
+
+void DistortionCorrectorComponent::log_undistortion_result(
+  const UndistortionResult & result, const PointCloud2 & pointcloud)
+{
+  switch (result.validity) {
+    case PointcloudValidity::kEmpty:
+      RCLCPP_WARN_STREAM_THROTTLE(
+        get_logger(), *get_clock(), 10000 /* ms */, "Input pointcloud is empty.");
+      break;
+    case PointcloudValidity::kMissingTimeStampField:
+      RCLCPP_WARN_STREAM_THROTTLE(
+        get_logger(), *get_clock(), 10000 /* ms */,
+        "Required field time stamp doesn't exist in the point cloud.");
+      break;
+    case PointcloudValidity::kIncompatibleLayout:
+      RCLCPP_ERROR(
+        get_logger(), "The pointcloud layout is not compatible with PointXYZIRCAEDT. Aborting");
+      if (utils::is_data_layout_compatible_with_point_xyziradrt(pointcloud)) {
+        RCLCPP_ERROR(
+          get_logger(),
+          "The pointcloud layout is compatible with PointXYZIRADRT. You may be using legacy "
+          "code/data");
+      }
+      break;
+    case PointcloudValidity::kValid:
+      break;
+  }
+
+  if (result.twist_queue_empty) {
+    RCLCPP_WARN_STREAM_THROTTLE(
+      get_logger(), *get_clock(), 10000 /* ms */, "Twist queue is empty.");
+  }
+  if (result.twist_timestamp_too_late) {
+    RCLCPP_WARN_STREAM_THROTTLE(
+      get_logger(), *get_clock(), 10000 /* ms */,
+      "Twist time_stamp is too late. Could not interpolate.");
+  }
+  if (result.imu_timestamp_too_late) {
+    RCLCPP_WARN_STREAM_THROTTLE(
+      get_logger(), *get_clock(), 10000 /* ms */,
+      "IMU time_stamp is too late. Could not interpolate.");
+  }
 }
 
 void DistortionCorrectorComponent::publish_diagnostics(

--- a/sensing/autoware_pointcloud_preprocessor/src/distortion_corrector/distortion_corrector_pybind.cpp
+++ b/sensing/autoware_pointcloud_preprocessor/src/distortion_corrector/distortion_corrector_pybind.cpp
@@ -1,0 +1,177 @@
+// Copyright 2024 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Python bindings for the (ROS-runtime-free) distortion corrector core. ROS messages cross the
+// boundary as CDR-serialized bytes (rclpy::serialize_message on the Python side), which keeps the
+// binding free of any C++/Python message-conversion machinery and fully deterministic.
+
+#include "autoware/pointcloud_preprocessor/distortion_corrector/distortion_corrector.hpp"
+
+#include <rclcpp/serialization.hpp>
+#include <rclcpp/serialized_message.hpp>
+
+#include <geometry_msgs/msg/transform_stamped.hpp>
+#include <geometry_msgs/msg/twist_with_covariance_stamped.hpp>
+#include <sensor_msgs/msg/imu.hpp>
+#include <sensor_msgs/msg/point_cloud2.hpp>
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include <cstring>
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+
+namespace py = pybind11;
+
+namespace
+{
+using autoware::pointcloud_preprocessor::AngleConversion;
+using autoware::pointcloud_preprocessor::DistortionCorrector2D;
+using autoware::pointcloud_preprocessor::DistortionCorrector3D;
+using autoware::pointcloud_preprocessor::DistortionCorrectorBase;
+using autoware::pointcloud_preprocessor::PointcloudValidity;
+using autoware::pointcloud_preprocessor::UndistortionResult;
+
+template <typename MsgT>
+MsgT deserialize(const py::bytes & data)
+{
+  const auto buffer = static_cast<std::string>(data);
+  rclcpp::SerializedMessage serialized(buffer.size());
+  auto & rcl_msg = serialized.get_rcl_serialized_message();
+  std::memcpy(rcl_msg.buffer, buffer.data(), buffer.size());
+  rcl_msg.buffer_length = buffer.size();
+
+  MsgT msg;
+  rclcpp::Serialization<MsgT>().deserialize_message(&serialized, &msg);
+  return msg;
+}
+
+template <typename MsgT>
+py::bytes serialize(const MsgT & msg)
+{
+  rclcpp::SerializedMessage serialized;
+  rclcpp::Serialization<MsgT>().serialize_message(&msg, &serialized);
+  const auto & rcl_msg = serialized.get_rcl_serialized_message();
+  return py::bytes(reinterpret_cast<const char *>(rcl_msg.buffer), rcl_msg.buffer_length);
+}
+
+// Mirrors the node's pointcloud_callback orchestration without any ROS runtime: holds the corrector
+// and the cached angle conversion, and converts serialized messages to/from the core's C++ types.
+class DistortionCorrectorWrapper
+{
+public:
+  explicit DistortionCorrectorWrapper(bool use_3d_distortion_correction)
+  {
+    if (use_3d_distortion_correction) {
+      corrector_ = std::make_unique<DistortionCorrector3D>();
+    } else {
+      corrector_ = std::make_unique<DistortionCorrector2D>();
+    }
+  }
+
+  void set_pointcloud_transform(const py::bytes & lidar_to_base_link)
+  {
+    corrector_->set_pointcloud_transform(
+      deserialize<geometry_msgs::msg::TransformStamped>(lidar_to_base_link));
+  }
+
+  void set_imu_transform(const py::bytes & imu_to_base_link)
+  {
+    corrector_->set_imu_transform(
+      deserialize<geometry_msgs::msg::TransformStamped>(imu_to_base_link));
+  }
+
+  void process_twist_message(const py::bytes & twist)
+  {
+    corrector_->process_twist_message(
+      std::make_shared<geometry_msgs::msg::TwistWithCovarianceStamped>(
+        deserialize<geometry_msgs::msg::TwistWithCovarianceStamped>(twist)));
+  }
+
+  void process_imu_message(const py::bytes & imu)
+  {
+    corrector_->process_imu_message(
+      std::make_shared<sensor_msgs::msg::Imu>(deserialize<sensor_msgs::msg::Imu>(imu)));
+  }
+
+  std::pair<py::bytes, UndistortionResult> undistort_pointcloud(
+    const py::bytes & pointcloud, bool use_imu, bool update_azimuth_and_distance)
+  {
+    auto cloud = deserialize<sensor_msgs::msg::PointCloud2>(pointcloud);
+
+    // Compute the Cartesian-to-azimuth conversion once and cache it, as the node does.
+    if (update_azimuth_and_distance && !angle_conversion_opt_.has_value()) {
+      angle_conversion_opt_ = corrector_->try_compute_angle_conversion(cloud);
+    }
+
+    const auto result = corrector_->undistort_pointcloud(
+      use_imu, update_azimuth_and_distance ? angle_conversion_opt_ : std::nullopt, cloud);
+    return {serialize(cloud), result};
+  }
+
+  [[nodiscard]] int get_timestamp_mismatch_count() const
+  {
+    return corrector_->get_timestamp_mismatch_count();
+  }
+
+  [[nodiscard]] double get_timestamp_mismatch_fraction() const
+  {
+    return corrector_->get_timestamp_mismatch_fraction();
+  }
+
+private:
+  std::unique_ptr<DistortionCorrectorBase> corrector_;
+  std::optional<AngleConversion> angle_conversion_opt_;
+};
+}  // namespace
+
+PYBIND11_MODULE(_distortion_corrector_pybind, m)
+{
+  m.doc() = "Python bindings for the autoware_pointcloud_preprocessor distortion corrector core.";
+
+  py::enum_<PointcloudValidity>(m, "PointcloudValidity")
+    .value("VALID", PointcloudValidity::kValid)
+    .value("EMPTY", PointcloudValidity::kEmpty)
+    .value("MISSING_TIME_STAMP_FIELD", PointcloudValidity::kMissingTimeStampField)
+    .value("INCOMPATIBLE_LAYOUT", PointcloudValidity::kIncompatibleLayout);
+
+  py::class_<UndistortionResult>(m, "UndistortionResult")
+    .def_readonly("validity", &UndistortionResult::validity)
+    .def_readonly("twist_queue_empty", &UndistortionResult::twist_queue_empty)
+    .def_readonly("twist_timestamp_too_late", &UndistortionResult::twist_timestamp_too_late)
+    .def_readonly("imu_timestamp_too_late", &UndistortionResult::imu_timestamp_too_late);
+
+  py::class_<DistortionCorrectorWrapper>(m, "DistortionCorrector")
+    .def(py::init<bool>(), py::arg("use_3d_distortion_correction") = false)
+    .def(
+      "set_pointcloud_transform", &DistortionCorrectorWrapper::set_pointcloud_transform,
+      py::arg("lidar_to_base_link"))
+    .def(
+      "set_imu_transform", &DistortionCorrectorWrapper::set_imu_transform,
+      py::arg("imu_to_base_link"))
+    .def(
+      "process_twist_message", &DistortionCorrectorWrapper::process_twist_message, py::arg("twist"))
+    .def("process_imu_message", &DistortionCorrectorWrapper::process_imu_message, py::arg("imu"))
+    .def(
+      "undistort_pointcloud", &DistortionCorrectorWrapper::undistort_pointcloud,
+      py::arg("pointcloud"), py::arg("use_imu") = true,
+      py::arg("update_azimuth_and_distance") = false)
+    .def_property_readonly(
+      "timestamp_mismatch_count", &DistortionCorrectorWrapper::get_timestamp_mismatch_count)
+    .def_property_readonly(
+      "timestamp_mismatch_fraction", &DistortionCorrectorWrapper::get_timestamp_mismatch_fraction);
+}

--- a/sensing/autoware_pointcloud_preprocessor/test/test_conversion.cpp
+++ b/sensing/autoware_pointcloud_preprocessor/test/test_conversion.cpp
@@ -1,0 +1,94 @@
+// Copyright 2024 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/pointcloud_preprocessor/utility/conversion.hpp"
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+
+namespace
+{
+using autoware::pointcloud_preprocessor::utils::to_eigen_matrix;
+using autoware::pointcloud_preprocessor::utils::to_nanoseconds;
+using autoware::pointcloud_preprocessor::utils::to_seconds;
+using autoware::pointcloud_preprocessor::utils::to_tf2_transform;
+
+geometry_msgs::msg::Transform make_transform(
+  double tx, double ty, double tz, double qx, double qy, double qz, double qw)
+{
+  geometry_msgs::msg::Transform transform;
+  transform.translation.x = tx;
+  transform.translation.y = ty;
+  transform.translation.z = tz;
+  transform.rotation.x = qx;
+  transform.rotation.y = qy;
+  transform.rotation.z = qz;
+  transform.rotation.w = qw;
+  return transform;
+}
+}  // namespace
+
+TEST(ConversionTest, ToNanoseconds)
+{
+  builtin_interfaces::msg::Time stamp;
+  stamp.sec = 10;
+  stamp.nanosec = 100000000;
+  EXPECT_EQ(to_nanoseconds(stamp), 10'100'000'000LL);
+
+  builtin_interfaces::msg::Time zero;
+  EXPECT_EQ(to_nanoseconds(zero), 0);
+}
+
+TEST(ConversionTest, ToSeconds)
+{
+  builtin_interfaces::msg::Time stamp;
+  stamp.sec = 10;
+  stamp.nanosec = 100000000;
+  EXPECT_NEAR(to_seconds(stamp), 10.1, 1e-9);
+}
+
+TEST(ConversionTest, ToTf2Transform)
+{
+  // Translation (1, 2, 3) and a +90 deg rotation about the z-axis.
+  const double s = std::sqrt(0.5);
+  const tf2::Transform tf = to_tf2_transform(make_transform(1.0, 2.0, 3.0, 0.0, 0.0, s, s));
+
+  EXPECT_NEAR(tf.getOrigin().x(), 1.0, 1e-9);
+  EXPECT_NEAR(tf.getOrigin().y(), 2.0, 1e-9);
+  EXPECT_NEAR(tf.getOrigin().z(), 3.0, 1e-9);
+
+  // The rotation alone maps the x-axis onto the y-axis.
+  const tf2::Vector3 rotated = tf.getBasis() * tf2::Vector3(1.0, 0.0, 0.0);
+  EXPECT_NEAR(rotated.x(), 0.0, 1e-6);
+  EXPECT_NEAR(rotated.y(), 1.0, 1e-6);
+  EXPECT_NEAR(rotated.z(), 0.0, 1e-6);
+}
+
+TEST(ConversionTest, ToEigenMatrix)
+{
+  // Translation (1, 2, 3) and a +90 deg rotation about the z-axis.
+  const double s = std::sqrt(0.5);
+  const Eigen::Matrix4f matrix = to_eigen_matrix(make_transform(1.0, 2.0, 3.0, 0.0, 0.0, s, s));
+
+  EXPECT_NEAR(matrix(0, 3), 1.0f, 1e-6f);
+  EXPECT_NEAR(matrix(1, 3), 2.0f, 1e-6f);
+  EXPECT_NEAR(matrix(2, 3), 3.0f, 1e-6f);
+
+  // (1, 0, 0) rotated by +90 deg about z is (0, 1, 0), then translated by (1, 2, 3) -> (1, 3, 3).
+  const Eigen::Vector4f transformed = matrix * Eigen::Vector4f(1.0f, 0.0f, 0.0f, 1.0f);
+  EXPECT_NEAR(transformed.x(), 1.0f, 1e-6f);
+  EXPECT_NEAR(transformed.y(), 3.0f, 1e-6f);
+  EXPECT_NEAR(transformed.z(), 3.0f, 1e-6f);
+}

--- a/sensing/autoware_pointcloud_preprocessor/test/test_distortion_corrector_node.cpp
+++ b/sensing/autoware_pointcloud_preprocessor/test/test_distortion_corrector_node.cpp
@@ -38,7 +38,6 @@
 #include <sensor_msgs/point_cloud2_iterator.hpp>
 
 #include <gtest/gtest.h>
-#include <tf2_ros/static_transform_broadcaster.h>
 
 #include <cassert>
 #include <memory>
@@ -54,21 +53,9 @@ protected:
   {
     node_ = std::make_shared<rclcpp::Node>("test_node");
     distortion_corrector_2d_ =
-      std::make_shared<autoware::pointcloud_preprocessor::DistortionCorrector2D>(*node_);
+      std::make_shared<autoware::pointcloud_preprocessor::DistortionCorrector2D>();
     distortion_corrector_3d_ =
-      std::make_shared<autoware::pointcloud_preprocessor::DistortionCorrector3D>(*node_);
-
-    // Setup TF
-    tf_broadcaster_ = std::make_shared<tf2_ros::StaticTransformBroadcaster>(node_);
-    tf_broadcaster_->sendTransform(generate_static_transform_msgs());
-
-    // Spin the node for a while to ensure transforms are published
-    auto start = std::chrono::steady_clock::now();
-    auto timeout = std::chrono::milliseconds(100);
-    while (std::chrono::steady_clock::now() - start < timeout) {
-      rclcpp::spin_some(node_);
-      std::this_thread::sleep_for(std::chrono::milliseconds(10));
-    }
+      std::make_shared<autoware::pointcloud_preprocessor::DistortionCorrector3D>();
   }
 
   void TearDown() override {}
@@ -108,12 +95,23 @@ protected:
     return tf_msg;
   }
 
-  static std::vector<geometry_msgs::msg::TransformStamped> generate_static_transform_msgs()
+  // Transforms previously looked up from TF and now injected directly into the corrector.
+  // The rotations are unit quaternions (as TF provides); the corrector assumes normalized input.
+  static geometry_msgs::msg::TransformStamped get_lidar_to_base_link_transform()
   {
-    // generate defined transformations
-    return {
-      generate_transform_msg("base_link", "lidar_top", 5.0, 5.0, 5.0, 0.683, 0.5, 0.183, 0.499),
-      generate_transform_msg("base_link", "imu_link", 1.0, 1.0, 3.0, 0.278, 0.717, 0.441, 0.453)};
+    return generate_transform_msg(
+      "base_link", "lidar_top", 5.0, 5.0, 5.0, 0.68334894, 0.50025545, 0.18309349, 0.49925493);
+  }
+
+  static geometry_msgs::msg::TransformStamped get_imu_to_base_link_transform()
+  {
+    return generate_transform_msg(
+      "base_link", "imu_link", 1.0, 1.0, 3.0, 0.27925063, 0.72022555, 0.44298392, 0.4550379);
+  }
+
+  static geometry_msgs::msg::TransformStamped get_base_link_transform()
+  {
+    return generate_transform_msg("base_link", "base_link", 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0);
   }
 
   static std::shared_ptr<geometry_msgs::msg::TwistWithCovarianceStamped> generate_twist_msg(
@@ -309,8 +307,9 @@ protected:
     const std::shared_ptr<T> & distortion_corrector, const rclcpp::Time & timestamp)
   {
     auto imu_msgs = generate_imu_msgs(timestamp);
+    distortion_corrector->set_imu_transform(get_imu_to_base_link_transform());
     for (const auto & imu_msg : imu_msgs) {
-      distortion_corrector->process_imu_message("base_link", imu_msg);
+      distortion_corrector->process_imu_message(imu_msg);
     }
   }
 
@@ -319,7 +318,6 @@ protected:
     distortion_corrector_2d_;
   std::shared_ptr<autoware::pointcloud_preprocessor::DistortionCorrector3D>
     distortion_corrector_3d_;
-  std::shared_ptr<tf2_ros::StaticTransformBroadcaster> tf_broadcaster_;
 
   static constexpr float standard_tolerance{1e-4};
   static constexpr float coarse_tolerance{5e-3};
@@ -364,7 +362,8 @@ TEST_F(DistortionCorrectorTest, TestProcessImuMessage)
 {
   rclcpp::Time timestamp(timestamp_seconds, timestamp_nanoseconds, RCL_ROS_TIME);
   auto imu_msg = generate_imu_msg(imu_angular_x, imu_angular_y, imu_angular_z, timestamp);
-  distortion_corrector_2d_->process_imu_message("base_link", imu_msg);
+  distortion_corrector_2d_->set_imu_transform(get_imu_to_base_link_transform());
+  distortion_corrector_2d_->process_imu_message(imu_msg);
 
   ASSERT_FALSE(distortion_corrector_2d_->get_angular_velocity_queue().empty());
   EXPECT_NEAR(
@@ -372,41 +371,34 @@ TEST_F(DistortionCorrectorTest, TestProcessImuMessage)
     standard_tolerance);
 }
 
-TEST_F(DistortionCorrectorTest, TestIsPointcloudValid)
+TEST_F(DistortionCorrectorTest, TestCheckPointcloudValidity)
 {
   rclcpp::Time timestamp(timestamp_seconds, timestamp_nanoseconds, RCL_ROS_TIME);
 
   auto [default_points, default_azimuths] =
     generate_default_pointcloud(AngleCoordinateSystem::CARTESIAN);
   auto pointcloud = generate_pointcloud_msg(false, timestamp, default_points, default_azimuths);
-  auto result = distortion_corrector_2d_->is_pointcloud_valid(pointcloud);
-  EXPECT_TRUE(result);
+  auto result = distortion_corrector_2d_->check_pointcloud_validity(pointcloud);
+  EXPECT_EQ(result, autoware::pointcloud_preprocessor::PointcloudValidity::kValid);
 
   // input empty pointcloud
   auto empty_pointcloud = generate_empty_pointcloud_msg(timestamp);
-  result = distortion_corrector_2d_->is_pointcloud_valid(empty_pointcloud);
-  EXPECT_FALSE(result);
+  result = distortion_corrector_2d_->check_pointcloud_validity(empty_pointcloud);
+  EXPECT_EQ(result, autoware::pointcloud_preprocessor::PointcloudValidity::kEmpty);
 }
 
 TEST_F(DistortionCorrectorTest, TestSetPointcloudTransformWithBaseLink)
 {
-  distortion_corrector_2d_->set_pointcloud_transform("base_link", "base_link");
+  distortion_corrector_2d_->set_pointcloud_transform(get_base_link_transform());
   EXPECT_TRUE(distortion_corrector_2d_->pointcloud_transform_exists());
   EXPECT_FALSE(distortion_corrector_2d_->pointcloud_transform_needed());
 }
 
 TEST_F(DistortionCorrectorTest, TestSetPointcloudTransformWithLidarFrame)
 {
-  distortion_corrector_2d_->set_pointcloud_transform("base_link", "lidar_top");
+  distortion_corrector_2d_->set_pointcloud_transform(get_lidar_to_base_link_transform());
   EXPECT_TRUE(distortion_corrector_2d_->pointcloud_transform_exists());
   EXPECT_TRUE(distortion_corrector_2d_->pointcloud_transform_needed());
-}
-
-TEST_F(DistortionCorrectorTest, TestSetPointcloudTransformWithMissingFrame)
-{
-  distortion_corrector_2d_->set_pointcloud_transform("base_link", "missing_lidar_frame");
-  EXPECT_FALSE(distortion_corrector_2d_->pointcloud_transform_exists());
-  EXPECT_FALSE(distortion_corrector_2d_->pointcloud_transform_needed());
 }
 
 TEST_F(DistortionCorrectorTest, TestUndistortPointcloudWithEmptyTwist)
@@ -480,7 +472,7 @@ TEST_F(DistortionCorrectorTest, TestUndistortPointcloud2dWithoutImuInBaseLink)
 
   // Test using only twist
   distortion_corrector_2d_->initialize();
-  distortion_corrector_2d_->set_pointcloud_transform("base_link", "base_link");
+  distortion_corrector_2d_->set_pointcloud_transform(get_base_link_transform());
   distortion_corrector_2d_->undistort_pointcloud(false, std::nullopt, pointcloud);
 
   sensor_msgs::PointCloud2ConstIterator<float> iter_x(pointcloud, "x");
@@ -528,7 +520,7 @@ TEST_F(DistortionCorrectorTest, TestUndistortPointcloud2dWithImuInBaseLink)
   generate_and_process_imu_msgs(distortion_corrector_2d_, timestamp);
 
   distortion_corrector_2d_->initialize();
-  distortion_corrector_2d_->set_pointcloud_transform("base_link", "base_link");
+  distortion_corrector_2d_->set_pointcloud_transform(get_base_link_transform());
   distortion_corrector_2d_->undistort_pointcloud(true, std::nullopt, pointcloud);
 
   sensor_msgs::PointCloud2ConstIterator<float> iter_x(pointcloud, "x");
@@ -576,7 +568,7 @@ TEST_F(DistortionCorrectorTest, TestUndistortPointcloud2dWithImuInLidarFrame)
   generate_and_process_imu_msgs(distortion_corrector_2d_, timestamp);
 
   distortion_corrector_2d_->initialize();
-  distortion_corrector_2d_->set_pointcloud_transform("base_link", "lidar_top");
+  distortion_corrector_2d_->set_pointcloud_transform(get_lidar_to_base_link_transform());
   distortion_corrector_2d_->undistort_pointcloud(true, std::nullopt, pointcloud);
 
   sensor_msgs::PointCloud2ConstIterator<float> iter_x(pointcloud, "x");
@@ -625,7 +617,7 @@ TEST_F(DistortionCorrectorTest, TestUndistortPointcloud3dWithoutImuInBaseLink)
 
   // Test using only twist
   distortion_corrector_3d_->initialize();
-  distortion_corrector_3d_->set_pointcloud_transform("base_link", "base_link");
+  distortion_corrector_3d_->set_pointcloud_transform(get_base_link_transform());
   distortion_corrector_3d_->undistort_pointcloud(false, std::nullopt, pointcloud);
 
   sensor_msgs::PointCloud2ConstIterator<float> iter_x(pointcloud, "x");
@@ -673,7 +665,7 @@ TEST_F(DistortionCorrectorTest, TestUndistortPointcloud3dWithImuInBaseLink)
   generate_and_process_imu_msgs(distortion_corrector_3d_, timestamp);
 
   distortion_corrector_3d_->initialize();
-  distortion_corrector_3d_->set_pointcloud_transform("base_link", "base_link");
+  distortion_corrector_3d_->set_pointcloud_transform(get_base_link_transform());
   distortion_corrector_3d_->undistort_pointcloud(true, std::nullopt, pointcloud);
 
   sensor_msgs::PointCloud2ConstIterator<float> iter_x(pointcloud, "x");
@@ -724,7 +716,7 @@ TEST_F(DistortionCorrectorTest, TestUndistortPointcloud3dWithImuInLidarFrame)
   generate_and_process_imu_msgs(distortion_corrector_3d_, timestamp);
 
   distortion_corrector_3d_->initialize();
-  distortion_corrector_3d_->set_pointcloud_transform("base_link", "lidar_top");
+  distortion_corrector_3d_->set_pointcloud_transform(get_lidar_to_base_link_transform());
   distortion_corrector_3d_->undistort_pointcloud(true, std::nullopt, pointcloud);
 
   sensor_msgs::PointCloud2ConstIterator<float> iter_x(pointcloud, "x");
@@ -774,12 +766,12 @@ TEST_F(DistortionCorrectorTest, TestUndistortPointcloudWithPureLinearMotion)
 
   distortion_corrector_2d_->process_twist_message(twist_msg);
   distortion_corrector_2d_->initialize();
-  distortion_corrector_2d_->set_pointcloud_transform("base_link", "base_link");
+  distortion_corrector_2d_->set_pointcloud_transform(get_base_link_transform());
   distortion_corrector_2d_->undistort_pointcloud(false, std::nullopt, test2d_pointcloud);
 
   distortion_corrector_3d_->process_twist_message(twist_msg);
   distortion_corrector_3d_->initialize();
-  distortion_corrector_3d_->set_pointcloud_transform("base_link", "base_link");
+  distortion_corrector_3d_->set_pointcloud_transform(get_base_link_transform());
   distortion_corrector_3d_->undistort_pointcloud(false, std::nullopt, test3d_pointcloud);
 
   // Generate expected point cloud for testing
@@ -867,12 +859,12 @@ TEST_F(DistortionCorrectorTest, TestUndistortPointcloudWithPureRotationalMotion)
 
   distortion_corrector_2d_->process_twist_message(twist_msg);
   distortion_corrector_2d_->initialize();
-  distortion_corrector_2d_->set_pointcloud_transform("base_link", "base_link");
+  distortion_corrector_2d_->set_pointcloud_transform(get_base_link_transform());
   distortion_corrector_2d_->undistort_pointcloud(false, std::nullopt, test2d_pointcloud);
 
   distortion_corrector_3d_->process_twist_message(twist_msg);
   distortion_corrector_3d_->initialize();
-  distortion_corrector_3d_->set_pointcloud_transform("base_link", "base_link");
+  distortion_corrector_3d_->set_pointcloud_transform(get_base_link_transform());
   distortion_corrector_3d_->undistort_pointcloud(false, std::nullopt, test3d_pointcloud);
 
   // Generate expected point cloud for testing
@@ -975,7 +967,7 @@ TEST_F(DistortionCorrectorTest, TestUndistortPointcloudNotUpdatingAzimuthAndDist
   generate_and_process_imu_msgs(distortion_corrector_2d_, timestamp);
 
   distortion_corrector_2d_->initialize();
-  distortion_corrector_2d_->set_pointcloud_transform("base_link", "base_link");
+  distortion_corrector_2d_->set_pointcloud_transform(get_base_link_transform());
   auto angle_conversion_opt =
     distortion_corrector_2d_->try_compute_angle_conversion(pointcloud_base_link);
 
@@ -1002,7 +994,7 @@ TEST_F(DistortionCorrectorTest, TestUndistortPointcloudNotUpdatingAzimuthAndDist
   generate_and_process_imu_msgs(distortion_corrector_2d_, timestamp);
 
   distortion_corrector_2d_->initialize();
-  distortion_corrector_2d_->set_pointcloud_transform("base_link", "lidar_top");
+  distortion_corrector_2d_->set_pointcloud_transform(get_lidar_to_base_link_transform());
 
   angle_conversion_opt = std::nullopt;
   distortion_corrector_2d_->undistort_pointcloud(true, angle_conversion_opt, pointcloud_lidar_top);
@@ -1057,7 +1049,7 @@ TEST_F(DistortionCorrectorTest, TestUndistortPointcloudUpdateAzimuthAndDistanceI
   generate_and_process_imu_msgs(distortion_corrector_2d_, timestamp);
 
   distortion_corrector_2d_->initialize();
-  distortion_corrector_2d_->set_pointcloud_transform("base_link", "lidar_top");
+  distortion_corrector_2d_->set_pointcloud_transform(get_lidar_to_base_link_transform());
 
   auto angle_conversion_opt = distortion_corrector_2d_->try_compute_angle_conversion(pointcloud);
   distortion_corrector_2d_->undistort_pointcloud(true, angle_conversion_opt, pointcloud);
@@ -1118,7 +1110,7 @@ TEST_F(DistortionCorrectorTest, TestUndistortPointcloudUpdateAzimuthAndDistanceI
   generate_and_process_imu_msgs(distortion_corrector_2d_, timestamp);
 
   distortion_corrector_2d_->initialize();
-  distortion_corrector_2d_->set_pointcloud_transform("base_link", "lidar_top");
+  distortion_corrector_2d_->set_pointcloud_transform(get_lidar_to_base_link_transform());
 
   auto angle_conversion_opt = distortion_corrector_2d_->try_compute_angle_conversion(pointcloud);
   distortion_corrector_2d_->undistort_pointcloud(true, angle_conversion_opt, pointcloud);

--- a/sensing/autoware_pointcloud_preprocessor/test/test_distortion_corrector_py.py
+++ b/sensing/autoware_pointcloud_preprocessor/test/test_distortion_corrector_py.py
@@ -1,0 +1,144 @@
+# Copyright 2024 TIER IV, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import struct
+
+from autoware_pointcloud_preprocessor.distortion_corrector import DistortionCorrector
+from autoware_pointcloud_preprocessor.distortion_corrector import PointcloudValidity
+from geometry_msgs.msg import TransformStamped
+from geometry_msgs.msg import TwistWithCovarianceStamped
+from sensor_msgs.msg import PointCloud2
+from sensor_msgs.msg import PointField
+
+# PointXYZIRCAEDT layout (matches the C++ unit test): 10 fields, point_step = 32, no padding.
+_POINT_STEP = 32
+_FIELDS = [
+    PointField(name="x", offset=0, datatype=PointField.FLOAT32, count=1),
+    PointField(name="y", offset=4, datatype=PointField.FLOAT32, count=1),
+    PointField(name="z", offset=8, datatype=PointField.FLOAT32, count=1),
+    PointField(name="intensity", offset=12, datatype=PointField.UINT8, count=1),
+    PointField(name="return_type", offset=13, datatype=PointField.UINT8, count=1),
+    PointField(name="channel", offset=14, datatype=PointField.UINT16, count=1),
+    PointField(name="azimuth", offset=16, datatype=PointField.FLOAT32, count=1),
+    PointField(name="elevation", offset=20, datatype=PointField.FLOAT32, count=1),
+    PointField(name="distance", offset=24, datatype=PointField.FLOAT32, count=1),
+    PointField(name="time_stamp", offset=28, datatype=PointField.UINT32, count=1),
+]
+
+_CLOUD_SEC = 10
+_CLOUD_NANOSEC = 100_000_000
+_POINT_INTERVAL_NS = 10_000_000  # 10 ms
+
+
+def _make_pointcloud(points):
+    msg = PointCloud2()
+    msg.header.stamp.sec = _CLOUD_SEC
+    msg.header.stamp.nanosec = _CLOUD_NANOSEC
+    msg.header.frame_id = "base_link"
+    msg.height = 1
+    msg.width = len(points)
+    msg.fields = _FIELDS
+    msg.is_bigendian = False
+    msg.point_step = _POINT_STEP
+    msg.row_step = _POINT_STEP * len(points)
+    msg.is_dense = True
+
+    data = bytearray()
+    for i, (x, y, z) in enumerate(points):
+        distance = (x * x + y * y + z * z) ** 0.5
+        time_stamp = i * _POINT_INTERVAL_NS
+        data += struct.pack("<fffBBHfffI", x, y, z, 0, 0, 0, 0.0, 0.0, distance, time_stamp)
+    msg.data = bytes(data)
+    return msg
+
+
+def _read_xyz(msg):
+    return [struct.unpack_from("<fff", msg.data, i * msg.point_step) for i in range(msg.width)]
+
+
+def _identity_transform(child_frame_id):
+    tf = TransformStamped()
+    tf.header.frame_id = "base_link"
+    tf.child_frame_id = child_frame_id
+    tf.transform.rotation.w = 1.0
+    return tf
+
+
+def _make_twist(sec, nanosec, linear_x=10.0, angular_z=0.02):
+    twist = TwistWithCovarianceStamped()
+    twist.header.stamp.sec = sec
+    twist.header.stamp.nanosec = nanosec
+    twist.header.frame_id = "base_link"
+    twist.twist.twist.linear.x = linear_x
+    twist.twist.twist.angular.z = angular_z
+    return twist
+
+
+_DEFAULT_POINTS = [
+    (10.0, 0.0, 1.0),
+    (5.0, -5.0, 2.0),
+    (0.0, -10.0, 3.0),
+    (-5.0, -5.0, 4.0),
+    (-10.0, 0.0, 5.0),
+]
+
+
+def _feed_twists(corrector):
+    # Twist stamps spanning the point times (10.10 .. 10.14 s).
+    for ms in (95, 110, 125, 140, 155):
+        corrector.process_twist_message(_make_twist(_CLOUD_SEC, 90_000_000 + ms * 1_000_000))
+
+
+def test_empty_pointcloud_reports_empty():
+    corrector = DistortionCorrector()
+    empty = _make_pointcloud([])
+    _, status = corrector.undistort_pointcloud(empty, use_imu=False)
+    assert status.validity == PointcloudValidity.EMPTY
+
+
+def test_empty_twist_queue_leaves_cloud_unchanged():
+    corrector = DistortionCorrector()
+    corrector.set_pointcloud_transform(_identity_transform("base_link"))
+    cloud = _make_pointcloud(_DEFAULT_POINTS)
+    out, status = corrector.undistort_pointcloud(cloud, use_imu=False)
+
+    assert status.validity == PointcloudValidity.VALID
+    assert status.twist_queue_empty is True
+    assert _read_xyz(out) == _read_xyz(cloud)
+
+
+def test_undistortion_changes_points_2d():
+    corrector = DistortionCorrector(use_3d_distortion_correction=False)
+    corrector.set_pointcloud_transform(_identity_transform("base_link"))
+    _feed_twists(corrector)
+
+    cloud = _make_pointcloud(_DEFAULT_POINTS)
+    out, status = corrector.undistort_pointcloud(cloud, use_imu=False)
+
+    assert status.validity == PointcloudValidity.VALID
+    assert status.twist_queue_empty is False
+    # Later points accumulate motion correction, so at least one point must move.
+    assert _read_xyz(out) != _read_xyz(cloud)
+
+
+def test_undistortion_runs_3d():
+    corrector = DistortionCorrector(use_3d_distortion_correction=True)
+    corrector.set_pointcloud_transform(_identity_transform("base_link"))
+    _feed_twists(corrector)
+
+    cloud = _make_pointcloud(_DEFAULT_POINTS)
+    out, status = corrector.undistort_pointcloud(cloud, use_imu=False)
+
+    assert status.validity == PointcloudValidity.VALID
+    assert _read_xyz(out) != _read_xyz(cloud)


### PR DESCRIPTION
## Description
Adds the inverse of `to_nanoseconds`: convert an absolute time in integer nanoseconds back to a
`builtin_interfaces::msg::Time` header stamp.

This is the small building block needed by the upcoming ROS-runtime-free concatenation core, which
sets output stamps from integer-nanosecond time without `rclcpp::Time`.

* Note that this work is based on Max's distortion correction implementation
* https://github.com/autowarefoundation/autoware_universe/pull/12811
* https://github.com/autowarefoundation/autoware_universe/pull/12795
* https://github.com/mojomex/autoware_universe/pull/10


## Related links
* Next PR: https://github.com/autowarefoundation/autoware_universe/pull/12874


**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->


## How was this PR tested?

- `colcon build --packages-select autoware_pointcloud_preprocessor`
- `colcon test --packages-select autoware_pointcloud_preprocessor` — runs the new
  pybind-backed `test_concatenate_pointclouds_py` (checks the offline concatenator
  matches expected grouping/timeout behavior) and the C++ tests.

## Notes for reviewers

Additive only — no existing ROS node code path changes. New surface is the
`concatenate_core` build target, the pybind module, and the `autoware_pointcloud_preprocessor`
Python package. Adds an `rclpy` exec-dependency for the offline driver.

## Interface changes

None on the ROS side (no topic/parameter changes). Adds a Python API
(`autoware_pointcloud_preprocessor.concatenate_pointclouds`).


<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
