### PR TITLE
fix(ptv3): guard extract indices kernel voxel writes against max_num_voxels overflow

### DIFF
--- a/perception/autoware_ptv3/lib/preprocess/preprocess_kernel.cu
+++ b/perception/autoware_ptv3/lib/preprocess/preprocess_kernel.cu
@@ -242,11 +242,17 @@ template <typename scalar_t, typename mask_t>
 __global__ void extractIndicesKernel(
   const scalar_t * __restrict__ input_data, mask_t * __restrict__ masks,
   mask_t * __restrict__ indices1, mask_t * __restrict__ indices2,
-  scalar_t * __restrict__ output_data, int num_points)
+  scalar_t * __restrict__ output_data, int num_points, int max_num_voxels)
 {
   int idx = blockIdx.x * blockDim.x + threadIdx.x;
   if (idx < num_points && masks[idx] == 1) {
-    output_data[indices1[idx] - 1] = input_data[indices2[idx]];
+    // indices1 is a 1-based unique-voxel prefix-sum id. Scattered clouds can produce more unique
+    // voxels than max_num_voxels; drop the overflow here (mirrors the host-side clip in
+    // PTv3TRT::preProcess) instead of writing past the max_num_voxels-sized output buffer.
+    const auto out_index = static_cast<std::int64_t>(indices1[idx]) - 1;
+    if (out_index < max_num_voxels) {
+      output_data[out_index] = input_data[indices2[idx]];
+    }
   }
 }
 
@@ -746,7 +752,8 @@ std::size_t PreprocessCuda::generateFeatures(
     extractIndicesKernel<<<num_cropped_blocks, config_.threads_per_block_, 0, stream_>>>(
       reinterpret_cast<float4 *>(cropped_points_d_.get()), unique_mask64_d_.get(),
       unique_indices64_d_.get(), sorted_hash_indexes64_d_.get(),
-      reinterpret_cast<float4 *>(voxel_features), *num_cropped_points_);
+      reinterpret_cast<float4 *>(voxel_features), *num_cropped_points_,
+      static_cast<int>(config_.max_num_voxels_));
     if (inverse_map != nullptr) {
       scatterInverseMapKernel<<<num_cropped_blocks, config_.threads_per_block_, 0, stream_>>>(
         unique_indices64_d_.get(), sorted_hash_indexes64_d_.get(), inverse_map,
@@ -758,25 +765,29 @@ std::size_t PreprocessCuda::generateFeatures(
         extractIndicesKernel<<<num_cropped_blocks, config_.threads_per_block_, 0, stream_>>>(
           reinterpret_cast<CloudPointTypeXYZIRCAEDT *>(cropped_input_points_d_.get()),
           unique_mask64_d_.get(), unique_indices64_d_.get(), sorted_hash_indexes64_d_.get(),
-          reinterpret_cast<CloudPointTypeXYZIRCAEDT *>(compact_points), *num_cropped_points_);
+          reinterpret_cast<CloudPointTypeXYZIRCAEDT *>(compact_points), *num_cropped_points_,
+          static_cast<int>(config_.max_num_voxels_));
         break;
       case CloudFormat::XYZIRADRT:
         extractIndicesKernel<<<num_cropped_blocks, config_.threads_per_block_, 0, stream_>>>(
           reinterpret_cast<CloudPointTypeXYZIRADRT *>(cropped_input_points_d_.get()),
           unique_mask64_d_.get(), unique_indices64_d_.get(), sorted_hash_indexes64_d_.get(),
-          reinterpret_cast<CloudPointTypeXYZIRADRT *>(compact_points), *num_cropped_points_);
+          reinterpret_cast<CloudPointTypeXYZIRADRT *>(compact_points), *num_cropped_points_,
+          static_cast<int>(config_.max_num_voxels_));
         break;
       case CloudFormat::XYZIRC:
         extractIndicesKernel<<<num_cropped_blocks, config_.threads_per_block_, 0, stream_>>>(
           reinterpret_cast<CloudPointTypeXYZIRC *>(cropped_input_points_d_.get()),
           unique_mask64_d_.get(), unique_indices64_d_.get(), sorted_hash_indexes64_d_.get(),
-          reinterpret_cast<CloudPointTypeXYZIRC *>(compact_points), *num_cropped_points_);
+          reinterpret_cast<CloudPointTypeXYZIRC *>(compact_points), *num_cropped_points_,
+          static_cast<int>(config_.max_num_voxels_));
         break;
       case CloudFormat::XYZI:
         extractIndicesKernel<<<num_cropped_blocks, config_.threads_per_block_, 0, stream_>>>(
           reinterpret_cast<CloudPointTypeXYZI *>(cropped_input_points_d_.get()),
           unique_mask64_d_.get(), unique_indices64_d_.get(), sorted_hash_indexes64_d_.get(),
-          reinterpret_cast<CloudPointTypeXYZI *>(compact_points), *num_cropped_points_);
+          reinterpret_cast<CloudPointTypeXYZI *>(compact_points), *num_cropped_points_,
+          static_cast<int>(config_.max_num_voxels_));
         break;
       default:
         throw std::runtime_error("Unsupported input point cloud format.");
