### PR TITLE
feat(trajectory_ranker): apply `agnocast_wrapper::Node` to `autoware_trajectory_ranker`

### DIFF
--- a/planning/autoware_trajectory_ranker/include/autoware/trajectory_ranker/evaluation.hpp
+++ b/planning/autoware_trajectory_ranker/include/autoware/trajectory_ranker/evaluation.hpp
@@ -19,6 +19,7 @@
 #include "autoware/trajectory_ranker/interface/data_interface.hpp"
 #include "autoware/trajectory_ranker/interface/metrics_interface.hpp"
 
+#include <autoware/agnocast_wrapper/node.hpp>
 #include <autoware/route_handler/route_handler.hpp>
 #include <autoware_vehicle_info_utils/vehicle_info_utils.hpp>
 #include <pluginlib/class_loader.hpp>
@@ -44,7 +45,7 @@ public:
   explicit Evaluator(
     const std::shared_ptr<RouteHandler> & route_handler,
     const std::shared_ptr<VehicleInfo> & vehicle_info, const rclcpp::Logger & logger,
-    rclcpp::Node * node = nullptr)
+    autoware::agnocast_wrapper::Node * node = nullptr)
   : plugin_loader_(
       "autoware_trajectory_ranker", "autoware::trajectory_ranker::metrics::MetricInterface"),
     route_handler_{route_handler},
@@ -164,7 +165,7 @@ private:
 
   rclcpp::Logger logger_;
 
-  rclcpp::Node * node_ptr_{nullptr};
+  autoware::agnocast_wrapper::Node * node_ptr_{nullptr};
 };
 
 }  // namespace autoware::trajectory_ranker

--- a/planning/autoware_trajectory_ranker/include/autoware/trajectory_ranker/interface/metrics_interface.hpp
+++ b/planning/autoware_trajectory_ranker/include/autoware/trajectory_ranker/interface/metrics_interface.hpp
@@ -17,6 +17,7 @@
 
 #include "autoware/trajectory_ranker/interface/data_interface.hpp"
 
+#include <autoware/agnocast_wrapper/node.hpp>
 #include <autoware_vehicle_info_utils/vehicle_info_utils.hpp>
 #include <rclcpp/rclcpp.hpp>
 
@@ -69,7 +70,7 @@ public:
    */
   void init(
     const std::shared_ptr<VehicleInfo> & vehicle_info, const float resolution,
-    rclcpp::Node * node = nullptr)
+    autoware::agnocast_wrapper::Node * node = nullptr)
   {
     vehicle_info_ = vehicle_info;
     resolution_ = resolution;
@@ -117,7 +118,7 @@ protected:
    * @brief Gets node pointer (for parameter access)
    * @return Node pointer
    */
-  rclcpp::Node * node() const { return node_ptr_; }
+  autoware::agnocast_wrapper::Node * node() const { return node_ptr_; }
 
 private:
   std::shared_ptr<VehicleInfo> vehicle_info_;
@@ -128,7 +129,7 @@ private:
 
   float resolution_;
 
-  rclcpp::Node * node_ptr_{nullptr};
+  autoware::agnocast_wrapper::Node * node_ptr_{nullptr};
 };
 
 }  // namespace autoware::trajectory_ranker::metrics

--- a/planning/autoware_trajectory_ranker/include/autoware/trajectory_ranker/trajectory_ranker_node.hpp
+++ b/planning/autoware_trajectory_ranker/include/autoware/trajectory_ranker/trajectory_ranker_node.hpp
@@ -60,8 +60,10 @@ private:
 
   std::shared_ptr<EvaluatorParameters> parameters() const;
 
-  AUTOWARE_POLLING_SUBSCRIBER_PTR(PredictedObjects) sub_objects_;
-  AUTOWARE_POLLING_SUBSCRIBER_PTR(Odometry) sub_odometry_;
+  AUTOWARE_POLLING_SUBSCRIBER_PTR(PredictedObjects) sub_objects_{
+    create_polling_subscriber<PredictedObjects>("~/input/objects", 1)};
+  AUTOWARE_POLLING_SUBSCRIBER_PTR(Odometry) sub_odometry_{
+    create_polling_subscriber<Odometry>("~/input/odometry", 1)};
 
   AUTOWARE_SUBSCRIPTION_PTR(LaneletMapBin) sub_map_;
   AUTOWARE_SUBSCRIPTION_PTR(LaneletRoute) sub_route_;

