### PR TITLE
refactor(traffic_light_selector): extract core logic

### DIFF
--- a/perception/autoware_traffic_light_selector/CMakeLists.txt
+++ b/perception/autoware_traffic_light_selector/CMakeLists.txt
@@ -21,6 +21,9 @@ if(BUILD_TESTING)
   ament_auto_add_gtest(${PROJECT_NAME}_test
     test/test_utils.cpp
   )
+  ament_auto_add_gtest(${PROJECT_NAME}_selector_test
+    test/test_traffic_light_selector.cpp
+  )
   ament_auto_add_gtest(${PROJECT_NAME}_node_test
     test/test_traffic_light_selector_node.cpp
   )

--- a/perception/autoware_traffic_light_selector/CMakeLists.txt
+++ b/perception/autoware_traffic_light_selector/CMakeLists.txt
@@ -7,6 +7,7 @@ autoware_package()
 
 # Targets
 ament_auto_add_library(${PROJECT_NAME} SHARED
+  src/traffic_light_selector.cpp
   src/traffic_light_selector_node.cpp
   src/traffic_light_selector_utils.cpp
 )

--- a/perception/autoware_traffic_light_selector/src/traffic_light_selector.cpp
+++ b/perception/autoware_traffic_light_selector/src/traffic_light_selector.cpp
@@ -51,8 +51,10 @@ void evaluateWholeRois(
 TrafficLightRoiArray TrafficLightSelector::select(
   const DetectedObjectsWithFeature & detected_traffic_light_msg,
   const TrafficLightRoiArray & rough_rois_msg, const TrafficLightRoiArray & expected_rois_msg,
-  uint32_t image_width, uint32_t image_height) const
+  const sensor_msgs::msg::CameraInfo & camera_info_msg) const
 {
+  const auto image_width = camera_info_msg.width;
+  const auto image_height = camera_info_msg.height;
   std::map<int64_t, RegionOfInterest> rough_rois_map;
   for (const auto & roi : rough_rois_msg.rois) {
     rough_rois_map[roi.traffic_light_id] = roi.roi;

--- a/perception/autoware_traffic_light_selector/src/traffic_light_selector.cpp
+++ b/perception/autoware_traffic_light_selector/src/traffic_light_selector.cpp
@@ -1,0 +1,126 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "traffic_light_selector.hpp"
+
+#include <sensor_msgs/msg/region_of_interest.hpp>
+
+#include <map>
+#include <utility>
+#include <vector>
+
+namespace autoware::traffic_light
+{
+
+namespace
+{
+
+void evaluateWholeRois(
+  const std::vector<RegionOfInterest> & detected_rois,
+  const std::map<int64_t, RegionOfInterest> & expect_rois_shifted_map, double & total_max_iou,
+  std::map<int64_t, RegionOfInterest> & total_max_iou_rois_map)
+{
+  for (const auto & expect_roi_shifted : expect_rois_shifted_map) {
+    double max_iou = 0.0;
+    RegionOfInterest max_iou_roi;
+    for (const auto & detected_roi : detected_rois) {
+      const double iou = utils::getGenIoU(expect_roi_shifted.second, detected_roi);
+      if (iou > max_iou) {
+        max_iou = iou;
+        max_iou_roi = detected_roi;
+      }
+    }
+    total_max_iou += max_iou;
+    total_max_iou_rois_map[expect_roi_shifted.first] = max_iou_roi;
+  }
+}
+
+}  // namespace
+
+TrafficLightRoiArray TrafficLightSelector::select(
+  const DetectedObjectsWithFeature & detected_traffic_light_msg,
+  const TrafficLightRoiArray & rough_rois_msg, const TrafficLightRoiArray & expected_rois_msg,
+  uint32_t image_width, uint32_t image_height) const
+{
+  std::map<int64_t, RegionOfInterest> rough_rois_map;
+  for (const auto & roi : rough_rois_msg.rois) {
+    rough_rois_map[roi.traffic_light_id] = roi.roi;
+  }
+
+  std::vector<RegionOfInterest> detected_rois;
+  for (const auto & detected_object : detected_traffic_light_msg.feature_objects) {
+    detected_rois.push_back(detected_object.feature.roi);
+  }
+
+  double final_iou = 0.0;
+  std::map<int64_t, RegionOfInterest> final_rois_map;
+  for (const auto & expected_rois_msg_rois : expected_rois_msg.rois) {
+    const auto traffic_light_id = expected_rois_msg_rois.traffic_light_id;
+    const auto & rough_roi = rough_rois_map[traffic_light_id];
+    const auto & expect_roi = expected_rois_msg_rois.roi;
+
+    for (const auto & detected_roi : detected_rois) {
+      if (!utils::isCenterInsideRoughRoi(detected_roi, rough_roi)) {
+        continue;
+      }
+
+      // shift expect roi because the location of detected roi is better that it
+      int32_t shift_x, shift_y;
+      utils::computeCenterOffset(detected_roi, expect_roi, shift_x, shift_y);
+
+      std::map<int64_t, RegionOfInterest> expect_rois_shifted_map;
+      for (const auto & rois : expected_rois_msg.rois) {
+        const auto expect_roi_shifted =
+          utils::getShiftedRoi(rois.roi, image_width, image_height, shift_x, shift_y);
+        expect_rois_shifted_map[rois.traffic_light_id] = expect_roi_shifted;
+      }
+
+      // check total IoU after all expect roi shift
+      double total_max_iou = 0.0;
+      std::map<int64_t, RegionOfInterest> total_max_iou_rois_map;
+      evaluateWholeRois(
+        detected_rois, expect_rois_shifted_map, total_max_iou, total_max_iou_rois_map);
+
+      if (total_max_iou > final_iou) {
+        final_iou = total_max_iou;
+        final_rois_map = std::move(total_max_iou_rois_map);
+      }
+    }
+  }
+
+  // assign max iou roi to output
+  using tier4_perception_msgs::msg::TrafficLightRoi;
+  TrafficLightRoiArray output;
+  output.header = detected_traffic_light_msg.header;
+  for (const auto & expected_rois_msg_rois : expected_rois_msg.rois) {
+    const auto traffic_light_id = expected_rois_msg_rois.traffic_light_id;
+    const auto traffic_light_type = expected_rois_msg_rois.traffic_light_type;
+    TrafficLightRoi traffic_light_roi;
+
+    if (final_rois_map.find(traffic_light_id) != final_rois_map.end()) {
+      traffic_light_roi.traffic_light_id = traffic_light_id;
+      traffic_light_roi.traffic_light_type = traffic_light_type;
+      traffic_light_roi.roi = final_rois_map[traffic_light_id];
+      output.rois.push_back(traffic_light_roi);
+    } else {
+      traffic_light_roi.traffic_light_id = traffic_light_id;
+      traffic_light_roi.traffic_light_type = traffic_light_type;
+      output.rois.push_back(traffic_light_roi);
+    }
+  }
+
+  return output;
+}
+
+}  // namespace autoware::traffic_light

--- a/perception/autoware_traffic_light_selector/src/traffic_light_selector.cpp
+++ b/perception/autoware_traffic_light_selector/src/traffic_light_selector.cpp
@@ -48,10 +48,10 @@ void evaluateWholeRois(
 
 }  // namespace
 
-TrafficLightRoiArray TrafficLightSelector::select(
+TrafficLightRoiArray select(
   const DetectedObjectsWithFeature & detected_traffic_light_msg,
   const TrafficLightRoiArray & rough_rois_msg, const TrafficLightRoiArray & expected_rois_msg,
-  const sensor_msgs::msg::CameraInfo & camera_info_msg) const
+  const sensor_msgs::msg::CameraInfo & camera_info_msg)
 {
   const auto image_width = camera_info_msg.width;
   const auto image_height = camera_info_msg.height;

--- a/perception/autoware_traffic_light_selector/src/traffic_light_selector.hpp
+++ b/perception/autoware_traffic_light_selector/src/traffic_light_selector.hpp
@@ -1,0 +1,45 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef TRAFFIC_LIGHT_SELECTOR_HPP_
+#define TRAFFIC_LIGHT_SELECTOR_HPP_
+
+#include "traffic_light_selector_utils.hpp"
+
+#include <tier4_perception_msgs/msg/detected_objects_with_feature.hpp>
+#include <tier4_perception_msgs/msg/traffic_light_roi_array.hpp>
+
+#include <map>
+#include <vector>
+
+namespace autoware::traffic_light
+{
+using sensor_msgs::msg::RegionOfInterest;
+using tier4_perception_msgs::msg::DetectedObjectsWithFeature;
+using tier4_perception_msgs::msg::TrafficLightRoiArray;
+
+class TrafficLightSelector
+{
+public:
+  TrafficLightSelector() = default;
+
+  TrafficLightRoiArray select(
+    const DetectedObjectsWithFeature & detected_traffic_light_msg,
+    const TrafficLightRoiArray & rough_rois_msg, const TrafficLightRoiArray & expected_rois_msg,
+    uint32_t image_width, uint32_t image_height) const;
+};
+
+}  // namespace autoware::traffic_light
+
+#endif  // TRAFFIC_LIGHT_SELECTOR_HPP_

--- a/perception/autoware_traffic_light_selector/src/traffic_light_selector.hpp
+++ b/perception/autoware_traffic_light_selector/src/traffic_light_selector.hpp
@@ -30,16 +30,24 @@ using sensor_msgs::msg::RegionOfInterest;
 using tier4_perception_msgs::msg::DetectedObjectsWithFeature;
 using tier4_perception_msgs::msg::TrafficLightRoiArray;
 
-class TrafficLightSelector
-{
-public:
-  TrafficLightSelector() = default;
-
-  TrafficLightRoiArray select(
-    const DetectedObjectsWithFeature & detected_traffic_light_msg,
-    const TrafficLightRoiArray & rough_rois_msg, const TrafficLightRoiArray & expected_rois_msg,
-    const sensor_msgs::msg::CameraInfo & camera_info_msg) const;
-};
+/**
+ * @brief For each expected traffic light ROI, select the detected ROI that best matches it.
+ *
+ * The expected ROIs are shifted onto each candidate detection (restricted to detections whose
+ * center falls inside the corresponding rough ROI), and the shift that maximizes the total IoU
+ * across all expected ROIs is chosen. Expected ROIs left unmatched fall back to a default
+ * (empty) ROI in the output.
+ *
+ * @param detected_traffic_light_msg traffic light detections from the detector
+ * @param rough_rois_msg rough ROIs used to gate candidate detections per traffic light
+ * @param expected_rois_msg expected ROIs projected from the map, one per traffic light
+ * @param camera_info_msg camera info used to clamp shifted ROIs to the image bounds
+ * @return selected ROI (or a default one when unmatched) for each expected traffic light
+ */
+TrafficLightRoiArray select(
+  const DetectedObjectsWithFeature & detected_traffic_light_msg,
+  const TrafficLightRoiArray & rough_rois_msg, const TrafficLightRoiArray & expected_rois_msg,
+  const sensor_msgs::msg::CameraInfo & camera_info_msg);
 
 }  // namespace autoware::traffic_light
 

--- a/perception/autoware_traffic_light_selector/src/traffic_light_selector.hpp
+++ b/perception/autoware_traffic_light_selector/src/traffic_light_selector.hpp
@@ -21,9 +21,6 @@
 #include <tier4_perception_msgs/msg/detected_objects_with_feature.hpp>
 #include <tier4_perception_msgs/msg/traffic_light_roi_array.hpp>
 
-#include <map>
-#include <vector>
-
 namespace autoware::traffic_light
 {
 using sensor_msgs::msg::RegionOfInterest;

--- a/perception/autoware_traffic_light_selector/src/traffic_light_selector.hpp
+++ b/perception/autoware_traffic_light_selector/src/traffic_light_selector.hpp
@@ -17,6 +17,7 @@
 
 #include "traffic_light_selector_utils.hpp"
 
+#include <sensor_msgs/msg/camera_info.hpp>
 #include <tier4_perception_msgs/msg/detected_objects_with_feature.hpp>
 #include <tier4_perception_msgs/msg/traffic_light_roi_array.hpp>
 
@@ -37,7 +38,7 @@ public:
   TrafficLightRoiArray select(
     const DetectedObjectsWithFeature & detected_traffic_light_msg,
     const TrafficLightRoiArray & rough_rois_msg, const TrafficLightRoiArray & expected_rois_msg,
-    uint32_t image_width, uint32_t image_height) const;
+    const sensor_msgs::msg::CameraInfo & camera_info_msg) const;
 };
 
 }  // namespace autoware::traffic_light

