### PR TITLE
feat(autoware_universe_designs): add node designs for sensing cuda_pointcloud_preprocessor packages

### DIFF
--- a/common/autoware_universe_designs/design/sensing/autoware_cuda_pointcloud_preprocessor/CudaPointCloudConcatenateDataSynchronizer.node.yaml
+++ b/common/autoware_universe_designs/design/sensing/autoware_cuda_pointcloud_preprocessor/CudaPointCloudConcatenateDataSynchronizer.node.yaml
@@ -1,0 +1,53 @@
+autoware_system_design_format: 0.3.0
+
+# node information
+name: CudaPointCloudConcatenateDataSynchronizer.node
+
+package:
+  name: autoware_cuda_pointcloud_preprocessor
+  provider: autoware
+
+launch:
+  plugin: autoware::cuda_pointcloud_preprocessor::CudaPointCloudConcatenateDataSynchronizerComponent
+  executable: cuda_concatenate_and_time_sync_node
+  node_output: screen
+
+# interfaces
+# NOTE: input clouds are built dynamically from the input_topics parameter
+# (input1/input2 representative). Cloud I/O uses cuda_blackboard transport
+# (CudaPointCloud2); represented as sensor_msgs/msg/PointCloud2 (negotiated
+# ROS-graph type). Mirrors the merged ConcatenateAndTimeSync design.
+subscribers:
+  - name: twist
+    message_type: geometry_msgs/msg/TwistWithCovarianceStamped
+  - name: odometry
+    message_type: nav_msgs/msg/Odometry
+  - name: input1
+    message_type: sensor_msgs/msg/PointCloud2
+  - name: input2
+    message_type: sensor_msgs/msg/PointCloud2
+
+publishers:
+  - name: output
+    message_type: sensor_msgs/msg/PointCloud2
+    remap_target: output
+  - name: output_info
+    message_type: autoware_sensing_msgs/msg/ConcatenatedPointCloudInfo
+    remap_target: output_info
+
+# parameters
+param_files: []
+
+param_values:
+  - name: input_topics
+    type: array
+    default: "[${input input1}, ${input input2}]"
+
+# processes
+processes:
+  - name: concatenate
+    trigger_conditions:
+      - on_input: input1
+      - on_input: input2
+    outcomes:
+      - to_output: output

--- a/common/autoware_universe_designs/design/sensing/autoware_cuda_pointcloud_preprocessor/CudaPointcloudPreprocessor.node.yaml
+++ b/common/autoware_universe_designs/design/sensing/autoware_cuda_pointcloud_preprocessor/CudaPointcloudPreprocessor.node.yaml
@@ -1,0 +1,51 @@
+autoware_system_design_format: 0.3.0
+
+# node information
+name: CudaPointcloudPreprocessor.node
+
+package:
+  name: autoware_cuda_pointcloud_preprocessor
+  provider: autoware
+
+launch:
+  plugin: autoware::cuda_pointcloud_preprocessor::CudaPointcloudPreprocessorNode
+  executable: cuda_pointcloud_preprocessor_node
+  node_output: screen
+
+# interfaces
+# NOTE: pointcloud output uses cuda_blackboard transport (CudaPointCloud2);
+# represented as sensor_msgs/msg/PointCloud2 (the negotiated ROS-graph type).
+subscribers:
+  - name: pointcloud
+    message_type: sensor_msgs/msg/PointCloud2
+    remap_target: ~/input/pointcloud
+  - name: twist
+    message_type: geometry_msgs/msg/TwistWithCovarianceStamped
+    remap_target: ~/input/twist
+  - name: imu
+    message_type: sensor_msgs/msg/Imu
+    remap_target: ~/input/imu
+
+publishers:
+  - name: pointcloud
+    message_type: sensor_msgs/msg/PointCloud2
+    remap_target: ~/output/pointcloud
+
+# parameters
+param_files:
+  - name: param_file
+    default: config/cuda_pointcloud_preprocessor.param.yaml
+
+param_values: []
+
+# processes
+processes:
+  - name: preprocess
+    trigger_conditions:
+      - and:
+          - on_input: pointcloud
+          - or:
+              - on_input: twist
+              - on_input: imu
+    outcomes:
+      - to_output: pointcloud

--- a/common/autoware_universe_designs/design/sensing/autoware_cuda_pointcloud_preprocessor/CudaPolarVoxelNoiseFilter.node.yaml
+++ b/common/autoware_universe_designs/design/sensing/autoware_cuda_pointcloud_preprocessor/CudaPolarVoxelNoiseFilter.node.yaml
@@ -1,0 +1,39 @@
+autoware_system_design_format: 0.3.0
+
+# node information
+name: CudaPolarVoxelNoiseFilter.node
+
+package:
+  name: autoware_cuda_pointcloud_preprocessor
+  provider: autoware
+
+launch:
+  plugin: autoware::cuda_pointcloud_preprocessor::CudaPolarVoxelNoiseFilterNode
+  executable: cuda_polar_voxel_noise_filter_node
+  node_output: screen
+
+# interfaces
+# NOTE: pointcloud I/O uses cuda_blackboard transport (CudaPointCloud2);
+# represented as sensor_msgs/msg/PointCloud2 (the negotiated ROS-graph type).
+subscribers:
+  - name: pointcloud
+    message_type: sensor_msgs/msg/PointCloud2
+    remap_target: ~/input/pointcloud
+
+publishers:
+  - name: pointcloud
+    message_type: sensor_msgs/msg/PointCloud2
+    remap_target: ~/output/pointcloud
+
+# parameters
+param_files: []
+
+param_values: []
+
+# processes
+processes:
+  - name: filter
+    trigger_conditions:
+      - on_input: pointcloud
+    outcomes:
+      - to_output: pointcloud

