### PR TITLE
refactor(autoware_traffic_light_arbiter): clean up arbiter core and validator interface

### DIFF
--- a/perception/autoware_traffic_light_arbiter/include/autoware/traffic_light_arbiter/signal_match_validator.hpp
+++ b/perception/autoware_traffic_light_arbiter/include/autoware/traffic_light_arbiter/signal_match_validator.hpp
@@ -77,7 +77,8 @@ public:
    * @return A validated TrafficSignalArray.
    */
   TrafficSignalArray validate_signals(
-    const TrafficSignalArray & perception_signals, const TrafficSignalArray & external_signals);
+    const TrafficSignalArray & perception_signals,
+    const TrafficSignalArray & external_signals) const;
 
   /**
    * @brief Sets the pedestrian signal IDs to be considered during validation.
@@ -104,7 +105,7 @@ private:
    * @param signal_id The ID of the signal to check.
    * @return True if the signal is a pedestrian signal, false otherwise.
    */
-  bool is_pedestrian_traffic_light(const lanelet::Id & signal_id);
+  bool is_pedestrian_traffic_light(const lanelet::Id & signal_id) const;
 };
 
 }  // namespace autoware::traffic_light

--- a/perception/autoware_traffic_light_arbiter/include/autoware/traffic_light_arbiter/traffic_light_arbiter_core.hpp
+++ b/perception/autoware_traffic_light_arbiter/include/autoware/traffic_light_arbiter/traffic_light_arbiter_core.hpp
@@ -78,8 +78,12 @@ private:
   // from `reference_time` beyond `tolerance`.
   void sweep_expired_external_signals(const rclcpp::Time & reference_time, double tolerance);
 
+  // Signal matching is on iff the validator exists: it is created in the
+  // constructor exactly when matching is enabled and never replaced afterward,
+  // so the pointer is the single source of truth for the mode.
+  bool is_signal_matching_enabled() const { return signal_match_validator_ != nullptr; }
+
   SourcePriority source_priority_;
-  bool enable_signal_matching_;
   double external_delay_tolerance_;
   double external_time_tolerance_;
   double perception_time_tolerance_;

--- a/perception/autoware_traffic_light_arbiter/include/autoware/traffic_light_arbiter/traffic_light_arbiter_core.hpp
+++ b/perception/autoware_traffic_light_arbiter/include/autoware/traffic_light_arbiter/traffic_light_arbiter_core.hpp
@@ -91,7 +91,7 @@ private:
   std::unique_ptr<std::unordered_set<lanelet::Id>> map_regulatory_elements_set_;
   std::unique_ptr<SignalMatchValidator> signal_match_validator_;
 
-  TrafficSignalArray latest_perception_msg_;
+  TrafficSignalArray perception_traffic_light_;
   std::unordered_map<lanelet::Id, std::pair<rclcpp::Time, TrafficSignal>> external_traffic_lights_;
 };
 

--- a/perception/autoware_traffic_light_arbiter/src/signal_match_validator.cpp
+++ b/perception/autoware_traffic_light_arbiter/src/signal_match_validator.cpp
@@ -221,7 +221,7 @@ namespace autoware::traffic_light
 {
 
 autoware_perception_msgs::msg::TrafficLightGroupArray SignalMatchValidator::validate_signals(
-  const TrafficSignalArray & perception_signals, const TrafficSignalArray & external_signals)
+  const TrafficSignalArray & perception_signals, const TrafficSignalArray & external_signals) const
 {
   TrafficSignalArray validated_signals;
 
@@ -286,7 +286,7 @@ void SignalMatchValidator::set_pedestrian_traffic_light_ids(std::unordered_set<l
   pedestrian_traffic_light_ids_ = std::move(ids);
 }
 
-bool SignalMatchValidator::is_pedestrian_traffic_light(const lanelet::Id & signal_id)
+bool SignalMatchValidator::is_pedestrian_traffic_light(const lanelet::Id & signal_id) const
 {
   return pedestrian_traffic_light_ids_.find(signal_id) != pedestrian_traffic_light_ids_.end();
 }

--- a/perception/autoware_traffic_light_arbiter/src/traffic_light_arbiter_core.cpp
+++ b/perception/autoware_traffic_light_arbiter/src/traffic_light_arbiter_core.cpp
@@ -282,10 +282,6 @@ TrafficLightArbiterCore::ArbitrationResult TrafficLightArbiterCore::arbitrate() 
 
   const auto external = collect_external_snapshot(external_traffic_lights_);
 
-  // perception_stamp is also the effective stamp: select_effective_perception()
-  // carries it onto the empty stand-in, so it is valid for latest_input_time
-  // below regardless of whether perception was gated out this cycle.
-  const auto perception_stamp = rclcpp::Time(perception_traffic_light_.stamp);
   const auto effective_perception =
     select_effective_perception(perception_traffic_light_, external, perception_time_tolerance_);
 
@@ -332,9 +328,9 @@ TrafficLightArbiterCore::ArbitrationResult TrafficLightArbiterCore::arbitrate() 
     output_signals_msg.traffic_light_groups.emplace_back(signal_msg);
   }
 