--- a/perception/autoware_traffic_light_selector/src/traffic_light_selector_node.cpp
+++ b/perception/autoware_traffic_light_selector/src/traffic_light_selector_node.cpp
@@ -55,8 +55,7 @@ void TrafficLightSelectorNode::objectsCallback(
   stop_watch_ptr_->toc("processing_time", true);
 
   const auto output = selector_.select(
-    *detected_traffic_light_msg, *rough_rois_msg, *expected_rois_msg, camera_info_msg->width,
-    camera_info_msg->height);
+    *detected_traffic_light_msg, *rough_rois_msg, *expected_rois_msg, *camera_info_msg);
 
   pub_traffic_light_rois_->publish(output);
 

--- a/perception/autoware_traffic_light_selector/src/traffic_light_selector_node.cpp
+++ b/perception/autoware_traffic_light_selector/src/traffic_light_selector_node.cpp
@@ -54,8 +54,8 @@ void TrafficLightSelectorNode::objectsCallback(
 {
   stop_watch_ptr_->toc("processing_time", true);
 
-  const auto output = selector_.select(
-    *detected_traffic_light_msg, *rough_rois_msg, *expected_rois_msg, *camera_info_msg);
+  const auto output =
+    select(*detected_traffic_light_msg, *rough_rois_msg, *expected_rois_msg, *camera_info_msg);
 
   pub_traffic_light_rois_->publish(output);
 

--- a/perception/autoware_traffic_light_selector/src/traffic_light_selector_node.cpp
+++ b/perception/autoware_traffic_light_selector/src/traffic_light_selector_node.cpp
@@ -14,12 +14,7 @@
 
 #include "traffic_light_selector_node.hpp"
 
-#include <sensor_msgs/msg/region_of_interest.hpp>
-
-#include <map>
 #include <memory>
-#include <utility>
-#include <vector>
 
 namespace autoware::traffic_light
 {
@@ -59,74 +54,9 @@ void TrafficLightSelectorNode::objectsCallback(
 {
   stop_watch_ptr_->toc("processing_time", true);
 
-  const auto image_width = camera_info_msg->width;
-  const auto image_height = camera_info_msg->height;
-
-  std::map<int64_t, RegionOfInterest> rough_rois_map;
-  for (const auto & roi : rough_rois_msg->rois) {
-    rough_rois_map[roi.traffic_light_id] = roi.roi;
-  }
-
-  std::vector<RegionOfInterest> detected_rois;
-  for (const auto & detected_object : detected_traffic_light_msg->feature_objects) {
-    detected_rois.push_back(detected_object.feature.roi);
-  }
-
-  double final_iou = 0.0;
-  std::map<int64_t, RegionOfInterest> final_rois_map;
-  for (const auto & expected_rois_msg_rois : expected_rois_msg->rois) {
-    const auto traffic_light_id = expected_rois_msg_rois.traffic_light_id;
-    const auto & rough_roi = rough_rois_map[traffic_light_id];
-    const auto & expect_roi = expected_rois_msg_rois.roi;
-
-    for (const auto & detected_roi : detected_rois) {
-      if (!utils::isCenterInsideRoughRoi(detected_roi, rough_roi)) {
-        continue;
-      }
-
-      // shift expect roi because the location of detected roi is better that it
-      int32_t shift_x, shift_y;
-      utils::computeCenterOffset(detected_roi, expect_roi, shift_x, shift_y);
-
-      std::map<int64_t, RegionOfInterest> expect_rois_shifted_map;
-      for (const auto & rois : expected_rois_msg->rois) {
-        const auto expect_roi_shifted =
-          utils::getShiftedRoi(rois.roi, image_width, image_height, shift_x, shift_y);
-        expect_rois_shifted_map[rois.traffic_light_id] = expect_roi_shifted;
-      }
-
-      // check total IoU after all expect roi shift
-      double total_max_iou = 0.0;
-      std::map<int64_t, RegionOfInterest> total_max_iou_rois_map;
-      evaluateWholeRois(
-        detected_rois, expect_rois_shifted_map, total_max_iou, total_max_iou_rois_map);
-
-      if (total_max_iou > final_iou) {
-        final_iou = total_max_iou;
-        final_rois_map = std::move(total_max_iou_rois_map);
-      }
-    }
-  }
-
-  // assign max iou roi to output
-  TrafficLightRoiArray output;
-  output.header = detected_traffic_light_msg->header;
-  for (const auto & expected_rois_msg_rois : expected_rois_msg->rois) {
-    const auto traffic_light_id = expected_rois_msg_rois.traffic_light_id;
-    const auto traffic_light_type = expected_rois_msg_rois.traffic_light_type;
-    TrafficLightRoi traffic_light_roi;
-
-    if (final_rois_map.find(traffic_light_id) != final_rois_map.end()) {
-      traffic_light_roi.traffic_light_id = traffic_light_id;
-      traffic_light_roi.traffic_light_type = traffic_light_type;
-      traffic_light_roi.roi = final_rois_map[traffic_light_id];
-      output.rois.push_back(traffic_light_roi);
-    } else {
-      traffic_light_roi.traffic_light_id = traffic_light_id;
-      traffic_light_roi.traffic_light_type = traffic_light_type;
-      output.rois.push_back(traffic_light_roi);
-    }
-  }
+  const auto output = selector_.select(
+    *detected_traffic_light_msg, *rough_rois_msg, *expected_rois_msg, camera_info_msg->width,
+    camera_info_msg->height);
 
   pub_traffic_light_rois_->publish(output);
 
@@ -143,26 +73,6 @@ void TrafficLightSelectorNode::objectsCallback(
       "debug/processing_time_ms", processing_time_ms);
     debug_publisher_->publish<autoware_internal_debug_msgs::msg::Float64Stamped>(
       "debug/pipeline_latency_ms", pipeline_latency_ms);
-  }
-}
-
-void TrafficLightSelectorNode::evaluateWholeRois(
-  const std::vector<RegionOfInterest> & detected_rois,
-  const std::map<int64_t, RegionOfInterest> & expect_rois_shifted_map, double & total_max_iou,
-  std::map<int64_t, RegionOfInterest> & total_max_iou_rois_map)
-{
-  for (const auto & expect_roi_shifted : expect_rois_shifted_map) {
-    double max_iou = 0.0;
-    RegionOfInterest max_iou_roi;
-    for (const auto & detected_roi : detected_rois) {
-      const double iou = utils::getGenIoU(expect_roi_shifted.second, detected_roi);
-      if (iou > max_iou) {
-        max_iou = iou;
-        max_iou_roi = detected_roi;
-      }
-    }
-    total_max_iou += max_iou;
-    total_max_iou_rois_map[expect_roi_shifted.first] = max_iou_roi;
   }
 }
 

--- a/perception/autoware_traffic_light_selector/src/traffic_light_selector_node.hpp
+++ b/perception/autoware_traffic_light_selector/src/traffic_light_selector_node.hpp
@@ -16,32 +16,24 @@
 #define TRAFFIC_LIGHT_SELECTOR_NODE_HPP_
 
 #include "traffic_light_selector.hpp"
-#include "traffic_light_selector_utils.hpp"
 
 #include <autoware_utils/ros/debug_publisher.hpp>
 #include <autoware_utils/system/stop_watch.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include <sensor_msgs/msg/camera_info.hpp>
-#include <tier4_perception_msgs/msg/detected_object_with_feature.hpp>
 #include <tier4_perception_msgs/msg/detected_objects_with_feature.hpp>
-#include <tier4_perception_msgs/msg/traffic_light_roi.hpp>
 #include <tier4_perception_msgs/msg/traffic_light_roi_array.hpp>
 
 #include <message_filters/subscriber.h>
 #include <message_filters/sync_policies/approximate_time.h>
 #include <message_filters/synchronizer.h>
 
-#include <map>
 #include <memory>
-#include <vector>
 
 namespace autoware::traffic_light
 {
-using sensor_msgs::msg::RegionOfInterest;
 using tier4_perception_msgs::msg::DetectedObjectsWithFeature;
-using tier4_perception_msgs::msg::DetectedObjectWithFeature;
-using tier4_perception_msgs::msg::TrafficLightRoi;
 using tier4_perception_msgs::msg::TrafficLightRoiArray;
 
 class TrafficLightSelectorNode : public rclcpp::Node

--- a/perception/autoware_traffic_light_selector/src/traffic_light_selector_node.hpp
+++ b/perception/autoware_traffic_light_selector/src/traffic_light_selector_node.hpp
@@ -15,6 +15,7 @@
 #ifndef TRAFFIC_LIGHT_SELECTOR_NODE_HPP_
 #define TRAFFIC_LIGHT_SELECTOR_NODE_HPP_
 
+#include "traffic_light_selector.hpp"
 #include "traffic_light_selector_utils.hpp"
 
 #include <autoware_utils/ros/debug_publisher.hpp>
@@ -66,16 +67,13 @@ private:
   std::unique_ptr<autoware_utils::StopWatch<std::chrono::milliseconds>> stop_watch_ptr_;
   std::unique_ptr<autoware_utils::DebugPublisher> debug_publisher_;
 
+  TrafficLightSelector selector_;
+
   void objectsCallback(
     const DetectedObjectsWithFeature::ConstSharedPtr & detected_rois_msg,
     const TrafficLightRoiArray::ConstSharedPtr & rough_rois_msg,
     const TrafficLightRoiArray::ConstSharedPtr & expect_rois_msg,
     const sensor_msgs::msg::CameraInfo::ConstSharedPtr & camera_info_msg);
-
-  void evaluateWholeRois(
-    const std::vector<RegionOfInterest> & detected_rois,
-    const std::map<int64_t, RegionOfInterest> & expect_rois_shifted_map, double & total_max_iou,
-    std::map<int64_t, RegionOfInterest> & total_max_iou_rois_map);
 };
 
 }  // namespace autoware::traffic_light

--- a/perception/autoware_traffic_light_selector/src/traffic_light_selector_node.hpp
+++ b/perception/autoware_traffic_light_selector/src/traffic_light_selector_node.hpp
@@ -67,8 +67,6 @@ private:
   std::unique_ptr<autoware_utils::StopWatch<std::chrono::milliseconds>> stop_watch_ptr_;
   std::unique_ptr<autoware_utils::DebugPublisher> debug_publisher_;
 
-  TrafficLightSelector selector_;
-
   void objectsCallback(
     const DetectedObjectsWithFeature::ConstSharedPtr & detected_rois_msg,
     const TrafficLightRoiArray::ConstSharedPtr & rough_rois_msg,

--- a/perception/autoware_traffic_light_selector/test/test_traffic_light_selector.cpp
+++ b/perception/autoware_traffic_light_selector/test/test_traffic_light_selector.cpp
@@ -39,10 +39,19 @@ RegionOfInterest make_roi(uint32_t x_offset, uint32_t y_offset, uint32_t width, 
   return roi;
 }
 
-bool is_same(const RegionOfInterest & lhs, const RegionOfInterest & rhs)
+void expect_same(const TrafficLightRoiArray & output, const TrafficLightRoiArray & expected_output)
 {
-  return lhs.x_offset == rhs.x_offset && lhs.y_offset == rhs.y_offset && lhs.width == rhs.width &&
-         lhs.height == rhs.height;
+  ASSERT_EQ(output.rois.size(), expected_output.rois.size());
+  for (size_t roi_index = 0; roi_index < output.rois.size(); ++roi_index) {
+    const auto & output_roi = output.rois.at(roi_index);
+    const auto & expected_roi = expected_output.rois.at(roi_index);
+    EXPECT_EQ(output_roi.traffic_light_id, expected_roi.traffic_light_id);
+    EXPECT_EQ(output_roi.traffic_light_type, expected_roi.traffic_light_type);
+    EXPECT_EQ(output_roi.roi.x_offset, expected_roi.roi.x_offset);
+    EXPECT_EQ(output_roi.roi.y_offset, expected_roi.roi.y_offset);
+    EXPECT_EQ(output_roi.roi.width, expected_roi.roi.width);
+    EXPECT_EQ(output_roi.roi.height, expected_roi.roi.height);
+  }
 }
 
 CameraInfo make_camera_info(uint32_t width, uint32_t height)
@@ -97,7 +106,7 @@ TEST(TrafficLightSelector, EmptyInputsProduceEmptyOutput)
   const auto output = select(detected_rois, rough_rois, expected_rois, camera_info);
 
   // Assert
-  EXPECT_TRUE(output.rois.empty());
+  expect_same(output, make_traffic_light_roi_array({}));
 }
 
 // Every expected ROI yields exactly one output entry. With no detections it cannot be matched, so
@@ -116,9 +125,9 @@ TEST(TrafficLightSelector, ExpectedRoiWithoutDetectionsOutputsDefaultRoi)
   const auto output = select(detected_rois, rough_rois, expected_rois, camera_info);
 
   // Assert
-  ASSERT_EQ(output.rois.size(), 1u);
-  EXPECT_EQ(output.rois.front().traffic_light_id, traffic_light_id);
-  EXPECT_TRUE(is_same(output.rois.front().roi, RegionOfInterest{}));
+  expect_same(
+    output,
+    make_traffic_light_roi_array({make_traffic_light_roi(traffic_light_id, RegionOfInterest{})}));
 }
 
 // The detected ROI center lies outside the rough ROI, so it is never considered as a match and the
@@ -143,9 +152,9 @@ TEST(TrafficLightSelector, DetectionCenterOutsideRoughRoiOutputsDefaultRoi)
   const auto output = select(detected_rois, rough_rois, expected_rois, camera_info);
 
   // Assert
-  ASSERT_EQ(output.rois.size(), 1u);
-  EXPECT_EQ(output.rois.front().traffic_light_id, traffic_light_id);
-  EXPECT_TRUE(is_same(output.rois.front().roi, RegionOfInterest{}));
+  expect_same(
+    output,
+    make_traffic_light_roi_array({make_traffic_light_roi(traffic_light_id, RegionOfInterest{})}));
 }
 
 // The detected ROI center is inside the rough ROI and overlaps the expected ROI. The expected ROI
