### PR TITLE
feat(trajectory_modifier): add surround obstacle stop plugin to trajectory modifier

### DIFF
--- a/common/autoware_obstacle_proximity_checker/CMakeLists.txt
+++ b/common/autoware_obstacle_proximity_checker/CMakeLists.txt
@@ -1,0 +1,44 @@
+cmake_minimum_required(VERSION 3.14)
+project(autoware_obstacle_proximity_checker)
+
+find_package(autoware_cmake REQUIRED)
+autoware_package()
+
+find_package(eigen3_cmake_module REQUIRED)
+find_package(Eigen3 REQUIRED)
+find_package(PCL REQUIRED COMPONENTS common)
+
+### Compile options
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 17)
+endif()
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wno-error=deprecated-declarations)
+endif()
+
+include_directories(
+  SYSTEM
+    ${EIGEN3_INCLUDE_DIR}
+)
+
+ament_auto_add_library(${PROJECT_NAME} SHARED
+  src/obstacle_proximity_checker.cpp
+)
+
+target_link_libraries(${PROJECT_NAME}
+  ${PCL_LIBRARIES}
+)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+
+  ament_add_gtest(test_${PROJECT_NAME}
+    test/test_obstacle_proximity_checker.cpp
+  )
+  target_link_libraries(test_${PROJECT_NAME}
+    ${PROJECT_NAME}
+  )
+endif()
+
+ament_auto_package()

--- a/common/autoware_obstacle_proximity_checker/README.md
+++ b/common/autoware_obstacle_proximity_checker/README.md
@@ -1,0 +1,98 @@
+# Obstacle Proximity Checker
+
+## Purpose
+
+This package provides a reusable library for detecting obstacles in close proximity to the ego vehicle.
+It computes the minimum distance between an expanded ego footprint and nearby point cloud points or dynamic object polygons, and reports whether any obstacle is within a caller-defined distance threshold.
+
+The core logic was extracted from [autoware_surround_obstacle_checker](../../planning/autoware_surround_obstacle_checker/README.md) so it can be shared across planning modules.
+Current consumers include:
+
+## Inner-workings / Algorithms
+
+### Get distance to nearest obstacle
+
+Calculate the distance between the ego vehicle and the nearest obstacle.
+The minimum distance is computed between ego vehicle footprint and:
+
+- all points in the input point cloud
+- the polygons of enabled dynamic objects
+
+The ego footprint is created based on vehicle info and user defined margins per obstacle type. For each given obstacle type (e.g car, pedestrian, pointcloud, etc) the following margins are defined:
+
+- `surround_check_front_distance`
+- `surround_check_side_distance`
+- `surround_check_back_distance`
+
+### Obstacle detection
+
+An obstacle is considered nearby when:
+
+```text
+nearest_distance < contact_distance_threshold
+```
+
+`contact_distance_threshold` is provided by the caller on each `check()` call.
+This allows callers to implement distance hysteresis (for example, a tight threshold when entering stop and a wider threshold when clearing stop).
+
+The library does **not** manage:
+
+- ego stopped checks
+- state machines (`PASS` / `STOP`)
+- time-based hysteresis
+- ROS subscriptions, publishers, or TF transforms
+
+Those responsibilities remain in the calling node or plugin.
+
+## API
+
+### Input (`Inputs`)
+
+| Field                     | Type                                                              | Description                             |
+| ------------------------- | ----------------------------------------------------------------- | --------------------------------------- |
+| `ego_pose`                | `geometry_msgs::msg::Pose`                                        | Ego pose used for dynamic object checks |
+| `pointcloud_in_base_link` | `pcl::PointCloud<pcl::PointXYZ>::ConstPtr`                        | Obstacle point cloud in `base_link`     |
+| `objects`                 | `autoware_perception_msgs::msg::PredictedObjects::ConstSharedPtr` | Dynamic objects                         |
+
+Callers must transform the point cloud to `base_link` before passing it to the library.
+
+### Output (`CheckResult`)
+
+| Field               | Type                               | Description                                                           |
+| ------------------- | ---------------------------------- | --------------------------------------------------------------------- |
+| `is_obstacle_found` | `bool`                             | `true` if the nearest obstacle is within `contact_distance_threshold` |
+| `nearest_obstacle`  | `std::optional<ProximityObstacle>` | Nearest obstacle and its distance, if any                             |
+
+`ProximityObstacle` contains:
+
+| Field              | Type                                | Description                                            |
+| ------------------ | ----------------------------------- | ------------------------------------------------------ |
+| `is_point_cloud`   | `bool`                              | `true` if the nearest obstacle came from a point cloud |
+| `nearest_distance` | `double`                            | Minimum distance to the ego footprint [m]              |
+| `nearest_point`    | `geometry_msgs::msg::Point`         | Nearest point in map coordinates                       |
+| `uuid`             | `unique_identifier_msgs::msg::UUID` | Object UUID, or empty for point clouds                 |
+
+### Parameters (`Parameters`)
+
+| Name                       | Type                                            | Description                                           |
+| -------------------------- | ----------------------------------------------- | ----------------------------------------------------- |
+| `pointcloud_enable_check`  | `bool`                                          | Enable point cloud proximity checks                   |
+| `object_type_enable_check` | `unordered_map<string, bool>`                   | Enable checks per object label (`car`, `truck`, etc.) |
+| `obstacle_types_map`       | `unordered_map<string, ObstacleTypeParameters>` | Per-type footprint margins                            |
+
+`ObstacleTypeParameters` fields:
+
+| Name                            | Type     | Description                                 | Typical value |
+| ------------------------------- | -------- | ------------------------------------------- | ------------- |
+| `surround_check_front_distance` | `double` | Front margin added to the ego footprint [m] | 0.5           |
+| `surround_check_side_distance`  | `double` | Side margin added to the ego footprint [m]  | 0.0–1.0       |
+| `surround_check_back_distance`  | `double` | Rear margin added to the ego footprint [m]  | 0.0–0.5       |
+
+Supported object labels:
+
+`unknown`, `car`, `truck`, `bus`, `trailer`, `motorcycle`, `bicycle`, `pedestrian`, `pointcloud`
+
+## Assumptions / Known limits
+
+- Point clouds must already be transformed to `base_link`.
+- The library performs geometric proximity checks only. Stop/release decisions, velocity limits, and trajectory modification are handled by callers.

--- a/common/autoware_obstacle_proximity_checker/include/autoware/obstacle_proximity_checker/obstacle_proximity_checker.hpp
+++ b/common/autoware_obstacle_proximity_checker/include/autoware/obstacle_proximity_checker/obstacle_proximity_checker.hpp
@@ -1,0 +1,76 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__OBSTACLE_PROXIMITY_CHECKER__OBSTACLE_PROXIMITY_CHECKER_HPP_
+#define AUTOWARE__OBSTACLE_PROXIMITY_CHECKER__OBSTACLE_PROXIMITY_CHECKER_HPP_
+
+#include "autoware/obstacle_proximity_checker/structs.hpp"
+
+#include <autoware/vehicle_info_utils/vehicle_info.hpp>
+
+#include <optional>
+
+namespace autoware::obstacle_proximity_checker
+{
+
+/// @brief class to check for nearby obstacles around the ego vehicle
+class ProximityChecker
+{
+public:
+  /**
+   * @brief constructor
+   * @param parameters parameters for proximity check
+   * @param vehicle_info vehicle information
+   */
+  ProximityChecker(
+    const Parameters & parameters, const vehicle_info_utils::VehicleInfo & vehicle_info);
+
+  /**
+   * @brief check for nearby obstacles
+   * @param input input data for proximity check
+   * @param contact_distance_threshold distance threshold below which an obstacle is considered
+   * nearby [m]
+   * @return result specifying if a nearby obstacle is found and the nearest obstacle
+   */
+  [[nodiscard]] CheckResult check(
+    const Inputs & input, double contact_distance_threshold) const;
+
+  /**
+   * @brief update parameters
+   * @param parameters new parameters
+   */
+  void update_parameters(const Parameters & parameters);
+
+private:
+  [[nodiscard]] bool getUseDynamicObject() const;
+
+  [[nodiscard]] std::optional<ProximityObstacle> getNearestObstacle(const Inputs & input) const;
+
+  [[nodiscard]] std::optional<ProximityObstacle> getNearestObstacleByPointCloud(
+    const Inputs & input) const;
+
+  [[nodiscard]] std::optional<ProximityObstacle> getNearestObstacleByDynamicObject(
+    const Inputs & input) const;
+
+  [[nodiscard]] bool isObstacleFound(
+    const std::optional<ProximityObstacle> & nearest_obstacle,
+    double contact_distance_threshold) const;
+
+  Parameters parameters_;
+  vehicle_info_utils::VehicleInfo vehicle_info_;
+};
+
+}  // namespace autoware::obstacle_proximity_checker
+
+#endif  // AUTOWARE__OBSTACLE_PROXIMITY_CHECKER__OBSTACLE_PROXIMITY_CHECKER_HPP_

--- a/common/autoware_obstacle_proximity_checker/include/autoware/obstacle_proximity_checker/obstacle_proximity_checker.hpp
+++ b/common/autoware_obstacle_proximity_checker/include/autoware/obstacle_proximity_checker/obstacle_proximity_checker.hpp
@@ -43,8 +43,7 @@ public:
    * nearby [m]
    * @return result specifying if a nearby obstacle is found and the nearest obstacle
    */