@@ -824,7 +835,8 @@ std::size_t PreprocessCuda::generateFeatures(
     extractIndicesKernel<<<num_cropped_blocks, config_.threads_per_block_, 0, stream_>>>(
       reinterpret_cast<float4 *>(cropped_points_d_.get()), unique_mask32_d_.get(),
       unique_indices32_d_.get(), sorted_hash_indexes32_d_.get(),
-      reinterpret_cast<float4 *>(voxel_features), *num_cropped_points_);
+      reinterpret_cast<float4 *>(voxel_features), *num_cropped_points_,
+      static_cast<int>(config_.max_num_voxels_));
     if (inverse_map != nullptr) {
       scatterInverseMapKernel<<<num_cropped_blocks, config_.threads_per_block_, 0, stream_>>>(
         unique_indices32_d_.get(), sorted_hash_indexes32_d_.get(), inverse_map,
@@ -836,25 +848,29 @@ std::size_t PreprocessCuda::generateFeatures(
         extractIndicesKernel<<<num_cropped_blocks, config_.threads_per_block_, 0, stream_>>>(
           reinterpret_cast<CloudPointTypeXYZIRCAEDT *>(cropped_input_points_d_.get()),
           unique_mask32_d_.get(), unique_indices32_d_.get(), sorted_hash_indexes32_d_.get(),
-          reinterpret_cast<CloudPointTypeXYZIRCAEDT *>(compact_points), *num_cropped_points_);
+          reinterpret_cast<CloudPointTypeXYZIRCAEDT *>(compact_points), *num_cropped_points_,
+          static_cast<int>(config_.max_num_voxels_));
         break;
       case CloudFormat::XYZIRADRT:
         extractIndicesKernel<<<num_cropped_blocks, config_.threads_per_block_, 0, stream_>>>(
           reinterpret_cast<CloudPointTypeXYZIRADRT *>(cropped_input_points_d_.get()),
           unique_mask32_d_.get(), unique_indices32_d_.get(), sorted_hash_indexes32_d_.get(),
-          reinterpret_cast<CloudPointTypeXYZIRADRT *>(compact_points), *num_cropped_points_);
+          reinterpret_cast<CloudPointTypeXYZIRADRT *>(compact_points), *num_cropped_points_,
+          static_cast<int>(config_.max_num_voxels_));
         break;
       case CloudFormat::XYZIRC:
         extractIndicesKernel<<<num_cropped_blocks, config_.threads_per_block_, 0, stream_>>>(
           reinterpret_cast<CloudPointTypeXYZIRC *>(cropped_input_points_d_.get()),
           unique_mask32_d_.get(), unique_indices32_d_.get(), sorted_hash_indexes32_d_.get(),
-          reinterpret_cast<CloudPointTypeXYZIRC *>(compact_points), *num_cropped_points_);
+          reinterpret_cast<CloudPointTypeXYZIRC *>(compact_points), *num_cropped_points_,
+          static_cast<int>(config_.max_num_voxels_));
         break;
       case CloudFormat::XYZI:
         extractIndicesKernel<<<num_cropped_blocks, config_.threads_per_block_, 0, stream_>>>(
           reinterpret_cast<CloudPointTypeXYZI *>(cropped_input_points_d_.get()),
           unique_mask32_d_.get(), unique_indices32_d_.get(), sorted_hash_indexes32_d_.get(),
-          reinterpret_cast<CloudPointTypeXYZI *>(compact_points), *num_cropped_points_);
+          reinterpret_cast<CloudPointTypeXYZI *>(compact_points), *num_cropped_points_,
+          static_cast<int>(config_.max_num_voxels_));
         break;
       default:
         throw std::runtime_error("Unsupported input point cloud format.");
@@ -864,10 +880,19 @@ std::size_t PreprocessCuda::generateFeatures(
     num_unique_points = static_cast<std::uint64_t>(*num_unique_points32_);
   }
 
+  // The extract kernels above dropped any voxels beyond max_num_voxels, so only the first
+  // max_num_voxels entries of voxel_features/voxel_coords/voxel_hashes are valid. Cap the count fed
+  // to the grid-coord kernel to that same limit; writing more would overrun those buffers (which are
+  // sized max_num_voxels) exactly as the unguarded extract did. The true count is still returned so
+  // the caller logs the "over the limit" warning and clips consistently.
+  const auto max_num_voxels_u = static_cast<std::uint64_t>(config_.max_num_voxels_);
+  const auto num_voxels_capped =
+    num_unique_points < max_num_voxels_u ? num_unique_points : max_num_voxels_u;
+
   computeGridCoordsAndSerializationKernel<<<
     num_cropped_blocks, config_.threads_per_block_, 0, stream_>>>(
     reinterpret_cast<float4 *>(voxel_features), reinterpret_cast<int3 *>(voxel_coords),
-    voxel_hashes, num_unique_points, config_.voxel_x_size_, config_.voxel_y_size_,
+    voxel_hashes, static_cast<int>(num_voxels_capped), config_.voxel_x_size_, config_.voxel_y_size_,
     config_.voxel_z_size_, coord_min_x, coord_min_y, coord_min_z, config_.serialization_depth_);
 
   return num_unique_points;

