### PR TITLE
feat(autoware_universe_designs): add node designs for perception detection, radar, tracking, and traffic light nodes

### DIFF
--- a/common/autoware_universe_designs/design/perception/autoware_bytetrack/ByteTrack.node.yaml
+++ b/common/autoware_universe_designs/design/perception/autoware_bytetrack/ByteTrack.node.yaml
@@ -1,0 +1,40 @@
+autoware_system_design_format: 0.3.0
+
+# node information
+name: ByteTrack.node
+
+package:
+  name: autoware_bytetrack
+  provider: autoware
+
+launch:
+  plugin: autoware::bytetrack::ByteTrackNode
+  executable: bytetrack_node_exe
+  node_output: screen
+
+# interfaces
+# uuid debug publisher (out/objects/debug/uuid) omitted.
+subscribers:
+  - name: rect
+    message_type: tier4_perception_msgs/msg/DetectedObjectsWithFeature
+    remap_target: ~/in/rect
+
+publishers:
+  - name: objects
+    message_type: tier4_perception_msgs/msg/DetectedObjectsWithFeature
+    remap_target: ~/out/objects
+
+# parameters
+param_files:
+  - name: param_file
+    default: config/bytetrack.param.yaml
+
+param_values: []
+
+# processes
+processes:
+  - name: track
+    trigger_conditions:
+      - on_input: rect
+    outcomes:
+      - to_output: objects

--- a/common/autoware_universe_designs/design/perception/autoware_bytetrack/ByteTrackVisualizer.node.yaml
+++ b/common/autoware_universe_designs/design/perception/autoware_bytetrack/ByteTrackVisualizer.node.yaml
@@ -1,0 +1,46 @@
+autoware_system_design_format: 0.3.0
+
+# node information
+name: ByteTrackVisualizer.node
+
+package:
+  name: autoware_bytetrack
+  provider: autoware
+
+launch:
+  plugin: autoware::bytetrack::ByteTrackVisualizerNode
+  executable: bytetrack_visualizer_node_exe
+  node_output: screen
+
+# interfaces
+# image I/O uses image_transport.
+subscribers:
+  - name: image
+    message_type: sensor_msgs/msg/Image
+    remap_target: ~/in/image
+  - name: rect
+    message_type: tier4_perception_msgs/msg/DetectedObjectsWithFeature
+    remap_target: ~/in/rect
+  - name: uuid
+    message_type: tier4_perception_msgs/msg/DynamicObjectArray
+    remap_target: ~/in/uuid
+
+publishers:
+  - name: image
+    message_type: sensor_msgs/msg/Image
+    remap_target: ~/out/image
+
+# parameters
+param_files:
+  - name: param_file
+    default: config/bytetrack_visualizer.param.yaml
+
+param_values: []
+
+# processes
+processes:
+  - name: visualize
+    trigger_conditions:
+      - on_input: image
+    outcomes:
+      - to_output: image

--- a/common/autoware_universe_designs/design/perception/autoware_detected_object_validation/ObjectPositionFilter.node.yaml
+++ b/common/autoware_universe_designs/design/perception/autoware_detected_object_validation/ObjectPositionFilter.node.yaml
@@ -1,0 +1,39 @@
+autoware_system_design_format: 0.3.0
+
+# node information
+name: ObjectPositionFilter.node
+
+package:
+  name: autoware_detected_object_validation
+  provider: autoware
+
+launch:
+  plugin: autoware::detected_object_validation::position_filter::ObjectPositionFilterNode
+  executable: object_position_filter_node
+  node_output: screen
+
+# interfaces
+subscribers:
+  - name: object
+    message_type: autoware_perception_msgs/msg/DetectedObjects
+    remap_target: input/object
+
+publishers:
+  - name: object
+    message_type: autoware_perception_msgs/msg/DetectedObjects
+    remap_target: output/object
+
+# parameters
+param_files:
+  - name: param_file
+    default: config/object_position_filter.param.yaml
+
+param_values: []
+
+# processes
+processes:
+  - name: filter
+    trigger_conditions:
+      - on_input: object
+    outcomes:
+      - to_output: object