-  // Latest input stamp across stored sources. The Node compares this against
-  // its trigger stamp to decide whether the published output is behind some
-  // input that has arrived but hasn't yet driven a publish cycle.
+  // Latest input stamp across stored sources, for the Node's behind-input check.
+  // perception_stamp stays valid even when perception was gated out (stand-in keeps it).
+  const auto perception_stamp = rclcpp::Time(effective_perception.stamp);
   result.latest_input_time = (external.has_any && external.max_stamp > perception_stamp)
                                ? external.max_stamp
                                : perception_stamp;

--- a/perception/autoware_traffic_light_arbiter/src/traffic_light_arbiter_core.cpp
+++ b/perception/autoware_traffic_light_arbiter/src/traffic_light_arbiter_core.cpp
@@ -224,7 +224,7 @@ void TrafficLightArbiterCore::sweep_expired_external_signals(
 
 void TrafficLightArbiterCore::ingest_perception(const TrafficSignalArray & msg)
 {
-  latest_perception_msg_ = msg;
+  perception_traffic_light_ = msg;
   sweep_expired_external_signals(rclcpp::Time(msg.stamp), external_time_tolerance_);
 }
 
@@ -262,15 +262,15 @@ TrafficLightArbiterCore::ArbitrationResult TrafficLightArbiterCore::arbitrate() 
 
   // Ignore perception for this cycle when it lags the freshest external by
   // more than perception_time_tolerance_. Done as a non-destructive view so
-  // ingest_perception() remains the sole writer of latest_perception_msg_.
-  const auto perception_stamp = rclcpp::Time(latest_perception_msg_.stamp);
+  // ingest_perception() remains the sole writer of perception_traffic_light_.
+  const auto perception_stamp = rclcpp::Time(perception_traffic_light_.stamp);
   const bool perception_is_stale =
     external.has_any &&
     (external.max_stamp - perception_stamp).seconds() > perception_time_tolerance_;
   TrafficSignalArray empty_perception;
-  empty_perception.stamp = latest_perception_msg_.stamp;
+  empty_perception.stamp = perception_traffic_light_.stamp;
   const auto & effective_perception =
-    perception_is_stale ? empty_perception : latest_perception_msg_;
+    perception_is_stale ? empty_perception : perception_traffic_light_;
 
   std::unordered_map<lanelet::Id, std::vector<PredictedTrafficLightState>> predictions_map;
   // add in order from perception msg

--- a/perception/autoware_traffic_light_arbiter/src/traffic_light_arbiter_core.cpp
+++ b/perception/autoware_traffic_light_arbiter/src/traffic_light_arbiter_core.cpp
@@ -69,6 +69,28 @@ ExternalSnapshot collect_external_snapshot(
   return snapshot;
 }
 
+// Applies the perception staleness gate. Returns the stored perception snapshot
+// to use this cycle, or an empty stand-in carrying the same stamp when
+// perception lags the freshest external by more than perception_time_tolerance.
+// Non-destructive: the stored perception is never modified, so
+// ingest_perception() stays its sole writer.
+TrafficLightGroupArray select_effective_perception(
+  const TrafficLightGroupArray & perception, const ExternalSnapshot & external,
+  double perception_time_tolerance)
+{
+  const auto perception_stamp = rclcpp::Time(perception.stamp);
+  const bool perception_is_stale =
+    external.has_any &&
+    (external.max_stamp - perception_stamp).seconds() > perception_time_tolerance;
+  if (!perception_is_stale) {
+    return perception;
+  }
+
+  TrafficLightGroupArray empty_perception;
+  empty_perception.stamp = perception.stamp;
+  return empty_perception;
+}
+
 // Appends each group's predictions into predictions_map keyed by
 // regulatory-element id. Predictions accumulate across sources in call order.
 void append_predictions(
@@ -260,17 +282,12 @@ TrafficLightArbiterCore::ArbitrationResult TrafficLightArbiterCore::arbitrate() 
 
   const auto external = collect_external_snapshot(external_traffic_lights_);
 
-  // Ignore perception for this cycle when it lags the freshest external by
-  // more than perception_time_tolerance_. Done as a non-destructive view so
-  // ingest_perception() remains the sole writer of perception_traffic_light_.
+  // perception_stamp is also the effective stamp: select_effective_perception()
+  // carries it onto the empty stand-in, so it is valid for latest_input_time
+  // below regardless of whether perception was gated out this cycle.
   const auto perception_stamp = rclcpp::Time(perception_traffic_light_.stamp);
-  const bool perception_is_stale =
-    external.has_any &&
-    (external.max_stamp - perception_stamp).seconds() > perception_time_tolerance_;
-  TrafficSignalArray empty_perception;
-  empty_perception.stamp = perception_traffic_light_.stamp;
-  const auto & effective_perception =
-    perception_is_stale ? empty_perception : perception_traffic_light_;
+  const auto effective_perception =
+    select_effective_perception(perception_traffic_light_, external, perception_time_tolerance_);
 
   std::unordered_map<lanelet::Id, std::vector<PredictedTrafficLightState>> predictions_map;
   // add in order from perception msg

--- a/perception/autoware_traffic_light_arbiter/src/traffic_light_arbiter_core.cpp
+++ b/perception/autoware_traffic_light_arbiter/src/traffic_light_arbiter_core.cpp
@@ -183,12 +183,11 @@ TrafficLightArbiterCore::TrafficLightArbiterCore(
   SourcePriority source_priority, bool enable_signal_matching, double external_delay_tolerance,
   double external_time_tolerance, double perception_time_tolerance)
 : source_priority_(source_priority),
-  enable_signal_matching_(enable_signal_matching),
   external_delay_tolerance_(external_delay_tolerance),
   external_time_tolerance_(external_time_tolerance),
   perception_time_tolerance_(perception_time_tolerance)
 {
-  if (enable_signal_matching_) {
+  if (enable_signal_matching) {
     signal_match_validator_ = std::make_unique<SignalMatchValidator>(source_priority_);
   }
 }
@@ -197,7 +196,7 @@ void TrafficLightArbiterCore::set_map(const lanelet::LaneletMapConstPtr & map)
 {
   map_regulatory_elements_set_ =
     std::make_unique<std::unordered_set<lanelet::Id>>(extract_traffic_light_ids(map));
-  if (enable_signal_matching_) {
+  if (is_signal_matching_enabled()) {
     signal_match_validator_->set_pedestrian_traffic_light_ids(
       extract_pedestrian_traffic_light_ids(map));
   }
@@ -291,7 +290,7 @@ TrafficLightArbiterCore::ArbitrationResult TrafficLightArbiterCore::arbitrate() 
   }
 
   const auto & map_regulatory_elements = *map_regulatory_elements_set_;
-  if (enable_signal_matching_) {
+  if (is_signal_matching_enabled()) {
     const auto validated_signals =
       signal_match_validator_->validate_signals(effective_perception, external.signals);
     route_signals(

--- a/perception/autoware_traffic_light_arbiter/test/test_traffic_arbiter_characteristic.cpp
+++ b/perception/autoware_traffic_light_arbiter/test/test_traffic_arbiter_characteristic.cpp
@@ -956,7 +956,7 @@ TEST_F(ArbiterCharacteristic, externalTimeToleranceCleanupOnPerception)
   EXPECT_EQ(observed_color(map_ids::vehicle_signal_a), TrafficLightElement::GREEN);
 }
 
-// on_external_msg compares its own stamp to latest_perception_msg_.stamp; if
+// on_external_msg compares its own stamp to perception_traffic_light_.stamp; if
 // the gap exceeds perception_time_tolerance it clears the stored perception
 // groups so the upcoming publish reflects only external.
 TEST_F(ArbiterCharacteristic, perceptionTimeToleranceClearsLatestPerception)


### PR DESCRIPTION
## Description

A series of small, behavior-preserving refactorings to `autoware_traffic_light_arbiter`, focused on clarifying `traffic_light_arbiter_core.cpp` and tightening the `SignalMatchValidator` interface. No functional changes.

Included changes (oldest to newest):

- Make `SignalMatchValidator` query methods `const`.
- Drop the redundant `enable_signal_matching_` member.
- Rename `latest_perception_msg_` to `perception_traffic_light_` for clarity.
- Extract a `select_effective_perception()` helper that applies the perception staleness gate non-destructively.
- Derive `perception_stamp` from `effective_perception.stamp` and move it next to its sole use.

## Related links

<!-- Link related issues / discussions here. -->

## How was this PR tested?

<!-- Describe how you verified the change (build, existing unit tests, etc.). -->

## Notes for reviewers

Pure refactoring; intended to be reviewed commit-by-commit.

## Effects on system behavior

None.
