### PR TITLE
refactor(autoware_traffic_light_classifier): extract a Node-free ColorClassifierCore

### DIFF
--- a/perception/autoware_traffic_light_classifier/src/classifier/color_classifier.cpp
+++ b/perception/autoware_traffic_light_classifier/src/classifier/color_classifier.cpp
@@ -65,156 +65,174 @@ bool ColorClassifierCore::filter_hsv(
   return true;
 }
 
-ColorClassifierCore::Result ColorClassifierCore::get_traffic_signals(
+ColorClassifierCore::ClassifierResult ColorClassifierCore::get_traffic_signals(
   const std::vector<cv::Mat> & images) const
 {
-  return classify_impl(images, nullptr);
-}
-
-ColorClassifierCore::Result ColorClassifierCore::get_traffic_signals(
-  const std::vector<cv::Mat> & images, std::vector<cv::Mat> & debug_images) const
-{
-  return classify_impl(images, &debug_images);
-}
-
-ColorClassifierCore::Result ColorClassifierCore::classify_impl(
-  const std::vector<cv::Mat> & images, std::vector<cv::Mat> * debug_images) const
-{
-  Result result;
+  ClassifierResult result;
   result.success = true;
   result.signals.signals.resize(images.size());
-  for (size_t image_i = 0; image_i < images.size(); image_i++) {
-    const auto & input_image = images[image_i];
-    auto & traffic_signal = result.signals.signals[image_i];
-    cv::Mat green_image;
-    cv::Mat yellow_image;
-    cv::Mat red_image;
-    if (!filter_hsv(input_image, green_image, yellow_image, red_image)) {
+  for (size_t roi_i = 0; roi_i < images.size(); roi_i++) {
+    const PipelineResult pipeline = run_pipeline(images[roi_i]);
+    result.signals.signals[roi_i].elements.push_back(classify_stages(pipeline.stages));
+    if (!pipeline.filter_ok) {
       result.success = false;
-    }
-    // binarize
-    cv::Mat green_bin_image;
-    cv::Mat yellow_bin_image;
-    cv::Mat red_bin_image;
-    const int bin_threshold = 127;
-    cv::threshold(green_image, green_bin_image, bin_threshold, 255, cv::THRESH_BINARY);
-    cv::threshold(yellow_image, yellow_bin_image, bin_threshold, 255, cv::THRESH_BINARY);
-    cv::threshold(red_image, red_bin_image, bin_threshold, 255, cv::THRESH_BINARY);
-    // filter noise
-    cv::Mat green_filtered_bin_image;
-    cv::Mat yellow_filtered_bin_image;
-    cv::Mat red_filtered_bin_image;
-    cv::Mat element4 = (cv::Mat_<uchar>(3, 3) << 0, 1, 0, 1, 1, 1, 0, 1, 0);
-    cv::erode(green_bin_image, green_filtered_bin_image, element4, cv::Point(-1, -1), 1);
-    cv::erode(yellow_bin_image, yellow_filtered_bin_image, element4, cv::Point(-1, -1), 1);
-    cv::erode(red_bin_image, red_filtered_bin_image, element4, cv::Point(-1, -1), 1);
-    cv::dilate(green_filtered_bin_image, green_filtered_bin_image, cv::Mat(), cv::Point(-1, -1), 1);
-    cv::dilate(
-      yellow_filtered_bin_image, yellow_filtered_bin_image, cv::Mat(), cv::Point(-1, -1), 1);
-    cv::dilate(red_filtered_bin_image, red_filtered_bin_image, cv::Mat(), cv::Point(-1, -1), 1);
-
-    /* debug */
-    if (debug_images != nullptr) {
-      cv::Mat debug_raw_image;
-      cv::Mat debug_green_image;
-      cv::Mat debug_yellow_image;
-      cv::Mat debug_red_image;
-      cv::hconcat(input_image, input_image, debug_raw_image);
-      cv::hconcat(debug_raw_image, input_image, debug_raw_image);
-      cv::hconcat(green_image, green_bin_image, debug_green_image);
-      cv::hconcat(debug_green_image, green_filtered_bin_image, debug_green_image);
-      cv::hconcat(yellow_image, yellow_bin_image, debug_yellow_image);
-      cv::hconcat(debug_yellow_image, yellow_filtered_bin_image, debug_yellow_image);
-      cv::hconcat(red_image, red_bin_image, debug_red_image);
-      cv::hconcat(debug_red_image, red_filtered_bin_image, debug_red_image);
-
-      cv::Mat debug_image;
-      cv::vconcat(debug_green_image, debug_yellow_image, debug_image);
-      cv::vconcat(debug_image, debug_red_image, debug_image);
-      cv::cvtColor(debug_image, debug_image, cv::COLOR_GRAY2RGB);
-      cv::vconcat(debug_raw_image, debug_image, debug_image);
-      const int width = input_image.cols;
-      const int height = input_image.rows;
-      cv::line(
-        debug_image, cv::Point(0, 0), cv::Point(debug_image.cols, 0), cv::Scalar(255, 255, 255), 1,
-        CV_AA, 0);
-      cv::line(
-        debug_image, cv::Point(0, height), cv::Point(debug_image.cols, height),
-        cv::Scalar(255, 255, 255), 1, CV_AA, 0);
-      cv::line(
-        debug_image, cv::Point(0, height * 2), cv::Point(debug_image.cols, height * 2),
-        cv::Scalar(255, 255, 255), 1, CV_AA, 0);
-      cv::line(
-        debug_image, cv::Point(0, height * 3), cv::Point(debug_image.cols, height * 3),
-        cv::Scalar(255, 255, 255), 1, CV_AA, 0);
-
-      cv::line(
-        debug_image, cv::Point(0, 0), cv::Point(0, debug_image.rows), cv::Scalar(255, 255, 255), 1,
-        CV_AA, 0);
-      cv::line(
-        debug_image, cv::Point(width, 0), cv::Point(width, debug_image.rows),
-        cv::Scalar(255, 255, 255), 1, CV_AA, 0);
-      cv::line(
-        debug_image, cv::Point(width * 2, 0), cv::Point(width * 2, debug_image.rows),
-        cv::Scalar(255, 255, 255), 1, CV_AA, 0);
-      cv::line(
-        debug_image, cv::Point(width * 3, 0), cv::Point(width * 3, debug_image.rows),
-        cv::Scalar(255, 255, 255), 1, CV_AA, 0);
-
-      cv::putText(
-        debug_image, "green", cv::Point(0, height * 1.5), cv::FONT_HERSHEY_SIMPLEX, 1.0,
-        cv::Scalar(255, 255, 255), 1, CV_AA);
-      cv::putText(
-        debug_image, "yellow", cv::Point(0, height * 2.5), cv::FONT_HERSHEY_SIMPLEX, 1.0,
-        cv::Scalar(255, 255, 255), 1, CV_AA);
-      cv::putText(
-        debug_image, "red", cv::Point(0, height * 3.5), cv::FONT_HERSHEY_SIMPLEX, 1.0,
-        cv::Scalar(255, 255, 255), 1, CV_AA);
-      debug_images->push_back(debug_image);
-    }
-    /* --- */
-
-    const int green_pixel_num = cv::countNonZero(green_filtered_bin_image);
-    const int yellow_pixel_num = cv::countNonZero(yellow_filtered_bin_image);
-    const int red_pixel_num = cv::countNonZero(red_filtered_bin_image);
-    const double green_ratio =
-      static_cast<double>(green_pixel_num) /
-      static_cast<double>(green_filtered_bin_image.rows * green_filtered_bin_image.cols);
-    const double yellow_ratio =
-      static_cast<double>(yellow_pixel_num) /
-      static_cast<double>(yellow_filtered_bin_image.rows * yellow_filtered_bin_image.cols);
-    const double red_ratio =
-      static_cast<double>(red_pixel_num) /
-      static_cast<double>(red_filtered_bin_image.rows * red_filtered_bin_image.cols);
-
-    if (yellow_ratio < green_ratio && red_ratio < green_ratio) {
-      tier4_perception_msgs::msg::TrafficLightElement element;
-      element.color = tier4_perception_msgs::msg::TrafficLightElement::GREEN;
-      element.confidence = std::min(1.0, static_cast<double>(green_pixel_num) / (20.0 * 20.0));
-      traffic_signal.elements.push_back(element);
-    } else if (green_ratio < yellow_ratio && red_ratio < yellow_ratio) {
-      tier4_perception_msgs::msg::TrafficLightElement element;
-      element.color = tier4_perception_msgs::msg::TrafficLightElement::AMBER;
-      element.confidence = std::min(1.0, static_cast<double>(yellow_pixel_num) / (20.0 * 20.0));
-      traffic_signal.elements.push_back(element);
-    } else if (green_ratio < red_ratio && yellow_ratio < red_ratio) {
-      tier4_perception_msgs::msg::TrafficLightElement element;
-      element.color = ::tier4_perception_msgs::msg::TrafficLightElement::RED;
-      element.confidence = std::min(1.0, static_cast<double>(red_pixel_num) / (20.0 * 20.0));
-      traffic_signal.elements.push_back(element);
-    } else {
-      tier4_perception_msgs::msg::TrafficLightElement element;
-      element.color = ::tier4_perception_msgs::msg::TrafficLightElement::UNKNOWN;
-      element.confidence = 0.0;
-      traffic_signal.elements.push_back(element);
     }
   }
   return result;
 }
 
+ColorClassifierCore::PipelineResult ColorClassifierCore::run_pipeline(
+  const cv::Mat & roi_image) const
+{
+  PipelineResult result;
+  cv::Mat green_image;
+  cv::Mat yellow_image;
+  cv::Mat red_image;
+  result.filter_ok = filter_hsv(roi_image, green_image, yellow_image, red_image);
+  // binarize
+  cv::Mat green_bin_image;
+  cv::Mat yellow_bin_image;
+  cv::Mat red_bin_image;
+  const int bin_threshold = 127;
+  cv::threshold(green_image, green_bin_image, bin_threshold, 255, cv::THRESH_BINARY);
+  cv::threshold(yellow_image, yellow_bin_image, bin_threshold, 255, cv::THRESH_BINARY);
+  cv::threshold(red_image, red_bin_image, bin_threshold, 255, cv::THRESH_BINARY);
+  // filter noise
+  cv::Mat green_filtered_bin_image;
+  cv::Mat yellow_filtered_bin_image;
+  cv::Mat red_filtered_bin_image;
+  cv::Mat element4 = (cv::Mat_<uchar>(3, 3) << 0, 1, 0, 1, 1, 1, 0, 1, 0);
+  cv::erode(green_bin_image, green_filtered_bin_image, element4, cv::Point(-1, -1), 1);
+  cv::erode(yellow_bin_image, yellow_filtered_bin_image, element4, cv::Point(-1, -1), 1);
+  cv::erode(red_bin_image, red_filtered_bin_image, element4, cv::Point(-1, -1), 1);
+  cv::dilate(green_filtered_bin_image, green_filtered_bin_image, cv::Mat(), cv::Point(-1, -1), 1);
+  cv::dilate(yellow_filtered_bin_image, yellow_filtered_bin_image, cv::Mat(), cv::Point(-1, -1), 1);
+  cv::dilate(red_filtered_bin_image, red_filtered_bin_image, cv::Mat(), cv::Point(-1, -1), 1);
+
+  result.stages.green = {green_image, green_bin_image, green_filtered_bin_image};
+  result.stages.yellow = {yellow_image, yellow_bin_image, yellow_filtered_bin_image};
+  result.stages.red = {red_image, red_bin_image, red_filtered_bin_image};
+  return result;
+}
+
+tier4_perception_msgs::msg::TrafficLightElement ColorClassifierCore::classify_stages(
+  const PipelineStages & stages) const
+{
+  const cv::Mat & green_filtered_bin_image = stages.green.denoised;
+  const cv::Mat & yellow_filtered_bin_image = stages.yellow.denoised;
+  const cv::Mat & red_filtered_bin_image = stages.red.denoised;
+
+  const int green_pixel_num = cv::countNonZero(green_filtered_bin_image);
+  const int yellow_pixel_num = cv::countNonZero(yellow_filtered_bin_image);
+  const int red_pixel_num = cv::countNonZero(red_filtered_bin_image);
+  const double green_ratio =
+    static_cast<double>(green_pixel_num) /
+    static_cast<double>(green_filtered_bin_image.rows * green_filtered_bin_image.cols);
+  const double yellow_ratio =
+    static_cast<double>(yellow_pixel_num) /
+    static_cast<double>(yellow_filtered_bin_image.rows * yellow_filtered_bin_image.cols);
+  const double red_ratio =
+    static_cast<double>(red_pixel_num) /
+    static_cast<double>(red_filtered_bin_image.rows * red_filtered_bin_image.cols);
+
+  tier4_perception_msgs::msg::TrafficLightElement element;
+  if (yellow_ratio < green_ratio && red_ratio < green_ratio) {
+    element.color = tier4_perception_msgs::msg::TrafficLightElement::GREEN;
+    element.confidence = std::min(1.0, static_cast<double>(green_pixel_num) / (20.0 * 20.0));
+  } else if (green_ratio < yellow_ratio && red_ratio < yellow_ratio) {
+    element.color = tier4_perception_msgs::msg::TrafficLightElement::AMBER;
+    element.confidence = std::min(1.0, static_cast<double>(yellow_pixel_num) / (20.0 * 20.0));
+  } else if (green_ratio < red_ratio && yellow_ratio < red_ratio) {
+    element.color = ::tier4_perception_msgs::msg::TrafficLightElement::RED;
+    element.confidence = std::min(1.0, static_cast<double>(red_pixel_num) / (20.0 * 20.0));
+  } else {
+    element.color = ::tier4_perception_msgs::msg::TrafficLightElement::UNKNOWN;
+    element.confidence = 0.0;
+  }
+  return element;
+}
+
+cv::Mat ColorClassifierCore::make_debug_image(const cv::Mat & roi_image) const
+{
+  const PipelineStages stages = run_pipeline(roi_image).stages;
+
+  cv::Mat debug_raw_image;
+  cv::Mat debug_green_image;
+  cv::Mat debug_yellow_image;
+  cv::Mat debug_red_image;
+  cv::hconcat(roi_image, roi_image, debug_raw_image);
+  cv::hconcat(debug_raw_image, roi_image, debug_raw_image);
+  cv::hconcat(stages.green.filtered, stages.green.binarized, debug_green_image);
+  cv::hconcat(debug_green_image, stages.green.denoised, debug_green_image);
+  cv::hconcat(stages.yellow.filtered, stages.yellow.binarized, debug_yellow_image);
+  cv::hconcat(debug_yellow_image, stages.yellow.denoised, debug_yellow_image);
+  cv::hconcat(stages.red.filtered, stages.red.binarized, debug_red_image);
+  cv::hconcat(debug_red_image, stages.red.denoised, debug_red_image);
+
+  cv::Mat debug_image;
+  cv::vconcat(debug_green_image, debug_yellow_image, debug_image);
+  cv::vconcat(debug_image, debug_red_image, debug_image);
+  cv::cvtColor(debug_image, debug_image, cv::COLOR_GRAY2RGB);
+  cv::vconcat(debug_raw_image, debug_image, debug_image);
+  const int width = roi_image.cols;
+  const int height = roi_image.rows;
+  cv::line(
+    debug_image, cv::Point(0, 0), cv::Point(debug_image.cols, 0), cv::Scalar(255, 255, 255), 1,
+    CV_AA, 0);
+  cv::line(
+    debug_image, cv::Point(0, height), cv::Point(debug_image.cols, height),
+    cv::Scalar(255, 255, 255), 1, CV_AA, 0);
+  cv::line(
+    debug_image, cv::Point(0, height * 2), cv::Point(debug_image.cols, height * 2),
+    cv::Scalar(255, 255, 255), 1, CV_AA, 0);
+  cv::line(
+    debug_image, cv::Point(0, height * 3), cv::Point(debug_image.cols, height * 3),
+    cv::Scalar(255, 255, 255), 1, CV_AA, 0);
+
+  cv::line(
+    debug_image, cv::Point(0, 0), cv::Point(0, debug_image.rows), cv::Scalar(255, 255, 255), 1,
+    CV_AA, 0);
+  cv::line(
+    debug_image, cv::Point(width, 0), cv::Point(width, debug_image.rows), cv::Scalar(255, 255, 255),
+    1, CV_AA, 0);
+  cv::line(
+    debug_image, cv::Point(width * 2, 0), cv::Point(width * 2, debug_image.rows),
+    cv::Scalar(255, 255, 255), 1, CV_AA, 0);
+  cv::line(
+    debug_image, cv::Point(width * 3, 0), cv::Point(width * 3, debug_image.rows),
+    cv::Scalar(255, 255, 255), 1, CV_AA, 0);
+
+  cv::putText(
+    debug_image, "green", cv::Point(0, height * 1.5), cv::FONT_HERSHEY_SIMPLEX, 1.0,
+    cv::Scalar(255, 255, 255), 1, CV_AA);
+  cv::putText(
+    debug_image, "yellow", cv::Point(0, height * 2.5), cv::FONT_HERSHEY_SIMPLEX, 1.0,
+    cv::Scalar(255, 255, 255), 1, CV_AA);
+  cv::putText(
+    debug_image, "red", cv::Point(0, height * 3.5), cv::FONT_HERSHEY_SIMPLEX, 1.0,
+    cv::Scalar(255, 255, 255), 1, CV_AA);
+  return debug_image;
+}
+
 // ============================== ColorClassifier ==============================
 // ROS adapter: declares parameters, wires dynamic reconfigure and debug-image
 // publishing, and delegates classification to the Node-free core.
+
+namespace
+{
+// Set `value` from the parameter named `name` if present; return whether it was found.
+bool update_param(
+  const std::vector<rclcpp::Parameter> & parameters, const std::string & name, int & value)
+{
+  for (const auto & parameter : parameters) {
+    if (parameter.get_name() == name) {
+      value = parameter.as_int();
+      return true;
+    }
+  }
+  return false;
+}
+}  // namespace
 
 ColorClassifier::ColorClassifier(rclcpp::Node * node_ptr) : node_ptr_(node_ptr)
 {
@@ -257,17 +275,17 @@ bool ColorClassifier::getTrafficSignals(
     return false;
   }
 
-  ColorClassifierCore::Result result;
+  const ColorClassifierCore::ClassifierResult result = core_.get_traffic_signals(images);
+
+  // Publish one debug mosaic per ROI image only when a debug consumer is attached;
+  // make_debug_image re-runs the HSV pipeline, so it stays off the hot path.
   if (0 < image_pub_.getNumSubscribers()) {
-    std::vector<cv::Mat> debug_images;
-    result = core_.get_traffic_signals(images, debug_images);
-    for (const auto & debug_image : debug_images) {
+    for (const auto & image : images) {
       const auto debug_image_msg =
-        cv_bridge::CvImage(std_msgs::msg::Header(), "bgr8", debug_image).toImageMsg();
+        cv_bridge::CvImage(std_msgs::msg::Header(), "bgr8", core_.make_debug_image(image))
+          .toImageMsg();
       image_pub_.publish(debug_image_msg);
     }
-  } else {
-    result = core_.get_traffic_signals(images);
   }
 
   // Attach the core's per-image color elements to the caller's pre-populated
@@ -287,35 +305,24 @@ bool ColorClassifier::getTrafficSignals(
 rcl_interfaces::msg::SetParametersResult ColorClassifier::parametersCallback(
   const std::vector<rclcpp::Parameter> & parameters)
 {
-  auto update_param = [&](const std::string & name, int & v) {
-    auto it = std::find_if(
-      parameters.cbegin(), parameters.cend(),
-      [&name](const rclcpp::Parameter & parameter) { return parameter.get_name() == name; });
-    if (it != parameters.cend()) {
-      v = it->as_int();
-      return true;
-    }
-    return false;
-  };
-
-  update_param("green_min_h", hsv_config_.green_min_h);
-  update_param("green_min_s", hsv_config_.green_min_s);
-  update_param("green_min_v", hsv_config_.green_min_v);
-  update_param("green_max_h", hsv_config_.green_max_h);
-  update_param("green_max_s", hsv_config_.green_max_s);
-  update_param("green_max_v", hsv_config_.green_max_v);
-  update_param("yellow_min_h", hsv_config_.yellow_min_h);
-  update_param("yellow_min_s", hsv_config_.yellow_min_s);
-  update_param("yellow_min_v", hsv_config_.yellow_min_v);
-  update_param("yellow_max_h", hsv_config_.yellow_max_h);
-  update_param("yellow_max_s", hsv_config_.yellow_max_s);
-  update_param("yellow_max_v", hsv_config_.yellow_max_v);
-  update_param("red_min_h", hsv_config_.red_min_h);
-  update_param("red_min_s", hsv_config_.red_min_s);
-  update_param("red_min_v", hsv_config_.red_min_v);
-  update_param("red_max_h", hsv_config_.red_max_h);
-  update_param("red_max_s", hsv_config_.red_max_s);
-  update_param("red_max_v", hsv_config_.red_max_v);
+  update_param(parameters, "green_min_h", hsv_config_.green_min_h);
+  update_param(parameters, "green_min_s", hsv_config_.green_min_s);
+  update_param(parameters, "green_min_v", hsv_config_.green_min_v);
+  update_param(parameters, "green_max_h", hsv_config_.green_max_h);
+  update_param(parameters, "green_max_s", hsv_config_.green_max_s);
+  update_param(parameters, "green_max_v", hsv_config_.green_max_v);
+  update_param(parameters, "yellow_min_h", hsv_config_.yellow_min_h);
+  update_param(parameters, "yellow_min_s", hsv_config_.yellow_min_s);
+  update_param(parameters, "yellow_min_v", hsv_config_.yellow_min_v);
+  update_param(parameters, "yellow_max_h", hsv_config_.yellow_max_h);
+  update_param(parameters, "yellow_max_s", hsv_config_.yellow_max_s);
+  update_param(parameters, "yellow_max_v", hsv_config_.yellow_max_v);
+  update_param(parameters, "red_min_h", hsv_config_.red_min_h);
+  update_param(parameters, "red_min_s", hsv_config_.red_min_s);
+  update_param(parameters, "red_min_v", hsv_config_.red_min_v);
+  update_param(parameters, "red_max_h", hsv_config_.red_max_h);
+  update_param(parameters, "red_max_s", hsv_config_.red_max_s);
+  update_param(parameters, "red_max_v", hsv_config_.red_max_v);
 
   core_.set_config(hsv_config_);
 

--- a/perception/autoware_traffic_light_classifier/src/classifier/color_classifier.cpp
+++ b/perception/autoware_traffic_light_classifier/src/classifier/color_classifier.cpp
@@ -50,15 +50,15 @@ void ColorClassifierCore::update_thresholds()
 }
 
 bool ColorClassifierCore::filter_hsv(
-  const cv::Mat & input_image, cv::Mat & green_image, cv::Mat & yellow_image,
-  cv::Mat & red_image) const
+  const cv::Mat & roi_image, cv::Mat & green_filtered_image, cv::Mat & yellow_filtered_image,
+  cv::Mat & red_filtered_image) const
 {
   cv::Mat hsv_image;
-  cv::cvtColor(input_image, hsv_image, cv::COLOR_BGR2HSV);
+  cv::cvtColor(roi_image, hsv_image, cv::COLOR_BGR2HSV);
   try {
-    cv::inRange(hsv_image, min_hsv_green_, max_hsv_green_, green_image);
-    cv::inRange(hsv_image, min_hsv_yellow_, max_hsv_yellow_, yellow_image);
-    cv::inRange(hsv_image, min_hsv_red_, max_hsv_red_, red_image);
+    cv::inRange(hsv_image, min_hsv_green_, max_hsv_green_, green_filtered_image);
+    cv::inRange(hsv_image, min_hsv_yellow_, max_hsv_yellow_, yellow_filtered_image);
+    cv::inRange(hsv_image, min_hsv_red_, max_hsv_red_, red_filtered_image);
   } catch (const cv::Exception &) {
     return false;
   }
@@ -85,33 +85,35 @@ ColorClassifierCore::PipelineResult ColorClassifierCore::run_pipeline(
   const cv::Mat & roi_image) const
 {
   PipelineResult result;
-  cv::Mat green_image;
-  cv::Mat yellow_image;
-  cv::Mat red_image;
-  result.filter_ok = filter_hsv(roi_image, green_image, yellow_image, red_image);
+  cv::Mat green_filtered_image;
+  cv::Mat yellow_filtered_image;
+  cv::Mat red_filtered_image;
+  result.filter_ok =
+    filter_hsv(roi_image, green_filtered_image, yellow_filtered_image, red_filtered_image);
   // binarize
-  cv::Mat green_bin_image;
-  cv::Mat yellow_bin_image;
-  cv::Mat red_bin_image;
+  cv::Mat green_binarized_image;
+  cv::Mat yellow_binarized_image;
+  cv::Mat red_binarized_image;
   const int bin_threshold = 127;
-  cv::threshold(green_image, green_bin_image, bin_threshold, 255, cv::THRESH_BINARY);
-  cv::threshold(yellow_image, yellow_bin_image, bin_threshold, 255, cv::THRESH_BINARY);
-  cv::threshold(red_image, red_bin_image, bin_threshold, 255, cv::THRESH_BINARY);
+  cv::threshold(green_filtered_image, green_binarized_image, bin_threshold, 255, cv::THRESH_BINARY);
+  cv::threshold(
+    yellow_filtered_image, yellow_binarized_image, bin_threshold, 255, cv::THRESH_BINARY);
+  cv::threshold(red_filtered_image, red_binarized_image, bin_threshold, 255, cv::THRESH_BINARY);
   // denoise (erode + dilate)
   cv::Mat green_denoised_image;
   cv::Mat yellow_denoised_image;
   cv::Mat red_denoised_image;
   cv::Mat element4 = (cv::Mat_<uchar>(3, 3) << 0, 1, 0, 1, 1, 1, 0, 1, 0);
-  cv::erode(green_bin_image, green_denoised_image, element4, cv::Point(-1, -1), 1);
-  cv::erode(yellow_bin_image, yellow_denoised_image, element4, cv::Point(-1, -1), 1);
-  cv::erode(red_bin_image, red_denoised_image, element4, cv::Point(-1, -1), 1);
+  cv::erode(green_binarized_image, green_denoised_image, element4, cv::Point(-1, -1), 1);
+  cv::erode(yellow_binarized_image, yellow_denoised_image, element4, cv::Point(-1, -1), 1);
+  cv::erode(red_binarized_image, red_denoised_image, element4, cv::Point(-1, -1), 1);
   cv::dilate(green_denoised_image, green_denoised_image, cv::Mat(), cv::Point(-1, -1), 1);
   cv::dilate(yellow_denoised_image, yellow_denoised_image, cv::Mat(), cv::Point(-1, -1), 1);
   cv::dilate(red_denoised_image, red_denoised_image, cv::Mat(), cv::Point(-1, -1), 1);
 
-  result.stages.green = {green_image, green_bin_image, green_denoised_image};
-  result.stages.yellow = {yellow_image, yellow_bin_image, yellow_denoised_image};
-  result.stages.red = {red_image, red_bin_image, red_denoised_image};
+  result.stages.green = {green_filtered_image, green_binarized_image, green_denoised_image};
+  result.stages.yellow = {yellow_filtered_image, yellow_binarized_image, yellow_denoised_image};
+  result.stages.red = {red_filtered_image, red_binarized_image, red_denoised_image};
   return result;
 }
 

--- a/perception/autoware_traffic_light_classifier/src/classifier/color_classifier.cpp
+++ b/perception/autoware_traffic_light_classifier/src/classifier/color_classifier.cpp
@@ -65,21 +65,33 @@ bool ColorClassifierCore::filter_hsv(
   return true;
 }
 
-bool ColorClassifierCore::get_traffic_signals(
-  const std::vector<cv::Mat> & images,
-  tier4_perception_msgs::msg::TrafficLightArray & traffic_signals,
-  std::vector<cv::Mat> * debug_images) const
+ColorClassifierCore::Result ColorClassifierCore::get_traffic_signals(
+  const std::vector<cv::Mat> & images) const
 {
-  if (images.size() != traffic_signals.signals.size()) {
-    return false;
-  }
+  return classify_impl(images, nullptr);
+}
+
+ColorClassifierCore::Result ColorClassifierCore::get_traffic_signals(
+  const std::vector<cv::Mat> & images, std::vector<cv::Mat> & debug_images) const
+{
+  return classify_impl(images, &debug_images);
+}
+
+ColorClassifierCore::Result ColorClassifierCore::classify_impl(
+  const std::vector<cv::Mat> & images, std::vector<cv::Mat> * debug_images) const
+{
+  Result result;
+  result.success = true;
+  result.signals.signals.resize(images.size());
   for (size_t image_i = 0; image_i < images.size(); image_i++) {
     const auto & input_image = images[image_i];
-    auto & traffic_signal = traffic_signals.signals[image_i];
+    auto & traffic_signal = result.signals.signals[image_i];
     cv::Mat green_image;
     cv::Mat yellow_image;
     cv::Mat red_image;
-    filter_hsv(input_image, green_image, yellow_image, red_image);
+    if (!filter_hsv(input_image, green_image, yellow_image, red_image)) {
+      result.success = false;
+    }
     // binarize
     cv::Mat green_bin_image;
     cv::Mat yellow_bin_image;
@@ -197,7 +209,7 @@ bool ColorClassifierCore::get_traffic_signals(
       traffic_signal.elements.push_back(element);
     }
   }
-  return true;
+  return result;
 }
 
 // ============================== ColorClassifier ==============================
@@ -240,20 +252,36 @@ bool ColorClassifier::getTrafficSignals(
   const std::vector<cv::Mat> & images,
   tier4_perception_msgs::msg::TrafficLightArray & traffic_signals)
 {
-  std::vector<cv::Mat> debug_images;
-  const bool want_debug = 0 < image_pub_.getNumSubscribers();
-  const bool ok =
-    core_.get_traffic_signals(images, traffic_signals, want_debug ? &debug_images : nullptr);
-  if (!ok) {
+  if (images.size() != traffic_signals.signals.size()) {
     RCLCPP_WARN(node_ptr_->get_logger(), "image number should be equal to traffic signal number!");
     return false;
   }
-  for (const auto & debug_image : debug_images) {
-    const auto debug_image_msg =
-      cv_bridge::CvImage(std_msgs::msg::Header(), "bgr8", debug_image).toImageMsg();
-    image_pub_.publish(debug_image_msg);
+
+  ColorClassifierCore::Result result;
+  if (0 < image_pub_.getNumSubscribers()) {
+    std::vector<cv::Mat> debug_images;
+    result = core_.get_traffic_signals(images, debug_images);
+    for (const auto & debug_image : debug_images) {
+      const auto debug_image_msg =
+        cv_bridge::CvImage(std_msgs::msg::Header(), "bgr8", debug_image).toImageMsg();
+      image_pub_.publish(debug_image_msg);
+    }
+  } else {
+    result = core_.get_traffic_signals(images);
   }
-  return true;
+
+  // Attach the core's per-image color elements to the caller's pre-populated
+  // signals, preserving the traffic_light_id / traffic_light_type set upstream.
+  for (size_t i = 0; i < traffic_signals.signals.size(); i++) {
+    auto & elements = traffic_signals.signals[i].elements;
+    const auto & classified = result.signals.signals[i].elements;
+    elements.insert(elements.end(), classified.begin(), classified.end());
+  }
+
+  if (!result.success) {
+    RCLCPP_ERROR(node_ptr_->get_logger(), "failed to filter image by hsv value");
+  }
+  return result.success;
 }
 
 rcl_interfaces::msg::SetParametersResult ColorClassifier::parametersCallback(

--- a/perception/autoware_traffic_light_classifier/src/classifier/color_classifier.cpp
+++ b/perception/autoware_traffic_light_classifier/src/classifier/color_classifier.cpp
@@ -21,42 +21,56 @@
 
 namespace autoware::traffic_light
 {
-ColorClassifier::ColorClassifier(rclcpp::Node * node_ptr) : node_ptr_(node_ptr)
+// ============================ ColorClassifierCore ============================
+// Node-free HSV classification core.
+
+ColorClassifierCore::ColorClassifierCore(const HSVConfig & config)
 {
-  using std::placeholders::_1;
-  image_pub_ = image_transport::create_publisher(
-    node_ptr_, "~/debug/image", rclcpp::QoS{1}.get_rmw_qos_profile());
-
-  hsv_config_.green_min_h = node_ptr_->declare_parameter("green_min_h", 50);
-  hsv_config_.green_min_s = node_ptr_->declare_parameter("green_min_s", 100);
-  hsv_config_.green_min_v = node_ptr_->declare_parameter("green_min_v", 150);
-  hsv_config_.green_max_h = node_ptr_->declare_parameter("green_max_h", 120);
-  hsv_config_.green_max_s = node_ptr_->declare_parameter("green_max_s", 200);
-  hsv_config_.green_max_v = node_ptr_->declare_parameter("green_max_v", 255);
-  hsv_config_.yellow_min_h = node_ptr_->declare_parameter("yellow_min_h", 0);
-  hsv_config_.yellow_min_s = node_ptr_->declare_parameter("yellow_min_s", 80);
-  hsv_config_.yellow_min_v = node_ptr_->declare_parameter("yellow_min_v", 150);
-  hsv_config_.yellow_max_h = node_ptr_->declare_parameter("yellow_max_h", 50);
-  hsv_config_.yellow_max_s = node_ptr_->declare_parameter("yellow_max_s", 200);
-  hsv_config_.yellow_max_v = node_ptr_->declare_parameter("yellow_max_v", 255);
-  hsv_config_.red_min_h = node_ptr_->declare_parameter("red_min_h", 160);
-  hsv_config_.red_min_s = node_ptr_->declare_parameter("red_min_s", 100);
-  hsv_config_.red_min_v = node_ptr_->declare_parameter("red_min_v", 150);
-  hsv_config_.red_max_h = node_ptr_->declare_parameter("red_max_h", 180);
-  hsv_config_.red_max_s = node_ptr_->declare_parameter("red_max_s", 255);
-  hsv_config_.red_max_v = node_ptr_->declare_parameter("red_max_v", 255);
-
-  // set parameter callback
-  set_param_res_ = node_ptr_->add_on_set_parameters_callback(
-    std::bind(&ColorClassifier::parametersCallback, this, _1));
+  set_config(config);
 }
 
-bool ColorClassifier::getTrafficSignals(
+void ColorClassifierCore::set_config(const HSVConfig & config)
+{
+  hsv_config_ = config;
+  update_thresholds();
+}
+
+void ColorClassifierCore::update_thresholds()
+{
+  min_hsv_green_ =
+    cv::Scalar(hsv_config_.green_min_h, hsv_config_.green_min_s, hsv_config_.green_min_v);
+  max_hsv_green_ =
+    cv::Scalar(hsv_config_.green_max_h, hsv_config_.green_max_s, hsv_config_.green_max_v);
+  min_hsv_yellow_ =
+    cv::Scalar(hsv_config_.yellow_min_h, hsv_config_.yellow_min_s, hsv_config_.yellow_min_v);
+  max_hsv_yellow_ =
+    cv::Scalar(hsv_config_.yellow_max_h, hsv_config_.yellow_max_s, hsv_config_.yellow_max_v);
+  min_hsv_red_ = cv::Scalar(hsv_config_.red_min_h, hsv_config_.red_min_s, hsv_config_.red_min_v);
+  max_hsv_red_ = cv::Scalar(hsv_config_.red_max_h, hsv_config_.red_max_s, hsv_config_.red_max_v);
+}
+
+bool ColorClassifierCore::filter_hsv(
+  const cv::Mat & input_image, cv::Mat & green_image, cv::Mat & yellow_image,
+  cv::Mat & red_image) const
+{
+  cv::Mat hsv_image;
+  cv::cvtColor(input_image, hsv_image, cv::COLOR_BGR2HSV);
+  try {
+    cv::inRange(hsv_image, min_hsv_green_, max_hsv_green_, green_image);
+    cv::inRange(hsv_image, min_hsv_yellow_, max_hsv_yellow_, yellow_image);
+    cv::inRange(hsv_image, min_hsv_red_, max_hsv_red_, red_image);
+  } catch (cv::Exception & e) {
+    return false;
+  }
+  return true;
+}
+
+bool ColorClassifierCore::get_traffic_signals(
   const std::vector<cv::Mat> & images,
-  tier4_perception_msgs::msg::TrafficLightArray & traffic_signals)
+  tier4_perception_msgs::msg::TrafficLightArray & traffic_signals,
+  std::vector<cv::Mat> * debug_images) const
 {
   if (images.size() != traffic_signals.signals.size()) {
-    RCLCPP_WARN(node_ptr_->get_logger(), "image number should be equal to traffic signal number!");
     return false;
   }
   for (size_t image_i = 0; image_i < images.size(); image_i++) {
@@ -65,7 +79,7 @@ bool ColorClassifier::getTrafficSignals(
     cv::Mat green_image;
     cv::Mat yellow_image;
     cv::Mat red_image;
-    filterHSV(input_image, green_image, yellow_image, red_image);
+    filter_hsv(input_image, green_image, yellow_image, red_image);
     // binarize
     cv::Mat green_bin_image;
     cv::Mat yellow_bin_image;
@@ -88,8 +102,7 @@ bool ColorClassifier::getTrafficSignals(
     cv::dilate(red_filtered_bin_image, red_filtered_bin_image, cv::Mat(), cv::Point(-1, -1), 1);
 
     /* debug */
-#if 1
-    if (0 < image_pub_.getNumSubscribers()) {
+    if (debug_images != nullptr) {
       cv::Mat debug_raw_image;
       cv::Mat debug_green_image;
       cv::Mat debug_yellow_image;
@@ -145,11 +158,8 @@ bool ColorClassifier::getTrafficSignals(
       cv::putText(
         debug_image, "red", cv::Point(0, height * 3.5), cv::FONT_HERSHEY_SIMPLEX, 1.0,
         cv::Scalar(255, 255, 255), 1, CV_AA);
-      const auto debug_image_msg =
-        cv_bridge::CvImage(std_msgs::msg::Header(), "bgr8", debug_image).toImageMsg();
-      image_pub_.publish(debug_image_msg);
+      debug_images->push_back(debug_image);
     }
-#endif
     /* --- */
 
     const int green_pixel_num = cv::countNonZero(green_filtered_bin_image);
@@ -190,21 +200,62 @@ bool ColorClassifier::getTrafficSignals(
   return true;
 }
 
-bool ColorClassifier::filterHSV(
-  const cv::Mat & input_image, cv::Mat & green_image, cv::Mat & yellow_image, cv::Mat & red_image)
+// ============================== ColorClassifier ==============================
+// ROS adapter: declares parameters, wires dynamic reconfigure and debug-image
+// publishing, and delegates classification to the Node-free core.
+
+ColorClassifier::ColorClassifier(rclcpp::Node * node_ptr) : node_ptr_(node_ptr)
 {
-  cv::Mat hsv_image;
-  cv::cvtColor(input_image, hsv_image, cv::COLOR_BGR2HSV);
-  try {
-    cv::inRange(hsv_image, min_hsv_green_, max_hsv_green_, green_image);
-    cv::inRange(hsv_image, min_hsv_yellow_, max_hsv_yellow_, yellow_image);
-    cv::inRange(hsv_image, min_hsv_red_, max_hsv_red_, red_image);
-  } catch (cv::Exception & e) {
-    RCLCPP_ERROR(node_ptr_->get_logger(), "failed to filter image by hsv value : %s", e.what());
+  using std::placeholders::_1;
+  image_pub_ = image_transport::create_publisher(
+    node_ptr_, "~/debug/image", rclcpp::QoS{1}.get_rmw_qos_profile());
+
+  hsv_config_.green_min_h = node_ptr_->declare_parameter("green_min_h", hsv_config_.green_min_h);
+  hsv_config_.green_min_s = node_ptr_->declare_parameter("green_min_s", hsv_config_.green_min_s);
+  hsv_config_.green_min_v = node_ptr_->declare_parameter("green_min_v", hsv_config_.green_min_v);
+  hsv_config_.green_max_h = node_ptr_->declare_parameter("green_max_h", hsv_config_.green_max_h);
+  hsv_config_.green_max_s = node_ptr_->declare_parameter("green_max_s", hsv_config_.green_max_s);
+  hsv_config_.green_max_v = node_ptr_->declare_parameter("green_max_v", hsv_config_.green_max_v);
+  hsv_config_.yellow_min_h = node_ptr_->declare_parameter("yellow_min_h", hsv_config_.yellow_min_h);
+  hsv_config_.yellow_min_s = node_ptr_->declare_parameter("yellow_min_s", hsv_config_.yellow_min_s);
+  hsv_config_.yellow_min_v = node_ptr_->declare_parameter("yellow_min_v", hsv_config_.yellow_min_v);
+  hsv_config_.yellow_max_h = node_ptr_->declare_parameter("yellow_max_h", hsv_config_.yellow_max_h);
+  hsv_config_.yellow_max_s = node_ptr_->declare_parameter("yellow_max_s", hsv_config_.yellow_max_s);
+  hsv_config_.yellow_max_v = node_ptr_->declare_parameter("yellow_max_v", hsv_config_.yellow_max_v);
+  hsv_config_.red_min_h = node_ptr_->declare_parameter("red_min_h", hsv_config_.red_min_h);
+  hsv_config_.red_min_s = node_ptr_->declare_parameter("red_min_s", hsv_config_.red_min_s);
+  hsv_config_.red_min_v = node_ptr_->declare_parameter("red_min_v", hsv_config_.red_min_v);
+  hsv_config_.red_max_h = node_ptr_->declare_parameter("red_max_h", hsv_config_.red_max_h);
+  hsv_config_.red_max_s = node_ptr_->declare_parameter("red_max_s", hsv_config_.red_max_s);
+  hsv_config_.red_max_v = node_ptr_->declare_parameter("red_max_v", hsv_config_.red_max_v);
+
+  core_.set_config(hsv_config_);
+
+  // set parameter callback
+  set_param_res_ = node_ptr_->add_on_set_parameters_callback(
+    std::bind(&ColorClassifier::parametersCallback, this, _1));
+}
+
+bool ColorClassifier::getTrafficSignals(
+  const std::vector<cv::Mat> & images,
+  tier4_perception_msgs::msg::TrafficLightArray & traffic_signals)
+{
+  std::vector<cv::Mat> debug_images;
+  const bool want_debug = 0 < image_pub_.getNumSubscribers();
+  const bool ok =
+    core_.get_traffic_signals(images, traffic_signals, want_debug ? &debug_images : nullptr);
+  if (!ok) {
+    RCLCPP_WARN(node_ptr_->get_logger(), "image number should be equal to traffic signal number!");
     return false;
+  }
+  for (const auto & debug_image : debug_images) {
+    const auto debug_image_msg =
+      cv_bridge::CvImage(std_msgs::msg::Header(), "bgr8", debug_image).toImageMsg();
+    image_pub_.publish(debug_image_msg);
   }
   return true;
 }
+
 rcl_interfaces::msg::SetParametersResult ColorClassifier::parametersCallback(
   const std::vector<rclcpp::Parameter> & parameters)
 {
@@ -238,16 +289,7 @@ rcl_interfaces::msg::SetParametersResult ColorClassifier::parametersCallback(
   update_param("red_max_s", hsv_config_.red_max_s);
   update_param("red_max_v", hsv_config_.red_max_v);
 
-  min_hsv_green_ =
-    cv::Scalar(hsv_config_.green_min_h, hsv_config_.green_min_s, hsv_config_.green_min_v);
-  max_hsv_green_ =
-    cv::Scalar(hsv_config_.green_max_h, hsv_config_.green_max_s, hsv_config_.green_max_v);
-  min_hsv_yellow_ =
-    cv::Scalar(hsv_config_.yellow_min_h, hsv_config_.yellow_min_s, hsv_config_.yellow_min_v);
-  max_hsv_yellow_ =
-    cv::Scalar(hsv_config_.yellow_max_h, hsv_config_.yellow_max_s, hsv_config_.yellow_max_v);
-  min_hsv_red_ = cv::Scalar(hsv_config_.red_min_h, hsv_config_.red_min_s, hsv_config_.red_min_v);
-  max_hsv_red_ = cv::Scalar(hsv_config_.red_max_h, hsv_config_.red_max_s, hsv_config_.red_max_v);
+  core_.set_config(hsv_config_);
 
   rcl_interfaces::msg::SetParametersResult result;
   result.successful = true;

--- a/perception/autoware_traffic_light_classifier/src/classifier/color_classifier.cpp
+++ b/perception/autoware_traffic_light_classifier/src/classifier/color_classifier.cpp
@@ -59,7 +59,7 @@ bool ColorClassifierCore::filter_hsv(
     cv::inRange(hsv_image, min_hsv_green_, max_hsv_green_, green_image);
     cv::inRange(hsv_image, min_hsv_yellow_, max_hsv_yellow_, yellow_image);
     cv::inRange(hsv_image, min_hsv_red_, max_hsv_red_, red_image);
-  } catch (cv::Exception & e) {
+  } catch (const cv::Exception &) {
     return false;
   }
   return true;
@@ -116,7 +116,7 @@ ColorClassifierCore::PipelineResult ColorClassifierCore::run_pipeline(
 }
 
 tier4_perception_msgs::msg::TrafficLightElement ColorClassifierCore::classify_stages(
-  const PipelineStages & stages) const
+  const PipelineStages & stages)
 {
   const cv::Mat & green_filtered_bin_image = stages.green.denoised;
   const cv::Mat & yellow_filtered_bin_image = stages.yellow.denoised;

--- a/perception/autoware_traffic_light_classifier/src/classifier/color_classifier.cpp
+++ b/perception/autoware_traffic_light_classifier/src/classifier/color_classifier.cpp
@@ -65,7 +65,7 @@ bool ColorClassifierCore::filter_hsv(
   return true;
 }
 
-ColorClassifierCore::ClassifierResult ColorClassifierCore::get_traffic_signals(
+ColorClassifierCore::ClassifierResult ColorClassifierCore::classify(
   const std::vector<cv::Mat> & images) const
 {
   ClassifierResult result;
@@ -73,7 +73,7 @@ ColorClassifierCore::ClassifierResult ColorClassifierCore::get_traffic_signals(
   result.signals.signals.resize(images.size());
   for (size_t roi_i = 0; roi_i < images.size(); roi_i++) {
     const PipelineResult pipeline = run_pipeline(images[roi_i]);
-    result.signals.signals[roi_i].elements.push_back(classify_stages(pipeline.stages));
+    result.signals.signals[roi_i].elements.push_back(classify_element(pipeline.stages));
     if (!pipeline.filter_ok) {
       result.success = false;
     }
@@ -97,43 +97,42 @@ ColorClassifierCore::PipelineResult ColorClassifierCore::run_pipeline(
   cv::threshold(green_image, green_bin_image, bin_threshold, 255, cv::THRESH_BINARY);
   cv::threshold(yellow_image, yellow_bin_image, bin_threshold, 255, cv::THRESH_BINARY);
   cv::threshold(red_image, red_bin_image, bin_threshold, 255, cv::THRESH_BINARY);
-  // filter noise
-  cv::Mat green_filtered_bin_image;
-  cv::Mat yellow_filtered_bin_image;
-  cv::Mat red_filtered_bin_image;
+  // denoise (erode + dilate)
+  cv::Mat green_denoised_image;
+  cv::Mat yellow_denoised_image;
+  cv::Mat red_denoised_image;
   cv::Mat element4 = (cv::Mat_<uchar>(3, 3) << 0, 1, 0, 1, 1, 1, 0, 1, 0);
-  cv::erode(green_bin_image, green_filtered_bin_image, element4, cv::Point(-1, -1), 1);
-  cv::erode(yellow_bin_image, yellow_filtered_bin_image, element4, cv::Point(-1, -1), 1);
-  cv::erode(red_bin_image, red_filtered_bin_image, element4, cv::Point(-1, -1), 1);
-  cv::dilate(green_filtered_bin_image, green_filtered_bin_image, cv::Mat(), cv::Point(-1, -1), 1);
-  cv::dilate(yellow_filtered_bin_image, yellow_filtered_bin_image, cv::Mat(), cv::Point(-1, -1), 1);
-  cv::dilate(red_filtered_bin_image, red_filtered_bin_image, cv::Mat(), cv::Point(-1, -1), 1);
+  cv::erode(green_bin_image, green_denoised_image, element4, cv::Point(-1, -1), 1);
+  cv::erode(yellow_bin_image, yellow_denoised_image, element4, cv::Point(-1, -1), 1);
+  cv::erode(red_bin_image, red_denoised_image, element4, cv::Point(-1, -1), 1);
+  cv::dilate(green_denoised_image, green_denoised_image, cv::Mat(), cv::Point(-1, -1), 1);
+  cv::dilate(yellow_denoised_image, yellow_denoised_image, cv::Mat(), cv::Point(-1, -1), 1);
+  cv::dilate(red_denoised_image, red_denoised_image, cv::Mat(), cv::Point(-1, -1), 1);
 
-  result.stages.green = {green_image, green_bin_image, green_filtered_bin_image};
-  result.stages.yellow = {yellow_image, yellow_bin_image, yellow_filtered_bin_image};
-  result.stages.red = {red_image, red_bin_image, red_filtered_bin_image};
+  result.stages.green = {green_image, green_bin_image, green_denoised_image};
+  result.stages.yellow = {yellow_image, yellow_bin_image, yellow_denoised_image};
+  result.stages.red = {red_image, red_bin_image, red_denoised_image};
   return result;
 }
 
-tier4_perception_msgs::msg::TrafficLightElement ColorClassifierCore::classify_stages(
+tier4_perception_msgs::msg::TrafficLightElement ColorClassifierCore::classify_element(
   const PipelineStages & stages)
 {
-  const cv::Mat & green_filtered_bin_image = stages.green.denoised;
-  const cv::Mat & yellow_filtered_bin_image = stages.yellow.denoised;
-  const cv::Mat & red_filtered_bin_image = stages.red.denoised;
+  const cv::Mat & green_denoised_image = stages.green.denoised;
+  const cv::Mat & yellow_denoised_image = stages.yellow.denoised;
+  const cv::Mat & red_denoised_image = stages.red.denoised;
 
-  const int green_pixel_num = cv::countNonZero(green_filtered_bin_image);
-  const int yellow_pixel_num = cv::countNonZero(yellow_filtered_bin_image);
-  const int red_pixel_num = cv::countNonZero(red_filtered_bin_image);
+  const int green_pixel_num = cv::countNonZero(green_denoised_image);
+  const int yellow_pixel_num = cv::countNonZero(yellow_denoised_image);
+  const int red_pixel_num = cv::countNonZero(red_denoised_image);
   const double green_ratio =
     static_cast<double>(green_pixel_num) /
-    static_cast<double>(green_filtered_bin_image.rows * green_filtered_bin_image.cols);
+    static_cast<double>(green_denoised_image.rows * green_denoised_image.cols);
   const double yellow_ratio =
     static_cast<double>(yellow_pixel_num) /
-    static_cast<double>(yellow_filtered_bin_image.rows * yellow_filtered_bin_image.cols);
-  const double red_ratio =
-    static_cast<double>(red_pixel_num) /
-    static_cast<double>(red_filtered_bin_image.rows * red_filtered_bin_image.cols);
+    static_cast<double>(yellow_denoised_image.rows * yellow_denoised_image.cols);
+  const double red_ratio = static_cast<double>(red_pixel_num) /
+                           static_cast<double>(red_denoised_image.rows * red_denoised_image.cols);
 
   tier4_perception_msgs::msg::TrafficLightElement element;
   if (yellow_ratio < green_ratio && red_ratio < green_ratio) {
@@ -275,7 +274,7 @@ bool ColorClassifier::getTrafficSignals(
     return false;
   }
 
-  const ColorClassifierCore::ClassifierResult result = core_.get_traffic_signals(images);
+  const ColorClassifierCore::ClassifierResult result = core_.classify(images);
 
   // Publish one debug mosaic per ROI image only when a debug consumer is attached;
   // make_debug_image re-runs the HSV pipeline, so it stays off the hot path.

--- a/perception/autoware_traffic_light_classifier/src/classifier/color_classifier.hpp
+++ b/perception/autoware_traffic_light_classifier/src/classifier/color_classifier.hpp
@@ -65,20 +65,30 @@ struct HSVConfig
 class ColorClassifierCore
 {
 public:
+  // Per-batch result: one signal (with a single color element) per input image,
+  // plus whether the HSV pipeline ran without error. traffic_light_id / type on
+  // the signals are left unset -- associating them is the caller's job.
+  struct Result
+  {
+    tier4_perception_msgs::msg::TrafficLightArray signals;
+    bool success = false;
+  };
+
   explicit ColorClassifierCore(const HSVConfig & config = HSVConfig{});
 
-  // Classify each image into a TrafficLightElement by HSV color band. Returns
-  // false only if the image and signal counts differ. When debug_images is
-  // non-null, one debug mosaic per input image is appended to it.
-  bool get_traffic_signals(
-    const std::vector<cv::Mat> & images,
-    tier4_perception_msgs::msg::TrafficLightArray & traffic_signals,
-    std::vector<cv::Mat> * debug_images = nullptr) const;
+  // Classify each image into a TrafficLightElement by HSV color band.
+  Result get_traffic_signals(const std::vector<cv::Mat> & images) const;
+  // Overload that also appends one debug mosaic per input image to debug_images.
+  Result get_traffic_signals(
+    const std::vector<cv::Mat> & images, std::vector<cv::Mat> & debug_images) const;
 
   // Replace the HSV thresholds and rebuild the color bands (dynamic reconfigure).
   void set_config(const HSVConfig & config);
 
 private:
+  // Shared classification pipeline; builds debug mosaics only when debug_images != nullptr.
+  Result classify_impl(
+    const std::vector<cv::Mat> & images, std::vector<cv::Mat> * debug_images) const;
   bool filter_hsv(
     const cv::Mat & input_image, cv::Mat & green_image, cv::Mat & yellow_image,
     cv::Mat & red_image) const;

--- a/perception/autoware_traffic_light_classifier/src/classifier/color_classifier.hpp
+++ b/perception/autoware_traffic_light_classifier/src/classifier/color_classifier.hpp
@@ -79,10 +79,10 @@ public:
 
   // Classify each ROI image (a cropped traffic-light region) into a
   // TrafficLightElement by HSV color band.
-  ClassifierResult get_traffic_signals(const std::vector<cv::Mat> & images) const;
+  ClassifierResult classify(const std::vector<cv::Mat> & images) const;
 
   // Render one debug mosaic for a single ROI image. Independent of
-  // get_traffic_signals: it re-runs the HSV pipeline internally, so the caller
+  // classify: it re-runs the HSV pipeline internally, so the caller
   // invokes it only when a debug consumer is attached (a cold path).
   cv::Mat make_debug_image(const cv::Mat & roi_image) const;
 
@@ -91,7 +91,7 @@ public:
 
 private:
   // The three pipeline stages of one color channel: filtered = cv::inRange output,
-  // binarized = post-threshold, denoised = post-erode/dilate. classify_stages reads
+  // binarized = post-threshold, denoised = post-erode/dilate. classify_element reads
   // the denoised mask; make_debug_image renders all three.
   struct ColorStageImages
   {
@@ -115,12 +115,12 @@ private:
   };
 
   // Run the HSV filter -> binarize -> denoise pipeline for one ROI image. Shared by
-  // classification (get_traffic_signals) and debug rendering (make_debug_image).
+  // classification (classify) and debug rendering (make_debug_image).
   PipelineResult run_pipeline(const cv::Mat & roi_image) const;
   // Pick one TrafficLightElement from the denoised per-color masks: the dominant
   // color band wins, with confidence scaled by its matching pixel count. Static: it
   // derives the element purely from the stage masks, using no member state.
-  static tier4_perception_msgs::msg::TrafficLightElement classify_stages(
+  static tier4_perception_msgs::msg::TrafficLightElement classify_element(
     const PipelineStages & stages);
   bool filter_hsv(
     const cv::Mat & input_image, cv::Mat & green_image, cv::Mat & yellow_image,

--- a/perception/autoware_traffic_light_classifier/src/classifier/color_classifier.hpp
+++ b/perception/autoware_traffic_light_classifier/src/classifier/color_classifier.hpp
@@ -23,6 +23,7 @@
 #include <rclcpp/rclcpp.hpp>
 
 #include <tier4_perception_msgs/msg/traffic_light_array.hpp>
+#include <tier4_perception_msgs/msg/traffic_light_element.hpp>
 
 #if __has_include(<cv_bridge/cv_bridge.hpp>)
 #include <cv_bridge/cv_bridge.hpp>
@@ -68,7 +69,7 @@ public:
   // Per-batch result: one signal (with a single color element) per input image,
   // plus whether the HSV pipeline ran without error. traffic_light_id / type on
   // the signals are left unset -- associating them is the caller's job.
-  struct Result
+  struct ClassifierResult
   {
     tier4_perception_msgs::msg::TrafficLightArray signals;
     bool success = false;
@@ -76,19 +77,50 @@ public:
 
   explicit ColorClassifierCore(const HSVConfig & config = HSVConfig{});
 
-  // Classify each image into a TrafficLightElement by HSV color band.
-  Result get_traffic_signals(const std::vector<cv::Mat> & images) const;
-  // Overload that also appends one debug mosaic per input image to debug_images.
-  Result get_traffic_signals(
-    const std::vector<cv::Mat> & images, std::vector<cv::Mat> & debug_images) const;
+  // Classify each ROI image (a cropped traffic-light region) into a
+  // TrafficLightElement by HSV color band.
+  ClassifierResult get_traffic_signals(const std::vector<cv::Mat> & images) const;
+
+  // Render one debug mosaic for a single ROI image. Independent of
+  // get_traffic_signals: it re-runs the HSV pipeline internally, so the caller
+  // invokes it only when a debug consumer is attached (a cold path).
+  cv::Mat make_debug_image(const cv::Mat & roi_image) const;
 
   // Replace the HSV thresholds and rebuild the color bands (dynamic reconfigure).
   void set_config(const HSVConfig & config);
 
 private:
-  // Shared classification pipeline; builds debug mosaics only when debug_images != nullptr.
-  Result classify_impl(
-    const std::vector<cv::Mat> & images, std::vector<cv::Mat> * debug_images) const;
+  // The three pipeline stages of one color channel: filtered = cv::inRange output,
+  // binarized = post-threshold, denoised = post-erode/dilate. classify_stages reads
+  // the denoised mask; make_debug_image renders all three.
+  struct ColorStageImages
+  {
+    cv::Mat filtered;
+    cv::Mat binarized;
+    cv::Mat denoised;
+  };
+  // Per-image intermediate images for all three color channels.
+  struct PipelineStages
+  {
+    ColorStageImages green;
+    ColorStageImages yellow;
+    ColorStageImages red;
+  };
+  // Output of run_pipeline: the per-color stage images plus whether the HSV filter
+  // ran without error.
+  struct PipelineResult
+  {
+    PipelineStages stages;
+    bool filter_ok = true;
+  };
+
+  // Run the HSV filter -> binarize -> denoise pipeline for one ROI image. Shared by
+  // classification (get_traffic_signals) and debug rendering (make_debug_image).
+  PipelineResult run_pipeline(const cv::Mat & roi_image) const;
+  // Pick one TrafficLightElement from the denoised per-color masks: the dominant
+  // color band wins, with confidence scaled by its matching pixel count.
+  tier4_perception_msgs::msg::TrafficLightElement classify_stages(
+    const PipelineStages & stages) const;
   bool filter_hsv(
     const cv::Mat & input_image, cv::Mat & green_image, cv::Mat & yellow_image,
     cv::Mat & red_image) const;

--- a/perception/autoware_traffic_light_classifier/src/classifier/color_classifier.hpp
+++ b/perception/autoware_traffic_light_classifier/src/classifier/color_classifier.hpp
@@ -123,8 +123,8 @@ private:
   static tier4_perception_msgs::msg::TrafficLightElement classify_element(
     const PipelineStages & stages);
   bool filter_hsv(
-    const cv::Mat & input_image, cv::Mat & green_image, cv::Mat & yellow_image,
-    cv::Mat & red_image) const;
+    const cv::Mat & roi_image, cv::Mat & green_filtered_image, cv::Mat & yellow_filtered_image,
+    cv::Mat & red_filtered_image) const;
   // Rebuild the cv::Scalar bands from hsv_config_.
   void update_thresholds();
 

--- a/perception/autoware_traffic_light_classifier/src/classifier/color_classifier.hpp
+++ b/perception/autoware_traffic_light_classifier/src/classifier/color_classifier.hpp
@@ -34,28 +34,69 @@
 
 namespace autoware::traffic_light
 {
+// HSV thresholds for the green / yellow / red bands. Defaults are the single
+// source of truth for the classifier's out-of-the-box behavior; the ROS adapter
+// exposes them as node parameters.
 struct HSVConfig
 {
-  int green_min_h;
-  int green_min_s;
-  int green_min_v;
-  int green_max_h;
-  int green_max_s;
-  int green_max_v;
-  int yellow_min_h;
-  int yellow_min_s;
-  int yellow_min_v;
-  int yellow_max_h;
-  int yellow_max_s;
-  int yellow_max_v;
-  int red_min_h;
-  int red_min_s;
-  int red_min_v;
-  int red_max_h;
-  int red_max_s;
-  int red_max_v;
+  int green_min_h = 50;
+  int green_min_s = 100;
+  int green_min_v = 150;
+  int green_max_h = 120;
+  int green_max_s = 200;
+  int green_max_v = 255;
+  int yellow_min_h = 0;
+  int yellow_min_s = 80;
+  int yellow_min_v = 150;
+  int yellow_max_h = 50;
+  int yellow_max_s = 200;
+  int yellow_max_v = 255;
+  int red_min_h = 160;
+  int red_min_s = 100;
+  int red_min_v = 150;
+  int red_max_h = 180;
+  int red_max_s = 255;
+  int red_max_v = 255;
 };
 
+// Node-free core of the HSV color classifier. Depends only on OpenCV and the
+// perception message types -- no rclcpp, image_transport, or logging -- so it can
+// be constructed and unit-tested without a running node.
+class ColorClassifierCore
+{
+public:
+  explicit ColorClassifierCore(const HSVConfig & config = HSVConfig{});
+
+  // Classify each image into a TrafficLightElement by HSV color band. Returns
+  // false only if the image and signal counts differ. When debug_images is
+  // non-null, one debug mosaic per input image is appended to it.
+  bool get_traffic_signals(
+    const std::vector<cv::Mat> & images,
+    tier4_perception_msgs::msg::TrafficLightArray & traffic_signals,
+    std::vector<cv::Mat> * debug_images = nullptr) const;
+
+  // Replace the HSV thresholds and rebuild the color bands (dynamic reconfigure).
+  void set_config(const HSVConfig & config);
+
+private:
+  bool filter_hsv(
+    const cv::Mat & input_image, cv::Mat & green_image, cv::Mat & yellow_image,
+    cv::Mat & red_image) const;
+  // Rebuild the cv::Scalar bands from hsv_config_.
+  void update_thresholds();
+
+  HSVConfig hsv_config_;
+  cv::Scalar min_hsv_green_;
+  cv::Scalar max_hsv_green_;
+  cv::Scalar min_hsv_yellow_;
+  cv::Scalar max_hsv_yellow_;
+  cv::Scalar min_hsv_red_;
+  cv::Scalar max_hsv_red_;
+};
+
+// Thin ROS adapter around ColorClassifierCore. Owns the node-facing concerns
+// (parameter declaration, dynamic reconfigure, debug-image publishing, logging)
+// and delegates classification to the core. Public API is unchanged.
 class ColorClassifier : public ClassifierInterface
 {
 public:
@@ -67,9 +108,6 @@ public:
     tier4_perception_msgs::msg::TrafficLightArray & traffic_signals) override;
 
 private:
-  bool filterHSV(
-    const cv::Mat & input_image, cv::Mat & green_image, cv::Mat & yellow_image,
-    cv::Mat & red_image);
   rcl_interfaces::msg::SetParametersResult parametersCallback(
     const std::vector<rclcpp::Parameter> & parameters);
 
@@ -85,12 +123,7 @@ private:
   rclcpp::Node * node_ptr_;
 
   HSVConfig hsv_config_;
-  cv::Scalar min_hsv_green_;
-  cv::Scalar max_hsv_green_;
-  cv::Scalar min_hsv_yellow_;
-  cv::Scalar max_hsv_yellow_;
-  cv::Scalar min_hsv_red_;
-  cv::Scalar max_hsv_red_;
+  ColorClassifierCore core_;
 };
 
 }  // namespace autoware::traffic_light

--- a/perception/autoware_traffic_light_classifier/src/classifier/color_classifier.hpp
+++ b/perception/autoware_traffic_light_classifier/src/classifier/color_classifier.hpp
@@ -118,9 +118,10 @@ private:
   // classification (get_traffic_signals) and debug rendering (make_debug_image).
   PipelineResult run_pipeline(const cv::Mat & roi_image) const;
   // Pick one TrafficLightElement from the denoised per-color masks: the dominant
-  // color band wins, with confidence scaled by its matching pixel count.
-  tier4_perception_msgs::msg::TrafficLightElement classify_stages(
-    const PipelineStages & stages) const;
+  // color band wins, with confidence scaled by its matching pixel count. Static: it
+  // derives the element purely from the stage masks, using no member state.
+  static tier4_perception_msgs::msg::TrafficLightElement classify_stages(
+    const PipelineStages & stages);
   bool filter_hsv(
     const cv::Mat & input_image, cv::Mat & green_image, cv::Mat & yellow_image,
     cv::Mat & red_image) const;


### PR DESCRIPTION
## Description

This PR extracts a **Node-free `ColorClassifierCore`** so the classification logic can be
constructed from a plain `HSVConfig` and called directly — no node, no parameters, no RMW.
The change is scoped entirely to `src/classifier/color_classifier.{hpp,cpp}`:

- **`ColorClassifierCore`** depends only on OpenCV + `tier4_perception_msgs` (no `rclcpp`,
  `image_transport`, `cv_bridge`, or logging). Return-based API
  `ClassifierResult classify(const std::vector<cv::Mat> &)`. The HSV bands are built
  in the constructor, fixing a latent issue where they were only built by the reconfigure
  callback.
- **Internal split**: `run_pipeline` (HSV filter → binarize → denoise, per ROI image) →
  `classify_element` (pure decision over the denoised masks) → `make_debug_image` (ROS-free
  mosaic renderer that re-runs `run_pipeline`, invoked only when a debug consumer is attached).
- **`ColorClassifier`** remains a thin ROS adapter with an **unchanged public API** (same
  `rclcpp::Node *` constructor and `getTrafficSignals` override). It keeps the ROS-facing
  concerns: parameter declaration, dynamic reconfigure, `~/debug/image` publishing, logging,
  the images/signals size guard, and element merging (preserving upstream traffic-light
  id/type). The reconfigure lambda was replaced with a named `update_param` helper.

`ClassifierInterface`, the CNN backends, and the node files are intentionally left untouched.

## Related links

**Parent Issue:**

- None

## How was this PR tested?

- `colcon build --packages-select autoware_traffic_light_classifier`
- `colcon test --packages-select autoware_traffic_light_classifier` → **49 tests, 0 failures**
- The existing `test_color_classifier` is kept **unchanged** and passes, confirming the
  refactor preserves behavior.

## Notes for reviewers

- Scope is intentionally minimal and self-contained to `src/classifier/color_classifier.{hpp,cpp}`
  plus a comment reference. The public API of `ColorClassifier` and the `ClassifierInterface`
  contract are unchanged, so all call sites compile without modification.
- A stacked follow-up PR rewrites `test_color_classifier` to construct `ColorClassifierCore`
  directly (ROS-free) and switches it from `ament_add_ros_isolated_gtest` to
  `ament_auto_add_gtest` — where the standalone testability this PR enables is realized.

## Interface changes

None. `ColorClassifier`'s public API and the `ClassifierInterface` abstract interface are
unchanged.

## Effects on system behavior

Behavior-preserving. One intentional refinement: an HSV-filter failure (previously swallowed)
now surfaces through the classifier's failure path — effectively unobservable in practice
since `cv::inRange` only throws on malformed images.