--- a/common/autoware_universe_designs/design/perception/autoware_detected_object_validation/OccupancyGridBasedValidator.node.yaml
+++ b/common/autoware_universe_designs/design/perception/autoware_detected_object_validation/OccupancyGridBasedValidator.node.yaml
@@ -1,0 +1,45 @@
+autoware_system_design_format: 0.3.0
+
+# node information
+name: OccupancyGridBasedValidator.node
+
+package:
+  name: autoware_detected_object_validation
+  provider: autoware
+
+launch:
+  plugin: autoware::detected_object_validation::occupancy_grid_map::OccupancyGridBasedValidator
+  executable: occupancy_grid_based_validator_node
+  node_output: screen
+
+# interfaces
+# detected_objects + occupancy_grid_map are message_filters-synced; debug marker omitted.
+subscribers:
+  - name: detected_objects
+    message_type: autoware_perception_msgs/msg/DetectedObjects
+    remap_target: ~/input/detected_objects
+  - name: occupancy_grid_map
+    message_type: nav_msgs/msg/OccupancyGrid
+    remap_target: ~/input/occupancy_grid_map
+
+publishers:
+  - name: objects
+    message_type: autoware_perception_msgs/msg/DetectedObjects
+    remap_target: ~/output/objects
+
+# parameters
+param_files:
+  - name: param_file
+    default: config/occupancy_grid_based_validator.param.yaml
+
+param_values: []
+
+# processes
+processes:
+  - name: validate
+    trigger_conditions:
+      - and:
+          - on_input: detected_objects
+          - on_input: occupancy_grid_map
+    outcomes:
+      - to_output: objects

--- a/common/autoware_universe_designs/design/perception/autoware_euclidean_cluster/EuclideanCluster.node.yaml
+++ b/common/autoware_universe_designs/design/perception/autoware_euclidean_cluster/EuclideanCluster.node.yaml
@@ -1,0 +1,39 @@
+autoware_system_design_format: 0.3.0
+
+# node information
+name: EuclideanCluster.node
+
+package:
+  name: autoware_euclidean_cluster
+  provider: autoware
+
+launch:
+  plugin: autoware::euclidean_cluster::EuclideanClusterNode
+  executable: euclidean_cluster_node
+  node_output: screen
+
+# interfaces
+subscribers:
+  - name: input
+    message_type: sensor_msgs/msg/PointCloud2
+    remap_target: input
+
+publishers:
+  - name: output
+    message_type: tier4_perception_msgs/msg/DetectedObjectsWithFeature
+    remap_target: output
+
+# parameters
+param_files:
+  - name: param_file
+    default: config/euclidean_cluster.param.yaml
+
+param_values: []
+
+# processes
+processes:
+  - name: cluster
+    trigger_conditions:
+      - on_input: input
+    outcomes:
+      - to_output: output

--- a/common/autoware_universe_designs/design/perception/autoware_image_object_locator/BboxObjectLocator.node.yaml
+++ b/common/autoware_universe_designs/design/perception/autoware_image_object_locator/BboxObjectLocator.node.yaml
@@ -1,0 +1,44 @@
+autoware_system_design_format: 0.3.0
+
+# node information
+name: BboxObjectLocator.node
+
+package:
+  name: autoware_image_object_locator
+  provider: autoware
+
+launch:
+  plugin: autoware::image_object_locator::BboxObjectLocatorNode
+  executable: bbox_object_locator_node
+  node_output: screen
+
+# interfaces
+# per-camera sockets built from the rois_ids parameter (rois0 representative):
+# input/camera_info<N>, input/rois<N> -> output/rois<N>/objects.
+subscribers:
+  - name: camera_info
+    message_type: sensor_msgs/msg/CameraInfo
+    remap_target: input/camera_info0
+  - name: rois
+    message_type: tier4_perception_msgs/msg/DetectedObjectsWithFeature
+    remap_target: input/rois0
+
+publishers:
+  - name: objects
+    message_type: autoware_perception_msgs/msg/DetectedObjects
+    remap_target: output/rois0/objects
+
+# parameters
+param_files:
+  - name: param_file
+    default: config/bbox_object_locator.param.yaml
+
+param_values: []
+
+# processes
+processes:
+  - name: locate
+    trigger_conditions:
+      - on_input: rois
+    outcomes:
+      - to_output: objects

