### PR TITLE
fix(acados_mpt): fix crash with parallel builds

### DIFF
--- a/planning/autoware_trajectory_optimizer/src/acados_mpt/generators/path_tracking_mpc_temporal.py
+++ b/planning/autoware_trajectory_optimizer/src/acados_mpt/generators/path_tracking_mpc_temporal.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import fcntl
+
 from acados_template import AcadosModel
 from acados_template import AcadosOcp
 from acados_template import AcadosOcpSolver
@@ -110,7 +112,13 @@ class PathTrackingMPCTemporal:
         ocp.solver_options.tol = 1e-4
 
         if not build:
-            AcadosOcpSolver.generate(ocp, json_file="acados_ocp.json")
+            lock_path = "/tmp/acados_codegen_temporal.lock"
+            with open(lock_path, "w") as lock_file:
+                fcntl.flock(lock_file, fcntl.LOCK_EX)
+                try:
+                    AcadosOcpSolver.generate(ocp, json_file="acados_ocp.json")
+                finally:
+                    fcntl.flock(lock_file, fcntl.LOCK_UN)
             return constraint, model, None
 
         acados_solver = AcadosOcpSolver(


### PR DESCRIPTION
## Description

Fix random crash that could occur when building `autoware_trajectory_optimizer` because some file generation could happen in parallel (e.g., https://github.com/autowarefoundation/autoware_universe/actions/runs/28498749295/job/84471860102?pr=12853).

## Related links

**Parent Issue:**

- https://tier4.atlassian.net/browse/T4DEV-56385

## How was this PR tested?

Could not longer reproduce the issue locally.

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