-  [[nodiscard]] CheckResult check(
-    const Inputs & input, double contact_distance_threshold) const;
+  [[nodiscard]] CheckResult check(const Inputs & input, double contact_distance_threshold) const;
 
   /**
    * @brief update parameters

--- a/common/autoware_obstacle_proximity_checker/include/autoware/obstacle_proximity_checker/structs.hpp
+++ b/common/autoware_obstacle_proximity_checker/include/autoware/obstacle_proximity_checker/structs.hpp
@@ -15,13 +15,13 @@
 #ifndef AUTOWARE__OBSTACLE_PROXIMITY_CHECKER__STRUCTS_HPP_
 #define AUTOWARE__OBSTACLE_PROXIMITY_CHECKER__STRUCTS_HPP_
 
+#include <Eigen/Geometry>
+
 #include <autoware_perception_msgs/msg/predicted_objects.hpp>
 #include <geometry_msgs/msg/point.hpp>
 #include <geometry_msgs/msg/pose.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
 #include <unique_identifier_msgs/msg/uuid.hpp>
-
-#include <Eigen/Geometry>
 
 #include <memory>
 #include <optional>

--- a/common/autoware_obstacle_proximity_checker/include/autoware/obstacle_proximity_checker/structs.hpp
+++ b/common/autoware_obstacle_proximity_checker/include/autoware/obstacle_proximity_checker/structs.hpp
@@ -1,0 +1,72 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__OBSTACLE_PROXIMITY_CHECKER__STRUCTS_HPP_
+#define AUTOWARE__OBSTACLE_PROXIMITY_CHECKER__STRUCTS_HPP_
+
+#include <autoware_perception_msgs/msg/predicted_objects.hpp>
+#include <geometry_msgs/msg/point.hpp>
+#include <geometry_msgs/msg/pose.hpp>
+#include <sensor_msgs/msg/point_cloud2.hpp>
+#include <unique_identifier_msgs/msg/uuid.hpp>
+
+#include <Eigen/Geometry>
+
+#include <memory>
+#include <optional>
+#include <string>
+#include <unordered_map>
+
+namespace autoware::obstacle_proximity_checker
+{
+
+struct ObstacleTypeParameters
+{
+  double surround_check_front_distance{0.0};
+  double surround_check_side_distance{0.0};
+  double surround_check_back_distance{0.0};
+};
+
+struct Parameters
+{
+  bool pointcloud_enable_check{false};
+  std::unordered_map<std::string, bool> object_type_enable_check;
+  std::unordered_map<std::string, ObstacleTypeParameters> obstacle_types_map;
+};
+
+struct ProximityObstacle
+{
+  bool is_point_cloud{false};
+  double nearest_distance{0.0};
+  geometry_msgs::msg::Point nearest_point;
+  unique_identifier_msgs::msg::UUID uuid;
+};
+
+struct Inputs
+{
+  geometry_msgs::msg::Pose ego_pose;
+  sensor_msgs::msg::PointCloud2::ConstSharedPtr pointcloud;
+  autoware_perception_msgs::msg::PredictedObjects::ConstSharedPtr objects;
+  std::optional<Eigen::Affine3f> pointcloud_to_base_link_transform;
+};
+
+struct CheckResult
+{
+  bool is_obstacle_found{false};
+  std::optional<ProximityObstacle> nearest_obstacle;
+};
+
+}  // namespace autoware::obstacle_proximity_checker
+
+#endif  // AUTOWARE__OBSTACLE_PROXIMITY_CHECKER__STRUCTS_HPP_

--- a/common/autoware_obstacle_proximity_checker/include/autoware/obstacle_proximity_checker/structs.hpp
+++ b/common/autoware_obstacle_proximity_checker/include/autoware/obstacle_proximity_checker/structs.hpp
@@ -15,13 +15,14 @@
 #ifndef AUTOWARE__OBSTACLE_PROXIMITY_CHECKER__STRUCTS_HPP_
 #define AUTOWARE__OBSTACLE_PROXIMITY_CHECKER__STRUCTS_HPP_
 
-#include <Eigen/Geometry>
-
 #include <autoware_perception_msgs/msg/predicted_objects.hpp>
 #include <geometry_msgs/msg/point.hpp>
 #include <geometry_msgs/msg/pose.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
 #include <unique_identifier_msgs/msg/uuid.hpp>
+
+#include <pcl/point_cloud.h>
+#include <pcl/point_types.h>
 
 #include <memory>
 #include <optional>
@@ -56,9 +57,8 @@ struct ProximityObstacle
 struct Inputs
 {
   geometry_msgs::msg::Pose ego_pose;
-  sensor_msgs::msg::PointCloud2::ConstSharedPtr pointcloud;
-  autoware_perception_msgs::msg::PredictedObjects::ConstSharedPtr objects;
-  std::optional<Eigen::Affine3f> pointcloud_to_base_link_transform;
+  pcl::PointCloud<pcl::PointXYZ>::ConstPtr pointcloud_in_base_link{nullptr};
+  autoware_perception_msgs::msg::PredictedObjects::ConstSharedPtr objects{nullptr};
 };
 
 struct CheckResult

--- a/common/autoware_obstacle_proximity_checker/package.xml
+++ b/common/autoware_obstacle_proximity_checker/package.xml
@@ -5,6 +5,8 @@
   <version>0.50.0</version>
   <description>Library for checking nearby obstacles around the ego vehicle</description>
   <maintainer email="alqudah.mohammad@tier4.jp">Alqudah Mohammad</maintainer>
+  <maintainer email="satoshi.ota@tier4.jp">Satoshi Ota</maintainer>
+  <maintainer email="takumi.odashima@tier4.jp">Takumi Odashima</maintainer>
 
   <license>Apache License 2.0</license>
 

--- a/common/autoware_obstacle_proximity_checker/package.xml
+++ b/common/autoware_obstacle_proximity_checker/package.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>autoware_obstacle_proximity_checker</name>
+  <version>0.50.0</version>
+  <description>Library for checking nearby obstacles around the ego vehicle</description>
+  <maintainer email="alqudah.mohammad@tier4.jp">Alqudah Mohammad</maintainer>
+
+  <license>Apache License 2.0</license>
+
+  <buildtool_depend>ament_cmake_auto</buildtool_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
+  <buildtool_depend>eigen3_cmake_module</buildtool_depend>
+
+  <depend>autoware_perception_msgs</depend>
+  <depend>autoware_universe_utils</depend>
+  <depend>autoware_utils</depend>
+  <depend>autoware_vehicle_info_utils</depend>
+  <depend>boost</depend>
+  <depend>eigen</depend>
+  <depend>geometry_msgs</depend>
+  <depend>libpcl-all-dev</depend>
+  <depend>pcl_conversions</depend>
+  <depend>sensor_msgs</depend>
+  <depend>unique_identifier_msgs</depend>
+
+  <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>autoware_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/common/autoware_obstacle_proximity_checker/src/obstacle_proximity_checker.cpp
+++ b/common/autoware_obstacle_proximity_checker/src/obstacle_proximity_checker.cpp
@@ -29,6 +29,7 @@
 #include <pcl_conversions/pcl_conversions.h>
 
 #include <limits>
+#include <string>
 #include <unordered_map>
 
 namespace autoware::obstacle_proximity_checker
@@ -197,7 +198,9 @@ std::optional<ProximityObstacle> ProximityChecker::getNearestObstacleByDynamicOb
 
     const auto & str_label = label_iter->second;
     const auto enable_check_iter = parameters_.object_type_enable_check.find(str_label);
-    if (enable_check_iter == parameters_.object_type_enable_check.end() || !enable_check_iter->second) {
+    if (
+      enable_check_iter == parameters_.object_type_enable_check.end() ||
+      !enable_check_iter->second) {
       continue;
     }
 
@@ -227,8 +230,7 @@ std::optional<ProximityObstacle> ProximityChecker::getNearestObstacleByDynamicOb
   ProximityObstacle obstacle;
   obstacle.is_point_cloud = false;
   obstacle.nearest_distance = minimum_distance;
-  obstacle.nearest_point =
-    nearest_object.kinematics.initial_pose_with_covariance.pose.position;
+  obstacle.nearest_point = nearest_object.kinematics.initial_pose_with_covariance.pose.position;
   obstacle.uuid = nearest_object.object_id;
   return obstacle;
 }

--- a/common/autoware_obstacle_proximity_checker/src/obstacle_proximity_checker.cpp
+++ b/common/autoware_obstacle_proximity_checker/src/obstacle_proximity_checker.cpp
@@ -17,7 +17,6 @@
 #include <autoware/universe_utils/geometry/geometry.hpp>
 #include <autoware_utils/geometry/boost_polygon_utils.hpp>
 #include <autoware_utils/geometry/geometry.hpp>
-#include <autoware_utils/transform/transforms.hpp>
 
 #include <autoware_perception_msgs/msg/object_classification.hpp>
 
@@ -128,19 +127,13 @@ std::optional<ProximityObstacle> ProximityChecker::getNearestObstacle(const Inpu
 std::optional<ProximityObstacle> ProximityChecker::getNearestObstacleByPointCloud(
   const Inputs & input) const
 {
-  if (!parameters_.pointcloud_enable_check || !input.pointcloud) {
+  if (!parameters_.pointcloud_enable_check || !input.pointcloud_in_base_link) {
     return std::nullopt;
   }
 
-  if (input.pointcloud->data.empty() || !input.pointcloud_to_base_link_transform.has_value()) {
+  if (input.pointcloud_in_base_link->empty()) {
     return std::nullopt;
   }
-
-  pcl::PointCloud<pcl::PointXYZ> transformed_pointcloud;
-  pcl::fromROSMsg(*input.pointcloud, transformed_pointcloud);
-  autoware_utils::transform_pointcloud(
-    transformed_pointcloud, transformed_pointcloud,
-    input.pointcloud_to_base_link_transform.value());
 
   const auto & pointcloud_param = parameters_.obstacle_types_map.at("pointcloud");
   const double front_margin = pointcloud_param.surround_check_front_distance;
@@ -155,7 +148,7 @@ std::optional<ProximityObstacle> ProximityChecker::getNearestObstacleByPointClou
   geometry_msgs::msg::Point nearest_point_base_link;
   double minimum_distance = std::numeric_limits<double>::max();
   bool was_minimum_distance_updated = false;
-  for (const auto & point : transformed_pointcloud) {
+  for (const auto & point : *input.pointcloud_in_base_link) {
     const Point2d boost_point(point.x, point.y);
     const auto distance_to_object = bg::distance(ego_polygon, boost_point);
 

--- a/common/autoware_obstacle_proximity_checker/src/obstacle_proximity_checker.cpp
+++ b/common/autoware_obstacle_proximity_checker/src/obstacle_proximity_checker.cpp
@@ -1,0 +1,236 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/obstacle_proximity_checker/obstacle_proximity_checker.hpp"
+
+#include <autoware/universe_utils/geometry/geometry.hpp>
+#include <autoware_utils/geometry/boost_polygon_utils.hpp>
+#include <autoware_utils/geometry/geometry.hpp>
+#include <autoware_utils/transform/transforms.hpp>
+
+#include <autoware_perception_msgs/msg/object_classification.hpp>
+
+#include <boost/geometry.hpp>
+#include <boost/geometry/geometries/point_xy.hpp>
+
+#include <pcl/point_cloud.h>
+#include <pcl/point_types.h>
+#include <pcl_conversions/pcl_conversions.h>
+
+#include <limits>
+#include <unordered_map>
+
+namespace autoware::obstacle_proximity_checker
+{
+namespace
+{
+namespace bg = boost::geometry;
+using Point2d = bg::model::d2::point_xy<double>;
+using Polygon2d = bg::model::polygon<Point2d>;
+using autoware_perception_msgs::msg::ObjectClassification;
+using autoware_utils::create_point;
+
+const std::unordered_map<int, std::string> kLabelMap = {
+  {ObjectClassification::UNKNOWN, "unknown"}, {ObjectClassification::CAR, "car"},
+  {ObjectClassification::TRUCK, "truck"},     {ObjectClassification::BUS, "bus"},
+  {ObjectClassification::TRAILER, "trailer"}, {ObjectClassification::MOTORCYCLE, "motorcycle"},
+  {ObjectClassification::BICYCLE, "bicycle"}, {ObjectClassification::PEDESTRIAN, "pedestrian"}};
+
+geometry_msgs::msg::Pose createBaseLinkOrigin()
+{
+  geometry_msgs::msg::Pose pose;
+  pose.position.x = 0.0;
+  pose.position.y = 0.0;
+  pose.position.z = 0.0;
+  pose.orientation = autoware_utils_geometry::create_quaternion_from_yaw(0.0);
+  return pose;
+}
+
+}  // namespace
+
+ProximityChecker::ProximityChecker(
+  const Parameters & parameters, const vehicle_info_utils::VehicleInfo & vehicle_info)
+: parameters_(parameters), vehicle_info_(vehicle_info)
+{
+}
+
+CheckResult ProximityChecker::check(
+  const Inputs & input, const double contact_distance_threshold) const
+{
+  const auto nearest_obstacle = getNearestObstacle(input);
+
+  CheckResult result;
+  result.nearest_obstacle = nearest_obstacle;
+  result.is_obstacle_found = isObstacleFound(nearest_obstacle, contact_distance_threshold);
+  return result;
+}
+
+void ProximityChecker::update_parameters(const Parameters & parameters)
+{
+  parameters_ = parameters;
+}
+
+bool ProximityChecker::getUseDynamicObject() const
+{
+  for (const auto & [label, enabled] : parameters_.object_type_enable_check) {
+    (void)label;
+    if (enabled) {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool ProximityChecker::isObstacleFound(
+  const std::optional<ProximityObstacle> & nearest_obstacle,
+  const double contact_distance_threshold) const
+{
+  if (!nearest_obstacle.has_value()) {
+    return false;
+  }
+
+  return nearest_obstacle.value().nearest_distance < contact_distance_threshold;
+}
+
+std::optional<ProximityObstacle> ProximityChecker::getNearestObstacle(const Inputs & input) const
+{
+  const auto nearest_pointcloud = getNearestObstacleByPointCloud(input);
+  const auto nearest_object = getNearestObstacleByDynamicObject(input);
+  if (!nearest_pointcloud.has_value() && !nearest_object.has_value()) {
+    return std::nullopt;
+  }
+
+  if (!nearest_pointcloud.has_value()) {
+    return nearest_object;
+  }
+
+  if (!nearest_object.has_value()) {
+    return nearest_pointcloud;
+  }
+
+  return nearest_pointcloud.value().nearest_distance < nearest_object.value().nearest_distance
+           ? nearest_pointcloud
+           : nearest_object;
+}
+
+std::optional<ProximityObstacle> ProximityChecker::getNearestObstacleByPointCloud(
+  const Inputs & input) const
+{
+  if (!parameters_.pointcloud_enable_check || !input.pointcloud) {
+    return std::nullopt;
+  }
+
+  if (input.pointcloud->data.empty() || !input.pointcloud_to_base_link_transform.has_value()) {
+    return std::nullopt;
+  }
+
+  pcl::PointCloud<pcl::PointXYZ> transformed_pointcloud;
+  pcl::fromROSMsg(*input.pointcloud, transformed_pointcloud);
+  autoware_utils::transform_pointcloud(
+    transformed_pointcloud, transformed_pointcloud,
+    input.pointcloud_to_base_link_transform.value());
+
+  const auto & pointcloud_param = parameters_.obstacle_types_map.at("pointcloud");
+  const double front_margin = pointcloud_param.surround_check_front_distance;
+  const double side_margin = pointcloud_param.surround_check_side_distance;
+  const double back_margin = pointcloud_param.surround_check_back_distance;
+  const double base_to_front = vehicle_info_.max_longitudinal_offset_m + front_margin;
+  const double base_to_rear = vehicle_info_.rear_overhang_m + back_margin;
+  const double width = vehicle_info_.vehicle_width_m + side_margin * 2;
+  const auto ego_polygon =
+    autoware_utils::to_footprint(createBaseLinkOrigin(), base_to_front, base_to_rear, width);
+
+  geometry_msgs::msg::Point nearest_point_base_link;
+  double minimum_distance = std::numeric_limits<double>::max();
+  bool was_minimum_distance_updated = false;
+  for (const auto & point : transformed_pointcloud) {
+    const Point2d boost_point(point.x, point.y);
+    const auto distance_to_object = bg::distance(ego_polygon, boost_point);
+
+    if (distance_to_object < minimum_distance) {
+      nearest_point_base_link = create_point(point.x, point.y, point.z);
+      minimum_distance = distance_to_object;
+      was_minimum_distance_updated = true;
+    }
+  }
+
+  if (!was_minimum_distance_updated) {
+    return std::nullopt;
+  }
+
+  ProximityObstacle obstacle;
+  obstacle.is_point_cloud = true;
+  obstacle.nearest_distance = minimum_distance;
+  obstacle.nearest_point =
+    autoware::universe_utils::transformPoint(nearest_point_base_link, input.ego_pose);
+  obstacle.uuid = unique_identifier_msgs::msg::UUID();
+  return obstacle;
+}
+
+std::optional<ProximityObstacle> ProximityChecker::getNearestObstacleByDynamicObject(
+  const Inputs & input) const
+{
+  if (!input.objects || !getUseDynamicObject()) {
+    return std::nullopt;
+  }
+
+  autoware_perception_msgs::msg::PredictedObject nearest_object;
+  double minimum_distance = std::numeric_limits<double>::max();
+  bool was_minimum_distance_updated = false;
+  for (const auto & object : input.objects->objects) {
+    const int label = object.classification.front().label;
+    const auto label_iter = kLabelMap.find(label);
+    if (label_iter == kLabelMap.end()) {
+      continue;
+    }
+
+    const auto & str_label = label_iter->second;
+    const auto enable_check_iter = parameters_.object_type_enable_check.find(str_label);
+    if (enable_check_iter == parameters_.object_type_enable_check.end() || !enable_check_iter->second) {
+      continue;
+    }
+
+    const auto & object_param = parameters_.obstacle_types_map.at(str_label);
+    const double front_margin = object_param.surround_check_front_distance;
+    const double side_margin = object_param.surround_check_side_distance;
+    const double back_margin = object_param.surround_check_back_distance;
+    const double base_to_front = vehicle_info_.max_longitudinal_offset_m + front_margin;
+    const double base_to_rear = vehicle_info_.rear_overhang_m + back_margin;
+    const double width = vehicle_info_.vehicle_width_m + side_margin * 2;
+    const auto ego_polygon =
+      autoware_utils::to_footprint(input.ego_pose, base_to_front, base_to_rear, width);
+    const auto object_polygon = autoware_utils::to_polygon2d(object);
+    const auto distance_to_object = bg::distance(ego_polygon, object_polygon);
+
+    if (distance_to_object < minimum_distance) {
+      nearest_object = object;
+      minimum_distance = distance_to_object;
+      was_minimum_distance_updated = true;
+    }
+  }
+
+  if (!was_minimum_distance_updated) {
+    return std::nullopt;
+  }
+
+  ProximityObstacle obstacle;
+  obstacle.is_point_cloud = false;
+  obstacle.nearest_distance = minimum_distance;
+  obstacle.nearest_point =
+    nearest_object.kinematics.initial_pose_with_covariance.pose.position;
+  obstacle.uuid = nearest_object.object_id;
+  return obstacle;
+}
+
+}  // namespace autoware::obstacle_proximity_checker

--- a/common/autoware_obstacle_proximity_checker/test/test_obstacle_proximity_checker.cpp
+++ b/common/autoware_obstacle_proximity_checker/test/test_obstacle_proximity_checker.cpp
@@ -14,6 +14,7 @@
 
 #include "autoware/obstacle_proximity_checker/obstacle_proximity_checker.hpp"
 
+#include <Eigen/Geometry>
 #include <autoware_utils/geometry/geometry.hpp>
 #include <autoware_vehicle_info_utils/vehicle_info_utils.hpp>
 
@@ -22,7 +23,6 @@
 #include <autoware_perception_msgs/msg/shape.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
 
-#include <Eigen/Geometry>
 #include <gtest/gtest.h>
 #include <pcl/point_cloud.h>
 #include <pcl/point_types.h>
@@ -45,8 +45,7 @@ constexpr double kContactDistanceThreshold = 1e-3;
 
 vehicle_info_utils::VehicleInfo make_vehicle_info()
 {
-  return vehicle_info_utils::createVehicleInfo(
-    0.3, 0.2, 2.5, 1.6, 1.0, 1.0, 0.5, 0.5, 1.8, 0.7);
+  return vehicle_info_utils::createVehicleInfo(0.3, 0.2, 2.5, 1.6, 1.0, 1.0, 0.5, 0.5, 1.8, 0.7);
 }
 
 ObstacleTypeParameters make_obstacle_type_parameters(
@@ -98,8 +97,7 @@ sensor_msgs::msg::PointCloud2::SharedPtr make_pointcloud(
   return cloud_msg;
 }
 
-PredictedObjects::SharedPtr make_predicted_objects(
-  const std::vector<PredictedObject> & objects)
+PredictedObjects::SharedPtr make_predicted_objects(const std::vector<PredictedObject> & objects)
 {
   auto objects_msg = std::make_shared<PredictedObjects>();
   objects_msg->objects = objects;
@@ -179,8 +177,7 @@ TEST_F(ProximityCheckerTest, NoObstacleWhenPointcloudCheckDisabled)
 TEST_F(ProximityCheckerTest, DetectsNearbyPointInPointcloud)
 {
   const auto pointcloud = make_pointcloud({{4.2F, 0.0F, 0.0F}});
-  const auto result =
-    checker_->check(make_inputs(ego_pose_, pointcloud), 0.5);
+  const auto result = checker_->check(make_inputs(ego_pose_, pointcloud), 0.5);
 
   ASSERT_TRUE(result.nearest_obstacle.has_value());
   EXPECT_TRUE(result.nearest_obstacle->is_point_cloud);
@@ -223,8 +220,7 @@ TEST_F(ProximityCheckerTest, NoObstacleWhenPointcloudTransformMissing)
 TEST_F(ProximityCheckerTest, DetectsNearbyDynamicObject)
 {
   const auto objects = make_predicted_objects({make_car_object(5.2, 0.0)});
-  const auto result =
-    checker_->check(make_inputs(ego_pose_, nullptr, objects), 0.5);
+  const auto result = checker_->check(make_inputs(ego_pose_, nullptr, objects), 0.5);
 
   ASSERT_TRUE(result.nearest_obstacle.has_value());
   EXPECT_FALSE(result.nearest_obstacle->is_point_cloud);
@@ -238,8 +234,7 @@ TEST_F(ProximityCheckerTest, IgnoresDisabledObjectTypes)
   checker_->update_parameters(parameters_);
 
   const auto objects = make_predicted_objects({make_car_object(5.2, 0.0)});
-  const auto result =
-    checker_->check(make_inputs(ego_pose_, nullptr, objects), 0.5);
+  const auto result = checker_->check(make_inputs(ego_pose_, nullptr, objects), 0.5);
 
   EXPECT_FALSE(result.is_obstacle_found);
   EXPECT_FALSE(result.nearest_obstacle.has_value());
@@ -250,8 +245,7 @@ TEST_F(ProximityCheckerTest, SelectsNearestBetweenPointcloudAndObject)
   const auto pointcloud = make_pointcloud({{4.5F, 0.0F, 0.0F}});
   const auto objects = make_predicted_objects({make_car_object(5.2, 0.0)});
 
-  const auto result = checker_->check(
-    make_inputs(ego_pose_, pointcloud, objects), 0.5);
+  const auto result = checker_->check(make_inputs(ego_pose_, pointcloud, objects), 0.5);
 
   ASSERT_TRUE(result.nearest_obstacle.has_value());
   EXPECT_FALSE(result.nearest_obstacle->is_point_cloud);

--- a/common/autoware_obstacle_proximity_checker/test/test_obstacle_proximity_checker.cpp
+++ b/common/autoware_obstacle_proximity_checker/test/test_obstacle_proximity_checker.cpp
@@ -41,8 +41,6 @@ using autoware_perception_msgs::msg::PredictedObject;
 using autoware_perception_msgs::msg::PredictedObjects;
 using autoware_perception_msgs::msg::Shape;
 
-constexpr double kContactDistanceThreshold = 1e-3;
-
 vehicle_info_utils::VehicleInfo make_vehicle_info()
 {
   return vehicle_info_utils::createVehicleInfo(0.3, 0.2, 2.5, 1.6, 1.0, 1.0, 0.5, 0.5, 1.8, 0.7);
@@ -83,18 +81,15 @@ geometry_msgs::msg::Pose make_pose(const double x, const double y)
   return pose;
 }
 
-sensor_msgs::msg::PointCloud2::SharedPtr make_pointcloud(
-  const std::vector<std::array<float, 3>> & points, const std::string & frame_id = "base_link")
+pcl::PointCloud<pcl::PointXYZ>::Ptr make_pointcloud(
+  const std::vector<std::array<float, 3>> & points)
 {
   pcl::PointCloud<pcl::PointXYZ> pcl_cloud;
   for (const auto & point : points) {
     pcl_cloud.push_back(pcl::PointXYZ(point[0], point[1], point[2]));
   }
 
-  auto cloud_msg = std::make_shared<sensor_msgs::msg::PointCloud2>();
-  pcl::toROSMsg(pcl_cloud, *cloud_msg);
-  cloud_msg->header.frame_id = frame_id;
-  return cloud_msg;
+  return pcl_cloud.makeShared();
 }
 
 PredictedObjects::SharedPtr make_predicted_objects(const std::vector<PredictedObject> & objects)
@@ -121,17 +116,13 @@ PredictedObject make_car_object(const double x, const double y, const uint8_t id
 
 Inputs make_inputs(
   const geometry_msgs::msg::Pose & ego_pose,
-  const sensor_msgs::msg::PointCloud2::ConstSharedPtr & pointcloud = nullptr,
-  const PredictedObjects::ConstSharedPtr & objects = nullptr,
-  const bool use_identity_transform = true)
+  const pcl::PointCloud<pcl::PointXYZ>::ConstPtr & pointcloud = nullptr,
+  const PredictedObjects::ConstSharedPtr & objects = nullptr)
 {
   Inputs inputs;
   inputs.ego_pose = ego_pose;
-  inputs.pointcloud = pointcloud;
+  inputs.pointcloud_in_base_link = pointcloud;
   inputs.objects = objects;
-  if (use_identity_transform) {
-    inputs.pointcloud_to_base_link_transform = Eigen::Affine3f::Identity();
-  }
   return inputs;
 }
 
@@ -156,7 +147,7 @@ protected:
 
 TEST_F(ProximityCheckerTest, NoObstacleWhenInputsAreEmpty)
 {
-  const auto result = checker_->check(make_inputs(ego_pose_), kContactDistanceThreshold);
+  const auto result = checker_->check(make_inputs(ego_pose_), 1e-3);
   EXPECT_FALSE(result.is_obstacle_found);
   EXPECT_FALSE(result.nearest_obstacle.has_value());
 }
@@ -167,8 +158,7 @@ TEST_F(ProximityCheckerTest, NoObstacleWhenPointcloudCheckDisabled)
   checker_->update_parameters(parameters_);
 
   const auto pointcloud = make_pointcloud({{0.0F, 0.0F, 0.0F}});
-  const auto result =
-    checker_->check(make_inputs(ego_pose_, pointcloud), kContactDistanceThreshold);
+  const auto result = checker_->check(make_inputs(ego_pose_, pointcloud), 1e-3);
 
   EXPECT_FALSE(result.is_obstacle_found);
   EXPECT_FALSE(result.nearest_obstacle.has_value());
@@ -188,8 +178,7 @@ TEST_F(ProximityCheckerTest, DetectsNearbyPointInPointcloud)
 TEST_F(ProximityCheckerTest, NoObstacleForFarPointInPointcloud)
 {
   const auto pointcloud = make_pointcloud({{20.0F, 0.0F, 0.0F}});
-  const auto result =
-    checker_->check(make_inputs(ego_pose_, pointcloud), kContactDistanceThreshold);
+  const auto result = checker_->check(make_inputs(ego_pose_, pointcloud), 1e-3);
 
   EXPECT_FALSE(result.is_obstacle_found);
 }
@@ -205,16 +194,6 @@ TEST_F(ProximityCheckerTest, RespectsContactDistanceThreshold)
 
   const auto result_above_threshold = checker_->check(inputs, 0.5);
   EXPECT_TRUE(result_above_threshold.is_obstacle_found);
-}
-
-TEST_F(ProximityCheckerTest, NoObstacleWhenPointcloudTransformMissing)
-{
-  auto inputs = make_inputs(ego_pose_, make_pointcloud({{4.2F, 0.0F, 0.0F}}), nullptr, false);
-  inputs.pointcloud_to_base_link_transform = std::nullopt;
-
-  const auto result = checker_->check(inputs, 0.5);
-  EXPECT_FALSE(result.is_obstacle_found);
-  EXPECT_FALSE(result.nearest_obstacle.has_value());
 }
 
 TEST_F(ProximityCheckerTest, DetectsNearbyDynamicObject)
@@ -258,7 +237,7 @@ TEST_F(ProximityCheckerTest, UpdateParametersDisablesPointcloudCheck)
   const auto inputs = make_inputs(ego_pose_, pointcloud);
 
   {
-    const auto result = checker_->check(inputs, kContactDistanceThreshold);
+    const auto result = checker_->check(inputs, 1e-3);
     EXPECT_TRUE(result.is_obstacle_found);
   }
 
@@ -266,7 +245,7 @@ TEST_F(ProximityCheckerTest, UpdateParametersDisablesPointcloudCheck)
   checker_->update_parameters(parameters_);
 
   {
-    const auto result = checker_->check(inputs, kContactDistanceThreshold);
+    const auto result = checker_->check(inputs, 1e-3);
     EXPECT_FALSE(result.is_obstacle_found);
   }
 }

--- a/common/autoware_obstacle_proximity_checker/test/test_obstacle_proximity_checker.cpp
+++ b/common/autoware_obstacle_proximity_checker/test/test_obstacle_proximity_checker.cpp
@@ -1,0 +1,280 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/obstacle_proximity_checker/obstacle_proximity_checker.hpp"
+
+#include <autoware_utils/geometry/geometry.hpp>
+#include <autoware_vehicle_info_utils/vehicle_info_utils.hpp>
+
+#include <autoware_perception_msgs/msg/object_classification.hpp>
+#include <autoware_perception_msgs/msg/predicted_objects.hpp>
+#include <autoware_perception_msgs/msg/shape.hpp>
+#include <sensor_msgs/msg/point_cloud2.hpp>
+
+#include <Eigen/Geometry>
+#include <gtest/gtest.h>
+#include <pcl/point_cloud.h>
+#include <pcl/point_types.h>
+#include <pcl_conversions/pcl_conversions.h>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace autoware::obstacle_proximity_checker
+{
+namespace
+{
+using autoware_perception_msgs::msg::ObjectClassification;
+using autoware_perception_msgs::msg::PredictedObject;
+using autoware_perception_msgs::msg::PredictedObjects;
+using autoware_perception_msgs::msg::Shape;
+
+constexpr double kContactDistanceThreshold = 1e-3;
+
+vehicle_info_utils::VehicleInfo make_vehicle_info()
+{
+  return vehicle_info_utils::createVehicleInfo(
+    0.3, 0.2, 2.5, 1.6, 1.0, 1.0, 0.5, 0.5, 1.8, 0.7);
+}
+
+ObstacleTypeParameters make_obstacle_type_parameters(
+  const double front = 0.5, const double side = 0.0, const double back = 0.0)
+{
+  ObstacleTypeParameters parameters;
+  parameters.surround_check_front_distance = front;
+  parameters.surround_check_side_distance = side;
+  parameters.surround_check_back_distance = back;
+  return parameters;
+}
+
+Parameters make_default_parameters()
+{
+  Parameters parameters;
+  parameters.pointcloud_enable_check = true;
+  parameters.object_type_enable_check["car"] = true;
+  parameters.object_type_enable_check["pedestrian"] = false;
+
+  const auto obstacle_params = make_obstacle_type_parameters();
+  parameters.obstacle_types_map["pointcloud"] = obstacle_params;
+  parameters.obstacle_types_map["car"] = obstacle_params;
+  parameters.obstacle_types_map["pedestrian"] = obstacle_params;
+
+  return parameters;
+}
+
+geometry_msgs::msg::Pose make_pose(const double x, const double y)
+{
+  geometry_msgs::msg::Pose pose;
+  pose.position.x = x;
+  pose.position.y = y;
+  pose.position.z = 0.0;
+  pose.orientation = autoware_utils_geometry::create_quaternion_from_yaw(0.0);
+  return pose;
+}
+
+sensor_msgs::msg::PointCloud2::SharedPtr make_pointcloud(
+  const std::vector<std::array<float, 3>> & points, const std::string & frame_id = "base_link")
+{
+  pcl::PointCloud<pcl::PointXYZ> pcl_cloud;
+  for (const auto & point : points) {
+    pcl_cloud.push_back(pcl::PointXYZ(point[0], point[1], point[2]));
+  }
+
+  auto cloud_msg = std::make_shared<sensor_msgs::msg::PointCloud2>();
+  pcl::toROSMsg(pcl_cloud, *cloud_msg);
+  cloud_msg->header.frame_id = frame_id;
+  return cloud_msg;
+}
+
+PredictedObjects::SharedPtr make_predicted_objects(
+  const std::vector<PredictedObject> & objects)
+{
+  auto objects_msg = std::make_shared<PredictedObjects>();
+  objects_msg->objects = objects;
+  return objects_msg;
+}
+
+PredictedObject make_car_object(const double x, const double y, const uint8_t id = 1)
+{
+  PredictedObject object;
+  object.object_id.uuid = {id};
+  object.classification.resize(1);
+  object.classification.front().label = ObjectClassification::CAR;
+  object.classification.front().probability = 1.0F;
+  object.shape.type = Shape::BOUNDING_BOX;
+  object.shape.dimensions.x = 2.0;
+  object.shape.dimensions.y = 2.0;
+  object.shape.dimensions.z = 1.5;
+  object.kinematics.initial_pose_with_covariance.pose = make_pose(x, y);
+  return object;
+}
+
+Inputs make_inputs(
+  const geometry_msgs::msg::Pose & ego_pose,
+  const sensor_msgs::msg::PointCloud2::ConstSharedPtr & pointcloud = nullptr,
+  const PredictedObjects::ConstSharedPtr & objects = nullptr,
+  const bool use_identity_transform = true)
+{
+  Inputs inputs;
+  inputs.ego_pose = ego_pose;
+  inputs.pointcloud = pointcloud;
+  inputs.objects = objects;
+  if (use_identity_transform) {
+    inputs.pointcloud_to_base_link_transform = Eigen::Affine3f::Identity();
+  }
+  return inputs;
+}
+
+}  // namespace
+
+class ProximityCheckerTest : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    vehicle_info_ = make_vehicle_info();
+    parameters_ = make_default_parameters();
+    checker_ = std::make_unique<ProximityChecker>(parameters_, vehicle_info_);
+    ego_pose_ = make_pose(0.0, 0.0);
+  }
+
+  vehicle_info_utils::VehicleInfo vehicle_info_;
+  Parameters parameters_;
+  std::unique_ptr<ProximityChecker> checker_;
+  geometry_msgs::msg::Pose ego_pose_;
+};
+
+TEST_F(ProximityCheckerTest, NoObstacleWhenInputsAreEmpty)
+{
+  const auto result = checker_->check(make_inputs(ego_pose_), kContactDistanceThreshold);
+  EXPECT_FALSE(result.is_obstacle_found);
+  EXPECT_FALSE(result.nearest_obstacle.has_value());
+}
+
+TEST_F(ProximityCheckerTest, NoObstacleWhenPointcloudCheckDisabled)
+{
+  parameters_.pointcloud_enable_check = false;
+  checker_->update_parameters(parameters_);
+
+  const auto pointcloud = make_pointcloud({{0.0F, 0.0F, 0.0F}});
+  const auto result =
+    checker_->check(make_inputs(ego_pose_, pointcloud), kContactDistanceThreshold);
+
+  EXPECT_FALSE(result.is_obstacle_found);
+  EXPECT_FALSE(result.nearest_obstacle.has_value());
+}
+
+TEST_F(ProximityCheckerTest, DetectsNearbyPointInPointcloud)
+{
+  const auto pointcloud = make_pointcloud({{4.2F, 0.0F, 0.0F}});
+  const auto result =
+    checker_->check(make_inputs(ego_pose_, pointcloud), 0.5);
+
+  ASSERT_TRUE(result.nearest_obstacle.has_value());
+  EXPECT_TRUE(result.nearest_obstacle->is_point_cloud);
+  EXPECT_NEAR(result.nearest_obstacle->nearest_distance, 0.2, 1e-3);
+  EXPECT_TRUE(result.is_obstacle_found);
+}
+
+TEST_F(ProximityCheckerTest, NoObstacleForFarPointInPointcloud)
+{
+  const auto pointcloud = make_pointcloud({{20.0F, 0.0F, 0.0F}});
+  const auto result =
+    checker_->check(make_inputs(ego_pose_, pointcloud), kContactDistanceThreshold);
+
+  EXPECT_FALSE(result.is_obstacle_found);
+}
+
+TEST_F(ProximityCheckerTest, RespectsContactDistanceThreshold)
+{
+  const auto pointcloud = make_pointcloud({{4.2F, 0.0F, 0.0F}});
+  const auto inputs = make_inputs(ego_pose_, pointcloud);
+
+  const auto result_below_threshold = checker_->check(inputs, 0.1);
+  EXPECT_FALSE(result_below_threshold.is_obstacle_found);
+  ASSERT_TRUE(result_below_threshold.nearest_obstacle.has_value());
+
+  const auto result_above_threshold = checker_->check(inputs, 0.5);
+  EXPECT_TRUE(result_above_threshold.is_obstacle_found);
+}
+
+TEST_F(ProximityCheckerTest, NoObstacleWhenPointcloudTransformMissing)
+{
+  auto inputs = make_inputs(ego_pose_, make_pointcloud({{4.2F, 0.0F, 0.0F}}), nullptr, false);
+  inputs.pointcloud_to_base_link_transform = std::nullopt;
+
+  const auto result = checker_->check(inputs, 0.5);
+  EXPECT_FALSE(result.is_obstacle_found);
+  EXPECT_FALSE(result.nearest_obstacle.has_value());
+}
+
+TEST_F(ProximityCheckerTest, DetectsNearbyDynamicObject)
+{
+  const auto objects = make_predicted_objects({make_car_object(5.2, 0.0)});
+  const auto result =
+    checker_->check(make_inputs(ego_pose_, nullptr, objects), 0.5);
+
+  ASSERT_TRUE(result.nearest_obstacle.has_value());
+  EXPECT_FALSE(result.nearest_obstacle->is_point_cloud);
+  EXPECT_NEAR(result.nearest_obstacle->nearest_distance, 0.2, 1e-3);
+  EXPECT_TRUE(result.is_obstacle_found);
+}
+
+TEST_F(ProximityCheckerTest, IgnoresDisabledObjectTypes)
+{
+  parameters_.object_type_enable_check["car"] = false;
+  checker_->update_parameters(parameters_);
+
+  const auto objects = make_predicted_objects({make_car_object(5.2, 0.0)});
+  const auto result =
+    checker_->check(make_inputs(ego_pose_, nullptr, objects), 0.5);
+
+  EXPECT_FALSE(result.is_obstacle_found);
+  EXPECT_FALSE(result.nearest_obstacle.has_value());
+}
+
+TEST_F(ProximityCheckerTest, SelectsNearestBetweenPointcloudAndObject)
+{
+  const auto pointcloud = make_pointcloud({{4.5F, 0.0F, 0.0F}});
+  const auto objects = make_predicted_objects({make_car_object(5.2, 0.0)});
+
+  const auto result = checker_->check(
+    make_inputs(ego_pose_, pointcloud, objects), 0.5);
+
+  ASSERT_TRUE(result.nearest_obstacle.has_value());
+  EXPECT_FALSE(result.nearest_obstacle->is_point_cloud);
+  EXPECT_NEAR(result.nearest_obstacle->nearest_distance, 0.2, 1e-3);
+}
+
+TEST_F(ProximityCheckerTest, UpdateParametersDisablesPointcloudCheck)
+{
+  const auto pointcloud = make_pointcloud({{0.0F, 0.0F, 0.0F}});
+  const auto inputs = make_inputs(ego_pose_, pointcloud);
+
+  {
+    const auto result = checker_->check(inputs, kContactDistanceThreshold);
+    EXPECT_TRUE(result.is_obstacle_found);
+  }
+
+  parameters_.pointcloud_enable_check = false;
+  checker_->update_parameters(parameters_);
+
+  {
+    const auto result = checker_->check(inputs, kContactDistanceThreshold);
+    EXPECT_FALSE(result.is_obstacle_found);
+  }
+}
+
+}  // namespace autoware::obstacle_proximity_checker

--- a/planning/autoware_surround_obstacle_checker/CMakeLists.txt
+++ b/planning/autoware_surround_obstacle_checker/CMakeLists.txt
@@ -4,10 +4,6 @@ project(autoware_surround_obstacle_checker)
 find_package(autoware_cmake REQUIRED)
 autoware_package()
 
-find_package(eigen3_cmake_module REQUIRED)
-find_package(Eigen3 REQUIRED)
-find_package(PCL REQUIRED COMPONENTS common)
-
 ### Compile options
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 17)
@@ -15,11 +11,6 @@ endif()
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wno-error=deprecated-declarations)
 endif()
-
-include_directories(
-  SYSTEM
-    ${EIGEN3_INCLUDE_DIR}
-)
 
 generate_parameter_library(surround_obstacle_checker_node_parameters
   param/surround_obstacle_checker_node_parameters.yaml
@@ -31,7 +22,6 @@ ament_auto_add_library(${PROJECT_NAME} SHARED
 )
 
 target_link_libraries(${PROJECT_NAME}
-  ${PCL_LIBRARIES}
   surround_obstacle_checker_node_parameters
 )
 

--- a/planning/autoware_surround_obstacle_checker/package.xml
+++ b/planning/autoware_surround_obstacle_checker/package.xml
@@ -12,7 +12,6 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
-  <buildtool_depend>eigen3_cmake_module</buildtool_depend>
 
   <depend>autoware_internal_planning_msgs</depend>
   <depend>autoware_motion_utils</depend>
@@ -20,20 +19,18 @@
   <depend>autoware_planning_factor_interface</depend>
   <depend>autoware_planning_msgs</depend>
   <depend>autoware_planning_test_manager</depend>
+  <depend>autoware_obstacle_proximity_checker</depend>
+  <depend>autoware_universe_utils</depend>
   <depend>autoware_utils</depend>
   <depend>autoware_vehicle_info_utils</depend>
   <depend>diagnostic_msgs</depend>
-  <depend>eigen</depend>
   <depend>generate_parameter_library</depend>
-  <depend>libpcl-all-dev</depend>
-  <depend>pcl_conversions</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>sensor_msgs</depend>
   <depend>std_msgs</depend>
   <depend>tf2</depend>
   <depend>tf2_eigen</depend>
-  <depend>tf2_geometry_msgs</depend>
   <depend>tf2_ros</depend>
   <depend>tier4_planning_msgs</depend>
   <depend>visualization_msgs</depend>

--- a/planning/autoware_surround_obstacle_checker/package.xml
+++ b/planning/autoware_surround_obstacle_checker/package.xml
@@ -15,11 +15,11 @@
 
   <depend>autoware_internal_planning_msgs</depend>
   <depend>autoware_motion_utils</depend>
+  <depend>autoware_obstacle_proximity_checker</depend>
   <depend>autoware_perception_msgs</depend>
   <depend>autoware_planning_factor_interface</depend>
   <depend>autoware_planning_msgs</depend>
   <depend>autoware_planning_test_manager</depend>
-  <depend>autoware_obstacle_proximity_checker</depend>
   <depend>autoware_universe_utils</depend>
   <depend>autoware_utils</depend>
   <depend>autoware_vehicle_info_utils</depend>

--- a/planning/autoware_surround_obstacle_checker/src/node.cpp
+++ b/planning/autoware_surround_obstacle_checker/src/node.cpp
@@ -14,45 +14,24 @@
 
 #include "node.hpp"
 
-#include <autoware_utils/geometry/boost_polygon_utils.hpp>
-#include <autoware_utils/geometry/geometry.hpp>
 #include <autoware_utils/ros/update_param.hpp>
 #include <autoware_utils/system/stop_watch.hpp>
-#include <autoware_utils/transform/transforms.hpp>
-#include <autoware_utils_geometry/geometry.hpp>
 #include <tf2_eigen/tf2_eigen.hpp>
 
-#include <boost/assert.hpp>
-#include <boost/assign/list_of.hpp>
-#include <boost/format.hpp>
-#include <boost/geometry.hpp>
-#include <boost/geometry/geometries/linestring.hpp>
-#include <boost/geometry/geometries/point_xy.hpp>
-
-#include <pcl/common/transforms.h>
-#include <pcl/point_cloud.h>
-#include <pcl_conversions/pcl_conversions.h>
-
-#include <algorithm>
 #include <functional>
-#include <limits>
 #include <memory>
 #include <optional>
 #include <string>
 #include <utility>
 
-#define EIGEN_MPL2_ONLY
-#include <Eigen/Core>
-#include <Eigen/Geometry>
-
 namespace autoware::surround_obstacle_checker
 {
-namespace bg = boost::geometry;
-using Point2d = bg::model::d2::point_xy<double>;
-using Polygon2d = bg::model::polygon<Point2d>;
+namespace
+{
+constexpr double kContactDistanceThreshold = 1e-3;
+}  // namespace
+
 using autoware_perception_msgs::msg::ObjectClassification;
-using autoware_utils::create_point;
-using autoware_utils::pose2transform;
 
 SurroundObstacleCheckerNode::SurroundObstacleCheckerNode(const rclcpp::NodeOptions & node_options)
 : Node("surround_obstacle_checker_node", node_options)
@@ -71,6 +50,9 @@ SurroundObstacleCheckerNode::SurroundObstacleCheckerNode(const rclcpp::NodeOptio
   }
 
   vehicle_info_ = autoware::vehicle_info_utils::VehicleInfoUtils(*this).getVehicleInfo();
+
+  proximity_checker_ = std::make_unique<obstacle_proximity_checker::ProximityChecker>(
+    toProximityCheckerParameters(), vehicle_info_);
 
   // Publishers
   pub_clear_velocity_limit_ = this->create_publisher<VelocityLimitClearCommand>(
@@ -119,6 +101,50 @@ bool SurroundObstacleCheckerNode::getUseDynamicObject() const
   return use_dynamic_object;
 }
 
+obstacle_proximity_checker::Parameters SurroundObstacleCheckerNode::toProximityCheckerParameters() const
+{
+  const auto param = param_listener_->get_params();
+
+  obstacle_proximity_checker::Parameters parameters;
+  parameters.pointcloud_enable_check = param.pointcloud.enable_check;
+
+  for (const auto & [label, object_type_param] : param.object_types_map) {
+    parameters.object_type_enable_check[label] = object_type_param.enable_check;
+  }
+
+  for (const auto & [label, obstacle_type_param] : param.obstacle_types_map) {
+    obstacle_proximity_checker::ObstacleTypeParameters obstacle_parameters;
+    obstacle_parameters.surround_check_front_distance =
+      obstacle_type_param.surround_check_front_distance;
+    obstacle_parameters.surround_check_side_distance =
+      obstacle_type_param.surround_check_side_distance;
+    obstacle_parameters.surround_check_back_distance =
+      obstacle_type_param.surround_check_back_distance;
+    parameters.obstacle_types_map[label] = obstacle_parameters;
+  }
+
+  return parameters;
+}
+
+obstacle_proximity_checker::Inputs SurroundObstacleCheckerNode::toProximityCheckerInputs() const
+{
+  obstacle_proximity_checker::Inputs inputs;
+  inputs.ego_pose = odometry_ptr_->pose.pose;
+  inputs.pointcloud = pointcloud_ptr_;
+  inputs.objects = object_ptr_;
+
+  if (pointcloud_ptr_) {
+    const auto transform_stamped = getTransform(
+      "base_link", pointcloud_ptr_->header.frame_id, pointcloud_ptr_->header.stamp, 0.5);
+    if (transform_stamped.has_value()) {
+      inputs.pointcloud_to_base_link_transform =
+        tf2::transformToEigen(transform_stamped.value().transform).cast<float>();
+    }
+  }
+
+  return inputs;
+}
+
 void SurroundObstacleCheckerNode::onTimer()
 {
   autoware_utils::StopWatch<std::chrono::milliseconds> stop_watch;
@@ -135,6 +161,7 @@ void SurroundObstacleCheckerNode::onTimer()
   }
 
   const auto param = param_listener_->get_params();
+  proximity_checker_->update_parameters(toProximityCheckerParameters());
   const auto use_dynamic_object = getUseDynamicObject();
 
   if (param.publish_debug_footprints) {
@@ -157,20 +184,18 @@ void SurroundObstacleCheckerNode::onTimer()
       "Surround obstacle check is disabled for all dynamic object types and for pointcloud check.");
   }
 
-  const auto nearest_obstacle = getNearestObstacle();
+  const double contact_distance_threshold = state_ == State::STOP
+                                              ? param.surround_check_hysteresis_distance
+                                              : kContactDistanceThreshold;
+  const auto proximity_result =
+    proximity_checker_->check(toProximityCheckerInputs(), contact_distance_threshold);
   const auto is_vehicle_stopped = vehicle_stop_checker_->isVehicleStopped();
 
-  constexpr double epsilon = 1e-3;
   switch (state_) {
     case State::PASS: {
-      const auto is_obstacle_found = [&]() {
-        if (!nearest_obstacle.has_value()) return false;
-        return nearest_obstacle.value().nearest_distance < epsilon;
-      }();
-
       bool is_stop_required = false;
       std::tie(is_stop_required, last_obstacle_found_time_) = isStopRequired(
-        is_obstacle_found, is_vehicle_stopped, state_, last_obstacle_found_time_,
+        proximity_result.is_obstacle_found, is_vehicle_stopped, state_, last_obstacle_found_time_,
         param.state_clear_time);
       if (!is_stop_required) {
         break;
@@ -193,14 +218,9 @@ void SurroundObstacleCheckerNode::onTimer()
     }
 
     case State::STOP: {
-      const auto is_obstacle_found = [&]() {
-        if (!nearest_obstacle.has_value()) return false;
-        return nearest_obstacle.value().nearest_distance < param.surround_check_hysteresis_distance;
-      }();
-
       bool is_stop_required = false;
       std::tie(is_stop_required, last_obstacle_found_time_) = isStopRequired(
-        is_obstacle_found, is_vehicle_stopped, state_, last_obstacle_found_time_,
+        proximity_result.is_obstacle_found, is_vehicle_stopped, state_, last_obstacle_found_time_,
         param.state_clear_time);
       if (is_stop_required) {
         break;
@@ -222,8 +242,8 @@ void SurroundObstacleCheckerNode::onTimer()
       break;
   }
 
-  if (nearest_obstacle.has_value()) {
-    debug_ptr_->pushStopObstacle(nearest_obstacle);
+  if (proximity_result.nearest_obstacle.has_value()) {
+    debug_ptr_->pushStopObstacle(proximity_result.nearest_obstacle);
   }
 
   if (state_ == State::STOP) {
@@ -236,155 +256,6 @@ void SurroundObstacleCheckerNode::onTimer()
   pub_processing_time_->publish(processing_time_msg);
 
   debug_ptr_->publish();
-}
-
-std::optional<StopObstacle> SurroundObstacleCheckerNode::getNearestObstacle() const
-{
-  const auto nearest_pointcloud = getNearestObstacleByPointCloud();
-  const auto nearest_object = getNearestObstacleByDynamicObject();
-  if (!nearest_pointcloud.has_value() && !nearest_object.has_value()) {
-    return {};
-  }
-
-  if (!nearest_pointcloud.has_value()) {
-    return nearest_object;
-  }
-
-  if (!nearest_object.has_value()) {
-    return nearest_pointcloud;
-  }
-
-  return nearest_pointcloud.value().nearest_distance < nearest_object.value().nearest_distance
-           ? nearest_pointcloud
-           : nearest_object;
-}
-
-std::optional<StopObstacle> SurroundObstacleCheckerNode::getNearestObstacleByPointCloud() const
-{
-  const auto param = param_listener_->get_params();
-
-  if (!param.pointcloud.enable_check || !pointcloud_ptr_) {
-    return std::nullopt;
-  }
-
-  if (pointcloud_ptr_->data.empty()) {
-    return std::nullopt;
-  }
-
-  const auto transform_stamped =
-    getTransform("base_link", pointcloud_ptr_->header.frame_id, pointcloud_ptr_->header.stamp, 0.5);
-
-  if (!transform_stamped.has_value()) {
-    return std::nullopt;
-  }
-
-  Eigen::Affine3f isometry =
-    tf2::transformToEigen(transform_stamped.value().transform).cast<float>();
-  pcl::PointCloud<pcl::PointXYZ> transformed_pointcloud;
-  pcl::fromROSMsg(*pointcloud_ptr_, transformed_pointcloud);
-  autoware_utils::transform_pointcloud(transformed_pointcloud, transformed_pointcloud, isometry);
-
-  const auto & pointcloud_param = param.obstacle_types_map.at("pointcloud");
-  const double front_margin = pointcloud_param.surround_check_front_distance;
-  const double side_margin = pointcloud_param.surround_check_side_distance;
-  const double back_margin = pointcloud_param.surround_check_back_distance;
-  const double base_to_front = vehicle_info_.max_longitudinal_offset_m + front_margin;
-  const double base_to_rear = vehicle_info_.rear_overhang_m + back_margin;
-  const double width = vehicle_info_.vehicle_width_m + side_margin * 2;
-  const auto base_link_origin = []() {
-    geometry_msgs::msg::Pose p;
-    p.position.x = 0.0;
-    p.position.y = 0.0;
-    p.position.z = 0.0;
-    p.orientation = autoware_utils_geometry::create_quaternion_from_yaw(0.0);
-    return p;
-  }();
-  const auto ego_polygon =
-    autoware_utils::to_footprint(base_link_origin, base_to_front, base_to_rear, width);
-
-  // distance comparison on base_link frame
-  geometry_msgs::msg::Point nearest_point_base_link;
-  double minimum_distance = std::numeric_limits<double>::max();
-  bool was_minimum_distance_updated = false;
-  for (const auto & p : transformed_pointcloud) {
-    Point2d boost_point(p.x, p.y);
-
-    const auto distance_to_object = bg::distance(ego_polygon, boost_point);
-
-    if (distance_to_object < minimum_distance) {
-      nearest_point_base_link = create_point(p.x, p.y, p.z);
-      minimum_distance = distance_to_object;
-      was_minimum_distance_updated = true;
-    }
-  }
-
-  if (was_minimum_distance_updated) {
-    // transform the nearest point from base_link to map frame
-    const auto & pose = odometry_ptr_->pose.pose;
-    const auto nearest_point_map =
-      autoware_utils_geometry::transform_point(nearest_point_base_link, pose);
-
-    StopObstacle obstacle;
-    obstacle.is_point_cloud = true;
-    obstacle.nearest_distance = minimum_distance;
-    obstacle.nearest_point = nearest_point_map;
-    obstacle.uuid = UUID();  // Default UUID
-    return obstacle;
-  }
-  return std::nullopt;
-}
-
-std::optional<StopObstacle> SurroundObstacleCheckerNode::getNearestObstacleByDynamicObject() const
-{
-  if (!object_ptr_ || !getUseDynamicObject()) {
-    return std::nullopt;
-  }
-
-  const auto param = param_listener_->get_params();
-
-  // TODO(murooka) check computation cost
-  PredictedObject nearest_object;
-  double minimum_distance = std::numeric_limits<double>::max();
-  bool was_minimum_distance_updated = false;
-  for (const auto & object : object_ptr_->objects) {
-    const int label = object.classification.front().label;
-    const auto & str_label = label_map_.at(label);
-
-    if (!param.object_types_map.at(str_label).enable_check) {
-      continue;
-    }
-    const auto & object_param = param.obstacle_types_map.at(str_label);
-    const double front_margin = object_param.surround_check_front_distance;
-    const double side_margin = object_param.surround_check_side_distance;
-    const double back_margin = object_param.surround_check_back_distance;
-    const double base_to_front = vehicle_info_.max_longitudinal_offset_m + front_margin;
-    const double base_to_rear = vehicle_info_.rear_overhang_m + back_margin;
-    const double width = vehicle_info_.vehicle_width_m + side_margin * 2;
-    const auto ego_polygon =
-      autoware_utils::to_footprint(odometry_ptr_->pose.pose, base_to_front, base_to_rear, width);
-
-    const auto object_polygon = autoware_utils::to_polygon2d(object);
-
-    const auto distance_to_object = bg::distance(ego_polygon, object_polygon);
-
-    if (distance_to_object < minimum_distance) {
-      nearest_object = object;
-      minimum_distance = distance_to_object;
-      was_minimum_distance_updated = true;
-    }
-  }
-
-  if (was_minimum_distance_updated) {
-    const auto & object_position =
-      nearest_object.kinematics.initial_pose_with_covariance.pose.position;
-    StopObstacle obstacle;
-    obstacle.is_point_cloud = false;
-    obstacle.nearest_distance = minimum_distance;
-    obstacle.nearest_point = object_position;
-    obstacle.uuid = nearest_object.object_id;
-    return obstacle;
-  }
-  return std::nullopt;
 }
 
 std::optional<geometry_msgs::msg::TransformStamped> SurroundObstacleCheckerNode::getTransform(

--- a/planning/autoware_surround_obstacle_checker/src/node.cpp
+++ b/planning/autoware_surround_obstacle_checker/src/node.cpp
@@ -16,7 +16,12 @@
 
 #include <autoware_utils/ros/update_param.hpp>
 #include <autoware_utils/system/stop_watch.hpp>
+#include <autoware_utils/transform/transforms.hpp>
 #include <tf2_eigen/tf2_eigen.hpp>
+
+#include <pcl/common/transforms.h>
+#include <pcl/point_cloud.h>
+#include <pcl_conversions/pcl_conversions.h>
 
 #include <functional>
 #include <memory>
@@ -26,10 +31,6 @@
 
 namespace autoware::surround_obstacle_checker
 {
-namespace
-{
-constexpr double kContactDistanceThreshold = 1e-3;
-}  // namespace
 
 using autoware_perception_msgs::msg::ObjectClassification;
 
@@ -131,17 +132,22 @@ obstacle_proximity_checker::Inputs SurroundObstacleCheckerNode::toProximityCheck
 {
   obstacle_proximity_checker::Inputs inputs;
   inputs.ego_pose = odometry_ptr_->pose.pose;
-  inputs.pointcloud = pointcloud_ptr_;
   inputs.objects = object_ptr_;
 
-  if (pointcloud_ptr_) {
-    const auto transform_stamped = getTransform(
-      "base_link", pointcloud_ptr_->header.frame_id, pointcloud_ptr_->header.stamp, 0.5);
-    if (transform_stamped.has_value()) {
-      inputs.pointcloud_to_base_link_transform =
-        tf2::transformToEigen(transform_stamped.value().transform).cast<float>();
-    }
-  }
+  if (!pointcloud_ptr_) return inputs;
+
+  const auto transform_stamped =
+    getTransform("base_link", pointcloud_ptr_->header.frame_id, pointcloud_ptr_->header.stamp, 0.5);
+
+  if (!transform_stamped.has_value()) return inputs;
+
+  Eigen::Affine3f isometry =
+    tf2::transformToEigen(transform_stamped.value().transform).cast<float>();
+  pcl::PointCloud<pcl::PointXYZ> transformed_pointcloud;
+  pcl::fromROSMsg(*pointcloud_ptr_, transformed_pointcloud);
+  autoware_utils::transform_pointcloud(transformed_pointcloud, transformed_pointcloud, isometry);
+
+  inputs.pointcloud_in_base_link = transformed_pointcloud.makeShared();
 
   return inputs;
 }
@@ -186,7 +192,7 @@ void SurroundObstacleCheckerNode::onTimer()
   }
 
   const double contact_distance_threshold =
-    state_ == State::STOP ? param.surround_check_hysteresis_distance : kContactDistanceThreshold;
+    state_ == State::STOP ? param.surround_check_hysteresis_distance : 1e-3;
   const auto proximity_result =
     proximity_checker_->check(toProximityCheckerInputs(), contact_distance_threshold);
   const auto is_vehicle_stopped = vehicle_stop_checker_->isVehicleStopped();

--- a/planning/autoware_surround_obstacle_checker/src/node.cpp
+++ b/planning/autoware_surround_obstacle_checker/src/node.cpp
@@ -101,7 +101,8 @@ bool SurroundObstacleCheckerNode::getUseDynamicObject() const
   return use_dynamic_object;
 }
 
-obstacle_proximity_checker::Parameters SurroundObstacleCheckerNode::toProximityCheckerParameters() const
+obstacle_proximity_checker::Parameters SurroundObstacleCheckerNode::toProximityCheckerParameters()
+  const
 {
   const auto param = param_listener_->get_params();
 
@@ -184,9 +185,8 @@ void SurroundObstacleCheckerNode::onTimer()
       "Surround obstacle check is disabled for all dynamic object types and for pointcloud check.");
   }
 
-  const double contact_distance_threshold = state_ == State::STOP
-                                              ? param.surround_check_hysteresis_distance
-                                              : kContactDistanceThreshold;
+  const double contact_distance_threshold =
+    state_ == State::STOP ? param.surround_check_hysteresis_distance : kContactDistanceThreshold;
   const auto proximity_result =
     proximity_checker_->check(toProximityCheckerInputs(), contact_distance_threshold);
   const auto is_vehicle_stopped = vehicle_stop_checker_->isVehicleStopped();

--- a/planning/autoware_surround_obstacle_checker/src/node.hpp
+++ b/planning/autoware_surround_obstacle_checker/src/node.hpp
@@ -22,6 +22,7 @@
 #include "types.hpp"
 
 #include <autoware/motion_utils/vehicle/vehicle_state_checker.hpp>
+#include <autoware/obstacle_proximity_checker/obstacle_proximity_checker.hpp>
 #include <autoware_surround_obstacle_checker/surround_obstacle_checker_node_parameters.hpp>
 #include <autoware_vehicle_info_utils/vehicle_info_utils.hpp>
 #include <rclcpp/rclcpp.hpp>
@@ -64,11 +65,9 @@ private:
 
   void onTimer();
 
-  std::optional<StopObstacle> getNearestObstacle() const;
+  obstacle_proximity_checker::Parameters toProximityCheckerParameters() const;
 
-  std::optional<StopObstacle> getNearestObstacleByPointCloud() const;
-
-  std::optional<StopObstacle> getNearestObstacleByDynamicObject() const;
+  obstacle_proximity_checker::Inputs toProximityCheckerInputs() const;
 
   std::optional<geometry_msgs::msg::TransformStamped> getTransform(
     const std::string & source, const std::string & target, const rclcpp::Time & stamp,
@@ -98,6 +97,9 @@ private:
 
   // stop checker
   std::unique_ptr<VehicleStopChecker> vehicle_stop_checker_;
+
+  // proximity checker
+  std::unique_ptr<obstacle_proximity_checker::ProximityChecker> proximity_checker_;
 
   // debug
   std::shared_ptr<SurroundObstacleCheckerDebugNode> debug_ptr_;

--- a/planning/autoware_surround_obstacle_checker/src/types.hpp
+++ b/planning/autoware_surround_obstacle_checker/src/types.hpp
@@ -15,18 +15,12 @@
 #ifndef TYPES_HPP_
 #define TYPES_HPP_
 
-#include "type_alias.hpp"
+#include <autoware/obstacle_proximity_checker/structs.hpp>
 
 namespace autoware::surround_obstacle_checker
 {
 
-struct StopObstacle
-{
-  bool is_point_cloud;
-  double nearest_distance;
-  Point nearest_point;
-  UUID uuid;
-};
+using StopObstacle = autoware::obstacle_proximity_checker::ProximityObstacle;
 
 }  // namespace autoware::surround_obstacle_checker
 

--- a/planning/autoware_trajectory_modifier/CMakeLists.txt
+++ b/planning/autoware_trajectory_modifier/CMakeLists.txt
@@ -38,6 +38,7 @@ ament_auto_add_library(${PROJECT_NAME}_plugins SHARED
   src/trajectory_modifier_plugins/stop_point_fixer.cpp
   src/trajectory_modifier_plugins/obstacle_stop.cpp
   src/trajectory_modifier_plugins/velocity_modifier.cpp
+  src/trajectory_modifier_plugins/surround_obstacle_stop.cpp
 )
 
 target_link_libraries(${PROJECT_NAME}_plugins

--- a/planning/autoware_trajectory_modifier/config/trajectory_modifier.param.yaml
+++ b/planning/autoware_trajectory_modifier/config/trajectory_modifier.param.yaml
@@ -2,11 +2,13 @@
   ros__parameters:
     plugin_names:
       - "autoware::trajectory_modifier::plugin::StopPointFixer"
+      - "autoware::trajectory_modifier::plugin::SurroundObstacleStop"
       - "autoware::trajectory_modifier::plugin::ObstacleStop"
       - "autoware::trajectory_modifier::plugin::VelocityModifier"
     use_stop_point_fixer: true
     use_obstacle_stop: true
     use_velocity_modifier: true
+    use_surround_obstacle_stop: false
     trajectory_time_step: 0.1 # [s]
 
     # Stop Point Fixer Plugin Parameters
@@ -76,3 +78,42 @@
         reaction_time: 0.2 # [s]
         safety_margin: 2.0 # [m]
         lookahead_horizon: 1.5 # [s]
+
+    # Surround Obstacle Stop Plugin Parameters
+    surround_obstacle_stop:
+      use_objects: true
+      use_pointcloud: true
+      object_types: ["car", "truck", "bus", "trailer", "motorcycle", "bicycle", "pedestrian"]
+      front_distance_th:
+        car: 0.5
+        truck: 0.5
+        bus: 0.5
+        trailer: 0.5
+        motorcycle: 0.5
+        bicycle: 0.5
+        pedestrian: 0.5
+        unknown: 0.5
+        pointcloud: 0.5
+      side_distance_th:
+        car: 0.0
+        truck: 0.0
+        bus: 0.0
+        trailer: 0.0
+        motorcycle: 1.0
+        bicycle: 1.0
+        pedestrian: 1.0
+        unknown: 0.5
+        pointcloud: 0.5
+      back_distance_th:
+        car: 0.0
+        truck: 0.0
+        bus: 0.0
+        trailer: 0.0
+        motorcycle: 0.5
+        bicycle: 0.5
+        pedestrian: 0.5
+        unknown: 0.5
+        pointcloud: 0.5
+      hysteresis_distance: 0.1
+      hysteresis_time: 0.2
+      ego_stopped_vel_th: 0.1 # [m/s]

--- a/planning/autoware_trajectory_modifier/config/trajectory_modifier.param.yaml
+++ b/planning/autoware_trajectory_modifier/config/trajectory_modifier.param.yaml
@@ -82,8 +82,8 @@
     # Surround Obstacle Stop Plugin Parameters
     surround_obstacle_stop:
       use_objects: true
-      use_pointcloud: true
-      object_types: ["car", "truck", "bus", "trailer", "motorcycle", "bicycle", "pedestrian"]
+      use_pointcloud: false
+      object_types: ["car", "truck", "bus", "trailer", "motorcycle", "bicycle", "pedestrian", "unknown"]
       front_distance_th:
         car: 0.5
         truck: 0.5
@@ -99,9 +99,9 @@
         truck: 0.0
         bus: 0.0
         trailer: 0.0
-        motorcycle: 1.0
-        bicycle: 1.0
-        pedestrian: 1.0
+        motorcycle: 0.0
+        bicycle: 0.5
+        pedestrian: 0.5
         unknown: 0.5
         pointcloud: 0.5
       back_distance_th:

--- a/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier_plugins/surround_obstacle_stop.hpp
+++ b/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier_plugins/surround_obstacle_stop.hpp
@@ -1,0 +1,68 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__TRAJECTORY_MODIFIER__TRAJECTORY_MODIFIER_PLUGINS__SURROUND_OBSTACLE_STOP_HPP_
+#define AUTOWARE__TRAJECTORY_MODIFIER__TRAJECTORY_MODIFIER_PLUGINS__SURROUND_OBSTACLE_STOP_HPP_
+
+#include "autoware/obstacle_proximity_checker/obstacle_proximity_checker.hpp"
+#include "autoware/trajectory_modifier/trajectory_modifier_plugins/trajectory_modifier_plugin_base.hpp"
+
+#include <autoware_internal_debug_msgs/msg/string_stamped.hpp>
+
+#include <memory>
+#include <optional>
+
+namespace autoware::trajectory_modifier::plugin
+{
+using autoware_internal_debug_msgs::msg::StringStamped;
+
+class SurroundObstacleStop : public TrajectoryModifierPluginBase
+{
+public:
+  SurroundObstacleStop() = default;
+
+  bool modify_trajectory(TrajectoryPoints & traj_points, const InputData & input) override;
+
+  [[nodiscard]] bool is_trajectory_modification_required(
+    const TrajectoryPoints & traj_points, const InputData & input) override;
+
+  void update_params(const TrajectoryModifierParams & params) override;
+
+  const TrajectoryModifierParams::SurroundObstacleStop & get_params() const { return params_; }
+
+protected:
+  void on_initialize(const TrajectoryModifierParams & params) override;
+
+private:
+  TrajectoryModifierParams::SurroundObstacleStop params_;
+
+  std::unique_ptr<obstacle_proximity_checker::ProximityChecker> proximity_checker_;
+
+  bool is_stop_active_{false};
+  std::optional<rclcpp::Time> last_obstacle_found_time_;
+
+  rclcpp::Publisher<StringStamped>::SharedPtr pub_debug_text_;
+
+  [[nodiscard]] bool check_inputs(const InputData & input) const;
+
+  [[nodiscard]] obstacle_proximity_checker::Inputs to_proximity_checker_inputs(const InputData & input) const;
+
+  [[nodiscard]] bool is_obstacle_nearby(const InputData & input);
+
+  void publish_debug_string(bool is_active) const;
+};
+
+}  // namespace autoware::trajectory_modifier::plugin
+
+#endif  // AUTOWARE__TRAJECTORY_MODIFIER__TRAJECTORY_MODIFIER_PLUGINS__SURROUND_OBSTACLE_STOP_HPP_

--- a/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier_plugins/surround_obstacle_stop.hpp
+++ b/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier_plugins/surround_obstacle_stop.hpp
@@ -22,6 +22,7 @@
 
 #include <memory>
 #include <optional>
+#include <string>
 
 namespace autoware::trajectory_modifier::plugin
 {
@@ -60,6 +61,10 @@ private:
     const InputData & input) const;
 
   [[nodiscard]] bool is_obstacle_nearby(const InputData & input);
+
+  std::optional<geometry_msgs::msg::TransformStamped> get_transform(
+    const std::string & source, const std::string & target, const rclcpp::Time & stamp,
+    double duration_sec) const;
 
   void publish_debug_string(bool is_active) const;
 };

--- a/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier_plugins/surround_obstacle_stop.hpp
+++ b/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier_plugins/surround_obstacle_stop.hpp
@@ -56,7 +56,8 @@ private:
 
   [[nodiscard]] bool check_inputs(const InputData & input) const;
 
-  [[nodiscard]] obstacle_proximity_checker::Inputs to_proximity_checker_inputs(const InputData & input) const;
+  [[nodiscard]] obstacle_proximity_checker::Inputs to_proximity_checker_inputs(
+    const InputData & input) const;
 
   [[nodiscard]] bool is_obstacle_nearby(const InputData & input);
 

--- a/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier_plugins/surround_obstacle_stop.hpp
+++ b/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier_plugins/surround_obstacle_stop.hpp
@@ -50,6 +50,10 @@ private:
 
   std::unique_ptr<obstacle_proximity_checker::ProximityChecker> proximity_checker_;
 
+  std::optional<obstacle_proximity_checker::CheckResult> proximity_check_result_;
+
+  std::optional<rclcpp::Time> last_frame_time_;
+
   bool is_stop_active_{false};
   std::optional<rclcpp::Time> last_obstacle_found_time_;
 

--- a/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier_utils/utils.hpp
+++ b/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier_utils/utils.hpp
@@ -32,7 +32,8 @@ double calculate_distance_to_last_point(
   const TrajectoryPoints & traj_points, const geometry_msgs::msg::Pose & ego_pose);
 
 void replace_trajectory_with_stop_point(
-  TrajectoryPoints & traj_points, const geometry_msgs::msg::Pose & ego_pose);
+  TrajectoryPoints & traj_points, const geometry_msgs::msg::Pose & ego_pose,
+  const double time_step);
 
 bool is_ego_vehicle_moving(
   const geometry_msgs::msg::Twist & twist, const double velocity_threshold);

--- a/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier_utils/utils.hpp
+++ b/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier_utils/utils.hpp
@@ -37,6 +37,8 @@ void replace_trajectory_with_stop_point(
 bool is_ego_vehicle_moving(
   const geometry_msgs::msg::Twist & twist, const double velocity_threshold);
 
+bool is_stop_trajectory(const TrajectoryPoints & trajectory, const double stopped_vel_th = 1e-3);
+
 }  // namespace autoware::trajectory_modifier::utils
 
 #endif  // AUTOWARE__TRAJECTORY_MODIFIER__TRAJECTORY_MODIFIER_UTILS__UTILS_HPP_

--- a/planning/autoware_trajectory_modifier/package.xml
+++ b/planning/autoware_trajectory_modifier/package.xml
@@ -20,11 +20,11 @@
   <depend>autoware_agnocast_wrapper</depend>
   <depend>autoware_internal_planning_msgs</depend>
   <depend>autoware_motion_utils</depend>
+  <depend>autoware_obstacle_proximity_checker</depend>
   <depend>autoware_path_optimizer</depend>
   <depend>autoware_path_smoother</depend>
   <depend>autoware_planning_factor_interface</depend>
   <depend>autoware_planning_msgs</depend>
-  <depend>autoware_obstacle_proximity_checker</depend>
   <depend>autoware_signal_processing</depend>
   <depend>autoware_trajectory</depend>
   <depend>autoware_utils</depend>

--- a/planning/autoware_trajectory_modifier/package.xml
+++ b/planning/autoware_trajectory_modifier/package.xml
@@ -24,6 +24,7 @@
   <depend>autoware_path_smoother</depend>
   <depend>autoware_planning_factor_interface</depend>
   <depend>autoware_planning_msgs</depend>
+  <depend>autoware_obstacle_proximity_checker</depend>
   <depend>autoware_signal_processing</depend>
   <depend>autoware_trajectory</depend>
   <depend>autoware_utils</depend>
@@ -37,6 +38,8 @@
   <depend>range-v3</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
+  <depend>tf2_eigen</depend>
+  <depend>tf2_ros</depend>
 
   <test_depend>ament_cmake_ros</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/planning/autoware_trajectory_modifier/param/trajectory_modifier_parameter_struct.yaml
+++ b/planning/autoware_trajectory_modifier/param/trajectory_modifier_parameter_struct.yaml
@@ -22,6 +22,11 @@ trajectory_modifier_params:
     default_value: true
     description: Enable the use of velocity modifier
     read_only: false
+  use_surround_obstacle_stop:
+    type: bool
+    default_value: false
+    description: Enable the use of surround obstacle stop
+    read_only: false
   trajectory_time_step:
     type: double
     default_value: 0.1
@@ -365,3 +370,206 @@ trajectory_modifier_params:
         validation:
           bounds<>: [0.0, 10.0]
         read_only: false
+
+  surround_obstacle_stop:
+    use_objects:
+      type: bool
+      default_value: true
+      description: Enable the use of objects for surround obstacle stop
+      read_only: false
+    use_pointcloud:
+      type: bool
+      default_value: true
+      description: Enable the use of pointcloud for surround obstacle stop
+      read_only: false
+    object_types:
+      type: string_array
+      default_value: [car, truck, bus, trailer, motorcycle, bicycle, pedestrian]
+      description: Types of objects to consider for surround obstacle stop
+      read_only: false
+    front_distance_th:
+      car:
+        type: double
+        default_value: 0.5
+        validation:
+          bounds<>: [0.0, 10.0]
+        read_only: false
+      truck:
+        type: double
+        default_value: 0.5
+        validation:
+          bounds<>: [0.0, 10.0]
+        read_only: false
+      bus:
+        type: double
+        default_value: 0.5
+        validation:
+          bounds<>: [0.0, 10.0]
+        read_only: false
+      trailer:
+        type: double
+        default_value: 0.5
+        validation:
+          bounds<>: [0.0, 10.0]
+        read_only: false
+      motorcycle:
+        type: double
+        default_value: 0.5
+        validation:
+          bounds<>: [0.0, 10.0]
+        read_only: false
+      bicycle:
+        type: double
+        default_value: 0.5
+        validation:
+          bounds<>: [0.0, 10.0]
+        read_only: false
+      pedestrian:
+        type: double
+        default_value: 0.5
+        validation:
+          bounds<>: [0.0, 10.0]
+        read_only: false
+      unknown:
+        type: double
+        default_value: 0.5
+        validation:
+          bounds<>: [0.0, 10.0]
+        read_only: false
+      pointcloud:
+        type: double
+        default_value: 0.5
+        validation:
+          bounds<>: [0.0, 10.0]
+        read_only: false
+    side_distance_th:
+      car:
+        type: double
+        default_value: 0.0
+        validation:
+          bounds<>: [0.0, 10.0]
+        read_only: false
+      truck:
+        type: double
+        default_value: 0.0
+        validation:
+          bounds<>: [0.0, 10.0]
+        read_only: false
+      bus:
+        type: double
+        default_value: 0.0
+        validation:
+          bounds<>: [0.0, 10.0]
+        read_only: false
+      trailer:
+        type: double
+        default_value: 0.0
+        validation:
+          bounds<>: [0.0, 10.0]
+        read_only: false
+      motorcycle:
+        type: double
+        default_value: 1.0
+        validation:
+          bounds<>: [0.0, 10.0]
+        read_only: false
+      bicycle:
+        type: double
+        default_value: 1.0
+        validation:
+          bounds<>: [0.0, 10.0]
+        read_only: false
+      pedestrian:
+        type: double
+        default_value: 1.0
+        validation:
+          bounds<>: [0.0, 10.0]
+        read_only: false
+      unknown:
+        type: double
+        default_value: 0.5
+        validation:
+          bounds<>: [0.0, 10.0]
+        read_only: false
+      pointcloud:
+        type: double
+        default_value: 0.5
+        validation:
+          bounds<>: [0.0, 10.0]
+        read_only: false
+    back_distance_th:
+      car:
+        type: double
+        default_value: 0.0
+        validation:
+          bounds<>: [0.0, 10.0]
+        read_only: false
+      truck:
+        type: double
+        default_value: 0.0
+        validation:
+          bounds<>: [0.0, 10.0]
+        read_only: false
+      bus:
+        type: double
+        default_value: 0.0
+        validation:
+          bounds<>: [0.0, 10.0]
+        read_only: false
+      trailer:
+        type: double
+        default_value: 0.0
+        validation:
+          bounds<>: [0.0, 10.0]
+        read_only: false
+      motorcycle:
+        type: double
+        default_value: 0.5
+        validation:
+          bounds<>: [0.0, 10.0]
+        read_only: false
+      bicycle:
+        type: double
+        default_value: 0.5
+        validation:
+          bounds<>: [0.0, 10.0]
+        read_only: false
+      pedestrian:
+        type: double
+        default_value: 0.5
+        validation:
+          bounds<>: [0.0, 10.0]
+        read_only: false
+      unknown:
+        type: double
+        default_value: 0.5
+        validation:
+          bounds<>: [0.0, 10.0]
+        read_only: false
+      pointcloud:
+        type: double
+        default_value: 0.5
+        validation:
+          bounds<>: [0.0, 10.0]
+        read_only: false
+    hysteresis_distance:
+      type: double
+      default_value: 0.1
+      description: Distance hysteresis threshold for clearing stop [m]
+      validation:
+        bounds<>: [0.0, 10.0]
+      read_only: false
+    hysteresis_time:
+      type: double
+      default_value: 0.2
+      description: Time hysteresis threshold for clearing stop [s]
+      validation:
+        bounds<>: [0.0, 10.0]
+      read_only: false
+    ego_stopped_vel_th:
+      type: double
+      default_value: 0.1
+      description: Velocity threshold below which ego vehicle is considered stopped [m/s]
+      validation:
+        bounds<>: [0.0, 10.0]
+      read_only: false

--- a/planning/autoware_trajectory_modifier/plugins.xml
+++ b/planning/autoware_trajectory_modifier/plugins.xml
@@ -18,4 +18,10 @@
       Modifies the velocity of a trajectory to smooth the motion
     </description>
   </class>
+  <class type="autoware::trajectory_modifier::plugin::SurroundObstacleStop"
+         base_class_type="autoware::trajectory_modifier::plugin::TrajectoryModifierPluginBase">
+    <description>
+      Replaces the trajectory with zero velocity when obstacles surround a stopped ego vehicle
+    </description>
+  </class>
 </library>

--- a/planning/autoware_trajectory_modifier/schema/trajectory_modifier.schema.json
+++ b/planning/autoware_trajectory_modifier/schema/trajectory_modifier.schema.json
@@ -28,6 +28,11 @@
           "description": "Enable the obstacle stop modifier plugin",
           "default": true
         },
+        "use_surround_obstacle_stop": {
+          "type": "boolean",
+          "description": "Enable the surround obstacle stop modifier plugin",
+          "default": false
+        },
         "use_velocity_modifier": {
           "type": "boolean",
           "description": "Enable the velocity modifier plugin",
@@ -402,6 +407,97 @@
               },
               "required": [],
               "additionalProperties": false
+            }
+          },
+          "required": [],
+          "additionalProperties": false
+        },
+        "surround_obstacle_stop": {
+          "type": "object",
+          "properties": {
+            "use_objects": {
+              "type": "boolean",
+              "description": "Enable the use of objects for surround obstacle stop",
+              "default": true
+            },
+            "use_pointcloud": {
+              "type": "boolean",
+              "description": "Enable the use of pointcloud for surround obstacle stop",
+              "default": true
+            },
+            "object_types": {
+              "type": "array",
+              "description": "Types of objects to consider for surround obstacle stop",
+              "default": ["car", "truck", "bus", "trailer", "motorcycle", "bicycle", "pedestrian"],
+              "items": {
+                "type": "string"
+              }
+            },
+            "front_distance_th": {
+              "type": "object",
+              "properties": {
+                "car": { "type": "number", "default": 0.5, "minimum": 0.0 },
+                "truck": { "type": "number", "default": 0.5, "minimum": 0.0 },
+                "bus": { "type": "number", "default": 0.5, "minimum": 0.0 },
+                "trailer": { "type": "number", "default": 0.5, "minimum": 0.0 },
+                "motorcycle": { "type": "number", "default": 0.5, "minimum": 0.0 },
+                "bicycle": { "type": "number", "default": 0.5, "minimum": 0.0 },
+                "pedestrian": { "type": "number", "default": 0.5, "minimum": 0.0 },
+                "unknown": { "type": "number", "default": 0.5, "minimum": 0.0 },
+                "pointcloud": { "type": "number", "default": 0.5, "minimum": 0.0 }
+              },
+              "required": [],
+              "additionalProperties": false
+            },
+            "side_distance_th": {
+              "type": "object",
+              "properties": {
+                "car": { "type": "number", "default": 0.0, "minimum": 0.0 },
+                "truck": { "type": "number", "default": 0.0, "minimum": 0.0 },
+                "bus": { "type": "number", "default": 0.0, "minimum": 0.0 },
+                "trailer": { "type": "number", "default": 0.0, "minimum": 0.0 },
+                "motorcycle": { "type": "number", "default": 1.0, "minimum": 0.0 },
+                "bicycle": { "type": "number", "default": 1.0, "minimum": 0.0 },
+                "pedestrian": { "type": "number", "default": 1.0, "minimum": 0.0 },
+                "unknown": { "type": "number", "default": 0.5, "minimum": 0.0 },
+                "pointcloud": { "type": "number", "default": 0.5, "minimum": 0.0 }
+              },
+              "required": [],
+              "additionalProperties": false
+            },
+            "back_distance_th": {
+              "type": "object",
+              "properties": {
+                "car": { "type": "number", "default": 0.0, "minimum": 0.0 },
+                "truck": { "type": "number", "default": 0.0, "minimum": 0.0 },
+                "bus": { "type": "number", "default": 0.0, "minimum": 0.0 },
+                "trailer": { "type": "number", "default": 0.0, "minimum": 0.0 },
+                "motorcycle": { "type": "number", "default": 0.5, "minimum": 0.0 },
+                "bicycle": { "type": "number", "default": 0.5, "minimum": 0.0 },
+                "pedestrian": { "type": "number", "default": 0.5, "minimum": 0.0 },
+                "unknown": { "type": "number", "default": 0.5, "minimum": 0.0 },
+                "pointcloud": { "type": "number", "default": 0.5, "minimum": 0.0 }
+              },
+              "required": [],
+              "additionalProperties": false
+            },
+            "hysteresis_distance": {
+              "type": "number",
+              "description": "Distance hysteresis threshold for clearing stop [m]",
+              "default": 0.1,
+              "minimum": 0.0
+            },
+            "hysteresis_time": {
+              "type": "number",
+              "description": "Time hysteresis threshold for clearing stop [s]",
+              "default": 0.2,
+              "minimum": 0.0
+            },
+            "ego_stopped_vel_th": {
+              "type": "number",
+              "description": "Velocity threshold below which ego vehicle is considered stopped [m/s]",
+              "default": 0.1,
+              "minimum": 0.0
             }
           },
           "required": [],

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/obstacle_stop.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/obstacle_stop.cpp
@@ -242,17 +242,8 @@ bool ObstacleStop::set_stop_point(TrajectoryPoints & traj_points, const InputDat
   if (
     target_stop_point_arc_length < params_.arrived_distance_threshold ||
     !apply_stopping(traj_points, target_stop_point_arc_length)) {
-    traj_points = std::invoke([&]() {
-      TrajectoryPoints stop_points;
-      auto p = traj_points.front();
-      p.longitudinal_velocity_mps = 0.0;
-      p.acceleration_mps2 = 0.0;
-      p.time_from_start = rclcpp::Duration::from_seconds(0.0);
-      stop_points.push_back(p);
-      p.time_from_start = rclcpp::Duration::from_seconds(trajectory_time_step_);
-      stop_points.push_back(p);
-      return stop_points;
-    });
+    utils::replace_trajectory_with_stop_point(
+      traj_points, input.current_odometry->pose.pose, trajectory_time_step_);
   }
 
   const auto & stop_pose = traj_points.back().pose;

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/stop_point_fixer.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/stop_point_fixer.cpp
@@ -83,7 +83,8 @@ bool StopPointFixer::modify_trajectory(TrajectoryPoints & traj_points, const Inp
 {
   if (!is_trajectory_modification_required(traj_points, input)) return false;
 
-  utils::replace_trajectory_with_stop_point(traj_points, input.current_odometry->pose.pose);
+  utils::replace_trajectory_with_stop_point(
+    traj_points, input.current_odometry->pose.pose, trajectory_time_step_);
   auto clock_ptr = get_node_ptr()->get_clock();
   RCLCPP_DEBUG_THROTTLE(
     get_node_ptr()->get_logger(), *clock_ptr, 5000,

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/surround_obstacle_stop.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/surround_obstacle_stop.cpp
@@ -20,6 +20,7 @@
 #include <tf2_eigen/tf2_eigen.hpp>
 
 #include <iomanip>
+#include <memory>
 #include <sstream>
 #include <string>
 #include <unordered_set>
@@ -42,7 +43,8 @@ ObstacleTypeParameters to_obstacle_type_parameters(
 }
 
 Parameters to_proximity_checker_parameters(
-  const autoware::trajectory_modifier::plugin::TrajectoryModifierParams::SurroundObstacleStop & params)
+  const autoware::trajectory_modifier::plugin::TrajectoryModifierParams::SurroundObstacleStop &
+    params)
 {
   Parameters parameters;
   parameters.pointcloud_enable_check = params.use_pointcloud;
@@ -70,12 +72,10 @@ Parameters to_proximity_checker_parameters(
     to_obstacle_type_parameters(front.pointcloud, side.pointcloud, back.pointcloud);
   parameters.obstacle_types_map["unknown"] =
     to_obstacle_type_parameters(front.unknown, side.unknown, back.unknown);
-  parameters.obstacle_types_map["car"] =
-    to_obstacle_type_parameters(front.car, side.car, back.car);
+  parameters.obstacle_types_map["car"] = to_obstacle_type_parameters(front.car, side.car, back.car);
   parameters.obstacle_types_map["truck"] =
     to_obstacle_type_parameters(front.truck, side.truck, back.truck);
-  parameters.obstacle_types_map["bus"] =
-    to_obstacle_type_parameters(front.bus, side.bus, back.bus);
+  parameters.obstacle_types_map["bus"] = to_obstacle_type_parameters(front.bus, side.bus, back.bus);
   parameters.obstacle_types_map["trailer"] =
     to_obstacle_type_parameters(front.trailer, side.trailer, back.trailer);
   parameters.obstacle_types_map["motorcycle"] =

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/surround_obstacle_stop.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/surround_obstacle_stop.cpp
@@ -183,9 +183,12 @@ bool SurroundObstacleStop::is_obstacle_nearby(const InputData & input)
 {
   const double contact_distance_threshold = is_stop_active_ ? params_.hysteresis_distance : 1e-3;
 
-  const auto result =
-    proximity_checker_->check(to_proximity_checker_inputs(input), contact_distance_threshold);
+  if (!proximity_check_result_.has_value()) {
+    proximity_check_result_ =
+      proximity_checker_->check(to_proximity_checker_inputs(input), contact_distance_threshold);
+  }
 
+  const auto & result = proximity_check_result_.value();
   if (result.is_obstacle_found) {
     last_obstacle_found_time_ = get_clock()->now();
     is_stop_active_ = true;
@@ -211,13 +214,16 @@ bool SurroundObstacleStop::is_trajectory_modification_required(
     "SurroundObstacleStop::is_trajectory_modification_required", *get_time_keeper());
 
   if (!enabled_ || !check_inputs(input)) {
+    proximity_check_result_ = std::nullopt;
     return false;
   }
 
-  if (utils::is_ego_vehicle_moving(
-        input.current_odometry->twist.twist, params_.ego_stopped_vel_th)) {
+  if (
+    utils::is_stop_trajectory(traj_points, params_.ego_stopped_vel_th) ||
+    utils::is_ego_vehicle_moving(input.current_odometry->twist.twist, params_.ego_stopped_vel_th)) {
     is_stop_active_ = false;
     last_obstacle_found_time_ = std::nullopt;
+    proximity_check_result_ = std::nullopt;
     return false;
   }
 
@@ -229,6 +235,13 @@ bool SurroundObstacleStop::modify_trajectory(
 {
   autoware_utils_debug::ScopedTimeTrack st(
     "SurroundObstacleStop::modify_trajectory", *get_time_keeper());
+
+  const auto current_time = rclcpp::Time(input.current_odometry->header.stamp);
+
+  if (!last_frame_time_ || *last_frame_time_ != current_time) {
+    proximity_check_result_ = std::nullopt;
+    last_frame_time_ = current_time;
+  }
 
   if (!is_trajectory_modification_required(traj_points, input)) {
     publish_debug_string(false);

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/surround_obstacle_stop.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/surround_obstacle_stop.cpp
@@ -16,8 +16,13 @@
 
 #include "autoware/trajectory_modifier/trajectory_modifier_utils/utils.hpp"
 
+#include <autoware_utils/transform/transforms.hpp>
 #include <autoware_utils_debug/time_keeper.hpp>
 #include <tf2_eigen/tf2_eigen.hpp>
+
+#include <pcl/common/transforms.h>
+#include <pcl/point_cloud.h>
+#include <pcl_conversions/pcl_conversions.h>
 
 #include <iomanip>
 #include <memory>
@@ -27,8 +32,6 @@
 
 namespace
 {
-constexpr double kContactDistanceThreshold = 1e-3;
-
 using autoware::obstacle_proximity_checker::ObstacleTypeParameters;
 using autoware::obstacle_proximity_checker::Parameters;
 
@@ -139,28 +142,46 @@ obstacle_proximity_checker::Inputs SurroundObstacleStop::to_proximity_checker_in
 {
   obstacle_proximity_checker::Inputs checker_inputs;
   checker_inputs.ego_pose = input.current_odometry->pose.pose;
-  checker_inputs.pointcloud = params_.use_pointcloud ? input.obstacle_pointcloud : nullptr;
-  checker_inputs.objects = params_.use_objects ? input.predicted_objects : nullptr;
+  checker_inputs.objects = input.predicted_objects;
 
-  if (checker_inputs.pointcloud) {
-    try {
-      const auto transform_stamped = context_->tf_buffer.lookupTransform(
-        "base_link", checker_inputs.pointcloud->header.frame_id,
-        checker_inputs.pointcloud->header.stamp, tf2::durationFromSec(0.5));
-      checker_inputs.pointcloud_to_base_link_transform =
-        tf2::transformToEigen(transform_stamped.transform).cast<float>();
-    } catch (const tf2::TransformException &) {
-      checker_inputs.pointcloud_to_base_link_transform = std::nullopt;
-    }
-  }
+  if (!input.obstacle_pointcloud) return checker_inputs;
+
+  const auto transform_stamped = get_transform(
+    "base_link", input.obstacle_pointcloud->header.frame_id,
+    input.obstacle_pointcloud->header.stamp, 0.5);
+
+  if (!transform_stamped.has_value()) return checker_inputs;
+
+  Eigen::Affine3f isometry =
+    tf2::transformToEigen(transform_stamped.value().transform).cast<float>();
+  pcl::PointCloud<pcl::PointXYZ> transformed_pointcloud;
+  pcl::fromROSMsg(*input.obstacle_pointcloud, transformed_pointcloud);
+  autoware_utils::transform_pointcloud(transformed_pointcloud, transformed_pointcloud, isometry);
+
+  checker_inputs.pointcloud_in_base_link = transformed_pointcloud.makeShared();
 
   return checker_inputs;
 }
 
+std::optional<geometry_msgs::msg::TransformStamped> SurroundObstacleStop::get_transform(
+  const std::string & source, const std::string & target, const rclcpp::Time & stamp,
+  double duration_sec) const
+{
+  geometry_msgs::msg::TransformStamped transform_stamped;
+
+  try {
+    transform_stamped = context_->tf_buffer.lookupTransform(
+      source, target, stamp, tf2::durationFromSec(duration_sec));
+  } catch (const tf2::TransformException & ex) {
+    return {};
+  }
+
+  return transform_stamped;
+}
+
 bool SurroundObstacleStop::is_obstacle_nearby(const InputData & input)
 {
-  const double contact_distance_threshold =
-    is_stop_active_ ? params_.hysteresis_distance : kContactDistanceThreshold;
+  const double contact_distance_threshold = is_stop_active_ ? params_.hysteresis_distance : 1e-3;
 
   const auto result =
     proximity_checker_->check(to_proximity_checker_inputs(input), contact_distance_threshold);

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/surround_obstacle_stop.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/surround_obstacle_stop.cpp
@@ -1,0 +1,251 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/trajectory_modifier/trajectory_modifier_plugins/surround_obstacle_stop.hpp"
+
+#include "autoware/trajectory_modifier/trajectory_modifier_utils/utils.hpp"
+
+#include <autoware_utils_debug/time_keeper.hpp>
+#include <tf2_eigen/tf2_eigen.hpp>
+
+#include <iomanip>
+#include <sstream>
+#include <string>
+#include <unordered_set>
+
+namespace
+{
+constexpr double kContactDistanceThreshold = 1e-3;
+
+using autoware::obstacle_proximity_checker::ObstacleTypeParameters;
+using autoware::obstacle_proximity_checker::Parameters;
+
+ObstacleTypeParameters to_obstacle_type_parameters(
+  const double front_distance, const double side_distance, const double back_distance)
+{
+  ObstacleTypeParameters parameters;
+  parameters.surround_check_front_distance = front_distance;
+  parameters.surround_check_side_distance = side_distance;
+  parameters.surround_check_back_distance = back_distance;
+  return parameters;
+}
+
+Parameters to_proximity_checker_parameters(
+  const autoware::trajectory_modifier::plugin::TrajectoryModifierParams::SurroundObstacleStop & params)
+{
+  Parameters parameters;
+  parameters.pointcloud_enable_check = params.use_pointcloud;
+
+  const std::unordered_set<std::string> enabled_object_types(
+    params.object_types.begin(), params.object_types.end());
+
+  const auto set_object_enable = [&](const std::string & label) {
+    parameters.object_type_enable_check[label] = enabled_object_types.count(label) > 0;
+  };
+  set_object_enable("unknown");
+  set_object_enable("car");
+  set_object_enable("truck");
+  set_object_enable("bus");
+  set_object_enable("trailer");
+  set_object_enable("motorcycle");
+  set_object_enable("bicycle");
+  set_object_enable("pedestrian");
+
+  const auto & front = params.front_distance_th;
+  const auto & side = params.side_distance_th;
+  const auto & back = params.back_distance_th;
+
+  parameters.obstacle_types_map["pointcloud"] =
+    to_obstacle_type_parameters(front.pointcloud, side.pointcloud, back.pointcloud);
+  parameters.obstacle_types_map["unknown"] =
+    to_obstacle_type_parameters(front.unknown, side.unknown, back.unknown);
+  parameters.obstacle_types_map["car"] =
+    to_obstacle_type_parameters(front.car, side.car, back.car);
+  parameters.obstacle_types_map["truck"] =
+    to_obstacle_type_parameters(front.truck, side.truck, back.truck);
+  parameters.obstacle_types_map["bus"] =
+    to_obstacle_type_parameters(front.bus, side.bus, back.bus);
+  parameters.obstacle_types_map["trailer"] =
+    to_obstacle_type_parameters(front.trailer, side.trailer, back.trailer);
+  parameters.obstacle_types_map["motorcycle"] =
+    to_obstacle_type_parameters(front.motorcycle, side.motorcycle, back.motorcycle);
+  parameters.obstacle_types_map["bicycle"] =
+    to_obstacle_type_parameters(front.bicycle, side.bicycle, back.bicycle);
+  parameters.obstacle_types_map["pedestrian"] =
+    to_obstacle_type_parameters(front.pedestrian, side.pedestrian, back.pedestrian);
+
+  return parameters;
+}
+}  // namespace
+
+namespace autoware::trajectory_modifier::plugin
+{
+
+void SurroundObstacleStop::on_initialize(const TrajectoryModifierParams & params)
+{
+  const auto node_ptr = get_node_ptr();
+  planning_factor_interface_ =
+    std::make_unique<autoware::planning_factor_interface::PlanningFactorInterface>(
+      node_ptr, "modifier_surround_obstacle_stop");
+
+  pub_debug_text_ =
+    node_ptr->create_publisher<StringStamped>("~/surround_obstacle_stop/debug/text", 1);
+
+  enabled_ = params.use_surround_obstacle_stop;
+  params_ = params.surround_obstacle_stop;
+  trajectory_time_step_ = params.trajectory_time_step;
+
+  proximity_checker_ = std::make_unique<obstacle_proximity_checker::ProximityChecker>(
+    to_proximity_checker_parameters(params_), context_->vehicle_info);
+}
+
+void SurroundObstacleStop::update_params(const TrajectoryModifierParams & params)
+{
+  enabled_ = params.use_surround_obstacle_stop;
+  params_ = params.surround_obstacle_stop;
+  trajectory_time_step_ = params.trajectory_time_step;
+  proximity_checker_->update_parameters(to_proximity_checker_parameters(params_));
+}
+
+bool SurroundObstacleStop::check_inputs(const InputData & input) const
+{
+  if (!input.current_odometry) {
+    return false;
+  }
+
+  if (!params_.use_pointcloud && !params_.use_objects) {
+    return false;
+  }
+
+  const bool has_pointcloud = params_.use_pointcloud && input.obstacle_pointcloud;
+  const bool has_objects = params_.use_objects && input.predicted_objects;
+
+  return has_pointcloud || has_objects;
+}
+
+obstacle_proximity_checker::Inputs SurroundObstacleStop::to_proximity_checker_inputs(
+  const InputData & input) const
+{
+  obstacle_proximity_checker::Inputs checker_inputs;
+  checker_inputs.ego_pose = input.current_odometry->pose.pose;
+  checker_inputs.pointcloud = params_.use_pointcloud ? input.obstacle_pointcloud : nullptr;
+  checker_inputs.objects = params_.use_objects ? input.predicted_objects : nullptr;
+
+  if (checker_inputs.pointcloud) {
+    try {
+      const auto transform_stamped = context_->tf_buffer.lookupTransform(
+        "base_link", checker_inputs.pointcloud->header.frame_id,
+        checker_inputs.pointcloud->header.stamp, tf2::durationFromSec(0.5));
+      checker_inputs.pointcloud_to_base_link_transform =
+        tf2::transformToEigen(transform_stamped.transform).cast<float>();
+    } catch (const tf2::TransformException &) {
+      checker_inputs.pointcloud_to_base_link_transform = std::nullopt;
+    }
+  }
+
+  return checker_inputs;
+}
+
+bool SurroundObstacleStop::is_obstacle_nearby(const InputData & input)
+{
+  const double contact_distance_threshold =
+    is_stop_active_ ? params_.hysteresis_distance : kContactDistanceThreshold;
+
+  const auto result =
+    proximity_checker_->check(to_proximity_checker_inputs(input), contact_distance_threshold);
+
+  if (result.is_obstacle_found) {
+    last_obstacle_found_time_ = get_clock()->now();
+    is_stop_active_ = true;
+    return true;
+  }
+
+  if (is_stop_active_ && last_obstacle_found_time_.has_value()) {
+    const auto elapsed_time = get_clock()->now() - last_obstacle_found_time_.value();
+    if (elapsed_time.seconds() <= params_.hysteresis_time) {
+      return true;
+    }
+  }
+
+  is_stop_active_ = false;
+  last_obstacle_found_time_ = std::nullopt;
+  return false;
+}
+
+bool SurroundObstacleStop::is_trajectory_modification_required(
+  [[maybe_unused]] const TrajectoryPoints & traj_points, const InputData & input)
+{
+  autoware_utils_debug::ScopedTimeTrack st(
+    "SurroundObstacleStop::is_trajectory_modification_required", *get_time_keeper());
+
+  if (!enabled_ || !check_inputs(input)) {
+    return false;
+  }
+
+  if (utils::is_ego_vehicle_moving(
+        input.current_odometry->twist.twist, params_.ego_stopped_vel_th)) {
+    is_stop_active_ = false;
+    last_obstacle_found_time_ = std::nullopt;
+    return false;
+  }
+
+  return is_obstacle_nearby(input);
+}
+
+bool SurroundObstacleStop::modify_trajectory(
+  TrajectoryPoints & traj_points, const InputData & input)
+{
+  autoware_utils_debug::ScopedTimeTrack st(
+    "SurroundObstacleStop::modify_trajectory", *get_time_keeper());
+
+  if (!is_trajectory_modification_required(traj_points, input)) {
+    publish_debug_string(false);
+    return false;
+  }
+
+  const auto & ego_pose = input.current_odometry->pose.pose;
+  utils::replace_trajectory_with_stop_point(traj_points, ego_pose);
+
+  planning_factor_interface_->add(
+    traj_points, ego_pose, ego_pose, PlanningFactor::STOP,
+    autoware_internal_planning_msgs::msg::SafetyFactorArray{});
+
+  RCLCPP_WARN_THROTTLE(
+    get_node_ptr()->get_logger(), *get_clock(), 1000,
+    "[TM SurroundObstacleStop] Replaced trajectory with zero velocity due to nearby obstacle.");
+
+  publish_debug_string(true);
+  return true;
+}
+
+void SurroundObstacleStop::publish_debug_string(const bool is_active) const
+{
+  std::ostringstream ss;
+  ss << std::fixed << std::setprecision(2) << std::boolalpha;
+  ss << "SURROUND OBSTACLE STOP MODIFIER:\n";
+  ss << "\t\tACTIVE: " << is_active << "\n";
+  ss << "\t\tSTOP_ACTIVE: " << is_stop_active_ << "\n";
+
+  StringStamped string_stamp;
+  string_stamp.stamp = get_clock()->now();
+  string_stamp.data = ss.str();
+  pub_debug_text_->publish(string_stamp);
+}
+
+}  // namespace autoware::trajectory_modifier::plugin
+
+#include <pluginlib/class_list_macros.hpp>
+PLUGINLIB_EXPORT_CLASS(
+  autoware::trajectory_modifier::plugin::SurroundObstacleStop,
+  autoware::trajectory_modifier::plugin::TrajectoryModifierPluginBase)

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/surround_obstacle_stop.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/surround_obstacle_stop.cpp
@@ -249,7 +249,7 @@ bool SurroundObstacleStop::modify_trajectory(
   }
 
   const auto & ego_pose = input.current_odometry->pose.pose;
-  utils::replace_trajectory_with_stop_point(traj_points, ego_pose);
+  utils::replace_trajectory_with_stop_point(traj_points, ego_pose, trajectory_time_step_);
 
   planning_factor_interface_->add(
     traj_points, ego_pose, ego_pose, PlanningFactor::STOP,

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier_utils/utils.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier_utils/utils.cpp
@@ -38,7 +38,7 @@ double calculate_distance_to_last_point(
 }
 
 void replace_trajectory_with_stop_point(
-  TrajectoryPoints & traj_points, const geometry_msgs::msg::Pose & ego_pose)
+  TrajectoryPoints & traj_points, const geometry_msgs::msg::Pose & ego_pose, const double time_step)
 {
   TrajectoryPoint stop_point;
 
@@ -49,11 +49,17 @@ void replace_trajectory_with_stop_point(
   stop_point.heading_rate_rps = 0.0;
   stop_point.front_wheel_angle_rad = 0.0;
   stop_point.rear_wheel_angle_rad = 0.0;
+  stop_point.time_from_start = rclcpp::Duration::from_seconds(0.0);
 
   traj_points.clear();
 
-  // Two points are added since that is the minimum handled by Control.
+  // Three points are added since that is the minimum handled by Control.
   traj_points.push_back(stop_point);
+  stop_point.time_from_start = rclcpp::Duration::from_seconds(time_step);
+  stop_point.pose = autoware_utils_geometry::calc_offset_pose(stop_point.pose, 1e-3, 0.0, 0.0);
+  traj_points.push_back(stop_point);
+  stop_point.time_from_start = rclcpp::Duration::from_seconds(2.0 * time_step);
+  stop_point.pose = autoware_utils_geometry::calc_offset_pose(stop_point.pose, 1e-3, 0.0, 0.0);
   traj_points.push_back(stop_point);
 }
 

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier_utils/utils.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier_utils/utils.cpp
@@ -27,14 +27,14 @@ bool validate_trajectory(const TrajectoryPoints & trajectory)
 }
 
 double calculate_distance_to_last_point(
-  const TrajectoryPoints & traj_points, const geometry_msgs::msg::Pose & ego_pose)
+  const TrajectoryPoints & traj_points, const geometry_msgs::msg::Pose & src_pose)
 {
   if (traj_points.empty()) {
     return 0.0;
   }
 
   return autoware::motion_utils::calcSignedArcLength(
-    traj_points, ego_pose.position, traj_points.back().pose.position);
+    traj_points, src_pose.position, traj_points.size() - 1);
 }
 
 void replace_trajectory_with_stop_point(
@@ -64,6 +64,19 @@ bool is_ego_vehicle_moving(const geometry_msgs::msg::Twist & twist, const double
     twist.linear.z * twist.linear.z);
 
   return current_velocity > velocity_threshold;
+}
+
+bool is_stop_trajectory(const TrajectoryPoints & traj_points, const double stopped_vel_th)
+{
+  if (traj_points.empty()) return false;
+
+  if (calculate_distance_to_last_point(traj_points, traj_points.front().pose) > 1.0) {
+    return false;
+  }
+
+  return std::find_if(traj_points.begin(), traj_points.end(), [&](const TrajectoryPoint & point) {
+           return point.longitudinal_velocity_mps > stopped_vel_th;
+         }) == traj_points.end();
 }
 
 }  // namespace autoware::trajectory_modifier::utils

--- a/planning/autoware_trajectory_modifier/tests/test_stop_point_fixer_integration.cpp
+++ b/planning/autoware_trajectory_modifier/tests/test_stop_point_fixer_integration.cpp
@@ -202,14 +202,14 @@ TEST_F(StopPointFixerIntegrationTest, ModifyTrajectoryWhenRequired)
   plugin_->modify_trajectory(trajectory, input);
 
   // Should replace with two stop points at ego position (minimum for Control)
-  EXPECT_EQ(trajectory.size(), 2);
+  EXPECT_EQ(trajectory.size(), 3);
   EXPECT_DOUBLE_EQ(trajectory[0].pose.position.x, 0.0);
   EXPECT_DOUBLE_EQ(trajectory[0].pose.position.y, 0.0);
   EXPECT_DOUBLE_EQ(trajectory[0].longitudinal_velocity_mps, 0.0);
   EXPECT_DOUBLE_EQ(trajectory[0].lateral_velocity_mps, 0.0);
   EXPECT_DOUBLE_EQ(trajectory[0].acceleration_mps2, 0.0);
-  EXPECT_DOUBLE_EQ(trajectory[1].pose.position.x, 0.0);
-  EXPECT_DOUBLE_EQ(trajectory[1].pose.position.y, 0.0);
+  EXPECT_NEAR(trajectory[1].pose.position.x, 0.0, 5e-2);
+  EXPECT_NEAR(trajectory[1].pose.position.y, 0.0, 5e-2);
   EXPECT_DOUBLE_EQ(trajectory[1].longitudinal_velocity_mps, 0.0);
 }
 

--- a/planning/autoware_trajectory_modifier/tests/test_surround_obstacle_stop_integration.cpp
+++ b/planning/autoware_trajectory_modifier/tests/test_surround_obstacle_stop_integration.cpp
@@ -79,10 +79,12 @@ TrajectoryPoints create_straight_trajectory(
   return trajectory;
 }
 
-Odometry::ConstSharedPtr make_odometry(double x, double y, double velocity)
+Odometry::ConstSharedPtr make_odometry(
+  double x, double y, double velocity, const rclcpp::Time & stamp)
 {
   Odometry odometry;
   odometry.header.frame_id = "map";
+  odometry.header.stamp = stamp;
   odometry.pose.pose.position.x = x;
   odometry.pose.pose.position.y = y;
   odometry.pose.pose.position.z = 0.0;
@@ -169,15 +171,6 @@ InputData create_input_data(
   return input;
 }
 
-InputData make_stopped_input(
-  PredictedObjects::ConstSharedPtr predicted_objects = nullptr,
-  sensor_msgs::msg::PointCloud2::ConstSharedPtr obstacle_pointcloud = nullptr)
-{
-  return create_input_data(
-    make_odometry(0.0, 0.0, 0.0), make_acceleration(0.0), std::move(predicted_objects),
-    std::move(obstacle_pointcloud));
-}
-
 void expect_stop_trajectory_at_ego(const TrajectoryPoints & trajectory)
 {
   ASSERT_EQ(trajectory.size(), 2U);
@@ -244,6 +237,16 @@ protected:
     p.side_distance_th.pointcloud = 1.0;
   }
 
+  InputData make_stopped_input(
+    PredictedObjects::ConstSharedPtr predicted_objects = nullptr,
+    sensor_msgs::msg::PointCloud2::ConstSharedPtr obstacle_pointcloud = nullptr)
+  {
+    const auto current_time = node_->now();
+    return create_input_data(
+      make_odometry(0.0, 0.0, 0.0, current_time), make_acceleration(0.0),
+      std::move(predicted_objects), std::move(obstacle_pointcloud));
+  }
+
   std::shared_ptr<rclcpp::Node> node_;
   std::shared_ptr<autoware_utils_debug::TimeKeeper> time_keeper_;
   std::unique_ptr<SurroundObstacleStop> plugin_;
@@ -267,8 +270,9 @@ TEST_F(SurroundObstacleStopIntegrationTest, TrajectoryNotModifiedWhenEgoMoving)
 {
   auto trajectory = create_straight_trajectory(10.0, 5.0);
   const auto objects = make_predicted_objects(0.0, 2.5);
+  const auto current_time = node_->now();
   const auto input =
-    create_input_data(make_odometry(0.0, 0.0, 5.0), make_acceleration(0.0), objects);
+    create_input_data(make_odometry(0.0, 0.0, 5.0, current_time), make_acceleration(0.0), objects);
 
   const bool modified = plugin_->modify_trajectory(trajectory, input);
 
@@ -317,6 +321,7 @@ TEST_F(SurroundObstacleStopIntegrationTest, TrajectoryModifiedWhenNearObjectDete
   ASSERT_TRUE(modified);
   expect_stop_trajectory_at_ego(trajectory);
 
+  trajectory = create_straight_trajectory(10.0, 0.0);
   objects = make_predicted_objects(0.0, 3.0);
   input = make_stopped_input(objects);
   const bool modified_with_hysteresis = plugin_->modify_trajectory(trajectory, input);

--- a/planning/autoware_trajectory_modifier/tests/test_surround_obstacle_stop_integration.cpp
+++ b/planning/autoware_trajectory_modifier/tests/test_surround_obstacle_stop_integration.cpp
@@ -173,15 +173,16 @@ InputData create_input_data(
 
 void expect_stop_trajectory_at_ego(const TrajectoryPoints & trajectory)
 {
-  ASSERT_EQ(trajectory.size(), 2U);
+  ASSERT_EQ(trajectory.size(), 3U);
+
+  EXPECT_FLOAT_EQ(trajectory.front().pose.position.x, 0.0);
+  EXPECT_FLOAT_EQ(trajectory.front().pose.position.y, 0.0);
   EXPECT_FLOAT_EQ(trajectory.front().longitudinal_velocity_mps, 0.0F);
-  EXPECT_FLOAT_EQ(trajectory.back().longitudinal_velocity_mps, 0.0F);
   EXPECT_FLOAT_EQ(trajectory.front().acceleration_mps2, 0.0F);
+  EXPECT_NEAR(trajectory.back().pose.position.x, 0.0, 1e-2);
+  EXPECT_NEAR(trajectory.back().pose.position.y, 0.0, 1e-2);
+  EXPECT_FLOAT_EQ(trajectory.back().longitudinal_velocity_mps, 0.0F);
   EXPECT_FLOAT_EQ(trajectory.back().acceleration_mps2, 0.0F);
-  EXPECT_NEAR(trajectory.front().pose.position.x, 0.0, 1e-3);
-  EXPECT_NEAR(trajectory.front().pose.position.y, 0.0, 1e-3);
-  EXPECT_NEAR(trajectory.back().pose.position.x, 0.0, 1e-3);
-  EXPECT_NEAR(trajectory.back().pose.position.y, 0.0, 1e-3);
 }
 
 }  // namespace

--- a/planning/autoware_trajectory_modifier/tests/test_surround_obstacle_stop_integration.cpp
+++ b/planning/autoware_trajectory_modifier/tests/test_surround_obstacle_stop_integration.cpp
@@ -1,0 +1,363 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/trajectory_modifier/trajectory_modifier_plugins/surround_obstacle_stop.hpp"
+
+#include <ament_index_cpp/get_package_share_directory.hpp>
+#include <autoware_test_utils/autoware_test_utils.hpp>
+#include <autoware_trajectory_modifier/trajectory_modifier_param.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+#include <autoware_perception_msgs/msg/object_classification.hpp>
+#include <autoware_perception_msgs/msg/predicted_objects.hpp>
+#include <autoware_perception_msgs/msg/shape.hpp>
+#include <geometry_msgs/msg/accel_with_covariance_stamped.hpp>
+#include <nav_msgs/msg/odometry.hpp>
+#include <sensor_msgs/msg/point_cloud2.hpp>
+#include <sensor_msgs/point_cloud2_iterator.hpp>
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <chrono>
+#include <memory>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
+
+namespace
+{
+using autoware::trajectory_modifier::TrajectoryModifierContext;
+using autoware::trajectory_modifier::plugin::InputData;
+using autoware::trajectory_modifier::plugin::SurroundObstacleStop;
+using autoware::trajectory_modifier::plugin::TrajectoryPoints;
+using autoware_perception_msgs::msg::ObjectClassification;
+using autoware_perception_msgs::msg::PredictedObject;
+using autoware_perception_msgs::msg::PredictedObjects;
+using autoware_perception_msgs::msg::Shape;
+using autoware_planning_msgs::msg::TrajectoryPoint;
+using geometry_msgs::msg::AccelWithCovarianceStamped;
+using nav_msgs::msg::Odometry;
+
+TrajectoryPoint create_trajectory_point(double x, double y, double velocity)
+{
+  TrajectoryPoint point;
+  point.pose.position.x = x;
+  point.pose.position.y = y;
+  point.pose.position.z = 0.0;
+  point.pose.orientation.x = 0.0;
+  point.pose.orientation.y = 0.0;
+  point.pose.orientation.z = 0.0;
+  point.pose.orientation.w = 1.0;
+  point.longitudinal_velocity_mps = static_cast<float>(velocity);
+  point.acceleration_mps2 = 0.0F;
+  return point;
+}
+
+TrajectoryPoints create_straight_trajectory(
+  double length, double init_velocity, double spacing = 1.0)
+{
+  constexpr double max_velocity = 5.0;
+  TrajectoryPoints trajectory;
+  auto vel = init_velocity;
+  for (double x = 0.0; x <= length + 1e-6; x += spacing) {
+    trajectory.push_back(create_trajectory_point(x, 0.0, vel));
+    vel = std::min(vel + 0.5, max_velocity);
+  }
+  return trajectory;
+}
+
+Odometry::ConstSharedPtr make_odometry(double x, double y, double velocity)
+{
+  Odometry odometry;
+  odometry.header.frame_id = "map";
+  odometry.pose.pose.position.x = x;
+  odometry.pose.pose.position.y = y;
+  odometry.pose.pose.position.z = 0.0;
+  odometry.pose.pose.orientation.w = 1.0;
+  odometry.twist.twist.linear.x = velocity;
+  return std::make_shared<const Odometry>(odometry);
+}
+
+AccelWithCovarianceStamped::ConstSharedPtr make_acceleration(double accel_x)
+{
+  AccelWithCovarianceStamped acceleration;
+  acceleration.accel.accel.linear.x = accel_x;
+  return std::make_shared<const AccelWithCovarianceStamped>(acceleration);
+}
+
+PredictedObject create_box_object(
+  double x, double y, double size_x, double size_y, double size_z, uint8_t classification_label)
+{
+  PredictedObject object;
+  object.kinematics.initial_pose_with_covariance.pose.position.x = x;
+  object.kinematics.initial_pose_with_covariance.pose.position.y = y;
+  object.kinematics.initial_pose_with_covariance.pose.position.z = 0.0;
+  object.kinematics.initial_pose_with_covariance.pose.orientation.w = 1.0;
+  object.kinematics.initial_twist_with_covariance.twist.linear.x = 0.0;
+
+  object.shape.type = Shape::BOUNDING_BOX;
+  object.shape.dimensions.x = size_x;
+  object.shape.dimensions.y = size_y;
+  object.shape.dimensions.z = size_z;
+
+  ObjectClassification classification;
+  classification.label = classification_label;
+  classification.probability = 1.0;
+  object.classification.push_back(classification);
+
+  return object;
+}
+
+PredictedObjects::ConstSharedPtr make_predicted_objects(
+  double x, double y, uint8_t classification_label = ObjectClassification::CAR)
+{
+  constexpr double size_x = 2.0;
+  constexpr double size_y = 2.0;
+  constexpr double size_z = 1.5;
+
+  PredictedObjects predicted_objects;
+  predicted_objects.header.frame_id = "map";
+  predicted_objects.objects.push_back(
+    create_box_object(x, y, size_x, size_y, size_z, classification_label));
+  return std::make_shared<const PredictedObjects>(predicted_objects);
+}
+
+sensor_msgs::msg::PointCloud2::ConstSharedPtr make_pointcloud_in_base_link(
+  double x, double y, double z)
+{
+  sensor_msgs::msg::PointCloud2 cloud;
+  cloud.header.frame_id = "base_link";
+  cloud.header.stamp = rclcpp::Time(0, 0, RCL_ROS_TIME);
+  sensor_msgs::PointCloud2Modifier modifier(cloud);
+  modifier.setPointCloud2FieldsByString(1, "xyz");
+  modifier.resize(1);
+
+  sensor_msgs::PointCloud2Iterator<float> iter_x(cloud, "x");
+  sensor_msgs::PointCloud2Iterator<float> iter_y(cloud, "y");
+  sensor_msgs::PointCloud2Iterator<float> iter_z(cloud, "z");
+  *iter_x = static_cast<float>(x);
+  *iter_y = static_cast<float>(y);
+  *iter_z = static_cast<float>(z);
+
+  return std::make_shared<const sensor_msgs::msg::PointCloud2>(cloud);
+}
+
+InputData create_input_data(
+  Odometry::ConstSharedPtr current_odometry,
+  AccelWithCovarianceStamped::ConstSharedPtr current_acceleration,
+  PredictedObjects::ConstSharedPtr predicted_objects = nullptr,
+  sensor_msgs::msg::PointCloud2::ConstSharedPtr obstacle_pointcloud = nullptr)
+{
+  InputData input;
+  input.current_odometry = std::move(current_odometry);
+  input.current_acceleration = std::move(current_acceleration);
+  input.predicted_objects = std::move(predicted_objects);
+  input.obstacle_pointcloud = std::move(obstacle_pointcloud);
+  return input;
+}
+
+InputData make_stopped_input(
+  PredictedObjects::ConstSharedPtr predicted_objects = nullptr,
+  sensor_msgs::msg::PointCloud2::ConstSharedPtr obstacle_pointcloud = nullptr)
+{
+  return create_input_data(
+    make_odometry(0.0, 0.0, 0.0), make_acceleration(0.0), std::move(predicted_objects),
+    std::move(obstacle_pointcloud));
+}
+
+void expect_stop_trajectory_at_ego(const TrajectoryPoints & trajectory)
+{
+  ASSERT_EQ(trajectory.size(), 2U);
+  EXPECT_FLOAT_EQ(trajectory.front().longitudinal_velocity_mps, 0.0F);
+  EXPECT_FLOAT_EQ(trajectory.back().longitudinal_velocity_mps, 0.0F);
+  EXPECT_FLOAT_EQ(trajectory.front().acceleration_mps2, 0.0F);
+  EXPECT_FLOAT_EQ(trajectory.back().acceleration_mps2, 0.0F);
+  EXPECT_NEAR(trajectory.front().pose.position.x, 0.0, 1e-3);
+  EXPECT_NEAR(trajectory.front().pose.position.y, 0.0, 1e-3);
+  EXPECT_NEAR(trajectory.back().pose.position.x, 0.0, 1e-3);
+  EXPECT_NEAR(trajectory.back().pose.position.y, 0.0, 1e-3);
+}
+
+}  // namespace
+
+class SurroundObstacleStopIntegrationTest : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    rclcpp::init(0, nullptr);
+
+    auto node_options = rclcpp::NodeOptions{};
+    const auto autoware_test_utils_dir =
+      ament_index_cpp::get_package_share_directory("autoware_test_utils");
+    autoware::test_utils::updateNodeOptions(
+      node_options, {autoware_test_utils_dir + "/config/test_vehicle_info.param.yaml"});
+
+    node_ = std::make_shared<rclcpp::Node>("test_surround_obstacle_stop_node", node_options);
+    time_keeper_ = std::make_shared<autoware_utils_debug::TimeKeeper>();
+
+    set_up_default_params();
+
+    context_ = std::make_shared<TrajectoryModifierContext>(node_.get());
+    plugin_ = std::make_unique<SurroundObstacleStop>();
+    plugin_->initialize(
+      "test_surround_obstacle_stop", node_.get(), time_keeper_, context_, params_);
+  }
+
+  void TearDown() override
+  {
+    rclcpp::shutdown();
+    plugin_.reset();
+    context_.reset();
+    node_.reset();
+  }
+
+  void set_up_default_params()
+  {
+    params_.use_stop_point_fixer = false;
+    params_.use_obstacle_stop = false;
+    params_.use_velocity_modifier = false;
+    params_.use_surround_obstacle_stop = true;
+    params_.trajectory_time_step = 0.1;
+
+    auto & p = params_.surround_obstacle_stop;
+    p.use_objects = true;
+    p.use_pointcloud = true;
+    p.object_types = {"car"};
+    p.hysteresis_distance = 0.5;
+    p.hysteresis_time = 0.0;
+    p.ego_stopped_vel_th = 0.1;
+    p.side_distance_th.car = 1.0;
+    p.side_distance_th.pointcloud = 1.0;
+  }
+
+  std::shared_ptr<rclcpp::Node> node_;
+  std::shared_ptr<autoware_utils_debug::TimeKeeper> time_keeper_;
+  std::unique_ptr<SurroundObstacleStop> plugin_;
+  trajectory_modifier_params::Params params_;
+  std::shared_ptr<TrajectoryModifierContext> context_;
+};
+
+TEST_F(SurroundObstacleStopIntegrationTest, TrajectoryNotModifiedWhenDisabled)
+{
+  params_.use_surround_obstacle_stop = false;
+  plugin_->update_params(params_);
+  auto trajectory = create_straight_trajectory(10.0, 0.0);
+  const auto input = make_stopped_input(make_predicted_objects(0.0, 4.0));
+
+  const bool modified = plugin_->modify_trajectory(trajectory, input);
+
+  EXPECT_FALSE(modified);
+}
+
+TEST_F(SurroundObstacleStopIntegrationTest, TrajectoryNotModifiedWhenEgoMoving)
+{
+  auto trajectory = create_straight_trajectory(10.0, 5.0);
+  const auto objects = make_predicted_objects(0.0, 2.5);
+  const auto input =
+    create_input_data(make_odometry(0.0, 0.0, 5.0), make_acceleration(0.0), objects);
+
+  const bool modified = plugin_->modify_trajectory(trajectory, input);
+
+  EXPECT_FALSE(modified);
+}
+
+TEST_F(SurroundObstacleStopIntegrationTest, TrajectoryNotModifiedWhenNoObstaclesDetected)
+{
+  auto trajectory = create_straight_trajectory(10.0, 0.0);
+  const auto input = make_stopped_input();
+
+  const bool modified = plugin_->modify_trajectory(trajectory, input);
+
+  EXPECT_FALSE(modified);
+}
+
+TEST_F(SurroundObstacleStopIntegrationTest, TrajectoryNotModifiedWhenObstacleIsFarAway)
+{
+  auto trajectory = create_straight_trajectory(10.0, 0.0);
+  auto objects = make_predicted_objects(0.0, 10.0);
+  const auto input = make_stopped_input(objects);
+
+  const bool modified = plugin_->modify_trajectory(trajectory, input);
+
+  EXPECT_FALSE(modified);
+}
+
+TEST_F(SurroundObstacleStopIntegrationTest, TrajectoryModifiedWhenNearObjectDetected)
+{
+  auto trajectory = create_straight_trajectory(10.0, 0.0);
+  auto objects = make_predicted_objects(0.0, 2.5);
+  const auto input = make_stopped_input(objects);
+
+  const bool modified = plugin_->modify_trajectory(trajectory, input);
+
+  ASSERT_TRUE(modified);
+  expect_stop_trajectory_at_ego(trajectory);
+}
+
+TEST_F(SurroundObstacleStopIntegrationTest, TrajectoryModifiedWhenNearObjectDetectedWithHysteresis)
+{
+  auto trajectory = create_straight_trajectory(10.0, 0.0);
+  auto objects = make_predicted_objects(0.0, 2.5);
+  auto input = make_stopped_input(objects);
+  const bool modified = plugin_->modify_trajectory(trajectory, input);
+  ASSERT_TRUE(modified);
+  expect_stop_trajectory_at_ego(trajectory);
+
+  objects = make_predicted_objects(0.0, 3.0);
+  input = make_stopped_input(objects);
+  const bool modified_with_hysteresis = plugin_->modify_trajectory(trajectory, input);
+  ASSERT_TRUE(modified_with_hysteresis);
+  expect_stop_trajectory_at_ego(trajectory);
+}
+
+TEST_F(SurroundObstacleStopIntegrationTest, TrajectoryModifiedWhenNearbyPointcloudDetected)
+{
+  auto trajectory = create_straight_trajectory(10.0, 5.0);
+  const auto pointcloud = make_pointcloud_in_base_link(0.0, 1.5, 0.5);
+  const auto input = make_stopped_input(nullptr, pointcloud);
+
+  const bool modified = plugin_->modify_trajectory(trajectory, input);
+
+  ASSERT_TRUE(modified);
+  expect_stop_trajectory_at_ego(trajectory);
+}
+
+TEST_F(SurroundObstacleStopIntegrationTest, StopStatePersistsDuringHysteresisTime)
+{
+  params_.surround_obstacle_stop.hysteresis_time = 0.2;
+  plugin_->update_params(params_);
+  auto trajectory = create_straight_trajectory(10.0, 5.0);
+  auto objects = make_predicted_objects(0.0, 2.5);
+  const auto nearby_input = make_stopped_input(objects);
+  ASSERT_TRUE(plugin_->modify_trajectory(trajectory, nearby_input));
+  expect_stop_trajectory_at_ego(trajectory);
+
+  trajectory = create_straight_trajectory(10.0, 5.0);
+  objects = make_predicted_objects(0.0, 10.0);
+  const auto far_input = make_stopped_input(objects);
+  const bool modified_within_hysteresis = plugin_->modify_trajectory(trajectory, far_input);
+
+  ASSERT_TRUE(modified_within_hysteresis);
+  expect_stop_trajectory_at_ego(trajectory);
+
+  std::this_thread::sleep_for(std::chrono::milliseconds(250));
+
+  trajectory = create_straight_trajectory(10.0, 5.0);
+  const bool modified_after_hysteresis = plugin_->modify_trajectory(trajectory, far_input);
+
+  EXPECT_FALSE(modified_after_hysteresis);
+}

--- a/planning/autoware_trajectory_modifier/tests/test_utils.cpp
+++ b/planning/autoware_trajectory_modifier/tests/test_utils.cpp
@@ -287,7 +287,7 @@ TEST_F(UtilsTest, ReplaceTrajectoryWithStopPointEmptyTrajectory)
   autoware::trajectory_modifier::utils::replace_trajectory_with_stop_point(
     trajectory, ego_pose, 0.1);
 
-  EXPECT_EQ(trajectory.size(), 2);
+  EXPECT_EQ(trajectory.size(), 3);
   EXPECT_DOUBLE_EQ(trajectory[0].pose.position.x, 5.0);
   EXPECT_DOUBLE_EQ(trajectory[0].pose.position.y, 10.0);
   EXPECT_DOUBLE_EQ(trajectory[0].longitudinal_velocity_mps, 0.0);
@@ -296,8 +296,8 @@ TEST_F(UtilsTest, ReplaceTrajectoryWithStopPointEmptyTrajectory)
   EXPECT_DOUBLE_EQ(trajectory[0].heading_rate_rps, 0.0);
   EXPECT_DOUBLE_EQ(trajectory[0].front_wheel_angle_rad, 0.0);
   EXPECT_DOUBLE_EQ(trajectory[0].rear_wheel_angle_rad, 0.0);
-  EXPECT_DOUBLE_EQ(trajectory[1].pose.position.x, 5.0);
-  EXPECT_DOUBLE_EQ(trajectory[1].pose.position.y, 10.0);
+  EXPECT_NEAR(trajectory[1].pose.position.x, 5.0, 1e-2);
+  EXPECT_NEAR(trajectory[1].pose.position.y, 10.0, 1e-2);
   EXPECT_DOUBLE_EQ(trajectory[1].longitudinal_velocity_mps, 0.0);
 }
 
@@ -313,12 +313,12 @@ TEST_F(UtilsTest, ReplaceTrajectoryWithStopPointNonEmptyTrajectory)
   autoware::trajectory_modifier::utils::replace_trajectory_with_stop_point(
     trajectory, ego_pose, 0.1);
 
-  EXPECT_EQ(trajectory.size(), 2);
+  EXPECT_EQ(trajectory.size(), 3);
   EXPECT_DOUBLE_EQ(trajectory[0].pose.position.x, 7.0);
   EXPECT_DOUBLE_EQ(trajectory[0].pose.position.y, 8.0);
   EXPECT_DOUBLE_EQ(trajectory[0].longitudinal_velocity_mps, 0.0);
-  EXPECT_DOUBLE_EQ(trajectory[1].pose.position.x, 7.0);
-  EXPECT_DOUBLE_EQ(trajectory[1].pose.position.y, 8.0);
+  EXPECT_NEAR(trajectory[1].pose.position.x, 7.0, 1e-2);
+  EXPECT_NEAR(trajectory[1].pose.position.y, 8.0, 1e-2);
   EXPECT_DOUBLE_EQ(trajectory[1].longitudinal_velocity_mps, 0.0);
   EXPECT_DOUBLE_EQ(trajectory[0].lateral_velocity_mps, 0.0);
   EXPECT_DOUBLE_EQ(trajectory[0].acceleration_mps2, 0.0);
@@ -341,19 +341,19 @@ TEST_F(UtilsTest, ReplaceTrajectoryWithStopPointPoseOrientation)
   autoware::trajectory_modifier::utils::replace_trajectory_with_stop_point(
     trajectory, ego_pose, 0.1);
 
-  EXPECT_EQ(trajectory.size(), 2);
+  EXPECT_EQ(trajectory.size(), 3);
   EXPECT_DOUBLE_EQ(trajectory[0].pose.position.x, 2.0);
   EXPECT_DOUBLE_EQ(trajectory[0].pose.position.y, 3.0);
   EXPECT_DOUBLE_EQ(trajectory[0].pose.orientation.x, 0.1);
   EXPECT_DOUBLE_EQ(trajectory[0].pose.orientation.y, 0.2);
   EXPECT_DOUBLE_EQ(trajectory[0].pose.orientation.z, 0.3);
   EXPECT_DOUBLE_EQ(trajectory[0].pose.orientation.w, 0.9);
-  EXPECT_DOUBLE_EQ(trajectory[1].pose.position.x, 2.0);
-  EXPECT_DOUBLE_EQ(trajectory[1].pose.position.y, 3.0);
-  EXPECT_DOUBLE_EQ(trajectory[1].pose.orientation.x, 0.1);
-  EXPECT_DOUBLE_EQ(trajectory[1].pose.orientation.y, 0.2);
-  EXPECT_DOUBLE_EQ(trajectory[1].pose.orientation.z, 0.3);
-  EXPECT_DOUBLE_EQ(trajectory[1].pose.orientation.w, 0.9);
+  EXPECT_NEAR(trajectory[1].pose.position.x, 2.0, 5e-2);
+  EXPECT_NEAR(trajectory[1].pose.position.y, 3.0, 5e-2);
+  EXPECT_NEAR(trajectory[1].pose.orientation.x, 0.1, 5e-2);
+  EXPECT_NEAR(trajectory[1].pose.orientation.y, 0.2, 5e-2);
+  EXPECT_NEAR(trajectory[1].pose.orientation.z, 0.3, 5e-2);
+  EXPECT_NEAR(trajectory[1].pose.orientation.w, 0.9, 5e-2);
 }
 
 TEST_F(UtilsTest, ReplaceTrajectoryWithStopPointNegativeCoordinates)
@@ -366,9 +366,9 @@ TEST_F(UtilsTest, ReplaceTrajectoryWithStopPointNegativeCoordinates)
   autoware::trajectory_modifier::utils::replace_trajectory_with_stop_point(
     trajectory, ego_pose, 0.1);
 
-  EXPECT_EQ(trajectory.size(), 2);
+  EXPECT_EQ(trajectory.size(), 3);
   EXPECT_DOUBLE_EQ(trajectory[0].pose.position.x, -5.0);
   EXPECT_DOUBLE_EQ(trajectory[0].pose.position.y, -7.5);
-  EXPECT_DOUBLE_EQ(trajectory[1].pose.position.x, -5.0);
-  EXPECT_DOUBLE_EQ(trajectory[1].pose.position.y, -7.5);
+  EXPECT_NEAR(trajectory[1].pose.position.x, -5.0, 1e-2);
+  EXPECT_NEAR(trajectory[1].pose.position.y, -7.5, 1e-2);
 }

--- a/planning/autoware_trajectory_modifier/tests/test_utils.cpp
+++ b/planning/autoware_trajectory_modifier/tests/test_utils.cpp
@@ -284,7 +284,8 @@ TEST_F(UtilsTest, ReplaceTrajectoryWithStopPointEmptyTrajectory)
   TrajectoryPoints trajectory;
   auto ego_pose = create_pose(5.0, 10.0);
 
-  autoware::trajectory_modifier::utils::replace_trajectory_with_stop_point(trajectory, ego_pose);
+  autoware::trajectory_modifier::utils::replace_trajectory_with_stop_point(
+    trajectory, ego_pose, 0.1);
 
   EXPECT_EQ(trajectory.size(), 2);
   EXPECT_DOUBLE_EQ(trajectory[0].pose.position.x, 5.0);
@@ -309,7 +310,8 @@ TEST_F(UtilsTest, ReplaceTrajectoryWithStopPointNonEmptyTrajectory)
 
   auto ego_pose = create_pose(7.0, 8.0);
 
-  autoware::trajectory_modifier::utils::replace_trajectory_with_stop_point(trajectory, ego_pose);
+  autoware::trajectory_modifier::utils::replace_trajectory_with_stop_point(
+    trajectory, ego_pose, 0.1);
 
   EXPECT_EQ(trajectory.size(), 2);
   EXPECT_DOUBLE_EQ(trajectory[0].pose.position.x, 7.0);
@@ -336,7 +338,8 @@ TEST_F(UtilsTest, ReplaceTrajectoryWithStopPointPoseOrientation)
   ego_pose.orientation.z = 0.3;
   ego_pose.orientation.w = 0.9;
 
-  autoware::trajectory_modifier::utils::replace_trajectory_with_stop_point(trajectory, ego_pose);
+  autoware::trajectory_modifier::utils::replace_trajectory_with_stop_point(
+    trajectory, ego_pose, 0.1);
 
   EXPECT_EQ(trajectory.size(), 2);
   EXPECT_DOUBLE_EQ(trajectory[0].pose.position.x, 2.0);
@@ -360,7 +363,8 @@ TEST_F(UtilsTest, ReplaceTrajectoryWithStopPointNegativeCoordinates)
 
   auto ego_pose = create_pose(-5.0, -7.5);
 
-  autoware::trajectory_modifier::utils::replace_trajectory_with_stop_point(trajectory, ego_pose);
+  autoware::trajectory_modifier::utils::replace_trajectory_with_stop_point(
+    trajectory, ego_pose, 0.1);
 
   EXPECT_EQ(trajectory.size(), 2);
   EXPECT_DOUBLE_EQ(trajectory[0].pose.position.x, -5.0);


### PR DESCRIPTION
## Description
This PR adds a `surround_obstacle_stop` plugin to trajectory_modifier to prevent ego from starting to move when an obstacle is too close to it.

### Changes:
- extract core logic from `surround_obstacle_checker` to new common package `obstacle_proximit_checker`
- add new modifier plugin `surround_obstacle_stop` which uses common package `obstacle_proximity_checker`
- add integration tests for `surround_obstacle_stop`

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
- `colcon build --packages-above autoware_obstacle_proximity_checker --symlink-install --cmake-args -DCMAKE_EXPORT_COMPILE_COMMANDS=1 -DCMAKE_BUILD_TYPE=Release`
- PSIM

[surround_obstacle_stop.webm](https://github.com/user-attachments/assets/68c820f6-426f-4353-a642-536b42823417)

## Notes for reviewers

None.

## Interface changes

### ROS Parameter Changes

Added new param section `surround_obstacle_stop` to trajectory_modifer.param.yaml

| Parameter Name | Type     | Default Value | Description       |
|:---------------|:---------|:--------------|:------------------|
| `use_objects`   | `bool` | `true`         | Flag to enable/disable stopping for predicted objects |
| `use_pointcloud`   | `bool` | `true`         | Flag to enable/disable stopping for pcd points |
| `object_types`   | `string_array` | -        | List of object types to check |
| `front_distance_th.XX`   | `double` | -        | Distance threshold from ego front to check per object type [m] |
| `side_distance_th.XX`   | `double` | -        | Distance threshold from ego side to check per object type [m] |
| `back_distance_th.XX`   | `double` | -        | Distance threshold from ego back to check per object type [m] |
| `hysteresis_distance`   | `double` | 0.1        | Distance hysteresis threshold for clearing stop [m] |
| `hysteresis_time`   | `double` | 0.2        | Time hysteresis threshold for clearing stop [s] |
| `ego_stopped_vel_th`   | `double` | 0.1        | Velocity threshold below which ego vehicle is considered stopped [m/s] |

## Effects on system behavior

Ego does not start moving when there's a nearby obstacle