@@ -170,9 +179,8 @@ TEST(TrafficLightSelector, DetectionInsideRoughRoiAssignsDetectedRoi)
   const auto output = select(detected_rois, rough_rois, expected_rois, camera_info);
 
   // Assert
-  ASSERT_EQ(output.rois.size(), 1u);
-  EXPECT_EQ(output.rois.front().traffic_light_id, traffic_light_id);
-  EXPECT_TRUE(is_same(output.rois.front().roi, detected_roi));
+  expect_same(
+    output, make_traffic_light_roi_array({make_traffic_light_roi(traffic_light_id, detected_roi)}));
 }
 
 // The traffic_light_type of each expected ROI must be copied verbatim onto the output entry.
@@ -193,8 +201,9 @@ TEST(TrafficLightSelector, TrafficLightTypePropagatedToOutput)
   const auto output = select(detected_rois, rough_rois, expected_rois, camera_info);
 
   // Assert
-  ASSERT_EQ(output.rois.size(), 1u);
-  EXPECT_EQ(output.rois.front().traffic_light_type, TrafficLightRoi::PEDESTRIAN_TRAFFIC_LIGHT);
+  expect_same(
+    output, make_traffic_light_roi_array({make_traffic_light_roi(
+              traffic_light_id, roi, TrafficLightRoi::PEDESTRIAN_TRAFFIC_LIGHT)}));
 }
 
 // When multiple detections sit inside the rough ROI, the one with the highest IoU against the
@@ -220,8 +229,9 @@ TEST(TrafficLightSelector, BestOverlappingDetectionIsSelected)
   const auto output = select(detected_rois, rough_rois, expected_rois, camera_info);
 
   // Assert
-  ASSERT_EQ(output.rois.size(), 1u);
-  EXPECT_TRUE(is_same(output.rois.front().roi, detected_roi_perfect));
+  expect_same(
+    output,
+    make_traffic_light_roi_array({make_traffic_light_roi(traffic_light_id, detected_roi_perfect)}));
 }
 
 // Shifting the expected ROI onto the detection pushes it outside the (small) image, so
@@ -246,8 +256,9 @@ TEST(TrafficLightSelector, ShiftedRoiOutOfImageBoundsOutputsDefaultRoi)
   const auto output = select(detected_rois, rough_rois, expected_rois, camera_info);
 
   // Assert
-  ASSERT_EQ(output.rois.size(), 1u);
-  EXPECT_TRUE(is_same(output.rois.front().roi, RegionOfInterest{}));
+  expect_same(
+    output,
+    make_traffic_light_roi_array({make_traffic_light_roi(traffic_light_id, RegionOfInterest{})}));
 }
 
 // Several expected traffic lights are matched independently; each gets its own detection assigned.
@@ -273,11 +284,10 @@ TEST(TrafficLightSelector, MultipleExpectedRoisEachAssigned)
   const auto output = select(detected_rois, rough_rois, expected_rois, camera_info);
 
   // Assert
-  ASSERT_EQ(output.rois.size(), 2u);
-  EXPECT_EQ(output.rois.at(0).traffic_light_id, first_traffic_light_id);
-  EXPECT_TRUE(is_same(output.rois.at(0).roi, first_roi));
-  EXPECT_EQ(output.rois.at(1).traffic_light_id, second_traffic_light_id);
-  EXPECT_TRUE(is_same(output.rois.at(1).roi, second_roi));
+  expect_same(
+    output, make_traffic_light_roi_array(
+              {make_traffic_light_roi(first_traffic_light_id, first_roi),
+               make_traffic_light_roi(second_traffic_light_id, second_roi)}));
 }
 
 int main(int argc, char ** argv)

--- a/perception/autoware_traffic_light_selector/test/test_traffic_light_selector.cpp
+++ b/perception/autoware_traffic_light_selector/test/test_traffic_light_selector.cpp
@@ -143,11 +143,12 @@ TEST(TrafficLightSelector, DetectionCenterOutsideRoughRoiOutputsDefaultRoi)
   const auto expected_roi = make_traffic_light_roi(traffic_light_id, make_roi(100, 100, 40, 40));
   const auto rough_roi = make_traffic_light_roi(traffic_light_id, make_roi(50, 50, 200, 200));
   // Detected ROI center (820, 620) is far outside the rough ROI span (50..250).
-  const auto detected_roi = make_roi(800, 600, 40, 40);
+  const auto detected_roi_outside_rough_roi = make_roi(800, 600, 40, 40);
   const auto camera_info = make_camera_info(1280, 720);
 
   // Act
-  const auto output = select_helper({detected_roi}, {rough_roi}, {expected_roi}, camera_info);
+  const auto output =
+    select_helper({detected_roi_outside_rough_roi}, {rough_roi}, {expected_roi}, camera_info);
 
   // Assert
   expect_same(output, {make_traffic_light_roi(traffic_light_id, RegionOfInterest{})});
@@ -162,14 +163,15 @@ TEST(TrafficLightSelector, DetectionInsideRoughRoiAssignsDetectedRoi)
   const auto expected_roi = make_traffic_light_roi(traffic_light_id, make_roi(100, 100, 40, 40));
   const auto rough_roi = make_traffic_light_roi(traffic_light_id, make_roi(50, 50, 200, 200));
   // Detected ROI center (130, 125) is inside the rough ROI but offset from the expected ROI.
-  const auto detected_roi = make_roi(110, 105, 40, 40);
+  const auto detected_roi_inside_rough_roi = make_roi(110, 105, 40, 40);
   const auto camera_info = make_camera_info(1280, 720);
 
   // Act
-  const auto output = select_helper({detected_roi}, {rough_roi}, {expected_roi}, camera_info);
+  const auto output =
+    select_helper({detected_roi_inside_rough_roi}, {rough_roi}, {expected_roi}, camera_info);
 
   // Assert
-  expect_same(output, {make_traffic_light_roi(traffic_light_id, detected_roi)});
+  expect_same(output, {make_traffic_light_roi(traffic_light_id, detected_roi_inside_rough_roi)});
 }
 
 // The traffic_light_type of each expected ROI must be copied verbatim onto the output entry.
