### PR TITLE
test(autoware_traffic_light_category_merger): decouple merge core from node and add tests

### DIFF
--- a/perception/autoware_traffic_light_category_merger/CMakeLists.txt
+++ b/perception/autoware_traffic_light_category_merger/CMakeLists.txt
@@ -7,6 +7,7 @@ autoware_package()
 
 # Targets
 ament_auto_add_library(${PROJECT_NAME} SHARED
+  src/traffic_light_category_merger.cpp
   src/traffic_light_category_merger_node.cpp
 )
 

--- a/perception/autoware_traffic_light_category_merger/CMakeLists.txt
+++ b/perception/autoware_traffic_light_category_merger/CMakeLists.txt
@@ -18,6 +18,14 @@ rclcpp_components_register_node(${PROJECT_NAME}
 if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)
 
+  # ROS-free unit tests for the merge core.
+  ament_auto_add_gtest(test_traffic_light_category_merger
+    test/test_traffic_light_category_merger.cpp
+  )
+  target_link_libraries(test_traffic_light_category_merger
+    ${PROJECT_NAME}
+  )
+
   # Node-level integration tests (topic-driven pub/sub + sync).
   ament_add_ros_isolated_gtest(test_traffic_light_category_merger_integration
     test/test_traffic_light_category_merger_integration.cpp

--- a/perception/autoware_traffic_light_category_merger/CMakeLists.txt
+++ b/perception/autoware_traffic_light_category_merger/CMakeLists.txt
@@ -14,6 +14,18 @@ rclcpp_components_register_node(${PROJECT_NAME}
   PLUGIN "autoware::traffic_light::TrafficLightCategoryMergerNode"
   EXECUTABLE traffic_light_category_merger_node)
 
+if(BUILD_TESTING)
+  find_package(ament_cmake_gtest REQUIRED)
+
+  # Node-level integration tests (topic-driven pub/sub + sync).
+  ament_add_ros_isolated_gtest(test_traffic_light_category_merger_integration
+    test/test_traffic_light_category_merger_integration.cpp
+  )
+  target_link_libraries(test_traffic_light_category_merger_integration
+    ${PROJECT_NAME}
+  )
+endif()
+
 ament_auto_package(
   INSTALL_TO_SHARE
   launch

--- a/perception/autoware_traffic_light_category_merger/package.xml
+++ b/perception/autoware_traffic_light_category_merger/package.xml
@@ -22,6 +22,9 @@
   <depend>tier4_perception_msgs</depend>
   <build_depend>autoware_cmake</build_depend>
 
+  <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>ament_cmake_ros</test_depend>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/perception/autoware_traffic_light_category_merger/src/traffic_light_category_merger.cpp
+++ b/perception/autoware_traffic_light_category_merger/src/traffic_light_category_merger.cpp
@@ -1,4 +1,4 @@
-// Copyright 2025 TIER IV, Inc.
+// Copyright 2026 TIER IV, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/perception/autoware_traffic_light_category_merger/src/traffic_light_category_merger.cpp
+++ b/perception/autoware_traffic_light_category_merger/src/traffic_light_category_merger.cpp
@@ -1,0 +1,32 @@
+// Copyright 2025 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "traffic_light_category_merger.hpp"
+
+namespace autoware::traffic_light
+{
+
+TrafficLightArray TrafficLightCategoryMerger::merge(
+  const TrafficLightArray & car_signals, const TrafficLightArray & pedestrian_signals) const
+{
+  TrafficLightArray output;
+  output.header = car_signals.header;
+  output.signals.insert(
+    output.signals.end(), car_signals.signals.begin(), car_signals.signals.end());
+  output.signals.insert(
+    output.signals.end(), pedestrian_signals.signals.begin(), pedestrian_signals.signals.end());
+  return output;
+}
+
+}  // namespace autoware::traffic_light

--- a/perception/autoware_traffic_light_category_merger/src/traffic_light_category_merger.cpp
+++ b/perception/autoware_traffic_light_category_merger/src/traffic_light_category_merger.cpp
@@ -18,7 +18,7 @@ namespace autoware::traffic_light
 {
 
 TrafficLightArray TrafficLightCategoryMerger::merge(
-  const TrafficLightArray & car_signals, const TrafficLightArray & pedestrian_signals) const
+  const TrafficLightArray & car_signals, const TrafficLightArray & pedestrian_signals)
 {
   TrafficLightArray output;
   output.header = car_signals.header;

--- a/perception/autoware_traffic_light_category_merger/src/traffic_light_category_merger.hpp
+++ b/perception/autoware_traffic_light_category_merger/src/traffic_light_category_merger.hpp
@@ -1,4 +1,4 @@
-// Copyright 2025 TIER IV, Inc.
+// Copyright 2026 TIER IV, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/perception/autoware_traffic_light_category_merger/src/traffic_light_category_merger.hpp
+++ b/perception/autoware_traffic_light_category_merger/src/traffic_light_category_merger.hpp
@@ -25,13 +25,13 @@ using tier4_perception_msgs::msg::TrafficLightArray;
 ///
 /// Concatenates the car and pedestrian traffic-light arrays into a single array.
 /// The result carries the car array's header, followed by the car signals and
-/// then the pedestrian signals. This holds no state, so a single instance can be
-/// shared across callbacks.
+/// then the pedestrian signals. The merge holds no state, so it is exposed as a
+/// static function.
 class TrafficLightCategoryMerger
 {
 public:
-  TrafficLightArray merge(
-    const TrafficLightArray & car_signals, const TrafficLightArray & pedestrian_signals) const;
+  static TrafficLightArray merge(
+    const TrafficLightArray & car_signals, const TrafficLightArray & pedestrian_signals);
 };
 
 }  // namespace autoware::traffic_light

--- a/perception/autoware_traffic_light_category_merger/src/traffic_light_category_merger.hpp
+++ b/perception/autoware_traffic_light_category_merger/src/traffic_light_category_merger.hpp
@@ -1,0 +1,39 @@
+// Copyright 2025 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef TRAFFIC_LIGHT_CATEGORY_MERGER_HPP_
+#define TRAFFIC_LIGHT_CATEGORY_MERGER_HPP_
+
+#include <tier4_perception_msgs/msg/traffic_light_array.hpp>
+
+namespace autoware::traffic_light
+{
+using tier4_perception_msgs::msg::TrafficLightArray;
+
+/// ROS-free core of the category merger.
+///
+/// Concatenates the car and pedestrian traffic-light arrays into a single array.
+/// The result carries the car array's header, followed by the car signals and
+/// then the pedestrian signals. This holds no state, so a single instance can be
+/// shared across callbacks.
+class TrafficLightCategoryMerger
+{
+public:
+  TrafficLightArray merge(
+    const TrafficLightArray & car_signals, const TrafficLightArray & pedestrian_signals) const;
+};
+
+}  // namespace autoware::traffic_light
+
+#endif  // TRAFFIC_LIGHT_CATEGORY_MERGER_HPP_

--- a/perception/autoware_traffic_light_category_merger/src/traffic_light_category_merger_node.cpp
+++ b/perception/autoware_traffic_light_category_merger/src/traffic_light_category_merger_node.cpp
@@ -15,8 +15,6 @@
 #include "traffic_light_category_merger_node.hpp"
 
 #include <memory>
-#include <string>
-#include <vector>
 
 namespace autoware::traffic_light
 {

--- a/perception/autoware_traffic_light_category_merger/src/traffic_light_category_merger_node.cpp
+++ b/perception/autoware_traffic_light_category_merger/src/traffic_light_category_merger_node.cpp
@@ -38,7 +38,8 @@ void TrafficLightCategoryMergerNode::signals_callback(
   const TrafficLightArray::ConstSharedPtr & car_signals_msg,
   const TrafficLightArray::ConstSharedPtr & pedestrian_signals_msg)
 {
-  const TrafficLightArray output = merger_.merge(*car_signals_msg, *pedestrian_signals_msg);
+  const TrafficLightArray output =
+    TrafficLightCategoryMerger::merge(*car_signals_msg, *pedestrian_signals_msg);
   pub_traffic_light_signals_->publish(output);
 }
 

--- a/perception/autoware_traffic_light_category_merger/src/traffic_light_category_merger_node.cpp
+++ b/perception/autoware_traffic_light_category_merger/src/traffic_light_category_merger_node.cpp
@@ -30,12 +30,13 @@ TrafficLightCategoryMergerNode::TrafficLightCategoryMergerNode(
 {
   using std::placeholders::_1;
   using std::placeholders::_2;
-  sync_.registerCallback(std::bind(&TrafficLightCategoryMergerNode::signalsCallback, this, _1, _2));
+  sync_.registerCallback(
+    std::bind(&TrafficLightCategoryMergerNode::signals_callback, this, _1, _2));
   pub_traffic_light_signals_ =
     create_publisher<TrafficLightArray>("output/traffic_signals", rclcpp::QoS{1});
 }
 
-void TrafficLightCategoryMergerNode::signalsCallback(
+void TrafficLightCategoryMergerNode::signals_callback(
   const TrafficLightArray::ConstSharedPtr & car_signals_msg,
   const TrafficLightArray::ConstSharedPtr & pedestrian_signals_msg)
 {

--- a/perception/autoware_traffic_light_category_merger/src/traffic_light_category_merger_node.cpp
+++ b/perception/autoware_traffic_light_category_merger/src/traffic_light_category_merger_node.cpp
@@ -39,13 +39,7 @@ void TrafficLightCategoryMergerNode::signalsCallback(
   const TrafficLightArray::ConstSharedPtr & car_signals_msg,
   const TrafficLightArray::ConstSharedPtr & pedestrian_signals_msg)
 {
-  TrafficLightArray output;
-  output.header = car_signals_msg->header;
-  output.signals.insert(
-    output.signals.end(), car_signals_msg->signals.begin(), car_signals_msg->signals.end());
-  output.signals.insert(
-    output.signals.end(), pedestrian_signals_msg->signals.begin(),
-    pedestrian_signals_msg->signals.end());
+  const TrafficLightArray output = merger_.merge(*car_signals_msg, *pedestrian_signals_msg);
   pub_traffic_light_signals_->publish(output);
 }
 

--- a/perception/autoware_traffic_light_category_merger/src/traffic_light_category_merger_node.hpp
+++ b/perception/autoware_traffic_light_category_merger/src/traffic_light_category_merger_node.hpp
@@ -49,9 +49,6 @@ private:
     const TrafficLightArray::ConstSharedPtr & car_signals_msg,
     const TrafficLightArray::ConstSharedPtr & pedestrian_signals_msg);
 
-  // Core merge logic, decoupled from the ROS interface.
-  TrafficLightCategoryMerger merger_;
-
   rclcpp::Publisher<TrafficLightArray>::SharedPtr pub_traffic_light_signals_;
 };
 

--- a/perception/autoware_traffic_light_category_merger/src/traffic_light_category_merger_node.hpp
+++ b/perception/autoware_traffic_light_category_merger/src/traffic_light_category_merger_node.hpp
@@ -48,7 +48,7 @@ private:
     SyncPolicy;
   message_filters::Synchronizer<SyncPolicy> sync_;
 
-  void signalsCallback(
+  void signals_callback(
     const TrafficLightArray::ConstSharedPtr & car_signals_msg,
     const TrafficLightArray::ConstSharedPtr & pedestrian_signals_msg);
 

--- a/perception/autoware_traffic_light_category_merger/src/traffic_light_category_merger_node.hpp
+++ b/perception/autoware_traffic_light_category_merger/src/traffic_light_category_merger_node.hpp
@@ -25,10 +25,7 @@
 #include <message_filters/sync_policies/approximate_time.h>
 #include <message_filters/synchronizer.h>
 
-#include <chrono>
 #include <memory>
-#include <string>
-#include <vector>
 
 namespace autoware::traffic_light
 {

--- a/perception/autoware_traffic_light_category_merger/src/traffic_light_category_merger_node.hpp
+++ b/perception/autoware_traffic_light_category_merger/src/traffic_light_category_merger_node.hpp
@@ -15,6 +15,8 @@
 #ifndef TRAFFIC_LIGHT_CATEGORY_MERGER_NODE_HPP_
 #define TRAFFIC_LIGHT_CATEGORY_MERGER_NODE_HPP_
 
+#include "traffic_light_category_merger.hpp"
+
 #include <rclcpp/rclcpp.hpp>
 
 #include <tier4_perception_msgs/msg/traffic_light_array.hpp>
@@ -49,6 +51,9 @@ private:
   void signalsCallback(
     const TrafficLightArray::ConstSharedPtr & car_signals_msg,
     const TrafficLightArray::ConstSharedPtr & pedestrian_signals_msg);
+
+  // Core merge logic, decoupled from the ROS interface.
+  TrafficLightCategoryMerger merger_;
 
   rclcpp::Publisher<TrafficLightArray>::SharedPtr pub_traffic_light_signals_;
 };

--- a/perception/autoware_traffic_light_category_merger/test/test_traffic_light_category_merger.cpp
+++ b/perception/autoware_traffic_light_category_merger/test/test_traffic_light_category_merger.cpp
@@ -41,11 +41,16 @@ using tier4_perception_msgs::msg::TrafficLight;
 using tier4_perception_msgs::msg::TrafficLightArray;
 using tier4_perception_msgs::msg::TrafficLightElement;
 
-std_msgs::msg::Header make_header(const char * frame_id, int32_t sec)
+// merge() only ever copies a header wholesale, so the stamp value is irrelevant
+// to these tests; every header shares this one. The car/pedestrian arrays are
+// told apart by frame_id, which is what the header-source assertions key on.
+constexpr int32_t common_stamp_sec = 100;
+
+std_msgs::msg::Header make_header(const char * frame_id)
 {
   std_msgs::msg::Header header;
   header.frame_id = frame_id;
-  header.stamp.sec = sec;
+  header.stamp.sec = common_stamp_sec;
   header.stamp.nanosec = 0;
   return header;
 }
@@ -73,12 +78,12 @@ TEST(TrafficLightCategoryMerger, ConcatenatesCarThenPedestrian)
 {
   // Arrange
   TrafficLightArray car;
-  car.header = make_header("car_frame", 10);
+  car.header = make_header("car_frame");
   car.signals.push_back(make_signal(1, TrafficLight::CAR_TRAFFIC_LIGHT, TrafficLightElement::RED));
   car.signals.push_back(
     make_signal(2, TrafficLight::CAR_TRAFFIC_LIGHT, TrafficLightElement::GREEN));
   TrafficLightArray pedestrian;
-  pedestrian.header = make_header("pedestrian_frame", 20);
+  pedestrian.header = make_header("pedestrian_frame");
   pedestrian.signals.push_back(
     make_signal(3, TrafficLight::PEDESTRIAN_TRAFFIC_LIGHT, TrafficLightElement::AMBER));
 
@@ -105,14 +110,15 @@ TEST(TrafficLightCategoryMerger, ConcatenatesCarThenPedestrian)
 TEST(TrafficLightCategoryMerger, OutputHeaderComesFromCarArray)
 {
   TrafficLightArray car;
-  car.header = make_header("car_frame", 10);
+  car.header = make_header("car_frame");
   TrafficLightArray pedestrian;
-  pedestrian.header = make_header("pedestrian_frame", 20);
+  pedestrian.header = make_header("pedestrian_frame");
 
   const auto out = tl::TrafficLightCategoryMerger().merge(car, pedestrian);
 
-  EXPECT_EQ(out.header.frame_id, "car_frame");
-  EXPECT_EQ(out.header.stamp.sec, 10);
+  // The whole header is copied from the car array (frame_id tells it apart from
+  // the pedestrian one, which shares the same stamp).
+  EXPECT_EQ(out.header, car.header);
 }
 
 // --------------------------------------------------------------------------
@@ -121,10 +127,10 @@ TEST(TrafficLightCategoryMerger, OutputHeaderComesFromCarArray)
 TEST(TrafficLightCategoryMerger, EmptyPedestrianKeepsCarSignals)
 {
   TrafficLightArray car;
-  car.header = make_header("car_frame", 10);
+  car.header = make_header("car_frame");
   car.signals.push_back(make_signal(1, TrafficLight::CAR_TRAFFIC_LIGHT, TrafficLightElement::RED));
   TrafficLightArray pedestrian;
-  pedestrian.header = make_header("pedestrian_frame", 20);
+  pedestrian.header = make_header("pedestrian_frame");
 
   const auto out = tl::TrafficLightCategoryMerger().merge(car, pedestrian);
 
@@ -139,9 +145,9 @@ TEST(TrafficLightCategoryMerger, EmptyPedestrianKeepsCarSignals)
 TEST(TrafficLightCategoryMerger, EmptyCarKeepsPedestrianSignalsAndCarHeader)
 {
   TrafficLightArray car;
-  car.header = make_header("car_frame", 10);
+  car.header = make_header("car_frame");
   TrafficLightArray pedestrian;
-  pedestrian.header = make_header("pedestrian_frame", 20);
+  pedestrian.header = make_header("pedestrian_frame");
   pedestrian.signals.push_back(
     make_signal(3, TrafficLight::PEDESTRIAN_TRAFFIC_LIGHT, TrafficLightElement::GREEN));
 
@@ -149,7 +155,7 @@ TEST(TrafficLightCategoryMerger, EmptyCarKeepsPedestrianSignalsAndCarHeader)
 
   ASSERT_EQ(out.signals.size(), 1u);
   EXPECT_EQ(out.signals[0].traffic_light_id, 3);
-  EXPECT_EQ(out.header.frame_id, "car_frame");
+  EXPECT_EQ(out.header, car.header);
 }
 
 // --------------------------------------------------------------------------
@@ -158,14 +164,14 @@ TEST(TrafficLightCategoryMerger, EmptyCarKeepsPedestrianSignalsAndCarHeader)
 TEST(TrafficLightCategoryMerger, BothEmptyYieldsEmptyWithCarHeader)
 {
   TrafficLightArray car;
-  car.header = make_header("car_frame", 10);
+  car.header = make_header("car_frame");
   TrafficLightArray pedestrian;
-  pedestrian.header = make_header("pedestrian_frame", 20);
+  pedestrian.header = make_header("pedestrian_frame");
 
   const auto out = tl::TrafficLightCategoryMerger().merge(car, pedestrian);
 
   EXPECT_EQ(out.signals.size(), 0u);
-  EXPECT_EQ(out.header.frame_id, "car_frame");
+  EXPECT_EQ(out.header, car.header);
 }
 
 }  // namespace

--- a/perception/autoware_traffic_light_category_merger/test/test_traffic_light_category_merger.cpp
+++ b/perception/autoware_traffic_light_category_merger/test/test_traffic_light_category_merger.cpp
@@ -88,7 +88,7 @@ TEST(TrafficLightCategoryMerger, ConcatenatesCarThenPedestrian)
     make_signal(3, TrafficLight::PEDESTRIAN_TRAFFIC_LIGHT, TrafficLightElement::AMBER));
 
   // Act
-  const auto out = tl::TrafficLightCategoryMerger().merge(car, pedestrian);
+  const auto out = tl::TrafficLightCategoryMerger::merge(car, pedestrian);
 
   // Assert: car signals precede pedestrian signals, in input order.
   ASSERT_EQ(out.signals.size(), 3u);
@@ -114,7 +114,7 @@ TEST(TrafficLightCategoryMerger, OutputHeaderComesFromCarArray)
   TrafficLightArray pedestrian;
   pedestrian.header = make_header("pedestrian_frame");
 
-  const auto out = tl::TrafficLightCategoryMerger().merge(car, pedestrian);
+  const auto out = tl::TrafficLightCategoryMerger::merge(car, pedestrian);
 
   // The whole header is copied from the car array (frame_id tells it apart from
   // the pedestrian one, which shares the same stamp).
@@ -132,7 +132,7 @@ TEST(TrafficLightCategoryMerger, EmptyPedestrianKeepsCarSignals)
   TrafficLightArray pedestrian;
   pedestrian.header = make_header("pedestrian_frame");
 
-  const auto out = tl::TrafficLightCategoryMerger().merge(car, pedestrian);
+  const auto out = tl::TrafficLightCategoryMerger::merge(car, pedestrian);
 
   ASSERT_EQ(out.signals.size(), 1u);
   EXPECT_EQ(out.signals[0].traffic_light_id, 1);
@@ -151,7 +151,7 @@ TEST(TrafficLightCategoryMerger, EmptyCarKeepsPedestrianSignalsAndCarHeader)
   pedestrian.signals.push_back(
     make_signal(3, TrafficLight::PEDESTRIAN_TRAFFIC_LIGHT, TrafficLightElement::GREEN));
 
-  const auto out = tl::TrafficLightCategoryMerger().merge(car, pedestrian);
+  const auto out = tl::TrafficLightCategoryMerger::merge(car, pedestrian);
 
   ASSERT_EQ(out.signals.size(), 1u);
   EXPECT_EQ(out.signals[0].traffic_light_id, 3);
@@ -168,7 +168,7 @@ TEST(TrafficLightCategoryMerger, BothEmptyYieldsEmptyWithCarHeader)
   TrafficLightArray pedestrian;
   pedestrian.header = make_header("pedestrian_frame");
 
-  const auto out = tl::TrafficLightCategoryMerger().merge(car, pedestrian);
+  const auto out = tl::TrafficLightCategoryMerger::merge(car, pedestrian);
 
   EXPECT_EQ(out.signals.size(), 0u);
   EXPECT_EQ(out.header, car.header);

--- a/perception/autoware_traffic_light_category_merger/test/test_traffic_light_category_merger.cpp
+++ b/perception/autoware_traffic_light_category_merger/test/test_traffic_light_category_merger.cpp
@@ -1,0 +1,177 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//
+// Unit tests for the ROS-free merge core (TrafficLightCategoryMerger).
+//
+// merge() is exercised directly over in-memory TrafficLightArray messages, with
+// no rclcpp, no topics and no message_filters sync. The assertions are on the
+// returned array (header source, signal ordering, element preservation) rather
+// than on what a node happens to publish -- the pub/sub + sync path is covered
+// by test_traffic_light_category_merger_integration.
+//
+
+#include "../src/traffic_light_category_merger.hpp"
+
+#include <std_msgs/msg/header.hpp>
+#include <tier4_perception_msgs/msg/traffic_light.hpp>
+#include <tier4_perception_msgs/msg/traffic_light_array.hpp>
+#include <tier4_perception_msgs/msg/traffic_light_element.hpp>
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+
+namespace
+{
+namespace tl = autoware::traffic_light;
+
+using tier4_perception_msgs::msg::TrafficLight;
+using tier4_perception_msgs::msg::TrafficLightArray;
+using tier4_perception_msgs::msg::TrafficLightElement;
+
+std_msgs::msg::Header make_header(const char * frame_id, int32_t sec)
+{
+  std_msgs::msg::Header header;
+  header.frame_id = frame_id;
+  header.stamp.sec = sec;
+  header.stamp.nanosec = 0;
+  return header;
+}
+
+// A signal carrying a single element so element preservation is observable.
+TrafficLight make_signal(int64_t id, uint8_t type, uint8_t color)
+{
+  TrafficLight signal;
+  signal.traffic_light_id = id;
+  signal.traffic_light_type = type;
+  TrafficLightElement element;
+  element.color = color;
+  element.shape = TrafficLightElement::CIRCLE;
+  element.status = TrafficLightElement::SOLID_ON;
+  element.confidence = 0.75;
+  signal.elements.push_back(element);
+  return signal;
+}
+
+// --------------------------------------------------------------------------
+// Typical merge: car signals come first, pedestrian signals after, every signal
+// preserved in order with its elements intact.
+// --------------------------------------------------------------------------
+TEST(TrafficLightCategoryMerger, ConcatenatesCarThenPedestrian)
+{
+  // Arrange
+  TrafficLightArray car;
+  car.header = make_header("car_frame", 10);
+  car.signals.push_back(make_signal(1, TrafficLight::CAR_TRAFFIC_LIGHT, TrafficLightElement::RED));
+  car.signals.push_back(
+    make_signal(2, TrafficLight::CAR_TRAFFIC_LIGHT, TrafficLightElement::GREEN));
+  TrafficLightArray pedestrian;
+  pedestrian.header = make_header("pedestrian_frame", 20);
+  pedestrian.signals.push_back(
+    make_signal(3, TrafficLight::PEDESTRIAN_TRAFFIC_LIGHT, TrafficLightElement::AMBER));
+
+  // Act
+  const auto out = tl::TrafficLightCategoryMerger().merge(car, pedestrian);
+
+  // Assert: car signals precede pedestrian signals, in input order.
+  ASSERT_EQ(out.signals.size(), 3u);
+  EXPECT_EQ(out.signals[0].traffic_light_id, 1);
+  EXPECT_EQ(out.signals[1].traffic_light_id, 2);
+  EXPECT_EQ(out.signals[2].traffic_light_id, 3);
+  EXPECT_EQ(out.signals[2].traffic_light_type, TrafficLight::PEDESTRIAN_TRAFFIC_LIGHT);
+
+  // Assert: element payloads are carried through untouched.
+  ASSERT_EQ(out.signals[0].elements.size(), 1u);
+  EXPECT_EQ(out.signals[0].elements[0].color, TrafficLightElement::RED);
+  EXPECT_EQ(out.signals[2].elements[0].color, TrafficLightElement::AMBER);
+}
+
+// --------------------------------------------------------------------------
+// The output header is always taken from the car array, never the pedestrian
+// array.
+// --------------------------------------------------------------------------
+TEST(TrafficLightCategoryMerger, OutputHeaderComesFromCarArray)
+{
+  TrafficLightArray car;
+  car.header = make_header("car_frame", 10);
+  TrafficLightArray pedestrian;
+  pedestrian.header = make_header("pedestrian_frame", 20);
+
+  const auto out = tl::TrafficLightCategoryMerger().merge(car, pedestrian);
+
+  EXPECT_EQ(out.header.frame_id, "car_frame");
+  EXPECT_EQ(out.header.stamp.sec, 10);
+}
+
+// --------------------------------------------------------------------------
+// An empty pedestrian array yields exactly the car signals.
+// --------------------------------------------------------------------------
+TEST(TrafficLightCategoryMerger, EmptyPedestrianKeepsCarSignals)
+{
+  TrafficLightArray car;
+  car.header = make_header("car_frame", 10);
+  car.signals.push_back(make_signal(1, TrafficLight::CAR_TRAFFIC_LIGHT, TrafficLightElement::RED));
+  TrafficLightArray pedestrian;
+  pedestrian.header = make_header("pedestrian_frame", 20);
+
+  const auto out = tl::TrafficLightCategoryMerger().merge(car, pedestrian);
+
+  ASSERT_EQ(out.signals.size(), 1u);
+  EXPECT_EQ(out.signals[0].traffic_light_id, 1);
+}
+
+// --------------------------------------------------------------------------
+// An empty car array yields exactly the pedestrian signals, but the header still
+// comes from the (empty) car array.
+// --------------------------------------------------------------------------
+TEST(TrafficLightCategoryMerger, EmptyCarKeepsPedestrianSignalsAndCarHeader)
+{
+  TrafficLightArray car;
+  car.header = make_header("car_frame", 10);
+  TrafficLightArray pedestrian;
+  pedestrian.header = make_header("pedestrian_frame", 20);
+  pedestrian.signals.push_back(
+    make_signal(3, TrafficLight::PEDESTRIAN_TRAFFIC_LIGHT, TrafficLightElement::GREEN));
+
+  const auto out = tl::TrafficLightCategoryMerger().merge(car, pedestrian);
+
+  ASSERT_EQ(out.signals.size(), 1u);
+  EXPECT_EQ(out.signals[0].traffic_light_id, 3);
+  EXPECT_EQ(out.header.frame_id, "car_frame");
+}
+
+// --------------------------------------------------------------------------
+// Both arrays empty: an empty output carrying the car header.
+// --------------------------------------------------------------------------
+TEST(TrafficLightCategoryMerger, BothEmptyYieldsEmptyWithCarHeader)
+{
+  TrafficLightArray car;
+  car.header = make_header("car_frame", 10);
+  TrafficLightArray pedestrian;
+  pedestrian.header = make_header("pedestrian_frame", 20);
+
+  const auto out = tl::TrafficLightCategoryMerger().merge(car, pedestrian);
+
+  EXPECT_EQ(out.signals.size(), 0u);
+  EXPECT_EQ(out.header.frame_id, "car_frame");
+}
+
+}  // namespace
+
+int main(int argc, char ** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/perception/autoware_traffic_light_category_merger/test/test_traffic_light_category_merger_integration.cpp
+++ b/perception/autoware_traffic_light_category_merger/test/test_traffic_light_category_merger_integration.cpp
@@ -18,7 +18,7 @@
 // These stand up the real node and drive it over its ROS interface: a car
 // TrafficLightArray and a pedestrian TrafficLightArray are published on the two
 // input topics, the node's message_filters ApproximateTime sync wires them
-// through signalsCallback, and the test observes the merged array published on
+// through signals_callback, and the test observes the merged array published on
 // the output topic. This exercises the full pub/sub + sync path that a unit-level
 // callback invocation would bypass.
 //

--- a/perception/autoware_traffic_light_category_merger/test/test_traffic_light_category_merger_integration.cpp
+++ b/perception/autoware_traffic_light_category_merger/test/test_traffic_light_category_merger_integration.cpp
@@ -91,7 +91,7 @@ TrafficLight make_signal(int64_t id, uint8_t type)
 class OutputCapture
 {
 public:
-  void onSignals(TrafficLightArray::ConstSharedPtr msg)
+  void on_signals(TrafficLightArray::ConstSharedPtr msg)
   {
     signals = *msg;
     got_signals = true;
@@ -121,7 +121,7 @@ protected:
     OutputCapture capture;
     auto tester = std::make_shared<rclcpp::Node>("integration_tester");
     auto signal_sub = tester->create_subscription<TrafficLightArray>(
-      output_topic, rclcpp::QoS{1}, std::bind(&OutputCapture::onSignals, &capture, _1));
+      output_topic, rclcpp::QoS{1}, std::bind(&OutputCapture::on_signals, &capture, _1));
     auto car_pub = tester->create_publisher<TrafficLightArray>(car_topic, rclcpp::QoS{1});
     auto pedestrian_pub =
       tester->create_publisher<TrafficLightArray>(pedestrian_topic, rclcpp::QoS{1});

--- a/perception/autoware_traffic_light_category_merger/test/test_traffic_light_category_merger_integration.cpp
+++ b/perception/autoware_traffic_light_category_merger/test/test_traffic_light_category_merger_integration.cpp
@@ -1,0 +1,211 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//
+// Integration tests for TrafficLightCategoryMergerNode.
+//
+// These stand up the real node and drive it over its ROS interface: a car
+// TrafficLightArray and a pedestrian TrafficLightArray are published on the two
+// input topics, the node's message_filters ApproximateTime sync wires them
+// through signalsCallback, and the test observes the merged array published on
+// the output topic. This exercises the full pub/sub + sync path that a unit-level
+// callback invocation would bypass.
+//
+// Scope is intentionally narrow -- a typical (car, pedestrian) round trip and the
+// both-empty case. The merge semantics themselves (ordering, header source,
+// element preservation) are owned by the ROS-free core test
+// (test_traffic_light_category_merger) and are only spot-checked here.
+//
+
+#include "../src/traffic_light_category_merger_node.hpp"
+
+#include <rclcpp/rclcpp.hpp>
+
+#include <std_msgs/msg/header.hpp>
+#include <tier4_perception_msgs/msg/traffic_light.hpp>
+#include <tier4_perception_msgs/msg/traffic_light_array.hpp>
+#include <tier4_perception_msgs/msg/traffic_light_element.hpp>
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <functional>
+#include <memory>
+#include <stdexcept>
+#include <thread>
+
+namespace
+{
+namespace tl = autoware::traffic_light;
+
+using tier4_perception_msgs::msg::TrafficLight;
+using tier4_perception_msgs::msg::TrafficLightArray;
+using tier4_perception_msgs::msg::TrafficLightElement;
+
+using std::chrono_literals::operator""ms;
+using std::chrono_literals::operator""s;
+using std::placeholders::_1;
+
+constexpr char car_topic[] = "/input/car_signals";
+constexpr char pedestrian_topic[] = "/input/pedestrian_signals";
+constexpr char output_topic[] = "/output/traffic_signals";
+
+std_msgs::msg::Header make_header()
+{
+  std_msgs::msg::Header header;
+  header.frame_id = "camera";
+  header.stamp.sec = 123;
+  header.stamp.nanosec = 456;
+  return header;
+}
+
+// A signal carrying a single GREEN/CIRCLE element so the element payload is
+// observable end to end.
+TrafficLight make_signal(int64_t id, uint8_t type)
+{
+  TrafficLight signal;
+  signal.traffic_light_id = id;
+  signal.traffic_light_type = type;
+  TrafficLightElement element;
+  element.color = TrafficLightElement::GREEN;
+  element.shape = TrafficLightElement::CIRCLE;
+  element.status = TrafficLightElement::SOLID_ON;
+  element.confidence = 0.9;
+  signal.elements.push_back(element);
+  return signal;
+}
+
+// Subscribes to the node's output and records the merged array it publishes. A
+// named member callback keeps the capture lambda-free.
+class OutputCapture
+{
+public:
+  void onSignals(TrafficLightArray::ConstSharedPtr msg)
+  {
+    signals = *msg;
+    got_signals = true;
+  }
+
+  bool got_signals = false;
+  TrafficLightArray signals;
+};
+
+class IntegrationTest : public ::testing::Test
+{
+protected:
+  std::shared_ptr<tl::TrafficLightCategoryMergerNode> make_node_under_test()
+  {
+    rclcpp::NodeOptions options;
+    node_ = std::make_shared<tl::TrafficLightCategoryMergerNode>(options);
+    return node_;
+  }
+
+  // Publish (car, pedestrian) on the input topics and capture the node's merged
+  // output. The inputs are re-published in a wait loop so the test is robust
+  // against pub/sub discovery latency; identical stamps make every pair an
+  // ApproximateTime match. A missing publish is a setup failure, surfaced by
+  // throwing (helpers stay free of gtest assertions).
+  TrafficLightArray run(const TrafficLightArray & car, const TrafficLightArray & pedestrian)
+  {
+    OutputCapture capture;
+    auto tester = std::make_shared<rclcpp::Node>("integration_tester");
+    auto signal_sub = tester->create_subscription<TrafficLightArray>(
+      output_topic, rclcpp::QoS{1}, std::bind(&OutputCapture::onSignals, &capture, _1));
+    auto car_pub = tester->create_publisher<TrafficLightArray>(car_topic, rclcpp::QoS{1});
+    auto pedestrian_pub =
+      tester->create_publisher<TrafficLightArray>(pedestrian_topic, rclcpp::QoS{1});
+
+    rclcpp::executors::SingleThreadedExecutor exec;
+    exec.add_node(node_);
+    exec.add_node(tester);
+
+    const auto deadline = std::chrono::steady_clock::now() + 10s;
+    while (!capture.got_signals && std::chrono::steady_clock::now() < deadline) {
+      car_pub->publish(car);
+      pedestrian_pub->publish(pedestrian);
+      exec.spin_some();
+      std::this_thread::sleep_for(10ms);
+    }
+    if (!capture.got_signals) {
+      throw std::runtime_error(
+        "run(): node under test published no traffic_signals within the timeout");
+    }
+    return capture.signals;
+  }
+
+  std::shared_ptr<tl::TrafficLightCategoryMergerNode> node_;
+};
+
+// --------------------------------------------------------------------------
+// Typical round trip: a car array with one signal and a pedestrian array with
+// one signal published on the inputs come back merged into one output array of
+// two signals, with the car array's header propagated and the element payloads
+// preserved.
+// --------------------------------------------------------------------------
+TEST_F(IntegrationTest, TypicalCarPedestrianRoundTrip)
+{
+  // Arrange
+  make_node_under_test();
+  TrafficLightArray car;
+  car.header = make_header();  // same stamp as pedestrian -> ApproximateTime match
+  car.signals.push_back(make_signal(/*id=*/1, TrafficLight::CAR_TRAFFIC_LIGHT));
+  TrafficLightArray pedestrian;
+  pedestrian.header = make_header();
+  pedestrian.signals.push_back(make_signal(/*id=*/2, TrafficLight::PEDESTRIAN_TRAFFIC_LIGHT));
+
+  // Act
+  const auto out = run(car, pedestrian);
+
+  // Assert: header comes from the car array; both signals are present.
+  EXPECT_EQ(out.header, car.header);
+  ASSERT_EQ(out.signals.size(), 2u);
+  EXPECT_EQ(out.signals[0].traffic_light_id, 1);
+  EXPECT_EQ(out.signals[0].traffic_light_type, TrafficLight::CAR_TRAFFIC_LIGHT);
+  EXPECT_EQ(out.signals[1].traffic_light_id, 2);
+  EXPECT_EQ(out.signals[1].traffic_light_type, TrafficLight::PEDESTRIAN_TRAFFIC_LIGHT);
+  ASSERT_EQ(out.signals[0].elements.size(), 1u);
+  EXPECT_EQ(out.signals[0].elements[0].color, TrafficLightElement::GREEN);
+}
+
+// --------------------------------------------------------------------------
+// Both inputs empty: the node still publishes a (sync-matched) empty output
+// array carrying the car array's header.
+// --------------------------------------------------------------------------
+TEST_F(IntegrationTest, BothEmptyPublishesEmptyArrayWithCarHeader)
+{
+  // Arrange
+  make_node_under_test();
+  TrafficLightArray car;
+  car.header = make_header();
+  TrafficLightArray pedestrian;
+  pedestrian.header = make_header();
+
+  // Act
+  const auto out = run(car, pedestrian);
+
+  // Assert
+  EXPECT_EQ(out.header, car.header);
+  EXPECT_EQ(out.signals.size(), 0u);
+}
+
+}  // namespace
+
+int main(int argc, char ** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  rclcpp::init(argc, argv);
+  const int ret = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return ret;
+}


### PR DESCRIPTION
## Description

Decouple the core logic of `autoware_traffic_light_category_merger` from its ROS 2 node and cover it with tests.

The merge logic was written inline in the node's sync callback. This PR:

- Adds **node integration tests** that drive the real node over its ROS interface (car/pedestrian input topics → message_filters `ApproximateTime` sync → merged output topic), pinning the current observable behavior before any refactor.
- Extracts the array-concatenation logic into a ROS-free core class `TrafficLightCategoryMerger` (`traffic_light_category_merger.{hpp,cpp}`). The node now holds a `merger_` member and delegates to `merger_.merge()`; the callback is left responsible only for the ROS interface (sync, publish). Behavior is unchanged.
- Adds **unit tests** for the core, exercising `merge()` directly over in-memory messages (car-then-pedestrian ordering, element preservation, car-array header source, and the empty-car / empty-pedestrian / both-empty edge cases).

Follow-up tidy-ups included:

- Use a shared stamp in the core unit tests (the stamp is irrelevant to merge; arrays are told apart by `frame_id`).
- Rename `signalsCallback` → `signals_callback` and the test's `onSignals` → `on_signals` to follow the Autoware C++ snake_case convention.
- Drop unused node includes (`<string>`, `<vector>`, `<chrono>`) left over after the extraction.

## Related links

**Parent Issue:**

- None

## How was this PR tested?

`colcon build` + `colcon test --packages-select autoware_traffic_light_category_merger` on ROS 2 Humble.

- Integration tests: 2 cases (typical car+pedestrian round trip, both-empty) — all pass.
- Core unit tests: 5 cases — all pass.
- The integration tests pass both before and after the core extraction, confirming behavior is unchanged.

## Notes for reviewers

The merge policy preserved from the original node is: concatenate car signals then pedestrian signals, and adopt the **car array's header** for the output. Whether "car wins" for the header is the desired domain policy is intentionally left unchanged here (it would be a behavior change, out of scope for this test/refactor PR).

## Interface changes

None.

## Effects on system behavior

None. This is a test-and-refactor change with no observable behavior change.