--- a/planning/autoware_trajectory_ranker/include/autoware/trajectory_ranker/trajectory_ranker_node.hpp
+++ b/planning/autoware_trajectory_ranker/include/autoware/trajectory_ranker/trajectory_ranker_node.hpp
@@ -78,7 +78,7 @@ private:
   size_t max_history_size_{10};
 
   AUTOWARE_PUBLISHER_PTR(autoware_utils_debug::ProcessingTimeDetail)
-    debug_processing_time_detail_pub_;
+  debug_processing_time_detail_pub_;
   mutable std::shared_ptr<autoware_utils_debug::TimeKeeper> time_keeper_{nullptr};
 };
 

--- a/planning/autoware_trajectory_ranker/include/autoware/trajectory_ranker/trajectory_ranker_node.hpp
+++ b/planning/autoware_trajectory_ranker/include/autoware/trajectory_ranker/trajectory_ranker_node.hpp
@@ -60,10 +60,14 @@ private:
 
   std::shared_ptr<EvaluatorParameters> parameters() const;
 
-  AUTOWARE_POLLING_SUBSCRIBER_PTR(PredictedObjects) sub_objects_{
-    create_polling_subscriber<PredictedObjects>("~/input/objects", 1)};
-  AUTOWARE_POLLING_SUBSCRIBER_PTR(Odometry) sub_odometry_{
-    create_polling_subscriber<Odometry>("~/input/odometry", 1)};
+  AUTOWARE_POLLING_SUBSCRIBER_PTR(PredictedObjects)
+  sub_objects_ {
+    create_polling_subscriber<PredictedObjects>("~/input/objects", 1)
+  };
+  AUTOWARE_POLLING_SUBSCRIBER_PTR(Odometry)
+  sub_odometry_ {
+    create_polling_subscriber<Odometry>("~/input/odometry", 1)
+  };
 
   AUTOWARE_SUBSCRIPTION_PTR(LaneletMapBin) sub_map_;
   AUTOWARE_SUBSCRIPTION_PTR(LaneletRoute) sub_route_;

--- a/planning/autoware_trajectory_ranker/include/autoware/trajectory_ranker/trajectory_ranker_node.hpp
+++ b/planning/autoware_trajectory_ranker/include/autoware/trajectory_ranker/trajectory_ranker_node.hpp
@@ -18,10 +18,10 @@
 #include "autoware/trajectory_ranker/data_structs.hpp"
 #include "autoware/trajectory_ranker/evaluation.hpp"
 
+#include <autoware/agnocast_wrapper/node.hpp>
 #include <autoware/route_handler/route_handler.hpp>
 #include <autoware_trajectory_ranker/trajectory_ranker_parameters.hpp>
 #include <autoware_utils_debug/time_keeper.hpp>
-#include <autoware_utils_rclcpp/polling_subscriber.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include <autoware_internal_planning_msgs/msg/candidate_trajectories.hpp>
@@ -47,30 +47,27 @@ using nav_msgs::msg::Odometry;
 using route_handler::RouteHandler;
 using visualization_msgs::msg::MarkerArray;
 
-class TrajectoryRanker : public rclcpp::Node
+class TrajectoryRanker : public autoware::agnocast_wrapper::Node
 {
 public:
   explicit TrajectoryRanker(const rclcpp::NodeOptions & options);
 
 private:
-  void process(const CandidateTrajectories::ConstSharedPtr msg);
+  void process(const AUTOWARE_MESSAGE_CONST_SHARED_PTR(CandidateTrajectories) & msg);
 
   ScoredCandidateTrajectories::ConstSharedPtr score(
-    const CandidateTrajectories::ConstSharedPtr msg);
+    const AUTOWARE_MESSAGE_CONST_SHARED_PTR(CandidateTrajectories) & msg);
 
   std::shared_ptr<EvaluatorParameters> parameters() const;
 
