### PR TITLE
fix(external_cmd_selector): data race bug

### DIFF
--- a/control/autoware_external_cmd_selector/include/autoware/external_cmd_selector/external_cmd_selector_node.hpp
+++ b/control/autoware_external_cmd_selector/include/autoware/external_cmd_selector/external_cmd_selector_node.hpp
@@ -28,8 +28,8 @@
 #include <tier4_control_msgs/msg/external_command_selector_mode.hpp>
 #include <tier4_control_msgs/srv/external_command_select.hpp>
 
+#include <atomic>
 #include <memory>
-#include <mutex>
 
 namespace autoware::external_cmd_selector
 {
@@ -92,8 +92,7 @@ private:
 
   // Service
   rclcpp::Service<CommandSourceSelect>::SharedPtr srv_select_external_command_;
-  CommandSourceMode current_selector_mode_;
-  std::mutex current_selector_mode_mutex_;
+  std::atomic<uint8_t> current_selector_mode_;
   bool on_select_external_command(
     const CommandSourceSelect::Request::SharedPtr req,
     const CommandSourceSelect::Response::SharedPtr res);

--- a/control/autoware_external_cmd_selector/include/autoware/external_cmd_selector/external_cmd_selector_node.hpp
+++ b/control/autoware_external_cmd_selector/include/autoware/external_cmd_selector/external_cmd_selector_node.hpp
@@ -92,9 +92,6 @@ private:
 
   // Service
   rclcpp::Service<CommandSourceSelect>::SharedPtr srv_select_external_command_;
-  // Guards current_selector_mode_: the service callback writes it while the command relays and the
-  // timer read it, and those run in separate callback groups (concurrent under a multi-threaded
-  // container executor).
   CommandSourceMode current_selector_mode_;
   std::mutex current_selector_mode_mutex_;
   bool on_select_external_command(

--- a/control/autoware_external_cmd_selector/include/autoware/external_cmd_selector/external_cmd_selector_node.hpp
+++ b/control/autoware_external_cmd_selector/include/autoware/external_cmd_selector/external_cmd_selector_node.hpp
@@ -29,6 +29,7 @@
 #include <tier4_control_msgs/srv/external_command_select.hpp>
 
 #include <memory>
+#include <mutex>
 
 namespace autoware::external_cmd_selector
 {
@@ -91,7 +92,11 @@ private:
 
   // Service
   rclcpp::Service<CommandSourceSelect>::SharedPtr srv_select_external_command_;
+  // Guards current_selector_mode_: the service callback writes it while the command relays and the
+  // timer read it, and those run in separate callback groups (concurrent under a multi-threaded
+  // container executor).
   CommandSourceMode current_selector_mode_;
+  std::mutex current_selector_mode_mutex_;
   bool on_select_external_command(
     const CommandSourceSelect::Request::SharedPtr req,
     const CommandSourceSelect::Response::SharedPtr res);

--- a/control/autoware_external_cmd_selector/src/autoware_external_cmd_selector/external_cmd_selector_node.cpp
+++ b/control/autoware_external_cmd_selector/src/autoware_external_cmd_selector/external_cmd_selector_node.cpp
@@ -17,8 +17,8 @@
 #include <autoware/qos_utils/qos_compatibility.hpp>
 
 #include <chrono>
+#include <cstdint>
 #include <memory>
-#include <mutex>
 #include <string>
 #include <utility>
 
@@ -126,7 +126,7 @@ ExternalCmdSelector::ExternalCmdSelector(const rclcpp::NodeOptions & node_option
     }
     throw std::invalid_argument("unknown selector mode");
   };
-  current_selector_mode_.data = convert_selector_mode(initial_selector_mode);
+  current_selector_mode_.store(convert_selector_mode(initial_selector_mode));
 
   // Diagnostics Updater
   updater_.setHardwareID("external_cmd_selector");
@@ -143,55 +143,37 @@ ExternalCmdSelector::ExternalCmdSelector(const rclcpp::NodeOptions & node_option
 
 void ExternalCmdSelector::on_pedals_cmd(const PedalsCommand & msg, uint8_t mode)
 {
-  {
-    std::lock_guard<std::mutex> lock(current_selector_mode_mutex_);
-    if (current_selector_mode_.data != mode) return;
-  }
+  if (current_selector_mode_.load() != mode) return;
   pub_pedals_cmd_->publish(msg);
 }
 
 void ExternalCmdSelector::on_steering_cmd(const SteeringCommand & msg, uint8_t mode)
 {
-  {
-    std::lock_guard<std::mutex> lock(current_selector_mode_mutex_);
-    if (current_selector_mode_.data != mode) return;
-  }
+  if (current_selector_mode_.load() != mode) return;
   pub_steering_cmd_->publish(msg);
 }
 
 void ExternalCmdSelector::on_heartbeat(const OperatorHeartbeat & msg, uint8_t mode)
 {
-  {
-    std::lock_guard<std::mutex> lock(current_selector_mode_mutex_);
-    if (current_selector_mode_.data != mode) return;
-  }
+  if (current_selector_mode_.load() != mode) return;
   pub_heartbeat_->publish(msg);
 }
 
 void ExternalCmdSelector::on_gear_cmd(const GearCommand & msg, uint8_t mode)
 {
-  {
-    std::lock_guard<std::mutex> lock(current_selector_mode_mutex_);
-    if (current_selector_mode_.data != mode) return;
-  }
+  if (current_selector_mode_.load() != mode) return;
   pub_gear_cmd_->publish(msg);
 }
 
 void ExternalCmdSelector::on_turn_indicators_cmd(const TurnIndicatorsCommand & msg, uint8_t mode)
 {
-  {
-    std::lock_guard<std::mutex> lock(current_selector_mode_mutex_);
-    if (current_selector_mode_.data != mode) return;
-  }
+  if (current_selector_mode_.load() != mode) return;
   pub_turn_indicators_cmd_->publish(msg);
 }
 
 void ExternalCmdSelector::on_hazard_lights_cmd(const HazardLightsCommand & msg, uint8_t mode)
 {
-  {
-    std::lock_guard<std::mutex> lock(current_selector_mode_mutex_);
-    if (current_selector_mode_.data != mode) return;
-  }
+  if (current_selector_mode_.load() != mode) return;
   pub_hazard_lights_cmd_->publish(msg);
 }
 
@@ -199,10 +181,7 @@ bool ExternalCmdSelector::on_select_external_command(
   const CommandSourceSelect::Request::SharedPtr req,
   const CommandSourceSelect::Response::SharedPtr res)
 {
-  {
-    std::lock_guard<std::mutex> lock(current_selector_mode_mutex_);
-    current_selector_mode_.data = req->mode.data;
-  }
+  current_selector_mode_.store(req->mode.data);
   res->success = true;
   res->message = "Success.";
   return true;
@@ -211,10 +190,7 @@ bool ExternalCmdSelector::on_select_external_command(
 void ExternalCmdSelector::on_timer()
 {
   CommandSourceMode mode;
-  {
-    std::lock_guard<std::mutex> lock(current_selector_mode_mutex_);
-    mode = current_selector_mode_;
-  }
+  mode.data = current_selector_mode_.load();
   pub_current_selector_mode_->publish(mode);
   updater_.force_update();
 }

--- a/control/autoware_external_cmd_selector/src/autoware_external_cmd_selector/external_cmd_selector_node.cpp
+++ b/control/autoware_external_cmd_selector/src/autoware_external_cmd_selector/external_cmd_selector_node.cpp
@@ -18,6 +18,7 @@
 
 #include <chrono>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <utility>
 
@@ -142,37 +143,55 @@ ExternalCmdSelector::ExternalCmdSelector(const rclcpp::NodeOptions & node_option
 
 void ExternalCmdSelector::on_pedals_cmd(const PedalsCommand & msg, uint8_t mode)
 {
-  if (current_selector_mode_.data != mode) return;
+  {
+    std::lock_guard<std::mutex> lock(current_selector_mode_mutex_);
+    if (current_selector_mode_.data != mode) return;
+  }
   pub_pedals_cmd_->publish(msg);
 }
 
 void ExternalCmdSelector::on_steering_cmd(const SteeringCommand & msg, uint8_t mode)
 {
-  if (current_selector_mode_.data != mode) return;
+  {
+    std::lock_guard<std::mutex> lock(current_selector_mode_mutex_);
+    if (current_selector_mode_.data != mode) return;
+  }
   pub_steering_cmd_->publish(msg);
 }
 
 void ExternalCmdSelector::on_heartbeat(const OperatorHeartbeat & msg, uint8_t mode)
 {
-  if (current_selector_mode_.data != mode) return;
+  {
+    std::lock_guard<std::mutex> lock(current_selector_mode_mutex_);
+    if (current_selector_mode_.data != mode) return;
+  }
   pub_heartbeat_->publish(msg);
 }
 
 void ExternalCmdSelector::on_gear_cmd(const GearCommand & msg, uint8_t mode)
 {
-  if (current_selector_mode_.data != mode) return;
+  {
+    std::lock_guard<std::mutex> lock(current_selector_mode_mutex_);
+    if (current_selector_mode_.data != mode) return;
+  }
   pub_gear_cmd_->publish(msg);
 }
 
 void ExternalCmdSelector::on_turn_indicators_cmd(const TurnIndicatorsCommand & msg, uint8_t mode)
 {
-  if (current_selector_mode_.data != mode) return;
+  {
+    std::lock_guard<std::mutex> lock(current_selector_mode_mutex_);
+    if (current_selector_mode_.data != mode) return;
+  }
   pub_turn_indicators_cmd_->publish(msg);
 }
 
 void ExternalCmdSelector::on_hazard_lights_cmd(const HazardLightsCommand & msg, uint8_t mode)
 {
-  if (current_selector_mode_.data != mode) return;
+  {
+    std::lock_guard<std::mutex> lock(current_selector_mode_mutex_);
+    if (current_selector_mode_.data != mode) return;
+  }
   pub_hazard_lights_cmd_->publish(msg);
 }
 
@@ -180,7 +199,10 @@ bool ExternalCmdSelector::on_select_external_command(
   const CommandSourceSelect::Request::SharedPtr req,
   const CommandSourceSelect::Response::SharedPtr res)
 {
-  current_selector_mode_.data = req->mode.data;
+  {
+    std::lock_guard<std::mutex> lock(current_selector_mode_mutex_);
+    current_selector_mode_.data = req->mode.data;
+  }
   res->success = true;
   res->message = "Success.";
   return true;
@@ -188,7 +210,12 @@ bool ExternalCmdSelector::on_select_external_command(
 
 void ExternalCmdSelector::on_timer()
 {
-  pub_current_selector_mode_->publish(current_selector_mode_);
+  CommandSourceMode mode;
+  {
+    std::lock_guard<std::mutex> lock(current_selector_mode_mutex_);
+    mode = current_selector_mode_;
+  }
+  pub_current_selector_mode_->publish(mode);
   updater_.force_update();
 }
 


### PR DESCRIPTION
## Description
`current_selector_mode_` is written by the service callback (`on_select_external_command`) and read by the command-relay subscriptions and the timer. These callbacks belong to two different callback groups, so they can run concurrently under a multi-threaded container executor, making the unguarded access a data race.

This PR adds a mutex to serialize all reads and writes of `current_selector_mode_`.

## Changes
- Add `current_selector_mode_mutex_` guarding every access to `current_selector_mode_`.
- `publish()` calls are kept outside the lock to avoid holding it longer than necessary.

## Tests performed
- `colcon build` for `autoware_external_cmd_selector` passes.
- (Will later check the behavior is preserved by running Psim)