--- a/common/autoware_universe_designs/design/perception/autoware_predicted_path_postprocessor/PredictedPathPostprocessor.node.yaml
+++ b/common/autoware_universe_designs/design/perception/autoware_predicted_path_postprocessor/PredictedPathPostprocessor.node.yaml
@@ -1,0 +1,42 @@
+autoware_system_design_format: 0.3.0
+
+# node information
+name: PredictedPathPostprocessor.node
+
+package:
+  name: autoware_predicted_path_postprocessor
+  provider: autoware
+
+launch:
+  plugin: autoware::predicted_path_postprocessor::PredictedPathPostprocessorNode
+  executable: autoware_predicted_path_postprocessor_exe
+  node_output: screen
+
+# interfaces
+subscribers:
+  - name: objects
+    message_type: autoware_perception_msgs/msg/PredictedObjects
+    remap_target: ~/input/objects
+  - name: lanelet_map
+    message_type: autoware_map_msgs/msg/LaneletMapBin
+    remap_target: ~/input/lanelet_map
+
+publishers:
+  - name: objects
+    message_type: autoware_perception_msgs/msg/PredictedObjects
+    remap_target: ~/output/objects
+
+# parameters
+param_files:
+  - name: param_file
+    default: config/predicted_path_postprocessor.param.yaml
+
+param_values: []
+
+# processes
+processes:
+  - name: postprocess
+    trigger_conditions:
+      - on_input: objects
+    outcomes:
+      - to_output: objects

--- a/common/autoware_universe_designs/design/perception/autoware_radar_fusion_to_detected_object/RadarObjectFusionToDetectedObject.node.yaml
+++ b/common/autoware_universe_designs/design/perception/autoware_radar_fusion_to_detected_object/RadarObjectFusionToDetectedObject.node.yaml
@@ -1,0 +1,45 @@
+autoware_system_design_format: 0.3.0
+
+# node information
+name: RadarObjectFusionToDetectedObject.node
+
+package:
+  name: autoware_radar_fusion_to_detected_object
+  provider: autoware
+
+launch:
+  plugin: autoware::radar_fusion_to_detected_object::RadarObjectFusionToDetectedObjectNode
+  executable: radar_fusion_to_detected_object_node
+  node_output: screen
+
+# interfaces
+# objects + radars are message_filters-synced; debug low_confidence_objects omitted.
+subscribers:
+  - name: objects
+    message_type: autoware_perception_msgs/msg/DetectedObjects
+    remap_target: ~/input/objects
+  - name: radars
+    message_type: autoware_perception_msgs/msg/DetectedObjects
+    remap_target: ~/input/radars
+
+publishers:
+  - name: objects
+    message_type: autoware_perception_msgs/msg/DetectedObjects
+    remap_target: ~/output/objects
+
+# parameters
+param_files:
+  - name: param_file
+    default: config/radar_object_fusion_to_detected_object.param.yaml
+
+param_values: []
+
+# processes
+processes:
+  - name: fuse
+    trigger_conditions:
+      - and:
+          - on_input: objects
+          - on_input: radars
+    outcomes:
+      - to_output: objects

--- a/common/autoware_universe_designs/design/perception/autoware_radar_tracks_msgs_converter/RadarTracksMsgsConverter.node.yaml
+++ b/common/autoware_universe_designs/design/perception/autoware_radar_tracks_msgs_converter/RadarTracksMsgsConverter.node.yaml
@@ -1,0 +1,46 @@
+autoware_system_design_format: 0.3.0
+
+# node information
+name: RadarTracksMsgsConverter.node
+
+package:
+  name: autoware_radar_tracks_msgs_converter
+  provider: autoware
+
+launch:
+  plugin: autoware::radar_tracks_msgs_converter::RadarTracksMsgsConverterNode
+  executable: radar_tracks_msgs_converter_node
+  node_output: screen
+
+# interfaces
+subscribers:
+  - name: radar_objects
+    message_type: radar_msgs/msg/RadarTracks
+    remap_target: ~/input/radar_objects
+  - name: odometry
+    message_type: nav_msgs/msg/Odometry
+    remap_target: ~/input/odometry
+
+publishers:
+  - name: radar_tracked_objects
+    message_type: autoware_perception_msgs/msg/TrackedObjects
+    remap_target: ~/output/radar_tracked_objects
+  - name: radar_detected_objects
+    message_type: autoware_perception_msgs/msg/DetectedObjects
+    remap_target: ~/output/radar_detected_objects
+
+# parameters
+param_files:
+  - name: param_file
+    default: config/radar_tracks_msgs_converter.param.yaml
+
+param_values: []
+
+# processes
+processes:
+  - name: convert
+    trigger_conditions:
+      - on_input: radar_objects
+    outcomes:
+      - to_output: radar_tracked_objects
+      - to_output: radar_detected_objects