-  autoware_utils_rclcpp::InterProcessPollingSubscriber<PredictedObjects> sub_objects_{
-    this, "~/input/objects"};
+  AUTOWARE_POLLING_SUBSCRIBER_PTR(PredictedObjects) sub_objects_;
+  AUTOWARE_POLLING_SUBSCRIBER_PTR(Odometry) sub_odometry_;
 
-  autoware_utils_rclcpp::InterProcessPollingSubscriber<Odometry> sub_odometry_{
-    this, "~/input/odometry"};
+  AUTOWARE_SUBSCRIPTION_PTR(LaneletMapBin) sub_map_;
+  AUTOWARE_SUBSCRIPTION_PTR(LaneletRoute) sub_route_;
+  AUTOWARE_SUBSCRIPTION_PTR(CandidateTrajectories) sub_trajectories_;
 
-  rclcpp::Subscription<LaneletMapBin>::SharedPtr sub_map_;
-  rclcpp::Subscription<LaneletRoute>::SharedPtr sub_route_;
-  rclcpp::Subscription<CandidateTrajectories>::SharedPtr sub_trajectories_;
-
-  rclcpp::Publisher<ScoredCandidateTrajectories>::SharedPtr pub_trajectories_;
+  AUTOWARE_PUBLISHER_PTR(ScoredCandidateTrajectories) pub_trajectories_;
 
   std::unique_ptr<evaluation::ParamListener> listener_;
   std::shared_ptr<RouteHandler> route_handler_;
@@ -80,7 +77,7 @@ private:
   std::deque<autoware_planning_msgs::msg::Trajectory> trajectory_history_;
   size_t max_history_size_{10};
 
-  rclcpp::Publisher<autoware_utils_debug::ProcessingTimeDetail>::SharedPtr
+  AUTOWARE_PUBLISHER_PTR(autoware_utils_debug::ProcessingTimeDetail)
     debug_processing_time_detail_pub_;
   mutable std::shared_ptr<autoware_utils_debug::TimeKeeper> time_keeper_{nullptr};
 };

--- a/planning/autoware_trajectory_ranker/launch/trajectory_ranker.launch.xml
+++ b/planning/autoware_trajectory_ranker/launch/trajectory_ranker.launch.xml
@@ -8,7 +8,10 @@
   <arg name="input_odometry" default="~/input/odometry"/>
   <arg name="input_objects" default="~/input/objects"/>
 
+  <include file="$(find-pkg-share autoware_agnocast_wrapper)/launch/agnocast_env.launch.xml"/>
+
   <node pkg="autoware_trajectory_ranker" exec="autoware_trajectory_ranker_node" name="trajectory_ranker_node" output="screen">
+    <env name="LD_PRELOAD" value="$(var ld_preload_value)"/>
     <param from="$(var trajectory_ranker_param_path)" allow_substs="true"/>
     <param from="$(find-pkg-share autoware_trajectory_ranker)/config/metrics/trajectory_consistency.param.yaml"/>
 

--- a/planning/autoware_trajectory_ranker/src/trajectory_ranker_node.cpp
+++ b/planning/autoware_trajectory_ranker/src/trajectory_ranker_node.cpp
@@ -50,10 +50,6 @@ TrajectoryRanker::TrajectoryRanker(const rclcpp::NodeOptions & options)
     evaluator_->load_metric(metrics.name.at(i), i, listener_->get_params().resolution);
   }
 
-  // Setup polling subscribers
-  sub_objects_ = this->create_polling_subscriber<PredictedObjects>("~/input/objects", 1);
-  sub_odometry_ = this->create_polling_subscriber<Odometry>("~/input/odometry", 1);
-
   // Setup subscriptions
   sub_map_ = create_subscription<LaneletMapBin>(
     "~/input/vector_map", rclcpp::QoS{1}.transient_local(),
@@ -82,8 +78,7 @@ TrajectoryRanker::TrajectoryRanker(const rclcpp::NodeOptions & options)
     std::make_shared<autoware_utils_debug::TimeKeeper>(debug_processing_time_detail_pub_);
 }
 
