### PR TITLE
refactor(autoware_traffic_light_arbiter): consolidate external snapshot in arbitrate()

### DIFF
--- a/perception/autoware_traffic_light_arbiter/src/traffic_light_arbiter_core.cpp
+++ b/perception/autoware_traffic_light_arbiter/src/traffic_light_arbiter_core.cpp
@@ -35,11 +35,39 @@ namespace
 using autoware_perception_msgs::msg::PredictedTrafficLightState;
 using autoware_perception_msgs::msg::TrafficLightElement;
 using autoware_perception_msgs::msg::TrafficLightGroup;
+using autoware_perception_msgs::msg::TrafficLightGroupArray;
 
 // One element paired with whether it came from the prioritized source.
 // Accumulated per regulatory-element id while routing signals, then reduced to
 // one element per shape by get_highest_confidence_elements().
 using ElementAndPriority = std::pair<TrafficLightElement, bool>;
+
+// Snapshot of the stored external signals plus the freshest stamp among them.
+// The perception-staleness check and latest_input_time both derive from
+// max_stamp/has_any, so they read from one source of truth.
+struct ExternalSnapshot
+{
+  TrafficLightGroupArray signals;
+  rclcpp::Time max_stamp{0, 0, RCL_ROS_TIME};
+  bool has_any = false;
+};
+
+// Builds the external-signal array and tracks the freshest stamp in one pass
+// over the per-id external cache.
+ExternalSnapshot collect_external_snapshot(
+  const std::unordered_map<lanelet::Id, std::pair<rclcpp::Time, TrafficLightGroup>> &
+    external_traffic_lights)
+{
+  ExternalSnapshot snapshot;
+  for (const auto & [id, info] : external_traffic_lights) {
+    snapshot.signals.traffic_light_groups.emplace_back(info.second);
+    if (!snapshot.has_any || info.first > snapshot.max_stamp) {
+      snapshot.max_stamp = info.first;
+      snapshot.has_any = true;
+    }
+  }
+  return snapshot;
+}
 
 // Appends each group's predictions into predictions_map keyed by
 // regulatory-element id. Predictions accumulate across sources in call order.
@@ -71,6 +99,18 @@ void route_signal(
   auto & elements_and_priority = signals_map[id];
   for (const auto & element : signal.elements) {
     elements_and_priority.emplace_back(element, priority);
+  }
+}
+
+// Routes every signal in `signals` into `signals_map` via route_signal().
+void route_signals(
+  const std::vector<TrafficLightGroup> & signals, bool priority,
+  const std::unordered_set<lanelet::Id> & map_regulatory_elements,
+  std::unordered_map<lanelet::Id, std::vector<ElementAndPriority>> & signals_map,
+  std::vector<lanelet::Id> & off_map_signal_ids)
+{
+  for (const auto & signal : signals) {
+    route_signal(signal, priority, map_regulatory_elements, signals_map, off_map_signal_ids);
   }
 }
 
@@ -219,25 +259,15 @@ TrafficLightArbiterCore::ArbitrationResult TrafficLightArbiterCore::arbitrate() 
 
   std::unordered_map<lanelet::Id, std::vector<ElementAndPriority>> regulatory_element_signals_map;
 
-  // Create external signals array from stored valid signals, tracking the
-  // freshest external stamp for the perception-staleness check below.
-  TrafficSignalArray valid_external_signals;
-  rclcpp::Time max_external_stamp{0, 0, RCL_ROS_TIME};
-  bool has_externals = false;
-  for (const auto & [id, info] : external_traffic_lights_) {
-    valid_external_signals.traffic_light_groups.emplace_back(info.second);
-    if (!has_externals || info.first > max_external_stamp) {
-      max_external_stamp = info.first;
-      has_externals = true;
-    }
-  }
+  const auto external = collect_external_snapshot(external_traffic_lights_);
 
   // Ignore perception for this cycle when it lags the freshest external by
   // more than perception_time_tolerance_. Done as a non-destructive view so
   // ingest_perception() remains the sole writer of latest_perception_msg_.
   const auto perception_stamp = rclcpp::Time(latest_perception_msg_.stamp);
   const bool perception_is_stale =
-    has_externals && (max_external_stamp - perception_stamp).seconds() > perception_time_tolerance_;
+    external.has_any &&
+    (external.max_stamp - perception_stamp).seconds() > perception_time_tolerance_;
   TrafficSignalArray empty_perception;
   empty_perception.stamp = latest_perception_msg_.stamp;
   const auto & effective_perception =