@@ -177,14 +179,15 @@ TEST(TrafficLightSelector, TrafficLightTypePropagatedToOutput)
 {
   // Arrange
   const int64_t traffic_light_id = 123;
-  const auto roi = make_roi(100, 100, 40, 40);
+  const auto detected_roi_matching_expected = make_roi(100, 100, 40, 40);
   const auto rough_roi = make_traffic_light_roi(traffic_light_id, make_roi(50, 50, 200, 200));
-  const auto expected_roi =
-    make_traffic_light_roi(traffic_light_id, roi, TrafficLightRoi::PEDESTRIAN_TRAFFIC_LIGHT);
+  const auto expected_roi = make_traffic_light_roi(
+    traffic_light_id, detected_roi_matching_expected, TrafficLightRoi::PEDESTRIAN_TRAFFIC_LIGHT);
   const auto camera_info = make_camera_info(1280, 720);
 
   // Act
-  const auto output = select_helper({roi}, {rough_roi}, {expected_roi}, camera_info);
+  const auto output =
+    select_helper({detected_roi_matching_expected}, {rough_roi}, {expected_roi}, camera_info);
 
   // Assert
   expect_same(output, {expected_roi});
@@ -218,14 +221,15 @@ TEST(TrafficLightSelector, ShiftedRoiOutOfImageBoundsOutputsDefaultRoi)
 {
   // Arrange
   const int64_t traffic_light_id = 123;
-  const auto roi = make_roi(100, 100, 40, 40);
+  const auto roi_outside_image_bounds = make_roi(100, 100, 40, 40);
   const auto rough_roi = make_traffic_light_roi(traffic_light_id, make_roi(0, 0, 200, 200));
-  const auto expected_roi = make_traffic_light_roi(traffic_light_id, roi);
+  const auto expected_roi = make_traffic_light_roi(traffic_light_id, roi_outside_image_bounds);
   // The ROI at (100, 100, 40, 40) does not fit inside a 50x50 image.
   const auto camera_info = make_camera_info(50, 50);
 
   // Act
-  const auto output = select_helper({roi}, {rough_roi}, {expected_roi}, camera_info);
+  const auto output =
+    select_helper({roi_outside_image_bounds}, {rough_roi}, {expected_roi}, camera_info);
 
   // Assert
   expect_same(output, {make_traffic_light_roi(traffic_light_id, RegionOfInterest{})});
@@ -239,9 +243,11 @@ TEST(TrafficLightSelector, MultipleExpectedRoisEachAssigned)
   const int64_t second_traffic_light_id = 2;
   const auto first_roi = make_roi(100, 100, 40, 40);
   const auto second_roi = make_roi(300, 100, 40, 40);
-  const auto rough_roi = make_roi(0, 0, 500, 500);
-  const auto first_rough_roi = make_traffic_light_roi(first_traffic_light_id, rough_roi);
-  const auto second_rough_roi = make_traffic_light_roi(second_traffic_light_id, rough_roi);
+  const auto common_rough_roi_area = make_roi(0, 0, 500, 500);
+  const auto first_rough_roi =
+    make_traffic_light_roi(first_traffic_light_id, common_rough_roi_area);
+  const auto second_rough_roi =
+    make_traffic_light_roi(second_traffic_light_id, common_rough_roi_area);
   const auto first_expected_roi = make_traffic_light_roi(first_traffic_light_id, first_roi);
   const auto second_expected_roi = make_traffic_light_roi(second_traffic_light_id, second_roi);
   const auto camera_info = make_camera_info(1280, 720);

--- a/perception/autoware_traffic_light_selector/test/test_traffic_light_selector.cpp
+++ b/perception/autoware_traffic_light_selector/test/test_traffic_light_selector.cpp
@@ -91,19 +91,26 @@ TrafficLightRoiArray make_traffic_light_roi_array(const std::vector<TrafficLight
   return traffic_light_roi_array;
 }
 
+TrafficLightRoiArray select_helper(
+  const std::vector<RegionOfInterest> & detected_rois,
+  const std::vector<TrafficLightRoi> & rough_rois,
+  const std::vector<TrafficLightRoi> & expected_rois, const CameraInfo & camera_info)
+{
+  return select(
+    make_detected_rois(detected_rois), make_traffic_light_roi_array(rough_rois),
+    make_traffic_light_roi_array(expected_rois), camera_info);
+}
+
 }  // namespace
 
 // With no expected ROIs the output loop produces nothing, so the result is an empty array.
 TEST(TrafficLightSelector, EmptyInputsProduceEmptyOutput)
 {
   // Arrange
-  const auto detected_rois = make_detected_rois({});
-  const auto rough_rois = make_traffic_light_roi_array({});
-  const auto expected_rois = make_traffic_light_roi_array({});
   const auto camera_info = make_camera_info(1280, 720);
 
   // Act
-  const auto output = select(detected_rois, rough_rois, expected_rois, camera_info);
+  const auto output = select_helper({}, {}, {}, camera_info);
 
   // Assert
   expect_same(output, make_traffic_light_roi_array({}));
@@ -115,14 +122,11 @@ TEST(TrafficLightSelector, ExpectedRoiWithoutDetectionsOutputsDefaultRoi)
 {
   // Arrange
   const int64_t traffic_light_id = 123;
-  const auto detected_rois = make_detected_rois({});
-  const auto rough_rois = make_traffic_light_roi_array({});
-  const auto expected_rois = make_traffic_light_roi_array(
-    {make_traffic_light_roi(traffic_light_id, make_roi(100, 100, 40, 40))});
+  const auto expected_roi = make_traffic_light_roi(traffic_light_id, make_roi(100, 100, 40, 40));
   const auto camera_info = make_camera_info(1280, 720);
 
   // Act
-  const auto output = select(detected_rois, rough_rois, expected_rois, camera_info);
+  const auto output = select_helper({}, {}, {expected_roi}, camera_info);
 
   // Assert
   expect_same(
@@ -136,20 +140,14 @@ TEST(TrafficLightSelector, DetectionCenterOutsideRoughRoiOutputsDefaultRoi)
 {
   // Arrange
   const int64_t traffic_light_id = 123;
-  const auto expected_roi = make_roi(100, 100, 40, 40);
-  const auto rough_roi = make_roi(50, 50, 200, 200);
+  const auto expected_roi = make_traffic_light_roi(traffic_light_id, make_roi(100, 100, 40, 40));
+  const auto rough_roi = make_traffic_light_roi(traffic_light_id, make_roi(50, 50, 200, 200));
   // Detected ROI center (820, 620) is far outside the rough ROI span (50..250).
   const auto detected_roi = make_roi(800, 600, 40, 40);
-
-  const auto detected_rois = make_detected_rois({detected_roi});
-  const auto rough_rois =
-    make_traffic_light_roi_array({make_traffic_light_roi(traffic_light_id, rough_roi)});
-  const auto expected_rois =
-    make_traffic_light_roi_array({make_traffic_light_roi(traffic_light_id, expected_roi)});
   const auto camera_info = make_camera_info(1280, 720);
 
   // Act
-  const auto output = select(detected_rois, rough_rois, expected_rois, camera_info);
+  const auto output = select_helper({detected_roi}, {rough_roi}, {expected_roi}, camera_info);
 
   // Assert
   expect_same(
@@ -163,20 +161,14 @@ TEST(TrafficLightSelector, DetectionInsideRoughRoiAssignsDetectedRoi)
 {
   // Arrange
   const int64_t traffic_light_id = 123;
-  const auto expected_roi = make_roi(100, 100, 40, 40);
-  const auto rough_roi = make_roi(50, 50, 200, 200);
+  const auto expected_roi = make_traffic_light_roi(traffic_light_id, make_roi(100, 100, 40, 40));
+  const auto rough_roi = make_traffic_light_roi(traffic_light_id, make_roi(50, 50, 200, 200));
   // Detected ROI center (130, 125) is inside the rough ROI but offset from the expected ROI.
   const auto detected_roi = make_roi(110, 105, 40, 40);
-
-  const auto detected_rois = make_detected_rois({detected_roi});
-  const auto rough_rois =
-    make_traffic_light_roi_array({make_traffic_light_roi(traffic_light_id, rough_roi)});
-  const auto expected_rois =
-    make_traffic_light_roi_array({make_traffic_light_roi(traffic_light_id, expected_roi)});
   const auto camera_info = make_camera_info(1280, 720);
 
   // Act
-  const auto output = select(detected_rois, rough_rois, expected_rois, camera_info);
+  const auto output = select_helper({detected_roi}, {rough_roi}, {expected_roi}, camera_info);
 
   // Assert
   expect_same(
@@ -189,21 +181,16 @@ TEST(TrafficLightSelector, TrafficLightTypePropagatedToOutput)
   // Arrange
   const int64_t traffic_light_id = 123;
   const auto roi = make_roi(100, 100, 40, 40);
-
-  const auto detected_rois = make_detected_rois({roi});
-  const auto rough_rois = make_traffic_light_roi_array(
-    {make_traffic_light_roi(traffic_light_id, make_roi(50, 50, 200, 200))});
-  const auto expected_rois = make_traffic_light_roi_array(
-    {make_traffic_light_roi(traffic_light_id, roi, TrafficLightRoi::PEDESTRIAN_TRAFFIC_LIGHT)});
+  const auto rough_roi = make_traffic_light_roi(traffic_light_id, make_roi(50, 50, 200, 200));
+  const auto expected_roi =
+    make_traffic_light_roi(traffic_light_id, roi, TrafficLightRoi::PEDESTRIAN_TRAFFIC_LIGHT);
   const auto camera_info = make_camera_info(1280, 720);
 
   // Act
-  const auto output = select(detected_rois, rough_rois, expected_rois, camera_info);
+  const auto output = select_helper({roi}, {rough_roi}, {expected_roi}, camera_info);
 
   // Assert
-  expect_same(
-    output, make_traffic_light_roi_array({make_traffic_light_roi(
-              traffic_light_id, roi, TrafficLightRoi::PEDESTRIAN_TRAFFIC_LIGHT)}));
+  expect_same(output, make_traffic_light_roi_array({expected_roi}));
 }
 
 // When multiple detections sit inside the rough ROI, the one with the highest IoU against the
@@ -212,21 +199,16 @@ TEST(TrafficLightSelector, BestOverlappingDetectionIsSelected)
 {
   // Arrange
   const int64_t traffic_light_id = 123;
-  const auto expected_roi = make_roi(100, 100, 40, 40);
-  const auto rough_roi = make_roi(50, 50, 200, 200);
+  const auto expected_roi = make_traffic_light_roi(traffic_light_id, make_roi(100, 100, 40, 40));
+  const auto rough_roi = make_traffic_light_roi(traffic_light_id, make_roi(50, 50, 200, 200));
   // Detection A perfectly overlaps the expected ROI; detection B only partially overlaps.
   const auto detected_roi_perfect = make_roi(100, 100, 40, 40);
   const auto detected_roi_partial = make_roi(200, 200, 10, 10);
-
-  const auto detected_rois = make_detected_rois({detected_roi_perfect, detected_roi_partial});
-  const auto rough_rois =
-    make_traffic_light_roi_array({make_traffic_light_roi(traffic_light_id, rough_roi)});
-  const auto expected_rois =
-    make_traffic_light_roi_array({make_traffic_light_roi(traffic_light_id, expected_roi)});
   const auto camera_info = make_camera_info(1280, 720);
 
   // Act
-  const auto output = select(detected_rois, rough_rois, expected_rois, camera_info);
+  const auto output = select_helper(
+    {detected_roi_perfect, detected_roi_partial}, {rough_roi}, {expected_roi}, camera_info);
 
   // Assert
   expect_same(
@@ -242,18 +224,13 @@ TEST(TrafficLightSelector, ShiftedRoiOutOfImageBoundsOutputsDefaultRoi)
   // Arrange
   const int64_t traffic_light_id = 123;
   const auto roi = make_roi(100, 100, 40, 40);
-  const auto rough_roi = make_roi(0, 0, 200, 200);
-
-  const auto detected_rois = make_detected_rois({roi});
-  const auto rough_rois =
-    make_traffic_light_roi_array({make_traffic_light_roi(traffic_light_id, rough_roi)});
-  const auto expected_rois =
-    make_traffic_light_roi_array({make_traffic_light_roi(traffic_light_id, roi)});
+  const auto rough_roi = make_traffic_light_roi(traffic_light_id, make_roi(0, 0, 200, 200));
+  const auto expected_roi = make_traffic_light_roi(traffic_light_id, roi);
   // The ROI at (100, 100, 40, 40) does not fit inside a 50x50 image.
   const auto camera_info = make_camera_info(50, 50);
 
   // Act
-  const auto output = select(detected_rois, rough_rois, expected_rois, camera_info);
+  const auto output = select_helper({roi}, {rough_roi}, {expected_roi}, camera_info);
 
   // Assert
   expect_same(
@@ -270,24 +247,19 @@ TEST(TrafficLightSelector, MultipleExpectedRoisEachAssigned)
   const auto first_roi = make_roi(100, 100, 40, 40);
   const auto second_roi = make_roi(300, 100, 40, 40);
   const auto rough_roi = make_roi(0, 0, 500, 500);
-
-  const auto detected_rois = make_detected_rois({first_roi, second_roi});
-  const auto rough_rois = make_traffic_light_roi_array(
-    {make_traffic_light_roi(first_traffic_light_id, rough_roi),
-     make_traffic_light_roi(second_traffic_light_id, rough_roi)});
-  const auto expected_rois = make_traffic_light_roi_array(
-    {make_traffic_light_roi(first_traffic_light_id, first_roi),
-     make_traffic_light_roi(second_traffic_light_id, second_roi)});
+  const auto first_rough_roi = make_traffic_light_roi(first_traffic_light_id, rough_roi);
+  const auto second_rough_roi = make_traffic_light_roi(second_traffic_light_id, rough_roi);
+  const auto first_expected_roi = make_traffic_light_roi(first_traffic_light_id, first_roi);
+  const auto second_expected_roi = make_traffic_light_roi(second_traffic_light_id, second_roi);
   const auto camera_info = make_camera_info(1280, 720);
 
   // Act
-  const auto output = select(detected_rois, rough_rois, expected_rois, camera_info);
+  const auto output = select_helper(
+    {first_roi, second_roi}, {first_rough_roi, second_rough_roi},
+    {first_expected_roi, second_expected_roi}, camera_info);
 
   // Assert
-  expect_same(
-    output, make_traffic_light_roi_array(
-              {make_traffic_light_roi(first_traffic_light_id, first_roi),
-               make_traffic_light_roi(second_traffic_light_id, second_roi)}));
+  expect_same(output, make_traffic_light_roi_array({first_expected_roi, second_expected_roi}));
 }
 
 int main(int argc, char ** argv)

--- a/perception/autoware_traffic_light_selector/test/test_traffic_light_selector.cpp
+++ b/perception/autoware_traffic_light_selector/test/test_traffic_light_selector.cpp
@@ -1,0 +1,294 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "../src/traffic_light_selector.hpp"
+
+#include <gtest/gtest.h>
+
+#include <vector>
+
+using autoware::traffic_light::TrafficLightSelector;
+using sensor_msgs::msg::CameraInfo;
+using sensor_msgs::msg::RegionOfInterest;
+using tier4_perception_msgs::msg::DetectedObjectsWithFeature;
+using tier4_perception_msgs::msg::DetectedObjectWithFeature;
+using tier4_perception_msgs::msg::TrafficLightRoi;
+using tier4_perception_msgs::msg::TrafficLightRoiArray;
+
+namespace
+{
+
+RegionOfInterest make_roi(uint32_t x_offset, uint32_t y_offset, uint32_t width, uint32_t height)
+{
+  RegionOfInterest roi;
+  roi.x_offset = x_offset;
+  roi.y_offset = y_offset;
+  roi.width = width;
+  roi.height = height;
+  return roi;
+}
+
+bool is_same(const RegionOfInterest & lhs, const RegionOfInterest & rhs)
+{
+  return lhs.x_offset == rhs.x_offset && lhs.y_offset == rhs.y_offset && lhs.width == rhs.width &&
+         lhs.height == rhs.height;
+}
+
+CameraInfo make_camera_info(uint32_t width, uint32_t height)
+{
+  CameraInfo camera_info;
+  camera_info.width = width;
+  camera_info.height = height;
+  return camera_info;
+}
+
+DetectedObjectsWithFeature make_detected_rois(const std::vector<RegionOfInterest> & rois)
+{
+  DetectedObjectsWithFeature detected_rois;
+  for (const auto & roi : rois) {
+    DetectedObjectWithFeature feature_object;
+    feature_object.feature.roi = roi;
+    detected_rois.feature_objects.push_back(feature_object);
+  }
+  return detected_rois;
+}
+
+TrafficLightRoi make_traffic_light_roi(
+  int64_t traffic_light_id, const RegionOfInterest & roi,
+  uint8_t traffic_light_type = TrafficLightRoi::CAR_TRAFFIC_LIGHT)
+{
+  TrafficLightRoi traffic_light_roi;
+  traffic_light_roi.traffic_light_id = traffic_light_id;
+  traffic_light_roi.traffic_light_type = traffic_light_type;
+  traffic_light_roi.roi = roi;
+  return traffic_light_roi;
+}
+
+TrafficLightRoiArray make_traffic_light_roi_array(const std::vector<TrafficLightRoi> & rois)
+{
+  TrafficLightRoiArray traffic_light_roi_array;
+  traffic_light_roi_array.rois = rois;
+  return traffic_light_roi_array;
+}
+
+}  // namespace
+
+// With no expected ROIs the output loop produces nothing, so the result is an empty array.
+TEST(TrafficLightSelector, EmptyInputsProduceEmptyOutput)
+{
+  // Arrange
+  const TrafficLightSelector selector;
+  const auto detected_rois = make_detected_rois({});
+  const auto rough_rois = make_traffic_light_roi_array({});
+  const auto expected_rois = make_traffic_light_roi_array({});
+  const auto camera_info = make_camera_info(1280, 720);
+
+  // Act
+  const auto output = selector.select(detected_rois, rough_rois, expected_rois, camera_info);
+
+  // Assert
+  EXPECT_TRUE(output.rois.empty());
+}
+
+// Every expected ROI yields exactly one output entry. With no detections it cannot be matched, so
+// the entry carries the expected ID with a default (empty) ROI.
+TEST(TrafficLightSelector, ExpectedRoiWithoutDetectionsOutputsDefaultRoi)
+{
+  // Arrange
+  const TrafficLightSelector selector;
+  const int64_t traffic_light_id = 123;
+  const auto detected_rois = make_detected_rois({});
+  const auto rough_rois = make_traffic_light_roi_array({});
+  const auto expected_rois =
+    make_traffic_light_roi_array({make_traffic_light_roi(traffic_light_id, make_roi(100, 100, 40, 40))});
+  const auto camera_info = make_camera_info(1280, 720);
+
+  // Act
+  const auto output = selector.select(detected_rois, rough_rois, expected_rois, camera_info);
+
+  // Assert
+  ASSERT_EQ(output.rois.size(), 1u);
+  EXPECT_EQ(output.rois.front().traffic_light_id, traffic_light_id);
+  EXPECT_TRUE(is_same(output.rois.front().roi, RegionOfInterest{}));
+}
+
+// The detected ROI center lies outside the rough ROI, so it is never considered as a match and the
+// output entry falls back to a default ROI.
+TEST(TrafficLightSelector, DetectionCenterOutsideRoughRoiOutputsDefaultRoi)
+{
+  // Arrange
+  const TrafficLightSelector selector;
+  const int64_t traffic_light_id = 123;
+  const auto expected_roi = make_roi(100, 100, 40, 40);
+  const auto rough_roi = make_roi(50, 50, 200, 200);
+  // Detected ROI center (820, 620) is far outside the rough ROI span (50..250).
+  const auto detected_roi = make_roi(800, 600, 40, 40);
+
+  const auto detected_rois = make_detected_rois({detected_roi});
+  const auto rough_rois =
+    make_traffic_light_roi_array({make_traffic_light_roi(traffic_light_id, rough_roi)});
+  const auto expected_rois =
+    make_traffic_light_roi_array({make_traffic_light_roi(traffic_light_id, expected_roi)});
+  const auto camera_info = make_camera_info(1280, 720);
+
+  // Act
+  const auto output = selector.select(detected_rois, rough_rois, expected_rois, camera_info);
+
+  // Assert
+  ASSERT_EQ(output.rois.size(), 1u);
+  EXPECT_EQ(output.rois.front().traffic_light_id, traffic_light_id);
+  EXPECT_TRUE(is_same(output.rois.front().roi, RegionOfInterest{}));
+}
+
+// The detected ROI center is inside the rough ROI and overlaps the expected ROI. The expected ROI
+// is shifted onto the detection, so the detected ROI (not the expected one) is assigned to output.
+TEST(TrafficLightSelector, DetectionInsideRoughRoiAssignsDetectedRoi)
+{
+  // Arrange
+  const TrafficLightSelector selector;
+  const int64_t traffic_light_id = 123;
+  const auto expected_roi = make_roi(100, 100, 40, 40);
+  const auto rough_roi = make_roi(50, 50, 200, 200);
+  // Detected ROI center (130, 125) is inside the rough ROI but offset from the expected ROI.
+  const auto detected_roi = make_roi(110, 105, 40, 40);
+
+  const auto detected_rois = make_detected_rois({detected_roi});
+  const auto rough_rois =
+    make_traffic_light_roi_array({make_traffic_light_roi(traffic_light_id, rough_roi)});
+  const auto expected_rois =
+    make_traffic_light_roi_array({make_traffic_light_roi(traffic_light_id, expected_roi)});
+  const auto camera_info = make_camera_info(1280, 720);
+
+  // Act
+  const auto output = selector.select(detected_rois, rough_rois, expected_rois, camera_info);
+
+  // Assert
+  ASSERT_EQ(output.rois.size(), 1u);
+  EXPECT_EQ(output.rois.front().traffic_light_id, traffic_light_id);
+  EXPECT_TRUE(is_same(output.rois.front().roi, detected_roi));
+}
+
+// The traffic_light_type of each expected ROI must be copied verbatim onto the output entry.
+TEST(TrafficLightSelector, TrafficLightTypePropagatedToOutput)
+{
+  // Arrange
+  const TrafficLightSelector selector;
+  const int64_t traffic_light_id = 123;
+  const auto roi = make_roi(100, 100, 40, 40);
+
+  const auto detected_rois = make_detected_rois({roi});
+  const auto rough_rois = make_traffic_light_roi_array(
+    {make_traffic_light_roi(traffic_light_id, make_roi(50, 50, 200, 200))});
+  const auto expected_rois = make_traffic_light_roi_array(
+    {make_traffic_light_roi(traffic_light_id, roi, TrafficLightRoi::PEDESTRIAN_TRAFFIC_LIGHT)});
+  const auto camera_info = make_camera_info(1280, 720);
+
+  // Act
+  const auto output = selector.select(detected_rois, rough_rois, expected_rois, camera_info);
+
+  // Assert
+  ASSERT_EQ(output.rois.size(), 1u);
+  EXPECT_EQ(output.rois.front().traffic_light_type, TrafficLightRoi::PEDESTRIAN_TRAFFIC_LIGHT);
+}
+
+// When multiple detections sit inside the rough ROI, the one with the highest IoU against the
+// (shifted) expected ROI is selected.
+TEST(TrafficLightSelector, BestOverlappingDetectionIsSelected)
+{
+  // Arrange
+  const TrafficLightSelector selector;
+  const int64_t traffic_light_id = 123;
+  const auto expected_roi = make_roi(100, 100, 40, 40);
+  const auto rough_roi = make_roi(50, 50, 200, 200);
+  // Detection A perfectly overlaps the expected ROI; detection B only partially overlaps.
+  const auto detected_roi_perfect = make_roi(100, 100, 40, 40);
+  const auto detected_roi_partial = make_roi(200, 200, 10, 10);
+
+  const auto detected_rois = make_detected_rois({detected_roi_perfect, detected_roi_partial});
+  const auto rough_rois =
+    make_traffic_light_roi_array({make_traffic_light_roi(traffic_light_id, rough_roi)});
+  const auto expected_rois =
+    make_traffic_light_roi_array({make_traffic_light_roi(traffic_light_id, expected_roi)});
+  const auto camera_info = make_camera_info(1280, 720);
+
+  // Act
+  const auto output = selector.select(detected_rois, rough_rois, expected_rois, camera_info);
+
+  // Assert
+  ASSERT_EQ(output.rois.size(), 1u);
+  EXPECT_TRUE(is_same(output.rois.front().roi, detected_roi_perfect));
+}
+
+// Shifting the expected ROI onto the detection pushes it outside the (small) image, so getShiftedRoi
+// clamps it to an empty ROI, no positive IoU accumulates, and the output falls back to a default ROI.
+TEST(TrafficLightSelector, ShiftedRoiOutOfImageBoundsOutputsDefaultRoi)
+{
+  // Arrange
+  const TrafficLightSelector selector;
+  const int64_t traffic_light_id = 123;
+  const auto roi = make_roi(100, 100, 40, 40);
+  const auto rough_roi = make_roi(0, 0, 200, 200);
+
+  const auto detected_rois = make_detected_rois({roi});
+  const auto rough_rois =
+    make_traffic_light_roi_array({make_traffic_light_roi(traffic_light_id, rough_roi)});
+  const auto expected_rois =
+    make_traffic_light_roi_array({make_traffic_light_roi(traffic_light_id, roi)});
+  // The ROI at (100, 100, 40, 40) does not fit inside a 50x50 image.
+  const auto camera_info = make_camera_info(50, 50);
+
+  // Act
+  const auto output = selector.select(detected_rois, rough_rois, expected_rois, camera_info);
+
+  // Assert
+  ASSERT_EQ(output.rois.size(), 1u);
+  EXPECT_TRUE(is_same(output.rois.front().roi, RegionOfInterest{}));
+}
+
+// Several expected traffic lights are matched independently; each gets its own detection assigned.
+TEST(TrafficLightSelector, MultipleExpectedRoisEachAssigned)
+{
+  // Arrange
+  const TrafficLightSelector selector;
+  const int64_t first_traffic_light_id = 1;
+  const int64_t second_traffic_light_id = 2;
+  const auto first_roi = make_roi(100, 100, 40, 40);
+  const auto second_roi = make_roi(300, 100, 40, 40);
+  const auto rough_roi = make_roi(0, 0, 500, 500);
+
+  const auto detected_rois = make_detected_rois({first_roi, second_roi});
+  const auto rough_rois = make_traffic_light_roi_array(
+    {make_traffic_light_roi(first_traffic_light_id, rough_roi),
+     make_traffic_light_roi(second_traffic_light_id, rough_roi)});
+  const auto expected_rois = make_traffic_light_roi_array(
+    {make_traffic_light_roi(first_traffic_light_id, first_roi),
+     make_traffic_light_roi(second_traffic_light_id, second_roi)});
+  const auto camera_info = make_camera_info(1280, 720);
+
+  // Act
+  const auto output = selector.select(detected_rois, rough_rois, expected_rois, camera_info);
+
+  // Assert
+  ASSERT_EQ(output.rois.size(), 2u);
+  EXPECT_EQ(output.rois.at(0).traffic_light_id, first_traffic_light_id);
+  EXPECT_TRUE(is_same(output.rois.at(0).roi, first_roi));
+  EXPECT_EQ(output.rois.at(1).traffic_light_id, second_traffic_light_id);
+  EXPECT_TRUE(is_same(output.rois.at(1).roi, second_roi));
+}
+
+int main(int argc, char ** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/perception/autoware_traffic_light_selector/test/test_traffic_light_selector.cpp
+++ b/perception/autoware_traffic_light_selector/test/test_traffic_light_selector.cpp
@@ -186,25 +186,6 @@ TEST(TrafficLightSelector, DetectionInsideRoughRoiAssignsDetectedRoi)
     output, {make_car_traffic_light_roi(traffic_light_id, detected_roi_inside_rough_roi)});
 }
 
-// The traffic_light_type of each expected ROI must be copied verbatim onto the output entry.
-TEST(TrafficLightSelector, TrafficLightTypePropagatedToOutput)
-{
-  // Arrange
-  const int64_t traffic_light_id = 123;
-  const auto detected_roi_matching_expected = make_roi(100, 100, 40, 40);
-  const auto rough_roi = make_car_traffic_light_roi(traffic_light_id, make_roi(50, 50, 200, 200));
-  const auto expected_roi =
-    make_pedestrian_traffic_light_roi(traffic_light_id, detected_roi_matching_expected);
-  const auto camera_info = make_camera_info(1280, 720);
-
-  // Act
-  const auto output =
-    select_helper({detected_roi_matching_expected}, {rough_roi}, {expected_roi}, camera_info);
-
-  // Assert
-  expect_same(output, {expected_roi});
-}
-
 // When multiple detections sit inside the rough ROI, the one with the highest IoU against the
 // (shifted) expected ROI is selected.
 TEST(TrafficLightSelector, BestOverlappingDetectionIsSelected)

--- a/perception/autoware_traffic_light_selector/test/test_traffic_light_selector.cpp
+++ b/perception/autoware_traffic_light_selector/test/test_traffic_light_selector.cpp
@@ -230,29 +230,37 @@ TEST(TrafficLightSelector, ShiftedRoiOutOfImageBoundsOutputsDefaultRoi)
 }
 
 // Several expected traffic lights are matched independently; each gets its own detection assigned.
+// Detected ROIs are deliberately offset from the expected ones so the assertion can confirm the
+// output carries the matched detection, not the expected ROI passed through unchanged.
 TEST(TrafficLightSelector, MultipleExpectedRoisEachAssigned)
 {
   // Arrange
   const int64_t first_traffic_light_id = 1;
   const int64_t second_traffic_light_id = 2;
-  const auto first_roi = make_roi(100, 100, 40, 40);
-  const auto second_roi = make_roi(300, 100, 40, 40);
+  const auto first_expected = make_roi(100, 100, 40, 40);
+  const auto second_expected = make_roi(300, 100, 40, 40);
+  const auto first_detected = make_roi(105, 105, 40, 40);
+  const auto second_detected = make_roi(305, 105, 40, 40);
   const auto common_rough_roi_area = make_roi(0, 0, 500, 500);
   const auto first_rough_roi =
     make_car_traffic_light_roi(first_traffic_light_id, common_rough_roi_area);
   const auto second_rough_roi =
     make_car_traffic_light_roi(second_traffic_light_id, common_rough_roi_area);
-  const auto first_expected_roi = make_car_traffic_light_roi(first_traffic_light_id, first_roi);
-  const auto second_expected_roi = make_car_traffic_light_roi(second_traffic_light_id, second_roi);
+  const auto first_expected_roi =
+    make_car_traffic_light_roi(first_traffic_light_id, first_expected);
+  const auto second_expected_roi =
+    make_car_traffic_light_roi(second_traffic_light_id, second_expected);
   const auto camera_info = make_camera_info(1280, 720);
 
   // Act
   const auto output = select_helper(
-    {first_roi, second_roi}, {first_rough_roi, second_rough_roi},
+    {first_detected, second_detected}, {first_rough_roi, second_rough_roi},
     {first_expected_roi, second_expected_roi}, camera_info);
 
   // Assert
-  expect_same(output, {first_expected_roi, second_expected_roi});
+  expect_same(
+    output, {make_car_traffic_light_roi(first_traffic_light_id, first_detected),
+             make_car_traffic_light_roi(second_traffic_light_id, second_detected)});
 }
 
 int main(int argc, char ** argv)

--- a/perception/autoware_traffic_light_selector/test/test_traffic_light_selector.cpp
+++ b/perception/autoware_traffic_light_selector/test/test_traffic_light_selector.cpp
@@ -39,12 +39,13 @@ RegionOfInterest make_roi(uint32_t x_offset, uint32_t y_offset, uint32_t width, 
   return roi;
 }
 
-void expect_same(const TrafficLightRoiArray & output, const TrafficLightRoiArray & expected_output)
+void expect_same(
+  const std::vector<TrafficLightRoi> & output, const std::vector<TrafficLightRoi> & expected_output)
 {
-  ASSERT_EQ(output.rois.size(), expected_output.rois.size());
-  for (size_t roi_index = 0; roi_index < output.rois.size(); ++roi_index) {
-    const auto & output_roi = output.rois.at(roi_index);
-    const auto & expected_roi = expected_output.rois.at(roi_index);
+  ASSERT_EQ(output.size(), expected_output.size());
+  for (size_t roi_index = 0; roi_index < output.size(); ++roi_index) {
+    const auto & output_roi = output.at(roi_index);
+    const auto & expected_roi = expected_output.at(roi_index);
     EXPECT_EQ(output_roi.traffic_light_id, expected_roi.traffic_light_id);
     EXPECT_EQ(output_roi.traffic_light_type, expected_roi.traffic_light_type);
     EXPECT_EQ(output_roi.roi.x_offset, expected_roi.roi.x_offset);
@@ -91,14 +92,15 @@ TrafficLightRoiArray make_traffic_light_roi_array(const std::vector<TrafficLight
   return traffic_light_roi_array;
 }
 
-TrafficLightRoiArray select_helper(
+std::vector<TrafficLightRoi> select_helper(
   const std::vector<RegionOfInterest> & detected_rois,
   const std::vector<TrafficLightRoi> & rough_rois,
   const std::vector<TrafficLightRoi> & expected_rois, const CameraInfo & camera_info)
 {
   return select(
-    make_detected_rois(detected_rois), make_traffic_light_roi_array(rough_rois),
-    make_traffic_light_roi_array(expected_rois), camera_info);
+           make_detected_rois(detected_rois), make_traffic_light_roi_array(rough_rois),
+           make_traffic_light_roi_array(expected_rois), camera_info)
+    .rois;
 }
 
 }  // namespace
@@ -113,7 +115,7 @@ TEST(TrafficLightSelector, EmptyInputsProduceEmptyOutput)
   const auto output = select_helper({}, {}, {}, camera_info);
 
   // Assert
-  expect_same(output, make_traffic_light_roi_array({}));
+  expect_same(output, {});
 }
 
 // Every expected ROI yields exactly one output entry. With no detections it cannot be matched, so
@@ -129,9 +131,7 @@ TEST(TrafficLightSelector, ExpectedRoiWithoutDetectionsOutputsDefaultRoi)
   const auto output = select_helper({}, {}, {expected_roi}, camera_info);
 
   // Assert
-  expect_same(
-    output,
-    make_traffic_light_roi_array({make_traffic_light_roi(traffic_light_id, RegionOfInterest{})}));
+  expect_same(output, {make_traffic_light_roi(traffic_light_id, RegionOfInterest{})});
 }
 
 // The detected ROI center lies outside the rough ROI, so it is never considered as a match and the
@@ -150,9 +150,7 @@ TEST(TrafficLightSelector, DetectionCenterOutsideRoughRoiOutputsDefaultRoi)
   const auto output = select_helper({detected_roi}, {rough_roi}, {expected_roi}, camera_info);
 
   // Assert
-  expect_same(
-    output,
-    make_traffic_light_roi_array({make_traffic_light_roi(traffic_light_id, RegionOfInterest{})}));
+  expect_same(output, {make_traffic_light_roi(traffic_light_id, RegionOfInterest{})});
 }
 
 // The detected ROI center is inside the rough ROI and overlaps the expected ROI. The expected ROI
@@ -171,8 +169,7 @@ TEST(TrafficLightSelector, DetectionInsideRoughRoiAssignsDetectedRoi)
   const auto output = select_helper({detected_roi}, {rough_roi}, {expected_roi}, camera_info);
 
   // Assert
-  expect_same(
-    output, make_traffic_light_roi_array({make_traffic_light_roi(traffic_light_id, detected_roi)}));
+  expect_same(output, {make_traffic_light_roi(traffic_light_id, detected_roi)});
 }
 
 // The traffic_light_type of each expected ROI must be copied verbatim onto the output entry.
@@ -190,7 +187,7 @@ TEST(TrafficLightSelector, TrafficLightTypePropagatedToOutput)
   const auto output = select_helper({roi}, {rough_roi}, {expected_roi}, camera_info);
 
   // Assert
-  expect_same(output, make_traffic_light_roi_array({expected_roi}));
+  expect_same(output, {expected_roi});
 }
 
 // When multiple detections sit inside the rough ROI, the one with the highest IoU against the
@@ -211,9 +208,7 @@ TEST(TrafficLightSelector, BestOverlappingDetectionIsSelected)
     {detected_roi_perfect, detected_roi_partial}, {rough_roi}, {expected_roi}, camera_info);
 
   // Assert
-  expect_same(
-    output,
-    make_traffic_light_roi_array({make_traffic_light_roi(traffic_light_id, detected_roi_perfect)}));
+  expect_same(output, {make_traffic_light_roi(traffic_light_id, detected_roi_perfect)});
 }
 
 // Shifting the expected ROI onto the detection pushes it outside the (small) image, so
@@ -233,9 +228,7 @@ TEST(TrafficLightSelector, ShiftedRoiOutOfImageBoundsOutputsDefaultRoi)
   const auto output = select_helper({roi}, {rough_roi}, {expected_roi}, camera_info);
 
   // Assert
-  expect_same(
-    output,
-    make_traffic_light_roi_array({make_traffic_light_roi(traffic_light_id, RegionOfInterest{})}));
+  expect_same(output, {make_traffic_light_roi(traffic_light_id, RegionOfInterest{})});
 }
 
 // Several expected traffic lights are matched independently; each gets its own detection assigned.
@@ -259,7 +252,7 @@ TEST(TrafficLightSelector, MultipleExpectedRoisEachAssigned)
     {first_expected_roi, second_expected_roi}, camera_info);
 
   // Assert