--- a/perception/autoware_ptv3/lib/preprocess/preprocess_kernel.cu
+++ b/perception/autoware_ptv3/lib/preprocess/preprocess_kernel.cu
@@ -882,9 +882,9 @@ std::size_t PreprocessCuda::generateFeatures(
 
   // The extract kernels above dropped any voxels beyond max_num_voxels, so only the first
   // max_num_voxels entries of voxel_features/voxel_coords/voxel_hashes are valid. Cap the count fed
-  // to the grid-coord kernel to that same limit; writing more would overrun those buffers (which are
-  // sized max_num_voxels) exactly as the unguarded extract did. The true count is still returned so
-  // the caller logs the "over the limit" warning and clips consistently.
+  // to the grid-coord kernel to that same limit; writing more would overrun those buffers (which
+  // are sized max_num_voxels) exactly as the unguarded extract did. The true count is still
+  // returned so the caller logs the "over the limit" warning and clips consistently.
   const auto max_num_voxels_u = static_cast<std::uint64_t>(config_.max_num_voxels_);
   const auto num_voxels_capped =
     num_unique_points < max_num_voxels_u ? num_unique_points : max_num_voxels_u;


### PR DESCRIPTION
## Description

Fixes a random `cudaErrorIllegalAddress` ("parallel_for: failed to synchronize") that surfaces intermittently in the perception CUDA pipeline. Because PTv3, BEVFusion and the pointcloud preprocessor share a single CUDA context inside `component_container_mt`, the async fault is sticky and gets attributed to a rotating set of nodes — which made this hard to localize.

`compute-sanitizer --tool memcheck` pinned it to an **unguarded out-of-bounds write in `autoware::ptv3::extractIndicesKernel`** (an invalid `__global__` write of 16 bytes / a `float4`), reached from `PreprocessCuda::generateFeatures`.

Root cause: `generateFeatures()` counts unique voxels via hash + sort + prefix-sum into `num_unique_points`, which can exceed `max_num_voxels_` — a **scattered** cloud makes nearly every point its own voxel. The device kernels then write buffers sized `max_num_voxels_` (`feat_d_`, `grid_coord_d_`, `serialized_code_d_`) indexed by the 1-based prefix-sum voxel id, **with no device-side bound check**. The host-side clip (`num_voxels_ = max_num_voxels_`) runs only *after* `generateFeatures` returns — too late; the OOB writes have already been enqueued. With `voxels_num: [.., .., 192000]`, any frame whose scattered cloud yields > 192000 unique voxels overruns the buffers.

This also explains the previously confusing empirical facts: scattered clouds trigger it, and *enlarging* the max voxel count makes it disappear (bigger buffers absorb more unique voxels). BEVFusion was a red herring — its spconv path guards every write with `< max_voxels`, so shrinking its max never reproduced the true bug.

### Fix

- Add a `max_num_voxels` parameter to `extractIndicesKernel` and guard the write: `if (out_index < max_num_voxels)`. Overflow voxels are dropped on-device, mirroring the existing host-side clip in `PTv3TRT::preProcess`. `out_index` is computed in `int64` to avoid intermediate overflow.
- Pass `config_.max_num_voxels_` at all `extractIndicesKernel` call sites (voxel_features + compact_points, across every cloud format, for both the 64-bit and 32-bit index paths).
- Cap the count fed to `computeGridCoordsAndSerializationKernel` to `min(num_unique_points, max_num_voxels_)`, since only the first `max_num_voxels_` entries are valid after the guarded extract.

`generateFeatures` still **returns the true `num_unique_points`**, so the caller's existing "exceeds maximum" WARN + clip behavior is preserved and consistent.

## Related links

**Parent Issue:**

- Link

## How was this PR tested?

- Reproduced the crash under `compute-sanitizer --tool memcheck` with `CUDA_LAUNCH_BLOCKING=1`, which reported the invalid `float4` write in `extractIndicesKernel` (host frame `PreprocessCuda::generateFeatures`).
- Rebuild `autoware_ptv3` and re-run the same scenario under `compute-sanitizer` to confirm a clean run (no illegal-access reports) — please verify on target hardware before merge.

## Notes for reviewers

Kernels intentionally left untouched:
- `extractIndicesKernel` crop overload (bounded by `num_cropped_points <= cloud_capacity`).
- `scatterInverseMapKernel` (index bounded; its stored value is guarded downstream in `postprocess_kernel.cu`).

## Interface changes

None. (`extractIndicesKernel` signature change is internal to the library.)

## Effects on system behavior

Eliminates the random `cudaErrorIllegalAddress` crash on scattered clouds. When unique voxels exceed `max_num_voxels_`, the overflow tail is now dropped deterministically on-device (same clip semantics as before) instead of corrupting the CUDA context.