-void TrajectoryRanker::process(
-  const AUTOWARE_MESSAGE_CONST_SHARED_PTR(CandidateTrajectories) & msg)
+void TrajectoryRanker::process(const AUTOWARE_MESSAGE_CONST_SHARED_PTR(CandidateTrajectories) & msg)
 {
   autoware_utils_debug::ScopedTimeTrack st(__func__, *time_keeper_);
   auto output = ALLOCATE_OUTPUT_MESSAGE_UNIQUE(pub_trajectories_);

--- a/planning/autoware_trajectory_ranker/src/trajectory_ranker_node.cpp
+++ b/planning/autoware_trajectory_ranker/src/trajectory_ranker_node.cpp
@@ -82,8 +82,7 @@ TrajectoryRanker::TrajectoryRanker(const rclcpp::NodeOptions & options)
     std::make_shared<autoware_utils_debug::TimeKeeper>(debug_processing_time_detail_pub_);
 }
 
-void TrajectoryRanker::process(
-  const AUTOWARE_MESSAGE_CONST_SHARED_PTR(CandidateTrajectories) & msg)
+void TrajectoryRanker::process(const AUTOWARE_MESSAGE_CONST_SHARED_PTR(CandidateTrajectories) & msg)
 {
   autoware_utils_debug::ScopedTimeTrack st(__func__, *time_keeper_);
   auto output = ALLOCATE_OUTPUT_MESSAGE_UNIQUE(pub_trajectories_);

--- a/planning/autoware_trajectory_ranker/src/trajectory_ranker_node.cpp
+++ b/planning/autoware_trajectory_ranker/src/trajectory_ranker_node.cpp
@@ -50,18 +50,26 @@ TrajectoryRanker::TrajectoryRanker(const rclcpp::NodeOptions & options)
     evaluator_->load_metric(metrics.name.at(i), i, listener_->get_params().resolution);
   }
 
+  // Setup polling subscribers
+  sub_objects_ = this->create_polling_subscriber<PredictedObjects>("~/input/objects", 1);
+  sub_odometry_ = this->create_polling_subscriber<Odometry>("~/input/odometry", 1);
+
   // Setup subscriptions
   sub_map_ = create_subscription<LaneletMapBin>(
     "~/input/vector_map", rclcpp::QoS{1}.transient_local(),
-    [this](const LaneletMapBin::ConstSharedPtr msg) { route_handler_->setMap(*msg); });
+    [this](const AUTOWARE_MESSAGE_CONST_SHARED_PTR(LaneletMapBin) & msg) {
+      route_handler_->setMap(*msg);
+    });
 
   sub_route_ = create_subscription<LaneletRoute>(
     "~/input/route", rclcpp::QoS{1}.transient_local(),
-    [this](const LaneletRoute::ConstSharedPtr msg) { route_handler_->setRoute(*msg); });
+    [this](const AUTOWARE_MESSAGE_CONST_SHARED_PTR(LaneletRoute) & msg) {
+      route_handler_->setRoute(*msg);
+    });
 
   sub_trajectories_ = create_subscription<CandidateTrajectories>(
     "~/input/candidate_trajectories", 1,
-    [this](const CandidateTrajectories::ConstSharedPtr msg) { process(msg); });
+    [this](const AUTOWARE_MESSAGE_CONST_SHARED_PTR(CandidateTrajectories) & msg) { process(msg); });
 
   // Setup publishers
   pub_trajectories_ =
@@ -74,14 +82,17 @@ TrajectoryRanker::TrajectoryRanker(const rclcpp::NodeOptions & options)
     std::make_shared<autoware_utils_debug::TimeKeeper>(debug_processing_time_detail_pub_);
 }
 