@@ -246,7 +276,7 @@ TrafficLightArbiterCore::ArbitrationResult TrafficLightArbiterCore::arbitrate() 
   std::unordered_map<lanelet::Id, std::vector<PredictedTrafficLightState>> predictions_map;
   // add in order from perception msg
   append_predictions(predictions_map, effective_perception.traffic_light_groups);
-  append_predictions(predictions_map, valid_external_signals.traffic_light_groups);
+  append_predictions(predictions_map, external.signals.traffic_light_groups);
 
   if (map_regulatory_elements_set_ == nullptr) {
     return result;
@@ -263,24 +293,17 @@ TrafficLightArbiterCore::ArbitrationResult TrafficLightArbiterCore::arbitrate() 
   const auto & map_regulatory_elements = *map_regulatory_elements_set_;
   if (enable_signal_matching_) {
     const auto validated_signals =
-      signal_match_validator_->validate_signals(effective_perception, valid_external_signals);
-    for (const auto & signal : validated_signals.traffic_light_groups) {
-      route_signal(
-        signal, false, map_regulatory_elements, regulatory_element_signals_map,
-        result.off_map_signal_ids);
-    }
+      signal_match_validator_->validate_signals(effective_perception, external.signals);
+    route_signals(
+      validated_signals.traffic_light_groups, false, map_regulatory_elements,
+      regulatory_element_signals_map, result.off_map_signal_ids);
   } else {
-    for (const auto & signal : effective_perception.traffic_light_groups) {
-      route_signal(
-        signal, source_priority_ == SourcePriority::PERCEPTION, map_regulatory_elements,
-        regulatory_element_signals_map, result.off_map_signal_ids);
-    }
-
-    for (const auto & signal : valid_external_signals.traffic_light_groups) {
-      route_signal(
-        signal, source_priority_ == SourcePriority::EXTERNAL, map_regulatory_elements,
-        regulatory_element_signals_map, result.off_map_signal_ids);
-    }
+    route_signals(
+      effective_perception.traffic_light_groups, source_priority_ == SourcePriority::PERCEPTION,
+      map_regulatory_elements, regulatory_element_signals_map, result.off_map_signal_ids);
+    route_signals(
+      external.signals.traffic_light_groups, source_priority_ == SourcePriority::EXTERNAL,
+      map_regulatory_elements, regulatory_element_signals_map, result.off_map_signal_ids);
   }
 
   output_signals_msg.traffic_light_groups.reserve(regulatory_element_signals_map.size());
@@ -296,8 +319,8 @@ TrafficLightArbiterCore::ArbitrationResult TrafficLightArbiterCore::arbitrate() 
   // Latest input stamp across stored sources. The Node compares this against
   // its trigger stamp to decide whether the published output is behind some
   // input that has arrived but hasn't yet driven a publish cycle.
-  result.latest_input_time = (has_externals && max_external_stamp > perception_stamp)
-                               ? max_external_stamp
+  result.latest_input_time = (external.has_any && external.max_stamp > perception_stamp)
+                               ? external.max_stamp
                                : perception_stamp;
 
   result.output = std::move(output_signals_msg);


### PR DESCRIPTION
## Description

Readability refactor of `TrafficLightArbiterCore::arbitrate()` — no behavior change.

The body previously hand-rolled the external-signal aggregation: a loop that simultaneously built the signals array, tracked the freshest stamp with a running max, and set a `has_externals` flag. That same "freshest external stamp" logic was then **recomputed** at the bottom for `latest_input_time`, so there was no single source of truth.

Changes (anonymous-namespace helpers in `traffic_light_arbiter_core.cpp`):

- Add `struct ExternalSnapshot { signals; max_stamp; has_any; }` and `collect_external_snapshot()`. The snapshot is built once; the perception-staleness check and `latest_input_time` now both read `external.max_stamp` / `external.has_any` instead of recomputing the max.
- Add `route_signals()` — routes a whole array via the existing `route_signal()` — and use it to fold the two inner `for` loops in the matching/priority dispatch. The policy decision (which priority flag, whether to validate) stays in `arbitrate()`.

`effective_perception` remains a non-destructive const-ref view (no per-cycle copy). Routing and accumulation semantics are unchanged.

## How was this PR tested?

- `colcon build --packages-select autoware_traffic_light_arbiter` — passes.
- `colcon test ... -R autoware_traffic_light_arbiter_core_test` — 39/39 pass, unchanged (the refactor is behavior-preserving; no test was modified).
- pre-commit hooks (clang-format / cpplint) pass.

## Notes for reviewers

Follow-up to the include/alias cleanup (already merged). Pure structural change scoped to a single file.