--- a/common/autoware_universe_designs/design/perception/autoware_traffic_light_classifier/SingleImageDebugInference.node.yaml
+++ b/common/autoware_universe_designs/design/perception/autoware_traffic_light_classifier/SingleImageDebugInference.node.yaml
@@ -1,0 +1,31 @@
+autoware_system_design_format: 0.3.0
+
+# node information
+name: SingleImageDebugInference.node
+
+package:
+  name: autoware_traffic_light_classifier
+  provider: autoware
+
+launch:
+  plugin: autoware::traffic_light::SingleImageDebugInferenceNode
+  executable: single_image_debug_inference
+  node_output: screen
+
+# interfaces
+# standalone debug tool: loads an image from the image_path parameter and runs
+# classifier inference in an OpenCV window. no ROS topic interface.
+subscribers: []
+
+publishers: []
+
+# parameters
+param_files: []
+
+param_values:
+  - name: image_path
+    type: string
+    default: ""
+
+# processes
+processes: []

--- a/common/autoware_universe_designs/design/perception/autoware_traffic_light_visualization/TrafficLightMapVisualizer.node.yaml
+++ b/common/autoware_universe_designs/design/perception/autoware_traffic_light_visualization/TrafficLightMapVisualizer.node.yaml
@@ -1,0 +1,40 @@
+autoware_system_design_format: 0.3.0
+
+# node information
+name: TrafficLightMapVisualizer.node
+
+package:
+  name: autoware_traffic_light_visualization
+  provider: autoware
+
+launch:
+  plugin: autoware::traffic_light::TrafficLightMapVisualizerNode
+  executable: traffic_light_map_visualizer_node
+  node_output: screen
+
+# interfaces
+subscribers:
+  - name: tl_state
+    message_type: autoware_perception_msgs/msg/TrafficLightGroupArray
+    remap_target: ~/input/tl_state
+  - name: vector_map
+    message_type: autoware_map_msgs/msg/LaneletMapBin
+    remap_target: ~/input/vector_map
+
+publishers:
+  - name: traffic_light
+    message_type: visualization_msgs/msg/MarkerArray
+    remap_target: ~/output/traffic_light
+
+# parameters
+param_files: []
+
+param_values: []
+
+# processes
+processes:
+  - name: visualize
+    trigger_conditions:
+      - on_input: tl_state
+    outcomes:
+      - to_output: traffic_light

--- a/common/autoware_universe_designs/design/perception/autoware_traffic_light_visualization/TrafficLightRoiVisualizer.node.yaml
+++ b/common/autoware_universe_designs/design/perception/autoware_traffic_light_visualization/TrafficLightRoiVisualizer.node.yaml
@@ -1,0 +1,50 @@
+autoware_system_design_format: 0.3.0
+
+# node information
+name: TrafficLightRoiVisualizer.node
+
+package:
+  name: autoware_traffic_light_visualization
+  provider: autoware
+
+launch:
+  plugin: autoware::traffic_light::TrafficLightRoiVisualizerNode
+  executable: traffic_light_visualization_node
+  node_output: screen
+
+# interfaces
+# image + rois + rough_rois + traffic_signals are message_filters-synced.
+# image I/O uses image_transport.
+subscribers:
+  - name: image
+    message_type: sensor_msgs/msg/Image
+    remap_target: ~/input/image
+  - name: rois
+    message_type: tier4_perception_msgs/msg/TrafficLightRoiArray
+    remap_target: ~/input/rois
+  - name: rough_rois
+    message_type: tier4_perception_msgs/msg/TrafficLightRoiArray
+    remap_target: ~/input/rough/rois
+  - name: traffic_signals
+    message_type: tier4_perception_msgs/msg/TrafficLightArray
+    remap_target: ~/input/traffic_signals
+
+publishers:
+  - name: image
+    message_type: sensor_msgs/msg/Image
+    remap_target: ~/output/image
+
+# parameters
+param_files:
+  - name: param_file
+    default: config/traffic_light_roi_visualizer.param.yaml
+
+param_values: []
+
+# processes
+processes:
+  - name: visualize
+    trigger_conditions:
+      - on_input: image
+    outcomes:
+      - to_output: image