-void TrajectoryRanker::process(const CandidateTrajectories::ConstSharedPtr msg)
+void TrajectoryRanker::process(
+  const AUTOWARE_MESSAGE_CONST_SHARED_PTR(CandidateTrajectories) & msg)
 {
   autoware_utils_debug::ScopedTimeTrack st(__func__, *time_keeper_);
-  pub_trajectories_->publish(*score(msg));
+  auto output = ALLOCATE_OUTPUT_MESSAGE_UNIQUE(pub_trajectories_);
+  *output = *score(msg);
+  pub_trajectories_->publish(std::move(output));
 }
 
 ScoredCandidateTrajectories::ConstSharedPtr TrajectoryRanker::score(
-  const CandidateTrajectories::ConstSharedPtr msg)
+  const AUTOWARE_MESSAGE_CONST_SHARED_PTR(CandidateTrajectories) & msg)
 {
   autoware_utils_debug::ScopedTimeTrack st(__func__, *time_keeper_);
 
@@ -94,19 +105,22 @@ ScoredCandidateTrajectories::ConstSharedPtr TrajectoryRanker::score(
     return std::make_shared<ScoredCandidateTrajectories>(output);
   }
 
-  const auto odometry_ptr = std::const_pointer_cast<Odometry>(sub_odometry_.take_data());
-  if (odometry_ptr == nullptr) {
+  const auto odometry_ptr = sub_odometry_->take_data();
+  if (!odometry_ptr) {
     RCLCPP_WARN_THROTTLE(
       get_logger(), *get_clock(), 5000, "Odometry data is not available. Returning empty output.");
     return std::make_shared<ScoredCandidateTrajectories>(output);
   }
 
-  const auto objects_ptr = std::const_pointer_cast<PredictedObjects>(sub_objects_.take_data());
-  if (objects_ptr == nullptr) {
+  const auto objects_msg = sub_objects_->take_data();
+  if (!objects_msg) {
     RCLCPP_WARN_THROTTLE(
       get_logger(), *get_clock(), 5000, "Objects data is not available. Returning empty output.");
     return std::make_shared<ScoredCandidateTrajectories>(output);
   }
+  // CoreData stores a mutable std::shared_ptr<PredictedObjects>, so copy out of the
+  // read-only shared-memory message at the subscription boundary.
+  const auto objects_ptr = std::make_shared<PredictedObjects>(*objects_msg);
 
   const auto preferred_lanes =
     std::make_shared<lanelet::ConstLanelets>(route_handler_->getPreferredLanelets());


### PR DESCRIPTION
## Description
Apply `agnocast_wrapper::Node` to `autoware_trajectory_ranker`.
Please read https://github.com/autowarefoundation/autoware/issues/7007 for the context and review guidelines of `autoware_agnocast_wrapper` adoption.  Also, please refer to https://github.com/autowarefoundation/autoware_core/blob/main/common/autoware_agnocast_wrapper/docs/review_guide.md for the review guide of `autoware_agnocast_wrapper` application PR. FYI: This node take [Method2](https://github.com/autowarefoundation/autoware_core/blob/main/common/autoware_agnocast_wrapper/docs/review_guide.md#method-2-agnocast_wrappernode-inheritance) of two integrations methods.

## Related Links

`agnocast_wrapper::Node`

- https://github.com/autowarefoundation/autoware/issues/7007
- https://github.com/orgs/autowarefoundation/discussions/6804

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
  - `colcon build` succeeds with both `ENABLE_AGNOCAST=1` and `ENABLE_AGNOCAST=0`.
  - Ran LSim with sample rosbag
    - build with `ENABLE_AGNOCAST=0` 
    - build with `ENABLE_AGNOCAST=1` , ran with `ENABLE_AGNOCAST = 0`
    - build with `ENABLE_AGNOCAST=1` , ran with `ENABLE_AGNOCAST = 1`


## Notes for reviewers

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None when `ENABLE_AGNOCAST` is unset or `0` at runtime.

When `ENABLE_AGNOCAST=1`, CPU time spent on message serialization/deserialization in this node is reduced (Agnocast zero-copy IPC). The executor also switches to CIE, but since CIE is almost equivalent to `MultiThreadedExecutor`, there is effectively no change in scheduling behavior.
