### PR TITLE
chore(diffusion_planner): add vehicle_info log

### DIFF
--- a/planning/autoware_diffusion_planner/src/diffusion_planner_node.cpp
+++ b/planning/autoware_diffusion_planner/src/diffusion_planner_node.cpp
@@ -99,6 +99,14 @@ DiffusionPlanner::DiffusionPlanner(const rclcpp::NodeOptions & options)
 
   set_up_params();
   vehicle_info_ = autoware::vehicle_info_utils::VehicleInfoUtils(*this).getVehicleInfo();
+  RCLCPP_INFO_STREAM(
+    get_logger(),
+    "vehicle_info: wheel_base_m=" << vehicle_info_.wheel_base_m
+                                  << ", front_overhang_m=" << vehicle_info_.front_overhang_m
+                                  << ", rear_overhang_m=" << vehicle_info_.rear_overhang_m
+                                  << ", left_overhang_m=" << vehicle_info_.left_overhang_m
+                                  << ", right_overhang_m=" << vehicle_info_.right_overhang_m
+                                  << ", wheel_tread_m=" << vehicle_info_.wheel_tread_m);
 
   // Create core instance
   core_ = std::make_unique<DiffusionPlannerCore>(params_, vehicle_info_);


### PR DESCRIPTION
## Description

I added `RCLCPP_INFO_STREAM` to `vehicle_info` so that the parameters actually being used can be viewed in the logs later.

## How was this PR tested?

- [x] planning simulator

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.