--- a/common/autoware_universe_designs/design/sensing/autoware_cuda_pointcloud_preprocessor/CudaPolarVoxelOutlierFilter.node.yaml
+++ b/common/autoware_universe_designs/design/sensing/autoware_cuda_pointcloud_preprocessor/CudaPolarVoxelOutlierFilter.node.yaml
@@ -1,0 +1,39 @@
+autoware_system_design_format: 0.3.0
+
+# node information
+name: CudaPolarVoxelOutlierFilter.node
+
+package:
+  name: autoware_cuda_pointcloud_preprocessor
+  provider: autoware
+
+launch:
+  plugin: autoware::cuda_pointcloud_preprocessor::CudaPolarVoxelOutlierFilterNode
+  executable: cuda_polar_voxel_outlier_filter_node
+  node_output: screen
+
+# interfaces
+# NOTE: pointcloud I/O uses cuda_blackboard transport (CudaPointCloud2);
+# represented as sensor_msgs/msg/PointCloud2 (the negotiated ROS-graph type).
+subscribers:
+  - name: pointcloud
+    message_type: sensor_msgs/msg/PointCloud2
+    remap_target: ~/input/pointcloud
+
+publishers:
+  - name: pointcloud
+    message_type: sensor_msgs/msg/PointCloud2
+    remap_target: ~/output/pointcloud
+
+# parameters
+param_files: []
+
+param_values: []
+
+# processes
+processes:
+  - name: filter
+    trigger_conditions:
+      - on_input: pointcloud
+    outcomes:
+      - to_output: pointcloud

--- a/common/autoware_universe_designs/design/sensing/autoware_cuda_pointcloud_preprocessor/CudaVoxelGridDownsampleFilter.node.yaml
+++ b/common/autoware_universe_designs/design/sensing/autoware_cuda_pointcloud_preprocessor/CudaVoxelGridDownsampleFilter.node.yaml
@@ -1,0 +1,41 @@
+autoware_system_design_format: 0.3.0
+
+# node information
+name: CudaVoxelGridDownsampleFilter.node
+
+package:
+  name: autoware_cuda_pointcloud_preprocessor
+  provider: autoware
+
+launch:
+  plugin: autoware::cuda_pointcloud_preprocessor::CudaVoxelGridDownsampleFilterNode
+  executable: cuda_voxel_grid_downsample_filter_node
+  node_output: screen
+
+# interfaces
+# NOTE: pointcloud I/O uses cuda_blackboard transport (CudaPointCloud2);
+# represented as sensor_msgs/msg/PointCloud2 (the negotiated ROS-graph type).
+subscribers:
+  - name: pointcloud
+    message_type: sensor_msgs/msg/PointCloud2
+    remap_target: ~/input/pointcloud
+
+publishers:
+  - name: pointcloud
+    message_type: sensor_msgs/msg/PointCloud2
+    remap_target: ~/output/pointcloud
+
+# parameters
+param_files:
+  - name: param_file
+    default: config/cuda_voxel_grid_downsample_filter.param.yaml
+
+param_values: []
+
+# processes
+processes:
+  - name: filter
+    trigger_conditions:
+      - on_input: pointcloud
+    outcomes:
+      - to_output: pointcloud


### PR DESCRIPTION
## Description
Adds the missing *.node.yaml design files (Autoware System Design Format 0.3.0) for the 5 CUDA nodes in autoware_cuda_pointcloud_preprocessor, under common/autoware_universe_designs/design/sensing/. Completes the sensing category alongside the pointcloud_preprocessor filter batch (#12884) and the radar/misc batch (#12891).

- CudaPointcloudPreprocessor
- CudaPolarVoxelNoiseFilter
- CudaPolarVoxelOutlierFilter
- CudaVoxelGridDownsampleFilter
- CudaPointCloudConcatenateDataSynchronizer

All interfaces were derived directly from each node's implementation and CMakeLists. These nodes use cuda_blackboard transport (cuda_blackboard::CudaPointCloud2); the cloud sockets are represented as sensor_msgs/msg/PointCloud2, the negotiated ROS-graph type. Debug publishers are omitted (consistent with the merged RingOutlierFilter / package convention). CudaPointcloudPreprocessor takes a plain PointCloud2 input plus twist and imu (mirroring DistortionCorrector); CudaPointCloudConcatenateDataSynchronizer's cloud inputs are built dynamically from the input_topics parameter, represented with input1/input2 following the merged ConcatenateAndTimeSync design, and publishes output + output_info (ConcatenatedPointCloudInfo).

## Related links
- https://github.com/autowarefoundation/autoware_system_designer
- https://github.com/autowarefoundation/autoware_universe/tree/main/common/autoware_universe_designs/design

## How was this PR tested?
pre-commit run lint-system-design-format passes on all 5 files.

These nodes are design/lint-verified only. They build behind a CUDA/TensorRT toolchain that isn't enabled in my workspace (4 of the 5 binaries aren't present), so unlike the previous sensing batches I did not run a designer launch test for them — that would require a CUDA-enabled build. Interfaces were derived from source (the cuda_blackboard publisher/subscriber declarations and topic strings) and follow the conventions of the already-merged CPU equivalents in this package family (CropBoxFilter / RingOutlierFilter / ConcatenateAndTimeSync). Same approach as CalibrationStatusClassifier in #12891.

## Notes for reviewers
- cuda_blackboard CudaPointCloud2 transport is documented as sensor_msgs/msg/PointCloud2 (the negotiated graph type) for interoperability and consistency with the CPU equivalents 
- CudaPointCloudConcatenateDataSynchronizer mirrors the merged ConcatenateAndTimeSync design (dynamic input_topics, twist/odometry, output + output_info).

## Interface changes
None.

## Effects on system behavior
None. Documentation-only change.