-  expect_same(output, make_traffic_light_roi_array({first_expected_roi, second_expected_roi}));
+  expect_same(output, {first_expected_roi, second_expected_roi});
 }
 
 int main(int argc, char ** argv)

--- a/perception/autoware_traffic_light_selector/test/test_traffic_light_selector.cpp
+++ b/perception/autoware_traffic_light_selector/test/test_traffic_light_selector.cpp
@@ -263,6 +263,23 @@ TEST(TrafficLightSelector, MultipleExpectedRoisEachAssigned)
              make_car_traffic_light_roi(second_traffic_light_id, second_detected)});
 }
 
+// The traffic_light_type carried by the expected ROI (pedestrian, in this case) is propagated to
+// the output entry unchanged, regardless of whether a detection is matched.
+TEST(TrafficLightSelector, PedestrianTrafficLightTypeIsPreserved)
+{
+  // Arrange
+  const int64_t traffic_light_id = 123;
+  const auto expected_roi =
+    make_pedestrian_traffic_light_roi(traffic_light_id, make_roi(100, 100, 40, 40));
+  const auto camera_info = make_camera_info(1280, 720);
+
+  // Act
+  const auto output = select_helper({}, {}, {expected_roi}, camera_info);
+
+  // Assert
+  expect_same(output, {make_pedestrian_traffic_light_roi(traffic_light_id, RegionOfInterest{})});
+}
+
 int main(int argc, char ** argv)
 {
   testing::InitGoogleTest(&argc, argv);

--- a/perception/autoware_traffic_light_selector/test/test_traffic_light_selector.cpp
+++ b/perception/autoware_traffic_light_selector/test/test_traffic_light_selector.cpp
@@ -18,7 +18,7 @@
 
 #include <vector>
 
-using autoware::traffic_light::TrafficLightSelector;
+using autoware::traffic_light::select;
 using sensor_msgs::msg::CameraInfo;
 using sensor_msgs::msg::RegionOfInterest;
 using tier4_perception_msgs::msg::DetectedObjectsWithFeature;
@@ -88,14 +88,13 @@ TrafficLightRoiArray make_traffic_light_roi_array(const std::vector<TrafficLight
 TEST(TrafficLightSelector, EmptyInputsProduceEmptyOutput)
 {
   // Arrange
-  const TrafficLightSelector selector;
   const auto detected_rois = make_detected_rois({});
   const auto rough_rois = make_traffic_light_roi_array({});
   const auto expected_rois = make_traffic_light_roi_array({});
   const auto camera_info = make_camera_info(1280, 720);
 
   // Act
-  const auto output = selector.select(detected_rois, rough_rois, expected_rois, camera_info);
+  const auto output = select(detected_rois, rough_rois, expected_rois, camera_info);
 
   // Assert
   EXPECT_TRUE(output.rois.empty());
@@ -106,16 +105,15 @@ TEST(TrafficLightSelector, EmptyInputsProduceEmptyOutput)
 TEST(TrafficLightSelector, ExpectedRoiWithoutDetectionsOutputsDefaultRoi)
 {
   // Arrange
-  const TrafficLightSelector selector;
   const int64_t traffic_light_id = 123;
   const auto detected_rois = make_detected_rois({});
   const auto rough_rois = make_traffic_light_roi_array({});
-  const auto expected_rois =
-    make_traffic_light_roi_array({make_traffic_light_roi(traffic_light_id, make_roi(100, 100, 40, 40))});
+  const auto expected_rois = make_traffic_light_roi_array(
+    {make_traffic_light_roi(traffic_light_id, make_roi(100, 100, 40, 40))});
   const auto camera_info = make_camera_info(1280, 720);
 
   // Act
-  const auto output = selector.select(detected_rois, rough_rois, expected_rois, camera_info);
+  const auto output = select(detected_rois, rough_rois, expected_rois, camera_info);
 
   // Assert
   ASSERT_EQ(output.rois.size(), 1u);
@@ -128,7 +126,6 @@ TEST(TrafficLightSelector, ExpectedRoiWithoutDetectionsOutputsDefaultRoi)
 TEST(TrafficLightSelector, DetectionCenterOutsideRoughRoiOutputsDefaultRoi)
 {
   // Arrange
-  const TrafficLightSelector selector;
   const int64_t traffic_light_id = 123;
   const auto expected_roi = make_roi(100, 100, 40, 40);
   const auto rough_roi = make_roi(50, 50, 200, 200);
@@ -143,7 +140,7 @@ TEST(TrafficLightSelector, DetectionCenterOutsideRoughRoiOutputsDefaultRoi)
   const auto camera_info = make_camera_info(1280, 720);
 
   // Act
-  const auto output = selector.select(detected_rois, rough_rois, expected_rois, camera_info);
+  const auto output = select(detected_rois, rough_rois, expected_rois, camera_info);
 
   // Assert
   ASSERT_EQ(output.rois.size(), 1u);
@@ -156,7 +153,6 @@ TEST(TrafficLightSelector, DetectionCenterOutsideRoughRoiOutputsDefaultRoi)
 TEST(TrafficLightSelector, DetectionInsideRoughRoiAssignsDetectedRoi)
 {
   // Arrange
-  const TrafficLightSelector selector;
   const int64_t traffic_light_id = 123;
   const auto expected_roi = make_roi(100, 100, 40, 40);
   const auto rough_roi = make_roi(50, 50, 200, 200);
@@ -171,7 +167,7 @@ TEST(TrafficLightSelector, DetectionInsideRoughRoiAssignsDetectedRoi)
   const auto camera_info = make_camera_info(1280, 720);
 
   // Act
-  const auto output = selector.select(detected_rois, rough_rois, expected_rois, camera_info);
+  const auto output = select(detected_rois, rough_rois, expected_rois, camera_info);
 
   // Assert
   ASSERT_EQ(output.rois.size(), 1u);
@@ -183,7 +179,6 @@ TEST(TrafficLightSelector, DetectionInsideRoughRoiAssignsDetectedRoi)
 TEST(TrafficLightSelector, TrafficLightTypePropagatedToOutput)
 {
   // Arrange
-  const TrafficLightSelector selector;
   const int64_t traffic_light_id = 123;
   const auto roi = make_roi(100, 100, 40, 40);
 
@@ -195,7 +190,7 @@ TEST(TrafficLightSelector, TrafficLightTypePropagatedToOutput)
   const auto camera_info = make_camera_info(1280, 720);
 
   // Act
-  const auto output = selector.select(detected_rois, rough_rois, expected_rois, camera_info);
+  const auto output = select(detected_rois, rough_rois, expected_rois, camera_info);
 
   // Assert
   ASSERT_EQ(output.rois.size(), 1u);
@@ -207,7 +202,6 @@ TEST(TrafficLightSelector, TrafficLightTypePropagatedToOutput)
 TEST(TrafficLightSelector, BestOverlappingDetectionIsSelected)
 {
   // Arrange
-  const TrafficLightSelector selector;
   const int64_t traffic_light_id = 123;
   const auto expected_roi = make_roi(100, 100, 40, 40);
   const auto rough_roi = make_roi(50, 50, 200, 200);
@@ -223,19 +217,19 @@ TEST(TrafficLightSelector, BestOverlappingDetectionIsSelected)
   const auto camera_info = make_camera_info(1280, 720);
 
   // Act
-  const auto output = selector.select(detected_rois, rough_rois, expected_rois, camera_info);
+  const auto output = select(detected_rois, rough_rois, expected_rois, camera_info);
 
   // Assert
   ASSERT_EQ(output.rois.size(), 1u);
   EXPECT_TRUE(is_same(output.rois.front().roi, detected_roi_perfect));
 }
 
-// Shifting the expected ROI onto the detection pushes it outside the (small) image, so getShiftedRoi
-// clamps it to an empty ROI, no positive IoU accumulates, and the output falls back to a default ROI.
+// Shifting the expected ROI onto the detection pushes it outside the (small) image, so
+// getShiftedRoi clamps it to an empty ROI, no positive IoU accumulates, and the output falls back
+// to a default ROI.
 TEST(TrafficLightSelector, ShiftedRoiOutOfImageBoundsOutputsDefaultRoi)
 {
   // Arrange
-  const TrafficLightSelector selector;
   const int64_t traffic_light_id = 123;
   const auto roi = make_roi(100, 100, 40, 40);
   const auto rough_roi = make_roi(0, 0, 200, 200);
@@ -249,7 +243,7 @@ TEST(TrafficLightSelector, ShiftedRoiOutOfImageBoundsOutputsDefaultRoi)
   const auto camera_info = make_camera_info(50, 50);
 
   // Act
-  const auto output = selector.select(detected_rois, rough_rois, expected_rois, camera_info);
+  const auto output = select(detected_rois, rough_rois, expected_rois, camera_info);
 
   // Assert
   ASSERT_EQ(output.rois.size(), 1u);
@@ -260,7 +254,6 @@ TEST(TrafficLightSelector, ShiftedRoiOutOfImageBoundsOutputsDefaultRoi)
 TEST(TrafficLightSelector, MultipleExpectedRoisEachAssigned)
 {
   // Arrange
-  const TrafficLightSelector selector;
   const int64_t first_traffic_light_id = 1;
   const int64_t second_traffic_light_id = 2;
   const auto first_roi = make_roi(100, 100, 40, 40);
@@ -277,7 +270,7 @@ TEST(TrafficLightSelector, MultipleExpectedRoisEachAssigned)
   const auto camera_info = make_camera_info(1280, 720);
 
   // Act
-  const auto output = selector.select(detected_rois, rough_rois, expected_rois, camera_info);
+  const auto output = select(detected_rois, rough_rois, expected_rois, camera_info);
 
   // Assert
   ASSERT_EQ(output.rois.size(), 2u);

--- a/perception/autoware_traffic_light_selector/test/test_traffic_light_selector.cpp
+++ b/perception/autoware_traffic_light_selector/test/test_traffic_light_selector.cpp
@@ -74,13 +74,21 @@ DetectedObjectsWithFeature make_detected_rois(const std::vector<RegionOfInterest
   return detected_rois;
 }
 
-TrafficLightRoi make_traffic_light_roi(
-  int64_t traffic_light_id, const RegionOfInterest & roi,
-  uint8_t traffic_light_type = TrafficLightRoi::CAR_TRAFFIC_LIGHT)
+TrafficLightRoi make_car_traffic_light_roi(int64_t traffic_light_id, const RegionOfInterest & roi)
 {
   TrafficLightRoi traffic_light_roi;
   traffic_light_roi.traffic_light_id = traffic_light_id;
-  traffic_light_roi.traffic_light_type = traffic_light_type;
+  traffic_light_roi.traffic_light_type = TrafficLightRoi::CAR_TRAFFIC_LIGHT;
+  traffic_light_roi.roi = roi;
+  return traffic_light_roi;
+}
+
+TrafficLightRoi make_pedestrian_traffic_light_roi(
+  int64_t traffic_light_id, const RegionOfInterest & roi)
+{
+  TrafficLightRoi traffic_light_roi;
+  traffic_light_roi.traffic_light_id = traffic_light_id;
+  traffic_light_roi.traffic_light_type = TrafficLightRoi::PEDESTRIAN_TRAFFIC_LIGHT;
   traffic_light_roi.roi = roi;
   return traffic_light_roi;
 }
@@ -124,14 +132,15 @@ TEST(TrafficLightSelector, ExpectedRoiWithoutDetectionsOutputsDefaultRoi)
 {
   // Arrange
   const int64_t traffic_light_id = 123;
-  const auto expected_roi = make_traffic_light_roi(traffic_light_id, make_roi(100, 100, 40, 40));
+  const auto expected_roi =
+    make_car_traffic_light_roi(traffic_light_id, make_roi(100, 100, 40, 40));
   const auto camera_info = make_camera_info(1280, 720);
 
   // Act
   const auto output = select_helper({}, {}, {expected_roi}, camera_info);
 
   // Assert
-  expect_same(output, {make_traffic_light_roi(traffic_light_id, RegionOfInterest{})});
+  expect_same(output, {make_car_traffic_light_roi(traffic_light_id, RegionOfInterest{})});
 }
 
 // The detected ROI center lies outside the rough ROI, so it is never considered as a match and the
@@ -140,8 +149,9 @@ TEST(TrafficLightSelector, DetectionCenterOutsideRoughRoiOutputsDefaultRoi)
 {
   // Arrange
   const int64_t traffic_light_id = 123;
-  const auto expected_roi = make_traffic_light_roi(traffic_light_id, make_roi(100, 100, 40, 40));
-  const auto rough_roi = make_traffic_light_roi(traffic_light_id, make_roi(50, 50, 200, 200));
+  const auto expected_roi =
+    make_car_traffic_light_roi(traffic_light_id, make_roi(100, 100, 40, 40));
+  const auto rough_roi = make_car_traffic_light_roi(traffic_light_id, make_roi(50, 50, 200, 200));
   // Detected ROI center (820, 620) is far outside the rough ROI span (50..250).
   const auto detected_roi_outside_rough_roi = make_roi(800, 600, 40, 40);
   const auto camera_info = make_camera_info(1280, 720);
@@ -151,7 +161,7 @@ TEST(TrafficLightSelector, DetectionCenterOutsideRoughRoiOutputsDefaultRoi)
     select_helper({detected_roi_outside_rough_roi}, {rough_roi}, {expected_roi}, camera_info);
 
   // Assert
-  expect_same(output, {make_traffic_light_roi(traffic_light_id, RegionOfInterest{})});
+  expect_same(output, {make_car_traffic_light_roi(traffic_light_id, RegionOfInterest{})});
 }
 
 // The detected ROI center is inside the rough ROI and overlaps the expected ROI. The expected ROI
@@ -160,8 +170,9 @@ TEST(TrafficLightSelector, DetectionInsideRoughRoiAssignsDetectedRoi)
 {
   // Arrange
   const int64_t traffic_light_id = 123;
-  const auto expected_roi = make_traffic_light_roi(traffic_light_id, make_roi(100, 100, 40, 40));
-  const auto rough_roi = make_traffic_light_roi(traffic_light_id, make_roi(50, 50, 200, 200));
+  const auto expected_roi =
+    make_car_traffic_light_roi(traffic_light_id, make_roi(100, 100, 40, 40));
+  const auto rough_roi = make_car_traffic_light_roi(traffic_light_id, make_roi(50, 50, 200, 200));
   // Detected ROI center (130, 125) is inside the rough ROI but offset from the expected ROI.
   const auto detected_roi_inside_rough_roi = make_roi(110, 105, 40, 40);
   const auto camera_info = make_camera_info(1280, 720);
@@ -171,7 +182,8 @@ TEST(TrafficLightSelector, DetectionInsideRoughRoiAssignsDetectedRoi)
     select_helper({detected_roi_inside_rough_roi}, {rough_roi}, {expected_roi}, camera_info);
 
   // Assert
-  expect_same(output, {make_traffic_light_roi(traffic_light_id, detected_roi_inside_rough_roi)});
+  expect_same(
+    output, {make_car_traffic_light_roi(traffic_light_id, detected_roi_inside_rough_roi)});
 }
 
 // The traffic_light_type of each expected ROI must be copied verbatim onto the output entry.
@@ -180,9 +192,9 @@ TEST(TrafficLightSelector, TrafficLightTypePropagatedToOutput)
   // Arrange
   const int64_t traffic_light_id = 123;
   const auto detected_roi_matching_expected = make_roi(100, 100, 40, 40);
-  const auto rough_roi = make_traffic_light_roi(traffic_light_id, make_roi(50, 50, 200, 200));
-  const auto expected_roi = make_traffic_light_roi(
-    traffic_light_id, detected_roi_matching_expected, TrafficLightRoi::PEDESTRIAN_TRAFFIC_LIGHT);
+  const auto rough_roi = make_car_traffic_light_roi(traffic_light_id, make_roi(50, 50, 200, 200));
+  const auto expected_roi =
+    make_pedestrian_traffic_light_roi(traffic_light_id, detected_roi_matching_expected);
   const auto camera_info = make_camera_info(1280, 720);
 
   // Act
@@ -199,8 +211,9 @@ TEST(TrafficLightSelector, BestOverlappingDetectionIsSelected)
 {
   // Arrange
   const int64_t traffic_light_id = 123;
-  const auto expected_roi = make_traffic_light_roi(traffic_light_id, make_roi(100, 100, 40, 40));
-  const auto rough_roi = make_traffic_light_roi(traffic_light_id, make_roi(50, 50, 200, 200));
+  const auto expected_roi =
+    make_car_traffic_light_roi(traffic_light_id, make_roi(100, 100, 40, 40));
+  const auto rough_roi = make_car_traffic_light_roi(traffic_light_id, make_roi(50, 50, 200, 200));
   // Detection A perfectly overlaps the expected ROI; detection B only partially overlaps.
   const auto detected_roi_perfect = make_roi(100, 100, 40, 40);
   const auto detected_roi_partial = make_roi(200, 200, 10, 10);
@@ -211,7 +224,7 @@ TEST(TrafficLightSelector, BestOverlappingDetectionIsSelected)
     {detected_roi_perfect, detected_roi_partial}, {rough_roi}, {expected_roi}, camera_info);
 
   // Assert
-  expect_same(output, {make_traffic_light_roi(traffic_light_id, detected_roi_perfect)});
+  expect_same(output, {make_car_traffic_light_roi(traffic_light_id, detected_roi_perfect)});
 }
 
 // Shifting the expected ROI onto the detection pushes it outside the (small) image, so
@@ -222,8 +235,8 @@ TEST(TrafficLightSelector, ShiftedRoiOutOfImageBoundsOutputsDefaultRoi)
   // Arrange
   const int64_t traffic_light_id = 123;
   const auto roi_outside_image_bounds = make_roi(100, 100, 40, 40);
-  const auto rough_roi = make_traffic_light_roi(traffic_light_id, make_roi(0, 0, 200, 200));
-  const auto expected_roi = make_traffic_light_roi(traffic_light_id, roi_outside_image_bounds);
+  const auto rough_roi = make_car_traffic_light_roi(traffic_light_id, make_roi(0, 0, 200, 200));
+  const auto expected_roi = make_car_traffic_light_roi(traffic_light_id, roi_outside_image_bounds);
   // The ROI at (100, 100, 40, 40) does not fit inside a 50x50 image.
   const auto camera_info = make_camera_info(50, 50);
 
@@ -232,7 +245,7 @@ TEST(TrafficLightSelector, ShiftedRoiOutOfImageBoundsOutputsDefaultRoi)
     select_helper({roi_outside_image_bounds}, {rough_roi}, {expected_roi}, camera_info);
 
   // Assert
-  expect_same(output, {make_traffic_light_roi(traffic_light_id, RegionOfInterest{})});
+  expect_same(output, {make_car_traffic_light_roi(traffic_light_id, RegionOfInterest{})});
 }
 
 // Several expected traffic lights are matched independently; each gets its own detection assigned.
@@ -245,11 +258,11 @@ TEST(TrafficLightSelector, MultipleExpectedRoisEachAssigned)
   const auto second_roi = make_roi(300, 100, 40, 40);
   const auto common_rough_roi_area = make_roi(0, 0, 500, 500);
   const auto first_rough_roi =
-    make_traffic_light_roi(first_traffic_light_id, common_rough_roi_area);
+    make_car_traffic_light_roi(first_traffic_light_id, common_rough_roi_area);
   const auto second_rough_roi =
-    make_traffic_light_roi(second_traffic_light_id, common_rough_roi_area);
-  const auto first_expected_roi = make_traffic_light_roi(first_traffic_light_id, first_roi);
-  const auto second_expected_roi = make_traffic_light_roi(second_traffic_light_id, second_roi);
+    make_car_traffic_light_roi(second_traffic_light_id, common_rough_roi_area);
+  const auto first_expected_roi = make_car_traffic_light_roi(first_traffic_light_id, first_roi);
+  const auto second_expected_roi = make_car_traffic_light_roi(second_traffic_light_id, second_roi);
   const auto camera_info = make_camera_info(1280, 720);
 
   // Act


### PR DESCRIPTION
## Description

Extract the ROI matching logic of `TrafficLightSelectorNode` into a standalone `select` free function (`traffic_light_selector.hpp`/`.cpp`), decoupled from `rclcpp::Node`, and add unit tests covering it directly instead of only through ROS 2 topic-level integration tests.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

- `colcon build --packages-select autoware_traffic_light_selector` succeeds.
- `colcon test --packages-select autoware_traffic_light_selector` passes, including the new `autoware_traffic_light_selector_selector_test` GoogleTest binary (7/7 tests pass).

Integration tests implemented in https://github.com/autowarefoundation/autoware_universe/pull/12892 also pass.

## Notes for reviewers

The `select` function's behavior is unchanged from the previous in-node implementation; this PR is a refactor plus test addition, not a functional change.


## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