### PR DESCRIPTION
## Description

Adds the missing `*.node.yaml` design files (Autoware System Design Format 0.3.0) for 12 perception nodes in the detection/clustering, validation, radar, tracking, prediction, and traffic-light packages, under `common/autoware_universe_designs/design/perception/`. Second of the perception batches; follows #12905 (map-segmentation and ground) and the sensing batches (#12884, #12891, #12897).

- **autoware_euclidean_cluster:** EuclideanCluster
- **autoware_detected_object_validation:** OccupancyGridBasedValidator, ObjectPositionFilter
- **autoware_image_object_locator:** BboxObjectLocator
- **autoware_radar_tracks_msgs_converter:** RadarTracksMsgsConverter
- **autoware_radar_fusion_to_detected_object:** RadarObjectFusionToDetectedObject
- **autoware_bytetrack:** ByteTrack, ByteTrackVisualizer
- **autoware_predicted_path_postprocessor:** PredictedPathPostprocessor
- **autoware_traffic_light_classifier:** SingleImageDebugInference
- **autoware_traffic_light_visualization:** TrafficLightMapVisualizer, TrafficLightRoiVisualizer


All interfaces were derived directly from each node's implementation and CMakeLists. A few notes:

- OccupancyGridBasedValidator (detected_objects + occupancy_grid_map) and RadarObjectFusionToDetectedObject (objects + radars) each `message_filters`-sync their inputs, reflected as `and` triggers. TrafficLightRoiVisualizer syncs four inputs (image + rois + rough_rois + traffic_signals).
- BboxObjectLocator builds its sockets dynamically per the `rois_ids` parameter (`input/camera_info<N>`, `input/rois<N>` → `output/rois<N>/objects`); a representative index is documented, mirroring the multi-camera convention.
- ByteTrack/ByteTrackVisualizer use `~/in/*`, `~/out/*` topics; the visualizers use `image_transport`. Debug publishers (e.g. bytetrack's `out/objects/debug/uuid`) are omitted, consistent with prior batches.
- SingleImageDebugInference is a standalone debug tool: it loads an image from the `image_path` parameter and runs classifier inference in an OpenCV window, with no ROS topic interface.

## Related links

- https://github.com/autowarefoundation/autoware_system_designer
- https://github.com/autowarefoundation/autoware_universe/tree/main/common/autoware_universe_designs/design

## How was this PR tested?

`pre-commit run lint-system-design-format` passes on all 12 files.

For the launch test I followed the same module-connect process as the previous batches: a `PerceptionDebugTools2` module added to `AutowareSample.system.yaml` as a `perception_tools2` component with a parameter_set, then deployed via the designer. The deploy builds cleanly and generates the launch XML and Node Diagram. Confirming the three points:

- **Topic types & remap targets** — the generated `perception_tools2.launch.xml` resolves every port; the Node Diagram renders each node's interfaces matching the source (the validators' synced inputs, radar converter's four ports, bytetrack in/out, and the traffic-light visualizers' multi-input syncs).
- **Visual** — the Node Diagram renders the `perception_tools2` component with all nodes and their ports (screenshot below).
- 
<img width="2796" height="1581" alt="Screenshot from 2026-07-02 10-26-02" src="https://github.com/user-attachments/assets/b2f7e23b-5f1d-4e54-a8a5-f9aaebe3c041" />


9 of the 12 were launch-tested with their binaries present in my workspace. Three are design/lint-verified only:

- **BboxObjectLocator** and **PredictedPathPostprocessor** — their binaries and param files are newer than my installed workspace, so they aren't running binaries here.
- **SingleImageDebugInference** — a standalone OpenCV CLI tool (blocking `cv::waitKey`) with no ROS topic interface, so there is nothing to deploy in the module test.

<attach the perception_tools2 screenshot here>

## Interface changes

None.

## Effects on system behavior

None. Documentation-only change.
